### PR TITLE
feat(tenancy): residuals — self-service re-provision, CP-store terminal events, RunOnStartup hazard doc

### DIFF
--- a/.dev/findings/platform-task-worker-runonstartup-hazard.md
+++ b/.dev/findings/platform-task-worker-runonstartup-hazard.md
@@ -1,0 +1,70 @@
+# Finding: `PlatformTaskWorker:RunOnStartup=true` is unsafe in production (shared-queue type collision)
+
+**Date**: 2026-06-10
+**Context**: tenancy residual #3 — "enable PlatformTaskWorker:RunOnStartup in prod when queued
+moves should execute" (post unified-tenancy merge, PR #343).
+**Verdict**: NOT enabled. Enabling it today silently destroys scheduled secret retirements.
+
+## Background
+
+`PlatformTaskWorker` (Story 28-6, `apps/tamma-elsa/src/Tamma.Api/Services/PlatformTasks/PlatformTaskWorker.cs`)
+drains `platform_queued_tasks`. It defaults to `RunOnStartup = false` (Round-2 H8) and is gated
+off in production, which is why queued `tenant.move` tasks from
+`POST /api/admin/tenants/{id}/move` do not execute. The naive fix is to set
+`PlatformTaskWorker:RunOnStartup=true` — its registry handlers (`tenant.move` via
+`MoveTenantTaskHandler`, `provisioning.tenant.v2` via `ProvisionTenantV2TaskHandler`) ARE wired
+in `Program.cs` / `ProvisioningServiceCollectionExtensions`.
+
+## The hazard
+
+`PlatformQueuedTaskRepository.ReserveNextAsync` claims **the oldest `pending` row of ANY type**:
+
+```sql
+WHERE "Status" = 'pending' ORDER BY "CreatedAt" ASC FOR UPDATE SKIP LOCKED LIMIT 1
+```
+
+No type filter, and `PlatformQueuedTask` has **no run-after column**. The table is shared by
+producers whose rows must remain `pending` and must NOT be consumed by this worker:
+
+1. **`RETIRE_SECRET_VERSION` (Story 29-6 secret rotation)** — `RotateSecretSagaActivity` /
+   `ScheduleRetireOldActivity` → `RetireScheduler.ScheduleRetireAsync` enqueues a pending row
+   whose `runAfter` (grace period before retiring the old secret version) lives ONLY in the JSON
+   payload. The companion `SweepDueRetireTasksAsync` reserves rows, releases not-yet-due/wrong-type
+   ones with `maxRetries: int.MaxValue`, and retires due ones.
+   With the worker enabled: no `IPlatformTaskHandler` exists for this type, so the worker parks
+   the row (`ParkUnprocessableAsync`: `RetryCount += 1`, status back to `pending`, original
+   `CreatedAt` kept). The row stays oldest-pending, so the worker re-claims it every
+   `PollInterval` (5s) tick and **dead-letters it after `MaxRetries` (5) observations — ~25
+   seconds after enqueue**, long before its `runAfter`. Old secret versions would never retire;
+   rotation is silently broken with no error surfaced to the rotation flow.
+
+2. **Orphan-webhook fallback rows** — `InstallationRouterService` enqueues webhook payloads onto
+   the platform queue when no installation→tenant mapping exists yet ("handlers can decide at
+   dispatch time"). No handler is registered → same park→dead-letter fate; orphan webhooks are
+   destroyed instead of waiting for the mapping.
+
+3. **v1 Cranl rows** (`provisioning.tenant`, `provisioning.tenant.deprovision`) — enqueued by
+   `CranlTenantProvisioner` and (deliberately, via the v1 constants) by `CranlTenantProviderV2`.
+   Their consumer is NOT an `IPlatformTaskHandler` → park→dead-letter. Moot while `Cranl:ApiKey`
+   is unset in prod (Null seam), but a footgun the moment Cranl is enabled.
+
+Secondary wart: the rotation sweeper's "not ours" release path calls `FailAsync` which still
+increments `RetryCount` on `tenant.move` / `provisioning.tenant.v2` rows it touches, eroding
+their real retry budget against the worker's `MaxRetries = 5`.
+
+## Prerequisite to enable
+
+Either of:
+
+- **Type-aware reservation** (preferred): `ReserveNextAsync(workerId, types[], ct)` so
+  `PlatformTaskWorker` only claims types present in its `IPlatformTaskHandlerRegistry`, and the
+  rotation sweeper only claims `RETIRE_SECRET_VERSION` (also removes the retry-budget erosion).
+  A first-class `RunAfter` column on `platform_queued_tasks` would let retire rows rejoin the
+  general worker afterwards.
+- Register an `IPlatformTaskHandler` for **every** producer type with correct semantics
+  (the retire handler must re-park until `runAfter` without consuming retry budget — i.e. it
+  still effectively needs run-after support).
+
+Until then `PlatformTaskWorker:RunOnStartup` must stay unset/false in production; queued
+`tenant.move` rows wait harmlessly in `pending` and execute on the first deploy that enables the
+worker safely.

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs
@@ -731,7 +731,7 @@ public static class OrgEndpoints
         IInviteRepository inviteRepo,
         IUserRepository userRepo,
         IDeleteConfirmationService confirmation,
-        IEventRepository events,
+        IPlatformEventPublisher publisher,
         ClaimsPrincipal principal,
         HttpContext httpContext,
         string? confirm)
