### PR TITLE
fix(intelligence): vitest 4 — replace beforeAll ctx.skip with module-level probe

### DIFF
--- a/packages/intelligence/src/vector-store/__tests__/integration/chromadb.integration.test.ts
+++ b/packages/intelligence/src/vector-store/__tests__/integration/chromadb.integration.test.ts
@@ -7,7 +7,7 @@
  * To run: pnpm test:integration
  */
 
-import { describe, it, expect, beforeAll, afterAll, beforeEach, type TaskContext } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { ChromaDBVectorStore } from '../../providers/chromadb.js';
 import { createChromaDBStore } from '../../factory.js';
 import type { VectorDocument, SearchQuery, HybridSearchQuery } from '../../interfaces.js';
@@ -19,24 +19,34 @@ import { join } from 'path';
 const SKIP_INTEGRATION = process.env['SKIP_INTEGRATION_TESTS'] === 'true';
 const CHROMADB_URL = process.env['CHROMADB_TEST_URL'] ?? '';
 
-describe.skipIf(SKIP_INTEGRATION || !CHROMADB_URL)('ChromaDB Integration Tests', () => {
+// Vitest 4 removed the ability to call `ctx.skip()` from top-level
+// `beforeAll`, so we probe ChromaDB at module load time (top-level await
+// is supported in ESM) and gate the suite via `describe.skipIf`.
+let chromaReachable = false;
+if (!SKIP_INTEGRATION && CHROMADB_URL) {
+  try {
+    const probe = createChromaDBStore(CHROMADB_URL, 64) as ChromaDBVectorStore;
+    await probe.initialize();
+    await probe.dispose();
+    chromaReachable = true;
+  } catch {
+    console.warn('ChromaDB not available at', CHROMADB_URL, '— skipping integration tests');
+  }
+}
+
+describe.skipIf(SKIP_INTEGRATION || !CHROMADB_URL || !chromaReachable)('ChromaDB Integration Tests', () => {
   let store: ChromaDBVectorStore;
   let tempDir: string;
   const testCollectionName = 'test-collection';
   const dimensions = 128; // Smaller dimensions for faster tests
 
-  beforeAll(async (ctx: TaskContext) => {
-    // Create temp directory for ChromaDB data
+  beforeAll(async () => {
+    // Create temp directory for ChromaDB data. Reachability already
+    // verified at module load — initialize() here is for the real
+    // long-lived store the tests use.
     tempDir = mkdtempSync(join(tmpdir(), 'chroma-test-'));
-
     store = createChromaDBStore(CHROMADB_URL, dimensions) as ChromaDBVectorStore;
-
-    try {
-      await store.initialize();
-    } catch (error) {
-      console.warn('ChromaDB not available, skipping integration tests');
-      ctx.skip();
-    }
+    await store.initialize();
   });
 
   afterAll(async () => {


### PR DESCRIPTION
## Summary
CI Integration Tests (Postgres) job failed on `feat/wave-a` tip `6d9dd18` post-#336 merge with `FixtureParseError` on `chromadb.integration.test.ts:28`. Vitest 4 rejects the v3 pattern `beforeAll(async (ctx: TaskContext) => ctx.skip())` — top-level `beforeAll` no longer accepts the suite/task context positionally; the new `ModuleContext` type has no `skip`.

This was the only call site in the repo using the v3 API (verified via grep across all `*.test.ts` and `*.test.tsx`).

## What changed
Restructured to probe ChromaDB at module load via top-level await (supported in ESM) and gate the suite via `describe.skipIf` based on the probe result. Behaviorally equivalent to the v3 implementation:

- URL unset → skipped (already handled)
- URL set, server unreachable → skipped (was via `ctx.skip`, now via probe + `skipIf`)
- URL set, server reachable → all tests run

## Test plan
- [x] Reproduced FixtureParseError locally (vitest 4.1.5 against unfixed code)
- [x] Single file run: 14 skipped, file parses cleanly
- [x] Full integration suite (matches CI): 3 passed | 5 skipped (was: 1 failed | 4 passed | 3 skipped)
- [ ] CI Integration Tests (Postgres) job green on this branch

## Why this slipped through PR #336's verification
Per the wave-4 review, PR #336 originally verified by running `pnpm vitest` from root, which uses the main `vitest.config.ts` that explicitly **excludes** `**/*.integration.test.ts`. The integration test runner uses a separate `vitest.integration.config.ts` invoked only by CI. Same verification-surface gap pattern as the original wave-4 finding — just one layer deeper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)