### PR TITLE
docs(plans): Epic 30, Epic 6 refresh, content sanitization refresh, missing-config notifications

### DIFF
--- a/docs/superpowers/plans/2026-06-11-content-sanitization-security-hooks.md
+++ b/docs/superpowers/plans/2026-06-11-content-sanitization-security-hooks.md
@@ -1,0 +1,237 @@
+# Content Sanitization & Security Hooks — Refreshed Plan (2026-06-11)
+
+> Refresh of the prior plan (`~/.claude/plans/hashed-purring-teapot.md`, file no longer
+> exists). Original design intent preserved: defense-in-depth sanitization across 5
+> integration paths, generic decorator over `IAgentProvider`, core modules in
+> `packages/shared/src/security/` (no new package), pre/post hooks on MCP
+> `invokeTool()`, and a tool-execution loop for the `IAIProvider` path with
+> sanitization at each step.
+>
+> **Headline finding**: roughly half of the original plan already shipped under
+> Epic 9 (stories 9-7 and 9-11, commits `bc0339a3..d036c608` and `b0737f51`).
+> The primitives exist; what remains is (a) the `IAIProvider` tool loop, and
+> (b) wiring the shipped-but-unconsumed primitives into the real composition
+> roots (`execute-agent`, MCP client construction, orchestrator direct-agent
+> path, action gating, secureFetch).
+
+## Current-State Verification (checked against main @ 98cfb1c2, 2026-06-10)
+
+| Original assumption | Status | Evidence |
+|---|---|---|
+| `packages/shared/src/security/` does not exist; plan creates it | **STALE — already exists** | `packages/shared/src/security/{content-sanitizer,url-validator,action-gating,secure-fetch}.ts` + colocated tests + `index.ts` barrel. `IContentSanitizer` + `ContentSanitizer` exported from `@tamma/shared`. |
+| `SecureAgentProvider` decorator to be created | **STALE — already exists** | `packages/providers/src/secure-agent-provider.ts` (+ test). Classic decorator over `IAgentProvider`; sanitizes `config.prompt` (input), `taskResult.output` / `taskResult.error` (output). Wired via `RoleBasedAgentResolver` optional `sanitizer` option (`packages/providers/src/role-based-agent-resolver.ts:232`). |
+| MCP client gets a `ToolHookRegistry` with pre/post hooks on `invokeTool()` | **STALE (renamed) — concept shipped as `ToolInterceptorChain`** | `packages/mcp-client/src/interceptors.ts`: `PreInterceptor`, `PostInterceptor`, `ToolInterceptorChain`, `createSanitizationInterceptor()`, `createUrlValidationInterceptor()`. Wired inside `MCPClient.invokeTool()` (`client.ts:341-396`, pre runs after schema validation/before execution; post runs after result construction/before events) plus `setInterceptorChain()` (`client.ts:672`). **BUT: zero non-test consumers — no production composition root ever constructs a chain or even an `MCPClient`.** |
+| New `executeToolLoop()` for the `IAIProvider` path | **HELD — still missing** | No `executeToolLoop` anywhere. `MessageRequest.tools` (`packages/providers/src/types.ts:233`) and `MessageResponse.tool_calls` exist as types, but no code outside `packages/providers/src` calls `sendMessage` at all. The LLM-API tool path is genuinely unbuilt. |
+| CLI integration path needed | **PARTIALLY STALE** | `tamma start` (`start.tsx:108`), `tamma server` (`server.ts:147`), `process-issue.ts:175` all build `ContentSanitizer` when `config.security.sanitizeContent !== false` and pass it to `RoleBasedAgentResolver`. **Gap**: `tamma execute-agent` (`packages/cli/src/commands/execute-agent.ts:384-410`) builds the agent via `AgentProviderFactory.create()` directly and calls `executeTask()` with **no** `SecureAgentProvider` wrap and no sanitizer — this is the worker entrypoint invoked by the C#/Elsa side, i.e. the highest-traffic unsanitized path. |
+| Orchestrator integration path needed | **HELD (gap confirmed)** | `packages/orchestrator/src/engine.ts` has zero security imports. It accepts either `agentResolver` (sanitized transitively when the resolver carries a sanitizer) or a raw `agent?: IAgentProvider` (`engine.ts:38`) which **bypasses sanitization entirely** (`executeTask` call sites at `engine.ts:572`, `engine.ts:804`). No security events are emitted to the event store. |
+| Two provider hierarchies: `IAIProvider` and `IAgentProvider`/`ICLIAgentProvider` | **HELD** | `IAIProvider` in `packages/providers/src/types.ts`; `IAgentProvider` in `packages/providers/src/agent-types.ts` (doc comment: "New code should prefer ICLIAgentProvider from './types.js'"). CLI agent providers live in `packages/providers/src/` (`claude-agent-provider.ts`, `opencode-provider.ts`, etc.) — there is no separate cli-agents package. |
+| Action gating / secure fetch usable by hooks | **SHIPPED BUT UNWIRED** | `evaluateAction` + `DEFAULT_BLOCKED_COMMANDS` (`action-gating.ts`) and `secureFetch` (`secure-fetch.ts`) have **zero consumers** outside their own tests. Dead exports awaiting integration. |
+| Tenancy merge (wave-b, PR #343) moved things the plan touches | **NO** | Wave-b was C#-side (`apps/tamma-elsa`) schema-per-tenant work. None of the TS files above moved or changed shape. However: `tamma api` now spawns the **C# ASP.NET Core binary** (`packages/cli/src/commands/api.ts`), and there is **no `packages/api`** anymore. The SaaS request path (incl. `LlmCallWorkflow` prompting) is C# and is **out of scope** for the TS `shared/src/security` modules — see Risks. |
+
+Also present (shipped under 9-11, complements this plan): `packages/mcp-client/src/security/{rate-limiter,sandbox,validator}.ts`, and `packages/providers/src/sanitize-error.ts` (error redaction for diagnostics).
+
+## Design Intent (unchanged)
+
+1. **Generic decorator, no per-provider changes** — `SecureAgentProvider` wraps ANY
+   `IAgentProvider`. (Done; this plan extends its *coverage*, not its shape.)
+2. **Core primitives live in `packages/shared/src/security/`** — no new package. (Done.)
+3. **Pre/post hooks on MCP tool invocation** — adopt the shipped
+   `ToolInterceptorChain` name; the planned `ToolHookRegistry` is dropped.
+4. **`executeToolLoop()` for the `IAIProvider` path** — sanitize at every step:
+   gate each tool call, sanitize each tool result before it re-enters the
+   conversation, bound iterations.
+5. **Fail-open warnings for heuristics, fail-closed for gates** — sanitizer never
+   throws (warnings only); action gating and URL validation block.
+
+## Phases — the 5 integration paths
+
+### Phase 1 — CLI agents path: close the `execute-agent` gap + action gating
+
+The resolver-based entrypoints (`start`, `server`, `process-issue`) are covered.
+`execute-agent` is not, and `allowedTools` are passed through unexamined.
+
+- **Files**
+  - `packages/cli/src/commands/execute-agent.ts` — after `factory.create(chainEntry)`
+    (~line 397), wrap: `const agent = new SecureAgentProvider(rawAgent, new ContentSanitizer(), logger)`
+    honoring the same `config.security.sanitizeContent !== false` toggle used by the
+    other commands (read from the repo `.tamma/config.json` already loaded by the command;
+    default ON).
+  - `packages/shared/src/security/action-gating.ts` — extend `evaluateAction` (if
+    needed) so it can evaluate an `allowedTools` entry of the form
+    `Bash(<command>)` used by Claude Code allowlists; no breaking change to the
+    existing signature.
+  - `packages/providers/src/role-based-agent-resolver.ts` — optional
+    `actionGate?: ActionGateOptions`; when set, the resolver filters/refuses
+    `allowedTools` entries that fail `evaluateAction` before constructing the
+    `AgentTaskConfig` (fail-closed: drop entry + `logger.warn`).
+- **Tests** (Vitest, colocated, ESM `.js` imports, strict TS)
+  - `execute-agent.test.ts`: prompt with injection markers reaches the (mock) provider
+    sanitized; `sanitizeContent: false` disables; output/error fields sanitized in the
+    result file.
+  - `role-based-agent-resolver.test.ts`: blocked `allowedTools` entries dropped with warning.
+
+### Phase 2 — LLM API providers (`IAIProvider`): build `executeToolLoop()`
+
+The only fully-unbuilt piece of the original plan.
+
+- **Files**
+  - `packages/providers/src/execute-tool-loop.ts` (+ `.test.ts`) — new:
+    ```ts
+    export interface ToolExecutor {
+      name: string;
+      description: string;
+      input_schema: Record<string, unknown>;
+      execute(args: Record<string, unknown>): Promise<string>;
+    }
+    export interface ToolLoopOptions {
+      maxIterations?: number;            // default 10
+      sanitizer?: IContentSanitizer;     // sanitize tool results + final output
+      actionGate?: ActionGateOptions;    // evaluateAction() on each tool call (fail-closed)
+      validateUrl?: boolean;             // gate URL-bearing args via validateUrl()
+      logger?: ILogger;
+    }
+    export async function executeToolLoop(
+      provider: IAIProvider,
+      request: MessageRequest,
+      tools: ToolExecutor[],
+      options?: ToolLoopOptions,
+    ): Promise<MessageResponse>;
+    ```
+    Loop: `sendMessage` → if `finishReason === 'tool_calls'`, for each call:
+    (1) `evaluateAction` gate — on block, return a refusal tool-result string,
+    do NOT execute; (2) execute; (3) `sanitizer.sanitizeOutput()` the tool result
+    before appending it to `messages`; repeat until `stop` or `maxIterations`
+    (then throw `createProviderError('TOOL_LOOP_LIMIT', …, false, 'medium')`).
+    Sanitize the final `content` once more on exit. Never mutate the caller's
+    `request` (build new message arrays — state-management rule).
+  - `packages/providers/src/index.ts` — export `executeToolLoop`, `ToolExecutor`,
+    `ToolLoopOptions`.
+  - Optional follow-up (only if a consumer materializes): a built-in `fetch` tool
+    executor backed by `secureFetch` from `@tamma/shared` — first real consumer
+    of `secure-fetch.ts`.
+- **Tests**: mock `IAIProvider` scripted to return `tool_calls` then `stop`;
+  assert gating blocks `rm -rf` style calls without executing; assert tool results
+  are sanitized (zero-width chars stripped, injection warnings logged); assert
+  iteration cap throws; assert no mutation of the input request.
+
+### Phase 3 — MCP client: wire the existing `ToolInterceptorChain`
+
+Mechanism shipped (9-11-T4) but no production code constructs a chain — or an
+`MCPClient`. Make secure-by-default composition trivial and use it where the
+client is composable.
+
+- **Files**
+  - `packages/mcp-client/src/interceptors.ts` — add
+    `createDefaultSecurityChain(sanitizer: IContentSanitizer, logger?: ILogger): ToolInterceptorChain`
+    combining `createSanitizationInterceptor` + `createUrlValidationInterceptor`
+    (with `validateUrl` from `@tamma/shared`); export from `index.ts`.
+  - `packages/intelligence-server/src/server.ts` / `types.ts` — when the caller
+    supplies `bundle.mcpClient`, call
+    `mcpClient.setInterceptorChain(createDefaultSecurityChain(...))` unless the
+    bundle explicitly opts out (`bundle.mcpInterceptors: false | ToolInterceptorChain`).
+    `McpManagementService.invokeTool` (`McpManagementService.ts:174`) then gets
+    pre/post hooks for free.
+  - `packages/intelligence/src/context/sources/mcp-source.ts` — no change
+    (`IMCPClientLike` consumers inherit hooks from the concrete client).
+- **Tests**: `interceptors.test.ts` for the default-chain factory;
+  `intelligence-server` route test proving an injected fake client receives a chain
+  and that `invokeTool` results pass through post-interceptors.
+
+### Phase 4 — Orchestrator: no unsanitized agent path + audit events
+
+- **Files**
+  - `packages/orchestrator/src/engine.ts` — add optional
+    `sanitizer?: IContentSanitizer` to `EngineContext`. In the constructor, if a
+    raw `agent` is injected AND a sanitizer is present, wrap it:
+    `this.agent = new SecureAgentProvider(agent, sanitizer, logger)`. The
+    resolver path stays as-is (already wraps internally). This removes the
+    bypass at `engine.ts:572` / `engine.ts:804` without breaking existing
+    constructor signatures.
+  - Security audit events (DCB): when sanitization produces warnings, emit
+    `SECURITY.INJECTION_DETECTED` / `SECURITY.CONTENT_SANITIZED` via the engine's
+    event store with tags `{ issueId, provider, phase }`. Implementation: a thin
+    `IContentSanitizer` decorator in `packages/orchestrator/src/` (e.g.
+    `auditing-sanitizer.ts`) that forwards to the inner sanitizer and appends
+    events on non-empty warnings — keeps `@tamma/shared` free of event-store
+    coupling.
+  - `packages/cli/src/commands/{start.tsx,server.ts,process-issue.ts}` — pass the
+    already-constructed sanitizer into `EngineContext` too (one-line each).
+- **Tests**: `engine.test.ts` — raw-agent injection + sanitizer ⇒ prompt reaching
+  the mock agent is sanitized; warnings ⇒ events appended with correct type/tags;
+  no sanitizer ⇒ behavior unchanged.
+
+### Phase 5 — CLI/config surface, docs, end-to-end
+
+- **Files**
+  - `packages/shared/src/types/security-config.ts` — extend alongside the existing
+    `sanitizeContent?: boolean`:
+    `actionGating?: boolean` (default true once Phase 1 lands),
+    `extraBlockedCommands?: string[]`, `urlValidation?: boolean`.
+  - `packages/shared/src/types/repo-config.ts` + `packages/shared/src/config/resolve-config.ts`
+    (`resolve-config.ts:181` area) — plumb the new fields from `.tamma/config.json`.
+  - `packages/cli` commands — thread the resolved security config into resolver
+    options / engine context (Phases 1 & 4 consume it).
+  - Docs: update `wiki`/README security section listing the five paths and the
+    config toggles. No new `.md` beyond existing doc locations.
+- **Tests**: `resolve-config.test.ts` precedence (repo config over defaults);
+  one CLI-level test per command asserting the toggles reach the resolver/engine.
+
+## Acceptance Criteria
+
+1. Every `executeTask()` call site in the monorepo goes through
+   `SecureAgentProvider` when `security.sanitizeContent !== false` — including
+   `tamma execute-agent` (grep gate: no direct factory-created agent executes
+   unwrapped outside tests).
+2. `executeToolLoop()` exists, is exported from `@tamma/providers`, blocks gated
+   tool calls without executing them, sanitizes every tool result before it
+   re-enters the conversation, and enforces an iteration cap.
+3. `ToolInterceptorChain` is constructible via a one-call default factory and is
+   attached wherever an `MCPClient` is composed (currently the
+   intelligence-server bundle path); `createSanitizationInterceptor` /
+   `createUrlValidationInterceptor` gain at least one production consumer.
+4. The orchestrator's raw-`agent` injection path can no longer bypass
+   sanitization when a sanitizer is configured, and sanitization warnings are
+   visible in the event stream as `SECURITY.*` events.
+5. `evaluateAction` and `secureFetch` each have ≥1 production consumer (no more
+   dead exports).
+6. All new code: strict TS (`exactOptionalPropertyTypes` conditional assignment),
+   ESM `.js` import suffixes, colocated `*.test.ts` Vitest suites; no mutation of
+   caller-owned objects; no sanitizer ever throws on content (warnings only).
+7. `pnpm build && pnpm test` green across the workspace.
+
+## Risks
+
+- **C#/SaaS path is out of scope**: `tamma api` spawns the ASP.NET Core binary;
+  `LlmCallWorkflow` prompt assembly happens in `apps/tamma-elsa`. This plan
+  secures the TS engine paths only. A mirrored C# sanitizer is a separate epic —
+  call this out explicitly so "sanitization is on" is not over-claimed for SaaS.
+- **Heuristic injection detection is warn-only by design** — do not convert to
+  blocking without a false-positive review; code diffs legitimately contain
+  strings like "ignore previous instructions" in test fixtures.
+- **Action gating false positives** in `allowedTools` filtering could break agent
+  runs mid-workflow; default-on should land only after running the gate in
+  log-only mode against existing fixtures (Phase 1 test corpus).
+- **Double sanitization**: resolver-wrapped providers + engine-level wrapping
+  (Phase 4) could sanitize twice. Sanitization is idempotent for the
+  strip/normalize steps, but warnings would be double-logged/double-evented —
+  engine must skip wrapping when the agent came from a resolver (track via the
+  existing `agentResolver` vs `agent` branch, which already distinguishes them).
+- **Interceptor chain ordering**: sanitization before URL validation (sanitizer
+  may unmask zero-width-obfuscated URLs); encode the order in
+  `createDefaultSecurityChain` and test it.
+- **`execute-agent` runs headless under Elsa** — a thrown gate error must still
+  produce a well-formed result file (the command already guards execution; keep
+  failures inside `taskResult.error`).
+
+## Delta from previous plan
+
+| # | Previous-plan assumption | What changed | Adaptation |
+|---|---|---|---|
+| 1 | Create core modules in `packages/shared/src/security/` | Already created by Epic 9 story 9-7 (commits `bc0339a3`, `b144d7ad`, `4bd837a0`, `507acc7b`): `ContentSanitizer`/`IContentSanitizer`, `validateUrl`/`isPrivateHost`, `evaluateAction`/`DEFAULT_BLOCKED_COMMANDS`, `secureFetch` | Phase dropped. Plan now *consumes* these; only minor additive extensions (Phase 1 gating helper, Phase 5 config types). |
+| 2 | Create `SecureAgentProvider` decorator | Already shipped (`d036c608`) and wired into `RoleBasedAgentResolver` + 3 CLI commands | Phase reframed as coverage-closing: wrap the missed `execute-agent` path (Phase 1) and the engine raw-`agent` path (Phase 4). |
+| 3 | MCP client gets a **`ToolHookRegistry`** with pre/post hooks on `invokeTool()` | Shipped under a different name in 9-11-T4 (`b0737f51`): `ToolInterceptorChain` already integrated inside `MCPClient.invokeTool()`; but nothing in production constructs a chain (or an `MCPClient`) | Drop the `ToolHookRegistry` name; adopt `ToolInterceptorChain`. Phase 3 = default-chain factory + wiring at the only current composition seam (intelligence-server bundle). |
+| 4 | New `executeToolLoop()` for `IAIProvider` with per-step sanitization | Still absent — assumption held; additionally verified there are **zero** `sendMessage` consumers outside `packages/providers`, so the loop currently has no caller | Phase 2 builds it as an exported utility (with `ToolExecutor` seam) rather than threading it into a nonexistent call site; first consumers arrive with future IAIProvider-based features. |
+| 5 | 5 integration paths incl. "orchestrator" and "CLI" as greenfield | CLI resolver paths already sanitized; orchestrator confirmed untouched; **`tamma api` is now a C# binary** (no `packages/api` exists) so the SaaS/API path moved out of TS reach | Orchestrator phase narrowed to the raw-agent bypass + DCB `SECURITY.*` audit events; SaaS/C# explicitly declared out of scope (risk #1). |
+| 6 | (implicit) sanitization config surface to be invented | `security.sanitizeContent` toggle already exists in `security-config.ts` / `repo-config.ts` / `resolve-config.ts:181` | Phase 5 extends the existing surface (`actionGating`, `extraBlockedCommands`, `urlValidation`) instead of creating one. |
+| 7 | (implicit) gating/secure-fetch wired by the same work that created them | They shipped consumer-less: `evaluateAction` and `secureFetch` have zero non-test references | New explicit acceptance criterion (#5): each gains a production consumer (resolver/loop gating; optional `fetch` tool executor). |
+| 8 | Recent tenancy merge might have moved touched files | Verified: wave-b (PR #343) was C#-side only; all TS files in scope unmoved | No adaptation needed; baseline is main @ `98cfb1c2`. |

--- a/docs/superpowers/plans/2026-06-11-epic-30-pluggable-provisioning.md
+++ b/docs/superpowers/plans/2026-06-11-epic-30-pluggable-provisioning.md
@@ -1,0 +1,386 @@
+# Epic 30 — Pluggable Provisioning: Finish the Seam, Tighten the Model
+
+> **For agentic workers:** This is an ARCHITECTURE + PHASE-DECOMPOSITION plan in the style of
+> `2026-06-09-unified-schema-per-tenant.md`. Each **Phase** below becomes its own detailed
+> `superpowers:writing-plans` task-plan at execution time, implemented via
+> `superpowers:subagent-driven-development`. Tasks inside phases use checkbox (`- [ ]`) syntax.
+> The project is test-first: every task lists the tests to write BEFORE implementation.
+
+**Status**: PLANNED (2026-06-11). Not started.
+
+**Goal:** Finish Epic 30's pluggable-provisioning seam on top of the now-merged unified
+schema-per-tenant model (PR #343, 98cfb1c2): retire the [Obsolete] V1 `ITenantProvisioner` surface
+("Wave C"), reconcile the V2 provider contract with the unified model (providers mint
+`tenant_databases` pool rows — they do NOT own tenant DB routing), tighten the two transitional
+CHECK constraints (parent-plan deviations 6–7), make Story 28-1's `MigrateTenantElsaAsync` real (or
+formally re-scope it with a recorded decision), and run the Story 28-13 OpenBao trigger review.
+
+**Architecture:** One provisioning contract — `ITenantInfrastructureProvider` (V2, already in code)
+— with backends registered in `TenantProviderRegistry` (`null`, `cranl` today; `hetzner`,
+`cloudflare`, `byo` reserved). Per locked decision 3 / deviation 22 of the parent plan, a backend's
+job is to **mint hosting infrastructure and register it as a `tenant_databases` pool row**;
+placement, schema lifecycle, and per-tenant connection strings stay owned by the unified model
+(`TenantPlacementService` + `TenantMoveService` + AES-GCM Search-Path envelopes). `ProviderKey` on
+the tenant is a backend LABEL only. The V2 endpoint directory narrows to engine-URL routing for
+dedicated-compute tenants; database routing is always the unified
+`EncryptedConnectionString` path.
+
+**Tech Stack:** .NET 9 / EF Core 9 / Npgsql / Testcontainers; platform task queue
+(`PlatformTaskWorker` + `IPlatformTaskHandler`); existing AES-GCM `TenantSecretProtector`.
+
+**Parent docs:**
+- `docs/superpowers/plans/2026-06-09-unified-schema-per-tenant.md` (deviations 6–7, 22; decision 3)
+- `docs/stories/epic-30/README.md` (story map — written 2026-04-20, partially stale, see findings)
+- `docs/stories/epic-28/story-28-13/28-13-openbao-kms-backend.md` (trigger checklist)
+
+---
+
+## 1. Current-state findings (verified 2026-06-10 on main @ 98cfb1c2 — do not re-derive)
+
+### 1.1 Two provisioning surfaces coexist; production still rides V1
+
+- **V1 (Obsolete, "Removed in Wave C")** —
+  `apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/`:
+  - `ITenantProvisioner.cs:27` — `[Obsolete("Use ITenantInfrastructureProvider (V2) instead. Removed in Wave C.")]`
+  - `NullTenantProvisioner.cs` — fakes "shared infra Ready" immediately (no-Cranl deployments).
+  - `CranlTenantProvisioner.cs` + `CranlProvisioningWorkflow.cs` (435 lines) +
+    `TenantProvisioningTaskHandler.cs` — the live Cranl walk.
+  - Wired in `Tamma.Api/Extensions/ProvisioningServiceCollectionExtensions.cs:76` (Cranl) and
+    `:93` (Null), both under `#pragma warning disable CS0618`.
+  - **Production callers**: `Tamma.Api/Endpoints/AdminEndpoints.cs:428-482`
+    (`ProvisionTenant` / `GetTenantProvisioning` / `DeprovisionTenant`) inject `ITenantProvisioner`.
+- **V2 (Stories 30-1, 30-2, 30-3, 30-8 — code landed in wave-b; commits 85ce1de8, 8a60c675,
+  8a9a58c0/20af4dd9, 441cad39/bebedba6, fix 9bf0341b)** —
+  `apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/V2/`:
+  - `ITenantInfrastructureProvider.cs` — `ProviderKey`, `GetCapabilities()`, `ProvisionAsync`,
+    `GetStatusAsync`, `DeprovisionAsync`, `ResolveEndpointsAsync`; idempotency contract in XML doc.
+    Reserved keys: `null`, `cranl`, `hetzner`, `cloudflare`, `byo`.
+  - `TenantProviderRegistry.cs` (singleton over `IEnumerable<ITenantInfrastructureProvider>`),
+    `NullTenantProvider.cs` (throws `NotSupportedException` on provision/deprovision/resolve —
+    deliberately NOT the V1 fake-Ready semantics; see `NullTenantProvider.cs:23-25`),
+    `Cranl/CranlTenantProviderV2.cs` (360 lines, scoped, adapted via
+    `ScopedTenantInfrastructureProviderAdapter`).
+  - `ProvisionTenantV2Workflow.cs` (30 KB) — 8-step compensating saga (ResolveProvider → Preflight
+    → ReserveResources → ExecuteProvision → PersistEndpoints → RegisterSecrets(placeholder) →
+    InitialProbe → Activate), resumable via `tenants.provisioning_state`; plain orchestrator class,
+    not Elsa (30-1 ADR §5 — Tamma.Activities does not reference Tamma.Api).
+  - `ProvisionTenantV2Dispatcher.cs` + `ProvisionTenantV2TaskHandler.cs` — platform-queue dispatch.
+    **The dispatcher has NO production caller** — only DI registration
+    (`ProvisioningServiceCollectionExtensions.cs:130`). Admin endpoints never reach V2.
+  - `V2TenantEndpointDirectory.cs` — bound as the `ITenantEndpointDirectory` the LRU resolver
+    consults BEFORE the legacy decrypt path (`Program.cs:274` `AddTenantProvisioningV2()`;
+    `Tamma.Data/Pooling/LruPooledTenantConnectionResolver.cs:112-126`, fallback flow at `:948-996`).
+    Resolution: `tenants.ProviderKey` NULL → `NotApplicable` → legacy `EncryptedConnectionString`.
+  - `SqlTenantProviderKeyLookup.cs` — tolerates a missing `provider_key` column (pre-30-3 deploys).
+- **Shared vocabulary**: `ProvisioningModels.cs:22` `enum ProvisioningState`
+  (`none → pending → database_provisioning → database_ready → app_provisioning → app_deploying →
+  ready | failed | deprovisioning | deprovisioned`) is used by BOTH surfaces
+  (`V2/ProvisioningStatusSnapshot.cs` doc: "deliberately does not mint a new state-machine
+  vocabulary"). Wave C must keep this enum when deleting the rest of `ProvisioningModels.cs`'s V1
+  types. Persisted on `tenants.ProvisioningState` (`Tamma.Data/Entities/Tenant.cs:51`).
+
+### 1.2 The V2/unified-model tension (the real architectural work)
+
+`CranlTenantProviderV2.ResolveEndpointsAsync` (`V2/Cranl/CranlTenantProviderV2.cs:240-340`)
+decrypts `tenants.CranlDatabaseUrlEncrypted` (`Tenant.cs:37`) and returns it as the tenant's
+`DatabaseUrl`. The LRU resolver would build an `NpgsqlDataSource` on that **raw Cranl DB URL — no
+`Search Path=t_<hex>`, no per-tenant role** — bypassing the unified isolation model entirely.
+Neither `CranlProvisioningWorkflow` (V1) nor `CranlTenantProviderV2` registers the minted hosting
+database into `tenant_databases` (grep: zero references). Today this path is dormant only because
+nothing sets `tenants.ProviderKey` in production (no V2 caller). Parent-plan decision 3 +
+deviation 22 define the fix: **the provider mints a pool row; the unified model places the tenant
+schema onto it.**
+
+### 1.3 The two transitional CHECKs (parent deviations 6–7) — exact current definitions
+
+Authoritative in `Tamma.Data/TammaModelConfiguration.cs`, hand-mirrored in
+`Migrations/ControlPlane/20260609205701_InitialControlPlane.cs` (`:457`, `:564`), its
+`.Designer.cs`, and `ControlPlaneDbContextModelSnapshot.cs` (`:487`, `:1406`) — the Phase-0 "C1
+procedure": edit all four, then `dotnet ef migrations has-pending-model-changes` must report none.
+
+- **Deviation 6** — `TammaModelConfiguration.cs:359-361`:
+  ```sql
+  CONSTRAINT ck_api_keys_scope CHECK ("Scope" IN ('platform','user','installation','service','tenant'))
+  ```
+  Spec target on CP is `('platform','user')`. Live writers of the extra scopes:
+  `Endpoints/OrgApiKeysEndpoints.cs:53,72` (`Scope = "tenant"` → CP),
+  `Services/GitHub/InstallationRouterService.cs:33,286` (`"installation"`), plus `"service"`
+  writers (`CiSecretsRotationHandler`, `ApiKeyRotationService` area). The tenant-side `api_keys`
+  table already exists with a `Scope = 'tenant'` CHECK
+  (`tests/Tamma.Api.Tests/Epic28/TenantDbContextModelTests.cs:90`).
+- **Deviation 7** — `TammaModelConfiguration.cs:277-282`:
+  ```sql
+  CONSTRAINT ck_tenants_connection_string_present CHECK (
+    "Status" IS NULL
+    OR "Status" IN ('pending_verification','provisioning','failed','deleted','deleting','delete_requested')
+    OR "EncryptedConnectionString" IS NOT NULL)
+  ```
+  Spec-exact target (parent plan §1): `"Status" = 'pending_verification' OR
+  "EncryptedConnectionString" IS NOT NULL`. The exemptions exist because (a) V1 Cranl flows minted
+  mid-provisioning — now false: unified creation mints at tenant creation (Phase 2/3, 2026-06-10);
+  (b) delete flows null the envelope and force-delete enters deleting/delete_requested from
+  never-minted `failed` rows (comment block `TammaModelConfiguration.cs:258-269`).
+
+### 1.4 Story 28-1's stub and the two Epic-30-gated ignored tests
+
+- `Tamma.Data/Pooling/EfTenantDbMigrator.cs:104-115` — `MigrateTenantElsaAsync` logs
+  `tenant.lifecycle.migrate_elsa skipped reason=elsa_db_not_split` and returns
+  `Task.CompletedTask`. Interface: `Tamma.Data/Abstractions/ITenantDbMigrator.cs:42`.
+  **No production caller exists** — only the interface + impl pair. Story doc
+  (`docs/stories/epic-28/story-28-1/28-1-ef-migration-scripts.md`): "MOSTLY DONE … per-tenant Elsa
+  DB migrate/run: INTENTIONAL no-op stub, NOT runtime-verified, deferred to the Epic 30
+  db-per-tenant runtime cutover."
+- `tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs:229-254` —
+  `Tenants_Cranl_Columns_Are_Ignored_On_NewContext` `[Ignore]`: "re-enable when Epic 30 lands the
+  alternative routing column" (asserts `CranlProjectId`/`CranlDatabaseId`/`CranlAppId`/
+  `CranlAppUrl`/`CranlDatabaseUrlEncrypted`/`CranlRegion`/`ProvisioningState`/`ProvisioningDetail`/
+  `ProvisioningUpdatedAt` leave the Tenant model).
+- `tests/Tamma.Api.Tests/Epic28/TenantDbContextModelTests.cs:59-87` —
+  `Tenant_Resident_Entities_Have_No_TenantId_Column` `[Ignore]`: rationale references the
+  now-deleted `StubTenantConnectionResolver` (stale premise — the unified resolver is
+  unconditional since Phase 3); the `TenantId` columns themselves may still exist.
+
+### 1.5 Story 28-13 (OpenBao) and the key seam
+
+- `Tamma.Api/Services/Provisioning/TenantSecretProtector.cs` — AES-GCM, key from
+  `Cranl:EncryptionKey` (base64 32 bytes), HKDF-from-ApiKey fallback strictly dev
+  (`FromConfiguration`, R2-H11). Doc comment `:13,:36`: migrate to an `IKeyProtector` abstraction
+  when 28-13 lands. **`IKeyProtector` does not exist anywhere in the codebase.**
+- `docs/stories/epic-28/story-28-13/28-13-openbao-kms-backend.md` § "Trigger Conditions": first
+  paying tenant with breach-notification clause / auditor finding / 10 paying tenants /
+  threat-model change / OpenBao LF graduation. Story stays DEFERRED until one fires; the firing
+  trigger must be recorded in the un-deferring commit.
+
+### 1.6 Stale docs + blocked stories
+
+- `docs/stories/epic-30/README.md` and ALL ten `30-*-impl-plan.md` headers say
+  "**Status**: Planned (2026-04-20)" although 30-1/30-2/30-3/30-8 code shipped in wave-b.
+- Epic 29 is "planning (briefs only)" and `ISecretStore` does not exist in code → Story 30-4
+  (Hetzner, depends on 29-7) is hard-blocked; 30-5/30-6/30-7/30-10 are large greenfield items with
+  no code. They are NOT in this plan's scope (see Non-goals).
+- Full-suite baseline at main: **4575 passed** (wave-b merge). Tests run via
+  `sg docker -c "dotnet test ..."` in `apps/tamma-elsa` (docker group note in memory).
+
+---
+
+## 2. Non-goals / explicitly out of scope
+
+- **New backends**: Hetzner Cloud (30-4, blocked on Epic 29), Cloudflare Workers+D1 (30-5),
+  BYO (30-6). The registry + capability matrix make these pure-additive later.
+- **Onboarding UI** (30-7) and **cost/quota dashboard** (30-10).
+- OpenBao **implementation** (28-13) — this plan only runs the trigger review and records the
+  outcome; implementation happens only if a trigger fired, as its own plan.
+- Billing, region failover, online tenant moves (parent plan §7).
+- Per-user/per-tenant pluggable providers — providers stay platform-operator-wired (30-1 ADR).
+
+---
+
+## 3. Phase decomposition (each becomes its own task-plan)
+
+### Phase A — Wave C: retire the V1 provisioner surface
+
+Port the three admin endpoints onto the V2 dispatcher; delete V1; preserve external API contract.
+
+- [ ] **Task A1 — Null-deployment semantics decision + dispatcher gap.** V1
+  `NullTenantProvisioner` marks tenants Ready immediately (CLAUDE.md: "admin endpoints still work —
+  they just mark tenants Ready immediately"); V2 `NullTenantProvider` throws. Bridge in the
+  **dispatcher**, not the provider: when the resolved provider's capabilities are
+  `ProviderCapabilities.None`, `ProvisionTenantV2Dispatcher.DispatchAsync` short-circuits to
+  `ProvisioningState.Ready` with detail `shared_infrastructure_no_backend_configured` (placement
+  already happened at tenant creation under the unified model — there is genuinely nothing to do).
+  Tests first: `ProvisionTenantV2DispatcherTests` — null-provider dispatch → Ready, no queue row,
+  no `NotSupportedException` escape.
+- [ ] **Task A2 — Port admin endpoints to V2.** `AdminEndpoints.cs:428-482` swap
+  `ITenantProvisioner` → `ProvisionTenantV2Dispatcher` (provision), provider
+  `GetStatusAsync`/`tenants.ProvisioningState` read (status), and a new
+  `DeprovisionAsync` dispatch path (deprovision rides the same platform-queue handler with a
+  payload flag — the 30-9 "reverse saga" reduced to Cranl+Null scope). Response DTO
+  (`TenantProvisioningResponse`) and state strings are unchanged — both surfaces share
+  `ProvisioningState.ToStorageString()`. Tests first: existing admin provisioning endpoint tests
+  re-pointed at the V2 wiring (202 + Location, status polling transitions, deprovision 202,
+  OwnerAccess 403s); keep them green through the swap.
+- [ ] **Task A3 — Delete V1.** Remove `ITenantProvisioner.cs`, `NullTenantProvisioner.cs`,
+  `CranlTenantProvisioner.cs`, `CranlProvisioningWorkflow.cs`, `TenantProvisioningTaskHandler.cs`,
+  the `CS0618` pragmas and V1 registrations in `ProvisioningServiceCollectionExtensions.cs`, and
+  `tests/.../Provisioning/CranlProvisioningWorkflowTests.cs` (port any behavior assertions V2
+  tests lack into `ProvisionTenantV2WorkflowTests` FIRST — diff the two test files before
+  deleting). Keep `ProvisioningModels.cs`'s `ProvisioningState` enum + `ToStorageString`/
+  `ParseState` (move into `V2/` or a neutral file; update the `Tenant.cs:48` doc ref).
+  Gate: `grep -rn "ITenantProvisioner\b" src tests` → zero hits; full suite green.
+
+### Phase B — Reconcile V2 with the unified model: providers mint pool rows
+
+This is decision 3 / deviation 22 made real. A `DatabaseOnly` provision = "mint a hosting DB,
+register it in `tenant_databases`, move the tenant's schema onto it." Database routing NEVER flows
+through provider-resolved raw URLs.
+
+- [ ] **Task B1 — Narrow `V2TenantEndpointDirectory` to engine routing.** The directory stops
+  returning `DatabaseUrl` (always `NotApplicable` for DB resolution; the LRU resolver's unified
+  `EncryptedConnectionString` path is the only DB route — matching CLAUDE.md "Routing (current
+  state)"). `TenantEndpoints.EngineUrl` remains for dedicated-compute engine dispatch.
+  Tests first: directory tests assert ProviderKey-set tenants still resolve DB connections via the
+  unified envelope (real-PG test through `LruPooledTenantConnectionResolver`), and engine-URL
+  resolution still works for a fake dedicated-compute provider.
+- [ ] **Task B2 — `CranlTenantProviderV2` registers the minted DB as a pool row.** On
+  `database_ready`: parse the Cranl `DATABASE_URL`, create a `tenant_databases` row (Label
+  `cranl-<tenant-slug>`, `PlacementClass='dedicated'`, encrypted admin conn via
+  `ITenantConnectionStringProtector`, `Status='active'`), record provenance in
+  `tenants.ProviderKey='cranl'` + `tenants.ProviderResourceIds` (already stamped at
+  `CranlTenantProviderV2.cs:152`), then drive the existing `TenantMoveService` (Phase-4 machinery:
+  draining → pg_dump -n t_<hex> → restore → re-point envelope → evict → drop source) to move the
+  tenant onto it. **Analysis sub-task (blocking)**: verify the Cranl-minted credential can
+  `CREATE SCHEMA`/`CREATE ROLE` on its DB; if not (no CREATEROLE), fall back to the documented
+  shared-role-per-DB placement for that row and record the decision. Tests first: provider unit
+  tests with a fake Cranl client asserting pool-row creation + move dispatch; env-gated e2e
+  (`CRANL_API_KEY_TEST`) for the real walk.
+- [ ] **Task B3 — Drop the legacy Cranl tenant columns + re-enable ignored test #1.** With B1/B2,
+  `tenants.CranlDatabaseUrlEncrypted`/`CranlProjectId`/`CranlDatabaseId`/`CranlAppId`/`CranlAppUrl`/
+  `CranlRegion` lose their last readers (resource ids live in `provider_resource_ids` JSONB;
+  `CranlAppUrl` moves to `TenantEndpoints`/resource ids for engine routing). Keep
+  `ProvisioningState`/`ProvisioningDetail`/`ProvisioningUpdatedAt` (still the saga's resume state)
+  — **amend the ignored test's expectations accordingly and record the deviation** (the 2026-04
+  test predates the 30-2 plain-orchestrator design). Un-`[Ignore]`
+  `ControlPlaneDbContextModelTests.Tenants_Cranl_Columns_Are_Ignored_On_NewContext` (re-scoped),
+  collapse-edit the CP baseline per the C1 four-artifact procedure, prove
+  `has-pending-model-changes` clean + baseline applies on throwaway Postgres.
+
+### Phase C — Tighten the transitional CHECKs (parent deviations 6–7)
+
+- [ ] **Task C1 — `ck_tenants_connection_string_present` → near-spec form.** Mint-at-creation is
+  live, so `provisioning` no longer needs the exemption. Delete flows DO null the envelope, so the
+  honest target (analysis task first — enumerate every writer of `Status` +
+  `EncryptedConnectionString = null`: `MarkTenantDeletingActivity`,
+  `AdminTenantsEndpoints.ForceDeleteTenant`, purge path) is expected to be:
+  ```sql
+  CONSTRAINT ck_tenants_connection_string_present CHECK (
+    "Status" IS NULL
+    OR "Status" IN ('pending_verification','deleting','deleted')
+    OR "EncryptedConnectionString" IS NOT NULL)
+  ```
+  with `failed`/`delete_requested`/`provisioning` dropped from the exemption list (a failed or
+  delete-requested tenant under the unified model HAS an envelope — it was minted at creation). If
+  the writer audit finds a flow that legitimately nulls earlier, keep the minimal exemption and
+  record it as a deviation. Tests first: real-PG tests asserting (a) `active` + NULL envelope →
+  23514, (b) `failed`/`delete_requested` + NULL envelope → 23514 (new), (c) the
+  force-delete-from-failed path still completes (it now carries its envelope into
+  deleting/deleted). Four-artifact C1 edit procedure + `has-pending-model-changes` + throwaway-PG
+  apply.
+- [ ] **Task C2 — `ck_api_keys_scope` tightening + tenant-key relocation.** Two sub-decisions,
+  analysis first:
+  1. `'tenant'`-scoped keys move out of CP: `OrgApiKeysEndpoints.cs:53,72` writes into the
+     tenant store's `api_keys` (table + `Scope='tenant'` CHECK already exist);
+     `ApiKeyAuthHandler` routes lookup by key-prefix → CP first, then active-tenant store (or a
+     prefix discriminator — analysis decides; auth hot path, benchmark before/after).
+  2. `'installation'`/`'service'` are platform-plane keys (GitHub App installation router, service
+     automation) — they have no tenant store to move to. Proposed: amend the spec enumeration
+     rather than relocate, landing:
+  ```sql
+  CONSTRAINT ck_api_keys_scope CHECK ("Scope" IN ('platform','user','installation','service'))
+  ```
+  i.e. `'tenant'` removed from CP. If the analysis instead justifies full spec
+  `('platform','user')`, fold installation/service into `platform` ownership semantics — decision
+  recorded either way in the execution record + parent-plan deviation note. Tests first: org
+  api-key CRUD round-trip against the tenant store, CP insert with `Scope='tenant'` → 23514,
+  auth-handler resolution for both stores, four-artifact CHECK edit + PG apply.
+
+### Phase D — Story 28-1 closeout: per-tenant Elsa runner
+
+- [ ] **Task D1 — Decide the Elsa topology under the unified model (blocking decision).** The
+  stub predates schema-per-tenant. Options: (a) per-tenant Elsa schema `t_<hex>_elsa` in the
+  tenant's pool DB, migrated by a real `MigrateTenantElsaAsync` (Elsa's EF migrations against a
+  Search-Path-scoped connection); (b) Elsa stays global except for dedicated-compute tenants,
+  where the per-tenant engine (Cranl App) owns Elsa tables in the tenant's hosting DB — the stub
+  becomes real only on the `DedicatedCompute` topology path; (c) formally close 28-1's residual as
+  "superseded by unified model" and delete the stub + interface member. Record in
+  `.dev/decisions/`. Current evidence: the stub has zero callers — (b) or (c) are the likely
+  outcomes; do NOT implement (a) without a consumer.
+- [ ] **Task D2 — Implement the decision.** If (b): wire `MigrateTenantElsaAsync` into the
+  dedicated-compute provision saga (between `database_ready` and `app_provisioning`), embed the
+  Elsa migration-assembly hash + fail-fast on drift (28-5 plan §9 open question), env-gated
+  runtime verification e2e (real Cranl creds: engine boots, Elsa tables present, workflow executes
+  in the tenant engine). If (c): delete `ITenantDbMigrator.MigrateTenantElsaAsync` +
+  `EfTenantDbMigrator.cs:104-115`, update Story 28-1 doc to DONE-with-decision. Either way:
+  re-evaluate ignored test #2
+  (`TenantDbContextModelTests.Tenant_Resident_Entities_Have_No_TenantId_Column:59`) — its stale
+  StubTenantConnectionResolver premise is gone; either drop the `TenantId` columns from
+  tenant-resident tables (schema isolation makes them redundant; baseline regen) and re-enable, or
+  re-scope the `[Ignore]` text to a true remaining blocker. Tests first per the chosen branch.
+
+### Phase E — Story 28-13 trigger review + docs closeout
+
+- [ ] **Task E1 — OpenBao trigger review.** Walk the five §"Trigger Conditions" checkboxes against
+  2026-06-11 reality (paying tenants: zero → triggers 1/3 not fired; check OpenBao LF graduation
+  status via WebSearch; auditor/threat-model: none). Record the dated outcome (expected: "still
+  deferred — no trigger fired") in the story doc + `.dev/decisions/`. **No code** unless a trigger
+  fired; if one fired, that spawns its own plan (incl. the `IKeyProtector` seam extraction from
+  `TenantSecretProtector`).
+- [ ] **Task E2 — Documentation truth-up.** Update `docs/stories/epic-30/README.md` + the ten
+  impl-plan Status headers (30-1/2/3/8 → DONE-in-wave-b with commit refs; 30-9 → partially
+  delivered by Phase A deprovision dispatch; 30-4/5/6/7/10 → deferred with blockers named);
+  CLAUDE.md "Multi-tenant provisioning" section (V1 `NullTenantProvisioner` reference → V2 seam,
+  `cranl_database_url_encrypted` sentence → pool-row registration); parent plan deviations section
+  gains the Phase C final CHECK forms; memory file updates; execution record per phase.
+
+---
+
+## 4. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Admin API contract drift during the V1→V2 endpoint swap breaks the dashboard | Shared `ProvisioningState` enum + unchanged `TenantProvisioningResponse`; endpoint tests pinned BEFORE the swap (Task A2 is test-first against the existing contract). |
+| B2's Cranl-minted credential lacks CREATEROLE → role-per-tenant impossible on that DB | Blocking analysis sub-task in B2; documented fallback (shared role per dedicated DB — still single-tenant DB, isolation preserved by topology) recorded as a deviation. |
+| Tightened conn-string CHECK trips a delete/purge flow not found in the writer audit (repeat of the original 23514 bug) | C1 writer audit enumerates ALL `Status` writers via grep before choosing the form; real-PG tests exercise force-delete-from-failed end-to-end; exemptions only removed with a passing test proving the flow. |
+| Auth hot-path regression from dual-store api-key lookup (C2) | Prefix-discriminated routing (single store hit per lookup) preferred; micro-benchmark in the C2 task-plan; CP lookup order preserved for platform keys. |
+| Four-artifact CHECK mirroring drifts (baseline vs snapshot vs designer vs model) | C1 procedure is mandatory per task; `has-pending-model-changes` + throwaway-Postgres baseline apply are phase gates (same as Phases 0/4 of the parent plan). |
+| Cranl e2e unverifiable in CI (no live Cranl) | All Cranl-real paths env-gated (`CRANL_API_KEY_TEST`); fake-client unit tests carry the contract; runtime verification recorded as done/blocked explicitly in the execution record — never silently skipped. |
+| Deleting V1 loses behavior only its tests covered | Task A3 mandates a test-diff (CranlProvisioningWorkflowTests vs ProvisionTenantV2WorkflowTests) and porting gaps BEFORE deletion. |
+
+---
+
+## 5. Acceptance criteria
+
+1. **One provisioning surface.** `ITenantProvisioner`, `NullTenantProvisioner`,
+   `CranlTenantProvisioner`, `CranlProvisioningWorkflow`, `TenantProvisioningTaskHandler` are
+   deleted; `grep -rn "ITenantProvisioner\b" apps/tamma-elsa/src apps/tamma-elsa/tests` → 0 hits;
+   admin provision/status/deprovision endpoints ride `ProvisionTenantV2Dispatcher` /
+   `TenantProviderRegistry`; no-backend deployments still mark tenants Ready immediately.
+2. **Providers mint pool rows; unified model owns routing.** A Cranl `DatabaseOnly` provision ends
+   with a `tenant_databases` row + the tenant's schema moved onto it + the tenant resolving through
+   its own AES-GCM Search-Path envelope; `V2TenantEndpointDirectory` never supplies a raw
+   `DatabaseUrl` to the LRU resolver; legacy `Cranl*` tenant columns are gone from the model and
+   baseline.
+3. **CHECKs tightened** (four artifacts each, `has-pending-model-changes` clean, baseline applies
+   on throwaway Postgres). Current transitional forms being replaced:
+   - `ck_api_keys_scope`: `"Scope" IN ('platform','user','installation','service','tenant')`
+     → final form per Task C2 decision (proposed:
+     `"Scope" IN ('platform','user','installation','service')`, `'tenant'` keys relocated to the
+     tenant store), decision recorded.
+   - `ck_tenants_connection_string_present`:
+     `"Status" IS NULL OR "Status" IN ('pending_verification','provisioning','failed','deleted','deleting','delete_requested') OR "EncryptedConnectionString" IS NOT NULL`
+     → final form per Task C1 audit (proposed exemptions only
+     `pending_verification`,`deleting`,`deleted`), with real-PG tests proving `active`/`failed`/
+     `delete_requested` + NULL envelope are rejected and the force-delete path still works.
+4. **28-1 closed.** `MigrateTenantElsaAsync` is either a real, runtime-verified (env-gated e2e)
+   step of the dedicated-compute saga, or deleted with a recorded supersession decision; Story
+   28-1 doc no longer says "MOSTLY DONE"; both Epic-30-gated `[Ignore]` tests are re-enabled or
+   re-scoped with accurate, current rationale (no stale StubTenantConnectionResolver references).
+5. **28-13 reviewed.** Dated trigger-review outcome recorded in the story doc +
+   `.dev/decisions/`; if a trigger fired, a follow-up plan exists.
+6. **Suite + docs.** Full suite ≥ baseline 4575 green (plus new tests); Epic 30 README/impl-plan
+   statuses, CLAUDE.md provisioning/routing sections, and the parent plan's deviation list reflect
+   the end state; per-phase execution records written.
+
+---
+
+## Self-review notes
+
+- Deliberately narrower than the 2026-04-20 story map: 30-4/5/6/7/10 stay deferred (Epic 29
+  blocker + no code), so this plan finishes the *seam* — the thing the unified-tenancy work left
+  as "loose threads" — rather than shipping four backends. New backends become pure-additive
+  `AddTenantProvider*` registrations afterward.
+- Highest-blast-radius items: Phase C2 (auth hot path) and Phase B1 (resolver routing). Both gate
+  behind real-PG integration tests and land after Phase A proves the V2 path under the existing
+  test contract.
+- Open question routed to Task D1 on purpose: the per-tenant Elsa story only makes sense for
+  dedicated compute, and the stub has zero callers today — implementing before a consumer exists
+  would violate the "don't ship the wrong default" rule.

--- a/docs/superpowers/plans/2026-06-11-epic-6-implementation.md
+++ b/docs/superpowers/plans/2026-06-11-epic-6-implementation.md
@@ -1,0 +1,164 @@
+# Epic 6 Implementation Plan — REFRESHED 2026-06-11
+
+**Supersedes**: `~/.claude/plans/epic-6-implementation.md` (written pre-Epic-19; its Phase 1 file targets no longer exist)
+**Verified against**: main @ `98cfb1c2` (post wave-b tenancy merge)
+**Epic docs**: `docs/stories/epic-6/README.md` (10 stories + drafted 6-11)
+**Companion audit**: `docs/audit/port-gaps/kb/index.md` (16 findings, all deferred to "a dedicated TypeScript work item" — this plan IS that work item)
+
+---
+
+## 1. What Changed Since the Old Plan (Delta from previous plan)
+
+| Old plan claim | Current reality (verified 2026-06-10) |
+|---|---|
+| 6 mock KB services live in `packages/api/src/services/knowledge-base/` | **STALE — `packages/api` was deleted** (Epic 19 Phase 3, commit `9e9a57cc`). The 6 services were ported to a new Fastify sidecar: `packages/intelligence-server/src/services/`. |
+| Services return hardcoded fake data (`vectorCount: 12450`) | **STALE — no hardcoded fakes remain.** Every service now wraps a narrow adapter interface and falls back to zeros/empty/`"(stub — no X configured)"` strings when the dependency is `null`. The string `12450` no longer exists anywhere in the repo. |
+| Old Phase 1: "rewrite 6 mock services to take DI deps" | **ALREADY DONE structurally.** Services accept optional deps (`IntelligenceServicesBundle`), 32 route tests pass. **The remaining gap moved up a level: no composition root ever constructs the real deps.** `startServer()` at `server.ts:~210` builds an empty bundle; `adapters.ts` factories are never called from source; `CHROMADB_URL` (set in docker-compose) is read nowhere in the sidecar. |
+| Old 1.7: update `createKBServices()` in `packages/api/src/routes/...` + `serve.ts` | **STALE — files gone.** Replacement: the C# API (`apps/tamma-elsa/src/Tamma.Api`) forwards all 30 `/api/kb/*` routes (Program.cs:1907-1943, behind `SettingsView`/`SettingsManage` policies) via `IntelligenceHttpClient` → sidecar `/kb/*`. C# contract layer is verified fine ("Not-a-gap" per audit). |
+| Old Phase 4: pgvector migration in `database/migrations/004_pgvector.sql` | **STALE — `database/migrations/` no longer exists** (SQL files moved to `database/archived-sql-migrations/`; control-plane schema is now owned by EF Core in `apps/tamma-elsa/src/Tamma.Data`). `docker/init-db.sql` creates `uuid-ossp` only — **no `vector` extension**. Deployment uses ChromaDB 1.5.8 container as the vector backend; pgvector is optional. |
+| "Only TS/JS chunker, no Python/Go" (6-1) | **PARTIALLY STALE**: `generic-chunker.ts` now exists as a language-agnostic fallback alongside `typescript-chunker.ts`. A dedicated Python/Go AST chunker still does not exist. |
+| WebSearchSource is empty placeholder (6-5) | **STILL TRUE** — 21 lines, returns nothing. |
+| Scrum Master `generatePlan()` is stub (6-10) | **STILL TRUE** — mock plan at `packages/scrum-master/src/scrum-master-service.ts:811`. |
+| Old 3.5: create `violations/recorder.ts`, `violations/alerter.ts` | **DONE** — `packages/gates/src/violations/{violation-recorder,violation-alerter}.ts` exist with tests. Permission *persistence* (PG store) still missing. |
+| KB/cost/permission stores are in-memory only | **STILL TRUE** — `knowledge-base/stores/` has only `in-memory-store.ts`; `cost-monitor/src/storage/` has in-memory + file (sync I/O) only; gates has no PG store. |
+| Qdrant/Pinecone/Weaviate are stubs | **STILL TRUE** — each is a 78-line stub that throws "only chromadb and pgvector are production-ready". |
+| (not in old plan) | **NEW BLOCKER**: `@tamma/intelligence` has **153 strict-mode TS errors** across 34 files (`npx tsc --noEmit`). The committed `dist/` (Mar 19) + stale `.tsbuildinfo` mask this — `tsc --build` reports "up to date". The sidecar deliberately avoids compile-time imports of `@tamma/intelligence` because of this (see `adapters.ts` header comment). Audit finding #014. |
+| (not in old plan) | **NEW**: dashboard ↔ contract drift. `packages/dashboard/src/services/knowledge-base/api-client.ts` calls ~12 routes **not in** the 30-route C#/sidecar contract: `/kb/index/cancel`, `/kb/index/history`, `/kb/analytics/quality`, `/kb/context/test`, `/kb/rag/test`, `/kb/mcp/servers/{name}/restart`, `/kb/mcp/servers/{name}/logs`, `/kb/mcp/servers/{name}/tools` (contract: `/kb/mcp/tools?serverName=`), `/kb/vector-db/storage`, `/kb/vector-db/collections/{name}/stats`, `POST/DELETE /kb/vector-db/collections...`. Those dashboard features 404 today. |
+| (not in old plan) | **NEW**: Story 6-11 (Context API Wiring) drafted at `docs/stories/epic-6/story-6-11/6-11-context-api-wiring.md` — but it targets the deleted `packages/api/src/routes/`; needs re-targeting before execution. |
+| (not in old plan) | `adapters.ts` only covers vectorStore + ragPipeline. **No adapters exist** for indexer, MCP client, context aggregator, or cost tracker — and the sidecar's `IIndexer` interface doesn't match `CodebaseIndexer` (`getIndexStatus()` vs `getIndexStatus(projectPath)`; `indexProject(path, {fullReindex})` vs `indexProject(path)`). |
+| (not in old plan) | `@tamma/mcp-client` and `@tamma/cost-monitor` are **not dependencies** of `@tamma/intelligence-server` (package.json has only `@tamma/intelligence`, `@tamma/shared`, fastify, pino, dotenv). Wiring MCP/Analytics requires adding workspace deps. |
+
+**Net effect**: the epic's center of gravity moved from "rewrite 6 mock services" (done) to **"build the composition root + fix the strict-mode debt that blocks it"**, exactly as the KB audit's remediation order says.
+
+---
+
+## 2. Current-State Table — the 6 KB Services
+
+All live in `packages/intelligence-server/src/services/` (Fastify sidecar, port 4100, deployed in `docker/docker-compose.yml` as `intelligence-server`, health-checked, consumed by C# API via `IntelligenceServer__Url`). All 6 are constructed dep-less in production today.
+
+| # | Service (file) | What it does today without deps | Real implementation it must wire to | Adapter status |
+|---|---|---|---|---|
+| 1 | `IndexManagementService.ts` (6 routes: status/trigger/config GET+PUT/stats/clear) | `getStatus()` → idle/0; `triggerIndex()` → `"Indexing triggered (stub — no indexer configured)"`; stats → zeros | `CodebaseIndexer` (`packages/intelligence/src/indexer/codebase-indexer.ts`, `indexProject(projectPath): Promise<IndexResult>`, `getIndexStatus(projectPath)`, `updateIndex(...)`, `stop()`) + `EmbeddingService` (openai/ollama/cohere/mock providers) | **Missing** — needs `adaptIndexer()`; signature mismatches (projectPath arg, no options bag) |
+| 2 | `VectorDbManagementService.ts` (6 routes: status/search/upsert/delete/collections/stats) | status → `not_configured`; search → `[]`; upsert/delete → `"(stub — no store configured)"`; stats → zeros | `createChromaDBStore()` / `createPgVectorStore()` from `packages/intelligence/src/vector-store/factory.ts` (ChromaDB 834-line impl, pgvector 954-line impl) + embed function for text queries | **Exists** — `adaptVectorStore(real, embedText)` in `adapters.ts`, never called |
+| 3 | `RagManagementService.ts` (4 routes: config GET+PUT/query/metrics) | query → blank answer, empty sources; metrics → zeros | `RAGPipeline` (`packages/intelligence/src/rag/rag-pipeline.ts`, `retrieve(query: RAGQuery): Promise<RAGResult>`) with vector/keyword/docs/github sources | **Exists** — `adaptRagPipeline(real)` in `adapters.ts`, never called |
+| 4 | `McpManagementService.ts` (8 routes: servers list/get/start/stop, config GET+PUT, tools list/invoke) | servers → `[]`; start/stop → stub strings; `invokeTool` → always errors | `MCPClient` (`packages/mcp-client/src/client.ts` — `listServers(): ServerInfo[]`, `listTools(serverName?)`, connect/disconnect via connection pool, audit logging) | **Missing** — needs `adaptMcpClient()` AND `@tamma/mcp-client` added to sidecar package.json |
+| 5 | `ContextTestingService.ts` (3 routes: history/feedback/config) | history → in-process array (lost on restart); feedback → in-process Map; `runQuery()` helper exists but no aggregator | `ContextAggregator` (`packages/intelligence/src/context/aggregator.ts`, `getContext(request: ContextRequest): Promise<ContextResponse>`; sources: VectorDB/RAG/MCP/WebSearch) | **Missing** — needs `adaptContextAggregator()` (shape is close) |
+| 6 | `AnalyticsService.ts` (3 routes: analytics/usage/costs) | all three → zeros / empty arrays | `CostTracker` (`packages/cost-monitor/src/cost-tracker.ts`, `createCostTracker`) + storage (currently in-memory/file only) | **Missing** — needs `adaptCostTracker()` AND `@tamma/cost-monitor` added to sidecar package.json; also needs a usage feed (nothing currently records LLM usage into cost-monitor in the deployed C# path) |
+
+**Request flow**: Dashboard (`VITE_API_BASE_URL`, default `/api`) → C# `Tamma.Api` `/api/kb/*` (auth: `SettingsView` read / `SettingsManage` write; 10s timeout; degraded-payload fallback on sidecar 5xx) → sidecar `/kb/*` → service → (today: null dep → zero state).
+
+---
+
+## 3. Phased Task Breakdown
+
+Conventions for every task: test-first (Vitest 3/4, colocated `*.test.ts`), ESM imports with `.js` extension, strict TS with `exactOptionalPropertyTypes` (use conditional assignment for optional props, never assign `undefined`), no `.then()/.catch()`, structured pino logging, no secrets in logs.
+
+### Phase 0 — Unblock: `@tamma/intelligence` strict-mode debt (audit #014) — P0
+
+The composition root cannot import `@tamma/intelligence` types/classes cleanly until this lands. 153 errors, top files: `typescript-chunker.ts` (28), `generic-chunker.ts` (15), `codebase-indexer.ts` (13), `embedding-service.ts` (9), `knowledge-service.ts` (7), `token-counter.ts` (7), `chromadb.ts` (6), `rag/ranker.ts` (6), `rag/assembler.ts` (6), `index.ts` (6), remainder ≤5 each.
+
+| Task | Files | Tests |
+|---|---|---|
+| 0.1 Fix indexer module errors (chunking, discovery, embedding, metadata, triggers, codebase-indexer, config) | `packages/intelligence/src/indexer/**` | Existing `__tests__` stay green; add cases only where a fix changes behavior |
+| 0.2 Fix rag + vector-store + knowledge-base + context errors | `packages/intelligence/src/{rag,vector-store,knowledge-base}/**`, `src/index.ts` | Same |
+| 0.3 Clean-build gate: `rm -rf dist .tsbuildinfo && pnpm --filter @tamma/intelligence build` green; add `typecheck` to CI path for this package so the stale-`.tsbuildinfo` masking can't recur | `packages/intelligence/tsconfig.json`, CI workflow if needed | `npx tsc --noEmit` → 0 errors |
+| 0.4 Triage the ~15 pre-existing failing tests across gates/intelligence/scrum-master/mcp-client (noted in `docs/architecture/mvp-status.md:34`) — fix or explicitly quarantine with linked issues | varies | Full Epic-6-package suites green |
+
+Known gotchas (from project memory): `exactOptionalPropertyTypes` → `if (val !== undefined) obj.prop = val;`; `noUncheckedIndexedAccess` → indexed access is `T | undefined`; chromadb client `Where` type needs proper narrowing, not `Record<string, unknown>`.
+
+### Phase 1 — Composition root: real backends in the sidecar (audit #001/#003/#004/#005) — P0
+
+| Task | Files | Tests |
+|---|---|---|
+| 1.1 Env config loader: `CHROMADB_URL`, `VECTOR_STORE_PROVIDER` (chromadb\|pgvector), `PGVECTOR_URL`, `EMBEDDING_PROVIDER` (openai\|ollama\|cohere\|mock), `OPENAI_API_KEY`/`OLLAMA_URL`, `INDEX_PROJECT_PATH`, `MCP_CONFIG_PATH` | NEW `packages/intelligence-server/src/config.ts` | NEW `src/config.test.ts` — env permutations, missing-var behavior (unset ⇒ dep stays null, never throw at boot) |
+| 1.2 Missing adapters: `adaptIndexer` (bind projectPath; map `getIndexStatus(path)` → no-arg; map `IndexResult` → status shape), `adaptMcpClient` (map `ServerInfo`/connection-pool ops), `adaptContextAggregator`, `adaptCostTracker` | `packages/intelligence-server/src/adapters.ts` (extend) | NEW `src/adapters.test.ts` — each adapter against a fake "real" impl; signature-mismatch regression cases |
+| 1.3 Add workspace deps `@tamma/mcp-client`, `@tamma/cost-monitor` to the sidecar; update Dockerfile manifest-copy list (it enumerates package.json files per workspace pkg) | `packages/intelligence-server/package.json`, `packages/intelligence-server/Dockerfile`, `pnpm-lock.yaml` | Docker build in CI |
+| 1.4 `buildBundleFromEnv(): Promise<IntelligenceServicesBundle>` composition root; call it from `startServer()` when no explicit bundle is passed | NEW `packages/intelligence-server/src/composition.ts`; `src/server.ts` entry block | NEW `src/composition.test.ts` (mock the factory imports); existing `routes.test.ts` (32) stays green via explicit-bundle injection |
+| 1.5 Kill user-visible `"(stub — …)"` strings (audit #002/#006-#010): when a dep is genuinely unconfigured return explicit `503 { error: 'not_configured', dependency: '...' }` (the C# client already renders degraded payloads on 5xx; the deleted TS API threw — never silently fake success) | all 6 service files + `server.ts` error mapping | Update `routes.test.ts` expectations; per-service `*.test.ts` for the 503 path |
+| 1.6 Compose/env wiring: add `OPENAI_API_KEY` (or `OLLAMA_URL`) + `VECTOR_STORE_PROVIDER` to the `intelligence-server` service; mount/decide the indexing target (see Risk R3); document in `.env.example` | `docker/docker-compose.yml`, `docker/docker-compose.prod.yml`, env examples | `docker/post-deploy-tests.sh` addition: `GET /kb/vector-db/status` returns `ready` |
+| 1.7 One live-compose smoke test (audit #016): boot sidecar + chromadb, upsert → search → non-empty result | NEW `packages/intelligence-server/src/__tests__/compose-smoke.integration.test.ts` (gated `INTEGRATION_TEST_ENABLED=true`) | Itself |
+
+Exit criterion: deployed dashboard KB pages show real (initially zero-but-live) data; `vector-db/status` = `ready`; triggering an index populates collections.
+
+### Phase 2 — Contract drift: dashboard ↔ C# ↔ sidecar — P1
+
+| Task | Files | Tests |
+|---|---|---|
+| 2.1 Decide per-route: extend contract vs trim dashboard. Recommended: ADD `index/history`+`index/cancel`, `mcp/servers/{id}/logs`+`restart`, `context/test` (wire to existing `ContextTestingService.runQuery()`), `rag/test` (alias of `rag/query`), `vector-db/collections` POST/DELETE + `{name}/stats` + `storage`; DROP `analytics/quality` from the dashboard (no backing data) | sidecar `server.ts` + services; C# `KbEndpoints.cs`, `IIntelligenceHttpClient(.cs)`, `IntelligenceHttpClient.cs`, `Program.cs` route map, `KnowledgeBaseDtos.cs`; `packages/dashboard/src/services/knowledge-base/api-client.ts`; `@tamma/shared` KB types | sidecar `routes.test.ts` additions; C# `KbEndpointsIntegrationTests`; dashboard service tests |
+| 2.2 Re-target Story 6-11 (engine context wiring): rewrite its "New API Routes (in packages/api/...)" section against the real surfaces (C# Tamma.Api or the sidecar); then implement per the revised story | `docs/stories/epic-6/story-6-11/...` first (doc), then code | per story |
+
+### Phase 3 — Persistence (carried over, re-pathed) — P1
+
+`database/migrations/` is archived; control-plane schema is EF-owned. Sidecar-owned tables need a decision (Task 3.0).
+
+| Task | Files | Tests |
+|---|---|---|
+| 3.0 Decide schema ownership for sidecar tables (recommended: a small sidecar-owned migration runner reusing `database/migrate.ts` pattern against a dedicated `intelligence` schema; do NOT touch EF control-plane). Note tenancy: sidecar is a single shared instance — tables must carry a tenant key or the KB stays explicitly instance-global (document which; see R6) | ADR in `.dev/decisions/` | n/a |
+| 3.1 Knowledge-base PG store (Story 6-9): implement `IKnowledgeStore` over PG | NEW `packages/intelligence/src/knowledge-base/stores/database-store.ts` + migration | NEW colocated `database-store.test.ts` (testcontainer or gated integration) |
+| 3.2 Cost-monitor PG store (Story 6-7): async PG store replacing sync FileStore in server contexts; feed it from the C# LLM call path or engine usage events (without a producer, analytics stay zero even when wired) | NEW `packages/cost-monitor/src/storage/pg-store.ts` + migration; producer wiring TBD in 6-11 scope | NEW `pg-store.test.ts` |
+| 3.3 Permission PG store (Story 6-8): persist project overrides + approval requests (violations recorder/alerter already exist) | NEW `packages/gates/src/permissions/pg-permission-store.ts` + migration | NEW colocated test |
+| 3.4 Context history + feedback persistence (audit #012); index-run history for `index/history` (2.1) | `ContextTestingService`, `IndexManagementService` + small tables | service tests |
+
+### Phase 4 — Quality gaps (carried over, still valid) — P2
+
+| Task | Files | Tests |
+|---|---|---|
+| 4.1 Python chunker via tree-sitter; route `.py` in `ChunkerFactory` (generic-chunker remains fallback for other langs) | NEW `packages/intelligence/src/indexer/chunking/python-chunker.ts`; `chunker-factory.ts` | NEW colocated test with Python fixtures |
+| 4.2 WebSearchSource real impl (Brave/SerpAPI/Tavily; key via env; **WebSearch latest docs before picking SDK/flags**) | `packages/intelligence/src/context/sources/web-search-source.ts` (currently 21 lines) | Colocated test w/ MSW mock |
+| 4.3 Learning summarizer (Story 6-9) — LLM summarization of task outcomes | NEW `packages/intelligence/src/knowledge-base/capture/learning-summarizer.ts` | Colocated test, mocked provider |
+| 4.4 Scrum Master `generatePlan()` → real LLM via engine pool (Story 6-10); blocked on engine execute-task surface (Story 6-11 / Phase 2.2) | `packages/scrum-master/src/scrum-master-service.ts:811` | Existing suite + new plan-generation tests |
+| 4.5 MCP tool invocation end-to-end through sidecar (audit #010) incl. server config discovery (`MCP_CONFIG_PATH`) | `McpManagementService`, composition root | Integration test against a local stdio MCP fixture |
+
+---
+
+## 4. Risks
+
+- **R1 — Strict-mode debt is the long pole.** 153 errors / 34 files; some fixes (chromadb `Where`, chunker index-access) may alter behavior. Mitigation: Phase 0 task split per module, suite green after each, no `as any` escapes.
+- **R2 — Stale-build masking.** Committed `dist/` (Mar 19) + `.tsbuildinfo` make `tsc --build` report "up to date" while `--noEmit` fails. Anything "working" today may be running months-old JS. Mitigation: Phase 0.3 clean-build gate in CI.
+- **R3 — Indexer filesystem access.** The sidecar container has no repo checkout; `CodebaseIndexer.indexProject(path)` needs real files. Options: mount a volume, accept `repositoryPath` per request against a workspace dir the engine clones, or run indexing in the engine and only query via sidecar. Decide in 1.6 (ADR-worthy).
+- **R4 — Analytics has no producer.** Wiring `CostTracker` shows zeros until something records LLM usage (the C# API / engine path doesn't feed cost-monitor today). Don't claim Story 6-7 done on Phase 1 alone — needs 3.2 producer wiring.
+- **R5 — Triple-surface contract changes.** Phase 2 touches dashboard TS, C# (endpoints+client+DTOs), and sidecar in lockstep; the C# `IIntelligenceHttpClient` is hand-mirrored. Mitigation: one route-set table as source of truth in the PR description; C# integration tests + sidecar route tests updated together.
+- **R6 — Tenancy.** KB routes sit behind per-tenant auth in the C# API, but the sidecar (and ChromaDB) is a single shared instance with no tenant scoping — in SaaS mode all tenants would share one index. Per the universal tenancy rule (CLAUDE.md), define both scoping models before exposing writes broadly; near-term mitigation: routes already require `SettingsView`/`SettingsManage`; document instance-global semantics, design tenant-scoped collections (e.g. collection-name prefix `t_<hex>_`) in the 3.0 ADR.
+- **R7 — Embedding cost/keys.** Real indexing burns embedding tokens; OPENAI_API_KEY in compose env. Mitigation: default `EMBEDDING_PROVIDER=ollama` option, batch-size caps, mock provider in tests.
+- **R8 — ChromaDB client/server version skew.** Compose pins server `chromadb/chroma:1.5.8`; verify the JS client in `@tamma/intelligence` matches its API (v2 heartbeat already needed a healthcheck workaround).
+
+---
+
+## 5. Acceptance Criteria
+
+From `docs/stories/epic-6/README.md` success metrics + audit remediation, restated for this plan:
+
+**Phase 0**
+- `pnpm --filter @tamma/intelligence build` from clean (`rm -rf dist .tsbuildinfo`) → 0 errors; `tsc --noEmit` → 0 errors.
+- Epic-6 package test suites (intelligence, gates, mcp-client, scrum-master, cost-monitor, intelligence-server) green; previously-failing ~15 tests fixed or quarantined with linked issues.
+
+**Phase 1 (the epic's headline)**
+- Sidecar started via `node dist/server.js` with compose env constructs real ChromaDB store + embedder + RAG pipeline (no code change needed to enable).
+- No response anywhere contains a literal "stub" string; unconfigured deps → 503 `not_configured`, which the C# client surfaces as its degraded envelope.
+- Live smoke: trigger index → `GET /api/kb/index/stats` shows documents/chunks > 0; `POST /api/kb/vector-db/search` returns real scored chunks; `GET /api/kb/vector-db/status` = `ready`.
+- Dashboard KB pages render real data with zero-state honesty (0 vectors when nothing indexed — never fabricated numbers).
+- All 32 existing sidecar route tests still pass; new config/adapters/composition tests added; one gated live-compose integration test exists (audit #016 closed).
+
+**Phase 2**
+- Every route the dashboard `api-client.ts` calls exists in the C# contract AND the sidecar (or is removed from the dashboard); no KB page issues a 404.
+- Story 6-11 doc re-targeted; C# activities listed in it no longer call nonexistent endpoints.
+
+**Phase 3**
+- KB entries, permissions, cost records, context history survive a sidecar/API restart (PG-backed).
+- Cost analytics show real usage once the producer is wired (tracking accuracy target: 100% of routed LLM calls).
+
+**Phase 4**
+- `.py` files chunked via AST (not generic fallback); WebSearchSource returns live results behind an env-keyed provider; `generatePlan()` produces an LLM-generated plan; MCP tool invocation works end-to-end through `/api/kb/mcp/tools/invoke`.
+
+**Epic-level metrics (unchanged from epic README)**: context retrieval p95 < 200ms; top-5 relevance > 85%; permission violation rate < 1%; learning capture > 80%.
+
+---
+
+## 6. Verification Sources (for future re-validation)
+
+- Sidecar: `packages/intelligence-server/src/{server,adapters,types}.ts`, `src/services/*.ts`, `src/__tests__/routes.test.ts` (32 tests, pass as of 2026-06-10)
+- C# bridge: `apps/tamma-elsa/src/Tamma.Api/Program.cs:1907-1943`, `Endpoints/KbEndpoints.cs`, `Services/KnowledgeBase/IntelligenceHttpClient.cs`, `Extensions/KnowledgeBaseServiceCollectionExtensions.cs`
+- Real impls: `packages/intelligence/src/{indexer,vector-store,rag,context,knowledge-base}/`, `packages/mcp-client/src/client.ts`, `packages/cost-monitor/src/`
+- Deploy: `docker/docker-compose.yml` (`chromadb` @ 1.5.8, `intelligence-server` @ 4100, `IntelligenceServer__Url`)
+- Audit: `docs/audit/port-gaps/kb/` (findings 001-016 + remediation-order rationale)
+- Pre-delete TS API snapshot: `git show 9e9a57cc~1:packages/api/src/services/knowledge-base/`

--- a/docs/superpowers/plans/2026-06-11-missing-config-notifications.md
+++ b/docs/superpowers/plans/2026-06-11-missing-config-notifications.md
@@ -1,0 +1,360 @@
+# Missing-Config Notifications Epic
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan story-by-story. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every story writes tests
+> before implementation.
+
+**Goal:** Tamma notifies — instead of silently degrading or only logging — when system-level or
+tenant-level configuration required by a feature is missing. Concretely: a taxonomy-valid
+`(role, action)` with no prompt/convention system default, a tenant whose expected override is
+absent, an unconfigured provider chain, or a mode-required platform setting (e.g.
+`Tamma:TenantSharedSecret`, `Cranl:EncryptionKey`) that is unset. Each gap becomes (a) a DCB
+event, (b) a deduplicated persisted record, (c) an alert through the existing Story 5.6 alert
+pipeline, and (d) a visible surface on the admin/tenant dashboard.
+
+**Seed note:** `~/.claude/projects/-home-meywd-tamma/memory/project_missing_config_notifications_epic.md`
+— planned follow-up to Epic 27; resolution is strictly tenant → system → error (NEVER empty/plain
+fallback), so a missing config row is a hard runtime error; the user wants proactive notification
+of gaps rather than discovering them when a workflow throws.
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane API + Elsa engine),
+React/Vite dashboard in `packages/dashboard` (Vitest). Tests live in
+`apps/tamma-elsa/tests/Tamma.Api.Tests/` (xUnit; docker-bound suites run via
+`sg docker -c "dotnet test ..."`).
+
+---
+
+## Non-goals (YAGNI guard)
+
+- NO change to resolution semantics. `tenant → system → TammaError` stays exactly as-is
+  (`feedback_resolution_no_empty_fallback`). Detection is a fire-and-forget side effect that must
+  never swallow, delay, or alter the throw.
+- NO new delivery channels. Email/Slack/PagerDuty/webhook delivery already exists in the alert
+  pipeline (`Services/Alerts/Channels/`); once the new built-in rules are linked to a channel by an
+  admin, delivery is free. No channel-linking UI in this epic (that is alert-pipeline Wave C.3
+  scope).
+- NO TypeScript-side (`packages/api`) detection. The prompt/convention stores, provider chains, and
+  provisioning config all live in the C# app; the engine's Elsa activities resolve via HTTP
+  callbacks to the central API, so server-side detection covers them with zero engine changes.
+- NO per-user notification preferences / mute lists. Acknowledge on the gap record is the v1 mute.
+- NO blocking startup validation. The scanner reports gaps; it does not fail the host (existing
+  fail-fast paths like `AddTammaSecretReveal` stay as they are).
+
+---
+
+## Current-state findings (verified 2026-06-10, repo @ main 98cfb1c2)
+
+### Where missing-config errors arise today
+
+| Site | Behaviour today |
+|---|---|
+| `src/Tamma.Api/Services/PromptStore/PromptStoreService.cs` — `NoPromptError(...)` (~line 671), thrown from `ResolveForUser` (~173) and tenant resolve (~389) | Throws `TammaError("PROMPT.RESOLVE.NO_DEFAULT", ..., severity High)` with role/action/userId/tenantId context. **No event emitted, no alert** — only the exception. |
+| `src/Tamma.Api/Services/Conventions/ConventionStore.cs` — `NoConventionError(...)` (~line 295), thrown from `ResolveAsync` (~138) | Throws `TammaError("CONVENTION_NOT_FOUND", ..., severity High)`. Same: exception only. |
+| `src/Tamma.Api/Endpoints/PromptEndpoints.cs` (~181, ~420) and `ConventionStoreEndpoints.cs` (~86, 142, 229, 457) | Catch `TammaError` → translate to 404. The gap is invisible past the HTTP response. |
+| `src/Tamma.Activities/LlmCall/ResolvePromptFromRegistryActivity.cs` (engine) | Calls central `POST /api/prompts/{role}/{action}/render`; on 404/error throws `TammaError("LLM.PROMPT.RESOLVE.NO_ROW" / "...REGISTRY_UNAVAILABLE")` and emits `LLM.PROMPT.RESOLVE.FAILED` — but only into the **transient** `tamma:events` workflow property + logs (see below). |
+| `src/Tamma.Activities/Context/ResolveConventionsActivity.cs` (engine) | Same pattern via `POST /api/conventions/resolve`; `LLM.CONVENTIONS.RESOLVE.FAILED` transient event. |
+| `src/Tamma.Api/Services/Providers/ProviderChainResolver.cs` (~line 86) | "No provider chain configured for role/action" → returns an ErrorMessage result. Log-level surface only. |
+| `src/Tamma.Api/Services/Provisioning/TenantSecretProtector.cs` (~111–140) | Missing `Cranl:EncryptionKey` in non-prod → HKDF-from-ApiKey **with only a logged warning**; prod requires it. |
+| `src/Tamma.Api/Services/Provisioning/CranlProvisioningWorkflow.cs` (~355–380) | Missing `Tamma:TenantSharedSecret` → `LogError` and the engine env file is **silently written without** `TAMMA_SHARED_SECRET`. |
+| `src/Tamma.Api/Program.cs` (~425–452) | Secret-store / reveal wiring is conditional on connection strings; misconfiguration either fails fast or silently skips registration. |
+
+**Key gap:** activity `*.FAILED` events from `TammaEventEmitter.EmitFailure`
+(`src/Tamma.Activities/Core/TammaActivity.cs` ~88–128) go to
+`WorkflowExecutionContext.TransientProperties["tamma:events"]` + logs only — **nothing flushes
+them to the DCB `DomainEvents` store**, so the alert rule evaluator can never see workflow-side
+resolution failures. Central-API-side detection (this epic) closes that hole because every engine
+resolution round-trips through the central endpoints.
+
+### Existing notification infrastructure (Story 5.6, Waves C.1–C.2 — substantial, reuse it)
+
+- **Write side:** `IAlertSink.RaiseAsync(AlertPayload)` →
+  `src/Tamma.Api/Services/Alerts/PostgresAlertSink.cs`. Severities critical/warning/info; alert
+  rows + per-channel `alert_delivery_attempts`; emits `ALERT.RAISED` DCB events.
+  `TokenBucketAlertRateLimiter` per RuleId.
+- **Rule engine:** `src/Tamma.Api/Services/Alerts/Rules/AlertRuleEvaluator.cs` — background poller
+  over `ControlPlaneDbContext.DomainEvents` + `PlatformEvents`, matches `alert_rules` by
+  `EventType` + JSON predicate (`always`, `count_gte`), in-process throttle keyed
+  `(ruleId, tenantId)` honoring `ThrottleSeconds`. Built-ins seeded idempotently by
+  `BuiltInAlertRuleSeeder` from `BuiltInAlertRules.All` (5 rules today: BUDGET.EXHAUSTED,
+  AGENT.DISPATCH.FAILED, WORKFLOW.RETRY_EXCEEDED, PLATFORM.API.UNHEALTHY, SECRET.ROTATION.FAILED).
+- **Delivery:** `NotificationDispatcher` background service + channels
+  (`Channels/EmailAlertChannel.cs`, Slack, PagerDuty, Webhook) with retry/backoff. Email transports
+  exist separately too (`Services/Email/ResendEmailService.cs`, `SmtpEmailService.cs`).
+- **API:** `src/Tamma.Api/Endpoints/AlertEndpoints.cs` — `/api/v1/admin/alerts/*` +
+  `/api/v1/admin/alert-channels/*` (OwnerAccess) and tenant-scoped
+  `/api/v1/orgs/{tenantId}/alerts/*` (list/detail/ack/resolve). `AlertRuleEndpoints.cs` for rules.
+- **Dashboard:** **no alert/notification UI exists yet** in `packages/dashboard` (admin tabs:
+  users, tenants, api-keys, health, links, audit-log — `src/pages/admin/AdminLayout.tsx`). SSE
+  exists only for admin tenant events (`Endpoints/Admin/AdminTenantEventsSseEndpoint.cs`).
+- **Event store:** `IEventRepository.AppendAsync(DomainEvent)`
+  (`src/Tamma.Data/Repositories/EventRepository.cs`); CP-resident today; per Story 28-1 audit the
+  evaluator migrates to per-tenant fan-out later with no rule-engine changes.
+
+### Mode + taxonomy seams
+
+- `src/Tamma.Api/Services/PromptStore/TammaMode.cs` — process-wide `ITammaModeProvider`
+  (SingleUser | SaaS; detection per CLAUDE.md "Operating Modes").
+- Taxonomy: `src/Tamma.Core/Agents/RolePhaseMap.cs` (`EligibleActions` frozen role×action matrix),
+  `src/Tamma.Core/Agents/AgentAction.cs`. Prompt system defaults in code:
+  `src/Tamma.Api/Auth/SystemPrompts.cs` (`RoleActionTemplates`, `RoleSystemPrompts`). Convention
+  system defaults DB-seeded from `src/Tamma.Api/Services/Conventions/ConventionSeedSpecs.cs` via
+  `ConventionStoreSeeder` (insert-missing-only).
+
+---
+
+## Architecture
+
+**Detection → record → event → alert → surface**, reusing the alert pipeline end-to-end:
+
+1. **`IMissingConfigRecorder`** (new, `src/Tamma.Api/Services/MissingConfig/`) — the single
+   write-side seam. `RecordAsync(MissingConfigGap gap, CancellationToken)` is fire-and-forget-safe
+   (never throws to callers; callers invoke it immediately before throwing their `TammaError`).
+2. **`config_gaps` table** (CP DB) — the deduplicated registry. Unique on
+   `(scope, tenant_id, user_id, domain, config_key)` (NULLS NOT DISTINCT, mirroring
+   `prompt_overrides`). Columns: scope (`system|tenant|user`), domain
+   (`prompt|convention|provider-chain|platform-config|secret`), config_key (e.g. `qa:write-tests`
+   or `Tamma:TenantSharedSecret`), status (`open|acknowledged|resolved`), severity, message,
+   first_seen, last_seen, hit_count, resolved_at. **Dedup rule:** insert-if-absent emits the event
+   + raises the alert; an existing `open`/`acknowledged` row just bumps `last_seen`/`hit_count` —
+   a hot workflow loop hitting the same gap 1000×/min produces ONE alert, not 1000.
+3. **DCB events** (AGGREGATE.ACTION.STATUS): `CONFIG.MISSING.DETECTED` on first detection,
+   `CONFIG.MISSING.RESOLVED` on resolution. Tags: `scope`, `domain`, `configKey`, `tenantId`,
+   `mode`, `source` (`runtime|scanner`). Appended via `IEventRepository` (CP store — exactly what
+   `AlertRuleEvaluator` polls).
+4. **Built-in alert rules** `config-missing-tenant` (warning) and `config-missing-system`
+   (critical) on `CONFIG.MISSING.DETECTED` with `ThrottleSeconds` belt-and-suspenders on top of
+   registry dedup. Delivery channels come free once linked.
+5. **Gap scanner** (`MissingConfigScanner` BackgroundService, startup + every 6h +
+   on-demand) — *proactive* detection (find gaps before a workflow throws) and *reconciliation*
+   (auto-resolve open gaps whose config now exists, e.g. after a PUT override or seeder reset).
+   Checks: taxonomy completeness (every `RolePhaseMap.EligibleActions` cell has a
+   `SystemPrompts.GetRoleAction` template AND an enabled convention system default), and
+   mode-required platform config (SaaS: `Tamma:TenantSharedSecret`, `ConnectionStrings:ControlPlane`;
+   Cranl enabled ⇒ `Cranl:EncryptionKey` in production; etc.).
+6. **Surfaces:** admin endpoints `/api/v1/admin/config-gaps` (+ ack/resolve/rescan), tenant
+   endpoints `/api/v1/orgs/{tenantId}/config-gaps`; dashboard admin tab + tenant settings banner.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns a **system-scope** gap (missing seed, missing platform config)? | The sole user — it's their instance; gap shows in their (only) feed. | Platform owner ONLY (`OwnerAccess`). Never exposed to tenants — a missing seed or `Cranl:EncryptionKey` is an operator concern and would leak platform internals. |
+| Who owns a **tenant/user-scope** gap (expected override absent, tenant provider chain unconfigured)? | The sole user (`user_id`-keyed, `tenant_id` NULL — same XOR as `prompt_overrides`). | The tenant: visible to `tenant_owner`/`tenant_admin` via `/api/v1/orgs/{tenantId}/config-gaps`; `member` users get read-only list, 403 on ack/resolve (mirrors prompt-store RBAC). |
+| Who can acknowledge/resolve? | The user. | System-scope: platform owner. Tenant-scope: tenant_owner/tenant_admin (or platform owner). |
+| Where do alerts fan out? | Platform feed (TenantId null) = the user's feed; `AlertPayload.TenantId` null. | Tenant-scope gaps raise with `TenantId` set → tenant-scoped channels + tenant alert feed; system-scope raise with `TenantId` null → admin feed only. |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`) — already process-stable. | same |
+
+---
+
+## Story breakdown
+
+### MCN-1: `config_gaps` registry + `IMissingConfigRecorder` + DCB events (core)
+
+**Scope:** New entity/table, recorder service with dedup + event emission + alert raise. No
+call-site wiring yet.
+
+**Files:**
+- New: `src/Tamma.Data/Entities/ConfigGap.cs`; DbSet + model config in
+  `src/Tamma.Data/ControlPlaneDbContext.cs` / `TammaModelConfiguration.cs` (CHECK constraints on
+  scope/domain/status; `UNIQUE NULLS NOT DISTINCT (scope, tenant_id, user_id, domain, config_key)`;
+  principal XOR check: tenant_id/user_id never both set). Additive EF migration under
+  `src/Tamma.Data/Migrations/ControlPlane/` (normal `dotnet ef migrations add` — new table, not a
+  baseline CHECK edit; still run `has-pending-model-changes` → none).
+- New: `src/Tamma.Api/Services/MissingConfig/IMissingConfigRecorder.cs`,
+  `MissingConfigRecorder.cs`, `MissingConfigGap.cs` (record type + `ConfigGapScope`/`ConfigGapDomain`
+  constants), `MissingConfigEventTypes.cs` (`CONFIG.MISSING.DETECTED`, `CONFIG.MISSING.RESOLVED`).
+- New: `src/Tamma.Api/Extensions/MissingConfigServiceCollectionExtensions.cs`; wire in
+  `src/Tamma.Api/Program.cs` (mirror `AlertServiceCollectionExtensions` pattern).
+
+**Tests (first):** `tests/Tamma.Api.Tests/MissingConfig/MissingConfigRecorderTests.cs` —
+first record inserts row + appends `CONFIG.MISSING.DETECTED` + calls `IAlertSink.RaiseAsync` once;
+duplicate record bumps `hit_count`/`last_seen`, NO second event/alert; acknowledged row stays
+deduped; resolved row re-detected → reopens + new DETECTED event; recorder never throws (DB down
+→ logged, swallowed); severity mapping; XOR/CHECK violations rejected.
+
+**Acceptance criteria:**
+- [ ] Recording the same gap N times concurrently yields exactly 1 open row, 1 DETECTED event, 1 alert (race handled via unique-index catch + retry-as-update).
+- [ ] `RecordAsync` never propagates an exception to the caller.
+- [ ] `ResolveAsync(scopeKey)` flips status, stamps `resolved_at`, emits `CONFIG.MISSING.RESOLVED`.
+- [ ] Full suite stays green; migration applies + rolls back cleanly.
+
+### MCN-2: Wire runtime detection points (prompt, convention, provider chain)
+
+**Scope:** Call `IMissingConfigRecorder.RecordAsync` at the existing fail-loud sites, immediately
+before the throw/error-return. Resolution behaviour is byte-for-byte unchanged.
+
+**Files:**
+- Modify: `src/Tamma.Api/Services/PromptStore/PromptStoreService.cs` — at both `NoPromptError`
+  throw sites (user path ~173, tenant path ~389): record gap
+  (domain `prompt`, config_key `"{role}:{action}"`, scope user/tenant per which id is set —
+  but note: a missing **system default** for a taxonomy-valid pair is scope `system`; derive scope
+  from whether the pair is taxonomy-valid, per the doc-comment on `NoPromptError` ~664–670).
+- Modify: `src/Tamma.Api/Services/Conventions/ConventionStore.cs` — `ResolveAsync` throw site
+  (~138), same scope derivation (domain `convention`).
+- Modify: `src/Tamma.Api/Services/Providers/ProviderChainResolver.cs` — "No provider chain
+  configured" path (~86): domain `provider-chain`, config_key `"{role}:{action}"`, scope tenant
+  (SaaS) / user (single-user).
+- DI: these services gain an optional `IMissingConfigRecorder?` ctor param (null-tolerant so
+  existing unit tests don't all need rework — but new tests assert it IS wired in Program.cs).
+
+**Tests (first):** extend `tests/Tamma.Api.Tests/PromptStore/`, `tests/Tamma.Api.Tests/Conventions/`,
+`tests/Tamma.Api.Tests/Providers/` — resolve-miss still throws the identical `TammaError`
+(code/context/severity unchanged) AND records exactly one gap; resolve-hit records nothing;
+recorder failure does not mask the `TammaError`. Endpoint-level test: engine-style
+`POST /api/conventions/resolve` and `POST /api/prompts/{role}/{action}/render` 404s create gaps —
+proving the engine activities (`ResolvePromptFromRegistryActivity`, `ResolveConventionsActivity`)
+are covered server-side with no engine changes.
+
+**Acceptance criteria:**
+- [ ] Every `PROMPT.RESOLVE.NO_DEFAULT` / `CONVENTION_NOT_FOUND` / no-chain occurrence leaves a `config_gaps` row.
+- [ ] Zero change to thrown error codes, messages, HTTP status mapping, or resolution order.
+- [ ] Hot-loop test: 100 sequential misses on one pair → 1 open gap, 1 alert.
+
+### MCN-3: Proactive gap scanner + reconciliation
+
+**Scope:** `MissingConfigScanner` BackgroundService — startup scan, periodic (default 6h,
+configurable `MissingConfig:ScanInterval`), and an injectable `ScanOnceAsync` for tests +
+on-demand trigger (MCN-5). Two jobs: detect gaps proactively; auto-resolve open gaps whose config
+now exists (covers PUT-override/seeder-reset healing without hooking every upsert path).
+
+**Files:**
+- New: `src/Tamma.Api/Services/MissingConfig/MissingConfigScanner.cs`,
+  `MissingConfigScannerOptions.cs` (RunOnStartup gate mirroring `AlertRuleEvaluatorOptions` /
+  `NotificationDispatcherOptions`), `IPlatformConfigRequirements.cs` +
+  `PlatformConfigRequirements.cs` (pure, mode-aware required-key list:
+  SaaS ⇒ `Tamma:TenantSharedSecret`, `ConnectionStrings:ControlPlane`; Cranl:ApiKey set +
+  production ⇒ `Cranl:EncryptionKey`; extensible table — keep it data, not branches).
+- Checks (pure helpers, DB-free where possible, mirroring `ConventionSeedSpecs` style):
+  taxonomy × `SystemPrompts.RoleActionTemplates` (scope system, domain prompt); taxonomy ×
+  enabled convention system defaults via `IConventionRepository` (scope system, domain
+  convention); platform config (scope system, domain platform-config).
+- Wire in `Program.cs` via the MCN-1 extension.
+
+**Tests (first):** `tests/Tamma.Api.Tests/MissingConfig/MissingConfigScannerTests.cs` — seeded-
+complete world → zero gaps; remove one convention system default → scanner opens exactly one
+system gap; restore it → next scan resolves it + emits `CONFIG.MISSING.RESOLVED`; mode matrix
+(SingleUser vs SaaS) drives which platform keys are required; scanner crash-isolated per tick
+(one failing check doesn't kill the loop); `RunOnStartup=false` gates the loop for unrelated tests.
+
+**Acceptance criteria:**
+- [ ] Fresh deploy with intact seeds + complete config scans clean.
+- [ ] A gap fixed via `PUT /api/prompts/...` or seeder reset is auto-resolved within one scan (or immediately via MCN-5 rescan).
+- [ ] Scanner honours `ITammaModeProvider` — no SaaS-only keys flagged in single-user mode.
+
+### MCN-4: Built-in alert rules for config gaps
+
+**Scope:** Two new specs in `BuiltInAlertRules.All`: `config-missing-system` (severity critical,
+EventType `CONFIG.MISSING.DETECTED`, predicate `{"op":"always"}` — registry dedup already gates
+volume; ThrottleSeconds 300) and `config-missing-tenant` (severity warning, ThrottleSeconds 300).
+Distinguish via predicate on the `scope` tag — extend `AlertRulePredicate` with a `tag_equals` op
+ONLY if it doesn't already support tag matching (verify `AlertRulePredicate.cs` first; if
+predicates can't read tags, ship one rule and let `AlertPayload.TenantId` null/non-null do the
+feed split — the simpler option wins).
+
+**Files:** modify `src/Tamma.Api/Services/Alerts/Rules/BuiltInAlertRules.cs` (+ possibly
+`AlertRulePredicate.cs`); seeder picks them up automatically (`BuiltInAlertRuleSeeder` is
+idempotent insert-by-`built_in_key`).
+
+**Tests (first):** extend `tests/Tamma.Api.Tests/Alerts/` — seeder creates the new rules;
+evaluator fires on an appended `CONFIG.MISSING.DETECTED` event; tenant-scoped event → alert with
+TenantId (tenant feed); system event → platform alert; throttle suppresses a burst.
+
+**Acceptance criteria:**
+- [ ] `CONFIG.MISSING.DETECTED` events produce alerts visible at `/api/v1/admin/alerts` (and `/api/v1/orgs/{id}/alerts` for tenant scope) with no manual rule setup.
+- [ ] Built-ins ship with empty ChannelIds (no auto-spam) per existing convention.
+
+### MCN-5: Config-gaps API endpoints
+
+**Scope:** Read + lifecycle endpoints over the registry, per-mode RBAC.
+
+```
+GET   /api/v1/admin/config-gaps                 (OwnerAccess; filters: scope, domain, status, tenantId)
+POST  /api/v1/admin/config-gaps/{id}/acknowledge
+POST  /api/v1/admin/config-gaps/{id}/resolve     (manual override; scanner may reopen if still missing)
+POST  /api/v1/admin/config-gaps/rescan           (202; triggers ScanOnceAsync via the platform task queue pattern)
+GET   /api/v1/orgs/{tenantId}/config-gaps        (tenant members; tenant-scope rows ONLY — never system rows)
+POST  /api/v1/orgs/{tenantId}/config-gaps/{id}/acknowledge  (tenant_owner/tenant_admin; member → 403)
+```
+
+**Files:** new `src/Tamma.Api/Endpoints/ConfigGapEndpoints.cs` (mirror `AlertEndpoints.cs`
+structure: admin section + tenant section, paging defaults 50/500); map in `Program.cs`.
+
+**Tests (first):** `tests/Tamma.Api.Tests/MissingConfig/ConfigGapEndpointsTests.cs` — RBAC matrix
+(owner / tenant_owner / tenant_admin / member / cross-tenant 404), tenant list never leaks
+system-scope or other-tenant rows, ack emits no DETECTED/RESOLVED event (status-only), rescan
+returns 202 and a subsequent GET reflects scan results, single-user mode: sole user sees
+system + user rows in one list.
+
+**Acceptance criteria:**
+- [ ] Endpoint shape identical between modes; auth middleware decides scope (prompt-store API precedent).
+- [ ] Acknowledged gaps stay deduped (no new alerts) but remain listed until resolved.
+
+### MCN-6: Dashboard surfaces
+
+**Scope:** Minimal visible surface — admin tab + tenant banner. No channel management UI.
+
+**Files:**
+- New: `packages/dashboard/src/services/admin/config-gaps-client.ts` (mirror
+  `admin-api-client.ts` conventions).
+- New: `packages/dashboard/src/pages/admin/ConfigGapsTab.tsx`; register in
+  `packages/dashboard/src/pages/admin/AdminLayout.tsx` (`AdminTab` union + `TABS`). Columns:
+  scope, domain, config key, severity, first/last seen, hit count, status; ack/resolve actions;
+  open-count badge on the tab label.
+- New: `packages/dashboard/src/components/config-gaps/ConfigGapsBanner.tsx` — tenant-facing
+  banner rendered on `packages/dashboard/src/pages/settings/PromptsPage.tsx` and
+  `ConventionsPage.tsx` when `GET /api/v1/orgs/{tenantId}/config-gaps?status=open` is non-empty,
+  deep-linking to the affected (role, action) editor.
+
+**Tests (first):** colocated Vitest + Testing Library (existing pattern, e.g.
+`components/secrets/__tests__/`) — tab renders rows/states, ack button calls client + optimistic
+update, banner hidden when zero gaps, member-role sees banner without ack button.
+
+**Acceptance criteria:**
+- [ ] Platform owner sees all gaps in admin panel; tenant admin sees only their tenant's gaps in settings.
+- [ ] `pnpm test --filter @tamma/dashboard` green; no new lint errors.
+
+### MCN-7 (stretch, explicitly deferrable): provisioning + secret-protector detection
+
+**Scope:** Record gaps at the two silent-degrade provisioning sites:
+`CranlProvisioningWorkflow` writing an engine env file without `TAMMA_SHARED_SECRET` (~364), and
+`TenantSecretProtector` dev-only HKDF fallback (~125–140) when running outside Development.
+Domain `secret`/`platform-config`, scope system. (MCN-3's static checks catch most of this at
+scan time; this story adds the in-flight detection.) Defer if the wave runs long — the scanner
+coverage is the 80%.
+
+**Tests:** extend `tests/Tamma.Api.Tests/Provisioning/` — env-file build without secret records a
+gap; protector fallback outside Development records a gap; behaviour otherwise unchanged.
+
+---
+
+## Story order & dependencies
+
+MCN-1 → MCN-2 → MCN-3 → MCN-4 (parallel-safe with 3) → MCN-5 → MCN-6 → MCN-7 (optional).
+MCN-1 is the only hard prerequisite for everything else; MCN-4/5 only need MCN-1.
+
+## Risks
+
+- **Alert noise / spam:** primary mitigation is registry dedup (one open row = one alert),
+  secondary is rule ThrottleSeconds, tertiary is sink rate limiter. Watch the reopen path: a
+  flapping gap (resolved by scanner, re-detected at runtime) re-alerts by design — if flapping is
+  observed, add a reopen-cooldown column (cheap follow-up).
+- **Recorder on the hot resolve path:** `RecordAsync` does a DB write on every miss. Misses are
+  exceptional (fail-loud bugs), so volume should be near-zero — but the never-throw +
+  short-timeout contract in MCN-1 is load-bearing; a broken CP DB must not turn a 404 into a hang.
+- **Event-store topology shift (Story 28-1 / Epic 30):** `CONFIG.MISSING.*` events append to the
+  CP `DomainEvents` table the evaluator polls today. When events move per-tenant, system-scope
+  events must stay CP-resident — keep the recorder writing system-scope events via the CP
+  `IEventRepository` explicitly so the migration only touches tenant-scope routing.
+- **Scope derivation subtlety (MCN-2):** taxonomy-valid pair missing a system default = `system`
+  scope (seed bug, platform owner's problem); taxonomy-valid pair where only the expected tenant
+  override is absent cannot happen today (system default backstops it) — so runtime tenant-scope
+  prompt/convention gaps only arise for provider chains. Get the derivation wrong and tenants get
+  paged for platform bugs. The MCN-2 tests must pin this matrix.
+- **Migration discipline:** Phase-0 collapsed-baseline rules apply to CHECK *edits* on existing
+  tables; `config_gaps` is additive, but still verify `has-pending-model-changes` reports none
+  after the migration, and mirror entity config in `TammaModelConfiguration.cs` only (the
+  established single source).
+- **Predicate capability unknown (MCN-4):** whether `AlertRulePredicate` can match event tags is
+  unverified — story starts by reading `AlertRulePredicate.cs` and takes the simpler of the two
+  designs described there.


### PR DESCRIPTION
## Summary
Four implementation plans prepared against current main (post-#343), each with current-state verification (file:line evidence), phased/story breakdown, risks, and acceptance criteria:

- `2026-06-11-epic-30-pluggable-provisioning.md` — V2 provider surface exists but has zero production callers; 5 phases to cut over, reconcile Cranl with the unified tenancy model, tighten the 2 transitional CHECKs, close out 28-1
- `2026-06-11-epic-6-implementation.md` — refresh: old plan targeted deleted `packages/api`; real gap is the empty services bundle in `packages/intelligence-server` + 153 masked strict-mode errors in `@tamma/intelligence`
- `2026-06-11-content-sanitization-security-hooks.md` — refresh: ~half shipped under Epic 9; remaining 5 integration paths re-scoped
- `2026-06-11-missing-config-notifications.md` — new epic, 7 stories, reuses the Story 5.6 alert pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)