@@ -760,16 +760,6 @@ public static class OrgEndpoints
             if (!confirmation.Verify(confirm, tenantId, callerId.Value))
                 return Results.BadRequest(new { error = "confirmation_expired", message = "Invalid or expired confirmation token" });
 
-            // Unified-tenancy Phase 3: emit BEFORE deleting. Once the
-            // tenant row is soft-deleted the resolver treats the tenant as
-            // gone (DeletedAt IS NULL filter) and its event store becomes
-            // unreachable -- emitting afterwards throws
-            // TenantNotFoundException after the delete already happened.
-            await EmitTenantEvent(events, "TENANT.PURGED.SUCCESS", tenantId, callerId.Value, new
-            {
-                phase = "hard-delete",
-            });
-
             await using var tx = await db.Database.BeginTransactionAsync();
             try
             {
@@ -789,21 +779,36 @@ public static class OrgEndpoints
                 throw;
             }
 
+            // Tenancy residual (post-#343): terminal lifecycle events live
+            // in the CONTROL-PLANE store, not the tenant's own schema — the
+            // tenant store is unreachable after the delete (DeletedAt filter
+            // in the resolver), which used to force an emit-BEFORE-delete
+            // ordering that recorded "PURGED" for purges that could still
+            // roll back. The CP store survives tenant deletion, so we emit
+            // AFTER the transaction commits: the event now means the purge
+            // actually happened.
+            await publisher.AppendAndPublishAsync(
+                BuildLifecycleEvent("TENANT.PURGED.SUCCESS", tenantId, callerId.Value, new Dictionary<string, object?>
+                {
+                    ["phase"] = "hard-delete",
+                }));
+
             return Results.NoContent();
         }
 
         // Phase 1 (soft-delete) — mint the HMAC confirmation token and return 202.
-        // Unified-tenancy Phase 3: emit BEFORE soft-deleting -- a
-        // soft-deleted tenant's event store is unreachable through the
-        // resolver (DeletedAt IS NULL filter), so emitting afterwards
-        // throws TenantNotFoundException after the delete already happened.
-        await EmitTenantEvent(events, "TENANT.DELETED.SUCCESS", tenantId, callerId.Value, new
-        {
-            phase = "soft-delete",
-        });
-
         await tenantRepo.SoftDeleteAsync(tenantId);
         await userRepo.SwitchActiveTenantAwayFromAsync(callerId.Value, tenantId);
+
+        // Tenancy residual (post-#343): terminal lifecycle event goes to the
+        // CONTROL-PLANE store (see the PURGED emission above for rationale) —
+        // emitted AFTER the soft-delete so the audit record reflects reality.
+        await publisher.AppendAndPublishAsync(
+            BuildLifecycleEvent("TENANT.DELETED.SUCCESS", tenantId, callerId.Value, new Dictionary<string, object?>
+            {
+                ["phase"] = "soft-delete",
+            }));
+
         var token = confirmation.Generate(tenantId, callerId.Value);
 
         return Results.Json(new

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs
@@ -7,8 +7,10 @@ using Tamma.Api.Authorization;
 using Tamma.Api.Dtos.Orgs;
 using Tamma.Api.Services.Email;
 using Tamma.Api.Services.RateLimit;
+using Tamma.Api.Services.TenantStatus;
 using Tamma.Api.Validation;
 using Tamma.Data;
+using Tamma.Data.Abstractions;
 using Tamma.Data.Entities;
 using Tamma.Data.Repositories;
 
@@ -812,6 +814,169 @@ public static class OrgEndpoints
         }, statusCode: StatusCodes.Status202Accepted);
     }
 
