### PR TITLE
feat(epic-28-1) PR B: outbox + queued-task scope split (Decision #5)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/AuthEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/AuthEndpoints.cs
@@ -277,10 +277,17 @@ public static class AuthEndpoints
         await userRepo.UpdateActiveTenantAsync(user.Id, tenant.Id);
 
         var verifyUrl = BuildVerificationUrl(config, verificationToken);
+        // Story 28-1 PR B — registration verification email is
+        // platform-scope: no tenant DB exists yet to land the row in
+        // (the personal tenant we just minted is shared-infra-only
+        // until provisioning runs separately). Leaving TenantId unset
+        // routes through IPlatformEmailOutboxRepository →
+        // platform_email_outbox. UserId is preserved for correlation.
+        // Decision matrix: .dev/decisions/story-28-1-design-calls.md §5.
         var message = EmailTemplates.VerificationEmail(user.Email, verifyUrl) with
         {
             Template = "verification",
-            TenantId = tenant.Id,
+            TenantId = null,
             UserId = user.Id,
         };
         var txnId = await emailService.SendAsync(message);
@@ -351,10 +358,13 @@ public static class AuthEndpoints
                 user.Id, HashToken(verificationToken), DateTime.UtcNow.AddHours(24));
 
             var verifyUrl = BuildVerificationUrl(config, verificationToken);
+            // Story 28-1 PR B — verification email is platform-scope (the
+            // user may not have a tenant yet, or the tenant DB may not be
+            // provisioned). Routes through IPlatformEmailOutboxRepository.
             var message = EmailTemplates.VerificationEmail(user.Email, verifyUrl) with
             {
                 Template = "verification",
-                TenantId = user.TenantId,
+                TenantId = null,
                 UserId = user.Id,
             };
             var txnId = await emailService.SendAsync(message);
@@ -805,10 +815,14 @@ public static class AuthEndpoints
         await resetRepo.CreateAsync(user.Id, tokenHash, expiresAt);
 
         var resetUrl = BuildResetUrl(config, rawToken);
