### PR TITLE
chore(ts-tests): resolve @tamma/* workspace aliases (+734 tests now loadable)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,52 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = (name: string, sub = 'index.ts') =>
+  resolve(__dirname, `packages/${name}/src/${sub}`);
 
 export default defineConfig({
   plugins: [react()],
+  // Resolve @tamma/* workspace imports straight from source during tests.
+  // Each package's package.json points main/exports at ./dist/* (built
+  // artifacts), but `pnpm vitest run` from the repo root does not run
+  // `pnpm build` first, so cross-package imports fail to resolve. The
+  // aliases below let vitest/vite read the TypeScript source directly,
+  // which mirrors what users get when packages ARE built and avoids
+  // requiring the entire workspace to compile cleanly before tests run.
+  // Subpath aliases (e.g. @tamma/shared/telemetry) are listed first so
+  // the longest-prefix match wins over the bare-package alias.
+  resolve: {
+    alias: [
+      { find: /^@tamma\/shared\/contracts$/, replacement: pkg('shared', 'contracts/index.ts') },
+      { find: /^@tamma\/shared\/telemetry$/, replacement: pkg('shared', 'telemetry/index.ts') },
+      { find: /^@tamma\/shared\/types$/, replacement: pkg('shared', 'types/index.ts') },
+      { find: /^@tamma\/shared\/utils$/, replacement: pkg('shared', 'utils/index.ts') },
+      { find: /^@tamma\/shared\/errors$/, replacement: pkg('shared', 'errors.ts') },
+      { find: /^@tamma\/shared\/config$/, replacement: pkg('shared', 'config/index.ts') },
+      { find: /^@tamma\/shared$/, replacement: pkg('shared') },
+      { find: /^@tamma\/intelligence\/vector-store$/, replacement: pkg('intelligence', 'vector-store/index.ts') },
+      { find: /^@tamma\/intelligence\/indexer$/, replacement: pkg('intelligence', 'indexer/index.ts') },
+      { find: /^@tamma\/intelligence\/knowledge-base$/, replacement: pkg('intelligence', 'knowledge-base/index.ts') },
+      { find: /^@tamma\/intelligence\/rag$/, replacement: pkg('intelligence', 'rag/index.ts') },
+      { find: /^@tamma\/intelligence\/context$/, replacement: pkg('intelligence', 'context/index.ts') },
+      { find: /^@tamma\/intelligence$/, replacement: pkg('intelligence') },
+      { find: /^@tamma\/mcp-client\/types$/, replacement: pkg('mcp-client', 'types.ts') },
+      { find: /^@tamma\/mcp-client\/errors$/, replacement: pkg('mcp-client', 'errors.ts') },
+      { find: /^@tamma\/mcp-client$/, replacement: pkg('mcp-client') },
+      { find: /^@tamma\/providers$/, replacement: pkg('providers') },
+      { find: /^@tamma\/orchestrator$/, replacement: pkg('orchestrator') },
+      { find: /^@tamma\/platforms$/, replacement: pkg('platforms') },
+      { find: /^@tamma\/events$/, replacement: pkg('events') },
+      { find: /^@tamma\/gates$/, replacement: pkg('gates') },
+      { find: /^@tamma\/cost-monitor$/, replacement: pkg('cost-monitor') },
+      { find: /^@tamma\/observability$/, replacement: pkg('observability') },
+      { find: /^@tamma\/scrum-master$/, replacement: pkg('scrum-master') },
+      { find: /^@tamma\/workers$/, replacement: pkg('workers') },
+    ],
+  },
   test: {
     globals: true,
     environment: 'node',


### PR DESCRIPTION
## Summary

Single-file fix for the **27 failing test files / 40-failure** count under `pnpm vitest run` from the repo root. Single root cause; single 44-line addition to root `vitest.config.ts`.

## Root cause

Every `@tamma/*` workspace package's `package.json` points `main` and `exports` at `./dist/*` (the `tsc --build` output). When `pnpm vitest run` runs from the repo root without first running `pnpm build`, vite's package-entry resolver hits ENOENT on those paths and fails with "Failed to resolve entry for package `@tamma/shared`". One resolution failure cascaded into 27 dependents.

The backlog note's "missing-module / nanoid" framing was wrong — `nanoid` was already a dep of every package that uses it; no missing exports; no vitest config issues other than the absent aliases.

## Fix

Added a `resolve.alias` block to root `vitest.config.ts` with 25 alias entries (longest-prefix-first ordering for subpath exports like `@tamma/shared/telemetry`). Tests read TS source directly via esbuild — `tsc --build` is no longer load-bearing.

## Why aliases beat fixing each `package.json`

`pnpm build` from root is broken at `feat/wave-a` tip due to:
- `packages/gates` strict-TS regressions (8 errors in permission-enforcer / -resolver / -service / violation-recorder / violation-alerter — mostly `exactOptionalPropertyTypes` issues)
- `apps/test-platform` missing `knex`/`express` deps (~30 errors)

Both are **out of scope** ("don't change test bodies; don't fix unrelated production code"). Aliases sidestep the strict-TS issues entirely; the test surface runs against TS source via esbuild, the build surface stays as broken as it was.

## Before / after

`pnpm vitest run` from root:
- **Before**: 27 failed test files / 136 passed (163 total); 3243 tests passed
- **After**: 0 failed / 163 passed (163 total); 3977 tests passed

The +734 tests aren't newly written — they're the tests inside the previously-unloadable files.

## Out of scope (deferred, NOT regressed by this PR)

- `pnpm build` at workspace root — still broken at `feat/wave-a` for the reasons above.
- `packages/dashboard*` have their own `vitest.config.ts` and are excluded from root run per existing config.

## Test plan

- [x] `pnpm install` clean
- [x] `pnpm vitest run` from repo root: 0 failed / 163 passed
- [x] Two consecutive runs: green both times (no flake)
- [x] No production code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)