+    /// <summary>
+    /// Self-service re-provision: <c>POST /api/v1/orgs/{tenantId}/reprovision</c>.
+    ///
+    /// <para>When <see cref="CreateOrg"/>'s synchronous provisioning throws
+    /// (placement → role → schema → minted connection string → migrations),
+    /// the org row survives in a degraded state — no encrypted connection
+    /// string, so the resolver can't reach ANY tenant data. Before this
+    /// endpoint the only recovery was the platform-owner-only
+    /// <c>POST /api/admin/tenants/{id}/actions/retry</c>; now the tenant's
+    /// own owner/admin can retry without filing a support ticket.</para>
+    ///
+    /// <para><b>Authorization</b>: path-tenant membership is enforced by
+    /// <see cref="RequireTenantMembershipFilter"/> (cross-tenant calls 404
+    /// before the handler runs); the handler additionally requires the
+    /// admin+ role (tenant_owner or tenant_admin) — same gate as
+    /// <see cref="UpdateOrgSettings"/>.</para>
+    ///
+    /// <para><b>State machine</b> (reads the <c>tenants.Status</c> shadow
+    /// column):</para>
+    /// <list type="bullet">
+    ///   <item><description><c>provisioning</c> / <c>pending_verification</c>
+    ///     → 409 <c>provisioning_in_progress</c> (a run is already in
+    ///     flight — never start a second).</description></item>
+    ///   <item><description><c>active</c> (or legacy NULL) with an encrypted
+    ///     connection string present → 409 <c>already_provisioned</c>
+    ///     (idempotent no-op refusal — nothing to repair).</description></item>
+    ///   <item><description><c>failed</c>, or <c>active</c>/NULL with NO
+    ///     stored envelope (the degraded CreateOrg leftover) → allowed:
+    ///     flip to <c>provisioning</c>, re-run the SAME
+    ///     <see cref="ITenantProvisioningService.ProvisionAsync"/> pipeline
+    ///     CreateOrg uses (idempotent: CREATE IF NOT EXISTS / re-grant /
+    ///     skip-reencrypt), which flips Status to <c>active</c> on
+    ///     success.</description></item>
+    ///   <item><description>Anything else (<c>suspended</c>, <c>draining</c>,
+    ///     <c>deleting</c>, ...) → 409 <c>tenant_not_reprovisionable</c>.</description></item>
+    /// </list>
+    /// </summary>
+    public static async Task<IResult> ReprovisionOrg(
+        Guid tenantId,
+        ControlPlaneDbContext db,
+        ITenantProvisioningService provisioning,
+        IPlatformEventPublisher publisher,
+        ITenantStatusCache statusCache,
+        ITenantConnectionResolver connectionResolver,
+        ITenantStatusInvalidationBus invalidationBus,
+        ClaimsPrincipal principal,
+        HttpContext httpContext)
+    {
+        var callerId = ResolveUserId(principal);
+        if (callerId is null) return Results.Unauthorized();
+
+        // Path-tenant membership gate already ran; require admin+ to
+        // trigger infrastructure work (mirrors UpdateOrgSettings).
+        if (!RoleAtLeast(httpContext, TenantRoleHierarchy.Admin))
+            return Results.Json(new { error = "Requires admin role or higher" }, statusCode: 403);
+
+        // Soft-deleted rows are filtered by the global query filter —
+        // a deleted org 404s here, same as GetOrg.
+        var tenant = await db.Tenants.FirstOrDefaultAsync(t => t.Id == tenantId);
+        if (tenant is null) return Results.NotFound(new { error = "Organization not found" });
+
+        var entry = db.Entry(tenant);
+        var status = (string?)entry.Property("Status").CurrentValue;
+        var envelope = (byte[]?)entry.Property("EncryptedConnectionString").CurrentValue;
+        var hasEnvelope = envelope is { Length: > 0 };
+
+        if (status is TenantStatusEvaluator.StatusProvisioning
+                   or TenantStatusEvaluator.StatusPendingVerification)
+        {
+            return Results.Json(
+                new { error = "provisioning_in_progress", message = "Provisioning is already in flight for this organization" },
+                statusCode: StatusCodes.Status409Conflict);
+        }
+
+        var looksActive = TenantStatusEvaluator.IsActive(status);
+        if (looksActive && hasEnvelope)
+        {
+            return Results.Json(
+                new { error = "already_provisioned", message = "Organization is already provisioned" },
+                statusCode: StatusCodes.Status409Conflict);
+        }
+
+        var retryable =
+            string.Equals(status, TenantStatusEvaluator.StatusFailed, StringComparison.OrdinalIgnoreCase)
+            || (looksActive && !hasEnvelope);  // degraded CreateOrg leftover
+        if (!retryable)
+        {
+            return Results.Json(
+                new { error = "tenant_not_reprovisionable", message = $"Organization status '{status}' does not allow re-provisioning" },
+                statusCode: StatusCodes.Status409Conflict);
+        }
+
+        // Claim the run: flip to 'provisioning' BEFORE doing work so a
+        // concurrent second call observes in-flight state and 409s.
+        entry.Property("Status").CurrentValue = TenantStatusEvaluator.StatusProvisioning;
+        entry.Property("FailureReason").CurrentValue = null;
+        tenant.UpdatedAt = DateTime.UtcNow;
+        await db.SaveChangesAsync();
+        statusCache.Invalidate(tenantId);
+        await invalidationBus.PublishAsync(tenantId);
+
+        // Audit breadcrumb in the CONTROL-PLANE store (the tenant store may
+        // be unreachable — that's exactly why we're here).
+        await publisher.AppendAndPublishAsync(
+            BuildLifecycleEvent(
+                "TENANT.PROVISIONING_REQUESTED",
+                tenantId,
+                callerId.Value,
+                new Dictionary<string, object?>
+                {
+                    ["requestedAt"] = DateTime.UtcNow,
+                    ["source"] = "self-service-reprovision",
+                }));
+
+        try
+        {
+            // Same pipeline CreateOrg runs — placement → role → schema →
+            // minted connection string → migrate → encrypt + persist →
+            // Status 'active'. Idempotent on partial prior runs.
+            await provisioning.ProvisionAsync(tenantId);
+        }
+        catch (Exception ex)
+        {
+            // ProvisionAsync uses its own DbContext scope; reload before
+            // stamping so we don't overwrite anything it persisted.
+            await entry.ReloadAsync();
+            entry.Property("Status").CurrentValue = TenantStatusEvaluator.StatusFailed;
+            entry.Property("FailureReason").CurrentValue = "reprovision_failed";
+            tenant.UpdatedAt = DateTime.UtcNow;
+            await db.SaveChangesAsync();
+            statusCache.Invalidate(tenantId);
+            await invalidationBus.PublishAsync(tenantId);
+
+            httpContext.RequestServices
+                .GetService<ILoggerFactory>()?
+                .CreateLogger(typeof(OrgEndpoints))
+                .LogError(ex, "Self-service re-provision failed tenantId={TenantId}", tenantId);
+
+            return Results.Json(
+                new { error = "provisioning_failed", message = "Re-provisioning failed; the organization was returned to the failed state" },
+                statusCode: StatusCodes.Status502BadGateway);
+        }
+
+        // Success — ProvisionAsync flipped Status to 'active' and persisted
+        // the encrypted connection string. Drop every stale cache layer so
+        // the next request routes against the fresh envelope.
+        statusCache.Invalidate(tenantId);
+        await connectionResolver.EvictAsync(tenantId);
+        await invalidationBus.PublishAsync(tenantId);
+
+        await publisher.AppendAndPublishAsync(
+            BuildLifecycleEvent(
+                "TENANT.PROVISIONED.SUCCESS",
+                tenantId,
+                callerId.Value,
+                new Dictionary<string, object?>
+                {
+                    ["source"] = "self-service-reprovision",
+                }));
+
+        return Results.Ok(new { tenantId, status = TenantStatusEvaluator.StatusActive });
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private static Guid? ResolveUserId(ClaimsPrincipal principal)
@@ -825,6 +990,43 @@ public static class OrgEndpoints
 
     private static OrgResponse BuildOrgResponse(Tenant t)
         => new(t.Id, t.Name, t.Slug, t.Type, t.Plan, t.OwnerId, t.Settings, t.CreatedAt);
+
+    /// <summary>
+    /// Build a tenant-lifecycle <see cref="PlatformEvent"/> for the
+    /// control-plane store. Terminal / pre-readiness lifecycle events must
+    /// NOT go through <see cref="EmitTenantEvent"/>: the tenant's own
+    /// event store is unreachable once the tenant is deleted (and before
+    /// it is provisioned), which defeats the audit purpose. Shape mirrors
+    /// <c>AdminTenantsEndpoints.BuildAdminEvent</c>.
+    /// </summary>
+    private static PlatformEvent BuildLifecycleEvent(
+        string type,
+        Guid tenantId,
+        Guid userId,
+        IReadOnlyDictionary<string, object?>? data = null)
+    {
+        var tags = new Dictionary<string, string?>
+        {
+            ["tenantId"] = tenantId.ToString("D"),
+            ["userId"] = userId.ToString("D"),
+            ["source"] = "self-service",
+        };
+
+        var enriched = data is null
+            ? new Dictionary<string, object?>()
+            : new Dictionary<string, object?>(data);
+        enriched["actorUserId"] = userId.ToString("D");
+
+        return new PlatformEvent
+        {
+            Type = type,
+            TenantId = tenantId,
+            UserId = userId,
+            Tags = JsonSerializer.Serialize(tags),
+            Metadata = """{"workflowVersion":"1.0.0","eventSource":"system"}""",
+            Data = JsonSerializer.Serialize(enriched),
+        };
+    }
 
     private static async Task EmitTenantEvent(
         IEventRepository events,

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -1526,6 +1526,11 @@ orgs.MapGet("/{tenantId:guid}", OrgEndpoints.GetOrg)
     .AddEndpointFilter<Tamma.Api.Authorization.RequireTenantMembershipFilter>();
 orgs.MapPut("/{tenantId:guid}/settings", OrgEndpoints.UpdateOrgSettings)
     .AddEndpointFilter<Tamma.Api.Authorization.RequireTenantMembershipFilter>();
+// Tenancy residual (post-#343): self-service re-provision for a tenant's
+// own owner/admin. Membership filter kills cross-tenant access; the
+// handler enforces admin+ role and the failed/degraded-only state machine.
+orgs.MapPost("/{tenantId:guid}/reprovision", OrgEndpoints.ReprovisionOrg)
+    .AddEndpointFilter<Tamma.Api.Authorization.RequireTenantMembershipFilter>();
 orgs.MapGet("/{tenantId:guid}/members", OrgEndpoints.ListMembers)
     .AddEndpointFilter<Tamma.Api.Authorization.RequireTenantMembershipFilter>();
 orgs.MapPut("/{tenantId:guid}/members/{userId:guid}/role", OrgEndpoints.UpdateMemberRole)

--- a/apps/tamma-elsa/src/Tamma.Api/Services/PlatformTasks/PlatformTaskWorker.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/PlatformTasks/PlatformTaskWorker.cs
@@ -45,6 +45,32 @@ public sealed class PlatformTaskWorkerOptions
     /// and parks itself (Round-2 H8). Set
     /// <c>PlatformTaskWorker:RunOnStartup = true</c> in the host
     /// configuration once handlers are wired.
+    ///
+    /// <para><b>⚠ Do NOT enable in production yet</b> (tenancy-residuals
+    /// assessment, 2026-06): handlers being wired is necessary but NOT
+    /// sufficient. <c>ReserveNextAsync</c> claims the oldest
+    /// <c>pending</c> row of <b>any</b> type, and
+    /// <c>platform_queued_tasks</c> is shared with producers whose rows
+    /// must stay pending:
+    /// <list type="bullet">
+    ///   <item><description><c>RETIRE_SECRET_VERSION</c> — the 29-6
+    ///     rotation saga parks these with <c>runAfter</c> ONLY in the
+    ///     payload (no run-after column); only the
+    ///     <c>RetireScheduler</c> sweeper may drain them. This worker
+    ///     has no handler for the type, so it would park+retry the row
+    ///     each tick and dead-letter it after
+    ///     <see cref="MaxRetries"/> ticks (~25s) — destroying the
+    ///     scheduled secret retirement before its grace period.</description></item>
+    ///   <item><description>Orphan-webhook fallback rows
+    ///     (<c>InstallationRouterService</c>) and v1 Cranl
+    ///     <c>provisioning.tenant</c>[.deprovision] rows — same
+    ///     no-handler park→dead-letter fate.</description></item>
+    /// </list>
+    /// Prerequisite for flipping this on: type-aware reservation (the
+    /// worker reserves only types present in its
+    /// <c>IPlatformTaskHandlerRegistry</c>) or handlers for every
+    /// producer type. See
+    /// <c>.dev/findings/platform-task-worker-runonstartup-hazard.md</c>.
     /// </summary>
     public bool RunOnStartup { get; set; } = false;
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Orgs/OrgEndpointHandlerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Orgs/OrgEndpointHandlerTests.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -36,6 +37,7 @@ public class OrgEndpointHandlerTests
     private IInviteRepository _inviteRepo = null!;
     private IUserRepository _userRepo = null!;
     private IEventRepository _events = null!;
+    private Tamma.Data.Abstractions.IPlatformEventPublisher _publisher = null!;
     private InMemoryEmailService _emailInbox = null!;
     private DeleteConfirmationService _confirmation = null!;
     private ITenantProvisioningService _provisioning = null!;
@@ -51,6 +53,7 @@ public class OrgEndpointHandlerTests
         _inviteRepo = _scope.ServiceProvider.GetRequiredService<IInviteRepository>();
         _userRepo = _scope.ServiceProvider.GetRequiredService<IUserRepository>();
         _events = _scope.ServiceProvider.GetRequiredService<IEventRepository>();
+        _publisher = _scope.ServiceProvider.GetRequiredService<Tamma.Data.Abstractions.IPlatformEventPublisher>();
         _provisioning = _scope.ServiceProvider.GetRequiredService<ITenantProvisioningService>();
         _emailInbox = new InMemoryEmailService();
         var config = new ConfigurationBuilder()
@@ -386,7 +389,7 @@ public class OrgEndpointHandlerTests
 
         var result = await OrgEndpoints.DeleteOrg(
             tenantId, _db, _tenantRepo, _membershipRepo, _inviteRepo, _userRepo,
-            _confirmation, _events, Principal(ownerId), ctx, confirm: null);
+            _confirmation, _publisher, Principal(ownerId), ctx, confirm: null);
         (await ExecuteAndGetStatus(result)).Should().Be(StatusCodes.Status409Conflict);
     }
 