+        // Story 28-1 PR B — password reset is platform-scope. Reset is
+        // an account-recovery flow; pinning it to a single TenantId
+        // would mean the email vanishes if that tenant is later
+        // deleted. Routes through IPlatformEmailOutboxRepository.
         var message = EmailTemplates.PasswordResetEmail(user.Email, resetUrl) with
         {
             Template = "password-reset",
-            TenantId = user.TenantId,
+            TenantId = null,
             UserId = user.Id,
         };
         var txnId = await emailService.SendAsync(message);

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/EmailServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/EmailServiceCollectionExtensions.cs
@@ -30,6 +30,11 @@ public static class EmailServiceCollectionExtensions
     {
         // Shared repository — Scoped because ControlPlaneDbContext is Scoped.
         services.TryAddScoped<IEmailOutboxRepository, EmailOutboxRepository>();
+        // Story 28-1 PR B — SmtpEmailService routes platform-scope email
+        // (verification, password reset, welcome) through the platform
+        // repo. TryAdd so callers that already register a custom impl
+        // win.
+        services.TryAddScoped<IPlatformEmailOutboxRepository, PlatformEmailOutboxRepository>();
 
         // The production SMTP transport. Can be replaced in tests by
         // substituting a test-double ISmtpTransport before AddEmailServices
@@ -126,6 +131,7 @@ internal sealed class ScopedSmtpEmailService : IEmailService
         using var scope = _rootProvider.CreateScope();
         var inner = new SmtpEmailService(
             scope.ServiceProvider.GetRequiredService<IEmailOutboxRepository>(),
+            scope.ServiceProvider.GetRequiredService<IPlatformEmailOutboxRepository>(),
             scope.ServiceProvider.GetRequiredService<IEventRepository>(),
             scope.ServiceProvider.GetRequiredService<Tamma.Data.ITenantContext>(),
             scope.ServiceProvider.GetRequiredService<IConfiguration>(),

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Email/OutboxSmtpSender.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Email/OutboxSmtpSender.cs
@@ -132,10 +132,7 @@ public sealed class OutboxSmtpSender : BackgroundService
     /// the platform outbox, returning <c>true</c> when a row was
     /// processed. Tenant outbox is drained first to preserve historical
     /// behaviour; platform outbox is checked only when the tenant queue
-    /// is empty so a heavy tenant load doesn't starve the platform
-    /// queue (the next poll cycle will visit the platform queue when
-    /// the tenant queue is drained). Exposed for tests so they don't
-    /// race the polling timer.
+    /// is empty. Exposed for tests so they don't race the polling timer.
     ///
     /// <para>Story 28-1 PR B — the tenant claim path now fans out
     /// across active tenants via
@@ -143,6 +140,19 @@ public sealed class OutboxSmtpSender : BackgroundService
     /// instead of the previous "scan a single shared CP table" path.
     /// Once PR D moves the per-tenant outbox into per-tenant DBs the
     /// fan-out becomes the only correct way to drain.</para>
+    ///
+    /// <para>Wave-4 review H3 — tenant-first ordering CAN starve the
+    /// platform queue indefinitely under continuous tenant traffic. Pre-PR
+    /// the direct-CP-scan path interleaved tenant + platform rows by
+    /// <c>NextAttemptAt</c>; the cycle-aware ordering here gives no
+    /// fairness guarantee. Acceptable today because (a) the platform
+    /// queue carries low-volume verification / password-reset / welcome
+    /// mail and (b) a busy tenant queue still drains one row per poll
+    /// so platform mail is delayed at most one poll cycle past the moment
+    /// the tenant queue empties. Round-robin (alternate tenant ↔
+    /// platform per cycle) is tracked as a follow-up. Re-evaluate when
+    /// EMAIL.QUEUED.SUCCESS rows pile up on the platform table without
+    /// EMAIL.SENT.SUCCESS catching up.</para>
     /// </summary>
     public async Task<bool> ProcessOnceAsync(CancellationToken ct)
     {

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Email/OutboxSmtpSender.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Email/OutboxSmtpSender.cs
@@ -136,6 +136,13 @@ public sealed class OutboxSmtpSender : BackgroundService
     /// queue (the next poll cycle will visit the platform queue when
     /// the tenant queue is drained). Exposed for tests so they don't
     /// race the polling timer.
+    ///
+    /// <para>Story 28-1 PR B — the tenant claim path now fans out
+    /// across active tenants via
+    /// <see cref="IEmailOutboxRepository.ClaimNextPendingFromAnyTenantAsync"/>
+    /// instead of the previous "scan a single shared CP table" path.
+    /// Once PR D moves the per-tenant outbox into per-tenant DBs the
+    /// fan-out becomes the only correct way to drain.</para>
     /// </summary>
     public async Task<bool> ProcessOnceAsync(CancellationToken ct)
     {
@@ -144,7 +151,7 @@ public sealed class OutboxSmtpSender : BackgroundService
         var transport = scope.ServiceProvider.GetRequiredService<ISmtpTransport>();
         var events = scope.ServiceProvider.GetRequiredService<IEventRepository>();
 
-        var claimed = await outbox.ClaimNextPendingAsync(DateTime.UtcNow, ct);
+        var claimed = await outbox.ClaimNextPendingFromAnyTenantAsync(DateTime.UtcNow, ct);
         if (claimed is not null)
         {
             await ProcessTenantClaimedAsync(outbox, transport, events, claimed, ct);
@@ -162,10 +169,22 @@ public sealed class OutboxSmtpSender : BackgroundService
         EmailOutboxMessage claimed,
         CancellationToken ct)
     {
+        // ClaimNextPendingFromAnyTenantAsync always returns a row whose
+        // TenantId is set — the tenant outbox is strictly tenant-scoped
+        // post Story 28-1 PR B. Defensive null-check kept so a future
+        // contract change shows up at runtime not as a silent CP hit.
+        if (claimed.TenantId is not Guid tid)
+        {
+            _logger.LogError(
+                "Tenant-outbox row {TxnId} has no TenantId — refusing to mark sent",
+                claimed.Id);
+            return;
+        }
+
         try
         {
             await transport.SendAsync(claimed, ct);
-            await outbox.MarkSentAsync(claimed.Id, ct);
+            await outbox.MarkSentAsync(tid, claimed.Id, ct);
             await EmitSentAsync(events, claimed);
 
             // Purge the row now that the event store has the permanent audit.
@@ -173,7 +192,7 @@ public sealed class OutboxSmtpSender : BackgroundService
             // delivery — EMAIL.SENT.SUCCESS holds txn id + template metadata.
             // Failed rows (MarkFailedAsync → Status=failed) are NOT deleted;
             // operators need them for inspection.
-            await outbox.DeleteAsync(claimed.Id, ct);
+            await outbox.DeleteAsync(tid, claimed.Id, ct);
 
             _logger.LogInformation("Email delivered txn={TxnId}", claimed.Id);
         }
@@ -182,7 +201,7 @@ public sealed class OutboxSmtpSender : BackgroundService
             // NEVER log recipient / subject / body / host — only the txn id.
             var attempt = claimed.Attempts + 1;
             var backoff = PickBackoff(attempt);
-            var updated = await outbox.MarkFailedAsync(claimed.Id, ex.Message, backoff, ct);
+            var updated = await outbox.MarkFailedAsync(tid, claimed.Id, ex.Message, backoff, ct);
 
             if (updated is not null && updated.Status == "failed")
             {
@@ -196,7 +215,7 @@ public sealed class OutboxSmtpSender : BackgroundService
                 // txn id + error class). The row carries recipient / subject
                 // / body which aren't needed after the terminal outcome, so
                 // delete it too.
-                await outbox.DeleteAsync(claimed.Id, ct);
+                await outbox.DeleteAsync(tid, claimed.Id, ct);
             }
             else
             {

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Email/SmtpEmailService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Email/SmtpEmailService.cs
@@ -7,10 +7,22 @@ namespace Tamma.Api.Services.Email;
 
 /// <summary>
 /// Outbox-backed <see cref="IEmailService"/>. <see cref="SendAsync"/> does not
-/// talk to SMTP — it persists the message in <c>email_outbox</c> and emits a
-/// <see cref="EmailEventTypes.Queued"/> event. The actual SMTP delivery is
-/// performed asynchronously by <c>OutboxSmtpSender</c>, which also emits
+/// talk to SMTP — it persists the message in the per-tenant
+/// <c>email_outbox</c> (when <see cref="EmailMessage.TenantId"/> is set)
+/// or the platform <c>platform_email_outbox</c> (when no tenant is
+/// supplied) and emits a <see cref="EmailEventTypes.Queued"/> event. The
+/// actual SMTP delivery is performed asynchronously by
+/// <c>OutboxSmtpSender</c>, which also emits
 /// <see cref="EmailEventTypes.Sent"/> / <see cref="EmailEventTypes.Failed"/>.
+///
+/// <para>Story 28-1 PR B — the platform vs tenant routing happens here.
+/// Callers shouldn't need to know which repo to use; they set
+/// <see cref="EmailMessage.TenantId"/> when the email belongs to a real
+/// tenant org (invite, internal notification) and leave it unset for
+/// platform-scope emails (verification, password reset, welcome) that
+/// fire before/after a tenant DB exists. The decision matrix is in
+/// <c>.dev/decisions/story-28-1-design-calls.md</c> §5 plus the
+/// commit body of PR B itself.</para>
 ///
 /// <para>
 /// Configuration keys (all under the <c>Email</c> root):
@@ -27,6 +39,7 @@ namespace Tamma.Api.Services.Email;
 public sealed class SmtpEmailService : IEmailService
 {
     private readonly IEmailOutboxRepository _outbox;
+    private readonly IPlatformEmailOutboxRepository _platformOutbox;
     private readonly IEventRepository _events;
     private readonly ITenantContext _tenantContext;
     private readonly IConfiguration _config;
@@ -34,12 +47,14 @@ public sealed class SmtpEmailService : IEmailService
 
     public SmtpEmailService(
         IEmailOutboxRepository outbox,
+        IPlatformEmailOutboxRepository platformOutbox,
         IEventRepository events,
         ITenantContext tenantContext,
         IConfiguration config,
         ILogger<SmtpEmailService> logger)
     {
         _outbox = outbox;
+        _platformOutbox = platformOutbox;
         _events = events;
         _tenantContext = tenantContext;
         _config = config;
@@ -57,8 +72,49 @@ public sealed class SmtpEmailService : IEmailService
 
         var maxAttempts = _config.GetValue("Email:OutboxMaxAttempts", 5);
         var now = DateTime.UtcNow;
+
+        // Story 28-1 PR B: routing.
+        //
+        // 1. message.TenantId is the most authoritative signal — callers
+        //    that intentionally set null mean "platform scope" (no tenant DB
+        //    exists yet, e.g. registration verification email).
+        // 2. When the message's TenantId is null but the ambient
+        //    ITenantContext.TenantId is set, prefer the ambient one. This
+        //    preserves the historical "implicit tenant" behaviour for
+        //    callers that haven't been audited yet — they'll keep working
+        //    after PR D's physical move.
+        // 3. Both null → platform path.
         var tenantId = message.TenantId ?? _tenantContext.TenantId;
 
+        var enqueuedId = tenantId is Guid tid && tid != Guid.Empty
+            ? await EnqueueTenantAsync(message, fromAddress, maxAttempts, now, tid, ct)
+            : await EnqueuePlatformAsync(message, fromAddress, maxAttempts, now, ct);
+
+        // Event emission MUST NOT fail the SendAsync contract — callers upstream
+        // rely on the Guid return. If the event store is down we log and carry
+        // on; the outbox row is the durable record of intent.
+        try
+        {
+            await EmitQueuedAsync(enqueuedId, message.Template ?? "unknown", tenantId, message.UserId, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Email queued event emission failed txn={TxnId}", enqueuedId);
+        }
+
+        _logger.LogInformation(
+            "Email queued to outbox txn={TxnId} template={Template} scope={Scope}",
+            enqueuedId, message.Template ?? "unknown",
+            tenantId is null ? "platform" : "tenant");
+
+        return enqueuedId;
+    }
+
+    private async Task<Guid> EnqueueTenantAsync(
+        EmailMessage message, string fromAddress, int maxAttempts,
+        DateTime now, Guid tenantId, CancellationToken ct)
+    {
         var row = new EmailOutboxMessage
         {
             Id = Guid.NewGuid(),
@@ -75,40 +131,46 @@ public sealed class SmtpEmailService : IEmailService
             MaxAttempts = maxAttempts,
             NextAttemptAt = now,
         };
-
         var enqueued = await _outbox.EnqueueAsync(row, ct);
-
-        // Event emission MUST NOT fail the SendAsync contract — callers upstream
-        // rely on the Guid return. If the event store is down we log and carry
-        // on; the outbox row is the durable record of intent.
-        try
-        {
-            await EmitQueuedAsync(enqueued, ct);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex,
-                "Email queued event emission failed txn={TxnId}", enqueued.Id);
-        }
-
-        _logger.LogInformation(
-            "Email queued to outbox txn={TxnId} template={Template}",
-            enqueued.Id, enqueued.Template);
-
         return enqueued.Id;
     }
 
-    private async Task EmitQueuedAsync(EmailOutboxMessage row, CancellationToken ct)
+    private async Task<Guid> EnqueuePlatformAsync(
+        EmailMessage message, string fromAddress, int maxAttempts,
+        DateTime now, CancellationToken ct)
+    {
+        var row = new PlatformEmailOutboxMessage
+        {
+            Id = Guid.NewGuid(),
+            TenantId = null,
+            UserId = message.UserId,
+            Template = message.Template ?? "unknown",
+            ToAddress = message.To,
+            Subject = message.Subject,
+            HtmlBody = message.Html,
+            TextBody = message.Text,
+            FromAddress = fromAddress,
+            Status = "pending",
+            Attempts = 0,
+            MaxAttempts = maxAttempts,
+            NextAttemptAt = now,
+        };
+        var enqueued = await _platformOutbox.EnqueueAsync(row, ct);
+        return enqueued.Id;
+    }
+
+    private async Task EmitQueuedAsync(
+        Guid txnId, string template, Guid? tenantId, Guid? userId, CancellationToken ct)
     {
         _ = ct; // IEventRepository doesn't take CT today; keep signature future-proof.
 
         // CodeQL-safe: no recipient / subject / body anywhere in tags or data.
         var tags = new Dictionary<string, string?>
         {
-            ["txn_id"] = row.Id.ToString(),
-            ["template"] = row.Template,
-            ["tenant_id"] = row.TenantId?.ToString(),
-            ["user_id"] = row.UserId?.ToString(),
+            ["txn_id"] = txnId.ToString(),
+            ["template"] = template,
+            ["tenant_id"] = tenantId?.ToString(),
+            ["user_id"] = userId?.ToString(),
         };
 
         var data = new Dictionary<string, object?>
@@ -119,7 +181,7 @@ public sealed class SmtpEmailService : IEmailService
         await _events.AppendAsync(new DomainEvent
         {
             Type = EmailEventTypes.Queued,
-            TenantId = row.TenantId,
+            TenantId = tenantId,
             Tags = JsonSerializer.Serialize(tags),
             Metadata = """{"eventSource":"system"}""",
             Data = JsonSerializer.Serialize(data),

--- a/apps/tamma-elsa/src/Tamma.Api/Services/GitHub/InstallationRouterService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/GitHub/InstallationRouterService.cs
@@ -36,6 +36,7 @@ public sealed class InstallationRouterService : IInstallationRouterService
     private readonly ITenantRepository _tenants;
     private readonly IUserRepository _users;
     private readonly ITaskQueue? _taskQueue;
+    private readonly IPlatformQueuedTaskRepository? _platformTasks;
     private readonly IMemoryCache _cache;
     private readonly IGitHubAppClient _gitHubApp;
     private readonly IGitHubSecretsProvisioner _provisioner;
@@ -43,6 +44,15 @@ public sealed class InstallationRouterService : IInstallationRouterService
     private readonly IWebhookSignalRegistry? _webhookSignals;
     private readonly ILogger<InstallationRouterService> _logger;
 
+    /// <summary>
+    /// Story 28-1 PR B — webhook deferral now routes by tenancy:
+    /// tenant-bound webhooks (installation has a TenantId) go to the
+    /// per-tenant queue via <see cref="ITaskQueue"/>; orphan webhooks
+    /// (no TenantId on the installation row) go to the platform queue
+    /// via <see cref="IPlatformQueuedTaskRepository"/>. Both repos are
+    /// optional so the existing test fixtures that wire only one of
+    /// them keep working.
+    /// </summary>
     public InstallationRouterService(
         IInstallationRepository installations,
         IEventRepository events,
@@ -54,6 +64,7 @@ public sealed class InstallationRouterService : IInstallationRouterService
         IApiKeyRepository apiKeys,
         ILogger<InstallationRouterService> logger,
         ITaskQueue? taskQueue = null,
+        IPlatformQueuedTaskRepository? platformTasks = null,
         IWebhookSignalRegistry? webhookSignals = null)
     {
         _installations = installations;
@@ -65,6 +76,7 @@ public sealed class InstallationRouterService : IInstallationRouterService
         _provisioner = provisioner;
         _apiKeys = apiKeys;
         _taskQueue = taskQueue;
+        _platformTasks = platformTasks;
         _webhookSignals = webhookSignals;
         _logger = logger;
     }
@@ -496,14 +508,26 @@ public sealed class InstallationRouterService : IInstallationRouterService
     /// webhook handler returns fast. When the task queue is not wired (tests
     /// that only register the installation router) the event falls through to
     /// <c>skipped = true</c> so old behaviour remains observable.
+    ///
+    /// <para>Story 28-1 PR B — routing splits by tenancy:
+    /// <list type="bullet">
+    ///   <item><description>installation has a TenantId → tenant queue
+    ///     (<see cref="ITaskQueue"/>). Per-tenant DB drains via the
+    ///     <c>TaskQueueProcessor</c>.</description></item>
+    ///   <item><description>orphan installation (TenantId is null) →
+    ///     platform queue (<see cref="IPlatformQueuedTaskRepository"/>).
+    ///     Drained by the <c>PlatformTaskWorker</c>. Without a tenant DB
+    ///     the per-tenant queue can't accept the row, so the platform
+    ///     queue is the only viable home.</description></item>
+    /// </list></para>
     /// </summary>
     private async Task<WebhookResult> EnqueueDeferredEventAsync(
         string eventType, string? action, JsonElement payload)
     {
-        if (_taskQueue is null)
+        if (_taskQueue is null && _platformTasks is null)
         {
             _logger.LogDebug(
-                "Webhook event {Event} (action={Action}) skipped: task queue not registered",
+                "Webhook event {Event} (action={Action}) skipped: no task queue registered",
                 Logging.LogSanitizer.Clean(eventType), Logging.LogSanitizer.Clean(action));
             return new WebhookResult(eventType, action, Skipped: true);
         }
@@ -529,18 +553,50 @@ public sealed class InstallationRouterService : IInstallationRouterService
             ? $"github.{eventType}"
             : $"github.{eventType}.{action}";
 
-        var task = await _taskQueue.EnqueueAsync(
-            type: taskType,
-            payloadJson: payload.GetRawText(),
-            installationId: installationId,
-            tenantIdOverride: tenantId);
+        Guid taskId;
+        string scope;
+        if (tenantId is Guid tid && tid != Guid.Empty && _taskQueue is not null)
+        {
+            var task = await _taskQueue.EnqueueAsync(
+                type: taskType,
+                payloadJson: payload.GetRawText(),
+                installationId: installationId,
+                tenantIdOverride: tid);
+            taskId = task.Id;
+            scope = "tenant";
+        }
+        else if (_platformTasks is not null)
+        {
+            // Orphan webhook (no installation→tenant mapping yet) OR the
+            // per-tenant queue isn't wired. Fall back to the platform
+            // queue — handlers can decide at dispatch time whether to
+            // process or drop.
+            var pt = await _platformTasks.EnqueueAsync(new Tamma.Data.Entities.PlatformQueuedTask
+            {
+                Type = taskType,
+                TenantId = tenantId,
+                InstallationId = installationId,
+                Payload = payload.GetRawText(),
+            });
+            taskId = pt.Id;
+            scope = "platform";
+        }
+        else
+        {
+            // _taskQueue is null and we'd want a tenant-scope enqueue —
+            // there's no orphan-tolerant fallback. Skip.
+            _logger.LogDebug(
+                "Webhook event {Event} (action={Action}) skipped: tenant queue unavailable",
+                Logging.LogSanitizer.Clean(eventType), Logging.LogSanitizer.Clean(action));
+            return new WebhookResult(eventType, action, Skipped: true);
+        }
 
         _logger.LogInformation(
-            "Webhook {Event} (action={Action}) queued as task {TaskId} (installation={InstallationId}, tenant={TenantId})",
+            "Webhook {Event} (action={Action}) queued as task {TaskId} (installation={InstallationId}, tenant={TenantId}, scope={Scope})",
             Logging.LogSanitizer.Clean(eventType), Logging.LogSanitizer.Clean(action),
-            task.Id, installationId, tenantId);
+            taskId, installationId, tenantId, scope);
 
-        return new WebhookResult(eventType, action, Skipped: false, TaskId: task.Id);
+        return new WebhookResult(eventType, action, Skipped: false, TaskId: taskId);
     }
 
     private async Task<WebhookResult> HandleInstallationEventAsync(

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/CranlTenantProvisioner.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/CranlTenantProvisioner.cs
@@ -1,9 +1,9 @@
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Tamma.Api.Services.Provisioning.Cranl;
-using Tamma.Api.Services.TaskQueue;
 using Tamma.Data;
 using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
 
 namespace Tamma.Api.Services.Provisioning;
 
@@ -45,16 +45,27 @@ public sealed class CranlTenantProvisioner : ITenantProvisioner
     public const string DeprovisioningTaskType = "provisioning.tenant.deprovision";
 
     private readonly ControlPlaneDbContext _db;
-    private readonly ITaskQueue _taskQueue;
+    private readonly IPlatformQueuedTaskRepository _platformTasks;
     private readonly ILogger<CranlTenantProvisioner> _logger;
 
+    /// <summary>
+    /// Story 28-1 PR B — provisioning + deprovisioning tasks live on
+    /// the <em>platform</em> queue, not the per-tenant queue. Reason:
+    /// at provisioning time the tenant DB doesn't exist yet (the task's
+    /// whole job is to create it!); at deprovisioning time the tenant
+    /// DB is about to be torn down. Either way the per-tenant queue is
+    /// not a viable home for the work item, so the task lives in
+    /// <c>platform_queued_tasks</c> and the
+    /// <see cref="Tamma.Api.Services.PlatformTasks.PlatformTaskWorker"/>
+    /// drains it.
+    /// </summary>
     public CranlTenantProvisioner(
         ControlPlaneDbContext db,
-        ITaskQueue taskQueue,
+        IPlatformQueuedTaskRepository platformTasks,
         ILogger<CranlTenantProvisioner> logger)
     {
         _db = db;
-        _taskQueue = taskQueue;
+        _platformTasks = platformTasks;
         _logger = logger;
     }
 
@@ -92,11 +103,12 @@ public sealed class CranlTenantProvisioner : ITenantProvisioner
             Region = options.Region,
             CustomName = options.CustomName
         });
-        await _taskQueue.EnqueueAsync(
-            type: ProvisioningTaskType,
-            payloadJson: payload,
-            tenantIdOverride: tenantId,
-            ct: ct);
+        await _platformTasks.EnqueueAsync(new PlatformQueuedTask
+        {
+            Type = ProvisioningTaskType,
+            TenantId = tenantId,
+            Payload = payload,
+        }, ct);
 
         _logger.LogInformation(
             "Enqueued Cranl provisioning task for tenant {TenantId} (region={Region})",
@@ -133,11 +145,12 @@ public sealed class CranlTenantProvisioner : ITenantProvisioner
             Region = tenant.CranlRegion ?? string.Empty,
             CustomName = null
         });
-        await _taskQueue.EnqueueAsync(
-            type: DeprovisioningTaskType,
-            payloadJson: payload,
-            tenantIdOverride: tenantId,
-            ct: ct);
+        await _platformTasks.EnqueueAsync(new PlatformQueuedTask
+        {
+            Type = DeprovisioningTaskType,
+            TenantId = tenantId,
+            Payload = payload,
+        }, ct);
 
         _logger.LogInformation("Enqueued Cranl deprovisioning task for tenant {TenantId}", tenantId);
     }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/TaskQueue/DbTaskQueue.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/TaskQueue/DbTaskQueue.cs
@@ -5,15 +5,17 @@ using Tamma.Data.Repositories;
 namespace Tamma.Api.Services.TaskQueue;
 
 /// <summary>
-/// Database-backed <see cref="ITaskQueue"/>. Derives tenant scoping from the
-/// ambient <see cref="ITenantContext"/>; accepts explicit overrides for
-/// sources where tenancy is resolved from something other than the caller
-/// (notably the GitHub App webhook, which binds tenancy via installation ID).
+/// Database-backed <see cref="ITaskQueue"/>. Strictly tenant-scoped:
+/// derives the tenant from the ambient <see cref="ITenantContext"/>
+/// unless an explicit override is supplied (used by the GitHub webhook
+/// handler that derives tenancy from the installation id, not the
+/// authenticated user).
 ///
-/// <para>Ported from the deleted TypeScript in-memory queue, with the
-/// behaviour of <c>requireInstallationId</c> folded into the webhook caller
-/// rather than this service — tenant isolation here is enforced via the
-/// ambient context, not the installationId field.</para>
+/// <para>Story 28-1 PR B — platform-scope tasks no longer flow through
+/// here. <c>CranlTenantProvisioner</c> and <c>RetireScheduler</c> hit
+/// <see cref="IPlatformQueuedTaskRepository"/> directly; the GitHub
+/// webhook handler routes orphan webhooks to the platform repo too.
+/// This surface ONLY enqueues into a real tenant's per-tenant queue.</para>
 /// </summary>
 public sealed class DbTaskQueue : ITaskQueue
 {
@@ -34,11 +36,18 @@ public sealed class DbTaskQueue : ITaskQueue
         CancellationToken ct = default)
     {
         var tenantId = tenantIdOverride ?? _tenantContext.TenantId;
+        if (tenantId is not Guid tid || tid == Guid.Empty)
+        {
+            throw new InvalidOperationException(
+                "DbTaskQueue.EnqueueAsync requires a tenant id. Set " +
+                "ITenantContext or pass tenantIdOverride. Platform-scope " +
+                "callers must use IPlatformQueuedTaskRepository directly.");
+        }
 
         var task = new QueuedTask
         {
             Type = type,
-            TenantId = tenantId,
+            TenantId = tid,
             InstallationId = installationId,
             Payload = string.IsNullOrWhiteSpace(payloadJson) ? "{}" : payloadJson
         };
@@ -46,18 +55,18 @@ public sealed class DbTaskQueue : ITaskQueue
         return _repo.EnqueueAsync(task, ct);
     }
 
-    public Task<QueuedTask?> GetAsync(Guid id, CancellationToken ct = default)
-        => _repo.GetAsync(id, ct);
+    public Task<QueuedTask?> GetAsync(Guid tenantId, Guid id, CancellationToken ct = default)
+        => _repo.GetAsync(tenantId, id, ct);
 
-    public Task<List<QueuedTask>> ListPendingAsync(int limit = 20, CancellationToken ct = default)
-        => _repo.ListPendingAsync(_tenantContext.TenantId, limit, ct);
+    public Task<List<QueuedTask>> ListPendingAsync(Guid tenantId, int limit = 20, CancellationToken ct = default)
+        => _repo.ListPendingAsync(tenantId, limit, ct);
 
-    public Task<QueuedTask?> MarkProcessingAsync(Guid id, CancellationToken ct = default)
-        => _repo.MarkProcessingAsync(id, ct);
+    public Task<QueuedTask?> MarkProcessingAsync(Guid tenantId, Guid id, CancellationToken ct = default)
+        => _repo.MarkProcessingAsync(tenantId, id, ct);
 
-    public Task MarkCompletedAsync(Guid id, CancellationToken ct = default)
-        => _repo.MarkCompletedAsync(id, ct);
+    public Task MarkCompletedAsync(Guid tenantId, Guid id, CancellationToken ct = default)
+        => _repo.MarkCompletedAsync(tenantId, id, ct);
 
-    public Task MarkFailedAsync(Guid id, string error, CancellationToken ct = default)
-        => _repo.MarkFailedAsync(id, error, ct);
+    public Task MarkFailedAsync(Guid tenantId, Guid id, string error, CancellationToken ct = default)
+        => _repo.MarkFailedAsync(tenantId, id, error, ct);
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/TaskQueue/ITaskQueue.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/TaskQueue/ITaskQueue.cs
@@ -3,9 +3,17 @@ using Tamma.Data.Entities;
 namespace Tamma.Api.Services.TaskQueue;
 
 /// <summary>
-/// Multi-tenant task queue surface used by the API layer. Wraps
-/// <see cref="Tamma.Data.Repositories.IQueuedTaskRepository"/> with tenant
-/// scoping derived from <see cref="Tamma.Data.ITenantContext"/>.
+/// Tenant-scoped task queue surface used by the API layer. Wraps
+/// <see cref="Tamma.Data.Repositories.IQueuedTaskRepository"/> with
+/// tenant scoping derived from <see cref="Tamma.Data.ITenantContext"/>.
+///
+/// <para>Story 28-1 PR B — this surface is now <b>tenant-scoped only</b>.
+/// Platform-scope tasks (tenant provisioning, secret retire, GitHub
+/// orphan webhooks) go straight to
+/// <see cref="Tamma.Data.Repositories.IPlatformQueuedTaskRepository"/>
+/// instead. The decision matrix is in
+/// <c>.dev/decisions/story-28-1-design-calls.md</c> §5 plus the commit
+/// body of PR B itself.</para>
 ///
 /// <para>
 /// Ported from the deleted TypeScript <c>ITaskQueue</c>
@@ -18,11 +26,12 @@ namespace Tamma.Api.Services.TaskQueue;
 public interface ITaskQueue
 {
     /// <summary>
-    /// Enqueue a new pending task. The tenant is resolved from the ambient
-    /// <c>ITenantContext</c>; callers do not set <see cref="QueuedTask.TenantId"/>
-    /// directly. Pass an explicit <paramref name="tenantIdOverride"/> to bypass
-    /// the ambient context (used by the webhook handler, which derives tenancy
-    /// from the GitHub installation ID, not the authenticated user).
+    /// Enqueue a new pending task for a tenant. The tenant is resolved
+    /// from the ambient <see cref="Tamma.Data.ITenantContext"/> unless
+    /// <paramref name="tenantIdOverride"/> is supplied. If neither is
+    /// available the call throws — platform-scope callers must use
+    /// <see cref="Tamma.Data.Repositories.IPlatformQueuedTaskRepository"/>
+    /// instead.
     /// </summary>
     Task<QueuedTask> EnqueueAsync(
         string type,
@@ -32,25 +41,24 @@ public interface ITaskQueue
         CancellationToken ct = default);
 
     /// <summary>
-    /// Fetch a single task by id. Returns the row regardless of tenant
-    /// (processor + observability tools may need cross-tenant reads); callers
-    /// that want tenant isolation must filter on the returned tenant.
+    /// Fetch a single task by id from the supplied tenant's queue.
+    /// Tenant id is required since the per-tenant queue lives in the
+    /// per-tenant DB.
     /// </summary>
-    Task<QueuedTask?> GetAsync(Guid id, CancellationToken ct = default);
+    Task<QueuedTask?> GetAsync(Guid tenantId, Guid id, CancellationToken ct = default);
 
     /// <summary>
-    /// List pending tasks for the ambient tenant. When the ambient tenant is
-    /// <c>null</c> (system scope / self-hosted), returns tasks for every
-    /// tenant — this is the lane the processor takes when it runs unscoped.
+    /// List pending tasks for the supplied tenant. Tenant id is
+    /// required since the per-tenant queue lives in the per-tenant DB.
     /// </summary>
-    Task<List<QueuedTask>> ListPendingAsync(int limit = 20, CancellationToken ct = default);
+    Task<List<QueuedTask>> ListPendingAsync(Guid tenantId, int limit = 20, CancellationToken ct = default);
 
     /// <summary>Claim a pending task. See repository for semantics.</summary>
-    Task<QueuedTask?> MarkProcessingAsync(Guid id, CancellationToken ct = default);
+    Task<QueuedTask?> MarkProcessingAsync(Guid tenantId, Guid id, CancellationToken ct = default);
 
     /// <summary>Mark a claimed task complete.</summary>
-    Task MarkCompletedAsync(Guid id, CancellationToken ct = default);
+    Task MarkCompletedAsync(Guid tenantId, Guid id, CancellationToken ct = default);
 
     /// <summary>Mark a claimed task failed with an error message.</summary>
-    Task MarkFailedAsync(Guid id, string error, CancellationToken ct = default);
+    Task MarkFailedAsync(Guid tenantId, Guid id, string error, CancellationToken ct = default);
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/TaskQueue/TaskQueueProcessor.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/TaskQueue/TaskQueueProcessor.cs
@@ -122,9 +122,14 @@ public sealed class TaskQueueProcessor : BackgroundService
         // new work, so a worker that died mid-task does not leave the row
         // stuck forever. Exceptions here are logged but do not abort the
         // poll; reaping is best-effort.
+        //
+        // Story 28-1 PR B — the reaper now fans out across active tenants
+        // via ReapStaleProcessingAcrossAllTenantsAsync. Once PR D moves
+        // the per-tenant queue into per-tenant DBs the fan-out becomes
+        // the only correct way to reap.
         try
         {
-            var reaped = await repo.ReapStaleProcessingAsync(
+            var reaped = await repo.ReapStaleProcessingAcrossAllTenantsAsync(
                 _options.VisibilityTimeout, _options.MaxRetries, ct);
             if (reaped > 0)
             {
@@ -139,7 +144,9 @@ public sealed class TaskQueueProcessor : BackgroundService
             _logger.LogWarning(ex, "TaskQueueProcessor reaper pass failed");
         }
 
-        var pending = await repo.ListPendingAsync(tenantId: null, _options.BatchSize, ct);
+        // Story 28-1 PR B — fan out across active tenants. The per-tenant
+        // batch is bounded so a hot tenant can't starve the rest.
+        var pending = await repo.ListPendingFromAnyTenantAsync(_options.BatchSize, ct);
         if (pending.Count == 0) return 0;
 
         var processed = 0;
@@ -147,7 +154,19 @@ public sealed class TaskQueueProcessor : BackgroundService
         {
             if (ct.IsCancellationRequested) break;
 
-            var claimed = await repo.MarkProcessingAsync(task.Id, ct);
+            // Every tenant-scope task has a non-null TenantId (enforced
+            // at enqueue time by EmailOutboxRepository / DbTaskQueue).
+            // Defensive null-check kept so a future contract change shows
+            // up at runtime rather than as a silent CP hit.
+            if (task.TenantId is not Guid tid)
+            {
+                _logger.LogError(
+                    "Tenant-queue task {TaskId} has no TenantId — skipping",
+                    task.Id);
+                continue;
+            }
+
+            var claimed = await repo.MarkProcessingAsync(tid, task.Id, ct);
             if (claimed is null)
             {
                 // Someone else claimed it between list + mark; move on.
@@ -167,6 +186,7 @@ public sealed class TaskQueueProcessor : BackgroundService
             if (handler is null)
             {
                 await repo.MarkFailedAsync(
+                    tid,
                     claimed.Id,
                     $"no handler registered for task type '{claimed.Type}'",
                     ct);
@@ -185,7 +205,7 @@ public sealed class TaskQueueProcessor : BackgroundService
             try
             {
                 await handler.HandleAsync(claimed, ct);
-                await repo.MarkCompletedAsync(claimed.Id, ct);
+                await repo.MarkCompletedAsync(tid, claimed.Id, ct);
                 if (bus is not null)
                 {
                     await bus.PublishAsync(new EngineLifecycleEvent(
@@ -197,7 +217,7 @@ public sealed class TaskQueueProcessor : BackgroundService
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                await HandleFailureAsync(repo, claimed, ex, ct);
+                await HandleFailureAsync(repo, tid, claimed, ex, ct);
                 if (bus is not null)
                 {
                     await bus.PublishAsync(new EngineLifecycleEvent(
@@ -216,13 +236,14 @@ public sealed class TaskQueueProcessor : BackgroundService
 
     private async Task HandleFailureAsync(
         IQueuedTaskRepository repo,
+        Guid tenantId,
         QueuedTask claimed,
         Exception ex,
         CancellationToken ct)
     {
         // RetryCount is bumped on every failure — even the terminal one — so the
         // persisted row tells ops exactly how many attempts the task consumed.
-        var requeued = await repo.IncrementRetryAndRequeueAsync(claimed.Id, ex.Message, ct);
+        var requeued = await repo.IncrementRetryAndRequeueAsync(tenantId, claimed.Id, ex.Message, ct);
         var retryCount = requeued?.RetryCount ?? claimed.RetryCount + 1;
 
         if (retryCount >= _options.MaxRetries)
@@ -230,7 +251,7 @@ public sealed class TaskQueueProcessor : BackgroundService
             _logger.LogError(ex,
                 "Task {TaskId} ({Type}) failed after {Attempts} attempts — marking failed",
                 claimed.Id, claimed.Type, retryCount);
-            await repo.MarkFailedAsync(claimed.Id, ex.Message, ct);
+            await repo.MarkFailedAsync(tenantId, claimed.Id, ex.Message, ct);
             return;
         }
 

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/EmailOutboxRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/EmailOutboxRepository.cs
@@ -63,9 +63,9 @@ public class EmailOutboxRepository(
 
         if (string.Equals(db.Database.ProviderName, NpgsqlProviderName, StringComparison.Ordinal))
         {
-            return await ClaimViaPostgresAsync(db, now, ct);
+            return await ClaimViaPostgresAsync(db, tenantId, now, ct);
         }
-        return await ClaimViaNaivePathAsync(db, now, ct);
+        return await ClaimViaNaivePathAsync(db, tenantId, now, ct);
     }
 
     public async Task<EmailOutboxMessage?> ClaimNextPendingFromAnyTenantAsync(
@@ -97,12 +97,14 @@ public class EmailOutboxRepository(
             {
                 row = await ClaimNextPendingAsync(tid, now, ct);
             }
-            catch (Exception)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 // Tenant might be mid-deletion or have a transient
                 // connection failure; don't let one tenant's outage
                 // starve the rest. The caller (OutboxSmtpSender) logs
-                // and the next poll re-tries.
+                // and the next poll re-tries. Wave-4 review M2 —
+                // cooperative cancellation must propagate, not be
+                // swallowed as a "tenant outage".
                 continue;
             }
 
@@ -113,8 +115,13 @@ public class EmailOutboxRepository(
     }
 
     private static async Task<EmailOutboxMessage?> ClaimViaPostgresAsync(
-        TenantDbContext db, DateTime now, CancellationToken ct)
+        TenantDbContext db, Guid tenantId, DateTime now, CancellationToken ct)
     {
+        // Story 28-1 PR B fix (wave-4 review H1) — `WHERE "TenantId" = @tid`
+        // is REQUIRED on both the inner SELECT and the outer UPDATE while the
+        // per-tenant `email_outbox` table physically still co-resides on the
+        // CP DB. Without it tenant A's call would claim the globally oldest
+        // pending row regardless of which tenant owns it.
         var rows = await db.EmailOutbox.FromSqlInterpolated($"""
             UPDATE email_outbox
             SET "Status" = 'sending', "UpdatedAt" = {now}
@@ -122,10 +129,12 @@ public class EmailOutboxRepository(
                 SELECT "Id" FROM email_outbox
                 WHERE "Status" = 'pending'
                   AND "NextAttemptAt" <= {now}
+                  AND "TenantId" = {tenantId}
                 ORDER BY "NextAttemptAt" ASC, "CreatedAt" ASC
                 FOR UPDATE SKIP LOCKED
                 LIMIT 1
             )
+              AND "TenantId" = {tenantId}
             RETURNING *
             """).AsNoTracking().ToListAsync(ct);
 
@@ -133,10 +142,16 @@ public class EmailOutboxRepository(
     }
 
     private static async Task<EmailOutboxMessage?> ClaimViaNaivePathAsync(
-        TenantDbContext db, DateTime now, CancellationToken ct)
+        TenantDbContext db, Guid tenantId, DateTime now, CancellationToken ct)
     {
+        // Story 28-1 PR B fix (wave-4 review H1) — `&& m.TenantId == tenantId`
+        // is REQUIRED in the predicate while the per-tenant table still
+        // physically co-resides on the CP DB. EF-InMemory hides the missing
+        // predicate; the cross-tenant negative tests catch it.
         var candidate = await db.EmailOutbox
-            .Where(m => m.Status == "pending" && m.NextAttemptAt <= now)
+            .Where(m => m.Status == "pending"
+                && m.NextAttemptAt <= now
+                && m.TenantId == tenantId)
             .OrderBy(m => m.NextAttemptAt)
             .ThenBy(m => m.CreatedAt)
             .FirstOrDefaultAsync(ct);
@@ -155,7 +170,13 @@ public class EmailOutboxRepository(
             throw new ArgumentException("Tenant id is required.", nameof(tenantId));
 
         await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
-        var msg = await db.EmailOutbox.FindAsync(new object[] { id }, ct);
+        // Story 28-1 PR B fix (wave-4 review H1) — FindAsync keys on PK
+        // only. While the per-tenant table physically co-resides on the
+        // CP DB, tenant A could mark tenant B's row sent. Predicate-based
+        // lookup makes the tenant id a hard guard.
+        var msg = await db.EmailOutbox
+            .Where(m => m.Id == id && m.TenantId == tenantId)
+            .FirstOrDefaultAsync(ct);
         if (msg is null) return;
 
         var now = DateTime.UtcNow;
@@ -173,7 +194,10 @@ public class EmailOutboxRepository(
             throw new ArgumentException("Tenant id is required.", nameof(tenantId));
 
         await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
-        var msg = await db.EmailOutbox.FindAsync(new object[] { id }, ct);
+        // Story 28-1 PR B fix (wave-4 review H1) — see MarkSentAsync.
+        var msg = await db.EmailOutbox
+            .Where(m => m.Id == id && m.TenantId == tenantId)
+            .FirstOrDefaultAsync(ct);
         if (msg is null) return null;
 
         var now = DateTime.UtcNow;
@@ -201,7 +225,10 @@ public class EmailOutboxRepository(
             throw new ArgumentException("Tenant id is required.", nameof(tenantId));
 
         await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
-        return await db.EmailOutbox.FindAsync(new object[] { id }, ct);
+        // Story 28-1 PR B fix (wave-4 review H1) — see MarkSentAsync.
+        return await db.EmailOutbox
+            .Where(m => m.Id == id && m.TenantId == tenantId)
+            .FirstOrDefaultAsync(ct);
     }
 
     public async Task DeleteAsync(Guid tenantId, Guid id, CancellationToken ct = default)
@@ -210,7 +237,10 @@ public class EmailOutboxRepository(
             throw new ArgumentException("Tenant id is required.", nameof(tenantId));
 
         await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
-        var row = await db.EmailOutbox.FindAsync(new object[] { id }, ct);
+        // Story 28-1 PR B fix (wave-4 review H1) — see MarkSentAsync.
+        var row = await db.EmailOutbox
+            .Where(m => m.Id == id && m.TenantId == tenantId)
+            .FirstOrDefaultAsync(ct);
         if (row is null) return;
         db.EmailOutbox.Remove(row);
         await db.SaveChangesAsync(ct);

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/EmailOutboxRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/EmailOutboxRepository.cs
@@ -5,16 +5,19 @@ using Tamma.Data.Entities;
 namespace Tamma.Data.Repositories;
 
 /// <summary>
-/// EF-backed <see cref="IEmailOutboxRepository"/>.
+/// EF-backed <see cref="IEmailOutboxRepository"/>. Strictly tenant-scoped:
+/// every operation routes through <see cref="ITenantDbContextFactory"/>
+/// so the read/write hits the per-tenant DB. Platform-scope email
+/// (verification, password reset, welcome) goes through
+/// <see cref="IPlatformEmailOutboxRepository"/> instead — see
+/// <c>.dev/decisions/story-28-1-design-calls.md</c> §5 for the matrix.
 ///
-/// <para>In the Epic 28 target architecture each tenant has its own outbox
-/// table in its own DB; the sender polls every tenant's outbox in round-robin
-/// fashion. During the transition the physical table is shared. Enqueue
-/// operations that know their tenant go through
-/// <see cref="ITenantDbContextFactory"/>; sender-facing cross-tenant
-/// operations (claim-next, mark-sent, mark-failed, by-id lookups) use
-/// <see cref="ControlPlaneDbContext"/> because they traverse the shared
-/// outbox as platform-infrastructure.</para>
+/// <para>During the Story 28-1 transition the per-tenant
+/// <c>email_outbox</c> table physically still co-resides on the CP DB —
+/// PR D moves it to per-tenant DBs. Until then a tenant-bound DB
+/// context built by the factory still sees rows that any other
+/// tenant-bound context with the same connection sees. The split here
+/// is logical so the eventual physical move is a no-op for callers.</para>
 /// </summary>
 public class EmailOutboxRepository(
     ITenantDbContextFactory tenantDbFactory,
@@ -25,6 +28,15 @@ public class EmailOutboxRepository(
     public async Task<EmailOutboxMessage> EnqueueAsync(
         EmailOutboxMessage msg, CancellationToken ct = default)
     {
+        if (msg.TenantId is not Guid tid || tid == Guid.Empty)
+        {
+            throw new ArgumentException(
+                "EmailOutboxRepository requires a non-empty TenantId. " +
+                "Platform-scope email (verification, password reset, " +
+                "welcome) must go through IPlatformEmailOutboxRepository.",
+                nameof(msg));
+        }
+
         var now = DateTime.UtcNow;
         msg.Status = "pending";
         msg.Attempts = 0;
@@ -35,33 +47,73 @@ public class EmailOutboxRepository(
         msg.UpdatedAt = now;
         if (msg.MaxAttempts <= 0) msg.MaxAttempts = 5;
 
-        if (msg.TenantId is Guid tid)
-        {
-            await using var db = await tenantDbFactory.CreateAsync(tid);
-            db.EmailOutbox.Add(msg);
-            await db.SaveChangesAsync(ct);
-            return msg;
-        }
-
-        // Platform-scope enqueue (system-generated emails with no tenant).
-        cp.EmailOutbox.Add(msg);
-        await cp.SaveChangesAsync(ct);
+        await using var db = await tenantDbFactory.CreateAsync(tid, ct);
+        db.EmailOutbox.Add(msg);
+        await db.SaveChangesAsync(ct);
         return msg;
     }
 
     public async Task<EmailOutboxMessage?> ClaimNextPendingAsync(
+        Guid tenantId, DateTime now, CancellationToken ct = default)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id is required.", nameof(tenantId));
+
+        await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
+
+        if (string.Equals(db.Database.ProviderName, NpgsqlProviderName, StringComparison.Ordinal))
+        {
+            return await ClaimViaPostgresAsync(db, now, ct);
+        }
+        return await ClaimViaNaivePathAsync(db, now, ct);
+    }
+
+    public async Task<EmailOutboxMessage?> ClaimNextPendingFromAnyTenantAsync(
         DateTime now, CancellationToken ct = default)
     {
-        // Sender path — cross-tenant scan, platform infrastructure.
-        if (string.Equals(cp.Database.ProviderName, NpgsqlProviderName, StringComparison.Ordinal))
+        // Snapshot the active tenant set up-front. Cheap (single SELECT
+        // bounded by the tenants table size) relative to the per-tenant
+        // SMTP delivery this drain pass precedes.
+        //
+        // Story 28-1 PR B: replaces the previous "scan a single shared
+        // CP table" path with a per-tenant fan-out. Returns the FIRST
+        // tenant that yields a claimable row; the next poll cycle picks
+        // up where this one left off. Doesn't try to be globally
+        // FIFO across tenants — within a tenant FIFO is preserved by
+        // ClaimNextPendingAsync's ORDER BY clause.
+        var activeTenantIds = await cp.Tenants
+            .AsNoTracking()
+            .Where(t => t.DeletedAt == null)
+            .OrderBy(t => t.Id) // deterministic-but-cheap traversal order
+            .Select(t => t.Id)
+            .ToListAsync(ct);
+
+        foreach (var tid in activeTenantIds)
         {
-            return await ClaimViaPostgresAsync(cp, now, ct);
+            if (ct.IsCancellationRequested) return null;
+
+            EmailOutboxMessage? row;
+            try
+            {
+                row = await ClaimNextPendingAsync(tid, now, ct);
+            }
+            catch (Exception)
+            {
+                // Tenant might be mid-deletion or have a transient
+                // connection failure; don't let one tenant's outage
+                // starve the rest. The caller (OutboxSmtpSender) logs
+                // and the next poll re-tries.
+                continue;
+            }
+
+            if (row is not null) return row;
         }
-        return await ClaimViaNaivePathAsync(cp, now, ct);
+
+        return null;
     }
 
     private static async Task<EmailOutboxMessage?> ClaimViaPostgresAsync(
-        ControlPlaneDbContext db, DateTime now, CancellationToken ct)
+        TenantDbContext db, DateTime now, CancellationToken ct)
     {
         var rows = await db.EmailOutbox.FromSqlInterpolated($"""
             UPDATE email_outbox
@@ -81,7 +133,7 @@ public class EmailOutboxRepository(
     }
 
     private static async Task<EmailOutboxMessage?> ClaimViaNaivePathAsync(
-        ControlPlaneDbContext db, DateTime now, CancellationToken ct)
+        TenantDbContext db, DateTime now, CancellationToken ct)
     {
         var candidate = await db.EmailOutbox
             .Where(m => m.Status == "pending" && m.NextAttemptAt <= now)
@@ -97,9 +149,13 @@ public class EmailOutboxRepository(
         return candidate;
     }
 
-    public async Task MarkSentAsync(Guid id, CancellationToken ct = default)
+    public async Task MarkSentAsync(Guid tenantId, Guid id, CancellationToken ct = default)
     {
-        var msg = await cp.EmailOutbox.FindAsync(new object[] { id }, ct);
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id is required.", nameof(tenantId));
+
+        await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
+        var msg = await db.EmailOutbox.FindAsync(new object[] { id }, ct);
         if (msg is null) return;
 
         var now = DateTime.UtcNow;
@@ -107,13 +163,17 @@ public class EmailOutboxRepository(
         msg.LastError = null;
         msg.SentAt = now;
         msg.UpdatedAt = now;
-        await cp.SaveChangesAsync(ct);
+        await db.SaveChangesAsync(ct);
     }
 
     public async Task<EmailOutboxMessage?> MarkFailedAsync(
-        Guid id, string error, TimeSpan? backoff, CancellationToken ct = default)
+        Guid tenantId, Guid id, string error, TimeSpan? backoff, CancellationToken ct = default)
     {
-        var msg = await cp.EmailOutbox.FindAsync(new object[] { id }, ct);
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id is required.", nameof(tenantId));
+
+        await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
+        var msg = await db.EmailOutbox.FindAsync(new object[] { id }, ct);
         if (msg is null) return null;
 
         var now = DateTime.UtcNow;
@@ -131,18 +191,28 @@ public class EmailOutboxRepository(
             msg.Status = "failed";
         }
 
-        await cp.SaveChangesAsync(ct);
+        await db.SaveChangesAsync(ct);
         return msg;
     }
 
-    public async Task<EmailOutboxMessage?> GetByIdAsync(Guid id, CancellationToken ct = default)
-        => await cp.EmailOutbox.FindAsync(new object[] { id }, ct);
-
-    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+    public async Task<EmailOutboxMessage?> GetByIdAsync(Guid tenantId, Guid id, CancellationToken ct = default)
     {
-        var row = await cp.EmailOutbox.FindAsync(new object[] { id }, ct);
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id is required.", nameof(tenantId));
+
+        await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
+        return await db.EmailOutbox.FindAsync(new object[] { id }, ct);
+    }
+
+    public async Task DeleteAsync(Guid tenantId, Guid id, CancellationToken ct = default)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id is required.", nameof(tenantId));
+
+        await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
+        var row = await db.EmailOutbox.FindAsync(new object[] { id }, ct);
         if (row is null) return;
-        cp.EmailOutbox.Remove(row);
-        await cp.SaveChangesAsync(ct);
+        db.EmailOutbox.Remove(row);
+        await db.SaveChangesAsync(ct);
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/IEmailOutboxRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/IEmailOutboxRepository.cs
@@ -3,36 +3,73 @@ using Tamma.Data.Entities;
 namespace Tamma.Data.Repositories;
 
 /// <summary>
-/// Persistence port for the email store-and-forward outbox. Pure CRUD;
-/// scheduling policy (poll cadence, backoff curve) lives in the
-/// <c>OutboxSmtpSender</c> hosted service.
+/// Persistence port for the per-tenant email store-and-forward outbox.
+/// Pure CRUD; scheduling policy (poll cadence, backoff curve) lives in
+/// the <c>OutboxSmtpSender</c> hosted service.
+///
+/// <para>Story 28-1 PR B — this repository is now <b>strictly
+/// tenant-scoped</b>. Every operation requires a <c>tenantId</c> so the
+/// implementation can route to the correct per-tenant DB. Callers that
+/// have no tenant (welcome / verification / password reset emails sent
+/// before a tenant DB exists) must use
+/// <see cref="IPlatformEmailOutboxRepository"/> instead. The decision
+/// matrix is in <c>.dev/decisions/story-28-1-design-calls.md</c> §5.</para>
+///
+/// <para>The platform table (<c>platform_email_outbox</c>) and the
+/// per-tenant table (<c>email_outbox</c>) physically co-reside on
+/// the control-plane DB until PR D moves the tenant table into per-tenant
+/// DBs. The split here is purely <em>logical</em>: PR B routes each
+/// caller to the right repo so PR D's physical move is mechanical.</para>
 /// </summary>
 public interface IEmailOutboxRepository
 {
     /// <summary>
-    /// Insert a new message in <c>pending</c> state and return the persisted row.
-    /// The returned <see cref="EmailOutboxMessage.Id"/> is the transaction id
-    /// callers log and tag domain events with.
+    /// Insert a new message in <c>pending</c> state into the tenant's
+    /// outbox and return the persisted row. The returned
+    /// <see cref="EmailOutboxMessage.Id"/> is the transaction id callers
+    /// log and tag domain events with.
+    /// <para>Throws <see cref="ArgumentException"/> if
+    /// <see cref="EmailOutboxMessage.TenantId"/> is null — platform-scope
+    /// callers must use <see cref="IPlatformEmailOutboxRepository"/>.</para>
     /// </summary>
     Task<EmailOutboxMessage> EnqueueAsync(EmailOutboxMessage msg, CancellationToken ct = default);
 
     /// <summary>
-    /// Atomically claim the next <c>pending</c> row whose <c>NextAttemptAt</c>
-    /// is at or before <paramref name="now"/>, flipping it to <c>sending</c> so
-    /// no other sender can pick it up. Returns <c>null</c> when nothing is due.
-    /// <para>
-    /// Postgres implementation uses <c>FOR UPDATE SKIP LOCKED</c> so concurrent
-    /// senders are cluster-safe; the provider-independent in-memory fallback
-    /// relies on change-tracking semantics (single-writer, adequate for tests).
-    /// </para>
+    /// Atomically claim the next <c>pending</c> row for the supplied
+    /// tenant whose <c>NextAttemptAt</c> is at or before
+    /// <paramref name="now"/>, flipping it to <c>sending</c> so no other
+    /// sender can pick it up. Returns <c>null</c> when nothing is due
+    /// for that tenant.
+    /// <para>Postgres implementation uses <c>FOR UPDATE SKIP LOCKED</c>
+    /// so concurrent senders are cluster-safe; the provider-independent
+    /// in-memory fallback relies on change-tracking semantics
+    /// (single-writer, adequate for tests).</para>
     /// </summary>
-    Task<EmailOutboxMessage?> ClaimNextPendingAsync(DateTime now, CancellationToken ct = default);
+    Task<EmailOutboxMessage?> ClaimNextPendingAsync(
+        Guid tenantId, DateTime now, CancellationToken ct = default);
 
     /// <summary>
-    /// Mark a claimed message as successfully delivered. Sets <c>Status=sent</c>
-    /// and <c>SentAt=UtcNow</c>.
+    /// Cross-tenant drain pass — list active tenants from the CP
+    /// <c>tenants</c> table and try
+    /// <see cref="ClaimNextPendingAsync"/> on each until one returns a
+    /// row, or every tenant has been visited. Returns the claimed row
+    /// (with its <see cref="EmailOutboxMessage.TenantId"/> populated for
+    /// the caller's subsequent mark-sent / mark-failed calls), or
+    /// <c>null</c> when no tenant has work.
+    /// <para>Used by <c>OutboxSmtpSender</c> to drain the tenant outbox
+    /// queues without holding a static enumeration of tenants. The
+    /// list-active-tenants query is bounded by the <c>tenants</c> table
+    /// size and runs at the configured poll cadence — cheap relative to
+    /// the SMTP delivery cost it precedes.</para>
     /// </summary>
-    Task MarkSentAsync(Guid id, CancellationToken ct = default);
+    Task<EmailOutboxMessage?> ClaimNextPendingFromAnyTenantAsync(
+        DateTime now, CancellationToken ct = default);
+
+    /// <summary>
+    /// Mark a claimed message as successfully delivered. Sets
+    /// <c>Status=sent</c> and <c>SentAt=UtcNow</c>.
+    /// </summary>
+    Task MarkSentAsync(Guid tenantId, Guid id, CancellationToken ct = default);
 
     /// <summary>
     /// Record a transport failure.
@@ -50,10 +87,10 @@ public interface IEmailOutboxRepository
     /// Returns the updated row so the caller knows whether the retry ceiling was hit.
     /// </summary>
     Task<EmailOutboxMessage?> MarkFailedAsync(
-        Guid id, string error, TimeSpan? backoff, CancellationToken ct = default);
+        Guid tenantId, Guid id, string error, TimeSpan? backoff, CancellationToken ct = default);
 
     /// <summary>Load a single row by id, or <c>null</c> if missing.</summary>
-    Task<EmailOutboxMessage?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task<EmailOutboxMessage?> GetByIdAsync(Guid tenantId, Guid id, CancellationToken ct = default);
 
     /// <summary>
     /// Permanently remove a row. Used by the sender after a successful delivery
@@ -62,5 +99,5 @@ public interface IEmailOutboxRepository
     /// which holds only txn id + template metadata. Failed rows are kept for
     /// operator inspection and are NOT deleted by this method.
     /// </summary>
-    Task DeleteAsync(Guid id, CancellationToken ct = default);
+    Task DeleteAsync(Guid tenantId, Guid id, CancellationToken ct = default);
 }

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/IQueuedTaskRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/IQueuedTaskRepository.cs
@@ -3,64 +3,99 @@ using Tamma.Data.Entities;
 namespace Tamma.Data.Repositories;
 
 /// <summary>
-/// Persistence port for the multi-tenant task queue. Ported from the deleted
-/// TypeScript <c>ITaskQueue</c> in <c>packages/api/src/services/task-queue.ts</c>.
+/// Persistence port for the per-tenant task queue. Pure CRUD — no
+/// polling, no retry semantics, no locking beyond what EF Core provides.
+/// The <c>DbTaskQueue</c> service layer adds tenant scoping; the
+/// <c>TaskQueueProcessor</c> hosted service adds the processing loop and
+/// retry policy.
 ///
-/// <para>
-/// This layer is pure CRUD — no polling, no retry semantics, no locking beyond
-/// what EF Core provides. The <c>DbTaskQueue</c> service layer adds tenant
-/// scoping; the <c>TaskQueueProcessor</c> hosted service adds the processing
-/// loop and retry policy.
-/// </para>
+/// <para>Story 28-1 PR B — this repository is now <b>strictly
+/// tenant-scoped</b>. Every operation requires a <c>tenantId</c> so the
+/// implementation routes to the correct per-tenant DB. Cross-tenant
+/// maintenance work (tenant provisioning, secret retire, GitHub orphan
+/// webhook) goes through <see cref="IPlatformQueuedTaskRepository"/>
+/// instead — see <c>.dev/decisions/story-28-1-design-calls.md</c> §5.</para>
 /// </summary>
 public interface IQueuedTaskRepository
 {
     /// <summary>
-    /// Insert a new row in <c>pending</c> status. The caller is responsible for
-    /// populating <see cref="QueuedTask.Type"/> + payload; everything else is
-    /// filled in by this method.
+    /// Insert a new row in <c>pending</c> status into the supplied
+    /// tenant's queue. The caller is responsible for populating
+    /// <see cref="QueuedTask.Type"/> + payload + a non-null
+    /// <see cref="QueuedTask.TenantId"/>; everything else is filled in
+    /// by this method.
+    /// <para>Throws <see cref="ArgumentException"/> if
+    /// <see cref="QueuedTask.TenantId"/> is null — platform-scope
+    /// callers (provisioning, retire, orphan webhook) must use
+    /// <see cref="IPlatformQueuedTaskRepository"/>.</para>
     /// </summary>
     Task<QueuedTask> EnqueueAsync(QueuedTask task, CancellationToken ct = default);
 
-    /// <summary>Fetch a single task by primary key (or null).</summary>
-    Task<QueuedTask?> GetAsync(Guid id, CancellationToken ct = default);
+    /// <summary>Fetch a single task by primary key from the supplied tenant's
+    /// queue (or null).</summary>
+    Task<QueuedTask?> GetAsync(Guid tenantId, Guid id, CancellationToken ct = default);
 
     /// <summary>
-    /// Return pending tasks in FIFO order (oldest first). When
-    /// <paramref name="tenantId"/> is supplied only tasks belonging to that
-    /// tenant are returned; otherwise every pending task is returned regardless
-    /// of tenant (for the self-hosted processor path).
+    /// Return pending tasks for the supplied tenant in FIFO order
+    /// (oldest first), capped at <paramref name="limit"/>.
     /// </summary>
-    Task<List<QueuedTask>> ListPendingAsync(Guid? tenantId, int limit, CancellationToken ct = default);
+    Task<List<QueuedTask>> ListPendingAsync(Guid tenantId, int limit, CancellationToken ct = default);
+
+    /// <summary>
+    /// Cross-tenant drain pass — list active tenants from the CP
+    /// <c>tenants</c> table and call <see cref="ListPendingAsync"/> on
+    /// each. Returns a flat list of pending tasks across all tenants
+    /// (with each row's <see cref="QueuedTask.TenantId"/> populated for
+    /// the caller's subsequent mark-* calls). Used by
+    /// <c>TaskQueueProcessor</c> as its drain primitive.
+    /// <para>The returned list is bounded by
+    /// <paramref name="batchSizePerTenant"/> per tenant so a hot tenant
+    /// can't starve the rest. The list-active-tenants query is bounded
+    /// by the <c>tenants</c> table size and runs at the configured poll
+    /// cadence — cheap relative to the per-task handler dispatch this
+    /// drain pass precedes.</para>
+    /// </summary>
+    Task<List<QueuedTask>> ListPendingFromAnyTenantAsync(
+        int batchSizePerTenant, CancellationToken ct = default);
 
     /// <summary>
     /// Transition a task from <c>pending</c> → <c>processing</c>. Returns the
     /// updated row, or <c>null</c> if the id was unknown or the row was not in
     /// pending state (already claimed by another worker).
     /// </summary>
-    Task<QueuedTask?> MarkProcessingAsync(Guid id, CancellationToken ct = default);
+    Task<QueuedTask?> MarkProcessingAsync(Guid tenantId, Guid id, CancellationToken ct = default);
 
     /// <summary>Transition to <c>completed</c>.</summary>
-    Task MarkCompletedAsync(Guid id, CancellationToken ct = default);
+    Task MarkCompletedAsync(Guid tenantId, Guid id, CancellationToken ct = default);
 
     /// <summary>
     /// Transition to <c>failed</c> and set <see cref="QueuedTask.Error"/>.
     /// </summary>
-    Task MarkFailedAsync(Guid id, string error, CancellationToken ct = default);
+    Task MarkFailedAsync(Guid tenantId, Guid id, string error, CancellationToken ct = default);
 
     /// <summary>
     /// Increment <see cref="QueuedTask.RetryCount"/> and reset status back to
     /// <c>pending</c> so the processor can re-claim it on its next cycle.
     /// </summary>
-    Task<QueuedTask?> IncrementRetryAndRequeueAsync(Guid id, string error, CancellationToken ct = default);
+    Task<QueuedTask?> IncrementRetryAndRequeueAsync(Guid tenantId, Guid id, string error, CancellationToken ct = default);
 
     /// <summary>
-    /// Audit finding 026 — visibility-timeout reaper. Rows stuck in
-    /// <c>processing</c> for longer than <paramref name="visibilityTimeout"/>
-    /// are presumed orphaned by a dead worker and either re-queued (if
-    /// retry budget remains) or marked <c>failed</c>. Returns the number
-    /// of rows touched.
+    /// Audit finding 026 — visibility-timeout reaper for the supplied
+    /// tenant's queue. Rows stuck in <c>processing</c> for longer than
+    /// <paramref name="visibilityTimeout"/> are presumed orphaned by a
+    /// dead worker and either re-queued (if retry budget remains) or
+    /// marked <c>failed</c>. Returns the number of rows touched.
     /// </summary>
     Task<int> ReapStaleProcessingAsync(
+        Guid tenantId, TimeSpan visibilityTimeout, int maxRetries, CancellationToken ct = default);
+
+    /// <summary>
+    /// Cross-tenant variant of <see cref="ReapStaleProcessingAsync"/> —
+    /// runs the reaper against every active tenant and returns the
+    /// total number of rows reaped. Used by <c>TaskQueueProcessor</c>
+    /// each poll cycle so a worker that died mid-task on any tenant
+    /// gets recovered.
+    /// </summary>
+    Task<int> ReapStaleProcessingAcrossAllTenantsAsync(
         TimeSpan visibilityTimeout, int maxRetries, CancellationToken ct = default);
 }

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/QueuedTaskRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/QueuedTaskRepository.cs
@@ -5,15 +5,19 @@ using Tamma.Data.Entities;
 namespace Tamma.Data.Repositories;
 
 /// <summary>
-/// EF-backed persistence for the <see cref="QueuedTask"/> queue.
+/// EF-backed persistence for the per-tenant <see cref="QueuedTask"/>
+/// queue. Strictly tenant-scoped — every operation routes through
+/// <see cref="ITenantDbContextFactory"/> so the read/write hits the
+/// per-tenant DB. Platform-scope tasks (tenant provisioning, secret
+/// retire, GitHub orphan webhook) use
+/// <see cref="IPlatformQueuedTaskRepository"/> instead — see
+/// <c>.dev/decisions/story-28-1-design-calls.md</c> §5.
 ///
-/// <para>In the Epic 28 target model each tenant's queue lives in its own
-/// DB; the processor round-robins across tenants. Transitional impl:
-/// enqueue uses <see cref="ITenantDbContextFactory"/> when a tenant is
-/// known; processor-facing cross-tenant operations (list-pending across
-/// tenants, reaper, mark-*, by-id lookup) use
-/// <see cref="ControlPlaneDbContext"/> because they walk the shared
-/// queue as platform-infrastructure.</para>
+/// <para>During the Story 28-1 transition the per-tenant
+/// <c>queued_tasks</c> table physically still co-resides on the CP DB —
+/// PR D moves it to per-tenant DBs. Until then a tenant-bound DB
+/// context built by the factory still sees the same shared table; the
+/// split here is logical so the eventual physical move is mechanical.</para>
 /// </summary>
 public class QueuedTaskRepository(
     ITenantDbContextFactory tenantDbFactory,
@@ -21,6 +25,15 @@ public class QueuedTaskRepository(
 {
     public async Task<QueuedTask> EnqueueAsync(QueuedTask task, CancellationToken ct = default)
     {
+        if (task.TenantId is not Guid tid || tid == Guid.Empty)
+        {
+            throw new ArgumentException(
+                "QueuedTaskRepository requires a non-empty TenantId. " +
+                "Platform-scope tasks (provisioning, retire, orphan " +
+                "webhook) must go through IPlatformQueuedTaskRepository.",
+                nameof(task));
+        }
+
         var now = DateTime.UtcNow;
         task.Status = "pending";
         task.RetryCount = 0;
@@ -28,47 +41,78 @@ public class QueuedTaskRepository(
         task.CreatedAt = now;
         task.UpdatedAt = now;
 
-        if (task.TenantId is Guid tid)
-        {
-            await using var db = await tenantDbFactory.CreateAsync(tid);
-            db.QueuedTasks.Add(task);
-            await db.SaveChangesAsync(ct);
-            return task;
-        }
-
-        // Platform-scope task (no tenant).
-        cp.QueuedTasks.Add(task);
-        await cp.SaveChangesAsync(ct);
+        await using var db = await tenantDbFactory.CreateAsync(tid, ct);
+        db.QueuedTasks.Add(task);
+        await db.SaveChangesAsync(ct);
         return task;
     }
 
-    public async Task<QueuedTask?> GetAsync(Guid id, CancellationToken ct = default)
-        => await cp.QueuedTasks.FindAsync(new object[] { id }, ct);
+    public async Task<QueuedTask?> GetAsync(Guid tenantId, Guid id, CancellationToken ct = default)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id is required.", nameof(tenantId));
+
+        await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
+        return await db.QueuedTasks.FindAsync(new object[] { id }, ct);
+    }
 
     public async Task<List<QueuedTask>> ListPendingAsync(
-        Guid? tenantId, int limit, CancellationToken ct = default)
+        Guid tenantId, int limit, CancellationToken ct = default)
     {
-        if (tenantId is Guid tid)
-        {
-            await using var db = await tenantDbFactory.CreateAsync(tid);
-            return await db.QueuedTasks
-                .Where(t => t.Status == "pending" && t.TenantId == tid)
-                .OrderBy(t => t.CreatedAt)
-                .Take(limit)
-                .ToListAsync(ct);
-        }
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id is required.", nameof(tenantId));
 
-        // Cross-tenant processor path — CP.
-        return await cp.QueuedTasks
-            .Where(t => t.Status == "pending")
+        await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
+        return await db.QueuedTasks
+            .Where(t => t.Status == "pending" && t.TenantId == tenantId)
             .OrderBy(t => t.CreatedAt)
             .Take(limit)
             .ToListAsync(ct);
     }
 
-    public async Task<QueuedTask?> MarkProcessingAsync(Guid id, CancellationToken ct = default)
+    public async Task<List<QueuedTask>> ListPendingFromAnyTenantAsync(
+        int batchSizePerTenant, CancellationToken ct = default)
     {
-        var task = await cp.QueuedTasks.FindAsync(new object[] { id }, ct);
+        // Snapshot the active tenant set first. Cheap (single SELECT
+        // bounded by the tenants table) relative to the per-task handler
+        // dispatch this drain pass precedes.
+        var activeTenantIds = await cp.Tenants
+            .AsNoTracking()
+            .Where(t => t.DeletedAt == null)
+            .OrderBy(t => t.Id)
+            .Select(t => t.Id)
+            .ToListAsync(ct);
+
+        var aggregate = new List<QueuedTask>(capacity: activeTenantIds.Count * batchSizePerTenant);
+        foreach (var tid in activeTenantIds)
+        {
+            if (ct.IsCancellationRequested) break;
+
+            try
+            {
+                var rows = await ListPendingAsync(tid, batchSizePerTenant, ct);
+                aggregate.AddRange(rows);
+            }
+            catch (Exception)
+            {
+                // Tenant might be mid-deletion or have a transient
+                // connection failure; don't let one tenant's outage
+                // starve the rest. The caller logs and the next poll
+                // re-tries.
+                continue;
+            }
+        }
+
+        return aggregate;
+    }
+
+    public async Task<QueuedTask?> MarkProcessingAsync(Guid tenantId, Guid id, CancellationToken ct = default)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id is required.", nameof(tenantId));
+
+        await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
+        var task = await db.QueuedTasks.FindAsync(new object[] { id }, ct);
         if (task is null) return null;
         if (task.Status != "pending") return null;
 
@@ -76,15 +120,19 @@ public class QueuedTaskRepository(
         task.Status = "processing";
         task.ClaimedAt = now;
         task.UpdatedAt = now;
-        await cp.SaveChangesAsync(ct);
+        await db.SaveChangesAsync(ct);
         return task;
     }
 
     public async Task<int> ReapStaleProcessingAsync(
-        TimeSpan visibilityTimeout, int maxRetries, CancellationToken ct = default)
+        Guid tenantId, TimeSpan visibilityTimeout, int maxRetries, CancellationToken ct = default)
     {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id is required.", nameof(tenantId));
+
+        await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
         var threshold = DateTime.UtcNow - visibilityTimeout;
-        var stale = await cp.QueuedTasks
+        var stale = await db.QueuedTasks
             .Where(t => t.Status == "processing"
                 && (t.ClaimedAt == null || t.ClaimedAt < threshold))
             .ToListAsync(ct);
@@ -108,43 +156,84 @@ public class QueuedTaskRepository(
                 task.ClaimedAt = null;
             }
         }
-        await cp.SaveChangesAsync(ct);
+        await db.SaveChangesAsync(ct);
         return stale.Count;
     }
 
-    public async Task MarkCompletedAsync(Guid id, CancellationToken ct = default)
+    public async Task<int> ReapStaleProcessingAcrossAllTenantsAsync(
+        TimeSpan visibilityTimeout, int maxRetries, CancellationToken ct = default)
     {
-        var task = await cp.QueuedTasks.FindAsync(new object[] { id }, ct);
+        var activeTenantIds = await cp.Tenants
+            .AsNoTracking()
+            .Where(t => t.DeletedAt == null)
+            .OrderBy(t => t.Id)
+            .Select(t => t.Id)
+            .ToListAsync(ct);
+
+        var total = 0;
+        foreach (var tid in activeTenantIds)
+        {
+            if (ct.IsCancellationRequested) break;
+
+            try
+            {
+                total += await ReapStaleProcessingAsync(tid, visibilityTimeout, maxRetries, ct);
+            }
+            catch (Exception)
+            {
+                // Don't let one tenant's outage starve the reaper for
+                // the rest; the caller logs and the next poll re-tries.
+                continue;
+            }
+        }
+        return total;
+    }
+
+    public async Task MarkCompletedAsync(Guid tenantId, Guid id, CancellationToken ct = default)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id is required.", nameof(tenantId));
+
+        await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
+        var task = await db.QueuedTasks.FindAsync(new object[] { id }, ct);
         if (task is null) return;
 
         task.Status = "completed";
         task.Error = null;
         task.UpdatedAt = DateTime.UtcNow;
-        await cp.SaveChangesAsync(ct);
+        await db.SaveChangesAsync(ct);
     }
 
-    public async Task MarkFailedAsync(Guid id, string error, CancellationToken ct = default)
+    public async Task MarkFailedAsync(Guid tenantId, Guid id, string error, CancellationToken ct = default)
     {
-        var task = await cp.QueuedTasks.FindAsync(new object[] { id }, ct);
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id is required.", nameof(tenantId));
+
+        await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
+        var task = await db.QueuedTasks.FindAsync(new object[] { id }, ct);
         if (task is null) return;
 
         task.Status = "failed";
         task.Error = error;
         task.UpdatedAt = DateTime.UtcNow;
-        await cp.SaveChangesAsync(ct);
+        await db.SaveChangesAsync(ct);
     }
 
     public async Task<QueuedTask?> IncrementRetryAndRequeueAsync(
-        Guid id, string error, CancellationToken ct = default)
+        Guid tenantId, Guid id, string error, CancellationToken ct = default)
     {
-        var task = await cp.QueuedTasks.FindAsync(new object[] { id }, ct);
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id is required.", nameof(tenantId));
+
+        await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
+        var task = await db.QueuedTasks.FindAsync(new object[] { id }, ct);
         if (task is null) return null;
 
         task.RetryCount += 1;
         task.Status = "pending";
         task.Error = error;
         task.UpdatedAt = DateTime.UtcNow;
-        await cp.SaveChangesAsync(ct);
+        await db.SaveChangesAsync(ct);
         return task;
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/QueuedTaskRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/QueuedTaskRepository.cs
@@ -53,7 +53,13 @@ public class QueuedTaskRepository(
             throw new ArgumentException("Tenant id is required.", nameof(tenantId));
 
         await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
-        return await db.QueuedTasks.FindAsync(new object[] { id }, ct);
+        // Story 28-1 PR B fix (wave-4 review H2) — FindAsync keys on PK
+        // only. While the per-tenant queue physically still co-resides
+        // on the CP DB, tenant A's call could read tenant B's row.
+        // Predicate-based lookup makes the tenant id a hard guard.
+        return await db.QueuedTasks
+            .Where(t => t.Id == id && t.TenantId == tenantId)
+            .FirstOrDefaultAsync(ct);
     }
 
     public async Task<List<QueuedTask>> ListPendingAsync(
@@ -93,12 +99,13 @@ public class QueuedTaskRepository(
                 var rows = await ListPendingAsync(tid, batchSizePerTenant, ct);
                 aggregate.AddRange(rows);
             }
-            catch (Exception)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 // Tenant might be mid-deletion or have a transient
                 // connection failure; don't let one tenant's outage
                 // starve the rest. The caller logs and the next poll
-                // re-tries.
+                // re-tries. Wave-4 review M2 — cooperative cancellation
+                // must propagate, not be swallowed as a "tenant outage".
                 continue;
             }
         }
@@ -112,7 +119,10 @@ public class QueuedTaskRepository(
             throw new ArgumentException("Tenant id is required.", nameof(tenantId));
 
         await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
-        var task = await db.QueuedTasks.FindAsync(new object[] { id }, ct);
+        // Story 28-1 PR B fix (wave-4 review H2) — see GetAsync.
+        var task = await db.QueuedTasks
+            .Where(t => t.Id == id && t.TenantId == tenantId)
+            .FirstOrDefaultAsync(ct);
         if (task is null) return null;
         if (task.Status != "pending") return null;
 
@@ -179,10 +189,12 @@ public class QueuedTaskRepository(
             {
                 total += await ReapStaleProcessingAsync(tid, visibilityTimeout, maxRetries, ct);
             }
-            catch (Exception)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 // Don't let one tenant's outage starve the reaper for
                 // the rest; the caller logs and the next poll re-tries.
+                // Wave-4 review M2 — cooperative cancellation must
+                // propagate, not be swallowed as a "tenant outage".
                 continue;
             }
         }
@@ -195,7 +207,10 @@ public class QueuedTaskRepository(
             throw new ArgumentException("Tenant id is required.", nameof(tenantId));
 
         await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
-        var task = await db.QueuedTasks.FindAsync(new object[] { id }, ct);
+        // Story 28-1 PR B fix (wave-4 review H2) — see GetAsync.
+        var task = await db.QueuedTasks
+            .Where(t => t.Id == id && t.TenantId == tenantId)
+            .FirstOrDefaultAsync(ct);
         if (task is null) return;
 
         task.Status = "completed";
@@ -210,7 +225,10 @@ public class QueuedTaskRepository(
             throw new ArgumentException("Tenant id is required.", nameof(tenantId));
 
         await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
-        var task = await db.QueuedTasks.FindAsync(new object[] { id }, ct);
+        // Story 28-1 PR B fix (wave-4 review H2) — see GetAsync.
+        var task = await db.QueuedTasks
+            .Where(t => t.Id == id && t.TenantId == tenantId)
+            .FirstOrDefaultAsync(ct);
         if (task is null) return;
 
         task.Status = "failed";
@@ -226,7 +244,10 @@ public class QueuedTaskRepository(
             throw new ArgumentException("Tenant id is required.", nameof(tenantId));
 
         await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
-        var task = await db.QueuedTasks.FindAsync(new object[] { id }, ct);
+        // Story 28-1 PR B fix (wave-4 review H2) — see GetAsync.
+        var task = await db.QueuedTasks
+            .Where(t => t.Id == id && t.TenantId == tenantId)
+            .FirstOrDefaultAsync(ct);
         if (task is null) return null;
 
         task.RetryCount += 1;

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Email/AuthRegisterLogAssertionTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Email/AuthRegisterLogAssertionTests.cs
@@ -114,13 +114,15 @@ public class AuthRegisterLogAssertionTests
             m => m.Contains("user-under-test@example.com"),
             "recipient address must never appear in any log line");
 
-        // SendAsync was called with a message tagged with the template name,
-        // the user id, and the tenant id — verify the propagation contract.
+        // SendAsync was called with a message tagged with the template
+        // name and the user id. Story 28-1 PR B — TenantId is null on
+        // verification emails (platform-scope: no tenant DB exists yet
+        // at registration). The user id is preserved for correlation.
         emailSvc.Verify(s => s.SendAsync(
             It.Is<EmailMessage>(m =>
                 m.Template == "verification" &&
                 m.UserId == createdUserId &&
-                m.TenantId == createdTenantId),
+                m.TenantId == null),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Email/AuthRegisterTxnIdIntegrationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Email/AuthRegisterTxnIdIntegrationTests.cs
@@ -16,12 +16,17 @@ namespace Tamma.Api.Tests.Email;
 /// email pipeline. Registers a user against the real HTTP + Postgres stack
 /// configured for SMTP provider mode (outbox path) and asserts:
 /// <list type="bullet">
-///   <item><description>A <c>EMAIL.QUEUED.SUCCESS</c> row appears in
-///     <c>domain_events</c> with a <c>txn_id</c> tag.</description></item>
-///   <item><description>An <c>email_outbox</c> row exists whose <c>Id</c>
-///     equals that <c>txn_id</c> — proving end-to-end correlation through
-///     the pipeline.</description></item>
+///   <item><description>A <c>EMAIL.QUEUED.SUCCESS</c> row appears with a
+///     <c>txn_id</c> tag.</description></item>
+///   <item><description>A <c>platform_email_outbox</c> row exists whose
+///     <c>Id</c> equals that <c>txn_id</c> — proving end-to-end correlation
+///     through the pipeline.</description></item>
 /// </list>
+///
+/// <para>Story 28-1 PR B — verification email is now platform-scope
+/// (no tenant DB exists yet at registration). The row lands in
+/// <c>platform_email_outbox</c> not the per-tenant <c>email_outbox</c>;
+/// the QUEUED event uses the same txn-id as the platform-outbox row.</para>
 ///
 /// <para>The log-line-level assertion ("Register logs the txn id") lives in
 /// <see cref="AuthRegisterLogAssertionTests"/> (unit scope). Serilog's hosted
@@ -91,11 +96,15 @@ public class AuthRegisterTxnIdIntegrationTests
         txnIdStr.Should().NotBeNullOrEmpty();
         tags["template"].Should().Be("verification");
 
-        // The txn_id on the event MUST equal the outbox row id — that is the
-        // end-to-end correlation contract the pipeline promises.
-        var outboxRows = await db.EmailOutbox.ToListAsync();
+        // Story 28-1 PR B — verification email is platform-scope.
+        // The txn_id on the event MUST equal the platform-outbox row id.
+        var outboxRows = await db.PlatformEmailOutbox.ToListAsync();
         outboxRows.Should().ContainSingle();
         outboxRows[0].Id.ToString().Should().Be(txnIdStr);
+
+        // No tenant-scope email row should exist — verification email is
+        // strictly platform-scope.
+        (await db.EmailOutbox.ToListAsync()).Should().BeEmpty();
 
         // Event payload must NOT leak recipient / subject / body — CodeQL
         // would flag those. Tags and data are checked separately.
@@ -120,7 +129,9 @@ public class AuthRegisterTxnIdIntegrationTests
         using var scope = ApiTestFixture.Factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<ControlPlaneDbContext>();
 
-        var rows = await db.EmailOutbox.ToListAsync();
+        // Story 28-1 PR B — verification email is platform-scope; row
+        // lands in platform_email_outbox.
+        var rows = await db.PlatformEmailOutbox.ToListAsync();
         rows.Should().ContainSingle();
         rows[0].Status.Should().Be("pending");
         rows[0].Template.Should().Be("verification");
@@ -134,6 +145,6 @@ public class AuthRegisterTxnIdIntegrationTests
 
         var tags = JsonSerializer.Deserialize<Dictionary<string, string?>>(queued[0].Tags)!;
         tags["txn_id"].Should().Be(rows[0].Id.ToString(),
-            "outbox row id IS the transaction id emitted in the QUEUED event");
+            "platform-outbox row id IS the transaction id emitted in the QUEUED event");
     }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Email/EmailOutboxRepositoryTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Email/EmailOutboxRepositoryTests.cs
@@ -13,10 +13,18 @@ namespace Tamma.Api.Tests.Email;
 /// provider for isolation — the <c>FOR UPDATE SKIP LOCKED</c> Postgres path is
 /// separately covered by integration tests in
 /// <see cref="AuthRegisterTxnIdIntegrationTests"/>.
+///
+/// <para>Story 28-1 PR B — every test now operates against a single
+/// fixed tenant id; the repo is strictly tenant-scoped post-PR-B and
+/// every operation requires the tenant id explicitly. The
+/// <c>FromAnyTenant</c> drain path is covered by a small additional
+/// suite at the bottom that seeds an active tenant row in CP and
+/// asserts the drain returns the seeded outbox row.</para>
 /// </summary>
 [TestFixture]
 public class EmailOutboxRepositoryTests
 {
+    private static readonly Guid TestTenantId = Guid.Parse("11111111-1111-1111-1111-111111111111");
     private ControlPlaneDbContext _db = null!;
     private EmailOutboxRepository _repo = null!;
 
@@ -38,6 +46,19 @@ public class EmailOutboxRepositoryTests
         _db = new TestControlPlaneDbContext(cpOptions);
         var factory = new TestTenantDbContextFactory(tenantOptions);
         _repo = new EmailOutboxRepository(factory, _db);
+
+        // Seed an active-tenant row so ClaimNextPendingFromAnyTenantAsync
+        // has a tenant to walk.
+        _db.Tenants.Add(new Tenant
+        {
+            Id = TestTenantId,
+            Name = "test",
+            Slug = "test",
+            Type = "personal",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        _db.SaveChanges();
     }
 
     [TearDown]
@@ -46,6 +67,7 @@ public class EmailOutboxRepositoryTests
     private static EmailOutboxMessage NewMessage(string template = "verification")
         => new()
         {
+            TenantId = TestTenantId,
             Template = template,
             ToAddress = "user@example.com",
             Subject = "Verify your email",
@@ -87,12 +109,24 @@ public class EmailOutboxRepositoryTests
         msg.MaxAttempts.Should().Be(5);
     }
 
+    [Test]
+    public async Task EnqueueAsync_ThrowsWhenTenantIdNull()
+    {
+        var seed = NewMessage();
+        seed.TenantId = null;
+
+        var act = async () => await _repo.EnqueueAsync(seed);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*TenantId*");
+    }
+
     // ── ClaimNextPendingAsync ──
 
     [Test]
     public async Task ClaimNextPendingAsync_ReturnsNull_WhenNothingPending()
     {
-        var claim = await _repo.ClaimNextPendingAsync(DateTime.UtcNow);
+        var claim = await _repo.ClaimNextPendingAsync(TestTenantId, DateTime.UtcNow);
         claim.Should().BeNull();
     }
 
@@ -101,12 +135,12 @@ public class EmailOutboxRepositoryTests
     {
         var msg = await _repo.EnqueueAsync(NewMessage());
 
-        var claimed = await _repo.ClaimNextPendingAsync(DateTime.UtcNow);
+        var claimed = await _repo.ClaimNextPendingAsync(TestTenantId, DateTime.UtcNow);
 
         claimed.Should().NotBeNull();
         claimed!.Id.Should().Be(msg.Id);
 
-        var stored = await _repo.GetByIdAsync(msg.Id);
+        var stored = await _repo.GetByIdAsync(TestTenantId, msg.Id);
         stored!.Status.Should().Be("sending");
     }
 
@@ -114,11 +148,16 @@ public class EmailOutboxRepositoryTests
     public async Task ClaimNextPendingAsync_SkipsRowsNotYetDue()
     {
         var msg = await _repo.EnqueueAsync(NewMessage());
-        // Schedule far in the future so current-time claims can't grab it.
-        msg.NextAttemptAt = DateTime.UtcNow.AddHours(1);
+
+        // Schedule far in the future so current-time claims can't grab
+        // it. Story 28-1 PR B — the row lives in the per-tenant DB; use
+        // a fresh CP-shared in-memory context to mutate it without
+        // wedging change-tracking on the test's CP context.
+        var stored = await _db.EmailOutbox.FindAsync(msg.Id);
+        stored!.NextAttemptAt = DateTime.UtcNow.AddHours(1);
         await _db.SaveChangesAsync();
 
-        var claim = await _repo.ClaimNextPendingAsync(DateTime.UtcNow);
+        var claim = await _repo.ClaimNextPendingAsync(TestTenantId, DateTime.UtcNow);
 
         claim.Should().BeNull("row is not due yet — NextAttemptAt > now");
     }
@@ -130,7 +169,7 @@ public class EmailOutboxRepositoryTests
         await Task.Delay(10);
         var second = await _repo.EnqueueAsync(NewMessage("second"));
 
-        var claim = await _repo.ClaimNextPendingAsync(DateTime.UtcNow);
+        var claim = await _repo.ClaimNextPendingAsync(TestTenantId, DateTime.UtcNow);
 
         claim!.Id.Should().Be(first.Id, "FIFO — the earlier NextAttemptAt wins");
     }
@@ -141,13 +180,47 @@ public class EmailOutboxRepositoryTests
         var first = await _repo.EnqueueAsync(NewMessage("first"));
         var second = await _repo.EnqueueAsync(NewMessage("second"));
 
-        var a = await _repo.ClaimNextPendingAsync(DateTime.UtcNow);
-        var b = await _repo.ClaimNextPendingAsync(DateTime.UtcNow);
+        var a = await _repo.ClaimNextPendingAsync(TestTenantId, DateTime.UtcNow);
+        var b = await _repo.ClaimNextPendingAsync(TestTenantId, DateTime.UtcNow);
 
         a!.Id.Should().Be(first.Id);
         b!.Id.Should().Be(second.Id, "second claim returns a different row");
-        var c = await _repo.ClaimNextPendingAsync(DateTime.UtcNow);
+        var c = await _repo.ClaimNextPendingAsync(TestTenantId, DateTime.UtcNow);
         c.Should().BeNull("no more pending rows");
+    }
+
+    // ── ClaimNextPendingFromAnyTenantAsync (Story 28-1 PR B) ──
+
+    [Test]
+    public async Task ClaimNextPendingFromAnyTenantAsync_ReturnsRowFromActiveTenant()
+    {
+        var msg = await _repo.EnqueueAsync(NewMessage("verification"));
+
+        var claimed = await _repo.ClaimNextPendingFromAnyTenantAsync(DateTime.UtcNow);
+
+        claimed.Should().NotBeNull();
+        claimed!.Id.Should().Be(msg.Id);
+        claimed.TenantId.Should().Be(TestTenantId);
+    }
+
+    [Test]
+    public async Task ClaimNextPendingFromAnyTenantAsync_ReturnsNull_WhenNoTenantsActive()
+    {
+        // Soft-delete the tenant.
+        var t = await _db.Tenants.FindAsync(TestTenantId);
+        t!.DeletedAt = DateTime.UtcNow;
+        await _db.SaveChangesAsync();
+
+        var claimed = await _repo.ClaimNextPendingFromAnyTenantAsync(DateTime.UtcNow);
+
+        claimed.Should().BeNull();
+    }
+
+    [Test]
+    public async Task ClaimNextPendingFromAnyTenantAsync_ReturnsNull_WhenNothingPending()
+    {
+        var claimed = await _repo.ClaimNextPendingFromAnyTenantAsync(DateTime.UtcNow);
+        claimed.Should().BeNull();
     }
 
     // ── MarkSent ──
@@ -156,11 +229,11 @@ public class EmailOutboxRepositoryTests
     public async Task MarkSentAsync_SetsStatusAndSentAt()
     {
         var msg = await _repo.EnqueueAsync(NewMessage());
-        await _repo.ClaimNextPendingAsync(DateTime.UtcNow);
+        await _repo.ClaimNextPendingAsync(TestTenantId, DateTime.UtcNow);
 
-        await _repo.MarkSentAsync(msg.Id);
+        await _repo.MarkSentAsync(TestTenantId, msg.Id);
 
-        var stored = await _repo.GetByIdAsync(msg.Id);
+        var stored = await _repo.GetByIdAsync(TestTenantId, msg.Id);
         stored!.Status.Should().Be("sent");
         stored.SentAt.Should().NotBeNull();
         stored.SentAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
@@ -170,7 +243,7 @@ public class EmailOutboxRepositoryTests
     [Test]
     public async Task MarkSentAsync_Noop_WhenRowMissing()
     {
-        var act = async () => await _repo.MarkSentAsync(Guid.NewGuid());
+        var act = async () => await _repo.MarkSentAsync(TestTenantId, Guid.NewGuid());
         await act.Should().NotThrowAsync("missing rows are silently ignored");
     }
 
@@ -180,11 +253,11 @@ public class EmailOutboxRepositoryTests
     public async Task MarkFailedAsync_UnderCeiling_IncrementsAttempts_RequeuesWithBackoff()
     {
         var msg = await _repo.EnqueueAsync(NewMessage());
-        await _repo.ClaimNextPendingAsync(DateTime.UtcNow);
+        await _repo.ClaimNextPendingAsync(TestTenantId, DateTime.UtcNow);
 
         var before = DateTime.UtcNow;
         var updated = await _repo.MarkFailedAsync(
-            msg.Id, "smtp connect refused", TimeSpan.FromMinutes(5));
+            TestTenantId, msg.Id, "smtp connect refused", TimeSpan.FromMinutes(5));
 
         updated.Should().NotBeNull();
         updated!.Status.Should().Be("pending", "requeue when attempts < max");
@@ -200,11 +273,11 @@ public class EmailOutboxRepositoryTests
         msg.MaxAttempts = 2;
         var enq = await _repo.EnqueueAsync(msg);
 
-        await _repo.ClaimNextPendingAsync(DateTime.UtcNow);
-        await _repo.MarkFailedAsync(enq.Id, "err1", TimeSpan.FromMinutes(1));
+        await _repo.ClaimNextPendingAsync(TestTenantId, DateTime.UtcNow);
+        await _repo.MarkFailedAsync(TestTenantId, enq.Id, "err1", TimeSpan.FromMinutes(1));
 
-        await _repo.ClaimNextPendingAsync(DateTime.UtcNow.AddHours(1));
-        var final = await _repo.MarkFailedAsync(enq.Id, "err2", TimeSpan.FromMinutes(5));
+        await _repo.ClaimNextPendingAsync(TestTenantId, DateTime.UtcNow.AddHours(1));
+        var final = await _repo.MarkFailedAsync(TestTenantId, enq.Id, "err2", TimeSpan.FromMinutes(5));
 
         final!.Status.Should().Be("failed");
         final.Attempts.Should().Be(2);
@@ -215,10 +288,10 @@ public class EmailOutboxRepositoryTests
     public async Task MarkFailedAsync_DefaultsBackoffWhenNull()
     {
         var msg = await _repo.EnqueueAsync(NewMessage());
-        await _repo.ClaimNextPendingAsync(DateTime.UtcNow);
+        await _repo.ClaimNextPendingAsync(TestTenantId, DateTime.UtcNow);
 
         var before = DateTime.UtcNow;
-        var updated = await _repo.MarkFailedAsync(msg.Id, "err", backoff: null);
+        var updated = await _repo.MarkFailedAsync(TestTenantId, msg.Id, "err", backoff: null);
 
         updated!.NextAttemptAt.Should().BeAfter(before,
             "default backoff still schedules NextAttemptAt in the future");
@@ -228,7 +301,7 @@ public class EmailOutboxRepositoryTests
 
     [Test]
     public async Task GetByIdAsync_ReturnsNull_ForUnknownId()
-        => (await _repo.GetByIdAsync(Guid.NewGuid())).Should().BeNull();
+        => (await _repo.GetByIdAsync(TestTenantId, Guid.NewGuid())).Should().BeNull();
 
     // ── DeleteAsync ──
 
@@ -237,15 +310,15 @@ public class EmailOutboxRepositoryTests
     {
         var msg = await _repo.EnqueueAsync(NewMessage());
 
-        await _repo.DeleteAsync(msg.Id);
+        await _repo.DeleteAsync(TestTenantId, msg.Id);
 
-        (await _repo.GetByIdAsync(msg.Id)).Should().BeNull();
+        (await _repo.GetByIdAsync(TestTenantId, msg.Id)).Should().BeNull();
     }
 
     [Test]
     public async Task DeleteAsync_Noop_WhenRowMissing()
     {
         // No exception on deleting a non-existent id.
-        await _repo.DeleteAsync(Guid.NewGuid());
+        await _repo.DeleteAsync(TestTenantId, Guid.NewGuid());
     }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Email/OutboxSmtpSenderTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Email/OutboxSmtpSenderTests.cs
@@ -24,6 +24,7 @@ namespace Tamma.Api.Tests.Email;
 [TestFixture]
 public class OutboxSmtpSenderTests
 {
+    private static readonly Guid TestTenantId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
     private ServiceProvider _services = null!;
     private DbContextOptions<ControlPlaneDbContext> _cpOptions = null!;
     private DbContextOptions<TenantDbContext> _tenantOptions = null!;
@@ -59,6 +60,23 @@ public class OutboxSmtpSenderTests
         services.AddSingleton(_transport.Object);
 
         _services = services.BuildServiceProvider();
+
+        // Seed an active tenant — Story 28-1 PR B: the cross-tenant
+        // drain path enumerates active tenants from CP. Without one,
+        // the sender finds nothing to drain.
+        using (var seed = new TestControlPlaneDbContext(_cpOptions))
+        {
+            seed.Tenants.Add(new Tenant
+            {
+                Id = TestTenantId,
+                Name = "test",
+                Slug = "test",
+                Type = "personal",
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+            });
+            seed.SaveChanges();
+        }
 
         _config = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -101,6 +119,7 @@ public class OutboxSmtpSenderTests
 
     private static EmailOutboxMessage NewRow(int maxAttempts = 5) => new()
     {
+        TenantId = TestTenantId,
         Template = "verification",
         ToAddress = "u@example.com",
         Subject = "Verify",
@@ -129,7 +148,7 @@ public class OutboxSmtpSenderTests
         // Row is deleted after successful delivery — audit trail lives in the
         // event store (EMAIL.SENT.SUCCESS below), so recipient/subject/body
         // don't persist in the outbox past the successful-send moment.
-        var stored = await FreshOutbox().GetByIdAsync(enq.Id);
+        var stored = await FreshOutbox().GetByIdAsync(TestTenantId, enq.Id);
         stored.Should().BeNull();
 
         var sent = await FreshEvents().QueryAsync(null, EmailEventTypes.Sent, null, 10);
@@ -147,7 +166,7 @@ public class OutboxSmtpSenderTests
 
         await _sender.ProcessOnceAsync(CancellationToken.None);
 
-        var stored = await FreshOutbox().GetByIdAsync(enq.Id);
+        var stored = await FreshOutbox().GetByIdAsync(TestTenantId, enq.Id);
         stored.Should().BeNull("the sent row must be purged so the recipient " +
                               "address and body don't linger beyond delivery");
     }
@@ -170,7 +189,7 @@ public class OutboxSmtpSenderTests
         var before = DateTime.UtcNow;
         await _sender.ProcessOnceAsync(CancellationToken.None);
 
-        var stored = await FreshOutbox().GetByIdAsync(enq.Id);
+        var stored = await FreshOutbox().GetByIdAsync(TestTenantId, enq.Id);
         stored!.Status.Should().Be("pending", "requeued — not yet at max attempts");
         stored.Attempts.Should().Be(1);
         stored.LastError.Should().Contain("connect refused");
@@ -193,7 +212,7 @@ public class OutboxSmtpSenderTests
 
         // Attempt 1 — transient, requeued with backoff into the future.
         await _sender.ProcessOnceAsync(CancellationToken.None);
-        var afterFirst = await FreshOutbox().GetByIdAsync(enq.Id);
+        var afterFirst = await FreshOutbox().GetByIdAsync(TestTenantId, enq.Id);
         afterFirst!.Status.Should().Be("pending");
 
         // Fast-forward NextAttemptAt so the next ProcessOnceAsync picks it up.
@@ -210,7 +229,7 @@ public class OutboxSmtpSenderTests
         // would mean recipient/subject/body lingering in the DB indefinitely.
         await _sender.ProcessOnceAsync(CancellationToken.None);
 
-        var stored = await FreshOutbox().GetByIdAsync(enq.Id);
+        var stored = await FreshOutbox().GetByIdAsync(TestTenantId, enq.Id);
         stored.Should().BeNull("terminal failure purges the row — event store holds the audit");
 
         var failed = await FreshEvents().QueryAsync(null, EmailEventTypes.Failed, null, 10);

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Email/SmtpEmailServiceOutboxTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Email/SmtpEmailServiceOutboxTests.cs
@@ -29,9 +29,11 @@ namespace Tamma.Api.Tests.Email;
 [TestFixture]
 public class SmtpEmailServiceOutboxTests
 {
+    private static readonly Guid TestTenantId = Guid.Parse("11111111-2222-3333-4444-555555555555");
     private InMemoryDbFixture _fx = null!;
     private ControlPlaneDbContext _db = null!;
     private EmailOutboxRepository _outbox = null!;
+    private PlatformEmailOutboxRepository _platformOutbox = null!;
     private EventRepository _events = null!;
     private TenantContext _tenantContext = null!;
     private IConfiguration _config = null!;
@@ -43,7 +45,21 @@ public class SmtpEmailServiceOutboxTests
         _tenantContext = new TenantContext();
         _db = _fx.Cp;
         _outbox = new EmailOutboxRepository(_fx.Factory, _db);
+        _platformOutbox = new PlatformEmailOutboxRepository(_db);
         _events = new EventRepository(_fx.Factory, _tenantContext, _db);
+
+        // Seed an active tenant so tenant-scope SendAsync calls can route
+        // to a real EF in-memory DB.
+        _db.Tenants.Add(new Tenant
+        {
+            Id = TestTenantId,
+            Name = "test",
+            Slug = "test",
+            Type = "personal",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        _db.SaveChanges();
 
         _config = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -57,7 +73,7 @@ public class SmtpEmailServiceOutboxTests
     public async Task TearDown() => await _fx.DisposeAsync();
 
     private SmtpEmailService NewService() => new(
-        _outbox, _events, _tenantContext, _config,
+        _outbox, _platformOutbox, _events, _tenantContext, _config,
         NullLogger<SmtpEmailService>.Instance);
 
     private static EmailMessage NewMessage(Guid? tenantId = null, Guid? userId = null)
@@ -74,14 +90,13 @@ public class SmtpEmailServiceOutboxTests
     public async Task SendAsync_EnqueuesRowWithRecipient_AndReturnsRowId()
     {
         var svc = NewService();
-        var tenantId = Guid.NewGuid();
         var userId = Guid.NewGuid();
 
-        var txnId = await svc.SendAsync(NewMessage(tenantId, userId));
+        var txnId = await svc.SendAsync(NewMessage(TestTenantId, userId));
 
         txnId.Should().NotBe(Guid.Empty);
 
-        var row = await _outbox.GetByIdAsync(txnId);
+        var row = await _outbox.GetByIdAsync(TestTenantId, txnId);
         row.Should().NotBeNull();
         row!.Status.Should().Be("pending");
         row.ToAddress.Should().Be("alice@example.com");
@@ -90,7 +105,7 @@ public class SmtpEmailServiceOutboxTests
         row.TextBody.Should().Be("hi");
         row.FromAddress.Should().Be("noreply@tamma.dev");
         row.Template.Should().Be("verification");
-        row.TenantId.Should().Be(tenantId);
+        row.TenantId.Should().Be(TestTenantId);
         row.UserId.Should().Be(userId);
         row.Attempts.Should().Be(0);
         row.MaxAttempts.Should().Be(5);
@@ -130,9 +145,12 @@ public class SmtpEmailServiceOutboxTests
     public async Task SendAsync_UsesConfigFromAddressWhenMessageFromIsNull()
     {
         var svc = NewService();
-        var txnId = await svc.SendAsync(NewMessage() with { From = null });
+        // Tenant-scope so the row lands in EmailOutboxRepository (we can
+        // GetByIdAsync it). The From-config behaviour is identical for
+        // platform-scope.
+        var txnId = await svc.SendAsync(NewMessage(TestTenantId) with { From = null });
 
-        var row = await _outbox.GetByIdAsync(txnId);
+        var row = await _outbox.GetByIdAsync(TestTenantId, txnId);
         row!.FromAddress.Should().Be("noreply@tamma.dev");
     }
 
@@ -140,10 +158,10 @@ public class SmtpEmailServiceOutboxTests
     public async Task SendAsync_ThrowsWhenNeitherMessageNorConfigHasFrom()
     {
         var emptyConfig = new ConfigurationBuilder().Build();
-        var svc = new SmtpEmailService(_outbox, _events, _tenantContext, emptyConfig,
+        var svc = new SmtpEmailService(_outbox, _platformOutbox, _events, _tenantContext, emptyConfig,
             NullLogger<SmtpEmailService>.Instance);
 
-        var act = async () => await svc.SendAsync(NewMessage() with { From = null });
+        var act = async () => await svc.SendAsync(NewMessage(TestTenantId) with { From = null });
 
         await act.Should().ThrowAsync<InvalidOperationException>(
             "programmer error — missing both message.From and Email:From config");
@@ -152,15 +170,39 @@ public class SmtpEmailServiceOutboxTests
     [Test]
     public async Task SendAsync_FallsBackToTenantContext_WhenMessageTenantIdNull()
     {
-        var ambientTenant = Guid.NewGuid();
-        _tenantContext.SetTenantId(ambientTenant);
+        // Story 28-1 PR B — when message.TenantId is null but the
+        // ambient ITenantContext.TenantId is set, the service still
+        // routes through the tenant repo. This preserves the historical
+        // "implicit tenant" behaviour.
+        _tenantContext.SetTenantId(TestTenantId);
 
         var svc = NewService();
         var txnId = await svc.SendAsync(NewMessage());
 
-        var row = await _outbox.GetByIdAsync(txnId);
-        row!.TenantId.Should().Be(ambientTenant,
+        var row = await _outbox.GetByIdAsync(TestTenantId, txnId);
+        row!.TenantId.Should().Be(TestTenantId,
             "SmtpEmailService falls back to the ambient tenant when the message didn't supply one");
+    }
+
+    [Test]
+    public async Task SendAsync_RoutesToPlatformOutbox_WhenNoTenantId()
+    {
+        // Story 28-1 PR B — verification / password-reset / welcome
+        // emails set TenantId=null and the ambient context is unset
+        // too. The platform repo gets the row, NOT the tenant repo.
+        var svc = NewService();
+        var txnId = await svc.SendAsync(NewMessage(tenantId: null, userId: Guid.NewGuid()));
+
+        // Tenant repo doesn't have it.
+        var tenantSearch = await _db.EmailOutbox.FindAsync(txnId);
+        tenantSearch.Should().BeNull("platform-scope email must NOT land in the tenant outbox");
+
+        // Platform repo does.
+        var platformRow = await _platformOutbox.GetByIdAsync(txnId);
+        platformRow.Should().NotBeNull();
+        platformRow!.Status.Should().Be("pending");
+        platformRow.Template.Should().Be("verification");
+        platformRow.TenantId.Should().BeNull();
     }
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Engine/TaskQueueProcessorLifecycleBusTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Engine/TaskQueueProcessorLifecycleBusTests.cs
@@ -82,10 +82,34 @@ public class TaskQueueProcessorLifecycleBusTests
         => new(new TestTenantDbContextFactory(_tenantOptions),
                new TestControlPlaneDbContext(_cpOptions));
 
+    /// <summary>
+    /// Seed a tenant so <see cref="QueuedTaskRepository.ListPendingFromAnyTenantAsync"/>
+    /// has a tenant to walk. Story 28-1 PR B — the processor's drain
+    /// path enumerates active tenants from CP.
+    /// </summary>
+    private void SeedTenant(Guid tenantId)
+    {
+        using var cp = new TestControlPlaneDbContext(_cpOptions);
+        if (cp.Tenants.Find(tenantId) is null)
+        {
+            cp.Tenants.Add(new Tenant
+            {
+                Id = tenantId,
+                Name = "test",
+                Slug = "test-" + tenantId.ToString()[..8],
+                Type = "personal",
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+            });
+            cp.SaveChanges();
+        }
+    }
+
     [Test]
     public async Task ProcessOnceAsync_SuccessfulTask_PublishesClaimedThenCompleted()
     {
         var tenantId = Guid.NewGuid();
+        SeedTenant(tenantId);
         await FreshRepo().EnqueueAsync(new QueuedTask
         {
             Type = "github.push.main",
@@ -122,6 +146,7 @@ public class TaskQueueProcessorLifecycleBusTests
     public async Task ProcessOnceAsync_HandlerThrows_PublishesClaimedThenFailed()
     {
         var tenantId = Guid.NewGuid();
+        SeedTenant(tenantId);
         await FreshRepo().EnqueueAsync(new QueuedTask
         {
             Type = "github.x",

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/CrossTenantIsolationPostgresTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/CrossTenantIsolationPostgresTests.cs
@@ -1,0 +1,609 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using NUnit.Framework;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Repositories;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Epic28;
+
+/// <summary>
+/// Wave-4 review M5 — cross-tenant isolation negative tests for the
+/// <see cref="EmailOutboxRepository"/> and <see cref="QueuedTaskRepository"/>
+/// against a real Postgres testcontainer.
+///
+/// <para>The pre-fix bug: <see cref="EmailOutboxRepository.ClaimNextPendingAsync"/>
+/// emitted a Postgres SQL <c>UPDATE ... FROM email_outbox</c> that lacked
+/// <c>WHERE "TenantId" = @tid</c>, and 5 <see cref="QueuedTaskRepository"/>
+/// methods (<c>GetAsync</c>, <c>MarkProcessingAsync</c>, <c>MarkCompletedAsync</c>,
+/// <c>MarkFailedAsync</c>, <c>IncrementRetryAndRequeueAsync</c>) used
+/// <c>FindAsync(id)</c> which keys on PK only. While the per-tenant tables
+/// physically still co-reside on the CP DB during the Story 28-1 transition,
+/// tenant A's call could read or mutate tenant B's row.</para>
+///
+/// <para>Why Postgres, not EF-InMemory: EF-InMemory satisfies <c>FindAsync(id)</c>
+/// from a global PK dictionary regardless of how the predicates filter, so
+/// the missing predicates pass silently. A real Postgres connection is the
+/// only thing that exposes the gap. These tests run against a
+/// <see cref="PostgreSqlContainer"/>, seed rows via raw SQL into a single
+/// shared <c>email_outbox</c> / <c>queued_tasks</c> table (mirroring the
+/// transitional shared-DB topology), then call the repository as the other
+/// tenant and assert the read/write is a no-op.</para>
+/// </summary>
+[TestFixture]
+public class CrossTenantIsolationPostgresTests
+{
+    private static readonly Guid TenantA = Guid.Parse("aaaaaaaa-1111-1111-1111-aaaaaaaaaaaa");
+    private static readonly Guid TenantB = Guid.Parse("bbbbbbbb-2222-2222-2222-bbbbbbbbbbbb");
+
+    private PostgreSqlContainer _postgres = null!;
+    private string _connectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("xtenant_iso_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _connectionString = _postgres.GetConnectionString();
+
+        // Create the two tables we need (mirroring the EmailOutbox /
+        // TaskQueue / TaskQueueClaimedAt migrations) plus a minimal
+        // tenants table for the active-tenant lookup. Skipping the full
+        // migration bundle keeps the fixture under 5s.
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            CREATE TABLE IF NOT EXISTS "Tenants" (
+                "Id" uuid PRIMARY KEY,
+                "DeletedAt" timestamptz NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS email_outbox (
+                "Id" uuid PRIMARY KEY,
+                "TenantId" uuid NULL,
+                "UserId" uuid NULL,
+                "Template" varchar(100) NOT NULL,
+                "ToAddress" varchar(320) NOT NULL,
+                "Subject" varchar(512) NOT NULL,
+                "HtmlBody" text NOT NULL,
+                "TextBody" text NOT NULL,
+                "FromAddress" varchar(320) NOT NULL,
+                "Status" varchar(20) NOT NULL DEFAULT 'pending',
+                "Attempts" integer NOT NULL DEFAULT 0,
+                "MaxAttempts" integer NOT NULL DEFAULT 5,
+                "NextAttemptAt" timestamptz NOT NULL DEFAULT now(),
+                "LastError" text NULL,
+                "CreatedAt" timestamptz NOT NULL DEFAULT now(),
+                "UpdatedAt" timestamptz NOT NULL DEFAULT now(),
+                "SentAt" timestamptz NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS queued_tasks (
+                "Id" uuid PRIMARY KEY,
+                "Type" varchar(255) NOT NULL,
+                "TenantId" uuid NULL,
+                "InstallationId" bigint NULL,
+                "Payload" jsonb NOT NULL DEFAULT '{}'::jsonb,
+                "Status" varchar(20) NOT NULL DEFAULT 'pending',
+                "Error" text NULL,
+                "RetryCount" integer NOT NULL DEFAULT 0,
+                "CreatedAt" timestamptz NOT NULL DEFAULT now(),
+                "UpdatedAt" timestamptz NOT NULL DEFAULT now(),
+                "ClaimedAt" timestamptz NULL
+            );
+            """;
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        // Reset both tables + reseed two active tenants per test.
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            TRUNCATE email_outbox, queued_tasks, "Tenants";
+            INSERT INTO "Tenants" ("Id") VALUES (@a), (@b);
+            """;
+        cmd.Parameters.AddWithValue("a", TenantA);
+        cmd.Parameters.AddWithValue("b", TenantB);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private (EmailOutboxRepository emailRepo, QueuedTaskRepository taskRepo, ControlPlaneDbContext cp)
+        BuildRepos()
+    {
+        // The TenantDbContextFactory used here is intentionally trivial:
+        // every tenant gets a context against the same connection string.
+        // That mirrors the transitional shared-DB topology — the very
+        // setting where the predicate-gap bug bites.
+        var cpOpts = new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseNpgsql(_connectionString)
+            .Options;
+        var tenantOpts = new DbContextOptionsBuilder<TenantDbContext>()
+            .UseNpgsql(_connectionString)
+            .Options;
+
+        // Use the production ControlPlaneDbContext but configure a
+        // minimal "Tenants" entity slice via a derived context. The CP
+        // model is large; for this test we only need the Tenants set
+        // for the active-tenant lookup. We override by using a raw
+        // scoped helper that the repositories actually consume.
+        var cp = new MinimalCpDbContext(cpOpts);
+        var factory = new SharedConnectionTenantFactory(tenantOpts);
+        var emailRepo = new EmailOutboxRepository(factory, cp);
+        var taskRepo = new QueuedTaskRepository(factory, cp);
+        return (emailRepo, taskRepo, cp);
+    }
+
+    private async Task SeedEmailRowAsync(Guid tenantId, Guid id, string status = "pending")
+    {
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            INSERT INTO email_outbox
+                ("Id","TenantId","Template","ToAddress","Subject","HtmlBody","TextBody",
+                 "FromAddress","Status","Attempts","MaxAttempts","NextAttemptAt",
+                 "CreatedAt","UpdatedAt")
+            VALUES (@id,@tid,'verification','to@example.com','subj','<p/>','t',
+                    'from@example.com',@status,0,5,now(),now(),now())
+            """;
+        cmd.Parameters.AddWithValue("id", id);
+        cmd.Parameters.AddWithValue("tid", tenantId);
+        cmd.Parameters.AddWithValue("status", status);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task SeedTaskRowAsync(Guid tenantId, Guid id, string status = "pending")
+    {
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            INSERT INTO queued_tasks
+                ("Id","Type","TenantId","Payload","Status","RetryCount",
+                 "CreatedAt","UpdatedAt")
+            VALUES (@id,'github.test',@tid,'{}'::jsonb,@status,0,now(),now())
+            """;
+        cmd.Parameters.AddWithValue("id", id);
+        cmd.Parameters.AddWithValue("tid", tenantId);
+        cmd.Parameters.AddWithValue("status", status);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task<(string status, Guid? tenantId)> ReadEmailRowAsync(Guid id)
+    {
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            SELECT "Status","TenantId" FROM email_outbox WHERE "Id" = @id
+            """;
+        cmd.Parameters.AddWithValue("id", id);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        await reader.ReadAsync();
+        var s = reader.GetString(0);
+        var tid = reader.IsDBNull(1) ? (Guid?)null : reader.GetGuid(1);
+        return (s, tid);
+    }
+
+    private async Task<(string status, Guid? tenantId, int retryCount)>
+        ReadTaskRowAsync(Guid id)
+    {
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            SELECT "Status","TenantId","RetryCount" FROM queued_tasks WHERE "Id" = @id
+            """;
+        cmd.Parameters.AddWithValue("id", id);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        await reader.ReadAsync();
+        var s = reader.GetString(0);
+        var tid = reader.IsDBNull(1) ? (Guid?)null : reader.GetGuid(1);
+        var rc = reader.GetInt32(2);
+        return (s, tid, rc);
+    }
+
+    // ── EmailOutboxRepository.ClaimNextPendingAsync ────────────────────
+
+    [Test]
+    public async Task ClaimNextPendingAsync_DoesNotReturn_OtherTenantsRow_OnPostgres()
+    {
+        // Seed-in-A; query-as-B; expect-null.
+        var rowId = Guid.NewGuid();
+        await SeedEmailRowAsync(TenantA, rowId);
+        var (emailRepo, _, _) = BuildRepos();
+
+        var claimed = await emailRepo.ClaimNextPendingAsync(TenantB, DateTime.UtcNow);
+
+        claimed.Should().BeNull(
+            "tenant B must not be able to claim tenant A's row from the shared email_outbox");
+
+        // Belt-and-braces: the row must still be tenant A's, still pending.
+        var (status, tid) = await ReadEmailRowAsync(rowId);
+        status.Should().Be("pending", "tenant B's claim must NOT have flipped status to 'sending'");
+        tid.Should().Be(TenantA);
+    }
+
+    [Test]
+    public async Task ClaimNextPendingAsync_ReturnsOwnTenantsRow_OnPostgres()
+    {
+        // Positive control — confirm the predicate doesn't reject the
+        // legitimate owner's claim. If this fails, the WHERE clause is
+        // over-tight, not under-tight.
+        var rowId = Guid.NewGuid();
+        await SeedEmailRowAsync(TenantA, rowId);
+        var (emailRepo, _, _) = BuildRepos();
+
+        var claimed = await emailRepo.ClaimNextPendingAsync(TenantA, DateTime.UtcNow);
+
+        claimed.Should().NotBeNull();
+        claimed!.Id.Should().Be(rowId);
+        claimed.TenantId.Should().Be(TenantA);
+    }
+
+    // ── EmailOutboxRepository.MarkSent / MarkFailed / GetByIdAsync /
+    //    DeleteAsync — wrong-tenant must be no-op ──────────────────────
+
+    [Test]
+    public async Task MarkSentAsync_IsNoop_WhenCalledWithWrongTenantId()
+    {
+        var rowId = Guid.NewGuid();
+        await SeedEmailRowAsync(TenantA, rowId);
+        var (emailRepo, _, _) = BuildRepos();
+
+        await emailRepo.MarkSentAsync(TenantB, rowId);
+
+        var (status, _) = await ReadEmailRowAsync(rowId);
+        status.Should().Be("pending",
+            "MarkSent called as tenant B must not flip tenant A's row to 'sent'");
+    }
+
+    [Test]
+    public async Task MarkFailedAsync_IsNoop_WhenCalledWithWrongTenantId()
+    {
+        var rowId = Guid.NewGuid();
+        await SeedEmailRowAsync(TenantA, rowId);
+        var (emailRepo, _, _) = BuildRepos();
+
+        var updated = await emailRepo.MarkFailedAsync(
+            TenantB, rowId, "boom", TimeSpan.FromMinutes(5));
+
+        updated.Should().BeNull(
+            "MarkFailed called as tenant B must not return tenant A's row");
+
+        var (status, _) = await ReadEmailRowAsync(rowId);
+        status.Should().Be("pending",
+            "the row must still be in its original state — no cross-tenant write");
+    }
+
+    [Test]
+    public async Task GetByIdAsync_ReturnsNull_WhenCalledWithWrongTenantId()
+    {
+        var rowId = Guid.NewGuid();
+        await SeedEmailRowAsync(TenantA, rowId);
+        var (emailRepo, _, _) = BuildRepos();
+
+        var fetched = await emailRepo.GetByIdAsync(TenantB, rowId);
+
+        fetched.Should().BeNull(
+            "GetById must NOT leak tenant A's row to tenant B's call");
+    }
+
+    [Test]
+    public async Task DeleteAsync_IsNoop_WhenCalledWithWrongTenantId()
+    {
+        var rowId = Guid.NewGuid();
+        await SeedEmailRowAsync(TenantA, rowId);
+        var (emailRepo, _, _) = BuildRepos();
+
+        await emailRepo.DeleteAsync(TenantB, rowId);
+
+        var (status, tid) = await ReadEmailRowAsync(rowId);
+        status.Should().Be("pending",
+            "the row must still exist after a wrong-tenant delete");
+        tid.Should().Be(TenantA);
+    }
+
+    // ── QueuedTaskRepository — every tenantId-bearing method must
+    //    refuse to act on a wrong-tenant row ──────────────────────────
+
+    [Test]
+    public async Task QueuedTask_GetAsync_ReturnsNull_WhenCalledWithWrongTenantId()
+    {
+        var rowId = Guid.NewGuid();
+        await SeedTaskRowAsync(TenantA, rowId);
+        var (_, taskRepo, _) = BuildRepos();
+
+        var fetched = await taskRepo.GetAsync(TenantB, rowId);
+
+        fetched.Should().BeNull(
+            "GetAsync must NOT leak tenant A's task to tenant B's call");
+    }
+
+    [Test]
+    public async Task QueuedTask_MarkProcessingAsync_IsNoop_WhenCalledWithWrongTenantId()
+    {
+        var rowId = Guid.NewGuid();
+        await SeedTaskRowAsync(TenantA, rowId);
+        var (_, taskRepo, _) = BuildRepos();
+
+        var claimed = await taskRepo.MarkProcessingAsync(TenantB, rowId);
+
+        claimed.Should().BeNull(
+            "MarkProcessing called as tenant B must not flip tenant A's row");
+
+        var (status, _, _) = await ReadTaskRowAsync(rowId);
+        status.Should().Be("pending");
+    }
+
+    [Test]
+    public async Task QueuedTask_MarkCompletedAsync_IsNoop_WhenCalledWithWrongTenantId()
+    {
+        var rowId = Guid.NewGuid();
+        await SeedTaskRowAsync(TenantA, rowId, status: "processing");
+        var (_, taskRepo, _) = BuildRepos();
+
+        await taskRepo.MarkCompletedAsync(TenantB, rowId);
+
+        var (status, _, _) = await ReadTaskRowAsync(rowId);
+        status.Should().Be("processing",
+            "MarkCompleted called as tenant B must not flip tenant A's row to 'completed'");
+    }
+
+    [Test]
+    public async Task QueuedTask_MarkFailedAsync_IsNoop_WhenCalledWithWrongTenantId()
+    {
+        var rowId = Guid.NewGuid();
+        await SeedTaskRowAsync(TenantA, rowId, status: "processing");
+        var (_, taskRepo, _) = BuildRepos();
+
+        await taskRepo.MarkFailedAsync(TenantB, rowId, "boom");
+
+        var (status, _, _) = await ReadTaskRowAsync(rowId);
+        status.Should().Be("processing",
+            "MarkFailed called as tenant B must not flip tenant A's row to 'failed'");
+    }
+
+    [Test]
+    public async Task QueuedTask_IncrementRetryAndRequeueAsync_IsNoop_WhenCalledWithWrongTenantId()
+    {
+        var rowId = Guid.NewGuid();
+        await SeedTaskRowAsync(TenantA, rowId, status: "processing");
+        var (_, taskRepo, _) = BuildRepos();
+
+        var requeued = await taskRepo.IncrementRetryAndRequeueAsync(TenantB, rowId, "transient");
+
+        requeued.Should().BeNull(
+            "IncrementRetryAndRequeue called as tenant B must not return tenant A's row");
+
+        var (status, _, retryCount) = await ReadTaskRowAsync(rowId);
+        status.Should().Be("processing",
+            "tenant A's row status must NOT have flipped to 'pending'");
+        retryCount.Should().Be(0,
+            "tenant A's RetryCount must NOT have incremented from a wrong-tenant call");
+    }
+
+    // ── Positive controls — own-tenant calls still work ───────────────
+
+    [Test]
+    public async Task QueuedTask_MarkProcessingAsync_Succeeds_ForOwnTenantsRow()
+    {
+        var rowId = Guid.NewGuid();
+        await SeedTaskRowAsync(TenantA, rowId);
+        var (_, taskRepo, _) = BuildRepos();
+
+        var claimed = await taskRepo.MarkProcessingAsync(TenantA, rowId);
+
+        claimed.Should().NotBeNull();
+        claimed!.Status.Should().Be("processing");
+
+        var (status, _, _) = await ReadTaskRowAsync(rowId);
+        status.Should().Be("processing");
+    }
+}
+
+/// <summary>
+/// Stripped <see cref="ControlPlaneDbContext"/> for the cross-tenant
+/// isolation fixture — the production CP model includes 30+ entities and
+/// would require the full migration bundle. We only need the
+/// <c>Tenants</c> set so the repositories' fan-out helpers can list active
+/// tenants.
+/// </summary>
+internal sealed class MinimalCpDbContext : ControlPlaneDbContext
+{
+    public MinimalCpDbContext(DbContextOptions<ControlPlaneDbContext> options)
+        : base(options) { }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        // Do NOT call base — we want a minimal model. Map only the
+        // <c>Tenants</c> table with the columns the fan-out helpers
+        // actually read (Id + DeletedAt). Ignore neighbour entities the
+        // production Tenant entity references via navigations, otherwise
+        // EF will pick them up and demand columns the fixture's stub
+        // table doesn't have.
+        modelBuilder.Ignore<Tamma.Data.Entities.User>();
+        modelBuilder.Ignore<Tamma.Data.Entities.TenantMembership>();
+        modelBuilder.Ignore<Tamma.Data.Entities.UserInvite>();
+        modelBuilder.Ignore<Tamma.Data.Entities.RefreshToken>();
+        modelBuilder.Ignore<Tamma.Data.Entities.PasswordResetToken>();
+        modelBuilder.Ignore<Tamma.Data.Entities.GitHubInstallation>();
+        modelBuilder.Ignore<Tamma.Data.Entities.GitHubInstallationRepo>();
+        modelBuilder.Ignore<Tamma.Data.Entities.GitHubWebhookDelivery>();
+        modelBuilder.Ignore<Tamma.Data.Entities.Plan>();
+        modelBuilder.Ignore<Tamma.Data.Entities.PlatformEvent>();
+        modelBuilder.Ignore<Tamma.Data.Entities.PlatformQueuedTask>();
+        modelBuilder.Ignore<Tamma.Data.Entities.PlatformEmailOutboxMessage>();
+        modelBuilder.Ignore<Tamma.Data.Entities.ApiKey>();
+
+        modelBuilder.Entity<Tamma.Data.Entities.Tenant>(b =>
+        {
+            b.ToTable("Tenants");
+            b.HasKey(t => t.Id);
+            b.Property(t => t.Id).HasColumnName("Id");
+            b.Property(t => t.DeletedAt).HasColumnName("DeletedAt");
+            // Ignore every other property the production Tenant entity
+            // carries — the fixture's stub "Tenants" table has only Id +
+            // DeletedAt, and the fan-out paths under test only read those.
+            b.Ignore(t => t.Name);
+            b.Ignore(t => t.Slug);
+            b.Ignore(t => t.Type);
+            b.Ignore(t => t.OwnerId);
+            b.Ignore(t => t.ExternalId);
+            b.Ignore(t => t.Plan);
+            b.Ignore(t => t.Settings);
+            b.Ignore(t => t.CreatedAt);
+            b.Ignore(t => t.UpdatedAt);
+            b.Ignore(t => t.CranlProjectId);
+            b.Ignore(t => t.CranlDatabaseId);
+            b.Ignore(t => t.CranlAppId);
+            b.Ignore(t => t.CranlRegion);
+            b.Ignore(t => t.CranlDatabaseUrlEncrypted);
+            b.Ignore(t => t.CranlAppUrl);
+            b.Ignore(t => t.ProvisioningState);
+            b.Ignore(t => t.ProvisioningDetail);
+            b.Ignore(t => t.ProvisioningUpdatedAt);
+            b.Ignore(t => t.Owner);
+            b.Ignore(t => t.Memberships);
+            b.Ignore(t => t.Invites);
+        });
+
+        // The repos under test reference <c>EmailOutbox</c> /
+        // <c>QueuedTasks</c> on the CP context only via the fan-out
+        // path's <c>cp.Tenants</c> read. They don't query EmailOutbox /
+        // QueuedTasks via the CP context directly. Map them defensively
+        // so the model graph compiles, but no test relies on these.
+        modelBuilder.Entity<Tamma.Data.Entities.EmailOutboxMessage>(b =>
+        {
+            b.ToTable("email_outbox");
+            b.HasKey(e => e.Id);
+        });
+        modelBuilder.Entity<Tamma.Data.Entities.QueuedTask>(b =>
+        {
+            b.ToTable("queued_tasks");
+            b.HasKey(e => e.Id);
+        });
+    }
+}
+
+/// <summary>
+/// <see cref="ITenantDbContextFactory"/> that hands every tenant a fresh
+/// <see cref="TenantDbContext"/> bound to the same shared connection. That
+/// matches the transitional shared-DB topology (Story 28-1 PR B's stated
+/// constraint): all tenants ride one Postgres database, isolation is
+/// supposed to come from the repository predicates we just hardened.
+/// </summary>
+internal sealed class SharedConnectionTenantFactory : ITenantDbContextFactory
+{
+    private readonly DbContextOptions<TenantDbContext> _options;
+
+    public SharedConnectionTenantFactory(DbContextOptions<TenantDbContext> options)
+    {
+        _options = options;
+    }
+
+    public ValueTask<TenantDbContext> CreateAsync(
+        Guid tenantId, CancellationToken cancellationToken = default)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id is required.", nameof(tenantId));
+        return ValueTask.FromResult<TenantDbContext>(
+            new MinimalTenantDbContext(_options, tenantId));
+    }
+}
+
+/// <summary>
+/// Minimal <see cref="TenantDbContext"/> that maps <c>email_outbox</c> +
+/// <c>queued_tasks</c> against the shared Postgres test container. The
+/// production tenant model graph references mentorship + workflow + agent
+/// entities the test schema doesn't have; this slim variant lets the EF
+/// model compile against the two tables under test.
+/// </summary>
+internal sealed class MinimalTenantDbContext : TenantDbContext
+{
+    public MinimalTenantDbContext(DbContextOptions<TenantDbContext> options, Guid tenantId)
+        : base(options, tenantId) { }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        // Skip base — the production tenant model maps a full graph
+        // (agent_configs, prompt_overrides, etc) that doesn't exist on
+        // the fixture. Map only the two tables the repos under test
+        // touch. Defensive ignores prevent EF from auto-discovering
+        // adjacent entities through navigation properties on QueuedTask
+        // / EmailOutboxMessage.
+        modelBuilder.Ignore<Tamma.Data.Entities.User>();
+        modelBuilder.Ignore<Tamma.Data.Entities.Tenant>();
+        modelBuilder.Ignore<Tamma.Data.Entities.TenantMembership>();
+        modelBuilder.Ignore<Tamma.Data.Entities.UserInvite>();
+        modelBuilder.Ignore<Tamma.Data.Entities.RefreshToken>();
+        modelBuilder.Ignore<Tamma.Data.Entities.PasswordResetToken>();
+        modelBuilder.Ignore<Tamma.Data.Entities.GitHubInstallation>();
+        modelBuilder.Ignore<Tamma.Data.Entities.GitHubInstallationRepo>();
+        modelBuilder.Ignore<Tamma.Data.Entities.GitHubWebhookDelivery>();
+        modelBuilder.Ignore<Tamma.Data.Entities.Plan>();
+        modelBuilder.Ignore<Tamma.Data.Entities.PlatformEvent>();
+        modelBuilder.Ignore<Tamma.Data.Entities.PlatformQueuedTask>();
+        modelBuilder.Ignore<Tamma.Data.Entities.PlatformEmailOutboxMessage>();
+        modelBuilder.Ignore<Tamma.Data.Entities.ApiKey>();
+
+        modelBuilder.Entity<Tamma.Data.Entities.EmailOutboxMessage>(b =>
+        {
+            b.ToTable("email_outbox");
+            b.HasKey(e => e.Id);
+            b.Property(e => e.Id).HasColumnName("Id");
+            b.Property(e => e.TenantId).HasColumnName("TenantId");
+            b.Property(e => e.UserId).HasColumnName("UserId");
+            b.Property(e => e.Template).HasColumnName("Template");
+            b.Property(e => e.ToAddress).HasColumnName("ToAddress");
+            b.Property(e => e.Subject).HasColumnName("Subject");
+            b.Property(e => e.HtmlBody).HasColumnName("HtmlBody");
+            b.Property(e => e.TextBody).HasColumnName("TextBody");
+            b.Property(e => e.FromAddress).HasColumnName("FromAddress");
+            b.Property(e => e.Status).HasColumnName("Status");
+            b.Property(e => e.Attempts).HasColumnName("Attempts");
+            b.Property(e => e.MaxAttempts).HasColumnName("MaxAttempts");
+            b.Property(e => e.NextAttemptAt).HasColumnName("NextAttemptAt");
+            b.Property(e => e.LastError).HasColumnName("LastError");
+            b.Property(e => e.CreatedAt).HasColumnName("CreatedAt");
+            b.Property(e => e.UpdatedAt).HasColumnName("UpdatedAt");
+            b.Property(e => e.SentAt).HasColumnName("SentAt");
+        });
+        modelBuilder.Entity<Tamma.Data.Entities.QueuedTask>(b =>
+        {
+            b.ToTable("queued_tasks");
+            b.HasKey(e => e.Id);
+            b.Property(e => e.Id).HasColumnName("Id");
+            b.Property(e => e.Type).HasColumnName("Type");
+            b.Property(e => e.TenantId).HasColumnName("TenantId");
+            b.Property(e => e.InstallationId).HasColumnName("InstallationId");
+            b.Property(e => e.Payload).HasColumnName("Payload").HasColumnType("jsonb");
+            b.Property(e => e.Status).HasColumnName("Status");
+            b.Property(e => e.Error).HasColumnName("Error");
+            b.Property(e => e.RetryCount).HasColumnName("RetryCount");
+            b.Property(e => e.ClaimedAt).HasColumnName("ClaimedAt");
+            b.Property(e => e.CreatedAt).HasColumnName("CreatedAt");
+            b.Property(e => e.UpdatedAt).HasColumnName("UpdatedAt");
+        });
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/OutboxSmtpSenderPlatformPathTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/OutboxSmtpSenderPlatformPathTests.cs
@@ -120,8 +120,11 @@ public class OutboxSmtpSenderPlatformPathTests
         MaxAttempts = maxAttempts,
     };
 
+    private static readonly Guid TenantPathTestId = Guid.Parse("ffffffff-1111-2222-3333-444444444444");
+
     private static EmailOutboxMessage NewTenantRow() => new()
     {
+        TenantId = TenantPathTestId,
         Template = "verification",
         ToAddress = "tenant@example.com",
         Subject = "Verify",
@@ -130,6 +133,30 @@ public class OutboxSmtpSenderPlatformPathTests
         FromAddress = "noreply@tamma.dev",
         MaxAttempts = 5,
     };
+
+    /// <summary>
+    /// Seed an active tenant row in CP. Story 28-1 PR B: the tenant
+    /// outbox drain path enumerates active tenants from CP — without
+    /// one, the tenant path returns null and only the platform path
+    /// drains.
+    /// </summary>
+    private void SeedActiveTenant(Guid tenantId)
+    {
+        using var cp = new TestControlPlaneDbContext(_cpOptions);
+        if (cp.Tenants.Find(tenantId) is null)
+        {
+            cp.Tenants.Add(new Tenant
+            {
+                Id = tenantId,
+                Name = "test-tenant",
+                Slug = "test-tenant-" + tenantId.ToString()[..8],
+                Type = "personal",
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+            });
+            cp.SaveChanges();
+        }
+    }
 
     // ── Platform path drains when tenant queue empty ─────────────────────────
 
@@ -214,11 +241,11 @@ public class OutboxSmtpSenderPlatformPathTests
             // options (see SetUp), so the tenant row is visible to the CP
             // scan too — the test's invariant is "tenant row delivers first",
             // which the sender enforces by polling CP first.
+            SeedActiveTenant(TenantPathTestId);
             var tenantRepo = new EmailOutboxRepository(
                 new TestTenantDbContextFactory(_tenantOptions),
                 new TestControlPlaneDbContext(_cpOptions));
             var tenantRow = NewTenantRow();
-            tenantRow.TenantId = Guid.NewGuid();
             var tenantEnq = await tenantRepo.EnqueueAsync(tenantRow);
 
             using var cp = new ControlPlaneDbContext(_cpOptions);

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/CranlTenantProvisionerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/CranlTenantProvisionerTests.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
 using Tamma.Api.Services.Provisioning;
-using Tamma.Api.Services.TaskQueue;
 using Tamma.Data;
 using Tamma.Data.Entities;
 using Tamma.Data.Repositories;
@@ -17,6 +16,14 @@ namespace Tamma.Api.Tests.Provisioning;
 /// is idempotent (already-provisioned tenants don't re-enqueue), correctly
 /// transitions to Pending on a fresh tenant, and enqueues the right task
 /// type for both provision + deprovision flows.
+///
+/// <para>Story 28-1 PR B — provisioning + deprovisioning tasks live on
+/// the platform queue (<see cref="IPlatformQueuedTaskRepository"/>),
+/// not the per-tenant queue. Reason: at provisioning time the tenant
+/// DB doesn't exist yet (the task's whole job is to create it!); at
+/// deprovisioning time the tenant DB is about to be torn down. Tests
+/// here mock <see cref="IPlatformQueuedTaskRepository"/> instead of
+/// <see cref="ITaskQueue"/>.</para>
 /// </summary>
 [TestFixture]
 public class CranlTenantProvisionerTests
@@ -25,7 +32,7 @@ public class CranlTenantProvisionerTests
 #pragma warning disable NUnit1032
     private ControlPlaneDbContext _db = null!;
 #pragma warning restore NUnit1032
-    private Mock<ITaskQueue> _queue = null!;
+    private Mock<IPlatformQueuedTaskRepository> _platformTasks = null!;
     private CranlTenantProvisioner _provisioner = null!;
 
     [SetUp]
@@ -35,17 +42,18 @@ public class CranlTenantProvisionerTests
         _scope = ApiTestFixture.Factory.Services.CreateScope();
         _db = _scope.ServiceProvider.GetRequiredService<ControlPlaneDbContext>();
 
-        _queue = new Mock<ITaskQueue>(MockBehavior.Strict);
-        _queue.Setup(q => q.EnqueueAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>(),
-                It.IsAny<long?>(),
-                It.IsAny<Guid?>(),
+        _platformTasks = new Mock<IPlatformQueuedTaskRepository>(MockBehavior.Strict);
+        _platformTasks.Setup(q => q.EnqueueAsync(
+                It.IsAny<PlatformQueuedTask>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new QueuedTask { Id = Guid.NewGuid() });
+            .ReturnsAsync((PlatformQueuedTask t, CancellationToken _) =>
+            {
+                t.Id = Guid.NewGuid();
+                return t;
+            });
 
         _provisioner = new CranlTenantProvisioner(
-            _db, _queue.Object, NullLogger<CranlTenantProvisioner>.Instance);
+            _db, _platformTasks.Object, NullLogger<CranlTenantProvisioner>.Instance);
     }
 
     [TearDown]
@@ -78,11 +86,13 @@ public class CranlTenantProvisionerTests
 
         status.State.Should().Be(ProvisioningState.Pending);
 
-        _queue.Verify(q => q.EnqueueAsync(
-            CranlTenantProvisioner.ProvisioningTaskType,
-            It.Is<string>(json => json.Contains(tenant.Id.ToString()) && json.Contains("germany-1")),
-            null,
-            tenant.Id,
+        _platformTasks.Verify(q => q.EnqueueAsync(
+            It.Is<PlatformQueuedTask>(t =>
+                t.Type == CranlTenantProvisioner.ProvisioningTaskType
+                && t.TenantId == tenant.Id
+                && t.Payload != null
+                && t.Payload.Contains(tenant.Id.ToString())
+                && t.Payload.Contains("germany-1")),
             It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -99,9 +109,9 @@ public class CranlTenantProvisionerTests
             tenant.Id, new ProvisioningOptions("germany-1"), CancellationToken.None);
 
         status.State.Should().Be(ProvisioningState.DatabaseProvisioning);
-        _queue.Verify(q => q.EnqueueAsync(
-            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<long?>(),
-            It.IsAny<Guid?>(), It.IsAny<CancellationToken>()),
+        _platformTasks.Verify(q => q.EnqueueAsync(
+            It.IsAny<PlatformQueuedTask>(),
+            It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -114,7 +124,7 @@ public class CranlTenantProvisionerTests
             tenant.Id, new ProvisioningOptions("germany-1"), CancellationToken.None);
 
         status.State.Should().Be(ProvisioningState.Ready);
-        _queue.VerifyNoOtherCalls();
+        _platformTasks.VerifyNoOtherCalls();
     }
 
     [Test]
@@ -124,11 +134,10 @@ public class CranlTenantProvisionerTests
 
         await _provisioner.DeprovisionAsync(tenant.Id, CancellationToken.None);
 
-        _queue.Verify(q => q.EnqueueAsync(
-            CranlTenantProvisioner.DeprovisioningTaskType,
-            It.IsAny<string>(),
-            null,
-            tenant.Id,
+        _platformTasks.Verify(q => q.EnqueueAsync(
+            It.Is<PlatformQueuedTask>(t =>
+                t.Type == CranlTenantProvisioner.DeprovisioningTaskType
+                && t.TenantId == tenant.Id),
             It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -140,6 +149,6 @@ public class CranlTenantProvisionerTests
 
         await _provisioner.DeprovisionAsync(tenant.Id, CancellationToken.None);
 
-        _queue.VerifyNoOtherCalls();
+        _platformTasks.VerifyNoOtherCalls();
     }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/TaskQueue/DbTaskQueueTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/TaskQueue/DbTaskQueueTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using Tamma.Api.Services.TaskQueue;
 using Tamma.Api.Tests.Infrastructure;
 using Tamma.Data;
+using Tamma.Data.Entities;
 using Tamma.Data.Repositories;
 
 namespace Tamma.Api.Tests.TaskQueue;
@@ -13,6 +14,11 @@ namespace Tamma.Api.Tests.TaskQueue;
 /// Tenant-isolation + FIFO contract for <see cref="DbTaskQueue"/>. Uses the
 /// EF Core InMemory provider behind a real repository so the service's tenant
 /// scoping is exercised against actual persistence, not a repo mock.
+///
+/// <para>Story 28-1 PR B — DbTaskQueue is now strictly tenant-scoped.
+/// Tests assert that calling EnqueueAsync without an ambient tenant
+/// throws (callers MUST use IPlatformQueuedTaskRepository for
+/// platform-scope work).</para>
 /// </summary>
 [TestFixture]
 public class DbTaskQueueTests
@@ -39,12 +45,30 @@ public class DbTaskQueueTests
         return new DbTaskQueue(repo, context.Object);
     }
 
+    private void SeedTenant(Guid tenantId)
+    {
+        if (_db.Tenants.Find(tenantId) is null)
+        {
+            _db.Tenants.Add(new Tenant
+            {
+                Id = tenantId,
+                Name = tenantId.ToString()[..8],
+                Slug = "t-" + tenantId.ToString()[..8],
+                Type = "personal",
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+            });
+            _db.SaveChanges();
+        }
+    }
+
     // ─── Enqueue + ambient tenant ─────────────────────────────────────────────
 
     [Test]
     public async Task EnqueueAsync_StampsAmbientTenant_WhenNoOverride()
     {
         var tenantA = Guid.NewGuid();
+        SeedTenant(tenantA);
         var queue = NewQueue(_repo, tenantA);
 
         var task = await queue.EnqueueAsync("x", "{}");
@@ -57,6 +81,8 @@ public class DbTaskQueueTests
     {
         var tenantA = Guid.NewGuid();
         var tenantB = Guid.NewGuid();
+        SeedTenant(tenantA);
+        SeedTenant(tenantB);
         var queue = NewQueue(_repo, tenantA);
 
         var task = await queue.EnqueueAsync(
@@ -67,13 +93,16 @@ public class DbTaskQueueTests
     }
 
     [Test]
-    public async Task EnqueueAsync_AllowsNullAmbientTenant()
+    public async Task EnqueueAsync_ThrowsWhenAmbientTenantNull()
     {
+        // Story 28-1 PR B — DbTaskQueue is strictly tenant-scoped now.
+        // Platform-scope callers must use IPlatformQueuedTaskRepository.
         var queue = NewQueue(_repo, null);
 
-        var task = await queue.EnqueueAsync("x", "{}");
+        var act = async () => await queue.EnqueueAsync("x", "{}");
 
-        task.TenantId.Should().BeNull();
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*tenant*");
     }
 
     // ─── Tenant isolation ────────────────────────────────────────────────────
@@ -83,30 +112,18 @@ public class DbTaskQueueTests
     {
         var tenantA = Guid.NewGuid();
         var tenantB = Guid.NewGuid();
+        SeedTenant(tenantA);
+        SeedTenant(tenantB);
 
         await NewQueue(_repo, tenantA).EnqueueAsync("a1", "{}");
         await NewQueue(_repo, tenantA).EnqueueAsync("a2", "{}");
         await NewQueue(_repo, tenantB).EnqueueAsync("b1", "{}");
 
-        var aPending = await NewQueue(_repo, tenantA).ListPendingAsync();
-        var bPending = await NewQueue(_repo, tenantB).ListPendingAsync();
+        var aPending = await NewQueue(_repo, tenantA).ListPendingAsync(tenantA);
+        var bPending = await NewQueue(_repo, tenantB).ListPendingAsync(tenantB);
 
         aPending.Select(t => t.Type).Should().BeEquivalentTo(new[] { "a1", "a2" });
         bPending.Select(t => t.Type).Should().BeEquivalentTo(new[] { "b1" });
-    }
-
-    [Test]
-    public async Task ListPendingAsync_NullTenant_ReturnsAllTenants()
-    {
-        var tenantA = Guid.NewGuid();
-        var tenantB = Guid.NewGuid();
-
-        await NewQueue(_repo, tenantA).EnqueueAsync("a1", "{}");
-        await NewQueue(_repo, tenantB).EnqueueAsync("b1", "{}");
-
-        var all = await NewQueue(_repo, null).ListPendingAsync();
-
-        all.Select(t => t.Type).Should().BeEquivalentTo(new[] { "a1", "b1" });
     }
 
     // ─── FIFO within a tenant ─────────────────────────────────────────────────
@@ -115,6 +132,7 @@ public class DbTaskQueueTests
     public async Task ListPendingAsync_ReturnsTasksInCreationOrder()
     {
         var tenant = Guid.NewGuid();
+        SeedTenant(tenant);
         var queue = NewQueue(_repo, tenant);
 
         var first = await queue.EnqueueAsync("first", "{}");
@@ -123,7 +141,7 @@ public class DbTaskQueueTests
         await Task.Delay(5);
         var third = await queue.EnqueueAsync("third", "{}");
 
-        var pending = await queue.ListPendingAsync();
+        var pending = await queue.ListPendingAsync(tenant);
 
         pending.Select(t => t.Id).Should().ContainInOrder(first.Id, second.Id, third.Id);
     }
@@ -131,13 +149,13 @@ public class DbTaskQueueTests
     // ─── Get/Mark transitions ─────────────────────────────────────────────────
 
     [Test]
-    public async Task GetAsync_ReturnsTaskAcrossTenants()
+    public async Task GetAsync_ReturnsTaskByTenantAndId()
     {
-        // Processor (null tenant) must be able to read any tenant's task.
         var tenantA = Guid.NewGuid();
+        SeedTenant(tenantA);
         var enqueued = await NewQueue(_repo, tenantA).EnqueueAsync("a1", "{}");
 
-        var fetched = await NewQueue(_repo, null).GetAsync(enqueued.Id);
+        var fetched = await NewQueue(_repo, tenantA).GetAsync(tenantA, enqueued.Id);
 
         fetched.Should().NotBeNull();
         fetched!.TenantId.Should().Be(tenantA);
@@ -147,26 +165,29 @@ public class DbTaskQueueTests
     public async Task MarkProcessing_ThenCompleted_ClearsFromPendingList()
     {
         var tenant = Guid.NewGuid();
+        SeedTenant(tenant);
         var queue = NewQueue(_repo, tenant);
         var t = await queue.EnqueueAsync("x", "{}");
 
-        await queue.MarkProcessingAsync(t.Id);
-        await queue.MarkCompletedAsync(t.Id);
+        await queue.MarkProcessingAsync(tenant, t.Id);
+        await queue.MarkCompletedAsync(tenant, t.Id);
 
-        var pending = await queue.ListPendingAsync();
+        var pending = await queue.ListPendingAsync(tenant);
         pending.Should().BeEmpty();
     }
 
     [Test]
     public async Task MarkFailed_StoresErrorString()
     {
-        var queue = NewQueue(_repo, Guid.NewGuid());
+        var tenant = Guid.NewGuid();
+        SeedTenant(tenant);
+        var queue = NewQueue(_repo, tenant);
         var t = await queue.EnqueueAsync("x", "{}");
-        await queue.MarkProcessingAsync(t.Id);
+        await queue.MarkProcessingAsync(tenant, t.Id);
 
-        await queue.MarkFailedAsync(t.Id, "nope");
+        await queue.MarkFailedAsync(tenant, t.Id, "nope");
 
-        var stored = await queue.GetAsync(t.Id);
+        var stored = await queue.GetAsync(tenant, t.Id);
         stored!.Status.Should().Be("failed");
         stored.Error.Should().Be("nope");
     }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/TaskQueue/GitHubWebhookTaskQueueIntegrationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/TaskQueue/GitHubWebhookTaskQueueIntegrationTests.cs
@@ -95,7 +95,11 @@ public class GitHubWebhookTaskQueueIntegrationTests
         using var scope = ApiTestFixture.Factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<ControlPlaneDbContext>();
 
-        var task = await db.QueuedTasks.FirstOrDefaultAsync();
+        // Story 28-1 PR B — orphan webhooks (no installation→tenant
+        // mapping) route to platform_queued_tasks, not the per-tenant
+        // queue. There's no tenant DB to land them in until the
+        // installation is claimed.
+        var task = await db.PlatformQueuedTasks.FirstOrDefaultAsync();
         task.Should().NotBeNull();
         task!.Type.Should().StartWith("github.push");
         task.InstallationId.Should().Be(9001L);
@@ -123,7 +127,8 @@ public class GitHubWebhookTaskQueueIntegrationTests
         using var scope = ApiTestFixture.Factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<ControlPlaneDbContext>();
 
-        var task = await db.QueuedTasks.FirstOrDefaultAsync(t => t.InstallationId == 9002L);
+        // Story 28-1 PR B — orphan webhook → platform_queued_tasks.
+        var task = await db.PlatformQueuedTasks.FirstOrDefaultAsync(t => t.InstallationId == 9002L);
         task.Should().NotBeNull();
         task!.Type.Should().Be("github.issues.opened");
     }
@@ -148,7 +153,8 @@ public class GitHubWebhookTaskQueueIntegrationTests
         using var scope = ApiTestFixture.Factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<ControlPlaneDbContext>();
 
-        var task = await db.QueuedTasks.FirstOrDefaultAsync(t => t.InstallationId == 9003L);
+        // Story 28-1 PR B — orphan webhook → platform_queued_tasks.
+        var task = await db.PlatformQueuedTasks.FirstOrDefaultAsync(t => t.InstallationId == 9003L);
         task.Should().NotBeNull();
         task!.Type.Should().Be("github.pull_request.opened");
     }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/TaskQueue/QueuedTaskRepositoryTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/TaskQueue/QueuedTaskRepositoryTests.cs
@@ -9,14 +9,23 @@ using Tamma.Data.Repositories;
 namespace Tamma.Api.Tests.TaskQueue;
 
 /// <summary>
-/// Exercises the pure persistence port for the task queue. Uses the EF Core
-/// InMemory provider — transitions and FIFO ordering are provider-independent
-/// and are separately validated against Postgres in
-/// <see cref="GitHubWebhookTaskQueueIntegrationTests"/>.
+/// Exercises the pure persistence port for the per-tenant task queue.
+/// Uses the EF Core InMemory provider — transitions and FIFO ordering
+/// are provider-independent and are separately validated against
+/// Postgres in <see cref="GitHubWebhookTaskQueueIntegrationTests"/>.
+///
+/// <para>Story 28-1 PR B — every test now operates against a fixed
+/// tenant id; the repo is strictly tenant-scoped post-PR-B and every
+/// operation requires the tenant id explicitly. The
+/// <c>FromAnyTenant</c> drain path is covered separately at the
+/// bottom.</para>
 /// </summary>
 [TestFixture]
 public class QueuedTaskRepositoryTests
 {
+    private static readonly Guid TenantA = Guid.Parse("aaaaaaaa-1111-1111-1111-aaaaaaaaaaaa");
+    private static readonly Guid TenantB = Guid.Parse("bbbbbbbb-2222-2222-2222-bbbbbbbbbbbb");
+
     private InMemoryDbFixture _fx = null!;
     private ControlPlaneDbContext _db = null!;
     private QueuedTaskRepository _repo = null!;
@@ -27,6 +36,12 @@ public class QueuedTaskRepositoryTests
         _fx = new InMemoryDbFixture();
         _db = _fx.Cp;
         _repo = new QueuedTaskRepository(_fx.Factory, _db);
+
+        // Seed two active tenants so cross-tenant drain has work to walk.
+        _db.Tenants.AddRange(
+            new Tenant { Id = TenantA, Name = "A", Slug = "a", Type = "personal", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow },
+            new Tenant { Id = TenantB, Name = "B", Slug = "b", Type = "personal", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow });
+        _db.SaveChanges();
     }
 
     [TearDown]
@@ -40,7 +55,7 @@ public class QueuedTaskRepositoryTests
         var task = await _repo.EnqueueAsync(new QueuedTask
         {
             Type = "github.push.main",
-            TenantId = Guid.NewGuid(),
+            TenantId = TenantA,
             InstallationId = 4242,
             Payload = "{\"a\":1}"
         });
@@ -59,9 +74,9 @@ public class QueuedTaskRepositoryTests
     }
 
     [Test]
-    public async Task EnqueueAsync_AllowsNullTenantAndInstallation()
+    public async Task EnqueueAsync_ThrowsWhenTenantIdNull()
     {
-        var task = await _repo.EnqueueAsync(new QueuedTask
+        var act = async () => await _repo.EnqueueAsync(new QueuedTask
         {
             Type = "system.cleanup",
             TenantId = null,
@@ -69,8 +84,8 @@ public class QueuedTaskRepositoryTests
             Payload = "{}"
         });
 
-        task.TenantId.Should().BeNull();
-        task.InstallationId.Should().BeNull();
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*TenantId*");
     }
 
     // ── ListPending ───────────────────────────────────────────────────────────
@@ -78,32 +93,29 @@ public class QueuedTaskRepositoryTests
     [Test]
     public async Task ListPendingAsync_ReturnsOnlyPending_InCreationOrder()
     {
-        var t1 = await _repo.EnqueueAsync(new QueuedTask { Type = "a" });
+        var t1 = await _repo.EnqueueAsync(new QueuedTask { Type = "a", TenantId = TenantA });
         await Task.Delay(5);
-        var t2 = await _repo.EnqueueAsync(new QueuedTask { Type = "b" });
+        var t2 = await _repo.EnqueueAsync(new QueuedTask { Type = "b", TenantId = TenantA });
         await Task.Delay(5);
-        var t3 = await _repo.EnqueueAsync(new QueuedTask { Type = "c" });
+        var t3 = await _repo.EnqueueAsync(new QueuedTask { Type = "c", TenantId = TenantA });
 
-        await _repo.MarkProcessingAsync(t2.Id);
-        await _repo.MarkCompletedAsync(t2.Id);
+        await _repo.MarkProcessingAsync(TenantA, t2.Id);
+        await _repo.MarkCompletedAsync(TenantA, t2.Id);
 
-        var pending = await _repo.ListPendingAsync(null, limit: 10);
+        var pending = await _repo.ListPendingAsync(TenantA, limit: 10);
 
         pending.Select(t => t.Id).Should().ContainInOrder(t1.Id, t3.Id);
         pending.Should().NotContain(t => t.Id == t2.Id);
     }
 
     [Test]
-    public async Task ListPendingAsync_FiltersByTenant_WhenSupplied()
+    public async Task ListPendingAsync_FiltersByTenant()
     {
-        var tenantA = Guid.NewGuid();
-        var tenantB = Guid.NewGuid();
+        var a1 = await _repo.EnqueueAsync(new QueuedTask { Type = "a1", TenantId = TenantA });
+        var b1 = await _repo.EnqueueAsync(new QueuedTask { Type = "b1", TenantId = TenantB });
+        var a2 = await _repo.EnqueueAsync(new QueuedTask { Type = "a2", TenantId = TenantA });
 
-        var a1 = await _repo.EnqueueAsync(new QueuedTask { Type = "a1", TenantId = tenantA });
-        var b1 = await _repo.EnqueueAsync(new QueuedTask { Type = "b1", TenantId = tenantB });
-        var a2 = await _repo.EnqueueAsync(new QueuedTask { Type = "a2", TenantId = tenantA });
-
-        var onlyA = await _repo.ListPendingAsync(tenantA, limit: 10);
+        var onlyA = await _repo.ListPendingAsync(TenantA, limit: 10);
 
         onlyA.Select(t => t.Id).Should().BeEquivalentTo(new[] { a1.Id, a2.Id });
         onlyA.Should().NotContain(t => t.Id == b1.Id);
@@ -112,12 +124,55 @@ public class QueuedTaskRepositoryTests
     [Test]
     public async Task ListPendingAsync_RespectsLimit()
     {
-        await _repo.EnqueueAsync(new QueuedTask { Type = "a" });
-        await _repo.EnqueueAsync(new QueuedTask { Type = "b" });
-        await _repo.EnqueueAsync(new QueuedTask { Type = "c" });
+        await _repo.EnqueueAsync(new QueuedTask { Type = "a", TenantId = TenantA });
+        await _repo.EnqueueAsync(new QueuedTask { Type = "b", TenantId = TenantA });
+        await _repo.EnqueueAsync(new QueuedTask { Type = "c", TenantId = TenantA });
 
-        var pending = await _repo.ListPendingAsync(null, limit: 2);
+        var pending = await _repo.ListPendingAsync(TenantA, limit: 2);
         pending.Should().HaveCount(2);
+    }
+
+    // ── ListPendingFromAnyTenantAsync (Story 28-1 PR B) ──────────────────────
+
+    [Test]
+    public async Task ListPendingFromAnyTenantAsync_AggregatesAcrossActiveTenants()
+    {
+        var a1 = await _repo.EnqueueAsync(new QueuedTask { Type = "a1", TenantId = TenantA });
+        var b1 = await _repo.EnqueueAsync(new QueuedTask { Type = "b1", TenantId = TenantB });
+
+        var aggregate = await _repo.ListPendingFromAnyTenantAsync(batchSizePerTenant: 10);
+
+        aggregate.Select(t => t.Id).Should().Contain(new[] { a1.Id, b1.Id });
+    }
+
+    [Test]
+    public async Task ListPendingFromAnyTenantAsync_RespectsBatchSizePerTenant()
+    {
+        for (int i = 0; i < 5; i++)
+        {
+            await _repo.EnqueueAsync(new QueuedTask { Type = $"a{i}", TenantId = TenantA });
+            await _repo.EnqueueAsync(new QueuedTask { Type = $"b{i}", TenantId = TenantB });
+        }
+
+        var aggregate = await _repo.ListPendingFromAnyTenantAsync(batchSizePerTenant: 2);
+
+        // 2 per tenant × 2 tenants = 4 rows total.
+        aggregate.Should().HaveCount(4);
+    }
+
+    [Test]
+    public async Task ListPendingFromAnyTenantAsync_IgnoresSoftDeletedTenants()
+    {
+        await _repo.EnqueueAsync(new QueuedTask { Type = "a1", TenantId = TenantA });
+        var b1 = await _repo.EnqueueAsync(new QueuedTask { Type = "b1", TenantId = TenantB });
+
+        var b = await _db.Tenants.FindAsync(TenantB);
+        b!.DeletedAt = DateTime.UtcNow;
+        await _db.SaveChangesAsync();
+
+        var aggregate = await _repo.ListPendingFromAnyTenantAsync(batchSizePerTenant: 10);
+
+        aggregate.Select(t => t.Id).Should().NotContain(b1.Id);
     }
 
     // ── MarkProcessing ────────────────────────────────────────────────────────
@@ -125,9 +180,9 @@ public class QueuedTaskRepositoryTests
     [Test]
     public async Task MarkProcessingAsync_FlipsPendingToProcessing()
     {
-        var t = await _repo.EnqueueAsync(new QueuedTask { Type = "x" });
+        var t = await _repo.EnqueueAsync(new QueuedTask { Type = "x", TenantId = TenantA });
 
-        var claimed = await _repo.MarkProcessingAsync(t.Id);
+        var claimed = await _repo.MarkProcessingAsync(TenantA, t.Id);
 
         claimed.Should().NotBeNull();
         claimed!.Status.Should().Be("processing");
@@ -137,28 +192,28 @@ public class QueuedTaskRepositoryTests
     [Test]
     public async Task MarkProcessingAsync_ReturnsNull_WhenAlreadyClaimed()
     {
-        var t = await _repo.EnqueueAsync(new QueuedTask { Type = "x" });
-        await _repo.MarkProcessingAsync(t.Id);
+        var t = await _repo.EnqueueAsync(new QueuedTask { Type = "x", TenantId = TenantA });
+        await _repo.MarkProcessingAsync(TenantA, t.Id);
 
-        var second = await _repo.MarkProcessingAsync(t.Id);
+        var second = await _repo.MarkProcessingAsync(TenantA, t.Id);
 
         second.Should().BeNull();
     }
 
     [Test]
     public async Task MarkProcessingAsync_ReturnsNull_ForUnknownId()
-        => (await _repo.MarkProcessingAsync(Guid.NewGuid())).Should().BeNull();
+        => (await _repo.MarkProcessingAsync(TenantA, Guid.NewGuid())).Should().BeNull();
 
     // ── MarkCompleted ─────────────────────────────────────────────────────────
 
     [Test]
     public async Task MarkCompletedAsync_FlipsStatus_AndLeavesErrorNull()
     {
-        var t = await _repo.EnqueueAsync(new QueuedTask { Type = "x" });
-        await _repo.MarkProcessingAsync(t.Id);
-        await _repo.MarkCompletedAsync(t.Id);
+        var t = await _repo.EnqueueAsync(new QueuedTask { Type = "x", TenantId = TenantA });
+        await _repo.MarkProcessingAsync(TenantA, t.Id);
+        await _repo.MarkCompletedAsync(TenantA, t.Id);
 
-        var stored = await _repo.GetAsync(t.Id);
+        var stored = await _repo.GetAsync(TenantA, t.Id);
         stored!.Status.Should().Be("completed");
         stored.Error.Should().BeNull();
     }
@@ -168,12 +223,12 @@ public class QueuedTaskRepositoryTests
     [Test]
     public async Task MarkFailedAsync_StoresErrorAndFlipsStatus()
     {
-        var t = await _repo.EnqueueAsync(new QueuedTask { Type = "x" });
-        await _repo.MarkProcessingAsync(t.Id);
+        var t = await _repo.EnqueueAsync(new QueuedTask { Type = "x", TenantId = TenantA });
+        await _repo.MarkProcessingAsync(TenantA, t.Id);
 
-        await _repo.MarkFailedAsync(t.Id, "boom");
+        await _repo.MarkFailedAsync(TenantA, t.Id, "boom");
 
-        var stored = await _repo.GetAsync(t.Id);
+        var stored = await _repo.GetAsync(TenantA, t.Id);
         stored!.Status.Should().Be("failed");
         stored.Error.Should().Be("boom");
     }
@@ -183,10 +238,10 @@ public class QueuedTaskRepositoryTests
     [Test]
     public async Task IncrementRetryAndRequeueAsync_BumpsCount_AndResetsToPending()
     {
-        var t = await _repo.EnqueueAsync(new QueuedTask { Type = "x" });
-        await _repo.MarkProcessingAsync(t.Id);
+        var t = await _repo.EnqueueAsync(new QueuedTask { Type = "x", TenantId = TenantA });
+        await _repo.MarkProcessingAsync(TenantA, t.Id);
 
-        var requeued = await _repo.IncrementRetryAndRequeueAsync(t.Id, "transient");
+        var requeued = await _repo.IncrementRetryAndRequeueAsync(TenantA, t.Id, "transient");
 
         requeued.Should().NotBeNull();
         requeued!.Status.Should().Be("pending");

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/TaskQueue/TaskQueueProcessorTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/TaskQueue/TaskQueueProcessorTests.cs
@@ -23,6 +23,8 @@ namespace Tamma.Api.Tests.TaskQueue;
 [TestFixture]
 public class TaskQueueProcessorTests
 {
+    private static readonly Guid TestTenantId = Guid.Parse("12345678-aaaa-bbbb-cccc-9999cafe0000");
+
     private ServiceProvider _services = null!;
     private DbContextOptions<ControlPlaneDbContext> _cpOptions = null!;
     private DbContextOptions<TenantDbContext> _tenantOptions = null!;
@@ -64,6 +66,21 @@ public class TaskQueueProcessorTests
 
         _services = services.BuildServiceProvider();
 
+        // Seed an active tenant so cross-tenant drain has a tenant to walk.
+        using (var seed = new TestControlPlaneDbContext(_cpOptions))
+        {
+            seed.Tenants.Add(new Tenant
+            {
+                Id = TestTenantId,
+                Name = "test",
+                Slug = "test",
+                Type = "personal",
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+            });
+            seed.SaveChanges();
+        }
+
         _processor = new TaskQueueProcessor(
             _services,
             new TaskQueueProcessorOptions
@@ -97,6 +114,7 @@ public class TaskQueueProcessorTests
         var enqueued = await FreshRepo().EnqueueAsync(new QueuedTask
         {
             Type = "github.push.main",
+            TenantId = TestTenantId,
             Payload = "{\"ref\":\"refs/heads/main\"}"
         });
 
@@ -110,7 +128,7 @@ public class TaskQueueProcessorTests
             It.Is<QueuedTask>(t => t.Id == enqueued.Id),
             It.IsAny<CancellationToken>()), Times.Once);
 
-        var stored = await FreshRepo().GetAsync(enqueued.Id);
+        var stored = await FreshRepo().GetAsync(TestTenantId, enqueued.Id);
         stored!.Status.Should().Be("completed");
         stored.Error.Should().BeNull();
     }
@@ -130,14 +148,14 @@ public class TaskQueueProcessorTests
     [Test]
     public async Task ProcessOnceAsync_HandlerThrows_RequeuesWithIncrementedRetry()
     {
-        var enqueued = await FreshRepo().EnqueueAsync(new QueuedTask { Type = "github.x" });
+        var enqueued = await FreshRepo().EnqueueAsync(new QueuedTask { Type = "github.x", TenantId = TestTenantId });
 
         _handler.Setup(h => h.HandleAsync(It.IsAny<QueuedTask>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("transient boom"));
 
         await _processor.ProcessOnceAsync(CancellationToken.None);
 
-        var stored = await FreshRepo().GetAsync(enqueued.Id);
+        var stored = await FreshRepo().GetAsync(TestTenantId, enqueued.Id);
         stored!.Status.Should().Be("pending");  // requeued
         stored.RetryCount.Should().Be(1);
         stored.Error.Should().Contain("transient boom");
@@ -146,23 +164,23 @@ public class TaskQueueProcessorTests
     [Test]
     public async Task ProcessOnceAsync_HandlerThrowsThreeTimes_MarksFailed()
     {
-        var enqueued = await FreshRepo().EnqueueAsync(new QueuedTask { Type = "github.x" });
+        var enqueued = await FreshRepo().EnqueueAsync(new QueuedTask { Type = "github.x", TenantId = TestTenantId });
 
         _handler.Setup(h => h.HandleAsync(It.IsAny<QueuedTask>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("broken"));
 
         // Attempt 1 → RetryCount 1, pending
         await _processor.ProcessOnceAsync(CancellationToken.None);
-        (await FreshRepo().GetAsync(enqueued.Id))!.Status.Should().Be("pending");
+        (await FreshRepo().GetAsync(TestTenantId, enqueued.Id))!.Status.Should().Be("pending");
 
         // Attempt 2 → RetryCount 2, pending
         await _processor.ProcessOnceAsync(CancellationToken.None);
-        (await FreshRepo().GetAsync(enqueued.Id))!.Status.Should().Be("pending");
+        (await FreshRepo().GetAsync(TestTenantId, enqueued.Id))!.Status.Should().Be("pending");
 
         // Attempt 3 → RetryCount 3, now failed (exhausted)
         await _processor.ProcessOnceAsync(CancellationToken.None);
 
-        var stored = await FreshRepo().GetAsync(enqueued.Id);
+        var stored = await FreshRepo().GetAsync(TestTenantId, enqueued.Id);
         stored!.Status.Should().Be("failed");
         stored.RetryCount.Should().Be(3);
         stored.Error.Should().Contain("broken");
@@ -174,11 +192,11 @@ public class TaskQueueProcessorTests
     public async Task ProcessOnceAsync_NoHandlerRegistered_MarksFailedWithClearError()
     {
         // Type does NOT start with "github." — registry returns null.
-        var enqueued = await FreshRepo().EnqueueAsync(new QueuedTask { Type = "unknown.type" });
+        var enqueued = await FreshRepo().EnqueueAsync(new QueuedTask { Type = "unknown.type", TenantId = TestTenantId });
 
         await _processor.ProcessOnceAsync(CancellationToken.None);
 
-        var stored = await FreshRepo().GetAsync(enqueued.Id);
+        var stored = await FreshRepo().GetAsync(TestTenantId, enqueued.Id);
         stored!.Status.Should().Be("failed");
         stored.Error.Should().Contain("no handler");
     }


### PR DESCRIPTION
## Summary

Implements **Decision #5** from `.dev/decisions/story-28-1-design-calls.md` — splits \`EmailOutboxRepository\` and \`QueuedTaskRepository\` cleanly along the existing \`IPlatform*Repository\` abstraction. Second PR in the 4-PR Story 28-1 sequence.

## Per-caller decision matrix

| Caller | Scope | Rationale |
|---|---|---|
| \`AuthEndpoints.Register\` (verification email) | **PLATFORM** | No tenant DB exists yet at registration |
| \`AuthEndpoints.ResendVerification\` | **PLATFORM** | User may not have a verified tenant DB |
| \`AuthEndpoints.PasswordResetRequest\` | **PLATFORM** | User-scope account-recovery, not pinned to one tenant |
| \`OrgEndpoints.CreateInvite\` | **TENANT** | Existing tenant org, tenant DB exists |
| \`OrgEndpoints.ResendInvite\` | **TENANT** | Existing tenant org |
| \`EmailAlertChannel\` | **PLATFORM** | Already direct-to-`platform_email_outbox`; no change |
| \`CranlTenantProvisioner.ProvisionAsync\` | **PLATFORM** | Tenant DB doesn't exist yet (the task creates it) |
| \`CranlTenantProvisioner.DeprovisionAsync\` | **PLATFORM** | Tenant DB about to be torn down |
| \`InstallationRouterService.EnqueueDeferredEvent\` | **SPLIT** | Tenant-bound webhooks → tenant queue; orphan webhooks → platform queue |
| \`RetireScheduler.ScheduleRetireAsync\` | **PLATFORM** | Already direct-to-\`IPlatformQueuedTaskRepository\`; no change |

No callers were unclassifiable.

## Design notes

1. **Cross-tenant drain** (\`ClaimNextPendingFromAnyTenantAsync\`, \`ListPendingFromAnyTenantAsync\`, \`ReapStaleProcessingAcrossAllTenantsAsync\`) walks active tenants from CP's \`tenants\` table (\`DeletedAt IS NULL\`) — robust against process restarts (LRU cache is empty on cold start). Cost is one cheap \`SELECT Id FROM tenants\` per poll cycle.
2. **Tenant-scope repos throw** when called without a tenant id (rather than silently routing to CP). Forces every caller to make an explicit tenant-vs-platform decision.
3. **Physical tables stay on CP for now** — PR D moves them. Tenant-scope repo's \`factory.CreateAsync(tid)\` returns a \`TenantDbContext\` bound to the same shared connection during transition; after PR D the factory hands back per-tenant data sources and the writes/reads physically split.

## Tests

3274 passing, 0 failed across all suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)