### PR TITLE
ci: deploy to VPS only on qa-* tag push

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,10 +1,16 @@
 # =============================================================================
 # Build & Publish Docker Images + Deploy
 #
-# Builds all Tamma Docker images, pushes to GHCR, then deploys to VPS.
+# Builds all Tamma Docker images and pushes to GHCR on every push/PR.
 # - main: tagged as :main and :sha-<commit>
-# - tags: tagged as :v1.2.3 and :latest
+# - v* tags: tagged as :v1.2.3 and :latest (release images; NOT deployed)
+# - qa-* tags: tagged as :sha-<commit> AND deployed to the VPS
 # - PRs: tagged as :pr-<number>
+#
+# DEPLOY runs ONLY on a `qa-*` tag push. Pushing to main, opening a PR, or
+# cutting a v* release tag builds/publishes images but never touches the VPS.
+# This makes VPS deploys deliberate and serial — eliminating the prior race
+# where concurrent PR/main deploys collided on the shared host.
 #
 # All Docker steps retry up to 3 times to handle Docker Hub rate limits.
 # =============================================================================
@@ -14,7 +20,7 @@ name: Build & Publish Docker Images
 on:
   push:
     branches: [main]
-    tags: ['v*']
+    tags: ['v*', 'qa-*']
   pull_request:
     branches: [main]
 
@@ -327,6 +333,9 @@ jobs:
   deploy:
     name: Deploy to VPS
     needs: [build-ts, build-dashboard, build-dotnet, build-intelligence-server]
+    # Deploy ONLY on a qa-* tag push. PRs, main pushes, and v* release tags
+    # build/publish images but never deploy.
+    if: startsWith(github.ref, 'refs/tags/qa-')
     runs-on: ubuntu-latest
     timeout-minutes: 15
 


### PR DESCRIPTION
## Problem
The `deploy` job in `docker-publish.yml` had **no ref gate** — it ran on every PR-to-main and every main push. Combined with a per-branch concurrency group (`docker-${{ github.ref }}`), concurrent PR/main deploys raced on the single shared VPS. That's what caused the 2026-06-11 deploy failures (`Conflict. The container name "/docker-rabbitmq-1" is already in use` during the volume-reset path) — an infrastructure race, not a code defect.

## Change
- **Deploy gated to `refs/tags/qa-*` only** (`if: startsWith(github.ref, 'refs/tags/qa-')`).
- Added `qa-*` to the build triggers so images are built/published for a QA tag.
- PRs, main pushes, and `v*` release tags still **build & publish** images — they just never touch the VPS.
- A deploy now happens **only when a `qa-*` tag is pushed**, making deploys deliberate and serial (race eliminated by design).
- The QA tag's commit is deployed via its `sha-<short>` image, which `docker/metadata-action`'s `type=sha` already produces on tag pushes (the deploy's "Determine image tag" step already resolves to `sha-<short>` for non-PR events).

## How to deploy after this lands
```
git tag qa-$(date +%Y%m%d-%H%M) <commit>   # e.g. qa-20260616-1430
git push origin qa-20260616-1430
```

Note: this PR will **not** trigger a deploy (it's a PR), which is the intended new behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)