@@ -401,8 +404,45 @@ public class OrgEndpointHandlerTests
         var ctx = HttpCtxWithRole(TenantRoleHierarchy.Owner);
         var result = await OrgEndpoints.DeleteOrg(
             tenantId, _db, _tenantRepo, _membershipRepo, _inviteRepo, _userRepo,
-            _confirmation, _events, Principal(ownerId), ctx, confirm: null);
+            _confirmation, _publisher, Principal(ownerId), ctx, confirm: null);
         (await ExecuteAndGetStatus(result)).Should().Be(StatusCodes.Status202Accepted);
+
+        // Tenancy residual (post-#343): the terminal soft-delete event must
+        // land in the CONTROL-PLANE store (the tenant's own store is
+        // unreachable post-delete, defeating the audit purpose).
+        var cpEvents = await _db.PlatformEvents.AsNoTracking()
+            .Where(e => e.TenantId == tenantId && e.Type == "TENANT.DELETED.SUCCESS")
+            .ToListAsync();
+        cpEvents.Should().HaveCount(1);
+        cpEvents[0].UserId.Should().Be(ownerId);
+        cpEvents[0].Data.Should().Contain("soft-delete");
+    }
+
+    [Test]
+    public async Task DeleteOrg_Phase2_EmitsPurgedEventToControlPlaneStore()
+    {
+        var (tenantId, ownerId, _) = await SeedTenantWithOwnerAndMember();
+        var second = await _tenantRepo.CreateAsync(new Tenant { Name = "Other", Slug = "other-co2", Type = "org" });
+        await _membershipRepo.AddAsync(second.Id, ownerId, "owner");
+
+        var ctx = HttpCtxWithRole(TenantRoleHierarchy.Owner);
+
+        // Phase 2: hard-delete with a VALID token. (The handler 404s
+        // already-soft-deleted rows, so phase 2 runs against the live row.)
+        var token = _confirmation.Generate(tenantId, ownerId);
+        var phase2 = await OrgEndpoints.DeleteOrg(
+            tenantId, _db, _tenantRepo, _membershipRepo, _inviteRepo, _userRepo,
+            _confirmation, _publisher, Principal(ownerId), ctx, confirm: token.Token);
+        (await ExecuteAndGetStatus(phase2)).Should().Be(StatusCodes.Status204NoContent);
+
+        // Terminal purge event survives in the control-plane store even
+        // though the tenant (and its event store) is gone.
+        var purged = await _db.PlatformEvents.AsNoTracking()
+            .Where(e => e.TenantId == tenantId && e.Type == "TENANT.PURGED.SUCCESS")
+            .ToListAsync();
+        purged.Should().HaveCount(1);
+        purged[0].UserId.Should().Be(ownerId);
+        purged[0].Data.Should().Contain("hard-delete");
     }
 
     [Test]
@@ -415,7 +455,7 @@ public class OrgEndpointHandlerTests
         var ctx = HttpCtxWithRole(TenantRoleHierarchy.Owner);
         var result = await OrgEndpoints.DeleteOrg(
             tenantId, _db, _tenantRepo, _membershipRepo, _inviteRepo, _userRepo,
-            _confirmation, _events, Principal(ownerId), ctx, confirm: "junk.deadbeef");
+            _confirmation, _publisher, Principal(ownerId), ctx, confirm: "junk.deadbeef");
         (await ExecuteAndGetStatus(result)).Should().Be(StatusCodes.Status400BadRequest);
     }
 

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Orgs/OrgReprovisionEndpointTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Orgs/OrgReprovisionEndpointTests.cs
@@ -1,0 +1,270 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Tamma.Api.Authorization;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Services.TenantStatus;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Orgs;
+
+/// <summary>
+/// Direct-handler tests for the self-service re-provision endpoint
+/// (<c>POST /api/v1/orgs/{tenantId}/reprovision</c> →
+/// <see cref="OrgEndpoints.ReprovisionOrg"/>). Mirrors the
+/// <see cref="OrgEndpointHandlerTests"/> style: handlers are invoked
+/// directly so the in-handler invariants (role gate, status state
+/// machine, CP-store audit events) are testable without minting JWTs.
+/// Cross-tenant protection is owned by
+/// <see cref="RequireTenantMembershipFilter"/> on the route — pinned by
+/// the existing filter test suite — so these tests focus on the handler
+/// body.
+/// </summary>
+[TestFixture]
+public class OrgReprovisionEndpointTests
+{
+    private IServiceScope _scope = null!;
+#pragma warning disable NUnit1032 // Disposed via _scope
+    private ControlPlaneDbContext _db = null!;
+#pragma warning restore NUnit1032
+    private ITenantRepository _tenantRepo = null!;
+    private ITenantMembershipRepository _membershipRepo = null!;
+    private IUserRepository _userRepo = null!;
+    private ITenantProvisioningService _provisioning = null!;
+    private IPlatformEventPublisher _publisher = null!;
+    private ITenantStatusCache _statusCache = null!;
+    private ITenantConnectionResolver _resolver = null!;
+    private ITenantStatusInvalidationBus _invalidationBus = null!;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        await ApiTestFixture.ResetDatabaseAsync();
+        _scope = ApiTestFixture.Factory.Services.CreateScope();
+        _db = _scope.ServiceProvider.GetRequiredService<ControlPlaneDbContext>();
+        _tenantRepo = _scope.ServiceProvider.GetRequiredService<ITenantRepository>();
+        _membershipRepo = _scope.ServiceProvider.GetRequiredService<ITenantMembershipRepository>();
+        _userRepo = _scope.ServiceProvider.GetRequiredService<IUserRepository>();
+        _provisioning = _scope.ServiceProvider.GetRequiredService<ITenantProvisioningService>();
+        _publisher = _scope.ServiceProvider.GetRequiredService<IPlatformEventPublisher>();
+        _statusCache = _scope.ServiceProvider.GetRequiredService<ITenantStatusCache>();
+        _resolver = _scope.ServiceProvider.GetRequiredService<ITenantConnectionResolver>();
+        _invalidationBus = _scope.ServiceProvider.GetRequiredService<ITenantStatusInvalidationBus>();
+    }
+
+    [TearDown]
+    public void TearDown() => _scope?.Dispose();
+
+    // ── Authorization ───────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Reprovision_Returns403_WhenCallerIsMemberRole()
+    {
+        var (tenantId, _, memberId) = await SeedUnprovisionedTenant(status: "failed");
+
+        var result = await Invoke(tenantId, memberId, role: TenantRoleHierarchy.Member);
+        (await ExecuteAndGetStatus(result)).Should().Be(StatusCodes.Status403Forbidden);
+    }
+
+    [Test]
+    public async Task Reprovision_Returns404_WhenTenantSoftDeleted()
+    {
+        var (tenantId, ownerId, _) = await SeedUnprovisionedTenant(status: "failed");
+        await _tenantRepo.SoftDeleteAsync(tenantId);
+        _db.ChangeTracker.Clear();
+
+        var result = await Invoke(tenantId, ownerId, role: TenantRoleHierarchy.Owner);
+        (await ExecuteAndGetStatus(result)).Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    // ── State machine ───────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Reprovision_Returns409_WhenProvisioningAlreadyInFlight()
+    {
+        var (tenantId, ownerId, _) = await SeedUnprovisionedTenant(status: "provisioning");
+
+        var result = await Invoke(tenantId, ownerId, role: TenantRoleHierarchy.Owner);
+        (await ExecuteAndGetStatus(result)).Should().Be(StatusCodes.Status409Conflict);
+
+        // Still in flight — the handler must not have touched the status.
+        (await ReadStatus(tenantId)).Should().Be("provisioning");
+    }
+
+    [Test]
+    public async Task Reprovision_Returns409_WhenAlreadyProvisioned()
+    {
+        // Seed via the real pipeline → Status 'active' + stored envelope.
+        var (tenantId, ownerId, _) = await SeedProvisionedTenant();
+
+        var result = await Invoke(tenantId, ownerId, role: TenantRoleHierarchy.Owner);
+        (await ExecuteAndGetStatus(result)).Should().Be(StatusCodes.Status409Conflict);
+    }
+
+    [Test]
+    public async Task Reprovision_Returns409_WhenTenantSuspended()
+    {
+        // ck_tenants_connection_string_present requires an envelope for
+        // 'suspended', so provision first, then flip the status.
+        var (tenantId, ownerId, _) = await SeedProvisionedTenant();
+        var tracked = await _db.Tenants.IgnoreQueryFilters().FirstAsync(t => t.Id == tenantId);
+        _db.Entry(tracked).Property("Status").CurrentValue = "suspended";
+        await _db.SaveChangesAsync();
+        _db.ChangeTracker.Clear();
+
+        var result = await Invoke(tenantId, ownerId, role: TenantRoleHierarchy.Owner);
+        (await ExecuteAndGetStatus(result)).Should().Be(StatusCodes.Status409Conflict);
+        (await ReadStatus(tenantId)).Should().Be("suspended");
+    }
+
+    // ── Happy path ──────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Reprovision_Succeeds_FromFailedState_AsTenantAdmin()
+    {
+        var (tenantId, _, _) = await SeedUnprovisionedTenant(status: "failed");
+        var admin = await CreateUser($"admin-{Guid.NewGuid():N}@example.com");
+        await _membershipRepo.AddAsync(tenantId, admin.Id, TenantRoleHierarchy.Admin);
+
+        var result = await Invoke(tenantId, admin.Id, role: TenantRoleHierarchy.Admin);
+        (await ExecuteAndGetStatus(result)).Should().Be(StatusCodes.Status200OK);
+
+        (await ReadStatus(tenantId)).Should().Be("active");
+        (await HasEnvelope(tenantId)).Should().BeTrue(
+            "the real provisioning pipeline must have minted + persisted the encrypted connection string");
+
+        // Audit trail lands in the CONTROL-PLANE store.
+        var types = await _db.PlatformEvents
+            .AsNoTracking()
+            .Where(e => e.TenantId == tenantId)
+            .Select(e => e.Type)
+            .ToListAsync();
+        types.Should().Contain("TENANT.PROVISIONING_REQUESTED");
+        types.Should().Contain("TENANT.PROVISIONED.SUCCESS");
+    }
+
+    [Test]
+    public async Task Reprovision_Succeeds_FromDegradedCreateOrgLeftover()
+    {
+        // CreateOrg leftover shape: row exists, Status never advanced past
+        // its default (NULL → treated as legacy-active), NO envelope.
+        var (tenantId, ownerId, _) = await SeedUnprovisionedTenant(status: null);
+
+        var result = await Invoke(tenantId, ownerId, role: TenantRoleHierarchy.Owner);
+        (await ExecuteAndGetStatus(result)).Should().Be(StatusCodes.Status200OK);
+
+        (await ReadStatus(tenantId)).Should().Be("active");
+        (await HasEnvelope(tenantId)).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Reprovision_IsIdempotent_SecondCallReturns409()
+    {
+        var (tenantId, ownerId, _) = await SeedUnprovisionedTenant(status: "failed");
+
+        var first = await Invoke(tenantId, ownerId, role: TenantRoleHierarchy.Owner);
+        (await ExecuteAndGetStatus(first)).Should().Be(StatusCodes.Status200OK);
+
+        _db.ChangeTracker.Clear();
+        var second = await Invoke(tenantId, ownerId, role: TenantRoleHierarchy.Owner);
+        (await ExecuteAndGetStatus(second)).Should().Be(StatusCodes.Status409Conflict);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private Task<IResult> Invoke(Guid tenantId, Guid callerId, string role)
+    {
+        var ctx = new DefaultHttpContext
+        {
+            RequestServices = _scope.ServiceProvider,
+        };
+        ctx.Items[RequireTenantMembershipFilter.TenantRoleItemKey] = role;
+
+        return OrgEndpoints.ReprovisionOrg(
+            tenantId, _db, _provisioning, _publisher, _statusCache,
+            _resolver, _invalidationBus, Principal(callerId), ctx);
+    }
+
+    private async Task<User> CreateUser(string email)
+        => await _userRepo.CreateAsync(new User { Email = email, DisplayName = "Test" });
+
+    /// <summary>
+    /// Tenant row + owner/member memberships WITHOUT running the
+    /// provisioning pipeline (no role/schema/envelope), then pins the
+    /// Status shadow column to <paramref name="status"/>.
+    /// </summary>
+    private async Task<(Guid TenantId, Guid OwnerId, Guid MemberId)> SeedUnprovisionedTenant(string? status)
+    {
+        var owner = await CreateUser($"owner-{Guid.NewGuid():N}@example.com");
+        var member = await CreateUser($"member-{Guid.NewGuid():N}@example.com");
+        var tenant = await _tenantRepo.CreateAsync(new Tenant
+        {
+            Name = "Reprov Org",
+            Slug = $"rp-{Guid.NewGuid():N}".Substring(0, 12),
+            Type = "org",
+            OwnerId = owner.Id,
+        });
+        await _membershipRepo.AddAsync(tenant.Id, owner.Id, TenantRoleHierarchy.Owner);
+        await _membershipRepo.AddAsync(tenant.Id, member.Id, TenantRoleHierarchy.Member);
+
+        if (status is not null)
+        {
+            var tracked = await _db.Tenants.IgnoreQueryFilters()
+                .FirstAsync(t => t.Id == tenant.Id);
+            _db.Entry(tracked).Property("Status").CurrentValue = status;
+            await _db.SaveChangesAsync();
+        }
+
+        _db.ChangeTracker.Clear();
+        return (tenant.Id, owner.Id, member.Id);
+    }
+
+    private async Task<(Guid TenantId, Guid OwnerId, Guid MemberId)> SeedProvisionedTenant()
+    {
+        var seeded = await SeedUnprovisionedTenant(status: null);
+        await ApiTestFixture.ProvisionTenantAsync(seeded.TenantId);
+        _db.ChangeTracker.Clear();
+        return seeded;
+    }
+
+    private async Task<string?> ReadStatus(Guid tenantId)
+        => await _db.Tenants.IgnoreQueryFilters()
+            .Where(t => t.Id == tenantId)
+            .Select(t => EF.Property<string?>(t, "Status"))
+            .FirstOrDefaultAsync();
+
+    private async Task<bool> HasEnvelope(Guid tenantId)
+    {
+        var envelope = await _db.Tenants.IgnoreQueryFilters()
+            .Where(t => t.Id == tenantId)
+            .Select(t => EF.Property<byte[]?>(t, "EncryptedConnectionString"))
+            .FirstOrDefaultAsync();
+        return envelope is { Length: > 0 };
+    }
+
+    private static ClaimsPrincipal Principal(Guid userId)
+    {
+        var identity = new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, userId.ToString()),
+        }, authenticationType: "Test");
+        return new ClaimsPrincipal(identity);
+    }
+
+    private async Task<int> ExecuteAndGetStatus(IResult result)
+    {
+        var ctx = new DefaultHttpContext
+        {
+            RequestServices = ApiTestFixture.Factory.Services,
+        };
+        ctx.Response.Body = new MemoryStream();
+        await result.ExecuteAsync(ctx);
+        return ctx.Response.StatusCode;
+    }
+}


### PR DESCRIPTION
## Summary
Three small tenancy residuals left over from the unified schema-per-tenant merge (#343):

1. **Self-service org re-provision** (`85922a30`): `POST /api/v1/orgs/{tenantId}/reprovision` — tenant owner/admin can re-provision their OWN tenant from failed/degraded states. Cross-tenant blocked by membership filter, 409 on in-flight (claims the run by flipping Status→provisioning), reuses `ITenantProvisioningService.ProvisionAsync`. 8 new endpoint tests.
2. **Terminal lifecycle events → control-plane store** (`be746728`): `TENANT.DELETED.SUCCESS` / `TENANT.PURGED.SUCCESS` now publish via `IPlatformEventPublisher` into CP `platform_events` AFTER the destructive commit — previously they were written to the tenant's own (post-delete unreachable) store. Non-terminal events unchanged.
3. **PlatformTaskWorker:RunOnStartup stays OFF — hazard documented** (`ca77a8c1`): enabling it would dead-letter the rotation saga's scheduled `RETIRE_SECRET_VERSION` rows within ~25s (`ReserveNextAsync` claims oldest-pending of ANY type; worker only handles `tenant.move`/`provisioning.tenant.v2`; MaxRetries=5 at 5s ticks). Analysis + enable-prerequisites in `.dev/findings/platform-task-worker-runonstartup-hazard.md`.

## Verification
Full C# suite (run twice, both green): **Failed: 0, Passed: 4,584, Skipped: 9** across all 10 test projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)