### PR TITLE
docs(epics): Epics 32/34/35/36/37 — agents, pricing, billing, analytics, audit (59 stories)

### DIFF
--- a/docs/sprint-status.yaml
+++ b/docs/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2025-10-29
-# updated: 2026-06-16 (full codebase audit: 32 epics re-verified against code; superseded items flagged; +25 discovered stories)
+# updated: 2026-06-17 (added Epics 32/34/35/36/37 — 59 drafted stories for agents/pricing/billing/analytics/audit; Epic 20 superseded)
 # project: Tamma
 # project_key: Tamma
 # tracking_system: file-system
@@ -271,11 +271,11 @@ development_status:
   epic-19-retrospective: optional
 
   epic-20: contexted
-  20-1-stripe-integration-plan-model: drafted       # No Stripe SDK or customer-create. Plan.cs catalogue exists but is tenancy placement (Epic 28), not the Stripe plan/customer model.
-  20-2-subscription-management: drafted             # No subscription CRUD, checkout, portal, or webhook handler. Spec only.
-  20-3-usage-metering: drafted                      # No usage metering: no meter events, capture hooks, or aggregation. Spec only.
-  20-4-usage-limits-enforcement: drafted            # No limit enforcement. Plan.Quotas JSON defined but unused by any billing/orchestrator check.
-  20-5-billing-dashboard: drafted                   # No billing dashboard UI in dashboard or dashboard-user. Spec only.
+  20-1-stripe-integration-plan-model: superseded       # No Stripe SDK or customer-create. Plan.cs catalogue exists but is tenancy placement (Epic 28), not the Stripe plan/customer model.  → superseded by Epic 34 (plan model) + 35-1 (Stripe)
+  20-2-subscription-management: superseded             # No subscription CRUD, checkout, portal, or webhook handler. Spec only.  → superseded by Epic 35-4 (subscription lifecycle)
+  20-3-usage-metering: superseded                      # No usage metering: no meter events, capture hooks, or aggregation. Spec only.  → superseded by Epic 35-3 (metering) + 32-9 (usage producer) + Epic 36 (analytics)
+  20-4-usage-limits-enforcement: superseded            # No limit enforcement. Plan.Quotas JSON defined but unused by any billing/orchestrator check.  → superseded by Epic 34-6 (entitlements) + 35-6 (enforcement)
+  20-5-billing-dashboard: superseded                   # No billing dashboard UI in dashboard or dashboard-user. Spec only.  → superseded by Epic 35-11 (billing dashboard) + 36-6 (analytics dashboard)
   epic-20-retrospective: optional
 
   epic-21: contexted
@@ -413,4 +413,79 @@ development_status:
   # Epic 33 (Per-Tenant Identity Providers) is explicitly DEFERRED per docs/stories/epic-33/README.md
   # Forward-looking stub only — no stories drafted; will be scoped when an enterprise SSO trigger fires
   epic-33-retrospective: optional
+
+
+  epic-32: contexted   # NEW Agents — entities, managed execution, benchmarking & learning (added 2026-06-17; all stories drafted)
+  32-1-agent-entity-model-and-versioned-saved-config: drafted # Agent Entity Model & Versioned Saved Config (public/private) [P0]
+  32-2-agent-registry-resolution-and-rbac-api: drafted # Agent Registry, Resolution & RBAC API [P0]
+  32-3-per-tenant-provider-credential-resolution: drafted # Per-Tenant Provider Credential Resolution (BYOK → platform) [P0]
+  32-4-saas-provider-auth-gating-api-key-only: drafted # SaaS Provider Auth Gating — API-key only (CLI/token providers single-user only) [P0]
+  32-5-managed-agent-execution-layer: drafted         # Managed Agent Execution Layer (IManagedAgent over IAIProvider) [P0]
+  32-6-agent-action-trail-in-tenant-store: drafted    # Agent Action Trail (DCB events tagged agent_id) in Tenant Store [P0]
+  32-7-multi-agent-design-review-panels-in-elsa: drafted # Multi-Agent Design/Review Panels in Elsa (strategy-driven) [P1]
+  32-8-outcome-capture-and-bug-taxonomy-at-review-gate: drafted # Outcome Capture & Bug Taxonomy at Review/Gate [P1]
+  32-9-cost-basis-plus-margin-metering-and-byok-pricing-model: drafted # Cost-Basis-Plus-Margin Metering & BYOK Pricing Model (re-targets Epic 20) [P1]
+  32-10-benchmark-projections-and-leaderboards: drafted # Benchmark Projections & Leaderboards (per agent/provider/prompt, per-tenant) [P1]
+  32-11-learning-persistence-and-auto-learning-into-rag: drafted # Learning Persistence & Auto-Learning into RAG [P1]
+  32-12-agent-personas-and-persona-aware-benchmarking: drafted # Agent Personas & Persona-Aware Benchmarking [P2]
+  32-13-agent-management-and-benchmark-dashboards: drafted # Agent Management & Benchmark Dashboards (admin public + tenant private) [P2]
+  32-14-a-b-experiment-framework-for-agents: drafted  # A/B Experiment Framework for Agents (Phase 2: cohorts, significance, rollout/rollback) [P2]
+  epic-32-retrospective: optional
+
+  epic-34: contexted   # NEW Pricing, Plans & Entitlements (added 2026-06-17; all stories drafted)
+  34-1-plan-and-price-book-catalog-data-model: drafted # Plan & Price-Book Catalog Data Model [P0]
+  34-2-plan-catalog-admin-api-and-custom-enterprise-plans: drafted # Plan Catalog Admin API & Custom Enterprise Plans [P0]
+  34-3-byok-vs-platform-provided-pricing-mode: drafted # BYOK vs Platform-Provided Pricing Mode (per-provider, secret-cabinet wired) [P0]
+  34-4-per-tenant-plan-assignment-and-lifecycle: drafted # Per-Tenant Plan Assignment & Lifecycle [P0]
+  34-5-cost-price-markup-engine: drafted              # Cost->Price Markup Engine (platform-provided usage) [P0]
+  34-6-entitlement-and-quota-resolution-service: drafted # Entitlement & Quota Resolution Service [P0]
+  34-7-trials-credits-and-promo-codes: drafted        # Trials, Credits & Promo Codes [P1]
+  34-8-pricing-audit-events-and-reproducibility: drafted # Pricing Audit, Events & Reproducibility [P1]
+  34-9-pricing-and-plan-management-dashboards: drafted # Pricing & Plan Management Dashboards [P1]
+  34-10-epic-20-decommission-and-pricing-contract-migration: drafted # Epic 20 Decommission & Pricing Contract Migration [P0]
+  epic-34-retrospective: optional
+
+  epic-35: contexted   # NEW Billing & Payments (C#) — supersedes Epic 20 (added 2026-06-17; all stories drafted)
+  35-1-stripe-integration-foundation-billing-plan-catalog-and-custo: drafted # Stripe Integration Foundation, Billing Plan Catalog & Customer Mapping (C#) [P0]
+  35-2-byok-vs-platform-provided-billing-mode-and-per-tenant-provid: drafted # BYOK vs Platform-Provided Billing Mode & Per-Tenant Provider Key Cabinet Integration [P0]
+  35-3-byok-aware-usage-metering-and-stripe-meter-event-reporting: drafted # BYOK-Aware Usage Metering & Stripe Meter Event Reporting [P0]
+  35-4-subscription-lifecycle-create-upgrade-downgrade-cancel-trial: drafted # Subscription Lifecycle — Create, Upgrade/Downgrade, Cancel, Trial & Proration [P0]
+  35-5-stripe-webhook-ingestion-idempotency-and-billing-event-proje: drafted # Stripe Webhook Ingestion, Idempotency & Billing Event Projection [P0]
+  35-6-plan-quota-and-usage-limit-enforcement: drafted # Plan Quota & Usage-Limit Enforcement (BYOK-Aware) [P0]
+  35-7-payment-methods-and-self-service-stripe-billing-portal: drafted # Payment Methods & Self-Service Stripe Billing Portal [P1]
+  35-8-invoicing-failed-payment-dunning-and-recovery: drafted # Invoicing, Failed-Payment Dunning & Recovery [P0]
+  35-9-tax-calculation-and-compliance: drafted        # Tax Calculation & Compliance (Stripe Tax / VAT) [P1]
+  35-10-credits-and-prepaid-wallet-ledger: drafted    # Credits & Prepaid Wallet Ledger [P2]
+  35-11-tenant-billing-dashboard-and-admin-billing-console: drafted # Tenant Billing Dashboard (dashboard-user) & Admin Billing Console (dashboard) [P1]
+  35-12-billing-audit-reconciliation-and-revenue-analytics: drafted # Billing Audit, Reconciliation & Revenue Analytics [P1]
+  epic-35-retrospective: optional
+
+  epic-36: contexted   # NEW Analytics & Reporting Platform (added 2026-06-17; all stories drafted)
+  36-1-dimensional-analytics-projection-schema-and-store: drafted # Dimensional Analytics Projection Schema & Store [P0]
+  36-2-dcb-to-analytics-projection-pipeline: drafted  # DCB-to-Analytics Projection Pipeline (Dimensional Rollup) [P0]
+  36-3-tenant-usage-analytics-api: drafted            # Tenant Usage Analytics API [P0]
+  36-4-cost-and-spend-analytics-api: drafted          # Cost & Spend Analytics API (BYOK vs Platform) [P0]
+  36-5-agent-and-tenant-performance-rollups-api: drafted # Agent & Tenant Performance Rollups API (consume Epic 32) [P1]
+  36-6-tenant-analytics-dashboard-ui: drafted         # Tenant Analytics Dashboard UI [P1]
+  36-7-pricing-cost-basis-and-platform-margin-model: drafted # Pricing / Cost-Basis & Platform Margin Model [P0]
+  36-8-analytics-exports: drafted                     # Analytics Exports (CSV / PDF) [P1]
+  36-9-scheduled-reports-and-delivery: drafted        # Scheduled Reports & Delivery [P2]
+  36-10-platform-business-analytics: drafted          # Platform Business Analytics (Owner-Only: MRR, Churn, Conversion) [P1]
+  36-11-analytics-event-catalog-backfill-and-reconciliation: drafted # Analytics Event Catalog, Backfill & Reconciliation [P2]
+  epic-36-retrospective: optional
+
+  epic-37: contexted   # NEW Audit, Compliance & Data Governance (added 2026-06-17; all stories drafted)
+  37-1-sensitive-action-audit-taxonomy-and-curated-audit-record-pro: drafted # Sensitive-Action Audit Taxonomy & Curated Audit-Record Projection [P0]
+  37-2-tamper-evident-hash-chain-over-audit-records: drafted # Tamper-Evident Hash-Chain over Audit Records [P0]
+  37-3-audit-query-search-and-filter-api: drafted     # Audit Query, Search & Filter API [P0]
+  37-4-signed-audit-export-with-integrity-manifest: drafted # Signed Audit Export (JSON/CSV) with Integrity Manifest [P1]
+  37-5-audit-retention-policies-and-tamper-aware-pruning: drafted # Audit Retention Policies & Tamper-Aware Pruning [P1]
+  37-6-legal-hold: drafted                            # Legal Hold [P1]
+  37-7-gdpr-dsar-data-subject-access-export: drafted  # GDPR DSAR — Data Subject Access Export [P1]
+  37-8-gdpr-right-to-erasure-with-crypto-shredding-and-audit-preser: drafted # GDPR Right-to-Erasure with Crypto-Shredding & Audit Preservation [P1]
+  37-9-consent-and-data-processing-logging: drafted   # Consent & Data-Processing Logging [P2]
+  37-10-sensitive-action-audit-emission-coverage: drafted # Sensitive-Action Audit Emission Coverage (BYOK, Billing/Plan, Auth/Login, Agent Actions) [P0]
+  37-11-soc2-aligned-control-mapping-and-evidence-pack: drafted # SOC2-Aligned Control Mapping & Evidence Pack [P2]
+  37-12-admin-and-tenant-audit-dashboard-ui: drafted  # Admin & Tenant Audit Dashboard UI [P1]
+  epic-37-retrospective: optional
 

--- a/docs/stories/README.md
+++ b/docs/stories/README.md
@@ -14,7 +14,14 @@ Stories are organized into epic-specific subdirectories:
 - **`epic-6/`** - Context & Knowledge Management (10 stories)
 - **`epic-7/`** - Autonomous Mentorship Workflow (10 stories)
 - **`epic-8/`** - Distribution & Installation (8 stories)
-- **`epic-20/`** - Billing & Payments (5 stories)
+- **`epic-20/`** - Billing & Payments (5 stories) — **superseded by Epics 34 & 35** (re-targeted to the C# `apps/tamma-elsa` stack)
+- **`epic-32/`** - Agents — First-Class Agent Entities, Managed Execution, Benchmarking & Learning (14 stories)
+- **`epic-34/`** - Pricing, Plans & Entitlements (10 stories)
+- **`epic-35/`** - Billing & Payments (C#) — Stripe, BYOK-Aware Metering, Subscriptions, Invoicing & Dunning (12 stories)
+- **`epic-36/`** - Analytics & Reporting Platform (11 stories)
+- **`epic-37/`** - Audit, Compliance & Data Governance (12 stories)
+
+> Note: this list is illustrative, not exhaustive — see each `epic-N/README.md` for the canonical per-epic detail and `docs/sprint-status.yaml` for live status across all epics.
 
 ## File Types
 

--- a/docs/stories/epic-32/README.md
+++ b/docs/stories/epic-32/README.md
@@ -1,0 +1,296 @@
+# Epic 32: Agents — First-Class Agent Entities, Managed Execution, Benchmarking & Learning
+
+## Overview
+
+Today agents are an **implicit** concept in Tamma. `agent_configs` is a tenant-scoped JSONB blob keyed by role (`Tamma.Data.Entities.AgentConfig`) merged into a `ResolvedAgentConfig`; provider API keys are global environment variables (`CallLlmInlineActivity` reads `_configuration["Anthropic:ApiKey"]`); performance lives in an undifferentiated `ProviderDiagnostic` table; and multi-agent review is a hardcoded 4-role sequence (`TriagePanelReviewWorkflow`).
+
+Epic 32 promotes agents into **first-class, versioned, identity-bearing entities**. An **Agent** is a saved configuration given a stable identity — tracked along two dimensions: **what it did** (an `agent_id`-tagged action trail) and **how well it did** (a per-tenant performance dataset). Each agent has an immutable `agent_id` + stable `name` + `role`, plus a monotonically-versioned saved config (provider chain / prompt / budget / tools / temperature / RAG). Visibility is **public** (system, platform-admin-owned, available to all tenants) or **private** (tenant-owned, available only to it); shipped defaults are public.
+
+The epic adds: a **managed-LLM-agent execution layer** (`IManagedAgent` over the existing `IAIProvider`/inline tool-loop HTTP path) — distinct from CLI/token agent providers (`ICLIAgentProvider`, which stay single-user/self-hosted only because **SaaS = API-key auth only**); **strategy-driven multi-agent panels** in Elsa; an `agent_id`-tagged **DCB action trail** in the tenant store; **outcome + bug-taxonomy capture** at review/gate; **benchmark projections + leaderboards** (per agent / provider / prompt, per-tenant); **BYOK-then-platform** credential resolution from the Epic 29 secret cabinet; a per-tenant **cost-basis-plus-margin metering** model that re-targets Epic 20 billing; **learning persistence + auto-learning into RAG**; and a Phase-2 **A/B experiment framework**.
+
+### The key tenancy rule (definition ownership ≠ data ownership)
+
+| Concern | Scope |
+|---|---|
+| **Agent definition** | **Public/system-wide** (platform-admin-owned, available to every tenant) **OR** **private/tenant-owned** (tenant-owned, available only to it). Shipped defaults are public. |
+| **Performance + action data** | **ALWAYS tenant-scoped** — belongs to the tenant that generated it; never system-wide, never cross-tenant. |
+
+- A tenant's usable agent set = **all public agents ∪ its own private agents**.
+- **One-to-many**: one agent definition → many independent per-tenant performance/action datasets. Two tenants running public agent `atlas` build *separate, private* profiles; neither sees the other's; the platform admin who owns `atlas` sees **none** of it.
+- Leaderboards/benchmarks are computed **within a tenant's own data**.
+
+This maps onto the unified schema-per-tenant model: **public agent definitions** live in the **control-plane** (`ControlPlaneDbContext`, shared, referenced by `agent_id`); **private agent definitions + all performance/action data** live in the **tenant's `t_<hex>` schema** (`TenantDbContext`) — isolation is structural. In **single-user mode**, "public" = shipped system agents, the sole user owns/creates private ones, and performance is the user's.
+
+### Supersedes
+
+Epic 32 is the canonical owner of the agent entity, execution, and tracking model. It **supersedes** the following earlier, now-replaced approaches:
+
+- **Story 1-13** (agent customization) — superseded by the first-class `Agent` + versioned `AgentVersion` entity (32-1) and the registry/RBAC API (32-2).
+- **Story 1-14** (performance analysis) — superseded by the `agent_id`-tagged action trail (32-6), benchmark projections + leaderboards (32-10), and the per-tenant performance dataset model.
+- **Epic 20 stories 20-3 / 20-4 / 20-5 (in part)** — usage metering, limit-enforcement injection, and the billing-dashboard data source are re-targeted by the cost-basis-plus-margin metering producer (32-9) and the agent/benchmark dashboards (32-13); Epic 32 *produces* the per-tenant cost data those billing surfaces consume.
+- **The `AgentConfig` role-keyed JSONB blob + `AgentSeeder`** — superseded by `Agent`/`AgentVersion` (CP-resident definitions) and the insert-missing-only `AgentEntitySeeder`. The legacy blob coexists during cutover, then retires.
+- **The hardcoded `TriagePanelReviewWorkflow`** — superseded by strategy-driven multi-agent panels (`RunAgentPanelActivity` / `AggregatePanelActivity`, 32-7).
+
+## Stories
+
+| Story | Title | Priority | Status | Est. Effort |
+|-------|-------|----------|--------|-------------|
+| 32-1 | Agent Entity Model & Versioned Saved Config (public/private) | P0 | drafted | 4-5 days |
+| 32-2 | Agent Registry, Resolution & RBAC API | P0 | drafted | 4-5 days |
+| 32-3 | Per-Tenant Provider Credential Resolution (BYOK → platform) | P0 | drafted | 4-5 days |
+| 32-4 | SaaS Provider Auth Gating — API-key only (CLI/token providers single-user only) | P0 | drafted | 2-3 days |
+| 32-5 | Managed Agent Execution Layer (`IManagedAgent` over `IAIProvider`) | P0 | drafted | 5-6 days |
+| 32-6 | Agent Action Trail (DCB events tagged `agent_id`) in Tenant Store | P0 | drafted | 4-5 days |
+| 32-7 | Multi-Agent Design/Review Panels in Elsa (strategy-driven) | P1 | drafted | 5-6 days |
+| 32-8 | Outcome Capture & Bug Taxonomy at Review/Gate | P1 | drafted | 3-4 days |
+| 32-9 | Cost-Basis-Plus-Margin Metering & BYOK Pricing Model (re-targets Epic 20) | P1 | drafted | 4-5 days |
+| 32-10 | Benchmark Projections & Leaderboards (per agent/provider/prompt, per-tenant) | P1 | drafted | 4-5 days |
+| 32-11 | Learning Persistence & Auto-Learning into RAG | P1 | drafted | 4-5 days |
+| 32-12 | Agent Personas & Persona-Aware Benchmarking | P2 | drafted | 3-4 days |
+| 32-13 | Agent Management & Benchmark Dashboards (admin public + tenant private) | P2 | drafted | 4-5 days |
+| 32-14 | A/B Experiment Framework for Agents (Phase 2: cohorts, significance, rollout/rollback) | P2 | drafted | 5-6 days |
+
+## Architecture
+
+```
++-----------------------------------------------------------------------------+
+|        EPIC 32: AGENTS — ENTITIES, EXECUTION, BENCHMARKING, LEARNING         |
++-----------------------------------------------------------------------------+
+|                                                                             |
+|  +-- LAYER 1: Agent Entity & Registry (32-1, 32-2) -------------------+     |
+|  |   CONTROL PLANE (shared)                | TENANT t_<hex> (isolated)|     |
+|  |   +--------------------+ +-----------+  | +--------------------+   |     |
+|  |   | Agent (identity)   | | Agent     |  | | Private agent defs |   |     |
+|  |   | id/name/role/      | | Version   |  | | (tenant-owned)     |   |     |
+|  |   | visibility (pub)   | | (config   |  | +--------------------+   |     |
+|  |   +--------------------+ |  snapshot)|  |                          |     |
+|  |   Registry + RBAC API: all public U caller's own private          |     |
+|  +------------------------------------------------------------------+      |
+|                              |                                              |
+|  +-- LAYER 2: Credential & Auth (32-3, 32-4) ------------------------+     |
+|  |   +------------------+  +------------------+  +------------------+ |     |
+|  |   | BYOK -> platform |  | Epic 29 secret   |  | SaaS gate:       | |     |
+|  |   | resolution       |  | cabinet (BYOK)   |  | API-key ONLY;    | |     |
+|  |   | (per tenant)     |  |                  |  | CLI = single-user| |     |
+|  |   +------------------+  +------------------+  +------------------+ |     |
+|  +------------------------------------------------------------------+      |
+|                              |                                              |
+|  +-- LAYER 3: Managed Execution (32-5) over IAIProvider --------------+    |
+|  |   IManagedAgent.RunAsync:                                          |    |
+|  |   resolve agent -> resolve credential -> SaaS gate ->             |    |
+|  |   context+RAG -> prompt render -> [reused inline tool loop] ->    |    |
+|  |   sanitize -> instrument (cost basis) -> AgentRunResult           |    |
+|  |   (distinct from ICLIAgentProvider; converge on AgentRunResult)  |    |
+|  +------------------------------------------------------------------+      |
+|                              |                                              |
+|  +-- LAYER 4: Panels (32-7) -----------------------------------------+     |
+|  |   RunAgentPanelActivity (fan-out N agents) ->                     |    |
+|  |   AggregatePanelActivity (single|consensus|lead+critics|         |    |
+|  |   llm-judge-merge). Design: lead+critics. Review: consensus.     |    |
+|  +------------------------------------------------------------------+      |
+|                              |                                              |
+|  +-- LAYER 5: Tracking — TENANT-SCOPED ALWAYS (32-6, 32-8, 32-9) ----+     |
+|  |   +------------------+  +------------------+  +------------------+ |     |
+|  |   | Action trail     |  | Outcome + bug    |  | Usage & cost     | |     |
+|  |   | DCB tagged       |  | taxonomy at      |  | emission         | |     |
+|  |   | agent_id (t_hex) |  | review/gate      |  | (producer ->     | |     |
+|  |   |                  |  | (bugType)        |  |  Epics 34/35/36) | |     |
+|  |   +------------------+  +------------------+  +------------------+ |     |
+|  +------------------------------------------------------------------+      |
+|                              |                                              |
+|  +-- LAYER 6: Benchmarking, Learning, Personas (32-10..32-14) -------+     |
+|  |   +------------------+  +------------------+  +------------------+ |     |
+|  |   | Leaderboards     |  | Learning persist |  | Personas +       | |     |
+|  |   | (per-tenant,     |  | + auto-learn     |  | persona-aware    | |     |
+|  |   | per agent/prov/  |  | into RAG         |  | benchmarking;    | |     |
+|  |   | prompt/version)  |  | (Epic 6 KB)      |  | A/B (Phase 2)    | |     |
+|  |   +------------------+  +------------------+  +------------------+ |     |
+|  |   Dashboards (32-13): admin = public defs; tenant = own private  |     |
+|  +------------------------------------------------------------------+      |
+|                                                                             |
++-----------------------------------------------------------------------------+
+```
+
+## Key Technical Decisions
+
+### Identity is the entity, not the role
+
+`Agent.Id` is the immutable join key for every metric, action, and benchmark — history survives config edits. `Role` (architect / reviewer / tester / …) is retained as a **benchmarking attribute** (so like-vs-like comparison is possible: reviewer A vs reviewer B), but the **Agent**, not the role, is the tracked entity. This replaces the anonymous, role-keyed `agent_configs` blob.
+
+### Versions are immutable; archive, never delete
+
+Each saved config is captured as an immutable, monotonically-versioned `AgentVersion` snapshot pinned to the run that produced it. Rollback = repoint `Agent.CurrentVersionId`, never delete-and-recreate. `AgentVersion` FK uses `OnDelete(DeleteBehavior.Restrict)` so audit history cannot cascade away.
+
+### Definitions in the control plane, data in the tenant schema
+
+Public agent definitions are shared cross-tenant → **`ControlPlaneDbContext`** holds public defs. **`TenantDbContext` (`t_<hex>`)** holds private defs **and ALL performance/action data**. No performance column ever appears on `Agent`/`AgentVersion`. Cross-tenant isolation is structural (schema-per-tenant + `ITenantDbContextFactory`), not an app-level filter — the platform admin who owns a public agent sees **zero** of any tenant's runs of it.
+
+### Managed-LLM-agent layer, distinct from CLI providers
+
+`IManagedAgent` (in `packages/providers`' managed-LLM-agent layer / `apps/tamma-elsa` `Tamma.Api.Services.Agents`) is the customization layer **above** the LLM API: context assembly (RAG, Epic 6) → prompt render (Epic 27 prompt/convention store, tenant → system → error) → the **reused** inline tool loop (`CallLlmInlineActivity` seam, *not forked*) → sanitization (`SecureAgentProvider`) → instrumentation (cost via `IProviderPricingService`) → outcome capture → a structured `AgentRunResult`. It is **not** an `ICLIAgentProvider`; both backends converge on `AgentRunResult` so workflows never branch on backend.
+
+### SaaS = API-key auth only
+
+The managed-LLM-agent path (`IAIProvider`) is the **sole** execution path in SaaS. **Token-based / CLI agent providers (`ICLIAgentProvider`) are NOT available in SaaS** — they remain single-user/self-hosted only. A CLI-backed agent resolved in SaaS yields a typed `GATE_DENIED` `AgentRunResult`, never an uncaught exception.
+
+### Credential-agnostic definitions; BYOK → platform resolution
+
+Agent definitions carry provider + model + prompt + settings, **never raw keys**. Credentials resolve at execution from the principal's secret source: **BYOK key (Epic 29 cabinet) → else platform-provided** (usage-metered, billed via Epic 34/35). Resolution stamps `CredentialSource` (`byok` | `platform`) onto `AgentRunResult` and the DCB tags, so a public agent run by a tenant executes with *that tenant's* key/budget → cost & performance are genuinely the tenant's.
+
+### Typed failures, never lost runs
+
+Expected failures (provider error, budget-exceeded, gate denial, missing-credential, loop exhaustion) are **data**, not exceptions: each produces a typed `AgentRunResult { Success = false, FailureCode, FailureReason }` with whatever cost accrued, and emits exactly one terminal DCB event. Only contract violations (e.g., null request) may throw.
+
+### Strategy-driven panels replace the hardcoded sequence
+
+`RunAgentPanelActivity` fans a step out to N agents of the relevant role(s); `AggregatePanelActivity` combines results via `single`, `consensus/vote`, `lead+critics`, or `llm-judge-merge`. Defaults: **`lead+critics`** for design, **`consensus`** for review. Specialized **security / performance / visual** reviewers participate in review panels. Budget clamps + max-iteration caps are mandatory (panels multiply token spend).
+
+### Action trail = DCB events, not a new table
+
+Every run, tool call, iteration, panel aggregation, and recorded bug is a DCB `DomainEvent` in the **tenant's own `domain_events` stream** (`AGGREGATE.ACTION.STATUS`), tagged with `agentId` + config version + role + provider + model + prompt key/version. Paginate on `SequenceNumber` (server-side `BIGSERIAL`), never `CreatedAt`. Trail capture is best-effort-non-blocking — a write failure never aborts a real agent run.
+
+### Cost is a producer, markup is downstream
+
+Epic 32 emits usage/cost events at **provider cost basis** (`IProviderPricingService.Compute`). The **markup engine is Epic 34 (Story 34-5), NOT here**; invoicing/payment (Epic 35), business analytics (Epic 36), and audit product features (Epic 37) all *consume* Epic 32's data. Epic 32 produces; it does not bill, invoice, or analyze.
+
+## Dependencies
+
+### On Other Epics
+
+- **Epic 1** (provider abstraction): `IAIProvider`, `IProviderPricingService`, provider config/allowlist, normalized LLM responses.
+- **Epic 4** (DCB event sourcing): `DomainEvent`, `IEventRepository`, the `SequenceNumber` cursor — reused for the action trail; no new event infrastructure.
+- **Epic 6** (RAG / context): `AssembleContextActivity` + the RAG pipeline supply assembled context; the learning loop (32-11) feeds learnings back into the KB.
+- **Epic 9** (unified agent API): engine ↔ central-API round-trips for agent resolution / credential / prompt; the panel + dispatch call-site convention.
+- **Epic 27** (prompt / convention store): prompt + convention resolution (tenant → system → error; NEVER empty/plain fallback); `AgentRole` / `AgentAction` taxonomy.
+- **Epic 28** (tenancy): `ControlPlaneDbContext`, `TenantDbContext`, schema-per-tenant, the CP migration pipeline, `ITenantDbContextFactory` / `ITenantContext`.
+- **Epic 29** (secret cabinet): encrypted per-tenant BYOK provider keys; canonical wiring in 32-3.
+- **Epics 34 / 35 / 36 / 37** (downstream consumers): pricing/markup, billing, analytics, audit consume Epic 32's usage/cost/action data. Epic 32 *produces*, never bills/invoices/analyzes.
+
+### External Dependencies
+
+- None new. All work is in the C# `apps/tamma-elsa` stack (`Tamma.Api`, `Tamma.Data` EF Core, `Tamma.Activities`, `Tamma.ElsaServer`), the `packages/providers` managed-LLM-agent layer, and `packages/intelligence` (RAG). **`packages/api` is deleted — never referenced.** Reuses EF Core 9 / Npgsql, the existing event store, `DiagnosticsService`, the inline tool loop, and the `SecureAgentProvider` sanitization seam.
+
+## Database Schema
+
+Definitions live in the **control plane**; all performance/action data lives in each **tenant's `t_<hex>` schema**.
+
+```sql
+-- ===== CONTROL PLANE (ControlPlaneDbContext) — agent DEFINITIONS =====
+
+-- Agent identity (public/system OR private/tenant-owned). NO performance columns.
+CREATE TABLE agents (
+  id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name               TEXT NOT NULL,                  -- stable handle, e.g. 'tamma-architect'
+  role               TEXT NOT NULL,                  -- AgentRole wire string
+  visibility         INT  NOT NULL,                  -- 0 = Public (system), 1 = Private
+  owner_tenant_id    UUID,                           -- set iff Private + SaaS
+  owner_user_id      UUID,                           -- set iff Private + single-user
+  status             INT  NOT NULL DEFAULT 0,        -- 0 = Active, 1 = Archived
+  current_version_id UUID,                           -- pointer to active agent_versions row
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by         UUID,
+  updated_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_by         UUID,
+  -- Visibility <-> ownership invariant (mirrors ck_prompt_overrides_principal_xor)
+  CONSTRAINT ck_agents_visibility_ownership CHECK (
+       (visibility = 0 AND owner_tenant_id IS NULL AND owner_user_id IS NULL)        -- public
+    OR (visibility = 1 AND owner_tenant_id IS NOT NULL AND owner_user_id IS NULL)    -- private/SaaS
+    OR (visibility = 1 AND owner_user_id IS NOT NULL AND owner_tenant_id IS NULL)    -- private/single-user
+  )
+);
+-- Public handles unique on (name, role); private handles unique per owner.
+CREATE UNIQUE INDEX IX_agents_public_name_role
+  ON agents (name, role) WHERE visibility = 0;
+CREATE UNIQUE INDEX IX_agents_private_tenant_name
+  ON agents (owner_tenant_id, name) WHERE visibility = 1 AND owner_tenant_id IS NOT NULL;
+CREATE UNIQUE INDEX IX_agents_private_user_name
+  ON agents (owner_user_id, name) WHERE visibility = 1 AND owner_user_id IS NOT NULL;
+
+-- Immutable, monotonically-versioned saved-config snapshots. Insert-only.
+CREATE TABLE agent_versions (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id    UUID NOT NULL REFERENCES agents(id) ON DELETE RESTRICT,
+  version     INT  NOT NULL,                         -- 1-based, monotonic per agent_id
+  config_json JSONB NOT NULL DEFAULT '{}'::jsonb,    -- provider chain / model / prompt / budget / tools / temperature / rag
+  notes       TEXT,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by  UUID
+);
+CREATE UNIQUE INDEX IX_agent_versions_agent_version ON agent_versions (agent_id, version);
+
+-- ===== TENANT SCHEMA t_<hex> (TenantDbContext) — DATA, ALWAYS tenant-scoped =====
+
+-- Private agent definitions (tenant-owned) — same shape as agents, in the tenant schema.
+
+-- Action trail: NO new table. Reuses the tenant's DCB event stream.
+--   domain_events (Id, Type, TenantId, IssueNumber, Tags JSONB, Metadata JSONB,
+--                  Data JSONB, CreatedAt, SequenceNumber BIGSERIAL)
+--   Types: AGENT.TASK.SUCCESS/FAILED/PARTIAL, AGENT.TOOL_CALL.SUCCESS/FAILED,
+--          AGENT.ITERATION.COMPLETED, AGENT.PANEL.AGGREGATED, REVIEW.BUG.RECORDED,
+--          AGENT.RUN.STARTED/SUCCESS/FAILED.
+--   Tags: { agentId, agentVersion, role, provider, model, promptRef, issueId,
+--           iteration, correlationId, credentialSource }; bug events add bugType.
+--   Cursor: SequenceNumber (BIGSERIAL total order), never CreatedAt.
+
+-- Benchmark / leaderboard projections + learning captures (32-10 / 32-11) — tenant-scoped.
+-- ProviderDiagnostic rows (cost/latency/tokens) linked to the trail by
+-- (agentId, correlationId); existing entity reused, no schema change required.
+```
+
+DCB event families (`AGGREGATE.ACTION.STATUS`): `AGENT.CREATED.SUCCESS`, `AGENT.VERSION_PUBLISHED.SUCCESS`, `AGENT.ARCHIVED.SUCCESS` (control-plane, definition lifecycle); `AGENT.RUN.STARTED/SUCCESS/FAILED`, `AGENT.TASK.SUCCESS/FAILED/PARTIAL`, `AGENT.TOOL_CALL.SUCCESS/FAILED`, `AGENT.ITERATION.COMPLETED`, `AGENT.PANEL.AGGREGATED`, `REVIEW.BUG.RECORDED` (tenant, action trail).
+
+## Implementation Phases
+
+### Phase 1: Entity, Credential & Execution Foundation (32-1 … 32-6) — P0
+
+The first-class `Agent` + versioned `AgentVersion` model, registry + RBAC API, BYOK → platform credential resolution, the SaaS API-key-only gate, the `IManagedAgent` managed execution layer (reusing the inline tool loop), and the `agent_id`-tagged tenant action trail. Nothing downstream can be built until the entity + execution + trail substrate exists.
+Estimated: 23-29 days
+
+### Phase 2: Panels, Tracking & Benchmarking (32-7 … 32-11) — P1
+
+Strategy-driven multi-agent design/review panels (replacing `TriagePanelReviewWorkflow`), outcome + bug-taxonomy capture at review/gate, cost-basis-plus-margin usage/cost emission (re-targeting Epic 20 billing as a producer), per-tenant benchmark projections + leaderboards, and learning persistence + auto-learning into RAG.
+Estimated: 20-25 days
+
+### Phase 3: Personas, Dashboards & Experiments (32-12 … 32-14) — P2
+
+Agent personas + persona-aware benchmarking, agent-management + benchmark dashboards (admin public defs + tenant private data), and the Phase-2 A/B experiment framework (cohorts, statistical significance, auto rollout/rollback on regression).
+Estimated: 12-15 days
+
+## Success Metrics
+
+- 100% of agent-driven workflow steps route through `RunManagedAgentActivity` → `IManagedAgent` (zero remaining ad-hoc role→llm-call dispatch for managed agents).
+- 100% of managed runs produce an `AgentRunResult` and exactly one terminal `AGENT.RUN.*` / `AGENT.TASK.*` event in the correct tenant schema.
+- Zero forks of the tool loop / sanitizer / compactor (single source confirmed by grep).
+- Zero cross-tenant action/performance reads possible (verified by the isolation test suite); a platform admin sees **none** of any tenant's run data, even for public agents.
+- 100% of agent runs resolve a credential via BYOK → platform, with `CredentialSource` (`byok` | `platform`) tagged on every run and cost event.
+- Every trail event carries all required tags; `REVIEW.BUG.RECORDED` always carries a valid `bugType` (`visual` | `functional` | `regression` | `security` | `perf` | `style`).
+- Trail-write failures never fail an agent run (non-blocking contract verified).
+- Per-tenant leaderboards compute success rate, avg iterations-to-done, bug counts by type, cost, and latency — sliceable by agent / provider / prompt / version.
+- Auto-generated learnings from outcomes are retrievable by RAG in subsequent runs.
+
+## Reference Documents
+
+- [Epic 32 Design of Record — Agent Entities, Personas, Benchmarking & Learning](../../superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md)
+- [Story 32-1 — Agent Entity Model & Versioned Saved Config](./story-32-1/32-1-agent-entity-model-and-versioned-saved-config.md)
+- [Story 32-2 — Agent Registry, Resolution & RBAC API](./story-32-2/32-2-agent-registry-resolution-and-rbac-api.md)
+- [Story 32-3 — Per-Tenant Provider Credential Resolution (BYOK → platform)](./story-32-3/32-3-per-tenant-provider-credential-resolution.md)
+- [Story 32-4 — SaaS Provider Auth Gating (API-key only)](./story-32-4/32-4-saas-provider-auth-gating-api-key-only.md)
+- [Story 32-5 — Managed Agent Execution Layer (`IManagedAgent`)](./story-32-5/32-5-managed-agent-execution-layer.md)
+- [Story 32-6 — Agent Action Trail (DCB events tagged `agent_id`) in Tenant Store](./story-32-6/32-6-agent-action-trail-in-tenant-store.md)
+- [Story 32-7 — Multi-Agent Design/Review Panels in Elsa](./story-32-7/32-7-multi-agent-design-review-panels-in-elsa.md)
+- [Story 32-8 — Outcome Capture & Bug Taxonomy at Review/Gate](./story-32-8/32-8-outcome-capture-and-bug-taxonomy-at-review-gate.md)
+- [Story 32-9 — Cost-Basis-Plus-Margin Metering & BYOK Pricing Model](./story-32-9/32-9-cost-basis-plus-margin-metering-and-byok-pricing-model.md)
+- [Story 32-10 — Benchmark Projections & Leaderboards](./story-32-10/32-10-benchmark-projections-and-leaderboards.md)
+- [Story 32-11 — Learning Persistence & Auto-Learning into RAG](./story-32-11/32-11-learning-persistence-and-auto-learning-into-rag.md)
+- [Story 32-12 — Agent Personas & Persona-Aware Benchmarking](./story-32-12/32-12-agent-personas-and-persona-aware-benchmarking.md)
+- [Story 32-13 — Agent Management & Benchmark Dashboards](./story-32-13/32-13-agent-management-and-benchmark-dashboards.md)
+- [Story 32-14 — A/B Experiment Framework for Agents (Phase 2)](./story-32-14/32-14-a-b-experiment-framework-for-agents.md)
+- [Prompt Store Architecture](../../../CLAUDE.md) — the RBAC + per-mode ownership pattern Epic 32 mirrors
+- [Unified Schema-per-Tenant Tenancy](../../../CLAUDE.md) — control-plane vs `t_<hex>` placement model
+
+---
+
+**Last Updated**: 2026-06-17
+**Epic Owner**: TBD
+**Implementation Start**: TBD
+**Total Estimated Effort**: 55-69 days

--- a/docs/stories/epic-32/story-32-1/32-1-agent-entity-model-and-versioned-saved-config.md
+++ b/docs/stories/epic-32/story-32-1/32-1-agent-entity-model-and-versioned-saved-config.md
@@ -1,0 +1,369 @@
+# Story 32-1: Agent Entity Model & Versioned Saved Config (public/private)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-Phase Development Workflow (Read → Research → Break Down → TDD → Quality Gates → Failure Handling), Knowledge Base usage (`.dev/` directory), TRACE/DEBUG logging requirements, Test-Driven Development, 100% critical-path coverage, and build-success enforcement.
+
+**Failure to follow this process will result in rework.**
+
+## User Story
+
+As a **platform owner (public/system agents) and a tenant owner/admin (private agents)**,
+I want **agents to be first-class, identity-bearing entities whose saved configuration is captured as immutable, monotonically-versioned snapshots**,
+So that **an agent's history, actions, and performance can be tracked by stable identity across config edits, prior versions can be rolled back, and public (platform-owned) vs private (tenant-owned) ownership is structurally enforced** — replacing the anonymous, role-keyed `agent_configs` JSONB blob.
+
+## Priority
+
+P0 — Foundational. Epic 32's entire action-trail, benchmarking, leaderboard, and learning stack (stories 32-2 … 32-14) joins on `agent_id` + config version. Nothing downstream can be built until the entity + versioning + ownership model exists. This is the canonical owner of the `Agent` / `AgentVersion` control-plane entities.
+
+## Acceptance Criteria
+
+1. Two new EF Core entities exist in `apps/tamma-elsa/src/Tamma.Data/Entities/`: `Agent` (`Id` Guid PK, `Name` string, `Role` string from the `AgentRole` taxonomy wire form, `Visibility` enum `public|private`, `OwnerTenantId` Guid?, `OwnerUserId` Guid?, `Status` enum `active|archived`, `CurrentVersionId` Guid?, `CreatedAt`/`CreatedBy`, `UpdatedAt`/`UpdatedBy`) and `AgentVersion` (`Id` Guid PK, `AgentId` Guid FK, `Version` int, `ConfigJson` jsonb, `Notes` string?, `CreatedAt`/`CreatedBy`, immutable after insert). Both are registered as `DbSet`s on `ControlPlaneDbContext` and configured **only** in `TammaModelConfiguration.cs` (the single source of model config), with a new additive migration under `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/`.
+
+2. The definition rows are **control-plane-resident** (cross-tenant visibility/identity is a CP concern); they are NOT added to `TenantDbContext`. All performance/action data stays in the tenant schema per later Epic 32 stories — no performance columns appear on `Agent`/`AgentVersion`.
+
+3. A `CHECK` constraint `ck_agents_visibility_ownership` enforces exactly-one ownership semantics consistent with the `Visibility` discriminator: `Visibility='public' ⇒ OwnerTenantId IS NULL AND OwnerUserId IS NULL`; `Visibility='private'` in SaaS ⇒ `OwnerTenantId IS NOT NULL AND OwnerUserId IS NULL`; `Visibility='private'` in single-user ⇒ `OwnerUserId IS NOT NULL AND OwnerTenantId IS NULL`. The constraint mirrors the `ck_prompt_overrides_principal_xor` pattern (a private agent never has both owner columns set, and never both null).
+
+4. A unique partial index `IX_agents_public_name_role` on `(Name, Role) WHERE Visibility='public'` guarantees public/system agents have unique `(name, role)` handles; a separate unique partial index scopes private-agent name uniqueness per owner (`(OwnerTenantId, Name)` and `(OwnerUserId, Name)` filtered on `Visibility='private'`) so two tenants may each own a private agent named `atlas` without collision.
+
+5. A unique index `IX_agent_versions_agent_version` on `(AgentId, Version)` guarantees monotonic, non-duplicated versions per agent. `AgentVersion.AgentId` is an FK to `Agent.Id` with `OnDelete(DeleteBehavior.Restrict)` (versions are immutable audit history; archive, never cascade-delete).
+
+6. A new `IAgentRepository` / `AgentRepository` in `apps/tamma-elsa/src/Tamma.Data/Repositories/` exposes `CreateAsync`, `PublishVersionAsync`, `ArchiveAsync`, `GetByIdAsync`, `GetVersionAsync`, `ListVersionsAsync`, and `ListVisibleAsync(principal)`. `PublishVersionAsync` writes a new immutable `AgentVersion` row with `Version = max(existing)+1`, then atomically updates the parent `Agent.CurrentVersionId` and `UpdatedAt`/`UpdatedBy` **in a single transaction**; prior versions remain queryable for rollback.
+
+7. `ConfigJson` is validated against the shape rules reused/extended from `AgentEndpoints.ValidateConfigShape` (provider name regex `^[a-z0-9][a-z0-9_-]{0,63}$`, `maxBudgetUsd` range `[0,100]`, provider-chain non-empty, prototype-pollution rejection, ReDoS guard on `blockedCommandPatterns`, `maxFetchSizeBytes` range), extended for the saved-config fields the Epic 32 design names (`provider`, `model`, `temperature`, `maxTokens`, `tokenBudget`, `tools[]`, `systemPromptRef`, `rag{}`). Validation runs **before any write** in both `CreateAsync` and `PublishVersionAsync`; an invalid config is rejected and no row is written and no event is emitted.
+
+8. DCB events (pattern `AGGREGATE.ACTION.STATUS`) are appended via `IEventRepository.AppendAsync` to the **control-plane** `DomainEvents` store: `AGENT.CREATED.SUCCESS` (on first create), `AGENT.VERSION_PUBLISHED.SUCCESS` (on each new version), `AGENT.ARCHIVED.SUCCESS` (on archive). Each event's `Tags` JSON includes `{ agentId, version, visibility, ownerTenantId?, ownerUserId?, role, mode }`; `Metadata` carries `{ workflowVersion: "1.0.0", eventSource: "system" }`. Events are emitted only after a real state transition (mirroring the existing `AGENT_CONFIG.UPDATED.SUCCESS` discipline — never a "lie" event for a write that did not happen).
+
+9. Single-user vs SaaS ownership is resolved **explicitly** via `ITammaModeProvider`: in `SingleUser` mode a private agent's principal is the sole user (`OwnerUserId` set, `OwnerTenantId` NULL); in `SaaS` mode it is the tenant (`OwnerTenantId` set, `OwnerUserId` NULL). The mapping is documented on the entity and enforced by an entity-level guard in `AgentRepository.CreateAsync` (rejecting a private create whose principal columns contradict the process mode) in addition to the DB `CHECK`.
+
+10. Public/system agents are migrated from the existing seeder into `Agent` + `AgentVersion` rows idempotently. A new `AgentEntitySeeder` (CP-resident, mirroring `ConventionStoreSeeder`'s insert-missing-only pattern) creates one public agent per role with `Visibility='public'`, `OwnerTenantId/OwnerUserId NULL`, preserving the `tamma-<role>` handles (`tamma-architect`, `tamma-tester`, …) currently produced by `Tamma.ElsaServer/AgentSeeder.cs`, each with a `Version=1` `AgentVersion` capturing the shipped provider chain / prompt / temperature / maxTokens. Re-running the seeder inserts nothing new (skip-by-existing-handle).
+
+11. New REST endpoints are added to `AgentEndpoints.cs` and mapped under the `/api/v1/agents` group in `Program.cs` with per-mode RBAC: `POST /api/v1/agents` (create; public ⇒ `PlatformOwnerAccess`, private ⇒ tenant owner/admin), `POST /api/v1/agents/{id}/versions` (publish version; same ownership rule), `POST /api/v1/agents/{id}/archive`, `GET /api/v1/agents` (list visible = all public ∪ caller's own private), `GET /api/v1/agents/{id}` and `GET /api/v1/agents/{id}/versions[/{version}]` (read). A `member` role in SaaS gets read access and a **403** on create/publish/archive (mirrors Prompt Store RBAC). The legacy `GET/PUT /api/v1/agents/config` endpoints remain untouched in this story (cutover is later in the epic).
+
+12. Cross-tenant isolation is provable: a SaaS caller listing visible agents sees every public agent plus only their own tenant's private agents — never another tenant's private agent — and a direct `GET /api/v1/agents/{id}` for another tenant's private agent returns **404** (not 403, to avoid leaking existence).
+
+13. The new migration applies cleanly and `dotnet ef migrations has-pending-model-changes` reports **none** after it is added; the full `Tamma.Api.Tests` suite stays green.
+
+14. Unit tests cover: version increment + monotonicity; rollback pointer integrity (`CurrentVersionId` always points at the highest published version, prior versions still fetchable); ownership `CHECK` rejection (public-with-owner, private-with-no-owner, private-with-both-owners); public vs private visibility queries; per-mode principal derivation; ConfigJson validation rejection; DCB event emission/no-emission-on-failure; seeder idempotency.
+
+15. **Logging**: structured Pino-equivalent (`ILogger<>`) logs at INFO for create/publish/archive (with `{ agentId, version, visibility, role }`), DEBUG for validation pass, WARN for validation rejection and CHECK violations surfaced as 400/409, ERROR for transaction failure — never logging raw `ConfigJson` if it could contain a secret reference (config is credential-agnostic by design, but redact `systemPromptRef` resolution failures).
+
+## Technical Design
+
+### C# namespace / file structure
+
+```
+apps/tamma-elsa/src/
+  Tamma.Data/
+    Entities/
+      Agent.cs                         # NEW — control-plane entity (identity)
+      AgentVersion.cs                  # NEW — immutable config snapshot
+      AgentVisibility.cs               # NEW — enum { Public, Private }
+      AgentStatus.cs                   # NEW — enum { Active, Archived }
+    ControlPlaneDbContext.cs           # MODIFY — add DbSet<Agent>, DbSet<AgentVersion>
+    TammaModelConfiguration.cs         # MODIFY — entity config, CHECK, partial indexes
+    Repositories/
+      IAgentRepository.cs              # NEW
+      AgentRepository.cs               # NEW
+    Migrations/ControlPlane/
+      <ts>_AddAgentEntities.cs         # NEW — additive migration
+  Tamma.Api/
+    Endpoints/
+      AgentEndpoints.cs                # MODIFY — add Create/PublishVersion/Archive/List/Get
+    Dtos/Agents/
+      AgentDtos.cs                     # NEW — request/response records
+    Services/Agents/
+      AgentConfigValidator.cs          # NEW — extract+extend ValidateConfigShape
+    Program.cs                         # MODIFY — map new routes with per-mode RBAC
+  Tamma.ElsaServer/  (or Tamma.Api seeding host)
+    AgentEntitySeeder.cs               # NEW — public-agent seeding into CP rows
+```
+
+> Note: the existing `Tamma.ElsaServer/AgentSeeder.cs` seeds the **Elsa Agents** store (`IAgentManager`) with `tamma-<role>` handles. The new `AgentEntitySeeder` populates the **Tamma control-plane** `agents`/`agent_versions` tables and is the source of truth for Epic 32. Both can coexist until the Elsa-side seeder is retired in a later story; `AgentEntitySeeder` reuses the same handles and shipped config values so the two stay aligned.
+
+### Entities (sketch)
+
+```csharp
+// Tamma.Data/Entities/AgentVisibility.cs
+public enum AgentVisibility { Public, Private }
+
+// Tamma.Data/Entities/AgentStatus.cs
+public enum AgentStatus { Active, Archived }
+
+// Tamma.Data/Entities/Agent.cs
+public class Agent
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;            // stable handle, e.g. "tamma-architect"
+    public string Role { get; set; } = null!;            // AgentRole wire string (NormalizeRole-valid)
+    public AgentVisibility Visibility { get; set; }       // Public => system; Private => tenant/user-owned
+    public Guid? OwnerTenantId { get; set; }              // set iff Private + SaaS
+    public Guid? OwnerUserId { get; set; }                // set iff Private + SingleUser
+    public AgentStatus Status { get; set; } = AgentStatus.Active;
+    public Guid? CurrentVersionId { get; set; }           // pointer to the active AgentVersion
+    public DateTime CreatedAt { get; set; }
+    public Guid? CreatedBy { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public Guid? UpdatedBy { get; set; }
+
+    public ICollection<AgentVersion> Versions { get; set; } = new List<AgentVersion>();
+}
+
+// Tamma.Data/Entities/AgentVersion.cs  (immutable — never UPDATEd after insert)
+public class AgentVersion
+{
+    public Guid Id { get; set; }
+    public Guid AgentId { get; set; }
+    public int Version { get; set; }                      // 1-based, monotonic per AgentId
+    public string ConfigJson { get; set; } = "{}";        // jsonb; the saved-config snapshot
+    public string? Notes { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public Guid? CreatedBy { get; set; }
+
+    public Agent? Agent { get; set; }
+}
+```
+
+### EF model configuration (in `TammaModelConfiguration.cs`, mirroring PromptOverride/AgentConfig)
+
+```csharp
+modelBuilder.Entity<Agent>(entity =>
+{
+    entity.ToTable("agents", t =>
+    {
+        // Visibility ⇄ ownership invariant (mirrors ck_prompt_overrides_principal_xor)
+        t.HasCheckConstraint(
+            "ck_agents_visibility_ownership",
+            "(\"Visibility\" = 0 AND \"OwnerTenantId\" IS NULL AND \"OwnerUserId\" IS NULL) " +   // 0 = Public
+            "OR (\"Visibility\" = 1 AND \"OwnerTenantId\" IS NOT NULL AND \"OwnerUserId\" IS NULL) " + // 1 = Private/SaaS
+            "OR (\"Visibility\" = 1 AND \"OwnerUserId\" IS NOT NULL AND \"OwnerTenantId\" IS NULL)");
+    });
+    entity.HasKey(e => e.Id);
+    entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+    entity.Property(e => e.Name).IsRequired().HasMaxLength(128);
+    entity.Property(e => e.Role).IsRequired().HasMaxLength(64);
+    entity.Property(e => e.Visibility).HasConversion<int>();
+    entity.Property(e => e.Status).HasConversion<int>().HasDefaultValue(AgentStatus.Active);
+    entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+    entity.Property(e => e.UpdatedAt).HasDefaultValueSql("now()");
+
+    // Public handles unique on (Name, Role)
+    entity.HasIndex(e => new { e.Name, e.Role })
+        .IsUnique().HasFilter("\"Visibility\" = 0")
+        .HasDatabaseName("IX_agents_public_name_role");
+    // Private handles unique per owner
+    entity.HasIndex(e => new { e.OwnerTenantId, e.Name })
+        .IsUnique().HasFilter("\"Visibility\" = 1 AND \"OwnerTenantId\" IS NOT NULL")
+        .HasDatabaseName("IX_agents_private_tenant_name");
+    entity.HasIndex(e => new { e.OwnerUserId, e.Name })
+        .IsUnique().HasFilter("\"Visibility\" = 1 AND \"OwnerUserId\" IS NOT NULL")
+        .HasDatabaseName("IX_agents_private_user_name");
+});
+
+modelBuilder.Entity<AgentVersion>(entity =>
+{
+    entity.ToTable("agent_versions");
+    entity.HasKey(e => e.Id);
+    entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+    entity.Property(e => e.ConfigJson).HasColumnType("jsonb").HasDefaultValueSql("'{}'::jsonb");
+    entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+    entity.HasIndex(e => new { e.AgentId, e.Version })
+        .IsUnique().HasDatabaseName("IX_agent_versions_agent_version");
+    entity.HasOne(e => e.Agent)
+        .WithMany(a => a.Versions)
+        .HasForeignKey(e => e.AgentId)
+        .OnDelete(DeleteBehavior.Restrict);  // versions are immutable history
+});
+```
+
+> `Agent.CurrentVersionId` is left as a plain nullable Guid pointer (no FK navigation back into `agent_versions`) to avoid a circular FK that complicates the create-then-publish-first-version flow. Pointer integrity is enforced in the repository transaction + an integration assertion, not a DB FK.
+
+### Repository (sketch)
+
+```csharp
+// Tamma.Data/Repositories/IAgentRepository.cs
+public interface IAgentRepository
+{
+    Task<Agent> CreateAsync(Agent agent, string firstVersionConfigJson, string? notes,
+                            Guid? createdBy, CancellationToken ct = default);
+    Task<AgentVersion> PublishVersionAsync(Guid agentId, string configJson, string? notes,
+                                           Guid? updatedBy, CancellationToken ct = default);
+    Task<Agent?> ArchiveAsync(Guid agentId, Guid? updatedBy, CancellationToken ct = default);
+    Task<Agent?> GetByIdAsync(Guid agentId, CancellationToken ct = default);
+    Task<AgentVersion?> GetVersionAsync(Guid agentId, int version, CancellationToken ct = default);
+    Task<IReadOnlyList<AgentVersion>> ListVersionsAsync(Guid agentId, CancellationToken ct = default);
+    // Visibility-scoped list: all public ∪ caller's own private.
+    Task<IReadOnlyList<Agent>> ListVisibleAsync(Guid? tenantId, Guid? userId, CancellationToken ct = default);
+}
+```
+
+`PublishVersionAsync` (the load-bearing transaction):
+
+```
+BEGIN
+  nextVersion = (SELECT COALESCE(MAX(Version),0)+1 FROM agent_versions WHERE AgentId=@id)
+  INSERT agent_versions (AgentId=@id, Version=nextVersion, ConfigJson=@cfg, Notes=@n, CreatedBy=@by)
+  UPDATE agents SET CurrentVersionId=<new id>, UpdatedAt=now(), UpdatedBy=@by WHERE Id=@id
+COMMIT
+```
+
+The unique index `(AgentId, Version)` makes a concurrent double-publish fail the second INSERT (caught → retried with a fresh `MAX(Version)+1`), guaranteeing monotonicity under races.
+
+### DCB event names (NEW)
+
+| Event | When | Tags |
+|---|---|---|
+| `AGENT.CREATED.SUCCESS` | new `Agent` + `Version=1` committed | `agentId, version=1, visibility, ownerTenantId?, ownerUserId?, role, mode` |
+| `AGENT.VERSION_PUBLISHED.SUCCESS` | new `AgentVersion` committed + pointer moved | `agentId, version, visibility, ownerTenantId?, ownerUserId?, role, mode` |
+| `AGENT.ARCHIVED.SUCCESS` | `Status` → archived | `agentId, visibility, ownerTenantId?, ownerUserId?, role, mode` |
+
+Emitted via the existing `IEventRepository.AppendAsync(DomainEvent { Type, TenantId, Tags, Metadata, Data, CreatedAt })` into the CP `DomainEvents` table — the same store `AlertRuleEvaluator` polls and the same path used by `AGENT_CONFIG.UPDATED.SUCCESS`. For private/SaaS agents `DomainEvent.TenantId` is set to `OwnerTenantId`; for public/system agents it is NULL (platform feed).
+
+### API shape
+
+```
+POST   /api/v1/agents
+  body: { name, role, visibility: "public"|"private", config: {...}, notes? }
+  → 201 { id, name, role, visibility, status, currentVersion: 1 }
+  RBAC: public ⇒ PlatformOwnerAccess; private ⇒ tenant owner/admin (SettingsManage-equivalent); member ⇒ 403
+
+POST   /api/v1/agents/{id}/versions
+  body: { config: {...}, notes? }
+  → 200 { id, version, createdAt }
+  RBAC: matches the agent's ownership
+
+POST   /api/v1/agents/{id}/archive   → 200 { id, status: "archived" }
+
+GET    /api/v1/agents                 → 200 [ AgentSummary ]  (all public ∪ own private)
+GET    /api/v1/agents/{id}            → 200 AgentDetail | 404
+GET    /api/v1/agents/{id}/versions   → 200 [ AgentVersionSummary ]
+GET    /api/v1/agents/{id}/versions/{version} → 200 AgentVersionDetail | 404
+```
+
+Per-mode + per-tenant handling at the endpoint layer:
+- **Public-scope writes** are gated by `PlatformOwnerAccess` (platform admin only) — same gate the spec assigns to public agent CRUD.
+- **Private-scope writes**: principal columns are derived from `ITammaModeProvider.Mode` + `ITenantContext`/`ClaimsPrincipal` — SaaS sets `OwnerTenantId` from the active tenant; single-user sets `OwnerUserId` from the sole user. Member-role SaaS callers are rejected 403.
+- **Reads** apply `ListVisibleAsync(tenantId, userId)`; a `GET {id}` for a private agent not owned by the caller returns 404.
+
+### Validation
+
+`AgentConfigValidator.Validate(string configJson) → (bool Valid, string[] Errors)` is extracted from the private `AgentEndpoints.ValidateConfigShape` (so the rules are shared, not duplicated) and extended to recognise the Epic 32 saved-config fields (`model` string, `temperature` ∈ `[0,2]`, `maxTokens` > 0, `tokenBudget` ≥ 0, `tools[]` of strings, `systemPromptRef` string, `rag{}` object) while keeping the existing provider-regex / budget-range / ReDoS / prototype-pollution guards. Both `CreateAsync`-backing endpoint and `PublishVersionAsync`-backing endpoint validate before persisting.
+
+### Integration points
+
+- **`AgentRole` taxonomy** (`Tamma.Core/Agents/AgentRole.cs`, `RolePhaseMap.cs`): `Role` is stored as the wire string; `AgentRoleExtensions.Parse` / `RolePhaseMap.NormalizeRole` validate it on create.
+- **`IEventRepository`** (`Tamma.Data/Repositories/EventRepository.cs`): DCB emission.
+- **`ITammaModeProvider`** (`Tamma.Api/Services/PromptStore/TammaMode.cs`): per-mode principal derivation.
+- **`ITenantContext`** (`Tamma.Data/ITenantContext.cs`) + `ClaimsPrincipal.GetUserId()`: caller identity.
+- **`ControlPlaneDbContext`** (`Tamma.Data/ControlPlaneDbContext.cs`): the repository resolves against the CP context (definitions are CP-resident), NOT `TenantDbContext`.
+- **Auth policies** (`Program.cs`): `PlatformOwnerAccess`, `SettingsManage`/owner-admin gates, `SettingsView` for reads.
+- **Downstream (later stories)**: 32-2 (registry/resolution API consumes `IAgentRepository`), 32-5/32-6 (managed execution + action trail join on `agentId` + version), 32-10 (benchmarks slice by version).
+
+## Dependencies
+
+- **Prerequisite**: Epic 27 — `AgentRole`/`AgentAction` taxonomy (`Tamma.Core/Agents/`) for the `Role` attribute and config validation.
+- **Prerequisite**: Epic 28 — `ControlPlaneDbContext`, schema-per-tenant model, and the CP migration pipeline (`Migrations/ControlPlane/`).
+- **Design of record**: `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md` (Epic 32 design).
+- **Blocks**: 32-2 (registry/resolution & RBAC API), 32-3 (provider credential resolution), 32-5 (managed execution layer), 32-6 (action trail), 32-10 (benchmarks) — all join on the entity + version this story introduces.
+- **Related (not modified here)**: `AgentConfig` / `agent_configs` (legacy role-keyed blob) — coexists; its cutover/retirement is a later Epic 32 story.
+
+## Testing Strategy
+
+**Unit tests** (`tests/Tamma.Api.Tests/Agents/` and/or `tests/Tamma.Api.Tests/MissingConfig`-style; in-memory or Postgres fixture per `Infrastructure/InMemoryDbFixture.cs` / `Epic28/ControlPlaneDbContextModelTests.cs` precedent):
+1. `CreateAsync` writes one `Agent` + one `Version=1` `AgentVersion`, sets `CurrentVersionId`, emits exactly one `AGENT.CREATED.SUCCESS`.
+2. `PublishVersionAsync` increments `Version` monotonically (1→2→3), each writes a new immutable row, moves `CurrentVersionId`, emits one `AGENT.VERSION_PUBLISHED.SUCCESS` per call; prior versions remain fetchable via `GetVersionAsync`.
+3. Rollback-pointer integrity: after N publishes, `CurrentVersionId` resolves to the row with `Version=N`; an explicit pointer set back to an older version (rollback path) leaves all versions intact.
+4. Ownership `CHECK` rejection: public-with-owner, private-with-no-owner, private-with-both-owner-columns all throw on `SaveChanges` (Postgres `CHECK` violation) — verified against a real Postgres fixture.
+5. Per-mode principal derivation: `SingleUser` create sets `OwnerUserId`/null tenant; `SaaS` create sets `OwnerTenantId`/null user; contradictory input rejected by the entity-level guard before DB.
+6. `ConfigJson` validation: invalid provider name / budget out of range / empty chain / prototype-pollution key / bad temperature → rejected, no row, no event.
+7. DCB no-emission-on-failure: a validation failure or transaction rollback leaves the `DomainEvents` store untouched.
+8. Seeder idempotency: first run creates one public agent per role with `tamma-<role>` handles + `Version=1`; second run inserts nothing.
+
+**Integration tests** (Postgres-bound, run via `sg docker -c "dotnet test ..."`):
+9. Migration applies + `has-pending-model-changes` reports none; `ControlPlaneDbContextModelTests` extended to assert the new tables/indexes/CHECK.
+10. Endpoint RBAC matrix: `PlatformOwnerAccess` required for public create; tenant owner/admin for private; SaaS `member` → 403 on create/publish/archive, 200 on reads.
+11. **Tenant-isolation** (mirrors `Epic28/CrossTenantIsolationPostgresTests.cs`): tenant A creates private agent `atlas`; tenant B's `GET /api/v1/agents` returns public agents + B's own only (never A's `atlas`); `GET /api/v1/agents/{A-atlas-id}` as B → 404; two tenants may each own a private `atlas` (partial-index allows it).
+
+**Coverage**: critical paths (version transaction, ownership guard, validation, event emission) → 100%; entity/repository line ≥ 80%.
+
+## Estimated Effort
+
+4-5 days
+
+## Files Created / Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/Agent.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/AgentVersion.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/AgentVisibility.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/AgentStatus.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/IAgentRepository.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/AgentRepository.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_AddAgentEntities.cs` (+ `.Designer.cs`, snapshot) | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/AgentDtos.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentConfigValidator.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.ElsaServer/AgentEntitySeeder.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentRepositoryTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentEntitySeederTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (add `DbSet<Agent>`, `DbSet<AgentVersion>`) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (entity config, CHECK, partial indexes) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs` | Modify (add Create/PublishVersion/Archive/List/Get; extract validator) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map new routes + RBAC; register `IAgentRepository`, `AgentEntitySeeder`) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs` | Modify (assert new tables/indexes/CHECK) |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, decisions
+3. Read the Epic 32 design of record: `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`
+4. Reviewed the closest existing patterns: `PromptOverride` (XOR CHECK + NULLS-NOT-DISTINCT unique index in `TammaModelConfiguration.cs`), `AgentConfig` (partial unique index + audit-event discipline in `AgentEndpoints.UpdateConfig`), `ConventionStoreSeeder` (insert-missing-only idempotency)
+5. Planned the TDD approach (Red-Green-Refactor)
+
+### Key design decisions
+
+- **Identity is the entity, not the role.** `Agent.Id` is the immutable join key for all later metrics; `Role` is a benchmarking attribute, not a primary key. This is the central premise of the Epic 32 design ("the Agent is the entity").
+- **Definitions in CP, data in tenant.** Public agent definitions are shared cross-tenant → control-plane. Private agent definitions are CP too (visibility/identity is a CP concern), but ALL performance/action data lands in the tenant schema in later stories. No performance column belongs on these entities — keep them definition-only.
+- **Versions are immutable; archive, never delete.** `AgentVersion` rows are insert-only; `OnDelete(Restrict)` prevents cascade loss of history. Rollback = repoint `CurrentVersionId`, not delete-and-recreate.
+- **Mode-aware ownership is explicit, two ways.** The DB `CHECK` is the structural backstop; the repository's entity-level guard fails fast with a clear error before hitting the DB. Per CLAUDE.md "Universal rule for any tenant-aware feature", both single-user (`OwnerUserId`) and SaaS (`OwnerTenantId`) ownership models are answered separately — never assume the SaaS model and bolt single-user on.
+- **Reuse the existing validator.** Extract `ValidateConfigShape` rather than re-implement; the provider-regex / budget / ReDoS / prototype-pollution guards are battle-tested (Finding 014) and must apply to saved configs too.
+- **Coexist with `agent_configs`.** This story adds the new model and seeds public agents; it does NOT migrate the legacy role-keyed blob off `agent_configs` or repoint workflows. Cutover is a later, separately-reviewable Epic 32 story to keep the blast radius small.
+
+### Migration discipline (Epic 28 conventions)
+
+- `agent_versions` / `agents` are **additive** tables — a normal `dotnet ef migrations add AddAgentEntities --context ControlPlaneDbContext`, not a baseline CHECK edit.
+- After adding, run `dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext` → must report none.
+- Mirror entity config **only** in `TammaModelConfiguration.cs` (the established single source); the snapshot/Designer are generated, not hand-edited.
+- Run C# tests with `sg docker -c "dotnet test ..."` (session docker group is stale; build needs no wrapper).
+
+### Edge cases
+
+- Concurrent double-publish on one agent: second INSERT hits the `(AgentId, Version)` unique index → catch, recompute `MAX(Version)+1`, retry. Test this race.
+- Create with a role string that needs normalization (legacy alias) → `RolePhaseMap.NormalizeRole` first, store canonical wire form.
+- Archiving an already-archived agent → idempotent no-op, no second `AGENT.ARCHIVED.SUCCESS`.
+- Public agent name collision with an existing handle → 409 (partial unique index), no event.
+
+## Logging Requirements
+
+- **INFO**: agent created (`agentId, name, role, visibility`), version published (`agentId, version`), agent archived (`agentId`), seeder summary (`created, skipped`).
+- **DEBUG**: config validation passed (`agentId|name`), visibility-scoped list resolved (`count, mode, tenantId?`).
+- **WARN**: config validation rejected (`errors[]` — no raw config body), CHECK/ownership-guard violation surfaced as 400/409, member-role 403 on write, concurrent-publish retry.
+- **ERROR**: publish transaction failed/rolled back (`agentId`), event append failure after commit.
+- **Structured context**: include `{ agentId, version, visibility, role, mode }` where applicable.
+- **Credential safety**: never log raw `ConfigJson` if it could carry a `systemPromptRef` resolving to sensitive content; configs are credential-agnostic by design (no raw keys) but redact on validation-error logs to be safe.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-32/story-32-10/32-10-benchmark-projections-and-leaderboards.md
+++ b/docs/stories/epic-32/story-32-10/32-10-benchmark-projections-and-leaderboards.md
@@ -1,0 +1,367 @@
+# Story 32-10: Benchmark Projections & Leaderboards (per agent/provider/prompt, per-tenant)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+This story targets the C# **`apps/tamma-elsa`** stack (Tamma.Api + Tamma.Data + Tamma.Core). The TypeScript `packages/api` is **deleted** — do not reference it. DCB event sourcing, the agent action trail (32-6), outcome/defect capture (32-8), usage/cost emission (32-9), the per-tenant `TenantDbContext`, and the `IEventRepository` tenant-scoped store all live in `apps/tamma-elsa`.
+
+## User Story
+
+As a **tenant owner/member choosing which agent, provider, prompt, or persona to trust with my design and review work**,
+I want my own action-trail + outcome + usage data folded into per-tenant **benchmark projections** — success rate, average iterations-to-done, defect rate by taxonomy category, p50/p95 latency, and average cost-basis / billable per task — and exposed as **leaderboards** that rank agents, providers, prompts, and personas *within my tenant only*,
+So that I can pick the best-performing configuration on real downstream quality and cost, while being certain my performance data never leaks to another tenant or to the platform admin who owns a public agent definition.
+
+## Priority
+
+P1 — the read-model payoff of the Epic 32 tracking stack. 32-6 captures the trail, 32-8 scores outcomes + classifies defects, 32-9 emits usage/cost; this story turns all three event families into the leaderboards a tenant actually reads to make decisions. Without it the captured data is queryable row-by-row but not comparable across agents/providers/prompts.
+
+## Acceptance Criteria
+
+1. A **projection engine** (`BenchmarkProjectionService`) deterministically folds the resolving tenant's `DomainEvents` — the `AGENT.TASK.SUCCESS`/`.FAILED`/`.PARTIAL` and `AGENT.OUTCOME.RECORDED` (32-6/32-8), `AGENT.DEFECT.RECORDED` (32-8), `AGENT.ITERATION.COMPLETED`/`AGENT.PANEL.AGGREGATED` (32-6/32-7), and `AGENT.USAGE.RECORDED` (32-9) families — into materialized **per-agent / per-provider / per-prompt / per-persona** benchmark rows stored in the **tenant's own schema** (`t_<hex>`), never on the control plane. Every projection row carries `TenantId` = the resolving tenant.
+2. Each benchmark row computes, over a selectable window: `successRate` (success ÷ terminal runs), `avgIterationsToDone` (mean of `iterationsToDone` over successful runs), `defectRateByCategory` (one rate per the 6 taxonomy buckets `visual|functional|regression|security|performance|style`, plus `other`), `latencyP50Ms` / `latencyP95Ms`, `avgCostBasisUsd` (provider/model cost basis), `avgBillableUsd` (marked-up/billable amount from 32-9), and `runCount`. Percentiles are computed over the run-latency distribution, not averaged.
+3. Projections fold **idempotently** with a **`SequenceNumber` cursor** per dimension: each projection-target row tracks the highest `SequenceNumber` it has consumed; re-folding the same events is a no-op (same input → same output). New events advance the cursor and update incrementally. A **full rebuild** (cursor reset → replay from 0) produces byte-identical rows to the incremental path. (AC tested for equivalence.)
+4. A **leaderboard query API** `GET /api/v1/orgs/{tenantId}/agents/leaderboard?dimension=agent|provider|prompt|persona&window=…` returns ranked, **tenant-scoped** results: ordered by the primary metric (default `successRate` desc) with documented, deterministic **tie-breaking** (`successRate` desc → `avgIterationsToDone` asc → `avgCostBasisUsd` asc → dimension key asc) and a **minimum-sample-size guard** (`minRuns`, default 5): rows below the threshold are returned in a separate `belowThreshold` bucket (or flagged `provisional: true`), never silently ranked as if statistically meaningful.
+5. **Tenant isolation is strict and structural.** All reads/writes go through `IEventRepository` / `ITenantDbContextFactory`, which scope to the resolving tenant's schema; there is **no cross-tenant and no platform-admin read path** for a tenant's benchmark rows. A platform owner (`OwnerAccess`/`PlatformOwnerAccess`) calling a tenant's leaderboard for another tenant gets 403/404, never that tenant's data. This holds even when the benchmarked agent is a **public/system** definition: one definition → many independent per-tenant datasets (design-spec tenancy rule). **Explicitly tested.**
+6. The **platform-admin cross-tenant view is limited to public agents and aggregated/anonymized**: `GET /api/v1/admin/agents/{agentId}/benchmark` (`PlatformOwnerAccess`) returns a fleet-wide rollup for a **public** agent definition **only**, computed across tenants with a **k-anonymity threshold** (`minTenants`, default 5) — below k tenants contributing, the rollup is suppressed (404/empty). It **never** returns a single tenant's row, a tenant identifier, or a private-agent rollup. **Explicitly tested** (the negative case: k-1 tenants → suppressed; private agent → 404; no `tenantId` ever in the payload).
+7. The projection read models are consistent with the **backend-development projection patterns**: idempotent fold, cursor-tracked, replayable from the event stream, with the projection as a derived materialized view that can be dropped and rebuilt from events at any time (the events are the source of truth; the projection is a cache).
+8. Benchmark rows are **member-readable** (any tenant member can GET the leaderboard); there is **no tenant mutation surface** for projection rows (they are derived, not edited). An admin/operator **rebuild** trigger exists (`POST /api/v1/orgs/{tenantId}/agents/leaderboard/rebuild`, tenant_owner/tenant_admin) that resets cursors and replays — `member` → 403.
+9. Projection updates are **non-blocking to agent runs**: the fold runs on a background projector (or on-demand at query time against the trail with a cache), never inside the managed-agent execution path. A projection-write failure is logged + retried and never fails or delays a run.
+10. **Tests** cover: (a) **metric correctness** against fixture event streams (known success/fail/partial mix, known iteration counts, known defect categories, known latency distribution for p50/p95, known cost/billable) → asserted exact metric values; (b) **incremental-vs-full-rebuild equivalence** (replay produces identical rows); (c) **leaderboard ordering + tie-break + min-sample guard**; (d) **tenant isolation** (tenant B cannot read tenant A's benchmark via any path; platform admin denied per-tenant); (e) **k-anonymity** on the admin public-agent rollup (below-k suppressed; no tenant id leaks); (f) **idempotency** (double-fold = single result).
+
+## Technical Design
+
+### Where the data comes from and where the projection lives (verified against repo @ main 98cfb1c2, 2026-06-17)
+
+The benchmark is a **read model derived from the tenant's DCB event stream** — the same `domain_events` table the action trail (32-6), outcome/defect capture (32-8), and usage/cost emission (32-9) write into. Isolation is **structural**: the projection table lives in the tenant's `t_<hex>` schema, written + read through `ITenantDbContextFactory`, exactly like every other tenant-resident entity on `TenantDbContext`.
+
+| Component | File (verified) | Role in this story |
+|---|---|---|
+| DCB event row (source of truth) | `apps/tamma-elsa/src/Tamma.Data/Entities/DomainEvent.cs` | `Type`, `TenantId`, JSONB `Tags`/`Data`, `CreatedAt`, **`SequenceNumber` (`BIGSERIAL`)** — the fold cursor. Reused verbatim, **no schema change**. |
+| Tenant-scoped event store | `apps/tamma-elsa/src/Tamma.Data/Repositories/{IEventRepository,EventRepository}.cs` | `QueryWithPaginationAsync`/`ListByTenantAsync` scope to one tenant and **throw `NotSupportedException` on a null tenant** — the isolation backbone the fold reads through. We add `QueryAgentEventsForProjectionAsync` (cursor-paged, tenant-scoped, type-prefix filtered). |
+| Per-tenant DbContext | `apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs` | Owns per-tenant business data; we add `DbSet<BenchmarkProjection>` + `DbSet<BenchmarkProjectionCursor>`. Target shape (Doc 01 §1.4) has **no `TenantId` column** on tenant tables — but we keep a transitional `TenantId` for the shared-DB phase, mirroring `agent_configs`/`domain_events`. |
+| Schema-per-tenant routing | `ITenantDbContextFactory` / `ITenantContext` (`Tamma.Data`) | Structural isolation plane — no new plumbing. |
+| DCB emission precedent | `apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs` (`UpdateConfig`, ~93-113) | Canonical `DomainEvent { Type, TenantId, Tags=flat strings, Metadata=envelope, Data }` shape; this story **reads** that shape, emits only `BENCHMARK.PROJECTION.*` lifecycle events. |
+| Cost/latency source | `apps/tamma-elsa/src/Tamma.Data/Entities/ProviderDiagnostic.cs` (`CorrelationId`, `AgentType`, `InputTokens`/`OutputTokens`, `Cost`, `RequestDurationMs`) | Latency + cost-basis substrate; 32-9 surfaces these as `AGENT.USAGE.RECORDED` events keyed by `(agentId, correlationId)` — this story folds the *events*, not the diagnostics table directly, so the fold stays replayable. |
+| Tenant-scope endpoint precedent | `apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs` + tenant `/api/v1/orgs/{tenantId}/…` group with `RequireTenantMembershipFilter` (`apps/tamma-elsa/src/Tamma.Api/Authorization/RequireTenantMembershipFilter.cs`) | The exact member-readable tenant-path pattern the leaderboard endpoints ride. |
+| Auth policies | `apps/tamma-elsa/src/Tamma.Api/Program.cs` (`OwnerAccess`, `PlatformOwnerAccess`, `MemberAccess`, ~971-991) | `MemberAccess` for tenant leaderboard read; tenant_owner/tenant_admin for rebuild; `PlatformOwnerAccess` for the public-agent fleet rollup. |
+| Analytics seam | `apps/tamma-elsa/src/Tamma.Api/Services/AnalyticsService.cs` + `apps/tamma-elsa/src/Tamma.Core/Interfaces/IAnalyticsService.cs` | The existing analytics service (mentorship-oriented, mostly TODO stubs). Benchmark projection is a **distinct, agent-scoped service** (`BenchmarkProjectionService`); we do **not** overload the mentorship `AnalyticsService`. They are cited together because both are the "analytics read-model" family; the leaderboard surface is the agent-benchmark half. |
+
+> **NEW files** are marked NEW in the Files table. `BenchmarkProjectionService.cs`, the `BenchmarkProjection`/`BenchmarkProjectionCursor` entities, the projector background service, and the leaderboard DTOs/endpoints do **not** exist yet — they are created by this story. `DomainEvent.cs`, `ProviderDiagnostic.cs`, `EventRepository.cs` (other than the additive query method), and `AnalyticsService.cs` are **referenced**, not rewritten.
+
+### Source events (the fold inputs)
+
+The projection consumes only events that already exist (or are introduced by sibling 32-x stories) — it adds **no new source event family**:
+
+| Source event | Producer | Fold contribution |
+|---|---|---|
+| `AGENT.TASK.SUCCESS` / `.FAILED` / `.PARTIAL` | 32-6 | terminal-run count + `successRate` numerator/denominator; `durationMs` (run latency for percentiles); `costUsd` fallback |
+| `AGENT.OUTCOME.RECORDED` | 32-8 | `outcome` + `iterationsToDone` (authoritative for `avgIterationsToDone`); supersedes the `AGENT.TASK.*` outcome when both present for a run |
+| `AGENT.DEFECT.RECORDED` | 32-8 | per-category defect count → `defectRateByCategory[category]` (defects per run); `category` ∈ `BugCategory` wire strings |
+| `AGENT.ITERATION.COMPLETED` | 32-6/32-7 | iteration count fallback when `AGENT.OUTCOME.RECORDED` is absent |
+| `AGENT.PANEL.AGGREGATED` | 32-7 | persona/strategy attribution for panel runs |
+| `AGENT.USAGE.RECORDED` | 32-9 (**sibling — mark NEW if 32-9 unmerged**) | `costBasisUsd` (provider/model cost) + `billableUsd` (marked-up) → `avgCostBasisUsd`/`avgBillableUsd`; tokens; provider/model dimension keys |
+
+> **32-9 dependency note:** the `AGENT.USAGE.RECORDED` event type and its `costBasisUsd`/`billableUsd` data fields are owned by **Story 32-9** (Agent usage & cost emission). At authoring time the 32-9 story file is **NEW (not yet drafted)**. This story consumes that event by name per the design spec (§Tracking: "usage/cost emission (tokens + provider/model cost basis) consumed by Epics 34/35/36"); if 32-9 lands after 32-10 begins, the cost columns degrade gracefully to `null`/`0` and the fold backfills on the next rebuild once usage events exist. **Do not invent a parallel usage event** — align the type/field names with 32-9 before merge.
+
+### Projection entity (tenant schema)
+
+```csharp
+// apps/tamma-elsa/src/Tamma.Data/Entities/BenchmarkProjection.cs  (NEW)
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Per-tenant materialized benchmark row: one row per (dimension, dimensionKey,
+/// window) within a tenant's schema. Derived (a cache) — the tenant's
+/// domain_events stream is the source of truth; this row can be dropped and
+/// rebuilt from events at any time (backend-development projection-patterns).
+/// </summary>
+public class BenchmarkProjection
+{
+    public Guid Id { get; set; }
+    public Guid? TenantId { get; set; }            // transitional (shared-DB phase); structural isolation is the schema
+
+    public string Dimension { get; set; } = null!; // "agent" | "provider" | "prompt" | "persona"
+    public string DimensionKey { get; set; } = null!; // agentId | provider name | promptRef | personaId
+    public string Window { get; set; } = null!;    // "7d" | "30d" | "90d" | "all"
+
+    // Counts
+    public int RunCount { get; set; }
+    public int SuccessCount { get; set; }
+    public int FailCount { get; set; }
+    public int PartialCount { get; set; }
+
+    // Metrics
+    public double SuccessRate { get; set; }
+    public double AvgIterationsToDone { get; set; }
+    public double LatencyP50Ms { get; set; }
+    public double LatencyP95Ms { get; set; }
+    public decimal AvgCostBasisUsd { get; set; }
+    public decimal AvgBillableUsd { get; set; }
+
+    /// JSON map { "functional": 0.12, "security": 0.03, ... } — rate per BugCategory.
+    public string DefectRateByCategory { get; set; } = "{}";
+
+    public DateTime ComputedAt { get; set; }
+}
+
+// apps/tamma-elsa/src/Tamma.Data/Entities/BenchmarkProjectionCursor.cs  (NEW)
+/// One cursor per (dimension, dimensionKey, window): the highest DomainEvent
+/// SequenceNumber folded into the row. Incremental folds resume from here;
+/// a rebuild resets it to 0. This is what makes the fold idempotent + replayable.
+public class BenchmarkProjectionCursor
+{
+    public Guid Id { get; set; }
+    public Guid? TenantId { get; set; }
+    public string Dimension { get; set; } = null!;
+    public string DimensionKey { get; set; } = null!;
+    public string Window { get; set; } = null!;
+    public long LastSequenceNumber { get; set; }   // BIGSERIAL cursor — never CreatedAt
+    public DateTime UpdatedAt { get; set; }
+}
+```
+
+`UNIQUE (TenantId, Dimension, DimensionKey, Window)` on both tables (NULLS NOT DISTINCT on `TenantId`, mirroring the established tenant-entity convention) so the upsert key is the fold target and a concurrent fold collapses to one row.
+
+### Projection engine (the fold)
+
+```csharp
+// apps/tamma-elsa/src/Tamma.Api/Services/Agents/BenchmarkProjectionService.cs  (NEW)
+public interface IBenchmarkProjectionService
+{
+    /// Incrementally fold new events (SequenceNumber > cursor) into the tenant's
+    /// benchmark rows for one or all dimensions. Idempotent; replayable.
+    Task ProjectAsync(Guid tenantId, string? dimension = null, CancellationToken ct = default);
+
+    /// Full rebuild: reset cursors → replay from SequenceNumber 0. Produces
+    /// byte-identical rows to the incremental path (AC3).
+    Task RebuildAsync(Guid tenantId, CancellationToken ct = default);
+
+    /// Read the ranked leaderboard for a dimension + window (query-time read;
+    /// no recompute — rows are pre-folded). Applies tie-break + min-sample guard.
+    Task<LeaderboardResult> GetLeaderboardAsync(
+        Guid tenantId, string dimension, string window, int minRuns, CancellationToken ct = default);
+}
+```
+
+The fold is a pure reducer over the event stream:
+
+```
+foreach event in events where SequenceNumber > cursor, ordered by SequenceNumber:
+    key = dimensionKeyFor(dimension, event.Tags)   // agentId | provider | promptRef | personaId
+    bucket[key].apply(event)                        // increment counts / accumulate latency / costs / defects
+    cursor[key] = event.SequenceNumber
+percentiles: p50/p95 computed from the accumulated per-run latency sample (t-digest or sorted-sample)
+upsert bucket rows; persist cursors
+```
+
+Idempotency comes from the `SequenceNumber` cursor — an event already folded (its `SequenceNumber <= cursor`) is skipped, so re-running `ProjectAsync` is a no-op (AC3). `RebuildAsync` zeroes the cursor and replays, guaranteeing the incremental and full-rebuild rows match.
+
+### Leaderboard query + ranking
+
+```csharp
+// GET /api/v1/orgs/{tenantId}/agents/leaderboard?dimension=agent&window=30d&minRuns=5
+public static async Task<IResult> GetLeaderboard(
+    HttpContext http, IBenchmarkProjectionService svc, ITenantContext tenantContext,
+    Guid tenantId, string dimension = "agent", string window = "30d", int? minRuns = null)
+{
+    // tenantId is route-bound + validated by RequireTenantMembershipFilter;
+    // the read is physically scoped by the tenant DbContext to that schema.
+    if (!ValidDimensions.Contains(dimension))
+        return Results.BadRequest(new { error = "invalid_dimension", valid = ValidDimensions });
+
+    var result = await svc.GetLeaderboardAsync(
+        tenantId, dimension, window, minRuns is > 0 ? minRuns.Value : 5, http.RequestAborted);
+
+    return Results.Ok(new
+    {
+        dimension, window,
+        ranked = result.Ranked,            // >= minRuns, ordered by tie-break chain
+        belowThreshold = result.Provisional // < minRuns, surfaced separately, never ranked
+    });
+}
+```
+
+**Ranking order (deterministic, documented):** `successRate` desc → `avgIterationsToDone` asc → `avgCostBasisUsd` asc → `dimensionKey` asc (final stable tiebreak). **Min-sample guard:** rows with `runCount < minRuns` go to `belowThreshold`, never into `ranked`.
+
+### Platform-admin fleet rollup (public agents only, k-anonymous)
+
+```csharp
+// GET /api/v1/admin/agents/{agentId}/benchmark?window=30d   (PlatformOwnerAccess)
+// - agentId MUST be a PUBLIC/system agent definition (else 404).
+// - Aggregates the SAME metrics across tenants that ran this public agent.
+// - k-anonymity: requires >= minTenants (default 5) distinct contributing tenants;
+//   below k → 404/empty. NEVER returns a per-tenant row, a tenantId, or a private-agent rollup.
+```
+
+This is the **only** cross-tenant view, and it is deliberately narrow: a platform admin who owns a public agent definition sees an anonymized fleet average (is `atlas` a good default?) but **zero** of any single tenant's data. Computing it requires a per-tenant fan-out over the warm-tenant set (the same fan-out `EventRepository` documents as "build when a story demands it" — this story is that demand, scoped to public agents only). The fan-out reads each contributing tenant's pre-folded `BenchmarkProjection` rows for the public agent's `agentId`, then aggregates with the k-guard; it never exposes the per-tenant rows it read.
+
+### Per-mode / per-tenant ownership (mandatory two-scoping answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns the benchmark data? | The sole user — their instance, their dataset (single tenant). | The tenant that generated it. ALWAYS tenant-scoped; one public agent definition → many independent per-tenant datasets (design spec §Ownership). |
+| Who reads the leaderboard? | The user (member-read). | Any tenant member (`MemberAccess`) for their own tenant only. |
+| Who can rebuild? | The user. | tenant_owner / tenant_admin; `member` → 403. |
+| Can a platform admin read a tenant's benchmark? | N/A (sole user). | **No.** Per-tenant rows are structurally unreachable cross-tenant. The only admin view is the **k-anonymized public-agent fleet rollup** — never a single tenant's data, never a tenant id. |
+| Where do projection rows + cursors live? | The single tenant store. | The originating tenant's `t_<hex>` schema (per-tenant routing via `ITenantDbContextFactory`). |
+| Mode source | `ITammaModeProvider` (process-stable). | same |
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Projection entities + tenant migration (AC 1, 3, 7)
+  - [ ] Subtask 1.1: Add `BenchmarkProjection` + `BenchmarkProjectionCursor` entities; `DbSet`s on `TenantDbContext`; model config (unique key, JSON column, transitional `TenantId`) in the tenant model configuration
+  - [ ] Subtask 1.2: Additive **Tenant** EF migration (`dotnet ef migrations add` against the Tenant context; the `InitialTenant` baseline exists — this is additive, not a baseline edit); verify `has-pending-model-changes` reports none after
+- [ ] Task 2: Projection engine (AC 1, 2, 3, 7, 9)
+  - [ ] Subtask 2.1: `IBenchmarkProjectionService` + `BenchmarkProjectionService`; `dimensionKeyFor` (agent/provider/prompt/persona from `Tags`); the per-bucket reducer (counts, success rate, iterations, defects-by-category, latency sample, cost/billable)
+  - [ ] Subtask 2.2: `IEventRepository.QueryAgentEventsForProjectionAsync` (tenant-scoped, `SequenceNumber > cursor`, type-prefix filter, `NotSupportedException` on null tenant) + `EventRepository` impl
+  - [ ] Subtask 2.3: p50/p95 from the run-latency distribution (sorted-sample or t-digest); cursor-tracked idempotent upsert; `ProjectAsync` (incremental) + `RebuildAsync` (reset→replay)
+  - [ ] Subtask 2.4: Background projector (BackgroundService, interval + on-demand) so the fold is off the run path; non-blocking failure handling (log + retry, never throw)
+- [ ] Task 3: Tenant leaderboard API (AC 4, 5, 8)
+  - [ ] Subtask 3.1: `GET /api/v1/orgs/{tenantId}/agents/leaderboard` (member-read) with dimension/window/minRuns; tie-break chain; `ranked` vs `belowThreshold` split
+  - [ ] Subtask 3.2: `POST /api/v1/orgs/{tenantId}/agents/leaderboard/rebuild` (tenant_owner/tenant_admin; member → 403) → 202, triggers `RebuildAsync`
+  - [ ] Subtask 3.3: Leaderboard DTOs + cursor-free read shape; map under `/api/v1/orgs/{tenantId}` with `RequireTenantMembershipFilter`
+- [ ] Task 4: Platform-admin public-agent fleet rollup (AC 6)
+  - [ ] Subtask 4.1: `GET /api/v1/admin/agents/{agentId}/benchmark` (`PlatformOwnerAccess`); reject non-public/private agent → 404
+  - [ ] Subtask 4.2: Per-tenant fan-out over warm tenants reading pre-folded rows; k-anonymity guard (`minTenants`, default 5) → suppress below k; assert payload carries no `tenantId`
+- [ ] Task 5: Tests (AC 10)
+  - [ ] Subtask 5.1: Metric correctness vs fixture streams (exact successRate / avgIterationsToDone / defectRateByCategory / p50 / p95 / avgCostBasisUsd / avgBillableUsd)
+  - [ ] Subtask 5.2: Incremental-vs-full-rebuild equivalence; double-fold idempotency
+  - [ ] Subtask 5.3: Leaderboard ordering + tie-break + min-sample guard
+  - [ ] Subtask 5.4: Tenant isolation (B cannot read A; platform admin denied per-tenant)
+  - [ ] Subtask 5.5: k-anonymity (k-1 tenants → suppressed; private agent → 404; no tenant id in payload)
+
+## Dependencies
+
+**Internal Dependencies:**
+
+- **Prerequisite — Story 32-6** (Agent action trail): supplies the `AGENT.TASK.*`, `AGENT.ITERATION.COMPLETED`, `AGENT.PANEL.AGGREGATED` events tagged `agentId`/`agentVersion`/`provider`/`promptRef` in the tenant store, and the `SequenceNumber` cursor convention this fold reuses. Hard prerequisite — there is nothing to project without the trail.
+- **Prerequisite — Story 32-8** (Outcome capture & bug taxonomy): supplies `AGENT.OUTCOME.RECORDED` (`outcome` + `iterationsToDone`) and `AGENT.DEFECT.RECORDED` (`category` ∈ `BugCategory`) — the success-rate, iterations-to-done, and defect-rate inputs. Hard prerequisite for those three metric families.
+- **Prerequisite — Story 32-9** (Agent usage & cost emission): supplies `AGENT.USAGE.RECORDED` carrying `costBasisUsd` / `billableUsd` / tokens — the cost columns. **The 32-9 story file is NEW (not yet drafted)**; align the event type + field names before merge. Soft-degrades: cost columns are `null`/`0` until usage events exist, backfilled on rebuild.
+- **Related — Story 32-7** (Multi-agent panels): `AGENT.PANEL.AGGREGATED` supplies persona/strategy attribution for the persona dimension; gracefully degrades if panels are off (single-agent runs still benchmark by agent/provider/prompt).
+- **Related — Story 32-12** (Agent personas & persona-aware benchmarking): the `persona` dimension is wired here; 32-12 enriches persona attribution. This story ships the dimension; 32-12 populates richer persona semantics.
+- **Related — Story 32-13** (Agent management & benchmark dashboards): the dashboard consumes the leaderboard + admin-rollup endpoints this story exposes.
+- **Epic 4** (DCB event sourcing): `DomainEvent`, `IEventRepository`, and the `SequenceNumber` `BIGSERIAL` cursor are the projection substrate — all reused, no new event infrastructure.
+- **Epic 36** (Analytics & Reporting Platform): the dimensional analytics store (36-1) and DCB-driven projection population (36-2) are the platform-wide analogue; this story is the **agent-benchmark** read model in the **tenant** schema. They share the cursor-tracked, idempotent, replayable projection pattern (36-1/36-2 establish it for the CP fleet store; this story applies it per-tenant for agent benchmarks). No code dependency — pattern alignment only.
+
+**External Dependencies:**
+
+- None new. Reuses EF Core 9 / Npgsql, the existing tenant event store, `ITenantDbContextFactory`, and the `RequireTenantMembershipFilter` tenant-path gate.
+
+## Testing Strategy
+
+1. **Metric-correctness tests (highest priority — AC 2, 10a)** (`Tamma.Api.Tests/Agents/BenchmarkProjectionServiceTests.cs`): build a fixture `DomainEvent` stream with a known mix — e.g. 10 runs (7 success / 2 fail / 1 partial), `iterationsToDone` {1,2,3,…}, defects {3 functional, 1 security}, run latencies {100,150,200,…ms}, costs {0.01,0.02,…} — and assert the folded row's `successRate == 0.7`, `avgIterationsToDone`, `defectRateByCategory["functional"]`, `latencyP50Ms`/`latencyP95Ms` (against a hand-computed percentile), `avgCostBasisUsd`, `avgBillableUsd`, `runCount` to exact values.
+2. **Idempotency + rebuild-equivalence tests (AC 3, 10b/f):** fold a stream; fold again → identical row + no double-count (cursor skip). Then `RebuildAsync` (cursor reset → replay) → byte-identical rows to the incremental path. Append more events → incremental advance equals a fresh full rebuild.
+3. **Leaderboard ordering tests (AC 4, 10c):** seed rows with deliberate ties on `successRate`; assert the full tie-break chain (`avgIterationsToDone` asc → `avgCostBasisUsd` asc → key asc); assert `runCount < minRuns` rows land in `belowThreshold`, not `ranked`.
+4. **Tenant-isolation tests (docker-bound, `sg docker -c "dotnet test ..."` — AC 5, 10d):** seed benchmark rows for tenant A and B; assert `GET /api/v1/orgs/{B}/agents/leaderboard` returns only B's; a member of A hitting B's path is rejected by `RequireTenantMembershipFilter` (403/404); a platform owner has no per-tenant leaderboard route; a public agent run by A leaves benchmark rows only in A's schema.
+5. **k-anonymity tests (AC 6, 10e):** stand up k-1 tenants contributing to a public agent → admin rollup suppressed (404/empty); k tenants → rollup returned with aggregated metrics and **no `tenantId` field anywhere in the payload** (assert via JSON inspection); a **private** agent → 404 regardless of tenant count.
+6. **Non-blocking / background tests (AC 9):** inject a projection-write failure; assert it is logged + retried and never surfaces to a run; assert the projector runs off the run path (the managed-agent execution does not call the fold synchronously).
+
+Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/`; docker-bound suites run via `sg docker -c "dotnet test ..."`. TDD: write the metric-correctness + isolation + k-anonymity tests first.
+
+## Estimated Effort
+
+5-6 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/BenchmarkProjection.cs` | Create (NEW) |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/BenchmarkProjectionCursor.cs` | Create (NEW) |
+| `apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs` | Modify (add `DbSet<BenchmarkProjection>` + `DbSet<BenchmarkProjectionCursor>`) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (configure the two tenant entities: unique key, JSON column, transitional `TenantId`) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/<ts>_AddBenchmarkProjections.cs` | Create (additive Tenant migration; baseline `InitialTenant` already exists) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/IBenchmarkProjectionService.cs` | Create (NEW) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/BenchmarkProjectionService.cs` | Create (NEW — the idempotent, cursor-tracked fold + leaderboard read) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/BenchmarkProjectorBackgroundService.cs` | Create (NEW — off-run-path projector; interval + on-demand) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/BenchmarkEventTypes.cs` | Create (NEW — `BENCHMARK.PROJECTION.UPDATED` / `.REBUILT` lifecycle event constants + the consumed source-type prefixes) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentLeaderboardEndpoints.cs` | Create (NEW — tenant leaderboard + rebuild + admin public-agent rollup) |
+| `apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/BenchmarkDtos.cs` | Create (NEW — leaderboard / row / rollup wire shapes) |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/IEventRepository.cs` | Modify (add `QueryAgentEventsForProjectionAsync`) |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/EventRepository.cs` | Modify (implement it; `SequenceNumber > cursor`, tenant-scoped, null-tenant guard) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (DI: `IBenchmarkProjectionService` + projector hosted service; map leaderboard + rebuild + admin-rollup routes) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/BenchmarkProjectionServiceTests.cs` | Create (NEW) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/BenchmarkLeaderboardEndpointsTests.cs` | Create (NEW) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/BenchmarkIsolationTests.cs` | Create (NEW) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/BenchmarkKAnonymityTests.cs` | Create (NEW) |
+
+> Note: `apps/tamma-elsa/src/Tamma.Data/Entities/DomainEvent.cs`, `ProviderDiagnostic.cs`, and `AnalyticsService.cs` are **referenced, not modified** — this story reads the existing DCB row shape and diagnostics, and does not overload the mentorship `AnalyticsService`. (`packages/api` is deleted; all work is in the C# `apps/tamma-elsa` stack.)
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes/bugs/findings/decisions — especially `.dev/decisions/story-28-1-design-calls.md` (Decision #2: cross-tenant read routing / per-tenant fan-out — the basis for the public-agent fleet rollup's fan-out and for why per-tenant rows are structurally unreachable)
+3. Read sibling stories **32-6** (action trail — the source events + `SequenceNumber` cursor), **32-8** (outcome/defect events + `BugCategory`), and the **32-9** design intent (usage/cost events) — align event type + tag/data field names exactly before merge
+4. Read the Epic 32 design spec `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md` (the tenancy rule: definition ownership ≠ data ownership; **leaderboards are computed within a tenant's own data**; platform admin cannot read tenant performance)
+5. Reviewed the **backend-development projection-patterns** (idempotent fold, cursor-tracked read models, replayable from the event stream) — and 36-1/36-2 for the in-repo precedent of a cursor-tracked, idempotent analytics projection
+6. Planned the TDD cycle (metric-correctness + isolation + k-anonymity tests first)
+
+### Key design decisions
+
+- **Projection is a derived cache; events are the source of truth.** The benchmark row can be dropped and rebuilt from the tenant's `domain_events` at any time. `RebuildAsync` (reset cursor → replay) is the safety valve and the equivalence-test target. This is the backend-development projection pattern applied per-tenant.
+- **`SequenceNumber` is the fold cursor, never `CreatedAt`.** `CreatedAt` has same-millisecond collisions; `SequenceNumber` is the server-side `BIGSERIAL` total order. Idempotency (skip `SequenceNumber <= cursor`) and incremental-vs-rebuild equivalence both ride on it.
+- **Isolation is structural, not an app filter.** Projection rows live in the tenant's `t_<hex>` schema and are read/written only through `ITenantDbContextFactory`; there is no cross-tenant route for per-tenant rows, and `IEventRepository` throws on null-tenant scoped reads. A platform owner who owns a public agent sees zero of any tenant's benchmark — exactly the design-spec tenancy rule.
+- **The single cross-tenant view is narrow, public-only, and k-anonymous.** The admin fleet rollup answers "is my public default any good?" without ever exposing a single tenant's data, a tenant id, or a private-agent rollup. k-anonymity (≥ minTenants) is the privacy floor; below it, suppress.
+- **Min-sample guard, not silent ranking.** A reviewer with 2 runs and 100% success is not "the best reviewer" — it is provisional. The leaderboard splits `ranked` (≥ minRuns) from `belowThreshold` so a tiny sample never masquerades as a meaningful ranking.
+- **Fold is off the run path.** Benchmark projection never executes inside a managed-agent run; a projector background service folds on an interval / on-demand. A projection failure can never fail or delay an agent run (matches the non-blocking precedent across 32-6/32-8).
+- **Do not overload the mentorship `AnalyticsService`.** It is a separate (mostly-stub) concern; agent benchmarking gets its own `BenchmarkProjectionService`. They are siblings in the analytics read-model family, not the same service.
+
+### Integration points
+
+- **32-6 trail + 32-8 outcomes/defects + 32-9 usage** are the producers; this story is a pure consumer of their DCB events. Coordinate event-type + tag/data field names before merge (especially 32-9's `AGENT.USAGE.RECORDED` shape, which is NEW).
+- **`RequireTenantMembershipFilter` + `/api/v1/orgs/{tenantId}` group** is the tenant path-gate the leaderboard rides — member-read, owner/admin rebuild.
+- **`ITenantDbContextFactory`** is the structural isolation plane for both the fold (per-tenant write) and the admin fan-out (per-tenant read of pre-folded rows for a public agent).
+- **36-1/36-2** are the platform-wide analytics analogue; share the projection pattern, not code.
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+| ---- | --------- | ---------- |
+| Cross-tenant leakage of performance data | Critical | Per-tenant schema + `ITenantDbContextFactory`; no per-tenant cross-tenant route; null-tenant scoped reads throw; explicit isolation tests incl. platform-admin-denied |
+| Admin rollup de-anonymizes a tenant | Critical | Public-agent-only; k-anonymity (≥ minTenants) suppression; assert no `tenantId` in payload; private agent → 404; negative-case test (k-1 suppressed) |
+| Incremental fold diverges from a full rebuild | High | `SequenceNumber` cursor + pure reducer; rebuild-equivalence test is a gate |
+| 32-9 usage events not yet defined | Medium | Cost columns soft-degrade to null/0; backfill on rebuild once usage events exist; align names before merge — do NOT invent a parallel usage event |
+| Projection fold inside a run aborts/delays it | High | Off-run-path background projector; non-blocking failure (log + retry); test induces failure and asserts run unaffected |
+| Tiny-sample rows ranked as meaningful | Medium | Min-sample guard splits `ranked` vs `belowThreshold` |
+| p50/p95 wrong on skewed latency | Medium | Percentiles from the run-latency distribution (sorted-sample / t-digest), not averaged; hand-computed fixture assertion |
+
+### Success Metrics
+
+- [ ] Folded benchmark rows match hand-computed metrics on the fixture stream (exact)
+- [ ] Incremental and full-rebuild rows are byte-identical (equivalence test green)
+- [ ] 0 cross-tenant benchmark reads possible (isolation suite green)
+- [ ] Admin public-agent rollup never exposes a tenant id and is suppressed below k tenants
+- [ ] Leaderboard ordering, tie-break, and min-sample guard are deterministic and tested
+
+## Logging Requirements
+
+- **INFO**: projection fold completed (`tenantId`, `dimension`, rows updated, events folded, `lastSequenceNumber`); leaderboard served (`tenantId`, `dimension`, `window`, ranked count, belowThreshold count); rebuild completed (`tenantId`, duration, rows)
+- **DEBUG**: per-bucket fold step (`dimensionKey`, `sequenceNumber`); cursor advance; admin rollup tenant fan-out (count of contributing tenants — never tenant ids at INFO)
+- **WARN**: projection write failed/retried (`tenantId`, `dimension`, error); admin rollup suppressed below k-anonymity threshold (`agentId`, contributing-tenant count, k); leaderboard requested with unknown dimension
+- **ERROR**: terminal projection-write failure after retries (run still unaffected); repository/migration failure
+- **Structured context**: include `{ tenantId, dimension, dimensionKey, window, sequenceNumber, runCount }` where applicable
+- **Credential / privacy safety**: NEVER log a tenant id inside the admin fleet-rollup result path; NEVER log raw prompt/tool content (only `promptRef`); the admin rollup logs counts, never per-tenant identifiers
+
+## Related
+
+- Design spec: `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md` (§Ownership/data-scoping — leaderboards are PER-TENANT; §Tracking — performance projections)
+- Implementation plan: `docs/superpowers/plans/2026-06-17-32-10-benchmark-projections-and-leaderboards-plan.md`
+- Sibling stories: `docs/stories/epic-32/story-32-6` (action trail), `docs/stories/epic-32/story-32-8` (outcome/defect), `docs/stories/epic-32/story-32-9` (usage/cost — NEW), `docs/stories/epic-32/story-32-7` (panels), `docs/stories/epic-32/story-32-12` (personas), `docs/stories/epic-32/story-32-13` (dashboards)
+- Pattern precedent: `docs/superpowers/plans/2026-06-17-36-1-dimensional-analytics-projection-schema-and-store-plan.md` (cursor-tracked, idempotent, replayable analytics projection — CP fleet analogue)
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |
+</content>
+</invoke>

--- a/docs/stories/epic-32/story-32-11/32-11-learning-persistence-and-auto-learning-into-rag.md
+++ b/docs/stories/epic-32/story-32-11/32-11-learning-persistence-and-auto-learning-into-rag.md
@@ -1,0 +1,272 @@
+# Story 32-11: Learning Persistence & Auto-Learning into RAG
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **tenant running Tamma agents over many issues**,
+I want durable learnings (what worked / what failed for a given agent + role + task pattern) to be captured automatically from run outcomes and fed back into the RAG knowledge base,
+So that future runs of the same agent retrieve those lessons and steadily improve — without any learning ever leaking across tenants.
+
+## Priority
+
+P1 - Closes the Epic 32 learning loop; turns the action/outcome trail (32-8) and benchmark projections (32-10) into a feedback mechanism that changes future agent behaviour.
+
+## Context
+
+The Epic 32 design spec calls for a closed learning loop: *"persist `LearningCapture`/`KnowledgeEntry`; auto-generate learnings from outcomes; feed into the KB so RAG retrieves them in future runs."* The TypeScript type vocabulary for this already exists — `LearningCapture`, `KnowledgeEntry`, `PendingLearning`, and the review/approval state machine — in `packages/shared/src/types/knowledge.ts`, and `KnowledgeService` (`packages/intelligence/src/knowledge-base/knowledge-service.ts`) already implements `captureLearning` → `getPendingLearnings` → `approveLearning` (creating a `KnowledgeEntry` with embedding) and a RAG retrieval pipeline lives in `packages/intelligence/src/rag/`.
+
+What is **missing** is the durable, tenant-scoped backend and the C# auto-learning hook:
+
+1. The captured learning has **no persistent, tenant-scoped backend** — `LearningCapture`/`PendingLearning` resolve through whatever store `KnowledgeService` is constructed with; nothing ties a learning to an `agentId` + tenant in the per-tenant database, and nothing prevents a public agent's learnings from one tenant being served to another.
+2. There is **no auto-learning hook**: nothing listens for run/outcome events (`AGENT.OUTCOME.RECORDED`, `AGENT.DEFECT.RECORDED` from 32-8) to derive learnings from `whatWorked` / `whatFailed` / `rootCause` and recurring defect categories.
+3. There is **no ingestion into RAG** of approved learnings tagged so retrieval is scoped to `(agentId, tenant)`, and managed-agent context assembly (32-5) does not yet retrieve agent-scoped learnings.
+
+This story adds: (a) a tenant-scoped `AgentLearning` entity persisted in the per-tenant `TenantDbContext` (schema-per-tenant — isolation is structural; the row never carries another tenant's data), (b) an `AgentLearningService` (C#) that runs after `AGENT.OUTCOME.RECORDED`/`AGENT.DEFECT.RECORDED` to auto-generate learnings, deduplicate them, route them through a review/approval flow (`PendingLearning`), and ingest **approved** learnings into the RAG KB via `IIntelligenceHttpClient` tagged with `agentId` + tenant, and (c) wiring in `ManagedAgent` (32-5) context assembly to retrieve agent-scoped learnings and inject them into the prompt.
+
+**Tenancy rule (from the design spec).** Definition ownership and *data* ownership are separate: a public/system agent's *definition* is shared, but every learning it accumulates is **ALWAYS tenant-scoped**. Two tenants running public agent `atlas` build separate, private learning sets; neither sees the other's; the platform admin who owns `atlas` sees none of it. Because the TypeScript intelligence sidecar (`@tamma/intelligence-server`, reached via the shared `IIntelligenceHttpClient`) is a process-shared service, **the C# side is the source of truth for tenancy**: every KB upsert and every RAG query is tagged/filtered by `(agentId, tenantId)`, and retrieval that omits the caller's tenant filter returns nothing.
+
+## Acceptance Criteria
+
+1. An **`AgentLearning`** entity (tenant-scoped, persisted via `TenantDbContext`) captures `{ agentId, agentVersion, role, taskPattern, signal: 'success' | 'failure' | 'defect-category', lesson, sourceRunCorrelationId, status, createdAt }`. The row lives in the tenant's `t_<hex>` schema with no cross-tenant column (isolation is structural, per the Epic 28 model), and an additive EF migration adds the table under `src/Tamma.Data/Migrations/` with `has-pending-model-changes` reporting none afterwards.
+
+2. An **auto-learning hook** in `AgentLearningService` runs after `AGENT.OUTCOME.RECORDED` and `AGENT.DEFECT.RECORDED` (the 32-8 outcome/defect events): a **success** outcome with a non-empty `whatWorked` derives a `signal: 'success'` learning; a **failure/partial** outcome with `whatFailed`/`rootCause` derives a `signal: 'failure'` learning; a **recurring defect category** (same `category` for the same agent crossing a configurable count threshold within a window) derives a `signal: 'defect-category'` learning. The hook is **fire-and-forget-safe** — a capture fault is logged (WARN) and never aborts the workflow or masks the originating event (matching the `IMissingConfigRecorder` / `AgentOutcomeService` precedent).
+
+3. Auto-generated learnings are **deduplicated by similarity** before persistence: a candidate learning whose `(agentId, role, taskPattern, signal)` matches an existing open learning AND whose `lesson` is within a similarity threshold of the existing `lesson` is collapsed (bump `hitCount`/`lastSeen`, no new row, no new event) so a hot retry loop or recurring pattern produces one durable learning, not thousands.
+
+4. Captured learnings enter a **review/approval flow** modelled on `PendingLearning` (`status: 'pending' | 'approved' | 'rejected'`): auto-captured learnings start `pending`; an approval action promotes a learning to `approved` (and triggers RAG ingestion, AC5); a rejection sets `rejected` with a reason and never ingests. Auto-approval for high-confidence signals is gated behind a configurable `AgentLearning:AutoApprove` flag (default off) so unbounded auto-ingestion is opt-in.
+
+5. **Approved** learnings are written into the RAG knowledge base via the existing `IIntelligenceHttpClient` (KB/vector ingestion path → `KnowledgeService.approveLearning` / KB upsert), creating a `KnowledgeEntry` of `type: 'learning'`, **tagged with `agentId` + `tenantId`** so retrieval is scoped. The ingest payload carries the agent and tenant identifiers in the entry's tags/metadata; ingestion of a `rejected` or still-`pending` learning is impossible.
+
+6. **Managed-agent context assembly** (32-5 `ManagedAgent` RAG step) retrieves agent-scoped learnings from RAG — querying with a filter that includes the current `(agentId, tenantId)` — and injects the retrieved lessons into the rendered prompt. An integration test demonstrates that a follow-up run of the same agent receives a **demonstrably different assembled context** (the injected lesson) versus a run before the learning was ingested.
+
+7. **Tenant isolation:** a tenant's learnings for a **public** agent are NEVER retrieved by another tenant. A cross-tenant RAG retrieval test runs the same public agent under tenant A (ingesting a learning) and tenant B, and asserts tenant B's context assembly does NOT contain tenant A's lesson. A RAG query that omits the caller's tenant filter returns no tenant-scoped learnings (fail-closed).
+
+8. **Learning capture respects content sanitization**: the `lesson`/`whatWorked`/`whatFailed`/`rootCause` text is sanitized (reusing the `ContentSanitizer` seam from the managed-agent path) before persistence and ingestion so no secrets/PII are durably stored, and capture is **rate-limited per agent** (configurable `AgentLearning:MaxCapturesPerWindow`) on top of similarity dedup to prevent unbounded growth.
+
+9. **DCB events** `AGENT.LEARNING.CAPTURED` (on first persistence of a new learning) and `AGENT.LEARNING.APPLIED` (when an agent-scoped learning is retrieved and injected into a run's context) are emitted via the tenant `IEventRepository`, tagged `{ agentId, signal, lessonId, tenantId }`. A deduped (collapsed) capture and a rejected learning emit no `CAPTURED` event.
+
+10. **Reconciliation / lifecycle:** approving a learning that was already ingested is idempotent (no duplicate KB entry); deleting/rejecting a previously-approved learning removes (or disables) the corresponding `KnowledgeEntry` from the KB so retrieval stops surfacing it.
+
+11. **Tests** cover: auto-capture from a **success** outcome; auto-capture from a **recurring defect category**; **similarity dedup** (N identical candidates → one durable learning, one `CAPTURED` event); the **RAG round-trip** (capture → approve → ingest → retrieve → inject, asserting context changes); and **tenant isolation** (cross-tenant public-agent retrieval test). C# service tests verify the hook is fire-and-forget-safe (DB fault → WARN, no throw) and that sanitization strips a seeded secret.
+
+## Technical Design
+
+### Component map (all paths verified against the C# `apps/tamma-elsa` stack; `packages/api` is deleted and never referenced)
+
+```
+apps/tamma-elsa/src/Tamma.Api/Services/Agents/
+  IAgentLearningService.cs        # NEW — capture + approve/reject + retrieve contract
+  AgentLearningService.cs         # NEW — auto-learning hook, dedup, sanitize, ingest, events
+  AgentLearningEventTypes.cs      # NEW — AGENT.LEARNING.CAPTURED / .APPLIED constants
+  AgentLearningOptions.cs         # NEW — AutoApprove, MaxCapturesPerWindow, defect-recurrence threshold, similarity threshold
+  ManagedAgent.cs                 # MODIFY (32-5) — context assembly retrieves + injects agent-scoped learnings
+
+apps/tamma-elsa/src/Tamma.Api/Services/KnowledgeBase/
+  IIntelligenceHttpClient.cs      # EXISTS — KB/vector/RAG sidecar client (verified); reuse for ingest + query
+  IntelligenceHttpClient.cs       # EXISTS — verified
+
+apps/tamma-elsa/src/Tamma.Data/
+  Entities/AgentLearning.cs       # NEW — tenant-scoped entity
+  TenantDbContext.cs              # MODIFY — add DbSet<AgentLearning>
+  TammaModelConfiguration.cs      # MODIFY — ConfigureTenantEntities: AgentLearning model config + CHECK constraints
+  Migrations/                     # NEW — additive EF migration (agent_learnings table)
+
+packages/intelligence/src/knowledge-base/
+  knowledge-service.ts            # EXISTS — captureLearning / getPendingLearnings / approveLearning (verified); ingest target
+packages/intelligence/src/rag/
+  retriever.ts / rag-pipeline.ts  # EXISTS — RAG retrieval (verified); query path with agent/tenant tag filter
+
+packages/shared/src/types/
+  knowledge.ts                    # EXISTS — LearningCapture / KnowledgeEntry / PendingLearning (verified); shared vocabulary
+```
+
+> **Source-of-truth note.** The TypeScript `KnowledgeService` + RAG pipeline are reached through the process-shared `@tamma/intelligence-server` sidecar via the existing `IIntelligenceHttpClient` (a plain `HttpClient` against `/kb/*` routes — verified). Because the sidecar is shared across tenants, **tenancy is enforced on the C# side**: every ingest and query carries `(agentId, tenantId)` tags and a tenant filter. No new TypeScript package is introduced — the existing `LearningCapture`/`KnowledgeEntry`/`PendingLearning` vocabulary and `captureLearning`/`approveLearning` flow are reused as-is.
+
+### `AgentLearning` entity (tenant-scoped)
+
+```csharp
+// apps/tamma-elsa/src/Tamma.Data/Entities/AgentLearning.cs
+public class AgentLearning
+{
+    public Guid Id { get; set; }
+    public Guid AgentId { get; set; }            // join key — survives config edits (32-1)
+    public int AgentVersion { get; set; }        // config version that produced the outcome
+    public string Role { get; set; } = null!;    // architect/reviewer/... — like-vs-like
+    public string TaskPattern { get; set; } = null!; // normalized task/phase descriptor
+    public string Signal { get; set; } = null!;  // 'success' | 'failure' | 'defect-category' (CHECK)
+    public string Lesson { get; set; } = null!;  // sanitized, deduped lesson text
+    public string? DefectCategory { get; set; }  // set when Signal = 'defect-category'
+    public Guid SourceRunCorrelationId { get; set; } // ties learning to the originating run (32-5/32-8)
+    public string Status { get; set; } = "pending"; // 'pending' | 'approved' | 'rejected' (CHECK)
+    public string? KnowledgeEntryId { get; set; }    // KB entry id once ingested (AC5/AC10)
+    public int HitCount { get; set; } = 1;       // bumped on similarity dedup (AC3)
+    public DateTime CreatedAt { get; set; }
+    public DateTime LastSeen { get; set; }
+    public DateTime? ReviewedAt { get; set; }
+    public string? RejectionReason { get; set; }
+}
+```
+
+No `TenantId` column on the entity (Epic 28 target architecture — the row lives in the tenant's own schema; isolation is structural via `TenantDbContext`). `TammaModelConfiguration.ConfigureTenantEntities` registers the model with CHECK constraints on `Signal`/`Status` and a unique index on `(AgentId, Role, TaskPattern, Signal)` to anchor dedup (similarity collapse updates the matching open row rather than inserting).
+
+### Auto-learning hook
+
+```csharp
+// AgentLearningService.RecordFromOutcomeAsync — invoked after the 32-8 outcome/defect flush
+//   (AGENT.OUTCOME.RECORDED / AGENT.DEFECT.RECORDED), e.g. from AgentOutcomeService or the
+//   review/gate activity's post-flush hook, never on the hot resolve path.
+//
+// 1. Derive candidate(s):
+//    - outcome = success  + whatWorked   → signal 'success'
+//    - outcome = failure/partial + whatFailed/rootCause → signal 'failure'
+//    - defect category crossing recurrence threshold for this agent → signal 'defect-category'
+// 2. Sanitize the lesson text via ContentSanitizer (AC8) — no secrets/PII persisted.
+// 3. Rate-limit per agent (MaxCapturesPerWindow) and dedup by similarity against open learnings
+//    matching (agentId, role, taskPattern, signal) (AC3): collapse → bump HitCount/LastSeen, return.
+// 4. Persist a new AgentLearning (status 'pending'); emit AGENT.LEARNING.CAPTURED via tenant
+//    IEventRepository tagged { agentId, signal, lessonId, tenantId } (AC9).
+// 5. If AgentLearning:AutoApprove and high-confidence → ApproveAsync immediately (AC4/AC5).
+//
+// The whole method is try/catch-wrapped: a fault logs WARN and returns — never throws to the
+// caller (AC2), mirroring AgentOutcomeService / IMissingConfigRecorder.
+```
+
+`AGENT.OUTCOME.RECORDED` (32-8) carries `outcome` + `iterationsToDone` tagged with `agentId`/`agentVersion`; the outcome's `whatWorked`/`whatFailed`/`rootCause` fields ride in the event `data` (the `LearningCapture` vocabulary). `AGENT.DEFECT.RECORDED` carries `category` + agent attribution; the recurrence check queries the tenant event store for prior same-category defects for the agent (the 32-8 trail) before opening a `defect-category` learning.
+
+### RAG ingestion (approved learnings)
+
+```csharp
+// AgentLearningService.ApproveAsync(lessonId, edits?)
+// 1. Flip status -> 'approved', stamp ReviewedAt.
+// 2. Build a KnowledgeEntry (type 'learning') from the AgentLearning, tags/metadata carrying
+//    agentId + tenantId (AC5). taskPattern/role become keywords for matching.
+// 3. Ingest via IIntelligenceHttpClient (KB upsert / approveLearning path on the sidecar) — the
+//    sidecar generates the embedding and persists the vector. Store the returned entry id in
+//    AgentLearning.KnowledgeEntryId (idempotent: re-approve is a no-op when already set, AC10).
+// RejectAsync(lessonId, reason): status -> 'rejected', no ingest; if previously approved, also
+//    disable/remove the KnowledgeEntry from the KB so retrieval stops surfacing it (AC10).
+```
+
+The ingest carries the agent + tenant identifiers so a later RAG query filtered by `(agentId, tenantId)` retrieves them. The shared sidecar never serves a learning to a query lacking the matching tenant tag (fail-closed, AC7).
+
+### Context assembly hook (32-5)
+
+```csharp
+// In ManagedAgent.RunAsync, during the "assemble context + RAG (Epic 6)" step:
+//   var learnings = await _intelligence.QueryRagAsync(new RagQueryRequest {
+//       Query = request.PhaseDescription,
+//       Filter = { AgentId = agentId, TenantId = tenantId, Type = "learning" }
+//   }, ct);
+//   contextBuilder.AppendLearnings(learnings);   // injected into the rendered prompt
+//   if (learnings.Any()) emit AGENT.LEARNING.APPLIED { agentId, signal, lessonId, tenantId };
+```
+
+This makes the loop closed: outcome → learning → KB → retrieval → next run's prompt. The integration test (AC6) asserts the assembled context for run #2 contains the lesson absent from run #1.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns a learning generated by a run? | The sole user — it's their instance; the learning is theirs (the user is the tenant). | The **tenant** that ran the agent — always tenant-scoped, even for a public agent definition. Never the platform admin who owns the public agent. |
+| Where is it stored? | The (single) tenant schema. | The generating tenant's `t_<hex>` schema (structural isolation). |
+| Who can approve/reject? | The user. | `tenant_owner` / `tenant_admin` (mirrors the Prompt Store RBAC for tenant data; members read). |
+| Who can retrieve it via RAG at run time? | The user's runs. | Only that tenant's runs — filtered by `(agentId, tenantId)`; cross-tenant retrieval returns nothing (AC7). |
+| Can the platform admin (owner of a public agent) see the learnings? | n/a (no platform/tenant split). | **No** — performance/learning data is never visible to the public-agent owner (design-spec rule). |
+
+## Dependencies
+
+- **Prerequisite — Story 32-8** (Outcome capture & bug taxonomy): emits `AGENT.OUTCOME.RECORDED` (with `outcome`/`iterationsToDone`) and `AGENT.DEFECT.RECORDED` (with `category`) tagged `agentId`+`agentVersion` in the tenant store. This story's auto-learning hook consumes those events and reuses the same fire-and-forget-safe, idempotent capture discipline.
+- **Prerequisite — Story 32-10** (Benchmark projections & leaderboards): the per-tenant outcome/defect dataset and recurrence counts the defect-category signal builds on; learnings complement the leaderboard with prescriptive lessons.
+- **Prerequisite — Story 32-5** (Managed agent execution layer): provides `ManagedAgent`'s context-assembly/RAG step and the `ContentSanitizer` seam this story hooks into; provides `correlationId` on the run for `sourceRunCorrelationId`.
+- **Prerequisite — Epic 6 (RAG/KB)**: the RAG retrieval pipeline (`packages/intelligence/src/rag/`) and the KB ingestion path (`KnowledgeService`, `packages/intelligence/src/knowledge-base/`) reached via `IIntelligenceHttpClient`.
+- **Related — Epic 9 (KnowledgeService / unified agent API)**: the `KnowledgeService` capture/approve flow and shared `LearningCapture`/`KnowledgeEntry`/`PendingLearning` vocabulary in `packages/shared/src/types/knowledge.ts`.
+- **Related — Story 32-1/32-2** (agent identity + resolver): `agentId` + config version are the join keys learnings are tagged with.
+
+## Testing Strategy
+
+1. **Auto-capture from success** (`Tamma.Api.Tests/Agents/AgentLearningServiceTests.cs`): feed a synthetic `AGENT.OUTCOME.RECORDED` (success + `whatWorked`) → exactly one `AgentLearning` (signal `success`, status `pending`) persisted + one `AGENT.LEARNING.CAPTURED` event tagged `{agentId, signal, lessonId, tenantId}`.
+2. **Auto-capture from recurring defect**: feed N `AGENT.DEFECT.RECORDED` of the same `category` for one agent crossing the threshold → one `defect-category` learning; sub-threshold → none.
+3. **Similarity dedup**: feed M near-identical success candidates → one durable learning, `HitCount = M`, exactly one `CAPTURED` event.
+4. **Sanitization**: an outcome whose `whatFailed` embeds a fake secret → persisted/ingested `lesson` has it redacted (no secret durably stored).
+5. **Fire-and-forget-safe**: simulate a `TenantDbContext` fault during capture → WARN logged, no throw, originating outcome event unaffected.
+6. **RAG round-trip (integration)**: capture → approve → ingest via `IIntelligenceHttpClient` → run `ManagedAgent` context assembly for the same agent → assert injected lesson present AND assembled context differs from a pre-ingest run; `AGENT.LEARNING.APPLIED` emitted.
+7. **Tenant isolation (integration)**: same public agent under tenant A (ingest lesson) and tenant B → tenant B's context assembly excludes A's lesson; a query without the tenant filter returns nothing (fail-closed).
+8. **Lifecycle/idempotency**: re-approve an already-ingested learning → no duplicate KB entry; reject a previously-approved learning → KB entry removed/disabled, subsequent retrieval excludes it.
+9. **RBAC (SaaS)**: member-role approve/reject → 403; `tenant_owner`/`tenant_admin` → allowed (mirrors Prompt Store RBAC).
+
+## Estimated Effort
+
+5-6 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/AgentLearning.cs` | Create (NEW) |
+| `apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs` | Modify (add `DbSet<AgentLearning>`) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (AgentLearning model config + CHECK/unique constraints in `ConfigureTenantEntities`) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/` (new EF migration) | Create (NEW — additive `agent_learnings` table) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/IAgentLearningService.cs` | Create (NEW) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentLearningService.cs` | Create (NEW) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentLearningEventTypes.cs` | Create (NEW — `AGENT.LEARNING.CAPTURED`, `AGENT.LEARNING.APPLIED`) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentLearningOptions.cs` | Create (NEW — AutoApprove, MaxCapturesPerWindow, recurrence + similarity thresholds) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ManagedAgent.cs` | Modify (retrieve + inject agent-scoped learnings; emit `AGENT.LEARNING.APPLIED`) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (register `IAgentLearningService` + options) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentLearningServiceTests.cs` | Create (NEW — unit: capture, dedup, sanitize, fire-and-forget) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentLearningRagIntegrationTests.cs` | Create (NEW — RAG round-trip + tenant isolation) |
+
+> **NEW file note.** `AgentLearningService.cs`, `IAgentLearningService.cs`, `AgentLearningEventTypes.cs`, `AgentLearningOptions.cs`, and `Entities/AgentLearning.cs` do **not** exist yet — they are created by this story. `IIntelligenceHttpClient.cs`/`IntelligenceHttpClient.cs`, `TenantDbContext.cs`, `TammaModelConfiguration.cs`, `ManagedAgent.cs` (from 32-5), `packages/shared/src/types/knowledge.ts`, and the `packages/intelligence` RAG/KB modules all exist (verified).
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` directory for related spikes, bugs, findings, and decisions
+3. Reviewed Stories 32-5 (managed agent + RAG step), 32-8 (outcome/defect events), and 32-10 (projections) — this story sits directly downstream of all three
+4. Reviewed the existing `LearningCapture`/`PendingLearning` flow in `packages/intelligence/src/knowledge-base/knowledge-service.ts` so the C# side mirrors, not forks, its semantics
+5. Planned a TDD approach (Red-Green-Refactor) — tests first, per project convention
+
+### Tenancy is the load-bearing invariant
+
+The shared `@tamma/intelligence-server` sidecar means a forgotten tenant tag silently cross-contaminates learnings between tenants for a shared public agent. Treat the `(agentId, tenantId)` tag on **both** ingest and query as mandatory and fail-closed: a query without a tenant filter must return zero tenant-scoped learnings. The cross-tenant isolation test (AC7) is the regression guard — do not weaken it.
+
+### Reuse, do not fork
+
+Reuse `ContentSanitizer` (32-5 managed-agent path) for lesson sanitization, the tenant `IEventRepository` for events, the `IIntelligenceHttpClient` KB/RAG methods for ingest/query, and the existing `LearningCapture`/`KnowledgeEntry`/`PendingLearning` vocabulary. Do not introduce a second sanitizer, a second event store, or a new TypeScript package.
+
+### Fire-and-forget on the cold path only
+
+Auto-capture runs **after** the 32-8 outcome/defect flush — never on the hot agent-resolve or LLM-call path. Capture is fire-and-forget-safe: a fault is a logged WARN, never a throw. The hook must not delay or alter the run's terminal outcome.
+
+### Dedup before persistence, before events
+
+Apply rate-limit + similarity dedup **before** inserting the row and **before** emitting `AGENT.LEARNING.CAPTURED`, so a collapsed candidate produces neither a new row nor a new event (AC3/AC9). Anchor the cheap exact-match dedup on the `(AgentId, Role, TaskPattern, Signal)` unique index; layer text-similarity on top for near-duplicates.
+
+### Migration discipline
+
+`agent_learnings` is an additive tenant-scoped table — normal `dotnet ef migrations add`. Mirror the entity config in `TammaModelConfiguration.ConfigureTenantEntities` only (the single source), verify `has-pending-model-changes` reports none, and confirm the migration applies + rolls back cleanly in the per-tenant migrator path. C# tests run via `sg docker -c "dotnet test ..."`.
+
+## Logging Requirements
+
+- **INFO**: Learning auto-captured (`agentId`, `signal`, `lessonId`), learning approved + ingested into KB (`agentId`, `lessonId`, `knowledgeEntryId`), learning applied to a run's context (`agentId`, `lessonId`, `correlationId`).
+- **DEBUG**: Candidate derived from outcome/defect (signal, taskPattern), similarity dedup collapse (matched `lessonId`, new `hitCount`), RAG query for agent-scoped learnings (filter, result count).
+- **WARN**: Capture fault swallowed (fire-and-forget — `agentId`, error), rate-limit hit for an agent (`agentId`, window), ingest failure (sidecar unreachable — `lessonId`, error).
+- **ERROR**: KB ingestion/upsert persistently failing after retry, tenant filter missing on a RAG query (must never happen — alert on it), migration/model mismatch.
+- **Structured context**: include `{ agentId, tenantId, signal, lessonId, correlationId }` where applicable.
+- **Credential safety**: NEVER log raw lesson text containing un-sanitized content; log only the post-sanitization lesson or its id. NEVER log provider keys or tenant secrets.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-32/story-32-12/32-12-agent-personas-and-persona-aware-benchmarking.md
+++ b/docs/stories/epic-32/story-32-12/32-12-agent-personas-and-persona-aware-benchmarking.md
@@ -1,0 +1,394 @@
+# Story 32-12: Agent Personas & Persona-Aware Benchmarking
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-Phase Development Workflow (Read → Research → Break Down → TDD → Quality Gates → Failure Handling), Knowledge Base usage (`.dev/` directory), TRACE/DEBUG logging requirements, Test-Driven Development, 100% critical-path coverage, and build-success enforcement.
+
+**Failure to follow this process will result in rework.**
+
+## User Story
+
+As a **tenant owner/admin (SaaS) or self-hosted user (single-user)**,
+I want **named, reusable personas — styling/behavior variants (tone, verbosity, risk-tolerance, review-strictness) that compose onto an existing agent without forking its provider config — and the ability to benchmark personas like-vs-like within a role**,
+So that **a single agent definition (e.g. the public `tamma-reviewer`) can be run under two personas (`atlas` and `nova`) on my own work, and my per-tenant leaderboards tell me which *style* performs best for my context — finding the right voice for the job without cloning a dozen near-identical agents**.
+
+## Priority
+
+P2 — A refinement layer on top of the first-class agent stack. Agents (32-1), resolution (32-2), and the action trail (32-6) must exist first; personas add a second benchmarking *dimension* (style) orthogonal to the agent/provider/prompt/version dimensions 32-10 already slices. Valuable, not foundational: workflows run fine without personas; personas make style a measurable, tunable knob.
+
+## Acceptance Criteria
+
+1. **Persona entity.** A new EF Core entity `Persona` exists in `apps/tamma-elsa/src/Tamma.Data/Entities/Persona.cs` with: `Id` (Guid PK), `Name` (stable handle, e.g. `atlas`), `Role` (the `AgentRole` wire string the persona is scoped to — a persona is a *named variant within a role*, mirroring the design-of-record's "personas are named variants within a role"), `Visibility` (reuses the `AgentVisibility` enum from 32-1: `public|private`), `OwnerTenantId` (Guid?), `OwnerUserId` (Guid?), `Status` (reuses `AgentStatus`: `active|archived`), `StyleJson` (jsonb — the style/behavior trait bag: `tone`, `verbosity`, `riskTolerance`, `reviewStrictness`, …), `SystemPromptFragmentRef` (string? — a Prompt-Store fragment key, never inline secret content), `CreatedAt`/`CreatedBy`, `UpdatedAt`/`UpdatedBy`. It is **control-plane-resident** for public personas and tenant-owned for private personas, exactly mirroring the `Agent` ownership model from 32-1.
+
+2. **Ownership invariants mirror Agent (32-1).** A `CHECK` constraint `ck_personas_visibility_ownership` enforces: `Visibility='public' ⇒ OwnerTenantId IS NULL AND OwnerUserId IS NULL`; `Visibility='private'` in SaaS ⇒ `OwnerTenantId IS NOT NULL AND OwnerUserId IS NULL`; `Visibility='private'` in single-user ⇒ `OwnerUserId IS NOT NULL AND OwnerTenantId IS NULL` — the same exactly-one-principal XOR pattern as `ck_agents_visibility_ownership` / `ck_prompt_overrides_principal_xor`. A unique partial index `IX_personas_public_name_role` on `(Name, Role) WHERE Visibility='public'` and per-owner private indexes (`(OwnerTenantId, Name, Role)` and `(OwnerUserId, Name, Role)` filtered on `Visibility='private'`) let two tenants each own a private persona named `atlas` for the same role without collision. Configured **only** in `TammaModelConfiguration.cs` (the single source of model config), with one additive migration under `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/`.
+
+3. **Multiple personas per role with the *same* agent.** Two distinct active personas (e.g. `atlas` and `nova`) may both target `role=reviewer` and both compose onto the same resolved reviewer agent, each producing a different `ResolvedAgentConfig` (different style params + prompt fragment) **without forking the underlying agent definition or provider config**. A test seeds one reviewer agent + two reviewer personas and asserts both resolve to the same `AgentId`/`AgentVersion` but distinct effective system prompts / style.
+
+4. **Stable persona name is the benchmark join key.** `Persona.Id` is the immutable identity and `Persona.Name` (within a role) is the stable, human-readable handle used as the join key for all per-persona metrics — exactly as `Agent.Id`/`Name` is for agents. Editing a persona's `StyleJson` or `SystemPromptFragmentRef` does **not** create a new persona identity, so a persona's benchmark history survives style edits (consistent with 32-1's "stable identity, dynamic config" premise). Persona edits are captured as an audit event (AC 8), not a new entity.
+
+5. **Persona composes at resolution time (no agent mutation).** `IAgentResolverService` gains an optional `personaId` parameter — `ResolveForRoleAsync(string role, Guid? personaId = null, …)` (and the phase variant). When a `personaId` is supplied, the resolver: (a) loads the persona and validates it is visible to the principal (public ∪ own private) AND its `Role` matches the requested role; (b) merges the persona's `StyleJson` (temperature/verbosity/etc.) and prompt fragment **onto** the already-resolved `ResolvedAgentConfig` returning a **new** object (never mutating the agent's pinned version, per CLAUDE.md state-immutability rule); (c) stamps `PersonaId`/`PersonaName` onto the returned config. A persona that does not match the role, or is not visible, is rejected (400/404) — it is **never** silently dropped.
+
+6. **Prompt composition reuses Epic 27 layering and never falls back to empty/plain.** The persona's `SystemPromptFragmentRef` is resolved through the existing Prompt Store (`PromptStoreService.ResolveRoleActionAsync` for single-user / `ResolveRoleActionForTenantAsync` for SaaS) and the resolved fragment is **appended** to the agent's system prompt in a deterministic order: `system role identity → role+action template → persona fragment`. The persona fragment layers *on top of* the existing prompt resolution; it never replaces it. If a non-null `SystemPromptFragmentRef` cannot be resolved, the resolver fails loud with a `TammaError` (mirroring `PromptStoreService.NoPromptError` / `feedback_resolution_no_empty_fallback`) — it must **never** fall back to an empty or plain persona fragment.
+
+7. **Persona is recorded on every run + action-trail entry as a tag.** The 32-6 action-trail tag builder is extended so every `AGENT.TASK.*` / `AGENT.ITERATION.COMPLETED` / `AGENT.PANEL.AGGREGATED` / `REVIEW.BUG.RECORDED` event (and the `AgentRunResult` it derives from) carries a `personaId` and `personaName` tag (flat string values, empty/absent when no persona was applied — agents run persona-free by default). This is the substrate that lets 32-10 compute per-persona leaderboards; the tag is populated from the same shared trail-tag builder so every emission site is consistent, with no raw `StyleJson` or prompt content in the tag.
+
+8. **DCB lifecycle + application events.** Events follow `AGGREGATE.ACTION.STATUS` and are appended via `IEventRepository.AppendAsync`: `PERSONA.CREATED.SUCCESS` (on create), `PERSONA.UPDATED.SUCCESS` (on style/fragment edit), `PERSONA.ARCHIVED.SUCCESS` (on archive), and `AGENT.PERSONA_APPLIED.SUCCESS` (each time a persona is composed onto an agent at resolution) with `Tags` `{ personaId, personaName, agentId, agentVersion, role, mode }`. `Metadata` carries `{ workflowVersion: "1.0.0", eventSource: "system" }`. Events fire only after a real state transition / real composition (no "lie" events). For private/SaaS personas `DomainEvent.TenantId` is the `OwnerTenantId` (or the resolving tenant for `AGENT.PERSONA_APPLIED`); for public personas it is NULL (platform feed).
+
+9. **Persona-aware leaderboards compare personas within a role.** The 32-10 benchmark projection gains a **persona slice**: per-tenant leaderboards can group by `(role, personaId)` so the question "which reviewer *persona* has the best success rate / fewest functional bugs / lowest cost on my work?" is answerable, comparing `atlas` vs `nova` **like-vs-like within the reviewer role** (never reviewer-persona vs architect-persona). Since 32-10's story file does not yet exist, this story defines the persona dimension contract (the `personaId`/`personaName` trail tags from AC 7 + a `groupBy=persona` / `?personaId=` query facet) that 32-10 consumes; the projection slice is delivered here against the 32-6 trail, and 32-10 surfaces it in its leaderboard API.
+
+10. **Per-mode public/private ownership (mandatory two-scoping-model answer).** In **single-user** mode "public" personas are the shipped system personas (read-only); the sole user owns/creates private personas (`OwnerUserId` set, `OwnerTenantId` NULL); their persona benchmarks are the user's. In **SaaS** mode public personas are platform-owned (control-plane resident, every tenant may *use* but not edit), and private personas are tenant-owned (`OwnerTenantId` set, in the tenant's `t_<hex>` data plane for benchmark data). A tenant's usable persona set = **all public personas ∪ its own private personas**. Performance/benchmark data per persona is **always tenant-scoped** — two tenants running public persona `atlas` build separate, private profiles; the platform owner who owns `atlas` sees neither.
+
+11. **RBAC mirrors agents.** Persona reads (`GET`) are allowed to any tenant member (SaaS) / the sole user (single-user). Private-persona create/update/archive/select require `tenant_owner`/`tenant_admin` (the existing `AgentManage` = `agents:manage` policy, or a sibling `personas:manage`); a SaaS `member` gets **403**. Public-persona mutation requires `PlatformOwnerAccess`; a tenant attempting `visibility:public` create/version gets **403** (`persona_public_write_forbidden`). Cross-tenant private read returns **404** (not 403, to avoid existence leak), mirroring 32-1/32-2.
+
+12. **Persona CRUD endpoints wired + RBAC-gated.** New handlers on `AgentEndpoints.cs` (or a colocated `PersonaEndpoints.cs`) mapped in `Program.cs` under `/api/personas`: `GET /api/personas` (list public ∪ own private; filters `?role=&visibility=&status=`), `POST /api/personas` (create; private ⇒ `AgentManage`/owner, public ⇒ `PlatformOwnerAccess`), `GET /api/personas/{id}` (get one | 404), `PUT /api/personas/{id}` (edit style/fragment), `POST /api/personas/{id}/archive`. The `resolve` surface from 32-2 (`GET /api/agents/resolve?role=&phase=`) accepts an optional `&personaId=` so workflows can request a persona-composed config. The endpoint shape is identical between modes — the auth middleware decides which owner column (`OwnerUserId` vs `OwnerTenantId`) applies based on mode + caller identity (Prompt Store precedent).
+
+13. **No empty/plain fallback, ever.** A requested persona that is unresolvable (unknown id, archived, role-mismatch, cross-tenant, or unresolvable prompt fragment) is a hard `TammaError` / 4xx — the resolver **never** returns the bare agent config "as if no persona were requested" and **never** returns a blank persona fragment (`feedback_resolution_no_empty_fallback`). Requesting *no* persona (`personaId == null`) is the legitimate persona-free path and returns the plain resolved agent config unchanged.
+
+14. **No regression.** Persona-free resolution is byte-for-byte unchanged: `IAgentResolverService.ResolveForRoleAsync(role)` / `ResolveForPhaseAsync(phase, role)` with no `personaId` return exactly what they returned before; the legacy `/api/v1/agents/*` routes and JSONB path are untouched. The new migration applies cleanly, `dotnet ef migrations has-pending-model-changes` reports **none**, and the full `Tamma.Api.Tests` suite stays green.
+
+15. **Tests** cover: persona composition into the resolved config (style merge + fragment append order, agent version unchanged); two personas / one agent / same role producing distinct configs; persona tagging on the action trail; the per-persona benchmark dimension (group-by-persona leaderboard within a role); RBAC/visibility matrix (member 403 on write, tenant public-write 403, cross-tenant 404); the no-empty-fallback failures (unknown persona, role mismatch, unresolvable fragment); per-mode principal derivation; and DCB event emission / no-emission-on-failure.
+
+## Technical Design
+
+### Architectural placement (per the Epic 32 design of record)
+
+Per `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`: **the Agent is the entity**; personas are a *named styling/behavior layer above* an agent, scoped to a role, that composes at resolution time. A persona is NOT a new provider config and NOT a fork of an agent — it is a thin, reusable overlay (style params + a prompt fragment) that rides on top of an already-resolved `ResolvedAgentConfig`. Benchmarking is like-vs-like: persona `atlas` vs persona `nova` **within the reviewer role**, on the tenant's own data, never cross-role and never cross-tenant.
+
+Ownership & data scoping reuse the design's key rule verbatim, one layer up:
+
+| Concern | Scope |
+|---|---|
+| **Persona definition** | Public/system (platform-owned, control-plane, usable by every tenant) **OR** private/tenant-owned (control-plane row keyed to the owner; usable only by it). Shipped defaults are public. |
+| **Persona performance/benchmark data** | **ALWAYS tenant-scoped** — the tenant that generated it owns it; never cross-tenant; platform admin who owns a public persona sees none of any tenant's per-persona metrics. |
+
+Story 32-1 (Agent/AgentVersion entities, `AgentVisibility`/`AgentStatus` enums, `IAgentRepository`, the visibility/ownership CHECK + per-owner partial-index pattern) and Story 32-2 (`IAgentResolverService.ResolveForRoleAsync`, the enriched `ResolvedAgentConfig` with `AgentId`/`AgentVersion`/`Source`, the `AgentManage` policy, the `/api/agents` route group) are **prerequisites**; the Agent entity is in-flight, so it is referenced **by interface** here. Every place a 32-1/32-2 field is depended on but not yet confirmed shipped is marked **(coordinate with 32-1/32-2)**.
+
+### C# namespace / file structure
+
+```
+apps/tamma-elsa/src/
+  Tamma.Data/
+    Entities/
+      Persona.cs                       # NEW — control-plane entity (style overlay, role-scoped)
+                                       #   reuses AgentVisibility / AgentStatus enums (32-1)
+    ControlPlaneDbContext.cs           # MODIFY — add DbSet<Persona>
+    TammaModelConfiguration.cs         # MODIFY — Persona config: CHECK + partial unique indexes
+    Repositories/
+      IPersonaRepository.cs            # NEW — Create/Update/Archive/GetById/ListVisible
+      PersonaRepository.cs             # NEW
+    Migrations/ControlPlane/
+      <ts>_AddPersonaEntity.cs         # NEW — additive migration (+ Designer + snapshot)
+  Tamma.Api/
+    Services/Agents/
+      AgentResolverService.cs          # MODIFY — personaId overload: compose style + fragment
+      IAgentResolverService.cs         # MODIFY — add optional personaId param
+      ResolvedAgentConfig.cs           # MODIFY — add PersonaId/PersonaName (additive)
+      PersonaComposer.cs               # NEW — pure merge: persona StyleJson + fragment → config
+      PersonaEventTypes.cs             # NEW — PERSONA.* / AGENT.PERSONA_APPLIED.* constants
+    Services/PromptStore/
+      PromptStoreService.cs            # REUSE — resolve SystemPromptFragmentRef (no change to API)
+    Endpoints/
+      AgentEndpoints.cs                # MODIFY — persona CRUD handlers (or new PersonaEndpoints.cs)
+    Dtos/Agents/
+      PersonaDtos.cs                   # NEW — request/response records
+    Program.cs                         # MODIFY — map /api/personas, RBAC, DI, &personaId= on resolve
+```
+
+### `Persona` entity (sketch)
+
+```csharp
+// Tamma.Data/Entities/Persona.cs — control-plane entity; reuses 32-1 enums
+public class Persona
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;             // stable handle, e.g. "atlas"
+    public string Role { get; set; } = null!;             // AgentRole wire string — persona is role-scoped
+    public AgentVisibility Visibility { get; set; }        // reuse 32-1 enum: Public | Private
+    public Guid? OwnerTenantId { get; set; }               // set iff Private + SaaS
+    public Guid? OwnerUserId { get; set; }                 // set iff Private + SingleUser
+    public AgentStatus Status { get; set; } = AgentStatus.Active;  // reuse 32-1 enum
+    public string StyleJson { get; set; } = "{}";          // jsonb: tone, verbosity, riskTolerance, reviewStrictness
+    public string? SystemPromptFragmentRef { get; set; }   // Prompt-Store fragment key (never inline secrets)
+    public DateTime CreatedAt { get; set; }
+    public Guid? CreatedBy { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public Guid? UpdatedBy { get; set; }
+}
+```
+
+> The persona carries **no** provider/model/credential fields — those are the agent's. A persona is purely a style overlay + an optional prompt fragment, by design credential-agnostic and provider-agnostic, so the same persona can ride any agent of the matching role.
+
+### EF model configuration (in `TammaModelConfiguration.cs`, mirroring `Agent` from 32-1)
+
+```csharp
+modelBuilder.Entity<Persona>(entity =>
+{
+    entity.ToTable("personas", t =>
+    {
+        t.HasCheckConstraint(
+            "ck_personas_visibility_ownership",
+            "(\"Visibility\" = 0 AND \"OwnerTenantId\" IS NULL AND \"OwnerUserId\" IS NULL) " +     // 0 = Public
+            "OR (\"Visibility\" = 1 AND \"OwnerTenantId\" IS NOT NULL AND \"OwnerUserId\" IS NULL) " + // 1 = Private/SaaS
+            "OR (\"Visibility\" = 1 AND \"OwnerUserId\" IS NOT NULL AND \"OwnerTenantId\" IS NULL)");
+    });
+    entity.HasKey(e => e.Id);
+    entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+    entity.Property(e => e.Name).IsRequired().HasMaxLength(128);
+    entity.Property(e => e.Role).IsRequired().HasMaxLength(64);
+    entity.Property(e => e.Visibility).HasConversion<int>();
+    entity.Property(e => e.Status).HasConversion<int>().HasDefaultValue(AgentStatus.Active);
+    entity.Property(e => e.StyleJson).HasColumnType("jsonb").HasDefaultValueSql("'{}'::jsonb");
+    entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+    entity.Property(e => e.UpdatedAt).HasDefaultValueSql("now()");
+
+    // Public persona handles unique on (Name, Role)
+    entity.HasIndex(e => new { e.Name, e.Role })
+        .IsUnique().HasFilter("\"Visibility\" = 0")
+        .HasDatabaseName("IX_personas_public_name_role");
+    // Private persona handles unique per owner within a role
+    entity.HasIndex(e => new { e.OwnerTenantId, e.Name, e.Role })
+        .IsUnique().HasFilter("\"Visibility\" = 1 AND \"OwnerTenantId\" IS NOT NULL")
+        .HasDatabaseName("IX_personas_private_tenant_name_role");
+    entity.HasIndex(e => new { e.OwnerUserId, e.Name, e.Role })
+        .IsUnique().HasFilter("\"Visibility\" = 1 AND \"OwnerUserId\" IS NOT NULL")
+        .HasDatabaseName("IX_personas_private_user_name_role");
+});
+```
+
+### Resolver extension — persona composition
+
+`IAgentResolverService` (extend; `personaId` is optional and defaults to today's behaviour):
+
+```csharp
+// Add an optional personaId to the 32-2 resolve methods (additive, non-breaking).
+Task<ResolvedAgentConfig> ResolveForRoleAsync(
+    string role, Guid? personaId = null, CancellationToken ct = default);
+
+Task<ResolvedAgentConfig> ResolveForRoleAndPhaseAsync(
+    string phase, string role, Guid? personaId = null, CancellationToken ct = default);
+```
+
+Composition flow (no agent mutation — returns a new object):
+
+```csharp
+public async Task<ResolvedAgentConfig> ResolveForRoleAsync(
+    string role, Guid? personaId, CancellationToken ct)
+{
+    // 1. Resolve the agent exactly as 32-2 does (precedence chain; fail-loud on no agent).
+    var resolved = await ResolveAgentForRoleAsync(role, ct);
+    if (personaId is null) return resolved;          // legitimate persona-free path (unchanged)
+
+    // 2. Load + validate the persona (visible to principal AND role matches).
+    var persona = await _personas.GetVisibleAsync(personaId.Value, _principal.Resolve(), ct)
+        ?? throw new TammaError("PERSONA.RESOLVE.NOT_FOUND", ..., severity: High);   // 404, not silent
+    if (!string.Equals(persona.Role, role, StringComparison.Ordinal))
+        throw new TammaError("PERSONA.ROLE_MISMATCH", ..., severity: High);          // 400, not silent
+
+    // 3. Resolve the prompt fragment via Epic 27 store; fail-loud if non-null & unresolvable.
+    var fragment = persona.SystemPromptFragmentRef is null
+        ? null
+        : await ResolveFragmentOrThrow(persona.SystemPromptFragmentRef, role, ct);  // NEVER empty fallback
+
+    // 4. Pure merge: style params + appended fragment → NEW ResolvedAgentConfig.
+    var composed = PersonaComposer.Compose(resolved, persona, fragment);
+    composed = composed with { PersonaId = persona.Id, PersonaName = persona.Name };
+
+    // 5. Audit the composition (real event, after a real compose).
+    await _events.AppendAsync(AgentPersonaApplied(persona, resolved, role), ct);
+    return composed;
+}
+```
+
+`PersonaComposer.Compose` is pure and deterministic:
+- **Style merge:** persona `StyleJson` overrides the agent's style-adjacent fields it explicitly sets (e.g. `temperature`, verbosity hints), leaving provider/model/budget/tools untouched (a persona styles, it does not re-provider).
+- **Prompt append order:** `system role identity → role+action template → persona fragment` — the persona fragment is *appended* to the already-resolved `SystemPrompt`, never replacing it (AC 6). Order is fixed and tested.
+- Returns a brand-new `ResolvedAgentConfig`; the input is never mutated (CLAUDE.md state-immutability rule).
+
+### `ResolvedAgentConfig` (additive)
+
+```csharp
+// Tamma.Api/Services/Agents/ResolvedAgentConfig.cs — ADDITIVE fields only
+public class ResolvedAgentConfig
+{
+    // ... all existing fields unchanged (Role, Handle, Provider, Model, Temperature,
+    //     MaxTokens, TokenBudget, Tools, SystemPrompt, Source, Phase, MaxBudgetUsd,
+    //     PermissionMode, AllowedTools, and the 32-2 AgentId/AgentVersion) ...
+
+    /// <summary>Persona composed onto this config (32-12). Null = persona-free run.</summary>
+    public Guid? PersonaId { get; init; }
+
+    /// <summary>Stable persona handle — the benchmark join key (e.g. "atlas").</summary>
+    public string? PersonaName { get; init; }
+}
+```
+
+### Benchmark slice (the persona dimension)
+
+The action trail (32-6) is the substrate. This story:
+1. Extends the **shared trail-tag builder** so every trail event + `AgentRunResult` carries `personaId`/`personaName` (flat strings; absent ⇒ persona-free). This is the join key 32-10 groups on.
+2. Delivers a **per-persona projection facet** over the 32-6 trail: aggregate success rate, avg iterations-to-done, bug-counts-by-type, cost, and latency grouped by `(role, personaId)` for the calling tenant only. This answers "best reviewer *persona* on my work."
+3. Defines the **dimension contract** 32-10 consumes (the leaderboard API gains `?groupBy=persona` / `?personaId=` facets). 32-10's story file does not yet exist; this story owns the persona tags + the projection slice, and 32-10 surfaces them in its leaderboard endpoint. Like-vs-like is enforced by always pairing `personaId` with its `role` — persona comparisons are scoped within a role, never across roles, never across tenants.
+
+### DCB events (NEW)
+
+| Event | When | Tags |
+|---|---|---|
+| `PERSONA.CREATED.SUCCESS` | new `Persona` committed | `personaId, personaName, role, visibility, ownerTenantId?, ownerUserId?, mode` |
+| `PERSONA.UPDATED.SUCCESS` | style/fragment edited | `personaId, personaName, role, visibility, mode` |
+| `PERSONA.ARCHIVED.SUCCESS` | `Status` → archived | `personaId, personaName, role, visibility, mode` |
+| `AGENT.PERSONA_APPLIED.SUCCESS` | persona composed onto an agent at resolution | `personaId, personaName, agentId, agentVersion, role, mode` |
+
+Appended via `IEventRepository.AppendAsync(DomainEvent { Type, TenantId, Tags, Metadata, Data, CreatedAt })` into the same store the rest of Epic 32 uses (`SequenceNumber` total-order cursor is server-assigned). Private/SaaS persona lifecycle events carry `TenantId = OwnerTenantId`; public-persona lifecycle events carry `TenantId = NULL` (platform feed); `AGENT.PERSONA_APPLIED` carries the *resolving* tenant's id (the run is the tenant's, even for a public persona — consistent with the design's "data is always tenant-scoped").
+
+### API shape
+
+```
+GET    /api/personas                  → 200 [PersonaSummary]   (public ∪ own private; ?role=&visibility=&status=)
+POST   /api/personas                  → 201 PersonaResponse     (private ⇒ AgentManage/owner; public ⇒ PlatformOwnerAccess; member ⇒ 403)
+GET    /api/personas/{id}             → 200 PersonaDetail | 404 (cross-tenant private ⇒ 404)
+PUT    /api/personas/{id}             → 200 PersonaResponse      (same ownership rule; emits PERSONA.UPDATED.SUCCESS)
+POST   /api/personas/{id}/archive     → 200 { id, status: "archived" }
+GET    /api/agents/resolve?role=&phase=&personaId=   → 200 ResolvedAgentConfig (persona composed) | 400 role-mismatch | 404 persona-not-found
+```
+
+Per-mode + per-tenant handling reuses the 32-2 endpoint conventions: public-scope writes gated by `PlatformOwnerAccess`; private-scope writes derive principal columns from `ITammaModeProvider` + `ITenantContext`/`ClaimsPrincipal` (SaaS ⇒ `OwnerTenantId`; single-user ⇒ `OwnerUserId`); member-role SaaS callers get 403 on writes; cross-tenant private read ⇒ 404.
+
+### Per-mode ownership (mandatory two-scoping-model answer)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Who owns a **private** persona? | The sole user (`OwnerUserId`; `OwnerTenantId` NULL). | The tenant (`OwnerTenantId`); `tenant_owner`/`tenant_admin` edit, `member` read-only. |
+| Who owns a **public** persona? | Shipped system personas (read-only to the user). | Platform owner (`PlatformOwnerAccess`); CP-resident; every tenant may *use* but not edit. |
+| Who can apply a persona to a run? | The user. | Any member (apply ≈ read of the persona + resolve); editing the persona needs owner/admin. |
+| Where do per-persona benchmarks live? | The user's data — `user_id`-keyed. | The tenant's `t_<hex>` data plane; never cross-tenant. |
+| Resolution / benchmark principal | `user_id` | `tenant_id` |
+| Mode source | `ITammaModeProvider` (process-stable) | same |
+
+### Integration points
+
+- **`Agent` / `AgentVersion` / `AgentVisibility` / `AgentStatus` / `IAgentRepository`** (32-1, in-flight) — persona reuses the enums + the visibility/ownership CHECK + per-owner partial-index pattern; referenced **by interface**.
+- **`IAgentResolverService` / `ResolvedAgentConfig`** (`Tamma.Api/Services/Agents/`) — the resolver gains the optional `personaId`; `ResolvedAgentConfig` gains `PersonaId`/`PersonaName` (additive).
+- **`AgentEndpoints.cs`** (`apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs`) — persona CRUD handlers + `&personaId=` on resolve.
+- **`PromptStoreService`** (`apps/tamma-elsa/src/Tamma.Api/Services/PromptStore/PromptStoreService.cs`) — `ResolveRoleActionAsync` / `ResolveRoleActionForTenantAsync` resolve the persona fragment through the existing Epic 27 layering; no Prompt-Store API change.
+- **`RolePhaseMap` / `AgentRole`** (`Tamma.Core/Agents/`) — persona `Role` validated on create/resolve.
+- **`IEventRepository`** (`Tamma.Data/Repositories/EventRepository.cs`) + **`DomainEvent`** (`Tamma.Data/Entities/DomainEvent.cs`) — DCB emission.
+- **`ITammaModeProvider`** (`Tamma.Api/Services/PromptStore/TammaMode.cs`) + **`ITenantContext`** + `ClaimsPrincipal` — per-mode principal derivation.
+- **Action trail (32-6)** (`AGENT.TASK.*` etc.) — extended tag builder carries `personaId`/`personaName`.
+- **Benchmark leaderboards (32-10)** — consumes the persona dimension contract defined here.
+- **Auth policies** (`Program.cs`): `PlatformOwnerAccess`, `AgentManage` (`agents:manage`), member read access — the 32-2 precedent.
+
+## Dependencies
+
+- **Prerequisite**: Story 32-1 (Agent entity model & versioned saved config) — provides `Agent`/`AgentVersion`, the `AgentVisibility`/`AgentStatus` enums the persona reuses, and the visibility/ownership CHECK + per-owner partial-index pattern. **In-flight — reference by interface.**
+- **Prerequisite**: Story 32-2 (Agent registry, resolution & RBAC API) — provides `IAgentResolverService.ResolveForRoleAsync`, the enriched `ResolvedAgentConfig` (`AgentId`/`AgentVersion`/`Source`), the `AgentManage` policy, the `/api/agents` route group, and the no-empty-fallback resolution discipline this story extends.
+- **Prerequisite / consumer**: Story 32-10 (Benchmark projections & leaderboards) — defines the leaderboard surface; this story supplies the **persona dimension** (trail tags + group-by-persona projection) it slices on. 32-10's story file does not yet exist; coordinate the leaderboard query facet (`?groupBy=persona` / `?personaId=`) at integration.
+- **Reuses**: Story 32-6 (action trail — extended with persona tags), Epic 27 (Prompt Store — fragment resolution + the RBAC/per-mode model mirrored), Epic 28 (schema-per-tenant — structural isolation of private personas + per-persona benchmark data).
+- **Design of record**: `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md` (Epic 32 design — "the Agent is the entity; personas are named variants within a role; benchmark like-vs-like").
+- **Related project rule**: `feedback_resolution_no_empty_fallback` — persona/fragment resolution is fail-loud, never empty/plain.
+
+## Testing Strategy
+
+Tests are xUnit under `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/` (and `Personas/`). Docker-bound suites run via `sg docker -c "dotnet test ..."` (see `reference_dotnet_test_docker`). TDD: write the failing test first.
+
+1. **Composition** (`PersonaComposerTests` / `AgentResolverServiceTests`): a persona's `StyleJson` overrides only style-adjacent fields (temperature/verbosity), leaving provider/model/budget/tools untouched; the fragment is *appended* to the agent system prompt in the fixed order `role identity → role+action → persona fragment`; the input `ResolvedAgentConfig` and the agent's pinned version are unmodified (immutability); `PersonaId`/`PersonaName` stamped on the output.
+2. **Two personas / one agent / same role** (`AgentResolverServiceTests`): seed one reviewer agent + personas `atlas` and `nova` (both `role=reviewer`); resolve under each — both return the same `AgentId`/`AgentVersion`, distinct effective `SystemPrompt`/style. Proves no agent fork.
+3. **Persona tagging on the trail** (`PersonaTrailTaggingTests`): a persona-composed run's `AGENT.TASK.*` / `AGENT.ITERATION.COMPLETED` / `REVIEW.BUG.RECORDED` events carry `personaId`/`personaName`; a persona-free run carries empty/absent persona tags; no raw `StyleJson`/prompt content in tags (redaction).
+4. **Per-persona benchmark dimension** (`PersonaLeaderboardProjectionTests`): seed trail rows for `atlas` and `nova` under `role=reviewer`; the group-by-`(role, personaId)` projection ranks them within the reviewer role on success rate / bug counts / cost; an architect-role persona never appears in the reviewer leaderboard (like-vs-like); tenant B's rows never appear in tenant A's projection (isolation).
+5. **RBAC / visibility matrix** (`PersonaEndpointsTests`, in-process `WebApplicationFactory`): member create/update/archive → 403; tenant `POST /api/personas {visibility:public}` → 403 `persona_public_write_forbidden`; platform owner public create → 201; cross-tenant `GET /api/personas/{B-private-id}` → 404; `GET /api/personas` from A never returns B's private rows.
+6. **No empty/plain fallback** (`AgentResolverServiceTests`): unknown `personaId` → `PERSONA.RESOLVE.NOT_FOUND` 404; persona role-mismatch → `PERSONA.ROLE_MISMATCH` 400; non-null `SystemPromptFragmentRef` that the Prompt Store can't resolve → `TammaError` (no blank fragment); `personaId == null` → plain resolved config (legitimate persona-free path).
+7. **Per-mode principal derivation** (`[Theory]` over `TammaMode.SingleUser`/`SaaS`): single-user private create sets `OwnerUserId`/null tenant; SaaS sets `OwnerTenantId`/null user; CHECK rejects public-with-owner / private-with-no-owner / private-with-both.
+8. **DCB events** (`PersonaEventsTests`): create/update/archive emit exactly one `PERSONA.*` event each with correct tags; a composed resolution emits one `AGENT.PERSONA_APPLIED.SUCCESS` with `{personaId, agentId, role}`; a validation/resolution failure leaves the event store untouched (no-emission-on-failure).
+9. **Migration + no regression** (`ControlPlaneDbContextModelTests` extended): migration applies, `has-pending-model-changes` → none, the `personas` table/indexes/CHECK exist; persona-free resolution and the legacy `/api/v1/agents/*` routes stay byte-for-byte green.
+
+**Coverage**: critical paths (composition merge, fragment-fail-loud, ownership guard, event emission, persona tagging) → 100%; entity/repository line ≥ 80%.
+
+## Estimated Effort
+
+4-5 days
+
+## Files Created / Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/Persona.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/IPersonaRepository.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/PersonaRepository.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_AddPersonaEntity.cs` (+ `.Designer.cs`, snapshot) | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/PersonaComposer.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/PersonaEventTypes.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/PersonaDtos.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Personas/PersonaComposerTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Personas/PersonaEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Personas/PersonaEventsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Personas/PersonaLeaderboardProjectionTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Personas/PersonaTrailTaggingTests.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/Persona.cs` style/visibility reuse of `AgentVisibility`/`AgentStatus` (32-1) | Reference (coordinate with 32-1) |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (add `DbSet<Persona>`) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (Persona entity config: CHECK + partial indexes) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentResolverService.cs` | Modify (personaId compose path) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/IAgentResolverService.cs` | Modify (optional `personaId` param) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ResolvedAgentConfig.cs` | Modify (add `PersonaId`/`PersonaName`) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs` | Modify (persona CRUD handlers + `&personaId=` on resolve) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map `/api/personas`, RBAC, DI `IPersonaRepository`) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentResolverServiceTests.cs` | Modify (persona composition + no-fallback cases) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs` | Modify (assert `personas` table/indexes/CHECK) |
+
+> The 32-6 shared trail-tag builder is extended to carry `personaId`/`personaName`; the exact file lands when 32-6 is implemented — coordinate so the persona tags are added to the single shared builder rather than per emission site.
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, decisions (esp. `feedback_resolution_no_empty_fallback`)
+3. Read the Epic 32 design of record: `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`
+4. Confirmed which `Agent`/`AgentVersion` fields and which enums (`AgentVisibility`/`AgentStatus`) Story 32-1 actually shipped, and which resolve methods + `ResolvedAgentConfig` fields Story 32-2 shipped — every **(coordinate with 32-1/32-2)** marker must be reconciled before coding
+5. Reviewed the Prompt Store RBAC + per-mode precedent (`PromptEndpoints.cs`, `PromptManage`) and the 32-1/32-2 agent ownership/visibility pattern this mirrors
+6. Planned the TDD approach (Red-Green-Refactor)
+
+### Key design decisions
+
+- **A persona is an overlay, not a fork.** The whole point is one agent definition, many styles — so the persona carries no provider/model/credential fields and composes at resolution time into a *new* `ResolvedAgentConfig`. Cloning an agent to change its tone would defeat the benchmark ("which style?" becomes unanswerable like-vs-like). This is the design-of-record's "personas are named variants within a role."
+- **Stable name is the join key.** Persona benchmark history must survive style edits, exactly as agent history survives config edits (32-1). Edit ⇒ `PERSONA.UPDATED.SUCCESS` audit event, never a new identity.
+- **Role-scoped so comparisons are like-vs-like.** A persona is bound to a role; leaderboards group by `(role, personaId)`. Comparing a reviewer persona to an architect persona is meaningless, so the model forbids it structurally.
+- **Fail loud, never plain.** A requested-but-unresolvable persona (or fragment) is a hard error — the load-bearing project rule. The only "no persona" path is an explicit `personaId == null`, which returns the plain agent config unchanged.
+- **Reuse 32-1 enums + the ownership/visibility pattern wholesale.** Personas mirror agents byte-for-byte on visibility, ownership XOR CHECK, per-owner partial indexes, and 404-not-403 cross-tenant reads. Do not invent a parallel ownership model.
+- **Data is always tenant-scoped.** Even running a *public* persona, the per-persona benchmark data belongs to the resolving tenant — the platform owner who authored the public persona sees none of any tenant's per-persona metrics.
+
+### Migration discipline (Epic 28 conventions)
+
+- `personas` is an **additive** table — a normal `dotnet ef migrations add AddPersonaEntity --context ControlPlaneDbContext`, not a baseline CHECK edit.
+- After adding, run `dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext` → must report none.
+- Mirror entity config **only** in `TammaModelConfiguration.cs` (the single source); the snapshot/Designer are generated, not hand-edited.
+- Run C# tests with `sg docker -c "dotnet test ..."` (session docker group is stale; build needs no wrapper).
+
+### Edge cases
+
+- Persona whose `Role` differs from the requested role → `PERSONA.ROLE_MISMATCH` 400 (never composed onto a mismatched agent).
+- Archived persona requested at resolve → treat as not-found (404); a persona archived mid-flight does not retroactively rewrite past trail tags.
+- `SystemPromptFragmentRef = null` → no fragment append; style merge still applies (a style-only persona is valid).
+- Public persona name collision with an existing handle → 409 (partial unique index), no event.
+- Two tenants each own a private persona `atlas`/`reviewer` → allowed (per-owner partial index); benchmarks stay separate.
+
+## Logging Requirements
+
+- **INFO**: persona created / updated / archived (`personaId, personaName, role, visibility`), persona applied at resolution (`personaId, agentId, role, mode`).
+- **DEBUG**: composition merge summary (which style fields overridden, fragment appended yes/no — never the fragment body), visibility-scoped persona list resolved (`count, mode, tenantId?`).
+- **WARN**: requested persona not visible / role-mismatch surfaced as 404/400 (`personaId, requestedRole, personaRole`), member-role 403 on write, tenant public-write 403.
+- **ERROR**: non-null `SystemPromptFragmentRef` unresolvable (fail-loud — `personaId, fragmentRef`), event append failure after a real compose, migration/DB write failure.
+- **Structured context**: include `{ personaId, personaName, agentId, agentVersion, role, mode, tenantId }` where applicable.
+- **Credential safety**: personas are credential-agnostic and provider-agnostic by design (style + fragment ref only); never log raw `StyleJson` if it could carry sensitive hints and never log resolved fragment bodies.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-32/story-32-13/32-13-agent-management-and-benchmark-dashboards.md
+++ b/docs/stories/epic-32/story-32-13/32-13-agent-management-and-benchmark-dashboards.md
@@ -1,0 +1,260 @@
+# Story 32-13: Agent Management & Benchmark Dashboards (admin public + tenant private)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **platform admin** (managing the shared agent catalog) **and as a tenant owner/admin/member** (running and observing my own agents),
+I want **two dashboards over the agent domain** — a platform-admin view to create, version, and govern **public/system** agents, personas, and margin config and to inspect anonymized cross-tenant public-agent leaderboards; and a tenant view to create and version **private** agents and personas, choose which agent serves each role, register my own provider keys (BYOK), and inspect **my own** action trail, run history, benchmarks, leaderboards, outcomes, and billable usage,
+So that **definition governance and performance observability are surfaced where each principal owns them**, while the platform admin never sees a single tenant's performance data and a tenant never sees another tenant's.
+
+## Priority
+
+P2 — The human-facing surface over the Epic 32 agent domain. The data and APIs exist (32-2/32-6/32-9/32-10/32-12); this story makes them usable without the API substrate being reachable only by curl.
+
+## Acceptance Criteria
+
+1. **Admin: public agent + persona CRUD/versioning.** The admin dashboard (`packages/dashboard`) extends `settings/AgentsPage.tsx` with a tab/section to list, create, publish a new pinned version of, and archive **public/system** agents (and their personas from 32-12), driving the 32-2 endpoints with `visibility: "public"`. All write calls go through the in-handler `PlatformOwnerAccess` gate; a non-owner never reaches these controls (route is already behind `AdminGuard`). System (shipped-default) agents render as read-only catalog rows with a "system default" badge.
+2. **Admin: margin/markup config + anonymized public-agent leaderboard.** The admin view includes a margin/markup config panel (a thin form over the 32-9/Epic-34 markup config it owns) and an **anonymized, cross-tenant** public-agent leaderboard view (success rate, avg iterations-to-done, cost basis, latency per public agent) — aggregated so **no single tenant's data is identifiable**; the view never calls a tenant-scoped trail/leaderboard endpoint and never accepts a `tenantId`.
+3. **Tenant: private agent + persona management.** The tenant dashboard (`packages/dashboard-user`) adds a page to list (public ∪ own-private), create, version, and archive **private** agents and their personas, driving the 32-2 endpoints scoped to the caller's active tenant. Public agents appear as browsable, non-editable rows (an "Adopt"/"Select for role" affordance, no edit). Attempting to edit a public agent is not offered in the UI and 403s on the API.
+4. **Tenant: per-role agent selection.** A "Roles" view lets a tenant owner/admin choose which agent (public or own-private) serves each role via `PUT /api/agents/role-selections/{role}` (32-2); the current resolved selection and its provenance (`system-public` / `tenant-public` / `tenant-private`) is shown per role; absent a tenant selection the UI shows the system-default agent the resolver would pick (never "none"/blank).
+5. **Tenant: BYOK provider-key registration (reveal-once).** A "Provider keys" section registers/rotates/removes a tenant's own provider API key per provider via the 32-3 endpoints (`POST/DELETE /api/v1/agents/providers/{provider}/credential` and `…/rotate`). On create/rotate the plaintext is shown **exactly once** via the Epic 29 reveal-once UX (mirrors `SecretRevealModal`); the stored key is **never** re-displayed afterward — the list shows provider, source (`byok`/`platform`), storage-key ref, and last-rotated, never the secret.
+6. **Tenant: own action trail + run history.** A per-agent detail view renders the tenant's **own** run history (`GET /api/v1/orgs/{tenantId}/agents/{agentId}/runs`) and flat action trail (`…/agents/{agentId}/trail`) from 32-6, with the documented filters (`from`/`to`, `role`, `provider`, `outcome`, `type` prefix) and cursor pagination. Every trail/runs call is bound to the caller's **own** `tenantId` (from `useAuth`); the UI never constructs a path with a foreign tenant id.
+7. **Tenant: benchmarks, leaderboards, outcomes, usage.** A "Benchmarks" view renders the tenant's own leaderboards and benchmark charts from 32-10 sliceable by **agent / provider / prompt / persona** dimensions with **window selection** (e.g. 7d/30d/90d/all) and **min-sample messaging** (a "not enough samples (n<N)" note instead of a misleading bar when the window has too few runs), plus outcome breakdown (bug counts by `bugType`) and billable usage (tokens/cost from 32-9).
+8. **Strict tenant isolation in the UI (asserted in tests).** No tenant-dashboard code path can request another tenant's trail/benchmarks/usage: the active tenant id is sourced only from the authenticated session (`useAuth().tenantId`), never from a route param the user can edit, a query string, or a dropdown of other tenants. A test asserts that every tenant-data fetch uses the session tenant id and that there is no UI affordance to enter or switch to a foreign tenant id. The API enforces it too (32-6 AC 4); the UI does not rely on that alone.
+9. **Admin never sees a single tenant's data.** No admin-dashboard code path calls a tenant-scoped trail/leaderboard/usage endpoint or passes a `tenantId` to read performance; the admin leaderboard is the anonymized cross-tenant aggregate only. A test asserts the admin agents bundle imports no tenant-trail client and issues no `/orgs/{tenantId}/agents/.../trail` request.
+10. **Member read-only gating.** SaaS `member`-role users get **read-only** views in the tenant dashboard: create/version/archive, role-selection writes, and BYOK register/rotate/remove controls are **hidden or disabled** (gated by `TenantAdminGuard` / role check) and the underlying API returns **403** for members per 32-2/32-3 RBAC. A 403 from the API surfaces as a "you need admin/owner role" message rather than a crash.
+11. **BYOK reveal-once correctness.** The reveal modal shows the plaintext once, requires an "I have saved this value" acknowledgement before close, copies to clipboard, and zeroes its local state on dismiss; the parent burns the one-shot reveal exactly once and drops the plaintext from its own state — mirroring the 29-3/29-5 secrets UI exactly (reuse the component/pattern, do not re-implement loosely).
+12. **Reuse existing primitives.** Both dashboards reuse existing patterns — the admin side reuses the `useAgentsConfig`/settings store + service-client conventions and common components (`Card`, `Badge`, `ConfirmDialog`, `LoadingSpinner`, `SecretRevealModal`); the tenant side reuses `apiClient` (`packages/dashboard-user/src/api/client.ts`), `useAuth`, `AuthGuard`/`TenantAdminGuard`, and the existing `api/*.ts` typed-module convention — **no new data layer, no new HTTP wrapper, no new state library** is introduced.
+13. **Routing & navigation wiring.** Admin: the public-agent + leaderboard surface is reachable from `settings/AgentsPage` (extended in place, not replaced) and registered in `packages/dashboard/src/router.tsx` behind `AdminGuard`. Tenant: new routes (`/agents`, `/agents/:agentId`, `/settings/provider-keys`) are registered in `packages/dashboard-user/src/App.tsx` behind `AuthGuard` (+ `TenantAdminGuard` for the management/BYOK/role-selection routes) and linked from `layouts/AppLayout.tsx`.
+14. **Tests.** Component/unit tests (Vitest + Testing Library, colocated `__tests__/` per existing pattern) with **mocked APIs** cover: admin-vs-tenant separation (AC 8/9), member read-only gating (AC 10), BYOK reveal-once (AC 11), per-role selection + provenance (AC 4), leaderboard rendering with window selection + min-sample messaging (AC 7), and 403/empty/error states. A small e2e/integration-style flow (admin creates a public agent; tenant browses it, selects it for a role, registers a BYOK key, views its own trail) runs against mocked endpoints.
+15. **No regression.** The existing `AgentsOverview` role-config UI keeps working unchanged (the public-agent surface is additive to `AgentsPage`); `pnpm test --filter @tamma/dashboard` and `pnpm test --filter @tamma/dashboard-user` stay green; no new lint errors.
+
+## Technical Design
+
+### Where each surface lives (two dashboards, two principals)
+
+Per the Epic 32 design spec tenancy rule and CLAUDE.md "Operating Modes", **definition ownership** and **data ownership** are separate, and the two dashboards map onto the two principals:
+
+| Surface | Package | Principal | Guard |
+|---|---|---|---|
+| Public/system agent + persona CRUD/versioning | `packages/dashboard` (admin) | platform owner | `AdminGuard` + in-handler `PlatformOwnerAccess` |
+| Margin/markup config | `packages/dashboard` (admin) | platform owner | `AdminGuard` |
+| Anonymized public-agent leaderboard | `packages/dashboard` (admin) | platform owner | `AdminGuard` |
+| Private agent + persona CRUD/versioning | `packages/dashboard-user` (tenant) | tenant owner/admin | `TenantAdminGuard` |
+| Per-role agent selection | `packages/dashboard-user` (tenant) | tenant owner/admin | `TenantAdminGuard` |
+| BYOK provider-key registration | `packages/dashboard-user` (tenant) | tenant owner/admin | `TenantAdminGuard` |
+| Own action trail / runs / benchmarks / leaderboards / outcomes / usage | `packages/dashboard-user` (tenant) | tenant member (read) | `AuthGuard` |
+
+> **The deleted `packages/api` is never referenced.** Backend endpoints are served by the C# control-plane in `apps/tamma-elsa` (`Tamma.Api`) per 32-2/32-3/32-6/32-9/32-10/32-12. This story is **dashboards only** — it wires React UIs to those already-built endpoints.
+
+### Admin dashboard — `packages/dashboard`
+
+`settings/AgentsPage.tsx` is **extended in place** (AC 1/15): the existing `<AgentsOverview/>` role-config card stays; a tabbed shell is added around it with new tabs **Public Agents**, **Margin**, and **Leaderboard**.
+
+```
+packages/dashboard/src/
+  pages/settings/AgentsPage.tsx                        (MODIFY — add tab shell; keep AgentsOverview)
+  components/settings/agents/
+    PublicAgentsPanel.tsx           (NEW — list/create/version/archive public agents)
+    PublicAgentForm.tsx             (NEW — create + new-version form; provider chain / model / prompt / budget / persona)
+    PersonaManager.tsx              (NEW — persona CRUD for an agent, 32-12)
+    MarginConfigPanel.tsx           (NEW — markup/margin config form, 32-9/Epic-34)
+    PublicLeaderboardPanel.tsx      (NEW — anonymized cross-tenant public-agent leaderboard)
+    LeaderboardChart.tsx            (NEW — shared chart; window selector + min-sample note)
+  hooks/settings/
+    usePublicAgents.ts              (NEW — list/create/version/archive via service client)
+    usePublicLeaderboard.ts         (NEW — anonymized aggregate; NO tenantId param)
+    useMarginConfig.ts              (NEW)
+  services/settings/
+    agents-admin-client.ts          (NEW — typed client for /api/admin/agents + /api/agents public writes + admin leaderboard + margin)
+  router.tsx                                            (MODIFY — keep /settings/agents behind AdminGuard)
+```
+
+Admin API calls (gated by `AdminGuard` + server `PlatformOwnerAccess`):
+- `GET    /api/agents?visibility=public` — list public/system agents (32-2).
+- `POST   /api/agents` with `{ visibility: "public", ... }` — create public agent (32-2; server 403s non-owner).
+- `POST   /api/agents/{id}/versions` — publish pinned version (32-2).
+- `POST   /api/agents/{id}/archive` — archive (32-2).
+- Persona CRUD for an agent (32-12 endpoints).
+- `GET    /api/admin/agents/leaderboard` — **anonymized cross-tenant** public-agent aggregate (32-10 admin projection; no `tenantId`).
+- Margin/markup config GET/PUT (32-9 / Epic-34).
+
+> **Isolation guarantee (AC 9):** `agents-admin-client.ts` exposes **no** method that takes a `tenantId` and **no** `/orgs/{tenantId}/...` path. A unit test greps the compiled client surface to prove it.
+
+### Tenant dashboard — `packages/dashboard-user`
+
+```
+packages/dashboard-user/src/
+  api/
+    agents.ts            (NEW — list/create/version/archive private agents; role-selections; resolve)
+    agent-trail.ts       (NEW — runs + trail for OWN tenant; benchmarks/leaderboards/outcomes/usage)
+    provider-keys.ts     (NEW — BYOK register/rotate/remove via 32-3)
+  pages/agents/
+    AgentsListPage.tsx           (NEW — public ∪ own-private; create/version/archive [admin]; browse [member])
+    AgentDetailPage.tsx          (NEW — tabs: Overview · Runs · Trail · Benchmarks · Outcomes · Usage)
+    RoleSelectionsPage.tsx       (NEW — per-role agent picker + provenance)
+  pages/settings/
+    ProviderKeysPage.tsx         (NEW — BYOK register/rotate/remove; reveal-once)
+  components/agents/
+    AgentCard.tsx                (NEW)
+    AgentForm.tsx                (NEW — create/version; persona section)
+    RunsTable.tsx                (NEW — paginated runs; filters)
+    ActionTrailTable.tsx         (NEW — paginated flat trail; type/role/provider/outcome filters)
+    LeaderboardView.tsx          (NEW — agent/provider/prompt/persona dimension + window selector + min-sample note)
+    OutcomeBreakdown.tsx         (NEW — bug counts by bugType)
+    UsagePanel.tsx               (NEW — tokens/cost)
+    ProviderKeyRow.tsx           (NEW)
+    ProviderKeyRevealModal.tsx   (NEW — mirrors dashboard SecretRevealModal reveal-once contract)
+  App.tsx                        (MODIFY — register routes under AuthGuard / TenantAdminGuard)
+  layouts/AppLayout.tsx          (MODIFY — add Agents nav links)
+```
+
+Tenant API calls (all bound to `useAuth().tenantId`):
+- `GET  /api/agents?role=&visibility=&status=` — list (public ∪ own-private) (32-2).
+- `POST /api/agents` (private create), `POST /api/agents/{id}/versions`, `POST /api/agents/{id}/archive` (32-2; member → 403).
+- `PUT  /api/agents/role-selections/{role}` + `GET /api/agents/resolve?role=&phase=` — selection + provenance (32-2).
+- `GET  /api/v1/orgs/{tenantId}/agents/{agentId}/runs` and `…/trail` — own runs + trail (32-6).
+- 32-10 leaderboard/benchmark + 32-9 usage/cost reads (own tenant only).
+- `POST/DELETE /api/v1/agents/providers/{provider}/credential`, `POST …/rotate` — BYOK (32-3; create/rotate → reveal-once envelope).
+
+> **Isolation guarantee (AC 8):** every method in `agent-trail.ts` takes the tenant id from a single `getActiveTenantId()` helper that reads `useAuth().tenantId`; there is no parameter, route segment, or input that lets the user supply a different tenant. A test renders the pages and asserts each network call's path contains the session tenant id and that no tenant-switcher control exists.
+
+### RBAC gating in the UI (AC 10)
+
+- Management routes (`/agents` create/version/archive, `/settings/provider-keys`, `/agents/roles`) sit behind `TenantAdminGuard` (admin/owner only); members hitting the route see the existing "Admin-only" panel.
+- Read routes (`/agents/:agentId` detail, runs/trail/benchmarks/usage) sit behind `AuthGuard` only — members can observe.
+- Within a page reachable by members, write affordances are hidden when `useAuth().role` is `member`; if the API still returns 403 (defense in depth), the error is rendered as a role message, not a crash.
+
+### Reveal-once BYOK (AC 5/11)
+
+Reuse the exact 29-3 contract embodied by `packages/dashboard/src/components/secrets/SecretRevealModal.tsx`: parent posts to the 32-3 credential create/rotate endpoint → server returns a reveal envelope (`revealToken`/`revealUrl`, **no plaintext in the create body**) → parent GETs the reveal URL **once** → mounts `ProviderKeyRevealModal` with the plaintext → user copies, acknowledges, closes → both component and parent drop the plaintext. The provider-key list never has a "show" action — only register / rotate / remove.
+
+### Min-sample & window messaging (AC 7)
+
+`LeaderboardChart` / `LeaderboardView` accept a `window` (`7d|30d|90d|all`) and per-row sample count `n`. When `n < minSamples` (config, default e.g. 5), the row renders a muted "not enough samples (n={n})" note instead of a bar/number, so a single lucky run never tops a leaderboard. Dimensions are a tab/segmented control: **agent · provider · prompt · persona**.
+
+## Dependencies
+
+- **Prerequisite (hard): Story 32-2** — Agent registry, resolution & RBAC API. Supplies `GET/POST /api/agents`, `/api/agents/{id}/versions`, `/archive`, `PUT /api/agents/role-selections/{role}`, `GET /api/agents/resolve`, the `system-public`/`tenant-public`/`tenant-private` provenance, and the `PlatformOwnerAccess` / member-403 gates this UI drives.
+- **Prerequisite (hard): Story 32-6** — Agent action trail in tenant store. Supplies `GET /api/v1/orgs/{tenantId}/agents/{agentId}/runs` and `…/trail` with filters/pagination and the structural tenant isolation the tenant detail view relies on.
+- **Prerequisite (hard): Story 32-10** — Benchmark projections & leaderboards. Supplies the per-tenant leaderboard/benchmark reads (agent/provider/prompt slices) and the anonymized cross-tenant public-agent aggregate the admin view renders.
+- **Prerequisite (hard): Story 32-12** — Agent personas & persona-aware benchmarking. Supplies persona CRUD endpoints and the **persona** leaderboard dimension.
+- **Prerequisite (hard): Story 32-3** — Per-tenant provider credential resolution (BYOK → platform). Supplies the BYOK register/rotate/remove endpoints and the reveal-once envelope.
+- **Reuses:** `packages/dashboard` — `useAgentsConfig` + settings store, `services/settings/settings-api-client.ts` conventions, `components/secrets/SecretRevealModal.tsx`, `components/common/*` (`Card`, `Badge`, `ConfirmDialog`, `LoadingSpinner`, `Toggle`, `Slider`), `guards/AdminGuard.tsx`. `packages/dashboard-user` — `api/client.ts` (`apiClient`), `hooks/useAuth.tsx`, `guards/AuthGuard.tsx` + `TenantAdminGuard.tsx`, `layouts/AppLayout.tsx`, the `api/*.ts` typed-module pattern.
+- **Related:** Epic 27 (Prompt Store — the per-mode RBAC + admin/tenant dashboard split this mirrors), Epic 29 (secret cabinet — the reveal-once UX), Epic 34/35/36 (consume the margin/usage surfaced here; not implemented by this story).
+
+## Testing Strategy
+
+1. **Admin component tests** (`packages/dashboard`, Vitest + Testing Library, colocated `__tests__/`): `PublicAgentsPanel` renders list/create/version/archive against mocked `agents-admin-client`; system-default rows are read-only with the badge; `MarginConfigPanel` GET/PUT round-trip; `PublicLeaderboardPanel` renders the anonymized aggregate with window selector and min-sample notes.
+2. **Admin isolation test (AC 9):** assert `agents-admin-client.ts` exposes no `tenantId`-taking method and no `/orgs/{tenantId}/...` path; render the admin agents surface and assert no request to a tenant-scoped trail/leaderboard endpoint is made.
+3. **Tenant component tests** (`packages/dashboard-user`): `AgentsListPage` shows public ∪ own-private with edit only on private; `RoleSelectionsPage` shows provenance and writes selections; `AgentDetailPage` runs/trail tables paginate and apply filters; `LeaderboardView` renders agent/provider/prompt/persona dimensions with window + min-sample messaging; `OutcomeBreakdown`/`UsagePanel` render from mocked 32-9/32-10 responses.
+4. **Tenant isolation test (AC 8):** mock `apiClient`; render each tenant page; assert every captured request path contains the session `tenantId` from `useAuth` and that there is **no** input/route/dropdown to supply a foreign tenant id; attempt to manually craft a foreign-tenant fetch is not reachable from any rendered control.
+5. **Member read-only test (AC 10):** with `useAuth().role === 'member'`, assert create/version/archive/select/BYOK controls are hidden/disabled and that management routes render the `TenantAdminGuard` "Admin-only" panel; simulate a 403 from a write call and assert the role message renders (no crash).
+6. **BYOK reveal-once test (AC 11):** mock create/rotate → reveal envelope → reveal GET; assert plaintext shows once, "Close" disabled until acknowledged, copy works, and after close the plaintext is gone from state and the list never re-displays it; assert the reveal GET is invoked exactly once.
+7. **e2e-style flow (mocked endpoints):** admin creates a public agent → tenant lists it (browse-only) → tenant selects it for a role (provenance `tenant-public`) → tenant registers a BYOK key (reveal-once) → tenant opens the agent detail and sees its own (empty-then-populated) trail. All against mocked clients; asserts the admin and tenant code paths never cross tenant/aggregate boundaries.
+8. **No-regression:** existing `AgentsOverview` tests and the rest of both dashboards' suites stay green; `pnpm test --filter @tamma/dashboard` and `--filter @tamma/dashboard-user`.
+
+## Estimated Effort
+
+6-7 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `packages/dashboard/src/pages/settings/AgentsPage.tsx` | Modify (add tab shell; keep `AgentsOverview`) |
+| `packages/dashboard/src/components/settings/agents/PublicAgentsPanel.tsx` | Create |
+| `packages/dashboard/src/components/settings/agents/PublicAgentForm.tsx` | Create |
+| `packages/dashboard/src/components/settings/agents/PersonaManager.tsx` | Create |
+| `packages/dashboard/src/components/settings/agents/MarginConfigPanel.tsx` | Create |
+| `packages/dashboard/src/components/settings/agents/PublicLeaderboardPanel.tsx` | Create |
+| `packages/dashboard/src/components/settings/agents/LeaderboardChart.tsx` | Create |
+| `packages/dashboard/src/components/settings/agents/__tests__/PublicAgentsPanel.test.tsx` | Create |
+| `packages/dashboard/src/components/settings/agents/__tests__/PublicLeaderboardPanel.test.tsx` | Create |
+| `packages/dashboard/src/hooks/settings/usePublicAgents.ts` | Create |
+| `packages/dashboard/src/hooks/settings/usePublicLeaderboard.ts` | Create |
+| `packages/dashboard/src/hooks/settings/useMarginConfig.ts` | Create |
+| `packages/dashboard/src/services/settings/agents-admin-client.ts` | Create |
+| `packages/dashboard/src/services/settings/__tests__/agents-admin-client.test.ts` | Create (isolation assertion) |
+| `packages/dashboard-user/src/api/agents.ts` | Create |
+| `packages/dashboard-user/src/api/agent-trail.ts` | Create |
+| `packages/dashboard-user/src/api/provider-keys.ts` | Create |
+| `packages/dashboard-user/src/pages/agents/AgentsListPage.tsx` | Create |
+| `packages/dashboard-user/src/pages/agents/AgentDetailPage.tsx` | Create |
+| `packages/dashboard-user/src/pages/agents/RoleSelectionsPage.tsx` | Create |
+| `packages/dashboard-user/src/pages/settings/ProviderKeysPage.tsx` | Create |
+| `packages/dashboard-user/src/components/agents/AgentCard.tsx` | Create |
+| `packages/dashboard-user/src/components/agents/AgentForm.tsx` | Create |
+| `packages/dashboard-user/src/components/agents/RunsTable.tsx` | Create |
+| `packages/dashboard-user/src/components/agents/ActionTrailTable.tsx` | Create |
+| `packages/dashboard-user/src/components/agents/LeaderboardView.tsx` | Create |
+| `packages/dashboard-user/src/components/agents/OutcomeBreakdown.tsx` | Create |
+| `packages/dashboard-user/src/components/agents/UsagePanel.tsx` | Create |
+| `packages/dashboard-user/src/components/agents/ProviderKeyRow.tsx` | Create |
+| `packages/dashboard-user/src/components/agents/ProviderKeyRevealModal.tsx` | Create |
+| `packages/dashboard-user/src/pages/agents/__tests__/AgentsListPage.test.tsx` | Create |
+| `packages/dashboard-user/src/pages/agents/__tests__/AgentDetailPage.test.tsx` | Create (incl. tenant-isolation) |
+| `packages/dashboard-user/src/pages/agents/__tests__/RoleSelectionsPage.test.tsx` | Create |
+| `packages/dashboard-user/src/pages/settings/__tests__/ProviderKeysPage.test.tsx` | Create (reveal-once) |
+| `packages/dashboard-user/src/components/agents/__tests__/LeaderboardView.test.tsx` | Create (window + min-sample) |
+| `packages/dashboard-user/src/App.tsx` | Modify (register routes + guards) |
+| `packages/dashboard-user/src/layouts/AppLayout.tsx` | Modify (add Agents nav links) |
+| `packages/dashboard/src/router.tsx` | Modify (keep `/settings/agents` AdminGuard; no new admin route needed if tabbed) |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, and decisions
+3. Read the dependency stories: 32-2 (agent CRUD/RBAC + provenance), 32-3 (BYOK reveal-once), 32-6 (trail/runs API + isolation), 32-10 (leaderboards), 32-12 (personas)
+4. Read the Epic 32 design spec `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md` (the tenancy rule in §"Ownership, visibility & data scoping" is load-bearing)
+5. Planned a TDD approach (Red-Green-Refactor) — tests for separation/isolation/member-gating/reveal-once first
+
+### `packages/api` is gone — this is a TS React story only
+
+Do **not** create or reference anything under `packages/api`. The backend lives in `apps/tamma-elsa` (`Tamma.Api`) and is implemented by 32-2/32-3/32-6/32-9/32-10/32-12. This story consumes those HTTP endpoints from React.
+
+### Two dashboards, two clients
+
+`packages/dashboard` uses the bare-`fetch` `fetchJSON` convention (see `services/settings/settings-api-client.ts` and `services/secrets/secrets-api-client.ts`) with `VITE_API_BASE_URL ?? '/api'`. `packages/dashboard-user` uses the `ApiClient` class (`api/client.ts`) with `credentials: 'include'` + refresh-on-401 and per-domain `api/*.ts` modules (see `api/dashboard.ts`). **Follow each package's own convention** — do not port one into the other.
+
+### Tenant id is session-only, never user input
+
+In `packages/dashboard-user`, the active tenant id comes from `useAuth().tenantId`. Build every `/api/v1/orgs/{tenantId}/...` path from that single source via a small helper; never accept a tenant id from a route param, query string, form field, or dropdown. This is AC 8 and the difference between "isolation enforced by the server" and "isolation the UI can't even ask to violate."
+
+### Anonymized admin leaderboard is a different endpoint
+
+The admin public-agent leaderboard (AC 2) is **not** a tenant leaderboard with the tenant id stripped client-side — it must be a server-side anonymized aggregate (32-10's admin projection). The admin client must not have the ability to read a single tenant's data at all (AC 9). If the 32-10 admin aggregate endpoint is not yet present, this story's admin leaderboard panel renders an explicit "aggregate not available" empty state rather than falling back to a tenant-scoped call.
+
+### Reuse `SecretRevealModal`, don't re-invent
+
+The BYOK reveal-once flow must match the secrets UI contract precisely (one-shot GET burned by the parent, acknowledge-before-close, local-state zeroing). Prefer importing/adapting the existing `SecretRevealModal` behaviour over a fresh modal; a loosely-built reveal modal that re-fetches or re-renders the plaintext is a security defect.
+
+### Min-sample messaging is a correctness feature, not polish
+
+A leaderboard that ranks an agent #1 on a single successful run is misleading. The `n < minSamples` muted-note path (AC 7) is required, not optional, and is unit-tested.
+
+## Logging Requirements
+
+(Dashboards are browser SPAs — "logging" here is client-side observability + error surfacing, not Pino server logs.)
+
+- **INFO/console.debug (dev only):** route entered, list/leaderboard fetched (counts + window), role selection saved, BYOK key registered/rotated/removed (provider + storage-key ref **only**).
+- **User-visible WARN/ERROR:** API 403 → "you need admin/owner role" message; API 404 (e.g. cross-tenant/foreign agent) → "not found"; reveal GET failure → "could not reveal key, rotate to retry"; min-sample → muted "not enough samples (n={n})" note.
+- **Credential safety:** **NEVER** log, store in component state beyond the reveal modal's one-shot, or render-after-reveal a BYOK plaintext or any reveal token. The provider-key list shows provider/source/storage-key/last-rotated only. No secret in URLs, query strings, or telemetry.
+- **Isolation safety:** never log or render another tenant's id; the only tenant id in scope is the session's own.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-32/story-32-14/32-14-a-b-experiment-framework-for-agents.md
+++ b/docs/stories/epic-32/story-32-14/32-14-a-b-experiment-framework-for-agents.md
@@ -1,0 +1,464 @@
+# Story 32-14: A/B Experiment Framework for Agents (Phase 2: cohorts, significance, rollout/rollback)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-Phase Development Workflow (Read → Research → Break Down → TDD → Quality Gates → Failure Handling), Knowledge Base usage (`.dev/` directory), TRACE/DEBUG logging requirements, Test-Driven Development, 100% critical-path coverage, and build-success enforcement.
+
+**Failure to follow this process will result in rework.**
+
+## User Story
+
+As a **tenant owner/admin (SaaS) or self-hosted user (single-user)**,
+I want to run a controlled A/B experiment for one role — defining variants that differ by agent, config version, provider, prompt, or persona, splitting my workflow runs into cohorts, and measuring each variant against the benchmark metrics my own runs already produce —
+So that I can decide *with statistical evidence* which agent configuration performs best for my work (higher success rate, fewer iterations-to-done, lower defect rate, lower cost), then **auto-promote the winner** to my per-role selection (or **roll back** on a guarded regression) instead of guessing from a leaderboard snapshot.
+
+## Priority
+
+P2 — Phase 2 of Epic 32. It is the production realization of the A/B-testing acceptance criterion that Story 1-13 specified but never built. It is additive on top of the agent entity (32-1), registry/selection (32-2), action trail (32-6), usage/cost emission (32-9), and benchmark projections (32-10); nothing else in Epic 32 depends on it. Experiments are strictly **tenant-scoped** — they observe and mutate only the calling tenant's data.
+
+## Acceptance Criteria
+
+1. **Experiment entity (tenant-scoped).** A new `AgentExperiment` entity persists in the **resolving tenant's** `t_<hex>` schema (NOT the control plane — performance data and the experiments that read it are always tenant-owned per the Epic 32 design tenancy rule). Fields: `Id` (Guid PK), `Name`, `Role` (one of `RolePhaseMap.ValidRoles`), `Metric` (enum `success-rate` | `iterations-to-done` | `defect-rate` | `cost`), `MinSampleSize` (int per variant), `SignificanceThreshold` (double, default `0.05` = 95% confidence), `MaxSpendUsd` (decimal? guardrail), `Status` (enum `draft` | `running` | `concluded` | `rolled-back`), `WinnerVariantId` (Guid?), `BaselineVariantId` (Guid, the control), `StartedAt`/`ConcludedAt`/`CreatedAt`/`CreatedBy`/`UpdatedAt`/`UpdatedBy`. In single-user mode the principal is the sole user; in SaaS the principal is the tenant — derived via `ITammaModeProvider` exactly as 32-1/32-2 do (no per-user layer in SaaS).
+
+2. **Variants.** A child `AgentExperimentVariant` entity (`Id`, `ExperimentId` FK `OnDelete(Cascade)`, `Label`, `AgentId` Guid, `AgentVersion` int?, `Provider` string?, `PromptRef` string?, `PersonaId` Guid?, `TrafficWeight` int) defines each arm. Every variant references an agent the tenant can actually resolve (public ∪ own private, validated through `IAgentRegistryService` from 32-2). Exactly one variant per experiment is the baseline (`BaselineVariantId`). Variant weights must be positive integers summing to a configured total (default 100); an experiment with `< 2` variants or weights summing to `0` is rejected at create with 400.
+
+3. **Deterministic cohort assignment across runs.** When a workflow resolves the role under test for an eligible run, an `ExperimentAssignmentService` deterministically maps a stable assignment key — `hash(experimentId + correlationId)` (the run/issue correlation id, NOT wall clock) — onto the weighted variant split, so the same run always lands in the same cohort and the distribution converges to the configured weights. The chosen `experimentId` + `variantId` are pinned onto the `ResolvedAgentConfig` (32-2) for that run **and** stamped onto the action trail (32-6) as tags `experimentId` / `variantId`, so every `AGENT.TASK.*` / cost event the run emits is attributable to its arm. A run not eligible for any running experiment resolves exactly as it does today (zero behaviour change off the experiment path).
+
+4. **Outcome metrics reuse 32-10 projections — no new measurement plumbing.** Significance is computed over the existing per-tenant benchmark read models (32-10) and action-trail/diagnostics data (32-6/32-9), sliced by `experimentId` + `variantId`. Per variant the framework derives: trials (`n`), successes (for `success-rate`/`defect-rate`), and the per-trial continuous values (iterations-to-done, cost) — by querying the tenant's own `domain_events` / projections filtered on the experiment tags. No experiment-specific metric is recomputed from scratch; the experiment is a *slice* of the benchmark substrate.
+
+5. **Statistical significance test.** A pure `SignificanceCalculator` selects the appropriate test by metric type: a **two-proportion z-test** for rate metrics (`success-rate`, `defect-rate`) and **Welch's two-sample t-test** for continuous metrics (`iterations-to-done`, `cost`), each comparing a challenger variant against the baseline. It returns `{ pValue, effectSize, baselineN, challengerN, baselineMean|Rate, challengerMean|Rate, significant }` where `significant = pValue < SignificanceThreshold`. The math is deterministic and fully unit-tested against fixed fixtures with known expected p-values/effect sizes.
+
+6. **Guardrails — never conclude early, never overspend, honor provider gating.** (a) A variant is **ineligible to win** until its trial count `≥ MinSampleSize`; significance is not even evaluated until *every* variant meets the floor — a hot run loop cannot trip an early conclusion. (b) If cumulative experiment spend (summed from the tenant's cost events tagged with the experiment, reusing 32-9) reaches `MaxSpendUsd`, the experiment auto-concludes on current evidence (winner if significant, else baseline) and emits `AGENT.EXPERIMENT.BUDGET_REACHED`. (c) Every variant's agent/provider must pass SaaS provider auth gating (32-4) at create time — a variant naming a CLI/token provider in SaaS is rejected with 400 (`experiment_variant_provider_gated`); per-tenant budgets (32-9) still clamp each individual run regardless of the experiment.
+
+7. **Rollout to winner / rollback — atomic against the per-role selection.** Concluding a running experiment with a statistically significant winner can (when `autoRollout` is set, or on an explicit `POST .../conclude?promote=true`) update the tenant's per-role agent selection (`agent_role_selections`, 32-2) to the winning variant's `(agentId, agentVersion)` **in a single transaction**, snapshotting the *prior* selection into the experiment row first. `POST .../rollback` restores that snapshotted prior selection atomically and flips status to `rolled-back`. A conclusion with no significant winner promotes nothing and leaves the baseline selection untouched.
+
+8. **Lifecycle events on the tenant DCB stream.** `AGENT.EXPERIMENT.STARTED` (draft → running), `AGENT.EXPERIMENT.VARIANT_ASSIGNED` (each cohort assignment; deduped/sampled so a 1000×/min loop does not flood the stream — emit per-run, not per-resolution-call), `AGENT.EXPERIMENT.CONCLUDED` (with `winnerVariantId`, `pValue`, `promoted` bool), `AGENT.EXPERIMENT.ROLLED_BACK`, and the guardrail `AGENT.EXPERIMENT.BUDGET_REACHED` are appended via `IEventRepository.AppendAsync` into the **tenant's** `domain_events` table (`TenantId` = the experiment's tenant). Tags carry `experimentId`, `variantId?`, `role`, `metric`, `mode`. Events are emitted only after a real state transition (same discipline as `AGENT_CONFIG.UPDATED.SUCCESS` — never a lie event).
+
+9. **Management API + per-mode RBAC (owner/admin only for writes).** Endpoints added to `AgentEndpoints.cs` (or a new `AgentExperimentEndpoints.cs`) and mapped in `Program.cs`:
+   - `POST   /api/v1/agents/experiments` — create (draft).
+   - `GET    /api/v1/agents/experiments` / `GET .../experiments/{id}` — list / detail (live cohort config + current results).
+   - `GET    /api/v1/agents/experiments/{id}/results` — per-variant `n`, metric value, and significance vs baseline (computed live from 32-10).
+   - `POST   /api/v1/agents/experiments/{id}/start` — draft → running.
+   - `POST   /api/v1/agents/experiments/{id}/conclude` (`?promote=true|false`) — running → concluded, optional winner rollout.
+   - `POST   /api/v1/agents/experiments/{id}/rollback` — restore prior selection.
+   Writes require tenant **owner/admin** (the `AgentManage` policy = `agents:manage` from 32-2, mirroring Prompt Store RBAC); SaaS `member` → **403**. Reads are member-readable. Single-user: the sole user does everything, no gate. Cross-tenant access returns **404** (existence not leaked).
+
+10. **Cross-tenant isolation.** An experiment, its variants, its assignments, and its results are visible and mutable only within the owning tenant's schema. Two tenants each running an experiment named `atlas-vs-orion` on the `reviewer` role never see, assign into, or conclude each other's experiment. A platform owner has **no** read path into a tenant's experiment results (mirrors the 32-6 action-trail isolation). Explicitly tested.
+
+11. **Concurrency / single-running-per-role guard.** At most one experiment may be in `running` status for a given `(principal, role)` at a time — starting a second returns **409** (`experiment_role_conflict`). This keeps cohort assignment unambiguous (a run is in at most one experiment's split for its role).
+
+12. **Tests** cover: cohort split distribution (assigning N keys yields a distribution within tolerance of the configured weights, and is stable/deterministic per key); significance math on fixtures (two-proportion z and Welch's t against precomputed expected values, including the degenerate equal-rate and zero-variance cases); winner rollout updates `agent_role_selections` and the prior selection is snapshotted; rollback restores it atomically; the `MinSampleSize` guard prevents conclusion below the floor; the `MaxSpendUsd` guardrail auto-concludes and emits `BUDGET_REACHED`; provider-gating rejection at create (SaaS CLI provider variant); the single-running-per-role 409; and tenant isolation (tenant B cannot read/assign/conclude tenant A's experiment, platform owner cannot read results). Critical paths (assignment determinism, significance, rollout/rollback transaction, guardrails) → 100%.
+
+## Technical Design
+
+### Architectural placement (per the Epic 32 design of record)
+
+Per `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md` §"Ownership, visibility & data scoping" and §"Tracking … Phase 2: A/B experiment framework":
+
+- **Agent definitions** (public/private) are control-plane / CP-resident (32-1).
+- **Performance + action data is ALWAYS tenant-scoped.** An A/B experiment *reads* that data and *acts on* the tenant's own per-role selection — so the experiment, its variants, its assignments, and its results all live in the tenant's `t_<hex>` schema (`TenantDbContext`), never on the control plane and never cross-tenant. This is the same structural isolation that backs the 32-6 action trail.
+- This story is purely **additive**: new tenant-schema tables + a deterministic assignment seam wired into the existing resolve path + a significance calculator over the 32-10 read models + a rollout controller over the 32-2 selection table. It does not change resolution semantics off the experiment path.
+
+Story 32-1 (entities), 32-2 (`IAgentRegistryService`, `agent_role_selections`, `ResolvedAgentConfig` enrichment, `AgentManage` policy), 32-6 (action-trail tags), 32-9 (cost emission), and 32-10 (benchmark projections) are assumed present. Where a sibling-story artifact is referenced and not yet confirmed in code, it is marked **(from 32-N)** and the integration is via that story's named seam, not a reimplementation.
+
+### C# namespace / file structure
+
+```
+apps/tamma-elsa/src/
+  Tamma.Data/
+    Entities/
+      AgentExperiment.cs                 # NEW — tenant-scoped experiment header
+      AgentExperimentVariant.cs          # NEW — one arm (agent/version/provider/prompt/persona + weight)
+      AgentExperimentMetric.cs           # NEW — enum { SuccessRate, IterationsToDone, DefectRate, Cost }
+      AgentExperimentStatus.cs           # NEW — enum { Draft, Running, Concluded, RolledBack }
+    TenantDbContext.cs                   # MODIFY — add DbSet<AgentExperiment>, DbSet<AgentExperimentVariant>
+    TammaModelConfiguration.cs           # MODIFY — ConfigureTenantEntities: tables, indexes, CHECK, cascade FK
+    Repositories/
+      IAgentExperimentRepository.cs      # NEW
+      AgentExperimentRepository.cs       # NEW
+    Migrations/Tenant/
+      <ts>_AddAgentExperiments.cs        # NEW — additive tenant-schema migration
+  Tamma.Api/
+    Services/Agents/
+      IExperimentAssignmentService.cs    # NEW — deterministic weighted cohort assignment
+      ExperimentAssignmentService.cs     # NEW
+      SignificanceCalculator.cs          # NEW — pure: two-proportion z + Welch's t
+      ISignificanceCalculator.cs         # NEW
+      ExperimentResultsService.cs        # NEW — slices 32-10 projections by experiment/variant
+      ExperimentRolloutController.cs     # NEW — atomic winner-promote / rollback over agent_role_selections
+      AgentExperimentService.cs          # NEW — orchestrates lifecycle (create/start/conclude/rollback) + events
+      AgentExperimentEventTypes.cs       # NEW — AGENT.EXPERIMENT.* constants
+    Endpoints/
+      AgentEndpoints.cs                  # MODIFY (or AgentExperimentEndpoints.cs NEW) — experiment routes
+    Dtos/Agents/
+      AgentExperimentDtos.cs             # NEW — request/response records
+    Services/TaskQueue/                  # REUSE — async significance re-eval + budget-watch via QueuedTask
+    Program.cs                           # MODIFY — register services + map routes with AgentManage RBAC
+packages/dashboard-user/src/
+  pages/experiments/                     # NEW — tenant experiment list + detail (cohort config, live results, conclude/rollback)
+  services/experiments-client.ts         # NEW — typed API client
+```
+
+### Entities (sketch)
+
+```csharp
+// Tamma.Data/Entities/AgentExperimentMetric.cs
+public enum AgentExperimentMetric { SuccessRate, IterationsToDone, DefectRate, Cost }
+
+// Tamma.Data/Entities/AgentExperimentStatus.cs
+public enum AgentExperimentStatus { Draft, Running, Concluded, RolledBack }
+
+// Tamma.Data/Entities/AgentExperiment.cs  (tenant-schema; t_<hex>.agent_experiments)
+public class AgentExperiment
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+    public string Role { get; set; } = null!;                 // RolePhaseMap.ValidRoles
+    public AgentExperimentMetric Metric { get; set; }
+    public int MinSampleSize { get; set; }                    // per variant, > 0
+    public double SignificanceThreshold { get; set; } = 0.05; // p-value gate
+    public decimal? MaxSpendUsd { get; set; }                 // guardrail; null = unbounded
+    public bool AutoRollout { get; set; }
+    public AgentExperimentStatus Status { get; set; } = AgentExperimentStatus.Draft;
+    public Guid BaselineVariantId { get; set; }               // the control arm
+    public Guid? WinnerVariantId { get; set; }
+    public string? PriorSelectionSnapshot { get; set; }       // JSON {agentId, agentVersion} captured before promote
+    public DateTime? StartedAt { get; set; }
+    public DateTime? ConcludedAt { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public Guid? CreatedBy { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public Guid? UpdatedBy { get; set; }
+
+    public ICollection<AgentExperimentVariant> Variants { get; set; } = new List<AgentExperimentVariant>();
+}
+
+// Tamma.Data/Entities/AgentExperimentVariant.cs  (t_<hex>.agent_experiment_variants)
+public class AgentExperimentVariant
+{
+    public Guid Id { get; set; }
+    public Guid ExperimentId { get; set; }
+    public string Label { get; set; } = null!;
+    public Guid AgentId { get; set; }            // resolvable: public ∪ own private (validated via 32-2)
+    public int? AgentVersion { get; set; }        // null = agent's current version
+    public string? Provider { get; set; }         // optional variant axis
+    public string? PromptRef { get; set; }
+    public Guid? PersonaId { get; set; }          // 32-12 persona axis
+    public int TrafficWeight { get; set; }        // positive int; weights sum to total (default 100)
+
+    public AgentExperiment? Experiment { get; set; }
+}
+```
+
+### EF model config (in `TammaModelConfiguration.ConfigureTenantEntities`, tenant-only)
+
+```csharp
+modelBuilder.Entity<AgentExperiment>(entity =>
+{
+    entity.ToTable("agent_experiments", t =>
+    {
+        t.HasCheckConstraint("ck_agent_experiments_min_sample", "\"MinSampleSize\" > 0");
+        t.HasCheckConstraint("ck_agent_experiments_threshold",
+            "\"SignificanceThreshold\" > 0 AND \"SignificanceThreshold\" < 1");
+    });
+    entity.HasKey(e => e.Id);
+    entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+    entity.Property(e => e.Name).IsRequired().HasMaxLength(128);
+    entity.Property(e => e.Role).IsRequired().HasMaxLength(64);
+    entity.Property(e => e.Metric).HasConversion<int>();
+    entity.Property(e => e.Status).HasConversion<int>().HasDefaultValue(AgentExperimentStatus.Draft);
+    entity.Property(e => e.PriorSelectionSnapshot).HasColumnType("jsonb");
+    entity.Property(e => e.MaxSpendUsd).HasColumnType("numeric(12,4)");
+    entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+    entity.Property(e => e.UpdatedAt).HasDefaultValueSql("now()");
+    // AC 11: at most one running experiment per role (per principal == per tenant schema)
+    entity.HasIndex(e => e.Role)
+        .IsUnique()
+        .HasFilter("\"Status\" = 1")   // 1 = Running
+        .HasDatabaseName("IX_agent_experiments_one_running_per_role");
+});
+
+modelBuilder.Entity<AgentExperimentVariant>(entity =>
+{
+    entity.ToTable("agent_experiment_variants", t =>
+        t.HasCheckConstraint("ck_agent_experiment_variants_weight", "\"TrafficWeight\" > 0"));
+    entity.HasKey(e => e.Id);
+    entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+    entity.HasOne(e => e.Experiment)
+        .WithMany(x => x.Variants)
+        .HasForeignKey(e => e.ExperimentId)
+        .OnDelete(DeleteBehavior.Cascade);   // variants are owned by the experiment
+    entity.HasIndex(e => new { e.ExperimentId, e.Label })
+        .IsUnique().HasDatabaseName("IX_agent_experiment_variants_label");
+});
+```
+
+> Per Epic 28 conventions these are tenant-resident: in the target architecture the tenant DB holds only that tenant's rows, so no `TenantId` column appears on the tables (the `ConfigureTenantEntities` configurator strips it). The `IX_agent_experiments_one_running_per_role` partial unique index is per-schema → naturally per-tenant; in single-user mode the user's instance is the schema.
+
+### Deterministic cohort assignment
+
+```csharp
+// Tamma.Api/Services/Agents/IExperimentAssignmentService.cs
+public interface IExperimentAssignmentService
+{
+    /// <summary>
+    /// Resolve the active experiment (if any) for (role) within the calling
+    /// tenant and deterministically assign this run to a variant by weighted
+    /// split keyed on assignmentKey (the run/issue correlationId — NEVER wall
+    /// clock — so a run is stable across retries and re-resolutions).
+    /// Returns null when no experiment is running for the role.
+    /// </summary>
+    Task<ExperimentAssignment?> AssignAsync(string role, string assignmentKey, CancellationToken ct = default);
+}
+
+public sealed record ExperimentAssignment(Guid ExperimentId, Guid VariantId, Guid AgentId, int? AgentVersion);
+```
+
+Weighted-split algorithm (stable, weight-proportional):
+
+```
+total   = Σ variant.TrafficWeight
+bucket  = (uint)(StableHash(experimentId + ":" + assignmentKey) % total)
+acc     = 0
+foreach variant ordered by Id:
+    acc += variant.TrafficWeight
+    if bucket < acc: return variant      // deterministic; same key → same arm
+```
+
+`StableHash` is a fixed, content-addressed hash (e.g. SHA-256 of the UTF-8 bytes, first 8 bytes as `uint64`) — **not** `string.GetHashCode()` (process-randomized in .NET). The hash and modulo are pure and unit-tested for distribution + determinism. The assignment is pinned onto `ResolvedAgentConfig` (32-2) and added to the action-trail tag builder (32-6) as `experimentId` / `variantId`, with `AGENT.EXPERIMENT.VARIANT_ASSIGNED` emitted once per run.
+
+### Significance calculation (pure)
+
+```csharp
+// Tamma.Api/Services/Agents/SignificanceCalculator.cs
+public sealed record VariantStats(Guid VariantId, int N, int Successes, double Sum, double SumSq);
+public sealed record SignificanceResult(
+    Guid BaselineVariantId, Guid ChallengerVariantId,
+    double PValue, double EffectSize,
+    int BaselineN, int ChallengerN,
+    double BaselineValue, double ChallengerValue,
+    bool Significant);
+
+public interface ISignificanceCalculator
+{
+    // Rate metrics (success-rate, defect-rate): two-proportion z-test.
+    SignificanceResult TwoProportionZ(VariantStats baseline, VariantStats challenger, double alpha);
+    // Continuous metrics (iterations-to-done, cost): Welch's two-sample t-test.
+    SignificanceResult WelchT(VariantStats baseline, VariantStats challenger, double alpha);
+}
+```
+
+- **Two-proportion z-test**: pooled proportion `p̂ = (x₁+x₂)/(n₁+n₂)`; `SE = √(p̂(1−p̂)(1/n₁+1/n₂))`; `z = (p̂₁−p̂₂)/SE`; two-tailed `pValue = 2·(1−Φ(|z|))` via a standard-normal CDF approximation (Abramowitz–Stegun erf); `effectSize` = absolute rate difference. Degenerate `SE=0` (both rates 0 or 1) → `pValue = 1`, not significant.
+- **Welch's t-test**: per-variant mean/variance from `Sum`/`SumSq`/`N`; Welch `t` and Welch–Satterthwaite `df`; two-tailed p via a t-distribution CDF (regularized incomplete beta); `effectSize` = Cohen's d (pooled-SD). Zero-variance/`N<2` guarded → not significant.
+
+Both are deterministic, dependency-light (no external stats library required for the core path; if a vetted package is added, pin it and keep the public contract), and exhaustively fixture-tested.
+
+### Results service — slicing 32-10, not re-measuring
+
+`ExperimentResultsService.GetResultsAsync(experimentId)` reads the tenant's benchmark projections / action-trail (32-10/32-6) filtered by the `experimentId` tag, groups by `variantId`, and builds a `VariantStats` per arm for the experiment's `Metric`:
+- `success-rate` → `N` = `AGENT.TASK.*` count, `Successes` = `AGENT.TASK.SUCCESS` count.
+- `defect-rate` → `N` = task count, `Successes` = runs with ≥1 `REVIEW.BUG.RECORDED` (the "defect" event), reported as a rate.
+- `iterations-to-done` → per-run `AGENT.ITERATION.COMPLETED` max / `iterations` from `AGENT.TASK.*` `Data`, accumulated into `Sum`/`SumSq`.
+- `cost` → per-run `costUsd` from cost events (32-9), accumulated into `Sum`/`SumSq` (also the source for the `MaxSpendUsd` guardrail tally).
+
+The framework adds **no** new measurement events — it is a query/slice over the existing substrate, which is why 32-10 is a hard dependency.
+
+### Rollout controller — atomic selection mutation
+
+```csharp
+// Tamma.Api/Services/Agents/ExperimentRolloutController.cs
+public interface IExperimentRolloutController
+{
+    // Promote the winner: snapshot prior selection into the experiment row,
+    // then upsert agent_role_selections to the winner's (agentId, version) — one transaction.
+    Task PromoteWinnerAsync(AgentExperiment exp, AgentExperimentVariant winner, CancellationToken ct);
+    // Restore the snapshotted prior selection — one transaction.
+    Task RollbackAsync(AgentExperiment exp, CancellationToken ct);
+}
+```
+
+`PromoteWinnerAsync`:
+
+```
+BEGIN
+  prior = SELECT agentId, version FROM agent_role_selections WHERE Role=@role   -- (32-2 selection)
+  UPDATE agent_experiments SET PriorSelectionSnapshot=@prior, WinnerVariantId=@w,
+         Status=Concluded, ConcludedAt=now() WHERE Id=@exp
+  UPSERT agent_role_selections (Role=@role, AgentId=@winnerAgent, Version=@winnerVersion)  -- via IAgentRegistryService.SelectForRoleAsync
+COMMIT
+→ emit AGENT.EXPERIMENT.CONCLUDED { winnerVariantId, pValue, promoted:true }
+```
+
+`RollbackAsync` reverses the upsert from `PriorSelectionSnapshot`, flips `Status=RolledBack`, emits `AGENT.EXPERIMENT.ROLLED_BACK`. Both run through the tenant `TenantDbContext` transaction so a partial promote can never leave a dangling selection.
+
+### Async re-evaluation + budget watch (reuse TaskQueue)
+
+Significance is recomputed live on `GET .../results`, but a background re-evaluation (and the `MaxSpendUsd` budget watch) runs off the existing `TaskQueueProcessor` (`Services/TaskQueue/`): on each tick a `agent.experiment.evaluate` `QueuedTask` (tenant-scoped) re-reads results for running experiments, and — when `AutoRollout` is set, every variant meets `MinSampleSize`, and a winner is significant — auto-concludes + promotes; or auto-concludes on `MaxSpendUsd`. This reuses the same poll-loop pattern as queued tenant moves; no new background-service plumbing.
+
+### DCB event names (NEW)
+
+| Event | When | Tags |
+|---|---|---|
+| `AGENT.EXPERIMENT.STARTED` | draft → running | `experimentId, role, metric, mode` |
+| `AGENT.EXPERIMENT.VARIANT_ASSIGNED` | a run is assigned to a cohort (once per run) | `experimentId, variantId, role, mode` |
+| `AGENT.EXPERIMENT.CONCLUDED` | running → concluded | `experimentId, role, metric, mode` + `Data { winnerVariantId, pValue, promoted }` |
+| `AGENT.EXPERIMENT.ROLLED_BACK` | prior selection restored | `experimentId, role, mode` |
+| `AGENT.EXPERIMENT.BUDGET_REACHED` | `MaxSpendUsd` guardrail tripped | `experimentId, role, mode` + `Data { spendUsd, maxSpendUsd }` |
+
+All appended via `IEventRepository.AppendAsync` into the **tenant** `domain_events` (`TenantId` = the experiment's tenant), `Metadata` = standard DCB envelope (`workflowVersion`, `eventSource:"system"`).
+
+### API shape
+
+```
+POST /api/v1/agents/experiments
+  body: { name, role, metric, minSampleSize, significanceThreshold?, maxSpendUsd?, autoRollout?,
+          variants:[{ label, agentId, agentVersion?, provider?, promptRef?, personaId?, trafficWeight }],
+          baselineLabel }
+  → 201 ExperimentDetail   RBAC: AgentManage (owner/admin); member → 403
+POST /api/v1/agents/experiments/{id}/start     → 200 (draft→running) | 409 experiment_role_conflict
+GET  /api/v1/agents/experiments                 → 200 [ ExperimentSummary ]   (member-readable)
+GET  /api/v1/agents/experiments/{id}            → 200 ExperimentDetail | 404
+GET  /api/v1/agents/experiments/{id}/results    → 200 { variants:[{ variantId, n, value, significance? }], metric, status }
+POST /api/v1/agents/experiments/{id}/conclude?promote=true|false  → 200 ExperimentDetail   RBAC: AgentManage
+POST /api/v1/agents/experiments/{id}/rollback   → 200 ExperimentDetail   RBAC: AgentManage
+```
+
+Per-mode + per-tenant handling: writes gated by `AgentManage` (= `agents:manage`, admin+owner; 32-2). Reads member-readable. Single-user: sole user, no gate. A `GET {id}` for another tenant's experiment → **404** (existence not leaked); the tenant schema makes cross-tenant rows physically unreachable anyway.
+
+### Integration points
+
+- **`IAgentRegistryService`** (`Tamma.Api/Services/Agents/`, from 32-2): validates each variant's `agentId` is resolvable (public ∪ own private); `SelectForRoleAsync` is the seam the rollout controller upserts through.
+- **`ResolvedAgentConfig`** (32-2): assignment pins `experimentId`/`variantId` + materializes the variant's `(agentId, version, provider, promptRef, personaId)` into the resolved config so the run executes the arm.
+- **`AgentTrailTags.Build`** (`Tamma.Api/Services/Agents/AgentTrailTags.cs`, 32-6): add `experimentId`/`variantId` so every trail + cost event is arm-attributable.
+- **Benchmark projections** (32-10) + **cost emission** (32-9): the read substrate the results service slices; the cost tally for the `MaxSpendUsd` guardrail.
+- **Provider gating** (32-4): variant create validates SaaS API-key-only gating.
+- **`IEventRepository`** (`Tamma.Data/Repositories/EventRepository.cs`): tenant DCB emission.
+- **`ITammaModeProvider`** (`Tamma.Api/Services/PromptStore/TammaMode.cs`): per-mode principal (tenant vs sole user).
+- **`TaskQueueProcessor`** (`Tamma.Api/Services/TaskQueue/`): async re-eval + budget watch.
+- **`AgentManage` policy** (`Program.cs`, from 32-2): write RBAC.
+- **`packages/dashboard-user/`**: tenant-facing experiment UI (list/detail/results/conclude/rollback).
+
+## Dependencies
+
+- **Prerequisite (hard)**: 32-1 (Agent/AgentVersion entities — variants reference `agentId` + version), 32-2 (registry/resolution, `agent_role_selections`, `ResolvedAgentConfig` enrichment, `AgentManage` policy — what assignment pins onto and rollout mutates), 32-10 (benchmark projections — the read models significance is computed over).
+- **Prerequisite (guardrails)**: 32-4 (SaaS provider auth gating — variant validation), 32-9 (usage & cost emission — the cost tally for `MaxSpendUsd` and the `cost` metric).
+- **Related**: 32-6 (action trail — assignment tags ride its `Tags` builder), 32-12 (personas — the `personaId` variant axis), 32-13 (dashboards — the experiment UI lives alongside the benchmark dashboard surface).
+- **Design of record**: `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md` (Epic 32 design; §"Phase 2: A/B experiment framework").
+- **Origin**: realizes the A/B-testing acceptance criterion Story 1-13 specified but never built.
+- **Blocks**: nothing — this is the terminal Phase-2 story of Epic 32.
+
+## Testing Strategy
+
+**Unit tests** (`tests/Tamma.Api.Tests/Agents/` — in-memory or Postgres fixture per `Infrastructure/InMemoryDbFixture.cs` / `Epic28/` precedent):
+1. **Cohort split distribution**: assign 100k stable keys across weights `{50,30,20}` → empirical distribution within tolerance of the weights; the *same* key always returns the *same* variant (determinism); changing `experimentId` reshuffles. `StableHash` is process-stable (run twice, identical buckets).
+2. **Significance math** — two-proportion z: fixtures with precomputed expected `pValue`/`z`/effect for clearly-different, marginal, and equal rates; degenerate `SE=0` → `pValue=1`, not significant; `n` below floor handled by the caller, not the calculator.
+3. **Significance math** — Welch's t: fixtures for different means, equal means, and zero-variance; Cohen's d effect size; `N<2` guarded.
+4. **MinSampleSize guard**: results with one variant under floor → no winner declared even if the over-floor variant is "significant"; all variants at floor + significant challenger → winner declared.
+5. **Rollout + rollback atomicity**: promote upserts `agent_role_selections` to the winner and snapshots the prior selection in one transaction; rollback restores it; a forced failure mid-transaction leaves the selection unchanged (no dangling state).
+6. **MaxSpendUsd guardrail**: cumulative tagged cost reaching the cap auto-concludes (winner if significant else baseline) and emits `AGENT.EXPERIMENT.BUDGET_REACHED`.
+7. **Provider gating**: a SaaS create with a variant naming a CLI/token provider → 400 `experiment_variant_provider_gated`; single-user allows it.
+8. **Lifecycle events**: start/conclude/rollback/budget each emit exactly one corresponding tenant DCB event; no event on a no-op (concluding an already-concluded experiment).
+9. **Single-running-per-role**: starting a second experiment for the same role while one runs → 409; partial-unique-index backstop verified against Postgres.
+
+**Integration tests** (Postgres-bound, run via `sg docker -c "dotnet test ..."`):
+10. Tenant migration applies + `dotnet ef migrations has-pending-model-changes --context TenantDbContext` reports none; tenant-model tests assert the new tables/indexes/CHECK.
+11. **Endpoint RBAC matrix**: `AgentManage` required for create/start/conclude/rollback; SaaS `member` → 403 on writes, 200 on reads; single-user sole user → all 200.
+12. **End-to-end A/B**: create 2-variant experiment, start, emit synthetic 32-6 trail/cost events for both arms tagged with `experimentId`/`variantId`, `GET /results` computes per-variant `n` + significance, conclude with `promote=true` repoints `agent_role_selections`, `rollback` restores the baseline — all within one tenant.
+13. **Tenant isolation** (mirrors `Epic28/CrossTenantIsolationPostgresTests.cs`): tenant A's experiment/results invisible to tenant B (404); platform owner has no results read path; two tenants run same-named experiments on the same role without collision.
+
+**Coverage**: critical paths (assignment determinism, significance, rollout/rollback transaction, guardrails) → 100%; service/repository line ≥ 80%.
+
+## Estimated Effort
+
+6-7 days
+
+## Files Created / Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/AgentExperiment.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/AgentExperimentVariant.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/AgentExperimentMetric.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/AgentExperimentStatus.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/IAgentExperimentRepository.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/AgentExperimentRepository.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/<ts>_AddAgentExperiments.cs` (+ `.Designer.cs`, snapshot) | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/IExperimentAssignmentService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ExperimentAssignmentService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ISignificanceCalculator.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/SignificanceCalculator.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ExperimentResultsService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ExperimentRolloutController.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentExperimentService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentExperimentEventTypes.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/AgentExperimentDtos.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentExperimentEndpoints.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/SignificanceCalculatorTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/ExperimentAssignmentServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/ExperimentRolloutControllerTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentExperimentEndpointsTests.cs` | Create |
+| `packages/dashboard-user/src/pages/experiments/ExperimentsPage.tsx` | Create |
+| `packages/dashboard-user/src/pages/experiments/ExperimentDetailPage.tsx` | Create |
+| `packages/dashboard-user/src/services/experiments-client.ts` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs` | Modify (add `DbSet<AgentExperiment>`, `DbSet<AgentExperimentVariant>`) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (`ConfigureTenantEntities`: tables, indexes, CHECK, cascade FK) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentTrailTags.cs` | Modify (add `experimentId`/`variantId` tags — coordinate with 32-6) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (register services; map experiment routes with `AgentManage` RBAC; wire TaskQueue handler) |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, decisions
+3. Read the Epic 32 design of record: `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md` (§"Phase 2")
+4. Read sibling stories 32-1 (entities), 32-2 (registry/selection + `AgentManage` + `ResolvedAgentConfig`), 32-6 (action-trail tags), and the 32-9/32-10 specs (cost + benchmark projections) — this story *consumes* their seams, it does not re-implement them
+5. Reviewed the closest existing patterns: `AgentConfig`/`AgentEndpoints.UpdateConfig` (tenant JSONB + audit-event discipline), `TammaModelConfiguration.ConfigureTenantEntities` (tenant-schema entity config + partial indexes), `TaskQueueProcessor` (`ProcessOnceAsync` poll loop), `Epic28/CrossTenantIsolationPostgresTests.cs` (isolation proof)
+6. Planned the TDD approach (Red-Green-Refactor) — start with `SignificanceCalculatorTests` (pure, fixture-driven) and `ExperimentAssignmentServiceTests` (deterministic distribution), which have zero DB dependency
+
+### Key design decisions
+
+- **Tenant-scoped, full stop.** The experiment, its variants, its assignments, and its results all live in the tenant schema. Per CLAUDE.md "Universal rule for any tenant-aware feature", both ownership models are answered explicitly: SaaS → the tenant owns it (`AgentManage` = owner/admin; member read-only); single-user → the sole user owns it (no gate). A platform owner has **no** read path into a tenant's experiment results — the same isolation backbone as the 32-6 action trail. This is also why the experiment lives in `TenantDbContext`, not the control plane where the agent *definitions* live.
+- **Slice, don't re-measure.** Significance is computed over the 32-10 benchmark projections filtered by `experimentId`/`variantId`. The framework introduces no new measurement events — it adds two tags to the existing trail and reads the existing substrate. That is the whole point of building it after 32-10.
+- **Determinism is load-bearing.** Cohort assignment hashes the *run correlation id*, never the clock, so a run is stable across retries/re-resolutions and lands in exactly one arm. Use a content-addressed hash (SHA-256), never `string.GetHashCode()` (process-randomized in .NET) — getting this wrong silently breaks both reproducibility and the split distribution.
+- **Guardrails before conclusions.** No significance is even evaluated until every variant clears `MinSampleSize`; spend is capped by `MaxSpendUsd` (auto-conclude + `BUDGET_REACHED`); SaaS provider gating (32-4) rejects ineligible variants at create; per-tenant budgets (32-9) still clamp each run. The framework can never declare a winner on thin evidence or run away on cost.
+- **Atomic rollout/rollback.** Promotion snapshots the prior selection *before* repointing `agent_role_selections`, all in one tenant transaction; rollback restores from the snapshot. A partial promote can never leave a dangling or half-applied selection — the rollout controller is the only writer to the selection during conclusion.
+- **No behaviour change off the experiment path.** A role with no running experiment resolves byte-for-byte as it does today; assignment returns null and the existing 32-2 precedence applies. The experiment seam is purely additive in the resolve path.
+
+### Migration discipline (Epic 28 conventions)
+
+- `agent_experiments` / `agent_experiment_variants` are **additive tenant-schema** tables — `dotnet ef migrations add AddAgentExperiments --context TenantDbContext`, not a baseline CHECK edit.
+- After adding, run `dotnet ef migrations has-pending-model-changes --context TenantDbContext` → must report none.
+- Mirror entity config **only** in `TammaModelConfiguration.ConfigureTenantEntities` (the established single source); the snapshot/Designer are generated, not hand-edited.
+- Run C# tests with `sg docker -c "dotnet test ..."` (session docker group is stale; build needs no wrapper).
+
+### Edge cases
+
+- **Two variants tie / no significant winner**: conclude promotes nothing; baseline selection untouched; `AGENT.EXPERIMENT.CONCLUDED` carries `winnerVariantId:null, promoted:false`.
+- **Variant references an agent that was archived mid-experiment**: assignment still pins the variant's pinned `(agentId, version)` (immutable history, 32-1); resolution materializes the pinned version even though the agent is archived — the experiment measures the version it started with.
+- **Concluding an already-concluded / rolled-back experiment**: idempotent no-op, no second event.
+- **Rollback when no prior selection existed** (role had no explicit selection, was resolving the system default): restore = delete the experiment-set selection so the role falls back to the system-default public agent (per 32-2 precedence), not a dangling row.
+- **Spend cap and significance reached on the same tick**: budget-reached takes precedence in messaging but the conclusion uses the significant winner — one `CONCLUDED` event, plus `BUDGET_REACHED`.
+- **Weights that don't sum to the configured total**: rejected at create (400) — never silently normalized, so the operator's intent is explicit.
+
+## Logging Requirements
+
+- **INFO**: experiment created (`experimentId, role, metric, variantCount`), started, concluded (`winnerVariantId, pValue, promoted`), rolled back, budget reached (`spendUsd, maxSpendUsd`), winner promoted to selection (`role, agentId, version`).
+- **DEBUG**: cohort assignment resolved (`experimentId, variantId, role` — never the raw assignment key if it could embed sensitive context), significance evaluated (`baselineN, challengerN, pValue, significant`), results sliced from projections (`variantCount, totalTrials`).
+- **WARN**: significance evaluation skipped — variant below `MinSampleSize` (`variantId, n, floor`); single-running-per-role 409; member-role 403 on write; provider-gating rejection at create (`provider`); weights-sum mismatch at create.
+- **ERROR**: rollout/rollback transaction failed/rolled back (`experimentId, role`), event append failure after a committed transition, TaskQueue re-eval handler failure (isolated per tick, does not kill the loop).
+- **Structured context**: include `{ experimentId, role, metric, mode }` where applicable; `{ variantId, n, pValue }` on significance logs.
+- **Credential safety**: never log raw provider keys (variants are credential-agnostic — provider *name* only, never a key); redact any blob-referenced content.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-32/story-32-2/32-2-agent-registry-resolution-and-rbac-api.md
+++ b/docs/stories/epic-32/story-32-2/32-2-agent-registry-resolution-and-rbac-api.md
@@ -1,0 +1,423 @@
+# Story 32-2: Agent Registry, Resolution & RBAC API
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **tenant owner/admin (SaaS) or self-hosted user (single-user)**,
+I want to list, create, version, archive, and select first-class agents — and have workflows resolve the *effective* agent for a `(role, phase)` request through a deterministic precedence chain,
+So that named, versioned agent entities (introduced in Story 32-1) actually drive workflow execution instead of the anonymous JSONB role config, with strict per-mode RBAC and zero silent-fallback behaviour.
+
+## Priority
+
+P0 — Without resolution + RBAC, the Story 32-1 agent entities are inert. This story is the seam that promotes them into the live `ResolvedAgentConfig` pipeline that `AgentResolverService` and the Elsa `CallLlmActivity` already consume. It is the prerequisite for managed execution (32-5), the action trail (32-6), and panels (32-7).
+
+## Acceptance Criteria
+
+1. **`AgentRegistryService`** (new, `Tamma.Api/Services/Agents/AgentRegistryService.cs`) implements `IAgentRegistryService` exposing: `ListAsync` (scoped to caller: all public agents ∪ own-tenant private agents), `GetWithVersionsAsync(agentId)`, `CreateAsync`, `PublishVersionAsync(agentId, version)`, `ArchiveAsync(agentId)`, `SelectForRoleAsync(role, agentId)`, and `GetRoleSelectionsAsync()`. Public-agent reads come from `ControlPlaneDbContext`; private-agent reads/writes and role selections come from the caller's `TenantDbContext` (`t_<hex>` schema).
+2. **`AgentResolverService.ResolveForRoleAsync(role)` / `ResolveForPhaseAsync(phase, role)`** return an enriched `ResolvedAgentConfig` carrying the new fields `AgentId` (Guid), `AgentVersion` (int), and `Source` (one of `system-public` | `tenant-public` | `tenant-private`), in addition to all existing fields. The existing legacy `ResolveAsync(tenantId, role)` JSONB path is preserved as the merge target — the agent's pinned config version is materialised into the same `ResolvedAgentConfig` shape so `CallLlmActivity` is unchanged.
+3. **Resolution precedence** for `(tenant, role)` is, in order, with NO empty/plain fallback (per `feedback_resolution_no_empty_fallback`):
+   1. Tenant-selected **private** agent for that role (from the tenant's `agent_role_selections`) → use it.
+   2. Tenant-selected **public** agent for that role (selection points at a control-plane public agent) → use it.
+   3. **System-default public** agent for that role (the shipped default selection) → use it.
+   4. None resolvable → emit `AGENT.RESOLVE.FAILED` + record a `MISSING_CONFIG` gap, then throw `TammaError("AGENT.RESOLVE.NO_DEFAULT", ..., severity: High)`. NEVER return a blank `ResolvedAgentConfig`.
+4. **Role-to-agent selection is persisted per tenant** in a new `agent_role_selections` table (tenant schema in SaaS; user-keyed row in single-user) — one selection per `(principal, role)`. `ResolveForRoleAsync` respects it; absent a tenant selection, resolution falls to the system-default public agent for the role (AC 3.3), never to empty.
+5. **Endpoints** wired in `AgentEndpoints.cs` and mapped in `Program.cs` under `/api/agents`:
+   - `GET  /api/agents` — list (public ∪ own private), filters `?role=&visibility=&status=`.
+   - `POST /api/agents` — create a **private** agent (SaaS: `AgentManage`; single-user: owner).
+   - `GET  /api/agents/{id}` — get one agent with its version history.
+   - `POST /api/agents/{id}/versions` — publish a new pinned config version.
+   - `POST /api/agents/{id}/archive` — archive (soft, status flip).
+   - `PUT  /api/agents/role-selections/{role}` — select which agent serves a role for the principal.
+   - `GET  /api/agents/resolve?role=&phase=` — return the enriched `ResolvedAgentConfig`.
+6. **Per-mode RBAC**, mirroring the Prompt Store:
+   - SaaS `member` → **403** on POST/PUT/POST-versions/POST-archive and role-selection writes; reads allowed.
+   - SaaS `tenant_owner`/`tenant_admin` → may create/version/archive/select only **private** agents owned by their own tenant.
+   - Public-agent mutation (create/version/archive a `visibility = public` agent) requires `PlatformOwnerAccess`; a tenant attempting it gets **403**.
+   - Single-user mode → sole user (auto-owner) may do everything; no member gate.
+7. **Cross-tenant isolation**: a tenant cannot read another tenant's private agents (404, not 403, to avoid existence leak) and cannot select or mutate them. A `GET /api/agents` from tenant A never returns tenant B's private rows.
+8. **Public-agent writes by a tenant are rejected**: a `POST /api/agents` body with `visibility: "public"` from a non-platform-owner returns **403** with code `agent_public_write_forbidden`; a tenant `POST /api/agents/{id}/versions` against a public agent returns **403**.
+9. **Resolution never falls back to empty/plain config**: a missing system-default public agent for a taxonomy-valid role emits `AGENT.RESOLVE.FAILED` and records a `MISSING_CONFIG` gap (ties into the Missing-Config Notifications epic, domain `agent`, config_key `role:{role}`) rather than returning a blank config. The thrown `TammaError` matches the prompt/convention fail-loud pattern.
+10. **Single-user mode** resolves with `user_id` as principal and no RBAC gate; **SaaS mode** resolves with `tenant_id` — verified by mode-parameterized tests over `ITammaModeProvider`.
+11. **DCB events** (`AGGREGATE.ACTION.STATUS`) emitted via `IEventRepository.AppendAsync`:
+    - `AGENT.SELECTED_FOR_ROLE.SUCCESS` on role selection, tags `{ agentId, role, source, mode }`.
+    - `AGENT.RESOLVE.FAILED` on unresolvable role, tags `{ role, phase, source, mode }`.
+    - `AGENT.CREATED.SUCCESS`, `AGENT.VERSION_PUBLISHED.SUCCESS`, `AGENT.ARCHIVED.SUCCESS` for lifecycle.
+12. **Role validation**: `role` is validated against `RolePhaseMap.ValidRoles`; `phase` (when present) against `RolePhaseMap.IsRoleEligibleForPhase`. Unknown role/phase → 400, not a resolution attempt.
+13. **Rollback-to-prior-version resolution**: selecting an agent whose pinned/active version was rolled back (a prior version re-activated via `POST /versions` with `activate: prior`) resolves to the *currently active* version's config — proven by an integration test.
+14. **Unit + integration tests** cover: resolution precedence (all four AC-3 branches), the 403 paths (member create/version/archive/select; tenant mutating a public agent), cross-tenant private read (404), rollback-to-prior-version resolution, mode-parameterized principal selection, and the no-empty-fallback `AGENT.RESOLVE.FAILED` + `MISSING_CONFIG` path.
+15. **No regression**: existing `/api/v1/agents/config`, `/api/v1/agents/{role}/resolve`, `/api/v1/agents/resolve-for-phase` endpoints and the legacy `AgentResolverService.ResolveAsync` JSONB behaviour stay byte-for-byte working; the full `dotnet test` suite stays green; `dotnet ef migrations has-pending-model-changes` reports none after the new migration.
+
+## Technical Design
+
+### Architectural placement (per the Epic 32 design of record)
+
+Per `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md` §"Ownership, visibility & data scoping":
+
+- **Public (system) agent definitions** are shared → live in the **control plane** (`ControlPlaneDbContext`), referenced by `agent_id`. Managed by platform owner (`PlatformOwnerAccess`).
+- **Private (tenant) agent definitions** + **role selections** are tenant-owned → live in the tenant's `t_<hex>` schema (`TenantDbContext`). Managed by `tenant_owner`/`tenant_admin` (new `AgentManage` policy = `agents:manage` = admin+owner, mirroring `PromptManage`).
+- A tenant's usable set = **all public agents ∪ its own private agents**.
+
+Story 32-1 is assumed to have created the `Agent` + `AgentVersion` entities and their DbSets in both contexts (control-plane for public, tenant for private). This story (32-2) adds the **selection** entity, the registry/resolver services, the endpoints, the new policy, and the enrichment of `ResolvedAgentConfig`. Where a 32-1 entity field is referenced and not yet confirmed present, it is marked **(NEW — coordinate with 32-1)**.
+
+### Enriched `ResolvedAgentConfig` (modify existing)
+
+```csharp
+// Tamma.Api/Services/Agents/ResolvedAgentConfig.cs — ADDITIVE fields only
+public class ResolvedAgentConfig
+{
+    // ... all existing fields unchanged (Role, Handle, Provider, Model,
+    //     Temperature, MaxTokens, TokenBudget, Tools, SystemPrompt, Source,
+    //     Phase, MaxBudgetUsd, PermissionMode, AllowedTools) ...
+
+    /// <summary>Stable identity of the agent that produced this config (32-1).
+    /// Null only on the legacy JSONB path for backward compatibility.</summary>
+    public Guid? AgentId { get; init; }
+
+    /// <summary>Pinned config version of the resolved agent.</summary>
+    public int? AgentVersion { get; init; }
+
+    // NOTE: `Source` already exists as string ("platform-default" |
+    // "tenant-override"). Extend the documented value set to add
+    // "system-public" | "tenant-public" | "tenant-private". Legacy values
+    // remain valid for the JSONB path.
+}
+```
+
+### `agent_role_selections` entity (NEW)
+
+```csharp
+// Tamma.Data/Entities/AgentRoleSelection.cs
+public class AgentRoleSelection
+{
+    public Guid Id { get; set; }
+
+    /// <summary>SaaS: the tenant schema scopes this implicitly; column kept
+    /// for the single-user CP-resident path. Exactly one of TenantId/UserId
+    /// is non-null (principal XOR), mirroring prompt_overrides.</summary>
+    public Guid? TenantId { get; set; }
+    public Guid? UserId { get; set; }
+
+    /// <summary>One of RolePhaseMap.ValidRoles.</summary>
+    public string Role { get; set; } = null!;
+
+    /// <summary>The selected agent (public OR own private). FK is logical —
+    /// public agents live in the CP, so no DB FK across schemas; the
+    /// registry validates the target is in (public ∪ own private).</summary>
+    public Guid AgentId { get; set; }
+
+    /// <summary>Resolved provenance at selection time: tenant-private |
+    /// tenant-public | system-public. Recomputed on resolve, not trusted.</summary>
+    public string Visibility { get; set; } = null!;
+
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public Guid? UpdatedBy { get; set; }
+}
+```
+
+EF model config (in `TammaModelConfiguration.cs`, the single source) for the tenant context (SaaS) and the CP context (single-user user-keyed rows):
+
+```csharp
+b.ToTable("agent_role_selections");
+b.HasKey(x => x.Id);
+b.Property(x => x.Role).IsRequired();
+b.Property(x => x.AgentId).IsRequired();
+// principal XOR (mirrors prompt_overrides)
+b.ToTable(t => t.HasCheckConstraint(
+    "ck_agent_role_selections_principal_xor",
+    "((tenant_id IS NOT NULL AND user_id IS NULL) OR (tenant_id IS NULL AND user_id IS NOT NULL))"));
+b.HasIndex(x => new { x.TenantId, x.UserId, x.Role })
+    .IsUnique()
+    .AreNullsDistinct(false);   // UNIQUE NULLS NOT DISTINCT
+```
+
+### `IAgentRegistryService` (NEW)
+
+```csharp
+// Tamma.Api/Services/Agents/IAgentRegistryService.cs
+public interface IAgentRegistryService
+{
+    /// <summary>Public ∪ own-tenant private, filtered by role/visibility/status.</summary>
+    Task<IReadOnlyList<AgentSummary>> ListAsync(AgentListFilter filter, CancellationToken ct = default);
+
+    Task<AgentWithVersions?> GetWithVersionsAsync(Guid agentId, CancellationToken ct = default);
+
+    /// <summary>Create a PRIVATE agent in the caller's tenant. Public creation
+    /// goes through the platform-owner path (CreatePublicAsync) only.</summary>
+    Task<Agent> CreateAsync(CreateAgentRequest req, CancellationToken ct = default);
+
+    /// <summary>Publish a new pinned config version. `activate` controls whether
+    /// the new version becomes active or a prior version is re-activated
+    /// (rollback). Rejects cross-visibility writes (tenant→public ⇒ throw).</summary>
+    Task<AgentVersion> PublishVersionAsync(Guid agentId, PublishVersionRequest req, CancellationToken ct = default);
+
+    Task ArchiveAsync(Guid agentId, CancellationToken ct = default);
+
+    /// <summary>Persist which agent serves a role for the current principal.
+    /// Validates target ∈ (public ∪ own private). Emits
+    /// AGENT.SELECTED_FOR_ROLE.SUCCESS.</summary>
+    Task SelectForRoleAsync(string role, Guid agentId, CancellationToken ct = default);
+
+    Task<IReadOnlyDictionary<string, AgentRoleSelection>> GetRoleSelectionsAsync(CancellationToken ct = default);
+}
+```
+
+Authorization is enforced at the endpoint layer (policies) AND defensively in the service: `CreateAsync`/`PublishVersionAsync` reject `visibility == public` unless the caller is a platform owner; cross-tenant target ids resolve to `null`/404.
+
+### `IAgentResolverService` (extend existing)
+
+```csharp
+// Add to IAgentResolverService.cs
+/// <summary>
+/// Resolve the EFFECTIVE agent for a (principal, role) via the 32-2
+/// precedence chain (private selection → public selection → system-default
+/// public → AGENT.RESOLVE.FAILED). Returns an enriched ResolvedAgentConfig
+/// carrying AgentId/AgentVersion/Source. NEVER returns a blank config.
+/// </summary>
+Task<ResolvedAgentConfig> ResolveForRoleAsync(string role, CancellationToken ct = default);
+
+/// <summary>Same chain plus phase eligibility validation
+/// (RolePhaseMap.IsRoleEligibleForPhase).</summary>
+Task<ResolvedAgentConfig> ResolveForRoleAndPhaseAsync(string phase, string role, CancellationToken ct = default);
+```
+
+The implementation derives the principal from `ITammaModeProvider` + `ITenantContext`/`ClaimsPrincipal` (SaaS ⇒ `tenant_id`; single-user ⇒ `user_id`), reads the role selection, materialises the pinned `AgentVersion.Config` into a `ResolvedAgentConfig` (reusing the existing merge/validation in `AgentResolverService`), and stamps `AgentId`/`AgentVersion`/`Source`. On no-resolution it calls the fail-loud path (AC 9).
+
+### Resolution precedence (pseudocode)
+
+```csharp
+public async Task<ResolvedAgentConfig> ResolveForRoleAsync(string role, CancellationToken ct)
+{
+    if (!RolePhaseMap.ValidRoles.Contains(role))
+        throw new ArgumentException($"Unknown role '{role}'");
+
+    var principal = _principal.Resolve(); // (Mode, TenantId?, UserId?)
+
+    // 1 + 2: tenant/user-selected agent (private OR public target)
+    var selection = await _registry.GetRoleSelectionsAsync(ct);
+    if (selection.TryGetValue(role, out var sel))
+    {
+        var agent = await _registry.ResolveSelectedAgentAsync(sel.AgentId, ct); // public ∪ own private
+        if (agent is not null)
+            return Materialise(agent, role, source: SourceFor(agent)); // tenant-private | tenant-public
+    }
+
+    // 3: system-default public agent for the role
+    var systemDefault = await _registry.GetSystemDefaultPublicAsync(role, ct);
+    if (systemDefault is not null)
+        return Materialise(systemDefault, role, source: "system-public");
+
+    // 4: NO empty fallback — fail loud
+    await _events.AppendAsync(new DomainEvent {
+        Type = "AGENT.RESOLVE.FAILED",
+        Tags = Json(new { role, phase = (string?)null, source = "none", mode = principal.Mode }),
+        // tenant-scoped in SaaS; CP/platform feed in single-user
+    });
+    await _missingConfig.RecordAsync(new MissingConfigGap(
+        domain: "agent", configKey: $"role:{role}", scope: "system", ...), ct); // best-effort
+    throw new TammaError("AGENT.RESOLVE.NO_DEFAULT",
+        $"No agent resolvable for role '{role}'", severity: High,
+        context: new { role });
+}
+```
+
+> `IMissingConfigRecorder` is from the Missing-Config Notifications epic (`Tamma.Api/Services/MissingConfig/`). It is **(NEW — soft dependency)**: inject as optional (`IMissingConfigRecorder?`) so resolution works before that epic lands; the `AGENT.RESOLVE.FAILED` event + throw are mandatory regardless. If the recorder is absent, skip the gap record (the event still fires).
+
+### `AgentEndpoints.cs` (extend existing static class)
+
+```csharp
+public static async Task<IResult> List(IAgentRegistryService registry, ClaimsPrincipal user,
+    string? role, string? visibility, string? status) { ... } // 200 list
+
+public static async Task<IResult> Create(CreateAgentRequest req, IAgentRegistryService registry,
+    ITammaModeProvider mode, ClaimsPrincipal user)
+{
+    if (string.Equals(req.Visibility, "public", StringComparison.OrdinalIgnoreCase)
+        && !user.IsPlatformOwner())
+        return Results.Json(new { error = "agent_public_write_forbidden" }, statusCode: 403);
+    var agent = await registry.CreateAsync(req);
+    return Results.Created($"/api/agents/{agent.Id}", AgentResponse.From(agent));
+}
+
+public static async Task<IResult> PublishVersion(Guid id, PublishVersionRequest req, ...) { ... }
+public static async Task<IResult> Archive(Guid id, ...) { ... }
+public static async Task<IResult> SelectForRole(string role, SelectRoleRequest req, ...) { ... }
+public static async Task<IResult> Resolve(string role, string? phase,
+    IAgentResolverService resolver) // 200 ResolvedAgentConfig | 400 bad role | maps TammaError → 404/409
+{ ... }
+```
+
+### Program.cs wiring
+
+New policy mirroring `PromptManage`:
+
+```csharp
+options.AddPolicy("AgentManage", p =>
+{
+    p.AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme, "ApiKey");
+    p.AddRequirements(new PermissionRequirement("agents:manage")); // admin+owner
+});
+```
+
+Add `["agents:manage"] = ["admin", "owner"]` to `Permissions.Matrix` (mirrors `prompts:manage`). Register `IAgentRegistryService` (Scoped). Map the new routes:
+
+```csharp
+var agentsV2 = app.MapGroup("/api/agents")
+    .RequireAuthorization("MemberAccess")        // reads allowed for any member
+    .RequireRateLimiting("ConfigRead");
+agentsV2.MapGet("/", AgentEndpoints.List);
+agentsV2.MapGet("/{id:guid}", AgentEndpoints.GetOne);
+agentsV2.MapGet("/resolve", AgentEndpoints.Resolve);
+agentsV2.MapPost("/", AgentEndpoints.Create)
+    .RequireAuthorization("AgentManage").RequireRateLimiting("ConfigWrite");
+agentsV2.MapPost("/{id:guid}/versions", AgentEndpoints.PublishVersion)
+    .RequireAuthorization("AgentManage").RequireRateLimiting("ConfigWrite");
+agentsV2.MapPost("/{id:guid}/archive", AgentEndpoints.Archive)
+    .RequireAuthorization("AgentManage").RequireRateLimiting("ConfigWrite");
+agentsV2.MapPut("/role-selections/{role}", AgentEndpoints.SelectForRole)
+    .RequireAuthorization("AgentManage").RequireRateLimiting("ConfigWrite");
+```
+
+> Public-agent mutation is gated *inside* the handler via `IsPlatformOwner()` (a tenant with `AgentManage` reaches the handler but is rejected 403 when `visibility == public`) — the same belt-and-suspenders pattern the convention store uses (system-default routes use `PlatformOwnerAccess`; tenant routes use `ConventionManage`). For clarity, dedicated public-agent admin routes MAY be added under `/api/admin/agents` with `PlatformOwnerAccess`; the in-handler check is the authoritative gate.
+
+### EF migrations
+
+Two additive migrations (collapsed-baseline discipline — additive table, not a CHECK edit on the baseline):
+
+```bash
+# Tenant context — agent_role_selections (SaaS path) + any private-agent FK indexes
+dotnet ef migrations add AddAgentRoleSelections \
+  --context TenantDbContext --output-dir Migrations/Tenant
+
+# Control-plane context — user-keyed agent_role_selections (single-user path)
+dotnet ef migrations add AddAgentRoleSelectionsCp \
+  --context ControlPlaneDbContext --output-dir Migrations/ControlPlane
+
+# Verify clean
+dotnet ef migrations has-pending-model-changes --context TenantDbContext   # → none
+dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext # → none
+```
+
+> If Story 32-1 already added the `Agent`/`AgentVersion` tables to both contexts, this story only adds `agent_role_selections`. Coordinate the migration ordering with 32-1 so the baselines don't collide.
+
+### DCB events
+
+| Event | Tags | When |
+|---|---|---|
+| `AGENT.SELECTED_FOR_ROLE.SUCCESS` | `{ agentId, role, source, mode }` | role selection upsert |
+| `AGENT.CREATED.SUCCESS` | `{ agentId, visibility, mode }` | private/public agent created |
+| `AGENT.VERSION_PUBLISHED.SUCCESS` | `{ agentId, version, activated, mode }` | new pinned version |
+| `AGENT.ARCHIVED.SUCCESS` | `{ agentId, mode }` | archive |
+| `AGENT.RESOLVE.FAILED` | `{ role, phase, source, mode }` | no agent resolvable |
+
+All appended via `IEventRepository.AppendAsync`. Tenant-scope events carry the ambient `TenantId` (tenant store); single-user/platform-scope events resolve through the platform-events path (`TenantId == null`).
+
+### Per-mode / per-tenant ownership (mandatory two-scoping-model answer)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Who owns a **private** agent? | The sole user (`user_id`-keyed; `tenant_id` NULL). | The tenant (`tenant_id`; lives in `t_<hex>`). `tenant_owner`/`tenant_admin` edit; `member` read-only. |
+| Who owns a **public** agent? | Shipped system agents (read-only to the user; the user creates their own private ones). | Platform owner (`PlatformOwnerAccess`); control-plane resident; every tenant may *use* but not edit. |
+| Who selects which agent serves a role? | The user. | `tenant_owner`/`tenant_admin`; `member` → 403. |
+| Resolution principal | `user_id` (CP-resident selection row). | `tenant_id` (tenant-schema selection row). |
+| Mode source | `ITammaModeProvider` (process-stable). | same |
+
+## Dependencies
+
+- **Prerequisite**: Story 32-1 (Agent entity model & versioned saved config) — establishes `Agent` + `AgentVersion` entities and DbSets in the control-plane (public) and tenant (private) contexts. 32-2 layers registry/resolution/RBAC over them.
+- **Soft dependency**: Missing-Config Notifications epic (`IMissingConfigRecorder`) — injected optionally; the `MISSING_CONFIG` gap record on `AGENT.RESOLVE.FAILED` degrades gracefully if absent.
+- **Reuses**: `AgentResolverService` (legacy JSONB merge), `RolePhaseMap` (role/phase taxonomy), `IEventRepository`, `ITenantContext`, `ITammaModeProvider`, `ClaimsPrincipalExtensions`, the `PromptManage`/`ConventionManage` RBAC precedent, `PlatformOwnerAccess` policy.
+- **Blocks**: Story 32-5 (managed execution resolves an `IManagedAgent` from this resolver), Story 32-6 (action trail tags `agent_id` from the resolved config), Story 32-7 (panels resolve N agents per role).
+- **Related**: Epic 27 (Prompt Store — the RBAC + per-mode model this mirrors), Epic 28 (schema-per-tenant — structural isolation of private agents/selections).
+
+## Testing Strategy
+
+Tests are xUnit under `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/`. Docker-bound suites run via `sg docker -c "dotnet test ..."` (see `reference_dotnet_test_docker`). TDD: write the failing test first.
+
+1. **Resolution precedence** (`AgentResolverServiceTests`): for each AC-3 branch — (a) tenant-selected private wins over everything; (b) tenant-selected public wins over system default; (c) no selection ⇒ system-default public; (d) no system default ⇒ `AGENT.RESOLVE.FAILED` + `TammaError("AGENT.RESOLVE.NO_DEFAULT")` and **no** blank config returned.
+2. **Mode-parameterized principal** (`[Theory]` over `TammaMode.SingleUser`/`SaaS`): same precedence, principal sourced from `user_id` vs `tenant_id`; selection rows read from the correct context.
+3. **RBAC matrix** (`AgentEndpointsTests`, in-process `WebApplicationFactory`): member create/version/archive/select → 403; tenant_owner/tenant_admin private create/version/archive → 200; tenant `POST /api/agents {visibility:public}` → 403 `agent_public_write_forbidden`; tenant `POST /{publicId}/versions` → 403; platform owner public create → 201.
+4. **Cross-tenant isolation** (`AgentRegistryIsolationTests`, real per-tenant `TenantDbContext`): tenant A `GET /api/agents/{B-private-id}` → 404; `GET /api/agents` from A never returns B's private rows; A cannot `PUT role-selections/{role}` targeting B's private agent (404).
+5. **Rollback-to-prior-version** (`AgentResolverServiceTests`): publish v2, then re-activate v1 via `POST /versions {activate:"prior"}`; resolve returns v1's config and `AgentVersion == 1`.
+6. **DCB events** (`AgentEventsTests`): selection appends exactly one `AGENT.SELECTED_FOR_ROLE.SUCCESS` with `{agentId, role, source}`; unresolvable role appends exactly one `AGENT.RESOLVE.FAILED`; lifecycle ops append create/version/archive events.
+7. **No regression**: existing `AgentEndpointsTests` for `/api/v1/agents/config|resolve|resolve-for-phase` and `AgentResolverService.ResolveAsync` JSONB tests stay green; `has-pending-model-changes` → none.
+8. **Tenant-isolation invariant**: a dedicated test seeds two tenants with the *same* public agent selected for a role and asserts each resolves independently with its own selection rows — no bleed.
+
+## Estimated Effort
+
+4-5 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/IAgentRegistryService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRegistryService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentResolverService.cs` | Modify (add `ResolveForRoleAsync` / `ResolveForRoleAndPhaseAsync` precedence chain) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/IAgentResolverService.cs` | Modify (declare new resolve methods) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ResolvedAgentConfig.cs` | Modify (add `AgentId`, `AgentVersion`; extend `Source` value set) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentEventTypes.cs` | Create (DCB event-type constants) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs` | Modify (add List/GetOne/Create/PublishVersion/Archive/SelectForRole/Resolve handlers) |
+| `apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/` (AgentResponse, CreateAgentRequest, PublishVersionRequest, SelectRoleRequest, AgentListFilter, AgentSummary, AgentWithVersions) | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Auth/Permissions.cs` | Modify (add `agents:manage`) |
+| `apps/tamma-elsa/src/Tamma.Api/Auth/ClaimsPrincipalExtensions.cs` | Modify (add `IsPlatformOwner()` helper if not present) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (`AgentManage` policy, DI registration, `/api/agents` route group) |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/AgentRoleSelection.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (entity config: XOR check, unique-nulls-not-distinct index) |
+| `apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs` | Modify (DbSet) |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (DbSet, single-user path) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/*_AddAgentRoleSelections.cs` | Create (generated) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/*_AddAgentRoleSelectionsCp.cs` | Create (generated) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentRegistryServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentResolverServiceTests.cs` | Create/Modify |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentEndpointsTests.cs` | Create/Modify |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentRegistryIsolationTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentEventsTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` directory for related spikes, bugs, findings, and decisions (esp. `feedback_resolution_no_empty_fallback`, `story-28-1-design-calls.md`)
+3. Confirmed which `Agent`/`AgentVersion` fields Story 32-1 actually shipped — every **(NEW — coordinate with 32-1)** marker must be reconciled before coding
+4. Reviewed the Prompt Store RBAC precedent (`PromptEndpoints.cs`, `PromptManage` policy) — this story mirrors it
+5. Planned TDD approach (Red-Green-Refactor cycle)
+
+### Key design decisions
+
+- **Public in CP, private in tenant schema** — isolation is structural, not a WHERE clause. Do not store private agents in the control plane "for convenience"; that breaks the Epic 28 tenancy guarantee and the design of record.
+- **404 over 403 for cross-tenant private reads** — returning 403 would leak the existence of another tenant's agent. The registry scopes reads to (public CP rows ∪ ambient-tenant private rows); anything else is simply not found.
+- **No empty/plain fallback, ever** — this is the load-bearing project rule (`feedback_resolution_no_empty_fallback`). The fourth precedence branch is a hard `TammaError`, mirroring `PromptStoreService.NoPromptError` and `ConventionStore.NoConventionError`. The `AGENT.RESOLVE.FAILED` event fires even if the missing-config recorder is absent.
+- **Selection points at an id, provenance is recomputed** — the stored `Visibility` on a selection is a hint; `ResolveForRoleAsync` recomputes whether the target is still in (public ∪ own private) at resolve time so a deleted/archived target degrades to the system default rather than resolving stale.
+- **Legacy JSONB path preserved** — `AgentResolverService.ResolveAsync(tenantId, role)` and the `/api/v1/agents/*` routes are untouched; the new `/api/agents/*` group is the entity-aware surface. `CallLlmActivity` consumes the same `ResolvedAgentConfig` shape, so enrichment is additive.
+- **In-handler public-write gate** — mirrors the convention store: tenant-reach policy (`AgentManage`) on the route, platform-owner check inside for `visibility == public`. Keeps one route group instead of duplicating per visibility.
+
+### Open coordination items with Story 32-1
+
+- Exact `Agent` entity shape (does it carry `Visibility`, `Status`, `Name`, `Role`, default-selection flag?) and whether system-default-per-role public agents are marked via a column or a CP `agent_default_selections` table. If 32-1 ships a system-default marker, AC 3.3 reads it directly; if not, 32-2 adds an `agent_default_selections` CP table.
+- Whether `AgentVersion` carries an `IsActive` flag (needed for rollback AC 13) or active-version is a pointer on `Agent`.
+
+## Logging Requirements
+
+- **INFO**: agent created / version published / archived (agentId, visibility, version), role selection upserted (role, agentId, source), resolution succeeded (role, phase, agentId, version, source).
+- **DEBUG**: resolution precedence branch taken (which of the 4), selection lookup hit/miss, materialise duration.
+- **WARN**: selection target no longer in (public ∪ own private) ⇒ degrading to system default (role, staleAgentId); cross-tenant access attempt (caller tenant, target id) → 404.
+- **ERROR**: `AGENT.RESOLVE.FAILED` — no agent resolvable for a taxonomy-valid role (role, phase, mode); migration / DB write failure.
+- **Structured context**: include `{ agentId, role, phase, source, mode, tenantId }` where applicable.
+- **Credential safety**: agent configs are credential-agnostic (provider+model+settings, never keys); never log resolved provider credentials — those resolve later in 32-3 from the secret cabinet.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-32/story-32-3/32-3-per-tenant-provider-credential-resolution.md
+++ b/docs/stories/epic-32/story-32-3/32-3-per-tenant-provider-credential-resolution.md
@@ -1,0 +1,443 @@
+# Story 32-3: Per-Tenant Provider Credential Resolution (BYOK → platform)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../BEFORE_YOU_CODE.md)
+
+> **Boundary note (canonical ownership):** This story is the **canonical owner of BYOK provider-key
+> resolution** from the Epic 29 secret cabinet into the LLM call path. Epics 34 (pricing/markup) and
+> 35 (billing) **consume** the `credentialSource` (`byok | platform`) this story emits; they MUST NOT
+> re-wire provider keys. All "where does the provider API key come from at execution time?" logic
+> lives behind the single `IProviderCredentialResolver` seam introduced here.
+
+## User Story
+
+As a **SaaS tenant administrator (and, in single-user mode, the self-hosted operator)**,
+I want each LLM call to use **my own provider API key (BYOK) when I have configured one**, and to
+fall back to the platform-provided key only when I have not — with the call **denied loudly** rather
+than silently using the wrong key when neither is allowed,
+So that my LLM usage hits **my** provider account and budget where I want it, cost/performance is
+genuinely attributed per-tenant for benchmarking (Epic 32) and pricing (Epics 34/35), and a missing
+key never leaks across tenants or degrades into a wrong-account charge.
+
+## Priority
+
+P0 — Closes the global-env API-key gap. Without it, every tenant's LLM call uses the single
+platform `Anthropic:ApiKey` / `OpenAI:ApiKey`, so cost attribution, BYOK, and per-tenant budgets
+(Epic 32 §"Provider credential & auth model", Risk "Global provider keys today") are all impossible.
+Blocks 32-5 (managed agent execution), 32-9 (usage/cost emission), 34/35 (pricing/billing branch on
+`credentialSource`).
+
+## Acceptance Criteria
+
+1. A new `IProviderCredentialResolver` resolves `(tenantId?, providerName)` →
+   `ProviderCredential { ApiKey, Source ∈ {Byok, Platform}, SecretRef?, VersionNumber? }` by first
+   querying the Epic 29 cabinet for a **Tenant-scoped `ApiKey` secret named by provider**
+   (`SecretRef.ForTenant(tenantId, "provider/<name>/api-key")`, `SecretScope.Tenant`,
+   `SecretPurpose.ApiKey`) and only when absent falling back to the platform-provided key.
+2. The platform fallback key is read through the **existing cabinet runtime path**
+   (`IRuntimeSecretResolver.GetAsync("<provider>/api-key")`, e.g. `StopgapSecretMap.PlatformAnthropicApiKey`)
+   — NOT a fresh `_configuration["Anthropic:ApiKey"]` read — so the env-var fallback removal of
+   Story 29-10 applies uniformly and there is one platform-key source of truth.
+3. `CallLlmInlineActivity` **stops reading `_configuration["<Provider>:ApiKey"]` directly** in
+   `LoadProviderConfig`; the activity instead receives the workflow's tenant context (new
+   `TenantIdProp` input, threaded from `LlmCallWorkflow`'s existing `TenantId` variable) and resolves
+   the key via `IProviderCredentialResolver`. `LlmProviderConfig.ApiKey` is populated from the
+   resolved credential; `BaseUrl` / `DefaultModel` / `TimeoutSeconds` keep their current config
+   source.
+4. The resolved **credential source** (`byok | platform`) is propagated into the call result
+   (`ProviderAttemptDiagnostic.CredentialSource`) and surfaced to the diagnostics / action-trail
+   layer as a tag (`credentialSource`) so metering/pricing (32-9, 34, 35) and benchmarking (32-10)
+   can branch on it — never the key itself.
+5. Tenant BYOK keys are **written and read only through the secret cabinet** (create uses the
+   reveal-once UX of Story 29-3; runtime read uses `ISecretStoreBackend.GetVersionPlaintextAsync` on
+   the active version, mirroring `RuntimeSecretResolver`). Raw keys **never** appear in DCB events,
+   diagnostics, action-trail tags, exceptions, or logs — proven by a dedicated redaction test that
+   feeds a known sentinel key through the full resolve→call→event path and asserts the sentinel is
+   absent from every emitted artifact.
+6. **Fail-closed (SaaS):** when mode is SaaS and **no tenant BYOK key exists** and **platform
+   fallback is disabled for that provider/plan**, the call returns a typed
+   `TammaError("PROVIDER_CREDENTIAL_UNAVAILABLE", …, retryable: false, severity: High)` and emits
+   `AGENT.CREDENTIAL.DENIED` — it does NOT silently use a wrong/empty key. **Single-user** mode falls
+   back to the local platform/env credential (its sole user owns everything).
+6.1. Whether platform fallback is allowed is decided by a `IPlatformFallbackPolicy` seam
+   (`IsPlatformFallbackAllowed(tenantId, providerName)`). v1 default: single-user ⇒ always allowed;
+   SaaS ⇒ allowed unless explicitly disabled by config (`Providers:PlatformFallbackDisabled` set, or
+   per-provider override). The plan-level / per-provider gating that Epics 34/35 will drive plugs in
+   here without changing the resolver.
+7. A **tenant-admin BYOK management API** registers / rotates / removes a tenant provider key,
+   delegating to the cabinet (create → reveal-once; rotate → `ISecretStore.RotateAsync`; remove →
+   retire), RBAC-gated to `tenant_owner` / `tenant_admin` (member → 403; cross-tenant → 404), mounted
+   on `AgentEndpoints` (or a new `ProviderCredentialEndpoints`) at
+   `POST/DELETE /api/v1/agents/providers/{provider}/credential` and `POST …/rotate`.
+8. DCB events are emitted via `IEventRepository.AppendAsync`: `AGENT.CREDENTIAL_RESOLVED.SUCCESS`
+   (tags: `tenantId`, `provider`, `source`, `secretRef` storage-key, `mode`; **no secret in `Data`**)
+   on every successful resolve, and `AGENT.CREDENTIAL.DENIED` (tags: `tenantId`, `provider`, `reason`,
+   `mode`) on fail-closed. Event `Type` follows the `AGGREGATE.ACTION.STATUS` convention.
+9. **Cache + rotation:** resolved BYOK plaintext is cached in-process with a short TTL (default 60s,
+   matching `RuntimeSecretResolver.DefaultCacheTtl`), keyed by `(tenantId, provider)`. A BYOK
+   register/rotate/remove (AC7) **invalidates** the affected cache entry immediately, and a
+   `SECRET.ROTATE.ACTIVATED` event for a matching cabinet ref invalidates it too — so the next call
+   resolves the new version. A rotation test asserts the resolver returns the new key after
+   invalidation, not the stale cached one.
+10. **Per-mode ownership** is explicit (two-scoping-model rule, CLAUDE.md "Operating Modes"):
+    single-user resolves with `tenantId == null` → platform/local credential; SaaS resolves with the
+    workflow's `tenantId` → BYOK-then-platform. The resolver never reads a `user_id`-keyed credential
+    (BYOK is tenant-scoped only, mirroring the Prompt Store's "no per-user override in SaaS").
+11. **Tenant isolation:** the resolver only ever reads `SecretScope.Tenant` rows for the **caller's**
+    `tenantId`; an isolation test proves tenant A's resolve never returns tenant B's BYOK key, and a
+    tenant with no BYOK key gets the platform key (never another tenant's).
+12. Backward compatibility: when no BYOK key and platform fallback allowed (single-user, or SaaS with
+    fallback enabled), behaviour is **byte-identical** to today's platform-key call path; existing
+    `CallLlmInlineActivity` single-turn and tool-loop tests continue to pass with the platform source.
+13. Unit tests cover: BYOK-present → tenant key + `source=byok`; BYOK-absent → platform key +
+    `source=platform`; both-absent in SaaS → `PROVIDER_CREDENTIAL_UNAVAILABLE` + `AGENT.CREDENTIAL.DENIED`;
+    secret redaction (AC5); rotation invalidates cache (AC9); tenant isolation (AC11); single-user
+    fallback (AC6); RBAC matrix on the management API (AC7).
+
+## Technical Design
+
+### The gap today (verified 2026-06-17)
+
+`apps/tamma-elsa/src/Tamma.Activities/LlmCall/CallLlmInlineActivity.cs` → `LoadProviderConfig`
+(lines ~1398–1443) reads provider keys **directly from process config**, tenant-agnostic:
+
+```csharp
+// CURRENT — the global-env-key gap (CallLlmInlineActivity.LoadProviderConfig)
+"anthropic" => new LlmProviderConfig {
+    ApiKey = _configuration?["Anthropic:ApiKey"] ?? "",   // ← one key for ALL tenants
+    ...
+},
+"openai" => new LlmProviderConfig {
+    ApiKey = _configuration?["OpenAI:ApiKey"] ?? "",       // ← same problem
+    ...
+},
+```
+
+`LlmCallWorkflow` already threads a `TenantId` string variable into other activities
+(`apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/LlmCallWorkflow.cs` lines ~70, 153, 208, 276 —
+`tenantIdVar.Set(context, context.GetInput<string>("tenantId") ?? "")`), but **CallLlmInlineActivity
+does not receive it**. Wiring that variable into a new `TenantIdProp` input is the integration seam.
+
+### New seam: `IProviderCredentialResolver`
+
+Lives in `apps/tamma-elsa/src/Tamma.Api/Services/Providers/` next to `ProviderChainResolver`.
+
+```csharp
+namespace Tamma.Api.Services.Providers;
+
+public enum CredentialSource { Byok, Platform }
+
+/// <summary>
+/// Resolved provider credential. ApiKey is plaintext for the immediate HTTP call ONLY —
+/// it is never serialized into events, diagnostics, or logs (see redaction test, AC5).
+/// </summary>
+public sealed record ProviderCredential(
+    string ApiKey,
+    CredentialSource Source,
+    string? SecretRefStorageKey,   // e.g. "tenant:<guid>:provider/anthropic/api-key" — safe to log/tag
+    int? VersionNumber)
+{
+    /// <summary>Tag-safe projection (NEVER includes ApiKey) for diagnostics/DCB events.</summary>
+    public object ToTag() => new { source = Source.ToString().ToLowerInvariant(),
+                                   secretRef = SecretRefStorageKey, version = VersionNumber };
+}
+
+public interface IProviderCredentialResolver
+{
+    /// <summary>
+    /// Resolve the API key for (tenant, provider). tenantId == null ⇒ single-user / platform scope.
+    /// Order: tenant BYOK cabinet key → platform-provided key. Fail-closed in SaaS when neither
+    /// is available/allowed (throws TammaError "PROVIDER_CREDENTIAL_UNAVAILABLE" + emits DENIED).
+    /// </summary>
+    Task<ProviderCredential> ResolveAsync(
+        Guid? tenantId, string providerName, CancellationToken ct = default);
+
+    /// <summary>Invalidate the cached BYOK entry for (tenant, provider). Called on register/rotate/remove.</summary>
+    void Invalidate(Guid? tenantId, string providerName);
+}
+```
+
+### Resolution algorithm (`DefaultProviderCredentialResolver`)
+
+```csharp
+public async Task<ProviderCredential> ResolveAsync(Guid? tenantId, string providerName, CancellationToken ct)
+{
+    var provider = NormalizeProvider(providerName);            // lower-invariant, allowlist-checked
+
+    // 1) BYOK — only in SaaS / when a tenant is present.
+    if (tenantId is { } tid)
+    {
+        if (_cache.TryGet((tid, provider), out var cached) && !cached.Expired)
+            return EmitResolved(tid, provider, cached.Credential, ct);
+
+        var byokRef = SecretRef.ForTenant(tid, ByokName(provider));      // "provider/anthropic/api-key"
+        var meta = await _secretStore.GetAsync(byokRef, ct);
+        if (meta is { ActiveVersionNumber: > 0 })
+        {
+            // Plaintext via backend, NOT ISecretStore (which never surfaces plaintext) — mirrors RuntimeSecretResolver.
+            var plaintext = await _backend.GetVersionPlaintextAsync(meta.Id, meta.ActiveVersionNumber, ct);
+            if (!string.IsNullOrWhiteSpace(plaintext))
+            {
+                var cred = new ProviderCredential(plaintext, CredentialSource.Byok,
+                                                  byokRef.ToStorageKey(), meta.ActiveVersionNumber);
+                _cache.Set((tid, provider), cred, _cacheTtl);
+                return await EmitResolved(tid, provider, cred, ct);
+            }
+        }
+    }
+
+    // 2) Platform fallback — gated.
+    if (_fallbackPolicy.IsPlatformFallbackAllowed(tenantId, provider))
+    {
+        var platformKey = await _runtimeSecrets.GetAsync(PlatformCabinetName(provider), ct); // cabinet → (29-9 window) config
+        if (!string.IsNullOrWhiteSpace(platformKey))
+        {
+            var cred = new ProviderCredential(platformKey, CredentialSource.Platform,
+                                              $"platform:{PlatformCabinetName(provider)}", null);
+            return await EmitResolved(tenantId, provider, cred, ct);
+        }
+    }
+
+    // 3) Fail-closed (SaaS). Single-user reaches here only if even the platform key is unset → still loud.
+    await EmitDenied(tenantId, provider, reason: "no_byok_and_platform_unavailable", ct);
+    throw new TammaError(
+        "PROVIDER_CREDENTIAL_UNAVAILABLE",
+        $"No usable credential for provider '{provider}'" +
+        (tenantId is null ? " (platform key unset)." : " (no tenant BYOK key and platform fallback unavailable)."),
+        new Dictionary<string, object?> { ["tenantId"] = tenantId, ["provider"] = provider },
+        retryable: false, severity: TammaErrorSeverity.High);
+}
+```
+
+- **Provider → cabinet name map** (constants, no string drift): `anthropic` → BYOK
+  `provider/anthropic/api-key`, platform `StopgapSecretMap.PlatformAnthropicApiKey` (`"anthropic/api-key"`);
+  `openai` → BYOK `provider/openai/api-key`, platform `"openai/api-key"`; `openrouter` similar. Map
+  lives in a `ProviderCabinetNames` static so AC1/AC2 names cannot drift from the management API.
+- **Plaintext read path is the cabinet backend** (`ISecretStoreBackend.GetVersionPlaintextAsync`),
+  exactly as `RuntimeSecretResolver.TryReadCabinetAsync` does — `ISecretStore` deliberately never
+  returns plaintext through its public surface (see `ISecretStore.cs` "Plaintext rule").
+
+### Cache + rotation (AC9)
+
+In-process `ConcurrentDictionary<(Guid,string), CacheEntry>`, TTL default
+`RuntimeSecretResolver.DefaultCacheTtl` (60s). `Invalidate((tenant,provider))` removes the entry and
+is called by the management API on register/rotate/remove. A lightweight handler subscribes to
+`SECRET.ROTATE.ACTIVATED` (the same event `RuntimeSecretResolver` documents for invalidation) and, if
+the rotated `SecretRef` matches a `provider/*/api-key` tenant ref, evicts `(tenantId, provider)`.
+
+### Wiring into `CallLlmInlineActivity`
+
+```csharp
+// New input, set from LlmCallWorkflow's existing TenantId variable.
+[Input(Description = "Tenant id (GUID string) for BYOK credential resolution; empty = single-user/platform")]
+public Input<string?> TenantIdProp { get; set; } = default!;
+
+// New ctor dependency (null-tolerant for [JsonConstructor] + existing tests).
+private readonly IProviderCredentialResolver? _credentialResolver;
+```
+
+`LoadProviderConfig` no longer sets `ApiKey`; a new async step resolves it just before the HTTP call:
+
+```csharp
+private async Task<LlmProviderConfig> LoadProviderConfigWithKeyAsync(
+    string providerName, Guid? tenantId, ActivityExecutionContext ctx)
+{
+    var cfg = LoadProviderConfig(providerName);  // BaseUrl / DefaultModel / TimeoutSeconds only
+    if (_credentialResolver is not null)
+    {
+        var cred = await _credentialResolver.ResolveAsync(tenantId, providerName, ctx.CancellationToken);
+        cfg.ApiKey = cred.ApiKey;                 // plaintext used immediately, never stored
+        ctx.SetVariable("CredentialSource", cred.Source.ToString().ToLowerInvariant()); // → diagnostic tag
+    }
+    return cfg;
+}
+```
+
+- Tenant id parsed from `TenantIdProp` (empty/whitespace → `null` → single-user/platform).
+- `ProviderAttemptDiagnostic` gains `string? CredentialSource` (already serialized into
+  `LastDiagnostic`; the diagnostics/action-trail layer reads it as the `credentialSource` tag).
+- `PROVIDER_CREDENTIAL_UNAVAILABLE` from the resolver is caught in the existing per-attempt
+  try/catch so the provider chain can advance to the next provider; if the **whole chain** yields no
+  usable credential, the last failure surfaces (fail-closed, no silent success).
+- `LlmCallWorkflow`: set `TenantId = new Input<string>(ctx => tenantIdVar.Get(ctx))` on the
+  `CallLlmInlineActivity` step (same pattern as the prompt/convention activities at lines 208, 276).
+
+### BYOK management API (AC7)
+
+```
+POST   /api/v1/agents/providers/{provider}/credential   body { apiKey } → 201 (reveal-once token via 29-3)
+POST   /api/v1/agents/providers/{provider}/credential/rotate  body { apiKey } → 200
+DELETE /api/v1/agents/providers/{provider}/credential   → 204 (retire active version)
+GET    /api/v1/agents/providers                          → list configured BYOK providers (metadata only, NO key)
+```
+
+- RBAC: `tenant_owner` / `tenant_admin` only (member → 403; cross-tenant → 404) — mirrors Prompt
+  Store and `AgentEndpoints.UpdateConfig` tenant-context guard.
+- Create → `ISecretStore.CreateAsync(new CreateSecretRequest { Scope = Tenant, TenantId = tid,
+  Name = ProviderCabinetNames.Byok(provider), Purpose = ApiKey, InitialPlaintext = apiKey })`; rotate
+  → `RotateAsync`; delete → retire active version. Every mutation calls `resolver.Invalidate` and is
+  recorded via the cabinet's existing audit pipeline; the endpoint emits no raw key.
+
+### Events (AC8)
+
+```csharp
+await _events.AppendAsync(new DomainEvent {
+    Id = Guid.NewGuid(),
+    Type = "AGENT.CREDENTIAL_RESOLVED.SUCCESS",
+    TenantId = tenantId,
+    Tags = JsonSerializer.Serialize(new {
+        tenantId = tenantId?.ToString(), provider, source = cred.Source.ToString().ToLowerInvariant(),
+        secretRef = cred.SecretRefStorageKey, mode = _mode.Mode.ToString() }),
+    Metadata = JsonSerializer.Serialize(new { workflowVersion = "1.0.0", eventSource = "system" }),
+    Data = JsonSerializer.Serialize(new { version = cred.VersionNumber }),  // NEVER cred.ApiKey
+    CreatedAt = DateTime.UtcNow,
+});
+// AGENT.CREDENTIAL.DENIED on fail-closed: Tags { tenantId, provider, reason, mode }, Data {}.
+```
+
+## Dependencies
+
+- **Prerequisite (hard): Epic 29 (secret cabinet)** — `ISecretStore`, `ISecretStoreBackend`,
+  `SecretRef.ForTenant`, `SecretScope.Tenant`, `SecretPurpose.ApiKey`, `IRuntimeSecretResolver`
+  (platform key path + cache/invalidate prior art), reveal-once create (Story 29-3), and the
+  `SECRET.ROTATE.ACTIVATED` invalidation signal (Story 29-7).
+- **Prerequisite: 32-1** — agent entity model (provider attribute / config that names the provider
+  chain whose keys this story resolves).
+- **Blocks: 32-4** (SaaS auth gating builds on the resolver), **32-5** (managed agent execution
+  consumes resolved credentials), **32-9** (usage/cost emission tags by `credentialSource`),
+  **Epic 34/35** (pricing/billing branch on `byok | platform`).
+- **Related:** `ProviderChainResolver` (chooses *which* provider; this story resolves *its key*);
+  `ITammaModeProvider` (`TammaMode.cs`) for single-user vs SaaS branch.
+
+## Testing Strategy
+
+1. **Resolver unit tests** (`tests/Tamma.Api.Tests/Providers/ProviderCredentialResolverTests.cs`,
+   in-memory `ISecretStoreBackend` + fake `IRuntimeSecretResolver`):
+   - BYOK present → returns tenant plaintext, `source=byok`, correct `SecretRefStorageKey` + version.
+   - BYOK absent, platform present, fallback allowed → `source=platform`.
+   - SaaS + BYOK absent + fallback disabled → throws `PROVIDER_CREDENTIAL_UNAVAILABLE`, emits
+     `AGENT.CREDENTIAL.DENIED`, emits NO `RESOLVED.SUCCESS`.
+   - Single-user (`tenantId=null`) + platform present → `source=platform` (never throws while key set).
+   - Single-user + platform unset → still throws loud (no empty key).
+2. **Tenant isolation** (AC11): seed BYOK for tenant A only; resolve as A → A's key; resolve as B →
+   platform key (or denied), **never A's key**.
+3. **Redaction** (AC5): seed a sentinel BYOK key (`SENTINEL-BYOK-XYZ`); run resolve → full
+   `CallLlmInlineActivity` (mocked HTTP) → assert the sentinel appears in the outbound `x-api-key` /
+   `Authorization` header ONLY, and is **absent** from every `DomainEvent` (`Tags`/`Data`),
+   `ProviderAttemptDiagnostic`, exception message, and captured log line.
+4. **Rotation / cache** (AC9): resolve (caches v1) → rotate BYOK → assert resolver returns v2 after
+   `Invalidate` / `SECRET.ROTATE.ACTIVATED`; assert stale v1 not returned; assert TTL expiry also
+   re-reads.
+5. **Activity integration** (`tests/Tamma.Activities.Tests/LlmCall/`): `CallLlmInlineActivity` with
+   `TenantIdProp` set resolves BYOK and sends it; with empty tenant resolves platform; existing
+   single-turn + tool-loop tests still green with `source=platform` (AC12 backward-compat).
+6. **Management API RBAC** (`tests/Tamma.Api.Tests/Agents/ProviderCredentialEndpointsTests.cs`):
+   tenant_owner/admin can create/rotate/delete; member → 403; cross-tenant → 404; response bodies
+   never contain the raw key; create→list shows metadata only; mutations invalidate the cache.
+7. **Edge cases:** unknown/non-allowlisted provider; whitespace key rejected on create; cabinet probe
+   throws → resolver does not leak, treats as BYOK-absent and proceeds to fallback (logs WARN).
+
+## Estimated Effort
+
+3–4 days (resolver + cache/invalidation ~1.5d; activity wiring + workflow input + diagnostics ~1d;
+management API + RBAC ~0.75d; tests incl. redaction/isolation/rotation ~0.75d).
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Services/Providers/IProviderCredentialResolver.cs` | Create (NEW — seam + `ProviderCredential`/`CredentialSource`) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Providers/DefaultProviderCredentialResolver.cs` | Create (NEW — BYOK→platform algorithm + cache) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Providers/IPlatformFallbackPolicy.cs` | Create (NEW — fallback gating seam) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Providers/ConfigPlatformFallbackPolicy.cs` | Create (NEW — v1 mode/config-driven policy) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderCabinetNames.cs` | Create (NEW — BYOK + platform cabinet-name map) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderCredentialCacheInvalidator.cs` | Create (NEW — `SECRET.ROTATE.ACTIVATED` handler) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/ProviderCredentialEndpoints.cs` | Create (NEW — BYOK management API) |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/ProviderCredentialServiceCollectionExtensions.cs` | Create (NEW — DI wiring) |
+| `apps/tamma-elsa/src/Tamma.Activities/LlmCall/CallLlmInlineActivity.cs` | Modify (NEW `TenantIdProp`, resolver ctor dep, drop direct `Anthropic/OpenAI:ApiKey` read, `CredentialSource` tag) |
+| `apps/tamma-elsa/src/Tamma.Activities/LlmCall/Models/LlmCallModels.cs` | Modify (`ProviderAttemptDiagnostic.CredentialSource`) |
+| `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/LlmCallWorkflow.cs` | Modify (thread `TenantId` into `CallLlmInlineActivity` step) |
+| `apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs` | Modify (register resolver + invalidator) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map endpoints + DI) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Providers/ProviderCredentialResolverTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/ProviderCredentialEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/LlmCall/CallLlmInlineCredentialTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+1. Read [BEFORE_YOU_CODE.md](../../../BEFORE_YOU_CODE.md).
+2. Search `.dev/` for related spikes/bugs/findings/decisions (esp. Epic 29 secret cabinet, KEK
+   decision `project_epic28_kek_decision.md`).
+3. Re-read the Epic 32 design (`docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`
+   §"Provider credential & auth model") — this story is the canonical owner of its key wiring.
+4. TDD (Red-Green-Refactor); docker-bound C# suites run via `sg docker -c "dotnet test ..."`.
+
+### Key Design Decisions
+
+- **Reuse the cabinet runtime path, don't reinvent it.** `RuntimeSecretResolver` already proves the
+  exact runtime-plaintext-from-cabinet pattern (cabinet → backend `GetVersionPlaintextAsync` → cache
+  → invalidate) — but platform-scoped only (`s.Scope == "platform"`, `StopgapSecretMap.Platform`).
+  This story adds the **tenant-scoped** sibling and delegates the platform leg back to
+  `IRuntimeSecretResolver` so there is one platform-key source of truth (AC2). Do NOT add a new
+  `_configuration["…:ApiKey"]` read anywhere.
+- **`ISecretStore` never surfaces plaintext** (its own doc-comment): use `ISecretStoreBackend` for the
+  byte read at runtime, `ISecretStore` for create/rotate/retire/metadata. Honour that boundary.
+- **Plaintext is request-scoped only.** `ProviderCredential.ApiKey` exists to feed one HTTP header
+  and is dropped after; `ToTag()` is the only thing that ever reaches an event/diagnostic.
+- **Fail-closed beats wrong-key.** A taxonomy of "no key" must throw (`PROVIDER_CREDENTIAL_UNAVAILABLE`),
+  mirroring the project's no-empty-fallback rule for prompts/conventions
+  (`feedback_resolution_no_empty_fallback`): never silently substitute.
+- **Null-tolerant activity ctor.** Mirror the existing optional-dependency pattern in
+  `CallLlmInlineActivity` (`[JsonConstructor]` + nullable deps) so DI + Elsa hydration + existing
+  tests keep working; assert real wiring in a Program-level test.
+
+### Integration Points
+
+- `LlmCallWorkflow` `TenantId` variable (already present) → new `CallLlmInlineActivity.TenantIdProp`.
+- `ProviderChainResolver` selects the provider; this resolver supplies that provider's key.
+- 32-9 reads `credentialSource` from the diagnostic/action-trail to attribute cost (BYOK = tenant's
+  account → cost basis differs from platform-metered).
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Raw key leaks into a DCB event / log | Critical | Tag-only projection (`ToTag()`), `Data` never includes `ApiKey`, dedicated redaction test (AC5) on the full path |
+| Cross-tenant key bleed via cache key collision | High | Cache keyed by `(tenantId, provider)`; isolation test (AC11); resolver only reads `SecretScope.Tenant` for caller's tenant |
+| Stale key after rotation | Medium | Short TTL + explicit `Invalidate` on mutate + `SECRET.ROTATE.ACTIVATED` handler; rotation test (AC9) |
+| Fail-closed breaks single-user dev who hasn't set any key | Medium | Single-user always allows platform fallback; only throws if even platform key unset (which is already broken today) — error is loud + actionable |
+| Behaviour change for existing platform-key tenants | Medium | AC12 backward-compat: identical bytes when `source=platform`; existing activity tests must stay green |
+| `_configuration` read sneaks back in during a future edit | Medium | Resolver is the only key source; add a test asserting `LoadProviderConfig` returns empty `ApiKey` |
+
+### Success Metrics
+
+- [ ] 100% of LLM calls resolve their key via `IProviderCredentialResolver` (zero direct
+      `_configuration["…:ApiKey"]` reads remain in the call path).
+- [ ] Tenants with a BYOK key see `credentialSource=byok` on their calls; cost attributes to them.
+- [ ] Zero raw keys in any DCB event / log (redaction test green; spot-check of event store clean).
+
+## Logging Requirements
+
+- **INFO**: credential resolved (`tenantId`, `provider`, `source`, `version` — **never the key**);
+  BYOK registered/rotated/removed (`tenantId`, `provider`, action); cache invalidated on rotation.
+- **DEBUG**: cache hit/miss for `(tenantId, provider)`; cabinet probe result (found/absent, **no
+  bytes**); platform fallback taken.
+- **WARN**: cabinet probe threw (treated as BYOK-absent, fell through to fallback); platform key
+  unset while fallback allowed.
+- **ERROR**: fail-closed denial (`PROVIDER_CREDENTIAL_UNAVAILABLE`) — include `tenantId`, `provider`,
+  `reason`, `mode`; never the (absent) key.
+- **Credential safety**: NEVER log API keys, plaintext, or any substring thereof. Only
+  `SecretRef.ToStorageKey()`, source, version, provider, tenant id are loggable.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-32/story-32-4/32-4-saas-provider-auth-gating-api-key-only.md
+++ b/docs/stories/epic-32/story-32-4/32-4-saas-provider-auth-gating-api-key-only.md
@@ -1,0 +1,328 @@
+# Story 32-4: SaaS Provider Auth Gating — API-key only (CLI/token providers single-user only)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **platform operator running Tamma in SaaS mode**,
+I want every agent definition, selection, and execution to be restricted to API-key (`ILLMProvider`) providers — never CLI/token (`ICLIAgentProvider`) providers,
+So that a tenant can never select or run a local-binary / token-auth agent (e.g. the Claude Code CLI) inside the managed multi-tenant service, where there is no host shell, no per-tenant local credential store, and no isolation boundary for a subprocess agent.
+
+## Priority
+
+P0 — Required guardrail before the managed-execution layer (32-5) goes live; a SaaS tenant selecting a CLI/token provider is a correctness and security defect, not a degraded experience.
+
+## Acceptance Criteria
+
+1. A **provider capability registry** (`IProviderAuthRegistry`) classifies every known provider by its auth model — `ApiKey` vs `CliToken` — and exposes whether it is **SaaS-eligible** (`ApiKey` ⇒ eligible; `CliToken` ⇒ ineligible). The known-provider source of truth stays the existing `ProviderAllowlist.DefaultProviders` list; this story adds the auth-model dimension, it does not duplicate the allowlist.
+2. In **SaaS mode**, creating, versioning, or selecting an agent whose resolved provider is `CliToken` returns **HTTP 400** with code `SAAS_PROVIDER_NOT_ALLOWED`, the offending provider named in the message and `TammaError.Context`, and the agent is **not** persisted/selected.
+3. In **single-user mode**, `CliToken` providers remain fully usable end-to-end — the gate is a no-op (no rejection, no event, no telemetry counter increment).
+4. The managed-execution entrypoint (32-5) **and** the existing provider-chain resolver (`ProviderChainResolver`) consult the registry. In SaaS mode the resolver **skips** `CliToken` entries from a chain (treats them as ineligible, not merely unhealthy); if a chain resolves to *only* ineligible entries, resolution fails closed with `SAAS_PROVIDER_NOT_ALLOWED` and emits `AGENT.PROVIDER.GATED`.
+5. Mode is read **once** from the existing process-wide `ITammaModeProvider` (`TammaMode.cs`) — no new per-request mode plumbing, no per-request mode ambiguity. The gate is a pure function of `(mode, providerName)`.
+6. The gate **reuses** the existing `ProviderAllowlist` / `ActionGate` seams in `Tamma.Activities/Security/` rather than duplicating them; new logic is **additive and fail-closed** — an unknown provider name (not in the registry) is treated as ineligible in SaaS mode (deny), and the existing allowlist rejection still runs first.
+7. A DCB event **`AGENT.PROVIDER.GATED`** is appended (via `IEventRepository`) on every gated rejection, with `Data` = `{ provider, authModel, mode, reason, role?, action? }` and tenant-scoped `Tags`. Single-user mode never emits it.
+8. An OpenTelemetry counter `tamma.provider.gated` is incremented on each gating decision, tagged `provider`, `auth_model`, `reason`. (Mirrors the `KekRotationMetrics` / existing-metrics pattern.)
+9. **Tests** cover: SaaS rejects a `CliToken` provider at **selection** (agent create/version) and at **execution** (resolver / managed entrypoint); single-user allows the same `CliToken` provider in both paths; an `ApiKey` provider passes in **both** modes; an unknown provider is denied (fail-closed) in SaaS and (per existing allowlist) rejected in single-user; the gate is pure and emits exactly one event + one counter increment per gated decision.
+
+## Technical Design
+
+### Where gating is enforced (two seams)
+
+The constraint is enforced at the **two boundaries a `CliToken` provider can enter the system in SaaS**:
+
+```
+                        ┌─────────────────────────────────────────────┐
+                        │  ITammaModeProvider.Mode  (process-stable)   │
+                        └───────────────────────┬─────────────────────┘
+                                                 │
+  (A) SELECTION boundary                         │      (B) EXECUTION boundary
+  AgentRegistryService (32-2) /                  │      ProviderChainResolver  +
+  AgentEndpoints create/version  ───────────────▶│◀───  managed-execution entrypoint (32-5)
+                                                 │
+                                   ┌─────────────▼─────────────┐
+                                   │  ISaaSProviderGate         │  ← NEW, the single seam
+                                   │  .Inspect(provider, role?, │
+                                   │           action?)         │
+                                   └─────────────┬─────────────┘
+                                                 │ consults
+                          ┌──────────────────────┴───────────────────────┐
+                          │ IProviderAuthRegistry (NEW)                   │
+                          │   AuthModel(provider) → ApiKey | CliToken     │
+                          │   IsSaaSEligible(provider) → bool             │
+                          │   (known set = ProviderAllowlist.Default...)  │
+                          └───────────────────────────────────────────────┘
+```
+
+- **(A) Selection** is the *primary* gate — reject at create/version/select so a bad config never lands in `agent_configs`. This is where users get the actionable 400.
+- **(B) Execution** is the *fail-closed backstop* — a config that predates the gate, or a default chain that still lists a CLI provider, must not silently execute a `CliToken` provider in SaaS. The resolver skips it; if nothing eligible remains, it fails closed.
+
+Single-user mode short-circuits both: `ISaaSProviderGate.Inspect` returns `Allowed` immediately when `Mode == SingleUser`.
+
+### Provider auth registry — `IProviderAuthRegistry`
+
+New file `apps/tamma-elsa/src/Tamma.Activities/Security/IProviderAuthRegistry.cs` + `ProviderAuthRegistry.cs` (co-located with `ProviderAllowlist.cs` — same seam, same project).
+
+```csharp
+namespace Tamma.Activities.Security;
+
+/// <summary>Auth model a provider uses to authenticate. Drives SaaS eligibility.</summary>
+public enum ProviderAuthModel
+{
+    /// <summary>Cloud/local LLM API authenticated by an API key (ILLMProvider).
+    /// SaaS-eligible — the key resolves from the principal's secret source (32-3).</summary>
+    ApiKey,
+
+    /// <summary>Headless CLI / token-based coding agent (ICLIAgentProvider, e.g.
+    /// claude-code, opencode). Requires a host shell + local credential — NOT
+    /// available in SaaS; single-user/self-hosted only.</summary>
+    CliToken,
+}
+
+public interface IProviderAuthRegistry
+{
+    /// <summary>Auth model for a known provider; <c>null</c> if the provider is unknown.</summary>
+    ProviderAuthModel? AuthModel(string? providerName);
+
+    /// <summary>True iff the provider is API-key (and therefore SaaS-eligible).
+    /// Unknown providers return <c>false</c> (fail-closed).</summary>
+    bool IsSaaSEligible(string? providerName);
+}
+```
+
+`ProviderAuthRegistry` classifies the `ProviderAllowlist.DefaultProviders` set. The `CliToken` members are the providers backed by `ICLIAgentProvider` in `packages/providers`: **`claude-code`**, **`opencode`** (and `zen-mcp` is treated per its backing factory — verify at impl time against `BUILTIN_PROVIDER_NAMES`). Everything else in the allowlist (`anthropic`, `openai`, `openrouter`, `google`/`gemini`, `github-copilot`, `azure-openai`, `local-llm`, `ollama`, `lmstudio`, `together`, `groq`, `z-ai`) is `ApiKey`.
+
+```csharp
+public sealed class ProviderAuthRegistry : IProviderAuthRegistry
+{
+    // CLI/token-backed providers (ICLIAgentProvider). The complement of this
+    // set within ProviderAllowlist.DefaultProviders is ApiKey.
+    private static readonly HashSet<string> CliTokenProviders =
+        new(StringComparer.OrdinalIgnoreCase) { "claude-code", "opencode" };
+
+    public ProviderAuthModel? AuthModel(string? providerName)
+    {
+        if (string.IsNullOrWhiteSpace(providerName)) return null;
+        var name = providerName.Trim();
+        if (!ProviderAllowlist.IsAllowedDefault(name)) return null; // unknown
+        return CliTokenProviders.Contains(name)
+            ? ProviderAuthModel.CliToken
+            : ProviderAuthModel.ApiKey;
+    }
+
+    public bool IsSaaSEligible(string? providerName) =>
+        AuthModel(providerName) == ProviderAuthModel.ApiKey; // null/CliToken ⇒ false
+}
+```
+
+> **Design note — single source of known providers.** The registry does not re-list every provider; it derives the `ApiKey` set as `ProviderAllowlist.DefaultProviders \ CliTokenProviders`. Adding a future provider to the allowlist auto-classifies it `ApiKey` unless it is also added to `CliTokenProviders`. A unit test asserts every allowlist entry has a deterministic auth model so a new provider can't be silently miscategorised.
+
+### The gate — `ISaaSProviderGate`
+
+New file `apps/tamma-elsa/src/Tamma.Api/Services/Security/ISaaSProviderGate.cs` + `SaaSProviderGate.cs` (Api-side because it needs `ITammaModeProvider` and emits DCB events; the registry stays in Activities so engine activities can reuse the classification).
+
+```csharp
+namespace Tamma.Api.Services.Security;
+
+public sealed record ProviderGateContext(
+    string ProviderName,
+    string? Role = null,
+    string? Action = null,
+    Guid? TenantId = null);
+
+public sealed record ProviderGateDecision(
+    bool Allowed,
+    string? Reason,                 // null when Allowed
+    ProviderAuthModel? AuthModel);
+
+public interface ISaaSProviderGate
+{
+    /// <summary>
+    /// Pure-ish decision: single-user ⇒ always Allowed (no event, no metric).
+    /// SaaS ⇒ Allowed only when the provider is SaaS-eligible (API-key).
+    /// On a SaaS denial this emits AGENT.PROVIDER.GATED + the metric as a side
+    /// effect (fire-and-forget, never throws back into the decision).
+    /// </summary>
+    Task<ProviderGateDecision> InspectAsync(ProviderGateContext ctx, CancellationToken ct = default);
+
+    /// <summary>
+    /// Convenience for selection paths: throws TammaError(SAAS_PROVIDER_NOT_ALLOWED,
+    /// severity High) when denied, so the endpoint's existing TammaError→400 mapping
+    /// produces the response with no extra branching.
+    /// </summary>
+    Task EnsureAllowedAsync(ProviderGateContext ctx, CancellationToken ct = default);
+}
+```
+
+`EnsureAllowedAsync` throws:
+
+```csharp
+throw new TammaError(
+    code: "SAAS_PROVIDER_NOT_ALLOWED",
+    message: $"Provider '{ctx.ProviderName}' uses CLI/token authentication and is not " +
+             "available in SaaS mode. Use an API-key provider (e.g. anthropic, openai).",
+    context: new Dictionary<string, object?>
+    {
+        ["provider"]  = ctx.ProviderName,
+        ["authModel"] = "cli-token",
+        ["mode"]      = "saas",
+        ["role"]      = ctx.Role,
+        ["action"]    = ctx.Action,
+    },
+    retryable: false,
+    severity: TammaErrorSeverity.High);
+```
+
+### DCB event — `AGENT.PROVIDER.GATED`
+
+Appended via `IEventRepository.AppendAsync` (same pattern as `AgentEndpoints` `AGENT_CONFIG.UPDATED.SUCCESS`, ~line 93). Emitted **only** in SaaS on a denial.
+
+```csharp
+await _events.AppendAsync(new DomainEvent
+{
+    Id = Guid.NewGuid(),
+    Type = "AGENT.PROVIDER.GATED",
+    TenantId = ctx.TenantId,
+    Tags = JsonSerializer.Serialize(new
+    {
+        tenantId = ctx.TenantId?.ToString(),
+        provider = ctx.ProviderName,
+        authModel = "cli-token",
+        mode = "saas",
+        role = ctx.Role,
+        action = ctx.Action,
+    }),
+    Metadata = JsonSerializer.Serialize(new { workflowVersion = "1.0.0", eventSource = "system" }),
+    Data = JsonSerializer.Serialize(new
+    {
+        provider = ctx.ProviderName,
+        authModel = "cli-token",
+        mode = "saas",
+        reason = "SAAS_PROVIDER_NOT_ALLOWED",
+        role = ctx.Role,
+        action = ctx.Action,
+    }),
+    CreatedAt = DateTime.UtcNow,
+});
+```
+
+Event-store note: appended via the CP/tenant `IEventRepository` exactly as sibling endpoints do; no new event topology. Failure to append is logged and swallowed so it never converts a clean 400 into a 500.
+
+### Resolver integration (execution boundary)
+
+`ProviderChainResolver.ResolveAsync` gains an injected `IProviderAuthRegistry?` (null-tolerant ctor overload, matching the existing optional `IDiagnosticsService?` pattern) **plus** an `ITammaModeProvider`. In the per-entry loop, before the circuit-breaker switch:
+
+```csharp
+// SaaS gating — exclude CLI/token providers entirely (not "unhealthy",
+// "ineligible"). Single-user: registry/mode null-check makes this a no-op.
+if (_mode?.Mode == TammaMode.SaaS && _authRegistry is not null
+    && !_authRegistry.IsSaaSEligible(handle.Provider))
+{
+    skipped.Add(new ChainEntry(handle, ChainReason.SaaSIneligible,
+        Healthy: false, CircuitOpen: false, CircuitOpenUntil: null,
+        BudgetAllowed: budgetAllowed, BudgetSpent: budgetSpent, Recommended: false));
+    continue;
+}
+```
+
+A new `ChainReason.SaaSIneligible` is added to `ProviderChainTypes.cs`. When the ordered set is empty *because of* gating, the existing "all exhausted" return is reused but with `ErrorCode: "SAAS_PROVIDER_NOT_ALLOWED"`, and the gate's `InspectAsync` is called once for the first gated entry so the `AGENT.PROVIDER.GATED` event + metric fire. (Existing `EMPTY_PROVIDER_CHAIN` / `NO_AVAILABLE_PROVIDER` returns are unchanged when no gating occurred.)
+
+### Selection integration (selection boundary)
+
+`AgentRegistryService` (32-2 — **NEW**, dependency) and the agent create/version path in `AgentEndpoints` call `ISaaSProviderGate.EnsureAllowedAsync` for **each** provider referenced by the submitted agent config (primary + every fallback in the chain) before persisting. The existing `TammaError`→400 endpoint mapping handles the response. Where 32-2 is not yet merged, this story wires the gate into the existing `AgentEndpoints` create/version write (`configRepo.UpsertAsync`, ~line 89) and leaves a documented hook for `AgentRegistryService`.
+
+### OpenTelemetry metric
+
+New `ProviderGatingMetrics` (mirrors `KekRotationMetrics`): a `Meter`-registered `Counter<long> tamma.provider.gated`, incremented in `InspectAsync` on a SaaS denial with tags `provider`, `auth_model`, `reason`.
+
+## Dependencies
+
+- **Prerequisite**: Story **32-2** (Agent registry, resolution & RBAC API) — provides the selection seam (`AgentRegistryService`) the gate hooks into. If 32-2 is not yet merged, the selection gate attaches to the existing `AgentEndpoints` create/version write and the resolver gate (execution boundary) ships fully regardless.
+- **Prerequisite**: Story **32-3** (Per-tenant provider credential resolution, BYOK → platform) — defines the API-key credential model the `ApiKey` classification presumes; gating runs *before* credential resolution.
+- **Reuses (no change required)**: `ProviderAllowlist` / `ActionGate` (`Tamma.Activities/Security/`), `ITammaModeProvider` (`Services/PromptStore/TammaMode.cs`), `IEventRepository` (`Tamma.Data/Repositories/`), `ProviderChainResolver` + `ProviderChainTypes` (`Services/Providers/`), `TammaError` (`Tamma.Core/`).
+- **Blocks**: Story **32-5** (Managed agent execution layer) — its `IManagedAgent` entrypoint must call the execution-boundary gate before dispatching; this story delivers the gate it consumes.
+- **Design alignment**: `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md` §"Provider credential & auth model" ("SaaS = API-key auth only … `ICLIAgentProvider` are NOT available in SaaS").
+
+## Testing Strategy
+
+1. **Registry unit tests** (`tests/Tamma.Activities.Tests/Security/ProviderAuthRegistryTests.cs`): every `ProviderAllowlist.DefaultProviders` entry has a deterministic `AuthModel` (no `null`); `claude-code`/`opencode` ⇒ `CliToken` / not SaaS-eligible; `anthropic`/`openai`/`openrouter`/`gemini` ⇒ `ApiKey` / SaaS-eligible; unknown provider ⇒ `AuthModel == null` and `IsSaaSEligible == false` (fail-closed); case-insensitivity.
+2. **Gate unit tests** (`tests/Tamma.Api.Tests/Security/SaaSProviderGateTests.cs`): **single-user** — every provider (incl. `claude-code`) ⇒ `Allowed`, **zero** events, **zero** counter increments; **SaaS** — `ApiKey` provider ⇒ `Allowed` (no event); `CliToken` provider ⇒ denied, **exactly one** `AGENT.PROVIDER.GATED` event with the right `Data`/`Tags`, **exactly one** counter increment; unknown provider ⇒ denied (fail-closed); `EnsureAllowedAsync` throws `TammaError("SAAS_PROVIDER_NOT_ALLOWED", severity High)` with the provider named in `Context`.
+3. **Resolver mode-gating tests** (`tests/Tamma.Api.Tests/Providers/ProviderChainResolverSaaSGatingTests.cs`): SaaS — chain `[claude-code, anthropic]` ⇒ `claude-code` in `Skipped` with `ChainReason.SaaSIneligible`, `anthropic` recommended; chain `[claude-code]` only ⇒ `ErrorCode == "SAAS_PROVIDER_NOT_ALLOWED"`, `AllExhausted`, one event; single-user — same chains resolve `claude-code` normally, no event, no skip-for-gating; the existing `EMPTY_PROVIDER_CHAIN` / `NO_AVAILABLE_PROVIDER` / budget paths are unchanged (regression assertions on existing resolver tests).
+4. **Selection endpoint tests** (`tests/Tamma.Api.Tests/Agents/` or extend `AgentEndpoints` tests): SaaS create/version with a `CliToken` provider in the chain ⇒ **400** `SAAS_PROVIDER_NOT_ALLOWED`, **not** persisted, one event; SaaS with all-`ApiKey` chain ⇒ persists; single-user with a `CliToken` chain ⇒ persists, no event.
+5. **Mode-matrix table test**: parameterise `(mode ∈ {SingleUser, SaaS}) × (provider ∈ {anthropic, claude-code, unknown})` over both boundaries and assert the 12-cell allow/deny/event/metric matrix — the canonical guard against regressions.
+6. **C# suites run** via `sg docker -c "dotnet test ..."` (session docker group is stale — see `reference_dotnet_test_docker.md`). TDD: tests authored red before implementation per `superpowers:test-driven-development`.
+
+## Estimated Effort
+
+2-3 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Activities/Security/IProviderAuthRegistry.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/Security/ProviderAuthRegistry.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Security/ISaaSProviderGate.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Security/SaaSProviderGate.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Security/ProviderGatingMetrics.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderChainResolver.cs` | Modify (inject registry + mode; skip ineligible; fail-closed return) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderChainTypes.cs` | Modify (add `ChainReason.SaaSIneligible`) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs` | Modify (call `EnsureAllowedAsync` on create/version) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRegistryService.cs` | Modify (gate at selection — **NEW from 32-2; hook only if merged**) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (DI: register registry, gate, metrics) |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/Security/ProviderAuthRegistryTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Security/SaaSProviderGateTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Providers/ProviderChainResolverSaaSGatingTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentSelectionGatingTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` directory for related spikes, bugs, findings, and decisions
+3. Reviewed the Epic 32 design spec (`docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`), §"Provider credential & auth model"
+4. Confirmed the two provider hierarchies in `packages/providers/src/types.ts`: `ILLMProvider` (`type: 'llm-api'`, API-key) vs `ICLIAgentProvider` (`type: 'cli-agent'`, CLI/token)
+5. Planned TDD approach (Red-Green-Refactor) — write the mode-matrix test first
+
+### Why two seams, not one
+
+The selection gate alone is insufficient: default provider chains and pre-gate configs already in `agent_configs` can name a CLI provider. The resolver/execution gate is the fail-closed backstop required by AC4 — without it, a stale config would silently dispatch a `CliToken` provider in SaaS. The selection gate alone would also be insufficient because 32-5's managed entrypoint can be reached by paths other than a fresh create. Both boundaries consult the *same* `IProviderAuthRegistry`, so classification is single-sourced.
+
+### Fail-closed semantics (AC6)
+
+In SaaS, the order at every boundary is: (1) existing `ProviderAllowlist.IsAllowed` (rejects junk/injection names — unchanged), then (2) `IProviderAuthRegistry.IsSaaSEligible`. An *unknown* provider is rejected by (1) already; a *known CliToken* provider passes (1) but is denied by (2). The registry returning `false` for unknown names is belt-and-suspenders so a future code path that bypasses (1) still denies in SaaS.
+
+### Single-user is a hard no-op
+
+`InspectAsync` checks `Mode == SingleUser` first and returns `Allowed` with no event and no metric increment — verified by tests asserting zero side effects. This keeps self-hosted users' Claude Code CLI usage completely untouched and avoids polluting their event stream / metrics.
+
+### Reuse, don't duplicate
+
+`ProviderAuthRegistry` derives its known set from `ProviderAllowlist.DefaultProviders` (does not re-declare provider names beyond the small `CliTokenProviders` set). `SaaSProviderGate` reads mode from the existing `ITammaModeProvider` and emits via the existing `IEventRepository`. No new allowlist, no new mode plumbing, no new event store.
+
+### Provider classification source of truth
+
+`claude-code` and `opencode` are the `ICLIAgentProvider` implementations in `packages/providers` (`claude-agent-provider.ts` `name = 'claude-code'`, `opencode-provider.ts` `name = 'opencode'`; both registered via `BUILTIN_PROVIDER_NAMES`). At implementation time, cross-check `BUILTIN_PROVIDER_NAMES` / `agent-provider-factory.ts` for any additional CLI-agent registrations (e.g. `zen-mcp`) and add them to `CliTokenProviders` — the registry test that asserts a deterministic auth model for every allowlist entry will surface any miss.
+
+## Logging Requirements
+
+- **INFO**: SaaS provider gated (provider, authModel, role, action, tenantId) — one line per denial.
+- **DEBUG**: Gate inspected and allowed (provider, mode); resolver skipped a SaaS-ineligible entry (provider).
+- **WARN**: Unknown provider denied in SaaS (provider) — signals a config referencing a provider not in the allowlist.
+- **ERROR**: `AGENT.PROVIDER.GATED` event append failed (the decision still returns; the throw/deny is never masked by an event-store failure).
+- **Structured context**: include `{ provider, authModel, mode, role, action, tenantId, reason }` where applicable.
+- **Credential safety**: NEVER log API keys, tokens, or CLI credentials — the gate operates on provider *names* only and must never touch secret material.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-32/story-32-5/32-5-managed-agent-execution-layer.md
+++ b/docs/stories/epic-32/story-32-5/32-5-managed-agent-execution-layer.md
@@ -1,0 +1,340 @@
+# Story 32-5: Managed Agent Execution Layer (IManagedAgent over IAIProvider)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **platform engineer building agent-driven workflows**,
+I want a single managed-LLM-agent execution abstraction (`IManagedAgent`) that turns a resolved agent + the existing inline LLM/tool-loop HTTP path into one coherent, instrumented agent run,
+So that every managed run carries a stable agent identity, resolves its own credential, sanitizes and instruments uniformly, and produces a structured `AgentRunResult` that the action-trail (32-6), outcome-capture (32-8) and cost-emission (32-9) stories can consume — and so that SaaS has exactly **one** execution path (the LLM-API path), with CLI/token providers excluded by the 32-4 gate.
+
+## Priority
+
+P0 - The managed execution seam that every later Epic 32 story (action trail, panels, outcome capture, benchmarking, learning) builds on. Without it, agent runs stay ad-hoc role→LLM-call dispatch with no run record, no uniform credential/gate path, and no clean producer for the tracking dataset.
+
+## Context
+
+Today, agent-driven workflow steps dispatch an LLM call through `CallLlmActivity` → the inline `CallLlmInlineActivity`, which already contains a complete agentic tool loop (sanitization → multi-turn LLM call → tool-call validation → tool execution → context compaction → output sanitization). Agent config is resolved separately via `IAgentResolverService`; prompt/convention rendering happens in separate Context/LlmCall activities; budget/circuit-breaker/concurrency are separate guard activities. **There is no single object that represents "run this agent end-to-end and give me a structured result."** Consequently there is no natural place to attach the stable `agent_id` + config version (32-1), the per-tenant credential source (32-3), the SaaS gate (32-4), or the run record that 32-6/32-8/32-9 need.
+
+This story introduces `IManagedAgent` / `ManagedAgent` as the **orchestration seam over** the existing inline path — it **reuses, does not fork**, the tool loop, `ContentSanitizer`, `ToolExecutorRegistry`, and `ContextCompactor` already living in `CallLlmInlineActivity`. The resolver (32-2) returns an `IManagedAgent` regardless of whether the backing executor is the LLM-API path (this story) or a CLI provider, so workflows treat all agents identically; **SaaS resolves only the LLM-API-backed `IManagedAgent`** because the 32-4 gate excludes `ICLIAgentProvider` outside single-user mode.
+
+> **Architecture note — distinct from CLI providers.** `IManagedAgent` is the customization layer *above* the LLM API (provider + model + prompt + tools + RAG + budget), and is **not** an `ICLIAgentProvider`. The two execution backends converge on the same `AgentRunResult` so callers never branch on backend. Per the Epic 32 design spec, SaaS = API-key auth only → managed path only.
+
+## Acceptance Criteria
+
+1. An **`IManagedAgent`** interface and a **`ManagedAgent`** implementation exist (`apps/tamma-elsa/src/Tamma.Api/Services/Agents/`). `RunAsync(ManagedAgentRequest, CancellationToken)` orchestrates, in order: **resolve agent (32-2)** → **resolve credential (32-3)** → **SaaS gate (32-4)** → **context + RAG assembly** → **prompt render (Epic 27 prompt/convention stores)** → **agentic tool loop (the existing `CallLlmInlineActivity` path)** → **sanitize** → **instrument** → **outcome capture**, and returns a structured `AgentRunResult`.
+2. `AgentRunResult` is a typed record carrying at minimum: `AgentId`, `Version`, `Provider`, `Model`, `Role`, `InputTokens`, `OutputTokens`, `CostUsd`, `DurationMs`, `Success`, `ToolCalls` (count + per-call summaries), `CorrelationId`, `CredentialSource` (`byok` | `platform`), `ResponseText`, and on failure a `FailureReason` + `FailureCode`. The same record shape is returned whether the run succeeded, failed, was budget-exceeded, or gate-denied.
+3. `ManagedAgent` **reuses (does NOT fork)** the existing inline tool loop, `ContentSanitizer` (input/output/tool-output sanitization), `IToolExecutorRegistry`, `IToolCallValidator`, and `ContextCompactor` in `CallLlmInlineActivity`. No second copy of the tool loop, sanitizer, or compactor is created; the loop body is factored into a reusable seam invoked by both the legacy activity and `ManagedAgent`.
+4. Clear separation is enforced: **`IManagedAgent` is the only execution path used by SaaS.** In SaaS mode the resolver never returns a CLI/token-backed agent (`ICLIAgentProvider` implementations are excluded by the 32-4 gate); attempting to resolve a CLI-backed agent in SaaS yields a typed gate-denied `AgentRunResult` (not a thrown bare exception).
+5. An Elsa activity **`RunManagedAgentActivity`** (`apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/`) exposes `IManagedAgent` to workflows, replacing ad-hoc role→llm-call dispatch in agent-driven steps. It accepts the agent/role + phase + issue context + per-task overrides, calls `IManagedAgent.RunAsync`, and writes the serialized `AgentRunResult` to a workflow variable.
+6. Token/cost accounting in `AgentRunResult.CostUsd` is computed via the existing **`IProviderPricingService.Compute(provider, model, inputTokens, outputTokens)`** (cost basis), and the result is tagged with `CredentialSource` so downstream pricing/markup (Epic 34) and billing (Epic 35) can attribute it. BYOK runs are tagged `byok`; platform-key runs are tagged `platform`.
+7. **Failures never lose the run record.** A provider error, budget-exceeded, gate denial, missing-credential, or tool-loop exception produces a typed `AgentRunResult { Success = false, FailureCode, FailureReason }` (with whatever token/cost was accrued before failure), never an unhandled exception that drops the run. The single exception is a programmer/contract error (e.g., null request), which may throw.
+8. **DCB events** `AGENT.RUN.STARTED`, `AGENT.RUN.SUCCESS`, and `AGENT.RUN.FAILED` are emitted (one STARTED before the loop; exactly one terminal SUCCESS or FAILED) via the tenant `IEventRepository`, tagged `{ agentId, version, provider, model, role, correlationId, credentialSource, tenantId }`. `AGENT.RUN.FAILED` additionally tags `failureCode`.
+9. **Unit + workflow tests** cover: happy path (all fields populated end-to-end), budget-exceeded, gate-denied (CLI-backed agent in SaaS), provider-failure, missing-credential, and tool-loop-exhausted; plus a test asserting every `AgentRunResult` field is populated on the happy path and that exactly one terminal DCB event is emitted per run.
+
+## Technical Design
+
+### Where it lives
+
+```
+apps/tamma-elsa/src/Tamma.Api/Services/Agents/
+  IManagedAgent.cs                 # NEW — the managed execution contract
+  ManagedAgent.cs                  # NEW — orchestrator over the inline LLM/tool-loop seam
+  ManagedAgentRequest.cs           # NEW — input record (role/agentId, phase, issue ctx, overrides, correlationId)
+  AgentRunResult.cs                # NEW — structured outcome record (the producer for 32-6/32-8/32-9)
+  AgentRunEventTypes.cs            # NEW — AGENT.RUN.STARTED/SUCCESS/FAILED constants
+  IManagedAgentResolver.cs         # NEW (or extends 32-2 resolver) — returns IManagedAgent for (tenant, role/agentId)
+
+apps/tamma-elsa/src/Tamma.Activities/LlmCall/
+  CallLlmInlineActivity.cs         # MODIFY — extract the agentic tool loop into a reusable seam (no behaviour change)
+  IInlineToolLoopRunner.cs         # NEW — the extracted, reusable tool-loop seam (interface)
+  InlineToolLoopRunner.cs          # NEW — the extracted loop body (moved verbatim from the activity)
+
+apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/
+  RunManagedAgentActivity.cs       # NEW — Elsa activity exposing IManagedAgent to workflows
+```
+
+### IManagedAgent contract (C#)
+
+```csharp
+namespace Tamma.Api.Services.Agents;
+
+/// <summary>
+/// The managed-LLM-agent execution layer (Epic 32). Composes a resolved agent +
+/// credential + the existing inline tool loop into one instrumented run that
+/// returns a structured <see cref="AgentRunResult"/>.
+///
+/// Distinct from <c>ICLIAgentProvider</c> (CLI/token providers, single-user only).
+/// In SaaS mode this is the ONLY execution path; CLI-backed agents are excluded by
+/// the 32-4 provider-auth gate.
+/// </summary>
+public interface IManagedAgent
+{
+    /// <summary>Stable agent identity + the pinned config version this instance runs.</summary>
+    Guid AgentId { get; }
+    int Version { get; }
+
+    /// <summary>
+    /// Run the agent end-to-end. Composition:
+    ///   resolve agent (32-2) -> resolve credential (32-3) -> SaaS gate (32-4)
+    ///   -> assemble context + RAG (Epic 6) -> render prompt (Epic 27)
+    ///   -> agentic tool loop (reused CallLlmInlineActivity seam)
+    ///   -> sanitize -> instrument (cost via IProviderPricingService) -> capture outcome.
+    ///
+    /// NEVER throws on an expected failure (provider error, budget exceeded, gate
+    /// denial, missing credential, loop exhaustion): returns a typed
+    /// <see cref="AgentRunResult"/> with Success=false and a FailureCode/Reason so
+    /// the run record is always captured. Emits exactly one terminal DCB event.
+    /// </summary>
+    Task<AgentRunResult> RunAsync(ManagedAgentRequest request, CancellationToken ct);
+}
+```
+
+### ManagedAgentRequest (input)
+
+```csharp
+public sealed record ManagedAgentRequest
+{
+    public required Guid? TenantId { get; init; }      // null => single-user / platform default
+    public required string Role { get; init; }         // 8 valid roles (RolePhaseMap.ValidRoles)
+    public Guid? AgentId { get; init; }                // explicit agent (32-1); else resolver picks for role
+    public string? Phase { get; init; }                // workflow phase, for ResolveForPhaseAsync
+    public required string UserPrompt { get; init; }   // task prompt (pre-render variables)
+    public int? IssueNumber { get; init; }             // issue/PR context for RAG + event tags
+    public TaskOverrides? Overrides { get; init; }     // clamped per resolver (budget min, tools intersect)
+    public required string CorrelationId { get; init; } // ties the run to the workflow instance / dispatch
+}
+```
+
+### AgentRunResult (output — the producer record)
+
+```csharp
+public sealed record AgentRunResult
+{
+    public required Guid AgentId { get; init; }
+    public required int Version { get; init; }
+    public required string Provider { get; init; }
+    public required string Model { get; init; }
+    public required string Role { get; init; }
+
+    public int InputTokens { get; init; }
+    public int OutputTokens { get; init; }
+    public decimal CostUsd { get; init; }              // IProviderPricingService.Compute(...)
+    public long DurationMs { get; init; }
+
+    public required bool Success { get; init; }
+    public string? ResponseText { get; init; }
+    public IReadOnlyList<ToolCallSummary> ToolCalls { get; init; } = Array.Empty<ToolCallSummary>();
+
+    public required string CorrelationId { get; init; }
+    public required string CredentialSource { get; init; }  // "byok" | "platform"
+
+    // Populated only when Success == false:
+    public string? FailureCode { get; init; }    // e.g. BUDGET_EXCEEDED | GATE_DENIED | PROVIDER_ERROR | NO_CREDENTIAL | LOOP_EXHAUSTED
+    public string? FailureReason { get; init; }
+}
+
+public sealed record ToolCallSummary(string ToolName, bool Success, long DurationMs);
+```
+
+### Composition inside ManagedAgent.RunAsync
+
+```
+1. resolved   = await _resolver.ResolveForPhaseAsync(tenantId, phase, role, overrides)   // 32-2
+                 -> ResolvedAgentConfig { Provider, Model, Temperature, MaxTokens, TokenBudget, Tools, ... }
+2. credential = await _credentialResolver.ResolveAsync(tenantId, resolved.Provider)      // 32-3 (BYOK -> platform)
+                 -> { ApiKey, BaseUrl, Source }; if null => FAILED(NO_CREDENTIAL)
+3. gate       = _saasGate.Check(mode, resolved)                                           // 32-4
+                 -> CLI-backed agent in SaaS => FAILED(GATE_DENIED)  (typed result, no throw)
+4. budget     = _budgetGuard.Check(resolved, tenantId)                                    // reuses CheckBudgetActivity logic
+                 -> over budget => FAILED(BUDGET_EXCEEDED)
+5. context    = await _contextAssembler.AssembleAsync(role, issueNumber, ...)             // Epic 6: AssembleContextActivity / RAG pipeline
+6. prompt     = await _promptRenderer.RenderAsync(role, phase/action, config, context)    // Epic 27 prompt + convention render (tenant->system->error)
+7. emit AGENT.RUN.STARTED { agentId, version, provider, model, role, correlationId, credentialSource, tenantId }
+8. loop       = await _toolLoop.RunAsync(provider=resolved.Provider, model=resolved.Model,
+                     systemPrompt=prompt.System, userPrompt=prompt.User, tools=resolved.Tools,
+                     credential, loopConfig)                                              // REUSED inline seam (sanitize+compact+validate inside)
+9. cost       = _pricing.Compute(resolved.Provider, resolved.Model, loop.InputTokens, loop.OutputTokens)  // IProviderPricingService
+10. result    = AgentRunResult { ... mapped from resolved + loop + cost + credential.Source ... }
+11. emit AGENT.RUN.SUCCESS or AGENT.RUN.FAILED (exactly one terminal event)
+12. return result
+```
+
+Steps 2–4, 8 each have a typed-failure exit that maps to `AgentRunResult { Success=false }` and emits `AGENT.RUN.FAILED` — never a propagated exception.
+
+### Reusing (not forking) the inline tool loop
+
+The agentic loop currently lives privately inside `CallLlmInlineActivity.AgenticToolLoop(...)` (sanitize prompts → multi-turn call → tool-call validation → sequential/parallel tool execution → tool-output sanitization + secret redaction → context compaction → token accounting). To satisfy AC3 the loop body is **extracted verbatim** into `InlineToolLoopRunner` behind `IInlineToolLoopRunner`, and:
+
+- `CallLlmInlineActivity` delegates to the runner (behaviour and outputs unchanged — its existing sanitization tests `CallLlmInlineActivitySanitizationTests` must still pass byte-for-byte).
+- `ManagedAgent` calls the **same** runner. No second copy of the loop, sanitizer, validator, compactor, or parallel executor.
+
+This is a pure refactor-extract: same `ContentSanitizer`, `IToolExecutorRegistry`, `IToolCallValidator`, `ContextCompactor`, `ParallelToolExecutor`, and `ToolLoopEventEmitter` instances are injected into the runner.
+
+### Integration with the C# Elsa workflow (Epic 9 unified API)
+
+`RunManagedAgentActivity` is the new call site for agent-driven steps. It replaces the `ResolveAgentConfig → ResolveLlmPrompt → ResolveTools → CheckBudget → CallLlm` ad-hoc chain for managed agents with a single activity that delegates the full composition to `IManagedAgent`:
+
+```csharp
+[Activity("Tamma.AgentDispatch", "Run Managed Agent",
+    "Execute a managed LLM agent end-to-end and capture a structured AgentRunResult",
+    Kind = ActivityKind.Task)]
+public class RunManagedAgentActivity : CodeActivity
+{
+    public Input<string> RoleProp { get; set; } = default!;
+    public Input<string?> PhaseProp { get; set; } = default!;
+    public Input<string> UserPromptProp { get; set; } = default!;
+    public Input<int?> IssueNumberProp { get; set; } = default!;
+    public Input<string?> OverridesJsonProp { get; set; } = default!;
+
+    // Resolves IManagedAgent via IManagedAgentResolver (32-2), runs it, and
+    // writes JsonSerializer.Serialize(AgentRunResult) to "AgentRunResult" variable.
+}
+```
+
+The existing single-turn `CallLlmActivity`/`CallLlmInlineActivity` path remains for non-agent inline LLM calls; managed agent steps move to `RunManagedAgentActivity`. Per Epic 9, all agent resolution/credential/prompt access round-trips through the central API, so the engine activity stays thin.
+
+### Cost basis
+
+```csharp
+// IProviderPricingService already exists (apps/tamma-elsa/src/Tamma.Api/Services/Providers/):
+//   decimal Compute(string provider, string? model, int inputTokens, int outputTokens);
+result.CostUsd = _pricing.Compute(resolved.Provider, resolved.Model,
+                                  loop.InputTokens, loop.OutputTokens);
+```
+
+`AgentRunResult` is a **producer** record: 32-9 emits the usage/cost events from these fields; 34/35/36 consume them. The markup engine is 34-5, NOT this story — `CostUsd` here is the raw provider cost basis only.
+
+## Dependencies
+
+**Internal:**
+
+- **Story 32-2** (Agent registry, resolution & RBAC API) — provides `IAgentResolverService` / `IManagedAgentResolver` returning the agent config (and, in this story, an `IManagedAgent`). Hard prerequisite.
+- **Story 32-3** (Per-tenant provider credential resolution, BYOK → platform) — canonical owner of cabinet key wiring; provides the credential + `CredentialSource`. Hard prerequisite.
+- **Story 32-4** (SaaS provider auth gating — API-key only) — provides the gate that excludes `ICLIAgentProvider` in SaaS; consumed at step 3. Hard prerequisite.
+- **Epic 1** (provider abstraction) — `IProviderPricingService`, provider config/allowlist, normalized LLM responses.
+- **Epic 6** (RAG/context) — `AssembleContextActivity` + the RAG pipeline supply the assembled context fed to prompt render.
+- **Epic 27** (prompt/convention render) — prompt + convention resolution (tenant → system → error; NEVER empty/plain fallback).
+- **Epic 9** (unified agent API) — engine ↔ central-API round-trips for resolution/credential/prompt; the call-site convention.
+
+**Consumers (downstream, not blockers):**
+
+- **Story 32-6** (action trail) — consumes `AGENT.RUN.*` events + `AgentRunResult`.
+- **Story 32-8** (outcome capture & bug taxonomy) — consumes the run outcome.
+- **Story 32-9** (usage & cost emission) — emits usage/cost events from `AgentRunResult` fields.
+
+**External:** none new (reuses existing HTTP/provider stack).
+
+## Testing Strategy
+
+1. **Unit — happy path:** mock resolver/credential/gate/context/prompt/tool-loop/pricing; assert `RunAsync` returns `AgentRunResult` with **every** field populated (agentId, version, provider, model, role, input/output tokens, costUsd, durationMs, success=true, toolCalls, correlationId, credentialSource), and that the composition calls each collaborator exactly once in order.
+2. **Unit — budget-exceeded:** budget guard reports over-budget → result `Success=false, FailureCode=BUDGET_EXCEEDED`; tool loop NOT invoked; `AGENT.RUN.FAILED` emitted once; no throw.
+3. **Unit — gate-denied:** SaaS mode + CLI-backed agent → `FailureCode=GATE_DENIED`; tool loop NOT invoked; typed result, no throw. Mirror test in single-user mode: CLI-backed agent is allowed (gate passes).
+4. **Unit — provider-failure:** tool-loop seam returns an unsuccessful `NormalizedLlmResponse` → `FailureCode=PROVIDER_ERROR`, accrued tokens/cost preserved, `AGENT.RUN.FAILED` emitted.
+5. **Unit — missing-credential:** credential resolver returns null → `FailureCode=NO_CREDENTIAL`; provider never called.
+6. **Unit — loop-exhausted:** tool loop returns `exhausted=true` → result still captured (`Success` per response), `AGENT.RUN.*` reflects it.
+7. **Unit — credentialSource tagging:** BYOK credential → result + event tagged `byok`; platform credential → `platform`.
+8. **Refactor-safety:** the existing `CallLlmInlineActivitySanitizationTests` (and the inline tool-loop tests) pass unchanged after the loop is extracted into `InlineToolLoopRunner` — proving AC3 (no fork, no behaviour drift).
+9. **Workflow/integration:** `RunManagedAgentActivity` inside a minimal Elsa workflow writes a serialized `AgentRunResult` variable; assert one `AGENT.RUN.STARTED` + one terminal event per run via a fake `IEventRepository`.
+10. **Event-shape:** assert `AGENT.RUN.*` tags include `{ agentId, version, provider, model, role, correlationId, credentialSource, tenantId }` and that FAILED adds `failureCode`.
+
+Docker-bound C# suites run via `sg docker -c "dotnet test apps/tamma-elsa/..."` (session docker group is stale).
+
+## Estimated Effort
+
+5-6 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/IManagedAgent.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ManagedAgent.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ManagedAgentRequest.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRunResult.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRunEventTypes.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/IManagedAgentResolver.cs` | Create (or extend 32-2 resolver) |
+| `apps/tamma-elsa/src/Tamma.Activities/LlmCall/IInlineToolLoopRunner.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/LlmCall/InlineToolLoopRunner.cs` | Create (loop extracted from activity) |
+| `apps/tamma-elsa/src/Tamma.Activities/LlmCall/CallLlmInlineActivity.cs` | Modify (delegate to runner; no behaviour change) |
+| `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/RunManagedAgentActivity.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/ManagedAgentServiceCollectionExtensions.cs` | Create (DI wiring) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (register IManagedAgent + activity) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/ManagedAgentTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/AgentDispatch/RunManagedAgentActivityTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/LlmCall/InlineToolLoopRunnerTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` directory for related spikes, bugs, findings, and decisions
+3. Reviewed `CallLlmInlineActivity.cs` (the existing tool loop you are reusing) and `IAgentResolverService` / `ResolvedAgentConfig`
+4. Confirmed the 32-2/32-3/32-4 contracts (resolver, credential resolver, gate) are landed before wiring them in
+5. Planned TDD approach (Red-Green-Refactor cycle)
+
+### Key Design Decisions
+
+- **Reuse, don't fork (AC3).** The tool loop is mature (sanitization, validation, parallel execution, compaction, token accounting). `ManagedAgent` must call the *same* code via an extracted `InlineToolLoopRunner`. The extraction is a pure move with the existing sanitization/loop tests as the regression net — if those change, the extraction is wrong.
+- **Typed failures, never lost runs (AC7).** Expected failures (provider/budget/gate/credential/loop) are *data*, not exceptions. The only allowable throw is a contract violation (null request). Every `RunAsync` path that returns must have emitted exactly one terminal DCB event first.
+- **`AgentRunResult` is a producer, not a consumer.** Keep cost at provider basis (`IProviderPricingService.Compute`); markup (34-5), invoicing (35), analytics (36) are downstream. Do not embed markup here.
+- **Resolver returns `IManagedAgent` uniformly.** Per the design spec, the resolver hands back an `IManagedAgent` whether LLM-API- or CLI-backed; workflows never branch on backend. SaaS exclusion is enforced at the gate (step 3), so a CLI-backed agent in SaaS returns a typed `GATE_DENIED` result rather than being unrepresentable.
+- **Credential source flows to the result (AC6).** `CredentialSource` from 32-3 (`byok`/`platform`) is copied onto `AgentRunResult` and the DCB tags so cost attribution is genuinely the tenant's (BYOK hits their account; platform is metered/billed).
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Which execution backends are available? | LLM-API-backed `IManagedAgent` **and** CLI/token-backed agents (`ICLIAgentProvider`). | **Only** LLM-API-backed `IManagedAgent`. CLI/token providers excluded by the 32-4 gate. |
+| Whose credential does a run use? | The sole user's configured key (BYOK) → else platform default. | The tenant's BYOK key (Epic 29 cabinet) → else platform-provided (metered). `CredentialSource` records which. |
+| Where do `AGENT.RUN.*` events land? | The user's (sole) tenant event store; `TenantId` may be null/the implicit user scope. | The tenant's `t_<hex>` event store via the tenant-scoped `IEventRepository`; `TenantId` set. Performance/action data is ALWAYS tenant-scoped, never cross-tenant. |
+| Who owns the run's performance data? | The user. | The tenant — platform admin sees none of it (design spec ownership rule). |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`) — process-stable. | same |
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Loop-extraction drifts behaviour (AC3) | High | Pure move; the existing `CallLlmInlineActivitySanitizationTests` + inline-loop tests are the unchanged regression net; no logic edits during extraction. |
+| A failure path throws and drops the run record (AC7) | High | Wrap each composition step; map exceptions to `AgentRunResult { Success=false }`; assert "exactly one terminal event per run" in tests. |
+| CLI agent leaks into SaaS (AC4) | High | Gate check at step 3 before any provider call; explicit SaaS+CLI test; resolver never returns CLI-backed agent in SaaS. |
+| Cost attribution wrong (BYOK vs platform) | Medium | `CredentialSource` is set by 32-3 and copied verbatim; unit test both branches; never re-derive it here. |
+| Double-counting events when reused activity also emits | Medium | `ManagedAgent` owns `AGENT.RUN.*`; the reused tool-loop seam emits only its existing tool-loop streaming events, not run-level events. |
+| Depends on 32-2/3/4 not yet landed | Medium | Code to the interfaces; gate the story behind those three; use fakes in tests until they land. |
+
+### Success Metrics
+
+- [ ] Every agent-driven workflow step routes through `RunManagedAgentActivity` → `IManagedAgent` (no remaining ad-hoc role→llm-call dispatch for managed agents).
+- [ ] 100% of managed runs produce an `AgentRunResult` and exactly one terminal `AGENT.RUN.*` event (success or failure).
+- [ ] Zero forks of the tool loop / sanitizer / compactor (single source confirmed by grep).
+
+## Related
+
+- Design spec: `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`
+- Implementation plan: `docs/superpowers/plans/2026-06-17-32-5-managed-agent-execution-layer-plan.md`
+- Sibling stories: `docs/stories/epic-32/story-32-2/`, `story-32-3/`, `story-32-4/`, `story-32-6/`, `story-32-8/`, `story-32-9/`
+- Reused code: `apps/tamma-elsa/src/Tamma.Activities/LlmCall/CallLlmInlineActivity.cs`
+
+## Logging Requirements
+
+- **INFO**: managed run started (agentId, version, provider, model, role, correlationId, credentialSource), run completed (success, durationMs, inputTokens, outputTokens, costUsd, toolCalls), gate decision (allow/deny + mode).
+- **DEBUG**: composition step boundaries (resolve → credential → gate → context → prompt → loop → cost), assembled-context size, rendered-prompt token estimate.
+- **WARN**: typed failure paths (budget-exceeded, gate-denied, provider-error, no-credential, loop-exhausted) with `failureCode` + correlationId.
+- **ERROR**: contract violations (null request), DCB event append failure (the run still returns its result; the append failure is logged, not swallowed silently).
+- **Structured context**: include `{ agentId, version, provider, model, role, correlationId, tenantId, credentialSource }` where applicable.
+- **Credential safety**: NEVER log the resolved API key, BaseUrl auth, or raw provider headers. `CredentialSource` (the label) is safe to log; the key is not.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-32/story-32-6/32-6-agent-action-trail-in-tenant-store.md
+++ b/docs/stories/epic-32/story-32-6/32-6-agent-action-trail-in-tenant-store.md
@@ -1,0 +1,334 @@
+# Story 32-6: Agent Action Trail (DCB events tagged agent_id) in Tenant Store
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **tenant owner/member observing my agents**,
+I want every managed agent run, iteration, panel aggregation, and recorded bug captured as DCB events in my own tenant event store — tagged with the agent's identity, config version, role, provider, model, and prompt reference — and queryable as a per-agent action history,
+So that I can audit exactly what each agent did on my work, and so the benchmarking, leaderboard, and learning stories (32-8/32-9/32-10/32-11) have a complete, tenant-isolated data substrate to consume.
+
+## Priority
+
+P0 - The audit/analytics substrate the rest of Epic 32's tracking, benchmarking, and learning stories are built on. Without a captured trail there is nothing to project, leaderboard, or learn from.
+
+## Acceptance Criteria
+
+1. Every managed agent run (`32-5` `IManagedAgent` execution) and every tool-call step within it is recorded as one or more DCB `DomainEvent` rows in the **resolving tenant's** schema (`t_<hex>.domain_events` via `IEventRepository.AppendAsync`), never on the control plane. Each event carries `TenantId` = the resolving tenant.
+2. Event `Type` values follow the `AGGREGATE.ACTION.STATUS` convention and cover these families: `AGENT.TASK.SUCCESS` / `AGENT.TASK.FAILED` / `AGENT.TASK.PARTIAL`, `AGENT.TOOL_CALL.SUCCESS` / `AGENT.TOOL_CALL.FAILED`, `AGENT.ITERATION.COMPLETED`, `AGENT.PANEL.AGGREGATED`, and `REVIEW.BUG.RECORDED`.
+3. Every action-trail event's `Tags` JSONB carries at minimum: `agentId`, `agentVersion`, `role`, `provider`, `model`, `promptRef`, `issueId`, `iteration`, `correlationId`, and `credentialSource` (`byok` | `platform`). Tags are flat string values (DCB tag convention), populated from a shared builder so every emission site is consistent. `REVIEW.BUG.RECORDED` additionally carries `bugType` (`visual` | `functional` | `regression` | `security` | `perf` | `style`).
+4. The trail is **strictly tenant-isolated**: all reads go through `IEventRepository`, which scopes to the ambient/resolving tenant via `ITenantDbContextFactory`; there is **no cross-tenant and no platform-admin read path** for a tenant's action trail. A platform owner (`OwnerAccess`/`PlatformOwnerAccess`) calling the trail API for another tenant gets a 404/403, never that tenant's events. This holds even when the run executed a public/system agent definition — one public agent produces N independent per-tenant trails (per the Epic 32 design spec tenancy rule). Explicitly tested.
+5. A tenant-scoped query API is exposed and is **member-readable** (read = any tenant member; no mutation):
+   - `GET /api/v1/orgs/{tenantId}/agents/{agentId}/runs` — paginated list of runs (one row per `AGENT.TASK.*`) for that agent within that tenant, filterable by `from`/`to` date, `role`, `provider`, and `outcome` (`success` | `failed` | `partial`).
+   - `GET /api/v1/orgs/{tenantId}/agents/{agentId}/trail` — paginated flat stream of all trail events for that agent within that tenant (runs, tool calls, iterations, panels, bugs), same filters plus `type` prefix.
+   - Both use `SequenceNumber` as the stable, total-order pagination cursor (immune to same-millisecond `CreatedAt` collisions), exposing `nextCursor` / `hasMore` on the wire.
+6. Prompt bodies and large blob payloads (full tool input/output, rendered prompt text, RAG context) are **referenced** (`promptRef`, `blobRef`), never inlined into the event stream, to keep `domain_events` lean. Sensitive content is sanitized/redacted (reuse the existing `SecureAgentProvider` / sanitization seam) before any value is persisted to `Tags`/`Data`.
+7. Trail capture is **best-effort-non-blocking** for the agent run: a trail-write failure does **not** abort or fail the run. The failure is itself captured durably — retried via the existing event-append durability path and, on terminal failure, surfaced as an `AGENT.TRAIL.WRITE_FAILED` event (or log + metric) so the gap is observable rather than silent.
+8. `ProviderDiagnostic` rows (cost/latency/tokens, written by `DiagnosticsService`) emitted during an agent run are linked to the trail via `agentId` + `correlationId`, so existing cost/latency aggregation (consumed by 32-9/32-10) can be re-keyed by agent. `ProviderDiagnostic` already carries `CorrelationId` and `AgentType`; this story adds/asserts the `agentId` linkage so a trail event and its diagnostics row share the same `correlationId`.
+9. **Tests**: tenant isolation (tenant B cannot read tenant A's trail through any path; platform admin cannot read either), pagination/cursor correctness (stable order across same-millisecond events, no dupes/skips at page boundaries), redaction (no raw prompt/secret content lands in `Tags`/`Data`), and link integrity (a run's `AGENT.TASK.*` event and its `ProviderDiagnostic` rows share `correlationId` + `agentId`).
+
+## Technical Design
+
+### Where the trail lives (architecture)
+
+The action trail is **DCB events in the tenant's own `domain_events` table** — not a new table, not on the control plane. This is structural isolation: `IEventRepository.AppendAsync` resolves the tenant via `evt.TenantId ?? tenantContext.TenantId` and writes through `ITenantDbContextFactory.CreateAsync(tid)` into the `t_<hex>` schema. There is no code path that writes a tenant-scoped (`TenantId != null`) event anywhere but that tenant's schema, and the read methods (`QueryWithPaginationAsync`, `ListByTenantAsync`) **throw `NotSupportedException` on a null `tenantId`** for paginated/tenant-scoped reads — so a cross-tenant trail read is not merely unauthorized, it is unimplementable through this repository. That property is the backbone of AC 4.
+
+```
+Managed agent run (32-5 IManagedAgent)
+  │
+  ├─ AgentTrailEmitter.RunStarted/StepCompleted/IterationCompleted/...
+  │     → builds DomainEvent { Type, TenantId = resolving tenant, Tags, Metadata, Data }
+  │     → IEventRepository.AppendAsync(evt)            // tenant t_<hex>.domain_events
+  │
+  └─ DiagnosticsService.RecordEventAsync(ProviderDiagnostic { CorrelationId, AgentType, TenantId })
+        → linked to trail by (agentId, correlationId)
+```
+
+### Event schema
+
+All events reuse the existing `Tamma.Data.Entities.DomainEvent` row shape (no schema change):
+`Id`, `Type`, `TenantId`, `IssueNumber`, `Tags` (JSONB), `Metadata` (JSONB), `Data` (JSONB), `CreatedAt`, `SequenceNumber` (server-side `BIGSERIAL`, the cursor).
+
+| Event `Type` | When | Notable `Data` fields (blob-referenced, never inlined) |
+|---|---|---|
+| `AGENT.TASK.SUCCESS` / `.FAILED` / `.PARTIAL` | A managed agent run completes | `durationMs`, `iterations`, `inputTokens`, `outputTokens`, `costUsd`, `outcomeRef` |
+| `AGENT.TOOL_CALL.SUCCESS` / `.FAILED` | One tool invocation in the run's tool loop | `toolName`, `argsRef` (sanitized ref), `resultRef`, `durationMs`, `errorCode?` |
+| `AGENT.ITERATION.COMPLETED` | One design/review iteration of the loop finishes | `iteration`, `gatePassed`, `findingsCount` |
+| `AGENT.PANEL.AGGREGATED` | `AggregatePanelActivity` combines N agent results (32-7) | `strategy` (`single`/`consensus`/`lead+critics`/`llm-judge-merge`), `participantAgentIds`, `chosenAgentId?` |
+| `REVIEW.BUG.RECORDED` | A bug is classified at review/gate (32-8) | `bugType`, `severity`, `descriptionRef` |
+
+**Tags builder (shared, consistent across all sites):**
+
+```csharp
+// src/Tamma.Api/Services/Agents/AgentTrailTags.cs
+public static string Build(AgentTrailContext c) =>
+    JsonSerializer.Serialize(new Dictionary<string, string?>
+    {
+        ["agentId"]          = c.AgentId.ToString(),
+        ["agentVersion"]     = c.AgentVersion.ToString(),
+        ["role"]             = c.Role,
+        ["provider"]         = c.Provider,
+        ["model"]            = c.Model,
+        ["promptRef"]        = c.PromptRef,        // key/version, NOT prompt body
+        ["issueId"]          = c.IssueId,
+        ["iteration"]        = c.Iteration.ToString(),
+        ["correlationId"]    = c.CorrelationId.ToString(),
+        ["credentialSource"] = c.CredentialSource, // "byok" | "platform"
+    });
+```
+
+`Metadata` is the standard DCB envelope (`workflowVersion`, `eventSource = "system"`), mirroring `AgentEndpoints.UpdateConfig`'s existing emission.
+
+### C# emission helper
+
+A thin, injectable emitter keeps every call site uniform and enforces the non-blocking contract (AC 7). It is the single seam 32-5/32-7/32-8 call; it never throws into the run.
+
+```csharp
+// src/Tamma.Api/Services/Agents/IAgentTrailEmitter.cs
+public interface IAgentTrailEmitter
+{
+    Task RunCompletedAsync(AgentTrailContext ctx, AgentRunOutcome outcome, CancellationToken ct = default);
+    Task ToolCallAsync(AgentTrailContext ctx, ToolCallRecord call, CancellationToken ct = default);
+    Task IterationCompletedAsync(AgentTrailContext ctx, IterationRecord it, CancellationToken ct = default);
+    Task PanelAggregatedAsync(AgentTrailContext ctx, PanelRecord panel, CancellationToken ct = default);
+    Task BugRecordedAsync(AgentTrailContext ctx, BugRecord bug, CancellationToken ct = default);
+}
+
+// src/Tamma.Api/Services/Agents/AgentTrailEmitter.cs
+public sealed class AgentTrailEmitter(
+    IEventRepository events,
+    IContentSanitizer sanitizer,   // SecureAgentProvider sanitization seam
+    ILogger<AgentTrailEmitter> logger) : IAgentTrailEmitter
+{
+    public async Task RunCompletedAsync(AgentTrailContext ctx, AgentRunOutcome o, CancellationToken ct = default)
+    {
+        var type = o.Status switch
+        {
+            RunStatus.Success => "AGENT.TASK.SUCCESS",
+            RunStatus.Partial => "AGENT.TASK.PARTIAL",
+            _                 => "AGENT.TASK.FAILED",
+        };
+        await EmitAsync(ctx, type, BuildRunData(o), ct);
+    }
+
+    // Never throws into the run: a trail-write failure is logged, retried by
+    // the durable append path, and on terminal failure emits a best-effort
+    // AGENT.TRAIL.WRITE_FAILED breadcrumb (AC 7).
+    private async Task EmitAsync(AgentTrailContext ctx, string type, object data, CancellationToken ct)
+    {
+        try
+        {
+            await events.AppendAsync(new DomainEvent
+            {
+                Id        = Guid.NewGuid(),
+                Type      = type,
+                TenantId  = ctx.TenantId,                         // resolving tenant — structural isolation
+                IssueNumber = ctx.IssueNumber,
+                Tags      = AgentTrailTags.Build(ctx),
+                Metadata  = StandardMetadata(),
+                Data      = JsonSerializer.Serialize(sanitizer.Redact(data)),
+                CreatedAt = DateTime.UtcNow,
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Agent trail write failed for {Type} agent={AgentId} corr={Corr}",
+                type, ctx.AgentId, ctx.CorrelationId);
+            await TryWriteFailureBreadcrumbAsync(ctx, type, ex, ct); // best-effort, swallows
+        }
+    }
+}
+```
+
+### Query endpoint
+
+The trail read API is a thin projection over `IEventRepository` so isolation is inherited, not re-implemented. Runs = `AGENT.TASK.*` events; trail = all `AGENT.*` / `REVIEW.BUG.*` events for the agent. Both filter by `agentId` (a `Tags` JSONB predicate) within the path tenant, and page on `SequenceNumber`.
+
+```csharp
+// src/Tamma.Api/Endpoints/AgentTrailEndpoints.cs
+
+// GET /api/v1/orgs/{tenantId}/agents/{agentId}/runs
+public static async Task<IResult> ListRuns(
+    HttpContext http, IEventRepository events, ITenantContext tenantContext,
+    Guid tenantId, Guid agentId,
+    DateTimeOffset? from = null, DateTimeOffset? to = null,
+    string? role = null, string? provider = null, string? outcome = null,
+    long? cursor = null, int? limit = null)
+{
+    // tenantId is route-bound and validated by RequireTenantMembershipFilter;
+    // the read is physically scoped by IEventRepository to that tenant's schema.
+    var take = Math.Min(limit is > 0 ? limit.Value : 50, 500);
+    var (rows, total) = await events.QueryAgentTrailAsync(
+        tenantId, agentId, typePrefix: "AGENT.TASK",
+        from, to, role, provider, outcome, cursor, take);
+
+    var items = rows.Select(ToRunDto).ToList();
+    var nextCursor = rows.Count == take ? rows[^1].SequenceNumber : (long?)null;
+    return Results.Ok(new { items, total, nextCursor, hasMore = nextCursor is not null });
+}
+```
+
+`QueryAgentTrailAsync` is a **new** method on `IEventRepository` (mirrors `QueryWithPaginationAsync` but adds the `agentId` Tags predicate + `SequenceNumber` cursor + the trail filters). It throws `NotSupportedException` on a null/empty tenant id — the same hard guard the existing paginated read uses — so AC 4 cannot be bypassed.
+
+```csharp
+// src/Tamma.Data/Repositories/IEventRepository.cs  (additive)
+Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryAgentTrailAsync(
+    Guid tenantId, Guid agentId, string? typePrefix,
+    DateTimeOffset? from, DateTimeOffset? to,
+    string? role, string? provider, string? outcome,
+    long? cursor, int limit);
+```
+
+### Diagnostics linkage (AC 8)
+
+`ProviderDiagnostic` already has `CorrelationId` and `AgentType`. The managed agent run threads one `correlationId` through both the trail emission (`Tags.correlationId`) and every `DiagnosticsService.RecordEventAsync` call in that run, and sets `AgentType` = role. Re-keying by agent for 32-9/32-10 is then a join on `(correlationId, agentId)`. No diagnostics schema change required; if a dedicated `agentId` column is wanted later it is an additive migration, but `correlationId` is sufficient for this story's link-integrity test.
+
+### Route wiring (`Program.cs`)
+
+Both endpoints attach `RequireTenantMembershipFilter` under the existing `/api/v1/orgs/{tenantId}` group (`MemberAccess` policy), exactly like the tenant-scope alert endpoints — read is member-level, there is no mutation surface, and the path-tenant gate plus `IEventRepository` scoping together enforce isolation.
+
+```csharp
+orgs.MapGet("/{tenantId}/agents/{agentId}/runs",  AgentTrailEndpoints.ListRuns)
+    .AddEndpointFilter<RequireTenantMembershipFilter>();
+orgs.MapGet("/{tenantId}/agents/{agentId}/trail", AgentTrailEndpoints.ListTrail)
+    .AddEndpointFilter<RequireTenantMembershipFilter>();
+```
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Trail emission core (AC 1, 2, 3, 6, 7)
+  - [ ] Subtask 1.1: Add `AgentTrailContext`, record types (`AgentRunOutcome`, `ToolCallRecord`, `IterationRecord`, `PanelRecord`, `BugRecord`), and `AgentTrailTags.Build` (shared flat-tag builder)
+  - [ ] Subtask 1.2: Add `IAgentTrailEmitter` + `AgentTrailEmitter`; wire sanitizer (`SecureAgentProvider` seam) so blob/prompt content is referenced + redacted, never inlined
+  - [ ] Subtask 1.3: Enforce non-blocking contract — emit `AGENT.TRAIL.WRITE_FAILED` breadcrumb on terminal write failure; never throw into the run
+  - [ ] Subtask 1.4: Register `IAgentTrailEmitter` in `Program.cs` DI
+- [ ] Task 2: Wire emission into the managed run + panels (AC 1, 2, 8)
+  - [ ] Subtask 2.1: Call `RunCompletedAsync`, `ToolCallAsync`, `IterationCompletedAsync` from the 32-5 `IManagedAgent` execution path (depends on 32-5)
+  - [ ] Subtask 2.2: Call `PanelAggregatedAsync` / `BugRecordedAsync` from the 32-7/32-8 panel + review-gate seams (forward-compatible stubs if those land later)
+  - [ ] Subtask 2.3: Thread one `correlationId` through trail emission and `DiagnosticsService.RecordEventAsync`; set `AgentType` = role
+- [ ] Task 3: Tenant-scoped query API (AC 4, 5)
+  - [ ] Subtask 3.1: Add `IEventRepository.QueryAgentTrailAsync` (agentId Tags predicate + `SequenceNumber` cursor + filters; `NotSupportedException` on null tenant)
+  - [ ] Subtask 3.2: Add `AgentTrailEndpoints.ListRuns` / `ListTrail`; map under `/api/v1/orgs/{tenantId}` with `RequireTenantMembershipFilter`
+  - [ ] Subtask 3.3: Add run/trail DTOs + cursor (`nextCursor`/`hasMore`) wire shape
+- [ ] Task 4: Tests (AC 9)
+  - [ ] Subtask 4.1: Tenant isolation — tenant B 404 on tenant A's agent trail; platform admin no read path; public-agent run produces only the running tenant's trail
+  - [ ] Subtask 4.2: Pagination/cursor — stable order across same-millisecond events, no dup/skip across page boundaries
+  - [ ] Subtask 4.3: Redaction — no raw prompt/secret in `Tags`/`Data`; blob refs only
+  - [ ] Subtask 4.4: Link integrity — `AGENT.TASK.*` event + `ProviderDiagnostic` share `correlationId` + `agentId`
+  - [ ] Subtask 4.5: Non-blocking — induced append failure does not fail the run; breadcrumb emitted
+
+## Dependencies
+
+**Internal Dependencies:**
+
+- **Story 32-1** (Agent entity model & versioned saved config): supplies the immutable `agentId` + `agentVersion` that every trail event is tagged with. The `Agent`/`AgentVersion` entity does **not** exist yet (`apps/tamma-elsa/src/Tamma.Data/Entities/Agent.cs` is NEW in 32-1) — until it lands, `agentId`/`agentVersion` come from the resolved config identity. Hard prerequisite.
+- **Story 32-5** (Managed agent execution layer): the `IManagedAgent` run is the producer that calls `IAgentTrailEmitter`. Hard prerequisite for the wiring in Task 2.
+- **Story 32-3** (per-tenant provider credential resolution): supplies `credentialSource` (`byok` | `platform`) for the tag. Soft — default to `platform` if 32-3 not yet wired.
+- **Story 32-7 / 32-8** (panels / outcome + bug taxonomy): consume `PanelAggregatedAsync` / `BugRecordedAsync`. Forward-compatible; this story ships the emitter API even if those sites are stubbed.
+- **Epic 4** (DCB event store): provides `DomainEvent`, `IEventRepository`, and the `SequenceNumber` cursor — all reused, no new event infrastructure.
+- **Epic 17/28** (tenant-scoped event store): `IEventRepository` already routes through `ITenantDbContextFactory` / `ITenantContext` per the unified schema-per-tenant model — the trail lands in `t_<hex>` structurally with no new tenancy plumbing.
+
+**External Dependencies:**
+
+- None new. Reuses EF Core 9 / Npgsql, the existing event store, `DiagnosticsService`, and the `SecureAgentProvider` sanitization seam.
+
+## Testing Strategy
+
+1. **Tenant-isolation tests (highest priority — AC 4):** seed agent-trail events for tenant A and tenant B; assert `GET /api/v1/orgs/{B}/agents/{agentId}/trail` returns only B's rows and never A's; assert a member of A hitting B's path is rejected by `RequireTenantMembershipFilter` (403/404); assert there is no `IEventRepository` code path that returns another tenant's events (null-tenant paginated read throws `NotSupportedException`); assert a run of a public/system agent by tenant A leaves a trail only in A's schema, none on the CP and none visible to a platform owner.
+2. **Pagination/cursor tests (AC 5):** insert >page-size events including several sharing the same `CreatedAt` millisecond; page with `SequenceNumber` cursor; assert total-order stability, exact page sizes, `nextCursor`/`hasMore` correctness, and zero duplicate/skipped rows at boundaries.
+3. **Redaction tests (AC 6):** emit a run whose prompt/tool args contain secret-shaped content; assert `Tags` and `Data` contain only `promptRef`/`blobRef` and sanitized values — no raw prompt body or secret material persisted.
+4. **Link-integrity tests (AC 8):** run a managed agent that records both a trail event and `ProviderDiagnostic` rows; assert they share `correlationId` and resolve to the same `agentId`; assert re-keying diagnostics by agent yields the expected cost/latency rollup.
+5. **Non-blocking tests (AC 7):** inject an `IEventRepository.AppendAsync` failure; assert the agent run still completes (no exception propagates), and an `AGENT.TRAIL.WRITE_FAILED` breadcrumb / WARN log + metric is produced.
+6. **Tag-completeness tests (AC 3):** every emitted event family carries all required tag keys; `REVIEW.BUG.RECORDED` carries a valid `bugType`.
+
+Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/`; docker-bound suites run via `sg docker -c "dotnet test ..."`. TDD: write the isolation + cursor tests first.
+
+## Estimated Effort
+
+4-5 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/IAgentTrailEmitter.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentTrailEmitter.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentTrailTags.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentTrailContext.cs` | Create (records: context + run/tool/iteration/panel/bug) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentTrailEventTypes.cs` | Create (the `AGENT.*` / `REVIEW.BUG.RECORDED` type constants) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentTrailEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/AgentTrailDtos.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/IEventRepository.cs` | Modify (add `QueryAgentTrailAsync`) |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/EventRepository.cs` | Modify (implement `QueryAgentTrailAsync`; null-tenant guard) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (DI for `IAgentTrailEmitter`; map `/orgs/{tenantId}/agents/{agentId}/runs` + `/trail`) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Diagnostics/DiagnosticsService.cs` | Modify (assert/thread `correlationId` + `AgentType` on agent-run diagnostics) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentTrailEmitterTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentTrailIsolationTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentTrailEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentTrailDiagnosticsLinkTests.cs` | Create |
+
+> Note: `apps/tamma-elsa/src/Tamma.Data/Entities/DomainEvent.cs` and `ProviderDiagnostic.cs` are **referenced, not modified** — the trail reuses the existing DCB row shape and diagnostics entity. (`packages/api` is deleted; all work is in the C# `apps/tamma-elsa` stack.)
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` directory for related spikes, bugs, findings, and decisions — especially `.dev/decisions/story-28-1-design-calls.md` (Decision #2: cross-tenant read routing, which this story depends on for isolation)
+3. Reviewed the Epic 32 design spec `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md` (the tenancy rule: definition ownership ≠ data ownership; action data is ALWAYS tenant-scoped)
+4. Read `EventRepository.cs` to understand exactly how tenant scoping and the `NotSupportedException` guards work — they ARE the isolation guarantee
+5. Planned TDD approach (Red-Green-Refactor cycle) — isolation + cursor tests first
+
+### Key Design Decisions
+
+- **No new table.** The trail is DCB events in the tenant's `domain_events` stream. Isolation is structural (schema-per-tenant + `ITenantDbContextFactory`), not enforced by an app-level filter that could be bypassed by a future bug. This is the cheapest correct design and it inherits Epic 4/28 guarantees.
+- **`SequenceNumber` is the cursor, never `Id` or `CreatedAt`.** `CreatedAt` has millisecond collisions; `SequenceNumber` is a server-side `BIGSERIAL` total order. The existing `QueryWithPaginationAsync` already tie-breaks on it — match that.
+- **Tags carry identity; Data carries metrics + refs.** Per the DCB convention (`AGENT_CONFIG.UPDATED.SUCCESS` precedent in `AgentEndpoints.cs`), `Tags` are flat strings used for cross-aggregate queries (`agentId`, `provider`, …); `Data` is the richer payload, always blob-referenced for large/sensitive content.
+- **Emitter is the single seam.** 32-5/32-7/32-8 never build a `DomainEvent` by hand — they call `IAgentTrailEmitter`. One place enforces tag completeness, redaction, and the non-blocking contract.
+- **Platform admin has no read path by construction.** There is no `OwnerAccess`/`PlatformOwnerAccess` route for a tenant's trail, and `IEventRepository` cannot return cross-tenant tenant-scoped events. A platform owner who owns a public agent definition sees zero of any tenant's runs of it — exactly the Epic 32 tenancy rule.
+
+### Integration Points
+
+- **32-5 managed run** is the primary producer; the emitter is injected into the run loop.
+- **`DiagnosticsService`** is the cost/latency producer; trail ↔ diagnostics link is `correlationId` + `agentId`. 32-9/32-10 re-key off this.
+- **`SecureAgentProvider` / sanitization** is reused for redaction before persistence — no new sanitizer.
+- **`RequireTenantMembershipFilter` + `/api/v1/orgs/{tenantId}` group** is the existing tenant path-gate; the trail API rides it like the tenant-scope alert endpoints.
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+| ---- | --------- | ---------- |
+| Cross-tenant leakage of action data | Critical | Reads only via `IEventRepository` (schema-per-tenant scoped); null-tenant paginated read throws; route behind `RequireTenantMembershipFilter`; explicit isolation tests including platform-admin-denied |
+| Trail write failure aborts a real agent run | High | Emitter swallows + retries + breadcrumbs; non-blocking test induces failure and asserts run completes |
+| Sensitive prompt/tool content persisted into events | High | `promptRef`/`blobRef` only + `SecureAgentProvider` redaction before persistence; redaction test |
+| Pagination dup/skip on same-millisecond bursts | Medium | `SequenceNumber` cursor (not `CreatedAt`); boundary test |
+| `agentId`/`agentVersion` unavailable before 32-1 lands | Medium | Source from resolved config identity until the entity ships; treat 32-1 as a hard prerequisite |
+
+### Success Metrics
+
+- [ ] 100% of managed agent runs produce a terminal `AGENT.TASK.*` event in the correct tenant schema
+- [ ] 0 cross-tenant trail reads possible (verified by isolation test suite)
+- [ ] Every trail event carries all required tags; `REVIEW.BUG.RECORDED` carries a valid `bugType`
+- [ ] Trail-write failures never fail an agent run (non-blocking test green)
+
+## Logging Requirements
+
+- **INFO**: agent run trail finalized (`agentId`, `correlationId`, outcome, event count); trail query served (`tenantId`, `agentId`, page size, total)
+- **DEBUG**: individual trail event appended (`type`, `agentId`, `sequenceNumber`); diagnostics row linked (`correlationId`)
+- **WARN**: trail write failed/retried (`type`, `agentId`, `correlationId`, error); `AGENT.TRAIL.WRITE_FAILED` breadcrumb emitted
+- **ERROR**: terminal trail-write failure after retries (run still completes); query repository failure
+- **Structured context**: include `{ tenantId, agentId, agentVersion, correlationId, type, sequenceNumber }` where applicable
+- **Credential safety**: NEVER log raw prompts, tool args/results, or secret material — log refs only; redaction is applied before any persistence or log
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-32/story-32-7/32-7-multi-agent-design-review-panels-in-elsa.md
+++ b/docs/stories/epic-32/story-32-7/32-7-multi-agent-design-review-panels-in-elsa.md
@@ -1,0 +1,353 @@
+# Story 32-7: Multi-Agent Design/Review Panels in Elsa (strategy-driven)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **workflow author building design and review steps**,
+I want reusable, strategy-driven multi-agent panel primitives (`RunAgentPanelActivity` + `AggregatePanelActivity`) that fan a step out to N agents of a role and combine their outputs under a selectable strategy (`single`, `consensus`, `lead+critics`, `llm-judge`),
+So that design/review steps are no longer hardcoded per-role sequences, every panel member is a first-class benchmarkable agent, and the panel result plus per-member action-trail entries are captured for audit and learning.
+
+## Priority
+
+P1 - Generalizes the hardcoded triage/plan review panels into the reusable primitive the rest of Epic 32's benchmarking, leaderboards, and learning loop depend on.
+
+## Context
+
+Today two workflows hardcode their panels:
+
+- **`TriagePanelReviewWorkflow`** (`apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TriagePanelReviewWorkflow.cs`) — a fixed 4-role **sequential** panel (security → developer → devops → tester). Each role is a `DispatchWorkflow` to the `llm-call` workflow with a role-specific triage action (`RolePhaseMap.GetTriageActionForRole`), then a `SetVariable` extracts the role's JSON from `llmResult["llmResponse"]`, and a final `Aggregate` `SetVariable` concatenates the four reviews into `{ reviews[], reviewCount }`. There is **no strategy** — aggregation is a dumb merge — and **no per-member agent identity**: the "panel members" are anonymous role strings, so nothing can be benchmarked.
+- **`PlanReviewWorkflow`** (`.../Workflows/PlanReviewWorkflow.cs`) — a richer 7-role sequential debate (independent review → anonymized rebuttal round → PO decision, looping to `maxRounds`). Same shape: per-role `DispatchWorkflow("llm-call")` + extract + `StoreRoleFindingActivity`, with a bespoke early-termination consensus check (`allRebuttalApproved`) baked into the flowchart.
+
+Both are sequential, role-hardcoded, and re-implement aggregation by hand. This story extracts the panel-fan-out and the aggregation into two reusable Elsa activities under a new `AggregatePanelStrategy` interface, makes every panel member a resolved first-class **Agent** (32-1/32-2) executed through the managed-agent layer (`IManagedAgent`, 32-5), emits per-member action-trail entries (32-6) and a single `AGENT.PANEL.AGGREGATED` event, and refactors both existing workflows onto the primitives with golden-output parity.
+
+The design spec for the epic is `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md` (§ "Multi-agent design/review steps"). It pins the defaults: **`lead+critics` for design steps, `consensus` for review steps**, with specialized **security / performance / visual** reviewers, and a workflow `iteration_count` loop until gates pass or max iterations.
+
+## Acceptance Criteria
+
+1. **`RunAgentPanelActivity` fans out to N agents of a role.** A new Elsa activity at `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/RunAgentPanelActivity.cs` accepts a panel definition — an ordered list of members `{ agentId? , role, weight, position: lead|critic|member }` plus a `PanelStrategy` and panel-level inputs (`variables`, `enableTools`) — resolves each member to an `IManagedAgent` (32-5) and executes the members, **parallel where the strategy permits** (single/consensus/llm-judge run members concurrently; `lead+critics` runs the lead first, then critics in parallel). It collects per-member `AgentRunResult`s into an ordered `PanelMemberResult[]` (member position, agentId, role, raw output, parsed verdict/score, token + cost basis, latency, success flag).
+
+2. **`AggregatePanelActivity` implements four strategies.** A new Elsa activity at `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/AggregatePanelActivity.cs` takes the `PanelMemberResult[]` and a `PanelStrategy` and produces a single `PanelAggregateResult` via the `IAggregatePanelStrategy` seam:
+   - **`single`** — passthrough of the sole (or first/lead) member's output; no combination.
+   - **`consensus`** — majority/weighted vote over member verdicts with a deterministic tie-break (highest summed weight wins; on a weight tie, the earliest member position wins). Records the vote tally and the winning verdict.
+   - **`lead+critics`** — the lead's proposal is fed back with the critics' annotations to the lead for one revision pass; the revised lead output is the aggregate. (This is the **design** default.)
+   - **`llm-judge`** — a designated **judge agent** (a configured member with `position: judge`, or a panel-level `judgeAgentId`) scores/selects among member outputs and emits a winner + rationale. The judge's rationale is **sanitized** before being recorded to the trail.
+   Each strategy is a separate `IAggregatePanelStrategy` implementation, unit-tested with **deterministic fixtures** (no live LLM).
+
+3. **Strategy defaults match the design spec.** When a panel definition omits a strategy, **design panels default to `lead+critics`** and **review panels default to `consensus`**, per `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`.
+
+4. **Design step + review step are expressible on the primitives.** A design step fans architect agents out under `lead+critics` and aggregates to a chosen/synthesized design. A review step fans reviewer agents — including specialized **security**, **performance**, and **visual** reviewers — out under `consensus` and aggregates to a verdict plus classified findings. Both are demonstrated by a `PanelStepWorkflow` (or equivalent composable sub-workflow) wired from the primitives.
+
+5. **Iteration loop until gates pass or max.** The panel-bearing workflow tracks an `iterationCount` and loops the design→review cycle until review gates pass (consensus verdict `approve` / no blocking findings) or `maxIterations` is reached; every iteration emits `AGENT.ITERATION.COMPLETED` (consumed downstream by 32-8/32-10). On max-iterations-without-pass the workflow escalates (mirrors `PlanReviewWorkflow`'s `forceNeedsHuman`).
+
+6. **Per-member action-trail entries.** Each panel member run produces its own action-trail entry (32-6) tagged with `panelId` + `memberPosition` (+ `agentId`, config version, role, provider, model, prompt key/version, `issueId`, `iteration`). The aggregate produces a single **`AGENT.PANEL.AGGREGATED`** DCB event carrying the chosen strategy, the winner/consensus metadata (vote tally or judge winner + sanitized rationale), member count, and aggregate token/cost basis.
+
+7. **Existing workflows refactored without regression.** `TriagePanelReviewWorkflow` and `PlanReviewWorkflow` are refactored to use `RunAgentPanelActivity` + `AggregatePanelActivity` instead of their hardcoded per-role `DispatchWorkflow` sequences. A **golden-output test** asserts the refactored workflows produce byte-equivalent `panelResultJson` / `decision`+`discussionLog` output for fixed (mocked) member outputs — no behavior regression. The legacy hardcoded per-role helpers are removed once parity is proven; the workflow `DefinitionId`s (`triage-panel-review`, `plan-review`) and their input/output contracts are unchanged so callers (`TriageItemCycleWorkflow`, etc.) need no edits.
+
+8. **Visibility + SaaS provider gating per member.** Panel definitions are persisted as part of an agent or workflow config and respect public/private agent visibility (32-1/32-2). When resolving members, an **ineligible member is gated**: in SaaS, members backed by `ICLIAgentProvider`/token providers are rejected (API-key-only path, per spec §"Provider credential & auth model"), and a member whose agent is not visible to the executing tenant is excluded. Gating an ineligible member never crashes the panel — it is dropped with a recorded `AGENT.PANEL.MEMBER_GATED` trail note, and the panel proceeds if a quorum remains (else fails loud).
+
+9. **Tenant-scoped execution + per-tenant credentials/budgets.** Panels execute tenant-scoped; each member resolves credentials via the per-tenant resolution order (BYOK → platform, 32-3) and is subject to per-tenant budget clamps. Member token/cost is attributed to the executing tenant. A panel that would breach the tenant budget stops adding members and aggregates over what completed (recorded in the aggregate event).
+
+10. **Tests.** Unit tests cover: each strategy's aggregation correctness with deterministic fixtures (`single` passthrough, `consensus` majority + weighted + tie-break, `lead+critics` revision, `llm-judge` selection + sanitized rationale); parallel member execution (members invoked concurrently; results ordered deterministically by position regardless of completion order); SaaS gating of an ineligible member (CLI-backed / not-visible) with quorum behavior; budget-clamp early stop; and refactor parity (golden output) for both `TriagePanelReviewWorkflow` and `PlanReviewWorkflow`.
+
+## Technical Design
+
+### New components
+
+```
+apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/
+  RunAgentPanelActivity.cs            # Elsa activity: fan out members → IManagedAgent
+  AggregatePanelActivity.cs           # Elsa activity: combine results under a strategy
+  Panels/
+    PanelStrategy.cs                  # enum: Single | Consensus | LeadCritics | LlmJudge
+    PanelMember.cs                    # record: AgentId?, Role, Weight, Position
+    PanelMemberPosition.cs            # enum: Lead | Critic | Member | Judge
+    PanelDefinition.cs               # record: Members[], Strategy?, JudgeAgentId?, MaxIterations
+    PanelMemberResult.cs              # per-member run result (output, verdict, tokens, cost, latency)
+    PanelAggregateResult.cs           # aggregate: Strategy, WinnerVerdict, Tally, Rationale, Members
+    IAggregatePanelStrategy.cs        # strategy seam
+    SinglePanelStrategy.cs
+    ConsensusPanelStrategy.cs
+    LeadCriticsPanelStrategy.cs
+    LlmJudgePanelStrategy.cs
+    PanelStrategyFactory.cs           # PanelStrategy → IAggregatePanelStrategy
+    PanelEventTypes.cs                # AGENT.PANEL.AGGREGATED, AGENT.PANEL.MEMBER_GATED
+
+apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/
+  PanelStepWorkflow.cs               # composable design/review step over the primitives (AC4/AC5)
+```
+
+### Strategy interface (C#)
+
+```csharp
+// IAggregatePanelStrategy.cs — pure, deterministic, no live LLM in the aggregation step
+// (LeadCritics / LlmJudge perform their LLM call BEFORE aggregation, via RunAgentPanelActivity's
+//  revision/judge member, so this seam stays unit-testable with fixtures).
+public interface IAggregatePanelStrategy
+{
+    PanelStrategy Strategy { get; }
+
+    /// <summary>Combine ordered per-member results into a single aggregate verdict/output.</summary>
+    PanelAggregateResult Aggregate(PanelDefinition definition, IReadOnlyList<PanelMemberResult> members);
+}
+
+public sealed record PanelMember(
+    string? AgentId,                  // null ⇒ resolve the tenant's default agent for Role
+    AgentRole Role,
+    double Weight = 1.0,
+    PanelMemberPosition Position = PanelMemberPosition.Member);
+
+public sealed record PanelMemberResult(
+    int Index,
+    PanelMemberPosition Position,
+    string? AgentId,
+    AgentRole Role,
+    string RawOutput,
+    string? ParsedVerdict,            // e.g. "approve" | "concerns" | "reject"
+    double? Score,                    // for llm-judge / weighted strategies
+    int PromptTokens,
+    int CompletionTokens,
+    long LatencyMs,
+    bool Success);
+
+public sealed record PanelAggregateResult(
+    PanelStrategy Strategy,
+    string WinnerVerdict,
+    IReadOnlyDictionary<string, double> Tally,   // verdict → summed weight (consensus)
+    string? Rationale,                            // sanitized judge rationale (llm-judge)
+    int? WinnerIndex,                             // selected member (single / llm-judge)
+    IReadOnlyList<PanelMemberResult> Members,
+    int TotalPromptTokens,
+    int TotalCompletionTokens);
+```
+
+### `RunAgentPanelActivity` (Elsa activity signature)
+
+Follows the existing `CallLlmActivity` pattern (`[Activity(...)]` + `[FlowNode(...)]`, `Input<T>` properties, `[JsonConstructor]` + DI ctor, `CompleteActivityWithOutcomesAsync`). Extends the `Tamma.Activities.AgentDispatch` namespace where the existing dispatch activities live.
+
+```csharp
+[Activity("Tamma.RunAgentPanel", "Run Agent Panel",
+    "Fan a step out to N agents of a role and collect per-member results", Kind = ActivityKind.Task)]
+[FlowNode("Done", "Gated", "Failed")]
+public class RunAgentPanelActivity : Activity   // outcomes ⇒ Activity, not CodeActivity
+{
+    [Input(Description = "Panel definition (members, strategy, judge, max iterations) as JSON", UIHint = "json-editor")]
+    public Input<string> PanelDefinitionJson { get; set; } = default!;
+
+    [Input(Description = "Panel-level variables passed to each member's prompt")]
+    public Input<IDictionary<string, object>> Variables { get; set; } = default!;
+
+    [Input(Description = "Enable tools for members", DefaultValue = true)]
+    public Input<bool> EnableTools { get; set; } = new(true);
+
+    [Input(Description = "Panel id (stable across iterations for trail correlation)")]
+    public Input<string> PanelId { get; set; } = default!;
+
+    [Input(Description = "Iteration number (1-based)", DefaultValue = 1)]
+    public Input<int> Iteration { get; set; } = new(1);
+
+    [Output(Description = "Ordered per-member results (JSON: PanelMemberResult[])")]
+    public Output<string> MemberResultsJson { get; set; } = default!;
+
+    // ctor: ILogger, IManagedAgentResolver (32-5), IAgentRegistry (32-2),
+    //       ITenantContextAccessor, ICredentialResolver (32-3), IContentSanitizer, IBudgetGuard
+}
+```
+
+Execution: parse definition → for each member, **gate** (visibility + SaaS provider class + budget) → resolve `IManagedAgent` → run concurrently (`Task.WhenAll`, except `lead+critics` which sequences lead before critics) → order results by member index → emit a per-member action-trail entry (32-6) tagged `panelId`+`memberPosition`+`iteration` → set `MemberResultsJson`. Outcome `Gated` if quorum lost, `Failed` on hard error, else `Done`.
+
+### `AggregatePanelActivity` (Elsa activity signature)
+
+```csharp
+[Activity("Tamma.AggregatePanel", "Aggregate Panel",
+    "Combine per-member results under a selectable strategy", Kind = ActivityKind.Task)]
+[FlowNode("Aggregated")]
+public class AggregatePanelActivity : Activity
+{
+    [Input] public Input<string> MemberResultsJson { get; set; } = default!;
+    [Input] public Input<string> PanelDefinitionJson { get; set; } = default!;
+    [Input] public Input<string> PanelId { get; set; } = default!;
+    [Input(DefaultValue = 1)] public Input<int> Iteration { get; set; } = new(1);
+
+    [Output(Description = "Aggregate result (JSON: PanelAggregateResult)")]
+    public Output<string> AggregateJson { get; set; } = default!;
+
+    // ctor: ILogger, PanelStrategyFactory, IContentSanitizer, IEventEmitter
+}
+```
+
+Execution: parse member results + definition → resolve strategy default (design ⇒ `lead+critics`, review ⇒ `consensus`) → `factory.Get(strategy).Aggregate(def, members)` → sanitize judge rationale → emit `AGENT.PANEL.AGGREGATED` with strategy + winner/tally/rationale + token totals → set `AggregateJson`.
+
+### DCB events
+
+Event-type pattern is `AGGREGATE.ACTION.STATUS` (CLAUDE.md). Events are composed via the existing `TammaEvent` model and flushed through the same path the activities already use (`TammaEventEmitter` → `tamma:events` transient property; per the action-trail story 32-6 these are durably appended to the **tenant** event store).
+
+| Event | When | Tags |
+|---|---|---|
+| `AGENT.PANEL.AGGREGATED` | aggregation completes | `panelId`, `strategy`, `winnerVerdict`, `iteration`, `tenantId`, `mode`, `memberCount` |
+| `AGENT.PANEL.MEMBER_GATED` | a member is dropped (visibility / SaaS provider class / budget) | `panelId`, `agentId`, `role`, `reason`, `tenantId` |
+| `AGENT.ITERATION.COMPLETED` | each design→review loop iteration (AC5) | `panelId`, `iteration`, `gatesPassed` |
+
+Per-member `AGENT.TASK.*` action-trail entries are emitted by the managed-agent layer (32-5) / action trail (32-6); this story adds the `panelId` + `memberPosition` tags to them.
+
+### Wiring into existing workflows (refactor)
+
+- **`TriagePanelReviewWorkflow`**: replace the four `RoleTriageDispatch` + `ExtractTriageReview` pairs and the `Aggregate` `SetVariable` with one `RunAgentPanelActivity` (members = security/developer/devops/tester, strategy `consensus`) → `AggregatePanelActivity` → map `AggregateJson` into the unchanged `panelResultJson` output shape (`{ reviews[], reviewCount }`) via a thin adapter `SetVariable`. `DefinitionId` `triage-panel-review` and inputs (`repository`, `itemJson`, `contextJson`) / output (`panelResultJson`) stay identical.
+- **`PlanReviewWorkflow`**: replace the Phase-1 7-role review fan and the Phase-2 rebuttal fan with `RunAgentPanelActivity`; the early-termination `allRebuttalApproved` check becomes the `consensus` strategy verdict; Phase-3 PO decision stays as-is (it is a single agent, not a panel). `StoreRoleFindingActivity` per-role persistence is preserved by emitting the per-member trail entries. `DefinitionId` `plan-review` + all inputs/outputs (`decision`, `planJson`, `reviewNotes`, `discussionLog`, ...) unchanged.
+- Both workflows auto-register via the existing assembly scan (`elsa.AddWorkflowsFrom<LlmCallWorkflow>()` in `apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs:118`); no registration edits needed for the new `PanelStepWorkflow` beyond it living in the same assembly.
+
+### Role→action helpers
+
+`RolePhaseMap` already exposes `GetReviewActionForRole` and `GetTriageActionForRole`. A small new `GetDesignActionForRole` helper (architect ⇒ `plan-system-design`, etc.) is added to `apps/tamma-elsa/src/Tamma.Core/Agents/RolePhaseMap.cs` for the design-step panel (the design actions `PlanSystemDesign`/`DesignApiContract`/… already exist in `AgentAction.cs`).
+
+## Dependencies
+
+**Internal:**
+
+- **Story 32-1** (Agent entity model & versioned saved config) — panel members reference first-class `agentId`s; member results tag `agentId` + config version. *(Story dir `docs/stories/epic-32/story-32-1/` is a placeholder at drafting time.)*
+- **Story 32-2** (Agent registry, resolution & RBAC API) — `IAgentRegistry` resolves a member's `agentId` (or the tenant's default agent for a role) and enforces public/private visibility.
+- **Story 32-5** (Managed agent execution layer, `IManagedAgent` over `ILLMProvider`) — the execution seam each member runs through; `IManagedAgentResolver` returns an `IManagedAgent`. **Hard prerequisite.**
+- **Story 32-6** (Agent action trail, DCB events tagged `agent_id`) — per-member trail entries; this story adds `panelId` + `memberPosition` tags. **Hard prerequisite.**
+- **Story 32-3** (Per-tenant provider credential resolution, BYOK → platform) — member credential/budget resolution at execution (AC9).
+- **Story 32-4** (SaaS provider auth gating — API-key only) — the SaaS member-gating rule in AC8.
+- **Epic 9** (unified agent API) — the agent-resolution contract the panel primitives consume to treat LLM-backed and CLI-backed agents identically (SaaS exposes LLM-API path only).
+
+**External / platform:**
+
+- Elsa Workflows activity model (`Activity`, `[Activity]`, `[FlowNode]`, `CompleteActivityWithOutcomesAsync`) — existing in `apps/tamma-elsa`.
+- No new NuGet packages anticipated.
+
+**Supersedes:** the hardcoded `TriagePanelReviewWorkflow` panel logic (and the per-role fan in `PlanReviewWorkflow`).
+
+## Testing Strategy
+
+1. **Strategy unit tests** (`tests/Tamma.Activities.Tests/AgentDispatch/Panels/`): one fixture file per strategy.
+   - `single` — N=1 passthrough; N>1 returns the lead/first member; verdict + winnerIndex correct.
+   - `consensus` — majority over `{approve, approve, concerns}` ⇒ approve; weighted vote where a high-weight member flips the result; **tie-break** (`{approve:1.0, reject:1.0}` ⇒ earliest position wins); tally recorded.
+   - `lead+critics` — lead proposal + critic annotations ⇒ revised lead output is the aggregate (revision member's output is fed in as a fixture).
+   - `llm-judge` — judge fixture selects member 2 with a rationale; rationale is **sanitized** (HTML/zero-width stripped) before it lands in `PanelAggregateResult.Rationale`.
+2. **Parallel execution test**: stub `IManagedAgent`s with staggered delays; assert members run concurrently (wall-clock < sum of delays) and that `PanelMemberResult[]` is ordered by member index regardless of completion order.
+3. **Gating tests** (SaaS mode via `ITammaModeProvider`): a CLI/token-backed member ⇒ gated with `AGENT.PANEL.MEMBER_GATED`; a not-visible-to-tenant agent ⇒ gated; quorum-lost ⇒ outcome `Gated`; quorum-retained ⇒ panel proceeds.
+4. **Budget-clamp test**: budget exhausted mid-fan ⇒ remaining members skipped, aggregate computed over completed members, recorded in the event.
+5. **Refactor parity (golden output)**: drive `TriagePanelReviewWorkflow` and `PlanReviewWorkflow` with mocked member outputs; assert `panelResultJson` and `decision`+`discussionLog` match the captured pre-refactor golden fixtures byte-for-byte.
+6. **Tenancy isolation**: member runs and trail entries carry the executing tenant id; no cross-tenant leakage (assert against the per-tenant event store).
+
+Run C# tests in `apps/tamma-elsa` per the repo convention: `sg docker -c "dotnet test ..."` for docker-bound suites (the build itself needs no wrapper).
+
+## Estimated Effort
+
+5-6 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/RunAgentPanelActivity.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/AggregatePanelActivity.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/Panels/PanelStrategy.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/Panels/PanelMember.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/Panels/PanelMemberPosition.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/Panels/PanelDefinition.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/Panels/PanelMemberResult.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/Panels/PanelAggregateResult.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/Panels/IAggregatePanelStrategy.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/Panels/SinglePanelStrategy.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/Panels/ConsensusPanelStrategy.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/Panels/LeadCriticsPanelStrategy.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/Panels/LlmJudgePanelStrategy.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/Panels/PanelStrategyFactory.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/Panels/PanelEventTypes.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/PanelStepWorkflow.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Core/Agents/RolePhaseMap.cs` | Modify (add `GetDesignActionForRole`) |
+| `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TriagePanelReviewWorkflow.cs` | Modify (refactor onto primitives) |
+| `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/PlanReviewWorkflow.cs` | Modify (refactor onto primitives) |
+| `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/AgentDispatchServiceCollectionExtensions.cs` | Modify or Create (register strategies + factory in DI) |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/AgentDispatch/Panels/SinglePanelStrategyTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/AgentDispatch/Panels/ConsensusPanelStrategyTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/AgentDispatch/Panels/LeadCriticsPanelStrategyTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/AgentDispatch/Panels/LlmJudgePanelStrategyTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/AgentDispatch/RunAgentPanelActivityTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/AgentDispatch/AggregatePanelActivityTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.ElsaServer.Tests/Workflows/TriagePanelReviewParityTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.ElsaServer.Tests/Workflows/PlanReviewParityTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` directory for related spikes, bugs, findings, and decisions
+3. Read the verified current panels: `TriagePanelReviewWorkflow.cs` (hardcoded 4-role sequential) and `PlanReviewWorkflow.cs` (7-role debate) — the refactor must preserve their input/output contracts
+4. Read the epic design spec `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md` (defaults: design ⇒ `lead+critics`, review ⇒ `consensus`)
+5. Confirmed 32-5 (`IManagedAgent`) and 32-6 (action trail) are landed — they are hard prerequisites; if stubbed, build against their interfaces and gate execution behind a feature flag
+
+### Key Design Decisions
+
+- **Aggregation is pure; LLM happens in the fan-out.** `lead+critics` revision and `llm-judge` selection both require an LLM call, but that call is performed by `RunAgentPanelActivity` as a designated member (the lead's revision pass, or the judge member), so `IAggregatePanelStrategy.Aggregate` stays a deterministic, fixture-testable function. This is what makes AC2's "deterministic fixtures" achievable.
+- **Two activities, not one.** Splitting fan-out from aggregation mirrors the existing `Dispatch* → Collect*` pattern in `AgentDispatch/` and keeps each unit-testable; it also lets a workflow re-aggregate captured member results under a different strategy without re-running the (expensive) members.
+- **Members are agents, not roles.** A member references an `agentId` (32-1) so its run is benchmarkable per-tenant (one definition → many per-tenant datasets, per the spec). A null `agentId` resolves the tenant's default agent for the role — this is the bridge that lets the refactored triage/plan workflows keep their role-only definitions.
+- **`tenant → system → error` resolution stays.** Prompt/convention resolution inside each member is unchanged (members run through 32-5 which uses the existing prompt store); panels add no fallback layer (`feedback_resolution_no_empty_fallback`).
+- **Gating is soft per member, hard per quorum.** A single ineligible member is dropped (trail note), not fatal; the panel only fails when quorum can't be met — this keeps a public agent that a tenant can't run from breaking the whole step.
+
+### Per-mode ownership (two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns a **panel definition**? | The sole user (private) or it's a shipped/system definition. | Public definitions: platform owner. Private: tenant owner/admin (32-2 RBAC). |
+| Which members can a principal run? | All shipped + the user's private agents; CLI/token providers allowed. | Public ∪ tenant-private agents; **LLM-API path only** — CLI/token-backed members gated (AC8). |
+| Whose credentials/budget does a member use? | The user's. | The tenant's, BYOK → platform (32-3); cost attributed to the tenant. |
+| Where do panel events land? | The user's (only) feed/store. | The executing tenant's event store (tenant-scoped); `AGENT.PANEL.AGGREGATED` tagged `tenantId`. |
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Panel multiplies token spend (N members × iterations) | High | Per-tenant budget clamps (AC9) + `maxIterations` cap (AC5); budget-exhaustion aggregates over completed members |
+| Refactor changes triage/plan output shape → breaks callers | High | Golden-output parity tests (AC7); preserve `DefinitionId`s and input/output contracts; thin adapter `SetVariable` maps aggregate → legacy shape |
+| `lead+critics`/`llm-judge` non-determinism leaks into tests | Medium | Aggregation seam is pure; LLM-bearing steps are fixtures; live behavior covered only by parity tests with mocked members |
+| SaaS gating drops too many members → empty panel | Medium | Quorum check; fail-loud with a clear error rather than silently producing an empty verdict |
+| 32-5/32-6 not landed at implementation time | Medium | Build against their interfaces; feature-flag panel execution until both are merged |
+
+### Success Metrics
+
+- [ ] Both `TriagePanelReviewWorkflow` and `PlanReviewWorkflow` run on the shared primitives with golden-output parity (zero diff on fixed member outputs).
+- [ ] Each of the four strategies has deterministic-fixture unit coverage ≥ 90% branch on the strategy class.
+- [ ] A SaaS ineligible member is gated without aborting the panel (quorum retained).
+
+## Logging Requirements
+
+- **INFO**: Panel started (`panelId`, member count, strategy, iteration); panel aggregated (`panelId`, strategy, winnerVerdict, totalTokens); iteration completed (`panelId`, iteration, gatesPassed).
+- **DEBUG**: Each member dispatched (`panelId`, index, position, agentId, role); each member result (verdict, tokens, latencyMs); vote tally / judge selection detail.
+- **WARN**: Member gated (`panelId`, agentId, reason); budget clamp triggered mid-fan (`panelId`, completedMembers); quorum at risk.
+- **ERROR**: Panel failed (no quorum / all members errored); aggregation strategy threw; managed-agent resolution failed for a required member.
+- **Structured context**: include `{ panelId, iteration, strategy, memberIndex, agentId, role, tenantId, mode }` where applicable.
+- **Credential safety**: NEVER log provider API keys; the judge rationale is **sanitized** before it is logged or stored.
+
+## Related
+
+- Epic design spec: `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`
+- Implementation plan: `docs/superpowers/plans/2026-06-17-32-7-multi-agent-design-review-panels-in-elsa-plan.md`
+- Superseded panel: `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TriagePanelReviewWorkflow.cs`
+- Refactor target: `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/PlanReviewWorkflow.cs`
+- Sibling stories: `docs/stories/epic-32/story-32-1/`, `story-32-2/`, `story-32-5/`, `story-32-6/`
+
+## References
+
+- **MANDATORY PROCESS:** [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+- **Knowledge Base:** [.dev/README.md](../../.dev/README.md)
+- Elsa Workflows activity model (`Activity`, `[Activity]`, `[FlowNode]`, `CompleteActivityWithOutcomesAsync`)
+- CLAUDE.md — Operating Modes; event-type pattern `AGGREGATE.ACTION.STATUS`
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-32/story-32-8/32-8-outcome-capture-and-bug-taxonomy-at-review-gate.md
+++ b/docs/stories/epic-32/story-32-8/32-8-outcome-capture-and-bug-taxonomy-at-review-gate.md
@@ -1,0 +1,330 @@
+# Story 32-8: Outcome Capture & Bug Taxonomy at Review/Gate
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../../BEFORE_YOU_CODE.md)
+
+This story targets the C# **`apps/tamma-elsa`** stack (Tamma.Activities + Tamma.Api/Tamma.ElsaServer + Tamma.Core + Tamma.Data). The TypeScript `packages/api` is **deleted** — do not reference it. DCB event sourcing, prompt/convention stores, agent registry, and provisioning all live in `apps/tamma-elsa`.
+
+## User Story
+
+As a **tenant evaluating which agents to trust with design and review work**,
+I want every workflow run/task to record its **outcome** (`success` | `fail` | `partial`), the **number of iterations it took to reach a passing gate**, and a **classified bug record** for each defect found at review and quality-gate steps (`visual` | `functional` | `regression` | `security` | `performance` | `style`), all attributed to the **originating agent (id + config version)** and stored only in my tenant's data,
+So that the benchmarking (32-10) and learning (32-11) stories can score agents on real downstream quality — not just token/latency — and I can compare reviewer A vs reviewer B on the defects they actually catch and the bugs their code actually ships.
+
+## Priority
+
+P1 — the quality-signal half of the agent performance dataset. 32-9 supplies cost/latency; this story supplies outcome + defect quality. Both feed 32-10 leaderboards and 32-11 learning.
+
+## Acceptance Criteria
+
+1. A versioned, tenant-scoped **`AgentOutcome`** record links a workflow run / task to its originating `agentId` + config `version` with an outcome enum `{success, fail, partial}` and an `iterationsToDone` count. The record lives only in the tenant's data (tenant `t_<hex>` schema / `DomainEvent.TenantId` scoping) and is never readable across tenants or by platform admins for another tenant.
+2. A fixed **bug taxonomy enum** `{visual, functional, regression, security, performance, style}` is defined in `Tamma.Core` using the established `[Wire]` / `EnumWire<TEnum>` pattern (mirrors `AgentRole`/`AgentAction`). Free-text categories are rejected on the wire; an unknown/unmappable category maps to a catch-all `other` and logs a WARN (it does NOT throw, so a malformed reviewer payload never aborts a workflow).
+3. Review steps (`Tamma.Activities/Review/MonitorReviewActivity` and the review-panel aggregation from 32-7) classify each found defect into the taxonomy and emit one **`AGENT.DEFECT.RECORDED`** DCB event per defect, tagged with `category`, `agentId`, `agentVersion`, `role`, `phase`, `source: "review"`, `issueId`, and `prNumber`.
+4. Quality-gate steps (`Tamma.Activities/Testing/GenerateQualityReportActivity` and `EvaluateResultsActivity`) map each `QualityIssue` in the report to the taxonomy (Coverage/Test→`functional`, Security→`security`, Lint→`style`, Build→`functional`, plus heuristics for regression/performance) and emit `AGENT.DEFECT.RECORDED` events tagged `source: "gate"` with the same agent attribution.
+5. Human review feedback (the `ReviewResult.Comments` carried by `MonitorReviewActivity` and reviewer-supplied categories on the review webhook) is captured as `AGENT.DEFECT.RECORDED` events tagged `source: "human"`, so manually-flagged defects join the same dataset.
+6. `iterationsToDone` is **derived** from the existing debug/CI retry loops (Epic 13 TDD/CI debug-retry; the `EvaluateResults → CommitFix → TriggerCI` cycle and the `WaitForFixes → ReRequestReview` review loop) by counting attempts until a passing gate / approval, attributed to the originating agent. No new loop construct is introduced — the count is read off existing per-run iteration state.
+7. On run/task completion, exactly one of **`AGENT.OUTCOME.RECORDED`** (carrying `outcome` and `iterationsToDone`) is emitted, tagged with `agentId` + `agentVersion`. (The spec's `AGENT.TASK.SUCCEEDED/FAILED/PARTIAL` family from 32-6 is reused as the outcome-typed alias; this story adds `iterationsToDone` and the `bugType`-classified defect events on top of that trail rather than inventing a parallel event family.)
+8. Capture hooks are **non-blocking and idempotent per `(runId, gateId)`** (and per `(runId, defectKey)` for defects): a re-run, a retried gate, or a replayed review webhook does NOT double-count outcomes or duplicate defect events. Capture failures never abort the workflow (fire-and-forget-safe, matching the `IMissingConfigRecorder` precedent).
+9. A taxonomy-validation unit suite proves: every taxonomy member round-trips through `EnumWire`; unknown wire strings map to `other` with a WARN (not a throw); `[Wire]` strings are distinct.
+10. Tests cover: outcome derivation across a multi-iteration retry loop (iterationsToDone = attempts-to-pass), taxonomy classification at both review and gate, the unknown→`other` fallback, idempotency on re-run/replay, and **tenant isolation** (tenant A's outcome/defect rows are invisible to tenant B and to a platform admin).
+
+## Technical Design
+
+### Where this fits (verified against repo @ main 98cfb1c2, 2026-06-17)
+
+| Component | File (verified) | Role in this story |
+|---|---|---|
+| DCB event entity | `apps/tamma-elsa/src/Tamma.Data/Entities/DomainEvent.cs` | `Type`, `TenantId`, `IssueNumber`, `Tags`(JSONB), `Metadata`(JSONB), `Data`(JSONB), `SequenceNumber`. The outcome/defect events are `DomainEvent` rows. |
+| Durable event seam | `apps/tamma-elsa/src/Tamma.Data/Repositories/IEventRepository.cs` (`AppendAsync`, tenant-scoped `QueryAsync`/`ListByTenantAsync`) | Persists events with `TenantId` set — structural tenant isolation. |
+| Activity event accumulation | `apps/tamma-elsa/src/Tamma.Activities/Core/TammaActivity.cs` (`TammaEventEmitter` → transient `tamma:events`) | Activities accumulate `TammaEvent`s; a central flush appends them as `DomainEvent`s (the `AgentEndpoints`/engine pattern). **Activity-side `tamma:events` are transient** — durability comes from the central `AgentOutcomeService` flush, NOT the activity. |
+| Review activity | `apps/tamma-elsa/src/Tamma.Activities/Review/MonitorReviewActivity.cs` (carries `ReviewResult` + `ReviewCommentDetail`) | Defect-capture hook point at review. |
+| Gate activities | `apps/tamma-elsa/src/Tamma.Activities/Testing/GenerateQualityReportActivity.cs` (produces `QualityReport.AllIssues: List<QualityIssue>`), `EvaluateResultsActivity.cs` (AllPass/Minor/Major/Critical routing) | Defect-capture + outcome hook points at gate. |
+| Retry loop | `EvaluateResults → CommitFix → TriggerCI → WaitForCIResults` (Testing) + `WaitForFixes → ReRequestReview` (Review) | Source of `iterationsToDone`. |
+| Taxonomy enum precedent | `apps/tamma-elsa/src/Tamma.Core/Agents/AgentRole.cs`, `AgentAction.cs`, `EnumWire.cs` | `[Wire]`/`EnumWire<TEnum>` is the canonical validated-enum pattern — `BugCategory` follows it exactly. |
+| Outcome enum precedent | `packages/shared/src/types/knowledge.ts` (`LearningCapture.outcome: 'success' | 'failure' | 'partial'`) | The TS learning layer already uses this triple; `AgentOutcomeKind` aligns wire strings to it. |
+| Action-trail base (32-6) | `docs/stories/epic-32/story-32-6` (sibling, in flight) | Establishes `AGENT.TASK.*` events tagged `agent_id` + version in the tenant store — this story extends that trail. |
+| Panels (32-7) | `docs/stories/epic-32/story-32-7` (sibling, in flight) | `RunAgentPanelActivity`/`AggregatePanelActivity` review verdicts are an additional defect source. |
+
+> **NOTE — NEW files** are marked NEW in the Files table. `AgentOutcomeService.cs` does **not** exist yet (the spec's path is aspirational); it is created by this story. All other cited C# files exist.
+
+### Taxonomy enum (Tamma.Core)
+
+`BugCategory` follows the verified `[Wire]`/`EnumWire<TEnum>` pattern so persisted wire strings are decoupled from C# identifiers and case-sensitively validated. Unlike `AgentRole.Parse` (which throws on unknown), the bug-classification path must be **non-fatal** — a bad reviewer payload cannot abort a run — so a `Classify(string)` helper maps unknown → `Other` + WARN.
+
+```csharp
+// apps/tamma-elsa/src/Tamma.Core/Agents/BugCategory.cs  (NEW)
+// Namespace kept as Tamma.Api.Services.Agents to match AgentRole/AgentAction
+// (Story 27-19 convention — taxonomy lives in Tamma.Core, namespace preserved).
+namespace Tamma.Api.Services.Agents;
+
+/// <summary>
+/// Fixed defect taxonomy recorded at review + quality gates (SPEC §Tracking).
+/// Wire strings are the stable DCB contract. <see cref="Other"/> is the
+/// catch-all for unknown/unmappable categories — never thrown, always logged.
+/// </summary>
+public enum BugCategory
+{
+    [Wire("visual")]      Visual,
+    [Wire("functional")]  Functional,
+    [Wire("regression")]  Regression,
+    [Wire("security")]    Security,
+    [Wire("performance")] Performance,
+    [Wire("style")]       Style,
+    [Wire("other")]       Other,   // catch-all — unknown categories map here
+}
+
+public static class BugCategoryExtensions
+{
+    public static string ToWire(this BugCategory c) => EnumWire<BugCategory>.ToWire(c);
+
+    /// <summary>
+    /// Non-throwing classification: returns the matching category, or
+    /// <see cref="BugCategory.Other"/> for null/empty/unknown input. Callers
+    /// MUST log a WARN with the offending raw string when Other is returned
+    /// for a non-empty input (AC2). Never throws — a malformed reviewer
+    /// payload must not abort a workflow.
+    /// </summary>
+    public static BugCategory Classify(string? raw)
+        => raw is not null && EnumWire<BugCategory>.TryParse(raw.Trim(), out var c) ? c : BugCategory.Other;
+}
+```
+
+### Outcome kind (Tamma.Core)
+
+```csharp
+// apps/tamma-elsa/src/Tamma.Core/Agents/AgentOutcomeKind.cs  (NEW)
+namespace Tamma.Api.Services.Agents;
+
+/// <summary>
+/// Run/task outcome. Wire strings align with the TS learning layer
+/// (knowledge.ts LearningCapture.outcome: success|failure|partial) so the
+/// learning loop (32-11) consumes one vocabulary.
+/// </summary>
+public enum AgentOutcomeKind
+{
+    [Wire("success")] Success,
+    [Wire("failure")] Failure,   // wire = "failure" (matches knowledge.ts), spec's "fail" is the short alias
+    [Wire("partial")] Partial,
+}
+```
+
+> **Wire alignment decision:** the spec writes `fail`; `knowledge.ts` (the consuming learning layer) already uses `failure`. We persist `failure` as the wire string to avoid a translation seam at the learning boundary, and document `fail` as the human-facing short alias. `Classify`-style parsing accepts both.
+
+### Event schema (DCB)
+
+All events are `DomainEvent` rows appended via `IEventRepository.AppendAsync` with `TenantId` set (structural isolation). Pattern `AGGREGATE.ACTION.STATUS`.
+
+**`AGENT.OUTCOME.RECORDED`** — one per completed run/task:
+```jsonc
+{
+  "type": "AGENT.OUTCOME.RECORDED",
+  "tenantId": "<tenant-guid>",
+  "issueNumber": 482,
+  "tags": {
+    "agentId": "<agent-guid>", "agentVersion": "7",
+    "role": "reviewer", "phase": "review",
+    "outcome": "success",            // success | failure | partial
+    "runId": "<workflow-instance-id>"
+  },
+  "data": {
+    "iterationsToDone": 3,           // attempts until passing gate / approval
+    "outcomeKind": "success",
+    "gateId": "quality-report",      // the gate that settled the outcome
+    "prNumber": 311
+  },
+  "metadata": { "workflowVersion": "1.0.0", "eventSource": "system" }
+}
+```
+
+**`AGENT.DEFECT.RECORDED`** — one per classified defect (review, gate, or human):
+```jsonc
+{
+  "type": "AGENT.DEFECT.RECORDED",
+  "tenantId": "<tenant-guid>",
+  "issueNumber": 482,
+  "tags": {
+    "agentId": "<agent-guid>", "agentVersion": "7",
+    "role": "reviewer", "phase": "review",
+    "category": "functional",        // BugCategory wire string (or "other")
+    "source": "review",              // review | gate | human
+    "runId": "<workflow-instance-id>"
+  },
+  "data": {
+    "defectKey": "<stable hash for idempotency>",
+    "filePath": "src/foo.ts", "message": "<redacted summary>",
+    "severity": "error", "rawCategory": "<original string if mapped to other>"
+  },
+  "metadata": { "workflowVersion": "1.0.0", "eventSource": "system" }
+}
+```
+
+> `AGENT.TASK.SUCCEEDED/FAILED/PARTIAL` (32-6 action trail) remain the per-task lifecycle events; `AGENT.OUTCOME.RECORDED` is the **scored** projection carrying `iterationsToDone`. The `AgentOutcomeService` emits the outcome event in the same flush as the corresponding 32-6 task event so the two never disagree.
+
+### AgentOutcomeService (the central durable seam)
+
+Activities accumulate defect/outcome intents in the transient `tamma:events` bag (per `TammaEventEmitter`); the **`AgentOutcomeService`** in `Tamma.Api` is the single write-side seam that flushes them to the DCB store with tenant scoping, dedup, and agent attribution — exactly the pattern `AgentEndpoints` uses today (`IEventRepository events ... await events.AppendAsync(new DomainEvent { TenantId = ... })`).
+
+```csharp
+// apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentOutcomeService.cs  (NEW)
+public interface IAgentOutcomeService
+{
+    /// Records the terminal outcome for a run/task. Idempotent per (runId, gateId).
+    Task RecordOutcomeAsync(AgentOutcome outcome, CancellationToken ct = default);
+
+    /// Records one classified defect. Idempotent per (runId, defectKey).
+    Task RecordDefectAsync(AgentDefect defect, CancellationToken ct = default);
+}
+
+// AgentOutcome: tenantId, agentId, agentVersion, role, phase, runId, gateId,
+//               outcome (AgentOutcomeKind), iterationsToDone, issueNumber, prNumber
+// AgentDefect:  tenantId, agentId, agentVersion, role, phase, runId, defectKey,
+//               category (BugCategory), source (review|gate|human), filePath,
+//               message (redacted via Tamma.Core CredentialRedactor), severity, rawCategory
+```
+
+**Idempotency:** dedup is enforced by querying the tenant event store for an existing `AGENT.OUTCOME.RECORDED` with the same `(runId, gateId)` tag (resp. `AGENT.DEFECT.RECORDED` with the same `(runId, defectKey)`) before append. `defectKey` = stable hash of `(runId, filePath, normalizedMessage, category, source)` so the same defect surfaced twice in a retry loop collapses to one row. Belt-and-suspenders: a partial unique index on the tenant `domain_events` projection of `(tenant_id, type, (tags->>'runId'), (data->>'defectKey'))`.
+
+**Non-blocking:** `RecordOutcomeAsync`/`RecordDefectAsync` never throw to the caller (try/catch → WARN), matching the `IMissingConfigRecorder` fire-and-forget contract — a CP/tenant DB blip must not turn a passing gate into a workflow abort.
+
+### iterationsToDone derivation
+
+No new loop. The Testing retry loop (`EvaluateResults → CommitFix → TriggerCI → WaitForCIResults`) and the Review loop (`WaitForFixes → ReRequestReview`) already advance a per-run attempt counter (the `ConsecutivePassCount` / CI run sequence on `CIResultsPayload.RunId`, and the review re-request count). `AgentOutcomeService` reads the final attempt index off the run state at the settling gate:
+- **success:** `iterationsToDone` = number of attempts up to and including the passing attempt.
+- **failure/partial:** `iterationsToDone` = attempts consumed before the terminal (max-iteration / escalation / timeout) state.
+Attribution: the agent that produced the code/design under iteration (the originating `agentId`+version pinned at run start, carried on the run context), not the reviewer.
+
+### Per-mode / per-tenant ownership (mandatory two-scoping answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns the outcome/defect data? | The sole user — their instance, their dataset (`TenantId` null / single tenant). | The tenant that ran the agent. ALWAYS tenant-scoped; one agent definition → many independent per-tenant datasets (design spec §Ownership). |
+| Can a platform admin read it? | N/A (sole user). | **No.** Platform admin owns *public agent definitions* but reads **no** tenant's performance/defect data — enforced structurally by `DomainEvent.TenantId` + per-tenant connection/role. |
+| Where do events land? | The single tenant store. | The originating tenant's `t_<hex>` schema event stream (per-tenant fan-out per Story 28-1 trajectory; `AgentOutcomeService` writes with `TenantId` set so the migration only touches routing). |
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Taxonomy + outcome enums in Tamma.Core (AC: 2, 9)
+  - [ ] Subtask 1.1: Add `BugCategory` enum + `BugCategoryExtensions.Classify` (non-throwing → `Other` + WARN) using `[Wire]`/`EnumWire`
+  - [ ] Subtask 1.2: Add `AgentOutcomeKind` enum (`success`/`failure`/`partial`, wire-aligned to knowledge.ts)
+  - [ ] Subtask 1.3: Unit tests — round-trip, distinct wires, unknown→Other, `fail`/`failure` alias parsing
+- [ ] Task 2: `AgentOutcomeService` + event schema (AC: 1, 7, 8)
+  - [ ] Subtask 2.1: `IAgentOutcomeService` + `AgentOutcome`/`AgentDefect` records, DI wiring in Program.cs
+  - [ ] Subtask 2.2: `AGENT.OUTCOME.RECORDED` / `AGENT.DEFECT.RECORDED` event types + tag/data builders (agentId+version, tenant-scoped)
+  - [ ] Subtask 2.3: Idempotency (query-before-append on `(runId, gateId)` / `(runId, defectKey)`) + partial unique index migration
+  - [ ] Subtask 2.4: Non-throwing contract (try/catch → WARN); message redaction via `CredentialRedactor`
+- [ ] Task 3: Defect capture at review (AC: 3, 5)
+  - [ ] Subtask 3.1: Hook `MonitorReviewActivity` resume path — classify `ReviewResult.Comments` + reviewer category → `RecordDefectAsync(source: review|human)`
+  - [ ] Subtask 3.2: Hook the 32-7 panel aggregation review verdict (guarded on 32-7 presence)
+- [ ] Task 4: Defect + outcome capture at gate (AC: 4, 6, 7)
+  - [ ] Subtask 4.1: Map `QualityReport.AllIssues` (`QualityIssueCategory`) → `BugCategory` and emit `RecordDefectAsync(source: gate)` from `GenerateQualityReportActivity`
+  - [ ] Subtask 4.2: Derive `iterationsToDone` from the Testing + Review retry loops; emit `RecordOutcomeAsync` at the settling gate/approval
+- [ ] Task 5: Tests (AC: 10)
+  - [ ] Subtask 5.1: Outcome derivation across a 3-iteration retry loop
+  - [ ] Subtask 5.2: Classification at review + gate; unknown→other WARN
+  - [ ] Subtask 5.3: Idempotency on re-run/replayed webhook
+  - [ ] Subtask 5.4: Tenant isolation (A invisible to B + platform admin)
+
+## Dependencies
+
+- **Prerequisite — Story 32-6** (Agent action trail: `AGENT.TASK.*` events tagged `agent_id`+version in the tenant store). This story extends that trail with outcome scoring + defect classification; it reuses 32-6's agent-attribution tagging and tenant-event-store wiring.
+- **Prerequisite — Story 32-7** (Multi-agent design/review panels): the panel review verdict is an additional defect source (AC3). Gracefully degrades if a deployment runs panels off — single-reviewer `MonitorReviewActivity` capture (AC3/AC5) is independent of 32-7.
+- **Prerequisite — Epic 4** (DCB event sourcing): `DomainEvent` + `IEventRepository` tenant-scoped append/query are the storage substrate.
+- **Related — Epic 13** (TDD/CI debug-retry loops): source of `iterationsToDone`; this story reads existing iteration state, adds no loop.
+- **Related — Epic 3** (quality gates): `GenerateQualityReportActivity`/`EvaluateResultsActivity` are the gate-side capture points.
+- **Consumed by — Story 32-10** (benchmark projections/leaderboards: success rate, avg iterations-to-done, bug counts by type) and **Story 32-11** (learning persistence — `LearningCapture.outcome` aligns to `AgentOutcomeKind`).
+
+## Testing Strategy
+
+1. **Enum unit tests** (`Tamma.Core.Tests`, xUnit): `BugCategory`/`AgentOutcomeKind` round-trip through `EnumWire`; distinct wire strings; `Classify("frobnicate")` → `Other` + WARN asserted; `Classify(null/"")` → `Other` silently; `fail`/`failure` both parse.
+2. **Service unit tests** (`Tamma.Api.Tests/Agents/AgentOutcomeServiceTests.cs`): `RecordOutcomeAsync` appends one `AGENT.OUTCOME.RECORDED` with correct tags+`iterationsToDone`; `RecordDefectAsync` appends one `AGENT.DEFECT.RECORDED`; **idempotency** — same `(runId, gateId)` / `(runId, defectKey)` twice → one row, no second event; recorder swallows a DB fault (WARN, no throw); message redaction applied.
+3. **Iteration derivation tests**: simulate a 3-attempt Testing loop (fail→fail→pass) → `iterationsToDone == 3`, outcome `success`; max-iterations-exhausted → outcome `failure` with attempts consumed; review re-request loop counted.
+4. **Classification mapping tests**: `QualityReport.AllIssues` with Coverage/Security/Lint/Build issues map to `functional/security/style/functional`; review `ReviewResult.Comments` with reviewer categories classify correctly; an unknown reviewer category → `other` + WARN + `rawCategory` preserved in `data`.
+5. **Tenant isolation tests** (docker-bound, `sg docker -c "dotnet test ..."`): seed outcome+defect events for tenant A; assert tenant B's `IEventRepository.ListByTenantAsync(B, ...)` returns none of A's rows and a platform-admin path cannot read A's outcome/defect data.
+6. **Edge cases**: zero-defect passing run (outcome `success`, no defect events); replayed review webhook (AutoBurn already covers bookmark, but defect dedup must still hold); concurrent defect records for the same `defectKey` (unique-index catch → single row).
+
+## Estimated Effort
+
+4-5 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Core/Agents/BugCategory.cs` | Create (NEW) |
+| `apps/tamma-elsa/src/Tamma.Core/Agents/AgentOutcomeKind.cs` | Create (NEW) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentOutcomeService.cs` | Create (NEW) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/IAgentOutcomeService.cs` | Create (NEW) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentOutcomeEventTypes.cs` | Create (NEW — `AGENT.OUTCOME.RECORDED`, `AGENT.DEFECT.RECORDED`) |
+| `apps/tamma-elsa/src/Tamma.Activities/Review/MonitorReviewActivity.cs` | Modify (defect/human capture hook on resume) |
+| `apps/tamma-elsa/src/Tamma.Activities/Testing/GenerateQualityReportActivity.cs` | Modify (QualityIssue→BugCategory mapping + gate defect capture) |
+| `apps/tamma-elsa/src/Tamma.Activities/Testing/EvaluateResultsActivity.cs` | Modify (settle outcome + iterationsToDone at gate) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (DI: register `IAgentOutcomeService`) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/...` | Create (additive: partial unique index for defect/outcome idempotency on tenant event projection) |
+| `apps/tamma-elsa/tests/Tamma.Core.Tests/Agents/BugCategoryTests.cs` | Create (NEW) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentOutcomeServiceTests.cs` | Create (NEW) |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/Review/MonitorReviewDefectCaptureTests.cs` | Create (NEW) |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/Testing/QualityGateOutcomeCaptureTests.cs` | Create (NEW) |
+
+> Final test project paths follow the repo's existing `apps/tamma-elsa/tests/*` layout; confirm exact project names against the solution before adding (mirror the nearest existing `Tamma.Activities.Tests`/`Tamma.Api.Tests` project).
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+1. Read [BEFORE_YOU_CODE.md](../../../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes/bugs/findings/decisions (esp. DCB tagging + tenant isolation)
+3. Read sibling stories 32-6 (action trail) and 32-7 (panels) — this story depends on their `agent_id`+version tagging and review-verdict shape; align tag names exactly
+4. Read the design spec `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md` §Tracking
+5. Planned the TDD cycle (enums + service tests first, then activity hooks)
+
+### Key design decisions
+
+- **`[Wire]`/`EnumWire` for the taxonomy** — reuses the verified `AgentRole`/`AgentAction` pattern: stable persisted contract, case-sensitive validation, no free-text. The one deliberate divergence is `BugCategory.Classify` is non-throwing (→ `Other` + WARN) because a malformed reviewer payload must never abort a workflow (AC2).
+- **`failure` wire string, `fail` alias** — aligns with `knowledge.ts` `LearningCapture.outcome` so 32-11 consumes one vocabulary; documented so the spec's `fail` is not lost.
+- **Central service is the durable seam, not the activity** — activity `tamma:events` are transient (per `TammaActivity.cs`); durability + tenant scoping + dedup live in `AgentOutcomeService` (the `AgentEndpoints` flush pattern). This also keeps capture out of the workflow's failure path.
+- **iterationsToDone is derived, not stored by a new loop** — read off existing Epic-13 retry state; attributed to the code/design-producing agent, not the reviewer.
+- **Idempotency is query-before-append + partial unique index** — survives re-runs, retried gates, and replayed webhooks without double-counting (AC8).
+
+### Integration points
+
+- **Review:** `MonitorReviewActivity.OnReviewReceivedAsync` already parses `ReviewResult` + `ReviewCommentDetail`; the capture hook classifies each comment's category (or reviewer-supplied `category` field on the webhook) and calls `RecordDefectAsync`.
+- **Gate:** `GenerateQualityReportActivity` already aggregates `QualityReport.AllIssues` with `QualityIssueCategory`; map that enum to `BugCategory` and emit defects; `EvaluateResultsActivity`'s AllPass/Major/Critical routing settles the outcome.
+- **Tenant context:** the originating `agentId`+version and `tenantId` are pinned on the run context at start (32-5/32-6); the service reads them — it never trusts a reviewer-supplied agentId.
+
+### Risks and mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Cross-tenant data leak | High | `DomainEvent.TenantId` + per-tenant connection/role; explicit isolation tests (AC10); service never accepts a caller-supplied tenantId from a reviewer payload |
+| Double-counting on retry/replay | Medium | `(runId, gateId)` / `(runId, defectKey)` dedup + partial unique index (AC8) |
+| Capture aborting a passing workflow | High | Fire-and-forget-safe service (try/catch → WARN), never throws to the activity |
+| Free-text category pollution | Medium | `EnumWire` validation + `Classify`→`Other` with `rawCategory` preserved (AC2) |
+| 32-6/32-7 not yet merged | Medium | Single-reviewer + gate capture work without 32-7; tag names mirror 32-6 — coordinate before merge |
+
+## Logging Requirements
+
+- **INFO:** outcome recorded (`agentId`, `outcome`, `iterationsToDone`, `runId`); defect recorded (`agentId`, `category`, `source`, `runId`)
+- **DEBUG:** classification decision (`rawCategory` → `BugCategory`); idempotency hit (duplicate `(runId, gateId|defectKey)` skipped); iteration count derivation
+- **WARN:** unknown category mapped to `other` (include `rawCategory`); capture swallowed a DB fault (`runId`, error); reviewer-supplied agentId mismatch ignored
+- **ERROR:** none on the capture path (failures are WARN — capture never blocks); reserve ERROR for the migration/idempotency-index creation path
+- **Structured context:** `{ tenantId, agentId, agentVersion, runId, gateId|defectKey, category, outcome, iterationsToDone }`
+- **Credential safety:** defect `message` is redacted via `Tamma.Core/Redaction/CredentialRedactor` before persistence; never log raw reviewer payloads or secrets
+
+## Related
+
+- Design spec: `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`
+- Implementation plan: `docs/superpowers/plans/2026-06-17-32-8-outcome-capture-and-bug-taxonomy-at-review-gate-plan.md`
+- Sibling stories: `docs/stories/epic-32/story-32-6` (action trail), `docs/stories/epic-32/story-32-7` (panels)
+- Consumers: Story 32-10 (leaderboards), Story 32-11 (learning → RAG)
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-32/story-32-9/32-9-cost-basis-plus-margin-metering-and-byok-pricing-model.md
+++ b/docs/stories/epic-32/story-32-9/32-9-cost-basis-plus-margin-metering-and-byok-pricing-model.md
@@ -1,0 +1,555 @@
+# Story 32-9: Agent Usage & Cost-Basis Emission (Producer for Pricing/Billing/Analytics)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+> **Boundary note (read first — this story is the PRODUCER, not the pricing engine):**
+> 32-9 makes agents **emit** a per-LLM-call usage + **cost-basis** event, tagged with
+> `agentId` / `tenant` / `provider` / `model` / `credentialSource`, into the tenant's DCB stream
+> and aggregate it per billing period. It is the data **source** consumed by **Epic 34 (pricing /
+> markup)**, **Epic 35 (billing / invoicing)**, and **Epic 36 (analytics)**.
+> It does **NOT** implement any markup, margin, or billable-amount computation. The
+> **margin/markup engine is owned by Epic 34-5** — branching cost-basis into a billable amount,
+> applying BYOK-vs-platform pricing rules, and re-pricing periods all live there. This story
+> emits `costBasisUsd` (the provider's own cost, already computed by `IProviderPricingService`)
+> and the `credentialSource` discriminator so 34-5 can branch; it never computes `billableUsd`,
+> a margin, or a seat/platform fee. (The spec key/title carries legacy "+margin / billable" framing
+> from when this story was scoped against Epic 20; the Epic 32 design spec §"Story breakdown" item 9
+> and §"Tracking" are canonical — **producer only, markup engine is 34-5**.)
+
+## User Story
+
+As **Epic 34 (pricing), Epic 35 (billing), and Epic 36 (analytics)** — and the tenant owner who
+will eventually see a usage/cost view —
+I want every LLM call made on behalf of an agent to emit a per-call **usage + cost-basis** event
+into the calling tenant's own DCB stream, tagged with the agent's identity, provider, model, token
+split, the provider's cost basis in USD, and whether the call ran on a **BYOK** or **platform**
+credential, and rolled up per billing period,
+So that the downstream pricing/billing/analytics epics have a complete, tenant-isolated, per-agent
+cost-basis substrate to apply markup, invoice, and report against — without this story making any
+pricing decision.
+
+## Priority
+
+P1 — The usage/cost producer the Epic 32 benchmarking + the Epic 34/35/36 consumers depend on. Cost
+basis is already computed on every diagnostic; this story turns it into a first-class, agent-keyed,
+per-period DCB usage signal. Depends on 32-3 (`credentialSource`), 32-5 (the managed run that owns the
+call), and 32-6 (the action-trail substrate and `correlationId` linkage this re-keys against).
+
+## Acceptance Criteria
+
+1. Every completed LLM call attributable to an agent run emits exactly one **`AGENT.USAGE.RECORDED`**
+   DCB `DomainEvent` into the **resolving tenant's** schema (`t_<hex>.domain_events` via
+   `IEventRepository.AppendAsync`), never on the control plane. `TenantId` = the resolving tenant.
+   One call → one usage event (a multi-turn tool loop is one logical call = one event carrying the
+   loop's accumulated tokens, mirroring how `CallLlmInlineActivity` accumulates `ToolLoopTokens`).
+2. The event's `Tags` JSONB carries (flat string values, shared builder): `agentId`, `agentVersion`,
+   `role`, `provider`, `model`, `credentialSource` (`byok` | `platform`), `correlationId`, `issueId`,
+   and `mode` (`single-user` | `saas`). These are the dimensions Epics 34/35/36 slice on.
+3. The event's `Data` carries the **cost basis only**: `{ inputTokens, outputTokens, totalTokens,
+   costBasisUsd, model, provider, credentialSource, durationMs }`. `costBasisUsd` is the provider's
+   own USD cost as computed today by `IProviderPricingService.Compute(provider, model, in, out)` —
+   the value already written to `ProviderDiagnostic.Cost`. **No `billableUsd`, no margin, no markup,
+   no seat/platform fee** is computed or stored here (those are Epic 34-5).
+4. The cost basis is **never recomputed** in this story — it reuses the single pricing seam
+   (`IProviderPricingService`) so there is one cost-basis source of truth. For a BYOK call the same
+   provider rate-sheet cost basis is recorded (BYOK changes *who pays the provider*, captured by
+   `credentialSource`, not the per-token rate); 34-5 decides what, if anything, a BYOK call bills.
+5. Each usage event is **linked to the action trail (32-6) and its diagnostic row** by sharing one
+   `correlationId` + `agentId`: a run's `AGENT.TASK.*` trail event, its `ProviderDiagnostic` row(s),
+   and its `AGENT.USAGE.RECORDED` event(s) all carry the same `correlationId` and resolve to the same
+   `agentId`. Re-keying usage by agent for benchmarking (32-10) is then a join on `(correlationId,
+   agentId)`.
+6. Per-call usage is **aggregated per billing period per (agent, provider, credentialSource)** into a
+   tenant-resident projection (`agent_usage_rollup` in the tenant schema), maintained from the
+   `AGENT.USAGE.RECORDED` stream. The rollup is **idempotent on the event id** (replaying an event
+   does not double-count). It stores summed `inputTokens`, `outputTokens`, `totalTokens`,
+   `costBasisUsd`, and `callCount` — **cost basis only, no billable column**.
+7. A tenant-scoped read endpoint **`GET /api/v1/orgs/{tenantId}/agents/usage`** returns the
+   current-period usage broken down by **agent** and **provider** (and `credentialSource`):
+   `{ periodStart, periodEnd, byAgent: [{ agentId, provider, credentialSource, inputTokens,
+   outputTokens, totalTokens, costBasisUsd, callCount }], totals: {…} }`. Read is **member-level**
+   (any tenant member); there is **no `billableUsd` field** on the wire — the billable view is an
+   Epic 34/35 concern over this data.
+8. The endpoint and rollup are **strictly tenant-isolated**: reads go through the tenant-scoped store
+   only; a platform owner calling another tenant's usage path gets 403/404, never that tenant's
+   numbers — even when the run used a public/system agent definition (one public agent → N
+   independent per-tenant usage datasets, per the Epic 32 tenancy rule). Explicitly tested.
+9. Usage emission is **best-effort-non-blocking** for the agent run: a usage-write failure does **not**
+   abort or fail the run, is retried via the durable append path, and on terminal failure surfaces an
+   **`AGENT.USAGE.EMIT_FAILED`** breadcrumb (or WARN log + metric) so the gap is observable, never
+   silent. (Mirrors the 32-6 trail non-blocking contract.)
+10. DCB events are emitted via `IEventRepository.AppendAsync` and follow `AGGREGATE.ACTION.STATUS`:
+    `AGENT.USAGE.RECORDED` (per call) and `AGENT.USAGE.EMIT_FAILED` (terminal write failure). Tokens
+    and `costBasisUsd` are in `Data`; identity dimensions are in `Tags`. No secret/raw-prompt content
+    is persisted (reuse the sanitization/redaction seam).
+11. **No pricing leakage:** there is **no code in this story** that reads/writes a margin, computes a
+    billable amount, branches the *price* on `credentialSource`, or touches `Plan.Quotas`/`Plan.
+    MonthlyPriceUsd` for pricing. A test asserts the emitted `Data` schema contains `costBasisUsd` and
+    **not** `billableUsd`/`marginPct`/`feeUsd`, guarding the 34-5 boundary.
+12. **Re-targets Epic 20 (documentation only):** a short note records that Epic 20's 20-3 (usage
+    metering), 20-4 (limit enforcement), and 20-5 (billing dashboard) — written against the deleted
+    TS `packages/api` flat per-token meter — are **superseded** by this agent-aware, cost-basis,
+    DCB-native producer on the C# `apps/tamma-elsa` stack. The note states 20-3's `workflow_runs` /
+    `llm_tokens` equivalents map to `callCount` / `totalTokens` in `agent_usage_rollup`; no Epic 20
+    code is created or modified (it does not exist in this stack).
+13. **Tests** cover: one-call-one-event (single-turn and tool-loop), tag/data completeness,
+    cost-basis-equals-pricing-seam parity, `(correlationId, agentId)` link integrity across trail +
+    diagnostic + usage, rollup idempotency on replay, BYOK vs platform `credentialSource` recorded
+    correctly at both branches, tenant isolation (B cannot read A; platform admin cannot read either),
+    non-blocking emit failure, and the no-pricing-leakage schema assertion (AC 11).
+
+## Technical Design
+
+### Where this sits (architecture)
+
+The cost **basis** already exists: every provider invocation records a `ProviderDiagnostic` whose
+`Cost` is `IProviderPricingService.Compute(provider, model, inputTokens, outputTokens)` — verified in
+`ProviderSessionService.ExecuteAsync` (`new ProviderDiagnostic { … Cost = invocation.CostUsd … }`,
+lines ~122–135) and in the SaaS `LlmProxyService` path. This story does **not** add a meter or a price;
+it **promotes that cost basis into an agent-keyed DCB usage event** in the tenant stream and rolls it
+up per period, so 34/35/36 can consume a clean per-agent signal instead of scraping diagnostics.
+
+```
+Managed agent run (32-5 IManagedAgent)  ── one logical LLM call ──┐
+  │ provider invoked; ProviderDiagnostic { Cost = pricing.Compute(...), CorrelationId, AgentType }
+  │
+  ├─ AgentUsageEmitter.RecordCallAsync(ctx, usage)            // PRODUCER (this story)
+  │     → DomainEvent { Type="AGENT.USAGE.RECORDED",
+  │                     TenantId = resolving tenant,           // structural isolation
+  │                     Tags  = {agentId, provider, model, credentialSource, correlationId, mode,…},
+  │                     Data  = {inputTokens, outputTokens, costBasisUsd, …} }  // cost BASIS only
+  │     → IEventRepository.AppendAsync(evt)                    // t_<hex>.domain_events
+  │
+  └─ AgentUsageRollupProjector  (consumes AGENT.USAGE.RECORDED, idempotent on event id)
+        → upsert agent_usage_rollup (per period, per agent/provider/credentialSource)
+
+   Downstream (NOT this story):
+     Epic 34-5  markup/margin engine → billableUsd = f(costBasisUsd, credentialSource, plan)
+     Epic 35    invoicing/billing dashboard
+     Epic 36    analytics / leaderboards
+```
+
+The usage event reuses the existing `Tamma.Data.Entities.DomainEvent` row shape (no event-schema
+change) and the existing tenant-scoped `IEventRepository` — isolation is inherited from the unified
+schema-per-tenant model (32-6 / Epic 28), not re-implemented.
+
+### Emitter seam (single producer site)
+
+A thin injectable emitter is the one seam the 32-5 managed run calls per LLM call. It owns tag/data
+shape, cost-basis sourcing (from the diagnostic / pricing seam — never a fresh computation), and the
+non-blocking contract.
+
+```csharp
+// src/Tamma.Api/Services/Agents/AgentUsageContext.cs
+public sealed record AgentUsageContext(
+    Guid    TenantId,
+    Guid    AgentId,
+    int     AgentVersion,
+    string  Role,
+    string  Provider,
+    string? Model,
+    string  CredentialSource,   // "byok" | "platform" — from 32-3 ProviderCredential.Source
+    Guid    CorrelationId,      // shared with 32-6 trail + ProviderDiagnostic
+    string? IssueId,
+    int?    IssueNumber,
+    string  Mode);              // "single-user" | "saas"
+
+// The measured facts of one logical call (single-turn or accumulated tool loop).
+public sealed record AgentCallUsage(
+    int     InputTokens,
+    int     OutputTokens,
+    decimal CostBasisUsd,       // == IProviderPricingService.Compute(...) / ProviderDiagnostic.Cost
+    double  DurationMs)
+{
+    public int TotalTokens => InputTokens + OutputTokens;
+}
+
+// src/Tamma.Api/Services/Agents/IAgentUsageEmitter.cs
+public interface IAgentUsageEmitter
+{
+    /// <summary>
+    /// Emit one AGENT.USAGE.RECORDED event for a completed LLM call. Non-blocking:
+    /// never throws into the agent run (AC 9). Records cost BASIS only — no markup.
+    /// </summary>
+    Task RecordCallAsync(AgentUsageContext ctx, AgentCallUsage usage, CancellationToken ct = default);
+}
+```
+
+```csharp
+// src/Tamma.Api/Services/Agents/AgentUsageEmitter.cs
+public sealed class AgentUsageEmitter(
+    IEventRepository events,
+    ILogger<AgentUsageEmitter> logger) : IAgentUsageEmitter
+{
+    public async Task RecordCallAsync(AgentUsageContext c, AgentCallUsage u, CancellationToken ct = default)
+    {
+        try
+        {
+            await events.AppendAsync(new DomainEvent
+            {
+                Id       = Guid.NewGuid(),
+                Type     = AgentUsageEventTypes.UsageRecorded,   // "AGENT.USAGE.RECORDED"
+                TenantId = c.TenantId,                            // resolving tenant — structural isolation
+                IssueNumber = c.IssueNumber,
+                Tags     = AgentUsageTags.Build(c),               // flat string dims (AC 2)
+                Metadata = StandardMetadata(),                    // { workflowVersion, eventSource = "system" }
+                Data     = JsonSerializer.Serialize(new
+                {
+                    inputTokens      = u.InputTokens,
+                    outputTokens     = u.OutputTokens,
+                    totalTokens      = u.TotalTokens,
+                    costBasisUsd     = u.CostBasisUsd,            // BASIS ONLY — no billableUsd (AC 3, 11)
+                    model            = c.Model,
+                    provider         = c.Provider,
+                    credentialSource = c.CredentialSource,
+                    durationMs       = u.DurationMs,
+                }),
+                CreatedAt = DateTime.UtcNow,
+            });
+        }
+        catch (Exception ex)
+        {
+            // Non-blocking (AC 9): log + best-effort breadcrumb; never throw into the run.
+            logger.LogWarning(ex,
+                "Agent usage emit failed agent={AgentId} provider={Provider} corr={Corr}",
+                c.AgentId, c.Provider, c.CorrelationId);
+            await TryEmitFailedBreadcrumbAsync(c, ex, ct);        // AGENT.USAGE.EMIT_FAILED, swallows
+        }
+    }
+}
+```
+
+`AgentUsageTags.Build` mirrors `AgentTrailTags.Build` (32-6) and the `Tags` convention already used by
+`AgentEndpoints.UpdateConfig` (flat string dict, serialized). `AgentUsageEventTypes` holds the two
+type constants.
+
+### Cost-basis sourcing (one source of truth — AC 4)
+
+The emitter is handed `CostBasisUsd` from the same value the diagnostic uses; it does **not** call
+pricing itself differently:
+
+```csharp
+// In the 32-5 managed run, after the provider call (single-turn or tool-loop):
+var usage = new AgentCallUsage(
+    InputTokens:  diag.InputTokens,      // ProviderDiagnostic / ProviderAttemptTokens
+    OutputTokens: diag.OutputTokens,
+    CostBasisUsd: diag.Cost,             // == IProviderPricingService.Compute(provider, model, in, out)
+    DurationMs:   diag.RequestDurationMs);
+await _usageEmitter.RecordCallAsync(usageCtx, usage, ct);
+```
+
+For BYOK, `diag.Cost` is still the provider rate-sheet cost basis (what the call *would* cost at list
+price); `credentialSource = byok` records that the tenant's own account was billed by the provider.
+Whether a BYOK call is charged anything by us is **entirely Epic 34-5's call** — this story only
+records the basis + the discriminator.
+
+### Per-period rollup projection (AC 6)
+
+A tenant-resident projection keeps a current/period rollup so the read endpoint (AC 7) is O(1) and
+34/35/36 can read aggregates without scanning the event stream. New tenant-schema table; no control-
+plane row.
+
+```sql
+-- tenant schema t_<hex>; created by the Tenant EF migration for this story
+CREATE TABLE IF NOT EXISTS agent_usage_rollup (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id          UUID        NOT NULL,
+  provider          TEXT        NOT NULL,
+  credential_source TEXT        NOT NULL,           -- 'byok' | 'platform'
+  period_start      TIMESTAMPTZ NOT NULL,
+  period_end        TIMESTAMPTZ NOT NULL,
+  input_tokens      BIGINT      NOT NULL DEFAULT 0,
+  output_tokens     BIGINT      NOT NULL DEFAULT 0,
+  total_tokens      BIGINT      NOT NULL DEFAULT 0,
+  cost_basis_usd    NUMERIC(18,6) NOT NULL DEFAULT 0,  -- BASIS ONLY; no billable column (AC 6, 11)
+  call_count        BIGINT      NOT NULL DEFAULT 0,
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (agent_id, provider, credential_source, period_start)
+);
+
+-- Idempotency ledger so an event id is never folded twice (AC 6).
+CREATE TABLE IF NOT EXISTS agent_usage_applied (
+  event_id   UUID PRIMARY KEY,
+  applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+```csharp
+// src/Tamma.Api/Services/Agents/AgentUsageRollupProjector.cs
+public sealed class AgentUsageRollupProjector(ITenantDbContextFactory tenantDb, ITenantContext tenant)
+{
+    /// <summary>
+    /// Fold one AGENT.USAGE.RECORDED event into agent_usage_rollup. Idempotent on event id:
+    /// inserts into agent_usage_applied first; a duplicate (already-applied) event is a no-op.
+    /// </summary>
+    public Task ApplyAsync(DomainEvent usageEvent, CancellationToken ct = default);
+}
+```
+
+The projector runs in-process from the same emission path (apply-on-append) and is replay-safe, so a
+future stream rebuild reproduces the rollup exactly. Period boundaries default to calendar-month
+(`date_trunc('month', …)`), matching the 20-3 convention; the period model is intentionally simple —
+34/35 own real billing cycles.
+
+### Read endpoint (AC 7, 8)
+
+```csharp
+// src/Tamma.Api/Endpoints/AgentUsageEndpoints.cs
+// GET /api/v1/orgs/{tenantId}/agents/usage?period=current
+public static async Task<IResult> GetCurrentUsage(
+    HttpContext http, ITenantDbContextFactory tenantDb, ITenantContext tenantContext,
+    Guid tenantId, string? period = "current")
+{
+    // tenantId is route-bound and validated by RequireTenantMembershipFilter (MemberAccess);
+    // the read is physically scoped to that tenant's schema via ITenantDbContextFactory.
+    var (start, end) = ResolvePeriod(period);                 // current calendar month by default
+    var rows = await QueryRollupAsync(tenantId, start, end);  // tenant-scoped only
+
+    return Results.Ok(new
+    {
+        periodStart = start, periodEnd = end,
+        byAgent = rows.Select(r => new {
+            r.AgentId, r.Provider, r.CredentialSource,
+            r.InputTokens, r.OutputTokens, r.TotalTokens,
+            costBasisUsd = r.CostBasisUsd,                     // NO billableUsd on the wire (AC 7, 11)
+            r.CallCount }),
+        totals = Totals(rows),
+    });
+}
+```
+
+Wired under the existing `/api/v1/orgs/{tenantId}` group with `RequireTenantMembershipFilter` — exactly
+like 32-6's trail endpoints. There is **no `OwnerAccess` cross-tenant usage route**; a platform owner
+cannot read any tenant's usage (AC 8).
+
+### Diagnostics linkage (AC 5)
+
+No `ProviderDiagnostic` schema change. The managed run threads one `correlationId` through the
+`ProviderDiagnostic` (already has `CorrelationId` + `AgentType`), the 32-6 trail event, and the
+`AGENT.USAGE.RECORDED` tag — so usage, trail, and cost/latency diagnostics for the same call join on
+`(correlationId, agentId)`. This is the seam 32-10's leaderboards re-key off.
+
+### Route + DI wiring (`Program.cs`)
+
+```csharp
+builder.Services.AddScoped<IAgentUsageEmitter, AgentUsageEmitter>();
+builder.Services.AddScoped<AgentUsageRollupProjector>();
+
+orgs.MapGet("/{tenantId}/agents/usage", AgentUsageEndpoints.GetCurrentUsage)
+    .AddEndpointFilter<RequireTenantMembershipFilter>();   // MemberAccess
+```
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Usage emitter core (AC 1, 2, 3, 4, 9, 10, 11)
+  - [ ] Subtask 1.1: Add `AgentUsageContext`, `AgentCallUsage`, `AgentUsageTags.Build`, `AgentUsageEventTypes` (`AGENT.USAGE.RECORDED`, `AGENT.USAGE.EMIT_FAILED`)
+  - [ ] Subtask 1.2: Add `IAgentUsageEmitter` + `AgentUsageEmitter`; `Data` = cost basis only, `Tags` = identity dims; assert no `billableUsd`/`margin` field in serialization
+  - [ ] Subtask 1.3: Enforce non-blocking contract — `AGENT.USAGE.EMIT_FAILED` breadcrumb on terminal failure; never throw into the run
+  - [ ] Subtask 1.4: Register `IAgentUsageEmitter` in `Program.cs` DI
+- [ ] Task 2: Wire emission into the managed run (AC 1, 4, 5)
+  - [ ] Subtask 2.1: Call `RecordCallAsync` once per logical LLM call from the 32-5 `IManagedAgent` path (single-turn and accumulated tool-loop), sourcing `CostBasisUsd` from the diagnostic (`IProviderPricingService.Compute` value — no recompute)
+  - [ ] Subtask 2.2: Thread the run's single `correlationId` + `agentId` through the diagnostic, the 32-6 trail event, and the usage tag; set `credentialSource` from 32-3's `ProviderCredential.Source` (default `platform` until 32-3 wired)
+- [ ] Task 3: Per-period rollup projection (AC 6)
+  - [ ] Subtask 3.1: Tenant EF migration: `agent_usage_rollup` + `agent_usage_applied` in the tenant schema
+  - [ ] Subtask 3.2: `AgentUsageRollupProjector.ApplyAsync` — idempotent on event id, upsert per `(agentId, provider, credentialSource, periodStart)`; cost-basis-only columns
+  - [ ] Subtask 3.3: Replay-safety test (apply same event twice → counted once)
+- [ ] Task 4: Tenant-scoped read API (AC 7, 8)
+  - [ ] Subtask 4.1: `AgentUsageEndpoints.GetCurrentUsage` + DTOs (byAgent/totals; no `billableUsd`)
+  - [ ] Subtask 4.2: Map under `/api/v1/orgs/{tenantId}` with `RequireTenantMembershipFilter`; period resolver (current calendar month default)
+- [ ] Task 5: Epic 20 re-target note (AC 12)
+  - [ ] Subtask 5.1: Add the supersession note (this file + a short pointer in the Epic 20 stories' "Status"/notes) mapping `workflow_runs`/`llm_tokens` → `callCount`/`totalTokens`; create/modify no Epic 20 code
+- [ ] Task 6: Tests (AC 13)
+  - [ ] Subtask 6.1: One-call-one-event (single-turn + tool-loop); tag/data completeness; cost-basis == pricing-seam value
+  - [ ] Subtask 6.2: Link integrity — trail + diagnostic + usage share `(correlationId, agentId)`
+  - [ ] Subtask 6.3: Rollup idempotency on replay; BYOK vs platform `credentialSource` at both branches
+  - [ ] Subtask 6.4: Tenant isolation (B≠A; platform admin denied), including a public-agent run
+  - [ ] Subtask 6.5: Non-blocking emit failure → run completes + breadcrumb; no-pricing-leakage schema assertion (AC 11)
+
+## Dependencies
+
+**Internal Dependencies:**
+
+- **Story 32-3** (per-tenant provider credential resolution) — supplies `credentialSource`
+  (`byok` | `platform`) via `ProviderCredential.Source` / the `credentialSource` diagnostic tag. Hard
+  for AC 2/AC 4 correctness; soft-default to `platform` if 32-3 not yet wired.
+- **Story 32-5** (managed agent execution layer) — the `IManagedAgent` run is the producer that calls
+  `IAgentUsageEmitter` once per LLM call and owns the `correlationId`. Hard prerequisite for Task 2.
+- **Story 32-6** (agent action trail) — provides the `correlationId` linkage, the tenant-scoped
+  `IEventRepository` emission pattern, the `AgentTrailTags` precedent, and the non-blocking emitter
+  contract this story mirrors. Hard for AC 5.
+- **Story 32-1** (agent entity model) — supplies the immutable `agentId` + `agentVersion` every usage
+  event is tagged with (`AgentConfig.cs` exists today; `Agent`/`AgentVersion` is NEW in 32-1). Source
+  from resolved config identity until it lands.
+- **Epic 4 / Epic 28** (DCB event store + tenant-scoped store) — `DomainEvent`, `IEventRepository`,
+  `ITenantDbContextFactory`, `SequenceNumber`. All reused; no new event infrastructure.
+- **`IProviderPricingService`** (`Tamma.Api.Services.Providers`) — the cost-basis source of truth
+  (`Compute(provider, model, in, out)`). Referenced, not modified.
+
+**Consumers (downstream — NOT built here):**
+
+- **Epic 34 (pricing / markup) — owner of 34-5 margin/markup engine**: branches `costBasisUsd` ×
+  `credentialSource` × plan into `billableUsd`. This story emits the inputs it consumes.
+- **Epic 35 (billing / invoicing)** and **Epic 36 (analytics)**: consume `AGENT.USAGE.RECORDED` +
+  `agent_usage_rollup`.
+
+**External Dependencies:** None new. EF Core 9 / Npgsql, existing event store, existing pricing seam.
+
+## Testing Strategy
+
+1. **Producer correctness (AC 1, 2, 3, 4):** drive a managed run (mocked HTTP) for single-turn and a
+   multi-turn tool loop; assert exactly one `AGENT.USAGE.RECORDED` per logical call, all required
+   `Tags` present, `Data.costBasisUsd == IProviderPricingService.Compute(provider, model, in, out)`,
+   token split correct, and `Data` contains **no** `billableUsd`/`marginPct`/`feeUsd` (AC 11).
+2. **Link integrity (AC 5):** one run produces a 32-6 `AGENT.TASK.*` trail event, a `ProviderDiagnostic`
+   row, and an `AGENT.USAGE.RECORDED` event all sharing `correlationId` + `agentId`; assert the join.
+3. **Rollup idempotency (AC 6):** apply the same usage event twice; assert `call_count`/tokens/
+   `cost_basis_usd` counted once; assert per-`(agent, provider, credentialSource, period)` bucketing.
+4. **BYOK vs platform (AC 2, 4):** run with `credentialSource=byok` and with `platform`; assert both
+   record the same provider rate-sheet `costBasisUsd` and the correct discriminator, and that the
+   rollup keeps them in separate buckets.
+5. **Tenant isolation (AC 8) — highest priority:** seed usage for tenants A and B; assert
+   `GET /api/v1/orgs/{B}/agents/usage` returns only B's numbers; assert a member of A hitting B's path
+   is rejected by `RequireTenantMembershipFilter` (403/404); assert a platform owner has no read path
+   to either; assert a **public/system agent** run by A produces a rollup only in A's schema, none on
+   the CP, none visible to the platform owner or to B.
+6. **Non-blocking (AC 9):** inject an `IEventRepository.AppendAsync` failure; assert the agent run
+   still completes (no exception propagates) and an `AGENT.USAGE.EMIT_FAILED` breadcrumb / WARN + metric
+   is produced.
+7. **Epic 20 mapping sanity (AC 12):** assert `callCount`/`totalTokens` in `agent_usage_rollup` are the
+   agent-aware equivalents of 20-3's `workflow_runs`/`llm_tokens` (documentation-backed parity check;
+   no Epic 20 code exists to exercise).
+
+Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/`; docker-bound suites run via
+`sg docker -c "dotnet test ..."`. TDD: write the isolation + producer-schema (no-leakage) tests first.
+
+## Estimated Effort
+
+4-5 days (emitter + types + non-blocking ~1d; managed-run wiring + correlation/credentialSource ~1d;
+rollup migration + idempotent projector ~1.25d; read endpoint + DTOs ~0.5d; tests incl. isolation /
+idempotency / no-leakage / non-blocking ~1.25d).
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/IAgentUsageEmitter.cs` | Create (NEW — emitter seam) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentUsageEmitter.cs` | Create (NEW — `AGENT.USAGE.RECORDED`, cost-basis only, non-blocking) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentUsageContext.cs` | Create (NEW — `AgentUsageContext` + `AgentCallUsage` records) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentUsageTags.cs` | Create (NEW — shared flat-tag builder) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentUsageEventTypes.cs` | Create (NEW — type constants) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentUsageRollupProjector.cs` | Create (NEW — idempotent per-period projector) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentUsageEndpoints.cs` | Create (NEW — tenant-scoped GET usage) |
+| `apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/AgentUsageDtos.cs` | Create (NEW — byAgent/totals; no billableUsd) |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/AgentUsageRollup.cs` | Create (NEW — tenant rollup entity) |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/AgentUsageApplied.cs` | Create (NEW — idempotency ledger entity) |
+| `apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs` | Modify (DbSets + model config for the two tenant tables) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/*_AddAgentUsageRollup.cs` | Create (NEW — tenant EF migration) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (DI for emitter/projector; map `/orgs/{tenantId}/agents/usage`) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentUsageEmitterTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentUsageRollupTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentUsageIsolationTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentUsageEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentUsageNoPricingLeakageTests.cs` | Create |
+
+> Note: `DomainEvent.cs`, `ProviderDiagnostic.cs`, `IProviderPricingService.cs`/`ProviderPricingService.cs`,
+> and `Plan.cs` are **referenced, not modified** — this story reuses the existing DCB row shape,
+> diagnostic entity, and cost-basis pricing seam, and does not touch `Plan` (no pricing here).
+> (`packages/api` is deleted; all work is in the C# `apps/tamma-elsa` stack.)
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, decisions — especially the cost-monitor /
+   pricing origin (`ProviderPricingService` was ported from the TS `packages/cost-monitor`) and the
+   28-1 tenant-scope routing decision (`.dev/decisions/story-28-1-design-calls.md`)
+3. Re-read the Epic 32 design spec `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`
+   — §"Story breakdown" item 9 (**producer; markup engine is 34-5, not here**) and §"Tracking" (usage/
+   cost emission consumed by 34/35/36) are canonical over the legacy "+margin" framing in the spec key
+4. Read 32-6 (`AgentTrailEmitter`/`AgentTrailTags`) — this story mirrors its tenant-scoped emission,
+   tag builder, `correlationId` linkage, and non-blocking contract
+5. Planned TDD approach (Red-Green-Refactor) — isolation + no-pricing-leakage tests first
+
+### Key Design Decisions
+
+- **Producer only — the markup boundary is sacred.** This story emits `costBasisUsd` (provider cost,
+  already computed) + `credentialSource`. It computes **no** `billableUsd`, margin, fee, or plan
+  branch. 34-5 owns that. AC 11 has a test that fails if a pricing field sneaks into `Data`.
+- **Reuse the cost-basis source of truth.** `costBasisUsd` is the existing `ProviderDiagnostic.Cost`
+  (= `IProviderPricingService.Compute`). Do **not** recompute or add a second pricing path.
+- **No new event infrastructure.** `AGENT.USAGE.RECORDED` is a `DomainEvent` in the tenant's
+  `domain_events`; isolation is structural (schema-per-tenant + `IEventRepository`), inherited from
+  Epic 4/28 — same property 32-6 relies on for its trail.
+- **`correlationId` is the join key**, shared across trail (32-6), diagnostic, and usage — so usage
+  re-keys by agent for 32-10 without a new column on `ProviderDiagnostic`.
+- **Rollup is idempotent on event id**, via an applied-ledger, so a future stream replay rebuilds it
+  exactly — DCB hygiene.
+- **One logical call → one usage event.** A multi-turn tool loop accumulates tokens (as
+  `CallLlmInlineActivity` already does via `ToolLoopTokens`) and emits once; benchmarking counts a
+  call, not a turn.
+- **Platform admin has no usage read path by construction** — there is no `OwnerAccess` route, and the
+  tenant-scoped store cannot return cross-tenant rows. A platform owner who owns a public agent sees
+  zero of any tenant's usage of it (Epic 32 tenancy rule).
+
+### Integration Points
+
+- **32-5 managed run** is the sole producer; the emitter is injected into the run loop and called once
+  per LLM call.
+- **`IProviderPricingService` / `ProviderDiagnostic.Cost`** is the cost-basis source.
+- **32-3 `ProviderCredential.Source`** supplies `credentialSource`.
+- **32-6 trail + `correlationId`** is the linkage substrate; **32-10** consumes the agent-keyed
+  rollup; **Epic 34-5/35/36** consume `AGENT.USAGE.RECORDED` + `agent_usage_rollup`.
+- **`RequireTenantMembershipFilter` + `/api/v1/orgs/{tenantId}`** is the existing tenant path-gate the
+  usage read rides, like the 32-6 trail endpoints.
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+| ---- | --------- | ---------- |
+| Pricing/markup logic leaks into the producer (34-5 boundary breach) | High | Cost-basis-only `Data`; no `Plan`/margin reads; AC 11 schema-assertion test fails on any pricing field |
+| Cross-tenant usage leakage | Critical | Tenant-scoped store only; route behind `RequireTenantMembershipFilter`; no `OwnerAccess` route; isolation tests incl. public-agent + platform-admin-denied |
+| Double-counted usage on replay/retry | High | `agent_usage_applied` idempotency ledger keyed by event id; replay test |
+| Usage write aborts a real agent run | High | Non-blocking emitter (swallow + retry + `AGENT.USAGE.EMIT_FAILED`); failure-injection test asserts run completes |
+| Cost basis drifts from the rest of the system | Medium | Single pricing seam reused; `costBasisUsd == Compute(...)` parity test |
+| `credentialSource` unavailable before 32-3 lands | Medium | Default to `platform`; correctness test once 32-3 wired |
+| `agentId`/`agentVersion` unavailable before 32-1 lands | Medium | Source from resolved config identity; treat 32-1 as prerequisite |
+
+### Success Metrics
+
+- [ ] 100% of agent LLM calls emit exactly one `AGENT.USAGE.RECORDED` in the correct tenant schema
+- [ ] `costBasisUsd` on every event equals the pricing-seam value (parity test green)
+- [ ] 0 pricing/markup fields present in emitted `Data` (AC 11 test green)
+- [ ] 0 cross-tenant usage reads possible (isolation suite green)
+- [ ] Rollup is replay-idempotent (idempotency test green)
+
+## Logging Requirements
+
+- **INFO**: usage recorded (`tenantId`, `agentId`, `provider`, `model`, `credentialSource`,
+  `totalTokens`, `costBasisUsd`, `correlationId`); usage view served (`tenantId`, period, agent count)
+- **DEBUG**: usage event appended (`type`, `agentId`, `sequenceNumber`); rollup folded (`agentId`,
+  `provider`, period, new totals); idempotent skip (event already applied)
+- **WARN**: usage emit failed/retried (`agentId`, `provider`, `correlationId`, error);
+  `AGENT.USAGE.EMIT_FAILED` breadcrumb emitted
+- **ERROR**: terminal usage-emit failure after retries (run still completes); rollup write failure;
+  usage query repository failure
+- **Structured context**: include `{ tenantId, agentId, agentVersion, provider, model,
+  credentialSource, correlationId, costBasisUsd }` where applicable
+- **Credential safety**: NEVER log API keys, raw prompts, or tool content; cost basis, token counts,
+  and identity dimensions only. `credentialSource` is the discriminator — never the key
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |
+</content>
+</invoke>

--- a/docs/stories/epic-34/README.md
+++ b/docs/stories/epic-34/README.md
@@ -1,0 +1,393 @@
+# Epic 34: Pricing, Plans & Entitlements
+
+## Overview
+
+Epic 34 is the **pricing model layer** of Tamma SaaS: a production catalog of plans, features,
+per-plan entitlements/quotas, and the rules that turn measured usage into a priced amount. It is the
+monetization foundation that Billing (Epic 35) charges against and a sibling Enforcement epic
+consumes — but it deliberately stops short of invoicing/payment capture and runtime gate
+enforcement.
+
+The catalog is a **tenant-aware price-book** built on the C# `apps/tamma-elsa` stack. Plans, features,
+typed entitlements, and prices are immutable, versioned, control-plane rows
+(`ControlPlaneDbContext`); a tenant assigned `team v1` keeps reproducible `team v1` pricing and
+quotas forever, even after `team v2` re-prices. The epic distinguishes **BYOK** (tenant brings its
+own provider API key, stored in the Epic 29 secret cabinet → flat platform/seat fee, no token markup)
+from **platform-provided** usage (our cost basis from `ProviderPricingService` + a configurable
+margin), assigns plans (including custom enterprise plans) to tenants, and applies trials, prepaid
+credits, and promo codes. It exposes a small set of read APIs — resolve plan, resolve entitlements,
+price a usage line, price net of credits — that downstream epics consume through a single published
+contract (`IPricingContract`, Story 34-10).
+
+Per CLAUDE.md's "two scoping models" rule, every pricing feature answers ownership in **both** modes:
+the plan/margin catalog is **platform-owned and global** in single-user (sole user reads it) and SaaS
+(platform owner authors it; tenants get read-only resolved snapshots); per-tenant state (plan
+assignment, BYOK mode, credits) is keyed by `user_id` in single-user mode and `tenant_id` in SaaS
+mode.
+
+### Supersedes
+
+Epic 34 re-targets and retires the stale TypeScript monetization surface (everything below is on the
+deleted `packages/api`; this epic re-implements it on `apps/tamma-elsa`):
+
+- **TS Epic 20 plan/pricing stories** — `20-1` (Stripe integration & **plan model**) and `20-4`
+  (**usage-limits enforcement** plan/quota model). Their plan/quota scope is now owned by 34-1
+  (catalog), 34-4 (assignment), and 34-6 (entitlements) + the sibling Enforcement epic. Story 34-10
+  marks `20-1` / `20-4` `superseded` in `docs/sprint-status.yaml`. (Stripe-specific subscription,
+  checkout, portal, webhook, metering, and billing-dashboard scope — `20-2`, `20-3`, `20-5` — is
+  **re-homed to Epic 35 (Billing)**, not retired by this epic.)
+- **The legacy `Plan.Quotas` opaque-JSON model** — replaced by typed `PlanFeature` /
+  `PlanEntitlement` / `PlanPrice` rows keyed off the closed `EntitlementMetricKey` enum. Story 34-10
+  back-fills every legacy `Plan.Quotas` blob and loose `Tenant.Plan` string into structured rows.
+- **The Epic 21-2 pricing page** — the public/admin pricing surface is now driven by the catalog +
+  the dashboards in Story 34-9.
+
+## Plans & Entitlements
+
+The seeded baseline catalog (`PlansSeeder` + structured child rows, insert-missing-only). Prices are
+split by **pricing mode**: BYOK rows carry a platform/seat fee with **no token markup**;
+platform-provided rows are billed cost-plus-margin (default global margin `1.3×`, Story 34-5).
+
+| Plan | Pricing mode | Recurring (USD/mo) | Workflow Runs | LLM Tokens | Seats | Repos | Agents | Custom |
+|------|--------------|--------------------|---------------|------------|-------|-------|--------|--------|
+| **Free** | platform-provided | $0 | metered/block | metered/block | 1 | 3 | limited | no |
+| **Team** | platform-provided · BYOK | paid · seat fee | metered | cost+margin · BYOK 0 markup | multi | multi | multi | no |
+| **Enterprise** | platform-provided · BYOK | custom | unlimited (`NULL`) | custom | custom | custom | custom | `IsCustom = true` |
+
+Typed entitlement metrics (closed `EntitlementMetricKey` enum, persisted snake_case, shared by
+entitlement limits, metered pricing, metering, and enforcement so a quota key never drifts):
+`agents`, `workflow_runs`, `llm_tokens`, `seats`, `repos`, `rag_storage_mb`,
+`benchmark_retention_days`. Each `PlanEntitlement` row carries a `LimitValue` (`NULL` = unlimited), a
+`Period` (`monthly | total`), and an `OverageMode` (`block | allow | meter`). Trials, prepaid/granted
+USD credits, and promo codes (Story 34-7) layer on top of the resolved plan price.
+
+> Concrete numeric limits per plan are seeded as `PlanEntitlement` rows and are admin-editable via the
+> catalog CRUD (Story 34-2); the table above is the structural shape, not a frozen price sheet.
+
+## Stories
+
+| Story | Title | Priority | Status | Est. Effort |
+|-------|-------|----------|--------|-------------|
+| 34-1 | Plan & Price-Book Catalog Data Model | P0 | drafted | 4-5 days |
+| 34-2 | Plan Catalog Admin API & Custom Enterprise Plans | P0 | drafted | 3-4 days |
+| 34-3 | BYOK vs Platform-Provided Pricing Mode (per-provider, secret-cabinet wired) | P0 | drafted | 4-5 days |
+| 34-4 | Per-Tenant Plan Assignment & Lifecycle | P0 | drafted | 3-4 days |
+| 34-5 | Cost→Price Markup Engine (platform-provided usage) | P0 | drafted | 3-4 days |
+| 34-6 | Entitlement & Quota Resolution Service | P0 | drafted | 3-4 days |
+| 34-7 | Trials, Credits & Promo Codes | P1 | drafted | 4-5 days |
+| 34-8 | Pricing Audit, Events & Reproducibility | P1 | drafted | 3-4 days |
+| 34-9 | Pricing & Plan Management Dashboards | P1 | drafted | 4-5 days |
+| 34-10 | Epic 20 Decommission & Pricing Contract Migration | P0 | drafted | 3-4 days |
+
+## Architecture
+
+```
++-----------------------------------------------------------------------------+
+|              EPIC 34: PRICING, PLANS & ENTITLEMENTS                          |
+|              (control-plane resident; apps/tamma-elsa C#)                    |
++-----------------------------------------------------------------------------+
+|                                                                             |
+|  +-- LAYER 1: Catalog Foundation (34-1, 34-2) -------------------------+    |
+|  |                                                                     |    |
+|  |  +----------------+ +------------------+ +----------------------+   |    |
+|  |  | Plan (versioned| | PlanFeature /    | | Plan Catalog Admin   |   |    |
+|  |  | immutable rows)| | Entitlement /    | | API + Custom         |   |    |
+|  |  | EntitlementKey | | Price (by mode)  | | Enterprise Plans     |   |    |
+|  |  +----------------+ +------------------+ +----------------------+   |    |
+|  +---------------------------------------------------------------------+    |
+|                              |                                              |
+|  +-- LAYER 2: Pricing Mode & Assignment (34-3, 34-4) ------------------+    |
+|  |                              |                                       |    |
+|  |  +-------------------------+ +-----------------------------------+   |    |
+|  |  | BYOK vs Platform mode   | | Per-Tenant Plan Assignment &      |   |    |
+|  |  | per (tenant, provider)  | | Lifecycle (pin PlanId+Version)    |   |    |
+|  |  | -> Epic 29 secret       | | TenantPlanAssignment (active row) |   |    |
+|  |  |    cabinet (ISecretStore)| |                                  |   |    |
+|  |  +-------------------------+ +-----------------------------------+   |    |
+|  +---------------------------------------------------------------------+    |
+|                              |                                              |
+|  +-- LAYER 3: Pricing & Entitlement Resolution (34-5, 34-6, 34-7) ----+    |
+|  |                              |                                       |    |
+|  |  +----------------+ +------------------+ +----------------------+   |    |
+|  |  | Cost->Price    | | Entitlement &    | | Trials / Credits /   |   |    |
+|  |  | Markup Engine  | | Quota Resolution | | Promo Codes          |   |    |
+|  |  | (pure; margin  | | (closed 7-metric | | (net price = sell -  |   |    |
+|  |  |  policy)       | |  map per tenant) | |  promo - credits)    |   |    |
+|  |  +----------------+ +------------------+ +----------------------+   |    |
+|  +---------------------------------------------------------------------+    |
+|                              |                                              |
+|  +-- LAYER 4: Audit, UI & Published Contract (34-8, 34-9, 34-10) -----+    |
+|  |                              |                                       |    |
+|  |  +----------------+ +------------------+ +----------------------+   |    |
+|  |  | Pricing Audit, | | Admin + Tenant   | | IPricingContract     |   |    |
+|  |  | Events & Time- | | Dashboards       | | (sole surface for    |   |    |
+|  |  | Travel Replay  | | (catalog + plan) | |  Epic 35 / Enforce)  |   |    |
+|  |  +----------------+ +------------------+ +----------------------+   |    |
+|  +---------------------------------------------------------------------+    |
+|                              |                                              |
+|        consumed by ->  Epic 35 (Billing)   +   Enforcement epic            |
++-----------------------------------------------------------------------------+
+```
+
+## Key Technical Decisions
+
+### Immutable, Versioned Catalog Rows (No In-Place Plan Edits)
+
+A `Plan` (and its `PlanFeature` / `PlanEntitlement` / `PlanPrice` children) is immutable once
+`Status = active | deprecated`. Editing produces a **new** `Plan` row with `Version = prior + 1` and
+`SupersedesPlanId = priorId`, and flips the prior row to `deprecated`. A partial unique index
+`UX_plans_OneActivePerSlug` (filtered on `Status = 'active'`) enforces exactly one active version per
+slug at the database level. Mutating an active/deprecated row throws
+`TammaError("PLAN.VERSION.IMMUTABLE", …)`. This is the reproducibility guarantee: a tenant pinned to
+`team v1` keeps `team v1` pricing/quotas forever, so billing and historical invoices re-derive
+identically.
+
+### `EntitlementMetricKey` — Single Source of Quota-Key Truth
+
+A closed enum (`Agents`, `WorkflowRuns`, `LlmTokens`, `Seats`, `Repos`, `RagStorageMb`,
+`BenchmarkRetentionDays`) in `Tamma.Core/Enums/`, persisted as snake_case text (never the numeric
+ordinal) via an EF `HasConversion` value converter. The same key is shared by entitlement limits,
+metered pricing components, usage metering (Epic 35), and enforcement — so a typo can never split
+`llm_tokens` from `llmTokens` across layers.
+
+### BYOK vs Platform-Provided as the Pricing-Mode Axis
+
+`PlanPrice` is split by `PricingMode` (`platform_provided | byok`) at the plan level; a
+per-`(tenant, provider)` override lives in `TenantProviderBilling` (Story 34-3). The
+`IProviderKeyResolver` resolves the effective key + mode: **BYOK** reads the tenant's secret from the
+Epic 29 cabinet (`ISecretStore`, `SecretScope.Tenant`); **platform** falls back to the global config
+key. There is **no silent empty fallback** — a BYOK row with a missing cabinet secret throws
+`TammaError("PROVIDER.KEY.RESOLVE.BYOK_MISSING", …)` (mirrors the no-empty-fallback rule), never
+degrading to the platform key (which would mis-bill and leak the platform quota). This story also
+closes a real production gap: `CallLlmActivity` currently only ever reads the global platform key.
+
+### Pure, Deterministic Markup Engine
+
+`IUsagePricingEngine.PriceUsage(UsageLine)` is **side-effect-free**: it takes a resolved
+`MarginPolicy` + `UsageLine` and returns `PricedUsage { CostBasisUsd, MarginUsd, SellPriceUsd,
+PricingMode }`. Cost basis comes from `ProviderPricingService` (input/output tokens billed at
+different rates). For `platform_provided`, `SellPrice = CostBasis × MarkupMultiplier (+ FixedUsdPer1M
+× tokens/1M)`; for `byok`, the **token component is 0** (the seat/plan fee is Billing's concern).
+Margin resolution order is **provider → plan → global → error** (`PRICING.MARGIN.NO_POLICY` if none —
+never a silent zero margin). Pricing is byte-stable: 6dp internal arithmetic
+(`MidpointRounding.ToEven`), 2dp invoice-facing, pinned by a golden-file test.
+
+### One Published Contract for Downstream Epics
+
+`IPricingContract` (Story 34-10) is the **only** surface Billing (Epic 35) and Enforcement call into,
+exposing `ResolvePlanAsync`, `ResolveEntitlementsAsync`, `PriceUsageAsync`, and `PriceNetAsync`. No
+other epic may take a direct dependency on `Plan`, `PlanEntitlement`, `PlanPrice`,
+`TenantPlanAssignment`, `IUsagePricingEngine`, `IEntitlementService`, or
+`ICreditAwarePricingEngine` — the façade freezes the surface and the contract conformance tests pin
+its shapes.
+
+### Event Sourcing & Time-Travel Pricing Audit
+
+Every pricing decision emits a canonical DCB event to the control-plane `platform_events` /
+`DomainEvents` store via `IPlatformEventPublisher` / `IEventRepository`:
+`PLAN.VERSION.CREATED`, `PLAN.DEPRECATED`, `PRICING.BYOK.ENABLED` / `.DISABLED`,
+`PRICING.MARGIN.UPDATED`, plan-assignment / credit / promo events, and the back-fill events
+(`PRICING.BACKFILL.*`). Story 34-8 adds a replay query that reconstructs exactly "what plan / price /
+entitlements / BYOK-mode applied to tenant X at timestamp T" — time-travel debugging of money.
+
+### Per-Mode Ownership
+
+| Concern | single-user | SaaS |
+|---|---|---|
+| Plan / margin catalog | platform-global rows; sole user reads | platform owner (`OwnerAccess`) authors; tenants read-only |
+| Plan assignment | the user's instance | per-tenant `TenantPlanAssignment` (owner/admin) |
+| BYOK mode + key | the user (no RBAC); global config key | per-`(tenant, provider)`; `PricingManage` gate (owner+admin); member → 403 |
+| Credits / trials / promos | the user | per-tenant; owner/admin manage |
+
+## Dependencies
+
+### On Other Epics
+
+- **Epic 4** (DCB events): `platform_events` / `DomainEvents` store, `PlatformEvent` entity,
+  `IPlatformEventPublisher.AppendAndPublishAsync` / `IEventRepository.AppendAsync` for the audit trail.
+- **Epic 28** (control plane / tenancy): `ControlPlaneDbContext`, `TammaModelConfiguration`, the
+  `Tenant.PlanId` shadow column + FK to `plans`, `PlansSeeder`, and the
+  `Migrations/ControlPlane/` pipeline.
+- **Epic 29** (secret cabinet): `ISecretStore`, `SecretRef.ForTenant`, `SecretScope.Tenant`,
+  `SecretPurpose.ApiKey` for BYOK key storage/retrieval (consumed, not modified).
+- **Epic 32** (agents / provider chain): defines the provider chain BYOK applies to; Story 32-3 owns
+  the cabinet read-path mechanics; per-call cost basis comes from the provider chain's diagnostics.
+- **`ProviderPricingService`** (existing): the per-call cost-basis source the markup engine reads.
+
+### Consumers (downstream — depend on this epic)
+
+- **Epic 35 (Billing)**: charges against `PlanEntitlement` / `PlanPrice`; metering keys off
+  `EntitlementMetricKey`; calls `IPricingContract` only.
+- **Sibling Enforcement epic**: consumes `EntitlementMetricKey` + resolved entitlements through
+  `IPricingContract` to gate runtime usage. (Enforcement is **not** in Epic 34 scope.)
+
+### External Dependencies
+
+- **PostgreSQL 17**: partial unique indexes (`WHERE Status = 'active'`), jsonb metered components,
+  CHECK constraints pinning closed enums.
+- **EF Core 9 / Npgsql**: value converters (`EntitlementMetricKey`), additive control-plane migrations.
+- **No Stripe / payment dependency in this epic** — pricing data is computed and stored, not charged.
+  Charging, checkout, invoices, and webhooks are Epic 35.
+
+## Database Schema
+
+All Epic 34 tables are **control-plane resident** (global rows in `ControlPlaneDbContext`) — there is
+**no per-tenant schema (`t_<hex>`) pricing table.
+
+```sql
+-- 34-1: Plan catalog (versioned, immutable). Plan gains versioning columns; legacy
+-- Slug/DisplayName/PlacementPolicy and the opaque Quotas JSON are kept for one deprecation window.
+ALTER TABLE plans ADD COLUMN "Version"          INT  NOT NULL DEFAULT 1;
+ALTER TABLE plans ADD COLUMN "Status"           TEXT NOT NULL DEFAULT 'active'
+  CHECK ("Status" IN ('active','deprecated','draft'));
+ALTER TABLE plans ADD COLUMN "IsCustom"         BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE plans ADD COLUMN "BillingInterval"  TEXT NOT NULL DEFAULT 'monthly'
+  CHECK ("BillingInterval" IN ('monthly','annual'));
+ALTER TABLE plans ADD COLUMN "SupersedesPlanId" UUID REFERENCES plans("Id");
+
+CREATE UNIQUE INDEX UX_plans_Slug_Version       ON plans ("Slug", "Version");
+CREATE UNIQUE INDEX UX_plans_OneActivePerSlug   ON plans ("Slug") WHERE "Status" = 'active';
+
+CREATE TABLE plan_features (
+  "Id"          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "PlanId"      UUID NOT NULL REFERENCES plans("Id") ON DELETE RESTRICT,
+  "FeatureKey"  TEXT NOT NULL,            -- e.g. byok_allowed, support_tier
+  "BoolValue"   BOOLEAN,
+  "StringValue" TEXT,
+  UNIQUE ("PlanId", "FeatureKey")
+);
+
+CREATE TABLE plan_entitlements (
+  "Id"          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "PlanId"      UUID NOT NULL REFERENCES plans("Id") ON DELETE RESTRICT,
+  "MetricKey"   TEXT NOT NULL,            -- EntitlementMetricKey snake_case
+  "LimitValue"  BIGINT,                   -- NULL = unlimited
+  "Period"      TEXT NOT NULL DEFAULT 'monthly' CHECK ("Period" IN ('monthly','total')),
+  "OverageMode" TEXT NOT NULL DEFAULT 'block' CHECK ("OverageMode" IN ('block','allow','meter')),
+  UNIQUE ("PlanId", "MetricKey")
+);
+
+CREATE TABLE plan_prices (
+  "Id"               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "PlanId"           UUID NOT NULL REFERENCES plans("Id") ON DELETE RESTRICT,
+  "PricingMode"      TEXT NOT NULL CHECK ("PricingMode" IN ('platform_provided','byok')),
+  "RecurringUsd"     NUMERIC(20,4) NOT NULL DEFAULT 0,
+  "SeatUsd"          NUMERIC(20,4) NOT NULL DEFAULT 0,
+  "MeteredComponent" JSONB NOT NULL DEFAULT '{}',
+  UNIQUE ("PlanId", "PricingMode")
+);
+
+-- 34-3: Per-(tenant, provider) BYOK vs platform mode. BYOK rows carry a cabinet secret name.
+CREATE TABLE tenant_provider_billing (
+  "Id"          UUID PRIMARY KEY DEFAULT gen_random_uuid(),  -- UUIDv7
+  "TenantId"    UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  "ProviderKey" TEXT NOT NULL,            -- "anthropic" | "openai" | "openrouter"
+  "Mode"        TEXT NOT NULL DEFAULT 'platform' CHECK ("Mode" IN ('platform','byok')),
+  "SecretName"  TEXT,                     -- cabinet name when byok; NULL for platform
+  "Status"      TEXT NOT NULL DEFAULT 'active' CHECK ("Status" IN ('active','disabled')),
+  CONSTRAINT ck_tpb_secret_xor CHECK (
+    ("Mode" = 'byok'     AND "SecretName" IS NOT NULL) OR
+    ("Mode" = 'platform' AND "SecretName" IS NULL)),
+  "CreatedAt"   TIMESTAMPTZ NOT NULL, "UpdatedAt" TIMESTAMPTZ NOT NULL,
+  "CreatedBy"   UUID, "UpdatedBy" UUID
+);
+CREATE UNIQUE INDEX ux_tpb_active_provider
+  ON tenant_provider_billing ("TenantId", "ProviderKey") WHERE "Status" = 'active';
+
+-- 34-3: per-call cost record gains the mode the markup engine keys off.
+ALTER TABLE provider_diagnostics ADD COLUMN "BillingMode" TEXT NOT NULL DEFAULT 'platform';
+
+-- 34-4: Pins each tenant to a specific (PlanId, PlanVersion) — exactly one active per tenant.
+CREATE TABLE tenant_plan_assignments (
+  "Id"          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "TenantId"    UUID NOT NULL REFERENCES tenants(id),
+  "PlanId"      UUID NOT NULL REFERENCES plans("Id"),
+  "PlanVersion" INT  NOT NULL,
+  "Status"      TEXT NOT NULL DEFAULT 'active' CHECK ("Status" IN ('active','superseded')),
+  "EffectiveFrom" TIMESTAMPTZ NOT NULL,
+  "CreatedAt"   TIMESTAMPTZ NOT NULL
+);
+CREATE UNIQUE INDEX ux_tpa_one_active_per_tenant
+  ON tenant_plan_assignments ("TenantId") WHERE "Status" = 'active';
+
+-- 34-5: Margin policy (provider > plan > global resolution). At least one of multiplier / fixed.
+CREATE TABLE margin_policies (
+  "Id"               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "Scope"            TEXT NOT NULL CHECK ("Scope" IN ('global','plan','provider')),
+  "RefKey"           TEXT,                 -- NULL=global, plan slug, or provider key
+  "MarkupMultiplier" NUMERIC(20,6),
+  "FixedUsdPer1M"    NUMERIC(20,6),
+  "EffectiveFrom"    TIMESTAMPTZ NOT NULL,
+  "Status"           TEXT NOT NULL DEFAULT 'active' CHECK ("Status" IN ('active','superseded')),
+  CONSTRAINT ck_margin_nonempty CHECK (
+    "MarkupMultiplier" IS NOT NULL OR "FixedUsdPer1M" IS NOT NULL),
+  "CreatedAt"        TIMESTAMPTZ NOT NULL, "UpdatedAt" TIMESTAMPTZ NOT NULL
+);
+CREATE UNIQUE INDEX ux_margin_one_active
+  ON margin_policies ("Scope", "RefKey") NULLS NOT DISTINCT WHERE "Status" = 'active';
+
+-- 34-7: trials, prepaid/granted USD credits, promo codes (control-plane, per-tenant).
+-- tenant_trials, tenant_credits (granted/consumed USD ledger), promo_codes + redemptions.
+```
+
+## Implementation Phases
+
+### Phase 1: Catalog Foundation (34-1, 34-2) — Week 1
+
+- Versioned/immutable `Plan` + `PlanFeature` / `PlanEntitlement` / `PlanPrice` rows;
+  `EntitlementMetricKey` enum; `IPlanCatalogService` + `PlanSnapshot`; immutability + supersede
+  guard; insert-missing-only seeder.
+- Admin CRUD / version-management API + custom enterprise plans.
+- Estimated: 7-9 days
+
+### Phase 2: Pricing Mode & Assignment (34-3, 34-4) — Week 2
+
+- `TenantProviderBilling` + `IProviderKeyResolver`; close the BYOK gap in `CallLlmActivity`;
+  enable/disable flows wired to the Epic 29 cabinet; `ProviderDiagnostic.BillingMode`.
+- `TenantPlanAssignment` (pin `PlanId` + `PlanVersion`); audited assign/change lifecycle.
+- Estimated: 7-9 days
+
+### Phase 3: Pricing & Entitlement Resolution (34-5, 34-6, 34-7) — Week 3
+
+- Pure `IUsagePricingEngine` + `MarginPolicy` (provider→plan→global); `IEntitlementService` (closed
+  7-metric resolved map per tenant); trials/credits/promos + net-price engine.
+- Estimated: 10-13 days
+
+### Phase 4: Audit, UI & Published Contract (34-8, 34-9, 34-10) — Week 4
+
+- Pricing audit events + time-travel replay query; admin + tenant dashboards; `IPricingContract`
+  façade, Epic 20 decommission, and the legacy `Plan.Quotas` / `Tenant.Plan` back-fill.
+- Estimated: 10-13 days
+
+## Success Metrics
+
+- A tenant pinned to a plan version re-derives identical pricing/quotas after that version is
+  deprecated (100% reproducibility; golden-file + contract conformance tests green).
+- 0% reads of the platform key for a BYOK `(tenant, provider)` row; 100% of BYOK-miss cases throw
+  `PROVIDER.KEY.RESOLVE.BYOK_MISSING` (no silent empty / no platform fallback in any test).
+- After back-fill, **no non-deleted tenant lacks an active plan assignment** (verification query
+  returns zero rows); the back-fill is idempotent (second run inserts zero rows).
+- Exactly one `active` plan version per slug and one `active` assignment per tenant at all times
+  (DB-enforced partial unique indexes; no race leaves two active rows).
+- `ResolveEntitlementsAsync` always returns all 7 `EntitlementMetricKey` members (closed map).
+- Every pricing decision is replayable: "plan/price/entitlements/BYOK-mode for tenant X at T" is
+  reconstructable from `platform_events` with zero un-explainable priced amounts.
+- No downstream epic takes a direct dependency on pricing entities — all cross-epic reads go through
+  `IPricingContract` (enforced by the contract conformance tests).
+
+## Reference Documents
+
+- [Epic 34 Stories](./) — `story-34-1/` … `story-34-10/`
+- [Pricing Contract (Story 34-10)](./pricing-contract.md) — the stable `IPricingContract` surface
+- [CLAUDE.md — Operating Modes & Prompt Store RBAC](../../../CLAUDE.md) — per-mode ownership rules
+- [CLAUDE.md — Multi-tenant provisioning (Cranl)](../../../CLAUDE.md) — control-plane / tenancy model
+- [Epic 20 README](../epic-20/README.md) — superseded TS billing/plan plan (see Supersedes above)
+- [Migration Ordering Note](../migration-ordering.md) — control-plane vs tenant-schema ordering
+- [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md) — mandatory 7-phase development workflow
+
+---
+
+**Last Updated**: 2026-06-17
+**Epic Owner**: TBD
+**Implementation Start**: TBD
+**Total Estimated Effort**: 34-44 days

--- a/docs/stories/epic-34/story-34-1/34-1-plan-and-price-book-catalog-data-model.md
+++ b/docs/stories/epic-34/story-34-1/34-1-plan-and-price-book-catalog-data-model.md
@@ -1,0 +1,381 @@
+# Story 34-1: Plan & Price-Book Catalog Data Model
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide covers the 7-phase workflow (Read → Research → Break Down → TDD → Quality Gates → Failure Handling), the `.dev/` knowledge base, TRACE/DEBUG logging, test-first development, 100% coverage on critical paths, and build-success enforcement.
+
+## User Story
+
+As a **platform owner**,
+I want a structured, immutable, versioned price-book on the control plane — plans with typed feature flags, typed quota entitlements, and recurring + metered pricing components — instead of the current opaque `Plan.Quotas` JSON blob,
+so that billing (Epic 35), the markup engine, and entitlement enforcement all read the same canonical catalog, and a tenant assigned a plan keeps reproducible pricing/quotas forever even after the plan is re-priced.
+
+## Priority
+
+P0 — This is the schema foundation every other Epic 34 story builds on. Without typed entitlements and a versioned, immutable catalog, billing charges and quota enforcement cannot reference a stable source of truth.
+
+## Acceptance Criteria
+
+1. New control-plane entity `Plan` is extended (replacing the thin skeleton in `apps/tamma-elsa/src/Tamma.Data/Entities/Plan.cs`) with: `Version` (int), `Status` (`active`|`deprecated`|`draft`), `IsCustom` (bool), `BillingInterval` (`monthly`|`annual`), and `SupersedesPlanId` (`Guid?` pointing at the prior version). The legacy `Slug`, `DisplayName`, `PlacementPolicy`, and `Tenant.PlanId` FK contract are preserved so `AdminTenantsEndpoints.UpdateTenantPlan` keeps working unchanged.
+2. New entity `PlanFeature` (`Id`, `PlanId`, `FeatureKey`, `BoolValue` nullable, `StringValue` nullable) added to `ControlPlaneDbContext` — boolean capability flags (e.g. `byok_allowed`) and string feature values (e.g. `support_tier = priority`) per plan version.
+3. New entity `PlanEntitlement` (`Id`, `PlanId`, `MetricKey` (enum), `LimitValue` `long?` where `NULL` = unlimited, `Period` (`monthly`|`total`), `OverageMode` (`block`|`allow`|`meter`)) added to `ControlPlaneDbContext` — one typed quota row per metric per plan version.
+4. New entity `PlanPrice` (`Id`, `PlanId`, `PricingMode` (`platform_provided`|`byok`), `RecurringUsd` `decimal`, `SeatUsd` `decimal`, `MeteredComponent` jsonb) added to `ControlPlaneDbContext` — recurring + per-seat + metered/overage pricing, split by pricing mode so BYOK tenants get a distinct price row from platform-provided tenants.
+5. `EntitlementMetricKey` is a closed enum in `Tamma.Core/Enums/EntitlementMetricKey.cs` with members `Agents`, `WorkflowRuns`, `LlmTokens`, `Seats`, `Repos`, `RagStorageMb`, `BenchmarkRetentionDays`, persisted as snake_case strings (`agents`, `workflow_runs`, `llm_tokens`, `seats`, `repos`, `rag_storage_mb`, `benchmark_retention_days`), shared by entitlement, pricing, metering, and enforcement layers so quota keys never drift.
+6. A plan version is immutable after activation: any attempt to mutate a `Plan` row (or its child `PlanFeature`/`PlanEntitlement`/`PlanPrice` rows) whose `Status = active` or `Status = deprecated` throws a `TammaError("PLAN.VERSION.IMMUTABLE", ...)`. Editing produces a NEW `Plan` row with `Version = prior + 1`, `SupersedesPlanId = priorId`, `Status = active`, and flips the prior row to `deprecated`.
+7. A `UNIQUE (Slug, Version)` constraint plus a partial unique index `UX_plans_OneActivePerSlug` filtered on `Status = 'active'` enforce exactly one `active` version per slug at the database level; `CHECK` constraints pin `Status`, `BillingInterval` on `Plan`, `Period`/`OverageMode` on `PlanEntitlement`, and `PricingMode` on `PlanPrice` to their closed enums.
+8. An EF Core migration in `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/` adds the three new tables (`plan_features`, `plan_entitlements`, `plan_prices`) and the new `Plan` columns, with FK `OnDelete(Restrict)` from each child to `plans(Id)` and a self-referencing FK `SupersedesPlanId → plans(Id)`. `dotnet ef migrations has-pending-model-changes` reports none after the migration is added.
+9. `PlansSeeder.cs` is extended to seed structured `PlanFeature` / `PlanEntitlement` / `PlanPrice` rows for `free` / `team` / `enterprise` with deterministic UUIDv7 ids, **insert-missing-only** (never reverts admin edits — mirrors convention system-defaults ownership). Existing `FreePlanId` / `TeamPlanId` / `EnterprisePlanId` constants stay; their version-1 rows get `Version = 1`, `Status = active`.
+10. All catalog reads go through `IPlanCatalogService` (`apps/tamma-elsa/src/Tamma.Api/Services/Pricing/`) returning a fully-resolved immutable `PlanSnapshot` (plan header + features + entitlements + prices for a given plan version). `GetActiveBySlugAsync(slug)`, `GetByIdAsync(planId)`, and `GetForTenantAsync(tenantId)` (resolves the tenant's `PlanId` shadow column then snapshots) are the read seams.
+11. Catalog mutations are admin-only (`OwnerAccess` policy) and emit DCB events to `platform_events` via `IPlatformEventPublisher`: `PLAN.VERSION.CREATED` on a new version, `PLAN.DEPRECATED` when a prior version flips to deprecated. Tags include `slug`, `version`, `planId`, `supersedesPlanId`, `source = admin`.
+12. Per-mode handling: the catalog is **platform-owned** in both modes (single-user and SaaS) — plans are global control-plane rows, never tenant-scoped. In single-user mode the sole user reads the catalog (no overrides). In SaaS mode, only platform owners (`OwnerAccess`) may create/deprecate versions; tenant members get read-only resolved snapshots for their assigned plan. There is no per-tenant plan override layer.
+13. Unit tests cover: immutability guard (mutating an `active`/`deprecated` plan throws `PLAN.VERSION.IMMUTABLE`), version-supersede chain (v1 → v2 → v3 with correct `SupersedesPlanId` links), one-active-version invariant (two active rows for one slug rejected by the partial unique index), seeder idempotency (second `SeedAsync` is a no-op and does not revert an edited row), snapshot resolution (features+entitlements+prices assembled correctly per version), and event emission (`PLAN.VERSION.CREATED` / `PLAN.DEPRECATED` appended with correct tags).
+
+## Technical Design
+
+### Namespace & file structure
+
+```
+apps/tamma-elsa/src/
+  Tamma.Core/Enums/
+    EntitlementMetricKey.cs            # NEW — closed quota-key enum (Tamma.Core.Enums)
+  Tamma.Data/Entities/
+    Plan.cs                            # MODIFIED — versioning + status + pricing-mode columns
+    PlanFeature.cs                     # NEW (Tamma.Data.Entities)
+    PlanEntitlement.cs                 # NEW
+    PlanPrice.cs                       # NEW
+  Tamma.Data/
+    ControlPlaneDbContext.cs           # MODIFIED — 3 new DbSets + Configure* methods
+    Seeders/PlansSeeder.cs             # MODIFIED — seed structured child rows
+    Migrations/ControlPlane/
+      <timestamp>_PlanPriceBookCatalog.cs   # NEW EF migration
+  Tamma.Api/Services/Pricing/          # NEW directory
+    IPlanCatalogService.cs             # NEW (Tamma.Api.Services.Pricing)
+    PlanCatalogService.cs              # NEW
+    PlanSnapshot.cs                    # NEW — immutable read DTO record
+    PlanVersionEditor.cs               # NEW — immutability + supersede orchestration
+    PlanCatalogEventTypes.cs           # NEW — PLAN.VERSION.CREATED / PLAN.DEPRECATED
+  Tamma.Api/Extensions/
+    PricingServiceCollectionExtensions.cs  # NEW — DI wiring (mirror Alert extension pattern)
+```
+
+### Enum — `EntitlementMetricKey` (Tamma.Core)
+
+```csharp
+namespace Tamma.Core.Enums;
+
+/// <summary>
+/// Closed set of meterable/limitable quota dimensions. Shared by
+/// PlanEntitlement (limits), PlanPrice metered components (pricing),
+/// usage metering (Epic 35), and enforcement (Epic 34 later stories) so a
+/// quota key is identical across every layer. Persisted as the snake_case
+/// string (see <see cref="EntitlementMetricKeyExtensions"/>), never the
+/// numeric ordinal — ordinals are not a stable wire/DB contract.
+/// </summary>
+public enum EntitlementMetricKey
+{
+    Agents,
+    WorkflowRuns,
+    LlmTokens,
+    Seats,
+    Repos,
+    RagStorageMb,
+    BenchmarkRetentionDays,
+}
+```
+
+A companion `EntitlementMetricKeyExtensions.ToMetricString()` / `Parse(string)` maps to/from the snake_case persisted form; EF uses a `HasConversion` value converter so the DB column stores `text`, not an int.
+
+### Entities
+
+`Plan.cs` (modified — new fields, legacy fields kept):
+
+```csharp
+public class Plan
+{
+    public Guid Id { get; set; }
+    public string Slug { get; set; } = null!;            // free | team | enterprise (kept)
+    public string DisplayName { get; set; } = null!;      // (kept)
+    public int Version { get; set; } = 1;                 // NEW
+    public string Status { get; set; } = "draft";         // NEW: active | deprecated | draft
+    public bool IsCustom { get; set; }                    // NEW: bespoke enterprise plan
+    public string BillingInterval { get; set; } = "monthly"; // NEW: monthly | annual
+    public Guid? SupersedesPlanId { get; set; }           // NEW: prior version
+    public decimal MonthlyPriceUsd { get; set; }          // kept (display convenience; canonical price now in PlanPrice)
+    public string PlacementPolicy { get; set; } = "shared"; // kept (unified tenancy)
+    public bool IsActive { get; set; } = true;            // kept (signup-surface flag)
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+
+    public ICollection<PlanFeature> Features { get; set; } = [];
+    public ICollection<PlanEntitlement> Entitlements { get; set; } = [];
+    public ICollection<PlanPrice> Prices { get; set; } = [];
+}
+```
+
+> The opaque `Quotas` string column is retained on the row (and migration) for one deprecation window so any not-yet-migrated reader still compiles; new code reads `Entitlements`. A follow-up story drops it once Epic 35 is off the JSON.
+
+`PlanEntitlement.cs`:
+
+```csharp
+public class PlanEntitlement
+{
+    public Guid Id { get; set; }
+    public Guid PlanId { get; set; }
+    public EntitlementMetricKey MetricKey { get; set; }   // value-converted to text
+    public long? LimitValue { get; set; }                 // NULL = unlimited
+    public string Period { get; set; } = "monthly";       // monthly | total
+    public string OverageMode { get; set; } = "block";    // block | allow | meter
+}
+```
+
+`PlanFeature.cs`: `Id`, `PlanId`, `FeatureKey` (text), `BoolValue` (`bool?`), `StringValue` (`string?`).
+`PlanPrice.cs`: `Id`, `PlanId`, `PricingMode` (`platform_provided`|`byok`), `RecurringUsd` (`decimal(20,4)`), `SeatUsd` (`decimal(20,4)`), `MeteredComponent` (jsonb, default `'{}'`).
+
+### EF model config (in `ControlPlaneDbContext.OnModelCreating`)
+
+Add `ConfigurePlans`, `ConfigurePlanFeatures`, `ConfigurePlanEntitlements`, `ConfigurePlanPrices` mirroring the existing `ConfigureAlertRules` / `ConfigureTenantDatabases` style:
+
+```csharp
+modelBuilder.Entity<Plan>(entity =>
+{
+    entity.ToTable("plans", t =>
+    {
+        t.HasCheckConstraint("ck_plans_status",
+            "\"Status\" IN ('active','deprecated','draft')");
+        t.HasCheckConstraint("ck_plans_billing_interval",
+            "\"BillingInterval\" IN ('monthly','annual')");
+    });
+    entity.HasKey(e => e.Id);
+    entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+    entity.Property(e => e.Slug).IsRequired().HasMaxLength(100);
+    entity.Property(e => e.Version).HasDefaultValue(1);
+    entity.Property(e => e.Status).IsRequired().HasMaxLength(20).HasDefaultValue("draft");
+    entity.Property(e => e.BillingInterval).IsRequired().HasMaxLength(20).HasDefaultValue("monthly");
+
+    entity.HasIndex(e => new { e.Slug, e.Version })
+        .HasDatabaseName("UX_plans_Slug_Version").IsUnique();
+
+    // Exactly one active version per slug — the immutability invariant in SQL.
+    entity.HasIndex(e => e.Slug)
+        .HasDatabaseName("UX_plans_OneActivePerSlug")
+        .HasFilter("\"Status\" = 'active'").IsUnique();
+
+    entity.HasOne<Plan>().WithMany()
+        .HasForeignKey(e => e.SupersedesPlanId)
+        .OnDelete(DeleteBehavior.Restrict);
+});
+```
+
+`PlanEntitlement` config adds CHECKs `ck_plan_entitlements_period` (`'monthly','total'`) and `ck_plan_entitlements_overage` (`'block','allow','meter'`); `PlanPrice` adds `ck_plan_prices_mode` (`'platform_provided','byok'`); each child gets `HasOne<Plan>().WithMany(p => p.Features/...).HasForeignKey(PlanId).OnDelete(Restrict)` and a unique index per natural key (`UX_plan_entitlements_PlanId_MetricKey`, `UX_plan_features_PlanId_FeatureKey`, `UX_plan_prices_PlanId_PricingMode`).
+
+### EF migration sketch
+
+```csharp
+// <timestamp>_PlanPriceBookCatalog.cs  (Tamma.Data.Migrations.ControlPlane)
+migrationBuilder.AddColumn<int>("Version", "plans", defaultValue: 1);
+migrationBuilder.AddColumn<string>("Status", "plans", maxLength: 20, defaultValue: "active"); // existing 3 rows become active
+migrationBuilder.AddColumn<bool>("IsCustom", "plans", defaultValue: false);
+migrationBuilder.AddColumn<string>("BillingInterval", "plans", maxLength: 20, defaultValue: "monthly");
+migrationBuilder.AddColumn<Guid>("SupersedesPlanId", "plans", nullable: true);
+
+migrationBuilder.CreateTable("plan_features", ...);       // Id, PlanId FK, FeatureKey, BoolValue, StringValue
+migrationBuilder.CreateTable("plan_entitlements", ...);   // Id, PlanId FK, MetricKey text, LimitValue, Period, OverageMode
+migrationBuilder.CreateTable("plan_prices", ...);         // Id, PlanId FK, PricingMode, RecurringUsd, SeatUsd, MeteredComponent jsonb
+
+// CHECK + partial-unique indexes per the model config above.
+```
+
+This is a purely additive migration (new columns with defaults backfill the 3 seeded rows, new tables) — `has-pending-model-changes` must report none after generation.
+
+### Snapshot + catalog service
+
+```csharp
+namespace Tamma.Api.Services.Pricing;
+
+public sealed record PlanSnapshot(
+    Guid PlanId, string Slug, string DisplayName, int Version, string Status,
+    bool IsCustom, string BillingInterval, Guid? SupersedesPlanId,
+    IReadOnlyList<PlanFeatureView> Features,
+    IReadOnlyList<PlanEntitlementView> Entitlements,
+    IReadOnlyList<PlanPriceView> Prices);
+
+public interface IPlanCatalogService
+{
+    Task<PlanSnapshot?> GetActiveBySlugAsync(string slug, CancellationToken ct = default);
+    Task<PlanSnapshot?> GetByIdAsync(Guid planId, CancellationToken ct = default);
+    Task<PlanSnapshot?> GetForTenantAsync(Guid tenantId, CancellationToken ct = default);
+    Task<IReadOnlyList<PlanSnapshot>> ListActiveAsync(CancellationToken ct = default);
+}
+```
+
+`GetForTenantAsync` reads the tenant's `PlanId` shadow column via `EF.Property<Guid?>(tenant, "PlanId")` (the existing shadow column wired in `TammaModelConfiguration`) and snapshots that exact version — historical reproducibility, since a deprecated version's rows are immutable.
+
+### Version editor (immutability + supersede)
+
+`PlanVersionEditor.CreateNewVersionAsync(slug, draftSpec, principal, ct)`:
+1. Load current `active` plan + children for `slug`.
+2. Insert a new `Plan` row: `Version = current.Version + 1`, `SupersedesPlanId = current.Id`, `Status = active`, copy/override features/entitlements/prices from `draftSpec`.
+3. Flip `current.Status` to `deprecated`.
+4. Both in one transaction; the partial unique index `UX_plans_OneActivePerSlug` guarantees the flip-then-insert ordering can never leave two active rows.
+5. Emit `PLAN.VERSION.CREATED` (new) + `PLAN.DEPRECATED` (prior) via `IPlatformEventPublisher.AppendAndPublishAsync` using a `BuildPlanEvent` helper modelled on `AdminTenantsEndpoints.BuildAdminEvent`.
+
+Immutability guard: a `SaveChanges` interceptor (or an explicit guard in the editor before any direct child mutation) rejects modifying a tracked `Plan`/child whose `Status` is `active` or `deprecated`, throwing `TammaError("PLAN.VERSION.IMMUTABLE", ..., severity: High)`. Only `draft` rows and the controlled deprecate-flip are writable.
+
+### DCB event names
+
+| Event | When | Tags |
+|---|---|---|
+| `PLAN.VERSION.CREATED` | new immutable version activated | `slug`, `version`, `planId`, `supersedesPlanId`, `source=admin`, `actorUserId` |
+| `PLAN.DEPRECATED` | prior version flipped to `deprecated` | `slug`, `version`, `planId`, `supersededByPlanId`, `source=admin`, `actorUserId` |
+
+Both append to `platform_events` (control-plane resident — the `AlertRuleEvaluator` already polls this table, so a later story can alert on catalog drift with no new plumbing).
+
+### Integration points
+
+- `AdminTenantsEndpoints.UpdateTenantPlan` (existing) keeps assigning `Tenant.PlanId` to a `Plan.Id`; it now points at a specific *version* row. No change required, but a follow-up may validate the target is `Status = active`.
+- `PlansSeeder.SeedAsync` (existing, wired at `Program.cs:2030`) is extended to also seed child rows; the `AnyAsync` short-circuit becomes per-table insert-missing-only so it can backfill children on a DB that already had bare plan rows.
+- `PricingServiceCollectionExtensions.AddPlanCatalog(services)` registers `IPlanCatalogService`, `PlanVersionEditor` (scoped) and is called from `Program.cs` composition root.
+
+### API shape (read-only surface added in this story; full admin CRUD lands in 34-2)
+
+```
+GET /api/admin/plans                 (OwnerAccess) → list active PlanSnapshots
+GET /api/admin/plans/{slug}          (OwnerAccess) → active PlanSnapshot for slug
+GET /api/admin/plans/{slug}/versions (OwnerAccess) → version chain (active + deprecated)
+```
+
+These read endpoints map to `IPlanCatalogService`. Mutating endpoints (create/deprecate version) are explicitly **deferred to Story 34-2** — this story ships the service method + the events, exercised by unit tests, so 34-2 only wires the endpoint.
+
+### Per-mode + per-tenant handling
+
+- **Single-user mode**: catalog is global; the sole user reads it. No RBAC; no overrides. `ITammaModeProvider` is not consulted for reads (the data is identical in both modes).
+- **SaaS mode**: catalog is platform-owned. Create/deprecate is `OwnerAccess` only. Tenant members get read-only snapshots of *their assigned plan version* via `GetForTenantAsync`. No per-tenant plan customization layer (custom enterprise plans are still platform-owned rows with `IsCustom = true`, assigned via `PlanId`).
+
+## Dependencies
+
+**Internal (prerequisite):**
+- Epic 28 (control-plane / tenancy) — provides `ControlPlaneDbContext`, the `Tenant.PlanId` shadow column + FK to `plans`, `PlansSeeder`, and the migration pipeline under `Migrations/ControlPlane/`.
+- Epic 4 (DCB events) — provides the `platform_events` store, `PlatformEvent` entity, and `IPlatformEventPublisher.AppendAndPublishAsync`.
+
+**Internal (blocks):**
+- Story 34-2 (plan admin CRUD / version-management API) — wires the editor/service behind admin endpoints.
+- Story 34-x (cost→price markup engine) — reads `PlanPrice.MeteredComponent` + `PlanEntitlement`.
+- Epic 35 (Billing) — charges against `PlanEntitlement` / `PlanPrice`; metering keys off `EntitlementMetricKey`.
+- Entitlement enforcement stories — consume `EntitlementMetricKey` + `PlanSnapshot.Entitlements`.
+
+**External:**
+- PostgreSQL 17 (partial unique index `WHERE Status = 'active'`, jsonb `MeteredComponent`).
+- EF Core 9 / Npgsql (value converter for `EntitlementMetricKey`, additive migration).
+- No Stripe dependency in this story — pricing data is stored, not charged (Epic 35 owns Stripe).
+
+## Testing Strategy
+
+**Unit tests** (`tests/Tamma.Api.Tests/Pricing/` + `tests/Tamma.Core.Tests/Enums/`), test-first:
+
+1. `EntitlementMetricKeyTests` — every member round-trips through `ToMetricString()` / `Parse()`; unknown string throws; snake_case mapping pinned (`LlmTokens ↔ "llm_tokens"`, `RagStorageMb ↔ "rag_storage_mb"`).
+2. `PlanCatalogServiceTests` — `GetActiveBySlugAsync` assembles features+entitlements+prices for the active version only; `GetByIdAsync` returns a deprecated version's frozen snapshot; `GetForTenantAsync` resolves via the `PlanId` shadow column; missing slug → null.
+3. `PlanVersionEditorTests` — `CreateNewVersionAsync` produces v2 with `SupersedesPlanId = v1.Id`, flips v1 to `deprecated`, emits `PLAN.VERSION.CREATED` + `PLAN.DEPRECATED` with correct tags (assert against a fake `IPlatformEventPublisher`); a 3-version chain links correctly.
+4. `PlanImmutabilityTests` — mutating an `active` plan throws `PLAN.VERSION.IMMUTABLE`; mutating a `deprecated` plan throws; mutating a `draft` plan succeeds.
+5. `PlansSeederTests` — first `SeedAsync` populates structured child rows for all three slugs with the known UUIDs and `Version = 1`/`Status = active`; second `SeedAsync` is a no-op; an admin-edited (`draft` v2) row is NOT reverted by re-seed (insert-missing-only).
+
+**Integration / DB tests** (docker-bound, run via `sg docker -c "dotnet test ..."`):
+
+6. `PlanCatalogMigrationTests` — apply the migration to a clean DB, assert the 3 new tables + columns + CHECK constraints + partial unique index exist; migration rolls back cleanly.
+7. `OneActiveVersionInvariantTests` — directly inserting a second `Status = active` row for an existing slug is rejected by `UX_plans_OneActivePerSlug` (catch the unique-violation `DbUpdateException`).
+8. **Tenant-isolation test** — the catalog is platform-global, so the test asserts a tenant-scoped read (`GetForTenantAsync`) never returns another tenant's *assigned* plan and never leaks `draft` versions to a tenant snapshot; two tenants on different plan versions each resolve their own frozen snapshot.
+
+**Mocks:** `IPlatformEventPublisher` is faked to capture emitted events (no real `platform_events` write in unit tests). No Stripe/provider mocks needed in this story (no external billing call). DB-bound tests use the real Npgsql provider against the docker Postgres (the project's standard for migration/constraint tests).
+
+## Estimated Effort
+
+4-5 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Core/Enums/EntitlementMetricKey.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Core/Enums/EntitlementMetricKeyExtensions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/PlanFeature.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/PlanEntitlement.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/PlanPrice.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/Plan.cs` | Modify (versioning + status + nav collections) |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (3 DbSets + 4 Configure* methods) |
+| `apps/tamma-elsa/src/Tamma.Data/Seeders/PlansSeeder.cs` | Modify (seed structured child rows, insert-missing-only) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<timestamp>_PlanPriceBookCatalog.cs` | Create (EF migration) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IPlanCatalogService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanCatalogService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanSnapshot.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanVersionEditor.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanCatalogEventTypes.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/PricingServiceCollectionExtensions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (call `AddPlanCatalog`; map 3 read endpoints) |
+| `apps/tamma-elsa/tests/Tamma.Core.Tests/Enums/EntitlementMetricKeyTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanCatalogServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanVersionEditorTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanImmutabilityTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlansSeederTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanCatalogMigrationTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md).
+2. Searched `.dev/` for related spikes/bugs/findings/decisions (especially any pricing/quota or migration discipline notes).
+3. Reviewed how `ControlPlaneDbContext` configures existing CP tables (`ConfigureAlertRules`, `ConfigureTenantDatabases`) — mirror that exact style.
+4. Reviewed `PlansSeeder.cs` and the convention system-defaults ownership rule (insert-missing-only, never revert admin edits).
+5. Planned the TDD Red-Green-Refactor cycle (enum + immutability tests first).
+
+### Key Design Decisions
+
+- **Immutable versioned rows over in-place plan edits.** A tenant assigned `team v1` must keep `team v1` pricing/quotas even after `team v2` ships at a higher price. Mutating in place would silently re-price existing tenants and break billing reproducibility. The partial unique index enforces "one active per slug" so the catalog always has exactly one current version to assign new tenants.
+- **`EntitlementMetricKey` is the single source of quota-key truth.** Entitlement limits, metered pricing components, usage metering, and enforcement all key off the same enum so a typo can never split `llm_tokens` from `llmTokens` across layers. Persist as snake_case text, never the ordinal.
+- **`PlanPrice` split by `PricingMode`.** BYOK tenants (bring-your-own AI keys) and platform-provided tenants get different price rows under the same plan version — the markup engine and billing each pick the row matching the tenant's mode. This is the hook for the epic's "BYOK-vs-platform-provided pricing modes" theme.
+- **Keep the legacy `Quotas` column + `MonthlyPriceUsd` for one deprecation window.** Avoids a big-bang change to every reader; new code reads structured rows. A later story drops the JSON.
+- **Read-only API in this story.** The data model + service + events are the foundation; admin write endpoints are Story 34-2's job. Shipping the editor as a tested service method (not an endpoint) keeps the boundary clean.
+
+### Boundary Notes (what this story does NOT do)
+
+- No Stripe / billing integration, no charging, no invoices (Epic 35).
+- No usage metering writes (Epic 35) — this story only defines the keys metering will use.
+- No quota *enforcement* (later Epic 34 stories) — this story stores limits; it does not block on them.
+- No admin write/CRUD endpoints (Story 34-2).
+- No cost→price markup computation (separate Epic 34 story) — `PlanPrice.MeteredComponent` is stored verbatim.
+- No tenant-scoped plan overrides — catalog is platform-global by design.
+
+### Migration discipline
+
+This is an additive migration (new columns with backfilling defaults, new tables). Generate with `dotnet ef migrations add PlanPriceBookCatalog --context ControlPlaneDbContext` and then verify `dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext` reports none. Mirror the entity configuration in `ControlPlaneDbContext.OnModelCreating` only (the established single source for CP entity config) — do not split config across files.
+
+### Per-mode ownership recap (CLAUDE.md "two scoping models" rule)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Who owns the plan catalog? | Platform (global rows); sole user reads it. | Platform owner (`OwnerAccess`); tenants read-only. |
+| Who creates/deprecates a version? | The sole user (no RBAC gate, but same code path). | `OwnerAccess` (platform owner) only. |
+| Per-tenant overrides? | None — global catalog. | None — custom plans are platform rows with `IsCustom = true`. |
+| Mode source | `ITammaModeProvider` (not consulted for reads — data identical). | same |
+
+## Logging Requirements
+
+- **INFO**: plan version created (`slug`, `version`, `planId`), plan deprecated (`slug`, `version`), seeder inserted N child rows, catalog snapshot served (`slug`, `version`).
+- **DEBUG**: snapshot assembly (counts of features/entitlements/prices), `GetForTenantAsync` resolved `PlanId` for a tenant, version-editor transaction begin/commit.
+- **WARN**: attempted mutation of an immutable (`active`/`deprecated`) plan version (before the throw), `GetForTenantAsync` found a tenant with a NULL `PlanId`.
+- **ERROR**: version-create transaction rollback, one-active-version unique-violation surfaced from the DB (should be impossible via the editor — log the unexpected race), migration apply failure.
+- **Structured context**: include `{ slug, version, planId, supersedesPlanId, metricKey, pricingMode }` where applicable.
+- **Credential safety**: pricing data is not secret, but never log encrypted connection strings or tenant secrets if a snapshot path ever touches a tenant row.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-34/story-34-10/34-10-epic-20-decommission-and-pricing-contract-migration.md
+++ b/docs/stories/epic-34/story-34-10/34-10-epic-20-decommission-and-pricing-contract-migration.md
@@ -1,0 +1,622 @@
+# Story 34-10: Epic 20 Decommission & Pricing Contract Migration
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide covers the 7-phase workflow (Read → Research → Break Down → TDD → Quality
+Gates → Failure Handling), the `.dev/` knowledge base, TRACE/DEBUG logging, test-first
+development, 100% coverage on critical paths, and build-success enforcement. Failure to follow it
+results in rework.
+
+## User Story
+
+As a **platform owner (and, downstream, the Billing and Enforcement epic authors)**,
+I want the stale TypeScript Epic 20 plan/pricing surface formally retired, every existing tenant
+and plan back-filled from the legacy opaque `Plan.Quotas` JSON and loose `Tenant.Plan` string onto
+the new structured catalog (34-1 `PlanEntitlement`) and assignment model (34-4
+`TenantPlanAssignment`), and a single stable read-contract published as the ONLY surface
+Billing (Epic 35) and the Enforcement epic call into,
+so that no consumer reaches into pricing entities directly, no tenant is ever left without an
+active plan assignment, and the cut-over from the JSON era is re-runnable, reproducible, and
+verifiable on a seeded environment with zero errors.
+
+## Priority
+
+P0 — This is the capstone that makes Epic 34 a stable, consumable foundation. Until the legacy
+`Plan.Quotas` JSON and `Tenant.Plan` string are back-filled into structured rows AND a single
+read-contract is published, Billing (Epic 35) and Enforcement would either re-derive limits from
+the old JSON (drift) or wire directly into 34-1/34-4/34-5/34-6/34-7 entities (coupling). This story
+freezes a façade and migrates the data so every downstream epic builds on one surface.
+
+## Acceptance Criteria
+
+1. A re-runnable, idempotent **back-fill** (EF migration data step + a guarded
+   `PricingBackfillService` invoked at startup, insert-missing-only) converts every populated legacy
+   `Plan.Quotas` JSON blob into typed `PlanEntitlement` rows (34-1) keyed by `EntitlementMetricKey`,
+   mapping the historic JSON keys (`llmTokensPerMonth → llm_tokens`, `concurrentWorkflows →`
+   *(dropped — not an entitlement metric, logged WARN)*, `seats → seats`, where a legacy `-1`
+   sentinel becomes `LimitValue = NULL` = unlimited). Plans already carrying structured
+   `PlanEntitlement` rows from the 34-1 seeder are left untouched (no double-insert).
+
+2. The same back-fill creates exactly one `active` `TenantPlanAssignment` (34-4) for every existing
+   non-deleted tenant, derived from its current `Tenant.PlanId` shadow column (preferred) or, when
+   NULL, from the `Plan` whose `Slug` matches the legacy `Tenant.Plan` string, falling back to
+   `plan_free`; `PlanVersion` is pinned from the resolved `Plan.Version`. After the back-fill **no
+   non-deleted tenant lacks an active assignment** (asserted by a verification query that returns
+   zero rows).
+
+3. The Epic 20 stories whose plan/pricing scope is now owned by Epic 34 are marked **`superseded`**
+   in `docs/sprint-status.yaml` with an inline note pointing at the Epic 34 owner story: `20-1`
+   (plan model → 34-1/34-4) and `20-4` (usage-limits-enforcement plan/quota model → 34-1/34-6 +
+   sibling Enforcement epic). Stripe-specific subscription/checkout/portal/webhook scope
+   (`20-2`), usage metering (`20-3`), and billing dashboard (`20-5`) are explicitly **re-homed to
+   Epic 35 (Billing), NOT Epic 34** — their status notes are updated to say so but they are NOT
+   marked superseded by this story (Epic 35 owns their retirement).
+
+4. A published `IPricingContract` façade
+   (`apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricingContract.cs`) is the ONLY surface
+   Billing (Epic 35) and Enforcement call into. It exposes four read seams that delegate to the
+   already-built Epic 34 services — `ResolvePlanAsync` (→ 34-1 `IPlanCatalogService` +
+   34-4 `IPlanAssignmentService.GetActiveAsync`), `ResolveEntitlementsAsync` (→ 34-6
+   `IEntitlementService.ResolveAsync`), `PriceUsageAsync` (→ 34-5 `IUsagePricingEngine.PriceUsage`
+   + 34-5 `IMarginPolicyResolver`), and `PriceNetAsync` (→ 34-7
+   `ICreditAwarePricingEngine.PriceNetAsync`) — returning the published contract DTOs in
+   `Tamma.Api/Dtos/Pricing/PricingContractDtos.cs`.
+
+5. The contract is documented as a stable surface in a new
+   `docs/stories/epic-34/pricing-contract.md` that states, in one place, the four operations, their
+   input/output shapes, the `PricingMode` (`platform_provided` | `byok`, 34-1/34-3) semantics, and
+   the explicit rule that **no other epic may take a direct dependency on `Plan`, `PlanEntitlement`,
+   `PlanPrice`, `TenantPlanAssignment`, `IUsagePricingEngine`, `IEntitlementService`, or
+   `ICreditAwarePricingEngine`** — every cross-epic read goes through `IPricingContract`.
+
+6. **Contract conformance tests** (`tests/Tamma.Api.Tests/Pricing/PricingContractTests.cs`) assert
+   the façade returns stable, complete shapes: `ResolveEntitlementsAsync` always returns all 7
+   `EntitlementMetricKey` members (closed map, mirrors 34-6 AC2); `ResolvePlanAsync` returns the
+   pinned `(PlanId, PlanVersion)` not "latest" after a deprecation; `PriceUsageAsync` honors
+   `PricingMode` end-to-end (a `byok` line returns `SellPriceUsd == CostBasisUsd` token markup of
+   zero per 34-5, a `platform_provided` line applies the markup); `PriceNetAsync` returns a
+   `NetPriceResult` whose `NetPriceUsd == SellPriceUsd − PromoDiscountUsd − CreditsAppliedUsd`
+   (34-7 invariant).
+
+7. A **migration-ordering note** mirroring `docs/stories/migration-ordering.md` records the
+   control-plane vs tenant-schema ordering for the new pricing tables (`plans` column adds,
+   `plan_features`, `plan_entitlements`, `plan_prices` from 34-1; `tenant_plan_assignments` from
+   34-4; plus this story's back-fill data step). All pricing tables are **control-plane resident**
+   (catalog + assignment are global/CP rows) — the note explicitly states there is NO per-tenant
+   schema (`t_<hex>`) pricing table, and that the back-fill data step runs **after** the 34-1 and
+   34-4 schema migrations have applied.
+
+8. A **smoke test** on a seeded environment (the docker integration suite) provisions a `free`, a
+   `team`, and an `enterprise` tenant, runs the full back-fill, then calls all four contract
+   operations for each tenant and asserts **zero errors**: each resolves a plan, a complete
+   entitlement set, a priced usage line, and a net price post-migration.
+
+9. **Rollback / re-run safety** is documented and tested: per CLAUDE.md "no-migration-anxiety", the
+   app is pre-production, so the contract is that the back-fill is **idempotent and re-runnable** —
+   a second invocation is a verified no-op (`PricingBackfillService` second run inserts zero rows,
+   emits no events, returns a `BackfillReport` with all-zero insert counts). The story documents
+   that "rollback" = drop-and-reseed (no production data to preserve), not a reversible down-migration
+   of data.
+
+10. The back-fill emits DCB / platform-audit events: `PRICING.BACKFILL.STARTED` (once per run, tags
+    `runId`, `mode`, `source=startup|admin`), `PRICING.BACKFILL.COMPLETED` (tags `runId`,
+    `plansConverted`, `tenantsAssigned`, `entitlementsCreated`, `durationMs`), and
+    `PRICING.BACKFILL.SKIPPED` when a prior completed run is detected (idempotent no-op path). Events
+    append via `IPlatformEventPublisher.AppendAndPublishAsync` to `platform_events` (CP-resident).
+
+11. The legacy `Plan.Quotas` string column and `Tenant.Plan` string remain on the row (per 34-1's
+    one-deprecation-window decision) but are **no longer read by any pricing path** after this story:
+    a `PricingContract`-only read rule is enforced by the conformance tests, and the legacy
+    `AdminTenantsEndpoints.UpdateTenantPlan` path (kept working by 34-1/34-4) is verified to flow
+    through `IPlanAssignmentService` (34-4), never re-deriving from `Quotas`.
+
+12. Per-mode + per-tenant ownership is honored: the catalog/contract is **platform-owned and global
+    in both modes** (single-user and SaaS) — there is no tenant-scoped pricing table. The back-fill
+    runs once per deployment regardless of mode (it operates on CP rows). `IPricingContract` reads
+    resolve per-mode via the underlying services' existing `ITammaModeProvider` handling (SaaS by
+    `tenant_id`; single-user by the sole user → personal tenant); the façade adds no new RBAC of its
+    own — callers (Epic 35/Enforcement) are already gated. The admin re-run trigger (AC10
+    `source=admin`) is `PlatformOwnerAccess` only.
+
+13. Unit + integration tests cover: legacy-JSON → `PlanEntitlement` mapping (incl. `-1 → NULL`
+    unlimited and the dropped `concurrentWorkflows` WARN), tenant back-fill from `PlanId` /
+    `Slug` / `plan_free` fallback chain, the zero-tenant-without-assignment invariant, second-run
+    no-op idempotency, the four contract operations' shape stability + `PricingMode` honoring,
+    pinned-version-survives-deprecation through the façade, the `BackfillReport` counts + events, and
+    **tenant isolation** (the back-fill assigns each tenant only its own plan; no cross-tenant row).
+
+## Technical Design
+
+### Namespace & file structure
+
+```
+apps/tamma-elsa/src/
+  Tamma.Api/Services/Pricing/                 # dir created by 34-1; this story adds the façade + back-fill
+    IPricingContract.cs                        # NEW — the published 4-op read façade (Tamma.Api.Services.Pricing)
+    PricingContract.cs                         # NEW — delegates to 34-1/34-4/34-5/34-6/34-7 services
+    IPricingBackfillService.cs                 # NEW — re-runnable back-fill orchestration
+    PricingBackfillService.cs                  # NEW — JSON→entitlements + tenant→assignment back-fill
+    PricingBackfillModels.cs                   # NEW — BackfillReport, LegacyQuotaMap records
+    PricingBackfillEventTypes.cs               # NEW — PRICING.BACKFILL.STARTED/.COMPLETED/.SKIPPED
+  Tamma.Api/Dtos/Pricing/
+    PricingContractDtos.cs                     # NEW — PlanContractView, EntitlementContractView,
+                                               #        PricedUsageView, NetPriceView (stable wire shapes)
+  Tamma.Api/Endpoints/
+    Admin/AdminPricingBackfillEndpoint.cs      # NEW — POST /api/admin/pricing/backfill (re-run; PlatformOwnerAccess)
+  Tamma.Api/Extensions/
+    PricingServiceCollectionExtensions.cs      # MODIFY (created by 34-1) — AddPricingContract + AddPricingBackfill
+  Tamma.Api/Program.cs                          # MODIFY — register façade + back-fill hosted-run; map admin re-run route
+  Tamma.Data/Migrations/ControlPlane/
+    <ts>_PricingBackfillDataStep.cs            # NEW — additive data-only migration (JSON→entitlements, tenant→assignment)
+docs/stories/epic-34/
+  pricing-contract.md                          # NEW — published stable-contract doc (AC5)
+  pricing-migration-ordering.md                # NEW — CP-vs-tenant ordering note (AC7), mirrors docs/stories/migration-ordering.md
+docs/sprint-status.yaml                         # MODIFY — Epic 20 supersede/re-home notes (AC3); add epic-34 block
+```
+
+> **Boundary note (Epic 34 ↔ siblings):** this story **owns the façade + the data back-fill + the
+> Epic 20 retirement bookkeeping only**. It does NOT re-implement any pricing logic — the catalog
+> (34-1), assignment (34-4), markup engine (34-5), entitlement resolution (34-6), and credit-aware
+> net price (34-7) are *consumed*, never re-built. It does NOT touch Stripe / subscriptions /
+> checkout / metering / dashboards — that scope is **re-homed to Epic 35 (Billing)** and only its
+> *status note* is updated here. It does NOT implement quota enforcement (sibling Enforcement epic).
+
+### The published façade (`IPricingContract.cs`)
+
+The whole point of the story: one surface, four operations, delegating to services that already
+exist after 34-1/34-4/34-5/34-6/34-7.
+
+```csharp
+namespace Tamma.Api.Services.Pricing;
+
+using Tamma.Api.Dtos.Pricing;
+
+/// <summary>
+/// THE stable read-contract for pricing. Epic 35 (Billing) and the Enforcement
+/// epic call ONLY these four methods — never the underlying catalog/assignment/
+/// engine services directly. Adding a method here is a deliberate contract
+/// change; reaching past it is a layering violation (see pricing-contract.md).
+/// </summary>
+public interface IPricingContract
+{
+    /// Resolve the tenant's pinned, effective plan (NOT "latest" — survives deprecation).
+    Task<PlanContractView> ResolvePlanAsync(Guid tenantId, CancellationToken ct = default);
+
+    /// Resolve the complete, closed 7-key entitlement set for the tenant.
+    Task<EntitlementContractView> ResolveEntitlementsAsync(Guid tenantId, CancellationToken ct = default);
+
+    /// Price one usage line at LIST price (cost basis × markup), honoring PricingMode.
+    Task<PricedUsageView> PriceUsageAsync(Guid tenantId, UsageLine line, CancellationToken ct = default);
+
+    /// Price one usage line NET of promos + credits + trial (the charge Billing issues).
+    Task<NetPriceView> PriceNetAsync(Guid tenantId, UsageLine line, CancellationToken ct = default);
+}
+```
+
+`PricingContract` implementation (delegation only — no business logic):
+
+```csharp
+public sealed class PricingContract(
+    IPlanCatalogService catalog,            // 34-1
+    IPlanAssignmentService assignments,     // 34-4
+    IEntitlementService entitlements,       // 34-6
+    IUsagePricingEngine usageEngine,        // 34-5 (pure)
+    IMarginPolicyResolver marginResolver,   // 34-5 (scoped, reads CP)
+    ICreditAwarePricingEngine creditEngine, // 34-7
+    ILogger<PricingContract> logger) : IPricingContract
+{
+    public async Task<PlanContractView> ResolvePlanAsync(Guid tenantId, CancellationToken ct)
+    {
+        var active = await assignments.GetActiveAsync(tenantId, ct)
+            ?? throw new TammaError("PRICING.CONTRACT.NO_ASSIGNMENT", $"tenant {tenantId} has no active plan", severity: ErrorSeverity.High);
+        var snapshot = await catalog.GetByIdAsync(active.PlanId, ct)  // pinned (PlanId, PlanVersion)
+            ?? throw new TammaError("PRICING.CONTRACT.CATALOG_UNAVAILABLE", $"plan {active.PlanId} not found", severity: ErrorSeverity.High);
+        return PlanContractView.From(snapshot, active);
+    }
+
+    public async Task<EntitlementContractView> ResolveEntitlementsAsync(Guid tenantId, CancellationToken ct)
+        => EntitlementContractView.From(await entitlements.ResolveAsync(EntitlementPrincipal.ForTenant(tenantId), ct));
+
+    public async Task<PricedUsageView> PriceUsageAsync(Guid tenantId, UsageLine line, CancellationToken ct)
+    {
+        var policy = await marginResolver.ResolveAsync(tenantId, line.Provider, ct);   // 34-5 — tenant/provider margin + PricingMode
+        return PricedUsageView.From(usageEngine.PriceUsage(line, policy));             // 34-5 — pure
+    }
+
+    public async Task<NetPriceView> PriceNetAsync(Guid tenantId, UsageLine line, CancellationToken ct)
+        => NetPriceView.From(await creditEngine.PriceNetAsync(line, tenantId, ct));     // 34-7
+}
+```
+
+> The façade is a thin, total adapter. It does NOT cache (34-6 already caches entitlement
+> snapshots), does NOT meter (Epic 35), and does NOT enforce (Enforcement). Resolution stays
+> fail-loud — a tenant with no active assignment throws `PRICING.CONTRACT.NO_ASSIGNMENT`
+> (never an empty/plain result, per `feedback_resolution_no_empty_fallback`).
+
+### Contract DTOs (`PricingContractDtos.cs`)
+
+Stable wire shapes so a future internal refactor of the underlying services cannot break Billing:
+
+```csharp
+namespace Tamma.Api.Dtos.Pricing;
+
+public sealed record PlanContractView(
+    Guid TenantId, Guid PlanId, string Slug, string DisplayName,
+    int PlanVersion, bool IsCustom, string BillingInterval, string Status);
+
+public sealed record EntitlementContractView(
+    Guid TenantId, Guid PlanId, int PlanVersion, bool IsCustom,
+    IReadOnlyList<EntitlementLineView> Limits);   // always all 7 EntitlementMetricKey members
+
+public sealed record EntitlementLineView(
+    string MetricKey, long? LimitValue, string Period, string OverageMode);
+
+public sealed record PricedUsageView(
+    decimal CostBasisUsd, decimal MarginUsd, decimal SellPriceUsd, string PricingMode);
+
+public sealed record NetPriceView(
+    decimal SellPriceUsd, decimal PromoDiscountUsd, decimal CreditsAppliedUsd,
+    decimal NetPriceUsd, bool TrialWaived);
+```
+
+### Back-fill orchestration (`PricingBackfillService.cs`)
+
+```csharp
+public interface IPricingBackfillService
+{
+    /// Idempotent. Converts legacy Plan.Quotas → PlanEntitlement rows and creates
+    /// one active TenantPlanAssignment per existing tenant. Re-runnable: a second
+    /// run inserts nothing and emits PRICING.BACKFILL.SKIPPED.
+    Task<BackfillReport> RunAsync(BackfillTrigger trigger, CancellationToken ct = default);
+}
+
+public sealed record BackfillReport(
+    Guid RunId, int PlansConverted, int EntitlementsCreated, int TenantsAssigned,
+    int SkippedTenants, bool WasNoOp, long DurationMs);
+
+public enum BackfillTrigger { Startup, Admin }
+```
+
+Algorithm:
+
+1. **Detect prior completion.** If a `PRICING.BACKFILL.COMPLETED` platform event exists AND every
+   non-deleted tenant already has an active `TenantPlanAssignment` AND every active plan already has
+   `PlanEntitlement` rows → emit `PRICING.BACKFILL.SKIPPED`, return `WasNoOp = true`. (Belt: the
+   service is insert-missing-only anyway, so a partial prior run self-heals on re-run.)
+2. **Plan quotas → entitlements** (insert-missing-only): for each active `Plan` with **no**
+   `PlanEntitlement` rows, parse `Plan.Quotas` JSON via `LegacyQuotaMap`, emit one `PlanEntitlement`
+   per recognized key (`llmTokensPerMonth → LlmTokens`, `seats → Seats`), `-1 → LimitValue = null`,
+   `Period = monthly`, `OverageMode = block`; log WARN for unmapped keys
+   (`concurrentWorkflows` is not an `EntitlementMetricKey`).
+3. **Tenant → assignment** (insert-missing-only): for each non-deleted `Tenant` with no active
+   `TenantPlanAssignment`, resolve plan via `Tenant.PlanId` shadow → else `Plan.Slug == Tenant.Plan`
+   → else `plan_free`; insert one `active` row with pinned `PlanVersion`, delegating to
+   `IPlanAssignmentService.AssignAsync` (so the tenant `PlanId`/`Plan` columns stay in lockstep and
+   `TENANT.PLAN.CHANGED` audit is consistent) **or** a direct insert with `Reason = "backfill: 34-10"`
+   when delegating would mis-classify `direction` for a first assignment (the migration data step
+   uses raw SQL; the service path is used for the startup `PricingBackfillService` so audit events
+   fire — see Edge Cases).
+4. **Verify invariant.** Run the AC2 check query; if any non-deleted tenant lacks an active
+   assignment, throw `PRICING.BACKFILL.INCOMPLETE` (severity Critical) — fail the run loudly.
+5. **Emit** `PRICING.BACKFILL.COMPLETED` with counts + duration; return the `BackfillReport`.
+
+`PricingBackfillService.RunAsync(Startup)` is invoked once at API startup after `PlansSeeder.SeedAsync`
+and the 34-4 migration back-fill (defense-in-depth: the EF migration data step does the bulk; the
+startup service heals any tenant created between migration and a later code deploy, and emits the
+audit events the raw-SQL migration cannot).
+
+### EF migration sketch (data-only, additive)
+
+```csharp
+// <ts>_PricingBackfillDataStep.cs  (Tamma.Data.Migrations.ControlPlane)
+public override void Up(MigrationBuilder migrationBuilder)
+{
+    // 1. Legacy Quotas JSON → plan_entitlements (only for plans with no rows yet).
+    //    Uses Postgres jsonb extraction; -1 sentinel → NULL (unlimited).
+    migrationBuilder.Sql(@"
+      INSERT INTO plan_entitlements (""Id"",""PlanId"",""MetricKey"",""LimitValue"",""Period"",""OverageMode"")
+      SELECT gen_random_uuid(), p.""Id"", 'llm_tokens',
+             NULLIF((p.""Quotas""::jsonb->>'llmTokensPerMonth')::bigint, -1),
+             'monthly','block'
+      FROM plans p
+      WHERE p.""Quotas"" IS NOT NULL AND p.""Quotas"" <> '{}'
+        AND (p.""Quotas""::jsonb ? 'llmTokensPerMonth')
+        AND NOT EXISTS (SELECT 1 FROM plan_entitlements e
+                        WHERE e.""PlanId"" = p.""Id"" AND e.""MetricKey"" = 'llm_tokens');
+      -- (repeat for seats → 'seats'; concurrentWorkflows intentionally NOT mapped)
+    ");
+
+    // 2. One active tenant_plan_assignment per non-deleted tenant (NOT EXISTS guard = idempotent).
+    migrationBuilder.Sql(@"
+      INSERT INTO tenant_plan_assignments
+        (""Id"",""TenantId"",""PlanId"",""PlanVersion"",""Status"",""EffectiveFrom"",
+         ""AssignedByUserId"",""Reason"",""CreatedAt"",""UpdatedAt"")
+      SELECT gen_random_uuid(), t.""Id"",
+             COALESCE(t.""PlanId"", s.""Id"", f.""Id""),
+             COALESCE(p.""Version"", s.""Version"", f.""Version"", 1),
+             'active', now(), NULL, 'backfill: 34-10', now(), now()
+      FROM tenants t
+      LEFT JOIN plans p ON p.""Id"" = t.""PlanId""
+      LEFT JOIN plans s ON s.""Slug"" = t.""Plan"" AND s.""Status"" = 'active'
+      LEFT JOIN plans f ON f.""Slug"" = 'free' AND f.""Status"" = 'active'
+      WHERE t.""DeletedAt"" IS NULL
+        AND NOT EXISTS (SELECT 1 FROM tenant_plan_assignments a
+                        WHERE a.""TenantId"" = t.""Id"" AND a.""Status"" = 'active');
+    ");
+}
+
+public override void Down(MigrationBuilder migrationBuilder)
+{
+    // Pre-production, no-migration-anxiety: data Down deletes only backfill-stamped rows.
+    migrationBuilder.Sql("DELETE FROM tenant_plan_assignments WHERE \"Reason\" = 'backfill: 34-10';");
+    // plan_entitlements created by backfill are left (the 34-1 seeder owns canonical rows).
+}
+```
+
+> This is a **data-only** migration — no DDL, no CHECK edits — so `has-pending-model-changes` must
+> report none after it is added. It depends on the 34-1 (`plan_entitlements`) and 34-4
+> (`tenant_plan_assignments`) schema migrations already being applied (ordering is recorded in
+> `pricing-migration-ordering.md`, AC7). The `NOT EXISTS` guards make a re-apply on a partially
+> migrated DB a no-op (AC9).
+
+### DCB / platform-audit event names (`AGGREGATE.ACTION.STATUS`)
+
+| Event | When | Tags / data |
+|---|---|---|
+| `PRICING.BACKFILL.STARTED` | run begins | tags `runId`, `mode`, `source` (`startup`\|`admin`) |
+| `PRICING.BACKFILL.COMPLETED` | run finishes (rows possibly inserted) | tags `runId`; data `plansConverted`, `tenantsAssigned`, `entitlementsCreated`, `durationMs` |
+| `PRICING.BACKFILL.SKIPPED` | prior completed run detected → no-op | tags `runId`, `reason=already_complete` |
+
+All append via `IPlatformEventPublisher.AppendAndPublishAsync(PlatformEvent)` to the CP-resident
+`platform_events` log (the `AlertRuleEvaluator` already polls it, so a later story can alert on a
+failed/incomplete back-fill with no new plumbing). Consumed (not emitted) by this story:
+`TENANT.PLAN.CHANGED` (34-4) when the startup service path delegates to `AssignAsync`.
+
+### API shape (admin re-run only — reads go through the in-process façade)
+
+```
+# Platform-owner re-run trigger (PlatformOwnerAccess) — for ops after a manual seed/restore
+POST /api/admin/pricing/backfill
+  → 200 { runId, plansConverted, entitlementsCreated, tenantsAssigned, skippedTenants, wasNoOp, durationMs }
+  → 409 backfill_in_progress       # a single-flight lock prevents concurrent runs
+```
+
+`IPricingContract` itself is an **in-process service**, not an HTTP endpoint — Billing/Enforcement
+consume it via DI. (34-6 already ships the tenant-facing `GET /api/pricing/entitlements` read API;
+this story does not duplicate it.)
+
+### Per-mode + per-tenant handling
+
+| Concern | single-user mode | SaaS mode |
+|---|---|---|
+| Catalog / contract ownership | platform-global rows; sole user reads via the façade | platform-global rows; tenants read via the underlying 34-6 API |
+| Back-fill scope | runs once on CP rows (the lone tenant gets one assignment) | runs once on CP rows (every tenant gets one assignment) |
+| Façade per-mode resolution | delegates to 34-6/34-4 which key by sole-user → personal tenant | delegates which key by `tenant_id` |
+| Re-run trigger RBAC | the sole user (authenticated; same code path) | `PlatformOwnerAccess` (platform owner) only |
+| Tenant-scoped pricing table? | none — global catalog | none — global catalog |
+| Mode source | `ITammaModeProvider` (via underlying services) | same |
+
+### Integration points
+
+- **34-1 `IPlanCatalogService` / `PlanSnapshot` / `EntitlementMetricKey`** — pinned catalog reads,
+  the quota-key enum the back-fill maps legacy JSON onto.
+- **34-4 `IPlanAssignmentService.GetActiveAsync` / `AssignAsync` / `TenantPlanAssignment`** — the
+  active-assignment source of truth; the startup back-fill path delegates to `AssignAsync`.
+- **34-5 `IUsagePricingEngine.PriceUsage` / `IMarginPolicyResolver` / `UsageLine` / `PricedUsage`** —
+  list-price computation with `PricingMode`.
+- **34-6 `IEntitlementService.ResolveAsync` / `ResolvedEntitlements`** — complete entitlement set.
+- **34-7 `ICreditAwarePricingEngine.PriceNetAsync` / `NetPriceResult`** — credit-aware net price.
+- **`IPlatformEventPublisher` / `PlatformEvent`** — back-fill audit events.
+- **`PlansSeeder`** — runs first; back-fill is insert-missing-only so it never conflicts with seeded
+  structured rows (34-1 extends the seeder).
+- **`PricingServiceCollectionExtensions`** — `AddPricingContract` + `AddPricingBackfill` extend the
+  34-1 DI module; `Program.cs` composition root wires the startup run + admin route.
+
+## Dependencies
+
+**Internal — prerequisite (hard):**
+- Story 34-1 (Plan & Price-Book Catalog) — `Plan` versioning, `PlanEntitlement`, `PlanPrice`,
+  `EntitlementMetricKey`, `IPlanCatalogService`, `PlanSnapshot`, `PricingServiceCollectionExtensions`,
+  the `Services/Pricing/` directory.
+- Story 34-3 (BYOK vs Platform-Provided Pricing Mode) — the `PricingMode` (`byok`|`platform`)
+  semantics the contract's `PriceUsageAsync` must honor end-to-end.
+- Story 34-4 (Per-Tenant Plan Assignment) — `TenantPlanAssignment`, `IPlanAssignmentService`, the
+  back-fill-one-active-per-tenant pattern (this story extends/heals it).
+- Story 34-5 (Cost→Price Markup Engine) — `IUsagePricingEngine`, `IMarginPolicyResolver`,
+  `UsageLine`, `PricedUsage`.
+- Story 34-6 (Entitlement & Quota Resolution) — `IEntitlementService.ResolveAsync`,
+  `ResolvedEntitlements`, the closed 7-key map.
+- Epic 28 (control-plane tenancy) — `ControlPlaneDbContext`, `Tenant` shadow `PlanId`,
+  `PlansSeeder`, the `Migrations/ControlPlane/` pipeline.
+- Epic 4 (DCB events) — `PlatformEvent`, `IPlatformEventPublisher`.
+
+**Internal — soft prerequisite:**
+- Story 34-7 (Trials, Credits & Promo Codes) — `ICreditAwarePricingEngine` / `NetPriceResult`. If
+  34-7 has not landed, `PriceNetAsync` is registered against a pass-through default
+  (`NetPriceUsd == SellPriceUsd`, all discounts zero) and the façade method is feature-flagged; the
+  conformance test for `PriceNetAsync` is skipped until 34-7 ships. (Documented in
+  `pricing-contract.md`.)
+
+**Internal — blocks:**
+- Epic 35 (Billing) — charges against `IPricingContract.PriceNetAsync` + `ResolveEntitlementsAsync`;
+  this story is its only sanctioned entry point.
+- Epic 34 Enforcement story — gates on `IPricingContract.ResolveEntitlementsAsync`.
+
+**External:**
+- PostgreSQL 17 (jsonb extraction in the back-fill SQL, partial unique indexes from 34-1/34-4).
+- EF Core 9 / Npgsql (data-only migration).
+- **No Stripe dependency** — pricing data is migrated and read, never charged (Epic 35 owns Stripe).
+  Conformance/smoke tests mock no Stripe; provider cost basis comes from `ProviderPricingService`
+  (existing) which the 34-5 engine consumes.
+
+## Testing Strategy
+
+**Unit (xUnit, `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/`), test-first:**
+
+1. `LegacyQuotaMapTests` — `{"llmTokensPerMonth":2000000,"seats":10}` → two `PlanEntitlement`
+   specs (`llm_tokens=2000000`, `seats=10`); `seats: -1` → `LimitValue = null` (unlimited);
+   `concurrentWorkflows` present → not mapped + WARN logged; empty/`{}` Quotas → no rows.
+2. `PricingBackfillServiceTests.Run_ConvertsQuotas_InsertMissingOnly` — a plan with legacy JSON and
+   no structured rows gets entitlements; a plan already carrying 34-1-seeded rows is untouched.
+3. `Run_AssignsEveryTenant_FallbackChain` — tenant with `PlanId` → that plan; tenant with NULL
+   `PlanId` but `Plan="team"` → team plan; tenant with neither → `plan_free`; all pin `PlanVersion`.
+4. `Run_ZeroTenantWithoutAssignment_Invariant` — after a run, the AC2 verification query returns
+   zero; a deliberately-skipped tenant makes the run throw `PRICING.BACKFILL.INCOMPLETE`.
+5. `Run_SecondRun_IsNoOp` — second `RunAsync` inserts zero rows, returns `WasNoOp = true`, emits
+   `PRICING.BACKFILL.SKIPPED`, emits no `COMPLETED` (idempotency, AC9).
+6. `Run_EmitsEvents` — first run emits `STARTED` then `COMPLETED` with correct counts/duration tags
+   (assert against a fake `IPlatformEventPublisher`).
+7. `PricingContractTests.ResolveEntitlements_ReturnsAllSevenKeys` — façade always returns the closed
+   7-key map (delegates to a faked `IEntitlementService`).
+8. `PricingContract_ResolvePlan_PinnedNotLatest` — assign v1, deprecate (catalog at v2), façade
+   `ResolvePlanAsync` still returns v1 (mock 34-1/34-4).
+9. `PricingContract_PriceUsage_HonorsPricingMode` — a `byok` margin policy → `SellPriceUsd ==
+   CostBasisUsd` (zero token markup, 34-5 rule); a `platform_provided` policy applies the multiplier.
+10. `PricingContract_PriceNet_Invariant` — `NetPriceUsd == SellPriceUsd − PromoDiscountUsd −
+    CreditsAppliedUsd` (mock 34-7 `ICreditAwarePricingEngine`); pass-through default when 34-7 absent.
+11. `PricingContract_NoAssignment_FailsLoud` — a tenant with no active assignment throws
+    `PRICING.CONTRACT.NO_ASSIGNMENT`, never an empty result (`feedback_resolution_no_empty_fallback`).
+
+**Integration (xUnit + Postgres via `sg docker -c "dotnet test ..."`):**
+
+12. `PricingBackfillMigrationTests` — apply 34-1 + 34-4 + this data migration to a clean DB seeded
+    with the three legacy plans; assert structured `plan_entitlements` rows + one `active`
+    `tenant_plan_assignments` per tenant; re-apply the data step → no new rows (idempotent).
+13. `PricingContractSmokeTests` (AC8) — seed `free`/`team`/`enterprise` tenants, run the back-fill,
+    then call all four contract ops for each tenant → zero errors; each returns a plan, a complete
+    entitlement set, a priced usage line, and a net price.
+14. **Tenant-isolation test** — two tenants on different plans: the back-fill assigns each only its
+    own plan (no cross-tenant assignment row); `ResolveEntitlementsAsync(A)` never returns B's limits.
+15. `LegacyPathFlowsThroughContract` — `AdminTenantsEndpoints.UpdateTenantPlan` (kept by 34-4)
+    routes through `IPlanAssignmentService`, never re-deriving from `Quotas`; a contract read after
+    the update reflects the new pinned assignment.
+
+**Mocks:** the five underlying services (`IPlanCatalogService`, `IPlanAssignmentService`,
+`IEntitlementService`, `IUsagePricingEngine`+`IMarginPolicyResolver`, `ICreditAwarePricingEngine`)
+are faked in façade unit tests; `IPlatformEventPublisher` is faked to capture back-fill events;
+`TimeProvider` injected where `durationMs` is asserted. DB-bound tests use the real Npgsql provider
+against docker Postgres. **No Stripe/provider HTTP mocks** — no external billing/provider call in
+this story (provider cost basis is the existing `ProviderPricingService` table, exercised in 34-5).
+
+## Estimated Effort
+
+3-4 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IPricingContract.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricingContract.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IPricingBackfillService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricingBackfillService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricingBackfillModels.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricingBackfillEventTypes.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Dtos/Pricing/PricingContractDtos.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminPricingBackfillEndpoint.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/PricingServiceCollectionExtensions.cs` | Modify (AddPricingContract + AddPricingBackfill) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (register façade + startup back-fill; map admin re-run route) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_PricingBackfillDataStep.cs` | Create (data-only migration) |
+| `docs/stories/epic-34/pricing-contract.md` | Create (published stable-contract doc) |
+| `docs/stories/epic-34/pricing-migration-ordering.md` | Create (CP-vs-tenant ordering note) |
+| `docs/sprint-status.yaml` | Modify (Epic 20 supersede/re-home notes; add epic-34 block) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/LegacyQuotaMapTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingBackfillServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingContractTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingBackfillMigrationTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingContractSmokeTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md).
+2. Searched `.dev/` for related spikes/bugs/findings/decisions (pricing, migrations, resolution
+   fail-loud, the no-migration-anxiety note).
+3. Reviewed **34-1, 34-3, 34-4, 34-5, 34-6, 34-7** — this story is the capstone; it *consumes* every
+   one of them and must NOT re-implement the catalog, assignment, engines, or credit logic.
+4. Reviewed `docs/stories/migration-ordering.md` (the format the new ordering note mirrors) and
+   `PlansSeeder.cs` (insert-missing-only ownership rule).
+5. Confirmed the C# test runner contract: `sg docker -c "dotnet test ..."` for docker-bound suites
+   (build needs no wrapper) — see `reference_dotnet_test_docker`.
+6. Planned a TDD (Red-Green-Refactor) approach — a failing test per AC before implementation.
+
+### Key Design Decisions
+
+- **The façade is the product; the back-fill is the one-time cost.** The lasting deliverable is
+  `IPricingContract` — one surface that freezes Epic 34's read shape so Billing/Enforcement never
+  couple to internals. Everything else (the migration, the supersede bookkeeping) is the work needed
+  to make that surface trustworthy.
+- **Delegate, never re-implement.** `PricingContract` contains zero pricing math — every method is a
+  one-liner over an already-tested service. A line of business logic in the façade is a smell that
+  means scope leaked from a sibling story.
+- **Insert-missing-only, re-runnable.** Both the migration data step and the startup service use
+  `NOT EXISTS` guards. Per CLAUDE.md no-migration-anxiety the app is pre-production, so "rollback" is
+  drop-and-reseed; the value we guarantee is *idempotency* (second run = no-op), not a reversible
+  data down-migration.
+- **Belt-and-suspenders migration + service.** The EF data step does the bulk back-fill fast and
+  in-transaction; the startup `PricingBackfillService` heals tenants created after the migration and
+  emits the audit events raw SQL cannot. Both are idempotent so running both is safe.
+- **Re-home Stripe scope, don't retire it here.** Only `20-1`/`20-4`'s *plan/quota model* scope is
+  owned by Epic 34 → `superseded`. Subscriptions/checkout/metering/dashboard (`20-2`/`20-3`/`20-5`)
+  are Billing's (Epic 35) to retire — touching their status beyond a re-home note would overstep the
+  Epic 34 ↔ Epic 35 boundary.
+
+### Boundary Notes (what this story does NOT do)
+
+- No Stripe / subscriptions / checkout / portal / webhooks (Epic 35) — only re-homes the status note.
+- No usage metering writes (Epic 35) — the contract reads gauge counts via 34-6's reader seam.
+- No quota **enforcement** / blocking (sibling Enforcement epic) — the contract resolves; callers
+  enforce.
+- No new pricing logic — catalog (34-1), assignment (34-4), markup (34-5), entitlements (34-6),
+  credits (34-7) are consumed verbatim.
+- No DDL change — the legacy `Plan.Quotas` / `Tenant.Plan` columns are dropped by a *later* story
+  once Epic 35 is off the JSON (34-1's deprecation-window decision).
+- No tenant-scoped pricing table — the catalog is platform-global by design.
+
+### Edge Cases
+
+- A tenant created between the migration data step and a later code deploy → healed by the startup
+  `PricingBackfillService` on next boot (idempotent NOT EXISTS guard).
+- A plan with malformed `Quotas` JSON → the back-fill logs WARN and skips that plan's quota
+  conversion (its 34-1-seeded structured rows, if present, are authoritative anyway); it does NOT
+  fail the whole run.
+- The startup service path delegating to `AssignAsync` for a tenant whose `direction` would be
+  mis-classified (no prior assignment) → use `Reason="backfill: 34-10"` and treat as `lateral`;
+  the migration raw-SQL path inserts directly with the same reason for speed.
+- 34-7 not yet merged → `PriceNetAsync` registered as a pass-through (`NetPriceUsd == SellPriceUsd`);
+  the conformance test for net price is `[Fact(Skip="awaiting 34-7")]` until it lands.
+- Concurrent admin re-run + startup run → a single-flight lock (named advisory lock or an in-process
+  semaphore) makes the second caller observe `WasNoOp`/`409 backfill_in_progress`.
+
+## Logging Requirements
+
+- **INFO**: back-fill run started (`runId`, `source`), back-fill completed (`plansConverted`,
+  `tenantsAssigned`, `entitlementsCreated`, `durationMs`), back-fill skipped (already complete),
+  contract op served on the slow/admin path (`tenantId`, op).
+- **DEBUG**: per-plan quota conversion (`slug`, mapped metric keys), per-tenant assignment resolution
+  (`tenantId`, source of plan = `planId|slug|free`), façade delegation entry/exit (`tenantId`, op).
+- **WARN**: unmapped legacy quota key encountered (`slug`, key — e.g. `concurrentWorkflows`),
+  malformed `Quotas` JSON skipped (`slug`), 34-7 absent → net-price pass-through engaged,
+  back-fill re-run requested while one is in progress.
+- **ERROR**: `PRICING.BACKFILL.INCOMPLETE` (a tenant left without an assignment — before the throw),
+  `PRICING.CONTRACT.NO_ASSIGNMENT` / `PRICING.CONTRACT.CATALOG_UNAVAILABLE` from the façade,
+  back-fill transaction rollback, event-emission failure.
+- **Structured context**: include `{ runId, tenantId, slug, planId, planVersion, metricKey, source,
+  op }` where applicable.
+- **Credential safety**: pricing data is not secret, but never log encrypted connection strings or
+  tenant secrets if a back-fill/contract path ever touches a tenant row.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-34/story-34-2/34-2-plan-catalog-admin-api-and-custom-enterprise-plans.md
+++ b/docs/stories/epic-34/story-34-2/34-2-plan-catalog-admin-api-and-custom-enterprise-plans.md
@@ -1,0 +1,391 @@
+# Story 34-2: Plan Catalog Admin API & Custom Enterprise Plans
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-phase development workflow, the `.dev/` knowledge base
+(spikes, bugs, findings, decisions), TRACE/DEBUG logging requirements, the test-first (TDD)
+workflow, the 100% critical-path coverage requirement, and quality-gate enforcement.
+
+**Failure to follow this process will result in rework.**
+
+## User Story
+
+As a **platform owner**,
+I want a platform-owner-gated admin API to create, version, and deprecate price-book plans, plus a
+way to mint a custom enterprise plan bound to a single tenant — while any authenticated tenant
+member can read the active public catalog —
+so that I can run the public pricing/upgrade UI off a live catalog and close bespoke enterprise
+deals with negotiated entitlements and pricing without polluting the public plan list.
+
+## Priority
+
+P0 - The catalog admin surface and custom-plan minting are prerequisites for plan assignment
+(34-4) and the pricing/upgrade UI; Billing (Epic 35) and Enforcement charge/consume against plan
+versions that this story lets operators create and deprecate.
+
+## Acceptance Criteria
+
+1. `GET /api/pricing/plans` returns the list of **active, public** (`Status='active'` AND
+   `IsCustom=false`) resolved `PlanSnapshot` rows (features + entitlements + prices), readable by
+   any authenticated tenant member (`MemberAccess`); deprecated, draft, and custom plans are
+   excluded from this list.
+2. `GET /api/pricing/plans/{slug}` returns the single active public `PlanSnapshot` for that slug via
+   `IPlanCatalogService` (the read seam from Story 34-1); a slug that has no active public version
+   returns 404; a custom plan's slug is never resolvable through this public route (404).
+3. `POST /api/admin/pricing/plans` creates a new plan (initial version) and `PUT /api/admin/pricing/plans/{slug}` versions an existing plan (new `Version` row, prior active version flipped to `deprecated`) — both gated by `PlatformOwnerAccess`; the one-active-version-per-slug invariant from Story 34-1 holds.
+4. `POST /api/admin/pricing/plans/custom` mints an `IsCustom=true` plan whose snapshot is bound to a
+   target `tenantId` (recorded in plan metadata / a `CustomTenantId` column), gated by
+   `PlatformOwnerAccess`; the response includes the new plan id, slug, and version.
+5. A custom plan request that sets `IsPublic`/surfaces the plan in the public catalog (e.g.
+   `Status='active'` with `IsCustom=true` intended for `GET /api/pricing/plans`) is rejected with
+   **400** — a custom plan must never appear in the public list; `GET /api/pricing/plans` proves the
+   exclusion in tests.
+6. Custom plans are bound to exactly one tenant: this story records the binding (`CustomTenantId`);
+   the **enforcement** that a custom plan may only be *assigned* to its bound tenant is owned by
+   Story 34-4 (assignment) — this story does not implement assignment, only the catalog row, the
+   binding column, and the validation that a custom plan stays out of the public catalog.
+7. `DELETE /api/admin/pricing/plans/{slug}/versions/{version}` (deprecate a specific version) with
+   active tenant assignments referencing that version returns **409** plus the count of affected
+   tenants, **unless** `?force=true` is supplied (force deprecates and leaves existing tenants on the
+   deprecated version — re-pricing is never silent, per Story 34-1's immutability rule); affected
+   tenants are counted by querying `Tenant` rows whose assignment pins the version (assignment model
+   from Story 34-4; until 34-4 lands, the count comes from the legacy `Tenant.Plan` slug match —
+   see Dev Notes).
+8. Entitlement metric keys submitted on create/version are validated against the
+   `EntitlementMetricKey` enum (`Tamma.Core/Enums`, from Story 34-1); pricing-mode is validated
+   against `platform_provided | byok`; any invalid metric key or pricing mode returns **422** with a
+   field-level error naming the offending key.
+9. Every mutation emits a DCB platform event via `IPlatformEventPublisher` to `platform_events`:
+   `PLAN.CATALOG.UPDATED` (create/version/deprecate) and `PLAN.CUSTOM.CREATED` (custom mint), each
+   carrying `actorUserId` + `actorEmail` (from the JWT `sub`/`email` claims), `slug`, `version`, and
+   for custom plans the bound `tenantId` — in both `tags` (queryable) and `data` (immutable record),
+   mirroring `AdminTenantsEndpoints.BuildAdminEvent`.
+10. A `member`-role caller receives **403** on every `/api/admin/pricing/*` route (mutations and
+    custom mint); a `PlatformOwnerAccess` caller can create, version, and deprecate.
+11. A custom plan round-trips: `POST .../custom` then `GET /api/admin/pricing/plans` lists it,
+    `GET /api/pricing/plans` (public) excludes it, and `GET /api/pricing/plans/{slug}` returns 404.
+12. All mutating endpoints are idempotent-safe under repeated PlatformOwnerAccess submission only in
+    that they validate inputs before writing; a `PUT` that would create a duplicate `(Slug, Version)`
+    is rejected by the Story 34-1 `UNIQUE(Slug, Version)` constraint → translated to **409**.
+13. Reads through `IPlanCatalogService` never leak the encrypted/internal plan-price metered JSON in
+    a malformed shape — the DTO mapping returns the typed `PlanSnapshot` projection only (no raw EF
+    entity is serialized).
+14. Unit + integration tests cover: public list excludes custom/deprecated/draft; member 403 on
+    admin routes; platform owner version + deprecate; deprecate-with-assignments 409 + force=true
+    path; invalid metric key 422; custom plan round-trip + public exclusion; both DCB events emitted
+    with actor id; tenant-isolation (a custom plan bound to tenant A is not surfaced to tenant B's
+    public catalog — which is trivially true since custom plans are excluded from public, but the
+    test pins it).
+
+## Technical Design
+
+### Namespace / File Structure
+
+```
+apps/tamma-elsa/src/Tamma.Api/
+  Endpoints/
+    PricingEndpoints.cs                     # NEW — public read routes (MemberAccess)
+    Admin/
+      AdminPricingEndpoints.cs              # NEW — admin CRUD + custom mint (PlatformOwnerAccess)
+  Dtos/
+    Pricing/
+      PlanDtos.cs                           # NEW — request/response DTOs + PlanSnapshot projection
+  Services/
+    Pricing/
+      PlanCatalogService.cs                 # MODIFY (created in 34-1) — add admin write methods
+      IPlanCatalogService.cs               # MODIFY (created in 34-1) — extend with write contract
+  Program.cs                                # MODIFY — register routes + service
+```
+
+> Story 34-1 creates `IPlanCatalogService` / `PlanCatalogService`, the `PlanSnapshot` read model,
+> the `Plan`/`PlanFeature`/`PlanEntitlement`/`PlanPrice` entities, and the `EntitlementMetricKey`
+> enum. Story 34-2 **extends** the catalog service with the write/admin path and adds the two
+> endpoint files. The `Plan` entity gains an additive `CustomTenantId` column (see migration sketch).
+
+### Plan entity extension (additive migration on the 34-1 schema)
+
+Story 34-1 already extends `Plan` with `Version`, `Status` (`active|deprecated|draft`), `IsCustom`,
+`BillingInterval`, and the supersede chain. Story 34-2 adds one nullable column to bind a custom
+plan to its tenant:
+
+```csharp
+// apps/tamma-elsa/src/Tamma.Data/Entities/Plan.cs  (MODIFY — add property)
+/// <summary>
+/// Set only when <see cref="IsCustom"/> is true. The single tenant this
+/// bespoke plan was negotiated for. Story 34-4 enforces that a custom plan
+/// may only be ASSIGNED to this tenant; Story 34-2 only records the binding
+/// and uses it to keep the plan out of the public catalog.
+/// </summary>
+public Guid? CustomTenantId { get; set; }
+```
+
+EF migration sketch (additive — normal `dotnet ef migrations add`, verify
+`has-pending-model-changes` reports none afterward):
+
+```csharp
+// apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_AddCustomTenantIdToPlan.cs
+migrationBuilder.AddColumn<Guid>(
+    name: "CustomTenantId",
+    schema: null,                 // control-plane (public) schema
+    table: "plans",
+    type: "uuid",
+    nullable: true);
+
+// Partial CHECK: CustomTenantId is set IFF IsCustom is true.
+migrationBuilder.Sql(
+    "ALTER TABLE plans ADD CONSTRAINT ck_plans_custom_tenant " +
+    "CHECK ((is_custom = false AND custom_tenant_id IS NULL) " +
+    "    OR (is_custom = true  AND custom_tenant_id IS NOT NULL));");
+```
+
+### Service contract extension
+
+```csharp
+// apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IPlanCatalogService.cs  (MODIFY)
+public interface IPlanCatalogService
+{
+    // --- read (from Story 34-1) ---
+    Task<IReadOnlyList<PlanSnapshot>> ListActivePublicAsync(CancellationToken ct = default);
+    Task<PlanSnapshot?> GetActivePublicBySlugAsync(string slug, CancellationToken ct = default);
+    Task<PlanSnapshot?> GetSnapshotAsync(string slug, int version, CancellationToken ct = default);
+
+    // --- admin (Story 34-2) ---
+    Task<PlanSnapshot> CreatePlanAsync(CreatePlanRequest req, ActorContext actor, CancellationToken ct = default);
+    Task<PlanSnapshot> VersionPlanAsync(string slug, VersionPlanRequest req, ActorContext actor, CancellationToken ct = default);
+    Task<PlanSnapshot> CreateCustomPlanAsync(CreateCustomPlanRequest req, ActorContext actor, CancellationToken ct = default);
+    Task<DeprecateResult> DeprecateVersionAsync(string slug, int version, bool force, ActorContext actor, CancellationToken ct = default);
+    Task<IReadOnlyList<PlanSnapshot>> ListAllForAdminAsync(PlanListFilter filter, CancellationToken ct = default);
+}
+
+public sealed record DeprecateResult(bool Deprecated, int AffectedTenantCount);
+public sealed record ActorContext(string? UserId, string? Email, string? PlatformRole);
+```
+
+`PlanCatalogService` validates every `EntitlementMetricKey` and `PricingMode` BEFORE any write,
+throws `TammaError` with stable codes (`PLAN.METRIC_KEY.INVALID`, `PLAN.PRICING_MODE.INVALID`,
+`PLAN.CUSTOM.PUBLIC_REJECTED`) that the endpoints translate to 422/400, and emits the platform event
+on success via the injected `IPlatformEventPublisher`.
+
+### Endpoint shape
+
+Public (any authenticated tenant member):
+
+```
+GET  /api/pricing/plans                              -> 200 PlanSnapshot[]   (active+public only)   [MemberAccess]
+GET  /api/pricing/plans/{slug}                       -> 200 PlanSnapshot | 404                       [MemberAccess]
+```
+
+Admin (platform owner only — `PlatformOwnerAccess`, mirroring `/api/admin/tenant-databases`):
+
+```
+GET    /api/admin/pricing/plans                      -> 200 PlanSnapshot[]   (filter: status, isCustom, tenantId)
+POST   /api/admin/pricing/plans                      -> 201 PlanSnapshot     (create initial version)
+PUT    /api/admin/pricing/plans/{slug}               -> 200 PlanSnapshot     (new version; prior -> deprecated)
+POST   /api/admin/pricing/plans/custom               -> 201 PlanSnapshot     (mint IsCustom bound to tenantId)
+DELETE /api/admin/pricing/plans/{slug}/versions/{version}?force=true|false
+                                                     -> 204 | 409 {affectedTenantCount} (deprecate)
+```
+
+Request DTOs (`Dtos/Pricing/PlanDtos.cs`):
+
+```csharp
+public sealed record CreatePlanRequest(
+    string Slug, string DisplayName, string BillingInterval,
+    IReadOnlyList<PlanFeatureDto> Features,
+    IReadOnlyList<PlanEntitlementDto> Entitlements,
+    IReadOnlyList<PlanPriceDto> Prices);
+
+public sealed record CreateCustomPlanRequest(
+    Guid TenantId, string DisplayName, string BillingInterval,
+    IReadOnlyList<PlanFeatureDto> Features,
+    IReadOnlyList<PlanEntitlementDto> Entitlements,
+    IReadOnlyList<PlanPriceDto> Prices);
+    // slug is server-derived (e.g. custom-{tenantSlug}-{n}); IsPublic is never accepted.
+
+public sealed record PlanEntitlementDto(string MetricKey, long? LimitValue, string Period, string OverageMode);
+public sealed record PlanPriceDto(string PricingMode, decimal RecurringUsd, decimal SeatUsd, string? MeteredComponentJson);
+```
+
+### Per-mode + per-tenant handling
+
+- **single-user mode**: the public read routes (`/api/pricing/plans*`) return the active public
+  catalog to the sole user; the admin routes are gated by `PlatformOwnerAccess` — in single-user the
+  sole user holds the `platform_admin` platformRole and can manage the catalog. Custom plans are a
+  SaaS-deal concept but the route stays available (the bound tenant is the user's own tenant).
+- **SaaS mode**: public read routes return the catalog to any tenant member (used by the pricing /
+  upgrade UI in `packages/dashboard-user`); admin/custom routes require platform-owner — a
+  `tenant_owner`/`tenant_admin`/`member` all receive 403 (the route gate is `PlatformOwnerAccess`,
+  which keys off the `platformRole` claim, NOT the per-tenant role). Custom-plan minting is the
+  primary SaaS use: a custom plan is bound to one tenant via `CustomTenantId`. Tenant isolation is
+  preserved by construction: custom plans are excluded from the public catalog, so tenant B can
+  never see tenant A's custom plan via `/api/pricing/plans*`.
+- The price-book lives entirely in the **control plane** (`ControlPlaneDbContext`); there is no
+  per-tenant schema write here, so no `TenantDbContext` involvement. This is consistent with the
+  existing `Plan`/`PlansSeeder` location.
+
+### DCB events
+
+| Event | When | Tags (queryable) | Data (immutable) |
+|---|---|---|---|
+| `PLAN.CATALOG.UPDATED` | create / version / deprecate | `slug`, `version`, `action` (`created\|versioned\|deprecated`), `actorUserId`, `actorEmail`, `source=admin` | full request echo + prior version + `affectedTenantCount` (on deprecate) + actor fields |
+| `PLAN.CUSTOM.CREATED` | custom mint | `slug`, `version`, `tenantId`, `actorUserId`, `actorEmail`, `source=admin` | full custom request + actor fields |
+
+Emitted to `platform_events` (control-plane) via `IPlatformEventPublisher.AppendAndPublishAsync`,
+following the `AdminTenantsEndpoints.BuildAdminEvent` actor-capture pattern (JWT `sub`/`email` into
+both `tags` and `data`). Event names follow the `AGGREGATE.ACTION.STATUS`-style convention used
+across the codebase (`PLAN.UPDATED` already referenced in the `Plan` entity doc-comment;
+`PLAN.VERSION.CREATED`/`PLAN.DEPRECATED` are the 34-1 lifecycle events — 34-2 adds the
+admin-surface-level `PLAN.CATALOG.UPDATED`/`PLAN.CUSTOM.CREATED`).
+
+### Integration points
+
+- **Story 34-1**: `IPlanCatalogService`, `PlanSnapshot`, the four entities, `EntitlementMetricKey`
+  enum, and the `UNIQUE(Slug, Version)` + one-active-version invariant are all consumed here.
+- **Story 34-4**: consumes the deprecate-with-assignments count and the `CustomTenantId` binding to
+  enforce that a custom plan is only assignable to its bound tenant (out of scope here).
+- **`packages/dashboard`** (admin) renders the admin catalog CRUD; **`packages/dashboard-user`**
+  (tenant) renders the public pricing/upgrade UI from `GET /api/pricing/plans` (UI is a later
+  story / sibling concern — this story ships the API only).
+- **Auth**: `PlatformOwnerAccess` and `MemberAccess` policies already exist in `Program.cs`; reused
+  verbatim with explicit `.RequireAuthorization(...)` per route (mirrors
+  `AdminTenantDatabasesEndpoints` registration).
+
+## Dependencies
+
+**Internal:**
+- **Prerequisite**: Story 34-1 (Plan & Price-Book Catalog Data Model) — entities, enum,
+  `IPlanCatalogService`, `PlanSnapshot`, immutability/one-active-version invariants.
+- **Blocks**: Story 34-4 (Per-Tenant Plan Assignment & Lifecycle) — uses the deprecate
+  affected-count, custom-plan binding, and active public catalog for upgrade/downgrade.
+- **Related**: Epic 35 (Billing) charges against plan versions created here; Story 34-3 (BYOK vs
+  platform-provided pricing mode) shares the `PricingMode` enum validated here.
+- **Related**: Epic 28 (control-plane/tenancy) — `ControlPlaneDbContext`, `PlatformEvent` store,
+  `PlatformOwnerAccess` policy.
+
+**External:**
+- No new third-party libraries. (Billing provider — Stripe — integration is Epic 35; this story has
+  no Stripe dependency.)
+- EF Core 9 / Npgsql migration tooling for the additive `CustomTenantId` column.
+
+## Testing Strategy
+
+**Unit tests** (`tests/Tamma.Api.Tests/Pricing/PlanCatalogServiceTests.cs`):
+1. `ListActivePublicAsync` excludes `IsCustom=true`, `Status='deprecated'`, and `Status='draft'`.
+2. `CreatePlanAsync` writes a version-1 active row and emits `PLAN.CATALOG.UPDATED` (action=created)
+   with the actor id; `VersionPlanAsync` flips the prior active to deprecated and creates version N+1
+   (one-active-version invariant preserved).
+3. Invalid `MetricKey` -> `TammaError("PLAN.METRIC_KEY.INVALID")`; invalid `PricingMode` ->
+   `TammaError("PLAN.PRICING_MODE.INVALID")` — asserted to map to 422 at the endpoint.
+4. `CreateCustomPlanAsync` sets `IsCustom=true` + `CustomTenantId`, emits `PLAN.CUSTOM.CREATED` with
+   the bound `tenantId`; a custom request flagged public -> `TammaError("PLAN.CUSTOM.PUBLIC_REJECTED")`
+   -> 400.
+5. `DeprecateVersionAsync` with affected tenants -> `DeprecateResult(false, count)` (no write);
+   with `force=true` -> deprecates and returns `DeprecateResult(true, count)`; with zero affected ->
+   deprecates.
+6. Duplicate `(Slug, Version)` -> unique-violation -> translated 409.
+
+**Integration tests** (`tests/Tamma.Api.Tests/Pricing/PricingEndpointsTests.cs`,
+`AdminPricingEndpointsTests.cs` — `WebApplicationFactory` + Testcontainers Postgres, docker-bound;
+run via `sg docker -c "dotnet test ..."`):
+7. Member-role JWT -> 403 on every `/api/admin/pricing/*` route; platform-owner -> 200/201.
+8. Custom plan round-trip: `POST .../custom` -> 201; `GET /api/admin/pricing/plans` lists it;
+   `GET /api/pricing/plans` excludes it; `GET /api/pricing/plans/{slug}` -> 404.
+9. **Tenant-isolation**: mint a custom plan bound to tenant A; assert tenant B's
+   `GET /api/pricing/plans` does not contain it and `GET /api/pricing/plans/{customSlug}` -> 404 for
+   tenant B (and A).
+10. Deprecate-with-assignments 409 surfaces `affectedTenantCount`; `?force=true` deprecates.
+11. Both DCB events land in `platform_events` with `actorUserId`/`actorEmail` in tags and data.
+
+**Mocks**: no Stripe/provider calls in this story; the platform-event publisher is stubbed in unit
+tests (`IPlatformEventPublisher` test double recording calls) and real in integration tests.
+`ITammaModeProvider` is driven SingleUser vs SaaS to assert the public route works in both modes and
+the admin route stays platform-owner-gated.
+
+## Estimated Effort
+
+3-4 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminPricingEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Dtos/Pricing/PlanDtos.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IPlanCatalogService.cs` | Modify (extend write contract — created in 34-1) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanCatalogService.cs` | Modify (add admin write methods — created in 34-1) |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/Plan.cs` | Modify (add `CustomTenantId`) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_AddCustomTenantIdToPlan.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (register routes + service) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanCatalogServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/AdminPricingEndpointsTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md).
+2. Searched `.dev/` for related spikes, bugs, findings, and decisions.
+3. Read Story 34-1's implementation (entities, `IPlanCatalogService`, `PlanSnapshot`, the
+   one-active-version invariant) — 34-2 builds directly on it; do not duplicate the schema.
+4. Reviewed `AdminTenantDatabasesEndpoints.cs` (route registration + `PlatformOwnerAccess` pattern)
+   and `AdminTenantsEndpoints.BuildAdminEvent` (actor-capture for platform events).
+5. Planned the TDD Red-Green-Refactor cycle (tests first).
+
+### Key Design Decisions
+
+- **Reuse the existing policies verbatim.** `PlatformOwnerAccess` (platformRole-keyed) gates all
+  mutations and the custom mint; `MemberAccess` gates the public read. Do NOT invent a new policy —
+  the existing two cover the exact RBAC matrix (platform owner writes, any member reads).
+- **Custom plans stay out of the public catalog by construction.** The public `ListActivePublicAsync`
+  filters `IsCustom=false`, so a custom plan is invisible to the pricing UI even if its `Status` is
+  `active`. The 400 on an attempt to publish a custom plan is a guard against an operator request
+  shape that would imply public visibility — the filter is the real defence, the 400 is the
+  fail-loud signal.
+- **Deprecate is non-destructive.** `?force=true` deprecates the version but leaves assigned tenants
+  on it (immutability rule from 34-1) — re-pricing existing tenants is an explicit assignment
+  operation (34-4), never a side effect of catalog deprecation.
+- **Affected-tenant count source.** Until Story 34-4's tracked assignment lands, the count comes
+  from matching `Tenant.Plan` slug (the legacy string column). Once 34-4 ships the version-pinned
+  assignment, switch the count query to the assignment table (single-line change behind
+  `IPlanCatalogService`). Note this transitional behaviour in the code with a TODO referencing 34-4.
+
+### Boundary note (sibling-epic ownership)
+
+- **34-1** owns the schema, the read seam, and the immutability/version invariants — do not reshape
+  them; only add the `CustomTenantId` binding column.
+- **34-3** owns BYOK-vs-platform-provided pricing-MODE selection per `(tenant, provider)`. This
+  story only validates the `PricingMode` enum value on a `PlanPrice` row; it does NOT resolve a
+  tenant's mode at LLM-call time or touch the secret cabinet.
+- **34-4** owns plan assignment and the enforcement that a custom plan is only assignable to its
+  bound tenant — this story records the binding but does not assign.
+
+## Logging Requirements
+
+- **INFO**: plan created/versioned/deprecated (slug, version, actorUserId), custom plan minted
+  (slug, version, boundTenantId, actorUserId), public catalog listed (count).
+- **DEBUG**: snapshot resolution (slug, version), entitlement/pricing-mode validation pass,
+  affected-tenant count query result.
+- **WARN**: deprecate blocked by active assignments (slug, version, affectedTenantCount) without
+  force; custom plan publish attempt rejected (slug, tenantId).
+- **ERROR**: platform-event append failure (do not fail the mutation if the event append errors —
+  log ERROR and continue, mirroring the resilient append pattern; the mutation is the source of
+  truth), DB constraint violation surfaced as 409.
+- **Structured context**: include `{ slug, version, isCustom, boundTenantId, actorUserId, mode }`
+  where applicable.
+- **Credential safety**: never log JWTs, encrypted connection strings, or any secret-cabinet
+  material; this story handles none, but the logging discipline is mandatory.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-34/story-34-3/34-3-byok-vs-platform-provided-pricing-mode.md
+++ b/docs/stories/epic-34/story-34-3/34-3-byok-vs-platform-provided-pricing-mode.md
@@ -1,0 +1,507 @@
+# Story 34-3: BYOK vs Platform-Provided Pricing Mode (per-provider mode selection)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-Phase Development Workflow (Read → Research → Break Down →
+TDD → Quality Gates → Failure Handling), the `.dev/` knowledge-base usage rules, TRACE/DEBUG
+logging requirements, the mandatory Test-Driven-Development workflow, and the build/coverage gates.
+
+**Failure to follow this process will result in rework.**
+
+> **Boundary note (canonical ownership):** This story owns **ONLY the pricing-MODE selection per
+> `(tenant, provider)`** — the `TenantProviderBilling` entity and the BYOK/platform toggle endpoints.
+> It does **NOT** own provider-key resolution or the LLM call path. **Story 32-3** is the canonical
+> owner of BYOK provider-key resolution from the Epic 29 secret cabinet into the LLM call path (the
+> `IProviderCredentialResolver` seam, exposing the resolved key AND a `ProviderCredential.Source`
+> discriminator of `byok | platform`), and **Story 32-4** owns SaaS provider-auth eligibility
+> (`IProviderAuthRegistry.IsSaaSEligible`). This story **CONSUMES** both seams and never re-wires the
+> cabinet, the resolver, or `CallLlmActivity`.
+
+## User Story
+
+As a **tenant owner running Tamma in SaaS mode**,
+I want to choose, per provider, whether Tamma calls the LLM with **my own API key (BYOK)** — billed a
+flat platform/seat fee with no token markup — or with **the platform's key (platform-provided)** — billed
+at cost-plus-margin,
+so that I control my LLM spend and the pricing engine charges me the right way for each provider.
+
+(And, in single-user mode, the sole user keeps full control of the same per-provider mode for their
+self-hosted instance.)
+
+## Priority
+
+P0 - The BYOK/platform mode is the input the cost→price markup engine (Story 34-5) keys off. The mode
+selected here also tells Story 32-3's `IProviderCredentialResolver` which credential source to use for
+the LLM call (32-3 owns the actual cabinet read + `CallLlmActivity` wiring); this story records the
+per-`(tenant, provider)` choice that drives both.
+
+## Acceptance Criteria
+
+1. A new control-plane entity **`TenantProviderBilling`** (`apps/tamma-elsa/src/Tamma.Data/Entities/TenantProviderBilling.cs`)
+   is added to `ControlPlaneDbContext` with columns: `Id` (UUIDv7), `TenantId` (Guid, FK → `Tenant`),
+   `ProviderKey` (string, e.g. `"anthropic"`), `Mode` (string enum `byok|platform`), `SecretName`
+   (nullable cabinet name, e.g. `"provider/anthropic/api-key"` — the name 32-3's resolver reads),
+   `Status` (`active|disabled`),
+   `CreatedAt`/`UpdatedAt`/`CreatedBy`/`UpdatedBy` audit columns. A partial unique index enforces **one
+   `active` row per `(TenantId, ProviderKey)`**. An additive EF migration is added under
+   `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/` and `has-pending-model-changes` reports
+   none after it is created.
+2. A new **`MetricBillingMode` enum** lives in `apps/tamma-elsa/src/Tamma.Core/Enums/MetricBillingMode.cs`
+   (`Platform`, `Byok`) and is the single shared token used by this story, the pricing engine (34-5),
+   and metering — so the mode never drifts between layers (mirrors the `EntitlementMetricKey`
+   single-source rule in Story 34-1).
+3. This story **CONSUMES Story 32-3's credential seam** — it does NOT define its own key resolver and
+   does NOT read the Epic 29 cabinet directly. The mode persisted here (`TenantProviderBilling.Mode`) is
+   the per-`(tenant, provider)` selection that 32-3's `IProviderCredentialResolver` honours when it
+   resolves the effective key; the resulting `ProviderCredential.Source` (`byok | platform`) is the
+   single discriminator both layers share. No `IProviderKeyResolver`/`ProviderKeyResolver`/
+   `ProviderKeyResolution` type is introduced by this story.
+4. This story does **NOT** modify `CallLlmActivity` or any LLM call path — that wiring (the direct
+   `_configuration["…:ApiKey"]` removal and the cabinet read) is owned entirely by Story 32-3. The mode
+   row created here is what 32-3's resolver reads to decide `byok` vs `platform`; the no-empty /
+   no-silent-platform-fallback guarantee on key resolution is 32-3's acceptance criterion, not this
+   story's.
+5. The **platform-provided mode is the default**: single-user mode and any `(tenant, provider)` with no
+   `active` BYOK row mean 32-3 resolves `Source=platform` (the global config key), so existing
+   platform-key deployments are unaffected. This story only persists the absence/presence of an `active`
+   BYOK row; the actual key resolution stays in 32-3.
+6. A **BYOK enable flow** (`POST /api/v1/orgs/{tenantId}/pricing/providers/{providerKey}/byok`) stores
+   the supplied provider key into the secret cabinet via `ISecretStore.CreateAsync` with typed
+   `SecretPurpose.ApiKey`, `SecretScope.Tenant`, then inserts/updates the `TenantProviderBilling` row to
+   `Mode=byok`, `Status=active`, `SecretName=<cabinet name>`. The cabinet `SecretName` convention
+   (`provider/{providerKey}/api-key`, scope `Tenant`) MUST match the lookup name 32-3's resolver expects,
+   so the key written here is the key 32-3 later reads. A **disable flow** (`DELETE …/byok`) flips the
+   row to `Mode=platform`, tombstones the secret ref (`SecretName=null`, retire the cabinet secret via
+   `ISecretStore.RetireVersionAsync`), and invalidates 32-3's cached credential for `(tenant, provider)`,
+   keeping the row for audit.
+7. **SaaS provider-auth guard**: attempting to register a CLI/token agent provider as a BYOK provider
+   returns **HTTP 422** with body `{ "error": "CLI providers are single-user only" }`. Eligibility is
+   decided by calling **Story 32-4's `IProviderAuthRegistry.IsSaaSEligible(providerKey)`** — this story
+   does NOT reinvent the allowlist or the rejection logic. A provider for which `IsSaaSEligible` returns
+   `false` (CLI/token providers from `packages/providers`, e.g. `claude-code`/`opencode`, and unknown
+   providers — fail-closed) is rejected with the 422.
+8. The pricing mode is surfaced on the **per-call cost record**: `ProviderDiagnostic`
+   (`apps/tamma-elsa/src/Tamma.Data/Entities/ProviderDiagnostic.cs`) gains a `BillingMode` string column
+   (`byok|platform`, default `platform`) populated from 32-3's `ProviderCredential.Source` on the
+   diagnostic ingest path so the markup engine (34-5) knows whether to apply a margin; the same value is
+   tagged on the emitted DCB event. (32-3 already propagates `CredentialSource` into the diagnostic; this
+   story persists it as the `BillingMode` column the markup engine keys off.)
+9. **DCB events** are emitted via `IEventRepository.AppendAsync`: `PRICING.BYOK.ENABLED` and
+   `PRICING.BYOK.DISABLED` (on the enable/disable flows) — each tagged with `tenantId`, `provider`,
+   `mode`. Tag/Data JSON follows the existing `DomainEvent` shape (`Type`, `TenantId`, `Tags`, `Data`).
+   (Key-resolution events are owned by 32-3, not this story.)
+10. **RBAC (per-mode)**: in SaaS, BYOK mode management (enable/disable, GET reveal-status) is reachable by
+    `tenant_owner` OR `tenant_admin` (via the `PricingManage` gate — see Dev Notes on policy choice); a
+    `member`-role caller hits **403**. In single-user mode the sole user has full control (no RBAC). Reads
+    of the current mode are available to any tenant member.
+11. **Per-tenant isolation**: the endpoints only ever read/write the `TenantProviderBilling` row and
+    cabinet secret for the caller's own tenant; a cross-tenant `tenantId` in the route resolves to 404
+    (mirrors prompt-store/secret-cabinet behaviour), and the cabinet `SecretRef` is built
+    `ForTenant(tenantId, …)` so the Epic 29 store's authorisation filter applies.
+12. **Mode-change idempotency**: re-enabling BYOK for a `(tenant, provider)` that already has an `active`
+    BYOK row updates the existing row (and rotates the cabinet secret) rather than creating a duplicate —
+    the partial unique index (one `active` row per `(TenantId, ProviderKey)`) is enforced.
+13. **Unit + integration tests** prove: enable writes the cabinet row + DB row + `PRICING.BYOK.ENABLED`
+    event and never echoes the key; disable retires the secret, flips to platform, invalidates 32-3's
+    cache, and emits `PRICING.BYOK.DISABLED`; the `member`-role caller is 403 on a BYOK mutation; a
+    provider for which `IProviderAuthRegistry.IsSaaSEligible` is `false` is 422; `ProviderDiagnostic.BillingMode`
+    is persisted from `ProviderCredential.Source`; a tenant cannot read/mutate another tenant's BYOK
+    config; the one-active-row invariant holds on re-enable.
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Catalog + enum foundation (AC: 1, 2)
+  - [ ] Subtask 1.1: Add `MetricBillingMode` enum to `Tamma.Core/Enums/`.
+  - [ ] Subtask 1.2: Add `TenantProviderBilling` entity + DbSet + model config (partial unique index,
+        CHECK on `mode`/`status`) in `ControlPlaneDbContext` / `TammaModelConfiguration`.
+  - [ ] Subtask 1.3: `dotnet ef migrations add AddTenantProviderBilling` under `Migrations/ControlPlane/`;
+        verify `has-pending-model-changes` reports none.
+
+- [ ] Task 2: BYOK enable/disable/get-mode endpoints + CLI guard (AC: 6, 7, 9, 10, 11, 12)
+  - [ ] Subtask 2.1: New `TenantProviderBillingService.cs` — enable/disable/get-mode over
+        `TenantProviderBilling`; one-active-row upsert.
+  - [ ] Subtask 2.2: New `PricingEndpoints.cs` — enable (POST), disable (DELETE), get-mode (GET).
+  - [ ] Subtask 2.3: Store/retire the cabinet secret via `ISecretStore` (purpose `ApiKey`, scope
+        `Tenant`, name `provider/{providerKey}/api-key` to match 32-3's lookup); on disable, call
+        32-3's `IProviderCredentialResolver.Invalidate(tenantId, providerKey)`; emit `PRICING.BYOK.*` events.
+  - [ ] Subtask 2.4: CLI-provider guard → call `IProviderAuthRegistry.IsSaaSEligible` (Story 32-4);
+        non-eligible → 422 `"CLI providers are single-user only"`.
+  - [ ] Subtask 2.5: RBAC wiring (`PricingManage` gate; member → 403; cross-tenant → 404).
+
+- [ ] Task 3: Cost-record tagging (AC: 8)
+  - [ ] Subtask 3.1: Add `BillingMode` column to `ProviderDiagnostic` + migration.
+  - [ ] Subtask 3.2: Populate it from 32-3's `ProviderCredential.Source` on the diagnostic ingest path
+        and tag the emitted DCB cost event with `mode`.
+
+- [ ] Task 4: Tests (AC: 13) — written FIRST per TDD.
+
+## Technical Design
+
+### Namespaces / file structure
+
+```
+apps/tamma-elsa/src/
+  Tamma.Core/Enums/
+    MetricBillingMode.cs                         # NEW — enum { Platform, Byok }
+  Tamma.Data/Entities/
+    TenantProviderBilling.cs                     # NEW — control-plane row
+    ProviderDiagnostic.cs                        # MODIFY — add BillingMode column
+  Tamma.Data/
+    ControlPlaneDbContext.cs                     # MODIFY — DbSet<TenantProviderBilling>
+    TammaModelConfiguration.cs                   # MODIFY — indexes + CHECK constraints
+    Migrations/ControlPlane/
+      <ts>_AddTenantProviderBilling.cs           # NEW — additive migration
+    Migrations/ControlPlane/
+      <ts>_AddProviderDiagnosticBillingMode.cs   # NEW — additive column migration
+  Tamma.Api/Services/Pricing/
+    TenantProviderBillingService.cs              # NEW — enable/disable/read mode
+    PricingEventTypes.cs                         # NEW — PRICING.BYOK.* constants
+  Tamma.Api/Endpoints/
+    PricingEndpoints.cs                          # NEW — tenant mode-toggle endpoints
+  Tamma.Api/Endpoints/
+    ProviderEndpoints.cs                         # MODIFY — set BillingMode on ingest
+```
+
+> **NOT NEW but CONSUMED (owned by other stories — do NOT modify):**
+> - **Story 32-3** — `Tamma.Api/Services/Providers/IProviderCredentialResolver.cs` (the
+>   `ProviderCredential { ApiKey, Source, … }` seam + `CredentialSource` enum). This story calls
+>   `Invalidate(tenantId, providerKey)` on disable and relies on its `ResolveAsync` for all key reads;
+>   it does NOT define a key resolver and does NOT touch `CallLlmActivity`/`CallLlmInlineActivity`.
+> - **Story 32-4** — `Tamma.Activities/Security/IProviderAuthRegistry.cs` (`IsSaaSEligible`) — the
+>   single source for the CLI-provider 422 gate.
+> - **Epic 29 cabinet** — `Tamma.Api/Services/Secrets/ISecretStore.cs`, `SecretRef.cs`, `SecretScope.cs`,
+>   `SecretPurpose.cs`, `SecretRequests.cs`. This story uses `ISecretStore.CreateAsync`/`RetireVersionAsync`
+>   only to write/retire the BYOK secret on the enable/disable flows (so 32-3 can later read it); it
+>   never performs the runtime read.
+
+### Entity sketch — `TenantProviderBilling`
+
+```csharp
+namespace Tamma.Data.Entities;
+
+public class TenantProviderBilling
+{
+    public Guid Id { get; set; }                  // UUIDv7
+    public Guid TenantId { get; set; }            // FK -> Tenant
+    public string ProviderKey { get; set; } = null!;   // "anthropic", "openai", "openrouter"
+    public string Mode { get; set; } = "platform";     // MetricBillingMode token
+    public string? SecretName { get; set; }       // cabinet name when Mode=byok; null otherwise
+    public string Status { get; set; } = "active";     // "active" | "disabled"
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public Guid? CreatedBy { get; set; }
+    public Guid? UpdatedBy { get; set; }
+    public Tenant? Tenant { get; set; }
+}
+```
+
+EF model configuration (in `TammaModelConfiguration`, single source per Epic 28 convention):
+
+```csharp
+b.Entity<TenantProviderBilling>(e =>
+{
+    e.ToTable("tenant_provider_billing", t =>
+    {
+        t.HasCheckConstraint("ck_tpb_mode", "mode IN ('platform','byok')");
+        t.HasCheckConstraint("ck_tpb_status", "status IN ('active','disabled')");
+        // BYOK rows MUST carry a secret name; platform rows MUST NOT.
+        t.HasCheckConstraint("ck_tpb_secret_xor",
+            "(mode = 'byok' AND secret_name IS NOT NULL) OR (mode = 'platform' AND secret_name IS NULL)");
+    });
+    // One ACTIVE row per (tenant, provider) — partial index, plain NULL semantics safe.
+    e.HasIndex(x => new { x.TenantId, x.ProviderKey })
+     .HasFilter("status = 'active'")
+     .IsUnique();
+    e.HasOne(x => x.Tenant).WithMany().HasForeignKey(x => x.TenantId);
+});
+```
+
+### Consuming Story 32-3 (credential source) — NOT re-implemented here
+
+Provider-key resolution is **owned by Story 32-3**. Its seam (do NOT duplicate):
+
+```csharp
+// apps/tamma-elsa/src/Tamma.Api/Services/Providers/  — OWNED BY 32-3, consumed here
+namespace Tamma.Api.Services.Providers;
+
+public enum CredentialSource { Byok, Platform }
+
+public sealed record ProviderCredential(
+    string ApiKey, CredentialSource Source, string? SecretRefStorageKey, int? VersionNumber);
+
+public interface IProviderCredentialResolver
+{
+    Task<ProviderCredential> ResolveAsync(Guid? tenantId, string providerName, CancellationToken ct = default);
+    void Invalidate(Guid? tenantId, string providerName);   // called by THIS story on enable/disable
+}
+```
+
+How this story consumes it:
+
+- **Mode is the input, not the resolver.** The `active` `TenantProviderBilling` row for
+  `(tenant, provider)` is what 32-3's resolver reads to decide `Source=Byok` vs `Source=Platform`. This
+  story persists the row; 32-3 reads the key. There is **no** `IProviderKeyResolver`,
+  `ProviderKeyResolver`, or `ProviderKeyResolution` in this story.
+- **No empty / no platform fallback.** The fail-loud guarantee (a BYOK row whose cabinet secret is
+  missing throws rather than degrading to the platform key) is **32-3's** acceptance criterion — this
+  story neither implements nor re-tests it here.
+- **Cache invalidation.** On a BYOK enable/disable mutation, this story calls
+  `IProviderCredentialResolver.Invalidate(tenantId, providerKey)` so 32-3's cache reflects the new mode
+  on the next LLM call.
+- **No LLM-call-path changes.** `CallLlmActivity` / `CallLlmInlineActivity` are untouched by this story.
+
+### API shape
+
+```
+# Tenant-facing (SaaS: tenant_owner/tenant_admin via PricingManage; single-user: the user)
+GET    /api/v1/orgs/{tenantId}/pricing/providers                 # list modes per provider (member: read)
+GET    /api/v1/orgs/{tenantId}/pricing/providers/{providerKey}   # current mode + whether a key is set
+POST   /api/v1/orgs/{tenantId}/pricing/providers/{providerKey}/byok   # body { apiKey }; -> 200 mode=byok
+DELETE /api/v1/orgs/{tenantId}/pricing/providers/{providerKey}/byok   # -> 200 mode=platform
+```
+
+POST `…/byok` body: `{ "apiKey": "sk-ant-…" }`. Response: `{ "provider": "anthropic", "mode": "byok",
+"keySet": true }`. The raw key is NEVER echoed back (reveal-once cabinet rule, Epic 29); GET returns
+`keySet: true/false`, never the value.
+
+`SecretName` convention: `provider/{providerKey}/api-key`, scope `Tenant`, purpose `ApiKey` — this MUST
+match the name 32-3's `IProviderCredentialResolver` reads (`SecretRef.ForTenant(tenantId,
+"provider/<name>/api-key")`) so the secret written on enable is the one 32-3 later resolves.
+
+### Per-mode + per-tenant handling
+
+| Concern | single-user | SaaS |
+|---|---|---|
+| Principal | the sole user (`tenantId` null) | the tenant (`tenant_id`) |
+| Default mode | platform (no BYOK row) | platform until a BYOK row is created |
+| Who manages BYOK | the user (no RBAC) | `tenant_owner` / `tenant_admin` via `PricingManage`; `member` → 403 |
+| Cabinet scope | no per-tenant cabinet row needed | `SecretRef.ForTenant(tenantId, …)` |
+| Cross-tenant | n/a | route `tenantId` ≠ caller's tenant → 404 |
+| Key resolution at call time | owned by 32-3 | owned by 32-3 |
+
+### DCB event names (AGGREGATE.ACTION.STATUS)
+
+| Event | When | Tags |
+|---|---|---|
+| `PRICING.BYOK.ENABLED` | BYOK enable flow succeeds | `tenantId`, `provider`, `mode=byok` |
+| `PRICING.BYOK.DISABLED` | BYOK disable flow succeeds | `tenantId`, `provider`, `mode=platform` |
+
+> Key-resolution events (`PRICING.PROVIDER_KEY.RESOLVED` / `…FAILED`) are **NOT** owned by this story —
+> Story 32-3 emits the credential-resolution audit (`credentialSource` tag) on the LLM call path.
+
+### Integration points
+
+- **Story 32-3 (canonical credential owner)** — `IProviderCredentialResolver` resolves the key + emits
+  `ProviderCredential.Source` (`byok|platform`). This story persists the per-`(tenant, provider)` mode
+  the resolver reads and calls `Invalidate(tenantId, providerKey)` on mutation. This story performs NO
+  runtime key reads and makes NO LLM-call-path changes.
+- **Story 32-4 (SaaS auth gating)** — `IProviderAuthRegistry.IsSaaSEligible(providerKey)` is the single
+  source for the CLI-provider 422 gate on BYOK registration.
+- **Epic 29 secret cabinet** — `ISecretStore` for create/retire of the per-tenant BYOK secret on the
+  enable/disable flows only (`SecretPurpose.ApiKey`, `SecretScope.Tenant`, `SecretRef.ForTenant`). The
+  cabinet **read** at call time is 32-3's, not this story's — do NOT re-wire the cabinet read path.
+- **Story 34-1** — `MetricBillingMode` lives beside `EntitlementMetricKey`; `PlanPrice.PricingMode`
+  (`platform_provided|byok`) from 34-1 is the plan-level default this per-(tenant,provider) override
+  layers on top of.
+- **Story 34-5 (markup engine)** — reads `ProviderDiagnostic.BillingMode` to decide markup vs flat.
+- **Epic 32** — agents define the provider chain (`AgentConfig`) BYOK applies to; this story does not
+  change the chain, only the per-`(tenant, provider)` mode for whichever provider the chain selects.
+
+### EF migration sketch
+
+```csharp
+migrationBuilder.CreateTable(
+    name: "tenant_provider_billing",
+    columns: t => new {
+        Id = t.Column<Guid>(nullable: false),
+        TenantId = t.Column<Guid>(nullable: false),
+        ProviderKey = t.Column<string>(nullable: false),
+        Mode = t.Column<string>(nullable: false, defaultValue: "platform"),
+        SecretName = t.Column<string>(nullable: true),
+        Status = t.Column<string>(nullable: false, defaultValue: "active"),
+        CreatedAt = t.Column<DateTime>(nullable: false),
+        UpdatedAt = t.Column<DateTime>(nullable: false),
+        CreatedBy = t.Column<Guid>(nullable: true),
+        UpdatedBy = t.Column<Guid>(nullable: true),
+    },
+    constraints: t => {
+        t.PrimaryKey("pk_tenant_provider_billing", x => x.Id);
+        t.ForeignKey("fk_tpb_tenant", x => x.TenantId, "tenants", "id", onDelete: Cascade);
+        t.CheckConstraint("ck_tpb_mode", "mode IN ('platform','byok')");
+        t.CheckConstraint("ck_tpb_status", "status IN ('active','disabled')");
+        t.CheckConstraint("ck_tpb_secret_xor",
+            "(mode='byok' AND secret_name IS NOT NULL) OR (mode='platform' AND secret_name IS NULL)");
+    });
+migrationBuilder.CreateIndex(
+    "ux_tpb_active_provider", "tenant_provider_billing",
+    new[] { "TenantId", "ProviderKey" }, unique: true, filter: "status = 'active'");
+
+// Second additive migration: ProviderDiagnostic.BillingMode
+migrationBuilder.AddColumn<string>(
+    "BillingMode", "provider_diagnostics", nullable: false, defaultValue: "platform");
+```
+
+## Dependencies
+
+**Internal:**
+
+- **Prerequisite** Story **32-3** (Per-Tenant Provider Credential Resolution) — the **canonical owner**
+  of provider-key resolution. Supplies `IProviderCredentialResolver` (the key) and
+  `ProviderCredential.Source` (`byok|platform`, the mode discriminator) that this story's
+  `TenantProviderBilling` row drives and that the markup engine reads. This story CONSUMES it for
+  everything key-related and never re-wires the cabinet or `CallLlmActivity`.
+- **Prerequisite** Story **32-4** (SaaS Provider Auth Gating) — supplies `IProviderAuthRegistry.IsSaaSEligible`,
+  the single source for the CLI-provider 422 rejection on BYOK registration.
+- **Prerequisite** Story 34-1 (Plan & Price-Book Catalog) — `MetricBillingMode` / `EntitlementMetricKey`
+  shared enums and `PlanPrice.PricingMode` plan-level default.
+- **Prerequisite** Epic 29 (secret cabinet) — `ISecretStore`, `SecretRef`, `SecretPurpose`, `SecretScope`
+  for writing/retiring the BYOK secret on enable/disable (NOT for runtime reads — that is 32-3's).
+- **Blocks** Story 34-5 (cost→price markup engine reads `ProviderDiagnostic.BillingMode`).
+- **Related** Epic 28 (control-plane / `ControlPlaneDbContext`, `TammaModelConfiguration`), Epic 4
+  (DCB events / `IEventRepository`).
+
+**External:**
+
+- No new third-party packages; uses the existing EF Core 9 / Npgsql stack.
+
+## Testing Strategy
+
+1. **Unit — `TenantProviderBillingService`** (`tests/Tamma.Api.Tests/Pricing/TenantProviderBillingServiceTests.cs`):
+   enable writes cabinet secret (`SecretPurpose.ApiKey`, name `provider/{p}/api-key`) + flips row to byok
+   + emits `PRICING.BYOK.ENABLED` + calls `IProviderCredentialResolver.Invalidate`; disable retires the
+   secret + flips to platform + emits `PRICING.BYOK.DISABLED` + invalidates; one-active-row invariant
+   (second enable updates, not duplicates).
+2. **Integration — endpoints** (`tests/Tamma.Api.Tests/Pricing/PricingEndpointsTests.cs`, docker-bound
+   via `sg docker -c "dotnet test …"`): POST byok stores a real cabinet row + DB row + DCB event; GET
+   returns `keySet:true` and never the value; DELETE reverts; the migration applies + rolls back.
+3. **RBAC / isolation tests**: SaaS `member` → 403 on POST/DELETE byok; `tenant_admin`/`tenant_owner` →
+   200; cross-tenant `tenantId` in route → 404; tenant A cannot read tenant B's mode; single-user mode
+   the sole user passes all gates.
+4. **CLI-provider guard test**: registering a provider for which `IProviderAuthRegistry.IsSaaSEligible`
+   returns `false` (e.g. `claude-code`) as BYOK → 422 `"CLI providers are single-user only"`. The
+   registry itself is unit-tested under Story 32-4; this story asserts the endpoint calls it and maps
+   the result to the 422.
+5. **`ProviderDiagnostic` test**: ingest path persists `BillingMode` from 32-3's `ProviderCredential.Source`;
+   DCB cost event carries the `mode` tag.
+6. **Mocks**: `ISecretStore` faked in-memory (no real KMS); `IProviderCredentialResolver` and
+   `IProviderAuthRegistry` stubbed; no Stripe in this story (billing/charging is Epic 35).
+   Tenant-isolation asserted via the cabinet `SecretRef.ForTenant` scope and the partial unique index.
+
+> Key-resolution correctness (BYOK→cabinet vs platform→global, the no-empty/no-platform-fallback throw,
+> and the `CallLlmActivity` wiring) is tested under **Story 32-3**, not here.
+
+## Estimated Effort
+
+4-5 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Core/Enums/MetricBillingMode.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/TenantProviderBilling.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/ProviderDiagnostic.cs` | Modify (add `BillingMode`) |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (add DbSet) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (indexes + CHECKs) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_AddTenantProviderBilling.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_AddProviderDiagnosticBillingMode.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/TenantProviderBillingService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricingEventTypes.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/ProviderEndpoints.cs` | Modify (set `BillingMode` on ingest from 32-3's `ProviderCredential.Source`) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (DI + map endpoints + `PricingManage` policy) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/TenantProviderBillingServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingEndpointsTests.cs` | Create |
+
+> **Consumed (NOT modified by this story):** `Tamma.Api/Services/Providers/IProviderCredentialResolver.cs`
+> (Story 32-3), `Tamma.Activities/Security/IProviderAuthRegistry.cs` (Story 32-4),
+> `Tamma.Activities/LlmCall/CallLlmActivity.cs` (Story 32-3 wires it — this story does not).
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md).
+2. Searched `.dev/` for related spikes/bugs/findings/decisions (esp. Epic 29 secret-cabinet notes and
+   the no-empty-fallback feedback).
+3. Reviewed `CLAUDE.md` "Operating Modes", "Prompt Store Architecture / RBAC", and "Multi-tenant
+   provisioning" — the per-mode ownership rules are mandatory here.
+4. Read **Story 32-3** (`IProviderCredentialResolver` / `ProviderCredential.Source`) and **Story 32-4**
+   (`IProviderAuthRegistry.IsSaaSEligible`) — this story consumes both seams and must not duplicate them.
+5. Planned the TDD Red-Green-Refactor cycle (tests first).
+
+### Key design decisions
+
+- **Key resolution is NOT this story's seam.** Story 32-3 owns `IProviderCredentialResolver` and the
+  `CallLlmActivity` wiring. This story owns only the per-`(tenant, provider)` mode selection
+  (`TenantProviderBilling`) that 32-3 reads, plus writing/retiring the BYOK secret on the toggle flows
+  so 32-3's resolver has something to read. On every mode mutation, call
+  `IProviderCredentialResolver.Invalidate(tenantId, providerKey)`.
+- **No empty / no platform fallback for BYOK** is a guarantee owned and tested by 32-3, not duplicated
+  here. This mirrors `feedback_resolution_no_empty_fallback` (tenant → system → error, never empty).
+- **CLI-provider gating is 32-4's `IsSaaSEligible`.** The 422 on BYOK registration of a CLI/token
+  provider calls `IProviderAuthRegistry.IsSaaSEligible(providerKey)` — this story does NOT reinvent the
+  allowlist, the auth-model classification, or the rejection logic; it only maps a `false` result to the
+  422 `"CLI providers are single-user only"` response.
+- **RBAC policy choice.** The spec names `SettingsManage` for BYOK management, but the codebase's
+  `SettingsManage` policy is **owner-only** (`settings:manage`) and 403s every `tenant_admin`
+  (see `Program.cs` ~1001 and the Story 27-3 comment ~1006). Per CLAUDE.md the prompt/convention
+  precedent is tenant_owner **OR** tenant_admin via the dedicated `PromptManage`/`ConventionManage`
+  gates. To honour the spec's intent (tenant admins manage BYOK) without re-defining `SettingsManage`,
+  add a `PricingManage` policy (permission `pricing:manage`, granted to owner+admin exactly like
+  `PromptManage`); document `SettingsManage` as the spec label and `PricingManage` as the concrete gate.
+- **`ProviderKey` overload.** Note the term `ProviderKey` here means the provider identifier
+  (`"anthropic"`) on `ProviderDiagnostic`/`TenantProviderBilling` — distinct from the Cranl tenancy
+  "ProviderKey backend label". Keep the column name `ProviderKey` to match `ProviderDiagnostic`.
+
+### Security requirements
+
+- The BYOK key is written once into the cabinet and never echoed back (reveal-once, Epic 29). GET
+  endpoints return `keySet` only.
+- NEVER log the supplied API key on the enable flow; log `provider`, `mode`, `tenantId` — not the value.
+  The POST body is never logged.
+- Cabinet `SecretRef.ForTenant(tenantId, …)` ensures the Epic 29 authorisation filter blocks
+  cross-tenant reads even if the route guard is bypassed (defence in depth).
+
+### Risks and mitigations
+
+| Risk | Severity | Mitigation |
+| --- | --- | --- |
+| Duplicating 32-3's key resolver / re-wiring `CallLlmActivity` (boundary violation) | High | This story persists the mode row + writes the cabinet secret only; key reads + LLM-call wiring stay in 32-3; reviewer checklist item |
+| Stale 32-3 credential cache after a mode toggle | Medium | Call `IProviderCredentialResolver.Invalidate(tenantId, providerKey)` on every enable/disable |
+| `SecretName` mismatch between this story's write and 32-3's read | Medium | Pin the shared name convention `provider/{providerKey}/api-key`, scope `Tenant`, purpose `ApiKey`; integration test asserts 32-3 can resolve the written secret |
+| Migration drift on the collapsed control-plane baseline | Medium | Additive table/column only; verify `has-pending-model-changes` reports none; mirror entity config solely in `TammaModelConfiguration` |
+| `SettingsManage` owner-only would 403 tenant admins | Medium | Use dedicated `PricingManage` (owner+admin) gate, documented above |
+| Logging the supplied key | High | Explicit no-secret logging rule + reviewer checklist |
+
+### Success metrics
+
+- [ ] A BYOK enable writes a cabinet secret that 32-3's `IProviderCredentialResolver` resolves to
+      `Source=Byok` on the next call.
+- [ ] Every mode mutation invalidates 32-3's credential cache for `(tenant, provider)`.
+- [ ] `ProviderDiagnostic.BillingMode` populated from `ProviderCredential.Source` on 100% of
+      post-migration cost records.
+
+## Logging Requirements
+
+- **INFO**: BYOK enabled/disabled (`tenantId`, `provider`, new mode) — never the key.
+- **DEBUG**: cabinet write/retire attempted (`secretName`, no value); 32-3 cache invalidation issued.
+- **WARN**: a BYOK registration rejected by `IsSaaSEligible` (`tenantId`, `provider`).
+- **ERROR**: cabinet store unreachable on enable/disable; mode upsert conflict.
+- **Structured context**: `{ tenantId, provider, mode, secretName }` where applicable.
+- **Credential safety**: NEVER log the supplied API key or the POST body.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |
+| 2026-06-17 | 1.1.0 | Scope-corrected: consume 32-3 credential resolver + 32-4 gating; removed duplicate key resolver | Claude |

--- a/docs/stories/epic-34/story-34-4/34-4-per-tenant-plan-assignment-and-lifecycle.md
+++ b/docs/stories/epic-34/story-34-4/34-4-per-tenant-plan-assignment-and-lifecycle.md
@@ -1,0 +1,513 @@
+# Story 34-4: Per-Tenant Plan Assignment & Lifecycle
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-phase workflow (Read → Research → Break Down → TDD →
+Quality Gates → Failure Handling), the `.dev/` knowledge-base usage rules, TRACE/DEBUG logging
+requirements, the test-first (TDD) mandate, 100% critical-path coverage, and build-success
+enforcement. Failure to follow it results in rework.
+
+## User Story
+
+As a **platform owner (and, in SaaS mode, a tenant owner/admin)**,
+I want plan assignment to be a first-class, audited operation that pins each tenant to a specific
+plan **version** with effective dates and proper upgrade/downgrade/cancel transitions,
+so that deprecating a plan never silently re-prices existing tenants, every price change is
+reproducible from the audit trail, and Billing (Epic 35) receives clean proration boundaries.
+
+## Priority
+
+P0 — the assignment layer is the source of truth for "what plan is this tenant on right now",
+which Billing (Epic 35) charges against and Enforcement consumes. Until this lands, the loose
+`Tenant.Plan` string and the ad-hoc `PATCH /api/admin/tenants/{id}/plan` path
+(`AdminTenantsEndpoints.UpdateTenantPlan`) are the only mechanism, and neither records a version,
+effective dates, nor a proration boundary.
+
+## Acceptance Criteria
+
+1. A new control-plane entity `Tamma.Data.Entities.TenantPlanAssignment` exists with columns
+   `Id` (UUIDv7), `TenantId` (FK → `tenants.Id`), `PlanId` (FK → `plans.Id`, which 34-1 made a
+   versioned row), `PlanVersion` (int, denormalized copy of the pinned `Plan.Version` so a later
+   plan deprecation cannot retro-mutate this assignment's effective version), `Status`
+   (`active` | `scheduled` | `cancelled`), `EffectiveFrom` (UTC), `EffectiveTo` (UTC, nullable),
+   `AssignedByUserId` (Guid?, the actor), `Reason` (text, nullable), `CreatedAt`, `UpdatedAt`. It
+   is registered as `ControlPlaneDbContext.TenantPlanAssignments` and configured in
+   `TammaModelConfiguration.cs`, with an additive EF migration under
+   `Tamma.Data/Migrations/ControlPlane/`.
+
+2. A partial unique index enforces **at most one `active` assignment per tenant**:
+   `CREATE UNIQUE INDEX ... ON tenant_plan_assignments (TenantId) WHERE Status = 'active'`
+   (modeled via `entity.HasIndex(e => e.TenantId).IsUnique().HasFilter("\"Status\" = 'active'")`),
+   plus CHECK constraints on `Status` ∈ {active, scheduled, cancelled} and
+   `EffectiveTo IS NULL OR EffectiveTo >= EffectiveFrom`. A `(TenantId, Status)` index backs the
+   "current assignment" lookup.
+
+3. `Tenant.PlanId` (today an Epic-28 **shadow** property, `EF.Property<Guid?>(t, "PlanId")`) and
+   the legacy `Tenant.Plan` slug string become **derived / back-filled** from the tenant's active
+   assignment — the assignment row is the source of truth. The EF migration back-fills exactly one
+   `active` `TenantPlanAssignment` per existing tenant from its current `PlanId`/`Plan` (pinning
+   the plan's current `Version`); after back-fill, `AssignAsync` is the only writer of those two
+   tenant columns and keeps them in lockstep with the active assignment.
+
+4. A new `IPlanAssignmentService` (`Tamma.Api/Services/Pricing/PlanAssignmentService.cs`) exposes
+   `AssignAsync(Guid tenantId, Guid planId, AssignPlanOptions opts, CancellationToken ct)` that
+   (a) resolves the plan version via 34-1's `IPlanCatalogService` and **pins** `PlanVersion`,
+   (b) refuses to assign a plan whose `Status` is `draft`, (c) refuses a plan whose `Status` is
+   `deprecated` unless `opts.Force == true`, and (d) validates custom-plan binding: an
+   `IsCustom == true` plan (34-2) may only be assigned to the tenant it is bound to — otherwise
+   the call is rejected with a typed `TammaError("PLAN.ASSIGN.CUSTOM_PLAN_MISBOUND", …)`.
+
+5. A successful assignment is transactional: within one DB transaction it flips the prior `active`
+   assignment to `cancelled` (stamping its `EffectiveTo`), inserts the new `active` row, and
+   updates `Tenant.PlanId` + `Tenant.Plan`. The one-active-per-tenant invariant (AC2) is enforced
+   by the partial unique index; a concurrent double-assign loses the race with a unique-violation
+   that the service translates to a `409`/retry rather than two active rows.
+
+6. Upgrade and downgrade transitions emit a DCB `TENANT.PLAN.CHANGED` event (via
+   `IEventRepository.AppendAsync` for tenant-scope, mirrored to `PlatformEvent` via
+   `IPlatformEventPublisher` for the platform audit timeline) carrying `tenantId`,
+   `oldPlanId`+`oldPlanVersion`, `newPlanId`+`newPlanVersion`, `direction`
+   (`upgrade`|`downgrade`|`lateral`), `mode` (single-user|saas), `actorUserId`, and a
+   **proration-boundary marker** (`prorationBoundaryAt` = the change instant, plus
+   `billingIntervalAnchor`) that Epic 35 Billing consumes. The event name follows the
+   `AGGREGATE.ACTION.STATUS` convention.
+
+7. Downgrades whose target entitlements are below the tenant's **current** usage are **flagged,
+   not blocked** (enforcement is a sibling epic): `AssignAsync` returns a
+   `PlanAssignmentResult` whose `Warnings` collection lists each over-limit
+   `EntitlementMetricKey` (from 34-1's enum) with current-vs-new values, and tags the
+   `TENANT.PLAN.CHANGED` event `entitlementWarnings=true`. This story does NOT compute live usage
+   itself — it reads the usage signal from the metering surface (Epic 35 / Epic 20) behind an
+   `ITenantUsageReader` seam, and degrades to "no warnings" if usage data is unavailable.
+
+8. Cancellation (`CancelAsync(Guid tenantId, CancelPlanOptions opts, ct)`) does NOT immediately
+   drop the tenant: it stamps `EffectiveTo` on the current `active` assignment at the **period
+   end** (default = current billing-interval boundary; `opts.Immediate` allows now) and inserts a
+   `scheduled` `TenantPlanAssignment` row pointing at `plan_free` with `EffectiveFrom` = that
+   boundary. A `TENANT.PLAN.CANCELLED` event is emitted with the scheduled `effectiveAt`.
+
+9. A boundary-activation path promotes a `scheduled` assignment to `active` once its `EffectiveFrom`
+   is reached: the existing `PlatformTaskQueueProcessor` enqueues an ` activate-scheduled-plan`
+   task at the boundary (mirroring the `MoveTenant` 202+poll pattern in `AdminTenantsEndpoints`),
+   which calls `IPlanAssignmentService.ActivateScheduledAsync`. Activation flips the expiring
+   `active` row to `cancelled`, the `scheduled` row to `active`, updates the tenant columns, and
+   emits `TENANT.PLAN.CHANGED` with `source=scheduled-activation`.
+
+10. Admin self-service: `PATCH /api/admin/tenants/{id}/plan` is refactored to delegate to
+    `IPlanAssignmentService.AssignAsync` (replacing the inline plan-flip + `PLAN.UPDATED` emit in
+    `AdminTenantsEndpoints.UpdateTenantPlan`), and a new
+    `PUT /api/admin/tenants/{id}/plan` (idempotent assign with version + reason body) is gated by
+    `PlatformOwnerAccess`. The legacy `PLAN.UPDATED` platform event is superseded by
+    `TENANT.PLAN.CHANGED` (kept as an alias tag for one release for dashboard back-compat).
+
+11. Tenant self-service: a new `POST /api/pricing/subscribe` (in `PricingEndpoints.cs`, the file
+    34-2 introduces) lets a tenant pick a **public** (`IsCustom == false`, `Status == active`)
+    plan for their own tenant; it resolves the caller's tenant via `ITenantContext` and is gated by
+    `SettingsManage` (tenant_owner). A `member`-role caller is rejected `403` via the
+    `RequireTenantAdmin`/membership-filter pattern used by `AlertEndpoints`. Subscribing to a
+    custom or draft/deprecated plan, or to a plan bound to another tenant, returns `422`/`403`.
+
+12. Per-mode + per-tenant ownership is honored end-to-end: in **single-user** mode the sole user
+    owns assignment (no RBAC beyond authentication; `AssignedByUserId` = the user); in **SaaS**
+    mode platform owners assign any tenant via the admin route while `tenant_owner` self-subscribes
+    via `/api/pricing/subscribe` and `member` is read-only (403 on subscribe). Mode is read from
+    `ITammaModeProvider`.
+
+13. Version pinning survives plan deprecation: assigning version N then deprecating the plan
+    (creating version N+1 and flipping N → `deprecated`, per 34-1/34-2) leaves the tenant's
+    assignment on `PlanVersion = N` with no re-price; reading the tenant's effective plan resolves
+    the pinned `(PlanId, PlanVersion)` snapshot, never the latest version.
+
+14. Unit + integration tests cover: version pinning survives deprecation, the one-active-assignment
+    invariant under concurrency, custom-plan misassignment rejection, draft/deprecated guard,
+    upgrade/downgrade `direction` classification, downgrade entitlement-warning surfacing,
+    cancel→`plan_free` scheduling and boundary activation, DCB `TENANT.PLAN.CHANGED` /
+    `TENANT.PLAN.CANCELLED` emission, RBAC (member 403 on subscribe, cross-tenant 404), and
+    tenant-isolation (a tenant can never assign/subscribe another tenant's plan).
+
+## Technical Design
+
+### Namespace / File Structure
+
+```
+apps/tamma-elsa/src/
+  Tamma.Data/
+    Entities/
+      TenantPlanAssignment.cs            # NEW — assignment row
+      Tenant.cs                          # MODIFY — doc note: Plan/PlanId derived from active assignment
+    ControlPlaneDbContext.cs             # MODIFY — DbSet<TenantPlanAssignment>
+    TammaModelConfiguration.cs           # MODIFY — entity config, partial unique index, CHECKs, FKs
+    Migrations/ControlPlane/
+      <ts>_AddTenantPlanAssignment.cs    # NEW — additive table + back-fill
+  Tamma.Core/
+    Enums/
+      PlanAssignmentStatus.cs            # NEW — active|scheduled|cancelled (string-backed constants)
+      PlanChangeDirection.cs             # NEW — upgrade|downgrade|lateral
+  Tamma.Api/
+    Services/Pricing/
+      IPlanAssignmentService.cs          # NEW — assign / cancel / activate / read-effective
+      PlanAssignmentService.cs           # NEW — core logic (txn, pin, guards, events)
+      PlanAssignmentModels.cs            # NEW — AssignPlanOptions, CancelPlanOptions,
+                                         #       PlanAssignmentResult, EntitlementWarning
+      ITenantUsageReader.cs              # NEW — usage seam (downgrade-warning input; Epic 35 impl)
+      PlanAssignmentEventTypes.cs        # NEW — TENANT.PLAN.CHANGED / .CANCELLED constants
+    Services/Provisioning/
+      ActivateScheduledPlanTaskPayload.cs # NEW — platform-queue payload for boundary activation
+    Endpoints/
+      Admin/AdminTenantsEndpoints.cs     # MODIFY — UpdateTenantPlan delegates; add PutTenantPlan
+      PricingEndpoints.cs                # MODIFY (NEW in 34-2) — add POST /api/pricing/subscribe
+    Extensions/
+      PricingServiceCollectionExtensions.cs # NEW (or extend 34-1's) — register the services
+    Program.cs                           # MODIFY — map PUT plan route + subscribe route; DI
+```
+
+> **Boundary note (Epic 34 ↔ siblings):** this story owns *assignment + lifecycle only*. The
+> versioned `Plan`/`PlanEntitlement`/`PlanPrice` catalog and `IPlanCatalogService` belong to
+> **34-1**; the admin catalog CRUD, `PricingEndpoints.cs` file, and custom-plan minting/binding
+> belong to **34-2** — this story *consumes* them (resolve version, read `IsCustom`, list public
+> plans) and *adds* the subscribe handler to the existing file. Quota **enforcement** and live
+> **usage metering** belong to Epic 35 / Epic 20 — this story only *reads behind a seam* and
+> *flags*, never blocks or charges. Proration/Billing math belongs to **Epic 35** — this story
+> only *emits the boundary marker*.
+
+### Key Entity (`TenantPlanAssignment.cs`)
+
+```csharp
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Audited, versioned record of which plan a tenant is on. Replaces the loose
+/// Tenant.Plan string as the source of truth (Story 34-4). At most one row per
+/// tenant has Status='active' (partial unique index). PlanVersion is a pinned
+/// copy of Plan.Version (34-1) so a later plan deprecation never re-prices an
+/// existing tenant.
+/// </summary>
+public class TenantPlanAssignment
+{
+    public Guid Id { get; set; }                 // UUIDv7
+    public Guid TenantId { get; set; }           // FK tenants.Id
+    public Guid PlanId { get; set; }             // FK plans.Id (versioned row, 34-1)
+    public int PlanVersion { get; set; }         // pinned copy of Plan.Version
+    public string Status { get; set; } = "active"; // active|scheduled|cancelled
+    public DateTime EffectiveFrom { get; set; }
+    public DateTime? EffectiveTo { get; set; }
+    public Guid? AssignedByUserId { get; set; }  // actor; null = system/scheduler
+    public string? Reason { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}
+```
+
+### EF Model Config (sketch, in `TammaModelConfiguration.cs`)
+
+```csharp
+modelBuilder.Entity<TenantPlanAssignment>(entity =>
+{
+    entity.ToTable("tenant_plan_assignments", t =>
+    {
+        t.HasCheckConstraint("ck_tpa_status",
+            "\"Status\" IN ('active','scheduled','cancelled')");
+        t.HasCheckConstraint("ck_tpa_effective_window",
+            "\"EffectiveTo\" IS NULL OR \"EffectiveTo\" >= \"EffectiveFrom\"");
+        t.HasCheckConstraint("ck_tpa_version_positive", "\"PlanVersion\" >= 1");
+    });
+    entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+    entity.Property(e => e.Status).HasMaxLength(16);
+
+    // AC2 — at most one active assignment per tenant.
+    entity.HasIndex(e => e.TenantId)
+        .IsUnique()
+        .HasFilter("\"Status\" = 'active'")
+        .HasDatabaseName("ux_tpa_one_active_per_tenant");
+    entity.HasIndex(e => new { e.TenantId, e.Status });
+    entity.HasIndex(e => e.PlanId);
+
+    entity.HasOne<Tenant>().WithMany()
+        .HasForeignKey(e => e.TenantId).OnDelete(DeleteBehavior.Cascade);
+    entity.HasOne<Plan>().WithMany()
+        .HasForeignKey(e => e.PlanId).OnDelete(DeleteBehavior.Restrict);
+});
+```
+
+### EF Migration Sketch (additive table + back-fill)
+
+```csharp
+// Up()
+migrationBuilder.CreateTable(name: "tenant_plan_assignments", columns: …);
+migrationBuilder.CreateIndex(
+    name: "ux_tpa_one_active_per_tenant",
+    table: "tenant_plan_assignments",
+    column: "TenantId", unique: true, filter: "\"Status\" = 'active'");
+
+// Back-fill one active assignment per existing tenant (AC3). Raw SQL so the
+// pinned PlanVersion is read from the plans row at migration time. Tenants
+// with a NULL shadow PlanId fall back to the plan whose Slug matches Tenant.Plan;
+// remaining NULLs fall back to plan_free.
+migrationBuilder.Sql(@"
+  INSERT INTO tenant_plan_assignments
+    (""Id"",""TenantId"",""PlanId"",""PlanVersion"",""Status"",
+     ""EffectiveFrom"",""AssignedByUserId"",""Reason"",""CreatedAt"",""UpdatedAt"")
+  SELECT gen_random_uuid(), t.""Id"",
+         COALESCE(t.""PlanId"", p.""Id"", f.""Id""),
+         COALESCE(p.""Version"", f.""Version"", 1),
+         'active', t.""CreatedAt"", NULL, 'backfill: 34-4 migration',
+         now(), now()
+  FROM tenants t
+  LEFT JOIN plans p ON p.""Id"" = t.""PlanId""
+  LEFT JOIN plans f ON f.""Slug"" = 'free' AND f.""Status"" = 'active'
+  WHERE t.""DeletedAt"" IS NULL;");
+```
+
+> `has-pending-model-changes` must report **none** after the migration; the table is additive (no
+> CHECK edits on existing tables, so Phase-0 collapsed-baseline rules do not apply).
+
+### Service Interface (`IPlanAssignmentService.cs`)
+
+```csharp
+public interface IPlanAssignmentService
+{
+    /// Pin tenant to a plan version. Guards draft/deprecated + custom binding;
+    /// classifies direction; flags (never blocks) over-limit downgrades.
+    Task<PlanAssignmentResult> AssignAsync(
+        Guid tenantId, Guid planId, AssignPlanOptions opts, CancellationToken ct);
+
+    /// Schedule cancel → plan_free at period end (or immediate).
+    Task<PlanAssignmentResult> CancelAsync(
+        Guid tenantId, CancelPlanOptions opts, CancellationToken ct);
+
+    /// Promote a due `scheduled` row to `active` (called by the platform-queue task).
+    Task<PlanAssignmentResult> ActivateScheduledAsync(
+        Guid tenantId, Guid assignmentId, CancellationToken ct);
+
+    /// Resolve the tenant's current effective (PlanId, PlanVersion) snapshot.
+    Task<TenantPlanAssignment?> GetActiveAsync(Guid tenantId, CancellationToken ct);
+}
+
+public sealed record AssignPlanOptions(
+    Guid? ActorUserId, string? Reason, bool Force = false);
+
+public sealed record CancelPlanOptions(
+    Guid? ActorUserId, string? Reason, bool Immediate = false);
+
+public sealed record PlanAssignmentResult(
+    TenantPlanAssignment Assignment,
+    PlanChangeDirection Direction,
+    IReadOnlyList<EntitlementWarning> Warnings,
+    DateTime? ScheduledEffectiveAt);
+
+public sealed record EntitlementWarning(
+    string MetricKey, long? CurrentUsage, long? NewLimit);  // MetricKey ⊂ EntitlementMetricKey (34-1)
+```
+
+### DCB Event Names (`AGGREGATE.ACTION.STATUS`)
+
+- `TENANT.PLAN.CHANGED` — emitted on assign + scheduled-activation.
+  Tags: `tenantId`, `oldPlanId`, `oldPlanVersion`, `newPlanId`, `newPlanVersion`, `direction`,
+  `mode`, `actorUserId`, `source` (`admin|self-service|scheduled-activation`),
+  `entitlementWarnings` (`true|false`). Data also carries `prorationBoundaryAt`,
+  `billingIntervalAnchor`, and the full `warnings` array for Billing/audit.
+- `TENANT.PLAN.CANCELLED` — emitted on cancel scheduling.
+  Tags: `tenantId`, `currentPlanId`, `effectiveAt`, `mode`, `actorUserId`, `immediate`.
+
+Tenant-scope events append via `IEventRepository.AppendAsync(DomainEvent)`; the platform audit
+mirror uses `IPlatformEventPublisher.AppendAndPublishAsync(PlatformEvent)` with actor tags built
+the same way `AdminTenantsEndpoints.BuildAdminEvent` does. (System-scope mirror keeps the
+evaluator-visible audit on the CP store, consistent with the Story-28-1 event-topology note.)
+
+### API Shape
+
+```
+# Admin (platform owner) — PlatformOwnerAccess
+PATCH /api/admin/tenants/{tenantId}/plan      # refactored: delegates to AssignAsync
+PUT   /api/admin/tenants/{tenantId}/plan      # idempotent assign; body { planId, reason?, force? }
+  → 200 { tenantId, planId, planVersion, status, direction, warnings[] }
+  → 409 illegal_transition | concurrent_assign
+  → 422 plan_draft | plan_deprecated_no_force | custom_plan_misbound
+POST  /api/admin/tenants/{tenantId}/plan/cancel  # body { reason?, immediate? } → 200 (scheduled)
+
+# Tenant self-service — SettingsManage (tenant_owner); member → 403
+POST  /api/pricing/subscribe                  # body { planSlug } ; tenant from ITenantContext
+  → 200 { planId, planVersion, status, direction, warnings[] }
+  → 403 member_role | cross_tenant
+  → 422 plan_not_public | plan_draft_or_deprecated
+```
+
+### Per-Mode + Per-Tenant Handling
+
+| Concern | single-user mode | SaaS mode |
+|---|---|---|
+| Who may assign | the sole user (authenticated) | platform owner (admin route) |
+| Who may self-subscribe | the sole user via `/api/pricing/subscribe` | `tenant_owner` (`SettingsManage`); `member` → 403 |
+| `AssignedByUserId` | the user | the platform owner / tenant owner |
+| Tenant resolution | `ITenantContext.TenantId` (the lone tenant) | `ITenantContext.TenantId` (caller's tenant); admin route takes `{tenantId}` route param |
+| Cross-tenant guard | n/a (one tenant) | subscribe ignores any body tenant id and uses `ITenantContext`; admin route 404s unknown tenant |
+| Mode source | `ITammaModeProvider.Mode` | same |
+
+### Integration Points
+
+- **34-1 `IPlanCatalogService`** — resolve `(planId → PlanSnapshot{Version, Status, IsCustom,
+  BoundTenantId, Entitlements})` for pinning + guards. `EntitlementMetricKey` enum from
+  `Tamma.Core/Enums` is reused verbatim in `EntitlementWarning.MetricKey`.
+- **34-2 `PricingEndpoints.cs` / `AdminPricingEndpoints`** — public-plan list reuse for subscribe
+  validation; custom-plan binding flag is read, not written, here.
+- **`AdminTenantsEndpoints`** — `UpdateTenantPlan` is refactored to delegate; `BuildAdminEvent`
+  actor-extraction pattern is reused for the platform mirror; the `MoveTenant` 202+poll pattern is
+  mirrored for boundary activation.
+- **`PlatformTaskQueueProcessor` / `IPlatformQueuedTaskRepository`** — boundary activation task is
+  enqueued/claimed exactly like `MoveTenantTaskPayload`.
+- **`IEventRepository` / `IPlatformEventPublisher`** — DCB + platform-audit emission.
+- **Epic 35 / Epic 20 `ITenantUsageReader`** — downgrade-warning input (this story ships the
+  interface + a null/no-op default; Epic 35 supplies the real reader).
+
+## Dependencies
+
+**Internal — prerequisite:**
+- Story 34-1 (Plan & Price-Book Catalog) — versioned `Plan` (Version/Status/IsCustom),
+  `PlanEntitlement`, `EntitlementMetricKey` enum, `IPlanCatalogService`/`PlanSnapshot`.
+- Story 34-2 (Plan Catalog Admin API & Custom Plans) — `PricingEndpoints.cs` file, public-catalog
+  reads, custom-plan binding semantics.
+- Epic 28 (control-plane tenancy) — `Tenant` shadow `PlanId`/`Status`, `ControlPlaneDbContext`,
+  `PlatformQueuedTask`/`PlatformTaskQueueProcessor`, `IPlatformEventPublisher`.
+- Epic 4 (DCB events) — `DomainEvent`/`IEventRepository` append path.
+
+**Internal — blocks:**
+- Epic 35 (Billing) — consumes `TENANT.PLAN.CHANGED` proration boundary + `ScheduledEffectiveAt`.
+- Epic 34 Enforcement story — consumes the active `(PlanId, PlanVersion)` snapshot for quota gating.
+
+**External:**
+- None in this story. The `ITenantUsageReader` seam keeps Stripe/metering (Epic 35) out of the
+  assignment path; tests mock it.
+
+## Testing Strategy
+
+**Unit (xUnit, `tests/Tamma.Api.Tests/Pricing/`):**
+1. `AssignAsync` pins `PlanVersion` from the catalog snapshot; reads of the active assignment after
+   a later deprecation still report the pinned version (AC13).
+2. One-active invariant: assigning twice flips prior → `cancelled` and inserts new `active`; never
+   two `active` rows; concurrent assign → unique-violation translated to 409 (mock the unique
+   index via the in-memory provider plus a forced `DbUpdateException` path).
+3. Custom-plan binding: assigning an `IsCustom` plan to a non-bound tenant throws
+   `PLAN.ASSIGN.CUSTOM_PLAN_MISBOUND`; to the bound tenant succeeds.
+4. Draft guard (always rejected) + deprecated guard (rejected unless `Force`).
+5. Direction classification (upgrade/downgrade/lateral) from `MonthlyPriceUsd`/`PlanPrice`
+   ordering; downgrade with over-limit usage (mock `ITenantUsageReader`) surfaces
+   `EntitlementWarning`s and sets `entitlementWarnings=true`; usage unavailable → no warnings,
+   no throw.
+6. `CancelAsync` stamps `EffectiveTo` at period end and inserts a `scheduled` `plan_free` row;
+   `Immediate` cancels now; emits `TENANT.PLAN.CANCELLED`.
+7. `ActivateScheduledAsync` promotes a due `scheduled` row, flips the expiring `active`, emits
+   `TENANT.PLAN.CHANGED` with `source=scheduled-activation`.
+8. Event-shape tests: `TENANT.PLAN.CHANGED` carries all required tags + the proration marker.
+
+**Integration (xUnit + Postgres via `sg docker -c "dotnet test …"`):**
+9. Migration applies + rolls back cleanly; back-fill produces exactly one `active` assignment per
+   existing tenant; partial unique index rejects a second `active` insert at the DB level.
+10. `PATCH`/`PUT /api/admin/tenants/{id}/plan` round-trip (PlatformOwnerAccess); a non-platform
+    JWT → 403; unknown tenant → 404.
+11. `POST /api/pricing/subscribe`: tenant_owner subscribes to a public plan (200); `member` → 403;
+    custom/draft/deprecated → 422; **tenant isolation** — caller A cannot subscribe/affect
+    tenant B (body tenant id is ignored; route is tenant-from-context).
+12. Cancel → boundary activation end-to-end via the platform queue: enqueue, run the processor,
+    assert the `scheduled` `plan_free` row becomes `active` and the tenant columns flip.
+
+**Mocks:** `ITenantUsageReader` (no Stripe in this story), `IPlanCatalogService` (34-1),
+`IEventRepository`/`IPlatformEventPublisher` (assert emission), `TimeProvider` (deterministic
+period-end boundaries).
+
+## Estimated Effort
+
+4 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/TenantPlanAssignment.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/Tenant.cs` | Modify (doc note: Plan/PlanId derived) |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (add DbSet) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (entity config, partial unique index, CHECKs, FKs) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_AddTenantPlanAssignment.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Core/Enums/PlanAssignmentStatus.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Core/Enums/PlanChangeDirection.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IPlanAssignmentService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanAssignmentService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanAssignmentModels.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/ITenantUsageReader.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanAssignmentEventTypes.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/ActivateScheduledPlanTaskPayload.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminTenantsEndpoints.cs` | Modify (delegate + PUT) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs` | Modify (add subscribe; file from 34-2) |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/PricingServiceCollectionExtensions.cs` | Create/Modify |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map PUT plan + subscribe; DI) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanAssignmentServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanAssignmentEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Data.Tests/Migrations/TenantPlanAssignmentMigrationTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md).
+2. Searched `.dev/` for related spikes/bugs/findings/decisions (tenancy, plans, events).
+3. Reviewed 34-1 and 34-2 stories — this story is strictly downstream of their catalog/version
+   model; do NOT re-implement the catalog here.
+4. Confirmed the C# test runner contract: `sg docker -c "dotnet test …"` for docker-bound suites
+   (build needs no wrapper). See `reference_dotnet_test_docker`.
+5. Planned a TDD (Red-Green-Refactor) approach — tests for each AC before implementation.
+
+### Key Design Decisions
+
+- **Pin the version, don't reference "latest".** `PlanVersion` is a denormalized column on the
+  assignment, not a join to the current plan row. This is the whole point of the story: a 34-1/34-2
+  deprecation flips the plan row but cannot retro-price an existing tenant.
+- **Assignment is the source of truth; `Tenant.Plan`/`PlanId` are a cache.** Keep them in lockstep
+  only so existing dashboards (`AdminTenantsEndpoints.ListTenants`, which reads
+  `EF.Property<Guid?>(t,"PlanId")`) render the right plan without a rewrite. New reads should call
+  `IPlanAssignmentService.GetActiveAsync`.
+- **Flag, don't block, downgrades.** Per the scope and the epic boundary, enforcement lives
+  elsewhere. `AssignAsync` always succeeds for a valid plan; it merely returns warnings. The
+  `ITenantUsageReader` seam keeps usage/Billing out of the assignment transaction.
+- **Reuse the platform queue for boundary work.** Boundary activation and period-end cancel mirror
+  `MoveTenant`'s enqueue + processor pattern instead of inventing a new scheduler.
+- **Supersede, don't shadow-emit.** `TENANT.PLAN.CHANGED` replaces the ad-hoc `PLAN.UPDATED`; keep
+  a one-release alias tag so the admin dashboard timeline doesn't blank out mid-migration.
+
+### Edge Cases
+
+- Assigning the tenant's current `(PlanId, PlanVersion)` again = no-op `lateral`; return 200 with
+  the existing row, no new event (idempotent PUT).
+- Cancel when already on `plan_free` = no-op (already free); return 200, no scheduled row.
+- A `scheduled` row whose boundary passed while the host was down → caught by the activation task
+  on next processor tick (the task is idempotent by `assignmentId`).
+- Concurrent admin + self-service assign → partial unique index makes one lose with a translated
+  409; never two `active` rows.
+
+## Logging Requirements
+
+- **INFO**: plan assigned (tenantId, oldPlan→newPlan, version, direction, source), plan cancel
+  scheduled (effectiveAt), scheduled activation completed.
+- **DEBUG**: catalog snapshot resolved, direction classification inputs, usage-reader lookup
+  result, transaction begin/commit.
+- **WARN**: downgrade with entitlement over-limit (metricKey, current, newLimit),
+  deprecated-plan assign with `Force=true`, usage reader unavailable (degraded to no warnings),
+  concurrent-assign unique violation retried/409.
+- **ERROR**: assignment transaction rollback, custom-plan misbinding attempt, FK/CHECK violation,
+  platform-queue enqueue failure for boundary activation.
+- **Structured context**: include `{ tenantId, planId, planVersion, direction, mode, actorUserId,
+  source }` where applicable.
+- **Credential / PII safety**: never log connection strings or actor PII beyond the user GUID +
+  (already-logged) email captured by the platform-event actor breadcrumb.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-34/story-34-5/34-5-cost-price-markup-engine.md
+++ b/docs/stories/epic-34/story-34-5/34-5-cost-price-markup-engine.md
@@ -1,0 +1,478 @@
+# Story 34-5: Cost->Price Markup Engine (platform-provided usage)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-phase workflow (Read -> Research -> Break Down -> TDD ->
+Quality Gates -> Failure Handling), knowledge-base usage (`.dev/`), TRACE/DEBUG logging
+requirements, test-first development, and the build/coverage gates. **Failure to follow this
+process will result in rework.**
+
+## User Story
+
+As a **platform owner monetizing platform-provided AI usage**,
+I want a pure, deterministic engine that turns a measured usage event into a priced amount by
+applying a configurable margin policy on top of the provider cost basis (and applies **no** token
+markup for BYOK tenants),
+so that Billing (Epic 35), the cost dashboard, and the upgrade/estimate UI all compute the same
+sell price from a single canonical source instead of each re-implementing markup math.
+
+## Priority
+
+P0 - The cost->price engine is the canonical pricing primitive that Billing (Epic 35), usage
+analytics (Epic 36-7), and the entitlement/quota UI all consume. Without it those layers would each
+re-derive markup, drift, and produce inconsistent invoices.
+
+## Acceptance Criteria
+
+1. New control-plane entity `MarginPolicy` (`Tamma.Data.Entities.MarginPolicy`) added to
+   `ControlPlaneDbContext` with columns: `Id` (UUIDv7), `Scope` (`global|plan|provider`), `RefKey`
+   (NULL for global; plan slug for plan scope; canonical provider key for provider scope),
+   `MarkupMultiplier` (nullable `decimal`), `FixedUsdPer1M` (nullable `decimal`), `EffectiveFrom`
+   (`timestamptz`), `Status` (`active|superseded`), `CreatedAt`, `UpdatedAt`. An EF migration is
+   added under `Tamma.Data/Migrations/ControlPlane/` and `dotnet ef migrations
+   has-pending-model-changes` reports none afterward.
+2. A CHECK constraint enforces that **at least one** of `MarkupMultiplier` / `FixedUsdPer1M` is
+   non-null (no all-null policy row), and a partial unique index enforces exactly one `active`
+   policy per `(Scope, RefKey)` (`RefKey` compared with NULLS NOT DISTINCT for the global row).
+3. `MarginPolicySeeder.SeedAsync(ControlPlaneDbContext)` seeds a deterministic-UUIDv7 default
+   **global** policy of `MarkupMultiplier = 1.3` (insert-missing-only, never reverts admin edits —
+   mirrors the convention/plan system-defaults ownership rule). Registered in `Program.cs`
+   alongside `PlansSeeder.SeedAsync` (~line 2030).
+4. Resolution order in `IMarginPolicyResolver.ResolveAsync(provider, planSlug, atTimestamp)` is
+   strictly **provider-override -> plan -> global -> error**: pick the most-specific `active`
+   policy whose `EffectiveFrom <= atTimestamp`; if none matches at any level, throw
+   `TammaError("PRICING.MARGIN.NO_POLICY", ..., severity High)` — **never** silently price at a
+   zero margin (mirrors the no-empty-fallback rule).
+5. `IUsagePricingEngine.PriceUsage(UsageLine)` returns a `PricedUsage` record
+   `{ CostBasisUsd, MarginUsd, SellPriceUsd, PricingMode }`. For `PricingMode.PlatformProvided`:
+   `CostBasisUsd = ProviderPricingService.Compute(provider, model, inputTokens, outputTokens)` and
+   `SellPriceUsd = CostBasisUsd * MarkupMultiplier (+ FixedUsdPer1M * totalTokens/1_000_000)`,
+   `MarginUsd = SellPriceUsd - CostBasisUsd`. For `PricingMode.Byok`: `CostBasisUsd` is still
+   computed (for reporting/analytics) but the **token component of** `SellPriceUsd` is `0` and
+   `MarginUsd` is `0` (the plan/seat fee is Billing's concern, not this engine's).
+6. The engine reads `inputTokens`, `outputTokens`, `provider`, `model`, and `pricingMode` from the
+   `UsageLine` input, which is built from the `ProviderDiagnostic` row (its `InputTokens` /
+   `OutputTokens` / `ProviderKey` / `Model` / `BillingMode` columns, the latter added by Story 34-3)
+   or from the equivalent DCB usage event emitted in Epic 32-9 — so per-call cost basis is exact
+   (input and output billed at different rates by `ProviderPricingService`).
+7. Pricing is **reproducible / byte-stable**: given the same `UsageLine` plus the `MarginPolicy`
+   that was `active` and `EffectiveFrom <= UsageLine.OccurredAt`, the output is identical across
+   runs — internal arithmetic carries 6 decimal places (`Math.Round(x, 6, MidpointRounding.ToEven)`
+   at each accumulation boundary), invoice-facing values round to 2dp. This is pinned by a
+   golden-file test (`PriceUsage_GoldenScenarios_AreByteStable`).
+8. Unknown `(provider, model)` (i.e. `ProviderPricingService.IsKnown` returns false) surfaces a
+   typed `TammaError("PRICING.UNKNOWN_MODEL", ..., severity Medium)` — the engine does **not**
+   silently price at `0` so misconfiguration is visible. A WARN is logged with `provider` + `model`.
+9. Admin API `GET /api/admin/pricing/margins` and `PUT /api/admin/pricing/margins`
+   (`AdminPricingEndpoints`, gated by the `PlatformOwnerAccess` policy) view and version margin
+   policies. A `PUT` that changes an existing `active` policy flips the prior row to `superseded`
+   and inserts a new `active` row (versioning, not in-place mutation), and emits
+   `PRICING.MARGIN.UPDATED` to the control-plane `DomainEvents` store via `IEventRepository.AppendAsync`
+   with tags `{ scope, refKey, actorUserId }`.
+10. Tenant API `GET /api/pricing/estimate` (`PricingEndpoints`, `MemberAccess`) returns a priced
+    estimate for a hypothetical `UsageLine` (provider, model, inputTokens, outputTokens) under the
+    **current tenant's plan + the tenant's pricing mode for that provider** (BYOK vs platform-
+    provided, resolved through the Story 34-3 seam) — powering the upgrade/cost UI in
+    `packages/dashboard-user`. In single-user mode the sole user's instance plan is used.
+11. The engine is **pure / side-effect-free**: `PriceUsage` does no I/O, takes the resolved
+    `MarginPolicy` (or a `MarginContext`) and `UsageLine` as inputs, and returns the `PricedUsage`
+    result — so Billing and the dashboard can both call it deterministically. Policy resolution
+    (the DB read) lives in `IMarginPolicyResolver`, kept separate from the pure engine.
+12. Per-mode + per-tenant: margin policies are platform-owned global config (no per-tenant margin
+    rows) — only `PlatformOwnerAccess` may mutate them in SaaS; in single-user mode the sole user
+    owns them. The **pricing mode** (BYOK vs platform) is per-`(tenant, provider)` and is read from
+    Story 34-3's `TenantProviderBilling` / `ProviderDiagnostic.BillingMode`, never invented here.
+13. Unit tests cover: platform markup math (multiplier-only, fixed-per-1M-only, both combined),
+    BYOK zero-token-markup with non-zero cost basis, margin resolution order
+    (provider > plan > global), timestamp-effective policy selection (an event priced under the
+    policy that was active at its `OccurredAt`, not the latest), unknown-model error, no-policy
+    error, and rounding determinism (6dp internal / 2dp invoice).
+14. Tenant-isolation test: a tenant's `GET /api/pricing/estimate` resolves only its own plan and
+    its own `(tenant, provider)` pricing mode; it can never read or mutate `MarginPolicy` rows
+    (403 on any `/api/admin/pricing/*` route for a non-platform-owner).
+
+## Technical Design
+
+### Namespace / File Structure
+
+```
+apps/tamma-elsa/src/
+  Tamma.Data/
+    Entities/
+      MarginPolicy.cs                         # NEW entity (control plane)
+    ControlPlaneDbContext.cs                   # MODIFY: add DbSet<MarginPolicy> + model config
+    Migrations/ControlPlane/
+      <ts>_AddMarginPolicy.cs                  # NEW EF migration (additive)
+    Seeders/
+      MarginPolicySeeder.cs                    # NEW seeder (global 1.3x default, insert-missing-only)
+  Tamma.Core/
+    Enums/
+      PricingMode.cs                           # NEW enum (PlatformProvided | Byok) — or reuse 34-1's
+                                               #   PlanPrice.PricingMode if it lands as a shared enum
+  Tamma.Api/
+    Services/Pricing/                          # dir created by 34-1; this story adds to it
+      IUsagePricingEngine.cs                   # NEW — pure engine contract
+      UsagePricingEngine.cs                    # NEW — pure engine impl
+      UsageLine.cs                             # NEW — engine input record
+      PricedUsage.cs                           # NEW — engine output record
+      IMarginPolicyResolver.cs                 # NEW — DB-backed policy resolution (impure)
+      MarginPolicyResolver.cs                  # NEW
+      PricingEventTypes.cs                      # NEW — DCB event-name constants
+    Endpoints/
+      Admin/AdminPricingEndpoints.cs           # NEW — GET/PUT /api/admin/pricing/margins
+      PricingEndpoints.cs                      # 34-3 creates this; this story adds GET /estimate
+    Extensions/
+      PricingServiceCollectionExtensions.cs    # NEW (or extend 34-1's) — DI wiring
+    Program.cs                                  # MODIFY: map endpoints + register seeder + DI
+```
+
+> **Boundary note (honored):** this story is the CANONICAL owner of the cost->price markup/margin
+> engine (cost basis from `ProviderPricingService` + margin -> sell price). It does **not**
+> re-implement the provider cost table (that is `ProviderPricingService`, Epic providers), does
+> **not** select BYOK-vs-platform mode (that is Story 34-3's `TenantProviderBilling` /
+> `IProviderKeyResolver`), does **not** produce the usage event (Epic 32-9), and does **not** move
+> money or render invoices (Epic 35 Billing). Those epics **consume** this engine and MUST NOT
+> re-implement markup.
+
+### Entity: `MarginPolicy`
+
+```csharp
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Control-plane margin policy applied by the cost->price engine (Story 34-5).
+/// Versioned: an edit supersedes the prior active row rather than mutating it,
+/// so a usage event is always priced under the policy that was active at its
+/// timestamp. Platform-owned global config — no per-tenant margin rows exist.
+/// </summary>
+public class MarginPolicy
+{
+    public Guid Id { get; set; }                       // UUIDv7
+
+    /// <summary>"global" | "plan" | "provider".</summary>
+    public string Scope { get; set; } = null!;
+
+    /// <summary>NULL for global; plan slug for plan scope; canonical provider key for provider scope.</summary>
+    public string? RefKey { get; set; }
+
+    /// <summary>Multiplicative markup on the provider cost basis (e.g. 1.3 = +30%). Nullable.</summary>
+    public decimal? MarkupMultiplier { get; set; }
+
+    /// <summary>Additive USD per 1,000,000 total tokens. Nullable. At least one of the two is set.</summary>
+    public decimal? FixedUsdPer1M { get; set; }
+
+    public DateTime EffectiveFrom { get; set; }        // timestamptz, UTC
+    public string Status { get; set; } = "active";     // "active" | "superseded"
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}
+```
+
+EF model config (in `ControlPlaneDbContext.OnModelCreating`, mirroring existing entity config):
+
+```csharp
+modelBuilder.Entity<MarginPolicy>(e =>
+{
+    e.ToTable("margin_policies", t =>
+    {
+        t.HasCheckConstraint("ck_margin_scope",
+            "scope IN ('global','plan','provider')");
+        t.HasCheckConstraint("ck_margin_status",
+            "status IN ('active','superseded')");
+        // At least one knob must be set — never an all-null policy.
+        t.HasCheckConstraint("ck_margin_has_knob",
+            "markup_multiplier IS NOT NULL OR fixed_usd_per_1m IS NOT NULL");
+    });
+    // Exactly one active policy per (scope, ref_key); NULLS NOT DISTINCT so the
+    // single global row (ref_key NULL) is unique too.
+    e.HasIndex(p => new { p.Scope, p.RefKey })
+        .HasFilter("status = 'active'")
+        .IsUnique()
+        .AreNullsDistinct(false);
+});
+```
+
+### Engine input / output records
+
+```csharp
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>One measured usage event to be priced. Built from a ProviderDiagnostic
+/// row or the equivalent DCB usage event (Epic 32-9 / Story 34-3).</summary>
+public sealed record UsageLine(
+    string Provider,
+    string? Model,
+    int InputTokens,
+    int OutputTokens,
+    PricingMode PricingMode,
+    DateTime OccurredAt);            // UTC — drives timestamp-effective policy selection
+
+/// <summary>Result of pricing a single usage line.</summary>
+public sealed record PricedUsage(
+    decimal CostBasisUsd,            // provider cost (always computed)
+    decimal MarginUsd,               // SellPriceUsd - CostBasisUsd (0 for BYOK token component)
+    decimal SellPriceUsd,            // what the tenant is charged for tokens
+    PricingMode PricingMode);
+```
+
+### Pure engine contract
+
+```csharp
+public interface IUsagePricingEngine
+{
+    /// <summary>Pure, deterministic. Throws PRICING.UNKNOWN_MODEL if the
+    /// (provider, model) is unpriced. The resolved policy is passed in so the
+    /// engine does no I/O; resolution lives in IMarginPolicyResolver.</summary>
+    PricedUsage PriceUsage(UsageLine line, MarginPolicy policy);
+}
+```
+
+Engine arithmetic (6dp internal, even-rounding at each boundary):
+
+```csharp
+public PricedUsage PriceUsage(UsageLine line, MarginPolicy policy)
+{
+    if (!_pricing.IsKnown(line.Provider, line.Model))
+        throw new TammaError("PRICING.UNKNOWN_MODEL", $"No pricing for {line.Provider}/{line.Model}",
+            new() { ["provider"] = line.Provider, ["model"] = line.Model ?? "" }, retryable: false,
+            severity: "medium");
+
+    var costBasis = Round6(_pricing.Compute(line.Provider, line.Model,
+        line.InputTokens, line.OutputTokens));
+
+    if (line.PricingMode == PricingMode.Byok)
+        return new PricedUsage(costBasis, 0m, 0m, PricingMode.Byok); // no token markup for BYOK
+
+    var totalTokens = (long)Math.Max(0, line.InputTokens) + Math.Max(0, line.OutputTokens);
+    var multiplied = Round6(costBasis * (policy.MarkupMultiplier ?? 1m));
+    var fixedAdd   = Round6((policy.FixedUsdPer1M ?? 0m) * (totalTokens / 1_000_000m));
+    var sell       = Round6(multiplied + fixedAdd);
+    return new PricedUsage(costBasis, Round6(sell - costBasis), sell, PricingMode.PlatformProvided);
+}
+
+private static decimal Round6(decimal v) => Math.Round(v, 6, MidpointRounding.ToEven);
+```
+
+### Policy resolver (impure — the only DB read)
+
+```csharp
+public interface IMarginPolicyResolver
+{
+    /// <summary>provider-override -> plan -> global -> throw PRICING.MARGIN.NO_POLICY.
+    /// Picks the most-specific active policy whose EffectiveFrom &lt;= atTimestamp.</summary>
+    Task<MarginPolicy> ResolveAsync(string provider, string? planSlug, DateTime atTimestamp, CancellationToken ct);
+}
+```
+
+`MarginPolicyResolver` queries `ControlPlaneDbContext.MarginPolicies` for `Status == "active"`
+(plus `superseded` rows whose window covers `atTimestamp`, ordered by `EffectiveFrom desc`) at each
+scope in priority order, returning the first hit. No match -> `TammaError("PRICING.MARGIN.NO_POLICY")`.
+
+### DCB events
+
+| Event | Store | Tags | When |
+|---|---|---|---|
+| `PRICING.MARGIN.UPDATED` | CP `DomainEvents` via `IEventRepository.AppendAsync` | `scope`, `refKey`, `actorUserId` | admin `PUT /api/admin/pricing/margins` supersedes + inserts |
+
+Event name follows the `AGGREGATE.ACTION.STATUS` convention (`PRICING.MARGIN.UPDATED`). Constants
+live in `PricingEventTypes.cs`. No event is emitted by the pure engine itself (it does no I/O);
+pricing reads are side-effect-free.
+
+### API shape
+
+```
+# Admin (PlatformOwnerAccess) — mounted on the existing /api/admin group
+GET  /api/admin/pricing/margins            -> { policies: MarginPolicyDto[] }   (all scopes, active + history)
+PUT  /api/admin/pricing/margins            body: { scope, refKey?, markupMultiplier?, fixedUsdPer1M?, effectiveFrom? }
+                                            -> 200 { policy: MarginPolicyDto }   (supersede + insert; emits PRICING.MARGIN.UPDATED)
+
+# Tenant (MemberAccess) — mounted on a new /api/pricing group
+GET  /api/pricing/estimate?provider=&model=&inputTokens=&outputTokens=
+                                            -> { costBasisUsd, marginUsd, sellPriceUsd, pricingMode }
+```
+
+`AdminPricingEndpoints` follows the static-handler style of `AdminAnalyticsEndpoints` /
+`ConventionStoreEndpoints`; mapped in `Program.cs` under a new
+`app.MapGroup("/api/admin/pricing").RequireAuthorization("PlatformOwnerAccess")` group (mirrors the
+`adminConventions` group at ~line 1769). `PricingEndpoints.GetEstimate` is added to the `/api/pricing`
+group with `RequireAuthorization("MemberAccess")` (mirrors the `orgs` group at ~line 1512); it reads
+the caller's tenant via `ITenantContext.TenantId` (SaaS) / falls back to the single-user instance
+plan, resolves the plan slug via `IPlanCatalogService` (Story 34-1) and the `(tenant, provider)`
+pricing mode via the Story 34-3 seam, then calls `IMarginPolicyResolver` + `IUsagePricingEngine`.
+
+### DI wiring (`PricingServiceCollectionExtensions`)
+
+```csharp
+services.TryAddSingleton<IUsagePricingEngine, UsagePricingEngine>(); // pure, depends on IProviderPricingService (already singleton)
+services.TryAddScoped<IMarginPolicyResolver, MarginPolicyResolver>(); // scoped — reads ControlPlaneDbContext (scoped)
+```
+
+`Program.cs` calls `MarginPolicySeeder.SeedAsync(dbContext)` next to `PlansSeeder.SeedAsync`
+(~line 2030) inside the same startup migration/seed scope.
+
+### Per-mode + per-tenant handling
+
+| Concern | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns `MarginPolicy` rows? | The sole user (their instance). | Platform owner ONLY (`PlatformOwnerAccess`). Tenants never see or set margins. |
+| `GET/PUT /api/admin/pricing/margins` | sole user (admin of own instance). | `PlatformOwnerAccess`; tenant roles -> 403. |
+| Pricing mode (BYOK vs platform) | default platform-provided unless the user sets BYOK. | per-`(tenant, provider)` from Story 34-3 `TenantProviderBilling`. |
+| `GET /api/pricing/estimate` | sole user's instance plan. | caller's tenant plan (`ITenantContext`), tenant's provider mode. |
+
+## Dependencies
+
+**Internal (prerequisite):**
+- **Story 34-1** (Plan & Price-Book Catalog) — provides `IPlanCatalogService` / `PlanSnapshot` (to
+  resolve the caller's plan slug for the estimate) and the `PricingMode` (`platform_provided|byok`)
+  shared concept on `PlanPrice`. Also creates the `Services/Pricing/` directory this story extends.
+- **Story 34-3** (BYOK vs Platform-Provided Pricing Mode) — provides per-`(tenant, provider)` mode
+  (`TenantProviderBilling`) and the `ProviderDiagnostic.BillingMode` column / DCB usage tag that the
+  engine reads to decide whether to apply markup.
+- **Epic 28** (control-plane / tenancy) — `ControlPlaneDbContext`, `ITenantContext`,
+  `ITammaModeProvider`, `IEventRepository` (CP `DomainEvents`).
+- **`ProviderPricingService`** (existing, `Tamma.Api/Services/Providers/`) — the cost-basis source
+  (`Compute` / `IsKnown`).
+
+**Internal (blocks / consumers — must NOT re-implement markup):**
+- **Epic 32-9** — usage-event producer; emits the usage line this engine prices.
+- **Epic 35** (Billing) — calls `IUsagePricingEngine` to compute invoice line sell prices.
+- **Epic 36-7** (analytics/cost view) — calls the engine for priced cost reporting.
+
+**External:** none for the engine itself. Billing's Stripe integration (Epic 35) and provider APIs
+are out of scope; tests mock `IProviderPricingService` and any provider/Stripe seams.
+
+## Testing Strategy
+
+Test framework: NUnit + FluentAssertions + Moq (matches `Tamma.Api.Tests`). DB-bound suites run via
+`sg docker -c "dotnet test ..."`. Test-first (TDD) — every behavior below gets a failing test first.
+
+1. **Engine unit tests** (`tests/Tamma.Api.Tests/Pricing/UsagePricingEngineTests.cs`, pure — mock
+   `IProviderPricingService`):
+   - multiplier-only markup (`1.3x` of a known cost basis),
+   - fixed-per-1M-only markup,
+   - multiplier + fixed combined,
+   - BYOK: non-zero `CostBasisUsd`, `SellPriceUsd == 0`, `MarginUsd == 0`,
+   - unknown model -> `PRICING.UNKNOWN_MODEL` thrown, WARN logged,
+   - rounding determinism: a cost basis that would produce >6dp is rounded even at 6dp; invoice
+     projection at 2dp,
+   - **golden-file test** `PriceUsage_GoldenScenarios_AreByteStable`: a fixed set of `(UsageLine,
+     MarginPolicy)` -> serialized `PricedUsage` compared byte-for-byte against a committed
+     `golden/pricing-scenarios.json`.
+2. **Resolver unit tests** (`MarginPolicyResolverTests.cs`, in-memory/Sqlite `ControlPlaneDbContext`
+   or mocked DbSet):
+   - resolution order provider > plan > global,
+   - timestamp-effective selection (two `superseded`/`active` rows with different `EffectiveFrom` —
+     an event at `t` resolves the row active at `t`, not the latest),
+   - no policy at any scope -> `PRICING.MARGIN.NO_POLICY`.
+3. **Seeder test:** `MarginPolicySeeder` inserts the global `1.3x` row on a fresh DB; a second run
+   is a no-op and does NOT revert an admin-edited global multiplier (insert-missing-only).
+4. **Admin endpoint integration** (`AdminPricingEndpointsTests.cs`): `PUT` supersedes the prior
+   active row, inserts a new active row, emits exactly one `PRICING.MARGIN.UPDATED` event; `GET`
+   returns active + history; a non-platform-owner gets 403.
+5. **Estimate endpoint integration** (`PricingEstimateEndpointTests.cs`): platform-provided tenant
+   gets a marked-up estimate; BYOK tenant gets `sellPriceUsd == 0` for the token component;
+   unknown model -> 4xx with `PRICING.UNKNOWN_MODEL`.
+6. **Tenant-isolation test:** tenant A's estimate resolves only A's plan and A's `(tenant,
+   provider)` mode; any `/api/admin/pricing/*` call by a tenant role -> 403; an estimate never reads
+   another tenant's data.
+7. **Mocks:** `IProviderPricingService` is mocked/stubbed in engine unit tests (cost basis is a
+   controlled input); Stripe/provider HTTP never touched (this engine moves no money).
+
+## Estimated Effort
+
+4-5 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/MarginPolicy.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (DbSet + model config) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_AddMarginPolicy.cs` | Create (EF migration) |
+| `apps/tamma-elsa/src/Tamma.Data/Seeders/MarginPolicySeeder.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Core/Enums/PricingMode.cs` | Create (or reuse 34-1 shared enum) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IUsagePricingEngine.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/UsagePricingEngine.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/UsageLine.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricedUsage.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IMarginPolicyResolver.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/MarginPolicyResolver.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricingEventTypes.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminPricingEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs` | Modify (add `GetEstimate`; file created by 34-3) |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/PricingServiceCollectionExtensions.cs` | Create (or extend 34-1's) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map endpoints, register seeder + DI) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/UsagePricingEngineTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/MarginPolicyResolverTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/MarginPolicySeederTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/AdminPricingEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingEstimateEndpointTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/golden/pricing-scenarios.json` | Create (golden file) |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, and decisions (cost-monitor, pricing).
+3. Read Story 34-1 and 34-3 first — this story depends on `IPlanCatalogService`, the `PricingMode`
+   shared concept, and `ProviderDiagnostic.BillingMode`.
+4. Verified `ProviderPricingService.Compute` / `IsKnown` semantics (existing code: unknown pairs
+   return `0m` from `Compute`, so this engine MUST gate on `IsKnown` to surface `PRICING.UNKNOWN_MODEL`
+   instead of inheriting the silent-zero).
+5. Planned the TDD approach (Red-Green-Refactor), starting with the pure engine tests.
+
+### Key Design Decisions
+
+- **Pure engine, impure resolver.** `PriceUsage` is total and side-effect-free; the DB read for the
+  applicable policy is isolated in `IMarginPolicyResolver`. This is what lets Billing and the
+  dashboard call the engine deterministically and is what makes the golden-file test possible.
+- **Versioned policies, not in-place edits.** A `PUT` supersedes; old usage events stay priced under
+  the policy that was active at their `OccurredAt`. This mirrors the immutable-version discipline in
+  Story 34-1's plan catalog and is required for reproducible historical invoices.
+- **Two independent fail-loud paths.** Unknown model -> `PRICING.UNKNOWN_MODEL`; no applicable
+  policy -> `PRICING.MARGIN.NO_POLICY`. Neither silently prices at zero — this is the no-empty-
+  fallback rule applied to pricing. `ProviderPricingService.Compute` returns `0m` for unknown pairs;
+  we deliberately gate on `IsKnown` first so a misconfigured model is loud, not free.
+- **BYOK token markup is exactly zero, but cost basis is still computed.** Analytics/reporting want
+  the would-be cost even for BYOK; only the chargeable token component is zeroed. Plan/seat fees are
+  Billing's (Epic 35) concern, not this engine's.
+- **6dp internal / 2dp invoice rounding with `MidpointRounding.ToEven`.** Banker's rounding at each
+  accumulation boundary keeps the golden file stable and avoids per-call drift.
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| `ProviderPricingService` silent-zero for unknown pairs leaks into pricing | High | Gate on `IsKnown` first; throw `PRICING.UNKNOWN_MODEL`; covered by a unit test |
+| Floating-point / rounding drift across runs breaks reproducibility | Medium | `decimal` throughout, even-rounding at fixed boundaries, golden-file regression test |
+| Margin policy edited in place would re-price historical usage | High | Versioned supersede + `EffectiveFrom`-windowed resolution; timestamp-effective test |
+| Consumer epics (35, 36-7, 32-9) re-implement markup | Medium | This story is the canonical owner; expose `IUsagePricingEngine`; boundary note in epic |
+| Estimate leaks cross-tenant plan/mode | High | Resolve plan/mode strictly from `ITenantContext`; tenant-isolation test; admin routes 403 for tenants |
+
+## Logging Requirements
+
+- **INFO:** `PRICING.MARGIN.UPDATED` applied (scope, refKey, actorUserId); estimate served
+  (tenantId, provider, pricingMode).
+- **DEBUG:** policy resolved (scope hit, effectiveFrom); priced line (costBasisUsd, sellPriceUsd) —
+  amounts only, never secrets.
+- **WARN:** unknown `(provider, model)` -> `PRICING.UNKNOWN_MODEL` (provider, model); no applicable
+  policy -> `PRICING.MARGIN.NO_POLICY` (provider, planSlug).
+- **ERROR:** margin-policy persistence failure on `PUT`; estimate handler unexpected failure.
+- **Structured context:** include `{ provider, model, pricingMode, scope, refKey, tenantId }` where
+  applicable.
+- **Credential safety:** NEVER log provider API keys, secret cabinet refs, or BYOK key material —
+  this engine only sees token counts and USD amounts.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-34/story-34-6/34-6-entitlement-and-quota-resolution-service.md
+++ b/docs/stories/epic-34/story-34-6/34-6-entitlement-and-quota-resolution-service.md
@@ -1,0 +1,542 @@
+# Story 34-6: Entitlement & Quota Resolution Service
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide covers the 7-phase workflow (Read → Research → Break Down → TDD → Quality
+Gates → Failure Handling), the `.dev/` knowledge base, TRACE/DEBUG logging, test-first
+development, 100% coverage on critical paths, and build-success enforcement. Failure to follow it
+results in rework.
+
+## User Story
+
+As a **platform owner (and, in SaaS mode, a tenant member/admin)**,
+I want a single read API that turns a tenant's pinned plan assignment (34-4) into a concrete,
+resolved entitlement set — a `LimitValue`/`Period`/`OverageMode` per `EntitlementMetricKey`
+(agents, workflow runs, LLM tokens, seats, repos, RAG storage, benchmark retention) — with a
+cached snapshot and a non-enforcing headroom helper,
+so that the sibling Enforcement epic, Billing (Epic 35), and both dashboards all answer "what is
+this tenant allowed?" from one canonical calculation that never drifts, and a plan deprecation
+never silently re-prices or re-limits an existing tenant.
+
+## Priority
+
+P0 — This is the read contract the Enforcement epic and the dashboards consume. Without a single
+resolution seam, every consumer would re-derive limits from the catalog independently and they
+would drift. It is the bridge between the assignment layer (34-4) and everything that asks "is the
+tenant over their quota?".
+
+## Acceptance Criteria
+
+1. A new `IEntitlementService` (`apps/tamma-elsa/src/Tamma.Api/Services/Pricing/EntitlementService.cs`)
+   exposes `Task<ResolvedEntitlements> ResolveAsync(EntitlementPrincipal principal, CancellationToken ct)`
+   that returns a `ResolvedEntitlements` map: **every** `EntitlementMetricKey` member (34-1) →
+   `{ MetricKey, LimitValue (null = unlimited), Period, OverageMode }`, sourced from the
+   `PlanEntitlement` rows of the tenant's active `TenantPlanAssignment` (34-4) pinned
+   `(PlanId, PlanVersion)` snapshot resolved via 34-1's `IPlanCatalogService.GetByIdAsync`.
+
+2. The resolved map is **complete and closed**: for each of the 7 `EntitlementMetricKey` members,
+   if the pinned plan version has no `PlanEntitlement` row for that key, the service falls back to
+   a documented, code-owned default (`LimitValue = 0`, `Period = monthly`, `OverageMode = block`)
+   so consumers can index any metric without a null-check. The set of keys is exactly the closed
+   enum — never a subset.
+
+3. Per-mode principal resolution mirrors `ITammaModeProvider` + the PromptStore/Convention
+   resolution order: in **SaaS** mode resolution keys by `tenant_id`; in **single-user** mode it
+   keys by the sole user via `user_id` → that user's personal tenant. `EntitlementPrincipal` is a
+   small discriminated record (`ForTenant(Guid tenantId)` / `ForUser(Guid userId)`). Resolution
+   **never** falls back to an empty/plain entitlement set — a principal with no active assignment
+   throws `TammaError("ENTITLEMENT.RESOLVE.NO_ASSIGNMENT", ...)` (severity High); the only fallback
+   tier is the per-metric documented default of AC2 within a *present* assignment.
+
+4. `GET /api/pricing/entitlements`
+   (`apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs`) returns the resolved set for the
+   **current** principal (any authenticated tenant member; gated `MemberAccess`), resolving the
+   tenant from `ITenantContext` (SaaS) or the sole user (single-user). The body is a
+   `ResolvedEntitlementsDto` (`apps/tamma-elsa/src/Tamma.Api/Dtos/Pricing/EntitlementDtos.cs`).
+
+5. `GET /api/admin/tenants/{tenantId}/entitlements` (gated `PlatformOwnerAccess`) returns the
+   resolved set for an arbitrary tenant — the platform-owner read seam. An unknown tenant → 404; a
+   tenant with no active assignment → 404 (the `NO_ASSIGNMENT` error mapped, not a 500).
+
+6. Entitlement snapshots are **cached per principal** in an in-memory `IEntitlementSnapshotCache`
+   (keyed by the resolved `tenant_id`), with TTL fallback, and are **invalidated on**
+   `TENANT.PLAN.CHANGED` and `PLAN.CATALOG.UPDATED` DCB/platform events. Invalidation is wired by a
+   new `EntitlementCacheInvalidationListener` that subscribes to the existing `IPlatformEventBus`
+   (`Subscribe("TENANT.PLAN.")` + the catalog event prefix) — the same subscriber pattern as
+   `TenantStatusInvalidationListener` / `NotificationDispatcher`. A `TENANT.PLAN.CHANGED` event for
+   tenant T evicts exactly T's snapshot; a catalog-wide `PLAN.CATALOG.UPDATED` flushes the whole
+   cache.
+
+7. Custom enterprise plan entitlements resolve correctly and **override public-plan defaults**:
+   when the tenant's active assignment points at an `IsCustom == true` plan version (34-2), the
+   service reads that custom version's `PlanEntitlement` rows verbatim — including `LimitValue =
+   NULL` (unlimited) — and the resolved set reflects the bespoke limits, not the public free/team
+   defaults.
+
+8. A typed, non-enforcing helper `EntitlementHeadroom CheckHeadroom(ResolvedEntitlements resolved,
+   EntitlementMetricKey metric, long currentUsage)` returns
+   `{ MetricKey, LimitValue, CurrentUsage, Remaining (null = unlimited), IsOver, OveragePercent }`
+   **without blocking** — it is the single shared calc the Enforcement epic and both dashboards
+   consume so over/remaining math never diverges. Unlimited (`LimitValue == null`) ⇒ `Remaining =
+   null`, `IsOver = false`, regardless of usage.
+
+9. Effort/estimate metric special cases are documented and resolved through an `IEntitlementUsageReader`
+   seam so the resolver surfaces *current values* for the gauge-style metrics: `Seats` reads the
+   `TenantMembership` count (`ITenantMembershipRepository.ListByTenantAsync` total), `Agents` reads
+   the Epic-32 agent count (`AgentConfig` rows for the tenant), `Repos` reads the active
+   `GitHubInstallationRepo` count for the tenant's installation. This story ships the reader
+   interface + a control-plane-backed default implementation for these three count metrics;
+   metering-backed metrics (`LlmTokens`, `WorkflowRuns`) return "unavailable" until Epic 35 supplies
+   the metering reader (the headroom helper degrades to `CurrentUsage = null` for those).
+
+10. A DCB event `ENTITLEMENT.RESOLVED.SUCCESS` is emitted (sampled / on cache-miss, not on every
+    cache hit) via `IEventRepository.AppendAsync` for tenant-scope with tags `tenantId`, `planId`,
+    `planVersion`, `mode`, `source` (`cache-miss|admin-read`); the failure path emits
+    `ENTITLEMENT.RESOLVED.FAILED` with `reason` (`no_assignment|catalog_unavailable`). Event names
+    follow the `AGGREGATE.ACTION.STATUS` convention.
+
+11. Per-mode + per-tenant ownership is honored end-to-end. **single-user**: the sole user reads
+    their own entitlements (no RBAC beyond authentication); `GET /api/pricing/entitlements` resolves
+    the lone tenant. **SaaS**: any tenant member (`member`/`tenant_admin`/`tenant_owner`) may read
+    `GET /api/pricing/entitlements` for their own tenant (read is not a privileged operation —
+    mirrors the PromptStore "GET resolved = any member" RBAC); the admin route is
+    `PlatformOwnerAccess` only; a tenant member can never read another tenant's entitlements
+    (tenant is taken from `ITenantContext`, never a request body/param on the member route).
+
+12. The resolver is **read-only and non-mutating**: it never writes `PlanEntitlement`/`Plan`/
+    `TenantPlanAssignment` rows, never charges, and never blocks a workflow. It does not meter
+    consumption (Epic 35) and does not enforce limits (sibling Enforcement epic) — it only resolves
+    and computes headroom.
+
+13. Unit + integration tests cover: resolution per mode (SaaS by tenant_id, single-user by
+    user_id→tenant), the complete-7-keys invariant + per-metric default backfill, unlimited
+    (`NULL` limit) handling through resolve + headroom, cache hit/miss + invalidation on
+    `TENANT.PLAN.CHANGED` (evicts one) and `PLAN.CATALOG.UPDATED` (flush all), custom-plan override,
+    headroom math (under / at / over / unlimited), the gauge-metric usage reader (seats/agents/repos
+    counts), `NO_ASSIGNMENT` fail-loud (no empty fallback), RBAC matrix (member can read own,
+    cross-tenant 404, admin route platform-owner-only), and **tenant isolation** (tenant A's resolve
+    never returns tenant B's limits or counts).
+
+## Technical Design
+
+### Namespace & file structure
+
+```
+apps/tamma-elsa/src/
+  Tamma.Api/Services/Pricing/             # existing dir (34-1/34-4 land here)
+    IEntitlementService.cs                # NEW — ResolveAsync + CheckHeadroom contract
+    EntitlementService.cs                 # NEW — core resolution (catalog → resolved map)
+    EntitlementModels.cs                  # NEW — EntitlementPrincipal, ResolvedEntitlements,
+                                          #        ResolvedEntitlement, EntitlementHeadroom records
+    IEntitlementSnapshotCache.cs          # NEW — per-tenant snapshot cache abstraction
+    EntitlementSnapshotCache.cs           # NEW — IMemoryCache-backed, TTL + explicit eviction
+    IEntitlementUsageReader.cs            # NEW — gauge-metric current-value seam (seats/agents/repos)
+    ControlPlaneEntitlementUsageReader.cs # NEW — CP-backed default impl for the 3 count metrics
+    EntitlementCacheInvalidationListener.cs # NEW — BackgroundService subscribing IPlatformEventBus
+    EntitlementEventTypes.cs              # NEW — ENTITLEMENT.RESOLVED.SUCCESS / .FAILED constants
+  Tamma.Api/Dtos/Pricing/                 # NEW directory
+    EntitlementDtos.cs                    # NEW — ResolvedEntitlementsDto + ResolvedEntitlementDto +
+                                          #        EntitlementHeadroomDto
+  Tamma.Api/Endpoints/
+    PricingEndpoints.cs                   # MODIFY (file introduced by 34-2) — add GET
+                                          #   /api/pricing/entitlements
+    Admin/AdminTenantsEndpoints.cs        # MODIFY — add GET /api/admin/tenants/{id}/entitlements
+  Tamma.Api/Extensions/
+    PricingServiceCollectionExtensions.cs # MODIFY (created by 34-1) — register entitlement services
+  Tamma.Api/Program.cs                    # MODIFY — map the two read routes; register the listener
+```
+
+> **Boundary note (Epic 34 ↔ siblings):** this story owns *entitlement resolution + headroom* only.
+> The versioned catalog (`Plan`/`PlanEntitlement`/`EntitlementMetricKey`/`IPlanCatalogService`)
+> belongs to **34-1**; the active-assignment source of truth (`TenantPlanAssignment` /
+> `IPlanAssignmentService.GetActiveAsync`) belongs to **34-4**; the `PricingEndpoints.cs` file
+> belongs to **34-2** (this story adds one GET handler to it). Usage **metering** is **Epic 35** —
+> this story reads gauge counts behind `IEntitlementUsageReader` and degrades to "unavailable" for
+> metering-only metrics. **Enforcement** (blocking on a quota) is a sibling epic — this story
+> resolves and computes headroom but never blocks.
+
+### Core models (`EntitlementModels.cs`)
+
+```csharp
+namespace Tamma.Api.Services.Pricing;
+
+using Tamma.Core.Enums;   // EntitlementMetricKey (34-1)
+
+/// <summary>
+/// Who we're resolving for. SaaS → ForTenant; single-user → ForUser (the
+/// sole user, resolved to their personal tenant). Mirrors the (userId|tenantId)
+/// XOR principal of the prompt store.
+/// </summary>
+public readonly record struct EntitlementPrincipal
+{
+    public Guid? TenantId { get; private init; }
+    public Guid? UserId { get; private init; }
+    public static EntitlementPrincipal ForTenant(Guid tenantId) => new() { TenantId = tenantId };
+    public static EntitlementPrincipal ForUser(Guid userId) => new() { UserId = userId };
+}
+
+/// <summary>One resolved quota line. LimitValue null = unlimited.</summary>
+public sealed record ResolvedEntitlement(
+    EntitlementMetricKey MetricKey,
+    long? LimitValue,
+    string Period,        // monthly | total
+    string OverageMode);  // block | allow | meter
+
+/// <summary>
+/// Complete, closed map: every EntitlementMetricKey member is present.
+/// Carries the pinned plan coordinates so callers can audit the source.
+/// </summary>
+public sealed record ResolvedEntitlements(
+    Guid TenantId,
+    Guid PlanId,
+    int PlanVersion,
+    bool IsCustom,
+    IReadOnlyDictionary<EntitlementMetricKey, ResolvedEntitlement> Limits)
+{
+    public ResolvedEntitlement Get(EntitlementMetricKey key) => Limits[key]; // never throws — closed
+}
+
+/// <summary>Non-enforcing headroom calc. Remaining null = unlimited.</summary>
+public sealed record EntitlementHeadroom(
+    EntitlementMetricKey MetricKey,
+    long? LimitValue,
+    long? CurrentUsage,
+    long? Remaining,
+    bool IsOver,
+    double? OveragePercent);
+```
+
+### Service contract (`IEntitlementService.cs`)
+
+```csharp
+public interface IEntitlementService
+{
+    /// Resolve the complete entitlement set for a principal (cache-first).
+    /// Throws TammaError("ENTITLEMENT.RESOLVE.NO_ASSIGNMENT") if no active
+    /// TenantPlanAssignment exists — never returns an empty/plain set.
+    Task<ResolvedEntitlements> ResolveAsync(EntitlementPrincipal principal, CancellationToken ct = default);
+
+    /// Pure, non-enforcing headroom calc shared by enforcement + dashboards.
+    EntitlementHeadroom CheckHeadroom(
+        ResolvedEntitlements resolved, EntitlementMetricKey metric, long currentUsage);
+}
+```
+
+### Resolution algorithm (`EntitlementService.ResolveAsync`)
+
+1. **Resolve principal → tenantId.** SaaS: `principal.TenantId` (required; from `ITenantContext`
+   at the endpoint). single-user: `principal.UserId` → the user's personal tenant via the existing
+   personal-tenant lookup (the `EnsurePersonalTenantMiddleware` invariant guarantees one). Mode read
+   from `ITammaModeProvider`.
+2. **Cache-first.** `IEntitlementSnapshotCache.TryGet(tenantId)` → return on hit.
+3. **Active assignment.** `IPlanAssignmentService.GetActiveAsync(tenantId)` (34-4). `null` →
+   emit `ENTITLEMENT.RESOLVED.FAILED{reason=no_assignment}`, throw
+   `TammaError("ENTITLEMENT.RESOLVE.NO_ASSIGNMENT", ..., severity: High)` — **no empty fallback**
+   (mirrors prompt/convention fail-loud, `feedback_resolution_no_empty_fallback`).
+4. **Pinned snapshot.** `IPlanCatalogService.GetByIdAsync(assignment.PlanId)` (34-1) — the pinned
+   `(PlanId, PlanVersion)` row, immutable, so a later deprecation cannot retro-mutate. `null` →
+   `ENTITLEMENT.RESOLVED.FAILED{reason=catalog_unavailable}`, throw
+   `TammaError("ENTITLEMENT.RESOLVE.CATALOG_UNAVAILABLE", ...)`.
+5. **Build the closed map.** For each of the 7 `EntitlementMetricKey` members, take the matching
+   `PlanSnapshot.Entitlements` row; if absent, backfill the documented default
+   (`LimitValue=0, Period=monthly, OverageMode=block`). This guarantees AC2's complete map.
+6. **Cache + event.** `cache.Set(tenantId, resolved)`; emit
+   `ENTITLEMENT.RESOLVED.SUCCESS{source=cache-miss}` (cache-miss only — not on every hit).
+7. **Return.**
+
+`CheckHeadroom` is pure: `Remaining = LimitValue is null ? null : Math.Max(0, LimitValue - usage)`,
+`IsOver = LimitValue is not null && usage > LimitValue`, `OveragePercent = LimitValue is > 0 ?
+(double)usage / LimitValue * 100 : null`. Unlimited short-circuits to `Remaining=null, IsOver=false`.
+
+### Gauge-metric usage reader (`IEntitlementUsageReader.cs`)
+
+```csharp
+/// Current value for gauge-style metrics, so headroom on the read API
+/// reflects live counts without the caller wiring three repositories.
+public interface IEntitlementUsageReader
+{
+    /// Returns null for metrics this reader can't answer (e.g. metering-only
+    /// LlmTokens/WorkflowRuns until Epic 35 supplies its reader).
+    Task<long?> GetCurrentAsync(Guid tenantId, EntitlementMetricKey metric, CancellationToken ct = default);
+}
+```
+
+`ControlPlaneEntitlementUsageReader` answers the three CP-resident counts and returns `null` for
+the rest:
+
+| Metric | Source | Notes |
+|---|---|---|
+| `Seats` | `ITenantMembershipRepository.ListByTenantAsync(tenantId, 1, 0)` → `Total` | membership count |
+| `Agents` | `AgentConfig` rows where `TenantId == tenantId` (Epic 32) | tenant agent count |
+| `Repos` | `GitHubInstallationRepo` where `IsActive` for the tenant's installation | active connected repos |
+| `LlmTokens`, `WorkflowRuns`, `RagStorageMb`, `BenchmarkRetentionDays` | `null` | metering-backed → Epic 35 reader |
+
+### Cache + invalidation
+
+`EntitlementSnapshotCache` wraps `IMemoryCache` (precedent: `DiagnosticsService`,
+`InMemoryBudgetConfigProvider`) keyed `"entitlements:{tenantId}"` with a default 5-minute TTL
+(belt-and-suspenders behind event invalidation) and `Invalidate(tenantId)` / `Flush()`.
+
+`EntitlementCacheInvalidationListener : BackgroundService` subscribes the in-process
+`IPlatformEventBus` (the same bus `TenantStatusInvalidationListener` and `NotificationDispatcher`
+use):
+
+- `Subscribe("TENANT.PLAN.")` — on `TENANT.PLAN.CHANGED` (34-4) read the `tenantId` tag and
+  `cache.Invalidate(tenantId)`.
+- `Subscribe("PLAN.CATALOG.UPDATED")` (or the 34-2 catalog-update event prefix) — `cache.Flush()`
+  (a catalog edit may touch any tenant's pinned version only if re-assigned, but a flush is the safe
+  cheap option). Handlers are best-effort and never throw back into the bus (matches the bus's
+  per-handler catch contract).
+
+> **Event-topology note (Story 28-1):** `ENTITLEMENT.RESOLVED.*` events append to the CP
+> `DomainEvents`/`PlatformEvents` store today; when events move per-tenant the invalidation listener
+> still works because it subscribes the in-process `IPlatformEventBus`, not a DB poller.
+
+### DCB event names (`AGGREGATE.ACTION.STATUS`)
+
+| Event | When | Tags |
+|---|---|---|
+| `ENTITLEMENT.RESOLVED.SUCCESS` | cache-miss resolve / admin read | `tenantId`, `planId`, `planVersion`, `mode`, `source` (`cache-miss\|admin-read`) |
+| `ENTITLEMENT.RESOLVED.FAILED` | no active assignment / catalog gone | `tenantId`, `mode`, `reason` (`no_assignment\|catalog_unavailable`) |
+
+Consumed events (not emitted here): `TENANT.PLAN.CHANGED` (34-4), `PLAN.CATALOG.UPDATED` (34-2) for
+cache invalidation.
+
+### API shape
+
+```
+# Tenant self-read — MemberAccess (any authenticated tenant member)
+GET /api/pricing/entitlements
+  → 200 {
+      tenantId, planId, planVersion, isCustom,
+      limits: [ { metricKey, limitValue|null, period, overageMode,
+                  currentUsage|null, remaining|null, isOver, overagePercent|null } ]
+    }
+  → 404 no_active_assignment            # NO_ASSIGNMENT mapped
+
+# Platform-owner read of any tenant — PlatformOwnerAccess
+GET /api/admin/tenants/{tenantId}/entitlements
+  → 200 (same body shape, tenant from route)
+  → 404 unknown_tenant | no_active_assignment
+```
+
+The DTO embeds the headroom fields inline (per-metric `currentUsage/remaining/isOver`) so dashboards
+get resolution + live headroom in one call. The endpoint composes `ResolveAsync` +
+`IEntitlementUsageReader.GetCurrentAsync` per metric + `CheckHeadroom`.
+
+### Per-mode + per-tenant handling
+
+| Concern | single-user mode | SaaS mode |
+|---|---|---|
+| Principal | the sole user → personal tenant (`EntitlementPrincipal.ForUser`) | the caller's tenant (`EntitlementPrincipal.ForTenant`, from `ITenantContext`) |
+| Who may read `/api/pricing/entitlements` | the sole user (authenticated) | any tenant member (`MemberAccess`) — read is unprivileged, mirrors PromptStore "GET resolved = any member" |
+| Who may read `/api/admin/tenants/{id}/entitlements` | the sole user (no RBAC gate, same code path) | platform owner (`PlatformOwnerAccess`) only |
+| Cross-tenant guard | n/a (one tenant) | member route ignores any body/param tenant; tenant from `ITenantContext` |
+| Cache key | personal tenant id | caller tenant id |
+| Mode source | `ITammaModeProvider.Mode` | same |
+
+### Integration points
+
+- **34-4 `IPlanAssignmentService.GetActiveAsync(tenantId)`** — the pinned `(PlanId, PlanVersion)`
+  source of truth.
+- **34-1 `IPlanCatalogService.GetByIdAsync(planId)`** → `PlanSnapshot.Entitlements` +
+  `EntitlementMetricKey` enum (reused verbatim) + `IsCustom` flag (custom-plan override, AC7).
+- **`ITammaModeProvider`** (`TammaMode.cs`) — per-mode principal resolution.
+- **`ITenantContext`** — caller tenant on the member route.
+- **`ITenantMembershipRepository`**, **`AgentConfig`** (via `ControlPlaneDbContext`),
+  **`GitHubInstallationRepo`** — gauge-metric counts.
+- **`IPlatformEventBus`** — cache invalidation subscription (precedent
+  `TenantStatusInvalidationListener`).
+- **`IEventRepository` / `IPlatformEventPublisher`** — `ENTITLEMENT.RESOLVED.*` emission.
+- **`PricingServiceCollectionExtensions.AddPlanCatalog`/`AddPricing`** — extend with
+  `AddEntitlementResolution(services)` registering the service, cache, usage reader, and listener.
+
+## Dependencies
+
+**Internal — prerequisite:**
+- Story 34-1 (Plan & Price-Book Catalog) — `EntitlementMetricKey` enum, `PlanEntitlement`,
+  `IPlanCatalogService`/`PlanSnapshot`, `PricingServiceCollectionExtensions`.
+- Story 34-4 (Per-Tenant Plan Assignment) — `TenantPlanAssignment`,
+  `IPlanAssignmentService.GetActiveAsync`, the pinned `(PlanId, PlanVersion)` contract, and the
+  `TENANT.PLAN.CHANGED` event the cache invalidates on.
+- Epic 28 (control-plane tenancy) — `ControlPlaneDbContext`, `ITenantContext`,
+  `EnsurePersonalTenantMiddleware` (single-user personal-tenant invariant), `IPlatformEventBus`.
+- Epic 4 (DCB events) — `IEventRepository` / `IPlatformEventPublisher`.
+- Epic 32 (agents) — `AgentConfig` for the `Agents` gauge count.
+
+**Internal — blocks:**
+- Epic 34 Enforcement story — consumes `IEntitlementService.ResolveAsync` + `CheckHeadroom` to gate.
+- Both dashboards (`packages/dashboard`, `packages/dashboard-user`) — render limits + headroom.
+- Epic 35 (Billing) — consumes resolved entitlements for overage attribution and supplies the
+  metering-backed `IEntitlementUsageReader` for `LlmTokens`/`WorkflowRuns`.
+
+**External:**
+- None in this story. No Stripe — entitlements are read from the catalog, not charged. The
+  `IEntitlementUsageReader` seam keeps metering (Epic 35) out of the resolve path; tests mock it.
+
+## Testing Strategy
+
+**Unit (xUnit, `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/`), test-first:**
+
+1. `EntitlementServiceTests.Resolve_SaaS_ByTenantId` — SaaS principal resolves the tenant's pinned
+   assignment → snapshot → complete 7-key map; mock `IPlanAssignmentService` + `IPlanCatalogService`.
+2. `Resolve_SingleUser_ByUserId` — single-user principal resolves the sole user's personal tenant
+   (`ITammaModeProvider.Mode = SingleUser`); same closed map.
+3. `Resolve_CompleteSevenKeys_AndDefaultBackfill` — a plan version with only 3 entitlement rows
+   still returns all 7 keys; the 4 missing keys carry the documented default
+   (`limit=0, monthly, block`).
+4. `Resolve_Unlimited_NullLimit` — a `LimitValue = NULL` entitlement resolves to unlimited and flows
+   through `CheckHeadroom` (`Remaining=null, IsOver=false` even with huge usage).
+5. `Resolve_NoAssignment_FailsLoud` — no active assignment throws
+   `ENTITLEMENT.RESOLVE.NO_ASSIGNMENT` (severity High) and emits `ENTITLEMENT.RESOLVED.FAILED`; the
+   service NEVER returns an empty set (pins `feedback_resolution_no_empty_fallback`).
+6. `Resolve_CustomPlan_Overrides` — an `IsCustom = true` plan version's bespoke (incl. unlimited)
+   entitlements override the public free/team defaults.
+7. `CheckHeadroomTests` — under / at-limit / over / unlimited matrix; `OveragePercent` math; zero
+   limit edge.
+8. `Cache_HitMiss` — second `ResolveAsync` for the same tenant is a cache hit (no second
+   `GetActiveAsync`/`GetByIdAsync` call); only the miss emits `ENTITLEMENT.RESOLVED.SUCCESS`.
+9. `CacheInvalidationListenerTests` — a `TENANT.PLAN.CHANGED` event for tenant T evicts T's
+   snapshot (next resolve re-hits the catalog); a `PLAN.CATALOG.UPDATED` event flushes all entries;
+   a malformed/handler-thrown event is swallowed (listener never breaks the bus).
+10. `ControlPlaneEntitlementUsageReaderTests` — `Seats` returns membership count, `Agents` returns
+    tenant `AgentConfig` count, `Repos` returns active `GitHubInstallationRepo` count;
+    `LlmTokens`/`WorkflowRuns` return `null`.
+
+**Integration (xUnit + Postgres via `sg docker -c "dotnet test ..."`):**
+
+11. `EntitlementEndpointsTests.MemberRead_OwnTenant` — `GET /api/pricing/entitlements` with a
+    `member` JWT returns the caller's resolved set (read is unprivileged); the body includes live
+    seat/agent/repo counts.
+12. `AdminRead_PlatformOwnerOnly` — `GET /api/admin/tenants/{id}/entitlements`: platform-owner JWT
+    → 200; non-platform JWT → 403; unknown tenant → 404; tenant with no assignment → 404.
+13. **Tenant-isolation test** — two tenants on different plan versions (one custom, one public) each
+    resolve their own frozen entitlement set + their own gauge counts; tenant A's member can never
+    read tenant B's entitlements (the member route uses `ITenantContext`, ignores any param); a
+    `TENANT.PLAN.CHANGED` for A never evicts B's cached snapshot.
+14. Version-pinning end-to-end — assign v1, deprecate (catalog creates v2), resolve again → still
+    v1's entitlements (the pinned snapshot, never latest).
+
+**Mocks:** `IPlanAssignmentService` (34-4) and `IPlanCatalogService` (34-1) faked for unit tests;
+`IEntitlementUsageReader` mocked for the resolve/headroom tests and exercised for real in the CP
+reader tests; `IEventRepository`/`IPlatformEventPublisher` faked to capture emitted events;
+`IMemoryCache` real (in-memory) for cache tests; `TimeProvider` injected where TTL is asserted. **No
+Stripe/provider mocks** — this story makes no external billing/provider calls.
+
+## Estimated Effort
+
+4 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IEntitlementService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/EntitlementService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/EntitlementModels.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IEntitlementSnapshotCache.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/EntitlementSnapshotCache.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IEntitlementUsageReader.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/ControlPlaneEntitlementUsageReader.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/EntitlementCacheInvalidationListener.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/EntitlementEventTypes.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Dtos/Pricing/EntitlementDtos.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs` | Modify (add GET /api/pricing/entitlements; file from 34-2) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminTenantsEndpoints.cs` | Modify (add GET /api/admin/tenants/{id}/entitlements) |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/PricingServiceCollectionExtensions.cs` | Modify (AddEntitlementResolution) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map 2 routes; register invalidation listener; DI) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/EntitlementServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/CheckHeadroomTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/EntitlementSnapshotCacheTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/EntitlementCacheInvalidationListenerTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/ControlPlaneEntitlementUsageReaderTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/EntitlementEndpointsTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md).
+2. Searched `.dev/` for related spikes/bugs/findings/decisions (pricing, caching, resolution
+   fail-loud).
+3. Reviewed **34-1** and **34-4** stories — this story is strictly downstream of their catalog +
+   assignment contracts; do NOT re-implement the catalog, the assignment, or the metric enum here.
+4. Reviewed the cache-invalidation precedent (`TenantStatusInvalidationListener`,
+   `NotificationDispatcher`) and the per-mode resolution precedent (`PromptStoreService`,
+   `TammaMode.cs`).
+5. Confirmed the C# test runner contract: `sg docker -c "dotnet test ..."` for docker-bound suites
+   (build needs no wrapper) — see `reference_dotnet_test_docker`.
+6. Planned a TDD (Red-Green-Refactor) approach — a failing test per AC before implementation.
+
+### Key Design Decisions
+
+- **One resolution seam, one headroom calc.** The whole point is that Enforcement and both
+  dashboards never re-derive limits or over/remaining math independently. `CheckHeadroom` is pure
+  and shared so a typo can't make the dashboard and the enforcer disagree about who's over quota.
+- **Closed, complete map (never a subset).** Consumers index any `EntitlementMetricKey` without a
+  null check. Missing catalog rows backfill a documented default (`limit 0, block`) — a missing
+  entitlement is the *safest* (most restrictive) default, but resolution itself still fails loud if
+  the *assignment* is absent.
+- **Fail loud on no assignment, never on a missing metric row.** Mirrors the prompt/convention
+  contract (`feedback_resolution_no_empty_fallback`): `tenant → catalog → error`, never an empty or
+  "plain" entitlement set. A tenant with no active plan is a real bug Billing/Enforcement must see.
+- **Pin via 34-4, snapshot via 34-1.** Resolve the *pinned* `(PlanId, PlanVersion)`, not "the
+  latest" — a plan deprecation must never silently re-limit an existing tenant. The catalog snapshot
+  is immutable for deprecated versions, so the pinned read is reproducible forever.
+- **Event-driven cache, not DB poll.** Subscribe the in-process `IPlatformEventBus` rather than
+  polling — invalidation is instant on `TENANT.PLAN.CHANGED` and survives the Story-28-1 event
+  topology shift (the bus is in-process, the poller would not be).
+- **Gauge counts behind a seam.** Seats/agents/repos are CP-resident counts answerable now;
+  tokens/runs are metering-only and stay `null` until Epic 35. The headroom helper degrades
+  gracefully (`CurrentUsage = null`) rather than blocking the read API on Epic 35.
+
+### Boundary Notes (what this story does NOT do)
+
+- No usage metering writes (Epic 35) — it only *reads* gauge counts behind `IEntitlementUsageReader`
+  and returns `null` for metering-only metrics.
+- No quota **enforcement** / blocking (sibling Enforcement epic) — it resolves + computes headroom;
+  it never blocks a workflow.
+- No Stripe / billing / charging (Epic 35).
+- No catalog or assignment mutation (34-1 / 34-2 / 34-4) — strictly read-only.
+- No dashboard UI (that consumes this API in a later story / the dashboards).
+
+### Edge Cases
+
+- Single-user mode where the personal tenant has the back-filled `plan_free` assignment (34-4
+  migration) → resolves the free entitlements; never `NO_ASSIGNMENT` for a normally-provisioned
+  instance.
+- A `PLAN.CATALOG.UPDATED` flush during a burst of resolves → next resolve is a cache miss and
+  re-reads the (still pinned) snapshot; correctness is unaffected, only one extra catalog read.
+- Cache TTL expiry independent of events → a stale-but-pinned snapshot can never be *wrong* (pinned
+  versions are immutable), so the TTL is purely a memory bound, not a correctness mechanism.
+- An `IEntitlementUsageReader` throwing for one metric → headroom for that metric degrades to
+  `CurrentUsage = null` (logged WARN); the rest of the set still resolves.
+
+## Logging Requirements
+
+- **INFO**: entitlements resolved on cache miss (`tenantId`, `planId`, `planVersion`, `mode`),
+  admin entitlement read (`tenantId`, actor), cache flushed/invalidated (`tenantId` or `all`).
+- **DEBUG**: cache hit (`tenantId`), per-metric default backfill (`metricKey`), usage-reader lookup
+  result (`metricKey`, value), invalidation event received (`eventType`, `tenantId`).
+- **WARN**: usage reader threw for a metric (degraded to null), resolve for a tenant whose snapshot
+  had fewer than 7 entitlement rows (backfilled), invalidation handler swallowed an exception.
+- **ERROR**: `ENTITLEMENT.RESOLVE.NO_ASSIGNMENT` before the throw, catalog unavailable for a pinned
+  `planId` (should be impossible — log the unexpected gap), event-emission failure.
+- **Structured context**: include `{ tenantId, planId, planVersion, metricKey, mode, source }`
+  where applicable.
+- **Credential safety**: entitlement data is not secret, but never log connection strings or tenant
+  secrets if a resolution path ever touches a tenant row.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-34/story-34-7/34-7-trials-credits-and-promo-codes.md
+++ b/docs/stories/epic-34/story-34-7/34-7-trials-credits-and-promo-codes.md
@@ -1,0 +1,626 @@
+# Story 34-7: Trials, Credits & Promo Codes
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-phase workflow (Read → Research → Break Down → TDD →
+Quality Gates → Failure Handling), the `.dev/` knowledge-base usage rules, TRACE/DEBUG logging
+requirements, the test-first (TDD) mandate, 100% critical-path coverage, and build-success
+enforcement. Failure to follow it results in rework.
+
+## User Story
+
+As a **platform owner (and, in SaaS mode, a tenant owner/admin)**,
+I want time-boxed trials, prepaid/granted USD credits, and promo codes to be first-class,
+audited primitives that lower the net price a tenant pays,
+so that we can run acquisition and retention offers (free trial windows, "$50 free credit",
+"20% off your first invoice") without hand-editing invoices, and so Billing (Epic 35) always sees
+a clean credit-aware *net* price that is reproducible from the audit trail.
+
+## Priority
+
+P1 — acquisition/retention pricing primitives. Plan assignment (34-4) and the cost→price markup
+engine (34-5) establish *list price*; this story layers the discount/credit primitives that turn
+list price into the *net* price Billing charges. Not on the P0 critical path, but required before
+Epic 35 can issue a real first invoice with a trial window or applied credit.
+
+## Acceptance Criteria
+
+1. Three new control-plane entities exist under `Tamma.Data.Entities`, registered as `DbSet`s on
+   `ControlPlaneDbContext` and configured in `TammaModelConfiguration.cs` with an additive EF
+   migration under `Tamma.Data/Migrations/ControlPlane/`:
+   - `TenantTrial` — `Id` (UUIDv7), `TenantId` (FK → `tenants.Id`), `PlanId` (FK → `plans.Id`),
+     `PlanVersion` (int, pinned copy mirroring 34-4's `TenantPlanAssignment.PlanVersion`),
+     `StartsAt` (UTC), `EndsAt` (UTC), `Status` (`active`|`converted`|`expired`),
+     `CreatedAt`, `UpdatedAt`.
+   - `CreditLedger` — `Id` (UUIDv7), `TenantId` (FK → `tenants.Id`), `DeltaUsd` (decimal(18,6),
+     signed), `Reason` (`grant`|`promo`|`consume`|`refund`), `BalanceAfter` (decimal(18,6)),
+     `RefEventId` (Guid?, the `DomainEvent.Id` that recorded the mutation), `Note` (text, nullable),
+     `CreatedByUserId` (Guid?, the actor; null = system), `CreatedAt`.
+   - `PromoCode` — `Id` (UUIDv7), `Code` (text, **case-insensitive unique** via a normalized
+     lowercase column/index), `DiscountKind` (`percent`|`fixed`), `Value` (decimal(18,6)),
+     `MaxRedemptions` (int?, null = unlimited), `RedemptionCount` (int, default 0), `Expiry`
+     (UTC, nullable), `AppliesTo` (text[] of plan slugs, empty/null = all plans), `IsActive`
+     (bool), `CreatedAt`, `UpdatedAt`. A companion `PromoRedemption` entity records each redeem
+     (`Id`, `PromoCodeId` FK, `TenantId` FK, `RedeemedByUserId`, `PlanSlug`, `RefEventId`,
+     `CreatedAt`) with a partial unique index `(PromoCodeId, TenantId)` so a tenant can redeem a
+     given code at most once.
+
+2. The credit ledger is **append-only and double-entry-safe**: `CreditLedger` rows are never
+   updated or deleted; `BalanceAfter` is the running sum of `DeltaUsd` for the tenant. A `consume`
+   entry may **never drive `BalanceAfter` below zero** — `CreditService.ConsumeAsync` reads the
+   current balance under a row-level lock (or serializable transaction), applies
+   `min(requestedConsume, currentBalance)`, and returns the *unfunded remainder* so the caller
+   (the net-price path) can flow it to Billing as a real charge. A consume of more than the
+   balance is partially applied (balance → 0), never rejected as a hard error; an *explicit*
+   overdraft attempt with `allowPartial = false` is rejected with
+   `TammaError("CREDIT.CONSUME.OVERDRAFT", …)`.
+
+3. `POST /api/pricing/promo/redeem` (gated by `SettingsManage`; tenant resolved from
+   `ITenantContext`) validates the submitted code and is rejected with `422` + a structured
+   `reason` when the code is: not found, `IsActive == false`, past `Expiry`, at/over
+   `MaxRedemptions`, already redeemed by this tenant, or not applicable to the chosen plan
+   (`AppliesTo` does not contain the plan slug). A `member`-role caller is rejected `403`
+   (via the `RequireTenantAdmin` membership pattern used by `AlertEndpoints`). A valid redeem
+   inserts a `PromoRedemption`, increments `RedemptionCount` atomically (guarded so concurrent
+   redeems cannot exceed `MaxRedemptions`), and — for a `fixed`-USD code — grants a matching
+   `CreditLedger` `Reason = promo` entry; a `percent` code is recorded for application at the
+   tenant's next invoice (no immediate credit).
+
+4. Trial assignment: subscribing to a **trial-eligible** plan (a plan whose `Quotas`/catalog flag
+   marks it trial-eligible) via `CreditService.StartTrialAsync` creates a `TenantTrial` row
+   (`Status = active`, `EndsAt = StartsAt + trialDays`) **and** delegates the plan assignment to
+   34-4's `IPlanAssignmentService.AssignAsync` with an `AssignPlanOptions` carrying a trial marker
+   (a `Reason`/flag the assignment records). At most one `active` trial per tenant is enforced by a
+   partial unique index `(TenantId) WHERE Status = 'active'`.
+
+5. Trial expiry is driven by a boundary task that mirrors 34-4's scheduled-activation pattern
+   (`PlatformTaskQueueProcessor` + a `TrialExpiryTaskPayload`): when `EndsAt` is reached the trial
+   either **converts** (`Status → converted`, plan assignment stays, recurring billing starts) or
+   **downgrades to free** (`Status → expired`, calls `IPlanAssignmentService.CancelAsync` /
+   assign `plan_free`). A `TENANT.TRIAL.ENDED` DCB event is emitted in both cases carrying
+   `tenantId`, `planId`, `planVersion`, `outcome` (`converted`|`downgraded`), `mode`, and the
+   trial window.
+
+6. The net-price seam: a new `ICreditAwarePricingEngine` (or a thin decorator
+   `CreditAwareUsagePricingEngine` wrapping 34-5's `IUsagePricingEngine`) returns a net result
+   `{ sellPriceUsd, creditsAppliedUsd, promoDiscountUsd, netPriceUsd, trialWaived }` where
+   `netPriceUsd = max(0, sellPriceUsd − promoDiscountUsd − creditsAppliedUsd)`. During an `active`
+   trial window the **recurring/plan charge component is zeroed** (`trialWaived = true`); usage
+   credit application still runs for any non-waived component. **This story does NOT re-implement
+   the markup math** (34-5 owns `sellPriceUsd`) and **does NOT move money** (Epic 35 owns
+   invoicing) — it only computes the credit-aware net the producer/Billing consumes.
+
+7. Admin credit grant: `POST /api/admin/tenants/{id}/credits` (gated by `PlatformOwnerAccess`,
+   mounted via `AdminPricingEndpoints`) with body `{ amountUsd, reason?, note? }` appends a
+   `CreditLedger` `Reason = grant` entry (positive `DeltaUsd`), recomputing `BalanceAfter`, and
+   `GET /api/admin/tenants/{id}/credits` returns the tenant's current balance + recent ledger.
+   A negative `amountUsd` (clawback) is supported as `Reason = refund`/`consume` per the body and
+   is still floor-clamped at zero balance.
+
+8. All ledger and promo mutations emit DCB events (`AGGREGATE.ACTION.STATUS`) appended via
+   `IEventRepository.AppendAsync` and mirrored to the platform audit timeline via
+   `IPlatformEventPublisher.AppendAndPublishAsync`: `CREDIT.GRANTED` (admin/promo grant),
+   `CREDIT.CONSUMED` (consume, with applied + remainder), `CREDIT.REFUNDED` (clawback/refund),
+   `PROMO.REDEEMED` (redeem), and `TENANT.TRIAL.STARTED` / `TENANT.TRIAL.ENDED`. Each carries
+   `tenantId`, `mode`, `actorUserId`, and the relevant amounts; the `RefEventId` on the inserted
+   `CreditLedger`/`PromoRedemption` row points back at the appended `DomainEvent.Id`.
+
+9. Per-mode + per-tenant ownership is honored: in **single-user** mode the sole user owns trials
+   and credits (no RBAC beyond authentication; `CreatedByUserId`/`AssignedByUserId` = the user);
+   in **SaaS** mode platform owners grant credits and create promo codes via the admin routes,
+   `tenant_owner` redeems promo codes and starts trials via `/api/pricing/*` (`SettingsManage`),
+   and `member` is read-only (403 on redeem/subscribe-trial). Mode is read from
+   `ITammaModeProvider`. Tenant-scope reads never leak another tenant's ledger or trial.
+
+10. Admin promo-code CRUD: `GET/POST/PATCH /api/admin/pricing/promo-codes` (PlatformOwnerAccess)
+    lets a platform owner list, create, and deactivate promo codes; creation validates
+    `DiscountKind`/`Value` (percent ∈ (0,100], fixed > 0) and normalizes `Code` to its
+    case-insensitive key. Mutations emit `PROMO.CODE.CREATED` / `PROMO.CODE.UPDATED`.
+
+11. A tenant-facing `GET /api/pricing/credits` (`SettingsView`) returns the caller's tenant
+    current balance, recent ledger entries, and active trial (if any); the credit-aware estimate
+    surface extends 34-5's `GET /api/pricing/estimate` response with `creditsAppliedUsd` /
+    `netPriceUsd` / `trialWaived` so the upgrade/cost UI shows net price.
+
+12. Reproducibility / determinism: given the same usage line, the same `MarginPolicy` (34-5), the
+    same ledger balance, and the same applicable promo, `ICreditAwarePricingEngine` produces a
+    **byte-stable** net result (decimals rounded 6dp internal / 2dp invoice, matching 34-5) —
+    covered by a golden-file test. Concurrency: two simultaneous `ConsumeAsync` calls on the same
+    tenant never sum to more than the available balance (serialized via lock/serializable txn).
+
+13. Unit + integration tests cover: ledger never goes negative (single + concurrent consume);
+    promo validation matrix (not-found / inactive / expired / cap-reached / already-redeemed /
+    plan-not-applicable / valid); trial convert vs expire→free; credit-aware net price
+    (`netPrice = sell − promo − credits`, floored at 0); trial window zeroes the recurring charge;
+    redemption cap enforced under concurrency; RBAC (member 403 on redeem, cross-tenant 404);
+    tenant isolation (tenant A cannot redeem against / read tenant B's ledger); DCB event emission
+    for every mutation.
+
+## Technical Design
+
+### Namespace / File Structure
+
+```
+apps/tamma-elsa/src/
+  Tamma.Data/
+    Entities/
+      TenantTrial.cs                      # NEW — trial row (one active per tenant)
+      CreditLedger.cs                     # NEW — append-only USD ledger
+      PromoCode.cs                        # NEW — promo definition
+      PromoRedemption.cs                  # NEW — per-tenant redemption record
+    ControlPlaneDbContext.cs              # MODIFY — 4 new DbSets
+    TammaModelConfiguration.cs            # MODIFY — entity config, CHECKs, partial unique indexes, FKs
+    Migrations/ControlPlane/
+      <ts>_AddTrialsCreditsPromos.cs      # NEW — additive tables + indexes
+  Tamma.Core/
+    Enums/
+      TrialStatus.cs                      # NEW — active|converted|expired (string-backed constants)
+      CreditReason.cs                     # NEW — grant|promo|consume|refund
+      DiscountKind.cs                     # NEW — percent|fixed
+  Tamma.Api/
+    Services/Pricing/
+      ICreditService.cs                   # NEW — grant / consume / balance / trial
+      CreditService.cs                    # NEW — ledger logic (serialized consume, floor-at-zero)
+      IPromoCodeService.cs                # NEW — validate / redeem / CRUD
+      PromoCodeService.cs                 # NEW — redemption + cap-guard + plan-applicability
+      ICreditAwarePricingEngine.cs        # NEW — net-price seam over 34-5 IUsagePricingEngine
+      CreditAwareUsagePricingEngine.cs    # NEW — decorator: sell → net (credits/promo/trial)
+      TrialsCreditsModels.cs              # NEW — GrantCreditOptions, ConsumeResult, NetPriceResult,
+                                          #       PromoValidationResult, StartTrialOptions
+      TrialsCreditsEventTypes.cs          # NEW — CREDIT.* / PROMO.* / TENANT.TRIAL.* constants
+    Services/Provisioning/
+      TrialExpiryTaskPayload.cs           # NEW — platform-queue payload for trial-end boundary
+    Endpoints/
+      PricingEndpoints.cs                 # MODIFY (file from 34-2) — promo/redeem, credits, estimate ext
+      Admin/AdminPricingEndpoints.cs      # MODIFY (file from 34-5) — credits grant, promo-code CRUD
+    Extensions/
+      PricingServiceCollectionExtensions.cs # MODIFY (from 34-1/34-5) — register the new services
+    Program.cs                            # MODIFY — map new routes; DI; decorate IUsagePricingEngine
+```
+
+> **Boundary note (Epic 34 ↔ siblings):** this story owns *trials, credits, and promo codes only*.
+> The versioned `Plan` catalog and `IPlanCatalogService` belong to **34-1**; the
+> `PricingEndpoints.cs`/`AdminPricingEndpoints.cs` files and custom-plan binding belong to
+> **34-2**; **plan assignment lifecycle** (`IPlanAssignmentService`, `TenantPlanAssignment`,
+> the scheduled-activation queue pattern) belongs to **34-4** — this story *delegates* trial
+> assignment/conversion/downgrade to it and *reuses* its boundary-task pattern, never duplicating
+> assignment logic. The **cost→price markup engine** (`IUsagePricingEngine`, `sellPriceUsd`,
+> `MarginPolicy`) belongs to **34-5** — this story *wraps* it and consumes `sellPriceUsd`, never
+> re-implements markup. **Invoicing, proration, and actually charging money** belong to **Epic 35**;
+> **quota/usage enforcement** belongs to the Epic 34 enforcement story and Epic 20 metering — this
+> story only computes the credit-aware *net* and flags overdraft remainder; it does not move money.
+
+### Key Entities (sketch)
+
+```csharp
+namespace Tamma.Data.Entities;
+
+/// <summary>One time-boxed trial per tenant (at most one active). Pins PlanVersion like
+/// TenantPlanAssignment (34-4) so a later plan deprecation can't re-price the trial.</summary>
+public class TenantTrial
+{
+    public Guid Id { get; set; }                 // UUIDv7
+    public Guid TenantId { get; set; }           // FK tenants.Id
+    public Guid PlanId { get; set; }             // FK plans.Id
+    public int PlanVersion { get; set; }         // pinned
+    public DateTime StartsAt { get; set; }
+    public DateTime EndsAt { get; set; }
+    public string Status { get; set; } = "active"; // active|converted|expired
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}
+
+/// <summary>Append-only, double-entry-safe USD credit ledger. BalanceAfter is the running sum;
+/// a 'consume' row can never push BalanceAfter below zero.</summary>
+public class CreditLedger
+{
+    public Guid Id { get; set; }                 // UUIDv7
+    public Guid TenantId { get; set; }           // FK tenants.Id
+    public decimal DeltaUsd { get; set; }        // signed; + grant/refund, - consume
+    public string Reason { get; set; } = null!;  // grant|promo|consume|refund
+    public decimal BalanceAfter { get; set; }    // >= 0 (CHECK)
+    public Guid? RefEventId { get; set; }        // DomainEvent.Id that recorded this
+    public string? Note { get; set; }
+    public Guid? CreatedByUserId { get; set; }   // actor; null = system/scheduler
+    public DateTime CreatedAt { get; set; }
+}
+
+public class PromoCode
+{
+    public Guid Id { get; set; }
+    public string Code { get; set; } = null!;        // display form
+    public string CodeKey { get; set; } = null!;     // lower(code), unique
+    public string DiscountKind { get; set; } = null!; // percent|fixed
+    public decimal Value { get; set; }               // percent ∈ (0,100] | fixed > 0
+    public int? MaxRedemptions { get; set; }         // null = unlimited
+    public int RedemptionCount { get; set; }
+    public DateTime? Expiry { get; set; }
+    public string[]? AppliesTo { get; set; }         // plan slugs; null/empty = all
+    public bool IsActive { get; set; } = true;
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}
+
+public class PromoRedemption
+{
+    public Guid Id { get; set; }
+    public Guid PromoCodeId { get; set; }            // FK promo_codes.Id
+    public Guid TenantId { get; set; }               // FK tenants.Id
+    public Guid? RedeemedByUserId { get; set; }
+    public string PlanSlug { get; set; } = null!;
+    public Guid? RefEventId { get; set; }
+    public DateTime CreatedAt { get; set; }
+}
+```
+
+### EF Model Config (sketch, in `TammaModelConfiguration.cs`)
+
+```csharp
+modelBuilder.Entity<CreditLedger>(e =>
+{
+    e.ToTable("credit_ledger", t =>
+        t.HasCheckConstraint("ck_credit_balance_nonneg", "\"BalanceAfter\" >= 0"));
+    e.Property(x => x.Id).HasDefaultValueSql("gen_random_uuid()");
+    e.Property(x => x.DeltaUsd).HasColumnType("numeric(18,6)");
+    e.Property(x => x.BalanceAfter).HasColumnType("numeric(18,6)");
+    e.Property(x => x.Reason).HasMaxLength(16);
+    e.HasIndex(x => new { x.TenantId, x.CreatedAt });   // running-balance / ledger read
+    e.HasOne<Tenant>().WithMany().HasForeignKey(x => x.TenantId).OnDelete(DeleteBehavior.Cascade);
+});
+
+modelBuilder.Entity<TenantTrial>(e =>
+{
+    e.ToTable("tenant_trials", t =>
+        t.HasCheckConstraint("ck_trial_status", "\"Status\" IN ('active','converted','expired')"));
+    e.HasIndex(x => x.TenantId).IsUnique()
+        .HasFilter("\"Status\" = 'active'")
+        .HasDatabaseName("ux_trial_one_active_per_tenant");   // AC4
+    e.HasOne<Tenant>().WithMany().HasForeignKey(x => x.TenantId).OnDelete(DeleteBehavior.Cascade);
+});
+
+modelBuilder.Entity<PromoCode>(e =>
+{
+    e.ToTable("promo_codes", t =>
+        t.HasCheckConstraint("ck_promo_kind", "\"DiscountKind\" IN ('percent','fixed')"));
+    e.HasIndex(x => x.CodeKey).IsUnique();                   // case-insensitive uniqueness
+});
+
+modelBuilder.Entity<PromoRedemption>(e =>
+{
+    e.HasIndex(x => new { x.PromoCodeId, x.TenantId }).IsUnique(); // one redeem per tenant per code
+    e.HasOne<PromoCode>().WithMany().HasForeignKey(x => x.PromoCodeId).OnDelete(DeleteBehavior.Cascade);
+    e.HasOne<Tenant>().WithMany().HasForeignKey(x => x.TenantId).OnDelete(DeleteBehavior.Cascade);
+});
+```
+
+> `dotnet ef migrations add AddTrialsCreditsPromos` — additive tables only (no CHECK edits on
+> existing tables, so the Phase-0 collapsed-baseline rules do not apply). `has-pending-model-changes`
+> must report **none** afterwards; mirror entity config in `TammaModelConfiguration.cs` (the single
+> source), not in `OnModelCreating` of the context.
+
+### Service Interfaces (sketch)
+
+```csharp
+public interface ICreditService
+{
+    /// Append a positive grant (admin/promo). Returns the new balance + appended event id.
+    Task<CreditMutationResult> GrantAsync(Guid tenantId, decimal amountUsd, CreditReason reason,
+        GrantCreditOptions opts, CancellationToken ct);
+
+    /// Apply up to `amountUsd` of credit (serialized; floor at 0). Returns applied + remainder.
+    Task<ConsumeResult> ConsumeAsync(Guid tenantId, decimal amountUsd,
+        bool allowPartial, CancellationToken ct);
+
+    Task<decimal> GetBalanceAsync(Guid tenantId, CancellationToken ct);
+    Task<IReadOnlyList<CreditLedger>> GetLedgerAsync(Guid tenantId, int limit, CancellationToken ct);
+
+    /// Start a trial: create TenantTrial + delegate assignment to 34-4 IPlanAssignmentService.
+    Task<TenantTrial> StartTrialAsync(Guid tenantId, Guid planId, StartTrialOptions opts,
+        CancellationToken ct);
+
+    /// Boundary task target: convert or downgrade an ended trial (idempotent by trialId).
+    Task EndTrialAsync(Guid tenantId, Guid trialId, CancellationToken ct);
+}
+
+public interface IPromoCodeService
+{
+    Task<PromoValidationResult> ValidateAsync(string code, string planSlug, Guid tenantId,
+        CancellationToken ct);
+    Task<PromoRedemption> RedeemAsync(string code, string planSlug, Guid tenantId,
+        Guid? actorUserId, CancellationToken ct);  // throws TammaError(422-mapped) on invalid
+}
+
+public interface ICreditAwarePricingEngine
+{
+    /// sell (34-5) → net = max(0, sell - promoDiscount - creditsApplied); trial zeroes recurring.
+    Task<NetPriceResult> PriceNetAsync(UsageLine usageLine, Guid tenantId, CancellationToken ct);
+}
+
+public sealed record ConsumeResult(decimal AppliedUsd, decimal RemainderUsd, decimal BalanceAfter);
+public sealed record NetPriceResult(decimal SellPriceUsd, decimal PromoDiscountUsd,
+    decimal CreditsAppliedUsd, decimal NetPriceUsd, bool TrialWaived);
+public sealed record PromoValidationResult(bool Ok, string? Reason, PromoCode? Code);
+```
+
+### Concurrency-safe consume (the load-bearing invariant)
+
+`ConsumeAsync` runs inside a `Serializable` (or `SELECT … FOR UPDATE` row-lock on the latest
+ledger row's tenant scope) transaction:
+
+```
+BEGIN ISOLATION LEVEL SERIALIZABLE;
+  balance := COALESCE((SELECT "BalanceAfter" FROM credit_ledger
+                       WHERE "TenantId" = @t ORDER BY "CreatedAt" DESC, "Id" DESC LIMIT 1), 0);
+  applied := LEAST(@amount, balance);                 -- never more than balance
+  IF applied = 0 AND NOT @allowPartial AND @amount > 0 -> throw CREDIT.CONSUME.OVERDRAFT
+  INSERT credit_ledger(... DeltaUsd = -applied, BalanceAfter = balance - applied, Reason='consume');
+COMMIT;  -- a concurrent consume retries on serialization failure (40001) → re-reads balance
+return ConsumeResult(applied, @amount - applied, balance - applied);
+```
+
+The `ck_credit_balance_nonneg` CHECK is the belt-and-suspenders backstop: even a logic bug cannot
+persist a negative balance.
+
+### DCB Event Names (`AGGREGATE.ACTION.STATUS`)
+
+- `CREDIT.GRANTED` — admin grant / fixed-promo grant. Tags: `tenantId`, `mode`, `actorUserId`,
+  `reason`; data: `amountUsd`, `balanceAfter`.
+- `CREDIT.CONSUMED` — consume on the net-price path. Tags: `tenantId`, `mode`; data: `requestedUsd`,
+  `appliedUsd`, `remainderUsd`, `balanceAfter`.
+- `CREDIT.REFUNDED` — clawback/refund. Tags: `tenantId`, `mode`, `actorUserId`; data: `amountUsd`,
+  `balanceAfter`.
+- `PROMO.REDEEMED` — tenant redeem. Tags: `tenantId`, `mode`, `actorUserId`, `code`; data:
+  `discountKind`, `value`, `planSlug`.
+- `PROMO.CODE.CREATED` / `PROMO.CODE.UPDATED` — admin CRUD (platform audit).
+- `TENANT.TRIAL.STARTED` — Tags: `tenantId`, `planId`, `planVersion`, `mode`; data: `startsAt`,
+  `endsAt`.
+- `TENANT.TRIAL.ENDED` — Tags: `tenantId`, `planId`, `planVersion`, `outcome`
+  (`converted`|`downgraded`), `mode`; data: trial window.
+
+Tenant-scope events append via `IEventRepository.AppendAsync(DomainEvent)` with `Tags`/`Data`
+JSON-serialized (the `OrgEndpoints` emit pattern); the platform-audit mirror uses
+`IPlatformEventPublisher.AppendAndPublishAsync(PlatformEvent)`. The appended `DomainEvent.Id` is
+written back into the inserted ledger/redemption row's `RefEventId` for forensic linkage.
+
+### API Shape
+
+```
+# Admin (platform owner) — PlatformOwnerAccess (AdminPricingEndpoints.cs)
+GET  /api/admin/tenants/{tenantId}/credits        # balance + recent ledger
+POST /api/admin/tenants/{tenantId}/credits        # body { amountUsd, reason?, note? } → CREDIT.GRANTED/REFUNDED
+GET  /api/admin/pricing/promo-codes               # list
+POST /api/admin/pricing/promo-codes               # body { code, discountKind, value, maxRedemptions?, expiry?, appliesTo[] }
+PATCH/api/admin/pricing/promo-codes/{id}          # deactivate / edit
+  → 200 created/updated ; 422 invalid_discount | duplicate_code
+
+# Tenant self-service — SettingsManage (tenant_owner); member → 403 (PricingEndpoints.cs)
+POST /api/pricing/promo/redeem                     # body { code, planSlug } ; tenant from ITenantContext
+  → 200 { applied: 'credit'|'percent', balanceAfter? }
+  → 422 code_not_found | code_inactive | code_expired | cap_reached | already_redeemed | plan_not_applicable
+  → 403 member_role
+GET  /api/pricing/credits                          # SettingsView — balance + ledger + active trial
+GET  /api/pricing/estimate                         # 34-5 surface, extended: + creditsApplied/netPrice/trialWaived
+```
+
+### Per-Mode + Per-Tenant Handling
+
+| Concern | single-user mode | SaaS mode |
+|---|---|---|
+| Grant credits | the sole user (admin route, authenticated) | platform owner (`PlatformOwnerAccess`) |
+| Create/manage promo codes | the sole user | platform owner |
+| Redeem promo / start trial | the sole user via `/api/pricing/*` | `tenant_owner` (`SettingsManage`); `member` → 403 |
+| Read balance/ledger/trial | the user | tenant members (`SettingsView`); never cross-tenant |
+| `CreatedByUserId` / actor | the user | the platform owner / tenant owner |
+| Tenant resolution | `ITenantContext.TenantId` (lone tenant) | `ITenantContext.TenantId` (caller's tenant); admin route takes `{tenantId}` |
+| Cross-tenant guard | n/a (one tenant) | redeem ignores any body tenant id, uses `ITenantContext`; admin route 404s unknown tenant |
+| Mode source | `ITammaModeProvider.Mode` | same |
+
+### Integration Points
+
+- **34-4 `IPlanAssignmentService`** — `StartTrialAsync` delegates the plan flip to `AssignAsync`
+  (trial marker in `AssignPlanOptions.Reason`); trial end delegates convert (keep) or downgrade
+  (`CancelAsync` / assign `plan_free`). The `TenantPlanAssignment.PlanVersion` pinning convention
+  is mirrored onto `TenantTrial.PlanVersion`.
+- **34-5 `IUsagePricingEngine`** — `CreditAwareUsagePricingEngine` decorates it: `sellPriceUsd`
+  comes from `PriceUsage`; this story subtracts promo discount + applied credit. Registered via
+  the existing `PricingServiceCollectionExtensions` so DI resolves the decorator.
+- **34-1 `IPlanCatalogService`** — resolve plan slug ↔ `(PlanId, Version)`, read trial-eligibility
+  + `IsCustom`/`Status` for trial/promo applicability guards.
+- **`AdminTenantsEndpoints.BuildAdminEvent`** — reuse the actor-extraction breadcrumb for the
+  platform-event mirror; the `MoveTenant` 202+poll / `PlatformTaskQueueProcessor` pattern is
+  mirrored for the trial-expiry boundary task (`TrialExpiryTaskPayload`).
+- **`IEventRepository` / `IPlatformEventPublisher`** — DCB + platform-audit emission.
+- **`ITammaModeProvider` (`TammaMode.cs`) / `ITenantContext`** — mode + tenant resolution.
+- **Epic 35 (Billing)** — consumes `NetPriceResult` (net price + `creditsApplied` + `remainder`)
+  and the `TENANT.TRIAL.ENDED` conversion signal; this story emits, Billing charges.
+
+## Dependencies
+
+**Internal — prerequisite:**
+- Story 34-4 (Per-Tenant Plan Assignment & Lifecycle) — `IPlanAssignmentService`,
+  `TenantPlanAssignment`, `AssignPlanOptions`/`CancelPlanOptions`, the `PlatformTaskQueueProcessor`
+  boundary-task pattern. Trial assignment/conversion/downgrade delegates to it.
+- Story 34-5 (Cost→Price Markup Engine) — `IUsagePricingEngine`, `NetPriceResult` inputs
+  (`sellPriceUsd`, `pricingMode`), the 6dp/2dp rounding convention, and the
+  `AdminPricingEndpoints.cs` / `PricingEndpoints.cs` files this story extends.
+- Story 34-1 (Plan & Price-Book Catalog) — `IPlanCatalogService`, plan slugs, trial-eligibility +
+  `Status`/`IsCustom` flags consumed for guards.
+- Epic 28 (control-plane tenancy) — `Tenant`, `ControlPlaneDbContext`, `PlatformQueuedTask` /
+  `PlatformTaskQueueProcessor`, `IPlatformEventPublisher`, `ITenantContext`.
+- Epic 4 (DCB events) — `DomainEvent` / `IEventRepository` append path.
+- Story 5.6 (alerts) RBAC precedent — `RequireTenantAdmin` / membership-filter pattern reused for
+  the tenant routes.
+
+**Internal — blocks:**
+- Epic 35 (Billing) — consumes the credit-aware net price, applied-credit + remainder split, and
+  the trial conversion signal to issue real invoices.
+
+**External:**
+- None required in this story. Stripe/payment movement is Epic 35; the unit/integration tests mock
+  `IUsagePricingEngine`, `IPlanAssignmentService`, and the providers — no live billing SDK is on
+  the path.
+
+## Testing Strategy
+
+**Unit (xUnit, `tests/Tamma.Api.Tests/Pricing/`):**
+1. `ConsumeAsync` floor-at-zero: consume 30 from a 20 balance → applied 20, remainder 10,
+   balance 0; never negative. `allowPartial = false` on an empty balance throws
+   `CREDIT.CONSUME.OVERDRAFT`.
+2. `ConsumeAsync` concurrency: two parallel consumes of 15 each on a 20 balance net to applied 20
+   total (one full, one partial), never > 20 (serializable retry path / forced
+   `DbUpdateException` simulation on the in-memory + real-Postgres provider).
+3. `GrantAsync` / refund: appends positive/clamped rows, recomputes `BalanceAfter`, emits
+   `CREDIT.GRANTED` / `CREDIT.REFUNDED`, writes `RefEventId`.
+4. Promo validation matrix: not-found, inactive, expired, cap-reached, already-redeemed (same
+   tenant), plan-not-applicable, and the valid case — each maps to the right `reason` / 422 or
+   success.
+5. `RedeemAsync` cap-guard under concurrency: `MaxRedemptions = 1`, two tenants redeem → exactly
+   one succeeds, one 422 `cap_reached`; same tenant twice → `already_redeemed`.
+6. Fixed-promo grants a `CreditLedger Reason = promo` entry; percent-promo records redemption but
+   grants no credit (applied at invoice).
+7. Trial: `StartTrialAsync` creates `active` trial + delegates `AssignAsync` (mock); a second
+   active trial is rejected (partial unique index / pre-check). `EndTrialAsync` convert → status
+   `converted`, assignment kept, `TENANT.TRIAL.ENDED outcome=converted`; downgrade → status
+   `expired`, `CancelAsync`/assign-free called, `outcome=downgraded`. Idempotent by `trialId`.
+8. `CreditAwareUsagePricingEngine`: `net = max(0, sell − promo − credits)` (mock
+   `IUsagePricingEngine`); active trial zeroes the recurring component (`trialWaived = true`);
+   net floored at 0 when discounts exceed sell.
+9. Golden-file determinism: a fixed usage line + balance + promo produces a byte-stable
+   `NetPriceResult` (6dp/2dp).
+10. DCB event-shape tests: each mutation appends the right event type with required tags + amounts.
+
+**Integration (xUnit + Postgres via `sg docker -c "dotnet test …"`):**
+11. Migration applies + rolls back cleanly; `ck_credit_balance_nonneg` rejects a negative
+    `BalanceAfter` at the DB level; the trial partial unique index rejects a second `active` trial;
+    the `(PromoCodeId, TenantId)` unique index rejects a duplicate redeem.
+12. `POST /api/admin/tenants/{id}/credits` (PlatformOwnerAccess) grants + `GET` returns the balance;
+    a non-platform JWT → 403; unknown tenant → 404.
+13. `POST /api/pricing/promo/redeem`: `tenant_owner` redeems a valid code (200); `member` → 403;
+    invalid code variants → 422 with reason; **tenant isolation** — caller A's redeem cannot
+    affect / read tenant B's ledger (body tenant id ignored; route is tenant-from-context).
+14. Trial-end boundary end-to-end via the platform queue: enqueue a `TrialExpiryTaskPayload`, run
+    the processor, assert convert vs downgrade outcome + emitted `TENANT.TRIAL.ENDED`.
+15. Concurrent consume against a real Postgres balance never oversells (serializable transaction).
+
+**Mocks:** `IUsagePricingEngine` (34-5, returns a fixed `sellPriceUsd`), `IPlanAssignmentService`
+(34-4, assert delegation), `IPlanCatalogService` (34-1), `IEventRepository` /
+`IPlatformEventPublisher` (assert emission), `TimeProvider` (deterministic trial windows / expiry),
+`ITammaModeProvider` + `ITenantContext` (mode + tenant). No Stripe/payment SDK on the path.
+
+## Estimated Effort
+
+4-5 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/TenantTrial.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/CreditLedger.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/PromoCode.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/PromoRedemption.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (4 DbSets) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (entity config, CHECKs, indexes, FKs) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_AddTrialsCreditsPromos.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Core/Enums/TrialStatus.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Core/Enums/CreditReason.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Core/Enums/DiscountKind.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/ICreditService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/CreditService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IPromoCodeService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PromoCodeService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/ICreditAwarePricingEngine.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/CreditAwareUsagePricingEngine.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/TrialsCreditsModels.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/TrialsCreditsEventTypes.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/TrialExpiryTaskPayload.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs` | Modify (redeem, credits, estimate ext; file from 34-2) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminPricingEndpoints.cs` | Modify (credits grant, promo CRUD; file from 34-5) |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/PricingServiceCollectionExtensions.cs` | Modify (DI + decorate IUsagePricingEngine) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map routes; DI) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/CreditServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PromoCodeServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/CreditAwarePricingEngineTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/TrialsCreditsEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Data.Tests/Migrations/TrialsCreditsMigrationTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md).
+2. Searched `.dev/` for related spikes/bugs/findings/decisions (pricing, tenancy, events, ledger).
+3. Reviewed 34-1, 34-4 and 34-5 — this story is strictly downstream of the catalog, assignment
+   lifecycle, and markup engine; do NOT re-implement any of them here.
+4. Confirmed the C# test-runner contract: `sg docker -c "dotnet test …"` for docker-bound suites
+   (build needs no wrapper). See `reference_dotnet_test_docker`.
+5. Planned a TDD (Red-Green-Refactor) approach — tests for each AC before implementation.
+
+### Key Design Decisions
+
+- **Append-only ledger, never UPDATE.** Every credit movement is a new immutable `CreditLedger`
+  row carrying its own `BalanceAfter`. This gives a forensic audit trail (matching the DCB/event
+  spirit) and makes balance reconstruction a pure running sum. Editing/deleting a ledger row is
+  never a code path.
+- **Floor consume at zero; remainder flows to Billing.** Credits *offset* a charge, they never
+  create debt. `ConsumeAsync` applies `min(request, balance)` and hands the unfunded remainder back
+  — Billing (Epic 35) charges the remainder as real money. The `ck_credit_balance_nonneg` CHECK is
+  the DB-level backstop.
+- **Serialize the consume, don't trust read-then-write.** Two simultaneous consumes on the same
+  tenant must not double-spend the same balance. A serializable transaction (retry on `40001`) or a
+  per-tenant row lock is load-bearing — pin it in the concurrency test.
+- **Decorate the markup engine, don't fork it.** `CreditAwareUsagePricingEngine` wraps 34-5's
+  `IUsagePricingEngine` so `sellPriceUsd` math lives in exactly one place; this story only subtracts
+  promo + credit and zeroes the trial-waived component.
+- **Pin the trial's plan version.** Mirror 34-4: `TenantTrial.PlanVersion` is denormalized so a
+  later plan deprecation cannot re-price an in-flight trial.
+- **Reuse the platform queue for the trial boundary.** Trial expiry mirrors 34-4's
+  scheduled-activation enqueue + processor pattern instead of inventing a scheduler; the task is
+  idempotent by `trialId` so a host that was down at `EndsAt` catches up on the next tick.
+- **Percent vs fixed split.** A `fixed` code grants a `CreditLedger` entry immediately (it *is* a
+  credit). A `percent` code is recorded as a redemption and applied at invoice time by Billing
+  (no ledger row) — keeping the ledger purely USD-denominated.
+
+### Edge Cases
+
+- Redeeming the same code twice for one tenant → `already_redeemed` 422 (unique
+  `(PromoCodeId, TenantId)`), `RedemptionCount` not double-incremented.
+- Concurrent redeem of the last remaining redemption → exactly one wins (atomic
+  `UPDATE … SET RedemptionCount = RedemptionCount + 1 WHERE RedemptionCount < MaxRedemptions`);
+  the loser gets `cap_reached`.
+- Promo `AppliesTo` empty/null = applies to all plans; non-empty must contain the chosen slug.
+- Trial `EndsAt` passed while host was down → caught by the boundary task on next processor tick.
+- Net price when promo + credits exceed sell → floored at 0, `creditsApplied` capped at the
+  pre-floor remainder (never "over-apply" credit beyond what the charge needs).
+- Admin negative grant (clawback) → `Reason = refund`/`consume`, still floor-clamped at 0.
+
+## Logging Requirements
+
+- **INFO**: credit granted (tenantId, amount, reason, balanceAfter), promo redeemed
+  (tenantId, code, kind), trial started (tenantId, planId, endsAt), trial ended
+  (tenantId, outcome).
+- **DEBUG**: consume request vs applied vs remainder, balance read under lock, promo validation
+  decision (which guard matched), trial boundary-task claim, transaction begin/commit/retry.
+- **WARN**: consume could not be fully funded (remainder flows to Billing), serializable retry on
+  concurrent consume, promo redeem rejected (reason), admin clawback applied.
+- **ERROR**: ledger transaction rollback, `ck_credit_balance_nonneg` violation surfaced (bug),
+  trial-boundary enqueue/claim failure, promo cap atomic-update failure.
+- **Structured context**: include `{ tenantId, amountUsd, balanceAfter, reason, code, planSlug,
+  trialId, outcome, mode, actorUserId }` where applicable.
+- **Credential / PII safety**: never log payment details or actor PII beyond the user GUID; promo
+  codes are low-sensitivity but still logged only on the audit path, never in client error bodies
+  beyond the validation reason.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-34/story-34-8/34-8-pricing-audit-events-and-reproducibility.md
+++ b/docs/stories/epic-34/story-34-8/34-8-pricing-audit-events-and-reproducibility.md
@@ -1,0 +1,371 @@
+# Story 34-8: Pricing Audit, Events & Reproducibility
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide covers the 7-phase workflow (Read → Research → Break Down → TDD → Quality Gates → Failure Handling), the `.dev/` knowledge base, TRACE/DEBUG logging, test-first development, 100% coverage on critical paths, and build-success enforcement.
+
+## User Story
+
+As a **platform owner (and a compliance/finance auditor acting on their behalf)**,
+I want every pricing decision — a plan version published, a tenant's plan changed, a margin policy edited, a credit grant, a promo applied, a BYOK-mode flip — captured as a canonical DCB event with consistent tags, and a query API that reconstructs exactly "what plan / price / entitlements / BYOK-mode applied to tenant X at timestamp T" by replaying those events,
+so that the whole Epic 34 pricing stack satisfies Tamma's 100%-audit-trail goal, no priced amount is ever un-explainable, and a historical invoice line can be re-derived deterministically (time-travel debugging of money).
+
+## Priority
+
+P1 — This is the cross-cutting consistency layer for the whole epic. Stories 34-1..34-7 each emit their own events; without one canonical taxonomy, one emitter that writes them transactionally with the state change, and one reconstruction API, the audit trail is fragmented and the "reproducible pricing" promise of 34-1/34-5 cannot be verified.
+
+## Acceptance Criteria
+
+1. A documented **pricing event catalog** (file `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricingEventTypes.cs` + a markdown table in this story) defines every pricing event as `AGGREGATE.ACTION.STATUS`: `PLAN.VERSION.CREATED`, `PLAN.DEPRECATED` (34-1), `TENANT.PLAN.CHANGED`, `TENANT.PLAN.CANCELLED` (34-4), `PRICING.MARGIN.UPDATED` (34-5), `CREDIT.GRANTED` / `CREDIT.CONSUMED` / `CREDIT.EXPIRED` (34-6), `PROMO.APPLIED` / `PROMO.REVOKED` (34-7), and `BYOK.MODE.CHANGED` (34-3) — each as a `const string` so producers reference the same symbol, never a string literal.
+2. A **canonical tag contract** is enforced by `PricingEventEmitter`: every pricing event carries the required tags `tenantId` (or empty for catalog-global events such as `PLAN.VERSION.CREATED`), `planId`, `planVersion`, `actorUserId`, `pricingMode` (`platform_provided`|`byok`), and `source` (`admin`|`system`|`tenant`). A `PricingEventTagValidator` rejects (in tests and in a DEBUG assertion) any emit missing a required tag for that event type.
+3. `PricingEventEmitter` (`apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricingEventEmitter.cs`) is the **single write seam** that stories 34-1..34-7 call. It routes each event to the correct plane exactly like `AlertEventEmitter`: tenant-scoped events (`TENANT.PLAN.*`, `CREDIT.*`, `PROMO.*`, `BYOK.MODE.CHANGED`) → tenant `DomainEvent` store via `IEventRepository.AppendAsync`; control-plane / catalog-global events (`PLAN.VERSION.CREATED`, `PLAN.DEPRECATED`, `PRICING.MARGIN.UPDATED`) → control-plane `PlatformEvent` store via `IPlatformEventPublisher.AppendAndPublishAsync`.
+4. Every priced state change is **emitted transactionally with the entity write** — the event append and the entity mutation share one DB transaction (the same `DbContext.SaveChangesAsync` for control-plane writes; tenant-scope appends join the producer's tenant `DbContext` transaction). An integration test asserts the invariant: a forced failure after the entity write but before commit leaves NEITHER the row NOR the event (no state change exists without its audit event, and no orphan audit event exists without its state change).
+5. `GET /api/admin/pricing/audit?tenantId={guid}&at={iso8601}` (`PlatformOwnerAccess`) reconstructs the **effective pricing snapshot** for the tenant at timestamp `T` by replaying/filtering the pricing event streams: effective `planId` + `planVersion` (last `TENANT.PLAN.CHANGED`/`CANCELLED` ≤ T), effective `MarginPolicy` (last `PRICING.MARGIN.UPDATED` ≤ T resolved by scope order provider→plan→global per 34-5), resolved entitlements (from the plan version snapshot via `IPlanCatalogService`), BYOK mode (last `BYOK.MODE.CHANGED` ≤ T), and any active credits/promos at T. Response is a `PricingAuditSnapshot` DTO.
+6. **Price replay is reproducible:** `GET /api/admin/pricing/audit/replay?tenantId={guid}&usageEventId={guid}` re-runs `IUsagePricingEngine.PriceUsage` (34-5) against the historical usage line (read from `ProviderDiagnostic`/the 34-3 usage event) **and the `MarginPolicy` effective at that usage event's timestamp**, and returns the recomputed `{ costBasisUsd, marginUsd, sellPriceUsd, pricingMode }`. A replay regression test asserts the recomputed `sellPriceUsd` is byte-stable against a golden value for a synthetic usage+policy history.
+7. A **point-in-time-equals-live invariant test** builds a synthetic plan-change history (assign v1 → upgrade to v2 → change margin → flip BYOK) and asserts that `GET /api/admin/pricing/audit?at=now` returns the same effective snapshot as the live read paths (`IPlanCatalogService.GetForTenantAsync` + the live `MarginPolicy` resolution + live BYOK mode) — the replay reconstruction never drifts from current state.
+8. A **configuration-audit feed** powers the admin dashboard: `GET /api/admin/pricing/audit/log?tenantId=&domain=&from=&to=` (`PlatformOwnerAccess`) returns a paginated, time-ordered list of pricing config changes (plan/margin/credit/promo/byok) each with `eventType`, `actorUserId`, `occurredAt`, and a `diff` (old→new) field; a new `packages/dashboard` admin tab (`PricingAuditTab.tsx`) renders it with actor + diff columns.
+9. **Sensitive-data redaction:** BYOK secret references in `BYOK.MODE.CHANGED` events (and any event `data` field that could carry a key) are emitted as opaque refs only (the secret-cabinet `SecretRow` id / handle), never plaintext keys; every free-text error/detail field passes through `CredentialRedactor.Clean` (`apps/tamma-elsa/src/Tamma.Core/Redaction/`) before serialisation, mirroring `AlertEventEmitter`.
+10. **Per-mode handling:** the audit/reconstruction API is platform-owned in both modes. In single-user mode the sole user is the platform owner and reads the audit for their own (single) tenant; in SaaS mode `PlatformOwnerAccess` gates the admin audit endpoints and a tenant-scoped read (`GET /api/v1/orgs/{tenantId}/pricing/audit`, `MemberAccess`) lets a tenant see their OWN pricing history (no margin-policy internals — margin/cost-basis fields are stripped from the tenant projection, since markup is a platform secret).
+11. **Per-tenant isolation:** the tenant-scoped audit read never returns another tenant's events; the reconstruction reads tenant-scope events via the per-tenant `DomainEvent` store (per-tenant connection is the isolation plane) and only catalog-global events (which carry no other tenant's data) from the control plane. A cross-tenant isolation test (tenant A's owner requesting tenant B's audit) returns 404/403.
+12. **Idempotent / dedup-safe emission:** `PricingEventEmitter` tolerates the `IPlatformEventPublisher` dedup no-op (null return = "already recorded" on a retried write) and never double-counts an event; the emitter itself never throws into the producer's transaction in a way that would silently drop the audit row — a failed append rolls back the state change (AC 4), it does not swallow.
+13. Unit + integration tests cover: tag-contract validation per event type, plane-routing per event type, the emitted-with-state transactional invariant, point-in-time reconstruction == live state, price-replay determinism (golden file), redaction of BYOK refs, per-mode RBAC matrix (owner / tenant_owner / member / cross-tenant), and the config-audit log diff shaping.
+
+## Technical Design
+
+### Namespace & file structure
+
+```
+apps/tamma-elsa/src/
+  Tamma.Api/Services/Pricing/              # directory created by 34-1; this story adds the audit seam
+    PricingEventTypes.cs                   # NEW — const string catalog (PLAN.*, TENANT.PLAN.*, PRICING.MARGIN.*, CREDIT.*, PROMO.*, BYOK.*)
+    IPricingEventEmitter.cs                # NEW (Tamma.Api.Services.Pricing)
+    PricingEventEmitter.cs                 # NEW — single write seam; dual-plane routing + redaction
+    PricingEventTags.cs                    # NEW — required-tag contract + PricingEventTagValidator
+    IPricingAuditService.cs                # NEW — reconstruction + replay read seam
+    PricingAuditService.cs                 # NEW — replays event streams into a PricingAuditSnapshot
+    PricingAuditSnapshot.cs                # NEW — immutable reconstruction DTO (record)
+    PricingAuditDtos.cs                    # NEW — audit-log row + replay response DTOs
+  Tamma.Api/Endpoints/Admin/
+    AdminPricingEndpoints.cs               # MODIFIED (created by 34-5) — add /audit, /audit/replay, /audit/log handlers
+  Tamma.Api/Endpoints/
+    PricingEndpoints.cs                    # MODIFIED (created by 34-4) — add tenant-scoped /orgs/{id}/pricing/audit
+  Tamma.Api/Extensions/
+    PricingServiceCollectionExtensions.cs  # MODIFIED (created by 34-1) — register emitter + audit service
+  Tamma.Data/Repositories/
+    IEventRepository.cs / EventRepository.cs           # REUSED — tenant DomainEvent append/query
+    IPlatformEventRepository.cs / PlatformEventRepository.cs  # REUSED — control-plane PlatformEvent query
+  Tamma.Core/Redaction/
+    CredentialRedactor.cs                  # REUSED — scrub free-text fields before serialisation
+
+packages/dashboard/src/
+  services/admin/pricing-audit-client.ts   # NEW — typed client (mirrors admin-tenants-client.ts)
+  pages/admin/PricingAuditTab.tsx          # NEW — config-audit feed (actor + diff columns)
+  pages/admin/AdminLayout.tsx              # MODIFIED — add 'pricing-audit' to AdminTab union + TABS
+```
+
+### Event catalog — `PricingEventTypes` (the canonical taxonomy)
+
+```csharp
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Canonical pricing event taxonomy (AGGREGATE.ACTION.STATUS). Every Epic 34
+/// producer references THESE constants — never a string literal — so the
+/// audit reconstruction (PricingAuditService) and the alert evaluator match
+/// a stable set. Plane assignment is data, not a producer concern: see
+/// <see cref="PricingEventTags.PlaneFor"/>.
+/// </summary>
+public static class PricingEventTypes
+{
+    // Catalog-global (control plane → PlatformEvent)
+    public const string PlanVersionCreated = "PLAN.VERSION.CREATED";   // 34-1
+    public const string PlanDeprecated     = "PLAN.DEPRECATED";        // 34-1
+    public const string MarginUpdated      = "PRICING.MARGIN.UPDATED"; // 34-5
+
+    // Tenant-scoped (tenant DomainEvent store)
+    public const string TenantPlanChanged   = "TENANT.PLAN.CHANGED";   // 34-4
+    public const string TenantPlanCancelled = "TENANT.PLAN.CANCELLED"; // 34-4
+    public const string CreditGranted       = "CREDIT.GRANTED";        // 34-6
+    public const string CreditConsumed      = "CREDIT.CONSUMED";       // 34-6
+    public const string CreditExpired       = "CREDIT.EXPIRED";        // 34-6
+    public const string PromoApplied        = "PROMO.APPLIED";         // 34-7
+    public const string PromoRevoked        = "PROMO.REVOKED";         // 34-7
+    public const string ByokModeChanged     = "BYOK.MODE.CHANGED";     // 34-3
+}
+```
+
+> **Boundary note:** this story does NOT define the *business semantics* of credits, promos, or BYOK mode (those are owned by 34-6, 34-7, 34-3). It owns the canonical event *names + tag contract + emission + reconstruction*. The producer stories call `IPricingEventEmitter` with their domain data; this story guarantees the tags and the audit replay.
+
+### Required-tag contract — `PricingEventTags`
+
+```csharp
+namespace Tamma.Api.Services.Pricing;
+
+public sealed record PricingEventTagSet(
+    Guid? TenantId,        // null/empty for catalog-global events
+    Guid? PlanId,
+    int? PlanVersion,
+    Guid? ActorUserId,
+    string PricingMode,    // "platform_provided" | "byok"
+    string Source);        // "admin" | "system" | "tenant"
+
+public static class PricingEventTags
+{
+    /// <summary>Which plane an event type writes to.</summary>
+    public static EventPlane PlaneFor(string eventType) => eventType switch
+    {
+        PricingEventTypes.PlanVersionCreated
+            or PricingEventTypes.PlanDeprecated
+            or PricingEventTypes.MarginUpdated => EventPlane.ControlPlane,
+        _ => EventPlane.Tenant,
+    };
+
+    /// <summary>Required tag keys per event type — drives PricingEventTagValidator.</summary>
+    public static IReadOnlyList<string> RequiredFor(string eventType);
+}
+
+public enum EventPlane { Tenant, ControlPlane }
+```
+
+`PricingEventTagValidator.Validate(eventType, tags)` returns the missing-key list. `PricingEventEmitter` calls it; in DEBUG a non-empty result is a `Debug.Assert` (loud in tests), in RELEASE it is a WARN log + the event is still emitted with the tags present (never drop an audit row over a tag bug).
+
+### Emitter — `PricingEventEmitter` (single write seam)
+
+```csharp
+public interface IPricingEventEmitter
+{
+    /// <summary>
+    /// Append a pricing event to the correct plane, with the canonical tag
+    /// set, transactionally with the producer's state change. The producer
+    /// passes its open tenant/control-plane DbContext so the append joins
+    /// the SAME transaction — no state change without its audit event.
+    /// </summary>
+    Task EmitAsync(
+        string eventType,
+        PricingEventTagSet tags,
+        IReadOnlyDictionary<string, object?> data,
+        DbContext producerContext,
+        CancellationToken ct = default);
+}
+```
+
+Implementation mirrors `AlertEventEmitter`:
+- Serialise `tags` (string-typed JSONB) and `data` (after running every string value through `CredentialRedactor.Clean`).
+- `Metadata` = `{"eventSource":"system","workflowVersion":"1.0.0"}`.
+- Route by `PricingEventTags.PlaneFor(eventType)`:
+  - **Tenant** → add a `DomainEvent` row to the producer's tenant `DbContext` (`db.DomainEvents.Add(...)`); the producer's single `SaveChangesAsync`/transaction commits both. (For producers that aren't already in a tenant `DbContext` — e.g. an Elsa activity — fall back to `IEventRepository.AppendAsync`.)
+  - **Control plane** → add a `PlatformEvent` to the producer's `ControlPlaneDbContext`; or, when emitted standalone, `IPlatformEventPublisher.AppendAndPublishAsync` (tolerate the null dedup no-op return).
+
+The transactional contract (AC 4) is the load-bearing piece: the emitter does **not** open its own transaction — it enlists in the producer's. The producer pattern (documented for 34-1..34-7 to follow) is:
+
+```csharp
+// inside e.g. PlanAssignmentService.AssignAsync (34-4)
+db.TenantPlanAssignments.Add(assignment);
+await emitter.EmitAsync(PricingEventTypes.TenantPlanChanged, tags, data, db, ct);
+await db.SaveChangesAsync(ct);   // one commit → row + event, atomically
+```
+
+### Reconstruction — `PricingAuditService`
+
+```csharp
+public interface IPricingAuditService
+{
+    /// <summary>Effective pricing snapshot for a tenant at timestamp T.</summary>
+    Task<PricingAuditSnapshot> ReconstructAsync(Guid tenantId, DateTime at, CancellationToken ct);
+
+    /// <summary>Re-price a historical usage line against the policy effective then.</summary>
+    Task<PricingReplayResult> ReplayUsageAsync(Guid tenantId, Guid usageEventId, CancellationToken ct);
+
+    /// <summary>Paginated, time-ordered config-change log (admin feed).</summary>
+    Task<(IReadOnlyList<PricingAuditLogRow> Rows, int Total)> QueryLogAsync(
+        Guid? tenantId, string? domain, DateTime? from, DateTime? to, int limit, int offset, CancellationToken ct);
+}
+```
+
+`ReconstructAsync` algorithm:
+1. Tenant-scope stream: `IEventRepository.QueryWithPaginationAsync(tenantId, type: null, ...)` filtered to the tenant pricing event types, `CreatedAt <= at`, newest-first → take last `TENANT.PLAN.CHANGED`/`CANCELLED` (effective plan+version), last `BYOK.MODE.CHANGED` (effective mode), and fold `CREDIT.*` / `PROMO.*` into the set active at T.
+2. Control-plane stream: `IPlatformEventRepository.QueryAsync(typePrefix: "PRICING.MARGIN", ...)` filtered `<= at` → resolve the effective `MarginPolicy` per 34-5's scope order (provider→plan→global). `PLAN.VERSION.CREATED`/`DEPRECATED` are consulted to confirm the effective version was active at T.
+3. Entitlements: hand the resolved `(planId, planVersion)` to `IPlanCatalogService.GetByIdAsync` (34-1) for the entitlement/feature/price snapshot.
+4. Assemble `PricingAuditSnapshot { TenantId, At, PlanId, PlanVersion, PlanSlug, PricingMode, MarginPolicySnapshot, Entitlements, ActiveCredits, ActivePromos }`.
+
+`ReplayUsageAsync` reads the usage line (`ProviderDiagnostic` row / 34-3 usage event by id), resolves the `MarginPolicy` effective at `usageEvent.CreatedAt` (NOT now), and calls `IUsagePricingEngine.PriceUsage(...)` (34-5) — the engine is pure, so feeding it the historical policy + historical tokens reproduces the original `sellPriceUsd` exactly.
+
+### DCB event names emitted/consumed (this story)
+
+| Event | Plane | Producer (story) | This story's role |
+|---|---|---|---|
+| `PLAN.VERSION.CREATED`, `PLAN.DEPRECATED` | control plane | 34-1 | catalog + emitter + audit reads |
+| `TENANT.PLAN.CHANGED`, `TENANT.PLAN.CANCELLED` | tenant | 34-4 | emitter + reconstruction |
+| `PRICING.MARGIN.UPDATED` | control plane | 34-5 | emitter + margin replay |
+| `CREDIT.GRANTED` / `CONSUMED` / `EXPIRED` | tenant | 34-6 | emitter + active-credit fold |
+| `PROMO.APPLIED` / `PROMO.REVOKED` | tenant | 34-7 | emitter + active-promo fold |
+| `BYOK.MODE.CHANGED` | tenant | 34-3 | emitter + redaction + mode reconstruction |
+
+This story emits no *new* event type of its own — it is the consistency layer. (The audit *read* endpoints are pure reads; they do not emit.)
+
+### API shape
+
+```
+# Admin (PlatformOwnerAccess) — under /api/admin/pricing (group created by 34-5)
+GET /api/admin/pricing/audit?tenantId={guid}&at={iso8601}
+      → 200 PricingAuditSnapshot
+GET /api/admin/pricing/audit/replay?tenantId={guid}&usageEventId={guid}
+      → 200 { costBasisUsd, marginUsd, sellPriceUsd, pricingMode, marginPolicyEffectiveAt }
+GET /api/admin/pricing/audit/log?tenantId=&domain=&from=&to=&limit=50&offset=0
+      → 200 { rows: PricingAuditLogRow[], total } ; PricingAuditLogRow = { eventType, actorUserId, occurredAt, domain, diff }
+
+# Tenant-scoped (MemberAccess) — under /api/v1/orgs/{tenantId} (group created by 34-4)
+GET /api/v1/orgs/{tenantId}/pricing/audit?at={iso8601}
+      → 200 TenantPricingAuditSnapshot  (margin/cost-basis fields STRIPPED — platform secret)
+```
+
+`at` defaults to `now` when omitted. All admin endpoints sit behind the existing `PlatformOwnerAccess` policy (Program.cs ~986); the tenant endpoint behind `MemberAccess` and explicitly scopes to the caller's tenant.
+
+### Per-mode + per-tenant handling (CLAUDE.md two-scoping-model rule)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Who reads the full pricing audit (incl. margin)? | The sole user (= platform owner); their one tenant. | `PlatformOwnerAccess` (platform owner) only. |
+| Who reads the tenant-scoped audit (no margin internals)? | The sole user. | `tenant_owner`/`tenant_admin`/`member` for their OWN tenant via `/orgs/{id}/pricing/audit`. |
+| Where do tenant-scope events live? | The sole user's tenant `DomainEvent` store. | The tenant's per-tenant `DomainEvent` store (isolation plane). |
+| Where do catalog/margin events live? | Control-plane `PlatformEvent` store. | Same — global, never per-tenant. |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`) — process-stable. | same |
+
+### Migration discipline
+
+This story adds **no new tables** — it reuses `domain_events` (tenant) and `platform_events` (control plane). No EF migration is required. If the audit-log diff needs an index hint, it is a read-only query against existing `Type`/`CreatedAt`/`SequenceNumber` columns already indexed for `AlertRuleEvaluator`. Verify `dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext` reports none after wiring (it must — no model change).
+
+## Dependencies
+
+**Internal Dependencies:**
+- **Prerequisite — Story 34-1** (Plan & Price-Book Catalog): provides `Plan` versioning, `IPlanCatalogService.GetByIdAsync` (entitlement snapshot for reconstruction), and the `PLAN.VERSION.CREATED`/`PLAN.DEPRECATED` event producers that route through this story's emitter.
+- **Prerequisite — Story 34-4** (Per-Tenant Plan Assignment): provides `TenantPlanAssignment`, `IPlanCatalogService.GetForTenantAsync` (live-state oracle for AC 7), the `PricingEndpoints` `/orgs/{id}` group, and the `TENANT.PLAN.CHANGED`/`CANCELLED` producers.
+- **Prerequisite — Story 34-5** (Cost→Price Markup Engine): provides `IUsagePricingEngine.PriceUsage` (replayed by AC 6), `MarginPolicy` (timestamp-effective resolution), `AdminPricingEndpoints` (the `/api/admin/pricing` group this story extends), and `PRICING.MARGIN.UPDATED`.
+- **Prerequisite — Epic 4 (DCB event sourcing)**: `DomainEvent`/`PlatformEvent` entities, `IEventRepository`, `IPlatformEventRepository`/`IPlatformEventPublisher` — the stores this story replays.
+- **Soft-coupled — Stories 34-3 (BYOK mode), 34-6 (credits), 34-7 (promos)**: this story defines `BYOK.MODE.CHANGED` / `CREDIT.*` / `PROMO.*` in the canonical taxonomy and folds them into reconstruction; those stories produce the events via `IPricingEventEmitter`. If a producer story is not yet merged, its events simply don't appear in the stream — reconstruction degrades gracefully (the snapshot omits that dimension, never errors).
+- **Reuses — `Tamma.Core/Redaction/CredentialRedactor`** (already exists) and the secret cabinet (`SecretRow`, Epic 29) for opaque BYOK refs.
+
+**External Dependencies:**
+- None at runtime. (No Stripe — billing/charging is Epic 35. This story re-derives priced amounts for *audit*, it never moves money.) Tests mock `IUsagePricingEngine`, `IPlanCatalogService`, and the event repositories.
+
+**Blocks:**
+- **Epic 35 (Billing)**: invoice line items reference the reconstructed pricing for dispute/audit; Epic 35 reads (does not re-implement) this audit API.
+- **Epic 36-7 (Analytics view)**: the config-audit feed and replay are the source for the pricing analytics surface.
+
+## Testing Strategy
+
+1. **Tag-contract unit tests** (`PricingEventTagValidatorTests`): for each event type, a tag set missing a required key is reported; a complete set validates; catalog-global events do not require `tenantId`.
+2. **Plane-routing unit tests** (`PricingEventEmitterTests`): mock `IEventRepository` + `IPlatformEventPublisher`; assert `TENANT.PLAN.CHANGED` lands on the tenant store and `PRICING.MARGIN.UPDATED` on the control plane; assert `CredentialRedactor.Clean` ran on every string `data` value; assert a BYOK ref is an opaque handle (no `tamma_sk_`/`sk_live_` pattern survives — reuse the redactor's prefix set).
+3. **Transactional-invariant integration test** (`PricingAuditTransactionTests`, docker-bound): drive a producer-style write that adds the entity + calls `EmitAsync`, then force a failure before commit → assert NEITHER row NOR event persisted; happy path → assert BOTH persisted. Run via `sg docker -c "dotnet test ..."`.
+4. **Point-in-time == live test** (`PricingAuditReconstructionTests`): build a synthetic history (assign v1 → upgrade v2 → margin edit → BYOK flip) by appending events; assert `ReconstructAsync(now)` matches `IPlanCatalogService.GetForTenantAsync` + live margin + live BYOK; assert `ReconstructAsync(t_before_upgrade)` returns v1.
+5. **Price-replay determinism test** (`PricingReplayTests`, golden file): a synthetic usage line + a `MarginPolicy` history; `ReplayUsageAsync` recomputes `sellPriceUsd` byte-stable against a checked-in golden value; changing the policy *after* the usage timestamp does not change the replayed price.
+6. **Tenant-isolation tests** (`PricingAuditIsolationTests`): tenant A's owner requesting tenant B's `/orgs/{B}/pricing/audit` → 403/404; the tenant projection strips `marginUsd`/`costBasisUsd`/`MarginPolicySnapshot`; reconstruction reads only the requesting tenant's `DomainEvent` store.
+7. **RBAC matrix tests** (`AdminPricingAuditEndpointsTests`): admin endpoints reject non-platform-owner with 403; tenant endpoint allows `member` read but the response omits margin internals; `at` defaulting to now.
+8. **Config-audit-log shaping test**: `QueryLogAsync` orders newest-first, filters by `domain` (plan/margin/credit/promo/byok derived from event type), and the `diff` field carries old→new from the event `data`.
+9. **Dashboard tests** (Vitest + Testing Library, colocated): `PricingAuditTab` renders rows with actor + diff columns; empty state; `pnpm test --filter @tamma/dashboard` green.
+
+## Estimated Effort
+
+3-4 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricingEventTypes.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IPricingEventEmitter.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricingEventEmitter.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricingEventTags.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IPricingAuditService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricingAuditService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricingAuditSnapshot.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricingAuditDtos.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminPricingEndpoints.cs` | Modify (created by 34-5 — add audit/replay/log handlers) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs` | Modify (created by 34-4 — add tenant `/orgs/{id}/pricing/audit`) |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/PricingServiceCollectionExtensions.cs` | Modify (created by 34-1 — register emitter + audit service) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map new audit routes) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingEventEmitterTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingEventTagValidatorTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingAuditReconstructionTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingReplayTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingAuditTransactionTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingAuditIsolationTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/AdminPricingAuditEndpointsTests.cs` | Create |
+| `packages/dashboard/src/services/admin/pricing-audit-client.ts` | Create |
+| `packages/dashboard/src/pages/admin/PricingAuditTab.tsx` | Create |
+| `packages/dashboard/src/pages/admin/__tests__/PricingAuditTab.test.tsx` | Create |
+| `packages/dashboard/src/pages/admin/AdminLayout.tsx` | Modify (add `pricing-audit` tab) |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` directory for related spikes, bugs, findings, and decisions (esp. `.dev/decisions/story-28-1-design-calls.md` for the tenant/control-plane event routing matrix this story depends on)
+3. Read stories 34-1, 34-4, 34-5 — this story is the consistency layer over their producers and must reference their real types (`IPlanCatalogService`, `TenantPlanAssignment`, `IUsagePricingEngine`, `MarginPolicy`)
+4. Studied `AlertEventEmitter.cs` — it is the exact pattern for dual-plane routing + redaction this story replicates for pricing
+5. Planned TDD approach (Red-Green-Refactor); the transactional invariant and replay-determinism tests are the highest-value reds to write first
+
+### Key Design Decisions
+
+- **One emitter, enlisted in the producer's transaction.** The "no state change without its audit event" invariant (AC 4) is impossible if the emitter opens its own transaction or fires-and-forgets. The emitter adds the event row to the *producer's* `DbContext` so a single `SaveChangesAsync` commits both or neither. This is the inverse of `AlertEventEmitter`'s fire-and-forget posture — alerts are best-effort observability; pricing audit is a hard correctness invariant. Document this difference loudly in the emitter XML doc.
+- **Reconstruction by event replay, not a snapshot table.** Per Epic 4 DCB philosophy, the event stream is the source of truth; a derived snapshot table would be a second thing to keep consistent. Reconstruction filters the existing `domain_events`/`platform_events` — no new table, no migration.
+- **The replay engine is pure (34-5).** `IUsagePricingEngine.PriceUsage` takes a usage line + a margin policy and is deterministic. Feeding it the *historical* policy is the whole trick to reproducibility — never let replay reach for the *current* policy.
+- **Margin is a platform secret.** The tenant-scoped projection strips `marginUsd`, `costBasisUsd`, and the `MarginPolicySnapshot`. A tenant can see their plan/version/entitlements/credits history, never the markup math. Enforced in the DTO mapping, not just the UI.
+- **Catalog-global events stay control-plane resident** even after Story 28-1/Epic 30 moves tenant events fully per-tenant — reconstruction always reads margin/plan-catalog events from `IPlatformEventRepository`, so the topology shift only touches tenant-scope routing (already abstracted behind `IEventRepository`).
+
+### Integration Points
+
+- **34-1..34-7 producers** call `IPricingEventEmitter.EmitAsync` in their write transaction (the canonical producer pattern shown above) — this story ships the emitter and the tests that pin the contract; the producer stories adopt it.
+- **`IPlanCatalogService` (34-1)** is the entitlement oracle for both reconstruction and the AC-7 live-state comparison.
+- **`IUsagePricingEngine` + `MarginPolicy` (34-5)** are the replay engine + policy source.
+- **`AlertRuleEvaluator` (Story 5.6)** already polls `domain_events`/`platform_events`; because pricing events now land there consistently, a future built-in rule (e.g. on `PRICING.MARGIN.UPDATED`) is free — out of scope here, but the consistent emission makes it possible.
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+| --- | --- | --- |
+| A producer story emits an event NOT through the emitter (string literal, own transaction) → audit gap | High | The canonical producer pattern + `PricingEventTypes` constants + a grep-guard test that fails if a pricing event string literal appears outside `PricingEventTypes`; document in each producer story's Dev Notes. |
+| Emitter opening its own transaction defeats the atomicity invariant | High | Emitter takes the producer's `DbContext`; the transactional integration test (AC 4) is the guard. |
+| Reconstruction drifts from live state as new dimensions are added (e.g. a future entitlement field) | Medium | The point-in-time-==-live test (AC 7) runs against `IPlanCatalogService.GetForTenantAsync`, so any new live dimension that isn't reconstructed fails the test. |
+| BYOK key leaks into an event `data` field | Critical | Opaque-ref-only contract (AC 9) + `CredentialRedactor.Clean` on every string + a redaction test asserting no secret-prefix survives. |
+| Event-store topology shift (Story 28-1 / Epic 30) | Medium | Tenant reads go through `IEventRepository` (already abstracted per-tenant); catalog reads pinned to `IPlatformEventRepository`. |
+
+### Success Metrics
+
+- [ ] 100% of Epic 34 priced state changes have a matching audit event (verified by the grep-guard + transactional invariant tests).
+- [ ] `ReconstructAsync(now)` == live state for the synthetic history fixture (zero drift).
+- [ ] Replayed `sellPriceUsd` matches the golden value byte-for-byte across runs.
+
+## Logging Requirements
+
+- **INFO**: audit snapshot served (`tenantId`, `at`, resolved `planId`/`planVersion`), price replay served (`usageEventId`, recomputed `sellPriceUsd`), config-audit log queried (`tenantId`, `domain`, row count).
+- **DEBUG**: pricing event emitted (`eventType`, plane, `tenantId`), reconstruction stream fold (events scanned, effective plan/margin/byok chosen), replay margin-policy-effective-at resolution.
+- **WARN**: emitted event missing a required tag (RELEASE path — event still written), reconstruction found a usage event with an unknown provider/model (replay surfaces `PricingUnknownModel` from 34-5), tenant requested an `at` before any pricing history (empty snapshot returned).
+- **ERROR**: producer transaction rolled back because the audit append failed (the atomicity invariant firing — this is the *correct* loud failure), control-plane event store unreachable during reconstruction.
+- **Structured context**: include `{ tenantId, eventType, planId, planVersion, pricingMode, usageEventId, at }` where applicable.
+- **Credential safety**: NEVER log BYOK plaintext keys, encrypted connection strings, or secret-cabinet values; BYOK is logged as the opaque `SecretRow` handle only; all free-text error fields pass through `CredentialRedactor.Clean`.
+
+## References
+
+- **MANDATORY PROCESS:** [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+- **Knowledge Base:** [.dev/README.md](../../../.dev/README.md)
+- Sibling stories: `docs/stories/epic-34/story-34-1/`, `story-34-4/`, `story-34-5/`
+- Routing precedent: `apps/tamma-elsa/src/Tamma.Api/Services/Alerts/AlertEventEmitter.cs`
+- Event stores: `apps/tamma-elsa/src/Tamma.Data/Repositories/EventRepository.cs`, `PlatformEventRepository.cs`
+- Redaction: `apps/tamma-elsa/src/Tamma.Core/Redaction/CredentialRedactor.cs`
+- Implementation plan: `docs/superpowers/plans/2026-06-17-34-8-pricing-audit-events-and-reproducibility-plan.md`
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-34/story-34-9/34-9-pricing-and-plan-management-dashboards.md
+++ b/docs/stories/epic-34/story-34-9/34-9-pricing-and-plan-management-dashboards.md
@@ -1,0 +1,545 @@
+# Story 34-9: Pricing & Plan Management Dashboards
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-phase workflow (Read → Research → Break Down → TDD →
+Quality Gates → Failure Handling), the `.dev/` knowledge base usage rules, TRACE/DEBUG logging
+requirements, the test-first (TDD) workflow, the 100%-critical-path coverage requirement, and
+the build/quality-gate enforcement. **Failure to follow this process will result in rework.**
+
+## User Story
+
+As a **platform owner** (admin dashboard) and as a **tenant owner/admin** (user dashboard),
+I want to author and assign the price-book from the admin UI and see my plan, entitlement
+headroom, BYOK/platform mode, and credit balance from the tenant UI with an upgrade/estimate
+flow,
+so that monetization is operable end-to-end through a UI — owners manage plans/margins/promos/credits
+and tenants understand and change what they pay — without anyone touching the database or curling
+the API.
+
+This story is the **presentation layer** for Epic 34. It reuses the read APIs delivered by
+34-2 (plan catalog), 34-5 (pricing/estimate engine), 34-6 (entitlement/headroom), and 34-7
+(trials/credits/promo), and the BYOK mode-toggle endpoint from 34-3. It owns NO new pricing
+business logic — it surfaces and orchestrates the existing endpoints. (Two thin tenant-read
+endpoints — `GET /api/pricing/estimate` and `POST /api/pricing/subscribe` — are CANONICALLY owned
+by 34-5 and 34-4 respectively; this story consumes them and does not re-implement them.)
+
+## Priority
+
+P1 — Required for self-service monetization; the engine (34-1..34-7) is unusable by non-engineers
+until both dashboards surface it. Sits behind the P0 data/engine stories.
+
+## Acceptance Criteria
+
+1. **Admin Pricing section gated to platform owners.** `packages/dashboard` gains a `pricing`
+   tab in `AdminLayout.tsx` (`AdminTab` union + `TABS` array) that is wrapped by the existing
+   `AdminGuard` so non-platform-owner users never see it; every read/mutation it issues targets
+   `apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminPricingEndpoints.cs` routes, all gated by
+   `PlatformOwnerAccess` server-side (the UI gate is UX-only; the server is authoritative).
+
+2. **Admin plan-version editor round-trip.** The Pricing tab lists active + deprecated plan
+   versions from `GET /api/admin/pricing/plans`, opens a version editor that edits features
+   (`PlanFeature`), typed entitlements (`PlanEntitlement` keyed by `EntitlementMetricKey`), and
+   prices (`PlanPrice`), and submits via `POST/PUT /api/admin/pricing/plans` (34-2). Because plan
+   versions are immutable after activation (34-1), a save of an active version surfaces the
+   server's "creates a new version + deprecates prior" behaviour and re-renders the supersede
+   chain; a deprecate call that returns `409` with affected-tenant count is surfaced with the
+   `?force=true` opt-in.
+
+3. **Admin margin-policy editor.** The tab includes a margin-policy panel reading/writing
+   `GET/PUT /api/admin/pricing/margins` (34-5) over `MarginPolicy` rows (scope plan|provider|global,
+   `MarkupMultiplier`/`FixedUsdPer1M`, `EffectiveFrom`); saving surfaces the `PRICING.MARGIN.UPDATED`
+   DCB event result (success/version) and validates that at least one of multiplier/fixed is set.
+
+4. **Admin promo + credit management.** The tab can create/list promo codes
+   (`POST /api/admin/pricing/promo` / list) and grant credits to a tenant
+   (`POST /api/admin/tenants/{id}/credits`, 34-7); a successful grant shows the new `CreditLedger`
+   balance returned by the API; promo creation validates `DiscountKind` (percent|fixed),
+   `MaxRedemptions`, and `Expiry` client-side before POST (server remains authoritative).
+
+5. **Admin custom-plan minting + assignment.** The tab can mint an `IsCustom` plan bound to a
+   target tenant via `POST /api/admin/pricing/plans/custom` (34-2) and assign it via
+   `PUT /api/admin/tenants/{id}/plan` (34-4); custom plans are visually flagged and excluded from
+   the public-catalog list; an attempt to surface a custom plan publicly is rejected server-side
+   (400) and the error is shown inline.
+
+6. **Tenant Plan & Pricing page.** `packages/dashboard-user` gains a `/settings/billing` route
+   (AuthGuard → AppLayout) rendering: the current plan + version (from
+   `GET /api/pricing/plans/{slug}` + the tenant's active assignment), the resolved entitlement set
+   with usage-vs-limit bars driven by `GET /api/pricing/entitlements` + the `CheckHeadroom` calc
+   (34-6), the per-provider BYOK/platform mode (34-3), the credit balance (34-7), and a cost
+   estimate widget. Unlimited entitlements (`LimitValue == null`) render as "Unlimited" with no bar.
+
+7. **BYOK toggle never leaks the key.** For each provider, owner/admin can switch
+   platform↔BYOK; enabling BYOK stores the provider key through the secret-cabinet-backed endpoint
+   from 34-3 (the key is POSTed once, never read back) and the UI thereafter shows only the
+   `Mode = byok` + a `SecretRef` presence indicator — the stored key value is **never** rendered,
+   logged, or returned in any GET. `member`-role callers see the mode as read-only (no toggle
+   control rendered; server returns 403 on the mutation regardless, mirroring `SettingsManage`).
+
+8. **Tenant upgrade flow with entitlement delta preview.** The tenant picks a public plan from
+   `GET /api/pricing/plans`; before committing, the UI computes and displays the entitlement
+   **gains and losses** by diffing the target plan's resolved entitlements against the current
+   resolved set + the `CheckHeadroom` result (so a downgrade that would put the tenant over a new
+   limit is flagged), then commits via `POST /api/pricing/subscribe` (`SettingsManage`); the
+   response's flagged-violation list (from 34-4) is surfaced as a non-blocking warning.
+
+9. **Cost estimate widget.** A form (provider, model, input/output tokens) calls
+   `GET /api/pricing/estimate` (34-5) and renders `{ costBasisUsd, marginUsd, sellPriceUsd,
+   creditsApplied, pricingMode }`; BYOK mode shows a zero token markup; an unknown provider/model
+   surfaces the server's `PricingUnknownModel` error inline (never silently 0).
+
+10. **Trial + promo affordances.** A redeem-promo input calls `POST /api/pricing/promo/redeem`
+    (`SettingsManage`, 34-7) and surfaces the `422` reason on rejection; an active `TenantTrial`
+    renders a countdown banner ("Trial ends in N days") computed from `EndsAt`; member role sees
+    the banner read-only (no redeem control).
+
+11. **Per-mode degradation (single-user vs SaaS).** In single-user mode (no RBAC, sole user owns
+    everything per `ITammaModeProvider`) the tenant Plan & Pricing page renders all controls for
+    the sole user with no role gating; in SaaS mode the same page gates mutations to owner/admin
+    and renders `member` as read-only. The admin Pricing section is platform-owner-only in both
+    modes. No feature throws or hard-fails when a tenant has no active trial/credits/custom plan
+    (empty states render).
+
+12. **RBAC parity with the APIs (negative tests).** Component/E2E tests prove: a `member`-role
+    tenant user cannot mutate (no controls + a stubbed 403 surfaces cleanly), a non-platform-owner
+    cannot see the admin Pricing tab, and the BYOK toggle round-trip never places the plaintext key
+    in any rendered DOM, network response body fixture, or console output.
+
+13. **No new server pricing logic.** This story adds at most thin DTO/route wiring only where a
+    dependency story did not already expose a needed read; it MUST NOT re-implement margin math,
+    entitlement resolution, headroom, or credit netting — those live in 34-5/34-6/34-7 and are
+    called, not duplicated (honors the 34-5 canonical-owner boundary note).
+
+## Technical Design
+
+### Component ownership map
+
+| Layer | Package | New artifacts |
+|---|---|---|
+| Admin price-book UI | `packages/dashboard` | `PricingTab.tsx` + sub-panels, `admin-pricing-client.ts` |
+| Tenant plan & pricing UI | `packages/dashboard-user` | `PlanPricingPage.tsx` + widgets, `pricing.ts` API client |
+| Backend (consumed, NOT owned here) | `apps/tamma-elsa` | `PricingEndpoints.cs` (34-2/4/5/6/7), `Admin/AdminPricingEndpoints.cs` (34-2/5/7) |
+
+The two C# endpoint files appear in this story's `primaryComponents` because they are the contract
+surface this UI binds to; their **implementations are delivered by the dependency stories**. This
+story only adds backend code if a consumed read is missing — see AC-13. Verified at authoring time:
+neither `Tamma.Api/Endpoints/PricingEndpoints.cs` nor `Endpoints/Admin/AdminPricingEndpoints.cs`
+nor `Services/Pricing/` exists yet (they land with 34-1..34-7), so this story is correctly
+sequenced after them.
+
+### Admin dashboard — file structure (`packages/dashboard/src`)
+
+```
+services/admin/
+  admin-pricing-client.ts            # typed client for AdminPricingEndpoints.cs + AdminTenantsEndpoints plan/credit
+  admin-pricing-client.test.ts
+pages/admin/
+  AdminLayout.tsx                    # MODIFY: add 'pricing' to AdminTab union + TABS + content switch
+  pricing/
+    PricingTab.tsx                   # tab shell: sub-tabs Plans | Margins | Promos & Credits | Custom Plans
+    PlanVersionEditor.tsx            # features/entitlements/prices editor, supersede-chain view, 409 force flow
+    MarginPolicyPanel.tsx            # MarginPolicy CRUD (scope/markup/fixed/effectiveFrom)
+    PromoCreditPanel.tsx             # promo create/list + credit grant
+    CustomPlanPanel.tsx              # mint IsCustom plan + assign to bound tenant
+    __tests__/
+      PricingTab.test.tsx
+      PlanVersionEditor.test.tsx
+      MarginPolicyPanel.test.tsx
+      PromoCreditPanel.test.tsx
+      CustomPlanPanel.test.tsx
+```
+
+`PricingTab` is rendered only inside the existing `AdminGuard` chain (admin dashboard is already
+platform-admin scoped); the tab follows the `AdminLayout.tsx` pattern exactly (a `TabDef` row in
+`TABS`, a content guard `{activeTab === 'pricing' && <PricingTab />}`). The client mirrors the
+`fetchJSON<T>` + typed-error pattern of `admin-tenants-client.ts` (`AdminTenantApiError`).
+
+Admin client surface (camelCase wire shapes match the default `System.Text.Json` policy, exactly
+as `admin-tenants-client.ts` documents):
+
+```typescript
+export const adminPricingApi = {
+  // Plan catalog (34-2)
+  listPlans: (opts?: { includeDeprecated?: boolean; includeCustom?: boolean }) =>
+    fetchJSON<PlanSnapshot[]>(`/admin/pricing/plans${query(opts)}`),
+  getPlan: (slug: string, version?: number) =>
+    fetchJSON<PlanSnapshot>(`/admin/pricing/plans/${slug}${version ? `?version=${version}` : ''}`),
+  createPlanVersion: (body: UpsertPlanBody) =>
+    fetchJSON<PlanSnapshot>(`/admin/pricing/plans`, { method: 'POST', body: JSON.stringify(body) }),
+  updatePlanVersion: (slug: string, body: UpsertPlanBody) =>
+    fetchJSON<PlanSnapshot>(`/admin/pricing/plans/${slug}`, { method: 'PUT', body: JSON.stringify(body) }),
+  deprecatePlan: (slug: string, version: number, force = false) =>
+    fetchJSON<DeprecateResult>(`/admin/pricing/plans/${slug}/${version}/deprecate?force=${force}`, { method: 'POST' }),
+  mintCustomPlan: (body: MintCustomPlanBody) =>
+    fetchJSON<PlanSnapshot>(`/admin/pricing/plans/custom`, { method: 'POST', body: JSON.stringify(body) }),
+  // Margins (34-5)
+  listMargins: () => fetchJSON<MarginPolicyDto[]>(`/admin/pricing/margins`),
+  upsertMargin: (body: UpsertMarginBody) =>
+    fetchJSON<MarginPolicyDto>(`/admin/pricing/margins`, { method: 'PUT', body: JSON.stringify(body) }),
+  // Promos + credits (34-7)
+  listPromos: () => fetchJSON<PromoCodeDto[]>(`/admin/pricing/promo`),
+  createPromo: (body: CreatePromoBody) =>
+    fetchJSON<PromoCodeDto>(`/admin/pricing/promo`, { method: 'POST', body: JSON.stringify(body) }),
+  grantCredits: (tenantId: string, body: GrantCreditsBody) =>
+    fetchJSON<CreditLedgerEntryDto>(`/admin/tenants/${tenantId}/credits`, { method: 'POST', body: JSON.stringify(body) }),
+  // Assignment (34-4) — reuse adminTenantsApi.updatePlan, do NOT duplicate
+};
+```
+
+`DeprecateResult` carries `{ deprecated: boolean; affectedTenants: number; requiresForce: boolean }`
+so the 409 path (AC-2) renders the affected count and a "Deprecate anyway (force)" confirmation.
+
+### Tenant dashboard — file structure (`packages/dashboard-user/src`)
+
+```
+api/
+  pricing.ts                         # typed client over PricingEndpoints.cs (tenant routes)
+  pricing.test.ts
+pages/settings/
+  PlanPricingPage.tsx                # current plan, entitlement bars, BYOK panel, credits, estimate, upgrade
+  PlanPricingPage.test.tsx
+components/pricing/
+  EntitlementBar.tsx                 # one metric: limit, usage, headroom bar (or "Unlimited")
+  ByokModePanel.tsx                  # per-provider platform/byok toggle + key-store form (write-only)
+  CostEstimateWidget.tsx            # estimate form -> GET /api/pricing/estimate
+  UpgradePlanModal.tsx               # plan picker + entitlement delta preview -> POST /api/pricing/subscribe
+  TrialBanner.tsx                    # countdown from TenantTrial.EndsAt
+  PromoRedeemForm.tsx                # POST /api/pricing/promo/redeem
+  __tests__/ (colocated *.test.tsx for each)
+App.tsx                              # MODIFY: add /settings/billing route under AuthGuard → AppLayout
+layouts/AppLayout.tsx               # MODIFY: add "Billing" nav link
+```
+
+Tenant client (built on the shared `ApiClient` so the refresh-on-401 dance is inherited, exactly
+like `api/alerts.ts`). `tenantId`/`role` come from `useAuth()` (`AuthUser.tenantId`, `AuthUser.role`):
+
+```typescript
+import { apiClient } from './client';
+
+export type PricingMode = 'platform_provided' | 'byok';
+export type EntitlementMetricKey =
+  | 'agents' | 'workflow_runs' | 'llm_tokens' | 'seats' | 'repos'
+  | 'rag_storage_mb' | 'benchmark_retention_days';
+
+export interface ResolvedEntitlement {
+  metric: EntitlementMetricKey;
+  limit: number | null;            // null = unlimited
+  period: 'monthly' | 'total';
+  overageMode: 'block' | 'allow' | 'meter';
+  currentUsage: number;            // from CheckHeadroom (34-6)
+  remaining: number | null;        // null when unlimited
+  over: boolean;
+}
+
+export interface CurrentPlanResponse {
+  planSlug: string; planName: string; version: number;
+  isCustom: boolean; status: string;
+  entitlements: ResolvedEntitlement[];
+  creditBalanceUsd: number;
+  trial: { endsAt: string; status: 'active' | 'converted' | 'expired' } | null;
+  providerModes: { provider: string; mode: PricingMode; hasSecretRef: boolean }[];
+}
+
+export interface EstimateResponse {
+  costBasisUsd: number; marginUsd: number; sellPriceUsd: number;
+  creditsApplied: number; pricingMode: PricingMode;
+}
+
+export const tenantPricingApi = {
+  getEntitlements: () => apiClient.get<{ entitlements: ResolvedEntitlement[] }>(`/api/pricing/entitlements`),
+  getCurrentPlan: () => apiClient.get<CurrentPlanResponse>(`/api/pricing/plan`),
+  listPublicPlans: () => apiClient.get<{ plans: PlanSnapshotDto[] }>(`/api/pricing/plans`),
+  estimate: (q: { provider: string; model: string; inputTokens: number; outputTokens: number }) =>
+    apiClient.get<EstimateResponse>(`/api/pricing/estimate?${new URLSearchParams(/* ... */)}`),
+  subscribe: (body: { planSlug: string; version?: number }) =>
+    apiClient.post<SubscribeResponse>(`/api/pricing/subscribe`, body),
+  redeemPromo: (body: { code: string; planSlug: string }) =>
+    apiClient.post<RedeemResponse>(`/api/pricing/promo/redeem`, body),
+  // BYOK mode (34-3)
+  setProviderMode: (provider: string, body: { mode: PricingMode; plaintextKey?: string }) =>
+    apiClient.put<{ provider: string; mode: PricingMode; hasSecretRef: boolean }>(
+      `/api/pricing/providers/${provider}/mode`, body),
+};
+```
+
+> `getCurrentPlan` / `setProviderMode` route shapes are owned by 34-3/34-4/34-6; if a dependency
+> exposes them under a slightly different path the client is the single adjustment point. The
+> `plaintextKey` is **write-only**: it is sent on the enable-BYOK PUT and never present in any
+> response type (AC-7). `EntitlementBar` and `UpgradePlanModal` consume `CheckHeadroom`-derived
+> `remaining`/`over` fields rather than recomputing — honoring AC-13.
+
+### BYOK key-handling (security-critical, AC-7)
+
+`ByokModePanel` posts the key exactly once, mirroring the secret-cabinet write pattern used by the
+admin secrets client (`secrets-api-client.ts`, `CreateSecretBody.plaintext`): the field lives only
+in component state, is cleared on submit, and is **never** stored in any response type or rendered
+back. The post-enable view reads `hasSecretRef: boolean` from the mode response and shows a neutral
+"Key stored (BYOK active)" badge. A client-side pre-flight (mirroring `hasPlaintextCredential` in
+`api/alerts.ts`) rejects any attempt to embed a key in a non-key field. The server (34-3) is
+authoritative — UI is UX-only.
+
+### Per-mode + per-tenant handling
+
+| Concern | single-user mode | SaaS mode |
+|---|---|---|
+| Tenant page principal | sole user (`user_id`) — no role gating; all controls enabled | `tenantId` from `useAuth()`; mutations gated owner/admin, `member` read-only |
+| BYOK / subscribe / promo / credits read-back gate | sole user does everything | `SettingsManage` (owner/admin); `member` → 403 |
+| Admin Pricing section | visible to the sole user (it is their instance) | `PlatformOwnerAccess` only; never shown to tenant members |
+| Source of mode | `ITammaModeProvider` (server) reflected in `/api/auth/me` role/tenant shape | same |
+
+The UI never decides the mode itself; it reads `useAuth()` (which is populated by `/api/auth/me`
+sourced from the server's mode + membership) and the server enforces the boundary. This mirrors the
+prompt-store "endpoint shape identical between modes; auth middleware decides" precedent.
+
+### DCB events (emitted by the consumed endpoints, surfaced — not raised — by the UI)
+
+The UI does not append DCB events; it triggers endpoints that do, and reflects their results:
+
+- `PLAN.CATALOG.UPDATED` / `PLAN.CUSTOM.CREATED` / `PLAN.VERSION.CREATED` / `PLAN.DEPRECATED` (34-1/34-2)
+- `PRICING.MARGIN.UPDATED` (34-5)
+- `TENANT.PLAN.CHANGED` (34-4) — on subscribe/upgrade; the UI may show a recent-change confirmation
+- `CREDIT.GRANTED` / `CREDIT.CONSUMED` / `PROMO.REDEEMED` / `TENANT.TRIAL.ENDED` (34-7)
+
+These names are AGGREGATE.ACTION.STATUS per CLAUDE.md and exist in the dependency stories; the UI
+only asserts (in tests) that the right endpoint was called with the right body.
+
+### EF migration sketch
+
+**None in this story.** All schema (`Plan`, `PlanFeature`, `PlanEntitlement`, `PlanPrice`,
+`MarginPolicy`, `TenantPlanAssignment`, `TenantProviderBilling`, `TenantTrial`, `CreditLedger`,
+`PromoCode`) is created by 34-1..34-7. If AC-13's "thin missing read" escape hatch is needed (e.g.
+a consolidated `GET /api/pricing/plan` for the tenant's current plan does not already exist), it is
+a read-only projection over existing entities via `ControlPlaneDbContext` — additive endpoint, no
+migration. Verify `dotnet ef migrations has-pending-model-changes` reports **none** if any backend
+file is touched.
+
+## Dependencies
+
+**Internal (prerequisite — all must be merged before this story starts):**
+
+- **Story 34-2** — Plan Catalog Admin API & Custom Enterprise Plans (provides
+  `AdminPricingEndpoints.cs` plan CRUD + custom-plan minting + `GET /api/pricing/plans`).
+- **Story 34-5** — Cost→Price Markup Engine (provides `GET/PUT /api/admin/pricing/margins` and the
+  tenant `GET /api/pricing/estimate`). 34-5 is the **canonical owner** of markup math — this story
+  must not re-implement it.
+- **Story 34-6** — Entitlement & Quota Resolution Service (provides `GET /api/pricing/entitlements`
+  and the `CheckHeadroom` calc the entitlement bars + upgrade delta consume).
+- **Story 34-7** — Trials, Credits & Promo Codes (provides promo redeem/admin-grant + trial state +
+  credit-aware net price).
+
+**Internal (transitive prerequisites of the above):**
+
+- **Story 34-1** — Plan & Price-Book data model + `EntitlementMetricKey` enum.
+- **Story 34-3** — BYOK vs platform mode endpoint + secret-cabinet wiring (the BYOK toggle target).
+- **Story 34-4** — Per-tenant plan assignment (`PUT /api/admin/tenants/{id}/plan`,
+  `POST /api/pricing/subscribe`).
+
+**Blocks:**
+
+- Epic 35 (Billing) UI surfaces, if any, build on the plan/entitlement views established here.
+
+**External:**
+
+- React 18 + Vite + React Router (already in both dashboard packages).
+- Vitest 3.x + Testing Library (already configured: `packages/dashboard/src/test/`,
+  `packages/dashboard-user/src/test/`).
+- No new npm dependencies expected.
+
+## Testing Strategy
+
+**Admin dashboard (`packages/dashboard`, Vitest + Testing Library, colocated `__tests__/`):**
+
+1. `admin-pricing-client.test.ts` — every method builds the right URL/method/body; non-2xx
+   surfaces `AdminTenantApiError`-style typed error; 409 deprecate parses `affectedTenants`.
+2. `PlanVersionEditor.test.tsx` — edit features/entitlements/prices → save calls
+   `createPlanVersion`/`updatePlanVersion`; saving an active version shows the "new version created"
+   result; deprecate with assignments shows the 409 affected-count + force opt-in (mock fetch).
+3. `MarginPolicyPanel.test.tsx` — list renders, save validates "at least one of multiplier/fixed",
+   calls `upsertMargin`.
+4. `PromoCreditPanel.test.tsx` — promo create validates DiscountKind/MaxRedemptions/Expiry; credit
+   grant shows new balance.
+5. `CustomPlanPanel.test.tsx` — mint custom plan bound to tenant; assign via `adminTenantsApi.updatePlan`;
+   custom plans excluded from public list view; public-surface attempt shows the 400 error.
+6. `PricingTab.test.tsx` + `AdminLayout.test.tsx` (extend existing) — tab appears in `TABS`,
+   renders inside `AdminGuard`, sub-tab switching works.
+
+**Tenant dashboard (`packages/dashboard-user`, Vitest + Testing Library):**
+
+7. `pricing.test.ts` — client URL/method/body matrix; estimate query-string assembly; refresh-on-401
+   inherited from `ApiClient`.
+8. `PlanPricingPage.test.tsx` — current plan renders; entitlement bars render usage/limit/headroom;
+   unlimited renders "Unlimited" with no bar; empty trial/credits render empty states; member role
+   renders read-only (no mutate controls) and a stubbed 403 surfaces cleanly.
+9. `EntitlementBar.test.tsx` — bar width/over-limit styling from `remaining`/`over`; null limit path.
+10. `ByokModePanel.test.tsx` — **key-leak test**: enable BYOK posts the key once; the plaintext key
+    NEVER appears in the rendered DOM after submit, NEVER in any response fixture, NEVER in
+    `console` output; post-enable shows `hasSecretRef` badge only; member sees read-only mode.
+11. `CostEstimateWidget.test.tsx` — estimate renders cost/margin/sell/credits/mode; BYOK shows zero
+    token markup; unknown-model surfaces `PricingUnknownModel` inline (not 0).
+12. `UpgradePlanModal.test.tsx` — delta preview shows gains AND losses vs current resolved set;
+    downgrade-over-limit flagged; commit calls `subscribe`; violation warning surfaced non-blocking.
+13. `TrialBanner.test.tsx` / `PromoRedeemForm.test.tsx` — countdown from `EndsAt`; 422 promo reason
+    surfaced; member read-only.
+
+**Tenant-isolation / RBAC (mocked-server) tests:**
+
+14. `member`-role user: all mutate controls absent; any forced mutation receives a stubbed 403 and
+    renders the message (no white-screen).
+15. Cross-tenant safety: the tenant client only ever derives `tenantId` from `useAuth()`, never from
+    a URL param the user controls — asserted by reading the client's call args.
+
+**Mocks:**
+
+- Stripe / provider SDKs are NOT touched here (this is UI over already-built endpoints) — fetch is
+  mocked via the existing `vi.fn()`/MSW-style helpers in each package's `test/` setup.
+- `useAuth()` is stubbed per-test to drive single-user vs SaaS vs member-role matrices.
+
+**Coverage:** follow project targets (80% line / 75% branch / 85% function); the BYOK key-leak path
+and the member-403 path are critical and must be 100% covered.
+
+## Estimated Effort
+
+5-6 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `packages/dashboard/src/services/admin/admin-pricing-client.ts` | Create |
+| `packages/dashboard/src/services/admin/admin-pricing-client.test.ts` | Create |
+| `packages/dashboard/src/pages/admin/pricing/PricingTab.tsx` | Create |
+| `packages/dashboard/src/pages/admin/pricing/PlanVersionEditor.tsx` | Create |
+| `packages/dashboard/src/pages/admin/pricing/MarginPolicyPanel.tsx` | Create |
+| `packages/dashboard/src/pages/admin/pricing/PromoCreditPanel.tsx` | Create |
+| `packages/dashboard/src/pages/admin/pricing/CustomPlanPanel.tsx` | Create |
+| `packages/dashboard/src/pages/admin/pricing/__tests__/PricingTab.test.tsx` | Create |
+| `packages/dashboard/src/pages/admin/pricing/__tests__/PlanVersionEditor.test.tsx` | Create |
+| `packages/dashboard/src/pages/admin/pricing/__tests__/MarginPolicyPanel.test.tsx` | Create |
+| `packages/dashboard/src/pages/admin/pricing/__tests__/PromoCreditPanel.test.tsx` | Create |
+| `packages/dashboard/src/pages/admin/pricing/__tests__/CustomPlanPanel.test.tsx` | Create |
+| `packages/dashboard/src/pages/admin/AdminLayout.tsx` | Modify (add `pricing` tab) |
+| `packages/dashboard/src/pages/admin/__tests__/AdminLayout.test.tsx` | Modify (assert tab) |
+| `packages/dashboard-user/src/api/pricing.ts` | Create |
+| `packages/dashboard-user/src/api/pricing.test.ts` | Create |
+| `packages/dashboard-user/src/pages/settings/PlanPricingPage.tsx` | Create |
+| `packages/dashboard-user/src/pages/settings/PlanPricingPage.test.tsx` | Create |
+| `packages/dashboard-user/src/components/pricing/EntitlementBar.tsx` | Create |
+| `packages/dashboard-user/src/components/pricing/ByokModePanel.tsx` | Create |
+| `packages/dashboard-user/src/components/pricing/CostEstimateWidget.tsx` | Create |
+| `packages/dashboard-user/src/components/pricing/UpgradePlanModal.tsx` | Create |
+| `packages/dashboard-user/src/components/pricing/TrialBanner.tsx` | Create |
+| `packages/dashboard-user/src/components/pricing/PromoRedeemForm.tsx` | Create |
+| `packages/dashboard-user/src/components/pricing/__tests__/*.test.tsx` | Create (one per component) |
+| `packages/dashboard-user/src/App.tsx` | Modify (add `/settings/billing` route) |
+| `packages/dashboard-user/src/layouts/AppLayout.tsx` | Modify (add Billing nav link) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs` | Modify only if a consumed tenant read is missing (AC-13; additive read, no migration) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminPricingEndpoints.cs` | Modify only if a consumed admin read is missing (AC-13; additive read, no migration) |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md).
+2. Searched `.dev/` for related spikes, bugs, findings, decisions.
+3. Confirmed 34-2/34-3/34-4/34-5/34-6/34-7 are merged and their endpoints exist (grep
+   `Tamma.Api/Endpoints/PricingEndpoints.cs` and `Endpoints/Admin/AdminPricingEndpoints.cs` — they
+   did NOT exist at this story's authoring time, which is why this story is sequenced last in Epic 34).
+4. Reviewed the existing dashboard patterns this story mirrors:
+   `packages/dashboard/src/pages/admin/AdminLayout.tsx` (tab union + TABS),
+   `packages/dashboard/src/services/admin/admin-tenants-client.ts` (typed `fetchJSON` client),
+   `packages/dashboard-user/src/pages/alerts/TenantAlertFeed.tsx` (tenant page + member read-only),
+   `packages/dashboard-user/src/api/alerts.ts` (ApiClient-based client + plaintext-credential
+   pre-flight), `packages/dashboard/src/services/secrets/secrets-api-client.ts` (write-only
+   secret-cabinet pattern for the BYOK key).
+5. Planned the TDD cycle (Red-Green-Refactor) per component.
+
+### Key Design Decisions
+
+- **Presentation only, zero business duplication.** The single biggest risk is re-implementing
+  margin/headroom/credit math in the UI. Decision: the UI calls the engine endpoints and renders
+  their numbers verbatim (AC-13). The entitlement delta preview (AC-8) is the only "compute" the UI
+  does, and it is a pure set-diff over server-resolved entitlement lists + the server's `CheckHeadroom`
+  output — no pricing math.
+- **BYOK key is write-only, never round-tripped.** Mirrors the secret cabinet's reveal-once design.
+  The mode response carries a boolean presence flag, never the key. This is enforced by a dedicated
+  leak test (AC-7, test #10).
+- **One source of truth for `tenantId`/`role` — `useAuth()`.** The tenant client never accepts a
+  caller-supplied tenant id; it derives identity from the authenticated session, so a member can't
+  spoof another tenant. The server is still authoritative (RequireTenantMembership filter).
+- **Admin reuses `adminTenantsApi.updatePlan` for assignment** rather than adding a duplicate plan
+  PATCH — assignment is owned by 34-4's `AdminTenantsEndpoints.cs`/`updatePlan` client method.
+- **Per-mode rendering is data-driven, not branchy.** A single `canMutate = isSingleUser || role in
+  {owner, admin}` gate (computed from `useAuth()`) controls every mutate control; the admin Pricing
+  tab is platform-owner-only via the existing `AdminGuard`.
+
+### Integration Points
+
+- Admin: `AdminPricingEndpoints.cs` (`PlatformOwnerAccess`), `AdminTenantsEndpoints.cs`
+  (`PlatformOwnerAccess`) plan + credit routes.
+- Tenant: `PricingEndpoints.cs` tenant routes (`MemberAccess` reads / `SettingsManage` mutations),
+  the 34-3 BYOK mode route, the secret cabinet (Epic 29) via the 34-3 enable flow.
+- Auth: `/api/auth/me` (drives `useAuth()` role/tenant/mode), the shared `ApiClient` refresh-on-401.
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Dependency endpoints not yet merged / shape drift | High | Hard-gate start on 34-2/3/4/5/6/7 merge; the typed clients are the single adjustment point if a path differs; integration smoke test against a running API before UI sign-off |
+| BYOK key leaks into DOM/logs/responses | Critical | Write-only field cleared on submit; dedicated leak test asserts absence in DOM + response fixtures + console; client-side plaintext pre-flight; server reveal-once is authoritative |
+| UI re-implements pricing/headroom math (drift from engine) | High | AC-13 forbids it; render server numbers verbatim; delta preview is pure set-diff only; code review checklist item |
+| Member-role user reaches a mutation | High | Controls hidden when `!canMutate` AND server returns 403; both paths tested; never trust the hidden control alone |
+| Single-user mode mis-gated as SaaS (or vice-versa) | Medium | `canMutate` derived from `useAuth()` which reflects server mode; per-mode test matrix in `PlanPricingPage.test.tsx` |
+| Deprecate-with-assignments 409 confusing UX | Medium | Surface affected-tenant count + explicit "Deprecate anyway (force)" confirm; no silent force |
+
+### Success Metrics
+
+- [ ] A platform owner can version a plan, set a margin, mint+assign a custom plan, and grant
+      credits entirely from the admin UI with no DB/API access.
+- [ ] A tenant owner can see plan + headroom, switch a provider to BYOK (key never visible), get a
+      cost estimate, and upgrade with a correct entitlement-delta preview.
+- [ ] `pnpm test --filter @tamma/dashboard` and `--filter @tamma/dashboard-user` green; no new lint
+      errors; BYOK key-leak + member-403 tests pass at 100% coverage on those paths.
+
+## Logging Requirements
+
+The browser UI uses sparse, structured console logging (no Pino in-browser); the server endpoints
+it calls own the authoritative Pino logs.
+
+- **INFO**: plan version saved, margin policy updated, custom plan minted/assigned, credits granted,
+  promo created/redeemed, subscribe committed (log endpoint + status + non-sensitive ids only).
+- **DEBUG**: client request issued (method + path, no body), tab/page mounted, estimate requested.
+- **WARN**: 409 deprecate-with-assignments surfaced, 422 promo rejection, 403 mutation attempt by
+  member, entitlement-violation downgrade flagged.
+- **ERROR**: non-2xx surfaced to the user (status + path), client typed-error thrown.
+- **Credential safety**: NEVER log the BYOK plaintext key, any secret-cabinet value, or full
+  response bodies that could contain a key/credential. The BYOK field is excluded from all logging
+  and from any error-context object.
+
+## Related
+
+- Epic 34 stories: `docs/stories/epic-34/story-34-1/` … `story-34-7/`
+- Implementation plan: `docs/superpowers/plans/2026-06-17-34-9-pricing-and-plan-management-dashboards-plan.md`
+- Pattern exemplars: `packages/dashboard/src/pages/admin/AdminLayout.tsx`,
+  `packages/dashboard-user/src/pages/alerts/TenantAlertFeed.tsx`
+
+## References
+
+- **MANDATORY PROCESS:** [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+- **Knowledge Base:** [.dev/README.md](../../.dev/README.md)
+- CLAUDE.md — Operating Modes (single-user vs SaaS) and per-mode ownership rule
+- CLAUDE.md — Prompt Store Architecture / RBAC (endpoint-shape-identical, auth-middleware-decides precedent)
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-35/README.md
+++ b/docs/stories/epic-35/README.md
@@ -1,0 +1,427 @@
+# Epic 35: Billing & Payments (C#) — Stripe, BYOK-Aware Metering, Subscriptions, Invoicing & Dunning
+
+## Overview
+
+Epic 35 monetizes the Tamma SaaS platform on the **current C# control plane** (`apps/tamma-elsa`:
+`Tamma.Api` minimal-API + `Tamma.Data` `ControlPlaneDbContext` + `Tamma.Activities`/Elsa +
+`TaskQueueProcessor`). It maps each tenant to a Stripe customer, manages the full subscription
+lifecycle, and charges for platform-provided AI usage (cost basis + margin) while treating BYOK
+tenants as a flat platform/seat fee with **zero token markup**. On top of that foundation it builds
+production-grade invoicing, payment methods, dunning, tax, a self-service billing portal, and a
+prepaid credits wallet — all per-tenant-isolated and audited via DCB `PlatformEvent`s.
+
+This epic **supersedes the deleted TypeScript Epic 20** (which lived in `packages/api`, now removed).
+Epic 35 re-targets every Epic 20 capability onto the live C# stack and splits the old "plan model"
+and "usage-limit model" concerns out to **Epic 34 (Pricing, Plans & Entitlements)** — the pricing
+model layer. **Epic 34 owns the price-book** (plans, features, typed entitlements, prices, the
+cost→price margin engine `IUsagePricingEngine`); **Epic 35 charges against it** (Stripe customers,
+subscriptions, metered usage reporting, invoicing, dunning, wallet). Epic 35 never re-implements
+margin math — it calls Epic 34's `IUsagePricingEngine.PriceUsage(...)`.
+
+The defining constraint is **BYOK-awareness**: platform-provided LLM usage is metered, cost-priced,
+and reported to Stripe Billing Meters, while BYOK tenants (provider key supplied by the tenant and
+held in the **Epic 29 secret cabinet**) are billed only the plan/seat fee with no per-token charge.
+
+**Per-mode (CLAUDE.md "two scoping models" rule):** billing is **SaaS-only**. In single-user mode the
+principal is the user, the deployment is self-hosted, and there is no Stripe coupling — a
+`NullBillingProvider` seam makes every billing path a no-op (zero Stripe SDK calls, billing endpoints
+absent/404). In SaaS mode the principal is the tenant; billing endpoints are RBAC-gated
+(`tenant_owner`/`tenant_admin` manage, `member` read-only), mirroring the prompt/convention store
+ownership pattern. State is schema-per-tenant for tenant-resident data; billing state itself
+(Stripe mappings, usage rollups, invoice mirrors, wallet ledger) is **control-plane resident, keyed
+by `tenant_id`**, because that is where the tenant registry, plans, and `PlatformAnalyticsHourly`
+already live.
+
+## Plans & Pricing
+
+> **Pricing model lives in Epic 34** (Pricing, Plans & Entitlements). Epic 35 does **not** define
+> prices, quotas, or margin — it reads the resolved plan/price from Epic 34's control-plane price-book
+> and **charges against it** through Stripe. The table below is the Epic 34 baseline catalog, shown
+> here only to ground what Epic 35 bills. Concrete numeric limits are seeded as `PlanEntitlement`
+> rows (Epic 34) and are admin-editable.
+
+| Plan | Pricing mode | Recurring (USD/mo) | LLM Tokens | Seats | What Epic 35 charges |
+|------|-------------|--------------------|-----------|-------|----------------------|
+| **Free** | platform-provided | $0 | metered / block at quota | 1 | no recurring; usage blocked at quota (35-6) |
+| **Team** | platform-provided · BYOK | paid · seat fee | platform: cost + margin · BYOK: 0 token markup | multi | base/seat fee + metered platform tokens (BYOK tokens not billed) |
+| **Enterprise** | platform-provided · BYOK | custom | custom (`NULL` = unlimited) | custom | custom contract; base + metered platform tokens |
+
+- **Platform-provided usage** → metered to Stripe meters (`tamma.platform_tokens_input`,
+  `tamma.platform_tokens_output`), priced `cost basis × (1 + margin)` via Epic 34's
+  `IUsagePricingEngine` (default global margin `1.3×`).
+- **BYOK usage** → recorded for analytics only (`Byok*` token counters); **never** emitted as a token
+  meter event. BYOK tenants pay the plan/seat fee alone.
+
+## Stories
+
+| Story | Title | Priority | Status | Est. Effort |
+|-------|-------|----------|--------|-------------|
+| 35-1 | Stripe Integration Foundation, Billing Plan Catalog & Customer Mapping (C#) | P0 | drafted | 4-5 days |
+| 35-2 | BYOK vs Platform-Provided Billing Mode & Per-Tenant Provider Key Cabinet Integration | P0 | drafted | 3-4 days |
+| 35-3 | BYOK-Aware Usage Metering & Stripe Meter Event Reporting | P0 | drafted | 5-6 days |
+| 35-4 | Subscription Lifecycle — Create, Upgrade/Downgrade, Cancel, Trial & Proration | P0 | drafted | 4-5 days |
+| 35-5 | Stripe Webhook Ingestion, Idempotency & Billing Event Projection | P0 | drafted | 4-5 days |
+| 35-6 | Plan Quota & Usage-Limit Enforcement (BYOK-Aware) | P0 | drafted | 3-4 days |
+| 35-7 | Payment Methods & Self-Service Stripe Billing Portal | P1 | drafted | 3-4 days |
+| 35-8 | Invoicing, Failed-Payment Dunning & Recovery | P0 | drafted | 4-5 days |
+| 35-9 | Tax Calculation & Compliance (Stripe Tax / VAT) | P1 | drafted | 3-4 days |
+| 35-10 | Credits & Prepaid Wallet Ledger | P2 | drafted | 4-5 days |
+| 35-11 | Tenant Billing Dashboard (dashboard-user) & Admin Billing Console (dashboard) | P1 | drafted | 5-6 days |
+| 35-12 | Billing Audit, Reconciliation & Revenue Analytics | P1 | drafted | 3-4 days |
+
+## Architecture
+
+```
++-----------------------------------------------------------------------------------+
+|        EPIC 35: BILLING & PAYMENTS (C#) — apps/tamma-elsa control plane            |
+|        (SaaS-only; single-user => NullBillingProvider no-op seam)                  |
++-----------------------------------------------------------------------------------+
+|                                                                                   |
+|  +-- LAYER 1: Stripe Foundation (35-1, 35-2) ------------------------------------+ |
+|  |  Tamma.Api/Services/Billing + Tamma.Data/Entities (ControlPlaneDbContext)     | |
+|  |  +------------------+  +------------------+  +------------------+              | |
+|  |  | IBillingProvider |  | BillingCustomer  |  | BYOK vs Platform |              | |
+|  |  | StripeClient     |  | (tenant->Stripe) |  | BillingMode      |              | |
+|  |  | (Stripe.net SDK) |  | + plan catalog   |  | (Epic 29 cabinet)|              | |
+|  |  | key via cabinet  |  | (Stripe ids/mtrs)|  |                  |              | |
+|  |  +------------------+  +------------------+  +------------------+              | |
+|  +--------------------------------------|----------------------------------------+ |
+|                                         v                                          |
+|  +-- LAYER 2: Subscriptions (35-4) ----------------------------------------------+ |
+|  |  +------------------+  +------------------+  +------------------+              | |
+|  |  | Create / Trial   |  | Upgrade / Down-  |  | Cancel +         |              | |
+|  |  | (charge vs Epic34|  | grade + Proration|  | Reactivate       |              | |
+|  |  |  resolved price) |  |                  |  |                  |              | |
+|  |  +------------------+  +------------------+  +------------------+              | |
+|  +--------------------------------------|----------------------------------------+ |
+|                                         v                                          |
+|  +-- LAYER 3: BYOK-Aware Metering (35-3) ----------------------------------------+ |
+|  |  source: DCB LLM.CALL.* events + ProviderDiagnostic cost substrate            | |
+|  |  +------------------+  +------------------+  +------------------+              | |
+|  |  | BillingUsage     |  | platform-only -> |  | BYOK -> counters |              | |
+|  |  | Rollup (CP, per  |  | Stripe Meters    |  | only (NO token   |              | |
+|  |  | tenant/period)   |  | (batched flush)  |  | meter, NO markup)|              | |
+|  |  | price=Epic34 eng |  |                  |  |                  |              | |
+|  |  +------------------+  +------------------+  +------------------+              | |
+|  +--------------------------------------|----------------------------------------+ |
+|                                         v                                          |
+|  +-- LAYER 4: Enforcement (35-6) ------------------------------------------------+ |
+|  |  +------------------+  +------------------+  +------------------+              | |
+|  |  | Pre-dispatch     |  | Graceful degrade |  | BYOK exempt from |              | |
+|  |  | quota check      |  | + over-quota     |  | token quotas     |              | |
+|  |  | (Epic34 entitl.) |  | alerts/events    |  |                  |              | |
+|  |  +------------------+  +------------------+  +------------------+              | |
+|  +--------------------------------------|----------------------------------------+ |
+|                                         v                                          |
+|  +-- LAYER 5: Invoicing & Dunning (35-8) + Webhooks (35-5) ----------------------+ |
+|  |  +------------------+  +------------------+  +------------------+              | |
+|  |  | Invoice mirror   |  | Failed-payment   |  | Stripe webhook   |              | |
+|  |  | + line items     |  | dunning ladder   |  | ingest + idem-   |              | |
+|  |  | (PDF via Stripe) |  | (past_due/grace/ |  | potency + event  |              | |
+|  |  |                  |  |  suspended)      |  | projection       |              | |
+|  |  +------------------+  +------------------+  +------------------+              | |
+|  +--------------------------------------|----------------------------------------+ |
+|                                         v                                          |
+|  +-- LAYER 6: Tax (35-9) --------------------------------------------------------+ |
+|  |  Stripe Tax / VAT calc, tax id collection, reverse-charge handling            | |
+|  +--------------------------------------|----------------------------------------+ |
+|                                         v                                          |
+|  +-- LAYER 7: Portal & Payment Methods (35-7) + Credits Wallet (35-10) ----------+ |
+|  |  +------------------+  +------------------+  +------------------+              | |
+|  |  | Stripe Billing   |  | Payment-method   |  | Prepaid wallet   |              | |
+|  |  | Portal session   |  | mirror + setup   |  | ledger + top-up  |              | |
+|  |  |                  |  | intents          |  | (Epic34 credits) |              | |
+|  |  +------------------+  +------------------+  +------------------+              | |
+|  +--------------------------------------|----------------------------------------+ |
+|                                         v                                          |
+|  +-- LAYER 8: Dashboards & Analytics (35-11, 35-12) -----------------------------+ |
+|  |  +-----------------------------+  +-----------------------------+              | |
+|  |  | packages/dashboard-user     |  | packages/dashboard (admin)  |              | |
+|  |  | tenant billing area:        |  | admin billing console:      |              | |
+|  |  | plan/mode/usage/invoices/   |  | per-tenant subs/MRR, catalog|              | |
+|  |  | payment/wallet/dunning      |  | sync, webhook/recon health  |              | |
+|  |  +-----------------------------+  +-----------------------------+              | |
+|  |       + 35-12: billing audit, reconciliation & revenue analytics              | |
+|  +------------------------------------------------------------------------------+ |
+|                                                                                   |
+|  All mutations emit DCB PlatformEvents (BILLING.*) via IEventRepository.AppendAsync |
++-----------------------------------------------------------------------------------+
+```
+
+## Key Technical Decisions
+
+### Stripe SDK in C# (`Stripe.net`)
+
+Billing uses the **`Stripe.net`** NuGet package (latest stable) registered in `Tamma.Api`, not the
+TypeScript `stripe` package the deleted Epic 20 used. Stripe access is wrapped behind an
+`IBillingProvider` seam (`StripeBillingProvider` for SaaS, `NullBillingProvider` for single-user) so
+the rest of the codebase never references the SDK directly. **Research the latest `Stripe.net` API
+surface** (`Billing.MeterService`, `Billing.MeterEvents`, `RequestOptions.IdempotencyKey`) before
+writing any call — do not assume method shapes.
+
+### Stripe Billing Meters for usage
+
+Usage is reported through **Stripe Billing Meters** (modern meter-event API), not the legacy usage
+records API. Three meters are seeded by Story 35-1's `seed-billing` command:
+`tamma.platform_tokens_input` (SUM), `tamma.platform_tokens_output` (SUM), and `tamma.seats`
+(LAST/gauge). Token counts are integers, so meter `value` payloads are whole-number strings. Events
+are pre-aggregated to one event per tenant-per-meter-per-period and batch-flushed (default 60s),
+keeping us orders of magnitude under Stripe's ~1,000 events/sec limit.
+
+### BYOK excluded from billable metering
+
+The hard rule: **only `billing_mode = platform` usage becomes a Stripe token meter event.** BYOK
+usage is recorded on the rollup (`Byok*` counters) for analytics but is *never* buffered as a token
+meter event and is exempt from token quotas. BYOK status flows from the **Epic 29 secret cabinet**
+(tenant supplied its own provider key) and is recorded on `BillingCustomer.BillingMode` (35-2). A
+missing `billing_mode` tag is treated as `platform` and WARN-logged so a wiring gap surfaces as
+revenue, not silent zeroing.
+
+### Derive usage from durable facts (don't capture on the hot path)
+
+Rather than hook the LLM call path to enqueue a meter event per call, metering **recomputes rollups
+from already-persisted facts** (DCB `LLM.CALL.*` events + `ProviderDiagnostic`/`PlatformAnalyticsHourly`
+cost substrate). This is idempotent (recompute = same answer), resilient (a worker crash loses
+nothing — facts are durable), and **fail-open for billing** — a Stripe/pricing failure never blocks
+an LLM call or a tenant workflow.
+
+### Webhook idempotency
+
+Stripe webhooks (Story 35-5) are signature-verified with the cabinet-sourced signing secret and
+processed **exactly once**: each `stripe_event_id` is recorded in a control-plane table with a unique
+constraint, so a redelivered webhook is a no-op. Verified events are projected into the local billing
+mirror and re-emitted as DCB `BILLING.*` events for the audit trail. Outbound mutating Stripe calls
+use **deterministic idempotency keys** (e.g. `billing-customer-{tenantId}`,
+`{tenantId}:{period}:{eventName}`) so retries never mint duplicate Stripe objects or double-bill.
+
+### Control-plane resident, per-mode, per-tenant isolated
+
+All billing state lives on the `ControlPlaneDbContext` keyed by `tenant_id` (one query answers "what
+does every tenant owe"). RBAC and ownership follow the CLAUDE.md per-mode model: SaaS read =
+`member`, manage = `tenant_owner`/`tenant_admin`; single-user = the sole user with no Stripe at all.
+A tenant resolves its own billing data from the ambient `ITenantContext` (never a route param), and
+cross-tenant isolation is asserted by dedicated tests.
+
+## Supersedes Epic 20
+
+Epic 35 replaces the deleted TypeScript **Epic 20: Billing & Payments for Tamma SaaS** (which lived in
+the now-removed `packages/api` on Fastify + the `stripe` npm package). The plan/pricing and
+usage-limit *model* concerns were split out to **Epic 34 (Pricing, Plans & Entitlements)**; the Stripe
+integration, metering, subscriptions, invoicing, dunning, and dashboards moved to **Epic 35** on the
+C# stack. The mapping:
+
+| Epic 20 (deleted TS, `packages/api`) | Replacement | Notes |
+|--------------------------------------|-------------|-------|
+| **20-1** Stripe Integration & Plan Model | **35-1** (Stripe integration foundation, customer mapping, billing plan catalog) **+ Epic 34-1** (plan & price-book data model) | Stripe-side foundation → 35-1 (C#, `Stripe.net`, cabinet-sourced key). The **plan/price model** → Epic 34's typed catalog (replaces the opaque `Plan.Quotas` JSON). |
+| **20-2** Subscription Management | **35-4** (subscription lifecycle: create/upgrade/downgrade/cancel/trial/proration) **+ 35-5** (webhook ingestion & event projection) | Subscription CRUD + checkout → 35-4; the Stripe webhook handler is promoted to its own hardened, idempotent story 35-5. |
+| **20-3** Usage Metering | **35-3** (BYOK-aware usage metering & Stripe meter event reporting) | Re-targeted to C# Billing Meters with the new **BYOK split** (platform metered + priced, BYOK counters-only) and derive-from-durable-facts design; pricing math delegated to Epic 34-5. |
+| **20-4** Usage Limits Enforcement | **35-6** (plan quota & usage-limit enforcement, BYOK-aware) **+ Epic 34** (entitlement/quota model) | Enforcement mechanism → 35-6 (BYOK exempt from token quotas); the quota/entitlement *model* → Epic 34's typed `PlanEntitlement` rows. |
+| **20-5** Billing Dashboard | **35-11** (tenant billing dashboard `dashboard-user` + admin billing console `dashboard`) | Re-targeted to the two React dashboards; reads existing 35-x endpoints only (no business logic in React). |
+| *(new in Epic 35, no Epic 20 equivalent)* | **35-7** portal/payment methods · **35-8** invoicing & dunning · **35-9** tax · **35-10** credits wallet · **35-12** billing audit/reconciliation/revenue analytics | Production-grade capabilities the TS epic never reached. |
+
+> **Do not reference `packages/api`** — it is deleted and is where the stale Epic 20 lived. All Epic 35
+> work lands in `apps/tamma-elsa` (C#) and the two dashboards (`packages/dashboard-user`,
+> `packages/dashboard`).
+
+## Dependencies
+
+### On other epics
+
+- **Epic 28** — control plane: `Tenant`/`Plan` entities, `ControlPlaneDbContext`,
+  `PlatformQueuedTask` + `IPlatformTaskHandler` / `TaskQueueProcessor`, `OrgEndpoints`/`AuthEndpoints`
+  tenant-create paths, `ITammaModeProvider`, schema-per-tenant tenancy.
+- **Epic 29** — secret cabinet: `ISecretStore`/`ISecretStoreBackend`/`IRuntimeSecretResolver`,
+  `SecretScope.Platform`, `SecretPurpose.ApiKey`/`Webhook` (Stripe secret key + webhook signing
+  secret; per-tenant BYOK provider keys that drive `BillingMode`).
+- **Epic 34** — pricing model layer: the plan/price-book catalog, typed `PlanEntitlement` quotas, and
+  the cost→price margin engine `IUsagePricingEngine` (35-3 calls it; 35-6 reads entitlements; 35-1
+  maps `Plan.Slug` → Stripe ids). **Epic 35 charges against Epic 34; it never re-implements pricing.**
+- **Epic 4** — DCB events: `DomainEvent`/`PlatformEvent`, `IEventRepository.AppendAsync` (the
+  `BILLING.*` audit trail; reconciliation/dunning events feed `AlertRuleEvaluator`).
+- **Epic 5 / 23 / 28-10** — `PlatformAnalyticsHourly` CP fact table (the metering aggregation source;
+  35-3 needs a `billing_mode` token split).
+- **Epic 9 / 32-9** — `ProviderDiagnostic` cost substrate + per-call usage/cost-basis events.
+
+### External
+
+- **`Stripe.net`** NuGet package (latest stable) — added to `Tamma.Api.csproj`.
+- **Stripe account** with test + live keys, Billing Meters and Stripe Tax enabled.
+- **Stripe Dashboard** product/price/meter configuration, seeded idempotently via `seed-billing`.
+
+## Database Schema (control-plane, `ControlPlaneDbContext`)
+
+All billing tables are control-plane resident and keyed by `tenant_id`. Sketch (authoritative
+column lists live in each story's `Technical Design`):
+
+```sql
+-- 35-1: tenant -> Stripe customer mapping + billing mode
+CREATE TABLE billing_customers (
+  "Id"               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "TenantId"         UUID NOT NULL UNIQUE REFERENCES tenants("Id") ON DELETE CASCADE,
+  "StripeCustomerId" TEXT,                                   -- null until Stripe acks (retry path)
+  "BillingMode"      TEXT NOT NULL DEFAULT 'PlatformProvided'
+                       CHECK ("BillingMode" IN ('PlatformProvided','Byok')),
+  "DefaultCurrency"  TEXT NOT NULL DEFAULT 'usd',
+  "TaxStatus"        TEXT NOT NULL DEFAULT 'none',           -- none | taxable | reverse_charge
+  "CreatedAt"        TIMESTAMPTZ NOT NULL,
+  "UpdatedAt"        TIMESTAMPTZ NOT NULL
+);
+CREATE UNIQUE INDEX ix_billing_customers_stripe
+  ON billing_customers ("StripeCustomerId") WHERE "StripeCustomerId" IS NOT NULL;
+
+-- 35-1: Stripe id catalog per plan slug (NOT overloading Plan.Quotas; platform-global)
+CREATE TABLE billing_plan_prices (
+  "Id"                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "PlanSlug"             TEXT NOT NULL UNIQUE,                -- free | team | enterprise
+  "StripeProductId"      TEXT,
+  "StripePriceId"        TEXT,                                -- base (flat seat/platform) price
+  "TokensInputMeterId"   TEXT, "TokensInputPriceId"  TEXT,
+  "TokensOutputMeterId"  TEXT, "TokensOutputPriceId" TEXT,
+  "SeatsMeterId"         TEXT, "SeatsPriceId"         TEXT,
+  "CreatedAt"            TIMESTAMPTZ NOT NULL,
+  "UpdatedAt"            TIMESTAMPTZ NOT NULL
+);
+
+-- 35-4: subscription mirror (lifecycle state projected from Stripe webhooks)
+CREATE TABLE billing_subscriptions (
+  "Id"                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "TenantId"              UUID NOT NULL REFERENCES tenants("Id") ON DELETE CASCADE,
+  "StripeSubscriptionId"  TEXT UNIQUE,
+  "PlanSlug"              TEXT NOT NULL,
+  "Status"                TEXT NOT NULL,                      -- trialing|active|past_due|canceled|...
+  "CurrentPeriodStart"    TIMESTAMPTZ,
+  "CurrentPeriodEnd"      TIMESTAMPTZ,
+  "CancelAtPeriodEnd"     BOOLEAN NOT NULL DEFAULT false,
+  "TrialEnd"              TIMESTAMPTZ,
+  "DunningStage"          TEXT,                               -- 35-8: null|past_due|grace|suspended
+  "CreatedAt"             TIMESTAMPTZ NOT NULL,
+  "UpdatedAt"             TIMESTAMPTZ NOT NULL
+);
+
+-- 35-3: per-tenant per-period usage rollup (token split by billing mode)
+CREATE TABLE billing_usage_rollup (
+  "Id"                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "TenantId"             UUID NOT NULL REFERENCES tenants("Id") ON DELETE CASCADE,
+  "PeriodStart"          TIMESTAMPTZ NOT NULL,
+  "PeriodEnd"            TIMESTAMPTZ NOT NULL,
+  "PlatformInputTokens"  BIGINT NOT NULL DEFAULT 0,
+  "PlatformOutputTokens" BIGINT NOT NULL DEFAULT 0,
+  "ByokInputTokens"      BIGINT NOT NULL DEFAULT 0,          -- analytics only; never metered
+  "ByokOutputTokens"     BIGINT NOT NULL DEFAULT 0,
+  "PlatformCostUsd"      NUMERIC(20,4) NOT NULL DEFAULT 0,   -- cost basis (no markup)
+  "BillableAmountUsd"    NUMERIC(20,4) NOT NULL DEFAULT 0,   -- from Epic 34 IUsagePricingEngine
+  "Seats"                INTEGER NOT NULL DEFAULT 0,
+  "LastSourceCursor"     BIGINT NOT NULL DEFAULT 0,          -- incremental recompute watermark
+  "UpdatedAt"            TIMESTAMPTZ NOT NULL,
+  CONSTRAINT uq_billing_usage_rollup_period UNIQUE ("TenantId","PeriodStart")
+);
+
+-- 35-3: pending Stripe meter events (buffered, idempotent flush)
+CREATE TABLE billing_meter_event_buffer (
+  "Id"               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "TenantId"         UUID NOT NULL REFERENCES tenants("Id") ON DELETE CASCADE,
+  "StripeCustomerId" TEXT NOT NULL,
+  "EventName"        TEXT NOT NULL,                          -- tamma.platform_tokens_input|output
+  "Value"            TEXT NOT NULL,                          -- whole-number string per Stripe
+  "IdempotencyKey"   TEXT NOT NULL UNIQUE,                   -- {tenantId}:{period}:{eventName}
+  "ReportedToStripe" BOOLEAN NOT NULL DEFAULT false,
+  "StripeEventId"    TEXT,
+  "AttemptCount"     INTEGER NOT NULL DEFAULT 0,
+  "LastAttemptAt"    TIMESTAMPTZ,
+  "CreatedAt"        TIMESTAMPTZ NOT NULL
+);
+
+-- 35-8: invoice mirror (PDF bytes always served by Stripe, not Tamma)
+CREATE TABLE billing_invoices (
+  "Id"                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "TenantId"          UUID NOT NULL REFERENCES tenants("Id") ON DELETE CASCADE,
+  "StripeInvoiceId"   TEXT UNIQUE,
+  "Status"            TEXT NOT NULL,                          -- draft|open|paid|uncollectible|void
+  "AmountDueUsd"      NUMERIC(20,4),
+  "AmountPaidUsd"     NUMERIC(20,4),
+  "PeriodStart"       TIMESTAMPTZ, "PeriodEnd" TIMESTAMPTZ,
+  "HostedInvoiceUrl"  TEXT, "PdfUrl" TEXT,
+  "AttemptCount"      INTEGER NOT NULL DEFAULT 0,             -- dunning
+  "CreatedAt"         TIMESTAMPTZ NOT NULL,
+  "UpdatedAt"         TIMESTAMPTZ NOT NULL
+);
+
+-- 35-5: webhook idempotency + raw projection log
+CREATE TABLE billing_webhook_events (
+  "Id"             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "StripeEventId"  TEXT NOT NULL UNIQUE,                      -- exactly-once guard
+  "TenantId"       UUID,                                      -- resolved from customer mapping
+  "EventType"      TEXT NOT NULL,
+  "Payload"        JSONB NOT NULL,
+  "ProcessedAt"    TIMESTAMPTZ
+);
+
+-- 35-10: prepaid credits wallet ledger (append-only; balance is derived)
+CREATE TABLE billing_wallet_ledger (
+  "Id"             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "TenantId"       UUID NOT NULL REFERENCES tenants("Id") ON DELETE CASCADE,
+  "EntryType"      TEXT NOT NULL,                             -- topup|consume|refund|adjust|promo
+  "AmountUsd"      NUMERIC(20,4) NOT NULL,                    -- signed
+  "StripeRef"      TEXT,                                      -- PaymentIntent / charge id
+  "Description"    TEXT,
+  "CreatedAt"      TIMESTAMPTZ NOT NULL
+);
+```
+
+> EF Core migrations land under `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/`;
+> `dotnet ef migrations has-pending-model-changes` must report none after each migration.
+
+## Implementation Phases
+
+### Phase 1: Stripe Foundation & Billing Mode (35-1, 35-2)
+Stripe.net registration, cabinet-sourced keys, `BillingCustomer` mapping on tenant-create, the
+`billing_plan_prices` catalog + `seed-billing` command, three Billing Meters, and BYOK-vs-platform
+mode resolution from the Epic 29 cabinet. **Est. 7-9 days.**
+
+### Phase 2: Subscriptions, Webhooks & Metering (35-4, 35-5, 35-3)
+Subscription lifecycle (create/trial/upgrade/downgrade/cancel/proration), hardened idempotent webhook
+ingestion + event projection, and BYOK-aware usage metering (rollup → buffered meter events →
+batch flush → reconciliation). **Est. 13-16 days.**
+
+### Phase 3: Enforcement, Invoicing & Dunning (35-6, 35-8)
+Pre-dispatch quota enforcement (BYOK exempt from token quotas) and the invoice mirror + failed-payment
+dunning ladder (`past_due` → `grace` → `suspended`) with recovery. **Est. 7-9 days.**
+
+### Phase 4: Tax, Portal, Payment Methods & Wallet (35-9, 35-7, 35-10)
+Stripe Tax / VAT calculation and tax-id collection, self-service Stripe Billing Portal + payment-method
+mirror, and the prepaid credits wallet ledger with top-up. **Est. 10-13 days.**
+
+### Phase 5: Dashboards & Analytics (35-11, 35-12)
+Tenant billing area (`dashboard-user`) + admin billing console (`dashboard`), and billing audit,
+Stripe↔local reconciliation, and revenue analytics. **Est. 8-10 days.**
+
+## Success Metrics
+
+- 100% of SaaS tenants have exactly one `BillingCustomer` row (unique `TenantId`) within 1 minute of
+  signup; `seed-billing` is idempotent (second run = 0 Stripe create calls).
+- Single-user boot makes **0 Stripe SDK calls** (asserted by tests via `NullBillingProvider`).
+- Platform-provided usage meter events delivered to Stripe within 120 seconds of the flush cycle;
+  **0 BYOK token meter events** ever emitted (asserted).
+- Quota enforcement blocks over-quota dispatch within 500ms (p99); BYOK tenants are never blocked on
+  token quotas.
+- Webhook processing is exactly-once (redelivery is a no-op) with p95 latency < 2s.
+- Local↔Stripe usage/revenue reconciliation drift stays within tolerance; any drift raises
+  `BILLING.USAGE.RECONCILIATION_MISMATCH` (zero silent revenue loss).
+- Dunning recovers failed payments through the `past_due`/`grace`/`suspended` ladder with full DCB
+  audit; tenant and admin billing dashboards load within 1 second (p95).
+
+## Reference Documents
+
+- Epic 34 (Pricing, Plans & Entitlements): `docs/stories/epic-34/README.md`
+- Epic 35 stories: `docs/stories/epic-35/story-35-1/` … `story-35-12/`
+- [Stripe Billing Meters API](https://docs.stripe.com/api/billing/meter)
+- [Stripe Meter Events API](https://docs.stripe.com/api/billing/meter-event)
+- [Stripe Subscriptions](https://docs.stripe.com/billing/subscriptions/overview)
+- [Stripe Customer / Billing Portal](https://docs.stripe.com/customer-management/integrate-customer-portal)
+- [Stripe Webhooks](https://docs.stripe.com/webhooks)
+- [Stripe Tax](https://docs.stripe.com/tax)
+- [Stripe.net (.NET SDK)](https://github.com/stripe/stripe-dotnet)
+
+---
+
+**Last Updated**: 2026-06-17

--- a/docs/stories/epic-35/story-35-1/35-1-stripe-integration-foundation-billing-plan-catalog-and-custo.md
+++ b/docs/stories/epic-35/story-35-1/35-1-stripe-integration-foundation-billing-plan-catalog-and-custo.md
@@ -1,0 +1,388 @@
+# Story 35-1: Stripe Integration Foundation, Billing Plan Catalog & Customer Mapping (C#)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-phase workflow (Read → Research → Break Down → TDD → Quality Gates → Failure Handling), `.dev/` knowledge-base usage (spikes, bugs, findings, decisions), TRACE/DEBUG logging requirements, the test-first (TDD) mandate, and the build-success / coverage gates.
+
+## User Story
+
+As a **platform owner** running Tamma in SaaS mode,
+I want each tenant mapped to a Stripe customer and a billing plan catalog that maps every `Plan.Slug` to Stripe Product/Price/Meter ids — wired through the Epic 29 secret cabinet, never raw env,
+So that downstream billing stories (subscriptions, metering, invoicing, dunning) have a stable customer-to-Stripe binding and a single source of truth for prices, while single-user deployments incur zero Stripe coupling.
+
+## Priority
+
+P0 - Foundational. Every other Epic 35 story (subscriptions 35-2, BYOK-aware metering 35-3, invoicing, dunning, portal, credits) depends on the `BillingCustomer` mapping and the `billing_plan_prices` catalog created here.
+
+## Acceptance Criteria
+
+1. A new control-plane entity `BillingCustomer` is added at `apps/tamma-elsa/src/Tamma.Data/Entities/BillingCustomer.cs` with: `Id` (Guid PK), `TenantId` (Guid, **unique** FK to `tenants.Id`), `StripeCustomerId` (string, nullable until Stripe ack), `BillingMode` (enum `BillingMode { PlatformProvided, Byok }` persisted as text), `DefaultCurrency` (string, ISO-4217, default `usd`), `TaxStatus` (string, e.g. `none`/`taxable`/`reverse_charge`), `CreatedAt`, `UpdatedAt`. Registered as `DbSet<BillingCustomer> BillingCustomers` on `ControlPlaneDbContext` and configured in `TammaModelConfiguration.ConfigureControlPlaneEntities` (table `billing_customers`, unique index on `TenantId`, FK to `tenants`, CHECK constraint on `BillingMode` text domain).
+
+2. A new control-plane entity `BillingPlanPrice` is added at `apps/tamma-elsa/src/Tamma.Data/Entities/BillingPlanPrice.cs` mapping a `PlanSlug` (`free`/`team`/`enterprise`) to `StripeProductId`, base `StripePriceId`, and per-meter metered price ids (`TokensInputPriceId`, `TokensOutputPriceId`, `SeatsPriceId`) plus the three meter ids (`TokensInputMeterId`, `TokensOutputMeterId`, `SeatsMeterId`). Stored in a `billing_plan_prices` table — it does **NOT** overload `Plan.Quotas` or `Plan.PlacementPolicy` (those remain tenancy-placement concerns per `Plan.cs`). Unique index on `PlanSlug`.
+
+3. An EF Core migration is added under `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/` creating both tables (plus snapshot update). `dotnet ef migrations has-pending-model-changes` reports none after the migration; `Update` then `Remove`/down applies and rolls back cleanly.
+
+4. An `IBillingProvider` seam (`apps/tamma-elsa/src/Tamma.Api/Services/Billing/IBillingProvider.cs`) exposes `CreateCustomerAsync(Guid tenantId, CustomerDescriptor)`, `SyncCatalogAsync(CancellationToken)`, and `IsEnabled` — implemented by `StripeBillingProvider` (SaaS) and `NullBillingProvider` (single-user no-op).
+
+5. The Stripe **secret key** and **webhook signing secret** resolve via the Epic 29 cabinet — `ISecretStore` / `ISecretStoreBackend` reads of platform-scoped rows (`SecretScope.Platform`, `SecretPurpose.ApiKey` for the API key, `SecretPurpose.Webhook` for the signing secret), accessed at runtime through the established `IRuntimeSecretResolver` pattern (cabinet name e.g. `billing/stripe-secret-key`). In production (`!IsDevelopment`) billing **refuses to boot** if the Stripe key is present only as a raw `IConfiguration`/env value with no cabinet row (fail-fast, mirroring `RuntimeSecretResolver` Story 29-10 semantics).
+
+6. On tenant creation (the `OrgEndpoints.CreateOrg` path at `apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs:57`, and the registration path that creates a tenant in `AuthEndpoints`), a Stripe Customer is created and the `BillingCustomer` row is persisted **within the same control-plane transaction** as the `TENANT.CREATED.SUCCESS` emission. If the Stripe API call fails, tenant creation is **not** blocked: a `billing.customer.create` retry is enqueued as a `PlatformQueuedTask` (handled by a new `IPlatformTaskHandler`) and the `BillingCustomer` row persists with `StripeCustomerId = null`.
+
+7. A CLI seed command (`dotnet run --project Tamma.Api -- seed-billing`, dispatched in `Program.cs` alongside the existing `migrate-secrets` command at `Program.cs:1143`) idempotently creates/updates Stripe Products, base Prices, three metered Prices, and **three Billing Meters** — `tamma.platform_tokens_input` (SUM), `tamma.platform_tokens_output` (SUM), `tamma.seats` (LAST/gauge) — and writes their ids into `billing_plan_prices`. Re-running the command is a no-op (existing ids are reused via Stripe idempotency keys + lookup-by-stored-id).
+
+8. The seed command and the customer-create path both emit DCB events to `DomainEvent` via `IEventRepository.AppendAsync`: `BILLING.PLAN_CATALOG.SYNCED` (tags `{ planSlug, source: "seed" }`) on a successful catalog sync, and `BILLING.CUSTOMER.CREATED` (tags `{ tenantId, stripeCustomerId, billingMode }`, `TenantId` set) on customer creation. Event types follow the `AGGREGATE.ACTION.STATUS` convention.
+
+9. In **single-user mode** (`ITammaModeProvider.Mode == TammaMode.SingleUser` — no `Tamma:TenantSharedSecret` / `ConnectionStrings:ControlPlane`), `NullBillingProvider` is registered: zero Stripe SDK calls are made, the tenant-create hook is a no-op (no `BillingCustomer` row, no event), and the billing endpoints / seed command short-circuit with a clear "billing is SaaS-only" message.
+
+10. `BillingMode` defaults to `PlatformProvided`; a tenant flagged BYOK (provider keys supplied by the tenant) is recorded as `Byok` so 35-3 metering can suppress token markup. This story only stores the flag and defaults it — it does **not** implement metering or markup suppression (Story 35-3 boundary).
+
+11. RBAC is enforced per CLAUDE.md per-mode ownership: in SaaS, the seed command and any admin billing-catalog read are `OwnerAccess` (platform-owner only); the customer-create hook runs as a system operation inside the tenant-create transaction (no extra caller permission). No tenant-facing endpoint is added in this story.
+
+12. Tenant isolation: `BillingCustomer` is keyed by `TenantId` with a unique constraint; a second create attempt for the same tenant resolves the existing row (no duplicate Stripe customer). The catalog (`billing_plan_prices`) is platform-global (keyed by `PlanSlug`, not tenant) and is never exposed cross-tenant.
+
+13. Stripe SDK calls use idempotency keys (`Stripe.RequestOptions.IdempotencyKey`) derived deterministically (`billing-customer-{tenantId}`, `billing-catalog-{planSlug}-{resource}`) so retries never mint duplicate Stripe objects.
+
+14. Unit tests (xUnit, `tests/Tamma.Api.Tests/Billing/`) cover: catalog slug→price mapping, idempotent seed (second run = no new Stripe calls / no row churn), customer-create-on-tenant-create with the Stripe SDK mocked, the `PlatformQueuedTask` retry enqueue on Stripe failure, and the single-user `NullBillingProvider` no-op seam. Tenant-isolation test asserts one `BillingCustomer` per tenant.
+
+15. Logging follows the project standard: INFO on customer created / catalog synced (counts), WARN on Stripe failure → retry enqueued, ERROR on production boot with no cabinet key; **Stripe secret key, webhook secret, and customer payment details are NEVER logged**.
+
+## Technical Design
+
+### Namespace / file structure
+
+```
+apps/tamma-elsa/src/Tamma.Data/
+  Entities/
+    BillingCustomer.cs              # NEW — control-plane entity (TenantId-unique)
+    BillingPlanPrice.cs             # NEW — control-plane catalog row (PlanSlug-keyed)
+  ControlPlaneDbContext.cs          # MODIFY — add DbSet<BillingCustomer>, DbSet<BillingPlanPrice>
+  TammaModelConfiguration.cs        # MODIFY — ConfigureControlPlaneEntities: tables, indexes, CHECKs, FK
+  Migrations/ControlPlane/
+    <ts>_AddBillingCustomerAndPlanPrices.cs        # NEW (+ .Designer.cs + snapshot update)
+  Seeders/
+    BillingSeeder.cs                # NEW — idempotent Stripe Product/Price/Meter sync + row upsert
+
+apps/tamma-elsa/src/Tamma.Core/
+  Billing/BillingMode.cs            # NEW — enum { PlatformProvided, Byok } (Core: shared enum)
+
+apps/tamma-elsa/src/Tamma.Api/
+  Services/Billing/
+    IBillingProvider.cs             # NEW — create-customer / sync-catalog / IsEnabled seam
+    StripeBillingProvider.cs        # NEW — Stripe.net implementation (SaaS)
+    NullBillingProvider.cs          # NEW — single-user no-op
+    IBillingCatalog.cs              # NEW — read-side: resolve BillingPlanPrice by slug (cached)
+    BillingCatalog.cs               # NEW — EF-backed catalog reader
+    StripeClientFactory.cs          # NEW — builds Stripe.StripeClient from cabinet-resolved key
+    BillingOptions.cs               # NEW — bound config (cabinet names, default currency)
+    SeedBillingCommand.cs           # NEW — CLI dispatch (mirrors MigrateSecretsCommand)
+  Services/Billing/Tasks/
+    CreateBillingCustomerTaskHandler.cs  # NEW — IPlatformTaskHandler retry seam
+    CreateBillingCustomerTaskPayload.cs  # NEW
+  Extensions/
+    BillingServiceCollectionExtensions.cs  # NEW — AddTammaBilling(mode-aware DI)
+  Endpoints/OrgEndpoints.cs         # MODIFY — invoke IBillingProvider.CreateCustomerAsync in tenant-create txn
+  Endpoints/AuthEndpoints.cs        # MODIFY — same hook on registration tenant-create path
+  Program.cs                        # MODIFY — AddTammaBilling(); seed-billing CLI dispatch
+```
+
+> **Why `AdminTenantsEndpoints.cs` is NOT the create path.** The spec listed `AdminTenantsEndpoints.cs`, but inspection shows it is the *lifecycle* manager (list/detail/retry/delete/change-plan, `OwnerAccess`) — it does not run `new Tenant`. The actual create sites are `OrgEndpoints.CreateOrg` (`OrgEndpoints.cs:57`) and the registration path in `AuthEndpoints` (`AuthEndpoints.cs:275`). The hook lands there. If a future admin-initiated tenant-create lands in `AdminTenantsEndpoints`, the same `IBillingProvider.CreateCustomerAsync` call is added there too.
+
+### Key entity signatures
+
+```csharp
+// Tamma.Core/Billing/BillingMode.cs
+namespace Tamma.Core.Billing;
+public enum BillingMode { PlatformProvided, Byok }
+
+// Tamma.Data/Entities/BillingCustomer.cs
+namespace Tamma.Data.Entities;
+public class BillingCustomer
+{
+    public Guid Id { get; set; }
+    public Guid TenantId { get; set; }                 // unique FK -> tenants.Id
+    public string? StripeCustomerId { get; set; }      // null until Stripe acks (retry path)
+    public string BillingMode { get; set; } = "PlatformProvided"; // text domain; CHECK-constrained
+    public string DefaultCurrency { get; set; } = "usd";
+    public string TaxStatus { get; set; } = "none";
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public Tenant? Tenant { get; set; }
+}
+
+// Tamma.Data/Entities/BillingPlanPrice.cs
+namespace Tamma.Data.Entities;
+public class BillingPlanPrice
+{
+    public Guid Id { get; set; }
+    public string PlanSlug { get; set; } = null!;      // free | team | enterprise (unique)
+    public string? StripeProductId { get; set; }
+    public string? StripePriceId { get; set; }         // base (flat seat/platform) price
+    public string? TokensInputMeterId { get; set; }
+    public string? TokensInputPriceId { get; set; }
+    public string? TokensOutputMeterId { get; set; }
+    public string? TokensOutputPriceId { get; set; }
+    public string? SeatsMeterId { get; set; }
+    public string? SeatsPriceId { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}
+```
+
+### EF model configuration sketch (`TammaModelConfiguration.ConfigureControlPlaneEntities`)
+
+```csharp
+modelBuilder.Entity<BillingCustomer>(entity =>
+{
+    entity.ToTable("billing_customers", t =>
+        t.HasCheckConstraint("ck_billing_customers_mode",
+            "\"BillingMode\" IN ('PlatformProvided','Byok')"));
+    entity.HasKey(e => e.Id);
+    entity.HasIndex(e => e.TenantId).IsUnique();
+    entity.HasIndex(e => e.StripeCustomerId).IsUnique()
+        .HasFilter("\"StripeCustomerId\" IS NOT NULL");
+    entity.HasOne(e => e.Tenant).WithMany()
+        .HasForeignKey(e => e.TenantId).OnDelete(DeleteBehavior.Cascade);
+});
+
+modelBuilder.Entity<BillingPlanPrice>(entity =>
+{
+    entity.ToTable("billing_plan_prices");
+    entity.HasKey(e => e.Id);
+    entity.HasIndex(e => e.PlanSlug).IsUnique();
+});
+```
+
+### EF migration sketch
+
+`dotnet ef migrations add AddBillingCustomerAndPlanPrices --context ControlPlaneDbContext --output-dir Migrations/ControlPlane` produces an additive migration:
+
+```csharp
+migrationBuilder.CreateTable(name: "billing_customers", columns: table => new {
+    Id = table.Column<Guid>(nullable: false),
+    TenantId = table.Column<Guid>(nullable: false),
+    StripeCustomerId = table.Column<string>(nullable: true),
+    BillingMode = table.Column<string>(nullable: false, defaultValue: "PlatformProvided"),
+    DefaultCurrency = table.Column<string>(nullable: false, defaultValue: "usd"),
+    TaxStatus = table.Column<string>(nullable: false, defaultValue: "none"),
+    CreatedAt = table.Column<DateTime>(nullable: false),
+    UpdatedAt = table.Column<DateTime>(nullable: false),
+}, constraints: table => {
+    table.PrimaryKey("PK_billing_customers", x => x.Id);
+    table.CheckConstraint("ck_billing_customers_mode",
+        "\"BillingMode\" IN ('PlatformProvided','Byok')");
+    table.ForeignKey("FK_billing_customers_tenants_TenantId",
+        x => x.TenantId, "tenants", "Id", onDelete: ReferentialAction.Cascade);
+});
+migrationBuilder.CreateIndex("IX_billing_customers_TenantId", "billing_customers",
+    "TenantId", unique: true);
+// + billing_plan_prices table, unique IX on PlanSlug
+```
+
+### Billing provider seam
+
+```csharp
+// Services/Billing/IBillingProvider.cs
+public interface IBillingProvider
+{
+    bool IsEnabled { get; }                                  // false for NullBillingProvider
+    Task<BillingCustomer> CreateCustomerAsync(
+        Guid tenantId, CustomerDescriptor descriptor, CancellationToken ct = default);
+    Task<CatalogSyncResult> SyncCatalogAsync(CancellationToken ct = default);
+}
+
+public sealed record CustomerDescriptor(
+    string TenantName, string TenantSlug, string? OwnerEmail, BillingMode Mode);
+```
+
+`StripeBillingProvider` resolves the Stripe key via `IRuntimeSecretResolver.GetAsync("billing/stripe-secret-key")`, builds a `Stripe.StripeClient`, and uses `Stripe.CustomerService` / `ProductService` / `PriceService` / `Billing.MeterService`. Every mutating call passes a deterministic `RequestOptions.IdempotencyKey`. `NullBillingProvider` returns `IsEnabled = false` and throws/`no-ops` on the mutating calls.
+
+### Tenant-create hook (same transaction as `TENANT.CREATED.SUCCESS`)
+
+In `OrgEndpoints.CreateOrg`, after `provisioning.ProvisionAsync(tenant.Id)` and before/with `EmitTenantEvent(...,"TENANT.CREATED.SUCCESS",...)`:
+
+```csharp
+if (billing.IsEnabled)
+{
+    try
+    {
+        var bc = await billing.CreateCustomerAsync(
+            tenant.Id,
+            new CustomerDescriptor(tenant.Name, tenant.Slug, ownerEmail, BillingMode.PlatformProvided),
+            ct);
+        await events.AppendAsync(BillingEvents.CustomerCreated(tenant.Id, bc.StripeCustomerId, bc.BillingMode));
+    }
+    catch (Exception ex) // Stripe unreachable / rate-limited
+    {
+        // Persist row with null StripeCustomerId + enqueue retry; DO NOT block tenant creation.
+        await platformTasks.EnqueueAsync(new PlatformQueuedTask {
+            Type = CreateBillingCustomerTaskHandler.TaskTypeName, // "billing.customer.create"
+            TenantId = tenant.Id,
+            Payload = JsonSerializer.Serialize(new CreateBillingCustomerTaskPayload(tenant.Id)),
+        });
+        logger.LogWarning(ex, "Stripe customer create failed for tenant {TenantId}; enqueued retry", tenant.Id);
+    }
+}
+```
+
+`CreateBillingCustomerTaskHandler : IPlatformTaskHandler` (`TaskType = "billing.customer.create"`) re-drives `CreateCustomerAsync`, fills `StripeCustomerId`, and emits `BILLING.CUSTOMER.CREATED`. A malformed payload throws `PlatformTaskTerminalException`; a transient Stripe error throws normally so the worker retries per its budget.
+
+### DCB event names
+
+| Event | When | Tags | `TenantId` |
+|---|---|---|---|
+| `BILLING.CUSTOMER.CREATED` | Stripe customer created + row persisted | `{ tenantId, stripeCustomerId, billingMode }` | set |
+| `BILLING.PLAN_CATALOG.SYNCED` | `seed-billing` finishes a slug's catalog sync | `{ planSlug, source: "seed" }` | null (platform) |
+
+Emitted via `IEventRepository.AppendAsync(new DomainEvent { Type=..., Tags=..., Metadata="""{"workflowVersion":"1.0.0","eventSource":"system"}""", Data=... })`, matching the `OrgEndpoints.EmitTenantEvent` shape. A `BillingEvents` static helper builds the rows. (These CP-resident events are what the Story 5.6 `AlertRuleEvaluator` can later observe; no alert rule is added in this story.)
+
+### API / CLI shape
+
+- No new HTTP endpoints for tenants in this story. The customer mapping is a side effect of the existing tenant-create endpoints.
+- `seed-billing` CLI: `dotnet run --project apps/tamma-elsa/src/Tamma.Api -- seed-billing` → runs `SeedBillingCommand.RunAsync(app.Services)` before the HTTP pipeline binds, prints a per-slug report (`product/price/meter ids created or reused`), exits with code 0/1. In single-user mode it prints "billing is SaaS-only" and exits 0.
+
+### Per-mode + per-tenant handling
+
+| Concern | single-user | SaaS |
+|---|---|---|
+| Provider registered | `NullBillingProvider` (`IsEnabled=false`) | `StripeBillingProvider` |
+| Tenant-create hook | no-op (no row, no event) | creates customer + row + event in the create txn |
+| Stripe key source | n/a | cabinet `billing/stripe-secret-key` (`SecretScope.Platform`, `SecretPurpose.ApiKey`); prod fail-fast if absent |
+| Seed command | prints SaaS-only, exits 0 | runs catalog sync (`OwnerAccess` when triggered via any future admin route) |
+| Catalog ownership | n/a | platform-global, `OwnerAccess` |
+| `BillingCustomer` ownership | n/a | one row per tenant (unique `TenantId`); never cross-tenant |
+
+## Dependencies
+
+**Internal (prerequisite):**
+- Epic 28 — control plane, `Tenant`/`Plan` entities, `ControlPlaneDbContext`, `PlatformQueuedTask` + `IPlatformTaskHandler` worker, `OrgEndpoints`/`AuthEndpoints` tenant-create paths, `ITammaModeProvider`.
+- Epic 29 — secret cabinet (`ISecretStore`, `ISecretStoreBackend`, `IRuntimeSecretResolver`, `SecretScope.Platform`, `SecretPurpose.ApiKey`/`Webhook`).
+- Epic 4 — DCB events (`DomainEvent`, `IEventRepository.AppendAsync`).
+
+**Internal (blocks):**
+- Story 35-2 (subscription lifecycle — needs `BillingCustomer` + base price ids).
+- Story 35-3 (BYOK-aware metering — needs the three meters + `BillingMode`).
+- Invoicing / dunning / portal / credits stories (need the customer mapping + catalog).
+
+**External:**
+- `Stripe.net` NuGet package (latest stable; add to `Tamma.Api.csproj`). Research latest API surface (`Billing.MeterService`, `RequestOptions.IdempotencyKey`) before coding — do not assume method shapes.
+- A Stripe account with test + live keys; Billing Meters enabled (on by default).
+
+## Testing Strategy
+
+**Unit (xUnit, `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/`):**
+1. `BillingCatalogTests` — slug→`BillingPlanPrice` resolution, unknown slug throws, cache hit.
+2. `BillingSeederTests` — first run creates products/prices/meters (mocked Stripe service interfaces) and writes ids; second run finds existing ids and makes zero create calls, no row churn; emits one `BILLING.PLAN_CATALOG.SYNCED` per slug.
+3. `StripeBillingProviderTests` — `CreateCustomerAsync` calls Stripe `CustomerService.CreateAsync` with the deterministic idempotency key, persists `BillingCustomer`, returns mapped row; duplicate tenant returns existing row (no second Stripe call).
+4. `CreateBillingCustomerTaskHandlerTests` — handler re-drives create on a `PlatformQueuedTask`, fills `StripeCustomerId`, emits `BILLING.CUSTOMER.CREATED`; malformed payload → `PlatformTaskTerminalException`; transient Stripe error rethrows (retry).
+5. `NullBillingProviderTests` — `IsEnabled=false`; tenant-create hook makes no Stripe calls and writes no row.
+6. `BillingSecretBootTests` — production env + cabinet key absent → boot throws; cabinet key present → boots.
+
+**Integration (`apps/tamma-elsa/tests/Tamma.Api.Tests`, docker-bound via `sg docker -c "dotnet test ..."`):**
+7. Migration applies + rolls back on a real Postgres CP DB; `has-pending-model-changes` reports none.
+8. Tenant-create through `OrgEndpoints.CreateOrg` (Stripe mocked) yields exactly one `BillingCustomer` row and one `BILLING.CUSTOMER.CREATED` event in `DomainEvents`.
+9. **Tenant isolation** — creating two tenants yields two distinct `BillingCustomer` rows; re-running create for the same tenant does not insert a second row (unique `TenantId`); a tenant's row is never returned to a different tenant context.
+
+**Mocks:** Stripe SDK is mocked at the `CustomerService`/`ProductService`/`PriceService`/`Billing.MeterService` interface boundary (no live Stripe in CI). `IRuntimeSecretResolver` stubbed to return a fake key. Live-Stripe integration is opt-in behind `STRIPE_SECRET_KEY_TEST` and excluded from default CI.
+
+## Estimated Effort
+
+4-5 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Core/Billing/BillingMode.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/BillingCustomer.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/BillingPlanPrice.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (add 2 DbSets) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (entity config) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_AddBillingCustomerAndPlanPrices.cs` | Create (+ Designer + snapshot) |
+| `apps/tamma-elsa/src/Tamma.Data/Seeders/BillingSeeder.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/IBillingProvider.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/StripeBillingProvider.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/NullBillingProvider.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/IBillingCatalog.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingCatalog.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/StripeClientFactory.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingOptions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingEvents.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/SeedBillingCommand.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/Tasks/CreateBillingCustomerTaskHandler.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/Tasks/CreateBillingCustomerTaskPayload.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/BillingServiceCollectionExtensions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs` | Modify (customer-create hook) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AuthEndpoints.cs` | Modify (customer-create hook) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (AddTammaBilling + seed-billing CLI dispatch) |
+| `apps/tamma-elsa/src/Tamma.Api/Tamma.Api.csproj` | Modify (add Stripe.net) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingCatalogTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingSeederTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/StripeBillingProviderTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/CreateBillingCustomerTaskHandlerTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/NullBillingProviderTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingTenantCreateIntegrationTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing, ensure you have:
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md).
+2. Searched `.dev/` for billing/Stripe/secret-cabinet spikes, bugs, findings, decisions.
+3. Reviewed the Epic 29 secret cabinet contracts (`ISecretStore`, `IRuntimeSecretResolver`, `SecretScope`, `SecretPurpose`) and the `PlatformQueuedTask` worker.
+4. **Researched the latest Stripe.net API** (Products, Prices, `Billing.MeterService`, `RequestOptions.IdempotencyKey`) via current docs before writing any SDK call — do not assume method names.
+5. Planned the TDD (Red-Green-Refactor) cycle for every new type.
+
+### Key Design Decisions
+
+- **Catalog is a separate table, not `Plan` columns.** `Plan.Quotas`/`Plan.PlacementPolicy` are tenancy-placement concerns (see `Plan.cs` doc-comment); Stripe ids are a billing concern keyed by `PlanSlug`. Overloading `Plan` would couple placement to Stripe.
+- **`BillingMode` lives in `Tamma.Core`** so both Data (text column) and Api (provider) reference one enum.
+- **Secret resolution reuses the Epic 29 cabinet seam, not a bespoke reader.** `IRuntimeSecretResolver` already implements cabinet-first + dev-only-fallback + prod fail-fast — exactly the AC5 requirement. Do not re-implement.
+- **The create path is `OrgEndpoints`/`AuthEndpoints`, not `AdminTenantsEndpoints`** (the latter is lifecycle-only — verified). See the callout in Technical Design.
+- **Non-blocking customer create** uses the existing `PlatformQueuedTask` + `IPlatformTaskHandler` worker for retries — no new queue infrastructure.
+- **Idempotency everywhere**: deterministic Stripe idempotency keys + lookup-by-stored-id make the seed and the customer-create safe to re-run.
+
+### Boundary Notes (do not implement sibling-story scope)
+
+- No subscriptions, no checkout, no webhook *ingestion* endpoint (35-2 / later — this story only stores the webhook signing secret reference).
+- No usage metering, no token markup, no BYOK suppression logic (35-3) — only the `BillingMode` flag + default.
+- No invoicing, dunning, tax computation, billing portal, or credits wallet (later stories).
+- No tenant-facing billing UI (later stories).
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Stripe outage blocks tenant creation | High | Non-blocking hook → `PlatformQueuedTask` retry; row persists with null `StripeCustomerId`. |
+| Duplicate Stripe customers/products on retry | Medium | Deterministic idempotency keys + unique `TenantId`/`PlanSlug` constraints + lookup-by-stored-id. |
+| Stripe.net API drift vs assumptions | Medium | Research latest docs before coding; mock at service-interface boundary. |
+| Raw env key in production | High | AC5 prod fail-fast via `IRuntimeSecretResolver` (Story 29-10 semantics). |
+| Single-user accidental Stripe coupling | Medium | `NullBillingProvider` registered by mode; tests assert zero SDK calls. |
+
+### Success Metrics
+
+- [ ] Every SaaS tenant has exactly one `BillingCustomer` row (unique `TenantId`).
+- [ ] `seed-billing` is idempotent: second run = 0 Stripe create calls.
+- [ ] Single-user boot makes 0 Stripe calls (asserted in tests).
+- [ ] Migration applies + rolls back; `has-pending-model-changes` = none.
+
+## Logging Requirements
+
+- **INFO**: `BillingCustomer` created (`tenantId`, `stripeCustomerId` presence boolean), catalog synced (`planSlug`, counts of created/reused resources), seed command summary.
+- **DEBUG**: each Stripe SDK call issued (resource type, idempotency key — never the value), cabinet key resolved (boolean found, never the value).
+- **WARN**: Stripe customer-create failure → retry enqueued (`tenantId`, error class), seed reused-existing on re-run.
+- **ERROR**: production boot with no cabinet Stripe key, unrecoverable seed failure, `PlatformQueuedTask` dead-lettered.
+- **Structured context**: include `{ tenantId, planSlug, billingMode, idempotencyKey }` where applicable.
+- **Credential safety**: NEVER log the Stripe secret key, webhook signing secret, or any customer payment details.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-35/story-35-10/35-10-credits-and-prepaid-wallet-ledger.md
+++ b/docs/stories/epic-35/story-35-10/35-10-credits-and-prepaid-wallet-ledger.md
@@ -1,0 +1,450 @@
+# Story 35-10: Credits & Prepaid Wallet Ledger
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-Phase Development Workflow (Read → Research → Break Down → TDD → Quality Gates → Failure Handling), the `.dev/` knowledge-base usage rules (spikes, bugs, findings, decisions), TRACE/DEBUG logging requirements, the Test-Driven Development workflow, and the build-success / 100%-critical-path coverage gates. Failure to follow this process will result in rework.
+
+## User Story
+
+As a **tenant_owner or tenant_admin** of a SaaS Tamma tenant,
+I want a prepaid credits wallet whose balance is derived from an append-only, double-entry-style ledger (grants, Stripe top-ups, consumption against invoices, expirations, refunds) and is automatically applied to my invoices before my card is charged,
+So that I can hold promotional/support credits or prepaid balance, see exactly where every cent went, and reduce or eliminate card charges — while BYOK tenants can still offset the platform/seat fee and platform-provided tenants can additionally offset metered token charges.
+
+## Priority
+
+P2 - Monetization quality-of-life. Builds on the foundation (35-1), webhook ingestion (35-5), and invoicing (35-8) backbones; not required for the first paying tenant but required for promo credits, prepaid plans, and support goodwill.
+
+## Acceptance Criteria
+
+1. A new append-only control-plane entity `BillingWalletLedger` (`apps/tamma-elsa/src/Tamma.Data/Entities/BillingWalletLedger.cs`, `DbSet<BillingWalletLedger> BillingWalletLedger` on `ControlPlaneDbContext`, configured in `TammaModelConfiguration.ConfigureControlPlaneEntities`, table `billing_wallet_ledger`) records one immutable row per ledger entry with columns: `Id` (Guid PK), `TenantId` (Guid FK → `tenants.Id`, indexed), `EntryType` (text, CHECK-constrained to `grant|topup|consume|expire|refund|adjustment`), `AmountUsd` (`numeric(12,4)`; positive credits the balance for `grant`/`topup`/`refund`, negative debits for `consume`/`expire`, signed for `adjustment`), `BalanceAfter` (`numeric(12,4)`; the derived running balance snapshot computed inside the same serialized transaction that appends the row), `Reference` (text, nullable — `invoiceId`/`usage period`/`promo code`/Stripe `payment_intent` id), `ReferenceKind` (text, nullable — `invoice|payment_intent|promo|usage_period|grant`), `ExpiresAt` (`timestamptz`, nullable — only meaningful for `grant`/`topup` lots), `IdempotencyKey` (text, nullable, **UNIQUE NULLS NOT DISTINCT**), `Note` (text, nullable), `CreatedBy` (Guid, nullable — admin/user who issued a grant), `CreatedAt` (`timestamptz`). **Rows are never UPDATEd or DELETEd** — corrections are new `adjustment`/`refund`/`expire` rows. The current balance is always derived as `SUM(AmountUsd)` per tenant (or read from the latest row's `BalanceAfter`), never stored mutably on the tenant.
+
+2. `POST /api/v1/billing/wallet/topup` (tenant route under `/api/v1/orgs/{tenantId}/...` gated by `RequireTenantMembershipFilter`; tenant_owner/tenant_admin only — `member` → 403) creates a Stripe **one-time** `PaymentIntent` for the requested USD amount via the Story 35-1 `IBillingProvider`/Stripe client (resolved through the Epic 29 cabinet), tagged with metadata `{ tenantId, purpose: "wallet_topup" }`, and returns the PaymentIntent `client_secret` to the caller. **No ledger row is written at intent-creation time** — the credit lands only when the payment actually succeeds (AC3).
+
+3. On `payment_intent.succeeded` for a wallet-topup PaymentIntent, the Story 35-5 `IBillingEventHandler` registry routes to a new `WalletTopupWebhookHandler` (registered via `services.AddBillingEventHandler<WalletTopupWebhookHandler>()`), which appends a `topup` ledger entry **idempotently keyed by the Stripe `payment_intent` id** (`IdempotencyKey = "topup:{paymentIntentId}"`); a duplicate webhook delivery (Stripe at-least-once) collides on the UNIQUE index and is a no-op. The handler emits `BILLING.CREDIT.TOPPED_UP`. Non-wallet PaymentIntents (e.g. invoice payment) are ignored by this handler (no metadata `purpose: "wallet_topup"` → skip).
+
+4. Available (non-expired) credit is applied to a tenant's invoice **before the card is charged**, inside the Story 35-8 invoice finalize path: a new `WalletCreditService.ApplyToInvoiceAsync(...)` is invoked from the `invoice.finalized` projection (35-8's `InvoiceWebhookHandler` / `InvoiceService`) before the invoice transitions to charge. The applied amount is `min(availableBalance, invoiceAmountDue)`, recorded as (a) a Stripe invoice **credit line item / customer balance transaction** so Stripe charges the reduced amount, and (b) a `consume` ledger entry with `Reference = invoiceId`, `ReferenceKind = "invoice"`, `IdempotencyKey = "consume:{invoiceId}"` (idempotent against re-finalization / webhook replay). The handler emits `BILLING.CREDIT.CONSUMED`.
+
+5. An admin grant endpoint `POST /api/v1/admin/billing/wallet/{tenantId}/grant` (policy `PlatformOwnerAccess` — platform-owner only) issues promotional/support credits: body `{ amountUsd, expiresAt?, note?, promoCode? }`, appends a `grant` ledger entry (`IdempotencyKey = "grant:{guid}"` minted server-side or `"promo:{promoCode}:{tenantId}"` when a promo code is supplied so the same promo is not double-granted), and emits `BILLING.CREDIT.GRANTED` with `CreatedBy` = the platform admin. Negative grants are rejected (use the adjustment path).
+
+6. `GET /api/v1/orgs/{tenantId}/billing/wallet` (tenant_owner/tenant_admin/**member-read**, behind `RequireTenantMembershipFilter`) returns `{ balanceUsd, availableUsd, expiringSoonUsd, currency }` plus a paged ledger history (`entries[]` with `entryType`, `amountUsd`, `balanceAfter`, `reference`, `referenceKind`, `expiresAt`, `createdAt`; default page 50, max 200, most-recent first). `availableUsd` excludes already-expired lots. An admin read `GET /api/v1/admin/billing/wallet/{tenantId}` (`PlatformOwnerAccess`) returns the same shape for any tenant.
+
+6b. RBAC follows CLAUDE.md per-mode ownership: in **SaaS** the tenant wallet is owned by `tenant_owner`/`tenant_admin` (top-up + read), `member` is read-only (403 on `topup`); grants/adjustments are platform-owner-only (`PlatformOwnerAccess`). In **single-user** mode there is no Stripe wiring (Story 35-1 `NullBillingProvider`); the wallet routes are **not mapped** and the credit-application hook is a no-op (matching 35-1 AC9 / 35-5 AC13).
+
+7. Credit application is **atomic and race-safe** (no double-spend) under concurrent invoice finalization for the same tenant: `WalletCreditService.ApplyToInvoiceAsync` runs inside a `Serializable` (or `pg_advisory_xact_lock(hashtextextended(tenantId, 0))`-guarded) control-plane transaction that re-reads the live balance, computes `BalanceAfter`, and appends the `consume` row in one unit — two concurrent finalizations for the same tenant cannot both spend the same dollar. The `consume` `IdempotencyKey` UNIQUE index is the second line of defence (one consume per invoice).
+
+8. An expired credit lot is swept by a scheduled `PlatformQueuedTask` (`Type = "billing.wallet.expire_sweep"`, handled by a new `WalletExpirySweepTaskHandler : IPlatformTaskHandler` on the existing `PlatformTaskWorker`): for each `grant`/`topup` lot whose `ExpiresAt < now` and whose remaining (unconsumed) balance is positive, it appends an `expire` ledger entry (negative `AmountUsd`, `Reference` = the originating lot id, `ReferenceKind = "grant"`, `IdempotencyKey = "expire:{lotId}"`) reducing the balance, and emits `BILLING.CREDIT.EXPIRED`. The sweep is idempotent (an already-swept lot collides on the UNIQUE key and is skipped).
+
+9. Refunds: when a wallet top-up is refunded (`charge.refunded` / `payment_intent` reversal surfaced by 35-5, or an admin-initiated `POST /api/v1/admin/billing/wallet/{tenantId}/refund` with `PlatformOwnerAccess`), a `refund` ledger entry (negative `AmountUsd`, `Reference` = the refunded `payment_intent`/`charge` id, `IdempotencyKey = "refund:{chargeId}"`) is appended and `BILLING.CREDIT.REFUNDED` emitted. A refund cannot drive the balance below zero (clamp + WARN log if it would).
+
+10. DCB events are emitted via `IEventRepository.AppendAsync(DomainEvent)` (CP store, `AGGREGATE.ACTION.STATUS`): `BILLING.CREDIT.GRANTED`, `BILLING.CREDIT.TOPPED_UP`, `BILLING.CREDIT.CONSUMED`, `BILLING.CREDIT.EXPIRED`, `BILLING.CREDIT.REFUNDED`, each with `TenantId` set and JSONB `tags = { tenantId, amountUsd, balanceAfter, reference, entryType }` and `Metadata = { "workflowVersion": "1.0.0", "eventSource": "system" }`. (These CP-resident events are visible to the Story 5.6 `AlertRuleEvaluator` for free — no alert rule is added here.)
+
+11. Tenant isolation: every ledger read/write filters `tenant_id = {tenantId}`; the tenant routes are behind `RequireTenantMembershipFilter` (cross-tenant 404), and `availableUsd`/balance are computed per tenant. A wallet entry for tenant A is never returned to tenant B and never offsets tenant B's invoice.
+
+12. An EF Core migration under `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/` adds the `billing_wallet_ledger` table (plus snapshot update). `dotnet ef migrations has-pending-model-changes` reports none after the migration; `Update` then down/`Remove` applies and rolls back cleanly. Entity config lives **only** in `TammaModelConfiguration` (the established single source).
+
+13. Unit + integration tests (xUnit, `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/`) cover: ledger append + derived-balance correctness across all six entry types; idempotent top-up (duplicate `payment_intent.succeeded` → one `topup` row); credit-before-card application in the finalize path (`min(balance, amountDue)`, Stripe credit line + `consume` row); **double-spend prevention** under concurrent finalization (two parallel applies for one tenant never over-spend); expiry sweep (expired lot → one `expire` row, idempotent re-run); admin grant RBAC (`PlatformOwnerAccess` only; promo double-grant blocked); tenant top-up/read RBAC (`member` 403 on top-up, read OK); single-user no-op seam; and tenant isolation.
+
+14. Logging follows the project standard: INFO on grant/top-up/consume/expire/refund (tenantId, entryType, amountUsd, balanceAfter); WARN on refund-would-go-negative clamp, sweep skip-on-collision; ERROR on Stripe PaymentIntent failure and migration/transaction failure. **Stripe secret key, `client_secret`, `payment_intent` secrets, and customer payment details are NEVER logged.**
+
+## Technical Design
+
+### C# namespace / file structure
+
+```
+apps/tamma-elsa/src/Tamma.Data/
+  Entities/
+    BillingWalletLedger.cs              # NEW — append-only ledger row (CP, TenantId-keyed)
+  ControlPlaneDbContext.cs             # MODIFY — add DbSet<BillingWalletLedger>
+  TammaModelConfiguration.cs           # MODIFY — table/indexes/CHECK/FK/unique-idempotency
+  Migrations/ControlPlane/
+    <ts>_AddBillingWalletLedger.cs     # NEW (+ .Designer.cs + snapshot update)
+  Repositories/
+    IWalletLedgerRepository.cs         # NEW — append + balance + paged history (CP)
+    WalletLedgerRepository.cs          # NEW — EF-backed, serialized append
+
+apps/tamma-elsa/src/Tamma.Api/
+  Services/Billing/
+    IWalletService.cs                  # NEW — top-up intent + grant + refund + read seam
+    WalletService.cs                   # NEW — orchestrates Stripe PaymentIntent + ledger
+    IWalletCreditService.cs            # NEW — invoice credit-application seam (35-8 consumes)
+    WalletCreditService.cs             # NEW — atomic min(balance, amountDue) apply + consume
+    WalletEventTypes.cs                # NEW — BILLING.CREDIT.* DCB type constants
+    Handlers/
+      WalletTopupWebhookHandler.cs     # NEW — IBillingEventHandler (payment_intent.succeeded)
+      WalletRefundWebhookHandler.cs    # NEW — IBillingEventHandler (charge.refunded)
+    Tasks/
+      WalletExpirySweepTaskHandler.cs  # NEW — IPlatformTaskHandler (billing.wallet.expire_sweep)
+      WalletExpirySweepScheduler.cs    # NEW — BackgroundService enqueues the sweep task
+  Endpoints/Billing/
+    WalletEndpoints.cs                 # NEW — tenant (top-up/read) + admin (grant/refund/read)
+  Extensions/
+    WalletServiceCollectionExtensions.cs # NEW — AddTammaWallet(mode-gated DI)
+  Program.cs                           # MODIFY — AddTammaWallet(); map routes (SaaS-gated)
+```
+
+> **Stripe.net** is already on `Tamma.Api.csproj` (added by Story 35-1). 35-10 consumes `Stripe.PaymentIntentService` (one-time top-up), `Stripe.CustomerBalanceTransactionService` / invoice credit, and the typed `Stripe.PaymentIntent` / `Stripe.Charge` event objects already delivered by 35-5.
+
+> **Boundary callout — `InvoiceService.cs` is owned by Story 35-8.** The spec listed `apps/tamma-elsa/src/Tamma.Api/Services/Billing/InvoiceService.cs` as a primary component for 35-10. Inspection of the epic shows the invoice mirror (`BillingInvoice`/`BillingInvoiceLine`) and the finalize path are 35-8's responsibility. 35-10 therefore exposes `IWalletCreditService.ApplyToInvoiceAsync` and 35-8's `InvoiceWebhookHandler`/`InvoiceService` **calls it** at finalize — 35-10 does not create or own the invoice entities. If 35-8 lands first, the call site is a one-line injection of `IWalletCreditService`; if 35-10 lands first, the seam is published and 35-8 wires it. This story modifies `InvoiceService.cs` only to add that single call site (a documented integration hook), never the invoice entity/mirror logic.
+
+### Key entity signature
+
+```csharp
+// Tamma.Data/Entities/BillingWalletLedger.cs
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Append-only, double-entry-style prepaid-credit ledger row (control plane).
+/// Rows are NEVER updated or deleted — corrections are new adjustment/refund/
+/// expire rows. Balance is derived (SUM(AmountUsd) per tenant) or read from the
+/// latest row's BalanceAfter; it is never stored mutably on the tenant.
+/// </summary>
+public class BillingWalletLedger
+{
+    public Guid Id { get; set; }
+    public Guid TenantId { get; set; }                  // FK -> tenants.Id (indexed)
+    public string EntryType { get; set; } = null!;      // grant|topup|consume|expire|refund|adjustment (CHECK)
+    public decimal AmountUsd { get; set; }              // signed; + credits, - debits
+    public decimal BalanceAfter { get; set; }           // running balance snapshot (serialized append)
+    public string? Reference { get; set; }              // invoiceId | payment_intent | promo | usage period | lot id
+    public string? ReferenceKind { get; set; }          // invoice|payment_intent|promo|usage_period|grant
+    public DateTime? ExpiresAt { get; set; }            // only for grant/topup lots
+    public string? IdempotencyKey { get; set; }         // UNIQUE NULLS NOT DISTINCT
+    public string? Note { get; set; }
+    public Guid? CreatedBy { get; set; }                // admin/user for grants
+    public DateTime CreatedAt { get; set; }
+    public Tenant? Tenant { get; set; }
+}
+```
+
+### EF model configuration sketch (`TammaModelConfiguration.ConfigureControlPlaneEntities`)
+
+```csharp
+modelBuilder.Entity<BillingWalletLedger>(entity =>
+{
+    entity.ToTable("billing_wallet_ledger", t =>
+        t.HasCheckConstraint("ck_billing_wallet_ledger_type",
+            "\"EntryType\" IN ('grant','topup','consume','expire','refund','adjustment')"));
+    entity.HasKey(e => e.Id);
+    entity.Property(e => e.AmountUsd).HasColumnType("numeric(12,4)");
+    entity.Property(e => e.BalanceAfter).HasColumnType("numeric(12,4)");
+    entity.HasIndex(e => new { e.TenantId, e.CreatedAt });
+    entity.HasIndex(e => e.IdempotencyKey)
+        .IsUnique()
+        .HasFilter("\"IdempotencyKey\" IS NOT NULL"); // UNIQUE NULLS NOT DISTINCT semantics
+    // sweep query: open lots with an expiry
+    entity.HasIndex(e => new { e.TenantId, e.ExpiresAt })
+        .HasFilter("\"ExpiresAt\" IS NOT NULL AND \"EntryType\" IN ('grant','topup')");
+    entity.HasOne(e => e.Tenant).WithMany()
+        .HasForeignKey(e => e.TenantId).OnDelete(DeleteBehavior.Cascade);
+});
+```
+
+### EF migration sketch (`dotnet ef migrations add AddBillingWalletLedger --context ControlPlaneDbContext --output-dir Migrations/ControlPlane`)
+
+```sql
+CREATE TABLE billing_wallet_ledger (
+    id               UUID PRIMARY KEY,
+    tenant_id        UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    entry_type       TEXT NOT NULL,
+    amount_usd       NUMERIC(12,4) NOT NULL,
+    balance_after    NUMERIC(12,4) NOT NULL,
+    reference        TEXT NULL,
+    reference_kind   TEXT NULL,
+    expires_at       TIMESTAMPTZ NULL,
+    idempotency_key  TEXT NULL,
+    note             TEXT NULL,
+    created_by       UUID NULL,
+    created_at       TIMESTAMPTZ NOT NULL,
+    CONSTRAINT ck_billing_wallet_ledger_type
+        CHECK (entry_type IN ('grant','topup','consume','expire','refund','adjustment'))
+);
+CREATE INDEX ix_wallet_ledger_tenant_created ON billing_wallet_ledger (tenant_id, created_at DESC);
+CREATE UNIQUE INDEX ux_wallet_ledger_idem ON billing_wallet_ledger (idempotency_key)
+    WHERE idempotency_key IS NOT NULL;
+CREATE INDEX ix_wallet_ledger_open_lots ON billing_wallet_ledger (tenant_id, expires_at)
+    WHERE expires_at IS NOT NULL AND entry_type IN ('grant','topup');
+```
+
+After adding, run `dotnet ef migrations has-pending-model-changes` → expect none (entity config in `TammaModelConfiguration` only).
+
+### Repository seam — `IWalletLedgerRepository`
+
+```csharp
+namespace Tamma.Data.Repositories;
+
+public interface IWalletLedgerRepository
+{
+    /// Serialized append: re-reads live balance, computes BalanceAfter, inserts the row,
+    /// all under pg_advisory_xact_lock(hashtextextended(tenantId,0)) + Serializable.
+    /// Returns the persisted row. A unique-idempotency-key collision returns the EXISTING
+    /// row (idempotent no-op) instead of throwing.
+    Task<BillingWalletLedger> AppendAsync(BillingWalletLedger entry, CancellationToken ct = default);
+
+    /// Live balance = SUM(AmountUsd) for the tenant (NOT excluding expiry — that is "available").
+    Task<decimal> GetBalanceAsync(Guid tenantId, CancellationToken ct = default);
+
+    /// Available = balance minus the remaining of any lot whose ExpiresAt < now and not yet swept.
+    Task<WalletBalanceView> GetBalanceViewAsync(Guid tenantId, DateTime now, CancellationToken ct = default);
+
+    Task<(IReadOnlyList<BillingWalletLedger> Entries, int Total)> ListAsync(
+        Guid tenantId, int limit, int offset, CancellationToken ct = default);
+
+    /// Open (unconsumed) lots past expiry across all tenants — drives the sweep.
+    Task<IReadOnlyList<WalletExpiredLot>> FindExpiredLotsAsync(DateTime now, int batch, CancellationToken ct = default);
+}
+
+public sealed record WalletBalanceView(decimal BalanceUsd, decimal AvailableUsd, decimal ExpiringSoonUsd);
+public sealed record WalletExpiredLot(Guid TenantId, Guid LotId, decimal RemainingUsd, DateTime ExpiresAt);
+```
+
+`AppendAsync` is the single race-safe write path. Every service (`WalletService`, `WalletCreditService`, the webhook + sweep handlers) appends through it — `BalanceAfter` is therefore always correct because it is computed under the per-tenant advisory lock inside one transaction (AC1, AC7). The advisory-lock + `Serializable` pattern mirrors `TenantMoveService` (`pg_try_advisory_lock(hashtextextended(@tid, 0))`, `TenantMoveService.cs:871`).
+
+### Service seams
+
+```csharp
+// Services/Billing/IWalletService.cs
+public interface IWalletService
+{
+    Task<TopupIntentResult> CreateTopupIntentAsync(Guid tenantId, decimal amountUsd, CancellationToken ct = default);
+    Task<BillingWalletLedger> GrantAsync(Guid tenantId, decimal amountUsd, DateTime? expiresAt,
+        string? note, string? promoCode, Guid grantedBy, CancellationToken ct = default);
+    Task<BillingWalletLedger> RefundAsync(Guid tenantId, string chargeOrIntentId, decimal amountUsd,
+        Guid refundedBy, CancellationToken ct = default);
+    Task<WalletDto> GetWalletAsync(Guid tenantId, int limit, int offset, CancellationToken ct = default);
+}
+public sealed record TopupIntentResult(string PaymentIntentId, string ClientSecret, decimal AmountUsd);
+
+// Services/Billing/IWalletCreditService.cs  (consumed by Story 35-8 InvoiceService finalize)
+public interface IWalletCreditService
+{
+    /// Apply min(availableBalance, amountDueUsd) to the invoice as a Stripe credit + a 'consume'
+    /// ledger row, atomically (serialized per tenant). Idempotent by invoiceId. Returns applied USD.
+    Task<decimal> ApplyToInvoiceAsync(Guid tenantId, string invoiceId, string stripeCustomerId,
+        decimal amountDueUsd, CancellationToken ct = default);
+}
+```
+
+`WalletService.CreateTopupIntentAsync` builds a Stripe `PaymentIntent` (`PaymentIntentService.CreateAsync`) for `amountUsd` with `Metadata = { tenantId, purpose = "wallet_topup" }`, deterministic `RequestOptions.IdempotencyKey = "topup-intent-{tenantId}-{amount}-{minuteBucket}"`, and **writes no ledger row** (the credit lands on `payment_intent.succeeded`). `WalletCreditService.ApplyToInvoiceAsync` reduces what Stripe will charge via a customer-balance credit / negative invoice line, then appends the `consume` row through `IWalletLedgerRepository.AppendAsync` with `IdempotencyKey = "consume:{invoiceId}"`.
+
+### Webhook handlers (Story 35-5 `IBillingEventHandler` seam)
+
+```csharp
+// Services/Billing/Handlers/WalletTopupWebhookHandler.cs
+public sealed class WalletTopupWebhookHandler : IBillingEventHandler
+{
+    public IReadOnlyCollection<string> HandledEventTypes => new[] { "payment_intent.succeeded" };
+
+    public async Task<BillingFollowup?> HandleAsync(BillingWebhookContext ctx, CancellationToken ct)
+    {
+        var pi = (Stripe.PaymentIntent)ctx.StripeEvent.Data.Object;
+        if (pi.Metadata is null ||
+            !pi.Metadata.TryGetValue("purpose", out var purpose) || purpose != "wallet_topup")
+            return null; // not a wallet top-up — leave for other handlers / NullBillingEventHandler
+
+        await _ledger.AppendAsync(new BillingWalletLedger {
+            TenantId = ctx.TenantId, EntryType = "topup",
+            AmountUsd = pi.AmountReceived / 100m,           // Stripe minor units → USD
+            Reference = pi.Id, ReferenceKind = "payment_intent",
+            IdempotencyKey = $"topup:{pi.Id}",
+        }, ct);
+        await _events.AppendAsync(WalletEvents.ToppedUp(ctx.TenantId, pi.AmountReceived / 100m, pi.Id));
+        return null;
+    }
+}
+```
+
+`WalletRefundWebhookHandler` claims `charge.refunded` and appends a `refund` row keyed `refund:{chargeId}` (only for charges whose originating PaymentIntent metadata is `wallet_topup`). Both are registered through `services.AddBillingEventHandler<T>()` from `WalletServiceCollectionExtensions`. Because 35-5 ships the `NullBillingEventHandler` default, these handlers can be registered and tested independently of 35-8.
+
+### Expiry sweep
+
+`WalletExpirySweepScheduler : BackgroundService` (mode-gated, default daily; `RunOnStartup` gate mirroring `PlatformTaskWorkerOptions`) enqueues a `PlatformQueuedTask { Type = "billing.wallet.expire_sweep" }` via `IPlatformQueuedTaskRepository.EnqueueAsync`. `WalletExpirySweepTaskHandler : IPlatformTaskHandler` (`TaskType = "billing.wallet.expire_sweep"`) calls `IWalletLedgerRepository.FindExpiredLotsAsync(now, batch)` and, per lot, appends an `expire` row (`IdempotencyKey = "expire:{lotId}"`) + emits `BILLING.CREDIT.EXPIRED`. Idempotent: an already-swept lot collides on the unique key (no double-expire). Malformed payload → `PlatformTaskTerminalException`; transient DB error rethrows (worker retry).
+
+### DCB event names (`WalletEventTypes`)
+
+| Event | When | Tags | `TenantId` |
+|---|---|---|---|
+| `BILLING.CREDIT.GRANTED` | admin grant | `{ tenantId, amountUsd, balanceAfter, reference, entryType:"grant" }` | set |
+| `BILLING.CREDIT.TOPPED_UP` | `payment_intent.succeeded` (wallet) | `{ tenantId, amountUsd, balanceAfter, reference:paymentIntentId, entryType:"topup" }` | set |
+| `BILLING.CREDIT.CONSUMED` | invoice finalize credit-apply | `{ tenantId, amountUsd, balanceAfter, reference:invoiceId, entryType:"consume" }` | set |
+| `BILLING.CREDIT.EXPIRED` | sweep | `{ tenantId, amountUsd, balanceAfter, reference:lotId, entryType:"expire" }` | set |
+| `BILLING.CREDIT.REFUNDED` | refund | `{ tenantId, amountUsd, balanceAfter, reference:chargeId, entryType:"refund" }` | set |
+
+All appended via `IEventRepository.AppendAsync(new DomainEvent { Type, TenantId, Tags, Metadata = """{"workflowVersion":"1.0.0","eventSource":"system"}""", Data })`, matching the `OrgEndpoints.EmitTenantEvent` / `BillingEvents` (35-1) shape. A `WalletEvents` static helper builds the rows.
+
+### API shape
+
+```
+# tenant routes (SaaS only; behind RequireTenantMembershipFilter on {tenantId})
+POST /api/v1/orgs/{tenantId}/billing/wallet/topup      (tenant_owner/tenant_admin; member→403)  → { paymentIntentId, clientSecret, amountUsd }
+GET  /api/v1/orgs/{tenantId}/billing/wallet            (tenant_owner/tenant_admin/member-read)   → { balanceUsd, availableUsd, expiringSoonUsd, currency, entries[] }
+
+# admin routes (PlatformOwnerAccess — platform-owner only)
+POST /api/v1/admin/billing/wallet/{tenantId}/grant     body { amountUsd, expiresAt?, note?, promoCode? }
+POST /api/v1/admin/billing/wallet/{tenantId}/refund    body { chargeId, amountUsd? }
+GET  /api/v1/admin/billing/wallet/{tenantId}           (any tenant; same DTO as tenant GET)
+```
+
+Tenant routes are registered in the `app.MapGroup("/api/v1/orgs")` block (Program.cs:1512) with `.AddEndpointFilter<RequireTenantMembershipFilter>()`; mutating tenant routes (top-up) gate `member` out inline via the `RequireTenantAdmin(http, out forbid)` helper pattern (`AlertEndpoints.cs:1008`) reading `HttpContext.Items[RequireTenantMembershipFilter.TenantRoleItemKey]`. Admin routes register under `app.MapGroup("/api/v1/admin")` / `/api/admin` with `.RequireAuthorization("PlatformOwnerAccess")`.
+
+### Per-mode + per-tenant handling
+
+| Concern | single-user mode | SaaS mode |
+|---|---|---|
+| Wallet routes mapped? | No — `NullBillingProvider` (35-1) means no Stripe; tenant + admin wallet routes unmapped. | Yes. |
+| Top-up | N/A | tenant_owner/tenant_admin create a Stripe PaymentIntent; `member` → 403. |
+| Grant / refund / adjustment | N/A | platform-owner only (`PlatformOwnerAccess`). |
+| Credit-apply hook (35-8 finalize) | no-op (`IWalletCreditService` registered as a no-op when billing disabled) | `min(balance, amountDue)` applied before card charge. |
+| Read | N/A | tenant_owner/tenant_admin/member-read scoped to `{tenantId}`; admin can read any tenant. |
+| Ledger ownership | N/A | one ledger stream per `TenantId`; never cross-tenant. |
+| Mode source | `ITammaModeProvider` (`Services/PromptStore/TammaMode.cs`) — process-stable. | same |
+
+### Integration points
+
+- **Story 35-1 foundation** — `BillingCustomer` (tenant ↔ Stripe customer), Stripe.net package + cabinet-resolved Stripe client (`StripeClientFactory`/`IBillingProvider`), `BillingEvents` event-helper precedent, `NullBillingProvider` single-user seam.
+- **Story 35-5 webhook ingestion** — registers `WalletTopupWebhookHandler`/`WalletRefundWebhookHandler` via the `IBillingEventHandler` registry; consumes `BillingWebhookContext` (`Stripe.Event`, resolved `TenantId`, raw payload). 35-10 owns no webhook endpoint.
+- **Story 35-8 invoicing** — 35-8's `InvoiceService`/`InvoiceWebhookHandler` finalize path calls `IWalletCreditService.ApplyToInvoiceAsync` before charge; the applied amount becomes a `credit` invoice line in 35-8's `BillingInvoiceLine` mirror. 35-10 owns the ledger + the credit-apply seam, not the invoice mirror.
+- **Platform task queue (Epic 28)** — `IPlatformQueuedTaskRepository.EnqueueAsync` + a new `IPlatformTaskHandler` (`billing.wallet.expire_sweep`) on the existing `PlatformTaskWorker`.
+- **DCB event store (Epic 4)** — `IEventRepository.AppendAsync` (CP `domain_events`), the store `AlertRuleEvaluator` polls.
+- **Mode + RBAC** — `ITammaModeProvider`, `RequireTenantMembershipFilter` + `RequireTenantAdmin` helper, `PlatformOwnerAccess` policy.
+
+## Dependencies
+
+**Internal:**
+- **Prerequisite — Story 35-1**: `BillingCustomer`, Stripe.net + cabinet Stripe client, `IBillingProvider`/`NullBillingProvider`, `BillingEvents` precedent, single-user no-op.
+- **Prerequisite — Story 35-5**: `IBillingEventHandler` registry + `BillingWebhookContext`; routes top-up/refund webhooks. 35-10 declares a dependency on 35-5.
+- **Prerequisite — Story 35-8**: invoice finalize path (`InvoiceService`/`InvoiceWebhookHandler`) that invokes `IWalletCreditService.ApplyToInvoiceAsync` before card charge; `BillingInvoiceLine` credit line item.
+- **Related — Epic 28**: `PlatformQueuedTask` + `PlatformTaskWorker` for the expiry sweep; `Tenant` FK; `ITammaModeProvider`.
+- **Related — Epic 29**: secret cabinet (Stripe key) via 35-1's `StripeClientFactory`.
+- **Related — Epic 4/5/23**: DCB events feed the alert evaluator / analytics.
+
+**External:**
+- **Stripe.net** SDK (added by 35-1) — `PaymentIntentService` (one-time top-up), `CustomerBalanceTransactionService` / invoice credit, typed `PaymentIntent`/`Charge` event objects.
+- A Stripe account with test + live keys; `STRIPE_SECRET_KEY_TEST` for opt-in live integration tests.
+
+## Testing Strategy
+
+**Unit tests** (`apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/`, xUnit; in-memory/SQLite CP context where determinism allows, real Postgres for the concurrency + serialized-append tests):
+1. **`WalletLedgerRepositoryTests`** — append each entry type; `BalanceAfter` equals running `SUM(AmountUsd)`; `GetBalanceAsync`/`GetBalanceViewAsync` derive correctly; `availableUsd` excludes expired-but-unswept lots; idempotency-key collision returns the existing row (no duplicate, no throw).
+2. **`WalletServiceTests`** — `CreateTopupIntentAsync` calls Stripe `PaymentIntentService.CreateAsync` with `purpose=wallet_topup` metadata + deterministic idempotency key and writes **no** ledger row; `GrantAsync` appends a `grant` row + emits `BILLING.CREDIT.GRANTED`; negative grant rejected; promo double-grant blocked by `promo:{code}:{tenantId}` key.
+3. **`WalletTopupWebhookHandlerTests`** — `payment_intent.succeeded` with `wallet_topup` metadata → one `topup` row (`topup:{pi}` key) + `BILLING.CREDIT.TOPPED_UP`; duplicate delivery → no second row; non-wallet PaymentIntent → handler returns null (no row).
+4. **`WalletCreditServiceTests`** — finalize apply records `min(balance, amountDue)` as a Stripe credit + a `consume` row (`consume:{invoice}` key) + `BILLING.CREDIT.CONSUMED`; zero balance → zero applied, no row; re-finalization (same invoiceId) → no second consume.
+5. **`WalletDoubleSpendTests`** (real Postgres) — seed balance 10 USD; two concurrent `ApplyToInvoiceAsync` for the same tenant against two invoices summing > 10 → total consumed ≤ 10, balance never negative, exactly the right number of `consume` rows; assert the per-tenant advisory lock serializes them.
+6. **`WalletExpirySweepTests`** — expired lot with remaining balance → one `expire` row (`expire:{lot}` key) + `BILLING.CREDIT.EXPIRED`; re-run sweep → no second expire; non-expired lot untouched; fully-consumed expired lot → no expire row (remaining is zero).
+7. **`WalletRefundTests`** — `charge.refunded` for a wallet top-up → `refund` row + `BILLING.CREDIT.REFUNDED`; admin refund endpoint same; refund that would go negative is clamped + WARN.
+8. **`WalletRbacTests`** — tenant `topup` as `member` → 403, as `tenant_admin`/`tenant_owner` → 200; tenant `GET wallet` as `member` → 200 (read); admin `grant`/`refund` requires `PlatformOwnerAccess` (403 for non-platform-admin); cross-tenant route → 404.
+9. **`WalletSingleUserSeamTests`** — single-user mode: wallet routes unmapped (404), `IWalletCreditService` is the no-op, zero Stripe calls.
+
+**Integration tests** (`Tamma.Api.Tests/Billing/` via `WebApplicationFactory`, docker-bound CP Postgres run as `sg docker -c "dotnet test ..."`):
+10. **Migration** applies + rolls back on real Postgres; `has-pending-model-changes` reports none.
+11. **End-to-end top-up** — POST top-up → PaymentIntent (Stripe mocked) → simulate `payment_intent.succeeded` through 35-5's processor → wallet `GET` shows the credited balance + a `topup` entry; replayed webhook → no balance change.
+12. **Credit-before-card** — seed credit, run 35-8 finalize (Stripe mocked) → Stripe charged `amountDue − applied`, `consume` row present, `BILLING.CREDIT.CONSUMED` in `DomainEvents`.
+13. **Tenant isolation** — tenant A's credit never appears in tenant B's `GET wallet`, never offsets tenant B's invoice; two tenants' ledgers are independent.
+
+**Mocks/fixtures**: Stripe is never live in unit tests — mock `PaymentIntentService`/`CustomerBalanceTransactionService` at the service-interface boundary (35-1's `StripeClientFactory` seam) and feed `payment_intent.succeeded`/`charge.refunded` as fixture `Stripe.Event` objects via 35-5's `BillingWebhookContext`. `IEventRepository`, `IPlatformQueuedTaskRepository`, `IWalletLedgerRepository` are faked. Live-Stripe integration is opt-in behind `STRIPE_SECRET_KEY_TEST` and excluded from default CI.
+
+## Estimated Effort
+
+4-5 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/BillingWalletLedger.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (add `DbSet<BillingWalletLedger>`) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (entity config + CHECK + indexes + unique idempotency) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_AddBillingWalletLedger.cs` | Create (+ Designer + snapshot) |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/IWalletLedgerRepository.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/WalletLedgerRepository.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/IWalletService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/WalletService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/IWalletCreditService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/WalletCreditService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/WalletEventTypes.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/WalletEvents.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/Handlers/WalletTopupWebhookHandler.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/Handlers/WalletRefundWebhookHandler.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/Tasks/WalletExpirySweepTaskHandler.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/Tasks/WalletExpirySweepScheduler.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/WalletEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/WalletServiceCollectionExtensions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/InvoiceService.cs` | Modify (35-8) — add `IWalletCreditService.ApplyToInvoiceAsync` call at finalize |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (AddTammaWallet + map routes, SaaS-gated) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/WalletLedgerRepositoryTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/WalletServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/WalletTopupWebhookHandlerTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/WalletCreditServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/WalletDoubleSpendTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/WalletExpirySweepTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/WalletRefundTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/WalletEndpointsTests.cs` | Create (RBAC + isolation) |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md).
+2. Searched `.dev/` for billing/Stripe/ledger/secret-cabinet spikes, bugs, findings, decisions.
+3. Confirmed Story 35-1 (`BillingCustomer`, Stripe.net, `StripeClientFactory`, `NullBillingProvider`) and Story 35-5 (`IBillingEventHandler` registry, `BillingWebhookContext`) are merged. Coordinate with Story 35-8 on the finalize call site.
+4. **Researched the latest Stripe.net API** (`PaymentIntentService.CreateAsync`, customer-balance / invoice credit, `RequestOptions.IdempotencyKey`, minor-unit ⇄ USD conversion) via current docs before writing any SDK call — do not assume method shapes.
+5. Planned the TDD (Red-Green-Refactor) cycle for every new type — tests first per the table above.
+
+### Key Design Decisions
+
+- **Append-only ledger, derived balance.** Per AC1, rows are immutable; balance is `SUM(AmountUsd)` (or the latest `BalanceAfter` snapshot). This is the auditable, time-travel-friendly model the DCB philosophy demands — no mutable `tenant.credit_balance` column that can drift from history.
+- **`BalanceAfter` computed under a per-tenant advisory lock + `Serializable`.** This is the load-bearing double-spend guard (AC7). The lock is `pg_advisory_xact_lock(hashtextextended(tenantId,0))` (same family as `TenantMoveService.cs:871`); the unique idempotency key (`consume:{invoiceId}`, `topup:{pi}`, `expire:{lot}`) is the belt-and-suspenders second line.
+- **Top-up credit lands on `payment_intent.succeeded`, never at intent creation.** A created-but-unpaid PaymentIntent must not credit the wallet — only the 35-5 webhook handler appends the `topup` row, keyed by the PaymentIntent id for at-least-once idempotency (AC2/AC3).
+- **Credit application is a seam (`IWalletCreditService`) that 35-8 calls, not an invoice mirror this story owns.** Honors the epic story boundary; 35-10 owns the ledger + apply logic, 35-8 owns the invoice entity and the finalize state machine.
+- **Stripe-side credit before card charge.** Applying credit as a Stripe customer-balance transaction / negative invoice line means Stripe itself charges the reduced amount — the local ledger and Stripe stay consistent and the card is never over-charged then refunded.
+- **Expiry via the existing `PlatformQueuedTask` worker**, not a bespoke timer — reuses the dead-letter / retry / visibility-timeout machinery (Epic 28).
+- **Single-user is a hard no-op** (`NullBillingProvider` seam from 35-1) — zero Stripe surface, routes unmapped, credit-apply no-op.
+
+### Boundary Notes (do not implement sibling-story scope)
+
+- No invoice mirror (`BillingInvoice`/`BillingInvoiceLine`), no dunning, no invoice finalize state machine — that is Story 35-8. 35-10 only **calls** the finalize hook and contributes the `credit` line amount.
+- No webhook endpoint / signature verification / dedup row — that is Story 35-5. 35-10 only **registers** `IBillingEventHandler` implementations.
+- No Stripe customer mapping / catalog / customer creation — that is Story 35-1.
+- No subscription lifecycle (35-4), no payment-method/portal (35-7), no metering/markup (35-3), no quota enforcement/suspension (35-6).
+- No tenant-facing wallet UI is mandated here; if a dashboard surface is added, it belongs in `packages/dashboard-user` (tenant) and would consume `GET /api/v1/orgs/{tenantId}/billing/wallet` — out of scope for this backend story.
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Double-spend under concurrent invoice finalization | High | `Serializable` + `pg_advisory_xact_lock(tenantId)` serialized append in `IWalletLedgerRepository.AppendAsync`; unique `consume:{invoiceId}` key as backstop; dedicated `WalletDoubleSpendTests` on real Postgres. |
+| Duplicate top-up credit from at-least-once webhooks | High | `topup:{paymentIntentId}` UNIQUE idempotency key; collision returns existing row (no second credit). |
+| Crediting on an unpaid/failed PaymentIntent | High | Ledger row only on `payment_intent.succeeded` via 35-5 handler — never at intent creation. |
+| Stripe ⇄ ledger drift (charge full then refund credit) | Medium | Apply credit as a Stripe customer-balance / negative line **before** charge so Stripe charges the net amount. |
+| Refund driving balance negative | Medium | Clamp to zero + WARN; refund cannot exceed remaining credited-from-that-charge balance. |
+| Expiry sweep double-expiring a lot | Medium | `expire:{lotId}` UNIQUE key; sweep skips collisions; idempotent re-run. |
+| Single-user accidental Stripe coupling | Medium | `NullBillingProvider` seam; routes unmapped; tests assert zero SDK calls. |
+
+### Success Metrics
+
+- [ ] Derived balance always equals `SUM(AmountUsd)` for every tenant (property test across random entry sequences).
+- [ ] Concurrent finalization never over-spends (double-spend test green on real Postgres).
+- [ ] Duplicate top-up / sweep / consume webhooks are exact no-ops (idempotency tests green).
+- [ ] Single-user boot makes 0 Stripe calls; wallet routes return 404.
+- [ ] Migration applies + rolls back; `has-pending-model-changes` = none.
+
+## Logging Requirements
+
+- **INFO**: credit granted / topped-up / consumed / expired / refunded (`tenantId`, `entryType`, `amountUsd`, `balanceAfter`, `reference`); top-up PaymentIntent created (`tenantId`, `amountUsd` — never the `client_secret`); sweep run summary (`lotsExpired`, `totalUsd`).
+- **DEBUG**: ledger append issued (`entryType`, `idempotencyKey`); advisory lock acquired/released (`tenantId`); idempotency-collision no-op (`idempotencyKey`).
+- **WARN**: refund-would-go-negative clamp (`tenantId`, `requestedUsd`, `remainingUsd`); sweep skip-on-collision; promo double-grant blocked.
+- **ERROR**: Stripe PaymentIntent create failure (`tenantId`, error class), serialized-append transaction failure, migration failure, `PlatformQueuedTask` dead-lettered.
+- **Structured context**: include `{ tenantId, entryType, amountUsd, balanceAfter, idempotencyKey, reference }` where applicable.
+- **Credential safety**: NEVER log the Stripe secret key, PaymentIntent `client_secret`, `Stripe-Signature`, or any customer payment details.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-35/story-35-11/35-11-tenant-billing-dashboard-and-admin-billing-console.md
+++ b/docs/stories/epic-35/story-35-11/35-11-tenant-billing-dashboard-and-admin-billing-console.md
@@ -1,0 +1,437 @@
+# Story 35-11: Tenant Billing Dashboard (dashboard-user) & Admin Billing Console (dashboard)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-phase development workflow (Read → Research → Break
+Down → TDD → Quality Gates → Failure Handling), the `.dev/` knowledge-base usage rules,
+TRACE/DEBUG logging requirements, test-driven development, the 100%-critical-path coverage
+target, and build/quality-gate enforcement.
+
+## User Story
+
+As a **tenant admin (SaaS) and as a platform owner**,
+I want a Billing area in the tenant dashboard (`packages/dashboard-user`) and a Billing console
+in the admin dashboard (`packages/dashboard`) that surface my plan, BYOK/platform mode, usage,
+invoices, payment method, wallet balance and dunning state (tenant) and per-tenant
+subscription/MRR, catalog-sync, webhook/reconciliation health and operator actions (admin),
+so that billing is fully self-service through the UI and operators can manage the revenue
+estate without touching Stripe or the database directly.
+
+## Priority
+
+P1 — The Epic 35 billing backend is invisible to users without these two surfaces; this story
+is the customer-facing and operator-facing front end for the whole billing domain. It re-targets
+the original TypeScript Story 20-5 ("billing dashboard") onto the current C# control-plane and
+the two React dashboards.
+
+## Acceptance Criteria
+
+This story is **frontend-only plus thin endpoint composition**. It renders data already produced
+by Stories 35-1 … 35-10 and MUST NOT re-implement any billing business logic in React or add new
+billing math on the server. Where a screen needs a single composed read that no existing 35-x
+endpoint provides, a thin aggregation endpoint may be added (see Technical Design), but it only
+reads from existing services/mirrors.
+
+1. **Tenant Billing area exists.** `packages/dashboard-user` gains a Billing section rooted at
+   `packages/dashboard-user/src/pages/billing/` with a route `/billing` (and sub-tabs Overview /
+   Usage / Invoices / Payment / Wallet) registered in `packages/dashboard-user/src/App.tsx`,
+   reachable from the app nav. The Overview tab shows the current plan name (from `Plan.DisplayName`
+   via `GET /api/v1/billing/subscription`) and the current `BillingMode` (PlatformProvided | Byok)
+   with a mode toggle (Story 35-2 `PUT /api/v1/billing/mode`).
+2. **Current-period usage with platform-vs-BYOK split** is rendered on the Usage tab from
+   `GET /api/v1/billing/usage` (Story 35-3): platform input/output tokens, BYOK input/output tokens,
+   `platform_cost_usd`, `billable_usd`, seats, and `period_start`/`period_end`. The platform and
+   BYOK figures are visually distinguished, and BYOK token usage is labelled "not billed for tokens".
+   Displayed numbers equal the endpoint payload and refresh on a manual refresh and on mount; a note
+   states figures lag billable Stripe state by at most the metering flush interval (Story 35-3, default 60s).
+3. **Quota & dunning banners.** When the tenant is at/over a plan quota (Story 35-6 quota state on the
+   subscription/usage read) a quota banner renders; when the tenant is in a non-`active` billing state
+   (`past_due` | `grace` | `suspended` from Story 35-8) a dunning banner renders with the current stage,
+   retry-attempt count, and next-retry time, deep-linking to the Payment tab.
+4. **Stripe portal + payment method.** The Payment tab shows the masked payment-method mirror from
+   `GET /api/v1/billing/payment-methods` (brand/last4/exp/default — Story 35-7), an "Open billing portal"
+   button that calls `POST /api/v1/billing/portal-session` and redirects to the returned Stripe URL, and
+   an "Add/replace card" action that uses the `POST /api/v1/billing/payment-methods/setup-intent` client
+   secret. No PAN/card data is ever entered into or stored by Tamma UI (Stripe Elements / portal handle it).
+5. **Invoice history + PDF.** The Invoices tab lists invoices (paged) from `GET /api/v1/billing/invoices`
+   (Story 35-8) showing period, amount due/paid, status, and a base/overage/credit line-item breakdown on
+   the detail view (`GET /api/v1/billing/invoices/{id}`), with "View / Download PDF" linking to the
+   Stripe-hosted `pdf_url`/`hosted_invoice_url`. Tamma never serves invoice PDF bytes itself.
+6. **Wallet balance + top-up.** The Wallet tab shows the derived balance and paged ledger history from
+   `GET /api/v1/billing/wallet` (Story 35-10) and a "Top up" action that calls
+   `POST /api/v1/billing/wallet/topup` to start the Stripe one-time PaymentIntent flow.
+7. **Tenant RBAC-aware rendering.** Read views are visible to any tenant member; manage controls
+   (mode toggle, portal/setup-intent, top-up) are rendered ONLY for `tenant_owner`/`tenant_admin`
+   (gated client-side by `TenantAdminGuard` / `user.role`), and the backend already returns 403 for a
+   `member` calling those endpoints (Stories 35-2/35-7/35-10). A member sees read-only views with no
+   manage buttons rendered.
+8. **Admin Billing console exists.** `packages/dashboard` gains a `billing` admin tab registered in
+   `packages/dashboard/src/pages/admin/AdminLayout.tsx` (`AdminTab` union + `TABS`), rendered behind the
+   admin route (`AdminGuard`) and gated on the server by `OwnerAccess`/`PlatformOwnerAccess`. It shows a
+   per-tenant subscription/revenue overview (plan, status, MRR/lifetime + period revenue) and total MRR.
+9. **Admin catalog & health panels.** The console surfaces plan-price-catalog sync status (Story 35-1
+   catalog) and webhook + reconciliation health (Stories 35-5 webhook ingest, 35-3 reconciliation):
+   last webhook received, unprocessed/dead-letter count, and last reconciliation result / drift count.
+10. **Admin operator actions.** The console exposes manual credit-grant (Story 35-10 admin grant,
+    `OwnerAccess`) and tenant suspend/reinstate (Story 35-8 `BILLING.TENANT.SUSPENDED`/`REINSTATED`)
+    actions, each behind a confirmation dialog and `OwnerAccess`. Successful actions optimistically update
+    the row and re-fetch.
+11. **All data comes from 35-x endpoints — no frontend business logic.** No billing computation
+    (margin, proration, credit application, dunning advancement) is performed in React or in any new
+    endpoint added by this story; aggregation endpoints only project existing service/mirror reads.
+12. **Single-user mode hides Billing entirely.** When the process is in `SingleUser` mode there is no
+    Stripe billing: the tenant Billing nav entry and route are hidden, and the admin Billing tab is hidden.
+    A new `GET /api/v1/billing/capabilities` (or the existing settings/me payload) exposes
+    `{ billingEnabled: boolean, mode }` derived from `ITammaModeProvider`; the dashboards gate on it
+    (never on a hardcoded build flag, so one build serves both modes).
+13. **Loading / empty / error states.** Every panel handles loading (skeleton/spinner), empty
+    ("No invoices yet", "No payment method on file", "Billing not provisioned"), and error (retryable
+    message, never a blank screen). Target p95 page load < 1s (data fetched lazily per tab, not all at once).
+14. **No secret/PAN exposure.** No BYOK provider key value, Stripe secret, or card PAN is ever rendered;
+    BYOK keys are referenced only by cabinet handle/last-4-style label (Epic 29 reveal path is server-side
+    only). The mode toggle shows BYOK as "configured / not configured", never the key.
+15. **Tests.** Vitest + Testing Library component/integration tests in both packages cover: RBAC-gated
+    rendering (member vs admin), platform-vs-BYOK usage split display, invoice list + PDF link, mode
+    toggle happy/error path, single-user hiding, loading/empty/error states, and the admin
+    suspend/reinstate + credit-grant actions — all against mocked endpoints (no live Stripe).
+
+## Technical Design
+
+This is a UI story spanning the two React dashboards, with a thin C# composition layer where a screen
+needs a single read no 35-x endpoint already provides. The C# entities, services and most endpoints are
+owned by sibling stories; this story consumes them.
+
+### Backend (C#) — thin composition only
+
+Namespace `Tamma.Api.Endpoints.Billing` (new dir `apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/`,
+also created by 35-2/35-3/35-7/35-8/35-10) and `Tamma.Api.Endpoints` for the admin file.
+
+**Capabilities (mode gate) — NEW, this story.** A tiny read so the dashboards know whether to render
+Billing at all:
+
+```csharp
+// apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/BillingCapabilitiesEndpoints.cs  (NEW)
+public static class BillingCapabilitiesEndpoints
+{
+    // GET /api/v1/billing/capabilities  (MemberAccess)
+    public static IResult GetCapabilities(ITammaModeProvider mode) =>
+        Results.Ok(new
+        {
+            billingEnabled = mode.Mode == TammaMode.SaaS,
+            mode = mode.Mode.ToString(),   // "SaaS" | "SingleUser"
+        });
+}
+```
+
+`ITammaModeProvider` lives at `apps/tamma-elsa/src/Tamma.Api/Services/PromptStore/TammaMode.cs`
+(verified) and is already a process-wide singleton. No new business logic.
+
+**Tenant subscription read — NEW thin endpoint, this story (only if 35-4 didn't already ship it).**
+The Overview tab needs `{ planSlug, planDisplayName, billingMode, subscriptionStatus, billingState,
+quotaState, periodStart, periodEnd }` in one call. If Story 35-4 already exposes
+`GET /api/v1/billing/subscription`, consume it as-is and add nothing. Otherwise add a read-only
+composition endpoint that reads the local subscription mirror (35-4), `Tenant.PlanId` →
+`Plan` (`apps/tamma-elsa/src/Tamma.Data/Entities/Plan.cs`, verified: `Slug`, `DisplayName`,
+`MonthlyPriceUsd`, `Quotas`), `BillingCustomer.BillingMode` (35-2) and the billing state (35-8) —
+projection only, no computation. Tenant scoping reuses the existing
+`/api/v1/orgs/{tenantId:guid}/...` membership filter pattern (see `UserDashboardEndpoints` +
+`RequireTenantMembershipFilter`) OR the caller-tenant pattern the 35-x billing endpoints already use
+(`GET /api/v1/billing/*` scoped to the caller's active tenant); MATCH whichever the sibling billing
+endpoints land on to keep one convention.
+
+**Admin billing overview — NEW thin endpoint, this story.** The admin console needs a per-tenant
+revenue/subscription roll-up. Add to a new
+`apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminBillingEndpoints.cs` (NEW; the spec's
+`Endpoints/Admin/AdminAnalyticsEndpoints.cs` path is wrong — the real analytics file is
+`apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminAnalyticsEndpoints.cs`, verified; mirror its
+`OwnerAccess`-gated static-class style):
+
+```csharp
+// apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminBillingEndpoints.cs  (NEW)
+public static class AdminBillingEndpoints
+{
+    // GET /api/v1/admin/billing/overview?limit=N   (OwnerAccess)
+    //   -> { totalMrrUsd, activeSubscriptions, pastDue, suspended,
+    //        tenants: [{ tenantId, name, planSlug, status, billingState,
+    //                    mrrUsd, lifetimeRevenueUsd, currentPeriodRevenueUsd }] }
+    public static Task<IResult> GetOverview([FromQuery] int? limit,
+        IBillingAdminReadService svc, CancellationToken ct);
+
+    // GET /api/v1/admin/billing/health   (OwnerAccess)
+    //   -> { catalogSync:{ inSync, lastSyncedAt, drift[] },
+    //        webhooks:{ lastReceivedAt, unprocessed, deadLettered },
+    //        reconciliation:{ lastRunAt, mismatches } }
+    public static Task<IResult> GetHealth(IBillingAdminReadService svc, CancellationToken ct);
+}
+```
+
+`IBillingAdminReadService` (NEW, `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingAdminReadService.cs`)
+is a **read-only projector** over the sibling mirrors: the 35-4 subscription mirror + `Plan` for MRR,
+35-8 `BillingInvoice` for lifetime/period revenue, 35-1 catalog state, 35-5 webhook ingest table, and
+the 35-3 reconciliation result. It performs sum/group reads only — the same posture as the existing
+`IPlatformAnalyticsService` (`apps/tamma-elsa/src/Tamma.Api/Services/Analytics/`). Manual credit-grant
+and suspend/reinstate are NOT re-implemented here — the console calls the already-owned admin endpoints:
+Story 35-10's admin grant endpoint (`Endpoints/Admin/`) and Story 35-8's suspend/reinstate
+(`InvoiceService`/`DunningStateMachine` surface).
+
+**Wiring.** Map the new endpoints in `apps/tamma-elsa/src/Tamma.Api/Program.cs` next to the other
+billing/admin maps: capabilities + subscription under `MemberAccess`/tenant-membership; admin overview
++ health under `OwnerAccess` (mirroring how `AdminAnalyticsEndpoints` are mapped). Register
+`IBillingAdminReadService` in DI alongside the other billing services.
+
+**DCB events.** This story emits NO new DCB events of its own — operator actions surface
+existing ones from sibling stories: `BILLING.CREDIT.GRANTED` (35-10), `BILLING.TENANT.SUSPENDED` /
+`BILLING.TENANT.REINSTATED` (35-8). The read endpoints are queries (no events). All DCB events stay
+`AGGREGATE.ACTION.STATUS` with JSONB tags `{ tenantId, ... }` per the existing convention.
+
+### Frontend — tenant dashboard (`packages/dashboard-user`, TS/React)
+
+```
+packages/dashboard-user/src/
+  api/
+    billing.ts                         # NEW — typed client over the 35-x /api/v1/billing/* reads + capabilities
+    billing.test.ts                    # NEW
+  pages/billing/
+    BillingPage.tsx                    # NEW — tab shell (Overview/Usage/Invoices/Payment/Wallet)
+    OverviewTab.tsx                    # NEW — plan + BillingMode toggle (35-2)
+    UsageTab.tsx                       # NEW — platform-vs-BYOK split (35-3)
+    InvoicesTab.tsx                    # NEW — list + detail + PDF link (35-8)
+    PaymentTab.tsx                     # NEW — masked PM mirror + portal + setup-intent (35-7)
+    WalletTab.tsx                      # NEW — balance + ledger + top-up (35-10)
+    components/
+      QuotaBanner.tsx                  # NEW — quota at/over (35-6)
+      DunningBanner.tsx                # NEW — past_due/grace/suspended (35-8)
+      BillingModeToggle.tsx            # NEW
+    __tests__/*.test.tsx               # NEW — colocated Vitest + Testing Library
+```
+
+- `api/billing.ts` reuses the existing `apiClient` (`packages/dashboard-user/src/api/client.ts`,
+  verified — `credentials:'include'`, refresh-on-401) and mirrors the `api/alerts.ts` shape. It
+  exposes typed DTOs (`SubscriptionDto`, `UsageDto`, `InvoiceDto`, `PaymentMethodDto`, `WalletDto`,
+  `BillingCapabilitiesDto`) matching the 35-x payloads, plus mutation wrappers
+  (`setBillingMode`, `openPortalSession`, `createSetupIntent`, `topUpWallet`).
+- Routing: add the `/billing` route group under the authenticated `AppLayout` in
+  `packages/dashboard-user/src/App.tsx`. The route itself is rendered for any member (read views);
+  manage controls inside tabs are gated with the existing `TenantAdminGuard` / `user.role`
+  (`packages/dashboard-user/src/guards/TenantAdminGuard.tsx`, verified — `admin`|`owner` set).
+- Mode gating: a small `useBillingCapabilities()` hook fetches `GET /api/v1/billing/capabilities`;
+  when `billingEnabled === false` the nav entry and route render nothing (single-user). The hook is
+  the single source for the gate so no hardcoded `import.meta.env` build flag is used.
+- Lazy per-tab fetching keeps the p95 < 1s budget: Overview loads on mount, other tabs fetch on first
+  activation. Each tab owns its own loading/empty/error state.
+
+### Frontend — admin dashboard (`packages/dashboard`, TS/React)
+
+```
+packages/dashboard/src/
+  services/admin/
+    billing-admin-client.ts            # NEW — over /api/v1/admin/billing/* + reuse 35-10 grant / 35-8 suspend
+    billing-admin-client.test.ts       # NEW
+  pages/admin/billing/
+    BillingConsoleTab.tsx              # NEW — top-level tab content (overview + health + actions)
+    TenantRevenueTable.tsx             # NEW — per-tenant subscription/MRR/revenue rows
+    BillingHealthPanel.tsx             # NEW — catalog-sync + webhook + reconciliation
+    GrantCreditDialog.tsx              # NEW — manual credit grant (35-10)
+    SuspendReinstateDialog.tsx         # NEW — suspend/reinstate (35-8)
+    __tests__/*.test.tsx               # NEW
+```
+
+- Register the tab in `packages/dashboard/src/pages/admin/AdminLayout.tsx`: extend the `AdminTab`
+  union (`... | 'billing'`), add `{ id: 'billing', label: 'Billing' }` to `TABS`, and render
+  `{activeTab === 'billing' && <BillingConsoleTab />}`. The admin shell is already behind `AdminGuard`
+  (`packages/dashboard/src/guards/AdminGuard.tsx`, verified) and the endpoints behind `OwnerAccess`.
+- `billing-admin-client.ts` follows the existing `services/admin/admin-api-client.ts` conventions.
+- Operator actions confirm before firing and re-fetch the overview on success; errors surface inline.
+
+### API shape consumed (owned by sibling stories — referenced, not built here)
+
+| Endpoint | Owner story |
+|---|---|
+| `GET /api/v1/billing/subscription` (or composed read) | 35-4 (this story may add the thin composition) |
+| `PUT /api/v1/billing/mode` | 35-2 |
+| `GET /api/v1/billing/usage` | 35-3 |
+| `GET /api/v1/billing/payment-methods`, `POST .../portal-session`, `POST .../setup-intent` | 35-7 |
+| `GET /api/v1/billing/invoices`, `GET .../invoices/{id}` | 35-8 |
+| `GET /api/v1/billing/wallet`, `POST .../wallet/topup`, admin grant | 35-10 |
+| suspend / reinstate | 35-8 |
+| `GET /api/v1/billing/capabilities`, `GET /api/v1/admin/billing/overview`, `GET .../health` | **35-11 (this story)** |
+
+### Per-mode + per-tenant handling
+
+- **SingleUser:** `billingEnabled=false` → no Stripe billing surfaces anywhere (AC 12). The capabilities
+  read is the single gate; both dashboards hide Billing without separate builds.
+- **SaaS:** tenant Billing is scoped to the caller's active tenant (every `/api/v1/billing/*` read is
+  tenant-scoped server-side; the admin overview is cross-tenant under `OwnerAccess`). RBAC: member =
+  read-only (no manage controls rendered AND server 403s on manage); `tenant_owner`/`tenant_admin` =
+  manage; platform owner = admin console + operator actions.
+
+## Dependencies
+
+**Internal (prerequisite — must ship first):**
+
+- **Story 35-2** — BillingMode + `PUT /api/v1/billing/mode` (Overview mode toggle).
+- **Story 35-3** — `GET /api/v1/billing/usage` (Usage split tab; reconciliation health for admin).
+- **Story 35-4** — subscription lifecycle + local subscription mirror (Overview plan/status; admin MRR).
+- **Story 35-7** — payment methods + portal/setup-intent (Payment tab).
+- **Story 35-8** — invoices + dunning state + suspend/reinstate (Invoices tab, dunning banner, admin action).
+- **Story 35-10** — wallet ledger + top-up + admin credit grant (Wallet tab, admin grant action).
+
+**Internal (related / consumed):** Story 35-1 (plan-price catalog → admin catalog-sync panel),
+Story 35-5 (webhook ingest → admin webhook health), Story 35-6 (quota state → quota banner),
+Epic 29 secret cabinet (BYOK referenced by handle only).
+
+**Internal infrastructure (already in repo, verified):** `apiClient`
+(`packages/dashboard-user/src/api/client.ts`), `TenantAdminGuard` (dashboard-user),
+`AdminGuard`/`AdminLayout` (dashboard), `ITammaModeProvider` (`TammaMode.cs`),
+`Plan` entity, `OwnerAccess`/`MemberAccess` policies (`Program.cs`).
+
+**Blocks:** none downstream in Epic 35 — this is the terminal UI story for the billing domain.
+
+**External:** Stripe Customer Portal + Stripe.js/Elements (loaded client-side for the portal redirect
+and setup-intent; no Stripe secret in the browser). React 18, react-router-dom, Vitest 3 + Testing
+Library, Tailwind (existing dashboard stack).
+
+## Testing Strategy
+
+All tests use **mocked endpoints** — no live Stripe, no live API. Stripe is only ever reached via the
+backend; the browser only opens a returned portal URL, so frontend tests mock the URL response.
+
+1. **Tenant dashboard component tests** (`packages/dashboard-user`, Vitest + Testing Library, colocated
+   `__tests__/`): Overview renders plan + mode and toggles mode (happy + 422/403 error path); Usage tab
+   renders the platform-vs-BYOK split exactly as the mocked `GET /api/v1/billing/usage` payload and labels
+   BYOK as not-token-billed; Invoices list renders rows + a PDF link to the mocked `pdf_url` and never
+   renders bytes; Payment tab shows masked last4 and triggers a portal redirect with the mocked URL;
+   Wallet tab shows derived balance + ledger and fires top-up.
+2. **RBAC-gated rendering tests:** with `user.role='member'`, manage controls (mode toggle, portal,
+   setup-intent, top-up) are NOT in the DOM; with `admin`/`owner` they are. Assert read views still render
+   for member.
+3. **Single-user hiding tests:** with mocked `capabilities.billingEnabled=false`, the Billing nav entry +
+   route render nothing in dashboard-user and the Billing tab is absent in dashboard.
+4. **State tests:** loading shows a skeleton/spinner; empty shows the right empty copy ("No invoices yet",
+   "No payment method on file", "Billing not provisioned"); error shows a retryable message, never blank.
+5. **Admin console tests** (`packages/dashboard`): TenantRevenueTable renders rows + total MRR from mocked
+   overview; BillingHealthPanel renders catalog/webhook/reconciliation states (including a drift warning);
+   suspend/reinstate and grant-credit dialogs confirm, call the client, optimistically update, and re-fetch;
+   a non-owner is blocked by `AdminGuard` (existing behaviour, asserted at the route).
+6. **Backend unit tests** (`apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/`, xUnit): `GetCapabilities`
+   returns `billingEnabled=true` in SaaS and `false` in SingleUser (drive `ITammaModeProvider`);
+   `BillingAdminReadService` projects MRR/revenue/health from seeded mirrors with sum/group only and never
+   mutates; tenant-scoped subscription read returns only the caller's tenant.
+7. **Tenant-isolation / integration tests** (`apps/tamma-elsa/tests/Tamma.Api.Tests/`): a tenant-A token
+   hitting the tenant billing reads never sees tenant-B subscription/invoice/wallet data (cross-tenant →
+   404/empty); a `member` token gets 403 on the manage endpoints owned by 35-2/35-7/35-10 (asserted at the
+   composition layer); a non-owner gets 403 on `/api/v1/admin/billing/*`. Stripe/provider clients are
+   mocked at the service seam (no `STRIPE_SECRET_KEY` needed for these).
+
+Coverage target: 80% line / 75% branch on the new React + endpoint code; RBAC, mode-gating, and the
+no-secret-render assertions are treated as critical paths (100%).
+
+## Estimated Effort
+
+5-6 days (2 days tenant dashboard, 2 days admin console, 1 day thin endpoints + DI/wiring, 1 day tests
++ isolation/RBAC hardening).
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/BillingCapabilitiesEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/BillingSubscriptionReadEndpoints.cs` | Create (only if 35-4 lacks the composed read) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminBillingEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/IBillingAdminReadService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingAdminReadService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/BillingServiceCollectionExtensions.cs` | Modify (register read service) or Create if absent |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map capabilities/subscription/admin-billing routes + DI) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingCapabilitiesEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingAdminReadServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingDashboardIsolationTests.cs` | Create |
+| `packages/dashboard-user/src/api/billing.ts` | Create |
+| `packages/dashboard-user/src/api/billing.test.ts` | Create |
+| `packages/dashboard-user/src/pages/billing/BillingPage.tsx` | Create |
+| `packages/dashboard-user/src/pages/billing/OverviewTab.tsx` | Create |
+| `packages/dashboard-user/src/pages/billing/UsageTab.tsx` | Create |
+| `packages/dashboard-user/src/pages/billing/InvoicesTab.tsx` | Create |
+| `packages/dashboard-user/src/pages/billing/PaymentTab.tsx` | Create |
+| `packages/dashboard-user/src/pages/billing/WalletTab.tsx` | Create |
+| `packages/dashboard-user/src/pages/billing/components/QuotaBanner.tsx` | Create |
+| `packages/dashboard-user/src/pages/billing/components/DunningBanner.tsx` | Create |
+| `packages/dashboard-user/src/pages/billing/components/BillingModeToggle.tsx` | Create |
+| `packages/dashboard-user/src/hooks/useBillingCapabilities.ts` | Create |
+| `packages/dashboard-user/src/pages/billing/__tests__/*.test.tsx` | Create |
+| `packages/dashboard-user/src/App.tsx` | Modify (register `/billing` route + nav) |
+| `packages/dashboard/src/services/admin/billing-admin-client.ts` | Create |
+| `packages/dashboard/src/services/admin/billing-admin-client.test.ts` | Create |
+| `packages/dashboard/src/pages/admin/billing/BillingConsoleTab.tsx` | Create |
+| `packages/dashboard/src/pages/admin/billing/TenantRevenueTable.tsx` | Create |
+| `packages/dashboard/src/pages/admin/billing/BillingHealthPanel.tsx` | Create |
+| `packages/dashboard/src/pages/admin/billing/GrantCreditDialog.tsx` | Create |
+| `packages/dashboard/src/pages/admin/billing/SuspendReinstateDialog.tsx` | Create |
+| `packages/dashboard/src/pages/admin/billing/__tests__/*.test.tsx` | Create |
+| `packages/dashboard/src/pages/admin/AdminLayout.tsx` | Modify (add `billing` tab) |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md).
+2. Searched `.dev/` for related spikes/bugs/findings/decisions (billing UI, RBAC rendering).
+3. Confirmed which `/api/v1/billing/*` endpoints have actually merged from Stories 35-2…35-10 before
+   wiring the client — build the UI against the real merged contract, not this story's assumptions, and
+   reconcile any shape drift.
+4. Verified the tenant-scoping convention the sibling billing endpoints landed on
+   (`/api/v1/billing/*` caller-tenant vs `/api/v1/orgs/{tenantId}/...`) and matched it exactly.
+5. Planned TDD (Red-Green-Refactor) for both React packages and the backend reads.
+
+### Key design decisions
+
+- **No business logic in the frontend or in this story's endpoints.** The dashboards are pure
+  projections; the only server code added is read composition (capabilities, subscription roll-up,
+  admin overview/health). This keeps the single source of truth in the 35-x services and satisfies AC 11.
+  Operator actions reuse the already-owned 35-8/35-10 endpoints rather than re-implementing suspend/grant.
+- **Mode gate is a server read, not a build flag.** `GET /api/v1/billing/capabilities` from
+  `ITammaModeProvider` lets one artifact serve both single-user and SaaS, matching how the rest of the
+  app stays mode-agnostic at build time.
+- **RBAC is defence-in-depth.** Client-side hiding (`TenantAdminGuard`/`AdminGuard`) is UX only; the
+  backend (35-2/35-7/35-10/admin policies) is the real gate. Tests assert both layers.
+- **No secrets/PAN in the browser, ever.** Card capture happens in Stripe Elements/portal; BYOK keys are
+  shown as configured/not-configured by cabinet handle. The setup-intent flow only ever hands the browser
+  a client secret, never a Stripe secret key.
+
+### Performance
+
+- Per-tab lazy fetching (Overview eager, others on activation) and paged invoice/ledger lists keep the
+  p95 page-load budget < 1s. The admin overview is a single composed read (sum/group), not N+1 per tenant.
+
+### Security requirements
+
+- No BYOK key value, Stripe secret, or PAN rendered (AC 14).
+- All manage/operator endpoints stay server-gated (`MemberAccess` for reads, tenant owner/admin for
+  tenant manage, `OwnerAccess` for admin actions); client gating is cosmetic.
+- Portal/return URLs come pre-validated from 35-7's allowlist; the UI only follows the returned URL.
+
+## Logging Requirements
+
+- **INFO:** billing page/tab opened (tenantId, tab), portal session opened, mode toggle submitted, admin
+  overview/health fetched, operator action invoked (admin credit grant / suspend / reinstate — log the
+  action + target tenantId, never amounts as secrets but amounts are fine for credit grants).
+- **DEBUG:** capabilities resolved (mode, billingEnabled), each tab data fetch start/finish + row counts.
+- **WARN:** a billing read returned an error surfaced to the user (endpoint, status), reconciliation drift
+  shown in the admin health panel, webhook backlog non-zero.
+- **ERROR:** admin overview/health composition read failed; operator action failed after confirmation.
+- **Structured context:** include `{ tenantId, tab, action }` where applicable. **Credential safety:**
+  NEVER log Stripe keys, BYOK key values, card PAN/last4 beyond the masked display value, or portal URLs
+  containing session tokens.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-35/story-35-12/35-12-billing-audit-reconciliation-and-revenue-analytics.md
+++ b/docs/stories/epic-35/story-35-12/35-12-billing-audit-reconciliation-and-revenue-analytics.md
@@ -1,0 +1,412 @@
+# Story 35-12: Billing Audit, Reconciliation & Revenue Analytics
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-Phase Development Workflow (Read → Research → Break Down → TDD → Quality Gates → Failure Handling), the `.dev/` knowledge-base usage rules, TRACE/DEBUG logging requirements, the Test-Driven Development workflow, the 100%-critical-path coverage target, and build/quality-gate enforcement. **Failure to follow this process will result in rework.**
+
+## User Story
+
+As a **Tamma platform operator (and finance/compliance stakeholder)**,
+I want every `BILLING.*` event projected into a queryable audit timeline, a daily reconciliation job that proves the local billing mirrors agree with Stripe and flags drift, and revenue analytics (MRR/ARR, churn, BYOK-vs-platform split, realized margin) computed on the existing platform-analytics substrate,
+so that billing is fully auditable, operationally trustworthy, and reportable — drift is caught before it becomes a revenue leak or a customer dispute, and I can answer "what is our MRR, churn, and margin" without exporting to Stripe.
+
+## Priority
+
+P1 — The cross-cutting integrity + reporting layer for Epic 35. The metering (35-3), subscription (35-4), webhook projection (35-5), dunning (35-8), and wallet (35-10) stories each own their own mirror and their own narrow DCB events; this story is the only place that proves those mirrors are *correct* against Stripe and turns the audit stream into revenue intelligence. It is the safety net the whole epic relies on once tenants are being charged real money.
+
+## Acceptance Criteria
+
+1. A **billing audit/timeline read model** is derived on demand from the CP `DomainEvent` rows whose `Type` matches `BILLING.%` (the events already appended by Stories 35-1/35-3/35-4/35-5/35-8/35-10 via `IEventRepository.AppendAsync`). A new `IBillingAuditService` (`apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingAuditService.cs`) exposes `GetTenantTimelineAsync(tenantId, filter, ct)` and `GetPlatformTimelineAsync(filter, ct)` returning chronological, paged `BillingTimelineEntry` records (newest-first by `(CreatedAt, SequenceNumber)`); filters: `eventType` prefix, `from`/`to`, `cursor`/`limit` (default 50, max 200).
+2. `GET /api/v1/orgs/{tenantId}/billing/timeline` (SaaS: `MemberAccess` group + `RequireTenantMembershipFilter`, any tenant member may read; single-user: the sole user) returns the per-tenant billing history; `GET /api/v1/admin/billing/timeline` (`OwnerAccess`) returns the platform-wide view across all tenants (and platform-scoped, `TenantId IS NULL`, billing events). A tenant timeline query is hard-scoped to the caller's `TenantId` (from `ITenantContext`, never a spoofable route param mismatch) so tenant A can never read tenant B's billing events.
+3. Each `BillingTimelineEntry` projects only **non-sensitive** fields: `eventType`, `createdAt`, `sequenceNumber`, decoded `tags` (`tenantId`, `stripeCustomerId`, `billingMode`, `stripeObjectId`, `invoiceId`, `stage` where present), and a small whitelisted `summary` (`amountUsd`, `currency`, `status`, `last4`). No raw card numbers, no full PANs, no API keys, no Stripe secrets, and no raw webhook payloads ever appear in the projection (AC verified by a redaction test asserting only whitelisted keys survive).
+4. A new `BillingReconciliationTaskHandler` (`apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingReconciliationTaskHandler.cs`) implementing `IPlatformTaskHandler` with `TaskType => "billing.reconcile"` runs **daily** (re-enqueued via the self-rescheduling `PlatformQueuedTask` pattern, cadence configurable via `Billing:Reconciliation:IntervalHours` default `24`) and, for each active `BillingCustomer`, cross-checks the four local mirrors against Stripe: `BillingSubscription` (35-4) vs Stripe `Subscriptions.List`, `BillingInvoice`/`BillingInvoiceLine` (35-8) vs Stripe `Invoices.List`, `BillingUsageRollup` (35-3) vs Stripe `Billing.Meters.ListEventSummaries`, and `BillingWalletLedger` (35-10) balance vs the Stripe credit-grant/customer-balance source.
+5. On any mismatch the handler emits a `BILLING.RECONCILIATION.DRIFT_DETECTED` DCB event (via `IEventRepository.AppendAsync`, CP store) with JSONB `tags = { tenantId, stripeCustomerId, mirror, billing_mode? }` and `data = { mirror, field, local, stripe, deltaUsd?, deltaCount? }`, plus a WARN structured log; a clean per-customer pass emits a single per-run `BILLING.RECONCILIATION.COMPLETED` platform event (`TenantId IS NULL`) carrying `{ customersChecked, mirrorsChecked, driftCount }`. The handler is **fail-isolated per customer and per mirror**: one customer's Stripe error or one mirror's exception is caught, logged, counted, and does not abort the run.
+6. The reconciliation handler **does not re-implement the per-meter usage check** owned by Story 35-3 (`billing.usage_reconcile` → `BILLING.USAGE.RECONCILIATION_MISMATCH`); for the usage mirror it consumes the existing `IUsageMeteringService`/35-3 drift signal (reads the latest `BILLING.USAGE.RECONCILIATION_MISMATCH` events and the local rollup) and rolls them up into the unified `BILLING.RECONCILIATION.DRIFT_DETECTED` view with `mirror = "usage"`, rather than calling `Billing.Meters.ListEventSummaries` a second time itself.
+7. **Revenue analytics** extend the existing `PlatformAnalyticsHourly` fact table + `ComputePlatformRollupActivity` substrate: `ComputePlatformRollupActivity.ComputeAsync` is augmented to additionally compute and persist a daily revenue snapshot onto a **new** `BillingRevenueDaily` CP entity (`apps/tamma-elsa/src/Tamma.Data/Entities/BillingRevenueDaily.cs`) carrying, per day (`Day` UTC midnight, `TenantId IS NULL` platform-wide): `MrrUsd`, `ArrUsd`, `ActiveSubscriptions`, `TrialingSubscriptions`, `PastDueSubscriptions`, `SuspendedSubscriptions`, `LogoChurnCount`, `RevenueChurnUsd`, `ByokRevenueUsd`, `PlatformRevenueUsd`, `PlatformUsageCostUsd`, `PlatformUsageMarginUsd`, with a partial unique index on `(Day, TenantId)` mirroring `PlatformAnalyticsHourly`'s idempotency pattern (replay overwrites).
+8. MRR is computed from the `BillingSubscription` (35-4) mirror: sum the monthly-normalized recurring price (seat count × per-seat plan price from 35-1's `BillingPlanPrice`, plus flat plan fee) over subscriptions in `active`/`trialing`/`past_due` status, normalizing annual plans to `/12`; ARR = MRR × 12. The BYOK-vs-platform split classifies each subscription's contribution by its `BillingCustomer.BillingMode` (`PlatformProvided` vs `Byok`) → `PlatformRevenueUsd` / `ByokRevenueUsd`. **No new pricing or markup math is implemented here** — per-seat/plan prices come from 35-1's `BillingPlanPrice` and platform-usage cost/sell come from the already-priced `BillingUsageRollup` (`PlatformCostUsd`, `BillableAmountUsd` from 35-3, which in turn calls 34-5's `IUsagePricingEngine`).
+9. Realized margin on platform-provided usage = `Σ BillingUsageRollup.BillableAmountUsd − Σ BillingUsageRollup.PlatformCostUsd` for the period over `PlatformProvided` tenants → `PlatformUsageMarginUsd`; `PlatformUsageCostUsd = Σ PlatformCostUsd`. Logo churn = count of subscriptions that transitioned to `canceled` in the day window (read from `BILLING.SUBSCRIPTION.CANCELED` events); revenue churn = the MRR those canceled subscriptions represented at cancellation.
+10. `GET /api/v1/admin/billing/metrics` (`OwnerAccess`, mounted in `apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminAnalyticsEndpoints.cs` — the real analytics endpoint file, NOT a `Admin/` sub-path) returns the revenue analytics for a requested window (`?from&to`, default current calendar month): `{ mrrUsd, arrUsd, activeSubscriptions, trialingSubscriptions, pastDueSubscriptions, suspendedSubscriptions, logoChurnCount, revenueChurnUsd, byokRevenueUsd, platformRevenueUsd, platformUsageCostUsd, platformUsageMarginUsd, periodStart, periodEnd, generatedAt }`, served from `BillingRevenueDaily` (no live fan-out). The returned `platformRevenueUsd + byokRevenueUsd` figures **reconcile to the sum of per-tenant `BillingInvoice` totals** for the same period within a documented tolerance (asserted by an integration test).
+11. **Alerting hook**: a new built-in alert rule `billing-reconciliation-drift` (severity `warning`, `EventType = "BILLING.RECONCILIATION.DRIFT_DETECTED"`, predicate `{"op":"always"}`, `ThrottleSeconds = 3600`) is added to `BuiltInAlertRules.All` so drift fires through the existing Story 5.6 `AlertRuleEvaluator` → `IAlertSink` path with no manual rule setup; tenant-scoped drift (event carries `TenantId`) raises a tenant-feed alert, platform-scoped raises an admin-feed alert. A second built-in `billing-dunning-spike` (severity `critical`, `EventType = "BILLING.DUNNING.ESCALATED"`, predicate `{"op":"count_gte","window_seconds":3600,"threshold":5}`) and `billing-meter-flush-backlog` (severity `warning`, `EventType = "BILLING.USAGE.FLUSH_FAILED"`, `{"op":"count_gte","window_seconds":1800,"threshold":10}`) cover dunning spikes and meter-flush backlog over threshold. Built-ins ship with empty `ChannelIds` per the existing convention (no auto-spam).
+12. **Consistent DCB tags for audit/compliance**: this story's events and the audit projection assume every `BILLING.*` event already carries the canonical tags (`tenantId`, `stripeCustomerId` where applicable, `billing_mode`). Where the audit projection observes a `BILLING.*` event **missing** a `tenantId` or `stripeCustomerId` tag that should be present (a sibling-story emission bug), it surfaces the event in the timeline with a `tagGap = true` marker and WARN-logs once — making a tagging regression visible to compliance export rather than silently dropping the row.
+13. **Per-mode handling**: in single-user mode (`ITammaModeProvider == SingleUser`) the reconciliation handler and revenue snapshot are **not registered** (no Stripe, no `BillingCustomer` rows), `GET /api/v1/admin/billing/metrics` and the admin timeline return an empty/zeroed payload (or 404 for the org timeline, mirroring 35-3's seam), and no Stripe calls are ever made; the sole user may still read their own billing timeline if any `BILLING.*` events exist. In SaaS mode all surfaces are mounted and tenant-scoped per AC 2.
+14. **Tenant isolation** is covered by tests: a tenant timeline request never returns another tenant's or a platform-scoped billing event; the reconciliation handler iterates `BillingCustomer` rows and never tags one tenant's drift event with another tenant's id; the admin metrics/timeline endpoints require `OwnerAccess` and 403 a tenant-role caller.
+15. Unit + integration tests cover: the audit projection query (ordering, paging, prefix filter, redaction whitelist, `tagGap` marker), reconciliation drift detection across **each** of the four mirrors (subscription/invoice/usage/wallet) including the clean-pass and per-mirror fail-isolation paths, MRR/ARR/churn/margin math against a seeded mirror set, the BYOK-vs-platform split correctness, the `metrics`-reconciles-to-invoices invariant, alert emission for each new built-in rule, and the single-user no-op seam.
+
+## Technical Design
+
+### Boundary statement (honor the epic split)
+
+This story is the **integrity + reporting** layer. It **reads** the mirrors and events the sibling stories own; it **owns** the cross-mirror reconciliation, the billing audit projection, and the revenue-analytics computation/snapshot.
+
+| Concern | Owner | This story's relationship |
+|---|---|---|
+| `BillingCustomer` (tenant↔Stripe, `BillingMode`), `BillingPlanPrice` | 35-1 / 35-2 | reads (customer iteration, MRR per-seat price, mode split) |
+| `BillingUsageRollup` (`PlatformCostUsd`, `BillableAmountUsd`), `billing.usage_reconcile` | 35-3 | reads for margin + consumes its usage-drift signal (does NOT re-run the per-meter check) |
+| `BillingSubscription` (status, seats, plan, period) | 35-4 | reads for MRR/churn + subscription-mirror reconciliation |
+| `BillingWebhookEvent` + the `BILLING.*` DCB emissions | 35-5 | the audit projection's source stream |
+| `BillingInvoice`/`BillingInvoiceLine`, `BillingDunningState`, dunning events | 35-8 | reads for invoice reconciliation + the `metrics`-reconciles-to-invoices invariant + dunning-spike alert |
+| `BillingWalletLedger` | 35-10 | reads for wallet-balance reconciliation |
+| Billing **dashboards** + `GET /api/v1/admin/billing/overview`/`health` (thin per-tenant table, sum/group) | 35-11 | **NOT this story** — 35-11 renders; this story produces the MRR/churn/margin numbers its admin console consumes. No React/dashboard files are created here. |
+| `IUsagePricingEngine` (cost→price markup) | 34-5 | never re-implemented; margin is read from already-priced rollup columns |
+
+**No markup/pricing math, no dashboard code, no second usage-meter reconciliation.** If you find yourself multiplying a cost by a margin, or editing `packages/dashboard*`, or calling `Billing.Meters.ListEventSummaries` for the usage mirror, stop — those belong to 34-5, 35-11, and 35-3 respectively.
+
+### C# namespace / file structure
+
+```
+apps/tamma-elsa/src/Tamma.Data/
+  Entities/
+    BillingRevenueDaily.cs                 # NEW — CP daily revenue snapshot (platform-wide, idempotent on (Day, TenantId))
+  ControlPlaneDbContext.cs                  # MODIFY — DbSet<BillingRevenueDaily>
+  TammaModelConfiguration.cs               # MODIFY — entity config + (Day, TenantId) partial unique indexes + precision
+  Migrations/ControlPlane/<ts>_AddBillingRevenueDaily.cs   # NEW — additive migration
+
+apps/tamma-elsa/src/Tamma.Api/Services/Billing/
+  IBillingAuditService.cs                   # NEW — timeline read model port
+  BillingAuditService.cs                    # NEW — projects BILLING.% DomainEvents → BillingTimelineEntry (redacted)
+  BillingTimelineEntry.cs                   # NEW — DTO + filter record
+  IBillingRevenueService.cs                 # NEW — revenue metrics read port (over BillingRevenueDaily)
+  BillingRevenueService.cs                  # NEW — windowed read + the snapshot computation helper
+  BillingReconciliationTaskHandler.cs       # NEW — IPlatformTaskHandler "billing.reconcile"
+  BillingReconciliationOptions.cs           # NEW — IntervalHours, drift tolerances per mirror
+  BillingMirrorReconciler.cs                # NEW — pure-ish per-mirror compare helpers (subscription/invoice/usage/wallet)
+  BillingAuditEventTypes.cs                 # NEW — RECONCILIATION.* DCB type constants
+
+apps/tamma-elsa/src/Tamma.Activities/Analytics/
+  ComputePlatformRollupActivity.cs          # MODIFY — also write the daily BillingRevenueDaily snapshot (SaaS only)
+
+apps/tamma-elsa/src/Tamma.Api/Endpoints/
+  AdminAnalyticsEndpoints.cs                # MODIFY — add GetBillingMetrics + GetBillingTimeline (OwnerAccess)
+apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/
+  BillingTimelineEndpoints.cs               # NEW — GET /api/v1/orgs/{tenantId}/billing/timeline (tenant)
+
+apps/tamma-elsa/src/Tamma.Api/Services/Alerts/Rules/
+  BuiltInAlertRules.cs                      # MODIFY — add 3 billing built-ins (drift / dunning-spike / flush-backlog)
+
+apps/tamma-elsa/src/Tamma.Api/Extensions/
+  BillingAuditServiceCollectionExtensions.cs  # NEW — wire audit/revenue services + reconcile handler (SaaS only)
+apps/tamma-elsa/src/Tamma.Api/Program.cs       # MODIFY — call AddBillingAuditAndAnalytics(); map endpoints
+```
+
+### Entity: `BillingRevenueDaily` (CP-resident)
+
+```csharp
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 35-12 — control-plane daily revenue snapshot. Platform-wide row
+/// (TenantId == null) carries fleet MRR/ARR/churn/margin; a future
+/// per-tenant breakdown can reuse the same table with TenantId set. Lives
+/// on the control plane next to PlatformAnalyticsHourly so a single SELECT
+/// answers "what is our MRR / margin this month" without per-tenant fan-out.
+/// Idempotent upsert keyed by (Day, TenantId) — a replay of a day overwrites.
+/// </summary>
+public class BillingRevenueDaily
+{
+    public Guid Id { get; set; }
+    public DateTime Day { get; set; }            // UTC midnight bucket
+    public Guid? TenantId { get; set; }          // null = platform-wide
+
+    public decimal MrrUsd { get; set; }
+    public decimal ArrUsd { get; set; }
+
+    public int ActiveSubscriptions { get; set; }
+    public int TrialingSubscriptions { get; set; }
+    public int PastDueSubscriptions { get; set; }
+    public int SuspendedSubscriptions { get; set; }
+
+    public int LogoChurnCount { get; set; }
+    public decimal RevenueChurnUsd { get; set; }
+
+    public decimal ByokRevenueUsd { get; set; }      // seat/plan fee from Byok tenants
+    public decimal PlatformRevenueUsd { get; set; }  // seat/plan fee + billable usage from PlatformProvided tenants
+    public decimal PlatformUsageCostUsd { get; set; }   // Σ BillingUsageRollup.PlatformCostUsd
+    public decimal PlatformUsageMarginUsd { get; set; } // Σ (BillableAmountUsd - PlatformCostUsd)
+
+    public DateTime ComputedAt { get; set; }
+}
+```
+
+EF config (in `TammaModelConfiguration.ConfigureControlPlaneEntities`):
+
+```csharp
+modelBuilder.Entity<BillingRevenueDaily>(e =>
+{
+    e.ToTable("billing_revenue_daily");
+    e.HasKey(x => x.Id);
+    e.Property(x => x.Id).HasDefaultValueSql("gen_random_uuid()");
+    // Two partial unique indexes mirror PlatformAnalyticsHourly's (Hour, TenantId) idempotency.
+    e.HasIndex(x => x.Day).HasFilter("\"TenantId\" IS NULL").IsUnique()
+        .HasDatabaseName("UX_billing_revenue_daily_Day_PlatformWide");
+    e.HasIndex(x => new { x.Day, x.TenantId }).HasFilter("\"TenantId\" IS NOT NULL").IsUnique()
+        .HasDatabaseName("UX_billing_revenue_daily_Day_Tenant");
+    foreach (var p in new[] { nameof(BillingRevenueDaily.MrrUsd), nameof(BillingRevenueDaily.ArrUsd),
+        nameof(BillingRevenueDaily.RevenueChurnUsd), nameof(BillingRevenueDaily.ByokRevenueUsd),
+        nameof(BillingRevenueDaily.PlatformRevenueUsd), nameof(BillingRevenueDaily.PlatformUsageCostUsd),
+        nameof(BillingRevenueDaily.PlatformUsageMarginUsd) })
+        e.Property(p).HasPrecision(20, 4);
+});
+```
+
+### Audit timeline service
+
+```csharp
+public interface IBillingAuditService
+{
+    Task<BillingTimelinePage> GetTenantTimelineAsync(
+        Guid tenantId, BillingTimelineFilter filter, CancellationToken ct = default);
+
+    Task<BillingTimelinePage> GetPlatformTimelineAsync(
+        BillingTimelineFilter filter, CancellationToken ct = default);
+}
+
+public sealed record BillingTimelineFilter(
+    string? EventTypePrefix = "BILLING.",
+    DateTime? From = null,
+    DateTime? To = null,
+    long? Cursor = null,          // SequenceNumber cursor (newest-first)
+    int Limit = 50);             // clamped 1..200
+
+public sealed record BillingTimelineEntry(
+    string EventType,
+    DateTime CreatedAt,
+    long SequenceNumber,
+    Guid? TenantId,
+    string? StripeCustomerId,
+    string? BillingMode,
+    string? StripeObjectId,
+    IReadOnlyDictionary<string, object?> Summary, // whitelisted: amountUsd, currency, status, last4, invoiceId, stage
+    bool TagGap);                // true when an expected tenantId/stripeCustomerId tag is missing
+
+public sealed record BillingTimelinePage(
+    IReadOnlyList<BillingTimelineEntry> Entries, long? NextCursor, int Total);
+```
+
+`GetTenantTimelineAsync` reads `DomainEvent` rows where `TenantId == tenantId AND Type LIKE 'BILLING.%'` via `IEventRepository` (or a direct `ControlPlaneDbContext.DomainEvents` query — same store), ordered by `SequenceNumber DESC`, deserializes `Tags`/`Data` JSON, and projects **only** the whitelisted summary keys through a `BillingAuditRedactor` (a `private static readonly HashSet<string> _allowedSummaryKeys`). Anything not on the whitelist is dropped — the redaction test asserts that injecting a `cardNumber`/`apiKey`/`rawPayload` key into a `BILLING.*` event's `data` does not survive the projection.
+
+### Reconciliation handler
+
+`BillingReconciliationTaskHandler : IPlatformTaskHandler`, `TaskType => "billing.reconcile"`. `HandleAsync(PlatformQueuedTask task, CancellationToken ct)`:
+
+1. If `ITammaModeProvider == SingleUser` → no-op (handler is not even registered, but defensive guard stays).
+2. Load active `BillingCustomer` rows (CP). For each customer, run four mirror checks via `BillingMirrorReconciler`, each wrapped in its own try/catch (per-mirror fail isolation):
+   - **subscription**: `BillingSubscription` rows vs `IBillingProvider`/Stripe `Subscriptions.List(customer)` → compare status + period + seats.
+   - **invoice**: `BillingInvoice` rows vs Stripe `Invoices.List(customer)` → compare count + status + `AmountDue`/`AmountPaid` totals within `Billing:Reconciliation:InvoiceToleranceUsd`.
+   - **usage**: consume 35-3's signal — read the most recent `BILLING.USAGE.RECONCILIATION_MISMATCH` events for the customer + the current `BillingUsageRollup`; surface as `mirror = "usage"` drift (no second meter-summary call).
+   - **wallet**: `BillingWalletLedger` running balance vs the Stripe credit-grant/customer-balance value within `Billing:Reconciliation:WalletToleranceUsd`.
+3. On any mismatch → `IEventRepository.AppendAsync(new DomainEvent { Type = "BILLING.RECONCILIATION.DRIFT_DETECTED", TenantId = customer.TenantId, Tags = {...}, Data = {...} })` + WARN log.
+4. After all customers → append a platform `BILLING.RECONCILIATION.COMPLETED` event (`TenantId = null`) with run totals.
+5. Self-reschedule: enqueue the next `billing.reconcile` `PlatformQueuedTask` at `now + IntervalHours` (rides the existing `PlatformTaskWorker` loop, mirroring 35-3's `billing.meter_flush` self-rescheduling pattern). A transient Stripe/DB error throws (worker retries the task); a structurally impossible run throws `PlatformTaskTerminalException`.
+
+### Revenue snapshot (extends `ComputePlatformRollupActivity`)
+
+`ComputePlatformRollupActivity.ComputeAsync` (the existing static pure-DI entry point, currently writes `PlatformAnalyticsHourly` for `TenantId = null`) gains a **SaaS-mode-gated** tail step that, once per day (on the top-of-day hour), computes and upserts a `BillingRevenueDaily` platform row via `IBillingRevenueService.ComputeDailySnapshotAsync(day, ct)`:
+
+- **MRR**: `Σ` over `BillingSubscription` in (`active`,`trialing`,`past_due`) of `monthlyNormalizedPrice(sub)` where `monthlyNormalizedPrice = flatPlanFee + seats × perSeatPrice` (prices from 35-1 `BillingPlanPrice`; annual plans `/12`). Split each contribution by `BillingCustomer.BillingMode` → `PlatformRevenueUsd` / `ByokRevenueUsd`.
+- **ARR** = MRR × 12.
+- **status counts** from the `BillingSubscription` mirror (`active`/`trialing`/`past_due`) + `BillingDunningState.Stage == suspended` for `SuspendedSubscriptions`.
+- **churn**: `LogoChurnCount` = `BILLING.SUBSCRIPTION.CANCELED` events in `[day, day+1)`; `RevenueChurnUsd` = the MRR those subs represented (read sub mirror at cancellation / event data).
+- **margin**: `PlatformUsageCostUsd = Σ BillingUsageRollup.PlatformCostUsd`, `PlatformUsageMarginUsd = Σ (BillableAmountUsd − PlatformCostUsd)` over `PlatformProvided` tenants for the period; add `BillingUsageRollup.BillableAmountUsd` into `PlatformRevenueUsd`.
+
+Keeping the computation in `IBillingRevenueService` (not inline in the activity) lets the unit tests exercise the math without an Elsa execution context (same split `RunAsync` vs `ComputeAsync` pattern the activity already uses). The activity only orchestrates; the service owns the SQL + math.
+
+### DCB event names (`AGGREGATE.ACTION.STATUS`) — owned by this story
+
+```
+BILLING.RECONCILIATION.DRIFT_DETECTED   # tenant-scoped (TenantId set) per drifting mirror
+BILLING.RECONCILIATION.COMPLETED        # platform event (TenantId null), per run summary
+```
+
+Consumed (read-only) from sibling stories: `BILLING.USAGE.RECONCILIATION_MISMATCH`, `BILLING.USAGE.FLUSH_FAILED` (35-3); `BILLING.SUBSCRIPTION.CANCELED`, `BILLING.SUBSCRIPTION.UPDATED` (35-4); `BILLING.INVOICE.*`, `BILLING.DUNNING.ESCALATED`, `BILLING.TENANT.SUSPENDED` (35-8); `BILLING.CREDIT.*` (35-10); `BILLING.CUSTOMER.CREATED` (35-1). All `BILLING.%`-prefixed events feed the audit timeline projection.
+
+### Alert built-ins (added to `BuiltInAlertRules.All`)
+
+```csharp
+new BuiltInAlertRuleSpec(
+    BuiltInKey: "billing-reconciliation-drift",
+    Name: "billing-reconciliation-drift",
+    Description: "Local billing mirror drifted from Stripe for tenant {tenantId} (mirror {mirror}).",
+    Severity: AlertSeverity.Warning,
+    EventType: "BILLING.RECONCILIATION.DRIFT_DETECTED",
+    Predicate: """{"op":"always"}""",
+    ThrottleSeconds: 3600),
+
+new BuiltInAlertRuleSpec(
+    BuiltInKey: "billing-dunning-spike",
+    Name: "billing-dunning-spike",
+    Description: "5+ dunning escalations in an hour — a payment-processing or pricing regression may be affecting many tenants.",
+    Severity: AlertSeverity.Critical,
+    EventType: "BILLING.DUNNING.ESCALATED",
+    Predicate: """{"op":"count_gte","window_seconds":3600,"threshold":5}""",
+    ThrottleSeconds: 3600),
+
+new BuiltInAlertRuleSpec(
+    BuiltInKey: "billing-meter-flush-backlog",
+    Name: "billing-meter-flush-backlog",
+    Description: "10+ meter-event flush failures in 30 minutes — usage may not be reaching Stripe; revenue at risk.",
+    Severity: AlertSeverity.Warning,
+    EventType: "BILLING.USAGE.FLUSH_FAILED",
+    Predicate: """{"op":"count_gte","window_seconds":1800,"threshold":10}""",
+    ThrottleSeconds: 1800),
+```
+
+`BuiltInAlertRuleSeeder` picks them up automatically (idempotent insert by `built_in_key`). The `AlertRuleEvaluator` already synthesizes a `scope` tag (`platform` | `tenant:<guid>`) from the event's `TenantId`, so a tenant-scoped drift event raises a tenant-feed alert and a platform event raises an admin-feed alert with no rule changes.
+
+### API shape
+
+```
+GET /api/v1/orgs/{tenantId}/billing/timeline    (SaaS: MemberAccess + RequireTenantMembershipFilter; single-user: sole user)
+GET /api/v1/admin/billing/timeline               (OwnerAccess)  — platform-wide billing audit
+GET /api/v1/admin/billing/metrics                (OwnerAccess)  — revenue analytics (MRR/ARR/churn/margin)
+```
+
+Tenant timeline DTO entries are the redacted `BillingTimelineEntry`; the metrics DTO mirrors the `BillingRevenueDaily` columns summed over the window. The tenant timeline resolves `tenantId` from `ITenantContext` and rejects a route/context mismatch (no cross-tenant read). `GET /api/v1/admin/billing/metrics` and `.../timeline` are mounted on the existing `/api/admin` group's analytics section in `AdminAnalyticsEndpoints.cs` with `.RequireAuthorization("OwnerAccess")` (matching the existing `/api/admin/analytics/*` wiring style; note the billing routes use the `/api/v1/...` epic-35 convention while the legacy analytics routes stay `/api/admin/analytics/*`).
+
+### EF migration sketch
+
+Additive migration under `Tamma.Data/Migrations/ControlPlane/` (`dotnet ef migrations add AddBillingRevenueDaily`). New table `billing_revenue_daily` with the two partial unique indexes above; numeric columns `NUMERIC(20,4)`. After generating, run `dotnet ef migrations has-pending-model-changes` → expect none. No CHECK edits on existing tables (additive only).
+
+### Integration points
+
+- **`PlatformAnalyticsHourly` + `ComputePlatformRollupActivity` (Story 28-10 / Epic 5/23):** the analytics substrate this story extends; the daily revenue snapshot is computed in the same activity's pure-DI `ComputeAsync` path so it inherits the leader-locked `HourlyAnalyticsRollupScheduler` cadence (no new BackgroundService for the snapshot).
+- **`IPlatformTaskHandler` / `PlatformTaskWorker` (Story 28-6):** the daily reconciliation rides the existing CP task queue (`billing.reconcile`). ⚠ `PlatformTaskWorker:RunOnStartup` is `false` in prod today (tenancy residual) — enabling the reconciliation handler in prod must coordinate with that gate (same hazard 35-3 flags).
+- **`IEventRepository` (Epic 4):** DCB append for `BILLING.RECONCILIATION.*`; the audit projection reads the same CP `domain_events` table.
+- **`IAlertSink` / `AlertRuleEvaluator` / `BuiltInAlertRules` (Story 5.6):** drift/dunning/backlog alerts fan out through the existing pipeline.
+- **`IBillingProvider`/`NullBillingProvider` (Story 35-1):** all Stripe reads (`Subscriptions.List`, `Invoices.List`, customer balance) go through the foundation seam; `NullBillingProvider` makes single-user a no-op.
+- **Sibling mirrors:** `BillingSubscription` (35-4), `BillingInvoice`/`BillingInvoiceLine` (35-8), `BillingUsageRollup` (35-3), `BillingWalletLedger` (35-10), `BillingCustomer`/`BillingPlanPrice` (35-1/35-2) — read-only.
+
+### Per-mode + per-tenant handling
+
+| Concern | single-user mode | SaaS mode |
+|---|---|---|
+| Principal | the sole user | the tenant (`BillingCustomer.TenantId`) / platform owner |
+| `billing.reconcile` handler | not registered (`NullBillingProvider`) | registered; iterates `BillingCustomer` rows |
+| `BillingRevenueDaily` snapshot | not computed (no subs/customers) | computed daily in `ComputePlatformRollupActivity` |
+| `GET /api/v1/admin/billing/metrics` | zeroed/empty | revenue analytics over `BillingRevenueDaily` |
+| `GET /api/v1/admin/billing/timeline` | sole-user feed (any `BILLING.*` events) | platform-wide, `OwnerAccess` |
+| `GET /api/v1/orgs/{id}/billing/timeline` | sole user / 404 if not applicable | tenant members; own-tenant rows only |
+| Stripe calls | none | reconciliation reads only (never writes Stripe) |
+
+## Dependencies
+
+**Prerequisite (internal):**
+- **Story 35-3** — `BillingUsageRollup` (`PlatformCostUsd`, `BillableAmountUsd`), `IUsageMeteringService`, `BILLING.USAGE.RECONCILIATION_MISMATCH`/`BILLING.USAGE.FLUSH_FAILED`, the `billing.usage_reconcile` per-meter check this story consumes (does not duplicate).
+- **Story 35-4** — `BillingSubscription` mirror (status/seats/plan/period), `BILLING.SUBSCRIPTION.CREATED/UPDATED/CANCELED/TRIAL_ENDED`.
+- **Story 35-5** — the `BILLING.*` DCB emission seam (the audit projection's source stream) + `BillingWebhookEvent`.
+- **Story 35-8** — `BillingInvoice`/`BillingInvoiceLine`, `BillingDunningState`, `BILLING.INVOICE.*`/`BILLING.DUNNING.ESCALATED`/`BILLING.TENANT.SUSPENDED`.
+- **Story 35-10** — `BillingWalletLedger` (wallet-balance reconciliation), `BILLING.CREDIT.*`.
+- **Story 35-1 / 35-2** — `BillingCustomer` (tenant↔Stripe, `BillingMode`), `BillingPlanPrice`, `IBillingProvider`/`NullBillingProvider`, single-user seam.
+- **Epic 5/23 + Story 28-10** — `PlatformAnalyticsHourly` + `ComputePlatformRollupActivity` + `HourlyAnalyticsRollupScheduler` substrate.
+- **Story 28-6** — `PlatformTaskWorker` / `IPlatformTaskHandler` CP queue.
+- **Story 5.6** — `IAlertSink` / `AlertRuleEvaluator` / `BuiltInAlertRules` pipeline.
+- **Epic 4** — `IEventRepository` DCB store.
+- **Story 34-5** — `IUsagePricingEngine` (consumed only transitively via 35-3's already-priced rollup columns; no direct call here).
+
+**Blocks:**
+- **Story 35-11** — the admin Billing console renders this story's `GET /api/v1/admin/billing/metrics` (MRR/churn/margin) and timeline; 35-11 must not re-implement the math.
+
+**External:**
+- **Stripe.net** SDK (added by 35-1) — read-only `Subscriptions.List`, `Invoices.List`, customer balance.
+- `STRIPE_SECRET_KEY_TEST` for reconciliation integration tests.
+
+## Testing Strategy
+
+**Unit (xUnit, `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/`):**
+1. `BillingAuditServiceTests` — projection ordering (newest-first by `SequenceNumber`), cursor paging, `BILLING.` prefix filter, `from`/`to` window; **redaction whitelist** (an injected `cardNumber`/`apiKey`/`rawPayload` key in a `BILLING.*` event's `data` does NOT survive the projection); `tagGap = true` when a `BILLING.INVOICE.PAID` event is missing its `tenantId` tag; tenant-scope query returns only the caller-tenant's events (cross-tenant isolation).
+2. `BillingReconciliationTaskHandlerTests` — per-mirror drift detection (subscription status mismatch, invoice total mismatch beyond tolerance, usage drift consumed from 35-3 signal, wallet-balance mismatch) each emit one `BILLING.RECONCILIATION.DRIFT_DETECTED` with correct `mirror` tag; clean pass emits zero drift events + one `BILLING.RECONCILIATION.COMPLETED`; **per-mirror fail isolation** (a thrown Stripe error on the invoice mirror does not stop the subscription/usage/wallet checks or the run); per-customer iteration never cross-tags; self-reschedule enqueues the next `billing.reconcile` task.
+3. `BillingRevenueServiceTests` — MRR from a seeded `BillingSubscription` set (seat × per-seat + flat fee, annual `/12`); ARR = MRR × 12; status counts; **BYOK-vs-platform split** (a `Byok` customer's seat fee lands in `ByokRevenueUsd`, never `PlatformRevenueUsd`; its usage contributes zero usage revenue); margin = `Σ(BillableAmountUsd − PlatformCostUsd)`; logo + revenue churn from `BILLING.SUBSCRIPTION.CANCELED` events; idempotent daily snapshot upsert (running twice = one row, same totals).
+4. `BillingMetricsEndpointTests` — `GET /api/v1/admin/billing/metrics` returns the windowed snapshot for `OwnerAccess`; **403** for a tenant-role caller; single-user mode → zeroed payload; the **`metrics`-reconciles-to-invoices invariant** (`platformRevenueUsd + byokRevenueUsd` ≈ `Σ BillingInvoice` totals for the window within tolerance) on a seeded mirror set.
+5. `BillingTimelineEndpointTests` — tenant timeline RBAC (member read OK; cross-tenant → never another tenant's rows); admin timeline `OwnerAccess` + 403 for tenant role; single-user seam.
+6. `BillingAuditAlertRuleTests` — `BuiltInAlertRuleSeeder` creates the three new rules; the evaluator fires on an appended `BILLING.RECONCILIATION.DRIFT_DETECTED` (tenant-scoped → tenant feed via the synthesized `scope` tag; platform → admin feed); dunning-spike + flush-backlog `count_gte` thresholds fire only over threshold and the throttle suppresses a burst.
+7. `BillingAuditSingleUserSeamTests` — single-user mode registers no `billing.reconcile` handler, computes no snapshot, makes zero Stripe calls (`NullBillingProvider`).
+
+**Integration (gated on `STRIPE_SECRET_KEY_TEST`, docker-bound CP Postgres via `sg docker -c "dotnet test ..."`):**
+8. Seed `BillingSubscription`/`BillingInvoice`/`BillingUsageRollup`/`BillingWalletLedger` rows + matching Stripe test-customer state → reconciliation reports no drift; mutate one mirror → exactly one `BILLING.RECONCILIATION.DRIFT_DETECTED` for that mirror.
+9. End-to-end revenue snapshot against a mixed platform+BYOK seeded fleet → correct MRR/ARR/split/margin; `GET /api/v1/admin/billing/metrics` reconciles to the seeded `BillingInvoice` sum.
+
+**Mocks:** `IBillingProvider` (Stripe reads), `IUsageMeteringService`/35-3 drift signal, `IEventRepository`, `IAlertSink`, and `ITammaModeProvider` are mocked/faked in unit tests; CP context is EF InMemory/SQLite for unit, docker Postgres for integration. Stripe is never live in unit tests.
+
+## Estimated Effort
+
+4-5 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/BillingRevenueDaily.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (add `DbSet<BillingRevenueDaily>`) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (entity config + partial unique indexes + precision) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_AddBillingRevenueDaily.cs` | Create (additive migration) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/IBillingAuditService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingAuditService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingTimelineEntry.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/IBillingRevenueService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingRevenueService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingReconciliationTaskHandler.cs` | Create (`IPlatformTaskHandler`) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingMirrorReconciler.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingReconciliationOptions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingAuditEventTypes.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/Analytics/ComputePlatformRollupActivity.cs` | Modify (daily revenue snapshot tail, SaaS only) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminAnalyticsEndpoints.cs` | Modify (`GetBillingMetrics`, `GetBillingTimeline`) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/BillingTimelineEndpoints.cs` | Create (tenant timeline) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Alerts/Rules/BuiltInAlertRules.cs` | Modify (3 billing built-ins) |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/BillingAuditServiceCollectionExtensions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (wire services + map endpoints, SaaS-gated) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingAuditServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingReconciliationTaskHandlerTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingRevenueServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingMetricsEndpointTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingTimelineEndpointTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingAuditAlertRuleTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingAuditSingleUserSeamTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, and decisions (especially `platform-task-worker-runonstartup-hazard` and the Story 28-10 analytics-rollup design notes)
+3. Confirmed Stories 35-1, 35-3, 35-4, 35-5, 35-8, 35-10 are merged (this story is a pure reader/aggregator of their mirrors + events)
+4. Reviewed Stripe.net read APIs (`Subscriptions.List`, `Invoices.List`, customer balance) — research the latest list-pagination + meter-summary flags before use; do NOT assume a flag exists
+5. Planned the TDD Red-Green-Refactor cycle (tests first per the table above)
+
+### Key design decisions
+
+- **Read-side, derive-don't-capture.** The audit timeline is a projection over the already-durable `BILLING.*` `DomainEvent` stream — no new write path on the billing hot path, no duplicate store. The revenue snapshot recomputes from mirrors, so a missed run loses nothing and a replay is idempotent (same `(Day, TenantId)` upsert pattern as `PlatformAnalyticsHourly`).
+- **Reconciliation is read-only against Stripe.** This story never *writes* Stripe — it observes drift and raises an alert; remediation is an operator decision (35-11 console actions) or a sibling-story handler. This keeps the integrity layer from masking the bug it is meant to surface.
+- **Don't duplicate 35-3's usage check.** The usage mirror is reconciled by 35-3's `billing.usage_reconcile`; this story consumes that signal and folds it into the unified drift view. Re-running `Billing.Meters.ListEventSummaries` here would double the Stripe API load and risk two contradictory verdicts.
+- **No margin math, no pricing.** Margin is `BillableAmountUsd − PlatformCostUsd` read straight off 35-3's rollup (those columns are already the output of 34-5's `IUsagePricingEngine`). MRR uses 35-1's `BillingPlanPrice`. If you multiply by a margin here, you have crossed into 34-5's territory.
+- **Backend only — 35-11 owns the UI.** This story creates zero `packages/dashboard*` files. It produces the numbers; 35-11's admin Billing console renders them. The `metrics`/`timeline` endpoints are the contract between the two.
+- **Compliance-first redaction.** The timeline projection is a strict whitelist (drop-by-default), not a denylist, so a sibling story that starts putting a new sensitive field in a `BILLING.*` event's `data` cannot leak it through the audit surface without an explicit whitelist add.
+
+### Reconciliation tolerance + drift semantics
+
+- Per-mirror tolerances are config-driven (`Billing:Reconciliation:InvoiceToleranceUsd`, `WalletToleranceUsd`) so currency-rounding noise does not page operators. Subscription drift is exact (status/seats/plan are categorical). A drift event always carries the precise `{ local, stripe, delta }` so the operator can act without re-querying.
+- A flapping mirror (drift on one run, clean the next) re-alerts by design; the `ThrottleSeconds: 3600` on the built-in rule + the sink rate limiter cap the noise.
+
+### Graceful degradation
+
+If Stripe is unreachable: the reconciliation run logs + counts the per-customer failure, emits `BILLING.RECONCILIATION.COMPLETED` with the partial result, and the `PlatformTaskWorker` retries the task — the audit timeline and `metrics` endpoint keep serving the last-good local data. The revenue snapshot reads only local mirrors, so it is unaffected by a Stripe outage.
+
+## Logging Requirements
+
+- **INFO**: reconciliation run started/completed (`customersChecked`, `mirrorsChecked`, `driftCount`), revenue snapshot computed (`day`, `mrrUsd`, `platformUsageMarginUsd`), timeline/metrics endpoint queried (`tenantId?`, `window`).
+- **DEBUG**: per-customer mirror check result (`tenantId`, `mirror`, `local`, `stripe`), audit projection page served (`prefix`, `cursor`, `count`), self-reschedule enqueued (`nextRunAt`).
+- **WARN**: drift detected (`tenantId`, `mirror`, `field`, `local`, `stripe`, `delta`), `tagGap` on a `BILLING.*` event (`eventType`, `sequenceNumber`, missing tag), per-customer Stripe error during reconciliation (`tenantId`, scrubbed error).
+- **ERROR**: reconciliation handler unrecoverable failure (CP DB write), revenue snapshot compute failure (logged; the activity tail is fail-isolated so the hourly analytics rollup is never blocked), `metrics`-to-invoices invariant breach beyond tolerance (a real revenue-integrity problem).
+- **Structured context**: include `{ tenantId, stripeCustomerId, mirror, day, window, driftCount }` where applicable.
+- **Credential safety**: NEVER log Stripe API keys, signing secrets, raw card/PAN data, full webhook payloads, or BYOK provider keys. Scrub any Stripe-error message through `CredentialRedactor.Clean` before persistence/logging. The audit timeline projection is whitelist-only — sensitive `data` fields are dropped before they reach a log or an API response.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-35/story-35-2/35-2-byok-vs-platform-provided-billing-mode-and-per-tenant-provid.md
+++ b/docs/stories/epic-35/story-35-2/35-2-byok-vs-platform-provided-billing-mode-and-per-tenant-provid.md
@@ -1,0 +1,261 @@
+# Story 35-2: BYOK vs Platform-Provided Billing Mode & Per-Tenant Provider Key Cabinet Integration
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-phase workflow (Read → Research → Break Down → TDD → Quality Gates → Failure Handling), the `.dev/` knowledge base usage rules, TRACE/DEBUG logging requirements, the test-first (TDD) workflow, the 100% critical-path coverage requirement, and build-success enforcement.
+
+## User Story
+
+As a **tenant owner of a Tamma SaaS organization**,
+I want every LLM usage record and billing event to carry the billing mode (BYOK vs platform-provided) that already governed the call — the mode declared on Story 34-3's `TenantProviderBilling` and the credential source resolved by Story 32-3's `IProviderCredentialResolver`,
+so that BYOK usage is billed as a platform/seat fee only (no token markup) while platform-provided usage is metered and marked up — and so Story 35-3 can split billable from non-billable token usage with a single tag filter.
+
+## Priority
+
+P0 — Required so Story 35-3 (BYOK-aware usage metering) can split billable from non-billable token usage. Without a billing-mode tag stamped onto the usage trail there is no correct basis to invoice.
+
+## Boundary (READ FIRST)
+
+This story owns the **billing TREATMENT of modes only** — it does **not** own key resolution or the mode source of truth:
+
+- **Story 32-3** owns BYOK→platform provider-key resolution from the Epic 29 secret cabinet into the LLM call path via `IProviderCredentialResolver` (`Tamma.Api.Services.Providers`), returning `ProviderCredential { ApiKey, Source ∈ {Byok, Platform}, ... }`. 35-2 **consumes** that `Source`; it does **not** read the cabinet or rewrite the proxy's `x-api-key` resolution.
+- **Story 34-3** owns the pricing-MODE selection per `(tenant, provider)` via the `TenantProviderBilling` entity and its `IProviderKeyResolver`/`ProviderKeyResolution` (`Tamma.Api.Services.Pricing`) — the single source of truth for BYOK-vs-platform mode — plus the BYOK enable/disable endpoints and the `ProviderDiagnostic.BillingMode` column. 35-2 **reads** the resolved mode from 34-3; it does **not** define a competing per-tenant mode field or endpoint, and it does **not** add the diagnostic column.
+
+35-2's sliver: propagate the already-resolved mode (34-3) + credential source (32-3) onto the **usage/billing DCB event** as a `BillingMode` tag so Story 35-3 meters ONLY platform-provided usage and excludes BYOK token usage from billable metering.
+
+## Acceptance Criteria
+
+1. A new `IBillingModeTagger` seam (`apps/tamma-elsa/src/Tamma.Api/Services/Billing/IBillingModeTagger.cs`) computes the canonical `billing_mode` token (`byok | platform`) for a `(tenantId, providerKey)` LLM call by **reading** Story 34-3's mode source of truth — `IProviderKeyResolver.ResolveAsync(...)` / the `TenantProviderBilling` row (`Tamma.Api.Services.Pricing`) — and reconciling it with Story 32-3's resolved credential source (`ProviderCredential.Source`) when that is already on the call context. 35-2 defines **no** mode field or mode-switch endpoint of its own.
+2. When both signals are present they MUST agree (34-3 mode == 32-3 source); a mismatch is logged WARN, the **32-3 credential source wins** for the tag (it is the source actually used for the wire call), and a `BILLING.MODE.MISMATCH` DCB diagnostic event is emitted so the divergence is auditable.
+3. The `billing_mode` token is propagated onto the **usage DCB event** emitted on the LLM path: every `LLM.CALL.SUCCESS` and `LLM.CALL.FAILED` event carries `billing_mode` (`byok | platform`), `provider`, `model`, and `tenantId` in its JSONB `Tags`, so Story 35-3's metering/alert evaluators can split usage off the event stream without a join.
+4. The same `billing_mode` token is written into the existing `ProviderDiagnostic.BillingMode` column (the column is **owned and created by Story 34-3** — this story only ensures the value on the LLM-call usage path matches the tag on the DCB event; it does **not** add or migrate the column).
+5. The LLM call path (`LlmProxyService.ChatAsync`, plus the agent provider-chain diagnostic path via `ProviderChainResolver`) obtains its provider key from Story 32-3's `IProviderCredentialResolver` — 35-2 **does not** resolve keys, read the cabinet, or rewrite the `x-api-key` header itself. If a call site does not yet consume 32-3's resolver, the billing-mode tag is derived from 34-3's mode alone (AC1) without 35-2 introducing a competing key path.
+6. The DCB usage event emission on the LLM path is added by this story (the current `LlmProxyService` records a `ProviderDiagnostic` but emits no `LLM.CALL.*` DCB event); events are appended via `IEventRepository.AppendAsync` to the tenant-scoped control-plane `DomainEvents` store (`DomainEvent.TenantId` set).
+7. The `billing_mode` token written to both the event tag and the diagnostic column is **read-only** with respect to 34-3 — 35-2 never writes `TenantProviderBilling`, never writes `BillingCustomer.BillingMode`, and exposes no `PUT/POST/DELETE` route that changes a tenant's mode. Mode changes remain Story 34-3's BYOK enable/disable endpoints.
+8. **Single-user mode** (`ITammaModeProvider.Mode == TammaMode.SingleUser`) treats all usage as self-owned: the tagger resolves to `platform` semantics from 34-3 (single-user always platform) and the markup-relevant `billing_mode` tagging is skipped — usage events/diagnostics for single-user calls carry no billable-mode implication. Registration uses a Null seam (mirroring Story 35-1's `NullBillingProvider`); request handlers never branch on mode.
+9. No provider key plaintext is read, handled, logged, or serialised by this story: key plaintext lives only inside Story 32-3's resolver. A redaction unit test asserts that no key string appears in any captured log output or in any usage/diagnostic response body produced on the 35-2 path.
+10. SaaS provider auth is **API-key only** (BYOK secrets are `SecretPurpose.ApiKey`, owned by 32-3/34-3); the CLI/token agent providers (`ICLIAgentProvider`) remain a single-user/self-hosted concern and are explicitly out of scope for the SaaS billing-mode tag.
+11. `BillingMode` tag values are constrained to exactly `byok` or `platform` (matching 32-3's `CredentialSource` and 34-3's `MetricBillingMode` tokens); any other resolved value is rejected with a logged ERROR rather than silently tagged.
+12. Unit tests cover: tagger reads 34-3 mode = `byok` → tag `byok`; 34-3 mode = `platform` → tag `platform`; 32-3 source present and agreeing → tag matches; 32-3 source disagreeing with 34-3 → 32-3 wins + WARN + `BILLING.MODE.MISMATCH` event; single-user → no billable-mode implication; a `byok`-tagged usage event/diagnostic is read by Story 35-3 as non-billable-for-tokens.
+13. Unit tests assert the usage event tagging: a `byok` call ⇒ `LLM.CALL.SUCCESS` tagged `billing_mode=byok` and `ProviderDiagnostic.BillingMode == "byok"`; a `platform` call ⇒ `billing_mode=platform`; an over-budget/failed call ⇒ `LLM.CALL.FAILED` carrying the same `billing_mode` tag.
+14. Integration tests (xUnit, control-plane DbContext on a real Postgres via the existing docker-bound test harness) cover tenant isolation of the tag: the `billing_mode` resolved for tenant A reflects A's `TenantProviderBilling` mode and never B's; the usage event/diagnostic for a call is tagged with the calling tenant's mode only. Stripe and the upstream provider HTTP handler are mocked.
+
+## Technical Design
+
+### Namespace & file structure
+
+```
+apps/tamma-elsa/src/Tamma.Api/Services/Billing/
+  IBillingModeTagger.cs            # NEW — seam: compute billing_mode token for (tenant, provider)
+  BillingModeTagger.cs             # NEW — READS 34-3 mode (IProviderKeyResolver) + reconciles 32-3 source
+  NullBillingModeTagger.cs         # NEW — single-user no-op (no billable-mode implication)
+  BillingModeEvents.cs             # NEW — LLM.CALL.SUCCESS/FAILED + BILLING.MODE.MISMATCH constants
+  BillingModeTokens.cs             # NEW — "byok" | "platform" constants (match 32-3/34-3 tokens)
+
+apps/tamma-elsa/src/Tamma.Api/Extensions/
+  BillingModeServiceCollectionExtensions.cs   # NEW — AddBillingModeTagging(); single-user registers Null seam
+
+apps/tamma-elsa/src/Tamma.Api/Services/SaaS/
+  LlmProxyService.cs               # MODIFY — tag usage DCB event + diagnostic with billing_mode (read from tagger);
+                                   #          key comes from 32-3's IProviderCredentialResolver, NOT this story
+  ILlmProxyService.cs              # (unchanged signature; behaviour change only)
+```
+
+> **Not owned by this story (consumed only):**
+> - `IProviderCredentialResolver` + `ProviderCredential { ApiKey, Source }` (`Tamma.Api.Services.Providers`) — **Story 32-3**. The LLM call path's `x-api-key` is resolved there; 35-2 reads `Source`.
+> - `TenantProviderBilling` entity + `IProviderKeyResolver`/`ProviderKeyResolution` + `MetricBillingMode` enum + BYOK enable/disable endpoints (`Tamma.Api.Services.Pricing`) — **Story 34-3**. The per-(tenant,provider) mode is read from here.
+> - `ProviderDiagnostic.BillingMode` column + its migration — **created by Story 34-3**. 35-2 only writes the value on the LLM-call usage path; it does **not** add or migrate the column.
+>
+> All names verified against the current tree. `IBillingProvider`/`NullBillingProvider` and the `Services/Billing/` directory are **created by Story 35-1** (prerequisite). `Services/SaaS/LlmProxyService.cs`, `Services/Providers/ProviderChainResolver.cs`, `Data/Repositories/IEventRepository.cs`, `Data/Entities/DomainEvent.cs`, and `Services/PromptStore/TammaMode.cs` (`ITammaModeProvider`) all exist today. No reference is made to the deleted `packages/api`.
+
+### Billing-mode tagger seam
+
+```csharp
+namespace Tamma.Api.Services.Billing;
+
+public interface IBillingModeTagger
+{
+    /// <summary>Compute the canonical billing_mode token ("byok" | "platform")
+    /// for an LLM call. READS Story 34-3's TenantProviderBilling mode (via
+    /// IProviderKeyResolver). If Story 32-3's resolved ProviderCredential.Source
+    /// is supplied, it is reconciled: on disagreement the 32-3 source wins (it is
+    /// the credential actually used on the wire) + WARN + BILLING.MODE.MISMATCH.
+    /// This seam OWNS no mode — it never writes TenantProviderBilling and never
+    /// reads or returns a key plaintext.</summary>
+    Task<string> ResolveTagAsync(
+        Guid? tenantId,
+        string providerKey,
+        string? credentialSource = null,   // from 32-3 ProviderCredential.Source when available
+        CancellationToken ct = default);
+}
+```
+
+`BillingModeTagger`:
+
+1. Calls Story 34-3's `IProviderKeyResolver.ResolveAsync(tenantId, providerKey)` (or its mode-only read) and takes `ProviderKeyResolution.Mode` (`MetricBillingMode` → `byok`/`platform`). **No cabinet read, no key plaintext handled here** — 34-3 owns that path.
+2. If `credentialSource` (from 32-3's `ProviderCredential.Source`) is non-null and disagrees with the 34-3 mode: log WARN, prefer the 32-3 source for the tag, and emit a `BILLING.MODE.MISMATCH` DCB diagnostic event (`Tags = { tenantId, provider, mode34, source32 }`).
+3. Validate the resulting token is exactly `byok` or `platform` (AC11) — anything else is an ERROR, not a silent tag.
+4. Single-user (`ITammaModeProvider.Mode == SingleUser`) ⇒ `NullBillingModeTagger` returns the platform semantics 34-3 already yields for single-user; the markup-relevant tagging is skipped.
+
+### LLM-call wiring (consume, don't reimplement)
+
+`LlmProxyService.ChatAsync` (and the `ProviderChainResolver` chain path) already obtain — or will obtain, once Story 32-3 lands — their outbound key from **32-3's `IProviderCredentialResolver`**. This story does **not** add a key resolver and does **not** rewrite the `x-api-key` resolution. 35-2's only change to the call path is:
+
+- After the credential is resolved (by 32-3) and the call completes, call `IBillingModeTagger.ResolveTagAsync(tenantId, providerKey, credentialSource)` to obtain the `billing_mode` token.
+- Stamp `diag.BillingMode = token` on the `ProviderDiagnostic` row (column owned by 34-3).
+- Append the usage DCB event (`LLM.CALL.SUCCESS`/`FAILED`) with `billing_mode` in `Tags` (this event emission is added by this story — see below).
+
+If a call site has not yet been migrated to 32-3's resolver, the tag is derived from 34-3's mode alone (AC5) — 35-2 never introduces a competing key path to fill the gap.
+
+### EF migration
+
+**None.** The `ProviderDiagnostic.BillingMode` column and its index are added by **Story 34-3** (`<ts>_AddProviderDiagnosticBillingMode.cs` under `Migrations/ControlPlane/` per 34-3's plan). This story adds no entity column and no migration; it only writes the existing column on the LLM-call usage path. If 34-3 has not landed the column, block on 34-3.
+
+### DCB event names
+
+| Event | When | TenantId | Tags | Data |
+|---|---|---|---|---|
+| `LLM.CALL.SUCCESS` | successful proxied call | tenant | `{ tenantId, billing_mode, provider, model }` | `{ inputTokens, outputTokens, totalTokens, costUsd, durationMs }` |
+| `LLM.CALL.FAILED` | failed/over-budget/upstream-error call | tenant | `{ tenantId, billing_mode, provider, model, reason }` | `{ durationMs }` |
+| `BILLING.MODE.MISMATCH` | 34-3 mode ≠ 32-3 credential source on a call | tenant | `{ tenantId, provider, mode34, source32 }` | `{ observedAt }` |
+
+Event types follow the `AGGREGATE.ACTION.STATUS` convention. `billing_mode` is the same `byok|platform` token written to the `ProviderDiagnostic.BillingMode` column (owned by 34-3), so the metering reader (35-3) can read it off either the event stream or the table. **There is no `BILLING.MODE.CHANGED` event in this story** — mode changes are owned by Story 34-3's BYOK enable/disable endpoints.
+
+> The current `LlmProxyService` records diagnostics but does not emit DCB `LLM.CALL.*` events. This story adds those emissions (via injected `IEventRepository`) so 35-3 has an event-stream basis in addition to the diagnostics table.
+
+### API shape
+
+**This story exposes no mutating HTTP endpoint.** It defines no `/api/v1/billing/mode` route — the per-(tenant,provider) mode is set via **Story 34-3's** `POST/DELETE /api/v1/orgs/{tenantId}/pricing/providers/{providerKey}/byok` and read via 34-3's `GET …/pricing/providers`. 35-2 is a producer of usage-event tags only.
+
+### Per-mode + per-tenant handling
+
+| Concern | single-user (`TammaMode.SingleUser`) | SaaS (`TammaMode.SaaS`) |
+|---|---|---|
+| Who owns the billing mode? | N/A — no billing dimension; the sole user owns all usage | The tenant, via **Story 34-3's** `TenantProviderBilling` (35-2 only reads it) |
+| Mode-change route | n/a | **Story 34-3's** `…/pricing/providers/{providerKey}/byok` (not this story) |
+| Provider key source | **Story 32-3** (`IProviderCredentialResolver`) — local/platform | **Story 32-3** — BYOK tenant cabinet key → platform key |
+| Diagnostic `BillingMode` (column owned by 34-3) | null (no billing implication) | `byok` or `platform`, written by 35-2 on the call path |
+| `billing_mode` usage-event tag | absent | `byok` or `platform` |
+| Markup applied (35-3) | never | `platform` only |
+| Mode source of truth | `ITammaModeProvider.Mode` (single-user ⇒ platform) | 34-3 `TenantProviderBilling.Mode` |
+
+Tenant isolation is inherited: 34-3's `IProviderKeyResolver` only reads the calling tenant's `TenantProviderBilling` row, and the usage event/diagnostic is stamped with the tenant on the call context, never a client-supplied id.
+
+### Integration points
+
+- **Story 32-3 (consumed)** supplies `IProviderCredentialResolver` + `ProviderCredential.Source`. The LLM call path resolves its key there; 35-2 reads `Source` to reconcile the tag. 35-2 adds **no** key resolution.
+- **Story 34-3 (consumed)** supplies `TenantProviderBilling` (mode source of truth), `IProviderKeyResolver`/`ProviderKeyResolution`/`MetricBillingMode`, the BYOK enable/disable endpoints, and the `ProviderDiagnostic.BillingMode` column + migration. 35-2 reads the mode and writes the column value on the usage path; it owns none of these.
+- **Story 35-1** supplies `IBillingProvider`/`NullBillingProvider` and the `Services/Billing/` directory. This story extends, never re-creates, those.
+- **Story 35-3 (feeds)** consumes the `ProviderDiagnostic.BillingMode` value and the `LLM.CALL.*` `billing_mode` tag to split billable vs non-billable token usage. This story is the producer of the tag; 35-3 is the consumer.
+- **`ProviderChainResolver`** (agent provider-chain path): the same `billing_mode` token is threaded onto the diagnostic that the chain path already writes, so chain-routed calls are tagged consistently with the proxy path.
+
+## Dependencies
+
+**Internal (prerequisite / consumed — hard blockers):**
+- **Story 32-3** (credential source) — `IProviderCredentialResolver` + `ProviderCredential.Source` (`byok | platform`). The LLM call path's key resolution lives here; 35-2 reads `Source`. 35-2 MUST NOT reimplement key resolution.
+- **Story 34-3** (mode) — `TenantProviderBilling` (single source of truth for BYOK-vs-platform mode), `IProviderKeyResolver`/`MetricBillingMode`, the BYOK enable/disable endpoints, **and the `ProviderDiagnostic.BillingMode` column + migration**. 35-2 reads the mode and writes the column value; it owns none of these.
+- **Story 35-1** — `IBillingProvider`/`NullBillingProvider`, the `Services/Billing/` directory. Hard blocker for the directory + Null-seam pattern.
+
+**Internal (feeds / blocks):**
+- **Story 35-3** (BYOK-aware usage metering) — depends on the `billing_mode` tag (on `LLM.CALL.*`) + the populated `ProviderDiagnostic.BillingMode` value this story produces, so it meters ONLY platform-provided usage and excludes BYOK token usage from billable metering.
+
+**Internal (supporting):**
+- **Epic 27 (RBAC/ownership pattern)** — the `tenant_owner`/`tenant_admin`/`member` matrix; relevant only because 34-3's mode-change endpoints (not this story's) gate on it.
+
+**External:**
+- PostgreSQL 17 control-plane DbContext (existing) for integration tests.
+- The upstream provider HTTP handler — mocked here; no live calls.
+
+## Testing Strategy
+
+**Unit tests** (`apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/`):
+1. `BillingModeTaggerTests` — 34-3 mode `byok` (faked `IProviderKeyResolver`) ⇒ tag `byok`; 34-3 mode `platform` ⇒ tag `platform`; 32-3 `credentialSource` supplied and agreeing ⇒ tag matches, no mismatch event; 32-3 source disagreeing with 34-3 ⇒ 32-3 wins + WARN + one `BILLING.MODE.MISMATCH` event; non-`byok|platform` token ⇒ ERROR (AC11); single-user (`NullBillingModeTagger`) ⇒ platform semantics, no billable-mode implication.
+2. `LlmProxyServiceBillingModeTests` — Byok call ⇒ diagnostic `BillingMode == "byok"` + `LLM.CALL.SUCCESS` tagged `billing_mode=byok`; platform call ⇒ `"platform"`; over-budget ⇒ `LLM.CALL.FAILED` carrying the same tag; the test asserts 35-2 reads the key via the faked **32-3** `IProviderCredentialResolver` and never resolves a key itself.
+3. `BillingModeRedactionTests` — capture logger output + response/usage-event payloads across a full Byok call; assert no key string ever appears (AC9). (Plaintext is owned by 32-3; this proves 35-2's path leaks nothing.)
+4. `ProviderChainBillingModeTests` — a chain-routed call writes the same `billing_mode` token onto the chain-path diagnostic, consistent with the proxy path.
+
+**Integration tests** (`Tamma.Api.Tests`, docker-bound, real Postgres control-plane):
+5. **Tenant isolation of the tag**: seed tenant A `TenantProviderBilling` mode `byok`, tenant B `platform`; assert the `billing_mode` resolved/stamped for A's call is `byok` and reflects only A's row, B's only `platform`.
+6. Round-trip: after 34-3 sets a tenant to `byok`, the next LLM call's `ProviderDiagnostic.BillingMode` and `LLM.CALL.SUCCESS` tag both read `byok`; after 34-3 disables BYOK, they read `platform`.
+7. Single-user mode: `BillingModeServiceCollectionExtensions` registers `NullBillingModeTagger` ⇒ usage events/diagnostics carry no billable-mode implication.
+
+**Mocks:** **32-3** `IProviderCredentialResolver` faked (returns `{ApiKey, Source}`); **34-3** `IProviderKeyResolver` faked (returns `ProviderKeyResolution.Mode`); upstream provider via `HttpMessageHandler` stub. No secret-cabinet fake is needed in 35-2 tests — 35-2 reads no cabinet.
+
+Coverage targets per `CLAUDE.md`: 80% line / 75% branch / 85% function; tag resolution + mismatch reconciliation + redaction are critical paths → 100%.
+
+## Estimated Effort
+
+2-3 days (reduced from 4-5: key resolution is consumed from 32-3 and the mode store + diagnostic column from 34-3, so this story is the tagger + usage-event wiring only)
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/IBillingModeTagger.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingModeTagger.cs` | Create (reads 34-3 `IProviderKeyResolver`; reconciles 32-3 `ProviderCredential.Source`) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/NullBillingModeTagger.cs` | Create (single-user no-op) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingModeEvents.cs` | Create (`LLM.CALL.*`, `BILLING.MODE.MISMATCH` constants) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingModeTokens.cs` | Create (`byok`/`platform` constants) |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/BillingModeServiceCollectionExtensions.cs` | Create (`AddBillingModeTagging`; single-user Null seam) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/SaaS/LlmProxyService.cs` | Modify (tag diagnostic + emit `LLM.CALL.*` DCB; key comes from 32-3 resolver) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderChainResolver.cs` | Modify (stamp same `billing_mode` on chain-path diagnostic) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (call `AddBillingModeTagging`) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingModeTaggerTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/LlmProxyServiceBillingModeTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/ProviderChainBillingModeTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingModeRedactionTests.cs` | Create |
+
+> **Not created/modified here (owned elsewhere):** `ProviderDiagnostic.cs` / `TammaModelConfiguration.cs` / the `AddProviderDiagnosticBillingMode` migration (Story 34-3); `IProviderCredentialResolver` (Story 32-3); any `/api/v1/billing/mode` endpoint (removed — mode changes are Story 34-3's BYOK endpoints).
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, decisions (especially Story 32-3 credential-resolution and Story 34-3 pricing-mode foundations)
+3. Confirmed Story 32-3 (`IProviderCredentialResolver`) and Story 34-3 (`TenantProviderBilling` + `ProviderDiagnostic.BillingMode` column) are merged — this story consumes both and must not reimplement them
+4. Reviewed Story 34-3's `IProviderKeyResolver` (mode read) and Story 32-3's `ProviderCredential.Source` as the two inputs to the tag
+5. Planned the TDD approach (Red-Green-Refactor)
+
+### Key design decisions
+
+- **Consume the mode and key, don't reimplement them.** The mode is read from Story 34-3's `TenantProviderBilling` (via `IProviderKeyResolver`); the key/credential source is Story 32-3's `IProviderCredentialResolver`. 35-2 adds neither a key resolver nor a mode store — it only computes and stamps a `billing_mode` tag.
+- **Billing mode is a tag on the usage event + the existing diagnostic value, not a join.** Writing `billing_mode` onto the `LLM.CALL.*` event tags and into 34-3's `ProviderDiagnostic.BillingMode` column lets Story 35-3 split usage with no extra lookup — the producer pays the small denormalisation cost once.
+- **Reconcile, don't duplicate, the two signals.** When both 34-3's mode and 32-3's credential source are present they should agree; on disagreement the 32-3 source (the credential actually used on the wire) wins for the tag, WARN is logged, and a `BILLING.MODE.MISMATCH` event makes the divergence auditable.
+- **Single-user is a registration-time no-op, not a runtime branch storm.** `AddBillingModeTagging` registers `NullBillingModeTagger` in single-user mode — the same pattern Story 35-1 uses for `NullBillingProvider` — so request handlers never branch on mode.
+
+### Boundary Note (honored exactly)
+
+This story **owns the BILLING TREATMENT of modes only**: stamp the resolved mode + credential source onto the usage/diagnostic record and the DCB billing tag so Story 35-3 meters ONLY platform-provided usage and excludes BYOK token usage from billable metering.
+
+It is **not** a key-resolution story — provider-key resolution from the Epic 29 cabinet into the LLM call path is **Story 32-3** (`IProviderCredentialResolver`, `ProviderCredential.Source`). It is **not** a mode-ownership story — the pricing-MODE per `(tenant, provider)` is **Story 34-3** (`TenantProviderBilling`, the single source of truth), which also owns the `ProviderDiagnostic.BillingMode` column and the BYOK enable/disable endpoints. 35-2 reads both and produces the `billing_mode` signal that 35-3 meters against. The multi-provider chain build-out remains Epic 1/9 territory.
+
+### Security requirements
+
+- No provider-key plaintext is read, handled, logged, or serialised by this story — plaintext lives only inside Story 32-3's resolver. 35-2 handles only the `byok`/`platform` token.
+- The `billing_mode` token is constrained to exactly `byok` or `platform`; any other value is an ERROR, never a silent tag.
+- Tenant isolation is inherited from 34-3's resolver (reads only the calling tenant's `TenantProviderBilling` row) and from the call context's tenant id; 35-2 introduces no client-supplied tenant path.
+
+## Logging Requirements
+
+- **INFO**: billing-mode tag resolved (`tenantId`, `provider`, `billingMode` — **no key**); LLM call completed (`tenantId`, `billingMode`, `model`, `totalTokens`, `costUsd`).
+- **DEBUG**: billing-mode tagging started (`tenantId`, `provider`); usage event/diagnostic stamped (`tenantId`, `billingMode`, `tokensUsed`).
+- **WARN**: 34-3 mode disagrees with 32-3 credential source (`tenantId`, `provider`, `mode34`, `source32`) — 32-3 source wins; over-budget LLM rejection.
+- **ERROR**: resolved `billing_mode` token is neither `byok` nor `platform`; DCB append failure on the usage/mismatch event.
+- **Structured context**: include `{ tenantId, billingMode, provider, model }` where applicable.
+- **Credential safety**: NEVER log any provider key or secret plaintext (35-2 never holds one). Redaction is asserted by `BillingModeRedactionTests`.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |
+| 2026-06-17 | 1.1.0   | Scope-corrected: consume 32-3 keys + 34-3 mode; removed duplicate key resolver and parallel mode store | Claude |

--- a/docs/stories/epic-35/story-35-3/35-3-byok-aware-usage-metering-and-stripe-meter-event-reporting.md
+++ b/docs/stories/epic-35/story-35-3/35-3-byok-aware-usage-metering-and-stripe-meter-event-reporting.md
@@ -1,0 +1,332 @@
+# Story 35-3: BYOK-Aware Usage Metering & Stripe Meter Event Reporting
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-phase workflow (Read → Research → Break Down → TDD → Quality Gates → Failure Handling), the `.dev/` knowledge-base usage rule, TRACE/DEBUG logging requirements, the test-first (TDD) mandate, the 100% critical-path coverage target, and build-success enforcement. **Failure to follow this process will result in rework.**
+
+## User Story
+
+As a **platform operator monetizing the Tamma SaaS control plane**,
+I want platform-provided AI token usage metered, priced (cost basis + margin), and reported to Stripe Billing Meters while BYOK token usage is recorded for analytics but never billed as tokens,
+so that each tenant is invoiced correctly — platform tenants pay for marked-up usage, BYOK tenants pay only the plan/seat fee — with a real-time local usage read, resilient batch flushing, and a reconciliation safety net against Stripe drift.
+
+## Priority
+
+P0 — Required to actually charge for platform-provided usage; the rest of Epic 35 (invoicing, dunning, portal) depends on accurate metered usage landing in Stripe.
+
+## Acceptance Criteria
+
+1. A new control-plane entity `BillingUsageRollup` (`Tamma.Data/Entities/BillingUsageRollup.cs`, registered on `ControlPlaneDbContext`) aggregates **per tenant per billing period** the columns: `TenantId`, `PeriodStart`, `PeriodEnd`, `PlatformInputTokens`, `PlatformOutputTokens`, `ByokInputTokens`, `ByokOutputTokens`, `PlatformCostUsd`, `BillableAmountUsd`, `Seats`, `LastSourceCursor`, `UpdatedAt`. A partial unique index on `(TenantId, PeriodStart)` makes period upserts idempotent (mirrors the `(Hour, TenantId)` idempotency pattern on `PlatformAnalyticsHourly`).
+2. The rollup is sourced from the `billing_mode`-tagged usage facts produced by Stories 35-2 (`ProviderDiagnostic.billing_mode` tag) and 32-9/34-5 (`LLM.CALL.SUCCESS` DCB events carrying `billingMode`, `costBasisUsd`, `sellPriceUsd`) — read from the CP `PlatformAnalyticsHourly` fact table (which must split tokens by `billing_mode`) and/or the priced usage events; **no new pricing/markup math is implemented in this story** (consumed from 34-5's `IUsagePricingEngine`).
+3. Only `billing_mode = platform` usage is enqueued as Stripe meter events to `tamma.platform_tokens_input` and `tamma.platform_tokens_output` (meter event names + `stripe_customer_id` customer mapping defined by Story 35-1's `BillingPlanCatalog`); `billing_mode = byok` usage increments `ByokInputTokens`/`ByokOutputTokens` on the rollup and is **explicitly skipped** for token meters (asserted by a dedicated test).
+4. `BillableAmountUsd` is computed as platform cost basis × (1 + margin) by calling 34-5's `IUsagePricingEngine.PriceUsage(...)`; the margin and price table are **config-driven via 34-5's `MarginPolicy` + 35-1's `billing_plan_prices`**, never hardcoded in `LlmProxyService` or this story's `UsageMeteringService`.
+5. `UsageMeteringService` (`Tamma.Api/Services/Billing/UsageMeteringService.cs`) exposes `UpsertRollupAsync(tenantId, period, ct)` (recompute a tenant-period from facts) and `GetCurrentUsageAsync(tenantId, ct)` (read the current-period rollup), and a `BufferMeterEventsAsync(...)` that writes pending meter events for the flush handler — all on the control plane, all tenant-scoped.
+6. Meter events are buffered (persisted as `PlatformQueuedTask` rows of type `billing.meter_flush`, or an equivalent CP-resident pending-events table) and flushed by `MeterEventFlushTaskHandler` (`Tamma.Api/Services/Billing/MeterEventFlushTaskHandler.cs`) implementing `IPlatformTaskHandler` (default cadence 60s, configurable via `Billing:MeterFlushIntervalSeconds`), staying within Stripe's meter-event rate limit (1,000 events/sec standard API); a successful flush marks the buffered row `reported_to_stripe = true`.
+7. Failed flushes persist with `reported_to_stripe = false` and are retried on the next cycle (the `PlatformTaskWorker` retry/dead-letter semantics apply); a flush failure emits `BILLING.USAGE.FLUSH_FAILED` and never throws back into the LLM call path.
+8. `GET /api/v1/billing/usage` (`Tamma.Api/Endpoints/Billing/BillingUsageEndpoints.cs`) returns the **current-period** `{ platformInputTokens, platformOutputTokens, byokInputTokens, byokOutputTokens, platformCostUsd, billableUsd, seats, periodStart, periodEnd }` for the **caller's tenant**, read from the local `BillingUsageRollup` (NOT Stripe, which lags); RBAC: SaaS tenant member read access (`MemberAccess`), single-user mode = the sole user.
+9. A reconciliation `IPlatformTaskHandler` of type `billing.usage_reconcile` (scheduled hourly) compares local `BillableAmountUsd`/token totals to Stripe meter event summaries (`Stripe.Billing.Meters.ListEventSummaries`) per active billing customer and emits `BILLING.USAGE.RECONCILIATION_MISMATCH` on drift beyond a configurable tolerance, with WARN-level structured logs.
+10. DCB events `BILLING.USAGE.RECORDED` (per rollup upsert / batch flush), `BILLING.USAGE.FLUSH_FAILED`, and `BILLING.USAGE.RECONCILIATION_MISMATCH` are appended via `IEventRepository.AppendAsync` with tags `{ tenantId, billingMode?, periodStart, stripeCustomerId? }` following the `AGGREGATE.ACTION.STATUS` convention; the reconciliation event also feeds the existing `AlertRuleEvaluator`.
+11. Metering is **fail-open for billing**: if the rollup write, Stripe call, or reconciliation throws, the LLM call path is never blocked — facts already live in `ProviderDiagnostic`/`PlatformAnalyticsHourly`, so the rollup is recomputed idempotently on the next cycle.
+12. Single-user mode (`ITammaModeProvider == SingleUser`) registers no flush/reconcile handlers and the `/api/v1/billing/usage` endpoint is absent (or returns 404), mirroring 35-1's `NullBillingProvider` seam; no Stripe calls are ever made.
+13. Tenant isolation: a tenant can only read its own rollup via `GET /api/v1/billing/usage`; the meter-flush and reconciliation handlers iterate `BillingCustomer` rows on the CP and never leak one tenant's usage into another's meter events (covered by a cross-tenant isolation test).
+14. Unit + integration tests (integration gated on `STRIPE_SECRET_KEY_TEST`) cover: platform-vs-BYOK token split, the margin/billable math path (delegated to a mocked `IUsagePricingEngine`), batch flush success/failure/retry, rollup aggregation query idempotency, reconciliation drift detection, and the single-user no-op seam.
+
+## Technical Design
+
+### Boundary statement (honor the epic split)
+
+This story is a **consumer**, not an owner, of pricing:
+
+- **32-9 (producer):** agents emit per-call usage + cost-basis facts tagged `agent_id/tenant/provider/model/billing_mode`. This story reads those facts.
+- **35-2 (mode):** owns `BillingCustomer.BillingMode` and the `billing_mode` tag on `ProviderDiagnostic`/`LLM.CALL.*` events. This story trusts that tag.
+- **34-5 (markup engine):** the **canonical** cost→price markup engine (`IUsagePricingEngine.PriceUsage`). This story **calls** it and must NOT re-implement margin math (`boundaryNote`: "does not own markup").
+- **35-1 (foundation):** owns `BillingCustomer` (tenant→`StripeCustomerId`), `BillingPlanCatalog`/`billing_plan_prices` (meter ids `tamma.platform_tokens_input/output`, `tamma.seats`), and the `Stripe.net` SDK registration + `ISecretStore`-sourced key.
+
+This story **reports PRICED usage to Stripe meters** and owns the rollup + flush + reconciliation pipeline.
+
+### Namespace / file structure (C#)
+
+```
+apps/tamma-elsa/src/Tamma.Data/
+  Entities/
+    BillingUsageRollup.cs                 # NEW — CP entity (token split + cost + billable + seats)
+    BillingMeterEventBuffer.cs            # NEW — CP pending meter-event row (idempotency + reported_to_stripe flag)
+  ControlPlaneDbContext.cs                # MODIFY — DbSet<BillingUsageRollup>, DbSet<BillingMeterEventBuffer>
+  TammaModelConfiguration.cs             # MODIFY — entity config: unique indexes, CHECK on billing_mode
+  Migrations/ControlPlane/               # NEW additive migration (billing_usage_rollup + billing_meter_event_buffer)
+
+apps/tamma-elsa/src/Tamma.Api/Services/Billing/
+  IUsageMeteringService.cs               # NEW
+  UsageMeteringService.cs                # NEW — rollup upsert from facts + current-period read + buffer writes
+  MeterEventFlushTaskHandler.cs          # NEW — IPlatformTaskHandler "billing.meter_flush"
+  UsageReconciliationTaskHandler.cs      # NEW — IPlatformTaskHandler "billing.usage_reconcile"
+  BillingUsageOptions.cs                 # NEW — MeterFlushIntervalSeconds, ReconcileIntervalMinutes, DriftToleranceUsd
+  BillingMeterEventTypes.cs             # NEW — DCB event-type constants
+
+apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/
+  BillingUsageEndpoints.cs               # NEW — GET /api/v1/billing/usage
+
+apps/tamma-elsa/src/Tamma.Api/Extensions/
+  BillingUsageServiceCollectionExtensions.cs  # NEW — wire services + handlers (SaaS only)
+
+apps/tamma-elsa/src/Tamma.Api/Program.cs       # MODIFY — call AddBillingUsageMetering(); map endpoints (SaaS only)
+```
+
+### Entity: `BillingUsageRollup` (CP-resident)
+
+```csharp
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 35-3 — control-plane per-tenant per-billing-period usage rollup.
+/// Token counts are split by billing mode so only platform-provided tokens
+/// become Stripe meter events; BYOK tokens are recorded for analytics only.
+/// CP-resident (like PlatformAnalyticsHourly) so the flush + reconciliation
+/// workers answer "what does this tenant owe this period" without per-tenant
+/// fan-out. Idempotent upsert keyed by (TenantId, PeriodStart).
+/// </summary>
+public class BillingUsageRollup
+{
+    public Guid Id { get; set; }
+    public Guid TenantId { get; set; }
+    public DateTime PeriodStart { get; set; }   // UTC, first instant of the billing period
+    public DateTime PeriodEnd { get; set; }     // UTC, exclusive
+
+    public long PlatformInputTokens { get; set; }
+    public long PlatformOutputTokens { get; set; }
+    public long ByokInputTokens { get; set; }
+    public long ByokOutputTokens { get; set; }
+
+    public decimal PlatformCostUsd { get; set; }     // cost basis (no markup) — for ops/audit
+    public decimal BillableAmountUsd { get; set; }   // cost basis x (1 + margin) from IUsagePricingEngine
+    public int Seats { get; set; }                   // last-known seat count (gauge)
+
+    /// <summary>Watermark into the source facts so a recompute is incremental and idempotent.</summary>
+    public long LastSourceCursor { get; set; }
+
+    public DateTime UpdatedAt { get; set; }
+}
+```
+
+EF model config (in `TammaModelConfiguration.cs`):
+
+```csharp
+modelBuilder.Entity<BillingUsageRollup>(e =>
+{
+    e.ToTable("billing_usage_rollup");
+    e.HasKey(x => x.Id);
+    e.Property(x => x.Id).HasDefaultValueSql("gen_random_uuid()");
+    e.HasIndex(x => new { x.TenantId, x.PeriodStart }).IsUnique();
+    e.Property(x => x.PlatformCostUsd).HasPrecision(20, 4);
+    e.Property(x => x.BillableAmountUsd).HasPrecision(20, 4);
+});
+```
+
+`BillingMeterEventBuffer` carries one pending Stripe meter event: `Id`, `TenantId`, `StripeCustomerId`, `EventName` (`tamma.platform_tokens_input` etc.), `Value` (whole-number string per Stripe), `IdempotencyKey` (`{tenantId}:{period}:{eventName}` so re-flush is safe), `ReportedToStripe`, `StripeEventId?`, `CreatedAt`, `LastAttemptAt?`, `AttemptCount`.
+
+### Service: `UsageMeteringService`
+
+```csharp
+public interface IUsageMeteringService
+{
+    /// <summary>Recompute a tenant's rollup for a period from the billing_mode-tagged facts. Idempotent.</summary>
+    Task UpsertRollupAsync(Guid tenantId, BillingPeriod period, CancellationToken ct = default);
+
+    /// <summary>Read the current-period rollup for the API endpoint (local, not Stripe).</summary>
+    Task<UsageSummaryDto> GetCurrentUsageAsync(Guid tenantId, CancellationToken ct = default);
+
+    /// <summary>Buffer platform-only token meter events for the flush handler (BYOK skipped here).</summary>
+    Task BufferMeterEventsAsync(Guid tenantId, BillingPeriod period, CancellationToken ct = default);
+}
+```
+
+`UpsertRollupAsync` (sketch):
+1. Resolve the active `BillingCustomer` (35-1) for `tenantId`; if none (single-user / not provisioned), no-op.
+2. Aggregate facts for the period **split by `billing_mode`** — sum input/output tokens for `platform` vs `byok` from `PlatformAnalyticsHourly` (CP) rows in `[PeriodStart, PeriodEnd)` (requires `PlatformAnalyticsHourly` to carry a `billing_mode` dimension — see Integration Points; until then read the priced `LLM.CALL.SUCCESS` events via `IEventRepository`).
+3. For platform usage, call `IUsagePricingEngine.PriceUsage(...)` (34-5) per provider/model line; sum `costBasisUsd` → `PlatformCostUsd` and `sellPriceUsd` → `BillableAmountUsd`. BYOK lines contribute token counters only (sell price token component = 0 by 34-5 contract).
+4. Upsert the `BillingUsageRollup` row (insert-or-update on `(TenantId, PeriodStart)`).
+5. Append `BILLING.USAGE.RECORDED` via `IEventRepository.AppendAsync` (tags `{ tenantId, periodStart }`).
+6. Wrap the whole body so an exception is logged + swallowed (fail-open for billing).
+
+### Handler: `MeterEventFlushTaskHandler : IPlatformTaskHandler`
+
+`TaskType => "billing.meter_flush"`. `HandleAsync`:
+1. Load pending `BillingMeterEventBuffer` rows where `ReportedToStripe == false` (bounded batch).
+2. For each, call `Stripe.Billing.MeterEvents.CreateAsync` (via 35-1's `IBillingProvider`) with the `IdempotencyKey` → on success set `ReportedToStripe = true`, `StripeEventId`; on failure increment `AttemptCount`, set `LastAttemptAt`, append `BILLING.USAGE.FLUSH_FAILED`, and leave the row pending.
+3. A normal throw signals the `PlatformTaskWorker` to retry the *task* (re-enqueue); a malformed batch throws `PlatformTaskTerminalException`.
+
+The handler is re-enqueued every `Billing:MeterFlushIntervalSeconds` (default 60) by a self-rescheduling pattern (enqueue next `billing.meter_flush` row at the end of a successful run) so it rides the existing `PlatformTaskWorker` loop without a new BackgroundService.
+
+### Handler: `UsageReconciliationTaskHandler : IPlatformTaskHandler`
+
+`TaskType => "billing.usage_reconcile"`. Hourly. For each active `BillingCustomer`: read local rollup totals, call `Stripe.Billing.Meters.ListEventSummariesAsync` for the platform token meters over the current period, compare; if `|local - stripe| > Billing:DriftToleranceUsd` (or token-count tolerance) emit `BILLING.USAGE.RECONCILIATION_MISMATCH` (tags `{ tenantId, meter, local, stripe }`) and WARN-log. Drift events flow into `AlertRuleEvaluator` (a built-in rule can be added later in Epic 35 dashboards work — out of scope here).
+
+### DCB event names (`AGGREGATE.ACTION.STATUS`)
+
+```
+BILLING.USAGE.RECORDED
+BILLING.USAGE.FLUSH_FAILED
+BILLING.USAGE.RECONCILIATION_MISMATCH
+```
+
+Appended via `IEventRepository.AppendAsync(new DomainEvent { Type = ..., TenantId = ..., Tags = JsonSerializer.Serialize(...), ... })`. Tenant-scope events carry `TenantId`; the reconciliation summary may also raise via `IAlertSink.RaiseAsync` (TenantId set → tenant feed).
+
+### API shape
+
+```
+GET /api/v1/billing/usage        (SaaS: MemberAccess; single-user: sole user) → 200 UsageSummaryDto
+```
+
+```jsonc
+// UsageSummaryDto
+{
+  "platformInputTokens": 1840221,
+  "platformOutputTokens": 412980,
+  "byokInputTokens": 90112,
+  "byokOutputTokens": 21044,
+  "platformCostUsd": 12.4310,
+  "billableUsd": 16.1603,
+  "seats": 7,
+  "periodStart": "2026-06-01T00:00:00.000Z",
+  "periodEnd": "2026-07-01T00:00:00.000Z"
+}
+```
+
+The caller's tenant is resolved from `ITenantContext` (ambient JWT/API-key tenant) — never a route param — so a tenant cannot read another tenant's usage.
+
+### EF migration sketch
+
+Additive migration under `Tamma.Data/Migrations/ControlPlane/` (normal `dotnet ef migrations add AddBillingUsageRollup` — new tables, not a baseline CHECK edit). After generating, run `dotnet ef migrations has-pending-model-changes` → expect none. Tables: `billing_usage_rollup` (unique `(tenant_id, period_start)`), `billing_meter_event_buffer` (unique `idempotency_key`; partial index on `reported_to_stripe = false`).
+
+### Integration points
+
+- **35-1 `IBillingProvider` / `BillingPlanCatalog`:** Stripe SDK calls + meter ids + `StripeCustomerId` lookup. The `NullBillingProvider` seam makes single-user a no-op.
+- **35-2 `billing_mode` tag:** the rollup's platform-vs-BYOK split *depends on* every `ProviderDiagnostic`/`LLM.CALL.*` carrying `billing_mode`. If a fact is missing the tag, treat it as `platform` and WARN (so a 35-2 wiring gap is visible, not silently free).
+- **34-5 `IUsagePricingEngine`:** the only source of `billable` amounts. Mocked in unit tests.
+- **`PlatformAnalyticsHourly` (Epic 5/23/28-10):** the CP fact table the rollup aggregates. **This story requires `PlatformAnalyticsHourly` to split `TokensIn`/`TokensOut` by `billing_mode`** (today it has flat `TokensIn`/`TokensOut`). The minimal change is two added columns (`PlatformTokensIn/Out`, `ByokTokensIn/Out`) populated by the existing `ComputeTenantRollupActivity`; if that change lands outside this story, fall back to reading priced `LLM.CALL.SUCCESS` events directly via `IEventRepository`. Flag this as the single cross-epic dependency to confirm before implementation.
+- **`PlatformTaskWorker` / `IPlatformTaskHandler` (Story 28-6):** flush + reconcile ride the existing CP task queue. ⚠ `PlatformTaskWorker:RunOnStartup` is `false` in prod today (tenancy-residuals hazard); enabling billing handlers in prod must coordinate with that gate (or use a dedicated worker scoped to billing types — see Risks).
+- **`IEventRepository` / `IAlertSink` (Epic 4 / Story 5.6):** DCB events + reconciliation alerts.
+
+### Per-mode + per-tenant handling
+
+| Concern | single-user mode | SaaS mode |
+|---|---|---|
+| Principal | the sole user (no Stripe, no billing) | the tenant (`BillingCustomer.TenantId`) |
+| Stripe meter events | none (`NullBillingProvider`) | `tamma.platform_tokens_input/output` per `BillingCustomer.StripeCustomerId` |
+| `/api/v1/billing/usage` | absent / 404 | `MemberAccess`; read own tenant rollup |
+| Flush + reconcile handlers | not registered | registered; iterate `BillingCustomer` rows |
+| BYOK | n/a (self-owned usage) | excluded from token meters; counters only |
+
+## Dependencies
+
+**Prerequisite (internal):**
+- Story 35-1 — `BillingCustomer`, `BillingPlanCatalog`/`billing_plan_prices`, `IBillingProvider`/`StripeBillingProvider`, meter ids, `ISecretStore`-sourced Stripe key, `NullBillingProvider` single-user seam.
+- Story 35-2 — `BillingCustomer.BillingMode`, the `billing_mode` tag on `ProviderDiagnostic` + `LLM.CALL.*` DCB events.
+- Story 34-5 — `IUsagePricingEngine.PriceUsage` (cost basis × margin; BYOK token markup = 0); `MarginPolicy`.
+- Story 32-9 — per-call usage + cost-basis events (the producer side).
+- Epic 5/23 + Story 28-10 — `PlatformAnalyticsHourly` CP fact table (the aggregation source; needs a `billing_mode` split).
+- Epic 9 — `DiagnosticsService` / `ProviderDiagnostic` cost fields (`InputTokens`, `OutputTokens`, `Cost`).
+- Story 28-6 — `PlatformTaskWorker` / `IPlatformTaskHandler` queue.
+- Epic 4 — `IEventRepository` DCB events.
+
+**Blocks:**
+- Story 35-x invoicing / dunning / billing portal (consume metered usage landing in Stripe).
+- Epic 36 analytics views of billable usage.
+
+**External:**
+- `Stripe.net` SDK (introduced by 35-1) — `Billing.MeterEvents`, `Billing.Meters.ListEventSummaries`.
+- `STRIPE_SECRET_KEY_TEST` for integration tests.
+
+## Testing Strategy
+
+**Unit (xUnit, `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/`):**
+1. `UsageMeteringServiceTests` — platform-vs-BYOK token split (BYOK tokens land in `Byok*` counters, never buffered as meter events); `BillableAmountUsd` equals the mocked `IUsagePricingEngine.PriceUsage` sum (no margin math in this service); `UpsertRollupAsync` is idempotent (running twice on the same facts yields one row, same totals); missing `billing_mode` tag → treated as `platform` + WARN; service never throws (fact-read failure logged + swallowed).
+2. `MeterEventFlushTaskHandlerTests` — buffered rows flushed via mocked `IBillingProvider`; success sets `ReportedToStripe = true` + `StripeEventId`; failure leaves row pending, increments `AttemptCount`, emits `BILLING.USAGE.FLUSH_FAILED`; idempotency key prevents double-billing on retry; empty buffer is a no-op.
+3. `UsageReconciliationTaskHandlerTests` — matching local/Stripe totals → no event; drift beyond `DriftToleranceUsd` → `BILLING.USAGE.RECONCILIATION_MISMATCH` + `IAlertSink.RaiseAsync` once; per-customer iteration.
+4. `BillingUsageEndpointsTests` — `GET /api/v1/billing/usage` returns the caller-tenant rollup; **tenant-isolation**: tenant A's token cannot read tenant B's rollup (ambient `ITenantContext`, no route param); single-user mode → endpoint absent/404.
+5. `BillingModeSeamTests` — single-user mode registers no flush/reconcile handlers and makes zero Stripe calls (`NullBillingProvider`).
+
+**Integration (gated on `STRIPE_SECRET_KEY_TEST`, `apps/tamma-elsa/tests/Tamma.Api.IntegrationTests` or docker-bound suite via `sg docker -c "dotnet test ..."`):**
+6. Buffer + flush real `tamma.platform_tokens_input/output` events to a Stripe test customer; after Stripe processing delay, `ListEventSummaries` returns matching values; reconciliation reports no drift.
+7. Rollup aggregation against a seeded `PlatformAnalyticsHourly`/event set with mixed platform+BYOK rows → correct split and billable totals.
+
+**Mocks:** `IBillingProvider` (Stripe) and `IUsagePricingEngine` (34-5) are mocked in all unit tests; `ITammaModeProvider` is switched per test to exercise both modes.
+
+## Estimated Effort
+
+5-6 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/BillingUsageRollup.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/BillingMeterEventBuffer.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (DbSets) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (entity config + indexes) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/*_AddBillingUsageRollup.cs` | Create (additive migration) |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/PlatformAnalyticsHourly.cs` | Modify (billing_mode token split) — coordinate w/ Epic 5/23/28-10 |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/IUsageMeteringService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/UsageMeteringService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/MeterEventFlushTaskHandler.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/UsageReconciliationTaskHandler.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingUsageOptions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingMeterEventTypes.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/BillingUsageEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/BillingUsageServiceCollectionExtensions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (wire services + map endpoint, SaaS only) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/UsageMeteringServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/MeterEventFlushTaskHandlerTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/UsageReconciliationTaskHandlerTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingUsageEndpointsTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` directory for related spikes, bugs, findings, and decisions (esp. `platform-task-worker-runonstartup-hazard.md` and `story-28-1-design-calls.md`)
+3. Reviewed Stripe Billing Meters docs + rate limits (research latest via the Stripe.net docs before using any meter-event API flag)
+4. Confirmed Stories 35-1, 35-2, 34-5 are merged (this story is a pure consumer of their seams)
+5. Planned the TDD approach (Red-Green-Refactor)
+
+### Key design decisions
+
+- **Rollup is CP-resident, not per-tenant.** Billing is a control-plane concern: the flush + reconciliation workers must answer "what does every tenant owe" in one query without fanning out to every tenant DB. This mirrors `PlatformAnalyticsHourly`'s rationale exactly. `ProviderDiagnostic` itself is per-tenant (Story 28-1 PR D), so the rollup is derived from the **CP** `PlatformAnalyticsHourly` fact table (or CP-resident priced events), never by scanning tenant DBs from the worker.
+- **Derive, don't capture-on-call.** Rather than hook `LlmProxyService` to enqueue a meter event per call (the 20-3 TS approach), this story recomputes rollups from already-persisted facts. This is resilient (a worker crash loses nothing — facts are durable), idempotent (recompute = same answer), and keeps the LLM hot path untouched (fail-open is automatic).
+- **Idempotency keys on every meter event.** Stripe meter events are deduplicated by `identifier`; `{tenantId}:{period}:{eventName}:{watermark}` guarantees a retry after a partial flush never double-bills.
+- **No margin math here.** `BillableAmountUsd` is whatever 34-5's `IUsagePricingEngine` returns. If you find yourself multiplying by a margin in this story, stop — that is a 34-5 responsibility and the `boundaryNote` forbids it.
+- **BYOK is a hard exclusion, not a zero.** BYOK token usage is recorded (`Byok*` counters) but is *never* buffered as a `tamma.platform_tokens_*` meter event. A dedicated test asserts the buffer contains zero BYOK rows.
+
+### Stripe meter-event constraints
+
+- `value` payloads accept whole-number strings only — token counts are already integers.
+- `timestamp` is Unix seconds.
+- Events are processed asynchronously by Stripe — summaries lag, which is *why* the API reads the local rollup and reconciliation runs hourly.
+- Standard `Billing.MeterEvents.Create` rate limit is ~1,000/sec; pre-aggregating to one event per tenant-per-meter-per-period keeps us orders of magnitude under it.
+
+### Graceful degradation (fail-open for billing)
+
+If Stripe is unreachable or pricing is misconfigured: facts stay durable in `ProviderDiagnostic`/`PlatformAnalyticsHourly`; the rollup is recomputed next cycle; buffered events stay `reported_to_stripe = false` and retry; the LLM call path and tenant workflows are never blocked. A missing `billing_mode` tag is treated as `platform` and WARN-logged so a 35-2 gap surfaces rather than silently zeroing revenue.
+
+## Logging Requirements
+
+- **INFO:** rollup upserted (tenantId, period, platformTokens, billableUsd), meter batch flushed (count, succeeded, failed), reconciliation completed (customersChecked, mismatches), usage endpoint queried.
+- **DEBUG:** individual meter event buffered (eventName, value), flush cycle started, Stripe API response id, pricing-engine call (provider, model, sellPriceUsd).
+- **WARN:** meter event flush failed (eventName, attemptCount, error), reconciliation mismatch (meter, local, stripe, drift), `billing_mode` tag missing on a fact (treated as platform), unreported buffer backlog over threshold.
+- **ERROR:** rollup recompute failed (swallowed, fail-open — logged for visibility), Stripe meter not found, CP DB write failure.
+- **Structured context:** include `{ tenantId, stripeCustomerId, periodStart, eventName, value, batchSize, billingMode }` where applicable.
+- **Credential safety:** NEVER log the Stripe API key, customer payment details, or any BYOK provider key (reads go through Epic 29's reveal/audit path; this story never touches BYOK key material directly).
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-35/story-35-4/35-4-subscription-lifecycle-create-upgrade-downgrade-cancel-trial.md
+++ b/docs/stories/epic-35/story-35-4/35-4-subscription-lifecycle-create-upgrade-downgrade-cancel-trial.md
@@ -1,0 +1,388 @@
+# Story 35-4: Subscription Lifecycle — Create, Upgrade/Downgrade, Cancel, Trial & Proration
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-phase workflow (Read → Research → Break Down → TDD → Quality Gates → Failure Handling), `.dev/` knowledge-base usage (spikes, bugs, findings, decisions), TRACE/DEBUG logging requirements, the test-first (TDD) mandate, and the build-success / coverage gates.
+
+## User Story
+
+As a **tenant owner/admin** of a Tamma SaaS organization,
+I want to subscribe to a plan via Stripe Checkout, upgrade or downgrade with correct proration, start and convert trials, change seat counts, and cancel (now or at period end) — with every change mirrored on the control plane,
+So that my billing reflects what I actually use, my plan/quota state never drifts from Stripe, and quota enforcement (Story 35-6) reads one authoritative subscription record.
+
+## Priority
+
+P0 - Required for monetization. Without a managed subscription lifecycle there is no recurring revenue, no plan changes, and no single source of truth for the quota enforcement in Story 35-6. Re-targets TypeScript Epic 20-2 to the current C# control plane.
+
+## Acceptance Criteria
+
+1. A new control-plane entity `BillingSubscription` is added at `apps/tamma-elsa/src/Tamma.Data/Entities/BillingSubscription.cs` with: `Id` (Guid PK), `TenantId` (Guid FK to `tenants.Id`), `StripeSubscriptionId` (string, nullable until Stripe acks), `PlanSlug` (string — `free`/`team`/`enterprise`), `Status` (string text domain — `trialing`/`active`/`past_due`/`canceled`/`incomplete`/`incomplete_expired`/`unpaid`), `CurrentPeriodStart`/`CurrentPeriodEnd` (DateTime), `CancelAtPeriodEnd` (bool), `TrialEnd` (DateTime?), `Seats` (int, default 1), `ScheduledPlanSlug` (string?, set for a pending downgrade), `ScheduledEffectiveAt` (DateTime?), `StripeScheduleId` (string?), `CreatedAt`/`UpdatedAt`. Registered as `DbSet<BillingSubscription> BillingSubscriptions` on `ControlPlaneDbContext` and configured in `TammaModelConfiguration.ConfigureControlPlaneEntities` (table `billing_subscriptions`, FK to `tenants` with `OnDelete(Cascade)`, CHECK on `Status` text domain, **partial unique index** enforcing at most one *non-terminal* subscription per tenant: `UNIQUE (TenantId) WHERE Status NOT IN ('canceled','incomplete_expired')`).
+
+2. `POST /api/v1/billing/subscription/checkout` (tenant-scoped, `MemberAccess` group + `RequireTenantMembershipFilter`) accepts `{ planSlug, seats?, trialDays? }`, resolves the tenant's `BillingCustomer` + the `BillingPlanPrice` for the slug (both from Story 35-1), and returns a Stripe Checkout Session URL (`mode: "subscription"`). The caller must be `tenant_owner` or `tenant_admin` (`TenantRoleHierarchy.IsAtLeast(role, Admin)`); a `member`-role caller receives **403** before any Stripe call. No local `BillingSubscription` row is created here — the subscription is materialized when the `customer.subscription.created` webhook arrives (Story 35-5).
+
+3. `POST /api/v1/billing/subscription/change` with `{ planSlug }` performs **upgrade with immediate proration** (Stripe `SubscriptionService.UpdateAsync` with `ProrationBehavior = "create_prorations"`) when the new plan's `MonthlyPriceUsd` ≥ the current plan's, and **schedules a downgrade at period end** (Stripe Subscription Schedule via `SubscriptionScheduleService`) when it is lower. A downgrade does **not** change the active `PlanSlug` immediately; it records `ScheduledPlanSlug` + `ScheduledEffectiveAt` (= `CurrentPeriodEnd`) + `StripeScheduleId` on the local mirror and leaves `PlanSlug`/quota at the current (higher) plan until the period rolls over.
+
+4. `POST /api/v1/billing/subscription/cancel` with `{ atPeriodEnd: bool }` supports both **at-period-end** (`CancelAtPeriodEnd = true` via `SubscriptionService.UpdateAsync(CancelAtPeriodEnd = true)` — keeps `Status = active` until the period ends) and **immediate** (`SubscriptionService.CancelAsync` — flips `Status = canceled` and recomputes quota to free now). The local mirror is updated to match in the same control-plane transaction as the Stripe call's confirmed result.
+
+5. Trial handling: a checkout with `trialDays` starts a trial subscription (`Status = trialing`, `TrialEnd` populated). On trial conversion the subscription transitions `trialing → active`; on trial expiry without a payment method it transitions to `canceled`/`unpaid`. When the trial ends, the service emits `BILLING.SUBSCRIPTION.TRIAL_ENDED` (tags `{ tenantId, planSlug, status }`). (The `customer.subscription.trial_will_end` and terminal transitions arrive via the Story 35-5 webhook; this story owns the *mirror update + event emission* helper the webhook processor calls.)
+
+6. `POST /api/v1/billing/subscription/seats` with `{ seats }` updates the Stripe subscription's seat quantity on the `tamma.seats` meter/price (from Story 35-1) and updates `BillingSubscription.Seats` in lockstep; the quota snapshot is recomputed so seat-cap enforcement (Story 35-6) sees the new count immediately. Decreasing seats below current active membership count is rejected with **409** and a stable error code (`seats_below_active_members`) — no Stripe call is made.
+
+7. `Tenant.Plan` (the legacy string column) **and** the shadow `Tenant.PlanId` (Guid? FK to `plans.Id`) are updated atomically with `BillingSubscription` whenever the **effective** plan changes (upgrade applied, downgrade rolled over, cancellation to free, trial conversion), mirroring the lockstep already done in `AdminTenantsEndpoints.UpdateTenantPlan` (`AdminTenantsEndpoints.cs:620-623`). After any lifecycle transition there is **no drift**: `Tenant.Plan == BillingSubscription.PlanSlug` for the active plan, asserted by an invariant test.
+
+8. DCB events are emitted via `IEventRepository.AppendAsync` (tenant-scoped → tenant `DomainEvents` store): `BILLING.SUBSCRIPTION.CREATED` (on first materialization), `BILLING.SUBSCRIPTION.UPDATED` (upgrade applied, downgrade scheduled, seat change, plan rollover), `BILLING.SUBSCRIPTION.CANCELED` (immediate or at-period-end recorded), and `BILLING.SUBSCRIPTION.TRIAL_ENDED`. All carry tags `{ tenantId, planSlug, status }` (the event-type names follow the `AGGREGATE.ACTION.STATUS` convention).
+
+9. `GET /api/v1/billing/subscription` (tenant-scoped, any tenant member) returns the current `BillingSubscription` projection for the route tenant: `{ planSlug, status, currentPeriodStart, currentPeriodEnd, cancelAtPeriodEnd, trialEnd, seats, scheduledPlanSlug, scheduledEffectiveAt }`. A tenant with no subscription returns the free-tier default (`status: "active"`, `planSlug: "free"`, `seats: 1`). The row is **never** returned for a tenant the caller is not a member of (`RequireTenantMembershipFilter` + tenant-scoped query).
+
+10. All mutating endpoints are **idempotent against Stripe**: every Stripe mutating call passes a deterministic `RequestOptions.IdempotencyKey` (e.g. `sub-change-{tenantId}-{planSlug}-{periodEnd:yyyyMMdd}`) so a retried request never double-applies proration or mints a duplicate schedule.
+
+11. Single-user mode (`ITammaModeProvider.Mode == TammaMode.SingleUser`): the `/api/v1/billing/subscription/*` endpoints are **not mapped** (or short-circuit with a clear "billing is SaaS-only" 404/501), and `SubscriptionService` resolves the `NullBillingProvider` (from Story 35-1, `IsEnabled = false`) so zero Stripe calls are made. No `BillingSubscription` rows exist in single-user mode.
+
+12. Tenant isolation: every lifecycle operation resolves the tenant from the route (`/api/v1/orgs/{tenantId}` membership filter) or the caller's active tenant, and every `BillingSubscription` query is filtered by `TenantId`; a partial-unique index guarantees at most one non-terminal subscription per tenant. A cross-tenant subscription read or mutation returns 404/403 — proven by a tenant-isolation integration test.
+
+13. Concurrency / out-of-order safety: a webhook-driven mirror update (Story 35-5) and an API-driven update can race. `BillingSubscription` updates apply Stripe's returned object as the source of truth and use the Stripe-supplied `current_period_*`/`status` so the last write that reflects Stripe's confirmed state wins; the service never blindly overwrites a newer Stripe state with a stale one (period/status are taken from the Stripe response, not the request).
+
+14. Unit + integration tests (xUnit, `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/`) cover: checkout-session creation (Stripe mocked), upgrade-with-proration, scheduled-downgrade (schedule created, mirror reflects `scheduledPlanSlug`/`scheduledEffectiveAt`), immediate vs at-period-end cancel, trial start + conversion + expiry event emission, seat increase/decrease (incl. the `seats_below_active_members` 409), RBAC (member → 403 on mutations), `Tenant.Plan`/`PlanId` lockstep (no-drift invariant), DCB event emission for each transition, tenant isolation, and the single-user no-op seam.
+
+15. Logging follows the project standard: INFO on each confirmed lifecycle transition (`tenantId`, `planSlug`, `status`, `seats`), WARN on a Stripe call that fails and is surfaced as a 502/retry, ERROR on a mirror/Stripe divergence detected during reconciliation; **the Stripe secret key and any customer payment details are NEVER logged**.
+
+## Technical Design
+
+### Namespace / file structure
+
+```
+apps/tamma-elsa/src/Tamma.Data/
+  Entities/
+    BillingSubscription.cs           # NEW — control-plane mirror (one non-terminal per tenant)
+  ControlPlaneDbContext.cs           # MODIFY — add DbSet<BillingSubscription>
+  TammaModelConfiguration.cs         # MODIFY — table/index/CHECK/FK config
+  Migrations/ControlPlane/
+    <ts>_AddBillingSubscription.cs   # NEW (+ .Designer.cs + snapshot update)
+  Repositories/
+    IBillingSubscriptionRepository.cs  # NEW — tenant-scoped CRUD + GetActiveByTenant
+    BillingSubscriptionRepository.cs   # NEW
+
+apps/tamma-elsa/src/Tamma.Api/
+  Services/Billing/
+    ISubscriptionService.cs          # NEW — lifecycle seam (checkout/change/cancel/seats/trial)
+    SubscriptionService.cs           # NEW — orchestrates Stripe (via IBillingProvider) + mirror + events
+    SubscriptionProjection.cs        # NEW — read DTO (GET response + free-tier default)
+    SubscriptionMirrorUpdater.cs     # NEW — applies a Stripe Subscription object onto the mirror
+                                     #        (called by both the API and the 35-5 webhook processor)
+    BillingEvents.cs                 # MODIFY (35-1 created it) — add SUBSCRIPTION.* builders
+  Endpoints/Billing/
+    SubscriptionEndpoints.cs         # NEW — checkout/change/cancel/seats + GET; tenant-scoped
+  Extensions/
+    BillingServiceCollectionExtensions.cs  # MODIFY (35-1 created it) — register subscription svc/repo
+  Program.cs                         # MODIFY — map SubscriptionEndpoints (SaaS only)
+```
+
+> **Why `SubscriptionService` lives in `Tamma.Api/Services/Billing/` and not `Tamma.Activities`.** Subscription lifecycle is a control-plane HTTP concern (Checkout, plan changes, RBAC), not an Elsa workflow activity. The engine never changes a subscription; it only *reads* quota (Story 35-6 via `QuotaService`). Keeping the service in `Tamma.Api` matches the 35-1 `StripeBillingProvider` placement.
+
+### Key entity signature
+
+```csharp
+// Tamma.Data/Entities/BillingSubscription.cs
+namespace Tamma.Data.Entities;
+
+public class BillingSubscription
+{
+    public Guid Id { get; set; }
+    public Guid TenantId { get; set; }                  // FK -> tenants.Id
+    public string? StripeSubscriptionId { get; set; }   // null until Stripe acks
+    public string PlanSlug { get; set; } = "free";      // current EFFECTIVE plan
+    public string Status { get; set; } = "active";      // text domain; CHECK-constrained
+    public DateTime CurrentPeriodStart { get; set; }
+    public DateTime CurrentPeriodEnd { get; set; }
+    public bool CancelAtPeriodEnd { get; set; }
+    public DateTime? TrialEnd { get; set; }
+    public int Seats { get; set; } = 1;
+
+    // Pending downgrade (scheduled at period end via a Stripe Subscription Schedule)
+    public string? ScheduledPlanSlug { get; set; }
+    public DateTime? ScheduledEffectiveAt { get; set; }
+    public string? StripeScheduleId { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public Tenant? Tenant { get; set; }
+}
+```
+
+### EF model configuration sketch (`TammaModelConfiguration.ConfigureControlPlaneEntities`)
+
+```csharp
+modelBuilder.Entity<BillingSubscription>(entity =>
+{
+    entity.ToTable("billing_subscriptions", t =>
+        t.HasCheckConstraint("ck_billing_subscriptions_status",
+            "\"Status\" IN ('trialing','active','past_due','canceled'," +
+            "'incomplete','incomplete_expired','unpaid')"));
+    entity.HasKey(e => e.Id);
+    // At most ONE non-terminal subscription per tenant.
+    entity.HasIndex(e => e.TenantId)
+        .IsUnique()
+        .HasFilter("\"Status\" NOT IN ('canceled','incomplete_expired')");
+    entity.HasIndex(e => e.StripeSubscriptionId).IsUnique()
+        .HasFilter("\"StripeSubscriptionId\" IS NOT NULL");
+    entity.HasOne(e => e.Tenant).WithMany()
+        .HasForeignKey(e => e.TenantId).OnDelete(DeleteBehavior.Cascade);
+});
+```
+
+### EF migration sketch
+
+`dotnet ef migrations add AddBillingSubscription --context ControlPlaneDbContext --output-dir Migrations/ControlPlane` produces an **additive** migration (new table — not a baseline CHECK edit):
+
+```csharp
+migrationBuilder.CreateTable(name: "billing_subscriptions", columns: table => new {
+    Id = table.Column<Guid>(nullable: false),
+    TenantId = table.Column<Guid>(nullable: false),
+    StripeSubscriptionId = table.Column<string>(nullable: true),
+    PlanSlug = table.Column<string>(nullable: false, defaultValue: "free"),
+    Status = table.Column<string>(nullable: false, defaultValue: "active"),
+    CurrentPeriodStart = table.Column<DateTime>(nullable: false),
+    CurrentPeriodEnd = table.Column<DateTime>(nullable: false),
+    CancelAtPeriodEnd = table.Column<bool>(nullable: false, defaultValue: false),
+    TrialEnd = table.Column<DateTime>(nullable: true),
+    Seats = table.Column<int>(nullable: false, defaultValue: 1),
+    ScheduledPlanSlug = table.Column<string>(nullable: true),
+    ScheduledEffectiveAt = table.Column<DateTime>(nullable: true),
+    StripeScheduleId = table.Column<string>(nullable: true),
+    CreatedAt = table.Column<DateTime>(nullable: false),
+    UpdatedAt = table.Column<DateTime>(nullable: false),
+}, constraints: table => {
+    table.PrimaryKey("PK_billing_subscriptions", x => x.Id);
+    table.CheckConstraint("ck_billing_subscriptions_status",
+        "\"Status\" IN ('trialing','active','past_due','canceled','incomplete','incomplete_expired','unpaid')");
+    table.ForeignKey("FK_billing_subscriptions_tenants_TenantId",
+        x => x.TenantId, "tenants", "Id", onDelete: ReferentialAction.Cascade);
+});
+// + partial unique IX on TenantId (filter Status NOT IN terminal) and partial unique IX on StripeSubscriptionId
+```
+Verify `dotnet ef migrations has-pending-model-changes` reports none afterwards; `Update` then down rolls back cleanly.
+
+### Service seam
+
+```csharp
+// Services/Billing/ISubscriptionService.cs
+public interface ISubscriptionService
+{
+    Task<CheckoutResult> CreateCheckoutSessionAsync(
+        Guid tenantId, string planSlug, int? seats, int? trialDays, CancellationToken ct = default);
+
+    Task<SubscriptionProjection> ChangePlanAsync(
+        Guid tenantId, string newPlanSlug, CancellationToken ct = default);   // upgrade=prorate, downgrade=schedule
+
+    Task<SubscriptionProjection> CancelAsync(
+        Guid tenantId, bool atPeriodEnd, CancellationToken ct = default);
+
+    Task<SubscriptionProjection> ChangeSeatsAsync(
+        Guid tenantId, int seats, CancellationToken ct = default);            // 409 if < active members
+
+    Task<SubscriptionProjection> GetAsync(Guid tenantId, CancellationToken ct = default); // free default if none
+}
+
+public sealed record CheckoutResult(string CheckoutUrl, string StripeSessionId);
+```
+
+`SubscriptionService` depends on: `IBillingProvider` (35-1, gives the `Stripe.StripeClient` / `IsEnabled`), `IBillingCatalog` (35-1, resolves `BillingPlanPrice` by slug), `IBillingSubscriptionRepository`, `ITenantRepository` (for the `Tenant.Plan`/`PlanId` lockstep), `IEventRepository` (DCB events), `ITenantMembershipRepository` (active-member count for the seats floor), and `ILogger`. Upgrade vs downgrade is decided by comparing `Plan.MonthlyPriceUsd` of the current vs target slug (read from `ControlPlaneDbContext.Plans`).
+
+### `SubscriptionMirrorUpdater` — shared with Story 35-5
+
+```csharp
+// Services/Billing/SubscriptionMirrorUpdater.cs
+public sealed class SubscriptionMirrorUpdater
+{
+    /// Apply a Stripe Subscription object onto the local mirror + Tenant.Plan/PlanId
+    /// in one control-plane transaction, emit the right BILLING.SUBSCRIPTION.* event,
+    /// and return the projection. Status/period/trialEnd are taken from the Stripe
+    /// object (source of truth) — never from the API request (AC13).
+    public Task<SubscriptionProjection> ApplyAsync(
+        Guid tenantId, Stripe.Subscription stripeSub, string transition, CancellationToken ct);
+}
+```
+Both `SubscriptionService` (after a synchronous Stripe call) and the Story 35-5 `StripeWebhookProcessor` (`customer.subscription.created/updated/deleted`) call `ApplyAsync`, so the mirror logic and the no-drift `Tenant.Plan`/`PlanId` lockstep exist in exactly one place. The 35-5 boundary is the *webhook endpoint, signature verification, and dedup*; the *mirror projection* is owned here so both code paths share it.
+
+### `Tenant.Plan` / `Tenant.PlanId` lockstep (no drift — AC7)
+
+When the **effective** plan changes, mirror both columns exactly as `AdminTenantsEndpoints.UpdateTenantPlan` does:
+
+```csharp
+var plan = await db.Plans.AsNoTracking().FirstAsync(p => p.Slug == effectiveSlug, ct);
+db.Entry(tenant).Property("PlanId").CurrentValue = plan.Id;   // shadow FK
+tenant.Plan = plan.Slug;                                      // legacy string column
+tenant.UpdatedAt = DateTime.UtcNow;
+```
+A **scheduled downgrade** does NOT touch `Tenant.Plan` until the rollover (the `customer.subscription.updated` webhook at period end, applied via `SubscriptionMirrorUpdater`). This keeps the higher plan's quota live until the user has actually paid through the period.
+
+### DCB event names
+
+| Event | When | Tags | `TenantId` |
+|---|---|---|---|
+| `BILLING.SUBSCRIPTION.CREATED` | First materialization (checkout completed / first webhook) | `{ tenantId, planSlug, status }` | set |
+| `BILLING.SUBSCRIPTION.UPDATED` | Upgrade applied, downgrade scheduled, seat change, plan rollover | `{ tenantId, planSlug, status }` (+ `scheduledPlanSlug` on a downgrade) | set |
+| `BILLING.SUBSCRIPTION.CANCELED` | Immediate cancel or at-period-end cancel recorded | `{ tenantId, planSlug, status }` | set |
+| `BILLING.SUBSCRIPTION.TRIAL_ENDED` | Trial converted or expired | `{ tenantId, planSlug, status }` | set |
+
+These are **tenant-scoped** (`TenantId` set), so `IEventRepository.AppendAsync` routes them to the tenant's own `DomainEvents` store (see `EventRepository.cs:53-86`). The event row shape mirrors `OrgEndpoints.EmitTenantEvent` (`Metadata = {"workflowVersion":"1.0.0","eventSource":"system"}`). A `BillingEvents` static helper (created in 35-1) gains `SubscriptionCreated/Updated/Canceled/TrialEnded` builders.
+
+### API shape
+
+| Endpoint | Method | Auth | Body / Response |
+|---|---|---|---|
+| `/api/v1/billing/subscription/checkout` | POST | tenant owner/admin (member → 403) | `{ planSlug, seats?, trialDays? }` → `{ checkoutUrl, stripeSessionId }` |
+| `/api/v1/billing/subscription/change` | POST | tenant owner/admin | `{ planSlug }` → `SubscriptionProjection` |
+| `/api/v1/billing/subscription/cancel` | POST | tenant owner/admin | `{ atPeriodEnd }` → `SubscriptionProjection` |
+| `/api/v1/billing/subscription/seats` | POST | tenant owner/admin | `{ seats }` → `SubscriptionProjection` (409 `seats_below_active_members`) |
+| `/api/v1/billing/subscription` | GET | any tenant member | → `SubscriptionProjection` (free default if none) |
+
+`SubscriptionEndpoints.MapSubscriptionEndpoints(app)` registers these under the existing tenant-scoped group pattern (`app.MapGroup("/api/v1/orgs/{tenantId}/billing/subscription")` + `RequireTenantMembershipFilter`, *or* a current-active-tenant `/api/v1/billing/subscription` group resolving the caller's active tenant — match whichever the sibling billing endpoints from 35-1/35-5 settle on; default to the `/api/v1/orgs/{tenantId}/...` membership-gated group, consistent with `OrgEndpoints` and `AlertEndpoints` tenant sections). Role is read from `httpContext.Items[RequireTenantMembershipFilter.TenantRoleItemKey]` and gated with `TenantRoleHierarchy.IsAtLeast(role, TenantRoleHierarchy.Admin)` for every mutation.
+
+### Per-mode + per-tenant handling
+
+| Concern | single-user | SaaS |
+|---|---|---|
+| Endpoints mapped | no (`ITammaModeProvider.Mode == SingleUser` short-circuits / not mapped) | yes (tenant-scoped, membership-gated) |
+| Provider | `NullBillingProvider` (`IsEnabled=false`) | `StripeBillingProvider` |
+| Principal / owner | n/a (no subscriptions in single-user) | the tenant; `tenant_owner`/`tenant_admin` mutate, `member` read-only (403 on mutate) |
+| Mirror rows | none | one non-terminal `BillingSubscription` per tenant (partial-unique) |
+| Quota source for 35-6 | n/a | the active `BillingSubscription.PlanSlug` + `Seats` |
+
+## Dependencies
+
+**Internal (prerequisite):**
+- **Story 35-1** — `BillingCustomer` mapping, `BillingPlanPrice` catalog (slug → Stripe Product/Price/Meter ids), `IBillingProvider`/`StripeBillingProvider`/`NullBillingProvider`, `IBillingCatalog`, `BillingMode` enum, `BillingServiceCollectionExtensions`, the three meters (`tamma.platform_tokens_input/output`, `tamma.seats`), and the cabinet-resolved Stripe key.
+- **Story 35-5** — Stripe webhook ingestion + idempotent dedup. This story owns the `SubscriptionMirrorUpdater` that 35-5's `StripeWebhookProcessor` calls; 35-5 owns signature verification + the `billing_webhook_events` dedup table. (Listed as a dependency because trial-end/rollover/cancel-confirmation transitions are *driven* by webhooks; the API-side calls here update the mirror optimistically and the webhook reconciles to Stripe's confirmed state.)
+- **Epic 28** — control plane, `Tenant`/`Plan`/`ControlPlaneDbContext`, `ITenantMembershipRepository`, `TenantRoleHierarchy`, `RequireTenantMembershipFilter`, `ITammaModeProvider`.
+- **Epic 4** — DCB events (`DomainEvent`, `IEventRepository.AppendAsync`).
+
+**Internal (blocks):**
+- **Story 35-6** — Plan Quota & Usage-Limit Enforcement reads the active `BillingSubscription` (PlanSlug + Seats) as its single source of truth; quota must recompute on every transition here.
+- Invoicing / dunning / portal / credits stories (display + act on subscription state).
+
+**External:**
+- `Stripe.net` NuGet (added in 35-1). Research the current API surface (`SubscriptionService.UpdateAsync` + `ProrationBehavior`, `SubscriptionScheduleService`, `Checkout.SessionService`, `RequestOptions.IdempotencyKey`) before coding — do not assume method shapes.
+- A Stripe account (test + live) with the catalog seeded by 35-1.
+
+## Testing Strategy
+
+**Unit (xUnit, `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/`):**
+1. `SubscriptionServiceCheckoutTests` — checkout builds a session with the right price id + seats + trial (Stripe `Checkout.SessionService` mocked); no local row created.
+2. `SubscriptionServiceChangeTests` — upgrade calls `UpdateAsync` with `ProrationBehavior=create_prorations` and applies the new slug now; downgrade creates a `SubscriptionSchedule`, records `ScheduledPlanSlug`/`ScheduledEffectiveAt`/`StripeScheduleId`, and leaves `PlanSlug`/`Tenant.Plan` unchanged.
+3. `SubscriptionServiceCancelTests` — `atPeriodEnd=true` sets `CancelAtPeriodEnd` + keeps `Status=active`; immediate cancel flips `Status=canceled` and recomputes `Tenant.Plan` to free now.
+4. `SubscriptionServiceTrialTests` — checkout with `trialDays` → `Status=trialing` + `TrialEnd`; `SubscriptionMirrorUpdater` conversion/expiry emits `BILLING.SUBSCRIPTION.TRIAL_ENDED`.
+5. `SubscriptionServiceSeatsTests` — seat increase updates Stripe quantity + `Seats`; decrease below active membership → 409 `seats_below_active_members`, zero Stripe calls.
+6. `SubscriptionMirrorUpdaterTests` — applying a Stripe object updates the mirror **and** `Tenant.Plan`/`PlanId` in lockstep (no-drift invariant); status/period taken from the Stripe object, not the request (AC13).
+7. `SubscriptionEndpointsRbacTests` — member-role caller gets 403 on checkout/change/cancel/seats; owner/admin pass; GET allowed for member.
+8. `SubscriptionEventEmissionTests` — each transition appends exactly the expected `BILLING.SUBSCRIPTION.*` event with `{tenantId,planSlug,status}` tags.
+9. `NullBillingSubscriptionTests` — single-user mode: endpoints unmapped / short-circuit, `SubscriptionService` makes zero Stripe calls.
+
+**Integration (docker-bound via `sg docker -c "dotnet test ..."`):**
+10. Migration applies + rolls back on a real Postgres CP DB; `has-pending-model-changes` = none; the partial-unique index rejects a second non-terminal subscription for one tenant.
+11. Full lifecycle through the HTTP endpoints (Stripe mocked) on a real CP+tenant DB: checkout → webhook-materialize (via `SubscriptionMirrorUpdater`) → upgrade → seat change → schedule downgrade → cancel; assert one `BillingSubscription` row, the matching `BILLING.SUBSCRIPTION.*` events in the tenant `DomainEvents` store, and `Tenant.Plan == BillingSubscription.PlanSlug` after each step.
+12. **Tenant isolation** — two tenants each get a subscription; tenant A's owner cannot read or mutate tenant B's subscription (404/403); a `BillingSubscription` query is always `TenantId`-filtered.
+
+**Mocks:** Stripe SDK mocked at the `SubscriptionService` / `SubscriptionScheduleService` / `Checkout.SessionService` interface boundary (no live Stripe in CI). `IBillingProvider.IsEnabled` toggled per mode. Live-Stripe lifecycle test is opt-in behind `STRIPE_SECRET_KEY_TEST`, excluded from default CI.
+
+## Estimated Effort
+
+5-6 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/BillingSubscription.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (add DbSet) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (entity config) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_AddBillingSubscription.cs` | Create (+ Designer + snapshot) |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/IBillingSubscriptionRepository.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/BillingSubscriptionRepository.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/ISubscriptionService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/SubscriptionService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/SubscriptionProjection.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/SubscriptionMirrorUpdater.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingEvents.cs` | Modify (add SUBSCRIPTION.* builders — created by 35-1) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/SubscriptionEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/BillingServiceCollectionExtensions.cs` | Modify (register svc/repo — created by 35-1) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map SubscriptionEndpoints, SaaS only) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionServiceCheckoutTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionServiceChangeTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionServiceCancelTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionServiceTrialTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionServiceSeatsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionMirrorUpdaterTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionEndpointsRbacTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionEventEmissionTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/NullBillingSubscriptionTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionLifecycleIntegrationTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing, ensure you have:
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md).
+2. Searched `.dev/` for billing/Stripe/subscription/proration spikes, bugs, findings, decisions.
+3. Reviewed the Story 35-1 billing seam (`IBillingProvider`, `IBillingCatalog`, `BillingPlanPrice`, `BillingEvents`) and Story 35-5's webhook processor contract.
+4. **Researched the latest Stripe.net subscription API** (`SubscriptionService.UpdateAsync` + `ProrationBehavior`, `SubscriptionScheduleService`, `Checkout.SessionService`, `RequestOptions.IdempotencyKey`) via current docs before writing any SDK call — do not assume method names.
+5. Planned the TDD (Red-Green-Refactor) cycle for every new type.
+
+### Key Design Decisions
+
+- **Mirror is the single source of truth for enforcement; Stripe is the source of truth for state.** The local `BillingSubscription` exists so Story 35-6 can enforce quota in < 100ms without calling Stripe. But on every transition the *state* (status/period/trialEnd) is copied from the Stripe object, never inferred from the request, so the mirror can never claim a state Stripe hasn't confirmed (AC13).
+- **Upgrade = immediate proration; downgrade = scheduled at period end.** Charging immediately for an upgrade matches user expectation; deferring a downgrade avoids refund complexity and keeps the paid-for quota live through the period. The downgrade uses a Stripe Subscription Schedule and only touches `Tenant.Plan` when the rollover webhook fires.
+- **`SubscriptionMirrorUpdater` is shared with Story 35-5.** Both the synchronous API path and the asynchronous webhook path must produce the identical mirror + `Tenant.Plan`/`PlanId` lockstep + DCB event, so that logic lives in exactly one place — the webhook reconciles, it does not re-implement.
+- **Partial-unique index, not a plain unique.** A tenant can have many *historical* canceled subscriptions but only one live one; the filtered unique index (`Status NOT IN terminal`) expresses that without a soft-delete column.
+- **`Tenant.Plan` (string) + `Tenant.PlanId` (shadow FK) kept in lockstep** exactly as `AdminTenantsEndpoints.UpdateTenantPlan` already does — dashboards reading the legacy string column and the FK-based admin views stay consistent.
+- **Seats floor is enforced before any Stripe call** (active membership count via `ITenantMembershipRepository`) so a rejected seat decrease never mutates Stripe.
+
+### Boundary Notes (do not implement sibling-story scope)
+
+- **No webhook endpoint, signature verification, or `billing_webhook_events` dedup table** — that is Story 35-5. This story provides the `SubscriptionMirrorUpdater` the webhook processor *calls*.
+- **No quota computation / enforcement / over-quota responses** — that is Story 35-6. This story keeps `Tenant.Plan`/`Seats` correct so 35-6 reads one truth.
+- **No customer mapping, plan catalog, or Stripe key wiring** — that is Story 35-1 (consumed here).
+- **No invoicing, dunning, tax, billing portal, or credits wallet** — later stories.
+- **No tenant-facing subscription *UI*** beyond what other Epic 35 dashboard stories add; this story is API + control-plane only. (The GET projection is what those UIs will render.)
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Mirror drifts from Stripe after a failed mid-transaction Stripe call | High | Apply Stripe's returned object inside one CP transaction; webhook (35-5) reconciles; no-drift invariant test. |
+| Double-applied proration / duplicate schedule on a retried request | High | Deterministic `RequestOptions.IdempotencyKey` on every mutating Stripe call. |
+| Race between API update and webhook update | Medium | `SubscriptionMirrorUpdater` takes status/period from the Stripe object; last-confirmed-state wins (AC13). |
+| Downgrade silently lowers quota mid-period | Medium | Scheduled downgrade leaves `PlanSlug`/`Tenant.Plan` at the higher plan until the rollover webhook. |
+| Seat decrease orphans active members | Medium | Reject below active-member count with 409 before any Stripe call. |
+| Stripe.net API drift vs assumptions | Medium | Research current docs before coding; mock at the service-interface boundary. |
+| Single-user accidental Stripe coupling | Medium | Endpoints unmapped + `NullBillingProvider`; tests assert zero SDK calls. |
+
+### Success Metrics
+
+- [ ] After any lifecycle transition, `Tenant.Plan == BillingSubscription.PlanSlug` for the active plan (no drift) — asserted by the invariant test.
+- [ ] Each tenant has at most one non-terminal `BillingSubscription` (partial-unique enforced).
+- [ ] Every transition emits exactly one `BILLING.SUBSCRIPTION.*` DCB event with `{tenantId,planSlug,status}` tags.
+- [ ] Single-user boot maps no subscription endpoints and makes 0 Stripe calls.
+- [ ] Migration applies + rolls back; `has-pending-model-changes` = none.
+
+## Logging Requirements
+
+- **INFO**: confirmed lifecycle transition (`tenantId`, `planSlug`, `status`, `seats`, `transition`), checkout session created (`tenantId`, `planSlug`, `stripeSessionId`).
+- **DEBUG**: each Stripe SDK call issued (resource type, idempotency key — never the value), upgrade-vs-downgrade decision (`currentSlug`, `targetSlug`, prices compared).
+- **WARN**: Stripe call failed → surfaced as 502 / pending webhook reconcile (`tenantId`, error class), seat decrease rejected (`tenantId`, requested, active members).
+- **ERROR**: mirror/Stripe divergence detected, DCB event append failure, `Tenant.Plan`/subscription lockstep violation.
+- **Structured context**: include `{ tenantId, planSlug, status, seats, idempotencyKey, transition }` where applicable.
+- **Credential safety**: NEVER log the Stripe secret key, webhook signing secret, or any customer payment details.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-35/story-35-5/35-5-stripe-webhook-ingestion-idempotency-and-billing-event-proje.md
+++ b/docs/stories/epic-35/story-35-5/35-5-stripe-webhook-ingestion-idempotency-and-billing-event-proje.md
@@ -1,0 +1,367 @@
+# Story 35-5: Stripe Webhook Ingestion, Idempotency & Billing Event Projection
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-Phase Development Workflow (Read → Research → Break Down → TDD → Quality Gates → Failure Handling), the `.dev/` knowledge base usage rules, TRACE/DEBUG logging requirements, the Test-Driven Development workflow, and the build/coverage quality gates. Failure to follow this process will result in rework.
+
+## User Story
+
+As a **Tamma platform operator**,
+I want a verified, idempotent Stripe webhook endpoint that ingests subscription/invoice/payment lifecycle events, projects them onto the control-plane billing mirrors, and fans them into the DCB event stream,
+So that the local control plane stays in sync with Stripe as the source of truth for billing state, replays and retries are safe, and every billing state change leaves a complete audit trail.
+
+## Priority
+
+P0 - Backbone for the entire billing epic. Stories 35-4 (subscription lifecycle), 35-7 (payment methods / portal), 35-8 (invoicing & dunning), and 35-10 (credits wallet) all depend on this webhook ingestion + projection seam to learn about Stripe-side state changes.
+
+## Acceptance Criteria
+
+1. `POST /api/v1/billing/stripe/webhook` is an anonymous-but-signature-gated endpoint (no JWT/API-key auth; verification is the Stripe signature) that captures the **raw** request body via `HttpRequest.EnableBuffering()` + a leave-open `StreamReader` (mirroring `GitHubEndpoints.Webhooks` in `apps/tamma-elsa/src/Tamma.Api/Endpoints/GitHubEndpoints.cs`), then validates it with `Stripe.EventUtility.ConstructEvent(rawBody, stripeSignatureHeader, signingSecret)`.
+2. The webhook **signing secret** is resolved through `ISecretStore.GetAsync(...)` at `SecretScope.Platform` / `SecretPurpose.ApiKey` exactly as Story 35-1 wires it (NOT a raw `IConfiguration` read). When the secret is unresolvable the endpoint returns `503` and logs ERROR — it never fails open, matching `GitHubEndpoints` audit finding 001 ("never fail open on missing secret").
+3. An invalid or missing signature returns `400 Bad Request`, no row is written, no event is emitted, and a WARN log is recorded with the Stripe event id (when parseable) — never the raw body.
+4. A new control-plane entity `BillingWebhookEvent` (`apps/tamma-elsa/src/Tamma.Data/Entities/BillingWebhookEvent.cs`, registered on `ControlPlaneDbContext` and configured in `TammaModelConfiguration`) dedupes deliveries on a `UNIQUE` index over `StripeEventId`; columns include `Id`, `StripeEventId`, `EventType`, `TenantId` (nullable — resolved from the Stripe customer), `Status` (`received|processing|projected|enqueued|failed|skipped`), `Attempts`, `Payload` (raw JSON), `LastError`, `ReceivedAt`, `ProcessedAt`.
+5. A duplicate delivery (same `StripeEventId`) is acknowledged `200 OK` **without** reprocessing — the unique-index insert collision is caught and treated as an idempotent ack, so Stripe at-least-once retries never double-project.
+6. Inbound events are mapped to a tenant via `BillingCustomer.StripeCustomerId → BillingCustomer.TenantId` (the Story 35-1 entity); the resolved `TenantId` is stamped on the `BillingWebhookEvent` row and on every emitted DCB event's `tenantId` tag. An event whose customer maps to no `BillingCustomer` is acknowledged `200`, recorded `Status = skipped`, and logged WARN (no exception, no Stripe retry storm).
+7. Handlers are dispatched through a pluggable `IBillingEventHandler` registry (`HandledEventTypes` + `HandleAsync(BillingWebhookContext, ct)`), so sibling stories register their own projection logic without 35-5 owning their entities. This story ships the dispatch seam plus default handlers covering at minimum: `customer.subscription.created/updated/deleted`, `invoice.created/finalized/paid/payment_failed`, `payment_intent.succeeded/payment_intent.payment_failed`, `customer.subscription.trial_will_end`, `charge.dispute.created`.
+8. Each successfully dispatched event emits a corresponding `BILLING.*` DCB event via `IEventRepository.AppendAsync(DomainEvent)` (CP store), named `AGGREGATE.ACTION.STATUS` (e.g. `BILLING.SUBSCRIPTION.UPDATED`, `BILLING.INVOICE.PAID`, `BILLING.PAYMENT.FAILED`, `BILLING.DISPUTE.OPENED`, `BILLING.SUBSCRIPTION.TRIAL_ENDING`) with JSONB `tags = { tenantId, stripeEventId, eventType, stripeObjectId }`.
+9. Mirror **updates** owned by sibling stories (e.g. `BillingSubscription` in 35-4, `BillingInvoice` in 35-8, `BillingPaymentMethod` in 35-7) are performed by **their** registered `IBillingEventHandler` implementations; 35-5 only guarantees the dispatch + DCB emission + a `NullBillingEventHandler`/logging default so the pipeline is testable standalone. 35-5 does **not** create `BillingSubscription`, `BillingInvoice`, or `BillingPaymentMethod` entities.
+10. The handler is **fast-ack**: the endpoint verifies → dedupes → projects the cheap mirror/DCB write inline, but any heavy follow-up (dunning escalation, email, Stripe round-trips) is enqueued as a `PlatformQueuedTask` (`Type = "billing.webhook.followup"`) via `IPlatformQueuedTaskRepository.EnqueueAsync`, never run inline. p95 ack latency `< 2s`.
+11. Unhandled/unknown event types (no `IBillingEventHandler` matches) are logged at INFO, recorded `Status = skipped`, and acknowledged `200` — the endpoint returns no `4xx`/`5xx` that would trigger Stripe retry storms (only signature failure → `400`, secret-unresolvable → `503`).
+12. An admin replay/inspect endpoint `GET /api/v1/admin/billing/webhook-events` (policy `PlatformOwnerAccess`) lists recent `BillingWebhookEvent` rows with processing status, filterable by `status`, `eventType`, `tenantId`, paged (default 50, max 200); `POST /api/v1/admin/billing/webhook-events/{id}/replay` (`PlatformOwnerAccess`) re-dispatches a stored payload through the same processor (idempotent — re-running a `projected` event is a no-op at the handler level).
+13. In **single-user mode** (`ITammaModeProvider` → `SingleUser`, no `Tamma:TenantSharedSecret`/SaaS markers) the webhook route and admin replay route are **not mapped** and the `NullBillingProvider` seam from Story 35-1 means no Stripe wiring is registered — matching 35-1 AC7. In **SaaS mode** the routes are mapped and tenant resolution is mandatory.
+14. Unit + integration tests cover: signature verify pass/fail, secret-unresolvable `503`, dedupe on replay (one row, one projection, one event), each default handler's DCB emission + dispatch, the fast-ack `PlatformQueuedTask` enqueue path, unknown-event-type `200 skipped`, no-customer-match `200 skipped`, admin list/replay RBAC, and tenant-isolation (a webhook for tenant A never writes a DCB event tagged tenant B).
+
+## Technical Design
+
+### C# namespace / file structure
+
+```
+apps/tamma-elsa/src/Tamma.Data/Entities/
+  BillingWebhookEvent.cs                       # NEW — dedup + audit row (CP)
+
+apps/tamma-elsa/src/Tamma.Data/
+  ControlPlaneDbContext.cs                      # MODIFY — DbSet<BillingWebhookEvent>
+  TammaModelConfiguration.cs                    # MODIFY — entity config + unique index
+  Migrations/ControlPlane/<ts>_BillingWebhookEvents.cs   # NEW — additive migration
+
+apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/
+  StripeWebhookEndpoint.cs                      # NEW — raw-body capture + verify + ack
+  BillingWebhookAdminEndpoints.cs              # NEW — list + replay (PlatformOwnerAccess)
+
+apps/tamma-elsa/src/Tamma.Api/Services/Billing/
+  StripeWebhookProcessor.cs                     # NEW — dedupe + dispatch + DCB + enqueue
+  IStripeWebhookProcessor.cs                    # NEW — processor seam (testable)
+  IBillingEventHandler.cs                       # NEW — pluggable handler contract
+  BillingEventHandlerRegistry.cs               # NEW — type → handler resolution
+  BillingWebhookContext.cs                      # NEW — Stripe.Event + tenant + raw payload
+  NullBillingEventHandler.cs                   # NEW — logging default (no mirror)
+  BillingWebhookEventTypes.cs                  # NEW — BILLING.* DCB type constants
+  Handlers/                                     # NEW — 35-5's default DCB-emitting handlers
+    SubscriptionWebhookHandler.cs              # emits BILLING.SUBSCRIPTION.* (mirror in 35-4)
+    InvoiceWebhookHandler.cs                   # emits BILLING.INVOICE.*     (mirror in 35-8)
+    PaymentWebhookHandler.cs                   # emits BILLING.PAYMENT.*     (method mirror 35-7)
+    DisputeWebhookHandler.cs                   # emits BILLING.DISPUTE.OPENED
+  BillingWebhookFollowupTaskHandler.cs         # NEW — IPlatformTaskHandler for fast-ack work
+
+apps/tamma-elsa/src/Tamma.Api/Extensions/
+  BillingWebhookServiceCollectionExtensions.cs # NEW — DI wiring (mode-gated)
+
+apps/tamma-elsa/src/Tamma.Api/Program.cs        # MODIFY — map routes (SaaS-mode-gated)
+```
+
+> **Stripe.net** is added to `Tamma.Api.csproj` by Story 35-1 (foundation). 35-5 consumes `Stripe.EventUtility`, `Stripe.Event`, and the typed `Stripe.Subscription` / `Stripe.Invoice` / `Stripe.PaymentIntent` / `Stripe.Charge` event objects already on the dependency.
+
+### Entity sketch — `BillingWebhookEvent`
+
+```csharp
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Control-plane dedup + audit row for an inbound Stripe webhook delivery.
+/// Stripe delivers at-least-once; the UNIQUE index on StripeEventId makes
+/// reprocessing safe — a duplicate insert collision is treated as an
+/// idempotent ack. Mirrors the GitHubWebhookDelivery audit-row pattern.
+/// </summary>
+public class BillingWebhookEvent
+{
+    public Guid Id { get; set; }
+    public string StripeEventId { get; set; } = null!;   // UNIQUE — "evt_..."
+    public string EventType { get; set; } = null!;       // "invoice.paid"
+    public Guid? TenantId { get; set; }                  // resolved from BillingCustomer
+    public string? StripeObjectId { get; set; }          // "sub_...", "in_...", "pi_..."
+    public string Status { get; set; } = "received";     // received|processing|projected|enqueued|failed|skipped
+    public int Attempts { get; set; }
+    public string Payload { get; set; } = "{}";          // raw JSON (redacted of nothing PII-sensitive beyond Stripe's own)
+    public string? LastError { get; set; }
+    public DateTime ReceivedAt { get; set; }
+    public DateTime? ProcessedAt { get; set; }
+}
+```
+
+### EF migration sketch (additive — `dotnet ef migrations add BillingWebhookEvents`)
+
+```sql
+CREATE TABLE billing_webhook_events (
+    id                UUID PRIMARY KEY,
+    stripe_event_id   TEXT NOT NULL,
+    event_type        TEXT NOT NULL,
+    tenant_id         UUID NULL REFERENCES tenants(id),
+    stripe_object_id  TEXT NULL,
+    status            TEXT NOT NULL DEFAULT 'received',
+    attempts          INTEGER NOT NULL DEFAULT 0,
+    payload           JSONB NOT NULL DEFAULT '{}',
+    last_error        TEXT NULL,
+    received_at       TIMESTAMPTZ NOT NULL,
+    processed_at      TIMESTAMPTZ NULL
+);
+CREATE UNIQUE INDEX ux_billing_webhook_events_stripe_event_id
+    ON billing_webhook_events (stripe_event_id);
+CREATE INDEX ix_billing_webhook_events_status_received
+    ON billing_webhook_events (status, received_at DESC);
+CREATE INDEX ix_billing_webhook_events_tenant
+    ON billing_webhook_events (tenant_id) WHERE tenant_id IS NOT NULL;
+```
+
+Entity config lives only in `TammaModelConfiguration.ConfigureControlPlaneEntities` (the established single source — same place `AlertRule`/`GitHubWebhookDelivery` indexes are declared). After adding, run `dotnet ef migrations has-pending-model-changes` → expect none.
+
+### Handler contract — `IBillingEventHandler`
+
+```csharp
+namespace Tamma.Api.Services.Billing;
+
+public interface IBillingEventHandler
+{
+    /// Stripe event types this handler claims (e.g. "invoice.paid").
+    IReadOnlyCollection<string> HandledEventTypes { get; }
+
+    /// Project the event onto local mirrors + emit the BILLING.* DCB event.
+    /// Must be idempotent: re-running an already-projected event is a no-op.
+    /// Returns the queued follow-up task payload (or null for none).
+    Task<BillingFollowup?> HandleAsync(BillingWebhookContext ctx, CancellationToken ct);
+}
+
+public sealed record BillingWebhookContext(
+    Stripe.Event StripeEvent,
+    Guid TenantId,
+    string RawPayload);
+
+public sealed record BillingFollowup(string TaskType, string Payload);
+```
+
+The `BillingEventHandlerRegistry` mirrors `PlatformTaskHandlerRegistry` exactly: a per-scope snapshot dict keyed by event type, duplicate-claim detection at construction, `Resolve(eventType) -> handler?`. Sibling stories register their handlers via `services.AddBillingEventHandler<T>()`; an unclaimed type falls through to `NullBillingEventHandler` (logs INFO, `Status = skipped`).
+
+### Processor signature — `StripeWebhookProcessor`
+
+```csharp
+public interface IStripeWebhookProcessor
+{
+    /// Verify-already-done caller passes the parsed Stripe.Event + raw body.
+    /// Returns the ack result (always 200 unless caller already rejected sig).
+    Task<WebhookProcessResult> ProcessAsync(
+        Stripe.Event stripeEvent, string rawPayload, CancellationToken ct);
+}
+```
+
+`ProcessAsync` flow:
+1. Insert `BillingWebhookEvent { Status = received }`. On `DbUpdateException` from the unique index → return `Duplicate` (idempotent ack, no further work).
+2. Resolve `TenantId` from `BillingCustomer` by the event's customer id. No match → `Status = skipped`, INFO/WARN log, return `Skipped`.
+3. `registry.Resolve(eventType)` → handler (or `NullBillingEventHandler`). Run `HandleAsync` (mirror write + `IEventRepository.AppendAsync` of the `BILLING.*` DCB event) inside the CP transaction.
+4. If handler returned a `BillingFollowup`, `IPlatformQueuedTaskRepository.EnqueueAsync(new PlatformQueuedTask { Type = "billing.webhook.followup", TenantId, Payload })`; stamp `Status = enqueued`, else `Status = projected`; set `ProcessedAt`.
+5. Any handler exception → `Status = failed`, `LastError` (scrubbed via `CredentialRedactor.Clean`), still ack `200` (Stripe replay is covered by our own dedup; we use the admin replay endpoint + follow-up queue for recovery rather than relying on Stripe retries, avoiding retry storms). The thrown error is logged ERROR.
+
+### Endpoint shape
+
+```
+POST /api/v1/billing/stripe/webhook            (SaaS only; signature-gated, no JWT)
+GET  /api/v1/admin/billing/webhook-events      (PlatformOwnerAccess; filters + paging)
+POST /api/v1/admin/billing/webhook-events/{id}/replay   (PlatformOwnerAccess)
+```
+
+`StripeWebhookEndpoint.Receive` mirrors `GitHubEndpoints.Webhooks`:
+
+```csharp
+public static async Task<IResult> Receive(
+    HttpContext context,
+    [FromServices] ISecretStore secrets,
+    [FromServices] IStripeWebhookProcessor processor,
+    [FromServices] ILoggerFactory loggerFactory)
+{
+    var logger = loggerFactory.CreateLogger("StripeWebhookEndpoint");
+    var sig = context.Request.Headers["Stripe-Signature"].FirstOrDefault();
+    if (string.IsNullOrEmpty(sig)) return Results.BadRequest(new { error = "missing signature" });
+
+    context.Request.EnableBuffering();
+    string raw;
+    using (var reader = new StreamReader(context.Request.Body, Encoding.UTF8,
+        detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true))
+    {
+        raw = await reader.ReadToEndAsync();
+        context.Request.Body.Position = 0;
+    }
+
+    var signingSecret = await ResolveSigningSecretAsync(secrets); // Platform/ApiKey
+    if (signingSecret is null) { logger.LogError("Stripe webhook secret unresolvable"); return Results.StatusCode(503); }
+
+    Stripe.Event evt;
+    try { evt = Stripe.EventUtility.ConstructEvent(raw, sig, signingSecret); }
+    catch (Stripe.StripeException) { logger.LogWarning("Stripe webhook signature rejected"); return Results.BadRequest(); }
+
+    var result = await processor.ProcessAsync(evt, raw, context.RequestAborted);
+    return Results.Ok(new { received = true, status = result.Status });
+}
+```
+
+### DCB event names (`BillingWebhookEventTypes`)
+
+```
+BILLING.SUBSCRIPTION.CREATED   BILLING.SUBSCRIPTION.UPDATED   BILLING.SUBSCRIPTION.DELETED
+BILLING.SUBSCRIPTION.TRIAL_ENDING
+BILLING.INVOICE.CREATED        BILLING.INVOICE.FINALIZED      BILLING.INVOICE.PAID
+BILLING.INVOICE.PAYMENT_FAILED
+BILLING.PAYMENT.SUCCEEDED      BILLING.PAYMENT.FAILED
+BILLING.DISPUTE.OPENED
+BILLING.WEBHOOK.SKIPPED        BILLING.WEBHOOK.FAILED         (operational, system event source)
+```
+
+All appended via `IEventRepository.AppendAsync(new DomainEvent { Type, TenantId, Tags, Metadata, Data })` with `Tags` JSON `{ tenantId, stripeEventId, eventType, stripeObjectId }` and `Metadata` `{ "workflowVersion": "1.0.0", "eventSource": "system" }`.
+
+### Per-mode + per-tenant handling
+
+| Concern | single-user mode | SaaS mode |
+|---|---|---|
+| Webhook route mapped? | No — `NullBillingProvider` (35-1) means no Stripe; route + admin route unmapped. | Yes. |
+| Tenant resolution | N/A | Mandatory: `BillingCustomer.StripeCustomerId → TenantId`; unresolved → `skipped`. |
+| DCB event `TenantId` | N/A | Always the resolved tenant; never null for a projected event. |
+| Admin replay/list | N/A | `PlatformOwnerAccess` (platform-admin claim only) — never a tenant-scoped route; a Stripe webhook is platform-operator concern. |
+| Mode source | `ITammaModeProvider` (`Services/PromptStore/TammaMode.cs`) — process-stable. | same |
+
+Tenant isolation is enforced two ways: (1) every `DomainEvent` is tagged with the resolved `TenantId` and written through the CP `IEventRepository` with that tenant id; (2) the admin endpoints are platform-scoped (no tenant route exists), so there is no path for a tenant to read another tenant's webhook rows.
+
+### Integration points
+
+- **Story 35-1 foundation** — `BillingCustomer` (tenant ↔ Stripe customer mapping), `IBillingProvider`/`NullBillingProvider` seam, Stripe.net package, and the `ISecretStore` resolution of the Stripe webhook signing secret (`SecretScope.Platform`, `SecretPurpose.ApiKey`).
+- **Secret cabinet (Epic 29)** — `ISecretStore.GetAsync` for the signing secret; never an env-var read.
+- **DCB event store** — `IEventRepository.AppendAsync` (CP `domain_events`), the same store `AlertRuleEvaluator` polls, so a future `BILLING.*` alert rule (Epic 5/23) sees these for free.
+- **Platform task queue (Epic 28)** — `IPlatformQueuedTaskRepository.EnqueueAsync` + a new `IPlatformTaskHandler` (`TaskType = "billing.webhook.followup"`) processed by the existing `PlatformTaskWorker`.
+- **Sibling stories** — 35-4/35-7/35-8/35-10 register `IBillingEventHandler` implementations that own their mirror entities.
+
+## Dependencies
+
+**Internal:**
+- **Prerequisite — Story 35-1**: `BillingCustomer`, `IBillingProvider`/`NullBillingProvider`, Stripe.net package, signing-secret-via-`ISecretStore` wiring, single-user no-op seam.
+- **Blocks — Story 35-4** (subscription lifecycle registers `SubscriptionWebhookHandler` mirror update; 35-4 declares a dependency on 35-5).
+- **Blocks — Story 35-7** (payment methods / portal consumes payment-method webhook events).
+- **Blocks — Story 35-8** (invoicing & dunning registers invoice/dunning handlers + `billing.webhook.followup` work).
+- **Blocks — Story 35-10** (credits wallet reacts to invoice/payment webhooks).
+- **Related — Epic 28**: `PlatformQueuedTask` + `PlatformTaskWorker` fast-ack queue.
+- **Related — Epic 29**: secret cabinet for the signing secret.
+- **Related — Epic 5/23**: DCB events feed the alert evaluator / analytics.
+
+**External:**
+- **Stripe.net** SDK (added by 35-1) — `EventUtility.ConstructEvent`, typed event objects.
+- A configured Stripe **webhook endpoint signing secret** (`whsec_...`) stored in the cabinet.
+- `STRIPE_SECRET_KEY_TEST` + a Stripe test fixture/CLI for integration tests.
+
+## Testing Strategy
+
+**Unit tests** (`apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/`, xUnit; SQLite/in-memory CP context, Stripe SDK behind a thin seam or fixture-string `ConstructEvent`):
+1. **Signature**: a fixture raw body + valid `Stripe-Signature` (computed with a test `whsec_`) verifies and processes; a tampered body / wrong secret → `400`, zero rows, zero events.
+2. **Secret unresolvable**: `ISecretStore.GetAsync` returns null → endpoint returns `503`, no processing (never fails open).
+3. **Dedupe**: process the same `evt_...` twice → exactly one `BillingWebhookEvent` row, one DCB event, one handler invocation; second call returns `Duplicate`/`200` with no new event.
+4. **Tenant resolution**: customer maps to tenant A → row + DCB event tagged tenant A; customer maps to nothing → `Status = skipped`, `200`, INFO/WARN, no DCB projection event.
+5. **Per-handler**: for each default handler, a representative Stripe event → correct `BILLING.*` DCB type emitted with `{ tenantId, stripeEventId, eventType, stripeObjectId }` tags; idempotent re-run is a no-op.
+6. **Unknown type**: `foo.bar.baz` → `NullBillingEventHandler`, `Status = skipped`, INFO, `200`, no `BILLING.*` projection event.
+7. **Fast-ack enqueue**: a handler returning a `BillingFollowup` → one `PlatformQueuedTask` (`Type = "billing.webhook.followup"`, correct `TenantId`/`Payload`) enqueued; `Status = enqueued`.
+8. **Handler failure**: handler throws → `Status = failed`, `LastError` scrubbed, still `200` (no Stripe retry storm), ERROR logged.
+9. **Registry**: duplicate event-type claim across two handlers throws at construction (mirrors `PlatformTaskHandlerRegistry`).
+
+**Integration tests** (`Tamma.Api.Tests/Billing/` via `WebApplicationFactory`, docker-bound CP Postgres run as `sg docker -c "dotnet test ..."`):
+10. **End-to-end ack**: POST a CLI-generated signed event → `200`, row persisted, DCB event readable via `IEventRepository`.
+11. **Tenant isolation**: two `BillingCustomer` rows (tenant A, tenant B) + interleaved webhooks → every DCB event/row carries the correct tenant; a query scoped to tenant A never returns tenant B's webhook events.
+12. **Admin RBAC**: `GET /webhook-events` and `POST .../replay` → `403` for non-platform-admin, `200` for `PlatformOwnerAccess`; replay re-dispatches a stored payload and a re-run of a `projected` event is a no-op.
+13. **Mode gating**: with single-user markers the webhook + admin routes return `404` (unmapped); with SaaS markers they are reachable.
+
+**Mocks/fixtures**: Stripe is never live in unit tests — use static fixture JSON bodies + a deterministic `whsec_` for `ConstructEvent`, or a thin `IStripeEventVerifier` seam so the SDK is swappable. `ISecretStore`, `IEventRepository`, `IPlatformQueuedTaskRepository`, and `IBillingEventHandler` are mocked/faked. Integration tests require `STRIPE_SECRET_KEY_TEST` and use the Stripe CLI `stripe trigger` (or recorded fixtures) — skip-gated when the env var is absent.
+
+## Estimated Effort
+
+4-5 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/BillingWebhookEvent.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (add `DbSet<BillingWebhookEvent>`) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (entity config + unique/secondary indexes) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_BillingWebhookEvents.cs` | Create (additive) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/StripeWebhookEndpoint.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/BillingWebhookAdminEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/IStripeWebhookProcessor.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/StripeWebhookProcessor.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/IBillingEventHandler.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingEventHandlerRegistry.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingWebhookContext.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/NullBillingEventHandler.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingWebhookEventTypes.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/Handlers/SubscriptionWebhookHandler.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/Handlers/InvoiceWebhookHandler.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/Handlers/PaymentWebhookHandler.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/Handlers/DisputeWebhookHandler.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingWebhookFollowupTaskHandler.cs` | Create (`IPlatformTaskHandler`) |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/BillingWebhookServiceCollectionExtensions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map routes, SaaS-mode-gated) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/StripeWebhookProcessorTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/StripeWebhookEndpointTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingEventHandlerRegistryTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingWebhookAdminEndpointsTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, and decisions (especially the GitHub webhook audit findings 001 + 020 referenced in `GitHubEndpoints.cs`)
+3. Confirmed Story 35-1 is merged (Stripe.net, `BillingCustomer`, signing-secret-via-`ISecretStore`, `NullBillingProvider`)
+4. Read `Stripe.net` webhook docs (`EventUtility.ConstructEvent`) — do NOT hand-roll HMAC; the SDK handles the `t=`/`v1=` scheme + timestamp tolerance
+5. Planned the TDD Red-Green-Refactor cycle (tests first per the table above)
+
+### Key Design Decisions
+
+- **Pluggable handler seam over monolithic switch.** The spec lists mirror updates for subscription/invoice/payment, but those entities are owned by 35-4/35-7/35-8. 35-5 ships the *dispatch + DCB emission* and a `NullBillingEventHandler` default; sibling stories register `IBillingEventHandler` for their entities. This honors the epic's story boundaries and lets 35-5 ship + be tested before 35-4/35-8 land.
+- **Dedup at the unique index, not a pre-SELECT.** Insert-then-catch on `UNIQUE(stripe_event_id)` is race-safe under concurrent Stripe retries (same pattern as `GitHubWebhookDelivery (PlatformKind, DeliveryId)`); a pre-check has a TOCTOU window.
+- **Never `4xx`/`5xx` except signature/secret.** Unknown types, no-customer-match, and handler errors all ack `200` and record status locally — Stripe retries on non-2xx and a storm of retries on a permanently-unprojectable event would be self-inflicted DoS. Recovery is our own admin-replay endpoint + the follow-up queue.
+- **Verify with raw bytes.** `EnableBuffering()` + leave-open `StreamReader` then reset `Body.Position = 0` so model binding (if any) still works — copied verbatim from `GitHubEndpoints.Webhooks`. Any middleware that re-serializes the body would break signature verification, so the route stays body-untouched until after verify.
+- **Secret from the cabinet, never env.** Matches 35-1 AC3 + GitHub audit finding 001 (never fail open). Unresolvable secret → `503`, not silent acceptance.
+- **Fast-ack.** Inline work is bounded to one CP transaction (dedup row + mirror + DCB event); everything heavy goes on `PlatformQueuedTask`. Target p95 ack `< 2s`.
+
+### Boundary note (epic ownership)
+
+35-5 does **not** create or migrate `BillingSubscription` (35-4), `BillingInvoice`/`BillingInvoiceLine` (35-8), `BillingPaymentMethod` (35-7), `BillingUsageRollup` (35-3), or `BillingWalletLedger` (35-10). It owns only `BillingWebhookEvent`, the webhook endpoint, the processor, the handler-dispatch seam + DCB emission, the admin replay/inspect endpoint, and the follow-up `PlatformQueuedTask` type. If a sibling story's handler is not yet registered, the corresponding event projects to its `BILLING.*` DCB event and acks `200` via the `NullBillingEventHandler` (DCB audit trail is complete even before the mirror handler exists).
+
+### Graceful degradation
+
+- CP DB write failure on the dedup row → ERROR log, return `503` so Stripe retries (this is the one case where retry is *wanted* — we never persisted the event). Distinct from handler failure, which we own and recover via replay.
+- Single-user / `NullBillingProvider`: route unmapped, zero Stripe surface.
+
+## Logging Requirements
+
+- **INFO**: webhook received (`stripeEventId`, `eventType`, `tenantId`), event projected/enqueued/skipped (with reason), admin list/replay invoked.
+- **DEBUG**: handler resolution (`eventType → handlerType`), dedup-hit (`stripeEventId`), follow-up task enqueued (`taskType`).
+- **WARN**: signature rejected (`stripeEventId` if parseable — never the raw body), no `BillingCustomer` match (`stripeCustomerId`), unknown event type.
+- **ERROR**: signing secret unresolvable, CP dedup-row write failure, handler exception (`stripeEventId`, scrubbed `lastError`).
+- **Structured context**: include `{ stripeEventId, eventType, tenantId, status, attempts }` where applicable.
+- **Credential safety**: NEVER log the signing secret, the `Stripe-Signature` header, Stripe API keys, raw card/PII fields, or the raw webhook body. Scrub `LastError`/`finalError` through `CredentialRedactor.Clean` before persistence.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-35/story-35-6/35-6-plan-quota-and-usage-limit-enforcement.md
+++ b/docs/stories/epic-35/story-35-6/35-6-plan-quota-and-usage-limit-enforcement.md
@@ -1,0 +1,430 @@
+# Story 35-6: Plan Quota & Usage-Limit Enforcement (BYOK-Aware)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-phase workflow (Read → Research → Break Down → TDD → Quality Gates → Failure Handling), the `.dev/` knowledge-base usage rules (spikes, bugs, findings, decisions), TRACE/DEBUG logging requirements, the test-first (TDD) mandate, the 100% critical-path coverage requirement, and build-success enforcement.
+
+## User Story
+
+As a **platform owner running Tamma in SaaS mode**,
+I want plan quotas (period token allowance, seat caps, concurrent workflows, connected repos) enforced at the right gates from the tenant's live subscription and usage state — with platform-provided tokens counted against the allowance and BYOK token volume exempt,
+so that free-tier tenants are correctly hard-blocked when they exhaust their allowance, paid tenants can run over with overage billing, BYOK tenants are never throttled on token volume, and an upgrade lifts the block instantly without a restart.
+
+## Priority
+
+P0 — Without quota enforcement the billing plans created in 35-1/35-4 are unenforced: a free tenant could consume unlimited platform tokens, and seat/repo caps would be advisory only. This story is the enforcement layer that makes plan tiers real.
+
+## Acceptance Criteria
+
+1. A new `QuotaService` (`apps/tamma-elsa/src/Tamma.Api/Services/Billing/QuotaService.cs`, contract `IQuotaService`) resolves the **effective quota** for a tenant from the active `BillingSubscription` (Story 35-4) joined to the `BillingPlanPrice` / `Plan` catalog (Story 35-1), parsing the `Plan.Quotas` JSON into a strongly-typed `PlanQuota` record. This replaces the current dead-config state where `Plan.Quotas` (`apps/tamma-elsa/src/Tamma.Data/Entities/Plan.cs:32`) is stored but never read by any enforcement path.
+
+2. The **platform-provided LLM path** (`LlmProxyService.ChatAsync`, `apps/tamma-elsa/src/Tamma.Api/Services/SaaS/LlmProxyService.cs`, and `/api/v1/llm/chat`) consults `IQuotaService.CheckTokenQuotaAsync(tenantId, ...)` **before** issuing the upstream call. When the period token allowance is exhausted the behaviour is plan-configurable: `OverageBehavior.HardBlock` (free tier) returns a denial; `OverageBehavior.AllowWithOverage` (paid tiers) permits the call and the spend is billed as overage by the metering path (35-3). This is **distinct** from the existing absolute `BudgetConfig` USD cap enforced by `CheckBudgetActivity` / `DiagnosticsService.GetBudgetAsync`.
+
+3. **BYOK tenants are never blocked on token volume.** When the resolved billing mode is `byok` (from `BillingCustomer.BillingMode` per Story 35-2, surfaced on the call via `ITenantProviderKeyResolver`/the `billing_mode` tag), `CheckTokenQuotaAsync` short-circuits to `QuotaDecision.Allowed` regardless of token usage. BYOK tenants are still gated on **seat count**, **connected-repo count**, and **feature flags** via the non-token quota checks.
+
+4. The engine LLM path reuses and extends the existing fail-closed seam: `CheckBudgetActivity` (`apps/tamma-elsa/src/Tamma.Activities/LlmCall/CheckBudgetActivity.cs`) gains a **quota check** alongside its budget check by calling a new central endpoint `GET /api/v1/billing/quota/{tenantId}/token` through `TammaApiClient`. Quota exhaustion completes the activity with the existing `"BudgetExhausted"` outcome (so the flowchart wiring is unchanged); any error in the quota check **fails closed** (denies), matching the activity's current `catch` semantics (`CheckBudgetActivity.cs:157-165`).
+
+5. A **pre-dispatch workflow-run check** is added to the workflow-dispatch entry points (`EngineEndpoints.ExecuteTask` and `EngineEndpoints.TriggerCi`, `apps/tamma-elsa/src/Tamma.Api/Endpoints/EngineEndpoints.cs`, mounted under `/api/engine/*` with `WorkflowsManage`): before dispatch, `IQuotaService.CheckConcurrentWorkflowQuotaAsync(tenantId)` rejects the run when the tenant is at its `MaxConcurrentWorkflows` cap (counting in-flight `WorkflowInstance` rows). Seat and connected-repo caps are enforced at their own mutation gates (member-invite path, GitHub installation-repo add path) — this story adds the `IQuotaService` checks; it does not relocate those endpoints.
+
+6. All quota checks complete **< 100ms p95** using a **local rollup**, never a synchronous Stripe call: token usage is read from the `BillingUsageRollup` table (Story 35-3) for the current period; seat count from `TenantMembership`; connected repos from active `GitHubInstallationRepo` rows. `QuotaService` caches the resolved `PlanQuota` per tenant with a short TTL (mirroring `PostgresBudgetConfigProvider.CacheTtl` = 60s), invalidated on subscription change (AC9).
+
+7. **Soft thresholds** are configurable per quota dimension (default 80% warn, 100% exceeded). Crossing 80% emits a `BILLING.QUOTA.WARN` DCB event (once per period per dimension); crossing 100% emits `BILLING.QUOTA.EXCEEDED`. Both append via `IEventRepository.AppendAsync` to the control-plane `DomainEvents` store with `TenantId` set and `Tags = { tenantId, which_quota, plan, mode, period_start }`, so the Story 5.6 `AlertRuleEvaluator` and the metering/notifications paths can react without a join.
+
+8. **Over-quota API responses** use a stable machine-readable shape consumable by both dashboards: `402 Payment Required` for token-allowance exhaustion under `HardBlock` and `429 Too Many Requests` for concurrent-workflow / seat / repo caps, with body `{ "error": "quota_exceeded", "which_quota": "platform_tokens|concurrent_workflows|seats|connected_repos", "reset_at": "<ISO-8601 | null>", "limit": <n>, "used": <n> }`. The `/api/v1/llm/chat` denial maps the existing `LlmProxyResult` error-reason switch (`SaaSEndpoints.cs`) to a new `"quota_exceeded"` reason → 402, kept distinct from the existing `"budget_exceeded"` → 402.
+
+9. Quotas are **recomputed immediately on subscription / seat change**: Story 35-4's subscription-lifecycle webhook handler (and the `BillingModeService` mode-switch from 35-2) call `IQuotaService.InvalidateAsync(tenantId)` so an upgrade (free → team) lifts a `HardBlock` on the **next** request with no process restart. A `SUBSCRIPTION.UPDATED`-driven invalidation is asserted by test.
+
+10. **Per-mode ownership** (CLAUDE.md "Operating Modes"): in **single-user mode** (`ITammaModeProvider.Mode == TammaMode.SingleUser`) quotas are not enforced — `NullQuotaService` is registered (every check returns `QuotaDecision.Allowed`), no `BillingUsageRollup` is required, and the engine/proxy paths fall back to the existing local `BudgetConfig` behaviour only. In **SaaS mode** the real `QuotaService` is wired; the tenant is the principal and quota state is keyed by `tenantId`.
+
+11. **Tenant isolation**: every quota read is keyed by the authenticated `tenantId` resolved from `ITenantContext` / the engine shared-secret tenant claim — never a client-supplied id. Tenant A's usage rollup, seat count, and subscription are never read for tenant B. The `BillingUsageRollup` query carries the ambient tenant filter as defence-in-depth.
+
+12. **Admin observability**: a read-only `GET /api/v1/admin/quota/{tenantId}` (`OwnerAccess`/platform-owner) returns the resolved `PlanQuota` + current usage for every dimension (`{ plan, mode, token_allowance, tokens_used, overage_behavior, seats_limit, seats_used, concurrent_limit, concurrent_used, repos_limit, repos_used, reset_at }`); a tenant-facing `GET /api/v1/orgs/{tenantId}/quota` (`MemberAccess`, any tenant member may read) returns the same shape scoped to the caller's tenant. No tenant-facing mutation endpoint is added (quota is derived, not set).
+
+13. **DCB event hygiene**: `BILLING.QUOTA.WARN` and `BILLING.QUOTA.EXCEEDED` are emitted **at most once per (tenant, dimension, period)** — a hot LLM loop that crosses 100% a thousand times in a minute produces exactly one `EXCEEDED` event for that period (deduplicated via a `quota_notifications` ledger row keyed `(tenant_id, which_quota, period_start)`), so the alert pipeline is not flooded.
+
+14. Unit + integration tests (xUnit, `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/`) cover: free-tier platform token **hard-block** at 100%; paid-tier **overage allow** at 100%; **BYOK token exemption** (over allowance ⇒ allowed); **seat-cap block** at the invite gate; concurrent-workflow cap at pre-dispatch; `WARN`/`EXCEEDED` **single-emission** dedup; **subscription-change recompute** lifting a block; the engine `CheckBudgetActivity` quota-check fail-closed path; and **tenant-isolation** (A's usage never gates B). Stripe SDK and provider HTTP are mocked.
+
+## Technical Design
+
+### Namespace / file structure
+
+```
+apps/tamma-elsa/src/Tamma.Core/
+  Billing/
+    PlanQuota.cs                    # NEW — strongly-typed quota record + OverageBehavior enum (Core: shared)
+    QuotaDimension.cs               # NEW — enum { PlatformTokens, ConcurrentWorkflows, Seats, ConnectedRepos }
+
+apps/tamma-elsa/src/Tamma.Api/
+  Services/Billing/
+    IQuotaService.cs                # NEW — resolve quota + per-dimension checks + invalidate
+    QuotaService.cs                 # NEW — EF-backed, cached, SaaS implementation
+    NullQuotaService.cs             # NEW — single-user no-op (always Allowed)
+    QuotaResolver.cs                # NEW — subscription→plan→PlanQuota resolution + JSON parse
+    QuotaDecision.cs                # NEW — record { Allowed, WhichQuota, Limit, Used, ResetAt, HttpStatus }
+    QuotaNotifier.cs                # NEW — dedup ledger + WARN/EXCEEDED DCB emission
+    QuotaEvents.cs                  # NEW — BILLING.QUOTA.WARN / BILLING.QUOTA.EXCEEDED constants
+    QuotaOptions.cs                 # NEW — bound config (warn threshold, cache TTL)
+  Endpoints/Billing/
+    QuotaEndpoints.cs               # NEW — GET admin/quota + orgs/{id}/quota
+  Extensions/
+    QuotaServiceCollectionExtensions.cs  # NEW — AddTammaQuota(mode-aware DI)
+  Services/SaaS/
+    LlmProxyService.cs              # MODIFY — call IQuotaService.CheckTokenQuotaAsync pre-call; quota_exceeded reason
+  Endpoints/
+    SaaSEndpoints.cs                # MODIFY — map "quota_exceeded" reason → 402 body
+    EngineEndpoints.cs              # MODIFY — pre-dispatch CheckConcurrentWorkflowQuotaAsync in ExecuteTask/TriggerCi
+    ProviderEndpoints.cs            # MODIFY — add GET /api/v1/billing/quota/{tenantId}/token (engine-callable)
+  Program.cs                        # MODIFY — AddTammaQuota(); map QuotaEndpoints; engine quota route
+
+apps/tamma-elsa/src/Tamma.Data/
+  Entities/
+    QuotaNotification.cs            # NEW — dedup ledger (tenant_id, which_quota, period_start, level)
+  ControlPlaneDbContext.cs          # MODIFY — add DbSet<QuotaNotification>
+  TammaModelConfiguration.cs        # MODIFY — table, unique index, CHECKs
+  Migrations/ControlPlane/
+    <ts>_AddQuotaNotifications.cs    # NEW (+ Designer + snapshot)
+
+apps/tamma-elsa/src/Tamma.Activities/LlmCall/
+  CheckBudgetActivity.cs            # MODIFY — add quota check via TammaApiClient (fail-closed)
+  TammaApiClient.cs                 # MODIFY — add GetTokenQuotaAsync(tenantId)
+```
+
+> **Verified against the current tree.** `Plan` (with the unread `Quotas` JSON, `Plan.cs:32`), `LlmProxyService`/`ILlmProxyService`, `/api/v1/llm/chat` (`Program.cs:1900`), `CheckBudgetActivity` + its `TammaApiClient.GetBudgetAsync` → `GET /api/providers/diagnostics/budget/{accountId}` → `DiagnosticsService.GetBudgetAsync` → `BudgetStatus`, `EngineEndpoints.ExecuteTask`/`TriggerCi` (`/api/engine/*`, `Program.cs:1853-1854`), `IEventRepository.AppendAsync`/`DomainEvent`, `ITenantContext`, `ITammaModeProvider` (`Services/PromptStore/TammaMode.cs`), `TenantMembership`, `GitHubInstallationRepo`, `WorkflowInstance`, `BudgetConfig`/`PostgresBudgetConfigProvider` (60s cache), and the `OwnerAccess`/`MemberAccess`/`PlatformOwnerAccess` policies (`Program.cs:971,991,986`) all exist today. **`BillingSubscription` (35-4), `BillingUsageRollup` (35-3), `BillingCustomer.BillingMode` + `ITenantProviderKeyResolver` (35-1/35-2) are created by prerequisite stories — this story consumes them.**
+
+### Key types
+
+```csharp
+// Tamma.Core/Billing/PlanQuota.cs
+namespace Tamma.Core.Billing;
+
+public enum OverageBehavior { HardBlock, AllowWithOverage }
+
+/// <summary>Effective per-period quota for a tenant, parsed from Plan.Quotas
+/// JSON and overlaid with any subscription-level override. A null limit means
+/// "unlimited" for that dimension (e.g. enterprise tokens).</summary>
+public sealed record PlanQuota(
+    string PlanSlug,
+    long? PlatformTokenAllowance,     // tokens/period; null = unlimited
+    OverageBehavior TokenOverage,
+    int? MaxSeats,
+    int? MaxConcurrentWorkflows,
+    int? MaxConnectedRepos,
+    double WarnThreshold);            // 0..1, default 0.8
+```
+
+```csharp
+// Tamma.Api/Services/Billing/QuotaDecision.cs
+namespace Tamma.Api.Services.Billing;
+
+public sealed record QuotaDecision(
+    bool Allowed,
+    QuotaDimension WhichQuota,
+    long Limit,
+    long Used,
+    DateTimeOffset? ResetAt,
+    int HttpStatus)                   // 402 tokens / 429 caps; 0 when Allowed
+{
+    public static QuotaDecision Allow(QuotaDimension d) =>
+        new(true, d, 0, 0, null, 0);
+}
+```
+
+```csharp
+// Tamma.Api/Services/Billing/IQuotaService.cs
+namespace Tamma.Api.Services.Billing;
+
+public interface IQuotaService
+{
+    /// <summary>Resolve the effective quota for a tenant (cached, ≤100ms).</summary>
+    Task<PlanQuota> GetQuotaAsync(Guid tenantId, CancellationToken ct = default);
+
+    /// <summary>Gate a platform-provided LLM call. BYOK ⇒ always Allow.
+    /// HardBlock plan over allowance ⇒ deny (402). AllowWithOverage ⇒ allow,
+    /// metering bills the overage. Emits WARN/EXCEEDED via QuotaNotifier.</summary>
+    Task<QuotaDecision> CheckTokenQuotaAsync(
+        Guid tenantId, string billingMode, long projectedTokens, CancellationToken ct = default);
+
+    /// <summary>Gate a workflow dispatch on the concurrent-workflow cap.</summary>
+    Task<QuotaDecision> CheckConcurrentWorkflowQuotaAsync(Guid tenantId, CancellationToken ct = default);
+
+    /// <summary>Gate a member-invite on the seat cap.</summary>
+    Task<QuotaDecision> CheckSeatQuotaAsync(Guid tenantId, CancellationToken ct = default);
+
+    /// <summary>Gate a repo-add on the connected-repo cap.</summary>
+    Task<QuotaDecision> CheckConnectedRepoQuotaAsync(Guid tenantId, CancellationToken ct = default);
+
+    /// <summary>Drop the cached PlanQuota for a tenant (sub/seat/mode change).</summary>
+    void Invalidate(Guid tenantId);
+}
+```
+
+### Quota resolution (`QuotaResolver`)
+
+`GetQuotaAsync(tenantId)`:
+1. Cache hit (per-tenant `ConcurrentDictionary<Guid, (PlanQuota, DateTime fetchedAt)>`, TTL `QuotaOptions.CacheTtl` default 60s) → return.
+2. Load the active `BillingSubscription` for the tenant (Story 35-4); fall back to `Tenant.Plan` slug (`Tenant.cs:11`) when no subscription row exists (free-tier tenants pre-checkout).
+3. Resolve the `Plan` row by slug; parse `Plan.Quotas` JSON (`Plan.cs:32`) into `PlanQuota` with a tolerant parser (missing keys ⇒ unlimited/default; malformed JSON ⇒ **fail closed** to the free-tier quota, logged WARN — never silently unlimited).
+4. Cache + return.
+
+### Token-quota check (the hot path)
+
+`CheckTokenQuotaAsync(tenantId, billingMode, projectedTokens)`:
+- `billingMode == "byok"` ⇒ `QuotaDecision.Allow(PlatformTokens)` (AC3) — no rollup read.
+- Load `PlanQuota`; `PlatformTokenAllowance == null` ⇒ allow (unlimited).
+- Read current-period platform-provided token usage from `BillingUsageRollup` (Story 35-3), filtered to `billing_mode = 'platform'` so BYOK usage already excluded at the rollup.
+- `used + projectedTokens` vs allowance:
+  - `< WarnThreshold * allowance` ⇒ allow.
+  - `>= WarnThreshold` and `< allowance` ⇒ allow + `QuotaNotifier.NotifyAsync(WARN)`.
+  - `>= allowance` ⇒ `QuotaNotifier.NotifyAsync(EXCEEDED)`; then `HardBlock` ⇒ deny (402, `ResetAt = period_end`), `AllowWithOverage` ⇒ allow (overage billed by 35-3).
+
+### Notifier dedup ledger
+
+```csharp
+// Tamma.Data/Entities/QuotaNotification.cs
+public class QuotaNotification
+{
+    public Guid Id { get; set; }
+    public Guid TenantId { get; set; }
+    public string WhichQuota { get; set; } = null!;   // platform_tokens | seats | ...
+    public DateTime PeriodStart { get; set; }
+    public string Level { get; set; } = null!;        // warn | exceeded
+    public DateTime CreatedAt { get; set; }
+}
+```
+
+`QuotaNotifier.NotifyAsync` inserts-if-absent on the unique key `(TenantId, WhichQuota, PeriodStart, Level)` (NULLS NOT DISTINCT not needed — no nullable key parts); on a fresh insert it appends the DCB event, on a unique-violation it no-ops (AC13). Mirrors the missing-config-notifications dedup pattern.
+
+### EF migration sketch
+
+Additive only (new table; no baseline CHECK edits):
+
+```csharp
+migrationBuilder.CreateTable(name: "quota_notifications", columns: table => new {
+    Id = table.Column<Guid>(nullable: false),
+    TenantId = table.Column<Guid>(nullable: false),
+    WhichQuota = table.Column<string>(nullable: false),
+    PeriodStart = table.Column<DateTime>(nullable: false),
+    Level = table.Column<string>(nullable: false),
+    CreatedAt = table.Column<DateTime>(nullable: false),
+}, constraints: table => {
+    table.PrimaryKey("PK_quota_notifications", x => x.Id);
+    table.CheckConstraint("ck_quota_notifications_level", "\"Level\" IN ('warn','exceeded')");
+});
+migrationBuilder.CreateIndex("IX_quota_notifications_dedup", "quota_notifications",
+    new[] { "TenantId", "WhichQuota", "PeriodStart", "Level" }, unique: true);
+```
+
+Run `dotnet ef migrations add AddQuotaNotifications --context ControlPlaneDbContext`; verify `has-pending-model-changes` reports none; mirror entity config in `TammaModelConfiguration.cs` (the single source).
+
+### DCB event names
+
+| Event | When | TenantId | Tags |
+|---|---|---|---|
+| `BILLING.QUOTA.WARN` | first crossing of `WarnThreshold` for a (tenant, dimension, period) | set | `{ tenantId, which_quota, plan, mode, period_start, used, limit }` |
+| `BILLING.QUOTA.EXCEEDED` | first crossing of 100% for a (tenant, dimension, period) | set | `{ tenantId, which_quota, plan, mode, period_start, used, limit, overage_behavior }` |
+
+Both follow `AGGREGATE.ACTION.STATUS` and append via `IEventRepository.AppendAsync(new DomainEvent { Type, TenantId, Tags, Metadata = "{\"workflowVersion\":\"1.0.0\",\"eventSource\":\"system\"}", Data })`. They are CP-resident exactly like `BUDGET.EXHAUSTED`, so the existing `AlertRuleEvaluator` can match them with no rule-engine change (alert-rule seeding for these is a follow-up, mirroring the budget-exhausted rule).
+
+### Engine path (CheckBudgetActivity extension)
+
+`CheckBudgetActivity.ExecuteAsync` already calls `TammaApiClient.GetBudgetAsync` and fails closed on any exception (`CheckBudgetActivity.cs:68-114, 157-165`). Add, after the budget check passes, a quota check:
+
+```csharp
+var quota = await apiClient.GetTokenQuotaAsync(budgetOwnerId, context.CancellationToken);
+if (quota is { Allowed: false })
+{
+    // reuse the existing exhausted outcome so the flowchart is unchanged
+    await context.CompleteActivityWithOutcomesAsync("BudgetExhausted");
+    return;
+}
+```
+
+`TammaApiClient.GetTokenQuotaAsync` calls `GET /api/v1/billing/quota/{tenantId}/token` (new in `ProviderEndpoints`/a billing endpoint, authenticated by the engine shared-secret scheme like the budget route). Any failure ⇒ the activity's outer `catch` already returns `"BudgetExhausted"` (fail-closed, AC4).
+
+### Pre-dispatch workflow check
+
+In `EngineEndpoints.ExecuteTask` and `TriggerCi`, after request validation and before dispatch:
+
+```csharp
+var decision = await quota.CheckConcurrentWorkflowQuotaAsync(tc.TenantId ?? Guid.Empty, ct);
+if (!decision.Allowed)
+    return Results.Json(QuotaResponse.From(decision), statusCode: decision.HttpStatus); // 429
+```
+
+`CheckConcurrentWorkflowQuotaAsync` counts in-flight `WorkflowInstance` rows for the tenant against `PlanQuota.MaxConcurrentWorkflows` (null ⇒ unlimited; single-user ⇒ `NullQuotaService` ⇒ always allowed).
+
+### Over-quota response shape (`QuotaResponse`)
+
+```jsonc
+// 402 (tokens, HardBlock) or 429 (concurrent / seats / repos)
+{ "error": "quota_exceeded", "which_quota": "platform_tokens",
+  "reset_at": "2026-07-01T00:00:00Z", "limit": 1000000, "used": 1000000 }
+```
+
+`SaaSEndpoints.LlmChat` extends its existing `response.ErrorReason switch` with `"quota_exceeded" => Results.Json(QuotaResponse..., statusCode: 402)`, kept separate from the existing `"budget_exceeded"` arm (different cause: allowance vs absolute USD cap).
+
+### Per-mode + per-tenant handling
+
+| Concern | single-user (`TammaMode.SingleUser`) | SaaS (`TammaMode.SaaS`) |
+|---|---|---|
+| Service registered | `NullQuotaService` (every check `Allowed`) | `QuotaService` (EF + cache) |
+| Quota source | n/a (only local `BudgetConfig` USD cap applies) | active `BillingSubscription` → `Plan.Quotas` |
+| Token usage source | n/a | `BillingUsageRollup` (`billing_mode='platform'`, current period) |
+| BYOK exemption | n/a (sole user owns all usage) | `byok` mode ⇒ token checks short-circuit Allow |
+| Principal / key | the user | the tenant (`tenantId`) |
+| WARN/EXCEEDED events | not emitted | emitted (deduped per period) |
+| Admin/tenant read endpoints | route absent | `/api/v1/admin/quota/{id}` (owner), `/api/v1/orgs/{id}/quota` (member) |
+
+## Dependencies
+
+**Internal (prerequisite):**
+- **Story 35-3** (BYOK-aware usage metering) — supplies the `BillingUsageRollup` table + `billing_mode` split this story reads for token usage. **Hard blocker.**
+- **Story 35-4** (subscription lifecycle) — supplies the `BillingSubscription` entity + the `SUBSCRIPTION.UPDATED` invalidation hook. **Hard blocker.**
+- **Story 35-1** — `BillingCustomer`, `BillingPlanPrice`, `Services/Billing/` directory, `Plan` catalog mapping.
+- **Story 35-2** — `BillingCustomer.BillingMode` + `ITenantProviderKeyResolver` + the `billing_mode` tag on `LLM.CALL.*` / `ProviderDiagnostic`.
+- **Epic 28** — `Tenant`/`Plan`, `ControlPlaneDbContext`, `ITenantContext`, `ITammaModeProvider`, `TenantMembership`, `WorkflowInstance`, `GitHubInstallationRepo`.
+- **Epic 4** — DCB events (`DomainEvent`, `IEventRepository.AppendAsync`); Story 5.6 `AlertRuleEvaluator`.
+- **Epic 9** — `CheckBudgetActivity` / `TammaApiClient` fail-closed budget seam (extended here).
+
+**Internal (blocks):**
+- Billing dashboard / usage-display stories (consume `/api/v1/orgs/{id}/quota`).
+- Invoicing / overage stories (rely on the `AllowWithOverage` decision + `EXCEEDED` events).
+
+**External:**
+- Stripe.net (via 35-1) — only mocked here; quota checks never call Stripe synchronously (AC6).
+- PostgreSQL 17 control-plane DbContext (existing) for integration tests.
+
+## Testing Strategy
+
+**Unit (xUnit, `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/`):**
+1. `QuotaResolverTests` — subscription→plan→`PlanQuota` parse (free/team/enterprise), missing JSON keys default sensibly, malformed `Plan.Quotas` ⇒ fail-closed to free quota + WARN, no-subscription falls back to `Tenant.Plan` slug.
+2. `QuotaServiceTokenTests` — free-tier at 100% ⇒ `HardBlock` deny (402, `reset_at` = period end); paid-tier at 100% ⇒ `AllowWithOverage` allow; BYOK over allowance ⇒ allow (no rollup read — asserted via mock never-called); 80% crossing ⇒ allow + one WARN; unlimited (null allowance) ⇒ allow.
+3. `QuotaServiceCapTests` — seat cap block at `CheckSeatQuotaAsync` (members == limit ⇒ deny 429); concurrent-workflow cap (in-flight == limit ⇒ deny); connected-repo cap.
+4. `QuotaNotifierTests` — first WARN/EXCEEDED inserts ledger row + appends DCB event once; repeat crossings in the same period ⇒ no second event (unique-violation no-op); new period ⇒ new event.
+5. `QuotaInvalidationTests` — `Invalidate(tenantId)` evicts cache; a subsequent `GetQuotaAsync` re-resolves the upgraded plan (free→team) and a previously-blocked token check now allows (AC9).
+6. `NullQuotaServiceTests` — single-user: every check returns `Allowed`, no DB read, no event.
+7. `CheckBudgetActivityQuotaTests` — quota-allowed ⇒ `"WithinBudget"`; quota-exhausted ⇒ `"BudgetExhausted"`; quota endpoint throws ⇒ fail-closed `"BudgetExhausted"` (AC4).
+8. `LlmProxyServiceQuotaTests` — platform call over allowance (HardBlock) ⇒ `ErrorReason == "quota_exceeded"`; BYOK call over allowance ⇒ succeeds.
+
+**Integration (`Tamma.Api.Tests`, docker-bound real Postgres, `sg docker -c "dotnet test ..."`):**
+9. Migration applies + rolls back; `has-pending-model-changes` reports none.
+10. `/api/v1/llm/chat` for a free tenant at allowance ⇒ HTTP 402 `quota_exceeded` body; same tenant after a simulated upgrade + `Invalidate` ⇒ 200.
+11. `/api/engine/execute-task` at the concurrent cap ⇒ HTTP 429 `quota_exceeded`/`concurrent_workflows`.
+12. **Tenant isolation** — seed tenant A at 100% usage, tenant B at 0%; A's `/llm/chat` ⇒ 402, B's ⇒ 200; assert A's rollup/subscription never read for B; `/api/v1/orgs/{B}/quota` never returns A's numbers; cross-tenant `/api/v1/orgs/{A}/quota` with B's token ⇒ 404.
+13. `GET /api/v1/admin/quota/{id}` (`OwnerAccess`) returns the full resolved shape; member-role caller on the admin route ⇒ 403; `GET /api/v1/orgs/{id}/quota` member ⇒ 200.
+
+**Mocks:** Stripe SDK mocked (no live calls); upstream provider via `HttpMessageHandler` stub; `BillingUsageRollup`/`BillingSubscription` repositories faked for unit tests, real for isolation integration tests.
+
+Coverage targets per `CLAUDE.md`: 80% line / 75% branch / 85% function; token-quota decision logic, BYOK exemption, fail-closed engine path, and notifier dedup are **critical paths → 100%**.
+
+## Estimated Effort
+
+4-5 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Core/Billing/PlanQuota.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Core/Billing/QuotaDimension.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/IQuotaService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/QuotaService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/NullQuotaService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/QuotaResolver.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/QuotaDecision.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/QuotaNotifier.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/QuotaEvents.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/QuotaOptions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/QuotaEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/QuotaServiceCollectionExtensions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/QuotaNotification.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_AddQuotaNotifications.cs` | Create (+ Designer + snapshot) |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (add DbSet) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (entity config) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/SaaS/LlmProxyService.cs` | Modify (token quota check + quota_exceeded reason) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/SaaSEndpoints.cs` | Modify (map quota_exceeded → 402) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/EngineEndpoints.cs` | Modify (pre-dispatch concurrent check) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/ProviderEndpoints.cs` | Modify (engine token-quota route) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (AddTammaQuota, map endpoints) |
+| `apps/tamma-elsa/src/Tamma.Activities/LlmCall/CheckBudgetActivity.cs` | Modify (quota check, fail-closed) |
+| `apps/tamma-elsa/src/Tamma.Activities/LlmCall/TammaApiClient.cs` | Modify (GetTokenQuotaAsync) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/QuotaResolverTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/QuotaServiceTokenTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/QuotaServiceCapTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/QuotaNotifierTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/QuotaInvalidationTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/NullQuotaServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/LlmProxyServiceQuotaTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/LlmCall/CheckBudgetActivityQuotaTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/QuotaEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/QuotaEnforcementIntegrationTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md).
+2. Searched `.dev/` for billing/quota/budget spikes, bugs, findings, decisions (especially the `CheckBudgetActivity` fail-closed history and the Story 5.6 alert-evaluator findings).
+3. Confirmed Stories 35-1/35-2/35-3/35-4 are merged so `BillingCustomer`/`BillingMode`/`BillingUsageRollup`/`BillingSubscription` exist.
+4. Reviewed `CheckBudgetActivity.cs` (the fail-closed pattern this story extends) and `PostgresBudgetConfigProvider.cs` (the 60s-cache pattern this story mirrors).
+5. Planned the TDD (Red-Green-Refactor) cycle for every new type.
+
+### Key Design Decisions
+
+- **Quota is derived, never set.** The effective `PlanQuota` is resolved from the live subscription + plan catalog at read time; there is no per-tenant "quota override" table to drift. `Plan.Quotas` becomes a *read* path (it is dead config today, `Plan.cs:32`).
+- **Quota is distinct from the absolute USD budget cap.** `BudgetConfig`/`CheckBudgetActivity` enforce a hard USD ceiling (a safety brake); plan quotas enforce the *allowance* a tenant paid for. Both can fire; the response reasons (`budget_exceeded` vs `quota_exceeded`) and the events (`BUDGET.EXHAUSTED` vs `BILLING.QUOTA.EXCEEDED`) stay separate so dashboards can tell them apart.
+- **Fail-closed in the engine, fail-closed on malformed config.** The engine quota check inherits `CheckBudgetActivity`'s deny-on-error contract; a malformed `Plan.Quotas` JSON degrades to the *free* quota (most restrictive), never to unlimited.
+- **BYOK exemption is checked first and cheaply.** `CheckTokenQuotaAsync` returns `Allow` on `byok` before any rollup read — BYOK tenants pay a seat fee, not a token markup (epic theme), so token volume must never gate them.
+- **Local rollup, never synchronous Stripe.** All checks read CP/per-tenant tables; Stripe is the system of record for invoicing, not for the < 100ms enforcement decision (AC6) — same principle as Story 20-3's "query local `usage_records`, not Stripe".
+- **Dedup the events, throttle the alerts.** One ledger row per (tenant, dimension, period, level) caps event volume at the source (AC13), belt-and-suspenders with the alert evaluator's `ThrottleSeconds`.
+- **Single-user is a registration-time no-op.** `NullQuotaService` keeps request handlers free of mode branching, mirroring 35-1's `NullBillingProvider` and 35-2's `NullBillingModeService`.
+
+### Boundary Notes (do not implement sibling-story scope)
+
+- **No usage metering or rollup writes** — `BillingUsageRollup` is written by Story 35-3; this story only *reads* it. No token-counting on the LLM response path beyond reading the existing rollup.
+- **No subscription lifecycle, checkout, or webhook ingestion** — Story 35-4 owns `BillingSubscription` and the `SUBSCRIPTION.UPDATED` hook; this story only consumes the entity and exposes `Invalidate` for 35-4 to call.
+- **No invoicing, overage line-item creation, dunning, tax, portal, or credits** — later stories. This story emits the `AllowWithOverage` *decision* and the `EXCEEDED` *event*; it does not bill.
+- **No seat/repo endpoint relocation** — the seat cap is checked at the existing member-invite gate and the repo cap at the existing installation-repo add gate; this story adds the `IQuotaService` call, it does not move those endpoints.
+- **No alert-rule seeding for quota events in this story** — the events are CP-resident and evaluator-visible; a `BuiltInAlertRules` entry for `BILLING.QUOTA.*` is a trivial follow-up (mirrors the budget-exhausted rule).
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Quota check adds latency to every LLM call | High | Cached `PlanQuota` (60s TTL) + single indexed rollup read; AC6 p95 < 100ms; load test in CI. |
+| Malformed `Plan.Quotas` JSON ⇒ accidental unlimited | High | Tolerant parser fails *closed* to free-tier quota + WARN; unit-tested. |
+| Event flood from a hot over-quota loop | Medium | Per-period dedup ledger (AC13) + alert ThrottleSeconds. |
+| Stale cache after upgrade keeps a tenant blocked | High | 35-4 calls `Invalidate(tenantId)` on `SUBSCRIPTION.UPDATED`; AC9 test asserts immediate lift. |
+| BYOK tenant wrongly throttled | High | BYOK short-circuit checked first; dedicated exemption test; never reads rollup for BYOK. |
+| Engine quota endpoint unreachable | Medium | `CheckBudgetActivity` fail-closed `catch` already denies; AC4 test. |
+
+### Success Metrics
+
+- [ ] Free-tier platform tokens are hard-blocked at 100%; paid-tier runs over with overage; BYOK never blocked on tokens.
+- [ ] Quota checks p95 < 100ms (no synchronous Stripe call).
+- [ ] One WARN + one EXCEEDED event per (tenant, dimension, period).
+- [ ] Upgrade lifts a block on the next request (no restart).
+- [ ] Single-user boot enforces no quotas (NullQuotaService); 0 billing reads asserted.
+
+## Logging Requirements
+
+- **INFO**: quota resolved (`tenantId`, `plan`, `mode`); quota decision denied (`tenantId`, `which_quota`, `limit`, `used`); WARN/EXCEEDED event emitted (`tenantId`, `which_quota`, `level`); cache invalidated (`tenantId`).
+- **DEBUG**: quota check started (`tenantId`, `dimension`, `projectedTokens`); cache hit/miss; rollup read (`tenantId`, `used`).
+- **WARN**: malformed `Plan.Quotas` ⇒ fail-closed to free quota (`tenantId`, `plan`); quota threshold crossed (`tenantId`, `which_quota`); engine quota endpoint fallback.
+- **ERROR**: control-plane read failure on quota resolution; DCB append failure; rollup query failure.
+- **Structured context**: include `{ tenantId, plan, mode, which_quota, limit, used }` where applicable.
+- **Credential safety**: NEVER log Stripe keys, provider API keys (BYOK or platform), or any secret plaintext. Quota logs carry counts and slugs only.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-35/story-35-7/35-7-payment-methods-and-self-service-stripe-billing-portal.md
+++ b/docs/stories/epic-35/story-35-7/35-7-payment-methods-and-self-service-stripe-billing-portal.md
@@ -1,0 +1,301 @@
+# Story 35-7: Payment Methods & Self-Service Stripe Billing Portal
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-Phase Development Workflow (Read → Research → Break Down → TDD → Quality Gates → Failure Handling), the `.dev/` knowledge-base usage rules (spikes, bugs, findings, decisions), TRACE/DEBUG logging requirements, the Test-Driven Development workflow, and the build/coverage quality gates. Failure to follow this process will result in rework.
+
+## User Story
+
+As a **tenant owner or admin** running on Tamma in SaaS mode,
+I want to manage my payment methods and billing details from inside Tamma — open the Stripe Customer Portal for card management, add or replace a default card via a setup-intent, and see my current card's brand/last4 at a glance,
+So that I can keep my billing current without leaving the product, never expose raw card data to Tamma, and avoid involuntary churn from a missing or expired card.
+
+## Priority
+
+P1 - Self-service billing management. Required for tenant retention and feeds the dunning/notifications path (Story 35-8): a paid-plan tenant with no payment method is a churn risk that must be surfaced and recoverable.
+
+## Acceptance Criteria
+
+1. `POST /api/v1/billing/portal-session` creates a Stripe Customer Portal session for the caller's tenant (resolving `BillingCustomer.StripeCustomerId` via `BillingCustomer.TenantId` from Story 35-1) and returns `{ url }`. The endpoint is gated to `tenant_owner`/`tenant_admin` (via the dedicated `BillingManage` policy); a `member`-role caller receives `403`. A cross-tenant caller (not a member of the path/active tenant) receives `404`.
+
+2. `POST /api/v1/billing/payment-methods/setup-intent` creates a Stripe `SetupIntent` (usage `off_session`, attached to the tenant's customer) and returns `{ clientSecret, setupIntentId }` so the dashboard can collect/replace the default card with Stripe Elements. Same `tenant_owner`/`tenant_admin` RBAC; `member` → `403`.
+
+3. A new control-plane entity `BillingPaymentMethod` (`apps/tamma-elsa/src/Tamma.Data/Entities/BillingPaymentMethod.cs`) mirrors the masked card for display and dunning decisions: `Id` (Guid PK), `TenantId` (Guid FK to `tenants.Id`), `StripeCustomerId`, `StripePaymentMethodId` (unique), `Brand`, `Last4`, `ExpMonth`, `ExpYear`, `IsDefault` (bool), `Status` (`active|expiring|expired|detached`), `CreatedAt`, `UpdatedAt`. Registered as `DbSet<BillingPaymentMethod>` on `ControlPlaneDbContext` and configured in `TammaModelConfiguration` (table `billing_payment_methods`, unique index on `StripePaymentMethodId`, index on `TenantId`, partial unique index enforcing at most one `IsDefault = true` per tenant, CHECK constraint on `Status`). **Raw PAN, CVC, or full card numbers never touch any Tamma column** — only brand/last4/exp are stored.
+
+4. `GET /api/v1/billing/payment-methods` returns the masked mirror for the caller's tenant (`{ id, brand, last4, expMonth, expYear, isDefault, status }[]`) **from the local table with no Stripe round-trip on read**. Any tenant member (including `member`) may read.
+
+5. The mirror is updated by an `IBillingEventHandler` (Story 35-5 dispatch seam) — `PaymentMethodBillingEventHandler` — that handles `payment_method.attached`, `payment_method.detached`, `payment_method.automatically_updated`, and `customer.updated` (for `invoice_settings.default_payment_method` changes). Attach upserts the mirror row; detach flips `Status = detached` (and clears `IsDefault`); a default change re-points `IsDefault` to the new method (atomically clearing the prior default). 35-7 owns ONLY this handler and the `BillingPaymentMethod` entity — it does not own webhook ingestion (35-5) or subscription/invoice mirrors (35-4/35-8).
+
+6. Portal `return_url` and any client-supplied `returnUrl` are validated against an **allowlist** of configured app origins (`Billing:PortalReturnUrlAllowlist`, defaulting to the dashboard origin) to prevent open-redirect; a `returnUrl` whose origin is not on the allowlist is rejected with `400` and the request is logged WARN. Portal sessions and setup-intents are short-lived/single-use (Stripe-enforced) and Tamma never persists the session URL or client secret.
+
+7. DCB events are emitted via `IEventRepository.AppendAsync(DomainEvent)` (CP store) following the `AGGREGATE.ACTION.STATUS` convention: `BILLING.PAYMENT_METHOD.ADDED` (on attach), `BILLING.PAYMENT_METHOD.REMOVED` (on detach), and `BILLING.PAYMENT_METHOD.DEFAULT_CHANGED` (on default re-point), each with JSONB `tags = { tenantId, last4, brand, stripePaymentMethodId }` and `TenantId` set. A `BILLING.PORTAL_SESSION.CREATED` event is emitted on portal-session creation (`tags = { tenantId, userId }`).
+
+8. A paid-plan tenant (subscription not on the `free` plan slug per Story 35-1's `BillingPlanPrice`/35-4 subscription state) with **zero** `active`/`expiring` `BillingPaymentMethod` rows is flagged for the dunning/notifications path: 35-7 emits a `BILLING.PAYMENT_METHOD.MISSING` DCB event when a detach/expiry leaves a paid tenant with no usable card, and `GET /api/v1/billing/payment-methods` returns a `hasUsableDefault: false` flag. **35-7 does not implement dunning escalation or notification delivery — that is Story 35-8's responsibility**; this story only emits the signal.
+
+9. In **single-user mode** (`ITammaModeProvider` → `SingleUser`) the portal-session, setup-intent, and payment-method routes are **not mapped** and the `NullBillingProvider` seam (Story 35-1 AC4/AC7) means no Stripe wiring is registered. In **SaaS mode** the routes are mapped and tenant resolution is mandatory. This mirrors the per-mode contract in CLAUDE.md "Operating Modes".
+
+10. Secret material (Stripe secret key) is resolved exclusively through the Epic 29 cabinet via `ISecretStore` / the `IBillingProvider` seam established in Story 35-1 (`SecretScope.Platform`, `SecretPurpose.ApiKey`) — never a raw `IConfiguration`/env read. In production billing refuses portal/setup-intent operations if the key is unresolvable, returning `503` and logging ERROR (never fails open).
+
+11. Stripe round-trips (`portal-session`, `setup-intent`) go through an `IStripeCustomerPortalClient` seam wrapping `Stripe.BillingPortal.SessionService` and `Stripe.SetupIntentService`, so the endpoints are unit-testable against a mock and the integration suite can drive Stripe test mode. Stripe API failures map to `502 Bad Gateway` with a `TammaError` (`code "BILLING.PORTAL.STRIPE_ERROR"`, retryable), logged ERROR with the Stripe request id but never card data.
+
+12. Unit + integration tests cover: portal-session creation + RBAC (owner/admin 200, member 403, cross-tenant 404), setup-intent flow, webhook-driven mirror updates for attach/detach/default-change (one DCB event each), masked read with no Stripe call, redirect-allowlist validation (allowed → 200, disallowed origin → 400), `BILLING.PAYMENT_METHOD.MISSING` emission on last-card-detach for a paid tenant, single-user route-not-mapped, and **tenant-isolation** (a `payment_method.attached` webhook for tenant A never writes a `BillingPaymentMethod` row or DCB event for tenant B; a portal session for tenant A never returns tenant B's customer).
+
+## Technical Design
+
+### Namespace & file structure
+
+```
+apps/tamma-elsa/src/Tamma.Api/
+  Endpoints/Billing/
+    BillingPortalEndpoints.cs            # NEW — portal-session, setup-intent, GET payment-methods
+  Services/Billing/
+    IStripeCustomerPortalClient.cs       # NEW — Stripe portal/setup-intent seam
+    StripeCustomerPortalClient.cs        # NEW — Stripe.BillingPortal + Stripe.SetupIntent impl
+    NullStripeCustomerPortalClient.cs    # NEW — single-user no-op (parallels NullBillingProvider, 35-1)
+    PaymentMethodService.cs              # NEW — mirror upsert/read + DCB emission + missing-card signal
+    IPaymentMethodService.cs             # NEW
+    PaymentMethodBillingEventHandler.cs  # NEW — IBillingEventHandler (registered into 35-5 dispatch)
+    ReturnUrlAllowlist.cs                # NEW — origin allowlist validator
+    BillingPaymentMethodEventTypes.cs    # NEW — DCB event-type constants
+  Authorization/
+    (reuse / add BillingManage policy in Program.cs — see RBAC below)
+  Extensions/
+    BillingPaymentMethodServiceCollectionExtensions.cs  # NEW — DI wiring (mirrors AlertServiceCollectionExtensions)
+
+apps/tamma-elsa/src/Tamma.Data/
+  Entities/BillingPaymentMethod.cs       # NEW
+  ControlPlaneDbContext.cs               # MODIFY — DbSet<BillingPaymentMethod>
+  TammaModelConfiguration.cs             # MODIFY — entity config (indexes, CHECK, partial-unique default)
+  Migrations/ControlPlane/<ts>_AddBillingPaymentMethods.cs  # NEW (+ snapshot update)
+
+packages/dashboard-user/src/
+  api/billing.ts                         # NEW — client (mirror api/alerts.ts conventions)
+  pages/settings/BillingPaymentMethods.tsx  # NEW — portal button, add-card (SetupIntent + Stripe Elements), masked list
+```
+
+### Entity sketch (`BillingPaymentMethod.cs`)
+
+```csharp
+namespace Tamma.Data.Entities;
+
+public class BillingPaymentMethod
+{
+    public Guid Id { get; set; }
+    public Guid TenantId { get; set; }
+    public string StripeCustomerId { get; set; } = null!;
+    public string StripePaymentMethodId { get; set; } = null!; // pm_... (unique)
+    public string Brand { get; set; } = null!;                 // visa, mastercard, ...
+    public string Last4 { get; set; } = null!;                 // "4242" — NEVER full PAN
+    public int ExpMonth { get; set; }
+    public int ExpYear { get; set; }
+    public bool IsDefault { get; set; }
+    public string Status { get; set; } = "active";             // active|expiring|expired|detached
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}
+```
+
+EF config (in `TammaModelConfiguration.ConfigureControlPlaneEntities`): `ToTable("billing_payment_methods")`; `HasIndex(StripePaymentMethodId).IsUnique()`; `HasIndex(TenantId)`; partial unique index `CREATE UNIQUE INDEX ix_bpm_one_default ON billing_payment_methods (tenant_id) WHERE is_default`; CHECK `status IN ('active','expiring','expired','detached')`. No navigation to `BillingCustomer` is strictly required — keyed by `TenantId` like the rest of the billing mirrors.
+
+### EF migration sketch
+
+`dotnet ef migrations add AddBillingPaymentMethods --context ControlPlaneDbContext --output-dir Migrations/ControlPlane` →
+
+```sql
+CREATE TABLE billing_payment_methods (
+  id UUID PRIMARY KEY,
+  tenant_id UUID NOT NULL,
+  stripe_customer_id TEXT NOT NULL,
+  stripe_payment_method_id TEXT NOT NULL,
+  brand TEXT NOT NULL,
+  last4 TEXT NOT NULL,
+  exp_month INT NOT NULL,
+  exp_year INT NOT NULL,
+  is_default BOOLEAN NOT NULL DEFAULT FALSE,
+  status TEXT NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active','expiring','expired','detached')),
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL,
+  CONSTRAINT fk_bpm_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id)
+);
+CREATE UNIQUE INDEX ix_bpm_stripe_pm ON billing_payment_methods (stripe_payment_method_id);
+CREATE INDEX ix_bpm_tenant ON billing_payment_methods (tenant_id);
+CREATE UNIQUE INDEX ix_bpm_one_default ON billing_payment_methods (tenant_id) WHERE is_default;
+```
+
+Additive table — `dotnet ef migrations has-pending-model-changes` must report **none** after the migration; `database update` then down must apply/roll back cleanly. (Mirror the snapshot-update discipline used by Story 35-1's `billing_customers`/`billing_plan_prices` migration.)
+
+### Service signatures
+
+```csharp
+public interface IStripeCustomerPortalClient
+{
+    Task<string> CreatePortalSessionAsync(string stripeCustomerId, string returnUrl, CancellationToken ct);
+    Task<(string ClientSecret, string SetupIntentId)> CreateSetupIntentAsync(string stripeCustomerId, CancellationToken ct);
+}
+
+public interface IPaymentMethodService
+{
+    Task<IReadOnlyList<PaymentMethodView> Methods, bool HasUsableDefault> ListAsync(Guid tenantId, CancellationToken ct);
+    Task UpsertFromStripeAsync(PaymentMethodMirrorInput input, CancellationToken ct);   // attach/auto-update
+    Task MarkDetachedAsync(Guid tenantId, string stripePaymentMethodId, CancellationToken ct);
+    Task SetDefaultAsync(Guid tenantId, string stripePaymentMethodId, CancellationToken ct);
+}
+```
+
+`PaymentMethodService` writes the mirror, emits the DCB event(s), and — on a detach/expiry that leaves a paid tenant with no `active|expiring` card — emits `BILLING.PAYMENT_METHOD.MISSING`. Paid-plan detection reads the tenant's subscription/plan state owned by 35-1/35-4 (read-only); 35-7 does not mutate it.
+
+### Webhook integration (Story 35-5 seam)
+
+`PaymentMethodBillingEventHandler : IBillingEventHandler` declares `HandledEventTypes = { "payment_method.attached", "payment_method.detached", "payment_method.automatically_updated", "customer.updated" }` and implements `HandleAsync(BillingWebhookContext ctx, ct)` — `ctx.TenantId` is already resolved by 35-5 from `BillingCustomer.StripeCustomerId → TenantId`, so the handler never re-derives tenancy (tenant-isolation comes free from the dispatch contract). The handler calls `IPaymentMethodService` and returns; heavy follow-up (dunning) is 35-8's enqueued task, not this handler's job.
+
+### API shape
+
+```
+POST /api/v1/billing/portal-session              → 200 { url }            (BillingManage; member 403)
+POST /api/v1/billing/payment-methods/setup-intent → 200 { clientSecret, setupIntentId } (BillingManage; member 403)
+GET  /api/v1/billing/payment-methods             → 200 { methods: PaymentMethodView[], hasUsableDefault }  (any member)
+```
+
+`PaymentMethodView = { id, brand, last4, expMonth, expYear, isDefault, status }`. All three resolve the tenant from the membership filter (active-tenant / path-tenant), exactly like `OrgEndpoints`/`AlertEndpoints` (`http.Items[RequireTenantMembershipFilter.TenantRoleItemKey]`).
+
+### RBAC — per-mode + per-tenant
+
+| Action | single-user | SaaS |
+|---|---|---|
+| Open portal / create setup-intent | route not mapped (NullBillingProvider) | `tenant_owner` / `tenant_admin` (member → 403) |
+| GET masked payment methods | route not mapped | any tenant member (member-read) |
+| Mirror update (webhook) | n/a | system, via 35-5 dispatch (tenant resolved upstream) |
+
+The `BillingManage` policy is added in `Program.cs` mirroring `PromptManage`/`ConventionManage` (a `PermissionRequirement("billing:manage")` mapped to owner+admin in the role matrix). GET routes use `MemberAccess` + the membership filter. This matches the prompt-store precedent: identical endpoint shape across modes, auth middleware decides scope.
+
+### DCB event names
+
+`BILLING.PAYMENT_METHOD.ADDED`, `BILLING.PAYMENT_METHOD.REMOVED`, `BILLING.PAYMENT_METHOD.DEFAULT_CHANGED`, `BILLING.PAYMENT_METHOD.MISSING`, `BILLING.PORTAL_SESSION.CREATED` — all appended to the CP `DomainEvents` store via `IEventRepository.AppendAsync`, tags carry `tenantId` (and the relevant `last4`/`brand`/`stripePaymentMethodId`). These are exactly the events the alert-rule evaluator polls, so dunning/notification rules (35-8) can subscribe with no engine changes.
+
+## Dependencies
+
+**Internal (prerequisite):**
+- **Story 35-1** (Stripe Integration Foundation): provides `BillingCustomer` (the `TenantId → StripeCustomerId` mapping the portal/setup-intent endpoints resolve), the `IBillingProvider` + `NullBillingProvider` seam, and the Epic 29 cabinet wiring for the Stripe secret key.
+- **Story 35-5** (Stripe Webhook Ingestion): provides the verified webhook endpoint and the `IBillingEventHandler` dispatch registry into which `PaymentMethodBillingEventHandler` registers — 35-7 does **not** build webhook ingestion.
+
+**Internal (blocks / feeds):**
+- **Story 35-8** (Invoicing & Dunning): consumes `BILLING.PAYMENT_METHOD.MISSING` / `REMOVED` events and the `hasUsableDefault` signal to drive dunning escalation and notifications. 35-7 emits the signal; 35-8 acts on it.
+
+**Internal (reuse, no change):**
+- Epic 29 secret cabinet (`ISecretStore`, `SecretScope.Platform`, `SecretPurpose.ApiKey`).
+- Story 5.6 alert pipeline (`IEventRepository` → `AlertRuleEvaluator`) — DCB events feed it for free.
+- `RequireTenantMembershipFilter` + `TenantRoleHierarchy` for tenant RBAC.
+- `IPlatformQueuedTaskRepository` (only if a portal-session retry is desired; not required for AC).
+
+**External:**
+- `Stripe.net` SDK (`Stripe.BillingPortal.SessionService`, `Stripe.SetupIntentService`, `Stripe.PaymentMethodService`) — already a dependency from Story 35-1/35-5.
+- Stripe test mode + `@stripe/stripe-js` / `@stripe/react-stripe-js` for the dashboard add-card UX.
+- Test secret: `STRIPE_SECRET_KEY_TEST` for the integration suite.
+
+## Testing Strategy
+
+**Unit tests** (`apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/`):
+1. `BillingPortalEndpointsTests` — portal-session: owner/admin → 200 with mocked `IStripeCustomerPortalClient`; member → 403; non-member/cross-tenant → 404; unresolvable Stripe customer → 409/422; Stripe error → 502; emits `BILLING.PORTAL_SESSION.CREATED`.
+2. setup-intent: owner/admin → 200 `{ clientSecret, setupIntentId }`; member → 403.
+3. `GET payment-methods` — returns masked mirror, **asserts `IStripeCustomerPortalClient` is never called** (no Stripe round-trip on read); `hasUsableDefault` true/false.
+4. `PaymentMethodServiceTests` — attach upserts + emits `BILLING.PAYMENT_METHOD.ADDED`; detach flips `Status=detached`, clears `IsDefault`, emits `BILLING.PAYMENT_METHOD.REMOVED`; default change re-points atomically + emits `BILLING.PAYMENT_METHOD.DEFAULT_CHANGED`; last usable card detached on a paid tenant emits `BILLING.PAYMENT_METHOD.MISSING`; never emits MISSING for a free-plan tenant.
+5. `ReturnUrlAllowlistTests` — allowed origin passes; foreign origin / scheme-downgrade / open-redirect attempt rejected.
+6. `PaymentMethodBillingEventHandlerTests` — `HandledEventTypes` cover the four event names; dispatch routes attach/detach/default to the right service call; unknown sub-type is a no-op.
+7. Single-user mode: routes are not mapped (404) and no Stripe client is registered.
+
+**Integration tests** (`STRIPE_SECRET_KEY_TEST`; xUnit, docker-bound suites via `sg docker -c "dotnet test ..."`):
+8. Create a portal session against Stripe test mode for a seeded test customer → non-empty `https://billing.stripe.com/...` URL.
+9. Create a setup-intent, confirm a Stripe test card off-session, verify the `payment_method.attached` webhook (replayed through 35-5's processor) upserts the `BillingPaymentMethod` mirror.
+10. **Tenant-isolation**: replay a `payment_method.attached`/`detached` for tenant A's customer; assert tenant B has zero `billing_payment_methods` rows and no DCB event tagged tenant B; assert a portal session for tenant A's customer never returns tenant B's `StripeCustomerId`.
+
+**Mocks:** `IStripeCustomerPortalClient` mocked for all endpoint unit tests (no live Stripe); Stripe SDK driven against test mode only in the integration suite. `ISecretStore` stubbed to return a test key in unit tests.
+
+**Dashboard tests** (`packages/dashboard-user`, Vitest + Testing Library, colocated): `BillingPaymentMethods.test.tsx` — masked list renders rows; "Manage billing" calls the portal client and redirects; "Add card" mounts the SetupIntent flow; member-role hides mutate buttons; empty-state shows the missing-card banner.
+
+## Estimated Effort
+
+3-4 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/BillingPortalEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/IStripeCustomerPortalClient.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/StripeCustomerPortalClient.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/NullStripeCustomerPortalClient.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/IPaymentMethodService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/PaymentMethodService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/PaymentMethodBillingEventHandler.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/ReturnUrlAllowlist.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingPaymentMethodEventTypes.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/BillingPaymentMethodServiceCollectionExtensions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/BillingPaymentMethod.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_AddBillingPaymentMethods.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (add `DbSet<BillingPaymentMethod>`) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (entity config) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/ControlPlaneDbContextModelSnapshot.cs` | Modify (snapshot) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (add `BillingManage` policy; map routes in SaaS mode; call DI extension) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingPortalEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/PaymentMethodServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/PaymentMethodBillingEventHandlerTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/ReturnUrlAllowlistTests.cs` | Create |
+| `packages/dashboard-user/src/api/billing.ts` | Create |
+| `packages/dashboard-user/src/pages/settings/BillingPaymentMethods.tsx` | Create |
+| `packages/dashboard-user/src/pages/settings/BillingPaymentMethods.test.tsx` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, decisions (billing/Stripe, tenant-isolation)
+3. Read Story 35-1 (`BillingCustomer`, `IBillingProvider`, cabinet wiring) and Story 35-5 (`IBillingEventHandler`, `BillingWebhookContext`) — they define the seams this story plugs into
+4. Reviewed `OrgEndpoints.cs` + `AlertEndpoints.cs` for the tenant-membership-filter RBAC pattern (`http.Items[RequireTenantMembershipFilter.TenantRoleItemKey]`)
+5. Planned the TDD approach (Red-Green-Refactor)
+
+### Key Design Decisions
+
+- **No raw card data, ever.** Tamma stores only brand/last4/exp from Stripe's `Card` object on a `PaymentMethod`. PAN/CVC are PCI-scope and stay entirely in Stripe; the dashboard collects cards client-side via Stripe Elements + SetupIntent, so card numbers never traverse Tamma's backend. This keeps Tamma out of PCI-DSS SAQ-D scope (SAQ-A territory).
+- **Mirror, don't query.** `GET /payment-methods` reads the local `billing_payment_methods` table; Stripe is the source of truth but is kept in sync by 35-5 webhooks, not polled on every read. A unit test asserts the portal client is never invoked on read.
+- **One default per tenant** enforced by a partial unique index (`WHERE is_default`), so a race during a default re-point fails loudly at the DB instead of silently keeping two defaults.
+- **35-7 emits the missing-card signal; 35-8 acts on it.** Honoring the epic boundary: dunning escalation, retries, and notification delivery belong to Story 35-8. 35-7 stops at the DCB event + the `hasUsableDefault` flag.
+- **Open-redirect guard is mandatory.** A portal return URL is a redirect target; allowlisting the origin prevents an attacker from crafting a `returnUrl` that bounces a logged-in admin to a phishing page after Stripe.
+- **Per-mode seam parity with 35-1/35-5.** `NullStripeCustomerPortalClient` keeps single-user deployments Stripe-free; routes are simply not mapped when `ITammaModeProvider.Mode == SingleUser`.
+
+### Security Requirements
+
+- Stripe secret key via Epic 29 cabinet only; never `IConfiguration`/env in production. Unresolvable → `503`, never fail open (mirrors 35-1 AC5 / 35-5 AC2).
+- Never log card data, client secrets, or session URLs. Log the Stripe request id (for support) and the masked last4 only.
+- `returnUrl` origin validated against `Billing:PortalReturnUrlAllowlist` before any Stripe call.
+- Tenant-isolation enforced by the membership filter on read/mutate endpoints and by 35-5's upstream tenant resolution on the webhook handler — both covered by dedicated isolation tests.
+
+### Edge Cases
+
+- Tenant with no `BillingCustomer.StripeCustomerId` yet (35-1 enqueued a retry): portal/setup-intent return `409 Conflict` with a "billing not yet provisioned" message rather than 500.
+- Card expiry: a `customer.updated`/`payment_method.automatically_updated` that bumps exp updates the mirror; a `Status=expiring` heuristic (exp within current month) feeds the missing-card calculation conservatively (still "usable" until actually declined).
+- Duplicate `payment_method.attached` (Stripe at-least-once): upsert keyed on `StripePaymentMethodId` is idempotent — one row, and 35-5's dedupe already gates re-projection.
+- Detaching a non-default card never emits `DEFAULT_CHANGED` or `MISSING` if a default remains.
+
+## Logging Requirements
+
+- **INFO**: portal session created (tenantId, userId — no URL), setup-intent created (tenantId, setupIntentId), mirror upsert/detach/default-change (tenantId, last4, eventType), missing-card signal emitted (tenantId, planSlug).
+- **DEBUG**: incoming webhook sub-type routed to handler, masked-list query executed (row count), allowlist check result (origin, allowed).
+- **WARN**: `returnUrl` origin rejected (origin — never full URL), portal requested for a tenant with no Stripe customer, paid tenant left with no usable card.
+- **ERROR**: Stripe API failure (Stripe request id, event/customer id — never card data), Stripe secret unresolvable (`503` path), DB write failure on mirror upsert.
+- **Structured context**: `{ tenantId, userId, stripePaymentMethodId, brand, last4, eventType }` where applicable.
+- **Credential safety**: NEVER log Stripe secret keys, client secrets, session URLs, or any card number beyond the masked last4.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-35/story-35-8/35-8-invoicing-failed-payment-dunning-and-recovery.md
+++ b/docs/stories/epic-35/story-35-8/35-8-invoicing-failed-payment-dunning-and-recovery.md
@@ -1,0 +1,350 @@
+# Story 35-8: Invoicing, Failed-Payment Dunning & Recovery
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-Phase Development Workflow (Read → Research → Break Down → TDD → Quality Gates → Failure Handling), the `.dev/` knowledge base usage rules, TRACE/DEBUG logging requirements, the Test-Driven Development workflow, and the build/coverage quality gates. Failure to follow this process will result in rework.
+
+## User Story
+
+As a **Tamma tenant owner/admin (and the platform operator)**,
+I want my Stripe invoices mirrored locally with a clear line-item breakdown (base plan + metered overage + credits), an invoice history with PDF links, and a robust failed-payment recovery flow that retries, escalates emails, and only suspends after a grace period,
+So that I always have an accurate billing record, I get timely warnings before service is cut off, BYOK tenants are still correctly billed the platform/seat fee, and a recovered payment instantly reinstates service — all with a complete DCB audit trail.
+
+## Priority
+
+P0 - Revenue recovery and billing transparency. Failed-payment dunning is the difference between churn and recovered MRR; invoice mirroring is required for the billing portal (35-7) and for the suspension signal that quota enforcement (35-6) reads.
+
+## Acceptance Criteria
+
+1. New control-plane entities `BillingInvoice` (`apps/tamma-elsa/src/Tamma.Data/Entities/BillingInvoice.cs`) and `BillingInvoiceLine` (`apps/tamma-elsa/src/Tamma.Data/Entities/BillingInvoiceLine.cs`) are registered as `DbSet`s on `ControlPlaneDbContext` and configured in `TammaModelConfiguration.ConfigureControlPlaneEntities`. `BillingInvoice` carries `{ Id, TenantId (FK tenants.Id), StripeInvoiceId (UNIQUE, nullable until finalized), StripeSubscriptionId, Status (text domain: draft|open|paid|uncollectible|void), AmountDue, AmountPaid, AmountRemaining, Currency, HostedInvoiceUrl, PdfUrl, PeriodStart, PeriodEnd, AttemptCount, NextPaymentAttempt, CreatedAt, UpdatedAt, FinalizedAt, PaidAt }`. `BillingInvoiceLine` carries `{ Id, InvoiceId (FK), Kind (text domain: base|metered_overage|credit), Description, Quantity, UnitAmount, Amount, Currency }`.
+2. `InvoiceService` (`apps/tamma-elsa/src/Tamma.Api/Services/Billing/InvoiceService.cs`, contract `IInvoiceService`) projects Stripe `invoice.*` payloads into the `BillingInvoice` + `BillingInvoiceLine` mirror **idempotently** (upsert keyed on `StripeInvoiceId`), classifying each Stripe line item into `base` / `metered_overage` / `credit` and emitting the corresponding `BILLING.INVOICE.*` DCB event via `IEventRepository.AppendAsync`.
+3. Projection is wired into the Story 35-5 webhook pipeline as `InvoiceWebhookHandler : IBillingEventHandler` (registered via `services.AddBillingEventHandler<InvoiceWebhookHandler>()`), claiming `invoice.created`, `invoice.finalized`, `invoice.paid`, `invoice.payment_failed`, and `charge.dispute.created`. 35-8 owns these handlers; 35-5 owns the dispatch seam, dedup, and the `NullBillingEventHandler` fallback (per 35-5 AC9 — 35-8 does **not** create `BillingWebhookEvent` or the endpoint).
+4. `GET /api/v1/billing/invoices` (paged, default 50/max 200, newest first) lists the authenticated tenant's invoices; `GET /api/v1/billing/invoices/{id}` returns invoice detail with line items and the `hosted_invoice_url` / `pdf_url`. Both are exposed by a new `InvoiceEndpoints` class under `MemberAccess` with in-handler tenant scoping, so `tenant_owner` / `tenant_admin` / `member` can all **read** their own tenant's invoices and never another tenant's (cross-tenant id → 404, not 403).
+5. A `DunningStateMachine` (`apps/tamma-elsa/src/Tamma.Api/Services/Billing/DunningStateMachine.cs`, contract `IDunningStateMachine`) advances a tenant's billing dunning state on `invoice.payment_failed`: `active → past_due → grace → suspended`, driven by an attempt counter and a retry schedule, with each transition scheduled on a `PlatformQueuedTask` (`Type = "billing.dunning.advance"`) processed by `DunningAdvanceTaskHandler : IPlatformTaskHandler`.
+6. A later `invoice.paid` (or `invoice.payment_succeeded`) **recovers** the tenant from any non-terminal dunning stage back to `active`, cancels any pending `billing.dunning.advance` task, and emits `BILLING.TENANT.REINSTATED`. Recovery from `suspended` is supported and lifts the suspension.
+7. Escalating dunning emails are **enqueued only** through `PlatformEmailOutboxMessage` (system/platform mail) and/or `EmailOutboxMessage` (tenant-scoped mail) — never via direct SMTP/transport calls. Each stage uses a distinct template key (`dunning-past-due`, `dunning-grace`, `dunning-suspended`, `dunning-recovered`) and the email carries the attempt count and next-retry timestamp; these same values are surfaced on the invoice/portal API.
+8. On terminal failure after the grace period, the tenant is moved to a `suspended` billing state persisted on a new `BillingDunningState` row (`apps/tamma-elsa/src/Tamma.Data/Entities/BillingDunningState.cs`, one-per-tenant) that Story 35-6's `QuotaService` reads to **hard-block platform-provided usage** (`QuotaDecision.HardBlock` with reason `billing_suspended`). BYOK token usage is **not** blocked by suspension (BYOK tenants are token-exempt per 35-6), but the platform/seat fee remains owed and the invoice stays `open`.
+9. BYOK awareness: suspension and dunning apply to **every** tenant with an unpaid platform/seat-fee invoice regardless of `BillingCustomer.BillingMode` (`PlatformProvided | Byok`). The only mode difference at suspend time is what gets hard-blocked: platform-provided usage is blocked; BYOK token calls continue (gated only by seat/feature limits, per 35-6).
+10. DCB events are emitted via `IEventRepository.AppendAsync` (CP store, the store `AlertRuleEvaluator` polls): `BILLING.INVOICE.FINALIZED`, `BILLING.INVOICE.PAID`, `BILLING.PAYMENT.FAILED`, `BILLING.DUNNING.ESCALATED`, `BILLING.TENANT.SUSPENDED`, `BILLING.TENANT.REINSTATED`, and `BILLING.INVOICE.DISPUTED`. Tags JSON include `{ tenantId, invoiceId, stage }` (plus `stripeInvoiceId`, `attemptCount` where relevant); Metadata is `{ "workflowVersion": "1.0.0", "eventSource": "system" }`.
+11. A dispute/chargeback (`charge.dispute.created`) flips the affected invoice and the tenant to a `flagged` state (`BillingDunningState.Stage = flagged`), emits `BILLING.INVOICE.DISPUTED`, and notifies platform admins by enqueuing a `PlatformEmailOutboxMessage` (template `dispute-opened`) — never auto-suspending on a dispute (a dispute is an operator decision).
+12. The dunning retry schedule and grace window are configuration-driven (`Billing:Dunning:RetryDelaysHours` default `[24, 72, 120]`, `Billing:Dunning:GraceHours` default `168`), so the cadence is tunable without code change; the `DunningStateMachine` is pure/deterministic given the schedule + attempt count and the clock is injected (`TimeProvider`) for test determinism.
+13. In **single-user mode** (`ITammaModeProvider.Mode == TammaMode.SingleUser` — no `Tamma:TenantSharedSecret` / `ConnectionStrings:ControlPlane`), no Stripe webhooks arrive (35-5 leaves the route unmapped, 35-1 registers `NullBillingProvider`), so `InvoiceEndpoints` short-circuits with a "billing is SaaS-only" response and the dunning machine / task handler are not registered — mirroring the 35-1/35-5 single-user seam.
+14. Unit + integration tests (xUnit, `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/`) cover: invoice projection + idempotent upsert on replay; line-item split (`base` / `metered_overage` / `credit`); dunning advance through every stage and recovery from each stage including `suspended`; email-outbox enqueue per stage (asserting **no** direct transport call); `suspended → reinstated` lifting the quota hard-block (35-6 read path); dispute → `flagged` + admin notify (no auto-suspend); and **tenant isolation** (tenant A's invoice/dunning never visible to or mutated for tenant B). Stripe SDK and provider HTTP are mocked.
+
+## Technical Design
+
+### C# namespace / file structure
+
+```
+apps/tamma-elsa/src/Tamma.Data/Entities/
+  BillingInvoice.cs                    # NEW — CP invoice mirror (StripeInvoiceId UNIQUE)
+  BillingInvoiceLine.cs                # NEW — CP invoice line (Kind: base|metered_overage|credit)
+  BillingDunningState.cs               # NEW — one-per-tenant dunning/suspension state
+
+apps/tamma-elsa/src/Tamma.Data/
+  ControlPlaneDbContext.cs             # MODIFY — DbSet<BillingInvoice/Line/DunningState>
+  TammaModelConfiguration.cs           # MODIFY — entity config + indexes + CHECK constraints
+  Migrations/ControlPlane/<ts>_BillingInvoicesAndDunning.cs   # NEW — additive migration
+
+apps/tamma-elsa/src/Tamma.Api/Services/Billing/
+  IInvoiceService.cs                   # NEW — projection + read seam
+  InvoiceService.cs                    # NEW — idempotent upsert + line split + DCB
+  IDunningStateMachine.cs              # NEW — pure transition fn + schedule
+  DunningStateMachine.cs               # NEW — active->past_due->grace->suspended + recover
+  DunningOptions.cs                    # NEW — RetryDelaysHours, GraceHours (IOptions)
+  InvoiceWebhookHandler.cs             # NEW — IBillingEventHandler (35-5 registration)
+  DunningAdvanceTaskHandler.cs         # NEW — IPlatformTaskHandler ("billing.dunning.advance")
+  BillingInvoiceEvents.cs              # NEW — BILLING.INVOICE.*/DUNNING.*/TENANT.* DCB constants
+  BillingDunningEmailComposer.cs       # NEW — stage -> template/subject/body (outbox rows)
+
+apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/
+  InvoiceEndpoints.cs                  # NEW — GET list + GET detail (MemberAccess, tenant-scoped)
+
+apps/tamma-elsa/src/Tamma.Api/Extensions/
+  BillingServiceCollectionExtensions.cs  # MODIFY (35-1 created) — register 35-8 services/handlers
+```
+
+### Key entity signatures
+
+```csharp
+// Tamma.Data/Entities/BillingInvoice.cs
+public class BillingInvoice
+{
+    public Guid Id { get; set; }
+    public Guid TenantId { get; set; }                    // FK tenants.Id
+    public string? StripeInvoiceId { get; set; }          // UNIQUE (filtered: NOT NULL)
+    public string? StripeSubscriptionId { get; set; }
+    public string Status { get; set; } = "draft";         // draft|open|paid|uncollectible|void (CHECK)
+    public long AmountDue { get; set; }                   // minor units (cents)
+    public long AmountPaid { get; set; }
+    public long AmountRemaining { get; set; }
+    public string Currency { get; set; } = "usd";
+    public string? HostedInvoiceUrl { get; set; }
+    public string? PdfUrl { get; set; }
+    public DateTime PeriodStart { get; set; }
+    public DateTime PeriodEnd { get; set; }
+    public int AttemptCount { get; set; }
+    public DateTime? NextPaymentAttempt { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public DateTime? FinalizedAt { get; set; }
+    public DateTime? PaidAt { get; set; }
+    public ICollection<BillingInvoiceLine> Lines { get; set; } = [];
+}
+
+// Tamma.Data/Entities/BillingInvoiceLine.cs
+public class BillingInvoiceLine
+{
+    public Guid Id { get; set; }
+    public Guid InvoiceId { get; set; }                   // FK billing_invoices.Id (cascade)
+    public string Kind { get; set; } = "base";            // base|metered_overage|credit (CHECK)
+    public string Description { get; set; } = "";
+    public long Quantity { get; set; }
+    public long UnitAmount { get; set; }
+    public long Amount { get; set; }                      // negative for credits
+    public string Currency { get; set; } = "usd";
+}
+
+// Tamma.Data/Entities/BillingDunningState.cs — one row per tenant
+public class BillingDunningState
+{
+    public Guid Id { get; set; }
+    public Guid TenantId { get; set; }                    // UNIQUE FK tenants.Id
+    public string Stage { get; set; } = "active";         // active|past_due|grace|suspended|flagged (CHECK)
+    public int FailedAttempts { get; set; }
+    public Guid? CurrentInvoiceId { get; set; }           // the invoice driving dunning
+    public DateTime? StageEnteredAt { get; set; }
+    public DateTime? NextAdvanceAt { get; set; }          // when the scheduled advance task fires
+    public Guid? PendingAdvanceTaskId { get; set; }       // PlatformQueuedTask to cancel on recovery
+    public DateTime? SuspendedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}
+```
+
+### Service signatures
+
+```csharp
+// IInvoiceService.cs
+public interface IInvoiceService
+{
+    /// Idempotent upsert of a Stripe invoice into the CP mirror + line split + DCB event.
+    Task<BillingInvoice> ProjectAsync(Stripe.Invoice invoice, Guid tenantId, CancellationToken ct);
+
+    Task<(IReadOnlyList<BillingInvoice> Items, int Total)> ListAsync(
+        Guid tenantId, int limit, int offset, CancellationToken ct);
+
+    Task<BillingInvoice?> GetAsync(Guid tenantId, Guid invoiceId, CancellationToken ct);
+}
+
+// IDunningStateMachine.cs
+public interface IDunningStateMachine
+{
+    /// Pure: given current stage + failed-attempt count + schedule, compute the next stage
+    /// and the delay until the next advance (null = terminal/suspend now).
+    DunningTransition Next(string currentStage, int failedAttempts, DunningOptions opts);
+
+    /// Apply a payment_failed: bump attempts, transition, schedule the advance task,
+    /// enqueue the stage email, emit BILLING.DUNNING.ESCALATED / BILLING.PAYMENT.FAILED.
+    Task OnPaymentFailedAsync(Guid tenantId, BillingInvoice invoice, CancellationToken ct);
+
+    /// Apply a payment success: recover to active, cancel pending advance task,
+    /// enqueue dunning-recovered email, emit BILLING.TENANT.REINSTATED.
+    Task OnPaymentRecoveredAsync(Guid tenantId, BillingInvoice invoice, CancellationToken ct);
+
+    /// Advance one stage (invoked by DunningAdvanceTaskHandler when NextAdvanceAt fires).
+    Task AdvanceAsync(Guid tenantId, CancellationToken ct);
+}
+
+public sealed record DunningTransition(string NextStage, TimeSpan? DelayUntilNext, bool Suspend);
+```
+
+### Line-item classification (Stripe → `Kind`)
+
+`InvoiceService.ProjectAsync` walks `Stripe.Invoice.Lines.Data`:
+- A line with a **negative** amount or a discount/credit-note origin → `Kind = "credit"`.
+- A line whose price/metadata marks it metered (Stripe `Price.Recurring.UsageType == "metered"`, or our Story 35-3 meter-event line metadata `tamma_meter = true`) → `Kind = "metered_overage"`.
+- Everything else (the recurring base subscription price) → `Kind = "base"`.
+
+The mapping is a pure helper (`ClassifyLine`) with its own unit tests; it never trusts a single field exclusively (negative amount wins for credits even on a base price id).
+
+### Dunning state machine
+
+```
+                 invoice.payment_failed (attempt 1)
+   active ───────────────────────────────────────────▶ past_due
+     ▲                                                    │  schedule advance (+RetryDelaysHours[1])
+     │ invoice.paid / payment_succeeded                   ▼
+     │   (BILLING.TENANT.REINSTATED)                    grace
+     │                                                    │  GraceHours elapsed, still unpaid
+     └────────────────────────────────────────────────  ▼
+                                                       suspended  ──▶ (35-6 hard-blocks platform usage)
+```
+
+- Each `invoice.payment_failed` increments `FailedAttempts` and either schedules the next retry (`PlatformQueuedTask Type="billing.dunning.advance"` with `RunAt = now + RetryDelaysHours[idx]`) or, once retries are exhausted, enters `grace`. After `GraceHours` with no successful payment, `AdvanceAsync` transitions `grace → suspended` and emits `BILLING.TENANT.SUSPENDED`.
+- `OnPaymentRecoveredAsync` short-circuits the schedule: it cancels `PendingAdvanceTaskId` (via `IPlatformQueuedTaskRepository.DeadLetterAsync`/complete), resets `Stage = active`, clears counters, and emits `BILLING.TENANT.REINSTATED` from any non-terminal stage **and** from `suspended`.
+- The transition table itself (`Next`) is pure and clock-free; scheduling and persistence live in `OnPaymentFailedAsync` / `AdvanceAsync`. `TimeProvider` is injected so tests assert grace expiry deterministically.
+
+### DCB event names (`BillingInvoiceEvents`)
+
+```
+BILLING.INVOICE.FINALIZED   BILLING.INVOICE.PAID        BILLING.INVOICE.DISPUTED
+BILLING.PAYMENT.FAILED
+BILLING.DUNNING.ESCALATED
+BILLING.TENANT.SUSPENDED    BILLING.TENANT.REINSTATED
+```
+
+All appended via `IEventRepository.AppendAsync(new DomainEvent { Type, TenantId, Tags, Metadata, Data })`. `Tags` JSON `{ tenantId, invoiceId, stage }` (+ `stripeInvoiceId`, `attemptCount` where relevant); `Metadata` `{ "workflowVersion": "1.0.0", "eventSource": "system" }`. These are CP-resident system-source events so the `AlertRuleEvaluator` and analytics see them with no extra wiring — a future `BILLING.TENANT.SUSPENDED` alert rule (Epic 5/23) costs nothing here.
+
+### Integration points
+
+- **Story 35-5 (webhook ingestion)** — `InvoiceWebhookHandler : IBillingEventHandler` registered via `services.AddBillingEventHandler<InvoiceWebhookHandler>()`. The processor resolves `TenantId` (from `BillingCustomer`) and passes a `BillingWebhookContext`; the handler returns a `BillingFollowup("billing.dunning.advance", payload)` for heavy/scheduled work so the webhook fast-acks (<2s).
+- **Story 35-1 (foundation)** — `BillingCustomer` (tenant ↔ Stripe customer), `BillingMode` enum (`Tamma.Core/Billing/BillingMode.cs`), `NullBillingProvider` single-user seam, Stripe.net.
+- **Story 35-4 (subscription)** — `BillingSubscription.{Status, PlanSlug, CurrentPeriodStart/End}` for the period stamped on invoices and the seat/plan context in dunning emails.
+- **Story 35-6 (quota enforcement)** — `QuotaService` reads `BillingDunningState.Stage == suspended` → `QuotaDecision.HardBlock(reason="billing_suspended")` on platform-provided usage; BYOK token calls remain exempt. 35-8 calls `IQuotaService.InvalidateAsync(tenantId)` on suspend/reinstate so the block lifts on the next request with no restart.
+- **Platform task queue (Epic 28)** — `IPlatformQueuedTaskRepository.EnqueueAsync` for `billing.dunning.advance`; `DunningAdvanceTaskHandler : IPlatformTaskHandler` drained by the existing `PlatformTaskWorker`.
+- **Email outbox (Epic 28 / Story 28-6)** — dunning + dispute mail rows inserted into `PlatformEmailOutbox` (`DbSet<PlatformEmailOutboxMessage>`) / `EmailOutbox` (`DbSet<EmailOutboxMessage>`) and drained by the existing `OutboxSmtpSender`/`ResendEmailService` — 35-8 never calls a transport directly.
+- **DCB event store** — `IEventRepository.AppendAsync` (CP `domain_events`).
+
+### API shape
+
+```
+GET /api/v1/billing/invoices            (MemberAccess; tenant-scoped; ?limit&offset; newest first)
+    -> { items: [ { id, status, amountDue, amountPaid, currency, periodStart, periodEnd,
+                    attemptCount, nextPaymentAttempt, hostedInvoiceUrl, pdfUrl } ], total }
+GET /api/v1/billing/invoices/{id}       (MemberAccess; tenant-scoped; cross-tenant -> 404)
+    -> { ...invoice, lines: [ { kind, description, quantity, unitAmount, amount, currency } ],
+         dunning: { stage, failedAttempts, nextAdvanceAt } }
+```
+
+Tenant scoping: `MemberAccess` authenticates; the handler reads the active tenant id from the principal (`ClaimsPrincipalExtensions`, same path `OrgEndpoints`/`AlertEndpoints` use) and filters every query by it. There is **no** admin cross-tenant invoice route in this story — platform-side invoice inspection rides the 35-5 admin webhook-events endpoint and the DCB stream.
+
+### Per-mode + per-tenant handling
+
+| Concern | single-user mode | SaaS mode |
+|---|---|---|
+| Webhook handler / dunning machine registered? | No — `NullBillingProvider` (35-1), 35-5 route unmapped; `InvoiceEndpoints` returns "billing is SaaS-only". | Yes. |
+| Invoice ownership | N/A (no Stripe invoices) | `BillingInvoice.TenantId`; read-only list for owner/admin/member. |
+| Suspension read | N/A | `BillingDunningState` per tenant; 35-6 `QuotaService` reads `Stage == suspended`. |
+| Email scope | N/A | tenant dunning mail → `EmailOutbox` (TenantId set); dispute/admin mail → `PlatformEmailOutbox`. |
+| DCB event `TenantId` | N/A | always the resolved tenant; never null for a projected/dunning event. |
+| Mode source | `ITammaModeProvider` (`Services/PromptStore/TammaMode.cs`) — process-stable. | same |
+
+Tenant isolation is enforced two ways: (1) every `BillingInvoice`/`BillingDunningState` row carries `TenantId` and every read filters by the principal's tenant; (2) every `DomainEvent` is tagged with the resolved `TenantId` and the email outbox rows carry it, so no path lets tenant A read or mutate tenant B's billing state.
+
+## Dependencies
+
+**Internal:**
+- **Prerequisite — Story 35-5** (Stripe webhook ingestion): supplies `IBillingEventHandler` dispatch seam, `BillingWebhookContext`, `BillingFollowup`, `AddBillingEventHandler<T>()`, the verified webhook endpoint, and the `BillingCustomer.StripeCustomerId → TenantId` resolution. **Hard blocker** — 35-8 registers handlers into this pipeline; it does not own the endpoint or `BillingWebhookEvent`.
+- **Prerequisite — Story 35-3** (BYOK-aware metering): supplies the metered-overage usage that materializes as `metered_overage` invoice lines and the `BillingUsageRollup`/`billing_mode` split that distinguishes BYOK (seat-fee-only) from platform-provided tenants.
+- **Prerequisite — Story 35-6** (quota enforcement): the consumer of `BillingDunningState.Stage == suspended`; 35-8 writes the suspension signal and calls `IQuotaService.InvalidateAsync`, 35-6 reads it to hard-block platform usage.
+- **Related — Story 35-1**: `BillingCustomer`, `BillingMode` enum, `NullBillingProvider`, Stripe.net.
+- **Related — Story 35-4**: `BillingSubscription` for invoice period + plan/seat context.
+- **Related — Story 35-7** (billing portal): the portal renders the invoice history this story projects.
+- **Related — Epic 28**: `PlatformQueuedTask` + `PlatformTaskWorker` (dunning advance), `PlatformEmailOutboxMessage`/`EmailOutboxMessage` + `OutboxSmtpSender` (escalation mail).
+- **Related — Epic 5/23**: DCB events feed the alert evaluator / analytics.
+
+**External:**
+- **Stripe.net** SDK (added by 35-1) — typed `Stripe.Invoice` / `Stripe.Charge` / `Stripe.Dispute` event objects.
+- A Stripe **webhook signing secret** (consumed by 35-5) and a configured invoice/dunning Stripe setup (smart retries off — Tamma owns the retry cadence locally).
+- `STRIPE_SECRET_KEY_TEST` + Stripe test fixtures/CLI for integration tests.
+
+## Testing Strategy
+
+1. **Invoice projection (unit)** — `InvoiceServiceTests`: a Stripe `invoice.finalized` payload projects one `BillingInvoice` + N `BillingInvoiceLine`; replaying the same `StripeInvoiceId` upserts (no duplicate row, no second `BILLING.INVOICE.FINALIZED`); status transitions `open → paid` stamp `PaidAt` and emit `BILLING.INVOICE.PAID`.
+2. **Line-item split (unit)** — `ClassifyLineTests`: base price → `base`; metered price / `tamma_meter` metadata → `metered_overage`; negative amount / credit-note → `credit` (negative-amount wins even on a base price id). Mixed invoice splits into the right three buckets and totals reconcile to `AmountDue`.
+3. **Dunning transitions (unit, pure)** — `DunningStateMachineTests` with an injected `TimeProvider` and a fixed schedule: `active → past_due → grace → suspended` over the attempt sequence; recovery to `active` from `past_due`, `grace`, **and** `suspended`; grace expiry triggers suspend exactly at `GraceHours`; schedule is config-driven (custom `RetryDelaysHours` honored).
+4. **Email-outbox enqueue (unit)** — `BillingDunningEmailComposerTests` + machine tests: each stage inserts a `PlatformEmailOutboxMessage`/`EmailOutboxMessage` row with the right template key, attempt count, and next-retry timestamp; assert via a fake repository that **no** SMTP/transport method is ever called (mock `IEmailTransport` / `OutboxSmtpSender` proves zero direct sends).
+5. **Suspend → quota block (integration)** — drive `payment_failed` to `suspended`, then assert `QuotaService` (35-6) returns `HardBlock(billing_suspended)` for a platform-provided call and `Allowed` for a BYOK call (same tenant, `BillingMode = Byok`); after `invoice.paid`, `QuotaService` returns `Allowed` for both (reinstatement + `InvalidateAsync`).
+6. **Dispute handling (unit + integration)** — `charge.dispute.created` flips the invoice + `BillingDunningState.Stage = flagged`, emits `BILLING.INVOICE.DISPUTED`, enqueues a `PlatformEmailOutboxMessage` (template `dispute-opened`), and does **not** auto-suspend.
+7. **Webhook handler wiring (integration)** — register `InvoiceWebhookHandler` in the 35-5 registry; feed `invoice.payment_failed` through `StripeWebhookProcessor`; assert the mirror update, the `BILLING.PAYMENT.FAILED` DCB event, and the `billing.dunning.advance` `PlatformQueuedTask` enqueue (fast-ack, no inline email send).
+8. **Tenant isolation (integration)** — tenant A's invoices never appear in tenant B's `GET /api/v1/billing/invoices`; a cross-tenant `GET /invoices/{id}` returns 404; a `payment_failed` for tenant A never mutates tenant B's `BillingDunningState`; DCB events carry the correct `tenantId`.
+9. **RBAC (integration)** — `member` can read invoices; an unauthenticated request is 401; there is no PUT/DELETE surface to over-authorize (read-only story).
+10. **Mocks** — Stripe SDK fully mocked (no live calls); email transport stubbed (assert outbox-only); `IPlatformQueuedTaskRepository` faked for unit tests, real for the advance/recovery integration test. Coverage per `CLAUDE.md` (80% line / 75% branch / 85% function); dunning transition logic, line classification, and the suspend/reinstate path are **critical paths → 100%**.
+
+## Estimated Effort
+
+5-6 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/BillingInvoice.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/BillingInvoiceLine.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/BillingDunningState.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (add 3 `DbSet`s) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (entity config, indexes, CHECKs) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_BillingInvoicesAndDunning.cs` | Create (additive) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/IInvoiceService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/InvoiceService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/IDunningStateMachine.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/DunningStateMachine.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/DunningOptions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/InvoiceWebhookHandler.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/DunningAdvanceTaskHandler.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingInvoiceEvents.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingDunningEmailComposer.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/InvoiceEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/BillingServiceCollectionExtensions.cs` | Modify (register 35-8 services/handlers) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map `InvoiceEndpoints`, SaaS-gated) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/InvoiceServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/DunningStateMachineTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/InvoiceWebhookHandlerTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/InvoiceEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/DunningSuspensionIntegrationTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md).
+2. Searched `.dev/` directory for related spikes, bugs, findings, and decisions (especially any billing/Stripe or outbox findings).
+3. Read Story 35-5 (the webhook dispatch seam you register into) and Story 35-6 (the suspension read contract you must honor) end-to-end.
+4. Reviewed Stripe Invoices + Dispute object docs and the local-vs-Stripe retry decision (Tamma owns the cadence; Stripe smart-retries off).
+5. Planned the TDD approach (Red-Green-Refactor) — start with the pure `DunningStateMachine.Next` transition table and the `ClassifyLine` helper before any DB/webhook wiring.
+
+### Key Design Decisions
+
+- **35-8 owns invoice + dunning, 35-5 owns the pipe.** Per 35-5 AC9, this story registers `IBillingEventHandler` implementations and creates `BillingInvoice`/`BillingInvoiceLine`/`BillingDunningState`; it never touches `BillingWebhookEvent`, the webhook endpoint, signature verification, or dedup. Boundary respected.
+- **Tamma owns the retry cadence, not Stripe.** Stripe smart-retries are disabled; the `DunningStateMachine` + `billing.dunning.advance` `PlatformQueuedTask` schedule is the single source of truth for the retry/escalation/grace timeline, so the portal can surface the exact next-retry time and the cadence is config-tunable.
+- **Pure transition core.** `DunningStateMachine.Next` is a clock-free pure function; all I/O (scheduling, email enqueue, DCB, persistence) is in the imperative shell. This makes the 100%-coverage critical path trivially testable with an injected `TimeProvider`.
+- **Suspension is a read-signal, not an enforcement.** 35-8 writes `BillingDunningState.Stage = suspended`; 35-6's `QuotaService` does the actual hard-block. 35-8 must not block requests itself (no enforcement code in the LLM/dispatch path) — that is 35-6's boundary. It only calls `IQuotaService.InvalidateAsync` so the read is fresh.
+- **Outbox-only mail.** Every dunning/dispute email is an `INSERT` into `PlatformEmailOutbox`/`EmailOutbox`; the existing `OutboxSmtpSender`/`ResendEmailService` deliver. This keeps delivery idempotent, retried, and PII-safe (bodies never logged), and a unit test asserts zero direct transport calls.
+- **BYOK still owes the seat fee.** Suspension applies to any tenant with an unpaid platform/seat-fee invoice regardless of mode; the only mode-difference is what gets blocked (platform usage blocked, BYOK token calls continue).
+
+### Money Handling
+
+- All amounts are stored in **minor units** (`long` cents) exactly as Stripe returns them — never `decimal` dollars, never float. Currency travels with every row. Credit lines are **negative** amounts; the projected `AmountDue` reconciles to the sum of line `Amount`s.
+
+### Idempotency & Reconciliation
+
+- Projection upserts on `StripeInvoiceId`; a webhook replay (Stripe at-least-once) is a no-op beyond a timestamp bump. The 35-5 `BillingWebhookEvent` dedup is the first line of defense; the upsert is the second.
+- A `payment_failed` whose attempt count is already reflected (replayed webhook) does not double-advance dunning — `DunningStateMachine.OnPaymentFailedAsync` is idempotent on `(invoiceId, attemptCount)`.
+
+### Graceful Degradation
+
+- If the CP DB is briefly unavailable when a webhook arrives, the 35-5 processor records the failure and the admin replay endpoint re-drives it; 35-8 handlers must be safe to re-run.
+- Email-outbox enqueue failures must not block the webhook ack or the dunning transition (the transition is the source of truth; the email is best-effort and the outbox itself retries).
+
+## Logging Requirements
+
+- **INFO**: invoice projected (`invoiceId`, `status`, `lineCount`), dunning stage transition (`tenantId`, `fromStage`, `toStage`, `attemptCount`), tenant suspended/reinstated, dispute opened.
+- **DEBUG**: line classification decision (`stripeLineId`, `kind`), advance task scheduled (`runAt`), email-outbox row enqueued (`template`, `outboxId` — never recipient/body).
+- **WARN**: invoice projection for a customer with no `BillingCustomer` match (skipped), dunning advance fired for an already-recovered tenant (no-op), email-outbox enqueue failed (retry on next cycle).
+- **ERROR**: DCB append failure, suspension write failure, `QuotaService.InvalidateAsync` failure after a suspend/reinstate (block may be stale until cache TTL).
+- **Structured context**: include `{ tenantId, invoiceId, stripeInvoiceId, stage, attemptCount }` where applicable.
+- **Credential / PII safety**: NEVER log Stripe secret keys, `hosted_invoice_url`/`pdf_url` query tokens, recipient addresses, or email bodies. Scrub via `CredentialRedactor.Clean` before any error log.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-35/story-35-9/35-9-tax-calculation-and-compliance.md
+++ b/docs/stories/epic-35/story-35-9/35-9-tax-calculation-and-compliance.md
@@ -1,0 +1,354 @@
+# Story 35-9: Tax Calculation & Compliance (Stripe Tax / VAT)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-phase workflow (Read → Research → Break Down → TDD → Quality Gates → Failure Handling), `.dev/` knowledge-base usage (spikes, bugs, findings, decisions), TRACE/DEBUG logging requirements, the test-first (TDD) mandate, and the build-success / coverage gates.
+
+## User Story
+
+As a **tenant_owner/tenant_admin** of a Tamma SaaS organization (and as the sole user of a single-user deployment that pays a platform fee),
+I want to provide my billing address and VAT/GST tax id so Tamma applies the correct tax to my invoices via Stripe Tax — including EU B2B reverse-charge — and surfaces tax line items in my invoice mirror and portal,
+So that my invoices are tax-compliant, reproducible for audit, and I am never silently billed the wrong tax because an unverifiable tax id was accepted.
+
+## Priority
+
+P1 - Required for compliant invoicing in tax-collecting jurisdictions (EU VAT, UK VAT, US sales tax). Builds on the customer mapping (35-1), the subscription that automatic-tax attaches to (35-4), and the invoice mirror + finalization path (35-8). Tamma uses Stripe Tax as the tax engine and only stores the minimal point-in-time tax metadata needed for compliance — it does **not** become a tax engine itself.
+
+## Acceptance Criteria
+
+1. The `BillingCustomer` entity (`apps/tamma-elsa/src/Tamma.Data/Entities/BillingCustomer.cs`, created in 35-1) gains tax fields: `BillingAddress` (JSONB — line1/line2/city/state/postal_code/country ISO-3166-1 alpha-2), `TaxIdType` (string, Stripe tax-id type e.g. `eu_vat`/`gb_vat`/`au_abn`, nullable), `TaxIdValue` (string, the raw id, nullable), and a `TaxExemptStatus` enum (`None`/`Exempt`/`ReverseCharge`) persisted as text with a CHECK constraint. The existing `TaxStatus` text column from 35-1 is repurposed/superseded by `TaxExemptStatus` (migration maps old values). An EF Core migration is added under `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/`; `dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext` reports none after it.
+
+2. A `TaxProfileService` (`apps/tamma-elsa/src/Tamma.Api/Services/Billing/TaxProfileService.cs`) exposes `GetProfileAsync(Guid tenantId)` and `UpdateProfileAsync(Guid tenantId, TaxProfileUpdate update, CancellationToken)` which validates the address + tax id, pushes them to the Stripe customer (`Customer.Address`, `Customer.TaxExempt`, and a Stripe `CustomerTaxId` via the tax-ids API), and updates the local `BillingCustomer` row atomically.
+
+3. A `PUT /api/v1/billing/tax-profile` endpoint (`apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/TaxProfileEndpoints.cs`) updates the profile and is restricted to `tenant_owner`/`tenant_admin` (a `member` receives 403, mirroring prompt-store RBAC); a paired `GET /api/v1/billing/tax-profile` returns the current profile to any tenant member. Both run under the tenant-membership filter so the caller's tenant is resolved from context, never a body field.
+
+4. Tax id format is validated **before** save: syntactic validation per `TaxIdType` (e.g. EU VAT country-prefix + checksum shape) and submission to Stripe whose async verification status is recorded; an invalid/unverifiable id is **rejected with a machine-readable `TammaError`** (code `BILLING.TAX_ID.INVALID`, severity `High`, context `{ taxIdType, country }`) and the row is **not** updated to a state that would silently bill incorrect tax. Resolution is never "accept and bill anyway" (no silent-degrade — aligns with the project's no-empty-fallback principle).
+
+5. Stripe Tax `automatic_tax` is enabled on the subscriptions/invoices created by 35-4/35-8: `SubscriptionService` (35-4) and the invoice/finalization path (35-8) pass `AutomaticTax = { Enabled = true }`. This story owns the toggle helper `IAutomaticTaxPolicy` that 35-4/35-8 call; it does not re-implement subscription or invoice creation.
+
+6. Tax line items are projected from the finalized Stripe invoice into `BillingInvoiceLine` (`apps/tamma-elsa/src/Tamma.Data/Entities/BillingInvoiceLine.cs`, created in 35-8) with a `LineKind` of `tax` (alongside `base`/`metered-overage`/`credit` from 35-8), carrying `Amount`, `Currency`, `TaxRatePercent`, `TaxJurisdiction`, and `TaxType` (e.g. `vat`/`gst`/`sales_tax`). The portal invoice detail shows the tax lines via the existing `GET /api/v1/billing/invoices/{id}` (35-8) — this story extends the projection in `InvoiceService` (`apps/tamma-elsa/src/Tamma.Api/Services/Billing/InvoiceService.cs`), not the endpoint.
+
+7. EU B2B **reverse-charge**: a valid VAT id in a supported reverse-charge country sets the Stripe customer to the appropriate tax-exempt treatment, and the finalized invoice produces the expected **zero / reverse-charge** tax line; the local mirror records `TaxExemptStatus = ReverseCharge` and a `BillingInvoiceLine` of kind `tax` with `Amount = 0` and `TaxType = reverse_charge`. The reverse-charge determination is made by Stripe Tax, not by Tamma's own rules.
+
+8. Tax-relevant fields are captured as a **point-in-time snapshot** on the invoice mirror at finalization: `BillingInvoice` (35-8) gains `TaxTotal`, `TaxCustomerAddressSnapshot` (JSONB), `TaxIdSnapshot` (type+value+verification status), and `TaxExemptSnapshot`, all written from the `invoice.finalized` projection so a later customer address/id change does **not** mutate historical invoices.
+
+9. DCB events are emitted to `DomainEvent` via `IEventRepository.AppendAsync` following `AGGREGATE.ACTION.STATUS`: `BILLING.TAX.PROFILE_UPDATED` (tags `{ tenantId, taxIdType, country, taxExemptStatus, verification }`, `TenantId` set) on a successful profile update, and `tax_total` is added to the existing `BILLING.INVOICE.FINALIZED` event tags (35-8) `{ ..., taxTotal, currency }`. A `BILLING.TAX_ID.VALIDATION_FAILED` event (tags `{ tenantId, taxIdType, country }`) is emitted on a rejected id.
+
+10. **Single-user mode** and **BYOK** both flow through the same tax path: tax applies to the platform/seat fee. In single-user mode there is no Stripe wiring (the `NullBillingProvider` from 35-1 governs), so the tax-profile endpoints/service no-op or are absent exactly as the other billing surfaces are; for a SaaS BYOK tenant (`BillingCustomer.BillingMode = Byok`), tax is still computed on the platform/seat fee invoice (BYOK only suppresses token markup per 35-3, never tax).
+
+11. Per-mode + per-tenant ownership (CLAUDE.md two-scoping rule): in SaaS the tax profile is owned by the **tenant** (`tenant_owner`/`tenant_admin` edit, `member` read-only); the catalog/automatic-tax toggle is platform-global (`OwnerAccess` for any admin read). In single-user mode the sole user owns their profile (no RBAC). Tenant isolation: the tax profile is resolved by `BillingCustomer.TenantId` (unique per 35-1) and is never readable/writable cross-tenant.
+
+12. Idempotency: tax-id and customer updates use deterministic Stripe idempotency keys (`billing-taxprofile-{tenantId}-{hash}`) so retries never create duplicate Stripe tax-id objects; updating a profile that already matches Stripe is a no-op.
+
+13. Unit + integration tests (xUnit, `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/`, Stripe mocked at the service-interface boundary; live Stripe with Tax enabled opt-in behind `STRIPE_SECRET_KEY_TEST`): address/tax-id save + validation (valid, invalid-syntax, unverifiable), `automatic_tax` enabled on invoice/subscription, the reverse-charge case (zero tax line + `ReverseCharge` status), and snapshot retention (change address after finalize → historical invoice tax snapshot unchanged). A tenant-isolation test asserts one tenant cannot read/update another tenant's tax profile, and the RBAC test asserts `member` → 403 on `PUT`.
+
+14. Logging follows the project standard: INFO on profile updated (tenantId, taxIdType, country, verification status — never the raw id beyond a redacted suffix), WARN on tax-id validation failure (type, country, reason), ERROR on Stripe Tax API failure during finalization projection; **the raw tax id, billing address PII, and any payment details are NEVER logged in full** (log a redacted form only).
+
+## Technical Design
+
+### Namespace / file structure
+
+```
+apps/tamma-elsa/src/Tamma.Core/
+  Billing/TaxExemptStatus.cs            # NEW — enum { None, Exempt, ReverseCharge } (shared)
+
+apps/tamma-elsa/src/Tamma.Data/
+  Entities/BillingCustomer.cs           # MODIFY (35-1) — add BillingAddress, TaxIdType, TaxIdValue, TaxExemptStatus
+  Entities/BillingInvoice.cs            # MODIFY (35-8) — add TaxTotal + tax snapshot columns
+  Entities/BillingInvoiceLine.cs        # MODIFY (35-8) — LineKind 'tax' + tax rate/jurisdiction/type fields
+  ControlPlaneDbContext.cs              # (no new DbSet — entities already registered by 35-1/35-8)
+  TammaModelConfiguration.cs            # MODIFY — CHECK on TaxExemptStatus / LineKind, jsonb columns
+  Migrations/ControlPlane/
+    <ts>_AddTaxProfileAndInvoiceTaxSnapshot.cs   # NEW (+ .Designer.cs + snapshot update)
+
+apps/tamma-elsa/src/Tamma.Api/
+  Services/Billing/
+    TaxProfileService.cs                # NEW — get/update profile, validate, push to Stripe
+    ITaxProfileService.cs               # NEW — seam
+    ITaxIdValidator.cs                  # NEW — syntactic + Stripe verification
+    TaxIdValidator.cs                   # NEW
+    IAutomaticTaxPolicy.cs              # NEW — toggle helper consumed by 35-4/35-8
+    AutomaticTaxPolicy.cs               # NEW
+    TaxLineProjector.cs                 # NEW — maps Stripe invoice tax → BillingInvoiceLine + snapshot
+    InvoiceService.cs                   # MODIFY (35-8) — call TaxLineProjector at invoice.finalized
+    BillingEvents.cs                    # MODIFY (35-1) — add TaxProfileUpdated / TaxIdValidationFailed / taxTotal tag
+  Endpoints/Billing/
+    TaxProfileEndpoints.cs              # NEW — GET/PUT /api/v1/billing/tax-profile
+  Extensions/
+    BillingServiceCollectionExtensions.cs  # MODIFY (35-1) — register tax services (mode-aware)
+  Program.cs                            # MODIFY — map TaxProfileEndpoints under the tenant-membership group
+```
+
+### Key entity changes
+
+```csharp
+// Tamma.Core/Billing/TaxExemptStatus.cs
+namespace Tamma.Core.Billing;
+public enum TaxExemptStatus { None, Exempt, ReverseCharge }
+
+// Tamma.Data/Entities/BillingCustomer.cs  (additions to the 35-1 entity)
+public string? BillingAddress { get; set; }          // jsonb: {line1,line2,city,state,postalCode,country}
+public string? TaxIdType { get; set; }               // Stripe tax-id type e.g. "eu_vat"
+public string? TaxIdValue { get; set; }              // raw id; never logged in full
+public string TaxExemptStatus { get; set; } = "None"; // text domain; CHECK ('None','Exempt','ReverseCharge')
+public string? TaxIdVerification { get; set; }        // "pending"|"verified"|"unverified" (Stripe async)
+
+// Tamma.Data/Entities/BillingInvoice.cs  (additions to the 35-8 entity)
+public long TaxTotal { get; set; }                    // minor units, point-in-time
+public string? TaxCustomerAddressSnapshot { get; set; } // jsonb snapshot at finalize
+public string? TaxIdSnapshot { get; set; }            // jsonb {type,valueRedacted,verification}
+public string TaxExemptSnapshot { get; set; } = "None";
+
+// Tamma.Data/Entities/BillingInvoiceLine.cs  (additions to the 35-8 entity)
+// LineKind gains 'tax'; tax lines carry:
+public decimal? TaxRatePercent { get; set; }
+public string? TaxJurisdiction { get; set; }
+public string? TaxType { get; set; }                  // "vat"|"gst"|"sales_tax"|"reverse_charge"
+```
+
+### EF model configuration sketch (`TammaModelConfiguration.ConfigureControlPlaneEntities`)
+
+```csharp
+modelBuilder.Entity<BillingCustomer>(entity =>
+{
+    entity.Property(e => e.BillingAddress).HasColumnType("jsonb");
+    entity.ToTable("billing_customers", t =>
+        t.HasCheckConstraint("ck_billing_customers_tax_exempt",
+            "\"TaxExemptStatus\" IN ('None','Exempt','ReverseCharge')"));
+});
+
+modelBuilder.Entity<BillingInvoice>(entity =>
+{
+    entity.Property(e => e.TaxCustomerAddressSnapshot).HasColumnType("jsonb");
+    entity.Property(e => e.TaxIdSnapshot).HasColumnType("jsonb");
+    entity.ToTable("billing_invoices", t =>
+        t.HasCheckConstraint("ck_billing_invoices_tax_exempt",
+            "\"TaxExemptSnapshot\" IN ('None','Exempt','ReverseCharge')"));
+});
+
+// BillingInvoiceLine: extend the existing LineKind CHECK to include 'tax'.
+```
+
+### EF migration sketch
+
+`dotnet ef migrations add AddTaxProfileAndInvoiceTaxSnapshot --context ControlPlaneDbContext --output-dir Migrations/ControlPlane` — **additive** (new columns on existing 35-1/35-8 tables), with a data step mapping the old `BillingCustomer.TaxStatus` text into `TaxExemptStatus`:
+
+```csharp
+migrationBuilder.AddColumn<string>("BillingAddress", "billing_customers", type: "jsonb", nullable: true);
+migrationBuilder.AddColumn<string>("TaxIdType", "billing_customers", nullable: true);
+migrationBuilder.AddColumn<string>("TaxIdValue", "billing_customers", nullable: true);
+migrationBuilder.AddColumn<string>("TaxExemptStatus", "billing_customers", nullable: false, defaultValue: "None");
+migrationBuilder.AddColumn<string>("TaxIdVerification", "billing_customers", nullable: true);
+migrationBuilder.Sql(@"UPDATE billing_customers
+    SET ""TaxExemptStatus"" = CASE ""TaxStatus""
+        WHEN 'reverse_charge' THEN 'ReverseCharge'
+        WHEN 'exempt' THEN 'Exempt' ELSE 'None' END;");
+// billing_invoices: TaxTotal, TaxCustomerAddressSnapshot (jsonb), TaxIdSnapshot (jsonb), TaxExemptSnapshot
+// billing_invoice_lines: TaxRatePercent, TaxJurisdiction, TaxType; replace LineKind CHECK to add 'tax'
+```
+
+> CHECK *edits* on existing tables follow the project's migration discipline (mirror entity config only in `TammaModelConfiguration.cs`, the single source); verify `has-pending-model-changes` reports none after generating.
+
+### Tax-profile service seam
+
+```csharp
+// Services/Billing/ITaxProfileService.cs
+public interface ITaxProfileService
+{
+    Task<TaxProfile> GetProfileAsync(Guid tenantId, CancellationToken ct = default);
+    Task<TaxProfile> UpdateProfileAsync(Guid tenantId, TaxProfileUpdate update, CancellationToken ct = default);
+}
+
+public sealed record TaxProfileUpdate(
+    BillingAddressDto Address, string? TaxIdType, string? TaxIdValue, bool ClaimExempt);
+
+public sealed record TaxProfile(
+    BillingAddressDto Address, string? TaxIdType, string? TaxIdValueRedacted,
+    TaxExemptStatus ExemptStatus, string? Verification);
+```
+
+`UpdateProfileAsync` flow: (1) `ITaxIdValidator.ValidateAsync(type, value, country)` — syntactic check, then create a Stripe `CustomerTaxId` and read its verification status; reject with `BILLING.TAX_ID.INVALID` + emit `BILLING.TAX_ID.VALIDATION_FAILED` on failure. (2) push `Customer.Address` + `Customer.TaxExempt` to Stripe with a deterministic idempotency key. (3) update `BillingCustomer` (address, type, redacted-store policy, `TaxExemptStatus`, `TaxIdVerification`) in one CP transaction. (4) emit `BILLING.TAX.PROFILE_UPDATED`. Stripe determines reverse-charge eligibility — Tamma maps Stripe's tax-exempt result onto `TaxExemptStatus`.
+
+### Automatic-tax toggle (consumed by 35-4 / 35-8)
+
+```csharp
+// Services/Billing/IAutomaticTaxPolicy.cs
+public interface IAutomaticTaxPolicy
+{
+    // Enabled whenever billing is enabled (SaaS) and the customer has a usable address.
+    bool ShouldEnable(BillingCustomer customer);
+}
+```
+
+35-4's `SubscriptionService` and 35-8's `InvoiceService` set `AutomaticTax = new() { Enabled = policy.ShouldEnable(customer) }` on the Stripe subscription/invoice. This story owns the policy; the call sites belong to those stories (boundary respected — this story only provides the helper and the projection).
+
+### Tax-line projection (invoice.finalized)
+
+`TaxLineProjector.Project(Stripe.Invoice invoice, BillingInvoice mirror)` runs inside 35-8's `InvoiceService` finalization projection: it reads `invoice.TotalTaxAmounts` / `invoice.AutomaticTax`, writes `BillingInvoice.TaxTotal` + the address/id/exempt **snapshots**, and appends one `BillingInvoiceLine { LineKind = "tax", ... }` per jurisdiction (reverse-charge → a single `Amount = 0`, `TaxType = "reverse_charge"` line). The snapshot makes historical invoices reproducible regardless of later profile edits.
+
+### DCB event names
+
+| Event | When | Tags | `TenantId` |
+|---|---|---|---|
+| `BILLING.TAX.PROFILE_UPDATED` | profile saved + pushed to Stripe | `{ tenantId, taxIdType, country, taxExemptStatus, verification }` | set |
+| `BILLING.TAX_ID.VALIDATION_FAILED` | tax id rejected | `{ tenantId, taxIdType, country, reason }` | set |
+| `BILLING.INVOICE.FINALIZED` (35-8) | finalize projection (extended) | `{ ..., taxTotal, currency }` | set |
+
+Emitted via `IEventRepository.AppendAsync(new DomainEvent { ... })` in the `OrgEndpoints.EmitTenantEvent` shape (`Metadata = {"workflowVersion":"1.0.0","eventSource":"system"}`); the `BillingEvents` static helper (35-1) gains the new builders. These CP-resident events are observable by the Story 5.6 `AlertRuleEvaluator`.
+
+### API shape
+
+```
+GET  /api/v1/billing/tax-profile      → 200 TaxProfile          (any tenant member; tax id redacted)
+PUT  /api/v1/billing/tax-profile      body: TaxProfileUpdate     (tenant_owner/tenant_admin; member 403)
+                                       → 200 TaxProfile | 422 {code:"BILLING.TAX_ID.INVALID", ...}
+```
+
+Both endpoints sit in the tenant-membership group (`RequireTenantMembershipFilter` resolves the tenant + role from context — `TenantRoleItemKey`); the caller's tenant is never read from a body field. RBAC mirrors the prompt-store precedent: read = any member, write = owner/admin, member write = 403.
+
+### Per-mode + per-tenant handling
+
+| Concern | single-user | SaaS |
+|---|---|---|
+| Provider | `NullBillingProvider` (35-1) — tax endpoints/service no-op or absent | `StripeBillingProvider` + Stripe Tax |
+| Profile owner | the sole user (no RBAC) | the tenant; `tenant_owner`/`tenant_admin` edit, `member` read-only |
+| Automatic-tax | n/a | on for platform/seat-fee invoices; BYOK tenants taxed on platform fee |
+| Reverse-charge | n/a | Stripe Tax decides; mirror records `ReverseCharge` |
+| Snapshot | n/a | written at finalize; immutable per invoice |
+| Tenant isolation | single tenant | profile keyed by unique `BillingCustomer.TenantId`; never cross-tenant |
+
+## Dependencies
+
+**Internal (prerequisite):**
+- **Story 35-1** — `BillingCustomer` entity + `IBillingProvider`/`NullBillingProvider` seam, `StripeClientFactory`, cabinet-resolved Stripe key, `BillingEvents` helper, mode-aware DI.
+- **Story 35-4** — `SubscriptionService` (sets `automatic_tax` on the subscription) and `BillingSubscription` mirror.
+- **Story 35-8** — `BillingInvoice` + `BillingInvoiceLine` mirrors, `InvoiceService` finalization projection, `BILLING.INVOICE.FINALIZED` event, the portal invoice endpoints.
+- Epic 28 — control plane, `Tenant`, `ControlPlaneDbContext`, `RequireTenantMembershipFilter`, `ITammaModeProvider`.
+- Epic 29 — secret cabinet (Stripe key resolution, via 35-1).
+- Epic 4 — DCB events (`DomainEvent`, `IEventRepository.AppendAsync`).
+
+**Internal (blocks):**
+- Story 35-10/35-11 (billing portal / dashboard surfaces) — display the tax profile editor + tax lines this story produces.
+
+**External:**
+- `Stripe.net` (added by 35-1) with **Stripe Tax** enabled on the account; tax-ids API + `Customer.TaxExempt` + invoice `AutomaticTax` / `TotalTaxAmounts`. Research the latest Stripe.net Tax surface before coding — do not assume method shapes.
+- A Stripe test account with Tax enabled and at least one origin tax registration configured (so test-mode tax is computed).
+
+## Testing Strategy
+
+**Unit (xUnit, `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/`):**
+1. `TaxIdValidatorTests` — valid EU VAT shape accepted; malformed prefix/checksum rejected (`BILLING.TAX_ID.INVALID`); Stripe "unverified" status → rejected, no silent accept.
+2. `TaxProfileServiceTests` — update pushes `Customer.Address`/`TaxExempt`/tax-id to Stripe (mocked) with the deterministic idempotency key; valid VAT in a reverse-charge country → `TaxExemptStatus = ReverseCharge`; row updated atomically; `BILLING.TAX.PROFILE_UPDATED` emitted once; rejected id leaves the row unchanged and emits `BILLING.TAX_ID.VALIDATION_FAILED`; idempotent re-save of an identical profile = no Stripe write.
+3. `AutomaticTaxPolicyTests` — enabled when billing on + address present; disabled with no address; disabled for `NullBillingProvider`.
+4. `TaxLineProjectorTests` — Stripe invoice with one tax jurisdiction → one `tax` line with rate/jurisdiction/type; reverse-charge invoice → single `Amount = 0`, `TaxType = "reverse_charge"` line; snapshot fields written from the finalize payload; `BillingInvoice.TaxTotal` set; `taxTotal` added to the `BILLING.INVOICE.FINALIZED` tags.
+
+**Integration (`apps/tamma-elsa/tests/Tamma.Api.Tests`, docker-bound via `sg docker -c "dotnet test ..."`):**
+5. Migration applies + rolls back on a real Postgres CP DB; `has-pending-model-changes` reports none; the `TaxStatus → TaxExemptStatus` data step maps existing rows.
+6. `PUT /api/v1/billing/tax-profile` end-to-end (Stripe mocked): owner/admin succeeds; **`member` → 403**; invalid id → 422 with the machine-readable code; `GET` returns the redacted profile.
+7. **Tenant isolation** — tenant A cannot `GET`/`PUT` tenant B's tax profile (resolved by `BillingCustomer.TenantId`); cross-tenant attempt → 403/404.
+8. **Snapshot retention** — finalize an invoice (mocked Stripe tax), then change the customer's address via `PUT`; re-read the historical `BillingInvoice` and assert its `TaxCustomerAddressSnapshot`/`TaxIdSnapshot`/`TaxTotal` are unchanged.
+
+**Live (opt-in, behind `STRIPE_SECRET_KEY_TEST` with Tax enabled, excluded from default CI):**
+9. Real Stripe test-mode: create an invoice with `automatic_tax` on for a taxable address → non-zero tax line; valid EU B2B VAT → reverse-charge zero line; verify the mirror matches.
+
+**Mocks:** Stripe SDK mocked at the `CustomerService` / `CustomerTaxIdService` / `InvoiceService` interface boundary; `IRuntimeSecretResolver` stubbed. Live Stripe Tax is opt-in only.
+
+## Estimated Effort
+
+3-4 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Core/Billing/TaxExemptStatus.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/BillingCustomer.cs` | Modify (tax fields) |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/BillingInvoice.cs` | Modify (tax total + snapshots) |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/BillingInvoiceLine.cs` | Modify (tax line kind + fields) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (jsonb cols + CHECKs) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_AddTaxProfileAndInvoiceTaxSnapshot.cs` | Create (+ Designer + snapshot) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/ITaxProfileService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/TaxProfileService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/ITaxIdValidator.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/TaxIdValidator.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/IAutomaticTaxPolicy.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/AutomaticTaxPolicy.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/TaxLineProjector.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/InvoiceService.cs` | Modify (call projector at finalize) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingEvents.cs` | Modify (tax events + taxTotal tag) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/TaxProfileEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/BillingServiceCollectionExtensions.cs` | Modify (register tax services) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map tax-profile endpoints) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/TaxIdValidatorTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/TaxProfileServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/AutomaticTaxPolicyTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/TaxLineProjectorTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/TaxProfileEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/TaxSnapshotIntegrationTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing, ensure you have:
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md).
+2. Searched `.dev/` for billing/Stripe/tax/VAT spikes, bugs, findings, decisions.
+3. Reviewed the 35-1 billing seam (`IBillingProvider`, `BillingCustomer`, `BillingEvents`, `StripeClientFactory`) and the 35-8 invoice mirror (`BillingInvoice`/`BillingInvoiceLine`, `InvoiceService` finalize path) — those are the entities/services this story extends.
+4. **Researched the latest Stripe.net Tax surface** (`Customer.TaxExempt`, `CustomerTaxIdService`, invoice `AutomaticTax` / `TotalTaxAmounts`, tax-id verification statuses) via current docs before writing any SDK call.
+5. Planned the TDD (Red-Green-Refactor) cycle for every new type.
+
+### Key Design Decisions
+
+- **Stripe Tax is the tax engine; Tamma stores minimal metadata.** We never compute rates ourselves — we collect the address/id, enable `automatic_tax`, and project Stripe's result. The validator only does *syntactic* pre-checks plus reading Stripe's verification status.
+- **No silent mis-billing.** An unverifiable VAT id is a hard `TammaError` (`BILLING.TAX_ID.INVALID`), never "accept and bill standard tax" — consistent with the project's no-empty-fallback principle (resolution is correct-or-error).
+- **Point-in-time snapshot at finalize.** Tax address/id/exempt and `TaxTotal` are copied onto `BillingInvoice` when Stripe finalizes, so a later profile edit cannot rewrite history (audit reproducibility).
+- **Reuse the 35-1 seam and 35-8 projection.** Tax fields ride on the existing `BillingCustomer`/`BillingInvoice(Line)` entities; this story adds columns + a projector + a profile service, not new tables or a parallel billing path.
+- **Automatic-tax toggle is a helper, not a re-implementation.** `IAutomaticTaxPolicy` is owned here but called by 35-4/35-8 — respects the subscription/invoice ownership boundaries.
+- **BYOK still pays tax.** BYOK suppresses token markup (35-3) but the platform/seat fee invoice is taxable; the same path applies.
+
+### Boundary Notes (do not implement sibling-story scope)
+
+- Do **not** re-implement subscription creation (35-4) or invoice creation/finalization/dunning (35-8) — only add the `automatic_tax` toggle helper and the tax-line projection those stories call.
+- Do **not** add webhook ingestion (35-5) — the finalize projection is invoked from the existing 35-8 path which 35-5 already drives.
+- Do **not** build the portal/dashboard tax UI (35-10/35-11) — this story exposes the API + projection only.
+- Do **not** add token-markup / BYOK suppression logic (35-3) — only assert tax applies to the platform/seat fee.
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Silently billing wrong tax on an unverifiable id | High | Hard reject (`BILLING.TAX_ID.INVALID`) + `VALIDATION_FAILED` event; row untouched; tested. |
+| Historical invoice tax mutates after a profile edit | High | Point-in-time snapshot written at `invoice.finalized`; snapshot-retention integration test. |
+| Stripe Tax not enabled / no origin registration in test account | Medium | Live tax tests opt-in behind `STRIPE_SECRET_KEY_TEST`; default CI mocks at the service boundary. |
+| Stripe.net Tax API drift vs assumptions | Medium | Research current docs before coding; mock at the service-interface boundary. |
+| PII / raw tax id leaking into logs | High | Redacted-only logging; tax id stored but never fully logged; credential-safety assertion in review. |
+| Cross-tenant tax-profile access | High | Resolve by unique `BillingCustomer.TenantId` via the membership filter; tenant-isolation test. |
+
+### Success Metrics
+
+- [ ] Invoices in tax-collecting jurisdictions carry a Stripe-computed tax line in `BillingInvoiceLine` (kind `tax`).
+- [ ] Valid EU B2B VAT id produces a reverse-charge zero line and `TaxExemptStatus = ReverseCharge`.
+- [ ] No unverifiable tax id is ever accepted (0 silent mis-bills in tests).
+- [ ] Historical invoice tax snapshot is immutable across profile edits.
+- [ ] Migration applies + rolls back; `has-pending-model-changes` = none.
+
+## Logging Requirements
+
+- **INFO**: tax profile updated (`tenantId`, `taxIdType`, `country`, `verification` — tax id only as redacted suffix), tax lines projected at finalize (`invoiceId`, `taxTotal`, jurisdiction count).
+- **DEBUG**: each Stripe SDK call issued (resource type, idempotency key — never the value), automatic-tax toggle decision (`enabled`, reason).
+- **WARN**: tax-id validation failure (`taxIdType`, `country`, `reason`), Stripe verification returned `unverified`.
+- **ERROR**: Stripe Tax API failure during the finalize projection (`invoiceId`, error class), production Stripe key absent (delegated to 35-1 boot path).
+- **Structured context**: include `{ tenantId, invoiceId, taxIdType, country, taxExemptStatus }` where applicable.
+- **Credential / PII safety**: NEVER log the raw tax id, full billing address, or any payment details; log redacted forms only.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-36/README.md
+++ b/docs/stories/epic-36/README.md
@@ -1,0 +1,308 @@
+# Epic 36: Analytics & Reporting Platform
+
+## Overview
+
+Epic 36 turns Tamma's DCB event stream and per-tenant operational data into a first-class,
+multi-dimensional analytics product. Today Tamma has only a thin, single-grain substrate: an
+hourly fact table (`platform_analytics_hourly`, Story 28-10) that carries fleet-wide and
+per-`(hour, tenant)` totals consumed exclusively by platform-owner admin endpoints, plus a live
+tenant dashboard that shows nothing but workflow counts and a success rate.
+
+This epic builds the real analytics product on top of the DCB event stream (`LLM.CALL.SUCCESS`,
+`AGENT.DISPATCH.*`, `WORKFLOW.*`) and per-call `ProviderDiagnostic` data. It delivers:
+
+- **A dimensional projection pipeline** that materializes per-tenant usage / cost / performance
+  rollups broken down by **provider, agent, workflow definition, repo, and a BYOK-vs-platform
+  cost basis** — at hourly and daily grain, idempotent, resumable, and per-tenant isolated.
+- **Tenant-facing analytics** — usage, cost/spend, and agent/tenant performance APIs and a
+  dashboard, plus CSV/PDF exports and scheduled email reports. RBAC-gated (owner/admin edit,
+  member read) and scoped per-mode (`user_id` in single-user, `tenant_id` in SaaS).
+- **A strictly-separated platform-owner business-analytics surface** (MRR, churn, conversion,
+  active/converting tenants) that is **NEVER** exposed per tenant — it lives on the control plane
+  and is reachable only behind `PlatformOwnerAccess` / owner-only admin endpoints.
+
+Epic 36 is built entirely in the C# `apps/tamma-elsa` solution. Per-tenant analytics live in the
+tenant schema (`Tamma.Data` `TenantDbContext`); platform business analytics live on the
+`ControlPlaneDbContext`. The two dashboards are `packages/dashboard-user` (tenant-facing) and
+`packages/dashboard` (admin, owner-only). It is **distinct from Epic 5/23 operational
+observability** (system health, ops metrics stay there) and re-targets the analytics slices of
+Epics 20/32 onto a single dimensional source of truth.
+
+## Stories
+
+| Story | Title | Priority | Status | Est. Effort |
+|-------|-------|----------|--------|-------------|
+| 36-1 | Dimensional Analytics Projection Schema & Store | P0 | drafted | 3-4 days |
+| 36-2 | DCB-to-Analytics Projection Pipeline (Dimensional Rollup) | P0 | drafted | 4-5 days |
+| 36-3 | Tenant Usage Analytics API | P0 | drafted | 3-4 days |
+| 36-4 | Cost & Spend Analytics API (BYOK vs Platform) | P0 | drafted | 3-4 days |
+| 36-5 | Agent & Tenant Performance Rollups API (consume Epic 32) | P1 | drafted | 3-4 days |
+| 36-6 | Tenant Analytics Dashboard UI | P1 | drafted | 4-5 days |
+| 36-7 | Pricing / Cost-Basis & Platform Margin Model | P0 | drafted | 3-4 days |
+| 36-8 | Analytics Exports (CSV / PDF) | P1 | drafted | 3-4 days |
+| 36-9 | Scheduled Reports & Delivery | P2 | drafted | 4-5 days |
+| 36-10 | Platform Business Analytics (Owner-Only: MRR, Churn, Conversion) | P1 | drafted | 4-5 days |
+| 36-11 | Analytics Event Catalog, Backfill & Reconciliation | P2 | drafted | 3-4 days |
+
+## Architecture
+
+```
++-----------------------------------------------------------------------------------+
+|                  EPIC 36: ANALYTICS & REPORTING PLATFORM                           |
+|                  (apps/tamma-elsa  — C# / Elsa / EF Core 9 / PG17)                 |
++-----------------------------------------------------------------------------------+
+|                                                                                   |
+|  SOURCE OF TRUTH: DCB event stream (Tamma.Data DomainEvent) + ProviderDiagnostic  |
+|    LLM.CALL.SUCCESS  AGENT.DISPATCH.*  WORKFLOW.*   (per-tenant schema)            |
+|                                   |                                               |
+|  +-- PROJECTION (36-1, 36-2) -----v-----------------------------------------+      |
+|  |  ComputeTenantDimensionalRollupActivity  (SequenceNumber checkpoint)     |      |
+|  |  CompactDailyAnalyticsActivity           PurgeStaleUsageAnalyticsActivity|      |
+|  |  fan-out step ON the existing HourlyAnalyticsRollupWorkflow (28-10)      |      |
+|  +-------------------------------|-----------------------------------------+      |
+|                                  v                                                 |
+|  PER-TENANT FACT STORE (tenant schema, no TenantId column — schema = isolation)    |
+|    analytics_usage_hourly   analytics_usage_daily   analytics_projection_checkpoint|
+|       dims: Provider, AgentId, WorkflowDefinitionId, RepoId, CostBasis(byok|platf) |
+|                                  |                                                 |
+|  +-- TENANT ANALYTICS APIs (36-3,4,5) ----------+   +-- PRICING (36-7) ---------+  |
+|  |  AnalyticsService / AdminAnalyticsEndpoints  |<--| IAnalyticsPricingConfig   |  |
+|  |  Usage | Cost/Spend (BYOK vs platform) | Perf|   | margin -> PlatformBilledUsd| |
+|  |  RBAC: MemberAccess read / owner+admin edit  |   +---------------------------+  |
+|  +----------------------|-----------------------+                                  |
+|         |               |                  |                                       |
+|   Exports (36-8)   Scheduled (36-9)  Tenant Dashboard UI (36-6)                    |
+|   CSV / PDF        email delivery    packages/dashboard-user                       |
+|                                                                                   |
+|  ===============  OWNER-ONLY (NEVER per tenant) ================================   |
+|  +-- PLATFORM BUSINESS ANALYTICS (36-10) -------------------------------------+    |
+|  |  ControlPlaneDbContext: platform_analytics_hourly (28-10) + business facts |    |
+|  |  MRR | churn | conversion | active/converting tenants                      |    |
+|  |  PlatformOwnerAccess only -> admin dashboard (packages/dashboard)          |    |
+|  +---------------------------------------------------------------------------+     |
+|                                                                                   |
+|  Catalog / Backfill / Reconciliation (36-11) — events, replay, totals tie-out     |
++-----------------------------------------------------------------------------------+
+```
+
+## Key Technical Decisions
+
+### Dimensional store, mirrored on (not extended from) the platform fact table
+
+The control-plane `platform_analytics_hourly` table (Story 28-10) stays the owner-only,
+single-grain fleet store — one `SELECT` answers "platform this week". Epic 36 adds **separate**
+per-tenant `analytics_usage_hourly` / `analytics_usage_daily` fact tables that carry the
+dimensions the CP row deliberately omits (`Provider`, `AgentId`, `WorkflowDefinitionId`,
+`RepoId`, `CostBasis`). The hourly and daily entities share their dimension + measure contract
+**exactly**, so the daily roll-up is a lossless `GROUP BY date_trunc('day', Hour), <dims>`. Measure
+types/precision (`long` counters, `decimal(20,4)` cost) match `PlatformAnalyticsHourly` so an
+owner-side reconciliation join is lossless.
+
+### Tenant isolation is the schema, not a column
+
+The per-tenant fact tables carry **no `TenantId` column** — tenancy is implicit in the per-tenant
+schema (`t_<hex>`) + connection string, matching the Doc 01 §1.4 target architecture
+(`TenantDbContext` carries no query filters; the search-path schema is the isolation plane). A row
+written to schema A is physically unreachable from schema B's context. The deliberate
+`ApplyTenantFilter` no-op keeps the EF migration graph in parity. These tables are **NOT** added to
+`ControlPlaneDbContext`.
+
+### NULLS NOT DISTINCT business key for idempotent upsert
+
+Nullable dimensions (`AgentId`, `WorkflowDefinitionId`, `RepoId`) would let duplicate
+"unattributed" rows accumulate under a naive unique index. A unique business-key index over the
+full dimension tuple with `.AreNullsDistinct(false)` (PG15+/PG17) collapses NULLs to one row per
+bucket — the upsert target the projection relies on (same pattern as `prompt_overrides` /
+`conventions`). Missing-dimension events bucket under that dimension `= NULL` and are **never**
+coerced to a sentinel string, so per-dimension breakdowns and the grand total always reconcile.
+
+### Projection is idempotent, resumable, and per-tenant-failure-tolerant
+
+The dimensional rollup is an **additional fan-out step** on the existing
+`HourlyAnalyticsRollupWorkflow` (one schedule, one advisory lock, one target hour) — it does not
+fork the scheduler. The activity recomputes the whole `(tenant, hour)` bucket from source and
+**overwrites** measures (read-then-upsert), so replay and backfill are naturally idempotent. An
+`analytics_projection_checkpoint` row records the highest folded `DomainEvent.SequenceNumber`
+(the monotonic `BIGSERIAL` total-order cursor — never `Id`/`CreatedAt`) for resumability. A single
+tenant's failure emits `…_FAILED` and continues the fan-out (Story 28-10 AC5 tolerance shape).
+
+### Cost basis from the Epic 35 `billing_mode` signal
+
+`CostBasis` (`byok | platform`) is resolved per usage record from the `billing_mode` tag on
+`LLM.CALL.*` events and the `ProviderDiagnostic.BillingMode` column (both produced by Story 35-2).
+The analytics path performs **no secret reads** — it reuses the already-surfaced discriminator, so
+provider-key plaintext is never on the analytics surface. Absent `billing_mode` (single-user mode /
+legacy events) defaults to `platform`. `platform`-basis rows carry
+`PlatformBilledUsd = CostUsd × (1 + margin)` from the Story 36-7 `IAnalyticsPricingConfig` seam;
+`byok` rows carry `PlatformBilledUsd = 0` (Tamma never marks up a BYOK call).
+
+### Per-tenant analytics vs. platform business analytics — a hard wall
+
+Tenant-facing analytics (usage/cost/performance) read the tenant schema behind `MemberAccess`
+(any member reads their tenant's data; member is read-only by default; owner/admin edit reports).
+Platform business analytics (MRR, churn, conversion) live on `ControlPlaneDbContext` and are
+reachable **only** behind `PlatformOwnerAccess` — they are never exposed on a tenant endpoint or
+the tenant dashboard. The endpoint shape stays identical across modes; the auth middleware
+resolves the override key (`user_id` single-user / `tenant_id` SaaS) per the prompt-store
+precedent.
+
+### Built in C#, never `packages/api`
+
+All server code lands in `apps/tamma-elsa` (`Tamma.Data`, `Tamma.Activities`, `Tamma.ElsaServer`,
+`AnalyticsService` / `AdminAnalyticsEndpoints`). The legacy `packages/api` is deleted and must not
+be referenced. UI is React: `packages/dashboard-user` (tenant) and `packages/dashboard` (admin).
+
+## Dependencies
+
+### On Other Epics
+
+- **Epic 4 (DCB event sourcing)** — the per-tenant `DomainEvent` stream (`LLM.CALL.SUCCESS`,
+  `AGENT.DISPATCH.*`, `WORKFLOW.*`) and its `SequenceNumber` total-order cursor that the projection
+  reads. **Consumed.**
+- **Epic 28 (per-tenant schema)** — `TenantDbContext`, `ITenantDbContextFactory`, the Tenant EF
+  migration graph, and `EfTenantDbMigrator` the fact tables and checkpoint live in.
+- **Story 28-10** — the `HourlyAnalyticsRollupWorkflow`, `FanOutTenantRollupsActivity`,
+  `ComputeTenantRollupActivity.AggregateLlmUsage`, `PurgeStaleAnalyticsActivity`, and
+  `AnalyticsRollupEvents` this epic extends/mirrors (and the CP `platform_analytics_hourly` table it
+  reuses for owner analytics, left intact).
+- **Epic 32 (agent action trail)** — the `agent_id` DCB tag and per-agent data the agent dimension
+  and performance rollups (36-5) **consume**. Absent → rows bucket under `AgentId = NULL`.
+- **Epic 34 (pricing / margin)** — pricing & platform-margin inputs feeding the cost-basis / margin
+  model (36-7) and `PlatformBilledUsd`.
+- **Epic 35 (billing)** — the `billing_mode` tag / `ProviderDiagnostic.BillingMode` (Story 35-2)
+  that resolves `CostBasis`; soft/forward dependency (defaults to `platform` if not yet landed).
+
+### Complements (does not duplicate)
+
+- **Epic 5 / Epic 23 (operational observability)** — system-health and ops metrics stay there.
+  Epic 36 owns **product analytics** (usage/cost/performance business facts), reconciling so the
+  two surfaces never re-implement each other. Operational lag/SLO of the projection itself is
+  emitted as analytics events (`ANALYTICS.ROLLUP.DIMENSIONAL_LAG`) and an OTel gauge, consumed by
+  the ops alerting Epic 5/23 owns.
+
+### External Dependencies
+
+- **PostgreSQL 17** — NULLS NOT DISTINCT business key (PG15+), per-tenant `ExecuteDeleteAsync`.
+- **EF Core 9 / Npgsql** — model-expressible `AreNullsDistinct(false)`, search-path schema routing.
+- **Elsa** — `HourlyAnalyticsRollupWorkflow` host for the scheduled projection fan-out.
+- **Testcontainers + Docker** — Postgres-17 integration suites (run via `sg docker -c "dotnet test …"`).
+- **CSV/PDF rendering** (36-8) and **email delivery** (36-9) — export/report surfaces.
+
+## Database Schema
+
+All per-tenant analytics tables live in each tenant schema via the `TenantDbContext` migration
+graph (no `TenantId` column — isolation is the schema). The control-plane
+`platform_analytics_hourly` (Story 28-10) is left intact and gains owner-only business-fact tables.
+
+```sql
+-- ── Per-tenant dimensional fact store (Story 36-1) — tenant schema (t_<hex>) ──
+CREATE TABLE analytics_usage_hourly (
+  id                     UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  hour                   TIMESTAMPTZ NOT NULL,          -- UTC top-of-hour bucket
+  -- dimensions
+  provider               TEXT NOT NULL,                 -- required
+  agent_id               TEXT,                          -- nullable (Epic 32 agent trail)
+  workflow_definition_id UUID,                          -- nullable
+  repo_id                TEXT,                          -- nullable
+  cost_basis             TEXT NOT NULL,                 -- 'byok' | 'platform' (HasConversion<string>)
+  -- measures
+  tokens_in              BIGINT  NOT NULL DEFAULT 0,
+  tokens_out             BIGINT  NOT NULL DEFAULT 0,
+  cost_usd               NUMERIC(20,4) NOT NULL DEFAULT 0,
+  platform_billed_usd    NUMERIC(20,4) NOT NULL DEFAULT 0,  -- CostUsd*(1+margin) for platform; 0 for byok
+  workflows_started      BIGINT  NOT NULL DEFAULT 0,
+  workflows_completed    BIGINT  NOT NULL DEFAULT 0,
+  workflows_failed       BIGINT  NOT NULL DEFAULT 0,
+  agent_dispatches       BIGINT  NOT NULL DEFAULT 0,
+  computed_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Breakdown index — drives "by provider / agent / workflow / cost-basis".
+CREATE INDEX IX_analytics_usage_hourly_breakdown
+  ON analytics_usage_hourly (hour, provider, agent_id, workflow_definition_id, cost_basis);
+
+-- Idempotent business key — full dimension tuple, NULLS NOT DISTINCT (one row per bucket-tuple).
+CREATE UNIQUE INDEX UX_analytics_usage_hourly_dims
+  ON analytics_usage_hourly (hour, provider, agent_id, workflow_definition_id, repo_id, cost_basis)
+  NULLS NOT DISTINCT;
+
+-- analytics_usage_daily: byte-for-byte identical shape, 'day' (UTC midnight) instead of 'hour'.
+-- Lossless GROUP BY date_trunc('day', hour), <dims>. Indexes: IX_/UX_analytics_usage_daily_*.
+
+-- ── Projection cursor (Story 36-2) — tenant schema ──
+CREATE TABLE analytics_projection_checkpoint (
+  id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  stream               TEXT NOT NULL,        -- 'dimensional'
+  last_sequence_number BIGINT NOT NULL,      -- highest DomainEvent.SequenceNumber folded in
+  updated_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ── Owner-only platform business analytics (Story 36-10) — control-plane DB ──
+-- platform_analytics_hourly (Story 28-10) left INTACT.
+-- + business-fact projections for MRR / churn / conversion / active+converting tenants,
+--   mapped on ControlPlaneDbContext, reachable ONLY behind PlatformOwnerAccess.
+```
+
+## Implementation Phases
+
+### Phase 1: Dimensional Foundation (36-1, 36-2, 36-7) — Weeks 1-2
+
+- Per-tenant fact schema + `CostBasis` enum + NULLS-NOT-DISTINCT business keys (36-1).
+- DCB→analytics projection pipeline: compute activity, checkpoint, daily compaction, retention
+  purge, fan-out on the 28-10 workflow, lag SLO (36-2).
+- Pricing / cost-basis & platform-margin model behind `IAnalyticsPricingConfig` (36-7).
+- Estimated: 10-13 days
+
+### Phase 2: Tenant Analytics APIs (36-3, 36-4, 36-5) — Weeks 3-4
+
+- Tenant usage analytics API; cost & spend (BYOK vs platform) API; agent/tenant performance
+  rollups API (consuming Epic 32). All `MemberAccess` read, owner/admin edit.
+- Estimated: 9-12 days
+
+### Phase 3: Surfaces & Delivery (36-6, 36-8, 36-9) — Weeks 5-6
+
+- Tenant analytics dashboard UI (`packages/dashboard-user`); CSV/PDF exports; scheduled reports +
+  email delivery.
+- Estimated: 11-14 days
+
+### Phase 4: Owner Business Analytics & Integrity (36-10, 36-11) — Week 7
+
+- Platform business analytics (MRR/churn/conversion), owner-only, on the admin dashboard
+  (`packages/dashboard`); analytics event catalog, backfill, and reconciliation tie-out.
+- Estimated: 7-9 days
+
+## Success Metrics
+
+- Projection lag p95 < 2 hours bucket-to-materialized; `ANALYTICS.ROLLUP.DIMENSIONAL_LAG` fires
+  only past the configured SLO budget.
+- 100% idempotent replay: re-running any hour leaves row counts and measures unchanged; backfill of
+  an already-projected bucket is a no-op on measures.
+- Reconciliation tie-out: `Σ(per-dimension rows)` equals the grand total for every tenant×bucket
+  (NULL buckets included), and owner-side CP totals reconcile losslessly against the per-tenant
+  dimensional sums (36-11).
+- Zero cross-tenant leakage: a row in tenant A's schema is unreachable from tenant B's context
+  (proven by Testcontainer isolation tests); a tenant A projection failure leaves tenant B intact.
+- Tenant analytics API p95 < 500ms reading pre-aggregated facts (no raw event re-scan).
+- Platform business analytics reachable **only** behind `PlatformOwnerAccess`; member-role SaaS
+  users hit 403 on every owner endpoint and the surface is absent from the tenant dashboard.
+- Cost basis correctly classified: 100% of `platform` rows carry `PlatformBilledUsd =
+  CostUsd × (1+margin)`; 100% of `byok` rows carry `PlatformBilledUsd = 0`.
+
+## Reference Documents
+
+- [Epic 36 stories](.) — `docs/stories/epic-36/story-36-*/`
+- [Story 36-1: Dimensional Analytics Projection Schema & Store](story-36-1/36-1-dimensional-analytics-projection-schema-and-store.md)
+- [Story 36-2: DCB-to-Analytics Projection Pipeline](story-36-2/36-2-dcb-to-analytics-projection-pipeline.md)
+- [Story 28-10: Platform Analytics Rollup](../epic-28/) — the `HourlyAnalyticsRollupWorkflow` +
+  `platform_analytics_hourly` foundation this epic extends.
+- [CLAUDE.md — Operating Modes & per-mode ownership](../../../CLAUDE.md) — single-user vs SaaS
+  principal/RBAC and the prompt-store resolution precedent.
+- DCB event sourcing (Epic 4); per-tenant schema (Epic 28); agent action trail (Epic 32);
+  pricing/margin (Epic 34); billing & `billing_mode` (Epic 35).
+
+---
+
+**Last Updated**: 2026-06-17
+**Epic Owner**: TBD
+**Implementation Start**: TBD
+**Total Estimated Effort**: 37-48 days

--- a/docs/stories/epic-36/story-36-1/36-1-dimensional-analytics-projection-schema-and-store.md
+++ b/docs/stories/epic-36/story-36-1/36-1-dimensional-analytics-projection-schema-and-store.md
@@ -1,0 +1,527 @@
+# Story 36-1: Dimensional Analytics Projection Schema & Store
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-phase workflow (Read → Research → Break Down → TDD →
+Quality Gates → Failure Handling), the `.dev/` knowledge base, TRACE/DEBUG logging
+requirements, test-first development, and the build-success / coverage gates.
+
+## User Story
+
+As a **tenant administrator** (SaaS) **/ self-hosted owner** (single-user),
+I want my usage, cost, and workflow performance facts stored per-tenant at hourly and daily
+grain with the dimensions that matter — provider, agent, workflow definition, repo, and a
+BYOK-vs-platform cost discriminator,
+so that every tenant-facing dashboard, export, and scheduled report in Epic 36 reads from one
+isolated, queryable, multi-dimensional analytics store instead of re-aggregating the raw DCB
+event stream on every request.
+
+## Priority
+
+P0 - The schema is the foundation the rest of Epic 36 (population, query API, exports, reports)
+builds on. Nothing in the epic ships until the fact tables and their EF model exist.
+
+## Scope
+
+Schema + EF model + migration **only**. This story defines and migrates the per-tenant
+`AnalyticsUsageHourly` and `AnalyticsUsageDaily` fact tables (in each tenant schema, via the
+`TenantDbContext` migration graph), wires them into the EF model, and proves InMemory/Npgsql
+parity and migration application. **Population is out of scope** — Story 36-2 owns the
+projection pipeline that fills these tables from DCB events. The control-plane
+`platform_analytics_hourly` fact table (Story 28-10) is left **entirely intact** for
+platform-owner business analytics.
+
+## Acceptance Criteria
+
+1. A new per-tenant EF entity `AnalyticsUsageHourly` is added at
+   `apps/tamma-elsa/src/Tamma.Data/Entities/AnalyticsUsageHourly.cs` with dimension columns
+   `Hour` (UTC top-of-hour, `timestamp with time zone`), `Provider` (string, required),
+   `AgentId` (nullable string), `WorkflowDefinitionId` (nullable `Guid`), `RepoId` (nullable
+   string), and `CostBasis` (enum `byok|platform`), plus measure columns `TokensIn`,
+   `TokensOut`, `WorkflowsStarted`, `WorkflowsCompleted`, `WorkflowsFailed`, `AgentDispatches`
+   (all `long`), `CostUsd` and `PlatformBilledUsd` (both `decimal(20,4)`), and a `ComputedAt`
+   write timestamp.
+
+2. A rolled-up per-tenant EF entity `AnalyticsUsageDaily` is added at
+   `apps/tamma-elsa/src/Tamma.Data/Entities/AnalyticsUsageDaily.cs` carrying the identical
+   dimension + measure shape, except the time bucket is `Day` (UTC midnight,
+   `timestamp with time zone`) instead of `Hour`. The two entities share their dimension and
+   measure contract exactly so the daily roll-up (Story 36-2) is a lossless `GROUP BY` of the
+   hourly grain.
+
+3. A new `CostBasis` enum is added at
+   `apps/tamma-elsa/src/Tamma.Core/Enums/CostBasis.cs` with members `Byok` and `Platform`, and
+   is mapped to a Postgres `text` column via `.HasConversion<string>()` so a `byok`/`platform`
+   discriminator round-trips identically on both the InMemory and Npgsql providers (mirrors the
+   `MentorshipState`/`SessionStatus` `HasConversion<string>()` precedent in
+   `TammaModelConfiguration.ConfigureMentorshipEntities`).
+
+4. Both entities are exposed as `DbSet`s on `TenantDbContext`
+   (`apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs`) — `AnalyticsUsageHourly` and
+   `AnalyticsUsageDaily` — and are configured exclusively through a new
+   `TammaModelConfiguration.ConfigureAnalyticsUsageEntities(...)` invoked from
+   `ConfigureTenantEntities`, mapping to tables `analytics_usage_hourly` and
+   `analytics_usage_daily`. They are **NOT** added to `ControlPlaneDbContext`, proving
+   per-tenant data isolation (AC tied to the spec: tenant schema only).
+
+5. The control-plane `platform_analytics_hourly` table, its entity
+   (`Tamma.Data.Entities.PlatformAnalyticsHourly`), and `ControlPlaneDbContext` mapping are
+   left unchanged — a `ControlPlaneDbContextModelTests` assertion confirms the CP model graph
+   still maps `platform_analytics_hourly` and does **not** map `analytics_usage_*`.
+
+6. Each fact table carries a composite breakdown index on
+   `(Hour|Day, Provider, AgentId, WorkflowDefinitionId, CostBasis)` named
+   `IX_analytics_usage_hourly_breakdown` / `IX_analytics_usage_daily_breakdown` to serve the
+   per-dimension breakdown queries the Epic 36 query API will run.
+
+7. Each fact table enforces idempotent upsert with a **unique** business-key index over the
+   full dimension tuple `(Hour|Day, Provider, AgentId, WorkflowDefinitionId, RepoId, CostBasis)`
+   using `.AreNullsDistinct(false)` (NULLS NOT DISTINCT, PG15+; production runs PG17) so the
+   nullable `AgentId`/`WorkflowDefinitionId`/`RepoId` dimensions dedupe on NULL exactly like
+   `prompt_overrides` / `conventions` do — one row per dimension-tuple per bucket. Index names:
+   `UX_analytics_usage_hourly_dims` / `UX_analytics_usage_daily_dims`.
+
+8. Measure columns use `long` for counters and `decimal` with `HasPrecision(20, 4)` for
+   `CostUsd` and `PlatformBilledUsd`, matching `PlatformAnalyticsHourly` conventions so values
+   round-trip losslessly between the two stores when an owner-side query joins/compares them.
+
+9. All counter measures default to `0L`, both decimals default to `0m`, `ComputedAt` defaults
+   to `now()`, and `Id` defaults to `gen_random_uuid()` — mirroring the
+   `ConfigurePlatformAnalyticsHourly` defaults so a partial upsert never writes a NULL measure.
+
+10. An EF model test asserts that **both** the InMemory provider and the Npgsql provider map
+    the `CostBasis` enum (as a `string`/text column) and the nullable dimension columns
+    (`AgentId`, `WorkflowDefinitionId`, `RepoId`) identically — column names, nullability, and
+    CLR-to-store type — following the `EF.Property<string?>(...)` projection-parity pattern used
+    by `PlatformAnalyticsService.GetTenantCountsAsync`.
+
+11. A new additive EF migration is generated under
+    `apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/` via
+    `dotnet ef migrations add AddAnalyticsUsageFactTables -c TenantDbContext` (resolved by
+    `TenantDesignTimeDbContextFactory`); `dotnet ef migrations has-pending-model-changes
+    -c TenantDbContext` reports **no** pending changes afterward, and the migration applies
+    cleanly under `EfTenantDbMigrator.MigrateTenantAppAsync` into a `t_<hex>` search-path schema.
+
+12. A migration smoke test (Postgres 17 Testcontainer, following
+    `SchemaPerTenantMigrationTests` / `ConventionStoreMigrationTests`) migrates two distinct
+    tenant schemas into one database and asserts: (a) both schemas carry their own
+    `analytics_usage_hourly` + `analytics_usage_daily` + `__TenantMigrationsHistory`; (b) a row
+    inserted into schema A's `analytics_usage_hourly` is invisible through schema B's context
+    (search-path isolation, no EF query filter); (c) a second insert of the same full
+    dimension-tuple within one bucket raises a unique-constraint violation (NULLS NOT DISTINCT
+    proven for NULL `AgentId`/`WorkflowDefinitionId`/`RepoId`).
+
+13. No DCB event is emitted by this story (schema-only). The DCB event catalogue for population
+    (`ANALYTICS.PROJECTION.*`) is owned by Story 36-2; the entity XML doc-comments reference the
+    existing `LLM.CALL.SUCCESS`, `AGENT.DISPATCH.*`, and `WORKFLOW.STEP_COMPLETED` event types
+    as the *future* projection sources, without consuming them here.
+
+## Tasks / Subtasks
+
+- [ ] Task 1: `CostBasis` enum (AC: 3)
+  - [ ] Add `apps/tamma-elsa/src/Tamma.Core/Enums/CostBasis.cs` with `Byok`, `Platform`.
+  - [ ] Unit test: enum members and `ToString()` lower-case round-trip expectation documented.
+
+- [ ] Task 2: `AnalyticsUsageHourly` + `AnalyticsUsageDaily` entities (AC: 1, 2, 8, 9)
+  - [ ] Add both entity classes under `Tamma.Data/Entities/` with shared dimension + measure
+        shape (Hour/Day differs only).
+  - [ ] XML doc-comments cite the Story 28-10 `PlatformAnalyticsHourly` precedent and the
+        future Story 36-2 projection sources.
+
+- [ ] Task 3: EF model configuration (AC: 4, 6, 7, 9)
+  - [ ] Add `TammaModelConfiguration.ConfigureAnalyticsUsageEntities(ModelBuilder, Guid? fixedTenantId)`.
+  - [ ] Map tables, defaults, `CostBasis` `HasConversion<string>()`, breakdown index, NULLS NOT
+        DISTINCT unique business-key index; call `ApplyTenantFilter` for graph parity.
+  - [ ] Invoke from `ConfigureTenantEntities`; add `DbSet`s to `TenantDbContext`.
+
+- [ ] Task 4: Model-parity unit tests (AC: 5, 10)
+  - [ ] `AnalyticsUsageModelTests` — InMemory + Npgsql model graph asserts column names,
+        nullability, `CostBasis` text mapping, table presence on `TenantDbContext`, absence on
+        `ControlPlaneDbContext`.
+  - [ ] Extend `ControlPlaneDbContextModelTests` — `platform_analytics_hourly` still mapped,
+        `analytics_usage_*` absent.
+
+- [ ] Task 5: Migration + smoke test (AC: 11, 12)
+  - [ ] Generate `AddAnalyticsUsageFactTables` Tenant migration; confirm
+        `has-pending-model-changes` is clean.
+  - [ ] `AnalyticsUsageMigrationTests` — two-schema isolation + NULLS NOT DISTINCT collision.
+
+## Technical Design
+
+### C# namespace / file structure
+
+```
+apps/tamma-elsa/src/
+  Tamma.Core/Enums/CostBasis.cs                              # NEW enum
+  Tamma.Data/Entities/AnalyticsUsageHourly.cs               # NEW per-tenant fact entity
+  Tamma.Data/Entities/AnalyticsUsageDaily.cs                # NEW per-tenant rolled-up fact entity
+  Tamma.Data/TenantDbContext.cs                             # MODIFY: + 2 DbSets
+  Tamma.Data/TammaModelConfiguration.cs                     # MODIFY: + ConfigureAnalyticsUsageEntities
+  Tamma.Data/Migrations/Tenant/<ts>_AddAnalyticsUsageFactTables.cs            # NEW (generated)
+  Tamma.Data/Migrations/Tenant/<ts>_AddAnalyticsUsageFactTables.Designer.cs   # NEW (generated)
+  Tamma.Data/Migrations/Tenant/TenantDbContextModelSnapshot.cs               # MODIFY (regenerated)
+
+apps/tamma-elsa/tests/Tamma.Api.Tests/
+  Analytics/AnalyticsUsageModelTests.cs                     # NEW model-parity tests
+  Analytics/AnalyticsUsageMigrationTests.cs                 # NEW Postgres smoke test
+  Epic28/ControlPlaneDbContextModelTests.cs                 # MODIFY: assert CP untouched
+```
+
+### `CostBasis` enum (Tamma.Core)
+
+```csharp
+namespace Tamma.Core.Enums;
+
+/// <summary>
+/// Discriminates whether the LLM/agent cost on an analytics fact row was
+/// paid against the tenant's own provider key (BYOK — Tamma never bills it)
+/// or against a Tamma-platform key (Tamma fronts the cost and may bill the
+/// tenant via <c>PlatformBilledUsd</c>). Persisted as lowercase text
+/// (<c>byok</c> / <c>platform</c>) via <c>HasConversion&lt;string&gt;()</c>.
+/// </summary>
+public enum CostBasis
+{
+    Byok = 0,
+    Platform = 1,
+}
+```
+
+### `AnalyticsUsageHourly` entity (shared shape; `AnalyticsUsageDaily` is identical except `Day`)
+
+```csharp
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Epic 36 Story 36-1 — per-tenant hourly usage/cost/performance fact row.
+/// Lives in the tenant schema (NOT the control-plane platform_analytics_hourly
+/// table — that stays owner-only, Story 28-10). Populated by the Story 36-2
+/// projection pipeline from LLM.CALL.SUCCESS / AGENT.DISPATCH.* /
+/// WORKFLOW.STEP_COMPLETED DCB events. Measure types mirror
+/// <see cref="PlatformAnalyticsHourly"/> so an owner-side comparison is lossless.
+/// </summary>
+public class AnalyticsUsageHourly
+{
+    public Guid Id { get; set; }
+
+    /// <summary>UTC top-of-hour bucket (e.g. 2026-06-17T12:00:00Z).</summary>
+    public DateTime Hour { get; set; }
+
+    // ── Dimensions ──
+    public string Provider { get; set; } = null!;        // required
+    public string? AgentId { get; set; }                 // nullable dimension
+    public Guid? WorkflowDefinitionId { get; set; }      // nullable dimension
+    public string? RepoId { get; set; }                  // nullable dimension
+    public CostBasis CostBasis { get; set; }             // byok | platform (text)
+
+    // ── Measures (counters: long; cost: decimal(20,4)) ──
+    public long TokensIn { get; set; }
+    public long TokensOut { get; set; }
+    public decimal CostUsd { get; set; }
+    public decimal PlatformBilledUsd { get; set; }
+    public long WorkflowsStarted { get; set; }
+    public long WorkflowsCompleted { get; set; }
+    public long WorkflowsFailed { get; set; }
+    public long AgentDispatches { get; set; }
+
+    /// <summary>Wall-clock write/last-update timestamp (replay-friendly).</summary>
+    public DateTime ComputedAt { get; set; }
+}
+```
+
+`AnalyticsUsageDaily` is byte-for-byte the same with `public DateTime Day { get; set; }` in
+place of `Hour`, so the daily roll-up (Story 36-2) is `GROUP BY date_trunc('day', Hour), <dims>`.
+
+### EF model configuration (`TammaModelConfiguration`)
+
+A new private static `ConfigureAnalyticsUsageEntities(ModelBuilder modelBuilder, Guid? fixedTenantId)`
+is called near the end of `ConfigureTenantEntities` (the same place `AgentConfig`,
+`PromptOverride`, `Convention` are configured). It mirrors
+`ControlPlaneDbContext.ConfigurePlatformAnalyticsHourly` for defaults/precision and the
+`prompt_overrides`/`conventions` indexes for NULLS NOT DISTINCT:
+
+```csharp
+private static void ConfigureAnalyticsUsageEntities(
+    ModelBuilder modelBuilder, Guid? fixedTenantId)
+{
+    modelBuilder.Entity<AnalyticsUsageHourly>(entity =>
+    {
+        entity.ToTable("analytics_usage_hourly");
+        entity.HasKey(e => e.Id);
+        entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+        entity.Property(e => e.Hour).HasColumnType("timestamp with time zone");
+        entity.Property(e => e.Provider).IsRequired().HasMaxLength(100);
+        entity.Property(e => e.AgentId).HasMaxLength(200);
+        entity.Property(e => e.RepoId).HasMaxLength(400);
+        entity.Property(e => e.CostBasis).HasConversion<string>().IsRequired().HasMaxLength(20);
+
+        entity.Property(e => e.TokensIn).HasDefaultValue(0L);
+        entity.Property(e => e.TokensOut).HasDefaultValue(0L);
+        entity.Property(e => e.WorkflowsStarted).HasDefaultValue(0L);
+        entity.Property(e => e.WorkflowsCompleted).HasDefaultValue(0L);
+        entity.Property(e => e.WorkflowsFailed).HasDefaultValue(0L);
+        entity.Property(e => e.AgentDispatches).HasDefaultValue(0L);
+        entity.Property(e => e.CostUsd).HasPrecision(20, 4).HasDefaultValue(0m);
+        entity.Property(e => e.PlatformBilledUsd).HasPrecision(20, 4).HasDefaultValue(0m);
+        entity.Property(e => e.ComputedAt).HasDefaultValueSql("now()");
+
+        // Breakdown index (AC6) — drives "by provider / agent / workflow / cost-basis".
+        entity.HasIndex(e => new
+            { e.Hour, e.Provider, e.AgentId, e.WorkflowDefinitionId, e.CostBasis })
+            .HasDatabaseName("IX_analytics_usage_hourly_breakdown");
+
+        // Idempotent business key (AC7) — full dimension tuple, NULLS NOT DISTINCT.
+        entity.HasIndex(e => new
+            { e.Hour, e.Provider, e.AgentId, e.WorkflowDefinitionId, e.RepoId, e.CostBasis })
+            .IsUnique()
+            .AreNullsDistinct(false)
+            .HasDatabaseName("UX_analytics_usage_hourly_dims");
+
+        // Migration-graph parity only (no-op filter on tenant DB).
+        ApplyTenantFilter(entity, fixedTenantId, _ => null);  // no TenantId column
+    });
+
+    modelBuilder.Entity<AnalyticsUsageDaily>(entity => { /* same, Day instead of Hour */ });
+}
+```
+
+> **Tenant-isolation note (Doc 01 §1.4).** These tables carry **no `TenantId` column** —
+> tenancy is implicit in the per-tenant schema + connection string. That matches the
+> target architecture (`TenantDbContext` carries no query filters; the search-path schema is
+> the isolation plane). `ApplyTenantFilter` is the deliberate no-op the codebase already uses;
+> the lambda returns `null` because there is no `TenantId` to filter on. This is the *correct*
+> shape for new tenant-resident tables — unlike the legacy `agent_configs`/`conventions` which
+> retain a transitional `TenantId` column.
+
+### `TenantDbContext` additions
+
+```csharp
+public DbSet<AnalyticsUsageHourly> AnalyticsUsageHourly => Set<AnalyticsUsageHourly>();
+public DbSet<AnalyticsUsageDaily> AnalyticsUsageDaily => Set<AnalyticsUsageDaily>();
+```
+
+`OnModelCreating` already calls `TammaModelConfiguration.ConfigureTenantEntities(modelBuilder,
+fixedTenantId: TenantId)`; the new `ConfigureAnalyticsUsageEntities` is invoked from inside
+that method, so no extra `OnModelCreating` wiring is needed.
+
+### EF migration sketch
+
+`dotnet ef migrations add AddAnalyticsUsageFactTables -c TenantDbContext` (resolved by
+`TenantDesignTimeDbContextFactory`, history table `__TenantMigrationsHistory`). The generated
+`Up()` creates two tables in the current search-path schema:
+
+```csharp
+migrationBuilder.CreateTable(
+    name: "analytics_usage_hourly",
+    columns: table => new
+    {
+        Id = table.Column<Guid>(nullable: false, defaultValueSql: "gen_random_uuid()"),
+        Hour = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+        Provider = table.Column<string>(maxLength: 100, nullable: false),
+        AgentId = table.Column<string>(maxLength: 200, nullable: true),
+        WorkflowDefinitionId = table.Column<Guid>(nullable: true),
+        RepoId = table.Column<string>(maxLength: 400, nullable: true),
+        CostBasis = table.Column<string>(maxLength: 20, nullable: false),
+        TokensIn = table.Column<long>(nullable: false, defaultValue: 0L),
+        TokensOut = table.Column<long>(nullable: false, defaultValue: 0L),
+        CostUsd = table.Column<decimal>(type: "numeric(20,4)", nullable: false, defaultValue: 0m),
+        PlatformBilledUsd = table.Column<decimal>(type: "numeric(20,4)", nullable: false, defaultValue: 0m),
+        WorkflowsStarted = table.Column<long>(nullable: false, defaultValue: 0L),
+        WorkflowsCompleted = table.Column<long>(nullable: false, defaultValue: 0L),
+        WorkflowsFailed = table.Column<long>(nullable: false, defaultValue: 0L),
+        AgentDispatches = table.Column<long>(nullable: false, defaultValue: 0L),
+        ComputedAt = table.Column<DateTime>(nullable: false, defaultValueSql: "now()"),
+    },
+    constraints: table => table.PrimaryKey("PK_analytics_usage_hourly", x => x.Id));
+// + analytics_usage_daily (Day instead of Hour)
+// + IX_*_breakdown and UX_*_dims (UX uses NULLS NOT DISTINCT — EF 9 emits it for AreNullsDistinct(false))
+```
+
+`Down()` drops both tables. The migration is **additive** (new tables only) — no baseline CHECK
+edit, so a plain `migrations add` is correct and `has-pending-model-changes` must report none
+afterward (AC11). Both `ControlPlaneDesignTimeDbContextFactory` and
+`TenantDesignTimeDbContextFactory` build cleanly; only the Tenant graph changes.
+
+### DCB events
+
+**None emitted by this story.** Population events (`ANALYTICS.PROJECTION.*` — e.g.
+`ANALYTICS.PROJECTION.HOUR_COMPLETED`) are Story 36-2's. This story only documents, in entity
+doc-comments, the *source* DCB events the future projection reads: `LLM.CALL.SUCCESS`
+(`data.inputTokens`/`outputTokens`/`costUsd`), `AGENT.DISPATCH.SUCCESS|FAILED`, and
+`WORKFLOW.STEP_COMPLETED` — the same prefixes `PlatformAnalyticsService` and
+`AnalyticsRollupEvents` already track.
+
+### Integration points
+
+- **`TenantDbContext` + `EfTenantDbMigrator.MigrateTenantAppAsync`** — the migrator applies the
+  new Tenant migration into each `t_<hex>` schema; new tenants get the tables on provisioning,
+  existing tenants on the next migrate pass (no data backfill in this story).
+- **Story 36-2 (population)** — reads/writes these tables via `TenantDbContext` resolved through
+  `ITenantDbContextFactory`; the `UX_*_dims` index is its upsert target.
+- **Story 28-10 `PlatformAnalyticsHourly`** — untouched; remains the owner-side CP fact table.
+  The measure types/precision deliberately match so an owner-side reconciliation join is lossless.
+
+### API shape
+
+**No new HTTP endpoints in this story.** The Epic 36 tenant query API (a later story) reads
+these tables behind `MemberAccess` (any tenant member may read their tenant's analytics) and
+`OwnerAccess`/`PlatformOwnerAccess` for the CP business-analytics surface. Endpoint shape stays
+identical across modes per the CLAUDE.md prompt-store precedent; the auth middleware resolves
+the tenant from the request, and the per-tenant `TenantDbContext` enforces isolation physically.
+
+### Per-mode + per-tenant handling
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns an `analytics_usage_*` row? | The sole user — it lives in their (only) tenant schema. | The tenant — it lives in that tenant's `t_<hex>` schema. |
+| Isolation plane | Search-path schema + connection string (no `TenantId` column, no query filter). | Same — physically separate schema per tenant. |
+| Who can read it (future query API)? | The user (no RBAC). | Any tenant member (`MemberAccess`); `member` is read-only by default. |
+| Cross-tenant leakage risk | N/A (one tenant). | Prevented at the storage layer — a row in schema A is unreachable from schema B's context (proven by AC12 smoke test). |
+
+Mode itself does not change the schema — the per-tenant store is mode-agnostic because both
+modes resolve to exactly one tenant schema per request. The platform-wide owner analytics stays
+on the CP `platform_analytics_hourly` table, which only `PlatformOwnerAccess` can read.
+
+## Dependencies
+
+**Prerequisite (internal):**
+- **Epic 28 (per-tenant schema + `TenantDbContext` + `EfTenantDbMigrator`)** — the migration
+  graph and per-tenant schema routing these tables live in.
+- **Story 28-10** — the `PlatformAnalyticsHourly` entity + `ConfigurePlatformAnalyticsHourly`
+  conventions (precision, defaults, partial-unique index style) this story mirrors.
+- **Epic 4 (DCB `DomainEvent`)** — the event stream the future projection (36-2) reads; only
+  referenced in doc-comments here.
+
+**Blocks (internal):**
+- **Story 36-2** (projection/population pipeline) — writes these tables.
+- All downstream Epic 36 stories (tenant analytics query API, exports, scheduled reports,
+  owner business analytics) — read these tables.
+
+**External:**
+- PostgreSQL 17 (NULLS NOT DISTINCT requires PG15+; production runs PG17).
+- EF Core 9 / Npgsql (model-expressible `AreNullsDistinct(false)`).
+- Testcontainers + Docker for the migration smoke test (run via
+  `sg docker -c "dotnet test ..."`).
+
+## Testing Strategy
+
+1. **Unit — `CostBasis` enum:** members present; documents the lowercase-text persistence
+   expectation that the model config enforces.
+
+2. **Unit — model parity (`AnalyticsUsageModelTests`, InMemory + Npgsql):**
+   - `TenantDbContext` model maps `analytics_usage_hourly` and `analytics_usage_daily`.
+   - `CostBasis` is mapped as a `string`/text column on both providers (assert store type +
+     column name, following the `EF.Property<string?>` parity pattern).
+   - Nullable dimension columns (`AgentId`, `WorkflowDefinitionId`, `RepoId`) are nullable;
+     `Provider`/`CostBasis` are required.
+   - Counter columns are `bigint`, `CostUsd`/`PlatformBilledUsd` are `numeric(20,4)`.
+   - The breakdown index and the `UX_*_dims` unique index exist with the expected column sets.
+
+3. **Unit — CP isolation (`ControlPlaneDbContextModelTests`, extended):** CP model still maps
+   `platform_analytics_hourly`; CP model does **not** map `analytics_usage_*` (tenant-only).
+
+4. **Integration — tenant isolation + idempotency (`AnalyticsUsageMigrationTests`, Postgres 17
+   Testcontainer):** following `SchemaPerTenantMigrationTests`:
+   - Migrate two tenant schemas into one DB; both carry `analytics_usage_hourly` +
+     `analytics_usage_daily` + `__TenantMigrationsHistory`.
+   - Insert a row through schema A's context; assert it is invisible through schema B's context
+     (search-path isolation — no EF query filter).
+   - Insert two rows with the same full dimension tuple (including NULL `AgentId`/
+     `WorkflowDefinitionId`/`RepoId`) in one bucket → second insert raises a unique violation
+     (NULLS NOT DISTINCT proven).
+   - Re-running the migrator for an already-migrated schema is a no-op.
+
+5. **Migration discipline:** after generating the migration, `dotnet ef
+   migrations has-pending-model-changes -c TenantDbContext` reports none; the new migration
+   applies and rolls back cleanly.
+
+**Mocks:** No Stripe or external provider calls in this story (schema-only). Tests use the
+InMemory provider for model-shape assertions and a real Postgres 17 Testcontainer for
+constraint/isolation assertions (EF InMemory does not honour NULLS NOT DISTINCT or CHECK
+constraints — same rationale documented in `ConventionStoreMigrationTests`).
+
+## Estimated Effort
+
+3-4 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Core/Enums/CostBasis.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/AnalyticsUsageHourly.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/AnalyticsUsageDaily.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs` | Modify (add 2 DbSets) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (add `ConfigureAnalyticsUsageEntities`, call from `ConfigureTenantEntities`) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/<ts>_AddAnalyticsUsageFactTables.cs` | Create (generated) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/<ts>_AddAnalyticsUsageFactTables.Designer.cs` | Create (generated) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/TenantDbContextModelSnapshot.cs` | Modify (regenerated) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/AnalyticsUsageModelTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/AnalyticsUsageMigrationTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs` | Modify (assert CP untouched) |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, decisions (analytics, tenancy, EF
+   migrations).
+3. Reviewed Story 28-10 (`PlatformAnalyticsHourly`, `ConfigurePlatformAnalyticsHourly`) and the
+   `prompt_overrides`/`conventions` NULLS NOT DISTINCT index precedent in
+   `TammaModelConfiguration`.
+4. Confirmed the test runner: docker-bound suites run via `sg docker -c "dotnet test ..."`
+   (session docker group is stale; the build itself needs no wrapper).
+5. Planned the TDD cycle (write `AnalyticsUsageModelTests` red first, then the entities/config).
+
+### Key Design Decisions
+
+- **Mirror `PlatformAnalyticsHourly`, don't extend it.** The CP table stays the owner-only
+  fleet-wide store (a single SELECT answers "platform this week"). The new per-tenant tables add
+  the dimensions (`Provider`, `AgentId`, `WorkflowDefinitionId`, `RepoId`, `CostBasis`) the CP
+  single-grain row deliberately omits, and live in the tenant schema so a tenant query never
+  touches CP data. Matching measure types/precision keeps an owner-side reconciliation lossless.
+- **No `TenantId` column.** New tenant-resident tables follow the Doc 01 §1.4 target shape:
+  isolation is the schema, not a column. `ApplyTenantFilter` is the established no-op; the lambda
+  returns `null`. Do **not** copy the legacy transitional `TenantId` column from `agent_configs`.
+- **NULLS NOT DISTINCT business key.** The nullable dimensions (`AgentId`,
+  `WorkflowDefinitionId`, `RepoId`) mean a naive unique index would let duplicate "unknown-agent"
+  rows accumulate. `AreNullsDistinct(false)` (PG15+/PG17) makes one NULL collapse to one row per
+  bucket — the upsert target Story 36-2 relies on. Same pattern as `prompt_overrides`.
+- **`CostBasis` as text, not int.** `HasConversion<string>()` (lowercase `byok`/`platform`)
+  keeps the column human-readable in ad-hoc SQL and InMemory/Npgsql parity simple — mirrors the
+  mentorship `HasConversion<string>()` precedent.
+- **Hourly + daily as separate tables, identical shape.** Keeping the dimension/measure contract
+  identical makes the daily roll-up a pure `GROUP BY`; a single shared private configurator avoids
+  drift.
+
+### Schema-only boundary
+
+This story creates **no** projection logic, **no** population workflow, **no** query endpoint,
+**no** DCB events, and **no** dashboard surface. Those are owned by later Epic 36 stories. Any PR
+that adds population or query code under cover of this story is out of scope — keep the diff to
+entities + enum + model config + migration + tests.
+
+## Logging Requirements
+
+This story adds no runtime code paths beyond EF model registration, so it introduces no new
+application logging. The standard EF/migration logging applies:
+- **INFO**: migration applied (table created) — emitted by `EfTenantDbMigrator` /
+  `dotnet ef database update`; per-schema (`t_<hex>`).
+- **DEBUG**: model-validation output during `OnModelCreating` (EF default).
+- **WARN/ERROR**: migration apply failure or pending-model-changes drift — surfaced by the
+  migrator and the CI `has-pending-model-changes` gate.
+- **Credential safety**: never log tenant connection strings or search-path schema secrets (the
+  `t_<hex>` connection string is AES-GCM-encrypted at rest via `TenantSecretProtector`).
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-36/story-36-10/36-10-platform-business-analytics.md
+++ b/docs/stories/epic-36/story-36-10/36-10-platform-business-analytics.md
@@ -1,0 +1,404 @@
+# Story 36-10: Platform Business Analytics (Owner-Only: MRR, Churn, Conversion)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+## User Story
+
+As the **platform owner**,
+I want a single owner-only business-analytics surface that reports MRR/ARR, churn, trial→paid
+conversion, active/trialing/churned tenant counts, plan distribution, and platform-wide gross
+margin — computed entirely from control-plane tenant/plan/subscription data plus the platform fact
+table,
+So that I can see how the business is performing across the whole fleet **without ever exposing one
+tenant's revenue, identity, or margin to another tenant**.
+
+## Priority
+
+P1 — Platform-owner business visibility. Built on the operational analytics rollup (Story 28-10)
+and the billing/pricing surfaces (Epic 35 billing, Story 36-7 pricing/margin).
+
+## Boundary Note (READ FIRST — non-negotiable scope guard)
+
+This story is **strictly platform-owner-only (SaaS mode only)** and adds a *business* analytics
+layer on top of the existing *operational* analytics rollup. The following boundaries are
+acceptance-blocking, not advisory:
+
+1. **Owner-only, never per-tenant.** Every endpoint added here is gated by the platform-owner
+   policy (`PlatformOwnerAccess` — the real policy name; the spec calls it "OwnerAccess"). There is
+   **no** tenant-facing variant. A tenant member/admin, or a cross-tenant principal, MUST receive
+   `403` (or `404` where the route is owner-namespaced) and a test asserts this.
+2. **Control-plane sourced only.** All metrics are computed from control-plane data:
+   `ControlPlaneDbContext` (`Tenant`, `Plan`, the Epic 35 subscription/billing entities) plus the
+   `platform_analytics_hourly` fact table and `platform_events`. This story MUST NOT open a
+   per-tenant schema connection to read per-tenant *business* detail. The only per-tenant data it
+   touches is the **pre-aggregated** fact-table rows (which are already CP-resident and fleet-wide
+   by design) and the owner-visible tenant directory it already exposes via
+   `GetTopTenantsAsync`.
+3. **No cross-tenant identity leakage.** Aggregate metrics (MRR, churn rate, conversion rate, plan
+   distribution) carry no per-tenant identifiers. Where a tenant breakdown is unavoidable (e.g. the
+   plan-distribution drill-down reuses `GetTopTenantsAsync`), it is only ever returned to the
+   platform owner — never assembled into a payload reachable by any tenant principal.
+4. **Do not duplicate Epic 5/23 ops metrics.** This extends `AdminAnalyticsEndpoints` /
+   `IPlatformAnalyticsService` with a new *business* surface; it does not re-implement the workflow/
+   agent-dispatch/cost ops counters that already exist there.
+5. **Single-user mode has no business analytics.** In single-user mode there is no MRR/churn/
+   conversion concept (one user, no billing relationship). The new endpoints are SaaS-only; in
+   single-user mode they are not mounted (or return `404`).
+
+## Acceptance Criteria
+
+1. **Business summary endpoint.** `GET /api/admin/analytics/business` returns, for a selectable UTC
+   window (default trailing 30d): `mrrUsd`, `arrUsd` (`mrrUsd × 12`), `netNewMrrUsd`,
+   `churnedMrrUsd`, `activeTenants`, `trialingTenants`, `churnedTenants` (in window),
+   `trialToPaidConversionRate`, and `planDistribution` (count + MRR per plan slug). Computed from
+   `Tenant` + `Plan` (+ subscription state from the re-targeted Epic 20 / Epic 35 billing entities).
+
+2. **MRR/ARR computation.** `mrrUsd` = sum of the active recurring monthly price for every tenant
+   in an active *paying* subscription state at window end, derived from each tenant's plan price
+   (`Plan.MonthlyPriceUsd`) net of any active discount/credit recorded by Epic 35. `arrUsd` is
+   `mrrUsd × 12`. Free-plan and trialing tenants contribute `0` to MRR. The math is unit-tested
+   against a fixed fixture.
+
+3. **Net-new vs churned MRR.** `netNewMrrUsd` = MRR added by tenants that became paying inside the
+   window (new + upgrades); `churnedMrrUsd` = MRR lost by tenants that cancelled/downgraded/expired
+   inside the window. Both are signed-consistent (churn reported as a positive "lost" figure) and
+   reconcile such that `endMrr − startMrr ≈ netNewMrrUsd − churnedMrrUsd` for a closed window.
+
+4. **Churn definition is documented and deterministic.** Churn is computed over a defined cohort
+   window (default trailing 30d): `churnRate` = churned paying tenants in window ÷ paying tenants at
+   window start. The exact definition (cohort = tenants paying at window start; churned = those who
+   left a paying state before window end) is documented in this story and in the service XML-doc.
+   For a given UTC window the result is **deterministic** — windowing derives from an injected clock
+   (`TimeProvider`/`IClock`) exactly like `PlatformAnalyticsService`, and a test pins determinism.
+
+5. **Trial→paid conversion.** `trialToPaidConversionRate` = tenants that converted from trialing to
+   a paying state in the window ÷ tenants whose trial ended in the window. The numerator/denominator
+   are also returned (`trialsConverted`, `trialsEnded`) so a zero denominator yields a `null`/`0`
+   rate rather than a divide-by-zero, and the raw counts are auditable.
+
+6. **Active / trialing / churned tenant counts.** `activeTenants` = tenants in a paying state at
+   window end (excludes soft-deleted via the CP `DeletedAt` query filter); `trialingTenants` =
+   tenants in a trial state at window end; `churnedTenants` = tenants who left a paying state inside
+   the window. Counts exclude soft-deleted and non-`org` placeholder tenants consistently with the
+   existing tenant-directory counts.
+
+7. **Plan distribution.** `planDistribution` is a list of `{ planSlug, displayName, tenantCount,
+   mrrUsd }`, one row per `Plan`, covering every active plan (zero-count plans included so the chart
+   is stable). Sourced from `Tenant.Plan` joined to `Plan`; no per-tenant identifiers in the
+   aggregate rows.
+
+8. **Margin endpoint.** `GET /api/admin/analytics/business/margin` returns platform gross margin for
+   the window: `platformBilledUsd` − `providerCostBasisUsd`, plus the two components and a
+   `grossMarginPct`. `platformBilledUsd` comes from the Epic 36-7 pricing/margin source (NEW —
+   marked below); `providerCostBasisUsd` is summed from `platform_analytics_hourly.CostUsd` (the
+   provider cost basis already rolled up by Story 28-10) over the same UTC window.
+
+9. **Owner-only RBAC enforced.** Both business endpoints are gated by `PlatformOwnerAccess`. A test
+   asserts a tenant principal (member, tenant_admin, tenant_owner) and a cross-tenant principal
+   cannot reach either route (`403`/`404`), and that an unauthenticated request is rejected.
+
+10. **Control-plane sourced; no per-tenant schema reads.** A test/assertion verifies the service
+    depends only on `ControlPlaneDbContext` + the fact table + the pricing source — it never
+    resolves a per-tenant connection. Per-tenant business detail beyond owner-visible aggregates is
+    never read.
+
+11. **No per-tenant identity leakage to other tenants.** Because the routes are owner-only there is
+    no tenant-reachable path; a test confirms the business payloads are only ever produced under the
+    owner policy, and that the aggregate fields contain no tenant ids/slugs except in the
+    owner-only plan/top-tenant drill-down which reuses `GetTopTenantsAsync`.
+
+12. **Reuse, don't re-implement.** The plan/tenant breakdown reuses `GetTopTenantsAsync` rather than
+    re-querying the tenant directory; the ops counters (workflows/dispatch/cost) are NOT duplicated.
+
+13. **Admin dashboard Business Analytics view.** The admin dashboard (`packages/dashboard`) gains a
+    "Business Analytics" tab rendering MRR/ARR, churn, trial→paid conversion, plan distribution, and
+    gross-margin charts, behind the existing owner-only admin gate. It is not shown to non-owner
+    users and is absent in single-user mode.
+
+14. **Window selection.** Both endpoints accept an optional `window` (or `from`/`to`) query param;
+    absent → trailing 30d. Inputs are parsed as UTC (mirroring the `DateTime.Kind` handling already
+    in `AdminAnalyticsEndpoints.GetEventHistogram`).
+
+15. **Tests.** Unit + integration tests cover MRR/ARR/net-new/churned math, churn-rate definition,
+    trial→paid conversion (incl. zero-denominator), plan distribution, margin computation,
+    `PlatformOwnerAccess` enforcement (tenant principal denied), and UTC determinism for a fixed
+    window + fixed clock.
+
+## Technical Design
+
+### Mode scoping (mandatory two-model answer per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns business analytics? | **N/A** — no billing relationship, no MRR/churn/conversion concept. The endpoints are not mounted (or return `404`). | The **platform owner** exclusively (`PlatformOwnerAccess`). Never any tenant. |
+| What data is read? | — | Control-plane only: `Tenant`, `Plan`, Epic 35 subscription/billing entities, `platform_analytics_hourly`, the Epic 36-7 pricing source. |
+| Where does it surface? | Hidden in the dashboard. | Owner-only "Business Analytics" admin tab. |
+
+Mode comes from the already process-stable `ITammaModeProvider` (`TammaMode.cs`). The endpoint
+mapping checks SaaS mode at wire time so single-user deployments never expose the routes.
+
+### Service: `BusinessAnalyticsService`
+
+New `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/BusinessAnalyticsService.cs` implementing a
+new `IBusinessAnalyticsService` port. It mirrors the existing `PlatformAnalyticsService` shape:
+
+- Constructor takes `ControlPlaneDbContext`, the Epic 35 billing/subscription read port, the Epic
+  36-7 pricing/margin read port, `IPlatformAnalyticsService` (to reuse `GetTopTenantsAsync`), and a
+  `TimeProvider`/`IClock` (so windowing is deterministic and unit-testable — same pattern as
+  `PlatformAnalyticsService`'s injected `_clock`).
+- All windows derive from `clock.GetUtcNow().UtcDateTime` at the call site; never `DateTime.UtcNow`
+  inline, so a fixed clock yields a fixed result.
+
+```csharp
+public interface IBusinessAnalyticsService
+{
+    /// <summary>
+    /// MRR/ARR, net-new vs churned MRR, active/trialing/churned tenant counts,
+    /// trial→paid conversion, and plan distribution for [windowStart, windowEnd).
+    /// Platform-owner-only — reads control-plane tenant/plan/subscription data;
+    /// never opens a per-tenant schema connection.
+    /// </summary>
+    Task<BusinessAnalyticsSummary> GetSummaryAsync(
+        DateTime? from = null, DateTime? to = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Platform gross margin = sum(platformBilledUsd) − sum(providerCostBasisUsd)
+    /// across all tenants for the window. Billed revenue from the Epic 36-7
+    /// pricing source; provider cost basis summed from platform_analytics_hourly.CostUsd.
+    /// </summary>
+    Task<PlatformMarginSummary> GetMarginAsync(
+        DateTime? from = null, DateTime? to = null, CancellationToken ct = default);
+}
+```
+
+### DTOs (new, alongside `PlatformAnalyticsDtos.cs`)
+
+```csharp
+public sealed record BusinessAnalyticsSummary(
+    DateTime WindowStart,
+    DateTime WindowEnd,
+    decimal MrrUsd,
+    decimal ArrUsd,                 // MrrUsd * 12
+    decimal NetNewMrrUsd,
+    decimal ChurnedMrrUsd,
+    int ActiveTenants,
+    int TrialingTenants,
+    int ChurnedTenants,
+    int PayingTenantsAtWindowStart,
+    double ChurnRate,               // churnedTenants / payingTenantsAtWindowStart
+    int TrialsEnded,
+    int TrialsConverted,
+    double? TrialToPaidConversionRate,   // null when TrialsEnded == 0
+    IReadOnlyList<PlanDistributionRow> PlanDistribution,
+    DateTime GeneratedAt);
+
+public sealed record PlanDistributionRow(
+    string PlanSlug,
+    string DisplayName,
+    int TenantCount,
+    decimal MrrUsd);
+
+public sealed record PlatformMarginSummary(
+    DateTime WindowStart,
+    DateTime WindowEnd,
+    decimal PlatformBilledUsd,       // Epic 36-7 pricing source (NEW)
+    decimal ProviderCostBasisUsd,    // sum(platform_analytics_hourly.CostUsd) in window
+    decimal GrossMarginUsd,          // billed − cost basis
+    double GrossMarginPct,           // grossMargin / billed (0 when billed == 0)
+    DateTime GeneratedAt);
+```
+
+### Metric definitions (documented, deterministic)
+
+- **MRR** — Σ over tenants in a paying subscription state at `windowEnd` of
+  `(plan.MonthlyPriceUsd − activeDiscountUsd)`. Free + trial tenants contribute 0. Subscription
+  state + discount come from the Epic 35 billing entities; the plan price from `Plan`.
+- **ARR** — `MRR × 12`.
+- **Net-new MRR** — Σ MRR gained by tenants entering/upgrading into a paying state in
+  `[windowStart, windowEnd)`.
+- **Churned MRR** — Σ MRR lost by tenants leaving a paying state (cancel/downgrade/expire) in the
+  window (reported positive).
+- **Churn rate** — cohort = tenants paying at `windowStart`; churned = those no longer paying at
+  `windowEnd`; `churnRate = churnedCount / cohortCount` (`0` when cohort empty).
+- **Trial→paid conversion** — `trialsConverted / trialsEnded` where `trialsEnded` = trials that
+  ended in the window and `trialsConverted` = of those, ones that entered a paying state. `null`
+  when `trialsEnded == 0`.
+- **Active / trialing / churned counts** — point-in-time at `windowEnd` (active, trialing) and
+  in-window flow (churned). Soft-deleted tenants excluded by the CP `DeletedAt` query filter.
+- **Plan distribution** — `GROUP BY Tenant.Plan` joined to `Plan`; one row per active plan including
+  zero-count plans. MRR per plan = Σ paying-tenant prices in that plan.
+- **Gross margin** — `platformBilledUsd − providerCostBasisUsd` over the window;
+  `providerCostBasisUsd = Σ platform_analytics_hourly.CostUsd WHERE Hour ∈ [windowStart, windowEnd)`.
+
+### Endpoints (extend `AdminAnalyticsEndpoints`)
+
+Two new static handlers in `AdminAnalyticsEndpoints.cs`, wired in `Program.cs` next to the existing
+`/analytics/*` maps with `RequireAuthorization("PlatformOwnerAccess")` (matching the existing
+owner-only admin endpoints — `AdminAnalyticsEndpoints` handlers are mounted on the
+`/api/admin` group). The maps are conditional on SaaS mode.
+
+```
+GET /api/admin/analytics/business[?from=ISO&to=ISO]        → BusinessAnalyticsSummary   (PlatformOwnerAccess)
+GET /api/admin/analytics/business/margin[?from=ISO&to=ISO] → PlatformMarginSummary      (PlatformOwnerAccess)
+```
+
+UTC handling mirrors `GetEventHistogram` — `from`/`to` are coerced to `DateTimeKind.Utc` before
+reaching the service so the window matches the UTC-stored CP columns.
+
+### Admin dashboard
+
+- New `packages/dashboard/src/services/admin/business-analytics-client.ts` (mirrors
+  `admin-api-client.ts`) calling the two endpoints.
+- New `packages/dashboard/src/pages/admin/BusinessAnalyticsTab.tsx`; register in
+  `packages/dashboard/src/pages/admin/AdminLayout.tsx` by adding `'business-analytics'` to the
+  `AdminTab` union and a `{ id: 'business-analytics', label: 'Business Analytics' }` entry to
+  `TABS`, plus the `activeTab === 'business-analytics' && <BusinessAnalyticsTab />` branch.
+- Charts: MRR/ARR tiles, net-new vs churned MRR, churn-rate trend, trial→paid conversion, plan
+  distribution (bar), gross-margin tile (billed vs cost basis). Reuse the chart primitives already
+  used by the knowledge-base analytics components where practical.
+- The tab is only rendered for platform-owner users (existing owner-only admin gate) and is absent
+  in single-user mode.
+
+## Dependencies
+
+- **Story 28-10** (platform fact table `platform_analytics_hourly` + `IPlatformAnalyticsService` +
+  `AdminAnalyticsEndpoints`) — extended here; provides `CostUsd` (provider cost basis) and
+  `GetTopTenantsAsync` (reused). VERIFIED present.
+- **Epic 35 billing** (subscription state, billing-cycle, discounts/credits) — **NEW**: subscription/
+  billing entities do **not** exist in `Tamma.Data/Entities` yet. This story's subscription-state
+  reads (paying/trialing/churned, conversion, net-new/churned MRR) depend on those entities landing.
+  Until then the service falls back to `Tenant.Plan` + `Plan.MonthlyPriceUsd` for a coarse MRR/plan
+  distribution and reports trial/churn/conversion as `0`/`null` (documented degraded mode).
+- **Epic 20 (re-targeted)** — the subscription/plan-state lineage the spec references; in the C#
+  control plane this lands as the Epic 35 billing entities above.
+- **Story 36-7** (pricing / margin) — **NEW**: provides `platformBilledUsd` for the margin endpoint.
+  Until 36-7 lands, the margin endpoint reports `platformBilledUsd = 0` (and thus a negative/zero
+  margin) behind the same degraded-mode flag.
+- **Epic 16 / OwnerAccess policy** — in this repo the platform-owner policy is `PlatformOwnerAccess`
+  (`Program.cs` ~986). VERIFIED present.
+
+## Testing Strategy
+
+1. **MRR/ARR math** — fixture of tenants across plans + subscription states; assert `mrrUsd`,
+   `arrUsd = mrr × 12`, free/trial contribute 0, discounts applied.
+2. **Net-new vs churned MRR** — fixture with new/upgrade/cancel/downgrade events inside the window;
+   assert `endMrr − startMrr ≈ netNew − churned`.
+3. **Churn rate** — cohort at window start vs leavers; zero-cohort → `0`; documented definition.
+4. **Trial→paid conversion** — trials ended/converted counts; zero `trialsEnded` → `null` rate (no
+   divide-by-zero).
+5. **Plan distribution** — every active plan present incl. zero-count; MRR per plan correct; no
+   tenant ids in aggregate rows.
+6. **Margin** — `platformBilledUsd` from the pricing source minus `Σ CostUsd` from
+   `platform_analytics_hourly`; `grossMarginPct` correct; billed == 0 → pct 0.
+7. **RBAC** — `PlatformOwnerAccess` allows owner; tenant member/tenant_admin/tenant_owner and
+   cross-tenant principals get `403`/`404`; unauthenticated rejected. (xUnit integration test
+   against the endpoint with a tenant principal.)
+8. **Control-plane only** — assert the service has no per-tenant-connection dependency (constructor
+   takes only `ControlPlaneDbContext` + ports; no `ITenantConnectionResolver`).
+9. **UTC determinism** — fixed `TimeProvider` + fixed `from`/`to` → byte-identical summary across
+   runs; `from`/`to` parsed as UTC regardless of request `DateTime.Kind`.
+10. **Mode** — SaaS mode mounts the routes; single-user mode does not (route returns `404`).
+11. **Dashboard** — colocated Vitest/Testing-Library: tab renders MRR/churn/conversion/margin,
+    hidden for non-owner, ack of degraded-mode banner when Epic 35/36-7 absent.
+
+Docker-bound xUnit suites run via `sg docker -c "dotnet test ..."` (see project memory
+`reference_dotnet_test_docker`).
+
+## Estimated Effort
+
+3-4 days (service + 2 endpoints + DTOs + dashboard tab + tests). Margin and full churn/conversion
+fidelity track Epic 35 / Story 36-7 availability; coarse plan/MRR works against existing
+`Tenant`/`Plan` today.
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/IBusinessAnalyticsService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/BusinessAnalyticsService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/BusinessAnalyticsDtos.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminAnalyticsEndpoints.cs` | Modify (add `GetBusiness`, `GetBusinessMargin`) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (register service; map 2 endpoints w/ `PlatformOwnerAccess`, SaaS-gated) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Epic36/BusinessAnalyticsServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Epic36/BusinessAnalyticsEndpointsRbacTests.cs` | Create |
+| `packages/dashboard/src/services/admin/business-analytics-client.ts` | Create |
+| `packages/dashboard/src/pages/admin/BusinessAnalyticsTab.tsx` | Create |
+| `packages/dashboard/src/pages/admin/AdminLayout.tsx` | Modify (add tab to `AdminTab` union + `TABS` + render branch) |
+| `packages/dashboard/src/pages/admin/__tests__/BusinessAnalyticsTab.test.tsx` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, decisions
+3. Reviewed Story 28-10 (`PlatformAnalyticsService`, `PlatformAnalyticsHourly`,
+   `AdminAnalyticsEndpoints`) — this story extends, not duplicates, it
+4. Confirmed which Epic 35 billing entities + Story 36-7 pricing source exist when you start; if
+   absent, ship the coarse `Tenant.Plan`/`Plan.MonthlyPriceUsd` MRR + plan distribution and gate the
+   churn/conversion/margin fields behind the documented degraded-mode flag
+5. Planned the TDD cycle (Red-Green-Refactor)
+
+### Architecture target (do not get this wrong)
+
+- Target is the C# control plane: `apps/tamma-elsa` (`Tamma.Api`, `Tamma.Data`) + the React admin
+  dashboard `packages/dashboard`. **`packages/api` is deleted — never target or cite it.**
+- Business analytics is **control-plane** data only. Read `ControlPlaneDbContext`
+  (`apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs`), the `platform_analytics_hourly` fact
+  table, and the Epic 35 / 36-7 read ports. Do **not** resolve a per-tenant connection for business
+  detail.
+
+### Determinism
+
+Inject `TimeProvider`/`IClock` exactly like `PlatformAnalyticsService` (`_clock` at
+`PlatformAnalyticsService.cs:84`). Derive `now`, `windowStart`, `windowEnd` once at the top of each
+method. Never call `DateTime.UtcNow` inline. This is what makes AC4/AC15 pass.
+
+### RBAC precedent
+
+`AdminAnalyticsEndpoints` handlers are mounted on `app.MapGroup("/api/admin")` with per-handler
+`RequireAuthorization("PlatformOwnerAccess")` (the platform-owner policy defined in `Program.cs`
+~986; the spec's "OwnerAccess" is `PlatformOwnerAccess` here — `OwnerAccess` is the looser
+per-tenant-owner gate and MUST NOT be used). Follow the same pattern; the existing owner-only
+analytics maps (`/analytics/summary|tenants|events`, `Program.cs` ~1343-1350) are the template.
+
+### Degraded mode (Epic 35 / 36-7 not yet landed)
+
+Subscription/billing entities and the pricing source are NEW. Until they exist:
+- MRR/ARR/plan distribution compute from `Tenant.Plan` + `Plan.MonthlyPriceUsd` (every non-free,
+  non-deleted tenant counts as paying — coarse but real).
+- Churn, trial→paid conversion, net-new/churned MRR report `0`/`null`.
+- Margin reports `platformBilledUsd = 0`.
+Surface a `degradedMode: true` flag (+ list of missing sources) in the payload and a dashboard
+banner, so the owner knows numbers are partial rather than wrong. Wire the real sources behind the
+ports once 35/36-7 land — no endpoint contract change.
+
+## Logging Requirements
+
+- **INFO**: Business summary computed (`windowStart`, `windowEnd`, `mrrUsd`, `activeTenants`,
+  `durationMs`); margin computed (`windowStart`, `windowEnd`, `platformBilledUsd`,
+  `providerCostBasisUsd`, `grossMarginUsd`).
+- **DEBUG**: Cohort/window boundaries resolved; degraded-mode source list; plan-distribution row
+  counts.
+- **WARN**: Degraded mode active (missing Epic 35 / 36-7 source named); zero paying cohort for churn
+  (rate forced to 0); zero `trialsEnded` (conversion null).
+- **ERROR**: CP query failure; pricing-source read failure (margin endpoint).
+- **Structured context**: `{ windowStart, windowEnd, mode, degradedMode, durationMs }` where
+  applicable.
+- **Credential / leakage safety**: NEVER log per-tenant revenue keyed to a tenant id in a way that
+  could surface cross-tenant; business payloads are owner-only — keep them out of any tenant-scoped
+  log stream.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-36/story-36-11/36-11-analytics-event-catalog-backfill-and-reconciliation.md
+++ b/docs/stories/epic-36/story-36-11/36-11-analytics-event-catalog-backfill-and-reconciliation.md
@@ -1,0 +1,653 @@
+# Story 36-11: Analytics Event Catalog, Backfill & Reconciliation
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-phase workflow (Read → Research → Break Down → TDD →
+Quality Gates → Failure Handling), the `.dev/` knowledge base, TRACE/DEBUG logging
+requirements, test-first development, and the build-success / coverage gates.
+
+## User Story
+
+As a **platform operator** (SaaS) **/ self-hosted owner** (single-user),
+I want a typed, drift-guarded catalog of the DCB event fields the analytics projection depends on,
+an admin-only backfill that rebuilds the dimensional store from historical `domain_events` for a
+tenant + time-range, and an hourly reconciliation that compares the projected analytics totals
+against a live DCB aggregation and alerts on drift,
+So that upstream event-shape changes are caught at build time, existing tenants can be onboarded
+into analytics (and rollup outages recovered) without double-counting, and a silently divergent
+projection can never quietly mislead a dashboard, export, or scheduled report.
+
+## Priority
+
+P2 — The projection (Story 36-2) makes analytics *work*; this story makes it *trustworthy in
+production*. A drifted event shape, an un-backfilled tenant, or a silently lossy projection all
+produce confidently-wrong numbers — the failure mode this story exists to prevent. It hardens the
+substrate every downstream Epic 36 surface reads.
+
+## Scope
+
+Production-hardening of the Story 36-2 projection — **three** additions, no schema change to the
+Story 36-1 fact tables and **no** change to the projection's compute semantics:
+
+1. **A typed analytics event-field catalog** (`AnalyticsEventCatalog`) — the single declared
+   contract of which DCB event types feed the projection and which fields/tags each one
+   contributes to which dimension or measure (`LLM.CALL.SUCCESS → {costUsd, inputTokens,
+   outputTokens, provider, model}`, `AGENT.DISPATCH.* → {agent_id, status}`, `WORKFLOW.* → status`).
+   A **build-time/test-time drift guard** asserts the projection's expected field set matches the
+   catalog (and, where statically checkable, the emitting sites) so an upstream rename of `costUsd`
+   or a dropped `agent_id` tag fails a test instead of silently zeroing a column.
+
+2. **An admin backfill** (`BackfillTenantAnalyticsActivity` + `POST /api/admin/analytics/backfill`)
+   — rebuilds `analytics_usage_hourly`/`_daily` for a tenant + `[from, to)` UTC range from
+   historical `domain_events`, driving the **same** Story 36-2 `ComputeTenantDimensionalRollupActivity.ComputeAsync`
+   idempotent code path hour-by-hour, with an optional `resetCheckpoint`. Used for onboarding
+   tenants that pre-date analytics and for recovering from rollup outages. Replay-safe: re-running
+   a range converges (never duplicates) because the underlying upsert recomputes each bucket whole.
+
+3. **An hourly reconciliation** (`ReconcileAnalyticsActivity`) — per active tenant, compares the
+   **projected** per-tenant totals (sum of `analytics_usage_hourly` over a window) against a
+   **live DCB aggregation** of the same window's `domain_events` + `ProviderDiagnostic` rows, and
+   emits `ANALYTICS.RECONCILIATION.MISMATCH` (WARN) tagged `tenant_id` when they diverge beyond a
+   configured tolerance. This mirrors the Story 28-10 / Story 20-3 reconciliation pattern (the
+   `PlatformAnalyticsService` fact-table-vs-live fallback, and the 20-3 hourly local-vs-Stripe
+   compare). It wires into the existing `HourlyAnalyticsRollupWorkflow` as a final, best-effort
+   step alongside the 36-2 fan-out — one schedule, one advisory lock, one target hour.
+
+The Story 36-2 `ComputeTenantDimensionalRollupActivity`, `CompactDailyAnalyticsActivity`,
+`PurgeStaleUsageAnalyticsActivity`, the platform `platform_analytics_hourly` rollup (Story 28-10),
+and the Story 36-1 fact-table schema are all left **entirely intact** — this story reads them,
+reuses their compute path, and observes their output; it does not alter them.
+
+## Acceptance Criteria
+
+1. A new `AnalyticsEventCatalog`
+   (`apps/tamma-elsa/src/Tamma.Activities/Analytics/AnalyticsEventCatalog.cs`) declares, as data
+   (not branches), the **analytics-relevant DCB event types** and each one's dimensional/measure
+   mapping. At minimum it covers: `LLM.CALL.SUCCESS` → measures `costUsd`, `inputTokens`,
+   `outputTokens` + dimensions `provider`, `model`; `AGENT.DISPATCH.SUCCESS`/`AGENT.DISPATCH.FAILED`
+   (matched by the `AGENT.DISPATCH.%` prefix) → dimension `agent_id` + `status` (success/failed
+   measure); `WORKFLOW.*` → workflow `status` (started/completed/failed counts) + dimension
+   `workflowDefinitionId`; and the shared dimension tags `repoId`/`ProjectId`, `tenantId`, and
+   `billing_mode` (35-2, cost basis). Each catalog entry records the source location (event `Data`
+   JSON field vs `Tags` key vs `ProviderDiagnostic` column) so the mapping is unambiguous.
+
+2. A **drift guard** test asserts that the field set the Story 36-2 projection actually reads
+   (`ComputeTenantDimensionalRollupActivity` / its `AggregateLlmUsage` + cost-basis + dimension
+   extraction) matches the catalog exactly — every catalog field is consumed and every consumed
+   field is cataloged. Where the emitting site is statically inspectable in the same solution
+   (e.g. the `AGENT.DISPATCH.*`/`LLM.CALL.SUCCESS`/`WORKFLOW.*` constants in
+   `PlatformAnalyticsService` and `AlertEventEmitter`), the guard also asserts the catalog's event
+   **type strings** match those constants, so a rename of `LLM.CALL.SUCCESS` or
+   `AGENT.DISPATCH.SUCCESS` breaks the build/test rather than silently dropping a measure. Catalog
+   field-name and event-type strings are exposed as `const`/`static readonly` so 36-2 can consume
+   them as a single source of truth (a follow-up refactor; not required to retro-fit 36-2 in this
+   story, but the guard pins the equivalence).
+
+3. A new `BackfillTenantAnalyticsActivity`
+   (`apps/tamma-elsa/src/Tamma.Activities/Analytics/BackfillTenantAnalyticsActivity.cs`, extending
+   `Tamma.Activities.Core.TammaAsyncActivity`) rebuilds a single tenant's dimensional store for a
+   `[from, to)` UTC half-open range by truncating to top-of-hour and invoking
+   `ComputeTenantDimensionalRollupActivity.ComputeAsync` once per hour bucket in the range, in
+   ascending order. It exposes a static pure-DI `BackfillAsync(ITenantDbContextFactory, …,
+   IPlatformEventPublisher, tenantId, from, to, resetCheckpoint, logger, ct)` entry point so the
+   endpoint, the platform task worker, and unit tests drive the identical code path without an
+   `ActivityExecutionContext` — mirroring `ComputeTenantRollupActivity.ComputeAsync`.
+
+4. The backfill is **idempotent / replay-safe**: re-running the same `(tenantId, from, to)` range
+   converges to identical rows and measures (proven by a test running the range twice and asserting
+   row counts + summed measures unchanged), because each hour bucket recomputes whole via the
+   Story 36-2 read-then-upsert on the NULLS-NOT-DISTINCT dimension business key. `resetCheckpoint`
+   rewinds the per-tenant `analytics_projection_checkpoint` so a corrupt/partial prior run can be
+   re-derived; omitting it backfills only buckets whose events post-date the checkpoint (efficient
+   gap-fill). Either way the upsert guarantees no double-count.
+
+5. An **admin backfill endpoint** `POST /api/admin/analytics/backfill`
+   (`apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminAnalyticsEndpoints.cs`, gated `PlatformOwnerAccess`
+   at the wiring site, mirroring the existing 28-10 admin analytics endpoints) accepts
+   `{ tenantId, from, to, resetCheckpoint? }`, validates the range (`from < to`, range not
+   absurdly large — clamp to a configurable max span, default 400 days), enqueues a
+   `analytics.backfill` platform task (`IPlatformTaskHandler` pattern, Story 28-6) and returns
+   **`202 Accepted`** with a status URI — the long-running per-hour replay runs on the existing
+   `PlatformTaskWorker` thread, never inline on the request (mirrors the Cranl provision 202 +
+   `TaskQueueProcessor` shape). A `GET /api/admin/analytics/backfill/{id}` reports progress
+   (`pending → running → completed | failed`, with `hoursDone/hoursTotal`).
+
+6. Backfill **fans out per tenant via `ITenantDbContextFactory`** and reads **only** the target
+   tenant's schema: events come from that tenant's `TenantDbContext` (search-path schema) and rows
+   are written to that tenant's own `analytics_usage_*` tables. A backfill for tenant A never reads
+   or writes tenant B's schema (proven by an isolation test). Backfilling one tenant does not block
+   or affect any other tenant's live traffic or scheduled rollup.
+
+7. A new `ReconcileAnalyticsActivity`
+   (`apps/tamma-elsa/src/Tamma.Activities/Analytics/ReconcileAnalyticsActivity.cs`, extending
+   `TammaAsyncActivity`) computes, for one tenant over a reconciliation window (default the last
+   completed UTC day), the **projected totals** (sum of `analytics_usage_hourly` measures —
+   `TokensIn`, `TokensOut`, `CostUsd`, `WorkflowsStarted/Completed/Failed`, `AgentDispatches`) and a
+   **live DCB aggregation** of the same window straight from `domain_events` + `ProviderDiagnostic`
+   (reusing the Story 36-2 `AggregateLlmUsage`/dispatch-count/workflow-count helpers — the *same*
+   extraction the projection uses, but un-bucketed grand totals). It exposes a static pure-DI
+   `ReconcileAsync(...)` entry point.
+
+8. When the projected and live totals diverge **beyond a configured tolerance** (relative
+   tolerance `MissingConfig`-style config key `Analytics:Reconciliation:Tolerance`, default 0.5%,
+   plus an absolute floor so a 1-vs-2 token blip on a near-empty tenant does not page), the activity
+   emits `ANALYTICS.RECONCILIATION.MISMATCH` (severity **WARN**) tagged `tenant_id`, carrying
+   `{ window, measure, projected, live, deltaPct }` for each diverging measure; when totals match
+   within tolerance it emits `ANALYTICS.RECONCILIATION.OK` (or simply logs — no per-measure event
+   spam) so a clean reconcile is observable. New event constants land on `AnalyticsRollupEvents`.
+
+9. Reconciliation is wired into `HourlyAnalyticsRollupWorkflow` as a **best-effort final step**,
+   after the Story 36-2 dimensional fan-out + compaction and after `EmitHourCompleted`, sharing the
+   one schedule / one advisory lock / one target hour. It fans out per tenant with **per-tenant
+   failure isolation** (Story 28-10 AC5 shape): a reconcile failure or mismatch for tenant A emits
+   the tenant-scoped event and the fan-out continues to tenant B; it never aborts the workflow and
+   never blocks tenant traffic. A structure test asserts the new step is present and ordered after
+   the dimensional fan-out.
+
+10. **Checkpoint management** is explicit and shared: backfill and the live reconciliation read the
+    same per-tenant `analytics_projection_checkpoint` (Story 36-2) cursor by `SequenceNumber` (never
+    `Id`/`CreatedAt`). Reconciliation reports the checkpoint lag (highest `domain_events.SequenceNumber`
+    vs the checkpoint) in its event so an un-advancing projection is visible. `resetCheckpoint` on
+    backfill rewinds the cursor atomically with the first re-projected bucket; a backfill that
+    completes a contiguous range never leaves the checkpoint ahead of un-projected events.
+
+11. Reconciliation + backfill **never block tenant traffic and isolate per-tenant failures**;
+    every outcome (mismatch, match, backfill progress, per-tenant failure) is observable via
+    emitted DCB/platform events and structured logs. A `MISMATCH` is a WARN-level signal, not a
+    failure — it does not fail the rollup; the runbook/alert pipeline consumes it (a built-in alert
+    rule on `ANALYTICS.RECONCILIATION.MISMATCH` is in scope as a one-line `BuiltInAlertRules` spec
+    so a divergence pages without manual setup).
+
+12. **Tenant isolation preserved throughout**: backfill and reconciliation read and write **only**
+    the target tenant's schema via `ITenantDbContextFactory`; no cross-tenant query, no
+    `IgnoreQueryFilters()` over tenant data, no read of another tenant's `analytics_usage_*`. The
+    active-tenant *directory* read (to know which tenants to reconcile) is the only CP-context touch
+    and mirrors the existing `FanOutTenantRollupsActivity` target-set query.
+
+13. **Per-mode ownership is answered for both scoping models** (CLAUDE.md universal rule): in
+    single-user mode the backfill/reconciliation run over the sole tenant schema and the sole user
+    owns the result; in SaaS mode they fan out across all active tenants, the backfill endpoint is
+    `PlatformOwnerAccess` (a platform-operator recovery tool, never tenant-self-service), and
+    mismatch events carry `tenant_id` so they surface on the owning tenant's alert feed while the
+    backfill stays an operator concern. (Detailed table in Technical Design.)
+
+14. Unit + integration tests cover: the **drift guard** (catalog ↔ projection field equivalence;
+    a deliberately-renamed field fails the guard); **idempotent backfill** (re-run a range → identical
+    rows/measures; `resetCheckpoint` rewind + re-derive with no double-count); **reconciliation
+    match** (projected == live within tolerance → no MISMATCH) and **mismatch** (inject a divergent
+    projected row → `ANALYTICS.RECONCILIATION.MISMATCH` with correct `deltaPct`); **per-tenant
+    failure isolation** (a forced failure on tenant A leaves tenant B's backfill/reconcile intact
+    and the fan-out completes); **tenant isolation** (a row in schema A is invisible through schema
+    B); the **202 + status** endpoint flow and `PlatformOwnerAccess` RBAC (member/tenant → 403/404);
+    and the workflow structure (reconcile step present + ordered last).
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Analytics event catalog + drift guard (AC: 1, 2)
+  - [ ] Add `AnalyticsEventCatalog` declaring event types + per-event field/tag/column → dimension/
+        measure mapping as data; expose event-type and field-name constants.
+  - [ ] Drift-guard test asserting catalog ↔ 36-2 projection field equivalence and catalog
+        event-type strings == in-solution emit-site constants; a renamed field/type fails red.
+
+- [ ] Task 2: Backfill activity + idempotency (AC: 3, 4, 6, 10, 12)
+  - [ ] `BackfillTenantAnalyticsActivity` with static `BackfillAsync` driving
+        `ComputeTenantDimensionalRollupActivity.ComputeAsync` per hour bucket over `[from, to)`.
+  - [ ] `resetCheckpoint` rewind atomic with the first re-projected bucket; range truncation/validation.
+  - [ ] Unit test: re-run range → identical rows/measures; reset + re-derive no double-count;
+        per-tenant isolation (schema A vs B).
+
+- [ ] Task 3: Backfill endpoint + platform task (AC: 5, 13)
+  - [ ] `analytics.backfill` `IPlatformTaskHandler` (Story 28-6) running `BackfillAsync` off-thread.
+  - [ ] `POST /api/admin/analytics/backfill` (202 + status URI) + `GET …/backfill/{id}` progress;
+        wire under `PlatformOwnerAccess` in `Program.cs`; range validation + max-span clamp.
+  - [ ] Endpoint tests: 202 + status transitions; RBAC (owner ok, member/tenant 403/404); bad range 400.
+
+- [ ] Task 4: Reconciliation activity + tolerance (AC: 7, 8, 10, 11)
+  - [ ] `ReconcileAnalyticsActivity` + static `ReconcileAsync` — projected sum vs live DCB
+        aggregation (reuse 36-2 helpers); relative tolerance + absolute floor from config.
+  - [ ] Emit `ANALYTICS.RECONCILIATION.MISMATCH` (WARN, per diverging measure) / `…OK`; checkpoint-lag
+        reporting; new `AnalyticsRollupEvents` constants.
+  - [ ] Unit test: within-tolerance → no mismatch; injected divergence → mismatch with correct deltaPct.
+
+- [ ] Task 5: Fan-out + workflow wiring (AC: 9, 11, 12)
+  - [ ] Per-tenant reconcile fan-out (mirror `FanOutTenantRollupsActivity` try/catch tolerance).
+  - [ ] Wire the reconcile step into `HourlyAnalyticsRollupWorkflow` after the 36-2 fan-out +
+        `EmitHourCompleted`, best-effort; structure test for presence + ordering.
+
+- [ ] Task 6: Built-in alert rule + tests (AC: 11, 14)
+  - [ ] `analytics-reconciliation-mismatch` spec in `BuiltInAlertRules.All` (warning,
+        `ANALYTICS.RECONCILIATION.MISMATCH`, throttled); seeder picks it up idempotently.
+  - [ ] Integration: per-tenant isolation (Postgres 17 Testcontainer) for backfill + reconcile.
+
+## Technical Design
+
+### C# namespace / file structure
+
+```
+apps/tamma-elsa/src/
+  Tamma.Activities/Analytics/
+    AnalyticsEventCatalog.cs                 # NEW — typed event-type → dimension/measure contract
+    BackfillTenantAnalyticsActivity.cs       # NEW — per-tenant per-hour backfill driver
+    ReconcileAnalyticsActivity.cs            # NEW — projected-vs-live compare + mismatch emit
+    FanOutTenantReconcileActivity.cs         # NEW — per-tenant reconcile fan-out (28-10 shape)
+    AnalyticsRollupEvents.cs                 # MODIFY — + RECONCILIATION.MISMATCH / .OK / BACKFILL.* constants
+    ComputeTenantDimensionalRollupActivity.cs # READ — ComputeAsync (36-2) reused per backfill hour
+  Tamma.Api/Endpoints/
+    AdminAnalyticsEndpoints.cs               # MODIFY — + Backfill (POST 202) + GetBackfillStatus (GET)
+  Tamma.Api/Services/Analytics/
+    AnalyticsBackfillTaskHandler.cs          # NEW — IPlatformTaskHandler ("analytics.backfill")
+    IAnalyticsBackfillStatusStore.cs / *.cs  # NEW — backfill job status (pending/running/completed/failed + progress)
+  Tamma.Api/Services/Alerts/Rules/
+    BuiltInAlertRules.cs                     # MODIFY — + analytics-reconciliation-mismatch spec
+  Tamma.Api/Program.cs                        # MODIFY — map backfill endpoints (PlatformOwnerAccess); register task handler
+  Tamma.Data/Entities/
+    DomainEvent.cs                           # READ — Type, Tags, Data, SequenceNumber
+    ProviderDiagnostic.cs                    # READ — ProviderKey, Input/OutputTokens, Cost, AgentType, ProjectId, (BillingMode 35-2)
+    AnalyticsUsageHourly.cs                  # READ — 36-1 fact table (projected totals source)
+    AnalyticsProjectionCheckpoint.cs         # READ — 36-2 per-tenant SequenceNumber cursor
+  Tamma.ElsaServer/Workflows/
+    HourlyAnalyticsRollupWorkflow.cs         # MODIFY — + reconcile fan-out step (final, best-effort)
+
+apps/tamma-elsa/tests/
+  Tamma.Activities.Tests/Analytics/
+    AnalyticsEventCatalogDriftTests.cs       # NEW — catalog ↔ projection ↔ emit-site equivalence
+    BackfillTenantAnalyticsTests.cs          # NEW — idempotent re-run / resetCheckpoint / no double-count
+    ReconcileAnalyticsTests.cs               # NEW — match (no mismatch) / divergence (deltaPct) / tolerance
+    HourlyAnalyticsRollupWorkflowStructureTests.cs # MODIFY — assert reconcile step present + ordered last
+    AnalyticsRollupEventsTests.cs            # MODIFY — new RECONCILIATION/BACKFILL constants
+  Tamma.Api.Tests/Analytics/
+    AnalyticsBackfillEndpointTests.cs        # NEW — 202 + status flow + PlatformOwnerAccess RBAC + bad-range 400
+    AnalyticsBackfillReconcileIsolationTests.cs # NEW — Postgres 17 Testcontainer: per-tenant isolation
+```
+
+### Event-field catalog (the contract being locked down)
+
+Verified against the live emit sites and the Story 36-2 projection:
+
+| Event type (string) | Source field | Maps to | Source location |
+|---|---|---|---|
+| `LLM.CALL.SUCCESS` | `costUsd`, `inputTokens`, `outputTokens` | measures `CostUsd`, `TokensIn`, `TokensOut` | event `Data` JSON (Story 9-2) |
+| `LLM.CALL.SUCCESS` | `provider`, `model` | dimensions `Provider`, (model attr) | event `Tags` / `Data` |
+| `AGENT.DISPATCH.SUCCESS` / `AGENT.DISPATCH.FAILED` (prefix `AGENT.DISPATCH.%`) | `agent_id`, status | dimension `AgentId`, `AgentDispatches` measure | event `Tags` (Epic 32) + `Type` |
+| `WORKFLOW.*` (via `workflow_instances.Status`) | `started`/`completed`/`failed` | `WorkflowsStarted/Completed/Failed` | `WorkflowInstance.Status` |
+| (shared dimension) | `repoId` / `ProjectId` | dimension `RepoId` | event `Tags` / `ProviderDiagnostic.ProjectId` |
+| (shared dimension) | `billing_mode` | `CostBasis` (byok/platform) | event `Tags` (35-2) / `ProviderDiagnostic.BillingMode` |
+| (provider diagnostics) | `ProviderKey`, `InputTokens`, `OutputTokens`, `Cost`, `AgentType` | measures + dims | `ProviderDiagnostic` columns |
+
+The catalog encodes this table as `static readonly` data. The drift guard test reflects over what
+`ComputeTenantDimensionalRollupActivity` reads and asserts set-equality with the catalog, and
+asserts the catalog's event-type strings equal the in-solution constants
+(`PlatformAnalyticsService.LlmCallSuccess` / `AgentDispatchPrefix` / `AgentDispatchSuccess` /
+`AgentDispatchFailed`, `ComputeTenantRollupActivity`'s `"completed"`/`"failed"` status literals).
+A rename anywhere flips the guard red.
+
+### Backfill (per-hour replay over the 36-2 code path)
+
+```csharp
+// Drive the SAME idempotent compute the hourly rollup uses, one bucket at a time.
+public static async Task BackfillAsync(
+    IDbContextFactory<ControlPlaneDbContext> cpFactory,
+    ITenantDbContextFactory tenantFactory,
+    IPlatformEventPublisher publisher,
+    IAnalyticsPricingConfig pricing,                // 36-2 seam
+    Guid tenantId, DateTime from, DateTime to, bool resetCheckpoint,
+    IProgress<(int done, int total)>? progress,
+    ILogger? logger, CancellationToken ct)
+{
+    from = AnalyticsRollupEvents.TruncateToHour(from);
+    to   = AnalyticsRollupEvents.TruncateToHour(to);          // half-open [from, to)
+    if (from >= to) throw new ArgumentException("from must precede to");
+
+    if (resetCheckpoint)
+        await RewindCheckpointAsync(tenantFactory, tenantId, from, ct).ConfigureAwait(false);
+
+    var total = (int)(to - from).TotalHours;
+    var done = 0;
+    for (var hour = from; hour < to; hour = hour.AddHours(1))
+    {
+        ct.ThrowIfCancellationRequested();
+        await ComputeTenantDimensionalRollupActivity.ComputeAsync(   // 36-2 — idempotent upsert
+            cpFactory, tenantFactory, publisher, pricing, tenantId, hour, logger, ct)
+            .ConfigureAwait(false);
+        progress?.Report((++done, total));
+    }
+    await publisher.AppendAndPublishAsync(
+        AnalyticsRollupEvents.BuildEvent(AnalyticsRollupEvents.BackfillCompleted, to, tenantId,
+            data: new() { ["from"] = from.ToString("O"), ["to"] = to.ToString("O"),
+                          ["hours"] = total, ["resetCheckpoint"] = resetCheckpoint }),
+        ct).ConfigureAwait(false);
+}
+```
+
+Idempotency comes for free from 36-2's whole-bucket read-then-upsert on the NULLS-NOT-DISTINCT
+business key — backfilling an already-projected bucket overwrites it with the same values.
+`resetCheckpoint` only matters for the *efficiency* cursor; the upsert is the correctness mechanism
+(same design rationale as 36-2 Dev Notes).
+
+### Backfill control surface (202 + off-thread)
+
+`POST /api/admin/analytics/backfill` validates `{ tenantId, from, to, resetCheckpoint? }`, clamps
+the span (default max 400 days), persists a backfill-status row (`pending`), enqueues an
+`analytics.backfill` platform task, and returns `202 Accepted` with `Location:
+/api/admin/analytics/backfill/{id}`. The `AnalyticsBackfillTaskHandler` (`IPlatformTaskHandler`,
+Story 28-6) deserializes the payload, flips status `running`, calls `BackfillAsync` reporting
+`(done,total)` into the status store, and flips `completed`/`failed`. This is the exact 202 +
+`PlatformTaskWorker`/`TaskQueueProcessor` shape the Cranl provision endpoints use — the request
+never blocks on the per-hour replay.
+
+### Reconciliation (projected vs live — the 28-10 / 20-3 pattern)
+
+```csharp
+public static async Task ReconcileAsync(
+    IDbContextFactory<ControlPlaneDbContext> cpFactory,
+    ITenantDbContextFactory tenantFactory,
+    IPlatformEventPublisher publisher,
+    AnalyticsReconciliationOptions opts,            // tolerance + absolute floor
+    Guid tenantId, DateTime windowStart, DateTime windowEnd,
+    ILogger? logger, CancellationToken ct)
+{
+    await using var db = await tenantFactory.CreateAsync(tenantId, ct).ConfigureAwait(false);
+
+    // PROJECTED — sum the dimensional fact table over the window.
+    var projected = await db.AnalyticsUsageHourly.AsNoTracking()
+        .Where(r => r.Hour >= windowStart && r.Hour < windowEnd)
+        .GroupBy(_ => 1)
+        .Select(g => new Totals {
+            CostUsd = g.Sum(r => r.CostUsd), TokensIn = g.Sum(r => r.TokensIn), /* … */ })
+        .FirstOrDefaultAsync(ct).ConfigureAwait(false) ?? Totals.Zero;
+
+    // LIVE — recompute grand totals straight from domain_events + diagnostics,
+    // reusing the EXACT 36-2 extraction helpers (un-bucketed).
+    var live = await ComputeLiveTotalsAsync(db, windowStart, windowEnd, ct).ConfigureAwait(false);
+
+    foreach (var m in Totals.Measures)             // costUsd, tokensIn/out, workflows*, dispatches
+    {
+        var (p, l) = (projected[m], live[m]);
+        if (Diverges(p, l, opts.RelativeTolerance, opts.AbsoluteFloor))
+            await publisher.AppendAndPublishAsync(
+                AnalyticsRollupEvents.BuildEvent(AnalyticsRollupEvents.ReconciliationMismatch,
+                    windowStart, tenantId,
+                    data: new() { ["measure"] = m, ["projected"] = p, ["live"] = l,
+                                  ["deltaPct"] = DeltaPct(p, l), ["window"] = windowStart.ToString("O"),
+                                  ["checkpointLag"] = await CheckpointLagAsync(db, ct) }),
+                ct).ConfigureAwait(false);
+    }
+}
+```
+
+`ComputeLiveTotalsAsync` reuses `ComputeTenantRollupActivity.AggregateLlmUsage`, the
+`AGENT.DISPATCH.%` `EF.Functions.Like` count, and the `WorkflowInstance.Status` counts — the same
+reads the projection performs, so a mismatch means the *projection* drifted (stale rows, a missed
+checkpoint advance, a dropped fan-out), not a different counting rule. This is the in-process twin
+of `PlatformAnalyticsService`'s fact-table-vs-live fallback (Story 28-10) and Story 20-3's hourly
+local-vs-Stripe compare.
+
+### Workflow wiring
+
+```
+HourlyAnalyticsRollupWorkflow.Build (MODIFY) — Sequence:
+  initBucket
+  platformRollup        (ComputePlatformRollupActivity)            — unchanged (28-10)
+  fanOut                (FanOutTenantRollupsActivity)               — unchanged (28-10)
+  fanOutDimensional     (FanOutTenantDimensionalRollupsActivity)    — 36-2
+  compactDaily          (CompactDailyAnalyticsActivity)            — 36-2
+  emitCompleted         (EmitHourCompletedActivity)                 — unchanged
+  purgeStale            (PurgeStaleAnalyticsActivity)              — unchanged (28-10)
+  purgeUsageStale       (PurgeStaleUsageAnalyticsActivity)         — 36-2
+  fanOutReconcile       (FanOutTenantReconcileActivity)            — NEW (this story, final, best-effort)
+```
+
+Reconcile runs **last** so it observes the freshly-written buckets, and is best-effort: a reconcile
+failure (or a flood of mismatches) never fails a rollup that already wrote useful rows. One
+schedule, one advisory lock, one target hour — reconciliation is one more consumer of the same
+fan-out, exactly like the 36-2 dimensional rollup.
+
+### DCB events (new — owned by this story)
+
+| Event | When | Key data |
+|---|---|---|
+| `ANALYTICS.RECONCILIATION.MISMATCH` | per tenant×measure when divergence > tolerance (WARN) | measure, projected, live, deltaPct, window, checkpointLag |
+| `ANALYTICS.RECONCILIATION.OK` | per tenant×window when all measures within tolerance | window, checkpointLag |
+| `ANALYTICS.BACKFILL.STARTED` / `…COMPLETED` / `…FAILED` | per backfill job | tenantId, from, to, hours, resetCheckpoint, (errorType/message) |
+
+Per-tenant events carry `tenantId` (Story 28-6 step-dedup index applies) and append via
+`IPlatformEventPublisher.AppendAndPublishAsync` (best-effort, same as the 28-10/36-2 path).
+
+### Built-in alert rule
+
+One additive spec in `BuiltInAlertRules.All`: `analytics-reconciliation-mismatch` (severity
+warning, `EventType = ANALYTICS.RECONCILIATION.MISMATCH`, predicate `{"op":"always"}`,
+`ThrottleSeconds` 3600 so a persistent drift pages once an hour, not once per tenant×measure).
+The idempotent `BuiltInAlertRuleSeeder` picks it up by `built_in_key`; ships with empty `ChannelIds`
+(no auto-spam) per existing convention.
+
+### Per-mode + per-tenant handling
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| What does the fan-out reconcile? | The sole tenant (one schema). | All active tenants from the CP directory (28-10 target set). |
+| Who triggers a backfill? | The sole user (owner of their instance). | Platform operator only — `POST /api/admin/analytics/backfill` is `PlatformOwnerAccess`; never tenant self-service (recovery/onboarding is an operator concern). |
+| Who owns a mismatch? | The sole user — it's their instance/feed (`tenant_id` = their tenant). | The tenant — `ANALYTICS.RECONCILIATION.MISMATCH` carries `tenant_id` → tenant alert feed; the alert rule routes per `AlertPayload.TenantId`. |
+| Isolation plane | Search-path schema + connection string. | Same — physically separate schema per tenant; backfill/reconcile of A is unreachable from B. |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`) — process-stable. | same |
+
+Mode does not change the backfill/reconcile shape — both resolve to exactly one tenant schema per
+unit of work; only the fan-out target-set size and the endpoint's effective audience differ.
+
+### API shape
+
+```
+POST /api/admin/analytics/backfill          (PlatformOwnerAccess; body { tenantId, from, to, resetCheckpoint? }) → 202 + Location
+GET  /api/admin/analytics/backfill/{id}     (PlatformOwnerAccess) → { id, tenantId, from, to, status, hoursDone, hoursTotal }
+```
+
+Reconciliation has **no** HTTP endpoint — it is a scheduled best-effort workflow step; its output is
+DCB events + the built-in alert rule + structured logs. (Operators force a reconcile by running the
+hourly rollup with an explicit `hour`, the existing 28-10 control surface.)
+
+## Dependencies
+
+**Prerequisite (internal):**
+- **Story 36-2** — `ComputeTenantDimensionalRollupActivity.ComputeAsync` (the idempotent per-hour
+  compute backfill replays), `AnalyticsProjectionCheckpoint` (the cursor checkpoint management
+  reads/rewinds), `AnalyticsRollupEvents` (extended here), `IAnalyticsPricingConfig`, and the
+  `HourlyAnalyticsRollupWorkflow` fan-out this story appends to. (Drafted.)
+- **Story 36-1** — `AnalyticsUsageHourly`/`AnalyticsUsageDaily` fact tables + `CostBasis` enum +
+  `UX_*_dims` NULLS-NOT-DISTINCT business-key indexes (the projected-totals source + the backfill
+  upsert backstop). (Drafted.)
+- **Story 28-10** — `FanOutTenantRollupsActivity` (the per-tenant fan-out + 5%-tolerance shape
+  mirrored here), `ComputeTenantRollupActivity.AggregateLlmUsage`/dispatch/workflow helpers (reused
+  for the live-totals path), `PlatformAnalyticsService` fact-table-vs-live fallback (the
+  reconciliation pattern reference), `AnalyticsRollupEvents`. (Merged.)
+- **Story 20-3** — the hourly local-vs-source reconciliation + `RECONCILIATION_MISMATCH` (WARN)
+  pattern this story mirrors for the analytics substrate. (Reference.)
+- **Story 28-6** — `IPlatformTaskHandler` / `PlatformTaskWorker` / `PlatformQueuedTask` (the
+  off-thread 202 backfill execution + step-dedup index). (Merged.)
+- **Epic 4 (DCB `DomainEvent`)** — the per-tenant event stream (`LLM.CALL.SUCCESS`,
+  `AGENT.DISPATCH.*`, `WORKFLOW.*`) + the `SequenceNumber` total-order cursor the catalog
+  documents, the backfill replays, and the reconciliation aggregates live. (In place.)
+- **Epic 28** — per-tenant schema + `ITenantDbContextFactory` (the isolation plane). (Merged.)
+
+**Soft / forward (degrade gracefully if absent):**
+- **Story 35-2 (Epic 35)** — `billing_mode` tag / `ProviderDiagnostic.BillingMode` (cost basis). If
+  absent, the catalog documents the `platform` default and reconciliation compares like-for-like
+  (projection and live both default to `platform`), so a missing 35-2 never produces a false
+  mismatch. (`BillingMode` is **not** yet on `ProviderDiagnostic` in this codebase — catalog marks
+  it forward.)
+- **Story 5.6 alert pipeline** — the built-in `analytics-reconciliation-mismatch` rule + delivery
+  channels. If unwired, mismatch events still land in the DCB store + logs; the rule just adds
+  zero-config paging once a channel is linked. (Merged for write side.)
+
+**Blocks (internal):**
+- Production rollout of Epic 36 dashboards/exports/reports for **existing** tenants (which need a
+  backfill before their charts have history) and the trust guarantee that those surfaces aren't
+  silently wrong (reconciliation).
+
+**External:**
+- PostgreSQL 17 (NULLS NOT DISTINCT upsert backstop via 36-2; per-tenant schema).
+- EF Core 9 / Npgsql.
+- Testcontainers + Docker for the isolation integration suite (run via `sg docker -c "dotnet test …"`).
+
+## Testing Strategy
+
+1. **Unit — drift guard (`AnalyticsEventCatalogDriftTests`):** assert the catalog field set equals
+   the set the 36-2 projection reads (every catalog field consumed; every consumed field cataloged);
+   assert catalog event-type strings equal the in-solution emit-site constants; a test that mutates
+   a copy of the catalog (renamed field / dropped type) fails the equivalence — proving the guard bites.
+
+2. **Unit — idempotent backfill (`BackfillTenantAnalyticsTests`, EF InMemory for the loop shape):**
+   backfill a 6-hour range → N rows; re-run the same range → identical row count + summed measures;
+   `resetCheckpoint=true` rewinds the cursor and re-derives without double-counting; `from >= to` → throws.
+
+3. **Unit — reconciliation match/mismatch (`ReconcileAnalyticsTests`):** projected == live within
+   tolerance → no `MISMATCH` event (optionally `…OK`); inject a divergent `analytics_usage_hourly`
+   row → `ANALYTICS.RECONCILIATION.MISMATCH` with correct `measure`/`projected`/`live`/`deltaPct`;
+   sub-floor divergence on a near-empty tenant → no event (absolute floor); tolerance is config-driven.
+
+4. **Unit — checkpoint management:** reconciliation reports `checkpointLag` = max `SequenceNumber` −
+   checkpoint; backfill `resetCheckpoint` rewind is atomic with the first re-projected bucket.
+
+5. **Integration — per-tenant isolation (`AnalyticsBackfillReconcileIsolationTests`, Postgres 17
+   Testcontainer):** backfill into schema A; a row in A's `analytics_usage_hourly` is invisible
+   through schema B; a forced failure backfilling/reconciling tenant A leaves tenant B intact and
+   the fan-out completes (28-10 AC5 tolerance).
+
+6. **Integration/endpoint — backfill control surface (`AnalyticsBackfillEndpointTests`):**
+   `POST …/backfill` returns 202 + `Location`; the enqueued task drives status `pending → running →
+   completed`; `GET …/backfill/{id}` reflects progress; `PlatformOwnerAccess` RBAC (platform owner
+   200; tenant member 403; cross-tenant/non-owner 403/404); `from >= to` or over-span → 400.
+
+7. **Unit — workflow structure (`HourlyAnalyticsRollupWorkflowStructureTests`, extended):** the
+   reconcile fan-out step is present and ordered after the 36-2 dimensional fan-out + `EmitHourCompleted`;
+   the platform + dimensional steps are unchanged.
+
+8. **Unit — alert rule seeding (extend `BuiltInAlertRules` tests):** the seeder creates
+   `analytics-reconciliation-mismatch`; the evaluator fires on an appended
+   `ANALYTICS.RECONCILIATION.MISMATCH`; throttle suppresses a burst.
+
+**Mocks:** No external provider/Stripe calls (read-only aggregation + replay). EF InMemory for the
+backfill-loop / reconciliation-math / catalog shape; a real Postgres 17 Testcontainer for per-tenant
+isolation + NULLS-NOT-DISTINCT upsert convergence (EF InMemory honours neither the unique-NULL
+collapse nor `ExecuteDeleteAsync` semantics — same rationale as 36-2 / `ConventionStoreMigrationTests`).
+
+## Estimated Effort
+
+3-4 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Activities/Analytics/AnalyticsEventCatalog.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/Analytics/BackfillTenantAnalyticsActivity.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/Analytics/ReconcileAnalyticsActivity.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/Analytics/FanOutTenantReconcileActivity.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/Analytics/AnalyticsRollupEvents.cs` | Modify (add RECONCILIATION/BACKFILL event constants) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminAnalyticsEndpoints.cs` | Modify (add Backfill POST 202 + GetBackfillStatus) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/AnalyticsBackfillTaskHandler.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/IAnalyticsBackfillStatusStore.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/AnalyticsBackfillStatusStore.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Alerts/Rules/BuiltInAlertRules.cs` | Modify (add analytics-reconciliation-mismatch spec) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map backfill endpoints PlatformOwnerAccess; register task handler) |
+| `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/HourlyAnalyticsRollupWorkflow.cs` | Modify (add reconcile fan-out step) |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/AnalyticsEventCatalogDriftTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/BackfillTenantAnalyticsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/ReconcileAnalyticsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/HourlyAnalyticsRollupWorkflowStructureTests.cs` | Modify (assert reconcile step present + ordering) |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/AnalyticsRollupEventsTests.cs` | Modify (new event constants) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/AnalyticsBackfillEndpointTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/AnalyticsBackfillReconcileIsolationTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, decisions (analytics, rollup, reconciliation,
+   tenancy, event sourcing, backfill).
+3. Reviewed Story 36-2 (`ComputeTenantDimensionalRollupActivity.ComputeAsync`,
+   `AnalyticsProjectionCheckpoint`, `AnalyticsRollupEvents`, `HourlyAnalyticsRollupWorkflow`) and
+   Story 28-10 (`FanOutTenantRollupsActivity` tolerance shape, `AggregateLlmUsage`,
+   `PlatformAnalyticsService` fact-table-vs-live fallback) — this story is a near-verbatim
+   extension/observation of those shapes.
+4. Reviewed Story 20-3 reconciliation (hourly local-vs-source compare, `RECONCILIATION_MISMATCH`
+   WARN) and Story 28-6 platform task queue (the 202 + `PlatformTaskWorker` off-thread pattern).
+5. Confirmed the test runner: docker-bound suites run via `sg docker -c "dotnet test …"` (the build
+   itself needs no wrapper).
+6. Planned the TDD cycle (drift guard + idempotency + match/mismatch tests red first, then activities).
+
+### Key Design Decisions
+
+- **The catalog is the single source of truth, the guard is the enforcement.** Rather than scatter
+  field-name string literals across emit and read sites, the catalog declares them once and a test
+  fails the build when read-site, catalog, and (in-solution) emit-site disagree. This is the
+  cheapest possible defence against the "someone renamed `costUsd` and the cost column silently went
+  to zero" failure — exactly the production-trust gap this story exists to close.
+- **Backfill reuses the projection, never forks it.** `BackfillAsync` is a thin loop over
+  `ComputeTenantDimensionalRollupActivity.ComputeAsync` — one bucket per hour. Backfill and the
+  hourly rollup are literally the same compute on different hours, so they cannot diverge and
+  backfill inherits 36-2's idempotency (whole-bucket overwrite) for free. The only backfill-specific
+  logic is range iteration + `resetCheckpoint` rewind.
+- **Idempotency is the upsert, not the checkpoint.** Re-running a range converges because each
+  bucket recomputes whole and overwrites; the checkpoint is an efficiency cursor (skip already-folded
+  events), so a checkpoint bug can re-fold without corrupting totals. `resetCheckpoint` is a deliberate
+  rewind for full re-derivation, not a correctness crutch.
+- **Reconciliation compares the projection to its own source via the same helpers.** `ReconcileAsync`
+  recomputes live grand totals with the *exact* `AggregateLlmUsage`/dispatch/workflow extraction the
+  projection uses — so any non-zero delta means the projection (not the counting rule) drifted: stale
+  rows, a missed checkpoint advance, a skipped fan-out tenant. This is the in-process analogue of the
+  28-10 fact-table-vs-live fallback and the 20-3 local-vs-Stripe compare.
+- **Mismatch is a signal, not a failure.** A `RECONCILIATION.MISMATCH` is WARN — it never fails the
+  rollup; the alert rule + runbook consume it. Tolerance (relative + absolute floor) keeps a 1-token
+  rounding blip on a near-empty tenant from paging, while a 5% drift on a busy tenant fires.
+- **Backfill runs off-thread (202).** A multi-month backfill over a busy tenant's event stream can
+  take minutes; running it inline on the admin request would hold a connection and time out. The
+  Story 28-6 platform task worker pattern (same as Cranl provision) keeps the request a 202 with a
+  pollable status — never blocking tenant traffic (AC11).
+- **Per-tenant failure isolation everywhere.** Both the reconcile fan-out and the backfill
+  per-hour/per-tenant loops mirror `FanOutTenantRollupsActivity`: catch, emit the tenant-scoped
+  `…_FAILED`/`MISMATCH`, continue. One bad tenant never aborts the sweep.
+
+### Hardening-only boundary
+
+This story adds **no** schema change to the Story 36-1 fact tables, **no** change to the Story 36-2
+projection compute (it *reuses* `ComputeAsync` unchanged), and **no** new tenant-facing dashboard
+surface. It does **not** touch the control-plane `platform_analytics_hourly` rollup or its purge.
+Any PR that alters the 36-1/36-2 schema or projection semantics under cover of this story is out of
+scope — keep the diff to the catalog, the backfill activity/endpoint/task, the reconciliation
+activity + fan-out, the workflow wiring, the one alert rule, and tests.
+
+## Logging Requirements
+
+- **INFO**: backfill started (`tenantId`, from, to, hours, resetCheckpoint); backfill progress
+  (`tenantId`, hoursDone, hoursTotal) at a throttled cadence; backfill completed (`tenantId`, hours);
+  reconcile fan-out start (`window`, tenantCount); per-tenant reconcile OK (`tenantId`, window,
+  checkpointLag); reconcile fan-out completed (`ok`, `mismatched`, `failed`).
+- **DEBUG**: per-hour bucket replay (`tenantId`, hour); per-measure projected-vs-live values; cursor
+  read/rewind (`from`, `to` SequenceNumber).
+- **WARN**: reconciliation mismatch (`tenantId`, measure, projected, live, deltaPct, window) — does
+  not fail the rollup; checkpoint lag over a configured threshold; per-tenant backfill/reconcile
+  failed (`tenantId`, errorType) — fan-out continues; 35-2 `billing_mode` absent → cost-basis defaults
+  to platform (informational, once per run).
+- **ERROR**: backfill aborted by host shutdown/cancellation (re-thrown `OperationCanceledException`);
+  backfill task moved to dead-letter (malformed payload, unknown tenant — `PlatformTaskTerminalException`).
+- **Structured context**: include `{ tenantId, from, to, hour, hoursDone, hoursTotal, measure,
+  projected, live, deltaPct, checkpointLag }` where applicable.
+- **Credential safety**: NEVER log tenant connection strings, search-path schema secrets, or provider
+  API keys; per-tenant exception messages surfaced into `…_FAILED`/`MISMATCH` events must not carry
+  connection strings (the activities read only tenant DB data — same guarantee as
+  `FanOutTenantRollupsActivity`/36-2). The reconciliation reads only the `billing_mode` discriminator,
+  never raw provider-key plaintext.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-36/story-36-2/36-2-dcb-to-analytics-projection-pipeline.md
+++ b/docs/stories/epic-36/story-36-2/36-2-dcb-to-analytics-projection-pipeline.md
@@ -1,0 +1,581 @@
+# Story 36-2: DCB-to-Analytics Projection Pipeline (Dimensional Rollup)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-phase workflow (Read → Research → Break Down → TDD →
+Quality Gates → Failure Handling), the `.dev/` knowledge base, TRACE/DEBUG logging
+requirements, test-first development, and the build-success / coverage gates.
+
+## User Story
+
+As a **tenant administrator** (SaaS) **/ self-hosted owner** (single-user),
+I want my per-tenant DCB event stream (`LLM.CALL.SUCCESS`, `AGENT.DISPATCH.*`, `WORKFLOW.*`) and
+`ProviderDiagnostic` rows projected, every hour, into the dimensional fact tables from Story 36-1
+— broken down by provider, agent, workflow definition, repo, and a BYOK-vs-platform cost basis —
+so that every Epic 36 dashboard, export, and scheduled report reads pre-aggregated,
+multi-dimensional facts instead of re-scanning the raw event stream, and the projection is
+idempotent, resumable, and per-tenant isolated.
+
+## Priority
+
+P0 — The schema (Story 36-1) is inert until something populates it. Every downstream Epic 36
+surface (query API, exports, scheduled reports) reads `analytics_usage_hourly` /
+`analytics_usage_daily`; nothing renders a tenant chart until this projection fills them.
+
+## Scope
+
+Population pipeline **only** — this story writes the Story 36-1 tables; it does **not** alter
+their schema. It **extends, does not replace,** the existing Story 28-10
+`HourlyAnalyticsRollupWorkflow`: the new per-tenant dimensional rollup runs as an additional fan-out
+step **alongside** the existing platform fact-table rollup, sharing the same idempotent-upsert +
+replay-safe + per-tenant-failure-tolerant shape. Concretely it adds:
+
+- a `ComputeTenantDimensionalRollupActivity` that aggregates one tenant's hour of
+  `domain_events` + `ProviderDiagnostic` rows into `analytics_usage_hourly` rows, one per
+  `(Provider, AgentId, WorkflowDefinitionId, RepoId, CostBasis)` tuple;
+- a `CompactDailyAnalyticsActivity` that rolls `analytics_usage_hourly` up into
+  `analytics_usage_daily` (a lossless `GROUP BY`) and a hourly-retention purge mirroring
+  `PurgeStaleAnalyticsActivity`;
+- a `SequenceNumber` checkpoint per tenant so the projection is resumable and a re-run never
+  double-counts;
+- backfill support (drive an arbitrary historical `hour` through the same code path).
+
+The control-plane `platform_analytics_hourly` rollup (Story 28-10) and its purge are left
+**entirely intact** — the platform fact table and the per-tenant dimensional store are two
+different consumers of the same fan-out.
+
+## Acceptance Criteria
+
+1. A new `ComputeTenantDimensionalRollupActivity`
+   (`apps/tamma-elsa/src/Tamma.Activities/Analytics/ComputeTenantDimensionalRollupActivity.cs`,
+   extending `Tamma.Activities.Core.TammaAsyncActivity`) reads one tenant's `domain_events` (via
+   `ITenantDbContextFactory.CreateAsync`) and `ProviderDiagnostic` rows for a single UTC
+   top-of-hour bucket and **emits one `AnalyticsUsageHourly` row per
+   `(Provider, AgentId, WorkflowDefinitionId, RepoId, CostBasis)` tuple**, with summed measures
+   `TokensIn`, `TokensOut`, `CostUsd`, `PlatformBilledUsd`, `WorkflowsStarted`,
+   `WorkflowsCompleted`, `WorkflowsFailed`, `AgentDispatches`. It exposes a static pure-DI
+   `ComputeAsync(...)` entry point (taking `ITenantDbContextFactory`, `ITenantDbContextFactory`-
+   resolved write context, `IPlatformEventPublisher`, `tenantId`, `hour`, pricing config, logger,
+   `CancellationToken`) so the fan-out, the backfill endpoint, and unit tests drive the same code
+   without an `ActivityExecutionContext` — mirroring `ComputeTenantRollupActivity.ComputeAsync`.
+
+2. The **provider** dimension is read from each usage row's provider key (`ProviderDiagnostic.ProviderKey`
+   for diagnostic-sourced measures; the `provider` field on the `LLM.CALL.SUCCESS` data/`Tags` for
+   event-sourced measures). The **workflow** dimension is read from the `WORKFLOW.*` event's
+   workflow-definition id (and the `workflowDefinitionId` tag on LLM/agent events when present);
+   the **repo** dimension from the `repoId`/`ProjectId` tag. Rows whose dimension value is absent
+   bucket under that dimension `= NULL` so totals still reconcile — never dropped, never coerced
+   to a sentinel string.
+
+3. The **agent** dimension is read from the `agent_id` DCB tag (Epic 32 action trail) on each
+   event — and from `ProviderDiagnostic.AgentType` for diagnostic-sourced measures. Rows with no
+   agent tag bucket under `AgentId = NULL`, so a tenant's per-agent breakdown and its grand total
+   reconcile exactly (the `NULL` bucket is "unattributed", not lost).
+
+4. `CostBasis` is resolved **per usage record**: `byok` when the call ran against a tenant
+   BYOK key, else `platform`. The discriminator is read from the `billing_mode` tag on the
+   `LLM.CALL.SUCCESS`/`LLM.CALL.FAILED` event and from the `ProviderDiagnostic.BillingMode`
+   column — both produced by Story 35-2 / Epic 35 (`byok | platform`). When no `billing_mode` is
+   present (single-user mode, or events predating 35-2) the row defaults to `CostBasis.Platform`
+   for self-hosted/legacy and is documented as such; the resolution helper is a single pure
+   function so the rule is testable in isolation.
+
+5. For `platform`-basis rows the activity computes
+   `PlatformBilledUsd = CostUsd * (1 + margin)` using the pricing/margin config from Story 36-7
+   (consumed via an injected `IAnalyticsPricingConfig` seam — this story **does not own** the
+   margin math); `byok`-basis rows carry `PlatformBilledUsd = 0` (Tamma never marks up a BYOK
+   call). When the 36-7 config is unavailable the seam yields a zero margin and the activity logs
+   a WARN — it never hardcodes a margin and never fails the rollup.
+
+6. The rollup is **idempotent**: for each computed tuple the activity reads the existing
+   `analytics_usage_hourly` row on the full dimension business key
+   (`Hour, Provider, AgentId, WorkflowDefinitionId, RepoId, CostBasis`) and **upserts in place**
+   (read-then-update, with the Story 36-1 `UX_analytics_usage_hourly_dims` NULLS-NOT-DISTINCT
+   unique index as the concurrent-replay backstop) rather than inserting duplicates. A replay test
+   re-runs the same hour twice and asserts row counts and measures are unchanged.
+
+7. The projection is **resumable via a `SequenceNumber` checkpoint**: a per-tenant
+   `analytics_projection_checkpoint` row records the highest `DomainEvent.SequenceNumber` already
+   folded into the dimensional store. A run processes events with `SequenceNumber > checkpoint`
+   for buckets it owns and advances the checkpoint atomically with the upsert; a crash mid-run
+   re-processes only un-checkpointed events (which the idempotent upsert absorbs without
+   double-counting). `SequenceNumber` — not `Id` or `CreatedAt` — is the cursor (it is the
+   monotonic `BIGSERIAL` total-order column on `DomainEvent`, immune to same-millisecond ties).
+
+8. **Per-tenant isolation** is physical: each tenant's events are read through that tenant's
+   `TenantDbContext` (search-path schema, no cross-tenant query filter) and written to that
+   tenant's own `analytics_usage_*` tables. A tenant's projection never reads or writes another
+   tenant's schema; a fan-out failure or skip for tenant A leaves tenant B's rollup untouched
+   (proven by an isolation test).
+
+9. **Backfill support**: the dimensional rollup accepts an explicit historical `hour` input (the
+   same `hour` backfill input the Story 28-10 workflow already threads through `InitBucket`) and an
+   optional `resetCheckpoint` flag, so an operator can re-project an arbitrary past window
+   (e.g. after a schema/pricing fix) through the identical idempotent code path. Backfilling a
+   bucket that was already projected is a no-op on measures (idempotent upsert) and re-derives
+   `PlatformBilledUsd` from the current 36-7 margin.
+
+10. A new `CompactDailyAnalyticsActivity`
+    (`apps/tamma-elsa/src/Tamma.Activities/Analytics/CompactDailyAnalyticsActivity.cs`) rolls a
+    tenant's `analytics_usage_hourly` rows for a completed UTC day into `analytics_usage_daily` as
+    a lossless `GROUP BY date_trunc('day', Hour), <all dims>` with summed measures, upserting on
+    the daily `UX_analytics_usage_daily_dims` business key (idempotent, same read-then-upsert
+    shape). It runs once per day (when the rollup's target hour is the first hour of a new UTC
+    day, compacting the day that just ended) so no second scheduler is introduced.
+
+11. An hourly **retention purge** for `analytics_usage_hourly` mirrors
+    `PurgeStaleAnalyticsActivity`: it deletes per-tenant hourly rows older than the configured
+    retention window (default 13 months, Doc 04 §7) via `ExecuteDeleteAsync`, runs last (after the
+    fresh bucket and daily compaction are persisted), is best-effort (never rethrows a transient
+    failure into a rollup that already wrote useful rows), and emits a terminal purge event.
+    Daily rows retain on the longer daily-retention window (config-driven, default longer than
+    hourly).
+
+12. Per `tenant × hour`, the activity emits
+    `ANALYTICS.ROLLUP.TENANT_DIMENSIONAL_COMPLETED` on success and
+    `ANALYTICS.ROLLUP.TENANT_DIMENSIONAL_FAILED` on failure (new constants on
+    `AnalyticsRollupEvents`), carrying `{ hour, tenantId, rowsWritten, tuples, tokensIn, tokensOut,
+    costUsd, platformBilledUsd, checkpoint }` (success) or `{ hour, tenantId, errorType, message }`
+    (failure). **A single tenant's failure does not abort the fan-out** — the fan-out catches,
+    emits `…_FAILED`, increments a failure counter, and continues to the next tenant (Story 28-10
+    AC5 tolerance shape). Compaction and purge emit
+    `ANALYTICS.COMPACT.DAILY` / `ANALYTICS.PURGE.USAGE_HOURLY` terminal events.
+
+13. A **projection-lag SLO** is observable: the workflow records, per fan-out pass, the wall-clock
+    lag between the rolled-up `hour` bucket and the time the projection completed, and emits a
+    `ANALYTICS.ROLLUP.DIMENSIONAL_LAG` event (and an OTel gauge `tamma.analytics.projection_lag_seconds`,
+    following the `KekRotationMetrics` gauge precedent) when the lag exceeds the configured SLO
+    budget (default 2 hours). The SLO breach is a WARN-level structured log + event, not a failure
+    — the runbook/alerts consume it.
+
+14. The new dimensional fan-out is wired into `HourlyAnalyticsRollupWorkflow` as an **additional
+    sequence step after** the existing `FanOutTenantRollups` (platform fact table) step and before
+    `EmitHourCompleted`/`PurgeStaleAnalytics`, so the platform rollup and the dimensional rollup
+    share one schedule, one advisory lock, and one target-hour. The existing platform rollup,
+    its events, and `PurgeStaleAnalyticsActivity` are unchanged (a structure test asserts the new
+    step is present and the platform step still precedes it).
+
+15. Unit + integration tests cover: provider/agent/workflow/repo/cost-basis bucketing (including
+    the `NULL` buckets reconciling to the grand total); BYOK-vs-platform classification from the
+    `billing_mode` tag / `ProviderDiagnostic.BillingMode`; `PlatformBilledUsd` margin application
+    (platform only; BYOK → 0) against a mocked `IAnalyticsPricingConfig`; JSON measure extraction
+    reuse (shared `AggregateLlmUsage`-style helper); idempotent replay (re-run an hour → identical
+    rows/measures); checkpoint advance + crash-resume (re-run un-checkpointed events → no
+    double-count); daily compaction lossless-sum; per-tenant isolation (row in schema A invisible
+    in schema B; tenant A failure leaves tenant B intact); and the projection-lag SLO event firing
+    past the budget.
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Event-catalogue + cost-basis helper (AC: 4, 12, 13)
+  - [ ] Add `TenantDimensionalRollupCompleted`/`…Failed`, `DailyCompacted`,
+        `UsageHourlyPurged`/`…Failed`, `DimensionalLag` constants to
+        `AnalyticsRollupEvents` (new section, same `AGGREGATE.ACTION.STATUS` shape).
+  - [ ] Add a pure `ResolveCostBasis(billingModeTag, providerDiagnosticBillingMode)` helper
+        returning `CostBasis` with the documented default; unit test all branches.
+
+- [ ] Task 2: `IAnalyticsPricingConfig` seam (AC: 5)
+  - [ ] Define the read-only margin seam (consumes Story 36-7); add a `NullAnalyticsPricingConfig`
+        zero-margin fallback + WARN log for when 36-7 is not yet wired.
+  - [ ] Unit test: `byok → 0`; `platform → CostUsd * (1 + margin)`; null config → zero margin.
+
+- [ ] Task 3: `analytics_projection_checkpoint` (AC: 7)
+  - [ ] Add the per-tenant checkpoint entity + Tenant EF mapping + additive Tenant migration
+        (one row, highest folded `SequenceNumber`); resumable read + atomic advance.
+  - [ ] Unit/integration test: checkpoint advances; crash-resume re-folds only un-checkpointed
+        events with no double-count.
+
+- [ ] Task 4: `ComputeTenantDimensionalRollupActivity` (AC: 1, 2, 3, 6, 8, 9)
+  - [ ] Aggregate `domain_events` + `ProviderDiagnostic` for the hour into per-tuple measures;
+        reuse the JSON measure-extraction helper; read-then-upsert on the dimension business key.
+  - [ ] Static `ComputeAsync` pure-DI entry point; backfill `hour` + `resetCheckpoint` inputs.
+
+- [ ] Task 5: `CompactDailyAnalyticsActivity` + usage-hourly purge (AC: 10, 11)
+  - [ ] Daily `GROUP BY` compaction (lossless) upserting on the daily business key.
+  - [ ] Best-effort hourly retention purge mirroring `PurgeStaleAnalyticsActivity`.
+
+- [ ] Task 6: Fan-out + workflow wiring + lag SLO (AC: 12, 13, 14)
+  - [ ] Add a dimensional fan-out (iterate active tenants, per-tenant try/catch, emit
+        `…COMPLETED`/`…FAILED`, count success/failed) — same shape as
+        `FanOutTenantRollupsActivity`, or extend it with a second compute step.
+  - [ ] Wire the new step into `HourlyAnalyticsRollupWorkflow` after the platform fan-out; record
+        + emit projection lag and the OTel gauge.
+
+- [ ] Task 7: Tests (AC: 15)
+  - [ ] Unit (InMemory) for bucketing/classification/margin/idempotency/checkpoint/compaction.
+  - [ ] Integration (Postgres 17 Testcontainer) for per-tenant isolation + NULLS-NOT-DISTINCT
+        upsert collision + checkpoint resume.
+
+## Technical Design
+
+### C# namespace / file structure
+
+```
+apps/tamma-elsa/src/
+  Tamma.Activities/Analytics/
+    ComputeTenantDimensionalRollupActivity.cs      # NEW — per-tenant dimensional projection
+    CompactDailyAnalyticsActivity.cs               # NEW — hourly→daily lossless compaction
+    PurgeStaleUsageAnalyticsActivity.cs            # NEW — per-tenant analytics_usage_hourly retention purge
+    FanOutTenantDimensionalRollupsActivity.cs      # NEW — fan-out (mirror of FanOutTenantRollupsActivity)
+    AnalyticsRollupEvents.cs                        # MODIFY — + dimensional/compact/purge/lag event constants
+    IAnalyticsPricingConfig.cs                      # NEW — margin seam (consumes Story 36-7)
+    NullAnalyticsPricingConfig.cs                   # NEW — zero-margin fallback + WARN
+  Tamma.Data/Entities/
+    AnalyticsProjectionCheckpoint.cs               # NEW — per-tenant SequenceNumber cursor
+    ProviderDiagnostic.cs                          # READ — BillingMode (35-2), ProviderKey, AgentType, ProjectId, Input/OutputTokens, Cost
+    DomainEvent.cs                                 # READ — Type, Tags (agent_id/billing_mode/provider/repoId), Data, SequenceNumber
+  Tamma.Data/TenantDbContext.cs                    # MODIFY — + DbSet<AnalyticsProjectionCheckpoint>
+  Tamma.Data/TammaModelConfiguration.cs            # MODIFY — + ConfigureAnalyticsProjectionCheckpoint (tenant graph)
+  Tamma.Data/Migrations/Tenant/<ts>_AddAnalyticsProjectionCheckpoint.cs   # NEW (generated)
+  Tamma.ElsaServer/Workflows/HourlyAnalyticsRollupWorkflow.cs             # MODIFY — + dimensional fan-out + compaction + usage purge steps
+
+apps/tamma-elsa/tests/
+  Tamma.Activities.Tests/Analytics/
+    ComputeTenantDimensionalRollupTests.cs         # NEW — bucketing / classification / margin / idempotency
+    CompactDailyAnalyticsActivityTests.cs          # NEW — lossless daily compaction
+    AnalyticsProjectionCheckpointTests.cs          # NEW — checkpoint advance + crash-resume
+    HourlyAnalyticsRollupWorkflowStructureTests.cs # MODIFY — assert new step present + ordering
+    AnalyticsRollupEventsTests.cs                  # MODIFY — new event constants
+  Tamma.Api.Tests/Analytics/
+    DimensionalRollupIsolationTests.cs             # NEW — Postgres 17 Testcontainer: per-tenant isolation + upsert collision
+```
+
+### Source events + diagnostic columns (verified, real)
+
+The projection reads two per-tenant sources, both in the tenant schema:
+
+- **`DomainEvent`** (`Tamma.Data/Entities/DomainEvent.cs`) — `Type`, JSONB `Tags`
+  (carries `agent_id` (Epic 32), `billing_mode` (35-2), `provider`, `repoId`,
+  `workflowDefinitionId`/`tenantId`), JSONB `Data` (`LLM.CALL.SUCCESS` carries `costUsd`,
+  `inputTokens`, `outputTokens` per Story 9-2), and `SequenceNumber` (monotonic `BIGSERIAL`
+  total-order cursor — the checkpoint column).
+- **`ProviderDiagnostic`** (`Tamma.Data/Entities/ProviderDiagnostic.cs`) — `ProviderKey`,
+  `InputTokens`/`OutputTokens`/`TokensUsed`, `Cost`, `AgentType` (agent dimension),
+  `ProjectId` (repo dimension), `Model`, and `BillingMode` (added by Story 35-2 → cost basis).
+
+The dimensional rollup mirrors `ComputeTenantRollupActivity` exactly for workflow counts
+(`WorkflowInstances` by `Status`), `AGENT.DISPATCH.%` counts (`EF.Functions.Like`, InMemory-and-
+Npgsql-safe), and `LLM.CALL.SUCCESS` JSON measure extraction (`AggregateLlmUsage`) — but groups
+those measures by the dimension tuple instead of collapsing to one tenant row.
+
+### Cost-basis resolution (pure helper)
+
+```csharp
+// CostBasis (Story 36-1 enum) from the 35-2 billing_mode signal.
+internal static CostBasis ResolveCostBasis(string? billingModeTag, string? diagnosticBillingMode)
+{
+    var mode = billingModeTag ?? diagnosticBillingMode;   // event tag wins; diagnostic backs it
+    return string.Equals(mode, "byok", StringComparison.OrdinalIgnoreCase)
+        ? CostBasis.Byok
+        : CostBasis.Platform;                              // platform | absent (single-user/legacy) → platform
+}
+```
+
+### Per-tenant dimensional upsert (idempotent, read-then-upsert)
+
+```csharp
+// One AnalyticsUsageHourly row per (Provider, AgentId, WorkflowDefinitionId, RepoId, CostBasis).
+foreach (var (key, m) in measuresByDimension)
+{
+    var existing = await tenantDb.AnalyticsUsageHourly.FirstOrDefaultAsync(
+        r => r.Hour == hour && r.Provider == key.Provider && r.AgentId == key.AgentId
+             && r.WorkflowDefinitionId == key.WorkflowDefinitionId && r.RepoId == key.RepoId
+             && r.CostBasis == key.CostBasis, ct);
+
+    var billed = key.CostBasis == CostBasis.Platform
+        ? Math.Round(m.CostUsd * (1 + pricing.MarginFor(key.Provider)), 4, MidpointRounding.AwayFromZero)
+        : 0m;
+
+    if (existing is null)
+        tenantDb.AnalyticsUsageHourly.Add(new AnalyticsUsageHourly { /* dims + measures + billed */ });
+    else
+        { existing.TokensIn = m.TokensIn; /* …overwrite all measures… */ existing.PlatformBilledUsd = billed; existing.ComputedAt = now; }
+}
+await AdvanceCheckpointAsync(tenantDb, maxSequenceNumber, ct);   // atomic with the upsert SaveChanges
+await tenantDb.SaveChangesAsync(ct);
+```
+
+Overwrite (not increment) on re-run keeps replay/backfill idempotent: the activity recomputes the
+**whole** bucket from source each pass, so a second run writes the same values. The
+`UX_analytics_usage_hourly_dims` NULLS-NOT-DISTINCT index (Story 36-1 AC7) is the concurrent-replay
+backstop.
+
+### Checkpoint (resumable)
+
+`AnalyticsProjectionCheckpoint` is a single per-tenant row (`Stream = "dimensional"`,
+`LastSequenceNumber long`, `UpdatedAt`). A run folds `domain_events` with
+`SequenceNumber > LastSequenceNumber` for the buckets it owns and advances the checkpoint in the
+same `SaveChanges` as the upsert. A crash before commit replays the same events on the next pass;
+the idempotent upsert (whole-bucket overwrite) absorbs the replay with no double-count. The
+cursor is `SequenceNumber` — never `Id`/`CreatedAt` — per the `DomainEvent.SequenceNumber`
+doc-comment (the `AlertRuleEvaluator` cursor precedent).
+
+### Daily compaction (lossless GROUP BY)
+
+`CompactDailyAnalyticsActivity` runs when the target hour is `00:xx` of a new UTC day (compacting
+the day that just ended). It is a pure `GROUP BY date_trunc('day', Hour), Provider, AgentId,
+WorkflowDefinitionId, RepoId, CostBasis` with summed measures, upserted on the daily business key
+— lossless because Story 36-1 made the hourly and daily entities share their dimension+measure
+contract exactly.
+
+### Retention purge
+
+`PurgeStaleUsageAnalyticsActivity` mirrors `PurgeStaleAnalyticsActivity`: per-tenant
+`ExecuteDeleteAsync` of `analytics_usage_hourly` rows older than the retention window (13-month
+default), best-effort (catches all but `OperationCanceledException`, emits
+`ANALYTICS.PURGE.USAGE_HOURLY` / `…FAILED`, never rethrows), runs last in the sequence.
+
+### Workflow wiring
+
+```
+HourlyAnalyticsRollupWorkflow.Build (MODIFY) — Sequence:
+  initBucket
+  platformRollup              (ComputePlatformRollupActivity)        — unchanged (28-10)
+  fanOut                      (FanOutTenantRollupsActivity)          — unchanged (28-10, platform fact table)
+  fanOutDimensional           (FanOutTenantDimensionalRollupsActivity) — NEW
+  compactDaily                (CompactDailyAnalyticsActivity, day-boundary only) — NEW
+  emitCompleted               (EmitHourCompletedActivity)            — unchanged
+  purgeStale                  (PurgeStaleAnalyticsActivity)          — unchanged (CP)
+  purgeUsageStale             (PurgeStaleUsageAnalyticsActivity)     — NEW (per-tenant)
+```
+
+One schedule (`0 5 * * * *`), one advisory lock, one target hour — the platform rollup and the
+dimensional rollup are two consumers of the same fan-out, exactly as the scope demands.
+
+### DCB events (new — owned by this story)
+
+Story 36-1 reserved the `ANALYTICS.PROJECTION.*` family for this story; we land the concrete
+names on `AnalyticsRollupEvents` (same `AGGREGATE.ACTION.STATUS` convention as 28-10):
+
+| Event | When | Key data |
+|---|---|---|
+| `ANALYTICS.ROLLUP.TENANT_DIMENSIONAL_COMPLETED` | per tenant×hour, success | rowsWritten, tuples, tokensIn/Out, costUsd, platformBilledUsd, checkpoint |
+| `ANALYTICS.ROLLUP.TENANT_DIMENSIONAL_FAILED` | per tenant×hour, failure (fan-out continues) | errorType, message |
+| `ANALYTICS.COMPACT.DAILY` | per tenant×day, after compaction | day, rowsWritten |
+| `ANALYTICS.PURGE.USAGE_HOURLY` / `…FAILED` | per tenant, after retention sweep | cutoff, rowsDeleted |
+| `ANALYTICS.ROLLUP.DIMENSIONAL_LAG` | per pass when lag > SLO budget | lagSeconds, hour, budgetSeconds |
+
+Per-tenant events carry `tenantId` so the Story 28-6 step-dedup index applies; events are appended
+via `IPlatformEventPublisher.AppendAndPublishAsync` (best-effort emission, same as the 28-10 path).
+
+### API shape
+
+**No new HTTP endpoints in this story.** Population is a scheduled workflow. A future Epic 36
+story exposes the query API over the populated tables (behind `MemberAccess`); an operator
+backfill/force-run uses the existing `POST /workflows/run/hourly-analytics-rollup` with an
+optional `hour` (and `resetCheckpoint`) input, the same control surface Story 28-10 already
+documents.
+
+### Per-mode + per-tenant handling
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| What does the fan-out iterate? | The sole tenant (one schema). | All active tenants from the CP directory (28-10 fan-out target set). |
+| Who owns a projected row? | The sole user — it lives in their (only) tenant schema. | The tenant — its `t_<hex>` schema. |
+| Cost basis default | `platform` (no `billing_mode` tag; self-hosted key) — never marked up unless a margin is configured. | `byok`/`platform` from the 35-2 `billing_mode` tag per call. |
+| Isolation plane | Search-path schema + connection string. | Same — physically separate schema per tenant; a row in A is unreachable from B. |
+| Margin / `PlatformBilledUsd` | Typically 0 (no platform billing). | `CostUsd × (1 + margin)` from 36-7 for `platform` rows; `0` for `byok`. |
+
+Mode does not change the projection shape — both resolve to exactly one tenant schema per run.
+The platform-wide owner rollup stays on the CP `platform_analytics_hourly` table (28-10), untouched.
+
+## Dependencies
+
+**Prerequisite (internal):**
+- **Story 36-1** — the per-tenant `AnalyticsUsageHourly` / `AnalyticsUsageDaily` fact tables +
+  `CostBasis` enum + `UX_*_dims` business-key indexes this story writes. (Authored; drafted.)
+- **Story 28-10** — the `HourlyAnalyticsRollupWorkflow` + `FanOutTenantRollupsActivity` +
+  `ComputeTenantRollupActivity.AggregateLlmUsage` + `PurgeStaleAnalyticsActivity` +
+  `AnalyticsRollupEvents` this story extends/mirrors. (Merged.)
+- **Epic 4 (DCB `DomainEvent`)** — the per-tenant event stream (`LLM.CALL.SUCCESS`,
+  `AGENT.DISPATCH.*`, `WORKFLOW.*`) and its `SequenceNumber` total-order cursor the projection
+  reads from. (In place.)
+- **Epic 28** — per-tenant schema + `ITenantDbContextFactory` + `EfTenantDbMigrator` (checkpoint
+  migration rides the Tenant graph). (Merged.)
+
+**Soft / forward (degrade gracefully if absent):**
+- **Story 35-2 (Epic 35)** — the `billing_mode` tag on `LLM.CALL.*` events + the
+  `ProviderDiagnostic.BillingMode` column that resolve `CostBasis`. The spec frames this as
+  "Epic 29 secret cabinet to detect BYOK key origin"; in this codebase the BYOK origin is already
+  surfaced as the `billing_mode` discriminator by 35-2 (which itself reads the cabinet via
+  `ISecretStore`). If 35-2 has not landed, all rows resolve to `CostBasis.Platform` and the
+  classification test pins that default.
+- **Epic 32 (agent_id DCB tags)** — the `agent_id` tag the agent dimension reads. If absent, rows
+  bucket under `AgentId = NULL` (totals still reconcile).
+- **Story 36-7 (pricing/margin config)** — consumed via `IAnalyticsPricingConfig` for
+  `PlatformBilledUsd`. If unavailable, the `NullAnalyticsPricingConfig` zero-margin fallback
+  applies and a WARN is logged.
+
+**Blocks (internal):**
+- Downstream Epic 36 stories — tenant analytics query API, exports, scheduled reports — all read
+  the tables this story populates.
+
+**External:**
+- PostgreSQL 17 (NULLS NOT DISTINCT upsert backstop; per-tenant `ExecuteDeleteAsync`).
+- EF Core 9 / Npgsql.
+- Testcontainers + Docker for the isolation/upsert/resume integration suite (run via
+  `sg docker -c "dotnet test ..."`).
+
+## Testing Strategy
+
+1. **Unit — cost-basis classification (`ComputeTenantDimensionalRollupTests`):** `billing_mode`
+   tag `byok`/`platform`, `ProviderDiagnostic.BillingMode` fallback, absent → `Platform` default.
+
+2. **Unit — dimensional bucketing:** events spanning multiple providers / agents / workflows /
+   repos produce one row per tuple; events missing a dimension bucket under `NULL`; assert
+   `Σ(per-dimension rows) == grand total` (reconciliation).
+
+3. **Unit — margin / `PlatformBilledUsd`:** mocked `IAnalyticsPricingConfig` → `platform` rows
+   carry `CostUsd × (1 + margin)`; `byok` rows carry `0`; null config → zero margin + WARN.
+
+4. **Unit — JSON measure extraction reuse:** the shared `AggregateLlmUsage`-style helper sums
+   `costUsd`/`inputTokens`/`outputTokens` and skips malformed blobs (same tolerance as 28-10).
+
+5. **Unit/integration — idempotent replay:** run an hour twice → identical row count + measures
+   (whole-bucket overwrite); concurrent replay collapses on the `UX_*_dims` index (Testcontainer).
+
+6. **Integration — checkpoint resume (`AnalyticsProjectionCheckpointTests`, Postgres 17):**
+   process a batch → checkpoint advances to max `SequenceNumber`; simulate a crash before commit →
+   re-run re-folds only un-checkpointed events with no double-count.
+
+7. **Unit — daily compaction (`CompactDailyAnalyticsActivityTests`):** 24 hourly buckets → one
+   daily set; measures sum losslessly; re-compaction is idempotent.
+
+8. **Integration — per-tenant isolation (`DimensionalRollupIsolationTests`, Postgres 17
+   Testcontainer, per `SchemaPerTenantMigrationTests`):** project into two schemas; a row written
+   to schema A's `analytics_usage_hourly` is invisible through schema B; a forced failure on
+   tenant A leaves tenant B's projection intact and the fan-out completes.
+
+9. **Unit — workflow structure (`HourlyAnalyticsRollupWorkflowStructureTests`, extended):** the
+   new dimensional fan-out + compaction + usage-purge steps are present; the platform fan-out
+   still precedes the dimensional one; `EmitHourCompleted` stays terminal-before-purge.
+
+10. **Unit — projection-lag SLO:** a pass whose completion lags the bucket beyond the budget emits
+    `ANALYTICS.ROLLUP.DIMENSIONAL_LAG` + the OTel gauge; under budget emits neither.
+
+**Mocks:** No external provider/Stripe calls (read-only aggregation). InMemory provider for
+bucketing/classification/margin shape; a real Postgres 17 Testcontainer for isolation, NULLS NOT
+DISTINCT upsert collision, and checkpoint resume (EF InMemory honours neither unique-NULL collapse
+nor `ExecuteDeleteAsync` semantics — same rationale as `ConventionStoreMigrationTests`).
+
+## Estimated Effort
+
+4-5 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Activities/Analytics/ComputeTenantDimensionalRollupActivity.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/Analytics/CompactDailyAnalyticsActivity.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/Analytics/PurgeStaleUsageAnalyticsActivity.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/Analytics/FanOutTenantDimensionalRollupsActivity.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/Analytics/IAnalyticsPricingConfig.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/Analytics/NullAnalyticsPricingConfig.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/Analytics/AnalyticsRollupEvents.cs` | Modify (add dimensional/compact/purge/lag event constants) |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/AnalyticsProjectionCheckpoint.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs` | Modify (add checkpoint DbSet) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (configure checkpoint entity in tenant graph) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/<ts>_AddAnalyticsProjectionCheckpoint.cs` | Create (generated) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/<ts>_AddAnalyticsProjectionCheckpoint.Designer.cs` | Create (generated) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/TenantDbContextModelSnapshot.cs` | Modify (regenerated) |
+| `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/HourlyAnalyticsRollupWorkflow.cs` | Modify (add dimensional fan-out + compaction + usage purge steps) |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/ComputeTenantDimensionalRollupTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/CompactDailyAnalyticsActivityTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/AnalyticsProjectionCheckpointTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/HourlyAnalyticsRollupWorkflowStructureTests.cs` | Modify (assert new steps + ordering) |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/AnalyticsRollupEventsTests.cs` | Modify (new event constants) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/DimensionalRollupIsolationTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, decisions (analytics, rollup, tenancy,
+   event sourcing).
+3. Reviewed Story 36-1 (the tables/enum/business-key indexes this story writes) and Story 28-10
+   (`HourlyAnalyticsRollupWorkflow`, `FanOutTenantRollupsActivity`,
+   `ComputeTenantRollupActivity.AggregateLlmUsage`, `PurgeStaleAnalyticsActivity`,
+   `AnalyticsRollupEvents`) — this story is a near-verbatim extension of that shape.
+4. Confirmed the test runner: docker-bound suites run via `sg docker -c "dotnet test ..."`
+   (session docker group is stale; the build itself needs no wrapper).
+5. Planned the TDD cycle (write the bucketing/classification/idempotency tests red first, then the
+   activity).
+
+### Key Design Decisions
+
+- **Extend the 28-10 fan-out, don't fork the schedule.** The dimensional rollup is one more
+  sequence step on the existing hourly workflow — one schedule, one advisory lock, one target
+  hour. Two cron jobs racing the same tenants would double the per-tenant pool churn and split the
+  runbook story. The platform fact-table rollup and the per-tenant dimensional store are two
+  consumers of the same fan-out.
+- **Whole-bucket overwrite, not increment.** The activity recomputes the entire `(tenant, hour)`
+  bucket from source each pass and overwrites the measures, so replay and backfill are naturally
+  idempotent without delta bookkeeping. The `SequenceNumber` checkpoint is a *resumability /
+  efficiency* cursor (skip already-folded events on the happy path), not the idempotency mechanism
+  — the upsert is. This is the safest combination: a checkpoint bug can re-fold without corrupting
+  totals.
+- **`SequenceNumber`, never `Id`/`CreatedAt`, for the cursor.** `DomainEvent.SequenceNumber` is the
+  monotonic `BIGSERIAL` total-order column built precisely to tiebreak same-millisecond events
+  (its doc-comment names the `AlertRuleEvaluator` precedent). Using `CreatedAt` would skip or
+  double-count events that share a millisecond.
+- **`NULL` dimension buckets, never sentinels.** An event missing `agent_id`/`provider`/`repo`/
+  `workflowDefinitionId` buckets under that dimension `= NULL` — preserved by Story 36-1's NULLS
+  NOT DISTINCT business key — so per-dimension breakdowns and the grand total always reconcile.
+  Coercing to a `"unknown"` string would fork the total and break the unique key's dedupe.
+- **Cost basis from the 35-2 `billing_mode` signal, not a re-derived cabinet lookup.** The spec
+  frames BYOK detection as "Epic 29 secret cabinet"; the codebase already surfaces that decision
+  as the `billing_mode` tag/column produced by Story 35-2 (which reads the cabinet). Reusing the
+  tag keeps this story a pure projection — no secret reads in the analytics path, no credential
+  exposure surface.
+- **Margin is consumed, not owned.** `PlatformBilledUsd` calls the `IAnalyticsPricingConfig` seam
+  (Story 36-7). This story implements zero margin math itself; a `NullAnalyticsPricingConfig`
+  zero-margin fallback keeps the rollup green before 36-7 lands.
+- **Per-tenant failure tolerance + best-effort housekeeping.** The dimensional fan-out catches per
+  tenant, emits `…_FAILED`, and continues (28-10 AC5 shape); compaction and purge are best-effort
+  (never rethrow a transient failure into a rollup that already wrote useful rows), exactly like
+  `PurgeStaleAnalyticsActivity`.
+
+### Population-only boundary
+
+This story creates **no** schema change to the Story 36-1 fact tables (only the additive
+`analytics_projection_checkpoint`), **no** query/export/report endpoint, and **no** dashboard
+surface — those are later Epic 36 stories. It does **not** touch the control-plane
+`platform_analytics_hourly` rollup, its events, or its purge. Any PR that adds a query API or
+alters the 36-1 fact-table schema under cover of this story is out of scope — keep the diff to the
+projection activities, the checkpoint entity/migration, the workflow wiring, and tests.
+
+## Logging Requirements
+
+- **INFO**: dimensional fan-out start (`hour`, tenantCount); per-tenant dimensional rollup
+  completed (`tenantId`, `hour`, rowsWritten, tuples, tokensIn/Out, costUsd, platformBilledUsd,
+  checkpoint); daily compaction completed (`tenantId`, day, rowsWritten); usage-hourly purge
+  completed (`cutoff`, rowsDeleted); fan-out completed (`success`, `failed`).
+- **DEBUG**: per-tuple measure aggregation; checkpoint read/advance (`from`, `to` SequenceNumber);
+  cost-basis resolution per source.
+- **WARN**: per-tenant rollup failed (`tenantId`, `hour`, errorType) — fan-out continues;
+  projection lag over SLO budget (`lagSeconds`, `budgetSeconds`); 36-7 pricing config unavailable
+  → zero margin; usage-hourly purge failed (best-effort).
+- **ERROR**: dimensional fan-out aborted by host shutdown/cancellation (re-thrown
+  `OperationCanceledException`); checkpoint write failure that prevents commit.
+- **Structured context**: include `{ tenantId, hour, rowsWritten, tuples, checkpoint, lagSeconds }`
+  where applicable.
+- **Credential safety**: NEVER log tenant connection strings, search-path schema secrets, or
+  provider API keys; per-tenant exception messages surfaced into `…_FAILED` events must not carry
+  connection strings (the compute activity reads only tenant DB data — same guarantee as
+  `FanOutTenantRollupsActivity`). The projection never reads raw provider-key plaintext — it reads
+  only the `billing_mode` discriminator.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-36/story-36-3/36-3-tenant-usage-analytics-api.md
+++ b/docs/stories/epic-36/story-36-3/36-3-tenant-usage-analytics-api.md
@@ -1,0 +1,539 @@
+# Story 36-3: Tenant Usage Analytics API
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-phase workflow (Read → Research → Break Down → TDD →
+Quality Gates → Failure Handling), the `.dev/` knowledge base, TRACE/DEBUG logging
+requirements, test-first development, and the build-success / coverage gates.
+
+## User Story
+
+As a **tenant administrator** (SaaS) **/ self-hosted owner** (single-user),
+I want a per-tenant, RBAC-gated query API that reads my pre-aggregated usage facts from Story
+36-1's `analytics_usage_hourly` / `analytics_usage_daily` tables (populated by Story 36-2) — and
+returns time-bucketed usage (workflows, agent dispatches, tokens) broken down by provider, agent,
+workflow, and repo over an arbitrary window at hourly or daily grain,
+so that the tenant dashboard (Story 36-6) and the CSV/JSON exporter (Story 36-8) read one stable,
+isolated, tenant-scoped contract instead of re-scanning the DCB stream — and a member of org A can
+never read org B's usage.
+
+## Priority
+
+P0 — The dimensional store (36-1) is populated (36-2) but inert without a read surface. Every
+tenant-facing Epic 36 consumer (dashboard 36-6, exporter 36-8) reads through this API; nothing
+renders a tenant usage chart until these endpoints ship.
+
+## Scope
+
+Read-only query API **only**. This story exposes two tenant-scoped HTTP endpoints over the Story
+36-1 fact tables, resolves the principal per-mode (single-user → sole user, SaaS → tenant), gates
+reads behind tenant membership (any member may read), and serves a stable response contract that
+the dashboard and exporter consume. It owns:
+
+- a `TenantAnalyticsService` that reads `AnalyticsUsageDaily` / `AnalyticsUsageHourly` through
+  `ITenantDbContextFactory.CreateAsync(tenantId)` (physical per-tenant schema isolation) and
+  shapes time-bucketed + breakdown results;
+- a `TenantAnalyticsEndpoints` pair (`GET …/analytics/usage`, `GET …/analytics/usage/breakdown`)
+  mounted under `/api/v1/orgs/{tenantId}/…`, gated by the existing `RequireTenantMembershipFilter`
+  (the cross-tenant 403 guard) and the `MemberAccess` policy;
+- request DTOs/validation (range clamping, granularity/groupBy enums, **forced-UTC DateTime
+  binding** mirroring the `AdminAnalyticsEndpoints` fix) and a response contract with
+  `period_start` / `period_end` echoes.
+
+It does **not** write or alter the fact tables (36-1), populate them (36-2), implement exports
+(36-8), render UI (36-6), or touch the control-plane `platform_analytics_hourly` /
+`AdminAnalyticsEndpoints` owner surface (Story 28-10) — that stays the platform-owner business
+analytics surface and is **not duplicated** here. It does not add per-tenant OPS/health metrics
+(Epic 5 / Epic 23) — usage analytics only.
+
+## Acceptance Criteria
+
+1. A new `GET /api/v1/orgs/{tenantId}/analytics/usage` endpoint
+   (`apps/tamma-elsa/src/Tamma.Api/Endpoints/TenantAnalyticsEndpoints.GetUsage`) returns
+   **time-bucketed** usage rows — each row carrying `period`, `workflowsStarted`,
+   `workflowsCompleted`, `workflowsFailed`, `agentDispatches`, `tokensIn`, `tokensOut` (and `costUsd`
+   / `platformBilledUsd` measures from the 36-1 schema) — for the requested window, reading
+   `AnalyticsUsageDaily` (granularity `day`) or `AnalyticsUsageHourly` (granularity `hour`) through
+   `ITenantDbContextFactory.CreateAsync(tenantId)`. It **never** re-scans `domain_events`.
+
+2. The endpoint accepts query params `from` (ISO-8601), `to` (ISO-8601),
+   `granularity` (`hour` | `day`, default `day`), and an optional `groupBy`
+   (`provider` | `agent` | `workflow` | `repo`). With `groupBy` absent, rows are summed across all
+   dimensions per time bucket (one row per bucket); with `groupBy` set, rows are
+   `GROUP BY (bucket, <dimension>)` so each bucket fans out into one row per dimension value, with
+   the dimension value echoed in a `key` field (and the `NULL` "unattributed" bucket surfaced as a
+   `null`/empty key, never dropped or coerced to a sentinel — preserving 36-2's reconciliation
+   guarantee).
+
+3. A new `GET /api/v1/orgs/{tenantId}/analytics/usage/breakdown` endpoint
+   (`TenantAnalyticsEndpoints.GetBreakdown`) returns **top-N rows for a single dimension** over the
+   window — `dimension` (`provider` | `agent` | `workflow` | `repo`, required), a `metric`
+   selector (`tokens` | `runs` | `dispatches` | `cost`, default `tokens`), and `limit` (default 10,
+   clamped 1..100) — each row carrying the dimension `key` and the aggregated `value` + the full
+   measure set, ordered by the selected metric descending (e.g. tokens by agent, runs by repo).
+
+4. **All queries are hard-scoped to the caller's tenant schema.** Both endpoints sit under
+   `/api/v1/orgs/{tenantId}/…` behind `RequireTenantMembershipFilter`, which returns **403** when
+   the authenticated caller has no membership row in the route `{tenantId}` (the cross-tenant
+   guard, finding 001/024). A test asserts a member of tenant A requesting tenant B's route gets
+   403 and that **no** tenant-B fact row is ever returned (no cross-tenant leakage) — physical
+   isolation is the `ITenantDbContextFactory` per-tenant connection, defence-in-depth is the
+   membership filter.
+
+5. **RBAC: any tenant member may read.** Both GET endpoints carry the `MemberAccess` policy +
+   `RequireTenantMembershipFilter` and **never** require `tenant_owner` / `tenant_admin` —
+   mirroring the prompt-store "GET resolved prompt → any tenant member" RBAC and the
+   `UserDashboardEndpoints` precedent. In single-user mode the sole user is the principal and no
+   role is required; in SaaS mode `member`-role callers read successfully (no 403 on GET).
+
+6. **Per-mode principal resolution** is identical in endpoint shape across both modes: the
+   `{tenantId}` route segment is the principal in both modes (single-user resolves to the sole
+   user's tenant schema, SaaS to the tenant's schema), the auth middleware/membership filter binds
+   the caller, and the per-tenant `TenantDbContext` enforces isolation physically — no per-mode
+   branch in the handler (the CLAUDE.md prompt-store "endpoint shape identical between modes"
+   precedent).
+
+7. **Responses are bounded.** The requested window is clamped to a maximum range of **365 days**
+   (a longer `from..to` is truncated to the most-recent 365 days and the effective window echoed),
+   `from` defaults to 30 days ago and `to` to now when omitted, `granularity` clamps so an `hour`
+   query over a window wider than a configured cap (default 31 days) is rejected with 400 (an
+   unbounded hourly scan is the anti-pattern), and `groupBy`/`dimension`/`metric` values outside
+   the allowed enums return 400 with a clear error.
+
+8. Every response echoes `period_start` and `period_end` (the **effective** UTC window after
+   clamping, ISO-8601) plus `granularity`, `groupBy`/`dimension`, and a `rows` array — a stable,
+   self-describing schema the dashboard (36-6) and the CSV exporter (36-8) consume without
+   re-deriving the window. The DTOs live in
+   `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/TenantAnalyticsDtos.cs` and the contract is
+   version-stable (additive-only).
+
+9. **DateTime binding forces UTC.** `from`/`to` bind as `DateTime?` and are normalized via
+   `DateTime.SpecifyKind(value.ToUniversalTime(), DateTimeKind.Utc)` (the exact
+   `AdminAnalyticsEndpoints.GetEventHistogram` fix) so the query window matches the stored
+   `Hour`/`Day` UTC buckets (`timestamp with time zone`, top-of-hour / midnight UTC per 36-1) — a
+   `from` parsed as Local never shifts the window off the bucket boundary.
+
+10. The `TenantAnalyticsService`
+    (`apps/tamma-elsa/src/Tamma.Api/Services/Analytics/TenantAnalyticsService.cs`,
+    `ITenantAnalyticsService` seam) is the single read seam: it takes
+    `ITenantDbContextFactory`, builds the grouped/aggregated query against the appropriate fact
+    table for the granularity, applies the `[from, to)` half-open window filter on the bucket
+    column, and returns the DTO — so the endpoints are thin and the aggregation is unit-testable in
+    isolation against a seeded InMemory context.
+
+11. The control-plane owner analytics surface (`AdminAnalyticsEndpoints`,
+    `IPlatformAnalyticsService`, `platform_analytics_hourly`, Story 28-10) is **left entirely
+    intact** — this story adds a parallel tenant-scoped surface and does **not** modify, re-route,
+    or read the CP business-analytics path. A test asserts the new endpoints never touch
+    `IPlatformAnalyticsService` / `ControlPlaneDbContext`.
+
+12. Integration tests (Postgres 17 Testcontainer, two tenant schemas) cover: **grouping
+    correctness** against seeded `analytics_usage_*` fact rows (per-dimension rows sum to the
+    grand total — the 36-2 reconciliation contract held at read time, including the `NULL`
+    dimension bucket); **range clamping** (a 400-day window truncates to 365; an hourly query past
+    the hour cap → 400); **UTC handling** (a `from` with a non-UTC offset selects the same buckets
+    as its UTC equivalent); and the **cross-tenant 403** (tenant-A caller on tenant-B route → 403,
+    no tenant-B rows returned).
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Request/response DTOs + validation (AC: 2, 3, 7, 8, 9)
+  - [ ] Add `TenantAnalyticsDtos.cs`: `UsageQuery` (from/to/granularity/groupBy),
+        `BreakdownQuery` (dimension/metric/limit), `UsageBucketRow`, `BreakdownRow`,
+        `UsageResponse`/`BreakdownResponse` (with `period_start`/`period_end`/`granularity` echoes).
+  - [ ] Add an `AnalyticsGranularity` (`Hour`|`Day`), `AnalyticsDimension`
+        (`Provider`|`Agent`|`Workflow`|`Repo`), `AnalyticsMetric`
+        (`Tokens`|`Runs`|`Dispatches`|`Cost`) parse/validate helper returning 400 on bad input.
+  - [ ] Window-clamp helper: default window, 365-day max range, hour-granularity cap; forced-UTC
+        normalization (mirror `AdminAnalyticsEndpoints`). Unit-test the clamp matrix in isolation.
+
+- [ ] Task 2: `ITenantAnalyticsService` + `TenantAnalyticsService` (AC: 1, 2, 3, 10)
+  - [ ] Read `AnalyticsUsageDaily` (day) / `AnalyticsUsageHourly` (hour) via
+        `ITenantDbContextFactory.CreateAsync(tenantId)`; `[from, to)` filter on `Day`/`Hour`.
+  - [ ] Time-bucketed aggregation (no groupBy → sum per bucket; groupBy → `GROUP BY bucket, dim`);
+        breakdown top-N by metric desc. `NULL` dimension surfaced, never dropped/sentinel-coerced.
+  - [ ] Unit tests against seeded InMemory contexts: grouping correctness + reconciliation.
+
+- [ ] Task 3: `TenantAnalyticsEndpoints` + Program.cs wiring (AC: 1, 3, 4, 5, 6, 11)
+  - [ ] `GetUsage` / `GetBreakdown` handlers (thin; service does the work).
+  - [ ] Map under `orgs` group with `RequireTenantMembershipFilter` + `MemberAccess` (mirror
+        `UserDashboardEndpoints` mapping); register `ITenantAnalyticsService` in DI.
+  - [ ] CP-untouched assertion (no `IPlatformAnalyticsService`/`ControlPlaneDbContext` reference).
+
+- [ ] Task 4: Integration tests (AC: 4, 12)
+  - [ ] Postgres 17 Testcontainer, two tenant schemas seeded with fact rows.
+  - [ ] Grouping correctness + reconciliation; range clamp; UTC handling; cross-tenant 403 +
+        no-leakage.
+
+## Technical Design
+
+### C# namespace / file structure
+
+```
+apps/tamma-elsa/src/
+  Tamma.Api/Endpoints/TenantAnalyticsEndpoints.cs              # NEW — GET usage + breakdown handlers
+  Tamma.Api/Services/Analytics/ITenantAnalyticsService.cs      # NEW — read seam
+  Tamma.Api/Services/Analytics/TenantAnalyticsService.cs       # NEW — per-tenant aggregation
+  Tamma.Api/Services/Analytics/TenantAnalyticsDtos.cs          # NEW — query + response DTOs + enums
+  Tamma.Api/Program.cs                                         # MODIFY — map 2 routes + register service
+
+apps/tamma-elsa/tests/Tamma.Api.Tests/
+  Analytics/TenantAnalyticsServiceTests.cs                     # NEW — grouping/clamp/UTC unit tests (InMemory)
+  Analytics/TenantAnalyticsEndpointsTests.cs                   # NEW — RBAC matrix + cross-tenant 403 + CP-untouched
+  Analytics/TenantAnalyticsIntegrationTests.cs                 # NEW — Postgres 17: grouping correctness, isolation
+```
+
+### Endpoint shape (mirrors `UserDashboardEndpoints` — route `{tenantId}` + factory)
+
+```csharp
+// GET /api/v1/orgs/{tenantId}/analytics/usage
+//   ?from=2026-05-01T00:00:00Z&to=2026-06-01T00:00:00Z&granularity=day&groupBy=provider
+public static async Task<IResult> GetUsage(
+    Guid tenantId,
+    [FromQuery] DateTime? from,
+    [FromQuery] DateTime? to,
+    [FromQuery] string? granularity,
+    [FromQuery] string? groupBy,
+    ITenantAnalyticsService analytics,
+    CancellationToken ct)
+{
+    // Forced-UTC binding (mirror AdminAnalyticsEndpoints.GetEventHistogram) so the
+    // window lands on the stored top-of-hour / midnight-UTC buckets, not a Local shift.
+    var window = AnalyticsWindow.Resolve(from, to, granularity);   // clamps 365d / hour-cap / defaults
+    if (!window.IsValid) return Results.BadRequest(new { error = window.Error });
+
+    var result = await analytics.GetUsageAsync(
+        tenantId, window, AnalyticsDimension.TryParse(groupBy), ct);
+    return Results.Ok(result);   // echoes period_start/period_end/granularity/groupBy + rows
+}
+
+// GET /api/v1/orgs/{tenantId}/analytics/usage/breakdown
+//   ?dimension=agent&metric=tokens&limit=10&from=…&to=…
+public static async Task<IResult> GetBreakdown(
+    Guid tenantId,
+    [FromQuery] DateTime? from,
+    [FromQuery] DateTime? to,
+    [FromQuery] string dimension,
+    [FromQuery] string? metric,
+    [FromQuery] int? limit,
+    ITenantAnalyticsService analytics,
+    CancellationToken ct) { /* parse+clamp → analytics.GetBreakdownAsync(...) */ }
+```
+
+`from`/`to` are normalized exactly as `AdminAnalyticsEndpoints.GetEventHistogram` does:
+`DateTime.SpecifyKind(value.ToUniversalTime(), DateTimeKind.Utc)` — the documented UTC-binding fix
+(AC9).
+
+### Service seam + per-tenant read (mirrors `UserDashboardEndpoints.GetStats`)
+
+```csharp
+public interface ITenantAnalyticsService
+{
+    Task<UsageResponse> GetUsageAsync(
+        Guid tenantId, AnalyticsWindow window, AnalyticsDimension? groupBy, CancellationToken ct);
+
+    Task<BreakdownResponse> GetBreakdownAsync(
+        Guid tenantId, AnalyticsWindow window, AnalyticsDimension dimension,
+        AnalyticsMetric metric, int limit, CancellationToken ct);
+}
+
+public sealed class TenantAnalyticsService(ITenantDbContextFactory tenantDbFactory)
+    : ITenantAnalyticsService
+{
+    public async Task<UsageResponse> GetUsageAsync(
+        Guid tenantId, AnalyticsWindow w, AnalyticsDimension? groupBy, CancellationToken ct)
+    {
+        await using var db = await tenantDbFactory.CreateAsync(tenantId);
+
+        if (w.Granularity == AnalyticsGranularity.Day)
+        {
+            var q = db.AnalyticsUsageDaily
+                .Where(r => r.Day >= w.From && r.Day < w.To);     // half-open [from, to)
+            var rows = groupBy switch
+            {
+                AnalyticsDimension.Provider => q
+                    .GroupBy(r => new { r.Day, r.Provider })
+                    .Select(g => new UsageBucketRow(/* bucket, key=Provider, summed measures */)),
+                AnalyticsDimension.Agent => q.GroupBy(r => new { r.Day, r.AgentId }) /* … */,
+                // workflow → WorkflowDefinitionId, repo → RepoId; NULL key preserved.
+                _ => q.GroupBy(r => r.Day).Select(g => new UsageBucketRow(/* bucket, summed */)),
+            };
+            return new UsageResponse(w.From, w.To, w.Granularity, groupBy, await Materialize(rows, ct));
+        }
+        // granularity == Hour → identical against db.AnalyticsUsageHourly (r.Hour bucket).
+    }
+    // GetBreakdownAsync: GROUP BY <dimension> over the window, OrderByDescending(metric), Take(limit).
+}
+```
+
+Measure summation matches the 36-1 columns (`TokensIn`, `TokensOut`, `WorkflowsStarted`,
+`WorkflowsCompleted`, `WorkflowsFailed`, `AgentDispatches` as `long`; `CostUsd`,
+`PlatformBilledUsd` as `decimal(20,4)`). There is **no `TenantId` column** on the fact tables
+(36-1 Doc 01 §1.4); isolation is the per-tenant schema the factory binds — the `Where` is only on
+the bucket + dimension, not a tenant predicate.
+
+### `AnalyticsWindow` clamp (AC7, AC9)
+
+```csharp
+public readonly record struct AnalyticsWindow(
+    DateTime From, DateTime To, AnalyticsGranularity Granularity, bool IsValid, string? Error)
+{
+    public static AnalyticsWindow Resolve(DateTime? from, DateTime? to, string? granularity)
+    {
+        var toUtc   = ToUtc(to)   ?? DateTime.UtcNow;
+        var fromUtc = ToUtc(from) ?? toUtc.AddDays(-30);            // default 30d
+        if (fromUtc >= toUtc) return Invalid("from must precede to");
+
+        // Max range 365d — truncate to the most-recent 365d, echo the effective window.
+        if ((toUtc - fromUtc).TotalDays > 365) fromUtc = toUtc.AddDays(-365);
+
+        var gran = ParseGranularity(granularity);                   // default Day; 400 on bad enum
+        // Hourly scans are capped (default 31d) — an unbounded hourly window is the anti-pattern.
+        if (gran == AnalyticsGranularity.Hour && (toUtc - fromUtc).TotalDays > 31)
+            return Invalid("granularity=hour requires a window <= 31 days");
+
+        return new(fromUtc, toUtc, gran, true, null);
+    }
+
+    private static DateTime? ToUtc(DateTime? v) => v is null
+        ? null : DateTime.SpecifyKind(v.Value.ToUniversalTime(), DateTimeKind.Utc);
+}
+```
+
+### Response contract (AC8 — stable, dashboard + exporter consumable)
+
+```jsonc
+// GET …/analytics/usage?granularity=day&groupBy=provider
+{
+  "tenantId": "…",
+  "period_start": "2026-05-18T00:00:00Z",  // effective UTC window after clamp
+  "period_end":   "2026-06-17T00:00:00Z",
+  "granularity":  "day",
+  "groupBy":      "provider",
+  "rows": [
+    { "period": "2026-05-18T00:00:00Z", "key": "anthropic-claude",
+      "workflowsStarted": 12, "workflowsCompleted": 11, "workflowsFailed": 1,
+      "agentDispatches": 34, "tokensIn": 120000, "tokensOut": 45000,
+      "costUsd": 1.2340, "platformBilledUsd": 1.4808 },
+    { "period": "2026-05-18T00:00:00Z", "key": null, /* unattributed bucket — never dropped */ … }
+  ]
+}
+```
+
+### Routing + RBAC wiring (Program.cs — mirror `UserDashboardEndpoints`)
+
+```csharp
+// orgs = app.MapGroup("/api/v1/orgs").RequireAuthorization("MemberAccess");  // (existing)
+orgs.MapGet("/{tenantId:guid}/analytics/usage", TenantAnalyticsEndpoints.GetUsage)
+    .AddEndpointFilter<Tamma.Api.Authorization.RequireTenantMembershipFilter>();
+orgs.MapGet("/{tenantId:guid}/analytics/usage/breakdown", TenantAnalyticsEndpoints.GetBreakdown)
+    .AddEndpointFilter<Tamma.Api.Authorization.RequireTenantMembershipFilter>();
+
+builder.Services.AddScoped<ITenantAnalyticsService, TenantAnalyticsService>();
+```
+
+`MemberAccess` requires only an authenticated user (Program.cs line ~991); the cross-tenant guard
+is `RequireTenantMembershipFilter` (403 when the caller has no membership in the route `{tenantId}`
+— `apps/tamma-elsa/src/Tamma.Api/Authorization/RequireTenantMembershipFilter.cs`). This is the
+exact gate the existing `/api/v1/orgs/{tenantId}/dashboard/*` and `/api/v1/orgs/{tenantId}/alerts`
+routes use. **No** owner/admin policy is added — GET is member-readable (AC5).
+
+> **Why not the admin analytics surface?** `AdminAnalyticsEndpoints` +
+> `IPlatformAnalyticsService` (Story 28-10) read **across all tenants** behind `OwnerAccess`/admin
+> and serve platform-owner business analytics off the CP `platform_analytics_hourly` table. This
+> story is the **tenant-facing** mirror: per-tenant, member-readable, reading the per-tenant
+> `analytics_usage_*` tables. The two surfaces are deliberately separate (CLAUDE.md two-scoping
+> rule); this story never reads CP analytics and never duplicates the OPS/health metrics of
+> Epic 5 / Epic 23.
+
+### Per-mode + per-tenant handling
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who is the principal? | The sole user — `{tenantId}` resolves to their (only) tenant schema. | The tenant — `{tenantId}` is the tenant's `t_<hex>` schema. |
+| Who can read (GET)? | The user (no RBAC). | Any tenant member (`MemberAccess` + membership filter); `member` is read-only and reads succeed (no 403 on GET). |
+| Endpoint shape | identical | identical — auth middleware/membership filter binds the caller, handler has no per-mode branch (prompt-store precedent). |
+| Isolation plane | search-path schema + connection string (no `TenantId` column, no query filter). | same — physically separate schema per tenant; a row in schema A is unreachable through schema B's context. |
+| Cross-tenant leakage | N/A (one tenant). | `RequireTenantMembershipFilter` 403s a non-member of the route tenant; the per-tenant `TenantDbContext` physically can't read another schema (AC4/AC12). |
+
+### Source tables (read-only; owned by 36-1, populated by 36-2)
+
+- **`AnalyticsUsageDaily`** (`db.AnalyticsUsageDaily`, bucket `Day` UTC-midnight) — default grain.
+- **`AnalyticsUsageHourly`** (`db.AnalyticsUsageHourly`, bucket `Hour` UTC top-of-hour) — fine grain.
+- Dimensions: `Provider` (required), `AgentId` / `WorkflowDefinitionId` / `RepoId` (nullable),
+  `CostBasis` (`byok`|`platform`). Breakdown index `IX_analytics_usage_*_breakdown` (36-1 AC6)
+  serves these grouped reads.
+- `ProviderDiagnostic` (`apps/tamma-elsa/src/Tamma.Data/Entities/ProviderDiagnostic.cs`) is a 36-2
+  *projection source*, **not** read by this query API — this story reads only the pre-aggregated
+  facts (AC1).
+
+## Dependencies
+
+**Prerequisite (internal):**
+- **Story 36-1** — the per-tenant `AnalyticsUsageHourly` / `AnalyticsUsageDaily` fact tables +
+  `CostBasis` enum + breakdown indexes this API reads. (Drafted.)
+- **Story 36-2** — the projection pipeline that populates those tables from DCB events +
+  `ProviderDiagnostic`. The query API returns the rows 36-2 writes; reconciliation (per-dimension
+  rows sum to total) is 36-2's contract verified here at read time. (Drafted.)
+- **Epic 28** — `TenantContextMiddleware`
+  (`apps/tamma-elsa/src/Tamma.Api/Middleware/TenantContextMiddleware.cs`), `ITenantContext`, and
+  `ITenantDbContextFactory` (`apps/tamma-elsa/src/Tamma.Data/Abstractions/ITenantDbContextFactory.cs`
+  / `TenantDbContextFactory.cs`) — the per-tenant schema routing this API resolves through. (Merged.)
+- **Epic 18** — tenant membership RBAC: `RequireTenantMembershipFilter`
+  (`apps/tamma-elsa/src/Tamma.Api/Authorization/RequireTenantMembershipFilter.cs`) +
+  `MemberAccess` policy (Program.cs) — the member-read gate + cross-tenant 403. (Merged.)
+
+**Blocks (internal):**
+- **Story 36-6** (tenant analytics dashboard, `packages/dashboard-user`) — consumes this contract.
+- **Story 36-8** (usage exports CSV/JSON) — re-uses the same `ITenantAnalyticsService` query +
+  `period_start`/`period_end` echo to label exports.
+
+**Left intact (NOT a dependency — explicitly untouched):**
+- **Story 28-10** — `AdminAnalyticsEndpoints`, `IPlatformAnalyticsService`,
+  `platform_analytics_hourly` (platform-owner business analytics). This story adds a parallel
+  tenant surface; it does not read, modify, or re-route the CP path (AC11).
+
+**External:**
+- PostgreSQL 17 (per-tenant schema; `timestamp with time zone` bucket columns).
+- EF Core 9 / Npgsql.
+- Testcontainers + Docker for the isolation/grouping integration suite (run via
+  `sg docker -c "dotnet test ..."`).
+
+## Testing Strategy
+
+1. **Unit — window clamp (`TenantAnalyticsServiceTests`):** default window (30d / now); 400-day
+   `from..to` truncates to most-recent 365d with the effective window echoed; `granularity=hour`
+   past the 31-day cap → 400; `from >= to` → 400; bad `granularity`/`groupBy`/`dimension`/`metric`
+   enum → 400.
+
+2. **Unit — UTC binding:** a `from` with a non-UTC offset (e.g. `+02:00`) normalizes to the same
+   UTC instant as its `Z` equivalent and selects the identical bucket set (the
+   `AdminAnalyticsEndpoints` fix proven for this surface).
+
+3. **Unit — grouping correctness (InMemory, seeded `AnalyticsUsageDaily`/`Hourly`):**
+   - `groupBy` absent → one summed row per bucket.
+   - `groupBy=provider|agent|workflow|repo` → one row per `(bucket, dimension)`; the `NULL`
+     dimension bucket is surfaced (key `null`), never dropped or coerced to `"unknown"`.
+   - **Reconciliation:** `Σ(grouped rows per bucket) == ungrouped row for that bucket` (the 36-2
+     reconciliation contract held at read time).
+   - breakdown: top-N by each `metric` (`tokens`/`runs`/`dispatches`/`cost`) ordered desc,
+     `limit` clamp respected.
+
+4. **Endpoint — RBAC matrix (`TenantAnalyticsEndpointsTests`):** member / tenant_admin /
+   tenant_owner all read 200; non-member of the route tenant → 403; unauthenticated → 401;
+   single-user mode (sole user) reads 200. Asserts the handlers reference **only**
+   `ITenantAnalyticsService` (no `IPlatformAnalyticsService` / `ControlPlaneDbContext`) — CP
+   untouched (AC11).
+
+5. **Integration — isolation + grouping (`TenantAnalyticsIntegrationTests`, Postgres 17
+   Testcontainer, two tenant schemas, per `SchemaPerTenantMigrationTests`):** seed distinct fact
+   rows in schema A and schema B; a tenant-A caller on tenant-A route sees only A's rows; a
+   tenant-A caller on tenant-B route → 403 and **zero** B rows returned (AC4/AC12); grouping
+   correctness + reconciliation against real Npgsql `GROUP BY`; range clamp + UTC bucket selection
+   on real `timestamp with time zone` columns.
+
+**Mocks:** No external provider/Stripe calls (read-only aggregation). InMemory provider for clamp
+/ grouping shape; a real Postgres 17 Testcontainer for per-tenant isolation + real `GROUP BY` /
+`timestamp with time zone` window selection (EF InMemory does not model schema isolation or
+date-bucket semantics faithfully — same rationale as `ConventionStoreMigrationTests`).
+
+## Estimated Effort
+
+3-4 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/TenantAnalyticsEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/ITenantAnalyticsService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/TenantAnalyticsService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/TenantAnalyticsDtos.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map 2 org routes + register `ITenantAnalyticsService`) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/TenantAnalyticsServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/TenantAnalyticsEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/TenantAnalyticsIntegrationTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, decisions (analytics, tenancy, RBAC,
+   cross-tenant leakage).
+3. Reviewed Story 36-1 (the fact tables/columns/indexes this API reads), Story 36-2 (the
+   reconciliation contract this API verifies at read time), and the precedents this story mirrors:
+   `UserDashboardEndpoints` (route `{tenantId}` + `ITenantDbContextFactory` + membership filter),
+   `AdminAnalyticsEndpoints` (the forced-UTC `from`/`since` binding fix), and
+   `RequireTenantMembershipFilter` (the cross-tenant 403 guard).
+4. Confirmed the test runner: docker-bound suites run via `sg docker -c "dotnet test ..."`
+   (session docker group is stale; the build itself needs no wrapper).
+5. Planned the TDD cycle (write `TenantAnalyticsServiceTests` grouping/clamp/UTC red first, then
+   the service, then the endpoints + integration suite).
+
+### Key Design Decisions
+
+- **Mirror `UserDashboardEndpoints`, not `AdminAnalyticsEndpoints`.** The tenant query API is a
+  route-`{tenantId}` + `ITenantDbContextFactory` + `RequireTenantMembershipFilter` surface (the
+  user-dashboard shape), NOT the cross-tenant `OwnerAccess` admin shape. The admin analytics
+  endpoints stay the platform-owner business surface (28-10) — this story does not read or touch
+  them. Two surfaces, two scoping models (CLAUDE.md two-scoping rule).
+- **Member-read RBAC.** GET carries `MemberAccess` + the membership filter and **never** an
+  owner/admin policy — usage analytics is read-only and tenant-wide, mirroring the prompt-store
+  "GET resolved → any tenant member". This is a deliberate divergence from `AlertEndpoints`, whose
+  mutating tenant routes inline-gate admin+ via `RequireTenantAdmin`; this story has no mutations.
+- **Read pre-aggregated facts, never re-scan the stream.** The whole point of 36-1/36-2 is that a
+  tenant chart reads one indexed `GROUP BY` over `analytics_usage_*`, not a `domain_events` scan.
+  The service touches only the fact tables (and `ProviderDiagnostic` is a 36-2 source, not read
+  here).
+- **Forced-UTC binding is load-bearing.** The 36-1 buckets are UTC top-of-hour / midnight. A
+  `from`/`to` parsed as Local would shift the window off the bucket boundary and silently drop or
+  double-count edge buckets — the `AdminAnalyticsEndpoints.GetEventHistogram` fix is replicated
+  verbatim (AC9). Pin it with the offset-equivalence test.
+- **Bounded by construction.** 365-day max range + hour-granularity cap keep a malicious or naive
+  `from=1970..to=now&granularity=hour` from issuing an unbounded scan. Clamping (not erroring) the
+  range keeps the dashboard forgiving; rejecting an oversized hourly window (400) keeps the cost
+  predictable.
+- **`NULL` dimension preserved.** A grouped query surfaces the `NULL` "unattributed" bucket as a
+  `null` key — never dropped, never `"unknown"` — so the per-dimension breakdown reconciles to the
+  ungrouped total, honoring 36-2's reconciliation guarantee. Coercing `NULL` to a sentinel would
+  fork the total.
+
+### Query-only boundary
+
+This story creates **no** schema change (reads 36-1's tables), **no** projection/population logic
+(36-2 owns it), **no** export format (36-8), **no** dashboard UI (36-6 in `packages/dashboard-user`),
+and **no** change to the control-plane `AdminAnalyticsEndpoints` / `platform_analytics_hourly`
+owner surface (28-10). Any PR that adds population, an export endpoint, or a UI under cover of this
+story is out of scope — keep the diff to the endpoints + service + DTOs + Program wiring + tests.
+
+## Logging Requirements
+
+- **INFO**: usage query served (`tenantId`, `granularity`, `groupBy`, effective
+  `periodStart`/`periodEnd`, `rowCount`, `durationMs`); breakdown query served (`tenantId`,
+  `dimension`, `metric`, `limit`, `rowCount`).
+- **DEBUG**: requested-vs-effective window after clamp (`requestedFrom`, `requestedTo`,
+  `effectiveFrom`, `effectiveTo`, `clamped`); fact table chosen (`hourly`|`daily`).
+- **WARN**: window clamped to 365-day max (`requestedDays`); hourly window rejected over cap
+  (`requestedDays`, `cap`); empty result for a non-trivial window (possible un-projected tenant —
+  hint to check the 36-2 rollup lag SLO).
+- **ERROR**: tenant DB context resolution failure (`tenantId`) surfaced as 500 — never leak the
+  tenant connection string into the response or log.
+- **Structured context**: include `{ tenantId, granularity, groupBy, dimension, metric,
+  periodStart, periodEnd, rowCount, durationMs }` where applicable.
+- **Credential safety**: NEVER log the per-tenant connection string or search-path schema secret
+  (AES-GCM-encrypted at rest via `TenantSecretProtector`); the cross-tenant 403 message must not
+  echo the other tenant's identity beyond the route value the caller already supplied.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-36/story-36-4/36-4-cost-and-spend-analytics-api.md
+++ b/docs/stories/epic-36/story-36-4/36-4-cost-and-spend-analytics-api.md
@@ -1,0 +1,556 @@
+# Story 36-4: Cost & Spend Analytics API (BYOK vs Platform)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-phase workflow (Read → Research → Break Down → TDD →
+Quality Gates → Failure Handling), the `.dev/` knowledge base, TRACE/DEBUG logging
+requirements, test-first development, and the build-success / coverage gates.
+
+## User Story
+
+As a **tenant administrator** (SaaS) **/ self-hosted owner** (single-user),
+I want a tenant-scoped cost & spend analytics endpoint that separates the raw provider cost I
+paid on my own BYOK keys (informational only — Tamma never marks it up) from the
+platform-provided usage Tamma fronts and bills (cost basis + margin = `PlatformBilledUsd`), and
+that shows my spend over time by provider and by agent, my month-to-date and projected
+end-of-month billable spend, and how that projection stands against my configured budget,
+so that I can see exactly where my money goes, distinguish my own provider bills from what
+Tamma will invoice me, and catch a budget overrun before the period closes.
+
+## Priority
+
+P0 — Cost transparency (BYOK vs platform split + budget projection) is the headline tenant-facing
+analytics surface of Epic 36 and gates the billing-dashboard trust story. It is the first
+**read** consumer of the dimensional fact tables (Story 36-1) populated by the projection
+pipeline (Story 36-2).
+
+## Scope
+
+The **analytics read side only**. This story builds a tenant-scoped `CostAnalyticsService` and a
+`GET /api/v1/orgs/{tenantId}/analytics/cost` endpoint that read the already-populated, per-tenant
+`analytics_usage_daily` fact table (Story 36-1 / Story 36-2) and join `BudgetConfig` for budget
+context, then emit a budget-projection-exceeded DCB event when the linear run-rate projection
+crosses the tenant's budget cap.
+
+**Out of scope (hard boundary):**
+- **No markup / margin computation.** The markup *engine* is Story 34-5; `PlatformBilledUsd` is
+  already materialized per fact row by Story 36-2 (which consumes 34-5's margin via the
+  `IAnalyticsPricingConfig` seam). This endpoint reads `PlatformBilledUsd` as the single source of
+  truth and **never re-applies a margin** (AC4). The BYOK-fee / seat-fee model (Story 36-7) is also
+  consumed upstream, not recomputed here.
+- **No billing / charging mechanics.** Invoicing, metering, overage line items, and limit
+  *enforcement* live in (re-targeted) Epic 20. This story reports spend; it does not charge, cap,
+  or block.
+- **No projection / population.** The fact tables are filled by Story 36-2's
+  `HourlyAnalyticsRollupWorkflow` fan-out; this story never writes a fact row.
+- **No schema change to the fact tables.** It reads `analytics_usage_daily`; the only new persisted
+  artefact is the DCB event it emits.
+- **No new budget write/limit surface.** `BudgetConfig` is read-only here (write/limits stay in
+  Epic 20 / the existing budget API).
+
+## Acceptance Criteria
+
+1. A new `CostAnalyticsService`
+   (`apps/tamma-elsa/src/Tamma.Api/Services/Analytics/CostAnalyticsService.cs`, behind a new
+   `ICostAnalyticsService` in the same folder) reads one tenant's `analytics_usage_daily` rows
+   (Story 36-1) through `ITenantDbContextFactory.CreateAsync(tenantId, ct)` — the per-tenant
+   search-path schema is the only data plane it touches; it never reads the control-plane
+   `platform_analytics_hourly` table or another tenant's schema.
+
+2. `GET /api/v1/orgs/{tenantId}/analytics/cost?from=ISO&to=ISO&groupBy=provider|agent` returns a
+   **daily spend time-series** in which every bucket carries two separate measures:
+   `byokCostUsd` (sum of `CostUsd` where `CostBasis = byok` — raw provider cost, informational) and
+   `platformBilledUsd` (sum of `PlatformBilledUsd` where `CostBasis = platform` — the billable
+   amount). The series is grouped by `Day`; an optional `groupBy=provider|agent` adds a second
+   grouping dimension (the `Provider` / `AgentId` fact dimension), with the `AgentId = NULL` bucket
+   surfaced as `"unattributed"` in the response (never dropped, so per-group sums reconcile to the
+   ungrouped total).
+
+3. The response includes a `summary` object with **month-to-date** `platformBilledUsd` (sum over
+   the current calendar-month-to-date in the tenant's reporting timezone — UTC), a **projected
+   end-of-month** `platformBilledUsd` computed by **linear run-rate**
+   (`mtdBilled / daysElapsed * daysInMonth`), and the current **budget** + **alertThreshold**
+   pulled from `BudgetConfig` for the tenant (`GetAsync(tenantId, accountId, ct)` where `accountId`
+   is the tenant GUID string, per the existing budget scope convention). When no `BudgetConfig`
+   row exists the budget fields are `null` and projection is still returned.
+
+4. **`PlatformBilledUsd` is read, never recomputed.** The endpoint sums the
+   `analytics_usage_daily.PlatformBilledUsd` column materialized by Story 36-2 (which is itself the
+   product of Story 34-5's markup engine) and **does not multiply by any margin**. A test asserts
+   that changing a (mocked) margin config has zero effect on this endpoint's output — proving the
+   single-source-of-truth contract.
+
+5. **BYOK rows never contribute to `platformBilledUsd`.** Because Story 36-2 writes
+   `PlatformBilledUsd = 0` for every `CostBasis = byok` fact row, a `byok`-basis day contributes
+   only to `byokCostUsd`. An integration test seeds a **fully-BYOK** tenant and asserts the
+   response shows `summary.platformBilledUsd == 0` (and `projectedPlatformBilledUsd == 0`) while
+   `byokCostUsd > 0` — markup on a BYOK call is structurally impossible here.
+
+6. **Cost trends** are derivable: the response exposes a `trend` block with the prior-equivalent-
+   window `platformBilledUsd` (the immediately preceding window of the same length) and the
+   percentage delta vs the requested window, so a dashboard can render "spend up/down X% vs last
+   period" without a second request. BYOK cost carries its own informational delta in the same
+   block.
+
+7. **Budget-vs-actual** is explicit: the `summary` reports `budgetUsd`, `mtdPlatformBilledUsd`,
+   `projectedPlatformBilledUsd`, `budgetUtilizationPct` (`mtdBilled / budgetUsd`),
+   `projectedUtilizationPct` (`projectedBilled / budgetUsd`), and a boolean
+   `projectedToExceedBudget` (`projectedBilled > budgetUsd`). All utilization fields are `null` when
+   no budget is configured.
+
+8. **RBAC — per mode.** The endpoint is tenant-scoped under the existing
+   `/api/v1/orgs` group (`MemberAccess` policy) plus the `RequireTenantMembershipFilter` endpoint
+   filter on the `{tenantId:guid}` route — exactly the pattern every other
+   `/api/v1/orgs/{tenantId:guid}/...` route uses. In **SaaS mode** any tenant member (including
+   `member`) may read; **no** owner/admin elevation is required for read (write/limits live in
+   Epic 20). In **single-user mode** the sole user is the only caller and owns the data. A
+   cross-tenant caller is rejected by the membership filter (404/403) before the handler runs.
+
+9. **Budget-projection-exceeded DCB event.** When `projectedToExceedBudget` is true (a budget is
+   configured and the linear projection exceeds it), the service appends one
+   `ANALYTICS.COST.BUDGET_PROJECTED_EXCEEDED` `DomainEvent` (via `IEventRepository.AppendAsync`,
+   `TenantId` set, `Type` following the `AGGREGATE.ACTION.STATUS` convention) tagged with
+   `tenantId`, `mode`, `budgetUsd`, `projectedPlatformBilledUsd`, and `window`, so the alerting /
+   scheduled-report pipeline (a downstream Epic 36 / Story 5.6 consumer) can act on it. Emission is
+   **best-effort and deduplicated within the calendar period** — a read that re-projects the same
+   exceed condition within the same month does **not** emit a second event (dedup keyed
+   `(tenantId, period)`); a read that does **not** breach emits nothing.
+
+10. **No markup, no charging, no fact-write.** The service performs read-only aggregation plus the
+    single DCB event append — it never writes `analytics_usage_*`, never calls a billing/charging
+    path, and never computes a margin. A code-shape test (or reviewer checklist item) confirms the
+    service has no dependency on the markup engine (Story 34-5) or any Epic 20 charging service.
+
+11. **Tenant isolation is physical and proven.** An integration test (Postgres 17 Testcontainer,
+    following `SchemaPerTenantMigrationTests`) seeds `analytics_usage_daily` rows into two tenant
+    schemas with different cost profiles and asserts that a request for tenant A returns only tenant
+    A's spend (tenant B's rows are unreachable through A's context — search-path isolation, no EF
+    query filter), and that the budget join reads only tenant A's `BudgetConfig`.
+
+12. **Validation + empty-state.** `from`/`to` default to the current calendar month when omitted,
+    are clamped to a max window (default 400 days) and rejected with `400` when `from > to`;
+    `groupBy` accepts only `provider` / `agent` (else `400`). A tenant with zero fact rows returns a
+    well-formed empty series with `summary` measures `0` and `null` trend deltas — never a 500.
+
+13. Unit + integration tests cover: the BYOK/platform split (AC2, AC5); projection math (AC3 —
+    run-rate against a fixed clock); the `BudgetConfig` join + budget-vs-actual fields (AC3, AC7);
+    `groupBy=provider` and `groupBy=agent` with the `NULL`→`"unattributed"` bucket reconciling to
+    the total (AC2); the read-only / no-re-markup contract (AC4); the
+    `ANALYTICS.COST.BUDGET_PROJECTED_EXCEEDED` emit + per-period dedup + no-emit-when-under (AC9);
+    RBAC (member read OK, cross-tenant rejected) (AC8); and per-tenant isolation (AC11).
+
+## Tasks / Subtasks
+
+- [ ] Task 1: DTOs + event constant (AC: 2, 3, 6, 7, 9)
+  - [ ] Add the response DTOs under `apps/tamma-elsa/src/Tamma.Api/Dtos/Analytics/`
+        (`CostAnalyticsResponse`, `CostSeriesBucket`, `CostSummary`, `CostTrend`).
+  - [ ] Add the `ANALYTICS.COST.BUDGET_PROJECTED_EXCEEDED` constant (a small
+        `CostAnalyticsEvents` static, or reuse the existing analytics event-constants home if one
+        fits) following the `AGGREGATE.ACTION.STATUS` convention.
+
+- [ ] Task 2: `ICostAnalyticsService` + `CostAnalyticsService` (AC: 1, 2, 3, 4, 5, 6, 7, 9, 10)
+  - [ ] Read `analytics_usage_daily` via `ITenantDbContextFactory`; aggregate `byokCostUsd`
+        (sum `CostUsd` where `CostBasis=byok`) and `platformBilledUsd` (sum `PlatformBilledUsd`)
+        per day, with optional second grouping by `Provider`/`AgentId`.
+  - [ ] Compute month-to-date + linear run-rate projection against an injected `IClock`/`TimeProvider`
+        (deterministic in tests).
+  - [ ] Join `BudgetConfig` (read-only) for budget-vs-actual; compute trend vs prior window.
+  - [ ] Best-effort, per-period-deduped `ANALYTICS.COST.BUDGET_PROJECTED_EXCEEDED` emit via
+        `IEventRepository.AppendAsync` when projected > budget.
+
+- [ ] Task 3: `TenantAnalyticsEndpoints` + wiring (AC: 8, 12)
+  - [ ] Add `apps/tamma-elsa/src/Tamma.Api/Endpoints/TenantAnalyticsEndpoints.cs` with the
+        `GetCost` handler (query binding, validation, defaulting, clamping).
+  - [ ] Wire `orgs.MapGet("/{tenantId:guid}/analytics/cost", TenantAnalyticsEndpoints.GetCost)
+        .AddEndpointFilter<RequireTenantMembershipFilter>()` in `Program.cs` (the `orgs` group is
+        already `MemberAccess`); register `ICostAnalyticsService` in DI.
+
+- [ ] Task 4: Unit tests (AC: 13)
+  - [ ] InMemory-provider service tests: split, projection (fixed clock), budget join,
+        budget-vs-actual fields, grouping + `NULL`→`unattributed`, trend, no-re-markup, empty-state.
+  - [ ] Event tests: emit on breach, per-period dedup, no-emit under budget.
+
+- [ ] Task 5: Integration tests (AC: 5, 8, 11, 13)
+  - [ ] Postgres 17 Testcontainer: fully-BYOK tenant → `platformBilledUsd=0`, `byokCostUsd>0`;
+        two-tenant isolation (A sees only A); RBAC (member read OK, cross-tenant rejected).
+
+## Technical Design
+
+### C# namespace / file structure
+
+```
+apps/tamma-elsa/src/
+  Tamma.Api/Endpoints/TenantAnalyticsEndpoints.cs            # NEW — tenant-scoped analytics endpoints
+  Tamma.Api/Services/Analytics/ICostAnalyticsService.cs      # NEW — read-side cost analytics contract
+  Tamma.Api/Services/Analytics/CostAnalyticsService.cs       # NEW — implementation
+  Tamma.Api/Services/Analytics/CostAnalyticsEvents.cs        # NEW — DCB event constant(s)
+  Tamma.Api/Dtos/Analytics/CostAnalyticsResponse.cs          # NEW — response DTOs
+  Tamma.Api/Program.cs                                       # MODIFY — register service + map route
+
+apps/tamma-elsa/tests/Tamma.Api.Tests/
+  Analytics/CostAnalyticsServiceTests.cs                     # NEW — unit (InMemory)
+  Analytics/CostAnalyticsEndpointTests.cs                    # NEW — endpoint/RBAC/validation
+  Analytics/CostAnalyticsIsolationTests.cs                   # NEW — Postgres 17 isolation + BYOK split
+```
+
+> **Targeting note.** All new code lands in the C# `apps/tamma-elsa` solution. The legacy
+> TypeScript `packages/api` is deleted and is **not** a target for any file in this story.
+
+### Source columns (verified, real)
+
+The service reads **only** the per-tenant `analytics_usage_daily` fact table (Story 36-1) plus the
+control-plane-resident `BudgetConfig` for budget context:
+
+- **`AnalyticsUsageDaily`** (NEW in Story 36-1 — `Day`, `Provider`, `AgentId`,
+  `WorkflowDefinitionId`, `RepoId`, `CostBasis` enum `byok|platform`, measures `CostUsd` and
+  `PlatformBilledUsd` as `decimal(20,4)`, plus token/workflow counters). This story consumes
+  `Day`, `Provider`, `AgentId`, `CostBasis`, `CostUsd`, `PlatformBilledUsd`.
+- **`BudgetConfig`** (`Tamma.Data/Entities/BudgetConfig.cs`, verified real) — `LimitUsd`,
+  `AlertThreshold`, `PeriodDays`, keyed `(TenantId, AccountId)` where `AccountId` is the tenant GUID
+  string today; read via the existing `BudgetConfigRepository.GetAsync(tenantId, accountId, ct)`.
+
+`PlatformBilledUsd` is the **materialized billable amount** written by Story 36-2 (cost basis ×
+margin, where the margin comes from Story 34-5's markup engine via 36-2's `IAnalyticsPricingConfig`
+seam). This endpoint **sums it; it does not derive it.** BYOK rows already carry
+`PlatformBilledUsd = 0` (Story 36-2 AC), so the split falls out of the data with no special-casing
+beyond reading the right column per cost basis.
+
+### `ICostAnalyticsService` (read-side contract)
+
+```csharp
+public interface ICostAnalyticsService
+{
+    /// <summary>
+    /// Tenant-scoped cost/spend analytics for [from, to): a daily byok/platform
+    /// split series (optionally grouped by provider|agent), month-to-date +
+    /// linear-run-rate projection, a BudgetConfig join, and a trend vs the prior
+    /// equivalent window. Emits ANALYTICS.COST.BUDGET_PROJECTED_EXCEEDED
+    /// (best-effort, per-period deduped) when the projection crosses the budget.
+    /// Reads analytics_usage_daily through the tenant's own schema only —
+    /// PlatformBilledUsd is read as the single source of truth (no re-markup).
+    /// </summary>
+    Task<CostAnalyticsResponse> GetCostAsync(
+        Guid tenantId,
+        DateOnly from,
+        DateOnly to,
+        CostGroupBy groupBy,        // None | Provider | Agent
+        string mode,                // ITammaModeProvider value, for the event tag
+        CancellationToken ct);
+}
+```
+
+### Aggregation sketch (read-only)
+
+```csharp
+await using var db = await _factory.CreateAsync(tenantId, ct);
+
+var rows = await db.AnalyticsUsageDaily
+    .Where(r => r.Day >= fromUtc && r.Day < toUtcExclusive)
+    .Select(r => new { r.Day, r.Provider, r.AgentId, r.CostBasis, r.CostUsd, r.PlatformBilledUsd })
+    .ToListAsync(ct);
+
+// byokCostUsd = Σ CostUsd where CostBasis == Byok  (informational)
+// platformBilledUsd = Σ PlatformBilledUsd          (billable; byok rows are already 0)
+// group by Day (+ Provider|AgentId when requested; AgentId NULL -> "unattributed")
+```
+
+Counters are decimals throughout (`decimal(20,4)` round-trips losslessly from the fact column). The
+run-rate projection uses an injected `TimeProvider` so tests pin "today" inside the month.
+
+### Budget-vs-actual + projection
+
+```csharp
+var budget = await _budgets.GetAsync(tenantId, tenantId.ToString(), ct);   // existing scope key
+var mtdBilled = /* Σ PlatformBilledUsd for current-month-to-date */;
+var daysElapsed = now.Day;                       // 1..daysInMonth
+var daysInMonth = DateTime.DaysInMonth(now.Year, now.Month);
+var projected = daysElapsed == 0 ? 0m : mtdBilled / daysElapsed * daysInMonth;
+
+var projectedToExceed = budget is not null && projected > budget.LimitUsd;
+```
+
+`budgetUtilizationPct` / `projectedUtilizationPct` are `null` when `budget is null`.
+`AlertThreshold` is echoed straight from `BudgetConfig` (no enforcement here — that is Epic 20).
+
+### DCB event
+
+```csharp
+// AGGREGATE.ACTION.STATUS — tenant-scoped, best-effort, per-period deduped.
+public const string BudgetProjectedExceeded = "ANALYTICS.COST.BUDGET_PROJECTED_EXCEEDED";
+
+await _events.AppendAsync(new DomainEvent
+{
+    Type = CostAnalyticsEvents.BudgetProjectedExceeded,
+    TenantId = tenantId,
+    Tags = JsonSerializer.Serialize(new { tenantId, mode, period }),
+    Data = JsonSerializer.Serialize(new { budgetUsd, projectedPlatformBilledUsd, mtdPlatformBilledUsd, window }),
+    Metadata = JsonSerializer.Serialize(new { workflowVersion = "1.0.0", eventSource = "system" }),
+});
+```
+
+**Dedup:** before appending, the service checks (via `IEventRepository`) whether a
+`BUDGET_PROJECTED_EXCEEDED` event for this `(tenantId, period)` already exists this calendar month
+(`GetLastByTypeAsync` + period-tag compare, or a period-scoped query) and skips if so — so a hot
+dashboard polling the endpoint produces at most one event per tenant per month, not one per request.
+Emission never throws into the read path (a failed append is logged WARN; the response still
+returns) — consistent with the best-effort emission shape used across the rollup/alert pipeline.
+
+### Endpoint + wiring
+
+```csharp
+// TenantAnalyticsEndpoints.GetCost — minimal-API handler.
+// orgs is already MapGroup("/api/v1/orgs").RequireAuthorization("MemberAccess").
+orgs.MapGet("/{tenantId:guid}/analytics/cost", TenantAnalyticsEndpoints.GetCost)
+    .AddEndpointFilter<Tamma.Api.Authorization.RequireTenantMembershipFilter>();
+```
+
+The membership filter (already used by every `/{tenantId:guid}/...` org route) verifies the caller
+belongs to the route tenant before the handler runs; the per-tenant `TenantDbContext` then enforces
+data isolation physically. No new auth policy is introduced.
+
+### API shape
+
+```
+GET /api/v1/orgs/{tenantId}/analytics/cost?from=2026-06-01&to=2026-06-30&groupBy=provider
+
+200 OK
+{
+  "window": { "from": "2026-06-01", "to": "2026-06-30" },
+  "groupBy": "provider",
+  "series": [
+    { "day": "2026-06-01", "group": "anthropic", "byokCostUsd": 4.12, "platformBilledUsd": 0.00 },
+    { "day": "2026-06-01", "group": "openai",    "byokCostUsd": 0.00, "platformBilledUsd": 6.30 },
+    ...
+  ],
+  "summary": {
+    "byokCostUsd": 128.40,
+    "mtdPlatformBilledUsd": 211.75,
+    "projectedPlatformBilledUsd": 423.50,
+    "budgetUsd": 400.00,
+    "alertThreshold": 0.8,
+    "budgetUtilizationPct": 0.529,
+    "projectedUtilizationPct": 1.059,
+    "projectedToExceedBudget": true
+  },
+  "trend": {
+    "platformBilledUsd": 190.10,        // prior equivalent window
+    "platformBilledDeltaPct": 0.114,
+    "byokCostUsd": 120.00,
+    "byokCostDeltaPct": 0.070
+  }
+}
+```
+
+`series[].platformBilledUsd` is `0` for any BYOK-only row; `groupBy=agent` substitutes the agent id
+(or `"unattributed"`) for `group`. Endpoint shape is identical across modes — the auth middleware +
+membership filter resolve the tenant; the per-tenant context enforces isolation (the CLAUDE.md
+prompt-store precedent: same wire shape, mode-aware scoping underneath).
+
+### Per-mode + per-tenant handling
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns the cost data? | The sole user — it lives in their (only) tenant schema. | The tenant — its `t_<hex>` schema. |
+| Who may read it? | The user (no RBAC). | Any tenant member (`MemberAccess` + membership filter); `member` reads, no elevation. |
+| Cost basis split | Typically all `platform` (no `billing_mode`/BYOK signal self-hosted) → `byokCostUsd` may be 0; `platformBilledUsd` carries any configured margin from 36-2/34-5. | `byok` vs `platform` per the 35-2 `billing_mode` already baked into the fact rows by 36-2; BYOK → `byokCostUsd` only, platform → `platformBilledUsd`. |
+| Budget source | `BudgetConfig` for the sole tenant (or the platform-default NULL-tenant row). | `BudgetConfig` for that tenant. |
+| Where does the budget-exceeded event land? | The user's (only) tenant event stream (`TenantId` set). | The tenant's event stream (`TenantId` set) → tenant-scoped alerting. |
+| Cross-tenant leakage risk | N/A (one tenant). | Prevented twice: membership filter rejects non-members; the per-tenant schema makes another tenant's rows physically unreachable. |
+
+Mode does not change the wire shape — both resolve to exactly one tenant schema per request. The
+`mode` value (from `ITammaModeProvider`) is carried only as an event tag for downstream alerting.
+
+## Dependencies
+
+**Prerequisite (internal):**
+- **Story 36-1** — the per-tenant `AnalyticsUsageDaily` fact table + `CostBasis` enum +
+  `CostUsd`/`PlatformBilledUsd` measure columns this story reads. (Drafted.)
+- **Story 36-2** — the projection pipeline that **populates** `analytics_usage_daily`, including the
+  materialized `PlatformBilledUsd` (the single source of truth this endpoint sums) and the
+  `byok→PlatformBilledUsd=0` rule that makes the BYOK split structural. (Drafted.)
+- **Epic 28** — per-tenant schema + `ITenantDbContextFactory` (the data plane) + the
+  `/api/v1/orgs/{tenantId:guid}` group + `RequireTenantMembershipFilter` (the RBAC plane). (Merged.)
+- **`BudgetConfig` + `BudgetConfigRepository`** — the read-only budget join. (Merged, verified.)
+
+**Soft / forward (degrade gracefully if absent):**
+- **Story 34-5 (markup engine)** — owns the margin math; consumed **upstream** by Story 36-2 to
+  materialize `PlatformBilledUsd`. This story is decoupled from it: it reads the materialized
+  column. If 34-5/36-2 wrote zero margin, `platformBilledUsd == CostUsd` for platform rows; the
+  endpoint is correct either way (AC4 pins "no re-markup").
+- **Story 35-2 (Epic 35 `billing_mode`)** — the BYOK-vs-platform discriminator baked into the fact
+  rows' `CostBasis` by 36-2. If 35-2 has not landed, 36-2 defaults rows to `platform`; this endpoint
+  then reports `byokCostUsd = 0` and all spend as `platformBilledUsd` — still well-formed.
+- **Story 36-7 (pricing / BYOK-fee model)** — consumed upstream (by 36-2 / 34-5); not recomputed
+  here.
+
+**Blocks (internal):**
+- Downstream Epic 36 surfaces — the cost dashboard tile, exports, and scheduled cost reports — read
+  this endpoint / service. The `ANALYTICS.COST.BUDGET_PROJECTED_EXCEEDED` event feeds the
+  alerting / scheduled-report consumers.
+
+**Out-of-scope siblings (explicitly NOT dependencies of the read path):**
+- **Epic 20 (billing / charging — re-targeted)** — invoicing, metering, limit enforcement. This
+  endpoint reports; it does not charge or cap.
+
+**External:**
+- PostgreSQL 17 (per-tenant schema; isolation test).
+- EF Core 9 / Npgsql.
+- Testcontainers + Docker for the isolation / BYOK-split integration suite (run via
+  `sg docker -c "dotnet test ..."`).
+
+## Testing Strategy
+
+1. **Unit — BYOK/platform split (`CostAnalyticsServiceTests`, InMemory):** seed `analytics_usage_daily`
+   rows mixing `byok` and `platform` cost bases; assert `byokCostUsd` sums only `CostUsd` of `byok`
+   rows and `platformBilledUsd` sums `PlatformBilledUsd` (byok rows contribute 0).
+
+2. **Unit — projection math (fixed `TimeProvider`):** with "today" pinned mid-month, assert
+   `projectedPlatformBilledUsd == mtdBilled / daysElapsed * daysInMonth`; day-1 and end-of-month
+   edge cases; zero-MTD → zero projection (no divide-by-zero).
+
+3. **Unit — budget join + budget-vs-actual (AC3, AC7):** with a `BudgetConfig`, assert `budgetUsd`,
+   `alertThreshold`, `budgetUtilizationPct`, `projectedUtilizationPct`, `projectedToExceedBudget`;
+   with **no** `BudgetConfig`, assert budget/utilization fields are `null` and the series/projection
+   still return.
+
+4. **Unit — grouping (`groupBy=provider` / `groupBy=agent`):** assert one bucket per (day, group);
+   the `AgentId = NULL` rows surface as `"unattributed"`; `Σ(group buckets) == ungrouped total`
+   (reconciliation).
+
+5. **Unit — no re-markup (AC4, AC10):** run with two different (mocked) margin configs present in
+   DI; assert byte-identical `platformBilledUsd` output — proving the endpoint reads the
+   materialized column and never multiplies.
+
+6. **Unit — trend (AC6):** seed the prior equivalent window; assert `trend.platformBilledUsd` and
+   `platformBilledDeltaPct` (and the byok counterparts); empty prior window → `null` delta.
+
+7. **Unit — budget event (AC9):** projection over budget → exactly one
+   `ANALYTICS.COST.BUDGET_PROJECTED_EXCEEDED` appended with `tenantId`/`mode`/budget tags; a second
+   call same period → no second event (dedup); projection under budget → no event; a failing
+   `AppendAsync` is swallowed (response still returns, WARN logged).
+
+8. **Unit — validation / empty-state (AC12):** `from > to` → 400; bad `groupBy` → 400; omitted
+   window defaults to current month; window clamp; zero fact rows → well-formed empty series +
+   zeroed summary + null trend.
+
+9. **Integration — fully-BYOK tenant (AC5, Postgres 17 Testcontainer):** seed a tenant whose
+   `analytics_usage_daily` rows are all `byok` (so `PlatformBilledUsd = 0`); assert
+   `summary.platformBilledUsd == 0`, `projectedPlatformBilledUsd == 0`, `byokCostUsd > 0`.
+
+10. **Integration — per-tenant isolation (AC11):** seed two tenant schemas with different cost
+    profiles; assert a request for A returns only A's spend (B unreachable through A's context) and
+    the budget join reads only A's `BudgetConfig`.
+
+11. **Integration — RBAC (AC8):** a `member` of the tenant reads `200`; a non-member / cross-tenant
+    caller is rejected by `RequireTenantMembershipFilter` (404/403) before the handler runs.
+
+**Mocks:** No external provider / Stripe calls (read-only aggregation + one DCB append). InMemory
+provider for split/projection/grouping/trend/event-shape assertions; a real Postgres 17
+Testcontainer for the BYOK-split end-to-end, per-tenant isolation, and RBAC (EF InMemory does not
+model per-tenant schemas — same rationale as `ConventionStoreMigrationTests`). The margin config is
+mocked only to prove it has **no** effect (AC4).
+
+## Estimated Effort
+
+3-4 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/TenantAnalyticsEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/ICostAnalyticsService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/CostAnalyticsService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/CostAnalyticsEvents.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Dtos/Analytics/CostAnalyticsResponse.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (register `ICostAnalyticsService`, map `/analytics/cost` route) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/CostAnalyticsServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/CostAnalyticsEndpointTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/CostAnalyticsIsolationTests.cs` | Create |
+
+> `AnalyticsUsageDaily` (Story 36-1) and `BudgetConfig` (existing) are **read** by this story; they
+> are not modified. `TenantAnalyticsEndpoints.cs` and `CostAnalyticsService.cs` are NEW (verified
+> absent at authoring time).
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, decisions (analytics, cost, budget, BYOK,
+   tenancy).
+3. Reviewed Story 36-1 (the `AnalyticsUsageDaily` shape + `CostBasis` enum +
+   `CostUsd`/`PlatformBilledUsd` columns) and Story 36-2 (how `PlatformBilledUsd` is materialized
+   and why BYOK rows carry 0) — this endpoint is a *reader* of both.
+4. Reviewed `BudgetConfig` / `BudgetConfigRepository` (scope key = tenant GUID string) and the
+   `/api/v1/orgs/{tenantId:guid}` + `RequireTenantMembershipFilter` wiring in `Program.cs`.
+5. Confirmed the test runner: docker-bound suites run via `sg docker -c "dotnet test ..."`
+   (session docker group is stale; the build itself needs no wrapper).
+6. Planned the TDD cycle (write the split + projection + no-re-markup tests red first, then the
+   service).
+
+### Key Design Decisions
+
+- **Read `PlatformBilledUsd`, never recompute it.** The markup engine is Story 34-5; the margin is
+  materialized into the fact rows by Story 36-2. If this endpoint re-applied a margin it would
+  double-charge and fork the single source of truth. AC4's "margin config has zero effect" test is
+  the guardrail.
+- **BYOK split is structural, not a special case.** Story 36-2 writes `PlatformBilledUsd = 0` for
+  every `byok` row, so summing the right column per cost basis yields the split with no branching —
+  a fully-BYOK tenant *cannot* show non-zero platform-billed spend (AC5). `byokCostUsd` is purely
+  informational ("here's what you paid your own provider").
+- **Linear run-rate projection, documented as such.** `mtd / daysElapsed * daysInMonth` is the
+  simplest defensible projection and matches how operators reason about budgets. It is deliberately
+  not a smoothed/seasonal model — that is a later enhancement, not P0. The clock is injected so the
+  math is deterministic in tests.
+- **Per-period event dedup, best-effort emission.** A dashboard may poll this endpoint many times a
+  day; the budget-exceeded DCB event is for *alerting*, so it fires at most once per tenant per
+  calendar period and never throws into the read path. The dedup key is `(tenantId, period)`, read
+  from the existing event store before appending.
+- **No new auth policy.** Tenant-scoped reads ride the established `/api/v1/orgs/{tenantId:guid}`
+  group (`MemberAccess` + `RequireTenantMembershipFilter`). Read access is `member`-level by design
+  (cost transparency is a team-wide concern); write/limit power stays in Epic 20.
+- **Daily grain, not hourly.** Cost dashboards and budget projection work on days; reading
+  `analytics_usage_daily` (pre-compacted by 36-2) keeps the query cheap and avoids re-aggregating
+  the hourly table on every request.
+
+### Read-only boundary
+
+This story adds **no** projection/population, **no** schema change to the fact tables, **no** markup
+/ margin math, **no** billing/charging/limit-enforcement, and **no** write to `analytics_usage_*`.
+Its only persisted side effect is the deduped `ANALYTICS.COST.BUDGET_PROJECTED_EXCEEDED` DCB event.
+Any PR that adds margin computation, a charging call, or a fact-table write under cover of this
+story is out of scope — keep the diff to the read service, the endpoint, the DTOs, the event
+constant, and tests.
+
+## Logging Requirements
+
+- **INFO**: cost analytics queried (`tenantId`, `from`, `to`, `groupBy`, `rows`,
+  `mtdPlatformBilledUsd`, `projectedPlatformBilledUsd`); budget-projected-exceeded event emitted
+  (`tenantId`, `budgetUsd`, `projectedPlatformBilledUsd`, `period`).
+- **DEBUG**: per-bucket aggregation; budget join result (`budgetUsd`, `alertThreshold` — never the
+  raw row); projection inputs (`mtdBilled`, `daysElapsed`, `daysInMonth`); dedup decision
+  (event already present this period → skip).
+- **WARN**: budget-exceeded event append failed (best-effort — response still returned);
+  request window clamped (`requested`, `clamped`).
+- **ERROR**: tenant context resolution failure / unexpected aggregation error surfaced as a 500
+  (with `tenantId`, no data values).
+- **Structured context**: include `{ tenantId, from, to, groupBy, mode, budgetUsd,
+  mtdPlatformBilledUsd, projectedPlatformBilledUsd }` where applicable.
+- **Credential safety**: NEVER log tenant connection strings, search-path schema secrets, or
+  provider API keys. The endpoint reads only aggregated cost/spend numbers and the `billing_mode`-
+  derived `CostBasis` discriminator — never raw provider-key plaintext. Cost figures are
+  business-sensitive but not secrets; still scope them to DEBUG, not INFO, beyond the summary.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-36/story-36-5/36-5-agent-and-tenant-performance-rollups-api.md
+++ b/docs/stories/epic-36/story-36-5/36-5-agent-and-tenant-performance-rollups-api.md
@@ -1,0 +1,602 @@
+# Story 36-5: Agent & Tenant Performance Rollups API (consume Epic 32)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-phase workflow (Read → Research → Break Down → TDD →
+Quality Gates → Failure Handling), the `.dev/` knowledge base, TRACE/DEBUG logging
+requirements, test-first development, and the build-success / coverage gates.
+
+This story targets the C# **`apps/tamma-elsa`** stack (Tamma.Api + Tamma.Data + Tamma.Core).
+The TypeScript `packages/api` is **deleted** — do not reference it. DCB event sourcing, the
+agent action trail (32-6) and outcome/defect capture (32-8), the `ProviderDiagnostic`
+diagnostics (Epic 9), the dimensional analytics store (36-1) and its projection pipeline (36-2),
+the per-tenant `TenantDbContext`, and the tenant-scoped `IEventRepository` all live in
+`apps/tamma-elsa`.
+
+## User Story
+
+As a **tenant owner/member deciding which agent and provider configuration to keep running my
+design and review work**,
+I want a **reporting API over my own pre-aggregated analytics** — per-agent rollups (runs,
+success rate, average duration, tokens-per-run, cost-per-run, platform-billed) over a selectable
+window, a daily trend per agent, and a tenant-level performance summary — read **only** from my
+tenant's datasets,
+So that I can compare my agents on real downstream success and cost without ever exposing my
+performance data to another tenant or to the platform admin who happens to own a public agent
+definition.
+
+## Priority
+
+P1 — the consumable reporting payoff of the Epic 36 analytics pipeline. Stories 36-1/36-2 build
+and fill the per-tenant `analytics_usage_hourly`/`analytics_usage_daily` fact tables; this story
+turns that dimensional store into the agent/tenant performance views a tenant actually reads.
+Without it the facts are queryable row-by-row but there is no rollup/reporting surface.
+
+## Scope
+
+**Reporting API only.** This story is a **read-side consumer** of the Story 36-1/36-2 dimensional
+fact tables and the Epic 9 `ProviderDiagnostic` outcome substrate. It:
+
+- adds an `AgentPerformanceAnalyticsService` that aggregates a tenant's own `analytics_usage_daily`
+  (with `analytics_usage_hourly` for sub-day windows) into **per-agent rollups** keyed by the
+  `AgentId` dimension, resolving each agent's display **name** from the Epic 32 agent registry;
+- adds a **daily trend** read (success rate + cost + tokens) for one agent;
+- adds a **tenant-level summary** (blended success rate, total billable spend, most/least
+  efficient agents);
+- exposes all three behind tenant-scoped `/api/v1/orgs/{tenantId}/analytics/agents*` endpoints
+  with member-read RBAC.
+
+It does **NOT**:
+
+- **recompute or duplicate Story 32-10's `BenchmarkProjectionService`.** 32-10 owns the
+  agent/provider/prompt/persona **leaderboard** read model (success rate, iterations-to-done,
+  defect-by-category, p50/p95 latency, k-anonymous public-agent fleet rollup) folded directly from
+  the `AGENT.*` action-trail events into the tenant's `BenchmarkProjection` rows. **This story is
+  the analytics-layer rollup/reporting API** that reads the Epic 36 **dimensional usage store**
+  (provider/agent/workflow/repo/cost-basis facts) — a different projection, a different shape
+  (cost/throughput-centric, not defect/latency-centric), serving the Epic 36 analytics product.
+  Where the two overlap (per-agent success rate), this story reads the 36-1 fact measures
+  (`WorkflowsStarted/Completed/Failed` per agent) and **references** 32-10 rather than re-folding
+  the action trail. The leaderboard and this rollup are sibling read models, not the same surface.
+- alter the 36-1 fact-table schema, change the 36-2 projection, or add a new source-event family;
+- expose any cross-tenant or platform-admin per-tenant performance path (performance rollups are
+  **strictly per-tenant** — a platform admin cannot read a tenant's agent performance; the only
+  cross-tenant analytics surface that exists is 32-10's k-anonymous **public-agent** fleet rollup,
+  which this story does not extend).
+
+## Acceptance Criteria
+
+1. A new `AgentPerformanceAnalyticsService`
+   (`apps/tamma-elsa/src/Tamma.Api/Services/Analytics/AgentPerformanceAnalyticsService.cs`,
+   behind `IAgentPerformanceAnalyticsService`) reads the resolving tenant's own
+   `analytics_usage_daily` rows (and `analytics_usage_hourly` for windows finer than a day) via
+   `ITenantDbContextFactory.CreateAsync(tenantId, ct)` and produces **per-agent rollups** grouped
+   by the `AgentId` dimension over a `[from, to)` window. It exposes a static pure-DI
+   `ComputeAgentRollupsAsync(...)` entry point (taking the resolved `TenantDbContext`, an
+   `IAgentNameResolver`, `tenantId`, window, ordering metric, logger, `CancellationToken`) so the
+   endpoint and unit tests drive the same code without an HTTP context — mirroring the
+   `PlatformAnalyticsService` aggregation shape.
+
+2. `GET /api/v1/orgs/{tenantId}/analytics/agents?from=&to=&orderBy=&limit=` returns per-agent
+   rollups — each row `{ agentId, name, runs, successRate, avgDurationMs, tokensPerRun,
+   costUsdPerRun, platformBilledUsd }` — over the window, **ordered by a selectable metric**
+   (`orderBy` ∈ `runs|successRate|avgDurationMs|tokensPerRun|costUsdPerRun|platformBilledUsd`;
+   default `runs` desc) with a documented stable final tie-break on `agentId` asc. `runs` is the
+   per-agent terminal-workflow count (`WorkflowsCompleted + WorkflowsFailed`); `successRate` is
+   `WorkflowsCompleted ÷ runs`; `tokensPerRun` is `(TokensIn + TokensOut) ÷ runs`; `costUsdPerRun`
+   is `CostUsd ÷ runs`; `platformBilledUsd` is the summed `PlatformBilledUsd` measure.
+
+3. **All performance numbers come strictly from the resolving tenant's own
+   `analytics_usage_*` rows** — the agent registry is consulted **only** to resolve the display
+   `name` for an `AgentId`. The agent identity/name is resolved from the Epic 32 agent registry
+   distinguishing public/system definitions from private/tenant ones, but a public agent's row
+   shows **only this tenant's** measures, never a fleet aggregate. **A test asserts** that a
+   public/system agent run by two tenants yields, for each tenant's call, only that tenant's
+   metrics (no aggregate, no other tenant's numbers).
+
+4. `GET /api/v1/orgs/{tenantId}/analytics/agents/{agentId}/trend?from=&to=&granularity=day`
+   returns the **daily trend series** for one agent: an ordered array of
+   `{ date, runs, successRate, costUsd, tokensIn, tokensOut, platformBilledUsd }` points, one per
+   UTC day in `[from, to)` that the agent had activity, read from `analytics_usage_daily` filtered
+   to the agent's `AgentId`. Days with no activity are omitted (the series is sparse, not
+   zero-padded) — see AC7 for the zero-activity contract.
+
+5. `GET /api/v1/orgs/{tenantId}/analytics/summary?from=&to=` returns a **tenant-level performance
+   summary**: `{ blendedSuccessRate, totalRuns, totalCostUsd, totalPlatformBilledUsd,
+   mostEfficientAgents[], leastEfficientAgents[] }` where the blended success rate is the
+   tenant-wide `Σ WorkflowsCompleted ÷ Σ (WorkflowsCompleted + WorkflowsFailed)` across all agents
+   in the window, total billable spend is `Σ PlatformBilledUsd`, and most/least efficient agents
+   are the top/bottom-N by an efficiency metric (default `costUsdPerRun` asc = most efficient),
+   each guarded by a minimum-run threshold so a 1-run agent never tops the chart.
+
+6. **RBAC, per-mode.** All read endpoints are gated `MemberAccess` + `RequireTenantMembershipFilter`
+   on `{tenantId}` — any tenant **member** may read their tenant's performance (single-user mode:
+   the sole user; SaaS mode: any member of that tenant). A caller who is not a member of `{tenantId}`
+   is rejected by `RequireTenantMembershipFilter` (403/404). **No cross-tenant agent performance is
+   ever returned**, and there is **no** platform-admin route that reads a tenant's agent
+   performance — a platform owner calling `/api/v1/orgs/{otherTenant}/analytics/*` is denied like
+   any non-member. **Explicitly tested** (member-read for own tenant; cross-tenant denied;
+   platform owner denied a tenant's performance).
+
+7. **Zero-activity and unknown/deleted agents are handled gracefully, never as errors.** An agent
+   with zero rows in the window returns an **empty trend** (`[]`, HTTP 200) — not a 404 or 500.
+   An `AgentId` present in the fact rows but **unknown/deleted** in the registry (e.g. a removed
+   private agent) renders with a **placeholder name** (`name: "(unknown)"`, the `agentId` still
+   carried) so the row still appears and the tenant can investigate — mirroring the
+   `PlatformAnalyticsService.GetTopTenantsAsync` `(unknown)` placeholder fallback for
+   hard-deleted tenant directory rows. The `AgentId = NULL` "unattributed" dimension bucket
+   (events with no `agent_id` tag, per 36-2 AC3) is surfaced as a synthetic row with
+   `agentId: null, name: "(unattributed)"` so per-agent rows reconcile to the tenant grand total.
+
+8. The endpoints are **read-only reporting** — there is no mutation surface for performance rows
+   (they are derived from the 36-1/36-2 fact tables; there is no edit, no rebuild trigger here —
+   the dimensional rollup is rebuilt by the Story 36-2 workflow / its backfill input, not this API).
+   The service performs **no recompute on the read path**: it aggregates the pre-folded
+   `analytics_usage_*` rows with a `GROUP BY AgentId` over the window, never re-scans the raw event
+   stream.
+
+9. **Windowing is bounded and validated.** `from`/`to` are optional ISO-8601 UTC instants; default
+   window is the trailing 30 days (`to = now`, `from = now − 30d`); `from` must be `< to`, the
+   window is capped (default 366 days, configurable) and `limit`/top-N are bounded
+   (`limit` default 50, max 500; top/bottom-N default 5, max 50) — mirroring the
+   `PlatformAnalyticsService.GetTopTenantsAsync` limit-clamp convention — so a malformed or
+   unbounded request returns 400, never a runaway scan.
+
+10. **No new DCB source events are produced.** This story emits, at most, lightweight
+    observability events for the reporting reads (`ANALYTICS.REPORT.AGENT_ROLLUP.SERVED`,
+    `ANALYTICS.REPORT.TENANT_SUMMARY.SERVED` on the `AGGREGATE.ACTION.STATUS` convention) carrying
+    `{ tenantId, window, agentCount, rowsRead }` for audit/usage telemetry — it consumes the
+    `analytics_usage_*` facts (36-1/36-2) and the `ProviderDiagnostic` substrate (Epic 9) and does
+    not write to either. The reporting events are best-effort and never block or fail a read.
+
+11. **Unit + integration tests** cover: per-agent aggregation (runs/successRate/tokensPerRun/
+    costUsdPerRun/platformBilledUsd from a known fact-row fixture → exact values); trend bucketing
+    (daily series ordered, sparse for inactive days, empty for a zero-activity agent); metric
+    ordering (each `orderBy` option produces the documented order + `agentId` tie-break);
+    name resolution (registry name; `(unknown)` placeholder for a missing/deleted agent;
+    `(unattributed)` for the `NULL` bucket); **public-agent isolation** (a public/system agent run
+    by two tenants → each tenant sees only its own metrics, proven across two tenant schemas);
+    tenant **isolation** (tenant B cannot read tenant A's rollup via any path; platform owner
+    denied a tenant's performance); zero-activity (empty trend, HTTP 200); and window validation
+    (bad `from`/`to` → 400, window clamp applied).
+
+## Tasks / Subtasks
+
+- [ ] Task 1: DTOs + service contract (AC: 1, 2, 4, 5)
+  - [ ] Add `AgentPerformanceDtos.cs` — `AgentRollupRow`, `AgentTrendPoint`, `TenantPerformanceSummary`,
+        and the window/order request shapes.
+  - [ ] Add `IAgentPerformanceAnalyticsService` + `IAgentNameResolver` seams.
+
+- [ ] Task 2: Agent name resolution (AC: 3, 7)
+  - [ ] `IAgentNameResolver` resolves `AgentId → name` from the Epic 32 agent registry
+        (public/system vs private/tenant); returns `"(unknown)"` for a missing/deleted id and
+        treats the `NULL` bucket as `"(unattributed)"`. The resolver reads **only** identity/name —
+        never performance numbers.
+  - [ ] Unit test all three name paths.
+
+- [ ] Task 3: `AgentPerformanceAnalyticsService` aggregation (AC: 1, 2, 5, 8, 9)
+  - [ ] `ComputeAgentRollupsAsync` — `GROUP BY AgentId` over `analytics_usage_daily`
+        (`analytics_usage_hourly` for sub-day windows), measures → rollup metrics; ordering metric
+        + `agentId` tie-break; window-clamp + validation.
+  - [ ] `GetAgentTrendAsync` — daily series for one agent (sparse, ordered).
+  - [ ] `GetTenantSummaryAsync` — blended success rate, total spend, most/least efficient (min-run
+        guarded).
+
+- [ ] Task 4: Tenant analytics endpoints (AC: 2, 4, 5, 6, 9, 10)
+  - [ ] `TenantAnalyticsEndpoints.cs` — map `GET …/analytics/agents`,
+        `GET …/analytics/agents/{agentId}/trend`, `GET …/analytics/summary` under the
+        `/api/v1/orgs/{tenantId}` group with `MemberAccess` + `RequireTenantMembershipFilter`;
+        window parse + 400 on bad input; best-effort `ANALYTICS.REPORT.*` events.
+  - [ ] DI wiring in `Program.cs`.
+
+- [ ] Task 5: Tests (AC: 11)
+  - [ ] Unit (InMemory) for aggregation/trend/ordering/name-resolution/summary against fact-row
+        fixtures.
+  - [ ] Integration (Postgres 17 Testcontainer) for public-agent isolation across two tenant
+        schemas, cross-tenant + platform-owner denial, zero-activity empty trend, window 400.
+
+## Technical Design
+
+### Where the data comes from (verified against repo @ main 98cfb1c2, 2026-06-17)
+
+This story is a **read model over read models**: the dimensional usage facts (36-1/36-2) are the
+primary source; the Epic 32 agent registry is the identity/name lookup; the Epic 9
+`ProviderDiagnostic` table is the diagnostic outcome substrate behind the facts. Isolation is
+**structural** — every fact read goes through the tenant's `TenantDbContext` (search-path schema),
+so a tenant query can only ever see that tenant's rows.
+
+| Component | File | Role in this story |
+|---|---|---|
+| Per-tenant usage facts (primary source) | `apps/tamma-elsa/src/Tamma.Data/Entities/AnalyticsUsageDaily.cs` (**Story 36-1 — NEW, drafted**), `AnalyticsUsageHourly.cs` (**36-1 NEW**) | `AgentId`, `Provider`, measures `TokensIn/Out`, `WorkflowsCompleted/Failed`, `CostUsd`, `PlatformBilledUsd`, `Day`/`Hour` — the rollup substrate, read-only. |
+| Per-tenant DbContext | `apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs` | Owns the `analytics_usage_*` DbSets (added by 36-1); the structural isolation plane (no cross-tenant query filter). Read-only here. |
+| Schema-per-tenant routing | `ITenantDbContextFactory` / `ITenantContext` (`Tamma.Data`) | Resolves the resolving tenant's schema for every read — no new plumbing. |
+| Diagnostic outcome substrate | `apps/tamma-elsa/src/Tamma.Data/Entities/ProviderDiagnostic.cs` (`AgentType`, `RequestDurationMs`, `InputTokens`/`OutputTokens`, `Cost`, `Success`) | The Epic 9 diagnostics the 36-2 projection already folds into the facts; referenced as the lineage of `avgDurationMs`/`success`. **Read/referenced, not modified.** |
+| Agent registry (identity/name only) | Epic 32 agent registry (`AgentConfig`/agent definition entity + `AgentEndpoints.cs`) | `AgentId → name` + public/system vs private/tenant flag. **Identity only — never a performance source.** |
+| Tenant-scope endpoint precedent | `apps/tamma-elsa/src/Tamma.Api/Authorization/RequireTenantMembershipFilter.cs` + the `/api/v1/orgs/{tenantId}/…` group (`Program.cs`, `AlertEndpoints.cs`, `OrgEndpoints.cs`) | The member-readable tenant-path pattern these endpoints ride. |
+| Auth policies | `apps/tamma-elsa/src/Tamma.Api/Program.cs` (`MemberAccess` ~991, `OwnerAccess`/`PlatformOwnerAccess` ~971-990) | `MemberAccess` for the reads; **no** `PlatformOwnerAccess` per-tenant route exists for performance. |
+| Placeholder fallback precedent | `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/PlatformAnalyticsService.cs` (`GetTopTenantsAsync` `(unknown)` fallback ~344-350; limit-clamp ~280-281) | The `(unknown)` placeholder + limit-clamp conventions this story mirrors for deleted agents + window bounds. |
+| Leaderboard read model (sibling, NOT duplicated) | `apps/tamma-elsa/src/Tamma.Api/Services/Agents/BenchmarkProjectionService.cs` (**Story 32-10 — NEW, drafted**) | The agent/provider/prompt/persona leaderboard folded from the action trail. **Referenced** as the sibling; this story does the cost/throughput rollup over the dimensional store instead — see Scope. |
+
+> **NEW files** are marked NEW in the Files table. `AgentPerformanceAnalyticsService.cs`,
+> `IAgentPerformanceAnalyticsService`, `IAgentNameResolver`, `TenantAnalyticsEndpoints.cs`, and
+> `AgentPerformanceDtos.cs` do **not** exist yet. `AnalyticsUsageDaily.cs`/`AnalyticsUsageHourly.cs`
+> are NEW from **Story 36-1** (drafted, not yet merged) — this story is hard-blocked on them.
+> `ProviderDiagnostic.cs`, `TenantDbContext.cs`, `RequireTenantMembershipFilter.cs`,
+> `PlatformAnalyticsService.cs`, and the Epic 32 agent registry are **referenced**, not rewritten.
+
+### C# namespace / file structure
+
+```
+apps/tamma-elsa/src/
+  Tamma.Api/Services/Analytics/
+    IAgentPerformanceAnalyticsService.cs        # NEW — service contract
+    AgentPerformanceAnalyticsService.cs         # NEW — per-agent rollup + trend + tenant summary
+    IAgentNameResolver.cs                        # NEW — AgentId → name (registry identity only)
+    AgentNameResolver.cs                         # NEW — registry-backed resolver + (unknown)/(unattributed)
+    AgentPerformanceDtos.cs                      # NEW — rollup row / trend point / summary wire shapes
+  Tamma.Api/Endpoints/
+    TenantAnalyticsEndpoints.cs                  # NEW — /api/v1/orgs/{tenantId}/analytics/* (member-read)
+  Tamma.Api/Program.cs                           # MODIFY — DI + map the three routes
+  Tamma.Data/Entities/AnalyticsUsageDaily.cs     # READ (Story 36-1) — primary source
+  Tamma.Data/Entities/AnalyticsUsageHourly.cs    # READ (Story 36-1) — sub-day windows
+  Tamma.Data/Entities/ProviderDiagnostic.cs      # READ (Epic 9) — outcome lineage
+
+apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/
+  AgentPerformanceAnalyticsServiceTests.cs       # NEW — aggregation/trend/ordering/name/summary (InMemory)
+  TenantAnalyticsEndpointsTests.cs               # NEW — RBAC, window 400, zero-activity 200
+  AgentPerformanceIsolationTests.cs              # NEW — public-agent isolation + cross-tenant denial (Postgres 17)
+```
+
+### Per-agent rollup (the aggregation)
+
+```csharp
+// apps/tamma-elsa/src/Tamma.Api/Services/Analytics/IAgentPerformanceAnalyticsService.cs (NEW)
+public interface IAgentPerformanceAnalyticsService
+{
+    /// Per-agent rollup over [from, to) for the resolving tenant, ordered by `orderBy`.
+    Task<IReadOnlyList<AgentRollupRow>> GetAgentRollupsAsync(
+        Guid tenantId, DateTime from, DateTime to, string orderBy, int limit, CancellationToken ct = default);
+
+    /// Daily trend (success rate + cost + tokens) for one agent. Empty (not 404) for zero activity.
+    Task<IReadOnlyList<AgentTrendPoint>> GetAgentTrendAsync(
+        Guid tenantId, string? agentId, DateTime from, DateTime to, CancellationToken ct = default);
+
+    /// Tenant-level blended summary + most/least efficient agents.
+    Task<TenantPerformanceSummary> GetTenantSummaryAsync(
+        Guid tenantId, DateTime from, DateTime to, int topN, CancellationToken ct = default);
+}
+```
+
+The rollup is a `GROUP BY AgentId` over the **pre-folded** facts — no event-stream rescan:
+
+```
+rows = tenantDb.AnalyticsUsageDaily.Where(r => r.Day >= from && r.Day < to)   // hourly for sub-day windows
+group rows by r.AgentId into g:
+    runs              = Σ (WorkflowsCompleted + WorkflowsFailed)
+    successRate       = runs == 0 ? 0 : Σ WorkflowsCompleted / runs
+    tokensPerRun      = runs == 0 ? 0 : Σ (TokensIn + TokensOut) / runs
+    costUsdPerRun     = runs == 0 ? 0 : Σ CostUsd / runs
+    platformBilledUsd = Σ PlatformBilledUsd
+    avgDurationMs     = avg run duration (from ProviderDiagnostic lineage carried on the facts / 36-2 measure)
+    name              = nameResolver.Resolve(AgentId)   // registry identity only
+order by orderBy (default runs desc) then agentId asc
+take limit
+```
+
+`avgDurationMs` is sourced from the duration substrate the 36-2 projection carries from
+`ProviderDiagnostic.RequestDurationMs`; if the dimensional store does not carry a duration measure
+at 36-2 merge time, this story reads `ProviderDiagnostic` per-agent (tenant-scoped) for the duration
+column only — **coordinate the duration measure with 36-2 before merge** (mark the duration source
+explicitly in the PR; do not invent a new fact column under cover of this story).
+
+### Daily trend
+
+```csharp
+// GET /api/v1/orgs/{tenantId}/analytics/agents/{agentId}/trend?from=&to=
+// Reads analytics_usage_daily filtered to AgentId == agentId, one point per active UTC day, ordered.
+// Zero activity → [] (HTTP 200), never 404.
+public record AgentTrendPoint(
+    DateOnly Date, long Runs, double SuccessRate,
+    decimal CostUsd, long TokensIn, long TokensOut, decimal PlatformBilledUsd);
+```
+
+### Tenant summary
+
+```csharp
+public record TenantPerformanceSummary(
+    double BlendedSuccessRate,     // Σ Completed / Σ (Completed + Failed) tenant-wide
+    long TotalRuns,
+    decimal TotalCostUsd,
+    decimal TotalPlatformBilledUsd,
+    IReadOnlyList<AgentRollupRow> MostEfficientAgents,   // top-N by costUsdPerRun asc, min-run guarded
+    IReadOnlyList<AgentRollupRow> LeastEfficientAgents); // bottom-N
+```
+
+### Name resolution (identity only — the isolation guarantee)
+
+`IAgentNameResolver` is the **only** place the Epic 32 registry is touched, and it reads **only**
+`AgentId → name` (+ public/system vs private/tenant). It never reads or returns a performance
+number. This is what enforces AC3: a public agent's *name* comes from the shared registry, but
+every metric comes from the tenant's own `analytics_usage_*` rows, so two tenants running the same
+public agent see two disjoint metric sets. Missing/deleted id → `"(unknown)"` (the
+`GetTopTenantsAsync` placeholder precedent); the `NULL` bucket → `"(unattributed)"`.
+
+### Endpoints
+
+```
+GET /api/v1/orgs/{tenantId}/analytics/agents
+      ?from=&to=&orderBy=runs&limit=50            → AgentRollupRow[]            (MemberAccess)
+GET /api/v1/orgs/{tenantId}/analytics/agents/{agentId}/trend
+      ?from=&to=                                   → AgentTrendPoint[] (or [])  (MemberAccess)
+GET /api/v1/orgs/{tenantId}/analytics/summary
+      ?from=&to=&topN=5                            → TenantPerformanceSummary   (MemberAccess)
+```
+
+All three ride the `/api/v1/orgs/{tenantId}` group with `RequireTenantMembershipFilter`, so
+`{tenantId}` is route-bound and validated against the caller's membership; the read is physically
+scoped by the per-tenant `TenantDbContext` to that schema. There is no admin/cross-tenant variant.
+
+### DCB events (this story)
+
+No new **source** events. At most two best-effort observability events on the
+`AGGREGATE.ACTION.STATUS` convention, appended via `IPlatformEventPublisher` (best-effort, never
+blocks a read), for usage telemetry / audit:
+
+| Event | When | Key data |
+|---|---|---|
+| `ANALYTICS.REPORT.AGENT_ROLLUP.SERVED` | a rollup/trend read served | `{ tenantId, window, agentCount, rowsRead }` |
+| `ANALYTICS.REPORT.TENANT_SUMMARY.SERVED` | a summary read served | `{ tenantId, window, totalRuns }` |
+
+These are optional telemetry; if the platform prefers zero events for read paths, they may be
+dropped — the reporting reads function without them. They are **never** new performance facts.
+
+### Per-mode + per-tenant handling (mandatory two-scoping answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns the performance data? | The sole user — their instance, their (single) tenant schema. | The tenant that generated it. ALWAYS tenant-scoped; one public agent definition → many independent per-tenant datasets. |
+| Who reads the rollups/trend/summary? | The user (member-read). | Any tenant member (`MemberAccess`) for their own tenant only. |
+| Can a platform admin read a tenant's agent performance? | N/A (sole user). | **No.** Per-tenant facts are structurally unreachable cross-tenant; there is no admin per-tenant performance route. (The only cross-tenant agent analytics that exists is 32-10's k-anonymous **public-agent** fleet rollup — a different surface this story does not extend.) |
+| Where do the facts live? | The single tenant store (`analytics_usage_*`). | The originating tenant's `t_<hex>` schema. |
+| Mode source | `ITammaModeProvider` (process-stable). | same |
+
+Mode does not change the endpoint shape — both resolve to exactly one tenant schema per request
+(the prompt-store precedent: identical endpoint shape, auth middleware decides scope). The
+platform-wide owner analytics stays on the CP `platform_analytics_hourly` table (Story 28-10),
+which this story never touches.
+
+## Dependencies
+
+**Prerequisite (internal):**
+
+- **Story 36-1** (dimensional analytics schema & store) — the `analytics_usage_daily` /
+  `analytics_usage_hourly` fact tables, the `AgentId`/`Provider` dimensions, and the
+  `WorkflowsCompleted/Failed`, `TokensIn/Out`, `CostUsd`, `PlatformBilledUsd` measures this story
+  aggregates. **Hard prerequisite** — there is nothing to roll up without the fact tables.
+  (Drafted; not yet merged.)
+- **Story 36-2** (DCB-to-analytics projection pipeline) — fills the fact tables (per-agent measures
+  bucketed by the `agent_id` Epic 32 tag, with the `NULL` "unattributed" bucket). **Hard
+  prerequisite** — the tables are inert until 36-2 populates them. (Drafted.)
+- **Story 36-3** (per the spec dependency list — the Epic 36 query-API foundation / shared analytics
+  read seam this reporting API builds on; align the tenant analytics route group + window/paging
+  conventions with 36-3 before merge). (Per spec dependency.)
+- **Epic 32 (agents as first-class entities + `agent_id` action trail + per-tenant datasets)** —
+  the agent registry this story resolves names from, and the `agent_id` DCB tag the 36-2 projection
+  buckets the per-agent facts by. The tenancy rule (one definition → many per-tenant datasets;
+  platform admin cannot read tenant performance) is the design constraint this story enforces.
+- **Epic 9 (`ProviderDiagnostic`)** — the diagnostic outcome substrate (duration, tokens, cost,
+  success) the 36-2 projection folds into the facts; referenced as the lineage of `avgDurationMs`
+  and the per-agent success/cost signal.
+
+**Related (sibling read model — referenced, NOT duplicated):**
+
+- **Story 32-10** (Benchmark projections & leaderboards) — the agent/provider/prompt/persona
+  leaderboard folded directly from the `AGENT.*` action trail (success rate, iterations-to-done,
+  defect-by-category, p50/p95 latency, k-anonymous public-agent fleet rollup). This story is the
+  **analytics-layer rollup/reporting API** over the Epic 36 **dimensional usage store** — a
+  different projection (cost/throughput-centric) serving the Epic 36 analytics product. Where they
+  overlap (per-agent success rate), this story reads the 36-1 fact measures and references 32-10;
+  it does **not** re-fold the action trail or re-implement the leaderboard. Coordinate the
+  per-agent success-rate definition with 32-10 so the two surfaces agree.
+
+**Blocks (internal):**
+
+- Downstream Epic 36 stories (exports, scheduled reports, dashboard) that surface agent/tenant
+  performance read these endpoints.
+
+**External:**
+
+- PostgreSQL 17 (per-tenant schema reads; `GROUP BY` over the fact tables).
+- EF Core 9 / Npgsql.
+- Testcontainers + Docker for the per-tenant isolation suite (run via
+  `sg docker -c "dotnet test ..."`).
+
+## Testing Strategy
+
+1. **Metric-correctness (highest priority — AC 2, 5, 11)**
+   (`AgentPerformanceAnalyticsServiceTests`, InMemory): seed `analytics_usage_daily` fact rows for
+   two agents over a known window (e.g. agent A: 7 completed / 3 failed, 12 000 tokens, $0.40 cost,
+   $0.52 billed; agent B: 4 completed / 1 failed, …) and assert the rollup row's
+   `runs == 10`, `successRate == 0.7`, `tokensPerRun`, `costUsdPerRun`, `platformBilledUsd`, and
+   the tenant summary's `blendedSuccessRate`, `totalPlatformBilledUsd`, and most/least-efficient
+   ordering to **exact** values.
+
+2. **Trend bucketing (AC 4, 7):** seed daily facts across a sparse set of days → the trend series
+   is ordered by date, has one point per active day, omits inactive days; an agent with zero rows
+   in the window → empty series (`[]`, HTTP 200), never 404.
+
+3. **Metric ordering (AC 2):** seed agents with deliberate ties → each `orderBy` option produces
+   the documented order with the `agentId` asc final tie-break; an invalid `orderBy` → 400.
+
+4. **Name resolution (AC 3, 7):** registry name resolved for a known agent; `(unknown)` for a
+   missing/deleted `AgentId`; `(unattributed)` for the `NULL` bucket; the resolver is asserted to
+   read **only** identity (a test injects a resolver that would throw if asked for a metric).
+
+5. **Public-agent isolation (AC 3, 11 — docker-bound, `sg docker -c "dotnet test ..."`):** a
+   public/system agent definition is run by tenant A and tenant B; seed each tenant's
+   `analytics_usage_daily` independently; assert `GET /api/v1/orgs/{A}/analytics/agents` returns
+   only A's metrics for that agent and `…/orgs/{B}/…` returns only B's — never a sum, never the
+   other tenant's numbers (proven across two `t_<hex>` schemas).
+
+6. **Tenant isolation + RBAC (AC 6):** a member of A hitting `/api/v1/orgs/{B}/analytics/*` is
+   rejected by `RequireTenantMembershipFilter` (403/404); a platform owner has no per-tenant
+   performance route and is denied a tenant's performance like any non-member; a member reads their
+   own tenant's rollups (200).
+
+7. **Window validation (AC 9):** `from >= to` → 400; window beyond the cap → clamped; `limit`/`topN`
+   beyond max → clamped (the `GetTopTenantsAsync` clamp precedent).
+
+**Mocks:** No external provider/Stripe calls (read-only aggregation). InMemory provider for the
+aggregation/trend/ordering/name/summary shape; a real Postgres 17 Testcontainer for per-tenant
+isolation across two schemas (EF InMemory cannot model the search-path isolation plane — same
+rationale as `ConventionStoreMigrationTests`). TDD: write the metric-correctness + public-agent
+isolation tests first.
+
+## Estimated Effort
+
+3-4 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/IAgentPerformanceAnalyticsService.cs` | Create (NEW) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/AgentPerformanceAnalyticsService.cs` | Create (NEW — per-agent rollup + trend + tenant summary over the 36-1 facts) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/IAgentNameResolver.cs` | Create (NEW) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/AgentNameResolver.cs` | Create (NEW — registry identity only; `(unknown)`/`(unattributed)`) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/AgentPerformanceDtos.cs` | Create (NEW — rollup row / trend point / summary) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/TenantAnalyticsEndpoints.cs` | Create (NEW — member-read tenant analytics routes) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (DI: `IAgentPerformanceAnalyticsService` + `IAgentNameResolver`; map the 3 routes under `/api/v1/orgs/{tenantId}`) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/AgentPerformanceAnalyticsServiceTests.cs` | Create (NEW) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/TenantAnalyticsEndpointsTests.cs` | Create (NEW) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/AgentPerformanceIsolationTests.cs` | Create (NEW — Postgres 17 Testcontainer) |
+
+> Note: `apps/tamma-elsa/src/Tamma.Data/Entities/AnalyticsUsageDaily.cs` +
+> `AnalyticsUsageHourly.cs` (Story 36-1, NEW/drafted), `ProviderDiagnostic.cs` (Epic 9), the Epic
+> 32 agent registry, `RequireTenantMembershipFilter.cs`, and `PlatformAnalyticsService.cs` are
+> **referenced/read, not modified** — this story consumes the pre-folded dimensional facts and the
+> registry identity; it does not change the schema, the projection, or any sibling service.
+> (`packages/api` is deleted; all work is in the C# `apps/tamma-elsa` stack.)
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes/bugs/findings/decisions (analytics, tenancy, EF, projection
+   read models) — especially the per-tenant cross-tenant read-routing decision behind why a
+   tenant's facts are structurally unreachable cross-tenant.
+3. Read **Story 36-1** (the fact tables/measures/dimensions this story reads), **Story 36-2** (how
+   the per-agent facts are bucketed by `agent_id`, including the `NULL` "unattributed" bucket), and
+   sibling **Story 32-10** (the leaderboard read model — align the per-agent success-rate
+   definition; do **not** duplicate its action-trail fold).
+4. Read the Epic 32 design spec (`docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`)
+   — the tenancy rule: definition ownership ≠ data ownership; **performance is per-tenant**;
+   platform admin cannot read tenant performance.
+5. Confirmed the test runner: docker-bound suites run via `sg docker -c "dotnet test ..."`
+   (session docker group is stale; the build itself needs no wrapper).
+6. Planned the TDD cycle (metric-correctness + public-agent isolation tests first).
+
+### Key design decisions
+
+- **Read the dimensional store, do not re-fold the trail.** The per-agent rollup reads the
+  pre-folded `analytics_usage_*` facts (36-1/36-2) with a `GROUP BY AgentId` — it never re-scans
+  the raw event stream and never re-implements 32-10's `BenchmarkProjectionService`. This keeps the
+  reporting API a thin, cheap consumer and avoids two folds of the same trail drifting apart.
+- **Sibling, not duplicate, of 32-10.** 32-10 is the **defect/latency/leaderboard** read model
+  folded from the action trail; this is the **cost/throughput rollup/reporting** read model over
+  the Epic 36 dimensional store. They share the per-tenant-isolation rule and overlap on per-agent
+  success rate (which this story reads from the facts and aligns to 32-10's definition). Keeping
+  them distinct is deliberate — the analytics product (36) and the agent-benchmark product (32) are
+  different surfaces.
+- **Performance is strictly per-tenant; identity is shared.** The registry is consulted *only* for
+  the display name (public/system vs private/tenant). Every metric comes from the resolving
+  tenant's own facts, read through `ITenantDbContextFactory`, so a public agent shows only this
+  tenant's numbers — the design-spec tenancy rule, enforced structurally by the schema and a
+  name-only resolver, and pinned by the public-agent isolation test.
+- **No platform-admin per-tenant performance path.** A platform owner cannot read a tenant's agent
+  performance — there is no admin variant of these routes. The only cross-tenant agent analytics
+  that exists anywhere is 32-10's k-anonymous public-agent fleet rollup, which this story does not
+  touch.
+- **Graceful, not erroring, on missing data.** Zero activity → empty trend (HTTP 200);
+  unknown/deleted agent → `(unknown)` placeholder (the `GetTopTenantsAsync` precedent); the
+  `AgentId = NULL` bucket → `(unattributed)` so per-agent rows reconcile to the grand total. A
+  reporting endpoint that 404s on an idle agent would be a worse experience than an honest empty
+  series.
+- **Bounded windows.** `from < to`, a window cap, and `limit`/top-N clamps (the
+  `GetTopTenantsAsync` clamp convention) keep a malformed or unbounded request a 400, not a runaway
+  scan over a large fact table.
+- **Read-only, no recompute on the read path.** The dimensional rollup is rebuilt by the Story 36-2
+  workflow (and its backfill input), not by this API — there is no rebuild trigger here. This story
+  only aggregates pre-folded facts.
+
+### Integration points
+
+- **36-1/36-2** are the producers of the facts; this story is a pure read consumer of the
+  dimensional store — coordinate the per-agent measure set (especially the duration measure feeding
+  `avgDurationMs`) with 36-2 before merge.
+- **Epic 32 agent registry** is the identity/name source (public/system vs private/tenant) — read
+  through `IAgentNameResolver`, identity only.
+- **`RequireTenantMembershipFilter` + `/api/v1/orgs/{tenantId}` group** is the member-read tenant
+  path-gate these endpoints ride.
+- **`ITenantDbContextFactory`** is the structural isolation plane for every fact read.
+- **32-10** is the sibling agent read model; align the per-agent success-rate definition, do not
+  duplicate the fold.
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+| ---- | --------- | ---------- |
+| Cross-tenant leakage of a public agent's performance | Critical | Per-tenant schema + `ITenantDbContextFactory`; registry resolves name only; no admin per-tenant route; explicit public-agent isolation test across two schemas |
+| Duplicating 32-10's leaderboard fold | High | This story reads the 36-1 dimensional facts (`GROUP BY AgentId`), never re-folds the action trail; references 32-10; aligns the success-rate definition before merge |
+| `avgDurationMs` source ambiguous (fact measure vs `ProviderDiagnostic`) | Medium | Coordinate the duration measure with 36-2; if absent, read `ProviderDiagnostic.RequestDurationMs` tenant-scoped for duration only — do not add a fact column under this story |
+| Unbounded window scans a huge fact table | Medium | `from < to` validation, window cap, `limit`/top-N clamps (the `GetTopTenantsAsync` precedent) |
+| Idle agent 404s instead of empty | Low | Zero-activity → empty trend (HTTP 200); deleted agent → `(unknown)`; `NULL` bucket → `(unattributed)` |
+| 36-1/36-2 not yet merged | High (blocking) | Hard prerequisite; story does not start until the fact tables + projection exist (mark NEW; coordinate measure names) |
+
+### Success Metrics
+
+- [ ] Rollup/trend/summary metrics match hand-computed values on the fact-row fixture (exact)
+- [ ] A public agent run by two tenants shows each tenant only its own metrics (isolation test green)
+- [ ] 0 cross-tenant + 0 platform-admin per-tenant performance reads possible (RBAC suite green)
+- [ ] Zero-activity agent returns an empty trend (HTTP 200); deleted agent renders `(unknown)`
+- [ ] Metric ordering + tie-break deterministic; window validation returns 400 on bad input
+
+## Logging Requirements
+
+- **INFO**: rollup served (`tenantId`, `window`, agentCount, rowsRead); trend served (`tenantId`,
+  `agentId`, points); summary served (`tenantId`, `window`, totalRuns)
+- **DEBUG**: per-agent group aggregation step (`agentId`, runs); name resolution
+  (`agentId` → resolved/`(unknown)`/`(unattributed)`); window parse + clamp
+- **WARN**: window validation failed (`from`, `to`) → 400; `orderBy` unknown → 400; name resolver
+  unavailable → fall back to `(unknown)` and log once
+- **ERROR**: tenant fact read failure (repository/context error) — surfaced as 500, never a
+  cross-tenant fallback
+- **Structured context**: include `{ tenantId, window, agentId, orderBy, rowsRead }` where applicable
+- **Credential / privacy safety**: NEVER log another tenant's id in a tenant's report path; NEVER
+  log tenant connection strings or search-path schema secrets; the reporting reads touch only the
+  resolving tenant's fact rows + the registry name lookup — no provider-key plaintext, no
+  cross-tenant identifiers
+
+## Related
+
+- Design spec: `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`
+  (§Ownership/data-scoping — performance is PER-TENANT; platform admin cannot read tenant performance)
+- Implementation plan: `docs/superpowers/plans/2026-06-17-36-5-agent-and-tenant-performance-rollups-api-plan.md`
+- Source stories: `docs/stories/epic-36/story-36-1` (fact tables), `docs/stories/epic-36/story-36-2`
+  (projection pipeline)
+- Sibling read model (NOT duplicated): `docs/stories/epic-32/story-32-10` (benchmark leaderboards)
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-36/story-36-6/36-6-tenant-analytics-dashboard-ui.md
+++ b/docs/stories/epic-36/story-36-6/36-6-tenant-analytics-dashboard-ui.md
@@ -1,0 +1,331 @@
+# Story 36-6: Tenant Analytics Dashboard UI
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **tenant member**,
+I want an Analytics section in my dashboard with usage, cost, and agent-performance views that I can slice by time range and dimension,
+So that I can see how my organization is consuming Tamma, what it is costing me (platform-billed vs my own BYOK tokens), and which agents perform best — all without ever seeing another tenant's data.
+
+## Priority
+
+P1 - Surfaces the Epic 36 analytics APIs (36-3/36-4/36-5) to the tenant; the read-only consumer that turns the dimensional projection pipeline into a product.
+
+## Acceptance Criteria
+
+1. New `/analytics` route tree is added to `packages/dashboard-user` under `AuthGuard → AppLayout`, with three sub-views — `/analytics/usage`, `/analytics/cost`, `/analytics/agents` — reachable from a new "Analytics" entry in the `AppLayout` sidebar nav for **any** authenticated tenant member (no admin/owner gate). `/analytics` redirects to `/analytics/usage`.
+2. A shared **TimeRange + GroupBy control bar** (presets: 7d / 30d / 90d / MTD / custom; granularity hour|day; GroupBy: provider | agent | workflow | repo) lives in one reusable component and drives all three views; changing a control re-queries the active view (no full-page reload) and is reflected in the URL query string so views are linkable/refreshable.
+3. **Usage view** renders a time-series (workflows, dispatches, tokens) plus a dimension breakdown table/bar driven by the shared control bar, wired to `GET /api/v1/orgs/{tenantId}/analytics/usage` (time-series) and `GET /api/v1/orgs/{tenantId}/analytics/usage/breakdown` (top-N by the selected dimension). The view echoes the API's `period_start`/`period_end`.
+4. **Cost view** wired to `GET /api/v1/orgs/{tenantId}/analytics/cost` shows a spend time-series split into `platformBilledUsd` (billable) and `byokCostUsd` (informational, labelled "BYOK — not billed"), plus month-to-date `platformBilledUsd`, projected end-of-month spend, and a budget marker (budget + alert threshold from the response). A fully-BYOK tenant renders `platformBilledUsd = $0.00` with a non-zero informational BYOK figure and no false "over budget" state.
+5. **Agents view** wired to `GET /api/v1/orgs/{tenantId}/analytics/agents` lists per-agent rows (name, runs, success rate, avg duration, tokens/run, cost/run, platform-billed) with a selectable order metric, plus a drill-down that calls `GET /api/v1/orgs/{tenantId}/analytics/agents/{agentId}/trend` to render that agent's daily success-rate / cost / tokens trend. Agents with zero activity render an empty trend (not an error); an unknown/deleted agent id renders a placeholder name.
+6. **Tenant isolation (hard):** every view resolves `tenantId` from the active org context (org switcher) and **only** ever issues requests to `/api/v1/orgs/{activeTenantId}/...`. A test asserts that no analytics call is ever made to any tenant id other than the active one (no cross-tenant leakage), mirroring the `TenantAlertFeed` isolation test.
+7. **Active-tenant resolution + switch:** views read the active tenant from the org context (today `useAuth().user.tenantId`; future org switcher from Story 18-5). When the active tenant changes, all in-flight requests are cancelled and the view re-queries against the new tenant. When the user has no active tenant, the section shows the "No organization" zero-state and issues **zero** API calls.
+8. **Loading / empty / error states** are handled per view and per panel: a skeleton/`Loading…` while fetching; a distinct **zero-state** ("No analytics data yet for this period") when the store returns empty rows — this is NOT treated as an error; and an inline `role="alert"` error panel only on an actual request failure (non-2xx / network). An empty store therefore never surfaces a red error.
+9. API client modules are added under `packages/dashboard-user/src/api` (`analytics.ts`) returning typed DTOs that mirror the 36-3/36-4/36-5 response shapes, going through the existing `apiClient` so the refresh-on-401 dance and `credentials: 'include'` are inherited. Date-range params are sent as UTC ISO 8601 strings to match the API's UTC binding.
+10. Data-fetching hooks are added under `packages/dashboard-user/src/hooks` (`useAnalyticsUsage`, `useAnalyticsCost`, `useAnalyticsAgents`, `useAnalyticsControls`) that encapsulate fetch + abort-on-change + loading/empty/error state, keyed on `(tenantId, range, groupBy, granularity)`.
+11. An **export hook seam** is wired into each view's header: an "Export" affordance that posts `{ type, format, from, to, groupBy }` to `POST /api/v1/orgs/{tenantId}/analytics/exports` (Story 36-8). The client function is added now and the button is rendered, gated behind a `VITE_FEATURE_ANALYTICS_EXPORT` flag (default off) so the UI ships before 36-8 lands; when off the affordance is hidden. No PDF/CSV rendering logic lives in the dashboard — that is server-side in 36-8.
+12. Components are colocated with Vitest tests; tests cover: (a) selector-driven refetch (changing range/groupBy fires a new request with the right query params), (b) BYOK vs platform cost rendering (fully-BYOK shows $0 billed), (c) empty-store zero-state vs error-state distinction, (d) tenant-switch cancels + refetches against the new tenant, and (e) the cross-tenant non-leakage assertion from AC 6. The `analytics.ts` API client has URL-construction tests in the `dashboard.test.ts` style. An e2e smoke spec is added to the root `e2e/` Playwright suite that loads `/analytics/usage` and asserts the section renders for an authenticated tenant member.
+
+## Technical Design
+
+### Target package
+
+This is a **TypeScript / React** story in `packages/dashboard-user` (the tenant-facing SPA, `dash.tamma.dev`). It renders the C# analytics APIs from Stories 36-3/36-4/36-5 — those endpoints live in `apps/tamma-elsa` and are **out of scope** here. There is no `packages/api` involvement (that package is deleted; never target it).
+
+Stack already in the package (verified): React 19, `react-router-dom` 7, Tailwind 4, Vitest 4 + `@testing-library/react` 16 (jsdom). No charting library is installed today.
+
+### Page / component structure (NEW)
+
+```
+packages/dashboard-user/src/
+  pages/analytics/
+    AnalyticsLayout.tsx            # NEW — sub-nav (Usage|Cost|Agents) + shared control bar + <Outlet/>
+    AnalyticsLayout.test.tsx       # NEW
+    UsageView.tsx                  # NEW — time-series + dimension breakdown
+    UsageView.test.tsx             # NEW
+    CostView.tsx                   # NEW — platform vs BYOK spend, MTD, projection, budget marker
+    CostView.test.tsx              # NEW
+    AgentsView.tsx                 # NEW — per-agent rows + per-agent trend drill-down
+    AgentsView.test.tsx            # NEW
+    components/
+      TimeRangeControls.tsx        # NEW — presets + custom range + granularity + GroupBy selectors
+      TimeRangeControls.test.tsx   # NEW
+      TimeSeriesChart.tsx          # NEW — lightweight inline SVG/CSS series (no chart dep); a11y table fallback
+      BreakdownTable.tsx           # NEW — top-N dimension rows
+      MetricCard.tsx               # NEW — reuse DashboardHome StatCard idiom
+      ExportButton.tsx             # NEW — 36-8 seam, flag-gated
+      EmptyState.tsx               # NEW — shared zero-state vs error panel
+  api/
+    analytics.ts                   # NEW — typed client for usage/cost/agents/exports
+    analytics.test.ts              # NEW — URL-construction + UTC param tests (dashboard.test.ts style)
+  hooks/
+    useAnalyticsControls.tsx       # NEW — range/groupBy/granularity state synced to URL query
+    useAnalyticsControls.test.tsx  # NEW
+    useAnalyticsUsage.tsx          # NEW
+    useAnalyticsCost.tsx           # NEW
+    useAnalyticsAgents.tsx         # NEW
+    useActiveTenant.tsx            # NEW — single source for the active tenant id (wraps useAuth today)
+```
+
+Routing change in `App.tsx` (nested under the existing `AuthGuard → AppLayout` element route):
+
+```tsx
+<Route path="/analytics" element={<AnalyticsLayout />}>
+  <Route index element={<Navigate to="usage" replace />} />
+  <Route path="usage" element={<UsageView />} />
+  <Route path="cost" element={<CostView />} />
+  <Route path="agents" element={<AgentsView />} />
+</Route>
+```
+
+Nav change in `AppLayout.tsx`: add an `Analytics` `<Link to="/analytics/usage">` to the sidebar. No `TenantAdminGuard` wrapper — analytics is member-read (AC 1).
+
+### Active-tenant resolution
+
+There is no dedicated org-switcher context in `dashboard-user` yet (the `AppLayout` header comment marks it as a later Story 18-5 sub-task). To stay forward-compatible, isolate the resolution behind one hook:
+
+```tsx
+// useActiveTenant.tsx
+export function useActiveTenant(): { tenantId: string | null } {
+  const { user } = useAuth();
+  // TODAY: the active tenant is the one on the session (/api/auth/me).
+  // FUTURE (Story 18-5 org switcher): swap this for the switcher's selected org.
+  return { tenantId: user?.tenantId ?? null };
+}
+```
+
+Every analytics hook depends on `tenantId` from this hook and lists it in its effect deps, so a tenant switch re-runs the effect (which aborts the prior `AbortController` and refetches). When `tenantId` is `null`, hooks early-return without fetching (mirrors `DashboardHome`).
+
+### API client (`analytics.ts`)
+
+DTOs mirror the 36-3/36-4/36-5 response contracts. All paths are `/api/v1/orgs/${tenantId}/analytics/...`; date params are UTC ISO 8601 to match the server's forced-UTC `DateTime` binding (36-3 AC).
+
+```ts
+import { apiClient } from './client';
+
+export type Granularity = 'hour' | 'day';
+export type GroupBy = 'provider' | 'agent' | 'workflow' | 'repo';
+
+export interface UsagePoint { bucket: string; workflows: number; dispatches: number; tokens: number; }
+export interface UsageSeriesResponse {
+  tenantId: string;
+  periodStart: string;   // echoes server period_start
+  periodEnd: string;
+  granularity: Granularity;
+  points: UsagePoint[];
+}
+export interface UsageBreakdownRow { key: string; label: string; workflows: number; dispatches: number; tokens: number; }
+export interface UsageBreakdownResponse { tenantId: string; dimension: GroupBy; rows: UsageBreakdownRow[]; }
+
+export interface CostPoint { bucket: string; platformBilledUsd: number; byokCostUsd: number; }
+export interface CostResponse {
+  tenantId: string;
+  periodStart: string;
+  periodEnd: string;
+  points: CostPoint[];
+  monthToDatePlatformBilledUsd: number;
+  projectedMonthPlatformBilledUsd: number;
+  budgetUsd: number | null;
+  alertThresholdPct: number | null;
+}
+
+export interface AgentRollupRow {
+  agentId: string; name: string; runs: number; successRate: number;
+  avgDurationMs: number; tokensPerRun: number; costUsdPerRun: number; platformBilledUsd: number;
+}
+export interface AgentRollupResponse { tenantId: string; rows: AgentRollupRow[]; }
+export interface AgentTrendPoint { day: string; successRate: number; costUsd: number; tokens: number; }
+export interface AgentTrendResponse { tenantId: string; agentId: string; name: string; points: AgentTrendPoint[]; }
+
+export interface RangeParams { from: string; to: string; granularity?: Granularity; groupBy?: GroupBy; }
+
+function qs(params: Record<string, string | undefined>): string {
+  const sp = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) if (v !== undefined) sp.set(k, v);
+  const s = sp.toString();
+  return s ? `?${s}` : '';
+}
+
+export async function fetchUsageSeries(tenantId: string, p: RangeParams): Promise<UsageSeriesResponse> {
+  return apiClient.get(`/api/v1/orgs/${tenantId}/analytics/usage${qs({ from: p.from, to: p.to, granularity: p.granularity, groupBy: p.groupBy })}`);
+}
+export async function fetchUsageBreakdown(tenantId: string, p: RangeParams & { groupBy: GroupBy }): Promise<UsageBreakdownResponse> {
+  return apiClient.get(`/api/v1/orgs/${tenantId}/analytics/usage/breakdown${qs({ from: p.from, to: p.to, groupBy: p.groupBy })}`);
+}
+export async function fetchCost(tenantId: string, p: RangeParams): Promise<CostResponse> {
+  return apiClient.get(`/api/v1/orgs/${tenantId}/analytics/cost${qs({ from: p.from, to: p.to, groupBy: p.groupBy })}`);
+}
+export async function fetchAgentRollups(tenantId: string, p: RangeParams & { orderBy?: string }): Promise<AgentRollupResponse> {
+  return apiClient.get(`/api/v1/orgs/${tenantId}/analytics/agents${qs({ from: p.from, to: p.to, orderBy: p.orderBy })}`);
+}
+export async function fetchAgentTrend(tenantId: string, agentId: string, p: RangeParams): Promise<AgentTrendResponse> {
+  return apiClient.get(`/api/v1/orgs/${tenantId}/analytics/agents/${agentId}/trend${qs({ from: p.from, to: p.to })}`);
+}
+
+// Story 36-8 seam — present now, gated by VITE_FEATURE_ANALYTICS_EXPORT.
+export type ExportType = 'usage' | 'cost' | 'agents';
+export type ExportFormat = 'csv' | 'pdf';
+export interface ExportRequest { type: ExportType; format: ExportFormat; from: string; to: string; groupBy?: GroupBy; }
+export async function requestAnalyticsExport(tenantId: string, body: ExportRequest): Promise<{ jobId?: string; downloadUrl?: string }> {
+  return apiClient.post(`/api/v1/orgs/${tenantId}/analytics/exports`, body);
+}
+```
+
+> The exact field names above must be reconciled against the final 36-3/36-4/36-5 DTOs when those stories land; this story owns the client and may adjust property names to match. The endpoint **paths** are fixed by the dependency specs.
+
+### Data-fetching hook pattern
+
+Each view-hook follows the `DashboardHome` cancel-on-unmount idiom, upgraded to `AbortController` + an empty/loading/error tri-state:
+
+```tsx
+export function useAnalyticsUsage(args: { from: string; to: string; granularity: Granularity; groupBy: GroupBy }) {
+  const { tenantId } = useActiveTenant();
+  const [state, setState] = useState<{ data: UsageSeriesResponse | null; loading: boolean; error: string | null }>(
+    { data: null, loading: false, error: null },
+  );
+  useEffect(() => {
+    if (!tenantId) { setState({ data: null, loading: false, error: null }); return; }
+    const ctrl = new AbortController();
+    setState((s) => ({ ...s, loading: true, error: null }));
+    (async () => {
+      try {
+        const data = await fetchUsageSeries(tenantId, args);
+        if (!ctrl.signal.aborted) setState({ data, loading: false, error: null });
+      } catch (err) {
+        if (ctrl.signal.aborted) return;
+        setState({ data: null, loading: false, error: err instanceof Error ? err.message : 'Failed to load usage' });
+      }
+    })();
+    return () => ctrl.abort();
+  }, [tenantId, args.from, args.to, args.granularity, args.groupBy]);
+  return state;
+}
+```
+
+Empty is derived in the view (`data && points.length === 0`) and rendered as the zero-state, never as an error (AC 8).
+
+### Controls + URL sync
+
+`useAnalyticsControls` holds `{ rangePreset, from, to, granularity, groupBy }` and reads/writes them via `useSearchParams` (react-router 7) so a `/analytics/usage?range=30d&groupBy=agent` URL is shareable and survives refresh. Presets compute `from`/`to` as UTC ISO at read time; custom range uses two date inputs. `TimeRangeControls` is presentational and calls back into this hook.
+
+### Charts without a new dependency (default)
+
+To avoid adding a chart library to the SPA's bundle floor, `TimeSeriesChart` renders a small inline SVG (line/area) plus a visually-hidden `<table>` for accessibility and for test assertions (tests assert on the table rows, not pixels). If the team prefers a library, `recharts` is the suggested option (tree-shakeable, React 19 compatible) — that is a one-line `package.json` add and a swap of `TimeSeriesChart`'s internals; the rest of the story is unaffected. Default: zero-dependency inline SVG.
+
+### Export seam (Story 36-8)
+
+`ExportButton` renders only when `import.meta.env.VITE_FEATURE_ANALYTICS_EXPORT === 'true'`. On click it calls `requestAnalyticsExport(tenantId, { type, format, from, to, groupBy })` with the active view's params. For an async `jobId` response it shows a "preparing export…" toast; for a `downloadUrl` it triggers the download. All file generation is server-side (36-8) — the dashboard only initiates and links.
+
+## Dependencies
+
+- **Prerequisite (API contracts):** Story 36-3 (`GET /analytics/usage[/breakdown]`), Story 36-4 (`GET /analytics/cost`), Story 36-5 (`GET /analytics/agents[/{id}/trend]`). These define the response DTOs this UI renders; the client types must be reconciled to the final shapes.
+- **Prerequisite (shell):** Epic 18 Story 18-5 — dashboard shell, `AuthGuard`, `AppLayout`, org context. Active-tenant resolution is isolated in `useActiveTenant` so the future org switcher drops in without touching the views.
+- **Prerequisite (pages):** Epic 21 Story 21-4 — user dashboard pages (this section sits alongside them).
+- **Forward seam:** Story 36-8 (Analytics Exports) — `requestAnalyticsExport` + `ExportButton` are added now behind a feature flag; 36-8 provides the server endpoint and turns the flag on.
+- **Related:** existing `packages/dashboard-user` `apiClient` (refresh-on-401), `useAuth`, `DashboardHome` (empty-state idiom), `TenantAlertFeed` (tenant-isolation test idiom), root `e2e/` Playwright suite.
+
+## Testing Strategy
+
+1. **Component tests (Vitest + Testing Library, jsdom)** — colocated `*.test.tsx`. Mock `globalThis.fetch` (the `TenantAlertFeed.test` / `dashboard.test` idiom). Render each view inside `<MemoryRouter><AuthProvider>…`.
+   - **Selector-driven refetch:** mount UsageView, change GroupBy to `agent`, assert a new fetch fires with `?groupBy=agent` and the breakdown table updates.
+   - **Cost BYOK vs platform:** feed a fully-BYOK response (`platformBilledUsd:0`, non-zero `byokCostUsd`); assert `$0.00` billed, the "BYOK — not billed" label, and no over-budget state.
+   - **Empty vs error:** an empty `points: []` response renders the zero-state ("No analytics data yet…"); a 500 renders the `role="alert"` error panel. Assert they are distinct and an empty store is NOT an error.
+   - **Tenant switch:** start with `tenantId: tnt-A`, assert the first call hits `/orgs/tnt-A/...`; re-render with the auth user on `tnt-B`, assert the prior request is aborted and a new call hits `/orgs/tnt-B/...`.
+   - **Cross-tenant non-leakage (AC 6):** inspect every `fetch` URL recorded during a render and assert none contains an org id other than the active tenant (mirrors `TenantAlertFeed` test line 86–89).
+2. **API client tests (`analytics.test.ts`)** — `dashboard.test.ts` style: assert each function builds the correct `/api/v1/orgs/{tenantId}/analytics/...` URL, that range params are UTC ISO, and that omitted optional params are absent from the query string.
+3. **Controls/hook tests** — `useAnalyticsControls` round-trips preset ↔ URL query; presets compute UTC `from`/`to`; custom range validates `from <= to`.
+4. **E2E smoke (root `e2e/` Playwright)** — add `e2e/tests/analytics.spec.ts`: authenticated session loads `/analytics/usage`, the Analytics nav link is visible, the three sub-tabs render, and switching to `/analytics/cost` shows the spend panels. Network-only smoke (no seeded-data assertions) to match the existing `dashboard.spec.ts` posture.
+5. **No backend/integration tests here** — the analytics query correctness, RBAC 403, and UTC binding are owned and tested by 36-3/36-4/36-5.
+
+## Estimated Effort
+
+4-5 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `packages/dashboard-user/src/pages/analytics/AnalyticsLayout.tsx` | Create |
+| `packages/dashboard-user/src/pages/analytics/AnalyticsLayout.test.tsx` | Create |
+| `packages/dashboard-user/src/pages/analytics/UsageView.tsx` | Create |
+| `packages/dashboard-user/src/pages/analytics/UsageView.test.tsx` | Create |
+| `packages/dashboard-user/src/pages/analytics/CostView.tsx` | Create |
+| `packages/dashboard-user/src/pages/analytics/CostView.test.tsx` | Create |
+| `packages/dashboard-user/src/pages/analytics/AgentsView.tsx` | Create |
+| `packages/dashboard-user/src/pages/analytics/AgentsView.test.tsx` | Create |
+| `packages/dashboard-user/src/pages/analytics/components/TimeRangeControls.tsx` | Create |
+| `packages/dashboard-user/src/pages/analytics/components/TimeRangeControls.test.tsx` | Create |
+| `packages/dashboard-user/src/pages/analytics/components/TimeSeriesChart.tsx` | Create |
+| `packages/dashboard-user/src/pages/analytics/components/BreakdownTable.tsx` | Create |
+| `packages/dashboard-user/src/pages/analytics/components/MetricCard.tsx` | Create |
+| `packages/dashboard-user/src/pages/analytics/components/ExportButton.tsx` | Create |
+| `packages/dashboard-user/src/pages/analytics/components/EmptyState.tsx` | Create |
+| `packages/dashboard-user/src/api/analytics.ts` | Create |
+| `packages/dashboard-user/src/api/analytics.test.ts` | Create |
+| `packages/dashboard-user/src/hooks/useActiveTenant.tsx` | Create |
+| `packages/dashboard-user/src/hooks/useAnalyticsControls.tsx` | Create |
+| `packages/dashboard-user/src/hooks/useAnalyticsControls.test.tsx` | Create |
+| `packages/dashboard-user/src/hooks/useAnalyticsUsage.tsx` | Create |
+| `packages/dashboard-user/src/hooks/useAnalyticsCost.tsx` | Create |
+| `packages/dashboard-user/src/hooks/useAnalyticsAgents.tsx` | Create |
+| `packages/dashboard-user/src/App.tsx` | Modify (register `/analytics` route tree) |
+| `packages/dashboard-user/src/layouts/AppLayout.tsx` | Modify (add Analytics nav link) |
+| `e2e/tests/analytics.spec.ts` | Create (Playwright smoke) |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes/bugs/findings/decisions (dashboard, analytics, tenant-isolation).
+3. Read the **final** 36-3/36-4/36-5 story files to lock the exact response DTO field names before writing `analytics.ts` (this story's types are the consumer of those contracts).
+4. Reviewed the existing `dashboard-user` idioms: `apiClient` (refresh-on-401), `useAuth`, `DashboardHome` (no-tenant zero-state), `TenantAlertFeed.test.tsx` (tenant-isolation assertion).
+5. Planned a TDD approach (Red-Green-Refactor) — write the API-client URL tests and the cross-tenant non-leakage test first.
+
+### Tenant isolation is the load-bearing invariant
+
+The dashboard must never construct an analytics URL with any org id other than the active tenant. The server (36-3) is authoritative and 403s a mismatched route tenant, but the client must not even attempt it. Keep tenant resolution in the single `useActiveTenant` hook; never pass a tenant id down from a query param, a list response, or a drill-down link. The non-leakage test (AC 6) is the regression guard.
+
+### Active tenant: today vs the org switcher
+
+Today the session's `user.tenantId` (from `/api/auth/me`) is the active tenant — there is exactly one membership exposed. The org switcher (Story 18-5 follow-up) will let a multi-org user pick. Because all views depend on `useActiveTenant`, swapping its body for the switcher's selection is the **only** change needed; the abort-and-refetch on tenant change already covers the switch behaviour (AC 7).
+
+### Empty store is not an error
+
+A brand-new tenant (or a quiet period) returns 200 with empty arrays. Treat `data && rows/points empty` as the zero-state. Only non-2xx / network failures are errors. This mirrors `DashboardHome` ("No runs yet.") and is explicitly tested (AC 8, AC 12c) so a future API change that returns 204/empty doesn't trip a red banner.
+
+### UTC everywhere
+
+Send `from`/`to` as UTC ISO 8601 (`new Date(...).toISOString()`); the API forces UTC binding (36-3 AC) so windows must align with stored UTC buckets. Preset math (7d/30d/90d/MTD) computes against `Date.now()` then `.toISOString()`. Display can localize via `toLocaleString()` (as `DashboardHome` does for run timestamps), but the wire format is always UTC.
+
+### Export ships dark
+
+`ExportButton` + `requestAnalyticsExport` land in this story behind `VITE_FEATURE_ANALYTICS_EXPORT` (default unset → hidden) so the analytics section ships before 36-8. When 36-8 lands, flip the flag; no dashboard code change needed beyond enabling it. The dashboard never generates CSV/PDF — it only POSTs the request and links the result.
+
+### Charting choice
+
+Default to the dependency-free inline `TimeSeriesChart` (SVG + a11y table). The `vite.config.ts` deliberately pins an older browser baseline (`es2020`, chrome87…) — any chart lib added must respect that floor. If `recharts` is adopted, confirm it builds under that target before committing the dependency.
+
+## Logging Requirements
+
+This is a browser SPA — there is no Pino logger. Observability conventions for this story:
+
+- **Console (dev only):** surface fetch failures via the inline error panel; do not `console.log` response bodies (may contain tenant cost figures).
+- **No sensitive data in the URL beyond the tenant id** the user already owns — never put another tenant's id, tokens, or cost figures in query strings or `localStorage`.
+- **Audit trail is server-side:** the analytics-read audit and the `ANALYTICS.EXPORT.REQUESTED` events are emitted by 36-3/36-4/36-5/36-8 on the API; the dashboard emits nothing to the DCB store.
+- **Error panels** must show a user-safe message (`error.message` from `ApiError`), never raw stack traces or other tenants' data.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-36/story-36-7/36-7-pricing-cost-basis-and-platform-margin-model.md
+++ b/docs/stories/epic-36/story-36-7/36-7-pricing-cost-basis-and-platform-margin-model.md
@@ -1,0 +1,540 @@
+# Story 36-7: Cost-Basis vs Margin Analytics View (Per-Tenant Gross Margin + Platform-Aggregate Margin)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-phase workflow (Read → Research → Break Down → TDD →
+Quality Gates → Failure Handling), the `.dev/` knowledge base, TRACE/DEBUG logging
+requirements, test-first development, and the build-success / coverage gates.
+
+## ⚠️ Boundary — this story is an analytics VIEW, NOT the markup engine
+
+This story is the **read-side analytics view** of cost-basis vs margin. It **reads** the
+already-computed pricing outputs of **Story 34-5 (Cost→Price Markup Engine)** as they were
+persisted onto the analytics fact tables by the **Story 36-2 projection pipeline** (the
+`CostUsd` cost basis and the `PlatformBilledUsd` sell price on `AnalyticsUsageHourly`/
+`AnalyticsUsageDaily`), and the per-call usage emitted by **Story 32-9 (cost-basis + margin
+metering)**. It presents per-tenant gross-margin and a platform-level margin aggregate
+(owner-only).
+
+**It MUST NOT recompute pricing.** The margin multiplier, the cost-basis rate sheet, the
+`cost × (1 + margin)` arithmetic, and the BYOK zero-markup rule all live in **34-5**
+(`IUsagePricingEngine` / `IMarginPolicyResolver` / `ProviderPricingService`) and are applied
+once, at projection time, by **36-2**. This story reads `PlatformBilledUsd` (revenue) and
+`CostUsd` (cost) off the fact rows and reports `revenue − cost` as margin. If this story ever
+multiplies a cost by a margin, classifies BYOK vs platform from a secret cabinet, or reads a
+margin policy row, it has crossed the boundary — that is a 34-5/36-2 change, not 36-7.
+
+## User Story
+
+As a **self-hosted owner** (single-user) **/ tenant administrator** (SaaS), and — for the
+fleet-wide view — as the **platform owner**,
+I want a profitability view that reads my already-priced usage facts and shows cost basis,
+billed revenue, and the resulting gross margin per tenant (and, for the platform owner only, a
+single platform-wide margin aggregate), broken down by provider / agent / workflow / cost-basis
+and trended over time,
+so that I can see where Tamma is making or losing money on platform-provided usage and confirm
+that BYOK usage carries zero token markup — without any pricing being recomputed in the
+reporting path.
+
+## Priority
+
+P0 - Profitability is the business question Epic 36's owner-side analytics exists to answer; the
+per-tenant gross-margin view is the tenant-facing counterpart that proves the BYOK/platform
+split is billing as designed.
+
+## Scope
+
+Read-model + query service + endpoints **only**. This story:
+
+- adds an `IMarginAnalyticsService` / `MarginAnalyticsService` that **reads** the Story 36-1
+  per-tenant fact tables (`analytics_usage_daily` / `analytics_usage_hourly`) through the
+  tenant's `TenantDbContext` and computes a **margin view** = `Σ PlatformBilledUsd` (revenue)
+  − `Σ CostUsd` (cost) per dimension and per period — **no markup math**;
+- exposes a **tenant-scoped** gross-margin endpoint (`MemberAccess`) returning cost / revenue /
+  margin / margin-% with provider·agent·workflow·cost-basis breakdowns and a daily/monthly
+  trend, scoped to exactly one tenant schema;
+- exposes a **platform-owner-only** margin-aggregate endpoint (`OwnerAccess` /
+  `PlatformOwnerAccess`) that fans the per-tenant `PlatformBilledUsd` − `CostUsd` figures into a
+  single fleet-wide profitability summary + trend, modelled on `AdminAnalyticsEndpoints` /
+  `PlatformAnalyticsService`.
+
+**Out of scope (owned elsewhere — do not touch):** the markup engine and margin policy
+(Story 34-5), the per-call usage emission + cost-basis classification (Story 32-9 / 35-2), the
+fact-table schema (Story 36-1), the projection that populates `CostUsd`/`PlatformBilledUsd`
+(Story 36-2), exports / scheduled reports (later Epic 36 stories), and the dashboard surface
+(a later Epic 36 story — this story ships the read API the dashboard will call).
+
+## Acceptance Criteria
+
+1. A new tenant-scoped read service `IMarginAnalyticsService` /
+   `MarginAnalyticsService`
+   (`apps/tamma-elsa/src/Tamma.Api/Services/Analytics/IMarginAnalyticsService.cs` +
+   `MarginAnalyticsService.cs`) computes, for the caller's tenant over a `[from, to]` UTC
+   window, a **margin view**: `CostUsd` (cost basis, summed from the fact rows),
+   `PlatformBilledUsd` (billed revenue, summed from the fact rows), `MarginUsd =
+   PlatformBilledUsd − CostUsd`, and `MarginPct = MarginUsd / PlatformBilledUsd` (0 when
+   revenue is 0). It reads `AnalyticsUsageDaily` for windows spanning whole days and
+   `AnalyticsUsageHourly` for sub-day windows, through the tenant's `TenantDbContext` resolved
+   via `ITenantDbContextFactory` — **the same tables Story 36-2 populates**.
+
+2. **No pricing is recomputed.** The service performs only summation and subtraction over the
+   already-persisted `CostUsd` and `PlatformBilledUsd` measures. It does **not** reference
+   `IUsagePricingEngine`, `IMarginPolicyResolver`, `ProviderPricingService`, any margin
+   multiplier, or any cost rate sheet. A code-level test (or analyzer assertion) confirms the
+   `Tamma.Api.Services.Analytics` margin-view types take **no** dependency on the 34-5 pricing
+   namespace. The boundary is documented in the service's XML doc-comment, citing 34-5 as the
+   owner of `PlatformBilledUsd` and 36-2 as the producer.
+
+3. The service returns dimension breakdowns — **by provider, by agent, by workflow definition,
+   and by cost-basis (`byok` / `platform`)** — each row carrying its own
+   `Cost / Revenue / Margin / MarginPct`, with a `NULL`-dimension ("unattributed") bucket
+   preserved so `Σ(breakdown rows) == grand total` (mirrors the Story 36-2 reconciliation
+   guarantee; the view never coerces a `NULL` dimension to a sentinel and never drops it).
+
+4. **BYOK rows surface a zero-revenue, zero-margin line.** Because Story 34-5/36-2 persist
+   `PlatformBilledUsd = 0` for every `CostBasis = byok` row (Tamma never marks up a BYOK call),
+   the `byok` cost-basis bucket reports `Revenue = 0`, `Margin = −Cost` (the BYOK platform/seat
+   fee is billed by Epic 35, not metered here as token revenue), and `MarginPct = 0`. The view
+   asserts this directly from the stored data — it does **not** re-derive the zero; a unit test
+   pins that a `byok` fact row yields `Revenue == 0` in the breakdown.
+
+5. A **trend** series is returned: a daily (and, on request, monthly) time series of
+   `Cost / Revenue / Margin / MarginPct` over the window, read from `AnalyticsUsageDaily`
+   (daily grain) so the tenant can chart profitability over time without re-scanning events.
+   The trend buckets sum losslessly to the window grand total (AC1).
+
+6. A **tenant-scoped** endpoint `GET /api/v1/orgs/{tenantId}/analytics/margin`
+   (`MemberAccess`) returns the tenant's cost/revenue/margin summary + breakdowns + trend for a
+   `from`/`to` (and optional `grain=day|month`) query. It resolves the tenant strictly from
+   `ITenantContext.TenantId` (SaaS) or the sole tenant (single-user) — a member of tenant A can
+   never read tenant B's margin (cross-tenant request → 404, mirroring the existing org-scoped
+   endpoint precedent); the per-tenant `TenantDbContext` enforces isolation physically.
+
+7. A **platform-owner-only** aggregate is exposed via a new method on the platform analytics
+   surface (`IPlatformAnalyticsService.GetPlatformMarginAsync(...)` +
+   `PlatformAnalyticsService`) and endpoint `GET /api/admin/analytics/margin`
+   (`OwnerAccess`), returning one **fleet-wide** profitability summary — total `CostUsd`, total
+   `PlatformBilledUsd`, total `MarginUsd`, blended `MarginPct` — plus a top-N
+   tenants-by-margin list and a fleet trend. This is **owner-only**: tenants and members cannot
+   call it (403) and never see another tenant's or the platform's aggregate margin.
+
+8. The platform aggregate is composed by **summing the per-tenant `PlatformBilledUsd` and
+   `CostUsd` fact figures across active tenants** (the CP `platform_analytics_hourly` table from
+   Story 28-10 carries `CostUsd` but **not** `PlatformBilledUsd`, so revenue must come from the
+   per-tenant `analytics_usage_*` store — verified). The fan-out mirrors
+   `FanOutTenantRollupsActivity` / `PlatformAnalyticsService.GetTenantResourceSummaryAsync`
+   tenant-iteration shape: a single tenant's read failure is caught, logged, excluded from the
+   aggregate with a counted skip, and never aborts the fleet view.
+
+9. **RBAC, per-mode.** Tenant-scope margin (cost/revenue/margin for one tenant) is readable by
+   any tenant member (`MemberAccess`) in SaaS and by the sole user in single-user; the
+   platform-aggregate margin is **`OwnerAccess` only** in both modes. The raw margin multiplier
+   and cost rate sheet are never exposed by this story at all — tenants see resulting billed
+   amounts and the derived margin, never the policy that produced them (that policy lives in
+   34-5 behind `PlatformOwnerAccess`). A test matrix asserts: member → tenant margin OK,
+   member → `/api/admin/analytics/margin` 403, cross-tenant → 404, owner → both OK.
+
+10. **Per-mode ownership is answered explicitly** (per CLAUDE.md "two scoping models"): in
+    single-user mode the sole user owns the one tenant schema's margin view and *is* the
+    platform owner (sees both surfaces against their single tenant); in SaaS mode tenant
+    admins/members see only their tenant's margin and the platform owner alone sees the
+    cross-tenant aggregate. The endpoint shape is identical across modes; auth middleware +
+    `ITenantContext` decide scope (prompt-store API precedent).
+
+11. **Empty / pre-projection safety.** A tenant with no projected fact rows yet (fresh tenant,
+    or 36-2 has not run for the window) returns a zeroed summary (`Cost = Revenue = Margin = 0`,
+    `MarginPct = 0`, empty breakdowns/trend) — never null, never throwing — mirroring
+    `TenantResourceSummary.Empty`. The platform aggregate over zero active tenants returns the
+    same zeroed shape.
+
+12. The view emits a lightweight **read-audit** DCB event `ANALYTICS.MARGIN.VIEWED`
+    (`AGGREGATE.ACTION.STATUS` convention) on each margin query, tagged
+    `{ scope: tenant|platform, tenantId?, from, to, grain }`, appended best-effort via the
+    existing `IEventRepository.AppendAsync` try/catch+log pattern (`PostgresAlertSink`
+    precedent) so the query path never fails on an emit error. **No `PRICING.*` event is emitted
+    by this story** — pricing-config audit (`PRICING.MARGIN.UPDATED`) is owned by 34-5; this
+    story only records that a margin *view* was read.
+
+13. Unit + integration tests cover: cost/revenue/margin summation and `MarginPct` (incl.
+    zero-revenue → 0); per-dimension breakdown reconciliation to the grand total (incl. the
+    `NULL` bucket); BYOK row → zero revenue / negative-of-cost margin read from stored data;
+    daily/monthly trend lossless sum; tenant isolation (tenant A's margin excludes tenant B's
+    rows — Postgres 17 Testcontainer, per `SchemaPerTenantMigrationTests`); platform aggregate
+    fan-out (sum across tenants; one tenant failure skipped, fleet view intact); RBAC matrix
+    (member/owner/cross-tenant); empty-tenant zeroed result; and the **no-recompute boundary**
+    assertion (AC2).
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Margin-view DTOs + reconciliation contract (AC: 1, 3, 5, 11)
+  - [ ] Add `MarginAnalyticsDtos.cs` records: `MarginSummary(CostUsd, RevenueUsd, MarginUsd,
+        MarginPct, GeneratedAt)`, `MarginBreakdownRow(Dimension, Key?, Cost, Revenue, Margin,
+        MarginPct)`, `MarginTrendPoint(Bucket, Cost, Revenue, Margin, MarginPct)`,
+        `TenantMarginReport(Summary, Breakdowns, Trend)`, `PlatformMarginReport(Summary,
+        TopTenantsByMargin, Trend)`. `MarginSummary.Empty` zeroed constant (AC11).
+  - [ ] Document each record's "revenue = persisted `PlatformBilledUsd`, cost = persisted
+        `CostUsd`, margin = revenue − cost; nothing is recomputed" contract in XML doc-comments.
+
+- [ ] Task 2: `IMarginAnalyticsService` / `MarginAnalyticsService` (AC: 1, 2, 3, 4, 5, 11)
+  - [ ] Read `AnalyticsUsageDaily` (whole-day windows) / `AnalyticsUsageHourly` (sub-day) via
+        `ITenantDbContextFactory`; `GROUP BY` dimension; `Σ CostUsd` / `Σ PlatformBilledUsd`;
+        derive `MarginUsd` / `MarginPct` (guard divide-by-zero).
+  - [ ] `NULL`-dimension bucket preserved; breakdown rows reconcile to summary.
+  - [ ] Zero deps on the 34-5 pricing namespace (assertable — AC2).
+
+- [ ] Task 3: Platform-aggregate read (AC: 7, 8, 11)
+  - [ ] Add `GetPlatformMarginAsync(from, to, grain, topN, ct)` to `IPlatformAnalyticsService`
+        + `PlatformAnalyticsService`; fan across active tenants (28-10 fan-out shape), sum
+        per-tenant `PlatformBilledUsd`/`CostUsd`; per-tenant read failure caught + skipped +
+        counted; top-N tenants by margin; fleet trend.
+
+- [ ] Task 4: Endpoints + RBAC (AC: 6, 7, 9, 10, 12)
+  - [ ] Tenant: `GET /api/v1/orgs/{tenantId}/analytics/margin` (`MemberAccess`) →
+        `MarginAnalyticsService`; resolve tenant from `ITenantContext`; cross-tenant 404.
+  - [ ] Admin: `GET /api/admin/analytics/margin` (`OwnerAccess`) → platform aggregate; map on
+        the existing `admin` group beside the other `/analytics/*` endpoints in `Program.cs`.
+  - [ ] Best-effort `ANALYTICS.MARGIN.VIEWED` DCB emit per query.
+  - [ ] DI: register `IMarginAnalyticsService` (scoped) in the analytics service-collection
+        extension.
+
+- [ ] Task 5: Tests (AC: 13)
+  - [ ] Unit (InMemory): summation/MarginPct/zero-revenue, breakdown reconciliation, BYOK
+        zero-revenue, trend lossless, empty-tenant, no-recompute dependency assertion.
+  - [ ] Integration (Postgres 17 Testcontainer): tenant isolation (A excludes B), platform
+        fan-out aggregate + one-tenant-failure tolerance, RBAC matrix.
+
+## Technical Design
+
+### Read-model boundary (the load-bearing decision)
+
+```
+Story 34-5  ── IUsagePricingEngine ─────────────►  (markup math: cost × margin → sell price; BYOK → 0)
+   │                                                 OWNS the margin policy + rate sheet
+   ▼  (sell price applied once, at projection time)
+Story 36-2  ── ComputeTenantDimensionalRollupActivity
+   │              writes per fact row:  CostUsd  (= 34-5 cost basis)
+   │                                    PlatformBilledUsd (= 34-5 sell price; 0 for BYOK)
+   ▼
+Story 36-1  ── analytics_usage_hourly / analytics_usage_daily  (per-tenant schema)
+   │              dims: Provider, AgentId, WorkflowDefinitionId, RepoId, CostBasis(byok|platform)
+   ▼
+Story 36-7 (THIS) ── MarginAnalyticsService  =  Σ PlatformBilledUsd − Σ CostUsd
+                       PURE READ. No multiply. No policy lookup. No cabinet read.
+```
+
+The whole story is summation + subtraction over two already-priced columns. The moment the
+reporting path multiplies a cost by a margin, it has duplicated 34-5 and will drift — the AC2
+no-recompute assertion exists to catch that in CI.
+
+### C# namespace / file structure
+
+```
+apps/tamma-elsa/src/Tamma.Api/Services/Analytics/
+  IMarginAnalyticsService.cs                 # NEW — tenant-scoped margin read port
+  MarginAnalyticsService.cs                  # NEW — Σ revenue − Σ cost over the fact tables
+  MarginAnalyticsDtos.cs                     # NEW — summary / breakdown / trend records
+  IPlatformAnalyticsService.cs               # MODIFY — + GetPlatformMarginAsync(...)
+  PlatformAnalyticsService.cs                # MODIFY — fleet-wide margin via per-tenant fan-out
+  PlatformAnalyticsDtos.cs                   # MODIFY — + PlatformMarginReport / TenantMarginRow
+
+apps/tamma-elsa/src/Tamma.Api/Endpoints/
+  AdminAnalyticsEndpoints.cs                 # MODIFY — + GetMargin (OwnerAccess, platform aggregate)
+  Analytics/MarginAnalyticsEndpoints.cs      # NEW — tenant GET /api/v1/orgs/{tenantId}/analytics/margin
+
+apps/tamma-elsa/src/Tamma.Api/
+  Program.cs                                 # MODIFY — map both routes; DI registration
+  Extensions/<AnalyticsServiceCollectionExtensions>.cs  # MODIFY/NEW — register IMarginAnalyticsService
+
+apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/
+  MarginAnalyticsServiceTests.cs             # NEW — summation / breakdown / BYOK / trend / no-recompute
+  MarginAnalyticsIsolationTests.cs           # NEW — Postgres 17: tenant isolation + platform fan-out
+  MarginAnalyticsEndpointsTests.cs           # NEW — RBAC matrix + cross-tenant 404 + empty
+```
+
+> **Note on the spec's `PricingConfigService` / `AdminPricingEndpoints` / `Plan` / `AgentConfig`
+> primary-components list:** those are the **34-5** markup-engine components
+> (`AdminPricingEndpoints`, `MarginPolicy`, the `Plan` price book), not 36-7's. This story
+> deliberately does **not** create or edit them — per the boundaryNote, 36-7 is the analytics
+> *view* of what 34-5 produced. The `Tamma.Api/Services/Analytics/*` files above are 36-7's.
+
+### Margin read (tenant scope — pure summation)
+
+```csharp
+// MarginAnalyticsService — NO pricing recompute. Reads the columns 34-5/36-2 already wrote.
+public async Task<TenantMarginReport> GetTenantMarginAsync(
+    Guid tenantId, DateTime fromUtc, DateTime toUtc, MarginGrain grain, CancellationToken ct)
+{
+    await using var db = await _tenantDbFactory.CreateAsync(tenantId, ct);
+
+    // Daily grain for whole-day windows (cheap); hourly only for sub-day windows.
+    var rows = await db.AnalyticsUsageDaily
+        .Where(r => r.Day >= fromUtc && r.Day < toUtc)
+        .ToListAsync(ct);
+
+    decimal cost    = rows.Sum(r => r.CostUsd);
+    decimal revenue = rows.Sum(r => r.PlatformBilledUsd);
+    var summary = MarginSummary.From(cost, revenue);   // Margin = revenue - cost; Pct guards /0
+
+    var byCostBasis = rows
+        .GroupBy(r => r.CostBasis)                       // byok rows already carry PlatformBilledUsd == 0
+        .Select(g => MarginBreakdownRow.From("costBasis", g.Key.ToString(),
+            g.Sum(x => x.CostUsd), g.Sum(x => x.PlatformBilledUsd)))
+        .ToList();
+    // …same GROUP BY for Provider / AgentId (NULL bucket kept) / WorkflowDefinitionId…
+
+    var trend = rows
+        .GroupBy(r => r.Day)
+        .OrderBy(g => g.Key)
+        .Select(g => MarginTrendPoint.From(g.Key,
+            g.Sum(x => x.CostUsd), g.Sum(x => x.PlatformBilledUsd)))
+        .ToList();
+
+    return new TenantMarginReport(summary, breakdowns: Combine(byCostBasis, …), trend);
+}
+
+// MarginSummary.From — the ONLY arithmetic in this story.
+public static MarginSummary From(decimal cost, decimal revenue) => new(
+    CostUsd: cost,
+    RevenueUsd: revenue,
+    MarginUsd: revenue - cost,
+    MarginPct: revenue == 0m ? 0m : Math.Round((revenue - cost) / revenue, 4, MidpointRounding.AwayFromZero),
+    GeneratedAt: DateTime.UtcNow);
+```
+
+### Platform aggregate (owner-only — fan across tenants)
+
+`platform_analytics_hourly` (Story 28-10, CP) carries `CostUsd` but **no `PlatformBilledUsd`**
+(verified — see `Tamma.Data/Entities/PlatformAnalyticsHourly.cs`). Revenue therefore comes from
+the per-tenant `analytics_usage_*` store. `GetPlatformMarginAsync` iterates active tenants (the
+28-10 fan-out target set), reads each tenant's `MarginSummary` via `MarginAnalyticsService`,
+sums them, and builds the fleet summary + top-N-by-margin + trend — mirroring
+`PlatformAnalyticsService.GetTenantResourceSummaryAsync` / `FanOutTenantRollupsActivity`
+tenant-iteration and per-tenant fault tolerance (one tenant's read failure is caught, logged,
+skipped with a counted skip, and never aborts the aggregate).
+
+### Endpoints
+
+```
+GET /api/v1/orgs/{tenantId}/analytics/margin?from=ISO&to=ISO&grain=day|month   (MemberAccess)
+    → TenantMarginReport   (tenant resolved from ITenantContext; cross-tenant → 404)
+
+GET /api/admin/analytics/margin?from=ISO&to=ISO&grain=day|month&limit=N         (OwnerAccess)
+    → PlatformMarginReport (fleet aggregate; tenant/member → 403)
+```
+
+The admin route is added on the existing `admin` group beside
+`admin.MapGet("/analytics/summary", AdminAnalyticsEndpoints.GetSummary)` in `Program.cs`
+(verified the group + `OwnerAccess` wiring already exist). The tenant route mounts on the
+existing `/api/v1/orgs` `MemberAccess` group (verified).
+
+### DCB events
+
+| Event | When | Tags |
+|---|---|---|
+| `ANALYTICS.MARGIN.VIEWED` | per margin query (tenant or platform) | `scope` (`tenant`/`platform`), `tenantId?`, `from`, `to`, `grain` |
+
+Appended best-effort via `IEventRepository.AppendAsync` inside try/catch+log (the
+`PostgresAlertSink` emit pattern) — a margin read never fails on an emit error. **No
+`PRICING.*` event is emitted here** (that family is 34-5's pricing-config audit).
+
+### Per-mode + per-tenant handling
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who reads a tenant's margin view? | The sole user (their one tenant schema; no RBAC). | Any tenant member (`MemberAccess`); member is read-only — margin is a read. |
+| Who reads the platform aggregate? | The sole user (they are the platform owner; aggregate = their single tenant). | Platform owner only (`OwnerAccess`); tenants/members 403. |
+| Where does the data come from? | The sole tenant's `analytics_usage_*` (36-2 populated). | Each tenant's own `t_<hex>` `analytics_usage_*`; aggregate fans across all active tenants. |
+| Is the margin policy ever exposed? | No — only resulting cost/revenue/margin (policy lives in 34-5). | No — same; tenants never see the multiplier. |
+| Isolation plane | Search-path schema + connection string. | Same — physically separate schema per tenant; a row in A is unreachable from B. |
+
+Mode does not change the read shape — both resolve to exactly one tenant schema per tenant-scope
+request; only the platform-aggregate fan-out target set differs (one tenant vs all active
+tenants).
+
+### Integration points
+
+- **Story 36-1 (`analytics_usage_hourly`/`_daily`, `CostBasis` enum)** — the fact tables and the
+  `byok|platform` discriminator this view reads. (Drafted.)
+- **Story 36-2 (projection)** — populates `CostUsd` + `PlatformBilledUsd`; this view is inert
+  until 36-2 has run for the window (AC11 zeroed-result handles the gap). (Drafted.)
+- **Story 34-5 (`IUsagePricingEngine`)** — the markup engine that *produced* `PlatformBilledUsd`
+  upstream. Referenced as the source of truth for the figures; **not called** by this story.
+  (Plan written; engine NEW — `IUsagePricingEngine`/`MarginPolicy` confirmed absent today.)
+- **Story 32-9** — emits the per-call cost-basis + margin usage line 36-2 folds in. (Plan
+  written.)
+- **Story 28-10 (`PlatformAnalyticsService` / `AdminAnalyticsEndpoints` / `IEventRepository`)**
+  — the owner-side analytics surface, fan-out shape, and DCB emit pattern this story extends.
+  (Merged.)
+
+## Dependencies
+
+**Prerequisite (internal):**
+- **Story 36-1** — per-tenant `AnalyticsUsageHourly`/`AnalyticsUsageDaily` + `CostBasis` enum
+  (the columns this view reads). Drafted.
+- **Story 36-2** — the projection that writes `CostUsd` + `PlatformBilledUsd` onto those rows.
+  Drafted. (Until it runs, AC11 returns a zeroed view.)
+- **Epic 28** — per-tenant schema + `ITenantDbContextFactory` + the 28-10
+  `PlatformAnalyticsService`/`AdminAnalyticsEndpoints` surface this extends. Merged.
+
+**Source-of-truth (read-only — this story consumes their *outputs*, never their math):**
+- **Story 34-5 (Cost→Price Markup Engine)** — owns `IUsagePricingEngine` / `IMarginPolicyResolver`
+  / `ProviderPricingService` and the `cost × (1 + margin)` / BYOK-zero-markup arithmetic that
+  produced `PlatformBilledUsd`. **Not invoked here.** Plan written; entities NEW.
+- **Story 32-9** — the cost-basis + margin metering producer that emits the per-call usage line.
+
+**Blocks (internal):**
+- Later Epic 36 stories — margin exports, scheduled profitability reports, and the dashboard
+  margin/profitability surface — all read this service's API.
+
+**External:**
+- PostgreSQL 17 (per-tenant schema isolation; the integration suite uses a Testcontainer).
+- EF Core 9 / Npgsql.
+- Testcontainers + Docker for the isolation + fan-out integration suite (run via
+  `sg docker -c "dotnet test ..."`).
+
+## Testing Strategy
+
+1. **Unit — margin math (`MarginAnalyticsServiceTests`, InMemory):** `Σ PlatformBilledUsd −
+   Σ CostUsd`; `MarginPct` (incl. zero-revenue → 0, negative margin when cost > revenue);
+   rounding determinism (4dp).
+
+2. **Unit — breakdown reconciliation:** rows spanning multiple providers/agents/workflows/
+   cost-bases produce one breakdown row per key with its own cost/revenue/margin;
+   `NULL`-dimension bucket preserved; `Σ(breakdown rows) == grand total`.
+
+3. **Unit — BYOK zero revenue:** a fact row with `CostBasis = byok` (and the
+   `PlatformBilledUsd = 0` 36-2 persists) yields `Revenue == 0`, `Margin == −Cost`,
+   `MarginPct == 0` — read from stored data, not re-derived.
+
+4. **Unit — trend lossless:** daily/monthly trend points sum to the window grand total; monthly
+   grain rolls daily rows up correctly.
+
+5. **Unit — empty tenant:** no fact rows → `MarginSummary.Empty` (all zero), empty
+   breakdowns/trend, never null/throwing.
+
+6. **Unit — no-recompute boundary (AC2):** assert the margin-view types reference **no** symbol
+   from the 34-5 pricing namespace (`IUsagePricingEngine` / `IMarginPolicyResolver` /
+   `ProviderPricingService` / `MarginPolicy`) — reflection-over-assembly-references or a
+   dependency test; documents the boundary as an executable guard.
+
+7. **Integration — tenant isolation (`MarginAnalyticsIsolationTests`, Postgres 17
+   Testcontainer, per `SchemaPerTenantMigrationTests`):** seed fact rows into two tenant schemas;
+   tenant A's margin reflects only A's rows; B's rows are invisible to A.
+
+8. **Integration — platform fan-out:** seed two tenants; `GetPlatformMarginAsync` sums both into
+   the fleet aggregate + top-N-by-margin; force a read failure on tenant A → A is skipped (counted),
+   tenant B still contributes, the aggregate completes.
+
+9. **Endpoint — RBAC matrix (`MarginAnalyticsEndpointsTests`):** member → tenant margin 200;
+   member → `/api/admin/analytics/margin` 403; cross-tenant `{tenantId}` → 404; owner → both
+   200; single-user → both 200 against the one tenant; empty window → zeroed 200.
+
+**Mocks:** No Stripe / external provider calls (read-only aggregation). InMemory provider for
+math/breakdown/trend shape; a real Postgres 17 Testcontainer for per-tenant isolation and the
+fan-out aggregate (EF InMemory does not model search-path schema isolation — same rationale as
+`ConventionStoreMigrationTests` / `SchemaPerTenantMigrationTests`).
+
+## Estimated Effort
+
+3-4 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/IMarginAnalyticsService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/MarginAnalyticsService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/MarginAnalyticsDtos.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/IPlatformAnalyticsService.cs` | Modify (add `GetPlatformMarginAsync`) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/PlatformAnalyticsService.cs` | Modify (fleet margin via per-tenant fan-out) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/PlatformAnalyticsDtos.cs` | Modify (add `PlatformMarginReport` / `TenantMarginRow`) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminAnalyticsEndpoints.cs` | Modify (add `GetMargin`, OwnerAccess) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Analytics/MarginAnalyticsEndpoints.cs` | Create (tenant `GET /api/v1/orgs/{tenantId}/analytics/margin`) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map both routes; DI) |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/AnalyticsServiceCollectionExtensions.cs` | Modify/Create (register `IMarginAnalyticsService`) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/MarginAnalyticsServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/MarginAnalyticsIsolationTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/MarginAnalyticsEndpointsTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, decisions (analytics, margin, tenancy,
+   event sourcing).
+3. Reviewed Story 36-1 (the fact tables + `CostBasis` enum + `PlatformBilledUsd` column),
+   Story 36-2 (which populates `CostUsd`/`PlatformBilledUsd`), and Story 34-5 (the markup
+   engine whose outputs this view reads — to understand the boundary you must not cross).
+4. Reviewed `PlatformAnalyticsService` / `AdminAnalyticsEndpoints` / `PlatformAnalyticsDtos`
+   (Story 28-10) — this story extends that exact surface and fan-out/tolerance shape.
+5. Confirmed the test runner: docker-bound suites run via `sg docker -c "dotnet test ..."`
+   (session docker group is stale; the build itself needs no wrapper).
+6. Planned the TDD cycle (write the margin-math + reconciliation + no-recompute tests red first,
+   then the service).
+
+### Key Design Decisions
+
+- **View, not engine — the boundary is the whole story.** 36-7 reads `PlatformBilledUsd`
+  (revenue) and `CostUsd` (cost) that 34-5 computed and 36-2 persisted, and reports
+  `revenue − cost`. It performs no markup math, no policy lookup, no cabinet read. The AC2
+  no-recompute test makes that boundary an executable CI guard so a future change can't quietly
+  duplicate 34-5's arithmetic and let the two drift.
+- **Revenue comes from the per-tenant store, not the CP fact table.** `platform_analytics_hourly`
+  (28-10) tracks `CostUsd` only — it has no `PlatformBilledUsd` column. The platform-aggregate
+  margin therefore sums the per-tenant `analytics_usage_*` revenue across tenants (fan-out),
+  rather than reading a non-existent CP revenue column. (If a future story adds
+  `PlatformBilledUsd` to the CP rollup, this aggregate can swap its source behind
+  `IPlatformAnalyticsService` with no endpoint change.)
+- **Platform aggregate is OWNER-ONLY.** A tenant must never see the fleet margin or another
+  tenant's margin; the admin route is `OwnerAccess`, the tenant route is `MemberAccess` and
+  hard-scoped to `ITenantContext.TenantId` (cross-tenant → 404). The raw margin multiplier is
+  never exposed by this story in either mode.
+- **`NULL` dimension buckets, never sentinels.** The breakdown preserves the 36-2 `NULL`
+  ("unattributed") buckets so per-dimension margin and the grand total reconcile exactly —
+  coercing `NULL` to `"unknown"` would fork the total.
+- **Daily grain by default.** Read `analytics_usage_daily` for whole-day windows (the common
+  dashboard case) so a month of margin is a small `GROUP BY`, not an hourly scan; fall to
+  `analytics_usage_hourly` only for sub-day windows.
+- **Empty is zero, not null.** Pre-projection / fresh-tenant windows return a zeroed summary
+  (mirrors `TenantResourceSummary.Empty`) so the dashboard renders "no margin yet" rather than
+  erroring.
+
+### Read-only boundary
+
+This story creates **no** markup engine, **no** margin policy, **no** `AdminPricingEndpoints`,
+**no** `PricingConfigService`, **no** change to `Plan` / `AgentConfig`, **no** fact-table schema
+change, and **no** projection logic — all of those are 34-5 / 36-1 / 36-2 scope. It adds only the
+read service, the two query endpoints, their DTOs, and tests. Any PR that recomputes a price,
+reads a margin policy, or classifies BYOK from a secret cabinet under cover of this story is out
+of scope — keep the diff to the analytics read path.
+
+## Logging Requirements
+
+- **INFO**: margin query served (`scope`, `tenantId?`, `from`, `to`, `grain`, `rowsRead`,
+  `costUsd`, `revenueUsd`, `marginUsd`); platform aggregate served (`tenantsIncluded`,
+  `tenantsSkipped`, totals).
+- **DEBUG**: per-dimension breakdown sizes; daily-vs-hourly grain selection; trend bucket count.
+- **WARN**: a per-tenant read skipped in the platform aggregate (`tenantId`, errorType) —
+  fan-out continues; `ANALYTICS.MARGIN.VIEWED` emit failure (best-effort, swallowed).
+- **ERROR**: tenant-scope margin read failed for the resolved tenant (surfaced to the caller as
+  5xx — a single-tenant read failure is not tolerated the way the fleet fan-out is); CP/tenant
+  context resolution failure.
+- **Structured context**: include `{ scope, tenantId, from, to, grain, costUsd, revenueUsd,
+  marginUsd, tenantsIncluded, tenantsSkipped }` where applicable.
+- **Credential safety**: NEVER log tenant connection strings, search-path schema secrets, or
+  provider API keys. This story reads only cost/revenue measures — it never touches provider-key
+  plaintext or the margin policy, so no pricing-config secret can leak through the view.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-36/story-36-8/36-8-analytics-exports.md
+++ b/docs/stories/epic-36/story-36-8/36-8-analytics-exports.md
@@ -1,0 +1,571 @@
+# Story 36-8: Analytics Exports (CSV / PDF)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-phase workflow (Read → Research → Break Down → TDD →
+Quality Gates → Failure Handling), the `.dev/` knowledge base, TRACE/DEBUG logging
+requirements, test-first development, and the build-success / coverage gates.
+
+## User Story
+
+As a **tenant administrator** (SaaS) **/ self-hosted owner** (single-user),
+I want to export any of my analytics views — usage, cost, or agent performance — as a CSV
+(raw dimensional rows) or a branded PDF (the same summary + breakdown tables and chart images the
+dashboard renders) for a chosen date range and grouping,
+so that I can hand a finance team a spreadsheet, attach a performance report to a ticket, or keep
+an offline archive — without ever seeing another tenant's data, and without a large range
+blocking the request thread.
+
+## Priority
+
+P1 — Exports are the first "take my analytics out of the product" surface. They are gated behind
+the Story 36-1 fact tables and the Story 36-3/36-4/36-5 query services; they ship after those
+read paths exist but are independent of scheduled reports (Story 36-9) and owner business
+analytics.
+
+## Scope
+
+Export pipeline **only**. This story adds, on top of the per-tenant dimensional store
+(Stories 36-1/36-2) and the tenant query services (Stories 36-3 usage / 36-4 cost / 36-5 agent
+performance):
+
+- a tenant-scoped `POST /api/v1/orgs/{tenantId}/analytics/exports` endpoint that accepts a
+  `{ type, format, from, to, groupBy }` spec, validates + bounds it, and either returns the file
+  inline (small ranges) or enqueues a background job and returns a job id (large ranges);
+- an `AnalyticsExportService` that renders one export by **calling the existing 36-3/36-4/36-5
+  query services** (never re-aggregating the raw event stream) into CSV (raw rows) or PDF
+  (rendered report);
+- a CSV writer with stable, documented column headers matching the query-service DTOs;
+- a PDF report renderer (summary + breakdown tables + chart images) branded for Tamma;
+- an async path on the existing tenant `QueuedTask` queue + `TaskQueueProcessor` for ranges over
+  the streaming threshold, with a signed, expiring download URL on completion;
+- a `DATA.EXPORT` DCB audit event (REQUESTED / COMPLETED / FAILED) appended to the tenant's own
+  event store, feeding Epic 37 (audit/compliance).
+
+**Out of scope:** the query services themselves (36-3/36-4/36-5 own the aggregation + DTOs — this
+story only reads them); scheduled/recurring report delivery (36-9); the platform-owner business
+analytics export (a later owner-only story); a long-lived object store / CDN — the signed download
+is served from the tenant DB-backed export-artifact row over the app, not an external blob store
+(an `IExportArtifactStore` seam keeps a future S3/blob backend a drop-in).
+
+## Acceptance Criteria
+
+1. `POST /api/v1/orgs/{tenantId}/analytics/exports` accepts a JSON body
+   `{ type: "usage"|"cost"|"agents", format: "csv"|"pdf", from: ISO8601, to: ISO8601,
+   groupBy?: string[] }` and returns **either** the rendered file inline
+   (`200`, `Content-Disposition: attachment`, correct content type) when the requested range is at
+   or under the streaming threshold, **or** `202 Accepted` with `{ jobId, status: "queued" }` when
+   the range exceeds the threshold. `type`/`format` are validated against allow-lists (400 on an
+   unknown value); `from`/`to` are required, must parse as UTC, and `from <= to` (400 otherwise);
+   `groupBy` entries are validated against the dimension allow-list the target query service
+   exposes (`provider`, `agent`, `workflow`, `repo`, `costBasis`) — an unknown dimension is a 400.
+
+2. **CSV export** emits one row per dimension-tuple per time bucket, with **stable, documented
+   column headers that match the corresponding query-service DTO** (usage → 36-3 DTO, cost → 36-4,
+   agents → 36-5). The dimension columns (`bucket`, `provider`, `agentId`, `workflowDefinitionId`,
+   `repoId`, `costBasis` — those the `groupBy` selects) come first, then the measure columns
+   (`tokensIn`, `tokensOut`, `costUsd`, `platformBilledUsd`, workflow counts, agent dispatches…).
+   Measure numbers are written as **unrounded raw measures** (the same `long`/`decimal(20,4)` the
+   fact store holds — no display rounding); the `NULL` dimension bucket (Story 36-2 "unattributed")
+   is written as an empty cell, never a `"unknown"` sentinel. The header row + a UTF-8 BOM make the
+   file Excel-friendly; the column order is asserted by a golden test so it never silently drifts.
+
+3. **PDF export** renders a branded report containing the **same summary block + per-dimension
+   breakdown tables (and chart images) the corresponding dashboard view shows** for the period:
+   a header (Tamma brand, tenant display name, report type, range, generated-at), a summary
+   section (period totals), one or more breakdown tables (one per `groupBy` dimension), and chart
+   image(s) matching the dashboard chart for that view. The PDF is generated server-side from the
+   same query-service results the CSV path uses (one source of truth — the two formats can never
+   disagree on the numbers for the same spec).
+
+4. **Hard tenant scoping** — identical guard to the Story 36-3 query endpoints:
+   `RequireTenantMembershipFilter` proves the caller is a member of `{tenantId}` (401 unauth /
+   403 non-member), the export reads **only** that tenant's per-tenant schema via
+   `ITenantDbContextFactory.CreateAsync(tenantId, ct)` (the query services it calls are already
+   per-tenant), and a download/job lookup for an export belonging to another tenant returns
+   **403/404** (never the file). In single-user mode the sole user owns every export; in SaaS mode
+   any tenant member may request + download their tenant's exports (read-only is fine — an export
+   is a read), mirroring `MemberAccess` on the 36-3 read path. A cross-tenant export attempt 403s.
+
+5. Export generation emits a **`DATA.EXPORT.REQUESTED`** DCB event on accept,
+   **`DATA.EXPORT.COMPLETED`** when the file is rendered (inline or async), and
+   **`DATA.EXPORT.FAILED`** on render failure — each appended via `IEventRepository.AppendAsync`
+   with `TenantId` set so it lands in the **tenant's own** `domain_events` store, tagged
+   `tenantId`, `userId`, `type`, `format` (+ `jobId`, `rowCount`, `bytes`, `durationMs` on
+   completion). These are the audit trail Epic 37 consumes; emission is best-effort and never
+   blocks or fails the export (PromptEvents/AlertEndpoints best-effort precedent).
+
+6. **Range/size are bounded.** The endpoint rejects (400) a range wider than the configured
+   maximum window (default 366 days). A configurable **streaming threshold** (default: estimated
+   row count > 50,000, or range > 92 days) decides sync-vs-async: at/under the threshold the file
+   renders inline on the request; over it, the request enqueues a tenant-scoped
+   `QueuedTask` (`Type = "analytics.export"`, `TenantId = {tenantId}`, payload = the validated
+   spec + requesting userId) and returns `202 { jobId }`. The `AnalyticsExportTaskHandler`
+   (`ITaskHandler`) renders the export on the `TaskQueueProcessor` thread, writes the artifact, and
+   emits `DATA.EXPORT.COMPLETED`/`FAILED`; the handler is idempotent on re-delivery (a completed
+   job id is a no-op).
+
+7. A completed async export is retrievable via **`GET /api/v1/orgs/{tenantId}/analytics/exports/{jobId}`**
+   (status + a **signed, time-bounded download URL** when `status = "completed"`) and
+   **`GET /api/v1/orgs/{tenantId}/analytics/exports/{jobId}/download?sig=…`** (streams the artifact
+   when the HMAC signature is valid and unexpired). The signature is computed over
+   `(tenantId, jobId, expiresAt)` with a server secret (HMAC-SHA256, constant-time compare); an
+   expired or tampered signature 403s; the artifact + its signing inputs are tenant-scoped so a
+   signed URL minted for tenant A can never resolve tenant B's file. Both routes sit behind
+   `RequireTenantMembershipFilter`.
+
+8. The export artifact is persisted to a per-tenant `analytics_exports` row (job state machine
+   `queued → running → completed | failed`, plus `type`, `format`, `spec` JSON, `requestedBy`,
+   `rowCount`, `byteSize`, `contentBytes`/storage-pointer, `expiresAt`, timestamps) in the
+   **tenant schema** (additive Tenant EF migration). Artifact bytes are read/written through an
+   `IExportArtifactStore` seam whose default implementation stores the bytes on the row
+   (`bytea`); the seam keeps a future external blob/S3 backend a drop-in with no endpoint change.
+   A retention sweep (best-effort, mirroring `PurgeStaleAnalyticsActivity`) deletes
+   `analytics_exports` rows past `expiresAt` (default 7-day artifact TTL).
+
+9. **Per-mode + per-tenant ownership is explicit.** single-user: the sole user owns every export
+   (`requestedBy = userId`, one tenant schema, no RBAC beyond authentication). SaaS: the export
+   belongs to the tenant; any member may request + download (an export is a read of data they can
+   already see); the artifact, job lookup, and signed URL are all hard-scoped to the path tenant.
+   The endpoint shape is identical across modes — the membership filter + per-tenant
+   `TenantDbContext` resolve scope, exactly as the prompt-store/36-3 precedent prescribes.
+
+10. **Tests** cover: CSV column correctness (golden header + row ordering + raw-number /
+    empty-NULL-cell formatting) for all three `type`s; PDF generation smoke (valid PDF bytes,
+    %PDF- magic, contains the summary + a breakdown table); the sync-vs-async threshold decision
+    (small → inline 200; large → 202 + jobId); the async job path end-to-end (enqueue → handler
+    renders → artifact persisted → status=completed → signed download streams the same bytes);
+    tenant isolation (cross-tenant export request 403; cross-tenant job/download lookup 403/404;
+    a signed URL for tenant A rejected on tenant B); signed-URL expiry + tamper rejection; and
+    `DATA.EXPORT.REQUESTED/COMPLETED/FAILED` audit-event emission (with the documented tags).
+
+11. The export **never re-aggregates the raw event stream** — it calls the Story 36-3/36-4/36-5
+    query services (or their shared query-result contracts) for the numbers. A structure/contract
+    test asserts the service depends on the query-service abstractions, not on `DomainEvent` /
+    `ProviderDiagnostic` directly, so the export and the dashboard are guaranteed to show the same
+    figures for the same spec.
+
+12. CSV and PDF rendering tolerate an **empty result** (a range with no facts) — CSV emits the
+    header row only; PDF emits a valid report with a "no data for this period" summary — both
+    still emit `DATA.EXPORT.COMPLETED` (rowCount 0). Rendering failures (e.g. PDF library throwing)
+    flip the job to `failed`, emit `DATA.EXPORT.FAILED` with `errorType`, and (sync path) return a
+    `500` with a sanitized message — never a partial/corrupt file.
+
+## Tasks / Subtasks
+
+- [ ] Task 1: `analytics_exports` entity + Tenant EF mapping + migration (AC: 6, 8)
+  - [ ] Add `apps/tamma-elsa/src/Tamma.Data/Entities/AnalyticsExport.cs` (job + artifact row);
+        DbSet on `TenantDbContext`; configure in `TammaModelConfiguration.ConfigureTenantEntities`
+        (status/type/format CHECK-style guards via length + allow-list constants; index on
+        `(Status, ExpiresAt)` for the retention sweep).
+  - [ ] Additive Tenant migration `AddAnalyticsExports` (`dotnet ef migrations add … -c
+        TenantDbContext`); `has-pending-model-changes -c TenantDbContext` reports none.
+
+- [ ] Task 2: Export spec + DTO/validation + event types (AC: 1, 5, 6)
+  - [ ] `AnalyticsExportSpec` record (type/format/from/to/groupBy) + validator (allow-lists,
+        UTC parse, `from<=to`, max-window, groupBy-dimension allow-list).
+  - [ ] `AnalyticsExportEventTypes` constants (`DATA.EXPORT.REQUESTED|COMPLETED|FAILED`).
+
+- [ ] Task 3: CSV writer (AC: 2, 12)
+  - [ ] `AnalyticsCsvWriter` — per-type column order from the query-service DTO; raw measures;
+        empty cell for NULL dimension; UTF-8 BOM; header-only on empty. Golden tests first.
+
+- [ ] Task 4: PDF renderer (AC: 3, 12)
+  - [ ] `AnalyticsPdfReportRenderer` — branded header, summary, per-dimension breakdown tables,
+        chart image(s); "no data" path. Pick a server-side PDF lib (research latest — QuestPDF /
+        PuppeteerSharp-from-HTML); document the choice in `.dev/decisions/`.
+
+- [ ] Task 5: `AnalyticsExportService` + `IExportArtifactStore` (AC: 1, 3, 5, 8, 11)
+  - [ ] Service calls 36-3/36-4/36-5 query services, dispatches to CSV/PDF, persists the artifact
+        via `IExportArtifactStore` (default: bytes on the row), emits audit events.
+  - [ ] Threshold estimator (sync vs async) driven by `AnalyticsExportOptions`.
+
+- [ ] Task 6: Async path — `QueuedTask` handler (AC: 6, 12)
+  - [ ] `AnalyticsExportTaskHandler : ITaskHandler` (`TypePrefix = "analytics.export"`):
+        deserialize spec, render, persist, emit COMPLETED/FAILED, idempotent on re-delivery.
+  - [ ] Register the handler in `ITaskHandlerRegistry` wiring.
+
+- [ ] Task 7: Signed download (AC: 7)
+  - [ ] `ExportDownloadSigner` (HMAC-SHA256 over `(tenantId, jobId, expiresAt)`, constant-time
+        verify); secret from config. Mint on status read; verify on download.
+
+- [ ] Task 8: Endpoints + wiring (AC: 1, 4, 6, 7, 9)
+  - [ ] `AnalyticsExportEndpoints` (POST exports, GET exports/{jobId}, GET …/download);
+        map under `/api/v1/orgs/{tenantId}/analytics/exports` with
+        `RequireTenantMembershipFilter` in `Program.cs`.
+
+- [ ] Task 9: Retention sweep (AC: 8)
+  - [ ] Best-effort `analytics_exports` purge past `ExpiresAt` (activity or handler-scheduled),
+        mirroring `PurgeStaleAnalyticsActivity` tolerance.
+
+- [ ] Task 10: Tests (AC: 10, 11, 12)
+  - [ ] CSV golden, PDF smoke, threshold, async end-to-end, tenant isolation, signed-URL
+        expiry/tamper, audit emission, empty-result, query-service-dependency structure test.
+
+## Technical Design
+
+### C# namespace / file structure
+
+```
+apps/tamma-elsa/src/
+  Tamma.Data/Entities/AnalyticsExport.cs                              # NEW — job + artifact row (tenant schema)
+  Tamma.Data/TenantDbContext.cs                                        # MODIFY — + DbSet<AnalyticsExport>
+  Tamma.Data/TammaModelConfiguration.cs                               # MODIFY — + ConfigureAnalyticsExports (tenant graph)
+  Tamma.Data/Migrations/Tenant/<ts>_AddAnalyticsExports.cs            # NEW (generated)
+
+  Tamma.Api/Endpoints/AnalyticsExportEndpoints.cs                     # NEW — POST exports + GET {jobId} + GET download
+  Tamma.Api/Services/Analytics/AnalyticsExportService.cs             # NEW — orchestrates render (reads 36-3/4/5 services)
+  Tamma.Api/Services/Analytics/IAnalyticsExportService.cs            # NEW
+  Tamma.Api/Services/Analytics/AnalyticsExportSpec.cs               # NEW — validated request spec
+  Tamma.Api/Services/Analytics/AnalyticsExportOptions.cs           # NEW — thresholds, max window, artifact TTL
+  Tamma.Api/Services/Analytics/AnalyticsExportEventTypes.cs        # NEW — DATA.EXPORT.* constants
+  Tamma.Api/Services/Analytics/Render/AnalyticsCsvWriter.cs        # NEW — raw-row CSV
+  Tamma.Api/Services/Analytics/Render/AnalyticsPdfReportRenderer.cs # NEW — branded PDF
+  Tamma.Api/Services/Analytics/IExportArtifactStore.cs            # NEW — bytes seam (default: row bytea)
+  Tamma.Api/Services/Analytics/DbExportArtifactStore.cs          # NEW — default impl
+  Tamma.Api/Services/Analytics/ExportDownloadSigner.cs          # NEW — HMAC signed URL
+  Tamma.Api/Services/TaskQueue/Handlers/AnalyticsExportTaskHandler.cs # NEW — ITaskHandler ("analytics.export")
+  Tamma.Api/Extensions/AnalyticsExportServiceCollectionExtensions.cs  # NEW — DI wiring
+  Tamma.Api/Program.cs                                                 # MODIFY — map endpoints + register services/handler
+
+apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/
+  AnalyticsCsvWriterTests.cs                  # NEW — golden column/row/format (per type)
+  AnalyticsPdfReportRendererTests.cs          # NEW — PDF smoke
+  AnalyticsExportServiceTests.cs              # NEW — sync render, threshold, audit emission, empty result
+  AnalyticsExportTaskHandlerTests.cs          # NEW — async path + idempotency
+  AnalyticsExportEndpointsTests.cs            # NEW — RBAC/tenant-isolation, sync 200 vs async 202, signed download
+  ExportDownloadSignerTests.cs                # NEW — sign/verify/expiry/tamper
+  AnalyticsExportMigrationTests.cs            # NEW — Postgres 17: per-tenant isolation of analytics_exports
+```
+
+### Reads the query services — does NOT re-aggregate (AC11)
+
+The service depends on the **Story 36-3 (usage), 36-4 (cost), 36-5 (agent performance) query
+service abstractions** — the same ones the tenant dashboard calls. It never touches `DomainEvent`
+or `ProviderDiagnostic` directly (that is the projection's job, Story 36-2). One source of truth
+means the CSV, the PDF, and the dashboard can never disagree:
+
+```csharp
+public sealed class AnalyticsExportService(
+    IUsageAnalyticsQueryService usageQuery,        // Story 36-3 (NEW dep)
+    ICostAnalyticsQueryService costQuery,          // Story 36-4 (NEW dep)
+    IAgentPerformanceQueryService agentQuery,      // Story 36-5 (NEW dep)
+    AnalyticsCsvWriter csv,
+    AnalyticsPdfReportRenderer pdf,
+    IExportArtifactStore artifacts,
+    IEventRepository events,
+    ITenantContext tenantContext,
+    AnalyticsExportOptions options,
+    TimeProvider clock,
+    ILogger<AnalyticsExportService> logger) : IAnalyticsExportService
+{
+    public async Task<ExportResult> RenderAsync(
+        Guid tenantId, Guid? userId, AnalyticsExportSpec spec, CancellationToken ct)
+    {
+        // 1. fetch via the right 36-3/4/5 query service for spec.Type
+        // 2. render CSV or PDF from that one result
+        // 3. persist artifact, emit DATA.EXPORT.COMPLETED
+    }
+}
+```
+
+> The 36-3/36-4/36-5 query services are **forward dependencies** — at authoring time only
+> Stories 36-1/36-2 exist. If a query service is not yet merged, this story is blocked on it; the
+> abstraction names above are the contract this story consumes (confirm the exact interface name +
+> DTO shape against the merged 36-3/4/5 before coding, and update the column-order golden test to
+> match the merged DTO).
+
+### Sync vs async threshold (AC1, AC6)
+
+```
+estimate rows for (type, from, to, groupBy)         # cheap COUNT/bucket estimate via query service
+  ≤ AnalyticsExportOptions.SyncRowThreshold (50_000)
+  AND (to - from) ≤ SyncRangeDays (92)
+    → render inline, return 200 file
+  else
+    → enqueue QueuedTask { Type="analytics.export", TenantId, Payload = {spec, userId} }
+    → emit DATA.EXPORT.REQUESTED, return 202 { jobId }
+```
+
+The async queue is the **tenant-scoped `QueuedTask`** (`TenantId` non-null) processed by the
+existing `TaskQueueProcessor` — *not* `PlatformQueuedTask` (which is CP/pre-routing only, for
+work with no tenant context yet). The `AnalyticsExportTaskHandler` runs on the processor thread,
+renders the same way the sync path does, writes the artifact, and emits COMPLETED/FAILED. On
+re-delivery of an already-completed job id the handler is a no-op (idempotent).
+
+### Signed download (AC7)
+
+```csharp
+// mint (on GET {jobId} when completed):  expiresAt = now + options.DownloadTtl (default 1h)
+sig = Base64Url(HMACSHA256(serverSecret, $"{tenantId:N}:{jobId:N}:{expiresAt:o}"))
+url = $"/api/v1/orgs/{tenantId}/analytics/exports/{jobId}/download?expires={expiresAt:o}&sig={sig}"
+
+// verify (on GET …/download):
+//   recompute sig, CryptographicOperations.FixedTimeEquals, reject 403 on mismatch
+//   reject 403 if expiresAt < now
+//   load artifact WHERE Id = jobId  (tenant TenantDbContext already scopes the schema)
+//   stream bytes with the artifact's content type + attachment disposition
+```
+
+`RequireTenantMembershipFilter` still guards the download route (membership is required even with
+a valid signature — the signature is a second factor binding the URL to the job, not a bypass).
+Tenant A's signed URL can never resolve tenant B's file: the route tenant must match the caller's
+membership AND the artifact lives in that tenant's schema.
+
+### `analytics_exports` entity (tenant schema)
+
+```csharp
+public class AnalyticsExport
+{
+    public Guid Id { get; set; }                 // == jobId
+    public string Type { get; set; } = null!;    // usage | cost | agents
+    public string Format { get; set; } = null!;  // csv | pdf
+    public string Spec { get; set; } = "{}";     // validated AnalyticsExportSpec JSON
+    public Guid? RequestedBy { get; set; }        // userId (single-user: sole user; SaaS: member)
+    public string Status { get; set; } = "queued"; // queued | running | completed | failed
+    public string? Error { get; set; }
+    public long RowCount { get; set; }
+    public long ByteSize { get; set; }
+    public byte[]? ContentBytes { get; set; }     // default artifact store (bytea); null when offloaded
+    public string ContentType { get; set; } = "text/csv";
+    public DateTime? ExpiresAt { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}
+```
+
+No `TenantId` column — tenancy is the per-tenant schema (Doc 01 §1.4 target shape, exactly as
+Story 36-1's fact tables; `ApplyTenantFilter` no-op). Index `(Status, ExpiresAt)` serves the
+retention sweep.
+
+### DCB audit events (AC5) — feed Epic 37
+
+```
+DATA.EXPORT.REQUESTED   on accept (sync render start OR async enqueue)
+DATA.EXPORT.COMPLETED   on rendered artifact (inline or async)
+DATA.EXPORT.FAILED      on render failure
+```
+
+Appended via `IEventRepository.AppendAsync(new DomainEvent { Type=…, TenantId=tenantId, Tags=… })`.
+Because `TenantId` is set, `EventRepository` routes the row into the **tenant's own**
+`domain_events` table (Story 28-1 PR D) — which is exactly where a tenant's audit trail belongs
+and what Epic 37 reads. Tags: `tenantId`, `userId`, `type`, `format`; completion data adds
+`jobId`, `rowCount`, `bytes`, `durationMs`. Emission is best-effort (wrapped, never throws to the
+caller) per the `PromptEventsService` / `AlertEndpoints.TryEmitAsync` precedent.
+
+### API shape
+
+| Endpoint | Method | Auth | Behaviour |
+|---|---|---|---|
+| `/api/v1/orgs/{tenantId}/analytics/exports` | POST | `MemberAccess` + membership filter | sync `200` file or async `202 {jobId}` |
+| `/api/v1/orgs/{tenantId}/analytics/exports/{jobId}` | GET | `MemberAccess` + membership filter | job status + signed download URL when completed |
+| `/api/v1/orgs/{tenantId}/analytics/exports/{jobId}/download` | GET | `MemberAccess` + membership filter + valid `sig` | streams the artifact |
+
+Mounted on the existing `var orgs = app.MapGroup("/api/v1/orgs").RequireAuthorization("MemberAccess")`
+group, each route `.AddEndpointFilter<RequireTenantMembershipFilter>()` — the identical wiring the
+Story 36-3 query endpoints (and the alerts tenant surface) use.
+
+### Per-mode + per-tenant handling
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns an export? | The sole user — it lives in their (only) tenant schema. | The tenant — its `t_<hex>` schema; `requestedBy` records the member. |
+| Who may request/download? | The user (authentication only). | Any tenant member (`MemberAccess` + membership) — an export is a read of data they can already see. |
+| Isolation plane | Search-path schema + connection string. | Same — physically separate schema per tenant; artifact + signed URL hard-scoped to the path tenant. |
+| Cross-tenant export/download | N/A (one tenant). | 403 on request; 403/404 on cross-tenant job/download lookup; tenant-A signature rejected on tenant-B. |
+| Audit event residency | Tenant's own `domain_events` (the user's). | Tenant's own `domain_events`. |
+
+Mode does not change the endpoint shape — the membership filter + per-tenant `TenantDbContext`
+resolve scope, per the CLAUDE.md prompt-store / Story 36-3 precedent.
+
+## Dependencies
+
+**Prerequisite (internal):**
+- **Story 36-1** — the per-tenant `analytics_usage_*` fact tables the query services read. (Drafted.)
+- **Story 36-2** — populates those tables; nothing to export until it runs. (Drafted.)
+- **Story 36-3 (usage query service)**, **Story 36-4 (cost query service)**, **Story 36-5 (agent
+  performance query service)** — the query abstractions + DTOs this story renders. **The CSV
+  column order and the PDF tables are defined by these DTOs.** *(NEW — not yet authored at the
+  time of writing; this story consumes their contracts and is blocked until they merge.)*
+- **Epic 28** — per-tenant schema, `ITenantDbContextFactory`, `EfTenantDbMigrator` (the
+  `analytics_exports` migration rides the Tenant graph); `QueuedTask` + `TaskQueueProcessor` +
+  `ITaskHandler` for the async path. (Merged.)
+- **Epic 4 (DCB `DomainEvent`)** + `IEventRepository.AppendAsync` (tenant-routed) for the audit
+  events. (In place.)
+
+**Blocks / feeds:**
+- **Epic 37 (audit & compliance)** — consumes the `DATA.EXPORT.*` events this story emits. *(NEW —
+  planned; the event-type contract above is the integration point.)*
+- **Story 36-9 (scheduled reports)** — reuses `AnalyticsExportService` + the renderers to produce
+  the recurring artifact; this story keeps the render path injectable so 36-9 calls it headless.
+
+**External:**
+- A server-side PDF library — **research the current best option before coding** (QuestPDF license
+  terms / PuppeteerSharp HTML-to-PDF); record the choice in `.dev/decisions/`. **No PDF or CSV
+  library is in the solution today — both are NEW package additions.**
+- PostgreSQL 17 (the `analytics_exports` table + per-tenant isolation).
+- EF Core 9 / Npgsql; Testcontainers + Docker for the isolation/migration suite (run via
+  `sg docker -c "dotnet test ..."`).
+
+## Testing Strategy
+
+1. **Unit — CSV golden (`AnalyticsCsvWriterTests`):** for each `type` (usage/cost/agents) assert
+   the exact header row (column names + order match the 36-3/4/5 DTO), one row per dimension-tuple
+   per bucket, raw unrounded measures, empty cell for a NULL dimension (never `"unknown"`), UTF-8
+   BOM present, header-only output on an empty result.
+
+2. **Unit — PDF smoke (`AnalyticsPdfReportRendererTests`):** rendered bytes start with `%PDF-`,
+   are non-trivial in size, and the report contains the summary + at least one breakdown table for
+   a populated spec; the empty-result path produces a valid "no data" PDF.
+
+3. **Unit — service (`AnalyticsExportServiceTests`):** calls the correct query service per `type`
+   (mocked 36-3/4/5); renders to the requested format; persists an artifact; emits
+   `DATA.EXPORT.REQUESTED` + `…COMPLETED` with the documented tags; the threshold estimator routes
+   small→inline / large→enqueue; a renderer throw flips the job `failed` + emits `…FAILED`.
+
+4. **Unit — async handler (`AnalyticsExportTaskHandlerTests`):** a `QueuedTask` payload renders +
+   persists + emits COMPLETED; a second delivery of a completed job id is a no-op (idempotent); a
+   render failure marks `failed` + emits FAILED (the processor's retry budget applies).
+
+5. **Unit — signer (`ExportDownloadSignerTests`):** sign→verify round-trips; a tampered `sig`,
+   a tampered `jobId`/`tenantId`, and an expired `expiresAt` each reject; constant-time compare.
+
+6. **Endpoint — RBAC / tenant isolation (`AnalyticsExportEndpointsTests`, WebApplicationFactory):**
+   unauthenticated → 401; non-member of `{tenantId}` → 403; member small range → 200 file with
+   `Content-Disposition: attachment`; member large range → 202 `{jobId}`; GET `{jobId}` →
+   status + signed URL; download with a valid sig → bytes; cross-tenant export request / job
+   lookup / download → 403/404; a signed URL minted for tenant A → 403 on tenant B.
+
+7. **Integration — per-tenant isolation (`AnalyticsExportMigrationTests`, Postgres 17
+   Testcontainer, per `SchemaPerTenantMigrationTests`):** two tenant schemas each carry
+   `analytics_exports`; an export row written to schema A is invisible through schema B's context;
+   `has-pending-model-changes -c TenantDbContext` is clean after the migration.
+
+**Mocks:** the 36-3/36-4/36-5 query services are mocked for render/threshold/audit unit tests (no
+raw-event aggregation in this story). InMemory provider for service/handler shape; a real
+Postgres 17 Testcontainer for the `analytics_exports` isolation + migration (EF InMemory does not
+honour search-path isolation — same rationale as `ConventionStoreMigrationTests`). No external
+provider / Stripe calls.
+
+## Estimated Effort
+
+3-4 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/AnalyticsExport.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs` | Modify (add DbSet) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (configure `AnalyticsExport` in tenant graph) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/<ts>_AddAnalyticsExports.cs` | Create (generated) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/<ts>_AddAnalyticsExports.Designer.cs` | Create (generated) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/TenantDbContextModelSnapshot.cs` | Modify (regenerated) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AnalyticsExportEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/AnalyticsExportService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/IAnalyticsExportService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/AnalyticsExportSpec.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/AnalyticsExportOptions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/AnalyticsExportEventTypes.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/Render/AnalyticsCsvWriter.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/Render/AnalyticsPdfReportRenderer.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/IExportArtifactStore.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/DbExportArtifactStore.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/ExportDownloadSigner.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/TaskQueue/Handlers/AnalyticsExportTaskHandler.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/AnalyticsExportServiceCollectionExtensions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map endpoints, register services + handler) |
+| `apps/tamma-elsa/src/Tamma.Api/Tamma.Api.csproj` | Modify (add CSV/PDF package refs) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/AnalyticsCsvWriterTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/AnalyticsPdfReportRendererTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/AnalyticsExportServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/AnalyticsExportTaskHandlerTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/AnalyticsExportEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/ExportDownloadSignerTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/AnalyticsExportMigrationTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, decisions (analytics, exports, tenancy,
+   task queue, PDF).
+3. Reviewed Story 36-1/36-2 (the fact tables + projection) and the **merged** Story 36-3/36-4/36-5
+   query services — **the CSV column order and the PDF tables are defined by their DTOs; pin them
+   before writing the golden test.**
+4. Reviewed the tenant-scope endpoint precedent (`AlertEndpoints` tenant surface +
+   `RequireTenantMembershipFilter`) and the `QueuedTask`/`TaskQueueProcessor`/`ITaskHandler`
+   async-job precedent.
+5. Confirmed the test runner: docker-bound suites run via `sg docker -c "dotnet test ..."`
+   (session docker group is stale; the build itself needs no wrapper).
+6. Planned the TDD cycle (CSV golden + signer + service tests red first, then the renderers +
+   endpoints).
+
+### Key Design Decisions
+
+- **Read the query services, never the raw stream (AC11).** The export must show the same numbers
+  the dashboard shows. Re-aggregating `DomainEvent`/`ProviderDiagnostic` here would fork the math
+  and silently diverge the CSV from the chart. The single source of truth is the 36-3/4/5 query
+  services; a structure test pins that dependency direction.
+- **Tenant-scoped `QueuedTask`, not `PlatformQueuedTask`.** The async export belongs to a resolved
+  tenant, so it rides the per-tenant `QueuedTask` queue (`TenantId` non-null) the
+  `TaskQueueProcessor` already fans out across tenants. `PlatformQueuedTask` is for pre-routing /
+  no-tenant-yet work (installation routing) — wrong queue for a tenant export.
+- **Whole-bucket render, idempotent job.** The async handler recomputes the entire export from the
+  query services each run, so a re-delivery (processor retry / visibility-timeout reap) of a
+  completed job is a safe no-op — no partial artifacts, no double-charged work.
+- **Signed URL = second factor, not a bypass.** Membership is still required on the download route;
+  the HMAC signature binds the URL to `(tenant, job, expiry)` so a leaked link can't be replayed
+  past expiry and can't cross tenants. Constant-time compare; secret from config (never logged).
+- **Artifact bytes behind a seam.** `IExportArtifactStore` defaults to `bytea` on the tenant row
+  (no new infra, no migration anxiety per CLAUDE.md), but the seam lets a future S3/blob backend
+  drop in without touching the endpoint or the signer. Keep artifacts small via the size bound +
+  the 7-day TTL retention sweep.
+- **Audit lands in the tenant's own event store.** Setting `DomainEvent.TenantId` routes the
+  `DATA.EXPORT.*` event into the tenant schema's `domain_events` via `EventRepository` — exactly
+  where a tenant's audit trail lives and what Epic 37 will read. Best-effort emission never blocks
+  the export.
+- **PDF library is a real decision.** No PDF lib exists in the solution; research current options
+  (QuestPDF Community-license eligibility for this project vs PuppeteerSharp HTML-to-PDF reusing
+  dashboard chart markup) and record it in `.dev/decisions/` before adding the package.
+
+### Export boundary
+
+This story creates **no** analytics aggregation logic (it reads 36-3/4/5), **no** schema change to
+the Story 36-1 fact tables (only the additive `analytics_exports` table), **no** scheduled/recurring
+delivery (36-9), and **no** owner business-analytics export. Any PR that adds aggregation or alters
+the fact-table schema under cover of this story is out of scope — keep the diff to the export
+service, renderers, artifact store, signer, async handler, endpoints, the `analytics_exports`
+entity/migration, and tests.
+
+## Logging Requirements
+
+- **INFO**: export requested (`tenantId`, `userId`, type, format, range, sync|async); export
+  completed (`jobId`, rowCount, bytes, durationMs); async job claimed/completed; retention sweep
+  completed (rowsDeleted).
+- **DEBUG**: threshold estimate (estimatedRows, decision); CSV/PDF render start; signed-URL minted
+  (`jobId`, expiresAt — never the secret); query-service call (`type`, range).
+- **WARN**: `DATA.EXPORT.*` audit emission failed (best-effort, swallowed); download rejected
+  (expired/tampered signature) — `jobId`, reason (never the signature value); large export over the
+  async threshold.
+- **ERROR**: export render failed (`jobId`, errorType — sanitized message, no raw stack to client);
+  artifact persist/read failure; async handler exhausted the retry budget.
+- **Structured context**: include `{ tenantId, jobId, type, format, rowCount, bytes, durationMs }`
+  where applicable.
+- **Credential safety**: NEVER log the download-signing secret, the signature value, tenant
+  connection strings, or search-path schema secrets; sanitized render-failure messages only (no
+  raw provider/connection detail) in `DATA.EXPORT.FAILED` data.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-36/story-36-9/36-9-scheduled-reports-and-delivery.md
+++ b/docs/stories/epic-36/story-36-9/36-9-scheduled-reports-and-delivery.md
@@ -1,0 +1,366 @@
+# Story 36-9: Scheduled Reports & Delivery
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **tenant owner/admin** (or, in single-user mode, the sole user),
+I want to schedule recurring analytics reports (daily/weekly/monthly) that Tamma generates
+server-side and emails to the recipients I choose,
+So that my team receives usage / cost / agent-performance summaries automatically without anyone
+having to open the dashboard and run an export by hand — plus an optional platform-owner business
+digest (MRR/churn) delivered to operators only.
+
+## Priority
+
+P2 — automation convenience layered on the analytics product (Epic 36). Depends on the export
+pipeline (36-8) and the email/notification infrastructure shipped with Story 5.6 / Epic 18.
+
+## Architecture Context
+
+> **Target stack:** C# / .NET 9 in `apps/tamma-elsa`. **The TypeScript `packages/api` tree is
+> DELETED — do NOT add anything there.** All endpoints, services, entities, Elsa workflows, and
+> tests for this story live under `apps/tamma-elsa/`.
+
+This story is a thin orchestration layer over machinery that already exists:
+
+| Capability | Where it already lives (verified 2026-06-17) | This story's use |
+|---|---|---|
+| **Recurring scheduler precedent** | `Tamma.ElsaServer/Workflows/HourlyAnalyticsRollupScheduler.cs` — `BackgroundService` that wakes on a poll interval, checks a cron offset, takes a Postgres `pg_try_advisory_lock` leader lock, and dispatches an Elsa workflow. | Copy the shape for `ScheduledReportsScheduler` (multi-pod safe, failure-isolated, `Enabled` gate for tests). |
+| **Recurring Elsa workflow precedent** | `Tamma.ElsaServer/Workflows/HourlyAnalyticsRollupWorkflow.cs` (`WorkflowBase`, fan-out per tenant, per-item failure isolation). | Model `ScheduledReportsWorkflow` on it: select due reports, generate each, enqueue mail, emit terminal event. |
+| **Export generation (36-8)** | `Tamma.Api/Services/Analytics/AnalyticsExportService.cs` — **NEW in Story 36-8** (CSV/PDF off the dimensional store). | The workflow asks this service to render each due report's artifact. **Hard dependency on 36-8.** |
+| **Per-tenant email outbox** | `Tamma.Data/Entities/EmailOutboxMessage.cs` + `IEmailOutboxRepository.EnqueueAsync` (`Tamma.Data/Repositories/IEmailOutboxRepository.cs`). | Enqueue tenant report deliveries here. |
+| **Platform email outbox** | `Tamma.Data/Entities/PlatformEmailOutboxMessage.cs` + `IPlatformEmailOutboxRepository`. | Enqueue the optional platform-owner business digest here (recipients live outside any tenant). |
+| **Outbox delivery (the actual transport)** | `Tamma.Api/Services/Email/OutboxSmtpSender.cs` — a hosted service that **already drains BOTH the per-tenant `email_outbox` AND the CP `platform_email_outbox`** with retry/backoff and emits `EMAIL.SENT.SUCCESS`. | **Reuse as-is.** Once a row is enqueued, delivery (including retry) is free — this story writes NO new transport. |
+| **Email templates** | `Tamma.Api/Services/Email/EmailTemplates.cs`. | Add a `scheduled-report` template (subject + html/text body wrapping the export). |
+| **DCB events** | `IEventRepository.AppendAsync(DomainEvent)` (`Tamma.Data/Repositories/IEventRepository.cs`). | Emit `ANALYTICS.REPORT.GENERATED/SENT/FAILED`. |
+| **Per-mode XOR / dedup precedent** | `prompt_overrides` — `ck_prompt_overrides_principal_xor` CHECK + `NULLS NOT DISTINCT` unique (`Tamma.Data/TammaModelConfiguration.cs` ~714). | Mirror exactly for `scheduled_reports` (user_id XOR tenant_id) and the run-idempotency unique. |
+| **Tenant RBAC (owner/admin gate; member → 403)** | `ConventionManage` policy on `ConventionStoreEndpoints.cs` (~248); tenant-scoped route shape `/api/conventions`. | Reuse the same policy / scope-resolution for the report-CRUD endpoints. |
+| **Async/queued task fallback** | `Tamma.Data/Entities/QueuedTask.cs` + `Tamma.Api/Services/TaskQueue/TaskQueueProcessor.cs` (Epic 28). | NOT required for v1 — the scheduler runs generation inline on its own background thread (cadence is hourly-coarse). The queue is the escape hatch if a single report ever needs to be re-run on demand (see Dev Notes). |
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns a **report schedule**? | The sole user — `user_id`-keyed, `tenant_id` NULL (same XOR as `prompt_overrides`). | The tenant — `tenant_id`-keyed, `user_id` NULL. Owned by `tenant_owner`/`tenant_admin`; `member` gets read-only. |
+| Who can create/edit/delete? | The user (no role check). | `tenant_owner`/`tenant_admin` only — `member` → **403** (mirrors prompt-store PUT/DELETE RBAC). |
+| Where do generated reports deliver? | Per-tenant `email_outbox` keyed to the sole user's tenant context. | Per-tenant `email_outbox` (`TenantId` set) — drained per-tenant by `OutboxSmtpSender`. |
+| Who owns the **platform business digest**? | N/A — single-user has no platform-owner separation; the digest is a SaaS/operator feature. Skip in single-user mode. | Platform owner ONLY (`OwnerAccess`). Delivered via the **platform** outbox; aggregates only — **never** per-tenant detail. |
+| Mode source | `ITammaModeProvider` (process-stable). | same |
+
+## Acceptance Criteria
+
+1. A `ScheduledReport` entity persists, per mode (`user_id` XOR `tenant_id`, enforced by a
+   `ck_scheduled_reports_principal_xor` CHECK mirroring `prompt_overrides`): `cadence`
+   (`daily|weekly|monthly`), `report_type` (`usage|cost|agents`), `format` (`csv|pdf`), `recipients`
+   (text[] of RFC-5322 addresses), `dimensions` / `group_by`, `enabled`, `time_zone`,
+   `last_run_at`, plus standard timestamps. CHECK constraints pin `cadence`/`report_type`/`format`
+   to closed enums.
+2. CRUD is exposed at `POST/GET/PATCH/DELETE /api/v1/orgs/{tenantId}/analytics/reports`
+   (+ `GET .../reports/{id}`); the route shape is identical between modes and the auth middleware
+   decides which principal key (`user_id` / `tenant_id`) the row carries.
+3. **RBAC**: create / update / delete are restricted to `tenant_owner` / `tenant_admin` in SaaS
+   mode (a `member` caller gets **403** before the handler body runs, using the same policy gate as
+   `ConventionStoreEndpoints` upsert/delete); in single-user mode there is no role check (sole user
+   owns everything). `GET` is allowed for any tenant member / the sole user.
+4. All report endpoints are **hard tenant-scoped** (same guard as 36-3): a caller may only read or
+   mutate schedules for a tenant they belong to; a cross-tenant access attempt returns **403/404**
+   (never the other tenant's rows).
+5. A `ScheduledReportsScheduler` (`BackgroundService`, modelled on `HourlyAnalyticsRollupScheduler`)
+   wakes on a configurable poll interval, is multi-pod safe via a Postgres advisory leader lock, has
+   an `Enabled` gate (default true; tests/non-Elsa hosts set false), and dispatches the
+   `ScheduledReportsWorkflow` once per scheduling tick.
+6. A `ScheduledReportsWorkflow` (Elsa `WorkflowBase`) selects all reports **due** for the current
+   tick (cadence + `time_zone` + `last_run_at` determine due-ness), generates each due report's
+   artifact via `AnalyticsExportService` (36-8), and enqueues delivery through the per-tenant
+   `IEmailOutboxRepository` (`EmailOutboxMessage` with the report artifact as attachment/body).
+7. Report runs are **idempotent per `(report_id, period_key)`**: a scheduler restart, duplicate
+   dispatch, or workflow replay must NOT generate or send a report twice for the same period. A
+   `scheduled_report_runs` ledger row with a `NULLS NOT DISTINCT` unique on `(report_id, period_key)`
+   is the dedup gate; a replay test covers this.
+8. Each run emits DCB events `ANALYTICS.REPORT.GENERATED`, `ANALYTICS.REPORT.SENT`, and
+   `ANALYTICS.REPORT.FAILED`, tagged with `tenantId` (or the single-user principal), `reportId`,
+   `reportType`, `format`, and `periodKey`, via `IEventRepository.AppendAsync` for audit.
+9. Failure isolation: a single report's generation/enqueue failure emits `ANALYTICS.REPORT.FAILED`,
+   marks that run failed, and **does not block** other tenants' / other reports' runs in the same
+   tick (per-item try/catch, mirroring `FanOutTenantRollupsActivity`). The run is retried on the
+   next due tick (no tight retry loop).
+10. **Email delivery is reused, not rebuilt**: the workflow only enqueues rows on the existing
+    outbox; `OutboxSmtpSender` performs the actual send, retry/backoff, and `EMAIL.SENT.SUCCESS`
+    emission. A new `scheduled-report` email template renders subject + body wrapping the generated
+    export.
+11. An **optional platform-owner business digest** (MRR / churn from Story 36-10) is delivered to
+    platform-owner recipients via the **platform** outbox (`IPlatformEmailOutboxRepository`),
+    contains **only aggregates** (never per-tenant detail), and is gated to platform owner
+    (`OwnerAccess`). It is skipped entirely in single-user mode and when 36-10 is unavailable.
+12. Recipient addresses are validated (RFC-5322) on write; an empty recipient list is rejected; the
+    recipient/subject/body of a queued report email are **never** written to logs or DCB event data
+    (the outbox already enforces this — preserve it).
+13. Unit + integration tests cover: schedule CRUD RBAC per mode (owner/admin/member/cross-tenant),
+    cadence due-selection (daily/weekly/monthly with `time_zone`), idempotent generation
+    (replay/restart → one run), email-outbox enqueue (correct table per scope), failure isolation
+    (one report failing leaves others delivered), and audit-event emission.
+
+## Technical Design
+
+### Data model
+
+```
+ScheduledReport (per-mode key: user_id XOR tenant_id, mirroring prompt_overrides)
+  id            uuid pk
+  user_id       uuid   -- set in single-user mode; NULL in SaaS
+  tenant_id     uuid   -- set in SaaS mode;        NULL in single-user
+  cadence       text   -- 'daily' | 'weekly' | 'monthly'
+  report_type   text   -- 'usage' | 'cost' | 'agents'
+  format        text   -- 'csv' | 'pdf'
+  recipients    text[] -- RFC-5322 addresses (>= 1)
+  group_by      text   -- dimension key passed to AnalyticsExportService
+  time_zone     text   -- IANA tz; default 'UTC' (drives "midnight of the day/week/month")
+  enabled       boolean default true
+  last_run_at   timestamptz null
+  created_at    timestamptz default now()
+  updated_at    timestamptz default now()
+  -- CK_scheduled_reports_principal_xor : exactly one of user_id / tenant_id
+  -- CK_scheduled_reports_cadence / _report_type / _format : closed enums
+  -- UNIQUE NULLS NOT DISTINCT (user_id, tenant_id, report_type, cadence, format, group_by)
+
+ScheduledReportRun (idempotency ledger + audit)
+  id            uuid pk
+  report_id     uuid fk -> scheduled_reports
+  period_key    text     -- canonical bucket id, e.g. '2026-06-16' (daily),
+                         --   '2026-W24' (weekly), '2026-06' (monthly)
+  status        text     -- 'generated' | 'sent' | 'failed'
+  outbox_msg_id uuid null -- the EmailOutboxMessage / PlatformEmailOutboxMessage id
+  error         text null
+  created_at    timestamptz default now()
+  -- UNIQUE NULLS NOT DISTINCT (report_id, period_key)  <- the dedup gate (AC7)
+```
+
+Both DbSets + EF model config go in `ControlPlaneDbContext` / `TammaModelConfiguration.cs` only
+(the single source of truth). Additive EF migration under
+`src/Tamma.Data/Migrations/ControlPlane/` (normal `dotnet ef migrations add` — new tables, not a
+baseline CHECK edit). Verify `has-pending-model-changes` reports none after generating it.
+
+### Components
+
+```
+src/Tamma.Data/Entities/ScheduledReport.cs                              (new)
+src/Tamma.Data/Entities/ScheduledReportRun.cs                           (new)
+src/Tamma.Data/Repositories/IScheduledReportRepository.cs              (new)
+src/Tamma.Data/Repositories/ScheduledReportRepository.cs              (new — CRUD + due-select + run-ledger upsert)
+src/Tamma.Api/Endpoints/ScheduledReportEndpoints.cs                    (new — CRUD, per-mode RBAC)
+src/Tamma.Api/Services/Analytics/ScheduledReportEventTypes.cs         (new — ANALYTICS.REPORT.*)
+src/Tamma.Api/Services/Analytics/ScheduledReportCadence.cs            (new — due-selection + period_key math, PURE/testable)
+src/Tamma.Activities/Analytics/GenerateScheduledReportActivity.cs     (new — render via AnalyticsExportService + enqueue outbox)
+src/Tamma.ElsaServer/Workflows/ScheduledReportsWorkflow.cs            (new — select due, fan out, terminal event)
+src/Tamma.ElsaServer/Workflows/ScheduledReportsScheduler.cs           (new — BackgroundService, advisory leader lock)
+```
+
+### Due-selection + idempotency (the load-bearing logic)
+
+`ScheduledReportCadence` is a pure static helper (no DB, fully unit-testable — `ConventionSeedSpecs`
+style): given `(cadence, time_zone, last_run_at, now)` it returns `(isDue, periodKey)`.
+
+- **daily**: due when `now` (in `time_zone`) has crossed a new calendar day vs `last_run_at`;
+  `periodKey = "yyyy-MM-dd"` of the **completed** day.
+- **weekly**: due on the configured week boundary (ISO week, Monday start); `periodKey = "yyyy-Www"`.
+- **monthly**: due on the 1st; `periodKey = "yyyy-MM"`.
+
+The `(report_id, period_key)` unique on `scheduled_report_runs` is the hard gate. The workflow does
+**insert-if-absent**: a successful insert means "I own this period → generate + enqueue"; a unique
+violation (concurrent pod / replay) means "already handled → skip silently." This makes a scheduler
+restart or Elsa replay a no-op, satisfying AC7 — exactly the dedup posture
+`HourlyAnalyticsRollupWorkflow` relies on via its UPSERT.
+
+### Workflow shape (mirrors `HourlyAnalyticsRollupWorkflow`)
+
+1. `SelectDueReports` — query all `enabled` schedules across the appropriate scope; filter via
+   `ScheduledReportCadence.IsDue`.
+2. Fan out → per report: `GenerateScheduledReportActivity`
+   - `INSERT scheduled_report_runs (report_id, period_key, 'generated')` — on unique violation,
+     skip (idempotent).
+   - call `AnalyticsExportService.Generate(type, format, period-range, group_by, tenantId)` (36-8).
+   - emit `ANALYTICS.REPORT.GENERATED`.
+   - build an `EmailOutboxMessage` (template `scheduled-report`, the export as body/attachment) and
+     `IEmailOutboxRepository.EnqueueAsync` → store `outbox_msg_id`, flip run → `sent`, emit
+     `ANALYTICS.REPORT.SENT`.
+   - **per-report try/catch**: on failure emit `ANALYTICS.REPORT.FAILED`, mark run `failed`,
+     continue the loop (AC9).
+3. Optional `GeneratePlatformDigest` step (SaaS only, 36-10 available) — same shape but uses
+   `IPlatformAnalyticsService` (36-10) + `IPlatformEmailOutboxRepository`; aggregates only.
+4. `EmitReportsTickCompleted` — terminal `ANALYTICS.REPORT.TICK_COMPLETED` with success/failure
+   counts for the ops view.
+
+### Scheduler (mirrors `HourlyAnalyticsRollupScheduler`)
+
+- `BackgroundService` with `ScheduledReportsSchedulerOptions { Enabled (default true), PollInterval
+  (default 5 min) }`.
+- Postgres advisory leader lock keyed on the current scheduling tick so an N-pod deploy dispatches
+  once (reuse the `IRollupSchedulerLeaderLock` / `PostgresAdvisoryLeaderLock` pattern — extract it
+  to a shared helper if cheap, otherwise mirror it).
+- Dispatch failure → WARN + continue (next tick is the recovery path).
+- An `internal InvokeTickForTestsAsync` entry point so unit tests drive one tick without the loop.
+
+### Endpoints (per-mode RBAC, mirrors `ConventionStoreEndpoints`)
+
+```
+GET    /api/v1/orgs/{tenantId}/analytics/reports          (member / sole user — list)
+GET    /api/v1/orgs/{tenantId}/analytics/reports/{id}     (member / sole user)
+POST   /api/v1/orgs/{tenantId}/analytics/reports          (tenant_owner|tenant_admin / sole user)
+PATCH  /api/v1/orgs/{tenantId}/analytics/reports/{id}     (tenant_owner|tenant_admin / sole user)
+DELETE /api/v1/orgs/{tenantId}/analytics/reports/{id}     (tenant_owner|tenant_admin / sole user)
+```
+
+Mutating routes carry the same authorization policy used by `ConventionStoreEndpoints` upsert/delete
+(tenant_owner/tenant_admin; member → 403). Scope is resolved from `ITenantContext` + `ITammaModeProvider`
+exactly as the prompt/convention stores do.
+
+## Dependencies
+
+- **Prerequisite (hard)**: **Story 36-8** (`AnalyticsExportService` + `AnalyticsExportEndpoints`) —
+  this story's workflow calls 36-8's export service to render each report. Without 36-8 there is
+  nothing to schedule.
+- **Prerequisite**: **Story 5.6 notification infrastructure** + **Epic 18** (email outbox +
+  `OutboxSmtpSender` + RBAC roles `tenant_owner`/`tenant_admin`/`member`). The outbox entities,
+  repositories, the sender hosted service, and the role gates are all reused unchanged.
+- **Prerequisite (analytics scope guard)**: **Story 36-3/36-4/36-5** (the per-tenant analytics query
+  services + the hard tenant-scope guard reused by the report endpoints).
+- **Optional**: **Story 36-10** (platform business analytics — MRR/churn) for the platform-owner
+  digest (AC11). The digest step is feature-flagged off when 36-10 is absent.
+- **Related**: Epic 27 (the per-mode override ownership + XOR CHECK + `NULLS NOT DISTINCT` pattern
+  this story copies); Story 28-10 (`HourlyAnalyticsRollup*` — the recurring scheduler/workflow
+  precedent).
+
+## Testing Strategy
+
+C# tests live under `apps/tamma-elsa/tests/` (xUnit). Docker-bound suites run via
+`sg docker -c "dotnet test ..."`.
+
+1. **Cadence unit tests** (`Tamma.Api.Tests/Analytics/ScheduledReportCadenceTests.cs`) — pure
+   due-selection + period_key for daily/weekly/monthly across `time_zone` boundaries (DST edge,
+   month rollover, ISO-week start); no DB.
+2. **Repository tests** — CRUD; XOR CHECK rejects both-null/both-set; `NULLS NOT DISTINCT` unique
+   blocks a duplicate schedule and a duplicate `(report_id, period_key)` run; due-select returns
+   only enabled + due rows.
+3. **Endpoint RBAC tests** (`ScheduledReportEndpointsTests.cs`) — matrix: owner/admin can CUD,
+   member → 403 on CUD but 200 on GET, cross-tenant → 403/404, single-user (sole user) full access,
+   recipient validation (empty list → 400, malformed address → 400).
+4. **Workflow / activity tests** (`Tamma.Activities.Tests/Analytics/`) — a due report generates via
+   a mocked `AnalyticsExportService`, enqueues exactly one `EmailOutboxMessage`, emits
+   GENERATED+SENT; a generation failure emits FAILED + leaves a sibling report delivered (isolation);
+   platform digest uses the platform outbox and contains aggregates only.
+5. **Idempotency / replay test** (AC7) — dispatch the same tick twice (and re-run a workflow
+   instance): exactly one run row, one enqueue, one GENERATED+SENT pair per `(report_id, period_key)`.
+6. **Scheduler test** — `InvokeTickForTestsAsync` dispatches once; `Enabled=false` skips; leader-lock
+   contention (second pod) does not double-dispatch.
+
+## Estimated Effort
+
+4-5 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/ScheduledReport.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/ScheduledReportRun.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/IScheduledReportRepository.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/ScheduledReportRepository.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (add DbSets) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (entity config: XOR + enum CHECKs + unique) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/*_ScheduledReports.cs` | Create (additive migration) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/ScheduledReportEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/ScheduledReportCadence.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/ScheduledReportEventTypes.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Email/EmailTemplates.cs` | Modify (add `scheduled-report` template) |
+| `apps/tamma-elsa/src/Tamma.Activities/Analytics/GenerateScheduledReportActivity.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ScheduledReportsWorkflow.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ScheduledReportsScheduler.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map endpoints; register repo) |
+| `apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs` | Modify (register workflow + scheduler) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/ScheduledReportCadenceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/ScheduledReportRepositoryTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/ScheduledReportEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/GenerateScheduledReportActivityTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/ScheduledReportsWorkflowTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, decisions (esp. Story 28-10 scheduler and
+   Epic 27 per-mode ownership notes)
+3. Read the verified precedents: `HourlyAnalyticsRollupScheduler.cs`, `HourlyAnalyticsRollupWorkflow.cs`,
+   `OutboxSmtpSender.cs`, `ConventionStoreEndpoints.cs`, and the `prompt_overrides` block in
+   `TammaModelConfiguration.cs`
+4. Confirmed Story **36-8** has landed (`AnalyticsExportService` exists) — it is the hard prerequisite
+5. Planned TDD (Red-Green-Refactor); write the cadence + idempotency tests first — they are the risky
+   logic
+
+### Delivery is reused — do NOT write a transport
+
+The single most important design constraint: this story **enqueues** outbox rows and stops. The
+existing `OutboxSmtpSender` hosted service already drains both the per-tenant `email_outbox` and the
+CP `platform_email_outbox`, with retry/backoff and `EMAIL.SENT.SUCCESS` emission. AC10/AC11 forbid a
+new sender. The `ANALYTICS.REPORT.SENT` event means "handed to the outbox," not "SMTP accepted";
+final transport status lives in the `EMAIL.SENT.SUCCESS` / outbox `failed` row keyed by the
+`outbox_msg_id` we store on the run ledger.
+
+### Why a `BackgroundService` scheduler, not Elsa cron
+
+Same reasoning as Story 28-10: a lightweight `BackgroundService` poll + advisory-lock leader election
+is the established pattern in this repo and avoids pulling extra Elsa scheduling packages. Match
+`HourlyAnalyticsRollupScheduler` so multi-pod safety and the `Enabled` test gate come for free.
+
+### Idempotency is the spec's hard requirement (AC7)
+
+Treat `(report_id, period_key)` as the dedup key end-to-end. Insert-if-absent on
+`scheduled_report_runs` is the gate; everything downstream (generate, enqueue) only happens on a
+fresh insert. A replay, a duplicate dispatch from two pods, or a process restart mid-tick must all
+collapse to a single send. The replay test is non-negotiable.
+
+### Platform digest is optional and aggregates-only (AC11)
+
+The platform-owner business digest is SaaS-only, gated to `OwnerAccess`, sourced from 36-10's
+`IPlatformAnalyticsService`, delivered via the **platform** outbox, and must never leak per-tenant
+rows — only platform aggregates (MRR/churn totals). Feature-flag it off when 36-10 is absent so this
+story can ship independently of 36-10.
+
+### Migration discipline
+
+The CP migration chain is collapsed to a single `InitialControlPlane` baseline (Phase 0). These are
+**additive** tables, so a normal `dotnet ef migrations add` is correct — but still run
+`dotnet ef migrations has-pending-model-changes` and confirm it reports none, and put all entity
+config in `TammaModelConfiguration.cs` (the single source), not inline in the DbContext.
+
+## Logging Requirements
+
+- **INFO**: scheduler tick dispatched (tick id, leader=true), report generated (reportId, type,
+  format, periodKey), report enqueued (reportId, periodKey, outboxMsgId — **id only**), tick
+  completed (due count, sent, failed), platform digest enqueued.
+- **DEBUG**: due-selection result per schedule (reportId, cadence, isDue, periodKey), workflow step
+  entered.
+- **WARN**: report run failed (reportId, periodKey, error class), scheduler dispatch failed (next
+  tick is recovery), not-leader skip (another pod owns this tick), 36-10 unavailable → digest
+  skipped.
+- **ERROR**: repository write failure on the run ledger, export-service unrecoverable error.
+- **Structured context**: include `{ tenantId, reportId, reportType, format, periodKey, outboxMsgId,
+  dueCount }` where applicable.
+- **Credential / PII safety**: NEVER log recipient addresses, email subjects, or report bodies — the
+  outbox entities are CodeQL-tainted; reference only the `outbox_msg_id` (txn id). DCB event `data`
+  carries metadata (reportId/type/format/periodKey/counts) only, never recipients or body.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-37/README.md
+++ b/docs/stories/epic-37/README.md
@@ -1,0 +1,265 @@
+# Epic 37: Audit, Compliance & Data Governance
+
+## Overview
+
+Tamma already captures **raw operational events** in the Epic 4 DCB single event stream (`domain_events` per-tenant + `platform_events` control-plane) and has point audit emitters for secrets (Epic 29) and impersonation (28-R2). Epic 37 turns that substrate into a **compliance-grade product layer**.
+
+This epic builds **ON TOP OF** the Epic 4 DCB event store — it does **NOT** rebuild, duplicate, or replace it. Raw immutable `DomainEvent` / `PlatformEvent` rows stay the authoritative source of truth and audit substrate. Epic 37 adds:
+
+- A **canonical taxonomy** of compliance-relevant sensitive actions (config/persona, RBAC, secret access, BYOK provider-key changes, billing/plan changes, data exports, logins, impersonation, tenant lifecycle, agent actions).
+- A **curated, queryable audit-record read-model** (`audit_records`) materialized from the raw stream via a cursor-tracked projection, with a back-reference (`source_event_id` + `source_sequence_number`) to the originating event.
+- A **tamper-evident hash chain** over the curated records, with signed periodic checkpoints, so any insertion, deletion, reordering, or in-place mutation — even by an attacker with direct DB write access — is detected and localized.
+- Rich **query/search/filter** and **signed export** with an integrity manifest.
+- **Retention policies, legal hold, and the GDPR rights** (DSAR access export, right-to-erasure via crypto-shredding) plus **consent/ROPA logging**.
+- **SOC2-aligned control mapping and an evidence pack**, and **admin/tenant audit dashboards**.
+
+The epic mirrors the Epic 27 **per-mode ownership** pattern (single-user `user_id` vs SaaS `tenant_id`, exactly-one XOR), the Epic 28 **schema-per-tenant** isolation (per-tenant audit lives in the tenant schema via `TenantDbContext`; platform audit lives in the control plane via `ControlPlaneDbContext` / `PlatformEvent`), and the Epic 29 **secret cabinet** crypto (signing keys and crypto-shred via `ISecretStore` / `TenantSecretProtector`). Target codebase is the C# app `apps/tamma-elsa/`. **`packages/api` is DELETED — it is never a target.**
+
+### Supersedes
+
+Epic 37 supersedes and re-targets the stale, TypeScript-era audit work absorbed from earlier epics:
+
+- **Epic 23 Story 23-4 (configuration-audit)** — drafted spec-only. Its intent (audit of config/persona/convention/agent-config changes) is absorbed into the `CONFIG`/`PERSONA` categories of the Story 37-1 catalog and materialized into the curated `audit_records` projection. The standalone 23-4 story is retired.
+- **Epic 23 Story 23-10 (security-access-audit)** — drafted spec-only. Its intent (auth/login, RBAC, secret-access, impersonation auditing) is absorbed into the `AUTH`/`RBAC`/`SECRET`/`IMPERSONATION` categories of the Story 37-1 catalog and the Story 37-10 emission-coverage work. The standalone 23-10 story is retired.
+- **The thin `GET /orgs/{id}/audit` endpoint (18-7)** — superseded by the Story 37-3 query/search/filter API and the Story 37-12 dashboard, which read the curated, tamper-evident `audit_records` read-model rather than scanning the raw stream. The 18-7 endpoint shape is re-pointed at the new read-model.
+
+## Stories
+
+| Story | Title | Priority | Status | Est. Effort |
+|-------|-------|----------|--------|-------------|
+| 37-1 | Sensitive-Action Audit Taxonomy & Curated Audit-Record Projection | P0 | drafted | 5-6 days |
+| 37-2 | Tamper-Evident Hash-Chain over Audit Records | P0 | drafted | 5-6 days |
+| 37-3 | Audit Query, Search & Filter API | P0 | drafted | 4-5 days |
+| 37-4 | Signed Audit Export (JSON/CSV) with Integrity Manifest | P1 | drafted | 3-4 days |
+| 37-5 | Audit Retention Policies & Tamper-Aware Pruning | P1 | drafted | 4-5 days |
+| 37-6 | Legal Hold | P1 | drafted | 3-4 days |
+| 37-7 | GDPR DSAR — Data Subject Access Export | P1 | drafted | 4-5 days |
+| 37-8 | GDPR Right-to-Erasure with Crypto-Shredding & Audit Preservation | P1 | drafted | 5-6 days |
+| 37-9 | Consent & Data-Processing Logging | P2 | drafted | 3-4 days |
+| 37-10 | Sensitive-Action Audit Emission Coverage (BYOK, Billing/Plan, Auth/Login, Agent Actions) | P0 | drafted | 4-5 days |
+| 37-11 | SOC2-Aligned Control Mapping & Evidence Pack | P2 | drafted | 3-4 days |
+| 37-12 | Admin & Tenant Audit Dashboard UI | P1 | drafted | 4-5 days |
+
+## Architecture
+
+```
++-----------------------------------------------------------------------------+
+|              EPIC 37: AUDIT, COMPLIANCE & DATA GOVERNANCE                    |
+|        (product layer ON TOP OF Epic 4 DCB — never rebuilds it)             |
++-----------------------------------------------------------------------------+
+|                                                                             |
+|  SUBSTRATE (Epic 4 — read-only source of truth, immutable):                |
+|  +-----------------------------+   +-------------------------------------+  |
+|  | domain_events (tenant)      |   | platform_events (control-plane)     |  |
+|  | TenantDbContext, BIGSERIAL  |   | ControlPlaneDbContext, BIGSERIAL    |  |
+|  +--------------+--------------+   +-----------------+-------------------+  |
+|                 |  (cursor read by SequenceNumber)   |                     |
+|  +-- LAYER 1: Curated Projection (37-1) -------------------------------+   |
+|  |  AuditProjector (cursor-tracked BackgroundService, redacting)       |   |
+|  |  ──► audit_records   [tenant schema]  |  audit_records [control-plane]|   |
+|  |       per-mode XOR (tenant_id / user_id) · source_event_id (unique) |   |
+|  +-------------------------------+------------------------------------+   |
+|                                  |                                          |
+|  +-- LAYER 2: Integrity (37-2) -----------------------------------------+  |
+|  |  hash-chain (record_hash ‖ prev_hash, per-scope chain_sequence)      |  |
+|  |  signed checkpoints (Epic 29 cabinet key) · AuditChainVerifier       |  |
+|  |  per-tenant chains + one platform chain · tamper → critical alert    |  |
+|  +-------------------------------+-------------------------------------+   |
+|                                  |                                          |
+|  +-- LAYER 3: Access (37-3, 37-4) -------------------------------------+   |
+|  |  Query/Search/Filter API        |  Signed Export (JSON/CSV)          |   |
+|  |  (actor/target/category/range)  |  + integrity manifest              |   |
+|  +-------------------------------+-------------------------------------+   |
+|                                  |                                          |
+|  +-- LAYER 4: Governance (37-5, 37-6, 37-7, 37-8, 37-9) ---------------+   |
+|  |  Retention   | Legal Hold | DSAR    | Right-to-Erasure | Consent /   |   |
+|  |  (tamper-     | (blocks    | export  | (crypto-shred +  | ROPA log    |   |
+|  |   aware prune)|  prune+    | (read)  |  chain re-anchor)|             |   |
+|  |              |  erasure)  |        |                  |             |   |
+|  +-------------------------------+-------------------------------------+   |
+|                                  |                                          |
+|  +-- LAYER 5: Evidence & Surfaces (37-10, 37-11, 37-12) ---------------+   |
+|  |  Emission Coverage  |  SOC2 control map + evidence pack | Dashboards |   |
+|  |  (BYOK/billing/auth/agent emitters feed Layer 1)                     |   |
+|  +---------------------------------------------------------------------+   |
+|                                                                             |
++-----------------------------------------------------------------------------+
+```
+
+## Key Technical Decisions
+
+### Build ON the DCB stream — never rebuild it
+
+The single biggest failure mode is treating this as "a new event store." It is not. Raw `DomainEvent` / `PlatformEvent` rows stay the immutable source of truth (BIGSERIAL `SequenceNumber` total-order cursor). The curated `audit_records` table is a **derived, fully rebuildable read-model** with a `source_event_id` back-reference: if it is ever wrong or corrupted, the fix is "truncate + reset cursor + re-project," never "patch the row." The projector only **reads** the DCB store; it never appends, mutates, or deletes raw events.
+
+### Cursor-tracked projection (mirror `AlertRuleEvaluator`)
+
+The `AuditProjector` is a near-clone of the existing `AlertRuleEvaluator` background poller: it reads new `DomainEvent` / `PlatformEvent` rows by `SequenceNumber`, persists progress in its own cursor entity (`AuditProjectorCursor`, mirroring `AlertEvaluatorCursor`), resumes on restart, and is crash-isolated per tick. Projection is **eventual and non-blocking** — the per-request hot path is never blocked. A `tamma.audit.projection_lag` OTel gauge tracks lag.
+
+### Per-mode ownership (mirror Epic 27 prompt-store)
+
+Every curated audit row answers ownership in both modes: single-user mode keys rows by `user_id` (`tenant_id` NULL); SaaS mode keys by `tenant_id` (`user_id` NULL). A CHECK constraint enforces exactly-one non-null (mirroring `prompt_overrides` `principal_xor`). There is **no per-user audit layer in SaaS** — tenant audit is owned by `tenant_owner`/`tenant_admin`; members read but never edit/configure.
+
+### Tenant vs platform scope routing
+
+Catalog-matched **tenant-scoped** events (those with a `TenantId` in SaaS) materialize into the **tenant schema** `audit_records`. **Platform-scoped** events (`TenantId` null — orchestrator/platform/lifecycle, e.g. impersonation against the platform) materialize into the **control-plane** `audit_records`. In single-user mode all rows collapse to the single-user `user_id` store. The tenant global query filter (same defence-in-depth as `EventRepository.ListByTenantAsync`) enforces cross-tenant isolation.
+
+### Tamper-evidence: two independent hash chains
+
+Mirroring the existing tenant-vs-platform event-plane split, there are **per-tenant chains** (one per `tenant_id`, in the tenant store) and a **single platform chain** (in the control-plane store). A record belongs to exactly one chain; chains never cross-link. `record_hash = SHA-256(prev_hash ‖ canonical(record))` over a deterministic, culture-invariant, field-ordered serialization. Per-scope insert is serialized with `pg_advisory_xact_lock` so concurrent appends stay strictly monotonic. Signed checkpoints anchor the chain head using an Epic 29 **cabinet** signing key (never a plaintext env key), with `key_version` so signing-key rotation does not invalidate historical anchors. A Postgres append-only trigger is belt-and-suspenders; the cryptographic chain is the actual proof.
+
+### Crypto-shred for GDPR erasure, never event mutation
+
+Right-to-erasure (37-8) never mutates the append-only event store. Plaintext `deletable` columns are hard-deleted; `must-retain-anonymized` columns (e.g. `users.email`) are overwritten with a stable pseudonymous tombstone; envelope-encrypted PII is **crypto-shredded** via the Epic 29 cabinet (`DeleteVersionAsync` scrubs ciphertext bytes, flips `SecretVersionRow.Status` to `revoked`, keeps the row). Curated audit identity fields are anonymized and the 37-2 chain is explicitly **re-anchored** (re-hashed, audited) — never silently edited. The erasure request, acting principal, reason, and destroyed `(SecretId, Version, KekId)` tuples are permanently retained as lawful-basis evidence.
+
+### Redaction before persistence
+
+`payload_json` on every curated record is passed through `Tamma.Core` redaction (`CredentialRedactor.Clean`) **before** the row is persisted — never "redact on read" — so no secret plaintext, API key, token, or password ever lands in `audit_records`.
+
+## Dependencies
+
+### On Other Epics
+
+- **Epic 4 (DCB event store)** — `DomainEvent` / `PlatformEvent` shape + `SequenceNumber` cursor; `IEventRepository` read methods + plane routing. The projector READS this store; it never writes to it. (Hard prerequisite.)
+- **Epic 28 (schema-per-tenant)** — `TenantDbContext`, `ControlPlaneDbContext`, the tenant-context global query filter, the cursor/background-pass infra (`AlertRuleEvaluator`, `AlertEvaluatorCursor`, `TaskQueueProcessor`), and KEK rotation lifecycle (checkpoint `key_version` coexistence).
+- **Epic 27 (per-mode ownership)** — the single-user `user_id` vs SaaS `tenant_id` XOR pattern (`prompt_overrides`) and `ITammaModeProvider` (`TammaMode.cs`).
+- **Epic 29 (secret cabinet)** — `ISecretStore` / `ISecretStoreBackend` / `TenantSecretProtector` (AES-GCM) for checkpoint signing keys and crypto-shred; `SecretVersionRow` per-version envelopes; `ISecretAccessAuditor` (`SecretAuditEventTypes`) as an existing emitter remapped by the catalog.
+- **Epic 5 (alerts)** — `IAlertSink` / `AlertEventEmitter` / `BuiltInAlertRuleSeeder` for the critical tamper alert.
+- **Epic 20 (billing)** — billing/plan/subscription/budget-change DCB events are absorbed as the `BILLING` category (emission coverage in 37-10).
+- **28-R2 (impersonation)** — `IMPERSONATION.STARTED` / `IMPERSONATION.ENDED` emitters remapped by the catalog.
+
+### Internal Story Dependencies
+
+- **37-1** is the foundation: 37-2 (chain), 37-3 (query), 37-5 (retention), and 37-10 (emission coverage) all consume the `audit_records` read-model it produces. 37-1 reserves the `record_hash` / `prev_record_hash` columns and the deterministic insert order that 37-2 needs.
+- **37-7 (DSAR / `SubjectDataMap`)**, **37-6 (legal hold / `ILegalHoldService`)**, and **37-2 (chain re-anchor / `AuditChainAnonymizer`)** are all consumed by **37-8 (erasure)** — DSAR (read) and erasure (destroy) share one PII inventory.
+- **37-5 (pruning)** consults **37-6 (legal hold)** before deleting and re-anchors the **37-2** chain after tamper-aware pruning.
+- **37-3 / 37-4 / 37-12** read the curated, tamper-evident model produced by 37-1 + 37-2.
+
+## Database Schema
+
+```sql
+-- 37-1: curated audit read-model (added to BOTH tenant schema and control-plane)
+CREATE TABLE audit_records (
+  id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),  -- UUID v7
+  action_code           TEXT NOT NULL,        -- canonical DCB event type
+  category              TEXT NOT NULL,         -- CONFIG|RBAC|SECRET|BYOK|BILLING|EXPORT|
+                                               --   AUTH|IMPERSONATION|TENANT|AGENT|PERSONA
+  severity              TEXT NOT NULL,         -- info|notice|warning|critical
+  actor_user_id         UUID NULL,
+  actor_email_snapshot  TEXT NULL,             -- point-in-time email
+  target_type           TEXT NULL,             -- 'secret' | 'user' | 'tenant' | ...
+  target_id             TEXT NULL,
+  outcome               TEXT NOT NULL DEFAULT 'success',  -- success | failure | denied
+  ip_address            TEXT NULL,
+  user_agent            TEXT NULL,
+  occurred_at           TIMESTAMPTZ NOT NULL,
+  source_event_id       UUID NOT NULL,         -- back-ref to raw DCB event (idempotency key)
+  source_sequence_number BIGINT NOT NULL,      -- DCB total-order cursor (deterministic replay)
+  payload_json          JSONB NOT NULL DEFAULT '{}',  -- REDACTED projection of raw Data/Tags
+  -- per-mode ownership — exactly one non-null
+  tenant_id             UUID NULL,             -- SaaS
+  user_id               UUID NULL,             -- single-user
+  -- reserved for 37-2 (left null by 37-1, populated by 37-2)
+  chain_sequence        BIGINT NULL,           -- per-scope monotonic
+  prev_hash             BYTEA NULL,            -- 32 bytes (genesis for first)
+  record_hash           BYTEA NULL,            -- 32 bytes SHA-256
+  CONSTRAINT ck_audit_records_principal_xor CHECK (
+    (user_id IS NOT NULL AND tenant_id IS NULL)
+    OR (user_id IS NULL AND tenant_id IS NOT NULL)
+  )
+);
+CREATE UNIQUE INDEX uq_audit_records_source_event ON audit_records (source_event_id);
+CREATE INDEX ix_audit_records_tenant_occurred ON audit_records (tenant_id, occurred_at);
+CREATE INDEX ix_audit_records_seq ON audit_records (source_sequence_number);
+
+-- 37-1: projector cursor (mirror AlertEvaluatorCursor)
+CREATE TABLE audit_projector_cursors (
+  projector_id                  TEXT PRIMARY KEY DEFAULT 'default',
+  last_domain_sequence_number   BIGINT NOT NULL DEFAULT 0,
+  last_platform_sequence_number BIGINT NOT NULL DEFAULT 0,
+  updated_at                    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- 37-2: signed chain checkpoints
+CREATE TABLE audit_chain_checkpoints (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  scope         TEXT NOT NULL,            -- 'tenant' | 'platform'
+  tenant_id     UUID NULL,                -- set for tenant scope; null for platform
+  head_sequence BIGINT NOT NULL,
+  head_hash     BYTEA NOT NULL,           -- 32 bytes
+  signed_at     TIMESTAMPTZ NOT NULL,
+  signature     BYTEA NOT NULL,           -- HMAC-SHA256 via Epic 29 cabinet key
+  key_version   INTEGER NOT NULL,         -- which cabinet key version signed
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT scope_tenant_consistency CHECK (
+    (scope = 'platform' AND tenant_id IS NULL)
+    OR (scope = 'tenant' AND tenant_id IS NOT NULL)
+  )
+);
+CREATE INDEX ix_audit_chain_checkpoints_scope_seq
+  ON audit_chain_checkpoints (scope, tenant_id, head_sequence DESC);
+
+-- 37-2: append-only trigger on audit_records rejects UPDATE/DELETE of chain + core fields
+--        (belt-and-suspenders; the cryptographic chain is the actual proof)
+
+-- 37-5 retention policies, 37-6 legal holds, 37-9 consent/ROPA records, and the
+-- 37-7/37-8 DSAR/erasure request-status rows are added by their respective stories,
+-- each per-mode-keyed (tenant_id / user_id XOR) in the appropriate store.
+```
+
+## Implementation Phases
+
+### Phase 1: Foundation & Integrity (Stories 37-1, 37-2, 37-10) — P0
+
+- Sensitive-action catalog (≥30 codes, 11 categories, SOC2 control ids), curated `audit_records` projection (cursor-tracked, redacting), per-mode + tenant/platform scope routing.
+- Tamper-evident hash chain, signed cabinet-keyed checkpoints, `AuditChainVerifier`, verify endpoints, append-only trigger, critical tamper alert.
+- Emission coverage: wire BYOK, billing/plan, auth/login, and agent-action emitters so the catalog has live events to project.
+- Estimated: 14-17 days
+
+### Phase 2: Access (Stories 37-3, 37-4) — P0/P1
+
+- Query/search/filter API over the curated read-model (actor/target/category/severity/outcome/range), per-mode RBAC.
+- Signed export (JSON/CSV) with an integrity manifest.
+- Estimated: 7-9 days
+
+### Phase 3: Governance (Stories 37-5, 37-6, 37-7, 37-8, 37-9) — P1/P2
+
+- Retention policies + tamper-aware pruning (re-anchors the chain), legal hold.
+- GDPR DSAR access export (`SubjectDataMap`), right-to-erasure with crypto-shredding + audit preservation, consent/ROPA logging.
+- Estimated: 19-24 days
+
+### Phase 4: Evidence & Surfaces (Stories 37-11, 37-12) — P1/P2
+
+- SOC2-aligned control mapping + evidence pack.
+- Admin & tenant audit dashboard UI.
+- Estimated: 7-9 days
+
+## Success Metrics
+
+- **Coverage**: 100% of catalog-defined sensitive actions (≥30 codes across all 11 categories) materialize into `audit_records`; a catalog-completeness CI test fails if any existing emitter event type is dropped/renamed without updating the catalog.
+- **No data leak**: zero secret plaintext, API key, token, or password ever appears in `audit_records.payload_json` (redaction-before-persist test is the gate).
+- **Tamper detection**: any insertion, deletion, reordering, or in-place mutation of a curated record is detected and localized to the exact `chain_sequence`; verification of 100k records completes within the documented budget (target < 10s on the reference VPS).
+- **Integrity**: the 37-2 chain still verifies after retention pruning (37-5) and after GDPR erasure (37-8); a real byte-level tamper still fails verification (proves the chain is not bypassed).
+- **Isolation**: a tenant-A audit record never materializes into tenant-B's schema; a tenant-scoped event never lands in the control-plane store (and vice-versa); the tenant global query filter rejects cross-tenant reads.
+- **Projection lag**: `tamma.audit.projection_lag` stays within threshold; a full pass drives it to 0.
+- **GDPR SLA**: subject erasure reaches a terminal state within the configured SLA (default 30 days, GDPR Art. 12(3)); crypto-shredded ciphertext is permanently unrecoverable (`GetVersionPlaintextAsync` → null).
+- **No write-path change**: zero `UPDATE`/`DELETE` against `domain_events` / `platform_events` from any Epic 37 component — the event store remains the immutable source of truth.
+
+## Reference Documents
+
+- [Epic 4 — DCB Event Sourcing](../epic-4/README.md) — the substrate Epic 37 builds on (read-only)
+- [Epic 27 — Convention/Prompt Store](../epic-27/README.md) — per-mode ownership pattern (`prompt_overrides` XOR)
+- [Epic 28 — Schema-per-Tenant](../epic-28/README.md) — tenant/control-plane context split, cursor/background-pass infra, KEK rotation
+- [Epic 29 — Secret Cabinet](../epic-29/README.md) — `ISecretStore` / `TenantSecretProtector` crypto, crypto-shred primitive
+- [GDPR Art. 17 — Right to erasure](https://gdpr-info.eu/art-17-gdpr/)
+- [GDPR Art. 30 — Records of processing activities (ROPA)](https://gdpr-info.eu/art-30-gdpr/)
+- [EDPB Guidelines 05/2021 — crypto-erasure](https://edpb.europa.eu/)
+- [ISO/IEC 27040 — cryptographic erase](https://www.iso.org/standard/80194.html)
+- [SOC2 Trust Services Criteria (Common Criteria CC6/CC7)](https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2)
+
+---
+
+**Last Updated**: 2026-06-17
+**Epic Owner**: TBD
+**Implementation Start**: TBD
+**Total Estimated Effort**: 47-59 days

--- a/docs/stories/epic-37/story-37-1/37-1-sensitive-action-audit-taxonomy-and-curated-audit-record-pro.md
+++ b/docs/stories/epic-37/story-37-1/37-1-sensitive-action-audit-taxonomy-and-curated-audit-record-pro.md
@@ -1,0 +1,444 @@
+# Story 37-1: Sensitive-Action Audit Taxonomy & Curated Audit-Record Projection
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+Then, before writing any code, check the knowledge base:
+
+- `.dev/spikes/` — existing research
+- `.dev/bugs/` — known bugs
+- `.dev/findings/` — pitfalls and best practices
+- `.dev/decisions/` — architecture decisions
+
+## User Story
+
+As a **compliance officer / platform operator** (and, in single-user mode, the sole user auditing their own instance),
+I want a **canonical catalog of compliance-relevant sensitive actions** and a **curated, queryable audit-record read-model** materialized from the existing DCB event stream,
+So that I can answer "who did what, when, to which target, with what outcome" for every sensitive action — across tenant and platform scope — without scanning the raw event store, and so that the curated trail is the stable substrate the rest of Epic 37 (tamper-evidence, query/export, retention, GDSR) builds on.
+
+## Priority
+
+P0 — Foundation for the entire Epic 37 audit/compliance product layer. Story 37-2 (tamper-evidence / hash-chain) and 37-10 (audit query/search/export API) both consume the `audit_records` read-model this story produces. Without a curated, normalized projection there is no audit product — only the raw, unindexed DCB stream.
+
+## Architectural Context (READ FIRST)
+
+This story builds **ON TOP OF** the Epic 4 DCB event store. It does **NOT** rebuild, duplicate, or replace the event store.
+
+- The **single DCB stream is the source of truth and the audit substrate** (per CLAUDE.md "DCB Pattern" and Epic 4). Raw immutable events stay authoritative. The curated `audit_records` table is a **read-optimized product layer** with a back-reference (`source_event_id` + `source_sequence_number`) to the originating raw event.
+- Target codebase is the C# app `apps/tamma-elsa/`. **`packages/api` is DELETED — never target it.**
+  - `Tamma.Core` — enums, redaction, pure catalog constants (`src/Tamma.Core/Redaction/CredentialRedactor.cs` exists).
+  - `Tamma.Data` — entities, EF `DbContext`s, repositories, migrations.
+    - `src/Tamma.Data/Entities/DomainEvent.cs` — the DCB event row (tenant `domain_events`; also a CP DbSet). Has `Id`, `Type`, `TenantId`, `IssueNumber`, `Tags` (JSONB), `Metadata`, `Data`, `CreatedAt`, and `SequenceNumber` (BIGSERIAL total-order cursor).
+    - `src/Tamma.Data/Entities/PlatformEvent.cs` — control-plane cross-tenant event store (`Id`, `Type`, `TenantId?`, `UserId?`, `Tags`, `Metadata`, `Data`, `CreatedAt`, `SequenceNumber`).
+    - `src/Tamma.Data/TenantDbContext.cs` — per-tenant schema context (`DomainEvents` DbSet lives here → **tenant audit records go in the tenant schema**).
+    - `src/Tamma.Data/ControlPlaneDbContext.cs` — control-plane context (`DomainEvents` + `PlatformEvents` DbSets → **platform audit records go in the control plane**).
+    - `src/Tamma.Data/Repositories/EventRepository.cs` / `IEventRepository.cs` — append + query DCB events (do NOT modify the write path; only read).
+  - `Tamma.Api` — endpoints, services, DI extensions, hosted/background services.
+- **Per-mode ownership (mirror Epic 27 / prompt-store, per CLAUDE.md "Operating Modes"):** single-user mode keys curated rows by `user_id` (tenant_id NULL); SaaS mode keys by `tenant_id` (user_id NULL). Exactly-one XOR, mirroring `prompt_overrides`. Mode comes from `ITammaModeProvider` (`src/Tamma.Api/Services/PromptStore/TammaMode.cs`).
+
+### Real cursor-projection precedent to mirror
+
+`AlertRuleEvaluator` (`src/Tamma.Api/Services/Alerts/Rules/AlertRuleEvaluator.cs`) is a background poller that already does exactly the cursor-tracked scan this story needs: it reads new `DomainEvent` + `PlatformEvent` rows by `SequenceNumber`, persists progress in the `AlertEvaluatorCursor` entity (`LastDomainSequenceNumber` / `LastPlatformSequenceNumber`), and resumes on restart. The `AuditProjector` MUST follow this established pattern (its own cursor entity, its own `EvaluatorId`-style id) rather than inventing a new mechanism.
+
+## Acceptance Criteria
+
+1. **Catalog exists and is centralized.** A `SensitiveActionCatalog` static class is added under `src/Tamma.Core/Audit/SensitiveActionCatalog.cs`, mirroring the shape of the existing `SecretAuditEventTypes` (`src/Tamma.Api/Services/Secrets/ISecretAccessAuditor.cs`). It enumerates **≥30 action codes** as named constants, each mapped to (a) a `category`, (b) a `severity`, and (c) a SOC2 control id, via a single immutable lookup (e.g. `IReadOnlyDictionary<string, SensitiveActionDescriptor>`).
+
+2. **Catalog categories are complete.** Action codes are grouped under the categories: `CONFIG` (prompt/persona/convention/agent-config/sanitization-rule edits), `RBAC` (role/membership/invite changes), `SECRET` (secret read/write/reveal/rotate/revoke), `BYOK` (provider-key / provider-chain changes), `BILLING` (plan/subscription/budget changes), `EXPORT` (data export / DSAR), `AUTH` (login success/failure, logout, password reset, token refresh), `IMPERSONATION` (start/end), `TENANT` (provision/deprovision/move/lifecycle), `AGENT` (agent dispatch / autonomous code action), and `PERSONA` (persona/system-prompt changes). Each category has ≥1 code; the catalog defines the `AuditCategory` and `AuditSeverity` enums (severity ∈ `info | notice | warning | critical`) in `Tamma.Core`.
+
+3. **Catalog reuses existing emitters without re-emitting.** The catalog **maps existing event types** already emitted elsewhere — `SECRET.*` (Epic 29, `SecretAuditEventTypes`), `IMPERSONATION.STARTED` / `IMPERSONATION.ENDED` (28-R2, `AdminImpersonationsEndpoints.cs`), `USER.ROLE_CHANGED.SUCCESS` (`AdminEndpoints.cs`), `TENANT.MEMBER_ROLE_CHANGED.SUCCESS` (`OrgEndpoints.cs`) — **without adding new emit call-sites for them**. The projection observes the already-flowing events; it does not change who emits or when.
+
+4. **`AuditRecord` entity + tables (tenant AND platform).** An `AuditRecord` entity is added (`src/Tamma.Data/Entities/AuditRecord.cs`) and registered as a DbSet in **both** `TenantDbContext` (per-tenant schema, tenant-scope audit) and `ControlPlaneDbContext` (platform-scope audit). Columns: `id`, `action_code`, `category`, `severity`, `actor_user_id`, `actor_email_snapshot`, `target_type`, `target_id`, `outcome` (`success | failure | denied`), `ip_address`, `user_agent`, `occurred_at`, `source_event_id`, `source_sequence_number`, `payload_json` (redacted), plus the per-mode ownership column(s): `tenant_id` (SaaS) / `user_id` (single-user). Entity config goes in `TammaModelConfiguration.cs` (the single configuration source).
+
+5. **Per-mode ownership XOR + uniqueness.** A CHECK constraint enforces exactly-one of (`user_id`, `tenant_id`) non-null (mirroring `prompt_overrides` `principal_xor`). A UNIQUE constraint on `source_event_id` guarantees idempotency (one curated row per raw event). The tenant-context global query filter (same defence-in-depth used by `EventRepository.ListByTenantAsync`) applies to the tenant `AuditRecord` set.
+
+6. **EF migration.** An additive EF migration is added under `src/Tamma.Data/Migrations/Tenant/` (tenant `audit_records`) and `src/Tamma.Data/Migrations/ControlPlane/` (platform `audit_records`). `dotnet ef migrations has-pending-model-changes` reports **none** after; migrations apply and roll back cleanly.
+
+7. **`IAuditProjector` reads by cursor and inserts exactly one row per catalog match.** An `IAuditProjector` / `AuditProjector` (`src/Tamma.Data/Audit/AuditProjector.cs`) reads new `DomainEvent` (tenant scope) / `PlatformEvent` (platform scope) rows by `SequenceNumber` cursor and inserts **exactly one** `audit_record` per **catalog-matched** event. Non-catalog event types are **skipped** (no row). The projector resolves `category`/`severity`/`outcome`/`actor`/`target` by joining the raw event's `Type` + `Tags` + `Data` against `SensitiveActionCatalog`.
+
+8. **Idempotent / replayable from cursor.** Re-running the projector from any cursor position **never double-inserts** (enforced by the `source_event_id` unique index + insert-if-absent). The projection is fully rebuildable: deleting `audit_records` and resetting the cursor to 0 reconstructs an identical curated trail from the raw DCB stream. `source_sequence_number` preserves the DCB total-order cursor so replay order is deterministic.
+
+9. **Eventual, non-blocking projection.** The projector runs as a **cursor-tracked background pass** (a `BackgroundService` mirroring `AlertRuleEvaluator` + its cursor entity, or hung off the existing `TaskQueueProcessor` / Elsa schedule). The per-request hot path is **never blocked** by projection — audit-record materialization is eventual. A **lag metric** (`tamma.audit.projection_lag` = max raw `SequenceNumber` − last projected `SequenceNumber`) is exposed via the existing OTel meter pattern.
+
+10. **Redaction before persistence.** `payload_json` is passed through `Tamma.Core` redaction (`CredentialRedactor.Clean` / equivalent) before the row is persisted, so no secret plaintext, API key, token, or password ever lands in `audit_records`. A dedicated test feeds a `SECRET.WRITE`-shaped event with a fake secret in `Data` and asserts the persisted `payload_json` contains the `[REDACTED]` placeholder and never the plaintext.
+
+11. **Tenant vs platform scope routing.** Catalog-matched **tenant-scoped** events (those with a `TenantId`, in SaaS mode) materialize into the **tenant schema** `audit_records` keyed by `tenant_id`. **Platform-scoped** events (`TenantId` null — orchestrator/platform/lifecycle, e.g. `IMPERSONATION.*` against the platform) materialize into the **control-plane** `audit_records`. In **single-user mode**, all curated rows are keyed by `user_id` (tenant_id NULL) and the routing collapses to the single-user store.
+
+12. **Tamper-evidence hook for 37-2.** `AuditRecord` carries the fields 37-2 needs to build its hash chain without a schema change: `source_sequence_number` (deterministic order), plus a nullable `record_hash` and `prev_record_hash` column reserved for 37-2 (populated by 37-2, NOT this story — this story only adds the columns and leaves them null). The projector inserts rows in strict `source_sequence_number` order so 37-2 can chain them deterministically.
+
+13. **Unit tests (xUnit, test-first).** Tests cover: (a) **catalog completeness** — every existing emitter event type asserted (`SECRET.*`, `IMPERSONATION.*`, `USER.ROLE_CHANGED.SUCCESS`, `TENANT.MEMBER_ROLE_CHANGED.SUCCESS`) is present in the catalog and ≥30 codes / all 11 categories populated; (b) **projector idempotency** — running twice over the same range yields exactly one row per event; (c) **per-mode key selection** — SaaS event → `tenant_id` set / `user_id` null; single-user → `user_id` set / `tenant_id` null; (d) **redaction enforcement** (AC10); (e) **non-catalog skip** — a `WORKFLOW.STEP_COMPLETED` event produces zero rows.
+
+14. **Cross-scope isolation test.** A tenant-A event never materializes into tenant-B's schema, and a tenant-scoped event never lands in the control-plane `audit_records` (and vice-versa). The tenant global query filter rejects a cross-tenant read of `audit_records`.
+
+15. **No write-path change to the DCB store.** A test asserts the projector only reads `DomainEvent` / `PlatformEvent` (via `IEventRepository` read methods or a read-only query) and never appends, mutates, or deletes raw events — the event store remains the immutable source of truth.
+
+## Technical Design
+
+### Component layout
+
+```
+apps/tamma-elsa/src/
+  Tamma.Core/
+    Audit/
+      SensitiveActionCatalog.cs        # NEW — ≥30 codes, category+severity+SOC2 control, immutable lookup
+      AuditCategory.cs                 # NEW — enum: CONFIG|RBAC|SECRET|BYOK|BILLING|EXPORT|AUTH|IMPERSONATION|TENANT|AGENT|PERSONA
+      AuditSeverity.cs                 # NEW — enum: info|notice|warning|critical
+      SensitiveActionDescriptor.cs     # NEW — record: ActionCode, Category, Severity, Soc2ControlId, TargetTypeHint
+    Redaction/
+      CredentialRedactor.cs            # EXISTING — reused for payload_json redaction
+  Tamma.Data/
+    Entities/
+      AuditRecord.cs                   # NEW — curated row (see schema below)
+      AuditProjectorCursor.cs          # NEW — cursor entity (mirror AlertEvaluatorCursor)
+      DomainEvent.cs                   # EXISTING — read source (tenant)
+      PlatformEvent.cs                 # EXISTING — read source (platform)
+    Audit/
+      IAuditProjector.cs               # NEW
+      AuditProjector.cs                # NEW — cursor-tracked, idempotent, redacting projection
+    Repositories/
+      IAuditRecordRepository.cs        # NEW
+      AuditRecordRepository.cs         # NEW — insert-if-absent + cursor read; reuses tenant/CP context
+      IEventRepository.cs              # EXISTING — read only
+    TenantDbContext.cs                 # MODIFY — add AuditRecords + AuditProjectorCursor DbSets
+    ControlPlaneDbContext.cs           # MODIFY — add AuditRecords + AuditProjectorCursor DbSets
+    TammaModelConfiguration.cs         # MODIFY — entity config (CHECK constraints, unique index, filter)
+    Migrations/Tenant/                 # NEW migration — tenant audit_records
+    Migrations/ControlPlane/           # NEW migration — platform audit_records
+  Tamma.Api/
+    Services/Audit/
+      AuditProjectorBackgroundService.cs   # NEW — BackgroundService host (mirror AlertRuleEvaluator)
+      AuditProjectorOptions.cs             # NEW — RunOnStartup gate, poll interval
+      AuditProjectionMetrics.cs            # NEW — projection_lag OTel gauge
+    Extensions/
+      AuditServiceCollectionExtensions.cs  # NEW — DI wiring; called from Program.cs
+    Program.cs                              # MODIFY — register projector + background service
+```
+
+> Note: this story produces the **catalog + projection + tables** only. It deliberately ships **no read/query/export endpoint** (that is Story 37-10) and **no hash chaining** (that is Story 37-2). It ships the `record_hash` / `prev_record_hash` columns and the deterministic-order guarantee that 37-2 needs.
+
+### Taxonomy enum + descriptor
+
+```csharp
+// src/Tamma.Core/Audit/AuditCategory.cs
+namespace Tamma.Core.Audit;
+
+public enum AuditCategory
+{
+    Config, Rbac, Secret, Byok, Billing, Export, Auth, Impersonation, Tenant, Agent, Persona
+}
+
+// src/Tamma.Core/Audit/AuditSeverity.cs
+public enum AuditSeverity { Info, Notice, Warning, Critical }
+
+// src/Tamma.Core/Audit/SensitiveActionDescriptor.cs
+public sealed record SensitiveActionDescriptor(
+    string ActionCode,        // canonical DCB event type, e.g. "SECRET.REVEAL"
+    AuditCategory Category,
+    AuditSeverity Severity,
+    string Soc2ControlId,     // e.g. "CC6.1"
+    string TargetTypeHint);   // e.g. "secret", "user", "tenant"
+```
+
+```csharp
+// src/Tamma.Core/Audit/SensitiveActionCatalog.cs  (shape mirrors SecretAuditEventTypes)
+namespace Tamma.Core.Audit;
+
+public static class SensitiveActionCatalog
+{
+    // ── SECRET (maps existing Epic 29 SecretAuditEventTypes — NOT re-emitted here) ──
+    public const string SecretRead        = "SECRET.READ";
+    public const string SecretWrite       = "SECRET.WRITE";
+    public const string SecretReveal      = "SECRET.REVEAL";
+    public const string SecretRotateStarted = "SECRET.ROTATE.STARTED";
+    public const string SecretRotateSuccess = "SECRET.ROTATE.SUCCESS";
+    public const string SecretVersionRevoked = "SECRET.VERSION.REVOKED";
+
+    // ── RBAC (maps existing AdminEndpoints / OrgEndpoints emitters) ──
+    public const string UserRoleChanged   = "USER.ROLE_CHANGED.SUCCESS";
+    public const string TenantMemberRoleChanged = "TENANT.MEMBER_ROLE_CHANGED.SUCCESS";
+    public const string TenantMemberAdded = "TENANT.MEMBER_ADDED.SUCCESS";
+    public const string TenantMemberRemoved = "TENANT.MEMBER_REMOVED.SUCCESS";
+    public const string UserInvited       = "USER.INVITED.SUCCESS";
+
+    // ── IMPERSONATION (maps existing 28-R2 emitters) ──
+    public const string ImpersonationStarted = "IMPERSONATION.STARTED";
+    public const string ImpersonationEnded   = "IMPERSONATION.ENDED";
+
+    // ── CONFIG / PERSONA ──
+    public const string PromptOverrideChanged   = "PROMPT.OVERRIDE.CHANGED";
+    public const string ConventionChanged       = "CONVENTION.CHANGED";
+    public const string AgentConfigChanged      = "AGENT_CONFIG.CHANGED";
+    public const string SanitizationRuleChanged = "SANITIZATION_RULE.CHANGED";
+    public const string PersonaChanged          = "PERSONA.CHANGED";
+    public const string SystemPromptChanged     = "SYSTEM_PROMPT.CHANGED";
+
+    // ── BYOK ──
+    public const string ProviderKeyChanged   = "PROVIDER_KEY.CHANGED";
+    public const string ProviderChainChanged = "PROVIDER_CHAIN.CHANGED";
+
+    // ── BILLING ──
+    public const string PlanChanged         = "BILLING.PLAN.CHANGED";
+    public const string SubscriptionChanged = "BILLING.SUBSCRIPTION.CHANGED";
+    public const string BudgetChanged       = "BUDGET.CONFIG.CHANGED";
+
+    // ── EXPORT ──
+    public const string DataExported = "DATA.EXPORTED.SUCCESS";
+    public const string DsarRequested = "GDPR.DSAR.REQUESTED";
+
+    // ── AUTH ──
+    public const string LoginSuccess  = "AUTH.LOGIN.SUCCESS";
+    public const string LoginFailure  = "AUTH.LOGIN.FAILURE";
+    public const string Logout        = "AUTH.LOGOUT.SUCCESS";
+    public const string PasswordReset = "AUTH.PASSWORD_RESET.SUCCESS";
+    public const string TokenRefreshed = "AUTH.TOKEN.REFRESHED";
+
+    // ── TENANT lifecycle ──
+    public const string TenantProvisioned   = "TENANT.PROVISIONED.SUCCESS";
+    public const string TenantDeprovisioned = "TENANT.DEPROVISIONED.SUCCESS";
+    public const string TenantMoved         = "TENANT.MOVED.SUCCESS";
+
+    // ── AGENT ──
+    public const string AgentDispatched = "AGENT.DISPATCH.SUCCESS";
+    public const string AgentCodeApplied = "CODE.GENERATED.SUCCESS";
+
+    /// <summary>Immutable code → descriptor lookup. The single source of truth
+    /// for "is this event a sensitive action, and how is it classified".</summary>
+    public static readonly IReadOnlyDictionary<string, SensitiveActionDescriptor> ByCode;
+
+    /// <summary>True if the projector should materialize an audit_record for this raw event type.</summary>
+    public static bool IsSensitive(string eventType) => ByCode.ContainsKey(eventType);
+
+    static SensitiveActionCatalog()
+    {
+        ByCode = new Dictionary<string, SensitiveActionDescriptor>
+        {
+            [SecretReveal] = new(SecretReveal, AuditCategory.Secret, AuditSeverity.Critical, "CC6.1", "secret"),
+            [UserRoleChanged] = new(UserRoleChanged, AuditCategory.Rbac, AuditSeverity.Warning, "CC6.3", "user"),
+            // … one entry per const above …
+        };
+    }
+}
+```
+
+> **Catalog-completeness test** (AC13a) reflects over the existing emitter constants (e.g. `SecretAuditEventTypes`) and asserts every one is a key in `SensitiveActionCatalog.ByCode`, so a future code that drops/renames an emitted type without updating the catalog fails CI.
+
+### AuditRecord entity
+
+```csharp
+// src/Tamma.Data/Entities/AuditRecord.cs
+namespace Tamma.Data.Entities;
+
+public class AuditRecord
+{
+    public Guid Id { get; set; }                       // UUID v7
+    public string ActionCode { get; set; } = null!;    // canonical event type
+    public string Category { get; set; } = null!;      // AuditCategory (string)
+    public string Severity { get; set; } = null!;      // AuditSeverity (string)
+
+    // Who
+    public Guid? ActorUserId { get; set; }
+    public string? ActorEmailSnapshot { get; set; }    // point-in-time email (actor row may later change)
+
+    // What / target
+    public string? TargetType { get; set; }            // "secret" | "user" | "tenant" | ...
+    public string? TargetId { get; set; }
+    public string Outcome { get; set; } = "success";   // success | failure | denied
+
+    // Context
+    public string? IpAddress { get; set; }
+    public string? UserAgent { get; set; }
+    public DateTime OccurredAt { get; set; }
+
+    // Back-reference to the raw DCB event (source of truth)
+    public Guid SourceEventId { get; set; }            // UNIQUE — idempotency key
+    public long SourceSequenceNumber { get; set; }     // DCB total-order cursor (deterministic replay)
+
+    public string PayloadJson { get; set; } = "{}";    // redacted projection of raw Data/Tags
+
+    // Per-mode ownership — exactly one is non-null (XOR CHECK)
+    public Guid? TenantId { get; set; }                // SaaS
+    public Guid? UserId { get; set; }                  // single-user
+
+    // Reserved for Story 37-2 tamper-evidence (this story leaves null)
+    public string? RecordHash { get; set; }
+    public string? PrevRecordHash { get; set; }
+}
+```
+
+### Projection cursor (mirror `AlertEvaluatorCursor`)
+
+```csharp
+// src/Tamma.Data/Entities/AuditProjectorCursor.cs
+public class AuditProjectorCursor
+{
+    public string ProjectorId { get; set; } = "default";
+    public long LastDomainSequenceNumber { get; set; }     // tenant DomainEvents cursor
+    public long LastPlatformSequenceNumber { get; set; }   // CP PlatformEvents cursor
+    public DateTime UpdatedAt { get; set; }
+}
+```
+
+### Projector loop (sketch)
+
+```csharp
+// src/Tamma.Data/Audit/AuditProjector.cs
+public async Task<int> ProjectBatchAsync(CancellationToken ct)
+{
+    var cursor = await LoadCursorAsync(ct);                       // resume — mirror AlertRuleEvaluator
+    var rawBatch = await ReadNewEventsAsync(cursor, batchSize: 500, ct);  // ORDER BY SequenceNumber
+    var inserted = 0;
+
+    foreach (var raw in rawBatch)                                // strict SequenceNumber order (37-2 needs this)
+    {
+        if (!SensitiveActionCatalog.ByCode.TryGetValue(raw.Type, out var desc))
+            continue;                                            // AC7 non-catalog skip
+
+        var record = BuildAuditRecord(raw, desc);                // map actor/target/outcome from Tags+Data
+        record.PayloadJson = CredentialRedactor.Clean(           // AC10 redact BEFORE persist
+            ProjectPayload(raw));
+        AssignOwnership(record, raw, _mode.Current);             // AC11 tenant_id vs user_id
+
+        // insert-if-absent on UNIQUE(source_event_id) — AC8 idempotent
+        if (await _repo.InsertIfAbsentAsync(record, ct)) inserted++;
+    }
+
+    await SaveCursorAsync(MaxSeq(rawBatch), ct);
+    _metrics.RecordLag(MaxRawSeq - cursor.LastDomainSequenceNumber);   // AC9 lag gauge
+    return inserted;
+}
+```
+
+### Background host
+
+`AuditProjectorBackgroundService : BackgroundService` mirrors `AlertRuleEvaluator`: a poll loop (default interval configurable via `AuditProjectorOptions`), a `RunOnStartup` gate (so unrelated tests can disable it, mirroring `AlertRuleEvaluatorOptions` / `NotificationDispatcherOptions`), and crash-isolation per tick (one bad batch logs + continues; it does not kill the host). Tenant-scoped projection fans out per active tenant context (consistent with the Story 28-1 per-tenant evaluator direction); platform projection reads the CP `PlatformEvents`.
+
+### EF model configuration (in `TammaModelConfiguration.cs`)
+
+```csharp
+// audit_records — applied to BOTH tenant + CP model builds
+b.Entity<AuditRecord>(e =>
+{
+    e.ToTable("audit_records", t =>
+    {
+        t.HasCheckConstraint("ck_audit_records_principal_xor",
+            "(user_id IS NOT NULL AND tenant_id IS NULL) OR (user_id IS NULL AND tenant_id IS NOT NULL)");
+    });
+    e.HasIndex(x => x.SourceEventId).IsUnique();                 // idempotency
+    e.HasIndex(x => new { x.TenantId, x.OccurredAt });           // tenant query path (37-10)
+    e.HasIndex(x => x.SourceSequenceNumber);                     // replay order / 37-2 chain
+    // tenant context global query filter (same defence-in-depth as DomainEvent)
+});
+```
+
+## Dependencies
+
+- **Prerequisite — Epic 4 (DCB event store):** Story 4-1 (event schema, `DomainEvent` shape + `SequenceNumber`), Story 4-7 (event query API / read patterns reused for the projector's cursor read). The projector READS this store; it never writes to it.
+- **Prerequisite — Epic 28 (schema-per-tenant):** `ControlPlaneDbContext`, `TenantDbContext`, the tenant-context global query filter, and the cursor/background-pass infrastructure (`AlertRuleEvaluator`, `AlertEvaluatorCursor`, `TaskQueueProcessor`).
+- **Prerequisite — Epic 27 (per-mode ownership):** the single-user `user_id` vs SaaS `tenant_id` XOR pattern (`prompt_overrides`), and `ITammaModeProvider` (`TammaMode.cs`).
+- **Consumed by — Story 37-2 (tamper-evidence / hash chain):** consumes the `audit_records` deterministic-order rows + the reserved `record_hash` / `prev_record_hash` columns. This story is the **tamper-evidence hook**.
+- **Consumed by — Story 37-10 (audit query/search/export API):** queries the curated `audit_records` read-model instead of scanning the raw stream.
+
+## Testing Strategy
+
+Tests are **xUnit**, live under `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/` and `tests/Tamma.Data.Tests/Audit/`, and are written **test-first (TDD, Red→Green→Refactor)**. Docker-bound suites run via `sg docker -c "dotnet test ..."` (see `.dev` / project memory on the stale session docker group).
+
+1. **Catalog completeness (pure, no DB):** reflect over `SecretAuditEventTypes` + the impersonation/role-change constants; assert each is in `SensitiveActionCatalog.ByCode`; assert ≥30 codes and all 11 `AuditCategory` values populated; assert every descriptor has a non-empty SOC2 control id.
+2. **Projector idempotency:** seed N raw events (mix of catalog + non-catalog); run projector twice over the full range; assert exactly one `audit_record` per catalog-matched event and zero for non-catalog; assert a from-scratch replay (truncate + cursor 0) reproduces an identical set.
+3. **Per-mode key selection:** with `ITammaModeProvider` = SaaS, a tenant event → `tenant_id` set / `user_id` null; with single-user, → `user_id` set / `tenant_id` null; XOR CHECK rejects a hand-crafted both-set row.
+4. **Redaction enforcement:** feed a `SECRET.WRITE` event whose `Data` carries a fake `tamma_sk_…` / `Bearer …` / `password=…`; assert persisted `payload_json` contains `[REDACTED]` and never the plaintext.
+5. **Non-catalog skip:** a `WORKFLOW.STEP_COMPLETED` raw event produces zero `audit_records`.
+6. **Cross-scope isolation (DB):** tenant-A event never lands in tenant-B schema; tenant-scoped event never lands in CP `audit_records`; the tenant global query filter rejects a cross-tenant read.
+7. **No-write-path assertion:** a spy/fake `IEventRepository` asserts the projector calls only read methods (no `AppendAsync` / mutate / delete) against `DomainEvent` / `PlatformEvent`.
+8. **Lag metric:** with M un-projected raw events, `tamma.audit.projection_lag` reports M; after a full pass it reports 0.
+9. **Background-service gating:** `RunOnStartup=false` keeps the loop idle for unrelated tests; crash-isolation — one throwing batch logs and the loop survives.
+10. **Migration discipline:** `dotnet ef migrations has-pending-model-changes` → none; migration applies + rolls back on both tenant and CP.
+
+## Estimated Effort
+
+5–6 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Core/Audit/SensitiveActionCatalog.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Core/Audit/AuditCategory.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Core/Audit/AuditSeverity.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Core/Audit/SensitiveActionDescriptor.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/AuditRecord.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/AuditProjectorCursor.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Audit/IAuditProjector.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Audit/AuditProjector.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/IAuditRecordRepository.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/AuditRecordRepository.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs` | Modify (add `AuditRecords` + `AuditProjectorCursors` DbSets) |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (add `AuditRecords` + `AuditProjectorCursors` DbSets) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (entity config, CHECK, unique index, query filter) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/*` | Create (tenant `audit_records` migration) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/*` | Create (platform `audit_records` migration) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditProjectorBackgroundService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditProjectorOptions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditProjectionMetrics.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/AuditServiceCollectionExtensions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (wire projector + background service) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/SensitiveActionCatalogTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditProjectorTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditRecordScopeIsolationTests.cs` | Create |
+
+> Paths under `apps/tamma-elsa/src/Tamma.Core/Audit/`, `src/Tamma.Data/Audit/`, `src/Tamma.Api/Services/Audit/`, and the `tests/.../Audit/` files are **NEW** (no existing audit package today). `DomainEvent.cs`, `PlatformEvent.cs`, `EventRepository.cs`, `TenantDbContext.cs`, `ControlPlaneDbContext.cs`, `TammaModelConfiguration.cs`, `CredentialRedactor.cs`, `TammaMode.cs`, `AlertRuleEvaluator.cs`, `AlertEvaluatorCursor.cs` are **EXISTING** (verified).
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, and decisions
+3. Read `AlertRuleEvaluator.cs` + `AlertEvaluatorCursor` end-to-end — the projector is a near-clone of its cursor-tracked scan; do not invent a new cursor mechanism
+4. Read `SecretAuditEventTypes` (`ISecretAccessAuditor.cs`) — the catalog mirrors its const-class shape and must remap (not re-emit) its codes
+5. Planned the TDD approach (Red→Green→Refactor)
+
+### Build ON the DCB stream — do not rebuild it
+
+The single biggest failure mode is treating this as "a new event store." It is not. Raw `DomainEvent` / `PlatformEvent` rows stay the immutable source of truth. `audit_records` is a derived, rebuildable read-model with a `source_event_id` back-reference. If `audit_records` is ever wrong or corrupted, the fix is "truncate + reset cursor + re-project," never "patch the row." AC8 + AC15 pin this.
+
+### Why a curated projection at all (vs. querying raw events)
+
+The raw stream is generic (`Type` + opaque JSONB `Tags`/`Data`). Compliance queries ("every secret reveal by user X last quarter, with outcome") need normalized, indexed columns (actor, target, outcome, occurred_at, category, severity) and a stable per-mode ownership key. The projection is the product layer that turns "we have all the events" into "we can answer auditor questions in one indexed query" — which 37-10 then exposes and 37-2 then makes tamper-evident.
+
+### Scope-derivation subtlety
+
+Tenant-scoped vs platform-scoped routing (AC11) is driven by the raw event's `TenantId` AND the process mode. In SaaS: `TenantId` non-null → tenant schema keyed by `tenant_id`; `TenantId` null → CP keyed by `tenant_id` null (platform row). In single-user: every curated row is keyed by `user_id`, `tenant_id` null — there is no tenant dimension. Get this wrong and a platform-internal action (e.g. impersonation against the platform) could surface in a tenant's audit view. The isolation test (AC14) and per-mode test (AC13c) must pin the matrix.
+
+### Redaction is non-negotiable and happens before persistence
+
+`payload_json` is the one field that can leak. Redact with `CredentialRedactor.Clean` (handles bearer tokens, `tamma_sk_` prefixes, key=value assignments, URL basic-auth) BEFORE the row is inserted — never "redact on read." AC10's test is the gate.
+
+### Reserved 37-2 columns
+
+`record_hash` / `prev_record_hash` are added now (nullable, left null) so 37-2 lands without a schema migration on the hot table, and so the projector's strict `source_sequence_number` insertion order gives 37-2 a deterministic chain to hash. Do not populate them in this story.
+
+### No migration anxiety
+
+`audit_records` is additive on both tenant and CP. Run `dotnet ef migrations has-pending-model-changes` after authoring entity config; it must report none. Mirror all entity config in `TammaModelConfiguration.cs` (the single source), not in `OnModelCreating` overrides scattered across contexts.
+
+## Logging Requirements
+
+- **INFO**: projection batch completed (`projectorId`, `domainCursor`, `platformCursor`, `eventsScanned`, `recordsInserted`, `recordsSkipped`, `batchDurationMs`); background service started/stopped.
+- **DEBUG**: per-event classification decision (`eventType`, `matched`, `category`, `severity`); cursor loaded/saved; lag gauge recorded.
+- **WARN**: projection batch tick threw and was crash-isolated (`error`, `lastCursor`); projection lag exceeds threshold (`lag`, `thresholdSeconds`); a catalog-matched event had no resolvable actor/target (`eventType`, `sourceEventId`) — projected with nulls, not dropped.
+- **ERROR**: cursor persistence failed; audit-record insert failed for a non-uniqueness reason; redactor threw (must never silently persist un-redacted payload — fail the row, keep the cursor un-advanced for that event).
+- **Structured context**: include `{ projectorId, sourceEventId, sourceSequenceNumber, actionCode, category, tenantId|userId }` where applicable.
+- **Credential safety**: NEVER log raw `Data` / `Tags` / `payload_json` before redaction; NEVER log secret plaintext, tokens, or passwords. Redact via `CredentialRedactor.Clean` before any payload appears in a log line.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-37/story-37-10/37-10-sensitive-action-audit-emission-coverage.md
+++ b/docs/stories/epic-37/story-37-10/37-10-sensitive-action-audit-emission-coverage.md
@@ -1,0 +1,366 @@
+# Story 37-10: Sensitive-Action Audit Emission Coverage (BYOK, Billing/Plan, Auth/Login, Agent Actions)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **platform owner / compliance reviewer**,
+I want every sensitive action — a tenant API key being set/rotated/removed, a plan or subscription
+change, a login success or failure, a membership/role change, a persona/config edit, an agent action,
+a data export — to emit a curated DCB audit event that lands in the correct scope (tenant vs
+control-plane),
+So that the Story 37-1 catalog is actually fed and the audit trail is complete enough to stand up to
+a SOC2 / GDPR review instead of being silently full of holes.
+
+## Priority
+
+P0 - The 37-1 taxonomy/catalog is worthless if the action sites never emit. This story closes the
+emission gaps that make the audit product trustworthy.
+
+## Context & Boundary
+
+Story 37-1 defines the **catalog** of sensitive-action event types and the projection that lands them
+into `audit_records`. This story (37-10) is the **wiring** story: it instruments the action sites that
+today mutate sensitive state **without** an audit event, mapping each onto the 37-1 catalog.
+
+Target architecture is the C# app **`apps/tamma-elsa`**. The TypeScript `packages/api` tree is
+DELETED and is never a target — the Epic 20 billing/metering path that lived there is re-targeted to
+the C# billing/plan surface (`Plan` / `BudgetConfig` + the admin plan endpoint).
+
+**Reuse, do not re-emit.** Some sites already have a single source of truth:
+- Secret cabinet — `ISecretAccessAuditor.EmitAsync` with `SecretAuditEventTypes.*`
+  (`SECRET.WRITE` / `SECRET.ROTATE.*` / `SECRET.REVEAL` / `SECRET.VERSION.REVOKED`), wired through
+  `SecretQueryService` / `SecretRevealService` / `StopgapSecretMigrator`.
+- Membership / RBAC — `OrgEndpoints.EmitTenantEvent(...)` already emits
+  `TENANT.MEMBER_ROLE_CHANGED.SUCCESS`, `TENANT.MEMBER_REMOVED.SUCCESS`,
+  `TENANT.MEMBER_INVITED.SUCCESS`, `TENANT.MEMBER_INVITE_RESENT.SUCCESS`,
+  `TENANT.MEMBER_JOINED.SUCCESS`.
+- Impersonation — `IMPERSONATION.STARTED` / `IMPERSONATION.ENDED` already exist.
+- Refresh-token reuse — `AUTH.REFRESH_REUSE_DETECTED` already emits a `PlatformEvent`.
+
+For these, this story **maps the existing event type into the 37-1 catalog** (so it surfaces in
+`audit_records`) and adds a coverage test asserting the single emission — it does NOT add a second
+emission at the same site (no double-emission).
+
+The genuinely **silent** sites — BYOK provider-key set/rotate/remove, billing/plan/subscription
+mutations, login success/failure + token refresh + API-key auth, agent-action `agent_id` tagging,
+persona/config edits, data export — get **new** emissions wired here.
+
+## Acceptance Criteria
+
+### Catalog mapping (no double-emission)
+
+1. The 37-1 `SensitiveActionCatalog` (NEW from 37-1, `apps/tamma-elsa/src/Tamma.Core/Audit/`) is
+   extended to include catalog entries for the event types reused from existing emitters — `SECRET.*`,
+   `IMPERSONATION.*`, `TENANT.MEMBER_*`, `AUTH.REFRESH_REUSE_DETECTED` — so they project into
+   `audit_records` **without** any change to their emission sites. A test asserts each is in the
+   catalog and that the existing site still emits exactly one event (no duplicate added).
+
+### BYOK / provider keys
+
+2. Tenant BYOK provider-key changes emit `BYOK.PROVIDER_KEY.SET`, `BYOK.PROVIDER_KEY.ROTATED`,
+   `BYOK.PROVIDER_KEY.REMOVED` at the secret-cabinet write path for `SecretPurpose.ApiKey`
+   tenant-scoped secrets (32-3 credential resolution). The emission carries tags `provider`,
+   `tenantId`, `actor` (user id), and `mode` (`byok` vs `platform-provided`) — aligned with the
+   BYOK-per-tenant constraint. The underlying `SECRET.WRITE`/`SECRET.ROTATE.*` event remains the
+   cabinet's source of truth; the `BYOK.*` event is the **catalog-facing curated** event derived from
+   it (one cabinet write → one `SECRET.*` + one `BYOK.*`, not two cabinet writes).
+
+3. Platform-provided fallback toggles (a tenant flips between BYOK and platform-provided keys for a
+   provider) emit `BILLING.BYOK_MODE_CHANGED` with old/new mode in `data`, tagged `provider`,
+   `tenantId`, `actor`.
+
+### Billing / plan / subscription
+
+4. Plan changes on the C# billing surface emit `BILLING.PLAN_CHANGED` from the admin plan-update path
+   (`AdminTenantsEndpoints` `PLAN.UPDATED` site) — the existing `PLAN.UPDATED` event is mapped into
+   the catalog as `BILLING.PLAN_CHANGED` (or re-typed; see Technical Design) carrying `tenantId`,
+   `actor`, and `{ oldPlanSlug, newPlanSlug }` in `data`, **replacing** the silent Epic 20 TS path.
+
+5. Subscription lifecycle mutations emit `SUBSCRIPTION.CREATED`, `SUBSCRIPTION.UPDATED`,
+   `SUBSCRIPTION.CANCELED` at the subscription state-change site, tagged `tenantId`, `actor`, with
+   plan/period in `data`. (If a subscription entity does not yet exist on the C# surface, these are
+   wired at the `Plan` + `BudgetConfig` mutation sites that stand in for subscription state — see
+   Technical Design / Dependencies.)
+
+### Auth / login
+
+6. The login endpoint emits `AUTH.LOGIN.SUCCESS` on a successful authentication and
+   `AUTH.LOGIN.FAILURE` (with a machine-readable `reason` — `bad_credentials`, `locked_out`,
+   `unverified_email`, etc.) on failure, both carrying `ip` and `user_agent` tags plus `userId`
+   (success) / `email` (failure, redaction-safe). Lockout-triggered failures still emit
+   `AUTH.LOGIN.FAILURE` with `reason=locked_out`.
+
+7. Token refresh emits `AUTH.TOKEN.REFRESHED` (tagged `userId`, `tenantId`, `ip`); the existing
+   `AUTH.REFRESH_REUSE_DETECTED` path is untouched and only mapped into the catalog (AC1).
+
+8. API-key authentication emits `AUTH.APIKEY.USED` from `ApiKeyAuthHandler` on a successful ticket,
+   tagged `tenantId`, `apiKeyPrefix` (NOT the key), `scope`, `ip`. Emission is rate-aware: a hot
+   per-request auth loop is de-duplicated (sampled/throttled) so the audit trail is not flooded — see
+   Technical Design.
+
+### Agent actions
+
+9. Agent actions (Epic 32) carry `agent_id` in their DCB event tags, and the catalog includes
+   `AGENT.ACTION.*` so per-tenant agent action trails appear in `audit_records` scoped to the tenant.
+   Existing `AGENT.DISPATCH.*` / `AGENT.RESULTS.*` / `AGENT_CONFIG.UPDATED.SUCCESS` events gain an
+   `agentId` tag where one is in scope and are mapped into the catalog.
+
+### Persona / config + data export
+
+10. Persona/config changes emit a catalog event — `AGENT_CONFIG.UPDATED.SUCCESS` (already emitted by
+    `AgentEndpoints`) is mapped into the catalog and gains `agentId`; persona edits at the
+    prompt-store / convention-store admin write sites emit `CONFIG.PERSONA_CHANGED` tagged with
+    `scope` (system/tenant), `role`, `action`, `actor`, `tenantId`.
+
+11. Data export actions (audit/DSAR export endpoints) emit `DATA.EXPORT.REQUESTED` /
+    `DATA.EXPORT.COMPLETED` tagged `tenantId`, `actor`, `exportType`, with row/record counts in
+    `data` (never the exported payload).
+
+### Scope routing + safety + coverage
+
+12. Every emission lands in the **correct scope**: tenant-scoped actions (BYOK, plan/subscription,
+    membership, persona/config, tenant agent actions, tenant data export) append to the tenant's
+    `domain_events` stream via `IEventRepository` with `TenantId` set; control-plane / platform-owner
+    actions (platform-owner login, API-key auth at the platform edge, system-scope persona/config,
+    impersonation) append to `platform_events` via `IPlatformEventPublisher` with `TenantId` null.
+    Per-mode: in single-user mode the sole user's actions land in their (only) feed.
+
+13. All new emissions are **redaction-safe** — no key material, no plaintext secret, no card/payment
+    data, no full API key (prefix only). A test feeds a BYOK key-set and asserts the stored
+    `audit_record` carries only metadata (provider, mode, version number) and zero key bytes.
+
+14. **No double-emission**: existing `SECRET.*` / `IMPERSONATION.*` / `TENANT.MEMBER_*` /
+    `AUTH.REFRESH_REUSE_DETECTED` remain the single source for their actions and are mapped into the
+    catalog rather than re-emitted; a coverage test asserts exactly one event per action at each
+    reused site.
+
+15. A **coverage test** enumerates the sensitive-action sites and, per site (BYOK, billing/plan,
+    subscription, login success, login failure, token refresh, API-key auth, agent action,
+    persona/config, data export), asserts: the emitted catalog code matches the 37-1 taxonomy, the
+    required tags (`actor`, `tenantId`/none, plus site-specific) are present, and the 37-1 projection
+    lands the event into `audit_records` in the correct scope.
+
+## Technical Design
+
+### Verified current state (repo @ main, 2026-06-17)
+
+| Site | Today | This story |
+|---|---|---|
+| Secret cabinet (`SecretQueryService`, `SecretRevealService`, `StopgapSecretMigrator`) | Emits `SECRET.*` via `ISecretAccessAuditor.EmitAsync` (`SecretAuditEventTypes`) | Map `SECRET.*` into catalog; derive curated `BYOK.PROVIDER_KEY.*` for `ApiKey`+Tenant writes |
+| `OrgEndpoints.EmitTenantEvent` | Emits `TENANT.MEMBER_*.SUCCESS` to `domain_events` | Map into catalog (no new emission) |
+| Impersonation | `IMPERSONATION.STARTED` / `ENDED` | Map into catalog |
+| `AuthEndpoints.Login` | No login audit event | Emit `AUTH.LOGIN.SUCCESS` / `AUTH.LOGIN.FAILURE` |
+| `AuthEndpoints.Refresh` | `AUTH.REFRESH_REUSE_DETECTED` only (PlatformEvent) | Add `AUTH.TOKEN.REFRESHED`; map reuse event into catalog |
+| `ApiKeyAuthHandler.BuildSuccessTicket` | No auth-usage event | Emit `AUTH.APIKEY.USED` (throttled) |
+| `AdminTenantsEndpoints` plan path | Emits `PLAN.UPDATED` | Re-type/alias to `BILLING.PLAN_CHANGED`; add subscription events |
+| `AgentEndpoints` config path | `AGENT_CONFIG.UPDATED.SUCCESS` (has `tenantId`/`userId`, no `agentId`) | Add `agentId` tag; map into catalog |
+| `AGENT.DISPATCH.*` / `AGENT.RESULTS.*` | Emitted by dispatch path | Add `agentId` tag; catalog `AGENT.ACTION.*` |
+| Audit/DSAR export endpoints (37-x) | (added in 37-1/37-x) | Emit `DATA.EXPORT.REQUESTED` / `COMPLETED` |
+
+### Emission helper
+
+Introduce a single, thin `ISensitiveActionEmitter` (NEW,
+`apps/tamma-elsa/src/Tamma.Api/Services/Audit/`) so every call site emits the same shape and the
+scope-routing decision lives in one place:
+
+```csharp
+public interface ISensitiveActionEmitter
+{
+    /// Append a curated sensitive-action event. Routes to the tenant
+    /// domain_events stream (TenantId set) via IEventRepository, or to
+    /// platform_events (TenantId null) via IPlatformEventPublisher.
+    /// Never throws to the caller — an audit-sink outage must not roll
+    /// back the action that already happened (mirrors ISecretAccessAuditor).
+    Task EmitAsync(SensitiveAction action, CancellationToken ct = default);
+}
+
+public sealed record SensitiveAction(
+    string Type,                       // must be a SensitiveActionCatalog code (37-1)
+    Guid? TenantId,                    // null => platform/control-plane scope
+    Guid? ActorUserId,
+    IReadOnlyDictionary<string, string?> Tags,   // provider, mode, ip, userAgent, ...
+    IReadOnlyDictionary<string, object?> Data);  // redaction-safe payload only
+```
+
+- **Validation:** `EmitAsync` rejects (logs + drops, never throws) a `Type` that is not in
+  `SensitiveActionCatalog` so a typo can't silently create an un-cataloged event.
+- **Scope routing:** `TenantId != null` → `IEventRepository.AppendAsync(DomainEvent{ TenantId, ... })`
+  (the established `OrgEndpoints.EmitTenantEvent` pattern); `TenantId == null` →
+  `IPlatformEventPublisher.AppendAndPublishAsync(PlatformEvent{ ... })`.
+- **Metadata** follows the repo convention: `{"workflowVersion":"1.0.0","eventSource":"system"}`.
+- **Redaction:** `Tags`/`Data` are caller-supplied; the emitter additionally runs a guard that strips
+  known-secret keys (`key`, `apiKey`, `token`, `password`, `secret`, `connectionString`, `card`,
+  `cardNumber`) defensively, and asserts no value matches the `tamma_sk_` / `sk-` / PEM prefixes.
+
+### Per-mode / per-tenant placement
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Who owns a tenant-scope sensitive action (BYOK, plan, persona, tenant agent action, export)? | The sole user — `TenantId` is their personal tenant; lands in their feed. | The tenant — `TenantId` set; lands in the tenant's `domain_events` (visible to `tenant_owner`/`tenant_admin`). |
+| Who owns a control-plane action (platform-owner login, impersonation, system-scope persona/config)? | The user (only one principal). | Platform owner — `platform_events`, `TenantId` null, never exposed to tenants. |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`) — process-stable | same |
+
+### Site wiring notes
+
+- **BYOK** (AC2/AC3): the curated `BYOK.PROVIDER_KEY.*` event is derived **alongside** the existing
+  `SECRET.*` emission — the natural seam is a decorator/observer on `ISecretAccessAuditor` (or a call
+  to `ISensitiveActionEmitter` inside the secret facade) gated on
+  `Reference.Purpose == ApiKey && Reference.Scope == Tenant`. `provider` is read from the secret's
+  consumer ref / metadata; `mode` is `byok` for a tenant-scoped key and `platform-provided` when the
+  tenant resolves the platform key (32-3 credential resolution decides which). One cabinet write
+  produces one `SECRET.WRITE` AND one `BYOK.PROVIDER_KEY.SET` (catalog-facing) — they are NOT two
+  writes.
+- **Auth** (AC6-8): `AuthEndpoints.Login` and `Refresh` resolve `ISensitiveActionEmitter` as a
+  `[FromServices]` parameter. `ApiKeyAuthHandler` resolves it from its injected `IServiceProvider`
+  (the handler already resolves services that way). `ip`/`user_agent` come from
+  `HttpContext.Connection.RemoteIpAddress` / `User-Agent` header. `AUTH.LOGIN.SUCCESS` is tenant- or
+  platform-scoped per the resolved active tenant; `AUTH.LOGIN.FAILURE` is platform-scoped (no trusted
+  tenant yet) and carries only the submitted email + reason (redaction-safe).
+- **API-key auth throttle** (AC8): `AUTH.APIKEY.USED` must not emit on every request. Throttle keyed
+  on `(apiKeyId, coarse time bucket)` (e.g. one event per key per N minutes) using the existing
+  in-process throttle pattern (`TokenBucketAlertRateLimiter` / `AlertRuleEvaluator` throttle) so a
+  busy key produces a heartbeat, not a flood.
+- **Billing** (AC4/5): re-type the `PLAN.UPDATED` emission in `AdminTenantsEndpoints` to
+  `BILLING.PLAN_CHANGED` (keep `PLAN.UPDATED` as a legacy alias in the catalog if dashboards depend on
+  it). Subscription events wire at the subscription-state mutation; if no subscription entity exists
+  yet, wire at the `Plan`/`BudgetConfig` change sites that represent subscription state and document
+  the gap in Dev Notes.
+- **Agent** (AC9/10): thread `agentId` into the `Tags` of `AGENT.DISPATCH.*` / `AGENT.RESULTS.*` /
+  `AGENT_CONFIG.UPDATED.SUCCESS`. The 32-6 trail expects `agent_id` on every agent DCB event so
+  per-tenant agent action trails are reconstructable.
+- **Export** (AC11): emit at the audit/DSAR export endpoint(s) introduced by 37-1/37-x — paired
+  `DATA.EXPORT.REQUESTED` (on accept) and `DATA.EXPORT.COMPLETED` (on finish) with counts only.
+
+## Dependencies
+
+- **Prerequisite**: Story 37-1 (sensitive-action **catalog** + `audit_records` projection — this
+  story extends the catalog and asserts the projection lands events). `SensitiveActionCatalog.cs` is
+  NEW from 37-1.
+- **Prerequisite / parallel**: Epic 29 (secret cabinet — `ISecretAccessAuditor`, `SecretQueryService`,
+  `SecretPurpose.ApiKey`) for the BYOK write path.
+- **Prerequisite / parallel**: Epic 32 — 32-3 (credential resolution: decides byok vs
+  platform-provided) and 32-6 (agent action trail: `agent_id` tagging).
+- **Re-targeted from**: Epic 20 (billing/plan/usage state — the silent TS `packages/api` path is
+  replaced by the C# `Plan` / `BudgetConfig` + admin plan endpoint surface).
+- **Related**: Epic 16 / 18 (auth, login, refresh, lockout — `AuthEndpoints`, `ApiKeyAuthHandler`,
+  `LoginLockoutService`); Epic 34 / 35 (billing/plan surface).
+- **Reuses**: `IEventRepository` / `IPlatformEventPublisher` (DCB/PlatformEvent emission),
+  `OrgEndpoints.EmitTenantEvent` pattern, `ISecretAccessAuditor`.
+
+## Testing Strategy
+
+Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/` (xUnit; docker-bound suites run via
+`sg docker -c "dotnet test ..."`). TDD — write the assertion first.
+
+1. **Catalog mapping**: every reused event type (`SECRET.*`, `IMPERSONATION.*`, `TENANT.MEMBER_*`,
+   `AUTH.REFRESH_REUSE_DETECTED`) and every new type (`BYOK.*`, `BILLING.*`, `SUBSCRIPTION.*`,
+   `AUTH.LOGIN.*`, `AUTH.TOKEN.REFRESHED`, `AUTH.APIKEY.USED`, `AGENT.ACTION.*`, `CONFIG.PERSONA_CHANGED`,
+   `DATA.EXPORT.*`) is present in `SensitiveActionCatalog`.
+2. **No double-emission**: a membership role change emits exactly one `TENANT.MEMBER_ROLE_CHANGED.SUCCESS`;
+   a secret write emits exactly one `SECRET.WRITE` + one `BYOK.PROVIDER_KEY.SET` (not two of either).
+3. **Per emission site** (the AC15 coverage test): BYOK set/rotate/remove, BYOK-mode toggle, plan
+   change, subscription create/update/cancel, login success, login failure (each reason), token
+   refresh, API-key auth, agent dispatch + results, persona/config edit, data export — assert catalog
+   code, tags (`actor`, `tenantId`/null, site-specific), and that the 37-1 projection writes the
+   `audit_record` to the correct scope.
+4. **Redaction**: feed a BYOK key-set with a real-looking `tamma_sk_...` value; assert the stored
+   `audit_record` `Tags`/`Data` contain zero key bytes (only provider/mode/version metadata). Same
+   for plan change (no card data) and login (no password).
+5. **Scope routing**: tenant-scoped action → `domain_events` row with `TenantId` set; platform action
+   → `platform_events` row with `TenantId` null. Cross-tenant leakage test: a tenant audit query
+   never returns another tenant's sensitive-action rows.
+6. **Throttle**: 100 API-key auths in one bucket → one (or sampled-N) `AUTH.APIKEY.USED`, not 100.
+7. **Never-throws**: emitter swallows a sink/DB failure (logged) and does NOT break the login,
+   secret write, or plan update.
+8. **Mode matrix**: single-user vs SaaS drives whether a system-scope action is platform-only or in
+   the sole user's feed.
+
+## Estimated Effort
+
+5-6 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Core/Audit/SensitiveActionCatalog.cs` | Modify (NEW from 37-1; add reused + new entries) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/ISensitiveActionEmitter.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/SensitiveActionEmitter.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/SensitiveAction.cs` | Create (record + scope-routing types) |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/AuditEmissionServiceCollectionExtensions.cs` | Create (DI wiring; map in `Program.cs`) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Secrets/ISecretAccessAuditor.cs` (or a decorator) | Modify (derive `BYOK.PROVIDER_KEY.*` for ApiKey+Tenant writes) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AuthEndpoints.cs` | Modify (login success/failure, token refresh) |
+| `apps/tamma-elsa/src/Tamma.Api/Auth/ApiKeyAuthHandler.cs` | Modify (`AUTH.APIKEY.USED`, throttled) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminTenantsEndpoints.cs` | Modify (`BILLING.PLAN_CHANGED`, subscription events) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs` | Modify (`agentId` tag, catalog mapping) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs` | Modify (catalog mapping only — no new emission) |
+| Persona/config write sites (prompt-store / convention-store admin endpoints) | Modify (`CONFIG.PERSONA_CHANGED`) |
+| Audit/DSAR export endpoint(s) (37-1/37-x) | Modify (`DATA.EXPORT.*`) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (register emitter) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/SensitiveActionEmitterTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/SensitiveActionCoverageTests.cs` | Create (AC15 per-site coverage) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/ByokEmissionTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuthEmissionTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, decisions
+3. Read the Story 37-1 catalog + `audit_records` projection so you extend (not fork) the catalog
+4. Confirmed which existing events already cover a site BEFORE adding a new emission (the
+   reuse-vs-new decision is the crux of this story; see the verified-current-state table)
+5. Planned a TDD approach (Red-Green-Refactor)
+
+### The one rule that prevents most of the bugs here
+
+**Decide reuse-vs-new per site, write that down, and test it.** The biggest failure mode is
+double-emission (a second event for an action that already audits) or, worse, a `BYOK.*` event that
+re-writes the secret to derive its payload. The curated catalog event is derived **from** the existing
+emission, side by side, never by re-doing the action.
+
+### Scope routing is load-bearing for tenant isolation
+
+A sensitive-action event written to the wrong stream is a compliance leak: a tenant-scope BYOK event
+in `platform_events` is invisible to the tenant's own audit view; a platform-owner action in a tenant
+`domain_events` stream leaks operator activity to the tenant. The single `ISensitiveActionEmitter`
+exists specifically so this decision is made in one tested place, not duplicated at 12 call sites.
+
+### Never-throws contract
+
+Mirror `ISecretAccessAuditor`: an audit-sink outage must NOT roll back the action that already
+happened. The emitter logs and swallows; it never turns a successful login or secret write into a 500.
+
+### Redaction is asserted, not assumed
+
+The AC13 test must feed a real-looking secret value through a BYOK key-set and assert zero key bytes
+land in the stored `audit_record`. The defensive strip in the emitter is belt-and-suspenders on top of
+callers passing only metadata.
+
+## Logging Requirements
+
+- **INFO**: Sensitive-action event emitted (`type`, `tenantId`/`platform`, `actor`), API-key-usage
+  heartbeat emitted (sampled).
+- **DEBUG**: Per-site emission detail (tags assembled), throttle suppressed an `AUTH.APIKEY.USED`.
+- **WARN**: Emitter dropped an event because `Type` is not in the catalog (typo guard); redaction
+  guard stripped an unexpected secret-shaped value (indicates a caller bug — fix the caller).
+- **ERROR**: Emitter sink/DB write failed (logged + swallowed; the action is NOT rolled back).
+- **Structured context**: `{ eventType, tenantId, actorUserId, scope }` where applicable.
+- **Credential safety**: NEVER log key material, plaintext secrets, card data, or full API keys
+  (prefix only).
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-37/story-37-11/37-11-soc2-aligned-control-mapping-and-evidence-pack.md
+++ b/docs/stories/epic-37/story-37-11/37-11-soc2-aligned-control-mapping-and-evidence-pack.md
@@ -1,0 +1,390 @@
+# Story 37-11: SOC2-Aligned Control Mapping & Evidence Pack
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **platform owner preparing for a SOC2 Type II audit** (and as a **tenant under their own attestation**),
+I want a declarative control catalog that maps SOC2 Trust Services Criteria to the Tamma features that satisfy them (auth/RBAC, secret cabinet encryption, audit logging, access reviews, backups, change management), plus an on-demand, signed evidence pack that bundles the supporting audit excerpts, chain-verification results, retention/legal-hold state, and config attestations for a chosen period,
+So that the raw audit machinery built in Epic 37 becomes a usable compliance posture report — each control shows its status (satisfied / gap), its supporting evidence, and any findings — that an auditor can be handed directly.
+
+## Priority
+
+P2 — turns the audit substrate into auditor-facing compliance product; required for Tamma's own SOC2 and for tenant attestations.
+
+## Context & Boundary
+
+This story is the **compliance product layer** that sits on top of the Epic 37 audit substrate. It does **not** create new audit events, retention machinery, or hash-chain logic — it **reads** them and **maps** them to a control framework.
+
+- **Target codebase**: C# `apps/tamma-elsa`. Control-catalog domain logic lives in `Tamma.Core`; evidence-pack collection + endpoints live in `Tamma.Api`; persistence/read-models live in `Tamma.Data`.
+- **`packages/api` is DELETED** — it is never a target. All compliance code is C#.
+- **Per-mode** (mandatory two-scoping-model answer, per CLAUDE.md "Operating Modes"): a control's *status* and its *evidence* are scoped differently in single-user vs SaaS — see [Per-Mode Ownership](#per-mode-ownership) below. The endpoint shape is identical between modes; auth middleware decides scope.
+- **Scope split**: platform-level (Tamma's own SOC2 — `PlatformOwnerAccess`) is the primary surface; per-tenant (a tenant under their own attestation — `tenant_owner`/`tenant_admin`) is the secondary surface and sees **only tenant-scoped evidence**, never platform internals.
+
+### Dependency status (verified 2026-06-17, repo @ main)
+
+The dependency stories supply the read-models and machinery this story consumes. Several are **not yet built** — this story declares the seams it binds to and marks them NEW where the artifact does not exist on disk today.
+
+| Dep | Supplies | On disk today? |
+|---|---|---|
+| 37-1 | Curated audit read-model (`AuditRecord` entity + query API) | **NEW** — no `AuditRecord` entity exists in `Tamma.Data/Entities/`; this story reads it via the 37-1 query service |
+| 37-2 | Hash-chain verification result over the audit read-model | **NEW** — no hash-chain verifier exists yet |
+| 37-3 | Audit query/search API | **NEW** |
+| 37-4 | Signed/encrypted/expiring export machinery (`AuditExportService`) | **NEW** — no `AuditExportService` exists; evidence pack reuses it |
+| 37-5 | Retention policy snapshot | **NEW** |
+| 37-6 | Legal-hold state | **NEW** |
+| 37-10 | Audit dashboard surfaces (this story adds a control-status tab) | **NEW** |
+
+**Real, verified controls this story maps to** (these exist on disk and are the *evidence sources* the catalog points at):
+
+| Control area | Real artifact (verified) |
+|---|---|
+| Auth / RBAC | `src/Tamma.Api/Program.cs` policies (`OwnerAccess`, `PlatformOwnerAccess`, `MemberAccess`); `src/Tamma.Api/Auth/Permissions.cs`; `src/Tamma.Api/Authorization/TenantRoleHierarchy.cs`, `RequireTenantMembershipFilter.cs` |
+| Encryption / secret cabinet (Epic 29) | `src/Tamma.Api/Services/Secrets/` (KEK provider, `KekRotationCoordinator`, `SecretRow`/`SecretVersionRow`); AES-GCM at rest via `TenantSecretProtector` |
+| Audit logging | `src/Tamma.Data/Entities/DomainEvent.cs` (+ `SequenceNumber`); `IEventRepository.AppendAsync`; `ISecretAccessAuditor` (`SECRET.READ/WRITE/ROTATE.*/REVEAL/VERSION.REVOKED`) |
+| Access / change monitoring | `src/Tamma.Api/Services/Alerts/` (`IAlertSink.RaiseAsync`, `AlertRuleEvaluator`); `AdminImpersonation` entity + `AdminImpersonationService` |
+| Change management | `src/Tamma.Data/Entities/WorkflowDefinition.cs`, `WorkflowInstance.cs`; `KekRotation` entity |
+| Backups (Epic 28) | `src/Tamma.Api/Services/Provisioning/TenantMoveService.cs`; tenant-database pool placement; `Cranl` backup capability flags |
+
+## Acceptance Criteria
+
+1. **Declarative ControlCatalog.** A code-resident, immutable `ControlCatalog` (`src/Tamma.Core/Compliance/ControlCatalog.cs`) maps each in-scope SOC2 criterion (at minimum CC6.x logical access, CC7.x monitoring/incident, CC8.x change management; plus CC1/CC2 governance and A1 availability where Tamma has supporting evidence) to a `ControlDefinition` carrying: the **required catalog action codes** (real audit event types, e.g. `SECRET.REVEAL`, `SECRET.ROTATE.SUCCESS`, `ALERT.RAISED`), a **retention floor** (minimum days the supporting evidence must be retained), a **chain-verification requirement** (bool: does this control require hash-chain integrity over its evidence), the **RBAC policy** that enforces the control (e.g. `PlatformOwnerAccess`), and an **ISO 27001 Annex A cross-reference** where the criteria overlap (informational).
+
+2. **No orphan references.** Every action code referenced by the catalog resolves to a real, emitted event type. A test enumerates the catalog and asserts each referenced action code is a known/emitted type (cross-checked against the audit catalog from 37-1/37-3 and the constants in `ISecretAccessAuditor`, alert event types, etc.) — the build fails if a control points at a non-existent code.
+
+3. **Platform control-status endpoint.** `GET /api/admin/compliance/controls` (**`PlatformOwnerAccess`**) returns every control with: identity (criterion id, title, category, ISO xref), `status` (`satisfied` | `gap`), `lastEvidenceAt` (most recent supporting audit record timestamp), `supportingRecordCount`, retention/chain requirements, and the enforcing RBAC policy.
+
+4. **Tenant control-status endpoint.** `GET /api/v1/orgs/{tenantId}/compliance/controls` (`tenant_owner`/`tenant_admin`; `member` → read-only list or 403 on any future mutation) returns the same shape but evaluated against **tenant-scoped evidence only** — platform-internal controls (e.g. KEK rotation, platform backups, seed/config gaps) are **never** included in the tenant view.
+
+5. **Gap detection with actionable findings.** A `ControlEvaluator` flags a control as `gap` when (a) it has **no supporting evidence in the lookback window** (e.g. an access-review control with no access-review/impersonation event in N days, default configurable `Compliance:EvidenceLookbackDays`), or (b) the effective retention for its evidence is **below the control's floor**, or (c) chain verification is required but the latest 37-2 verification **failed**. Each gap carries a human-readable `finding` string and a `remediationHint`.
+
+6. **Evidence-pack generation (async, signed).** `POST /api/admin/compliance/evidence-pack` (`PlatformOwnerAccess`) and `POST /api/v1/orgs/{tenantId}/compliance/evidence-pack` (tenant scope) accept `{ periodStart, periodEnd, criteria?: string[] }`, return **`202 Accepted`** with a job/artifact id, and run the long collection on the existing platform task-queue thread (mirrors the provisioning/KEK-rotation `Results.Accepted` pattern). The generated bundle contains: the **control → evidence map** (each control with its supporting audit excerpts pulled via the 37-1/37-3 query API), the **hash-chain verification result** (37-2), the **retention policy snapshot** (37-5), the **legal-hold state** (37-6), and a **coverage summary** (counts of satisfied vs gap controls, per-category rollup).
+
+7. **Evidence pack reuses export machinery & is encrypted/expiring.** Bundle production goes through the 37-4 `AuditExportService` (NEW) so the artifact is **signed**, **encrypted at rest**, and **expiring** exactly like other audit exports — no bespoke crypto in this story. `GET .../compliance/evidence-pack/{id}` returns generation status (`pending → collecting → signing → ready`/`failed`) and, when ready, a short-lived download reference.
+
+8. **Evidence pack is itself signed AND audited.** Generation emits `COMPLIANCE.EVIDENCE_PACK.GENERATED` (sensitive, audited) via `IEventRepository.AppendAsync` with tags `{ scope, tenantId?, periodStart, periodEnd, criteriaCount, coverageSatisfied, coverageGap, mode }`; a download emits `COMPLIANCE.EVIDENCE_PACK.DOWNLOADED`. The signature over the bundle is verifiable independently of Tamma (signature + the public verification material are included in the pack manifest), so an auditor can confirm the pack was not tampered with after generation.
+
+9. **Per-mode scoping is honored.** In **single-user** mode the sole user (their JWT) sees system + their own evidence as one feed (`tenantId` null). In **SaaS** mode platform controls are `PlatformOwnerAccess`-only and never leak to tenants; tenant controls are `tenantId`-scoped via the existing `/api/v1/orgs/{tenantId}/*` path-tenant gate. Mode is read from `ITammaModeProvider` (`src/Tamma.Api/Services/PromptStore/TammaMode.cs`).
+
+10. **Control-status report/dashboard data shape.** The platform endpoint additionally exposes a `GET /api/admin/compliance/controls/summary` rollup (counts by category and status, oldest-gap age, last evidence-pack timestamp) suitable for a dashboard widget on the 37-10 audit dashboard (UI itself is a thin add in 37-10; this story ships the data + DTO).
+
+11. **RBAC enforced end-to-end.** Platform endpoints reject non-`platform_admin` callers (403); tenant endpoints reject cross-tenant access (404 — never reveal existence) and reject `member`-role mutations (403). A test matrix covers platform-owner / tenant_owner / tenant_admin / member / cross-tenant.
+
+12. **Evidence-pack artifact lifecycle is audited & bounded.** Expired/failed packs are not downloadable (410/404); the artifact id is opaque (no PII / criterion leakage in the id); the manifest never embeds secret material (the secret cabinet is *attested to*, never *exported*).
+
+13. **Config attestations are point-in-time and signed into the pack.** The pack includes a `ConfigAttestation` section: a redacted snapshot of compliance-relevant configuration (encryption-at-rest enabled, KEK rotation cadence, retention policy floors, alert channels configured count, mode) — **values that prove a control's posture, never the secrets themselves** (no API keys, no connection strings). The attestation is collected at generation time and covered by the pack signature.
+
+14. **Tests.** (a) Catalog maps to real catalog codes — no orphan references (AC2); (b) gap detection fires on missing/aged evidence, sub-floor retention, and failed chain verification; (c) evidence-pack signature round-trips (generate → verify signature → tamper → verify fails); (d) RBAC per mode (AC11 matrix); (e) tenant view never contains platform-scope controls; (f) `COMPLIANCE.EVIDENCE_PACK.GENERATED` event emitted exactly once per successful generation with correct tags.
+
+## Technical Design
+
+### Component layout
+
+```
+src/Tamma.Core/Compliance/                         # NEW directory — pure, dependency-light
+  ControlCatalog.cs            # immutable list of ControlDefinition (the framework map)
+  ControlDefinition.cs         # record: CriterionId, Title, Category, IsoXref,
+                               #   RequiredActionCodes[], RetentionFloorDays,
+                               #   RequiresChainVerification, RbacPolicy, Scope (Platform|Tenant)
+  TrustServiceCriteria.cs      # SOC2 TSC enum/constants (CC1..CC9, A1, C1, PI1, P1..)
+  ControlStatus.cs             # record: status, lastEvidenceAt, supportingRecordCount,
+                               #   finding?, remediationHint?
+  ControlScope.cs              # Platform | Tenant
+
+src/Tamma.Api/Services/Compliance/                 # NEW directory
+  IControlEvaluator.cs
+  ControlEvaluator.cs          # reads 37-1/37-3 audit read-model + 37-5 retention +
+                               #   37-2 chain result → produces ControlStatus per control
+  IEvidencePackService.cs
+  EvidencePackService.cs       # orchestrates collection → 37-4 AuditExportService (sign/encrypt)
+  EvidencePackJob.cs           # status record (pending/collecting/signing/ready/failed)
+  ConfigAttestationCollector.cs# redacted point-in-time config snapshot (AC13)
+  ComplianceEventTypes.cs      # COMPLIANCE.EVIDENCE_PACK.GENERATED / .DOWNLOADED
+  EvidencePackTaskHandler.cs   # IPlatformTaskHandler — runs the async collection (AC6)
+
+src/Tamma.Api/Endpoints/
+  ComplianceEndpoints.cs       # NEW — admin section + tenant section (mirror AlertEndpoints.cs)
+
+src/Tamma.Data/Entities/
+  EvidencePackArtifact.cs      # NEW — persisted pack metadata (id, scope, tenant_id, period,
+                               #   status, coverage counts, expires_at, signature_ref)
+```
+
+### ControlDefinition (catalog row)
+
+```csharp
+// src/Tamma.Core/Compliance/ControlDefinition.cs  (NEW)
+public sealed record ControlDefinition(
+    string CriterionId,            // "CC6.1"
+    string Title,                  // "Logical access controls restrict ..."
+    string Category,               // "CC6 — Logical & Physical Access"
+    string? IsoXref,               // "A.9.2.x" (informational overlap)
+    IReadOnlyList<string> RequiredActionCodes, // real event types that evidence this control
+    int RetentionFloorDays,        // evidence must be retained >= this
+    bool RequiresChainVerification,
+    string RbacPolicy,             // "PlatformOwnerAccess"
+    ControlScope Scope);           // Platform | Tenant
+```
+
+### Catalog excerpt (illustrative — real action codes only)
+
+```csharp
+// src/Tamma.Core/Compliance/ControlCatalog.cs  (NEW)
+public static class ControlCatalog
+{
+    public static readonly IReadOnlyList<ControlDefinition> All = new[]
+    {
+        new ControlDefinition(
+            CriterionId: "CC6.1",
+            Title: "The entity implements logical access security controls (RBAC, least privilege).",
+            Category: "CC6 — Logical and Physical Access",
+            IsoXref: "A.9.2",
+            RequiredActionCodes: new[] { "USER.LOGIN.SUCCESS", "ADMIN.IMPERSONATION.STARTED" },
+            RetentionFloorDays: 365,
+            RequiresChainVerification: true,
+            RbacPolicy: "PlatformOwnerAccess",
+            Scope: ControlScope.Platform),
+
+        new ControlDefinition(
+            CriterionId: "CC6.7",
+            Title: "Data at rest is encrypted (secret cabinet, KEK-wrapped secrets).",
+            Category: "CC6 — Logical and Physical Access",
+            IsoXref: "A.10.1",
+            RequiredActionCodes: new[] { "SECRET.ROTATE.SUCCESS", "SECRET.VERSION.REVOKED" },
+            RetentionFloorDays: 365,
+            RequiresChainVerification: true,
+            RbacPolicy: "PlatformOwnerAccess",
+            Scope: ControlScope.Platform),
+
+        new ControlDefinition(
+            CriterionId: "CC7.2",
+            Title: "Security events are monitored and alerted on.",
+            Category: "CC7 — System Operations",
+            IsoXref: "A.12.4",
+            RequiredActionCodes: new[] { "ALERT.RAISED" },
+            RetentionFloorDays: 180,
+            RequiresChainVerification: false,
+            RbacPolicy: "PlatformOwnerAccess",
+            Scope: ControlScope.Platform),
+
+        new ControlDefinition(
+            CriterionId: "CC8.1",
+            Title: "Changes are authorized, tested, and tracked (workflow defs, KEK rotation).",
+            Category: "CC8 — Change Management",
+            IsoXref: "A.12.1.2",
+            RequiredActionCodes: new[] { "SECRET.ROTATE.STARTED", "SECRET.ROTATE.SUCCESS" },
+            RetentionFloorDays: 365,
+            RequiresChainVerification: true,
+            RbacPolicy: "PlatformOwnerAccess",
+            Scope: ControlScope.Platform),
+        // ... tenant-scope controls (e.g. tenant access reviews, tenant data export logging)
+        //     carry Scope = ControlScope.Tenant.
+    };
+}
+```
+
+> **AC2 enforcement:** a test enumerates `ControlCatalog.All.SelectMany(c => c.RequiredActionCodes)` and asserts each is present in the audit-catalog known-codes set (from 37-1/37-3) ∪ `ISecretAccessAuditor` constants ∪ alert/known event types. Any orphan fails the build. (Where a 37-1 dependency code is not yet emitted on disk, the test asserts against the **declared** catalog from 37-1 — the seam — and is marked pending until 37-1 lands; see Dev Notes.)
+
+### ControlEvaluator
+
+```csharp
+// src/Tamma.Api/Services/Compliance/ControlEvaluator.cs  (NEW)
+public sealed class ControlEvaluator : IControlEvaluator
+{
+    // deps (all NEW seams from dep stories + real existing services):
+    //   IAuditQuery auditQuery            // 37-1/37-3 read-model query (NEW)
+    //   IChainVerifier chainVerifier      // 37-2 (NEW)
+    //   IRetentionPolicyReader retention  // 37-5 (NEW)
+    //   ITammaModeProvider mode           // existing — TammaMode.cs
+    //   IOptions<ComplianceOptions> opts  // EvidenceLookbackDays etc.
+
+    public async Task<ControlStatus> EvaluateAsync(
+        ControlDefinition control, ComplianceScopeKey scope, CancellationToken ct)
+    {
+        // 1. count + latest supporting record in lookback window via auditQuery
+        // 2. effective retention for the control's evidence via retention reader
+        // 3. chain verification result (only if control.RequiresChainVerification)
+        // gap when: no evidence in window, OR retention < floor, OR chain failed.
+    }
+}
+```
+
+### Evidence pack — async generation through 37-4 export
+
+```csharp
+// POST .../compliance/evidence-pack -> 202 + { artifactId }
+// 1. ComplianceEndpoints validates period + (optional) criteria filter, RBAC, scope.
+// 2. Persists EvidencePackArtifact { status = pending }, enqueues a PlatformQueuedTask.
+// 3. EvidencePackTaskHandler (IPlatformTaskHandler) runs on the existing
+//    PlatformTaskWorker thread:
+//       collecting -> build control->evidence map (auditQuery excerpts),
+//                     chain result (37-2), retention snapshot (37-5),
+//                     legal-hold state (37-6), config attestation (AC13),
+//                     coverage summary.
+//       signing    -> hand the assembled bundle to AuditExportService (37-4) which
+//                     signs + encrypts + sets expiry. Store signature_ref + expires_at.
+//       ready      -> append COMPLIANCE.EVIDENCE_PACK.GENERATED (sensitive, audited).
+// 4. GET .../evidence-pack/{id} reports status; when ready returns short-lived ref.
+//    Download appends COMPLIANCE.EVIDENCE_PACK.DOWNLOADED.
+```
+
+The handler **never** invents crypto — `AuditExportService` (37-4) owns sign/encrypt/expiry so the evidence pack inherits the same tamper-evidence guarantees and expiry policy as every other audit export.
+
+### Endpoints (mirror `AlertEndpoints.cs` admin + tenant sections)
+
+```
+# Platform (PlatformOwnerAccess)
+GET  /api/admin/compliance/controls                  -> ControlStatus[] (platform scope)
+GET  /api/admin/compliance/controls/summary          -> coverage rollup (AC10)
+POST /api/admin/compliance/evidence-pack             -> 202 { artifactId }
+GET  /api/admin/compliance/evidence-pack/{id}        -> status / download ref
+GET  /api/admin/compliance/evidence-packs            -> paged list (50/500)
+
+# Tenant (tenant_owner / tenant_admin; member read-only)
+GET  /api/v1/orgs/{tenantId}/compliance/controls     -> ControlStatus[] (tenant scope ONLY)
+POST /api/v1/orgs/{tenantId}/compliance/evidence-pack-> 202 { artifactId }
+GET  /api/v1/orgs/{tenantId}/compliance/evidence-pack/{id}
+```
+
+Tenant routes attach to the existing `/api/v1/orgs/{tenantId}` group (path-tenant gate, `Program.cs` ~1505–1512) and filter the catalog to `Scope == Tenant`. The admin group mirrors the `AlertEndpoints` admin section (paging defaults 50/500).
+
+### Per-Mode Ownership
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who sees **platform-scope** controls/evidence (KEK rotation, backups, seed config)? | The sole user — it's their instance; one feed, `tenantId` null. | Platform owner ONLY (`PlatformOwnerAccess`). Never exposed to tenants — would leak platform internals. |
+| Who sees **tenant-scope** controls (tenant access reviews, tenant data-export logging)? | The sole user (`tenantId` null; same XOR as the rest of the schema). | `tenant_owner`/`tenant_admin` via `/api/v1/orgs/{tenantId}/...`; `member` read-only. |
+| Who can generate an evidence pack? | The user. | Platform-scope pack: platform owner. Tenant-scope pack: tenant_owner/tenant_admin (or platform owner). |
+| Where is `COMPLIANCE.EVIDENCE_PACK.GENERATED` tagged? | `tenantId` null. | Platform pack → `tenantId` null (admin feed); tenant pack → `tenantId` set (tenant feed). |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`) — process-stable. | same |
+
+### Persistence
+
+```csharp
+// src/Tamma.Data/Entities/EvidencePackArtifact.cs  (NEW)
+public class EvidencePackArtifact
+{
+    public Guid Id { get; set; }
+    public string Scope { get; set; } = "platform"; // platform | tenant
+    public Guid? TenantId { get; set; }             // set for tenant scope; null otherwise
+    public DateTime PeriodStart { get; set; }
+    public DateTime PeriodEnd { get; set; }
+    public string Status { get; set; } = "pending"; // pending|collecting|signing|ready|failed
+    public int CoverageSatisfied { get; set; }
+    public int CoverageGap { get; set; }
+    public string? SignatureRef { get; set; }       // reference into 37-4 export store
+    public DateTime CreatedAt { get; set; }
+    public DateTime? ExpiresAt { get; set; }         // mirrors 37-4 export expiry
+}
+```
+
+Additive EF migration under `src/Tamma.Data/Migrations/ControlPlane/`; entity config in `TammaModelConfiguration.cs` (single source per repo convention). Verify `has-pending-model-changes` reports none after the migration. Per CLAUDE.md "no migration anxiety" — additive, no data backfill.
+
+## Dependencies
+
+- **Prerequisite 37-1** (audit read-model): `ControlEvaluator` reads supporting records via the 37-1 query service; AC2 catalog cross-check uses the 37-1 known-codes set. **NEW** on disk.
+- **Prerequisite 37-2** (hash chain): chain-verification requirement on controls consumes 37-2's verifier result. **NEW**.
+- **Prerequisite 37-3** (query/search API): evidence excerpts in the pack are pulled via 37-3. **NEW**.
+- **Prerequisite 37-4** (export machinery): evidence pack is produced through `AuditExportService` for sign/encrypt/expiry. **NEW**.
+- **Prerequisite 37-5** (retention): retention policy snapshot in the pack + sub-floor gap detection. **NEW**.
+- **Prerequisite 37-6** (legal hold): legal-hold state section of the pack. **NEW**.
+- **Related 37-10** (audit dashboard): this story ships the control-status data + DTO for a thin dashboard widget. **NEW**.
+- **Reuses (real, on disk)**: Epic 29 secret cabinet (`Services/Secrets/`) and Epic 28 backup/move (`TenantMoveService`) as *evidence sources*; `IAlertSink`/`AlertRuleEvaluator`; `IEventRepository`; `ITammaModeProvider`; `PlatformTaskWorker`/`IPlatformTaskHandler` for async generation; `TenantRoleHierarchy`/`RequireTenantMembershipFilter` for RBAC; auth policies in `Program.cs`.
+
+## Testing Strategy
+
+Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/Compliance/` (xUnit) and `tests/Tamma.Core.Tests/Compliance/`. Docker-bound suites run via `sg docker -c "dotnet test ..."`.
+
+1. **Catalog integrity (Core, no DB)**: `ControlCatalog.All` has unique criterion ids; every `RequiredActionCodes` entry resolves to a known/emitted event type (AC2 — no orphans); every control carries a valid `RbacPolicy` and `Scope`.
+2. **Gap detection (Api)**: with a stubbed `IAuditQuery`/`IRetentionPolicyReader`/`IChainVerifier` — control with no evidence in window → `gap` + finding; evidence present but retention < floor → `gap`; chain required + verification failed → `gap`; everything satisfied → `satisfied` with `lastEvidenceAt` + count.
+3. **Evidence-pack signature round-trip**: generate (handler) → bundle signed by 37-4 stub → verify signature passes → mutate a byte → verify fails. Asserts the pack is tamper-evident.
+4. **Async lifecycle**: `POST` returns 202 + artifact id with status `pending`; running the task handler transitions `collecting → signing → ready`; `GET` reflects each state; failure path sets `failed` and is not downloadable.
+5. **RBAC per mode (AC11 matrix)**: platform endpoint — platform_admin 200, non-admin 403; tenant endpoint — tenant_owner/tenant_admin 200, member read-only/403 on generate, cross-tenant 404; single-user mode — sole user sees platform + tenant controls in one list.
+6. **Tenant-view isolation**: `GET /api/v1/orgs/{id}/compliance/controls` never returns a `Scope == Platform` control; never another tenant's evidence.
+7. **Event emission**: successful generation appends exactly one `COMPLIANCE.EVIDENCE_PACK.GENERATED` with correct tags (scope, tenantId?, period, coverage counts, mode); download appends `COMPLIANCE.EVIDENCE_PACK.DOWNLOADED`.
+8. **Config attestation redaction (AC13)**: attestation section contains posture booleans/counts and **no** secret values (assert no connection string / API-key shaped strings appear).
+
+## Estimated Effort
+
+4–5 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Core/Compliance/ControlCatalog.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Core/Compliance/ControlDefinition.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Core/Compliance/TrustServiceCriteria.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Core/Compliance/ControlStatus.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Core/Compliance/ControlScope.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/IControlEvaluator.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/ControlEvaluator.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/IEvidencePackService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/EvidencePackService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/EvidencePackJob.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/ConfigAttestationCollector.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/EvidencePackTaskHandler.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/ComplianceEventTypes.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/ComplianceEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/ComplianceServiceCollectionExtensions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/EvidencePackArtifact.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/*_AddEvidencePackArtifact.cs` | Create (EF gen) |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (DbSet) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (entity config) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map endpoints + register services) |
+| `apps/tamma-elsa/tests/Tamma.Core.Tests/Compliance/ControlCatalogTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Compliance/ControlEvaluatorTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Compliance/EvidencePackServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Compliance/ComplianceEndpointsTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, and decisions (esp. any audit/compliance spikes from Epic 37).
+3. Confirmed the **dependency seams**: 37-1 (`IAuditQuery`/known-codes), 37-2 (`IChainVerifier`), 37-4 (`AuditExportService`), 37-5 (`IRetentionPolicyReader`), 37-6 (legal-hold reader). These are **NEW** — if a dependency interface is not yet on disk, define the consuming seam as an interface in this story and bind to the real implementation when the dependency lands; do not duplicate the dependency's logic.
+4. Planned TDD (Red-Green-Refactor); the catalog-integrity test (AC2) is the first red test.
+
+### Dependency-not-yet-landed handling
+
+This story's primary content — the **ControlCatalog** and **per-mode RBAC/endpoints** — is buildable today against the real existing controls (auth, secret cabinet, alerts, audit events). The evidence-*collection* paths depend on 37-1/37-3/37-4/37-5/37-6 read-models. Code against narrow consumer interfaces (`IAuditQuery`, `IChainVerifier`, `IRetentionPolicyReader`, `ILegalHoldReader`, `AuditExportService`); where the dependency is unmerged, ship the interface + a test double and gate the live wiring behind the dependency's DI registration. **Never** target `packages/api` (deleted) and **never** re-implement a dependency's machinery here.
+
+### Why a code-resident catalog (not a DB table)
+
+The control framework is **policy-as-code**: it ships with Tamma, is reviewed in PRs, and must be version-controlled for the audit trail (a catalog change is itself a change-management event). Mirrors the precedent of `SystemPrompts.cs` (system defaults in code) and `BuiltInAlertRules.cs` (built-in rules in code, seeded idempotently). Only the *generated artifacts* (`EvidencePackArtifact`) and the *evidence* (DCB events) live in the DB.
+
+### Config attestation must never become a secret exfiltration path
+
+AC13 is deliberately narrow: the attestation proves **posture** (encryption-at-rest = true, KEK rotation cadence = 90d, retention floor = 365d, mode = SaaS, alert channels configured = 3) — never the secret material itself. The `ConfigAttestationCollector` reads only non-sensitive config and explicitly excludes anything from the secret cabinet, connection strings, or API keys. The redaction test (Testing #8) is load-bearing.
+
+### Async generation reuses the platform task queue
+
+Evidence-pack collection (audit excerpts across a period + chain verify + retention + legal hold) is long-running, so it follows the established 202-Accepted + `PlatformTaskWorker`/`IPlatformTaskHandler` pattern (same as tenant provisioning and KEK rotation — see `AdminEndpoints.cs` ~442 / `KekRotationEndpoints.cs` ~54). Do not block the request thread.
+
+### Event-store topology (Story 28-1 / Epic 30 forward-compat)
+
+`COMPLIANCE.EVIDENCE_PACK.*` events append to the CP `DomainEvents` store via `IEventRepository` (what `AlertRuleEvaluator` polls). Platform-scope evidence-pack events must stay **CP-resident**; tenant-scope events follow the per-tenant fan-out when Epic 30 lands — keep the recorder explicit about scope so the migration only touches tenant routing.
+
+## Logging Requirements
+
+- **INFO**: evidence-pack requested (scope, tenantId?, period, criteriaCount); pack ready (artifactId, coverageSatisfied/Gap, durationMs); control-status endpoint queried (scope, controlCount, gapCount); pack downloaded (artifactId).
+- **DEBUG**: per-control evaluation result (criterionId, status, supportingRecordCount, lastEvidenceAt); task-queue state transition (collecting/signing/ready).
+- **WARN**: control flagged `gap` with finding (criterionId, reason — no-evidence / sub-floor-retention / chain-failed); evidence-pack generation retried.
+- **ERROR**: evidence-pack generation failed (artifactId, stage, error); 37-4 export sign/encrypt failure; chain-verifier (37-2) unavailable.
+- **Structured context**: include `{ scope, tenantId, criterionId, artifactId, periodStart, periodEnd, mode }` where applicable.
+- **Credential safety**: NEVER log secret cabinet material, connection strings, API keys, or signature private material. The config attestation log line logs **counts/booleans only**, never values.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-37/story-37-12/37-12-admin-and-tenant-audit-dashboard-ui.md
+++ b/docs/stories/epic-37/story-37-12/37-12-admin-and-tenant-audit-dashboard-ui.md
@@ -1,0 +1,489 @@
+# Story 37-12: Admin & Tenant Audit Dashboard UI
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **platform owner** (and, separately, as a **tenant admin/owner**),
+I want operator-facing audit & compliance pages that render the Epic 37 audit query/export/chain-verification/legal-hold/DSAR APIs,
+So that I can investigate sensitive actions, prove tamper-evidence, satisfy GDPR data-subject requests, and manage retention/legal holds — each principal seeing only the audit they are entitled to, gated by per-mode RBAC.
+
+## Priority
+
+P1 — The audit/compliance APIs (37-2..37-9, 37-11) are useless to operators without a UI; this story is the human surface of the entire epic.
+
+## Architecture Note (read first — deviates from the raw spec)
+
+The story spec's `primaryComponents` named the Blazor `apps/tamma-elsa/src/Tamma.Studio` app for the
+admin surface. **This story deliberately re-targets the admin audit UI onto the React
+`packages/dashboard` app** for three verified reasons:
+
+1. `packages/dashboard` is the live admin/platform dashboard (deployed at app.tamma.dev) and already
+   ships an **`AuditLogTab` stub** (`packages/dashboard/src/pages/admin/AuditLogTab.tsx`) explicitly
+   marked "Full implementation will be wired when the audit-log API lands" — this story lands it.
+2. The tenant audit surface lives in the React `packages/dashboard-user` app (per the spec and the
+   `feat/wave-b` architecture); keeping admin in React too means one component library, one test
+   stack (Vitest + Testing Library), and one API-client pattern across both surfaces.
+3. The C# `Tamma.Studio` Blazor app has no audit pages today and is the Elsa-engine operator console,
+   not the customer-facing audit product.
+
+`packages/api` is **deleted** and is NOT a target of this story. The audit/compliance HTTP APIs this
+UI consumes are owned by the C# control-plane (`apps/tamma-elsa/src/Tamma.Api`), shipped by the
+dependency stories (37-2..37-9, 37-11). This story ships **only** the two React dashboards plus their
+typed API clients and route/guard wiring.
+
+## Per-Mode Ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+Every audit surface must answer "in single-user mode, who owns this?" AND "in SaaS mode, who owns
+this?" The UI mirrors the server-side scoping; it never decides authorization (the server is
+authoritative) but it must not render controls the caller can't use, and must never request
+cross-tenant data.
+
+| Surface | single-user mode | SaaS mode |
+|---|---|---|
+| **Tenant audit page** (`packages/dashboard-user`) | The sole user sees their own audit records (their instance). Owner-only actions are always available (they are the owner). | `tenant_admin`/`tenant_owner` see their tenant's audit; `member` sees a read-only audit view (or no nav entry). Cross-tenant reads 404 server-side; the UI only ever sends the caller's active `tenantId`. |
+| **Platform audit page** (`packages/dashboard`) | The sole user IS the platform owner — sees the platform audit log + impersonation/chain/evidence controls. | `PlatformOwnerAccess` only. Tenant users have no admin nav entry; a deep-linked route renders the existing 403 `ForbiddenPage`. |
+| **Retention editor / legal holds (owner-only)** | The user (they are owner). | `tenant_owner` mutates; `tenant_admin` read-only; `member` 403. |
+| **DSAR / erasure request** | The user. | `tenant_admin`+ submits; `member` 403 on submit. |
+
+Mode is process-stable server-side; the UI does not branch on mode. It branches on the caller's
+**role** (`user.role` from `/api/auth/me`) and tenant (`user.tenantId`). In single-user mode the sole
+user's role resolves to owner-equivalent, so owner-only controls appear — exactly the desired
+single-user behavior with zero mode-specific UI code.
+
+## Acceptance Criteria
+
+1. **Tenant audit page exists and is reachable.** `packages/dashboard-user` gains an `/audit` route
+   (under `AuthGuard` → `AppLayout`) rendering a `TenantAuditPage` that lists the caller's own audit
+   records via `GET /api/v1/orgs/{tenantId}/audit` (37-3). A nav entry "Audit" is added to
+   `AppLayout`. The page only ever sends `user.tenantId`; it has no UI affordance to query another
+   tenant.
+
+2. **Tenant audit table: filters, facets, pagination.** The audit table supports the 37-3 filter set
+   (actor, action/event-type, category, severity, resource id, date range) plus severity/category
+   facet chips, and **keyset (cursor) pagination** ("Load more" / next-cursor) — never offset
+   pagination — so a 100k+ row trail pages without a slow `COUNT(*)`. Active filters are reflected in
+   the request and round-trip on refresh.
+
+3. **Tenant audit export.** An "Export" button submits the current filter set to `POST
+   /api/v1/orgs/{tenantId}/audit/export` (37-4) and the client downloads via the returned
+   **time-limited signed URL** (37-4). The export request carries exactly the filters shown, so the
+   exported view matches the on-screen view. No raw artifact/object-store URLs are ever rendered or
+   logged — only the signed, expiring export URL is used, and it is opened, not persisted in app
+   state beyond the click.
+
+4. **Chain-verification status badge.** The tenant audit page shows a chain-verification status badge
+   sourced from `GET /api/v1/orgs/{tenantId}/audit/chain/verify` (37-2): `verified`
+   (green), `tampered`/`broken` (red, with the first broken sequence/range surfaced), or `pending`
+   (neutral) while the check runs. A manual "Re-verify" action re-requests it.
+
+5. **Tenant Compliance sub-pages.** `packages/dashboard-user` settings gain Compliance controls:
+   - **Retention policy editor** (37-5) at `/settings/compliance/retention` — read for admin, edit
+     for owner; a `member` sees 403.
+   - **Legal Holds** (37-6) at `/settings/compliance/legal-holds` — list + place + release; place/
+     release are owner-only; the list is read-only for admin.
+   - **DSAR + Erasure requests** (37-7/37-8) at `/settings/compliance/data-requests` — submit a DSAR
+     export or a right-to-erasure request and poll job status (`pending → running → completed/failed`)
+     with the completed DSAR download served via a signed URL (37-4 pattern).
+   - **Consent history** (37-9) at `/settings/compliance/consent` — read-only timeline of consent
+     grant/revoke events for the tenant's data subjects.
+
+6. **Platform audit page exists (PlatformOwnerAccess).** `packages/dashboard` gains a platform Audit &
+   Compliance surface by wiring the existing `AuditLogTab` (today a "Coming soon" stub) to `GET
+   /api/admin/audit` (37-3): the platform-wide audit log with the same filter/facet/keyset-pagination
+   capabilities as the tenant view. The whole admin route is already behind `AdminGuard`
+   (`PlatformOwnerAccess` server-side); a non-owner deep-linking the route hits `ForbiddenPage`.
+
+7. **Platform impersonation log.** The platform Audit page surfaces active + historical impersonation
+   sessions by reusing the existing `AdminImpersonationsEndpoints`: active sessions from `GET
+   /api/admin/impersonations/active`, history filtered from the platform audit log
+   (`IMPERSONATION.STARTED`/`IMPERSONATION.ENDED` events). Each row shows impersonator → target,
+   reason, started/ended timestamps, and the `impersonationId` that joins the event stream to the
+   `admin_impersonations` audit row.
+
+8. **Platform chain verification + evidence pack.** The platform Audit page exposes (a) a chain-verify
+   action over the platform audit log (37-2) with the same badge semantics as AC4, and (b) an
+   **evidence-pack generation** control (37-11): submit a date range + scope, kick off the pack job,
+   poll status, and download the completed pack via its signed URL (37-4 pattern). No raw artifact
+   URLs are exposed.
+
+9. **Platform legal-hold management.** The platform Audit page lists all legal holds across tenants
+   (37-6) and lets the platform owner place/release a hold scoped to a tenant or resource. (Tenant-
+   scoped place/release also lives in the tenant Compliance page per AC5; this is the cross-tenant
+   admin view.)
+
+10. **RBAC enforced in the UI per mode — no cross-tenant, no over-privilege.** SaaS `member` users get
+    no admin nav entry and a 403 on any direct admin route; on the tenant side a `member` either gets
+    a read-only audit view or no nav entry per the table above, and owner-only mutations (retention
+    edit, legal-hold place/release) are hidden/disabled for non-owners. The single-user variant shows
+    the user-owned surface with owner-level controls. **Every tenant request is keyed to the caller's
+    active `tenantId` only** — the UI never constructs a URL for another tenant, and relies on the
+    server returning 404 for cross-tenant attempts (defense in depth).
+
+11. **Meta-audit + signed-URL contract honored.** Every audit read from the UI is a normal `GET` that
+    the server records as the `AUDIT.QUERIED` meta-audit (37-3) — the UI adds no header to suppress
+    it. All downloads (export, DSAR, evidence pack) use the **time-limited signed-export URLs** (37-4);
+    the client never receives, renders, persists, or logs a raw object-store/artifact URL.
+
+12. **Loading / empty / error / large-table states.** Each surface renders distinct loading, empty,
+    and error states (error states are `role="alert"`). The audit table virtualizes rows (windowed
+    rendering) so a 100k+ row trail scrolls without freezing the main thread; keyset pagination caps
+    the working set per page. A failed signed-URL fetch or expired URL surfaces a retryable error, not
+    a broken download.
+
+13. **Tests: component + RBAC-per-mode + isolation + e2e.** Vitest + Testing Library cover the audit
+    table (rows/filters/facets/keyset "load more"), the chain badge states, the export trigger
+    (asserts the request body equals the shown filters and that the signed URL — not a raw URL — is
+    used), and the retention/legal-hold/DSAR/consent forms (validation, owner-only gating, job-status
+    polling). RBAC guard tests assert: SaaS `member` → no nav + read-only/403; `tenant_admin` →
+    read-only where owner-only actions exist; owner → full controls; single-user → user-owned variant.
+    An **isolation test** asserts the tenant client never builds a URL for a tenant other than
+    `user.tenantId`. An e2e/integration test (mocked API) walks tenant-audit → filter → export and
+    admin-audit → chain-verify → evidence-pack.
+
+## Technical Design
+
+### Surface map
+
+```
+packages/dashboard-user/  (tenant audit — dash.tamma.dev)
+  src/api/
+    audit.ts                      # NEW — tenant audit query/export/chain client (37-3/37-4/37-2)
+    compliance.ts                 # NEW — retention/legal-hold/DSAR/erasure/consent client (37-5..37-9)
+    audit.test.ts                 # NEW
+    compliance.test.ts            # NEW
+  src/pages/audit/
+    TenantAuditPage.tsx           # NEW — table + filters + facets + keyset paging + chain badge + export
+    TenantAuditPage.test.tsx      # NEW
+  src/pages/settings/compliance/
+    RetentionPolicyPage.tsx       # NEW (37-5)
+    LegalHoldsPage.tsx            # NEW (37-6)
+    DataRequestsPage.tsx          # NEW (37-7/37-8: DSAR + erasure + job status)
+    ConsentHistoryPage.tsx        # NEW (37-9)
+    *.test.tsx                    # NEW (one per page)
+  src/components/audit/
+    AuditTable.tsx                # NEW — virtualized table (shared by tenant page)
+    AuditFilters.tsx              # NEW — filter bar + facet chips
+    ChainStatusBadge.tsx          # NEW
+    JobStatusPoller.tsx           # NEW — shared poll-until-terminal helper component/hook
+    *.test.tsx                    # NEW
+  src/App.tsx                     # MODIFY — add /audit + /settings/compliance/* routes + guards
+  src/layouts/AppLayout.tsx       # MODIFY — add "Audit" + "Compliance" nav entries (role-aware)
+
+packages/dashboard/  (platform audit — app.tamma.dev admin panel)
+  src/services/admin/
+    audit-api-client.ts           # NEW — platform audit + chain + evidence + impersonation client
+    compliance-api-client.ts      # NEW — cross-tenant legal-hold client (37-6)
+    audit-api-client.test.ts      # NEW
+  src/pages/admin/
+    AuditLogTab.tsx               # MODIFY — replace stub viewer with the wired platform audit page
+    AuditLogTab.test.tsx          # MODIFY — extend existing test
+    audit/
+      PlatformAuditPanel.tsx      # NEW — audit table + filters + chain verify
+      ImpersonationPanel.tsx      # NEW — active + history (AdminImpersonationsEndpoints)
+      EvidencePackPanel.tsx       # NEW — generate + poll + signed-URL download (37-11)
+      LegalHoldAdminPanel.tsx     # NEW — cross-tenant legal holds (37-6)
+      *.test.tsx                  # NEW
+  src/pages/admin/AdminLayout.tsx # MODIFY — relabel "Audit Log" tab → "Audit & Compliance" (optional)
+```
+
+The `AuditTable`, `AuditFilters`, and `ChainStatusBadge` are authored in `dashboard-user` first (the
+tenant page is the simpler instance) and the platform panel re-implements the same shape against the
+admin client. (Cross-package component sharing is out of scope — the two apps don't import each other;
+duplication of ~150 lines of presentational table code is the accepted trade-off, matching how
+`alerts.ts` is duplicated between the two apps today.)
+
+### API clients (NEW — consume dependency-story endpoints)
+
+The audit/compliance HTTP endpoints are owned by `apps/tamma-elsa/src/Tamma.Api` and shipped by
+37-2..37-9 / 37-11. These clients are the only new "API" code; they follow the existing client
+patterns exactly: `dashboard-user` uses the shared `ApiClient` (`src/api/client.ts`, refresh-on-401
+built in); `dashboard` uses the `fetchJSON` helper in `services/admin/`.
+
+Tenant client (`packages/dashboard-user/src/api/audit.ts`), mirroring `api/alerts.ts`:
+
+```typescript
+import { apiClient } from './client';
+
+export type AuditSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
+export interface AuditRecordDto {
+  id: string;
+  sequence: number;            // chain position (37-2)
+  eventType: string;           // AGGREGATE.ACTION.STATUS
+  category: string;
+  severity: AuditSeverity;
+  actor: string;
+  actorId: string | null;
+  resourceType: string | null;
+  resourceId: string | null;
+  tenantId: string | null;
+  occurredAt: string;          // ISO 8601
+  summary: string;
+}
+export interface AuditQuery {
+  actor?: string;
+  eventType?: string;
+  category?: string;
+  severity?: AuditSeverity;
+  resourceId?: string;
+  from?: string;               // ISO 8601
+  to?: string;                 // ISO 8601
+  cursor?: string;             // keyset cursor — NOT a page number
+  limit?: number;              // default 100
+}
+export interface AuditPage {
+  items: AuditRecordDto[];
+  nextCursor: string | null;   // null ⇒ end of trail
+}
+export interface ChainVerifyResult {
+  status: 'verified' | 'tampered' | 'pending';
+  verifiedThrough: number | null;
+  firstBrokenSequence: number | null;
+  checkedAt: string;
+}
+export interface ExportTicket { downloadUrl: string; expiresAt: string; format: string; }
+
+export async function queryTenantAudit(tenantId: string, q: AuditQuery): Promise<AuditPage> { /* GET /api/v1/orgs/{tenantId}/audit?... */ }
+export async function verifyTenantChain(tenantId: string): Promise<ChainVerifyResult> { /* GET .../audit/chain/verify */ }
+export async function exportTenantAudit(tenantId: string, q: AuditQuery, format: 'csv' | 'jsonl'): Promise<ExportTicket> { /* POST .../audit/export */ }
+```
+
+`compliance.ts` adds `getRetentionPolicy`/`putRetentionPolicy` (37-5), `listLegalHolds`/
+`placeLegalHold`/`releaseLegalHold` (37-6), `submitDsarRequest`/`submitErasureRequest`/`getJobStatus`
+(37-7/37-8), `listConsentHistory` (37-9) — all keyed to `tenantId`, all over `apiClient`.
+
+Admin client (`packages/dashboard/src/services/admin/audit-api-client.ts`), mirroring
+`admin-api-client.ts` (`fetchJSON`, `credentials: 'include'`): `queryPlatformAudit`,
+`verifyPlatformChain`, `listActiveImpersonations` (reusing `GET /api/admin/impersonations/active`),
+`generateEvidencePack` + `getEvidencePackStatus` (37-11), and cross-tenant `listLegalHolds`/
+`placeLegalHold`/`releaseLegalHold` (37-6).
+
+### Keyset pagination & virtualization
+
+- The table requests `limit` rows + an opaque `cursor`; the server returns `nextCursor`. "Load more"
+  appends the next page; the working set is the accumulated rows. This avoids `OFFSET`/`COUNT(*)` on a
+  100k+ trail.
+- Row virtualization: render only the visible window (a lightweight windowing approach — e.g. a fixed
+  row height + `IntersectionObserver` sentinel that triggers the next keyset fetch). No new heavy
+  dependency is required; if `@tanstack/react-virtual` is already in the dashboard dep tree it may be
+  used, otherwise a hand-rolled windowing hook keeps the bundle lean. **Verify the dep tree before
+  adding a library.**
+
+### Signed-URL download contract (37-4)
+
+Export / DSAR / evidence-pack downloads NEVER expose a raw object-store URL. The flow is: POST the
+job/export request → receive `{ downloadUrl, expiresAt }` where `downloadUrl` is a short-lived signed
+URL → trigger the browser download (anchor click / `window.open`) → discard the URL. The client must
+not store the signed URL in long-lived state, must not log it, and must surface an "expired — retry"
+error if the signed URL 403s.
+
+### Routing & guards
+
+`dashboard-user/src/App.tsx` adds:
+
+```
+/audit                              AuthGuard → AppLayout → TenantAuditPage          (members read-only)
+/settings/compliance/retention      AuthGuard → TenantAdminGuard → AppLayout → RetentionPolicyPage
+/settings/compliance/legal-holds    AuthGuard → TenantAdminGuard → AppLayout → LegalHoldsPage
+/settings/compliance/data-requests  AuthGuard → TenantAdminGuard → AppLayout → DataRequestsPage
+/settings/compliance/consent        AuthGuard → TenantAdminGuard → AppLayout → ConsentHistoryPage
+```
+
+Owner-only controls inside admin-guarded pages are gated by an inline `role === 'owner'` check
+(retention edit, legal-hold place/release) — `TenantAdminGuard` admits admin+owner; the finer
+owner-only split is done in-page exactly as `TenantAlertFeed` gates ack/resolve by role.
+
+`dashboard` admin routes are already inside `AdminGuard`; no new route is needed — the existing
+`audit-log` tab in `AdminLayout` becomes the entry point.
+
+### Component behavior cribbed from existing exemplars
+
+- Filter bar + table + modal patterns follow `dashboard-user/src/pages/alerts/TenantAlertFeed.tsx`
+  (filters, `role`-gated action buttons, `Modal`, `SeverityPill`, `role="alert"` error banner).
+- The tab-wiring and feature-flag fallback follow `dashboard/src/pages/admin/AuditLogTab.tsx`
+  (the `VITE_FEATURE_ADMIN_AUDIT_LOG` flag may stay as the kill-switch; flip its default to enabled
+  once the 37-3 admin endpoint is confirmed live).
+
+## Dependencies
+
+- **Prerequisite (hard): Story 37-3** — Audit query/search API (`GET /api/v1/orgs/{tenantId}/audit`,
+  `GET /api/admin/audit`, filters, keyset pagination, the `AUDIT.QUERIED` meta-audit). The entire
+  audit table renders this. Until 37-3 lands the tenant page and `AuditLogTab` stay behind their
+  feature flags / show the "API pending" placeholder.
+- **Prerequisite (hard): Story 37-4** — Export API + time-limited signed URLs. All downloads (export,
+  DSAR, evidence pack) go through the signed-URL contract.
+- **Prerequisite: Story 37-2** — Chain verification API. Powers the chain status badge + re-verify.
+- **Prerequisite: Story 37-5** — Retention policy API (retention editor page).
+- **Prerequisite: Story 37-6** — Legal hold API (tenant + cross-tenant legal-hold panels).
+- **Prerequisite: Story 37-7 / 37-8** — DSAR export + right-to-erasure APIs + job status (data-requests
+  page).
+- **Related: Story 37-9** — Consent logging API (consent history page).
+- **Prerequisite: Story 37-11** — Evidence-pack generation API (admin evidence-pack panel).
+- **Reuses (already shipped): `AdminImpersonationsEndpoints`** —
+  `apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminImpersonationsEndpoints.cs`
+  (`GET /api/admin/impersonations/active`, `PlatformOwnerAccess`).
+- **Builds on (already shipped):** `packages/dashboard` admin shell (`AdminLayout`, `AdminGuard`,
+  `services/admin/admin-api-client.ts`, the `AuditLogTab` stub); `packages/dashboard-user` shell
+  (`App.tsx`, `AppLayout`, `AuthGuard`, `TenantAdminGuard`, `api/client.ts`, `api/alerts.ts`,
+  `useAuth`).
+
+**Sequencing note:** This is a UI-only story and can be drafted/scaffolded in parallel with its
+dependencies behind feature flags, but it cannot be marked done until 37-3 and 37-4 are live (the two
+hard prerequisites every page depends on). The chain/legal-hold/DSAR/evidence sub-features go live as
+their respective dependency endpoints land.
+
+## Testing Strategy
+
+1. **Component tests (Vitest + Testing Library), colocated `*.test.tsx`:**
+   - `AuditTable`: renders rows from a mocked `AuditPage`; applying a filter re-queries with the right
+     params; "Load more" appends the next keyset page and stops when `nextCursor` is null; empty +
+     error states.
+   - `ChainStatusBadge`: `verified`/`tampered`/`pending` render distinct, accessible states; "Re-verify"
+     re-requests.
+   - `AuditFilters`: facet chips toggle category/severity; date-range round-trips into the query.
+   - Export: clicking Export posts the **current** filter set (assert request body equals shown
+     filters) and downloads via the returned signed URL; an expired/403 signed URL shows a retry error.
+   - Retention/legal-hold/DSAR/consent pages: form validation, owner-only gating (admin sees
+     read-only), job-status polling transitions (`pending → running → completed`) drive the download
+     button enable.
+2. **RBAC-per-mode guard tests:** mock `useAuth`/`useCurrentUser` to return owner / tenant_admin /
+   member / single-user; assert nav entries, route guards (member → no admin nav + 403 on admin route;
+   member → read-only or no tenant-audit nav), and owner-only control visibility. Mirror existing
+   `guards/__tests__/` and `AdminLayout.test.tsx` patterns.
+3. **Isolation test:** spy on `apiClient`/`fetch`; assert the tenant client only ever issues URLs
+   containing `user.tenantId` — feeding a different tenant id must be impossible from the UI (no input
+   that accepts a foreign tenant id), and the client surfaces a server 404 cleanly when one is forced
+   in a test.
+4. **e2e/integration (mocked API, MSW or fetch-mock):** tenant flow audit → filter → export →
+   signed-URL download; admin flow audit → chain-verify badge → evidence-pack generate/poll/download;
+   assert no raw artifact URL ever appears in the DOM or in any logged value.
+5. **Large-table behavior:** render a mocked 100k-row source through the virtualized table; assert only
+   a windowed subset is in the DOM and scrolling/"Load more" does not block (smoke-level — full perf
+   profiling is out of scope, but the windowing assertion guards regressions).
+6. **Run:** `pnpm test --filter @tamma/dashboard-user` and `pnpm test --filter @tamma/dashboard` green;
+   `pnpm typecheck` clean for both; no new ESLint errors.
+
+## Estimated Effort
+
+6-7 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `packages/dashboard-user/src/api/audit.ts` | Create |
+| `packages/dashboard-user/src/api/audit.test.ts` | Create |
+| `packages/dashboard-user/src/api/compliance.ts` | Create |
+| `packages/dashboard-user/src/api/compliance.test.ts` | Create |
+| `packages/dashboard-user/src/components/audit/AuditTable.tsx` | Create |
+| `packages/dashboard-user/src/components/audit/AuditFilters.tsx` | Create |
+| `packages/dashboard-user/src/components/audit/ChainStatusBadge.tsx` | Create |
+| `packages/dashboard-user/src/components/audit/JobStatusPoller.tsx` | Create |
+| `packages/dashboard-user/src/components/audit/AuditTable.test.tsx` | Create |
+| `packages/dashboard-user/src/components/audit/AuditFilters.test.tsx` | Create |
+| `packages/dashboard-user/src/components/audit/ChainStatusBadge.test.tsx` | Create |
+| `packages/dashboard-user/src/pages/audit/TenantAuditPage.tsx` | Create |
+| `packages/dashboard-user/src/pages/audit/TenantAuditPage.test.tsx` | Create |
+| `packages/dashboard-user/src/pages/settings/compliance/RetentionPolicyPage.tsx` | Create |
+| `packages/dashboard-user/src/pages/settings/compliance/LegalHoldsPage.tsx` | Create |
+| `packages/dashboard-user/src/pages/settings/compliance/DataRequestsPage.tsx` | Create |
+| `packages/dashboard-user/src/pages/settings/compliance/ConsentHistoryPage.tsx` | Create |
+| `packages/dashboard-user/src/pages/settings/compliance/RetentionPolicyPage.test.tsx` | Create |
+| `packages/dashboard-user/src/pages/settings/compliance/LegalHoldsPage.test.tsx` | Create |
+| `packages/dashboard-user/src/pages/settings/compliance/DataRequestsPage.test.tsx` | Create |
+| `packages/dashboard-user/src/pages/settings/compliance/ConsentHistoryPage.test.tsx` | Create |
+| `packages/dashboard-user/src/App.tsx` | Modify (routes + guards) |
+| `packages/dashboard-user/src/layouts/AppLayout.tsx` | Modify (nav entries) |
+| `packages/dashboard/src/services/admin/audit-api-client.ts` | Create |
+| `packages/dashboard/src/services/admin/audit-api-client.test.ts` | Create |
+| `packages/dashboard/src/services/admin/compliance-api-client.ts` | Create |
+| `packages/dashboard/src/pages/admin/audit/PlatformAuditPanel.tsx` | Create |
+| `packages/dashboard/src/pages/admin/audit/ImpersonationPanel.tsx` | Create |
+| `packages/dashboard/src/pages/admin/audit/EvidencePackPanel.tsx` | Create |
+| `packages/dashboard/src/pages/admin/audit/LegalHoldAdminPanel.tsx` | Create |
+| `packages/dashboard/src/pages/admin/audit/PlatformAuditPanel.test.tsx` | Create |
+| `packages/dashboard/src/pages/admin/audit/ImpersonationPanel.test.tsx` | Create |
+| `packages/dashboard/src/pages/admin/audit/EvidencePackPanel.test.tsx` | Create |
+| `packages/dashboard/src/pages/admin/AuditLogTab.tsx` | Modify (wire viewer) |
+| `packages/dashboard/src/pages/admin/__tests__/AuditLogTab.test.tsx` | Modify (extend) |
+| `packages/dashboard/src/pages/admin/AdminLayout.tsx` | Modify (relabel tab — optional) |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, and decisions (esp. anything on audit/DCB,
+   signed URLs, or tenant isolation in the dashboards).
+3. Confirmed the 37-3 / 37-4 endpoint shapes against the as-built `apps/tamma-elsa/src/Tamma.Api`
+   audit endpoints — **the DTOs sketched above are the contract this story expects; reconcile with the
+   real endpoint responses before coding the clients.** If a field name differs, the client is the
+   single place it's mapped.
+4. Verified whether a virtualization library is already in the dashboard dep tree before adding one
+   (`pnpm why @tanstack/react-virtual` in each package).
+5. Planned the TDD approach (Red-Green-Refactor) — these are pure React components with a fetch seam;
+   mock the client, write the component test first.
+
+### Why React, not Tamma.Studio
+
+The spec named `Tamma.Studio` (Blazor). This story targets the React `packages/dashboard` instead
+because that is the live admin product with the existing `AuditLogTab` stub waiting for exactly this
+API, and it keeps both audit surfaces on one component/test stack. See the Architecture Note above.
+`packages/api` is deleted and is never a target.
+
+### Tenant isolation is the load-bearing invariant
+
+The server is authoritative (cross-tenant reads 404 behind `RequireTenantMembershipFilter`), but the
+UI must never even *attempt* a cross-tenant request: the tenant client takes `tenantId` only from
+`user.tenantId` (`useAuth`), there is no free-text tenant-id input on tenant pages, and the isolation
+test pins this. The platform (cross-tenant) view lives exclusively in `packages/dashboard` behind
+`AdminGuard`/`PlatformOwnerAccess`.
+
+### Signed URLs only
+
+Treat any raw artifact/object-store URL as a leak. Downloads always go through the 37-4 signed-URL
+ticket; never store it past the click, never log it, and handle expiry as a retryable error.
+
+### Meta-audit is automatic
+
+Audit reads are plain `GET`s; the server records `AUDIT.QUERIED` (37-3) on its side. The UI does
+nothing special — and must NOT send any "skip audit" header. Do not add request de-duplication that
+would hide reads from the meta-audit.
+
+### Feature flags as kill-switches
+
+`AuditLogTab` already gates on `VITE_FEATURE_ADMIN_AUDIT_LOG`. Keep a flag per surface as a deploy
+kill-switch so the UI can ship ahead of, or be disabled independently of, the backing endpoints.
+
+## Logging Requirements
+
+(Browser/dashboard logging — `console`/structured client logger; no server-side Pino here.)
+
+- **INFO:** audit query issued (surface, filter summary — never PII values, never the signed URL),
+  chain verification requested + result status, export/DSAR/evidence-pack job submitted + terminal
+  status.
+- **DEBUG:** keyset page fetched (cursor in/out, row count), job-status poll tick (job id + state),
+  filter changes.
+- **WARN:** signed-URL download expired/403 (retry surfaced), job ended `failed`, audit query returned
+  an error the page recovered from.
+- **ERROR:** unrecoverable load failure for a surface (renders the `role="alert"` error state).
+- **Structured context:** include `{ surface, tenantId?, jobId?, eventType?, cursor? }` where
+  applicable.
+- **Credential / PII safety:** NEVER log signed URLs, raw artifact URLs, actor PII (emails/ids beyond
+  what the row already shows), or any export payload. The signed URL is treated as a secret.
+- **Cross-tenant safety:** the tenant surface logs only the caller's own `tenantId`; it can never log
+  another tenant's id because it can never request one.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-37/story-37-2/37-2-tamper-evident-hash-chain-over-audit-records.md
+++ b/docs/stories/epic-37/story-37-2/37-2-tamper-evident-hash-chain-over-audit-records.md
@@ -1,0 +1,314 @@
+# Story 37-2: Tamper-Evident Hash-Chain over Audit Records
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **compliance / security operator** (platform owner) and a **tenant administrator**,
+I want every curated audit record to carry a cryptographic hash that links it to the prior record in its scope, plus a verification routine and signed periodic checkpoints,
+So that any insertion, deletion, reordering, or in-place mutation of the audit trail — even by an attacker with direct database write access — is detected and localized, satisfying SOC2 / ISO27001 integrity-of-audit-evidence controls.
+
+## Priority
+
+P0 - Tamper-evidence is the integrity backbone of the entire audit/compliance product layer (Epic 37). Without it, the curated trail from 37-1 is merely a copy that an insider could silently rewrite.
+
+## Context & Boundary
+
+This story sits on the **curated `audit_records` projection** delivered by Story **37-1**, NOT on the raw DCB `domain_events` event store (`Tamma.Data/Entities/DomainEvent.cs`). The raw event store is already monotonic and append-mostly (BIGSERIAL `SequenceNumber`); this story adds an *independent* cryptographic integrity layer over the curated read-model so the human-facing audit trail can be proven unmodified.
+
+Two independent chains exist, mirroring the two event planes already in the codebase (per `AlertEventEmitter`'s tenant-vs-platform split):
+
+- **Per-tenant chains** — one hash-chain per `tenant_id`, persisted in the tenant's own store (`TenantDbContext`).
+- **Platform chain** — a single chain for platform-scoped audit records (`tenant_id` NULL), persisted in the control-plane store (`ControlPlaneDbContext`).
+
+A record is only ever a member of exactly one chain (its scope). Chains never cross-link.
+
+> **NEW vs EXISTING**: `audit_records` and its projector (`AuditProjector`) are introduced by **37-1** and are treated here as EXISTING dependencies. Every component this story adds (chain columns, `audit_chain_checkpoints`, `AuditChainVerifier`, the checkpoint workflow, the verify endpoints) is **NEW**. The spec's cited paths `Tamma.Core/Audit/AuditChainVerifier.cs`, `Tamma.Data/Audit/AuditProjector.cs`, and `Tamma.Data/Entities/AuditChainCheckpoint.cs` do not exist yet — `Tamma.Core` and the Elsa `Workflows` folder DO exist as target locations (verified). `packages/api` is deleted and is never a target.
+
+## Acceptance Criteria
+
+1. **Chain columns on `audit_records`.** The `audit_records` entity (from 37-1) gains `record_hash` (`bytea`/`char(64)` hex, SHA-256) and `prev_hash` columns, plus a per-scope monotonic `chain_sequence` (`bigint`). The first record in each scope chains its `prev_hash` to a fixed **genesis constant** (`AuditChainGenesis.Hash`, a documented well-known 32-byte value). Additive EF migration on both `TenantDbContext` (per-tenant chain) and `ControlPlaneDbContext` (platform chain); `dotnet ef migrations has-pending-model-changes` reports none afterward.
+
+2. **Hash computed over a canonical serialization.** `record_hash = SHA-256( prev_hash ‖ canonical(record) )` where `canonical(record)` is a deterministic, field-ordered, culture-invariant serialization of the record's stable fields (id, scope, tenant_id, actor, action, target, occurred_at in UTC ISO-8601 ms, payload). A dedicated `AuditRecordCanonicalizer` produces byte-stable output independent of JSON key ordering or platform locale; canonicalization is unit-tested for stability across two runs and across machines (no `Dictionary` enumeration-order dependence).
+
+3. **Chaining enforced at insert time inside `AuditProjector`.** When `AuditProjector` (37-1) appends a record, it reads the current chain head for that scope, sets `prev_hash` = head's `record_hash` (or genesis), computes `record_hash`, assigns the next `chain_sequence`, and persists atomically. Per-scope insert is **serialized** (Postgres `pg_advisory_xact_lock` keyed on the scope, mirroring `PostgresAdvisoryLeaderLock`) so concurrent appends to the same chain remain strictly monotonic with no forked/duplicate sequence.
+
+4. **`AuditChainVerifier.VerifyAsync(scope, from, to)`** recomputes each record's hash from its canonical form and validates `prev_hash` linkage record-to-record across the requested range. It returns either `Ok` or the **first broken link** as a structured result: `{ recordId, chainSequence, reason }` where `reason ∈ { mutated, missing (gap in chain_sequence), reordered, prev_hash_mismatch }`. Verification is O(n) over the range and streams records rather than loading the whole chain into memory.
+
+5. **Signed checkpoints (`audit_chain_checkpoints`).** A new entity/table `audit_chain_checkpoints` (`scope`, `tenant_id` nullable, `head_sequence`, `head_hash`, `signed_at`, `signature`, `key_version`) records a signed anchor of the chain head. The signature is an HMAC-SHA256 (or AES-GCM envelope) over `canonical(scope ‖ head_sequence ‖ head_hash ‖ signed_at)` using a signing key drawn from the **Epic 29 secret cabinet** via `ISecretStore` / `TenantSecretProtector` — **never** a plaintext env key. `key_version` records which key version signed it so signing-key rotation does not invalidate historical checkpoints.
+
+6. **Checkpoint written on a schedule and on demand.** A `BackgroundService` scheduler (`AuditChainCheckpointScheduler`, modeled on `HourlyAnalyticsRollupScheduler`) dispatches an Elsa workflow (`AuditChainCheckpointWorkflow`) hourly (configurable cadence, `RunOnStartup` gate, multi-pod-safe via `pg_try_advisory_lock`) that writes one checkpoint per active scope. An on-demand path (admin endpoint, below) writes a checkpoint immediately.
+
+7. **Cross-checkpoint verification.** `VerifyAsync` over a range spanning a checkpoint confirms the persisted checkpoint `head_hash` matches the recomputed chain head at `head_sequence` AND that the checkpoint `signature` validates against the cabinet key for its `key_version`. A record mutated/reordered between two checkpoints is detected and the broken link is localized to the exact `chain_sequence`; a checkpoint whose signature fails validation is reported distinctly from a chain-body break.
+
+8. **Verification endpoints (per-mode RBAC).** `GET /api/v1/orgs/{tenantId}/audit/verify` (tenant member; `tenant_admin`+ required, mirroring `OrgEndpoints.ListTenantAudit`) verifies that tenant's chain and never reads another tenant's records or the platform chain. `GET /api/admin/audit/verify` (`PlatformOwnerAccess`) verifies the platform chain and, with a `tenantId` query param, any tenant's chain. Both return `{ status, firstBrokenLink?, lastCheckpoint }`. Optional `from`/`to` query params bound the range (defaults: from last checkpoint, to head).
+
+9. **DCB events emitted.** `AUDIT.CHAIN.VERIFIED` (on a clean verify) and `AUDIT.CHAIN.TAMPER_DETECTED` (on any break) are appended via `IEventRepository` (tenant-scope → tenant `domain_events`; platform-scope → `platform_events`), following the `AlertEventEmitter` plane-routing precedent. `AUDIT.CHAIN.CHECKPOINTED` is emitted per checkpoint write. Tags include `scope`, `tenantId`, `chainSequence`, `reason`. No record payload contents are copied into event data.
+
+10. **Tamper detection raises a critical alert.** A `AUDIT.CHAIN.TAMPER_DETECTED` event raises a `critical` alert through the existing `IAlertSink.RaiseAsync` / `AlertEventEmitter` path (`Tamma.Api/Services/Alerts`), `TenantId` set for tenant-scope tampering and null (platform feed) for platform-scope. A built-in alert rule (`audit-chain-tamper`, severity `critical`) on `AUDIT.CHAIN.TAMPER_DETECTED` is seeded idempotently by `BuiltInAlertRuleSeeder` so detection fans out with no manual rule setup.
+
+11. **Append-only enforcement (defense-in-depth).** A Postgres trigger (or rule) on `audit_records` rejects `UPDATE` and `DELETE` on the chain columns and core record fields, so accidental ORM writes can't silently rewrite history; the hash-chain is the *cryptographic* guarantee and the trigger is the *belt-and-suspenders* DB guarantee. The trigger is documented as a best-effort barrier (a superuser/`ALTER TABLE DISABLE TRIGGER` still bypasses it — which is exactly why the cryptographic chain exists).
+
+12. **Performance acceptable.** Per-record chaining adds bounded overhead to the 37-1 projection: hashing is O(record size); the per-scope advisory lock is held only for the head read + insert. A verification of 100k records completes within a documented budget (target < 10s on the reference VPS) by streaming + batch reads. A perf test asserts append throughput regression from chaining stays under a documented threshold.
+
+13. **Per-mode ownership answered.** single-user mode: the sole user owns and verifies their (single) chain — system/platform-scope and the user's records surface in one verify view; the verify endpoint requires only an authenticated user. SaaS mode: tenant chains are owned by `tenant_owner`/`tenant_admin` (`member` → 403 on verify, mirroring prompt-store RBAC); the platform chain is owned by the platform owner (`PlatformOwnerAccess`) and is never exposed to tenants. Mode is read from `ITammaModeProvider`.
+
+14. **Unit + integration tests** (see Testing Strategy): clean chain verifies OK; mutate one record → `mutated` detected at its sequence; delete a record → `missing` gap detected; reorder two records → `reordered`/`prev_hash_mismatch` detected; tampered checkpoint signature → detected and reported distinctly; concurrent inserts on one scope keep `chain_sequence` strictly monotonic with no fork; cross-tenant isolation (verifying tenant A never touches tenant B's chain); per-mode RBAC matrix.
+
+## Technical Design
+
+### Component layout
+
+| Component | Project / namespace | New/Existing |
+|---|---|---|
+| `audit_records` (+ `record_hash`, `prev_hash`, `chain_sequence`) | `Tamma.Data` (entity from 37-1) | Existing entity, NEW columns |
+| `AuditProjector` (chaining at insert) | `Tamma.Data/Audit` (from 37-1) | Existing, NEW chaining logic |
+| `AuditChainGenesis` (genesis constant) | `Tamma.Core/Audit` | NEW |
+| `AuditRecordCanonicalizer` | `Tamma.Core/Audit` | NEW |
+| `AuditChainHasher` (SHA-256 compose) | `Tamma.Core/Audit` | NEW |
+| `IAuditChainVerifier` + `AuditChainVerifier` | `Tamma.Core/Audit` (logic) reading via `Tamma.Data` repo | NEW |
+| `AuditChainCheckpoint` (entity) | `Tamma.Data/Entities` | NEW |
+| `IAuditChainSigner` + `SecretCabinetAuditChainSigner` | `Tamma.Api/Services/Audit` | NEW (uses `ISecretStore`/`TenantSecretProtector`) |
+| `AuditChainCheckpointWorkflow` + `AuditChainCheckpointScheduler` | `Tamma.ElsaServer/Workflows` | NEW (mirror `HourlyAnalyticsRollup*`) |
+| Verify endpoints | `Tamma.Api/Endpoints/OrgEndpoints.cs`, `AdminEndpoints.cs` | Existing files, NEW handlers |
+| `AUDIT.CHAIN.*` event emission | via `IEventRepository` / `AlertEventEmitter` pattern | NEW event types, existing seam |
+| `audit-chain-tamper` built-in alert rule | `Tamma.Api/Services/Alerts/Rules/BuiltInAlertRules.cs` | Existing file, NEW spec |
+| Append-only trigger | EF migration raw SQL | NEW |
+
+> Note: the spec lists `Tamma.Api/Services/Secrets/ISecretStore.cs` as a primary component — it is **existing** (verified) and is consumed (not modified) by the new `SecretCabinetAuditChainSigner`. The Epic 29 cabinet already emits access-audit events per read, so signing-key reads are themselves audited.
+
+### Hash-chain schema (additive)
+
+```sql
+-- on audit_records (37-1 table), both tenant + control-plane stores
+ALTER TABLE audit_records
+  ADD COLUMN chain_sequence BIGINT NOT NULL,        -- per-scope monotonic
+  ADD COLUMN prev_hash      BYTEA  NOT NULL,         -- 32 bytes (genesis for first)
+  ADD COLUMN record_hash    BYTEA  NOT NULL;         -- 32 bytes SHA-256
+
+-- one chain per scope: tenant chain is the whole tenant store table;
+-- platform chain is the whole control-plane store table. Uniqueness of
+-- chain_sequence per scope is enforced per-store.
+CREATE UNIQUE INDEX uq_audit_records_chain_seq ON audit_records (chain_sequence);
+
+CREATE TABLE audit_chain_checkpoints (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  scope         TEXT NOT NULL,                       -- 'tenant' | 'platform'
+  tenant_id     UUID NULL,                           -- set for tenant scope; null for platform
+  head_sequence BIGINT NOT NULL,
+  head_hash     BYTEA  NOT NULL,                     -- 32 bytes
+  signed_at     TIMESTAMPTZ NOT NULL,
+  signature     BYTEA  NOT NULL,
+  key_version   INTEGER NOT NULL,                    -- which cabinet key version signed
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT scope_tenant_consistency CHECK (
+    (scope = 'platform' AND tenant_id IS NULL)
+    OR (scope = 'tenant' AND tenant_id IS NOT NULL)
+  )
+);
+CREATE INDEX ix_audit_chain_checkpoints_scope_seq
+  ON audit_chain_checkpoints (scope, tenant_id, head_sequence DESC);
+```
+
+### Compute (insert-time chaining)
+
+`AuditProjector` (37-1) gains a chaining step. Pseudocode (real impl uses the EF context + `pg_advisory_xact_lock` inside the projection transaction):
+
+```csharp
+// inside AuditProjector.AppendAsync, within the projection transaction
+await db.AcquireScopeAdvisoryLockAsync(scopeKey, ct);   // serialize this chain
+var head = await db.AuditRecords
+    .OrderByDescending(r => r.ChainSequence)
+    .Select(r => new { r.ChainSequence, r.RecordHash })
+    .FirstOrDefaultAsync(ct);
+
+record.ChainSequence = (head?.ChainSequence ?? 0) + 1;
+record.PrevHash      = head?.RecordHash ?? AuditChainGenesis.Hash;
+var canonical        = AuditRecordCanonicalizer.ToBytes(record);   // deterministic
+record.RecordHash    = AuditChainHasher.Compose(record.PrevHash, canonical); // SHA-256(prev ‖ canon)
+
+db.AuditRecords.Add(record);
+// committed atomically with the rest of the 37-1 projection
+```
+
+`AuditChainHasher.Compose(prev, canon)`:
+
+```csharp
+using var sha = SHA256.Create();
+sha.TransformBlock(prev, 0, prev.Length, null, 0);
+sha.TransformFinalBlock(canon, 0, canon.Length);
+return sha.Hash!;   // 32 bytes
+```
+
+### Verify
+
+```csharp
+public async Task<ChainVerificationResult> VerifyAsync(
+    AuditChainScope scope, long? from, long? to, CancellationToken ct)
+{
+    long? expectedSeq = null;
+    byte[]? expectedPrev = (from is null or 1) ? AuditChainGenesis.Hash : null;
+    // when starting mid-chain, anchor expectedPrev to the record at (from-1)
+    await foreach (var r in repo.StreamRecordsAsync(scope, from, to, ct))
+    {
+        if (expectedSeq is not null && r.ChainSequence != expectedSeq)
+            return ChainVerificationResult.Missing(r.RecordId, expectedSeq.Value); // gap / reorder
+        if (expectedPrev is not null && !r.PrevHash.SequenceEqual(expectedPrev))
+            return ChainVerificationResult.PrevHashMismatch(r.RecordId, r.ChainSequence);
+        var recomputed = AuditChainHasher.Compose(r.PrevHash, AuditRecordCanonicalizer.ToBytes(r));
+        if (!recomputed.SequenceEqual(r.RecordHash))
+            return ChainVerificationResult.Mutated(r.RecordId, r.ChainSequence);
+        expectedPrev = r.RecordHash;
+        expectedSeq  = r.ChainSequence + 1;
+    }
+    // cross-checkpoint confirmation
+    var cp = await checkpoints.GetLastCoveringAsync(scope, to, ct);
+    if (cp is not null)
+    {
+        if (!await signer.VerifyAsync(cp, ct))
+            return ChainVerificationResult.CheckpointSignatureInvalid(cp.Id, cp.HeadSequence);
+        if (cp.HeadSequence == lastSeenSeq && !cp.HeadHash.SequenceEqual(lastSeenHash))
+            return ChainVerificationResult.CheckpointHeadMismatch(cp.Id, cp.HeadSequence);
+    }
+    return ChainVerificationResult.Ok(lastSeenSeq, lastCheckpoint: cp);
+}
+```
+
+### Signing (Epic 29 cabinet)
+
+`SecretCabinetAuditChainSigner` resolves a signing key from `ISecretStore` (a dedicated cabinet secret, e.g. `SecretRef("platform", null, "audit-chain-signing-key")`), and HMAC-SHA256-signs the canonical checkpoint preimage. The plaintext key is delivered only through the cabinet's out-of-band path (per `ISecretStore`'s plaintext rule); the signer caches the active version in-process with a short TTL and records `key_version` on every checkpoint so rotation (Epic 28/29) doesn't strand old anchors. `TenantSecretProtector`'s AES-GCM is the at-rest envelope the cabinet already uses; this story reuses that protector, it does not invent new key handling.
+
+### Checkpoint scheduling
+
+`AuditChainCheckpointScheduler : BackgroundService` (copy `HourlyAnalyticsRollupScheduler`'s structure verbatim: `Enabled`/`FireAtMinute`/`PollInterval` options, `pg_try_advisory_lock` leader election, `_lastFired` hour-key dedup, WARN-and-continue failure isolation) dispatches `AuditChainCheckpointWorkflow`, which enumerates active scopes (platform + each tenant with new records since its last checkpoint) and writes one signed checkpoint per scope. On-demand checkpointing reuses the same per-scope write routine called directly from the admin endpoint.
+
+### Endpoints
+
+```
+GET /api/v1/orgs/{tenantId}/audit/verify          (tenant_admin+; tenant chain only)
+    ?from=<seq>&to=<seq>
+    → { status: "ok"|"tampered", firstBrokenLink?: {recordId, chainSequence, reason}, lastCheckpoint }
+
+GET /api/admin/audit/verify                        (PlatformOwnerAccess; platform chain, or ?tenantId=<id>)
+    ?tenantId=<id>&from=<seq>&to=<seq>
+    → same shape
+
+POST /api/admin/audit/checkpoint                   (PlatformOwnerAccess; on-demand, 202)
+    ?tenantId=<id>   (omit for platform scope)
+```
+
+Tenant handler mirrors `OrgEndpoints.ListTenantAudit`: reads role from `RequireTenantMembershipFilter.TenantRoleItemKey`, requires `TenantRoleHierarchy.Admin`, sets ambient `ITenantContext.SetTenantId(tenantId)` for defense-in-depth global query filtering. Admin handlers gate on the `PlatformOwnerAccess` policy (verified to exist in `Program.cs`).
+
+## Dependencies
+
+- **Prerequisite (hard)**: Story **37-1** — provides `audit_records` entity, `AuditProjector`, and the curated-projection transaction this story hooks chaining into. 37-1 is currently **not yet written** (`docs/stories/epic-37/story-37-1/` is empty); 37-2 cannot start until 37-1's projection schema is settled.
+- **Prerequisite**: **Epic 4** (DCB event substrate) — `DomainEvent`, `IEventRepository`, `PlatformEvent` plane routing used for `AUDIT.CHAIN.*` events (verified present).
+- **Prerequisite**: **Epic 29** (secret cabinet) — `ISecretStore` / `TenantSecretProtector` for the checkpoint signing key (verified present).
+- **Prerequisite**: **Epic 5** (alerts) — `IAlertSink` / `AlertEventEmitter` / `BuiltInAlertRuleSeeder` for the critical tamper alert (verified present).
+- **Related**: Epic 28 KEK rotation — checkpoint `key_version` must coexist with the cabinet's key-rotation lifecycle.
+- **Related**: Elsa workflow + scheduler infra (`HourlyAnalyticsRollupScheduler` as the copy-from template; verified present).
+
+## Testing Strategy
+
+1. **Canonicalization tests** (`Tamma.Core.Tests/Audit/`): identical record → identical bytes across two serializations and across `Dictionary` insertion orders; differing payloads → differing bytes; UTC/locale invariance (run under a non-invariant culture).
+2. **Hasher tests**: `Compose(prev, canon)` is 32 bytes, deterministic, and a single bit flip in either input changes the output (avalanche sanity).
+3. **Projector chaining tests** (`Tamma.Data.Tests` / `Tamma.Api.Tests`, docker-bound via `sg docker -c "dotnet test ..."`): sequential appends produce `chain_sequence` 1..N with `prev_hash[i] == record_hash[i-1]`; first record's `prev_hash == AuditChainGenesis.Hash`.
+4. **Concurrency test**: N parallel appends to one scope → exactly N rows, `chain_sequence` strictly monotonic 1..N, no duplicate/fork (advisory-lock serialization holds).
+5. **Verifier tamper matrix** (the AC14 core): clean → `Ok`; in-place mutate one record's payload → `mutated` at that sequence; delete a middle record → `missing` gap; swap two records' sequences → `reordered`/`prev_hash_mismatch`; clip the chain tail → detected at the truncation point.
+6. **Checkpoint tests**: checkpoint signature validates against cabinet key; corrupt the stored `signature` → `CheckpointSignatureInvalid` (distinct from body break); mutate a record between two checkpoints → break localized to its sequence and head-hash mismatch surfaced; rotated signing key (new `key_version`) still validates historical checkpoints with their original version.
+7. **Isolation tests**: verifying tenant A's chain issues no read against tenant B's store / platform store; admin platform verify never reads tenant rows unless `?tenantId` given.
+8. **RBAC / per-mode tests**: SaaS `member` → 403 on tenant verify; `tenant_admin` → 200; cross-tenant → 404/403; platform endpoints reject non-owner; single-user mode lets the sole authenticated user verify.
+9. **Endpoint tests**: response shape, `from`/`to` bounding, `AUDIT.CHAIN.VERIFIED` / `AUDIT.CHAIN.TAMPER_DETECTED` emitted with correct plane + tags; tamper raises a `critical` alert (assert `IAlertSink` invoked).
+10. **Scheduler tests**: `RunOnStartup=false` gates the loop; single tick writes one checkpoint per active scope; multi-pod advisory lock yields one leader (mirror `HourlyAnalyticsRollupSchedulerTests`).
+11. **Append-only trigger test**: direct `UPDATE`/`DELETE` on `audit_records` chain columns is rejected by the trigger.
+12. **Performance test**: 100k-record verify within the documented budget; per-append chaining overhead under the documented threshold.
+
+## Estimated Effort
+
+5-6 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Core/Audit/AuditChainGenesis.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Core/Audit/AuditRecordCanonicalizer.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Core/Audit/AuditChainHasher.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Core/Audit/IAuditChainVerifier.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Core/Audit/AuditChainVerifier.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Core/Audit/ChainVerificationResult.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Core/Audit/AuditChainScope.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/AuditChainCheckpoint.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Audit/AuditProjector.cs` | Modify (37-1 file — add insert-time chaining + advisory lock) |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/AuditRecord.cs` | Modify (37-1 file — add chain columns) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (configure new columns + checkpoint entity + index) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/*` | Create (EF migration — chain columns + append-only trigger) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/*` | Create (EF migration — chain columns + checkpoint table + trigger) |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/IAuditChainRepository.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/AuditChainRepository.cs` | Create (streaming reads + advisory lock helper) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/IAuditChainSigner.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/SecretCabinetAuditChainSigner.cs` | Create (uses `ISecretStore`/`TenantSecretProtector`) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditChainEventEmitter.cs` | Create (`AUDIT.CHAIN.*` via `IEventRepository`/`IPlatformEventPublisher` + alert raise) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditChainEventTypes.cs` | Create (event-type constants) |
+| `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AuditChainCheckpointWorkflow.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AuditChainCheckpointScheduler.cs` | Create (mirror `HourlyAnalyticsRollupScheduler`) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs` | Modify (add tenant `audit/verify` handler) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminEndpoints.cs` | Modify (add admin `audit/verify` + on-demand checkpoint) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Alerts/Rules/BuiltInAlertRules.cs` | Modify (add `audit-chain-tamper` rule) |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/AuditChainServiceCollectionExtensions.cs` | Create (DI wiring; mirror `AlertServiceCollectionExtensions`) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (wire extension + scheduler + endpoints) |
+| `apps/tamma-elsa/tests/Tamma.Core.Tests/Audit/*` | Create (canonicalizer, hasher, verifier matrix) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/*` | Create (projector chaining, signer, endpoints, RBAC, scheduler, trigger, perf) |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes/bugs/findings/decisions (notably any 37-1 projection notes and Epic 28/29 KEK decisions)
+3. Confirmed Story 37-1 has landed and its `audit_records` schema + `AuditProjector` transaction boundary are stable — 37-2's chaining hooks INTO that transaction
+4. Planned the TDD cycle (canonicalizer + hasher first; they are pure and the whole chain's determinism rests on them)
+5. Run C# tests via `sg docker -c "dotnet test ..."` for docker-bound suites (the build itself needs no wrapper) — see `reference_dotnet_test_docker`
+
+### Why two chains, not one
+
+The codebase already splits events tenant-vs-platform (`AlertEventEmitter`, `IEventRepository` vs `IPlatformEventPublisher`). Audit records live in `TenantDbContext` (per-tenant) and `ControlPlaneDbContext` (platform). A single global chain would force every tenant's audit append to serialize behind one lock and would couple tenant data lifecycles (a tenant purge would punch a hole in a shared chain). Per-scope chains keep each tenant's integrity independent and let a tenant verify its own trail without platform access.
+
+### Genesis constant
+
+`AuditChainGenesis.Hash` is a fixed, documented 32-byte value (e.g. `SHA-256("tamma.audit.chain.genesis.v1")`). It is a public well-known constant, NOT a secret — its only job is to give the first record a deterministic `prev_hash` so verification has a defined start. Document it inline so an external auditor can reproduce verification.
+
+### Canonicalization is load-bearing
+
+Verification only works if `canonical(record)` is byte-identical at write time and at verify time, forever. Avoid `JsonSerializer` default key ordering, `Dictionary` enumeration order, `DateTime.ToString()` without a fixed format, and culture-sensitive number formatting. Pin a fixed field order, UTC ISO-8601 with millisecond precision (`dayjs`-equivalent `"yyyy-MM-ddTHH:mm:ss.fffZ"` in C#), and invariant culture. Add a `canonicalVersion` byte so a future format change is detectable rather than silently breaking old records.
+
+### Append-only is defense, the chain is the proof
+
+The Postgres trigger blocks accidental ORM writes but a DBA with `ALTER TABLE` can disable it. That is acceptable: the cryptographic chain + signed external-key checkpoints are what make tampering *detectable*. State this in the runbook so operators don't treat the trigger as the security boundary.
+
+### Signing key, not env key (AC5)
+
+Per the spec boundary, the checkpoint signature key comes from the Epic 29 cabinet via `ISecretStore`, encrypted at rest by `TenantSecretProtector` (AES-GCM). Do NOT add a `appsettings`/`env` signing key — that would make a config-file reader able to forge checkpoints. The cabinet read is itself audited (`ISecretAccessAuditor`), so signing-key access leaves a trail.
+
+## Logging Requirements
+
+- **INFO**: chain checkpoint written (scope, head_sequence, key_version), verification completed (scope, range, result), scheduler dispatched.
+- **DEBUG**: per-record chaining (scope, chain_sequence) — sampled, not per-row in hot paths; verify cursor progress.
+- **WARN**: checkpoint scheduler tick failed (continue), signing-key read degraded/cached-stale, verify range empty.
+- **ERROR / CRITICAL**: `AUDIT.CHAIN.TAMPER_DETECTED` (always raises the critical alert), checkpoint signature validation failure, append-only trigger violation surfaced from the DB.
+- **Structured context**: `{ scope, tenantId, chainSequence, recordId, reason, keyVersion, rangeFrom, rangeTo }` where applicable.
+- **Credential safety**: NEVER log the signing key, key material, or raw audit-record payload contents; hashes are safe to log (they are non-reversible) but record payloads are not.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-37/story-37-3/37-3-audit-query-search-and-filter-api.md
+++ b/docs/stories/epic-37/story-37-3/37-3-audit-query-search-and-filter-api.md
@@ -1,0 +1,349 @@
+# Story 37-3: Audit Query, Search & Filter API
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **tenant administrator** (and, separately, a **platform owner**),
+I want to query, search, and filter the curated audit trail by actor, action, target, severity, outcome, IP, and time range with stable pagination,
+So that I can investigate "who did what, to what, when, and from where" for compliance (SOC2 / GDPR), incident response, and customer support — without ever seeing another tenant's records.
+
+## Priority
+
+P0 — Audit query/search is the primary consumer-facing surface of the Epic 37 audit product; the curated read-model from Story 37-1 is useless without a queryable API on top of it.
+
+## Context & Scope
+
+Story 37-1 introduces a **curated audit read-model**: a per-tenant `audit_records` table (in each tenant's own database via `TenantDbContext`) and a control-plane `platform_records` table (in `ControlPlaneDbContext`) that capture *sensitive* actions (RBAC changes, BYOK/secret access, tenant lifecycle, impersonation, prompt/provider config edits) projected from the Epic 4 DCB event substrate. Each curated row carries normalized columns — `actor_user_id`, `action_category`, `action_code`, `target_type`, `target_id`, `severity`, `outcome`, `ip_address`, `occurred_at`, a JSONB `payload`, and a monotonic `source_sequence_number` (the DCB global sequence the row was projected from) for stable ordering.
+
+This story (37-3) **replaces the thin type-prefix tenant audit read** that exists today —
+`OrgEndpoints.ListTenantAudit` at `src/Tamma.Api/Endpoints/OrgEndpoints.cs:527`, which calls `IEventRepository.ListByTenantAsync(tenantId, type, limit, offset)` over the raw `domain_events` table and supports only an exact `type` prefix + offset paging — with a **rich, filterable, keyset-paginated query API** over the curated 37-1 tables. It adds a parallel **platform-scoped** endpoint for the control-plane `platform_records`.
+
+> **Re-targeting note.** This story re-targets the stale Epic 23-10 / 23-4 audit-query specs (which assumed the deleted TypeScript `packages/api`) onto the live C# stack in `apps/tamma-elsa`. The TypeScript `packages/api` is DELETED — it is **not** a target of this story under any circumstance. All work lands in `Tamma.Api` (endpoints, DTOs, query service) and `Tamma.Data` (repositories, indexes).
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who can read **tenant** audit (`audit_records`)? | The sole user — it is their instance; the user owns and reads everything. | `tenant_owner` / `tenant_admin` of **that tenant only**. `member` → 403. Cross-tenant → rejected (membership filter + global query filter, defence-in-depth). |
+| Who can read **platform** audit (`platform_records`)? | The sole user (they are the operator). | Platform owner ONLY (`PlatformOwnerAccess`). Never exposed to tenants — it would leak cross-tenant + platform internals (impersonation, tenant lifecycle, platform RBAC, platform-level BYOK). |
+| Mode source | `ITammaModeProvider` (`src/Tamma.Api/Services/PromptStore/TammaMode.cs`) — process-stable. | same |
+
+The endpoint shape is **identical between modes**; the auth filter (`RequireTenantMembershipFilter` + `TenantRoleHierarchy.IsAtLeast`) decides what the caller may read, exactly as the prompt-store and current `ListTenantAudit` precedents do.
+
+## Acceptance Criteria
+
+1. **Tenant audit query endpoint.** `GET /api/v1/orgs/{tenantId}/audit` (extending `OrgEndpoints.ListTenantAudit`, now reading the curated `audit_records` table instead of raw `domain_events`) accepts the query parameters `category`, `action`, `actorUserId`, `targetType`, `targetId`, `severity`, `outcome`, `ipAddress`, `from`, `to`, `q` (search), `limit`, and `cursor`. It returns `{ records: AuditRecordResponse[], nextCursor: string | null, total: number }` where `total` is an estimate (see AC 9). Unknown/invalid filter values yield `400` with a descriptive error (not a silent empty list).
+
+2. **Platform audit query endpoint.** `GET /api/v1/admin/audit` (gated by `PlatformOwnerAccess`, matching the established platform-audit route convention used by `/api/v1/admin/alerts`) exposes the **same filter surface** over the control-plane `platform_records` table (impersonation, tenant lifecycle, platform RBAC, platform-level BYOK). Tenant audit and platform audit are physically separate tables — a platform query NEVER reads tenant `audit_records` and vice-versa.
+
+3. **Filter semantics — each dimension independently applied (AND-combined).**
+   - `category` / `action` — exact match on `action_category` / `action_code` (enumerated; invalid value → 400).
+   - `actorUserId` — exact `Guid` match on `actor_user_id`.
+   - `targetType` / `targetId` — exact match on `target_type` / `target_id`.
+   - `severity` — exact match on the enumerated severity (`info` / `warning` / `critical`).
+   - `outcome` — exact match (`success` / `failure` / `denied`).
+   - `ipAddress` — exact match on `ip_address`.
+   - `from` / `to` — half-open `occurred_at` range `[from, to)`, ISO-8601 UTC; `from > to` → 400.
+   Absent filters impose no constraint; all supplied filters AND-combine.
+
+4. **Search (`q`).** A non-empty `q` performs a case-insensitive contains match across `actor` (display/email captured in the curated row), `target_id`, and the JSONB `payload` rendered as text, AND-combined with the structured filters. `q` is parameterized — no string interpolation into SQL; injection attempts are inert. Empty/whitespace `q` is ignored.
+
+5. **Keyset (cursor) pagination.** Pagination is **keyset by `source_sequence_number`**, NOT offset. Ordering is most-recent-first: `ORDER BY source_sequence_number DESC` (`source_sequence_number` is unique and monotonic, so it is its own deterministic tiebreak — no secondary sort key needed). The opaque `cursor` encodes the last-seen `source_sequence_number`; the next page is `WHERE source_sequence_number < {cursor} ...`. Results are stable under concurrent inserts (a new row appended mid-pagination never shifts, duplicates, or skips a page boundary). `nextCursor` is `null` on the last page.
+
+6. **`limit` clamping.** `limit` defaults to 50 and is clamped to `[1, 200]` (matching the existing `ListTenantAudit` clamp). An out-of-range or non-integer `limit` is clamped, not rejected.
+
+7. **RBAC enforced per mode (the matrix).**
+   - SaaS `member` → `403` on `GET /api/v1/orgs/{tenantId}/audit`.
+   - SaaS `tenant_admin` / `tenant_owner` → allowed for **their own tenant only**.
+   - SaaS non-platform-owner → `403` on `GET /api/v1/admin/audit`.
+   - single-user sole user → allowed on both endpoints.
+   - Caller requesting a tenant they are not a member of → `403` (via `RequireTenantMembershipFilter`), never `200`.
+
+8. **No cross-tenant leakage (defence-in-depth).** Even with RBAC satisfied, the tenant query reads through `TenantDbContext` with the ambient `ITenantContext` ID set to the path `tenantId`, so the global query filter on `audit_records` is the second wall: a regression in the explicit `WHERE tenant_id = ...` predicate still cannot return another tenant's rows. An integration test asserts that injecting a foreign `tenantId` into the filter (with the ambient context pinned to the caller's tenant) returns zero foreign rows.
+
+9. **Query performance & supporting indexes.** A filtered query over a table seeded with ~1M `audit_records` for one tenant returns **p95 < 300ms**. Supporting composite indexes exist on `audit_records`: `(tenant_id, action_category, occurred_at DESC)`, `(tenant_id, actor_user_id, occurred_at DESC)`, and the pagination index `(tenant_id, source_sequence_number DESC)`; the same pattern (minus `tenant_id` where rows are control-plane-wide) applies to `platform_records`. `total` is an **estimated** count (the bounded planner estimate or a capped exact count) so paging is not gated on a full `COUNT(*)` over millions of rows.
+
+10. **Meta-audit on every read.** Every successful audit read (tenant or platform) itself emits an `AUDIT.QUERIED` DCB event — so *access to the audit log is itself auditable*. Tags: `tenantId` (null for platform reads), `actorUserId`, `scope` (`tenant` | `platform`), `mode`. Data captures the applied filter set (NOT the result rows) and the result count. A read that 403s does NOT emit `AUDIT.QUERIED` (no successful access occurred); RBAC denials are covered by existing auth-failure logging.
+
+11. **Response DTO.** `AuditRecordResponse` projects the curated row: `id`, `actionCategory`, `actionCode`, `actorUserId`, `actorLabel`, `targetType`, `targetId`, `severity`, `outcome`, `ipAddress`, `occurredAt`, `payload` (raw JSON string, as the existing `AuditEventResponse` does for `Tags`/`Data`), and `sourceSequenceNumber`. Platform-internal columns (raw DCB metadata) are NOT exposed.
+
+12. **Backward-compatible deprecation of the thin read.** The legacy `type` + `offset` query parameters on `GET /api/v1/orgs/{tenantId}/audit` continue to function for one release (mapped onto `action` and ignored-with-warning for `offset`) so the existing dashboard `AuditLogTab` does not break; new clients use `cursor`. The deprecation is documented in the Change Log and Dev Notes.
+
+13. **Tests.** Unit + integration tests cover: each filter dimension in isolation and combined; `q` search across all three target fields; keyset pagination correctness across page boundaries (including a concurrent-insert stability test); the full RBAC matrix per mode (member 403, admin own-tenant, cross-tenant 403, platform-owner-only platform endpoint, single-user allowed); cross-tenant non-leakage via the global query filter; `AUDIT.QUERIED` emission on success and non-emission on 403; `400` on invalid filter values and `from > to`; `limit` clamping.
+
+## Technical Design
+
+### Component layout
+
+```
+apps/tamma-elsa/src/Tamma.Api/
+  Endpoints/
+    OrgEndpoints.cs                     # MODIFY: ListTenantAudit → rich query over audit_records
+    AdminEndpoints.cs                   # MODIFY: add ListPlatformAudit handler (PlatformOwnerAccess)
+  Services/Audit/
+    AuditQueryService.cs                # NEW: builds the IQueryable, applies filters/search/keyset
+    IAuditQueryService.cs              # NEW
+    AuditQueryFilter.cs                # NEW: parsed/validated filter record + cursor codec
+    AuditQueryEventTypes.cs           # NEW: "AUDIT.QUERIED" (meta-audit)
+  Dtos/Audit/
+    AuditRecordResponse.cs             # NEW: curated-row projection (AC 11)
+    AuditQueryResponse.cs              # NEW: { records, nextCursor, total }
+
+apps/tamma-elsa/src/Tamma.Data/
+  Repositories/
+    IAuditRecordRepository.cs          # NEW (or extend 37-1's): keyset query over audit_records
+    AuditRecordRepository.cs           # NEW: TenantDbContext-bound, global-query-filter aware
+    IPlatformAuditRecordRepository.cs  # NEW: keyset query over platform_records (CP store)
+    PlatformAuditRecordRepository.cs   # NEW: ControlPlaneDbContext-bound
+  Migrations/Tenant/                    # NEW: composite indexes on audit_records (AC 9)
+  Migrations/ControlPlane/             # NEW: composite indexes on platform_records (AC 9)
+```
+
+> `audit_records` / `platform_records` entities + DbSets are owned by **Story 37-1**. If 37-1 has not yet defined `IAuditRecordRepository`, this story creates it; if it has a basic read, this story extends it with the keyset/filter query. Confirm the seam at implementation time.
+
+### Filter parsing & validation (`AuditQueryFilter`)
+
+A single immutable record parses raw query strings into typed, validated values up front so handlers stay thin:
+
+```csharp
+public sealed record AuditQueryFilter(
+    string? Category,
+    string? Action,
+    Guid? ActorUserId,
+    string? TargetType,
+    string? TargetId,
+    string? Severity,       // validated against {info, warning, critical}
+    string? Outcome,        // validated against {success, failure, denied}
+    string? IpAddress,
+    DateTime? From,         // UTC
+    DateTime? To,           // UTC; From < To enforced
+    string? Search,         // q
+    int Limit,              // clamped [1,200]
+    long? Cursor)           // last-seen source_sequence_number
+{
+    // TryParse(...) returns (filter, error?) — error → 400 in the handler.
+}
+```
+
+`Severity`/`Outcome`/`Category`/`Action` validate against the enums the 37-1 projector writes; an unknown value returns a `400` error string (AC 3) rather than silently matching nothing.
+
+### Keyset query (the load-bearing part)
+
+```csharp
+// AuditQueryService — tenant scope (same shape for platform scope)
+public async Task<AuditQueryResult> QueryTenantAsync(
+    Guid tenantId, AuditQueryFilter f, CancellationToken ct)
+{
+    // Ambient context pinned so the global query filter is the 2nd wall (AC 8).
+    _tenantContext.SetTenantId(tenantId);
+
+    var q = _db.AuditRecords.AsNoTracking()
+        .Where(r => r.TenantId == tenantId);                 // explicit 1st wall
+
+    if (f.Category is not null)   q = q.Where(r => r.ActionCategory == f.Category);
+    if (f.Action is not null)     q = q.Where(r => r.ActionCode == f.Action);
+    if (f.ActorUserId is not null)q = q.Where(r => r.ActorUserId == f.ActorUserId);
+    if (f.TargetType is not null) q = q.Where(r => r.TargetType == f.TargetType);
+    if (f.TargetId is not null)   q = q.Where(r => r.TargetId == f.TargetId);
+    if (f.Severity is not null)   q = q.Where(r => r.Severity == f.Severity);
+    if (f.Outcome is not null)    q = q.Where(r => r.Outcome == f.Outcome);
+    if (f.IpAddress is not null)  q = q.Where(r => r.IpAddress == f.IpAddress);
+    if (f.From is not null)       q = q.Where(r => r.OccurredAt >= f.From);
+    if (f.To is not null)         q = q.Where(r => r.OccurredAt <  f.To);
+
+    if (!string.IsNullOrWhiteSpace(f.Search))
+    {
+        var term = $"%{f.Search.Trim()}%";
+        q = q.Where(r =>
+            EF.Functions.ILike(r.ActorLabel, term) ||
+            EF.Functions.ILike(r.TargetId,  term) ||
+            EF.Functions.ILike(r.PayloadText, term));        // payload::text column or computed
+    }
+
+    // Keyset (AC 5): cursor < last-seen sequence, most-recent first.
+    if (f.Cursor is not null)
+        q = q.Where(r => r.SourceSequenceNumber < f.Cursor);
+
+    var page = await q
+        .OrderByDescending(r => r.SourceSequenceNumber)
+        .Take(f.Limit + 1)                                    // +1 to compute nextCursor
+        .ToListAsync(ct);
+
+    var hasMore = page.Count > f.Limit;
+    var rows = hasMore ? page.Take(f.Limit).ToList() : page;
+    long? nextCursor = hasMore ? rows[^1].SourceSequenceNumber : null;
+
+    var total = await EstimateCountAsync(q, ct);              // planner estimate / capped (AC 9)
+    return new AuditQueryResult(rows, nextCursor, total);
+}
+```
+
+**Why keyset over offset:** offset pagination over a high-write audit table shifts rows when a new event is appended between page loads (the classic "row appears twice / row skipped" bug). `source_sequence_number` is monotonic and unique, so `WHERE source_sequence_number < cursor ORDER BY ... DESC` is a stable, index-friendly seek that the `(tenant_id, source_sequence_number DESC)` index serves with no sort.
+
+**Cursor encoding:** the opaque `cursor` is the base64url of the `source_sequence_number` (a single `long`). Opaque so clients don't build their own; trivially decodable server-side. An undecodable cursor → 400.
+
+### Indexes (AC 9)
+
+```sql
+-- audit_records (per-tenant DB; created via Tenant migration)
+CREATE INDEX IF NOT EXISTS ix_audit_records_tenant_category_occurred
+  ON audit_records (tenant_id, action_category, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS ix_audit_records_tenant_actor_occurred
+  ON audit_records (tenant_id, actor_user_id, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS ix_audit_records_tenant_seq
+  ON audit_records (tenant_id, source_sequence_number DESC);   -- pagination seek
+
+-- platform_records (control-plane DB; created via ControlPlane migration)
+CREATE INDEX IF NOT EXISTS ix_platform_records_category_occurred
+  ON platform_records (action_category, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS ix_platform_records_seq
+  ON platform_records (source_sequence_number DESC);
+```
+
+For `q` payload search at scale, a `pg_trgm` GIN index on `payload_text` / `actor_label` is a documented follow-up (Dev Notes) — out of scope for the p95-on-structured-filters AC, which the composite B-tree indexes satisfy.
+
+### Meta-audit emission (AC 10)
+
+After a successful query, emit one `AUDIT.QUERIED` event via `IEventRepository.AppendAsync` (tenant scope; routed to the tenant store) / the platform event repository (platform scope, control-plane store):
+
+```csharp
+await _events.AppendAsync(new DomainEvent
+{
+    Type = AuditQueryEventTypes.Queried,            // "AUDIT.QUERIED"
+    Tags = Json(new {
+        tenantId,                                    // null for platform reads
+        actorUserId,
+        scope = "tenant",                            // or "platform"
+        mode = _mode.Mode.ToString(),
+    }),
+    Data = Json(new {
+        filters = f.ToAuditableShape(),              // applied filter set, NOT result rows
+        resultCount = rows.Count,
+    }),
+}, ct);
+```
+
+Emission is best-effort relative to the response (the read already succeeded); a failure to append `AUDIT.QUERIED` is logged at WARN and does not fail the request. The filter set is captured for forensic value; result rows are NOT duplicated into the meta-audit event (avoids unbounded event payloads and PII fan-out).
+
+### Endpoint wiring
+
+```csharp
+// Program.cs — tenant audit stays on the existing orgs group (MemberAccess base;
+// handler enforces admin+ and membership), now backed by AuditQueryService.
+orgs.MapGet("/{tenantId:guid}/audit", OrgEndpoints.ListTenantAudit);   // existing route, richer handler
+
+// Platform audit — v1Admin group (AdminAccess base), per-route PlatformOwnerAccess,
+// matching the alerts/alert-rules platform-admin convention.
+v1Admin.MapGet("/audit", AdminEndpoints.ListPlatformAudit)
+    .RequireAuthorization("PlatformOwnerAccess");
+```
+
+> The spec lists `GET /api/admin/audit`; the live platform-admin convention in `Program.cs` is the `/api/v1/admin/*` group (`v1Admin`) with a `PlatformOwnerAccess` per-route gate (see `/api/v1/admin/alerts`). This story follows the live convention (`/api/v1/admin/audit`); if a `/api/admin/audit` alias is required for parity it is a one-line additional `MapGet`. Confirm with the Epic 37 lead at implementation time.
+
+## Dependencies
+
+- **Hard prerequisite — Story 37-1** (Curated audit read-model): defines the `audit_records` / `platform_records` entities, the projector that populates them (including `source_sequence_number`, `action_category`, `action_code`, `actor_label`, `outcome`, `ip_address`), and possibly a base `IAuditRecordRepository`. 37-3 cannot land without these tables.
+- **Related — Story 37-2** (whatever 37-2 contributes to the curated trail, e.g. tamper-evidence / signing or export prerequisites): consumed read-only here; this story does not modify the write/projection path.
+- **Epic 28** (RBAC + isolation): `RequireTenantMembershipFilter`, `TenantRoleHierarchy`, the `PlatformOwnerAccess` policy, `ITenantContext`, and the per-tenant global query filter on `TenantDbContext` are all reused as-is for the RBAC matrix (AC 7) and cross-tenant defence-in-depth (AC 8).
+- **Blocks** the Epic 37 audit dashboard work (admin + tenant audit dashboards) — they consume these endpoints.
+
+## Testing Strategy
+
+Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/` (xUnit; docker-bound integration suites run via `sg docker -c "dotnet test ..."`).
+
+1. **Filter-dimension unit tests** (`Audit/AuditQueryServiceTests.cs`): seed a fixed set of `audit_records`; assert each filter (`category`, `action`, `actorUserId`, `targetType`, `targetId`, `severity`, `outcome`, `ipAddress`, `from`/`to`) returns exactly the expected subset; assert AND-combination of two+ filters narrows correctly; assert invalid `severity`/`outcome`/`category` → parse error (→ 400).
+2. **Search tests:** `q` matches on `actorLabel`, on `targetId`, and on `payload` text; case-insensitive; a SQL-injection-shaped `q` (`' OR 1=1 --`) returns only legitimately-matching rows (proves parameterization).
+3. **Keyset-pagination correctness** (`Audit/AuditKeysetPaginationTests.cs`): page through a 250-row set at `limit=100`, assert 3 pages with no overlaps/gaps and `nextCursor` null on the last page; **concurrent-insert stability** — capture page 1's cursor, append 10 newer rows, fetch page 2, assert page 2 contains exactly the originally-expected rows (newer rows do not shift the boundary); undecodable cursor → 400; `from > to` → 400.
+4. **RBAC matrix** (integration, `Audit/AuditRbacTests.cs`): per mode (single-user, SaaS) assert — member → 403, tenant_admin own-tenant → 200, tenant_admin foreign-tenant → 403, non-platform-owner on `/api/v1/admin/audit` → 403, platform owner → 200, single-user → 200 on both.
+5. **Cross-tenant non-leakage** (integration): seed tenant A and tenant B `audit_records`; as a tenant-A admin, attempt a query whose explicit predicate is tampered to tenant B (ambient context pinned to A) — assert zero tenant-B rows (global query filter wall). Assert tenant query never reads `platform_records` and vice-versa.
+6. **Meta-audit** (integration): a successful tenant read appends exactly one `AUDIT.QUERIED` event tagged `scope=tenant` with the filter set and result count in `Data`; a successful platform read appends `scope=platform` with `tenantId=null`; a 403 read appends NO `AUDIT.QUERIED`.
+7. **Performance** (integration, gated/optional locally): seed ~1M `audit_records` for one tenant; assert a representative filtered + keyset query is **p95 < 300ms** with the composite indexes present; assert the same query degrades sharply (regression canary) if the `(tenant_id, source_sequence_number DESC)` index is dropped.
+8. **Backward-compat** (integration): legacy `?type=X&offset=Y` against the tenant route still returns rows (mapped to `action`; `offset` ignored-with-warning), proving the existing `AuditLogTab` is not broken.
+
+## Estimated Effort
+
+4-5 days (1 day query service + filter/cursor codec; 1 day repositories + indexes + migrations; 1 day endpoints + DTOs + meta-audit; 1.5-2 days the full test matrix including the cross-tenant/concurrent-insert/perf cases).
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs` | Modify (`ListTenantAudit` → rich query over `audit_records`; keep legacy params) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminEndpoints.cs` | Modify (add `ListPlatformAudit` handler) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/IAuditQueryService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditQueryService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditQueryFilter.cs` | Create (parse/validate + cursor codec) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditQueryEventTypes.cs` | Create (`AUDIT.QUERIED`) |
+| `apps/tamma-elsa/src/Tamma.Api/Dtos/Audit/AuditRecordResponse.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Dtos/Audit/AuditQueryResponse.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/IAuditRecordRepository.cs` | Create or extend (37-1 seam) |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/AuditRecordRepository.cs` | Create or extend |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/IPlatformAuditRecordRepository.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/PlatformAuditRecordRepository.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/*_AuditRecordsQueryIndexes.cs` | Create (composite indexes) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/*_PlatformRecordsQueryIndexes.cs` | Create (composite indexes) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (register `/api/v1/admin/audit`; DI for `AuditQueryService` + repos) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditQueryServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditKeysetPaginationTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditRbacTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditCrossTenantTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditMetaAuditTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md).
+2. Searched `.dev/` for related spikes/bugs/findings/decisions (audit, keyset pagination, tenant isolation).
+3. Confirmed the Story 37-1 seam: the exact entity names/columns of `audit_records` / `platform_records`, whether `IAuditRecordRepository` already exists, and the precise name + type of the sequence column (this story assumes `SourceSequenceNumber` / `source_sequence_number`, a monotonic `long` from the DCB global sequence).
+4. Planned TDD (Red-Green-Refactor) — tests first, especially the keyset and cross-tenant cases.
+
+### `packages/api` is deleted — do NOT target it
+
+The TypeScript `packages/api` referenced by the stale Epic 23 specs no longer exists. Every artifact in this story lands in the C# `apps/tamma-elsa` solution (`Tamma.Api`, `Tamma.Data`, `Tamma.Api.Tests`). Do not create or cite `packages/api`.
+
+### Reuse the existing isolation seams verbatim
+
+- RBAC: `RequireTenantMembershipFilter` (sets `httpContext.Items[RequireTenantMembershipFilter.TenantRoleItemKey]`) + `TenantRoleHierarchy.IsAtLeast(role, TenantRoleHierarchy.Admin)` — the exact pattern already in `ListTenantAudit` (`OrgEndpoints.cs:539`). Copy it; do not invent a new gate.
+- Cross-tenant wall: pin `ITenantContext.SetTenantId(tenantId)` before the query so the per-tenant global query filter on `TenantDbContext` engages (defence-in-depth), exactly as the current handler does.
+- Platform gate: `PlatformOwnerAccess` policy (defined in `Program.cs:986`), used per-route on the `v1Admin` group as the alerts endpoints do.
+
+### Keyset, not offset
+
+The current handler uses `offset` — fine for a small dashboard, wrong for a 1M-row compliance trail. The new contract is `cursor` (keyset on `source_sequence_number`). Keep `offset` accepted-but-ignored-with-WARN for one release for the existing `AuditLogTab` (`packages/dashboard/src/pages/admin/AuditLogTab.tsx`); the dashboard migration to `cursor` is a separate follow-up.
+
+### `total` is an estimate by design
+
+A full `COUNT(*)` over filtered millions of rows would blow the p95 budget. Return the Postgres planner's row estimate (`EXPLAIN`-style) or a capped exact count (e.g. exact up to 10k, then "10000+"). The dashboard shows "~N" / "N+" — document the semantics in the response field comment.
+
+### `q` search scaling
+
+The B-tree composite indexes serve the structured-filter p95 (AC 9). `ILIKE '%term%'` over `payload_text`/`actor_label` is a sequential scan within the already-narrowed result set; for large unfiltered `q`-only queries, add a `pg_trgm` GIN index as a documented follow-up — out of scope here.
+
+### Meta-audit must not recurse or fail the read
+
+`AUDIT.QUERIED` is a DCB event, NOT an `audit_records` row, so it does not feed back into this query surface (no recursion). Append it best-effort after the response data is materialized; a WARN-logged append failure must not fail the user's read.
+
+## Logging Requirements
+
+- **INFO**: audit query served (scope, tenantId, actorUserId, applied-filter keys, resultCount, page durationMs); `AUDIT.QUERIED` emitted.
+- **DEBUG**: parsed filter set, decoded cursor, generated keyset predicate (no PII — filter *keys*, not full payload search terms at INFO).
+- **WARN**: `AUDIT.QUERIED` append failed (read still served); legacy `offset` param used (deprecation); `total` fell back to estimate after count cap; undecodable cursor (paired with the 400).
+- **ERROR**: query execution failure (DB/timeout) — surfaced as 500 with a correlation id, never a partial result.
+- **Structured context**: `{ scope, tenantId, actorUserId, filterKeys, resultCount, durationMs, mode }`.
+- **Credential / PII safety**: NEVER log full `q` search terms at INFO+ (may contain emails/IDs); NEVER log `ip_address` of audited rows in application logs; NEVER log row payloads. Redact per the existing logging conventions.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-37/story-37-4/37-4-signed-audit-export-with-integrity-manifest.md
+++ b/docs/stories/epic-37/story-37-4/37-4-signed-audit-export-with-integrity-manifest.md
@@ -1,0 +1,492 @@
+# Story 37-4: Signed Audit Export (JSON/CSV) with Integrity Manifest
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **compliance officer / platform owner / tenant admin**,
+I want to export a time- and filter-bounded slice of the tamper-evident audit
+trail in JSON and CSV, accompanied by an integrity manifest (record count,
+chain head hash + checkpoint reference, and a cryptographic signature),
+So that I can hand the export to an auditor or external reviewer who can
+verify offline that the export was not altered and corresponds to the
+hash-chained audit log — and so that the act of exporting the audit log is
+itself captured in the audit log.
+
+## Priority
+
+P1 - Required compliance-evidence capability for SOC2 / ISO27001 / GDPR audits.
+
+## Scope
+
+Let admins export a slice of the audit trail (the curated, hash-chained
+`audit_records` read-model from Stories 37-1/37-2, queried with the same
+filters as 37-3) for external review, in JSON and CSV, accompanied by an
+**integrity manifest** so the recipient can verify the export was not altered
+and corresponds to the tamper-evident chain.
+
+- **Tenant exports own their own audit** (`audit_records` rows scoped to the
+  caller's tenant); **platform exports own platform audit** (platform-scope
+  records). Per-mode ownership is settled the same way the rest of the audit
+  product is (single-user: the sole user; SaaS: tenant_admin+ for the tenant
+  slice, platform owner for the platform slice).
+- **Large exports run asynchronously** (a `QueuedTask` job + a downloadable,
+  encrypted, auto-expiring artifact) to avoid request timeouts — mirroring the
+  async pattern already used by tenant provisioning
+  (`TaskQueueProcessor`/`QueuedTask`). Small exports (< 10k rows) MAY stream
+  synchronously.
+- **The export action is itself a sensitive, audited action** — it emits
+  `AUDIT.EXPORTED` into `audit_records`, so exporting the audit log appears in
+  the audit log.
+
+Target codebase: **C# `apps/tamma-elsa`** — `Tamma.Api` (endpoints + export
+service), `Tamma.Data` (the `audit_records` read-model + hash chain from
+37-1/37-2, per-tenant; `QueuedTask` for async jobs), signing via the existing
+Epic 29 secret cabinet crypto. (The deleted `packages/api` TypeScript API is
+NOT a target.)
+
+## Acceptance Criteria
+
+1. **Tenant + platform export endpoints (same filters as 37-3 + format).**
+   `POST /api/v1/orgs/{tenantId}/audit/export` (tenant_admin+, gated by
+   `RequireTenantMembershipFilter` + admin-role check) and
+   `POST /api/admin/audit/export` (`PlatformOwnerAccess`) accept the **same
+   filter set as Story 37-3** (time range, actor, action/event type, resource,
+   severity, etc.) plus `format=json|csv`, and return **`202 Accepted` with a
+   `jobId`**. Small exports (< 10k matching rows) MAY be produced and streamed
+   synchronously instead of queued (config-gated threshold).
+
+2. **Export bundle + manifest.json.** The export bundle is a single artifact
+   (a `.zip` containing the data file `audit.json` / `audit.csv` plus
+   `manifest.json`). `manifest.json` includes: `record_count`, the `filter`
+   criteria (echoed), `scope` (`tenant`/`platform` + the tenant id when
+   tenant-scoped), the audit chain `head_hash` and `checkpoint_id` at export
+   time (from 37-2), `format`, `export_signature`, `generated_at`,
+   `generated_by` (actor id), and `manifest_version`.
+
+3. **Signature over canonical manifest.** `export_signature` is computed over a
+   canonical (stable key order, no-whitespace) serialization of the manifest's
+   signed fields, including a content digest of the exported data file
+   (`data_sha256`), using the **Epic 29 cabinet key** (resolved via
+   `ISecretStore`/`KekProvider`). The signing algorithm + key version are
+   recorded in the manifest so a verifier can select the right key.
+
+4. **Async job lifecycle + download URL.**
+   `GET /api/v1/orgs/{tenantId}/audit/export/{jobId}` and
+   `GET /api/admin/audit/export/{jobId}` report job state
+   (`pending → generating → ready → expired`, plus `failed`) and, when `ready`,
+   yield a **time-limited download URL** (or a `download` sub-route guarded by a
+   single-use, signed token). The handler that produces the artifact is an
+   `ITaskHandler` (`audit.export.*`) driven by `TaskQueueProcessor`.
+
+5. **Encrypted at rest + auto-expiry.** The generated artifact is **stored
+   encrypted at rest** (AES-GCM, mirroring `TenantSecretProtector` /
+   `AesGcmConnectionStringDecryptor`) and **auto-expires** (default 24h,
+   configurable `Audit:Export:ArtifactTtl`). After expiry the job reports
+   `expired`, the download route returns `410 Gone`, and a reaper purges the
+   ciphertext + DB row.
+
+6. **Offline verifiability.** A verifier (a documented procedure + a small
+   `tamma audit verify-export` helper / standalone script) can, given the
+   bundle and the public verification material, **(a)** recompute `data_sha256`
+   over the data file, **(b)** recompute and confirm `export_signature` over the
+   canonical manifest, and **(c)** recompute the audit chain hash over the
+   exported rows and confirm it matches the recorded `head_hash`/`checkpoint_id`
+   — thereby detecting any post-export tampering of the data file OR the
+   manifest. The verification recipe is documented in the story’s Dev Notes and
+   the bundle’s `README`.
+
+7. **Export is itself audited (`AUDIT.EXPORTED`).** Initiating an export emits
+   an `AUDIT.EXPORTED` audit record (a sensitive action captured in
+   `audit_records`, NOT just a DCB event) tagging `actor` (`generated_by`),
+   `scope`, `record_count`, `filter` summary, and `format`. Exporting the audit
+   log therefore appears in the audit log. (The `AUDIT.EXPORTED` row is written
+   so it falls AFTER the exported chain head — it does not retroactively alter
+   the slice that was exported.)
+
+8. **CSV formula-injection neutralization.** CSV output **escapes/neutralizes
+   formula injection**: any cell whose value begins with `=`, `+`, `-`, `@`,
+   tab, or carriage-return is prefixed with a single quote (`'`) (or wrapped per
+   the chosen safe-CSV rule), and standard CSV quoting/escaping of `"`, `,`, and
+   newlines is applied to every field.
+
+9. **Redaction is preserved in both formats.** The field-level redaction applied
+   by Story 37-1 to sensitive audit fields is preserved identically in BOTH JSON
+   and CSV output — the export reads the already-redacted read-model and never
+   re-derives or un-redacts values.
+
+10. **Per-mode RBAC + isolation.**
+    - single-user: the sole user can export their instance's audit
+      (system/platform + their own records) — no role gate beyond authn.
+    - SaaS: `POST /api/v1/orgs/{tenantId}/audit/export` requires
+      `tenant_owner`/`tenant_admin` for the route tenant (member → `403`);
+      `POST /api/admin/audit/export` requires `PlatformOwnerAccess`. A tenant
+      export NEVER includes platform-scope or other-tenant records (defence in
+      depth via the read-model's tenant scoping); a platform export NEVER leaks
+      into a tenant's `/orgs/{id}/...` job namespace. `jobId`s are
+      scope-namespaced so a tenant cannot fetch/download another scope's job.
+
+11. **Job ownership + cross-tenant fetch rejected.** `GET .../export/{jobId}`
+    and the download route resolve the job ONLY within the caller's scope; a
+    job belonging to another tenant (or to the platform scope) returns `404`
+    (not `403`, to avoid leaking existence).
+
+12. **Graceful failure.** If artifact generation fails (DB error, signing key
+    unavailable), the job transitions to `failed` with a non-leaky error
+    summary, the partial artifact (if any) is purged, and the failure is logged
+    at ERROR; the initiating request still returned `202` and is not blocked.
+
+## Technical Design
+
+### Component overview
+
+```
+apps/tamma-elsa/src/
+  Tamma.Api/Endpoints/
+    OrgEndpoints.cs                         (MODIFY: tenant audit export + status + download)
+    AdminEndpoints.cs                       (MODIFY: platform audit export + status + download)
+  Tamma.Api/Services/Audit/                 (NEW directory)
+    IAuditExportService.cs                  (NEW)
+    AuditExportService.cs                   (NEW: orchestrates query → serialize → sign → encrypt → persist)
+    AuditExportManifest.cs                  (NEW: manifest record + canonical-serialization + signed-field set)
+    AuditExportSigner.cs                    (NEW: sign/verify over canonical manifest via ISecretStore cabinet key)
+    AuditCsvWriter.cs                       (NEW: RFC-4180 CSV + formula-injection neutralization)
+    AuditJsonWriter.cs                      (NEW: deterministic/streamed JSON array of redacted rows)
+    AuditExportTaskHandler.cs               (NEW: ITaskHandler for "audit.export.*")
+    AuditExportArtifactProtector.cs         (NEW: AES-GCM at-rest wrapper, mirrors TenantSecretProtector)
+    AuditExportOptions.cs                   (NEW: SyncRowThreshold, ArtifactTtl, MaxRows, ...)
+  Tamma.Api/Extensions/
+    AuditExportServiceCollectionExtensions.cs (NEW: AddAuditExport(); called once from Program.cs)
+  Tamma.Data/Entities/
+    AuditExportJob.cs                       (NEW: job + artifact metadata row)
+    QueuedTask.cs                           (REUSE: async job queue; new Type "audit.export.{scope}")
+  Tamma.Data/Migrations/ControlPlane/       (NEW: additive migration for audit_export_jobs)
+```
+
+> `audit_records` + the hash chain (`head_hash`, checkpoint) come from Stories
+> 37-1 (curated record + redaction) and 37-2 (hash chain + checkpoints); the
+> shared filter model comes from 37-3. This story consumes those read APIs and
+> does not redefine them. Where 37-1/37-2/37-3 types are not yet merged, the
+> implementation depends on their public surfaces and is sequenced after them
+> (see Dependencies).
+
+### Endpoint shapes
+
+```
+POST /api/v1/orgs/{tenantId}/audit/export      → 202 { jobId, status }      (tenant_admin+)
+GET  /api/v1/orgs/{tenantId}/audit/export/{id} → 200 { status, recordCount?, downloadUrl?, expiresAt? }
+GET  /api/v1/orgs/{tenantId}/audit/export/{id}/download → 200 (application/zip) | 410 Gone
+
+POST /api/admin/audit/export                    → 202 { jobId, status }      (PlatformOwnerAccess)
+GET  /api/admin/audit/export/{id}               → 200 { status, ... }
+GET  /api/admin/audit/export/{id}/download      → 200 (application/zip) | 410 Gone
+```
+
+Request body (both scopes), reusing the 37-3 filter DTO:
+
+```jsonc
+{
+  "format": "json",            // "json" | "csv"
+  "filter": {                  // identical shape to Story 37-3 query filter
+    "from": "2026-01-01T00:00:00Z",
+    "to":   "2026-06-17T00:00:00Z",
+    "actor": "...",            // optional
+    "action": "...",          // optional (audit event type)
+    "resource": "...",        // optional
+    "severity": "..."         // optional
+  }
+}
+```
+
+Sync fast path: when the matching `record_count < SyncRowThreshold` (default
+10_000) the handler MAY build the bundle inline and return the artifact (or a
+`ready` job with an immediate `downloadUrl`); otherwise it enqueues a
+`QueuedTask` of type `audit.export.tenant` / `audit.export.platform` and
+returns `202` with the persisted `AuditExportJob.Id`.
+
+### Manifest
+
+```jsonc
+// manifest.json (signed fields are everything except `export_signature`)
+{
+  "manifest_version": "1.0",
+  "scope": "tenant",                 // "tenant" | "platform"
+  "tenant_id": "…",                  // present when scope=tenant
+  "format": "csv",
+  "record_count": 4821,
+  "filter": { /* echoed 37-3 filter */ },
+  "chain": {
+    "head_hash": "…",                // 37-2 chain head at export time
+    "checkpoint_id": "…",            // 37-2 checkpoint reference
+    "algorithm": "sha-256"
+  },
+  "data_sha256": "…",                // digest of the data file (audit.json/csv)
+  "generated_at": "2026-06-17T12:00:00.000Z",
+  "generated_by": "<actor user id>",
+  "signing": { "alg": "HMACSHA256", "key_version": 3 },  // or ECDSA per cabinet key type
+  "export_signature": "base64(…)"    // over canonical(signed-fields)
+}
+```
+
+- **Canonical serialization**: stable (sorted) key order, UTC ISO-8601 ms
+  timestamps, no insignificant whitespace — deterministic so the verifier
+  reproduces byte-for-byte.
+- **`data_sha256`** binds the signature to the actual data file so tampering
+  with rows is detected even if the manifest is untouched.
+- **`chain.head_hash` / `checkpoint_id`** bind the export to the tamper-evident
+  chain so a verifier can recompute the chain over the exported rows and confirm
+  they reconstruct the recorded head (detecting row insertion/deletion).
+
+### Signing (Epic 29 cabinet key)
+
+`AuditExportSigner` resolves the platform signing key via `ISecretStore`
+(`SecretScope` platform, a dedicated `SecretPurpose` such as
+`AuditExportSigning`) / `KekProvider`. The implementation uses the existing
+crypto already present in the repo (`System.Security.Cryptography` —
+HMAC-SHA-256 with a cabinet-held key as the minimum bar, or ECDSA/RSA if a
+cabinet asymmetric key is provisioned, which is preferable for offline
+verification without sharing a secret). `key_version` is recorded so rotation
+(Epic 28-12 KEK rotation precedent) does not break old-bundle verification.
+`Verify(manifest, key)` re-canonicalizes the signed fields and checks the
+signature — used by tests and the verify helper.
+
+### At-rest encryption + expiry
+
+`AuditExportArtifactProtector` wraps the `.zip` bytes with AES-GCM (12-byte
+nonce ‖ ciphertext ‖ 16-byte tag), keyed from the Epic 29 cabinet, mirroring
+`TenantSecretProtector` / `AesGcmConnectionStringDecryptor`. The ciphertext is
+stored as a `bytea` on `audit_export_jobs` (or an object-store ref behind the
+same interface). `ExpiresAt = generated_at + ArtifactTtl` (default 24h); a
+periodic reaper (or the existing `QueuedTask` visibility reaper pattern) flips
+expired jobs to `expired` and scrubs the ciphertext. The download route
+decrypts on the fly and streams.
+
+### `audit_export_jobs` (additive migration)
+
+```sql
+CREATE TABLE audit_export_jobs (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  scope         TEXT NOT NULL,                 -- 'tenant' | 'platform'
+  tenant_id     UUID,                          -- set when scope='tenant'; NULL for platform
+  requested_by  UUID NOT NULL,                 -- actor (generated_by)
+  format        TEXT NOT NULL,                 -- 'json' | 'csv'
+  filter        JSONB NOT NULL,                -- echoed 37-3 filter
+  status        TEXT NOT NULL DEFAULT 'pending', -- pending|generating|ready|expired|failed
+  record_count  BIGINT,
+  manifest      JSONB,                         -- the signed manifest (for status/audit)
+  artifact_ciphertext BYTEA,                   -- AES-GCM bundle; NULL until ready / after purge
+  error         TEXT,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at    TIMESTAMPTZ,
+  CONSTRAINT audit_export_scope_xor CHECK (
+    (scope = 'tenant'   AND tenant_id IS NOT NULL) OR
+    (scope = 'platform' AND tenant_id IS NULL)
+  )
+);
+CREATE INDEX idx_audit_export_jobs_scope_tenant ON audit_export_jobs (scope, tenant_id, status);
+CREATE INDEX idx_audit_export_jobs_expiry       ON audit_export_jobs (expires_at) WHERE status = 'ready';
+```
+
+> Additive table — run `dotnet ef migrations add` and confirm
+> `has-pending-model-changes` reports none; mirror entity config in
+> `TammaModelConfiguration.cs` (the single source for model config).
+
+### Async via QueuedTask / TaskQueueProcessor
+
+`AuditExportTaskHandler : ITaskHandler` with `TypePrefix = "audit.export."`.
+The `QueuedTask.Payload` carries `{ jobId }`; the handler loads the
+`AuditExportJob`, flips `generating`, runs query → serialize → digest → sign →
+zip → encrypt → persist → `ready`, and is idempotent on retry (re-running a
+`ready`/`generating` job is a no-op or regenerates safely). `QueuedTask.TenantId`
+is set for tenant-scope so per-tenant routing/visibility holds; platform-scope
+uses the platform task path (`PlatformTaskWorker`) per the provisioning
+precedent. Failures count against the retry budget; terminal failure flips the
+job to `failed`.
+
+### Per-mode ownership (mandatory two-scoping-model answer)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Who can export the **tenant** slice? | The sole user (no role gate beyond authn). | `tenant_owner`/`tenant_admin` of the route tenant; `member` → 403. |
+| Who can export the **platform** slice? | The sole user (their instance's platform audit). | `PlatformOwnerAccess` only. |
+| What rows are in a tenant export? | The user's records. | ONLY the route tenant's `audit_records` (read-model tenant scoping = defence in depth); never platform/other-tenant rows. |
+| Where does the artifact live? | Encrypted, the user's job. | Encrypted, scope-namespaced job; cross-scope/cross-tenant fetch → 404. |
+| Who can fetch/download the job? | The user. | The export's scope owner only; other scopes → 404 (no existence leak). |
+| Mode source | `ITammaModeProvider` (process-stable). | same |
+
+## Dependencies
+
+- **Prerequisite — Story 37-1**: curated `audit_records` read-model + field-level
+  redaction (export reads the already-redacted rows — AC9).
+- **Prerequisite — Story 37-2**: hash chain + checkpoints (`head_hash`,
+  `checkpoint_id`) bound into the manifest (AC2, AC6).
+- **Prerequisite — Story 37-3**: the shared audit query/filter model reused by
+  the export request body (AC1).
+- **Prerequisite — Epic 29 (signing key)**: `ISecretStore` / `KekProvider`
+  cabinet key for `export_signature` and at-rest encryption (AC3, AC5). Key
+  rotation precedent: Story 28-12.
+- **Reuses (no change required)**: `QueuedTask` + `TaskQueueProcessor` /
+  `ITaskHandler` async pattern; `TenantSecretProtector` /
+  `AesGcmConnectionStringDecryptor` AES-GCM helper; `RequireTenantMembershipFilter`
+  + `OwnerAccess`/`PlatformOwnerAccess` policies; `IEventRepository`/audit append.
+
+## Testing Strategy
+
+Tests are TDD-first, xUnit under `apps/tamma-elsa/tests/Tamma.Api.Tests/`
+(docker-bound suites run via `sg docker -c "dotnet test ..."`).
+
+1. **Manifest signature round-trip**: build a manifest, sign with a fixture
+   cabinet key, `Verify` succeeds; flip one byte of the data file (so
+   `data_sha256` changes) → verify fails; flip one signed manifest field →
+   verify fails; tamper with `export_signature` → verify fails.
+2. **Chain reconstruction**: recompute the audit chain over the exported rows →
+   matches the manifest `head_hash`/`checkpoint_id`; remove/insert one exported
+   row → reconstruction mismatch (post-export tampering detected — AC6).
+3. **Async job lifecycle**: `POST .../export` returns `202` + `jobId`; the task
+   handler drives `pending → generating → ready`; `GET .../export/{id}` reflects
+   each state and yields a `downloadUrl` only when `ready`; handler retry is
+   idempotent; terminal failure → `failed` with non-leaky error (AC4, AC12).
+4. **Sync fast path**: a sub-threshold export (< `SyncRowThreshold`) produces a
+   downloadable bundle without queueing.
+5. **Expiry**: after `ArtifactTtl`, the job reports `expired`, download → `410`,
+   reaper scrubs ciphertext (AC5).
+6. **CSV injection neutralization**: cells starting `= + - @`, tab, CR are
+   neutralized; embedded `"`, `,`, newlines are RFC-4180-quoted; round-trips
+   through a CSV parser to the safe value (AC8).
+7. **Redaction preserved**: a record with a 37-1-redacted field exports redacted
+   in BOTH JSON and CSV; the writer never un-redacts (AC9).
+8. **`AUDIT.EXPORTED` emission**: initiating an export writes exactly one
+   `AUDIT.EXPORTED` audit record tagging actor/scope/record_count/filter/format;
+   the row sorts AFTER the exported head and is not in the exported slice (AC7).
+9. **RBAC per mode**: SaaS matrix (member → 403 on tenant export; non-owner →
+   403 on platform export; tenant export excludes platform/other-tenant rows;
+   cross-scope/cross-tenant `GET {jobId}` → 404). single-user: sole user exports
+   both slices (AC10, AC11).
+10. **Encryption at rest**: persisted `artifact_ciphertext` is not the plaintext
+    zip; decrypt-and-stream yields the original bundle; tampered ciphertext
+    fails AES-GCM auth (AC5).
+11. **Suite green + migration**: full suite stays green; the additive migration
+    applies + rolls back cleanly; `has-pending-model-changes` → none.
+
+## Estimated Effort
+
+4-5 days.
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/IAuditExportService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditExportService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditExportManifest.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditExportSigner.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditCsvWriter.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditJsonWriter.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditExportTaskHandler.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditExportArtifactProtector.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditExportOptions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/AuditExportServiceCollectionExtensions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/AuditExportJob.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_AddAuditExportJobs.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs` | Modify (tenant export + status + download) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminEndpoints.cs` | Modify (platform export + status + download) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (AuditExportJob model config) |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (DbSet) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (call `AddAuditExport()`; map routes) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditExportSignerTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditExportServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditCsvWriterTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditExportEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditExportTaskHandlerTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md).
+2. Searched `.dev/` for related spikes/bugs/findings/decisions (audit, signing,
+   CSV-injection, AES-GCM at-rest).
+3. Confirmed the public surfaces of 37-1/37-2/37-3 (read-model shape, chain
+   head/checkpoint API, filter DTO) — this story consumes them.
+4. Confirmed the Epic 29 cabinet key purpose/scope used for signing
+   (`ISecretStore`/`KekProvider`); coordinate a dedicated signing purpose rather
+   than reusing a KEK.
+5. Planned TDD (Red-Green-Refactor) — signer + CSV + manifest are pure and
+   should be tested first.
+
+### Offline verification recipe (ships in the bundle README)
+
+Given `audit.(json|csv)` + `manifest.json` + the public verification material:
+
+1. Compute `sha256(audit.<format>)` → must equal `manifest.data_sha256`.
+2. Re-canonicalize `manifest` minus `export_signature` (sorted keys, no
+   whitespace, UTC ms timestamps) and verify `export_signature` with the key
+   identified by `manifest.signing` (`alg` + `key_version`).
+3. Recompute the audit hash chain over the exported rows in order and confirm
+   the reconstructed head equals `manifest.chain.head_hash` (and the recorded
+   `checkpoint_id`). Any mismatch = tampering or an incomplete slice.
+
+A `tamma audit verify-export <bundle.zip>` helper performs all three and exits
+non-zero on any failure.
+
+### Safe CSV
+
+Neutralize formula injection per OWASP CSV-injection guidance: prefix any field
+beginning with `= + - @`, tab (`0x09`), or CR (`0x0D`) with a leading `'`; then
+apply RFC-4180 quoting (wrap in `"…"` and double internal `"`) to every field
+containing `" , \n \r`. Apply neutralization to the value, not just the display.
+
+### Reuse, don't reinvent
+
+- AES-GCM at rest: copy the nonce‖ciphertext‖tag layout from
+  `TenantSecretProtector`; do not hand-roll a new scheme.
+- Async: `QueuedTask` + `ITaskHandler` (TypePrefix `audit.export.`) +
+  `TaskQueueProcessor`; platform-scope uses `PlatformTaskWorker` like
+  provisioning.
+- RBAC: `RequireTenantMembershipFilter` + admin-role check for tenant;
+  `PlatformOwnerAccess` for platform — mirror `OrgEndpoints.ListTenantAudit`
+  and the admin endpoints.
+
+### Audit-of-the-audit ordering
+
+Write `AUDIT.EXPORTED` AFTER capturing the chain head for the slice, so the
+export record is never inside the slice it describes (avoids a chicken-and-egg
+self-reference and keeps the recorded `head_hash` reproducible).
+
+### Migration discipline
+
+`audit_export_jobs` is additive: standard `dotnet ef migrations add`, then
+verify `has-pending-model-changes` reports none and mirror config in
+`TammaModelConfiguration.cs` only.
+
+## Logging Requirements
+
+- **INFO**: export requested (scope, format, sync|async, filter summary, actor),
+  job state transitions (`generating`→`ready`/`failed`), reaper purged N expired
+  artifacts, download served (jobId, scope).
+- **DEBUG**: row count resolved, sync-vs-async decision, signing key_version
+  selected, artifact byte size.
+- **WARN**: download requested for `expired`/missing job (410/404),
+  cross-scope/cross-tenant fetch rejected.
+- **ERROR**: artifact generation failed (jobId, non-leaky reason), signing key
+  unavailable, AES-GCM decrypt failure on download, migration/model mismatch.
+- **Structured context**: `{ jobId, scope, tenantId?, format, recordCount,
+  actorId }` where applicable.
+- **Credential safety**: NEVER log the cabinet signing key, the AES-GCM key, the
+  decrypted artifact bytes, or any un-redacted audit field. Signatures + hashes
+  are safe to log; key MATERIAL is not.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-37/story-37-5/37-5-audit-retention-policies-and-tamper-aware-pruning.md
+++ b/docs/stories/epic-37/story-37-5/37-5-audit-retention-policies-and-tamper-aware-pruning.md
@@ -1,0 +1,456 @@
+# Story 37-5: Audit Retention Policies & Tamper-Aware Pruning
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **compliance owner** (platform owner in SaaS; the sole user in single-user mode),
+I want **configurable per-category retention windows for the curated audit trail with a scheduled pruning job that deletes expired records without breaking the tamper-evident hash chain or violating an active legal hold**,
+So that **Tamma satisfies SOC2/GDPR data-minimization (don't keep audit records longer than the policy) while keeping the audit chain verifiable and legally-held records untouchable**.
+
+## Priority
+
+P1 — Required for SOC2 retention controls and GDPR data-minimization; depends on the curated audit
+projection (37-1) and the hash chain (37-2), and is gated by legal hold (37-6).
+
+## Context & Architecture Boundary
+
+This story targets the **C# port** in `apps/tamma-elsa`. **`packages/api` (the legacy TypeScript
+API) is DELETED and is NEVER a target.** All work lands in:
+
+- `Tamma.Data` — the `audit_records` read model + hash chain landed by 37-1/37-2 live in
+  `TenantDbContext` (per-tenant schema) and `ControlPlaneDbContext` (platform scope). The new
+  retention-policy entity and the pruner live here.
+- `Tamma.ElsaServer/Workflows` — a scheduled workflow + a `BackgroundService` scheduler, modeled on
+  the existing `HourlyAnalyticsRollupScheduler` / `HourlyAnalyticsRollupWorkflow` pair (Story 28-10).
+- `Tamma.Activities` — the prune activity, modeled on the existing
+  `Tamma.Activities/Analytics/PurgeStaleAnalyticsActivity.cs` (Story 28-10) but operating on
+  `audit_records` with chain re-anchoring and legal-hold consultation.
+- `Tamma.Api` — `AuditRetentionService`, plus retention endpoints on `OrgEndpoints.cs` (tenant
+  scope) and `AdminEndpoints.cs` (platform scope).
+
+**Distinct from existing analytics retention.** Story 28-10's `PurgeStaleAnalyticsActivity` already
+prunes `platform_analytics_hourly` rollups on a fixed 13-month window. That code is the **pattern
+exemplar**, NOT the thing being extended — analytics rollups have no hash chain and no legal hold.
+Audit pruning is a separate, policy-driven, chain-aware sweep over `audit_records`.
+
+**Dependency state (verified 2026-06-17):** 37-1/37-2/37-6 are not yet landed
+(`Tamma.Data/Audit`, `Tamma.Core/Audit`, `Tamma.Api/Services/Audit` do not exist). This story
+**consumes** the artifacts those stories create — `AuditRecord`, `AuditChainCheckpoint`,
+`AuditChainVerifier`, `AuditProjector`, `IAuditRecordRepository`, and `ILegalHoldService` /
+`legal_holds`. Sequence 37-1 → 37-2 → 37-6 → 37-5.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+Mirrors Epic 27 / `PromptOverride` (`user_id` XOR `tenant_id`):
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns a retention policy? | The sole user — `user_id` set, `tenant_id` NULL. | The tenant — `tenant_id` set, `user_id` NULL (one policy set per tenant). |
+| Who configures it (PUT)? | The user. | `tenant_owner` / `tenant_admin` only; `member` → 403. |
+| Who sets **platform** defaults & minimums? | The user (it's their instance). | Platform owner only (`PlatformOwnerAccess` / `OwnerAccess`), via `/api/admin/audit/retention`. |
+| What does the pruner scope to? | The user's audit chain (single chain). | Each tenant's chain (per-tenant schema) + the platform chain (control plane). |
+| Mode source | `ITammaModeProvider` (`Services/PromptStore/TammaMode.cs`) — process-stable. | same |
+
+## Acceptance Criteria
+
+1. **Retention-policy entity & table.** An `audit_retention_policies` table is added to
+   `TenantDbContext` (per-tenant, `tenant_id`-keyed) AND `ControlPlaneDbContext` (platform /
+   single-user, `user_id`-keyed) with an EF migration under `Tamma.Data/Migrations/Tenant` and
+   `.../ControlPlane`. Columns: `id`, `user_id` (single-user) / `tenant_id` (SaaS),
+   `category` (one of the 37-1 catalog control categories: CONFIG, RBAC, SECRET, BYOK, BILLING,
+   EXPORT, AUTH, IMPERSONATION, TENANT, AGENT, PERSONA), `retention_days`, `created_at`,
+   `updated_at`, `updated_by`. A `principal_xor` CHECK (`user_id` XOR `tenant_id`, mirroring
+   `PromptOverride`) and `UNIQUE NULLS NOT DISTINCT (user_id, tenant_id, category)`. A missing row
+   for a category means "use the platform default for that category".
+
+2. **Platform minimums with a compliance floor.** Platform-enforced minimum retention days per
+   category are defined in code (a static `AuditRetentionDefaults` map in `Tamma.Core/Audit` or
+   `Tamma.Data`), with the compliance-critical categories (SECRET, RBAC, BYOK, BILLING, AUTH,
+   IMPERSONATION) floored at **>= 365 days** and informational categories at a lower default
+   (e.g. AGENT/CONFIG 90 days). The floor is the hard lower bound a tenant/user policy may not go
+   below; the default is the value used when no policy row exists.
+
+3. **Read/configure retention API — tenant scope.**
+   `GET /api/v1/orgs/{tenantId}/audit/retention` returns the effective policy per category
+   (resolved row → platform default) plus the platform minimum per category, readable by any tenant
+   member. `PUT /api/v1/orgs/{tenantId}/audit/retention` upserts per-category `retention_days`,
+   gated `tenant_owner`/`tenant_admin` (member → 403). Single-user mode hits the same shape with the
+   sole user as principal.
+
+4. **Platform-default API — admin scope.** `GET` / `PUT /api/admin/audit/retention`
+   (`PlatformOwnerAccess`) reads and sets the platform default retention per category. Defaults may
+   be raised above the compliance floor but never set below it (422 if attempted, AC 8).
+
+5. **Minimum-floor enforcement on write (422, no retroactive delete).** A PUT that sets any
+   category below its platform minimum is rejected with **422** and a clear, actionable message
+   (`"category SECRET requires >= 365 days; got 90"`). Lowering retention **does not** delete
+   anything on save — only the scheduled job (AC 6) prunes, and only on its next run.
+
+6. **Scheduled pruning workflow (Elsa, daily).** An `AuditRetentionWorkflow` + `AuditRetentionScheduler`
+   `BackgroundService` (modeled on `HourlyAnalyticsRollupWorkflow` / `HourlyAnalyticsRollupScheduler`,
+   incl. the `pg_try_advisory_lock` multi-pod leader election) dispatches a daily prune. For each
+   scope (each tenant schema + the control plane), the `PruneExpiredAuditRecordsActivity` deletes
+   `audit_records` whose `occurred_at` is older than `now - effective_retention_days(category)`,
+   computed per category. Pruning **never** deletes below the platform minimum (AC 2) and **never**
+   deletes records under an active legal hold (AC 7).
+
+7. **Legal-hold exclusion (dep 37-6).** Before deleting any record, the pruner consults
+   `ILegalHoldService` (37-6). Records matching an active hold scope (category / actor / subject /
+   time-range / case_ref) are **excluded from the delete set and retained**, regardless of age. When
+   the prune set is reduced by an active hold, the pruner emits `AUDIT.RETENTION.BLOCKED_BY_HOLD`
+   (the event 37-6 expects) with the hold id and the count of records spared.
+
+8. **Below-minimum rejection message.** (Companion to AC 5.) The 422 response body names the
+   offending category, the requested value, and the enforced minimum, so the caller can correct it
+   without guessing.
+
+9. **Chain-preserving prune (re-anchor / boundary checkpoint).** Deleting a contiguous expired
+   prefix of a chain would break `prev_hash` linkage for the first surviving record and trip a false
+   tamper alarm in `AuditChainVerifier` (37-2). The pruner therefore **seals the pruned range with a
+   retained boundary checkpoint**: before deleting, it writes (or updates) an
+   `AuditChainCheckpoint` (37-2 entity) at the last-pruned sequence with `head_hash` = the hash of
+   the last record being deleted, marked as a **prune boundary**. Verification (37-2) treats records
+   at/after a prune-boundary checkpoint as chaining to the checkpoint, not to a now-deleted
+   `prev_hash`. After a prune, `AuditChainVerifier.VerifyAsync(scope, from, to)` returns **OK** for
+   the surviving range.
+
+10. **Pruning is itself audited.** A successful prune emits `AUDIT.RETENTION.PRUNED` with per-scope,
+    per-category counts (`{ scope, category, deleted, retainedByHold, cutoff }`), the new boundary
+    checkpoint sequence, and the policy snapshot used. This event is one of the sensitive actions in
+    the 37-1 catalog, so it is itself projected into `audit_records` (audit of the audit pruning).
+
+11. **Best-effort, isolated, replayable.** A prune failure for one scope is logged at WARN, emits
+    `AUDIT.RETENTION.FAILED`, and **does not** abort the other scopes or fail the workflow (same
+    best-effort contract as `PurgeStaleAnalyticsActivity`). `OperationCanceledException` on host
+    shutdown propagates cleanly (not swallowed as a failure). A missed daily run self-recovers on
+    the next run because pruning is idempotent (deleting an already-deleted range is a no-op).
+
+12. **Tests.** Policy CRUD + per-mode RBAC (owner/admin/member 403, single-user sole user);
+    minimum-floor enforcement (422 below floor, accepts at/above); lowering retention does not
+    delete on save; prune deletes only past-cutoff records per category; prune respects an active
+    legal hold (held records survive, `AUDIT.RETENTION.BLOCKED_BY_HOLD` emitted); **post-prune chain
+    verifies OK via `AuditChainVerifier`** (the load-bearing test); `AUDIT.RETENTION.PRUNED`
+    emission with correct counts; prune below platform minimum is impossible (clamps).
+
+## Technical Design
+
+### Entity — `AuditRetentionPolicy`
+
+`apps/tamma-elsa/src/Tamma.Data/Entities/AuditRetentionPolicy.cs` (mirrors the `PromptOverride`
+per-mode XOR shape):
+
+```csharp
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 37-5 — per-category audit retention window. Per-mode owned:
+/// single-user keys by UserId (TenantId NULL); SaaS keys by TenantId
+/// (UserId NULL) — the same XOR invariant as <see cref="PromptOverride"/>.
+/// A missing row for a category means "use the platform default".
+/// </summary>
+public class AuditRetentionPolicy
+{
+    public Guid Id { get; set; }
+    public Guid? UserId { get; set; }       // single-user mode
+    public Guid? TenantId { get; set; }     // SaaS mode
+
+    /// <summary>37-1 control category (CONFIG, RBAC, SECRET, ...).</summary>
+    public string Category { get; set; } = null!;
+
+    /// <summary>Retention window in days. CHECK > 0; enforced >= platform minimum at write time.</summary>
+    public int RetentionDays { get; set; }
+
+    public Guid? UpdatedBy { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}
+```
+
+Model config goes in `Tamma.Data/TammaModelConfiguration.cs` (the single source for entity config in
+this codebase): the `principal_xor` CHECK, the `retention_days > 0` CHECK, and
+`UNIQUE NULLS NOT DISTINCT (user_id, tenant_id, category)`. EF migrations: additive new table, so a
+normal `dotnet ef migrations add AddAuditRetentionPolicies` against both the Tenant and ControlPlane
+contexts; verify `has-pending-model-changes` reports none afterward.
+
+### Platform minimums & defaults — `AuditRetentionDefaults`
+
+`apps/tamma-elsa/src/Tamma.Core/Audit/AuditRetentionDefaults.cs` (data, not branches):
+
+```csharp
+public static class AuditRetentionDefaults
+{
+    public const int ComplianceFloorDays = 365;   // SOC2 / GDPR floor
+
+    // Per-category (Minimum, Default). Default >= Minimum always.
+    public static readonly IReadOnlyDictionary<string, (int MinDays, int DefaultDays)> ByCategory =
+        new Dictionary<string, (int, int)>
+        {
+            ["SECRET"]        = (365, 730),
+            ["RBAC"]          = (365, 730),
+            ["BYOK"]          = (365, 730),
+            ["BILLING"]       = (365, 730),
+            ["AUTH"]          = (365, 365),
+            ["IMPERSONATION"] = (365, 730),
+            ["TENANT"]        = (365, 730),
+            ["EXPORT"]        = (365, 365),
+            ["PERSONA"]       = (90,  365),
+            ["CONFIG"]        = (90,  365),
+            ["AGENT"]         = (30,  90),
+        };
+
+    public static (int MinDays, int DefaultDays) For(string category)
+        => ByCategory.TryGetValue(category, out var v) ? v : (ComplianceFloorDays, ComplianceFloorDays);
+}
+```
+
+The exact category list comes from the 37-1 `SensitiveActionCatalog` categories; this map MUST cover
+every category the catalog defines (a completeness test pins that).
+
+### Resolution order (effective retention)
+
+For a given `(principal, category)`:
+1. Principal's policy row for the category → if present, use `RetentionDays` (already validated
+   `>= minimum` at write time).
+2. Platform default for the category (`AuditRetentionDefaults.For(category).DefaultDays`).
+
+Never falls below `AuditRetentionDefaults.For(category).MinDays` even if a stale row somehow holds a
+smaller value — the pruner clamps `effective = max(resolved, minimum)` as a belt-and-suspenders guard
+(AC 6).
+
+### Service — `AuditRetentionService`
+
+`apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditRetentionService.cs`:
+
+- `GetEffectivePolicyAsync(principal)` → per-category `{ category, effectiveDays, minimumDays, source: row|default }`.
+- `UpsertAsync(principal, category, retentionDays, updatedBy)` → validates `retentionDays >= minimum`
+  (throws a `TammaError("AUDIT.RETENTION.BELOW_MINIMUM", ..., severity: Medium)` that the endpoint
+  maps to **422**); upserts the row; emits `AUDIT.RETENTION.POLICY_CHANGED` (sensitive → projected).
+- `GetPlatformDefaultsAsync()` / `SetPlatformDefaultAsync(category, days)` — admin path; same floor
+  check.
+
+### Activity — `PruneExpiredAuditRecordsActivity`
+
+`apps/tamma-elsa/src/Tamma.Activities/Audit/PruneExpiredAuditRecordsActivity.cs`. Direct analog of
+`PurgeStaleAnalyticsActivity` (best-effort, `ExecuteDeleteAsync`, pure-DI `PruneScopeAsync` entry
+point callable from an admin force-prune endpoint, `ComputeCutoff`-style helper). Per scope:
+
+```
+for each category in catalog:
+    effectiveDays = max(resolvedPolicy(category), AuditRetentionDefaults.For(category).MinDays)
+    cutoff        = nowUtc.AddDays(-effectiveDays)
+
+    candidates    = audit_records where category = @category and occurred_at < @cutoff   // (scope-filtered)
+    held          = candidates intersect activeLegalHoldScopes (via ILegalHoldService)
+    toDelete      = candidates except held
+
+    if toDelete is empty: continue
+
+    // CHAIN RE-ANCHOR (AC 9) — before deleting, seal the pruned prefix:
+    lastPruned = max(source_sequence_number) in toDelete that is contiguous from the chain head
+    write/update AuditChainCheckpoint { scope, head_sequence = lastPruned,
+                                        head_hash = record_hash(lastPruned), is_prune_boundary = true,
+                                        signed_at, signature }   // signature via 37-2 envelope key
+
+    deleted = ExecuteDeleteAsync(toDelete)
+    emit AUDIT.RETENTION.PRUNED { scope, category, deleted, retainedByHold = held.Count, cutoff, boundarySeq = lastPruned }
+    if held.Any(): emit AUDIT.RETENTION.BLOCKED_BY_HOLD { scope, category, holdIds, spared = held.Count }
+```
+
+> **Chain re-anchor detail (AC 9).** The hash chain is per-scope and ordered by
+> `source_sequence_number`. Pruning only ever removes a **contiguous prefix** (oldest records) — you
+> never punch a hole in the middle, because retention is age-based and monotone. The boundary
+> checkpoint records the hash of the last deleted record so the first **surviving** record's
+> `prev_hash` still has a verifiable anchor. `AuditChainVerifier.VerifyAsync` (37-2) must, when it
+> encounters a record whose `prev_hash` points at a row that no longer exists, look for a
+> prune-boundary checkpoint at that sequence and treat a match as a valid link (no tamper). If a
+> record under an active hold prevents a contiguous prefix delete (a held record sits in the
+> middle of the expired range), the pruner deletes only up to the first held record this run — the
+> rest is reconsidered on the next run after the hold releases. This keeps "contiguous prefix"
+> invariant true and the chain always verifiable.
+
+### Workflow + scheduler
+
+- `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AuditRetentionWorkflow.cs` — single-step workflow
+  running `PruneExpiredAuditRecordsActivity` across all scopes (iterate tenant schemas via the
+  tenant registry; control plane as the platform scope). Mirror `HourlyAnalyticsRollupWorkflow`'s
+  `DefinitionId` + `CronExpression` shape (daily, e.g. `0 30 3 * * *`).
+- `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AuditRetentionScheduler.cs` — `BackgroundService`
+  copy of `HourlyAnalyticsRollupScheduler`: `Enabled` gate (default true; tests/non-Elsa roots set
+  false), `FireAtMinute`/poll, `pg_try_advisory_lock` leader election (reuse the
+  `IRollupSchedulerLeaderLock` abstraction or a parallel `IAuditRetentionLeaderLock`), idempotent
+  last-fired-day tracking, WARN-and-continue on dispatch failure. Options section
+  `AuditRetention` with `Enabled`, `FireAtHourUtc`, `PollInterval`.
+
+### Endpoints
+
+Tenant (`OrgEndpoints.cs`, gated via `RequireTenantMembershipFilter` + `RoleAtLeast(..Admin)` for
+writes, the same pattern OrgEndpoints already uses; reads any member):
+
+```
+GET /api/v1/orgs/{tenantId}/audit/retention          -> effective per-category policy + minimums (member+)
+PUT /api/v1/orgs/{tenantId}/audit/retention          -> upsert (tenant_owner/tenant_admin; member 403); 422 below floor
+```
+
+Platform (`AdminEndpoints.cs`, `PlatformOwnerAccess`):
+
+```
+GET /api/admin/audit/retention                       -> platform default per-category retention + minimums
+PUT /api/admin/audit/retention                        -> set platform defaults (>= floor; 422 otherwise)
+```
+
+## Dependencies
+
+- **37-1 (Sensitive-Action Audit Taxonomy & Curated Projection)** — provides `audit_records`,
+  `SensitiveActionCatalog` (the category list this story's policies key on), `AuditProjector`,
+  `IAuditRecordRepository`. **Hard prerequisite.**
+- **37-2 (Tamper-Evident Hash-Chain)** — provides `record_hash`/`prev_hash`,
+  `AuditChainCheckpoint`, `AuditChainVerifier`, and the envelope signing key. The prune re-anchor
+  (AC 9) writes a prune-boundary checkpoint and relies on the verifier honoring it. **Hard
+  prerequisite.**
+- **37-6 (Legal Hold)** — provides `legal_holds` + `ILegalHoldService`; the pruner consults active
+  holds before deleting (AC 7) and emits the `AUDIT.RETENTION.BLOCKED_BY_HOLD` event 37-6 expects.
+  **Hard prerequisite.**
+- **Story 28-10 (analytics retention)** — `PurgeStaleAnalyticsActivity` /
+  `HourlyAnalyticsRollupScheduler` are the **pattern exemplars** (best-effort prune + advisory-lock
+  scheduler). Not modified.
+- **Epic 27 / `PromptOverride`** — per-mode `user_id` XOR `tenant_id` ownership pattern.
+- **Blocks**: 37-8 (right-to-erasure) shares the "consult legal hold before delete" path and may
+  reuse `AuditRetentionDefaults`; the retention dashboard story surfaces these policies.
+
+## Testing Strategy
+
+Tests live in `apps/tamma-elsa/tests/`; docker-bound suites run via
+`sg docker -c "dotnet test ..."` (session docker group is stale).
+
+1. **Policy CRUD + RBAC (`tests/Tamma.Api.Tests/Audit/AuditRetentionEndpointsTests.cs`)** — per
+   mode: SaaS tenant_owner & tenant_admin can PUT, member → 403, cross-tenant → 404; single-user
+   sole user can PUT; admin platform-default route requires `PlatformOwnerAccess`. GET returns
+   effective policy + minimums.
+2. **Minimum-floor (`AuditRetentionServiceTests.cs`)** — PUT below floor → 422 with category +
+   requested + minimum in the message; PUT at floor and above → accepted; defaults completeness:
+   every `SensitiveActionCatalog` category has an `AuditRetentionDefaults` entry; lowering retention
+   does NOT delete on save (no rows removed by `UpsertAsync`).
+3. **Prune correctness (`PruneExpiredAuditRecordsActivityTests.cs`)** — seed records straddling the
+   cutoff per category; assert only past-cutoff rows deleted, per-category cutoffs honored, clamp to
+   minimum even with a stale sub-minimum row; `OperationCanceledException` propagates;
+   per-scope failure isolated (`AUDIT.RETENTION.FAILED`, other scopes still run).
+4. **Legal hold (`PruneRespectsLegalHoldTests.cs`)** — active hold covering some expired records →
+   those records survive the prune, `AUDIT.RETENTION.BLOCKED_BY_HOLD` emitted with hold id + spared
+   count; release the hold → next prune deletes them.
+5. **Post-prune chain verifies (LOAD-BEARING, `PruneChainReanchorTests.cs`)** — build a chain via
+   the 37-2 projector, prune the expired prefix, write the boundary checkpoint, then
+   `AuditChainVerifier.VerifyAsync(scope, from, to)` returns **OK** for the surviving range (no false
+   tamper). Negative control: prune WITHOUT writing the boundary checkpoint → verifier reports a
+   broken link (proves the re-anchor is what keeps it valid). Held-record-in-the-middle → only the
+   contiguous prefix up to it is pruned, chain still verifies.
+6. **Event emission (`AuditRetentionEventsTests.cs`)** — successful prune emits
+   `AUDIT.RETENTION.PRUNED` with `{ scope, category, deleted, retainedByHold, cutoff, boundarySeq }`;
+   `AUDIT.RETENTION.POLICY_CHANGED` on PUT; both projected into `audit_records` by 37-1.
+7. **Scheduler (`AuditRetentionSchedulerTests.cs`)** — mirror `HourlyAnalyticsRollupSchedulerTests`:
+   fires once per day at the configured hour, advisory-lock leader election skips non-leaders,
+   `Enabled=false` suppresses the loop, dispatch failure → WARN + continue.
+
+## Estimated Effort
+
+4-5 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/AuditRetentionPolicy.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Core/Audit/AuditRetentionDefaults.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (entity config: XOR + unique + CHECK) |
+| `apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs` | Modify (add `DbSet<AuditRetentionPolicy>`) |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (add `DbSet<AuditRetentionPolicy>`) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/*_AddAuditRetentionPolicies.cs` | Create (EF migration) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/*_AddAuditRetentionPolicies.cs` | Create (EF migration) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditRetentionService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/IAuditRetentionService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/Audit/PruneExpiredAuditRecordsActivity.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/Audit/AuditRetentionEventTypes.cs` | Create (PRUNED / BLOCKED_BY_HOLD / FAILED / POLICY_CHANGED) |
+| `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AuditRetentionWorkflow.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AuditRetentionScheduler.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs` | Modify (tenant retention GET/PUT) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminEndpoints.cs` | Modify (platform retention GET/PUT) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (register service + scheduler + map endpoints) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditRetentionEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditRetentionServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/Audit/PruneExpiredAuditRecordsActivityTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/Audit/PruneRespectsLegalHoldTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/Audit/PruneChainReanchorTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/Audit/AuditRetentionSchedulerTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes/bugs/findings/decisions (esp. Epic 28-10 retention, Epic 29
+   secret cabinet, Epic 27 per-mode ownership).
+3. Confirmed 37-1, 37-2, 37-6 have landed (this story consumes `AuditRecord`,
+   `AuditChainCheckpoint`, `AuditChainVerifier`, `ILegalHoldService`). If they have not, the
+   activity/service interfaces must be coded against the contracts those stories define.
+4. Planned a TDD approach — write AC 12 tests first, especially the post-prune chain verification.
+
+### Why a boundary checkpoint instead of recomputing the chain
+
+Re-hashing surviving records to "close the gap" would (a) mutate immutable audit rows, defeating the
+tamper-evidence, and (b) be O(chain length) per prune. The boundary checkpoint is O(1): it records
+the hash of the last-pruned record and lets the verifier treat that as the anchor for the first
+survivor. This is the same envelope-signed checkpoint mechanism 37-2 already uses for periodic chain
+anchoring — the prune path reuses it with `is_prune_boundary = true` so verification can distinguish
+a routine periodic anchor from a "everything before here was lawfully pruned" anchor.
+
+### Contiguous-prefix invariant
+
+Age-based retention only ever expires the oldest records, so the delete set is always a prefix of the
+chain ordered by `source_sequence_number` — never a hole. A legal hold in the middle of the expired
+range caps this run's delete at the first held record; the prefix invariant (and thus chain
+verifiability) is preserved. Document this clearly so a future "prune by actor/subject" feature
+(which would punch holes) is consciously rejected or designed to re-anchor differently.
+
+### Per-mode is non-negotiable
+
+Do not ship the single-user model and assume it works for SaaS (CLAUDE.md universal rule). The
+policy entity carries both `user_id` and `tenant_id` with an XOR CHECK; the service selects the
+column from `ITammaModeProvider`; the pruner scopes per tenant schema in SaaS and to the sole
+user/control-plane in single-user.
+
+### Best-effort, never the point of the run
+
+Copy `PurgeStaleAnalyticsActivity`'s failure contract verbatim: per-scope try/catch, WARN +
+`AUDIT.RETENTION.FAILED` event, never rethrow (except `OperationCanceledException` on shutdown).
+Retention housekeeping must never crash the scheduled workflow or starve other tenants' prunes.
+
+## Logging Requirements
+
+- **INFO**: prune completed per scope (`scope`, `category`, `deleted`, `retainedByHold`, `cutoff`,
+  `boundarySeq`); policy upserted (`principal`, `category`, `retentionDays`); scheduler dispatched
+  (day, instance, lockKey).
+- **DEBUG**: per-category candidate count and cutoff; effective-policy resolution
+  (row vs default); leader-lock acquire/skip.
+- **WARN**: prune failed for a scope (`scope`, error) → continues; PUT below minimum (422); flapping
+  legal-hold reducing prune sets repeatedly; scheduler dispatch failed (next-run recovery).
+- **ERROR**: boundary-checkpoint write failed (prune is aborted for that scope to avoid breaking the
+  chain — never delete without a valid re-anchor); chain verification fails immediately after a prune
+  (regression guard).
+- **Structured context**: `{ scope, tenantId|userId, category, deleted, retainedByHold, cutoff,
+  boundarySeq, holdIds }` where applicable.
+- **Credential / data safety**: never log audit `payload_json`, secret plaintext, or signing-key
+  material; the prune logs counts and cutoffs only, never record bodies.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-37/story-37-6/37-6-legal-hold.md
+++ b/docs/stories/epic-37/story-37-6/37-6-legal-hold.md
@@ -1,0 +1,386 @@
+# Story 37-6: Legal Hold
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **compliance/legal operator** (platform owner) and a **tenant administrator**,
+I want to place a legal hold that freezes audit records (and optionally related per-tenant data) matching a defined scope — time range, actor, subject, or case reference,
+So that retention pruning (Story 37-5) and right-to-erasure (Story 37-8) cannot delete those records while litigation, investigation, or regulatory inquiry is active, and so the act of placing/releasing a hold is itself an immutable, auditable event.
+
+## Priority
+
+P1 - Required for litigation-readiness and to make destructive compliance operations (retention pruning, GDPR erasure) safe. A hold is a hard "do not delete" gate that overrides every automated and operator-initiated deletion path.
+
+## Context & Architecture Alignment
+
+This story targets the **C# `apps/tamma-elsa`** application — the legacy TypeScript `packages/api` is deleted and is NOT a target.
+
+- **`Tamma.Data`** — owns the audit read-model (created in Story 37-1), the per-tenant `TenantDbContext`, and the platform `ControlPlaneDbContext`. The `legal_holds` registry and the `LegalHold` entity live here.
+- **`Tamma.Api`** — owns the HTTP surface (`OrgEndpoints` for tenant scope, `AdminEndpoints` for platform scope) and the hold service.
+- **DCB substrate** — every lifecycle and enforcement event is appended via `IEventRepository.AppendAsync(DomainEvent)` (`Tamma.Data/Repositories/EventRepository.cs`), exactly as `AlertEndpoints` already does.
+
+A legal hold sits **upstream** of the two destructive operations in this epic:
+
+```
+                  ┌──────────────────────────┐
+                  │  legal_holds (registry)  │   ← this story
+                  └────────────┬─────────────┘
+                               │  ILegalHoldGuard.IsHeld(scope)
+              ┌────────────────┴─────────────────┐
+              ▼                                   ▼
+   Retention pruner (37-5)              Right-to-erasure (37-8)
+   skips in-scope records              refuses in-scope records
+   emits RETENTION.BLOCKED_BY_HOLD     emits ERASURE.BLOCKED_BY_HOLD
+```
+
+Per CLAUDE.md "Operating Modes", ownership is answered for **both** modes (the two-scoping-model rule):
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who places/releases a **tenant-scope** hold? | The sole user (no RBAC). | `tenant_owner` only (route + role gate); `tenant_admin` MAY be granted by configuration but default is owner-only; `member` → 403. |
+| Who places/releases a **platform-wide** hold (spans tenants / system audit)? | The sole user (it is their instance). | Platform owner ONLY (`PlatformOwnerAccess`). Never exposed on the tenant surface. |
+| Where is hold ownership stored? | `user_id` set, `tenant_id` NULL (principal XOR, mirroring `prompt_overrides`). | `tenant_id` set, `user_id` NULL; platform-wide holds have BOTH NULL (`is_platform_wide = true`). |
+| Mode source | `ITammaModeProvider` (`Services/PromptStore/TammaMode.cs`) — process-stable. | same |
+
+## Acceptance Criteria
+
+1. A **`legal_holds`** table (per-mode owned) stores at minimum: `id` (UUID), `tenant_id` (NULL for platform-wide / single-user-platform holds), `user_id` (set only in single-user mode), `is_platform_wide` (bool), `scope_category` (e.g. `audit` | `tenant-data`), `scope_actor_id`, `scope_subject_id`, `scope_time_from`, `scope_time_to`, `case_ref`, `reason`, `status` (`active` | `released`), `placed_by`, `placed_at`, `released_by`, `released_at`, `created_at`, `updated_at`. A `LegalHold` entity in `Tamma.Data/Entities/LegalHold.cs` maps it; EF config (CHECK + indexes) lives in `TammaModelConfiguration.cs`.
+
+2. A **principal-XOR CHECK constraint** enforces the per-mode ownership invariant: a hold is either tenant-scope (`tenant_id` set, `user_id` NULL, `is_platform_wide=false`), single-user-scope (`user_id` set, `tenant_id` NULL), or platform-wide (`tenant_id` NULL, `user_id` NULL, `is_platform_wide=true`) — never an ambiguous mix. A CHECK also restricts `status` to `{active, released}` and `scope_category` to the allowed set.
+
+3. **Place hold** — tenant scope: `POST /api/v1/orgs/{tenantId}/audit/legal-holds`. Requires `tenant_owner` in SaaS (member → **403**); any user in single-user mode. Body carries the scope (`scope_category`, optional `actor`, `subject`, `time_from`, `time_to`, `case_ref`) + `reason` (required). Forces `tenant_id = {tenantId}` server-side (body `tenantId` mismatch → 400, mirroring `CreateTenantChannel`). Returns `201 Created` with the hold DTO.
+
+4. **Place hold** — platform scope: `POST /api/v1/admin/audit/legal-holds`. Requires `PlatformOwnerAccess`. May target a specific `tenant_id` (cross-tenant hold) or set `is_platform_wide=true` (spans all tenants + system audit). Returns `201`.
+
+5. **Release hold** — `DELETE /api/v1/orgs/{tenantId}/audit/legal-holds/{id}` (tenant, `tenant_owner`; cross-tenant `id` → 404) and `DELETE /api/v1/admin/audit/legal-holds/{id}` (platform, `PlatformOwnerAccess`). Release is a **status flip to `released`** (stamps `released_by`/`released_at`) — rows are NEVER hard-deleted, so the hold history survives for compliance. Releasing an already-released hold → `409 Conflict`.
+
+6. An active hold sets a queryable predicate that 37-5 and 37-8 MUST consult before deleting. This story ships **`ILegalHoldGuard`** with `Task<HoldDecision> EvaluateAsync(LegalHoldQuery candidate, CancellationToken)` returning whether a candidate record (tenant, actor, subject, timestamp, case) is covered by ANY active hold, plus the matching `hold_id`(s). The guard is the single seam both destructive stories depend on.
+
+7. While a hold is active, any prune attempt against in-scope records is **blocked** (the pruner skips them and continues with out-of-scope rows) and emits **`AUDIT.RETENTION.BLOCKED_BY_HOLD`** (tags: `tenantId`, `holdId`, `caseRef`, count of records skipped). The 37-5 pruner calls `ILegalHoldGuard` before each delete batch; this story provides the guard + the event type + the integration test, and adds the call site as a NEW hook in the 37-5 pruner.
+
+8. While a hold is active, any right-to-erasure attempt against in-scope records is **refused** and emits **`AUDIT.ERASURE.BLOCKED_BY_HOLD`** (tags: `tenantId`, `holdId`, `subjectId`, `caseRef`). Erasure of a held subject does not partially delete — it fails closed (the whole erasure request is rejected with a 409-style result surfaced to 37-8's caller) so no in-scope record is removed while held. This story provides the guard + event type + integration test, and adds the call site as a NEW hook in the 37-8 erasure flow.
+
+9. Placing a hold emits **`AUDIT.LEGAL_HOLD.PLACED`** and releasing emits **`AUDIT.LEGAL_HOLD.RELEASED`** — both sensitive, appended to the audit read-model via `IEventRepository.AppendAsync`, immutable (no update/delete path), with tags `tenantId`, `holdId`, `caseRef`, `placedBy`/`releasedBy`, `scopeCategory`, and `isPlatformWide`.
+
+10. **List holds** — `GET /api/v1/orgs/{tenantId}/audit/legal-holds` (tenant members; tenant-scope rows ONLY — never platform-wide or other-tenant rows) and `GET /api/v1/admin/audit/legal-holds` (`PlatformOwnerAccess`; all holds, filterable by `tenantId`, `status`, `caseRef`). Lists return active + historical (released) holds with scope, `placed_by`, `placed_at`, `released_by`, `released_at`, and `status`. Tenant member sees the list read-only and gets **403** on place/release in SaaS.
+
+11. **Overlapping holds are handled additively** — a record covered by ≥1 active hold is held; releasing ONE overlapping hold does NOT unfreeze a record still covered by another. `ILegalHoldGuard.EvaluateAsync` returns `IsHeld=true` while any active hold matches, and the prune/erasure paths re-evaluate per operation (no caching of a stale "not held" decision across a hold placement).
+
+12. **Release re-enables deletion** — once the last covering hold is released, a subsequent prune/erasure of the (now out-of-scope) record proceeds normally and emits the standard 37-5/37-8 success events (no `BLOCKED_BY_HOLD`).
+
+13. Unit + integration tests cover: hold blocks retention prune, hold blocks erasure, release re-enables prune AND erasure, RBAC per mode (single-user any-user; SaaS owner-only place/release, member 403, cross-tenant 404), hold place/release audited (PLACED/RELEASED events appended exactly once), overlapping holds (two holds, release one, still held), and scope matching (actor-only, subject-only, time-range, case-ref, and combined predicates).
+
+## Technical Design
+
+### Entity — `Tamma.Data/Entities/LegalHold.cs` (NEW)
+
+```csharp
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 37-6 — a legal hold freezes audit records (and optionally related
+/// per-tenant data) matching its scope so retention pruning (37-5) and
+/// right-to-erasure (37-8) cannot delete them while <see cref="Status"/> is
+/// <c>active</c>. Per-mode owned (CLAUDE.md "Operating Modes"):
+/// exactly one of tenant-scope / single-user-scope / platform-wide.
+/// </summary>
+public class LegalHold
+{
+    public Guid Id { get; set; }
+
+    // ── Ownership (principal XOR, mirrors prompt_overrides) ──
+    public Guid? TenantId { get; set; }       // tenant-scope hold
+    public Guid? UserId { get; set; }         // single-user-mode hold
+    public bool IsPlatformWide { get; set; }  // spans all tenants + system audit
+
+    // ── Scope predicate (any subset; NULL field = unconstrained) ──
+    public string ScopeCategory { get; set; } = "audit"; // audit | tenant-data
+    public Guid? ScopeActorId { get; set; }    // the acting user/agent
+    public string? ScopeSubjectId { get; set; } // data subject (GDPR subject ref)
+    public DateTime? ScopeTimeFrom { get; set; }
+    public DateTime? ScopeTimeTo { get; set; }
+    public string? CaseRef { get; set; }        // matter / case identifier
+
+    public string Reason { get; set; } = null!;
+
+    // ── Lifecycle ──
+    public string Status { get; set; } = LegalHoldStatus.Active; // active | released
+    public Guid? PlacedBy { get; set; }
+    public DateTime PlacedAt { get; set; }
+    public Guid? ReleasedBy { get; set; }
+    public DateTime? ReleasedAt { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}
+
+public static class LegalHoldStatus
+{
+    public const string Active = "active";
+    public const string Released = "released";
+    public static readonly string[] All = { Active, Released };
+}
+
+public static class LegalHoldScopeCategory
+{
+    public const string Audit = "audit";
+    public const string TenantData = "tenant-data";
+    public static readonly string[] All = { Audit, TenantData };
+}
+```
+
+### EF model config — `Tamma.Data/TammaModelConfiguration.cs` (MODIFY)
+
+Mirror the existing `users`/`tenants` style (`ToTable` + `HasCheckConstraint` + `HasIndex`):
+
+```csharp
+modelBuilder.Entity<LegalHold>(entity =>
+{
+    entity.ToTable("legal_holds", t =>
+    {
+        // Per-mode ownership XOR: tenant-scope OR single-user-scope OR platform-wide.
+        t.HasCheckConstraint("ck_legal_holds_principal_xor",
+            "(\"TenantId\" IS NOT NULL AND \"UserId\" IS NULL AND \"IsPlatformWide\" = false) " +
+            "OR (\"UserId\" IS NOT NULL AND \"TenantId\" IS NULL AND \"IsPlatformWide\" = false) " +
+            "OR (\"TenantId\" IS NULL AND \"UserId\" IS NULL AND \"IsPlatformWide\" = true)");
+        t.HasCheckConstraint("ck_legal_holds_status",
+            "\"Status\" IN ('active','released')");
+        t.HasCheckConstraint("ck_legal_holds_scope_category",
+            "\"ScopeCategory\" IN ('audit','tenant-data')");
+    });
+
+    entity.HasKey(e => e.Id);
+    entity.Property(e => e.Reason).IsRequired();
+
+    // Hot path: "is this candidate covered by an active hold?" — filtered
+    // partial index keeps the guard fast even with thousands of released rows.
+    entity.HasIndex(e => new { e.TenantId, e.Status })
+        .HasFilter("\"Status\" = 'active'");
+    entity.HasIndex(e => e.CaseRef);
+    entity.HasIndex(e => e.ScopeSubjectId);
+});
+```
+
+Add `public DbSet<LegalHold> LegalHolds => Set<LegalHold>();` to `ControlPlaneDbContext.cs`. (The registry is platform-resident so platform-wide and cross-tenant holds are evaluable in one query; tenant-scope rows carry `tenant_id`. This mirrors how `Alerts`/`AlertChannels` are CP-resident yet carry an optional `TenantId`.) Add an additive EF migration under `Tamma.Data/Migrations/ControlPlane/` (`dotnet ef migrations add AddLegalHolds`); confirm `has-pending-model-changes` reports none afterwards.
+
+### Guard — `Tamma.Api/Services/Audit/ILegalHoldGuard.cs` + `LegalHoldGuard.cs` (NEW)
+
+The single seam 37-5 and 37-8 depend on. Pure read against `legal_holds` where `Status = active`.
+
+```csharp
+namespace Tamma.Api.Services.Audit;
+
+/// <summary>Candidate record being considered for deletion.</summary>
+public sealed record LegalHoldQuery(
+    Guid? TenantId,
+    string ScopeCategory,
+    Guid? ActorId,
+    string? SubjectId,
+    DateTime Timestamp,
+    string? CaseRef);
+
+/// <summary>Decision returned to the pruner / erasure flow.</summary>
+public sealed record HoldDecision(bool IsHeld, IReadOnlyList<Guid> MatchingHoldIds);
+
+public interface ILegalHoldGuard
+{
+    /// <summary>
+    /// Returns <see cref="HoldDecision.IsHeld"/> = true when ANY active hold
+    /// covers the candidate. Coverage = ownership match (platform-wide, OR
+    /// same tenant, OR single-user) AND every non-null scope predicate
+    /// matches (actor, subject, [time_from, time_to], case_ref). NULL scope
+    /// fields are wildcards. Overlapping holds are additive — true while one
+    /// matches. Never throws "blocked" itself; callers act on the decision.
+    /// </summary>
+    Task<HoldDecision> EvaluateAsync(LegalHoldQuery candidate, CancellationToken ct);
+}
+```
+
+`LegalHoldGuard` filters in SQL on ownership + `Status = active` (using the partial index) and applies the scope predicates. Fail-closed contract: if the guard query throws (CP DB unavailable), the pruner/erasure MUST treat the decision as **held** (do not delete) — destructive operations fail safe, not open. This is documented on the interface and asserted by a test.
+
+### Service — `Tamma.Api/Services/Audit/LegalHoldService.cs` (NEW)
+
+Owns place/release/list with per-mode scope derivation + lifecycle event emission (`AUDIT.LEGAL_HOLD.PLACED` / `RELEASED` via `IEventRepository`). Endpoints stay thin (validation + RBAC + DTO), delegating to the service — the established `AlertEndpoints` → repo pattern, but with a service layer because the scope-derivation + event-emission logic is shared across the four route variants.
+
+```csharp
+public sealed class LegalHoldService
+{
+    public LegalHoldService(
+        ControlPlaneDbContext db,
+        IEventRepository events,
+        ITammaModeProvider mode,
+        TimeProvider clock,
+        ILogger<LegalHoldService> logger) { /* ... */ }
+
+    public Task<LegalHold> PlaceAsync(PlaceHoldCommand cmd, CancellationToken ct);
+    public Task<LegalHold> ReleaseAsync(Guid id, Guid? releasedBy, /* scope */ Guid? tenantId, bool platform, CancellationToken ct);
+    public Task<IReadOnlyList<LegalHold>> ListAsync(LegalHoldListFilter filter, CancellationToken ct);
+}
+```
+
+### Event types — `Tamma.Api/Services/Audit/LegalHoldEventTypes.cs` (NEW)
+
+```csharp
+public static class LegalHoldEventTypes
+{
+    public const string Placed   = "AUDIT.LEGAL_HOLD.PLACED";
+    public const string Released = "AUDIT.LEGAL_HOLD.RELEASED";
+}
+
+public static class AuditDeletionEventTypes
+{
+    public const string RetentionBlockedByHold = "AUDIT.RETENTION.BLOCKED_BY_HOLD";
+    public const string ErasureBlockedByHold   = "AUDIT.ERASURE.BLOCKED_BY_HOLD";
+}
+```
+
+### Endpoints — `Tamma.Api/Endpoints/OrgEndpoints.cs` + `AdminEndpoints.cs` (MODIFY)
+
+Tenant-scope handlers added to `OrgEndpoints` (alongside the existing `ListTenantAudit`), platform-scope handlers added to `AdminEndpoints`. Both mirror `AlertEndpoints`' tenant/admin split and its `RequireTenantAdmin`-style inline role gate.
+
+```
+# tenant scope (RequireTenantMembershipFilter; place/release require owner in SaaS)
+GET    /api/v1/orgs/{tenantId}/audit/legal-holds
+POST   /api/v1/orgs/{tenantId}/audit/legal-holds
+DELETE /api/v1/orgs/{tenantId}/audit/legal-holds/{id}
+
+# platform scope (PlatformOwnerAccess)
+GET    /api/v1/admin/audit/legal-holds
+POST   /api/v1/admin/audit/legal-holds
+DELETE /api/v1/admin/audit/legal-holds/{id}
+```
+
+Route registration in `Program.cs`: tenant routes on the `orgs` group with `RequireTenantMembershipFilter` (matching the existing `/{tenantId}/alerts` block); admin routes with `.RequireAuthorization("PlatformOwnerAccess")` (matching the platform-admin block).
+
+### Enforcement hooks (NEW call sites in sibling stories)
+
+This story owns the guard + event types + the integration tests that prove blocking; the **call sites** are added into the 37-5 pruner and the 37-8 erasure flow as part of this story's diff (they are NEW because those stories are siblings in the same epic):
+
+- **37-5 pruner** — before deleting an audit batch, call `ILegalHoldGuard.EvaluateAsync` per candidate; skip held rows, append `AUDIT.RETENTION.BLOCKED_BY_HOLD` once per affected hold with the skipped count, continue with unheld rows.
+- **37-8 erasure** — before erasing a subject's records, evaluate the hold guard; if held, append `AUDIT.ERASURE.BLOCKED_BY_HOLD` and reject the whole erasure request (fail closed — no partial delete).
+
+If 37-5 / 37-8 land after this story, the hooks land here as guarded no-ops against the (yet-absent) delete loop and are wired fully when those stories merge; the guard + events + registry are complete and independently testable regardless of merge order.
+
+## Dependencies
+
+- **Hard prerequisite — Story 37-1** (audit read-model + `IEventRepository` audit-event path). The `legal_holds` registry and the PLACED/RELEASED events build on the read-model 37-1 establishes.
+- **Consumer — Story 37-5 (Retention)**: the pruner MUST call `ILegalHoldGuard` before deleting; emits `AUDIT.RETENTION.BLOCKED_BY_HOLD`. This story adds that call site.
+- **Consumer — Story 37-8 (Right-to-Erasure)**: erasure MUST call `ILegalHoldGuard` before deleting; emits `AUDIT.ERASURE.BLOCKED_BY_HOLD`. This story adds that call site.
+- **Reuses (no change)**: `ITammaModeProvider` (`Services/PromptStore/TammaMode.cs`), `RequireTenantMembershipFilter` + `TenantRoleHierarchy` (`Authorization/`), `PlatformOwnerAccess` policy (`Program.cs`), `IEventRepository` (`Tamma.Data/Repositories/`).
+
+## Testing Strategy
+
+Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/` (xUnit; docker-bound suites run via `sg docker -c "dotnet test ..."`). TDD — write tests first.
+
+1. **Guard unit tests** (`LegalHoldGuardTests.cs`):
+   - No active hold → `IsHeld=false`.
+   - Tenant-scope hold matches same-tenant candidate; does NOT match other-tenant candidate.
+   - Platform-wide hold matches every tenant + system (tenant_id null) candidate.
+   - Scope matching: actor-only, subject-only, time-range (inclusive bounds, before/after misses), case-ref, and combined-predicate (all must match); NULL scope field = wildcard.
+   - **Overlapping holds**: two active holds cover one record; releasing one → still `IsHeld=true`; releasing both → `IsHeld=false`.
+   - Released hold never matches.
+   - **Fail-closed**: guard query failure → decision treated as held (no delete).
+
+2. **Hold-blocks-prune integration** (`LegalHoldRetentionTests.cs`): seed audit rows past the retention window; place a hold covering a subset; run the 37-5 pruner; assert in-scope rows survive, out-of-scope rows are deleted, and exactly one `AUDIT.RETENTION.BLOCKED_BY_HOLD` event per affected hold.
+
+3. **Hold-blocks-erasure integration** (`LegalHoldErasureTests.cs`): place a hold covering a data subject; run the 37-8 erasure for that subject; assert no records are deleted (fail closed), the request is rejected, and one `AUDIT.ERASURE.BLOCKED_BY_HOLD` event is emitted.
+
+4. **Release re-enables** (both integration files): release the covering hold; re-run prune and erasure; assert the now-unheld records are deleted and the standard 37-5/37-8 success events fire (no `BLOCKED_BY_HOLD`).
+
+5. **Lifecycle audit** (`LegalHoldServiceTests.cs`): place emits exactly one `AUDIT.LEGAL_HOLD.PLACED`; release emits exactly one `AUDIT.LEGAL_HOLD.RELEASED`; releasing an already-released hold → 409 and NO second event.
+
+6. **RBAC + per-mode matrix** (`LegalHoldEndpointsTests.cs`):
+   - single-user mode: sole user can place/release/list; rows keyed `user_id`.
+   - SaaS tenant scope: `tenant_owner` can place/release; `member` → 403 on place/release, read-only list allowed; cross-tenant `id` → 404; body `tenantId` mismatch → 400.
+   - SaaS platform scope: `PlatformOwnerAccess` required; a tenant member hitting `/api/v1/admin/audit/legal-holds` → 403; platform-wide list never leaks onto the tenant surface.
+
+7. **CHECK constraint** (`LegalHoldServiceTests.cs`): inserting a row violating the principal-XOR (e.g. both `tenant_id` and `user_id` set) is rejected by Postgres; invalid `status` / `scope_category` rejected.
+
+8. **Migration discipline**: `has-pending-model-changes` reports none after `AddLegalHolds`; migration applies and rolls back cleanly; full suite stays green.
+
+## Estimated Effort
+
+3-4 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/LegalHold.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (add `LegalHold` entity config — CHECK + indexes) |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (add `DbSet<LegalHold>`) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_AddLegalHolds.cs` | Create (additive EF migration) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/ILegalHoldGuard.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/LegalHoldGuard.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/LegalHoldService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Audit/LegalHoldEventTypes.cs` | Create (`AUDIT.LEGAL_HOLD.*`, `AUDIT.*.BLOCKED_BY_HOLD`) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs` | Modify (tenant legal-hold handlers) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminEndpoints.cs` | Modify (platform legal-hold handlers) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (route registration; DI for service + guard) |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/IAuditRecordRepository.cs` | Modify (37-1 read-model: add hold-aware delete-candidate query if 37-1 exposes the prune surface here) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/LegalHoldGuardTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/LegalHoldServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/LegalHoldEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/LegalHoldRetentionTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/LegalHoldErasureTests.cs` | Create |
+
+> `IAuditRecordRepository.cs` is a **37-1 artifact** — verify it exists at implementation time. If 37-1 names the prune surface elsewhere, attach the hold-aware candidate query to whatever 37-1 actually exposes; do NOT invent a second read-model.
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story:
+
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md).
+2. Search `.dev/` for related spikes/bugs/findings/decisions.
+3. Confirm Story 37-1 has landed and note the exact name/shape of its audit read-model + prune surface (`IAuditRecordRepository` is the spec's assumption — verify before wiring).
+4. Confirm whether 37-5 / 37-8 have landed; if so, add the guard call sites into their real delete loops; if not, land the hooks as guarded no-ops with the integration tests pending those loops.
+5. Plan the TDD cycle (Red-Green-Refactor) — guard + service tests first.
+
+### Fail-Closed Is Load-Bearing
+
+The single most important invariant: **a hold-guard failure must never let a deletion through.** If the registry query throws, the candidate is treated as held. A destructive compliance operation failing safe (refusing to delete) is always preferable to deleting a record that a court ordered preserved. This is the opposite of the alert pipeline's `TryEmitAsync` swallow-and-continue posture — do not copy that pattern into the guard.
+
+### Per-Mode Scope Derivation
+
+Derive ownership from `ITammaModeProvider.Mode` + the route, not from request body fields:
+- single-user mode → `user_id` = caller, `tenant_id` NULL.
+- SaaS tenant route → `tenant_id` = path tenant (forced), `user_id` NULL.
+- SaaS admin route → `tenant_id` = body target tenant OR `is_platform_wide = true`; `user_id` NULL.
+
+Getting this wrong leaks a tenant's hold onto the platform surface or vice-versa — pin it in `LegalHoldEndpointsTests`.
+
+### Overlapping Holds = Additive, Re-Evaluated Per Operation
+
+Never cache a "not held" decision across a hold placement. The pruner/erasure call `EvaluateAsync` per operation so a hold placed mid-run still protects records the run hasn't reached. Releasing one of several overlapping holds must not unfreeze a still-covered record — the guard returns `IsHeld=true` while any active hold matches.
+
+### Release Is a Status Flip, Not a Delete
+
+`legal_holds` rows are append-then-flip. A released hold stays in the table (status `released`) forever so "who placed/released this hold and when" is permanently auditable. There is no hard-delete endpoint.
+
+### Time-Range Bounds
+
+`scope_time_from`/`scope_time_to` are inclusive; a NULL bound is open-ended (NULL `from` = "since the beginning", NULL `to` = "until forever"). Store and compare in UTC (`DateTime` UTC, consistent with `DomainEvent.CreatedAt`).
+
+## Logging Requirements
+
+- **INFO**: hold placed (`holdId`, `scopeCategory`, `caseRef`, `tenantId`/`isPlatformWide`, `placedBy`), hold released (`holdId`, `releasedBy`), prune blocked by hold (`holdId`, skipped count), erasure blocked by hold (`holdId`, `subjectId`).
+- **DEBUG**: guard evaluation (candidate scope, matched hold ids, decision), list-holds query (filter, row count).
+- **WARN**: release attempt on an already-released hold; member-role place/release attempt rejected (403); cross-tenant hold access attempt rejected (404).
+- **ERROR**: guard query failure (then **treated as held** — log loudly because deletions are now being suppressed and the operator must know the registry is unreachable), migration/CHECK violation on insert.
+- **Structured context**: include `{ holdId, tenantId, scopeCategory, caseRef, decision, mode }` where applicable.
+- **Credential / PII safety**: `case_ref`, `reason`, `scope_subject_id` may reference sensitive matters — log identifiers, never free-text `reason` at INFO+; redact `scope_subject_id` if it can be a natural-person identifier.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-37/story-37-7/37-7-gdpr-dsar-data-subject-access-export.md
+++ b/docs/stories/epic-37/story-37-7/37-7-gdpr-dsar-data-subject-access-export.md
@@ -1,0 +1,444 @@
+# Story 37-7: GDPR DSAR — Data Subject Access Export
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **tenant owner/admin (SaaS), a platform owner, or a self-hosted user**,
+I want to run a Data Subject Access Request (DSAR) that gathers **all** personal data Tamma
+holds about a given subject — across the control plane and the relevant tenant schema(s) — and
+produces a portable, machine-readable + human-readable export bundle,
+So that Tamma can satisfy GDPR Art. 15 (right of access) / Art. 20 (data portability) and
+CCPA right-to-know obligations with a complete, audited, RBAC-gated, secret-safe artifact.
+
+## Priority
+
+P1 — required for GDPR/CCPA compliance posture and the Epic 37 data-governance product layer.
+
+## Context & Boundaries
+
+A DSAR identifies a **data subject** — a `User`/member referenced by `userId` or `email` — and
+collects every record that is *about* that person:
+
+- **Control plane** (`ControlPlaneDbContext`): `User`, `TenantMembership`, `UserInvite`,
+  `RefreshToken` (metadata only), `ApiKey` (metadata only), `AdminImpersonation` (where the subject
+  is `TargetUserId` or `ImpersonatorUserId`), platform audit records (`PlatformEvent`, plus
+  `DomainEvent` rows where the subject is actor/target), and `SecretRow` ownership (metadata only —
+  "secret X exists", never the value).
+- **Per-tenant schema** (`TenantDbContext` via `ITenantDbContextFactory.CreateAsync(tenantId)`):
+  the subject's authored `PromptOverride` (`CreatedBy`/`UserId`), `Convention` (`CreatedBy`),
+  `AgentConfig` (`CreatedBy`), `SanitizationRule`, `Alert` ownership, and tenant audit records
+  (`DomainEvent` rows where the subject is actor/target).
+
+The export runs as an **async job** (the existing `PlatformQueuedTask` / `TaskQueueProcessor`
+pattern — same machinery 37-4 uses for audit export) and is **itself** an audited, RBAC-gated,
+secret-redacting action. The collector is **data-map-driven**: a declarative `SubjectDataMap`
+enumerates every PII source so adding a new PII-bearing entity is a single registration, not a
+scatter of edits across services.
+
+> **Architecture note.** This story targets the C# engine in `apps/tamma-elsa`
+> (`Tamma.Api` + `Tamma.Data`). The legacy TypeScript `packages/api` is deleted and is NOT a
+> target. New collector/data-map types live under
+> `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/` (NEW directory).
+
+## Acceptance Criteria
+
+1. **Three initiation surfaces, per mode.**
+   `POST /api/v1/orgs/{tenantId}/dsar` (gated `OwnerAccess` — tenant_owner/tenant_admin) and
+   `POST /api/admin/dsar` (gated `PlatformOwnerAccess`) accept a subject reference
+   (`{ userId }` or `{ email }`) and return **202 Accepted** with `{ jobId, status: "pending" }`.
+   In **single-user mode** a self-service `POST /api/v1/dsar/self` lets the sole user export their
+   own data with no admin role required (subject is pinned to the caller; a supplied
+   `userId`/`email` that is not the caller is rejected 403).
+
+2. **Identity resolution + verification.** The subject reference resolves to exactly one `User`
+   (case-insensitive email match per the `LOWER(email)` index). An ambiguous/unknown reference
+   returns 404. The requested subject **must belong to the requesting tenant** in SaaS mode
+   (a member of `{tenantId}` via `TenantMembership`); a cross-tenant subject returns 404 (not 403,
+   to avoid confirming the subject exists elsewhere). The DSAR request records the verified
+   requester identity and the (separately verified) subject identity in the job record.
+
+3. **Declarative data map.** A `SubjectDataMap` declares every personal-data source as a
+   `SubjectDataSource` entry: `{ Category, Scope (control-plane|tenant), EntityType, PiiFields,
+   SubjectKeySelector, Collect(...) }`. The map is the single registry of "where personal data
+   about a subject lives" and is the only file edited when a new PII-bearing entity is added.
+
+4. **Data-map completeness guard.** A test asserts that **every** entity flagged as PII-bearing
+   (entities decorated with a `[ContainsPersonalData]` marker attribute, or listed in a
+   `KnownPiiEntities` allow-list) appears in the `SubjectDataMap`. A PII entity missing from the
+   map fails the build/test — the collector cannot silently miss a data category.
+
+5. **DsarCollector compiles the bundle.** `DsarCollector` enumerates the `SubjectDataMap`,
+   queries the control plane once and each in-scope tenant schema once (via
+   `ITenantDbContextFactory`), and produces a structured result: one section per `Category`, each
+   row annotated with **provenance** (`{ source, scope, entityType, tenantId? }`).
+
+6. **Machine-readable + human-readable export.** The bundle is emitted as (a) `export.json` — a
+   structured JSON document, one top-level key per category, with a top-level `manifest`
+   (`{ subjectId, subjectEmail, generatedAt, requestedBy, mode, sourceCount, categories[],
+   schemaVersion }`); and (b) `export.html` (or `export.md`) — a human-readable rendering of the
+   same data for a non-technical data subject. Both are packaged together (zip) under the manifest.
+
+7. **Secret-value exclusion (load-bearing).** Credential/secret **values** are NEVER included.
+   `SecretRow`, `ApiKey`, `RefreshToken`, password hashes, and verification-token hashes contribute
+   **metadata only** — e.g. `{ name, purpose, scope, createdAt, exists: true }` — never the
+   protected value, hash, or ciphertext. A test asserts no secret value / hash / token plaintext
+   appears anywhere in a generated bundle.
+
+8. **Async job lifecycle.** `POST` enqueues a `PlatformQueuedTask` (type `compliance.dsar.export`)
+   handled by a `DsarExportTaskHandler : IPlatformTaskHandler` on the `TaskQueueProcessor`. State
+   transitions are observable via `GET /api/v1/orgs/{tenantId}/dsar/{jobId}` /
+   `GET /api/admin/dsar/{jobId}`: `pending → collecting → packaging → ready` (or `failed` with a
+   non-sensitive reason). The handler is crash-isolated and idempotent on retry.
+
+9. **Artifact at rest, encrypted, time-limited download (37-4 parity).** The packaged bundle is
+   stored encrypted at rest and downloadable via a single-use, time-limited token
+   (`GET /api/.../dsar/{jobId}/download?token=...`), mirroring the 37-4 artifact + reveal-token
+   pattern (`SecretRevealTokenRow`-style: `TokenHash`, `ExpiresAt`, single-consume, expiry sweep).
+   The artifact and token expire on a configurable TTL; expired downloads return 410 Gone.
+
+10. **Audited (37-1).** DSAR generation emits DCB events `GDPR.DSAR.REQUESTED` and
+    `GDPR.DSAR.COMPLETED` (and `GDPR.DSAR.FAILED` on failure), flagged **sensitive** so 37-1's
+    curated audit trail captures them. Tags: `subjectId`, `requestedBy`, `tenantId` (SaaS),
+    `mode`, `jobId`. The download is audited too (`GDPR.DSAR.DOWNLOADED`). The **subject's data
+    values are NOT in the event payload** — only references/counts.
+
+11. **RBAC matrix.** SaaS `member` users cannot run a DSAR for others (403). A tenant
+    owner/admin can DSAR only subjects belonging to their tenant (cross-tenant → 404). Platform
+    owner can DSAR any subject. Single-user mode: self-only (the sole user). All three are enforced
+    by the existing policy stack (`OwnerAccess`, `PlatformOwnerAccess`) plus an in-handler subject
+    membership check.
+
+12. **Multi-tenant subject coverage.** When a subject belongs to multiple tenants and the caller
+    is the **platform owner**, the export covers the control plane + every tenant the subject is a
+    member of. When the caller is a **tenant owner/admin**, the export is scoped to **their tenant
+    only** (no other-tenant data leaks into a tenant-initiated DSAR).
+
+13. **Tests.** Collector coverage vs `SubjectDataMap`; PII-entity completeness guard;
+    secret-value exclusion; cross-tenant subject rejection (404); identity resolution
+    (email/userId, ambiguous → 404); RBAC matrix (member 403, tenant scoping, platform-owner
+    multi-tenant, single-user self-only); async job lifecycle (pending→ready, failure path,
+    idempotent retry); `GDPR.DSAR.*` emission; download token single-use + expiry (410).
+
+## Technical Design
+
+### Directory / file layout (NEW unless noted)
+
+```
+apps/tamma-elsa/src/Tamma.Api/Services/Compliance/
+  ISubjectDataMap.cs                # contract: enumerate SubjectDataSource entries
+  SubjectDataMap.cs                 # the declarative registry of PII sources
+  SubjectDataSource.cs             # record: Category, Scope, EntityType, PiiFields, Collect(...)
+  ContainsPersonalDataAttribute.cs # marker on PII-bearing entities (or KnownPiiEntities list)
+  IDsarCollector.cs                 # contract
+  DsarCollector.cs                  # enumerates map, queries CP + tenant schemas, builds sections
+  DsarBundle.cs                     # in-memory model: manifest + sections (provenance-tagged)
+  DsarBundlePackager.cs            # json + html render → encrypted zip artifact
+  DsarExportTaskHandler.cs         # IPlatformTaskHandler ("compliance.dsar.export")
+  IDsarJobStore.cs / DsarJobStore.cs   # job lifecycle persistence (status, artifact ref, token)
+  DsarRedactionPolicy.cs           # central secret/hash/value exclusion rules
+apps/tamma-elsa/src/Tamma.Api/Endpoints/
+  ComplianceDsarEndpoints.cs        # NEW — admin + org + self-service maps; or fold into Org/Admin
+  OrgEndpoints.cs                   # MODIFY — add org DSAR routes (or delegate to new file)
+  AdminEndpoints.cs                 # MODIFY — add admin DSAR routes
+apps/tamma-elsa/src/Tamma.Data/Entities/
+  DsarJob.cs                        # NEW — job record (CP-resident)
+apps/tamma-elsa/src/Tamma.Data/
+  ControlPlaneDbContext.cs          # MODIFY — DbSet<DsarJob>; CP collectors read here
+  TammaModelConfiguration.cs        # MODIFY — DsarJob mapping (indices, CHECK on status)
+  TenantDbContext.cs                # READ-ONLY in collector — no schema change
+  Migrations/ControlPlane/          # NEW additive migration (DsarJob table)
+apps/tamma-elsa/tests/Tamma.Api.Tests/Compliance/
+  SubjectDataMapCompletenessTests.cs
+  DsarCollectorTests.cs
+  DsarRedactionTests.cs
+  ComplianceDsarEndpointsTests.cs
+  DsarExportTaskHandlerTests.cs
+```
+
+### `SubjectDataSource` (the registry primitive)
+
+```csharp
+public sealed record SubjectDataSource(
+    string Category,                 // "account", "memberships", "authored-prompts", ...
+    DsarScope Scope,                 // ControlPlane | Tenant
+    Type EntityType,                 // typeof(User), typeof(PromptOverride), ...
+    IReadOnlyList<string> PiiFields, // documented PII columns (for the completeness audit)
+    // Returns provenance-tagged, already-redacted rows for one subject.
+    Func<DsarQueryContext, CancellationToken, Task<IReadOnlyList<DsarRecord>>> Collect);
+
+public enum DsarScope { ControlPlane, Tenant }
+
+public sealed record DsarQueryContext(
+    Guid SubjectUserId,
+    string SubjectEmail,
+    ControlPlaneDbContext Cp,
+    TenantDbContext? Tenant,         // non-null only for Scope == Tenant
+    Guid? TenantId);
+```
+
+Each entry's `Collect` delegate runs the narrow query for that one entity keyed by the subject and
+maps to provenance-tagged `DsarRecord`s, applying `DsarRedactionPolicy` (AC7). The map is the only
+place that "knows" a category exists; the collector is generic over it.
+
+### Data map coverage (initial registration)
+
+| Category | Scope | Entity | Subject key | Redaction |
+|---|---|---|---|---|
+| account | ControlPlane | `User` | `Id` / `Email` | drop `PasswordHash`, `*TokenHash` |
+| memberships | ControlPlane | `TenantMembership` | `UserId` | full (no secrets) |
+| invites | ControlPlane | `UserInvite` | invited email | full |
+| refresh-sessions | ControlPlane | `RefreshToken` | `UserId` | **metadata only** (no token) |
+| api-keys | ControlPlane | `ApiKey` | owner | **metadata only** (no key/hash) |
+| secrets-owned | ControlPlane/Tenant | `SecretRow` | `OwnerUserId` | **metadata only** (`exists:true`) |
+| impersonation | ControlPlane | `AdminImpersonation` | `TargetUserId`/`ImpersonatorUserId` | full |
+| platform-audit | ControlPlane | `PlatformEvent` + `DomainEvent` | actor/target tag | redact secret tags |
+| authored-prompts | Tenant | `PromptOverride` | `CreatedBy`/`UserId` | full |
+| authored-conventions | Tenant | `Convention` | `CreatedBy` | full |
+| agent-configs | Tenant | `AgentConfig` | `CreatedBy` | full |
+| sanitization-rules | Tenant | `SanitizationRule` | owner | full |
+| alerts | Tenant | `Alert` | owner | full |
+| tenant-audit | Tenant | `DomainEvent` | actor/target tag | redact secret tags |
+
+### `DsarCollector` flow
+
+```csharp
+public async Task<DsarBundle> CollectAsync(DsarRequest req, CancellationToken ct)
+{
+    // 1. resolve + verify subject (404 if unknown/ambiguous; membership check upstream)
+    // 2. partition map: ControlPlane sources vs Tenant sources
+    // 3. one CP context: run every ControlPlane source's Collect
+    // 4. for each in-scope tenant (single in tenant-initiated; N for platform-owner multi-tenant):
+    //      using ctx = await tenantFactory.CreateAsync(tenantId, ct);
+    //      run every Tenant source's Collect
+    // 5. assemble DsarBundle { manifest, sections[] }, provenance-tagged
+}
+```
+
+In-scope tenants: tenant-initiated DSAR ⇒ exactly `{tenantId}`; platform-owner DSAR ⇒ every tenant
+the subject is a member of (AC12).
+
+### Packaging + artifact (37-4 parity)
+
+`DsarBundlePackager` renders `export.json` (manifest + sections) and `export.html` (human-readable),
+zips them, encrypts the zip at rest (reuse the 37-4 artifact encryption seam), and registers a
+single-use download token (`SecretRevealTokenRow`-style: `TokenHash`, `ExpiresAt`, `Status`,
+single-consume) on the `DsarJob`. Download endpoint validates the token, streams once, marks
+consumed; expired/consumed ⇒ 410.
+
+### Async job: `DsarExportTaskHandler`
+
+```csharp
+public sealed class DsarExportTaskHandler : IPlatformTaskHandler
+{
+    public string TaskType => "compliance.dsar.export";
+    public async Task HandleAsync(PlatformQueuedTask task, CancellationToken ct)
+    {
+        // payload: { jobId, subjectUserId, requestedBy, tenantScope, mode }
+        // collecting -> bundle = collector.CollectAsync(...)
+        // packaging  -> artifact = packager.PackAsync(bundle)
+        // ready      -> jobStore.MarkReady(jobId, artifactRef, downloadToken)
+        // emit GDPR.DSAR.COMPLETED; on throw -> GDPR.DSAR.FAILED + retry semantics
+    }
+}
+```
+
+Throwing a normal exception → retryable (worker re-enqueues); `PlatformTaskTerminalException` for
+permanently-bad payloads → dead-letter. Handler is idempotent: re-running a `ready` job is a no-op.
+
+### Endpoints (per-mode shape)
+
+```
+POST /api/v1/orgs/{tenantId}/dsar              OwnerAccess        body {userId|email}      -> 202 {jobId}
+GET  /api/v1/orgs/{tenantId}/dsar/{jobId}      OwnerAccess        -> status
+GET  /api/v1/orgs/{tenantId}/dsar/{jobId}/download?token=  OwnerAccess -> artifact / 410
+POST /api/admin/dsar                            PlatformOwnerAccess body {userId|email}     -> 202 {jobId}
+GET  /api/admin/dsar/{jobId}                    PlatformOwnerAccess -> status
+GET  /api/admin/dsar/{jobId}/download?token=    PlatformOwnerAccess -> artifact / 410
+POST /api/v1/dsar/self                          AuthenticatedAny (single-user) -> 202 {jobId}  # subject pinned to caller
+GET  /api/v1/dsar/self/{jobId}                  AuthenticatedAny (single-user) -> status
+```
+
+Tenant-route subject scoping rides the existing `RequireTenantMembershipFilter` for the caller plus
+an in-handler check that the **subject** is a member of `{tenantId}`. Self-service is gated by
+`ITammaModeProvider` returning `SingleUser`.
+
+### Events (DCB)
+
+| Type | When | Tags | Payload (NO subject values) |
+|---|---|---|---|
+| `GDPR.DSAR.REQUESTED` | on enqueue | subjectId, requestedBy, tenantId?, mode, jobId | `{ subjectRefType }` |
+| `GDPR.DSAR.COMPLETED` | on ready | + sectionCount | `{ categories, recordCount, artifactBytes }` |
+| `GDPR.DSAR.FAILED` | on failure | + reasonCode | `{ reasonCode }` (non-sensitive) |
+| `GDPR.DSAR.DOWNLOADED` | on consume | + downloadedBy | `{}` |
+
+Emitted via `IEventRepository.AppendAsync` (mirroring `OrgEndpoints.EmitTenantEvent`). System-scope
+(admin/single-user) events use `TenantId = null`.
+
+### `DsarJob` entity (CP-resident, NEW)
+
+```csharp
+public class DsarJob {
+  public Guid Id { get; set; }
+  public Guid SubjectUserId { get; set; }
+  public string SubjectEmail { get; set; } = null!;
+  public Guid RequestedByUserId { get; set; }
+  public Guid? TenantId { get; set; }          // null in admin/single-user system-scope
+  public string Mode { get; set; } = null!;     // "single-user" | "saas"
+  public string Status { get; set; } = "pending"; // CHECK: pending|collecting|packaging|ready|failed
+  public string? ArtifactRef { get; set; }      // encrypted-at-rest blob reference
+  public byte[]? DownloadTokenHash { get; set; }
+  public DateTime? DownloadExpiresAt { get; set; }
+  public DateTime? DownloadConsumedAt { get; set; }
+  public string? FailureReasonCode { get; set; }
+  public DateTime CreatedAt { get; set; }
+  public DateTime UpdatedAt { get; set; }
+}
+```
+
+## Dependencies
+
+- **37-1 (curated audit trail)** — DSAR events are sensitive, audited actions. `GDPR.DSAR.*` must
+  flow into 37-1's curated trail. *(Sibling story dir exists; not yet authored — treat the
+  sensitive-event taxonomy as the integration contract.)*
+- **37-4 (async export + artifact pattern)** — reuse the `PlatformQueuedTask`/`TaskQueueProcessor`
+  async-export flow, encrypted-at-rest artifact, and single-use time-limited download token. *(NEW
+  sibling — if it lands first, consume its packager/token seam directly; if this lands first,
+  factor the artifact+token helper so 37-4 reuses it.)*
+- **Epic 28 (tenancy)** — control-plane + per-tenant schema access. Uses `ControlPlaneDbContext`
+  for CP sources and `ITenantDbContextFactory.CreateAsync(tenantId)` for tenant sources
+  (`LruPooledTenantConnectionResolver` is unconditionally wired per the tenancy plan).
+- **Existing infra** — `IEventRepository`, `IPlatformTaskHandler`/`PlatformQueuedTask`,
+  `OwnerAccess`/`PlatformOwnerAccess` policies, `RequireTenantMembershipFilter`,
+  `ITammaModeProvider`, `SecretRevealTokenRow`-style token pattern.
+
+## Testing Strategy
+
+1. **Completeness guard (`SubjectDataMapCompletenessTests`)** — reflect over entities marked
+   `[ContainsPersonalData]` (or the `KnownPiiEntities` list); assert each appears as a
+   `SubjectDataSource` in `SubjectDataMap`. A new PII entity without a map entry fails the build.
+2. **Collector coverage (`DsarCollectorTests`)** — seed a subject with rows in every category
+   across CP + two tenant schemas; assert the bundle has one section per category, correct row
+   counts, provenance tags, and that platform-owner multi-tenant covers both tenants while
+   tenant-initiated covers only one (AC12).
+3. **Redaction (`DsarRedactionTests`)** — generate a bundle for a subject who owns secrets,
+   API keys, refresh tokens, and a password; assert NO secret value, ciphertext, key, hash, or
+   token plaintext appears anywhere in `export.json`/`export.html`; assert metadata-only rows carry
+   `exists: true` (AC7).
+4. **Endpoints / RBAC (`ComplianceDsarEndpointsTests`)** — member 403; tenant owner/admin scoped
+   to own tenant; cross-tenant subject 404; unknown/ambiguous subject 404; email vs userId
+   resolution; platform owner any subject; single-user self-only (non-self ref 403); 202 + jobId
+   shape.
+5. **Job lifecycle (`DsarExportTaskHandlerTests`)** — pending→collecting→packaging→ready;
+   failure path → failed + `GDPR.DSAR.FAILED`; idempotent retry (ready job re-run is a no-op);
+   terminal vs retryable exception routing.
+6. **Events** — `GDPR.DSAR.REQUESTED` on enqueue, `COMPLETED` on ready, `DOWNLOADED` on consume;
+   payloads contain no subject data values.
+7. **Download token** — single-use (second consume 410), expiry (410 after TTL), tamper (401).
+8. **DB suites** run via `sg docker -c "dotnet test ..."` (Postgres-bound), per the project
+   .NET-test convention.
+
+## Estimated Effort
+
+5-6 days.
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/SubjectDataMap.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/ISubjectDataMap.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/SubjectDataSource.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/ContainsPersonalDataAttribute.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/IDsarCollector.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/DsarCollector.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/DsarBundle.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/DsarBundlePackager.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/DsarRedactionPolicy.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/DsarExportTaskHandler.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/IDsarJobStore.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/DsarJobStore.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/ComplianceDsarEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/ComplianceServiceCollectionExtensions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/DsarJob.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (add `DbSet<DsarJob>`) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (DsarJob mapping + CHECK) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/*_AddDsarJob.cs` | Create (additive) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (DI + route + task-handler registration) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminEndpoints.cs` | Modify (admin DSAR routes) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs` | Modify (org DSAR routes) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Compliance/SubjectDataMapCompletenessTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Compliance/DsarCollectorTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Compliance/DsarRedactionTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Compliance/ComplianceDsarEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Compliance/DsarExportTaskHandlerTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, and decisions
+3. Read sibling stories 37-1 (audit taxonomy) and 37-4 (async export + artifact) once authored —
+   reuse their artifact/token seam rather than re-inventing it
+4. Reviewed the tenancy access seams (`ITenantDbContextFactory`, `LruPooledTenantConnectionResolver`)
+5. Planned a TDD approach (Red-Green-Refactor) — completeness guard and redaction tests first
+
+### Architecture target
+
+- **Target `apps/tamma-elsa` (C#) only.** `packages/api` (TypeScript) is deleted — never a target.
+- CP personal data: `ControlPlaneDbContext`. Tenant personal data:
+  `ITenantDbContextFactory.CreateAsync(tenantId)` — never raw SQL across schemas.
+- Async work uses the `PlatformQueuedTask` + `TaskQueueProcessor` + `IPlatformTaskHandler` machinery
+  (same as 37-4 and the Cranl provisioning flow), not an ad-hoc thread.
+
+### Secret safety (the highest-risk requirement)
+
+`DsarRedactionPolicy` is the single chokepoint for value exclusion — every `Collect` delegate runs
+its rows through it. Default-deny: a field is included only if explicitly listed in the source's
+non-secret projection. `SecretRow`/`ApiKey`/`RefreshToken`/`PasswordHash`/`*TokenHash` columns map
+to `{ exists: true, ... }` metadata. The `DsarRedactionTests` scan the full serialized bundle for
+known secret material and MUST fail if any leaks.
+
+### Identity verification subtlety
+
+Resolving by `email` uses the same case-insensitive semantics as the `LOWER(email)` partial unique
+index; resolving by `userId` is exact. Reject ambiguous matches with 404 (do not partial-match).
+The requester's identity comes from the verified JWT/claims; the subject is verified independently
+(existence + tenant membership) — never trust the request body's claim that the subject "belongs"
+to the tenant.
+
+### Mode awareness
+
+`ITammaModeProvider` gates which surfaces are live: SaaS exposes org + admin routes; single-user
+exposes the self-service route. A single deployment is one mode for the process lifetime — do not
+branch per-request on mode beyond reading the provider.
+
+## Logging Requirements
+
+- **INFO**: DSAR requested (jobId, subjectId, requestedBy, mode), collection started/finished
+  (sectionCount, recordCount), artifact packaged (bytes), download served (jobId), job completed.
+- **DEBUG**: per-source row counts during collection, tenant-schema context opened/closed,
+  flush cycle of the packager.
+- **WARN**: subject resolved to multiple users (rejected), download token expired/consumed,
+  retryable handler failure (re-enqueue).
+- **ERROR**: collection failed (reasonCode, no subject values), artifact encryption/storage
+  failure, task moved to dead-letter.
+- **Structured context**: `{ jobId, subjectId, requestedBy, tenantId, mode, sectionCount,
+  recordCount }` where applicable.
+- **Credential safety**: NEVER log subject personal data values, secret values/hashes, download
+  tokens, or artifact contents. Log references and counts only.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-37/story-37-8/37-8-gdpr-right-to-erasure-with-crypto-shredding-and-audit-preser.md
+++ b/docs/stories/epic-37/story-37-8/37-8-gdpr-right-to-erasure-with-crypto-shredding-and-audit-preser.md
@@ -1,0 +1,407 @@
+# Story 37-8: GDPR Right-to-Erasure with Crypto-Shredding & Audit Preservation
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **data-protection officer (platform owner) or a tenant owner acting for a data subject**,
+I want a verified right-to-erasure request to irreversibly destroy or anonymize a subject's
+personal data across the control-plane and that subject's tenant schema — using crypto-shredding
+(destroying the subject's envelope-encryption key version) for any encrypted PII — while the
+tamper-evident audit chain stays intact and active legal holds block the deletion,
+So that Tamma satisfies GDPR Art. 17 (right to erasure) without breaking the SOC2 / Art. 30
+audit evidence the platform is required to retain.
+
+## Priority
+
+P1 — Required GDPR control; gates SOC2 Type II evidence for the audit/compliance product layer.
+
+## Context & Boundary
+
+This story builds on the Epic 37 audit substrate and the Epic 29 secret cabinet. Three Epic 37
+dependencies are **not yet authored** at the time of drafting and are referenced as NEW seams to
+be produced by their own stories; this story consumes their contracts:
+
+- **37-2 (audit hash chain)** — NEW. Provides the tamper-evident per-row hash chain over curated
+  audit records and a `VerifyChainAsync` check. Erasure must NOT break it: audit rows are
+  anonymized/tombstoned and re-anchored, never deleted.
+- **37-6 (legal hold)** — NEW. Provides an `ILegalHoldService` that answers "is subject X (or any
+  of records R) under an active hold?". Erasure is blocked for held records.
+- **37-7 (DSAR export)** — NEW. Provides the `SubjectDataMap` — the authoritative catalogue of
+  every place a subject's PII lives (control-plane columns, tenant-schema columns, encrypted
+  secret refs) plus a per-field **erasure policy** (`deletable` vs `must-retain-anonymized`).
+  Erasure walks this same map; DSAR (read) and erasure (destroy) share one inventory.
+
+What already exists and is reused unchanged (verified against `apps/tamma-elsa` @ main):
+
+- **Crypto-shred substrate**: `SecretVersionRow` (`apps/tamma-elsa/src/Tamma.Data/Entities/SecretVersionRow.cs`)
+  already carries a per-version AES-256-GCM envelope, a per-version `KekId`, and a `revoked`
+  status. `ISecretStoreBackend.DeleteVersionAsync` (`.../Services/Secrets/ISecretStoreBackend.cs`)
+  already **scrubs the ciphertext (zeroes the bytes) while keeping the row for audit history** —
+  this is exactly crypto-shred: destroy the key/ciphertext, keep the tombstone.
+- **Tenant-purge machinery**: `TenantLifecycleEvents`
+  (`.../Tamma.Activities/TenantLifecycle/TenantLifecycleEvents.cs`) already models the
+  `TENANT.DELETE.*` / `TENANT.DELETED.SUCCESS` lifecycle. Subject erasure shares its event-builder
+  shape and reuses the secret-scrub primitive that tenant purge uses.
+- **Append-only event store**: `DomainEvent` (`.../Tamma.Data/Entities/DomainEvent.cs`) is
+  immutable with a `BIGSERIAL SequenceNumber`. Erasure NEVER mutates a `DomainEvent`; PII inside
+  events is handled by crypto-shred + the anonymized re-anchor on the curated audit projection.
+
+**Out of scope (YAGNI):** no UI in this story (admin/tenant dashboard surfaces are 37-12);
+no automated subject-discovery crawler beyond the 37-7 `SubjectDataMap`; no third-party
+sub-processor erasure fan-out (documented as a manual runbook step); no `packages/api` work —
+that package is deleted, all work targets the C# `apps/tamma-elsa`.
+
+## Acceptance Criteria
+
+1. **Erasure request endpoints exist, per-mode.**
+   `POST /api/v1/orgs/{tenantId}/erasure` (SaaS/single-user tenant scope) and
+   `POST /api/v1/admin/tenants/{tenantId}/erasure` (platform scope) accept a body
+   `{ subjectRef, reason }` where `subjectRef` identifies the data subject (user id and/or email)
+   and `reason` is a free-text justification. Both return `202 Accepted` with an
+   `erasureRequestId`; the long-running execution runs off the request thread (see AC11).
+
+2. **`ErasureExecutor` walks the `SubjectDataMap` and applies each field's policy.**
+   For every entry in the 37-7 `SubjectDataMap` for the subject, the executor either
+   **hard-deletes** the field/row (policy `deletable`) or **anonymizes** it in place
+   (policy `must-retain-anonymized`, e.g. replacing `Email`/`DisplayName`/`AvatarUrl`/`GitHubLogin`
+   on `User` with a stable pseudonymous tombstone). The applied action per field is recorded.
+
+3. **Envelope-encrypted PII is crypto-shredded, not merely deleted.**
+   For any `SubjectDataMap` entry of kind `encrypted-secret`, the executor revokes/destroys the
+   subject-scoped key version through the Epic 29 cabinet
+   (`ISecretStore.RetireVersionAsync` / `ISecretStoreBackend.DeleteVersionAsync`), which scrubs the
+   ciphertext and flips `SecretVersionRow.Status` to `revoked` while keeping the row. The result
+   records **which `(SecretId, VersionNumber, KekId)` tuples were destroyed**.
+
+4. **The append-only event store is never mutated.**
+   No `DomainEvent` row is updated or deleted. PII embedded in events is rendered unrecoverable by
+   the crypto-shred of AC3 (events store encrypted refs / ciphertext, not plaintext) and by the
+   curated-audit anonymization of AC5. A test asserts zero `UPDATE`/`DELETE` against `domain_events`.
+
+5. **Audit records are anonymized + re-anchored, not deleted; the 37-2 chain still verifies.**
+   The subject's actor/target identity fields on curated audit records are replaced with a stable
+   pseudonymous tombstone (e.g. `erased-subject:{hashedSubjectId}`); the affected rows are re-hashed
+   and the 37-2 chain is **re-anchored** (an explicit, audited re-anchor — not a silent in-place
+   edit). `ILegalHoldService`-independent `VerifyChainAsync` passes after erasure.
+
+6. **Legal hold (37-6) blocks erasure for held records and returns a partial result.**
+   Before touching any record the executor consults `ILegalHoldService`; records under an active
+   hold are skipped, the response/result lists each held-back item with the hold id + reason, and a
+   `GDPR.ERASURE.BLOCKED_BY_HOLD` event is emitted. The non-held remainder still erases.
+
+7. **Erasure itself is audited with per-category counts; the request is permanently retained.**
+   Erasure emits `GDPR.ERASURE.REQUESTED` (on accept), then exactly one terminal event —
+   `GDPR.ERASURE.COMPLETED` (nothing held back) or `GDPR.ERASURE.PARTIAL` (something held back) —
+   carrying per-category counts (`deleted`, `anonymized`, `crypto_shredded`, `held`). These are
+   sensitive/audited events. The request id, the acting principal, the reason, and the destroyed
+   key-version tuples are themselves **permanently retained** (never erased), as the lawful basis +
+   evidence of the erasure.
+
+8. **RBAC is enforced per-mode.**
+   SaaS tenant endpoint: `tenant_owner` only (tenant_admin/member → 403). Single-user mode: the
+   sole user. Platform endpoint: `PlatformOwnerAccess` policy (`platform_admin` claim). Cross-tenant
+   callers 404 via the path-tenant membership filter. The subject must be in scope for the chosen
+   tenant; an out-of-scope subject → 404 (do not leak existence).
+
+9. **Crypto-shred renders ciphertext permanently unrecoverable (verification).**
+   After erasure, reading any crypto-shredded secret version returns null ciphertext
+   (`GetVersionPlaintextAsync` → null) and `Status = revoked`; there is no key path to recover the
+   plaintext. A verification step (`VerifyErasureAsync`) re-walks the `SubjectDataMap` and asserts:
+   no plaintext PII remains in deletable/anonymizable fields, and every `encrypted-secret` entry is
+   scrubbed.
+
+10. **Erasure is idempotent.**
+    Re-running erasure for the same subject is a safe no-op for already-erased fields/secrets
+    (DeleteVersionAsync is already idempotent; anonymized rows stay anonymized; hard-deleted rows
+    stay gone) and emits a terminal event with zero-or-unchanged counts — no double-counting, no
+    error.
+
+11. **Execution is asynchronous via the platform task queue with an SLA.**
+    The endpoint enqueues a platform-scope task (`IPlatformQueuedTaskRepository`) processed by the
+    existing `TaskQueueProcessor`; subject erasure must reach a terminal state within the configured
+    SLA (default 30 days per GDPR Art. 12(3), configurable via `Gdpr:ErasureSlaDays`), and the
+    target operational completion is recorded. A `GET /api/v1/orgs/{tenantId}/erasure/{id}` (and
+    admin variant) reports state: `requested → in_progress → completed | partial | failed`.
+
+12. **Tenant-purge reconciliation.**
+    Subject erasure and the existing `TENANT.DELETED.SUCCESS` purge share the secret-scrub primitive
+    and the per-mode scoping; a documented note + a test confirm a full tenant purge crypto-shreds
+    every subject's keys (erasure is the subset, tenant-purge the superset) with no duplicated logic.
+
+13. **Recorder/executor never partially corrupts the chain on failure.**
+    If any step throws mid-walk, already-applied deletions/shreds stand (they are individually
+    durable + idempotent), the task is marked failed with the last-completed cursor, a retry resumes
+    from that cursor, and the 37-2 chain still verifies (re-anchor is the last step, applied
+    atomically per affected row).
+
+## Technical Design
+
+### Component overview
+
+```
+POST /api/v1/orgs/{tenantId}/erasure            ─┐
+POST /api/v1/admin/tenants/{tenantId}/erasure   ─┤  OrgEndpoints / AdminTenantsEndpoints
+                                                  │   (RBAC + 202 + enqueue)
+                                                  ▼
+                              IPlatformQueuedTaskRepository ("GDPR_ERASURE" task)
+                                                  ▼  TaskQueueProcessor (existing thread)
+                                                  ▼
+                                          ErasureExecutor
+                       ┌──────────────────────────┼──────────────────────────┐
+                       ▼                          ▼                            ▼
+              SubjectDataMap (37-7)      ILegalHoldService (37-6)      ISecretStore /
+              (what + per-field           (block held records)         ISecretStoreBackend
+               erasure policy)                                          (crypto-shred:
+                       │                                                 DeleteVersionAsync)
+                       ▼                                                       │
+              TenantDbContext / ControlPlaneDbContext                         ▼
+              (hard-delete / anonymize columns)                       AuditChainAnonymizer (37-2)
+                       │                                              (anonymize + re-anchor)
+                       └──────────────────────► IEventRepository (GDPR.ERASURE.* events)
+```
+
+### Crypto-shred design (the core)
+
+PII falls into three storage classes; each has a destruction strategy that **preserves the
+append-only event store and the audit chain**:
+
+| Storage class | Where | Erasure strategy | Audit effect |
+|---|---|---|---|
+| Plaintext column, `deletable` | e.g. `users.password_hash`, refresh tokens | hard `DELETE` / set NULL | none — not audit data |
+| Plaintext column, `must-retain-anonymized` | `users.email`, `display_name`, `avatar_url`, `github_login` | overwrite with stable tombstone `erased:{hashedSubjectId}` | row kept; FK integrity preserved |
+| Envelope-encrypted (Epic 29) | `secret_versions.Ciphertext` for subject-scoped secrets | **crypto-shred**: `DeleteVersionAsync` scrubs bytes, `Status=revoked`, KEK link severed | row kept; ciphertext unrecoverable |
+| Audit identity fields (37-2) | curated audit rows' actor/target | anonymize to tombstone, **re-hash + re-anchor chain** | chain re-anchored, `VerifyChainAsync` passes |
+| `domain_events` (append-only) | DCB stream | **never touched**; PII lives only as encrypted refs/ciphertext rendered dead by the shred above | immutable, intact |
+
+Why crypto-shred for encrypted PII rather than deleting event rows: `DomainEvent` is immutable
+(append-only with a `BIGSERIAL` total-order cursor used by `AlertRuleEvaluator`). Destroying the
+per-subject key version makes the ciphertext permanently undecryptable while leaving the
+tamper-evident structure — bytes and sequence — fully intact. This is the GDPR-recognised
+"crypto-erasure" technique (EDPB Guidelines 05/2021; ISO/IEC 27040 §3.7 cryptographic erase).
+
+### Key management for per-subject shred
+
+The Epic 29 cabinet already keys versions individually (`SecretVersionRow.KekId` per version,
+ciphertext per version, `revoked` terminal status). For erasure we treat any
+**subject-scoped secret** (a `SecretRow` whose `SubjectDataMap` entry attributes it to the subject)
+as the unit of shredding: revoke every live version of that secret via `RetireVersionAsync` /
+`DeleteVersionAsync`. The destroyed `(SecretId, VersionNumber, KekId)` tuples are recorded in the
+terminal `GDPR.ERASURE.COMPLETED`/`PARTIAL` event `data` (retained as evidence). No new key
+hierarchy is introduced — per-version envelopes are the existing per-subject granularity.
+
+> Note: a coarser KEK-per-subject scheme is explicitly NOT introduced here — it would require an
+> Epic 29 schema change and the existing per-version scrub already gives irreversibility. If a
+> future story adds subject-scoped DEKs, `ErasureExecutor` swaps the shred call without changing its
+> contract.
+
+### Scope resolution (per-mode, mandatory two-model answer)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who may request erasure? | the sole user (their instance) | `tenant_owner` only (admin/member 403); platform owner via admin endpoint |
+| What is the subject scope? | the user's own data (their tenant = themselves) | a data subject within the named tenant |
+| Where does the subject's data live? | control-plane (single instance) | control-plane (user identity) + the tenant's own schema (`TenantDbContext`) |
+| Who owns the audit-of-erasure record? | the sole user's feed (`TenantId` null) | tenant feed (`TenantId` set) + platform feed for the admin-initiated path |
+| Mode source | `ITammaModeProvider` (process-stable) | same |
+
+### Key types (NEW unless marked)
+
+```csharp
+// apps/tamma-elsa/src/Tamma.Api/Services/Compliance/ErasureExecutor.cs (NEW)
+public sealed class ErasureExecutor
+{
+    public Task<ErasureResult> ExecuteAsync(ErasureRequest request, CancellationToken ct = default);
+    public Task<ErasureVerification> VerifyErasureAsync(SubjectRef subject, CancellationToken ct = default);
+}
+
+public sealed record ErasureRequest(
+    Guid ErasureRequestId, Guid TenantId, SubjectRef Subject, string Reason,
+    Guid ActorUserId, ErasureScope Scope /* TenantSelfService | PlatformAdmin */);
+
+public sealed record ErasureResult(
+    Guid ErasureRequestId,
+    int Deleted, int Anonymized, int CryptoShredded, int Held,
+    IReadOnlyList<ShreddedKeyVersion> DestroyedKeyVersions,   // (SecretId, Version, KekId)
+    IReadOnlyList<HeldBackItem> HeldBack,                     // (mapEntryId, holdId, reason)
+    ErasureStatus Status /* Completed | Partial | Failed */);
+```
+
+`SubjectDataMap` + `SubjectRef` + per-field `ErasurePolicy` come from **37-7 (NEW)**;
+`ILegalHoldService` from **37-6 (NEW)**; `AuditChainAnonymizer` + `VerifyChainAsync` from
+**37-2 (NEW)**. This story defines `ErasureExecutor`, the endpoints, the task payload, the event
+types, and the secret-shred integration; it depends on those three contracts and stubs/mocks them
+in tests until their stories land.
+
+### Event types (`AGGREGATE.ACTION.STATUS`)
+
+`GDPR.ERASURE.REQUESTED`, `GDPR.ERASURE.COMPLETED`, `GDPR.ERASURE.PARTIAL`,
+`GDPR.ERASURE.BLOCKED_BY_HOLD`, `GDPR.ERASURE.FAILED`. Appended via `IEventRepository.AppendAsync`
+(control-plane store for the platform path; tenant store for tenant-scope counts) following the
+`TenantLifecycleEvents.BuildEvent` shape (tags: `tenantId`, `subjectHash`, `erasureRequestId`,
+`mode`, `actorUserId`; metadata: `eventSource=system`). Tags carry a **hashed** subject id, never
+the plaintext email/id.
+
+### Async execution & SLA
+
+Endpoint validates RBAC + scope, generates `erasureRequestId`, appends `GDPR.ERASURE.REQUESTED`,
+enqueues a `GDPR_ERASURE` platform task (`IPlatformQueuedTaskRepository`), returns `202`. The
+existing `TaskQueueProcessor` picks it up and invokes `ErasureExecutor.ExecuteAsync`. Status is
+read back from the queued-task row + terminal event. SLA default 30 days
+(`Gdpr:ErasureSlaDays`); the executor records a target-completion timestamp and a WARN log if the
+task is still non-terminal past SLA.
+
+### Endpoint wiring
+
+```
+POST /api/v1/orgs/{tenantId}/erasure              → OrgEndpoints.RequestErasure (tenant_owner)
+GET  /api/v1/orgs/{tenantId}/erasure/{id}         → OrgEndpoints.GetErasureStatus
+POST /api/v1/admin/tenants/{tenantId}/erasure     → AdminTenantsEndpoints.RequestErasure (PlatformOwnerAccess)
+GET  /api/v1/admin/tenants/{tenantId}/erasure/{id}→ AdminTenantsEndpoints.GetErasureStatus
+```
+
+Tenant routes sit behind `RequireTenantMembershipFilter` (cross-tenant 404) + a `tenant_owner`
+role check (mirrors `ReprovisionOrg`'s `RoleAtLeast` gate, tightened to owner). Admin routes use
+`.RequireAuthorization("PlatformOwnerAccess")` (the same policy `AdminTenantsEndpoints` uses today).
+
+## Dependencies
+
+- **Prerequisite (NEW): Story 37-2** — audit hash chain + `VerifyChainAsync` + re-anchor seam
+  (`AuditChainAnonymizer`). Erasure re-anchors the chain after anonymizing audit identity fields.
+- **Prerequisite (NEW): Story 37-6** — `ILegalHoldService`; blocks erasure of held records.
+- **Prerequisite (NEW): Story 37-7** — `SubjectDataMap` + `SubjectRef` + per-field `ErasurePolicy`;
+  erasure walks the same inventory DSAR exports.
+- **Prerequisite: Epic 29** — secret cabinet (`ISecretStore`, `ISecretStoreBackend`,
+  `SecretVersionRow`, `DeleteVersionAsync` scrub). EXISTS — verified.
+- **Reuses (EXISTS):** `DomainEvent` (immutable), `IEventRepository.AppendAsync`,
+  `TenantLifecycleEvents` (purge machinery + event shape), `IPlatformQueuedTaskRepository` +
+  `TaskQueueProcessor` (async), `ITammaModeProvider` (mode), `PlatformOwnerAccess` policy +
+  `RequireTenantMembershipFilter` (RBAC), `User` entity (PII fields).
+- **Related:** Story 37-12 (compliance dashboard) surfaces erasure status — out of scope here.
+
+## Testing Strategy
+
+Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/Compliance/` (xUnit; docker-bound suites run
+via `sg docker -c "dotnet test ..."`). Mock `SubjectDataMap`, `ILegalHoldService`,
+`AuditChainAnonymizer` until 37-2/6/7 land.
+
+1. **Policy application** — a map with both `deletable` and `must-retain-anonymized` fields: deletes
+   the former, anonymizes the latter to a stable tombstone; counts correct.
+2. **Crypto-shred unrecoverability** — an `encrypted-secret` entry: after erasure
+   `GetVersionPlaintextAsync` → null, `Status = revoked`; destroyed `(SecretId, Version, KekId)`
+   recorded in the terminal event; no key path recovers plaintext.
+3. **Chain intact after erasure** — seed a 37-2 chain over audit rows including the subject; run
+   erasure; `VerifyChainAsync` passes (re-anchored), and an asserted-tamper (manual byte edit)
+   still fails verification (proves the chain is real, not bypassed).
+4. **Append-only store untouched** — assert zero `UPDATE`/`DELETE` statements hit `domain_events`
+   during erasure (interceptor/spy).
+5. **Legal-hold blocks** — held records skipped, `GDPR.ERASURE.BLOCKED_BY_HOLD` emitted, partial
+   result lists held items with hold id + reason, remainder erased, terminal = `PARTIAL`.
+6. **Partial-result reporting** — counts per category (`deleted`/`anonymized`/`crypto_shredded`/`held`)
+   match the map; `held > 0` ⇒ `GDPR.ERASURE.PARTIAL`, else `COMPLETED`.
+7. **Event emission** — `REQUESTED` on accept, exactly one terminal event, subject id hashed in
+   tags, request/actor/reason retained.
+8. **Idempotent re-run** — second run is a no-op (no double counts, no throw); already-shredded
+   versions stay revoked.
+9. **RBAC matrix** — tenant_owner ✓, tenant_admin 403, member 403, cross-tenant 404, platform admin
+   ✓ on admin route, non-platform 403; out-of-scope subject 404.
+10. **SLA / status** — status endpoint reports `requested→in_progress→completed|partial|failed`;
+    WARN logged when non-terminal past `Gdpr:ErasureSlaDays`.
+11. **Resume after mid-walk failure** — inject a throw mid-map; task marked failed with cursor;
+    retry resumes; chain verifies.
+12. **Tenant-purge reconciliation** — a full purge shreds every subject's keys via the same
+    primitive; erasure (single subject) is the subset.
+
+## Estimated Effort
+
+5-6 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/ErasureExecutor.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/ErasureRequest.cs` (records: request/result/held/shredded-key) | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/ErasureEventTypes.cs` (`GDPR.ERASURE.*`) | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/IAuditChainAnonymizer.cs` (consumes 37-2; stub until then) | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/GdprErasureTaskHandler.cs` (TaskQueueProcessor handler for `GDPR_ERASURE`) | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/ErasureOptions.cs` (`Gdpr:ErasureSlaDays`) | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/ComplianceServiceCollectionExtensions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs` | Modify (add `RequestErasure` + `GetErasureStatus`, tenant routes) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminTenantsEndpoints.cs` | Modify (add platform erasure routes) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map routes; register compliance services + task handler) |
+| `apps/tamma-elsa/src/Tamma.Api/Dtos/Compliance/ErasureDtos.cs` (request/status DTOs) | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Compliance/ErasureExecutorTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Compliance/ErasureEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Compliance/ErasureChainPreservationTests.cs` | Create |
+
+> The SubjectDataMap / SubjectRef / ErasurePolicy (37-7), ILegalHoldService (37-6), and
+> AuditChainAnonymizer impl (37-2) are owned by their respective stories. This story references
+> their contracts and mocks them in tests; it does not create the production implementations.
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes/bugs/findings/decisions (esp. Epic 28 KEK decision
+   `project_epic28_kek_decision.md` and Epic 29 secret-cabinet notes)
+3. Confirmed 37-2/37-6/37-7 contracts are stable enough to mock; if their shapes shift, update the
+   stub interfaces in `Services/Compliance/`
+4. Planned a TDD approach (Red-Green-Refactor)
+
+### Crypto-shred is destroy-the-key, not delete-the-row
+
+`DomainEvent` is append-only and load-bearing for the alert evaluator's `SequenceNumber` cursor.
+Never `UPDATE`/`DELETE` it. The `SecretVersionRow` scrub (`DeleteVersionAsync`) already zeroes
+ciphertext and keeps the row — lean on it; do not invent a parallel deletion path. The audit chain
+(37-2) is anonymized + **re-anchored** (re-hashed and re-signed as an explicit step), never silently
+mutated — a silent edit would itself look like tampering to `VerifyChainAsync`.
+
+### Never log PII; hash the subject everywhere
+
+Subject id/email appears in tags only as a salted hash (`subjectHash`). Logs, events, and the
+held-back report use the hash. The plaintext reason + acting principal ARE retained (lawful-basis
+evidence) but the subject's own PII is the thing being destroyed — do not echo it back.
+
+### Idempotency + resume
+
+Every destructive primitive is individually idempotent (DeleteVersionAsync no-op on revoked;
+anonymize-if-not-already-tombstoned; hard-delete-if-exists). Persist a per-map cursor on the queued
+task so a crash resumes rather than restarts. Apply the chain re-anchor last and per-affected-row
+atomically so a partial run never leaves an unverifiable chain.
+
+### Reconcile with TENANT.PURGED
+
+A full tenant purge is "erase every subject in the tenant." Share the secret-scrub primitive and
+the per-mode scoping with `TenantLifecycleEvents` so purge and subject-erasure can't drift. Subject
+erasure does NOT delete the tenant; tenant purge does (and additionally drops the schema).
+
+## Logging Requirements
+
+- **INFO**: Erasure requested (erasureRequestId, tenantId, mode, hashed subject), erasure completed
+  (counts per category), task picked up / terminal.
+- **DEBUG**: Per-map-entry action (entry kind, policy, action taken), per-secret shred
+  (SecretId, version), chain re-anchor span (rows touched).
+- **WARN**: Legal-hold blocked items (count, hold ids), erasure still non-terminal past SLA, retry
+  resuming from cursor.
+- **ERROR**: Executor step failure (step, cursor), chain verification failed post-erasure (must
+  page — this is a compliance-integrity incident), secret-store unreachable.
+- **Structured context**: `{ erasureRequestId, tenantId, mode, subjectHash, deleted, anonymized,
+  cryptoShredded, held }` where applicable.
+- **Credential / PII safety**: NEVER log the subject's email/id/PII or any secret plaintext or KEK
+  bytes; subject identity is always the salted hash.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-37/story-37-9/37-9-consent-and-data-processing-logging.md
+++ b/docs/stories/epic-37/story-37-9/37-9-consent-and-data-processing-logging.md
@@ -1,0 +1,498 @@
+# Story 37-9: Consent & Data-Processing Logging
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **tenant owner (SaaS) or self-hosting user (single-user)**,
+I want every consent and data-processing decision — terms/DPA acceptance, BYOK
+vs platform-provided data handling, telemetry opt-in/out, and AI-training-data
+usage — recorded as immutable, versioned, who/what/when history that feeds the
+audit trail,
+So that I can prove (for SOC2 / GDPR Records of Processing Activities) exactly
+when consent was granted or withdrawn, and the platform can gate behaviour on
+the current effective consent.
+
+## Priority
+
+P2 — GDPR/SOC2 control evidence. Part of the Epic 37 compliance product layer
+(consent logging is an explicit deliverable of the epic theme: "GDPR controls
+(DSAR export, right-to-erasure, consent logging)").
+
+## Context & Background
+
+Tamma processes user repository content, prompts, and LLM payloads on behalf of
+tenants. GDPR Art. 6/7 requires a demonstrable record of the legal basis and
+consent for each processing purpose; Art. 30 requires a Record of Processing
+Activities (ROPA). SOC2 privacy criteria require the same evidence trail. Today
+Tamma has **no consent capture and no ROPA** — there is no way for a tenant to
+prove when they accepted the DPA or opted out of telemetry.
+
+This story adds an **append-only consent log** (`consent_records`) plus a small
+**ROPA registry** (`processing_activities`), both per-mode owned (mirroring the
+`prompt_overrides` / `Convention` dual-scoping precedent), with every change
+emitting a sensitive `CONSENT.*` audit event that flows into the curated audit
+trail from Story 37-1 and the hash-chain from Story 37-2.
+
+**Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md):**
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns a **consent record**? | The sole user — `user_id`-keyed, `tenant_id` NULL (same XOR as `prompt_overrides`). | The tenant — `tenant_id`-keyed, `user_id` NULL. `tenant_owner`/`tenant_admin` grant/withdraw on the org's behalf. |
+| Who can **grant/withdraw**? | The user (no RBAC). | `tenant_owner` / `tenant_admin` only; `member` gets read-only (403 on write), mirroring prompt-store RBAC. |
+| Who can **read** consent state + history? | The user. | Any tenant member (own tenant only); cross-tenant rejected. |
+| Where is the **ROPA registry** owned? | System-defined activities (shipped defaults) + the sole user's tenant view. | System-defined activities (platform-owner via `OwnerAccess`) surfaced read-only to every tenant member; tenant-scoped notes optional. |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`) — process-stable. | same |
+
+## Dependency note on the audit substrate
+
+The epic sequences this story **after 37-1 (curated audit trail) and 37-2
+(tamper-evident hash-chain)**. Those stories deliver the `audit_records` table
+and the `IAuditTrail` write seam (NEW — not yet in the repo as of this draft).
+Until 37-1/37-2 land, the only audit substrate present is the DCB `DomainEvent`
+store via `IEventRepository.AppendAsync` (verified at
+`apps/tamma-elsa/src/Tamma.Data/Repositories/IEventRepository.cs`). This story
+writes `CONSENT.GRANTED` / `CONSENT.WITHDRAWN` through the 37-1 audit seam (and,
+because the audit trail itself is built on the DCB stream, the same events also
+land as `DomainEvent` rows that the `AlertRuleEvaluator` already polls). **If
+37-1/37-2 are not yet merged when this story is implemented, fall back to
+appending directly via `IEventRepository.AppendAsync` and tag the events
+`sensitive: "true"` so the 37-1 ingest backfills them into `audit_records`.**
+
+## Acceptance Criteria
+
+1. **AC1 — `consent_records` entity (append-only, per-mode owned).** A new
+   `consent_records` table stores `consent_type`, `version`, `granted` (bool),
+   `actor_user_id`, `occurred_at`, `ip_address`, `user_agent`, and
+   `source_event_id` (back-reference to the emitted `CONSENT.*` audit event).
+   Exactly one of `user_id` / `tenant_id` is non-null (principal XOR CHECK,
+   mirroring `ck_prompt_overrides_principal_xor`). The table is **append-only**:
+   no UPDATE/DELETE path exists in the service or repository; a withdrawal is a
+   NEW row with `granted = false`, never an in-place edit of the grant row.
+
+2. **AC2 — record grant/withdraw + read effective state & history.** Endpoints:
+   `POST /api/v1/orgs/{tenantId}/consent` (SaaS, `tenant_owner`/`tenant_admin`)
+   and a self-service single-user variant record a grant or withdrawal;
+   `GET /api/v1/orgs/{tenantId}/consent` returns the **current effective
+   consent per type** plus `?history=true` for the full append-only timeline.
+   Endpoint shape is identical across modes — auth middleware decides which
+   principal key (`user_id` vs `tenant_id`) is written, exactly as the
+   prompt-store API does.
+
+3. **AC3 — consent changes emit hash-chained sensitive audit events.** Every
+   grant emits `CONSENT.GRANTED` and every withdrawal emits `CONSENT.WITHDRAWN`
+   (pattern `AGGREGATE.ACTION.STATUS`), flagged sensitive, written through the
+   Story 37-1 audit trail and hash-chained via Story 37-2. Tags include
+   `consentType`, `version`, `scope` (`user`/`tenant`), `tenantId`, `actorUserId`,
+   `mode`. The resulting `audit_records` (or DCB) row id is stored back on the
+   `consent_records.source_event_id` column.
+
+4. **AC4 — canonical, versioned consent types.** A `ConsentType` constants set
+   ships at minimum: `terms_of_service`, `data_processing_agreement`,
+   `byok_data_handling`, `telemetry_opt_in`, `ai_training_data_usage`. Each type
+   carries a current **active version** (from `ConsentTypeCatalog` in code, the
+   `SystemPrompts` precedent for shipped defaults). A TOS/DPA version bump
+   requires re-consent — a grant at v1 does not satisfy a v2 requirement.
+
+5. **AC5 — effective-consent resolution + staleness flag.** Resolution returns
+   the latest record per `(scope, consent_type)` ordered by `occurred_at` then
+   the `BIGSERIAL` tiebreak (mirroring `DomainEvent.SequenceNumber` ordering),
+   and flags `stale = true` when `catalog.activeVersion > consentedVersion`
+   (re-consent required) and `granted = false` when the latest record is a
+   withdrawal. A type with no record returns `granted = false, stale = false,
+   consentedVersion = null`.
+
+6. **AC6 — Records of Processing Activities (ROPA) registry.** A
+   `processing_activities` table (system-scoped defaults seeded insert-missing-
+   only, the `ConventionSeedSpecs` precedent) records each processing purpose:
+   `activity_key`, `name`, `purpose`, `lawful_basis`, `data_categories`,
+   `retention`, `recipients`, `is_active`. `GET /api/v1/orgs/{tenantId}/processing-activities`
+   returns the registry for tenant members (read-only); platform-owner CRUD lives
+   at `GET/POST/PATCH /api/v1/admin/processing-activities` (`OwnerAccess`).
+
+7. **AC7 — RBAC per mode; cross-tenant rejected.** In SaaS, `member` users can
+   read their own tenant's consent + ROPA but receive **403** on
+   `POST .../consent`; `tenant_owner`/`tenant_admin` may write. Any request whose
+   path `{tenantId}` differs from the caller's membership is rejected by the
+   existing `RequireTenantMembershipFilter` (cross-tenant 403/404). In
+   single-user mode, the sole user has full read+write with no role check.
+
+8. **AC8 — consent gating helper.** An `IConsentGate.RequireAsync(scopeKey,
+   consentType)` helper resolves effective consent and throws a
+   `TammaError("CONSENT.REQUIRED.MISSING", ..., severity High)` when consent is
+   absent, withdrawn, or stale — for callers that must enforce a gate (e.g. an
+   AI-training-data-dependent code path). The gate **reads only**; it never
+   auto-grants. Gating is wired at one demonstrative call site (telemetry emit
+   or AI-training-data usage) and exposed for future call sites; it does NOT
+   silently degrade — a missing-consent gate is a hard error, consistent with
+   the project's no-empty-fallback rule.
+
+9. **AC9 — append-only enforcement is structural, not advisory.** There is no
+   service/repository method that updates or deletes a `consent_records` row;
+   a test asserts the repository surface exposes only append + query. (DB-level
+   immutability hardening — e.g. a revoke trigger — is out of scope; the
+   service surface is the enforcement boundary, matching how the DCB event
+   store is append-only by API not by DB trigger today.)
+
+10. **AC10 — tests cover the compliance-critical paths.** Unit + integration
+    tests cover: append-only enforcement (AC9); grant→withdraw→re-grant history
+    correctness and ordering; version-bump staleness detection (AC5); `CONSENT.*`
+    emission with correct tags + `source_event_id` round-trip (AC3); per-mode
+    RBAC matrix incl. SaaS `member` 403 and cross-tenant rejection (AC7); ROPA
+    read/seed + admin CRUD (AC6); `IConsentGate` throws on missing/withdrawn/
+    stale and passes on a fresh grant (AC8).
+
+11. **AC11 — full suite stays green; migration applies + rolls back cleanly.**
+    The additive EF migration (new tables, no baseline CHECK edits) reports no
+    pending model changes after `dotnet ef migrations add`; entity config lives
+    only in `TammaModelConfiguration.cs` (the established single source).
+
+## Technical Design
+
+### Substrate verified in-repo (do NOT invent new substrate)
+
+| Concern | Real anchor (verified) |
+|---|---|
+| Subject identity | `apps/tamma-elsa/src/Tamma.Data/Entities/User.cs` (`Id`, `TenantId`, `Role`, `PlatformRole`) |
+| Audit event row | `apps/tamma-elsa/src/Tamma.Data/Entities/DomainEvent.cs` (`Type`, `TenantId`, `Tags`, `Data`, `SequenceNumber`) |
+| Audit write seam | `apps/tamma-elsa/src/Tamma.Data/Repositories/IEventRepository.cs` (`AppendAsync`) |
+| Dual-scoping precedent | `apps/tamma-elsa/src/Tamma.Data/Entities/PromptOverride.cs` + `TammaModelConfiguration.cs` ~714 (`ck_prompt_overrides_principal_xor`, `NULLS NOT DISTINCT` unique index) |
+| Mode | `apps/tamma-elsa/src/Tamma.Api/Services/PromptStore/TammaMode.cs` (`ITammaModeProvider`) |
+| Tenant RBAC | `apps/tamma-elsa/src/Tamma.Api/Authorization/TenantRoleHierarchy.cs` + `RequireTenantMembershipFilter` (path-tenant gate) |
+| Org endpoints (target) | `apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs` (`ListTenantAudit` precedent) |
+| Platform-owner gate | `OwnerAccess` policy (admin endpoints under `/api/v1/admin/*`) |
+| Seed-defaults precedent | `apps/tamma-elsa/src/Tamma.Api/Services/Conventions/ConventionSeedSpecs.cs` (insert-missing-only) |
+| 37-1/37-2 audit trail | `audit_records` table + `IAuditTrail` / hash-chain — **NEW (delivered by deps)** |
+
+> Note: `packages/api` (TypeScript) is DELETED. All targets are the C#
+> `apps/tamma-elsa` solution. Do not reference or create TS-side code.
+
+### `ConsentRecord` entity (NEW)
+
+`apps/tamma-elsa/src/Tamma.Data/Entities/ConsentRecord.cs`:
+
+```csharp
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Append-only consent / data-processing decision. One row per grant or
+/// withdrawal — there is NO in-place edit. Per-mode owned (XOR on
+/// user_id / tenant_id), mirroring <see cref="PromptOverride"/>.
+/// </summary>
+public class ConsentRecord
+{
+    public Guid Id { get; set; }
+
+    /// <summary>Single-user mode: the sole user. NULL in SaaS.</summary>
+    public Guid? UserId { get; set; }
+
+    /// <summary>SaaS mode: the owning tenant. NULL in single-user.</summary>
+    public Guid? TenantId { get; set; }
+
+    /// <summary>One of <see cref="Tamma.Api.Services.Compliance.ConsentType"/>.</summary>
+    public string ConsentType { get; set; } = null!;
+
+    /// <summary>Version of the TOS/DPA/policy this decision applies to.</summary>
+    public string Version { get; set; } = null!;
+
+    /// <summary>true = granted, false = withdrawn.</summary>
+    public bool Granted { get; set; }
+
+    /// <summary>The user who performed the action (audit who).</summary>
+    public Guid ActorUserId { get; set; }
+
+    public string? IpAddress { get; set; }
+    public string? UserAgent { get; set; }
+
+    /// <summary>FK to the CONSENT.* audit/DCB row this change emitted.</summary>
+    public Guid? SourceEventId { get; set; }
+
+    public DateTime OccurredAt { get; set; }
+
+    /// <summary>
+    /// Monotonic insertion-order tiebreak (BIGSERIAL), mirroring
+    /// <see cref="DomainEvent.SequenceNumber"/> — disambiguates two records
+    /// that share an <see cref="OccurredAt"/> millisecond when resolving the
+    /// latest decision per (scope, type).
+    /// </summary>
+    public long SequenceNumber { get; set; }
+}
+```
+
+Model config (in `TammaModelConfiguration.cs`, mirroring the PromptOverride block):
+
+- `principal_xor` CHECK: exactly one of `UserId` / `TenantId` non-null.
+- `granted_type` CHECK on `ConsentType` IN the canonical set (or leave open and
+  validate in service — match the project's existing CHECK-vs-service split).
+- Index on `(UserId, TenantId, ConsentType, SequenceNumber DESC)` for the
+  latest-per-type resolution query. **No unique index** — multiple rows per
+  `(scope, type)` are the whole point (history).
+- `SequenceNumber` as `BIGSERIAL` identity (same as `DomainEvent`).
+
+### `ProcessingActivity` entity (NEW — ROPA)
+
+`apps/tamma-elsa/src/Tamma.Data/Entities/ProcessingActivity.cs`:
+
+```csharp
+public class ProcessingActivity
+{
+    public Guid Id { get; set; }
+    public string ActivityKey { get; set; } = null!;   // e.g. "llm_payload_processing"
+    public string Name { get; set; } = null!;
+    public string Purpose { get; set; } = null!;
+    public string LawfulBasis { get; set; } = null!;   // GDPR Art.6 basis
+    public string[] DataCategories { get; set; } = [];
+    public string Retention { get; set; } = null!;
+    public string[] Recipients { get; set; } = [];     // sub-processors
+    public bool IsActive { get; set; } = true;
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}
+```
+
+System-scoped (no tenant key) — these are platform-level processing facts,
+seeded insert-missing-only via a `ProcessingActivitySeedSpecs` mirroring
+`ConventionSeedSpecs`. Unique on `ActivityKey`.
+
+### `ConsentType` catalog (NEW — code-shipped defaults)
+
+`apps/tamma-elsa/src/Tamma.Api/Services/Compliance/ConsentTypeCatalog.cs`:
+
+```csharp
+public static class ConsentType
+{
+    public const string TermsOfService        = "terms_of_service";
+    public const string DataProcessingAgreement = "data_processing_agreement";
+    public const string ByokDataHandling      = "byok_data_handling";
+    public const string TelemetryOptIn        = "telemetry_opt_in";
+    public const string AiTrainingDataUsage   = "ai_training_data_usage";
+}
+
+public static class ConsentTypeCatalog
+{
+    // Active version per type — a bump here forces re-consent (AC4/AC5).
+    public static readonly IReadOnlyDictionary<string, string> ActiveVersions =
+        new Dictionary<string, string>
+        {
+            [ConsentType.TermsOfService]          = "2026-06-01",
+            [ConsentType.DataProcessingAgreement] = "2026-06-01",
+            [ConsentType.ByokDataHandling]        = "1.0",
+            [ConsentType.TelemetryOptIn]          = "1.0",
+            [ConsentType.AiTrainingDataUsage]     = "1.0",
+        };
+}
+```
+
+### `ConsentService` (NEW)
+
+`apps/tamma-elsa/src/Tamma.Api/Services/Compliance/ConsentService.cs`:
+
+- `RecordAsync(scope, consentType, granted, actorUserId, ip, ua)` →
+  validates `consentType` against the catalog, resolves `version` from
+  `ConsentTypeCatalog.ActiveVersions`, emits `CONSENT.GRANTED`/`CONSENT.WITHDRAWN`
+  via the 37-1 audit trail (fallback `IEventRepository.AppendAsync`), inserts a
+  new `ConsentRecord` with `SourceEventId` set, returns the new record.
+  **Append-only — no update path.**
+- `GetEffectiveAsync(scope)` → latest record per `(scope, type)` +
+  `stale`/`granted` flags (AC5). Returns one row per known consent type
+  (absent → `granted=false`).
+- `GetHistoryAsync(scope, consentType?)` → full append-only timeline, newest
+  first by `(OccurredAt, SequenceNumber)`.
+
+Scope is resolved from `ITammaModeProvider` + caller identity exactly like the
+prompt store: single-user → `user_id`; SaaS → `tenant_id`.
+
+### `IConsentGate` (NEW)
+
+`apps/tamma-elsa/src/Tamma.Api/Services/Compliance/IConsentGate.cs`:
+
+```csharp
+public interface IConsentGate
+{
+    /// <summary>Throws TammaError("CONSENT.REQUIRED.MISSING", High) when the
+    /// effective consent for <paramref name="consentType"/> is absent,
+    /// withdrawn, or stale. Read-only; never grants.</summary>
+    Task RequireAsync(ConsentScope scope, string consentType, CancellationToken ct = default);
+}
+```
+
+Wired at one demonstrative site (telemetry emit OR AI-training-data path) to
+prove the gate; not retro-fitted across the codebase in this story.
+
+### Endpoints
+
+In `OrgEndpoints.cs` (the spec target), mirroring `ListTenantAudit`:
+
+```
+POST /api/v1/orgs/{tenantId}/consent      → ConsentService.RecordAsync (admin+ via RoleAtLeast; member → 403)
+GET  /api/v1/orgs/{tenantId}/consent      → effective state (any member); ?history=true → timeline
+GET  /api/v1/orgs/{tenantId}/processing-activities  → ROPA read (any member)
+```
+
+Single-user self-service variant: `POST /api/v1/consent` + `GET /api/v1/consent`
+(no path-tenant; principal = the user). Route registration in `Program.cs`
+alongside the existing `orgs.MapGet("/{tenantId:guid}/audit", ...)` block (line
+~1550), each org route attaching `RequireTenantMembershipFilter`.
+
+Platform-owner ROPA CRUD under `/api/v1/admin/processing-activities`
+(`OwnerAccess`), mirroring existing admin endpoints.
+
+### Migration
+
+Additive EF migration under
+`apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/` via
+`dotnet ef migrations add AddConsentAndProcessingActivities`. New tables only —
+no baseline CHECK edits — so it is a normal additive migration. Verify
+`has-pending-model-changes` reports none afterwards.
+
+## Dependencies
+
+- **Prerequisite — Story 37-1** (curated audit trail): provides the
+  `audit_records` table + `IAuditTrail` write seam that `CONSENT.*` events flow
+  into. Fallback to `IEventRepository.AppendAsync` if not yet merged.
+- **Prerequisite — Story 37-2** (tamper-evident hash-chain): hash-chains the
+  `CONSENT.*` audit rows so consent history is tamper-evident.
+- **Prerequisite — Epic 18 (auth)**: `User`, `TenantMembership`,
+  `TenantRoleHierarchy`, `RequireTenantMembershipFilter`, `OwnerAccess`/
+  `PlatformOwnerAccess` policies — the RBAC substrate this story's per-mode
+  gating relies on.
+- **Related — `ITammaModeProvider`** (`TammaMode.cs`): single source for
+  per-mode scope derivation.
+- **Related — Epic 37 GDPR DSAR/erasure stories**: consent history is part of
+  the DSAR export payload and must be preserved (audit) on erasure.
+
+## Testing Strategy
+
+Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/Compliance/` (new folder;
+xUnit/NUnit per existing convention). Docker-bound suites run via
+`sg docker -c "dotnet test ..."`.
+
+1. **`ConsentServiceTests`** — grant inserts one row + emits `CONSENT.GRANTED`
+   with correct tags and round-trips `SourceEventId`; withdraw inserts a second
+   row (`granted=false`) + `CONSENT.WITHDRAWN`, never edits the grant row;
+   grant→withdraw→re-grant produces 3 rows in correct order; effective state
+   returns the latest; staleness flips when the catalog version is bumped above
+   the consented version.
+2. **`ConsentAppendOnlyTests`** — repository/service surface exposes only
+   append + query (no update/delete); reflection or interface assertion (AC9).
+3. **`ConsentEndpointsTests`** — per-mode RBAC matrix: single-user user
+   read+write; SaaS `tenant_owner`/`tenant_admin` write, `member` read-only
+   (403 on POST); cross-tenant path rejected by the membership filter; history
+   query returns ordered timeline.
+4. **`ProcessingActivityTests`** — seed is insert-missing-only (re-run adds
+   nothing, never reverts edits); tenant read returns active activities;
+   platform-owner CRUD gated by `OwnerAccess` (non-owner 403).
+5. **`ConsentGateTests`** — `RequireAsync` throws `CONSENT.REQUIRED.MISSING` on
+   absent/withdrawn/stale; passes on a fresh active-version grant; never grants.
+6. **Migration test** — apply + rollback clean; no pending model changes.
+
+## Estimated Effort
+
+3-4 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/ConsentRecord.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/ProcessingActivity.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (add `DbSet<ConsentRecord>`, `DbSet<ProcessingActivity>`) |
+| `apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs` | Modify (ignore/scope the new sets per the established dual-context pattern) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (entity config: XOR CHECK, indexes, BIGSERIAL — single source) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/*_AddConsentAndProcessingActivities.cs` | Create (EF migration) |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/IConsentRepository.cs` | Create (append + query only) |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/ConsentRepository.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/ConsentType.cs` (+ `ConsentTypeCatalog`) | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/ConsentService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/IConsentGate.cs` (+ `ConsentGate.cs`) | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/ConsentEventTypes.cs` (`CONSENT.GRANTED`, `CONSENT.WITHDRAWN`) | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Compliance/ProcessingActivitySeedSpecs.cs` (+ seeder) | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs` | Modify (add consent + ROPA handlers) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminProcessingActivityEndpoints.cs` | Create (platform-owner CRUD) |
+| `apps/tamma-elsa/src/Tamma.Api/Dtos/Orgs/OrgDtos.cs` (or new `ConsentDtos.cs`) | Modify/Create (request/response shapes) |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/ComplianceServiceCollectionExtensions.cs` | Create (DI wiring) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (route mapping + DI registration) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Compliance/ConsentServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Compliance/ConsentAppendOnlyTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Compliance/ConsentEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Compliance/ProcessingActivityTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Compliance/ConsentGateTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, and decisions
+3. Confirmed the state of Stories 37-1 and 37-2 (audit trail + hash-chain). If
+   `audit_records` / `IAuditTrail` are merged, write `CONSENT.*` through them; if
+   not, append via `IEventRepository.AppendAsync` and tag `sensitive: "true"`.
+4. Planned a TDD approach (Red-Green-Refactor).
+
+### Append-only is the load-bearing invariant
+
+Consent history's evidentiary value depends on immutability. Enforce it at the
+**service + repository surface** (no update/delete method exists) — the same way
+the DCB event store is append-only by API. A withdrawal is always a new row.
+A test (`ConsentAppendOnlyTests`) must pin this so a future "convenience" edit
+method can't slip in. DB-level immutability (revoke triggers) is a deliberate
+non-goal here; the API boundary is the enforcement line, matching project
+precedent.
+
+### Per-mode scope derivation — reuse, don't reinvent
+
+Derive scope (`user_id` vs `tenant_id`) from `ITammaModeProvider` + caller
+identity exactly as `PromptStoreService` does. Do NOT add a per-user override
+layer in SaaS — consent is owned by the tenant (tenant_owner/tenant_admin),
+mirroring the prompt-store "no per-user layer in SaaS" decision in CLAUDE.md.
+
+### Staleness, not deletion, drives re-consent
+
+A TOS/DPA version bump must NOT invalidate or delete the old grant — it stays in
+history. Staleness is computed at read time: `activeVersion > consentedVersion`.
+This keeps the audit trail intact while still forcing a fresh decision.
+
+### No empty/plain fallback
+
+Consistent with the project's resolution rule
+(`feedback_resolution_no_empty_fallback`): `IConsentGate.RequireAsync` is a hard
+error on missing/withdrawn/stale consent. It never auto-grants and never
+silently passes.
+
+### Migration discipline
+
+`consent_records` and `processing_activities` are additive new tables, so a
+normal `dotnet ef migrations add` applies — NOT a baseline CHECK edit. Still run
+`has-pending-model-changes` afterwards (must report none) and put all entity
+config in `TammaModelConfiguration.cs` only.
+
+## Logging Requirements
+
+- **INFO**: consent recorded (`consentType`, `granted`, `scope`, `version`,
+  `actorUserId`, `mode`); ROPA seeded (`added` count); effective-consent endpoint
+  queried.
+- **DEBUG**: effective-consent resolution result per type (`granted`, `stale`,
+  `consentedVersion`, `activeVersion`); consent-gate check outcome.
+- **WARN**: consent-gate denial (`consentType`, `scope`, reason: absent/
+  withdrawn/stale); attempted write by a `member` role (403).
+- **ERROR**: audit-event emission failed (consent NOT recorded — the row insert
+  and the event emission must be atomic; a failed emit aborts the record); DB
+  write failure.
+- **Structured context**: `{ scope, tenantId, userId, consentType, version,
+  granted, mode, sourceEventId }` where applicable.
+- **Credential / PII safety**: NEVER log full IP/user-agent at INFO+ beyond what
+  the consent row already persists for evidence; never log auth tokens.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation | Claude |

--- a/docs/superpowers/plans/2026-06-17-32-1-agent-entity-model-and-versioned-saved-config-plan.md
+++ b/docs/superpowers/plans/2026-06-17-32-1-agent-entity-model-and-versioned-saved-config-plan.md
@@ -1,0 +1,301 @@
+# Story 32-1 — Agent Entity Model & Versioned Saved Config (public/private)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation.
+
+**Story:** `docs/stories/epic-32/story-32-1/32-1-agent-entity-model-and-versioned-saved-config.md`
+**Epic:** 32 — Agents: First-Class Agent Entities, Managed Execution, Benchmarking & Learning
+**Design of record:** `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`
+**Priority:** P0 (foundational — everything in Epic 32 joins on `agent_id` + config version)
+**Est. effort:** 4-5 days
+**Date:** 2026-06-17
+
+---
+
+## Goal
+
+Promote agents from the anonymous, role-keyed `agent_configs` JSONB blob into first-class,
+identity-bearing **entities** with immutable, monotonically **versioned** saved-config snapshots.
+Introduce two control-plane-resident EF entities — `Agent` (stable identity, role,
+public/private visibility, owner, status, current-version pointer) and `AgentVersion` (immutable
+config snapshot) — with a CHECK-enforced ownership invariant, a versioning transaction, DCB audit
+events, a public-agent seeder, and per-mode/per-tenant RBAC'd REST endpoints. This is the
+canonical owner of the `Agent`/`AgentVersion` entities the rest of Epic 32 builds on.
+
+## Non-goals (YAGNI guard)
+
+- **NO performance/action data on these entities.** Per the design, performance is ALWAYS
+  tenant-scoped and lands in the tenant schema in later stories (32-6, 32-10). `Agent`/`AgentVersion`
+  are definition-only.
+- **NO cutover of the legacy `agent_configs` blob.** The new model coexists; repointing workflows
+  and retiring `agent_configs` is a separate, later Epic 32 story. Keep the blast radius small.
+- **NO managed execution layer, no resolution-with-merge, no benchmarking.** Those are 32-2/32-5/32-10.
+  This story stops at: entity + version + ownership + seed + CRUD endpoints + events.
+- **NO TenantDbContext changes.** Definitions are control-plane-resident (cross-tenant identity is a
+  CP concern). Do not add these entities to `TenantDbContext`.
+- **NO new auth policies.** Reuse `PlatformOwnerAccess` (public writes), the owner/admin gate
+  (private writes), and `SettingsView` (reads). Member 403 is enforced at the handler, mirroring
+  the Prompt Store.
+- **NO BYOK / credential wiring.** Agent definitions are credential-agnostic (provider+model+prompt,
+  never raw keys). Credential resolution is 32-3.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### The thing being replaced
+
+| Site | Today |
+|---|---|
+| `src/Tamma.Data/Entities/AgentConfig.cs` | One row per principal: `Id`, nullable `TenantId` (NULL = system default, non-NULL = tenant override), `Config` jsonb blob, `Version` int, audit cols. No identity, no per-agent versioning history (Version is bumped in place on the single row), no public/private split beyond null-tenant. |
+| `src/Tamma.Data/TammaModelConfiguration.cs` ~675-712 | `agent_configs` table config: jsonb `Config`, partial unique index `HasFilter("\"TenantId\" IS NOT NULL")`, `omitTenantIdColumn`/`isTenantContext` branches. |
+| `src/Tamma.Api/Endpoints/AgentEndpoints.cs` | `GetConfig`/`UpdateConfig`/`ValidateConfig` over the blob; `ResolveAgent`/`ResolveForPhase` via `IAgentResolverService`. `UpdateConfig` validates via private `ValidateConfigShape` (provider regex `^[a-z0-9][a-z0-9_-]{0,63}$`, `maxBudgetUsd` ∈ [0,100], ReDoS guard, prototype-pollution rejection) and emits `AGENT_CONFIG.UPDATED.SUCCESS` ONLY after a real write (Story 28-1 PR A discipline). |
+| `src/Tamma.ElsaServer/AgentSeeder.cs` | `BackgroundService` seeding the **Elsa Agents** store (`IAgentManager`) with 9 `tamma-<role>` definitions (`tamma-architect`, `tamma-tester`, `tamma-reviewer`, …), each with prompt + `temperature` + `maxTokens=4096` + `providerChain ["anthropic","openai","openrouter"]` + `maxBudgetUsd=10.0`. Idempotent skip-by-name. This seeds Elsa's store, NOT the Tamma CP tables — the new `AgentEntitySeeder` is additive and reuses the same handles/values. |
+
+### Patterns to mirror (verified)
+
+- **Ownership XOR CHECK + NULLS-NOT-DISTINCT unique index:** `PromptOverride` in
+  `TammaModelConfiguration.cs` ~714-756 — `ck_prompt_overrides_principal_xor`
+  (`("UserId" IS NOT NULL AND "TenantId" IS NULL) OR (...)`), and
+  `HasIndex(...).IsUnique().AreNullsDistinct(false)`. This is the canonical template for
+  `ck_agents_visibility_ownership` and the partial unique indexes.
+- **Partial unique index:** `AgentConfig` ~700/704 — `HasIndex(e => e.TenantId).IsUnique().HasFilter("\"TenantId\" IS NOT NULL")`.
+- **Audit-event-only-on-real-write:** `AgentEndpoints.UpdateConfig` ~91-113 — `IEventRepository.AppendAsync(new DomainEvent { Type, TenantId, Tags=JSON, Metadata=JSON, Data=JSON, CreatedAt })`. `DomainEvent` fields verified in `Entities/DomainEvent.cs` (`Id, Type, TenantId, Tags, Metadata, Data, CreatedAt, SequenceNumber`).
+- **Insert-missing-only seeder:** `ConventionStoreSeeder` (per memory) / `AgentSeeder` skip-by-existing — `AgentEntitySeeder` follows the same shape.
+- **CP DbContext + DbSet registration:** `ControlPlaneDbContext.cs` line 185 (`DbSet<AgentConfig>`), full DbSet list verified; add `DbSet<Agent>` / `DbSet<AgentVersion>` alongside.
+- **CP migration pipeline:** `src/Tamma.Data/Migrations/ControlPlane/` (namespace `Tamma.Data.Migrations.ControlPlane`, e.g. `20260609205701_InitialControlPlane`); `ControlPlaneDesignTimeDbContextFactory.cs` exists.
+- **Mode + identity seams:** `ITammaModeProvider` (`Services/PromptStore/TammaMode.cs`, singleton, `Mode` is `SingleUser`|`SaaS`), `ITenantContext` (`Tamma.Data/ITenantContext.cs`, `Guid? TenantId`), `ClaimsPrincipal.GetUserId()`.
+- **Taxonomy:** `Tamma.Core/Agents/AgentRole.cs` (8 roles, `[Wire(...)]` strings, `AgentRoleExtensions.Parse` → `RolePhaseMap.NormalizeRole`), `RolePhaseMap.ValidRoles` / `LegacyRoleAliases` / `ForbiddenKeys`.
+- **Auth policies:** `Program.cs` ~966-1090 — `PlatformOwnerAccess` (platform_admin claim), `OwnerAccess` (users:manage), `SettingsManage`, `SettingsView`. Agents group mapped ~1679-1688 (`/api/v1/agents` `.RequireAuthorization("SettingsView")`).
+- **Test fixtures:** `tests/Tamma.Api.Tests/Agents/` exists; CP model/isolation precedents in `tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs` + `CrossTenantIsolationPostgresTests.cs`; in-memory + Postgres fixtures in `Infrastructure/`. Run via `sg docker -c "dotnet test ..."`.
+
+### Environment notes
+
+- C# tests: `sg docker -c "dotnet test apps/tamma-elsa/... "` (session docker group stale; build needs no wrapper).
+- Postgres 17 in prod/CI — `NULLS NOT DISTINCT` and partial-index filters are available.
+- `dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext` must report none after the migration.
+
+---
+
+## Architecture (one paragraph)
+
+Two CP-resident entities: `Agent` (identity + role + visibility + owner + status + `CurrentVersionId`
+pointer) and `AgentVersion` (immutable `(AgentId, Version, ConfigJson)` snapshot). A DB `CHECK`
+ties `Visibility` to ownership columns (public ⇒ no owner; private ⇒ exactly one of tenant/user
+owner, picked by process mode). `AgentRepository.PublishVersionAsync` runs a single transaction:
+insert next-version row → repoint `CurrentVersionId`; the `(AgentId, Version)` unique index makes
+concurrent publishes safe (retry on conflict). Every state transition appends a DCB event
+(`AGENT.CREATED|VERSION_PUBLISHED|ARCHIVED.SUCCESS`) to the CP `DomainEvents` store via
+`IEventRepository`. An idempotent `AgentEntitySeeder` populates one public agent per role with the
+existing `tamma-<role>` handles. REST endpoints on `/api/v1/agents` expose create/publish/archive/
+list/get with per-mode RBAC (public writes → `PlatformOwnerAccess`; private writes → tenant
+owner/admin; member → 403; reads scoped to public ∪ own private, cross-tenant → 404).
+
+---
+
+## Phased task breakdown (TDD — tests first in every task)
+
+### Task 1 — Entities + EF model config + migration (AC 1-5, 13)
+
+**Files:**
+- New: `Tamma.Data/Entities/Agent.cs`, `AgentVersion.cs`, `AgentVisibility.cs`, `AgentStatus.cs`.
+- Modify: `Tamma.Data/ControlPlaneDbContext.cs` — add `DbSet<Agent> Agents`, `DbSet<AgentVersion> AgentVersions`.
+- Modify: `Tamma.Data/TammaModelConfiguration.cs` — `Entity<Agent>` (table `agents`,
+  `ck_agents_visibility_ownership` CHECK mirroring `ck_prompt_overrides_principal_xor`, partial
+  unique indexes `IX_agents_public_name_role` / `IX_agents_private_tenant_name` /
+  `IX_agents_private_user_name`, enum→int conversions, default-value SQL) and `Entity<AgentVersion>`
+  (table `agent_versions`, `IX_agent_versions_agent_version` unique, FK `OnDelete(Restrict)`).
+  Note: `agents`/`agent_versions` are CP-only — do NOT apply `omitTenantIdColumn`/`isTenantContext`
+  branches; they are not in `TenantDbContext`.
+- New: migration `Migrations/ControlPlane/<ts>_AddAgentEntities.cs` via
+  `dotnet ef migrations add AddAgentEntities --context ControlPlaneDbContext`.
+
+**Approach:** Plain enum→int storage so the CHECK can compare numeric discriminators
+(`Visibility = 0` public / `1` private), exactly as the comment in the story's model sketch.
+`CurrentVersionId` is a bare nullable Guid pointer (no FK back to versions) to dodge a circular FK
+on first-version create.
+
+**Tests (first):** extend `tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs` —
+assert the two tables exist, the CHECK + three partial indexes + the `(AgentId, Version)` unique
+index are in the model; `dotnet ef migrations has-pending-model-changes` reports none (add a model-
+shape assertion test if the harness has one). New `AgentEntityMappingTests` against a Postgres
+fixture: insert valid public/private rows; assert CHECK rejects public-with-owner,
+private-with-no-owner, private-with-both-owners.
+
+**Done when:** migration applies + rolls back cleanly; `has-pending-model-changes` clean; model
+tests green.
+
+### Task 2 — `AgentConfigValidator` (extract + extend) (AC 7)
+
+**Files:**
+- New: `Tamma.Api/Services/Agents/AgentConfigValidator.cs` — public
+  `static (bool Valid, string[] Errors) Validate(string configJson)`.
+- Modify: `Tamma.Api/Endpoints/AgentEndpoints.cs` — make the existing private `ValidateConfigShape`
+  delegate to (or be moved into) `AgentConfigValidator` so rules are shared, not duplicated.
+
+**Approach:** Lift the existing rules verbatim (provider regex, `maxBudgetUsd` [0,100], non-empty
+chains, prototype-pollution, ReDoS `blockedCommandPatterns`, `maxFetchSizeBytes`). Extend for the
+Epic 32 saved-config fields: `model` (string), `temperature` ∈ [0,2], `maxTokens` > 0,
+`tokenBudget` ≥ 0, `tools[]` (strings), `systemPromptRef` (string), `rag{}` (object). Tolerant of
+empty config (valid).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/AgentConfigValidatorTests.cs` — each new rule's
+accept/reject; regression cases proving the legacy rules still fire; existing `AgentEndpoints`
+validation tests still pass after the extraction.
+
+**Done when:** validator covers old + new rules; no behavior change to existing `ValidateConfig`.
+
+### Task 3 — `IAgentRepository` / `AgentRepository` with versioning transaction + events (AC 6, 8, 9, 14)
+
+**Files:**
+- New: `Tamma.Data/Repositories/IAgentRepository.cs`, `AgentRepository.cs` (resolves against
+  `ControlPlaneDbContext` + `IEventRepository`).
+
+**Approach:**
+- `CreateAsync(agent, firstVersionConfigJson, notes, createdBy)`: validate config (call site passes
+  validated JSON; repo asserts non-empty); single transaction — insert `Agent`, insert
+  `AgentVersion{Version=1}`, set `CurrentVersionId`; append `AGENT.CREATED.SUCCESS`.
+- `PublishVersionAsync(agentId, configJson, notes, updatedBy)`: transaction —
+  `nextVersion = MAX(Version)+1`, insert version, repoint `CurrentVersionId` + `UpdatedAt/By`;
+  append `AGENT.VERSION_PUBLISHED.SUCCESS`. Catch unique-index violation on `(AgentId, Version)` →
+  recompute + retry (bounded). Prior versions untouched.
+- `ArchiveAsync(agentId, updatedBy)`: set `Status=Archived` (idempotent — no event if already
+  archived); append `AGENT.ARCHIVED.SUCCESS` only on transition.
+- `ListVisibleAsync(tenantId, userId)`: `WHERE Visibility=Public OR (Visibility=Private AND
+  ((tenantId != null AND OwnerTenantId=tenantId) OR (userId != null AND OwnerUserId=userId)))`.
+- Entity-level ownership guard: a private create whose owner columns contradict the resolved
+  principal throws a `TammaError`-style guard before DB (belt to the CHECK's suspenders).
+- DCB tags include `{ agentId, version, visibility, ownerTenantId?, ownerUserId?, role, mode }`;
+  `DomainEvent.TenantId = OwnerTenantId` for private/SaaS, NULL for public.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/AgentRepositoryTests.cs` — version increment 1→2→3;
+rollback-pointer integrity (CurrentVersionId = highest; older versions fetchable; explicit repoint
+keeps all rows); concurrent double-publish race → monotonic, no dup; archive idempotency;
+DCB event emitted once per transition; no event on validation/transaction failure; per-mode
+principal derivation; ownership guard rejects contradictory input.
+
+**Done when:** all repository tests green against the Postgres fixture; events land in `DomainEvents`.
+
+### Task 4 — `AgentEntitySeeder` (idempotent public-agent seed) (AC 10)
+
+**Files:**
+- New: `Tamma.ElsaServer/AgentEntitySeeder.cs` (`BackgroundService`, or a hosted seeder invoked
+  from `Program.cs`) — creates one public `Agent` + `Version=1` `AgentVersion` per role, reusing the
+  `tamma-<role>` handles and shipped config values currently in `AgentSeeder.GetDefaultAgents()`.
+
+**Approach:** Skip-by-existing-handle (query `agents WHERE Visibility=Public AND Name=@handle`).
+Build `ConfigJson` from the shipped `providerChain` / `temperature` / `maxTokens` / `maxBudgetUsd`
+so the CP rows mirror the Elsa-store definitions. Owner columns NULL (public). Idempotent: second
+run inserts nothing.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/AgentEntitySeederTests.cs` — first run creates N
+public agents with correct handles + Version=1; second run is a no-op (count unchanged, no new
+events); each seeded config validates.
+
+**Done when:** seeder is idempotent and produces validating public agents preserving handles.
+
+### Task 5 — REST endpoints + DTOs + route mapping with per-mode RBAC (AC 11, 12)
+
+**Files:**
+- New: `Tamma.Api/Dtos/Agents/AgentDtos.cs` (request/response records: `CreateAgentRequest`,
+  `PublishVersionRequest`, `AgentSummary`, `AgentDetail`, `AgentVersionSummary/Detail`).
+- Modify: `Tamma.Api/Endpoints/AgentEndpoints.cs` — add `CreateAgent`, `PublishVersion`,
+  `ArchiveAgent`, `ListAgents`, `GetAgent`, `ListVersions`, `GetVersion` handlers. Derive principal
+  from `ITammaModeProvider` + `ITenantContext`/`ClaimsPrincipal`; validate config via Task 2;
+  reject member-role SaaS writes with 403; private `GET {id}` not owned by caller → 404.
+- Modify: `Tamma.Api/Program.cs` — register `IAgentRepository`, `AgentConfigValidator` (if DI'd),
+  `AgentEntitySeeder`; map routes under the existing `/api/v1/agents` group: public writes
+  `.RequireAuthorization("PlatformOwnerAccess")`, private writes owner/admin gate (`SettingsManage`
+  + handler ownership check), reads under `SettingsView`. Leave legacy `config` routes untouched.
+
+**Approach:** Public-vs-private gating: a single create endpoint inspects `visibility` in the body;
+for `public` it requires `PlatformOwnerAccess` (enforced via a handler-level check or a second
+mapped route) — simplest is one route gated at the lower `SettingsManage` bar that then 403s public
+creates from non-platform-admins, OR (preferred) two distinct mapped routes. Pick the simpler that
+passes the RBAC matrix test; document the choice.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/AgentEndpointsTests.cs` — RBAC matrix (platform
+owner / tenant owner / tenant admin / member / cross-tenant); create→publish→get round-trip; list
+returns public ∪ own-private; cross-tenant private `GET {id}` → 404; member write → 403; invalid
+config → 400 + no row/event. **Tenant-isolation** test mirroring
+`Epic28/CrossTenantIsolationPostgresTests.cs`: two tenants each own a private `atlas`; neither sees
+the other's; partial index allows both.
+
+**Done when:** endpoint + isolation tests green; routes mapped; legacy endpoints unaffected.
+
+### Task 6 — Full-suite green + migration verification + docs touch-up (AC 13)
+
+**Files:** none new (verification task). Optionally update `docs/stories/epic-32/story-32-1/` status
+to `ready-for-dev` on hand-off.
+
+**Approach:** `sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/..."` full suite;
+`dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext` → none; confirm no
+regression in existing `AgentEndpoints`/Epic28 tests.
+
+**Done when:** full suite green; migration clean; no pending model changes.
+
+---
+
+## Sequencing & dependencies
+
+```
+Task 1 (entities+migration) ─┬─> Task 3 (repository+events) ─> Task 4 (seeder) ─> Task 5 (endpoints) ─> Task 6 (verify)
+Task 2 (validator) ──────────┘                                          ▲
+                                            Task 2 also feeds Task 5 ────┘
+```
+
+- **Task 1 is the only hard prerequisite for everything else** (no entity → nothing to persist).
+- **Task 2** (validator) is independent of Task 1 and can run in parallel; Task 3 and Task 5 both
+  depend on it.
+- **Task 3** depends on Task 1 (+ Task 2 for validation at write).
+- **Task 4** depends on Task 1 + Task 3 (uses the repository to create public agents).
+- **Task 5** depends on Tasks 1-3 (and 2). **Task 6** is last.
+
+External prerequisites already satisfied on `main`: Epic 27 taxonomy (`Tamma.Core/Agents/`),
+Epic 28 `ControlPlaneDbContext` + CP migration pipeline, `ITammaModeProvider`, `IEventRepository`.
+
+---
+
+## Risks & mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Circular FK between `agents.CurrentVersionId` and `agent_versions.AgentId` blocks first-version create | Medium | `CurrentVersionId` is a bare nullable Guid pointer (no DB FK); integrity enforced in the repo transaction + an integration assertion. |
+| Concurrent `PublishVersionAsync` races produce duplicate/non-monotonic versions | Medium | `(AgentId, Version)` unique index + catch-and-retry on conflict; explicit race test. |
+| CHECK constraint numeric-vs-string mismatch (enum stored as int but CHECK written for text) | Medium | Store `Visibility`/`Status` via `HasConversion<int>()` and write the CHECK against the int discriminator (`= 0` / `= 1`); assert in the Postgres mapping test. |
+| `has-pending-model-changes` non-empty because config was placed outside `TammaModelConfiguration.cs` | Medium | Mirror entity config **only** in `TammaModelConfiguration.cs` (single source); Task 6 gates on the EF check. |
+| Scope creep into legacy `agent_configs` cutover or managed execution | Medium | Explicit non-goal; this story is definition + version + seed + CRUD only. Coexist with `agent_configs`. |
+| Public/private RBAC matrix wrong → tenant pages itself for platform ops, or member edits public agents | High | Mirror Prompt Store RBAC exactly; `PlatformOwnerAccess` for public writes; member 403; encode the full matrix in `AgentEndpointsTests`. |
+| Cross-tenant private-agent leak | High | `ListVisibleAsync` scoping + `GET {id}` 404 (not 403) for un-owned private; isolation test mirroring `CrossTenantIsolationPostgresTests`. |
+| Seeder double-creates on restart | Low | Skip-by-existing-handle idempotency + idempotency test. |
+| Event-store topology shift (Story 28-1 / Epic 30 per-tenant fan-out) | Low | Agent definition events are CP-resident by design; keep emitting via the CP `IEventRepository` so a later tenant-routing migration doesn't touch this code. |
+
+---
+
+## Acceptance criteria (mirrors the story)
+
+- [ ] `Agent` + `AgentVersion` entities exist, CP-resident, registered as `DbSet`s, configured only in
+      `TammaModelConfiguration.cs`, with an additive CP migration; not added to `TenantDbContext`.
+- [ ] `ck_agents_visibility_ownership` CHECK enforces public⇒no-owner / private⇒exactly-one-owner
+      (tenant in SaaS, user in single-user), mirroring `ck_prompt_overrides_principal_xor`.
+- [ ] Partial unique indexes: public `(Name, Role)`; private per-owner `(OwnerTenantId, Name)` /
+      `(OwnerUserId, Name)`; `(AgentId, Version)` unique on versions.
+- [ ] `PublishVersionAsync` writes an immutable new version, increments monotonically, atomically
+      repoints `CurrentVersionId`; prior versions remain queryable; concurrent publishes are safe.
+- [ ] `ConfigJson` validated (reused+extended `ValidateConfigShape`) before any write; invalid ⇒ no
+      row, no event.
+- [ ] DCB events `AGENT.CREATED.SUCCESS` / `AGENT.VERSION_PUBLISHED.SUCCESS` /
+      `AGENT.ARCHIVED.SUCCESS` appended to the CP `DomainEvents` store with the specified tags, only
+      on real state transitions.
+- [ ] Per-mode ownership explicit: single-user ⇒ `OwnerUserId`; SaaS ⇒ `OwnerTenantId`; enforced by
+      both the entity-level guard and the DB CHECK.
+- [ ] `AgentEntitySeeder` idempotently creates one public agent per role preserving `tamma-<role>`
+      handles + `Version=1`.
+- [ ] REST endpoints with per-mode RBAC: public writes `PlatformOwnerAccess`; private writes tenant
+      owner/admin; member 403 on writes; reads = public ∪ own private; cross-tenant private `GET {id}` → 404.
+- [ ] `has-pending-model-changes` reports none; full `Tamma.Api.Tests` suite green.
+- [ ] Unit + integration tests cover version increment, rollback-pointer integrity, ownership CHECK
+      rejection, public/private visibility queries, per-mode derivation, validation rejection, event
+      emission/no-emission, seeder idempotency, and tenant isolation.

--- a/docs/superpowers/plans/2026-06-17-32-10-benchmark-projections-and-leaderboards-plan.md
+++ b/docs/superpowers/plans/2026-06-17-32-10-benchmark-projections-and-leaderboards-plan.md
@@ -1,0 +1,290 @@
+# Story 32-10 — Benchmark Projections & Leaderboards (per agent/provider/prompt, per-tenant) (implementation plan)
+
+> Epic 32 (Agents — First-Class Agent Entities, Managed Execution, Benchmarking & Learning) · P1 ·
+> est. 5-6 days · author Claude · 2026-06-17 ·
+> REQUIRED SUB-SKILL: use `superpowers:subagent-driven-development` (recommended) or
+> `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`)
+> syntax for tracking. Project is test-first (TDD) — every task writes its failing test first.
+> Docker-bound C# suites run via `sg docker -c "dotnet test ..."`; the build itself needs no wrapper.
+
+**Goal:** Turn the per-tenant agent **action trail + outcome + usage** event families into materialized
+**benchmark projections** and **leaderboards**. Build cursor-tracked, idempotent, replayable read-model
+projections — per **agent / provider / prompt / persona** — computing `successRate`,
+`avgIterationsToDone`, `defectRateByCategory` (6 taxonomy buckets + `other`), `latencyP50Ms`/`P95Ms`,
+`avgCostBasisUsd`, `avgBillableUsd`, and `runCount` over a selectable window. Expose tenant-scoped
+leaderboards (ranked, tie-broken, min-sample-guarded). **All projections are PER-TENANT**: a tenant
+sees only its own data; the only cross-tenant view is a **k-anonymized, public-agent-only fleet rollup**
+for the platform admin that never exposes a single tenant's data or a tenant id.
+
+**Story file:** `docs/stories/epic-32/story-32-10/32-10-benchmark-projections-and-leaderboards.md`
+
+**Design source:** `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`
+(§"Ownership, visibility & data scoping" — *leaderboards are computed within a tenant's own data,
+platform admin cannot read tenant performance*; §"Tracking: actions + performance + learning" —
+performance projections).
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane API + Elsa engine).
+Tests in `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/` (xUnit). **`packages/api` is deleted** — all
+work is C#.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO new source event family.** This story is a pure *consumer* of events that 32-6 (action trail),
+  32-8 (outcome/defect), 32-7 (panels), and 32-9 (usage/cost) emit. It emits only `BENCHMARK.PROJECTION.*`
+  lifecycle breadcrumbs. Do **not** invent a parallel usage/outcome event.
+- **NO cross-tenant per-tenant view.** Per-tenant benchmark rows are structurally unreachable across
+  tenants. The single cross-tenant surface is the public-agent, k-anonymized fleet rollup — and even
+  that returns no tenant id and no private-agent data. This is the load-bearing privacy invariant.
+- **NO recompute inside an agent run.** The fold runs on a background projector / on-demand, never in
+  the managed-agent execution path. A projection failure must never fail or delay a run.
+- **NO overloading the mentorship `AnalyticsService`.** Agent benchmarking gets its own
+  `BenchmarkProjectionService`. `AnalyticsService.cs` (mentorship, mostly TODO stubs) is referenced as
+  a sibling in the analytics read-model family, not modified.
+- **NO `DomainEvent`/`ProviderDiagnostic` schema change.** Reuse the DCB row + the diagnostics entity.
+  The projection is a derived cache in the tenant schema; events are the source of truth.
+- **NO dashboard surface.** 32-13 consumes these endpoints; the UI is out of scope here.
+- **NO A/B experiment / statistical-significance machinery.** That is 32-14 (Phase 2).
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### What exists and is the pattern to mirror
+
+| Asset | Location | What it gives us |
+|---|---|---|
+| `DomainEvent` (DCB row) | `apps/tamma-elsa/src/Tamma.Data/Entities/DomainEvent.cs` | `Type`, `TenantId`, JSONB `Tags`/`Metadata`/`Data`, `CreatedAt`, **`SequenceNumber` (`BIGSERIAL`)** — the fold cursor. Reused verbatim, **no change**. |
+| `IEventRepository` / `EventRepository` | `apps/tamma-elsa/src/Tamma.Data/Repositories/{IEventRepository,EventRepository}.cs` | `QueryWithPaginationAsync`/`ListByTenantAsync` are tenant-scoped and **throw `NotSupportedException` on a null tenant** — the isolation backbone. `AppendAsync` routes `evt.TenantId ?? tenantContext.TenantId` to `t_<hex>` via `ITenantDbContextFactory`. We add `QueryAgentEventsForProjectionAsync` (cursor-paged, type-prefix filtered, null-tenant guard). |
+| Per-tenant DbContext | `apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs` | Owns per-tenant business data (agent configs, diagnostics, domain events…). We add `DbSet<BenchmarkProjection>` + `DbSet<BenchmarkProjectionCursor>`. Model config via `TammaModelConfiguration.ConfigureTenantEntities` (strips `TenantId` in the target schema-per-tenant shape; keep a transitional `TenantId` like `agent_configs`). |
+| Tenant migration baseline | `apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260610013731_InitialTenant.cs` (+ snapshot) | The Tenant context has a baseline; our migration is **additive** (`dotnet ef migrations add` against the Tenant context), not a baseline edit. Verify `has-pending-model-changes` reports none after. |
+| Schema-per-tenant routing | `ITenantDbContextFactory` / `ITenantContext` (`Tamma.Data`) | Structural isolation plane for fold-write + admin fan-out-read. No new plumbing. |
+| DCB emission precedent | `apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs` (`UpdateConfig`, ~93-113) | Canonical `DomainEvent { Type, TenantId, Tags=flat strings, Metadata=envelope, Data }`. We **read** this shape; emit only `BENCHMARK.PROJECTION.*`. |
+| Cost/latency source | `apps/tamma-elsa/src/Tamma.Data/Entities/ProviderDiagnostic.cs` | `CorrelationId`, `AgentType`, `InputTokens`/`OutputTokens`, `Cost`, `RequestDurationMs`. 32-9 surfaces these as `AGENT.USAGE.RECORDED` events; we fold the events (replayable), not the diagnostics table directly. |
+| Tenant-scope endpoint + path gate | `apps/tamma-elsa/src/Tamma.Api/Authorization/RequireTenantMembershipFilter.cs`; `/api/v1/orgs/{tenantId}/…` group | Exact member-readable tenant-path pattern the leaderboard rides. |
+| Auth policies | `apps/tamma-elsa/src/Tamma.Api/Program.cs` (~971-991) | `MemberAccess` (tenant leaderboard read), tenant_owner/tenant_admin (rebuild), `PlatformOwnerAccess` (public-agent fleet rollup). |
+| Analytics sibling | `apps/tamma-elsa/src/Tamma.Api/Services/AnalyticsService.cs` + `apps/tamma-elsa/src/Tamma.Core/Interfaces/IAnalyticsService.cs` | Mentorship analytics (mostly stubs). Referenced as family; **not** modified. |
+| Projection-pattern precedent (in-repo) | `docs/superpowers/plans/2026-06-17-36-1-dimensional-analytics-projection-schema-and-store-plan.md` (36-1) + 36-2 | 36-1/36-2 establish the cursor-tracked, idempotent, replayable analytics projection for the **CP fleet** store; we apply the same pattern **per-tenant** for agent benchmarks. Pattern alignment only — no code dependency. |
+
+### Source events the fold consumes (no new family added)
+
+| Event | Producer story | Fold contribution |
+|---|---|---|
+| `AGENT.TASK.SUCCESS`/`.FAILED`/`.PARTIAL` | 32-6 | terminal-run count; `successRate`; run `durationMs` (latency sample); cost fallback |
+| `AGENT.OUTCOME.RECORDED` | 32-8 | authoritative `outcome` + `iterationsToDone` |
+| `AGENT.DEFECT.RECORDED` | 32-8 | per-`category` defect count → `defectRateByCategory` |
+| `AGENT.ITERATION.COMPLETED` | 32-6/32-7 | iteration fallback |
+| `AGENT.PANEL.AGGREGATED` | 32-7 | persona/strategy attribution |
+| `AGENT.USAGE.RECORDED` | **32-9 (NEW — story not yet drafted)** | `costBasisUsd` + `billableUsd` + tokens; provider/model dimension keys |
+
+> **32-9 coupling:** the `AGENT.USAGE.RECORDED` type + `costBasisUsd`/`billableUsd` fields are owned by
+> 32-9, whose story file does not exist yet. Align names before merge. Until usage events exist, cost
+> columns soft-degrade to `null`/`0` and backfill on the next `RebuildAsync`.
+
+---
+
+## Architecture
+
+**Events (tenant `domain_events`, source of truth) → cursor-tracked idempotent fold → materialized
+`BenchmarkProjection` rows (tenant schema) → leaderboard read (tenant) / k-anonymous fleet rollup (admin,
+public agents only).**
+
+```
+tenant t_<hex>.domain_events  (AGENT.TASK.* / AGENT.OUTCOME.* / AGENT.DEFECT.* / AGENT.USAGE.* / …)
+        │  IEventRepository.QueryAgentEventsForProjectionAsync(tenant, typePrefix, SequenceNumber > cursor)
+        ▼
+BenchmarkProjectionService.ProjectAsync(tenant, dimension)      ← background projector / on-demand (OFF the run path)
+   foreach event ordered by SequenceNumber:
+       key = dimensionKeyFor(dimension, Tags)   // agentId | provider | promptRef | personaId
+       bucket[key].apply(event)                 // counts, successRate, iterations, defects, latency sample, cost/billable
+       cursor[key] = SequenceNumber             // idempotency + incremental resume
+   upsert BenchmarkProjection rows  +  persist BenchmarkProjectionCursor   (tenant t_<hex>)
+        │
+        ├── GET /api/v1/orgs/{tenantId}/agents/leaderboard      (MemberAccess)  → ranked + belowThreshold
+        ├── POST /api/v1/orgs/{tenantId}/agents/leaderboard/rebuild (owner/admin) → 202 → RebuildAsync (reset→replay)
+        └── GET /api/v1/admin/agents/{agentId}/benchmark        (PlatformOwnerAccess, PUBLIC agent only)
+                → per-tenant fan-out over warm tenants reading pre-folded rows
+                → k-anonymity (≥ minTenants) aggregate; NEVER a tenant id / per-tenant row / private agent
+```
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns the benchmark data? | The sole user (single tenant). | The tenant that generated it — ALWAYS tenant-scoped; one public agent → many per-tenant datasets. |
+| Who reads the leaderboard? | The user (member-read). | Any tenant member, own tenant only (`MemberAccess`). |
+| Who can rebuild? | The user. | tenant_owner/tenant_admin; `member` → 403. |
+| Can a platform admin read a tenant's benchmark? | N/A. | **No** — only the k-anonymized public-agent fleet rollup; never a single tenant's data or a tenant id. |
+| Where do rows + cursors live? | The single tenant store. | The originating tenant's `t_<hex>` schema (`ITenantDbContextFactory`). |
+| Mode source | `ITammaModeProvider` (process-stable). | same |
+
+---
+
+## Task breakdown (TDD — failing test first per task)
+
+### Task 1 — Projection entities + tenant migration (AC 1, 3, 7)
+
+**Scope:** Two tenant-resident entities (`BenchmarkProjection`, `BenchmarkProjectionCursor`), DbSets,
+model config (unique key, JSON column, transitional `TenantId`), additive Tenant migration.
+
+**Files:**
+- New: `src/Tamma.Data/Entities/BenchmarkProjection.cs`, `BenchmarkProjectionCursor.cs`
+  (shapes per the story Technical Design; `UNIQUE (TenantId, Dimension, DimensionKey, Window)` NULLS NOT
+  DISTINCT on both).
+- Modify: `src/Tamma.Data/TenantDbContext.cs` (DbSets); `src/Tamma.Data/TammaModelConfiguration.cs`
+  (`ConfigureTenantEntities` additions — unique index, `DefectRateByCategory` as JSON/text column).
+- New: `src/Tamma.Data/Migrations/Tenant/<ts>_AddBenchmarkProjections.cs` (`dotnet ef migrations add
+  AddBenchmarkProjections --context TenantDbContext`).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/BenchmarkProjectionEntityTests.cs` (or fold into the
+service tests) — InMemory + Npgsql parity for the two entities; unique-key upsert collapses a duplicate
+(dimension, key, window) to one row; migration applies + rolls back cleanly; `has-pending-model-changes`
+reports none.
+
+**Acceptance:**
+- [ ] Entities map on `TenantDbContext`; unique key enforced; JSON `DefectRateByCategory` round-trips.
+- [ ] Additive Tenant migration applies/rolls back; no pending model changes after.
+
+### Task 2 — Projection engine: idempotent cursor-tracked fold (AC 1, 2, 3, 7, 9)
+
+**Scope:** `IBenchmarkProjectionService` + `BenchmarkProjectionService` (the reducer), the additive
+event-query method, percentiles, `ProjectAsync` (incremental) + `RebuildAsync` (reset→replay), and the
+off-run-path background projector.
+
+**Files:**
+- New: `src/Tamma.Api/Services/Agents/IBenchmarkProjectionService.cs`, `BenchmarkProjectionService.cs`
+  (`dimensionKeyFor`; per-bucket reducer: counts → successRate; `iterationsToDone` mean; per-category
+  defect rate; latency p50/p95 from a sorted-sample/t-digest; cost-basis/billable means; cursor upsert).
+- New: `src/Tamma.Api/Services/Agents/BenchmarkProjectorBackgroundService.cs` (interval + on-demand;
+  iterate warm tenants; non-blocking failure → log + retry, never throw into a run).
+- New: `src/Tamma.Api/Services/Agents/BenchmarkEventTypes.cs` (`BENCHMARK.PROJECTION.UPDATED`/`.REBUILT`
+  + the consumed source-type prefix constants).
+- Modify: `src/Tamma.Data/Repositories/IEventRepository.cs` + `EventRepository.cs` — add
+  `QueryAgentEventsForProjectionAsync(Guid tenantId, string? typePrefix, long afterSequence, int limit)`
+  (tenant-scoped, `SequenceNumber > afterSequence` ordered ascending, `NotSupportedException` on null
+  tenant — same hard guard as `QueryWithPaginationAsync`).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/BenchmarkProjectionServiceTests.cs` —
+1. **Metric correctness** on a hand-built fixture stream (known success/fail/partial, iteration counts,
+   defect categories, latency distribution, costs) → assert exact `successRate`, `avgIterationsToDone`,
+   `defectRateByCategory[*]`, `latencyP50Ms`/`P95Ms` (hand-computed), `avgCostBasisUsd`/`avgBillableUsd`,
+   `runCount`.
+2. **Idempotency** — fold twice → one result, no double-count (cursor skip).
+3. **Incremental-vs-rebuild equivalence** — incremental advance == fresh full rebuild (byte-identical).
+4. **Soft-degrade** — stream with no `AGENT.USAGE.RECORDED` → cost columns null/0; add usage + rebuild →
+   backfilled.
+5. **Non-blocking** — induced write failure logged + retried, never thrown.
+
+**Acceptance:**
+- [ ] Fold is pure + idempotent on `SequenceNumber`; incremental == full rebuild.
+- [ ] All 9 metrics computed correctly (percentiles from distribution, not averaged).
+- [ ] Fold runs off the run path; failure never propagates.
+
+### Task 3 — Tenant leaderboard API (AC 4, 5, 8)
+
+**Scope:** Member-readable leaderboard read (ranked + belowThreshold), owner/admin rebuild trigger.
+
+**Files:**
+- New: `src/Tamma.Api/Endpoints/AgentLeaderboardEndpoints.cs`
+  (`GET /api/v1/orgs/{tenantId}/agents/leaderboard?dimension=&window=&minRuns=` → tie-break chain
+  `successRate desc → avgIterationsToDone asc → avgCostBasisUsd asc → key asc`; `ranked` vs
+  `belowThreshold` split; `POST .../leaderboard/rebuild` → 202 → `RebuildAsync`, owner/admin only).
+- New: `src/Tamma.Api/Dtos/Agents/BenchmarkDtos.cs` (leaderboard / row wire shapes).
+- Modify: `src/Tamma.Api/Program.cs` — map both under `/api/v1/orgs/{tenantId}` with
+  `RequireTenantMembershipFilter`; rebuild gated to tenant_owner/tenant_admin.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/BenchmarkLeaderboardEndpointsTests.cs` —
+1. **Ordering + tie-break** — deliberate `successRate` ties resolve down the documented chain.
+2. **Min-sample guard** — `runCount < minRuns` → `belowThreshold`, not `ranked`.
+3. **RBAC** — member can read; member → 403 on rebuild; owner/admin → 202.
+4. **Dimension validation** — unknown dimension → 400.
+
+**Acceptance:**
+- [ ] Leaderboard ordering + tie-break + min-sample guard deterministic.
+- [ ] Read is member-level; rebuild is owner/admin; member rebuild → 403.
+
+### Task 4 — Platform-admin public-agent fleet rollup, k-anonymous (AC 6)
+
+**Scope:** The only cross-tenant view: `GET /api/v1/admin/agents/{agentId}/benchmark`
+(`PlatformOwnerAccess`), public agents only, k-anonymized.
+
+**Files:**
+- Modify: `src/Tamma.Api/Endpoints/AgentLeaderboardEndpoints.cs` (add the admin rollup handler);
+  `src/Tamma.Api/Program.cs` (map under `/api/v1/admin/agents/{agentId}/benchmark`, `PlatformOwnerAccess`).
+- Service: add `GetPublicAgentFleetRollupAsync(agentId, window, minTenants)` to
+  `BenchmarkProjectionService` — reject non-public/private agent (404); per-tenant fan-out over warm
+  tenants reading their pre-folded rows for `agentId`; aggregate; suppress below `minTenants` (default 5).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/BenchmarkKAnonymityTests.cs` (docker-bound) —
+1. k-1 contributing tenants → suppressed (404/empty).
+2. k tenants → aggregated metrics returned; **no `tenantId` anywhere in the JSON** (assert via inspection).
+3. private agent → 404 regardless of tenant count.
+4. a member / tenant_owner (non-platform) → 403 on the admin route.
+
+**Acceptance:**
+- [ ] Public agent only; below-k suppressed; no tenant id / per-tenant row ever returned.
+- [ ] Private agent → 404; non-platform-owner → 403.
+
+### Task 5 — Tenant isolation suite + DI wiring (AC 5, 10)
+
+**Scope:** The cross-cutting isolation guarantee + Program.cs DI.
+
+**Files:**
+- Modify: `src/Tamma.Api/Program.cs` (DI: `IBenchmarkProjectionService`, `BenchmarkProjectorBackgroundService`
+  hosted service).
+- New: `tests/Tamma.Api.Tests/Agents/BenchmarkIsolationTests.cs` (docker-bound).
+
+**Tests (first):**
+1. Seed benchmark rows for tenant A + B; `GET /orgs/{B}/agents/leaderboard` returns only B's.
+2. Member of A hitting B's path → 403/404 (`RequireTenantMembershipFilter`).
+3. No per-tenant cross-tenant leaderboard route exists; platform owner has no per-tenant read.
+4. Public agent run by A leaves benchmark rows only in A's schema (none on CP, none visible to admin
+   per-tenant).
+
+**Acceptance:**
+- [ ] 0 cross-tenant benchmark reads possible; platform admin denied per-tenant.
+- [ ] Full suite green; build clean; `sg docker -c "dotnet test ..."` green for docker-bound suites.
+
+---
+
+## Task order & dependencies
+
+Task 1 (entities/migration) → Task 2 (fold engine + event query) → Task 3 (tenant leaderboard) →
+Task 4 (admin k-anonymous rollup) → Task 5 (isolation suite + DI). Task 4 depends on Task 2's pre-folded
+rows + the fan-out; Task 5 ties the whole isolation story and wires DI (do it last so all routes exist).
+
+**Cross-story prerequisites:** 32-6 (source trail events + `SequenceNumber` convention) and 32-8
+(outcome/defect events + `BugCategory`) must be merged (hard). 32-9 (usage/cost events) is soft — cost
+columns degrade until it lands; align event/field names before merge. 32-7 (panels) is soft for the
+persona dimension.
+
+## Risks
+
+- **Cross-tenant leakage (Critical):** mitigated structurally — per-tenant schema + `ITenantDbContextFactory`,
+  no per-tenant cross-tenant route, null-tenant scoped reads throw, explicit isolation suite. The admin
+  rollup is the one cross-tenant path and is public-agent-only + k-anonymized; the negative tests
+  (k-1 suppressed, no tenant id, private→404) are gates.
+- **Incremental fold diverges from full rebuild (High):** `SequenceNumber` cursor + a pure reducer; the
+  rebuild-equivalence test is a merge gate. Never key the fold on `CreatedAt` (same-ms collisions).
+- **32-9 usage event undefined (Medium):** soft-degrade to null/0 cost columns + rebuild backfill;
+  align `AGENT.USAGE.RECORDED` type + `costBasisUsd`/`billableUsd` field names with 32-9 before merge —
+  do not invent a parallel event.
+- **Fold on the run path (High):** off-run-path background projector; non-blocking failure (log+retry);
+  test induces a write failure and asserts the run is unaffected.
+- **Percentile accuracy on skewed latency (Medium):** compute p50/p95 from the run-latency distribution
+  (sorted-sample or t-digest), not by averaging; hand-computed fixture assertion.
+- **Tiny-sample rows ranked as meaningful (Medium):** min-sample guard splits `ranked` vs `belowThreshold`.
+- **Migration discipline (Low):** the Tenant context has an `InitialTenant` baseline; this migration is
+  additive — still verify `has-pending-model-changes` reports none, and mirror entity config in
+  `TammaModelConfiguration.cs` (the single source).
+
+## Definition of done
+
+- [ ] All 5 tasks' ACs checked; story ACs 1-10 satisfied.
+- [ ] Metric-correctness, idempotency/rebuild-equivalence, ordering/tie-break/min-sample,
+      tenant-isolation, and k-anonymity test suites green (docker-bound via `sg docker -c "dotnet test ..."`).
+- [ ] `has-pending-model-changes` clean after the Tenant migration; build clean.
+- [ ] Event type + tag/data field names aligned with 32-6/32-8/32-9 (no parallel event invented).
+- [ ] No cross-tenant per-tenant read path; admin rollup public-only + k-anonymized + no tenant id.
+</content>

--- a/docs/superpowers/plans/2026-06-17-32-11-learning-persistence-and-auto-learning-into-rag-plan.md
+++ b/docs/superpowers/plans/2026-06-17-32-11-learning-persistence-and-auto-learning-into-rag-plan.md
@@ -1,0 +1,256 @@
+# Story 32-11 — Learning Persistence & Auto-Learning into RAG (Implementation Plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation.
+
+**Goal:** Close the Epic 32 learning loop. Persist durable, **tenant-scoped** learnings derived
+from agent run outcomes (what worked / what failed / recurring defect categories), route them
+through a `PendingLearning`-style review/approval flow, ingest **approved** learnings into the RAG
+knowledge base tagged by `(agentId, tenantId)`, and wire managed-agent context assembly (32-5) to
+retrieve and inject those learnings so future runs of the same agent improve — with **zero
+cross-tenant leakage**, even for shared public agents.
+
+**Story file:** `docs/stories/epic-32/story-32-11/32-11-learning-persistence-and-auto-learning-into-rag.md`
+**Design spec:** `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md` (Epic 32 §"Tracking: ... learning")
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane API + Elsa engine;
+per-tenant `TenantDbContext`); TypeScript `@tamma/intelligence` RAG/KB pipeline reached through the
+process-shared `@tamma/intelligence-server` sidecar via the existing C# `IIntelligenceHttpClient`.
+C# tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/` (xUnit; docker-bound suites run via
+`sg docker -c "dotnet test ..."`).
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO new TypeScript package.** The `LearningCapture` / `KnowledgeEntry` / `PendingLearning`
+  vocabulary (`packages/shared/src/types/knowledge.ts`) and the `KnowledgeService`
+  capture/approve flow (`packages/intelligence/src/knowledge-base/knowledge-service.ts`) already
+  exist — reuse them via `IIntelligenceHttpClient`, do not fork.
+- **NO `packages/api` anything.** It is deleted. Persistence and the auto-learning hook are
+  C# (`apps/tamma-elsa`).
+- **NO new sanitizer / event store / RAG pipeline.** Reuse `ContentSanitizer` (32-5 path), the
+  tenant `IEventRepository`, and the Epic 6 RAG retriever.
+- **NO change to 32-8 outcome/defect events.** This story *consumes* `AGENT.OUTCOME.RECORDED` /
+  `AGENT.DEFECT.RECORDED`; it adds learnings on top, it does not re-shape the outcome trail.
+- **NO unbounded auto-ingestion.** Auto-approve is opt-in (default off); everything else flows
+  through the review/approval flow. Similarity dedup + per-agent rate-limit cap growth.
+- **NO cross-tenant learning sharing.** A public agent's learnings are ALWAYS tenant-scoped.
+  Platform admins who own a public agent see none of any tenant's learnings.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main)
+
+| Seam | State today |
+|---|---|
+| `packages/shared/src/types/knowledge.ts` | **EXISTS.** Defines `LearningCapture` (`taskId`, `outcome`, `whatWorked`, `whatFailed`, `rootCause`, suggested*), `PendingLearning` (extends + `status: pending\|approved\|rejected`, review fields), `KnowledgeEntry` (`type: 'learning'`, keywords, embedding, stats), `KnowledgeQuery`/`KnowledgeResult`. **No `agentId` / `tenantId` field — tagging is this story's job (carried in tags/metadata).** |
+| `packages/intelligence/src/knowledge-base/knowledge-service.ts` | **EXISTS.** `captureLearning()` → `learningCapture.captureExplicit`; `getPendingLearnings()`; `approveLearning(id, edits?)` builds a `KnowledgeEntry` (`type 'learning'`, generates embedding) + persists. `getRelevantKnowledge()` for retrieval. This is the ingest/approve target reached via the sidecar. |
+| `packages/intelligence/src/rag/` | **EXISTS** — `retriever.ts`, `rag-pipeline.ts`, `ranker.ts`, `query-processor.ts`, `assembler.ts`. The retrieval path managed-agent context assembly queries. |
+| `apps/tamma-elsa/src/Tamma.Api/Services/KnowledgeBase/IIntelligenceHttpClient.cs` | **EXISTS.** Typed `HttpClient` against the sidecar `/kb/*` routes: `QueryRagAsync`, `SearchVectorsAsync`, `UpsertVectorsAsync`, KB index methods. Plain HTTP — **carries no tenant scoping by itself; tenancy must be tagged on payloads (C#-side responsibility).** Degraded fallback on 5xx is built in. |
+| `apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs` | **EXISTS.** Per-tenant `DbContext` (one per request+tenant via `ITenantDbContextFactory`). Target arch: **no `TenantId` column** on tenant tables — isolation is structural (schema-per-tenant). `OnModelCreating` → `TammaModelConfiguration.ConfigureTenantEntities`. Add `DbSet<AgentLearning>` here. |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/DomainEvent.cs` | **EXISTS.** `{ Id, Type, TenantId?, IssueNumber?, Tags(json), Metadata(json), Data(json), CreatedAt, SequenceNumber }`. Appended via `IEventRepository.AppendAsync(DomainEvent)` (`Repositories/IEventRepository.cs`). |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/` | **EXISTS:** `AgentResolverService`, `ResolvedAgentConfig`, `DefaultAgentConfig`. **`AgentLearningService` / `IAgentLearningService` / event-types / options do NOT exist — created here.** `ManagedAgent.cs` lands in **32-5** (prerequisite) and owns the context-assembly/RAG step + `ContentSanitizer` seam this story hooks. |
+| 32-8 events | `AGENT.OUTCOME.RECORDED` (carries `outcome`, `iterationsToDone`; the `LearningCapture` fields ride in `data`) and `AGENT.DEFECT.RECORDED` (carries `category`), tagged `agentId`+`agentVersion`, idempotent per `(runId, gateId)` / `(runId, defectKey)`, fire-and-forget-safe (the precedent this story matches). Emitted by `AgentOutcomeService` (32-8). |
+
+**Key gap closed by this story:** captured learnings have no durable tenant-scoped backend, no
+auto-learning hook, and no scoped RAG ingestion/retrieval. We add all three on the C# stack,
+reusing the existing TS vocabulary + KB/RAG pipeline via `IIntelligenceHttpClient`.
+
+---
+
+## Architecture
+
+**Outcome event → derive → sanitize → dedup → persist → (approve) → ingest → retrieve → inject.**
+
+1. **`AgentLearning` entity** (tenant-scoped, `TenantDbContext`) — the durable registry. No
+   `TenantId` column (structural isolation). Unique index `(AgentId, Role, TaskPattern, Signal)`
+   anchors exact-match dedup; similarity collapse updates the matching open row.
+2. **`AgentLearningService`** (new C#) — the single write-side seam:
+   - `RecordFromOutcomeAsync(outcome/defect)` — the **auto-learning hook**, invoked after the
+     32-8 flush (never on the hot path). Derives candidate(s) by signal, sanitizes via
+     `ContentSanitizer`, rate-limits + similarity-dedups, persists `pending`, emits
+     `AGENT.LEARNING.CAPTURED`. Fire-and-forget-safe (fault → WARN, no throw).
+   - `ApproveAsync` / `RejectAsync` — the review/approval flow. Approve flips status + ingests the
+     learning into the KB via `IIntelligenceHttpClient` (KB upsert / `approveLearning` path),
+     tagged `(agentId, tenantId)`, storing the returned `KnowledgeEntryId` (idempotent).
+   - `RetrieveForRunAsync(agentId, tenantId, query)` — queries RAG filtered by `(agentId,
+     tenantId)` for `ManagedAgent` context assembly; emits `AGENT.LEARNING.APPLIED`.
+3. **DCB events** `AGENT.LEARNING.CAPTURED` / `AGENT.LEARNING.APPLIED` via tenant
+   `IEventRepository`, tagged `{ agentId, signal, lessonId, tenantId }`.
+4. **`ManagedAgent` (32-5) context hook** — during RAG assembly, retrieve agent-scoped learnings
+   and inject them into the rendered prompt; emit `APPLIED`.
+5. **Tenancy = C#-side, fail-closed.** Every ingest + query carries the `(agentId, tenantId)` tag;
+   a query without the tenant filter returns zero tenant-scoped learnings. The cross-tenant
+   isolation test is the regression guard.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns a learning generated by a run? | The sole user (the user is the tenant). | The **tenant** that ran the agent — always, even for a public agent. |
+| Where stored? | The single tenant schema. | The generating tenant's `t_<hex>` schema (structural isolation). |
+| Who approves/rejects? | The user. | `tenant_owner`/`tenant_admin` (members read) — mirrors Prompt Store RBAC. |
+| Who retrieves it at run time? | The user's runs. | Only that tenant's runs (`(agentId, tenantId)` filter); cross-tenant → nothing. |
+| Can the public-agent owner (platform admin) see it? | n/a | **No** — performance/learning data never visible to the definition owner. |
+
+---
+
+## Task breakdown
+
+### T1: `AgentLearning` entity + migration + model config (core persistence)
+
+**Scope:** New tenant-scoped entity, `DbSet`, EF model config with CHECK + unique constraints, and
+an additive migration. No service logic yet.
+
+**Files:**
+- New: `apps/tamma-elsa/src/Tamma.Data/Entities/AgentLearning.cs` (fields per story Technical Design:
+  `Id, AgentId, AgentVersion, Role, TaskPattern, Signal, Lesson, DefectCategory?, SourceRunCorrelationId,
+  Status, KnowledgeEntryId?, HitCount, CreatedAt, LastSeen, ReviewedAt?, RejectionReason?`).
+- Modify: `apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs` — add `DbSet<AgentLearning> AgentLearnings`.
+- Modify: `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` — in `ConfigureTenantEntities`:
+  CHECK on `Signal IN ('success','failure','defect-category')` and `Status IN ('pending','approved','rejected')`;
+  unique index `(AgentId, Role, TaskPattern, Signal)`; no `TenantId` column (structural isolation).
+- New: additive EF migration under `apps/tamma-elsa/src/Tamma.Data/Migrations/` (`dotnet ef migrations add`).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/AgentLearningEntityTests.cs` (or fold into the
+service tests) — entity persists + round-trips through `TenantDbContext`; CHECK rejects an invalid
+`Signal`/`Status`; unique index rejects a second open row for the same `(AgentId, Role, TaskPattern,
+Signal)`; migration applies + rolls back cleanly; `has-pending-model-changes` reports none.
+
+**Acceptance criteria:**
+- [ ] `AgentLearning` persists and round-trips through `TenantDbContext`.
+- [ ] CHECK + unique constraints enforced at the DB level.
+- [ ] Migration is additive, applies + rolls back, no pending model changes.
+
+### T2: `AgentLearningService` core — capture, sanitize, dedup, events (no RAG yet)
+
+**Scope:** The write-side seam: derive candidate(s), sanitize, rate-limit + similarity-dedup,
+persist `pending`, emit `AGENT.LEARNING.CAPTURED`. Fire-and-forget-safe. No ingest/retrieve yet.
+
+**Files:**
+- New: `apps/tamma-elsa/src/Tamma.Api/Services/Agents/IAgentLearningService.cs`,
+  `AgentLearningService.cs`, `AgentLearningEventTypes.cs`
+  (`AGENT.LEARNING.CAPTURED`, `AGENT.LEARNING.APPLIED`),
+  `AgentLearningOptions.cs` (`AutoApprove` default false, `MaxCapturesPerWindow`, `Window`,
+  `DefectRecurrenceThreshold`, `SimilarityThreshold`).
+- Reuse: `ContentSanitizer` (32-5 path), tenant `IEventRepository`, `TenantDbContext`.
+- Modify: `apps/tamma-elsa/src/Tamma.Api/Program.cs` — register `IAgentLearningService` + options.
+
+**Derivation rules (`RecordFromOutcomeAsync`):**
+- success + non-empty `whatWorked` → `signal 'success'`.
+- failure/partial + `whatFailed`/`rootCause` → `signal 'failure'`.
+- defect category crossing `DefectRecurrenceThreshold` for this agent (query tenant event store
+  for prior same-category `AGENT.DEFECT.RECORDED` for the agent) → `signal 'defect-category'`.
+
+**Order (load-bearing):** sanitize → rate-limit → similarity dedup → persist → emit `CAPTURED`.
+A collapsed candidate yields no new row and no event.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/AgentLearningServiceTests.cs` —
+auto-capture from success (one pending row + one `CAPTURED` event tagged
+`{agentId, signal, lessonId, tenantId}`); auto-capture from recurring defect (threshold gates it);
+similarity dedup (M near-identical → 1 row, `HitCount=M`, 1 event); sanitization strips a seeded
+secret from `lesson`; rate-limit caps captures per window; **fire-and-forget-safe** (DB fault →
+WARN, no throw, originating event unaffected).
+
+**Acceptance criteria:**
+- [ ] Each signal type derives correctly; sub-threshold defect → no learning.
+- [ ] Dedup + rate-limit cap growth; collapsed candidate emits no event.
+- [ ] Sanitization applied before persistence/ingestion.
+- [ ] `RecordFromOutcomeAsync` never throws to its caller.
+
+### T3: Approval flow + RAG ingestion via `IIntelligenceHttpClient`
+
+**Scope:** `ApproveAsync` / `RejectAsync`. Approve flips status, builds a `KnowledgeEntry`
+(`type 'learning'`, tags/metadata = `agentId` + `tenantId`, keywords = role/taskPattern), ingests
+via `IIntelligenceHttpClient` (KB upsert / `approveLearning` sidecar path), stores
+`KnowledgeEntryId` (idempotent). Reject sets `rejected` + reason, no ingest; reject-of-approved
+removes/disables the KB entry. `AutoApprove` opt-in auto-promotes high-confidence captures from T2.
+
+**Files:** modify `AgentLearningService.cs`; reuse `IIntelligenceHttpClient` (verified) for ingest.
+
+**Tests (first):** extend `AgentLearningServiceTests.cs` — approve → KB upsert called once with
+`(agentId, tenantId)` tags + `KnowledgeEntryId` stored; re-approve idempotent (no duplicate);
+reject → no ingest; reject-of-approved → KB entry removed/disabled; `AutoApprove=true` →
+high-confidence capture auto-ingests; `AutoApprove=false` (default) → stays `pending`.
+
+**Acceptance criteria:**
+- [ ] Only `approved` learnings ingest; pending/rejected never reach the KB.
+- [ ] Ingest payload carries `agentId` + `tenantId`.
+- [ ] Approve is idempotent; reject-of-approved cleans up the KB entry.
+
+### T4: `ManagedAgent` (32-5) retrieval + injection hook
+
+**Scope:** In `ManagedAgent.RunAsync`'s context-assembly/RAG step, call
+`RetrieveForRunAsync(agentId, tenantId, phaseDescription)` → query RAG filtered by
+`(agentId, tenantId, type 'learning')`, inject retrieved lessons into the rendered prompt, emit
+`AGENT.LEARNING.APPLIED` when any are injected.
+
+**Files:** modify `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ManagedAgent.cs` (32-5);
+add `RetrieveForRunAsync` to `AgentLearningService`.
+
+**Tests (first):** integration `tests/Tamma.Api.Tests/Agents/AgentLearningRagIntegrationTests.cs` —
+**RAG round-trip**: capture → approve → ingest → run context assembly for the same agent → injected
+lesson present AND assembled context **differs** from a pre-ingest run; `AGENT.LEARNING.APPLIED`
+emitted with `{agentId, signal, lessonId, tenantId}`.
+
+**Acceptance criteria:**
+- [ ] A follow-up run's assembled context demonstrably changes after a learning is ingested.
+- [ ] `AGENT.LEARNING.APPLIED` emitted on retrieval+injection.
+- [ ] No learnings ingested → context unchanged, no `APPLIED` event.
+
+### T5: Tenant isolation hardening + lifecycle/idempotency
+
+**Scope:** Make tenancy fail-closed and verified; finish the lifecycle edges.
+
+**Files:** harden `AgentLearningService` query path (tenant filter mandatory; missing filter →
+zero results + ERROR log); ensure reject-of-approved + re-approve idempotency from T3 is covered
+end-to-end.
+
+**Tests (first):** extend `AgentLearningRagIntegrationTests.cs` — **cross-tenant isolation**: same
+public agent under tenant A (ingest lesson) and tenant B → tenant B's context assembly excludes
+A's lesson; a RAG query omitting the tenant filter returns nothing (fail-closed); SaaS RBAC —
+member approve/reject → 403, `tenant_owner`/`tenant_admin` allowed.
+
+**Acceptance criteria:**
+- [ ] Tenant B never retrieves tenant A's lesson for a shared public agent.
+- [ ] Query without tenant filter returns zero tenant-scoped learnings (fail-closed, ERROR-logged).
+- [ ] SaaS RBAC enforced on approve/reject.
+- [ ] Full C# suite green via `sg docker -c "dotnet test ..."`.
+
+---
+
+## Task order & dependencies
+
+T1 → T2 → T3 → T4 → T5. T1 is the only hard prerequisite for the rest; T3 needs T2; T4 needs T3 +
+the 32-5 `ManagedAgent`; T5 needs T3/T4.
+
+**Story prerequisites (must be merged first):** 32-5 (`ManagedAgent` + RAG step + `ContentSanitizer`),
+32-8 (`AGENT.OUTCOME.RECORDED` / `AGENT.DEFECT.RECORDED`), 32-10 (per-tenant outcome dataset +
+recurrence). Epic 6 (RAG/KB pipeline) + Epic 9 (`KnowledgeService` vocabulary) are standing deps.
+
+## Risks
+
+- **Cross-tenant leakage (primary).** The shared intelligence sidecar means a forgotten tenant tag
+  silently mixes learnings across tenants for a shared public agent. Mitigation: tenant tag
+  mandatory on ingest AND query, fail-closed on a missing query filter, cross-tenant isolation
+  test as the regression guard (T5). Do not weaken AC7.
+- **Learning noise / unbounded growth.** Mitigation order: similarity dedup (one durable learning
+  per `(agent, role, taskPattern, signal)`), per-agent rate-limit, approval gate (auto-approve off
+  by default). Watch a flapping signal (approve → reject → re-derive) — if observed, add a
+  per-lesson cooldown (cheap follow-up).
+- **Auto-capture on the wrong path.** It must run only **after** the 32-8 flush, never on the hot
+  resolve/LLM path, and be fire-and-forget-safe. A capture fault must never delay or alter a run's
+  terminal outcome — the never-throw contract in T2 is load-bearing.
+- **Sidecar tenancy mismatch.** `IIntelligenceHttpClient` is a plain shared `HttpClient` with no
+  tenant scoping of its own; ALL scoping rides on payload tags. If the sidecar's KB/RAG schema
+  cannot store/filter arbitrary tags, verify and, if needed, namespace by tenant in the collection
+  key — take the simpler option that keeps isolation structural.
+- **Migration discipline.** `agent_learnings` is additive (normal `migrations add`); still mirror
+  config in `TammaModelConfiguration.ConfigureTenantEntities` only, verify no pending model
+  changes, and confirm apply+rollback in the per-tenant migrator path.
+- **Event-store topology (Story 28-1 / Epic 30).** `AGENT.LEARNING.*` events append to the tenant
+  store via `IEventRepository`, consistent with the 32-8 outcome trail; keep emission going through
+  the tenant repository so any future per-tenant fan-out is transparent.

--- a/docs/superpowers/plans/2026-06-17-32-12-agent-personas-and-persona-aware-benchmarking-plan.md
+++ b/docs/superpowers/plans/2026-06-17-32-12-agent-personas-and-persona-aware-benchmarking-plan.md
@@ -1,0 +1,284 @@
+# Story 32-12 — Agent Personas & Persona-Aware Benchmarking (implementation plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation. C# docker-bound suites run via `sg docker -c "dotnet test ..."`
+> (`reference_dotnet_test_docker`); the build itself needs no wrapper.
+
+**Goal:** Add **personas** — a named, reusable styling/behavior layer (tone, verbosity,
+risk-tolerance, review-strictness) that composes onto an existing agent without forking its provider
+config — and make persona a first-class **benchmarking dimension**. A single agent definition (e.g.
+the public `tamma-reviewer`) can be run under two personas (`atlas`, `nova`) on a tenant's own work,
+and per-tenant leaderboards compare those personas **like-vs-like within a role**. Persona
+definitions are public (platform) or private (tenant); per-persona benchmark data is always
+tenant-scoped.
+
+**Story file:** `docs/stories/epic-32/story-32-12/32-12-agent-personas-and-persona-aware-benchmarking.md`
+**Design of record:** `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`
+("the Agent is the entity; personas are named variants within a role; benchmark like-vs-like").
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane API + Elsa engine).
+Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/` (xUnit). **`packages/api` is deleted — never
+reference it.** The agent stack is C#: `Tamma.Data` entities + `Tamma.Api` `AgentEndpoints` /
+`AgentResolverService` / `PromptStoreService`, DCB `DomainEvent` + `IEventRepository`.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO new provider/model fields on the persona.** A persona is style + an optional prompt fragment
+  ref only. Provider/model/credential/budget belong to the *agent* (32-1). A persona that re-providers
+  is a fork, which is exactly what this story exists to avoid.
+- **NO change to resolution semantics for persona-free runs.** `ResolveForRoleAsync(role)` /
+  `ResolveForPhaseAsync(phase, role)` with no `personaId` stay byte-for-byte. The `personaId` param is
+  additive and optional; `personaId == null` is the legitimate persona-free path.
+- **NO empty/plain fallback.** A requested-but-unresolvable persona or fragment is a hard
+  `TammaError`/4xx (`feedback_resolution_no_empty_fallback`). Never return the bare agent config "as
+  if no persona were asked for"; never return a blank fragment.
+- **NO per-user persona layer in SaaS.** Mirrors the Prompt Store: SaaS persona ownership is tenant
+  (owner/admin edit, member read); single-user ownership is the sole user. No per-member persona
+  personalization.
+- **NO building the 32-10 leaderboard API itself.** This story owns the persona *dimension* (trail
+  tags + a group-by-persona projection) and the query-facet contract; 32-10 surfaces it. 32-10's
+  story file does not yet exist — coordinate the facet at integration.
+- **NO new dashboard UI.** Surfacing personas in the admin/tenant benchmark dashboards is 32-13.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main)
+
+| Seam | State |
+|---|---|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/` | Has `AgentConfig`, `DomainEvent`, `PromptOverride`. **`Agent`/`AgentVersion`/`AgentVisibility`/`AgentStatus` are 32-1 in-flight** (story drafted; entity files not yet on main) — reference by interface; reuse the enums + the `ck_agents_visibility_ownership` CHECK + per-owner partial-index pattern. |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/IAgentResolverService.cs` | Real. Has `ResolveAsync(tenantId, role)`, `ResolveForPhaseAsync(...)`, and the task-overrides variant. 32-2 adds `ResolveForRoleAsync(role)` returning the enriched config. |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ResolvedAgentConfig.cs` | Real. Has `Role`, `Handle`, `Provider`, `Model`, `Temperature`, `MaxTokens`, `TokenBudget`, `Tools`, `SystemPrompt`, `Source`, `Phase`, `MaxBudgetUsd`, `PermissionMode`, `AllowedTools`. 32-2 adds `AgentId`/`AgentVersion`. This story adds `PersonaId`/`PersonaName`. |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs` | Real — the place persona CRUD handlers + `&personaId=` on resolve land. |
+| `apps/tamma-elsa/src/Tamma.Api/Services/PromptStore/PromptStoreService.cs` | Real. `ResolveRoleActionAsync(userId, role, action)` (single-user) + `ResolveRoleActionForTenantAsync(tenantId, role, action)` (SaaS); layering `system role → role+action template`; `ResolvedPrompt` record; fail-loud `NoPromptError`. Persona fragment resolves through this — no Prompt-Store API change. |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/DomainEvent.cs` | Real. `{ Id, Type, TenantId, IssueNumber, Tags, Metadata, Data, CreatedAt, SequenceNumber }`. DCB tag/`AGGREGATE.ACTION.STATUS` convention. Appended via `IEventRepository.AppendAsync`. |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Single source of EF model config — CHECK + partial indexes live here only (PromptOverride XOR precedent). |
+| Action trail (32-6) | Story drafted (`docs/stories/epic-32/story-32-6/`). Tags already: `agentId, agentVersion, role, provider, model, promptRef, issueId, iteration, correlationId, credentialSource`, via a shared tag builder. This story adds `personaId`/`personaName` to that builder. |
+| RBAC | `PlatformOwnerAccess` (platform owner) + `AgentManage` (`agents:manage` = admin+owner, 32-2) + member-read; 403-on-write / 404-cross-tenant pattern from 32-1/32-2 + Prompt Store. |
+| `ITammaModeProvider` | `Tamma.Api/Services/PromptStore/TammaMode.cs` — process-stable `SingleUser`/`SaaS`. |
+
+**Key dependency posture:** 32-1 (entities/enums) and 32-2 (resolve + enriched config + policy)
+are hard prerequisites and in-flight; every reference is by interface and marked
+**(coordinate with 32-1/32-2)** in the story. 32-6 (trail) is reused; 32-10 (leaderboards) consumes
+the dimension this story defines.
+
+---
+
+## Architecture
+
+**Persona = role-scoped style overlay that composes at resolution time into a new
+`ResolvedAgentConfig`, recorded on the trail, sliced by the leaderboard.**
+
+1. **`Persona` entity** (CP-resident; public ∪ tenant-private) — `Name` (stable handle), `Role`,
+   `Visibility`/owner columns (reuse 32-1 enums + ownership CHECK + per-owner partial indexes),
+   `StyleJson` (jsonb traits), `SystemPromptFragmentRef` (Prompt-Store key). No provider/model.
+2. **`PersonaComposer`** (pure) — merges persona `StyleJson` onto an already-resolved agent config
+   (style-adjacent fields only; provider/model/budget/tools untouched) and **appends** the resolved
+   prompt fragment in fixed order `role identity → role+action → persona fragment`. Returns a new
+   object; never mutates input (state-immutability rule). Stamps `PersonaId`/`PersonaName`.
+3. **Resolver extension** — `IAgentResolverService.ResolveForRoleAsync(role, personaId?, ct)` (+ phase
+   variant): resolve agent (32-2 chain) → if `personaId` set, load+validate persona (visible AND role
+   matches) → resolve fragment via Epic 27 (fail-loud if non-null & unresolvable) →
+   `PersonaComposer.Compose` → emit `AGENT.PERSONA_APPLIED.SUCCESS`. `personaId == null` ⇒ unchanged.
+4. **Trail tag** — extend the 32-6 shared tag builder so every `AGENT.TASK.*` /
+   `AGENT.ITERATION.COMPLETED` / `AGENT.PANEL.AGGREGATED` / `REVIEW.BUG.RECORDED` event +
+   `AgentRunResult` carries `personaId`/`personaName` (flat strings; empty when persona-free).
+5. **Benchmark slice** — a per-persona projection over the 32-6 trail grouping by `(role, personaId)`
+   for the calling tenant only (success rate, avg iterations-to-done, bug-by-type, cost, latency).
+   Defines the `?groupBy=persona` / `?personaId=` facet contract 32-10 surfaces.
+6. **CRUD + resolve endpoints** — `/api/personas` (list/create/get/put/archive) + `&personaId=` on
+   `/api/agents/resolve`, per-mode RBAC (private ⇒ `AgentManage`/owner; public ⇒ `PlatformOwnerAccess`;
+   member ⇒ 403; cross-tenant private ⇒ 404).
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Who owns a **public** persona? | Shipped system personas (read-only to the user). | Platform owner (`PlatformOwnerAccess`); CP-resident; every tenant may *use*, not edit. |
+| Who owns a **private** persona? | The sole user (`OwnerUserId`; `OwnerTenantId` NULL). | The tenant (`OwnerTenantId`); `tenant_owner`/`tenant_admin` edit, `member` read-only. |
+| Who can apply a persona to a run? | The user. | Any member (apply ≈ read + resolve); editing needs owner/admin. |
+| Where do per-persona benchmarks live? | The user's data (`user_id`). | The tenant's `t_<hex>` data plane; never cross-tenant; platform admin sees none. |
+| Resolution / benchmark principal | `user_id` | `tenant_id` |
+| Mode source | `ITammaModeProvider` (process-stable) | same |
+
+---
+
+## Task breakdown
+
+### T1 — `Persona` entity + EF config + migration (core)
+
+**Scope:** New CP entity, model config (CHECK + partial indexes), additive migration. No resolver
+wiring yet.
+
+**Files:**
+- New: `src/Tamma.Data/Entities/Persona.cs` (reuses `AgentVisibility`/`AgentStatus` from 32-1).
+- Modify: `src/Tamma.Data/ControlPlaneDbContext.cs` (add `DbSet<Persona>`),
+  `src/Tamma.Data/TammaModelConfiguration.cs` (`ck_personas_visibility_ownership`,
+  `IX_personas_public_name_role`, per-owner private partial indexes; `StyleJson` jsonb default).
+- New: additive migration under `src/Tamma.Data/Migrations/ControlPlane/` (`AddPersonaEntity`).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Personas/PersonaEntityTests.cs` (or extend
+`Epic28/ControlPlaneDbContextModelTests`) — table/indexes/CHECK exist; ownership CHECK rejects
+public-with-owner / private-with-no-owner / private-with-both; two tenants each own private
+`atlas`/`reviewer` (per-owner partial index allows it); public `(Name, Role)` uniqueness enforced.
+
+**Acceptance:**
+- [ ] Migration applies; `dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext` → none.
+- [ ] CHECK + partial-index behaviour proven against a real Postgres fixture.
+- [ ] Entity config lives **only** in `TammaModelConfiguration.cs`.
+
+### T2 — `IPersonaRepository` + lifecycle DCB events
+
+**Scope:** Repository (`CreateAsync`, `UpdateAsync`, `ArchiveAsync`, `GetByIdAsync`,
+`GetVisibleAsync(id, principal)`, `ListVisibleAsync(principal, filter)`) with per-mode principal
+derivation and `PERSONA.CREATED/UPDATED/ARCHIVED.SUCCESS` emission. `GetVisibleAsync` returns public
+∪ own-private only; cross-tenant private ⇒ null (→ 404 at the endpoint).
+
+**Files:**
+- New: `src/Tamma.Data/Repositories/IPersonaRepository.cs`, `PersonaRepository.cs`.
+- New: `src/Tamma.Api/Services/Agents/PersonaEventTypes.cs`
+  (`PERSONA.CREATED.SUCCESS`, `PERSONA.UPDATED.SUCCESS`, `PERSONA.ARCHIVED.SUCCESS`,
+  `AGENT.PERSONA_APPLIED.SUCCESS`).
+- DI: register `IPersonaRepository` (Scoped) in `Program.cs`.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Personas/PersonaRepositoryTests.cs` +
+`PersonaEventsTests.cs` — create/update/archive each emit exactly one event with correct tags
+(`personaId, personaName, role, visibility, mode`); `GetVisibleAsync` returns public ∪ own-private,
+null for other-tenant private; per-mode principal derivation (single-user `OwnerUserId` / SaaS
+`OwnerTenantId`); no event on a rejected write (CHECK violation / mode contradiction).
+
+**Acceptance:**
+- [ ] Lifecycle events emit only after a real state transition (no "lie" events).
+- [ ] Per-mode ownership derived from `ITammaModeProvider`; contradictory input rejected pre-DB.
+- [ ] Cross-tenant private read returns null (→ 404), never another tenant's row.
+
+### T3 — `PersonaComposer` + resolver extension + `ResolvedAgentConfig` fields
+
+**Scope:** The load-bearing composition. Pure composer + the `personaId` resolve path + the
+`AGENT.PERSONA_APPLIED.SUCCESS` event + fail-loud fragment resolution.
+
+**Files:**
+- Modify: `src/Tamma.Api/Services/Agents/ResolvedAgentConfig.cs` (add `Guid? PersonaId`,
+  `string? PersonaName` — additive).
+- New: `src/Tamma.Api/Services/Agents/PersonaComposer.cs` (pure: style merge + fragment append in
+  fixed order; returns new config; never mutates input).
+- Modify: `src/Tamma.Api/Services/Agents/IAgentResolverService.cs` +
+  `AgentResolverService.cs` (add optional `personaId` to `ResolveForRoleAsync` / phase variant;
+  load+validate persona via `IPersonaRepository.GetVisibleAsync`; role-match check; resolve fragment
+  via `PromptStoreService.ResolveRoleActionAsync`/`ResolveRoleActionForTenantAsync`, fail-loud if
+  non-null & unresolvable; compose; emit applied event).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Personas/PersonaComposerTests.cs` +
+extend `Agents/AgentResolverServiceTests.cs`:
+- style merge overrides only style-adjacent fields, provider/model/budget/tools untouched;
+- fragment appended in fixed order `role identity → role+action → persona fragment`;
+- input config + agent pinned version unmodified (immutability);
+- two personas / one agent / same role → same `AgentId`/`AgentVersion`, distinct `SystemPrompt`;
+- `personaId == null` → plain config unchanged (no regression);
+- unknown persona → `PERSONA.RESOLVE.NOT_FOUND` (404); role-mismatch → `PERSONA.ROLE_MISMATCH` (400);
+  non-null `SystemPromptFragmentRef` unresolvable → `TammaError`, no blank fallback;
+- composed resolution emits exactly one `AGENT.PERSONA_APPLIED.SUCCESS` `{personaId, agentId, role}`;
+  failure path emits nothing.
+
+**Acceptance:**
+- [ ] Persona-free resolution byte-for-byte unchanged.
+- [ ] No empty/plain fallback on any unresolvable-persona path.
+- [ ] Composition is pure + immutable; agent version never mutated.
+
+### T4 — Persona CRUD + resolve endpoints + RBAC
+
+**Scope:** `/api/personas` handlers + `&personaId=` on `/api/agents/resolve`, per-mode RBAC,
+404-cross-tenant.
+
+**Files:**
+- Modify: `src/Tamma.Api/Endpoints/AgentEndpoints.cs` (or new `PersonaEndpoints.cs`) —
+  `List`, `Create`, `GetOne`, `Update`, `Archive`; in-handler public-write gate
+  (`persona_public_write_forbidden` 403 for `visibility:public` from non-platform-owner).
+- New: `src/Tamma.Api/Dtos/Agents/PersonaDtos.cs` (request/response records).
+- Modify: `src/Tamma.Api/Program.cs` — map `/api/personas` group (`MemberAccess` reads;
+  `AgentManage` writes; rate-limiting mirroring 32-2), add `&personaId=` to the resolve handler.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Personas/PersonaEndpointsTests.cs`
+(in-process `WebApplicationFactory`) — RBAC matrix: member create/update/archive → 403; tenant
+`POST {visibility:public}` → 403 `persona_public_write_forbidden`; platform owner public create →
+201; cross-tenant `GET /{B-private-id}` → 404; `GET /api/personas` from A never returns B's private;
+`GET /api/agents/resolve?role=reviewer&personaId=...` returns a persona-composed config; role
+mismatch via that route → 400.
+
+**Acceptance:**
+- [ ] Endpoint shape identical between modes; auth middleware picks the owner column by mode + identity.
+- [ ] Cross-tenant private read → 404 (existence not leaked).
+- [ ] Member → 403 on all writes; reads allowed.
+
+### T5 — Persona trail tags + per-persona benchmark slice (the dimension)
+
+**Scope:** Extend the 32-6 shared trail-tag builder with `personaId`/`personaName`; deliver the
+per-persona projection grouping by `(role, personaId)` for the calling tenant; define the
+`?groupBy=persona` / `?personaId=` facet contract for 32-10.
+
+**Files:**
+- Modify: the 32-6 shared trail-tag builder (file lands with 32-6 — add `personaId`/`personaName` to
+  the single builder, not per emission site; coordinate ordering with 32-6).
+- New: the per-persona projection helper + its `(role, personaId)` group-by (over the 32-6 trail;
+  exact home coordinates with the 32-10 projection layer).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Personas/PersonaTrailTaggingTests.cs` +
+`PersonaLeaderboardProjectionTests.cs` — persona-composed run's trail events carry
+`personaId`/`personaName`; persona-free run carries empty/absent; no raw `StyleJson`/fragment in
+tags (redaction); group-by-`(role, personaId)` ranks `atlas` vs `nova` within reviewer; an
+architect-role persona never appears in the reviewer leaderboard (like-vs-like); tenant B rows never
+appear in tenant A's projection (isolation).
+
+**Acceptance:**
+- [ ] Every trail event + `AgentRunResult` from a persona run carries the persona tags via the shared builder.
+- [ ] Per-persona leaderboard compares within a role only, on the tenant's own data only.
+- [ ] Facet contract (`?groupBy=persona` / `?personaId=`) documented for 32-10 to surface.
+
+### T6 — Regression + migration verification + suite green
+
+**Scope:** Prove no regression and clean migration.
+
+**Files:** Modify `tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs` (assert
+`personas` table/indexes/CHECK); run the full `Tamma.Api.Tests` suite.
+
+**Acceptance:**
+- [ ] Persona-free resolution + legacy `/api/v1/agents/*` routes byte-for-byte green.
+- [ ] `dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext` → none.
+- [ ] Full `sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests"` green.
+
+---
+
+## Task order & dependencies
+
+T1 → T2 → T3 → T4 → T5 → T6.
+T1 is the only hard prerequisite for everything else. T4 needs T2+T3; T5 needs T3 (composition stamps
+the persona) + the 32-6 trail builder. T5 has a soft seam on 32-6/32-10 — implement the tags + the
+projection here; the leaderboard *surface* is 32-10.
+
+## Risks
+
+- **32-1/32-2 in-flight:** the `Agent`/`AgentVersion` entities, `AgentVisibility`/`AgentStatus`
+  enums, `ResolveForRoleAsync`, and the enriched `ResolvedAgentConfig`/`AgentManage` policy must land
+  first. Every reference is by interface and marked **(coordinate with 32-1/32-2)** — reconcile each
+  before coding. If 32-1 names the enums or ownership CHECK differently, follow 32-1, do not fork.
+- **Composition altitude:** the composer must touch *only* style-adjacent fields. Letting persona
+  `StyleJson` override provider/model/budget/tools turns a persona into a fork and breaks like-vs-like
+  benchmarking. Pin the allowed-override field set in `PersonaComposerTests`.
+- **Fail-loud fragment:** a non-null `SystemPromptFragmentRef` that the Prompt Store can't resolve
+  MUST throw — the most likely accidental regression is "fall back to no fragment." The no-empty
+  test (T3) is load-bearing (`feedback_resolution_no_empty_fallback`).
+- **Trail-tag builder coupling (T5):** the persona tags must go in the *single* 32-6 shared builder,
+  or emission sites will drift. Coordinate file ordering with 32-6 so this story extends the builder
+  rather than re-implementing tags per site.
+- **Leaderboard ownership (T5/32-10):** 32-10's story file does not exist yet. This story owns the
+  persona tags + the projection slice + the facet contract; do not build the full leaderboard API
+  here — keep the blast radius to the dimension.
+- **Migration discipline (Epic 28):** `personas` is additive — normal `migrations add`, not a
+  baseline CHECK edit; verify `has-pending-model-changes` reports none; mirror config only in
+  `TammaModelConfiguration.cs`.
+- **Cross-tenant leakage:** per-persona benchmark data must never escape the tenant — enforce via the
+  per-tenant connection + 404-not-403 cross-tenant reads; covered by isolation tests in T2/T4/T5.

--- a/docs/superpowers/plans/2026-06-17-32-13-agent-management-and-benchmark-dashboards-plan.md
+++ b/docs/superpowers/plans/2026-06-17-32-13-agent-management-and-benchmark-dashboards-plan.md
@@ -1,0 +1,357 @@
+# Story 32-13 — Agent Management & Benchmark Dashboards (admin public + tenant private)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan wave-by-wave. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every wave writes tests
+> before implementation.
+
+**Goal:** Surface the Epic 32 agent domain in the two React dashboards. A **platform-admin** view
+(`packages/dashboard`) to manage **public/system** agents, personas, and margin config and to view
+an **anonymized** cross-tenant public-agent leaderboard; and a **tenant** view
+(`packages/dashboard-user`) to manage **private** agents/personas, select which agent serves each
+role, register **BYOK** provider keys (reveal-once), and view its **own** action trail, run history,
+benchmarks, leaderboards, outcomes, and usage. Strictly: a tenant sees only its own performance
+data; a platform admin never sees a single tenant's data. `settings/AgentsPage` is **extended**, not
+replaced.
+
+**Story file:** `docs/stories/epic-32/story-32-13/32-13-agent-management-and-benchmark-dashboards.md`
+**Design spec:** `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`
+(§"Ownership, visibility & data scoping" is the load-bearing tenancy rule).
+
+**Tech stack:** TypeScript + React + Vite, Vitest 3.x + Testing Library, colocated `__tests__/`.
+Two dashboards with two HTTP conventions:
+- `packages/dashboard` (admin) — bare-`fetch` `fetchJSON`, `VITE_API_BASE_URL ?? '/api'`
+  (see `services/settings/settings-api-client.ts`, `services/secrets/secrets-api-client.ts`).
+- `packages/dashboard-user` (tenant) — `ApiClient` class with `credentials: 'include'` +
+  refresh-on-401 (`api/client.ts`), per-domain `api/*.ts` modules (see `api/dashboard.ts`).
+
+**Backend:** already built in `apps/tamma-elsa` (`Tamma.Api`) by 32-2 (agent CRUD/RBAC + provenance),
+32-3 (BYOK reveal-once), 32-6 (trail/runs + isolation), 32-9 (usage/cost + margin), 32-10
+(leaderboards), 32-12 (personas). **`packages/api` is deleted and must never be referenced.**
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO backend code.** Every endpoint exists per the dependency stories; this plan is dashboards only.
+  If a needed read endpoint (e.g. 32-10 admin anonymized aggregate, 32-9 usage) is genuinely absent,
+  render an explicit empty state — do **not** synthesize it client-side from a tenant-scoped call.
+- **NO new HTTP wrapper, state library, or data layer.** Reuse each package's existing client +
+  hook/store conventions (story AC 12). Admin reuses `useAgentsConfig`/settings store + `fetchJSON`;
+  tenant reuses `apiClient` + `api/*.ts` modules.
+- **NO tenant-switcher / impersonation UI.** The tenant id is `useAuth().tenantId`, full stop.
+- **NO per-user (member) personalization layer.** Members are read-only (mirrors Prompt Store).
+- **NO replacing `AgentsOverview`.** `AgentsPage` gains a tab shell; the role-config card stays.
+- **NO new charting dependency** unless the repo already has one — otherwise render simple
+  CSS/SVG bars (leaderboards are tables-with-bars, not a BI tool).
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### Admin dashboard (`packages/dashboard`)
+- `pages/settings/AgentsPage.tsx` — thin wrapper rendering `<AgentsOverview/>`; route
+  `/settings/agents` is behind `AdminGuard` in `router.tsx`. **Extend this page in place.**
+- `components/settings/agents/` already holds `AgentsOverview`, `AgentRoleCard`,
+  `ProviderChainEditor`, `ProviderEntryForm` — the new public-agent UI lives alongside them.
+- `hooks/settings/useAgentsConfig.ts` + `stores/settings/store.ts` — the load/save pattern to mirror
+  for `usePublicAgents`/`useMarginConfig`.
+- `services/settings/settings-api-client.ts` — `fetchJSON<T>` against `VITE_API_BASE_URL ?? '/api'`;
+  `services/secrets/secrets-api-client.ts` — richer example incl. `credentials: 'include'`,
+  typed error class, reveal envelope types. Model `agents-admin-client.ts` on these.
+- `components/secrets/SecretRevealModal.tsx` — the reveal-once contract (acknowledge-before-close,
+  parent burns the one-shot GET, local-state zeroing). The BYOK modal mirrors this.
+- `components/common/` — `Card`, `Badge`, `ConfirmDialog`, `LoadingSpinner`, `Toggle`, `Slider`,
+  `FormField`. Reuse, don't rebuild.
+- `guards/AdminGuard.tsx` — role check via `useCurrentUser`; already wraps the agents route.
+- Tabbed-shell precedent: `pages/admin/AdminLayout.tsx` (`AdminTab` union + `TABS` + button nav).
+  Copy this pattern into `AgentsPage`.
+
+### Tenant dashboard (`packages/dashboard-user`)
+- `api/client.ts` — `ApiClient` (`get/post/put/delete`, `credentials: 'include'`, refresh-on-401,
+  `ApiError`/`UnauthorizedError`); singleton `apiClient`. **All tenant calls go through this.**
+- `api/dashboard.ts` — the per-domain typed-module pattern (`/api/v1/orgs/${tenantId}/...`). Model
+  `agents.ts`/`agent-trail.ts`/`provider-keys.ts` on it.
+- `hooks/useAuth.tsx` — `AuthUser { id, ..., tenantId?, role? }`; `useAuth()` gives the **only**
+  source of the active tenant id. (AC 8 hinges on this.)
+- `guards/AuthGuard.tsx` (any authenticated) + `guards/TenantAdminGuard.tsx` (admin/owner; renders
+  an "Admin-only" panel for members) — the read-vs-write gate.
+- `App.tsx` — `BrowserRouter`/`Routes`; nested routes under `AuthGuard → AppLayout`, with
+  `TenantAdminGuard` wrapping admin-only routes (see `/settings/alerts`). Add agent routes here.
+- `layouts/AppLayout.tsx` — minimal sidebar `<Link>` nav; add Agents links.
+- **No agent UI exists yet** in this package — green field for the tenant surface.
+
+### Endpoint shapes (from dependency stories)
+- **32-2:** `GET /api/agents?role=&visibility=&status=`, `POST /api/agents` (body `visibility`
+  `public|private`; server 403 `agent_public_write_forbidden` for tenant→public),
+  `GET /api/agents/{id}`, `POST /api/agents/{id}/versions`, `POST /api/agents/{id}/archive`,
+  `PUT /api/agents/role-selections/{role}`, `GET /api/agents/resolve?role=&phase=` →
+  `ResolvedAgentConfig { AgentId, AgentVersion, Source: system-public|tenant-public|tenant-private }`.
+  Member → 403 on writes; cross-tenant private read → 404.
+- **32-3:** `POST/DELETE /api/v1/agents/providers/{provider}/credential`, `POST …/rotate`;
+  create/rotate → reveal envelope (token/url, **no plaintext in body**); list shows
+  source `byok|platform` + storage-key ref, never the secret. RBAC: tenant_owner/admin; member → 403.
+- **32-6:** `GET /api/v1/orgs/{tenantId}/agents/{agentId}/runs` (filters `from/to/role/provider/
+  outcome`) and `…/trail` (+ `type` prefix), cursor/`SequenceNumber` paging,
+  `RequireTenantMembershipFilter` (MemberAccess). **No cross-tenant / platform-admin read path.**
+- **32-10:** per-tenant leaderboards sliceable by agent/provider/prompt; admin anonymized
+  cross-tenant public-agent aggregate (separate projection — no `tenantId`).
+- **32-12:** persona CRUD per agent + the **persona** leaderboard dimension.
+- **32-9:** usage/cost reads (own tenant); margin/markup config (admin; Epic-34 owns the engine).
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who manages **public/system** agents + personas + margin? | The sole user edits their instance's shipped+own catalog; "public" = shipped system agents. | Platform owner only (`PlatformOwnerAccess`); admin dashboard, `AdminGuard`. |
+| Who manages **private** agents + personas + role selection + BYOK? | The sole user. | `tenant_owner`/`tenant_admin`; `member` → read-only + 403. Tenant dashboard, `TenantAdminGuard`. |
+| Whose performance/trail/benchmarks does the tenant view show? | The user's own. | The caller's own tenant only (`useAuth().tenantId`); never another tenant's. |
+| What does the admin leaderboard show? | The user's instance public-agent aggregate. | **Anonymized cross-tenant** aggregate; admin never sees a single tenant. |
+| Tenant id source | session (`useAuth`) | session (`useAuth`) — never user input |
+
+---
+
+## Architecture
+
+**Admin (`packages/dashboard`):** extend `AgentsPage` into a tabbed shell — keep `AgentsOverview`;
+add **Public Agents** (CRUD/version/archive + personas), **Margin** (markup config), **Leaderboard**
+(anonymized aggregate). One typed client `agents-admin-client.ts` with **zero** tenant-scoped methods
+(isolation asserted by a test). Hooks mirror `useAgentsConfig`.
+
+**Tenant (`packages/dashboard-user`):** new `api/agents.ts` / `agent-trail.ts` / `provider-keys.ts`
+over `apiClient`; pages for list/detail/role-selection/provider-keys; the detail page tabs
+Overview · Runs · Trail · Benchmarks · Outcomes · Usage. A single `getActiveTenantId()` helper reads
+`useAuth().tenantId` — the only tenant-id source (AC 8). Management routes behind `TenantAdminGuard`;
+read routes behind `AuthGuard`; in-page write affordances hidden for members.
+
+**Reveal-once BYOK:** parent posts create/rotate → reveal envelope → GET reveal once → mount reveal
+modal (mirrors `SecretRevealModal`) → acknowledge/copy/close → drop plaintext. List never re-shows it.
+
+---
+
+## Wave order & dependencies
+
+W1 (admin client + isolation test) and W4 (tenant client + helper) are independent and parallel-safe.
+W2/W3 depend on W1; W5/W6/W7 depend on W4. W8 is the cross-cutting e2e + regression gate.
+
+```
+W1 ─┬─ W2 ─ W3
+    │
+W4 ─┴─ W5 ─ W6 ─ W7 ──┐
+                      └─ W8
+```
+
+---
+
+## Wave 1 — Admin agent client + isolation guarantee (foundation)
+
+**Scope:** Typed admin client for public-agent CRUD/version/archive, persona CRUD, margin config,
+and the anonymized leaderboard — with a structural guarantee it can never read a single tenant's
+data.
+
+**Files:**
+- New: `packages/dashboard/src/services/settings/agents-admin-client.ts` — `fetchJSON` against
+  `/api/agents` (public reads/writes), persona endpoints, `/api/admin/agents/leaderboard`
+  (anonymized), and margin GET/PUT. **No method takes a `tenantId`; no `/orgs/{tenantId}/...` path.**
+- New: `packages/dashboard/src/services/settings/__tests__/agents-admin-client.test.ts`.
+
+**Tests (first):**
+- [ ] Each method calls the expected path/verb with the right body (mock `fetch`).
+- [ ] **Isolation:** no exported method accepts a `tenantId` arg and no path string contains
+      `/orgs/` — assert by reflecting the client surface + scanning the source/paths.
+- [ ] `create` with `visibility: "public"` is the only create path; error class surfaces 403 message.
+
+**Acceptance criteria:**
+- [ ] Client compiles strict; covers list/create/version/archive/persona/margin/leaderboard.
+- [ ] Isolation test proves no tenant-scoped capability exists.
+
+---
+
+## Wave 2 — Admin public-agent + persona + margin UI
+
+**Scope:** The management surface inside `AgentsPage`'s new tab shell.
+
+**Files:**
+- Modify: `packages/dashboard/src/pages/settings/AgentsPage.tsx` — add `AdminLayout`-style tab shell
+  (`Roles` = existing `AgentsOverview`, `Public Agents`, `Margin`, `Leaderboard`); keep
+  `AgentsOverview` untouched.
+- New: `components/settings/agents/PublicAgentsPanel.tsx`, `PublicAgentForm.tsx`,
+  `PersonaManager.tsx`, `MarginConfigPanel.tsx`.
+- New: `hooks/settings/usePublicAgents.ts`, `useMarginConfig.ts` (mirror `useAgentsConfig`).
+- New: `components/settings/agents/__tests__/PublicAgentsPanel.test.tsx`.
+
+**Tests (first):**
+- [ ] List renders public agents; system-default rows are read-only with a "system default" badge.
+- [ ] Create/version/archive call the client; `ConfirmDialog` gates archive.
+- [ ] Persona CRUD round-trips; margin panel GET/PUT round-trips.
+- [ ] A 403 (defense-in-depth) renders an inline message, no crash.
+
+**Acceptance criteria:**
+- [ ] `AgentsOverview` still works (no-regression); story AC 1, AC 2 (margin), AC 15 met.
+- [ ] All writes use `visibility: "public"` and the admin client only.
+
+---
+
+## Wave 3 — Admin anonymized leaderboard
+
+**Scope:** Cross-tenant, anonymized public-agent leaderboard — provably not a tenant view.
+
+**Files:**
+- New: `components/settings/agents/PublicLeaderboardPanel.tsx`, `LeaderboardChart.tsx` (shared
+  window selector + min-sample note; CSS/SVG bars).
+- New: `hooks/settings/usePublicLeaderboard.ts` (no `tenantId`).
+- New: `components/settings/agents/__tests__/PublicLeaderboardPanel.test.tsx`.
+
+**Tests (first):**
+- [ ] Renders aggregate rows (success rate / avg iterations / cost / latency) per public agent.
+- [ ] Window selector (7d/30d/90d/all) re-queries; min-sample rows show "not enough samples (n=…)".
+- [ ] **Isolation (AC 9):** the panel never issues a `/orgs/{tenantId}/...` request and the bundle
+      imports no tenant-trail client; if the aggregate endpoint 404s, an explicit empty state shows
+      (no tenant-scoped fallback).
+
+**Acceptance criteria:**
+- [ ] Story AC 2, AC 9 met; admin never reads a single tenant's data.
+
+---
+
+## Wave 4 — Tenant agent clients + active-tenant helper (foundation)
+
+**Scope:** Typed tenant clients over `apiClient`, all bound to the session tenant id via one helper.
+
+**Files:**
+- New: `packages/dashboard-user/src/api/agents.ts` — list (public ∪ own-private), create/version/
+  archive (private), `role-selections/{role}` PUT + `resolve` GET (provenance).
+- New: `packages/dashboard-user/src/api/agent-trail.ts` — runs + trail (32-6), benchmarks/
+  leaderboards (32-10), outcomes, usage (32-9); **every method takes the tenant id from a single
+  `getActiveTenantId()` that reads `useAuth().tenantId`** (no other source).
+- New: `packages/dashboard-user/src/api/provider-keys.ts` — BYOK register/rotate/remove + reveal
+  envelope handling (32-3).
+- New: colocated `*.test.ts` for each.
+
+**Tests (first):**
+- [ ] Each method hits the expected `/api/v1/orgs/{tenantId}/...` or `/api/agents/...` path/verb.
+- [ ] **Isolation (AC 8):** `agent-trail.ts` exposes no parameter/route/input for a foreign tenant
+      id; every path uses the session tenant id; a duplicated/foreign id is unreachable from the API.
+- [ ] Reveal-envelope parsing: create/rotate return token/url and **no plaintext** in the body.
+
+**Acceptance criteria:**
+- [ ] Clients compile strict; reuse `apiClient` (no new wrapper); story AC 8, AC 12 foundations met.
+
+---
+
+## Wave 5 — Tenant agent list, form, role selection (management)
+
+**Scope:** Private agent CRUD + per-role selection, gated for members.
+
+**Files:**
+- New: `pages/agents/AgentsListPage.tsx`, `pages/agents/RoleSelectionsPage.tsx`.
+- New: `components/agents/AgentCard.tsx`, `AgentForm.tsx` (create/version + persona section).
+- Modify: `App.tsx` (routes: `/agents` + `/agents/roles` under `AuthGuard`, management actions/
+  routes under `TenantAdminGuard`), `layouts/AppLayout.tsx` (nav links).
+- New: colocated tests.
+
+**Tests (first):**
+- [ ] List shows public ∪ own-private; edit/version/archive offered only on private rows; public rows
+      are browse + "Select for role" only (no edit) — 403 on a forced public write.
+- [ ] Role selection PUT works; current selection + provenance (`system-public`/`tenant-public`/
+      `tenant-private`) is shown per role; absent selection shows the system-default agent (never blank).
+- [ ] **Member gating (AC 10):** `role === 'member'` hides write controls; management route renders
+      the `TenantAdminGuard` "Admin-only" panel; a simulated 403 renders a role message, no crash.
+
+**Acceptance criteria:**
+- [ ] Story AC 3, AC 4, AC 10, AC 13 met.
+
+---
+
+## Wave 6 — Tenant agent detail: runs + trail (own data)
+
+**Scope:** Per-agent observability over the tenant's own trail.
+
+**Files:**
+- New: `pages/agents/AgentDetailPage.tsx` (tabs: Overview · Runs · Trail · Benchmarks · Outcomes ·
+  Usage — Benchmarks/Outcomes/Usage filled in W7).
+- New: `components/agents/RunsTable.tsx`, `ActionTrailTable.tsx` (paginated; filters
+  `from/to/role/provider/outcome/type`).
+- New: colocated tests incl. the tenant-isolation assertion.
+
+**Tests (first):**
+- [ ] Runs + trail tables render mocked 32-6 responses; filters re-query; cursor paging has no
+      dupes/skips at boundaries.
+- [ ] **Isolation (AC 8):** every captured request path contains the session `tenantId`; no UI
+      control accepts/switches a foreign tenant id; opening a foreign agent id 404s gracefully.
+
+**Acceptance criteria:**
+- [ ] Story AC 6, AC 8 met; detail view shows only the caller's own data.
+
+---
+
+## Wave 7 — Tenant benchmarks, outcomes, usage + BYOK provider keys
+
+**Scope:** The remaining detail tabs + the BYOK reveal-once page.
+
+**Files:**
+- New: `components/agents/LeaderboardView.tsx` (agent/provider/prompt/persona dimension control +
+  window selector + min-sample note), `OutcomeBreakdown.tsx` (bug counts by `bugType`),
+  `UsagePanel.tsx` (tokens/cost).
+- New: `pages/settings/ProviderKeysPage.tsx`, `components/agents/ProviderKeyRow.tsx`,
+  `ProviderKeyRevealModal.tsx` (mirror `SecretRevealModal`).
+- Modify: `App.tsx` (route `/settings/provider-keys` under `TenantAdminGuard`),
+  `layouts/AppLayout.tsx` (link).
+- New: colocated tests (`LeaderboardView.test.tsx`, `ProviderKeysPage.test.tsx`).
+
+**Tests (first):**
+- [ ] Leaderboard renders all four dimensions; window selector re-queries; `n < minSamples` shows
+      the muted "not enough samples (n=…)" note instead of a bar (AC 7 correctness path).
+- [ ] Outcome breakdown + usage render from mocked 32-9/32-10 responses.
+- [ ] **BYOK reveal-once (AC 11):** create/rotate → reveal envelope → reveal GET (invoked **exactly
+      once**) → plaintext shown once → "Close" disabled until acknowledged → copy works → on close
+      plaintext is gone from state; the list never re-displays the secret (shows provider/source/
+      storage-key/last-rotated only); remove works; member → controls hidden + 403 message.
+
+**Acceptance criteria:**
+- [ ] Story AC 5, AC 7, AC 11 met; no secret ever rendered after the one-shot reveal.
+
+---
+
+## Wave 8 — Cross-cutting e2e flow + regression gate
+
+**Scope:** Tie the surfaces together and prove the boundaries hold; lock no-regression.
+
+**Steps:**
+- [ ] e2e-style test (mocked endpoints, both packages where feasible): admin creates a public agent →
+      tenant lists it (browse-only) → tenant selects it for a role (provenance `tenant-public`) →
+      tenant registers a BYOK key (reveal-once) → tenant opens the agent detail and sees its own
+      trail (empty → populated). Assert admin path issues no tenant-scoped request and tenant path
+      issues no aggregate/admin request.
+- [ ] Run `pnpm test --filter @tamma/dashboard` and `pnpm test --filter @tamma/dashboard-user` —
+      both green; existing `AgentsOverview` + secrets + auth suites unaffected.
+- [ ] `pnpm lint` clean for both packages; strict TS compile (no `any`, honor
+      `exactOptionalPropertyTypes` / `noUncheckedIndexedAccess` per project memory).
+
+**Acceptance criteria:**
+- [ ] Story AC 14, AC 15 met; the admin/tenant and tenant/tenant boundaries are asserted, not assumed.
+
+---
+
+## Risks
+
+- **Boundary leakage is the headline risk.** The whole story is "two principals, never each other's
+  data." Mitigations are structural, not policy: the admin client has **no** tenant-scoped method
+  (W1 test); the tenant trail client takes its tenant id only from `useAuth` (W4 helper + W6 test);
+  the admin leaderboard hits a server-side anonymized aggregate, never a stripped tenant call (W3).
+  Get any of these wrong and a single bug exposes cross-tenant performance data.
+- **Missing upstream endpoints.** 32-10's admin anonymized aggregate and 32-9 usage reads may lag.
+  Contract: render an explicit empty state, **never** fabricate the aggregate from tenant data.
+  Confirm the exact endpoint paths against the 32-9/32-10 story files before W3/W7 (those dirs were
+  empty at draft time — coordinate or stub the client behind a typed interface).
+- **Reveal-once correctness.** A loosely-built reveal modal that re-fetches or re-renders the
+  plaintext is a security defect. Reuse the `SecretRevealModal` contract verbatim; the parent owns
+  the one-shot GET and burns it exactly once (W7 test asserts the single invocation).
+- **Two HTTP conventions.** Admin uses `fetchJSON`; tenant uses `apiClient`. Don't port one into the
+  other — match each package's existing files (`settings-api-client.ts` vs `api/dashboard.ts`).
+- **Min-sample is correctness, not polish.** A #1 ranking on n=1 is misleading; the muted-note path
+  is required and unit-tested (W3/W7).
+- **`AgentsPage` regression.** It's extended, not replaced — the tab shell must leave `AgentsOverview`
+  byte-for-byte behaviourally intact; W2/W8 guard this.
+- **Charting dependency.** Prefer CSS/SVG bars over adding a charting lib unless one already exists
+  in the package — check `package.json` before W3.

--- a/docs/superpowers/plans/2026-06-17-32-14-a-b-experiment-framework-for-agents-plan.md
+++ b/docs/superpowers/plans/2026-06-17-32-14-a-b-experiment-framework-for-agents-plan.md
@@ -1,0 +1,312 @@
+# Story 32-14 — A/B Experiment Framework for Agents (Phase 2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan step-by-step. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every step writes tests
+> before implementation. Read [BEFORE_YOU_CODE.md](../../guides/BEFORE_YOU_CODE.md) first.
+
+**Goal:** Let a tenant (SaaS) or sole user (single-user) run a controlled A/B experiment for one
+role — variants differing by agent / config version / provider / prompt / persona — split workflow
+runs into deterministic cohorts, measure each arm against the **existing** per-tenant benchmark
+read models (32-10), compute statistical significance, and **auto-promote the winner** (atomic
+update of the per-role selection from 32-2) or **roll back** on a guarded regression, with
+guardrails (min sample, max spend, provider gating) and tenant-scoped lifecycle events. This is the
+production realization of the A/B-testing AC that Story 1-13 specified but never built.
+
+**Story file:** `docs/stories/epic-32/story-32-14/32-14-a-b-experiment-framework-for-agents.md`
+**Design of record:** `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md` (§"Phase 2").
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane API + Elsa engine),
+React/Vite dashboard in `packages/dashboard-user` (Vitest). C# tests live in
+`apps/tamma-elsa/tests/Tamma.Api.Tests/` (xUnit; docker-bound suites run via
+`sg docker -c "dotnet test ..."`). Experiments + variants + assignments + results are **tenant-schema-resident**
+(`TenantDbContext`, `t_<hex>`) — never the control plane, never cross-tenant.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO new measurement plumbing.** Significance is computed by *slicing* the 32-10 benchmark
+  projections / 32-6 action-trail / 32-9 cost events by `experimentId` + `variantId`. The only
+  measurement change is adding two tags to the existing trail builder. If 32-10's projections can
+  measure it, this story reads them; it never recomputes a metric from raw events except where it
+  already aggregates per-variant `VariantStats`.
+- **NO change to resolution semantics off the experiment path.** A role with no running experiment
+  resolves byte-for-byte as today (32-2 precedence). Assignment returns null and nothing changes.
+  The seam is purely additive — `feedback_resolution_no_empty_fallback` stays intact.
+- **NO control-plane experiment storage and NO platform-admin read path.** Performance data is
+  always tenant-owned (Epic 32 design rule); a platform owner cannot read a tenant's experiment
+  results, mirroring the 32-6 action-trail isolation.
+- **NO per-user override layer in SaaS.** SaaS principal = tenant (`AgentManage` = owner/admin;
+  member read-only). Single-user principal = the sole user. Mode via `ITammaModeProvider`, exactly
+  as 32-1/32-2.
+- **NO multi-experiment-per-role concurrency.** At most one `running` experiment per `(principal, role)`
+  — a partial unique index + a 409 at start. Keeps cohort assignment unambiguous.
+- **NO external heavyweight stats dependency on the core path.** The two-proportion z-test and
+  Welch's t-test are implemented directly (standard-normal/t CDFs). A vetted package may back them
+  only if pinned and behind the `ISignificanceCalculator` contract.
+- **NO Bayesian / sequential-testing / multi-armed-bandit sophistication.** Fixed-horizon
+  frequentist A/B with a min-sample floor is the v1; bandits are a later story if wanted.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main)
+
+### What exists today (consumed, not built here)
+
+| Seam | Where | Used for |
+|---|---|---|
+| `TenantDbContext` (per-tenant `t_<hex>`; tenant entities config'd via `TammaModelConfiguration.ConfigureTenantEntities`) | `apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs` | Where the new experiment tables live (additive tenant migration). |
+| `DomainEvent` row + `IEventRepository.AppendAsync` (tenant-scoped writes route to `t_<hex>.domain_events`) | `apps/tamma-elsa/src/Tamma.Data/Entities/DomainEvent.cs`, `Repositories/IEventRepository.cs`, `EventRepository.cs` | Lifecycle DCB events (`AGENT.EXPERIMENT.*`). |
+| `TaskQueueProcessor` (`ProcessOnceAsync`, `RunOnStartup`, poll loop) + `QueuedTask` (`Type`, `TenantId`, `Payload`, `Status`, retry) | `apps/tamma-elsa/src/Tamma.Api/Services/TaskQueue/TaskQueueProcessor.cs`, `Tamma.Data/Entities/QueuedTask.cs` | Async significance re-eval + `MaxSpendUsd` budget watch (`agent.experiment.evaluate` task). |
+| Agent config endpoint discipline (validate-before-write, audit event only after a real write) | `apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs` (`UpdateConfig`) | The "never a lie event" pattern the lifecycle events follow. |
+| Auth policies `AgentManage` (`agents:manage`, owner/admin — from 32-2), `PlatformOwnerAccess`, `SettingsManage` | `apps/tamma-elsa/src/Tamma.Api/Program.cs` (~986–1115), `Auth/Permissions.cs` | Write RBAC on experiment endpoints. |
+| `ITammaModeProvider` (process-stable SingleUser/SaaS) | `apps/tamma-elsa/src/Tamma.Api/Services/PromptStore/TammaMode.cs` | Per-mode principal derivation. |
+| Tenant-isolation test precedent | `apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/CrossTenantIsolationPostgresTests.cs` | Template for the isolation integration test. |
+
+### Sibling-story seams (drafted; coordinate, do not re-implement)
+
+| From | Artifact | This story's use |
+|---|---|---|
+| **32-1** | `Agent` / `AgentVersion` CP entities + `IAgentRepository`; immutable versions | Variants reference `(agentId, agentVersion)`; pinned versions survive archive. |
+| **32-2** | `IAgentRegistryService` (`SelectForRoleAsync`, visibility-scoped `ListAsync`); `agent_role_selections` (tenant); `ResolvedAgentConfig` `+ AgentId/AgentVersion`; `AgentManage` policy | Variant validation (resolvable agent), the selection table rollout mutates, the config assignment pins onto, the write RBAC. |
+| **32-4** | SaaS provider auth gating (API-key only; CLI/token single-user only) | Variant create rejects gated providers (400). |
+| **32-6** | `AgentTrailTags.Build` + tenant action-trail event families | Add `experimentId`/`variantId` tags so trail + cost events are arm-attributable. |
+| **32-9** | Usage & cost emission (per-run `costUsd`, tagged) | The `cost` metric and the `MaxSpendUsd` guardrail tally. |
+| **32-10** | Per-tenant benchmark projections / leaderboards (success rate, iterations-to-done, defect rate, cost — sliceable) | The read substrate `ExperimentResultsService` slices by `experimentId`/`variantId`. **Hard dependency.** |
+| **32-12** | Personas + persona-aware benchmarking | The `personaId` variant axis. |
+| **32-13** | Tenant private benchmark dashboard | Where the experiment UI surface lives alongside. |
+
+> If a 32-N artifact is not yet in `main` when this story starts, build against its named seam
+> (interface/method) and add a thin local shim only where unavoidable; never fork its data model.
+
+---
+
+## Architecture
+
+**Define → assign → measure → test → conclude (rollout/rollback)**, all tenant-scoped, reusing the
+benchmark substrate end-to-end:
+
+1. **`AgentExperiment` + `AgentExperimentVariant`** (new tenant-schema entities) — the experiment
+   header (role, metric, min-sample, threshold, max-spend, status, baseline/winner, prior-selection
+   snapshot) and its arms (agent/version/provider/prompt/persona + traffic weight). Additive
+   `TenantDbContext` migration; config in `ConfigureTenantEntities` only.
+2. **`ExperimentAssignmentService`** — on resolve of the role-under-test for an eligible run,
+   deterministically map `StableHash(experimentId + correlationId)` onto the weighted split, pin
+   `experimentId`/`variantId` + the variant's `(agentId, version, provider, promptRef, personaId)`
+   onto `ResolvedAgentConfig` (32-2), and add the two tags to the action-trail builder (32-6).
+   No running experiment → null → today's behaviour.
+3. **`SignificanceCalculator`** (pure) — two-proportion z-test for rate metrics, Welch's t-test for
+   continuous metrics; returns `{ pValue, effectSize, baselineN, challengerN, values, significant }`.
+4. **`ExperimentResultsService`** — slices the 32-10 projections by `experimentId`/`variantId` into
+   per-variant `VariantStats`; feeds the calculator; also computes the spend tally (32-9) for the
+   guardrail.
+5. **`ExperimentRolloutController`** — atomic winner-promote (snapshot prior selection → upsert
+   `agent_role_selections` via 32-2) / rollback (restore snapshot), one tenant transaction.
+6. **`AgentExperimentService`** — lifecycle orchestration (create/start/conclude/rollback) +
+   guardrails (min-sample floor, max-spend, provider gating, single-running-per-role) + DCB events.
+7. **TaskQueue handler** (`agent.experiment.evaluate`) — async re-eval + budget watch off the
+   existing poll loop; auto-conclude/promote when `AutoRollout` + floors met + significant, or on
+   `MaxSpendUsd`.
+8. **Endpoints + dashboard** — `/api/v1/agents/experiments/*` (writes `AgentManage`, reads member);
+   tenant-facing experiment UI in `packages/dashboard-user`.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns an experiment? | The sole user — it's their instance/schema. | The tenant — lives in `t_<hex>`. |
+| Who can create/start/conclude/rollback? | The user (no gate). | `tenant_owner`/`tenant_admin` (`AgentManage`); `member` → 403. |
+| Who can read results? | The user. | Any tenant member (read-only). Platform owner: **no read path** (isolation). |
+| Where do events land? | Tenant feed (= the user's). | Tenant `domain_events` (`TenantId` = tenant). |
+| Principal source | `ITammaModeProvider` (process-stable). | same. |
+
+---
+
+## Story breakdown
+
+### S1 — Experiment entities + tenant migration + repository (core)
+
+**Scope:** New tenant-schema entities + DbSets + model config + additive migration + repository
+CRUD. No assignment/significance/rollout yet.
+
+**Files:**
+- New: `Tamma.Data/Entities/AgentExperiment.cs`, `AgentExperimentVariant.cs`,
+  `AgentExperimentMetric.cs` (enum), `AgentExperimentStatus.cs` (enum).
+- Modify: `Tamma.Data/TenantDbContext.cs` (DbSets), `TammaModelConfiguration.cs`
+  (`ConfigureTenantEntities`: tables, `ck_agent_experiments_min_sample`,
+  `ck_agent_experiments_threshold`, `ck_agent_experiment_variants_weight`, cascade FK,
+  `IX_agent_experiments_one_running_per_role` partial unique on `Status=Running`,
+  `IX_agent_experiment_variants_label`). Additive migration under `Migrations/Tenant/`.
+- New: `Tamma.Data/Repositories/IAgentExperimentRepository.cs` + `AgentExperimentRepository.cs`
+  (`CreateAsync`, `GetByIdAsync`, `ListAsync`, `UpdateStatusAsync`, `SetWinnerAndSnapshotAsync`).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/AgentExperimentRepositoryTests.cs` — create writes
+header + variants (cascade); CHECK rejections (min-sample 0, threshold ≤0/≥1, weight 0); one-running-
+per-role partial index rejects a second running row for the same role (Postgres fixture); list scoped
+to the schema.
+
+**Acceptance criteria:**
+- [ ] Tenant migration applies; `dotnet ef migrations has-pending-model-changes --context TenantDbContext` → none.
+- [ ] CHECK + partial-unique constraints enforced (verified against a real Postgres fixture).
+- [ ] Variants cascade-delete with their experiment; full suite stays green.
+
+### S2 — `SignificanceCalculator` (pure, fixture-driven — zero DB)
+
+**Scope:** Two-proportion z-test + Welch's t-test + standard-normal & t CDFs. No I/O.
+
+**Files:** New `Tamma.Api/Services/Agents/ISignificanceCalculator.cs` + `SignificanceCalculator.cs`
+(`VariantStats`, `SignificanceResult` records).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/SignificanceCalculatorTests.cs` — z-test against
+precomputed `pValue`/`z`/effect for clearly-different / marginal / equal rates; degenerate `SE=0` →
+`pValue=1` not significant. Welch's t against precomputed mean-diff / `df` / p for different / equal
+means / zero-variance; Cohen's d; `N<2` guarded. Determinism (same input → same output).
+
+**Acceptance criteria:**
+- [ ] Computed p-values within tight tolerance of fixture expectations (cross-checked against a known stats reference offline).
+- [ ] Degenerate cases (SE=0, zero variance, N<2) never throw and never declare significance.
+
+### S3 — `ExperimentAssignmentService` (deterministic cohorts)
+
+**Scope:** Resolve the running experiment for `(role)` in the tenant, deterministically assign a run
+to a variant by weighted split keyed on the run correlation id, pin onto `ResolvedAgentConfig`, add
+trail tags.
+
+**Files:**
+- New: `Tamma.Api/Services/Agents/IExperimentAssignmentService.cs` + `ExperimentAssignmentService.cs`
+  (`StableHash` via SHA-256 → uint64; weighted-bucket select; `ExperimentAssignment` record).
+- Modify: `Tamma.Api/Services/Agents/AgentTrailTags.cs` (add `experimentId`/`variantId` — coordinate
+  with 32-6); wire assignment into the 32-2 resolve path so the variant's pinned `(agentId, version,
+  provider, promptRef, personaId)` materializes into `ResolvedAgentConfig`.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/ExperimentAssignmentServiceTests.cs` — 100k keys
+across weights `{50,30,20}` → empirical split within tolerance; same key → same variant
+(determinism) across two process runs; different `experimentId` reshuffles; no running experiment →
+null (no behaviour change); `StableHash` is NOT `string.GetHashCode()` (assert stability).
+
+**Acceptance criteria:**
+- [ ] Distribution converges to configured weights; assignment is stable per key and process-independent.
+- [ ] A role with no running experiment resolves exactly as today (assignment returns null).
+- [ ] `VARIANT_ASSIGNED` emitted once per run (not per resolution call).
+
+### S4 — `ExperimentResultsService` (slice 32-10) + spend tally
+
+**Scope:** Build per-variant `VariantStats` for the experiment's metric by reading the tenant's
+32-10 projections / 32-6 trail / 32-9 cost events filtered by `experimentId`/`variantId`; compute
+cumulative experiment spend for the guardrail.
+
+**Files:** New `Tamma.Api/Services/Agents/ExperimentResultsService.cs` (`GetResultsAsync` →
+`{ per-variant VariantStats, metric, status }`; `GetSpendUsdAsync`).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/ExperimentResultsServiceTests.cs` — seed synthetic
+trail/cost events tagged per arm; success-rate / defect-rate / iterations / cost each aggregate to
+the right `VariantStats`; spend tally sums tagged cost; an arm with zero events → `N=0`.
+
+**Acceptance criteria:**
+- [ ] Results derive entirely from the existing substrate (no new measurement events introduced).
+- [ ] Each metric maps to the correct `VariantStats` shape (successes for rates; Sum/SumSq for continuous).
+
+### S5 — `ExperimentRolloutController` (atomic promote / rollback)
+
+**Scope:** Atomic winner promotion (snapshot prior selection → upsert `agent_role_selections` via
+32-2 `SelectForRoleAsync`) and rollback (restore snapshot), one tenant transaction each.
+
+**Files:** New `Tamma.Api/Services/Agents/ExperimentRolloutController.cs` +
+`IExperimentRolloutController`.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/ExperimentRolloutControllerTests.cs` — promote
+upserts the selection to the winner + snapshots prior in one tx; rollback restores it; forced
+mid-tx failure leaves the selection unchanged; rollback with no prior selection deletes the
+experiment-set selection (falls back to system default per 32-2), not a dangling row.
+
+**Acceptance criteria:**
+- [ ] Promote + snapshot are atomic; a partial promote never leaves a dangling/half-applied selection.
+- [ ] Rollback restores exactly the snapshotted prior state (or clean fallback when none).
+
+### S6 — `AgentExperimentService` lifecycle + guardrails + DCB events
+
+**Scope:** Orchestrate create/start/conclude/rollback; enforce guardrails (min-sample floor before
+any conclusion, max-spend auto-conclude, provider gating at create, single-running-per-role,
+weights-sum); emit `AGENT.EXPERIMENT.*` events only after real transitions.
+
+**Files:** New `Tamma.Api/Services/Agents/AgentExperimentService.cs`, `AgentExperimentEventTypes.cs`.
+Validates variants via `IAgentRegistryService` (resolvable) + 32-4 provider gating.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/AgentExperimentServiceTests.cs` — min-sample guard
+(no winner below floor even if "significant"); max-spend auto-concludes + `BUDGET_REACHED`;
+provider-gating reject at create (SaaS CLI provider → 400, single-user allows); single-running-per-
+role 409; weights-sum mismatch 400; each transition emits exactly one event; no event on a no-op
+(re-conclude). Mode-parameterized (SingleUser vs SaaS principal).
+
+**Acceptance criteria:**
+- [ ] Significance is never evaluated until every variant clears `MinSampleSize`.
+- [ ] Max-spend / provider-gating / single-running-per-role / weights-sum guardrails all enforced.
+- [ ] Lifecycle events emitted only after a real state transition.
+
+### S7 — Endpoints + RBAC + TaskQueue handler
+
+**Scope:** REST surface + per-mode RBAC + async re-eval/budget-watch off `TaskQueueProcessor`.
+
+**Files:**
+- New: `Tamma.Api/Endpoints/AgentExperimentEndpoints.cs`, `Dtos/Agents/AgentExperimentDtos.cs`.
+- Modify: `Program.cs` (map routes under `/api/v1/agents/experiments`; writes `AgentManage`, reads
+  member; register services; register the `agent.experiment.evaluate` queued-task handler).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/AgentExperimentEndpointsTests.cs` — RBAC matrix
+(owner/admin write 200, member write 403, member read 200, single-user all 200); cross-tenant
+GET → 404; create→start→(synthetic results)→conclude(promote)→rollback end-to-end within one tenant;
+202/async re-eval auto-concludes when wired.
+
+**Acceptance criteria:**
+- [ ] Endpoint shape identical between modes; auth middleware decides scope (Prompt Store precedent).
+- [ ] Cross-tenant access returns 404 (existence not leaked); platform owner has no results path.
+
+### S8 — Dashboard surface (tenant-facing)
+
+**Scope:** Experiment list + detail (cohort config, live per-variant results + significance,
+conclude/rollback actions) in the user dashboard. No platform-admin experiment UI.
+
+**Files:** New `packages/dashboard-user/src/services/experiments-client.ts`,
+`pages/experiments/ExperimentsPage.tsx`, `pages/experiments/ExperimentDetailPage.tsx`; register
+routes alongside the 32-13 benchmark dashboard.
+
+**Tests (first):** colocated Vitest + Testing Library — list renders rows/status; detail renders
+per-variant `n` + significance; conclude/rollback call the client; member sees results without
+write actions; zero-experiment empty state.
+
+**Acceptance criteria:**
+- [ ] Tenant owner/admin sees conclude/rollback; member sees read-only results.
+- [ ] `pnpm test --filter @tamma/dashboard-user` green; no new lint errors.
+
+---
+
+## Story order & dependencies
+
+S1 → S2 (parallel-safe, pure) → S3 → S4 → S5 → S6 (needs S2/S4/S5) → S7 → S8.
+S2 and S3 have zero DB dependency and can start immediately (TDD-friendly first targets).
+S1 is the only hard prerequisite for S4–S7. S8 needs S7's API.
+
+## Risks
+
+- **Determinism / split correctness:** using `string.GetHashCode()` (process-randomized) instead of
+  a content-addressed hash silently breaks reproducibility and the distribution. S3's tests must
+  assert process-stable hashing and run the distribution check.
+- **Statistics correctness:** a wrong CDF approximation produces plausible-but-wrong p-values →
+  bad rollouts. S2 cross-checks every fixture against a known stats reference offline; the
+  min-sample floor + significance gate together are the safety net against thin-evidence wins.
+- **Cross-tenant leakage:** experiment results read benchmark data — the read path must scope to the
+  tenant schema via `ITenantDbContextFactory`; a platform owner must have no path. Covered by the
+  isolation integration test (mirror `CrossTenantIsolationPostgresTests.cs`).
+- **Rollout atomicity:** a half-applied promote (selection moved but snapshot not stored, or vice
+  versa) corrupts rollback. S5 wraps both in one tenant transaction and tests the forced-failure
+  path.
+- **Dependency on unbuilt siblings (32-9/32-10/32-12/32-13 story files not yet written):** build
+  against their named seams from the design spec; if a seam is absent at start, add a thin shim
+  behind the interface and flag it for reconciliation — never fork the data model. The Epic 32
+  design spec is the contract.
+- **Migration discipline:** `agent_experiments` / `agent_experiment_variants` are additive
+  tenant-schema tables — normal `dotnet ef migrations add ... --context TenantDbContext`; verify
+  `has-pending-model-changes` reports none; mirror config only in `TammaModelConfiguration`.
+- **Alert/event volume:** `VARIANT_ASSIGNED` must emit once per run, not per resolution call, or a
+  hot loop floods the tenant stream. S3 pins this.

--- a/docs/superpowers/plans/2026-06-17-32-2-agent-registry-resolution-and-rbac-api-plan.md
+++ b/docs/superpowers/plans/2026-06-17-32-2-agent-registry-resolution-and-rbac-api-plan.md
@@ -1,0 +1,260 @@
+# Story 32-2 — Agent Registry, Resolution & RBAC API — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan phase-by-phase. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every phase writes tests
+> before implementation.
+
+**Story:** `docs/stories/epic-32/story-32-2/32-2-agent-registry-resolution-and-rbac-api.md`
+**Epic 32 design of record:** `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`
+
+---
+
+## Goal
+
+Promote the first-class agent entities introduced in Story 32-1 into the live workflow by adding:
+(1) an `AgentRegistryService` that lists/creates/versions/archives agents and persists per-principal
+role→agent selections; (2) an enriched `AgentResolverService` that resolves the *effective* agent for
+a `(role, phase)` via a deterministic, no-empty-fallback precedence chain; (3) the `/api/agents`
+minimal-API surface with per-mode RBAC mirroring the Prompt Store; (4) the DCB events and
+`MISSING_CONFIG` integration. Public agents live in the control plane; private agents + selections
+live in the per-tenant schema — isolation is structural.
+
+## Non-goals (YAGNI guard)
+
+- NO new agent entity model — `Agent`/`AgentVersion` come from Story 32-1. This plan only adds
+  `agent_role_selections` and (if 32-1 didn't) a system-default-per-role marker.
+- NO managed execution layer (`IManagedAgent`) — that is Story 32-5; this story returns an enriched
+  `ResolvedAgentConfig`, which 32-5 consumes.
+- NO provider credential resolution / BYOK (Story 32-3). Resolved configs stay credential-agnostic.
+- NO action trail / benchmarking / panels (32-6/32-7/32-10). This story emits only the
+  selection/lifecycle/resolve-failure DCB events.
+- NO change to resolution semantics elsewhere: `tenant → system → TammaError`
+  (`feedback_resolution_no_empty_fallback`) is preserved exactly; the new chain is the agent-entity
+  analogue, never an empty/plain fallback.
+- NO change to the legacy `/api/v1/agents/*` JSONB endpoints or `AgentResolverService.ResolveAsync`.
+- NO dashboard work — admin/tenant UI for agents is Story 32-13.
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+| Concern | Where it lives today | Note for this story |
+|---|---|---|
+| Legacy resolver | `src/Tamma.Api/Services/Agents/AgentResolverService.cs` (+ `IAgentResolverService.cs`, `DefaultAgentConfig.cs`) | Merges platform default + tenant JSONB override into `ResolvedAgentConfig`. Reuse its merge/validation; add the new entity-aware resolve methods alongside, do not rewrite. |
+| Resolved config DTO | `src/Tamma.Api/Services/Agents/ResolvedAgentConfig.cs` | Already has `Source` (string: `platform-default`/`tenant-override`). Add `AgentId`/`AgentVersion`; extend `Source` value set. |
+| Existing agent endpoints | `src/Tamma.Api/Endpoints/AgentEndpoints.cs` → mapped at `Program.cs` ~1679-1688 under `/api/v1/agents` (`GetConfig`/`UpdateConfig`/`ValidateConfig`/`ResolveAgent`/`ResolveForPhase`) | Keep untouched. Add new handlers in the same static class; map a new `/api/agents` group. |
+| Legacy JSONB entity | `src/Tamma.Data/Entities/AgentConfig.cs` (`agent_configs`, `TenantId?` null=system default) | Untouched. The new entities are 32-1's `Agent`/`AgentVersion`. |
+| Auth policies | `Program.cs` ~966-1085: `AdminAccess`, `OwnerAccess`, `PlatformOwnerAccess`, `MemberAccess`, `SettingsManage`, `PromptManage` (`prompts:manage`), `ConventionManage` (`conventions:manage`) | Add `AgentManage` (`agents:manage` = admin+owner) mirroring `PromptManage`. Public mutation → `PlatformOwnerAccess` / in-handler `IsPlatformOwner`. |
+| Permission matrix | `src/Tamma.Api/Auth/Permissions.cs` — `["prompts:manage"] = ["admin","owner"]`, `["conventions:manage"] = ["admin","owner"]` | Add `["agents:manage"] = ["admin","owner"]`. |
+| Principal / role claim | `ClaimsPrincipalExtensions.GetUserId`; JWT `role` claim (`JwtService.cs` ~167, `RoleClaimType="role"`); per-tenant role on `HttpContext.Items["TenantRole"]` (`RequireTenantMembershipFilter`) | Use `GetUserId` for single-user principal; the `role` claim + `PermissionRequirement` drive the member 403. Add `IsPlatformOwner()` helper (reads `platformRole`/`platform_admin`). |
+| Mode | `src/Tamma.Api/Services/PromptStore/TammaMode.cs` — `ITammaModeProvider` (singleton, process-stable) | Drives principal selection (SaaS ⇒ tenant_id; single-user ⇒ user_id). |
+| Tenancy | `ITenantContext` (`src/Tamma.Data/ITenantContext.cs`); `TenantDbContext` (`t_<hex>`) has `AgentConfigs`/`PromptOverrides`/`Conventions`/`DomainEvents`; `ControlPlaneDbContext` is shared | Private agents + `agent_role_selections` → tenant context; public agents → control plane (per 32-1). Single-user user-keyed selection rows → CP context. |
+| Events | `IEventRepository.AppendAsync(DomainEvent)` (`src/Tamma.Data/Repositories/EventRepository.cs`); tenant-scope ⇒ tenant store, `TenantId==null` ⇒ platform-events path | All `AGENT.*` events go through this; tenant-scope carry ambient `TenantId`. |
+| Migrations | Collapsed baseline: `Migrations/ControlPlane/...InitialControlPlane`, `Migrations/Tenant/...InitialTenant` + snapshots. Entity config lives ONLY in `TammaModelConfiguration.cs`. | Additive `agent_role_selections` migration per context; verify `has-pending-model-changes` → none. |
+| RBAC precedent | `PromptEndpoints.cs` + `PromptManage` policy; convention store splits tenant routes (`ConventionManage`) vs system-default routes (`PlatformOwnerAccess`) | Mirror exactly. |
+| No-empty-fallback rule | `feedback_resolution_no_empty_fallback`; `PromptStoreService.NoPromptError`, `ConventionStore.NoConventionError` | The 4th resolution branch is a hard `TammaError`, never blank config. |
+| Missing-config recorder | `IMissingConfigRecorder` (Missing-Config Notifications epic, not yet merged) | Inject as optional; degrade gracefully. The `AGENT.RESOLVE.FAILED` event is mandatory regardless. |
+
+**Key dependency gap:** Story 32-1's exact `Agent`/`AgentVersion` shape (does it carry
+`Visibility`/`Status`/`Role`/active-version pointer; how is the *system-default public agent per role*
+marked?) is the one unknown that gates Phase 1. Resolve it before coding (Phase 0).
+
+---
+
+## Architecture (one-paragraph)
+
+A request resolves through `AgentResolverService.ResolveForRoleAsync(role)`: derive principal from
+`ITammaModeProvider` + `ITenantContext`/`ClaimsPrincipal`; read the principal's `agent_role_selections`
+row for the role; if it points at an agent still in (public ∪ own private), materialise that agent's
+active version into `ResolvedAgentConfig` (source `tenant-private`/`tenant-public`); else fall to the
+system-default public agent (source `system-public`); else emit `AGENT.RESOLVE.FAILED`, best-effort
+record a `MISSING_CONFIG` gap, and throw `TammaError`. `AgentRegistryService` owns list/create/version/
+archive/select with public→CP, private→tenant placement and in-handler public-write gating. Endpoints
+mirror the Prompt Store: member read-only, admin/owner manage private, platform-owner manages public.
+
+---
+
+## Phased tasks (TDD throughout)
+
+### Phase 0 — 32-1 reconciliation (no code)
+
+- [ ] Read the merged Story 32-1 entities (`Agent.cs`, `AgentVersion.cs`) and their DbSets in
+      `TenantDbContext`/`ControlPlaneDbContext` + config in `TammaModelConfiguration.cs`.
+- [ ] Confirm: `Visibility` (public/private), `Status` (active/archived), `Role`, `Name`, and the
+      **active-version pointer** (flag on `AgentVersion.IsActive` OR `Agent.ActiveVersionId`).
+- [ ] Confirm how the **system-default public agent per role** is marked. If 32-1 ships it → use it.
+      If not → this story adds a CP `agent_default_selections` table (1 row per role) as part of
+      Phase 1, and the story's "(NEW — coordinate with 32-1)" markers resolve here.
+- [ ] Update the story's Files table / AC if the 32-1 shape diverges from the assumptions.
+
+**Done when:** every "(NEW — coordinate with 32-1)" marker in the story is reconciled to a concrete
+field/table; no assumption remains unverified.
+
+### Phase 1 — `agent_role_selections` entity + migration (core data)
+
+**Files:** new `src/Tamma.Data/Entities/AgentRoleSelection.cs`; DbSet in `TenantDbContext.cs` +
+`ControlPlaneDbContext.cs`; config in `TammaModelConfiguration.cs` (principal XOR check;
+`UNIQUE NULLS NOT DISTINCT (tenant_id, user_id, role)`); additive EF migrations per context.
+(If Phase 0 found no 32-1 system-default marker: also add `agent_default_selections` CP table here.)
+
+**Approach:** mirror `PromptOverride` config exactly for the XOR + unique-nulls-not-distinct index.
+Tenant-context table for SaaS; CP-context table for single-user user-keyed rows. Generate migrations
+with `dotnet ef migrations add ... --context <Ctx> --output-dir Migrations/<Ctx>`; verify
+`has-pending-model-changes` → none for both contexts.
+
+**Tests first** (`tests/Tamma.Data.Tests/` or the docker-bound migration test):
+- [ ] XOR violation (both tenant_id and user_id set, or neither) is rejected by the CHECK.
+- [ ] Duplicate `(principal, role)` rejected by the unique index; NULL principal halves collapse
+      correctly (nulls-not-distinct).
+- [ ] Migration applies + rolls back cleanly; `has-pending-model-changes` → none.
+
+**Done when:** both migrations apply, entity round-trips in both contexts, constraints enforced.
+
+### Phase 2 — `IAgentRegistryService` + `AgentRegistryService` (registry core)
+
+**Files:** new `IAgentRegistryService.cs`, `AgentRegistryService.cs`, DTOs under `Dtos/Agents/`
+(`AgentSummary`, `AgentWithVersions`, `CreateAgentRequest`, `PublishVersionRequest`,
+`SelectRoleRequest`, `AgentListFilter`, `AgentResponse`), `AgentEventTypes.cs` (event-type constants).
+
+**Approach:** constructor injects `ControlPlaneDbContext`/`ITenantDbContextFactory`, `ITenantContext`,
+`ITammaModeProvider`, `IEventRepository`, `ClaimsPrincipal`-derived principal, optional
+`IMissingConfigRecorder?`. `ListAsync` UNIONs public CP rows with ambient-tenant private rows.
+`CreateAsync`/`PublishVersionAsync` reject `visibility == public` unless platform owner (defensive,
+belt to the endpoint policy). `SelectForRoleAsync` validates target ∈ (public ∪ own private), upserts
+the selection, emits `AGENT.SELECTED_FOR_ROLE.SUCCESS`. Cross-tenant target id → returns null (→ 404
+at endpoint). Lifecycle ops emit `AGENT.CREATED/VERSION_PUBLISHED/ARCHIVED.SUCCESS`.
+
+**Tests first** (`tests/Tamma.Api.Tests/Agents/AgentRegistryServiceTests.cs`):
+- [ ] `ListAsync` returns public ∪ own private; never another tenant's private rows.
+- [ ] `CreateAsync` with `visibility=private` succeeds in tenant schema; `visibility=public` from a
+      non-platform-owner throws (forbidden).
+- [ ] `PublishVersionAsync` appends a version + emits event; `activate:"prior"` re-activates a prior
+      version (rollback).
+- [ ] `SelectForRoleAsync` validates target membership (own private OR any public); cross-tenant
+      target → not-found; emits exactly one `AGENT.SELECTED_FOR_ROLE.SUCCESS`.
+- [ ] `ArchiveAsync` flips status, emits event; archived agent excluded from default `ListAsync`.
+
+**Done when:** registry CRUD + selection works against real per-context DbContexts with correct
+placement and events; cross-tenant isolation holds at the service layer.
+
+### Phase 3 — enriched `AgentResolverService` resolution chain (the heart)
+
+**Files:** modify `ResolvedAgentConfig.cs` (add `AgentId`/`AgentVersion`; extend `Source`),
+`IAgentResolverService.cs` (declare `ResolveForRoleAsync`/`ResolveForRoleAndPhaseAsync`),
+`AgentResolverService.cs` (implement the precedence chain; reuse existing merge/validation to
+materialise the pinned version config).
+
+**Approach:** validate role against `RolePhaseMap.ValidRoles` (and phase eligibility when present).
+Derive principal from mode. Run the 4-branch chain (private selection → public selection →
+system-default public → fail-loud). Materialise the active `AgentVersion.Config` into
+`ResolvedAgentConfig` via the existing merge path, stamping `AgentId`/`AgentVersion`/`Source`.
+Recompute provenance at resolve time (stale/archived selection target degrades to system default with
+a WARN). On the 4th branch: emit `AGENT.RESOLVE.FAILED`, best-effort `IMissingConfigRecorder?.RecordAsync`
+(domain `agent`, config_key `role:{role}`, scope `system`), then `throw TammaError("AGENT.RESOLVE.NO_DEFAULT", severity High)`.
+
+**Tests first** (`tests/Tamma.Api.Tests/Agents/AgentResolverServiceTests.cs`):
+- [ ] Branch (a): tenant-selected private wins; `Source == "tenant-private"`, correct `AgentId/Version`.
+- [ ] Branch (b): tenant-selected public wins over system default; `Source == "tenant-public"`.
+- [ ] Branch (c): no selection ⇒ system-default public; `Source == "system-public"`.
+- [ ] Branch (d): no system default ⇒ `AGENT.RESOLVE.FAILED` emitted + `TammaError("AGENT.RESOLVE.NO_DEFAULT")`;
+      assert **no** `ResolvedAgentConfig` is returned (never blank).
+- [ ] Stale selection (target archived) degrades to system default with WARN.
+- [ ] Rollback: re-activate v1 after v2 → resolve returns v1 config + `AgentVersion==1`.
+- [ ] Unknown role → `ArgumentException`/400 before any resolution; phase ineligibility → 400.
+- [ ] `[Theory]` over `TammaMode.SingleUser`/`SaaS`: principal sourced from user_id vs tenant_id;
+      selection read from the correct context.
+- [ ] Missing-config recorder absent ⇒ event still fires, throw still happens (no crash).
+
+**Done when:** every AC-3 branch + mode matrix + rollback + no-empty-fallback proven green.
+
+### Phase 4 — endpoints + RBAC wiring
+
+**Files:** modify `AgentEndpoints.cs` (List/GetOne/Create/PublishVersion/Archive/SelectForRole/Resolve),
+`Permissions.cs` (`agents:manage`), `ClaimsPrincipalExtensions.cs` (`IsPlatformOwner()` if absent),
+`Program.cs` (`AgentManage` policy, DI for `IAgentRegistryService`, `/api/agents` route group +
+rate-limit groups `ConfigRead`/`ConfigWrite`).
+
+**Approach:** read routes under `MemberAccess` (any member); write routes under `AgentManage`
+(admin+owner). In `Create`/`PublishVersion`: reject `visibility==public` unless `IsPlatformOwner()`
+→ 403 `agent_public_write_forbidden`. `Resolve` maps `ArgumentException`→400,
+`TammaError("AGENT.RESOLVE.NO_DEFAULT")`→404/409 (match prompt-store HTTP mapping). Cross-tenant
+private GET → 404. Mirror `PromptEndpoints` structure for principal/mode derivation.
+
+**Tests first** (`tests/Tamma.Api.Tests/Agents/AgentEndpointsTests.cs`, in-process `WebApplicationFactory`):
+- [ ] RBAC matrix: member create/version/archive/select → 403; tenant_owner/tenant_admin private
+      manage → 200/201; platform owner public create → 201.
+- [ ] Tenant `POST /api/agents {visibility:public}` → 403 `agent_public_write_forbidden`;
+      tenant `POST /api/agents/{publicId}/versions` → 403.
+- [ ] `GET /api/agents` returns public ∪ own private; cross-tenant private GET → 404.
+- [ ] `PUT /api/agents/role-selections/{role}` persists + respected by subsequent `GET /api/agents/resolve`.
+- [ ] `GET /api/agents/resolve?role=&phase=` returns enriched config; bad role → 400; unresolvable → 404/409.
+
+**Done when:** full RBAC + isolation enforced at the HTTP boundary; no-regression on `/api/v1/agents/*`.
+
+### Phase 5 — DCB events + cross-tenant isolation tests + green-suite gate
+
+**Files:** `tests/Tamma.Api.Tests/Agents/AgentEventsTests.cs`,
+`tests/Tamma.Api.Tests/Agents/AgentRegistryIsolationTests.cs`.
+
+**Approach:** assert exact event shapes/tags; assert two tenants selecting the same public agent for a
+role resolve independently (no bleed); run the whole suite + `has-pending-model-changes`.
+
+**Tests first:**
+- [ ] Selection appends exactly one `AGENT.SELECTED_FOR_ROLE.SUCCESS` with `{agentId, role, source}`.
+- [ ] Unresolvable role appends exactly one `AGENT.RESOLVE.FAILED` with `{role, phase, source, mode}`.
+- [ ] Lifecycle ops append create/version/archive events with correct tags.
+- [ ] Two-tenant invariant: same public agent selected → separate selection rows, independent resolve.
+- [ ] `sg docker -c "dotnet test apps/tamma-elsa/..."` full suite green; both contexts'
+      `has-pending-model-changes` → none.
+
+**Done when:** all events verified, isolation invariant holds, full suite + migration check green.
+
+---
+
+## Sequencing
+
+Phase 0 → Phase 1 → Phase 2 → Phase 3 → Phase 4 → Phase 5.
+Phase 0 is a hard gate (32-1 shape). Phases 2 and 3 may overlap once Phase 1's entity exists (registry
+and resolver share the selection table). Phase 4 needs 2+3. Phase 5 is the closeout gate.
+
+## Risks
+
+- **32-1 shape drift** (primary): the resolver/registry assume `Agent.Visibility`/`Status`, an
+  active-version pointer, and a system-default-per-role marker. If 32-1 modelled these differently,
+  Phase 0 must adjust the story + this plan before coding. Mitigation: Phase 0 is a no-code gate.
+- **Empty/plain fallback regression**: the cardinal project rule. The 4th branch MUST throw, never
+  return blank — pin it with branch (d) tests AND assert no config object is produced. Mirror
+  `PromptStoreService.NoPromptError` precisely.
+- **Cross-schema selection target**: a tenant selection may point at a CP-resident public agent — there
+  is no DB FK across schemas. The registry validates membership in code at write AND recomputes at
+  resolve; never trust the stored `Visibility`. Stale/deleted targets degrade to system default, not
+  to error, except when no system default exists.
+- **Cross-tenant leak**: private agents/selections must never escape the tenant schema. Enforce via the
+  per-tenant `TenantDbContext`; cover with `AgentRegistryIsolationTests` (real two-tenant setup), not
+  mocks. Use 404 (not 403) for cross-tenant private reads to avoid existence leak.
+- **Event-store topology (Story 28-1)**: `AGENT.RESOLVE.FAILED` for a *system* gap is platform-scope;
+  ensure system-scope resolve failures append via the platform-events path (`TenantId==null`) while
+  selection/lifecycle events stay tenant-scoped. Mirror the recorder discipline from the missing-config
+  plan.
+- **Missing-config epic not merged**: inject `IMissingConfigRecorder?` optional; the gap record is
+  best-effort, the event + throw are not. Tests cover the absent-recorder path.
+- **Migration discipline**: `agent_role_selections` is additive (new table), but collapsed-baseline
+  rules still apply — entity config only in `TammaModelConfiguration.cs`, verify
+  `has-pending-model-changes` → none for BOTH contexts after generating migrations.
+- **Public-write gate split**: route policy (`AgentManage`) admits tenant admins; the platform-owner
+  check is in-handler. A missing in-handler check would let a tenant admin mint a public agent — pin
+  with the `agent_public_write_forbidden` 403 tests on both create and version routes.
+
+## Acceptance criteria (plan-level)
+
+- [ ] All 15 story ACs satisfied; each mapped to at least one passing test.
+- [ ] Resolution precedence: all 4 branches green, including the no-empty-fallback throw + event.
+- [ ] Per-mode (single-user user_id vs SaaS tenant_id) proven by mode-parameterized tests.
+- [ ] RBAC: member 403s, tenant private-only management, platform-owner public management, tenant
+      public-write 403 — all green.
+- [ ] Cross-tenant isolation (private read 404, no list bleed, two-tenant independent resolve) green.
+- [ ] Rollback-to-prior-version resolution green.
+- [ ] DCB events `AGENT.SELECTED_FOR_ROLE.SUCCESS` / `AGENT.RESOLVE.FAILED` (+ lifecycle) emitted with
+      correct tags.
+- [ ] No regression on `/api/v1/agents/*` and `AgentResolverService.ResolveAsync`.
+- [ ] Both contexts' migrations apply + roll back; `has-pending-model-changes` → none.
+- [ ] Full `dotnet test` suite green (`sg docker -c "dotnet test ..."`).

--- a/docs/superpowers/plans/2026-06-17-32-3-per-tenant-provider-credential-resolution-plan.md
+++ b/docs/superpowers/plans/2026-06-17-32-3-per-tenant-provider-credential-resolution-plan.md
@@ -1,0 +1,282 @@
+# Story 32-3 — Per-Tenant Provider Credential Resolution (BYOK → platform) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement phase-by-phase. Steps use checkbox
+> (`- [ ]`) syntax. Project is test-first (TDD) — write the failing test before the implementation in
+> every phase.
+
+**Story:** `docs/stories/epic-32/story-32-3/32-3-per-tenant-provider-credential-resolution.md`
+**Epic:** 32 — `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`
+**Date:** 2026-06-17
+
+**Goal:** Replace the global-env provider-key lookup in `CallLlmInlineActivity` with a single
+`IProviderCredentialResolver` seam that, per call, resolves a tenant's **own** provider API key from
+the Epic 29 secret cabinet (`SecretScope.Tenant`, `SecretPurpose.ApiKey`, keyed by provider) and
+falls back to the platform-provided key only when the tenant has none — **fail-closed** in SaaS when
+neither is allowed. Record `credentialSource` (`byok | platform`) per call (for 32-9 / 34 / 35),
+expose a tenant-admin BYOK management API, and never let a raw key reach an event, diagnostic, or log.
+This story is the **canonical owner** of BYOK key wiring into the LLM call path.
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (`Tamma.Api`, `Tamma.Data`,
+`Tamma.Activities`, `Tamma.ElsaServer`, `Tamma.Core`). Tests: xUnit under
+`apps/tamma-elsa/tests/` (docker-bound suites via `sg docker -c "dotnet test ..."`; build needs no
+wrapper — see memory `reference_dotnet_test_docker.md`).
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO pricing/markup engine** — that is 34-5. This story only *emits* `credentialSource`; it does not
+  compute cost differently for BYOK vs platform.
+- **NO new provider implementations** (Epic 1-10). Resolution targets the providers
+  `CallLlmInlineActivity` already supports (`anthropic`, `openai`/OpenAI-compatible, `openrouter`).
+- **NO per-user BYOK layer.** BYOK is tenant-scoped only (single-user: the sole user == the
+  tenant-equivalent). Mirrors Prompt Store "no per-user override in SaaS".
+- **NO OpenBao / KMS work** — the cabinet's backend is whatever Epic 29 wired (env-KEK Postgres
+  backend today); this story consumes `ISecretStoreBackend` as-is. Story 28-13 is out of scope.
+- **NO change to provider *selection*** (`ProviderChainResolver` keeps choosing which provider). This
+  story resolves the chosen provider's *key*.
+- **NO removal of the Story 29-9 env-var fallback** for the platform key — we *reuse*
+  `IRuntimeSecretResolver`, inheriting whatever fallback state Epic 29 has configured.
+- **NO TypeScript-side work** — `packages/api` is deleted; everything is C# `apps/tamma-elsa`.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### The gap — direct env-key reads, tenant-agnostic
+
+`apps/tamma-elsa/src/Tamma.Activities/LlmCall/CallLlmInlineActivity.cs` → `LoadProviderConfig`
+(lines **~1398–1443**) reads provider keys straight from process config — one key for all tenants:
+
+```csharp
+"anthropic" => new LlmProviderConfig { ApiKey = _configuration?["Anthropic:ApiKey"] ?? "", ... },
+"openai"    => new LlmProviderConfig { ApiKey = _configuration?["OpenAI:ApiKey"] ?? "", ... },
+"openrouter"=> new LlmProviderConfig { ApiKey = _configuration?["OpenRouter:ApiKey"] ?? "", ... },
+```
+
+The same `config.ApiKey` flows into `CallAnthropicMessages`/`CallAnthropicMultiTurn` (`x-api-key`
+header, lines ~853, ~1273) and `CallOpenAiCompatible`/`CallOpenAiMultiTurn` (`Authorization: Bearer`,
+lines ~891, ~1334). This is the Epic 32 design Risk "Global provider keys today".
+
+### Tenant context is threaded into the workflow — but not into this activity
+
+`apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/LlmCallWorkflow.cs`:
+- line ~70: `var tenantIdVar = builder.WithVariable<string>("TenantId", "");`
+- line ~153: `tenantIdVar.Set(context, context.GetInput<string>("tenantId") ?? "");`
+- lines ~208, ~276: `TenantId = new Input<string>(ctx => tenantIdVar.Get(ctx))` is passed to the
+  **prompt/convention** activities — proving the wiring pattern. `CallLlmInlineActivity` is
+  instantiated in the same workflow (lines ~176/211 of `Tamma.ElsaServer/Program.cs` reference it) but
+  **does not receive `TenantId`**. This is the integration seam (Phase 3).
+
+### Epic 29 secret cabinet — the primitives to build on (all verified present)
+
+| Primitive | Path | Use |
+|---|---|---|
+| `ISecretStore` (create/get/rotate/retire/version) | `Tamma.Api/Services/Secrets/ISecretStore.cs` | BYOK create/rotate/remove + metadata lookup. **Never returns plaintext** (its own doc-comment "Plaintext rule"). |
+| `ISecretStoreBackend.GetVersionPlaintextAsync(secretId, versionNumber)` | `Tamma.Api/Services/Secrets/ISecretStoreBackend.cs` | The ONLY runtime plaintext read path. |
+| `SecretRef.ForTenant(tenantId, name)` / `SecretScope.Tenant` | `…/Secrets/SecretRef.cs`, `SecretScope.cs` | Tenant-scoped ref; ctor enforces non-null tenantId. |
+| `SecretPurpose.ApiKey` | `…/Secrets/SecretPurpose.cs` | Purpose for provider keys. |
+| `IRuntimeSecretResolver.GetAsync("anthropic/api-key")` + `Invalidate` + `DefaultCacheTtl=60s` | `…/Secrets/Stopgap/IRuntimeSecretResolver.cs`, `RuntimeSecretResolver.cs` | **Prior art + platform-key source of truth.** Already does cabinet→backend→cache→config-fallback, but **platform-scoped only** (`s.Scope == "platform"`, `StopgapSecretMap.Platform`). We model the tenant resolver on it and delegate the platform leg to it. |
+| `StopgapSecretMap.PlatformAnthropicApiKey = "anthropic/api-key"` (+ GitHub, Cranl, …) | `…/Secrets/Stopgap/StopgapSecretMap.cs` | Canonical platform cabinet names. No OpenAI/OpenRouter entry yet — add platform cabinet names for them in `ProviderCabinetNames` (Phase 1) or extend the stopgap map if a platform OpenAI key needs migrating. |
+
+**Key architectural fact:** `RuntimeSecretResolver` is exactly the shape we want, restricted to
+platform scope. 32-3 = its tenant-scoped sibling + BYOK→platform precedence + fail-closed.
+
+### DCB + error + endpoint patterns (to mirror)
+
+- **Events:** `Tamma.Data/Entities/DomainEvent.cs` (`Id, Type, TenantId, Tags, Metadata, Data,
+  CreatedAt, SequenceNumber`) appended via `Tamma.Data/Repositories/IEventRepository.AppendAsync`.
+  Emission exemplar: `AgentEndpoints.UpdateConfig` (`AGENT_CONFIG.UPDATED.SUCCESS`, JSON-serialized
+  Tags/Metadata/Data). Type follows `AGGREGATE.ACTION.STATUS`.
+- **Typed error:** `Tamma.Core/TammaError.cs` — `new TammaError(code, message, context, retryable,
+  severity)`; `PROVIDER_CREDENTIAL_UNAVAILABLE` joins `PROMPT.RESOLVE.NO_DEFAULT` etc. as a
+  fail-loud code (project rule `feedback_resolution_no_empty_fallback`: never silent empty fallback).
+- **Tenant context / RBAC:** `Tamma.Data/ITenantContext.cs` (`Guid? TenantId`);
+  `AgentEndpoints.UpdateConfig` shows the tenant-context guard (400/short-circuit) and
+  `principal.GetUserId()`; Prompt Store RBAC (CLAUDE.md) is the owner/admin-vs-member precedent.
+- **Mode:** `Tamma.Api/Services/PromptStore/TammaMode.cs` `ITammaModeProvider` (SingleUser | SaaS) —
+  drives the single-user-always-fallback vs SaaS-fail-closed branch.
+
+### Per-mode ownership (mandatory two-scoping-model answer, CLAUDE.md)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Who owns a BYOK key? | The sole user (resolve with `tenantId == null` → platform/local; no separate BYOK layer needed — their config IS the platform config). | The tenant (`SecretScope.Tenant`, keyed by `tenantId`); `tenant_owner`/`tenant_admin` manage, members read metadata. |
+| Resolution order | platform/local key (env→cabinet via `IRuntimeSecretResolver`). | tenant BYOK cabinet key → platform-provided key (gated). |
+| Fail-closed? | Only if even the platform key is unset (already broken today) → loud error. | YES when no BYOK + fallback disabled → `PROVIDER_CREDENTIAL_UNAVAILABLE` + `AGENT.CREDENTIAL.DENIED`. |
+| Who sees `credentialSource`? | the user. | the tenant (in diagnostics/action-trail); platform admin sees aggregate, never the key. |
+| Mode source | `ITammaModeProvider` | same |
+
+---
+
+## Phases (TDD — failing test first in every phase)
+
+### Phase 1 — `ProviderCabinetNames` + `IPlatformFallbackPolicy` (pure, no I/O)
+
+**Approach:** Pure helpers so the resolver's name-mapping and fallback gating are unit-testable
+without a DB. `ProviderCabinetNames.Byok("anthropic") => "provider/anthropic/api-key"`;
+`.Platform("anthropic") => StopgapSecretMap.PlatformAnthropicApiKey`. Allowlist via existing
+`ProviderAllowlist` (already used in `CallLlmInlineActivity.LoadProviderConfig`).
+`ConfigPlatformFallbackPolicy`: single-user ⇒ true; SaaS ⇒ true unless
+`Providers:PlatformFallbackDisabled` (global) or `Providers:<provider>:PlatformFallbackDisabled`
+(per-provider) is set.
+
+**Files:** new `Services/Providers/ProviderCabinetNames.cs`, `IPlatformFallbackPolicy.cs`,
+`ConfigPlatformFallbackPolicy.cs`.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Providers/ProviderCabinetNamesTests.cs`,
+`ConfigPlatformFallbackPolicyTests.cs` — name mapping for anthropic/openai/openrouter; unknown
+provider rejected; single-user always true; SaaS true by default, false when disabled globally /
+per-provider.
+
+- [ ] Write failing tests for name mapping + fallback policy matrix.
+- [ ] Implement `ProviderCabinetNames`, `IPlatformFallbackPolicy`, `ConfigPlatformFallbackPolicy`.
+- [ ] Green; no direct config reads outside the policy.
+
+### Phase 2 — `IProviderCredentialResolver` + `DefaultProviderCredentialResolver` (core)
+
+**Approach:** Implement the BYOK→platform algorithm from the story Technical Design.
+- BYOK leg: `ISecretStore.GetAsync(SecretRef.ForTenant(tid, ByokName))` for metadata →
+  `ISecretStoreBackend.GetVersionPlaintextAsync(meta.Id, meta.ActiveVersionNumber)` for bytes (mirror
+  `RuntimeSecretResolver.TryReadCabinetAsync`, incl. the catch-and-degrade-to-absent behaviour).
+- Platform leg: `IRuntimeSecretResolver.GetAsync(ProviderCabinetNames.Platform(provider))`.
+- Cache: `ConcurrentDictionary<(Guid,string), CacheEntry>`, TTL `RuntimeSecretResolver.DefaultCacheTtl`;
+  `Invalidate((tenant,provider))`.
+- Emit `AGENT.CREDENTIAL_RESOLVED.SUCCESS` / `AGENT.CREDENTIAL.DENIED` via `IEventRepository`
+  (tag-only projection, **never** `ApiKey`). Fail-closed → `TammaError("PROVIDER_CREDENTIAL_UNAVAILABLE")`.
+- `ProviderCredential.ToTag()` is the ONLY thing handed to events/diagnostics.
+
+**Files:** new `Services/Providers/IProviderCredentialResolver.cs` (+ `ProviderCredential`,
+`CredentialSource`), `DefaultProviderCredentialResolver.cs`.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Providers/ProviderCredentialResolverTests.cs` with
+`InMemorySecretStoreBackend` + fakes for `ISecretStore`, `IRuntimeSecretResolver`, `IEventRepository`,
+`ITammaModeProvider`, `IPlatformFallbackPolicy`:
+- BYOK present → tenant key, `source=byok`, ref + version correct, one `RESOLVED.SUCCESS`.
+- BYOK absent + platform present + allowed → `source=platform`.
+- SaaS + BYOK absent + fallback disabled → `PROVIDER_CREDENTIAL_UNAVAILABLE` + `DENIED`, no SUCCESS.
+- single-user + platform present → `source=platform`; single-user + platform unset → loud throw.
+- **Tenant isolation:** tenant A BYOK seeded; resolve A→A's key, resolve B→platform (never A's).
+- **Redaction:** sentinel BYOK key never in any emitted `DomainEvent` Tags/Data or log.
+- Cabinet probe throws → treated as BYOK-absent, WARN, proceeds to fallback.
+
+- [ ] Write failing resolver tests (all AC13 cases + isolation + redaction).
+- [ ] Implement resolver + cache + events + fail-closed.
+- [ ] Green.
+
+### Phase 3 — Wire resolver into `CallLlmInlineActivity` + workflow + diagnostics
+
+**Approach:**
+- Add `Input<string?> TenantIdProp` to `CallLlmInlineActivity`; parse to `Guid?` (empty → null).
+- Add `IProviderCredentialResolver?` ctor dep (null-tolerant; extend `[JsonConstructor]` chain).
+- Replace `ApiKey` population: keep `LoadProviderConfig` for BaseUrl/Model/Timeout; add
+  `LoadProviderConfigWithKeyAsync(provider, tenantId, ctx)` that calls the resolver and sets
+  `cfg.ApiKey`. Call it in both single-turn and tool-loop entry points (lines ~298, ~123).
+- Set `ctx.SetVariable("CredentialSource", …)` and add `ProviderAttemptDiagnostic.CredentialSource`
+  (`LlmCallModels.cs`) — already serialized into `LastDiagnostic`.
+- Catch `TammaError("PROVIDER_CREDENTIAL_UNAVAILABLE")` inside the existing per-attempt try/catch so
+  the chain can advance; if the whole chain has no usable credential, surface the failure (loud).
+- `LlmCallWorkflow`: pass `TenantId = new Input<string>(ctx => tenantIdVar.Get(ctx))` to the
+  `CallLlmInlineActivity` step (same as prompt/convention steps).
+- Register resolver + invalidator in `Tamma.ElsaServer/Program.cs`.
+
+**Tests (first):** `tests/Tamma.Activities.Tests/LlmCall/CallLlmInlineCredentialTests.cs` (mock
+`IHttpClientFactory`): with `TenantIdProp` set + BYOK seeded → outbound header carries BYOK key,
+`CredentialSource=byok` on diagnostic; empty tenant → platform key, `source=platform`; resolver
+denial → diagnostic `Succeeded=false` with the typed error, no header sent. Existing single-turn +
+tool-loop sanitization tests stay green (AC12).
+
+- [ ] Write failing activity-credential tests.
+- [ ] Add `TenantIdProp` + resolver dep; drop direct env-key read; wire diagnostics.
+- [ ] Thread `TenantId` in `LlmCallWorkflow`; register in `Program.cs`.
+- [ ] Green incl. existing CallLlmInline tests; add a guard test asserting `LoadProviderConfig`
+      returns empty `ApiKey`.
+
+### Phase 4 — BYOK management API + RBAC + cache invalidation on mutate
+
+**Approach:** New `ProviderCredentialEndpoints` (or extend `AgentEndpoints`):
+```
+POST   /api/v1/agents/providers/{provider}/credential          → ISecretStore.CreateAsync (reveal-once, 29-3)
+POST   /api/v1/agents/providers/{provider}/credential/rotate   → ISecretStore.RotateAsync
+DELETE /api/v1/agents/providers/{provider}/credential          → retire active version
+GET    /api/v1/agents/providers                                 → metadata list (NO key)
+```
+- RBAC: tenant_owner/tenant_admin only (member → 403; cross-tenant → 404); tenant-context guard like
+  `AgentEndpoints.UpdateConfig`.
+- Every mutation → `resolver.Invalidate(tid, provider)`; cabinet audit pipeline records the change;
+  response never echoes the raw key (create returns the reveal-once token only).
+- `ProviderCredentialCacheInvalidator`: subscribe/handle `SECRET.ROTATE.ACTIVATED`; if rotated ref is
+  a `provider/*/api-key` tenant ref, evict `(tenantId, provider)`.
+- DI in `Tamma.Api/Program.cs` + `ProviderCredentialServiceCollectionExtensions`.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/ProviderCredentialEndpointsTests.cs` — RBAC matrix
+(owner/admin create/rotate/delete; member 403; cross-tenant 404); create→list shows metadata only, no
+key; whitespace key rejected; mutation invalidates cache (resolver re-reads). Invalidator test:
+`SECRET.ROTATE.ACTIVATED` for a matching ref evicts the cache entry.
+
+- [ ] Write failing endpoint RBAC + invalidation tests.
+- [ ] Implement endpoints, DI, invalidator.
+- [ ] Green.
+
+### Phase 5 — Hardening, redaction sweep, full-suite + docker run
+
+**Approach:** Cross-cutting verification.
+- Redaction: end-to-end sentinel test (Phase 2 + Phase 3 combined) — sentinel key in HTTP header
+  ONLY; absent from events, diagnostics, exceptions, logs.
+- Edge: unknown provider; cabinet down (degrade, not leak); TTL expiry re-read; backward-compat byte
+  check for platform path.
+- Run `sg docker -c "dotnet test apps/tamma-elsa/Tamma.sln"` (or per-project) — full suite green.
+- Confirm `has-pending-model-changes` is clean (this story adds **no** EF migration — BYOK keys live
+  in the existing cabinet tables; only verify nothing inadvertently changed the model).
+
+- [ ] End-to-end redaction test green.
+- [ ] Edge-case tests green.
+- [ ] Full C# suite green via docker wrapper; no model drift.
+
+---
+
+## Sequencing & dependencies
+
+Phase 1 → Phase 2 (needs P1 helpers) → Phase 3 (needs P2 resolver) → Phase 4 (needs P2 resolver;
+parallel-safe with P3) → Phase 5 (needs all). Hard external prerequisite: **Epic 29** primitives
+(verified present). 32-1 (agent entity) supplies the provider attribute but is not strictly required
+to land the resolver — the resolver keys off `(tenantId, providerName)` which already flows from the
+workflow.
+
+## Risks
+
+- **Raw-key leakage** (Critical): tag-only `ToTag()`, `Data` excludes `ApiKey`, dedicated end-to-end
+  redaction test (Phase 5). Audit every new `LogInformation`/event-`Data` line during review.
+- **`ISecretStore` plaintext-rule violation:** it deliberately never returns plaintext — must read
+  via `ISecretStoreBackend.GetVersionPlaintextAsync` (Phase 2). A reviewer should reject any
+  `ISecretStore`-to-plaintext shortcut.
+- **Cross-tenant cache collision** (High): cache keyed by `(tenantId, provider)`; isolation test
+  (Phase 2). Never cache platform key under a tenant key.
+- **Stale key after rotation** (Medium): TTL + `Invalidate` on mutate + `SECRET.ROTATE.ACTIVATED`
+  handler; rotation test (Phase 2/4).
+- **Behaviour change for platform-key tenants** (Medium): AC12 byte-identical platform path; keep all
+  existing `CallLlmInlineActivity` tests green (Phase 3).
+- **`_configuration["…:ApiKey"]` regressing back in** (Medium): resolver is the only key source; add
+  the `LoadProviderConfig` empty-`ApiKey` guard test (Phase 3).
+- **Elsa activity hydration** (Low): null-tolerant ctor + `[JsonConstructor]`; Program-level wiring
+  test confirms the resolver is actually injected at runtime.
+- **Platform cabinet name absent for OpenAI/OpenRouter** (Low): `StopgapSecretMap` only ships
+  `anthropic/api-key` today; `ProviderCabinetNames.Platform` defines the others (and the platform key
+  may simply be unset → fail-closed/loud, which is correct).
+
+## Acceptance criteria (plan-level — maps to story ACs)
+
+- [ ] `IProviderCredentialResolver` resolves BYOK-then-platform per `(tenantId, provider)` (story AC1, AC2).
+- [ ] `CallLlmInlineActivity` no longer reads `_configuration["<Provider>:ApiKey"]`; resolves via the
+      resolver with the workflow's tenant context (AC3); guard test proves it.
+- [ ] `credentialSource` (`byok | platform`) on the diagnostic/action-trail; never the key (AC4).
+- [ ] BYOK read/written only through the cabinet; raw key never in events/diagnostics/logs — redaction
+      test green (AC5).
+- [ ] Fail-closed in SaaS (`PROVIDER_CREDENTIAL_UNAVAILABLE` + `AGENT.CREDENTIAL.DENIED`); single-user
+      falls back (AC6); fallback gated by `IPlatformFallbackPolicy` (AC6.1).
+- [ ] Tenant-admin BYOK register/rotate/remove API, owner/admin-gated, member 403, cross-tenant 404 (AC7).
+- [ ] `AGENT.CREDENTIAL_RESOLVED.SUCCESS` + `AGENT.CREDENTIAL.DENIED` DCB events, no secret (AC8).
+- [ ] Cache TTL + invalidate-on-rotate; rotation returns new key (AC9).
+- [ ] Per-mode ownership explicit; no per-user BYOK (AC10); tenant isolation proven (AC11).
+- [ ] Backward-compatible platform path (AC12); all unit tests (AC13) green; full C# suite green.

--- a/docs/superpowers/plans/2026-06-17-32-4-saas-provider-auth-gating-api-key-only-plan.md
+++ b/docs/superpowers/plans/2026-06-17-32-4-saas-provider-auth-gating-api-key-only-plan.md
@@ -1,0 +1,212 @@
+# Story 32-4 — SaaS Provider Auth Gating (API-key only) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan phase-by-phase. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every phase writes tests
+> before implementation.
+
+**Story:** `docs/stories/epic-32/story-32-4/32-4-saas-provider-auth-gating-api-key-only.md`
+**Epic:** 32 — Agents (first-class entities, managed execution, benchmarking, learning)
+**Design spec:** `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md` (§"Provider credential & auth model")
+
+---
+
+## Goal
+
+Enforce the product invariant that **SaaS provider authentication is API-key only**. In SaaS mode,
+CLI/token-based agent providers (`ICLIAgentProvider` — `claude-code`, `opencode`, …) can be neither
+**selected** (agent create/version) nor **executed** (provider-chain resolver / managed entrypoint).
+In single-user/self-hosted mode they remain fully usable. The gate is a pure function of
+`(process mode, provider name)`, fail-closed, additive on top of the existing
+`ProviderAllowlist`/`ActionGate` seams, and observable via a DCB event (`AGENT.PROVIDER.GATED`) +
+an OTel counter (`tamma.provider.gated`).
+
+## Non-goals (YAGNI guard)
+
+- **NO new provider implementations** and **no change to `packages/providers`** — the TS provider
+  hierarchies (`ILLMProvider` vs `ICLIAgentProvider`) are the *classification reference*, not edited.
+  The C# side owns the gate.
+- **NO change to single-user behaviour** — single-user is a hard no-op (no rejection, no event, no
+  metric). Self-hosted Claude Code CLI usage is untouched.
+- **NO new allowlist / no new mode plumbing / no new event store.** Reuse
+  `ProviderAllowlist.DefaultProviders`, `ITammaModeProvider`, and `IEventRepository` respectively.
+- **NO BYOK/platform credential resolution here** — that is Story 32-3. Gating runs *before*
+  credential resolution and only inspects provider *names* (never secret material).
+- **NO managed-execution layer here** — that is Story 32-5. This plan delivers the execution-boundary
+  gate that 32-5 will call; it does not build `IManagedAgent`.
+- **NO `packages/api`** — that package is DELETED. All work is in `apps/tamma-elsa` (C#).
+
+## Current-state findings (verified 2026-06-17, repo @ main)
+
+| Seam | Verified location | Relevance |
+|---|---|---|
+| Two provider hierarchies | `packages/providers/src/types.ts` — `ProviderCategory = 'llm-api' \| 'cli-agent'`; `ILLMProvider extends IProvider { type: 'llm-api' }` (L162); `ICLIAgentProvider extends IProvider { type: 'cli-agent' }` (L182) | Classification reference — `llm-api` ⇒ ApiKey, `cli-agent` ⇒ CliToken. |
+| CLI agent provider names | `packages/providers/src/claude-agent-provider.ts` L80 `name = 'claude-code'`; `opencode-provider.ts` L69 `name = 'opencode'`; registered via `BUILTIN_PROVIDER_NAMES` (`agent-provider-factory.ts` L199) | The `CliToken` member set. Cross-check `BUILTIN_PROVIDER_NAMES` for extras (e.g. `zen-mcp`) at impl time. |
+| Known-provider allowlist | `apps/tamma-elsa/src/Tamma.Activities/Security/ProviderAllowlist.cs` — `DefaultProviders` set (15 names: anthropic, openai, openrouter, google, github-copilot, local-llm, opencode, z-ai, zen-mcp, azure-openai, gemini, ollama, lmstudio, together, groq); `IsAllowedDefault(name)`; static `DefaultInstance` | **Reuse** as the single source of known providers; derive ApiKey set as `DefaultProviders \ CliTokenProviders`. |
+| Sibling guardrail pattern | `apps/tamma-elsa/src/Tamma.Activities/Security/ActionGate.cs` — pure, fast, default-set + `IOptions` extension, `IsBlocked(cmd, out name)` | Pattern to mirror for the registry (pure, default-set, DI-friendly). |
+| Process mode | `apps/tamma-elsa/src/Tamma.Api/Services/PromptStore/TammaMode.cs` — `enum TammaMode { SingleUser, SaaS }`; `ITammaModeProvider { TammaMode Mode }`; process-stable singleton | **Reuse** — the mode source; gate reads `.Mode` once. |
+| Provider chain resolver | `apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderChainResolver.cs` — `ResolveAsync(tenantId, role, action, options, ct)`; per-entry loop over `configured` handles with CB switch (L118-162); optional `IDiagnosticsService?` ctor overload (L45-58); returns `ChainResolveResult` with `EMPTY_PROVIDER_CHAIN`/`NO_AVAILABLE_PROVIDER` error codes | **Execution boundary.** Add `IProviderAuthRegistry?` + `ITammaModeProvider` via the same optional-ctor pattern; skip ineligible entries pre-CB-switch. |
+| Chain types | `apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderChainTypes.cs` — `ChainEntry`, `ChainReason` (Healthy/Unknown/HalfOpenProbeCandidate/CircuitOpen), `ProviderHandle`, `ChainResolveResult` | Add `ChainReason.SaaSIneligible`. |
+| Agent selection seam | `apps/tamma-elsa/src/Tamma.Api/Services/Agents/` (`AgentResolverService`, `IAgentResolverService`, `ResolvedAgentConfig`, `DefaultAgentConfig`); `AgentRegistryService.cs` does **NOT** exist yet (NEW from 32-2); create/version write in `Endpoints/AgentEndpoints.cs` (`configRepo.UpsertAsync`, ~L89) | **Selection boundary.** Hook `AgentRegistryService` if 32-2 merged; otherwise wire `AgentEndpoints` create/version. |
+| DCB event emission | `Endpoints/AgentEndpoints.cs` L93 `await events.AppendAsync(new DomainEvent { Type=..., TenantId, Tags, Metadata, Data, CreatedAt })`; `IEventRepository.AppendAsync` (`Tamma.Data/Repositories/IEventRepository.cs`); `DomainEvent` entity (`Tamma.Data/Entities/DomainEvent.cs`) | **Reuse** exact pattern for `AGENT.PROVIDER.GATED`. |
+| Error type | `apps/tamma-elsa/src/Tamma.Core/TammaError.cs` — `TammaError(code, message, context?, retryable=false, severity=Medium)`; `TammaErrorSeverity` | Throw `SAAS_PROVIDER_NOT_ALLOWED` at selection; existing endpoint `TammaError`→400 mapping produces the response. |
+| Metrics pattern | `KekRotationMetrics` (per MEMORY: `tamma.kek_rotation.remaining` OTel gauge) | Mirror for `tamma.provider.gated` counter. |
+| Existing AGENT.* events | `AGENT.DISPATCH.STARTED/SUCCESS/FAILED`, `AGENT.RESULTS.PARTIAL`, `AGENT_CONFIG.UPDATED.SUCCESS` | `AGENT.PROVIDER.GATED` is new, follows the `AGGREGATE.ACTION.STATUS` convention. |
+
+**Test execution:** C# docker-bound suites run `sg docker -c "dotnet test ..."` (session docker group
+is stale — `reference_dotnet_test_docker.md`); build needs no wrapper.
+
+---
+
+## Phased tasks
+
+### Phase 1 — Provider auth registry (`IProviderAuthRegistry`)
+
+The pure classification layer. Lives in `Tamma.Activities/Security/` beside `ProviderAllowlist` so
+engine activities can reuse it without an Api dependency.
+
+- [ ] **Test first:** `tests/Tamma.Activities.Tests/Security/ProviderAuthRegistryTests.cs`
+  - every `ProviderAllowlist.DefaultProviders` entry returns a non-null `AuthModel` (no
+    silent miscategorisation);
+  - `claude-code`, `opencode` ⇒ `CliToken`, `IsSaaSEligible == false`;
+  - `anthropic`, `openai`, `openrouter`, `gemini`, `google`, `github-copilot`, `azure-openai`,
+    `local-llm`, `ollama`, `lmstudio`, `together`, `groq`, `z-ai` ⇒ `ApiKey`, eligible;
+  - unknown name ⇒ `AuthModel == null`, `IsSaaSEligible == false` (fail-closed);
+  - null/whitespace ⇒ `null`/`false`; case-insensitivity.
+- [ ] Implement `IProviderAuthRegistry.cs` (enum `ProviderAuthModel { ApiKey, CliToken }`,
+  interface) and `ProviderAuthRegistry.cs` (derive ApiKey = `DefaultProviders \ CliTokenProviders`;
+  `CliTokenProviders = { claude-code, opencode }` + any extra CLI registrations found in
+  `BUILTIN_PROVIDER_NAMES`).
+- [ ] **Files:** create both under `apps/tamma-elsa/src/Tamma.Activities/Security/`.
+
+**Done when:** registry tests green; the "every allowlist entry classifies" test passes (guards
+future provider additions).
+
+### Phase 2 — The gate (`ISaaSProviderGate`) + event + metric
+
+Api-side because it needs `ITammaModeProvider` and emits DCB events.
+
+- [ ] **Test first:** `tests/Tamma.Api.Tests/Security/SaaSProviderGateTests.cs`
+  - single-user: every provider ⇒ `Allowed`, **zero** events, **zero** metric increments;
+  - SaaS: `ApiKey` ⇒ `Allowed`, no event; `CliToken` ⇒ denied, **exactly one**
+    `AGENT.PROVIDER.GATED` event (assert `Type`, `Data.provider/authModel/mode/reason`, `Tags`,
+    `TenantId`), **exactly one** counter increment;
+  - SaaS unknown ⇒ denied (fail-closed);
+  - `EnsureAllowedAsync` throws `TammaError("SAAS_PROVIDER_NOT_ALLOWED", severity High)` with
+    `Context.provider` set; event append failure is swallowed (decision/throw still returns).
+- [ ] Implement `ProviderGateContext`/`ProviderGateDecision` records, `ISaaSProviderGate`,
+  `SaaSProviderGate` (`InspectAsync` short-circuits single-user; SaaS denial emits event + metric;
+  `EnsureAllowedAsync` calls `InspectAsync` then throws on deny).
+- [ ] Implement `ProviderGatingMetrics` (Meter + `Counter<long> tamma.provider.gated`, tags
+  `provider`/`auth_model`/`reason`) mirroring `KekRotationMetrics`.
+- [ ] **Files:** create `ISaaSProviderGate.cs`, `SaaSProviderGate.cs`, `ProviderGatingMetrics.cs`
+  under `apps/tamma-elsa/src/Tamma.Api/Services/Security/`.
+
+**Done when:** gate tests green incl. the zero-side-effect single-user assertions and the
+event-append-failure-is-swallowed assertion.
+
+### Phase 3 — Execution boundary (resolver fail-closed backstop)
+
+- [ ] **Test first:** `tests/Tamma.Api.Tests/Providers/ProviderChainResolverSaaSGatingTests.cs`
+  - SaaS chain `[claude-code, anthropic]` ⇒ `claude-code` in `Skipped` w/ `ChainReason.SaaSIneligible`,
+    `anthropic` recommended;
+  - SaaS chain `[claude-code]` ⇒ `ErrorCode == "SAAS_PROVIDER_NOT_ALLOWED"`, `AllExhausted`,
+    one `AGENT.PROVIDER.GATED` event;
+  - single-user: both chains resolve `claude-code` normally, no skip-for-gating, no event;
+  - regression: existing `EMPTY_PROVIDER_CHAIN` / `NO_AVAILABLE_PROVIDER` / budget / CB tests
+    still pass unchanged.
+- [ ] Add `ChainReason.SaaSIneligible` to `ProviderChainTypes.cs`.
+- [ ] Modify `ProviderChainResolver`: add optional-ctor overload injecting `IProviderAuthRegistry?`
+  + `ITammaModeProvider?` (mirror the existing `IDiagnosticsService?` optional pattern so existing
+  unit tests don't all need rework); in the per-entry loop, before the CB switch, when
+  `Mode == SaaS && !registry.IsSaaSEligible(handle.Provider)` add to `skipped` with
+  `SaaSIneligible` and `continue`; when the ordered set is empty *due to* gating, return
+  `ErrorCode "SAAS_PROVIDER_NOT_ALLOWED"` and call the gate once (for the event/metric).
+- [ ] **Files:** modify `ProviderChainResolver.cs`, `ProviderChainTypes.cs`.
+
+**Done when:** resolver gating tests green AND every pre-existing resolver test still green.
+
+### Phase 4 — Selection boundary
+
+- [ ] **Test first:** `tests/Tamma.Api.Tests/Agents/AgentSelectionGatingTests.cs`
+  - SaaS create/version with a `CliToken` provider in the chain ⇒ **400** `SAAS_PROVIDER_NOT_ALLOWED`,
+    config **not** persisted, one event;
+  - SaaS all-`ApiKey` chain ⇒ persists;
+  - single-user `CliToken` chain ⇒ persists, no event.
+- [ ] Wire `ISaaSProviderGate.EnsureAllowedAsync` into the agent create/version write — call for the
+  primary + every fallback provider in the submitted config **before** `UpsertAsync`. Prefer
+  `AgentRegistryService` (32-2) if merged; else attach to `AgentEndpoints` create/version (~L89) and
+  leave a `// TODO(32-2): move to AgentRegistryService` hook.
+- [ ] **Files:** modify `AgentEndpoints.cs` (and/or `AgentRegistryService.cs` if present).
+
+**Done when:** selection tests green; rejected configs are provably absent from `agent_configs`.
+
+### Phase 5 — DI wiring + mode-matrix integration test + full-suite gate
+
+- [ ] Register in `Program.cs`: `IProviderAuthRegistry → ProviderAuthRegistry` (singleton),
+  `ISaaSProviderGate → SaaSProviderGate` (scoped — emits tenant-scoped events), `ProviderGatingMetrics`
+  (singleton); pass registry + mode into `ProviderChainResolver` registration.
+- [ ] **Mode-matrix integration test** (parameterised): `(mode ∈ {SingleUser, SaaS}) ×
+  (provider ∈ {anthropic, claude-code, unknown})` over both boundaries → assert the 12-cell
+  allow/deny/event/metric matrix.
+- [ ] Run the full C# suite via `sg docker -c "dotnet test ..."`; confirm green and
+  `has-pending-model-changes` reports none (no EF migration in this story — no schema change).
+
+**Done when:** full suite green; matrix test passes; no migration drift.
+
+---
+
+## Sequencing
+
+```
+Phase 1 (registry, pure) ─▶ Phase 2 (gate + event + metric)
+                                   │
+                   ┌───────────────┴───────────────┐
+                   ▼                                ▼
+            Phase 3 (resolver)              Phase 4 (selection)   ← parallel-safe after Phase 2
+                   └───────────────┬───────────────┘
+                                   ▼
+                          Phase 5 (DI + matrix + full suite)
+```
+
+Phase 1 is the only hard prerequisite for everything. Phases 3 and 4 are independent once Phase 2
+lands and may be split across subagents. Phase 5 closes the wave.
+
+## Risks
+
+- **CLI-provider enumeration drift.** If `BUILTIN_PROVIDER_NAMES` registers a CLI agent beyond
+  `claude-code`/`opencode` (e.g. `zen-mcp` is in the allowlist), missing it would let a CLI provider
+  through in SaaS. *Mitigation:* the Phase-1 "every allowlist entry has a deterministic auth model"
+  test forces an explicit decision per provider; cross-check the TS factory at impl time.
+- **Resolver regression.** `ProviderChainResolver` is load-bearing (Story 9-5 budget, CB). *Mitigation:*
+  null-tolerant optional-ctor (single-user / no-registry ⇒ untouched behaviour); Phase-3 includes a
+  full regression pass on existing resolver tests.
+- **Event-store failure masking the deny.** An `AppendAsync` failure must never turn a clean 400 into
+  a 500 or let a CLI provider slip through. *Mitigation:* event emission is fire-and-forget (logged,
+  swallowed); the deny decision is independent of the append. Asserted in Phase 2.
+- **32-2 timing.** `AgentRegistryService` may not be merged when this lands. *Mitigation:* selection
+  gate attaches to the existing `AgentEndpoints` write with a documented hook; the execution-boundary
+  gate (the security-critical backstop) ships fully regardless of 32-2.
+- **Double-emission.** Both boundaries could emit `AGENT.PROVIDER.GATED` for one logical request
+  (select then resolve). *Mitigation:* acceptable by design (distinct boundaries, distinct
+  reasons/tags); tests assert *exactly one* event *per boundary call*, not per request.
+- **Single-user pollution.** A bug making the gate active in single-user would break self-hosted CLI
+  usage. *Mitigation:* `Mode == SingleUser` short-circuit is the first line of `InspectAsync`; tests
+  assert zero events/metrics in single-user.
+
+## Acceptance criteria (plan-level — maps 1:1 to story ACs)
+
+- [ ] `IProviderAuthRegistry` classifies every allowlist provider ApiKey/CliToken; unknown ⇒
+  ineligible (fail-closed). *(Story AC1, AC6)*
+- [ ] SaaS create/version/select of a `CliToken` provider ⇒ 400 `SAAS_PROVIDER_NOT_ALLOWED`, named
+  provider, not persisted. *(AC2)*
+- [ ] Single-user allows `CliToken` providers with zero gating side effects. *(AC3)*
+- [ ] Resolver + managed entrypoint skip/deny SaaS-ineligible providers, fail closed, emit
+  `AGENT.PROVIDER.GATED`. *(AC4)*
+- [ ] Mode read once from `ITammaModeProvider`; gate is pure `(mode, provider)`. *(AC5)*
+- [ ] `ProviderAllowlist`/`ActionGate`/`ITammaModeProvider`/`IEventRepository` reused, not
+  duplicated; logic additive + fail-closed. *(AC6)*
+- [ ] `AGENT.PROVIDER.GATED` emitted with `{provider, authModel, mode, reason}` (+ role/action);
+  `tamma.provider.gated` counter incremented. *(AC7, AC8)*
+- [ ] Tests cover SaaS-reject-at-selection, SaaS-reject-at-execution, single-user-allow,
+  api-key-passes-both-modes, unknown-denied; full C# suite green, no migration drift. *(AC9)*

--- a/docs/superpowers/plans/2026-06-17-32-5-managed-agent-execution-layer-plan.md
+++ b/docs/superpowers/plans/2026-06-17-32-5-managed-agent-execution-layer-plan.md
@@ -1,0 +1,287 @@
+# Story 32-5 — Managed Agent Execution Layer (`IManagedAgent` over `IAIProvider`)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation.
+
+**Goal:** Introduce a single managed-LLM-agent execution abstraction (`IManagedAgent` /
+`ManagedAgent`) that turns a resolved agent (32-2) + per-tenant credential (32-3) + the SaaS gate
+(32-4) + RAG/context (Epic 6) + prompt render (Epic 27) + the **existing** inline LLM/tool-loop path
+(`CallLlmInlineActivity`) + sanitize + instrument + outcome capture into one coherent run that
+returns a structured `AgentRunResult`. This is the producer record every later Epic 32 story (action
+trail 32-6, outcome capture 32-8, cost emission 32-9, benchmarking 32-10) consumes. SaaS uses ONLY
+this path; CLI/token providers (`ICLIAgentProvider`) are excluded by the 32-4 gate.
+
+**Story file:** `docs/stories/epic-32/story-32-5/32-5-managed-agent-execution-layer.md`
+**Design spec:** `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`
+
+**Tech stack:** .NET 9 / Elsa 3 in `apps/tamma-elsa` (central API `Tamma.Api` + activities
+`Tamma.Activities` + engine). Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/` and
+`apps/tamma-elsa/tests/Tamma.Activities.Tests/` (xUnit). Docker-bound suites run via
+`sg docker -c "dotnet test ..."` (session docker group is stale; plain `dotnet build` needs no
+wrapper). **`packages/api` is DELETED — there is no TypeScript execution path; all of this is C#.**
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO new tool loop, sanitizer, validator, or compactor.** AC3 is "reuse, don't fork." The agentic
+  loop already exists, complete, inside `CallLlmInlineActivity.AgenticToolLoop(...)`
+  (sanitize → multi-turn call → tool-call validation → sequential/parallel tool exec → tool-output
+  sanitize + secret redaction → context compaction → token accounting). This plan EXTRACTS it into a
+  reusable seam and calls it from two places — it does not reimplement any of it.
+- **NO markup / invoicing / analytics.** `AgentRunResult.CostUsd` is the raw provider cost basis from
+  `IProviderPricingService.Compute`. Markup is 34-5; invoicing 35; analytics 36. This story is a
+  *producer* only.
+- **NO new providers.** Reuse the existing provider stack and `IProviderPricingService`.
+- **NO change to single-turn `CallLlmActivity`/`CallLlmInlineActivity` behaviour.** Non-agent inline
+  calls keep working byte-for-byte; only agent-driven steps move to `RunManagedAgentActivity`. The
+  existing `CallLlmInlineActivitySanitizationTests` are the regression net for the extraction.
+- **NO per-user override layer / cross-tenant data.** Performance/action data is ALWAYS tenant-scoped
+  (design spec). `AGENT.RUN.*` events go to the tenant `IEventRepository`.
+- **NO implementation of 32-2/32-3/32-4 here.** Code to their interfaces; this story is gated behind
+  them and uses fakes in tests until they land.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main)
+
+| Seam | Where it is today | How 32-5 uses it |
+|---|---|---|
+| **Agentic tool loop** | `apps/tamma-elsa/src/Tamma.Activities/LlmCall/CallLlmInlineActivity.cs` — private `AgenticToolLoop(...)` (lines ~396–834): multi-turn Anthropic/OpenAI calls, `IToolCallValidator`, `IToolExecutorRegistry`, `ParallelToolExecutor`, `ContextCompactor`, `ToolLoopEventEmitter`, token accounting; sanitization via `IContentSanitizer` (input/output/tool-output) + `ToolOutputHelper.RedactSecrets`. | **Extract** into `IInlineToolLoopRunner`/`InlineToolLoopRunner` (verbatim move); activity delegates; `ManagedAgent` calls the same runner. |
+| **Sanitizer** | `Tamma.Activities/Security/IContentSanitizer.cs` + `Tamma.Api/Services/Sanitization/ContentSanitizer.cs` | Reused inside the extracted runner — unchanged. |
+| **Agent resolution** | `Tamma.Api/Services/Agents/IAgentResolverService.cs` → `ResolvedAgentConfig` (Provider, Model, Temperature, MaxTokens, TokenBudget, Tools, SystemPrompt, MaxBudgetUsd, PermissionMode, AllowedTools). `ResolveForPhaseAsync(tenantId, phase, role, TaskOverrides?)` clamps budget/tools. | 32-2 extends this to return `IManagedAgent`; 32-5 calls it at composition step 1. |
+| **Cost basis** | `Tamma.Api/Services/Providers/IProviderPricingService.cs` — `decimal Compute(string provider, string? model, int inputTokens, int outputTokens)`. | `AgentRunResult.CostUsd = _pricing.Compute(...)` at step 9. |
+| **DCB events** | `Tamma.Data/Repositories/IEventRepository.cs` — `Task<DomainEvent> AppendAsync(DomainEvent)`, tenant-scoped. Existing `AGENT.DISPATCH.*` family in analytics/alerts. | Emit `AGENT.RUN.STARTED/SUCCESS/FAILED` via `AppendAsync`, tenant-scoped. |
+| **Budget / circuit / concurrency guards** | `Tamma.Activities/LlmCall/CheckBudgetActivity.cs`, `CheckCircuitBreakerActivity.cs`, `CheckLlmConcurrencyActivity.cs`. | `ManagedAgent` reuses the budget-check logic at step 4 (typed `BUDGET_EXCEEDED` failure). |
+| **Context / RAG** | `Tamma.Activities/Context/AssembleContextActivity.cs` (`CodeActivity<AssembledContext>`) + `packages/intelligence/src/rag/rag-pipeline.ts` (TS RAG pipeline used by the engine via the central API). | Step 5 assembles context; fed to prompt render. (If the C# context assembler is sufficient, call it directly; otherwise round-trip per Epic 9.) |
+| **Prompt + convention render** | Epic 27 prompt store + convention store (central API; engine round-trips). Resolution is tenant → system → error, NEVER empty/plain. | Step 6 renders system+user prompt from agent config + assembled context. |
+| **Mode** | `Tamma.Api/Services/PromptStore/TammaMode.cs` — `ITammaModeProvider` (SingleUser | SaaS), process-stable. | Step 3 gate consults mode; CLI-backed agent in SaaS → typed `GATE_DENIED`. |
+
+**Key insight:** the only genuinely new code is the *orchestration shell* (`ManagedAgent`),
+the *records* (`ManagedAgentRequest`, `AgentRunResult`), the *Elsa activity*
+(`RunManagedAgentActivity`), and the *extraction* of the existing loop into a runner. Everything else
+is wiring existing collaborators in order with typed-failure exits.
+
+---
+
+## Architecture
+
+**Compose, instrument, capture — over the existing inline path:**
+
+```
+RunManagedAgentActivity (Elsa)            -- workflow call site (replaces ad-hoc role->llm dispatch)
+        |
+        v
+IManagedAgentResolver.Resolve(tenant, role/agentId)   -- 32-2, returns IManagedAgent
+        |
+        v
+IManagedAgent.RunAsync(ManagedAgentRequest)           -- ManagedAgent orchestrates:
+  1 resolve agent config (32-2)                        \
+  2 resolve credential   (32-3)  BYOK -> platform       |  typed-failure exits:
+  3 SaaS gate            (32-4)  CLI in SaaS => denied   |  NO_CREDENTIAL / GATE_DENIED /
+  4 budget guard                                          >  BUDGET_EXCEEDED / PROVIDER_ERROR /
+  5 assemble context + RAG (Epic 6)                      |  LOOP_EXHAUSTED  -> AgentRunResult{Success=false}
+  6 render prompt (Epic 27)                              |  (NEVER a bare throw)
+  7 emit AGENT.RUN.STARTED                              /
+  8 IInlineToolLoopRunner.RunAsync(...)  <-- REUSED inline seam (sanitize+validate+compact inside)
+  9 cost = IProviderPricingService.Compute(...)
+ 10 map -> AgentRunResult{...}
+ 11 emit AGENT.RUN.SUCCESS | AGENT.RUN.FAILED  (exactly one terminal event)
+ 12 return AgentRunResult
+```
+
+Per-mode ownership (CLAUDE.md two-scoping-model rule): single-user = LLM-API **and** CLI backends, the
+sole user's credential, events in the user's store; SaaS = LLM-API backend **only**, tenant BYOK →
+platform credential, events in the tenant `t_<hex>` store, data never cross-tenant. Mode from
+`ITammaModeProvider`.
+
+---
+
+## Task breakdown
+
+Order: T1 (records) → T2 (extract loop) → T3 (ManagedAgent core) → T4 (failure paths + events) →
+T5 (Elsa activity + wiring) → T6 (mode/RBAC + isolation tests). T1 and T2 are parallel-safe; T3
+needs both.
+
+### T1 — Records + event-type constants (`AgentRunResult`, `ManagedAgentRequest`)
+
+**Scope:** The producer/consumer data shapes. No behaviour.
+
+**Files (new):** `Services/Agents/ManagedAgentRequest.cs`, `Services/Agents/AgentRunResult.cs`
+(+ `ToolCallSummary`), `Services/Agents/AgentRunEventTypes.cs` (`AGENT.RUN.STARTED`,
+`AGENT.RUN.SUCCESS`, `AGENT.RUN.FAILED`), `Services/Agents/IManagedAgent.cs`.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/AgentRunResultTests.cs` — record equality, required
+fields enforced, `Success=false` always carries `FailureCode`+`FailureReason`, success carries none;
+`CredentialSource` is one of `byok|platform`.
+
+**Acceptance:**
+- [ ] `AgentRunResult` has all AC2 fields (AgentId, Version, Provider, Model, Role, InputTokens,
+      OutputTokens, CostUsd, DurationMs, Success, ResponseText, ToolCalls, CorrelationId,
+      CredentialSource, FailureCode?, FailureReason?).
+- [ ] Builds clean; no analyzer warnings.
+
+### T2 — Extract the agentic tool loop into a reusable seam (pure refactor, AC3)
+
+**Scope:** Move `CallLlmInlineActivity.AgenticToolLoop(...)` and its private helpers (multi-turn
+builders, parsers, `LoadProviderConfig`, sanitize/redact calls, compaction call) verbatim into
+`InlineToolLoopRunner : IInlineToolLoopRunner`. The activity becomes a thin delegate. **No logic
+change.**
+
+**Files:** new `Tamma.Activities/LlmCall/IInlineToolLoopRunner.cs`,
+`Tamma.Activities/LlmCall/InlineToolLoopRunner.cs`; modify
+`Tamma.Activities/LlmCall/CallLlmInlineActivity.cs` (delegate to runner; keep single-turn path as-is);
+DI registration alongside the activity.
+
+**Seam shape (provider/model/prompt/tools/credential in; result+tokens+toolcalls out):**
+```csharp
+public interface IInlineToolLoopRunner
+{
+    Task<InlineToolLoopResult> RunAsync(
+        string provider, LlmProviderConfig providerConfig, string model,
+        string systemPrompt, string userPrompt, int maxTokens, double temperature,
+        IReadOnlyList<ResolvedTool>? tools, ToolLoopConfig loopConfig,
+        string workflowInstanceId, CancellationToken ct);
+}
+// InlineToolLoopResult { NormalizedLlmResponse Response, int InputTokens, int OutputTokens,
+//                        int Turns, bool Exhausted, IReadOnlyList<ToolCallSummary> ToolCalls }
+```
+
+**Tests (first):** `tests/Tamma.Activities.Tests/LlmCall/InlineToolLoopRunnerTests.cs` — port/point
+the existing loop assertions at the runner; **and the existing
+`CallLlmInlineActivitySanitizationTests` MUST pass unchanged** (the regression net proving no drift).
+
+**Acceptance:**
+- [ ] `CallLlmInlineActivity` delegates to `InlineToolLoopRunner`; its tool-loop output variables are
+      byte-for-byte identical (token totals, turns, exhausted, sanitized output).
+- [ ] `grep` confirms exactly ONE copy of the loop / one sanitizer call-site cluster (no fork).
+- [ ] Full activities suite green via `sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Activities.Tests/..."`.
+
+### T3 — `ManagedAgent` core composition (happy path)
+
+**Scope:** `ManagedAgent : IManagedAgent`. Wire collaborators in order 1→10 for the success path;
+return a fully-populated `AgentRunResult`. Cost via `IProviderPricingService`.
+
+**Files:** new `Services/Agents/ManagedAgent.cs`, `Services/Agents/IManagedAgentResolver.cs` (thin —
+returns an `IManagedAgent` for `(tenantId, role/agentId)`; concrete impl may live in 32-2, this story
+defines/consumes the interface).
+
+**Collaborators (constructor-injected interfaces — fakes in tests):** `IAgentResolverService` (32-2),
+`IProviderCredentialResolver` (32-3, yields `{ApiKey, BaseUrl, Source}`), `ISaasProviderGate` (32-4),
+budget guard (reuse `CheckBudgetActivity` logic behind a small interface), context assembler (Epic 6),
+prompt renderer (Epic 27), `IInlineToolLoopRunner` (T2), `IProviderPricingService`,
+`IEventRepository`, `ITammaModeProvider`, `ILogger<ManagedAgent>`.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/ManagedAgentTests.cs` — happy path: every field
+populated; collaborators each called once in order; `CostUsd == _pricing.Compute(...)`;
+`CredentialSource` copied from credential resolver.
+
+**Acceptance:**
+- [ ] Happy-path `RunAsync` returns `AgentRunResult{Success=true}` with **all** fields populated.
+- [ ] BYOK credential → `CredentialSource="byok"`; platform → `"platform"`.
+
+### T4 — Typed failure paths + DCB events (AC7, AC8)
+
+**Scope:** Each composition step gets a typed-failure exit mapping to
+`AgentRunResult{Success=false, FailureCode, FailureReason}` with accrued tokens/cost. Emit exactly
+one `AGENT.RUN.STARTED` (before the loop, step 7) and exactly one terminal `AGENT.RUN.SUCCESS|FAILED`.
+No expected failure throws.
+
+**Failure codes:** `NO_CREDENTIAL` (step 2), `GATE_DENIED` (step 3), `BUDGET_EXCEEDED` (step 4),
+`PROVIDER_ERROR` (step 8 unsuccessful response / exception), `LOOP_EXHAUSTED` (step 8 exhausted +
+no usable response). Contract violation (null request) MAY throw `ArgumentNullException`.
+
+**Event tags:** `{ agentId, version, provider, model, role, correlationId, credentialSource,
+tenantId }`; FAILED adds `failureCode`.
+
+**Tests (first):** extend `ManagedAgentTests` — one test per failure code: tool loop NOT invoked for
+pre-loop failures; accrued tokens/cost preserved for in-loop failures; `AGENT.RUN.FAILED` emitted
+exactly once; never a propagated exception; "exactly one terminal event per run" invariant via a fake
+`IEventRepository` that records appends.
+
+**Acceptance:**
+- [ ] All five failure codes produce typed results; none throw.
+- [ ] Every `RunAsync` return is preceded by exactly one terminal DCB event (STARTED only emitted
+      once the run reaches the loop; pre-loop failures emit STARTED+FAILED or FAILED-only per chosen
+      contract — pin it in a test).
+- [ ] Event tags match AC8.
+
+### T5 — `RunManagedAgentActivity` + DI wiring (AC5)
+
+**Scope:** Elsa activity exposing `IManagedAgent` to workflows; replaces the ad-hoc
+`ResolveAgentConfig → ResolveLlmPrompt → ResolveTools → CheckBudget → CallLlm` chain for managed
+agents. Resolves `IManagedAgent` via `IManagedAgentResolver`, runs it, serializes `AgentRunResult` to
+the `AgentRunResult` workflow variable.
+
+**Files:** new `Tamma.Activities/AgentDispatch/RunManagedAgentActivity.cs`,
+`Tamma.Api/Extensions/ManagedAgentServiceCollectionExtensions.cs`; modify `Tamma.Api/Program.cs`
+(register `IManagedAgent`, `IManagedAgentResolver`, `IInlineToolLoopRunner`, and the activity —
+mirror existing activity registration patterns).
+
+**Tests (first):** `tests/Tamma.Activities.Tests/AgentDispatch/RunManagedAgentActivityTests.cs` —
+activity inside a minimal Elsa workflow writes a serialized `AgentRunResult`; one STARTED + one
+terminal event per run via a fake `IEventRepository`; inputs (role/phase/userPrompt/issue/overrides)
+flow into `ManagedAgentRequest`.
+
+**Acceptance:**
+- [ ] `RunManagedAgentActivity` produces the `AgentRunResult` variable for both success and failure.
+- [ ] DI resolves the whole chain at host startup (smoke test / `WebApplicationFactory`).
+
+### T6 — Mode separation, RBAC posture & isolation (AC4)
+
+**Scope:** Prove SaaS uses ONLY the managed path and CLI-backed agents are gate-denied; prove
+single-user allows CLI backends; prove events land in the tenant store and never cross-tenant.
+
+**Files:** extend `ManagedAgentTests` (mode matrix) + a small isolation test asserting
+`AGENT.RUN.*` append uses the tenant-scoped `IEventRepository` with `TenantId` set in SaaS.
+
+**Tests (first):**
+- SaaS + CLI-backed agent → `GATE_DENIED` typed result, loop never invoked.
+- SaaS + LLM-API agent → runs normally.
+- single-user + CLI-backed agent → gate passes (allowed).
+- two tenants → events tagged with their own `TenantId`; no leakage (fake repo asserts per-tenant).
+
+**Acceptance:**
+- [ ] Mode matrix passes; SaaS never reaches a CLI provider.
+- [ ] `AGENT.RUN.*` events carry the correct `tenantId`; cross-tenant assertion holds.
+
+---
+
+## Story order & dependencies
+
+External prereqs (must land first): **32-2** (resolver/`IManagedAgent` return), **32-3**
+(credential resolver + `CredentialSource`), **32-4** (SaaS gate). Code to their interfaces; use fakes
+until landed. Internal: T1 ∥ T2 → T3 → T4 → T5 → T6. Downstream consumers (32-6/8/9) depend on this;
+they are NOT blockers.
+
+## Verification
+
+```bash
+# build (no docker wrapper needed)
+dotnet build apps/tamma-elsa/Tamma.sln
+# tests (docker-bound suites need the sg wrapper; session docker group is stale)
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~Agents"
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Activities.Tests/ --filter FullyQualifiedName~LlmCall|FullyQualifiedName~AgentDispatch"
+# AC3 no-fork check: exactly one tool-loop implementation
+grep -rn "AgenticToolLoop\|class InlineToolLoopRunner" apps/tamma-elsa/src
+```
+
+## Risks
+
+- **Extraction drift (T2, AC3):** the loop is large and security-critical (injection sanitization at
+  every boundary). Mitigation: pure move, zero logic edits, existing `CallLlmInlineActivitySanitizationTests`
+  unchanged as the net. If those tests need edits, the extraction is wrong — stop and re-do as a move.
+- **Lost run records (T4, AC7):** any throw on an expected failure drops the record. Mitigation: the
+  "exactly one terminal event per run" invariant test + per-failure-code tests; only null-request may
+  throw.
+- **CLI leak into SaaS (T6, AC4):** gate must run BEFORE any provider call. Mitigation: gate at step 3;
+  explicit SaaS+CLI test asserting the loop is never invoked.
+- **Cost mis-attribution:** `CredentialSource` must be copied from 32-3, never re-derived. Mitigation:
+  both-branch tests; keep `CostUsd` at provider basis (no markup — that's 34-5).
+- **Double event emission:** the reused tool-loop seam emits its own *tool-loop streaming* events;
+  `ManagedAgent` owns the *run-level* `AGENT.RUN.*` events. Keep the two event families distinct so
+  there's no double counting in 32-6/32-9.
+- **Dependency timing:** 32-2/3/4 may land after this is scheduled. Mitigation: interfaces + fakes;
+  this story is the integrator, not the owner, of those seams.

--- a/docs/superpowers/plans/2026-06-17-32-6-agent-action-trail-in-tenant-store-plan.md
+++ b/docs/superpowers/plans/2026-06-17-32-6-agent-action-trail-in-tenant-store-plan.md
@@ -1,0 +1,247 @@
+# Story 32-6 — Agent Action Trail (DCB events tagged agent_id) in Tenant Store
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation. Docker-bound C# suites run via `sg docker -c "dotnet test ..."`; the build
+> needs no wrapper.
+
+**Goal:** Capture a complete, queryable **action trail** for every managed agent run as DCB events
+written to the **tenant-scoped** `domain_events` stream — tagged with `agentId` + `agentVersion` +
+`role` + `provider` + `model` + `promptRef` + `issueId` + `iteration` + `correlationId` +
+`credentialSource` — and expose a per-agent, tenant-isolated, member-readable action-history query
+API. This is the audit/analytics substrate that 32-8/32-9/32-10/32-11 consume. Action data is
+**ALWAYS tenant-scoped**: a platform admin cannot read another tenant's trail, and one public agent
+definition produces N independent per-tenant trails.
+
+**Story file:** `docs/stories/epic-32/story-32-6/32-6-agent-action-trail-in-tenant-store.md`
+
+**Design source:** `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`
+(§"Ownership, visibility & data scoping" + §"Tracking: actions + performance + learning").
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane API + Elsa engine).
+Tests in `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/` (xUnit). **`packages/api` is deleted** — all
+work is C#.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO new table.** The trail reuses the existing tenant `domain_events` (`DomainEvent` entity).
+  No projection table, no read-model materialization — that is 32-10's job (leaderboards). This
+  story only writes events and exposes a thin read over them.
+- **NO new event infrastructure.** `IEventRepository.AppendAsync` already routes tenant-scoped
+  events to `t_<hex>` via `ITenantDbContextFactory`; `SequenceNumber` already exists as the
+  `BIGSERIAL` cursor. Reuse both.
+- **NO cross-tenant or platform-admin read path.** Not "guarded" — *unbuilt*. The repository throws
+  `NotSupportedException` on null-tenant paginated reads; no `OwnerAccess` route is added. A platform
+  owner who owns a public agent sees none of any tenant's runs of it.
+- **NO inlined blobs.** Prompt bodies, tool args/results, RAG context → `promptRef`/`blobRef` +
+  sanitized values only. Reuse the existing `SecureAgentProvider` sanitization seam; do not write a
+  new sanitizer.
+- **NO benchmarking/leaderboard/learning logic.** 32-9 (cost emission), 32-10 (projections), 32-11
+  (learning) consume this trail; they are out of scope. This story only guarantees the data is
+  captured, isolated, and queryable.
+- **NO `ProviderDiagnostic` schema change.** Link via the existing `CorrelationId` + `AgentType`
+  columns. A dedicated `agentId` column is a later additive migration if ever needed.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+| Asset | Location | What it gives us |
+|---|---|---|
+| `DomainEvent` (DCB row) | `apps/tamma-elsa/src/Tamma.Data/Entities/DomainEvent.cs` | `Id`, `Type`, `TenantId`, `IssueNumber`, JSONB `Tags`/`Metadata`/`Data`, `CreatedAt`, **`SequenceNumber` (`BIGSERIAL`)** — the cursor. Reused verbatim, no change. |
+| `IEventRepository` / `EventRepository` | `apps/tamma-elsa/src/Tamma.Data/Repositories/{IEventRepository,EventRepository}.cs` | `AppendAsync` resolves `evt.TenantId ?? tenantContext.TenantId` → writes through `ITenantDbContextFactory.CreateAsync(tid)` (the `t_<hex>` schema). `QueryWithPaginationAsync`/`ListByTenantAsync` are tenant-scoped and **throw `NotSupportedException` on null tenant** — the isolation backbone. We add `QueryAgentTrailAsync` alongside. |
+| Tenant context + factory | `apps/tamma-elsa/src/Tamma.Data/{ITenantContext,TenantContext}.cs`, `ITenantDbContextFactory` | Schema-per-tenant routing — the structural isolation plane. No new plumbing. |
+| Existing DCB emission precedent | `apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs` (`UpdateConfig`, ~93–113) | Shows the canonical `DomainEvent { Type, TenantId, Tags=flat strings, Metadata=envelope, Data }` shape to mirror. |
+| `ProviderDiagnostic` | `apps/tamma-elsa/src/Tamma.Data/Entities/ProviderDiagnostic.cs` | Already has `CorrelationId`, `AgentType`, `TenantId`, tokens, cost. Link key for AC 8 — no schema change. |
+| `DiagnosticsService` | `apps/tamma-elsa/src/Tamma.Api/Services/Diagnostics/DiagnosticsService.cs` | `RecordEventAsync(ProviderDiagnostic)` — thread the run's `correlationId` + `AgentType` here. |
+| Tenant-scope endpoint precedent | `apps/tamma-elsa/src/Tamma.Api/Endpoints/AlertEndpoints.cs` (`ListTenantAlerts`, ~576) | Exact pattern for a member-readable `/api/v1/orgs/{tenantId}/...` list filtering `tenant_id` + paging. |
+| Path-tenant gate | `apps/tamma-elsa/src/Tamma.Api/Program.cs` (~350, ~1512 `orgs` group, `RequireTenantMembershipFilter`) | `/api/v1/orgs/{tenantId}/*` under `MemberAccess` + `RequireTenantMembershipFilter`. Map the trail endpoints here. |
+| Agent resolver (32-2) | `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentResolverService.cs` | Source of `provider`/`model`/`role`/version for tags until 32-1's entity lands. |
+| Sanitization seam | `SecureAgentProvider` (Content Sanitization plan; `packages/shared/src/security/` design + C# equivalent) | Redaction before persistence. Reuse. |
+
+**Not-yet-existing (mark NEW / prerequisite):**
+- `Agent`/`AgentVersion` entity (`Tamma.Data/Entities/Agent.cs`) — **NEW in story 32-1** (not present
+  today). Supplies `agentId`/`agentVersion`. Hard prerequisite; until it lands, derive identity from
+  the resolved config.
+- `IManagedAgent` execution layer — **story 32-5**. The producer that calls the emitter. Hard
+  prerequisite for Task 2 wiring.
+- Panel/bug seams — **stories 32-7/32-8**. Emitter API ships now; those call sites stub forward.
+
+---
+
+## Architecture
+
+**Producer → emitter → tenant event store → tenant-scoped read.** No new storage layer.
+
+```
+32-5 IManagedAgent run ──┐
+32-7 panel aggregate ────┤── IAgentTrailEmitter ──► IEventRepository.AppendAsync(DomainEvent)
+32-8 review/gate bug  ────┘     (sanitize + tag)          │ TenantId = resolving tenant
+                                                          ▼
+                                          t_<hex>.domain_events  (schema-per-tenant)
+                                                          ▲
+GET /api/v1/orgs/{tenantId}/agents/{agentId}/runs ───────┤  IEventRepository.QueryAgentTrailAsync
+GET /api/v1/orgs/{tenantId}/agents/{agentId}/trail ──────┘  (agentId Tags predicate, SequenceNumber cursor)
+
+ProviderDiagnostic { CorrelationId, AgentType } ── linked by (correlationId, agentId) ── 32-9/32-10
+```
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns the **action trail** of a run? | The sole user (their instance, their schema). Trail is `TenantId`-scoped to the personal tenant. | The tenant that ran the agent. Visible to its members via `/api/v1/orgs/{tenantId}/agents/...`. |
+| Can a platform admin read it? | N/A (no platform/tenant split). | **No.** No `OwnerAccess` route exists and `IEventRepository` cannot return cross-tenant tenant-scoped events. Even the platform admin who owns the *public agent definition* sees none of any tenant's runs. |
+| Public/system agent run? | Trail belongs to the sole user. | One public definition → N independent per-tenant trails; each tenant sees only its own. |
+| Who can read via API? | The user. | Any tenant **member** (read-only; no mutation surface). |
+| Mode source | `ITammaModeProvider` (process-stable) | same |
+
+The isolation guarantee is **structural** (schema-per-tenant + repository null-tenant guards), not an
+app filter — that is the single most important property to preserve and test.
+
+---
+
+## Task breakdown
+
+### T1: Trail emission core (no producer wiring yet)
+
+**Scope:** The emitter seam, tag builder, context/record types, event-type constants, redaction,
+non-blocking contract, DI. No call sites changed yet.
+
+**Files (all NEW under `src/Tamma.Api/Services/Agents/`):**
+- `AgentTrailContext.cs` — `AgentTrailContext` (identity/tags fields) + records `AgentRunOutcome`,
+  `ToolCallRecord`, `IterationRecord`, `PanelRecord`, `BugRecord`.
+- `AgentTrailTags.cs` — `Build(AgentTrailContext)` → flat-string JSONB (the shared tag contract).
+- `AgentTrailEventTypes.cs` — constants: `AGENT.TASK.SUCCESS/FAILED/PARTIAL`,
+  `AGENT.TOOL_CALL.SUCCESS/FAILED`, `AGENT.ITERATION.COMPLETED`, `AGENT.PANEL.AGGREGATED`,
+  `REVIEW.BUG.RECORDED`, `AGENT.TRAIL.WRITE_FAILED`.
+- `IAgentTrailEmitter.cs` + `AgentTrailEmitter.cs` — `RunCompletedAsync`, `ToolCallAsync`,
+  `IterationCompletedAsync`, `PanelAggregatedAsync`, `BugRecordedAsync`. Each builds a `DomainEvent`
+  with `TenantId = ctx.TenantId`, sanitized `Data`, full `Tags`; appends via `IEventRepository`;
+  **never throws into the run** (catch → WARN → best-effort `AGENT.TRAIL.WRITE_FAILED` breadcrumb).
+- Wire DI in `Program.cs` (mirror existing `Services/Agents/` registrations).
+
+**Tests first (`tests/Tamma.Api.Tests/Agents/AgentTrailEmitterTests.cs`):**
+- [ ] Each family emits the right `Type` and full required tag set; `REVIEW.BUG.RECORDED` carries `bugType`.
+- [ ] `Data` contains only refs/sanitized values for secret-shaped input (redaction).
+- [ ] `AppendAsync` failure does NOT propagate; WARN logged; `AGENT.TRAIL.WRITE_FAILED` attempted.
+- [ ] `TenantId` on every emitted event = the context's resolving tenant.
+
+**Acceptance:**
+- [ ] Emitter is the single seam; no hand-built `DomainEvent` outside it.
+- [ ] Non-blocking contract holds under induced failure.
+- [ ] Full C# suite stays green.
+
+### T2: Wire emission into the managed run, panels, diagnostics link
+
+**Scope:** Call the emitter from the producers; thread one `correlationId` through trail + diagnostics.
+
+**Files (modify):**
+- 32-5 `IManagedAgent` execution path — call `RunCompletedAsync` (terminal), `ToolCallAsync` (per
+  tool loop step), `IterationCompletedAsync` (per design/review iteration). Depends on 32-5.
+- 32-7/32-8 seams — `PanelAggregatedAsync` (`AggregatePanelActivity`), `BugRecordedAsync`
+  (review/gate). Forward-compatible: if those land later, ship the calls behind their seam and stub.
+- `Services/Diagnostics/DiagnosticsService.cs` (or the run that calls `RecordEventAsync`) — set
+  `ProviderDiagnostic.CorrelationId` = run `correlationId` and `AgentType` = role so AC 8's link
+  holds.
+
+**Tests first:**
+- [ ] `tests/Tamma.Api.Tests/Agents/AgentTrailDiagnosticsLinkTests.cs` — a run's `AGENT.TASK.*`
+  event and its `ProviderDiagnostic` rows share `correlationId` + `agentId`; re-key by agent yields
+  expected rollup.
+- [ ] Run-completion emits exactly one terminal `AGENT.TASK.*`; tool steps and iterations each emit.
+
+**Acceptance:**
+- [ ] One `correlationId` spans trail + diagnostics for a run.
+- [ ] Producer wiring does not change run semantics (run still completes on trail failure — T1 contract).
+
+### T3: Tenant-scoped query API
+
+**Scope:** `QueryAgentTrailAsync` + two member-readable endpoints under `/api/v1/orgs/{tenantId}`.
+
+**Files:**
+- Modify `Tamma.Data/Repositories/IEventRepository.cs` — add
+  `QueryAgentTrailAsync(Guid tenantId, Guid agentId, string? typePrefix, DateTimeOffset? from,
+  DateTimeOffset? to, string? role, string? provider, string? outcome, long? cursor, int limit)`.
+- Modify `Tamma.Data/Repositories/EventRepository.cs` — implement it: `tenantDbFactory.CreateAsync`,
+  `Where(e => e.TenantId == tid)`, `agentId` Tags JSONB predicate, optional `type` prefix +
+  date/role/provider/outcome filters, `WHERE SequenceNumber < cursor` (or `>` per order),
+  `OrderByDescending(SequenceNumber)`, `Take(limit)`. **Throw `NotSupportedException` on empty
+  tenant** — match the existing paginated-read guard.
+- New `Tamma.Api/Endpoints/AgentTrailEndpoints.cs` — `ListRuns` (typePrefix `AGENT.TASK`) and
+  `ListTrail` (all `AGENT.`/`REVIEW.BUG.`). `tenantId`/`agentId` route-bound; `nextCursor`/`hasMore`
+  wire shape; paging defaults 50 / max 500 (mirror `AlertEndpoints`).
+- New `Tamma.Api/Dtos/Agents/AgentTrailDtos.cs` — run + trail-event DTOs.
+- Modify `Program.cs` — map both under the `orgs` group with `RequireTenantMembershipFilter`.
+
+**Tests first (`tests/Tamma.Api.Tests/Agents/AgentTrailEndpointsTests.cs`):**
+- [ ] `runs` returns only `AGENT.TASK.*` for the agent + tenant; filters (date/role/provider/outcome) apply.
+- [ ] `trail` returns the full family stream for the agent + tenant.
+- [ ] Cursor: page through >page-size events incl. same-millisecond `CreatedAt`; stable order via
+  `SequenceNumber`; no dup/skip at boundaries; `nextCursor`/`hasMore` correct.
+- [ ] Member can read; no mutation endpoint exists.
+
+**Acceptance:**
+- [ ] Both endpoints page on `SequenceNumber`, filterable per AC 5.
+- [ ] Endpoint shape identical between modes; the path-tenant gate + repository scoping enforce isolation.
+
+### T4: Tenant-isolation test suite (the load-bearing AC)
+
+**Scope:** Prove AC 4 across every path. Highest priority — write alongside T3, do not defer.
+
+**Files:** `tests/Tamma.Api.Tests/Agents/AgentTrailIsolationTests.cs`.
+
+**Tests:**
+- [ ] Seed trail events for tenant A and B; `GET /orgs/{B}/agents/{agentId}/trail` returns only B's
+  rows, never A's.
+- [ ] A member of A hitting B's path → `RequireTenantMembershipFilter` rejects (403/404).
+- [ ] Platform owner has **no route** to a tenant's trail; `IEventRepository` null-tenant paginated /
+  trail read throws `NotSupportedException`.
+- [ ] A run of a public/system agent by tenant A leaves a trail only in A's schema — none on CP, none
+  visible to platform owner, none to tenant B.
+
+**Acceptance:**
+- [ ] Zero cross-tenant trail reads possible via any code path.
+
+---
+
+## Task order & dependencies
+
+T1 → T2 (needs 32-5 producer; soft on 32-7/32-8) ; T3 → T4 (write T4 with T3). T1 is the only hard
+prerequisite within the story; T3/T4 only need T1 + the seeded `DomainEvent` shape. Story-level
+hard prerequisites: **32-1** (agent identity) and **32-5** (the producing run). 32-3 (credential
+source) and 32-7/32-8 (panel/bug producers) are soft — default/stub if not yet landed.
+
+## Risks
+
+- **Cross-tenant leakage (the #1 invariant):** mitigated by schema-per-tenant routing +
+  `NotSupportedException` null-tenant guards + `RequireTenantMembershipFilter` + the T4 suite.
+  Watch: any future "admin view all agent runs" request must fan out per-tenant explicitly — do NOT
+  relax the repository guard. The platform admin owning a public agent definition must still see zero
+  tenant data; pin this in T4.
+- **Trail on the hot run path:** every step appends a row. Tool-heavy runs can be chatty — keep `Data`
+  blob-referenced and lean; the non-blocking emitter must use a short append timeout so a slow tenant
+  DB never stalls a run. If volume becomes a problem, batch emission per run (cheap follow-up) — not
+  in scope now.
+- **Identity before 32-1:** `agentId`/`agentVersion` come from resolved-config identity until the
+  entity lands; ensure the tag value is stable (the join key for all of 32-10) — a churning id breaks
+  history. Treat 32-1 as a hard gate before merge.
+- **Cursor correctness on bursts:** `SequenceNumber` (not `CreatedAt`) is the cursor — the existing
+  `QueryWithPaginationAsync` already tie-breaks on it; match exactly. Same-millisecond burst test in
+  T3 is the guard.
+- **Diagnostics link drift:** if the run forgets to thread `correlationId`/`AgentType` into
+  `RecordEventAsync`, 32-9/32-10 can't re-key by agent. AC 8's link-integrity test is the tripwire.
+- **Redaction completeness:** a missed sanitization path leaks prompt/secret content into an immutable
+  event stream (un-deletable audit). Route ALL `Data` through the sanitizer in the emitter (one
+  choke point), and assert it in T1's redaction test.
+
+## Verification
+
+- `sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests --filter FullyQualifiedName~Agents.AgentTrail"`
+  green (isolation, emitter, endpoints, diagnostics-link).
+- Full `apps/tamma-elsa` suite stays green (no regression).
+- Manual: run a managed agent in a dev tenant, hit `GET /api/v1/orgs/{tenantId}/agents/{agentId}/runs`
+  and `/trail`, confirm events land in the tenant schema only and a second tenant sees nothing.

--- a/docs/superpowers/plans/2026-06-17-32-7-multi-agent-design-review-panels-in-elsa-plan.md
+++ b/docs/superpowers/plans/2026-06-17-32-7-multi-agent-design-review-panels-in-elsa-plan.md
@@ -1,0 +1,298 @@
+# Story 32-7 — Multi-Agent Design/Review Panels in Elsa (strategy-driven)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes failing
+> tests before implementation. Run C# tests in `apps/tamma-elsa` as `sg docker -c "dotnet test ..."`
+> for docker-bound suites (the build itself needs no wrapper).
+
+**Goal:** Generalize the two hardcoded panels (`TriagePanelReviewWorkflow`, `PlanReviewWorkflow`)
+into reusable, strategy-driven Elsa primitives — `RunAgentPanelActivity` (fan a step out to N
+agents of a role, each via `IManagedAgent`) and `AggregatePanelActivity` (combine member outputs
+under a selectable strategy: `single`, `consensus`, `lead+critics`, `llm-judge`). Panels back both
+**design** steps (default `lead+critics`) and **review** steps (default `consensus`, incl.
+specialized security/performance/visual reviewers), loop on `iterationCount` until gates pass or
+max, emit per-member action-trail entries (32-6) tagged `panelId`+`memberPosition` plus a single
+`AGENT.PANEL.AGGREGATED` event, and respect public/private visibility + SaaS provider gating +
+per-tenant credentials/budgets for every member.
+
+**Story file:** `docs/stories/epic-32/story-32-7/32-7-multi-agent-design-review-panels-in-elsa.md`
+**Design spec:** `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`
+(§"Multi-agent design/review steps")
+
+**Tech stack:** .NET 9 / Elsa Workflows in `apps/tamma-elsa` (C#). Activities live in
+`Tamma.Activities`, workflows in `Tamma.ElsaServer`, taxonomy in `Tamma.Core`. Tests in
+`apps/tamma-elsa/tests/Tamma.Activities.Tests/` and `tests/Tamma.ElsaServer.Tests/` (xUnit).
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO new aggregation semantics beyond the four named strategies.** `single`/`consensus`/
+  `lead+critics`/`llm-judge` only. A/B experiment cohorts are Story 32-14.
+- **NO changes to the `llm-call` workflow or `CallLlmActivity`.** Members run through the 32-5
+  managed-agent layer; the panel never talks HTTP to a provider directly.
+- **NO change to prompt/convention resolution.** `tenant → system → error` stays exactly as-is
+  (`feedback_resolution_no_empty_fallback`). Panels add no fallback layer.
+- **NO behavior change to the triage/plan workflow contracts.** `DefinitionId`s
+  (`triage-panel-review`, `plan-review`) and their inputs/outputs are frozen — callers
+  (`TriageItemCycleWorkflow`, etc.) must not need edits. Parity is proven by golden-output tests.
+- **NO per-member personalization layer.** Members reference agents (32-1); credentials resolve at
+  execution (32-3). No new credential storage here.
+- **NO leaderboard/benchmark projection.** This story *produces* per-member trail + aggregate
+  events; consumption is 32-8/32-10.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+> `packages/api` is **deleted** — all server + engine code is the C# `apps/tamma-elsa` stack.
+
+### The two panels being generalized
+
+| File | Shape today |
+|---|---|
+| `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TriagePanelReviewWorkflow.cs` | Hardcoded **4-role sequential** panel (`security → developer → devops → tester`). Each role: a `DispatchWorkflow{ WorkflowDefinitionId = "llm-call" }` with `role`=`AgentRole.X.ToWire()`, `action`=`RolePhaseMap.GetTriageActionForRole(role).ToWire()`, `enableTools=true`, `WaitForCompletion=true`, `Result → llmResult`. Then a `SetVariable` (`ExtractTriageReview`) pulls JSON out of `llmResult["llmResponse"]`. Final `Aggregate` `SetVariable` concatenates the four into `{ reviews[], reviewCount }` → output `panelResultJson`. **No strategy; no agent identity.** `DefinitionId = "triage-panel-review"`; inputs `repository,itemJson,contextJson`; output `panelResultJson`. |
+| `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/PlanReviewWorkflow.cs` | **7-role sequential debate**: Phase 1 independent review (`RoleReviewDispatch` + `ExtractReview` + `StoreRoleFindingActivity`, per role), Phase 2 anonymized rebuttal (`RebuttalDispatch` + `ExtractRebuttal` + store), early-termination consensus check via `allRebuttalApproved`, Phase 3 PO decision (single agent), loop to `maxRounds` (default 3), `forceNeedsHuman` on max. `DefinitionId = "plan-review"`; outputs `decision,planJson,reviewNotes,deferred,split,discussionLog,suggestionsJson`. |
+
+Both call the `llm-call` workflow whose output key is **`llmResponse`** (string)
+(`LlmCallWorkflow.cs:599-607`). Both auto-register via `elsa.AddWorkflowsFrom<LlmCallWorkflow>()`
+(`apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs:118`) — assembly scan, no per-workflow add.
+`TriagePanelReviewWorkflow` is dispatched by `TriageItemCycleWorkflow.cs`.
+
+### Activity + event seams to reuse
+
+- **Existing dispatch home:** `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/` already hosts
+  `DispatchAgentWorkflowActivity`, `CollectAgentResultsActivity`, `AgentDispatchService`,
+  `AgentExecutorFactory`, etc. (these are the **CLI/process** dispatch path — GitHub Actions /
+  local executors). The new panel activities are **NEW** in the same folder; the existing
+  CLI-dispatch classes are unrelated and untouched.
+- **Activity pattern:** `CallLlmActivity.cs` is the reference — `[Activity("Tamma.X", ...)]` +
+  `[FlowNode("Success","Retryable","Fatal")]`, `Input<T>`/`Output<T>` props, `[JsonConstructor]`
+  + DI ctor, `context.CompleteActivityWithOutcomesAsync(...)`. Outcome-bearing activities derive
+  from `Activity` (not `CodeActivity`); see `TammaOutcomeActivity` in
+  `Tamma.Activities/Core/TammaActivity.cs`.
+- **Event emission:** `TammaEventEmitter.Emit(context, source, logger, new TammaEvent{ EventType,
+  Status, Data })` writes to `WorkflowExecutionContext.TransientProperties["tamma:events"]`. Per
+  story 32-6 the action trail durably appends these to the **tenant** event store; this story
+  composes `AGENT.PANEL.AGGREGATED` / `AGENT.PANEL.MEMBER_GATED` / `AGENT.ITERATION.COMPLETED` the
+  same way and adds `panelId`+`memberPosition` tags to per-member entries.
+- **Taxonomy:** `Tamma.Core/Agents/AgentRole.cs` (enum, `.ToWire()`), `AgentAction.cs` (wire
+  actions incl. design actions `plan-system-design`/`design-api-contract`/…), `RolePhaseMap.cs`
+  (`GetReviewActionForRole`, `GetTriageActionForRole`, `EligibleActions`). **No
+  `GetDesignActionForRole` yet** → add one (architect ⇒ `PlanSystemDesign`, etc.).
+
+### Dependency status
+
+- Sibling story dirs `docs/stories/epic-32/story-32-1..32-14/` exist but are **empty placeholders**
+  at drafting time — 32-1/32-2/32-5/32-6 are referenced by contract, not by landed code.
+  `IManagedAgent` / action-trail types do **not** yet exist in the tree
+  (`grep IManagedAgent` → none). Build against their interfaces; feature-flag panel execution
+  until 32-5 + 32-6 merge.
+
+---
+
+## Architecture
+
+**Two activities + a pure strategy seam, wired into a composable step workflow, then retrofitted
+onto the two legacy panels.**
+
+```
+PanelStepWorkflow (design or review step)
+  └─ loop iterationCount ≤ maxIterations:
+       RunAgentPanelActivity   ── gate each member (visibility / SaaS provider class / budget)
+         │                        resolve IManagedAgent (32-5), run (parallel where safe),
+         │                        emit per-member trail entry (panelId+memberPosition)
+         ▼  MemberResultsJson
+       AggregatePanelActivity  ── PanelStrategyFactory → IAggregatePanelStrategy.Aggregate(...)
+         │                        (pure; LLM-bearing revision/judge already ran as a member)
+         │                        sanitize judge rationale; emit AGENT.PANEL.AGGREGATED
+         ▼  AggregateJson
+       gates pass? → done : iterationCount++ → loop  (max → escalate)
+```
+
+- **Pure aggregation, LLM in the fan-out:** `lead+critics` revision and `llm-judge` selection need
+  an LLM call — performed by `RunAgentPanelActivity` as a designated member (lead-revision member /
+  judge member), so `IAggregatePanelStrategy.Aggregate` is a deterministic, fixture-testable
+  function. This is the keystone that makes the AC2 "deterministic fixtures" requirement real.
+- **Member = agent, not role:** a member carries an `agentId` (32-1); a null `agentId` resolves the
+  tenant's default agent for the role — the bridge that lets the refactored role-only triage/plan
+  definitions keep working.
+- **Soft member gate, hard quorum:** one ineligible member is dropped with an
+  `AGENT.PANEL.MEMBER_GATED` note; the panel only fails when quorum is unmet.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Concern | single-user | SaaS |
+|---|---|---|
+| Panel definition ownership | sole user (private) or shipped/system | public: platform owner; private: tenant owner/admin (32-2) |
+| Runnable members | shipped ∪ user-private; CLI/token allowed | public ∪ tenant-private; **LLM-API only** — CLI/token members gated |
+| Member credentials/budget | the user's | the tenant's, BYOK → platform (32-3); cost attributed to tenant |
+| Panel events | the user's feed/store | executing tenant's store; `AGENT.PANEL.AGGREGATED` tagged `tenantId` |
+
+---
+
+## Task breakdown
+
+### T1: Panel domain types + pure strategy seam (no Elsa, no LLM)
+
+**Scope:** All record/enum types and the four `IAggregatePanelStrategy` implementations + factory.
+Pure C#, fully unit-testable with fixtures. **This is the only hard prerequisite for the rest.**
+
+**Files (new):** under `Tamma.Activities/AgentDispatch/Panels/` — `PanelStrategy.cs`,
+`PanelMemberPosition.cs`, `PanelMember.cs`, `PanelDefinition.cs`, `PanelMemberResult.cs`,
+`PanelAggregateResult.cs`, `IAggregatePanelStrategy.cs`, `SinglePanelStrategy.cs`,
+`ConsensusPanelStrategy.cs`, `LeadCriticsPanelStrategy.cs`, `LlmJudgePanelStrategy.cs`,
+`PanelStrategyFactory.cs`, `PanelEventTypes.cs`.
+
+**Tests first** (`tests/Tamma.Activities.Tests/AgentDispatch/Panels/`):
+- `single` — N=1 passthrough; N>1 returns lead/first; `WinnerIndex` correct.
+- `consensus` — majority (`{approve,approve,concerns}`→approve); weighted flip; **tie-break**
+  (`{approve:1.0,reject:1.0}` → earliest position); `Tally` recorded.
+- `lead+critics` — lead proposal + critics' annotations + lead-revision-member output ⇒ revised
+  output is the aggregate.
+- `llm-judge` — judge fixture selects member 2 + rationale; rationale **sanitized** (HTML/zero-width
+  stripped) into `PanelAggregateResult.Rationale`.
+- factory maps each `PanelStrategy` → its impl; unknown ⇒ throws.
+
+**Acceptance:**
+- [ ] Each strategy unit-tested with deterministic fixtures; ≥90% branch on each strategy class.
+- [ ] Tie-break + weighted-vote behavior pinned by tests.
+- [ ] No Elsa / no `IManagedAgent` dependency in this layer (compiles standalone).
+
+### T2: `RunAgentPanelActivity` (fan-out + gating + per-member trail)
+
+**Scope:** Elsa activity that parses a `PanelDefinition`, gates + resolves + runs each member via
+`IManagedAgent` (parallel where the strategy allows; `lead+critics` sequences lead→critics),
+orders results by member index, emits per-member trail entries, sets `MemberResultsJson`.
+
+**Files (new):** `Tamma.Activities/AgentDispatch/RunAgentPanelActivity.cs`.
+**DI ctor:** `ILogger`, `IManagedAgentResolver` (32-5), `IAgentRegistry` (32-2),
+`ITenantContextAccessor`, `ICredentialResolver` (32-3), `IContentSanitizer`, `IBudgetGuard`.
+Outcomes `[FlowNode("Done","Gated","Failed")]`.
+
+**Gating rule (AC8):** in SaaS (`ITammaModeProvider`), drop members backed by
+`ICLIAgentProvider`/token providers and members whose agent isn't visible to the tenant; record
+`AGENT.PANEL.MEMBER_GATED`; proceed if quorum remains else `Gated`. Budget exhaustion mid-fan ⇒
+skip remaining, aggregate over completed (AC9).
+
+**Tests first** (`tests/.../AgentDispatch/RunAgentPanelActivityTests.cs`): stub `IManagedAgent`s with
+staggered delays → assert concurrency (wall-clock < sum) + deterministic index ordering; SaaS gating
+(CLI-backed / not-visible → gated, with quorum behaviors); budget clamp early-stop; per-member trail
+entry carries `panelId`+`memberPosition`+`agentId`+`iteration`+`tenantId`.
+
+**Acceptance:**
+- [ ] Members run concurrently except `lead+critics`; results ordered by position regardless of
+      completion order.
+- [ ] Ineligible member gated without aborting the panel (quorum retained); quorum-lost → `Gated`.
+- [ ] Each member emits its own action-trail entry tagged `panelId`+`memberPosition`.
+
+### T3: `AggregatePanelActivity` (strategy default + aggregate event)
+
+**Scope:** Elsa activity wrapping T1: parse member results + definition, resolve strategy default
+(design ⇒ `lead+critics`, review ⇒ `consensus`), aggregate, sanitize judge rationale, emit
+`AGENT.PANEL.AGGREGATED`, set `AggregateJson`.
+
+**Files (new):** `Tamma.Activities/AgentDispatch/AggregatePanelActivity.cs`. DI ctor: `ILogger`,
+`PanelStrategyFactory`, `IContentSanitizer`. Outcome `[FlowNode("Aggregated")]`.
+
+**Tests first** (`tests/.../AgentDispatch/AggregatePanelActivityTests.cs`): default-strategy
+resolution (omitted strategy → design/review defaults); `AGENT.PANEL.AGGREGATED` carries strategy +
+winner/tally + token totals; judge rationale sanitized before emit.
+
+**Acceptance:**
+- [ ] Omitted strategy resolves to the spec default per step kind.
+- [ ] Exactly one `AGENT.PANEL.AGGREGATED` per aggregation with winner/consensus metadata.
+
+### T4: `PanelStepWorkflow` + `GetDesignActionForRole` + iteration loop (AC3/AC4/AC5)
+
+**Scope:** A composable design/review step over the primitives, with the iteration loop until gates
+pass / max, emitting `AGENT.ITERATION.COMPLETED`. Add `GetDesignActionForRole` to `RolePhaseMap`.
+
+**Files:** new `Tamma.ElsaServer/Workflows/PanelStepWorkflow.cs`; modify
+`Tamma.Core/Agents/RolePhaseMap.cs` (add `GetDesignActionForRole`); modify or create
+`Tamma.Activities/AgentDispatch/AgentDispatchServiceCollectionExtensions.cs` (register strategies +
+factory in DI). Auto-registers via the existing assembly scan — no `Program.cs` workflow-add edit.
+
+**Tests first:** `RolePhaseMap` design-action mapping; a design-step run aggregates under
+`lead+critics`; a review-step run with security/performance/visual reviewers aggregates under
+`consensus`; loop stops on gate pass and on `maxIterations` (escalation), emitting one
+`AGENT.ITERATION.COMPLETED` per iteration.
+
+**Acceptance:**
+- [ ] Design step defaults `lead+critics`; review step defaults `consensus`.
+- [ ] Loop terminates on gates-pass or max; escalates on max-without-pass.
+
+### T5: Refactor `TriagePanelReviewWorkflow` onto the primitives (parity)
+
+**Scope:** Replace the four `RoleTriageDispatch`+`ExtractTriageReview` pairs and the `Aggregate`
+`SetVariable` with `RunAgentPanelActivity` (members security/developer/devops/tester, strategy
+`consensus`) → `AggregatePanelActivity` → a thin adapter `SetVariable` mapping `AggregateJson` into
+the unchanged `{ reviews[], reviewCount }` `panelResultJson`. Keep `DefinitionId =
+"triage-panel-review"` + inputs/output. Remove the now-dead per-role helpers.
+
+**Tests first:** `tests/Tamma.ElsaServer.Tests/Workflows/TriagePanelReviewParityTests.cs` — capture
+pre-refactor golden `panelResultJson` for fixed mocked member outputs; assert the refactored
+workflow reproduces it byte-for-byte.
+
+**Acceptance:**
+- [ ] Golden-output parity (zero diff) on fixed member outputs.
+- [ ] `DefinitionId` + inputs (`repository,itemJson,contextJson`) + output (`panelResultJson`)
+      unchanged; `TriageItemCycleWorkflow` needs no edit.
+
+### T6: Refactor `PlanReviewWorkflow` onto the primitives (parity)
+
+**Scope:** Replace the Phase-1 review fan and Phase-2 rebuttal fan with `RunAgentPanelActivity`; the
+`allRebuttalApproved` early-termination becomes the `consensus` strategy verdict; Phase-3 PO
+decision stays a single agent; preserve per-role persistence via the per-member trail entries; keep
+the `maxRounds`/`forceNeedsHuman` loop. `DefinitionId = "plan-review"` + all inputs/outputs frozen.
+
+**Tests first:** `tests/Tamma.ElsaServer.Tests/Workflows/PlanReviewParityTests.cs` — golden parity on
+`decision` + `discussionLog` for fixed mocked member outputs, including the early-termination path
+and a `maxRounds` exhaustion path.
+
+**Acceptance:**
+- [ ] Golden-output parity on `decision`+`discussionLog` incl. early-termination + max-rounds paths.
+- [ ] Outputs (`decision,planJson,reviewNotes,deferred,split,discussionLog,suggestionsJson`)
+      unchanged.
+
+### T7: Tenancy + budget integration + suite green
+
+**Scope:** Confirm member runs + trail entries carry the executing tenant id (no cross-tenant
+leakage), budget-clamp path is exercised end-to-end, and the full `apps/tamma-elsa` suite is green.
+
+**Tests:** tenancy-isolation assertion against the per-tenant event store; budget-exhaustion panel
+aggregates over completed members and records it in the event. Run docker-bound suites via
+`sg docker -c "dotnet test ..."`.
+
+**Acceptance:**
+- [ ] Panel events/trail entries tenant-scoped; isolation test passes.
+- [ ] Full suite green; no regressions in triage/plan or AgentDispatch CLI tests.
+
+---
+
+## Task order & dependencies
+
+T1 → T2 → T3 → T4 → (T5 ∥ T6) → T7.
+T1 is the only hard prerequisite for everything. T2 needs 32-5 (`IManagedAgent`) + 32-6 (trail)
+interfaces; if those aren't landed, build against the interfaces and feature-flag execution. T5/T6
+are parallel-safe (independent workflows). T3 needs T1; T4 needs T2+T3.
+
+## Risks
+
+- **Token-spend blowup:** N members × iterations multiplies cost — primary mitigation is per-tenant
+  budget clamps (T2/AC9) + `maxIterations` cap (T4/AC5); budget exhaustion aggregates over completed
+  members rather than failing.
+- **Refactor regresses caller contracts:** the golden-output parity tests (T5/T6) are load-bearing —
+  preserve `DefinitionId`s and input/output shapes; map the aggregate back into the legacy JSON via a
+  thin adapter rather than changing the output schema.
+- **Strategy non-determinism in tests:** keep `IAggregatePanelStrategy.Aggregate` pure; the only
+  LLM-bearing steps (`lead+critics` revision, `llm-judge`) run as members and are fixtures in unit
+  tests — live behavior is covered solely by parity tests with mocked members.
+- **32-5/32-6 not yet in tree:** `IManagedAgent` and the action-trail types don't exist at drafting
+  time (verified). Build against their interfaces and gate panel execution behind a feature flag
+  until both merge; T1/T5/T6 (pure types + workflow wiring) can proceed regardless.
+- **SaaS over-gating → empty panel:** quorum check + fail-loud (no silent empty verdict).
+- **Event-store topology (Story 28-1 / Epic 30):** `AGENT.PANEL.*` and per-member trail events are
+  tenant-scoped by design — route them through the tenant event store the action trail (32-6) owns,
+  so a later per-tenant fan-out migration touches only routing, not this story's emission sites.

--- a/docs/superpowers/plans/2026-06-17-32-8-outcome-capture-and-bug-taxonomy-at-review-gate-plan.md
+++ b/docs/superpowers/plans/2026-06-17-32-8-outcome-capture-and-bug-taxonomy-at-review-gate-plan.md
@@ -1,0 +1,255 @@
+# Story 32-8 — Outcome Capture & Bug Taxonomy at Review/Gate (Implementation Plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation. Tests run via `sg docker -c "dotnet test ..."` for docker-bound suites
+> (the session docker group is stale; build itself needs no wrapper).
+
+**Goal:** Attribute development outcomes back to the agent(s) that produced the work. Capture
+per-run/per-task outcome (`success | failure | partial`) and iteration-to-done count, and classify
+defects found at review + quality gates into a fixed taxonomy (`visual | functional | regression |
+security | performance | style`, catch-all `other`). Outcomes and defect records are **tenant-scoped
+DCB events** tagged with the originating `agentId` + config version, so 32-10 (leaderboards) and
+32-11 (learning) can score agents on real downstream quality — not just token/latency.
+
+**Story file:** `docs/stories/epic-32/story-32-8/32-8-outcome-capture-and-bug-taxonomy-at-review-gate.md`
+**Design spec:** `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md` (§Tracking, §Ownership)
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (Elsa engine + control-plane API).
+C# only — the TypeScript `packages/api` is **deleted**; do not reference it. Tests live in
+`apps/tamma-elsa/tests/Tamma.Core.Tests/`, `Tamma.Api.Tests/`, `Tamma.Activities.Tests/` (xUnit).
+
+---
+
+## Non-goals (YAGNI guard)
+
+- NO leaderboards / projections / aggregation — that is **32-10**. This story only *emits* the raw
+  outcome + defect events (and the idempotent record store behind them).
+- NO learning persistence / RAG feed — that is **32-11**. We align outcome wire strings to
+  `knowledge.ts` so 32-11 consumes them with no translation, but we do not write `LearningCapture`.
+- NO cost/latency/token emission — that is **32-9** (the other half of the performance dataset).
+- NO new retry/iteration loop construct. `iterationsToDone` is *derived* by reading existing
+  Epic-13 retry state (Testing `EvaluateResults→CommitFix→TriggerCI` + Review `WaitForFixes→
+  ReRequestReview`). Adding a loop is out of scope and would duplicate Epic 13.
+- NO new reviewer UI or webhook schema redesign — we read the categories the existing review webhook
+  already carries (`ReviewResult.Comments` + an optional reviewer `category` field).
+- NO platform-admin visibility into tenant outcome/defect data — by design (§Ownership) it is
+  ALWAYS tenant-scoped; admin reads none of it.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+| Seam | File (verified) | State today |
+|---|---|---|
+| DCB event row | `src/Tamma.Data/Entities/DomainEvent.cs` | `Type`, `TenantId`, `IssueNumber`, `Tags`/`Metadata`/`Data` (JSONB strings), `SequenceNumber` (BIGSERIAL total order). |
+| Durable append + tenant query | `src/Tamma.Data/Repositories/IEventRepository.cs` | `AppendAsync`, `QueryAsync(tenantId,...)`, `ListByTenantAsync`, `GetLastByTypeAsync(tenantId,type)` — tenant-scoped; ideal for query-before-append dedup. |
+| Activity event accumulation | `src/Tamma.Activities/Core/TammaActivity.cs` | `TammaEventEmitter` writes `TammaEvent`s to **transient** `WorkflowExecutionContext.TransientProperties["tamma:events"]` + logs. **Not durable** — a central flush appends them as `DomainEvent`s. |
+| Central flush precedent | `src/Tamma.Api/Endpoints/AgentEndpoints.cs` (~line 93) | `await events.AppendAsync(new DomainEvent { TenantId = tenantContext.TenantId, ... })` — the exact append-with-tenant pattern `AgentOutcomeService` follows. |
+| Review hook | `src/Tamma.Activities/Review/MonitorReviewActivity.cs` | `OnReviewReceivedAsync` parses `ReviewResult` (Approved/ChangesRequested/TimedOut) + `ReviewCommentDetail` (FilePath/Body/Author). Bookmark `AutoBurn=true` (dedups the bookmark, NOT the defect rows). |
+| Gate hook | `src/Tamma.Activities/Testing/GenerateQualityReportActivity.cs` | Builds `QualityReport.AllIssues: List<QualityIssue>` with `QualityIssueCategory` (Coverage/Test/Lint/Security/Build) + `QualityIssueSeverity`. `EvaluateResultsActivity.cs` routes AllPass/MinorIssues/MajorIssues/Critical. |
+| Retry loop (iterations) | Testing `EvaluateResults→CommitFix→TriggerCI→WaitForCIResults`; Review `WaitForFixes→ReRequestReview` | `CIResultsPayload.RunId` + `ConsecutivePassCount` track Testing attempts; review re-request count tracks review attempts. No central iteration counter — must read off run state at the settling gate. |
+| Taxonomy enum precedent | `src/Tamma.Core/Agents/{AgentRole,AgentAction,EnumWire}.cs` | `[Wire("...")]` attribute + `EnumWire<TEnum>` bidirectional frozen map; static-ctor validates distinct wires + exactly-one `[Wire]`; case-sensitive parse. Namespace kept `Tamma.Api.Services.Agents` (Story 27-19) though the type lives in `Tamma.Core`. |
+| Outcome vocab precedent | `packages/shared/src/types/knowledge.ts` | `LearningCapture.outcome: 'success' | 'failure' | 'partial'` already exists — align `AgentOutcomeKind` wires to it. |
+| Redaction | `src/Tamma.Core/Redaction/CredentialRedactor.cs` | Redact defect `message` before persistence. |
+| Fire-and-forget precedent | `IMissingConfigRecorder` (missing-config plan) | Never-throw recorder contract — `AgentOutcomeService` mirrors it. |
+| Sibling deps | `docs/stories/epic-32/story-32-6` (action trail), `32-7` (panels) | **Dirs exist, empty** — authored in the same wave. 32-6 establishes `agent_id`+version tagging in the tenant store; 32-7 the panel review verdict. Coordinate tag names before merge. |
+
+**Key gap this story closes:** review/gate defects and run outcomes today exist only as transient
+`tamma:events` + logs (or not at all). There is no durable, tenant-scoped, agent-attributed,
+classified quality signal. `AgentOutcomeService` is the new durable seam; the activities are thin
+capture hooks over it.
+
+---
+
+## Architecture
+
+**classify → record (idempotent, tenant-scoped) → DCB event → (consumed by 32-10/32-11)**
+
+1. **`BugCategory` + `AgentOutcomeKind`** enums in `Tamma.Core` (`[Wire]`/`EnumWire`). `BugCategory`
+   adds a non-throwing `Classify(string?)` → `Other` + WARN (the one deliberate divergence from
+   `AgentRole.Parse` which throws). `AgentOutcomeKind` wires align to `knowledge.ts`
+   (`failure` not `fail`; `fail` accepted as an alias).
+2. **`IAgentOutcomeService`** (new, `Tamma.Api/Services/Agents/`) — the single write-side seam.
+   `RecordOutcomeAsync` (idempotent per `(runId, gateId)`) and `RecordDefectAsync` (idempotent per
+   `(runId, defectKey)`). Both **never throw to the caller** (try/catch → WARN). Appends
+   `DomainEvent`s via `IEventRepository.AppendAsync` with `TenantId` set — structural isolation.
+3. **DCB events:** `AGENT.OUTCOME.RECORDED` (tags: `agentId`, `agentVersion`, `role`, `phase`,
+   `outcome`, `runId`; data: `iterationsToDone`, `gateId`, `prNumber`) and `AGENT.DEFECT.RECORDED`
+   (tags: `agentId`, `agentVersion`, `role`, `phase`, `category`, `source` review|gate|human,
+   `runId`; data: `defectKey`, `filePath`, redacted `message`, `severity`, `rawCategory`).
+4. **Idempotency:** query-before-append against the tenant event store (`GetLastByType`-style /
+   `QueryAsync` filtered by `runId`+`gateId|defectKey`) PLUS a belt-and-suspenders partial unique
+   index on the tenant `domain_events` projection of `(tenant_id, type, (tags->>'runId'),
+   (data->>'defectKey'))`. `defectKey` = stable hash of `(runId, filePath, normalizedMessage,
+   category, source)`.
+5. **Capture hooks (thin):** `MonitorReviewActivity` (review + human defects), `GenerateQuality
+   ReportActivity` (gate defects via `QualityIssueCategory→BugCategory`), `EvaluateResultsActivity`
+   (settle outcome + `iterationsToDone`). 32-7 panel verdict capture is guarded on 32-7 presence.
+
+### Per-mode ownership (mandatory two-scoping answer, per CLAUDE.md)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Who owns outcome/defect data? | sole user (single tenant / `TenantId` null) | the originating tenant — ALWAYS tenant-scoped (§Ownership) |
+| Platform admin read? | n/a | **never** — admin owns public agent *definitions*, reads no tenant performance data |
+| Where stored? | the single tenant store | originating tenant `t_<hex>` event stream; `AgentOutcomeService` writes `TenantId` so per-tenant fan-out (28-1) only touches routing |
+| agentId trust | from run context | from run context (pinned at start by 32-5/32-6) — NEVER from a reviewer payload |
+
+---
+
+## Task breakdown
+
+### T1: Taxonomy + outcome enums (Tamma.Core) — core, no deps
+
+**Scope:** `BugCategory` + `AgentOutcomeKind` enums + extensions; no service/activity wiring yet.
+
+**Files:**
+- New: `src/Tamma.Core/Agents/BugCategory.cs` (enum + `BugCategoryExtensions.ToWire`/`Classify`),
+  `src/Tamma.Core/Agents/AgentOutcomeKind.cs` (enum + `ToWire`/`Parse` accepting `fail`/`failure`).
+  Namespace `Tamma.Api.Services.Agents` to match `AgentRole`/`AgentAction` (Story 27-19 convention).
+
+**Tests (first):** `tests/Tamma.Core.Tests/Agents/BugCategoryTests.cs`,
+`AgentOutcomeKindTests.cs` — every member round-trips `EnumWire`; distinct wires; `Classify("xyz")`
+→ `Other` (assert WARN at call sites, not the helper); `Classify(null/"")` → `Other`;
+`AgentOutcomeKind` parses both `fail` and `failure`.
+
+**Acceptance:**
+- [ ] All taxonomy + outcome members round-trip; `EnumWire` static ctor validates distinctness.
+- [ ] `Classify` is total (never throws) and maps unknown → `Other`.
+- [ ] `dotnet build` clean; `Tamma.Core.Tests` green.
+
+### T2: `AgentOutcomeService` + event schema + idempotency — depends T1
+
+**Scope:** the durable seam. Record types, event-type constants, append-with-tenant, dedup,
+never-throw contract, redaction. No activity wiring yet.
+
+**Files:**
+- New: `src/Tamma.Api/Services/Agents/IAgentOutcomeService.cs`, `AgentOutcomeService.cs`,
+  `AgentOutcome.cs`/`AgentDefect.cs` (record types), `AgentOutcomeEventTypes.cs`
+  (`AGENT.OUTCOME.RECORDED`, `AGENT.DEFECT.RECORDED`).
+- New: idempotency migration under `src/Tamma.Data/Migrations/...` (additive partial unique index
+  on the tenant `domain_events` projection of `(tenant_id, type, (tags->>'runId'),
+  (data->>'defectKey'))` for `AGENT.DEFECT.RECORDED`, and `(... gateId)` for outcomes). Run
+  `dotnet ef migrations add` then verify `has-pending-model-changes` reports none.
+- Modify: `src/Tamma.Api/Program.cs` — register `IAgentOutcomeService` (mirror existing agent-service
+  registration).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/AgentOutcomeServiceTests.cs` — first record appends
+exactly one event with correct tags/data; duplicate `(runId,gateId)` / `(runId,defectKey)` → no
+second event (query-before-append + unique-index catch); recorder swallows a DB fault (WARN, no
+throw); `message` redacted via `CredentialRedactor`; `rawCategory` preserved when classify→Other;
+events carry `TenantId`.
+
+**Acceptance:**
+- [ ] One outcome event per `(runId,gateId)`; one defect event per `(runId,defectKey)` under concurrency.
+- [ ] `RecordOutcomeAsync`/`RecordDefectAsync` never propagate an exception to the caller.
+- [ ] Migration applies + rolls back cleanly; `has-pending-model-changes` → none.
+
+### T3: Gate capture — defects + outcome + iterationsToDone — depends T1, T2
+
+**Scope:** map `QualityReport.AllIssues` → `BugCategory`, emit gate defects; derive
+`iterationsToDone` from Testing+Review loops; settle the outcome at the gate.
+
+**Files:**
+- Modify: `src/Tamma.Activities/Testing/GenerateQualityReportActivity.cs` — after building
+  `AllIssues`, classify each `QualityIssueCategory` → `BugCategory`
+  (Coverage/Test/Build→`functional`, Security→`security`, Lint→`style`; regression/performance via
+  message heuristics) and call `RecordDefectAsync(source: gate)`.
+- Modify: `src/Tamma.Activities/Testing/EvaluateResultsActivity.cs` — at the settling routing
+  (AllPass = success; Critical/exhausted = failure; MajorIssues mid-loop = no terminal yet),
+  read the attempt count off run state and `RecordOutcomeAsync(outcome, iterationsToDone)`.
+- The activities take an injected `IAgentOutcomeService?` (null-tolerant so existing activity unit
+  tests don't all need rework; a new test asserts it IS wired in Program.cs).
+
+**Tests (first):** `tests/Tamma.Activities.Tests/Testing/QualityGateOutcomeCaptureTests.cs` —
+QualityReport with Coverage+Security+Lint+Build issues emits 4 defects with mapped categories;
+3-attempt loop (fail→fail→pass) → `iterationsToDone==3`, outcome `success`; max-iterations →
+`failure`; zero-defect pass → success + no defect events; unknown heuristic → `functional` default.
+
+**Acceptance:**
+- [ ] Every `QualityIssue` produces exactly one classified defect event (gate source).
+- [ ] `iterationsToDone` matches the attempt count to the passing gate; failure path counts attempts consumed.
+- [ ] No change to gate routing outcomes / scoring.
+
+### T4: Review capture — defects + human feedback — depends T1, T2
+
+**Scope:** classify review comments + reviewer-supplied categories; emit review/human defects.
+
+**Files:**
+- Modify: `src/Tamma.Activities/Review/MonitorReviewActivity.cs` — in `OnReviewReceivedAsync`, for
+  each `ReviewCommentDetail` classify `category` (reviewer field) or infer, call
+  `RecordDefectAsync(source: review)`; an explicit human-flagged category → `source: human`.
+  Injected `IAgentOutcomeService?` (null-tolerant).
+- (Guarded) 32-7 panel aggregation review verdict → defects, behind a 32-7-present check.
+
+**Tests (first):** `tests/Tamma.Activities.Tests/Review/MonitorReviewDefectCaptureTests.cs` —
+ChangesRequested with N comments → N classified defect events; reviewer `category="visual"` →
+`Visual`; unknown reviewer category → `Other` + WARN + `rawCategory` in data; Approved with no
+comments → no defect events; TimedOut → no defect events; replayed webhook → defect dedup holds.
+
+**Acceptance:**
+- [ ] Each review comment becomes one classified defect (review/human source).
+- [ ] Unknown reviewer category → `other` (never throws, never aborts review).
+- [ ] No change to review outcomes (Approved/ChangesRequested/TimedOut).
+
+### T5: Tenant isolation + end-to-end tests — depends T2–T4
+
+**Scope:** prove cross-tenant invisibility and the full capture path; docker-bound.
+
+**Files:** `tests/Tamma.Api.Tests/Agents/AgentOutcomeIsolationTests.cs` (+ reuse T2-T4 suites).
+
+**Tests (first, docker-bound — `sg docker -c "dotnet test ..."`):** seed outcome+defect events for
+tenant A; tenant B's `ListByTenantAsync(B,...)` returns none of A's; a platform-admin path reads
+none of A's outcome/defect data; full path: run a simulated 2-iteration workflow with 3 gate defects
++ 2 review comments → 1 `AGENT.OUTCOME.RECORDED` (iterations=2) + 5 `AGENT.DEFECT.RECORDED`, all
+tagged `agentId`+version, all `TenantId`=A.
+
+**Acceptance:**
+- [ ] Tenant A data invisible to B and to platform admin (structural + query tests).
+- [ ] End-to-end run produces exactly the expected event counts (idempotent on re-run).
+- [ ] Full suite green (`sg docker -c "dotnet test apps/tamma-elsa/Tamma.sln"`).
+
+---
+
+## Task order & dependencies
+
+T1 → T2 → (T3 ∥ T4) → T5. T1 is the only hard prerequisite for everything; T3 and T4 are
+parallel-safe once T2 lands; T5 closes the loop. 32-6/32-7 should land (or at least pin their
+`agent_id`+version tag names) before T3/T4 merge — coordinate tag spelling.
+
+## Risks
+
+- **Cross-tenant leak (highest):** the whole value prop is per-tenant private datasets. Mitigation:
+  `DomainEvent.TenantId` + per-tenant connection/role; `AgentOutcomeService` reads tenantId+agentId
+  from run context, NEVER from a reviewer payload; explicit isolation tests in T5. Get this wrong and
+  one tenant scores another's agents.
+- **Double-counting on retry/replay:** hot retry loops + replayed webhooks re-surface the same
+  defect. Mitigation: `(runId,gateId)`/`(runId,defectKey)` query-before-append + partial unique
+  index. `defectKey` hash must be stable across attempts (normalize message, exclude volatile fields).
+- **Capture aborting a passing workflow:** a DB blip on the capture path must not fail a gate.
+  Mitigation: never-throw recorder (try/catch→WARN), matching `IMissingConfigRecorder`. The
+  contract is load-bearing — assert it in T2.
+- **iterationsToDone derivation drift:** Testing and Review loops count attempts differently;
+  attribution must be the code/design-producing agent, not the reviewer. Mitigation: read the final
+  attempt index off run state at the settling gate; pin attribution to the run-start `agentId`.
+  T3 tests pin the count semantics.
+- **32-6/32-7 tag-name mismatch:** if this story tags `agentId` but 32-6 tags `agent_id`, 32-10
+  joins break. Mitigation: read the sibling stories before T3/T4; use the exact tag spelling 32-6
+  establishes (the design spec writes `agent_id`).
+- **Migration discipline:** the idempotency index is additive, but still verify
+  `has-pending-model-changes` reports none and mirror any entity config in the established single
+  source; a JSONB-expression unique index needs a raw-SQL migration step (EF won't infer it).
+- **`fail` vs `failure` wire drift:** the spec says `fail`, `knowledge.ts` says `failure`. We persist
+  `failure` and accept `fail` as an alias — document it so 32-11 isn't surprised. Pinned in T1 tests.
+
+## Definition of done
+
+- [ ] All five tasks' acceptance boxes checked; story ACs 1-10 satisfied.
+- [ ] `BugCategory`/`AgentOutcomeKind` validated via `EnumWire`; unknown→`other` non-throwing.
+- [ ] `AGENT.OUTCOME.RECORDED` + `AGENT.DEFECT.RECORDED` emitted, tenant-scoped, `agentId`+version
+      tagged, idempotent per `(run, gate/defect)`.
+- [ ] Tenant isolation proven; capture never aborts a workflow.
+- [ ] Full `dotnet test` suite green (docker-bound via `sg docker -c`); no new lint/build warnings.
+- [ ] No reference to the deleted `packages/api`; all touched code in `apps/tamma-elsa`.

--- a/docs/superpowers/plans/2026-06-17-32-9-cost-basis-plus-margin-metering-and-byok-pricing-model-plan.md
+++ b/docs/superpowers/plans/2026-06-17-32-9-cost-basis-plus-margin-metering-and-byok-pricing-model-plan.md
@@ -1,0 +1,252 @@
+# Story 32-9 — Agent Usage & Cost-Basis Emission (Producer) — Implementation Plan
+
+**Date:** 2026-06-17
+**Story:** [32-9](../../stories/epic-32/story-32-9/32-9-cost-basis-plus-margin-metering-and-byok-pricing-model.md)
+**Epic:** 32 (Agents — first-class entities, managed execution, benchmarking & learning)
+**Design spec:** [2026-06-17-agent-entities-benchmarking-design.md](../specs/2026-06-17-agent-entities-benchmarking-design.md)
+**Stack:** C# `apps/tamma-elsa` (Tamma.Api / Tamma.Data / Tamma.Activities). `packages/api` is deleted — never target it.
+
+## Goal
+
+Make every LLM call attributable to an agent run **emit a per-call usage + cost-basis DCB event**
+(`AGENT.USAGE.RECORDED`) into the calling **tenant's own** schema, tagged with
+`agentId` / `tenant` / `provider` / `model` / `credentialSource`, and **roll it up per billing
+period** (`agent_usage_rollup`) behind a tenant-scoped read endpoint. This is the **producer** that
+Epic 34 (pricing/markup), Epic 35 (billing), and Epic 36 (analytics) consume.
+
+## Non-goals (YAGNI / boundary guard)
+
+- **No markup / margin / billable computation.** `billableUsd`, `marginPct`, seat/platform fee, plan
+  branching on `credentialSource` → **all Epic 34-5**. This story emits `costBasisUsd` (provider cost,
+  already computed) + the `credentialSource` discriminator and stops there. An automated test
+  (Phase 1) fails if a pricing field appears in the event `Data`.
+- **No re-pricing of past periods**, no invoicing, no dashboards — Epic 34/35/36.
+- **No new pricing path.** Reuse `IProviderPricingService` / `ProviderDiagnostic.Cost` as the single
+  cost-basis source of truth; do not recompute.
+- **No new event infrastructure or new tenancy plumbing.** Reuse `DomainEvent`, `IEventRepository`,
+  `ITenantDbContextFactory`, `SequenceNumber`.
+- **No Epic 20 code.** 20-3/20-4/20-5 live in the deleted TS `packages/api`; the re-target is a
+  **documentation note** only.
+- **No `Plan.cs` / quota changes** for pricing here. (Limit-enforcement against budgets is 32-5's
+  fail-closed gate; this story only produces the cost-basis signal it can read.)
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### The cost basis already exists — promote it, don't compute it
+
+- `apps/tamma-elsa/src/Tamma.Api/Services/Providers/IProviderPricingService.cs` —
+  `decimal Compute(string provider, string? model, int inputTokens, int outputTokens)`; unknown
+  `(provider, model)` → `0m`. `ProviderPricingService` is a frozen rate table ported from the TS
+  `packages/cost-monitor`.
+- `ProviderSessionService.ExecuteAsync` (`src/Tamma.Api/Services/Providers/ProviderSessionService.cs`,
+  ~lines 122–135) already writes `new ProviderDiagnostic { … InputTokens, OutputTokens, Cost =
+  invocation.CostUsd, TenantId, CorrelationId?, AgentType? … }` via `IDiagnosticsService.RecordEventAsync`.
+  The SaaS path (`Services/SaaS/LlmProxyService.cs`) does the same with `EstimateCost`.
+  → **`ProviderDiagnostic.Cost` IS the cost basis.** 32-9 reads it; it does not re-derive a price.
+- `src/Tamma.Data/Entities/ProviderDiagnostic.cs` carries `InputTokens`, `OutputTokens`, `Cost`,
+  `Model`, `TenantId`, `CorrelationId`, `AgentType` — every dimension this story needs already lands
+  on the diagnostic. No `ProviderDiagnostic` schema change required.
+
+### DCB emission + tenant isolation are reusable as-is
+
+- `src/Tamma.Data/Entities/DomainEvent.cs` — `Id, Type, TenantId, IssueNumber, Tags(JSONB),
+  Metadata(JSONB), Data(JSONB), CreatedAt, SequenceNumber(BIGSERIAL cursor)`. Reuse unchanged.
+- `src/Tamma.Data/Repositories/EventRepository.cs` — `AppendAsync` resolves
+  `evt.TenantId ?? tenantContext.TenantId` and writes through `ITenantDbContextFactory` into the
+  `t_<hex>` schema; tenant-scope isolation is **structural**. A tenant-scoped (`TenantId != null`)
+  event physically cannot land anywhere but that tenant's schema. This is the isolation backbone.
+- Emission precedent: `src/Tamma.Api/Endpoints/AgentEndpoints.cs` `UpdateConfig` (~lines 93–113)
+  appends `AGENT_CONFIG.UPDATED.SUCCESS` with flat-string `Tags`, standard `Metadata`
+  (`workflowVersion`, `eventSource = "system"`), `Data` payload — copy this shape.
+
+### 32-6 is the sibling to mirror (already drafted)
+
+- `docs/stories/epic-32/story-32-6/…` ships `AgentTrailEmitter` / `AgentTrailTags` /
+  `IEventRepository` tenant-scoped emission, the `correlationId` linkage to `ProviderDiagnostic`, and
+  the **non-blocking** contract (`AGENT.TRAIL.WRITE_FAILED` breadcrumb). 32-9's emitter is a near-twin
+  (`AgentUsageEmitter` / `AgentUsageTags` / `AGENT.USAGE.EMIT_FAILED`). Match its conventions.
+
+### `credentialSource` comes from 32-3
+
+- `docs/stories/epic-32/story-32-3/…` introduces `IProviderCredentialResolver` →
+  `ProviderCredential { Source ∈ {Byok, Platform} }`, surfaced as `ProviderAttemptDiagnostic.
+  CredentialSource` and the `credentialSource` diagnostic/trail tag. 32-9 reads that tag; default
+  `platform` until 32-3 is wired. Today only `BudgetConfig.cs` mentions BYOK — no `credentialSource`
+  in the call path yet (confirms the 32-3 dependency).
+
+### The 32-5 managed run is the producer host
+
+- 32-5 (`IManagedAgent` over `ILLMProvider`) owns the LLM call and the `correlationId`. It is where
+  `IAgentUsageEmitter.RecordCallAsync` is called once per logical call. Until 32-5 lands, the emitter
+  + rollup + endpoint are independently testable; the run-loop wiring is the only piece gated on it.
+- `CallLlmInlineActivity` already accumulates tool-loop tokens (`ToolLoopTokens` / `PromptTokens` +
+  `CompletionTokens`) → "one logical call = one usage event" is natural (emit once with accumulated
+  totals).
+
+### Agent identity
+
+- `src/Tamma.Data/Entities/AgentConfig.cs` exists (tenant-nullable config). The immutable
+  `Agent`/`AgentVersion` entity is NEW in 32-1; until then, source `agentId`/`agentVersion` from the
+  resolved config identity.
+
+### Tenant migrations
+
+- Tenant EF model: `src/Tamma.Data/TenantDbContext.cs` (+ `Migrations/Tenant/…`,
+  `TenantDbContextModelSnapshot.cs`). New tenant tables (`agent_usage_rollup`, `agent_usage_applied`)
+  go here, scaffolded into the Tenant migration set.
+
+## Architecture (what we add)
+
+```
+32-5 managed run ── one logical LLM call ─────────────────────────────────────────┐
+  ProviderDiagnostic { Cost = pricing.Compute(...), InputTokens, OutputTokens,     │  (exists)
+                       CorrelationId, AgentType }                                   │
+                                                                                    ▼
+  IAgentUsageEmitter.RecordCallAsync(AgentUsageContext, AgentCallUsage)   ◄── NEW (producer)
+     → DomainEvent "AGENT.USAGE.RECORDED" { TenantId, Tags{agentId,provider,model,
+              credentialSource,correlationId,mode,…}, Data{inputTokens,outputTokens,
+              costBasisUsd,…}  ── COST BASIS ONLY }
+     → IEventRepository.AppendAsync  → t_<hex>.domain_events     (structural isolation)
+                                                                                    │
+  AgentUsageRollupProjector.ApplyAsync(evt)  ◄── NEW (idempotent on event id)       │
+     → upsert agent_usage_rollup (per period × agent × provider × credentialSource) │
+                                                                                    ▼
+  GET /api/v1/orgs/{tenantId}/agents/usage  ◄── NEW (MemberAccess, tenant-scoped)
+     → { byAgent[], totals }   ── NO billableUsd on the wire
+
+Downstream (NOT here): Epic 34-5 markup → billableUsd; Epic 35 billing; Epic 36 analytics.
+```
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md "Operating Modes")
+
+- **single-user:** the sole user owns everything; `credentialSource` is `platform` (local/platform key);
+  events tag `mode = single-user`; the tenant is the user's personal tenant; usage rollup is the user's.
+- **saas:** usage data is **ALWAYS tenant-scoped** (Epic 32 tenancy rule); `credentialSource` is
+  `byok | platform` from 32-3; events tag `mode = saas`; a public/system agent run by a tenant produces
+  a rollup only in **that tenant's** schema; platform admin has **no** read path to any tenant's usage.
+
+## Phased TDD tasks
+
+Each phase: write the failing tests first (Red), implement (Green), refactor. Docker-bound C# suites
+run via `sg docker -c "dotnet test ..."`; the build itself needs no wrapper.
+
+### Phase 1 — Emitter + types + non-blocking contract (the producer core)
+
+**Files (NEW):** `Services/Agents/IAgentUsageEmitter.cs`, `AgentUsageEmitter.cs`,
+`AgentUsageContext.cs` (`AgentUsageContext` + `AgentCallUsage` records), `AgentUsageTags.cs`,
+`AgentUsageEventTypes.cs` (`AGENT.USAGE.RECORDED`, `AGENT.USAGE.EMIT_FAILED`).
+**Modify:** `Program.cs` (DI: `AddScoped<IAgentUsageEmitter, AgentUsageEmitter>`).
+
+**Approach:** `RecordCallAsync` builds one `DomainEvent` (Tags = identity dims via `AgentUsageTags.
+Build`; `Data` = `{inputTokens, outputTokens, totalTokens, costBasisUsd, model, provider,
+credentialSource, durationMs}`) and `AppendAsync`. Wrap in try/catch that logs + emits
+`AGENT.USAGE.EMIT_FAILED` and **never rethrows** (mirror `AgentTrailEmitter`).
+
+**Tests** (`tests/Tamma.Api.Tests/Agents/AgentUsageEmitterTests.cs`,
+`AgentUsageNoPricingLeakageTests.cs`, fake `IEventRepository`):
+- Happy path → exactly one `AGENT.USAGE.RECORDED`; all required `Tags` keys present (AC 2);
+  `Data` token split + `costBasisUsd` correct (AC 3).
+- **No-pricing-leakage (AC 11):** deserialize emitted `Data` → assert `costBasisUsd` present and
+  `billableUsd`/`marginPct`/`feeUsd` **absent**. (Write this test first.)
+- Non-blocking (AC 9): `AppendAsync` throws → `RecordCallAsync` does not throw; `AGENT.USAGE.
+  EMIT_FAILED` breadcrumb attempted.
+
+### Phase 2 — Per-period rollup projection (idempotent)
+
+**Files (NEW):** `Data/Entities/AgentUsageRollup.cs`, `Data/Entities/AgentUsageApplied.cs`,
+`Services/Agents/AgentUsageRollupProjector.cs`, `Migrations/Tenant/*_AddAgentUsageRollup.cs`.
+**Modify:** `Data/TenantDbContext.cs` (DbSets + model config; unique
+`(agent_id, provider, credential_source, period_start)`).
+
+**Approach:** `ApplyAsync(DomainEvent)` — insert event id into `agent_usage_applied` first; if it
+already exists, no-op (idempotent, AC 6). Else parse Tags/Data, `date_trunc('month')` the period,
+upsert the per-`(agent, provider, credentialSource, period)` bucket adding tokens / `costBasisUsd` /
+`callCount`. Cost-basis columns only — **no billable column**. Run the projector from the emission
+path (apply-on-append) so it is replay-safe.
+
+**Tests** (`AgentUsageRollupTests.cs`, in-memory/test tenant DB):
+- Apply N distinct events → summed correctly, bucketed by `(agent, provider, credentialSource, period)`.
+- **Idempotency:** apply the same event id twice → counted once (AC 6).
+- BYOK vs platform kept in separate buckets, same provider rate-sheet `costBasisUsd` (AC 4).
+
+### Phase 3 — Tenant-scoped read endpoint
+
+**Files (NEW):** `Endpoints/AgentUsageEndpoints.cs`, `Dtos/Agents/AgentUsageDtos.cs`.
+**Modify:** `Program.cs` (map `GET /api/v1/orgs/{tenantId}/agents/usage` under the orgs group with
+`RequireTenantMembershipFilter` / `MemberAccess`).
+
+**Approach:** read `agent_usage_rollup` for the route tenant + current calendar month; project to
+`{ periodStart, periodEnd, byAgent[], totals }`. **No `billableUsd` field** on the wire (AC 7).
+Isolation is inherited (tenant-scoped store + path-tenant gate).
+
+**Tests** (`AgentUsageEndpointsTests.cs`, `AgentUsageIsolationTests.cs`):
+- Returns current-period breakdown by agent + provider + credentialSource; totals correct.
+- **Isolation (AC 8, highest priority):** B's path returns only B; member of A on B's path → 403/404;
+  platform owner → no read path to either; public-agent run by A → rollup only in A's schema.
+
+### Phase 4 — Wire emission into the 32-5 managed run + correlation linkage
+
+**Modify:** the 32-5 `IManagedAgent` execution path (gated on 32-5) — call `RecordCallAsync` once per
+logical LLM call (single-turn and accumulated tool-loop), sourcing `CostBasisUsd` from the
+diagnostic's `Cost` (the `IProviderPricingService.Compute` value — **no recompute**), threading the
+run's single `correlationId` + `agentId` through the diagnostic, the 32-6 trail event, and the usage
+tag; set `credentialSource` from 32-3's `ProviderCredential.Source` (default `platform`).
+
+**Tests** (`AgentUsageEmitterTests.cs` integration slice):
+- One-call-one-event for single-turn and tool-loop (AC 1).
+- **Link integrity (AC 5):** trail event + `ProviderDiagnostic` + `AGENT.USAGE.RECORDED` share
+  `(correlationId, agentId)`.
+- **Cost-basis parity (AC 4):** `Data.costBasisUsd == IProviderPricingService.Compute(provider, model,
+  in, out)`.
+
+### Phase 5 — Epic 20 re-target note (docs only)
+
+**Modify:** this story's AC 12 note + a one-line pointer in the Epic 20 20-3/20-4/20-5 story files
+("Superseded by 32-9 agent-aware cost-basis producer on the C# stack; `workflow_runs`/`llm_tokens` →
+`callCount`/`totalTokens` in `agent_usage_rollup`"). **No Epic 20 code** is created/modified — it does
+not exist in this stack.
+
+**Tests:** documentation parity check only (no Epic 20 code to exercise).
+
+## Sequencing & dependencies
+
+1. **Phase 1 → Phase 2 → Phase 3** are independently shippable against the existing event store and a
+   test tenant DB — **not gated on 32-5**. Build and test these first.
+2. **Phase 4** (run-loop wiring) is gated on **32-5** (the managed run) and reads **32-3**'s
+   `credentialSource` + **32-6**'s `correlationId`. If 32-5/32-3 lag, ship Phases 1-3 and stub the
+   call site (default `credentialSource = platform`, `correlationId` from the run).
+2. **32-1** supplies `agentId`/`agentVersion`; source from resolved config identity until it lands.
+3. **Phase 5** is doc-only, do any time.
+4. **Downstream:** Epic 34-5 / 35 / 36 consume the output; nothing in this story waits on them.
+
+## Risks
+
+| Risk | Severity | Mitigation |
+| ---- | --------- | ---------- |
+| Pricing/markup logic leaks into the producer (34-5 boundary breach) | High | Cost-basis-only `Data`; no `Plan`/margin reads; AC 11 no-leakage test written **first** (Phase 1) |
+| Cross-tenant usage leakage | Critical | Tenant-scoped store only; `RequireTenantMembershipFilter`; no `OwnerAccess` route; Phase 3 isolation suite (incl. public-agent + platform-admin-denied) |
+| Double-counted usage on replay/retry | High | `agent_usage_applied` idempotency ledger keyed by event id; Phase 2 replay test |
+| Usage write aborts a real agent run | High | Non-blocking emitter (swallow + retry + `AGENT.USAGE.EMIT_FAILED`); Phase 1 failure-injection test |
+| Cost basis drifts from the rest of the system | Medium | Single pricing seam reused (`ProviderDiagnostic.Cost`); Phase 4 parity test |
+| `credentialSource` / `agentId` unavailable before 32-3 / 32-1 | Medium | Default `credentialSource=platform`; source identity from resolved config; correctness tests once deps wire |
+| 32-5 not yet landed | Medium | Phases 1-3 ship + test standalone; Phase 4 is the only gated piece |
+
+## Acceptance criteria (definition of done)
+
+- [ ] Every agent LLM call emits exactly one `AGENT.USAGE.RECORDED` in the resolving tenant's schema
+      (single-turn + tool-loop), `Tags` + `Data` complete, `Data.costBasisUsd == IProviderPricingService.
+      Compute(...)`, and **no** `billableUsd`/margin/fee field anywhere (AC 1-4, 11 tests green).
+- [ ] `AGENT.USAGE.RECORDED`, its `ProviderDiagnostic`, and the 32-6 `AGENT.TASK.*` trail event share
+      `(correlationId, agentId)` (AC 5 link test green).
+- [ ] `agent_usage_rollup` aggregates per period × agent × provider × credentialSource, **idempotent on
+      event id** (AC 6 replay test green).
+- [ ] `GET /api/v1/orgs/{tenantId}/agents/usage` returns current-period byAgent/provider/credentialSource
+      breakdown (cost basis only, no `billableUsd`), member-readable, strictly tenant-isolated incl.
+      platform-admin-denied and public-agent run (AC 7, 8 isolation suite green).
+- [ ] Usage emission is non-blocking: induced append failure does not fail the run; `AGENT.USAGE.
+      EMIT_FAILED` breadcrumb emitted (AC 9 test green).
+- [ ] Both DCB types follow `AGGREGATE.ACTION.STATUS`; no secret/raw-prompt content persisted (AC 10).
+- [ ] Epic 20 re-target note present; **no Epic 20 code** created/modified (AC 12).
+- [ ] Full `apps/tamma-elsa` suite green via `sg docker -c "dotnet test ..."`; no regression in existing
+      diagnostics / `CallLlmInlineActivity` tests.
+</content>

--- a/docs/superpowers/plans/2026-06-17-34-1-plan-and-price-book-catalog-data-model-plan.md
+++ b/docs/superpowers/plans/2026-06-17-34-1-plan-and-price-book-catalog-data-model-plan.md
@@ -1,0 +1,322 @@
+# Story 34-1: Plan & Price-Book Catalog Data Model — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan phase-by-phase. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every phase writes tests
+> before implementation. C# suites that touch Postgres run via `sg docker -c "dotnet test ..."`.
+
+**Goal:** Replace the thin `Plan.Quotas` opaque-JSON skeleton with a structured, immutable,
+versioned price-book on the control plane: extended `Plan` + new `PlanFeature`, `PlanEntitlement`
+(typed quota rows), and `PlanPrice` (recurring + per-seat + metered components, split by BYOK vs
+platform-provided pricing mode). Plans become immutable, versioned rows — a new version supersedes
+rather than mutates, so historical tenant assignments stay reproducible. Reads go through
+`IPlanCatalogService → PlanSnapshot`. This is the schema foundation every other Epic 34 story
+builds on.
+
+**Story file:** `docs/stories/epic-34/story-34-1/34-1-plan-and-price-book-catalog-data-model.md`
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane API + Elsa engine).
+Catalog entities live in `Tamma.Data`, the quota-key enum in `Tamma.Core`, the catalog service in
+`Tamma.Api/Services/Pricing/` (NEW directory). Tests in `apps/tamma-elsa/tests/Tamma.Api.Tests/` and
+`tests/Tamma.Core.Tests/` (xUnit; docker-bound migration/constraint suites via
+`sg docker -c "dotnet test ..."`).
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO Stripe / billing / charging.** This story stores pricing data; Epic 35 charges against it.
+- **NO usage metering writes.** This story only defines the `EntitlementMetricKey` keys metering
+  will use later.
+- **NO quota enforcement.** Limits are stored; no request is blocked on them in this story (later
+  Epic 34 enforcement stories consume `PlanSnapshot.Entitlements`).
+- **NO admin write/CRUD endpoints.** The version editor ships as a tested service method; wiring it
+  behind admin endpoints is Story 34-2. This story adds only three read-only `GET` endpoints.
+- **NO cost→price markup computation.** `PlanPrice.MeteredComponent` is stored verbatim; the markup
+  engine is a separate Epic 34 story.
+- **NO per-tenant plan overrides.** The catalog is platform-global. Custom enterprise plans are
+  platform rows with `IsCustom = true`, assigned via the existing `Tenant.PlanId` FK.
+- **NO drop of the legacy `Plan.Quotas` / `MonthlyPriceUsd` columns.** Kept for one deprecation
+  window so not-yet-migrated readers compile; a follow-up story removes them.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### What exists today
+
+| Site | State |
+|---|---|
+| `src/Tamma.Data/Entities/Plan.cs` | Thin skeleton: `Id`, `Slug`, `DisplayName`, `MonthlyPriceUsd`, `Quotas` (opaque JSON string), `IsActive`, `PlacementPolicy`, timestamps. No version/status. Docstring already anticipates `PLAN.UPDATED` to `platform_events`. |
+| `src/Tamma.Data/Seeders/PlansSeeder.cs` | Seeds 3 rows (`free`/`team`/`enterprise`) with stable UUIDs (`FreePlanId`/`TeamPlanId`/`EnterprisePlanId` = `aaaaaaaa-…-0001/0002/0003`). Idempotency = `Plans.AnyAsync()` short-circuit (whole-table, not per-row). Quotas seeded as inline JSON strings. Wired at `src/Tamma.Api/Program.cs:2030`. |
+| `src/Tamma.Data/ControlPlaneDbContext.cs:76` | `DbSet<Plan> Plans`. `OnModelCreating` (line 215) calls a series of private `Configure*` methods (`ConfigureAlertRules`, `ConfigureTenantDatabases`, etc.) — the established pattern to mirror for the new tables. No `ConfigurePlans` exists; Plan config lives in `TammaModelConfiguration`. |
+| `src/Tamma.Data/TammaModelConfiguration.cs:203-296` | Epic 28 **shadow columns** on `tenants`: `Status`, **`PlanId` (Guid?)**, `EncryptedConnectionString`, `KekVersion`, etc. `PlanId` has an index (line 288) and an FK to `plans` with `OnDelete(Restrict)` (line 292). This is the seam `GetForTenantAsync` reads via `EF.Property<Guid?>(tenant, "PlanId")`. |
+| `src/Tamma.Api/Endpoints/Admin/AdminTenantsEndpoints.cs:590-644` | `UpdateTenantPlan` (PATCH `/api/admin/tenants/{id}/plan`) sets the `PlanId` shadow column to a `Plan.Id`, keeps `Tenant.Plan` string in lockstep, emits `PLAN.UPDATED` to `platform_events` via `IPlatformEventPublisher`. Validates `plan.IsActive`. Mapped at `Program.cs:1378`. **Must keep working unchanged.** |
+| `src/Tamma.Api/Endpoints/Admin/AdminTenantsEndpoints.cs:900-940` | `BuildAdminEvent(type, tenantId, principal, data)` helper — builds a `PlatformEvent` with `tags` (`tenantId`, `source`, actor) + enriched `data` + `Metadata = {"workflowVersion":"1.0.0","eventSource":"system"}`. Model the new `BuildPlanEvent` helper on this. |
+| `src/Tamma.Api/Services/PlatformEvents/PlatformEventPublisher.cs` + `IPlatformEventBus.cs` | `IPlatformEventPublisher.AppendAndPublishAsync(PlatformEvent, ct)` durably appends to `platform_events` then publishes in-process. Singleton; resolves a scoped `IPlatformEventRepository` per call. This is the DCB-event write seam (Epic 4). |
+| `src/Tamma.Data/Entities/PlatformEvent.cs` | CP-resident event row: `Id`, `Type`, `TenantId?`, `UserId?`, `Tags`/`Metadata`/`Data` (JSON strings), `CreatedAt`, `SequenceNumber` (BIGSERIAL). `AlertRuleEvaluator` polls this table. |
+| `src/Tamma.Data/Migrations/ControlPlane/` | `20260609205701_InitialControlPlane.cs` (Phase-0 collapsed baseline) + snapshot. New migration lands here via `dotnet ef migrations add … --context ControlPlaneDbContext`. |
+| `src/Tamma.Core/Enums/` | `AssessmentResult`, `BlockerType`, `MentorshipState`, `QualityGateResult`. Style = plain `public enum` with XML doc per member. `EntitlementMetricKey` lands here. |
+| `src/Tamma.Api/Services/Pricing/` | **Does not exist.** New directory for the catalog service. |
+| Auth policies (`src/Tamma.Api/Program.cs:971-1012`) | `OwnerAccess`, `PlatformOwnerAccess`, `MemberAccess`, `PromptManage` registered. Admin group `app.MapGroup("/api/admin").RequireAuthorization("AdminAccess")` (line 1244). The three read endpoints attach `OwnerAccess`. |
+| Test layout | `tests/Tamma.Api.Tests/` has per-area dirs (Admin, Alerts, Epic28, Provisioning, …) + `tests/Tamma.Core.Tests/`. New: `tests/Tamma.Api.Tests/Pricing/`, `tests/Tamma.Core.Tests/Enums/`. |
+| `docs/stories/epic-34/story-34-1/` | Exists, empty until this plan's story file. |
+
+### Key constraints derived from findings
+
+- The `Tenant.PlanId` FK to `plans(Id)` with `OnDelete(Restrict)` already exists — versioned plans
+  must not break it. A deprecated version is a normal `plans` row; the FK still resolves. Never
+  hard-delete a plan row that any tenant references (Restrict enforces this).
+- `PlansSeeder` currently uses a whole-table `AnyAsync` short-circuit. To seed child rows
+  insert-missing-only **and** backfill children on a DB that already has the 3 bare plan rows, the
+  short-circuit must become per-table / per-row existence checks.
+- `platform_events` is the correct store for `PLAN.VERSION.CREATED` / `PLAN.DEPRECATED` (CP-resident,
+  cross-tenant, polled by the alert evaluator) — not the per-tenant `domain_events`.
+
+---
+
+## Architecture
+
+**Versioned immutable catalog → typed entitlements/prices → resolved snapshot → DCB events.**
+
+1. **`EntitlementMetricKey`** (Tamma.Core) — closed quota-key enum, persisted as snake_case text via
+   a value converter. The single source of truth shared by entitlement, pricing, metering,
+   enforcement.
+2. **Extended `Plan` + `PlanFeature` / `PlanEntitlement` / `PlanPrice`** (Tamma.Data) — one
+   immutable version row per `(Slug, Version)`; `UNIQUE(Slug, Version)` + partial unique
+   `UX_plans_OneActivePerSlug WHERE Status='active'` enforce one current version per slug. Children
+   FK to `plans(Id)` with `OnDelete(Restrict)`.
+3. **`PlanVersionEditor`** (Tamma.Api) — the only write path. `CreateNewVersionAsync` inserts a new
+   active version, flips the prior to `deprecated`, emits events. An immutability guard rejects any
+   mutation of an `active`/`deprecated` row with `TammaError("PLAN.VERSION.IMMUTABLE")`.
+4. **`IPlanCatalogService → PlanSnapshot`** (Tamma.Api) — all reads. `GetActiveBySlugAsync`,
+   `GetByIdAsync`, `GetForTenantAsync` (via the `PlanId` shadow column), `ListActiveAsync`.
+5. **DCB events** `PLAN.VERSION.CREATED` / `PLAN.DEPRECATED` to `platform_events` via
+   `IPlatformEventPublisher`.
+6. **Read-only API** — three `GET /api/admin/plans*` endpoints (OwnerAccess). Write endpoints are
+   Story 34-2.
+
+### Per-mode ownership (CLAUDE.md two-scoping-model rule)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Who owns the catalog? | Platform (global rows); sole user reads it. | Platform owner (`OwnerAccess`); tenants read-only snapshots. |
+| Who creates/deprecates a version? | Sole user (same code path, no extra RBAC gate). | `OwnerAccess` only. |
+| Per-tenant override? | None. | None — custom plans are platform rows `IsCustom=true`. |
+| Reads consult mode? | No — catalog data is identical in both modes. | No. |
+
+---
+
+## Phased task breakdown (test-first)
+
+### Phase 1 — `EntitlementMetricKey` enum + value converter
+
+**Files:**
+- New: `src/Tamma.Core/Enums/EntitlementMetricKey.cs` — enum with 7 members
+  (`Agents`, `WorkflowRuns`, `LlmTokens`, `Seats`, `Repos`, `RagStorageMb`,
+  `BenchmarkRetentionDays`).
+- New: `src/Tamma.Core/Enums/EntitlementMetricKeyExtensions.cs` — `ToMetricString()` and
+  `Parse(string)` with the snake_case map; `Parse` throws `TammaError("PLAN.METRIC_KEY.UNKNOWN")`
+  on an unmapped string.
+
+**Tests first:** `tests/Tamma.Core.Tests/Enums/EntitlementMetricKeyTests.cs` —
+every member round-trips; `LlmTokens ↔ "llm_tokens"`, `RagStorageMb ↔ "rag_storage_mb"`,
+`BenchmarkRetentionDays ↔ "benchmark_retention_days"` pinned; unknown string throws; the snake_case
+set has no duplicates and exactly 7 entries (guards against adding an enum member without a mapping).
+
+**Approach:** Plain enum (ordinals never persisted). Extensions own the string contract. No DB in
+this phase — fast unit suite.
+
+### Phase 2 — Entities + EF model config
+
+**Files:**
+- New: `src/Tamma.Data/Entities/PlanFeature.cs`, `PlanEntitlement.cs`, `PlanPrice.cs`.
+- Modify: `src/Tamma.Data/Entities/Plan.cs` — add `Version`, `Status`, `IsCustom`,
+  `BillingInterval`, `SupersedesPlanId`, and nav collections `Features`/`Entitlements`/`Prices`.
+  Keep `Quotas`, `MonthlyPriceUsd`, `IsActive`, `PlacementPolicy`.
+- Modify: `src/Tamma.Data/ControlPlaneDbContext.cs` — add `DbSet<PlanFeature>`,
+  `DbSet<PlanEntitlement>`, `DbSet<PlanPrice>`; add `ConfigurePlans`, `ConfigurePlanFeatures`,
+  `ConfigurePlanEntitlements`, `ConfigurePlanPrices` and call them from `OnModelCreating` (mirror
+  `ConfigureAlertRules` / `ConfigureTenantDatabases` exactly).
+
+**Model config details:**
+- `plans`: CHECK `ck_plans_status` (`active`/`deprecated`/`draft`), `ck_plans_billing_interval`
+  (`monthly`/`annual`); `UX_plans_Slug_Version` unique; `UX_plans_OneActivePerSlug` partial unique
+  `WHERE "Status" = 'active'`; self-FK `SupersedesPlanId → plans(Id)` `OnDelete(Restrict)`.
+- `plan_entitlements`: `MetricKey` via `HasConversion(k => k.ToMetricString(), s => Parse(s))`
+  stored as `text`; CHECK `ck_plan_entitlements_period` + `ck_plan_entitlements_overage`;
+  `UX_plan_entitlements_PlanId_MetricKey` unique; FK `PlanId → plans(Id)` `OnDelete(Restrict)`.
+- `plan_features`: `UX_plan_features_PlanId_FeatureKey` unique; FK Restrict.
+- `plan_prices`: CHECK `ck_plan_prices_mode`; `RecurringUsd`/`SeatUsd` `HasPrecision(20,4)`;
+  `MeteredComponent` jsonb default `'{}'::jsonb`; `UX_plan_prices_PlanId_PricingMode` unique; FK
+  Restrict.
+
+**Tests first:** these are validated by the migration + constraint suite in Phase 4 (constraints
+are DB-level). Add a focused `ControlPlaneDbContext` model-shape unit test asserting the three
+DbSets resolve and `MetricKey` has the value converter configured (model metadata assertion, no DB).
+
+**Approach:** Configuration lives in `ControlPlaneDbContext.OnModelCreating` only (the established
+single source for CP entity config). Do not split across files.
+
+### Phase 3 — Snapshot, catalog service, version editor, events, DI
+
+**Files:**
+- New: `src/Tamma.Api/Services/Pricing/PlanSnapshot.cs` — immutable `record` + `PlanFeatureView` /
+  `PlanEntitlementView` / `PlanPriceView` projections.
+- New: `src/Tamma.Api/Services/Pricing/IPlanCatalogService.cs` + `PlanCatalogService.cs` —
+  `GetActiveBySlugAsync`, `GetByIdAsync`, `GetForTenantAsync` (reads `EF.Property<Guid?>(tenant,
+  "PlanId")`), `ListActiveAsync`. Eager-loads `Include(p => p.Features/Entitlements/Prices)`.
+- New: `src/Tamma.Api/Services/Pricing/PlanCatalogEventTypes.cs` — `PLAN.VERSION.CREATED`,
+  `PLAN.DEPRECATED`.
+- New: `src/Tamma.Api/Services/Pricing/PlanVersionEditor.cs` — `CreateNewVersionAsync(slug,
+  draftSpec, principal, ct)`: in one transaction, insert new active version (`Version+1`,
+  `SupersedesPlanId`), flip prior to `deprecated`, emit both events via `IPlatformEventPublisher`
+  (`BuildPlanEvent` helper modelled on `BuildAdminEvent`). Immutability guard throws
+  `TammaError("PLAN.VERSION.IMMUTABLE", severity High)` on any attempt to mutate an
+  `active`/`deprecated` row (implement as an explicit pre-write check in the editor; optionally a
+  `SavingChanges` interceptor for defence-in-depth).
+- New: `src/Tamma.Api/Extensions/PricingServiceCollectionExtensions.cs` — `AddPlanCatalog(services)`
+  registers `IPlanCatalogService` + `PlanVersionEditor` (scoped).
+- Modify: `src/Tamma.Api/Program.cs` — call `AddPlanCatalog`; map three read endpoints.
+
+**Tests first:**
+- `tests/Tamma.Api.Tests/Pricing/PlanCatalogServiceTests.cs` — snapshot assembly; active-only by
+  slug; frozen deprecated version by id; `GetForTenantAsync` resolves via shadow column; missing →
+  null.
+- `tests/Tamma.Api.Tests/Pricing/PlanVersionEditorTests.cs` — v1→v2 supersede link, prior flipped
+  to deprecated, both events emitted with correct tags (fake `IPlatformEventPublisher`); 3-version
+  chain.
+- `tests/Tamma.Api.Tests/Pricing/PlanImmutabilityTests.cs` — mutate active → throws; mutate
+  deprecated → throws; mutate draft → ok.
+
+**Approach:** Service is read-only and never throws on missing (returns null); editor owns all
+writes + events. Use an in-memory/Sqlite-backed `ControlPlaneDbContext` for service/editor unit
+tests where the partial-unique/CHECK behaviour is not under test; the DB-level invariants are
+covered in Phase 4.
+
+### Phase 4 — Seeder + migration + DB-level invariants
+
+**Files:**
+- Modify: `src/Tamma.Data/Seeders/PlansSeeder.cs` — keep the 3 plan UUIDs; set `Version=1`,
+  `Status="active"` on each; seed structured `PlanFeature`/`PlanEntitlement`/`PlanPrice` rows
+  (deterministic UUIDs) **insert-missing-only** per row (replace the whole-table `AnyAsync`
+  short-circuit with per-row `AnyAsync(predicate)` checks so children backfill and admin edits are
+  never reverted).
+- New: `src/Tamma.Data/Migrations/ControlPlane/<timestamp>_PlanPriceBookCatalog.cs` — generate via
+  `dotnet ef migrations add PlanPriceBookCatalog --context ControlPlaneDbContext`. Additive: new
+  `plans` columns (defaults backfill the 3 existing rows to `Version=1`/`Status='active'`), 3 new
+  tables, CHECKs, FKs, partial unique index.
+
+**Tests first:**
+- `tests/Tamma.Api.Tests/Pricing/PlansSeederTests.cs` — first seed populates child rows for all 3
+  slugs with known UUIDs + `Version=1`/`Status=active`; second seed is a no-op; an admin-edited
+  (draft v2) row is NOT reverted by re-seed.
+- `tests/Tamma.Api.Tests/Pricing/PlanCatalogMigrationTests.cs` (docker-bound) — apply migration to a
+  clean DB, assert tables/columns/CHECKs/partial-unique exist; rollback clean.
+- One-active-version invariant test (docker-bound) — inserting a second `Status='active'` row for an
+  existing slug raises a unique-violation `DbUpdateException`.
+- **Tenant-isolation test** — catalog is platform-global; `GetForTenantAsync` returns only the
+  tenant's own assigned plan version and never leaks `draft` versions; two tenants on different
+  versions each resolve their own frozen snapshot.
+
+**Approach:** Run `dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext`
+after generating — must report none. Docker-bound suites via `sg docker -c "dotnet test ..."`.
+
+### Phase 5 — Read endpoints + verification
+
+**Files:**
+- Modify: `src/Tamma.Api/Program.cs` — map (under the `admin` group, `OwnerAccess`):
+  `GET /api/admin/plans`, `GET /api/admin/plans/{slug}`, `GET /api/admin/plans/{slug}/versions`.
+- Optional new: `src/Tamma.Api/Endpoints/Admin/PlanCatalogEndpoints.cs` for the handlers (mirror
+  `AdminTenantsEndpoints` static-handler style) — or inline if trivial.
+
+**Tests first:** `tests/Tamma.Api.Tests/Pricing/PlanCatalogEndpointsTests.cs` — OwnerAccess required
+(non-owner → 403); list returns active snapshots; `{slug}` returns active version; `{slug}/versions`
+returns the active+deprecated chain; unknown slug → 404.
+
+**Verification:** full C# suite green (`sg docker -c "dotnet test apps/tamma-elsa"`), build clean,
+`has-pending-model-changes` clean, migration up+down clean.
+
+---
+
+## Sequencing & dependencies
+
+Phase 1 (enum) → Phase 2 (entities/config) → Phase 3 (service/editor/events) →
+Phase 4 (seeder/migration/DB-invariants) → Phase 5 (endpoints).
+
+- Phase 1 is the only hard prerequisite for everything else (the enum is referenced by entities,
+  service, seeder).
+- Phase 2 must land before Phase 4's migration (the migration is generated from the model).
+- Phase 3 and Phase 4's seeder can proceed in parallel once Phase 2 lands; the DB-invariant tests in
+  Phase 4 need the migration applied.
+- **External prerequisites:** Epic 28 (ControlPlaneDbContext, `Tenant.PlanId` shadow FK, seeder
+  pipeline, `Migrations/ControlPlane/`) and Epic 4 (`platform_events`, `IPlatformEventPublisher`) —
+  both already shipped on main.
+- **This story blocks:** Story 34-2 (admin CRUD wires the editor behind endpoints), the markup-engine
+  story (reads `PlanPrice.MeteredComponent`), Epic 35 Billing, and the entitlement-enforcement
+  stories.
+
+---
+
+## Risks + mitigations
+
+- **Breaking the existing `Tenant.PlanId` FK / `UpdateTenantPlan`.** The FK targets `plans(Id)`;
+  versioned plans are still normal `plans` rows, so the FK resolves to a specific version. Mitigation:
+  keep `Slug`/`DisplayName`/`IsActive` columns; do not change `UpdateTenantPlan`; add a regression
+  test that asserts the existing PATCH `/api/admin/tenants/{id}/plan` flow still works against a
+  versioned plan row.
+- **Seeder reverting admin edits.** The current whole-table `AnyAsync` short-circuit would mask the
+  need for per-row insert-missing-only. Mitigation: switch to per-row existence checks; a dedicated
+  seeder test asserts an edited row survives a re-seed (mirrors convention system-defaults ownership,
+  `feedback_resolution` / `project_convention_system_defaults_ownership`).
+- **Two active versions slipping through under concurrency.** The application-level flip-then-insert
+  could race. Mitigation: the partial unique index `UX_plans_OneActivePerSlug` is the load-bearing
+  guard — the DB rejects a second active row regardless of app logic; the editor runs the flip+insert
+  in one transaction and surfaces the unique-violation as a clear error. A docker-bound test inserts
+  a second active row directly and asserts the violation.
+- **Migration not additive / pending model changes.** Mitigation: generate with EF tooling, run
+  `has-pending-model-changes` (must be none), test up+down on a clean DB. New columns carry
+  backfilling defaults so the 3 existing seeded rows become `Version=1`/`Status='active'` without a
+  data migration.
+- **`EntitlementMetricKey` drift between layers.** A new enum member without a string mapping would
+  silently break persistence. Mitigation: the enum test asserts the snake_case map has exactly one
+  entry per member (count + no-duplicates check), so adding a member without a mapping fails the
+  suite.
+- **Event-store topology shift (Story 28-1 / Epic 30).** `PLAN.*` events are platform-scope and must
+  stay CP-resident. Mitigation: emit via `IPlatformEventPublisher` (writes `platform_events`)
+  explicitly, never the per-tenant `domain_events` path — same precedent as `PLAN.UPDATED`.
+- **Legacy `Quotas` JSON divergence.** Keeping the JSON column alongside typed rows risks two sources
+  of truth. Mitigation: the column is read-only legacy for one deprecation window; new code reads
+  `Entitlements`; the seeder writes both consistently; a follow-up story drops the JSON once Epic 35
+  is off it. Documented in the story's boundary notes.
+
+---
+
+## Acceptance criteria (mirror the story)
+
+- [ ] `Plan` extended with `Version`, `Status` (`active`/`deprecated`/`draft`), `IsCustom`,
+      `BillingInterval` (`monthly`/`annual`), `SupersedesPlanId`; legacy `Slug`/`DisplayName`/
+      `IsActive`/`PlacementPolicy` + `Tenant.PlanId` FK preserved.
+- [ ] `PlanFeature`, `PlanEntitlement`, `PlanPrice` entities + DbSets added to
+      `ControlPlaneDbContext`; FKs `OnDelete(Restrict)` to `plans(Id)`.
+- [ ] `EntitlementMetricKey` closed enum in `Tamma.Core/Enums` with 7 members, persisted as
+      snake_case text, shared by entitlement/pricing/metering/enforcement.
+- [ ] Plan versions immutable after activation: mutating an `active`/`deprecated` row throws
+      `PLAN.VERSION.IMMUTABLE`; editing creates `Version+1` + flips prior to `deprecated`.
+- [ ] `UNIQUE(Slug, Version)` + partial unique `UX_plans_OneActivePerSlug WHERE Status='active'`;
+      CHECKs pin `Status`/`BillingInterval`/`Period`/`OverageMode`/`PricingMode`.
+- [ ] Additive EF migration under `Migrations/ControlPlane/`; `has-pending-model-changes` reports
+      none; up+down clean.
+- [ ] `PlansSeeder` seeds structured feature/entitlement/price rows for free/team/enterprise with
+      deterministic UUIDs, insert-missing-only, never reverting admin edits.
+- [ ] `IPlanCatalogService` returns fully-resolved immutable `PlanSnapshot`
+      (`GetActiveBySlugAsync`/`GetByIdAsync`/`GetForTenantAsync`/`ListActiveAsync`).
+- [ ] Catalog mutations emit `PLAN.VERSION.CREATED` / `PLAN.DEPRECATED` to `platform_events` via
+      `IPlatformEventPublisher` with `slug`/`version`/`planId`/`supersedesPlanId` tags.
+- [ ] Three read-only `GET /api/admin/plans*` endpoints gated by `OwnerAccess`; write endpoints
+      deferred to Story 34-2.
+- [ ] Per-mode: catalog platform-owned in both modes; SaaS owner-only create/deprecate, tenant
+      read-only snapshots; no per-tenant override layer.
+- [ ] Unit + integration tests cover immutability, supersede chain, one-active-version invariant,
+      seeder idempotency, snapshot resolution, event emission, and tenant-isolation; full suite
+      green; build clean.

--- a/docs/superpowers/plans/2026-06-17-34-10-epic-20-decommission-and-pricing-contract-migration-plan.md
+++ b/docs/superpowers/plans/2026-06-17-34-10-epic-20-decommission-and-pricing-contract-migration-plan.md
@@ -1,0 +1,297 @@
+# Story 34-10: Epic 20 Decommission & Pricing Contract Migration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan phase-by-phase. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every phase writes tests
+> before implementation. C# docker-bound suites run via `sg docker -c "dotnet test ..."`; the build
+> needs no wrapper (`reference_dotnet_test_docker`).
+
+**Goal:** Formally retire the stale TypeScript Epic 20 plan/pricing surface, back-fill every
+existing plan and tenant from the legacy opaque `Plan.Quotas` JSON and loose `Tenant.Plan` string
+onto Epic 34's structured catalog (34-1 `PlanEntitlement`) and assignment model (34-4
+`TenantPlanAssignment`), and publish a single stable `IPricingContract` façade as the ONLY surface
+Billing (Epic 35) and the Enforcement epic call into. The migration is idempotent/re-runnable; the
+façade delegates to already-built services and adds zero pricing logic.
+
+**Story file:** `docs/stories/epic-34/story-34-10/34-10-epic-20-decommission-and-pricing-contract-migration.md`
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane API + Elsa engine).
+Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/` (xUnit). Docs in `docs/stories/` and
+`docs/sprint-status.yaml`.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- NO new pricing logic. The catalog (34-1), assignment (34-4), markup engine (34-5), entitlement
+  resolution (34-6), and credit-aware net price (34-7) are *consumed*. A single line of pricing math
+  in the façade means scope leaked from a sibling story.
+- NO Stripe / subscriptions / checkout / portal / webhooks / metering / billing dashboard. That
+  scope is **re-homed to Epic 35 (Billing)** — this story only updates the Epic 20 status *notes*.
+- NO quota enforcement / blocking. The contract resolves and prices; the sibling Enforcement epic
+  gates on it.
+- NO DDL change to drop `Plan.Quotas` / `Tenant.Plan` — those columns stay one deprecation window
+  (34-1's decision); a later story drops them once Epic 35 is off the JSON.
+- NO tenant-scoped pricing table. The catalog/assignment are platform-global CP rows in both modes.
+- NO reversible data down-migration. Per CLAUDE.md no-migration-anxiety (pre-production), "rollback"
+  = drop-and-reseed; the guarantee is idempotency (second run = no-op), not data reversal.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### What exists today (the legacy surface to migrate off)
+
+| Site | State today |
+|---|---|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/Plan.cs` | Thin skeleton: `Id`, `Slug`, `DisplayName`, `MonthlyPriceUsd`, **`Quotas` (opaque JSON string, default `"{}"`)**, `IsActive`, `PlacementPolicy`. 34-1 extends it with `Version`/`Status`/nav collections. |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/Tenant.cs` (line 11) | `public string Plan { get; set; } = "free";` — the loose slug string. `Tenant.PlanId` is an Epic-28 **shadow** column (`EF.Property<Guid?>`), not a CLR property on the entity. |
+| `apps/tamma-elsa/src/Tamma.Data/Seeders/PlansSeeder.cs` | Seeds 3 plans with `Quotas` JSON: free `{"llmTokensPerMonth":100000,"concurrentWorkflows":1,"seats":1}`, team `…2000000…seats:10`, enterprise `…50000000…"seats":-1` (line 84 — **`-1` = unlimited sentinel**). `SeedAsync` short-circuits if **any** plan exists (line 44-48) — 34-1 changes this to per-table insert-missing-only. Stable IDs: `FreePlanId`/`TeamPlanId`/`EnterprisePlanId` (lines 23-32). |
+| `docs/sprint-status.yaml` (lines 273-279) | `epic-20: contexted`; `20-1`..`20-5` all `drafted` with "spec only" notes. The `20-1` note literally says "Plan.cs catalogue exists but is tenancy placement (Epic 28), not the Stripe plan/customer model"; `20-4` note: "Plan.Quotas JSON defined but unused by any billing/orchestrator check". **`epic-34` is NOT yet a block in this file** — this story adds it. |
+| `docs/stories/migration-ordering.md` | The canonical cross-epic migration-number ledger (001-018 listed; rules: never reuse/reorder a number, idempotency required). The format the new pricing ordering note mirrors. Note: this ledger tracks the legacy `database/migrations/*.sql` numbering; the C# CP migrations live under `Tamma.Data/Migrations/ControlPlane/` (EF, timestamp-named) — the new note records the EF ordering. |
+
+### What 34-1..34-7 will have built (this story's hard inputs)
+
+> Verified by reading the drafted sibling stories under `docs/stories/epic-34/story-34-*/`. All land
+> in `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/` (a NEW directory created by 34-1 — confirmed
+> absent today: `ls apps/tamma-elsa/src/Tamma.Api/Services/Pricing/` → no such directory).
+
+| From | Surface this story consumes |
+|---|---|
+| 34-1 | `EntitlementMetricKey` (closed enum: `Agents`,`WorkflowRuns`,`LlmTokens`,`Seats`,`Repos`,`RagStorageMb`,`BenchmarkRetentionDays`; snake_case persisted), `PlanEntitlement` (`MetricKey`,`LimitValue long?`=NULL unlimited,`Period`,`OverageMode`), `IPlanCatalogService.GetByIdAsync`, `PlanSnapshot`, `PricingServiceCollectionExtensions`, the `Services/Pricing/` dir. |
+| 34-3 | `PricingMode` (`byok`\|`platform`) semantics — `TenantProviderBilling` per-(tenant,provider) override; the contract's `PriceUsageAsync` must honor mode end-to-end. |
+| 34-4 | `TenantPlanAssignment` (`PlanVersion` pinned, partial-unique `Status='active'`), `IPlanAssignmentService.GetActiveAsync`/`AssignAsync`, the back-fill-one-active-per-tenant migration pattern (raw SQL with `COALESCE(PlanId, slug-match, plan_free)`). |
+| 34-5 | `IUsagePricingEngine.PriceUsage(UsageLine, MarginPolicy)` → `PricedUsage(CostBasisUsd, MarginUsd, SellPriceUsd, PricingMode)` (pure; BYOK → zero token markup), `IMarginPolicyResolver.ResolveAsync(tenantId, provider)`, `UsageLine`. Cost basis from existing `IProviderPricingService` (verified at `apps/tamma-elsa/src/Tamma.Api/Services/Providers/IProviderPricingService.cs` — `Compute`/`IsKnown`). |
+| 34-6 | `IEntitlementService.ResolveAsync(EntitlementPrincipal)` → `ResolvedEntitlements` (closed 7-key map), `EntitlementPrincipal.ForTenant`. Fail-loud `ENTITLEMENT.RESOLVE.NO_ASSIGNMENT` (no empty fallback). |
+| 34-7 | `ICreditAwarePricingEngine.PriceNetAsync(UsageLine, tenantId)` → `NetPriceResult(SellPriceUsd, PromoDiscountUsd, CreditsAppliedUsd, NetPriceUsd, TrialWaived)`. **Soft dep** — pass-through default if not yet merged. |
+
+### Infrastructure seams (verified present today)
+
+- `apps/tamma-elsa/src/Tamma.Data/Abstractions/IPlatformEventPublisher.cs` — `AppendAndPublishAsync(PlatformEvent, ct)` → CP `platform_events`, idempotent (null on dedup collision). The back-fill audit path.
+- `apps/tamma-elsa/src/Tamma.Data/Entities/PlatformEvent.cs` + `DomainEvent.cs` — event rows.
+- `apps/tamma-elsa/src/Tamma.Data/Repositories/IEventRepository.cs` — DCB append (tenant-scope; not needed for the CP-resident back-fill events but available).
+- Authorization policies confirmed in use (`apps/tamma-elsa/src/Tamma.Api/Auth/PermissionHandler.cs`, endpoints): `OwnerAccess`, `PlatformOwnerAccess`, `MemberAccess`, `PromptManage`. The admin re-run uses `PlatformOwnerAccess`.
+- `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/` — EF CP migration dir (`20260609205701_InitialControlPlane` is the baseline). New data-only migration lands here.
+
+---
+
+## Architecture
+
+**Migrate the data → freeze the surface → record the retirement.** Three pillars:
+
+1. **`IPricingContract`** (`Tamma.Api/Services/Pricing/`) — a thin, total façade with four read ops
+   (`ResolvePlanAsync`, `ResolveEntitlementsAsync`, `PriceUsageAsync`, `PriceNetAsync`) that each
+   delegate one-to-one to a 34-x service. Zero pricing math. Returns published DTOs
+   (`Tamma.Api/Dtos/Pricing/PricingContractDtos.cs`) so a later refactor of internals can't break
+   Billing. Fail-loud on no assignment (`PRICING.CONTRACT.NO_ASSIGNMENT`).
+2. **`PricingBackfillService` + data-only EF migration** — idempotent, insert-missing-only.
+   Migration does the bulk (jsonb→entitlements, tenant→assignment via `NOT EXISTS` guards); the
+   startup service heals stragglers and emits `PRICING.BACKFILL.*` audit events the raw SQL can't.
+3. **Retirement bookkeeping** — `docs/sprint-status.yaml` Epic 20 supersede/re-home notes + a new
+   `epic-34` block; `docs/stories/epic-34/pricing-contract.md` (the published contract) +
+   `pricing-migration-ordering.md` (CP-vs-tenant ordering, mirrors `migration-ordering.md`).
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns the catalog/contract? | Platform-global CP rows; the sole user reads via the façade/underlying API. | Platform-global CP rows; tenants read via 34-6's `GET /api/pricing/entitlements`. Façade is in-process for Billing/Enforcement. |
+| Who/what does the back-fill scope? | Runs once on CP rows; the lone tenant gets one assignment. | Runs once on CP rows; every non-deleted tenant gets exactly one `active` assignment. |
+| Façade per-mode resolution | Delegates to 34-6/34-4 which key sole-user → personal tenant. | Delegates which key by `tenant_id`. The façade adds NO new RBAC. |
+| Who may trigger the admin re-run? | The sole user (authenticated; same code path). | `PlatformOwnerAccess` (platform owner) only. |
+| Tenant-scoped pricing table? | None — global catalog. | None — global catalog. |
+| Mode source | `ITammaModeProvider` (via the underlying services). | same |
+
+---
+
+## Phased task breakdown
+
+### Phase 0: Prerequisite gate + research (no code)
+
+- [ ] Confirm 34-1, 34-3, 34-4, 34-5, 34-6 are merged (their entities/services exist in
+      `Services/Pricing/`). 34-7 is a soft dep — note whether it is present (drives the
+      `PriceNetAsync` pass-through decision).
+- [ ] Read `.dev/` for pricing/migration/resolution-fail-loud findings and the no-migration-anxiety
+      note; read `docs/stories/migration-ordering.md` (format) and `PlansSeeder.cs` (insert-missing
+      ownership rule).
+- [ ] Verify the C# test runner contract (`sg docker -c "dotnet test ..."`).
+
+### Phase 1: Published contract DTOs + façade (TDD)
+
+**Files:** `Tamma.Api/Dtos/Pricing/PricingContractDtos.cs` (new), `Services/Pricing/IPricingContract.cs`
+(new), `Services/Pricing/PricingContract.cs` (new), `Extensions/PricingServiceCollectionExtensions.cs`
+(modify — `AddPricingContract`), `Program.cs` (modify — DI).
+
+- [ ] **Test first** `tests/Tamma.Api.Tests/Pricing/PricingContractTests.cs`:
+  - `ResolveEntitlements_ReturnsAllSevenKeys` (façade returns the closed 7-key map; fake `IEntitlementService`).
+  - `ResolvePlan_PinnedNotLatest` (assign v1, deprecate to v2; façade still returns v1; mock 34-1/34-4).
+  - `PriceUsage_HonorsPricingMode` (byok → `SellPriceUsd == CostBasisUsd`; platform → markup applied; mock 34-5).
+  - `PriceNet_Invariant` (`NetPriceUsd == SellPriceUsd − PromoDiscountUsd − CreditsAppliedUsd`; mock 34-7; pass-through when 34-7 absent).
+  - `NoAssignment_FailsLoud` (`PRICING.CONTRACT.NO_ASSIGNMENT`; never empty — pins `feedback_resolution_no_empty_fallback`).
+- [ ] Define `PricingContractDtos.cs`: `PlanContractView`, `EntitlementContractView`+`EntitlementLineView`, `PricedUsageView`, `NetPriceView` with `From(...)` mappers off the underlying records.
+- [ ] Implement `IPricingContract` + `PricingContract` (delegation only — each method ≤3 lines + the fail-loud guard, as sketched in the story Technical Design).
+- [ ] `AddPricingContract(services)` registers `IPricingContract` scoped; call from `Program.cs`. Register `PriceNetAsync`'s engine as a pass-through default when 34-7 is absent (feature flag / null-object).
+- [ ] Green the Phase-1 tests.
+
+### Phase 2: Legacy quota mapper + back-fill service (TDD)
+
+**Files:** `Services/Pricing/PricingBackfillModels.cs` (new — `BackfillReport`, `LegacyQuotaMap`,
+`BackfillTrigger`), `Services/Pricing/IPricingBackfillService.cs` (new),
+`Services/Pricing/PricingBackfillService.cs` (new), `Services/Pricing/PricingBackfillEventTypes.cs`
+(new — `PRICING.BACKFILL.STARTED/.COMPLETED/.SKIPPED`).
+
+- [ ] **Test first** `tests/Tamma.Api.Tests/Pricing/LegacyQuotaMapTests.cs`:
+  - `{"llmTokensPerMonth":2000000,"seats":10}` → 2 `PlanEntitlement` specs.
+  - `seats:-1` → `LimitValue = null` (unlimited sentinel).
+  - `concurrentWorkflows` present → NOT mapped + WARN logged (it is not an `EntitlementMetricKey`).
+  - empty/`{}`/malformed JSON → no rows, no throw.
+- [ ] **Test first** `tests/Tamma.Api.Tests/Pricing/PricingBackfillServiceTests.cs`:
+  - `Run_ConvertsQuotas_InsertMissingOnly` (plan with legacy JSON + no rows → entitlements; plan already seeded by 34-1 → untouched).
+  - `Run_AssignsEveryTenant_FallbackChain` (`PlanId` → that plan; NULL `PlanId` + `Plan="team"` → team; neither → `plan_free`; pin `PlanVersion`).
+  - `Run_ZeroTenantWithoutAssignment_Invariant` (AC2 query returns zero; a skipped tenant → `PRICING.BACKFILL.INCOMPLETE` thrown).
+  - `Run_SecondRun_IsNoOp` (zero inserts, `WasNoOp=true`, emits `SKIPPED`, no `COMPLETED`).
+  - `Run_EmitsEvents` (`STARTED` then `COMPLETED` with counts/duration; fake `IPlatformEventPublisher`).
+- [ ] Implement `LegacyQuotaMap` (pure JSON→`PlanEntitlement`-spec; the `-1→NULL` + unmapped-key WARN rules).
+- [ ] Implement `PricingBackfillService.RunAsync` per the story algorithm: detect-prior-completion → quotas→entitlements (insert-missing) → tenant→assignment (insert-missing, delegate to `AssignAsync` with `Reason="backfill: 34-10"`) → verify invariant (throw on miss) → emit `COMPLETED`. Single-flight lock (in-process semaphore + DB advisory lock).
+- [ ] `AddPricingBackfill(services)` + invoke `RunAsync(Startup)` once at API startup **after**
+      `PlansSeeder.SeedAsync` (mirror its startup wiring in `Program.cs`).
+- [ ] Green the Phase-2 tests.
+
+### Phase 3: Data-only EF migration (TDD via integration)
+
+**Files:** `Tamma.Data/Migrations/ControlPlane/<ts>_PricingBackfillDataStep.cs` (new),
+`docs/stories/epic-34/pricing-migration-ordering.md` (new).
+
+- [ ] **Test first** `tests/Tamma.Api.Tests/Pricing/PricingBackfillMigrationTests.cs` (docker):
+  - apply 34-1 + 34-4 + this data step to a clean DB seeded with the 3 legacy plans → assert
+    structured `plan_entitlements` + one `active` `tenant_plan_assignments` per tenant.
+  - re-apply the data step → zero new rows (idempotent `NOT EXISTS`).
+- [ ] Write the data-only migration (jsonb extraction for entitlements; `COALESCE(PlanId, slug, free)`
+      tenant assignment; both `NOT EXISTS`-guarded), as sketched in the story. `Down()` deletes only
+      `Reason='backfill: 34-10'` rows.
+- [ ] Run `dotnet ef migrations add PricingBackfillDataStep --context ControlPlaneDbContext`, then
+      `dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext` → MUST report
+      none (data-only, no DDL).
+- [ ] Write `pricing-migration-ordering.md`: list the EF CP migration order (34-1 schema → 34-4
+      schema → this data step), state all pricing tables are CP-resident (NO `t_<hex>` pricing
+      table), and that the data step runs after both schema migrations. Mirror the rules section of
+      `docs/stories/migration-ordering.md`.
+- [ ] Green the Phase-3 docker tests.
+
+### Phase 4: Admin re-run endpoint + smoke + isolation tests (TDD)
+
+**Files:** `Endpoints/Admin/AdminPricingBackfillEndpoint.cs` (new), `Program.cs` (modify — map route),
+`tests/Tamma.Api.Tests/Pricing/PricingContractSmokeTests.cs` (new).
+
+- [ ] **Test first** in `PricingContractSmokeTests` (docker, AC8): seed `free`/`team`/`enterprise`
+      tenants, run the back-fill, call all four contract ops per tenant → zero errors (plan +
+      complete entitlements + priced usage + net price).
+- [ ] **Test first** tenant-isolation (AC13): two tenants on different plans — back-fill assigns each
+      only its own plan (no cross-tenant assignment); `ResolveEntitlementsAsync(A)` never returns B's
+      limits.
+- [ ] **Test first** `LegacyPathFlowsThroughContract`: `AdminTenantsEndpoints.UpdateTenantPlan`
+      routes through `IPlanAssignmentService`, never re-deriving from `Quotas`; a contract read after
+      reflects the new pinned assignment.
+- [ ] Implement `POST /api/admin/pricing/backfill` (`PlatformOwnerAccess`) → `RunAsync(Admin)`,
+      returning the `BackfillReport`; 409 on `backfill_in_progress` (single-flight).
+- [ ] Green Phase-4 tests.
+
+### Phase 5: Published contract doc + Epic 20 retirement bookkeeping (no code)
+
+**Files:** `docs/stories/epic-34/pricing-contract.md` (new), `docs/sprint-status.yaml` (modify).
+
+- [ ] Write `pricing-contract.md` (AC5): the four operations + I/O shapes, `PricingMode`
+      (`platform_provided`|`byok`) semantics, and the explicit rule that no epic may take a direct
+      dependency on `Plan`/`PlanEntitlement`/`PlanPrice`/`TenantPlanAssignment`/`IUsagePricingEngine`/
+      `IEntitlementService`/`ICreditAwarePricingEngine` — every cross-epic read goes through
+      `IPricingContract`.
+- [ ] Edit `docs/sprint-status.yaml`:
+  - `20-1-stripe-integration-plan-model: superseded` — note "Plan/quota model owned by Epic 34 (34-1/34-4); Stripe subscription/customer scope re-homed to Epic 35".
+  - `20-4-usage-limits-enforcement: superseded` — note "Quota model owned by Epic 34 (34-1/34-6); enforcement re-homed to the Epic 34 Enforcement story".
+  - `20-2`/`20-3`/`20-5` — leave status `drafted`, update notes to "re-homed to Epic 35 (Billing); retired there, not here".
+  - Add an `epic-34:` block (mirror the existing `epic-NN:` blocks' style) with `34-10-…: drafted`
+    plus the sibling story statuses if not already present.
+- [ ] Final full-suite run: `sg docker -c "dotnet test apps/tamma-elsa"` green; build green.
+
+---
+
+## Sequencing & dependencies
+
+```
+Phase 0 (gate) → Phase 1 (façade) ─┐
+                                    ├→ Phase 4 (admin re-run + smoke/isolation)
+Phase 0 → Phase 2 (back-fill svc) ─┤
+              → Phase 3 (migration)┘
+Phase 5 (docs/bookkeeping) — after Phase 4 (so the contract doc matches the shipped façade)
+```
+
+- Phase 1 (façade) and Phase 2 (back-fill) are independent and can be built in parallel; both need
+  Phase 0's prereq gate.
+- Phase 3 (migration) depends on Phase 2's `LegacyQuotaMap`/assignment logic for parity (the SQL
+  mirrors the service's mapping rules) but can be drafted alongside.
+- Phase 4 needs both the façade (Phase 1) and the back-fill (Phase 2/3) to run the smoke test.
+- Phase 5 is documentation; write the contract doc last so it describes the actually-shipped surface.
+- **Hard external prereq:** 34-1, 34-3, 34-4, 34-5, 34-6 merged. **Soft:** 34-7 (pass-through if absent).
+
+---
+
+## Risks + mitigations
+
+- **Scope leak into the façade.** The biggest risk is re-implementing pricing logic in
+  `PricingContract`. *Mitigation:* the conformance tests mock every underlying service and assert the
+  façade only *delegates*; any business logic would fail "delegates to faked service exactly once".
+  Code-review rule: each façade method ≤3 lines + the fail-loud guard.
+- **Back-fill leaves a tenant without an assignment.** A silent gap would break every downstream
+  read. *Mitigation:* AC2 verification query runs at the end of `RunAsync` and throws
+  `PRICING.BACKFILL.INCOMPLETE` (Critical) — fail loud, never partial-silent. Tested explicitly.
+- **Non-idempotent re-run double-inserts.** *Mitigation:* `NOT EXISTS` guards in both the SQL and the
+  service; second-run-is-no-op test pins it; `Reason='backfill: 34-10'` stamps backfill rows so
+  `Down()` is surgical.
+- **`-1` sentinel mis-mapped to a real (huge) limit instead of unlimited.** *Mitigation:*
+  `NULLIF(..., -1)` in SQL and the `LegacyQuotaMap` `-1 → null` rule, both tested (enterprise
+  `seats:-1` → unlimited).
+- **Migration topology shift (Story 28-1 / Epic 30).** Pricing tables + back-fill events are
+  CP-resident. *Mitigation:* `pricing-migration-ordering.md` states this explicitly; events append
+  via the CP `IPlatformEventPublisher` so a later per-tenant event move only touches tenant-scope
+  routing, not pricing.
+- **34-7 not merged when this lands.** *Mitigation:* `PriceNetAsync` registered as a pass-through
+  (`NetPriceUsd == SellPriceUsd`), feature-flagged; its conformance test `[Fact(Skip="awaiting 34-7")]`
+  until 34-7 ships. Documented in `pricing-contract.md`.
+- **Over-retiring Epic 20.** Marking `20-2`/`20-3`/`20-5` superseded would overstep the Epic 34 ↔
+  Epic 35 boundary. *Mitigation:* AC3 pins exactly which stories are `superseded` here (`20-1`,
+  `20-4`) vs only re-homed (the Stripe/metering/dashboard trio). Boundary note in the story.
+- **`has-pending-model-changes` noise.** The data-only migration must add no DDL. *Mitigation:* no
+  entity/`OnModelCreating` change in this story; verify `has-pending-model-changes` reports none.
+
+---
+
+## Acceptance criteria (mirror the story)
+
+1. Re-runnable, idempotent back-fill converts legacy `Plan.Quotas` JSON → typed `PlanEntitlement`
+   rows (`-1 → NULL` unlimited; `concurrentWorkflows` dropped + WARN); plans already carrying
+   structured rows are untouched.
+2. Exactly one `active` `TenantPlanAssignment` per non-deleted tenant (`PlanId` → `Slug` →
+   `plan_free` fallback; `PlanVersion` pinned); no tenant left without an assignment (verified query
+   returns zero).
+3. Epic 20 `20-1`/`20-4` marked `superseded` in `docs/sprint-status.yaml` pointing at Epic 34;
+   `20-2`/`20-3`/`20-5` re-homed to Epic 35 (note only, NOT superseded here).
+4. `IPricingContract` façade (4 ops: resolve-plan, resolve-entitlements, price-usage,
+   net-price-with-credits) is the ONLY surface Epic 35/Enforcement call into; it delegates to
+   34-1/34-4/34-5/34-6/34-7 with no direct entity access from other epics.
+5. `docs/stories/epic-34/pricing-contract.md` documents the contract + the no-direct-dependency rule.
+6. Conformance tests assert stable shapes + BYOK-vs-platform pricing honored end-to-end + the
+   net-price invariant.
+7. `pricing-migration-ordering.md` records CP-vs-tenant ordering (all pricing tables CP-resident; data
+   step after 34-1/34-4 schema migrations).
+8. Smoke test on a seeded env: free/team/enterprise tenants all resolve plan + entitlements + price +
+   net price with zero errors post-migration.
+9. Rollback story documented: pre-production drop-and-reseed; back-fill re-runnable/idempotent;
+   second-run no-op verified.
+10. Back-fill emits `PRICING.BACKFILL.STARTED/.COMPLETED/.SKIPPED` to CP `platform_events`.
+11. Legacy `Plan.Quotas`/`Tenant.Plan` columns retained but no longer read by any pricing path;
+    `UpdateTenantPlan` verified to flow through `IPlanAssignmentService`.
+12. Per-mode + per-tenant ownership honored (platform-global catalog; no tenant pricing table;
+    underlying services key per-mode; admin re-run `PlatformOwnerAccess`).
+13. Tests cover JSON mapping, fallback chain, the zero-without-assignment invariant, second-run
+    no-op, the four ops' shape + `PricingMode`, pinned-version-survives-deprecation, the
+    `BackfillReport`/events, and tenant isolation.

--- a/docs/superpowers/plans/2026-06-17-34-2-plan-catalog-admin-api-and-custom-enterprise-plans-plan.md
+++ b/docs/superpowers/plans/2026-06-17-34-2-plan-catalog-admin-api-and-custom-enterprise-plans-plan.md
@@ -1,0 +1,254 @@
+# Story 34-2 — Plan Catalog Admin API & Custom Enterprise Plans
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use superpowers:executing-plans (or
+> superpowers:subagent-driven-development) to work this plan task-by-task. Steps use checkbox
+> (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests before
+> implementation. C# suites that touch Postgres run via `sg docker -c "dotnet test ..."`.
+
+**Story:** `docs/stories/epic-34/story-34-2/34-2-plan-catalog-admin-api-and-custom-enterprise-plans.md`
+**Epic:** 34 — Pricing, Plans & Entitlements · **Priority:** P0 · **Est:** 3-4 days ·
+**Depends on:** Story 34-1 (catalog data model) · **Blocks:** 34-4 (assignment)
+
+## Goal
+
+Ship the platform-owner-gated admin API over the price-book catalog (create / version / deprecate)
+plus custom (per-tenant) enterprise-plan minting, and the public read API any authenticated tenant
+member uses for the pricing/upgrade UI. Catalog reads resolve through `IPlanCatalogService`
+(Story 34-1). Every mutation is audited via a DCB `platform_events` row carrying the actor.
+
+## Non-goals (YAGNI guard)
+
+- NO plan **assignment** logic. Pinning a tenant to a plan version, upgrade/downgrade/cancel,
+  proration, and enforcing "a custom plan is only assignable to its bound tenant" are **Story 34-4**.
+  This story records the `CustomTenantId` binding and the affected-tenant count, nothing more.
+- NO BYOK-vs-platform-provided pricing-MODE resolution. This story validates the `PricingMode` enum
+  value on a `PlanPrice`; resolving a tenant's mode at LLM-call time and the secret cabinet are
+  **Story 34-3 / Epic 29**.
+- NO reshaping of the 34-1 schema, read seam, or immutability invariants — only an additive
+  `CustomTenantId` column + CHECK.
+- NO Stripe / billing integration (Epic 35). No new third-party libraries.
+- NO dashboard UI in this story — API only. (`packages/dashboard` admin CRUD and
+  `packages/dashboard-user` pricing UI are sibling/later work.)
+- NO new auth policy. `PlatformOwnerAccess` (mutations) + `MemberAccess` (reads) already exist and
+  cover the exact RBAC matrix.
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### What 34-1 provides (prerequisite — assume present at implementation time)
+
+Per `/tmp/pab_stories/34-1.json`: extended `Plan` entity (`Version`, `Status active|deprecated|draft`,
+`IsCustom`, `BillingInterval`, supersede chain), new `PlanFeature` / `PlanEntitlement` / `PlanPrice`
+entities, `EntitlementMetricKey` closed enum in `Tamma.Core/Enums`, `IPlanCatalogService` returning
+`PlanSnapshot`, `UNIQUE(Slug, Version)` + a partial index enforcing one `active` version per slug,
+and lifecycle events `PLAN.VERSION.CREATED` / `PLAN.DEPRECATED` on `platform_events`. 34-2 extends
+the service and adds the endpoint layer.
+
+### Existing entity + seed (today, pre-34-1)
+
+- `apps/tamma-elsa/src/Tamma.Data/Entities/Plan.cs` — thin entity (`Slug`, `DisplayName`,
+  `MonthlyPriceUsd`, opaque `Quotas` JSON, `IsActive`, `PlacementPolicy`). Doc-comment already
+  anticipates admin mutation emitting `PLAN.UPDATED` to `platform_events`.
+- `apps/tamma-elsa/src/Tamma.Data/Seeders/PlansSeeder.cs` — three deterministic-UUID seed rows
+  (`free`/`team`/`enterprise`), insert-missing-only.
+- `apps/tamma-elsa/src/Tamma.Data/Entities/Tenant.cs:11` — `public string Plan { get; set; } = "free";`
+  the legacy plan-slug string used for the transitional affected-tenant count until 34-4.
+
+### Auth policies (`apps/tamma-elsa/src/Tamma.Api/Program.cs`)
+
+- `PlatformOwnerAccess` (Program.cs:986) — `PlatformPermissionRequirement("platform_admin")`, keys
+  off the JWT `platformRole` claim. This is the gate for ALL `/api/admin/pricing/*` routes (mutations
+  + custom mint). Comment at 976-985 mandates platform-scoped admin work use this, not `OwnerAccess`.
+- `MemberAccess` (Program.cs:991) — any authenticated user. Gate for the public `/api/pricing/*`
+  reads. (`AuthenticatedAny` at 1082 is an alternative; `MemberAccess` matches "any tenant member".)
+- Admin routes register under `var admin = app.MapGroup("/api/admin").RequireAuthorization("AdminAccess");`
+  (Program.cs:1244) with a **per-route** `.RequireAuthorization("PlatformOwnerAccess")` override —
+  see the `tenant-databases` block at Program.cs:1400-1414 (the canonical pattern to copy).
+
+### Platform-event emission (the audit seam)
+
+- `IPlatformEventPublisher.AppendAndPublishAsync(PlatformEvent, ct)` —
+  `apps/tamma-elsa/src/Tamma.Data/Abstractions/IPlatformEventPublisher.cs`; impl
+  `apps/tamma-elsa/src/Tamma.Api/Services/PlatformEvents/PlatformEventPublisher.cs` (singleton,
+  opens its own DI scope for the repo). Appends to `platform_events` (control-plane) and fans out
+  in-process.
+- `PlatformEvent` entity — `apps/tamma-elsa/src/Tamma.Data/Entities/PlatformEvent.cs`
+  (`Type`, `TenantId?`, `UserId?`, `Tags` JSON, `Metadata` JSON, `Data` JSON, server-assigned
+  `SequenceNumber`).
+- Actor-capture precedent — `AdminTenantsEndpoints.BuildAdminEvent` /
+  `ExtractActor(ClaimsPrincipal)` (`apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminTenantsEndpoints.cs:900-969`):
+  pulls JWT `sub`/`email`/`platformRole` into both `tags` (queryable) and `data` (immutable). Copy
+  this pattern for `PLAN.CATALOG.UPDATED` / `PLAN.CUSTOM.CREATED`.
+
+### Endpoint + DTO conventions
+
+- Endpoints are `public static` minimal-API handler classes (e.g.
+  `AdminTenantDatabasesEndpoints.cs`): handlers take EF context / services / `ClaimsPrincipal` /
+  `CancellationToken` as parameters, return `IResult` (`Results.Ok/Created/NotFound/Conflict/
+  Problem(...)`). Enum validation via static `HashSet<string>` allow-lists
+  (`AllowedPlacementClasses`, `AllowedStatuses` at AdminTenantDatabasesEndpoints.cs:39-43).
+- DTOs live under `Tamma.Api/Dtos/<Area>/`; no `Pricing` folder yet (verified — must be created).
+- `Tamma.Api/Services/Pricing/` does not exist yet (34-1 creates it).
+- `TammaError` — `apps/tamma-elsa/src/Tamma.Core/TammaError.cs` (`Code`, message, severity). The
+  service throws stable-coded `TammaError`; endpoints translate to HTTP status.
+
+### Test layout
+
+- `apps/tamma-elsa/tests/Tamma.Api.Tests/` — per-area folders (Admin, Alerts, PromptStore,
+  Conventions, Providers, Tenancy, …). Add a `Pricing/` folder. xUnit. Docker-bound integration
+  suites run via `sg docker -c "dotnet test ..."`; pure-unit suites run plain `dotnet test`.
+
+## Architecture (one screen)
+
+```
+GET /api/pricing/plans*            ──MemberAccess──▶ PricingEndpoints
+                                                       └─▶ IPlanCatalogService.ListActivePublic / GetActivePublicBySlug
+POST/PUT/DELETE /api/admin/pricing/* ─PlatformOwnerAccess─▶ AdminPricingEndpoints
+   POST .../custom                                          └─▶ IPlanCatalogService.{Create,Version,CreateCustom,DeprecateVersion}
+                                                                  ├─ validate EntitlementMetricKey + PricingMode  (422)
+                                                                  ├─ reject custom-as-public                       (400)
+                                                                  ├─ write Plan/PlanFeature/PlanEntitlement/PlanPrice (ControlPlaneDbContext)
+                                                                  ├─ enforce UNIQUE(Slug,Version)                  (409)
+                                                                  └─ IPlatformEventPublisher.AppendAndPublish(PLAN.CATALOG.UPDATED | PLAN.CUSTOM.CREATED)
+```
+
+All catalog state lives in the **control plane** — no `TenantDbContext` write. Custom plans are
+excluded from the public list by the `IsCustom=false` filter (tenant isolation by construction).
+
+## Phased task breakdown (test-first)
+
+### Phase 0 — Branch + verify 34-1 prerequisites
+
+- [ ] Branch off `main` (wave pattern, e.g. `feat/wave-c` or `feat/34-2`).
+- [ ] Confirm 34-1 merged: `Plan` has `Version`/`Status`/`IsCustom`/`BillingInterval`,
+      `EntitlementMetricKey` exists in `Tamma.Core/Enums`, `IPlanCatalogService`/`PlanSnapshot`
+      exist, `UNIQUE(Slug, Version)` + one-active-version index present. If not merged, this story is
+      blocked — stop.
+
+### Phase 1 — `CustomTenantId` binding column (additive migration)
+
+**Files:** `Tamma.Data/Entities/Plan.cs`, `Tamma.Data/ControlPlaneDbContext.cs` /
+`TammaModelConfiguration.cs` (model config), new migration under
+`Tamma.Data/Migrations/ControlPlane/`.
+
+- [ ] **Test first:** `tests/Tamma.Api.Tests/Pricing/PlanCustomBindingTests.cs` — inserting a
+      `Plan` with `IsCustom=true` and null `CustomTenantId` violates the CHECK; `IsCustom=false`
+      with a non-null `CustomTenantId` violates it; the valid combinations persist.
+- [ ] Add nullable `Guid? CustomTenantId` to `Plan.cs` with the binding doc-comment.
+- [ ] Configure the column + CHECK constraint in `TammaModelConfiguration.cs` (single source of
+      entity config — mirror existing CHECK config style).
+- [ ] `dotnet ef migrations add AddCustomTenantIdToPlan -c ControlPlaneDbContext` (additive); then
+      `dotnet ef migrations has-pending-model-changes` → must report none.
+- [ ] Verify migration applies + rolls back cleanly on a throwaway DB.
+
+### Phase 2 — Extend `IPlanCatalogService` with the admin write path
+
+**Files:** `Tamma.Api/Services/Pricing/IPlanCatalogService.cs`,
+`Tamma.Api/Services/Pricing/PlanCatalogService.cs`, `Tamma.Api/Dtos/Pricing/PlanDtos.cs`,
+`Tamma.Api/Services/Pricing/MissingConfigEventTypes`-style `PlanCatalogEventTypes.cs` (constants:
+`PLAN.CATALOG.UPDATED`, `PLAN.CUSTOM.CREATED`).
+
+- [ ] **Test first:** `tests/Tamma.Api.Tests/Pricing/PlanCatalogServiceTests.cs` covering:
+  - `CreatePlanAsync` → version-1 active row + `PLAN.CATALOG.UPDATED` (action=created) with actor id.
+  - `VersionPlanAsync` → prior active flipped to deprecated, new version active, one-active invariant.
+  - invalid `MetricKey` → `TammaError("PLAN.METRIC_KEY.INVALID")`; invalid `PricingMode` →
+    `TammaError("PLAN.PRICING_MODE.INVALID")`.
+  - `CreateCustomPlanAsync` → `IsCustom=true` + `CustomTenantId` + `PLAN.CUSTOM.CREATED` with bound
+    tenantId; custom-flagged-public → `TammaError("PLAN.CUSTOM.PUBLIC_REJECTED")`.
+  - `DeprecateVersionAsync`: affected>0 no-force → `DeprecateResult(false, count)`, no write;
+    affected>0 force → `DeprecateResult(true, count)`; affected==0 → deprecates.
+  - duplicate `(Slug, Version)` → unique violation surfaced.
+  - platform-event append failure does NOT roll back the write (logged ERROR, write committed).
+- [ ] Define DTOs in `PlanDtos.cs` (`CreatePlanRequest`, `VersionPlanRequest`,
+      `CreateCustomPlanRequest`, `PlanEntitlementDto`, `PlanPriceDto`, `PlanFeatureDto`,
+      `PlanListFilter`, response `PlanSnapshot` projection — reuse 34-1's `PlanSnapshot` if it is the
+      same shape; otherwise add an admin projection). No raw EF entity is serialized.
+- [ ] Add `ActorContext` + `DeprecateResult` records to the service contract.
+- [ ] Implement validation helpers: `EntitlementMetricKey` enum parse (closed set) and
+      `PricingMode` allow-list (`platform_provided`, `byok`) — static `HashSet`/`Enum.TryParse`,
+      mirroring the AdminTenantDatabases allow-list style.
+- [ ] Implement `CreatePlanAsync` / `VersionPlanAsync` / `CreateCustomPlanAsync` /
+      `DeprecateVersionAsync` / `ListAllForAdminAsync` against `ControlPlaneDbContext`; emit the
+      platform event via injected `IPlatformEventPublisher` (build the event with actor from
+      `ActorContext`, tags + data, following `BuildAdminEvent`).
+- [ ] Affected-tenant count: `ControlPlaneDbContext.Tenants.Count(t => t.Plan == slug && t.DeletedAt == null)`
+      with a `// TODO(34-4): switch to version-pinned assignment table` comment.
+
+### Phase 3 — Public read endpoints (`PricingEndpoints.cs`)
+
+**Files:** `Tamma.Api/Endpoints/PricingEndpoints.cs`, `Program.cs` (route registration).
+
+- [ ] **Test first:** `tests/Tamma.Api.Tests/Pricing/PricingEndpointsTests.cs`
+      (`WebApplicationFactory`): `GET /api/pricing/plans` returns active+public only (excludes
+      custom/deprecated/draft); `GET /api/pricing/plans/{slug}` → 200 for active public, 404 for
+      custom slug, 404 for unknown slug; both modes (SingleUser/SaaS) return the catalog to any
+      authenticated member.
+- [ ] Implement static handlers `ListPublic` / `GetPublicBySlug` calling
+      `IPlanCatalogService.ListActivePublicAsync` / `GetActivePublicBySlugAsync`.
+- [ ] Register in `Program.cs`: `app.MapGet("/api/pricing/plans", ...).RequireAuthorization("MemberAccess")`
+      and the `{slug}` variant (place near the other `/api/v1`/public read routes).
+
+### Phase 4 — Admin CRUD + custom mint endpoints (`AdminPricingEndpoints.cs`)
+
+**Files:** `Tamma.Api/Endpoints/Admin/AdminPricingEndpoints.cs`, `Program.cs`.
+
+- [ ] **Test first:** `tests/Tamma.Api.Tests/Pricing/AdminPricingEndpointsTests.cs`:
+  - member-role JWT → 403 on POST/PUT/DELETE/custom; platform-owner → 201/200/204.
+  - `POST` create → 201 + snapshot; `PUT` version → 200 + new version, prior deprecated.
+  - invalid metric key / pricing mode → 422 with field-level error.
+  - custom flagged public → 400.
+  - custom round-trip: `POST .../custom` 201 → `GET /api/admin/pricing/plans` lists it →
+    `GET /api/pricing/plans` excludes it → `GET /api/pricing/plans/{slug}` 404.
+  - **tenant-isolation**: custom plan bound to tenant A absent from tenant B's public catalog +
+    404 on the slug for tenant B.
+  - deprecate-with-assignments → 409 `{ affectedTenantCount }`; `?force=true` → 204.
+  - `PLAN.CATALOG.UPDATED` + `PLAN.CUSTOM.CREATED` rows land in `platform_events` with
+    `actorUserId`/`actorEmail` in tags and data.
+- [ ] Implement static handlers (`ListForAdmin`, `CreatePlan`, `VersionPlan`, `CreateCustomPlan`,
+      `DeprecateVersion`) taking `ClaimsPrincipal` → build `ActorContext` via an `ExtractActor`
+      helper (reuse the `AdminTenantsEndpoints` pattern; consider lifting `ExtractActor` to a shared
+      helper if practical, otherwise duplicate the small method).
+- [ ] Map `TammaError` codes → HTTP: `PLAN.METRIC_KEY.INVALID`/`PLAN.PRICING_MODE.INVALID` → 422,
+      `PLAN.CUSTOM.PUBLIC_REJECTED` → 400, unique violation → 409, `DeprecateResult(false, n)` → 409
+      with `{ affectedTenantCount = n }`.
+- [ ] Register routes in `Program.cs` under the `admin` group with explicit
+      `.RequireAuthorization("PlatformOwnerAccess")` per route (copy the `tenant-databases` block at
+      Program.cs:1400-1414).
+
+### Phase 5 — Wire-up, quality gates, docs
+
+- [ ] Register `IPlanCatalogService` write dependencies in `Program.cs` (if 34-1 already registers
+      the service, confirm the `IPlatformEventPublisher` dependency resolves in its scope).
+- [ ] Full suite green: `sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests"`.
+- [ ] `dotnet ef migrations has-pending-model-changes` → none. Build clean (no warnings-as-errors).
+- [ ] Update CLAUDE.md "API Endpoints" / pricing notes if a catalog section exists; add an entry to
+      the epic-34 status memory.
+
+## Sequencing & dependencies
+
+Phase 0 → 1 → 2 → (3 ∥ 4) → 5. Phase 1 (column) and Phase 2 (service) are the hard prerequisites;
+Phase 3 (public reads) and Phase 4 (admin writes) can proceed in parallel once the service contract
+exists. The whole story is blocked on **Story 34-1** being merged. Story **34-4** depends on this
+story's `CustomTenantId` binding and the deprecate affected-count.
+
+## Risks + mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| 34-1 schema not yet merged / shape differs from the spec | High | Phase 0 verifies the exact entity/enum/service shape before any code; stop if absent. Reference 34-1's actual files, not the spec, at implementation time. |
+| Affected-tenant count is wrong because assignment model (34-4) doesn't exist yet | Medium | Use the legacy `Tenant.Plan` slug match as the transitional source with a `TODO(34-4)` to swap to the version-pinned assignment table; the 409/force contract is stable across the swap. |
+| Custom plan leaks into the public catalog | High | Defence in depth: `ListActivePublicAsync` filters `IsCustom=false` (the real guard) AND a 400 rejects a custom-as-public request; explicit tenant-isolation integration test pins both. |
+| Platform-event append failure rolls back a valid mutation | Medium | Treat the event append as best-effort after the DB commit: log ERROR and continue (the catalog row is the source of truth), matching the resilient-append convention; unit test asserts the write survives an append failure. |
+| Using the wrong auth policy (e.g. `OwnerAccess` lets every personal-tenant owner through) | High | Use `PlatformOwnerAccess` (platformRole-keyed) verbatim for all mutations — the Program.cs:976-985 comment is explicit; member-403 integration test catches a wrong gate. |
+| Migration is a baseline CHECK edit (Phase-0 collapsed-baseline rules) | Low | `CustomTenantId` is an additive column + new CHECK, not an edit to an existing baseline CHECK; still verify `has-pending-model-changes` reports none and put entity config in `TammaModelConfiguration.cs` only. |
+| Scope creep into 34-3/34-4 | Medium | Honor the boundary note: validate `PricingMode` value only (no mode resolution); record `CustomTenantId` only (no assignment/enforcement). |
+
+## Acceptance criteria (mirror of the story)
+
+- [ ] `GET /api/pricing/plans` returns active public snapshots only (excludes custom/deprecated/draft); `GET /api/pricing/plans/{slug}` resolves one or 404; both readable by any `MemberAccess` caller.
+- [ ] `POST`/`PUT /api/admin/pricing/plans` create/version a plan; `POST /api/admin/pricing/plans/custom` mints an `IsCustom` plan bound to `tenantId` — all gated by `PlatformOwnerAccess`; member → 403.
+- [ ] A custom plan never appears in the public catalog (filter + 400 on publish attempt); `GET /api/pricing/plans/{customSlug}` → 404.
+- [ ] Deprecate a version with active assignments → 409 + affected count, unless `?force=true` (leaves tenants on the deprecated version).
+- [ ] Invalid `EntitlementMetricKey` or pricing-mode (not `platform_provided|byok`) → 422.
+- [ ] Each mutation emits `PLAN.CATALOG.UPDATED` / `PLAN.CUSTOM.CREATED` to `platform_events` with `actorUserId`/`actorEmail` in tags and data.
+- [ ] Tenant-isolation: a custom plan bound to tenant A is not surfaced to tenant B's public catalog.
+- [ ] Additive `CustomTenantId` migration applies + rolls back; `has-pending-model-changes` reports none; full `Tamma.Api.Tests` suite green.

--- a/docs/superpowers/plans/2026-06-17-34-3-byok-vs-platform-provided-pricing-mode-plan.md
+++ b/docs/superpowers/plans/2026-06-17-34-3-byok-vs-platform-provided-pricing-mode-plan.md
@@ -1,0 +1,332 @@
+# Story 34-3 — BYOK vs Platform-Provided Pricing Mode (per-provider mode selection)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation.
+
+**Goal:** Let each tenant choose, per provider, between **BYOK** (their API key lives in the Epic 29
+secret cabinet → billed a flat platform/seat fee, no token markup) and **platform-provided** (Tamma
+supplies the key from global config → usage billed at cost+margin). Persist the mode per
+`(tenant, provider)` on the control plane via the `TenantProviderBilling` entity + the BYOK/platform
+toggle endpoints, and surface the mode on the cost record so the markup engine (34-5) keys off it.
+SaaS BYOK is API-key-only; CLI/token agent providers stay single-user/self-hosted.
+
+> **Boundary (canonical ownership):** Provider-key resolution from the Epic 29 cabinet into the LLM call
+> path is owned by **Story 32-3** (the `IProviderCredentialResolver` seam, exposing the resolved key AND
+> a `ProviderCredential.Source` discriminator of `byok|platform`). SaaS provider-auth eligibility is
+> owned by **Story 32-4** (`IProviderAuthRegistry.IsSaaSEligible`). This story **CONSUMES** both: it
+> persists the per-`(tenant, provider)` mode 32-3 reads, writes/retires the BYOK secret on the toggle
+> flows, and calls 32-4 for the CLI-provider 422 gate. It does **NOT** define its own key resolver,
+> read the cabinet at call time, or modify `CallLlmActivity`.
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane API `Tamma.Api`,
+control-plane data `Tamma.Data`, Elsa engine activities `Tamma.Activities`, shared enums `Tamma.Core`).
+Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/` and `…/tests/Tamma.Activities.Tests/` (xUnit;
+docker-bound suites run via `sg docker -c "dotnet test …"`; build needs no wrapper).
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO cost→price markup math.** This story records `BillingMode`; applying the margin is Story 34-5.
+- **NO billing/charging.** Stripe meters/invoices are Epic 35. No Stripe dependency here.
+- **NO own key resolver.** Provider-key resolution is **owned by Story 32-3**
+  (`IProviderCredentialResolver` + `ProviderCredential.Source`). This story does NOT define
+  `IProviderKeyResolver`/`ProviderKeyResolver`/`ProviderKeyResolution`, does NOT read the cabinet at
+  call time, and does NOT add an internal key-resolution callback endpoint.
+- **NO `CallLlmActivity` changes.** The LLM-call-path wiring (removing the direct
+  `_configuration["…:ApiKey"]` reads, the cabinet read) is 32-3's. This story leaves the activity alone.
+- **NO re-wiring the secret cabinet.** This story uses `ISecretStore.CreateAsync`/`RetireVersionAsync`
+  only to write/retire the BYOK secret on the toggle flows (so 32-3 can later read it); it does not
+  change the cabinet or its runtime read path (Epic 29 / 32-3).
+- **NO reinventing the CLI-provider rejection.** The 422 gate calls Story 32-4's
+  `IProviderAuthRegistry.IsSaaSEligible`; this story does not duplicate the allowlist or the message logic.
+- **NO per-user BYOK layer in SaaS.** Mode is owned by the tenant (tenant_owner/tenant_admin), mirroring
+  the prompt-store "no per-user override in SaaS" rule.
+- **NO new provider implementations.** Provider selection stays in the Epic 32 chain (`AgentConfig`);
+  this story only persists the mode for whatever provider the chain picks.
+- **NO CLI/token-agent BYOK in SaaS.** Those (`packages/providers` CLI agents) remain single-user; a
+  SaaS BYOK request for one is a hard 422.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### Story 32-3 credential seam (canonical owner — CONSUME, don't duplicate)
+
+- `apps/tamma-elsa/src/Tamma.Api/Services/Providers/IProviderCredentialResolver.cs` (Story 32-3) is the
+  **single owner** of provider-key resolution: `ResolveAsync(tenantId?, providerName)` → `ProviderCredential
+  { ApiKey, Source ∈ {Byok, Platform}, SecretRefStorageKey?, VersionNumber? }`, plus
+  `Invalidate(tenantId, providerName)`. It reads the tenant BYOK cabinet key
+  (`SecretRef.ForTenant(tenantId, "provider/<name>/api-key")`) first, then the platform key; a missing
+  BYOK secret throws (no silent platform fallback). 32-3 also owns the `CallLlmActivity` /
+  `CallLlmInlineActivity` wiring that replaces the direct `_configuration["…:ApiKey"]` reads. **This
+  story does NOT touch any of that** — it persists the mode 32-3 reads and calls `Invalidate` on toggle.
+- 32-3 propagates the resolved `ProviderCredential.Source` into `ProviderAttemptDiagnostic.CredentialSource`
+  / the `credentialSource` diagnostic tag — the value this story persists as `ProviderDiagnostic.BillingMode`.
+
+### Story 32-4 SaaS auth gating (consume for the 422)
+
+- `apps/tamma-elsa/src/Tamma.Activities/Security/IProviderAuthRegistry.cs` (Story 32-4) —
+  `IsSaaSEligible(providerName)` returns `true` only for API-key providers (CLI/token providers like
+  `claude-code`/`opencode` and unknown providers → `false`, fail-closed). This is the single source for
+  the BYOK-registration 422 gate; this story calls it and maps `false` → 422.
+
+### Secret cabinet seam (Epic 29 — write/retire only on toggle)
+
+- `apps/tamma-elsa/src/Tamma.Api/Services/Secrets/ISecretStore.cs` — `CreateAsync`/`GetAsync`/
+  `RotateAsync`/`RetireVersionAsync`; plaintext only flows out-of-band to a rotation handler (the
+  HTTP-visible read API never returns plaintext). This story uses `CreateAsync` (enable) and
+  `RetireVersionAsync` (disable) ONLY; the runtime read is 32-3's.
+- `apps/tamma-elsa/src/Tamma.Api/Services/Secrets/SecretRef.cs` — `ForTenant(tenantId, name)` /
+  `ForPlatform(name)`; constructor enforces the tenant-id/scope invariant.
+- `apps/tamma-elsa/src/Tamma.Api/Services/Secrets/SecretScope.cs` (`Platform`/`Tenant`),
+  `SecretPurpose.cs` (`ApiKey` is the canonical purpose for an external provider key, lines **24–29**),
+  `SecretRequests.cs` (`CreateSecretRequest` with `InitialPlaintext`).
+- The cabinet name written on enable MUST be `provider/{providerKey}/api-key` (scope `Tenant`) to match
+  the name 32-3's resolver reads — see `StopgapSecretMap` only for the platform-side names that 32-3
+  (not this story) consumes.
+
+### Control-plane data + events
+
+- `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` + `TammaModelConfiguration.cs` (single
+  source for entity config per Epic 28 convention). Migrations under
+  `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/` — current state is a **single collapsed
+  baseline** `20260609205701_InitialControlPlane(.Designer).cs` + `ControlPlaneDbContextModelSnapshot.cs`,
+  so a new entity is a clean additive `dotnet ef migrations add`.
+- `apps/tamma-elsa/src/Tamma.Data/Entities/ProviderDiagnostic.cs` — the per-call cost record
+  (`ProviderKey`, `InputTokens`, `OutputTokens`, `Cost`, `TenantId`, `Model`, …). Needs a `BillingMode`
+  column, populated from 32-3's `ProviderCredential.Source` (the `credentialSource` diagnostic tag).
+  Written at three sites: `ProviderEndpoints.IngestDiagnostic` (POST `/api/providers/diagnostics`,
+  `Program.cs` line **1821**), `ProviderSessionService.cs` (lines **122**, **158**),
+  `LlmProxyService.cs` (line **223**).
+- `apps/tamma-elsa/src/Tamma.Data/Entities/DomainEvent.cs` — `Type`, `TenantId`, `Tags` (JSON),
+  `Metadata`, `Data`, `SequenceNumber`. Appended via
+  `apps/tamma-elsa/src/Tamma.Data/Repositories/IEventRepository.cs` `AppendAsync(DomainEvent)` — used
+  here only for `PRICING.BYOK.ENABLED/DISABLED` on the toggle flows.
+
+### Mode + RBAC seams
+
+- `apps/tamma-elsa/src/Tamma.Api/Services/PromptStore/TammaMode.cs` — process-wide
+  `ITammaModeProvider` (`SingleUser`/`SaaS`).
+- `apps/tamma-elsa/src/Tamma.Api/Program.cs` auth policies: `SettingsManage` = `settings:manage`
+  **owner-only** (line **1001**); `PromptManage` = `prompts:manage`, **tenant_owner OR tenant_admin**
+  (lines **1012–1016**, with the explanatory comment **1006–1011** that `SettingsManage` would 403 every
+  tenant_admin); `MemberAccess` = any authenticated user (line **991**); `PlatformOwnerAccess` =
+  platform_admin (line **986**). Tenant-scoped endpoints follow `/api/v1/orgs/{tenantId}/…`.
+- `apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderChainResolver.cs` (chain selection, line
+  **67**) and `IProviderPricingService` (`Services/Providers/IProviderPricingService.cs`) exist — this
+  story's mode selection complements, not replaces, these; key resolution stays in 32-3's
+  `IProviderCredentialResolver` (same `Services/Providers/` folder).
+
+**Decision flagged for the implementer:** the spec says BYOK management uses `SettingsManage`, but that
+policy is owner-only in this codebase and would 403 tenant admins. Follow the `PromptManage`/`ConventionManage`
+precedent: add a dedicated **`PricingManage`** policy (`pricing:manage`, owner+admin) and use it on the
+BYOK mutation routes. Document `SettingsManage` as the spec's label.
+
+---
+
+## Architecture
+
+**Control-plane mode registry + toggle endpoints + cost-record tag (key resolution stays in 32-3):**
+
+1. **`TenantProviderBilling`** (CP table) — one `active` row per `(tenant, provider)`; `Mode` +
+   `SecretName` + audit. Partial unique index + CHECKs (mode/status/secret-xor). This is the per-(tenant,
+   provider) mode that 32-3's resolver reads.
+2. **`MetricBillingMode`** (`Tamma.Core/Enums`) — `Platform|Byok`; shared with 34-1/34-5/metering.
+3. **Key resolution = CONSUME Story 32-3** — `IProviderCredentialResolver.ResolveAsync` returns the key
+   + `ProviderCredential.Source`. This story does NOT add a resolver; it persists the mode 32-3 reads and
+   calls `Invalidate(tenantId, providerKey)` on every toggle.
+4. **No LLM-call-path wiring here** — `CallLlmActivity` is wired to the resolver by Story 32-3, not this
+   story. No internal key-resolution callback endpoint is added.
+5. **BYOK lifecycle** — tenant endpoints store/retire the cabinet secret (`provider/{p}/api-key`, scope
+   `Tenant`, purpose `ApiKey`) + flip the row + invalidate 32-3's cache; emit
+   `PRICING.BYOK.ENABLED/DISABLED` DCB events.
+6. **Cost tag** — `ProviderDiagnostic.BillingMode` populated on ingest from 32-3's
+   `ProviderCredential.Source`; tagged on the cost DCB event so the 34-5 markup engine keys off it.
+7. **CLI-provider 422** — the BYOK registration gate calls Story 32-4's
+   `IProviderAuthRegistry.IsSaaSEligible`.
+
+### Per-mode ownership (mandatory two-scoping answer, per CLAUDE.md)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Who owns the `(provider, mode)` choice? | the sole user (`tenantId` null) | the tenant (`tenant_id`) |
+| Default | platform (no BYOK row → 32-3 resolves platform) | platform until a BYOK row exists |
+| Who manages BYOK? | the user (no RBAC) | `tenant_owner`/`tenant_admin` via `PricingManage`; `member` → 403 |
+| Cabinet scope | no per-tenant cabinet row needed | `SecretRef.ForTenant(tenantId, "provider/{p}/api-key")` |
+| Cross-tenant | n/a | route `tenantId` ≠ caller's tenant → 404 |
+| Key resolution at call time | owned by 32-3 | owned by 32-3 |
+| Mode source | `ITammaModeProvider` (process-stable) | same |
+
+---
+
+## Task breakdown
+
+### T1: `MetricBillingMode` enum + `TenantProviderBilling` entity + migration (core)
+
+**Scope:** Shared enum, CP entity, model config, additive migration. No endpoints yet.
+
+**Files:**
+- New: `src/Tamma.Core/Enums/MetricBillingMode.cs` (`Platform`, `Byok`; with a `ToToken()`/`Parse`
+  helper producing `"platform"`/`"byok"`).
+- New: `src/Tamma.Data/Entities/TenantProviderBilling.cs` (shape per story Technical Design).
+- Modify: `src/Tamma.Data/ControlPlaneDbContext.cs` (`DbSet<TenantProviderBilling>`),
+  `src/Tamma.Data/TammaModelConfiguration.cs` (table name `tenant_provider_billing`, CHECK
+  `ck_tpb_mode`/`ck_tpb_status`/`ck_tpb_secret_xor`, partial unique index
+  `ux_tpb_active_provider` on `(TenantId, ProviderKey)` filtered `status='active'`, FK → tenants).
+- Migration: `dotnet ef migrations add AddTenantProviderBilling -c ControlPlaneDbContext`
+  (additive — new table, not a baseline CHECK edit). Then run `has-pending-model-changes` → none.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Pricing/TenantProviderBillingModelTests.cs` (extend the
+existing `Epic28/ControlPlaneDbContextModelTests.cs` pattern) — model builds; the partial unique index
+rejects a second active row for the same `(tenant, provider)`; secret-xor CHECK rejects byok-without-secret
+and platform-with-secret; enum round-trips token ↔ value.
+
+**Done when:** migration applies + rolls back cleanly; `has-pending-model-changes` clean; suite green.
+
+### T2: BYOK lifecycle service + endpoints + CLI guard + RBAC
+
+**Scope:** `TenantProviderBillingService` (enable/disable/get-mode) and `PricingEndpoints`. CLI-provider
+guard via 32-4. `PricingManage` policy. 32-3 cache invalidation on toggle. NO key resolver, NO internal
+key-resolution callback endpoint.
+
+**Files:**
+- New: `src/Tamma.Api/Services/Pricing/TenantProviderBillingService.cs` — `EnableByokAsync(tenantId,
+  provider, apiKey, actor)` (store cabinet secret via `ISecretStore.CreateAsync` purpose `ApiKey` scope
+  `Tenant` name `provider/{provider}/api-key` — the name 32-3 reads; upsert row byok/active/secretName;
+  emit `PRICING.BYOK.ENABLED`; call `IProviderCredentialResolver.Invalidate(tenantId, provider)`);
+  `DisableByokAsync` (retire secret via `RetireVersionAsync`; flip row to platform, `SecretName=null`;
+  emit `PRICING.BYOK.DISABLED`; invalidate); `GetModeAsync` (mode + `keySet`).
+- New: `src/Tamma.Api/Services/Pricing/PricingEventTypes.cs` (`PRICING.BYOK.ENABLED`,
+  `PRICING.BYOK.DISABLED` only — key-resolution events belong to 32-3).
+- New: `src/Tamma.Api/Endpoints/PricingEndpoints.cs` — tenant routes only (list/get/POST byok/DELETE
+  byok). Mirror `AlertEndpoints.cs` structure. NO internal callback route.
+- Modify: `src/Tamma.Api/Program.cs` — register `TenantProviderBillingService` (scoped) via a
+  `PricingServiceCollectionExtensions` (mirror `AlertServiceCollectionExtensions`); add `PricingManage`
+  policy (`pricing:manage`, owner+admin like `PromptManage`); map the routes (`PricingManage` on
+  mutations, `MemberAccess` on reads). Add `pricing:manage` to the role-permission grant table next to
+  `prompts:manage`.
+- CLI-provider guard: call **Story 32-4's `IProviderAuthRegistry.IsSaaSEligible(provider)`**; `false`
+  (CLI/token or unknown) → 422 `"CLI providers are single-user only"`. Do NOT reimplement the allowlist.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Pricing/PricingEndpointsTests.cs` (docker-bound) +
+`TenantProviderBillingServiceTests.cs` —
+enable stores cabinet row + DB row + event + invalidates 32-3 cache, returns `keySet:true`, never echoes
+the key; disable retires + reverts + event + invalidates; one-active-row (second enable updates); RBAC
+matrix (member 403, admin/owner 200, platform-owner 200); cross-tenant route 404; tenant A can't read
+tenant B; a provider where `IsSaaSEligible` is `false` → 422; single-user mode passes all gates.
+Stub `IProviderCredentialResolver` and `IProviderAuthRegistry`.
+
+**Done when:** RBAC + isolation + 422 + reveal-once + cache-invalidation all asserted.
+
+### T3: `ProviderDiagnostic.BillingMode` migration + default
+
+**Scope:** Additive column (default `'platform'`).
+
+**Files:**
+- Modify: `src/Tamma.Data/Entities/ProviderDiagnostic.cs` (`public string BillingMode { get; set; } =
+  "platform";`), `TammaModelConfiguration.cs` (default value).
+- Migration: `dotnet ef migrations add AddProviderDiagnosticBillingMode` (additive column,
+  `defaultValue: "platform"`). `has-pending-model-changes` → none.
+
+> Note: `provider_diagnostics` may be tenant-DB-resident (per-tenant `TenantDbContext`) vs CP — verify
+> which context owns `ProviderDiagnostic` before generating the migration; add the column to the owning
+> context's migration set. (If both, mirror in both — check `ControlPlaneDbContext` vs `TenantDbContext`
+> DbSets first.)
+
+**Tests (first):** model test asserts default `platform`; the T4 ingest test asserts persistence.
+
+**Done when:** column present, default applied, suite green.
+
+### T4: Populate `ProviderDiagnostic.BillingMode` from 32-3's `ProviderCredential.Source`
+
+**Scope:** Set the cost-record `BillingMode` from 32-3's credential source on the diagnostic
+ingest/record path and tag the cost DCB event. NO `CallLlmActivity` changes.
+
+**Files:**
+- Modify: `src/Tamma.Api/Endpoints/ProviderEndpoints.cs` (+ `ProviderSessionService.cs`,
+  `LlmProxyService.cs`) — set `ProviderDiagnostic.BillingMode` from the `credentialSource` 32-3 already
+  surfaces on the diagnostic/attempt, and tag the cost DCB event with `mode`. (32-3 owns producing
+  `credentialSource`; this story persists it as the `BillingMode` column the 34-5 markup engine reads.)
+
+**Tests (first):** extend `tests/Tamma.Api.Tests/ProviderSession/` — a diagnostic carrying
+`credentialSource=byok` persists `BillingMode=byok`; default `platform` when absent; the cost DCB event
+carries the `mode` tag.
+
+**Done when:** `BillingMode` persists from `ProviderCredential.Source`; default `platform` holds.
+
+---
+
+## Sequencing & dependencies
+
+```
+T1 (enum + entity + migration)
+  ├─> T2 (mode service + endpoints + 32-4 guard + RBAC)
+  └─> T3 (diagnostic column) ──> T4 (populate BillingMode from 32-3 source + cost tag)
+```
+
+- **T1** is the only hard prerequisite for everything.
+- **T2** and **T3** are parallel-safe after T1.
+- **T2** consumes Story 32-3 (`IProviderCredentialResolver.Invalidate`) and Story 32-4
+  (`IProviderAuthRegistry.IsSaaSEligible`) — both are external prerequisites, not built here.
+- **T4** needs T3 (the column) and consumes 32-3's `credentialSource` on the diagnostic.
+
+**External prerequisites:** Story **32-3** (provider-key resolution: `IProviderCredentialResolver` +
+`ProviderCredential.Source`), Story **32-4** (`IProviderAuthRegistry.IsSaaSEligible`), Story 34-1
+(shared enums + `PlanPrice.PricingMode`), Epic 29 cabinet (`ISecretStore` et al.). **Blocks:**
+Story 34-5 (markup engine reads `BillingMode`).
+
+---
+
+## Risks + mitigations
+
+- **Boundary violation: duplicating 32-3's key resolver or re-wiring `CallLlmActivity`.** *High.* This
+  story persists the mode row + writes/retires the cabinet secret on toggle only; key reads and the
+  LLM-call wiring stay in 32-3. Reviewer checklist item; no `IProviderKeyResolver`/internal callback in
+  the file set.
+- **Stale 32-3 credential cache after a mode toggle.** *Medium.* Call
+  `IProviderCredentialResolver.Invalidate(tenantId, providerKey)` on every enable/disable; T2 asserts it.
+- **`SecretName` mismatch between this story's write and 32-3's read.** *Medium.* Pin the shared name
+  `provider/{providerKey}/api-key` (scope `Tenant`, purpose `ApiKey`); integration test asserts 32-3 can
+  resolve the secret this story writes.
+- **`SettingsManage` is owner-only and would 403 tenant admins.** *Medium.* Add the dedicated
+  `PricingManage` (owner+admin) policy following the `PromptManage` precedent; document the spec's
+  `SettingsManage` label.
+- **Reinventing the CLI-provider rejection.** *Medium.* The 422 gate calls 32-4's
+  `IProviderAuthRegistry.IsSaaSEligible`; do not duplicate the allowlist or message logic.
+- **Migration discipline on the collapsed CP baseline.** *Medium.* Both changes are additive (new table,
+  new column). Verify `has-pending-model-changes` reports none; mirror entity config solely in
+  `TammaModelConfiguration.cs` (the established single source).
+- **`ProviderKey` term overload (provider id vs Cranl backend label).** *Low.* The column is the provider
+  identifier (`"anthropic"`), matching `ProviderDiagnostic.ProviderKey`; not the Cranl tenancy label.
+  Documented in story Dev Notes.
+- **Which context owns `ProviderDiagnostic`.** *Low/Medium.* Verify CP vs tenant DbContext before the
+  T3 migration; add the column to the owning context (both if dual-resident).
+- **Logging the supplied key.** *High.* Explicit no-secret logging rule (`provider`/`mode`/`tenantId`
+  only); the POST body is never logged; reviewer checklist item.
+
+---
+
+## Acceptance criteria (mirrors the story)
+
+- [ ] `TenantProviderBilling` entity + DbSet + partial-unique-index (one active row per
+      `(tenant, provider)`) + CHECKs + additive migration; `has-pending-model-changes` clean.
+- [ ] `MetricBillingMode` enum in `Tamma.Core/Enums` shared across pricing/metering layers.
+- [ ] Key resolution CONSUMES Story 32-3's `IProviderCredentialResolver` / `ProviderCredential.Source`;
+      this story defines NO key resolver and makes NO `CallLlmActivity` changes. The persisted mode is
+      what 32-3 reads; platform is the default for single-user and rows-absent (32-3's resolution).
+- [ ] BYOK enable stores the key in the cabinet (`SecretPurpose.ApiKey`, name `provider/{p}/api-key`) +
+      flips the row to byok + invalidates 32-3's cache; disable reverts to platform + tombstones the
+      secret ref + invalidates; both emit `PRICING.BYOK.ENABLED/DISABLED`.
+- [ ] SaaS BYOK guard: a provider where `IProviderAuthRegistry.IsSaaSEligible` (Story 32-4) is `false`
+      → 422 `"CLI providers are single-user only"`; this story does not reimplement the registry.
+- [ ] `ProviderDiagnostic.BillingMode` (byok|platform) populated from 32-3's `ProviderCredential.Source`
+      on the cost record + tagged on the DCB cost event so the 34-5 markup engine keys off it.
+- [ ] RBAC: BYOK mutation reachable by tenant_owner/tenant_admin (via `PricingManage`); member → 403;
+      single-user user has full control; reads available to any member.
+- [ ] Per-tenant isolation: cross-tenant route → 404; cabinet `SecretRef.ForTenant` scoping; a tenant
+      can't read another tenant's mode.
+- [ ] Unit + integration tests cover all the above incl. tenant-isolation; no Stripe; `ISecretStore`,
+      `IProviderCredentialResolver`, and `IProviderAuthRegistry` mocked. Full suite green.

--- a/docs/superpowers/plans/2026-06-17-34-4-per-tenant-plan-assignment-and-lifecycle-plan.md
+++ b/docs/superpowers/plans/2026-06-17-34-4-per-tenant-plan-assignment-and-lifecycle-plan.md
@@ -1,0 +1,294 @@
+# Story 34-4 — Per-Tenant Plan Assignment & Lifecycle (Implementation Plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use superpowers:executing-plans (or
+> superpowers:subagent-driven-development) to run this plan phase-by-phase. Steps use checkbox
+> (`- [ ]`) tracking. Project is test-first (TDD) — every phase writes failing tests before
+> implementation. C# docker-bound suites run via `sg docker -c "dotnet test …"`; build needs no
+> wrapper. | Epic 34 (Pricing, Plans & Entitlements) | Story file:
+> `docs/stories/epic-34/story-34-4/34-4-per-tenant-plan-assignment-and-lifecycle.md`
+
+**Goal:** Make plan assignment a first-class, audited, *version-pinned* operation on the control
+plane. A `TenantPlanAssignment` row becomes the source of truth for "what plan is this tenant on
+right now" (and *which version*), with effective dates and upgrade/downgrade/cancel transitions
+that hand Billing (Epic 35) a clean proration boundary. Deprecating a plan (34-1/34-2) must never
+silently re-price an existing tenant.
+
+## Non-goals (YAGNI guard)
+
+- **NO catalog/version model here.** `Plan` (Version/Status/IsCustom/supersedes),
+  `PlanEntitlement`, `PlanPrice`, `EntitlementMetricKey`, and `IPlanCatalogService` are **34-1**.
+  This plan *consumes* them. If 34-1 has not landed, stop — it is a hard prerequisite.
+- **NO admin catalog CRUD / custom-plan minting.** That is **34-2**. This plan only *reads*
+  `IsCustom`/`BoundTenantId` and *adds* the subscribe handler to the `PricingEndpoints.cs` file
+  34-2 introduces.
+- **NO quota enforcement.** Downgrades are *flagged, never blocked* (epic boundary). Enforcement
+  is a sibling story; this plan ships only the warning surface behind `ITenantUsageReader`.
+- **NO Billing/proration math, NO Stripe.** This plan emits the `prorationBoundaryAt` marker on
+  `TENANT.PLAN.CHANGED`; Epic 35 does the charging. `ITenantUsageReader` ships as a null/no-op
+  default so no metering dependency leaks into the assignment path.
+- **NO new scheduler.** Boundary activation reuses the existing `PlatformTaskQueueProcessor`
+  (`MoveTenant` 202+poll pattern), not a bespoke timer.
+- **NO change to resolution/tenancy semantics.** Tenant routing, schema-per-tenant, and the
+  Epic-28 shadow columns are untouched apart from keeping `Tenant.Plan`/`PlanId` in lockstep with
+  the active assignment.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### What exists today (the loose path this story replaces)
+
+| Site | Behaviour today | File:line |
+|---|---|---|
+| `PATCH /api/admin/tenants/{id}/plan` → `AdminTenantsEndpoints.UpdateTenantPlan` | Inline: validates `req.PlanId`, checks `plan.IsActive`, flips the **shadow** `EF.Property<Guid?>(t,"PlanId")` + legacy `tenant.Plan` slug, emits a `PLAN.UPDATED` platform event. **No version, no effective dates, no proration boundary, no assignment row.** | `Tamma.Api/Endpoints/Admin/AdminTenantsEndpoints.cs:590-644` |
+| `Tenant.PlanId` | NOT a property on the POCO — an Epic-28 **shadow** column declared `entity.Property<Guid?>("PlanId")`, indexed, FK→plans (Restrict). Read via `EF.Property`. | `Tamma.Data/Entities/Tenant.cs` (no PlanId field); `Tamma.Data/TammaModelConfiguration.cs:214,288,292-295` |
+| `Tenant.Plan` | Legacy string slug (`"free"` default), still rendered by `AdminTenantsEndpoints.ListTenants`. | `Tamma.Data/Entities/Tenant.cs:11` |
+| `Plan` entity | Today: `Id, Slug, DisplayName, MonthlyPriceUsd, Quotas(json), IsActive, PlacementPolicy`. **34-1 extends it** with `Version`, `Status` (active/deprecated/draft), `IsCustom`, `BillingInterval`, supersedes. This plan assumes the 34-1 shape. | `Tamma.Data/Entities/Plan.cs:14-47` |
+| `PlansSeeder` | Seeds `free`/`team`/`enterprise` with stable UUIDs. 34-1 extends it to structured rows. | `Tamma.Data/Seeders/PlansSeeder.cs:57,69,81` |
+
+### Reusable infrastructure (verified)
+
+- **DbContext:** `ControlPlaneDbContext` exposes `Tenants`, `Plans`, `PlatformEvents`,
+  `PlatformQueuedTasks`, `DomainEvents` DbSets — `Tamma.Data/ControlPlaneDbContext.cs:36,76,77,78,199`.
+  Single model-config file `Tamma.Data/TammaModelConfiguration.cs` is the established source for
+  entity config (partial unique indexes + CHECKs already used, e.g. `:249-250`, `:270-283`).
+- **Events:** tenant-scope DCB append `IEventRepository.AppendAsync(DomainEvent)`
+  (`Tamma.Data/Repositories/IEventRepository.cs`); platform-audit mirror
+  `IPlatformEventPublisher.AppendAndPublishAsync(PlatformEvent)`
+  (`Tamma.Data/Abstractions/IPlatformEventPublisher.cs:44`). Both `DomainEvent`/`PlatformEvent`
+  carry `Type, TenantId, Tags(json), Metadata, Data, CreatedAt, SequenceNumber`. Actor-tag
+  builder pattern: `AdminTenantsEndpoints.BuildAdminEvent`/`ExtractActor` (`:900-969`).
+- **Platform queue (boundary work):** `IPlatformQueuedTaskRepository.EnqueueAsync(PlatformQueuedTask)`
+  + the 202+poll pattern in `AdminTenantsEndpoints.MoveTenant` (`:659-735`) and its
+  `MoveTenantTaskPayload`. `PlatformTaskQueueProcessor` claims tasks (RunOnStartup gate noted in
+  MEMORY). Reuse this for `activate-scheduled-plan`.
+- **Auth policies (`Tamma.Api/Program.cs:986-1005`):** `PlatformOwnerAccess` (JWT `platformRole =
+  platform_admin`) for admin routes; `SettingsManage` (`settings:manage`, owner-only) for tenant
+  self-service. Admin routes mapped under the `admin` group (`Program.cs:1292-1388`), e.g. the
+  existing `admin.MapPatch("/tenants/{tenantId:guid}/plan", …UpdateTenantPlan)` at `:1378-1379`.
+- **Tenant role gate (member 403):** `RequireTenantAdmin(HttpContext, out IResult? forbid)` reading
+  `HttpContext.Items[RequireTenantMembershipFilter.TenantRoleItemKey]` +
+  `TenantRoleHierarchy.IsAtLeast(role, Admin)` — `Tamma.Api/Endpoints/AlertEndpoints.cs:1008-1028`.
+  Mirror this for `/api/pricing/subscribe`.
+- **Mode + tenant context:** `ITammaModeProvider.Mode` (`Tamma.Api/Services/PromptStore/TammaMode.cs:48-50`,
+  SingleUser|SaaS) and `ITenantContext.TenantId` (`Tamma.Data/ITenantContext.cs:5`) — the same pair
+  `PromptEndpoints` uses to pick the override key (`PromptEndpoints.cs:36,70`).
+- **DI extension precedent:** `Tamma.Api/Extensions/AlertServiceCollectionExtensions.cs` (and
+  siblings) — add `PricingServiceCollectionExtensions` or extend 34-1's, wired in `Program.cs`.
+- **Migration layout:** `Tamma.Data/Migrations/ControlPlane/` (e.g.
+  `20260609205701_InitialControlPlane.cs`); `dotnet ef migrations add` produces the additive table;
+  verify `has-pending-model-changes` reports none.
+
+### Key gap this story closes
+
+There is no record of *which plan version* a tenant is on, no effective dating, and no proration
+boundary for Billing — only a mutable `(PlanId, Plan-slug)` pair that 34-1/34-2 deprecation would
+silently re-interpret. The `TenantPlanAssignment` row + pinned `PlanVersion` is the fix.
+
+---
+
+## Architecture
+
+```
+caller (admin route | /api/pricing/subscribe)
+        │
+        ▼
+IPlanAssignmentService.AssignAsync / CancelAsync / ActivateScheduledAsync
+        │   1. resolve PlanSnapshot via IPlanCatalogService (34-1) → pin Version
+        │   2. guards: draft → reject; deprecated → reject unless Force; custom → binding check
+        │   3. classify direction (price/interval); read ITenantUsageReader → EntitlementWarnings
+        │   4. TRANSACTION: cancel prior active (stamp EffectiveTo) → insert active/scheduled →
+        │                   update Tenant.PlanId + Tenant.Plan
+        │   5. emit DCB TENANT.PLAN.CHANGED (+ platform mirror) with proration marker
+        ▼
+ControlPlaneDbContext.TenantPlanAssignments  (ux_tpa_one_active_per_tenant partial unique index)
+        │
+boundary work: cancel → schedule plan_free row + enqueue activate-scheduled-plan task
+        ▼
+PlatformTaskQueueProcessor → ActivateScheduledAsync (promote scheduled → active)
+```
+
+### Per-mode ownership (mandatory two-scoping-model answer)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Who assigns? | the sole user (authenticated; no RBAC) | platform owner via `/api/admin/tenants/{id}/plan` (`PlatformOwnerAccess`) |
+| Who self-subscribes? | the sole user via `/api/pricing/subscribe` | `tenant_owner` (`SettingsManage`); `member` → 403 |
+| Tenant resolution | `ITenantContext.TenantId` | `ITenantContext.TenantId` (subscribe) / route `{tenantId}` (admin) |
+| Cross-tenant guard | n/a | subscribe ignores body tenant id; admin 404s unknown tenant |
+| Actor stamped | the user → `AssignedByUserId` | platform/tenant owner → `AssignedByUserId` |
+| Mode source | `ITammaModeProvider` | same |
+
+---
+
+## Phased task breakdown (TDD — tests first in every phase)
+
+### Phase 1 — Entity, model config, migration, back-fill (AC1-3)
+
+**Tests first** (`tests/Tamma.Data.Tests/Migrations/TenantPlanAssignmentMigrationTests.cs`,
+Postgres-backed):
+- Migration applies + rolls back cleanly.
+- Partial unique index rejects a second `Status='active'` insert for the same tenant (raw insert).
+- CHECKs reject bad `Status`, `EffectiveTo < EffectiveFrom`, `PlanVersion < 1`.
+- Back-fill: N existing tenants → exactly N `active` assignments, each pinning the plan's current
+  `Version`; a tenant with NULL shadow `PlanId` back-fills via `Plan` slug, else `plan_free`.
+
+**Implement:**
+- [ ] New `Tamma.Data/Entities/TenantPlanAssignment.cs` (entity per story).
+- [ ] New `Tamma.Core/Enums/PlanAssignmentStatus.cs`, `PlanChangeDirection.cs` (string-backed
+      constants to match the catalog enum style in 34-1).
+- [ ] `ControlPlaneDbContext.cs` — add `DbSet<TenantPlanAssignment> TenantPlanAssignments`.
+- [ ] `TammaModelConfiguration.cs` — entity config: `gen_random_uuid()` default, `Status` len 16,
+      `ux_tpa_one_active_per_tenant` partial unique index, `(TenantId,Status)` + `PlanId` indexes,
+      FKs (TenantId Cascade, PlanId Restrict), three CHECKs.
+- [ ] `Tenant.cs` — doc-comment note only: `Plan`/`PlanId` are derived from the active assignment.
+- [ ] `dotnet ef migrations add AddTenantPlanAssignment -c ControlPlaneDbContext` →
+      `Migrations/ControlPlane/<ts>_AddTenantPlanAssignment.cs`; hand-add the partial unique index
+      + the raw-SQL back-fill `INSERT … SELECT` (story sketch); run `has-pending-model-changes` → none.
+
+**Approach note:** `Tenant.PlanId` stays a shadow column (Epic-28 owns the POCO); the back-fill and
+the service both read/write it via `EF.Property<Guid?>` exactly as `AdminTenantsEndpoints` does.
+
+### Phase 2 — `PlanAssignmentService` core: assign + guards + direction + pin (AC4-7, 13)
+
+**Tests first** (`tests/Tamma.Api.Tests/Pricing/PlanAssignmentServiceTests.cs`, mocked
+`IPlanCatalogService`/`ITenantUsageReader`/`IEventRepository`/`IPlatformEventPublisher`,
+deterministic `TimeProvider`):
+- Pin: assign v=N, then deprecate (catalog now returns v=N+1) → `GetActiveAsync` still v=N.
+- One-active: second assign flips prior→cancelled (EffectiveTo stamped) + inserts new active;
+  forced `DbUpdateException`/unique-violation path → translated 409, no second active row.
+- Custom binding: misbound `IsCustom` plan → `PLAN.ASSIGN.CUSTOM_PLAN_MISBOUND`; bound → ok.
+- Draft → reject always; deprecated → reject unless `Force=true`.
+- Direction classification upgrade/downgrade/lateral; idempotent re-assign of same (PlanId,Version)
+  → lateral no-op (no new event).
+- Downgrade with over-limit usage (mock reader) → `Warnings` populated, event
+  `entitlementWarnings=true`; reader unavailable → no warnings, no throw.
+- Event-shape: `TENANT.PLAN.CHANGED` carries all tags + `prorationBoundaryAt`/`billingIntervalAnchor`.
+
+**Implement:**
+- [ ] `Services/Pricing/PlanAssignmentModels.cs` — `AssignPlanOptions`, `CancelPlanOptions`,
+      `PlanAssignmentResult`, `EntitlementWarning`.
+- [ ] `Services/Pricing/ITenantUsageReader.cs` + a `NullTenantUsageReader` default (returns
+      "unknown" → no warnings). Real impl is Epic 35.
+- [ ] `Services/Pricing/PlanAssignmentEventTypes.cs` — `TENANT.PLAN.CHANGED`, `TENANT.PLAN.CANCELLED`.
+- [ ] `Services/Pricing/IPlanAssignmentService.cs` + `PlanAssignmentService.cs`:
+      `AssignAsync` (resolve+pin via catalog, guards, direction, warnings, transactional swap,
+      lockstep `Tenant.PlanId`/`Plan` via `EF.Property`, dual event emit). Translate unique
+      violations to a typed 409.
+- [ ] Reuse the actor-tag pattern from `AdminTenantsEndpoints.BuildAdminEvent` for the platform mirror.
+
+### Phase 3 — Cancel + scheduled activation via platform queue (AC8-9)
+
+**Tests first** (extend `PlanAssignmentServiceTests.cs` + a processor integration test):
+- `CancelAsync`: stamps active `EffectiveTo` at period end, inserts `scheduled` `plan_free` row at
+  that `EffectiveFrom`, emits `TENANT.PLAN.CANCELLED`; `Immediate=true` cancels now; already-free →
+  no-op.
+- `ActivateScheduledAsync`: promotes a due scheduled row, flips expiring active→cancelled, updates
+  tenant columns, emits `TENANT.PLAN.CHANGED` `source=scheduled-activation`; idempotent by
+  `assignmentId` (re-run = no-op).
+- Integration: cancel → enqueue → run `PlatformTaskQueueProcessor` → scheduled row becomes active.
+
+**Implement:**
+- [ ] `PlanAssignmentService.CancelAsync` + `ActivateScheduledAsync` (period-end boundary via
+      `Plan.BillingInterval` from 34-1; `TimeProvider`-driven).
+- [ ] `Services/Provisioning/ActivateScheduledPlanTaskPayload.cs` (mirror `MoveTenantTaskPayload`:
+      `TaskType` const + `TenantId` + `AssignmentId`).
+- [ ] Enqueue the activation task in `CancelAsync`/`AssignAsync`-with-future-EffectiveFrom via
+      `IPlatformQueuedTaskRepository.EnqueueAsync`; add a claim handler in the processor that
+      dispatches to `ActivateScheduledAsync`.
+
+### Phase 4 — Admin + tenant self-service endpoints (AC10-12)
+
+**Tests first** (`tests/Tamma.Api.Tests/Pricing/PlanAssignmentEndpointsTests.cs`, WebApplicationFactory):
+- `PATCH`/`PUT /api/admin/tenants/{id}/plan` round-trip (PlatformOwnerAccess); non-platform JWT →
+  403; unknown tenant → 404; draft/deprecated/custom-misbound → 422; idempotent PUT.
+- `POST /api/pricing/subscribe`: tenant_owner → 200; `member` → 403; custom/draft/deprecated/
+  non-public → 422; **tenant isolation** — caller A's body tenant id is ignored, route uses
+  `ITenantContext`, cannot touch tenant B.
+- `POST /api/admin/tenants/{id}/plan/cancel` → 200, scheduled `plan_free` row created.
+- Single-user mode: the sole user can both admin-assign and self-subscribe.
+
+**Implement:**
+- [ ] Refactor `AdminTenantsEndpoints.UpdateTenantPlan` to delegate to `AssignAsync` (drop the
+      inline plan-flip + `PLAN.UPDATED`; keep `PLAN.UPDATED` as an alias tag on `TENANT.PLAN.CHANGED`
+      for one release).
+- [ ] Add `AdminTenantsEndpoints.PutTenantPlan` + `CancelTenantPlan`.
+- [ ] Add `PricingEndpoints.Subscribe` (file from 34-2): resolve tenant via `ITenantContext`,
+      `RequireTenantAdmin` member-403 gate (mirror `AlertEndpoints`), public-plan validation via
+      `IPlanCatalogService`, then `AssignAsync`.
+- [ ] `Program.cs` — map `admin.MapPut("/tenants/{tenantId:guid}/plan", …)` +
+      `admin.MapPost("/tenants/{tenantId:guid}/plan/cancel", …)` (`PlatformOwnerAccess`) and
+      `MapPost("/api/pricing/subscribe", …)` (`SettingsManage`); register
+      `IPlanAssignmentService`/`ITenantUsageReader` via `PricingServiceCollectionExtensions`.
+
+### Phase 5 — Wire-up, full suite, docs (AC14)
+
+- [ ] `PricingServiceCollectionExtensions.cs` registers `IPlanAssignmentService`,
+      `NullTenantUsageReader`, and the activation task handler; called from `Program.cs`.
+- [ ] Run `dotnet build` then `sg docker -c "dotnet test apps/tamma-elsa"` — full green.
+- [ ] Verify `has-pending-model-changes` → none; migration up/down clean.
+- [ ] Confirm `AdminTenantsEndpoints.ListTenants` still renders plan (lockstep columns intact).
+
+---
+
+## Sequencing & dependencies
+
+- **Hard prerequisite:** 34-1 (versioned `Plan` + `IPlanCatalogService` + `EntitlementMetricKey`)
+  and 34-2 (`PricingEndpoints.cs` + custom-plan binding). Do not start Phase 2 until 34-1's catalog
+  service compiles.
+- Internal order: **Phase 1 → 2 → 3 → 4 → 5.** Phase 1 (entity+migration) gates everything;
+  Phases 2-3 are the service core; Phase 4 is the API surface; Phase 5 is wiring + green-suite.
+- **Blocks:** Epic 35 Billing (consumes `TENANT.PLAN.CHANGED` proration boundary +
+  `ScheduledEffectiveAt`); Epic 34 Enforcement (consumes the active pinned snapshot).
+
+---
+
+## Risks + mitigations
+
+- **Plan deprecation silently re-prices tenants** (the headline risk). Mitigation: `PlanVersion`
+  is a *denormalized pinned column*, never a "latest" join; Phase-1 test asserts the pin survives a
+  deprecate. Phase-2 test re-asserts at the service layer.
+- **Two active assignments via a race** (concurrent admin + self-service). Mitigation: partial
+  unique index `ux_tpa_one_active_per_tenant` is the DB-level invariant; the service catches the
+  unique violation and returns 409 rather than two rows. Phase-1 (DB) + Phase-2 (service) tests.
+- **Cancel drops the tenant immediately instead of at period end.** Mitigation: cancel writes a
+  *scheduled* row at the boundary and only the queue-driven `ActivateScheduledAsync` promotes it;
+  default is period end, `Immediate` is opt-in. Phase-3 tests pin both paths.
+- **Downgrade accidentally blocks** (scope creep into enforcement). Mitigation: `AssignAsync`
+  always succeeds for a valid plan and only returns `Warnings`; `ITenantUsageReader` is a no-op
+  default so no metering coupling. Boundary note + Phase-2 test guard this.
+- **Boundary activation lost if host was down at the boundary.** Mitigation: the activation task is
+  idempotent by `assignmentId` and re-evaluated on the next `PlatformTaskQueueProcessor` tick;
+  `RunOnStartup` gating (per MEMORY) means prod must enable the processor for queued boundary work.
+- **Dashboard timeline blanks on `PLAN.UPDATED` → `TENANT.PLAN.CHANGED` rename.** Mitigation: keep
+  `PLAN.UPDATED` as an alias tag on the new event for one release.
+- **Migration discipline.** Table is additive (no CHECK edits to existing tables, so Phase-0
+  collapsed-baseline rules don't apply), but still mirror entity config in
+  `TammaModelConfiguration.cs` only and verify `has-pending-model-changes` → none after the add.
+- **34-1 shape drift.** If 34-1 named `Plan.Status` values or `IPlanCatalogService` differently,
+  align the guard logic to the real names at Phase-2 start (read 34-1's merged code first).
+
+---
+
+## Acceptance criteria (mirror of the story)
+
+- [ ] `TenantPlanAssignment` entity + table + additive migration; partial unique index gives one
+      `active` assignment per tenant; CHECKs on status/window/version. (AC1-2)
+- [ ] `Tenant.PlanId`/`Plan` derived & back-filled from the active assignment; assignment is the
+      source of truth thereafter. (AC3)
+- [ ] `IPlanAssignmentService.AssignAsync` pins the plan version, refuses draft, refuses
+      deprecated-without-force, validates custom-plan binding. (AC4)
+- [ ] Transactional swap keeps exactly one active row + lockstep tenant columns; concurrent assign
+      → 409, never two active rows. (AC5)
+- [ ] Upgrade/downgrade emit `TENANT.PLAN.CHANGED` with old/new plan+version, direction, and a
+      proration boundary marker for Epic 35. (AC6)
+- [ ] Over-limit downgrades are flagged in `PlanAssignmentResult.Warnings` (not blocked); usage
+      read behind `ITenantUsageReader`. (AC7)
+- [ ] Cancel schedules `EffectiveTo` at period end + a `scheduled` `plan_free` row; boundary
+      activation promotes it via the platform queue. (AC8-9)
+- [ ] `PATCH`+`PUT /api/admin/tenants/{id}/plan` (PlatformOwnerAccess) delegate to the service;
+      `POST /api/pricing/subscribe` (SettingsManage) self-serves a public plan; `member` → 403. (AC10-11)
+- [ ] Per-mode + per-tenant ownership honored; tenant isolation enforced. (AC12)
+- [ ] Version pinning survives plan deprecation (no re-price). (AC13)
+- [ ] Unit + integration tests cover pinning, one-active invariant, custom misassignment,
+      cancel→free scheduling, DCB emission, RBAC, and tenant isolation; full suite green. (AC14)

--- a/docs/superpowers/plans/2026-06-17-34-5-cost-price-markup-engine-plan.md
+++ b/docs/superpowers/plans/2026-06-17-34-5-cost-price-markup-engine-plan.md
@@ -1,0 +1,198 @@
+# Story 34-5: Cost->Price Markup Engine — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan phase-by-phase. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every phase writes failing
+> tests before implementation.
+
+**Story:** `docs/stories/epic-34/story-34-5/34-5-cost-price-markup-engine.md` | **Epic 34** Pricing,
+Plans & Entitlements | **Priority** P0 | **Effort** 4-5 days | **Date** 2026-06-17
+
+---
+
+## Goal
+
+Build the canonical, pure, deterministic engine that turns a measured usage event into a priced
+amount: provider cost basis (`ProviderPricingService`) × a versioned, configurable margin policy ->
+sell price for platform-provided usage, and **zero** token markup for BYOK usage. Ship the
+control-plane `MarginPolicy` entity + resolver, the platform-owner admin API to view/version
+margins, and a tenant-facing estimate endpoint. The engine moves no money; Billing (Epic 35), cost
+analytics (36-7), and the producer (32-9) all consume it.
+
+## Non-goals (YAGNI guard)
+
+- **NO money movement, no invoices, no Stripe.** Sell price computation only; Epic 35 charges.
+- **NO provider cost table changes.** `ProviderPricingService` is the cost-basis source of truth;
+  this story consumes `Compute`/`IsKnown`, it does not edit the rate sheet.
+- **NO BYOK-vs-platform mode selection.** That is Story 34-3 (`TenantProviderBilling`,
+  `IProviderKeyResolver`, `ProviderDiagnostic.BillingMode`). This engine *reads* the mode.
+- **NO usage-event production.** Epic 32-9 emits the usage line; this engine prices a line handed to
+  it.
+- **NO per-tenant margin rows.** Margins are platform-owned global config (global/plan/provider
+  scope). Per-tenant customization of markup is intentionally not a feature.
+- **NO TypeScript-side pricing.** Pricing lives in the C# control plane (`apps/tamma-elsa`);
+  `packages/*` providers/dashboards consume it over HTTP.
+
+## Current-state findings (verified 2026-06-17, repo @ main)
+
+| Site | What exists today |
+|---|---|
+| `apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderPricingService.cs` + `IProviderPricingService.cs` | Frozen-table cost basis. `Compute(provider, model, in, out)` returns USD; **unknown `(provider, model)` returns `0m`** (silent zero). `IsKnown(provider, model)` is the gate this story must use to avoid inheriting the silent zero. Registered `TryAddSingleton` in `Tamma.Api/Extensions/ProviderSessionServiceCollectionExtensions.cs:27`. |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/ProviderDiagnostic.cs` | Per-call diagnostic row: `InputTokens`, `OutputTokens`, `TokensUsed`, `Cost`, `ProviderKey`, `Model`, `TenantId`, `CorrelationId`. Story 34-3 adds `BillingMode` (byok|platform) here (or as a DCB tag) — the engine reads it via `UsageLine.PricingMode`. |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Providers/HttpProviderClient.cs:202,248` | Already calls `_pricing.Compute(...)` to set `ProviderDiagnostic.Cost`. Confirms the cost-basis seam and the split input/output token model. |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/Plan.cs` + `Services/.../PlansSeeder.cs` (Story 34-1) | Plan catalog; 34-1 adds `PlanPrice` with `PricingMode platform_provided|byok` and `IPlanCatalogService`/`PlanSnapshot`. Used to resolve the caller's plan slug for the estimate. |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | CP DbSets (Plans:76, ProviderDiagnostics:191, DomainEvents:199, …). `OnModelCreating` is where entity config + CHECK constraints + indexes go. Add `DbSet<MarginPolicy>` here. |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/` | EF migrations live here. `margin_policies` is **additive** — normal `dotnet ef migrations add`, then `has-pending-model-changes` -> none. |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Alerts/PostgresAlertSink.cs:133,180` | Canonical DCB emit pattern: `await _events.AppendAsync(new DomainEvent { Type=..., TenantId=..., Tags=JsonSerializer.Serialize(...), Metadata="""{"eventSource":"system"}""", Data=... })`, wrapped in try/catch + log-on-failure. Copy this for `PRICING.MARGIN.UPDATED`. `IEventRepository` is scoped (`AlertServiceCollectionExtensions.cs:66`). |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminAnalyticsEndpoints.cs` | Static-handler endpoint style for `PlatformOwnerAccess`/`OwnerAccess` admin reads. Model `AdminPricingEndpoints` on this. |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/ConventionStoreEndpoints.cs` + `Program.cs:1769` | `var adminConventions = app.MapGroup("/api/admin/conventions").RequireAuthorization("PlatformOwnerAccess")` — exact pattern for the new `/api/admin/pricing` group. |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs:1512` | `var orgs = app.MapGroup("/api/v1/orgs").RequireAuthorization("MemberAccess")` — tenant-scoped group pattern for the estimate endpoint (`/api/pricing`). |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs:2030` | `await Tamma.Data.Seeders.PlansSeeder.SeedAsync(dbContext);` inside startup seed scope — register `MarginPolicySeeder.SeedAsync` right beside it. |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/PromptEndpoints.cs:36` | `if (modeProvider.Mode == TammaMode.SaaS && tenantContext.TenantId is Guid tenantId)` — the per-mode + `ITenantContext.TenantId` pattern the estimate endpoint uses. `ITammaModeProvider` is in `Services/PromptStore/TammaMode.cs`. |
+| Auth policies in `Program.cs` | `PlatformOwnerAccess` (986), `MemberAccess` (991), `OwnerAccess` (971) — all already registered; reuse, don't add. |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Providers/ProviderChainResolverTests.cs` | Test conventions: NUnit (`[TestFixture]`/`[Test]`/`[SetUp]`), FluentAssertions, Moq. Mirror for the new `tests/Tamma.Api.Tests/Pricing/` suite. |
+
+**Confirmed absent (this story creates):** `MarginPolicy`, `IUsagePricingEngine`/`UsagePricingEngine`,
+`IMarginPolicyResolver`, `PRICING.*` events, `AdminPricingEndpoints`,
+`Tamma.Api/Services/Pricing/` (34-1 creates the dir), and `PricingEndpoints` (34-3 creates the file;
+this story adds `GetEstimate`).
+
+**Key gotcha:** `ProviderPricingService.Compute` returns `0m` for unknown pairs — the engine MUST
+call `IsKnown` first and throw `PRICING.UNKNOWN_MODEL`, otherwise an unpriced model silently bills
+at zero (the exact misconfig the AC forbids).
+
+---
+
+## Phased task breakdown (test-first / TDD)
+
+### Phase 0 — Prereq gate (no code)
+
+- [ ] Confirm Stories 34-1 and 34-3 are merged (or stub their seams): `IPlanCatalogService`/
+      `PlanSnapshot`, the shared `PricingMode` concept, and `ProviderDiagnostic.BillingMode`. If 34-3
+      isn't done, the engine + admin API + golden tests can still land; the estimate endpoint's mode
+      lookup degrades to "platform-provided" until 34-3 wires `TenantProviderBilling`.
+
+### Phase 1 — `MarginPolicy` entity, migration, seeder (control plane)
+
+- **Files:** `Tamma.Data/Entities/MarginPolicy.cs` (new), `Tamma.Data/ControlPlaneDbContext.cs`
+  (DbSet + `OnModelCreating` config), `Tamma.Data/Migrations/ControlPlane/<ts>_AddMarginPolicy.cs`
+  (new), `Tamma.Data/Seeders/MarginPolicySeeder.cs` (new),
+  `Tamma.Core/Enums/PricingMode.cs` (new, unless 34-1 ships a shared enum to reuse).
+- **Tests first:** `tests/Tamma.Api.Tests/Pricing/MarginPolicySeederTests.cs` — fresh DB gets the
+  global `1.3x` row with a deterministic UUIDv7; second run is a no-op; an admin-edited multiplier
+  is NOT reverted (insert-missing-only). Schema test: all-null knobs rejected by
+  `ck_margin_has_knob`; two `active` rows for the same `(scope, refKey)` rejected by the partial
+  unique index.
+- **Approach:** entity + EF config per the story's model-config block (3 CHECK constraints +
+  filtered unique index with `AreNullsDistinct(false)`). `MarginPolicySeeder.SeedAsync` mirrors
+  `PlansSeeder` (deterministic ids, `AnyAsync` guard before insert). Run `dotnet ef migrations add
+  AddMarginPolicy -c ControlPlaneDbContext`; verify `has-pending-model-changes` -> none.
+
+### Phase 2 — Pure engine (`IUsagePricingEngine`) + records
+
+- **Files:** `Tamma.Api/Services/Pricing/UsageLine.cs`, `PricedUsage.cs`, `IUsagePricingEngine.cs`,
+  `UsagePricingEngine.cs`, `PricingEventTypes.cs` (constants).
+- **Tests first:** `tests/Tamma.Api.Tests/Pricing/UsagePricingEngineTests.cs` (mock
+  `IProviderPricingService`): multiplier-only, fixed-per-1M-only, combined; BYOK -> non-zero
+  `CostBasisUsd`, `SellPriceUsd==0`, `MarginUsd==0`; unknown model -> `PRICING.UNKNOWN_MODEL` + WARN;
+  rounding determinism (6dp even, 2dp invoice projection); plus the **golden-file** test
+  `PriceUsage_GoldenScenarios_AreByteStable` comparing serialized `PricedUsage` to
+  `Pricing/golden/pricing-scenarios.json`.
+- **Approach:** implement exactly the arithmetic in the story (gate on `IsKnown` -> throw on miss;
+  `Round6` at every boundary; BYOK short-circuit). Pure, no I/O, no DB. The golden JSON is generated
+  once from the agreed scenarios and committed.
+
+### Phase 3 — Margin policy resolver (impure, DB-backed)
+
+- **Files:** `Tamma.Api/Services/Pricing/IMarginPolicyResolver.cs`, `MarginPolicyResolver.cs`.
+- **Tests first:** `MarginPolicyResolverTests.cs` (Sqlite/in-memory `ControlPlaneDbContext` or
+  mocked DbSet): resolution order provider > plan > global; timestamp-effective selection (event at
+  `t` resolves the row whose `EffectiveFrom <= t`, newest-first, not the latest overall); no policy
+  at any scope -> `TammaError("PRICING.MARGIN.NO_POLICY")`.
+- **Approach:** query `MarginPolicies` per scope in priority order, filtering `EffectiveFrom <=
+  atTimestamp`, ordered `EffectiveFrom desc`, take first; fall through scopes; throw on total miss.
+  Scoped service (`ControlPlaneDbContext` is scoped).
+
+### Phase 4 — Admin API (view/version margins, `PlatformOwnerAccess`)
+
+- **Files:** `Tamma.Api/Endpoints/Admin/AdminPricingEndpoints.cs` (new), `Program.cs` (map new
+  `/api/admin/pricing` group + DI in `PricingServiceCollectionExtensions.cs`).
+- **Tests first:** `AdminPricingEndpointsTests.cs`: `PUT` supersedes prior active + inserts new
+  active + emits exactly one `PRICING.MARGIN.UPDATED` (assert via captured `IEventRepository`); `GET`
+  returns active + history; non-platform-owner -> 403.
+- **Approach:** static handlers like `AdminAnalyticsEndpoints`; `PUT` runs supersede+insert in a
+  transaction, then `IEventRepository.AppendAsync` (try/catch+log per `PostgresAlertSink`). Map under
+  `app.MapGroup("/api/admin/pricing").RequireAuthorization("PlatformOwnerAccess")`. Wire DI:
+  `TryAddSingleton<IUsagePricingEngine,…>`, `TryAddScoped<IMarginPolicyResolver,…>`; call
+  `MarginPolicySeeder.SeedAsync` beside `PlansSeeder.SeedAsync` (~Program.cs:2030).
+
+### Phase 5 — Tenant estimate endpoint (`MemberAccess`)
+
+- **Files:** `Tamma.Api/Endpoints/PricingEndpoints.cs` (add `GetEstimate`; file from 34-3),
+  `Program.cs` (map `/api/pricing` group).
+- **Tests first:** `PricingEstimateEndpointTests.cs`: platform-provided tenant -> marked-up
+  estimate; BYOK tenant -> `sellPriceUsd==0` token component; unknown model -> 4xx
+  `PRICING.UNKNOWN_MODEL`; **tenant-isolation** — tenant A's estimate uses only A's plan/mode; any
+  `/api/admin/pricing/*` call by a tenant role -> 403.
+- **Approach:** `GetEstimate` reads `ITenantContext.TenantId` + `ITammaModeProvider` (single-user ->
+  instance plan), resolves plan slug via `IPlanCatalogService` (34-1), resolves `(tenant, provider)`
+  mode via the 34-3 seam, calls `IMarginPolicyResolver.ResolveAsync` then
+  `IUsagePricingEngine.PriceUsage`, returns `PricedUsage`. Map under
+  `app.MapGroup("/api/pricing").RequireAuthorization("MemberAccess")`.
+
+### Phase 6 — Wire-up, quality gates, docs
+
+- [ ] `dotnet build` clean; `sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests"` green.
+- [ ] `dotnet ef migrations has-pending-model-changes -c ControlPlaneDbContext` -> none; migration
+      applies + rolls back cleanly.
+- [ ] Logging per the story's Logging Requirements (INFO/DEBUG/WARN/ERROR, no secrets).
+- [ ] Update epic/consumer notes so Epic 35/36-7/32-9 reference `IUsagePricingEngine` rather than
+      re-implementing markup (boundary note).
+
+## Sequencing & dependencies
+
+Phase 0 (prereq gate) -> Phase 1 (entity/migration/seeder) -> Phase 2 (pure engine) -> Phase 3
+(resolver) -> Phase 4 (admin API) -> Phase 5 (estimate) -> Phase 6 (gates). Phases 2 and 3 are
+parallel-safe after Phase 1. Phase 4 needs 1+3; Phase 5 needs 1+2+3 plus the 34-1/34-3 seams.
+Hard prerequisites: Story 34-1 (`IPlanCatalogService`, shared `PricingMode`) and Story 34-3
+(`ProviderDiagnostic.BillingMode` / `TenantProviderBilling`). The pure engine + admin API can land
+ahead of 34-3 with the mode defaulting to platform-provided.
+
+## Risks + mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| `ProviderPricingService.Compute` silent-zero leaks into sell price | High | Gate on `IsKnown`, throw `PRICING.UNKNOWN_MODEL`; explicit unit test |
+| Rounding/float drift breaks reproducibility | Medium | `decimal` only, even-rounding at fixed 6dp boundaries, golden-file regression test |
+| In-place margin edit re-prices historical usage | High | Versioned supersede + `EffectiveFrom`-windowed resolution; timestamp-effective test |
+| Consumer epics (35/36-7/32-9) duplicate markup math | Medium | Canonical `IUsagePricingEngine`; boundary note; expose engine, not raw math |
+| Cross-tenant leak in estimate | High | Resolve plan/mode strictly from `ITenantContext`/`ITammaModeProvider`; tenant-isolation test; admin routes 403 for tenant roles |
+| 34-3 `BillingMode` not yet present | Medium | `UsageLine.PricingMode` is an explicit input; estimate defaults to platform-provided until 34-3 lands; engine unchanged |
+| Migration discipline (additive table) | Low | Normal `ef migrations add`; verify `has-pending-model-changes` none; config only in `OnModelCreating` |
+
+## Acceptance criteria (mirror of the story)
+
+- [ ] `MarginPolicy` entity + `margin_policies` table (scope/refKey/markupMultiplier/fixedUsdPer1M/
+      effectiveFrom/status), CHECK `ck_margin_has_knob` (>=1 knob non-null), CHECK on scope/status,
+      partial unique index (one active per `(scope, refKey)`, NULLS NOT DISTINCT). `has-pending-
+      model-changes` -> none.
+- [ ] `MarginPolicySeeder` seeds global `1.3x` (deterministic id, insert-missing-only, never reverts
+      admin edits).
+- [ ] `IMarginPolicyResolver` resolves provider-override -> plan -> global -> `PRICING.MARGIN.NO_POLICY`
+      (never silent zero), honoring `EffectiveFrom <= timestamp`.
+- [ ] `IUsagePricingEngine.PriceUsage` returns `{ CostBasisUsd, MarginUsd, SellPriceUsd, PricingMode }`;
+      platform-provided -> cost × margin (+ fixed/1M); BYOK -> cost basis computed but token sell
+      price = 0.
+- [ ] Engine reads input/output tokens + provider + model + mode from the `UsageLine`
+      (ProviderDiagnostic / DCB usage event); per-call basis exact (input/output at different rates).
+- [ ] Reproducible / byte-stable (6dp internal even-rounding, 2dp invoice) — golden-file test.
+- [ ] Unknown `(provider, model)` -> `PRICING.UNKNOWN_MODEL` (not silent zero), WARN logged.
+- [ ] `GET/PUT /api/admin/pricing/margins` (`PlatformOwnerAccess`); `PUT` versions + emits
+      `PRICING.MARGIN.UPDATED`.
+- [ ] `GET /api/pricing/estimate` (tenant `MemberAccess`) returns a priced estimate under the
+      tenant's plan + mode.
+- [ ] Unit tests: platform markup math, BYOK zero-markup, resolution order, timestamp-effective
+      selection, unknown-model error, no-policy error, rounding determinism.
+- [ ] Tenant-isolation test: estimate uses only the caller's plan/mode; tenant roles 403 on
+      `/api/admin/pricing/*`.
+- [ ] Full `Tamma.Api.Tests` suite green; build clean; migration applies + rolls back.

--- a/docs/superpowers/plans/2026-06-17-34-6-entitlement-and-quota-resolution-service-plan.md
+++ b/docs/superpowers/plans/2026-06-17-34-6-entitlement-and-quota-resolution-service-plan.md
@@ -1,0 +1,323 @@
+# Story 34-6 — Entitlement & Quota Resolution Service
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation. C# suites that touch Postgres run via `sg docker -c "dotnet test ..."`;
+> the build itself needs no wrapper.
+
+**Goal:** Ship the single read seam that turns a tenant's pinned plan assignment (34-4) into a
+concrete, closed, cached `ResolvedEntitlements` map — one `{ limit, period, overageMode }` per
+`EntitlementMetricKey` (34-1) — plus a non-enforcing `CheckHeadroom` calc that the sibling
+Enforcement epic, Billing (Epic 35), and both dashboards all consume. The resolver answers "what is
+this tenant allowed?", per-mode (SaaS tenant_id vs single-user user_id→tenant), with event-driven
+cache invalidation. It does NOT meter consumption (Epic 35) and does NOT block (Enforcement).
+
+**Story file:** `docs/stories/epic-34/story-34-6/34-6-entitlement-and-quota-resolution-service.md`
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane API). Tests live in
+`apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/` (xUnit). No new package; everything lands under the
+existing `Tamma.Api/Services/Pricing/` directory (introduced by 34-1) + a new `Dtos/Pricing/`.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- NO usage **metering** writes (Epic 35). The resolver only *reads* gauge counts behind
+  `IEntitlementUsageReader` and returns `null` for metering-only metrics (`LlmTokens`,
+  `WorkflowRuns`) until Epic 35 supplies its reader.
+- NO quota **enforcement** / blocking. `CheckHeadroom` computes over/remaining; nothing in this
+  story blocks a workflow, a request, or a provider call (sibling Enforcement epic owns that).
+- NO Stripe / billing / charging (Epic 35).
+- NO catalog / assignment **mutation**. This story is read-only over 34-1 (`IPlanCatalogService`)
+  and 34-4 (`IPlanAssignmentService.GetActiveAsync`). It never writes `Plan`/`PlanEntitlement`/
+  `TenantPlanAssignment`.
+- NO new EF migration. The resolver reads existing tables; the only new state is an in-memory cache.
+- NO dashboard UI. The two dashboards consume this API in a later story.
+- NO change to the metric enum or the catalog/assignment contracts — they are imported verbatim.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### Prerequisites this story builds on (sibling stories, already drafted)
+
+| Contract | Owner | Where |
+|---|---|---|
+| `EntitlementMetricKey` closed enum (`Agents, WorkflowRuns, LlmTokens, Seats, Repos, RagStorageMb, BenchmarkRetentionDays`), snake_case persisted | **34-1** | `Tamma.Core/Enums/EntitlementMetricKey.cs` (NEW in 34-1) |
+| `PlanEntitlement { MetricKey, LimitValue long? (null=unlimited), Period, OverageMode }` | **34-1** | `Tamma.Data/Entities/PlanEntitlement.cs` (NEW in 34-1) |
+| `IPlanCatalogService.GetByIdAsync(planId) → PlanSnapshot{ Version, Status, IsCustom, Entitlements }` | **34-1** | `Tamma.Api/Services/Pricing/IPlanCatalogService.cs` (NEW in 34-1) |
+| `IPlanAssignmentService.GetActiveAsync(tenantId) → TenantPlanAssignment{ PlanId, PlanVersion }` (pinned) | **34-4** | `Tamma.Api/Services/Pricing/IPlanAssignmentService.cs` (NEW in 34-4) |
+| `TENANT.PLAN.CHANGED` event (tags incl. `tenantId`) on assign/activation | **34-4** | `Tamma.Api/Services/Pricing/PlanAssignmentEventTypes.cs` (NEW in 34-4) |
+| `PricingEndpoints.cs` file (tenant pricing surface) | **34-2** | `Tamma.Api/Endpoints/PricingEndpoints.cs` (NEW in 34-2) |
+| `PricingServiceCollectionExtensions` DI seam | **34-1** | `Tamma.Api/Extensions/PricingServiceCollectionExtensions.cs` (NEW in 34-1) |
+| `PLAN.CATALOG.UPDATED` (or equivalent catalog-edit event) | **34-2** | catalog admin CRUD; verify exact event name in `PlanCatalogEventTypes.cs` |
+
+> **Sequencing reality:** 34-1, 34-2, 34-4 are *drafted* (story files exist) but not yet
+> implemented. This plan's Task 0 verifies the live signatures before coding; if a sibling has not
+> landed, stub the consumed interfaces behind the seam and pin against the story contracts above
+> (the unit tests mock these interfaces, so this story can be built and tested ahead of full
+> sibling implementation, then re-verified once they land).
+
+### Existing seams this story reuses (verified live in repo)
+
+| Seam | File (verified) | Use |
+|---|---|---|
+| `ITammaModeProvider.Mode` (SingleUser \| SaaS, process-stable) | `src/Tamma.Api/Services/PromptStore/TammaMode.cs:48` | per-mode principal resolution |
+| Fail-loud resolution precedent (`tenant → system → throw`, no empty fallback) | `src/Tamma.Api/Services/PromptStore/PromptStoreService.cs:145-173` | mirror for `NO_ASSIGNMENT` |
+| `ITenantContext.TenantId` | `src/Tamma.Data/ITenantContext.cs:3` | caller tenant on member route |
+| In-process event-bus subscriber (cache invalidation precedent) | `src/Tamma.Api/Services/TenantStatus/TenantStatusInvalidationListener.cs:42` | `EntitlementCacheInvalidationListener` model |
+| `IPlatformEventBus.Subscribe(typePrefix, handler)` (prefix subscription, per-handler catch) | `src/Tamma.Api/Services/PlatformEvents/IPlatformEventBus.cs:52-74` | subscribe `TENANT.PLAN.` + catalog prefix |
+| `IEventRepository.AppendAsync(DomainEvent)` (tenant-scope DCB) | `src/Tamma.Data/Repositories/IEventRepository.cs:7` | `ENTITLEMENT.RESOLVED.*` emit |
+| `IPlatformEventPublisher.AppendAndPublishAsync(PlatformEvent)` | `src/Tamma.Api/Services/PlatformEvents/PlatformEventPublisher.cs:33` | platform-audit mirror |
+| `IMemoryCache` cache precedent | `src/Tamma.Api/Services/Diagnostics/DiagnosticsService.cs`, `InMemoryBudgetConfigProvider.cs` | `EntitlementSnapshotCache` |
+| `ITenantMembershipRepository.ListByTenantAsync(tenantId, limit, offset) → (Members, Total)` | `src/Tamma.Data/Repositories/ITenantMembershipRepository.cs:10` | `Seats` count |
+| `AgentConfig { TenantId }` (Epic 32) | `src/Tamma.Data/Entities/AgentConfig.cs:13` | `Agents` count |
+| `GitHubInstallationRepo { IsActive, InstallationEntityId }` | `src/Tamma.Data/Entities/GitHubInstallationRepo.cs` | `Repos` count |
+| `TenantMembership { Role }` + `TenantRoleHierarchy` (owner/admin/member) | `src/Tamma.Data/Entities/TenantMembership.cs`, `src/Tamma.Api/Authorization/TenantRoleHierarchy.cs:16-21` | RBAC |
+| Auth policies `MemberAccess` / `PlatformOwnerAccess` | `src/Tamma.Api/Program.cs:986-994` | endpoint gating |
+| `TammaError(code, message, context, retryable, severity)` | `src/Tamma.Core/TammaError.cs:44` | fail-loud errors |
+| `DomainEvent { Type, TenantId, Tags, Metadata, Data }` | `src/Tamma.Data/Entities/DomainEvent.cs` | event shape |
+
+**Key reuse note:** the cache-invalidation listener is a near-clone of
+`TenantStatusInvalidationListener` *but simpler* — it subscribes the in-process `IPlatformEventBus`
+(no Postgres LISTEN/NOTIFY), so no Npgsql connection management, no shutdown drain. Lift the
+subscribe/handler/swallow shape, drop the LISTEN machinery.
+
+---
+
+## Architecture
+
+**resolve (cache-first) → snapshot (pinned) → closed map → headroom**, all read-only:
+
+1. **`IEntitlementService.ResolveAsync(principal)`** — single read seam. Principal → tenantId
+   (per-mode), cache-first, else `IPlanAssignmentService.GetActiveAsync` → `IPlanCatalogService.
+   GetByIdAsync` → build a complete 7-key `ResolvedEntitlements` (backfill missing metrics with a
+   documented default), cache it, emit `ENTITLEMENT.RESOLVED.SUCCESS` on the miss.
+2. **`CheckHeadroom(resolved, metric, usage)`** — pure, shared, non-enforcing over/remaining calc.
+3. **`IEntitlementSnapshotCache`** — `IMemoryCache`-backed, keyed by tenantId, TTL + explicit
+   eviction.
+4. **`EntitlementCacheInvalidationListener`** — `BackgroundService` subscribing `IPlatformEventBus`:
+   `TENANT.PLAN.CHANGED` evicts one tenant; `PLAN.CATALOG.UPDATED` flushes all.
+5. **`IEntitlementUsageReader`** — gauge-metric current-value seam; CP-backed default answers
+   seats/agents/repos, returns `null` for metering-only metrics (Epic 35).
+6. **Endpoints:** `GET /api/pricing/entitlements` (MemberAccess, tenant from `ITenantContext`),
+   `GET /api/admin/tenants/{id}/entitlements` (PlatformOwnerAccess).
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Principal | sole user → personal tenant (`ForUser`) | caller tenant (`ForTenant`, `ITenantContext`) |
+| Read own entitlements | the sole user (authenticated) | any tenant member (`MemberAccess`) — read is unprivileged |
+| Read arbitrary tenant | the sole user (same code path) | platform owner (`PlatformOwnerAccess`) only |
+| Cross-tenant guard | n/a | member route ignores body/param tenant; uses `ITenantContext` |
+| Cache key | personal tenant id | caller tenant id |
+| Mode source | `ITammaModeProvider.Mode` | same |
+
+---
+
+## Task breakdown
+
+### Task 0 — Verify sibling contracts + scaffold (no behaviour)
+
+- [ ] **Verify** the live signatures of `EntitlementMetricKey`, `PlanSnapshot.Entitlements`,
+  `IPlanCatalogService.GetByIdAsync`, `IPlanAssignmentService.GetActiveAsync`, the exact
+  `TENANT.PLAN.CHANGED` + catalog-update event names, and the `PricingServiceCollectionExtensions`
+  shape. If a sibling hasn't landed, record the pinned contract (story §Current-state) and proceed
+  against the interface (unit tests mock it).
+- [ ] Create the `Tamma.Api/Dtos/Pricing/` directory.
+- [ ] Confirm `MemberAccess` + `PlatformOwnerAccess` policies (Program.cs:986-994) and the
+  `sg docker -c "dotnet test ..."` runner contract.
+
+**Files:** read-only verification + empty dir. **Tests:** none (scaffold).
+
+### Task 1 — Models + headroom (pure, no I/O) [TDD]
+
+- [ ] **Tests first** `CheckHeadroomTests.cs`: under / at-limit / over / unlimited(`null`) / zero-
+  limit matrix; assert `Remaining`, `IsOver`, `OveragePercent` (unlimited ⇒ `Remaining=null,
+  IsOver=false` even at huge usage; zero limit ⇒ `OveragePercent=null`, `IsOver` when usage>0).
+- [ ] Implement `EntitlementModels.cs`: `EntitlementPrincipal` (ForTenant/ForUser),
+  `ResolvedEntitlement`, `ResolvedEntitlements` (closed `IReadOnlyDictionary<EntitlementMetricKey,
+  ResolvedEntitlement>` + non-throwing `Get`), `EntitlementHeadroom`.
+- [ ] Implement the pure `CheckHeadroom` as a static helper (and the `IEntitlementService` member
+  delegates to it) so it's testable without the service.
+
+**Files:** `EntitlementModels.cs`, `IEntitlementService.cs` (signature only),
+`CheckHeadroomTests.cs`. **Approach:** records + a pure static; no dependencies.
+
+### Task 2 — Snapshot cache [TDD]
+
+- [ ] **Tests first** `EntitlementSnapshotCacheTests.cs`: `Set`+`TryGet` round-trips per tenant;
+  `Invalidate(tenantId)` evicts exactly one; `Flush()` clears all; TTL expiry evicts (inject
+  `TimeProvider`/fake clock); two tenants never collide.
+- [ ] Implement `IEntitlementSnapshotCache` + `EntitlementSnapshotCache` over `IMemoryCache`
+  (precedent `DiagnosticsService`), key `"entitlements:{tenantId}"`, default 5-min TTL, explicit
+  `Invalidate`/`Flush`.
+
+**Files:** `IEntitlementSnapshotCache.cs`, `EntitlementSnapshotCache.cs`, test. **Approach:** thin
+`IMemoryCache` wrapper; keep a `ConcurrentDictionary<Guid, byte>` key registry so `Flush` and
+per-tenant eviction are O(1) (IMemoryCache has no enumerate-keys API).
+
+### Task 3 — Gauge-metric usage reader [TDD]
+
+- [ ] **Tests first** `ControlPlaneEntitlementUsageReaderTests.cs`: `Seats` = membership Total
+  (`ITenantMembershipRepository.ListByTenantAsync(t,1,0).Total`); `Agents` = `AgentConfig` count for
+  the tenant; `Repos` = active `GitHubInstallationRepo` count for the tenant's installation;
+  `LlmTokens`/`WorkflowRuns`/`RagStorageMb`/`BenchmarkRetentionDays` return `null`; reader throwing
+  for one metric is caught by the caller (assert at Task 4/5, here assert it returns the count).
+- [ ] Implement `IEntitlementUsageReader` + `ControlPlaneEntitlementUsageReader` (inject
+  `ITenantMembershipRepository`, `ControlPlaneDbContext` for `AgentConfig`/`GitHubInstallationRepo`,
+  scoped via `IServiceScopeFactory` if needed for the listener path).
+
+**Files:** `IEntitlementUsageReader.cs`, `ControlPlaneEntitlementUsageReader.cs`, test.
+**Approach:** a `switch` on `EntitlementMetricKey`; `default → null`. Repo/agent/repo counts via the
+existing repository + `CountAsync` on the DbSets.
+
+### Task 4 — Core resolution service [TDD]
+
+- [ ] **Tests first** `EntitlementServiceTests.cs`:
+  - SaaS-by-tenantId and single-user-by-userId→tenant resolve the pinned assignment → complete map;
+  - complete-7-keys invariant + per-metric default backfill (`limit=0, monthly, block`) when the
+    snapshot has fewer rows;
+  - unlimited (`null` limit) flows through resolve;
+  - `NO_ASSIGNMENT` fail-loud (throws `ENTITLEMENT.RESOLVE.NO_ASSIGNMENT` severity High, emits
+    `ENTITLEMENT.RESOLVED.FAILED{reason=no_assignment}`, NEVER returns empty);
+  - catalog-unavailable for a pinned planId → `CATALOG_UNAVAILABLE` + FAILED event;
+  - custom-plan override (IsCustom snapshot's bespoke/unlimited limits win);
+  - cache hit (second resolve does NOT call `GetActiveAsync`/`GetByIdAsync`; only the miss emits
+    `ENTITLEMENT.RESOLVED.SUCCESS`).
+- [ ] Implement `EntitlementService` (algorithm in story §Resolution algorithm), `EntitlementEventTypes.cs`.
+  Mode + principal→tenant via `ITammaModeProvider`; single-user user→personal-tenant lookup
+  (reuse the personal-tenant resolution the `EnsurePersonalTenantMiddleware` invariant guarantees).
+- [ ] Emit `ENTITLEMENT.RESOLVED.SUCCESS` (cache-miss) / `.FAILED` via `IEventRepository` +
+  platform mirror via `IPlatformEventPublisher`.
+
+**Files:** `EntitlementService.cs`, `EntitlementEventTypes.cs`, complete `IEntitlementService.cs`,
+test. **Approach:** mock `IPlanAssignmentService`, `IPlanCatalogService`, `IEntitlementSnapshotCache`,
+`IEventRepository`/`IPlatformEventPublisher` in unit tests.
+
+### Task 5 — Cache invalidation listener [TDD]
+
+- [ ] **Tests first** `EntitlementCacheInvalidationListenerTests.cs`: a published
+  `TENANT.PLAN.CHANGED{tenantId=T}` invalidates exactly T; `PLAN.CATALOG.UPDATED` flushes all; a
+  handler exception / malformed payload is swallowed (listener never throws back into the bus,
+  cache untouched for unrelated tenants).
+- [ ] Implement `EntitlementCacheInvalidationListener : BackgroundService` — on `StartAsync`
+  `Subscribe("TENANT.PLAN.", handler)` + `Subscribe(<catalog-update-prefix>, handler)`; handler
+  parses `tenantId` tag → `Invalidate`, catalog event → `Flush`; wrap in try/catch (precedent
+  `TenantStatusInvalidationListener.OnNotification`). Dispose subscriptions on `StopAsync`.
+
+**Files:** `EntitlementCacheInvalidationListener.cs`, test. **Approach:** lift the subscribe/handler
+shape from `TenantStatusInvalidationListener` *minus* the Npgsql LISTEN/NOTIFY + shutdown-drain
+machinery (in-process bus, no connection).
+
+### Task 6 — DTOs + endpoints + DI wiring [TDD]
+
+- [ ] **Tests first** `EntitlementEndpointsTests.cs` (integration, `sg docker`): member reads own
+  tenant (`GET /api/pricing/entitlements`, `MemberAccess`, body includes live seat/agent/repo
+  counts); admin reads any tenant (`GET /api/admin/tenants/{id}/entitlements`,
+  `PlatformOwnerAccess` → 200; non-platform → 403; unknown tenant → 404; no assignment → 404);
+  **tenant isolation** (tenant A member cannot read tenant B; `TENANT.PLAN.CHANGED` for A doesn't
+  evict B); version-pinning end-to-end (assign v1, deprecate→v2, resolve still v1).
+- [ ] Implement `EntitlementDtos.cs` (`ResolvedEntitlementsDto` with inline per-metric headroom
+  fields).
+- [ ] Add `GET /api/pricing/entitlements` to `PricingEndpoints.cs` (tenant from `ITenantContext` in
+  SaaS / sole user in single-user) and `GET /api/admin/tenants/{id}/entitlements` to
+  `AdminTenantsEndpoints.cs`. Each endpoint composes `ResolveAsync` + per-metric
+  `IEntitlementUsageReader.GetCurrentAsync` + `CheckHeadroom`. Map `NO_ASSIGNMENT` → 404.
+- [ ] `PricingServiceCollectionExtensions.AddEntitlementResolution(services)`: register
+  `IEntitlementService`, `IEntitlementSnapshotCache` (singleton), `IEntitlementUsageReader`
+  (scoped), and `AddHostedService<EntitlementCacheInvalidationListener>()`. Call from `Program.cs`;
+  map the two routes.
+
+**Files:** `EntitlementDtos.cs`, `PricingEndpoints.cs` (mod), `AdminTenantsEndpoints.cs` (mod),
+`PricingServiceCollectionExtensions.cs` (mod), `Program.cs` (mod), test.
+
+### Task 7 — Full-suite green + verification
+
+- [ ] `dotnet build` clean (no wrapper).
+- [ ] `sg docker -c "dotnet test apps/tamma-elsa/..."` — new Pricing tests + full suite green.
+- [ ] Confirm no migration was generated (`has-pending-model-changes` reports none — this story adds
+  no schema).
+- [ ] Re-verify against the live sibling interfaces if 34-1/34-2/34-4 landed during implementation.
+
+---
+
+## Sequencing & dependencies
+
+```
+Task 0 (verify) → Task 1 (models+headroom) → Task 2 (cache) ┐
+                                              Task 3 (reader) ┼→ Task 4 (service) → Task 5 (listener) → Task 6 (endpoints+DI) → Task 7 (verify)
+```
+
+- Task 1 is the only hard prerequisite for everything (models). Tasks 2 and 3 are independent and
+  parallel-safe. Task 4 needs 1+2 (cache) and benefits from 3 (reader, but the service can be built
+  with the reader mocked and wired fully in Task 6). Task 5 needs 2. Task 6 needs 4+5+3.
+- **Cross-story:** depends on 34-1 (`IPlanCatalogService`, `EntitlementMetricKey`, `PlanEntitlement`,
+  `PricingServiceCollectionExtensions`) and 34-4 (`IPlanAssignmentService.GetActiveAsync`,
+  `TENANT.PLAN.CHANGED`); consumes the `PricingEndpoints.cs` file from 34-2. Because the service
+  depends only on *interfaces* (mocked in unit tests), Tasks 1-5 can be built ahead of full sibling
+  implementation; Task 6 integration tests + Task 0 re-verification need the siblings live (or their
+  interfaces stubbed against the pinned contracts).
+
+---
+
+## Risks + mitigations
+
+- **Sibling stories not yet implemented (34-1/34-2/34-4 are drafted, not built).** Mitigation: code
+  against the pinned interface contracts (story §Current-state table), mock them in unit tests,
+  gate the docker integration tests (Task 6) behind sibling availability, and re-verify signatures
+  in Task 0 + Task 7. The seam-based design means this story is buildable and unit-testable ahead of
+  the siblings.
+- **Resolution must never fall back to empty/plain** (`feedback_resolution_no_empty_fallback`).
+  Mitigation: the *assignment* missing is a hard `NO_ASSIGNMENT` throw; only a *missing metric row
+  within a present assignment* backfills the documented default — Task 4 tests pin both paths
+  explicitly so a future refactor can't soften the throw into an empty map.
+- **Cache staleness.** Mitigation: pinned snapshots are immutable (deprecated plan versions never
+  mutate, 34-1), so a stale cached snapshot can never be *wrong* — only outdated if a tenant was
+  re-assigned, which `TENANT.PLAN.CHANGED` invalidation catches instantly; the TTL is a memory
+  bound, not a correctness mechanism. Task 5 tests the invalidation path; Task 2 tests TTL.
+- **Listener swallowing too much.** Mitigation: handler try/catch is per-event (precedent
+  `TenantStatusInvalidationListener`), logged WARN; a malformed event evicts nothing rather than
+  flushing everything — Task 5 asserts unrelated tenants are untouched on a bad event.
+- **Gauge reader coupling to other epics.** Mitigation: the `IEntitlementUsageReader` seam keeps
+  metering (Epic 35) out of the resolve path; the CP reader answers only seats/agents/repos and
+  returns `null` elsewhere; a reader exception degrades one metric to `CurrentUsage=null`, never
+  failing the whole read (Task 6 endpoint composition catches per-metric).
+- **Event-topology shift (Story 28-1).** Mitigation: the invalidation listener subscribes the
+  **in-process** `IPlatformEventBus`, not a DB poller, so the per-tenant event-store migration
+  doesn't break invalidation; `ENTITLEMENT.RESOLVED.*` system-scope events keep appending via the CP
+  `IEventRepository` explicitly.
+- **No migration discipline trap.** This story adds no schema — confirm `has-pending-model-changes`
+  reports none in Task 7 so no accidental migration sneaks in.
+
+---
+
+## Acceptance criteria (mirror of the story)
+
+- [ ] `IEntitlementService.ResolveAsync(principal)` returns a complete, closed `ResolvedEntitlements`
+  map (all 7 `EntitlementMetricKey` members) sourced from the pinned `(PlanId, PlanVersion)`
+  snapshot via 34-1/34-4; missing metric rows backfill the documented default (`limit 0, monthly,
+  block`).
+- [ ] Per-mode principal: SaaS by `tenant_id`, single-user by `user_id`→personal tenant; resolution
+  NEVER falls back to empty/plain — no active assignment throws
+  `ENTITLEMENT.RESOLVE.NO_ASSIGNMENT`.
+- [ ] `GET /api/pricing/entitlements` (MemberAccess, own tenant) and
+  `GET /api/admin/tenants/{id}/entitlements` (PlatformOwnerAccess) return the resolved set; unknown
+  tenant / no assignment → 404.
+- [ ] Snapshots cached per tenant; invalidated on `TENANT.PLAN.CHANGED` (evict one) and
+  `PLAN.CATALOG.UPDATED` (flush all) via an `IPlatformEventBus` subscriber.
+- [ ] Custom enterprise plan entitlements (incl. unlimited) resolve and override public defaults.
+- [ ] `CheckHeadroom(resolved, metric, usage)` returns remaining/over without enforcing — one shared
+  calc for enforcement + dashboards; unlimited ⇒ `Remaining=null, IsOver=false`.
+- [ ] Gauge metrics resolved via `IEntitlementUsageReader`: `Seats` = `TenantMembership` count,
+  `Agents` = Epic-32 agent count, `Repos` = active `GitHubInstallationRepo` count; metering-only
+  metrics return `null`.
+- [ ] `ENTITLEMENT.RESOLVED.SUCCESS`/`.FAILED` DCB events emitted (cache-miss / failure, not every
+  hit).
+- [ ] Per-mode + per-tenant ownership honored; tenant isolation enforced (A never reads B; A's plan
+  change never evicts B's cache).
+- [ ] Unit + integration tests cover resolution per mode, complete-keys + default backfill, unlimited
+  handling, cache invalidation on plan change, custom-plan override, headroom math, gauge counts,
+  RBAC matrix, tenant isolation, and version pinning. Full suite green; no migration generated.

--- a/docs/superpowers/plans/2026-06-17-34-7-trials-credits-and-promo-codes-plan.md
+++ b/docs/superpowers/plans/2026-06-17-34-7-trials-credits-and-promo-codes-plan.md
@@ -1,0 +1,298 @@
+# Story 34-7 — Trials, Credits & Promo Codes (Implementation Plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is **test-first (TDD)** — every task writes its
+> tests before implementation. C# test runner: `sg docker -c "dotnet test …"` for docker-bound
+> suites (build needs no wrapper) — see `reference_dotnet_test_docker`.
+
+**Story:** `docs/stories/epic-34/story-34-7/34-7-trials-credits-and-promo-codes.md` ·
+**Epic 34 — Pricing, Plans & Entitlements** · Priority P1 · Est. 4-5 days · Deps: 34-1, 34-4, 34-5
+
+---
+
+## Goal
+
+Add the three acquisition/retention pricing primitives — **time-boxed trials**, **prepaid/granted
+USD credits** (append-only, never-negative ledger), and **promo codes** (percent or fixed
+discount) — to the C# control plane (`apps/tamma-elsa`). Surface a **credit-aware net price**
+(`net = max(0, sell − promo − credits)`, recurring charge waived during a trial) that Billing
+(Epic 35) consumes. Every mutation is audited via DCB + platform events, gated by per-mode RBAC.
+
+## Non-goals (YAGNI guard)
+
+- **No markup/margin math.** `sellPriceUsd` comes from 34-5's `IUsagePricingEngine`; this story
+  decorates it, never re-implements `MarginPolicy`/cost-basis (34-5 boundary note: it is the
+  canonical owner).
+- **No plan-assignment logic.** Trial start/convert/downgrade *delegates* to 34-4's
+  `IPlanAssignmentService` (`AssignAsync`/`CancelAsync`); we do not duplicate `TenantPlanAssignment`
+  transitions or the partial-unique-active-row machinery.
+- **No money movement / invoicing / proration.** Epic 35 charges; this story computes the *net* and
+  emits the trial-conversion + remainder signals.
+- **No quota/usage enforcement.** Epic 34 enforcement + Epic 20 metering own that; we only flag the
+  unfunded consume remainder.
+- **No new payment SDK dependency.** Stripe stays in Epic 35; tests mock the upstream seams.
+- **No per-user credit/trial layer in SaaS.** Credits/trials are tenant-scoped (CLAUDE.md
+  two-scoping rule: SaaS principal = `tenant_id`); member users are read-only.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main)
+
+### What exists and is reused
+
+| Seam | Location (verified) | Use |
+|---|---|---|
+| Control-plane DbContext | `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` (DbSets at ~33-209; e.g. `Plans` L76, `BudgetConfigs` L205, `DomainEvents` L199) | Add 4 new `DbSet`s |
+| Entity model config (single source) | `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | CHECKs, partial unique indexes, FKs (mirror the 34-4 `TenantPlanAssignment` config sketch) |
+| Migrations | `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/` (baseline `20260609205701_InitialControlPlane`) | Additive `AddTrialsCreditsPromos` migration |
+| DCB append + tags pattern | `apps/tamma-elsa/src/Tamma.Data/Repositories/IEventRepository.cs` (`AppendAsync(DomainEvent)`); emit style at `Tamma.Api/Endpoints/OrgEndpoints.cs:1043-1058` (`Tags = JsonSerializer.Serialize(...)`, `Data = ...`) | Emit `CREDIT.*` / `PROMO.*` / `TENANT.TRIAL.*` |
+| `DomainEvent` shape | `apps/tamma-elsa/src/Tamma.Data/Entities/DomainEvent.cs` (`Type`, `TenantId`, `Tags`, `Metadata`, `Data`, `SequenceNumber`) | Event rows |
+| Platform-audit mirror | `apps/tamma-elsa/src/Tamma.Data/Abstractions/IPlatformEventPublisher.cs` (`AppendAndPublishAsync(PlatformEvent)`) | Admin/platform audit timeline |
+| Tenant-scoped financial entity precedent | `apps/tamma-elsa/src/Tamma.Data/Entities/BudgetConfig.cs` (decimal `LimitUsd`, nullable `TenantId`) | Pattern for USD decimal columns |
+| Plan entity | `apps/tamma-elsa/src/Tamma.Data/Entities/Plan.cs` (`Slug`, `MonthlyPriceUsd`, `Quotas`, `IsActive`, `PlacementPolicy`) | Plan slug ↔ id; trial-eligibility (34-1 adds the flag) |
+| Markup engine (34-5) | `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/UsagePricingEngine.cs` (NEW in 34-5), cost basis `apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderPricingService.cs` (`Compute(provider, model, in, out)` L53) | `sellPriceUsd` source to decorate |
+| Assignment lifecycle (34-4) | `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanAssignmentService.cs` + `IPlanAssignmentService` (NEW in 34-4) | Trial start/convert/downgrade delegation |
+| Pricing endpoint files | `PricingEndpoints.cs` (NEW in 34-2), `Endpoints/Admin/AdminPricingEndpoints.cs` (NEW in 34-5) | Extend with redeem/credits/promo CRUD |
+| Auth policies | `Tamma.Api/Program.cs`: `PlatformOwnerAccess` (L986), `SettingsManage` (L1001), `SettingsView` (L996), `MemberAccess` (L991) | Route gating |
+| Tenant-route RBAC precedent | `Tamma.Api/Endpoints/AlertEndpoints.cs` — `RequireTenantAdmin` (L1008), `RequireTenantMembershipFilter.TenantRoleItemKey`, admin/tenant section split, paging 50/500 | Mirror for `/api/pricing/*` + member 403 |
+| Mode | `Tamma.Api/Services/PromptStore/TammaMode.cs` (`enum TammaMode` L14, `ITammaModeProvider` L48, SaaS detection L74-95) | Per-mode ownership |
+| Tenant ctx | `apps/tamma-elsa/src/Tamma.Data/ITenantContext.cs` (`TenantId`, `SetTenantId`, `ClearTenantId`) | Resolve caller tenant; ignore body tenant id |
+| Boundary-task pattern | `PlatformQueuedTask` entity + `PlatformTaskQueueProcessor` (Epic 28); 34-4 mirrors it with `ActivateScheduledPlanTaskPayload` | Mirror with `TrialExpiryTaskPayload` |
+| Error type | `apps/tamma-elsa/src/Tamma.Core/TammaError.cs` (`TammaError(code, message, context?, retryable?, severity?)` L44) | Typed rejections (mapped to 422/403) |
+| Test layout | `apps/tamma-elsa/tests/Tamma.Api.Tests/` (per-area dirs incl. `Pricing` to be added, `Providers`, `Alerts`); docker suites via `sg docker -c "dotnet test …"` | xUnit tests |
+
+### Key facts that shape the design
+
+- **34-5 is the canonical markup owner** (its boundary note explicitly forbids consumers from
+  re-implementing markup) — so this story is a *decorator* on `IUsagePricingEngine`, registered in
+  DI so `ICreditAwarePricingEngine` (or the decorated `IUsagePricingEngine`) is what Billing/UI
+  resolves.
+- **34-4 owns plan assignment** including version pinning and the scheduled-activation queue
+  pattern — trial start/end reuse it verbatim (`AssignAsync` with a trial marker; `CancelAsync` /
+  assign `plan_free` on downgrade).
+- **`ck_*` CHECK constraints + partial unique indexes** are the established invariant-enforcement
+  mechanism (34-4 sketch). Use `ck_credit_balance_nonneg`, `ux_trial_one_active_per_tenant`,
+  unique `(PromoCodeId, TenantId)`, unique `CodeKey`.
+- **Append-only ledger** matches the DCB/event-sourcing spirit already pervasive in the repo;
+  `BalanceAfter` makes balance a running sum, no stateful "balance" column to race on.
+- **Migration discipline:** all new tables are *additive*; `dotnet ef migrations add` (not a
+  baseline CHECK edit), then `dotnet ef migrations has-pending-model-changes` must report none, and
+  config goes only in `TammaModelConfiguration.cs`.
+
+---
+
+## Phased task breakdown (TDD — tests first in every task)
+
+### Task 1 — Entities, enums, EF config, additive migration (core)
+
+**Files (create):** `Tamma.Data/Entities/{TenantTrial,CreditLedger,PromoCode,PromoRedemption}.cs`;
+`Tamma.Core/Enums/{TrialStatus,CreditReason,DiscountKind}.cs`. **(modify):**
+`Tamma.Data/ControlPlaneDbContext.cs` (4 DbSets), `Tamma.Data/TammaModelConfiguration.cs` (config),
+new migration under `Tamma.Data/Migrations/ControlPlane/`.
+
+**Approach:**
+- Entities per the story sketch. USD columns `numeric(18,6)` (mirror `BudgetConfig` decimal style).
+- `TammaModelConfiguration.cs`: `ck_credit_balance_nonneg` (`"BalanceAfter" >= 0`),
+  `ck_trial_status`, `ck_promo_kind`; partial unique `ux_trial_one_active_per_tenant`
+  (`HasFilter("\"Status\" = 'active'")`); unique `PromoCode.CodeKey`; unique
+  `(PromoRedemption.PromoCodeId, TenantId)`; index `CreditLedger (TenantId, CreatedAt)` for the
+  running-balance read; FKs to `Tenant`/`Plan` (`OnDelete` Cascade for tenant, Restrict for plan).
+- `dotnet ef migrations add AddTrialsCreditsPromos -c ControlPlaneDbContext`; then
+  `dotnet ef migrations has-pending-model-changes` → expect none.
+
+**Tests first:** `tests/Tamma.Data.Tests/Migrations/TrialsCreditsMigrationTests.cs` — migration
+applies + rolls back cleanly on real Postgres; `ck_credit_balance_nonneg` rejects a negative
+`BalanceAfter`; `ux_trial_one_active_per_tenant` rejects a second active trial; `(PromoCodeId,
+TenantId)` unique rejects a duplicate redeem; `CodeKey` unique rejects a case-insensitive dup.
+
+### Task 2 — `ICreditService` / `CreditService` (append-only, never-negative ledger)
+
+**Files (create):** `Tamma.Api/Services/Pricing/{ICreditService,CreditService,TrialsCreditsModels,
+TrialsCreditsEventTypes}.cs`.
+
+**Approach:**
+- `GetBalanceAsync` = latest `BalanceAfter` for tenant (or 0).
+- `GrantAsync` — append positive `DeltaUsd`, `BalanceAfter = prev + delta`, emit `CREDIT.GRANTED`
+  (or `CREDIT.REFUNDED` for negative/clawback, floor-clamped), write back `RefEventId`.
+- `ConsumeAsync` — **serializable transaction** (retry on `40001`): `applied = min(request,
+  balance)`; if `applied == 0 && !allowPartial && request > 0` → throw
+  `TammaError("CREDIT.CONSUME.OVERDRAFT", …)`; else insert `Reason='consume'`, `DeltaUsd=-applied`,
+  `BalanceAfter=balance-applied`; emit `CREDIT.CONSUMED`; return `ConsumeResult(applied, remainder,
+  balanceAfter)`.
+- Event emission via `IEventRepository.AppendAsync` (tenant scope, JSON `Tags`/`Data` per
+  `OrgEndpoints` style) + `IPlatformEventPublisher.AppendAndPublishAsync` (platform mirror).
+
+**Tests first:** `tests/Tamma.Api.Tests/Pricing/CreditServiceTests.cs` — floor-at-zero (consume 30
+of 20 → applied 20, remainder 10, balance 0); overdraft throw when `allowPartial=false` on empty;
+**concurrency** (two parallel consumes never oversell — real-Postgres serializable + simulated
+`DbUpdateException` retry); grant/refund balance math + event emission + `RefEventId` linkage.
+
+### Task 3 — `IPromoCodeService` / `PromoCodeService` (validation + atomic cap)
+
+**Files (create):** `Tamma.Api/Services/Pricing/{IPromoCodeService,PromoCodeService}.cs`.
+
+**Approach:**
+- `ValidateAsync(code, planSlug, tenantId)` → `PromoValidationResult(Ok, Reason?, Code?)` checking,
+  in order: found (by `CodeKey = lower(code)`), `IsActive`, not past `Expiry`, under
+  `MaxRedemptions`, not already redeemed by tenant (`PromoRedemption` lookup), `AppliesTo`
+  empty-or-contains slug. Each failure → distinct `Reason`.
+- `RedeemAsync` — validate; insert `PromoRedemption`; **atomic** `UPDATE promo_codes SET
+  RedemptionCount = RedemptionCount + 1 WHERE Id=@id AND (MaxRedemptions IS NULL OR RedemptionCount
+  < MaxRedemptions)` (0 rows ⇒ cap raced ⇒ `cap_reached`); for `fixed` kind, call
+  `CreditService.GrantAsync(Reason=promo)`; for `percent`, record only. Emit `PROMO.REDEEMED`.
+  Invalid → `TammaError` (endpoint maps to 422 with reason).
+
+**Tests first:** `tests/Tamma.Api.Tests/Pricing/PromoCodeServiceTests.cs` — full validation matrix
+(not-found / inactive / expired / cap-reached / already-redeemed / plan-not-applicable / valid);
+fixed grants a `promo` ledger row, percent does not; **concurrency** (last redemption: one wins,
+one `cap_reached`; same tenant twice → `already_redeemed`); `PROMO.REDEEMED` emitted.
+
+### Task 4 — Trials: start + boundary expiry (delegates to 34-4)
+
+**Files (create):** `Tamma.Api/Services/Provisioning/TrialExpiryTaskPayload.cs`; extend
+`CreditService` (or a `TrialService` partial) for `StartTrialAsync` / `EndTrialAsync`.
+
+**Approach:**
+- `StartTrialAsync(tenantId, planId, opts)` — guard plan trial-eligibility (34-1
+  `IPlanCatalogService`); insert `TenantTrial` (`active`, pinned `PlanVersion`, `EndsAt = now +
+  trialDays`); delegate `IPlanAssignmentService.AssignAsync` with a trial marker in
+  `AssignPlanOptions.Reason`; emit `TENANT.TRIAL.STARTED`; second active trial rejected (pre-check +
+  partial unique index).
+- Enqueue a `TrialExpiryTaskPayload(trialId)` on the platform queue at `EndsAt` (mirror 34-4's
+  `ActivateScheduledPlanTaskPayload` enqueue).
+- `EndTrialAsync(tenantId, trialId)` — idempotent by `trialId`: convert (`Status→converted`, keep
+  assignment) or downgrade (`Status→expired`, `IPlanAssignmentService.CancelAsync` / assign
+  `plan_free`); emit `TENANT.TRIAL.ENDED` with `outcome`.
+- Wire the processor branch for `TrialExpiryTaskPayload` (mirror the `MoveTenant`/activate-scheduled
+  handler).
+
+**Tests first:** extend `CreditServiceTests` (or `TrialServiceTests`) — start creates trial +
+delegates `AssignAsync` (mock); second active trial rejected; convert keeps assignment, downgrade
+calls cancel/assign-free; idempotent `EndTrialAsync`; `TENANT.TRIAL.STARTED/ENDED` shapes.
+Integration: enqueue payload → run processor → assert outcome.
+
+### Task 5 — `ICreditAwarePricingEngine` decorator (net price)
+
+**Files (create):** `Tamma.Api/Services/Pricing/{ICreditAwarePricingEngine,
+CreditAwareUsagePricingEngine}.cs`. **(modify):**
+`Tamma.Api/Extensions/PricingServiceCollectionExtensions.cs` (DI + decorate).
+
+**Approach:**
+- `PriceNetAsync(usageLine, tenantId)` — call 34-5 `IUsagePricingEngine.PriceUsage` for
+  `sellPriceUsd`; resolve any applicable percent-promo discount + available credit balance; compute
+  `net = max(0, sell − promoDiscount − creditsApplied)` (credits capped at the pre-floor remainder);
+  if an `active` trial covers the recurring component, zero it and set `trialWaived = true`;
+  optionally call `CreditService.ConsumeAsync` on the billing path (or return the figure for Epic 35
+  to consume) — keep "compute" vs "commit consume" cleanly separated. Round 6dp internal / 2dp
+  invoice (34-5 convention).
+- Register so DI hands consumers the credit-aware result; do not shadow 34-5's engine for callers
+  that need raw sell.
+
+**Tests first:** `tests/Tamma.Api.Tests/Pricing/CreditAwarePricingEngineTests.cs` — `net = max(0,
+sell − promo − credits)` (mock `IUsagePricingEngine`); trial zeroes recurring (`trialWaived`); net
+floored at 0 when discounts exceed sell, credit not over-applied; **golden-file** byte-stable
+determinism (fixed usage line + balance + promo, 6dp/2dp).
+
+### Task 6 — Endpoints (admin + tenant) with per-mode RBAC
+
+**Files (modify):** `Tamma.Api/Endpoints/Admin/AdminPricingEndpoints.cs` (credits grant/read, promo
+CRUD), `Tamma.Api/Endpoints/PricingEndpoints.cs` (redeem, credits read, estimate extension),
+`Tamma.Api/Program.cs` (map routes + DI), `PricingServiceCollectionExtensions.cs`.
+
+**Approach:**
+- Admin (`PlatformOwnerAccess`): `GET/POST /api/admin/tenants/{id}/credits`,
+  `GET/POST/PATCH /api/admin/pricing/promo-codes`. Promo create validates `DiscountKind`/`Value`
+  (percent ∈ (0,100], fixed > 0), normalizes `CodeKey`; emit `PROMO.CODE.CREATED/UPDATED`.
+- Tenant (`SettingsManage`): `POST /api/pricing/promo/redeem` (member → 403 via `RequireTenantAdmin`
+  membership pattern; tenant from `ITenantContext`, body tenant id ignored; invalid → 422 reason);
+  `GET /api/pricing/credits` (`SettingsView`); extend 34-5 `GET /api/pricing/estimate` response with
+  `creditsApplied`/`netPrice`/`trialWaived`.
+- Map `TammaError` codes → 422/403 in the endpoint catch (mirror existing prompt/convention 404
+  translation style).
+
+**Tests first:** `tests/Tamma.Api.Tests/Pricing/TrialsCreditsEndpointsTests.cs` — admin grant +
+read (PlatformOwnerAccess; non-platform JWT 403; unknown tenant 404); redeem RBAC (tenant_owner
+200, member 403); invalid-code 422 matrix; **tenant isolation** (caller A cannot redeem/read tenant
+B's ledger); single-user mode (sole user sees own credits/trial).
+
+### Task 7 — Wire-up, full-suite green, migration verification
+
+**Approach:** register all services + the decorator in `PricingServiceCollectionExtensions`; map
+all routes in `Program.cs`; run the full `Tamma.Api.Tests` + `Tamma.Data.Tests` suites via
+`sg docker -c "dotnet test …"`; confirm `has-pending-model-changes` reports none; lint/build clean.
+
+**Tests first:** N/A (integration gate) — the gate is the green full suite + clean migration check.
+
+---
+
+## Sequencing & dependencies
+
+```
+Task 1 (entities/migration)
+   ├─> Task 2 (CreditService)
+   │      └─> Task 4 (Trials)         ──┐
+   ├─> Task 3 (PromoCodeService) ───────┤
+   │                                    ├─> Task 6 (Endpoints) ─> Task 7 (wire-up + suite gate)
+   └─> Task 2 + 3 ─> Task 5 (decorator)─┘
+```
+
+- **Task 1 is the only hard prerequisite for everything.** Tasks 2 and 3 are parallel-safe after 1.
+- Task 4 needs Task 2 (grant on fixed conversion is reused) + 34-4's `IPlanAssignmentService`.
+- Task 5 needs Tasks 2 + 3 (balance + promo) and 34-5's `IUsagePricingEngine`.
+- Task 6 needs 2-5; Task 7 closes the wave.
+- **External story prerequisites:** 34-1 (`IPlanCatalogService`, trial-eligibility flag), 34-4
+  (`IPlanAssignmentService`, boundary-task pattern), 34-5 (`IUsagePricingEngine`,
+  `PricingEndpoints.cs`/`AdminPricingEndpoints.cs` files, rounding convention). If those are not yet
+  merged, stub their interfaces behind the seams already named in the story and swap to the real
+  impls when they land — do **not** re-implement them here (epic boundary).
+
+## Risks & mitigations
+
+- **Double-spend on concurrent consume** (the load-bearing invariant). *Mitigation:* serializable
+  transaction with `40001` retry (or per-tenant row lock) **and** the `ck_credit_balance_nonneg`
+  CHECK as a DB backstop; pin both in a real-Postgres concurrency test. A logic bug must still be
+  unable to persist a negative balance.
+- **Re-implementing 34-5 markup or 34-4 assignment** (boundary violation). *Mitigation:* the
+  decorator only subtracts; trials only delegate. Code review check: no `MarginPolicy` /
+  `ProviderPricingService` math and no `TenantPlanAssignment` transition logic in this story's files.
+- **Promo cap race / over-redemption.** *Mitigation:* conditional atomic `UPDATE … WHERE
+  RedemptionCount < MaxRedemptions` (0 rows ⇒ cap raced) + unique `(PromoCodeId, TenantId)`; never a
+  read-then-write.
+- **Trial boundary missed while host down.** *Mitigation:* reuse 34-4's idempotent-by-id platform
+  queue task; `EndTrialAsync` is idempotent so a late catch-up tick is safe.
+- **Net price not reproducible** (Epic 35 + cost dashboard must agree). *Mitigation:* pure
+  decorator + 34-5's fixed 6dp/2dp rounding + a golden-file determinism test.
+- **Cross-tenant leakage.** *Mitigation:* tenant routes resolve from `ITenantContext` and ignore
+  any body tenant id; reuse `AlertEndpoints` membership/`RequireTenantAdmin` gate; tenant-isolation
+  test for read + redeem.
+- **Migration discipline.** *Mitigation:* additive tables only; `has-pending-model-changes` →
+  none; entity config exclusively in `TammaModelConfiguration.cs`; up/down round-trip test.
+- **Event-topology shift (Story 28-1 / Epic 30).** *Mitigation:* tenant-scope `CREDIT.*`/`PROMO.*`/
+  `TENANT.TRIAL.*` events append via `IEventRepository`; the platform-audit mirror via
+  `IPlatformEventPublisher` keeps the platform timeline CP-resident — consistent with the existing
+  CP/per-tenant split, no special-casing needed now.
+
+## Acceptance criteria (mirror the story)
+
+- [ ] `TenantTrial`, `CreditLedger`, `PromoCode`, `PromoRedemption` entities + DbSets + EF config +
+      additive migration; `has-pending-model-changes` reports none.
+- [ ] Ledger is append-only and `BalanceAfter` never goes below zero (CHECK + serialized consume);
+      over-consume is partially applied with remainder returned; `allowPartial=false` overdraft →
+      `CREDIT.CONSUME.OVERDRAFT`.
+- [ ] `POST /api/pricing/promo/redeem` (`SettingsManage`) validates code (active/expiry/cap/
+      applicability/already-redeemed); invalid → 422 reason; member → 403; valid records redemption +
+      (fixed) grants credit.
+- [ ] Trial start creates `TenantTrial` + delegates `IPlanAssignmentService.AssignAsync` (trial
+      flag); one active trial per tenant; expiry emits `TENANT.TRIAL.ENDED` and converts or
+      downgrades to free via the boundary task.
+- [ ] `ICreditAwarePricingEngine` returns `net = max(0, sell − promo − credits)` with
+      `creditsApplied`; trial zeroes the recurring charge (`trialWaived`); deterministic (golden file).
+- [ ] Admin grants credits `POST /api/admin/tenants/{id}/credits` (`PlatformOwnerAccess`); all
+      mutations emit `CREDIT.GRANTED` / `CREDIT.CONSUMED` / `CREDIT.REFUNDED` / `PROMO.REDEEMED` /
+      `TENANT.TRIAL.STARTED` / `TENANT.TRIAL.ENDED` DCB events + platform mirror.
+- [ ] Per-mode + per-tenant ownership honored (single-user sole user; SaaS owner/admin/member with
+      member read-only; cross-tenant 404/403; tenant isolation).
+- [ ] Unit + integration tests: ledger never negative (incl. concurrent), promo validation matrix +
+      cap under concurrency, trial convert vs expire, credit-aware net price, RBAC + tenant
+      isolation, DCB emission — all green via `sg docker -c "dotnet test …"`.

--- a/docs/superpowers/plans/2026-06-17-34-8-pricing-audit-events-and-reproducibility-plan.md
+++ b/docs/superpowers/plans/2026-06-17-34-8-pricing-audit-events-and-reproducibility-plan.md
@@ -1,0 +1,353 @@
+# Story 34-8 — Pricing Audit, Events & Reproducibility (implementation plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes its
+> tests before implementation. Story: `docs/stories/epic-34/story-34-8/34-8-pricing-audit-events-and-reproducibility.md`.
+
+**Goal:** Make every Epic 34 pricing decision auditable and time-travel-reproducible through the
+DCB event stream. Ship (a) the canonical pricing event taxonomy as code constants
+(`PLAN.*`, `TENANT.PLAN.*`, `PRICING.MARGIN.*`, `CREDIT.*`, `PROMO.*`, `BYOK.*`), (b) a single
+`PricingEventEmitter` write-seam that 34-1..34-7 route through, emitting events **transactionally
+with the state change** and routing tenant vs control-plane planes exactly like `AlertEventEmitter`,
+(c) a reconstruction API that replays the streams into "what plan/price/entitlements/BYOK applied
+to tenant X at time T", (d) a deterministic price-replay that re-runs `IUsagePricingEngine` against
+the margin policy effective at a historical usage event, and (e) an admin config-audit dashboard
+feed with actor + diff.
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (Tamma.Api minimal-API +
+Tamma.Data EF + Tamma.Core), React/Vite dashboard in `packages/dashboard` (Vitest). C# tests live
+in `apps/tamma-elsa/tests/Tamma.Api.Tests/` (xUnit; docker-bound suites run via
+`sg docker -c "dotnet test ..."`). Build needs no docker wrapper.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO new event type of this story's own.** 34-8 is the consistency layer; it names + emits +
+  reconstructs the producers' events. It does not invent a `PRICING.AUDIT.*` event.
+- **NO new table / EF migration.** Reconstruction replays the existing `domain_events`
+  (tenant) and `platform_events` (control-plane) stores. A derived snapshot table would be a second
+  source of truth to keep consistent — rejected. `has-pending-model-changes` must report none.
+- **NO money movement.** Re-deriving a priced amount for *audit* is in scope; charging, invoices,
+  Stripe are Epic 35. Replay calls the pure `IUsagePricingEngine`, never a billing API.
+- **NO re-implementation of the markup engine, plan catalog, credit/promo/BYOK semantics.** Those
+  are owned by 34-5 / 34-1 / 34-6 / 34-7 / 34-3 respectively (34-5 carries the CANONICAL-owner
+  boundary note for markup). This story *consumes* `IUsagePricingEngine`, `IPlanCatalogService`,
+  `MarginPolicy`, and the producers' domain data.
+- **NO alert rules for pricing events.** Consistent emission makes a future `PRICING.MARGIN.UPDATED`
+  alert rule trivial, but wiring it is out of scope (Story 5.6 / a later story).
+- **NO mutation of resolution/pricing semantics.** Replay must reproduce the original number; it
+  must never "fix" or re-price with current policy.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### Event stores + dual-plane routing (the pattern to copy)
+
+- `apps/tamma-elsa/src/Tamma.Data/Entities/DomainEvent.cs` — tenant-scope event row:
+  `Id, Type, TenantId?, IssueNumber?, Tags(jsonb), Metadata(jsonb), Data(jsonb), CreatedAt,
+  SequenceNumber(BIGSERIAL)`.
+- `apps/tamma-elsa/src/Tamma.Data/Entities/PlatformEvent.cs` — control-plane event row, same column
+  shape minus `IssueNumber`, plus `UserId?`. Doc 01 §5.1–5.2: cross-tenant / catalog-global events
+  (`TENANT.*`, etc.) write here.
+- `apps/tamma-elsa/src/Tamma.Data/Repositories/EventRepository.cs` —
+  `AppendAsync` routes a null-tenant event to `IPlatformEventRepository`; a tenant event to the
+  per-tenant `DbContext` via `ITenantDbContextFactory.CreateAsync(tid)` then `SaveChangesAsync`
+  (lines ~49–87). `QueryWithPaginationAsync` (tenant-scoped, paginated, exact type, ordered by
+  `CreatedAt` then `SequenceNumber`, lines ~176–209) is the reconstruction read seam.
+- `apps/tamma-elsa/src/Tamma.Data/Repositories/PlatformEventRepository.cs` /
+  `IPlatformEventRepository.cs` — control-plane query (`QueryAsync(typePrefix, limit)`).
+- `apps/tamma-elsa/src/Tamma.Data/Abstractions/IPlatformEventPublisher.cs` +
+  `Tamma.Api/Services/PlatformEvents/PlatformEventPublisher.cs` — append+publish; **returns null on
+  the partial-unique dedup no-op** (idempotent retry — treat null as "already recorded").
+- **Reference emitter — `apps/tamma-elsa/src/Tamma.Api/Services/Alerts/AlertEventEmitter.cs`:**
+  tenant-scope events → `IEventRepository.AppendAsync(new DomainEvent{...})`; platform-scope →
+  `IPlatformEventPublisher.AppendAndPublishAsync(new PlatformEvent{...}, ct)`; **every `lastError` /
+  `finalError` string runs through `CredentialRedactor.Clean` before serialisation** (lines ~96,
+  135, 211); `Tags`/`Data` serialised with `JsonSerializerOptions{WriteIndented=false}`;
+  `Metadata = {"eventSource":"system","workflowVersion":"1.0.0"}`. **Difference to flag:**
+  `AlertEventEmitter` is fire-and-forget (`try/catch → LogWarning`, never throws) — 34-8's emitter
+  must be the opposite (a failed append must roll back the producer's state change).
+
+### Redaction (reuse, do not reinvent)
+
+- `apps/tamma-elsa/src/Tamma.Core/Redaction/CredentialRedactor.cs` — `Clean(string?)` scrubs Bearer
+  tokens, `key=value` credential assignments, URL basic-auth, and known secret prefixes
+  (`tamma_sk_`, `sk_live_`, `sk_test_`, `ghp_`, `github_pat_`, `xoxb-`, …), strips control chars,
+  caps at 1024 chars. The redaction test for BYOK refs asserts none of these prefixes survive.
+
+### Authorization policies (Program.cs, verified)
+
+- `apps/tamma-elsa/src/Tamma.Api/Program.cs` defines policies (~966–1082):
+  `OwnerAccess` (~971), **`PlatformOwnerAccess` (~986)** — platform-admin gate used by all
+  `/api/admin/*` admin CRUD, `MemberAccess` (~991). Admin group: `app.MapGroup("/api/admin")`
+  (~1244). Admin endpoint exemplar:
+  `apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminTenantDatabasesEndpoints.cs` (static
+  minimal-API handlers, `[FromServices]` DI, DTOs in `Tamma.Api/Dtos/Admin`).
+
+### Dependency-story artifacts this story references (created by 34-1/34-4/34-5)
+
+- **34-1** (`docs/stories/epic-34/story-34-1/...`): `Plan` gains `Version`, `Status`,
+  `IsCustom`, `BillingInterval`, `SupersedesPlanId`; new `IPlanCatalogService` (in
+  `Tamma.Api/Services/Pricing/` — **directory created by 34-1**) with `GetByIdAsync(planId)`,
+  `GetForTenantAsync(tenantId)`, returning an immutable `PlanSnapshot`; producers emit
+  `PLAN.VERSION.CREATED` / `PLAN.DEPRECATED` to `platform_events`. `EntitlementMetricKey` enum in
+  `Tamma.Core/Enums`.
+- **34-4** (`story-34-4/...`): `TenantPlanAssignment` entity (TenantId, PlanId+Version, Status,
+  EffectiveFrom/To); `IPlanAssignmentService.AssignAsync`; emits `TENANT.PLAN.CHANGED`; adds
+  `PricingEndpoints.cs` (the `/orgs/{id}` tenant group + `/api/pricing/*`).
+- **34-5** (`story-34-5/...`): `IUsagePricingEngine.PriceUsage(usageLine) →
+  {costBasisUsd, marginUsd, sellPriceUsd, pricingMode}` (pure/deterministic); `MarginPolicy`
+  entity (Scope plan|provider|global, RefKey, MarkupMultiplier/FixedUsdPer1M, EffectiveFrom);
+  `AdminPricingEndpoints.cs` (**the `/api/admin/pricing` group this story extends**); emits
+  `PRICING.MARGIN.UPDATED`. Cost basis from existing
+  `apps/tamma-elsa/src/Tamma.Api/Services/Providers/IProviderPricingService.cs`
+  (`Compute(provider, model, inputTokens, outputTokens)`).
+- Usage line source: `apps/tamma-elsa/src/Tamma.Data/Entities/ProviderDiagnostic.cs` — carries
+  `ProviderKey, Model, InputTokens, OutputTokens, Cost, TenantId?, CorrelationId?, CreatedAt`
+  (34-3 enriches with BillingMode). `Tenant.Plan` is today a **string** (`free`) — 34-4 introduces
+  the `PlanId`/assignment as source of truth, which this story's reconstruction relies on.
+
+### Dashboard surface
+
+- `packages/dashboard/src/pages/admin/AdminLayout.tsx` — `AdminTab` union (~17:
+  `'users'|'api-keys'|'health'|'links'|'audit-log'|'tenants'`) + `TABS` array (~24); tabs render by
+  `activeTab` switch (~82). Service clients in `packages/dashboard/src/services/admin/`
+  (`admin-tenants-client.ts` is the closest pattern). `AuditLogTab.tsx` is the closest existing
+  tab to mirror for a time-ordered list.
+
+### Gotcha worth pinning
+
+- `EventRepository.AppendAsync` opens **its own** per-tenant `DbContext` + `SaveChangesAsync`. For
+  the transactional invariant (AC 4) the emitter must instead enlist in the **producer's** open
+  `DbContext` for the common producer path; `IEventRepository.AppendAsync` is the standalone
+  fallback only (e.g. Elsa activities with no ambient producer transaction).
+
+---
+
+## Architecture
+
+**taxonomy (constants) → emitter (one seam, transactional, dual-plane, redacted) → reconstruction
+(replay streams) → replay (pure engine + historical policy) → surfaces (admin endpoints + tenant
+endpoint + dashboard tab).** No new table; reuse `domain_events` + `platform_events`.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Full audit incl. margin internals | sole user (= platform owner) | `PlatformOwnerAccess` only |
+| Tenant audit (no margin) | sole user | tenant_owner/admin/member for own tenant (`/orgs/{id}/pricing/audit`) |
+| Tenant-scope event store | sole user's tenant `domain_events` | per-tenant `domain_events` (isolation plane) |
+| Catalog/margin event store | control-plane `platform_events` | same — global |
+| Mode source | `ITammaModeProvider` | same |
+
+---
+
+## Task breakdown (test-first)
+
+### Task 1 — Canonical taxonomy + tag contract (`PricingEventTypes`, `PricingEventTags`)
+
+**Files:**
+- New `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricingEventTypes.cs` — `const string` per
+  event (see story event-catalog table).
+- New `apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricingEventTags.cs` — `PricingEventTagSet`
+  record, `EventPlane` enum, `PlaneFor(eventType)`, `RequiredFor(eventType)`,
+  `PricingEventTagValidator.Validate(eventType, tagSet) → IReadOnlyList<string>` (missing keys).
+
+**Tests first** (`tests/Tamma.Api.Tests/Pricing/PricingEventTagValidatorTests.cs`):
+- each event type's required-tag list; missing-key detection; catalog-global events don't require
+  `tenantId`; `PlaneFor` returns ControlPlane for `PLAN.*`/`PRICING.MARGIN.*`, Tenant otherwise.
+
+**Approach:** pure static — no DI, no DB. Fast unit suite, no docker.
+
+### Task 2 — `PricingEventEmitter` (single write seam, transactional, redacted)
+
+**Files:**
+- New `IPricingEventEmitter.cs` (`EmitAsync(eventType, tags, data, producerContext, ct)`).
+- New `PricingEventEmitter.cs` — mirror `AlertEventEmitter` for serialisation + redaction
+  (`CredentialRedactor.Clean` on every string `data` value; `Metadata` constant; `JsonOpts`),
+  but enlist in the producer's `DbContext`: route by `PlaneFor` → add `DomainEvent` (tenant) or
+  `PlatformEvent` (control-plane) to `producerContext`; provide a standalone fallback using
+  `IEventRepository` / `IPlatformEventPublisher` when `producerContext` is null. **Do not catch +
+  swallow** — let an append failure propagate so the producer's transaction rolls back.
+
+**Tests first** (`tests/Tamma.Api.Tests/Pricing/PricingEventEmitterTests.cs`):
+- plane routing per event type (mock repos / in-memory `DbContext`); redaction ran on every string
+  `data` value; BYOK ref opaque (no secret prefix survives); validator wired (missing tag →
+  Debug.Assert in DEBUG); standalone fallback path when `producerContext` null.
+
+**Approach:** keep the emitter dependency-light (logger + optional `IEventRepository` +
+`IPlatformEventPublisher` for the fallback). The producer-context overload is the primary path.
+
+### Task 3 — Transactional invariant (atomicity) integration test + producer pattern doc
+
+**Files:**
+- New `tests/Tamma.Api.Tests/Pricing/PricingAuditTransactionTests.cs` (docker-bound).
+- Doc the canonical producer pattern in the story Dev Notes (already written) + a short XML-doc on
+  `IPricingEventEmitter.EmitAsync` so 34-1..34-7 adopt: `db.Add(entity);
+  await emitter.EmitAsync(..., db, ct); await db.SaveChangesAsync(ct);`.
+
+**Tests first:** drive a producer-style write that adds an entity + calls `EmitAsync` against a real
+`DbContext`; force a failure before commit → assert NEITHER row NOR event; happy path → assert
+BOTH. Run `sg docker -c "dotnet test --filter PricingAuditTransactionTests ..."`.
+
+**Approach:** this test is the load-bearing guard for AC 4 — write it red first; it drives the
+"enlist in producer transaction" design from Task 2.
+
+### Task 4 — `PricingAuditService.ReconstructAsync` (point-in-time replay)
+
+**Files:**
+- New `IPricingAuditService.cs`, `PricingAuditService.cs`, `PricingAuditSnapshot.cs`.
+
+**Tests first** (`tests/Tamma.Api.Tests/Pricing/PricingAuditReconstructionTests.cs`):
+- synthetic history (assign v1 → upgrade v2 → margin edit → BYOK flip) appended to the stores;
+  `ReconstructAsync(now)` == live (`IPlanCatalogService.GetForTenantAsync` + live margin + live
+  BYOK); `ReconstructAsync(t_before_upgrade)` == v1; empty-history → empty snapshot (no throw).
+
+**Approach:** fold the two streams (tenant via `IEventRepository.QueryWithPaginationAsync`,
+control-plane via `IPlatformEventRepository.QueryAsync`) filtered `CreatedAt <= at`; pick last
+plan-change / BYOK-change; resolve margin by 34-5 scope order; snapshot entitlements via
+`IPlanCatalogService.GetByIdAsync`. Mock `IPlanCatalogService` + repos in unit tests; one
+docker-bound integration test exercises the real stores.
+
+### Task 5 — `PricingAuditService.ReplayUsageAsync` (deterministic re-pricing)
+
+**Files:** extend `PricingAuditService.cs`; `PricingReplayResult` in `PricingAuditDtos.cs`.
+
+**Tests first** (`tests/Tamma.Api.Tests/Pricing/PricingReplayTests.cs`, golden file):
+- synthetic usage line (`ProviderDiagnostic`) + a `MarginPolicy` history; `ReplayUsageAsync`
+  recomputes `sellPriceUsd` byte-stable against a checked-in golden value; a policy edit AFTER the
+  usage timestamp does not change the replayed price; unknown provider/model → surfaces
+  `PricingUnknownModel` (from 34-5), logged WARN.
+
+**Approach:** read the usage line by id; resolve the `MarginPolicy` effective at
+`usageEvent.CreatedAt` (NOT now) via the reconstruction's margin fold; call the pure
+`IUsagePricingEngine.PriceUsage`. Determinism comes from the engine + historical policy — assert,
+don't recompute, in the test.
+
+### Task 6 — Config-audit log query + diff shaping
+
+**Files:** extend `PricingAuditService.QueryLogAsync`; `PricingAuditLogRow` in `PricingAuditDtos.cs`.
+
+**Tests first:** newest-first ordering; `domain` filter (plan/margin/credit/promo/byok derived from
+event type prefix); `diff` carries old→new from event `data`; pagination (`limit`/`offset`/`total`).
+
+**Approach:** union tenant + control-plane pricing events in the requested window, map to rows,
+derive `domain` from the event type, derive `diff` from the producer's `data` (producers should
+include `before`/`after` keys — note this in the producer-pattern doc).
+
+### Task 7 — Admin + tenant endpoints
+
+**Files:**
+- Modify `apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminPricingEndpoints.cs` (created by 34-5):
+  add `GetAudit`, `ReplayUsage`, `GetAuditLog` handlers under `/api/admin/pricing/audit*`
+  (`PlatformOwnerAccess`).
+- Modify `apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs` (created by 34-4): add
+  `GET /api/v1/orgs/{tenantId}/pricing/audit` (`MemberAccess`, scoped to caller tenant, margin
+  fields stripped).
+- Modify `Program.cs` to map the routes (mirror existing admin route registration ~1244+).
+- Modify `Tamma.Api/Extensions/PricingServiceCollectionExtensions.cs` (created by 34-1): register
+  `IPricingEventEmitter` + `IPricingAuditService`.
+
+**Tests first** (`tests/Tamma.Api.Tests/Pricing/AdminPricingAuditEndpointsTests.cs` +
+`PricingAuditIsolationTests.cs`):
+- RBAC matrix (owner 200 / non-owner 403); tenant endpoint allows `member` read but response omits
+  `marginUsd`/`costBasisUsd`/`MarginPolicySnapshot`; cross-tenant (A → B) 403/404; `at` defaults to
+  now; tenant reconstruction reads only the requesting tenant's store.
+
+**Approach:** static minimal-API handlers + DTOs (mirror `AdminTenantDatabasesEndpoints`). The
+tenant projection is a separate `TenantPricingAuditSnapshot` mapping that drops margin fields — pin
+that in the isolation test, not just the UI.
+
+### Task 8 — Dashboard config-audit tab
+
+**Files:**
+- New `packages/dashboard/src/services/admin/pricing-audit-client.ts` (mirror
+  `admin-tenants-client.ts`).
+- New `packages/dashboard/src/pages/admin/PricingAuditTab.tsx` (columns: eventType, actor,
+  occurredAt, domain, diff; filters by tenant/domain/date).
+- Modify `packages/dashboard/src/pages/admin/AdminLayout.tsx` — add `'pricing-audit'` to `AdminTab`
+  + `TABS` + render switch.
+- New `packages/dashboard/src/pages/admin/__tests__/PricingAuditTab.test.tsx`.
+
+**Tests first** (Vitest + Testing Library): renders rows with actor + diff; empty state; filter
+calls client. `pnpm test --filter @tamma/dashboard` green; no new lint errors.
+
+---
+
+## Sequencing & dependencies
+
+```
+Task 1 (taxonomy/tags) ─┬─→ Task 2 (emitter) ─→ Task 3 (atomicity test)
+                        │
+                        └─→ Task 4 (reconstruct) ─→ Task 5 (replay) ─→ Task 6 (log)
+                                                                          │
+                                          Tasks 2/4/5/6 ─→ Task 7 (endpoints) ─→ Task 8 (dashboard)
+```
+
+- **Hard prerequisites (must be merged first):** Story 34-1 (creates the `Services/Pricing/`
+  directory, `IPlanCatalogService`, `EntitlementMetricKey`), 34-4 (`PricingEndpoints`,
+  `TenantPlanAssignment`, `GetForTenantAsync`), 34-5 (`AdminPricingEndpoints`,
+  `IUsagePricingEngine`, `MarginPolicy`). Epic 4 DCB stores already exist.
+- **Soft prerequisites (graceful-degradation if absent):** 34-3 (BYOK mode), 34-6 (credits),
+  34-7 (promos) — their events are folded when present; reconstruction omits the dimension when not.
+- Task 1 has no dependency and can start immediately. Task 3 (atomicity) gates the merge — it is the
+  invariant the whole story exists to guarantee. Task 8 is independent of the C# tasks once the
+  endpoints (Task 7) exist or are stubbed in the client.
+
+---
+
+## Risks + mitigations
+
+- **A producer emits an event NOT through the emitter (string literal / own transaction) → audit
+  gap.** *Mitigation:* `PricingEventTypes` constants + a grep-guard test that fails if a pricing
+  event string literal appears outside `PricingEventTypes.cs`; document the canonical producer
+  pattern in each producer story's Dev Notes; the atomicity test (Task 3) proves the pattern.
+- **Emitter opening its own transaction defeats atomicity.** *Mitigation:* emitter enlists in the
+  producer's `DbContext`; Task 3 integration test is the guard (write it red first).
+- **Reconstruction drifts from live state as new dimensions are added.** *Mitigation:* the
+  point-in-time-==-live test (Task 4) compares against `IPlanCatalogService.GetForTenantAsync`, so
+  any new live dimension that isn't reconstructed fails the test.
+- **BYOK key leaks into an event `data` field.** *Severity: critical.* *Mitigation:* opaque-ref-only
+  contract + `CredentialRedactor.Clean` on every string + a redaction test asserting no secret
+  prefix survives.
+- **Replay reaches for the current policy instead of the historical one → wrong audit number.**
+  *Mitigation:* `ReplayUsageAsync` resolves the policy at `usageEvent.CreatedAt`; the
+  "policy edited after usage doesn't change replay" test (Task 5) pins it.
+- **Event-store topology shift (Story 28-1 / Epic 30 moves tenant events fully per-tenant).**
+  *Mitigation:* tenant reads go through `IEventRepository` (already per-tenant-abstracted);
+  catalog/margin reads pinned to `IPlatformEventRepository` so the shift only touches tenant
+  routing.
+- **`Tenant.Plan` is still a string today.** *Mitigation:* reconstruction relies on 34-4's
+  `TenantPlanAssignment` / `PlanId` source-of-truth — 34-4 is a hard prerequisite; do not start
+  Task 4 against the legacy string field.
+- **Migration discipline.** No new table; after wiring run
+  `dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext` and confirm none.
+
+---
+
+## Acceptance criteria (mirrors the story)
+
+- [ ] Canonical taxonomy as `const string`s in `PricingEventTypes.cs` covering `PLAN.*`,
+      `TENANT.PLAN.*`, `PRICING.MARGIN.*`, `CREDIT.*`, `PROMO.*`, `BYOK.MODE.CHANGED`; no producer
+      uses a string literal (grep-guard test green).
+- [ ] Required tag contract (`tenantId`/`planId`/`planVersion`/`actorUserId`/`pricingMode`/`source`)
+      enforced by `PricingEventTagValidator`; missing tag detected in tests.
+- [ ] `PricingEventEmitter` routes tenant events → `DomainEvent` and catalog/margin → `PlatformEvent`
+      (verified per event type), redacts every string `data` value, BYOK ref opaque-only.
+- [ ] Emitted-with-state transactional invariant: forced pre-commit failure leaves NEITHER row NOR
+      event; happy path commits BOTH (docker-bound integration test green).
+- [ ] `GET /api/admin/pricing/audit?tenantId=&at=` reconstructs effective plan version + margin +
+      entitlements + BYOK mode + active credits/promos at T (`PlatformOwnerAccess`).
+- [ ] `GET /api/admin/pricing/audit/replay` re-prices a historical usage line against the policy
+      effective then; recomputed `sellPriceUsd` byte-stable vs golden (regression test green).
+- [ ] Point-in-time reconstruction == live state for the synthetic history fixture.
+- [ ] Config-audit log feed (`/api/admin/pricing/audit/log`) + `PricingAuditTab` render
+      plan/margin/credit/promo/byok changes with actor + diff.
+- [ ] Tenant-scoped audit (`/api/v1/orgs/{id}/pricing/audit`) returns the tenant's own history with
+      margin/cost-basis stripped; cross-tenant request 403/404; reads only the tenant's store.
+- [ ] Per-mode RBAC matrix (owner / tenant_owner / member / cross-tenant) covered by tests.
+- [ ] Full C# suite + `pnpm test --filter @tamma/dashboard` green; `has-pending-model-changes`
+      reports none.

--- a/docs/superpowers/plans/2026-06-17-34-9-pricing-and-plan-management-dashboards-plan.md
+++ b/docs/superpowers/plans/2026-06-17-34-9-pricing-and-plan-management-dashboards-plan.md
@@ -1,0 +1,302 @@
+# Story 34-9 — Pricing & Plan Management Dashboards (implementation plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation. Frontend stack is React + Vite + Vitest + Testing Library.
+
+**Epic:** 34 — Pricing, Plans & Entitlements · **Story:** 34-9 · **Priority:** P1 · **Est:** 5-6 days
+**Story file:** `docs/stories/epic-34/story-34-9/34-9-pricing-and-plan-management-dashboards.md`
+
+---
+
+## Goal
+
+Ship the two UI surfaces that make Epic 34 operable by humans: (a) an **admin price-book manager**
+in `packages/dashboard` (platform owners author plans/features/entitlements/margins/promos/credits
+and mint+assign custom enterprise plans) and (b) a **tenant Plan & Pricing page** in
+`packages/dashboard-user` (current plan, entitlement-vs-usage headroom bars, per-provider BYOK/
+platform toggle, credit balance, cost-estimate widget, upgrade flow with entitlement-delta preview,
+trial countdown, promo redeem). Reuse the read APIs from 34-2/34-5/34-6/34-7 and the BYOK mode
+endpoint from 34-3.
+
+## Non-goals (YAGNI guard)
+
+- **NO new pricing business logic.** Margin math (34-5), entitlement/headroom resolution (34-6),
+  credit netting / trial state (34-7), plan immutability/versioning (34-1) all stay server-side.
+  The UI calls those endpoints and renders their numbers verbatim. The ONLY UI-side compute is the
+  upgrade entitlement-delta preview, which is a pure set-diff over server-resolved entitlement lists
+  + the server `CheckHeadroom` output — not a price calculation.
+- **NO EF migrations.** All schema lands in 34-1..34-7. If a consumed read genuinely doesn't exist,
+  add a thin read-only projection endpoint (additive, no migration) — and only then.
+- **NO new backend services / DCB-event emission from the UI.** The UI triggers endpoints that emit
+  events; it asserts (in tests) the right call was made, never appends events itself.
+- **NO new npm dependencies.** React Router, Vitest, Testing Library are already wired in both packages.
+- **NO billing/charging UI.** Money movement is Epic 35; this is plan/entitlement/estimate presentation.
+- **NO alert-channel UI, NO admin SSE.** Out of scope.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### Dependency endpoints DO NOT exist yet (this story is correctly sequenced last in Epic 34)
+
+```
+$ ls apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs            → No such file
+$ ls apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminPricingEndpoints.cs → No such file
+$ ls apps/tamma-elsa/src/Tamma.Api/Services/Pricing/                        → No such directory
+```
+
+`Tamma.Data/Entities/` today has `Plan.cs` (the thin opaque-`Quotas` skeleton 34-1 replaces),
+`ProviderDiagnostic.cs`, `SecretRow.cs`/`SecretVersionRow.cs`, `TenantMembership.cs`, `Tenant.cs`,
+`GitHubInstallationRepo.cs` — but NO `PlanEntitlement`/`PlanPrice`/`MarginPolicy`/`TenantTrial`/
+`CreditLedger`/`PromoCode`/`TenantPlanAssignment`/`TenantProviderBilling`. Those are created by
+34-1..34-7. **Hard gate: do not start 34-9 until 34-2/3/4/5/6/7 are merged.**
+
+### Authorization policies exist and are the contract (verified `Tamma.Api/Program.cs:966-1016`)
+
+- `PlatformOwnerAccess` (line 986) — JWT `platformRole == platform_admin`. Every `/api/admin/*`
+  platform-scoped route uses this. → admin Pricing section.
+- `OwnerAccess` (971) — per-tenant `users:manage`. (Used by `AdminTenantsEndpoints`.)
+- `SettingsManage` (1001) — `settings:manage` (owner/admin). → tenant pricing mutations.
+- `MemberAccess` (991) — any authenticated user. → tenant pricing reads.
+- Prompt-store precedent (1006-1016): "endpoint shape identical between modes; auth middleware
+  decides which key" — 34-9 follows it for single-user vs SaaS.
+
+### Admin dashboard patterns to mirror (`packages/dashboard/src`)
+
+- `pages/admin/AdminLayout.tsx` — `type AdminTab = 'users' | 'tenants' | ...`; `TABS: TabDef[]`;
+  content switch `{activeTab === 'x' && <XTab />}`. **Add `'pricing'` here.** Lazy-loaded by
+  `router.tsx` behind `AdminGuard` + `AuthGuard` (admin dashboard is platform-admin scoped).
+- `services/admin/admin-tenants-client.ts` — the canonical typed client: module-level `fetchJSON<T>`
+  with `credentials: 'include'`, a typed `AdminTenantApiError(status, message, body)`, camelCase wire
+  types (default `System.Text.Json`), a `buildQuery(filters)` helper, and a frozen `adminTenantsApi`
+  object. **Mirror exactly** for `admin-pricing-client.ts`. Reuse `adminTenantsApi.updatePlan(tenantId, planId)`
+  (lines 170-177) for assignment — do NOT add a duplicate.
+- `services/secrets/secrets-api-client.ts` — the write-only secret pattern: `CreateSecretBody.plaintext`
+  is POSTed; responses carry metadata + a reveal token, never the plaintext. **Mirror** for the BYOK key.
+- Tests: colocated `__tests__/*.test.tsx`; `src/test/` has `setup.ts`, `render-helpers.tsx`, `fixtures.ts`.
+  `pages/admin/__tests__/AdminLayout.test.tsx` already asserts the tab set — extend it.
+
+### Tenant dashboard patterns to mirror (`packages/dashboard-user/src`)
+
+- `App.tsx` — `<BrowserRouter><AuthProvider><Routes>`; routes nest under
+  `<AuthGuard><AppLayout/></AuthGuard>`; admin-only routes add `<TenantAdminGuard>`. **Add
+  `/settings/billing` under AuthGuard → AppLayout** (page self-gates mutations by role, like
+  `TenantAlertFeed`).
+- `api/client.ts` — `ApiClient` with `get/post/put/delete`, `credentials: 'include'`, single-shot
+  refresh-on-401, `ApiError`/`UnauthorizedError`. **Build `api/pricing.ts` on `apiClient`** (like
+  `api/alerts.ts`).
+- `api/alerts.ts` — tenant client precedent: derives nothing from URL the user controls; has a
+  client-side `hasPlaintextCredential()` pre-flight that rejects secrets in config blobs (lines
+  212-245). **Mirror that pre-flight idea** for the BYOK key field.
+- `pages/alerts/TenantAlertFeed.tsx` — the closest UI analog: reads `tenantId`/`role` from
+  `useAuth()` (lines 34-37), computes `canMutate = role === 'admin' || role === 'owner'`, hides
+  mutate controls for members, surfaces errors via `role="alert"`, uses an inline `Modal`. **Mirror
+  this structure** for `PlanPricingPage.tsx`.
+- `hooks/useAuth.tsx` — `AuthUser { id, email, displayName, tenantId?, role? }` from `/api/auth/me`.
+  `tenantId`/`role` reflect the server's mode + membership. The page never decides mode itself.
+- `guards/TenantAdminGuard.tsx` — `ADMIN_OR_HIGHER = {'admin','owner'}`; renders a 403-style panel
+  for members rather than redirecting. (Used for routes that are entirely admin; the billing page is
+  member-visible read-only, so it self-gates instead of wrapping in this guard.)
+- `layouts/AppLayout.tsx` — sidebar nav `<Link>` list (Dashboard/Repositories/Runs/Settings). **Add
+  a "Billing" link.**
+- Tests: colocated `*.test.tsx`; `src/test/` setup; `useAuth` stubbed per test for the mode/role matrix.
+
+### Mode seam
+
+`useAuth()` → `/api/auth/me` is the UI's single source of mode + identity. Single-user: sole user,
+no role gating. SaaS: `tenantId` + `role` populated; `member` read-only. The server
+(`ITammaModeProvider` + `RequireTenantMembership` filter + the policies above) is authoritative; the
+UI gate is UX-only.
+
+---
+
+## Phased task breakdown (test-first)
+
+### Phase 0 — Preflight gate (no code)
+
+- [ ] **0.1** Verify 34-2/34-3/34-4/34-5/34-6/34-7 are merged: confirm
+      `Tamma.Api/Endpoints/PricingEndpoints.cs` + `Endpoints/Admin/AdminPricingEndpoints.cs` exist
+      and enumerate their real route paths + DTO shapes (the clients below must match the actual
+      wire shapes, not this plan's sketch). Capture any path/shape deltas as the single edit point.
+- [ ] **0.2** Run `pnpm test --filter @tamma/dashboard` and `--filter @tamma/dashboard-user` to
+      confirm a green baseline before touching anything.
+
+### Phase 1 — Admin typed client (`packages/dashboard`)
+
+- [ ] **1.1 (test first)** `services/admin/admin-pricing-client.test.ts` — assert URL/method/body
+      for `listPlans` (incl. `includeDeprecated`/`includeCustom` query), `getPlan`,
+      `createPlanVersion`, `updatePlanVersion`, `deprecatePlan` (parses 409 `{affectedTenants,
+      requiresForce}`), `mintCustomPlan`, `listMargins`/`upsertMargin`, `listPromos`/`createPromo`,
+      `grantCredits`; non-2xx throws the typed error. Mock `fetch`.
+- [ ] **1.2** Implement `services/admin/admin-pricing-client.ts` mirroring `admin-tenants-client.ts`
+      (`fetchJSON<T>`, `AdminPricingApiError`, camelCase wire types: `PlanSnapshot`, `PlanFeatureDto`,
+      `PlanEntitlementDto` keyed by `EntitlementMetricKey`, `PlanPriceDto`, `MarginPolicyDto`,
+      `PromoCodeDto`, `CreditLedgerEntryDto`, `DeprecateResult`). Reuse `adminTenantsApi.updatePlan`
+      for assignment (import it; do NOT re-declare).
+- [ ] **1.3** Verify green: `pnpm test --filter @tamma/dashboard -- admin-pricing-client`.
+
+### Phase 2 — Admin Pricing tab + sub-panels (`packages/dashboard`)
+
+- [ ] **2.1 (test first)** `pages/admin/pricing/__tests__/PlanVersionEditor.test.tsx` — edit
+      feature/entitlement/price rows → save calls create/update; saving an active version surfaces
+      the "new version created + prior deprecated" result and re-renders the supersede chain;
+      deprecate-with-assignments shows the 409 affected count + a "Deprecate anyway (force)" confirm
+      that re-calls with `force=true`.
+- [ ] **2.2** Implement `PlanVersionEditor.tsx` (entitlement keys constrained to the
+      `EntitlementMetricKey` union; immutable-active-version UX; force-deprecate confirm).
+- [ ] **2.3 (test first)** `MarginPolicyPanel.test.tsx` — list renders; save validates "at least one
+      of MarkupMultiplier / FixedUsdPer1M"; calls `upsertMargin`; surfaces `PRICING.MARGIN.UPDATED`
+      success.
+- [ ] **2.4** Implement `MarginPolicyPanel.tsx` (scope plan|provider|global, RefKey, multiplier/fixed,
+      EffectiveFrom).
+- [ ] **2.5 (test first)** `PromoCreditPanel.test.tsx` — promo create validates
+      DiscountKind/MaxRedemptions/Expiry client-side; credit grant shows new balance.
+- [ ] **2.6** Implement `PromoCreditPanel.tsx`.
+- [ ] **2.7 (test first)** `CustomPlanPanel.test.tsx` — mint `IsCustom` plan bound to tenant; assign
+      via `adminTenantsApi.updatePlan`; custom plans excluded from public-catalog view; public-surface
+      attempt shows the server 400 inline.
+- [ ] **2.8** Implement `CustomPlanPanel.tsx`.
+- [ ] **2.9 (test first)** `PricingTab.test.tsx` — sub-tab switching (Plans | Margins | Promos &
+      Credits | Custom Plans); each sub-panel mounts.
+- [ ] **2.10** Implement `PricingTab.tsx` (sub-tab shell composing the four panels).
+- [ ] **2.11** Modify `pages/admin/AdminLayout.tsx`: add `'pricing'` to `AdminTab`, a `TABS` entry
+      `{ id: 'pricing', label: 'Pricing' }`, and `{activeTab === 'pricing' && <PricingTab />}`.
+      Extend `pages/admin/__tests__/AdminLayout.test.tsx` to assert the tab exists + renders.
+- [ ] **2.12** Verify green: `pnpm test --filter @tamma/dashboard`.
+
+### Phase 3 — Tenant typed client (`packages/dashboard-user`)
+
+- [ ] **3.1 (test first)** `api/pricing.test.ts` — URL/method/body for `getEntitlements`,
+      `getCurrentPlan`, `listPublicPlans`, `estimate` (query-string assembly), `subscribe`,
+      `redeemPromo`, `setProviderMode` (PUT body carries `plaintextKey` only on enable; response
+      type has NO key field); refresh-on-401 inherited from `ApiClient`; BYOK pre-flight rejects a
+      key in a non-key field.
+- [ ] **3.2** Implement `api/pricing.ts` on `apiClient` (types: `ResolvedEntitlement` with
+      null=unlimited + `currentUsage`/`remaining`/`over` from `CheckHeadroom`; `CurrentPlanResponse`
+      incl. `providerModes[]` with `hasSecretRef` boolean + `trial` + `creditBalanceUsd`;
+      `EstimateResponse`; `PricingMode`). `plaintextKey` is request-only and never in any response type.
+- [ ] **3.3** Verify green: `pnpm test --filter @tamma/dashboard-user -- pricing`.
+
+### Phase 4 — Tenant widgets (`packages/dashboard-user/src/components/pricing/`)
+
+- [ ] **4.1 (test first)** `EntitlementBar.test.tsx` — bar from `remaining`/`over`; over-limit
+      styling; `limit === null` → "Unlimited", no bar.
+- [ ] **4.2** Implement `EntitlementBar.tsx`.
+- [ ] **4.3 (test first, CRITICAL)** `ByokModePanel.test.tsx` — enable BYOK posts the key once; the
+      plaintext key NEVER appears in rendered DOM after submit, NEVER in any response fixture, NEVER
+      in `console` (spy on `console.*`); post-enable shows only a `hasSecretRef` badge; member role
+      renders mode read-only (no toggle); a 403 on mutate surfaces cleanly.
+- [ ] **4.4** Implement `ByokModePanel.tsx` (key field in local state, cleared on submit, excluded
+      from all logging/error context; client-side pre-flight from `api/pricing.ts`).
+- [ ] **4.5 (test first)** `CostEstimateWidget.test.tsx` — renders cost/margin/sell/credits/mode;
+      BYOK → zero token markup; unknown model → `PricingUnknownModel` inline (never 0).
+- [ ] **4.6** Implement `CostEstimateWidget.tsx`.
+- [ ] **4.7 (test first)** `UpgradePlanModal.test.tsx` — entitlement delta preview shows gains AND
+      losses vs current resolved set; downgrade that exceeds a new limit flagged; commit calls
+      `subscribe`; the server's flagged-violation list surfaces as a non-blocking warning.
+- [ ] **4.8** Implement `UpgradePlanModal.tsx` (pure set-diff over resolved entitlement lists; no
+      price math).
+- [ ] **4.9 (test first)** `TrialBanner.test.tsx` + `PromoRedeemForm.test.tsx` — countdown from
+      `EndsAt`; 422 promo reason surfaced; member read-only.
+- [ ] **4.10** Implement `TrialBanner.tsx` + `PromoRedeemForm.tsx`.
+- [ ] **4.11** Verify green: `pnpm test --filter @tamma/dashboard-user -- components/pricing`.
+
+### Phase 5 — Tenant page + routing (`packages/dashboard-user`)
+
+- [ ] **5.1 (test first)** `pages/settings/PlanPricingPage.test.tsx` — current plan + version render;
+      entitlement bars render; unlimited path; empty trial/credits/custom-plan states; **per-mode
+      matrix**: single-user (all controls, no gating) vs SaaS owner/admin (controls) vs SaaS member
+      (read-only, stubbed 403 surfaces cleanly); `tenantId`/`role` sourced only from `useAuth()`.
+- [ ] **5.2** Implement `PlanPricingPage.tsx` composing the widgets; `canMutate = isSingleUser ||
+      role ∈ {owner, admin}`; loading/error/empty states like `TenantAlertFeed`.
+- [ ] **5.3** Modify `App.tsx`: add `/settings/billing` route under `AuthGuard → AppLayout` (page
+      self-gates; not wrapped in `TenantAdminGuard` since members get a read-only view). Modify
+      `layouts/AppLayout.tsx`: add a "Billing" sidebar `<Link to="/settings/billing">`.
+- [ ] **5.4** Verify green: `pnpm test --filter @tamma/dashboard-user`.
+
+### Phase 6 — Cross-cutting RBAC / isolation hardening + (only-if-needed) backend reads
+
+- [ ] **6.1** Add the negative RBAC tests called out in the story (member can't mutate in either
+      dashboard; non-platform-owner can't see the admin Pricing tab; cross-tenant id never derived
+      from a URL param). Confirm the BYOK key-leak test asserts absence across DOM + response
+      fixtures + console.
+- [ ] **6.2 (escape hatch, only if Phase 0.1 found a missing consumed read)** add a thin read-only
+      projection endpoint in `PricingEndpoints.cs` (tenant, `MemberAccess`) or
+      `AdminPricingEndpoints.cs` (`PlatformOwnerAccess`) over existing entities via
+      `ControlPlaneDbContext`. Additive — run `dotnet ef migrations has-pending-model-changes` and
+      confirm **none**. Write xUnit endpoint tests in `tests/Tamma.Api.Tests/`. **Skip entirely if
+      all reads already exist.**
+- [ ] **6.3** Full verification: `pnpm test --filter @tamma/dashboard --filter @tamma/dashboard-user`,
+      `pnpm lint`, `pnpm build`; if 6.2 touched C#, `sg docker -c "dotnet test ..."` for the new
+      endpoint tests. No success claim without green output (superpowers:verification-before-completion).
+
+---
+
+## Sequencing & dependencies
+
+```
+Phase 0 (gate) ─► Phase 1 (admin client) ─► Phase 2 (admin UI)
+            └────► Phase 3 (tenant client) ─► Phase 4 (tenant widgets) ─► Phase 5 (tenant page/route)
+                                                                                 └► Phase 6 (RBAC + optional backend)
+```
+
+- Phase 0 is a HARD gate on 34-2/3/4/5/6/7 being merged.
+- Phases 1-2 (admin) and 3-5 (tenant) are independent and can be parallelized across two agents
+  after Phase 0 (superpowers:dispatching-parallel-agents) — they share no files.
+- Phase 6 runs last (needs both UIs to exist for the cross-cutting tests).
+
+**External deps:** React/Vite/Vitest/Testing Library (present); no new npm packages.
+**Internal deps:** 34-2 (plan catalog + custom plans), 34-3 (BYOK mode + secret cabinet),
+34-4 (assignment + subscribe), 34-5 (margins + estimate, canonical markup owner), 34-6 (entitlements
++ headroom), 34-7 (trials/credits/promo). Transitively 34-1 (data model + `EntitlementMetricKey`).
+
+---
+
+## Risks + mitigations
+
+- **Dependency endpoints not merged / wire-shape drift (High).** Phase 0 hard-gates and enumerates
+  the real routes/DTOs; the typed clients (`admin-pricing-client.ts`, `api/pricing.ts`) are the
+  single adjustment point if a path/field differs from this plan's sketch. Do an integration smoke
+  test against a running API before UI sign-off.
+- **BYOK key leak (Critical).** Write-only field cleared on submit; the response type has no key
+  field; a dedicated leak test (Phase 4.3) asserts absence in DOM + response fixtures + console; the
+  key is excluded from all logging and error-context objects; the server's reveal-once cabinet (34-3)
+  is authoritative.
+- **UI re-implements pricing/headroom math (High).** Non-goal + AC-13 forbid it; render server
+  numbers verbatim; the only UI compute is the upgrade set-diff (no prices). Code-review checklist item.
+- **Member reaches a mutation (High).** Two layers: controls hidden when `!canMutate` AND server 403;
+  both tested (never trust the hidden control alone).
+- **Single-user vs SaaS mis-gating (Medium).** `canMutate` derives from `useAuth()` which reflects
+  the server mode; per-mode test matrix in `PlanPricingPage.test.tsx`.
+- **Deprecate-with-assignments confusion (Medium).** Surface affected-tenant count + explicit
+  force confirm; no silent force.
+- **Accidental backend scope creep (Medium).** Phase 6.2 is an escape hatch only for a genuinely
+  missing read; default is zero backend changes, no migration.
+
+---
+
+## Acceptance criteria (mirror of the story)
+
+- [ ] Admin `packages/dashboard`: a Pricing tab (gated by the existing `AdminGuard`; routes
+      `PlatformOwnerAccess`) with plan-version editor (features/entitlements/prices, immutable-active
+      + supersede chain + 409-force deprecate), margin-policy editor, promo/credit management, and
+      custom-plan minting + assignment (via `adminTenantsApi.updatePlan`); non-owner users never see it.
+- [ ] Tenant `packages/dashboard-user`: a Plan & Pricing page (`/settings/billing`) showing current
+      plan + entitlements with usage-vs-limit bars (via `CheckHeadroom`, unlimited handled),
+      per-provider BYOK/platform toggle (`SettingsManage`), credit balance, and a cost-estimate widget
+      calling `GET /api/pricing/estimate`.
+- [ ] BYOK toggle stores the key via the secret-cabinet-backed 34-3 endpoint and shows mode +
+      `hasSecretRef` without EVER displaying/logging the stored key; member role sees read-only state.
+- [ ] Upgrade flow: tenant picks a public plan → `POST /api/pricing/subscribe`; entitlement deltas
+      (gains/losses, downgrade-over-limit flagged) confirmed before commit using the headroom calc.
+- [ ] Trial/promo affordances: redeem-promo input (`POST /api/pricing/promo/redeem`, 422 reason
+      surfaced) + trial countdown banner driven by 34-7 data.
+- [ ] All pricing UI gated by the same RBAC as the APIs (admin section platform-owner; tenant
+      mutations owner/admin; members read-only) and degrades cleanly in single-user mode (no RBAC,
+      sole user).
+- [ ] Component/E2E tests for: admin plan-edit round-trip, tenant headroom bars, BYOK toggle never
+      leaks key, upgrade delta preview, member read-only enforcement.
+- [ ] No new server pricing logic; no EF migration; `pnpm test`/`lint`/`build` green for both
+      dashboard packages.

--- a/docs/superpowers/plans/2026-06-17-35-1-stripe-integration-foundation-billing-plan-catalog-and-custo-plan.md
+++ b/docs/superpowers/plans/2026-06-17-35-1-stripe-integration-foundation-billing-plan-catalog-and-custo-plan.md
@@ -1,0 +1,322 @@
+# Story 35-1 — Stripe Integration Foundation, Billing Plan Catalog & Customer Mapping (C#)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development for every
+> task — write the failing test first, then the implementation. This story is part of Epic 35
+> (Billing & Payments, C# control plane). Steps use checkbox (`- [ ]`) syntax for tracking.
+> SaaS-only: every Stripe touch-point must no-op in single-user mode.
+
+**Goal:** Introduce the `Stripe.net` SDK into `Tamma.Api`, a mode-aware billing seam
+(`IBillingProvider` → `StripeBillingProvider` / `NullBillingProvider`), a control-plane
+`BillingCustomer` mapping (one per tenant) created in the tenant-create transaction, and a
+`billing_plan_prices` catalog (slug → Stripe Product/Price/Meter ids) populated by an idempotent
+`seed-billing` CLI command. Stripe credentials resolve through the Epic 29 secret cabinet (never raw
+env in prod). All actions audited via DCB events. This is the foundation every other Epic 35 story
+builds on.
+
+**Non-goals (YAGNI guard):**
+- NO subscription lifecycle, checkout, or webhook *ingestion* endpoint (Story 35-2 / later). This
+  story only stores the webhook signing-secret cabinet reference.
+- NO usage metering, token markup, or BYOK suppression (Story 35-3). Only the `BillingMode` flag +
+  default `PlatformProvided` is stored here; the three meters are *created* but never *read*.
+- NO invoicing, dunning, tax computation, billing portal, or credits wallet (later stories).
+- NO tenant-facing billing UI or endpoints. The customer mapping is a side effect of existing
+  tenant-create endpoints; the only operator surface is the `seed-billing` CLI.
+- NO change to tenancy placement — `Plan.Quotas`/`Plan.PlacementPolicy` are untouched; Stripe ids
+  live in a new `billing_plan_prices` table keyed by slug.
+- NO new alert rules (Story 5.6 scope). Events are emitted CP-resident so a future rule can observe
+  them.
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane API). Tests in
+`apps/tamma-elsa/tests/Tamma.Api.Tests/` (xUnit; docker-bound suites run via
+`sg docker -c "dotnet test ..."`, builds need no wrapper). New dep: `Stripe.net`.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### Control-plane data layer
+- `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` — DbSets declared as
+  `public DbSet<X> Xs => Set<X>();` (e.g. `Plans` line 76, `DomainEvents` line 199,
+  `PlatformQueuedTasks` line 78). Add `BillingCustomers` + `BillingPlanPrices` here.
+- `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` — `ConfigureControlPlaneEntities`
+  (line 47) is the *single* place entity mapping lives: `entity.ToTable(...)`, `HasCheckConstraint`
+  (e.g. line 61), `HasIndex(...).IsUnique().HasFilter(...)` (e.g. line 86–88, tenants 298–299).
+  Mirror this exactly for the two new entities.
+- `apps/tamma-elsa/src/Tamma.Data/Entities/Plan.cs` — `Plan.Slug` (`free`/`team`/`enterprise`),
+  `Quotas`/`PlacementPolicy` are **placement** concerns (doc-comment line 39–43). Do NOT add Stripe
+  ids here.
+- `apps/tamma-elsa/src/Tamma.Data/Entities/Tenant.cs` — tenant entity; FK target.
+- `apps/tamma-elsa/src/Tamma.Data/Seeders/PlansSeeder.cs` — idempotent seed pattern: `AnyAsync`
+  short-circuit then `AddRangeAsync` (lines 44–93). `BillingSeeder` follows the same
+  re-run-is-no-op contract but with Stripe upserts.
+- `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/` — existing baseline
+  `20260609205701_InitialControlPlane.cs` + snapshot. New migration is **additive** (two new tables)
+  — normal `dotnet ef migrations add`, then verify `has-pending-model-changes` reports none.
+- `apps/tamma-elsa/src/Tamma.Data/Repositories/IEventRepository.cs` — `AppendAsync(DomainEvent)`
+  (line 7). `DomainEvent` (`Tamma.Data/Entities/DomainEvent.cs`) has `Type`, `TenantId`, `Tags`,
+  `Metadata`, `Data`, `CreatedAt`. DCB shape is set by `OrgEndpoints.EmitTenantEvent`
+  (`OrgEndpoints.cs:1036–1066`): `Metadata` = `{"workflowVersion":"1.0.0","eventSource":"system"}`,
+  `Tags`/`Data` JSON-serialized. Reuse that shape for `BillingEvents`.
+
+### Tenant-create paths (the real hook sites)
+- `apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs:30–89` — `CreateOrg`: `new Tenant` via
+  `tenantRepo.CreateAsync` (line 57), `provisioning.ProvisionAsync(tenant.Id)` (line 78), then
+  `EmitTenantEvent(..., "TENANT.CREATED.SUCCESS", ...)` (line 81). **This is the primary hook.**
+- `apps/tamma-elsa/src/Tamma.Api/Endpoints/AuthEndpoints.cs:275` — registration path also runs
+  `new Tenant`/`CreateAsync`. Add the same hook.
+- `apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminTenantsEndpoints.cs` — **NOT a create path.**
+  It is the Story 28-11 lifecycle manager (list/detail/retry/delete/change-plan, `OwnerAccess`),
+  no `new Tenant`. The spec named it; correct target is OrgEndpoints/AuthEndpoints. (Documented in
+  the story's Technical Design callout.)
+
+### Secret cabinet (Epic 29) — reuse, don't reinvent
+- `apps/tamma-elsa/src/Tamma.Api/Services/Secrets/ISecretStore.cs` — write/rotate surface;
+  **never returns plaintext** through public signatures (doc-comment lines 9–16).
+- `apps/tamma-elsa/src/Tamma.Api/Services/Secrets/SecretScope.cs` — `Platform` (TenantId null,
+  platform-admin only) vs `Tenant`. Stripe key = `Platform`.
+- `apps/tamma-elsa/src/Tamma.Api/Services/Secrets/SecretPurpose.cs` — `ApiKey` (line 29, "OpenAI
+  key, GitHub App credentials"), `Webhook` (line 50). Stripe key → `ApiKey`; webhook signing
+  secret → `Webhook`.
+- `apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Stopgap/RuntimeSecretResolver.cs` — the
+  runtime-read pattern: cabinet-first, dev-only env fallback, **Story 29-10 prod fail-fast** (line
+  ~88 onward "no fallback. Fail-fast"). `IRuntimeSecretResolver.GetAsync(cabinetName)` is exactly
+  AC5. Resolve `billing/stripe-secret-key` through it.
+- `apps/tamma-elsa/src/Tamma.Api/Services/Alerts/IAlertChannelSecretReader.cs` — precedent for a
+  minimal read-only secret seam (`DefaultAlertChannelSecretReader` reads active version via
+  `ISecretStoreBackend.GetVersionPlaintextAsync`). Use as a model if a dedicated reader is needed,
+  but prefer `IRuntimeSecretResolver`.
+
+### Platform task queue (retry seam)
+- `apps/tamma-elsa/src/Tamma.Data/Entities/PlatformQueuedTask.cs` — `Type`, `TenantId`, `Payload`,
+  `Status`, `RetryCount`, dead-letter on ceiling.
+- `apps/tamma-elsa/src/Tamma.Api/Services/PlatformTasks/IPlatformTaskHandler.cs` — `TaskType` +
+  `HandleAsync(task, ct)`. Normal throw = retryable; `PlatformTaskTerminalException` = dead-letter.
+  Registered via `services.AddPlatformTaskHandler<T>()`. `CreateBillingCustomerTaskHandler` plugs in
+  here.
+
+### Mode + CLI dispatch
+- `apps/tamma-elsa/src/Tamma.Api/Services/PromptStore/TammaMode.cs` — `ITammaModeProvider.Mode`
+  (`SingleUser`/`SaaS`); detection from `Tamma:Mode` explicit, else `Tamma:TenantSharedSecret` /
+  `ConnectionStrings:ControlPlane` presence (lines 67–96). Drives `NullBillingProvider` vs
+  `StripeBillingProvider` registration.
+- `apps/tamma-elsa/src/Tamma.Api/Program.cs:1140–1148` — CLI dispatch precedent: `migrate-secrets`
+  runs `MigrateSecretsCommand.RunAsync(app.Services)` *before* the HTTP pipeline and returns an exit
+  code. `apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Stopgap/MigrateSecretsCommand.cs` —
+  `ShouldRun(args)` (line 21, `args[0] == "migrate-secrets"`) + `RunAsync`. `SeedBillingCommand`
+  mirrors this exactly with `seed-billing`.
+- Seeders run at startup post-migration in `Program.cs` (`PlansSeeder.SeedAsync` at line 2030,
+  `TenantDatabasesSeeder` at line 2064). `BillingSeeder` is NOT auto-run at startup (Stripe calls
+  must be explicit/operator-triggered) — it runs only via `seed-billing`.
+- Auth policies (`Program.cs:971–1012`): `OwnerAccess`, `PlatformOwnerAccess`, `MemberAccess`,
+  `PromptManage`. Any future admin billing route uses `OwnerAccess`.
+
+### Not present yet (all NEW)
+- No `Stripe` reference in any `.csproj` (grep clean). No `Services/Billing/` directory. No billing
+  entity. All billing code is greenfield.
+
+---
+
+## Architecture
+
+**Mode-gated seam → cabinet-resolved Stripe client → CP entities → DCB events**, reusing the secret
+cabinet and platform task queue end-to-end:
+
+1. **`IBillingProvider`** is the single billing seam. `StripeBillingProvider` (SaaS) resolves the
+   key from the cabinet and calls Stripe; `NullBillingProvider` (single-user) reports
+   `IsEnabled=false` and no-ops. DI picks one based on `ITammaModeProvider.Mode`.
+2. **`BillingCustomer`** (CP table, unique `TenantId`) is the tenant→Stripe mapping, created inside
+   the tenant-create transaction; Stripe failure falls back to a `PlatformQueuedTask` retry so
+   tenant creation is never blocked.
+3. **`BillingPlanPrice`** (CP table, unique `PlanSlug`) is the slug→Stripe-ids catalog, populated by
+   the idempotent `seed-billing` command which also mints the three Billing Meters.
+4. **DCB events** `BILLING.CUSTOMER.CREATED` and `BILLING.PLAN_CATALOG.SYNCED` append to the CP
+   `DomainEvents` store via `IEventRepository` (same store the alert evaluator polls).
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Billing provider | `NullBillingProvider` (`IsEnabled=false`) | `StripeBillingProvider` |
+| Who owns the catalog? | n/a (no Stripe) | Platform owner (`OwnerAccess`); platform-global, slug-keyed |
+| Who owns a customer mapping? | n/a | The tenant — exactly one `BillingCustomer` per `TenantId`, never cross-tenant |
+| Stripe key source | n/a | cabinet `billing/stripe-secret-key` (`SecretScope.Platform`, `SecretPurpose.ApiKey`); prod fail-fast if absent |
+| Seed command | prints "billing is SaaS-only", exit 0 | runs catalog sync |
+| Mode source | `ITammaModeProvider` (process-stable) | same |
+
+---
+
+## Phased task breakdown
+
+### Phase 1 — Data layer: entities, DbContext, migration (foundation)
+
+- [ ] **T1.1 — `BillingMode` enum.** New `apps/tamma-elsa/src/Tamma.Core/Billing/BillingMode.cs`
+  (`{ PlatformProvided, Byok }`). *Test first:* trivial — covered transitively by T1.2 column tests.
+- [ ] **T1.2 — `BillingCustomer` + `BillingPlanPrice` entities.** New
+  `Tamma.Data/Entities/BillingCustomer.cs` (Id, TenantId, StripeCustomerId?, BillingMode text,
+  DefaultCurrency, TaxStatus, timestamps, Tenant nav) and
+  `Tamma.Data/Entities/BillingPlanPrice.cs` (Id, PlanSlug, product/base-price + 3×(meter,price)
+  ids, timestamps). *Tests first:* `BillingEntityModelTests` — assert column defaults
+  (`BillingMode="PlatformProvided"`, `DefaultCurrency="usd"`).
+- [ ] **T1.3 — DbContext + model config.** Add `DbSet<BillingCustomer> BillingCustomers` and
+  `DbSet<BillingPlanPrice> BillingPlanPrices` to `ControlPlaneDbContext.cs`; configure in
+  `TammaModelConfiguration.ConfigureControlPlaneEntities`: tables `billing_customers` /
+  `billing_plan_prices`, unique index on `BillingCustomer.TenantId`, filtered-unique on
+  `StripeCustomerId`, unique on `BillingPlanPrice.PlanSlug`, CHECK on `BillingMode`, FK to `tenants`
+  (cascade). *Tests first:* model-snapshot/EnsureCreated test asserting the indexes + CHECK exist.
+- [ ] **T1.4 — EF migration.** `dotnet ef migrations add AddBillingCustomerAndPlanPrices --context
+  ControlPlaneDbContext --output-dir Migrations/ControlPlane` (build, no wrapper). Verify
+  `dotnet ef migrations has-pending-model-changes` → none. *Tests first (integration, docker):*
+  `BillingMigrationTests` applies `Update` then down/`Remove`-equivalent on a real Postgres CP DB.
+
+### Phase 2 — Billing seam + Stripe client + secret resolution
+
+- [ ] **T2.1 — Add `Stripe.net` to `Tamma.Api.csproj`.** Research the latest stable version + the
+  `Billing.MeterService`, `CustomerService`, `ProductService`, `PriceService`, and
+  `RequestOptions.IdempotencyKey` surfaces **before** writing calls (do not assume signatures).
+- [ ] **T2.2 — `BillingOptions` + `StripeClientFactory`.** New `Services/Billing/BillingOptions.cs`
+  (cabinet names `billing/stripe-secret-key`, `billing/stripe-webhook-secret`; `DefaultCurrency`)
+  and `StripeClientFactory.cs` building `Stripe.StripeClient` from
+  `IRuntimeSecretResolver.GetAsync(...)`. *Tests first:* `StripeClientFactoryTests` — resolves key
+  from a stubbed resolver; production env + null key → throws (AC5 fail-fast); dev env + null →
+  documented behaviour.
+- [ ] **T2.3 — `IBillingProvider` + `NullBillingProvider`.** New
+  `Services/Billing/IBillingProvider.cs` (`IsEnabled`, `CreateCustomerAsync`, `SyncCatalogAsync`)
+  and `NullBillingProvider.cs` (`IsEnabled=false`, no-op/throw). *Tests first:*
+  `NullBillingProviderTests` — `IsEnabled=false`, no Stripe calls possible.
+- [ ] **T2.4 — `StripeBillingProvider.CreateCustomerAsync`.** New `StripeBillingProvider.cs` —
+  create Stripe `Customer` with deterministic idempotency key `billing-customer-{tenantId}`, persist
+  `BillingCustomer`, return mapped row; duplicate tenant returns the existing row (lookup before
+  create). *Tests first:* `StripeBillingProviderTests` — correct idempotency key, row persisted,
+  duplicate-tenant short-circuit, mocked `CustomerService`.
+
+### Phase 3 — Catalog reader + idempotent seed
+
+- [ ] **T3.1 — `IBillingCatalog` + `BillingCatalog`.** New read-side seam resolving
+  `BillingPlanPrice` by slug (EF-backed, cached). *Tests first:* `BillingCatalogTests` — known slug
+  returns row, unknown slug throws, cache hit.
+- [ ] **T3.2 — `BillingSeeder` + `StripeBillingProvider.SyncCatalogAsync`.** New
+  `Tamma.Data/Seeders/BillingSeeder.cs` orchestrating: for each `Plan.Slug`, upsert Stripe Product,
+  base Price, three metered Prices, and three Billing Meters (`tamma.platform_tokens_input` SUM,
+  `tamma.platform_tokens_output` SUM, `tamma.seats` LAST), then write ids into `billing_plan_prices`
+  (insert-if-absent / update-existing). Deterministic idempotency keys
+  `billing-catalog-{slug}-{resource}`. *Tests first:* `BillingSeederTests` — first run creates +
+  writes ids; second run reuses existing ids (0 create calls, no row churn); emits one
+  `BILLING.PLAN_CATALOG.SYNCED` per slug; meters created with correct aggregation
+  (SUM/SUM/LAST), all Stripe services mocked.
+- [ ] **T3.3 — `BillingEvents` helper.** New `Services/Billing/BillingEvents.cs` building
+  `DomainEvent` rows for `BILLING.CUSTOMER.CREATED` / `BILLING.PLAN_CATALOG.SYNCED` in the
+  `EmitTenantEvent` shape. *Tests first:* assert Type, Tags JSON, TenantId set/null per event.
+
+### Phase 4 — Tenant-create hook + retry handler
+
+- [ ] **T4.1 — `CreateBillingCustomerTaskPayload` + handler.** New
+  `Services/Billing/Tasks/CreateBillingCustomerTaskPayload.cs` and
+  `CreateBillingCustomerTaskHandler.cs` (`IPlatformTaskHandler`, `TaskType="billing.customer.create"`)
+  re-driving `CreateCustomerAsync`, filling `StripeCustomerId`, emitting `BILLING.CUSTOMER.CREATED`.
+  Malformed payload → `PlatformTaskTerminalException`; transient Stripe error rethrows (retry).
+  *Tests first:* `CreateBillingCustomerTaskHandlerTests` — happy path fills id + emits; terminal vs
+  retryable failure paths.
+- [ ] **T4.2 — Wire the hook into `OrgEndpoints.CreateOrg`.** After `ProvisionAsync`, if
+  `billing.IsEnabled`: try `CreateCustomerAsync` + emit event; on failure enqueue the
+  `PlatformQueuedTask` (do NOT block creation). Inject `IBillingProvider` +
+  `IPlatformQueuedTaskRepository` into the endpoint. *Tests first (integration):*
+  `BillingTenantCreateIntegrationTests` — create org (Stripe mocked) → one `BillingCustomer` + one
+  `BILLING.CUSTOMER.CREATED`; Stripe-fail → row with null id + one queued task, tenant still created.
+- [ ] **T4.3 — Wire the same hook into `AuthEndpoints` registration tenant-create path
+  (`AuthEndpoints.cs:275`).** *Tests:* extend integration coverage for the registration path.
+
+### Phase 5 — DI wiring + CLI command + single-user seam
+
+- [ ] **T5.1 — `BillingServiceCollectionExtensions.AddTammaBilling`.** New extension: register
+  `IBillingProvider` as `StripeBillingProvider` when `Mode==SaaS` else `NullBillingProvider`;
+  register `IBillingCatalog`, `StripeClientFactory`, `BillingOptions`, and the task handler via
+  `AddPlatformTaskHandler<CreateBillingCustomerTaskHandler>()`. *Tests first:*
+  `AddTammaBillingTests` — SaaS config resolves `StripeBillingProvider`; single-user config resolves
+  `NullBillingProvider`.
+- [ ] **T5.2 — `SeedBillingCommand` + `Program.cs` dispatch.** New `Services/Billing/
+  SeedBillingCommand.cs` (`ShouldRun(args) => args[0]=="seed-billing"`, `RunAsync(services)`):
+  single-user → print SaaS-only + exit 0; SaaS → run `BillingSeeder`, print per-slug report, exit
+  0/1. Add `AddTammaBilling()` call + the `seed-billing` dispatch block in `Program.cs` next to the
+  `migrate-secrets` block (line ~1143). *Tests first:* `SeedBillingCommandTests` — `ShouldRun`
+  arg matching; single-user no-op exit 0.
+
+### Phase 6 — Verification
+
+- [ ] **T6.1** Run `sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests"` — full suite
+  green (no regressions in the existing 4575).
+- [ ] **T6.2** `dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext` →
+  none.
+- [ ] **T6.3** Manually run `dotnet run --project apps/tamma-elsa/src/Tamma.Api -- seed-billing`
+  twice against a Stripe test account (opt-in, behind `STRIPE_SECRET_KEY_TEST`); confirm second run
+  is a no-op (0 created).
+
+---
+
+## Sequencing & dependencies
+
+```
+T1.1 → T1.2 → T1.3 → T1.4            (data layer — must land first)
+              ↓
+T2.1 → T2.2 → T2.3 → T2.4            (seam + client; T2.4 needs T1.2)
+              ↓
+T3.1 → T3.2 → T3.3                   (catalog + seed; needs T1 + T2)
+              ↓
+T4.1 → T4.2 → T4.3                   (hook + retry; needs T2.4 + T3.3 + queue)
+              ↓
+T5.1 → T5.2                          (DI + CLI; needs all providers/handlers)
+              ↓
+T6.x                                 (verification)
+```
+
+- **Hard prerequisite:** Phase 1 (data) before everything. Phase 2 before Phase 3/4.
+- **External:** `Stripe.net` (T2.1) gates all Stripe SDK calls — research latest API first.
+- **Story prerequisites:** Epic 28 (CP, tenants, plan, queue, mode), Epic 29 (cabinet +
+  `IRuntimeSecretResolver`), Epic 4 (DCB events) — all present at main.
+
+## Risks + mitigations
+
+- **Stripe outage blocks tenant creation.** *Mitigation:* T4.2 non-blocking try/catch →
+  `PlatformQueuedTask` retry (the established worker), row persists with null `StripeCustomerId`. The
+  integration test pins this.
+- **Duplicate Stripe objects on retry/re-seed.** *Mitigation:* deterministic idempotency keys
+  (`billing-customer-{tenantId}`, `billing-catalog-{slug}-{resource}`) + unique `TenantId`/`PlanSlug`
+  DB constraints + lookup-by-stored-id in the seeder. Tests assert second seed run = 0 creates.
+- **Stripe.net API drift vs assumed signatures.** *Mitigation:* T2.1 mandates researching current
+  docs before coding; all tests mock at the Stripe *service-interface* boundary, so the SDK shape is
+  isolated to a few factory/provider files.
+- **Raw env Stripe key in production.** *Mitigation:* AC5 + T2.2 reuse `IRuntimeSecretResolver`'s
+  Story 29-10 prod fail-fast; a `BillingSecretBootTests` case proves boot throws when the cabinet row
+  is absent in production.
+- **Accidental Stripe coupling in single-user.** *Mitigation:* mode-gated DI (T5.1) +
+  `NullBillingProvider`; tests assert zero SDK calls and zero rows in single-user.
+- **Migration discipline.** *Mitigation:* `billing_*` tables are additive (not a baseline CHECK
+  edit), but T1.4 still verifies `has-pending-model-changes` reports none and mirrors entity config
+  only in `TammaModelConfiguration.cs` (the single source).
+- **Wrong create-path hook.** *Mitigation:* finding above documents that `AdminTenantsEndpoints` is
+  lifecycle-only; the hook lands in `OrgEndpoints.CreateOrg` + `AuthEndpoints` (verified `new
+  Tenant` sites).
+
+## Acceptance criteria (mirror the story)
+
+- [ ] `BillingCustomer` entity + table exist (unique `TenantId`, FK to `tenants`, CHECK on
+  `BillingMode`); `BillingPlanPrice` entity + table exist (unique `PlanSlug`); both wired into
+  `ControlPlaneDbContext` + `TammaModelConfiguration`; additive migration applies + rolls back;
+  `has-pending-model-changes` = none.
+- [ ] `IBillingProvider` resolves to `StripeBillingProvider` in SaaS, `NullBillingProvider` in
+  single-user.
+- [ ] Stripe key + webhook secret resolve via the Epic 29 cabinet (`SecretScope.Platform`,
+  `SecretPurpose.ApiKey`/`Webhook`); production refuses to boot billing with only a raw env key.
+- [ ] Tenant creation in `OrgEndpoints.CreateOrg` / `AuthEndpoints` creates a Stripe customer +
+  `BillingCustomer` row in the create transaction; Stripe failure enqueues a `PlatformQueuedTask`
+  retry instead of blocking creation.
+- [ ] `seed-billing` CLI idempotently creates/updates Stripe Products, Prices, and the three Billing
+  Meters (`tamma.platform_tokens_input` SUM, `tamma.platform_tokens_output` SUM, `tamma.seats` LAST)
+  and writes ids into `billing_plan_prices`; re-run is a no-op.
+- [ ] `BILLING.CUSTOMER.CREATED` (tags `{tenantId, stripeCustomerId, billingMode}`) and
+  `BILLING.PLAN_CATALOG.SYNCED` (tags `{planSlug, source}`) appended to `DomainEvents`.
+- [ ] Single-user mode registers `NullBillingProvider`: no Stripe calls, no `BillingCustomer` row,
+  no billing endpoints/command effect.
+- [ ] Unit tests cover catalog mapping, idempotent seed, customer-create-on-tenant-create
+  (Stripe mocked), retry enqueue, and the single-user no-op seam; tenant-isolation test asserts one
+  `BillingCustomer` per tenant.
+- [ ] Full xUnit suite green; Stripe secret/webhook/payment details never logged.

--- a/docs/superpowers/plans/2026-06-17-35-10-credits-and-prepaid-wallet-ledger-plan.md
+++ b/docs/superpowers/plans/2026-06-17-35-10-credits-and-prepaid-wallet-ledger-plan.md
@@ -1,0 +1,261 @@
+# Story 35-10: Credits & Prepaid Wallet Ledger — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes its
+> xUnit tests before the implementation it covers.
+
+**Goal:** Give SaaS tenants a prepaid credits wallet whose balance is derived from an append-only,
+double-entry-style ledger (grant / topup / consume / expire / refund / adjustment) on the control
+plane, applied to invoices before the card is charged. Top-ups via Stripe one-time PaymentIntents
+credit the wallet only on `payment_intent.succeeded` (idempotent by intent id); available credit
+offsets invoice `amount_due` at finalize (BYOK ⇒ platform/seat fee, platform-provided ⇒ also token
+charges); expired lots are swept on the platform task queue; every mutation emits a `BILLING.CREDIT.*`
+DCB event. Balance is never stored mutably — it is `SUM(AmountUsd)` per tenant.
+
+**Story file:** `docs/stories/epic-35/story-35-10/35-10-credits-and-prepaid-wallet-ledger.md`
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane API `Tamma.Api`,
+data `Tamma.Data`, core `Tamma.Core`). Stripe.net (added by Story 35-1). Tests in
+`apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/` (xUnit; docker-bound CP-Postgres suites run via
+`sg docker -c "dotnet test ..."`).
+
+---
+
+## Non-goals (YAGNI guard)
+
+- NO invoice mirror, invoice finalize state machine, or dunning — that is **Story 35-8**. This plan
+  only adds the credit-apply call site (`IWalletCreditService.ApplyToInvoiceAsync`) and the `credit`
+  line amount; it does not own `BillingInvoice`/`BillingInvoiceLine`.
+- NO webhook endpoint / signature verification / dedup row — that is **Story 35-5**. This plan only
+  *registers* `IBillingEventHandler` implementations (`WalletTopupWebhookHandler`,
+  `WalletRefundWebhookHandler`) into 35-5's registry.
+- NO Stripe customer mapping / catalog / customer creation — that is **Story 35-1**. This plan reuses
+  35-1's `BillingCustomer`, `StripeClientFactory`/`IBillingProvider`, and `NullBillingProvider` seam.
+- NO subscription lifecycle (35-4), payment methods/portal (35-7), metering/markup (35-3), or quota
+  enforcement/suspension (35-6).
+- NO tenant-facing dashboard UI (would live in `packages/dashboard-user`, consuming
+  `GET /api/v1/orgs/{tenantId}/billing/wallet`). Backend only.
+- NO mutable `tenant.credit_balance` column. Balance stays derived from the ledger.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### What exists to build on
+
+| Seam | File / location | Use |
+|---|---|---|
+| Control-plane DbContext + DbSets | `src/Tamma.Data/ControlPlaneDbContext.cs` (DbSets ~33-102) | add `DbSet<BillingWalletLedger>`. |
+| Single source of EF model config | `src/Tamma.Data/TammaModelConfiguration.cs` (`ConfigureControlPlaneEntities`) | table/CHECK/index/FK config goes here ONLY. |
+| CP migrations dir | `src/Tamma.Data/Migrations/ControlPlane/` (baseline `20260609205701_InitialControlPlane.cs` + `ControlPlaneDbContextModelSnapshot.cs`) | additive migration lands here. |
+| DCB event append | `src/Tamma.Data/Repositories/IEventRepository.cs` → `AppendAsync(DomainEvent)`; entity `src/Tamma.Data/Entities/DomainEvent.cs` (`Type`, `TenantId`, `Tags`, `Metadata`, `Data`, server-side `SequenceNumber`) | emit `BILLING.CREDIT.*`. |
+| Platform task queue | `src/Tamma.Data/Entities/PlatformQueuedTask.cs`; `src/Tamma.Data/Repositories/IPlatformQueuedTaskRepository.cs` → `EnqueueAsync(task, ct)` (line 29) | enqueue the expiry sweep. |
+| Platform task handler contract | `src/Tamma.Api/Services/PlatformTasks/IPlatformTaskHandler.cs` (`TaskType`, `HandleAsync`; `PlatformTaskTerminalException` for non-retryable); exemplar `Services/Provisioning/MoveTenantTaskHandler.cs`; worker `Services/PlatformTasks/PlatformTaskWorker.cs` (`RunOnStartup` gate line 75, `MaxRetries=5`, `VisibilityTimeout=10m`) | `WalletExpirySweepTaskHandler`. |
+| Per-tenant advisory lock + serialized work | `src/Tamma.Api/Services/Provisioning/TenantMoveService.cs:843-923` (`pg_try_advisory_lock(hashtextextended(@tid,0))`) | the double-spend guard pattern for `AppendAsync`. |
+| Tenant-scoped routing + RBAC | `Program.cs:1512` (`app.MapGroup("/api/v1/orgs").RequireAuthorization("MemberAccess")` + `.AddEndpointFilter<RequireTenantMembershipFilter>()`); filter `src/Tamma.Api/Authorization/RequireTenantMembershipFilter.cs` (`TenantRoleItemKey="TenantRole"`, line 30); inline admin gate `Endpoints/AlertEndpoints.cs:1008` `RequireTenantAdmin(http, out forbid)` reading `HttpContext.Items["TenantRole"]` | tenant top-up/read routes + member-403 on top-up. |
+| Platform-owner gate | `Program.cs:986` `PlatformOwnerAccess` policy (`PlatformPermissionRequirement("platform_admin")`) | admin grant/refund/read routes. |
+| Org+admin endpoint exemplar | `src/Tamma.Api/Endpoints/AlertEndpoints.cs` (admin section + tenant `/api/v1/orgs/{tenantId}/...` section, paging `DefaultPageSize=50`/`MaxPageSize=500`, cross-tenant 404 invariant ~617) | `WalletEndpoints` structure. |
+| Tenant entity / FK | `src/Tamma.Data/Entities/Tenant.cs` (`Id`, `Slug`, `Plan`) | `BillingWalletLedger.TenantId` FK. |
+
+### Sibling-story seams this plan consumes (must exist or be co-developed)
+
+- **35-1** (`docs/stories/epic-35/story-35-1/...`, drafted): `BillingCustomer` (`StripeCustomerId ↔ TenantId`),
+  Stripe.net on `Tamma.Api.csproj`, `StripeClientFactory`/`IBillingProvider`/`NullBillingProvider`,
+  `BillingEvents` event-helper precedent, `BillingServiceCollectionExtensions.AddTammaBilling`,
+  `Services/Billing/` namespace, single-user no-op seam (AC9).
+- **35-5** (`docs/stories/epic-35/story-35-5/...`, drafted): `IBillingEventHandler`
+  (`HandledEventTypes` + `HandleAsync(BillingWebhookContext, ct) → BillingFollowup?`),
+  `BillingEventHandlerRegistry`, `BillingWebhookContext(StripeEvent, TenantId, RawPayload)`,
+  `services.AddBillingEventHandler<T>()`, `NullBillingEventHandler` default. 35-10's handlers plug in here.
+- **35-8** (spec `/tmp/pab_stories/35-8.json`, not yet authored): `InvoiceService` / `InvoiceWebhookHandler`
+  finalize path, `BillingInvoice`/`BillingInvoiceLine` mirrors, `credit` line item type. 35-8 calls
+  `IWalletCreditService.ApplyToInvoiceAsync` at finalize. **Coordinate the call site.**
+
+### Gaps / decisions
+
+- **No billing infrastructure exists on `main` yet** — `find apps/tamma-elsa/src -iname "*billing*"` is empty.
+  Everything billing (incl. 35-1/35-5/35-8) is in-flight under Epic 35. This plan assumes 35-1 + 35-5 land
+  first (hard prerequisites) and treats the 35-8 finalize call site as a published seam.
+- **No `tenant.credit_balance` column and we will not add one** — derived balance only (AC1).
+- **Stripe minor-unit ⇄ USD** — Stripe amounts are integer minor units (cents); convert `amount/100m`
+  to the `numeric(12,4)` USD ledger. Research the exact Stripe.net field (`AmountReceived`) before coding.
+
+---
+
+## Architecture
+
+**Append-only ledger → derived balance → Stripe-coupled mutations → DCB events**, all per-tenant-isolated:
+
+1. **`BillingWalletLedger`** (CP entity/table) — immutable rows; `BalanceAfter` snapshot computed at
+   append time; balance = `SUM(AmountUsd)`; unique idempotency key (`topup:{pi}`, `consume:{invoice}`,
+   `expire:{lot}`, `refund:{charge}`, `grant:{guid}`/`promo:{code}:{tenant}`).
+2. **`IWalletLedgerRepository.AppendAsync`** — the single race-safe write path: `pg_advisory_xact_lock`
+   per tenant + `Serializable`, re-read balance, compute `BalanceAfter`, insert; idempotency-key
+   collision returns the existing row (no throw, no double).
+3. **`WalletService`** — top-up PaymentIntent (no ledger row at creation), admin grant, admin refund,
+   wallet read DTO.
+4. **`WalletCreditService.ApplyToInvoiceAsync`** — `min(available, amountDue)` as a Stripe credit +
+   one `consume` row, idempotent by invoice id; called by 35-8 finalize before card charge.
+5. **`WalletTopupWebhookHandler` / `WalletRefundWebhookHandler`** — `IBillingEventHandler` plug-ins for
+   `payment_intent.succeeded` (wallet-only via metadata) / `charge.refunded`.
+6. **`WalletExpirySweepScheduler` + `WalletExpirySweepTaskHandler`** — daily `PlatformQueuedTask` that
+   appends `expire` rows for past-expiry lots, idempotent.
+7. **`WalletEndpoints`** — tenant top-up/read (`RequireTenantMembershipFilter`, member-read,
+   member-403-on-topup) + admin grant/refund/read (`PlatformOwnerAccess`).
+8. **Mode gating** — SaaS only; single-user registers a no-op `IWalletCreditService` and maps no routes.
+
+### Per-mode ownership (mandatory two-scoping answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns the wallet? | N/A — no Stripe (`NullBillingProvider`); routes unmapped, credit-apply is a no-op. | The tenant (`tenant_id`-keyed ledger). |
+| Who can top-up? | N/A | `tenant_owner` / `tenant_admin` (`member` → 403). |
+| Who can read balance/history? | N/A | `tenant_owner` / `tenant_admin` / `member` (read-only); platform owner any tenant. |
+| Who can grant / refund / adjust? | N/A | platform owner only (`PlatformOwnerAccess`). |
+| Mode source | `ITammaModeProvider` (`Services/PromptStore/TammaMode.cs`) — process-stable. | same |
+
+---
+
+## Task breakdown (TDD — tests first per task)
+
+### Task 1 — `BillingWalletLedger` entity + migration + repository (core, AC1/AC7/AC12)
+
+**Files:**
+- New `src/Tamma.Data/Entities/BillingWalletLedger.cs` (see story Technical Design for the full shape).
+- Modify `src/Tamma.Data/ControlPlaneDbContext.cs` — `public DbSet<BillingWalletLedger> BillingWalletLedger => Set<BillingWalletLedger>();`.
+- Modify `src/Tamma.Data/TammaModelConfiguration.cs` (`ConfigureControlPlaneEntities`) — `billing_wallet_ledger` table, `ck_billing_wallet_ledger_type` CHECK, `numeric(12,4)` on amount columns, `(TenantId, CreatedAt)` index, **UNIQUE filtered** index on `IdempotencyKey` (NULLS NOT DISTINCT semantics), filtered open-lots index, FK to `tenants` cascade.
+- New `src/Tamma.Data/Repositories/IWalletLedgerRepository.cs` + `WalletLedgerRepository.cs`:
+  `AppendAsync` (advisory-lock + `Serializable`, compute `BalanceAfter`, idempotency-collision → return existing), `GetBalanceAsync`, `GetBalanceViewAsync`, `ListAsync` (paged), `FindExpiredLotsAsync`.
+- Migration: `dotnet ef migrations add AddBillingWalletLedger --context ControlPlaneDbContext --output-dir Migrations/ControlPlane` (+ Designer + snapshot).
+
+**Approach:** entity + config first (compile), then `dotnet ef migrations has-pending-model-changes` → must report none. `AppendAsync` opens a transaction, runs `SELECT pg_advisory_xact_lock(hashtextextended(@tid,0))` (mirror `TenantMoveService.cs:871`), `SELECT COALESCE(SUM(amount_usd),0)` for the tenant, sets `BalanceAfter = balance + entry.AmountUsd`, inserts; on `DbUpdateException` from the idempotency unique index, roll back and re-query the existing row to return it.
+
+**Tests (first) — `WalletLedgerRepositoryTests` (real Postgres via `sg docker`):** append each entry type; `BalanceAfter` == running `SUM`; balance/availability derivation; idempotency collision returns existing row (no throw, no duplicate); `FindExpiredLotsAsync` only returns past-expiry open lots with positive remaining. Plus a migration apply/rollback + `has-pending-model-changes`=none test.
+
+### Task 2 — `WalletService` + `WalletEvents` + `WalletEventTypes` (top-up intent, grant, refund, read; AC2/AC5/AC9/AC10)
+
+**Files:**
+- New `src/Tamma.Api/Services/Billing/WalletEventTypes.cs` (`BILLING.CREDIT.GRANTED|TOPPED_UP|CONSUMED|EXPIRED|REFUNDED` constants).
+- New `src/Tamma.Api/Services/Billing/WalletEvents.cs` (static `DomainEvent` builders, mirroring 35-1 `BillingEvents`: `Tags = { tenantId, amountUsd, balanceAfter, reference, entryType }`, `Metadata = {"workflowVersion":"1.0.0","eventSource":"system"}`).
+- New `IWalletService.cs` + `WalletService.cs`: `CreateTopupIntentAsync` (Stripe `PaymentIntentService.CreateAsync`, `Metadata {tenantId, purpose:"wallet_topup"}`, deterministic idempotency key, **no ledger row**), `GrantAsync` (append `grant`, reject negative, promo dedup via `promo:{code}:{tenant}`, emit `BILLING.CREDIT.GRANTED`), `RefundAsync` (append `refund`, clamp-non-negative + WARN, emit `BILLING.CREDIT.REFUNDED`), `GetWalletAsync` (DTO + paged entries).
+
+**Approach:** resolve the Stripe client through 35-1's `StripeClientFactory`/`IBillingProvider`. All ledger writes go through `IWalletLedgerRepository.AppendAsync`. All events via `IEventRepository.AppendAsync`. Research the Stripe.net `PaymentIntentCreateOptions`/`PaymentIntentService` surface before coding.
+
+**Tests (first) — `WalletServiceTests`:** top-up creates intent with correct metadata + idempotency key and writes no row (mocked `PaymentIntentService`); grant appends + emits, negative rejected, promo double-grant blocked; refund clamps at zero + WARN.
+
+### Task 3 — `WalletTopupWebhookHandler` + `WalletRefundWebhookHandler` (35-5 plug-ins; AC3/AC9)
+
+**Files:** new `Services/Billing/Handlers/WalletTopupWebhookHandler.cs` (`IBillingEventHandler`, claims `payment_intent.succeeded`, wallet-only via `purpose=wallet_topup` metadata, append `topup` keyed `topup:{pi}`, emit `BILLING.CREDIT.TOPPED_UP`) + `WalletRefundWebhookHandler.cs` (`charge.refunded`, wallet-only, `refund:{charge}`, emit `BILLING.CREDIT.REFUNDED`).
+
+**Approach:** consume 35-5's `BillingWebhookContext` (`StripeEvent`, resolved `TenantId`, raw payload). Cast `ctx.StripeEvent.Data.Object` to the typed `Stripe.PaymentIntent`/`Stripe.Charge`. Return `null` (no follow-up) — work is inline + idempotent. Non-wallet objects → return `null` without a row.
+
+**Tests (first) — `WalletTopupWebhookHandlerTests` / refund cases:** wallet `payment_intent.succeeded` → one `topup` row + event; duplicate delivery → no second row; non-wallet PaymentIntent → no row; `charge.refunded` for a wallet top-up → `refund` row + event.
+
+### Task 4 — `WalletCreditService.ApplyToInvoiceAsync` + 35-8 finalize call site (AC4/AC7)
+
+**Files:** new `IWalletCreditService.cs` + `WalletCreditService.cs` (`min(available, amountDue)` → Stripe credit (`CustomerBalanceTransactionService` / negative invoice line) + `consume` row keyed `consume:{invoice}` + emit `BILLING.CREDIT.CONSUMED`, all in one serialized append); modify `Services/Billing/InvoiceService.cs` (35-8) to inject `IWalletCreditService` and call `ApplyToInvoiceAsync` at `invoice.finalized` **before** the charge transition.
+
+**Approach:** the apply is itself an `AppendAsync` (so it inherits the per-tenant advisory lock + `Serializable` double-spend guard). Compute apply amount from `GetBalanceViewAsync(...).AvailableUsd`. If 35-8 has not landed, publish the seam + a unit test against a fake invoice; coordinate the one-line injection when 35-8 merges. Single-user registers a no-op `IWalletCreditService` (returns 0).
+
+**Tests (first) — `WalletCreditServiceTests`:** apply records `min(balance, amountDue)` as credit + `consume` row + event; zero balance → zero applied, no row; re-finalization (same invoiceId) → no second consume (idempotency key).
+
+### Task 5 — Double-spend concurrency test (AC7/AC13 #5)
+
+**Files:** new `tests/.../Billing/WalletDoubleSpendTests.cs` (real Postgres).
+
+**Approach:** seed 10 USD; fire two concurrent `ApplyToInvoiceAsync` for the same tenant against two invoices summing > 10 USD; assert total consumed ≤ 10, balance never negative, correct `consume` row count. This test *is* the proof that the advisory-lock serialized append works — write it before finalizing `AppendAsync`'s locking.
+
+### Task 6 — Expiry sweep: scheduler + task handler (AC8)
+
+**Files:** new `Services/Billing/Tasks/WalletExpirySweepScheduler.cs` (`BackgroundService`, mode-gated, default daily, `RunOnStartup` gate mirroring `PlatformTaskWorkerOptions`, enqueues `PlatformQueuedTask{Type="billing.wallet.expire_sweep"}` via `IPlatformQueuedTaskRepository.EnqueueAsync`) + `Tasks/WalletExpirySweepTaskHandler.cs` (`IPlatformTaskHandler`, `TaskType="billing.wallet.expire_sweep"`, per lot append `expire` keyed `expire:{lot}` + emit `BILLING.CREDIT.EXPIRED`; malformed payload → `PlatformTaskTerminalException`; transient → rethrow for retry).
+
+**Tests (first) — `WalletExpirySweepTests`:** expired lot with remaining → one `expire` row + event; re-run → no second expire (idempotent); non-expired untouched; fully-consumed expired lot → no expire row.
+
+### Task 7 — `WalletEndpoints` + route mapping + DI extension (AC2/AC5/AC6/AC6b/AC11)
+
+**Files:** new `src/Tamma.Api/Endpoints/Billing/WalletEndpoints.cs` (tenant: `POST topup` [member→403 via `RequireTenantAdmin` helper], `GET wallet` [member-read]; admin: `POST grant`, `POST refund`, `GET wallet/{tenantId}`); new `src/Tamma.Api/Extensions/WalletServiceCollectionExtensions.cs` (`AddTammaWallet` — mode-aware: SaaS registers services + handlers + scheduler; single-user registers no-op `IWalletCreditService` only); modify `Program.cs` — `AddTammaWallet()` + map tenant routes in the `/api/v1/orgs` group (line 1512) with `RequireTenantMembershipFilter`, admin routes under `/api/v1/admin` with `PlatformOwnerAccess`, **SaaS-mode-gated** route mapping.
+
+**Approach:** mirror `AlertEndpoints` admin+tenant split. Tenant routes filter `tenant_id = {tenantId}` (cross-tenant 404). Register `WalletTopupWebhookHandler`/`WalletRefundWebhookHandler` via `services.AddBillingEventHandler<T>()` inside `AddTammaWallet` (SaaS only).
+
+**Tests (first) — `WalletEndpointsTests`:** RBAC matrix (member 403 on top-up, member 200 on read; admin grant/refund require `PlatformOwnerAccess`; cross-tenant 404); tenant isolation (A's credit never in B's wallet); single-user routes 404; top-up returns `{paymentIntentId, clientSecret}` (Stripe mocked).
+
+### Task 8 — Single-user seam + tenant-isolation integration tests (AC6b/AC11/AC13)
+
+**Files:** new `tests/.../Billing/WalletSingleUserSeamTests.cs`, extend `WalletEndpointsTests` / add an isolation integration test via `WebApplicationFactory`.
+
+**Approach:** single-user markers → routes unmapped (404), `IWalletCreditService` no-op, zero Stripe calls. Two-tenant isolation: independent ledgers, no cross-tenant read/offset.
+
+---
+
+## Sequencing & dependencies
+
+```
+Task 1 (entity + migration + repository)  ── hard prerequisite for everything
+   ├── Task 2 (WalletService + events)
+   │      └── Task 3 (webhook handlers)         needs 35-5 registry
+   │      └── Task 4 (credit-apply service)      needs 35-8 finalize call site
+   │             └── Task 5 (double-spend test)  pins Task 1 locking + Task 4
+   │      └── Task 6 (expiry sweep)              needs Epic 28 task worker
+   └── Task 7 (endpoints + DI + routing)         needs Tasks 2/4
+          └── Task 8 (single-user + isolation tests)
+```
+
+- **External prerequisites:** Story 35-1 (Stripe.net, `BillingCustomer`, `StripeClientFactory`,
+  `NullBillingProvider`) and Story 35-5 (`IBillingEventHandler` registry, `BillingWebhookContext`)
+  must be merged before Tasks 2-4/7 can wire fully. Story 35-8's finalize call site (Task 4) is
+  coordinated — publish the `IWalletCreditService` seam first if 35-8 is not yet merged.
+- Task 1 + Task 5 are the load-bearing correctness work; do them on real Postgres (not SQLite — the
+  advisory lock + `Serializable` semantics need the real engine).
+
+---
+
+## Risks + mitigations
+
+- **Double-spend under concurrent finalization (High):** per-tenant `pg_advisory_xact_lock` +
+  `Serializable` serialized append in `WalletLedgerRepository.AppendAsync`; unique `consume:{invoiceId}`
+  backstop; dedicated `WalletDoubleSpendTests` on real Postgres is the proof (Task 5).
+- **Duplicate top-up credit from at-least-once webhooks (High):** `topup:{paymentIntentId}` UNIQUE
+  idempotency key; collision returns the existing row.
+- **Crediting an unpaid PaymentIntent (High):** ledger row only on `payment_intent.succeeded` via the
+  35-5 handler — never at intent creation (Task 2 writes no row; Task 3 does).
+- **Stripe ⇄ ledger drift (Medium):** apply credit as a Stripe customer-balance / negative invoice line
+  **before** charge so Stripe charges the net amount (Task 4).
+- **Refund below zero (Medium):** clamp + WARN; refund cannot exceed credited-from-that-charge balance.
+- **Expiry double-expire (Medium):** `expire:{lotId}` UNIQUE key; idempotent re-run (Task 6).
+- **Migration discipline (Medium):** `billing_wallet_ledger` is additive — still run
+  `has-pending-model-changes` after the migration (expect none); entity config in
+  `TammaModelConfiguration` only (the established single source).
+- **Sibling-story drift (Medium):** 35-1/35-5/35-8 are concurrently in-flight — pin the consumed seams
+  (`StripeClientFactory`, `IBillingEventHandler`/`BillingWebhookContext`, `InvoiceService` finalize) in
+  the first task that touches each, and fail the build loudly if a seam signature drifts.
+- **Single-user accidental Stripe coupling (Medium):** `NullBillingProvider` seam; routes unmapped;
+  `WalletSingleUserSeamTests` asserts zero SDK calls (Task 8).
+- **Stripe.net API drift (Medium):** research current `PaymentIntentService` /
+  `CustomerBalanceTransactionService` / `RequestOptions.IdempotencyKey` / minor-unit fields before
+  coding; mock at the service-interface boundary.
+
+---
+
+## Acceptance criteria (mirror of the story)
+
+- [ ] Append-only `BillingWalletLedger` (CP) with `{grant|topup|consume|expire|refund|adjustment}`,
+      signed `AmountUsd`, computed `BalanceAfter`, `Reference`/`ReferenceKind`, `ExpiresAt`, unique
+      `IdempotencyKey`; balance derived (`SUM`), never mutated in place. (Task 1)
+- [ ] `POST /api/v1/orgs/{tenantId}/billing/wallet/topup` creates a Stripe one-time PaymentIntent;
+      `payment_intent.succeeded` appends a `topup` row idempotently by intent id. (Tasks 2, 3)
+- [ ] Available credit applied to invoices before card charge in the 35-8 finalize path, as a Stripe
+      credit line + a `consume` ledger entry. (Task 4)
+- [ ] Admin grant endpoint (`PlatformOwnerAccess`) issues promo/support credits with optional expiry;
+      emits `BILLING.CREDIT.GRANTED`. (Tasks 2, 7)
+- [ ] `GET .../billing/wallet` returns balance + paged ledger history for owner/admin/member-read. (Tasks 2, 7)
+- [ ] Credit application atomic + race-safe (no double-spend) under concurrent finalization; expired
+      entries swept by a `PlatformQueuedTask` recording an `expire` entry. (Tasks 4, 5, 6)
+- [ ] DCB events `BILLING.CREDIT.GRANTED|TOPPED_UP|CONSUMED|EXPIRED|REFUNDED` with
+      `{tenantId, amountUsd, reference, ...}` tags. (Tasks 2, 3, 4, 6)
+- [ ] Per-mode + per-tenant: SaaS RBAC (member-read, admin-grant), single-user no-op + unmapped routes,
+      tenant isolation. (Tasks 7, 8)
+- [ ] Migration applies + rolls back; `has-pending-model-changes` = none. (Task 1)
+- [ ] Unit + integration tests: ledger append + derived balance, idempotent top-up, credit-before-card,
+      double-spend prevention, expiry sweep, admin grant RBAC, single-user seam, tenant isolation.
+      (Tasks 1-8)

--- a/docs/superpowers/plans/2026-06-17-35-11-tenant-billing-dashboard-and-admin-billing-console-plan.md
+++ b/docs/superpowers/plans/2026-06-17-35-11-tenant-billing-dashboard-and-admin-billing-console-plan.md
@@ -1,0 +1,248 @@
+# Story 35-11 — Tenant Billing Dashboard & Admin Billing Console — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan phase-by-phase. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every phase writes tests
+> before implementation. Story file:
+> `docs/stories/epic-35/story-35-11/35-11-tenant-billing-dashboard-and-admin-billing-console.md`.
+
+**Goal:** Surface the entire Epic 35 billing domain in the two existing React dashboards —
+a tenant-facing Billing area in `packages/dashboard-user` (plan + BYOK/platform mode, usage split,
+invoices + PDF, payment method + portal, wallet, quota/dunning banners) and an admin Billing console
+in `packages/dashboard` (per-tenant subscription/MRR, catalog/webhook/reconciliation health, manual
+credit grant, suspend/reinstate) — plus the thin C# read endpoints needed to compose those screens.
+Re-targets the deprecated TypeScript Story 20-5 onto the current C# control-plane + React stack.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO billing business logic in React or in this story's endpoints.** Margin, proration, credit
+  application, dunning advancement, metering — all owned by Stories 35-1…35-10. This story only
+  projects/reads. New server code is read-composition only.
+- **NO re-implementation of operator actions.** Suspend/reinstate (35-8) and admin credit grant
+  (35-10) already have endpoints; the console calls them. We do not add new mutate paths for them.
+- **NO Stripe secret or PAN in the browser.** Card capture is Stripe Elements/portal; BYOK keys are
+  shown by cabinet handle only (Epic 29 reveal stays server-side).
+- **NO single-user billing.** Single-user mode hides Billing entirely via a server capability read —
+  no separate build, no `import.meta.env` flag.
+- **NO new DCB events.** Operator actions surface existing `BILLING.*` events; reads emit nothing.
+- **NO dependency on a live Stripe account for tests.** Stripe is reached only by the backend; tests
+  mock the service seam / endpoint responses.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### Dashboards (both exist; both are mounted in prod)
+
+- **Tenant dashboard** `packages/dashboard-user/` (TS/React, Vitest + jsdom; `vitest.config.ts`
+  includes `src/**/*.test.{ts,tsx}`, setup `src/test/setup.ts`).
+  - Router: `packages/dashboard-user/src/App.tsx` — `BrowserRouter`; authenticated routes nest under
+    `AuthGuard → AppLayout`; tenant-admin routes wrap children in `TenantAdminGuard`
+    (`/settings/alerts`, `/onboarding/platforms`, …). Add `/billing` here.
+  - API client: `packages/dashboard-user/src/api/client.ts` — `apiClient` singleton,
+    `credentials:'include'`, single-shot refresh-on-401, `VITE_API_URL` base. Reuse it.
+  - Existing tenant-scope client to mirror: `packages/dashboard-user/src/api/alerts.ts`
+    (DTOs + `/api/v1/orgs/{tenantId}/...` calls, no plaintext creds — exactly the posture billing needs).
+  - Guard: `packages/dashboard-user/src/guards/TenantAdminGuard.tsx` — `ADMIN_OR_HIGHER = {admin,owner}`,
+    fails closed; renders inline "Admin-only" for members. Auth: `hooks/useAuth.tsx` exposes
+    `AuthUser { id,email,displayName,tenantId?,role? }` from `/api/auth/me`.
+- **Admin dashboard** `packages/dashboard/` (TS/React, Vitest).
+  - Tab shell: `packages/dashboard/src/pages/admin/AdminLayout.tsx` — `type AdminTab = 'users' |
+    'tenants' | 'api-keys' | 'health' | 'links' | 'audit-log'`; `TABS` array; switch on `activeTab`.
+    Add `'billing'`.
+  - Router: `packages/dashboard/src/router.tsx` — admin routes behind `AdminGuard`
+    (`guards/AdminGuard.tsx`: `useCurrentUser().isAdmin`, redirects non-admins).
+  - Admin service-client convention: `packages/dashboard/src/services/admin/admin-api-client.ts`
+    (+ `admin-tenants-client.ts`, `prompts-api-client.ts`). Mirror for `billing-admin-client.ts`.
+
+### Backend (C# `apps/tamma-elsa`)
+
+- **Mode provider** `apps/tamma-elsa/src/Tamma.Api/Services/PromptStore/TammaMode.cs` — verified:
+  `ITammaModeProvider.Mode` (`TammaMode.SaaS | SingleUser`), process-wide singleton; `Resolve(...)`
+  pure helper for tests. This is the single source for the billing-enabled gate.
+- **Authorization policies** `apps/tamma-elsa/src/Tamma.Api/Program.cs` (~956-1082): `OwnerAccess`,
+  `PlatformOwnerAccess`, `MemberAccess`, `SettingsView/Manage`, `PromptManage`, etc. (verified).
+  Admin analytics routes use `OwnerAccess`. Use `MemberAccess` for tenant reads, `OwnerAccess` for
+  admin billing.
+- **Analytics precedent to mirror** `apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminAnalyticsEndpoints.cs`
+  (verified — NOT under `Endpoints/Admin/`; the spec path is wrong) + service interface
+  `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/IPlatformAnalyticsService.cs`. Cross-tenant
+  read-only sum/group projector — the exact shape `IBillingAdminReadService` should take.
+- **Tenant-scoped dashboard precedent** `apps/tamma-elsa/src/Tamma.Api/Endpoints/UserDashboardEndpoints.cs`
+  — `/api/v1/orgs/{tenantId:guid}/dashboard/*`, validated by `RequireTenantMembershipFilter` before the
+  handler; uses `ITenantDbContextFactory` for per-tenant reads. Pattern for any tenant-scoped read this
+  story adds (match whichever convention the sibling `/api/v1/billing/*` endpoints land on).
+- **Entities present today (verified):** `Plan.cs` (`Slug`, `DisplayName`, `MonthlyPriceUsd`, `Quotas`,
+  `PlacementPolicy`), `Tenant.cs`, `BudgetConfig.cs`, `ProviderDiagnostic.cs`. **Billing entities are
+  owned by siblings** (NEW in their stories, do not pre-create): `BillingUsageRollup` (35-3),
+  `BillingCustomer`/`BillingMode` (35-2), `BillingPaymentMethod` (35-7), `BillingInvoice`/`Line` (35-8),
+  `BillingWalletLedger` (35-10), subscription mirror (35-4).
+- **Endpoints dir** `apps/tamma-elsa/src/Tamma.Api/Endpoints/` — no `Billing/` subdir yet (siblings
+  create it). `Program.cs` maps endpoints explicitly with `.RequireAuthorization("<policy>")`.
+
+### Sibling-endpoint contract this UI consumes (from specs `/tmp/pab_stories/35-*.json`)
+
+| UI need | Endpoint | Story |
+|---|---|---|
+| plan + status | `GET /api/v1/billing/subscription` (or this story's composed read) | 35-4 |
+| mode toggle | `PUT /api/v1/billing/mode` (422 if BYOK key absent; member 403) | 35-2 |
+| usage split | `GET /api/v1/billing/usage` → `{platform tokens, byok tokens, platform_cost_usd, billable_usd, seats, period}` | 35-3 |
+| payment method | `GET /api/v1/billing/payment-methods`, `POST .../portal-session`, `POST .../payment-methods/setup-intent` | 35-7 |
+| invoices | `GET /api/v1/billing/invoices`, `GET .../invoices/{id}` (+ `pdf_url`/`hosted_invoice_url`) | 35-8 |
+| wallet | `GET /api/v1/billing/wallet`, `POST .../wallet/topup`, admin grant | 35-10 |
+| suspend/reinstate | 35-8 admin surface | 35-8 |
+
+DCB events surfaced (not emitted here): `BILLING.MODE.CHANGED` (35-2), `BILLING.USAGE.*` (35-3),
+`BILLING.PAYMENT_METHOD.*` (35-7), `BILLING.INVOICE.*`/`BILLING.PAYMENT.FAILED`/`BILLING.DUNNING.ESCALATED`/
+`BILLING.TENANT.SUSPENDED|REINSTATED` (35-8), `BILLING.CREDIT.GRANTED|CONSUMED|EXPIRED|REFUNDED` (35-10).
+All `AGGREGATE.ACTION.STATUS` with `{tenantId, ...}` JSONB tags.
+
+---
+
+## Phased task breakdown (test-first)
+
+### Phase 1 — Backend: capabilities + admin read composition (C#)
+
+**Goal:** the thin server reads the dashboards need that no sibling endpoint provides.
+
+- [ ] **1.1 Tests first** — `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingCapabilitiesEndpointsTests.cs`:
+  `GetCapabilities` returns `billingEnabled=true` for `TammaMode.SaaS` and `false` for `SingleUser`
+  (drive a fake `ITammaModeProvider`); `mode` string matches.
+- [ ] **1.2** `apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/BillingCapabilitiesEndpoints.cs` (NEW):
+  static `GetCapabilities(ITammaModeProvider)` → `{ billingEnabled, mode }`. No business logic.
+- [ ] **1.3 Tests first** — `BillingAdminReadServiceTests.cs`: seed a subscription mirror + `Plan` rows +
+  `BillingInvoice` rows + catalog/webhook/reconciliation state; assert `GetOverviewAsync` computes
+  `totalMrrUsd`/counts/per-tenant `mrrUsd`/`lifetimeRevenueUsd`/`currentPeriodRevenueUsd` by sum/group
+  ONLY (no writes), and `GetHealthAsync` projects catalog-sync/webhook/reconciliation. Limit clamped.
+  (Gate behind whichever sibling mirrors exist; stub missing mirrors with the merged entity types.)
+- [ ] **1.4** `IBillingAdminReadService` + `BillingAdminReadService`
+  (`apps/tamma-elsa/src/Tamma.Api/Services/Billing/`): read-only projector over 35-1/35-3/35-4/35-5/35-8
+  mirrors, mirroring `PlatformAnalyticsService` style. No mutation, no Stripe calls.
+- [ ] **1.5** `apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminBillingEndpoints.cs` (NEW):
+  `GET /api/v1/admin/billing/overview?limit=N`, `GET /api/v1/admin/billing/health` — both `OwnerAccess`,
+  delegate to the service (mirror `AdminAnalyticsEndpoints`).
+- [ ] **1.6** Subscription composed read — IF Story 35-4 already exposes `GET /api/v1/billing/subscription`,
+  skip; else add `BillingSubscriptionReadEndpoints.cs` (NEW, `MemberAccess`, tenant-scoped) projecting
+  subscription mirror + `Plan` + `BillingCustomer.BillingMode` + billing state. Projection only.
+- [ ] **1.7** Wire in `Program.cs` (map routes with `RequireAuthorization`) + register
+  `IBillingAdminReadService` in DI (extend `BillingServiceCollectionExtensions` if siblings created it,
+  else create it). Run `dotnet build` + targeted tests via `sg docker -c "dotnet test ..."`.
+
+### Phase 2 — Tenant dashboard: API client + capabilities gate + page shell
+
+- [ ] **2.1 Tests first** — `packages/dashboard-user/src/api/billing.test.ts`: client methods hit the right
+  paths/verbs, parse DTOs, propagate `ApiError`/`UnauthorizedError` from `apiClient`.
+- [ ] **2.2** `packages/dashboard-user/src/api/billing.ts` (NEW): typed DTOs (`SubscriptionDto`,
+  `UsageDto`, `InvoiceDto`, `InvoiceDetailDto`, `PaymentMethodDto`, `WalletDto`, `BillingCapabilitiesDto`)
+  + read/mutation wrappers over the 35-x endpoints, on `apiClient` (mirror `api/alerts.ts`).
+- [ ] **2.3 Tests first** — `useBillingCapabilities.test.ts(x)`: hook returns `{billingEnabled, mode, loading}`,
+  fetches `GET /api/v1/billing/capabilities` once, treats fetch error as `billingEnabled=false` (fail-safe hide).
+- [ ] **2.4** `packages/dashboard-user/src/hooks/useBillingCapabilities.ts` (NEW).
+- [ ] **2.5 Tests first** — `pages/billing/__tests__/BillingPage.test.tsx`: renders the tab shell; when
+  capabilities `billingEnabled=false`, renders nothing (single-user hide); lazy-loads non-Overview tabs.
+- [ ] **2.6** `pages/billing/BillingPage.tsx` (NEW): tab shell (Overview/Usage/Invoices/Payment/Wallet),
+  per-tab lazy fetch. Register `/billing` route + nav entry in `App.tsx` (read route open to members).
+
+### Phase 3 — Tenant dashboard: tabs + banners
+
+- [ ] **3.1 OverviewTab** (tests first): plan name + `BillingMode` toggle (`BillingModeToggle.tsx`);
+  toggle calls `PUT /api/v1/billing/mode`; happy path + 422 (BYOK key missing) + 403 (member) handled;
+  manage control hidden for members.
+- [ ] **3.2 UsageTab** (tests first): renders platform-vs-BYOK split exactly from mocked `GET .../usage`;
+  BYOK labelled "not billed for tokens"; manual refresh; "figures lag ≤ flush interval" note.
+- [ ] **3.3 InvoicesTab** (tests first): paged list; detail with base/overage/credit line split; PDF link
+  to mocked `pdf_url` (no bytes served by Tamma); empty state "No invoices yet".
+- [ ] **3.4 PaymentTab** (tests first): masked PM mirror (brand/last4/exp/default); "Open billing portal"
+  → redirect to mocked URL; "Add/replace card" via setup-intent client secret; empty "No payment method
+  on file"; manage controls hidden for members; assert no PAN/secret in DOM.
+- [ ] **3.5 WalletTab** (tests first): derived balance + paged ledger; "Top up" → `POST .../wallet/topup`;
+  empty state; manage hidden for members.
+- [ ] **3.6 Banners** (tests first): `QuotaBanner` shows at/over quota (35-6 state); `DunningBanner` shows
+  for `past_due`/`grace`/`suspended` with stage + retry count + next-retry, deep-links to Payment tab.
+- [ ] **3.7** Loading/empty/error states for every tab (skeleton/spinner, empty copy, retryable error).
+
+### Phase 4 — Admin dashboard: console tab + client + actions
+
+- [ ] **4.1 Tests first** — `services/admin/billing-admin-client.test.ts`: methods hit
+  `/api/v1/admin/billing/overview|health` + reuse 35-10 grant / 35-8 suspend-reinstate paths; parse DTOs.
+- [ ] **4.2** `packages/dashboard/src/services/admin/billing-admin-client.ts` (NEW), mirroring
+  `admin-api-client.ts`.
+- [ ] **4.3 Tests first** — `pages/admin/billing/__tests__/*`: `TenantRevenueTable` renders rows + total MRR
+  from mocked overview; `BillingHealthPanel` renders catalog/webhook/reconciliation incl. a drift warning;
+  `SuspendReinstateDialog` + `GrantCreditDialog` confirm → call client → optimistic update → re-fetch;
+  errors surface inline.
+- [ ] **4.4** Implement `BillingConsoleTab.tsx`, `TenantRevenueTable.tsx`, `BillingHealthPanel.tsx`,
+  `GrantCreditDialog.tsx`, `SuspendReinstateDialog.tsx`.
+- [ ] **4.5** Register the tab in `AdminLayout.tsx`: extend `AdminTab` union (`| 'billing'`), add to
+  `TABS`, render `{activeTab === 'billing' && <BillingConsoleTab />}`. (Shell already behind `AdminGuard`.)
+- [ ] **4.6 Single-user hide:** admin Billing tab absent when capabilities `billingEnabled=false`
+  (reuse capabilities read on the admin side, or the existing admin health/mode signal). Test it.
+
+### Phase 5 — Isolation, RBAC hardening, polish
+
+- [ ] **5.1** `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingDashboardIsolationTests.cs`:
+  tenant-A token never sees tenant-B subscription/invoice/wallet (cross-tenant → 404/empty); member → 403
+  on manage endpoints (35-2/35-7/35-10) at the composition layer; non-owner → 403 on `/api/v1/admin/billing/*`.
+  Stripe/provider clients mocked at the service seam.
+- [ ] **5.2** Frontend RBAC tests across both dashboards: member sees read-only (no manage controls in DOM);
+  admin/owner sees controls; non-admin blocked at admin route.
+- [ ] **5.3** No-secret-render assertions: grep-style DOM assertions that no BYOK key value, Stripe secret,
+  or PAN appears (only masked last4).
+- [ ] **5.4** Performance: confirm per-tab lazy fetch + paging; admin overview is one composed read (no N+1).
+- [ ] **5.5** Logging per the story's Logging Requirements (INFO/DEBUG/WARN/ERROR; never log keys/PAN/portal
+  URLs). Run full suites: `pnpm test --filter @tamma/dashboard-user`,
+  `pnpm test --filter @tamma/dashboard`, and `sg docker -c "dotnet test apps/tamma-elsa/..."`.
+
+---
+
+## Sequencing & dependencies
+
+```
+Phase 1 (backend reads) ─┬─► Phase 2 (tenant client + shell) ─► Phase 3 (tenant tabs)
+                         └─► Phase 4 (admin console)            ─► Phase 5 (isolation/RBAC/polish)
+```
+
+- **Hard external prerequisites:** Stories 35-2, 35-3, 35-4, 35-7, 35-8, 35-10 must have merged their
+  endpoints — this story's UI binds to their real contracts. **Before Phase 2**, confirm the merged
+  `/api/v1/billing/*` shapes and the tenant-scoping convention (caller-tenant vs `/orgs/{tenantId}`) and
+  reconcile the client + composed reads to match.
+- Phase 1 has no UI dependency and can start as soon as the sibling mirrors exist (it reads them).
+- Phases 3 and 4 are parallel-safe (different packages); Phase 5 depends on both.
+
+## Risks + mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Sibling endpoint shapes drift from this story's assumptions | High | Build the TS client against the **merged** contracts; reconcile DTOs in Phase 2 before tabs; isolate the contract in `api/billing.ts` so drift is one-file. |
+| Tenant-scoping convention mismatch (`/api/v1/billing/*` vs `/orgs/{tenantId}/...`) | Medium | Inspect the merged sibling billing endpoints first; match exactly; isolation test (5.1) catches leakage. |
+| Single-user accidentally exposes Billing | High | Server `capabilities` read is the single gate; fail-safe hide on fetch error; explicit hide tests in both dashboards (2.5, 4.6). |
+| Member sees/uses manage controls | High | Defence-in-depth: client guard (cosmetic) + server 403 (real); RBAC tests on both layers (5.1, 5.2). |
+| Secret/PAN leakage into the DOM | Critical | Stripe Elements/portal only; BYOK by cabinet handle; no-secret-render DOM assertions (5.3); never log keys/portal URLs. |
+| Adding business logic into the dashboard "for convenience" | Medium | Non-goal #1; new endpoints are read-projection only; code review checks for any math in React/new endpoints. |
+| Admin overview N+1 over tenants | Low | One composed sum/group read in `BillingAdminReadService` (mirrors `PlatformAnalyticsService`); perf check 5.4. |
+| Stripe needed in CI | Low | All tests mock the service seam / endpoint responses; no `STRIPE_SECRET_KEY` required. |
+
+## Acceptance criteria (mirror the story)
+
+- [ ] Tenant Billing area (`packages/dashboard-user/src/pages/billing/`) with Overview/Usage/Invoices/
+  Payment/Wallet, route + nav registered in `App.tsx`; Overview shows plan + `BillingMode` toggle (35-2).
+- [ ] Usage tab renders platform-vs-BYOK split from `GET /api/v1/billing/usage` (35-3), BYOK labelled
+  not-token-billed, with the flush-interval lag note.
+- [ ] Quota banner (35-6) and dunning banner (35-8 stage/retry/next-retry) render on the right states.
+- [ ] Payment tab: masked PM mirror (35-7), portal redirect, setup-intent add/replace — no PAN/secret in UI.
+- [ ] Invoices tab: paged list + detail line-split + Stripe-hosted PDF link (35-8); Tamma serves no bytes.
+- [ ] Wallet tab: derived balance + ledger + top-up (35-10).
+- [ ] Tenant RBAC: member read-only (no manage controls); owner/admin manage; backend 403 on manage.
+- [ ] Admin Billing console tab in `AdminLayout.tsx`: per-tenant subscription + MRR/revenue + total MRR
+  (OwnerAccess).
+- [ ] Admin catalog-sync (35-1) + webhook (35-5) + reconciliation (35-3) health panel.
+- [ ] Admin operator actions: manual credit grant (35-10) + suspend/reinstate (35-8), confirmed, OwnerAccess.
+- [ ] No frontend/new-endpoint billing business logic — projection only.
+- [ ] Single-user mode hides Billing in both dashboards via `GET /api/v1/billing/capabilities`
+  (`ITammaModeProvider`), no build flag.
+- [ ] Loading/empty/error states everywhere; p95 page load < 1s (lazy per-tab + paging).
+- [ ] No BYOK key value / Stripe secret / PAN ever rendered; BYOK by cabinet handle.
+- [ ] Vitest + Testing Library tests (both packages) + xUnit backend/isolation tests cover RBAC,
+  usage split, invoices, mode toggle, single-user hide, states, and admin suspend/grant against mocks.

--- a/docs/superpowers/plans/2026-06-17-35-12-billing-audit-reconciliation-and-revenue-analytics-plan.md
+++ b/docs/superpowers/plans/2026-06-17-35-12-billing-audit-reconciliation-and-revenue-analytics-plan.md
@@ -1,0 +1,401 @@
+# Story 35-12: Billing Audit, Reconciliation & Revenue Analytics — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation. Read
+> [BEFORE_YOU_CODE.md](../../guides/BEFORE_YOU_CODE.md) first.
+
+**Goal:** Make Epic 35 billing fully **auditable** and **operationally trustworthy**. Three
+deliverables, one integrity/reporting layer:
+
+1. A **billing audit timeline** — a read-side projection over the already-durable `BILLING.*`
+   `DomainEvent` stream, exposed per-tenant (tenant members) and platform-wide (`OwnerAccess`),
+   strictly **redacted** (whitelist, drop-by-default) so no card/PAN/secret/raw-payload ever
+   surfaces.
+2. A **daily reconciliation job** (`billing.reconcile` `PlatformQueuedTask`) that proves the four
+   local mirrors — subscription (35-4), invoice (35-8), usage rollup (35-3), wallet (35-10) — agree
+   with Stripe, emitting `BILLING.RECONCILIATION.DRIFT_DETECTED` on any mismatch and a per-run
+   `BILLING.RECONCILIATION.COMPLETED`.
+3. **Revenue analytics** (MRR/ARR, status counts, logo+revenue churn, BYOK-vs-platform split,
+   realized margin) computed on the existing `PlatformAnalyticsHourly` / `ComputePlatformRollupActivity`
+   substrate, snapshotted to a new `BillingRevenueDaily` table and served at
+   `GET /api/v1/admin/billing/metrics`.
+
+**Story file:** `docs/stories/epic-35/story-35-12/35-12-billing-audit-reconciliation-and-revenue-analytics.md`
+(15 acceptance criteria — this plan implements them in dependency order).
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane `Tamma.Api` +
+`Tamma.Activities` Elsa engine). Stripe.net (added by Story 35-1). Tests live in
+`apps/tamma-elsa/tests/Tamma.Api.Tests/` (xUnit; docker-bound suites run via
+`sg docker -c "dotnet test ..."`, build needs no wrapper). **`packages/api` is deleted — never
+reference it; all billing lives in the C# control plane.**
+
+---
+
+## Non-goals (YAGNI guard — honor the epic split)
+
+- **NO markup/pricing math.** Margin is `BillableAmountUsd − PlatformCostUsd` read straight off
+  35-3's `BillingUsageRollup` columns (already the output of 34-5's `IUsagePricingEngine`). MRR uses
+  35-1's `BillingPlanPrice`. If you multiply a cost by a margin here, you have crossed into 34-5.
+- **NO dashboard / React code.** Zero `packages/dashboard*` files. This story produces the
+  MRR/churn/margin numbers; Story 35-11's admin Billing console renders them. The `metrics`/`timeline`
+  endpoints are the contract between the two.
+- **NO second usage-meter reconciliation.** The usage mirror is reconciled by 35-3's
+  `billing.usage_reconcile` (→ `BILLING.USAGE.RECONCILIATION_MISMATCH`); this story **consumes** that
+  signal and folds it into the unified drift view. Do **not** call `Billing.Meters.ListEventSummaries`
+  again here — double Stripe load + two contradictory verdicts.
+- **NO Stripe *writes*.** Reconciliation is read-only against Stripe (`Subscriptions.List`,
+  `Invoices.List`, customer balance). It observes drift and raises an alert; remediation is an
+  operator decision (35-11 console) or a sibling handler — the integrity layer must not mask the bug
+  it surfaces.
+- **NO new billing write path on the hot path.** The audit timeline is a derive-on-read projection;
+  the revenue snapshot recomputes from mirrors (idempotent `(Day, TenantId)` upsert). A missed run
+  loses nothing; a replay overwrites.
+- **NO new mirror entities.** This story creates exactly one new entity, `BillingRevenueDaily`. It
+  reads `BillingCustomer`/`BillingPlanPrice` (35-1/35-2), `BillingSubscription` (35-4),
+  `BillingInvoice`/`BillingInvoiceLine`/`BillingDunningState` (35-8), `BillingUsageRollup` (35-3),
+  `BillingWalletLedger` (35-10) — read-only.
+- **NO new BackgroundService for the snapshot.** It rides the existing leader-locked
+  `HourlyAnalyticsRollupScheduler` cadence by extending `ComputePlatformRollupActivity.ComputeAsync`.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main)
+
+### Substrate this story extends (all real, all verified)
+
+| Seam | File | Shape relied on |
+|---|---|---|
+| DCB event store | `apps/tamma-elsa/src/Tamma.Data/Entities/DomainEvent.cs` | `Type`, `TenantId` (nullable), `Tags`/`Metadata`/`Data` (JSON strings), `CreatedAt`, `SequenceNumber` (long). The audit projection filters `Type LIKE 'BILLING.%'` and orders by `SequenceNumber DESC`. |
+| Event append | `apps/tamma-elsa/src/Tamma.Data/Repositories/IEventRepository.cs` | `AppendAsync(DomainEvent)` — CP `domain_events`; the same store `AlertRuleEvaluator` polls. |
+| Analytics fact | `apps/tamma-elsa/src/Tamma.Data/Entities/PlatformAnalyticsHourly.cs` | Dual **partial unique indexes** on `(Hour, TenantId)` — one `TenantId IS NULL`, one `IS NOT NULL` — the idempotency pattern `BillingRevenueDaily` copies for `(Day, TenantId)`. |
+| Rollup activity | `apps/tamma-elsa/src/Tamma.Activities/Analytics/ComputePlatformRollupActivity.cs` | `TammaAsyncActivity` with `RunAsync` + a **static `ComputeAsync(factory, publisher, hour, logger, ct)`** that writes the `TenantId = null` platform row. The daily revenue snapshot is a SaaS-gated tail step on this static path (testable without an Elsa context). |
+| Task queue | `apps/tamma-elsa/src/Tamma.Api/Services/PlatformTasks/IPlatformTaskHandler.cs` | `TaskType` (dot-snake-case) + `HandleAsync`. Throw `Exception` → retryable; throw `PlatformTaskTerminalException` → dead-letter. The reconciliation handler self-reschedules the next run, mirroring 35-3's `billing.meter_flush`. |
+| Alert built-ins | `apps/tamma-elsa/src/Tamma.Api/Services/Alerts/Rules/BuiltInAlertRules.cs` | Positional `record BuiltInAlertRuleSpec(BuiltInKey, Name, Description, Severity, EventType, Predicate, ThrottleSeconds)`. **5 built-ins today** (budget-exhausted, agent-dispatch-failed, workflow-retry-exceeded, platform-api-unhealthy, secret-rotation-failed). This story adds 3. |
+| Alert seeder | `apps/tamma-elsa/src/Tamma.Api/Services/Alerts/Rules/BuiltInAlertRuleSeeder.cs` | Idempotent insert-by-`built_in_key` — new specs are picked up automatically, no seeder edit. |
+| Alert evaluator | `apps/tamma-elsa/src/Tamma.Api/Services/Alerts/Rules/AlertRuleEvaluator.cs` | Polls `DomainEvents` + `PlatformEvents`; throttle keyed `(rule.Id, payload.TenantId)`; synthesizes feed from `TenantId` (null → platform/admin feed, set → tenant feed). Predicates supported: `always`, `count_gte`. The three new built-ins use exactly those. |
+| Admin analytics API | `apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminAnalyticsEndpoints.cs` | The real analytics endpoint file (**NOT** an `Endpoints/Admin/` sub-path). `metrics` + admin `timeline` mount here with `.RequireAuthorization("OwnerAccess")`. |
+| Mode source | `apps/tamma-elsa/src/Tamma.Api/Services/PromptStore/TammaMode.cs` | `ITammaModeProvider` (SingleUser | SaaS), process-stable. Single-user → handler/snapshot not registered, `NullBillingProvider` (35-1) → zero Stripe surface. |
+
+### Sibling mirrors this story reads (owned elsewhere — do not create or modify)
+
+`BillingCustomer` (tenant↔Stripe, `BillingMode`) + `BillingPlanPrice` (35-1/35-2);
+`BillingUsageRollup` (`PlatformCostUsd`, `BillableAmountUsd`) + `billing.usage_reconcile` (35-3);
+`BillingSubscription` (status/seats/plan/period) (35-4); `BillingWebhookEvent` + the `BILLING.*`
+emission seam (35-5); `BillingInvoice`/`BillingInvoiceLine`/`BillingDunningState` (35-8);
+`BillingWalletLedger` (35-10). **If a sibling mirror is not yet merged, that mirror's reconciliation
+check and its contribution to the revenue snapshot degrade gracefully (skipped + logged), so 35-12
+can land and be partially exercised before every sibling is in.**
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Principal for a billing timeline entry | the sole user (their instance, their feed) | the tenant (`BillingCustomer.TenantId`) / platform owner |
+| `billing.reconcile` handler | **not registered** (`NullBillingProvider`, no `BillingCustomer` rows) | registered; iterates `BillingCustomer` rows |
+| `BillingRevenueDaily` snapshot | not computed (no subs/customers) | computed daily in `ComputePlatformRollupActivity` |
+| `GET /api/v1/admin/billing/metrics` | zeroed/empty payload | revenue analytics over `BillingRevenueDaily` (`OwnerAccess`) |
+| `GET /api/v1/admin/billing/timeline` | sole-user feed (any `BILLING.*` events) | platform-wide, `OwnerAccess` |
+| `GET /api/v1/orgs/{id}/billing/timeline` | sole user / 404 if N/A (mirrors 35-3 seam) | tenant members; **own-tenant rows only** (`ITenantContext`, never a spoofable route param) |
+| Stripe calls | none | reconciliation **reads** only (never writes Stripe) |
+
+---
+
+## Architecture
+
+**Read-side, derive-don't-capture.** Two read services + one reconciliation handler + one revenue
+snapshot tail + three alert built-ins:
+
+```
+            BILLING.* DomainEvents (CP)  ────────────►  IBillingAuditService
+            (35-1/3/4/5/8/10 emit them)                 (redacted timeline projection)
+                                                            │
+                                                            ▼
+                                          GET /orgs/{id}/billing/timeline  (tenant members)
+                                          GET /admin/billing/timeline      (OwnerAccess)
+
+  sibling mirrors (read-only) ──► BillingMirrorReconciler ──► BillingReconciliationTaskHandler
+  (sub / invoice / usage / wallet)   (per-mirror compare)      "billing.reconcile" daily, self-rescheduled
+                                                            │
+                                            BILLING.RECONCILIATION.DRIFT_DETECTED  (tenant-scoped)
+                                            BILLING.RECONCILIATION.COMPLETED       (platform, per run)
+                                                            │
+                                                            ▼
+                                          BuiltInAlertRules (3 new) → AlertRuleEvaluator → IAlertSink
+
+  sibling mirrors (read-only) ──► IBillingRevenueService.ComputeDailySnapshotAsync
+  (sub price, usage cost/sell)        (MRR/ARR/churn/margin/BYOK-split, no markup math)
+                                                            │
+                                  ComputePlatformRollupActivity.ComputeAsync tail (SaaS only, daily)
+                                                            │
+                                            upsert BillingRevenueDaily  (Day, TenantId) idempotent
+                                                            │
+                                                            ▼
+                                          GET /admin/billing/metrics  (OwnerAccess, from snapshot)
+```
+
+**Redaction is a whitelist, not a denylist.** `BillingAuditService` projects only
+`{ amountUsd, currency, status, last4, invoiceId, stage }` from a `BILLING.*` event's `data` through
+a `private static readonly HashSet<string> _allowedSummaryKeys`. Anything else is dropped — so a
+sibling story that later puts a new sensitive field in a billing event cannot leak it through the
+audit surface without an explicit whitelist add. A redaction test injects `cardNumber`/`apiKey`/
+`rawPayload` and asserts they do not survive.
+
+**`tagGap` marker.** Where the projection sees a `BILLING.*` event missing a `tenantId`/
+`stripeCustomerId` tag that should be present (a sibling emission bug), it surfaces the row with
+`tagGap = true` and WARN-logs once — making a tagging regression visible to compliance export rather
+than silently dropping it.
+
+---
+
+## Task breakdown (TDD; tests before implementation in every task)
+
+### 35-12-T1: `BillingRevenueDaily` entity + EF config + additive migration
+
+**Scope:** The CP daily-revenue snapshot table only. No computation, no endpoint.
+
+**Files:**
+- New: `apps/tamma-elsa/src/Tamma.Data/Entities/BillingRevenueDaily.cs` — columns per the story's
+  entity sketch (`Day` UTC midnight, nullable `TenantId`, `MrrUsd`/`ArrUsd`, four status counts,
+  `LogoChurnCount`/`RevenueChurnUsd`, `ByokRevenueUsd`/`PlatformRevenueUsd`,
+  `PlatformUsageCostUsd`/`PlatformUsageMarginUsd`, `ComputedAt`).
+- Modify: `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` — `DbSet<BillingRevenueDaily>`.
+- Modify: `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs`
+  (`ConfigureControlPlaneEntities` — the established single source) — `gen_random_uuid()` default,
+  **two partial unique indexes** on `(Day)` `WHERE TenantId IS NULL` and `(Day, TenantId)`
+  `WHERE TenantId IS NOT NULL` (mirroring `PlatformAnalyticsHourly`), `HasPrecision(20,4)` on all
+  decimals.
+- New: `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_AddBillingRevenueDaily.cs` —
+  additive (`dotnet ef migrations add AddBillingRevenueDaily`). New table, no CHECK edits on
+  existing tables.
+
+**Tests (first):** entity round-trips through the CP context; the two partial unique indexes reject
+a duplicate `(Day, null)` and `(Day, tenantId)` respectively but allow the same `Day` across
+distinct tenants and one platform row.
+
+**Acceptance:**
+- [ ] `dotnet ef migrations has-pending-model-changes` reports **none** after generation.
+- [ ] Migration applies + rolls back cleanly; full suite stays green.
+
+### 35-12-T2: `IBillingAuditService` + redacted timeline projection
+
+**Scope:** The read-side projection over `BILLING.%` `DomainEvent` rows. No endpoints yet.
+
+**Files:**
+- New: `IBillingAuditService.cs`, `BillingAuditService.cs`, `BillingTimelineEntry.cs`
+  (DTO + `BillingTimelineFilter` + `BillingTimelinePage` records) in
+  `apps/tamma-elsa/src/Tamma.Api/Services/Billing/`.
+- The service exposes `GetTenantTimelineAsync(tenantId, filter, ct)` (hard-scoped
+  `TenantId == tenantId AND Type LIKE 'BILLING.%'`) and `GetPlatformTimelineAsync(filter, ct)`
+  (all tenants + `TenantId IS NULL` platform billing events), newest-first by `SequenceNumber DESC`,
+  cursor-paged (default 50, max 200), `eventType` prefix + `from`/`to` filters.
+- Redaction: `private static readonly HashSet<string> _allowedSummaryKeys`
+  (`amountUsd`, `currency`, `status`, `last4`, `invoiceId`, `stage`) — drop-by-default.
+- `tagGap` derivation: set when an expected `tenantId`/`stripeCustomerId` tag is absent.
+
+**Tests (first):** `BillingAuditServiceTests` — ordering (newest-first), cursor paging,
+`BILLING.` prefix filter, `from`/`to` window; **redaction whitelist** (injected
+`cardNumber`/`apiKey`/`rawPayload` key does NOT survive); `tagGap = true` for a
+`BILLING.INVOICE.PAID` missing its `tenantId` tag; tenant-scope query returns only the caller
+tenant's rows (cross-tenant isolation).
+
+**Acceptance:**
+- [ ] No non-whitelisted `data` key ever appears in a `BillingTimelineEntry.Summary`.
+- [ ] Tenant timeline never returns another tenant's or a platform-scoped event.
+
+### 35-12-T3: `BillingMirrorReconciler` + `BillingReconciliationTaskHandler` + drift events
+
+**Scope:** The daily cross-mirror reconciliation. Reads sibling mirrors, reads Stripe via 35-1's
+`IBillingProvider`, emits drift/completed events. Consumes 35-3's usage signal (does not re-run the
+meter check).
+
+**Files:**
+- New: `BillingMirrorReconciler.cs` — pure-ish per-mirror compare helpers (subscription / invoice /
+  usage / wallet), each returning a drift descriptor or none.
+- New: `BillingReconciliationTaskHandler.cs` (`IPlatformTaskHandler`, `TaskType => "billing.reconcile"`)
+  — iterates active `BillingCustomer` rows, runs the four checks each in its own try/catch
+  (**per-mirror + per-customer fail isolation**), emits `BILLING.RECONCILIATION.DRIFT_DETECTED`
+  (tenant-scoped) on mismatch + a single `BILLING.RECONCILIATION.COMPLETED` (platform, `TenantId = null`)
+  per run, self-reschedules the next run at `now + IntervalHours`.
+- New: `BillingReconciliationOptions.cs` (`Billing:Reconciliation:IntervalHours` default `24`,
+  `InvoiceToleranceUsd`, `WalletToleranceUsd`).
+- New: `BillingAuditEventTypes.cs` (`RECONCILIATION.*` DCB type constants).
+- **Usage mirror:** read the latest `BILLING.USAGE.RECONCILIATION_MISMATCH` events + the local
+  `BillingUsageRollup`; surface as `mirror = "usage"` — **no** `Billing.Meters.ListEventSummaries`
+  call here.
+- Defensive single-user guard in `HandleAsync` even though it is not registered in single-user mode.
+
+**Tests (first):** `BillingReconciliationTaskHandlerTests` — per-mirror drift (subscription status
+mismatch, invoice total beyond tolerance, usage drift consumed from 35-3 signal, wallet-balance
+mismatch) each emit one drift event with the correct `mirror` tag; clean pass emits zero drift +
+one `COMPLETED`; **per-mirror fail isolation** (a thrown Stripe error on the invoice mirror does not
+stop the others or the run); per-customer iteration never cross-tags; self-reschedule enqueues the
+next `billing.reconcile` task.
+
+**Acceptance:**
+- [ ] One drifting mirror → exactly one `DRIFT_DETECTED` with `tags.mirror` set + a WARN log.
+- [ ] One customer's Stripe error never aborts the run; `COMPLETED` carries the partial result.
+- [ ] No second Stripe meter-summary call for the usage mirror.
+
+### 35-12-T4: `IBillingRevenueService` + snapshot tail on `ComputePlatformRollupActivity`
+
+**Scope:** MRR/ARR/churn/margin/BYOK-split computation + idempotent daily snapshot. No new pricing.
+
+**Files:**
+- New: `IBillingRevenueService.cs`, `BillingRevenueService.cs` — `ComputeDailySnapshotAsync(day, ct)`
+  (the SQL + math, callable from unit tests without an Elsa context) and a windowed read
+  (`GetMetricsAsync(from, to, ct)` over `BillingRevenueDaily`).
+  - MRR = `Σ` over `BillingSubscription` in (`active`,`trialing`,`past_due`) of
+    `flatPlanFee + seats × perSeatPrice` (prices from 35-1 `BillingPlanPrice`; annual `/12`).
+    ARR = MRR × 12.
+  - BYOK-vs-platform split by `BillingCustomer.BillingMode` (`PlatformProvided` vs `Byok`).
+  - Margin = `Σ(BillableAmountUsd − PlatformCostUsd)` over `PlatformProvided` tenants;
+    `PlatformUsageCostUsd = Σ PlatformCostUsd`; usage revenue folds into `PlatformRevenueUsd`.
+  - Churn: `LogoChurnCount` = `BILLING.SUBSCRIPTION.CANCELED` events in `[day, day+1)`;
+    `RevenueChurnUsd` = the MRR those subs represented at cancellation.
+- Modify: `apps/tamma-elsa/src/Tamma.Activities/Analytics/ComputePlatformRollupActivity.cs` — a
+  **SaaS-gated, once-per-day (top-of-day hour)** tail step in the static `ComputeAsync` path calls
+  `IBillingRevenueService.ComputeDailySnapshotAsync` and upserts the `BillingRevenueDaily` platform
+  row. Fail-isolated so the hourly analytics rollup is never blocked by a snapshot error.
+
+**Tests (first):** `BillingRevenueServiceTests` — MRR from a seeded subscription set (seat × per-seat
++ flat fee, annual `/12`); ARR = MRR × 12; status counts; **BYOK-vs-platform split** (a `Byok`
+customer's seat fee lands in `ByokRevenueUsd` only; its usage contributes zero usage revenue);
+margin = `Σ(BillableAmountUsd − PlatformCostUsd)`; logo + revenue churn from `CANCELED` events;
+**idempotent upsert** (running twice = one row, same totals).
+
+**Acceptance:**
+- [ ] No markup multiplication anywhere — prices come from `BillingPlanPrice`, margin from rollup columns.
+- [ ] Replaying a day overwrites its single `(Day, null)` row (idempotent).
+- [ ] Snapshot failure is logged + isolated; the hourly analytics rollup still completes.
+
+### 35-12-T5: Endpoints — tenant timeline, admin timeline, admin metrics
+
+**Scope:** The three read endpoints; per-mode RBAC; the `metrics`-reconciles-to-invoices invariant.
+
+**Files:**
+- New: `apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/BillingTimelineEndpoints.cs` —
+  `GET /api/v1/orgs/{tenantId}/billing/timeline` (SaaS: `MemberAccess` + `RequireTenantMembershipFilter`;
+  single-user: sole user / 404 if N/A). Resolve `tenantId` from `ITenantContext`; reject a
+  route/context mismatch (no cross-tenant read).
+- Modify: `apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminAnalyticsEndpoints.cs` —
+  `GET /api/v1/admin/billing/timeline` (`OwnerAccess`, platform-wide via `GetPlatformTimelineAsync`)
+  and `GET /api/v1/admin/billing/metrics` (`OwnerAccess`, windowed `?from&to`, default current
+  calendar month, served from `BillingRevenueDaily` — no live fan-out). Note: billing routes use the
+  `/api/v1/...` epic-35 convention; legacy analytics routes stay `/api/admin/analytics/*`.
+
+**Tests (first):** `BillingTimelineEndpointTests` — tenant RBAC (member read OK; cross-tenant never
+returns another tenant's rows), admin timeline `OwnerAccess` + 403 tenant role, single-user seam.
+`BillingMetricsEndpointTests` — windowed snapshot for `OwnerAccess`; **403** tenant role;
+single-user → zeroed payload; the **`metrics`-reconciles-to-invoices invariant**
+(`platformRevenueUsd + byokRevenueUsd` ≈ `Σ BillingInvoice` totals for the window within tolerance)
+on a seeded mirror set.
+
+**Acceptance:**
+- [ ] Tenant timeline is hard-scoped to `ITenantContext` — no spoofable route param read.
+- [ ] `metrics` reconciles to the sum of per-tenant invoices within the documented tolerance.
+
+### 35-12-T6: Three billing alert built-ins
+
+**Scope:** Add three specs to `BuiltInAlertRules.All` (seeder picks them up automatically). No
+seeder/evaluator changes.
+
+**Files:** Modify `apps/tamma-elsa/src/Tamma.Api/Services/Alerts/Rules/BuiltInAlertRules.cs` —
+- `billing-reconciliation-drift` — `Warning`, `BILLING.RECONCILIATION.DRIFT_DETECTED`,
+  `{"op":"always"}`, `ThrottleSeconds: 3600`.
+- `billing-dunning-spike` — `Critical`, `BILLING.DUNNING.ESCALATED`,
+  `{"op":"count_gte","window_seconds":3600,"threshold":5}`, `ThrottleSeconds: 3600`.
+- `billing-meter-flush-backlog` — `Warning`, `BILLING.USAGE.FLUSH_FAILED`,
+  `{"op":"count_gte","window_seconds":1800,"threshold":10}`, `ThrottleSeconds: 1800`.
+
+All ship with empty `ChannelIds` per the existing convention (no auto-spam). The evaluator already
+synthesizes the feed from `TenantId` (tenant-scoped drift → tenant feed; platform → admin feed).
+
+**Tests (first):** `BillingAuditAlertRuleTests` — `BuiltInAlertRuleSeeder` creates the three rules;
+the evaluator fires on an appended `BILLING.RECONCILIATION.DRIFT_DETECTED` (tenant-scoped → tenant
+feed; platform → admin feed); the `count_gte` thresholds fire only over threshold and the throttle
+suppresses a burst.
+
+**Acceptance:**
+- [ ] Drift/dunning/backlog events produce alerts with no manual rule setup; built-ins have empty `ChannelIds`.
+
+### 35-12-T7: DI wiring + mode gating + single-user seam
+
+**Scope:** Register the audit/revenue services + reconciliation handler (SaaS only); map endpoints.
+
+**Files:**
+- New: `apps/tamma-elsa/src/Tamma.Api/Extensions/BillingAuditServiceCollectionExtensions.cs` —
+  `AddBillingAuditAndAnalytics()`: registers `IBillingAuditService`, `IBillingRevenueService`,
+  `BillingReconciliationOptions`, and (SaaS only) `AddPlatformTaskHandler<BillingReconciliationTaskHandler>()`.
+- Modify: `apps/tamma-elsa/src/Tamma.Api/Program.cs` — call the extension; map the tenant + admin
+  endpoints (SaaS-gated where applicable, mirroring 35-3/35-5 mode gating).
+
+**Tests (first):** `BillingAuditSingleUserSeamTests` — single-user mode registers no
+`billing.reconcile` handler, computes no snapshot, makes **zero** Stripe calls (`NullBillingProvider`);
+`GET /api/v1/admin/billing/metrics` returns a zeroed payload; the org timeline returns the sole-user
+feed / 404 per the 35-3 seam.
+
+**Acceptance:**
+- [ ] Single-user: no reconciliation handler, no snapshot, no Stripe surface.
+- [ ] SaaS: all surfaces mounted + tenant-scoped per T2/T5.
+
+---
+
+## Task order & dependencies
+
+```
+T1 (entity/migration) ──► T4 (revenue service/snapshot) ──► T5 (endpoints)
+                       └─► (T2, T3 independent of T1) ─────► T5
+T2 (audit projection) ─────────────────────────────────────► T5
+T3 (reconciliation) ──► T6 (alerts, needs T3's event types) ──► T7 (wiring)
+T6 ──────────────────────────────────────────────────────────► T7
+```
+
+T2 and T3 are independent of T1 and of each other (parallel-safe). T4 needs T1 (the snapshot table).
+T5 needs T2 + T4. T6 needs T3's event-type constants. T7 (wiring + single-user seam) is last and
+ties everything together. **Each sibling mirror is read-only and degrades gracefully if not yet
+merged**, so the wave can start the moment 35-1/35-5 are in and backfill reconciliation/revenue
+coverage as 35-3/35-4/35-8/35-10 land.
+
+---
+
+## Risks
+
+- **`PlatformTaskWorker:RunOnStartup` is `false` in prod today (tenancy residual).** The daily
+  reconciliation rides the CP task queue; enabling it in prod must coordinate with that gate — the
+  same hazard 35-3's `billing.meter_flush` flags. Note it in the rollout checklist; do not flip the
+  gate as part of this story.
+- **Sibling-mirror skew during the wave.** Tasks read 35-3/35-4/35-8/35-10 mirrors that may not all
+  be merged when 35-12 starts. The per-mirror reconciliation and per-mirror revenue contribution
+  must skip-and-log a missing mirror, not throw — so the integrity layer can ship and grow coverage.
+- **Redaction must be drop-by-default.** A denylist would leak the next sensitive field a sibling
+  adds. The whitelist test (`cardNumber`/`apiKey`/`rawPayload` injected) is load-bearing — keep it.
+- **Double-counting revenue.** Usage revenue contributes to `PlatformRevenueUsd` via
+  `BillableAmountUsd`; subscription seat/plan fees contribute separately. The
+  `metrics`-reconciles-to-invoices invariant test pins that the two paths sum to the invoice total —
+  if it breaks, suspect double-counting platform usage in both the rollup and an invoice line.
+- **Flapping drift re-alerts by design.** A mirror that drifts then clears re-fires; `ThrottleSeconds`
+  on the built-in + the sink rate limiter cap the noise. If flapping is observed in prod, a
+  reopen-cooldown is a cheap follow-up — out of scope here.
+- **Snapshot must never block the hourly rollup.** The `ComputePlatformRollupActivity` tail is
+  fail-isolated (try/catch + ERROR log); a revenue-snapshot bug must not stop
+  `PlatformAnalyticsHourly` from being written.
+- **Migration discipline.** `BillingRevenueDaily` is additive; still verify
+  `has-pending-model-changes` reports none and mirror the entity config in
+  `TammaModelConfiguration.cs` only (the established single source).
+
+## Verification before completion
+
+- [ ] `sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests"` green (unit + docker-bound).
+- [ ] `dotnet ef migrations has-pending-model-changes` → none.
+- [ ] No reference to `packages/api` anywhere in the diff (deleted package).
+- [ ] No `packages/dashboard*` files touched (35-11 owns the UI).
+- [ ] No markup/pricing multiplication, no second `Billing.Meters.ListEventSummaries` call.
+- [ ] Single-user mode: zero Stripe calls, zeroed `metrics`, no `billing.reconcile` handler registered.
+
+## Change Log
+
+| Date       | Version | Changes              | Author |
+| ---------- | ------- | -------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial plan         | Claude |

--- a/docs/superpowers/plans/2026-06-17-35-2-byok-vs-platform-provided-billing-mode-and-per-tenant-provid-plan.md
+++ b/docs/superpowers/plans/2026-06-17-35-2-byok-vs-platform-provided-billing-mode-and-per-tenant-provid-plan.md
@@ -1,0 +1,216 @@
+# Story 35-2 — BYOK vs Platform-Provided Billing Mode & Per-Tenant Provider Key Cabinet Integration
+
+> Implementation plan · Epic 35 (Billing & Payments, C#) · target `apps/tamma-elsa` · written 2026-06-17 · rev 1.1.0 (2026-06-17): scope-corrected — consume 32-3 keys + 34-3 mode; removed duplicate key resolver and parallel mode store · TDD (test-first) · est. 2-3 days
+
+> **For agentic workers:** REQUIRED SUB-SKILL — use `superpowers:subagent-driven-development`
+> (recommended) or `superpowers:executing-plans` to implement this plan phase-by-phase. Phases use
+> checkbox (`- [ ]`) tracking. Project is test-first: every phase writes failing tests before
+> implementation. Docker-bound suites run via `sg docker -c "dotnet test ..."`; the build itself
+> needs no wrapper.
+
+## Goal
+
+Make the BYOK decision **visible on the billing trail**. The mode is already decided by Story 34-3
+(`TenantProviderBilling`, the single source of truth) and the key already resolved by Story 32-3
+(`IProviderCredentialResolver`, `ProviderCredential.Source`). This story computes a canonical
+`billing_mode` token from those two inputs and tags every `LLM.CALL.*` DCB usage event with it (and
+stamps the existing `ProviderDiagnostic.BillingMode` column owned by 34-3) so Story 35-3 can split
+billable vs non-billable usage with a single column/tag filter — BYOK token usage excluded from
+billable metering, platform-provided usage metered + marked up.
+
+## Boundary (canonical — read first)
+
+- **Story 32-3** owns BYOK→platform provider-key resolution into the LLM call path via
+  `IProviderCredentialResolver` (`ProviderCredential { ApiKey, Source ∈ {Byok, Platform} }`,
+  namespace `Tamma.Api.Services.Providers`). 35-2 **consumes** `Source`; it does **not** read the
+  cabinet, resolve keys, or rewrite the proxy `x-api-key`.
+- **Story 34-3** owns the pricing-MODE per `(tenant, provider)` via `TenantProviderBilling` +
+  `IProviderKeyResolver`/`MetricBillingMode` (`Tamma.Api.Services.Pricing`), the BYOK enable/disable
+  endpoints, **and the `ProviderDiagnostic.BillingMode` column + migration**. 35-2 **reads** the mode
+  and **writes the column value** on the usage path; it owns no mode field, no mode endpoint, and no
+  diagnostic-column migration.
+
+## Non-goals (YAGNI guard)
+
+- **NOT a key-resolution story.** Provider-key resolution from the Epic 29 cabinet into the call path
+  is Story 32-3. This story reads no cabinet and handles no key plaintext. (Boundary.)
+- **NOT a mode-ownership story.** The per-(tenant,provider) mode source of truth is Story 34-3's
+  `TenantProviderBilling`. This story defines **no** `BillingMode` field of its own, **no**
+  `/api/v1/billing/mode` endpoint, and **no** `BILLING.MODE.CHANGED` event — mode changes are 34-3's
+  BYOK enable/disable endpoints.
+- **NO diagnostic-column ownership.** `ProviderDiagnostic.BillingMode` (column + migration) is Story
+  34-3's. This story only writes the value on the LLM-call usage path.
+- **NO multi-provider chain build-out.** `LlmProxyService` stays Anthropic-shaped; this story changes
+  only the *tagging* of usage, not the provider matrix (Epic 1/9 territory).
+- **NO metering / invoicing logic.** Producing the `billing_mode` signal is in scope; *consuming* it
+  to split billable usage is Story 35-3.
+- **NO single-user billing.** Single-user mode skips the markup/mode tagging — registration-time
+  Null seam, no runtime branching.
+- **NO CLI/token agent provider BYOK.** SaaS provider auth is API-key only; `ICLIAgentProvider` stays
+  single-user/self-hosted.
+- **NO new secret-handling primitives.** 35-2 never touches the cabinet; key plaintext lives only in
+  32-3's resolver.
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### What exists today
+
+| Component | Path | Notes |
+|---|---|---|
+| LLM proxy | `src/Tamma.Api/Services/SaaS/LlmProxyService.cs` | Records `ProviderDiagnostic` via `IDiagnosticsService.RecordEventAsync` (line ~213-237). **Emits no DCB `LLM.CALL.*` events** — this story adds those. The outbound key is resolved by **Story 32-3's** `IProviderCredentialResolver` (not this story). Budget check at ~58-68. |
+| LLM proxy contract | `src/Tamma.Api/Services/SaaS/ILlmProxyService.cs` | `ChatAsync(ChatRequest, Guid? tenantId, ct)` — tenant id already threaded. |
+| Diagnostic entity | `src/Tamma.Data/Entities/ProviderDiagnostic.cs` | Has `ProviderKey`, `Model`, `TenantId`, `InputTokens`/`OutputTokens`, `Cost`. The **`BillingMode` column is added by Story 34-3** — this story only writes its value on the usage path. |
+| **Mode source of truth (34-3)** | `src/Tamma.Api/Services/Pricing/` — `IProviderKeyResolver`/`ProviderKeyResolver` reading `TenantProviderBilling`; `ProviderKeyResolution(ApiKey, MetricBillingMode Mode, SecretName)` | **Story 34-3.** 35-2 reads `.Mode` for the tag. Do not duplicate. |
+| **Credential source (32-3)** | `src/Tamma.Api/Services/Providers/` — `IProviderCredentialResolver`; `ProviderCredential { ApiKey, Source ∈ {Byok, Platform} }` | **Story 32-3.** 35-2 reads `.Source` to reconcile the tag. Do not duplicate. |
+| DCB events | `src/Tamma.Data/Repositories/IEventRepository.cs` — `AppendAsync(DomainEvent)`; `src/Tamma.Data/Entities/DomainEvent.cs` (`Type`, `TenantId`, `Tags`, `Metadata`, `Data` JSONB strings) | CP-resident store the alert/metering evaluators poll. Emit pattern in `OrgEndpoints.cs` ~1043 (`new DomainEvent { Type, TenantId, Tags = JsonSerializer.Serialize(...), Data = ... }`). |
+| Mode (process) | `src/Tamma.Api/Services/PromptStore/TammaMode.cs` — `ITammaModeProvider.Mode` (`SingleUser`/`SaaS`), process-stable | Drives the Null-seam registration. |
+| Provider chain | `src/Tamma.Api/Services/Providers/ProviderChainResolver.cs` | Reads `agent_configs.config` chains; writes diagnostics on the chain path — needs the same `billing_mode` tag stamped. |
+| Tests | `tests/Tamma.Api.Tests/SaaS`, `tests/Tamma.Api.Tests/Providers` | New `Billing/` test folder. |
+
+> No reference is made to the deleted `packages/api`. All paths are under `apps/tamma-elsa/`.
+
+### What the prerequisite stories provide (hard blockers)
+
+- **Story 32-3** — `IProviderCredentialResolver` + `ProviderCredential.Source` (`byok|platform`). The
+  LLM call path's key resolution. 35-2 consumes `Source`.
+- **Story 34-3** — `TenantProviderBilling` (single source of truth for mode), `IProviderKeyResolver` /
+  `MetricBillingMode`, the BYOK enable/disable endpoints, and the `ProviderDiagnostic.BillingMode`
+  column + migration. 35-2 reads the mode and writes the column value.
+- **Story 35-1** — `IBillingProvider`/`NullBillingProvider`, the `src/Tamma.Api/Services/Billing/`
+  directory + the Null-seam registration pattern. **All `Services/Billing/*` paths assume that
+  directory already exists.** If 35-1 is not merged, stop and land it first.
+
+### Key gap this story closes
+
+Today's proxy writes diagnostics with no billing dimension and emits no usage DCB event, so there is
+no way to tell a BYOK call (no token markup) from a platform call (billable) off the trail. This plan
+adds (1) a `billing_mode` *tagger* that reads 34-3's mode and reconciles 32-3's credential source, and
+(2) the `LLM.CALL.*` DCB usage-event emission tagged with that token (plus stamping 34-3's existing
+diagnostic column). It adds **no** key resolver and **no** mode store.
+
+## Architecture
+
+```
+Mode change          ──► owned by Story 34-3 (POST/DELETE …/pricing/providers/{providerKey}/byok)
+                         writes TenantProviderBilling — NOT this story.
+
+Key resolution       ──► owned by Story 32-3 (IProviderCredentialResolver.ResolveAsync)
+                         returns ProviderCredential { ApiKey, Source } — NOT this story.
+
+LlmProxyService.ChatAsync (+ ProviderChainResolver path):
+   key  ◄── 32-3 IProviderCredentialResolver  (ApiKey + Source)        [consumed]
+   tag  ◄── IBillingModeTagger.ResolveTagAsync(tenantId, providerKey, source)   [this story]
+              ├─ read 34-3 IProviderKeyResolver → ProviderKeyResolution.Mode (byok|platform)
+              ├─ reconcile with 32-3 source: disagree ⇒ 32-3 wins + WARN + BILLING.MODE.MISMATCH
+              └─ validate token ∈ {byok, platform}
+   ──► ProviderDiagnostic.BillingMode = tag          (column owned by 34-3; this story writes value)
+   ──► IEventRepository.AppendAsync(LLM.CALL.SUCCESS|FAILED, Tags = { tenantId, billing_mode, provider, model })
+```
+
+Per-mode ownership (mandatory two-scoping answer): single-user ⇒ no billing dimension, `NullBillingModeTagger`,
+no billable-mode implication (34-3 yields platform for single-user). SaaS ⇒ tenant owns mode via 34-3's
+`TenantProviderBilling` (35-2 reads it); the key is 32-3's. Tenant isolation is inherited: 34-3's
+resolver reads only the calling tenant's row; the usage event/diagnostic is stamped with the call
+context's tenant id, never a client-supplied id.
+
+## Phased task breakdown (TDD)
+
+### Phase 1 — `IBillingModeTagger` + `BillingModeTagger` + tokens/events
+
+**Files:** `src/Tamma.Api/Services/Billing/IBillingModeTagger.cs` (contract),
+`BillingModeTagger.cs`, `BillingModeTokens.cs` (`byok`/`platform` constants),
+`BillingModeEvents.cs` (`LLM.CALL.SUCCESS`/`LLM.CALL.FAILED`/`BILLING.MODE.MISMATCH` constants).
+
+**Tests first:** `tests/Tamma.Api.Tests/Billing/BillingModeTaggerTests.cs` —
+(a) faked 34-3 `IProviderKeyResolver` mode `byok` ⇒ tag `byok`; (b) mode `platform` ⇒ `platform`;
+(c) 32-3 `credentialSource` supplied + agreeing ⇒ tag matches, **no** mismatch event;
+(d) 32-3 source disagrees with 34-3 ⇒ 32-3 wins + WARN + exactly one `BILLING.MODE.MISMATCH`;
+(e) resolved token not in `{byok,platform}` ⇒ ERROR (AC11).
+
+**Approach:** Inject 34-3's `IProviderKeyResolver`, `IEventRepository` (mismatch event), `ILogger`.
+`ResolveTagAsync(tenantId, providerKey, credentialSource?)` reads `ProviderKeyResolution.Mode`,
+reconciles against `credentialSource` (32-3), validates the token. **No cabinet, no key plaintext.**
+
+### Phase 2 — `NullBillingModeTagger` + DI extension + Program wiring
+
+**Files:** `src/Tamma.Api/Services/Billing/NullBillingModeTagger.cs`,
+`src/Tamma.Api/Extensions/BillingModeServiceCollectionExtensions.cs` (`AddBillingModeTagging()`),
+`Program.cs` (call `AddBillingModeTagging()`).
+
+**Tests first:** `tests/Tamma.Api.Tests/Billing/BillingModeTaggerTests.cs` (single-user case) —
+`ITammaModeProvider.Mode == SingleUser` ⇒ `NullBillingModeTagger` yields platform semantics, no
+billable-mode implication, no mismatch event.
+
+**Approach:** Extension registers `BillingModeTagger` in SaaS and `NullBillingModeTagger` in
+single-user (same Null-seam pattern as Story 35-1's `NullBillingProvider`); handlers never branch on
+mode. **No HTTP endpoint is mapped** — 35-2 exposes no mutating route.
+
+### Phase 3 — Wire `LlmProxyService` (tag diagnostic value + emit DCB usage events)
+
+**Files:** `src/Tamma.Api/Services/SaaS/LlmProxyService.cs` (inject `IBillingModeTagger` +
+`IEventRepository`); `src/Tamma.Api/Services/Providers/ProviderChainResolver.cs` (stamp same tag on
+the chain-path diagnostic); `Program.cs` (constructor DI). The outbound key is **already** resolved by
+Story 32-3's `IProviderCredentialResolver` — this story does not touch key resolution.
+
+**Tests first:** `tests/Tamma.Api.Tests/Billing/LlmProxyServiceBillingModeTests.cs` —
+(a) Byok call ⇒ `diag.BillingMode == "byok"` + `LLM.CALL.SUCCESS` tagged `billing_mode=byok`; the key
+comes from a faked **32-3** `IProviderCredentialResolver` (assert 35-2 resolves no key itself);
+(b) platform call ⇒ `"platform"`; (c) over-budget ⇒ `LLM.CALL.FAILED` with the same tag;
+(d) single-user ⇒ no billable-mode implication.
+Plus `tests/Tamma.Api.Tests/Billing/ProviderChainBillingModeTests.cs` — chain path stamps the same
+token; and `tests/Tamma.Api.Tests/Billing/BillingModeRedactionTests.cs` — capture logs + usage-event
+payloads; assert no key string ever appears (35-2 holds no plaintext).
+
+**Approach:** After the call (key from 32-3), call `_tagger.ResolveTagAsync(tenantId, providerKey,
+credentialSource)`; stamp `diag.BillingMode = token` (column owned by 34-3); append
+`LLM.CALL.SUCCESS|FAILED` with `Tags = { tenantId, billing_mode, provider, model }`. Keep budget
+check + error shape unchanged.
+
+### Phase 4 — Full-suite green + docs
+
+**Tests:** run `sg docker -c "dotnet test apps/tamma-elsa"` (Api.Tests at minimum). No migration is
+added by this story (the `ProviderDiagnostic.BillingMode` column is Story 34-3's); confirm
+`has-pending-model-changes` is clean — if it is not, the model change belongs to 34-3, not here.
+
+**Approach:** Fix any cross-cutting fallout (DI registration order, existing `LlmProxyServiceTests`
+needing the new ctor deps `IBillingModeTagger`/`IEventRepository`). Update Epic 35 status note if one
+exists.
+
+## Sequencing & dependencies
+
+```
+Phase 1 (tagger) ──► Phase 2 (Null seam + DI) ──► Phase 3 (proxy/chain wiring) ──► Phase 4 (suite green)
+```
+
+- **Hard prerequisites:** Story 32-3 (`IProviderCredentialResolver`), Story 34-3
+  (`TenantProviderBilling` mode + `ProviderDiagnostic.BillingMode` column), Story 35-1
+  (`Services/Billing` dir + Null-seam pattern). Block on all three.
+- Phases are sequential: the tagger (1) is registered (2) then consumed by the proxy/chain (3); suite
+  green (4) last.
+- **Feeds Story 35-3** (consumes the `billing_mode` tag + the populated diagnostic value).
+
+## Risks + mitigations
+
+| Risk | Sev | Mitigation |
+|---|---|---|
+| 35-2 accidentally reimplements key resolution or a mode store | High | Plan + story Boundary make 32-3 (keys) and 34-3 (mode + diagnostic column) the only owners; 35-2 has no cabinet dep and no mode endpoint; tests assert the key comes from the faked 32-3 resolver. |
+| 34-3 not merged ⇒ `TenantProviderBilling` / `ProviderDiagnostic.BillingMode` missing | High | Plan opens by checking 34-3 (and 32-3, 35-1) are merged; do not stub the entity or add the column here. |
+| 34-3 mode disagrees with 32-3 credential source at call time | Med | Reconcile: 32-3 source wins (it is the wire credential) + WARN + `BILLING.MODE.MISMATCH` event for audit; no silent mistag. |
+| Provider key plaintext leaks via 35-2 | Low | 35-2 never holds plaintext (32-3 owns it); `BillingModeRedactionTests` asserts no key in 35-2 logs/payloads. |
+| Diagnostic/event store topology shift (Story 28-1 / Epic 30 per-tenant events) | Med | `billing_mode` is a value on 34-3's existing column + a tag on tenant-scoped DCB events appended via the CP `IEventRepository` today — later re-routing leaves the value/tag unchanged. |
+| Existing `LlmProxyServiceTests` break on new ctor deps | Low | Phase 3/4 update the test fixtures with faked `IBillingModeTagger` + `IProviderCredentialResolver` (32-3) + `IEventRepository`. |
+| Spurious `has-pending-model-changes` because 34-3's column not yet applied | Low | This story adds no model change; if drift appears it belongs to 34-3 — land 34-3's migration first, do not generate one here. |
+
+## Acceptance criteria (mirror of the story)
+
+- [ ] `IBillingModeTagger` computes the `billing_mode` token by **reading** Story 34-3's mode (`IProviderKeyResolver`/`TenantProviderBilling`) and reconciling Story 32-3's `ProviderCredential.Source`; 35-2 defines no mode field and no mode-switch endpoint.
+- [ ] On 34-3 mode ≠ 32-3 source: 32-3 source wins for the tag, WARN logged, one `BILLING.MODE.MISMATCH` DCB event emitted.
+- [ ] Every `LLM.CALL.SUCCESS|FAILED` usage event is tagged `billing_mode` (`byok|platform`), `provider`, `model`, `tenantId`; the same token is written into 34-3's `ProviderDiagnostic.BillingMode` column (this story writes the value, does not own/migrate the column).
+- [ ] The LLM call path obtains its key from Story 32-3's `IProviderCredentialResolver` — 35-2 resolves no key, reads no cabinet, rewrites no `x-api-key`.
+- [ ] The usage DCB event emission is added by this story (none exists today) via tenant-scoped `IEventRepository.AppendAsync`.
+- [ ] `billing_mode` is read-only w.r.t. 34-3: 35-2 never writes `TenantProviderBilling` / `BillingCustomer.BillingMode` and exposes no mutating mode route; mode changes stay on 34-3's BYOK endpoints.
+- [ ] Token is constrained to `byok` or `platform`; any other value is a logged ERROR, not a silent tag.
+- [ ] No provider-key plaintext is read/logged/serialised by 35-2; redaction test asserts absence in 35-2 logs/payloads.
+- [ ] Single-user mode skips the billable-mode tagging (Null seam, no implication); SaaS provider auth is API-key only; CLI/token providers out of scope.
+- [ ] Unit tests: tagger mode reads + mismatch reconciliation, usage-event/diagnostic tagging, Byok call flagged non-billable-for-tokens, single-user no-op. Integration tests: tenant isolation of the tag, mode round-trip (34-3 enable/disable reflected on next call).
+- [ ] Full `dotnet test` suite green; this story adds no migration; `has-pending-model-changes` clean (any drift belongs to 34-3).

--- a/docs/superpowers/plans/2026-06-17-35-3-byok-aware-usage-metering-and-stripe-meter-event-reporting-plan.md
+++ b/docs/superpowers/plans/2026-06-17-35-3-byok-aware-usage-metering-and-stripe-meter-event-reporting-plan.md
@@ -1,0 +1,286 @@
+# Story 35-3 — BYOK-Aware Usage Metering & Stripe Meter Event Reporting (Implementation Plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan phase-by-phase. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every phase writes tests
+> before implementation. Story file: `docs/stories/epic-35/story-35-3/35-3-byok-aware-usage-metering-and-stripe-meter-event-reporting.md`.
+
+**Goal:** Turn the per-call usage facts already produced by 32-9 (cost basis) / 35-2 (`billing_mode`
+tag) and priced by 34-5 (`IUsagePricingEngine`) into billable usage. Platform-provided token usage
+is priced (cost basis × margin, from 34-5) and reported to Stripe Billing Meters
+(`tamma.platform_tokens_input/output`, customer-mapped via 35-1's `BillingCustomer`); BYOK token
+usage is recorded for analytics but **never** reported as billable tokens. Aggregate locally first
+(a CP `billing_usage_rollup`) for real-time reads + resilience, batch-flush meter events on the
+control-plane `PlatformTaskWorker`, and reconcile hourly against Stripe summaries.
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane API + Elsa engine);
+`Stripe.net` SDK (introduced by Story 35-1). Tests in `apps/tamma-elsa/tests/Tamma.Api.Tests/`
+(xUnit); docker-bound + Stripe integration suites run via `sg docker -c "dotnet test ..."`.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO markup/margin math.** `BillableAmountUsd` is whatever 34-5's `IUsagePricingEngine.PriceUsage`
+  returns. This story's `boundaryNote`: "does not own markup." If you multiply by a margin here,
+  stop.
+- **NO `BillingCustomer`, Stripe SDK registration, plan catalog, or meter creation.** All owned by
+  Story 35-1. This story consumes `IBillingProvider`, `BillingCustomer`, and the meter ids.
+- **NO `billing_mode` decision or tagging.** Story 35-2 owns `BillingCustomer.BillingMode` and the
+  `billing_mode` tag on `ProviderDiagnostic`/`LLM.CALL.*`. This story trusts the tag.
+- **NO new BackgroundService.** Flush + reconcile ride the existing `PlatformTaskWorker` via
+  `IPlatformTaskHandler` (Story 28-6), not a bespoke timer.
+- **NO billing dashboard UI, invoicing, or dunning.** Later Epic 35 stories; this story stops at
+  `GET /api/v1/billing/usage` + the metering pipeline.
+- **NO single-user billing.** Single-user mode registers no handlers, makes no Stripe calls, and the
+  usage endpoint is absent (mirrors 35-1's `NullBillingProvider`).
+- **NO capture-on-call hook in `LlmProxyService`.** Rollups are *derived* from durable facts, so the
+  LLM hot path is untouched and metering is automatically fail-open.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### Facts the rollup will read
+
+| Source | Where | Shape |
+|---|---|---|
+| `ProviderDiagnostic` | `src/Tamma.Data/Entities/ProviderDiagnostic.cs` | Per-call: `InputTokens`, `OutputTokens`, `Cost` (decimal), `TenantId?`, `Model`, `ProviderKey`, `AgentType`, `CreatedAt`. **Per-tenant DB** (Story 28-1 PR D) — NOT directly queryable from a CP worker without fan-out. 35-2 adds the `billing_mode` tag here. |
+| `PlatformAnalyticsHourly` | `src/Tamma.Data/Entities/PlatformAnalyticsHourly.cs` | **CP-resident** hourly fact: `Hour`, `TenantId?`, `TokensIn`, `TokensOut` (long), `CostUsd` (decimal 20,4). Per-tenant rows (`TenantId` non-null) + a cross-tenant row (`TenantId` null). Populated by Elsa `HourlyAnalyticsRollupWorkflow` → `ComputeTenantRollupActivity`. **Today it does NOT split tokens by `billing_mode`** — this is the single cross-epic gap (see Phase 1). |
+| Priced `LLM.CALL.SUCCESS` DCB events | `IEventRepository` (`src/Tamma.Data/Repositories/EventRepository.cs`, iface `IEventRepository.cs`) | Carry `billingMode`, `costBasisUsd`, `sellPriceUsd` (32-9/34-5). Tenant-scoped; CP read for tenant-less is the platform-events union. Fallback source if `PlatformAnalyticsHourly` split lands later. |
+
+**Decision:** the rollup is **CP-resident** and aggregates the **CP** `PlatformAnalyticsHourly`
+table (extended with a `billing_mode` split), so the flush/reconcile workers never fan out to tenant
+DBs. `DiagnosticsService.GetReportAsync` (`src/Tamma.Api/Services/Diagnostics/DiagnosticsService.cs`
+~113-163) already demonstrates a CP-resident cross-tenant rollup over `ProviderDiagnostic` via raw
+SQL — but the doc-comment there (~86-112) warns `ProviderDiagnostic` moves off CP in PR D, so we do
+NOT depend on that path; `PlatformAnalyticsHourly` is the durable CP source.
+
+### Pipeline infrastructure (reuse, do not rebuild)
+
+- **Task queue:** `PlatformQueuedTask` entity (`src/Tamma.Data/Entities/PlatformQueuedTask.cs`,
+  DbSet at `ControlPlaneDbContext.cs:78`) + `IPlatformTaskHandler`
+  (`src/Tamma.Api/Services/PlatformTasks/IPlatformTaskHandler.cs`) +
+  `PlatformTaskWorker : BackgroundService` (`PlatformTaskWorker.cs`). `ProcessOnceAsync` is the
+  testable drive-once entry; retry/dead-letter/reaper already implemented.
+  ⚠ `PlatformTaskWorkerOptions.RunOnStartup` defaults `false` and the XML doc
+  (`PlatformTaskWorker.cs:40-75`) warns it MUST NOT be enabled in prod until type-aware reservation
+  exists, because `ReserveNextAsync` claims the oldest pending row of **any** type (would
+  dead-letter `RETIRE_SECRET_VERSION` etc.). See `.dev/findings/platform-task-worker-runonstartup-hazard.md`.
+- **DCB events:** `IEventRepository.AppendAsync(DomainEvent)` (`EventRepository.cs:53`);
+  `DomainEvent` = `{ Type, TenantId?, Tags (json), Metadata (json), Data (json), CreatedAt,
+  SequenceNumber }` (`src/Tamma.Data/Entities/DomainEvent.cs`). Tenant-scope events carry
+  `TenantId`; tenant-less events route to `platform_events` automatically.
+- **Alerts:** `IAlertSink.RaiseAsync(AlertPayload)` (`src/Tamma.Api/Services/Alerts/IAlertSink.cs`);
+  `AlertRuleEvaluator` (`Services/Alerts/Rules/AlertRuleEvaluator.cs`) polls `DomainEvents` and would
+  pick up a future `config-missing`-style built-in rule on `BILLING.USAGE.RECONCILIATION_MISMATCH`
+  (rule seeding is out of scope; the event + `IAlertSink` call is in scope).
+- **EF model config:** entities are configured in `src/Tamma.Data/TammaModelConfiguration.cs` (single
+  source of truth); DbSets exposed on `src/Tamma.Data/ControlPlaneDbContext.cs`. Migrations under
+  `src/Tamma.Data/Migrations/ControlPlane/` (baseline `20260609205701_InitialControlPlane`).
+- **Mode seam:** `ITammaModeProvider` (`src/Tamma.Api/Services/PromptStore/TammaMode.cs`) — process-
+  stable SingleUser | SaaS.
+- **Auth policies** (`src/Tamma.Api/Program.cs:966-1118`): `MemberAccess` (any authenticated tenant
+  member), `OwnerAccess`, `PlatformOwnerAccess` (platform admin). Tenant-scope reads use
+  `MemberAccess`; the caller's tenant comes from `ITenantContext` (ambient), never a route param.
+- **Endpoint pattern:** `src/Tamma.Api/Endpoints/AlertEndpoints.cs` — static methods, `IResult`
+  returns, `ControlPlaneDbContext` injected, paging defaults (50/500). Mirror for
+  `BillingUsageEndpoints`.
+
+### Dependency seams this story consumes (must exist first)
+
+- **35-1:** `src/Tamma.Api/Services/Billing/IBillingProvider.cs` + `StripeBillingProvider.cs`,
+  `BillingCustomer` entity (tenant→`StripeCustomerId`, `BillingMode`), `BillingPlanPrice`/catalog
+  (meter ids), `NullBillingProvider` single-user seam. **`Services/Billing/` does not exist yet** —
+  35-1 creates it; this story adds to it.
+- **35-2:** `BillingCustomer.BillingMode`; `billing_mode` tag on facts; `BillingModeService`.
+- **34-5:** `src/Tamma.Api/Services/Pricing/UsagePricingEngine.cs` implementing `IUsagePricingEngine`
+  (`PriceUsage` → `{ costBasisUsd, marginUsd, sellPriceUsd, pricingMode }`; BYOK token component 0).
+- **32-9:** producer of per-call usage + cost-basis events.
+
+---
+
+## Phased task breakdown (test-first / TDD)
+
+### Phase 0 — Prerequisite confirmation (no code)
+
+- [ ] Confirm Stories 35-1, 35-2, 34-5 are merged: `IBillingProvider`, `BillingCustomer`,
+      `IUsagePricingEngine`, and the `billing_mode` tag all exist. If any is absent, block this
+      story (it is a pure consumer).
+- [ ] Decide the `PlatformAnalyticsHourly` `billing_mode` split route (Phase 1) vs the
+      `LLM.CALL.SUCCESS`-events fallback. Confirm with the Epic 5/23/28-10 owner whether adding
+      `PlatformTokensIn/Out` + `ByokTokensIn/Out` columns to `PlatformAnalyticsHourly` (populated by
+      `ComputeTenantRollupActivity`) belongs in this story or theirs.
+
+### Phase 1 — Source-fact billing_mode split (coordinate; may be a dependency PR)
+
+**Approach:** extend the CP fact so platform vs BYOK tokens are separable without a per-tenant scan.
+
+- [ ] **Test first:** `ComputeTenantRollupActivityTests` (in `Tamma.Activities.Tests`) — a tenant
+      with mixed platform+BYOK `LLM.CALL.SUCCESS` events in an hour produces a `PlatformAnalyticsHourly`
+      row with correct `PlatformTokensIn/Out` and `ByokTokensIn/Out`.
+- [ ] Files: `src/Tamma.Data/Entities/PlatformAnalyticsHourly.cs` (+4 long columns),
+      `TammaModelConfiguration.cs` (config), additive migration; the `ComputeTenantRollupActivity`
+      (in `Tamma.Activities`) populates the split from the `billing_mode` tag.
+- [ ] **If this lands in the analytics epic instead:** implement the Phase-2 aggregation against the
+      priced `LLM.CALL.SUCCESS` events via `IEventRepository` (CP read) as the fallback source and
+      skip this phase. Document which path was taken in the story Dev Notes.
+
+### Phase 2 — `BillingUsageRollup` entity + EF migration
+
+- [ ] **Test first:** `BillingUsageRollupModelTests` / use an EF in-memory or Postgres test fixture —
+      insert two rows for the same `(TenantId, PeriodStart)` → unique-index violation; precision on
+      `PlatformCostUsd`/`BillableAmountUsd` is 20,4.
+- [ ] Files: `src/Tamma.Data/Entities/BillingUsageRollup.cs`,
+      `src/Tamma.Data/Entities/BillingMeterEventBuffer.cs`; DbSets on `ControlPlaneDbContext.cs`;
+      config + indexes in `TammaModelConfiguration.cs` (unique `(tenant_id, period_start)`; unique
+      `idempotency_key`; partial index `reported_to_stripe = false`).
+- [ ] Generate additive migration: `dotnet ef migrations add AddBillingUsageRollup` under
+      `Migrations/ControlPlane/`; then `dotnet ef migrations has-pending-model-changes` → expect none.
+- [ ] Verify migration applies + rolls back cleanly against a throwaway Postgres
+      (`sg docker -c "dotnet test ..."` fixture).
+
+### Phase 3 — `UsageMeteringService` (rollup upsert + current-period read + buffer writes)
+
+- [ ] **Test first:** `UsageMeteringServiceTests` (`tests/Tamma.Api.Tests/Billing/`) — mock
+      `IUsagePricingEngine`, `IBillingProvider` (for `BillingCustomer` lookup), `IEventRepository`:
+  - platform-vs-BYOK split: BYOK tokens land in `Byok*`, never buffered as meter events;
+  - `BillableAmountUsd` equals the summed mocked `PriceUsage(...)` (no margin arithmetic in the service);
+  - `UpsertRollupAsync` idempotent (run twice → one row, identical totals, watermark advances);
+  - missing `billing_mode` → treated as `platform` + WARN;
+  - exception in fact-read → logged + swallowed (fail-open), no throw;
+  - `GetCurrentUsageAsync` maps the rollup row → `UsageSummaryDto`;
+  - no `BillingCustomer` (single-user / unprovisioned) → no-op.
+- [ ] Files: `src/Tamma.Api/Services/Billing/IUsageMeteringService.cs`, `UsageMeteringService.cs`,
+      `BillingUsageOptions.cs` (`MeterFlushIntervalSeconds=60`, `ReconcileIntervalMinutes=60`,
+      `DriftToleranceUsd`), `BillingMeterEventTypes.cs` (`BILLING.USAGE.RECORDED`,
+      `BILLING.USAGE.FLUSH_FAILED`, `BILLING.USAGE.RECONCILIATION_MISMATCH`).
+- [ ] `UpsertRollupAsync`: resolve `BillingCustomer` → aggregate period facts split by `billing_mode`
+      → call `IUsagePricingEngine.PriceUsage` for platform lines → upsert row → append
+      `BILLING.USAGE.RECORDED` → swallow on error.
+- [ ] `BufferMeterEventsAsync`: write `BillingMeterEventBuffer` rows for platform token totals only
+      (idempotency key `{tenantId}:{period}:{eventName}:{watermark}`).
+
+### Phase 4 — `MeterEventFlushTaskHandler : IPlatformTaskHandler`
+
+- [ ] **Test first:** `MeterEventFlushTaskHandlerTests` — mock `IBillingProvider`:
+  - pending buffer rows flushed; success sets `ReportedToStripe=true` + `StripeEventId`;
+  - failure leaves row pending, bumps `AttemptCount`, emits `BILLING.USAGE.FLUSH_FAILED`, does not throw past the handler contract;
+  - idempotency key prevents double-billing on retry;
+  - empty buffer → no-op;
+  - malformed batch → `PlatformTaskTerminalException`.
+- [ ] Files: `src/Tamma.Api/Services/Billing/MeterEventFlushTaskHandler.cs` (`TaskType =>
+      "billing.meter_flush"`). Self-reschedule: on completion enqueue the next `billing.meter_flush`
+      `PlatformQueuedTask` with a delay of `MeterFlushIntervalSeconds`.
+- [ ] Drive via `PlatformTaskWorker.ProcessOnceAsync` in an integration-ish test to prove the
+      handler is resolved by `IPlatformTaskHandlerRegistry`.
+
+### Phase 5 — `UsageReconciliationTaskHandler : IPlatformTaskHandler`
+
+- [ ] **Test first:** `UsageReconciliationTaskHandlerTests` — mock `IBillingProvider`
+      (`ListEventSummaries`) + `IAlertSink`:
+  - matching local/Stripe totals → no event, no alert;
+  - drift > `DriftToleranceUsd` → `BILLING.USAGE.RECONCILIATION_MISMATCH` appended + `IAlertSink.RaiseAsync` called once (TenantId set);
+  - iterates every active `BillingCustomer`; one customer's failure doesn't abort the rest.
+- [ ] Files: `src/Tamma.Api/Services/Billing/UsageReconciliationTaskHandler.cs` (`TaskType =>
+      "billing.usage_reconcile"`); hourly self-reschedule.
+
+### Phase 6 — `GET /api/v1/billing/usage` endpoint
+
+- [ ] **Test first:** `BillingUsageEndpointsTests` — returns caller-tenant `UsageSummaryDto`;
+      **tenant isolation**: tenant A cannot read tenant B (ambient `ITenantContext`, no route param);
+      single-user mode → endpoint absent/404; `MemberAccess` allows any tenant member, unauthenticated
+      → 401.
+- [ ] Files: `src/Tamma.Api/Endpoints/Billing/BillingUsageEndpoints.cs` (static, mirror
+      `AlertEndpoints.cs`); `UsageSummaryDto` record.
+
+### Phase 7 — DI wiring + mode gating
+
+- [ ] **Test first:** `BillingModeSeamTests` — single-user mode registers no flush/reconcile handlers
+      and makes zero Stripe calls; SaaS mode registers both handlers + maps the endpoint.
+- [ ] Files: `src/Tamma.Api/Extensions/BillingUsageServiceCollectionExtensions.cs`
+      (`AddBillingUsageMetering(this IServiceCollection, IConfiguration)` — register
+      `IUsageMeteringService`, the two `IPlatformTaskHandler`s via
+      `AddPlatformTaskHandler<...>()`, bind `BillingUsageOptions`; gate the handler registration on
+      `ITammaModeProvider == SaaS`). Wire in `Program.cs` and map the endpoint (SaaS only), mirroring
+      the alert/`AddPlatformTaskHandler` registration pattern.
+- [ ] ⚠ Do NOT flip `PlatformTaskWorker:RunOnStartup` to true in prod as part of this story — call
+      out the prod-enablement coordination in the PR description (see Risks).
+
+### Phase 8 — Integration tests (Stripe test key)
+
+- [ ] `tests/Tamma.Api.IntegrationTests` (or docker-bound suite): gated on `STRIPE_SECRET_KEY_TEST`.
+      Buffer + flush real `tamma.platform_tokens_input/output` events to a Stripe test customer; after
+      Stripe's processing delay, `ListEventSummaries` returns matching values; reconciliation reports
+      no drift; rollup aggregation against a seeded mixed platform+BYOK fact set yields the correct
+      split.
+- [ ] Run full suite: `sg docker -c "dotnet test apps/tamma-elsa/Tamma.sln"`; expect green.
+
+---
+
+## Sequencing & dependencies
+
+```
+Phase 0 (confirm 35-1/35-2/34-5 merged)
+  → Phase 1 (billing_mode split on PlatformAnalyticsHourly — or fallback to events)
+  → Phase 2 (BillingUsageRollup + buffer entities + migration)
+  → Phase 3 (UsageMeteringService)
+  → Phase 4 (flush handler) ─┐
+  → Phase 5 (reconcile handler) ─┤ (4 and 5 parallel-safe after 3)
+  → Phase 6 (usage endpoint)   ─┘
+  → Phase 7 (DI + mode gating)  → Phase 8 (Stripe integration tests)
+```
+
+Hard prerequisites: 35-1, 35-2, 34-5 merged (Phase 0). Phase 2 blocks everything after it. Phases 4,
+5, 6 only need Phase 3. The Phase-1 fact split is the one cross-epic coordination point — resolve its
+ownership before starting.
+
+## Risks + mitigations
+
+- **`PlatformAnalyticsHourly` has no `billing_mode` split (the real gap).** Mitigation: Phase 1 adds
+  it, or fall back to aggregating priced `LLM.CALL.SUCCESS` events via `IEventRepository`. Pin the
+  decision in Phase 0; the rollup design supports either source behind `UsageMeteringService`.
+- **`PlatformTaskWorker:RunOnStartup` is `false` in prod (hazard).** Enabling billing handlers in
+  prod requires either type-aware reservation or handlers for every producer type
+  (`PlatformTaskWorker.cs:40-75`). Mitigation: this story registers the handlers but does NOT enable
+  the worker in prod; flag the prod-enablement as a separate ops step; consider a dedicated
+  billing-scoped worker if type-aware reservation isn't ready.
+- **Double-billing on flush retry.** Mitigation: every meter event carries a deterministic
+  idempotency key (`{tenantId}:{period}:{eventName}:{watermark}`); Stripe dedups on `identifier`, and
+  `ReportedToStripe` gates re-buffering.
+- **Re-implementing markup (boundary violation).** Mitigation: `BillableAmountUsd` is *only* ever
+  the sum of `IUsagePricingEngine.PriceUsage` results; a unit test asserts the service performs no
+  margin arithmetic (mock returns a sentinel sell price, service must echo it).
+- **BYOK leaking into token meters (revenue/compliance bug).** Mitigation: BYOK lines never reach
+  `BufferMeterEventsAsync`; a dedicated test asserts the buffer contains zero `byok` rows.
+- **CP/per-tenant topology drift (Story 28-1 / Epic 30).** Mitigation: rollup + buffer + events are
+  CP-resident by design (sourced from CP `PlatformAnalyticsHourly`), so the metering workers never
+  fan out to tenant DBs; `BILLING.USAGE.*` events append via the CP `IEventRepository` path the
+  `AlertRuleEvaluator` already polls.
+- **Stripe summary lag causing false reconciliation mismatches.** Mitigation: reconciliation tolerance
+  (`DriftToleranceUsd`) + WARN (not ERROR); the API never reads Stripe (always the local rollup).
+- **Migration discipline.** `billing_usage_rollup`/`billing_meter_event_buffer` are additive (new
+  tables), but still run `has-pending-model-changes` after the migration and mirror config in
+  `TammaModelConfiguration.cs` only (single source).
+
+## Acceptance criteria (mirror the story)
+
+- [ ] `BillingUsageRollup` CP entity aggregates per-tenant-per-period platform/BYOK token split,
+      `PlatformCostUsd`, `BillableAmountUsd`, `Seats`; idempotent on `(TenantId, PeriodStart)`.
+- [ ] Only `billing_mode = platform` usage becomes `tamma.platform_tokens_input/output` meter events;
+      BYOK increments counters and is explicitly skipped.
+- [ ] `BillableAmountUsd` comes entirely from 34-5's `IUsagePricingEngine`; no margin math in this
+      story's services.
+- [ ] Meter events buffered + flushed via `MeterEventFlushTaskHandler` (`IPlatformTaskHandler`,
+      default 60s, configurable); failed flushes persist `reported_to_stripe = false` and retry; emit
+      `BILLING.USAGE.FLUSH_FAILED`.
+- [ ] `GET /api/v1/billing/usage` returns the caller-tenant current-period summary from the local
+      rollup; tenant-isolated; single-user → absent/404.
+- [ ] Hourly `UsageReconciliationTaskHandler` compares local vs Stripe summaries and emits
+      `BILLING.USAGE.RECONCILIATION_MISMATCH` (+ alert) on drift.
+- [ ] DCB events `BILLING.USAGE.RECORDED` / `FLUSH_FAILED` / `RECONCILIATION_MISMATCH` emitted via
+      `IEventRepository`; metering is fail-open (never blocks the LLM call path).
+- [ ] Single-user mode registers no handlers, makes no Stripe calls (`NullBillingProvider` seam).
+- [ ] Unit + integration tests (`STRIPE_SECRET_KEY_TEST`) cover platform-vs-BYOK split, billable
+      delegation, flush success/failure/retry, rollup idempotency, reconciliation drift, tenant
+      isolation, and the single-user no-op seam; full suite green.

--- a/docs/superpowers/plans/2026-06-17-35-4-subscription-lifecycle-create-upgrade-downgrade-cancel-trial-plan.md
+++ b/docs/superpowers/plans/2026-06-17-35-4-subscription-lifecycle-create-upgrade-downgrade-cancel-trial-plan.md
@@ -1,0 +1,344 @@
+# Story 35-4 — Subscription Lifecycle (Create, Upgrade/Downgrade, Cancel, Trial & Proration)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation. Story file:
+> `docs/stories/epic-35/story-35-4/35-4-subscription-lifecycle-create-upgrade-downgrade-cancel-trial.md`.
+
+**Goal:** Implement the full Stripe subscription lifecycle for SaaS tenants on the C# control
+plane — Checkout-based subscribe, upgrade (immediate proration) / downgrade (scheduled at period
+end), cancel (immediate or at-period-end), trial start/convert/expire, and seat changes — with a
+local `BillingSubscription` mirror that keeps `Tenant.Plan`/`Tenant.PlanId` and the quota state in
+lockstep so Story 35-6 enforcement reads a single source of truth. Every transition is audited via
+`BILLING.SUBSCRIPTION.*` DCB events. SaaS-only; single-user mode is a hard no-op.
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (`Tamma.Api` minimal-API +
+`Tamma.Data` EF Core control plane). `Stripe.net` (added by Story 35-1). Tests: xUnit in
+`apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/`; docker-bound suites run via
+`sg docker -c "dotnet test ..."` (session docker group is stale per project memory).
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO Stripe webhook endpoint / signature verification / `billing_webhook_events` dedup** — that
+  is Story 35-5. This story *provides* the `SubscriptionMirrorUpdater` the 35-5 webhook processor
+  calls; it does not own ingestion.
+- **NO quota computation, enforcement gates, or over-quota API responses** — Story 35-6. This story
+  only keeps `Tenant.Plan`/`Seats` correct so 35-6 reads one truth.
+- **NO customer mapping, plan catalog, meters, or Stripe-key wiring** — Story 35-1 (consumed here).
+- **NO invoicing, dunning, tax, billing portal, or credits wallet** — later Epic 35 stories.
+- **NO tenant-facing subscription UI** — API + control-plane only; the GET projection is what the
+  dashboard stories render.
+- **NO single-user subscription support** — billing is SaaS-only; in single-user mode the endpoints
+  are unmapped and `NullBillingProvider` makes zero Stripe calls.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### What exists
+
+| Asset | Path | Note |
+|---|---|---|
+| `Tenant` entity | `apps/tamma-elsa/src/Tamma.Data/Entities/Tenant.cs:11` | `Plan` string column (default `"free"`); a **shadow** `PlanId` (Guid?) FK exists in EF config (set via `db.Entry(tenant).Property("PlanId")`, see below) — both kept in lockstep. |
+| `Plan` entity | `apps/tamma-elsa/src/Tamma.Data/Entities/Plan.cs:14` | Keyed by `Slug` (`free`/`team`/`enterprise`), `MonthlyPriceUsd` (decimal — used to decide upgrade vs downgrade), `Quotas` JSON, `IsActive`, `PlacementPolicy`. Seeded by `PlansSeeder`. |
+| `ControlPlaneDbContext` | `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Control-plane DbSets; entity config centralized in `TammaModelConfiguration.cs`. |
+| Plan-change lockstep precedent | `apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminTenantsEndpoints.cs:619-624` | `db.Entry(tenant).Property("PlanId").CurrentValue = plan.Id; tenant.Plan = plan.Slug;` then `SaveChangesAsync` — **copy this lockstep exactly** for the effective-plan update. |
+| `DomainEvent` entity | `apps/tamma-elsa/src/Tamma.Data/Entities/DomainEvent.cs:3` | `Type`, `TenantId?`, `Tags`/`Metadata`/`Data` JSON, server `SequenceNumber`. |
+| Tenant-scoped DCB append | `apps/tamma-elsa/src/Tamma.Data/Repositories/EventRepository.cs:49-87` | `AppendAsync`: `TenantId` set → tenant `DomainEvents` store; `TenantId` null → `IPlatformEventRepository` (platform). Subscription events are tenant-scoped → set `TenantId`. |
+| Tenant event emit shape | `apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs:1036-1060` (`EmitTenantEvent`) | `Metadata = {"workflowVersion":"1.0.0","eventSource":"system"}`; mirror this row shape in `BillingEvents`. |
+| Tenant-route group + membership gate | `apps/tamma-elsa/src/Tamma.Api/Program.cs:1505-1533` (`app.MapGroup("/api/v1/orgs").RequireAuthorization("MemberAccess")` + `.AddEndpointFilter<RequireTenantMembershipFilter>()`) | Role read from `httpContext.Items[RequireTenantMembershipFilter.TenantRoleItemKey]`; member-403 via `TenantRoleHierarchy.IsAtLeast(role, Admin)` (see `OrgEndpoints.cs:254`, `AlertEndpoints.cs:1019`). |
+| `IPlatformTaskHandler` | `apps/tamma-elsa/src/Tamma.Api/Services/PlatformTasks/IPlatformTaskHandler.cs:25` | `TaskType` + `HandleAsync`; `PlatformTaskTerminalException` for non-retryable. (Not strictly needed here; checkout is synchronous — kept as a reference for any async retry.) |
+| Mode seam | `apps/tamma-elsa/src/Tamma.Api/Services/PromptStore/TammaMode.cs:14,48` (`enum TammaMode`, `ITammaModeProvider`) | `Mode == SingleUser` short-circuits endpoint mapping + provider selection. |
+| Auth policies | `apps/tamma-elsa/src/Tamma.Api/Program.cs:959-1095` | `MemberAccess` (any authenticated) is the tenant-route group policy; per-route role gating is done in the handler via the membership-filter item key (not a policy). `OwnerAccess`/`PlatformOwnerAccess` are platform/admin gates — NOT used for tenant-scoped subscription mutations. |
+
+### What Story 35-1 provides (consumed here; do NOT re-create)
+
+`BillingCustomer` (`Tamma.Data/Entities/BillingCustomer.cs`, TenantId-unique), `BillingPlanPrice`
+(`Tamma.Data/Entities/BillingPlanPrice.cs`, slug → Stripe Product/Price/Meter ids incl. `SeatsPriceId`/
+`SeatsMeterId`), `IBillingProvider`/`StripeBillingProvider`/`NullBillingProvider`
+(`Tamma.Api/Services/Billing/`), `IBillingCatalog`/`BillingCatalog`, `BillingMode` enum
+(`Tamma.Core/Billing/BillingMode.cs`), `BillingEvents` static helper, `BillingServiceCollectionExtensions`
+(`AddTammaBilling`), and the three seeded meters (`tamma.platform_tokens_input/output`, `tamma.seats`).
+Story 35-1 also resolves the Stripe key from the Epic 29 cabinet and registers `NullBillingProvider`
+in single-user mode.
+
+### What does NOT exist yet (all NEW in this story or sibling 35-x)
+
+- No `BillingSubscription` entity / table / repository.
+- No `ISubscriptionService` / `SubscriptionService` / `SubscriptionMirrorUpdater` / `SubscriptionProjection`.
+- No `Endpoints/Billing/` directory or `SubscriptionEndpoints.cs`.
+- No Stripe code in the repo at all yet (`Stripe` only appears in a Studio Razor page string). `Stripe.net`
+  is added by 35-1; this story assumes the package is present.
+
+### Verified pitfalls
+
+- `EventRepository.AppendAsync` **throws** for a null-`TenantId` event when no `IPlatformEventRepository`
+  is wired (`EventRepository.cs:61-68`). Subscription events MUST set `TenantId` (they are tenant-scoped),
+  so they route to the tenant `DomainEvents` store — correct and unaffected.
+- `Tenant.PlanId` is an EF **shadow** property (not a CLR property on `Tenant.cs`); update it via
+  `db.Entry(tenant).Property("PlanId").CurrentValue`, exactly as `AdminTenantsEndpoints.cs:620`.
+- Per-route role gating for tenant routes is done **in the handler** via the membership-filter item key,
+  not by an authorization policy (the group policy `MemberAccess` only requires authentication).
+
+---
+
+## Architecture
+
+**Checkout → webhook-materialize → API transitions (proration/schedule/cancel/seats) → mirror +
+`Tenant.Plan` lockstep → DCB event → 35-6 reads quota.** One service (`SubscriptionService`) owns the
+API verbs; one updater (`SubscriptionMirrorUpdater`, shared with Story 35-5) owns turning a Stripe
+`Subscription` object into the local mirror + lockstep + event.
+
+```
+HTTP (tenant owner/admin)                 Stripe webhook (Story 35-5)
+   │ checkout/change/cancel/seats               │ subscription.created/updated/deleted
+   ▼                                            ▼
+SubscriptionService ──Stripe.net──►  (returns Stripe.Subscription)
+   │                                            │
+   └──────────────► SubscriptionMirrorUpdater.ApplyAsync(tenantId, stripeSub, transition) ◄──┘
+                          │ one CP transaction:
+                          ├─ upsert BillingSubscription (status/period/trialEnd FROM stripeSub)
+                          ├─ on EFFECTIVE plan change: Tenant.Plan + Tenant.PlanId lockstep
+                          └─ IEventRepository.AppendAsync(BILLING.SUBSCRIPTION.<transition>)
+```
+
+### Per-mode ownership (mandatory two-scoping-model answer)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Are subscription endpoints mapped? | No (`ITammaModeProvider.Mode == SingleUser` → not mapped / 404). | Yes, tenant-scoped + membership-gated. |
+| Provider | `NullBillingProvider` (`IsEnabled=false`, zero Stripe). | `StripeBillingProvider`. |
+| Who owns the subscription? | n/a (none). | The tenant: `tenant_owner`/`tenant_admin` mutate; `member` is read-only (403 on mutate, 200 on GET). |
+| Mirror rows | none | one non-terminal `BillingSubscription` per tenant (partial-unique). |
+| Quota source for 35-6 | n/a | active `BillingSubscription.PlanSlug` + `Seats`. |
+
+---
+
+## Task breakdown (test-first / TDD)
+
+### Task 1 — `BillingSubscription` entity, EF config, migration, repository (story AC1, AC12)
+
+**Files to touch**
+- New: `src/Tamma.Data/Entities/BillingSubscription.cs`.
+- Modify: `src/Tamma.Data/ControlPlaneDbContext.cs` (add `DbSet<BillingSubscription> BillingSubscriptions`).
+- Modify: `src/Tamma.Data/TammaModelConfiguration.cs` (`ConfigureControlPlaneEntities`: table
+  `billing_subscriptions`, status CHECK, FK→`tenants` cascade, **partial unique** on `TenantId`
+  filtered `Status NOT IN ('canceled','incomplete_expired')`, partial unique on `StripeSubscriptionId`).
+- New: `src/Tamma.Data/Migrations/ControlPlane/<ts>_AddBillingSubscription.cs` (+ Designer + snapshot)
+  via `dotnet ef migrations add AddBillingSubscription --context ControlPlaneDbContext --output-dir Migrations/ControlPlane`.
+- New: `src/Tamma.Data/Repositories/IBillingSubscriptionRepository.cs`,
+  `BillingSubscriptionRepository.cs` (`GetActiveByTenantAsync`, `UpsertAsync`, all `TenantId`-scoped).
+
+**Approach:** entity per the story signature. CHECK + partial-unique mirror the 35-1 `BillingCustomer`
+config style. Update the snapshot; run `dotnet ef migrations has-pending-model-changes` → expect none.
+
+**Tests first** (`tests/Tamma.Api.Tests/Billing/BillingSubscriptionRepositoryTests.cs`,
+`BillingSubscriptionMigrationTests.cs` — docker-bound): repository CRUD is `TenantId`-scoped;
+`GetActiveByTenantAsync` ignores terminal rows; the partial-unique index rejects a second non-terminal
+row for one tenant but allows a canceled + a new active row; migration applies + rolls back; pending
+model changes = none.
+
+### Task 2 — `SubscriptionProjection` + `SubscriptionMirrorUpdater` (story AC5, AC7, AC8, AC13)
+
+**Files to touch**
+- New: `src/Tamma.Api/Services/Billing/SubscriptionProjection.cs` (read DTO + `FreeDefault(tenantId)`).
+- New: `src/Tamma.Api/Services/Billing/SubscriptionMirrorUpdater.cs` —
+  `ApplyAsync(Guid tenantId, Stripe.Subscription stripeSub, string transition, CancellationToken ct)`:
+  one CP transaction that (a) upserts the mirror with status/period/trialEnd/seats **from `stripeSub`**,
+  (b) on an effective-plan change applies the `Tenant.Plan` + shadow `PlanId` lockstep (copy
+  `AdminTenantsEndpoints.cs:619-624`), (c) appends the right `BILLING.SUBSCRIPTION.*` event via
+  `IEventRepository.AppendAsync` (TenantId set).
+- Modify: `src/Tamma.Api/Services/Billing/BillingEvents.cs` (35-1's helper) — add
+  `SubscriptionCreated/Updated/Canceled/TrialEnded` builders, tags `{ tenantId, planSlug, status }`,
+  metadata `{"workflowVersion":"1.0.0","eventSource":"system"}`.
+
+**Approach:** the updater is the *single* place mirror logic lives, shared with Story 35-5's webhook
+processor. It never reads status/period from a request — always from the Stripe object (AC13). It maps
+the Stripe `status` string to the entity's CHECK-constrained domain.
+
+**Tests first** (`SubscriptionMirrorUpdaterTests.cs`): applying a Stripe object upserts the mirror and
+the `Tenant.Plan`/`PlanId` lockstep (no-drift invariant); status/period come from the Stripe object not
+the caller; a `transition="trial_ended"` apply emits `BILLING.SUBSCRIPTION.TRIAL_ENDED`; each transition
+emits exactly one event with the right tags; a scheduled-downgrade apply does NOT change `Tenant.Plan`.
+
+### Task 3 — `ISubscriptionService` / `SubscriptionService`: checkout (story AC2, AC10, AC11)
+
+**Files to touch**
+- New: `src/Tamma.Api/Services/Billing/ISubscriptionService.cs`, `SubscriptionService.cs`.
+- Modify: `src/Tamma.Api/Extensions/BillingServiceCollectionExtensions.cs` — register
+  `ISubscriptionService`, `SubscriptionMirrorUpdater`, `IBillingSubscriptionRepository` (SaaS only;
+  in single-user the 35-1 `NullBillingProvider` is already wired so the service is a no-op seam).
+
+**Approach:** `CreateCheckoutSessionAsync` resolves `BillingCustomer` (35-1) + `BillingPlanPrice` (35-1)
+for the slug, builds a Stripe `Checkout.Session` (`mode=subscription`, line items = base price +
+optional `tamma.seats` quantity, `subscription_data.trial_period_days = trialDays`), with a deterministic
+`RequestOptions.IdempotencyKey`. Returns `CheckoutResult(url, sessionId)`. **No** local row created here
+(materialized by the 35-5 `customer.subscription.created` webhook via the Task-2 updater). Guard on
+`IBillingProvider.IsEnabled` — single-user returns a SaaS-only result.
+
+**Tests first** (`SubscriptionServiceCheckoutTests.cs`): builds the session with the right price id,
+seat quantity, trial days, and idempotency key (Stripe `Checkout.SessionService` mocked); no local row;
+single-user/`NullBillingProvider` → zero Stripe calls.
+
+### Task 4 — change plan: upgrade proration vs scheduled downgrade (story AC3, AC7, AC8, AC10)
+
+**Files to touch**
+- Modify: `src/Tamma.Api/Services/Billing/SubscriptionService.cs` (add `ChangePlanAsync`).
+
+**Approach:** load the active mirror + the current and target `Plan` rows; compare `MonthlyPriceUsd`.
+- **Upgrade (target ≥ current):** `SubscriptionService.UpdateAsync(stripeSubId, { Items=newPrice,
+  ProrationBehavior="create_prorations" }, idempotencyKey)`; pass the returned `Stripe.Subscription` to
+  `SubscriptionMirrorUpdater.ApplyAsync(..., "upgraded")` → applies new slug + lockstep + `UPDATED` event.
+- **Downgrade (target < current):** create a `SubscriptionSchedule` (`SubscriptionScheduleService`)
+  with a phase change at `CurrentPeriodEnd`; record `ScheduledPlanSlug`/`ScheduledEffectiveAt`/
+  `StripeScheduleId` on the mirror, emit `UPDATED` (tag `scheduledPlanSlug`), and **leave `PlanSlug`/
+  `Tenant.Plan` unchanged**. The actual rollover happens via the 35-5 webhook → updater.
+
+**Tests first** (`SubscriptionServiceChangeTests.cs`): upgrade calls `UpdateAsync` with
+`create_prorations` and applies the slug now; downgrade creates a schedule, records the scheduled
+fields, leaves `PlanSlug`/`Tenant.Plan` at the current plan; idempotency key deterministic; unknown slug
+rejected.
+
+### Task 5 — cancel (immediate vs at-period-end) + trial transitions (story AC4, AC5, AC8)
+
+**Files to touch**
+- Modify: `src/Tamma.Api/Services/Billing/SubscriptionService.cs` (add `CancelAsync`).
+
+**Approach:**
+- `atPeriodEnd=true`: `UpdateAsync(CancelAtPeriodEnd=true)` → updater applies (`Status` stays `active`,
+  `CancelAtPeriodEnd=true`), emit `CANCELED` (recorded-pending).
+- `atPeriodEnd=false`: `CancelAsync(stripeSubId)` → updater applies (`Status=canceled`), recompute
+  `Tenant.Plan` to `free` now, emit `CANCELED`.
+- Trial conversion/expiry transitions are *driven by webhooks* (35-5) but flow through the same Task-2
+  updater with `transition="trial_ended"` emitting `TRIAL_ENDED`; ensure the updater handles a Stripe
+  object whose `status` moves `trialing → active` or `trialing → canceled/unpaid`.
+
+**Tests first** (`SubscriptionServiceCancelTests.cs`, `SubscriptionServiceTrialTests.cs`): at-period-end
+keeps `active`+`CancelAtPeriodEnd`; immediate flips to `canceled` + `Tenant.Plan=free`; trial
+conversion/expiry through the updater emits `TRIAL_ENDED` and lands the right status.
+
+### Task 6 — seat changes with active-member floor (story AC6, AC7, AC8)
+
+**Files to touch**
+- Modify: `src/Tamma.Api/Services/Billing/SubscriptionService.cs` (add `ChangeSeatsAsync`).
+
+**Approach:** count active members via `ITenantMembershipRepository`; if `seats < activeMembers` →
+throw a typed conflict mapped to **409 `seats_below_active_members`**, no Stripe call. Otherwise update
+the Stripe subscription item quantity on the `tamma.seats` price (35-1 `SeatsPriceId`) with a
+deterministic idempotency key; updater applies new `Seats`, emit `UPDATED`. (Recompute hook for 35-6 is
+just the persisted `Seats` — 35-6 reads it.)
+
+**Tests first** (`SubscriptionServiceSeatsTests.cs`): increase updates Stripe quantity + `Seats`;
+decrease below active members → 409 `seats_below_active_members`, zero Stripe calls; equal-to floor
+allowed.
+
+### Task 7 — `SubscriptionEndpoints` + Program.cs mapping + RBAC (story AC2, AC9, AC11, AC12)
+
+**Files to touch**
+- New: `src/Tamma.Api/Endpoints/Billing/SubscriptionEndpoints.cs` —
+  `MapSubscriptionEndpoints(IEndpointRouteBuilder)`: `POST checkout/change/cancel/seats`, `GET ` (current).
+  Mount under the tenant-scoped membership-gated group (`/api/v1/orgs/{tenantId}/billing/subscription`
+  + `RequireTenantMembershipFilter`), matching `OrgEndpoints`/`AlertEndpoints` tenant sections. Each
+  mutation reads the role from `httpContext.Items[RequireTenantMembershipFilter.TenantRoleItemKey]` and
+  returns 403 unless `TenantRoleHierarchy.IsAtLeast(role, TenantRoleHierarchy.Admin)`. GET allowed for
+  any member; free-tier default when no row.
+- Modify: `src/Tamma.Api/Program.cs` — call `MapSubscriptionEndpoints` only when
+  `ITammaModeProvider.Mode == TammaMode.SaaS` (mirror how other SaaS-only wiring guards on mode).
+
+**Approach:** thin endpoints → `ISubscriptionService`. Map the typed conflict to 409 with the stable
+code; map Stripe failures to 502 (with a WARN log + the webhook reconcile note).
+
+**Tests first** (`SubscriptionEndpointsRbacTests.cs`): member → 403 on every mutation, owner/admin pass;
+GET 200 for member; cross-tenant access (not a member of the route tenant) → 404/403 via the membership
+filter; single-user mode → endpoints unmapped (404).
+
+### Task 8 — event-emission + lifecycle integration + tenant-isolation tests (story AC8, AC12, AC14)
+
+**Files to touch**
+- New: `tests/Tamma.Api.Tests/Billing/SubscriptionEventEmissionTests.cs`,
+  `NullBillingSubscriptionTests.cs`, `SubscriptionLifecycleIntegrationTests.cs` (docker-bound).
+
+**Approach:** assert each transition appends exactly one `BILLING.SUBSCRIPTION.*` event with
+`{tenantId,planSlug,status}` tags in the tenant `DomainEvents` store; run the full lifecycle through the
+HTTP endpoints on a real CP+tenant DB (Stripe mocked) and assert one mirror row, the matching events,
+and the `Tenant.Plan == BillingSubscription.PlanSlug` no-drift invariant after each step; tenant
+isolation (A cannot read/mutate B); single-user no-op (zero Stripe, no rows, endpoints unmapped).
+
+---
+
+## Sequencing & dependencies
+
+```
+Task 1 (entity/migration/repo)
+   └─► Task 2 (projection + mirror updater + events)
+          ├─► Task 3 (checkout)
+          ├─► Task 4 (change: upgrade/downgrade)   ── parallel-safe with 3,5,6 once Task 2 lands
+          ├─► Task 5 (cancel + trial)
+          └─► Task 6 (seats)
+                 └─► Task 7 (endpoints + RBAC + Program mapping)
+                        └─► Task 8 (event/integration/isolation tests)
+```
+- **Hard prerequisite:** Story 35-1 merged (provides `BillingCustomer`, `BillingPlanPrice`,
+  `IBillingProvider`/`Null...`, `IBillingCatalog`, `BillingEvents`, `BillingServiceCollectionExtensions`,
+  `Stripe.net`, seeded meters, mode-aware billing DI).
+- **Co-dependent:** Story 35-5 (webhook ingestion) — this story exposes `SubscriptionMirrorUpdater` for
+  it. If 35-5 is not yet merged, the trial/rollover/cancel-confirmation transitions are tested by calling
+  `SubscriptionMirrorUpdater.ApplyAsync` directly with a fabricated `Stripe.Subscription` (the same entry
+  point the webhook will use).
+- **Blocks:** Story 35-6 (quota enforcement reads the active `BillingSubscription`).
+- Task 2 is the linchpin (the shared updater); Tasks 3–6 only need Task 2.
+
+---
+
+## Risks + mitigations
+
+- **Mirror drift from Stripe.** Apply Stripe's returned object inside one CP transaction; status/period
+  taken from the object, not the request (AC13); the 35-5 webhook reconciles to confirmed state; a
+  no-drift invariant test (`Tenant.Plan == BillingSubscription.PlanSlug`) runs after each transition.
+- **Double-applied proration / duplicate schedule on retry.** Deterministic
+  `RequestOptions.IdempotencyKey` on every mutating Stripe call.
+- **API ↔ webhook race.** Single shared `SubscriptionMirrorUpdater`; last write that reflects Stripe's
+  confirmed state wins; never overwrite a newer Stripe state with a stale one.
+- **Downgrade lowering quota mid-period.** Scheduled downgrade leaves `PlanSlug`/`Tenant.Plan` at the
+  higher plan until the rollover webhook fires.
+- **Seat decrease orphaning members.** Reject below the active-member count with 409 before any Stripe
+  call.
+- **`Tenant.PlanId` is a shadow property.** Update via `db.Entry(tenant).Property("PlanId")`, exactly as
+  `AdminTenantsEndpoints.cs:620` — not a CLR setter.
+- **Stripe.net API drift.** Research current docs (`SubscriptionService.UpdateAsync`+`ProrationBehavior`,
+  `SubscriptionScheduleService`, `Checkout.SessionService`, `RequestOptions.IdempotencyKey`) before
+  writing SDK calls; mock at the service-interface boundary; live-Stripe test opt-in behind
+  `STRIPE_SECRET_KEY_TEST`.
+- **Single-user accidental coupling.** Endpoints unmapped by mode + `NullBillingProvider`; tests assert
+  zero SDK calls and no rows.
+- **Migration discipline.** `billing_subscriptions` is additive; still run
+  `dotnet ef migrations has-pending-model-changes` (expect none) and put entity config only in
+  `TammaModelConfiguration.cs` (the established single source); docker-bound migration test asserts
+  apply + rollback.
+
+---
+
+## Acceptance criteria (mirror of the story)
+
+- [ ] `BillingSubscription` entity + table + partial-unique (one non-terminal per tenant) + status CHECK
+      + FK; migration applies/rolls back, `has-pending-model-changes` = none.
+- [ ] `POST .../checkout` returns a Stripe Checkout Session for the slug; owner/admin only (member 403);
+      no local row created (materialized by the 35-5 webhook).
+- [ ] `POST .../change`: upgrade applies immediate proration; downgrade schedules at period end and is
+      reflected as `scheduledPlanSlug`/`scheduledEffectiveAt` without changing the live plan.
+- [ ] `POST .../cancel`: immediate (`canceled` + `Tenant.Plan=free` now) and at-period-end
+      (`CancelAtPeriodEnd`, stays `active`) both supported; trial convert/expire emits
+      `BILLING.SUBSCRIPTION.TRIAL_ENDED`.
+- [ ] `POST .../seats`: updates the `tamma.seats` quantity + `Seats`; decrease below active members →
+      409 `seats_below_active_members` (no Stripe call); quota reads the new seat count.
+- [ ] `Tenant.Plan` + `Tenant.PlanId` updated atomically with the mirror on every effective-plan change;
+      no-drift invariant holds.
+- [ ] `BILLING.SUBSCRIPTION.CREATED/UPDATED/CANCELED/TRIAL_ENDED` emitted with `{tenantId,planSlug,status}`.
+- [ ] `GET .../subscription` returns the projection (free default when none); never cross-tenant.
+- [ ] Single-user mode: endpoints unmapped, `NullBillingProvider`, zero Stripe calls, no rows.
+- [ ] Unit + integration tests green (checkout, upgrade proration, scheduled downgrade, immediate vs
+      end-of-period cancel, trial conversion, seat change incl. floor 409, RBAC, no-drift, event
+      emission, tenant isolation); docker-bound suites run via `sg docker -c "dotnet test ..."`.

--- a/docs/superpowers/plans/2026-06-17-35-5-stripe-webhook-ingestion-idempotency-and-billing-event-proje-plan.md
+++ b/docs/superpowers/plans/2026-06-17-35-5-stripe-webhook-ingestion-idempotency-and-billing-event-proje-plan.md
@@ -1,0 +1,362 @@
+# Story 35-5 — Stripe Webhook Ingestion, Idempotency & Billing Event Projection (Implementation Plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation. Story: `docs/stories/epic-35/story-35-5/35-5-stripe-webhook-ingestion-idempotency-and-billing-event-proje.md`.
+
+**Goal:** Ship a verified, idempotent Stripe webhook endpoint on `Tamma.Api` (SaaS mode) that
+ingests subscription/invoice/payment/dispute lifecycle events, dedupes them by Stripe event id,
+dispatches each through a pluggable `IBillingEventHandler` seam, emits a canonical `BILLING.*` DCB
+event per event, fast-acks (heavy work → `PlatformQueuedTask`), and exposes an admin
+replay/inspect surface. This is the source-of-truth sync backbone the rest of Epic 35 builds on.
+
+**Tech stack:** .NET 8 / EF Core 8 / Npgsql in `apps/tamma-elsa` (control-plane API). Stripe.net
+arrives via Story 35-1. Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/` (xUnit;
+docker-bound CP-Postgres suites run via `sg docker -c "dotnet test ..."`).
+
+---
+
+## Non-goals (YAGNI guard)
+
+- NO ownership of sibling-story mirror entities. `BillingSubscription` (35-4),
+  `BillingInvoice`/`BillingInvoiceLine` (35-8), `BillingPaymentMethod` (35-7),
+  `BillingUsageRollup` (35-3), `BillingWalletLedger` (35-10) are created by their stories. 35-5
+  ships the dispatch seam + DCB emission + a logging `NullBillingEventHandler` default; the actual
+  mirror writes are sibling handlers registered later.
+- NO Stripe-side resource creation (customers, subscriptions, prices, meters). 35-1 owns
+  customer/catalog creation; 35-4 owns subscription mutations. 35-5 only *receives* Stripe's view.
+- NO inline heavy work (dunning escalation, email sends, Stripe round-trips). Those are
+  `PlatformQueuedTask` (`Type = "billing.webhook.followup"`) processed by the existing
+  `PlatformTaskWorker`.
+- NO single-user billing surface. In `SingleUser` mode the routes are unmapped and the
+  `NullBillingProvider` (35-1) means zero Stripe wiring.
+- NO tenant-facing webhook route. A Stripe webhook is a platform-operator concern; the only read
+  surface is `PlatformOwnerAccess`-gated admin endpoints.
+- NO reliance on Stripe's retry for recovery of *projection* failures. We ack `200` and recover via
+  our own admin-replay endpoint + the follow-up queue, to avoid retry storms.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### Webhook + signature pattern to mirror
+
+- `apps/tamma-elsa/src/Tamma.Api/Endpoints/GitHubEndpoints.cs:109-170` — `Webhooks(...)` is the
+  canonical raw-body-capture + verify-before-dispatch pattern: `context.Request.EnableBuffering()`
+  (line 125) → leave-open `StreamReader` (127-136) → `Body.Position = 0`. **Audit finding 001**
+  (138-149): *never fail open on a missing secret* — reject when the secret is unset. We copy this
+  shape exactly but use `Stripe.EventUtility.ConstructEvent` instead of hand-rolled HMAC, and
+  resolve the secret from the cabinet (not `IConfiguration`).
+- `VerifySignature` (274-282) shows the timing-safe HMAC the SDK does for us — do **not**
+  re-implement; `Stripe.net` handles the `t=`/`v1=` scheme + tolerance window.
+
+### Story 35-1 foundation this story consumes (verified via `/tmp/pab_stories/35-1.json`)
+
+- `apps/tamma-elsa/src/Tamma.Data/Entities/BillingCustomer.cs` — `TenantId` (unique FK),
+  `StripeCustomerId`, `BillingMode` enum (`PlatformProvided|Byok`). This is the tenant-resolution
+  table: `StripeCustomerId → TenantId`.
+- `apps/tamma-elsa/src/Tamma.Api/Services/Billing/IBillingProvider.cs` +
+  `StripeBillingProvider.cs` + `NullBillingProvider` (single-user no-op seam, 35-1 AC7).
+- Stripe API key + webhook signing secret resolve via `ISecretStore`
+  (`SecretScope.Platform`, `SecretPurpose.ApiKey`) — 35-1 AC3; production refuses to boot billing
+  if the key is only a raw env var. **35-5 reuses this resolution path for the signing secret.**
+- Stripe.net package added to `Tamma.Api.csproj` by 35-1 (it is **not** present today — confirmed
+  no `Stripe` ref in `apps/tamma-elsa/src/Tamma.Api/Tamma.Api.csproj`).
+
+### Secret cabinet (Epic 29)
+
+- `apps/tamma-elsa/src/Tamma.Api/Services/Secrets/ISecretStore.cs` — `GetAsync(SecretRef, ct)`.
+  Note: `ISecretStore` does **not** return plaintext through its public signature (the doc-comment
+  is explicit). 35-1 establishes the concrete read path for the Stripe key/secret; 35-5 must call
+  whatever 35-1 exposes for plaintext resolution of the signing secret (likely a billing-scoped
+  helper on `StripeBillingProvider` / a reveal path). **Implementation task 5 reads 35-1's actual
+  surface and binds to it; do not assume `ISecretStore.GetAsync` returns the plaintext.**
+- `SecretScope.Platform` (`Services/Secrets/SecretScope.cs:26`) and `SecretPurpose.ApiKey`
+  (`Services/Secrets/SecretPurpose.cs:29`) exist.
+
+### DCB event store
+
+- `apps/tamma-elsa/src/Tamma.Data/Entities/DomainEvent.cs` — `Id`, `Type`, `TenantId`,
+  `IssueNumber`, `Tags` (JSONB string), `Metadata`, `Data`, `CreatedAt`, `SequenceNumber`.
+- `apps/tamma-elsa/src/Tamma.Data/Repositories/IEventRepository.cs` —
+  `Task<DomainEvent> AppendAsync(DomainEvent evt)` (CP-resident; the store `AlertRuleEvaluator`
+  polls). `AlertEventEmitter.cs:31-50` shows the tenant-vs-platform routing precedent and the
+  `CredentialRedactor.Clean` scrub-before-persist rule.
+
+### Platform task queue (Epic 28)
+
+- `apps/tamma-elsa/src/Tamma.Data/Entities/PlatformQueuedTask.cs` — `Id`, `Type`, `TenantId`,
+  `InstallationId`, `Payload`, `Status`, retry/claim fields.
+- `apps/tamma-elsa/src/Tamma.Data/Repositories/IPlatformQueuedTaskRepository.cs:29` —
+  `EnqueueAsync(PlatformQueuedTask, ct)`; usage example at
+  `Endpoints/Admin/AdminTenantsEndpoints.cs:700` (`MoveTenantTaskPayload.TaskType` pattern).
+- `apps/tamma-elsa/src/Tamma.Api/Services/PlatformTasks/IPlatformTaskHandler.cs` — `TaskType` +
+  `HandleAsync(PlatformQueuedTask, ct)`; `PlatformTaskTerminalException` for non-retryable.
+  `IPlatformTaskHandlerRegistry.cs` shows the per-scope snapshot-dict + duplicate-type detection
+  pattern we mirror for `BillingEventHandlerRegistry`. Register via
+  `services.AddPlatformTaskHandler<T>()`.
+
+### DbContext / model config / migrations
+
+- `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs:36-78` — existing
+  `DbSet<Tenant>`/`Plan`/`PlatformQueuedTask`. Add `DbSet<BillingWebhookEvent>` here.
+- `ControlPlaneDbContext.cs:218` calls
+  `TammaModelConfiguration.ConfigureControlPlaneEntities(...)` — entity config + indexes belong in
+  `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` (the established single source; e.g.
+  `GitHubWebhookDelivery` unique index at `ControlPlaneDbContext.cs:269-271` is the dedup-index
+  precedent, but declare ours in `TammaModelConfiguration`).
+- Migrations under `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/` —
+  `BillingWebhookEvent` is an **additive** table (normal `dotnet ef migrations add`); after, run
+  `dotnet ef migrations has-pending-model-changes` → expect none.
+
+### Authorization policies (`Program.cs`)
+
+- `Program.cs:986-990` — `PlatformOwnerAccess` (requires JWT `platformRole = platform_admin`). Use
+  for the admin list/replay routes — *not* `OwnerAccess` (per the policy comment at 976-985, admin
+  platform-scoped work must use `PlatformOwnerAccess`).
+- Route mapping precedent: `Program.cs:1244` `var admin = app.MapGroup("/api/admin")...`; anonymous
+  webhook routes mapped without `RequireAuthorization` (GitHub webhook is mapped likewise).
+- Mode gating: `ITammaModeProvider` (`Services/PromptStore/TammaMode.cs:48`,
+  `TammaMode.SingleUser|SaaS`). Map billing routes only when `SaaS`.
+
+### Tests
+
+- `apps/tamma-elsa/tests/Tamma.Api.Tests/` has per-area folders (`GitHub/`, `Alerts/`,
+  `Provisioning/`, `TaskQueue/`, `Webhooks/`). Create a new `Billing/` folder. `WebApplicationFactory`
+  end-to-end pattern exists (e.g. `Webhooks/`, `GitHub/`). Docker-bound CP-Postgres suites run as
+  `sg docker -c "dotnet test apps/tamma-elsa/... "` (session docker group is stale; build needs no
+  wrapper) — see `reference_dotnet_test_docker` memory.
+
+---
+
+## Architecture
+
+**Receive → verify → dedupe → resolve tenant → dispatch → emit DCB → fast-ack enqueue → record.**
+
+```
+POST /api/v1/billing/stripe/webhook
+  └─ StripeWebhookEndpoint.Receive
+       ├─ EnableBuffering + raw-body read (mirror GitHubEndpoints.Webhooks)
+       ├─ resolve signing secret via 35-1's cabinet path  → 503 if unresolvable
+       ├─ Stripe.EventUtility.ConstructEvent(raw, sig, secret) → 400 on StripeException
+       └─ IStripeWebhookProcessor.ProcessAsync(evt, raw)
+            ├─ insert BillingWebhookEvent{received}; UNIQUE collision → Duplicate (200)
+            ├─ resolve TenantId via BillingCustomer.StripeCustomerId; none → skipped (200)
+            ├─ BillingEventHandlerRegistry.Resolve(evt.Type) ?? NullBillingEventHandler
+            ├─ handler.HandleAsync(ctx) → mirror write (sibling) + IEventRepository.AppendAsync(BILLING.*)
+            ├─ if BillingFollowup → IPlatformQueuedTaskRepository.EnqueueAsync(billing.webhook.followup)
+            └─ stamp Status projected|enqueued|skipped|failed; always ack 200 (except sig/secret)
+```
+
+Sibling stories `services.AddBillingEventHandler<T>()`; 35-5's default handlers emit the canonical
+`BILLING.*` DCB events even before sibling mirror handlers register, so the audit trail is complete
+from day one.
+
+---
+
+## Task breakdown (TDD — tests first in every task)
+
+### Task 1 — `BillingWebhookEvent` entity + EF migration (core data)
+
+**Files:**
+- New: `src/Tamma.Data/Entities/BillingWebhookEvent.cs` (per story entity sketch).
+- Modify: `src/Tamma.Data/ControlPlaneDbContext.cs` — `DbSet<BillingWebhookEvent>`.
+- Modify: `src/Tamma.Data/TammaModelConfiguration.cs` — `ConfigureControlPlaneEntities`: table
+  `billing_webhook_events`, `UNIQUE(stripe_event_id)`, `(status, received_at DESC)` index, partial
+  `(tenant_id) WHERE NOT NULL` index, default `status='received'`/`attempts=0`/`payload='{}'`.
+- New: migration under `src/Tamma.Data/Migrations/ControlPlane/<ts>_BillingWebhookEvents.cs`.
+
+**Approach:** additive table only. Mirror `GitHubWebhookDelivery` config style. Generate via
+`dotnet ef migrations add BillingWebhookEvents -c ControlPlaneDbContext`.
+
+**Tests (first):** `Billing/BillingWebhookEventModelTests.cs` — context creates the table (in-memory
++ SQLite relational for index assertions); inserting two rows with the same `StripeEventId` throws
+on the unique index; `has-pending-model-changes` reports none (CI guard).
+
+### Task 2 — Handler seam: `IBillingEventHandler` + registry + `NullBillingEventHandler`
+
+**Files:**
+- New: `src/Tamma.Api/Services/Billing/IBillingEventHandler.cs`,
+  `BillingEventHandlerRegistry.cs`, `BillingWebhookContext.cs`, `BillingFollowup` (record),
+  `NullBillingEventHandler.cs`, `BillingWebhookEventTypes.cs`.
+
+**Approach:** clone `PlatformTaskHandlerRegistry` structure — per-scope snapshot dict keyed by
+event type, duplicate-claim throws at construction, `Resolve(type) -> handler?`. `NullBillingEventHandler`
+logs INFO + returns null follow-up; the processor uses it when `Resolve` is null. Define an
+`AddBillingEventHandler<T>()` DI helper.
+
+**Tests (first):** `Billing/BillingEventHandlerRegistryTests.cs` — resolves a registered handler by
+type; returns null for unclaimed type; two handlers claiming the same type throw at construction;
+`NullBillingEventHandler` returns a null follow-up and emits no projection.
+
+### Task 3 — `StripeWebhookProcessor` (dedupe + dispatch + DCB + enqueue)
+
+**Files:**
+- New: `src/Tamma.Api/Services/Billing/IStripeWebhookProcessor.cs`, `StripeWebhookProcessor.cs`,
+  `WebhookProcessResult` (record/enum).
+
+**Approach:** the flow in the Architecture section. Insert-then-catch on the unique index for
+dedupe (race-safe). Tenant resolve via `BillingCustomer`. Append `BILLING.*` via
+`IEventRepository.AppendAsync` with tags `{ tenantId, stripeEventId, eventType, stripeObjectId }`
+and metadata `{ workflowVersion: "1.0.0", eventSource: "system" }`. Follow-up → `PlatformQueuedTask`.
+Handler exception → `Status=failed`, `LastError` via `CredentialRedactor.Clean`, ack `200`. CP
+dedup-row write failure → bubble so the endpoint returns `503` (the only case where Stripe retry is
+wanted). All in one CP transaction for the inline path.
+
+**Tests (first):** `Billing/StripeWebhookProcessorTests.cs` — dedupe (one row/event/handler call on
+double-process); no-customer-match → `skipped`+`200`+no projection event; per default-handler DCB
+type + tags; unknown type → `NullBillingEventHandler`+`skipped`; follow-up → one `PlatformQueuedTask`
+with right `TenantId`/`Payload`+`Status=enqueued`; handler throw → `failed`+scrubbed `LastError`+`200`;
+tenant-isolation (interleaved A/B → correct tenant on every row + event).
+
+### Task 4 — Default handlers (subscription / invoice / payment / dispute)
+
+**Files:**
+- New: `src/Tamma.Api/Services/Billing/Handlers/SubscriptionWebhookHandler.cs`,
+  `InvoiceWebhookHandler.cs`, `PaymentWebhookHandler.cs`, `DisputeWebhookHandler.cs`.
+
+**Approach:** each claims its Stripe types (subscription: created/updated/deleted/trial_will_end;
+invoice: created/finalized/paid/payment_failed; payment: payment_intent.succeeded/payment_failed;
+dispute: charge.dispute.created), reads the typed `evt.Data.Object` (`Stripe.Subscription` etc.),
+emits the matching `BILLING.*` DCB event, and returns a `BillingFollowup` ONLY for events that need
+heavy follow-up (e.g. `invoice.payment_failed` → dunning follow-up). **No mirror writes here** —
+those are sibling-story handlers (35-4/35-7/35-8); 35-5's handlers are DCB-emitting + idempotent.
+Idempotency: re-dispatch of an already-`projected` row is a no-op (the processor short-circuits on
+`Status=projected` during replay; handlers themselves stay side-effect-light).
+
+**Tests (first):** extend `StripeWebhookProcessorTests` with fixture events per handler asserting the
+exact `BILLING.*` type and that `payment_failed`/`dispute` enqueue a follow-up while `paid`/`created`
+do not.
+
+### Task 5 — Webhook endpoint (raw-body capture, verify, secret-from-cabinet, ack)
+
+**Files:**
+- New: `src/Tamma.Api/Endpoints/Billing/StripeWebhookEndpoint.cs`.
+
+**Approach:** mirror `GitHubEndpoints.Webhooks` raw-body capture verbatim. **First, read 35-1's
+actual signing-secret resolution surface** (`StripeBillingProvider` / cabinet helper) and bind to it
+— do not assume `ISecretStore.GetAsync` returns plaintext (its doc-comment forbids that). Missing
+`Stripe-Signature` → `400`; unresolvable secret → `503`+ERROR (never fail open);
+`EventUtility.ConstructEvent` throws → `400`+WARN (no raw body in logs). On success delegate to
+`IStripeWebhookProcessor.ProcessAsync` and `Results.Ok`.
+
+**Tests (first):** `Billing/StripeWebhookEndpointTests.cs` (WebApplicationFactory) — valid signed
+fixture → `200`+row+DCB event; tampered body → `400`+no row; missing signature → `400`;
+secret-unresolvable → `503`; duplicate delivery → `200`+one row.
+
+### Task 6 — Admin replay/inspect endpoints
+
+**Files:**
+- New: `src/Tamma.Api/Endpoints/Billing/BillingWebhookAdminEndpoints.cs`.
+
+**Approach:** `GET /api/v1/admin/billing/webhook-events` (filters `status`/`eventType`/`tenantId`,
+paging default 50/max 200) + `POST /api/v1/admin/billing/webhook-events/{id}/replay` (re-dispatch
+the stored payload through `IStripeWebhookProcessor`; re-running a `projected` event is a no-op).
+Both `PlatformOwnerAccess`.
+
+**Tests (first):** `Billing/BillingWebhookAdminEndpointsTests.cs` — RBAC matrix (`403` non-platform-admin,
+`200` platform-admin); list filters + paging; replay re-dispatches and a re-run of `projected` is a
+no-op (no duplicate DCB event).
+
+### Task 7 — Follow-up `IPlatformTaskHandler` + DI wiring + route mapping (mode-gated)
+
+**Files:**
+- New: `src/Tamma.Api/Services/Billing/BillingWebhookFollowupTaskHandler.cs`
+  (`TaskType = "billing.webhook.followup"`).
+- New: `src/Tamma.Api/Extensions/BillingWebhookServiceCollectionExtensions.cs` —
+  `AddBillingWebhookIngestion()`: registers processor, registry, `NullBillingEventHandler`, the four
+  default handlers, the follow-up `IPlatformTaskHandler`. Wired only when
+  `ITammaModeProvider == SaaS`.
+- Modify: `src/Tamma.Api/Program.cs` — call the extension; map the webhook + admin routes only in
+  SaaS mode (single-user → unmapped).
+
+**Approach:** mirror `AlertServiceCollectionExtensions` / `PlatformTaskServiceCollectionExtensions`.
+The follow-up handler is a thin v1 (logs + acks); 35-8 dunning replaces its body — keep it minimal,
+non-throwing for unknown follow-up subtypes.
+
+**Tests (first):** mode-gating test — single-user markers → `POST /webhook` and admin routes `404`;
+SaaS markers → reachable. Follow-up handler test — a `billing.webhook.followup` task is processed
+without throwing.
+
+---
+
+## Sequencing & dependencies
+
+```
+Task 1 (entity/migration) ─┐
+Task 2 (handler seam) ──────┼─► Task 3 (processor) ─► Task 4 (default handlers)
+                            │                          │
+                            └──────────────────────────┴─► Task 5 (endpoint) ─► Task 6 (admin) ─► Task 7 (DI + mode-gate)
+```
+
+- **Prerequisite:** Story 35-1 merged (Stripe.net, `BillingCustomer`, `NullBillingProvider`,
+  signing-secret cabinet path). Task 5 is blocked on knowing 35-1's secret-resolution surface.
+- Tasks 1 + 2 are parallel-safe. Task 3 needs both. Task 4 extends Task 3's tests. Tasks 5→6→7 are
+  sequential (endpoint → admin → wiring/mode-gate).
+- **Downstream:** 35-4/35-7/35-8/35-10 register `IBillingEventHandler` against this seam.
+
+---
+
+## Risks + mitigations
+
+- **Stripe retry storm from non-2xx acks.** Mitigation: only signature (`400`) and unresolvable
+  secret (`503`) are non-2xx; unknown types, no-customer-match, and handler failures all ack `200`
+  and record local status. Recovery via admin-replay + follow-up queue, not Stripe retries.
+- **Body consumed before signature verify.** Mitigation: `EnableBuffering()` + leave-open reader +
+  `Body.Position = 0`, copied from `GitHubEndpoints.Webhooks`; route stays body-untouched until
+  after verify; no JSON model binding on the route.
+- **Secret resolution coupling to 35-1.** `ISecretStore` doc-comment forbids returning plaintext;
+  Task 5 must bind to whatever concrete plaintext path 35-1 exposes. Mitigation: Task 5 starts by
+  reading 35-1's `StripeBillingProvider`/cabinet helper; if 35-1 is not yet merged, stub behind a
+  small `IStripeSigningSecretSource` seam and bind on integration.
+- **Dedup race under concurrent retries.** Mitigation: insert-then-catch on `UNIQUE(stripe_event_id)`
+  (no TOCTOU window), exactly the `GitHubWebhookDelivery (PlatformKind, DeliveryId)` precedent.
+- **Owning a sibling's entity by accident.** Mitigation: explicit boundary — 35-5 creates only
+  `BillingWebhookEvent`; mirror writes are sibling handlers; `NullBillingEventHandler` keeps the DCB
+  trail complete before they register. Code review checks no `BillingSubscription`/`BillingInvoice`/
+  `BillingPaymentMethod` entity is added here.
+- **Event-store topology shift (Story 28-1 / Epic 30).** `BILLING.*` events append to the CP
+  `domain_events` via `IEventRepository` today. Mitigation: keep the recorder writing through the CP
+  `IEventRepository` with the resolved `TenantId` tag, so a future per-tenant fan-out only touches
+  routing, not the emission call sites.
+- **Migration discipline.** `billing_webhook_events` is additive; still run
+  `has-pending-model-changes` (expect none) and declare config only in `TammaModelConfiguration`
+  (single source).
+- **Credential leakage into the event/audit store.** Mitigation: never persist the raw body beyond
+  the `payload` column (Stripe's own redaction applies), never log the signing secret /
+  `Stripe-Signature`; scrub `LastError` via `CredentialRedactor.Clean`.
+
+---
+
+## Acceptance criteria (mirrors the story)
+
+- [ ] `POST /api/v1/billing/stripe/webhook` captures the raw body via `EnableBuffering()` and
+      verifies with `Stripe.EventUtility.ConstructEvent`; the signing secret resolves through 35-1's
+      cabinet path (`SecretScope.Platform`/`SecretPurpose.ApiKey`), never `IConfiguration`.
+- [ ] Invalid/missing signature → `400` (no row, no event, WARN without raw body); unresolvable
+      secret → `503` (never fail open).
+- [ ] `BillingWebhookEvent` table dedupes on `UNIQUE(stripe_event_id)`; duplicate delivery → `200`
+      with no reprocessing (one row, one projection, one DCB event).
+- [ ] Tenant resolved via `BillingCustomer.StripeCustomerId → TenantId`; unresolved → `200 skipped`.
+- [ ] Default handlers cover `customer.subscription.created/updated/deleted`,
+      `invoice.created/finalized/paid/payment_failed`,
+      `payment_intent.succeeded/payment_intent.payment_failed`,
+      `customer.subscription.trial_will_end`, `charge.dispute.created`.
+- [ ] Each dispatched event emits a `BILLING.*` DCB event via `IEventRepository.AppendAsync` with
+      tags `{ tenantId, stripeEventId, eventType, stripeObjectId }`.
+- [ ] Mirror updates are performed by sibling-registered `IBillingEventHandler`s; 35-5 ships only
+      the dispatch seam + DCB emission + `NullBillingEventHandler` (no `BillingSubscription`/
+      `BillingInvoice`/`BillingPaymentMethod` entities created here).
+- [ ] Fast-ack: heavy work → `PlatformQueuedTask` (`Type = "billing.webhook.followup"`), never
+      inline; p95 ack `< 2s`.
+- [ ] Unknown event types → INFO + `200 skipped`; no `4xx`/`5xx` that triggers Stripe retries
+      (except signature/secret).
+- [ ] Admin `GET /api/v1/admin/billing/webhook-events` + `POST .../{id}/replay` (`PlatformOwnerAccess`)
+      list + re-dispatch; replay of a `projected` event is a no-op.
+- [ ] Single-user mode: webhook + admin routes unmapped (`NullBillingProvider`); SaaS mode: mapped,
+      tenant resolution mandatory.
+- [ ] Tenant isolation: a webhook for tenant A never writes a DCB event/row tagged tenant B;
+      verified by an integration test with interleaved A/B deliveries.
+- [ ] Unit + integration suite green (`sg docker -c "dotnet test ..."`); migration applies +
+      rolls back cleanly; `has-pending-model-changes` reports none.

--- a/docs/superpowers/plans/2026-06-17-35-6-plan-quota-and-usage-limit-enforcement-plan.md
+++ b/docs/superpowers/plans/2026-06-17-35-6-plan-quota-and-usage-limit-enforcement-plan.md
@@ -1,0 +1,228 @@
+# Story 35-6 — Plan Quota & Usage-Limit Enforcement (BYOK-Aware)
+
+> Implementation plan · Epic 35 (Billing & Payments, C#) · drafted 2026-06-17 · target: `apps/tamma-elsa` (.NET 9 / EF Core 9 / Npgsql) · test-first (TDD), xUnit; docker-bound suites run via `sg docker -c "dotnet test ..."`.
+
+> **For agentic workers:** REQUIRED SUB-SKILL — use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan phase-by-phase. Steps use checkbox (`- [ ]`) syntax for tracking. Every phase writes tests **before** implementation.
+
+**Goal:** Enforce plan quotas (period platform-token allowance, seat caps, concurrent workflows, connected repos) at the right gates, resolved from the tenant's *live* subscription + plan catalog. Platform-provided token usage counts against the allowance; BYOK token volume is exempt (BYOK is gated only on seats/repos/features). Reuse and extend the existing `CheckBudgetActivity` fail-closed seam for the engine LLM path, add a pre-dispatch check for workflow runs, emit soft-warn / over-quota DCB events into the alert pipeline, and return a stable machine-readable over-quota response — all distinct from the existing absolute `BudgetConfig` USD cap, per-tenant-isolated, and a single-user no-op.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO usage metering / rollup writes.** `BillingUsageRollup` is *written* by Story 35-3. This story only *reads* the current-period rollup. No new token-counting on the LLM response path.
+- **NO subscription lifecycle / checkout / webhook ingestion.** `BillingSubscription` and the `SUBSCRIPTION.UPDATED` hook belong to Story 35-4. This story consumes the entity and exposes `IQuotaService.Invalidate(tenantId)` for 35-4 to call on change.
+- **NO invoicing, overage line-item creation, dunning, tax, billing portal, or credits wallet.** This story emits the `AllowWithOverage` *decision* + the `BILLING.QUOTA.EXCEEDED` *event*; it does not bill.
+- **NO synchronous Stripe call on the enforcement path.** All checks read CP / per-tenant tables. Stripe is the invoicing system of record, never the < 100ms decision source (mirrors Story 20-3's "query local, not Stripe").
+- **NO seat/repo endpoint relocation.** Seat cap is checked at the existing member-invite gate, repo cap at the existing installation-repo add gate. This plan adds the `IQuotaService` call only.
+- **NO alert-rule seeding for `BILLING.QUOTA.*`.** The events are CP-resident and `AlertRuleEvaluator`-visible; a `BuiltInAlertRules` entry is a trivial follow-up (mirrors the budget-exhausted rule).
+- **NO change to the absolute `BudgetConfig` USD cap semantics.** The quota check is *additive* alongside the budget check; both can fire, with separate reasons/events.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### What enforcement exists today, and where the seams are
+
+| Site | Behaviour today | Relevance |
+|---|---|---|
+| `src/Tamma.Activities/LlmCall/CheckBudgetActivity.cs` (`ExecuteAsync` ~49) | Calls `TammaApiClient.GetBudgetAsync(budgetOwnerId, ...)` → `GET /api/providers/diagnostics/budget/{accountId}`. On `Spent >= Limit` completes outcome `"BudgetExhausted"`; otherwise `"WithinBudget"`. Any exception ⇒ **fail closed** to `"BudgetExhausted"` (`:157-165`). Emits `BUDGET.EXHAUSTED` via `IAlertEventEmitter`. | **The fail-closed seam to extend** (AC4). Add a quota check after the budget check; reuse the `"BudgetExhausted"` outcome so the flowchart wiring is untouched. |
+| `src/Tamma.Activities/LlmCall/TammaApiClient.cs` (`GetBudgetAsync` ~139) | `GET {base}/api/providers/diagnostics/budget/{budgetOwnerId}` returning `BudgetStatus?`; engine-auth via shared secret. | Add `GetTokenQuotaAsync(tenantId)` calling the new `GET /api/v1/billing/quota/{tenantId}/token`. |
+| `src/Tamma.Api/Endpoints/ProviderEndpoints.cs` (`GetBudget` ~393) → `DiagnosticsService.GetBudgetAsync` (~280) → `BudgetStatus` record (`Services/Diagnostics/Models/DiagnosticsModels.cs:115`) | Returns `{ Spent, Limit, Remaining, PercentUsed, ShouldAlert, IsOverBudget }` from `PostgresBudgetConfigProvider` (60s cache, `PostgresBudgetConfigProvider.cs:33`). | Pattern to mirror for the engine-callable token-quota route + the 60s cache. |
+| `src/Tamma.Api/Services/SaaS/LlmProxyService.cs` (`ChatAsync`) → `/api/v1/llm/chat` (`Program.cs:1900`, handler `SaaSEndpoints.LlmChat:38`) | Platform-provided LLM proxy. On failure maps `response.ErrorReason switch`: `"budget_exceeded" => 402`, `"invalid_request" => 400`, else 502. | **The platform-token gate** (AC2/AC8). Add a `CheckTokenQuotaAsync` pre-call; add a `"quota_exceeded" => 402` arm (distinct from `budget_exceeded`). |
+| `src/Tamma.Api/Endpoints/EngineEndpoints.cs` (`ExecuteTask` ~581, `TriggerCi` ~545) → `/api/engine/execute-task`, `/api/engine/trigger-ci` (`Program.cs:1853-1854`, `WorkflowsManage`) | Workflow-dispatch entry points; `ExecuteTask` already resolves `ITenantContext tc`. | **The pre-dispatch gate** (AC5): add `CheckConcurrentWorkflowQuotaAsync` before dispatch. |
+| `src/Tamma.Data/Entities/Plan.cs:32` — `public string Quotas { get; set; } = "{}";` | Stored by `PlansSeeder`, **read by nothing**. Doc-comment says "opaque JSON consumed by the billing layer" — that layer doesn't exist yet. | **Dead config this story activates** (AC1): parse into `PlanQuota`. |
+| `src/Tamma.Data/Entities/Tenant.cs:11` — `public string Plan { get; set; } = "free";` | The tenant's plan slug. Separate from any `BillingSubscription` (created by 35-4). | Fallback plan source when no subscription row exists (free-tier pre-checkout). |
+
+### Inputs for the non-token quota dimensions
+
+- **Seats** — count `TenantMembership` rows for the tenant (`Tamma.Data/Entities/TenantMembership.cs`: `TenantId`, `UserId`, `Role`).
+- **Connected repos** — count active `GitHubInstallationRepo` rows (`IsActive == true`) for the tenant's installation (`Tamma.Data/Entities/GitHubInstallationRepo.cs`).
+- **Concurrent workflows** — count in-flight `WorkflowInstance` rows for the tenant (`Tamma.Data/Entities/WorkflowInstance.cs`).
+
+### Billing entities this story consumes (created by prerequisite stories — NOT created here)
+
+- `BillingSubscription` — **Story 35-4** (active subscription → plan slug + overage flags).
+- `BillingUsageRollup` — **Story 35-3** (current-period token usage, `billing_mode='platform'` split).
+- `BillingCustomer.BillingMode` (`PlatformProvided|Byok`) + `ITenantProviderKeyResolver` + the `billing_mode` tag on `LLM.CALL.*` / `ProviderDiagnostic.BillingMode` — **Stories 35-1 / 35-2**.
+- `Services/Billing/` directory + `IBillingProvider`/`NullBillingProvider` registration pattern — **Story 35-1**.
+
+> If a prerequisite entity name differs at implementation time, adapt the read in `QuotaResolver`/`QuotaService` only — the public `IQuotaService` contract is stable.
+
+### Infrastructure to reuse
+
+- **Events:** `IEventRepository.AppendAsync(DomainEvent)` (`src/Tamma.Data/Repositories/IEventRepository.cs`); `DomainEvent { Type, TenantId, Tags(JSONB), Metadata, Data }`. CP-resident; the Story 5.6 `AlertRuleEvaluator` polls this exact table.
+- **Mode:** `ITammaModeProvider` (`src/Tamma.Api/Services/PromptStore/TammaMode.cs`) — process-stable SingleUser | SaaS.
+- **Tenant context:** `ITenantContext` (`src/Tamma.Data/ITenantContext.cs`) — ambient `TenantId`, also a global query filter (defence-in-depth isolation).
+- **Auth policies (`Program.cs`):** `OwnerAccess` (`:971`, `users:manage`), `MemberAccess` (`:991`, authenticated tenant member), `PlatformOwnerAccess` (`:986`, platform admin). Tenant-scope endpoints mirror `AlertEndpoints.cs` (admin section + `/api/v1/orgs/{tenantId}/...` section).
+- **Cache pattern:** `PostgresBudgetConfigProvider` — `ConcurrentDictionary` + 60s TTL, invalidated on write. Reuse the shape for `PlanQuota`.
+- **DI extension pattern:** `BillingServiceCollectionExtensions` (35-1) / `AddDiagnosticsServices` — mode-aware registration of real-vs-null seam.
+
+---
+
+## Architecture
+
+**Resolve → check → decide → emit → respond**, with a single `IQuotaService` seam and a null seam for single-user:
+
+1. **`IQuotaService`** (new) — the one enforcement seam. `GetQuotaAsync`, `CheckTokenQuotaAsync`, `CheckConcurrentWorkflowQuotaAsync`, `CheckSeatQuotaAsync`, `CheckConnectedRepoQuotaAsync`, `Invalidate`. `QuotaService` (SaaS, EF + 60s cache) and `NullQuotaService` (single-user, always `Allowed`).
+2. **`QuotaResolver`** — subscription (35-4) → plan slug → `Plan.Quotas` JSON → strongly-typed `PlanQuota` (tolerant parse; malformed ⇒ fail-closed to free quota). Cached per tenant.
+3. **`QuotaDecision`** — `{ Allowed, WhichQuota, Limit, Used, ResetAt, HttpStatus }`; `402` for token HardBlock, `429` for caps.
+4. **`QuotaNotifier`** — per-(tenant, dimension, period, level) dedup ledger (`quota_notifications` table) gating `BILLING.QUOTA.WARN` / `BILLING.QUOTA.EXCEEDED` DCB emission to exactly once.
+5. **Gates wired:** platform-token → `LlmProxyService` + engine `CheckBudgetActivity`; concurrent-workflow → `EngineEndpoints` pre-dispatch; seat/repo → existing mutation gates.
+6. **Surfaces:** `GET /api/v1/admin/quota/{tenantId}` (OwnerAccess), `GET /api/v1/orgs/{tenantId}/quota` (MemberAccess).
+
+### Per-mode ownership (the mandatory two-scoping-model answer)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Is there a quota dimension? | No — sole user owns all usage; `NullQuotaService` returns `Allowed` for every check. | Yes — the tenant is the principal; quota keyed by `tenantId`. |
+| What still applies in single-user? | Only the existing local `BudgetConfig` USD cap (unchanged). | Quota *and* the USD cap (separate reasons/events). |
+| Who reads the quota surfaces? | Route absent. | Platform owner (`/api/v1/admin/quota/{id}`); tenant members (`/api/v1/orgs/{id}/quota`). |
+| Where do quota events fan out? | Not emitted. | Tenant-scoped (`TenantId` set) → tenant alert feed + notifications. |
+| Mode source | `ITammaModeProvider` (process-stable). | same |
+
+---
+
+## Phased task breakdown
+
+### Phase 1 — Core types + `quota_notifications` ledger + `IQuotaService`/`NullQuotaService` skeleton (no gate wiring yet)
+
+**Files:**
+- New: `src/Tamma.Core/Billing/PlanQuota.cs` (record + `OverageBehavior` enum), `QuotaDimension.cs`.
+- New: `src/Tamma.Api/Services/Billing/IQuotaService.cs`, `QuotaDecision.cs`, `QuotaEvents.cs`, `QuotaOptions.cs`, `NullQuotaService.cs`.
+- New: `src/Tamma.Data/Entities/QuotaNotification.cs`; DbSet + config in `ControlPlaneDbContext.cs` / `TammaModelConfiguration.cs` (CHECK on `Level IN ('warn','exceeded')`; `UNIQUE (TenantId, WhichQuota, PeriodStart, Level)`). Additive EF migration under `Migrations/ControlPlane/` (`dotnet ef migrations add AddQuotaNotifications --context ControlPlaneDbContext`).
+- New: `src/Tamma.Api/Extensions/QuotaServiceCollectionExtensions.cs` (`AddTammaQuota` registers `NullQuotaService` in single-user, real `QuotaService` in SaaS); wire in `Program.cs` (mirror `BillingServiceCollectionExtensions`).
+
+**Approach:** Define the stable contract first; register the null seam so the host boots; the real `QuotaService` body lands in Phase 2. `NullQuotaService` short-circuits every method to `QuotaDecision.Allow(d)` with zero DB access.
+
+**Tests first (`tests/Tamma.Api.Tests/Billing/NullQuotaServiceTests.cs`):** every check returns `Allowed`, no DB read, no event; `AddTammaQuota` registers `NullQuotaService` under `TammaMode.SingleUser` and `QuotaService` under `TammaMode.SaaS`. Migration applies + rolls back; `has-pending-model-changes` reports none.
+
+---
+
+### Phase 2 — `QuotaResolver` + `QuotaService` token-quota decision (the hot path, BYOK-aware)
+
+**Files:**
+- New: `src/Tamma.Api/Services/Billing/QuotaResolver.cs` (subscription→plan→`PlanQuota`, tolerant JSON parse, fail-closed to free on malformed), `QuotaService.cs` (`GetQuotaAsync` cached 60s; `CheckTokenQuotaAsync`), `QuotaNotifier.cs` (dedup insert + DCB emit).
+- Read deps: `BillingSubscription` (35-4) with `Tenant.Plan` fallback; `Plan` by slug; `BillingUsageRollup` (35-3) current-period `billing_mode='platform'` sum; `BillingCustomer.BillingMode` for the BYOK short-circuit.
+
+**Approach (TDD):**
+1. `QuotaResolver`: resolve active subscription → plan slug (fallback `Tenant.Plan`); load `Plan`; parse `Plan.Quotas` into `PlanQuota`; malformed JSON ⇒ free quota + WARN log. Cache `(PlanQuota, fetchedAt)` per tenant, 60s TTL.
+2. `CheckTokenQuotaAsync(tenantId, billingMode, projectedTokens)`: `byok` ⇒ `Allow` (no rollup read, asserted by a never-called mock); `allowance == null` ⇒ `Allow`; read rollup `used`; compute `used + projected` vs `WarnThreshold*allowance` and `allowance`; emit WARN at ≥80% (once), EXCEEDED at ≥100% (once); HardBlock ⇒ deny 402 (`ResetAt`=period end), AllowWithOverage ⇒ allow.
+3. `QuotaNotifier.NotifyAsync`: insert-if-absent on `(TenantId, WhichQuota, PeriodStart, Level)`; fresh insert ⇒ append DCB event; unique-violation ⇒ no-op.
+
+**Tests first:**
+- `QuotaResolverTests.cs` — free/team/enterprise parse; missing keys default; malformed ⇒ fail-closed free + WARN; no-subscription ⇒ `Tenant.Plan` fallback; cache hit avoids re-resolve.
+- `QuotaServiceTokenTests.cs` — free at 100% ⇒ deny 402 (`reset_at`); paid at 100% ⇒ allow (overage); BYOK over allowance ⇒ allow (rollup mock never called); 80% ⇒ allow + one WARN; null allowance ⇒ allow.
+- `QuotaNotifierTests.cs` — first WARN/EXCEEDED inserts + emits once; repeat in same period ⇒ no second event; new period ⇒ new event.
+
+---
+
+### Phase 3 — Cap checks (seats, concurrent workflows, connected repos) + invalidation
+
+**Files:**
+- Modify: `QuotaService.cs` — `CheckSeatQuotaAsync` (count `TenantMembership`), `CheckConcurrentWorkflowQuotaAsync` (count in-flight `WorkflowInstance`), `CheckConnectedRepoQuotaAsync` (count active `GitHubInstallationRepo`); each vs the `PlanQuota` cap (null ⇒ unlimited); `Invalidate(tenantId)` evicts the cache.
+
+**Approach (TDD):** each cap check loads `PlanQuota` (cached), counts the relevant rows, returns `Allow` or deny 429 with `WhichQuota`/`Limit`/`Used`. `Invalidate` removes the per-tenant cache entry so the next `GetQuotaAsync` re-resolves.
+
+**Tests first:**
+- `QuotaServiceCapTests.cs` — seat cap (members == limit ⇒ deny 429; below ⇒ allow); concurrent cap (in-flight == limit ⇒ deny); repo cap; null cap ⇒ always allow.
+- `QuotaInvalidationTests.cs` — `Invalidate` evicts; subsequent `GetQuotaAsync` re-resolves the upgraded plan; a previously-blocked token check now allows (AC9).
+
+---
+
+### Phase 4 — Wire the platform-token gate (LlmProxyService + SaaSEndpoints)
+
+**Files:**
+- Modify: `src/Tamma.Api/Services/SaaS/LlmProxyService.cs` — before the upstream call, resolve `billing_mode` (from `ITenantProviderKeyResolver`/the 35-2 path), call `CheckTokenQuotaAsync(tenantId, mode, projectedTokens)`; deny ⇒ set `ErrorReason = "quota_exceeded"` and surface the `QuotaDecision` numbers.
+- Modify: `src/Tamma.Api/Endpoints/SaaSEndpoints.cs` — extend the `ErrorReason switch` with `"quota_exceeded" => Results.Json(QuotaResponse..., statusCode: 402)`, distinct from `"budget_exceeded"`.
+
+**Approach (TDD):** `projectedTokens` uses the request `MaxTokens` (or a conservative default) as the pre-call projection; the actual spend is metered by 35-3. BYOK ⇒ the quota check short-circuits Allow, so a BYOK call over allowance still succeeds.
+
+**Tests first (`LlmProxyServiceQuotaTests.cs`):** platform call over allowance (HardBlock) ⇒ `ErrorReason == "quota_exceeded"` ⇒ endpoint 402 with the `quota_exceeded` body; paid-tier over allowance ⇒ success (overage); BYOK over allowance ⇒ success; under allowance ⇒ success.
+
+---
+
+### Phase 5 — Wire the engine gate (CheckBudgetActivity) + the pre-dispatch gate (EngineEndpoints) + engine quota route
+
+**Files:**
+- Modify: `src/Tamma.Activities/LlmCall/CheckBudgetActivity.cs` — after the budget check passes, call `apiClient.GetTokenQuotaAsync(budgetOwnerId, ct)`; `!Allowed` ⇒ `"BudgetExhausted"`; the existing outer `catch` already fails closed to `"BudgetExhausted"` (AC4).
+- Modify: `src/Tamma.Activities/LlmCall/TammaApiClient.cs` — add `GetTokenQuotaAsync(tenantId)` → `GET /api/v1/billing/quota/{tenantId}/token`.
+- Modify: `src/Tamma.Api/Endpoints/ProviderEndpoints.cs` (+ `Program.cs` route map) — add the engine-callable `GET /api/v1/billing/quota/{tenantId}/token` returning `{ allowed, which_quota, limit, used, reset_at }` from `IQuotaService.CheckTokenQuotaAsync` (mode read server-side; engine-auth scheme like the budget route).
+- Modify: `src/Tamma.Api/Endpoints/EngineEndpoints.cs` — in `ExecuteTask` and `TriggerCi`, before dispatch, `CheckConcurrentWorkflowQuotaAsync(tc.TenantId)`; deny ⇒ `Results.Json(QuotaResponse, statusCode: 429)`.
+
+**Approach (TDD):** keep `CheckBudgetActivity`'s outcome alphabet (`WithinBudget`/`BudgetExhausted`) unchanged so the flowchart is untouched. The pre-dispatch check resolves the tenant from `ITenantContext`, never the request body (isolation).
+
+**Tests first:**
+- `tests/Tamma.Activities.Tests/LlmCall/CheckBudgetActivityQuotaTests.cs` — budget-ok + quota-ok ⇒ `WithinBudget`; budget-ok + quota-exhausted ⇒ `BudgetExhausted`; quota endpoint throws ⇒ fail-closed `BudgetExhausted`.
+- Endpoint test (Phase 7 integration): `/api/engine/execute-task` at concurrent cap ⇒ 429 `concurrent_workflows`.
+
+---
+
+### Phase 6 — Quota observability endpoints (admin + tenant)
+
+**Files:**
+- New: `src/Tamma.Api/Endpoints/Billing/QuotaEndpoints.cs` (mirror `AlertEndpoints.cs`: admin section + `/api/v1/orgs/{tenantId}/...` section); map in `Program.cs`.
+  - `GET /api/v1/admin/quota/{tenantId}` (`OwnerAccess`) ⇒ full resolved `PlanQuota` + usage per dimension.
+  - `GET /api/v1/orgs/{tenantId}/quota` (`MemberAccess`) ⇒ same shape, tenant resolved from context; cross-tenant ⇒ 404.
+
+**Approach (TDD):** compose the response from `GetQuotaAsync` + the per-dimension counts. Tenant route never accepts a client-supplied id for the read scope (isolation); the `{tenantId}` segment is validated against the authenticated tenant.
+
+**Tests first (`QuotaEndpointsTests.cs`):** admin route owner ⇒ 200 full shape; member on admin route ⇒ 403; `/orgs/{id}/quota` member ⇒ 200; cross-tenant ⇒ 404; single-user ⇒ routes absent (NullQuotaService path).
+
+---
+
+### Phase 7 — Integration + isolation + perf (docker-bound, real Postgres)
+
+**Files:** `tests/Tamma.Api.Tests/Billing/QuotaEnforcementIntegrationTests.cs` (run via `sg docker -c "dotnet test ..."`).
+
+**Tests:**
+- `/api/v1/llm/chat` free tenant at allowance ⇒ 402 `quota_exceeded`; after simulated upgrade + `Invalidate` ⇒ 200 (AC9).
+- `/api/engine/execute-task` at concurrent cap ⇒ 429.
+- **Tenant isolation**: seed A at 100%, B at 0%; A ⇒ 402, B ⇒ 200; A's rollup/subscription never read for B; `/orgs/{B}/quota` never returns A's numbers; cross-tenant `/orgs/{A}/quota` with B's token ⇒ 404.
+- Migration applies + rolls back; `has-pending-model-changes` none.
+- **Perf**: warm-cache quota check p95 < 100ms over N iterations (AC6) — assert no Stripe client is constructed on the path.
+
+---
+
+## Sequencing & dependencies
+
+```
+Phase 1 (core + ledger + null seam)
+  └─ Phase 2 (resolver + token decision)        ← needs P1 contract
+       ├─ Phase 3 (cap checks + invalidate)      ← needs P2 service
+       ├─ Phase 4 (LlmProxy + SaaS endpoint)     ← needs P2 token decision
+       └─ Phase 5 (engine activity + pre-dispatch)← needs P2/P3
+            └─ Phase 6 (observability endpoints)  ← needs P2/P3
+                 └─ Phase 7 (integration/isolation/perf)
+```
+
+- **Phase 1** is the only hard prerequisite for everything else.
+- **Phases 3, 4, 5** are parallel-safe once Phase 2 lands (independent gates).
+- **External story prerequisites:** 35-3 (`BillingUsageRollup`) and 35-4 (`BillingSubscription` + invalidation hook) must be merged before Phase 2; 35-1/35-2 (`BillingCustomer.BillingMode`, `Services/Billing/`) before Phase 1.
+
+---
+
+## Risks + mitigations
+
+- **Latency on every LLM call** (High) — cached `PlanQuota` (60s) + a single indexed rollup read; BYOK short-circuits before any read; Phase 7 perf test asserts p95 < 100ms and no Stripe client construction.
+- **Malformed `Plan.Quotas` ⇒ accidental unlimited** (High) — tolerant parser fails *closed* to the free-tier quota with a WARN; `QuotaResolverTests` pins this.
+- **Event flood from a hot over-quota loop** (Medium) — per-(tenant, dimension, period, level) dedup ledger caps emission at one; alert evaluator `ThrottleSeconds` is the secondary guard.
+- **Stale cache after upgrade keeps a tenant blocked** (High) — 35-4 calls `Invalidate(tenantId)` on `SUBSCRIPTION.UPDATED`; `QuotaInvalidationTests` + the Phase 7 upgrade test assert immediate lift.
+- **BYOK tenant wrongly throttled** (High) — BYOK short-circuit is checked first and is the dedicated `QuotaServiceTokenTests` BYOK case; the rollup is never read for BYOK.
+- **Engine quota endpoint unreachable** (Medium) — `CheckBudgetActivity`'s existing fail-closed `catch` denies; `CheckBudgetActivityQuotaTests` asserts it.
+- **Prerequisite entity-name drift (35-3/35-4)** (Medium) — confine all reads of `BillingUsageRollup`/`BillingSubscription` to `QuotaResolver`/`QuotaService`; the public `IQuotaService` contract is stable so call-sites don't churn.
+- **Migration discipline** (Low) — `quota_notifications` is additive (new table, not a baseline CHECK edit); still verify `has-pending-model-changes` reports none and mirror config in `TammaModelConfiguration.cs` only.
+
+---
+
+## Acceptance criteria (mirror the story)
+
+- [ ] `QuotaService` resolves the effective quota from the active `BillingSubscription` + plan catalog, parsing `Plan.Quotas` (previously dead config) into `PlanQuota`.
+- [ ] Platform-provided LLM calls are gated against the period token allowance; free ⇒ HardBlock (402), paid ⇒ AllowWithOverage — distinct from the `BudgetConfig` USD cap.
+- [ ] BYOK tenants are never blocked on token volume; still gated on seats / connected repos / feature flags.
+- [ ] Engine path reuses/extends `CheckBudgetActivity` (fail-closed) for the LLM check; a pre-dispatch concurrent-workflow check is added; all checks complete < 100ms p95 from the local rollup (no Stripe).
+- [ ] Soft thresholds (80/100%) emit `BILLING.QUOTA.WARN` / `BILLING.QUOTA.EXCEEDED` DCB events feeding the notifications/alert path, deduped once per (tenant, dimension, period).
+- [ ] Over-quota responses use a stable shape (402/429 with `code quota_exceeded`, `which_quota`, `reset_at`, `limit`, `used`) consumable by the dashboards.
+- [ ] Quotas recompute immediately on subscription/seat change (`Invalidate`) so an upgrade lifts the block without a restart.
+- [ ] Single-user mode enforces no quotas (`NullQuotaService`); SaaS mode keys quota by `tenantId`; tenant isolation holds (A's usage never gates B).
+- [ ] Unit + integration tests cover: free-tier hard block, paid overage allow, BYOK exemption, seat-cap block, concurrent-cap block, warn/exceeded single-emission, sub-change recompute, engine fail-closed, tenant isolation — Stripe + provider HTTP mocked.

--- a/docs/superpowers/plans/2026-06-17-35-7-payment-methods-and-self-service-stripe-billing-portal-plan.md
+++ b/docs/superpowers/plans/2026-06-17-35-7-payment-methods-and-self-service-stripe-billing-portal-plan.md
@@ -1,0 +1,260 @@
+# Story 35-7 — Payment Methods & Self-Service Stripe Billing Portal — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan phase-by-phase. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every phase writes tests
+> before implementation.
+
+**Story:** `docs/stories/epic-35/story-35-7/35-7-payment-methods-and-self-service-stripe-billing-portal.md` · **Epic 35** (Billing & Payments, C#) · **Priority P1** · **Est. 3-4 days** · **Today: 2026-06-17**
+
+**Goal:** Let tenant admins manage payment methods and billing details without leaving Tamma —
+integrate the Stripe Customer Portal (session creation + allowlisted return URL), a SetupIntent flow
+for adding/replacing the default card, and a local masked `BillingPaymentMethod` mirror (brand/last4/
+exp/default/status) kept in sync by Story 35-5 webhooks. Everything is SaaS-RBAC-gated, per-tenant
+isolated, and audited via DCB events; a paid tenant left without a usable card emits a signal for the
+Story 35-8 dunning path.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO webhook ingestion.** Story 35-5 owns the verified Stripe webhook endpoint and the
+  `IBillingEventHandler` dispatch registry. 35-7 only registers `PaymentMethodBillingEventHandler`
+  into it — it does not parse signatures, dedupe deliveries, or resolve tenancy from customer ids.
+- **NO dunning / notification delivery.** 35-7 emits `BILLING.PAYMENT_METHOD.MISSING`/`REMOVED` DCB
+  events and surfaces `hasUsableDefault`. Story 35-8 builds the escalation, retries, emails, and
+  alert-rule wiring. Boundary is strict — do not implement another story's responsibility.
+- **NO subscription / invoice mirrors.** `BillingSubscription` (35-4) and `BillingInvoice` (35-8)
+  are not touched. Paid-plan detection reads existing subscription/plan state **read-only**.
+- **NO raw card storage.** PAN/CVC never reach any Tamma column. Cards are collected client-side via
+  Stripe Elements + SetupIntent; only brand/last4/exp are mirrored. Keeps Tamma in SAQ-A scope.
+- **NO single-user Stripe coupling.** In `SingleUser` mode the routes are not mapped and the
+  `NullStripeCustomerPortalClient` no-op wins (parallels 35-1 `NullBillingProvider`).
+- **NO Stripe round-trip on read.** `GET /payment-methods` reads only the local mirror.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### What exists and is reused
+
+| Seam | File (verified) | Use in 35-7 |
+|---|---|---|
+| Tenant→Stripe customer mapping | `BillingCustomer` (Story 35-1, `apps/tamma-elsa/src/Tamma.Data/Entities/BillingCustomer.cs`) | resolve `StripeCustomerId` from `TenantId` for portal/setup-intent |
+| Billing provider seam + Null impl | `IBillingProvider` / `NullBillingProvider` (Story 35-1) | mirror the Null-seam pattern for `IStripeCustomerPortalClient` |
+| Webhook dispatch registry | `IBillingEventHandler` + `BillingWebhookContext` (Story 35-5) | register `PaymentMethodBillingEventHandler`; `ctx.TenantId` pre-resolved |
+| Secret cabinet | `apps/tamma-elsa/src/Tamma.Api/Services/Secrets/ISecretStore.cs`; `SecretScope.Platform`, `SecretPurpose.ApiKey` (`Secrets/SecretPurpose.cs`) | resolve Stripe secret key — never raw env |
+| DCB event append | `apps/tamma-elsa/src/Tamma.Data/Repositories/IEventRepository.cs` → `AppendAsync(DomainEvent)`; entity `Entities/DomainEvent.cs` (`Type`, `TenantId`, `Tags` JSON, `Data`, `SequenceNumber`) | emit `BILLING.PAYMENT_METHOD.*` / `BILLING.PORTAL_SESSION.CREATED` |
+| Alert pipeline (downstream) | `Services/Alerts/IAlertSink.cs` (`RaiseAsync(AlertPayload)`); `AlertRuleEvaluator` polls `DomainEvents` | 35-8 subscribes to our DCB events — no work here |
+| Tenant RBAC | `Authorization/TenantRoleHierarchy.cs` (owner=2/admin=1/member=0); `RequireTenantMembershipFilter.TenantRoleItemKey` (used across `OrgEndpoints.cs`, `AlertEndpoints.cs:1010`) | gate portal/setup-intent to owner+admin; GET to any member |
+| Authz policies | `Program.cs:966-1038` — `PromptManage`/`ConventionManage` are the owner+admin precedent (`PermissionRequirement("prompts:manage")`) | add `BillingManage` = `PermissionRequirement("billing:manage")` the same way |
+| Mode provider | `Services/PromptStore/TammaMode.cs` — `ITammaModeProvider.Mode` (`SingleUser`/`SaaS`), process-stable | gate route mapping |
+| At-rest crypto pattern | `Services/Provisioning/TenantSecretProtector.cs` (AES-GCM) | reference only — 35-7 stores no secrets, only masked card data |
+| CP DbContext + model config | `ControlPlaneDbContext.cs` (DbSets, line ~33+); `TammaModelConfiguration.cs` (single source for entity config) | register `BillingPaymentMethod` here |
+| CP migrations dir | `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/` (snapshot `ControlPlaneDbContextModelSnapshot.cs`) | additive migration here |
+| Endpoint mapping | `Program.cs:1443+` (`v1Admin.MapGet("/alerts", ...)`) and tenant `/api/v1/orgs/{tenantId}/...` sections | map billing routes conditionally on SaaS mode |
+| Tenant dashboard | `packages/dashboard-user/src/api/alerts.ts`, `pages/alerts/TenantAlertFeed.tsx`, `pages/settings/ConnectedPlatforms.tsx` | mirror conventions for `api/billing.ts` + settings page |
+
+### Where the gaps are
+
+- **No `BillingPaymentMethod` entity / table** exists — `ControlPlaneDbContext` has billing-adjacent
+  sets (35-1's `BillingCustomers` lands first) but no payment-method mirror. **NEW.**
+- **No portal/setup-intent endpoints** — `Endpoints/` has no `Billing/` directory yet. **NEW.**
+- **No Stripe portal client seam** — `Services/Billing/` is created by 35-1; 35-7 adds the portal
+  client + payment-method service + the `IBillingEventHandler` impl. **NEW.**
+- **No `BillingManage` policy** — `Program.cs` has `PromptManage`/`ConventionManage`; add the
+  billing analogue. **MODIFY.**
+- **Tenant tests dir** — `apps/tamma-elsa/tests/Tamma.Api.Tests/` exists (xUnit; docker-bound suites
+  run `sg docker -c "dotnet test ..."` per `reference_dotnet_test_docker.md`). Add `Billing/`.
+
+### Hard dependency status
+
+35-1 and 35-5 are **drafted, not implemented** (verified: both story files exist under
+`docs/stories/epic-35/`, statuses `drafted`). 35-7 must not start until both land — it consumes
+`BillingCustomer` (35-1) and the `IBillingEventHandler` registry + `BillingWebhookContext` (35-5).
+If a phase needs a seam that 35-1/35-5 haven't shipped, **stop and flag** rather than re-implement it.
+
+---
+
+## Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns a payment method? | n/a — routes not mapped; `NullStripeCustomerPortalClient` registered; no Stripe coupling | the tenant; `BillingPaymentMethod` keyed by `TenantId` |
+| Who can open the portal / add a card? | n/a | `tenant_owner` / `tenant_admin` (`BillingManage`); `member` → 403 |
+| Who can read masked methods? | n/a | any tenant member (`MemberAccess` + membership filter) |
+| Where do DCB events go? | n/a | CP `DomainEvents`, `TenantId` set → tenant-scoped alert feeds (35-8) |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`) | same |
+
+---
+
+## Phased task breakdown (TDD — tests first each phase)
+
+### Phase 1 — `BillingPaymentMethod` entity, table, migration (core data)
+
+**Files:** new `Tamma.Data/Entities/BillingPaymentMethod.cs`; modify `ControlPlaneDbContext.cs`
+(`DbSet<BillingPaymentMethod> BillingPaymentMethods`) + `TammaModelConfiguration.cs` (table config,
+unique index on `StripePaymentMethodId`, index on `TenantId`, partial unique `WHERE is_default`,
+CHECK on `Status`); new additive migration under `Migrations/ControlPlane/` (+ snapshot update).
+
+**Tests first:** `tests/Tamma.Api.Tests/Billing/BillingPaymentMethodEntityTests.cs` — round-trip
+insert/read; two `IsDefault=true` rows for one tenant violate the partial unique index;
+invalid `Status` rejected by CHECK; `StripePaymentMethodId` collision rejected.
+
+**Approach:** mirror 35-1's `billing_customers` config in `TammaModelConfiguration` (single source —
+do NOT use data annotations). Run `dotnet ef migrations add AddBillingPaymentMethods --context
+ControlPlaneDbContext --output-dir Migrations/ControlPlane`; then
+`dotnet ef migrations has-pending-model-changes` MUST report none; apply + down to prove reversible.
+
+- [ ] write entity + EF-config tests (red)
+- [ ] add entity, DbSet, model config
+- [ ] generate migration; verify no pending model changes; apply + roll back
+- [ ] green
+
+### Phase 2 — `IPaymentMethodService` mirror + DCB events + missing-card signal
+
+**Files:** new `Services/Billing/IPaymentMethodService.cs`, `PaymentMethodService.cs`,
+`BillingPaymentMethodEventTypes.cs` (constants for the five event names),
+`Services/Billing/Dtos` (`PaymentMethodView`, `PaymentMethodMirrorInput`).
+
+**Tests first:** `tests/Tamma.Api.Tests/Billing/PaymentMethodServiceTests.cs` — attach upserts +
+emits `BILLING.PAYMENT_METHOD.ADDED`; detach flips `Status=detached` + clears `IsDefault` + emits
+`REMOVED`; default re-point clears prior default atomically + emits `DEFAULT_CHANGED`; last usable
+card detached on a **paid** tenant emits `BILLING.PAYMENT_METHOD.MISSING`; **free** tenant never
+emits MISSING; `ListAsync` returns masked view + correct `hasUsableDefault`; idempotent re-attach
+(same `StripePaymentMethodId`) → one row.
+
+**Approach:** all writes inside a CP transaction; DCB append via `IEventRepository.AppendAsync` with
+`TenantId` set and `Tags` JSON `{ tenantId, last4, brand, stripePaymentMethodId }`. Paid-plan check
+reads subscription/plan state from 35-1/35-4 read-only (inject a small `IBillingPlanState` query
+seam if 35-4's surface isn't directly queryable — keep it a thin read).
+
+- [ ] write service tests (red)
+- [ ] implement service (upsert/detach/default/list + event emission + missing signal)
+- [ ] green
+
+### Phase 3 — Stripe portal client seam + Null impl
+
+**Files:** new `Services/Billing/IStripeCustomerPortalClient.cs`, `StripeCustomerPortalClient.cs`
+(wraps `Stripe.BillingPortal.SessionService` + `Stripe.SetupIntentService`),
+`NullStripeCustomerPortalClient.cs`. Stripe secret key resolved via the 35-1 cabinet path
+(`ISecretStore` / `IBillingProvider`), never `IConfiguration`.
+
+**Tests first:** `tests/Tamma.Api.Tests/Billing/StripeCustomerPortalClientTests.cs` — Null impl
+throws/returns no-op as designed; secret unresolvable surfaces the 503 path (assert at endpoint level
+in Phase 4). (Live Stripe behaviour is covered in the integration suite, Phase 6.)
+
+**Approach:** parallel the `StripeBillingProvider`/`NullBillingProvider` split from 35-1. The real
+client constructs Stripe service options from the cabinet-resolved key per call (or a cached client
+refreshed on rotation, matching 35-1's resolver).
+
+- [ ] write client seam tests (red)
+- [ ] implement real + null clients
+- [ ] green
+
+### Phase 4 — Return-URL allowlist + endpoints + `BillingManage` policy + route mapping
+
+**Files:** new `Services/Billing/ReturnUrlAllowlist.cs`; new
+`Endpoints/Billing/BillingPortalEndpoints.cs` (`CreatePortalSession`, `CreateSetupIntent`,
+`ListPaymentMethods`); modify `Program.cs` — add `BillingManage` policy (mirror `PromptManage`),
+map the three routes **only when `ITammaModeProvider.Mode == SaaS`**, call the DI extension; new
+`Extensions/BillingPaymentMethodServiceCollectionExtensions.cs`.
+
+**Tests first:** `tests/Tamma.Api.Tests/Billing/ReturnUrlAllowlistTests.cs` (allowed/foreign/
+scheme-downgrade) and `BillingPortalEndpointsTests.cs` — portal: owner/admin 200, member 403,
+cross-tenant 404, no Stripe customer 409, Stripe error 502, secret unresolvable 503, emits
+`BILLING.PORTAL_SESSION.CREATED`; setup-intent: owner/admin 200, member 403; GET: masked list,
+**asserts `IStripeCustomerPortalClient` never called** on read; disallowed `returnUrl` → 400;
+single-user mode → routes not mapped (404).
+
+**Approach:** resolve tenant + role from `http.Items[RequireTenantMembershipFilter.TenantRoleItemKey]`
+exactly like `OrgEndpoints`/`AlertEndpoints`. Validate `returnUrl` origin before any Stripe call.
+
+- [ ] write allowlist + endpoint tests (red)
+- [ ] implement allowlist, endpoints, policy, DI extension, conditional route mapping
+- [ ] green
+
+### Phase 5 — `PaymentMethodBillingEventHandler` (register into 35-5 dispatch)
+
+**Files:** new `Services/Billing/PaymentMethodBillingEventHandler.cs` implementing 35-5's
+`IBillingEventHandler`; register in the DI extension.
+
+**Tests first:** `tests/Tamma.Api.Tests/Billing/PaymentMethodBillingEventHandlerTests.cs` —
+`HandledEventTypes` cover `payment_method.attached/detached/automatically_updated` + `customer.updated`;
+dispatch routes each to the right `IPaymentMethodService` call; uses `ctx.TenantId` (never re-derives
+tenancy); unknown sub-type is a no-op; **tenant-isolation** — a handler invocation for tenant A never
+writes a row/event for tenant B.
+
+**Approach:** thin adapter — parse the Stripe object from `BillingWebhookContext`, call the service.
+No heavy work inline (35-5's fast-ack contract); dunning follow-up is 35-8.
+
+- [ ] write handler tests (red)
+- [ ] implement handler + register it
+- [ ] green
+
+### Phase 6 — Integration tests (Stripe test mode + tenant isolation)
+
+**Files:** integration tests in `tests/Tamma.Api.Tests/Billing/` gated on `STRIPE_SECRET_KEY_TEST`.
+
+**Tests:** create a portal session against Stripe test mode → real `https://billing.stripe.com/...`
+URL; create a setup-intent + confirm a test card off-session → replay the `payment_method.attached`
+webhook through 35-5's processor → mirror upserted; **tenant-isolation** — replay tenant A's
+attach/detach → tenant B has zero rows and no DCB event tagged B; portal for tenant A never returns
+tenant B's customer.
+
+- [ ] write integration tests (run via `sg docker -c "dotnet test ..."`)
+- [ ] verify against Stripe test mode; full suite green
+
+### Phase 7 — Tenant dashboard surface
+
+**Files:** new `packages/dashboard-user/src/api/billing.ts` (mirror `api/alerts.ts`); new
+`pages/settings/BillingPaymentMethods.tsx` (Manage-billing portal button, Add-card via SetupIntent +
+Stripe Elements, masked list, missing-card banner); register in the settings router.
+
+**Tests first:** colocated `BillingPaymentMethods.test.tsx` (Vitest + Testing Library) — list renders
+masked rows; Manage-billing calls client + redirects to portal URL; Add-card mounts SetupIntent flow;
+member-role hides mutate buttons; empty state shows missing-card banner.
+
+**Approach:** load `@stripe/stripe-js` lazily; never render anything but masked last4. `pnpm test
+--filter @tamma/dashboard-user` green; no new lint errors.
+
+- [ ] write component tests (red)
+- [ ] implement client + page; register route
+- [ ] green
+
+---
+
+## Sequencing & dependencies
+
+External prerequisites (must be merged first): **35-1** (`BillingCustomer`, `IBillingProvider`/Null,
+cabinet wiring) and **35-5** (`IBillingEventHandler`, `BillingWebhookContext`, webhook ingestion).
+
+Internal order: **P1 → P2 → P3 → P4 → P5 → P6 → P7.** P3 (Stripe client) and P2 (service) are
+parallel-safe after P1. P5 needs P2 (service) + 35-5 (registry). P6 needs P4+P5. P7 needs P4 (API
+shape). 35-8 (dunning) consumes the DCB events this story emits — it is downstream, not a blocker.
+
+## Risks & mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| 35-1 / 35-5 seams not yet merged | High | Hard-gate: do not start until both land; if a needed seam is absent, stop and flag — never re-implement another story's surface |
+| Storing card data → PCI scope blowout | High | Mirror only brand/last4/exp; cards collected client-side via Elements + SetupIntent; PAN/CVC never reach the backend; assert in tests no full-PAN column exists |
+| Open-redirect via `returnUrl` | High | `ReturnUrlAllowlist` validates origin against `Billing:PortalReturnUrlAllowlist` before any Stripe call; disallowed → 400 + WARN |
+| Two defaults per tenant on a race | Medium | Partial unique index `WHERE is_default` fails loudly; service clears prior default in the same transaction |
+| Stripe at-least-once duplicate `attached` | Medium | Upsert keyed on `StripePaymentMethodId` is idempotent; 35-5 dedupe gates re-projection |
+| Cross-tenant leak | High | Read/mutate endpoints behind membership filter; webhook handler uses pre-resolved `ctx.TenantId`; dedicated isolation tests in P5+P6 |
+| Secret in raw env in prod | High | Resolve via Epic 29 cabinet only; unresolvable → 503, never fail open (mirrors 35-1 AC5 / 35-5 AC2) |
+| Logging card data | High | Log only masked last4 + Stripe request id; explicit WARN/ERROR rules forbid URLs/client-secrets/PAN |
+| Migration drift | Medium | Additive table; `has-pending-model-changes` must report none; config in `TammaModelConfiguration` only; apply + down verified |
+
+## Acceptance criteria (mirror of the story)
+
+- [ ] `POST /api/v1/billing/portal-session` returns a tenant-scoped Stripe Portal URL; owner/admin only (member 403, cross-tenant 404). Emits `BILLING.PORTAL_SESSION.CREATED`.
+- [ ] `POST /api/v1/billing/payment-methods/setup-intent` returns `{ clientSecret, setupIntentId }`; owner/admin only (member 403).
+- [ ] `BillingPaymentMethod` mirror stores `{ brand, last4, exp, isDefault, status }`, updated by `PaymentMethodBillingEventHandler` via 35-5 webhooks; raw PAN/card data never stored.
+- [ ] `GET /api/v1/billing/payment-methods` returns the masked mirror with **no Stripe round-trip on read**; includes `hasUsableDefault`.
+- [ ] `returnUrl` validated against the allowlist (disallowed → 400); sessions/setup-intents short-lived; URLs/secrets never persisted.
+- [ ] DCB `BILLING.PAYMENT_METHOD.ADDED/REMOVED/DEFAULT_CHANGED` emitted with `tags { tenantId, last4, brand, stripePaymentMethodId }`.
+- [ ] A paid-plan tenant with no usable card emits `BILLING.PAYMENT_METHOD.MISSING` and `hasUsableDefault: false` (signal only — 35-8 acts).
+- [ ] Single-user mode: routes not mapped, `NullStripeCustomerPortalClient` registered, no Stripe coupling.
+- [ ] Unit + integration tests pass, including tenant-isolation (tenant A webhook/portal never touches tenant B) and redirect-allowlist validation; full C# suite green via `sg docker -c "dotnet test ..."`; `pnpm test --filter @tamma/dashboard-user` green.

--- a/docs/superpowers/plans/2026-06-17-35-8-invoicing-failed-payment-dunning-and-recovery-plan.md
+++ b/docs/superpowers/plans/2026-06-17-35-8-invoicing-failed-payment-dunning-and-recovery-plan.md
@@ -1,0 +1,303 @@
+# Story 35-8 — Invoicing, Failed-Payment Dunning & Recovery (implementation plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan phase-by-phase. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every phase writes tests
+> before implementation. C# suites run via `sg docker -c "dotnet test ..."` (session docker group
+> is stale; build needs no wrapper).
+
+**Story:** `docs/stories/epic-35/story-35-8/35-8-invoicing-failed-payment-dunning-and-recovery.md`
+· **Epic 35** (Billing & Payments, C#) · **P0** · est **5-6 days** · today **2026-06-17**.
+
+---
+
+## Goal
+
+Mirror Stripe invoices into the control plane with a line-item breakdown (base / metered-overage /
+credit), expose a tenant-scoped invoice history + PDF retrieval, and run a deterministic, config-
+driven failed-payment dunning state machine (`active → past_due → grace → suspended`, recover on
+later payment) that escalates via the existing email outbox, suspends only after a grace period,
+and writes the suspension signal Story 35-6 reads to hard-block platform-provided usage — all
+BYOK-aware and audited via DCB events.
+
+## Non-goals (YAGNI guard)
+
+- NO webhook endpoint, signature verification, dedup, or `BillingWebhookEvent` — that is **Story
+  35-5**. 35-8 only registers `IBillingEventHandler` implementations into 35-5's dispatch seam.
+- NO quota/usage enforcement in the request path — that is **Story 35-6**. 35-8 writes
+  `BillingDunningState.Stage = suspended` and calls `IQuotaService.InvalidateAsync`; 35-6 reads it
+  and blocks. 35-8 ships zero code in the LLM/dispatch gate.
+- NO subscription lifecycle (create/upgrade/downgrade/cancel/trial) — **Story 35-4**. 35-8 only
+  reads `BillingSubscription` for invoice period + plan/seat context.
+- NO metering pipeline / Stripe meter reporting — **Story 35-3**. 35-8 consumes the metered-overage
+  lines that already appear on the Stripe invoice.
+- NO direct SMTP / transport calls. Dunning + dispute mail is `INSERT` into the existing outbox
+  tables only (`OutboxSmtpSender`/`ResendEmailService` deliver).
+- NO new delivery channels, no portal UI (Story 35-7 renders this data), no admin cross-tenant
+  invoice route (platform-side inspection rides 35-5's webhook-events endpoint + the DCB stream).
+- NO Stripe smart-retries — Tamma owns the retry/escalation cadence locally.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### Real infrastructure 35-8 builds on (all confirmed present)
+
+| Seam | File | Notes |
+|---|---|---|
+| Control-plane DbContext | `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | DbSets declared here; `DomainEvents`, `PlatformQueuedTasks`, `PlatformEmailOutbox`, `EmailOutbox`, `Plans`, `Tenants` all present (lines 36–213). 35-8 adds `BillingInvoices`, `BillingInvoiceLines`, `BillingDunningStates`. |
+| Entity model config (single source) | `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` → `ConfigureControlPlaneEntities` | Per 35-5, this is where indexes/CHECKs live — same place `AlertRule`/`GitHubWebhookDelivery` are configured. |
+| DCB append | `apps/tamma-elsa/src/Tamma.Data/Repositories/IEventRepository.cs` (`AppendAsync(DomainEvent)`, line 7); impl `EventRepository.cs:49` | `DomainEvent` = `{ Id, Type, TenantId, Tags(json), Metadata(json), Data(json), CreatedAt, SequenceNumber }` (`Entities/DomainEvent.cs`). |
+| Platform task queue | `IPlatformQueuedTaskRepository.cs` (`EnqueueAsync`, `CompleteAsync`, `FailAsync`, `DeadLetterAsync`, `GetAsync`); handler contract `Services/PlatformTasks/IPlatformTaskHandler.cs` (`TaskType` + `HandleAsync`); worker `PlatformTaskWorker.cs`; registry `IPlatformTaskHandlerRegistry.cs` | `PlatformQueuedTask` = `{ Id, Type, TenantId?, InstallationId?, Payload, Status, RetryCount, ... }` (`Entities/PlatformQueuedTask.cs`). Register via `services.AddPlatformTaskHandler<T>()`. |
+| Email outbox (no direct SMTP) | `Entities/PlatformEmailOutboxMessage.cs` (system mail) + `Entities/EmailOutboxMessage.cs` (tenant mail) | Both carry `{ Template, ToAddress, Subject, HtmlBody, TextBody, Status, Attempts, NextAttemptAt, TenantId? }`. Bodies are CodeQL-tainted private data — never log. Drained by existing `OutboxSmtpSender`/`ResendEmailService`. |
+| Tenant + plan | `Entities/Tenant.cs` (`Id, Slug, Plan, ...`), `Entities/Plan.cs` (`Slug, MonthlyPriceUsd, Quotas`) | Invoice `TenantId` FK → `tenants.Id`. |
+| Auth policies | `Tamma.Api/Program.cs` — `OwnerAccess` (971), `PlatformOwnerAccess` (986), `MemberAccess` (991), `PromptManage` (1012) | Tenant RBAC via `Authorization/RequireTenantMembershipFilter.cs` (`TenantRoleItemKey`) + `Authorization/TenantRoleHierarchy.cs` (`Level(role)`), as used in `Endpoints/OrgEndpoints.cs:181-210` and `Endpoints/AlertEndpoints.cs`. |
+| Mode | `Tamma.Api/Services/PromptStore/TammaMode.cs` (`ITammaModeProvider`, `TammaMode.SingleUser|SaaS`) | Process-stable; gates SaaS-only registration (same pattern 35-1/35-5 use). |
+| Endpoint exemplar | `Tamma.Api/Endpoints/AlertEndpoints.cs` | Admin section (`/api/v1/admin/alerts/*`) + tenant section (`/api/v1/orgs/{tenantId}/alerts/*`, lines 562–760). 35-8's `InvoiceEndpoints` mirrors the **tenant** read pattern at `/api/v1/billing/invoices`. |
+
+### Sibling-story contracts 35-8 plugs into (from drafted story files)
+
+- **35-5** (`docs/stories/epic-35/story-35-5/...md`): the dispatch seam —
+  `IBillingEventHandler { IReadOnlyCollection<string> HandledEventTypes; Task<BillingFollowup?>
+  HandleAsync(BillingWebhookContext ctx, ct); }`, `BillingWebhookContext(Stripe.Event, Guid
+  TenantId, string RawPayload)`, `BillingFollowup(string TaskType, string Payload)`,
+  `BillingEventHandlerRegistry` (mirrors `PlatformTaskHandlerRegistry`),
+  `services.AddBillingEventHandler<T>()`, and the `billing.webhook.followup` `PlatformQueuedTask`
+  fast-ack path. 35-5 emits `BILLING.INVOICE.FINALIZED/PAID/PAYMENT_FAILED` + `BILLING.DISPUTE.OPENED`
+  via the **NullBillingEventHandler** even before 35-8's handler exists — 35-8 takes over the
+  mirror + dunning logic for those types.
+- **35-1**: `BillingCustomer { TenantId(unique), StripeCustomerId, BillingMode }`,
+  `BillingMode { PlatformProvided, Byok }` (`Tamma.Core/Billing/BillingMode.cs`),
+  `NullBillingProvider` single-user seam, `BillingServiceCollectionExtensions`, Stripe.net.
+- **35-4**: `BillingSubscription { Status, PlanSlug, CurrentPeriodStart/End, Seats }`.
+- **35-6**: `IQuotaService` with `InvalidateAsync(tenantId)` and a `QuotaDecision.HardBlock` reason
+  taxonomy; 35-6 reads `BillingDunningState.Stage == suspended` for platform-provided calls; BYOK
+  token calls are exempt.
+
+### Gaps / risks surfaced by the scan
+
+- **No Stripe code exists in C# yet** (`grep -ril stripe apps/tamma-elsa/src` → only a Studio razor
+  page). Stripe.net, `BillingCustomer`, the webhook seam are **prerequisites** (35-1/35-5). This
+  plan assumes they are merged; if not, 35-8 is blocked.
+- The 35-5 handler returns a **single** `BillingFollowup`; dunning may need to both schedule an
+  advance *and* enqueue an email. Resolution: the email enqueue is cheap (an `INSERT`) and runs
+  inline in the handler; only the *time-delayed* advance becomes the `billing.webhook.followup`/
+  `billing.dunning.advance` task. Keep heavy/Stripe round-trips out of the inline path.
+
+---
+
+## Architecture
+
+**Pure core + imperative shell.** `DunningStateMachine.Next(stage, attempts, opts)` and
+`InvoiceService.ClassifyLine(...)` are clock-free pure functions (100%-coverage critical paths).
+All I/O — projection upsert, DCB append, task scheduling, email-outbox enqueue, quota
+invalidation — lives in the imperative shell with an injected `TimeProvider`.
+
+```
+Stripe invoice.*  ──(35-5 webhook + dispatch)──▶  InvoiceWebhookHandler : IBillingEventHandler
+                                                       │
+                                 ┌─────────────────────┼──────────────────────────┐
+                                 ▼                      ▼                          ▼
+                         InvoiceService           DunningStateMachine        BillingInvoiceEvents
+                       (upsert mirror +          (transition + schedule +     (DCB append via
+                        line split + DCB)         email-outbox enqueue)        IEventRepository)
+                                 │                      │
+                                 ▼                      ▼
+                      BillingInvoice/Line       BillingDunningState ──(suspended)──▶ 35-6 QuotaService
+                                                        │  (+IQuotaService.InvalidateAsync)
+                                                        ▼
+                                          PlatformQueuedTask "billing.dunning.advance"
+                                                        │ (fires at NextAdvanceAt)
+                                                        ▼
+                                          DunningAdvanceTaskHandler : IPlatformTaskHandler
+```
+
+---
+
+## Phased task breakdown (test-first / TDD)
+
+### Phase 0 — Confirm prerequisites & read contracts (no code)
+
+- [ ] Verify `BillingCustomer`, `BillingMode`, `NullBillingProvider`, `BillingServiceCollectionExtensions`
+      (35-1) and the `IBillingEventHandler`/`BillingWebhookContext`/`BillingFollowup`/`AddBillingEventHandler<T>`
+      seam (35-5) and `BillingSubscription` (35-4) and `IQuotaService.InvalidateAsync` + the
+      `HardBlock` reason taxonomy (35-6) exist in the tree. If any is missing, **stop** — 35-8 is blocked.
+- [ ] Re-read 35-5 §"Handler contract" and 35-6 §"suspension read path" to pin exact signatures.
+- [ ] `grep -rn "billing" apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` to see how
+      sibling billing entities are configured (copy the index/CHECK idiom).
+
+### Phase 1 — Pure cores (TDD, zero I/O)
+
+**Files:** `Services/Billing/DunningOptions.cs`, `Services/Billing/IDunningStateMachine.cs`
+(+ `DunningTransition` record), `Services/Billing/DunningStateMachine.cs` (transition table only),
+`Services/Billing/InvoiceService.cs` (`ClassifyLine` static helper stub).
+
+- [ ] **Tests first** — `tests/Tamma.Api.Tests/Billing/DunningStateMachineTests.cs`:
+      `Next("active", 1, opts)` → `past_due` + delay `RetryDelaysHours[0]`; `Next` walks
+      `past_due → grace → suspended` as attempts climb / retries exhaust; grace→suspend has
+      `Suspend = true, DelayUntilNext = null`; custom `RetryDelaysHours`/`GraceHours` honored;
+      recovery target is always `active`. Pure — no DB, no clock except via the schedule.
+- [ ] **Tests first** — `tests/Tamma.Api.Tests/Billing/InvoiceServiceTests.cs` (classification
+      subset): `ClassifyLine` → `base` (recurring price), `metered_overage` (metered/`tamma_meter`),
+      `credit` (negative amount / credit-note); negative-amount wins on a base price id; mixed
+      invoice splits + totals reconcile to `AmountDue`.
+- [ ] Implement `DunningOptions` (bound to `Billing:Dunning:*`, defaults `[24,72,120]`h /
+      `168`h), `DunningTransition`, `DunningStateMachine.Next`, and `ClassifyLine`. Green.
+
+### Phase 2 — Entities + EF migration (TDD around model)
+
+**Files:** `Entities/BillingInvoice.cs`, `Entities/BillingInvoiceLine.cs`,
+`Entities/BillingDunningState.cs`; modify `ControlPlaneDbContext.cs` (3 DbSets) +
+`TammaModelConfiguration.cs` (config, indexes, CHECKs); new additive migration under
+`Migrations/ControlPlane/`.
+
+- [ ] Add entities exactly as the story's "Key entity signatures" section specifies (minor-unit
+      `long` money; `Kind`/`Status`/`Stage` text domains).
+- [ ] In `TammaModelConfiguration.ConfigureControlPlaneEntities`: `BillingInvoice` → filtered
+      UNIQUE on `StripeInvoiceId` (`WHERE StripeInvoiceId IS NOT NULL`), index on
+      `(TenantId, CreatedAt DESC)`, CHECK on `Status`; `BillingInvoiceLine` → FK→invoice cascade,
+      CHECK on `Kind`; `BillingDunningState` → UNIQUE on `TenantId`, CHECK on `Stage`.
+- [ ] `dotnet ef migrations add BillingInvoicesAndDunning` (CP context). Run
+      `dotnet ef migrations has-pending-model-changes` → expect **none**. Verify up/down apply
+      cleanly (additive — no baseline CHECK edit, so Phase-0 collapsed-baseline rules don't bite).
+- [ ] **Test:** a DbContext round-trip persists + reads an invoice with lines; the filtered unique
+      index rejects a duplicate `StripeInvoiceId`; `BillingDunningState` rejects a second row per
+      tenant.
+
+### Phase 3 — InvoiceService projection + DCB (TDD)
+
+**Files:** `Services/Billing/IInvoiceService.cs`, `Services/Billing/InvoiceService.cs` (full),
+`Services/Billing/BillingInvoiceEvents.cs` (DCB constants).
+
+- [ ] **Tests first** (extend `InvoiceServiceTests.cs`): `ProjectAsync(invoice, tenantId)` inserts
+      one `BillingInvoice` + N lines and appends the right `BILLING.INVOICE.*` DCB event
+      (FINALIZED on finalize, PAID on paid) with tags `{ tenantId, invoiceId, stage }`; **replay**
+      same `StripeInvoiceId` upserts (no dup row, no second event); `open→paid` stamps `PaidAt`;
+      money in minor units; tenant-isolation (project for A never touches B).
+- [ ] Implement `ProjectAsync` (idempotent upsert keyed on `StripeInvoiceId`, line split via
+      `ClassifyLine`, DCB append via `IEventRepository.AppendAsync`), `ListAsync`, `GetAsync`
+      (both tenant-filtered). `BillingInvoiceEvents` constants:
+      `BILLING.INVOICE.FINALIZED/PAID/DISPUTED`, `BILLING.PAYMENT.FAILED`,
+      `BILLING.DUNNING.ESCALATED`, `BILLING.TENANT.SUSPENDED/REINSTATED`.
+
+### Phase 4 — Dunning shell: transitions + scheduling + email + suspend/reinstate (TDD)
+
+**Files:** `Services/Billing/DunningStateMachine.cs` (imperative methods),
+`Services/Billing/BillingDunningEmailComposer.cs`, `Services/Billing/DunningAdvanceTaskHandler.cs`.
+
+- [ ] **Tests first** — extend `DunningStateMachineTests.cs` (now with fakes for
+      `IPlatformQueuedTaskRepository`, `IEventRepository`, the outbox DbSets, `IQuotaService`,
+      injected `TimeProvider`): `OnPaymentFailedAsync` bumps attempts, transitions, schedules a
+      `billing.dunning.advance` task at `now + delay`, enqueues the stage email
+      (`PlatformEmailOutbox`/`EmailOutbox`), emits `BILLING.PAYMENT.FAILED` + `BILLING.DUNNING.ESCALATED`;
+      idempotent on `(invoiceId, attemptCount)` (replay = no double-advance);
+      `AdvanceAsync` grace→suspended emits `BILLING.TENANT.SUSPENDED`, sets `SuspendedAt`, calls
+      `IQuotaService.InvalidateAsync`; `OnPaymentRecoveredAsync` from **every** stage incl.
+      `suspended` → `active`, cancels the pending task, enqueues `dunning-recovered`, emits
+      `BILLING.TENANT.REINSTATED`, calls `InvalidateAsync`.
+- [ ] **Email test** — `BillingDunningEmailComposerTests.cs`: each stage → distinct template
+      (`dunning-past-due|dunning-grace|dunning-suspended|dunning-recovered`) with attempt count +
+      next-retry in the body; **assert no direct transport call** (mock `IEmailTransport`/
+      `OutboxSmtpSender` never invoked — outbox `INSERT` only).
+- [ ] Implement the shell + `DunningAdvanceTaskHandler : IPlatformTaskHandler`
+      (`TaskType = "billing.dunning.advance"`, calls `DunningStateMachine.AdvanceAsync`).
+
+### Phase 5 — Webhook handler wiring (TDD against the 35-5 seam)
+
+**Files:** `Services/Billing/InvoiceWebhookHandler.cs`; modify
+`Extensions/BillingServiceCollectionExtensions.cs` (`AddBillingEventHandler<InvoiceWebhookHandler>()`,
+`AddPlatformTaskHandler<DunningAdvanceTaskHandler>()`, register `IInvoiceService`/`IDunningStateMachine`/
+`DunningOptions`).
+
+- [ ] **Tests first** — `tests/Tamma.Api.Tests/Billing/InvoiceWebhookHandlerTests.cs`:
+      `HandledEventTypes` = `{ invoice.created, invoice.finalized, invoice.paid,
+      invoice.payment_failed, charge.dispute.created }`; `invoice.finalized` → projects + DCB;
+      `invoice.paid` → projects + `OnPaymentRecoveredAsync`; `invoice.payment_failed` →
+      projects + `OnPaymentFailedAsync` and returns a `BillingFollowup` (no inline Stripe round-trip);
+      `charge.dispute.created` → `Stage = flagged` + `BILLING.INVOICE.DISPUTED` +
+      `PlatformEmailOutbox` `dispute-opened` + **no auto-suspend**.
+- [ ] Implement the handler dispatching on `ctx.StripeEvent.Type`; resolve the typed object
+      (`(Stripe.Invoice)evt.Data.Object` etc.). Wire registration; assert DI resolves it in a
+      `Program.cs`-host test (SaaS mode).
+
+### Phase 6 — Invoice read API (TDD)
+
+**Files:** `Endpoints/Billing/InvoiceEndpoints.cs`; map in `Program.cs` (SaaS-gated, `MemberAccess`).
+
+- [ ] **Tests first** — `tests/Tamma.Api.Tests/Billing/InvoiceEndpointsTests.cs`:
+      `GET /api/v1/billing/invoices` returns the caller's tenant invoices paged newest-first;
+      `GET /invoices/{id}` returns detail + lines + `hosted_invoice_url`/`pdf_url` + dunning summary;
+      **cross-tenant id → 404**; `member`/`tenant_admin`/`tenant_owner` all read; unauthenticated → 401;
+      single-user mode → "billing is SaaS-only".
+- [ ] Implement endpoints mirroring `AlertEndpoints` tenant section: read active tenant id from the
+      principal (`ClaimsPrincipalExtensions`), filter every query by it, paging defaults 50/max 200.
+
+### Phase 7 — Suspend↔reinstate ↔ 35-6 integration + isolation (TDD)
+
+**Files:** `tests/Tamma.Api.Tests/Billing/DunningSuspensionIntegrationTests.cs`.
+
+- [ ] Drive `payment_failed` → `suspended`; assert `QuotaService` (35-6) returns
+      `HardBlock(billing_suspended)` for a platform-provided call and `Allowed` for a BYOK call on
+      the same tenant; after `invoice.paid`, both `Allowed` (reinstate + `InvalidateAsync`).
+- [ ] Tenant-isolation: A's `payment_failed` never mutates B's `BillingDunningState`; A's invoices
+      never appear in B's list; DCB events carry the right `tenantId`.
+- [ ] Full suite green: `sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests"`.
+
+---
+
+## Sequencing & dependencies
+
+```
+Phase 0 (verify prereqs)
+  └─▶ Phase 1 (pure cores)
+        └─▶ Phase 2 (entities + migration)
+              └─▶ Phase 3 (InvoiceService projection + DCB)
+                    └─▶ Phase 4 (dunning shell + email + suspend/reinstate + task handler)
+                          └─▶ Phase 5 (webhook handler wiring into 35-5 seam)
+                                └─▶ Phase 6 (read API)        ── parallel-safe with Phase 7 ──
+                                      └─▶ Phase 7 (35-6 integration + isolation)
+```
+
+- **Hard external prerequisites (merged before starting):** 35-5 (dispatch seam), 35-1
+  (`BillingCustomer`/`BillingMode`/Stripe.net/`NullBillingProvider`), 35-6 (`IQuotaService`), and
+  35-4 (`BillingSubscription`, for period/seat context).
+- Phases 1–2 have no sibling dependency and can begin as soon as the entity/EF tooling is set up.
+- Phase 5 is the only phase that hard-couples to the 35-5 seam; if 35-5 is mid-flight, stub
+  `IBillingEventHandler` locally to the agreed signature and re-point at merge.
+
+## Risks + mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Stripe smart-retries fight Tamma's local cadence (double dunning) | High | Disable Stripe smart-retries; Tamma's `billing.dunning.advance` schedule is the single source of truth. Document in Stripe setup runbook. |
+| Webhook replay double-advances dunning or double-charges line items | High | Idempotent upsert on `StripeInvoiceId` (second line of defense behind 35-5's `BillingWebhookEvent` dedup); `OnPaymentFailedAsync` idempotent on `(invoiceId, attemptCount)`. |
+| Suspending a BYOK tenant blocks their token usage (wrong) | High | Suspension writes a *signal*; 35-6 enforcement exempts BYOK token calls. 35-8 ships no enforcement; Phase-7 test pins BYOK-allowed-while-suspended. |
+| Money rounding / currency drift | High | Store minor-unit `long` (never decimal/float); currency on every row; reconcile line sum to `AmountDue` in a test. |
+| Dunning email storm on a flapping gap | Medium | One email per *stage transition* (not per webhook); outbox dedup is at the row level; recovery cancels the pending advance task. |
+| Stale quota block after reinstate (cache TTL) | Medium | Call `IQuotaService.InvalidateAsync` on both suspend and reinstate; ERROR-log if it fails (block may be stale until TTL — acceptable, bounded). |
+| Single `BillingFollowup` can't carry both schedule + email | Low | Email is a cheap inline `INSERT` in the handler; only the time-delayed advance becomes the task. |
+| Migration discipline | Low | `config`/entity config in `TammaModelConfiguration` only; additive table; verify `has-pending-model-changes` → none; up/down clean. |
+
+## Acceptance criteria (mirror of the story)
+
+- [ ] `BillingInvoice` + `BillingInvoiceLine` mirrors populated idempotently from `invoice.*`
+      webhooks with `{ amount_due, amount_paid, status, hosted_invoice_url, pdf_url, period }` and
+      lines split `base` / `metered_overage` / `credit`.
+- [ ] `GET /api/v1/billing/invoices` (paged) + `GET /api/v1/billing/invoices/{id}` (detail + PDF
+      link) readable by `tenant_owner`/`tenant_admin`/`member`; cross-tenant → 404.
+- [ ] Dunning state machine advances `active → past_due → grace → suspended` on
+      `invoice.payment_failed` via a `PlatformQueuedTask` schedule and recovers to `active` on a
+      later `invoice.paid` (from any stage incl. `suspended`).
+- [ ] Escalating dunning emails enqueued through `PlatformEmailOutboxMessage`/`EmailOutboxMessage`
+      (no direct SMTP), with attempt count + next-retry surfaced on the invoice API.
+- [ ] Terminal failure after grace → `BillingDunningState.Stage = suspended` that Story 35-6 reads
+      to hard-block platform-provided usage; BYOK token usage continues but the platform/seat fee
+      stays owed.
+- [ ] DCB events `BILLING.INVOICE.FINALIZED/PAID`, `BILLING.PAYMENT.FAILED`,
+      `BILLING.DUNNING.ESCALATED`, `BILLING.TENANT.SUSPENDED/REINSTATED`, `BILLING.INVOICE.DISPUTED`
+      emitted with tags `{ tenantId, invoiceId, stage }`.
+- [ ] `charge.dispute.created` flips invoice/tenant to `flagged` and notifies platform admins (no
+      auto-suspend).
+- [ ] Unit + integration tests cover projection + line split, dunning advance/recover, email-outbox
+      enqueue (no direct send), suspend→reinstate (35-6 read), dispute handling, and tenant isolation;
+      Stripe SDK + providers mocked. Coverage targets met (critical paths 100%).

--- a/docs/superpowers/plans/2026-06-17-35-9-tax-calculation-and-compliance-plan.md
+++ b/docs/superpowers/plans/2026-06-17-35-9-tax-calculation-and-compliance-plan.md
@@ -1,0 +1,309 @@
+# Story 35-9 — Tax Calculation & Compliance (Stripe Tax / VAT)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development for every
+> task — write the failing test first, then the implementation. This story is part of Epic 35
+> (Billing & Payments, C# control plane). Steps use checkbox (`- [ ]`) syntax for tracking.
+> SaaS-only at runtime: every Stripe Tax touch-point must no-op under the single-user
+> `NullBillingProvider` from 35-1.
+
+**Goal:** Apply correct tax to Tamma SaaS invoices using **Stripe Tax** — collect/validate the
+tenant's billing address + VAT/GST tax id, set the Stripe customer's tax-exempt status, enable
+`automatic_tax` on the subscriptions/invoices that 35-4/35-8 already create, project Stripe's tax
+line items into the local invoice mirror, handle **EU B2B reverse-charge**, and store a
+**point-in-time tax snapshot** on each finalized invoice for compliance/audit. Tamma uses Stripe as
+the tax engine and stores only the minimal metadata — it never computes rates itself, and it never
+silently bills incorrect tax on an unverifiable id.
+
+**Non-goals (YAGNI guard):**
+- NO building of subscription creation (35-4) or invoice creation/finalization/dunning (35-8). This
+  story only adds the `automatic_tax` toggle helper those stories call and the tax-line projection
+  invoked from 35-8's finalize path.
+- NO webhook ingestion (35-5). The finalize projection runs inside the existing 35-8 path that 35-5
+  drives.
+- NO portal / dashboard tax UI (35-10/35-11). This story ships the API + projection only.
+- NO token-markup or BYOK suppression (35-3). We only assert tax applies to the platform/seat fee.
+- NO bespoke tax engine. Rates, jurisdictions, and reverse-charge eligibility are decided by Stripe
+  Tax; Tamma validates id syntax + reads Stripe's verification result, then projects.
+- NO silent-degrade. An unverifiable tax id is a hard `TammaError`, never "accept and bill standard
+  tax" (consistent with the project's no-empty-fallback principle).
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane API). Tests in
+`apps/tamma-elsa/tests/Tamma.Api.Tests/` (xUnit; docker-bound suites run via
+`sg docker -c "dotnet test ..."`, builds need no wrapper). Dep `Stripe.net` is added by 35-1; this
+story uses its Tax surface (`Customer.TaxExempt`, `CustomerTaxIdService`, invoice `AutomaticTax` /
+`TotalTaxAmounts`).
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### Sibling-story foundations this story extends (all NEW, authored ahead of this in Epic 35)
+- **35-1** (`docs/stories/epic-35/story-35-1/35-1-...md`, authored): introduces
+  `apps/tamma-elsa/src/Tamma.Data/Entities/BillingCustomer.cs` (unique `TenantId`, `BillingMode`
+  text, a `TaxStatus` text column we repurpose), the `IBillingProvider` /
+  `StripeBillingProvider` / `NullBillingProvider` seam, `StripeClientFactory` (cabinet-resolved
+  key), `BillingEvents` static DCB helper, `Tamma.Core/Billing/BillingMode.cs`, and the mode-aware
+  `BillingServiceCollectionExtensions.AddTammaBilling`. **These are prerequisites — do not
+  re-create them.**
+- **35-4** (`/tmp` spec): `apps/tamma-elsa/src/Tamma.Api/Services/Billing/SubscriptionService.cs`
+  creates Stripe subscriptions — the call site that sets `AutomaticTax` on the subscription.
+- **35-8** (`/tmp` spec): `apps/tamma-elsa/src/Tamma.Data/Entities/BillingInvoice.cs` +
+  `BillingInvoiceLine.cs` (line split base/metered-overage/credit, which we extend with `tax`),
+  `apps/tamma-elsa/src/Tamma.Api/Services/Billing/InvoiceService.cs` (the `invoice.finalized`
+  projection we hook), and the `BILLING.INVOICE.FINALIZED` DCB event we extend with `taxTotal`.
+
+> At implementation time 35-1/35-4/35-8 must be merged. The billing `Entities` / `Services/Billing`
+> directories do **not** exist on `main` yet (verified: `Tamma.Api/Services/Billing/` absent, no
+> `Stripe` ref in `Tamma.Api.csproj`) — they are created by the prerequisite stories.
+
+### Control-plane data layer (verified present on main)
+- `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` — DbSets declared
+  `public DbSet<X> Xs => Set<X>();`. `BillingCustomer`/`BillingInvoice`/`BillingInvoiceLine` are
+  registered by 35-1/35-8; this story adds **columns only**, no new DbSet.
+- `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` — `ConfigureControlPlaneEntities` is
+  the single place entity mapping lives (`ToTable`, `HasCheckConstraint`, `HasColumnType("jsonb")`,
+  `HasIndex`). Mirror 35-1's `billing_customers` block; add jsonb columns + CHECKs there.
+- `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/` — additive migration; verify
+  `dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext` reports none
+  after generating. CHECK *edits* (extending `LineKind` to allow `tax`, the new `TaxExemptStatus`
+  CHECK) follow the project's migration discipline — mirror config only in
+  `TammaModelConfiguration.cs`.
+- `apps/tamma-elsa/src/Tamma.Data/Entities/DomainEvent.cs` — `Type`, `TenantId`, `Tags`,
+  `Metadata`, `Data`, `CreatedAt`, server-side `SequenceNumber`. DCB shape set by
+  `OrgEndpoints.EmitTenantEvent` (`OrgEndpoints.cs:1036-1061`):
+  `Metadata = {"workflowVersion":"1.0.0","eventSource":"system"}`; `Tags`/`Data` JSON. `BillingEvents`
+  (35-1) reuses this shape — add the tax builders.
+- `apps/tamma-elsa/src/Tamma.Data/Repositories/IEventRepository.cs` — `AppendAsync(DomainEvent)`
+  (line 7) is the append seam.
+
+### Endpoint + RBAC seams (verified present on main)
+- `apps/tamma-elsa/src/Tamma.Api/Authorization/RequireTenantMembershipFilter.cs` — resolves the
+  path/context tenant + role into `http.Items[TenantRoleItemKey]` (line 30) /
+  `PathTenantIdItemKey` (line 31). The tax-profile endpoints run under this group so the tenant is
+  resolved from context, never a body field. RBAC precedent: read = any member, write =
+  owner/admin, member-write = 403 (prompt-store / `OrgEndpoints` role-gate pattern,
+  `TenantRoleHierarchy.IsAtLeast(role, Admin)`).
+- `apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs` — `EmitTenantEvent` helper
+  (line 1036), `TenantRoleHierarchy` role checks (e.g. lines 106, 254). Mirror for the tax
+  endpoints.
+- `apps/tamma-elsa/src/Tamma.Api/Program.cs` — auth policies `OwnerAccess` (971), `MemberAccess`
+  (991), `PromptManage` (1012); path-tenant routes attach the membership filter (~1505/1596). Map
+  `TaxProfileEndpoints` into that `/api/v1/billing/*` (tenant-membership) group.
+
+### Mode + secret seams (verified present on main)
+- `apps/tamma-elsa/src/Tamma.Api/Services/PromptStore/TammaMode.cs` — `ITammaModeProvider.Mode`
+  (`SingleUser`/`SaaS`). Drives whether tax services are wired at all (single-user →
+  `NullBillingProvider` from 35-1 governs; tax endpoints no-op/absent).
+- Stripe key resolution is owned by 35-1 (`StripeClientFactory` + `IRuntimeSecretResolver`); this
+  story reuses the resolved client, no new secret reader.
+
+### Not present yet (NEW in this story)
+- No tax-profile entity columns, service, validator, automatic-tax policy, tax-line projector, or
+  tax-profile endpoints. No `TaxExemptStatus` enum. All tax code is greenfield on top of the 35-1/8
+  entities.
+
+---
+
+## Architecture
+
+**Collect + validate profile → push to Stripe → enable automatic_tax → project Stripe's tax → snapshot at finalize**, reusing the 35-1 seam and the 35-8 invoice projection end-to-end:
+
+1. **`ITaxProfileService`** is the single profile write seam: validate (syntactic + Stripe
+   verification), push `Customer.Address`/`TaxExempt`/tax-id to Stripe, update `BillingCustomer`
+   atomically, emit `BILLING.TAX.PROFILE_UPDATED`. An unverifiable id → hard `TammaError`
+   (`BILLING.TAX_ID.INVALID`) + `BILLING.TAX_ID.VALIDATION_FAILED`, row untouched.
+2. **`IAutomaticTaxPolicy`** is a tiny helper that 35-4's `SubscriptionService` and 35-8's
+   `InvoiceService` call to set `AutomaticTax = { Enabled = ... }`. Owned here, called there
+   (boundary respected).
+3. **`TaxLineProjector`** runs inside 35-8's finalize projection: reads Stripe's
+   `TotalTaxAmounts`/`AutomaticTax`, writes `BillingInvoice.TaxTotal` + the address/id/exempt
+   **snapshot**, and appends one `BillingInvoiceLine { LineKind="tax", ... }` per jurisdiction
+   (reverse-charge → a single `Amount=0` line). Snapshot = audit reproducibility.
+4. **DCB events** `BILLING.TAX.PROFILE_UPDATED` / `BILLING.TAX_ID.VALIDATION_FAILED` and an extended
+   `BILLING.INVOICE.FINALIZED` (`taxTotal` tag) append to the CP `DomainEvents` store via
+   `IEventRepository` (the store the alert evaluator polls).
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Tax provider | `NullBillingProvider` (35-1) — tax endpoints/service no-op or absent | `StripeBillingProvider` + Stripe Tax |
+| Who owns the tax profile? | the sole user (no RBAC) | the tenant; `tenant_owner`/`tenant_admin` edit, `member` read-only |
+| Automatic-tax | n/a | on for platform/seat-fee invoices; BYOK tenants taxed on the platform fee |
+| Reverse-charge decision | n/a | Stripe Tax decides; mirror records `ReverseCharge` |
+| Snapshot ownership | n/a | per-invoice, immutable, written at finalize |
+| Mode source | `ITammaModeProvider` (process-stable) | same |
+| Tenant isolation | single tenant | profile keyed by unique `BillingCustomer.TenantId`; never cross-tenant |
+
+---
+
+## Phased task breakdown
+
+### Phase 1 — Data layer: tax columns + migration (foundation)
+
+- [ ] **T1.1 — `TaxExemptStatus` enum.** New `apps/tamma-elsa/src/Tamma.Core/Billing/TaxExemptStatus.cs`
+  (`{ None, Exempt, ReverseCharge }`). *Test first:* covered transitively by T1.3 column tests.
+- [ ] **T1.2 — Extend billing entities.** Add tax fields to `BillingCustomer.cs` (BillingAddress
+  jsonb, TaxIdType, TaxIdValue, TaxExemptStatus text default `None`, TaxIdVerification), to
+  `BillingInvoice.cs` (TaxTotal, TaxCustomerAddressSnapshot jsonb, TaxIdSnapshot jsonb,
+  TaxExemptSnapshot text), and to `BillingInvoiceLine.cs` (TaxRatePercent, TaxJurisdiction,
+  TaxType; `LineKind` gains `tax`). *Tests first:* `BillingTaxEntityModelTests` — defaults
+  (`TaxExemptStatus="None"`, `TaxExemptSnapshot="None"`).
+- [ ] **T1.3 — Model config.** In `TammaModelConfiguration.ConfigureControlPlaneEntities`: jsonb
+  column types for the address/snapshot columns; CHECK `ck_billing_customers_tax_exempt` and
+  `ck_billing_invoices_tax_exempt` on the enum domain; extend the `BillingInvoiceLine.LineKind`
+  CHECK (from 35-8) to include `tax`. *Tests first:* EnsureCreated/snapshot test asserting the
+  CHECKs + jsonb columns exist.
+- [ ] **T1.4 — EF migration.** `dotnet ef migrations add AddTaxProfileAndInvoiceTaxSnapshot
+  --context ControlPlaneDbContext --output-dir Migrations/ControlPlane` (build, no wrapper). Add the
+  data step mapping `BillingCustomer.TaxStatus` → `TaxExemptStatus`. Verify
+  `has-pending-model-changes` → none. *Tests first (integration, docker):* `TaxMigrationTests`
+  applies `Update` then down/`Remove`-equivalent on a real Postgres CP DB and asserts the data step
+  maps existing rows.
+
+### Phase 2 — Tax-id validation
+
+- [ ] **T2.1 — `ITaxIdValidator` + `TaxIdValidator`.** New `Services/Billing/ITaxIdValidator.cs` /
+  `TaxIdValidator.cs`: syntactic check per `TaxIdType` (EU VAT country prefix + length/shape; GB/AU
+  variants), then create a Stripe `CustomerTaxId` (mocked in tests) and read its verification
+  status. Returns a `TaxIdValidationResult { Ok, Verification, Reason }`; unverifiable → not Ok.
+  **Research the latest Stripe.net tax-id verification statuses before coding.** *Tests first:*
+  `TaxIdValidatorTests` — valid EU VAT shape accepted; malformed prefix/checksum rejected; Stripe
+  `unverified` → rejected (no silent accept); each branch maps to `BILLING.TAX_ID.INVALID` context.
+
+### Phase 3 — Tax-profile service + events
+
+- [ ] **T3.1 — `BillingEvents` tax builders.** Modify `Services/Billing/BillingEvents.cs` (35-1):
+  add `TaxProfileUpdated(tenantId, type, country, exempt, verification)`,
+  `TaxIdValidationFailed(tenantId, type, country, reason)`, and a `taxTotal`/`currency` tag on the
+  `InvoiceFinalized` builder (35-8). *Tests first:* assert Type, Tags JSON, `TenantId` set.
+- [ ] **T3.2 — `ITaxProfileService` + `TaxProfileService`.** New seam + impl: `GetProfileAsync`
+  (returns redacted id), `UpdateProfileAsync` — validate via T2.1, push `Customer.Address` +
+  `Customer.TaxExempt` + tax-id to Stripe with deterministic idempotency key
+  `billing-taxprofile-{tenantId}-{hash}`, map Stripe's exempt result onto `TaxExemptStatus`
+  (reverse-charge in a supported country → `ReverseCharge`), update `BillingCustomer` atomically,
+  emit `BILLING.TAX.PROFILE_UPDATED`. Rejected id → `TammaError("BILLING.TAX_ID.INVALID")` +
+  `BILLING.TAX_ID.VALIDATION_FAILED`, row unchanged. Identical re-save → no Stripe write. *Tests
+  first:* `TaxProfileServiceTests` — happy path, reverse-charge mapping, rejected-id leaves row +
+  emits failure, idempotent re-save, atomic update, single event.
+
+### Phase 4 — Automatic-tax policy + tax-line projection
+
+- [ ] **T4.1 — `IAutomaticTaxPolicy` + `AutomaticTaxPolicy`.** New helper: `ShouldEnable(customer)`
+  = billing enabled (SaaS) AND a usable address present. *Tests first:* `AutomaticTaxPolicyTests` —
+  on with address, off without, off under `NullBillingProvider`. (Call sites in 35-4/35-8 are out of
+  scope — only the helper ships here; a thin integration test asserts those services *would* read
+  it, but the wiring lands in those stories.)
+- [ ] **T4.2 — `TaxLineProjector`.** New `Services/Billing/TaxLineProjector.cs`:
+  `Project(Stripe.Invoice, BillingInvoice mirror)` reads `TotalTaxAmounts`/`AutomaticTax`, writes
+  `TaxTotal` + the address/id/exempt **snapshot** onto the mirror, and appends `BillingInvoiceLine`
+  rows of kind `tax` (one per jurisdiction; reverse-charge → single `Amount=0`,
+  `TaxType="reverse_charge"`). *Tests first:* `TaxLineProjectorTests` — one-jurisdiction →
+  one line with rate/jurisdiction/type; reverse-charge → zero line; snapshot written; `TaxTotal`
+  set; `taxTotal` added to the `BILLING.INVOICE.FINALIZED` tags.
+- [ ] **T4.3 — Hook the projector into 35-8's `InvoiceService` finalize path.** Modify
+  `Services/Billing/InvoiceService.cs` to call `TaxLineProjector.Project(...)` inside the existing
+  `invoice.finalized` projection (the single touch into 35-8 code, kept minimal). *Tests first
+  (integration):* finalize an invoice (Stripe tax mocked) → mirror has the tax line + snapshot +
+  `TaxTotal`, event carries `taxTotal`.
+
+### Phase 5 — Endpoints + DI wiring
+
+- [ ] **T5.1 — `TaxProfileEndpoints`.** New `Endpoints/Billing/TaxProfileEndpoints.cs`:
+  `GET /api/v1/billing/tax-profile` (any tenant member; returns redacted profile) and
+  `PUT /api/v1/billing/tax-profile` (owner/admin; member → 403; invalid id → 422 with the
+  machine-readable code). Resolve tenant + role from `RequireTenantMembershipFilter` context. *Tests
+  first:* `TaxProfileEndpointsTests` — owner/admin PUT succeeds, member 403, invalid id 422, GET
+  redacted, cross-tenant 403/404.
+- [ ] **T5.2 — DI + route mapping.** Modify `Extensions/BillingServiceCollectionExtensions.cs`
+  (35-1) to register `ITaxProfileService`, `ITaxIdValidator`, `IAutomaticTaxPolicy`,
+  `TaxLineProjector` (only when `Mode==SaaS`; single-user keeps the no-op seam). Map
+  `TaxProfileEndpoints` in `Program.cs` under the `/api/v1/billing/*` tenant-membership group.
+  *Tests first:* `AddTammaTaxTests` — SaaS resolves the real services; single-user resolves nothing
+  / no-op.
+
+### Phase 6 — Verification
+
+- [ ] **T6.1** Run `sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests"` — full suite
+  green (no regressions).
+- [ ] **T6.2** `dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext` →
+  none.
+- [ ] **T6.3** Snapshot-retention integration test (`TaxSnapshotIntegrationTests`): finalize →
+  change address → historical invoice tax snapshot unchanged.
+- [ ] **T6.4** (opt-in) Live Stripe test mode with Tax enabled behind `STRIPE_SECRET_KEY_TEST`:
+  taxable address → non-zero tax line; valid EU B2B VAT → reverse-charge zero line.
+
+---
+
+## Sequencing & dependencies
+
+```
+T1.1 → T1.2 → T1.3 → T1.4            (data layer — must land first)
+              ↓
+T2.1                                 (validator; needs entities for store shape)
+              ↓
+T3.1 → T3.2                          (events + profile service; needs validator + Stripe client)
+              ↓
+T4.1 → T4.2 → T4.3                   (policy + projector + 35-8 hook; needs entities + events)
+              ↓
+T5.1 → T5.2                          (endpoints + DI; needs profile service)
+              ↓
+T6.x                                 (verification)
+```
+
+- **Hard prerequisite:** Stories **35-1, 35-4, 35-8 merged** (entities, billing seam, invoice
+  mirror + finalize path, `BillingEvents`). Phase 1 (data) before everything else here.
+- **External:** `Stripe.net` (from 35-1) with **Stripe Tax** enabled on the account; research the
+  current Tax surface (`Customer.TaxExempt`, `CustomerTaxIdService`, invoice `AutomaticTax` /
+  `TotalTaxAmounts`, verification statuses) before T2.1/T3.2/T4.2.
+- **Story prerequisites present at main:** Epic 28 (CP, tenants, membership filter, mode), Epic 29
+  (cabinet via 35-1), Epic 4 (DCB events).
+
+## Risks + mitigations
+
+- **Silently billing wrong tax on an unverifiable id.** *Mitigation:* T2.1/T3.2 hard-reject with
+  `BILLING.TAX_ID.INVALID` + `VALIDATION_FAILED` event; the row is never updated to a bill-anyway
+  state. Tested across valid/invalid-syntax/unverified branches.
+- **Historical invoice tax mutates after a profile edit.** *Mitigation:* T4.2 writes a point-in-time
+  snapshot (address/id/exempt/total) at `invoice.finalized`; T6.3 snapshot-retention test pins
+  immutability.
+- **Stripe Tax not enabled / no origin registration in the test account.** *Mitigation:* live tax
+  tests are opt-in behind `STRIPE_SECRET_KEY_TEST`; default CI mocks at the
+  `CustomerService`/`CustomerTaxIdService`/`InvoiceService` interface boundary.
+- **Stripe.net Tax API drift vs assumed signatures.** *Mitigation:* research current docs before
+  coding; all tests mock at the service-interface boundary so SDK shape is isolated to validator +
+  profile service + projector.
+- **Boundary creep into 35-4/35-8.** *Mitigation:* this story ships only the `IAutomaticTaxPolicy`
+  helper + `TaxLineProjector` + one minimal call from `InvoiceService`; subscription/invoice
+  creation stays owned by 35-4/35-8. The story's Boundary Notes pin this.
+- **PII / raw tax id leaking into logs.** *Mitigation:* redacted-only logging; tax id stored but
+  never fully logged; credential-safety asserted in review and in the logging requirements.
+- **Cross-tenant tax-profile access.** *Mitigation:* resolve by unique `BillingCustomer.TenantId`
+  via `RequireTenantMembershipFilter`; tenant-isolation + RBAC (member 403) tests.
+- **Migration discipline.** *Mitigation:* additive columns + CHECK edits mirrored only in
+  `TammaModelConfiguration.cs`; T1.4 verifies `has-pending-model-changes` reports none and the
+  `TaxStatus → TaxExemptStatus` data step runs.
+
+## Acceptance criteria (mirror the story)
+
+- [ ] `BillingCustomer` gains `{BillingAddress, TaxIdType, TaxIdValue, TaxExemptStatus,
+  TaxIdVerification}`; `BillingInvoice` gains `{TaxTotal, TaxCustomerAddressSnapshot, TaxIdSnapshot,
+  TaxExemptSnapshot}`; `BillingInvoiceLine` gains tax fields + `tax` kind; additive migration applies
+  + rolls back; `has-pending-model-changes` = none; `TaxStatus → TaxExemptStatus` mapped.
+- [ ] `PUT /api/v1/billing/tax-profile` (owner/admin; member 403) validates + pushes address/id/
+  exempt to Stripe and updates the local row; `GET` returns the redacted profile to any member.
+- [ ] Tax id is validated before save; an invalid/unverifiable id is rejected with the
+  machine-readable `BILLING.TAX_ID.INVALID` and never silently bills wrong tax.
+- [ ] `automatic_tax` is enabled on 35-4/35-8 subscriptions/invoices via `IAutomaticTaxPolicy`; tax
+  lines are projected into `BillingInvoiceLine` (kind `tax`) and shown via the 35-8 portal endpoint.
+- [ ] Valid EU B2B VAT in a supported country → reverse-charge zero/`reverse_charge` tax line and
+  `TaxExemptStatus = ReverseCharge` in the mirror.
+- [ ] Tax fields snapshot onto `BillingInvoice` at finalize so historical invoices are reproducible
+  after a later profile change.
+- [ ] `BILLING.TAX.PROFILE_UPDATED` emitted on update; `taxTotal` added to
+  `BILLING.INVOICE.FINALIZED` tags; `BILLING.TAX_ID.VALIDATION_FAILED` on rejection.
+- [ ] Single-user mode and BYOK both flow through the same tax path (tax applies to the platform/seat
+  fee; single-user no-ops via `NullBillingProvider`).
+- [ ] Unit + integration tests (Stripe mocked; live opt-in behind `STRIPE_SECRET_KEY_TEST`): save +
+  validation, `automatic_tax` on invoice, reverse-charge, snapshot retention, tenant-isolation, RBAC.
+- [ ] Full xUnit suite green; raw tax id / billing PII / payment details never logged in full.

--- a/docs/superpowers/plans/2026-06-17-36-1-dimensional-analytics-projection-schema-and-store-plan.md
+++ b/docs/superpowers/plans/2026-06-17-36-1-dimensional-analytics-projection-schema-and-store-plan.md
@@ -1,0 +1,194 @@
+# Story 36-1 — Dimensional Analytics Projection Schema & Store (implementation plan)
+
+> Epic 36 (Analytics & Reporting Platform) · P0 · est. 3-4 days · author Claude · 2026-06-17 ·
+> SUB-SKILL: use `superpowers:test-driven-development` — every task writes its failing test first.
+> Docker-bound suites run via `sg docker -c "dotnet test ..."`; the build itself needs no wrapper.
+
+**Goal:** Stand up the per-tenant dimensional analytics store that the rest of Epic 36 reads
+from. Add two per-tenant fact entities — `AnalyticsUsageHourly` and `AnalyticsUsageDaily` —
+carrying the dimensions the single-grain `platform_analytics_hourly` model lacks (provider,
+agent, workflow definition, repo, and a `byok|platform` cost basis), wire them into the
+`TenantDbContext` EF model + Tenant migration graph, and prove InMemory/Npgsql parity, schema
+isolation, and idempotent upsert keys. **Schema + EF model + migration only.**
+
+**Non-goals (YAGNI guard):**
+- NO population/projection logic — that is Story 36-2 (it writes these tables from DCB events).
+- NO query/export/report endpoints — later Epic 36 stories.
+- NO change to the control-plane `platform_analytics_hourly` table/entity/mapping — it stays the
+  owner-only fleet-wide store (Story 28-10). This story only *adds* tenant-resident tables.
+- NO DCB events emitted here. The `ANALYTICS.PROJECTION.*` catalogue belongs to 36-2; this story
+  only references existing source events (`LLM.CALL.SUCCESS`, `AGENT.DISPATCH.*`,
+  `WORKFLOW.STEP_COMPLETED`) in doc-comments.
+- NO `TenantId` column on the new tables — tenancy is the schema (Doc 01 §1.4 target shape), not
+  a column. Do not copy the legacy transitional `TenantId` from `agent_configs`/`conventions`.
+- NO dashboard surface.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### What exists and is the pattern to mirror
+
+| Site | What it gives us |
+|---|---|
+| `src/Tamma.Data/Entities/PlatformAnalyticsHourly.cs` | The single-grain CP fact entity. Measures: `WorkflowsStarted/Completed/Failed`, `AgentDispatches`, `TokensIn/Out` (all `long`), `CostUsd` (`decimal`), `ActiveTenantsAtHourEnd` (`int`), `ComputedAt`. **No** provider/agent/workflow/repo/cost-basis dimensions — exactly the gap 36-1 fills. Copy its `long`/`decimal` conventions verbatim. |
+| `src/Tamma.Data/ControlPlaneDbContext.cs` — `ConfigurePlatformAnalyticsHourly` (lines 713-762) | The mapping precedent: `gen_random_uuid()` PK default, `timestamp with time zone` on the bucket, `HasDefaultValue(0L)` on counters, `HasPrecision(20, 4).HasDefaultValue(0m)` on `CostUsd`, `HasDefaultValueSql("now()")` on `ComputedAt`, and partial-unique indexes with `IsUnique()` + `HasFilter(...)`. **Note:** the CP analytics entity is configured *here in ControlPlaneDbContext*, not in `TammaModelConfiguration` — but our new tenant tables go through `TammaModelConfiguration.ConfigureTenantEntities` (the tenant graph's single config source). |
+| `src/Tamma.Data/TenantDbContext.cs` (lines 51-93) | Where tenant DbSets are declared and `OnModelCreating` calls `TammaModelConfiguration.ConfigureTenantEntities(modelBuilder, fixedTenantId: TenantId)`. Add the two new DbSets here; no extra `OnModelCreating` wiring needed once the new configurator is invoked from `ConfigureTenantEntities`. |
+| `src/Tamma.Data/TammaModelConfiguration.cs` — `ConfigureTenantEntities` (lines 642-756+) | The single source for tenant-entity mapping. `fixedTenantId is not null` ⇒ tenant context; CP POCOs are `Ignore`d. Each entity ends with `ApplyTenantFilter(entity, fixedTenantId, e => e.TenantId)`. New tables have no `TenantId`, so the filter lambda returns `null` (the filter is a deliberate no-op — see line 1137-1160). |
+| `TammaModelConfiguration` `prompt_overrides` (lines 749-752) / `conventions` index | The `.IsUnique().AreNullsDistinct(false)` (NULLS NOT DISTINCT, EF 9 model-expressible, PG15+) precedent for the idempotent business key over nullable dimensions. |
+| `TammaModelConfiguration.ConfigureMentorshipEntities` (lines 1216-1226) | The `.HasConversion<string>()` enum-to-text precedent (`CurrentState`, `Status` enums) — copy for `CostBasis`. |
+| `src/Tamma.Core/Enums/` (`MentorshipState.cs`, `QualityGateResult.cs`, `AssessmentResult.cs`, `BlockerType.cs`) | Where the new `CostBasis` enum lives. |
+| `src/Tamma.Data/TenantDesignTimeDbContextFactory.cs` | Resolves `dotnet ef ... -c TenantDbContext`; history table `__TenantMigrationsHistory`. Migrations land in `src/Tamma.Data/Migrations/Tenant/`. |
+| `src/Tamma.Data/Pooling/EfTenantDbMigrator.cs` — `MigrateTenantAppAsync` | Applies the Tenant migration graph into a `t_<hex>` search-path schema; the smoke test drives it. |
+| `src/Tamma.Api/Services/Analytics/PlatformAnalyticsService.cs` (lines 462-478) | The `EF.Property<string?>(t, "...")` projection-parity idiom — InMemory and Npgsql see the same shadow/text column. The model-parity test follows this. |
+
+### Existing test patterns to follow
+
+| Test | Pattern |
+|---|---|
+| `tests/Tamma.Api.Tests/Epic28/TenantDbContextModelTests.cs` | InMemory/Npgsql model-shape assertions over `ctx.Model.GetEntityTypes()` — `GetTableName()`, column presence. Copy for `AnalyticsUsageModelTests`. |
+| `tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs` | CP model-shape assertions — extend to confirm `platform_analytics_hourly` stays and `analytics_usage_*` are absent. |
+| `tests/Tamma.Api.Tests/Tenancy/SchemaPerTenantMigrationTests.cs` | Postgres 17 Testcontainer; migrate two schemas into one DB; prove search-path isolation (row in A invisible in B). Copy for `AnalyticsUsageMigrationTests`. |
+| `tests/Tamma.Api.Tests/Conventions/ConventionStoreMigrationTests.cs` | Postgres 17 Testcontainer driving NULLS NOT DISTINCT unique-collision assertions via raw SQL. Copy for the dimension-tuple collision test. |
+
+### Confirmed absent (so these are genuinely NEW)
+
+`grep -rln "AnalyticsUsage|analytics_usage|CostBasis" src/ tests/` → **no matches**. The entities,
+table names, and enum do not exist yet. `InternalsVisibleTo("Tamma.Api.Tests")` is declared in
+`Tamma.Data.csproj` (line 47), so the test project can reach internal config if needed.
+
+---
+
+## Phased task breakdown (test-first)
+
+### Task 1 — `CostBasis` enum (AC3)
+
+- **Test first:** `tests/Tamma.Core.Tests/Enums/CostBasisTests.cs` (or colocated with existing
+  enum tests) — assert the two members exist and pin the lowercase `byok`/`platform` text
+  expectation that the model config will enforce (`Enum.GetName(...)?.ToLowerInvariant()`).
+- **Implement:** `src/Tamma.Core/Enums/CostBasis.cs` — `enum CostBasis { Byok = 0, Platform = 1 }`
+  with the XML doc-comment from the story (BYOK vs platform-fronted cost).
+- **Run:** `dotnet test --filter "FullyQualifiedName~CostBasis"`.
+
+### Task 2 — fact entities (AC1, AC2, AC8, AC9)
+
+- **Test first:** add stub assertions to `AnalyticsUsageModelTests` (Task 4) referencing the
+  entity properties — they won't compile until the entities exist (red).
+- **Implement:**
+  - `src/Tamma.Data/Entities/AnalyticsUsageHourly.cs` — dimensions
+    (`Provider` required, `AgentId?`, `WorkflowDefinitionId?` Guid, `RepoId?`, `CostBasis`),
+    measures (`TokensIn/Out`, `WorkflowsStarted/Completed/Failed`, `AgentDispatches` as `long`;
+    `CostUsd`, `PlatformBilledUsd` as `decimal`), `Hour`, `Id`, `ComputedAt`.
+  - `src/Tamma.Data/Entities/AnalyticsUsageDaily.cs` — identical shape, `Day` instead of `Hour`.
+  - Doc-comments cite Story 28-10 `PlatformAnalyticsHourly` + the future 36-2 projection sources.
+- **Approach:** keep the dimension/measure contract byte-identical across the two so the daily
+  roll-up is a pure `GROUP BY`. Do **not** add a `TenantId` property.
+
+### Task 3 — EF model configuration + DbSets (AC4, AC6, AC7, AC9)
+
+- **Test first:** the index/column/nullability assertions in `AnalyticsUsageModelTests` (Task 4)
+  drive this (red → green).
+- **Implement:**
+  - `TammaModelConfiguration`: add `private static void ConfigureAnalyticsUsageEntities(
+    ModelBuilder modelBuilder, Guid? fixedTenantId)` mirroring `ConfigurePlatformAnalyticsHourly`
+    for defaults/precision; map `CostBasis` with `.HasConversion<string>().HasMaxLength(20)`;
+    `Provider` required `HasMaxLength(100)`; `AgentId` `HasMaxLength(200)`; `RepoId`
+    `HasMaxLength(400)`. Add `IX_analytics_usage_hourly_breakdown` (`Hour, Provider, AgentId,
+    WorkflowDefinitionId, CostBasis`) and `UX_analytics_usage_hourly_dims`
+    (`Hour, Provider, AgentId, WorkflowDefinitionId, RepoId, CostBasis`,
+    `.IsUnique().AreNullsDistinct(false)`). Same for daily with `Day`.
+    End each entity with `ApplyTenantFilter(entity, fixedTenantId, _ => null)` (no `TenantId`).
+  - Call `ConfigureAnalyticsUsageEntities(modelBuilder, fixedTenantId)` from the end of
+    `ConfigureTenantEntities`.
+  - `TenantDbContext`: add `DbSet<AnalyticsUsageHourly>` + `DbSet<AnalyticsUsageDaily>`.
+- **Approach:** a single shared private configurator with one inner `Action<EntityTypeBuilder<T>>`
+  applied to both entities avoids drift between hourly/daily (parameterise the bucket column).
+
+### Task 4 — model-parity unit tests (AC5, AC10)
+
+- **Files:** `tests/Tamma.Api.Tests/Analytics/AnalyticsUsageModelTests.cs` (new);
+  extend `tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs`.
+- **Assertions (InMemory + Npgsql, per `TenantDbContextModelTests`):**
+  - `TenantDbContext` model maps `analytics_usage_hourly` + `analytics_usage_daily`.
+  - `CostBasis` is a `string`/text store type on both providers; column name correct.
+  - `AgentId`/`WorkflowDefinitionId`/`RepoId` nullable; `Provider`/`CostBasis` required.
+  - counters are `bigint`; `CostUsd`/`PlatformBilledUsd` are `numeric(20,4)`.
+  - `IX_*_breakdown` and `UX_*_dims` present with expected column sets; `UX_*_dims` is unique.
+  - CP test: `platform_analytics_hourly` still mapped on `ControlPlaneDbContext`;
+    `analytics_usage_*` absent from the CP model graph.
+- **Run:** `dotnet test --filter "FullyQualifiedName~AnalyticsUsageModel|ControlPlaneDbContextModel"`.
+
+### Task 5 — Tenant migration + smoke test (AC11, AC12)
+
+- **Generate:** `dotnet ef migrations add AddAnalyticsUsageFactTables -c TenantDbContext`
+  (project `src/Tamma.Data`). Verify the `Up()` creates both tables + both indexes with the
+  NULLS NOT DISTINCT clause on `UX_*_dims`; `Down()` drops both.
+- **Gate:** `dotnet ef migrations has-pending-model-changes -c TenantDbContext` ⇒ **none**
+  (regenerate snapshot if it reports drift).
+- **Test first/alongside:** `tests/Tamma.Api.Tests/Analytics/AnalyticsUsageMigrationTests.cs`
+  (Postgres 17 Testcontainer, per `SchemaPerTenantMigrationTests` + `ConventionStoreMigrationTests`):
+  1. migrate two `t_<hex>` schemas into one DB; both carry `analytics_usage_hourly` +
+     `analytics_usage_daily` + `__TenantMigrationsHistory`.
+  2. insert a row through schema A's `TenantDbContext`; assert invisible through schema B's.
+  3. insert two rows with the same full dimension tuple (NULL `AgentId`/`WorkflowDefinitionId`/
+     `RepoId`) in one bucket → second raises a unique violation (NULLS NOT DISTINCT proven).
+  4. re-running the migrator for an already-migrated schema is a no-op.
+- **Run:** `sg docker -c "dotnet test --filter 'FullyQualifiedName~AnalyticsUsageMigration'"`.
+
+### Task 6 — full-suite + CI gate
+
+- **Run:** `sg docker -c "dotnet test apps/tamma-elsa/Tamma.sln"` (or the Tamma.Api.Tests +
+  Tamma.Core.Tests projects) — full green.
+- **Verify** the migration applies + rolls back cleanly and `has-pending-model-changes` stays
+  clean (CI gate).
+
+---
+
+## Sequencing & dependencies
+
+Task 1 (enum) → Task 2 (entities) → Task 3 (config + DbSets) → Task 4 (model tests, red→green) →
+Task 5 (migration + smoke test) → Task 6 (full suite). Tasks 1-3 are a tight compile chain; Task
+4 can be written red against Task 2's stubs and turned green by Task 3. Task 5 must follow Task 3
+(migration is generated from the finished model). No external story is a hard blocker beyond the
+already-merged Epic 28 / Story 28-10 infrastructure.
+
+## Risks + mitigations
+
+- **NULLS NOT DISTINCT not emitted by the migration.** EF 9 supports `AreNullsDistinct(false)`
+  but the generated SQL must carry `NULLS NOT DISTINCT`. *Mitigation:* the Postgres Testcontainer
+  collision test (Task 5) is the real proof — InMemory cannot verify it (same caveat documented
+  in `ConventionStoreMigrationTests`). If EF emits a plain unique index, fix the model and
+  regenerate before the test passes.
+- **Accidental `TenantId` column.** Copy-pasting from `agent_configs`/`conventions` would
+  reintroduce the legacy transitional column. *Mitigation:* the `ApplyTenantFilter(..., _ => null)`
+  signature + an explicit model test asserting **no** `TenantId` column on either table.
+- **CP table touched by mistake.** *Mitigation:* AC5 + the extended `ControlPlaneDbContextModelTests`
+  assert `platform_analytics_hourly` is unchanged and `analytics_usage_*` are absent from CP.
+- **`has-pending-model-changes` drift.** The model snapshot must regenerate exactly.
+  *Mitigation:* run the gate after `migrations add`; regenerate snapshot if drift; CI enforces it.
+- **Hourly/daily drift.** Two hand-maintained mappings could diverge. *Mitigation:* a single
+  shared private configurator parameterised on the bucket column.
+- **Docker-group staleness in the test session.** *Mitigation:* run Testcontainer suites via
+  `sg docker -c "dotnet test ..."` (per project memory `reference_dotnet_test_docker`).
+
+## Acceptance criteria (mirror of the story)
+
+- [ ] `AnalyticsUsageHourly` + `AnalyticsUsageDaily` entities exist with the full dimension
+      (`Provider`, `AgentId?`, `WorkflowDefinitionId?`, `RepoId?`, `CostBasis`) + measure
+      (`TokensIn/Out`, `CostUsd`, `PlatformBilledUsd`, `WorkflowsStarted/Completed/Failed`,
+      `AgentDispatches`) contract; bucket is `Hour` / `Day`.
+- [ ] `CostBasis` enum (`Byok`/`Platform`) maps to a lowercase text column via
+      `HasConversion<string>()`, identical on InMemory + Npgsql.
+- [ ] Both tables live in the tenant schema via `TenantDbContext` / `Migrations/Tenant` and carry
+      **no** `TenantId` column; they are absent from `ControlPlaneDbContext`;
+      `platform_analytics_hourly` is unchanged.
+- [ ] Composite breakdown index `(bucket, Provider, AgentId, WorkflowDefinitionId, CostBasis)`
+      and a NULLS NOT DISTINCT unique business-key index over the full dimension tuple exist.
+- [ ] Counters are `long`, costs are `decimal(20,4)` matching `PlatformAnalyticsHourly`; measures
+      default to 0, `ComputedAt` defaults to `now()`, `Id` to `gen_random_uuid()`.
+- [ ] Model-parity tests pass on both providers; CP-isolation test passes.
+- [ ] `AddAnalyticsUsageFactTables` migration applies cleanly under the Tenant design-time
+      factory + `EfTenantDbMigrator`, `has-pending-model-changes` reports none, and the two-schema
+      smoke test proves search-path isolation + NULLS NOT DISTINCT collision.
+- [ ] No DCB events, population logic, endpoints, or dashboard changes introduced.
+- [ ] Full test suite green.

--- a/docs/superpowers/plans/2026-06-17-36-10-platform-business-analytics-plan.md
+++ b/docs/superpowers/plans/2026-06-17-36-10-platform-business-analytics-plan.md
@@ -1,0 +1,215 @@
+# Story 36-10 — Platform Business Analytics (Owner-Only: MRR, Churn, Conversion) — Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan step-by-step. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every step writes tests
+> before implementation. Read [BEFORE_YOU_CODE.md](../../guides/BEFORE_YOU_CODE.md) first.
+
+**Goal:** Give the platform owner a single owner-only business-analytics surface — MRR/ARR, net-new
+vs churned MRR, churn rate, trial→paid conversion, active/trialing/churned tenant counts, plan
+distribution, and platform-wide gross margin — computed entirely from **control-plane** data
+(`ControlPlaneDbContext`: `Tenant`, `Plan`, Epic 35 subscription/billing entities; the
+`platform_analytics_hourly` fact table; the Epic 36-7 pricing source). It is **SaaS-mode only** and
+**strictly never exposed to any tenant** — gated behind `PlatformOwnerAccess`. It **extends**
+`AdminAnalyticsEndpoints` / `IPlatformAnalyticsService` (Story 28-10) rather than duplicating the
+ops counters from Epic 5/23.
+
+**Story file:** `docs/stories/epic-36/story-36-10/36-10-platform-business-analytics.md`
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane API), React/Vite
+dashboard in `packages/dashboard` (Vitest). xUnit tests live in
+`apps/tamma-elsa/tests/Tamma.Api.Tests/`; docker-bound suites run via
+`sg docker -c "dotnet test ..."` (memory `reference_dotnet_test_docker`). Dashboard tests:
+`pnpm test --filter @tamma/dashboard`.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO tenant-facing business analytics.** There is no `/api/v1/orgs/{tenantId}/analytics/business`
+  variant and never will be in this story. Owner-only, full stop.
+- **NO per-tenant schema reads for business detail.** Business metrics come from CP tables + the
+  CP-resident `platform_analytics_hourly` fact table + the pricing source. The service must not take
+  an `ITenantConnectionResolver` dependency.
+- **NO duplication of Epic 5/23 ops metrics.** Workflow/agent-dispatch/cost counters already exist
+  on `IPlatformAnalyticsService`; reuse `GetTopTenantsAsync`, don't re-query the tenant directory.
+- **NO new fact table or migration.** Provider cost basis comes from existing
+  `platform_analytics_hourly.CostUsd`; revenue from the Epic 36-7 pricing source; subscription state
+  from Epic 35 entities. This story adds a read-side service + 2 endpoints + a dashboard tab only.
+- **NO single-user surface.** No MRR/churn concept with one user; routes are not mounted in
+  single-user mode.
+- **NO blocking on Epic 35 / 36-7.** Ship a documented degraded mode (coarse MRR from
+  `Tenant.Plan`+`Plan.MonthlyPriceUsd`; churn/conversion/margin zeroed) and swap real sources behind
+  the ports when they land — no contract change.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### What exists and is reused
+
+| Artifact | Path | Use |
+|---|---|---|
+| `AdminAnalyticsEndpoints` (3 owner-only handlers) | `apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminAnalyticsEndpoints.cs` | Extend with `GetBusiness` + `GetBusinessMargin`. |
+| `IPlatformAnalyticsService` + impl (`GetTopTenantsAsync`, injected `_clock`) | `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/{IPlatformAnalyticsService,PlatformAnalyticsService}.cs` | Reuse `GetTopTenantsAsync`; copy the `_clock`-based UTC windowing pattern (`PlatformAnalyticsService.cs:84`). |
+| Analytics DTOs (`TenantAnalyticsRow`, `CostAggregates`, …) | `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/PlatformAnalyticsDtos.cs` | Add new business DTOs alongside. |
+| `PlatformAnalyticsHourly` (`CostUsd` = provider cost basis) | `apps/tamma-elsa/src/Tamma.Data/Entities/PlatformAnalyticsHourly.cs` | Sum `CostUsd` over the UTC window for `providerCostBasisUsd`. |
+| `Plan` (`MonthlyPriceUsd`, `Slug`, `DisplayName`, `IsActive`) | `apps/tamma-elsa/src/Tamma.Data/Entities/Plan.cs` | MRR per plan; plan distribution rows. |
+| `Tenant` (`Plan` slug, `Type`, `DeletedAt`, `ProvisioningState`) | `apps/tamma-elsa/src/Tamma.Data/Entities/Tenant.cs` | Active/plan-distribution counts; CP `DeletedAt` filter excludes soft-deleted. |
+| `ControlPlaneDbContext` | `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Sole DB dependency of the new service. |
+| `PlatformOwnerAccess` policy | `apps/tamma-elsa/src/Tamma.Api/Program.cs` ~986 | Gate both endpoints. (Spec says "OwnerAccess"; the real platform-owner policy is `PlatformOwnerAccess`. `OwnerAccess` ~971 is the looser per-tenant-owner gate — DO NOT use it here.) |
+| Owner-only analytics maps (template) | `Program.cs` ~1343-1350 (`/analytics/summary|tenants|events` each `RequireAuthorization("PlatformOwnerAccess")`) | Copy the mapping shape. |
+| Endpoint UTC coercion precedent | `AdminAnalyticsEndpoints.GetEventHistogram` (`DateTime.SpecifyKind(... ToUniversalTime(), Utc)`) | Apply to `from`/`to`. |
+| `ITammaModeProvider` / `TammaMode.cs` | `apps/tamma-elsa/src/Tamma.Api/Services/PromptStore/TammaMode.cs` | SaaS-gate the route mapping. |
+| Admin dashboard tabs (`AdminTab` union + `TABS` + render switch) | `packages/dashboard/src/pages/admin/AdminLayout.tsx` | Add the "Business Analytics" tab. |
+| Admin API client convention | `packages/dashboard/src/services/admin/admin-api-client.ts` | Mirror for `business-analytics-client.ts`. |
+| Chart primitives | `packages/dashboard/src/components/knowledge-base/analytics/*` | Reuse for the new charts where practical. |
+
+### What does NOT exist yet (mark NEW; degraded-mode until they land)
+
+- **Epic 35 subscription/billing entities** — `grep Entities | -iE 'subscript|billing|invoice|...'`
+  returns **nothing**. So paying/trialing/churned subscription *state*, discounts, billing-cycle
+  events, and conversion data have no source today. Until they land: coarse MRR/plan distribution
+  from `Tenant.Plan` + `Plan.MonthlyPriceUsd`; churn/conversion/net-new/churned MRR = `0`/`null`.
+- **Story 36-7 pricing/margin source** (`platformBilledUsd`) — NEW. Until it lands: margin endpoint
+  reports `platformBilledUsd = 0`. The story dirs `docs/stories/epic-36/story-36-7` and
+  `story-36-3` exist (planned), the C# entities do not.
+- **`Tenant` has no `Status`/`TrialEndsAt`/`PlanId`** — only `Plan` (string slug), `Type`,
+  `DeletedAt`, `ProvisioningState`. Conversion/trial/churn fidelity therefore *requires* Epic 35.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Who owns business analytics? | N/A — no billing relationship; routes not mounted (`404`). | Platform owner ONLY (`PlatformOwnerAccess`). Never any tenant. |
+| What data is read? | — | CP only: `Tenant`, `Plan`, Epic 35 entities, `platform_analytics_hourly`, Epic 36-7 pricing. |
+| Surface? | Hidden. | Owner-only "Business Analytics" admin tab. |
+
+---
+
+## Architecture
+
+**CP-only read service → 2 owner-only endpoints → owner-only dashboard tab.** No new persistence.
+
+1. **`IBusinessAnalyticsService` + `BusinessAnalyticsService`** (new, `Services/Analytics/`) — the
+   single read-side seam. Ctor: `ControlPlaneDbContext`, Epic 35 billing read port, Epic 36-7
+   pricing read port, `IPlatformAnalyticsService` (for `GetTopTenantsAsync`), `TimeProvider`/`IClock`
+   (deterministic windowing). No per-tenant connection dependency — that absence is asserted by a
+   test (AC10).
+2. **DTOs** (new, alongside `PlatformAnalyticsDtos.cs`): `BusinessAnalyticsSummary`,
+   `PlanDistributionRow`, `PlatformMarginSummary`, with a `degradedMode` flag + missing-source list.
+3. **Endpoints** (extend `AdminAnalyticsEndpoints`): `GET /api/admin/analytics/business` and
+   `GET /api/admin/analytics/business/margin`, mapped in `Program.cs` with
+   `RequireAuthorization("PlatformOwnerAccess")`, SaaS-gated via `ITammaModeProvider`. `from`/`to`
+   coerced to UTC like `GetEventHistogram`.
+4. **Dashboard**: `BusinessAnalyticsTab.tsx` + `business-analytics-client.ts`; registered in
+   `AdminLayout.tsx`. Owner-only; degraded-mode banner when Epic 35/36-7 absent.
+
+**Metric definitions** are pinned in the story (MRR, ARR=MRR×12, net-new/churned MRR, churn rate
+over a window-start cohort, trial→paid conversion with null-on-zero-denominator, plan distribution,
+gross margin = billed − cost basis). All windows derive from the injected clock so a fixed clock +
+fixed `from`/`to` gives a byte-identical result.
+
+---
+
+## Step breakdown (TDD; each step: tests first → implement → green)
+
+### Step 1 — DTOs + `IBusinessAnalyticsService` port + degraded-mode shape
+
+- [ ] Add `BusinessAnalyticsSummary`, `PlanDistributionRow`, `PlatformMarginSummary` (+ `DegradedMode`
+      bool + `MissingSources` list) to a new `Services/Analytics/BusinessAnalyticsDtos.cs`.
+- [ ] Add `IBusinessAnalyticsService` with `GetSummaryAsync(from?, to?, ct)` and
+      `GetMarginAsync(from?, to?, ct)`.
+- [ ] No tests yet (pure declarations); compiles clean.
+
+### Step 2 — `BusinessAnalyticsService`: MRR/ARR + plan distribution (coarse path) — TESTS FIRST
+
+- [ ] `tests/Tamma.Api.Tests/Epic36/BusinessAnalyticsServiceTests.cs`: fixed `TimeProvider`, in-memory
+      CP fixture of tenants across `free`/`team`/`enterprise` + a soft-deleted tenant. Assert:
+      `mrrUsd` = Σ non-free non-deleted `Plan.MonthlyPriceUsd`; `arrUsd = mrr × 12`; free contributes
+      0; soft-deleted excluded; `planDistribution` has one row per active plan incl. zero-count;
+      per-plan MRR correct; **no tenant ids in `PlanDistribution` rows**.
+- [ ] Implement the coarse path: CP query grouped by `Tenant.Plan` joined to `Plan`; clock-derived
+      `windowEnd`. Set `degradedMode = true` + `MissingSources = ["Epic35.Billing","Story36-7.Pricing"]`
+      when those ports are absent/null.
+- [ ] Green.
+
+### Step 3 — Churn, net-new/churned MRR, trial→paid conversion (Epic 35 path + degraded fallback) — TESTS FIRST
+
+- [ ] Extend the service test: with an Epic 35 billing read-port **fake** supplying subscription
+      state + transitions, assert `churnRate` (window-start cohort), `netNewMrrUsd`/`churnedMrrUsd`
+      (`endMrr − startMrr ≈ netNew − churned`), `trialsEnded`/`trialsConverted`/
+      `trialToPaidConversionRate`, zero-cohort → churn 0, zero `trialsEnded` → conversion `null`.
+- [ ] With the port **absent** (degraded), assert churn/conversion/net-new/churned = `0`/`null` and
+      `degradedMode = true`.
+- [ ] Implement against the Epic 35 read port (define a thin `IBillingSubscriptionReadPort` if Epic 35
+      hasn't shipped one yet — keep it a minimal read contract the eventual entities satisfy).
+- [ ] Green.
+
+### Step 4 — Margin endpoint logic — TESTS FIRST
+
+- [ ] Test: `providerCostBasisUsd` = Σ `platform_analytics_hourly.CostUsd` where `Hour ∈ [from,to)`;
+      `platformBilledUsd` from a pricing read-port fake; `grossMarginUsd = billed − cost`;
+      `grossMarginPct = margin / billed` (billed 0 → pct 0); degraded → `platformBilledUsd = 0`.
+- [ ] Implement `GetMarginAsync` querying the fact table (CP) + pricing port.
+- [ ] Green.
+
+### Step 5 — Determinism + control-plane-only assertions — TESTS FIRST
+
+- [ ] Test: fixed `TimeProvider` + fixed `from`/`to` → two calls produce byte-identical summaries
+      (serialize + compare). Default window = trailing 30d off the fixed clock.
+- [ ] Test/assertion: `BusinessAnalyticsService` ctor takes only `ControlPlaneDbContext` + the read
+      ports + `IPlatformAnalyticsService` + `TimeProvider` — **no** `ITenantConnectionResolver`
+      (reflect over the ctor params, or a compile-time check).
+- [ ] Green.
+
+### Step 6 — Endpoints + Program.cs wiring (SaaS-gated, owner-only) — TESTS FIRST
+
+- [ ] `tests/Tamma.Api.Tests/Epic36/BusinessAnalyticsEndpointsRbacTests.cs`: WebApplicationFactory.
+      Owner principal → 200 on both routes; tenant member / tenant_admin / tenant_owner → 403;
+      cross-tenant principal → 403/404; unauthenticated → 401. `from`/`to` parsed as UTC regardless
+      of `DateTime.Kind`. Single-user mode → routes return 404.
+- [ ] Add `GetBusiness` + `GetBusinessMargin` static handlers to `AdminAnalyticsEndpoints.cs`
+      (coerce `from`/`to` to UTC like `GetEventHistogram`).
+- [ ] Register `IBusinessAnalyticsService` in DI (next to `IPlatformAnalyticsService`); map both
+      routes in `Program.cs` near the `/analytics/*` block with `RequireAuthorization("PlatformOwnerAccess")`,
+      conditional on `ITammaModeProvider` reporting SaaS.
+- [ ] Green; full C# suite stays green.
+
+### Step 7 — Dashboard Business Analytics tab — TESTS FIRST
+
+- [ ] `business-analytics-client.ts` mirroring `admin-api-client.ts`; calls both endpoints.
+- [ ] `packages/dashboard/src/pages/admin/__tests__/BusinessAnalyticsTab.test.tsx` (Vitest + Testing
+      Library): tab renders MRR/ARR/churn/conversion/plan-distribution/margin from a mocked client;
+      degraded-mode banner when `degradedMode`; tab hidden for non-owner.
+- [ ] `BusinessAnalyticsTab.tsx` (reuse KB analytics chart primitives where practical).
+- [ ] Register in `AdminLayout.tsx`: add `'business-analytics'` to `AdminTab`, a `TABS` entry, and the
+      render branch; gate visibility on the existing owner-only admin gate.
+- [ ] `pnpm test --filter @tamma/dashboard` green; no new lint errors.
+
+---
+
+## Step order & dependencies
+
+Step 1 → 2 → 3 → 4 → 5 → 6 → 7. Steps 2–5 build the service incrementally; Step 6 exposes it; Step 7
+visualizes it. Steps 3/4 degrade gracefully if Epic 35 / 36-7 ports are absent, so the wave is not
+blocked on those landing.
+
+## Risks
+
+- **Cross-tenant leakage (the cardinal sin).** Mitigation: routes are owner-only (`PlatformOwnerAccess`);
+  there is no tenant-reachable code path; aggregate DTOs carry no tenant ids except the owner-only
+  drill-down via `GetTopTenantsAsync`. The RBAC test (Step 6) is acceptance-blocking.
+- **Epic 35 / 36-7 not landed.** Mitigation: documented degraded mode — coarse MRR from
+  `Tenant.Plan`/`Plan.MonthlyPriceUsd`, churn/conversion/margin zeroed, `degradedMode` flag + banner.
+  Real sources swap in behind the ports with no contract change.
+- **`OwnerAccess` vs `PlatformOwnerAccess` confusion.** The spec says "OwnerAccess"; the *real*
+  platform-owner-only policy is `PlatformOwnerAccess` (`OwnerAccess` lets every personal-tenant owner
+  through). Using the wrong one would expose business analytics to every tenant owner — exactly the
+  forbidden outcome. Step 6 wires `PlatformOwnerAccess` and tests a tenant_owner gets 403.
+- **Non-deterministic windows.** Mitigation: inject `TimeProvider`/`IClock` (mirror
+  `PlatformAnalyticsService._clock`); never `DateTime.UtcNow` inline; Step 5 pins determinism.
+- **Accidental per-tenant schema read.** Mitigation: ctor takes only `ControlPlaneDbContext` + ports;
+  Step 5 asserts no `ITenantConnectionResolver` dependency.
+- **Ops/business metric duplication.** Mitigation: reuse `GetTopTenantsAsync` and the existing fact
+  table; do not re-add workflow/dispatch/cost counters.

--- a/docs/superpowers/plans/2026-06-17-36-11-analytics-event-catalog-backfill-and-reconciliation-plan.md
+++ b/docs/superpowers/plans/2026-06-17-36-11-analytics-event-catalog-backfill-and-reconciliation-plan.md
@@ -1,0 +1,284 @@
+# Story 36-11 — Analytics Event Catalog, Backfill & Reconciliation (Implementation Plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes its
+> tests RED before implementation. Story file:
+> `docs/stories/epic-36/story-36-11/36-11-analytics-event-catalog-backfill-and-reconciliation.md`.
+
+**Goal:** Make the Epic 36 analytics substrate *trustworthy in production*. Three additions on top
+of the Story 36-2 projection: (a) a typed, drift-guarded **event-field catalog** so an upstream
+rename of `costUsd`/`agent_id` fails a test instead of silently zeroing a column; (b) an admin-only
+**backfill** that rebuilds `analytics_usage_*` for a tenant + time-range from historical
+`domain_events` by replaying the *same* 36-2 idempotent compute hour-by-hour (onboarding existing
+tenants, recovering rollup outages); (c) an hourly **reconciliation** that compares the projected
+per-tenant totals against a live DCB aggregation and emits `ANALYTICS.RECONCILIATION.MISMATCH`
+(WARN) on drift — the in-process twin of the 28-10 fact-table-vs-live fallback and the 20-3
+local-vs-Stripe compare.
+
+**Seed note:** Spec `/tmp/pab_stories/36-11.json` (P2, est 3-4 days). Dependencies: 36-1 (fact
+tables), 36-2 (`ComputeTenantDimensionalRollupActivity.ComputeAsync` + checkpoint), Epic 4 (DCB),
+28-10 (fan-out + fact-table fallback pattern), 20-3 (reconciliation pattern), 28-6 (platform task
+queue / 202).
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane API + Elsa engine).
+C# activities under `Tamma.Activities/Analytics/`; admin endpoints in `Tamma.Api/Endpoints/`; tests
+under `apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/` and
+`tests/Tamma.Api.Tests/Analytics/` (xUnit; docker-bound suites run via
+`sg docker -c "dotnet test ..."`; the build itself needs no wrapper).
+
+> **ARCH guard:** the target is the C# `apps/tamma-elsa` app. `packages/api` (TypeScript) is DELETED —
+> never cite or target it. This story extends the schema-per-tenant, per-tenant `TenantDbContext`
+> projection seam from 36-2, never the old TS billing path.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO change to the 36-2 projection compute or the 36-1 fact-table schema.** Backfill *reuses*
+  `ComputeTenantDimensionalRollupActivity.ComputeAsync` unchanged; reconciliation *reads* the fact
+  tables. Any PR that alters projection semantics or fact-table DDL is out of scope.
+- **NO tenant self-service backfill.** `POST /api/admin/analytics/backfill` is `PlatformOwnerAccess`
+  only — it is an operator recovery/onboarding tool, never a tenant-facing endpoint.
+- **NO new dashboard surface.** Mismatch is observable via DCB events + the built-in alert rule +
+  logs; backfill status is a JSON `GET`. Tenant-facing analytics UI is later Epic 36 stories.
+- **NO reconciliation HTTP endpoint.** Reconciliation is a scheduled best-effort workflow step;
+  operators force one via the existing `POST /workflows/run/hourly-analytics-rollup` with `hour`.
+- **NO inline backfill.** A multi-month replay runs off-thread on the Story 28-6 `PlatformTaskWorker`
+  (202 + pollable status), never on the admin request thread.
+- **NO mismatch-as-failure.** A `RECONCILIATION.MISMATCH` is WARN — it never fails a rollup that
+  already wrote useful rows.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+| File | Status | Relevance |
+|---|---|---|
+| `src/Tamma.Activities/Analytics/AnalyticsRollupEvents.cs` | EXISTS | Event catalogue + `BuildEvent`/`TruncateToHour` helpers — extend with `RECONCILIATION.*` / `BACKFILL.*` constants. |
+| `src/Tamma.Activities/Analytics/ComputeTenantRollupActivity.cs` | EXISTS | `AggregateLlmUsage` + `AGENT.DISPATCH.%` `EF.Functions.Like` count + `WorkflowInstance.Status` counts — REUSE for the live-totals reconciliation path; `ComputeAsync` pure-DI shape is the backfill template. |
+| `src/Tamma.Activities/Analytics/FanOutTenantRollupsActivity.cs` | EXISTS | Per-tenant try/catch + `…_FAILED` emit + continue (28-10 AC5). Mirror exactly for the reconcile fan-out and the backfill per-hour loop. CP-directory target-set query is the tenant-list pattern. |
+| `src/Tamma.ElsaServer/Workflows/HourlyAnalyticsRollupWorkflow.cs` | EXISTS | `Sequence` of steps — append the reconcile fan-out as the final best-effort step (after the 36-2 dimensional fan-out + `EmitHourCompleted` + purges). |
+| `src/Tamma.Activities/Analytics/ComputeTenantDimensionalRollupActivity.cs` | 36-2 (drafted) | `ComputeAsync(...)` is the per-hour compute the backfill loops over. **Mark forward** — author 36-2 first or the backfill loop has nothing to call. |
+| `src/Tamma.Data/Entities/AnalyticsUsageHourly.cs`, `AnalyticsProjectionCheckpoint.cs`, `CostBasis` enum | 36-1/36-2 (drafted) | Projected-totals source + checkpoint cursor. **Mark forward** — not yet in the codebase. |
+| `src/Tamma.Api/Endpoints/AdminAnalyticsEndpoints.cs` | EXISTS (28-10) | 3 GET handlers, gated `PlatformOwnerAccess` at `Program.cs:1346-1351`. Add `Backfill` (POST 202) + `GetBackfillStatus` here; wire under the same `admin` group + policy. |
+| `src/Tamma.Api/Services/Analytics/PlatformAnalyticsService.cs` | EXISTS | The fact-table-first-with-live-fallback (`ShouldPreferFactTableAsync`, `GetXFromFactTableAsync` vs `GetXAsync`) is the **reconciliation pattern reference** — projected vs live, same helpers. Also holds the event-type constants (`LlmCallSuccess`, `AgentDispatchPrefix/Success/Failed`, `WfStatus*`) the drift guard pins. |
+| `src/Tamma.Api/Services/PlatformTasks/IPlatformTaskHandler.cs` + `PlatformTaskWorker.cs` | EXISTS (28-6) | The off-thread 202 execution seam. Add `AnalyticsBackfillTaskHandler : IPlatformTaskHandler` (`TaskType = "analytics.backfill"`). `PlatformTaskTerminalException` for malformed payloads. |
+| `src/Tamma.Api/Services/Alerts/Rules/BuiltInAlertRules.cs` | EXISTS | Add `analytics-reconciliation-mismatch` spec; idempotent seeder picks it up by `built_in_key`. |
+| `src/Tamma.Data/Entities/DomainEvent.cs` | EXISTS | `Type`, `Tags`, `Data`, `SequenceNumber` (the `BIGSERIAL` total-order cursor — checkpoint column; doc-comment names the `AlertRuleEvaluator` precedent). |
+| `src/Tamma.Data/Entities/ProviderDiagnostic.cs` | EXISTS | `ProviderKey`, `InputTokens`/`OutputTokens`, `Cost`, `AgentType`, `ProjectId`. **`BillingMode` is NOT yet present** (35-2 not landed) — catalog marks it forward; cost basis defaults to `platform`. |
+| `src/Tamma.Api/Services/PromptStore/TammaMode.cs` | EXISTS | `ITammaModeProvider` (SingleUser/SaaS) — process-stable mode source for the per-mode answers. |
+| `docs/guides/BEFORE_YOU_CODE.md` | EXISTS | Mandatory pre-code guide (linked from the story). |
+
+**Key reuse insight:** backfill = a loop over 36-2's `ComputeAsync`; reconciliation = 28-10's
+live-aggregation helpers run un-bucketed and compared to the fact-table sum. Neither forks the
+counting logic — that is what makes backfill idempotent-by-construction and reconciliation a true
+drift detector rather than a second, divergent counter.
+
+---
+
+## Architecture
+
+**Catalog → guard; backfill → replay-the-projection; reconcile → projected-vs-live → WARN event → alert.**
+
+1. **`AnalyticsEventCatalog`** (`Tamma.Activities/Analytics/`) — declares, as `static readonly`
+   data, every analytics-relevant DCB event type and its field/tag/column → dimension/measure
+   mapping (table in the story AC1). Exposes event-type + field-name constants. The **drift guard**
+   test asserts catalog ↔ 36-2-projection field-set equality and catalog ↔ in-solution emit-site
+   type-string equality.
+2. **`BackfillTenantAnalyticsActivity`** + static `BackfillAsync` — truncate `[from, to)` to
+   top-of-hour, optionally rewind the 36-2 checkpoint, loop `ComputeTenantDimensionalRollupActivity.ComputeAsync`
+   per hour, report progress, emit `ANALYTICS.BACKFILL.*`. Idempotent via 36-2's whole-bucket upsert.
+3. **`AnalyticsBackfillTaskHandler`** (`IPlatformTaskHandler`, `"analytics.backfill"`) + status
+   store — runs `BackfillAsync` off-thread on the `PlatformTaskWorker`. `POST /api/admin/analytics/backfill`
+   validates + enqueues + returns 202; `GET …/{id}` reports progress.
+4. **`ReconcileAnalyticsActivity`** + static `ReconcileAsync` — projected sum (`analytics_usage_hourly`)
+   vs live DCB aggregation (reuse 28-10 helpers, un-bucketed) over a window; emit
+   `ANALYTICS.RECONCILIATION.MISMATCH` (WARN, per diverging measure, tagged `tenant_id`) past
+   tolerance, else `…OK`; report `checkpointLag`.
+5. **`FanOutTenantReconcileActivity`** — per-tenant fan-out (28-10 try/catch tolerance) wired as the
+   final best-effort step in `HourlyAnalyticsRollupWorkflow`.
+6. **`analytics-reconciliation-mismatch`** built-in alert rule — zero-config paging once a channel
+   is linked.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Fan-out target (reconcile) | the sole tenant schema | all active tenants (28-10 CP-directory set) |
+| Who triggers a backfill | the sole user (owns the instance) | platform operator only — `PlatformOwnerAccess`, never tenant self-service |
+| Who owns a mismatch | the sole user — their feed (`tenant_id` = their tenant) | the tenant — `MISMATCH` carries `tenant_id` → tenant alert feed |
+| Isolation plane | search-path schema + connection string | physically separate schema per tenant; A unreachable from B |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`) | same |
+
+Mode never changes the unit-of-work shape (one tenant schema per backfill/reconcile); only the
+fan-out set size and the endpoint's effective audience differ.
+
+---
+
+## Task breakdown
+
+### T1: Analytics event catalog + drift guard (AC: 1, 2)
+
+**Scope:** Declare the contract; enforce it with a test. No backfill/reconcile yet.
+
+**Files:**
+- New: `src/Tamma.Activities/Analytics/AnalyticsEventCatalog.cs` — event-type + field-name constants;
+  `static readonly` mapping data (event → fields → dimension/measure + source location).
+- Test (first): `tests/Tamma.Activities.Tests/Analytics/AnalyticsEventCatalogDriftTests.cs`.
+
+**Tests (first):** catalog field set == the set the 36-2 projection reads (every catalog field
+consumed; every consumed field cataloged); catalog event-type strings == in-solution emit-site
+constants (`PlatformAnalyticsService.LlmCallSuccess`/`AgentDispatchPrefix`/`AgentDispatchSuccess`/
+`AgentDispatchFailed`, the `"completed"`/`"failed"` workflow-status literals); a mutated copy of the
+catalog (renamed field / dropped type) fails the equivalence — proving the guard bites.
+
+**Acceptance:**
+- [ ] Catalog declares ≥ the AC1 event types + mappings as data, with source-location per field.
+- [ ] Drift guard is green against 36-2 as authored; a deliberate rename fails it.
+- [ ] Constants are reusable by 36-2 as a single source of truth (equivalence pinned; no 36-2 retrofit required here).
+
+### T2: Backfill activity + idempotency (AC: 3, 4, 6, 10, 12)
+
+**Scope:** `BackfillTenantAnalyticsActivity` + static `BackfillAsync` looping 36-2's `ComputeAsync`
+per hour over `[from, to)`; `resetCheckpoint` rewind; per-tenant isolation via `ITenantDbContextFactory`.
+
+**Files:**
+- New: `src/Tamma.Activities/Analytics/BackfillTenantAnalyticsActivity.cs`.
+- Test (first): `tests/Tamma.Activities.Tests/Analytics/BackfillTenantAnalyticsTests.cs`.
+
+**Tests (first):** backfill a 6-hour range → N rows; re-run → identical row count + summed measures
+(idempotent); `resetCheckpoint=true` rewinds the cursor + re-derives with no double-count;
+`from >= to` → throws; isolation (a row written to schema A invisible through schema B — InMemory
+shape unit + Postgres integration in T6).
+
+**Acceptance:**
+- [ ] `BackfillAsync` pure-DI entry point drives `ComputeTenantDimensionalRollupActivity.ComputeAsync` per hour.
+- [ ] Re-running a range converges (no duplicates); `resetCheckpoint` rewind is atomic with the first re-projected bucket.
+- [ ] Reads/writes only the target tenant's schema.
+
+### T3: Backfill endpoint + platform task (AC: 5, 11, 13)
+
+**Scope:** Off-thread 202 execution + pollable status, `PlatformOwnerAccess`.
+
+**Files:**
+- New: `src/Tamma.Api/Services/Analytics/AnalyticsBackfillTaskHandler.cs` (`IPlatformTaskHandler`,
+  `"analytics.backfill"`), `IAnalyticsBackfillStatusStore.cs` + `AnalyticsBackfillStatusStore.cs`
+  (status pending/running/completed/failed + hoursDone/hoursTotal).
+- Modify: `src/Tamma.Api/Endpoints/AdminAnalyticsEndpoints.cs` — `Backfill` (POST 202 + `Location`)
+  + `GetBackfillStatus` (GET). `src/Tamma.Api/Program.cs` — map both under the `admin` group with
+  `RequireAuthorization("PlatformOwnerAccess")` (mirror lines 1346-1351); register the task handler
+  via the Story 28-6 `AddPlatformTaskHandler<>` extension.
+- Test (first): `tests/Tamma.Api.Tests/Analytics/AnalyticsBackfillEndpointTests.cs`.
+
+**Tests (first):** `POST …/backfill` → 202 + `Location`; the enqueued task drives status
+`pending → running → completed`; `GET …/{id}` reflects progress; RBAC (platform owner 200; tenant
+member 403; cross-tenant/non-owner 403/404); `from >= to` or over-span → 400; unknown tenant →
+`PlatformTaskTerminalException` → dead-letter (not retried).
+
+**Acceptance:**
+- [ ] Request returns 202 immediately; the per-hour replay never runs inline.
+- [ ] Endpoint gated `PlatformOwnerAccess` (verified by the wiring + RBAC test).
+- [ ] Range validation + max-span clamp (default 400 days).
+
+### T4: Reconciliation activity + tolerance (AC: 7, 8, 10, 11)
+
+**Scope:** Projected-vs-live compare per tenant over a window; WARN mismatch + checkpoint-lag.
+
+**Files:**
+- New: `src/Tamma.Activities/Analytics/ReconcileAnalyticsActivity.cs` + `ReconcileAsync` static
+  entry; `AnalyticsReconciliationOptions` (relative tolerance default 0.5% + absolute floor).
+- Modify: `src/Tamma.Activities/Analytics/AnalyticsRollupEvents.cs` — add
+  `ReconciliationMismatch`, `ReconciliationOk`, `BackfillStarted/Completed/Failed` constants.
+- Test (first): `tests/Tamma.Activities.Tests/Analytics/ReconcileAnalyticsTests.cs`,
+  `…/AnalyticsRollupEventsTests.cs` (modify).
+
+**Tests (first):** projected == live within tolerance → no `MISMATCH` (optionally `…OK`); inject a
+divergent `analytics_usage_hourly` row → `ANALYTICS.RECONCILIATION.MISMATCH` with correct
+`measure`/`projected`/`live`/`deltaPct`/`checkpointLag`; sub-floor divergence on a near-empty tenant
+→ no event; tolerance is config-driven; new event constants exist + match convention.
+
+**Acceptance:**
+- [ ] `ReconcileAsync` reuses the 28-10 live-aggregation helpers (same counting rule as the projection).
+- [ ] Mismatch is WARN, per diverging measure, tagged `tenant_id`; within-tolerance is quiet.
+- [ ] `checkpointLag` (max `SequenceNumber` − checkpoint) is reported.
+
+### T5: Fan-out + workflow wiring (AC: 9, 11, 12)
+
+**Scope:** Per-tenant reconcile fan-out as the final best-effort workflow step.
+
+**Files:**
+- New: `src/Tamma.Activities/Analytics/FanOutTenantReconcileActivity.cs` (mirror
+  `FanOutTenantRollupsActivity` try/catch tolerance + CP-directory target set + `ComputeOneOverride`
+  test seam).
+- Modify: `src/Tamma.ElsaServer/Workflows/HourlyAnalyticsRollupWorkflow.cs` — append the reconcile
+  fan-out after the 36-2 dimensional fan-out + `EmitHourCompleted` + purges.
+- Test (first): `tests/Tamma.Activities.Tests/Analytics/HourlyAnalyticsRollupWorkflowStructureTests.cs`
+  (modify).
+
+**Tests (first):** reconcile step present + ordered after the 36-2 dimensional fan-out; a forced
+failure on tenant A leaves tenant B's reconcile intact + the fan-out completes; platform +
+dimensional steps unchanged.
+
+**Acceptance:**
+- [ ] Reconcile shares one schedule / one advisory lock / one target hour with the existing rollup.
+- [ ] Per-tenant failure isolation (28-10 AC5); never aborts the workflow; never blocks tenant traffic.
+
+### T6: Built-in alert rule + integration isolation (AC: 11, 14)
+
+**Scope:** Zero-config paging + the Postgres-backed isolation proof.
+
+**Files:**
+- Modify: `src/Tamma.Api/Services/Alerts/Rules/BuiltInAlertRules.cs` — `analytics-reconciliation-mismatch`
+  (warning, `ANALYTICS.RECONCILIATION.MISMATCH`, `{"op":"always"}`, `ThrottleSeconds` 3600, empty `ChannelIds`).
+- Test (first): extend `tests/Tamma.Api.Tests/Alerts/` (seeder + evaluator + throttle); new
+  `tests/Tamma.Api.Tests/Analytics/AnalyticsBackfillReconcileIsolationTests.cs` (Postgres 17 Testcontainer).
+
+**Tests (first):** seeder creates the rule; evaluator fires on an appended
+`ANALYTICS.RECONCILIATION.MISMATCH`; throttle suppresses a burst. Isolation: backfill into schema A
+invisible through B; NULLS-NOT-DISTINCT upsert convergence on re-run; per-tenant failure isolation.
+
+**Acceptance:**
+- [ ] A mismatch pages with no manual rule setup (ships with empty `ChannelIds` per convention).
+- [ ] Per-tenant isolation + idempotent convergence proven against real Postgres 17 (`sg docker -c "dotnet test …"`).
+
+---
+
+## Task order & dependencies
+
+T1 (catalog/guard) is independent and first — it pins the contract everything else honours.
+T2 (backfill activity) needs 36-2's `ComputeAsync`; T3 (endpoint/task) needs T2; T4 (reconcile) is
+parallel-safe with T2/T3; T5 (workflow wiring) needs T4; T6 (alert + integration) needs T4 (event)
+and T2 (backfill) for the isolation suite. Critical path: **T1 → T2 → T3** and **T1 → T4 → T5 → T6**.
+
+> **Hard prerequisite:** Story 36-2 must be authored/implemented far enough that
+> `ComputeTenantDimensionalRollupActivity.ComputeAsync`, `AnalyticsProjectionCheckpoint`,
+> `AnalyticsUsageHourly`, and the extended `AnalyticsRollupEvents` exist — T2/T4 call into them
+> directly. If implementing 36-11 before 36-2 lands, stub the 36-2 seam behind an interface and
+> mark it forward, or sequence 36-2 first.
+
+## Risks
+
+- **36-2 not yet landed.** T2/T4 depend on 36-2's `ComputeAsync` + checkpoint + fact tables (drafted,
+  not implemented). Mitigation: sequence 36-2 first, or gate T2/T4 behind a thin seam. The catalog
+  (T1) and the drift guard can be authored against the 36-2 *story* contract before 36-2 code lands.
+- **Backfill cost on busy tenants.** A multi-month replay reads a large event window per hour.
+  Mitigation: off-thread 202 (T3) + honour cancellation + the max-span clamp; the 36-2 per-bucket
+  read is already hour-bounded.
+- **Reconciliation false positives.** Same-source-different-window or async-event-arrival could
+  trigger a spurious mismatch. Mitigation: reconcile a *completed* window (last full UTC day), reuse
+  the *exact* projection helpers (so the counting rule can't differ), and apply relative tolerance +
+  absolute floor. If flapping persists, widen the window or add a settle delay (cheap follow-up).
+- **Alert noise.** A persistently drifted tenant could page every hour. Mitigation: rule
+  `ThrottleSeconds` 3600 + per-measure dedup; the registry of mismatch events stays in the DCB store
+  for the runbook regardless of paging.
+- **`BillingMode` (35-2) absent.** Cost basis defaults to `platform` on both projected and live
+  sides, so the catalog marks it forward and reconciliation compares like-for-like — no false
+  mismatch from a missing 35-2. Pin this in the T4 tolerance test.
+- **Event-store topology shift (Story 28-1 / Epic 30).** Per-tenant events move under per-tenant
+  fan-out later; the reconcile already reads each tenant's `TenantDbContext`, and the mismatch
+  events carry `tenant_id`, so the migration only touches the CP-directory target-set read — keep
+  the directory read isolated (mirror `FanOutTenantRollupsActivity`).
+- **Catalog drift-guard brittleness.** Over-strict reflection could break on benign refactors.
+  Mitigation: assert on declared field-name/event-type *strings* (the contract), not on private
+  member shapes; the guard's job is to catch a rename, not to freeze the implementation.

--- a/docs/superpowers/plans/2026-06-17-36-2-dcb-to-analytics-projection-pipeline-plan.md
+++ b/docs/superpowers/plans/2026-06-17-36-2-dcb-to-analytics-projection-pipeline-plan.md
@@ -1,0 +1,256 @@
+# Story 36-2 — DCB-to-Analytics Projection Pipeline / Dimensional Rollup (implementation plan)
+
+> Epic 36 (Analytics & Reporting Platform) · P0 · est. 4-5 days · author Claude · 2026-06-17 ·
+> SUB-SKILL: use `superpowers:test-driven-development` — every task writes its failing test first.
+> Docker-bound suites run via `sg docker -c "dotnet test ..."`; the build itself needs no wrapper.
+
+**Goal:** Populate the Story 36-1 per-tenant dimensional fact tables (`analytics_usage_hourly` /
+`analytics_usage_daily`) from each tenant's DCB event stream + `ProviderDiagnostic` rows, broken
+down by provider / agent / workflow / repo / cost-basis. Do it by **extending** the Story 28-10
+`HourlyAnalyticsRollupWorkflow` with an additional per-tenant dimensional fan-out step (sharing its
+schedule, advisory lock, target hour, fan-out shape, idempotent-upsert + per-tenant-failure
+tolerance), plus a daily compaction step and a per-tenant retention purge. Make the projection
+idempotent (whole-bucket overwrite), resumable (per-tenant `SequenceNumber` checkpoint), backfillable
+(historical `hour` input), per-tenant isolated (physical schema), and SLO-observable (projection lag
+event + OTel gauge). **Population only — no fact-table schema change, no query/export endpoint, no
+dashboard.**
+
+**Non-goals (YAGNI guard):**
+- NO change to the Story 36-1 `analytics_usage_*` table shape (only the additive
+  `analytics_projection_checkpoint` table is new schema).
+- NO change to the control-plane `platform_analytics_hourly` rollup (28-10), its events, or its
+  purge — the platform fact table stays the owner-only fleet store.
+- NO query / export / scheduled-report endpoint and NO dashboard — later Epic 36 stories.
+- NO margin/markup math implemented here — consumed from Story 36-7 via `IAnalyticsPricingConfig`.
+- NO secret/cabinet read in the analytics path — cost basis comes from the 35-2 `billing_mode`
+  tag/column, not a fresh BYOK lookup.
+- NO second scheduler — the dimensional rollup, daily compaction, and usage purge ride the existing
+  hourly workflow.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### What exists and is the pattern to mirror
+
+| Site | What it gives us |
+|---|---|
+| `src/Tamma.ElsaServer/Workflows/HourlyAnalyticsRollupWorkflow.cs` | The host workflow to extend. `Build()` is a `Sequence` of `initBucket → platformRollup → fanOut → emitCompleted → purgeStale`, schedule `0 5 * * * *`, optional `hour` backfill input via `InitBucket`. Insert the dimensional fan-out after `fanOut`, daily compaction after it, the usage purge last. The structure test (`HourlyAnalyticsRollupWorkflowStructureTests`) pins the step graph — extend it. |
+| `src/Tamma.Activities/Analytics/ComputeTenantRollupActivity.cs` | The canonical per-tenant compute: static `ComputeAsync(cpFactory, tenantFactory, publisher, tenantId, hour, logger, ct)` pure-DI entry point; reads `WorkflowInstances` by `Status`, counts `AGENT.DISPATCH.%` via `EF.Functions.Like` (InMemory+Npgsql safe), pulls `LLM.CALL.SUCCESS` `Data` blobs and aggregates with `AggregateLlmUsage` (skips malformed JSON, rounds cost to 4dp). Read-then-upsert on the business key. **Copy this verbatim, but GROUP BY the dimension tuple instead of collapsing to one tenant row, and write to the tenant's own `analytics_usage_hourly` via `TenantDbContext` instead of CP.** |
+| `src/Tamma.Activities/Analytics/FanOutTenantRollupsActivity.cs` | The fan-out: lists active tenants from the CP directory (`DeletedAt == null`, `CreatedAt < hour+1`, `Status` null-or-`active`), loops serially, per-tenant `try/catch` → emits `ANALYTICS.ROLLUP.TENANT_FAILED` + increments `failed` + continues, sets `TenantsSuccess`/`TenantsFailed` outputs, has a `ComputeOneOverride` test seam. Copy for `FanOutTenantDimensionalRollupsActivity` (or extend it with a second compute call per tenant). |
+| `src/Tamma.Activities/Analytics/PurgeStaleAnalyticsActivity.cs` | The retention sweeper: `ExecuteDeleteAsync` of rows older than `ComputeCutoff(now, 13mo)`, best-effort (catches all but `OperationCanceledException`, emits `ANALYTICS.PURGE.HOURLY`/`…FAILED`, never rethrows), static pure-DI `PurgeAsync`. Copy for `PurgeStaleUsageAnalyticsActivity` (per-tenant `analytics_usage_hourly` instead of CP `platform_analytics_hourly`). |
+| `src/Tamma.Activities/Analytics/AnalyticsRollupEvents.cs` | Event catalogue + `BuildEvent(type, hour, tenantId?, data?)` + `TruncateToHour`. Add the new dimensional/compact/purge/lag constants here, same `AGGREGATE.ACTION.STATUS` shape; the `ANALYTICS.PROJECTION.*` family was reserved for this story by 36-1 §"DCB events". |
+| `src/Tamma.Data/Entities/DomainEvent.cs` | The source stream: `Type`, JSONB `Tags` (`agent_id` Epic 32, `billing_mode` 35-2, `provider`, `repoId`, `workflowDefinitionId`), JSONB `Data` (`costUsd`/`inputTokens`/`outputTokens`), and **`SequenceNumber`** — the monotonic `BIGSERIAL` total-order cursor (doc-comment names `AlertRuleEvaluator` as the precedent consumer). This is the checkpoint column. |
+| `src/Tamma.Data/Entities/ProviderDiagnostic.cs` | The diagnostic source: `ProviderKey` (provider dim), `InputTokens`/`OutputTokens`/`Cost`, `AgentType` (agent dim), `ProjectId` (repo dim), `Model`, and **`BillingMode`** (`byok`/`platform`, added by 35-2 → cost basis). DbSet `ProviderDiagnostics` on `TenantDbContext` (line 56). |
+| `src/Tamma.Data/Entities/AnalyticsUsageHourly.cs` / `AnalyticsUsageDaily.cs` (Story 36-1) | The write targets: dims `Provider`(req)/`AgentId?`/`WorkflowDefinitionId?`/`RepoId?`/`CostBasis`; measures `TokensIn/Out`, `CostUsd`, `PlatformBilledUsd`, `WorkflowsStarted/Completed/Failed`, `AgentDispatches`; `Hour`/`Day`; `ComputedAt`. `UX_*_dims` NULLS-NOT-DISTINCT unique business key is the upsert backstop; `CostBasis` enum is in `Tamma.Core/Enums`. (Authored, drafted — see `docs/stories/epic-36/story-36-1/`.) |
+| `src/Tamma.Core/Enums/CostBasis.cs` (Story 36-1) | `Byok`/`Platform`, lowercase-text persisted. The cost-basis helper returns this. |
+| `src/Tamma.Data/Abstractions/ITenantDbContextFactory.cs` | `ValueTask<TenantDbContext> CreateAsync(tenantId, ct)` — the per-tenant read+write seam (search-path schema, no cross-tenant filter). |
+| `src/Tamma.Activities/Core/TammaActivity.cs` (`TammaAsyncActivity`) | The activity base every analytics activity extends (`Logger`, `EventType`, `RunAsync`). |
+| `src/Tamma.Data/Abstractions/IPlatformEventPublisher.cs` | `AppendAndPublishAsync(PlatformEvent, ct)` — durable event emission (best-effort in the catch paths). |
+| KekRotationMetrics (Story 28-12, `tamma.kek_rotation.remaining` OTel gauge) | The OTel gauge precedent for the `tamma.analytics.projection_lag_seconds` SLO gauge (per project memory: 28-12 added a gauge via a metrics class). |
+
+### Where cost basis really comes from (resolve the spec's Epic-29 framing)
+
+The spec lists **Epic 29 (secret cabinet) to detect BYOK key origin**. In this codebase the BYOK
+decision is already surfaced one layer up, as the `billing_mode` discriminator produced by
+**Story 35-2 / Epic 35** (verified in `docs/stories/epic-35/story-35-2/...`, ACs 7-8):
+
+- `ProviderDiagnostic.BillingMode` string column (`byok | platform`) — 35-2 AC7.
+- `LLM.CALL.SUCCESS` / `LLM.CALL.FAILED` DCB `Tags` carry `billing_mode` (`byok|platform`),
+  `provider`, `model`, `tenantId` — 35-2 AC8.
+
+35-2 itself reads the cabinet (`ISecretStore`) to decide the mode, so 36-2 stays a pure projection:
+read the `billing_mode` tag/column, never touch a secret. **Honor the spec's dependency list** (it
+names Epic 29 / 32 / 36-7) but point the implementation at the real `billing_mode` signal, and
+degrade gracefully (`CostBasis.Platform` default) when 35-2 hasn't landed.
+
+### Confirmed absent (so these are genuinely NEW)
+
+- `ComputeTenantDimensionalRollupActivity`, `CompactDailyAnalyticsActivity`,
+  `PurgeStaleUsageAnalyticsActivity`, `FanOutTenantDimensionalRollupsActivity`,
+  `IAnalyticsPricingConfig`, `AnalyticsProjectionCheckpoint` — none exist
+  (`grep -rln "Dimensional|AnalyticsProjectionCheckpoint|IAnalyticsPricingConfig" src/` → no match).
+- Story 36-7 (`IAnalyticsPricingConfig` source), Epic 32 `agent_id` tag wiring, and Story 35-2
+  `billing_mode` are **not yet present in `src/`** (`grep` for `billing_mode`/`agent_id` in
+  analytics paths → no match). All three are forward/soft deps — design degrades gracefully.
+
+---
+
+## Phased task breakdown (test-first)
+
+### Task 1 — event catalogue + cost-basis helper (AC 4, 12, 13)
+
+- **Test first:** extend `tests/Tamma.Activities.Tests/Analytics/AnalyticsRollupEventsTests.cs` —
+  assert the new constants (`TenantDimensionalRollupCompleted`/`…Failed`, `DailyCompacted`,
+  `UsageHourlyPurged`/`…Failed`, `DimensionalLag`) follow `AGGREGATE.ACTION.STATUS`; add a
+  `CostBasis ResolveCostBasis(...)` test covering tag `byok`/`platform`, diagnostic fallback,
+  absent → `Platform`.
+- **Implement:** add the constants to `AnalyticsRollupEvents`; add the pure
+  `ResolveCostBasis(string? billingModeTag, string? diagnosticBillingMode)` helper.
+- **Run:** `dotnet test --filter "FullyQualifiedName~AnalyticsRollupEvents|ResolveCostBasis"`.
+
+### Task 2 — `IAnalyticsPricingConfig` margin seam (AC 5)
+
+- **Test first:** a pricing-application test — `platform` → `CostUsd*(1+margin)`; `byok` → `0`;
+  `NullAnalyticsPricingConfig` → zero margin + WARN.
+- **Implement:** `IAnalyticsPricingConfig` (`decimal MarginFor(string provider)` or similar,
+  shaped to consume Story 36-7) + `NullAnalyticsPricingConfig` zero-margin fallback. Register the
+  Null seam in DI so the rollup is green before 36-7 lands.
+- **Run:** `dotnet test --filter "FullyQualifiedName~AnalyticsPricing"`.
+
+### Task 3 — `AnalyticsProjectionCheckpoint` entity + migration (AC 7)
+
+- **Test first:** `AnalyticsProjectionCheckpointTests` (red against the entity stub) — read default
+  (0), advance to max `SequenceNumber`, re-run folds only `> checkpoint`.
+- **Implement:**
+  - `src/Tamma.Data/Entities/AnalyticsProjectionCheckpoint.cs` — `{ Id, Stream("dimensional"),
+    LastSequenceNumber long, UpdatedAt }` (one row per stream; no `TenantId` column — tenant schema
+    is the isolation plane, per 36-1 §"Tenant-isolation note").
+  - `TammaModelConfiguration.ConfigureAnalyticsProjectionCheckpoint(...)` in the tenant graph
+    (unique on `Stream`, `ApplyTenantFilter(entity, fixedTenantId, _ => null)`); add the DbSet to
+    `TenantDbContext`.
+  - `dotnet ef migrations add AddAnalyticsProjectionCheckpoint -c TenantDbContext`
+    (`TenantDesignTimeDbContextFactory`, history `__TenantMigrationsHistory`,
+    `Migrations/Tenant/`); `has-pending-model-changes -c TenantDbContext` → none.
+- **Run:** `sg docker -c "dotnet test --filter 'FullyQualifiedName~AnalyticsProjectionCheckpoint'"`.
+
+### Task 4 — `ComputeTenantDimensionalRollupActivity` (AC 1, 2, 3, 6, 8, 9)
+
+- **Test first:** `ComputeTenantDimensionalRollupTests` (InMemory) — bucketing across
+  provider/agent/workflow/repo/cost-basis; `NULL` buckets reconcile to grand total; idempotent
+  replay (run twice → identical rows/measures); margin applied to `platform`, `0` for `byok`.
+- **Implement:** new activity extending `TammaAsyncActivity`; static `ComputeAsync(...)` pure-DI
+  entry point. Algorithm:
+  1. `tenantDb = tenantFactory.CreateAsync(tenantId)`; window `[hour, hour+1)`.
+  2. Read `WorkflowInstances` counts (started/completed/failed) — these have no provider/agent
+     dimension, so they land on a `(Provider=?, Agent=NULL, ...)` workflow-dimensioned bucket keyed
+     by the workflow's definition id (or a workflow-only tuple — pin the exact rule in the test).
+  3. `AGENT.DISPATCH.%` events → group by `(agent_id, provider, repoId, workflowDefinitionId,
+     billing_mode→CostBasis)` → `AgentDispatches`.
+  4. `LLM.CALL.SUCCESS` events → parse `Data` (reuse the `AggregateLlmUsage` JSON shape) → group by
+     the dimension tuple → `TokensIn/Out`, `CostUsd`. `ProviderDiagnostic` rows in-window contribute
+     the diagnostic-sourced measures + dims (`ProviderKey`, `AgentType`, `ProjectId`, `BillingMode`).
+  5. For each tuple compute `PlatformBilledUsd` (Task 2 seam; `platform` only).
+  6. Read-then-upsert each tuple on the full business key into `tenantDb.AnalyticsUsageHourly`;
+     advance the checkpoint to the max `SequenceNumber` seen; one `SaveChanges`.
+  7. Emit `ANALYTICS.ROLLUP.TENANT_DIMENSIONAL_COMPLETED`.
+- **Approach:** **overwrite** measures on re-run (whole-bucket recompute) so replay/backfill are
+  idempotent; the checkpoint is a skip-optimisation, not the idempotency mechanism. Accept `hour` +
+  `resetCheckpoint` inputs for backfill.
+
+### Task 5 — daily compaction + usage-hourly purge (AC 10, 11)
+
+- **Test first:** `CompactDailyAnalyticsActivityTests` — 24 hourly buckets → one daily set; measures
+  sum losslessly; re-compaction idempotent. Purge test (Postgres) — rows older than cutoff deleted,
+  best-effort on failure.
+- **Implement:**
+  - `CompactDailyAnalyticsActivity` — `GROUP BY date_trunc('day', Hour), <all dims>` → upsert on the
+    daily business key; runs when target hour is `00:xx` (compacts the day that just ended); emits
+    `ANALYTICS.COMPACT.DAILY`.
+  - `PurgeStaleUsageAnalyticsActivity` — copy `PurgeStaleAnalyticsActivity`, target
+    `tenantDb.AnalyticsUsageHourly`, default 13-month window, best-effort, emits
+    `ANALYTICS.PURGE.USAGE_HOURLY`/`…FAILED`.
+
+### Task 6 — fan-out + workflow wiring + lag SLO (AC 12, 13, 14)
+
+- **Test first:** extend `HourlyAnalyticsRollupWorkflowStructureTests` — assert the dimensional
+  fan-out + compaction + usage-purge steps exist and the platform fan-out precedes the dimensional
+  one; a lag-over-budget test emits `ANALYTICS.ROLLUP.DIMENSIONAL_LAG` + gauge.
+- **Implement:**
+  - `FanOutTenantDimensionalRollupsActivity` — mirror `FanOutTenantRollupsActivity` (same tenant
+    target set, serial loop, per-tenant `try/catch` → `…_FAILED` + continue, success/failed
+    outputs, `ComputeOneOverride` test seam). (Alternative considered: extend the existing fan-out
+    to call both compute helpers per tenant — keeps one tenant iteration; decide in implementation
+    based on the journal/coupling tradeoff and pin the choice in the structure test.)
+  - Wire into `HourlyAnalyticsRollupWorkflow.Build` after `fanOut`: `fanOutDimensional →
+    compactDaily(day-boundary) → emitCompleted → purgeStale → purgeUsageStale`.
+  - Record projection lag (`now − hour`) per pass; emit `ANALYTICS.ROLLUP.DIMENSIONAL_LAG` + the
+    `tamma.analytics.projection_lag_seconds` OTel gauge (KekRotationMetrics precedent) when over
+    the SLO budget (default 2h, config-driven).
+
+### Task 7 — isolation integration suite + full-suite gate (AC 8, 15)
+
+- **Test first/alongside:** `tests/Tamma.Api.Tests/Analytics/DimensionalRollupIsolationTests.cs`
+  (Postgres 17 Testcontainer, per `SchemaPerTenantMigrationTests`):
+  1. project into two `t_<hex>` schemas; a row in A's `analytics_usage_hourly` is invisible in B.
+  2. a forced failure on tenant A leaves tenant B's projection intact + fan-out completes.
+  3. concurrent re-run of the same tuple collapses on `UX_*_dims` (NULLS NOT DISTINCT).
+  4. checkpoint resume re-folds only un-checkpointed events with no double-count.
+- **Run:** `sg docker -c "dotnet test apps/tamma-elsa/Tamma.sln"` — full green; confirm the
+  checkpoint migration applies + rolls back and `has-pending-model-changes -c TenantDbContext`
+  stays clean (CI gate).
+
+---
+
+## Sequencing & dependencies
+
+Task 1 (events + cost-basis) → Task 2 (margin seam) → Task 3 (checkpoint entity/migration) →
+Task 4 (dimensional compute, depends on 1-3) → Task 5 (compaction + purge) → Task 6 (fan-out +
+workflow + lag) → Task 7 (isolation suite + full gate). Tasks 1-2 are leaf helpers; Task 3 is an
+independent additive migration; Task 4 is the core and depends on all three; Tasks 5-6 build on
+Task 4's compute; Task 7 proves the whole pipeline. Hard prereqs are already merged (28-10, Epic 4,
+Epic 28) plus the drafted 36-1 schema; soft deps (35-2 `billing_mode`, Epic 32 `agent_id`, 36-7
+margin) degrade gracefully and are pinned by their default-path tests.
+
+## Risks + mitigations
+
+- **Double-counting on re-run/backfill.** *Mitigation:* whole-bucket overwrite (recompute the
+  entire `(tenant, hour)` from source each pass) makes the upsert idempotent regardless of the
+  checkpoint; the checkpoint is a skip-optimisation only. A replay test asserts identical
+  rows/measures after a second run.
+- **`SequenceNumber` cursor vs `CreatedAt`.** Using `CreatedAt` would skip/double same-millisecond
+  events. *Mitigation:* cursor strictly on `DomainEvent.SequenceNumber` (the `BIGSERIAL` total
+  order); the resume test exercises a same-millisecond batch.
+- **`NULL` dimension buckets breaking the unique key / reconciliation.** *Mitigation:* rely on
+  36-1's `UX_*_dims` NULLS NOT DISTINCT key; a bucketing test asserts `Σ(per-dim rows) == grand
+  total`. The Postgres collision test (Task 7) proves the NULL dedupe (InMemory can't).
+- **Cost-basis source not yet shipped (35-2).** *Mitigation:* resolve from the `billing_mode`
+  tag/column with a documented `CostBasis.Platform` default; a classification test pins the default
+  so the rollup is correct pre-35-2 and flips automatically once tags appear.
+- **36-7 margin not yet shipped.** *Mitigation:* `IAnalyticsPricingConfig` seam +
+  `NullAnalyticsPricingConfig` zero-margin fallback + WARN; never hardcode a margin.
+- **Per-tenant failure cascading.** *Mitigation:* copy the 28-10 fan-out tolerance — per-tenant
+  `try/catch` → `…_FAILED` + continue; isolation test proves A's failure leaves B intact.
+- **Two schedulers racing the same tenants.** *Mitigation:* extend the single 28-10 workflow (one
+  schedule, one advisory lock, one target hour); the structure test pins step ordering.
+- **`has-pending-model-changes` drift on the checkpoint migration.** *Mitigation:* run the gate
+  after `migrations add`; regenerate the snapshot if it drifts; CI enforces it.
+- **Memory/cost of pulling LLM `Data` blobs.** *Mitigation:* same bounded hour-window read as
+  28-10's `ComputeTenantRollupActivity` (≤ tens of thousands/tenant/hour); aggregate in memory with
+  the shared helper; if a tenant proves pathological, the per-tenant failure tolerance contains it.
+- **Docker-group staleness in the test session.** *Mitigation:* run Testcontainer suites via
+  `sg docker -c "dotnet test ..."` (per project memory `reference_dotnet_test_docker`).
+
+## Acceptance criteria (mirror of the story)
+
+- [ ] `ComputeTenantDimensionalRollupActivity` projects one tenant's hour of `domain_events` +
+      `ProviderDiagnostic` into one `analytics_usage_hourly` row per `(Provider, AgentId,
+      WorkflowDefinitionId, RepoId, CostBasis)` tuple with summed measures; static `ComputeAsync`
+      pure-DI entry point.
+- [ ] Provider/agent/workflow/repo dimensions read from the DCB tags / diagnostic columns; absent
+      dimension → `NULL` bucket; per-dim rows reconcile to the grand total.
+- [ ] Agent dimension from the `agent_id` tag (Epic 32) / `ProviderDiagnostic.AgentType`; no agent
+      → `AgentId = NULL`.
+- [ ] `CostBasis` resolved per record from the 35-2 `billing_mode` tag/`ProviderDiagnostic.BillingMode`
+      (default `platform`); `PlatformBilledUsd = CostUsd*(1+margin)` for `platform` (36-7 seam),
+      `0` for `byok`.
+- [ ] Idempotent: re-running an hour upserts on the full dimension business key (whole-bucket
+      overwrite) — replay test shows unchanged rows/measures.
+- [ ] Resumable: per-tenant `analytics_projection_checkpoint` on `DomainEvent.SequenceNumber`;
+      crash-resume re-folds only un-checkpointed events with no double-count.
+- [ ] Per-tenant isolation: read+write through the tenant's own schema; A's failure leaves B
+      intact (Postgres isolation test).
+- [ ] Backfill: explicit historical `hour` (+ `resetCheckpoint`) re-projects through the same
+      idempotent path.
+- [ ] `CompactDailyAnalyticsActivity` rolls hourly → daily losslessly (idempotent upsert on the
+      daily business key); usage-hourly retention purge mirrors `PurgeStaleAnalyticsActivity`
+      (best-effort, 13-month default, runs last).
+- [ ] `ANALYTICS.ROLLUP.TENANT_DIMENSIONAL_COMPLETED/FAILED` per tenant×hour; one tenant's failure
+      doesn't abort the fan-out; compaction/purge/lag events emitted.
+- [ ] Projection-lag SLO observable via `ANALYTICS.ROLLUP.DIMENSIONAL_LAG` + the
+      `tamma.analytics.projection_lag_seconds` OTel gauge past the budget.
+- [ ] Wired into `HourlyAnalyticsRollupWorkflow` after the platform fan-out; 28-10 platform rollup
+      + CP purge unchanged (structure test).
+- [ ] No fact-table schema change, no query/export endpoint, no dashboard, no CP-table change.
+- [ ] Full test suite green; checkpoint migration applies + rolls back; `has-pending-model-changes`
+      clean.

--- a/docs/superpowers/plans/2026-06-17-36-3-tenant-usage-analytics-api-plan.md
+++ b/docs/superpowers/plans/2026-06-17-36-3-tenant-usage-analytics-api-plan.md
@@ -1,0 +1,253 @@
+# Story 36-3 — Tenant Usage Analytics API — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan phase-by-phase. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every phase writes its
+> failing test before the implementation. Story file:
+> `docs/stories/epic-36/story-36-3/36-3-tenant-usage-analytics-api.md`.
+
+**Goal:** Expose a per-tenant, RBAC-gated, read-only query API over the Story 36-1 dimensional
+fact tables (`analytics_usage_hourly` / `analytics_usage_daily`, populated by Story 36-2) that
+returns time-bucketed usage (workflows, agent dispatches, tokens, cost) broken down by provider,
+agent, workflow, and repo over an arbitrary window at hourly or daily grain — plus a top-N
+single-dimension breakdown. Endpoints are tenant-scoped under `/api/v1/orgs/{tenantId}/…`, gated by
+the existing tenant-membership filter (any member may read; cross-tenant route → 403), window-
+bounded (365-day max, hour-granularity cap), and UTC-binding-correct, serving the dashboard
+(36-6) and exporter (36-8) one stable contract.
+
+**Seed note:** Epic 36 turns the DCB stream + per-tenant operational data into a multi-dimensional
+analytics product (`docs/stories/epic-36/`). 36-1 built the schema, 36-2 the projection; 36-3 is
+the **first read surface**. Per-mode: single-user resolves the principal to the sole user's tenant
+schema, SaaS to the tenant's schema — identical endpoint shape, auth middleware decides binding
+(CLAUDE.md prompt-store precedent). Member-read RBAC mirrors prompt-store "GET resolved → any
+member".
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane API + Elsa
+engine). Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/` (xUnit; docker-bound
+suites run via `sg docker -c "dotnet test ..."` — the build itself needs no wrapper; the session
+docker group is stale).
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO schema change.** This story reads 36-1's tables verbatim. It adds no column, index, or
+  migration. (If a read needs an index 36-1 didn't ship, raise it against 36-1 — don't add it
+  here.)
+- **NO population logic.** Story 36-2 owns the DCB→fact projection. The query API reads only the
+  pre-aggregated rows; it never re-scans `domain_events` and never reads `ProviderDiagnostic` (a
+  36-2 source).
+- **NO export format / NO dashboard UI.** 36-8 owns CSV/JSON exports; 36-6 owns the
+  `packages/dashboard-user` UI. This story ships the JSON contract both consume — and nothing more.
+- **NO change to the platform-owner analytics surface.** `AdminAnalyticsEndpoints`,
+  `IPlatformAnalyticsService`, and `platform_analytics_hourly` (Story 28-10) stay the cross-tenant
+  `OwnerAccess` business-analytics path, untouched. This story is the parallel tenant-facing
+  mirror.
+- **NO duplication of Epic 5 / Epic 23 OPS/health metrics.** Usage analytics only (workflows,
+  dispatches, tokens, cost). System health / liveness / readiness stays where it is.
+- **NO mutations.** GET only. No ack/resolve/write — so no admin+ RBAC gate is introduced (unlike
+  `AlertEndpoints`' tenant mutations).
+- **NO per-mode handler branch.** The endpoint shape is identical across single-user/SaaS; the
+  membership filter + per-tenant context do the mode work.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### Target architecture (C# `apps/tamma-elsa` — `packages/api` is DELETED, never a target)
+
+| Concern | Verified path | Note |
+|---|---|---|
+| Per-tenant context factory (read seam) | `apps/tamma-elsa/src/Tamma.Data/Abstractions/ITenantDbContextFactory.cs`, `apps/tamma-elsa/src/Tamma.Data/TenantDbContextFactory.cs` | `CreateAsync(tenantId)` → schema-scoped `TenantDbContext`; the physical isolation plane. |
+| Fact tables (read targets) | `apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs` → `AnalyticsUsageHourly` / `AnalyticsUsageDaily` DbSets | **Authored by 36-1 (drafted).** Buckets `Hour`/`Day` (`timestamp with time zone`, UTC); dims `Provider`/`AgentId`/`WorkflowDefinitionId`/`RepoId`/`CostBasis`; measures `TokensIn/Out`, `Workflows*`, `AgentDispatches` (long), `CostUsd`/`PlatformBilledUsd` (decimal(20,4)). No `TenantId` column. |
+| Tenant resolution middleware | `apps/tamma-elsa/src/Tamma.Api/Middleware/TenantContextMiddleware.cs` | Resolves tenant + warms the per-tenant pool. **Bypasses `/api/v1/admin/` but NOT `/api/v1/orgs/`** — org routes get tenant binding + the membership filter. |
+| Cross-tenant 403 guard | `apps/tamma-elsa/src/Tamma.Api/Authorization/RequireTenantMembershipFilter.cs` | Endpoint filter: 401 unauth, 400 bad route `tenantId`, **403 if caller has no membership in route `{tenantId}`**; stashes role in `HttpContext.Items["TenantRole"]`. This is the AC4/AC12 guard. |
+| Member-read policy | `apps/tamma-elsa/src/Tamma.Api/Program.cs` ~line 991, `options.AddPolicy("MemberAccess", …RequireAuthenticatedUser())` | Authenticated-only; the `orgs` group already carries it (`MapGroup("/api/v1/orgs").RequireAuthorization("MemberAccess")`, ~line 1512). |
+| **Exact precedent endpoint** | `apps/tamma-elsa/src/Tamma.Api/Endpoints/UserDashboardEndpoints.cs` | `GET /api/v1/orgs/{tenantId:guid}/dashboard/{summary,runs,stats}` — route `{tenantId}` + `ITenantDbContextFactory.CreateAsync(tenantId)` + `.AddEndpointFilter<RequireTenantMembershipFilter>()` (Program.cs ~1599). **Copy this shape.** |
+| Forced-UTC binding fix | `apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminAnalyticsEndpoints.cs` `GetEventHistogram` | `DateTime.SpecifyKind(since.Value.ToUniversalTime(), DateTimeKind.Utc)` — replicate for `from`/`to` (AC9). |
+| Owner analytics surface (LEAVE INTACT) | `apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminAnalyticsEndpoints.cs`, `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/PlatformAnalyticsService.cs` + `IPlatformAnalyticsService.cs` | Cross-tenant, `OwnerAccess`/admin, reads CP `platform_analytics_hourly`. Do not read/modify. |
+| Tenant dashboard SPA (36-6 consumer) | `packages/dashboard-user/` | Consumes this contract later; out of scope here. |
+| Tenant-scope mutation RBAC precedent (for contrast) | `apps/tamma-elsa/src/Tamma.Api/Endpoints/AlertEndpoints.cs` (`ListTenantAlerts` etc.) | Tenant alert reads use the same membership filter; mutations inline-gate admin+ via `RequireTenantAdmin`. 36-3 has **no** mutations → no admin+ gate. |
+
+### Key reuse / divergence facts
+
+- **The read seam is `ITenantDbContextFactory`, not a repository.** `UserDashboardEndpoints.GetStats`
+  is the canonical pattern: `await using var db = await tenantDbFactory.CreateAsync(tenantId);` then
+  LINQ over the DbSet. No `TenantId` predicate is needed for the new fact tables (they have no such
+  column — 36-1 §1.4); the filter is on the bucket + dimension only.
+- **The cross-tenant guard is already built.** `RequireTenantMembershipFilter` is registered
+  (Program.cs ~352) and attached per-route via `.AddEndpointFilter<…>()`. 36-3 just attaches it to
+  the two new routes. No new guard code.
+- **`MemberAccess` is the right policy.** It only requires an authenticated user; combined with the
+  membership filter it yields "any member of the route tenant may read" — exactly AC5. Do **not**
+  reach for `OwnerAccess`/`SettingsManage` (owner-only) or `PromptManage`/`ConventionManage`
+  (admin+).
+- **UTC binding is a known fix, not a discovery.** `AdminAnalyticsEndpoints` already documents the
+  Local-vs-UTC binding hazard; 36-3 inherits the exact normalization for `from`/`to`.
+- **InMemory vs Postgres test split is established.** Model/grouping shape on InMemory; isolation +
+  real `GROUP BY` / `timestamp with time zone` on a Postgres 17 Testcontainer (per
+  `SchemaPerTenantMigrationTests` / `ConventionStoreMigrationTests`).
+
+---
+
+## Architecture
+
+**Thin endpoints → one read service → per-tenant fact tables**, reusing the user-dashboard +
+membership-filter shape end-to-end:
+
+1. **`TenantAnalyticsDtos.cs`** — request DTOs (`UsageQuery`, `BreakdownQuery`), the
+   `AnalyticsWindow` clamp record (default window, 365-day max, hour-granularity cap, forced-UTC),
+   the `AnalyticsGranularity`/`AnalyticsDimension`/`AnalyticsMetric` enums + parse helpers (400 on
+   bad enum), and response contracts (`UsageResponse`/`BreakdownResponse` with
+   `period_start`/`period_end`/`granularity` echoes — AC7/8/9).
+2. **`ITenantAnalyticsService` / `TenantAnalyticsService`** — the single read seam. Opens the
+   per-tenant context via `ITenantDbContextFactory.CreateAsync(tenantId)`, picks `AnalyticsUsageDaily`
+   (day) or `AnalyticsUsageHourly` (hour), applies the half-open `[from, to)` filter on the bucket
+   column, and builds the grouped/breakdown projection (NULL dimension preserved) — unit-testable in
+   isolation against a seeded InMemory context (AC1/2/3/10).
+3. **`TenantAnalyticsEndpoints`** — `GetUsage` / `GetBreakdown` handlers: parse+clamp the window,
+   400 on invalid, delegate to the service, return `Results.Ok(...)`. Thin (AC1/3).
+4. **Program.cs wiring** — map both routes under the `orgs` group with
+   `.AddEndpointFilter<RequireTenantMembershipFilter>()` (member-read + cross-tenant 403) and
+   register `ITenantAnalyticsService` (AC4/5/6). CP owner surface untouched (AC11).
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who is the principal? | The sole user — `{tenantId}` = their (only) tenant schema. | The tenant — `{tenantId}` = its `t_<hex>` schema. |
+| Who can read (GET)? | The user (no role). | Any tenant member (`MemberAccess` + membership filter); `member` reads succeed (no 403 on GET). |
+| Endpoint shape | identical | identical — no per-mode branch; the membership filter + per-tenant context do the work. |
+| Isolation plane | search-path schema + connection string (no `TenantId` column/filter). | same — physically separate schema per tenant; schema A unreachable from schema B's context. |
+| Cross-tenant leakage | N/A (one tenant). | `RequireTenantMembershipFilter` 403s a non-member of the route tenant; physical schema isolation backstops it. |
+
+---
+
+## Phased TDD tasks
+
+### Phase 1 — DTOs, enums, and the `AnalyticsWindow` clamp (pure, no DB)
+
+- [ ] Write `TenantAnalyticsServiceTests` clamp/UTC cases **red first**: default window;
+      400-day → truncate to 365 (effective echoed); `granularity=hour` over 31d → invalid;
+      `from >= to` → invalid; bad `granularity`/`groupBy`/`dimension`/`metric` enum → invalid; a
+      `+02:00` `from` normalizes to the same UTC instant/bucket as its `Z` equivalent.
+- [ ] Add `Tamma.Api/Services/Analytics/TenantAnalyticsDtos.cs`: `UsageQuery`, `BreakdownQuery`,
+      `UsageBucketRow`, `BreakdownRow`, `UsageResponse`, `BreakdownResponse`; `AnalyticsGranularity`
+      / `AnalyticsDimension` / `AnalyticsMetric` enums + `TryParse`; `AnalyticsWindow.Resolve(...)`
+      with forced-UTC (`DateTime.SpecifyKind(v.ToUniversalTime(), DateTimeKind.Utc)`), 30d default,
+      365d max-range truncation, hour-granularity 31d cap.
+- [ ] Green: clamp/UTC tests pass. **No DB touched yet.**
+
+### Phase 2 — `TenantAnalyticsService` aggregation (InMemory)
+
+- [ ] Write grouping tests **red first** against a seeded InMemory `TenantDbContext`
+      (`AnalyticsUsageDaily` + `Hourly` rows spanning multiple providers/agents/workflows/repos,
+      including NULL-dimension rows):
+  - groupBy absent → one summed row per bucket;
+  - groupBy=provider|agent|workflow|repo → one row per `(bucket, dim)`, NULL key surfaced not
+    dropped;
+  - **reconciliation:** `Σ(grouped per bucket) == ungrouped bucket`;
+  - breakdown top-N by each metric ordered desc, `limit` clamp respected.
+- [ ] Add `ITenantAnalyticsService` + `TenantAnalyticsService(ITenantDbContextFactory)`:
+      `GetUsageAsync` (granularity switch → `AnalyticsUsageDaily`/`Hourly`, half-open `[from,to)`
+      bucket filter, GROUP BY bucket [+ dim], summed measures) and `GetBreakdownAsync` (GROUP BY
+      dim over window, OrderByDescending(metric), Take(limit)).
+- [ ] Green: grouping + reconciliation pass on InMemory.
+
+### Phase 3 — `TenantAnalyticsEndpoints` + Program.cs wiring (RBAC matrix)
+
+- [ ] Write `TenantAnalyticsEndpointsTests` **red first**: member/tenant_admin/tenant_owner →
+      200; non-member of route tenant → 403; unauth → 401; single-user sole user → 200; handlers
+      reference only `ITenantAnalyticsService` (assert no `IPlatformAnalyticsService` /
+      `ControlPlaneDbContext` usage — AC11).
+- [ ] Add `Tamma.Api/Endpoints/TenantAnalyticsEndpoints.cs`: `GetUsage` / `GetBreakdown` (parse +
+      `AnalyticsWindow.Resolve` → 400 on invalid → service → `Results.Ok`).
+- [ ] Wire Program.cs: `orgs.MapGet("/{tenantId:guid}/analytics/usage", …GetUsage)` and
+      `…/analytics/usage/breakdown` each `.AddEndpointFilter<RequireTenantMembershipFilter>()`;
+      `builder.Services.AddScoped<ITenantAnalyticsService, TenantAnalyticsService>()`.
+- [ ] Green: RBAC matrix passes; CP-untouched assertion holds.
+
+### Phase 4 — Postgres 17 integration (isolation + grouping + clamp + UTC)
+
+- [ ] Write `TenantAnalyticsIntegrationTests` **red first** (Postgres 17 Testcontainer, two tenant
+      schemas seeded with distinct fact rows, per `SchemaPerTenantMigrationTests`):
+  - tenant-A caller on tenant-A route sees only A's rows;
+  - tenant-A caller on tenant-B route → 403 and **zero** B rows returned (AC4/AC12);
+  - grouping correctness + reconciliation against real Npgsql `GROUP BY`;
+  - range clamp (400-day → 365) and hour-cap rejection on real columns;
+  - UTC: a non-UTC-offset `from` selects the same buckets as its UTC equivalent on real
+    `timestamp with time zone`.
+- [ ] Make green; run via `sg docker -c "dotnet test --filter TenantAnalytics ..."`.
+- [ ] Full suite green; no `has-pending-model-changes` drift (this story adds no migration —
+      confirm none was generated).
+
+---
+
+## Sequencing
+
+Phase 1 → Phase 2 → Phase 3 → Phase 4. Phase 1 is pure (no DB) and unblocks everything. Phase 2
+needs the DTOs/enums from Phase 1. Phase 3 needs the service from Phase 2. Phase 4 needs the wired
+endpoints from Phase 3 (it drives them through the real host). Phases 1–2 can be done by one agent;
+Phase 4's Testcontainer suite is the long pole — start its scaffolding (two-schema seed helper)
+early but it can only assert once Phase 3 lands.
+
+**Hard prerequisites:** Story 36-1 (the fact tables/DbSets must exist to compile the service) and
+Epic 18/28 (membership filter + factory, already merged). Story 36-2 is a *soft* prerequisite for
+**meaningful** integration data — the integration suite seeds fact rows directly (it does not run
+the 36-2 projection), so 36-3 can land and be tested before 36-2 merges; the reconciliation
+assertion verifies the read-side math, which is independent of how the rows were written.
+
+---
+
+## Risks
+
+- **Cross-tenant leakage is the headline risk.** Mitigation is layered: (1) the route sits under
+  the `orgs` group so `RequireTenantMembershipFilter` 403s a non-member of `{tenantId}`; (2)
+  `ITenantDbContextFactory.CreateAsync(tenantId)` binds a physically separate schema/connection, so
+  even a filter bug can't read another tenant's rows. The integration test asserts BOTH the 403 and
+  zero leaked rows. **Do not** use a shared `ControlPlaneDbContext` with a `TenantId` predicate for
+  these reads — that would be the leak.
+- **Forced-UTC binding off-by-one.** A `from`/`to` parsed as Local shifts the window off the UTC
+  bucket boundary and silently drops/double-counts edge buckets. Replicate the
+  `AdminAnalyticsEndpoints` normalization exactly and pin it with the offset-equivalence test (the
+  bug is invisible without it).
+- **Unbounded hourly scan.** `from=1970..to=now&granularity=hour` would scan years of hourly rows.
+  The 31-day hour cap (400) + 365-day max range bound the cost. Make the caps configurable but
+  shipped with safe defaults.
+- **NULL-dimension reconciliation.** Coercing a NULL `AgentId`/`RepoId`/`WorkflowDefinitionId` to
+  `"unknown"` would fork the per-dimension total away from the ungrouped total. Surface NULL as a
+  `null` key and assert `Σ(grouped) == ungrouped` per bucket — the 36-2 reconciliation contract
+  must hold at read time.
+- **Accidental CP coupling.** It is tempting to "reuse" `IPlatformAnalyticsService`. That surface
+  is cross-tenant `OwnerAccess` over CP `platform_analytics_hourly` — reusing it would either leak
+  cross-tenant data or 403 every member. The CP-untouched assertion (AC11) guards against this
+  regressing.
+- **InMemory does not model schema isolation or date-bucket `GROUP BY` faithfully.** Grouping
+  *shape* is fine on InMemory, but isolation + real `timestamp with time zone` window selection +
+  Npgsql `GROUP BY` semantics must run on a Postgres 17 Testcontainer (same rationale as
+  `ConventionStoreMigrationTests`). Don't certify isolation on InMemory.
+- **Schema-edit temptation.** If a grouped read wants an index 36-1 didn't ship, the fix belongs in
+  36-1 — adding it here violates the query-only boundary and breaks the
+  `has-pending-model-changes` clean gate. Raise it upstream.
+
+---
+
+## Acceptance criteria (plan-level — maps to story ACs)
+
+- [ ] `GET /api/v1/orgs/{tenantId}/analytics/usage` returns time-bucketed usage reading
+      `AnalyticsUsageDaily`/`Hourly` via `ITenantDbContextFactory`, with `from`/`to`/`granularity`/
+      `groupBy` params and `period_start`/`period_end` echoes (story AC1/2/8).
+- [ ] `GET …/analytics/usage/breakdown` returns top-N rows for a single dimension by the selected
+      metric (story AC3).
+- [ ] Both routes sit behind `RequireTenantMembershipFilter`; a cross-tenant route returns 403 with
+      a test asserting **no** cross-tenant rows leak (story AC4/12).
+- [ ] GET is member-readable — `MemberAccess` + membership filter, **no** owner/admin gate;
+      single-user requires no role (story AC5/6).
+- [ ] Window bounded (365-day max, hour cap), forced-UTC binding mirrors `AdminAnalyticsEndpoints`
+      (story AC7/9).
+- [ ] CP owner analytics surface (`AdminAnalyticsEndpoints`/`IPlatformAnalyticsService`/
+      `platform_analytics_hourly`) left intact; handlers reference neither (story AC11).
+- [ ] Integration tests (Postgres 17, two schemas) cover grouping correctness + reconciliation,
+      range clamping, UTC handling, and cross-tenant 403 (story AC12).
+- [ ] No EF migration generated; `has-pending-model-changes` clean; full suite green via
+      `sg docker -c "dotnet test ..."`.

--- a/docs/superpowers/plans/2026-06-17-36-4-cost-and-spend-analytics-api-plan.md
+++ b/docs/superpowers/plans/2026-06-17-36-4-cost-and-spend-analytics-api-plan.md
@@ -1,0 +1,262 @@
+# Story 36-4 — Cost & Spend Analytics API (BYOK vs Platform) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation. Story file:
+> `docs/stories/epic-36/story-36-4/36-4-cost-and-spend-analytics-api.md`.
+
+**Goal:** Ship the tenant-facing **read side** for cost & spend. A new
+`GET /api/v1/orgs/{tenantId}/analytics/cost` endpoint, backed by a `CostAnalyticsService`, reads the
+per-tenant `analytics_usage_daily` fact table (Story 36-1, populated by Story 36-2) and returns a
+daily spend time-series that **separates BYOK token cost** (raw provider cost, informational, never
+marked up) **from platform-provided billable spend** (`PlatformBilledUsd`, already materialized
+upstream), plus month-to-date + linear-run-rate projection, a `BudgetConfig` join for
+budget-vs-actual, and a trend vs the prior window. When the projection crosses the budget the
+service emits one tenant-tagged `ANALYTICS.COST.BUDGET_PROJECTED_EXCEEDED` DCB event (best-effort,
+per-period deduped) for the alerting / scheduled-report pipeline.
+
+**Seed note:** PAB spec `/tmp/pab_stories/36-4.json` — "analytics read side; the billing/charging
+mechanics remain in (re-targeted) Epic 20; reuses BudgetConfig for budget context." The markup
+*engine* is Story 34-5; `PlatformBilledUsd` is materialized by Story 36-2 — this story READS
+cost/spend, it does **not** compute markup.
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane API + Elsa engine).
+Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/` (xUnit; docker-bound suites run via
+`sg docker -c "dotnet test ..."`). The legacy TypeScript `packages/api` is **deleted** — never a
+target.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO markup / margin math.** The markup engine is Story 34-5; the margin is baked into
+  `analytics_usage_daily.PlatformBilledUsd` by Story 36-2. This endpoint SUMS that column and never
+  multiplies by a margin. (Story AC4 is the guardrail: "margin config has zero effect on output".)
+- **NO billing / charging / metering / limit enforcement.** Invoicing, overage line items, and
+  caps live in (re-targeted) Epic 20. This story reports spend; it never charges, blocks, or caps.
+- **NO projection / population.** The fact tables are filled by Story 36-2's
+  `HourlyAnalyticsRollupWorkflow` fan-out. This story writes **no** fact row.
+- **NO schema change to the fact tables.** It reads `analytics_usage_daily`. The only new persisted
+  artefact is the DCB event it emits.
+- **NO budget write/limit surface.** `BudgetConfig` is read-only here; write/limits stay in Epic 20
+  and the existing budget API.
+- **NO new auth policy.** Reads ride the established `/api/v1/orgs/{tenantId:guid}` group
+  (`MemberAccess` + `RequireTenantMembershipFilter`).
+- **NO hourly-grain endpoint.** Daily grain only (`analytics_usage_daily`); budget projection works
+  on days.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main)
+
+### Targets that DO exist (read / extend)
+
+| Artefact | Path | Role for 36-4 |
+|---|---|---|
+| `BudgetConfig` entity | `apps/tamma-elsa/src/Tamma.Data/Entities/BudgetConfig.cs` | Read-only budget context. Keyed `(TenantId, AccountId)`; `AccountId` is the **tenant GUID string** today; carries `LimitUsd`, `AlertThreshold`, `PeriodDays`. |
+| `BudgetConfigRepository` | `apps/tamma-elsa/src/Tamma.Data/Repositories/BudgetConfigRepository.cs` | `GetAsync(Guid? tenantId, string accountId, CancellationToken)` — the budget join. |
+| `ProviderDiagnostic` | `apps/tamma-elsa/src/Tamma.Data/Entities/ProviderDiagnostic.cs` | Background only — the raw per-call cost source 36-2 projects from. **No `BillingMode` column yet** (Story 35-2 adds it). 36-4 does NOT read this directly. |
+| `ITenantDbContextFactory` | `apps/tamma-elsa/src/Tamma.Data/Abstractions/ITenantDbContextFactory.cs` | `CreateAsync(tenantId, ct)` — the per-tenant data plane. Each call returns a fresh `await using` context. |
+| `IEventRepository` | `apps/tamma-elsa/src/Tamma.Data/Repositories/IEventRepository.cs` | `AppendAsync(DomainEvent)` + `GetLastByTypeAsync(tenantId, type)` — the DCB emit + dedup-check path. |
+| `DomainEvent` | `apps/tamma-elsa/src/Tamma.Data/Entities/DomainEvent.cs` | `Type`, `TenantId`, JSONB `Tags`/`Metadata`/`Data`, `SequenceNumber`. The event shape. |
+| `/api/v1/orgs/{tenantId:guid}` group | `apps/tamma-elsa/src/Tamma.Api/Program.cs` (~1512) | `MapGroup("/api/v1/orgs").RequireAuthorization("MemberAccess")`; every `{tenantId:guid}/...` route adds `.AddEndpointFilter<RequireTenantMembershipFilter>()`. The exact RBAC pattern 36-4's route uses. |
+| `RequireTenantMembershipFilter` | `apps/tamma-elsa/src/Tamma.Api/Authorization/RequireTenantMembershipFilter.cs` | Rejects cross-tenant callers before the handler runs. |
+| `AdminAnalyticsEndpoints` | `apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminAnalyticsEndpoints.cs` | Owner-only `/api/admin/analytics/*` precedent for endpoint shape + UTC query-binding gotcha (force `DateTimeKind.Utc`). |
+| `ITammaModeProvider` | `apps/tamma-elsa/src/Tamma.Api/Services/PromptStore/TammaMode.cs` | Process-stable mode (`SingleUser`/`SaaS`) for the event tag. |
+
+### Targets that do NOT exist yet (NEW in this story or upstream)
+
+| Artefact | Status |
+|---|---|
+| `Tamma.Api/Endpoints/TenantAnalyticsEndpoints.cs` | **NEW (this story).** No tenant-scoped analytics endpoint exists today. |
+| `Tamma.Api/Services/Analytics/CostAnalyticsService.cs` + `ICostAnalyticsService.cs` | **NEW (this story).** |
+| `AnalyticsUsageDaily` entity / `analytics_usage_daily` table | **NEW upstream — Story 36-1** (drafted, not yet built). 36-4 reads it; cannot land until 36-1 + 36-2 are merged (or stubbed). |
+| `analytics_usage_daily.PlatformBilledUsd` populated | **Story 36-2** (drafted). The single source of truth 36-4 sums; BYOK rows already 0. |
+| `billing_mode` / `ProviderDiagnostic.BillingMode` | **Story 35-2** (Epic 35) — not in the C# code yet. Soft dependency: absent ⇒ 36-2 defaults rows to `platform` ⇒ 36-4 reports all spend as `platformBilledUsd`, `byokCostUsd=0`. Well-formed either way. |
+
+**Key gotcha:** `BudgetConfig.AccountId` is the tenant GUID **as a string** — call
+`budgets.GetAsync(tenantId, tenantId.ToString(), ct)`. A NULL-`TenantId` row is the platform default
+(fallback only in single-user). Do not invent a new scope key.
+
+---
+
+## Architecture
+
+**Read fact table → split by cost basis → project → join budget → (maybe) emit event → respond.**
+
+1. **`ICostAnalyticsService.GetCostAsync(tenantId, from, to, groupBy, mode, ct)`** — opens the
+   tenant's `TenantDbContext` via `ITenantDbContextFactory`, reads `analytics_usage_daily` for the
+   window, and aggregates two separate measures per day (and per provider/agent when grouped):
+   - `byokCostUsd` = Σ `CostUsd` where `CostBasis = byok` (informational).
+   - `platformBilledUsd` = Σ `PlatformBilledUsd` (billable; byok rows are already 0 — structural).
+2. **Projection** — month-to-date `platformBilledUsd` + linear run-rate
+   (`mtd / daysElapsed * daysInMonth`) against an injected `TimeProvider`.
+3. **Budget join** — `BudgetConfigRepository.GetAsync(tenantId, tenantId.ToString(), ct)` →
+   `budgetUsd`, `alertThreshold`, and the budget-vs-actual fields (`budgetUtilizationPct`,
+   `projectedUtilizationPct`, `projectedToExceedBudget`). All `null` when no budget configured.
+4. **Trend** — same aggregation over the prior equivalent window → delta % (platform + byok).
+5. **DCB event** — when `projectedToExceedBudget` and no `ANALYTICS.COST.BUDGET_PROJECTED_EXCEEDED`
+   event exists for `(tenantId, period)` this month, append one (best-effort, swallowed on failure,
+   tenant-tagged).
+6. **Endpoint** — `GET /api/v1/orgs/{tenantId:guid}/analytics/cost` on the existing `orgs`
+   `MemberAccess` group + `RequireTenantMembershipFilter`; validates/defaults/clamps the window and
+   `groupBy`.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns the cost data? | The sole user — their (only) tenant schema. | The tenant — its `t_<hex>` schema. |
+| Who may read it? | The user (no RBAC). | Any tenant member (`MemberAccess` + membership filter); `member` reads with **no** elevation (read/limits split per CLAUDE.md prompt-store RBAC). |
+| Cost-basis split | Usually all `platform` (no BYOK signal self-hosted) ⇒ `byokCostUsd` may be 0. | `byok`/`platform` per the 35-2 `billing_mode` baked into `CostBasis` by 36-2. |
+| Budget source | `BudgetConfig` for the sole tenant (or platform-default NULL row). | `BudgetConfig` for that tenant. |
+| Budget-exceeded event | Lands in the user's (only) tenant stream (`TenantId` set). | Tenant's stream (`TenantId` set) ⇒ tenant-scoped alerting. |
+| Cross-tenant leakage | N/A. | Prevented twice: membership filter + physical per-tenant schema. |
+
+Mode never changes the wire shape — both resolve to exactly one tenant schema per request; `mode`
+is carried only as an event tag.
+
+---
+
+## Task breakdown
+
+### T1: DTOs + DCB event constant (core scaffolding)
+
+**Scope:** Response shape + the event name. No logic yet.
+
+**Files:**
+- New: `src/Tamma.Api/Dtos/Analytics/CostAnalyticsResponse.cs` — `CostAnalyticsResponse`,
+  `CostSeriesBucket` (`Day`, `Group?`, `ByokCostUsd`, `PlatformBilledUsd`), `CostSummary`
+  (`ByokCostUsd`, `MtdPlatformBilledUsd`, `ProjectedPlatformBilledUsd`, `BudgetUsd?`,
+  `AlertThreshold?`, `BudgetUtilizationPct?`, `ProjectedUtilizationPct?`, `ProjectedToExceedBudget`),
+  `CostTrend`, and a `CostGroupBy` enum (`None|Provider|Agent`).
+- New: `src/Tamma.Api/Services/Analytics/CostAnalyticsEvents.cs` —
+  `public const string BudgetProjectedExceeded = "ANALYTICS.COST.BUDGET_PROJECTED_EXCEEDED";`
+  (AGGREGATE.ACTION.STATUS).
+
+**Tests (first):** trivial DTO/enum presence + the event-constant value (`AnalyticsRollupEventsTests`
+precedent — assert the string literal and `.` segment shape).
+
+**Acceptance:**
+- [ ] DTOs compile; `CostGroupBy` parses `provider`/`agent` (case-insensitive), rejects others.
+- [ ] Event constant equals `ANALYTICS.COST.BUDGET_PROJECTED_EXCEEDED`.
+
+### T2: `ICostAnalyticsService` + `CostAnalyticsService` (the read + project + budget core)
+
+**Scope:** All aggregation, projection, budget join, trend, and the deduped event emit. **No markup
+math, no fact write.**
+
+**Files:**
+- New: `src/Tamma.Api/Services/Analytics/ICostAnalyticsService.cs`,
+  `CostAnalyticsService.cs`. Ctor deps: `ITenantDbContextFactory`, `IBudgetConfigRepository`
+  (or `BudgetConfigRepository`), `IEventRepository`, `TimeProvider`, `ILogger<CostAnalyticsService>`.
+- Aggregation: read `analytics_usage_daily` for `[fromUtc, toUtcExclusive)`; split
+  `byokCostUsd` (Σ `CostUsd` where `CostBasis=Byok`) and `platformBilledUsd` (Σ `PlatformBilledUsd`);
+  group by `Day` (+ `Provider`/`AgentId` when requested; `AgentId NULL → "unattributed"`).
+- Projection: MTD `platformBilledUsd` + `mtd/daysElapsed*daysInMonth` via `TimeProvider`.
+- Budget join: `GetAsync(tenantId, tenantId.ToString(), ct)`; budget-vs-actual fields; `null` when
+  absent.
+- Trend: prior equivalent window aggregation → delta % (platform + byok); `null` when prior empty.
+- Event: when `projectedToExceedBudget`, check `GetLastByTypeAsync(tenantId, BudgetProjectedExceeded)`
+  for a same-period event; if none, `AppendAsync` one (tenant-tagged, `mode`, budget/projection in
+  `Data`); swallow append failures (WARN), never throw into the read.
+
+**Tests (first) — `CostAnalyticsServiceTests` (InMemory):** split; projection (fixed
+`TimeProvider`, incl. day-1 + zero-MTD); budget join present/absent; grouping +
+`NULL→"unattributed"` reconciling to total; trend present/empty; **no-re-markup** (two mocked margin
+configs → identical output); event-on-breach + per-period dedup + no-emit-under + swallowed
+append failure; empty-state (zero rows → well-formed empty series, zeroed summary, null trend).
+
+**Acceptance:**
+- [ ] `byokCostUsd` sums only `byok` rows' `CostUsd`; `platformBilledUsd` sums `PlatformBilledUsd`
+      (byok rows contribute 0).
+- [ ] Projection == `mtd/daysElapsed*daysInMonth`; no divide-by-zero on day-1/zero-MTD.
+- [ ] Budget-vs-actual fields correct with a budget; all `null` without one.
+- [ ] Grouped buckets reconcile to the ungrouped total; `AgentId NULL` → `"unattributed"`.
+- [ ] Output is byte-identical under two different margin configs (no re-markup).
+- [ ] Exactly one event per `(tenantId, period)` on breach; none under budget; append failure does
+      not fail the response.
+
+### T3: `TenantAnalyticsEndpoints` + Program.cs wiring (the HTTP surface)
+
+**Scope:** Minimal-API handler + validation/defaulting/clamping + DI/route registration.
+
+**Files:**
+- New: `src/Tamma.Api/Endpoints/TenantAnalyticsEndpoints.cs` — `GetCost(Guid tenantId,
+  [FromQuery] DateTime? from, [FromQuery] DateTime? to, [FromQuery] string? groupBy,
+  ICostAnalyticsService svc, ITammaModeProvider mode, CancellationToken ct)`. Default window =
+  current calendar month; force `DateTimeKind.Utc` (AdminAnalyticsEndpoints gotcha); `400` on
+  `from > to` or bad `groupBy`; clamp window to ≤400 days.
+- Modify: `src/Tamma.Api/Program.cs` —
+  `orgs.MapGet("/{tenantId:guid}/analytics/cost", TenantAnalyticsEndpoints.GetCost)
+  .AddEndpointFilter<Tamma.Api.Authorization.RequireTenantMembershipFilter>();` and register
+  `ICostAnalyticsService` (scoped) + `TimeProvider.System` if not already registered.
+
+**Tests (first) — `CostAnalyticsEndpointTests`:** validation matrix (`from>to`→400, bad
+`groupBy`→400, omitted window→current month); default `groupBy=None`; member read returns 200 with
+a well-formed body; `mode` tag threaded into the service call.
+
+**Acceptance:**
+- [ ] Route mounted under the `MemberAccess` `orgs` group with `RequireTenantMembershipFilter`.
+- [ ] Validation/defaulting/clamping behave per AC12; UTC kind forced on the window.
+
+### T4: Integration suite (Postgres 17 — BYOK split, isolation, RBAC)
+
+**Scope:** Prove the structural BYOK=0 guarantee, physical isolation, and RBAC end-to-end against a
+real schema (InMemory can't model per-tenant schemas — `ConventionStoreMigrationTests` rationale).
+
+**Files:**
+- New: `tests/Tamma.Api.Tests/Analytics/CostAnalyticsIsolationTests.cs` (Postgres 17 Testcontainer,
+  following `SchemaPerTenantMigrationTests`).
+
+**Tests:**
+- Fully-BYOK tenant (all `analytics_usage_daily` rows `byok`, so `PlatformBilledUsd=0`) →
+  `summary.platformBilledUsd==0`, `projectedPlatformBilledUsd==0`, `byokCostUsd>0`.
+- Two tenant schemas, different cost profiles → request for A returns only A; budget join reads only
+  A's `BudgetConfig`.
+- RBAC: tenant `member` → 200; non-member / cross-tenant → 404/403 (filter rejects pre-handler).
+
+**Acceptance:**
+- [ ] Fully-BYOK tenant shows `platformBilledUsd=0` + non-zero `byokCostUsd`.
+- [ ] A's request never returns B's rows; budget join is tenant-scoped.
+- [ ] Cross-tenant caller blocked before the handler; member read succeeds.
+- [ ] Suite green via `sg docker -c "dotnet test ..."`.
+
+---
+
+## Task order & dependencies
+
+T1 → T2 → T3 → T4. T2 is the heart (TDD it hardest). T1 is pure scaffolding; T3 wraps T2 in HTTP;
+T4 proves the cross-cutting guarantees (BYOK=0, isolation, RBAC) that unit tests can't.
+
+**Upstream gating:** the service reads `AnalyticsUsageDaily` (Story 36-1) populated with
+`PlatformBilledUsd` (Story 36-2). Implement against the **drafted** 36-1 entity shape; if 36-1/36-2
+have not merged when 36-4 starts, T2/T4 are blocked on the real table — coordinate the merge order
+(36-1 → 36-2 → 36-4) or land a thin local test-fixture entity that matches 36-1 AC1/AC2 exactly and
+swap to the real one on merge.
+
+## Risks
+
+- **Re-markup leak (highest correctness risk):** the temptation is to "compute billed = cost ×
+  margin" in the endpoint. That double-charges and forks the source of truth. Mitigation: AC4's
+  "margin config has zero effect" test is mandatory and the service takes **no** dependency on the
+  markup engine (34-5) or any pricing config. If a reviewer sees a margin import in this story,
+  reject it.
+- **BYOK split correctness depends on 36-2's invariant** (`byok ⇒ PlatformBilledUsd=0`). If 36-2
+  ever writes a non-zero billed amount on a byok row, the split breaks silently. Mitigation: the
+  fully-BYOK integration test (T4) asserts `platformBilledUsd==0` end-to-end, catching a 36-2
+  regression at this layer too.
+- **Projection edge cases:** day-1 (`daysElapsed=1`), zero-MTD (`projected=0`, no divide-by-zero),
+  month boundaries, leap-Feb `daysInMonth`. Inject `TimeProvider` and pin each case in T2.
+- **Event spam from dashboard polling:** the budget-exceeded DCB event must be per-period deduped
+  (one per `(tenantId, period)`), or a polled dashboard floods the alert pipeline. Dedup is a
+  pre-append `GetLastByTypeAsync` + period-tag check; secondary throttle lives in the downstream
+  alert rule. Best-effort emission must never throw into the read.
+- **Budget scope key:** `BudgetConfig.AccountId == tenantId.ToString()` today. Hardcoding a
+  different key returns no budget silently. Pin the exact call in T2/T4.
+- **Window default timezone:** "current calendar month" / MTD is UTC (matching the fact table's UTC
+  `Day` bucket). Force `DateTimeKind.Utc` on bound query params (AdminAnalyticsEndpoints precedent)
+  so a Local-parsed `from`/`to` doesn't shift the window.
+- **Upstream not merged:** see "Upstream gating" — the single biggest schedule risk is starting
+  36-4 before 36-1/36-2 land. Sequence the merge or use a matching test fixture entity.

--- a/docs/superpowers/plans/2026-06-17-36-5-agent-and-tenant-performance-rollups-api-plan.md
+++ b/docs/superpowers/plans/2026-06-17-36-5-agent-and-tenant-performance-rollups-api-plan.md
@@ -1,0 +1,273 @@
+# Story 36-5: Agent & Tenant Performance Rollups API — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation. Read [BEFORE_YOU_CODE.md](../../guides/BEFORE_YOU_CODE.md) first.
+
+**Goal:** Ship a **tenant-scoped reporting API** over the Epic 36 dimensional analytics store: a
+per-agent performance rollup (runs, success rate, avg duration, tokens/run, cost/run,
+platform-billed), a per-agent daily trend, and a tenant-level performance summary — read **only**
+from the resolving tenant's `analytics_usage_*` facts (Story 36-1, populated by 36-2), with agent
+identity/name resolved from the Epic 32 registry. Performance is **strictly per-tenant**: a public
+agent shows only this tenant's numbers, no platform-admin per-tenant read exists, and this story is
+a **sibling, not a duplicate,** of Story 32-10's leaderboard projection — it consumes the
+dimensional store rather than re-folding the action trail.
+
+**Story file:** `docs/stories/epic-36/story-36-5/36-5-agent-and-tenant-performance-rollups-api.md`
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (Tamma.Api + Tamma.Data +
+Tamma.Core). Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/` (xUnit; docker-bound
+suites run via `sg docker -c "dotnet test ..."` — session docker group is stale; the build itself
+needs no wrapper). `packages/api` is **deleted** — never a target.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO new schema or migration.** This story reads the Story 36-1 fact tables
+  (`analytics_usage_hourly` / `analytics_usage_daily`) and the Epic 9 `ProviderDiagnostic`; it adds
+  no entity, no column, no EF migration. Any PR that alters the 36-1 schema or the 36-2 projection
+  under cover of this story is out of scope.
+- **NO re-folding the action trail.** Story 32-10's `BenchmarkProjectionService` owns the
+  agent/provider/prompt/persona leaderboard (defect-by-category, p50/p95 latency, k-anonymous
+  public-agent fleet rollup) folded directly from `AGENT.*` events. This story reads the **pre-folded
+  dimensional facts** (`GROUP BY AgentId`) — it does not re-implement the leaderboard, and it
+  references 32-10 for the shared per-agent success-rate definition.
+- **NO cross-tenant or platform-admin per-tenant performance path.** Performance rollups are
+  per-tenant only. There is no admin variant of these routes. The only cross-tenant agent analytics
+  that exists is 32-10's k-anonymous public-agent fleet rollup, which this story does not extend.
+- **NO mutation surface.** Performance rows are derived from the facts; there is no edit and no
+  rebuild trigger here (the dimensional rollup is rebuilt by the 36-2 workflow / its backfill input).
+- **NO event-stream rescan on the read path.** The reads aggregate the pre-folded facts; they never
+  scan `domain_events`.
+- **NO dashboard surface, export, or scheduled report** — those are later Epic 36 stories that
+  consume these endpoints.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### Sources this story reads
+
+| Component | File (verified, unless marked NEW) | Role |
+|---|---|---|
+| Per-tenant usage facts (primary source) | `src/Tamma.Data/Entities/AnalyticsUsageDaily.cs` + `AnalyticsUsageHourly.cs` — **Story 36-1 NEW (drafted, not merged)** | `AgentId`, `Provider` dims; measures `TokensIn/Out`, `WorkflowsCompleted/Failed`, `CostUsd`, `PlatformBilledUsd`; `Day`/`Hour`. The rollup substrate. |
+| Per-tenant DbContext | `src/Tamma.Data/TenantDbContext.cs` (verified) | Owns the `analytics_usage_*` DbSets (added by 36-1); structural isolation plane (no cross-tenant query filter). |
+| Schema-per-tenant routing | `ITenantDbContextFactory` / `ITenantContext` (`Tamma.Data`, verified) | Resolves the tenant's schema per request — no new plumbing. |
+| Diagnostic outcome substrate | `src/Tamma.Data/Entities/ProviderDiagnostic.cs` (verified — `AgentType`, `RequestDurationMs`, `InputTokens`/`OutputTokens`, `Cost`, `Success`) | Lineage of `avgDurationMs`/success the 36-2 projection folds into the facts. Read/referenced only. |
+| Agent registry (identity only) | Epic 32 agent registry (`AgentConfig` + `src/Tamma.Api/Endpoints/AgentEndpoints.cs`, verified present) | `AgentId → name` + public/system vs private/tenant. Identity only — never a performance source. |
+| Tenant-path gate | `src/Tamma.Api/Authorization/RequireTenantMembershipFilter.cs` (verified) + `/api/v1/orgs/{tenantId}` group (`Program.cs`, `AlertEndpoints.cs`, `OrgEndpoints.cs`, verified) | The member-readable tenant-path pattern these endpoints ride. |
+| Auth policies | `src/Tamma.Api/Program.cs` — `MemberAccess` (~991, verified: `RequireAuthenticatedUser`), `OwnerAccess` (~971), `PlatformOwnerAccess` (~986) | `MemberAccess` for the reads; no `PlatformOwnerAccess` per-tenant performance route exists. |
+| Placeholder + clamp precedent | `src/Tamma.Api/Services/Analytics/PlatformAnalyticsService.cs` — `GetTopTenantsAsync` `(unknown)` fallback (~344-350), limit clamp (~280-281), per-tenant fan-out via `ITenantDbContextFactory` (~288-311) | The `(unknown)` placeholder + limit-clamp + per-tenant-read conventions this story mirrors. |
+| Sibling read model (NOT duplicated) | `src/Tamma.Api/Services/Agents/BenchmarkProjectionService.cs` — **Story 32-10 NEW (drafted)** | The leaderboard fold from the action trail. Referenced; this story does the dimensional cost/throughput rollup instead. |
+
+### Files this story creates (all NEW)
+
+`AgentPerformanceAnalyticsService.cs` + `IAgentPerformanceAnalyticsService.cs`,
+`AgentNameResolver.cs` + `IAgentNameResolver.cs`, `AgentPerformanceDtos.cs` (all in
+`src/Tamma.Api/Services/Analytics/`), and `TenantAnalyticsEndpoints.cs` in
+`src/Tamma.Api/Endpoints/`. `Program.cs` is modified for DI + route mapping. None of these exist
+today (verified via glob).
+
+### Key constraints carried from the codebase
+
+- **Isolation is structural** — every fact read goes through `ITenantDbContextFactory.CreateAsync`
+  to the tenant's search-path schema; there is no cross-tenant query filter, so a tenant context
+  can only ever see that tenant's rows. This is what makes "a public agent shows only this tenant's
+  numbers" true by construction, not by an app filter.
+- **`MemberAccess` is authenticate-only** (`Program.cs` ~991); the tenant-scoping is enforced by
+  `RequireTenantMembershipFilter` on the `{tenantId}` route, exactly as `AlertEndpoints` tenant
+  routes do. Reuse that group — do not invent a new gate.
+- **`(unknown)` placeholder + limit clamp** are established in `GetTopTenantsAsync` — reuse the same
+  shape for deleted-agent names and window/limit bounds.
+
+---
+
+## Architecture
+
+**Read the dimensional store → group by agent → resolve name (identity only) → serve.** A thin
+reporting service over pre-folded facts, behind member-read tenant-scoped endpoints.
+
+1. **`IAgentPerformanceAnalyticsService` / `AgentPerformanceAnalyticsService`** (new,
+   `src/Tamma.Api/Services/Analytics/`) — the read-side seam. Three methods:
+   `GetAgentRollupsAsync` (`GROUP BY AgentId` over `analytics_usage_daily`, `analytics_usage_hourly`
+   for sub-day windows → per-agent metrics, ordered by a selectable metric + `agentId` tie-break),
+   `GetAgentTrendAsync` (daily series for one agent, sparse, empty for zero activity), and
+   `GetTenantSummaryAsync` (blended success rate, total spend, most/least efficient, min-run
+   guarded). A static pure-DI `ComputeAgentRollupsAsync(...)` entry point drives the endpoint and
+   unit tests without an HTTP context (the `PlatformAnalyticsService` aggregation shape).
+2. **`IAgentNameResolver` / `AgentNameResolver`** (new) — the **only** place the Epic 32 registry is
+   touched, reading **only** `AgentId → name` (+ public/system vs private/tenant). Missing/deleted →
+   `"(unknown)"`; `NULL` bucket → `"(unattributed)"`. It never reads a performance number — this is
+   the isolation guarantee for public agents.
+3. **`TenantAnalyticsEndpoints.cs`** (new) — maps the three reads under `/api/v1/orgs/{tenantId}`
+   with `MemberAccess` + `RequireTenantMembershipFilter`; window parse + 400 on bad input; optional
+   best-effort `ANALYTICS.REPORT.*` observability events.
+4. **`Program.cs`** (modify) — DI for the service + resolver; map the three routes.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns the performance data? | The sole user — their (single) tenant schema. | The tenant that generated it; one public definition → many per-tenant datasets. |
+| Who reads rollups/trend/summary? | The user (member-read). | Any tenant member (`MemberAccess`) for their own tenant only. |
+| Can a platform admin read a tenant's agent performance? | N/A (sole user). | **No** — no admin per-tenant route; per-tenant facts are structurally unreachable cross-tenant. |
+| Where do the facts live? | The single tenant store. | The originating tenant's `t_<hex>` schema. |
+| Mode source | `ITammaModeProvider` (process-stable). | same |
+
+Endpoint shape is identical between modes (the prompt-store precedent); the auth middleware +
+`RequireTenantMembershipFilter` decide scope; the per-tenant `TenantDbContext` enforces isolation
+physically.
+
+---
+
+## Task breakdown
+
+### Task 1: DTOs + service/resolver contracts (story AC: 1, 2, 4, 5)
+
+**Scope:** Wire shapes + interfaces only — no aggregation logic yet.
+
+**Files:**
+- New: `src/Tamma.Api/Services/Analytics/AgentPerformanceDtos.cs` — `AgentRollupRow`
+  (`agentId, name, runs, successRate, avgDurationMs, tokensPerRun, costUsdPerRun, platformBilledUsd`),
+  `AgentTrendPoint` (`date, runs, successRate, costUsd, tokensIn, tokensOut, platformBilledUsd`),
+  `TenantPerformanceSummary` (`blendedSuccessRate, totalRuns, totalCostUsd, totalPlatformBilledUsd,
+  mostEfficientAgents[], leastEfficientAgents[]`).
+- New: `src/Tamma.Api/Services/Analytics/IAgentPerformanceAnalyticsService.cs`,
+  `IAgentNameResolver.cs`.
+
+**Tests (first):** a contract/DTO-shape test asserting record fields + nullability (`agentId`
+nullable for the `(unattributed)` bucket).
+
+**Acceptance:**
+- [ ] DTOs + interfaces compile; `AgentRollupRow.agentId` is nullable (NULL-bucket support).
+
+### Task 2: Agent name resolution (story AC: 3, 7)
+
+**Scope:** `AgentNameResolver` — registry identity only.
+
+**Files:**
+- New: `src/Tamma.Api/Services/Analytics/AgentNameResolver.cs` — resolves `AgentId → name` from the
+  Epic 32 registry (public/system vs private/tenant); `"(unknown)"` for a missing/deleted id;
+  `"(unattributed)"` for `null`. Reads only identity/name — never a metric.
+
+**Tests (first):** `AgentPerformanceAnalyticsServiceTests` (name section) — known agent → registry
+name; missing/deleted id → `(unknown)` (the `GetTopTenantsAsync` placeholder precedent); `null` →
+`(unattributed)`; a resolver injected with a metric-throwing registry double proves identity-only
+reads.
+
+**Acceptance:**
+- [ ] All three name paths covered; resolver never touches performance data.
+
+### Task 3: `AgentPerformanceAnalyticsService` aggregation (story AC: 1, 2, 5, 8, 9)
+
+**Scope:** The read-side aggregation over the 36-1 facts — no event-stream rescan.
+
+**Files:**
+- New: `src/Tamma.Api/Services/Analytics/AgentPerformanceAnalyticsService.cs`:
+  - `GetAgentRollupsAsync` / static `ComputeAgentRollupsAsync` — `GROUP BY AgentId` over
+    `analytics_usage_daily` (`analytics_usage_hourly` for sub-day windows); `runs = Σ(Completed +
+    Failed)`, `successRate = Σ Completed / runs`, `tokensPerRun = Σ(TokensIn+TokensOut)/runs`,
+    `costUsdPerRun = Σ CostUsd / runs`, `platformBilledUsd = Σ PlatformBilledUsd`, `avgDurationMs`
+    from the duration substrate (coordinate with 36-2; fall back to tenant-scoped
+    `ProviderDiagnostic.RequestDurationMs` if the fact carries no duration measure — duration only,
+    no new column); ordering by `orderBy` (default `runs` desc) + `agentId` asc tie-break; window
+    validation (`from < to`), window cap (default 366d), `limit` clamp (default 50, max 500) —
+    mirroring `GetTopTenantsAsync`.
+  - `GetTenantSummaryAsync` — blended success rate, total cost/billable, most/least efficient
+    (default `costUsdPerRun` asc, min-run guarded, top/bottom-N default 5 max 50).
+
+**Tests (first):** metric-correctness (InMemory) against a fact-row fixture — exact `runs`,
+`successRate`, `tokensPerRun`, `costUsdPerRun`, `platformBilledUsd`, summary `blendedSuccessRate`,
+`totalPlatformBilledUsd`, most/least-efficient ordering; ordering-option matrix + tie-break;
+window validation (`from >= to` → throw/400-mapped; clamps applied); the `NULL` bucket surfaces as
+an `(unattributed)` row reconciling to the grand total.
+
+**Acceptance:**
+- [ ] Rollup + summary metrics exact on the fixture; ordering deterministic with `agentId`
+      tie-break; window/limit bounded; no event-stream rescan (assert facts-only reads).
+
+### Task 4: Daily trend (story AC: 4, 7)
+
+**Scope:** `GetAgentTrendAsync` — daily series for one agent.
+
+**Files:**
+- Modify (same file): `AgentPerformanceAnalyticsService.GetAgentTrendAsync` — read
+  `analytics_usage_daily` filtered to `AgentId == agentId`, one ordered point per active UTC day,
+  sparse (inactive days omitted); zero activity → empty list (HTTP 200 at the endpoint), never 404.
+
+**Tests (first):** sparse trend ordering; zero-activity agent → `[]`; deleted-agent trend still
+returns its fact rows (name not needed for the trend points).
+
+**Acceptance:**
+- [ ] Trend ordered + sparse; zero activity → empty (200), never 404.
+
+### Task 5: Tenant analytics endpoints (story AC: 2, 4, 5, 6, 9, 10)
+
+**Scope:** The three member-read routes + DI + best-effort telemetry events.
+
+**Files:**
+- New: `src/Tamma.Api/Endpoints/TenantAnalyticsEndpoints.cs` — map
+  `GET /api/v1/orgs/{tenantId}/analytics/agents`,
+  `GET /api/v1/orgs/{tenantId}/analytics/agents/{agentId}/trend`,
+  `GET /api/v1/orgs/{tenantId}/analytics/summary` under the `/api/v1/orgs/{tenantId}` group with
+  `MemberAccess` + `RequireTenantMembershipFilter`; window query parse (ISO-8601, default trailing
+  30d) → 400 on `from >= to` / bad `orderBy`; optional best-effort `ANALYTICS.REPORT.*` events via
+  `IPlatformEventPublisher` (never block the read).
+- Modify: `src/Tamma.Api/Program.cs` — register `IAgentPerformanceAnalyticsService` +
+  `IAgentNameResolver`; call `TenantAnalyticsEndpoints.Map(...)`.
+
+**Tests (first):** `TenantAnalyticsEndpointsTests` — member reads own tenant (200); window `from
+>= to` → 400; bad `orderBy` → 400; zero-activity trend → 200 `[]`; best-effort event emission does
+not fail the read when the publisher throws.
+
+**Acceptance:**
+- [ ] Three routes mapped + gated; window/order 400s; zero-activity 200; telemetry best-effort.
+
+### Task 6: Isolation + RBAC integration tests (story AC: 3, 6, 11 — docker-bound)
+
+**Scope:** The Postgres-17-Testcontainer suite proving structural isolation.
+
+**Files:**
+- New: `src/.../tests/Tamma.Api.Tests/Analytics/AgentPerformanceIsolationTests.cs` — migrate two
+  tenant schemas; a public/system agent run by tenant A and tenant B; seed each tenant's
+  `analytics_usage_daily` independently; assert `…/orgs/{A}/analytics/agents` returns only A's
+  metrics for that agent and `…/orgs/{B}/…` only B's (no sum, no leak); a member of A hitting
+  `/orgs/{B}/analytics/*` is rejected by `RequireTenantMembershipFilter` (403/404); a platform owner
+  is denied a tenant's performance like any non-member (no admin route exists).
+
+**Tests (first):** the suite itself is the test.
+
+**Acceptance:**
+- [ ] Public-agent metrics isolated across two schemas; cross-tenant + platform-owner denied; suite
+      green via `sg docker -c "dotnet test ..."`.
+
+---
+
+## Task order & dependencies
+
+Task 1 → Task 2 → Task 3 → Task 4 → Task 5 → Task 6.
+Tasks 1-4 are pure-service (InMemory tests, no docker); Task 5 wires the HTTP surface; Task 6 is the
+docker-bound isolation proof and should run last. **Hard prerequisite:** Stories 36-1 (fact tables)
+and 36-2 (population) must be merged — this story has nothing to read until they are. Coordinate the
+per-agent duration measure and the per-agent success-rate definition with 36-2 / 32-10 before merge.
+
+## Risks
+
+- **Cross-tenant leakage of a public agent's performance (critical):** mitigated structurally —
+  per-tenant schema via `ITenantDbContextFactory`, registry resolves name only, no admin per-tenant
+  route. The public-agent isolation test (Task 6) is the gate.
+- **Duplicating 32-10's leaderboard (high):** this story reads the dimensional facts (`GROUP BY
+  AgentId`), never re-folds the action trail; it references 32-10 and aligns the per-agent
+  success-rate definition. If the two surfaces disagree on success rate, reconcile to the fact-based
+  definition (`WorkflowsCompleted ÷ terminal runs`) and note it in the PR.
+- **`avgDurationMs` source ambiguous (medium):** the 36-1 fact set may not carry a duration measure
+  at merge time. Coordinate with 36-2; if absent, read `ProviderDiagnostic.RequestDurationMs`
+  tenant-scoped for duration **only** — do not add a fact column under this story.
+- **36-1/36-2 not merged (high, blocking):** hard prerequisite; do not start until the fact tables +
+  projection exist. Mark the NEW source files and align measure/tag names first.
+- **Unbounded window scans (medium):** `from < to` validation, window cap, `limit`/top-N clamps (the
+  `GetTopTenantsAsync` precedent) keep a malformed request a 400, not a runaway scan.
+- **Idle agent 404 vs empty (low):** zero activity → empty trend (200); deleted agent → `(unknown)`;
+  `NULL` bucket → `(unattributed)` so per-agent rows reconcile to the grand total.

--- a/docs/superpowers/plans/2026-06-17-36-6-tenant-analytics-dashboard-ui-plan.md
+++ b/docs/superpowers/plans/2026-06-17-36-6-tenant-analytics-dashboard-ui-plan.md
@@ -1,0 +1,269 @@
+# Story 36-6: Tenant Analytics Dashboard UI — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan step-by-step. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every step writes tests
+> before implementation. Read `docs/guides/BEFORE_YOU_CODE.md` first.
+
+**Goal:** Add a tenant-facing **Analytics** section to `packages/dashboard-user` (`dash.tamma.dev`)
+with three read-only views — **Usage**, **Cost (BYOK vs platform)**, and **Agents** — sliced by a
+shared TimeRange + GroupBy control bar, wired to the Story 36-3/36-4/36-5 query APIs. Every view is
+hard-scoped to the active tenant (no cross-tenant leakage), handles loading/empty/error distinctly
+(empty store ≠ error), and carries a flag-gated **Export** seam for Story 36-8.
+
+**Story file:** `docs/stories/epic-36/story-36-6/36-6-tenant-analytics-dashboard-ui.md`
+
+**Spec source:** `/tmp/pab_stories/36-6.json` (P1, est 4-5 days, boundaryNote empty).
+
+**Tech stack (verified in `packages/dashboard-user/package.json`):** React 19, `react-router-dom` 7,
+Tailwind 4, Vite 8 (pinned to an es2020/chrome87 browser floor), Vitest 4 + `@testing-library/react`
+16 (jsdom). Tests are colocated `*.test.tsx`; run via `pnpm test --filter @tamma/dashboard-user`.
+No charting library is installed — default to dependency-free inline SVG.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO backend code.** The analytics queries, RBAC 403, UTC binding, and audit events live in
+  `apps/tamma-elsa` (Stories 36-3/36-4/36-5) and are out of scope. `packages/api` is deleted — never
+  target it.
+- **NO export file generation.** CSV/PDF rendering is server-side (36-8). This story only adds the
+  `requestAnalyticsExport` client + a flag-gated button.
+- **NO new org-switcher.** The active tenant is resolved through a single `useActiveTenant` hook that
+  wraps `useAuth().user.tenantId` today; the Story 18-5 switcher drops in later by editing only that
+  hook.
+- **NO per-user analytics personalization, saved dashboards, or alerting UI.** Read-only views only.
+- **NO new chart dependency by default.** Inline SVG + a11y table. `recharts` is a documented opt-in
+  if the team wants it (must respect the vite browser floor).
+- **NO admin/owner gate.** Analytics is member-read (spec + CLAUDE.md prompt-store GET-resolved RBAC
+  precedent). No `TenantAdminGuard` wrapper.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### What exists in `packages/dashboard-user` (reuse it)
+
+| Seam | File | Reuse |
+|---|---|---|
+| API client w/ refresh-on-401 + `credentials:'include'` | `src/api/client.ts` (`apiClient`, `ApiError`, `UnauthorizedError`) | All analytics calls go through `apiClient.get/post`. |
+| Tenant-scoped API idiom | `src/api/dashboard.ts`, `src/api/alerts.ts` | Path shape `/api/v1/orgs/${tenantId}/...`; `analytics.ts` mirrors it. |
+| Auth/session + active tenant | `src/hooks/useAuth.tsx` (`user.tenantId`, `user.role`) | `useActiveTenant` wraps it. |
+| Route tree under guard+shell | `src/App.tsx` (`AuthGuard → AppLayout` element route) | Nest `/analytics/*` here. |
+| Sidebar nav | `src/layouts/AppLayout.tsx` (Dashboard/Repos/Runs/Settings links) | Add "Analytics" link. |
+| No-tenant zero-state + cancel-on-unmount fetch idiom | `src/pages/DashboardHome.tsx` | Hooks copy the early-return-when-no-tenant + cancel pattern (upgraded to AbortController). |
+| Tenant-isolation test idiom | `src/pages/alerts/TenantAlertFeed.test.tsx` (lines 36–90) | Cross-tenant non-leakage test copies this `fetchMock.mock.calls[i][0]` URL assertion. |
+| API URL-construction test idiom | `src/api/dashboard.test.ts` | `analytics.test.ts` copies it. |
+| jsdom matchMedia/ResizeObserver mocks | `src/test/setup.ts` | Already wired via `vitest.config.ts`. |
+
+### What does NOT exist (build it)
+
+- No `/analytics` route, no analytics pages/components, no analytics API client/hooks.
+- **No org-switcher context** — `AppLayout` header comment marks it a later Story 18-5 sub-task. We
+  isolate resolution in `useActiveTenant` so the switcher lands without touching views.
+- No charting library. No `recharts`/`d3`/`victory`/`nivo` in the package.
+- The 36-3/36-4/36-5 story files are not yet authored — only their JSON specs exist. **The endpoint
+  paths are fixed; the exact DTO field names must be reconciled when those stories land** (Step 0).
+
+### API contracts being rendered (from the dependency specs)
+
+| Story | Endpoint | Notes |
+|---|---|---|
+| 36-3 | `GET /api/v1/orgs/{tenantId}/analytics/usage` | params `from,to,granularity(hour\|day),groupBy(provider\|agent\|workflow\|repo)`; echoes `period_start/period_end`. |
+| 36-3 | `GET /api/v1/orgs/{tenantId}/analytics/usage/breakdown` | top-N rows for one dimension. |
+| 36-4 | `GET /api/v1/orgs/{tenantId}/analytics/cost` | `platformBilledUsd` (billable) + `byokCostUsd` (informational), MTD, projection, budget + alert threshold. BYOK never contributes to billed. |
+| 36-5 | `GET /api/v1/orgs/{tenantId}/analytics/agents` | per-agent rollups, selectable order metric. |
+| 36-5 | `GET /api/v1/orgs/{tenantId}/analytics/agents/{agentId}/trend` | daily success/cost/tokens; zero-activity → empty trend not error. |
+| 36-8 | `POST /api/v1/orgs/{tenantId}/analytics/exports` | `{type,format,from,to,groupBy}` → download or async jobId. Flag-gated seam. |
+
+All endpoints are tenant-member read; cross-tenant route id → 403 (server-side). DateTime is UTC.
+
+---
+
+## Architecture
+
+**Three views over a shared control bar, one tenant resolver, typed client → hooks → presentational
+components.**
+
+```
+AppLayout (sidebar: + Analytics)
+  └─ /analytics  → AnalyticsLayout (sub-nav Usage|Cost|Agents + <TimeRangeControls/> + <Outlet/>)
+        ├─ usage  → UsageView   → useAnalyticsUsage  → fetchUsageSeries + fetchUsageBreakdown
+        ├─ cost   → CostView    → useAnalyticsCost   → fetchCost
+        └─ agents → AgentsView  → useAnalyticsAgents → fetchAgentRollups + fetchAgentTrend
+
+useActiveTenant ──(tenantId)──> every hook (effect dep; abort+refetch on change)
+useAnalyticsControls ──(range/groupBy/granularity, synced to URL ?range=&groupBy=)──> control bar + hooks
+```
+
+**Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md):** the dashboard is a pure
+consumer; ownership is enforced server-side. In **SaaS** the active tenant is the caller's org
+membership (`user.tenantId`); in **single-user** the API resolves the principal to the sole user and
+the same `/orgs/{tenantId}` path is served. The dashboard treats both identically — it always sends
+the one tenant id it knows. No UI branch on mode.
+
+**Load-bearing invariant:** the client never builds an analytics URL with any org id other than the
+active tenant. Tenant id flows from `useActiveTenant` only — never from a list response, query param,
+or drill-down link. AC 6 non-leakage test is the regression guard.
+
+---
+
+## Step breakdown
+
+### S0: Reconcile DTO field names with 36-3/36-4/36-5 (gate)
+
+**Files:** read-only — `docs/stories/epic-36/story-36-3/...`, `story-36-4/...`, `story-36-5/...`
+(when authored) or their `/tmp/pab_stories/36-3..5.json` specs.
+
+- [ ] Confirm the exact response field names for usage series/breakdown, cost (billed vs byok, MTD,
+      projection, budget/threshold), and agent rollups/trend.
+- [ ] If they differ from the story's draft DTOs, update `analytics.ts` types accordingly. Endpoint
+      **paths** are fixed; only field names are negotiable.
+
+**Acceptance:** `analytics.ts` types match the dependency contracts (or the deltas are noted in the
+story Change Log).
+
+### S1: API client `analytics.ts` + tests (foundation, TDD)
+
+**Files:** new `src/api/analytics.ts`, `src/api/analytics.test.ts`.
+
+- [ ] Write `analytics.test.ts` FIRST (dashboard.test.ts style): each function builds the correct
+      `/api/v1/orgs/{tenantId}/analytics/...` URL; `from`/`to` are UTC ISO; omitted optional params
+      absent from the query string; `requestAnalyticsExport` POSTs the right body.
+- [ ] Implement `analytics.ts` (DTOs + `fetchUsageSeries`, `fetchUsageBreakdown`, `fetchCost`,
+      `fetchAgentRollups`, `fetchAgentTrend`, `requestAnalyticsExport`) through `apiClient`.
+
+**Acceptance:** URL-construction tests green; all calls inherit refresh-on-401.
+
+### S2: `useActiveTenant` + `useAnalyticsControls` + tests
+
+**Files:** new `src/hooks/useActiveTenant.tsx`, `src/hooks/useAnalyticsControls.tsx`,
+`src/hooks/useAnalyticsControls.test.tsx`.
+
+- [ ] `useActiveTenant` returns `{ tenantId: user?.tenantId ?? null }` with a TODO marking the
+      Story 18-5 org-switcher swap point.
+- [ ] `useAnalyticsControls` holds `{ rangePreset, from, to, granularity, groupBy }` synced to
+      `useSearchParams` (react-router 7); presets (7d/30d/90d/MTD/custom) compute UTC `from`/`to`.
+- [ ] Tests: preset ↔ URL query round-trip; preset computes UTC bounds; custom range validates
+      `from <= to`.
+
+**Acceptance:** controls hook round-trips to URL; tenant resolver is the single source.
+
+### S3: View hooks `useAnalyticsUsage` / `useAnalyticsCost` / `useAnalyticsAgents`
+
+**Files:** new `src/hooks/useAnalyticsUsage.tsx`, `useAnalyticsCost.tsx`, `useAnalyticsAgents.tsx`.
+
+- [ ] Each hook: depends on `useActiveTenant().tenantId` + control args; `AbortController`
+      cancel-on-change; tri-state `{ data, loading, error }`; early-return (no fetch) when
+      `tenantId === null`.
+- [ ] `useAnalyticsAgents` also exposes a `loadTrend(agentId)` for the drill-down.
+
+**Acceptance:** changing controls/tenant aborts the prior request and refetches; no fetch without a
+tenant. (Covered by view tests in S5–S7.)
+
+### S4: Shared presentational components
+
+**Files:** new `src/pages/analytics/components/TimeRangeControls.tsx` (+ test),
+`TimeSeriesChart.tsx`, `BreakdownTable.tsx`, `MetricCard.tsx`, `ExportButton.tsx`, `EmptyState.tsx`.
+
+- [ ] `TimeRangeControls` — presentational; presets + custom date inputs + granularity + GroupBy
+      selects; calls back into `useAnalyticsControls`. Test: selecting a preset/groupBy invokes the
+      callback with the right values.
+- [ ] `TimeSeriesChart` — inline SVG line/area + visually-hidden `<table>` (a11y + test target). No
+      chart dependency.
+- [ ] `BreakdownTable` — top-N dimension rows. `MetricCard` — reuse the `DashboardHome.StatCard`
+      idiom. `EmptyState` — shared zero-state vs `role="alert"` error panel (two variants).
+- [ ] `ExportButton` — renders only when `import.meta.env.VITE_FEATURE_ANALYTICS_EXPORT === 'true'`;
+      on click calls `requestAnalyticsExport` with the active view's params.
+
+**Acceptance:** components render in isolation; `ExportButton` hidden when the flag is unset.
+
+### S5: Usage view + tests
+
+**Files:** new `src/pages/analytics/UsageView.tsx`, `UsageView.test.tsx`.
+
+- [ ] Time-series (workflows/dispatches/tokens) + dimension breakdown driven by the control bar;
+      echoes `period_start/period_end`; loading/empty/error states.
+- [ ] Tests: selector-driven refetch fires `?groupBy=agent`; empty `points:[]` → zero-state; 500 →
+      error panel (distinct from empty).
+
+**Acceptance:** AC 3 + AC 8 (usage) + AC 12a green.
+
+### S6: Cost view + tests
+
+**Files:** new `src/pages/analytics/CostView.tsx`, `CostView.test.tsx`.
+
+- [ ] Platform-billed vs BYOK(informational) series, MTD billed, projected spend, budget marker +
+      alert threshold; "BYOK — not billed" label.
+- [ ] Tests: fully-BYOK response (`platformBilledUsd:0`, non-zero `byokCostUsd`) renders `$0.00`
+      billed + label + no over-budget; budget marker renders when budget present.
+
+**Acceptance:** AC 4 + AC 12b green.
+
+### S7: Agents view + drill-down + tests
+
+**Files:** new `src/pages/analytics/AgentsView.tsx`, `AgentsView.test.tsx`.
+
+- [ ] Per-agent rollup rows with selectable order metric; row click → trend drill-down via
+      `fetchAgentTrend`; zero-activity agent → empty trend (not error); unknown agent id →
+      placeholder name.
+- [ ] Tests: rows render + order metric changes the request; drill-down loads a trend; zero-activity
+      trend renders empty-not-error.
+
+**Acceptance:** AC 5 green.
+
+### S8: Layout, routing, nav wiring + isolation/tenant-switch tests
+
+**Files:** new `src/pages/analytics/AnalyticsLayout.tsx` (+ test); modify `src/App.tsx`,
+`src/layouts/AppLayout.tsx`.
+
+- [ ] `AnalyticsLayout` — sub-nav (Usage|Cost|Agents) + `<TimeRangeControls/>` + `<Outlet/>`.
+- [ ] `App.tsx` — nest `/analytics` (index → redirect to `usage`; `usage`/`cost`/`agents`) under the
+      existing `AuthGuard → AppLayout` element route. **No `TenantAdminGuard`.**
+- [ ] `AppLayout.tsx` — add `Analytics` sidebar link (`/analytics/usage`).
+- [ ] Tests: **cross-tenant non-leakage** (every recorded fetch URL contains only the active
+      tenant id — `TenantAlertFeed.test` idiom); **tenant switch** (auth user `tnt-A` → first call
+      `/orgs/tnt-A/...`; re-render on `tnt-B` → prior request aborted, new call `/orgs/tnt-B/...`);
+      **no-tenant** → zero-state, zero fetches.
+
+**Acceptance:** AC 1, 2, 6, 7 green; nav link visible to any member.
+
+### S9: E2E smoke + final verification
+
+**Files:** new `e2e/tests/analytics.spec.ts` (root Playwright suite, `dashboard.spec.ts` style).
+
+- [ ] Authenticated session loads `/analytics/usage`; Analytics nav link visible; three sub-tabs
+      render; switch to `/analytics/cost` shows spend panels. Network-only smoke (no seeded-data
+      assertions), targeting `E2E_BASE_URL` (default `app.tamma.dev`).
+- [ ] Run `pnpm test --filter @tamma/dashboard-user` (all green), `pnpm --filter
+      @tamma/dashboard-user typecheck`, and `pnpm --filter @tamma/dashboard-user build` (respect the
+      vite es2020/chrome87 floor — fail if a dependency tightens it).
+
+**Acceptance:** suite green; typecheck + build clean; e2e smoke passes against a deployed env.
+
+---
+
+## Step order & dependencies
+
+```
+S0 (gate: lock DTO names)
+  → S1 (client) → S2 (controls/tenant hooks) → S3 (view hooks)
+  → S4 (components) → S5 / S6 / S7 (views, parallelizable) → S8 (layout+routing+isolation)
+  → S9 (e2e + verify)
+```
+
+S5/S6/S7 are independent once S1–S4 land and may be parallelized (one subagent each). S8's isolation
++ tenant-switch tests are the gating quality checks; do not mark the story Ready until they pass.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| 36-3/36-4/36-5 DTO field names not final | S0 gate; story owns `analytics.ts` types and reconciles when those stories land. Endpoint paths are fixed. |
+| Cross-tenant leakage via a stray query-param/drill-down id | Tenant id flows from `useActiveTenant` only; AC 6 non-leakage test asserts every fetch URL; drill-down passes `agentId` only, never a tenant. |
+| Empty store mistaken for error (red banner on a new tenant) | `EmptyState` two-variant component; explicit empty-vs-error tests (S5). Mirrors `DashboardHome`. |
+| Adding a chart lib tightens the browser floor | Default zero-dependency inline SVG; if `recharts` adopted, verify `pnpm build` under `es2020/chrome87` first. |
+| Org switcher (18-5) not yet present | `useActiveTenant` isolates resolution; abort+refetch already handles a switch — only the hook body changes later. |
+| Export endpoint (36-8) not live | `ExportButton` flag-gated (`VITE_FEATURE_ANALYTICS_EXPORT`, default off); ships dark, no code change to enable. |
+| Timezone drift (local vs UTC buckets) | Send `from`/`to` as `.toISOString()` UTC; display localizes only. Matches 36-3 forced-UTC binding. |
+```

--- a/docs/superpowers/plans/2026-06-17-36-7-pricing-cost-basis-and-platform-margin-model-plan.md
+++ b/docs/superpowers/plans/2026-06-17-36-7-pricing-cost-basis-and-platform-margin-model-plan.md
@@ -1,0 +1,220 @@
+# Story 36-7: Cost-Basis vs Margin Analytics View — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan phase-by-phase. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every phase writes failing
+> tests before implementation.
+
+**Story:** `docs/stories/epic-36/story-36-7/36-7-pricing-cost-basis-and-platform-margin-model.md` |
+**Epic 36** Analytics & Reporting Platform | **Priority** P0 | **Effort** 3-4 days |
+**Date** 2026-06-17
+
+---
+
+## Goal
+
+Ship the **read-side analytics view** of cost-basis vs margin: a per-tenant gross-margin report
+(cost / billed revenue / margin / margin-% with provider·agent·workflow·cost-basis breakdowns and
+a daily/monthly trend) and an **owner-only** platform-wide margin aggregate. The view **reads**
+the already-priced `CostUsd` (cost basis) and `PlatformBilledUsd` (sell price) columns that
+**Story 34-5** computed and **Story 36-2** persisted onto the **Story 36-1** fact tables, and
+reports `revenue − cost`. It moves no money and **recomputes no pricing**.
+
+## Boundary (the one rule that governs every phase)
+
+This is the analytics **VIEW**, not the markup engine. Pricing — the margin multiplier, the cost
+rate sheet, `cost × (1 + margin)`, BYOK zero-markup, the cabinet-based BYOK/platform
+classification — all live in **Story 34-5** (`IUsagePricingEngine` / `IMarginPolicyResolver` /
+`ProviderPricingService`) and **Story 32-9** (usage emission), applied once at projection time by
+**Story 36-2**. 36-7 sums two already-priced columns and subtracts. **If a phase multiplies a cost
+by a margin, reads a margin policy, or reads a secret cabinet, it has crossed into 34-5/36-2 — stop
+and reconsider.** Phase 2 ships an executable CI guard (the AC2 no-recompute dependency test) so
+this can't regress.
+
+## Non-goals (YAGNI guard)
+
+- **NO markup math, NO margin policy, NO rate sheet.** Read `PlatformBilledUsd` / `CostUsd`;
+  never recompute them. (34-5 owns it.)
+- **NO `PricingConfigService` / `AdminPricingEndpoints` / `MarginPolicy` / `Plan` / `AgentConfig`
+  changes.** Those are the 34-5 markup-engine components the spec's primary-components list named;
+  they are explicitly out of this story's scope per the boundaryNote.
+- **NO fact-table schema change and NO projection logic.** 36-1 owns the schema; 36-2 owns
+  population. This story only reads.
+- **NO exports, NO scheduled reports, NO dashboard.** Later Epic 36 stories. This story ships the
+  read API the dashboard will call.
+- **NO money movement / Stripe.** Billing is Epic 35. This is reporting.
+- **NO TypeScript-side analytics.** The view lives in the C# control plane (`apps/tamma-elsa`);
+  `packages/*` consume it over HTTP. (`packages/api` is DELETED — never a target.)
+
+## Current-state findings (verified 2026-06-17, repo @ main)
+
+| Site | What exists today |
+|---|---|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/PlatformAnalyticsHourly.cs` | CP fleet-wide hourly fact (28-10): `WorkflowsStarted/Completed/Failed`, `AgentDispatches`, `TokensIn/Out`, **`CostUsd` (decimal 20,4)** — but **NO `PlatformBilledUsd`** column. ⇒ platform-aggregate revenue must come from the per-tenant store. |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/IPlatformAnalyticsService.cs` + `PlatformAnalyticsService.cs` | Owner-side read port: `GetSummaryAsync`, `GetTopTenantsAsync`, `GetEventHistogramAsync`, `GetTenantResourceSummaryAsync`. Doc-comment: "Gate calls behind `OwnerAccess`." The fan-out + per-tenant-tolerance + `*.Empty` zeroed-result shape to mirror. Add `GetPlatformMarginAsync` here. |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminAnalyticsEndpoints.cs` | Static-handler style for `/api/admin/analytics/*`; `GetSummary`/`GetTopTenants`/`GetEventHistogram` injecting `IPlatformAnalyticsService`. Add `GetMargin` here. |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/PlatformAnalyticsDtos.cs` | `sealed record` DTO precedent (`PlatformAnalyticsSummary`, `CostAggregates(decimal Last24hUsd, …)`, windowed counts). Mirror for `PlatformMarginReport` / `TenantMarginRow`. |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs:1346-1351` | `admin.MapGet("/analytics/summary", AdminAnalyticsEndpoints.GetSummary).RequireAuthorization("OwnerAccess")` (+ tenants/events). Add `admin.MapGet("/analytics/margin", …)` beside it. |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs:971/986/991` | `OwnerAccess` (971), `PlatformOwnerAccess` (986), `MemberAccess` (991) policies already registered — reuse, don't add. |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs:1512` (per 34-5 plan) | `var orgs = app.MapGroup("/api/v1/orgs").RequireAuthorization("MemberAccess")` — the tenant-scoped group for `GET /api/v1/orgs/{tenantId}/analytics/margin`. |
+| `apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs` | Per-tenant DbSets (`ProviderDiagnostics`, `DomainEvents`, …). Story 36-1 adds `AnalyticsUsageHourly`/`AnalyticsUsageDaily` here (drafted, not yet merged). |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/ProviderDiagnostic.cs` | Per-call cost row: `Cost`, `InputTokens`/`OutputTokens`, `ProviderKey`, `AgentType`, `ProjectId`, `TenantId`. The diagnostic source 36-2 folds — read here only via the projected facts, not directly. |
+| `apps/tamma-elsa/src/Tamma.Data/ITenantContext.cs` | `Guid? TenantId { get; }` — the per-request tenant the tenant-scope endpoint resolves from. `ITammaModeProvider` in `Services/PromptStore/TammaMode.cs`. |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Alerts/PostgresAlertSink.cs` (per 34-5 plan ~133/180) | Canonical DCB emit: `IEventRepository.AppendAsync(new DomainEvent { Type, TenantId, Tags, Metadata, Data })` in try/catch+log. Copy for `ANALYTICS.MARGIN.VIEWED`. |
+| `apps/tamma-elsa/docs/.../SchemaPerTenantMigrationTests` / `ConventionStoreMigrationTests` | Postgres 17 Testcontainer precedent for per-tenant isolation tests (run via `sg docker -c "dotnet test ..."`). |
+
+**Confirmed absent (this story creates):** `IMarginAnalyticsService` / `MarginAnalyticsService`,
+`MarginAnalyticsDtos`, `MarginAnalyticsEndpoints`, `PlatformMarginReport`,
+`IPlatformAnalyticsService.GetPlatformMarginAsync`, the `ANALYTICS.MARGIN.VIEWED` event.
+
+**Confirmed absent today (upstream, NEW elsewhere — referenced, not built here):**
+`IUsagePricingEngine` / `MarginPolicy` (Story 34-5); `AnalyticsUsageHourly`/`AnalyticsUsageDaily`
+(Story 36-1, drafted) — both are dependencies, not 36-7 targets.
+
+**Key gotcha:** `PlatformAnalyticsHourly` has **no `PlatformBilledUsd`** — do not try to read
+revenue from the CP fact table. Sum per-tenant `analytics_usage_*` revenue across tenants for the
+platform aggregate (Phase 3).
+
+---
+
+## Phased task breakdown (test-first / TDD)
+
+### Phase 0 — Prereq gate (no code)
+
+- [ ] Confirm Stories 36-1 (fact tables + `CostBasis` enum + `PlatformBilledUsd` column) and 36-2
+      (which populates `CostUsd`/`PlatformBilledUsd`) are merged, or stub `AnalyticsUsageDaily`/
+      `AnalyticsUsageHourly` on `TenantDbContext` so the read service + tests can compile. The view
+      tolerates an unpopulated store (AC11 zeroed result) so it can land ahead of real projection
+      data — but it cannot compile without the 36-1 entities.
+- [ ] Re-read the boundary above and Story 34-5's plan §Goal so you know exactly which symbols you
+      must NOT touch.
+
+### Phase 1 — Margin-view DTOs (read-side contract)
+
+- **Files:** `Tamma.Api/Services/Analytics/MarginAnalyticsDtos.cs` (new).
+- **Tests first:** `tests/Tamma.Api.Tests/Analytics/MarginAnalyticsServiceTests.cs` (DTO portion):
+  `MarginSummary.From(cost, revenue)` ⇒ `Margin = revenue − cost`, `MarginPct = (revenue−cost)/
+  revenue` rounded 4dp, `Pct == 0` when `revenue == 0`, negative margin when `cost > revenue`;
+  `MarginSummary.Empty` is all-zero.
+- **Approach:** `sealed record` DTOs mirroring `PlatformAnalyticsDtos`: `MarginSummary`,
+  `MarginBreakdownRow(string Dimension, string? Key, decimal Cost, decimal Revenue, decimal
+  Margin, decimal MarginPct)`, `MarginTrendPoint(DateTime Bucket, …)`, `TenantMarginReport`,
+  `PlatformMarginReport`, `TenantMarginRow`. `MarginSummary.From` is the **only** arithmetic in
+  the whole story (sum/subtract/divide-guard). Document the read-only contract in XML comments.
+
+### Phase 2 — `MarginAnalyticsService` (tenant-scope, pure read) + no-recompute guard
+
+- **Files:** `Tamma.Api/Services/Analytics/IMarginAnalyticsService.cs`,
+  `MarginAnalyticsService.cs` (new).
+- **Tests first (same `MarginAnalyticsServiceTests`):**
+  - summation `Σ PlatformBilledUsd − Σ CostUsd` over seeded `AnalyticsUsageDaily` rows;
+  - per-dimension breakdown (provider / agent / workflow / cost-basis) each with its own
+    cost/revenue/margin; `NULL`-dimension bucket preserved; `Σ(breakdown) == grand total`;
+  - **BYOK row → `Revenue == 0`, `Margin == −Cost`, `Pct == 0`** read from stored data;
+  - daily/monthly trend lossless sum;
+  - empty tenant → `MarginSummary.Empty`, empty breakdowns/trend, never null/throw;
+  - **AC2 no-recompute dependency test** — assert (reflection over the assembly's referenced
+    symbols, or an ArchUnitNET/manual-type-scan test) that the margin-view types reference **no**
+    `IUsagePricingEngine` / `IMarginPolicyResolver` / `ProviderPricingService` / `MarginPolicy`
+    symbol.
+- **Approach:** inject `ITenantDbContextFactory`; `GetTenantMarginAsync(tenantId, from, to, grain,
+  ct)` reads `AnalyticsUsageDaily` for whole-day windows (else `AnalyticsUsageHourly`), `GROUP BY`
+  each dimension, sums `CostUsd`/`PlatformBilledUsd`, derives margin via `MarginSummary.From`. Pure
+  read — no pricing namespace import (the import is the thing the AC2 test forbids). InMemory
+  provider for these unit tests.
+
+### Phase 3 — Platform-aggregate read (owner-only, fan-out)
+
+- **Files:** `Tamma.Api/Services/Analytics/IPlatformAnalyticsService.cs` (+ `GetPlatformMarginAsync`),
+  `PlatformAnalyticsService.cs` (impl), `PlatformAnalyticsDtos.cs` (+ `PlatformMarginReport` /
+  `TenantMarginRow`).
+- **Tests first:** `tests/Tamma.Api.Tests/Analytics/MarginAnalyticsIsolationTests.cs` (Postgres 17
+  Testcontainer, per `SchemaPerTenantMigrationTests`):
+  - seed fact rows in two tenant schemas; tenant A's margin reflects only A (isolation);
+  - `GetPlatformMarginAsync` sums both into the fleet aggregate + top-N-by-margin + trend;
+  - force a read failure on tenant A → A skipped (counted), B still contributes, aggregate
+    completes (28-10 AC5 tolerance shape);
+  - zero active tenants → zeroed `PlatformMarginReport`.
+- **Approach:** iterate the active-tenant set (the 28-10 fan-out target — reuse
+  `PlatformAnalyticsService`'s existing tenant enumeration), call `MarginAnalyticsService`
+  per tenant, sum summaries, build top-N + fleet trend. Per-tenant try/catch → log WARN + skip +
+  increment `tenantsSkipped`; never abort. **Revenue is the per-tenant `PlatformBilledUsd` sum** —
+  the CP `platform_analytics_hourly` has no revenue column (Phase-0 finding).
+
+### Phase 4 — Endpoints + RBAC + DCB emit + DI
+
+- **Files:** `Tamma.Api/Endpoints/AdminAnalyticsEndpoints.cs` (+ `GetMargin`),
+  `Tamma.Api/Endpoints/Analytics/MarginAnalyticsEndpoints.cs` (new tenant handler),
+  `Program.cs` (map both routes + DI), `Extensions/AnalyticsServiceCollectionExtensions.cs`
+  (register `IMarginAnalyticsService` scoped — create the extension if analytics DI is inline today).
+- **Tests first:** `tests/Tamma.Api.Tests/Analytics/MarginAnalyticsEndpointsTests.cs` —
+  member → `GET /api/v1/orgs/{tenantId}/analytics/margin` 200; member →
+  `GET /api/admin/analytics/margin` 403; cross-tenant `{tenantId}` → 404; owner → both 200;
+  single-user → both 200 against the one tenant; empty window → zeroed 200; assert exactly one
+  `ANALYTICS.MARGIN.VIEWED` event per query (captured `IEventRepository`), and that emit failure
+  does not fail the request.
+- **Approach:**
+  - Admin: `admin.MapGet("/analytics/margin", AdminAnalyticsEndpoints.GetMargin)
+    .RequireAuthorization("OwnerAccess")` beside the existing `/analytics/*` maps (Program.cs:1346).
+    `GetMargin` injects `IPlatformAnalyticsService`, parses `from`/`to`/`grain`/`limit` (UTC-force
+    like `GetEventHistogram`), returns `PlatformMarginReport`.
+  - Tenant: map on the `/api/v1/orgs` `MemberAccess` group; resolve tenant from
+    `ITenantContext.TenantId`; if the route `{tenantId}` ≠ context tenant → 404 (cross-tenant
+    guard, the org-scoped precedent). Inject `IMarginAnalyticsService`.
+  - DCB: best-effort `ANALYTICS.MARGIN.VIEWED` via `IEventRepository.AppendAsync` in try/catch+log
+    (PostgresAlertSink pattern). No `PRICING.*` event.
+
+### Phase 5 — Wire-up, quality gates, boundary doc
+
+- [ ] `dotnet build` clean; `sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests"` green.
+- [ ] Logging per the story's Logging Requirements (INFO/DEBUG/WARN/ERROR; no connection strings,
+      no provider keys — the view never touches them).
+- [ ] Confirm the AC2 no-recompute test is in the suite and passing (the boundary's CI guard).
+- [ ] No migration in this story (read-only over 36-1's tables) — verify `has-pending-model-changes`
+      stays clean for both contexts (no accidental entity edit).
+- [ ] Update the Epic 36 consumer notes so downstream margin export/report/dashboard stories
+      reference `IMarginAnalyticsService` / `GetPlatformMarginAsync` rather than re-summing facts.
+
+## Sequencing & dependencies
+
+Phase 0 (prereq gate) → Phase 1 (DTOs) → Phase 2 (tenant read + no-recompute guard) → Phase 3
+(platform aggregate, needs Phase 2) → Phase 4 (endpoints, needs 2+3) → Phase 5 (gates). Phases 1
+and the AC2 guard can land ahead of real 36-2 data (AC11 zeroed result). Hard prerequisites:
+Story 36-1 (fact-table entities — must compile against them) and, for meaningful numbers, Story
+36-2 (population). Source-of-truth dependency (consumed, never invoked): Story 34-5
+(`IUsagePricingEngine` produced `PlatformBilledUsd`) and Story 32-9 (usage emission).
+
+## Risks + mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Reporting path recomputes margin → drifts from 34-5 | High | The view only sums two persisted columns; AC2 no-recompute dependency test is an executable CI guard; boundary doc in service comment + non-goals. |
+| Revenue read from the wrong table (CP `platform_analytics_hourly` has no `PlatformBilledUsd`) | High | Phase-0 finding pins it; platform aggregate sums per-tenant `analytics_usage_*` revenue via fan-out; swap source behind `IPlatformAnalyticsService` if a CP revenue column ever lands. |
+| Cross-tenant margin leak | High | Tenant route hard-scoped to `ITenantContext.TenantId` (cross-tenant → 404); admin aggregate `OwnerAccess`; tenant roles 403 on `/api/admin/*`; isolation + RBAC tests. |
+| Platform fan-out aborts on one tenant's read error | Medium | Per-tenant try/catch → log + skip + count (28-10 tolerance shape); fan-out test forces a tenant failure and asserts the aggregate still completes. |
+| Pre-projection window returns null/throws | Medium | `MarginSummary.Empty` zeroed result (mirrors `TenantResourceSummary.Empty`); empty-tenant + empty-window tests. |
+| `MarginPct` divide-by-zero | Low | `revenue == 0 ? 0 : (revenue−cost)/revenue` in `MarginSummary.From`; unit-tested. |
+| Spec primary-components mislead the implementer toward the markup engine | Medium | Story + plan explicitly call out that `PricingConfigService`/`AdminPricingEndpoints`/`Plan`/`AgentConfig` are 34-5's, NOT 36-7's; the Files table lists only `Services/Analytics/*` view files. |
+| Targeting deleted `packages/api` | Low | All targets are `apps/tamma-elsa`; `packages/api` is DELETED and never referenced. |
+
+## Acceptance criteria (mirror of the story)
+
+- [ ] `IMarginAnalyticsService` reads `analytics_usage_daily`/`_hourly` via `ITenantDbContextFactory`
+      and returns `CostUsd` / `PlatformBilledUsd` / `MarginUsd = revenue−cost` / `MarginPct` for a
+      `[from,to]` window — pure summation, no pricing recompute.
+- [ ] AC2 boundary: margin-view types take **no** dependency on the 34-5 pricing namespace
+      (executable test).
+- [ ] Breakdowns by provider / agent / workflow / cost-basis, each with own cost/revenue/margin;
+      `NULL` bucket preserved; `Σ(breakdown) == grand total`.
+- [ ] BYOK rows surface `Revenue == 0`, `Margin == −Cost`, `Pct == 0` read from stored data.
+- [ ] Daily (and monthly) trend, lossless to the window total.
+- [ ] `GET /api/v1/orgs/{tenantId}/analytics/margin` (`MemberAccess`) — tenant-scoped, cross-tenant
+      → 404.
+- [ ] `GET /api/admin/analytics/margin` (`OwnerAccess`) — fleet aggregate via per-tenant fan-out;
+      one-tenant failure skipped; tenant/member → 403.
+- [ ] Per-mode ownership answered (single-user sole user = both surfaces; SaaS tenant = own margin,
+      owner = aggregate); raw margin multiplier never exposed.
+- [ ] Empty/pre-projection → zeroed result, never null/throw.
+- [ ] `ANALYTICS.MARGIN.VIEWED` best-effort DCB emit per query; no `PRICING.*` event here.
+- [ ] Unit + integration tests (math/breakdown/BYOK/trend/isolation/fan-out/RBAC/empty/no-recompute)
+      green; build clean; no pending model changes.

--- a/docs/superpowers/plans/2026-06-17-36-8-analytics-exports-plan.md
+++ b/docs/superpowers/plans/2026-06-17-36-8-analytics-exports-plan.md
@@ -1,0 +1,275 @@
+# Story 36-8 — Analytics Exports (CSV / PDF) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation.
+
+**Goal:** Let a tenant export any analytics view — usage (36-3), cost (36-4), or agent performance
+(36-5) — as a raw-row **CSV** or a branded **PDF** report, for a chosen range + grouping. Exports
+run server-side off the per-tenant dimensional store, **read the existing query services (never
+re-aggregate the raw event stream)**, are hard tenant-scoped + RBAC-gated, emit `DATA.EXPORT.*` DCB
+audit events (Epic 37), and switch from inline rendering to a background `QueuedTask` job (with a
+signed, expiring download) when the range is large.
+
+**Story file:** `docs/stories/epic-36/story-36-8/36-8-analytics-exports.md` (drafted; 12 ACs).
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (`Tamma.Api` endpoints +
+services, `Tamma.Data` per-tenant entities). Tests live in
+`apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/` (xUnit; docker-bound suites run via
+`sg docker -c "dotnet test ..."`). PDF/CSV libraries are NEW package additions (decide first).
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+| Seam | File (verified) | Note |
+|---|---|---|
+| Per-tenant DB factory | `Tamma.Data/Abstractions/ITenantDbContextFactory.cs` | `CreateAsync(tenantId, ct)` → per-tenant `TenantDbContext` (search-path schema). Analytics read models (36-1/2) live here. |
+| Tenant guard | `Tamma.Api/Authorization/RequireTenantMembershipFilter.cs` | 401 unauth / 400 bad `tenantId` / 403 non-member; stashes `Items["TenantRole"]`. The "same guard as 36-3". |
+| Tenant-scope endpoint precedent | `Tamma.Api/Endpoints/AlertEndpoints.cs` (tenant section ~L560+) + `Program.cs` orgs group (L1512+) | `MapGroup("/api/v1/orgs").RequireAuthorization("MemberAccess")` + per-route `.AddEndpointFilter<RequireTenantMembershipFilter>()`; admin+ mutation gate via `TenantRoleHierarchy.IsAtLeast`. |
+| Async job queue | `Tamma.Data/Entities/QueuedTask.cs` (tenant-scoped, `TenantId` non-null), `Tamma.Api/Services/TaskQueue/TaskQueueProcessor.cs`, `ITaskHandler.cs` | Processor fans out across tenants, `MarkProcessing/Completed/Failed`, retry budget, visibility-timeout reaper. `PlatformQueuedTask` is CP/pre-routing — **do not** use it for tenant exports. |
+| DCB append | `Tamma.Data/Repositories/EventRepository.cs` `AppendAsync` | `DomainEvent.TenantId` set → routes the event into the **tenant's own** `domain_events`. Best-effort emit precedent: `PromptEventsService`, `AlertEndpoints.TryEmitAsync`. |
+| Analytics endpoint precedent | `Tamma.Api/Endpoints/AdminAnalyticsEndpoints.cs` (owner-only, CP) | `/api/admin/analytics/*` is owner/CP; tenant exports are a NEW tenant-scope surface. |
+| Activities/Analytics dir | `Tamma.Activities/Analytics/` (`AnalyticsRollupEvents`, `PurgeStaleAnalyticsActivity`, …) | Retention-purge tolerance shape to mirror for the artifact sweep. |
+
+**Gaps (NEW — must build):**
+- Stories **36-3/36-4/36-5 query services are not yet authored** — they are this story's read
+  contract. Confirm their merged interface + DTO names before pinning the CSV golden header.
+- **No CSV or PDF library** in the solution — both are NEW package refs (decide PDF lib first).
+- **No blob/object store** — artifact bytes go on the tenant row (`bytea`) behind an
+  `IExportArtifactStore` seam; signed download is served by the app, not a CDN.
+- **Epic 37** (audit/compliance) is planned/NEW — this story's `DATA.EXPORT.*` events are its input.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- NO analytics aggregation here — read 36-3/4/5; re-aggregating `DomainEvent`/`ProviderDiagnostic`
+  would fork the numbers from the dashboard. A structure test pins the dependency direction.
+- NO schema change to the 36-1 fact tables — only the additive `analytics_exports` table.
+- NO scheduled/recurring delivery (Story 36-9) and NO owner business-analytics export — keep the
+  render path injectable so 36-9 can reuse it later.
+- NO external object store / CDN — `bytea` on the tenant row behind `IExportArtifactStore`; the
+  seam makes S3/blob a future drop-in with no endpoint change.
+- NO `PlatformQueuedTask` — tenant exports use the tenant-scoped `QueuedTask` queue.
+- NO new alert delivery — `DATA.EXPORT.*` are audit events for Epic 37, not alerts.
+
+---
+
+## Architecture
+
+**request → validate/bound → (sync render | enqueue) → render via 36-3/4/5 → persist artifact →
+audit event → signed download**, reusing the tenant guard, the task queue, and the DCB store.
+
+```
+POST /api/v1/orgs/{tenantId}/analytics/exports   (MemberAccess + RequireTenantMembershipFilter)
+  │  validate spec (type/format/from/to/groupBy allow-lists, UTC, from<=to, max-window)
+  │  estimate rows  ──► ≤ threshold ─► AnalyticsExportService.RenderAsync (inline) ─► 200 file
+  │                  └► > threshold ─► enqueue QueuedTask{analytics.export, TenantId} ─► 202 {jobId}
+  │  emit DATA.EXPORT.REQUESTED
+  ▼
+AnalyticsExportService.RenderAsync(tenantId, userId, spec)
+  │  switch spec.Type → IUsage/Cost/AgentPerformance QueryService  (36-3/4/5 — reads, no re-agg)
+  │  switch spec.Format → AnalyticsCsvWriter | AnalyticsPdfReportRenderer
+  │  IExportArtifactStore.SaveAsync(bytes) → analytics_exports row (tenant schema, bytea default)
+  │  emit DATA.EXPORT.COMPLETED  (best-effort)   |   on throw → status=failed + DATA.EXPORT.FAILED
+  ▼
+AnalyticsExportTaskHandler : ITaskHandler ("analytics.export")  — same RenderAsync, idempotent
+  ▼
+GET  …/exports/{jobId}            → status + signed URL (ExportDownloadSigner, HMAC, TTL)
+GET  …/exports/{jobId}/download   → verify sig (fixed-time, expiry) → stream artifact bytes
+```
+
+### Per-mode ownership (mandatory two-scoping-model answer)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Who owns an export? | sole user; their one tenant schema. | the tenant; its `t_<hex>` schema (`requestedBy` = member). |
+| Who may request/download? | the user (authentication only). | any tenant member (`MemberAccess` + membership) — an export is a read. |
+| Cross-tenant | N/A | 403 request; 403/404 job/download lookup; tenant-A signature → 403 on tenant-B. |
+| Audit residency | tenant's own `domain_events`. | tenant's own `domain_events`. |
+| Mode source | `RequireTenantMembershipFilter` + per-tenant `TenantDbContext`. | same. |
+
+---
+
+## Task breakdown
+
+### T1: `analytics_exports` entity + Tenant mapping + migration (AC 6, 8)
+
+**Files:** new `Tamma.Data/Entities/AnalyticsExport.cs`; DbSet on `Tamma.Data/TenantDbContext.cs`;
+`ConfigureAnalyticsExports` in `Tamma.Data/TammaModelConfiguration.cs` (called from
+`ConfigureTenantEntities`, no `TenantId` column — `ApplyTenantFilter` no-op per Story 36-1; index
+`(Status, ExpiresAt)`); additive migration via
+`dotnet ef migrations add AddAnalyticsExports -c TenantDbContext`.
+
+**Tests (first):** `AnalyticsExportMigrationTests` (Postgres 17 Testcontainer) — two schemas each
+carry `analytics_exports`; a row in schema A invisible through schema B; `has-pending-model-changes
+-c TenantDbContext` clean.
+
+**AC:**
+- [ ] Entity + tenant mapping + DbSet; no `TenantId` column (schema isolation).
+- [ ] Migration applies/rolls back cleanly; pending-model-changes reports none.
+- [ ] Per-tenant isolation proven (schema A row unreachable from schema B).
+
+### T2: spec + validation + event-type constants (AC 1, 5, 6)
+
+**Files:** new `AnalyticsExportSpec.cs` (record + validator), `AnalyticsExportOptions.cs`
+(SyncRowThreshold=50_000, SyncRangeDays=92, MaxWindowDays=366, DownloadTtl=1h, ArtifactTtl=7d),
+`AnalyticsExportEventTypes.cs` (`DATA.EXPORT.REQUESTED|COMPLETED|FAILED`).
+
+**Tests (first):** spec validator — unknown type/format → invalid; non-UTC / unparseable date →
+invalid; `from > to` → invalid; range > MaxWindowDays → invalid; unknown `groupBy` dimension →
+invalid; valid spec round-trips.
+
+**AC:**
+- [ ] Allow-lists + UTC + `from<=to` + max-window + groupBy-dimension validation.
+- [ ] Event-type constants match the `AGGREGATE.ACTION.STATUS` convention.
+
+### T3: CSV writer (AC 2, 12)
+
+**Files:** new `Render/AnalyticsCsvWriter.cs` — per-type column order **from the 36-3/4/5 DTO**;
+dimensions first then measures; raw unrounded numbers; empty cell for NULL dimension; UTF-8 BOM;
+header-only on empty.
+
+**Tests (first):** `AnalyticsCsvWriterTests` — golden header + row order per type; raw-measure
+formatting; empty-NULL cell (never `"unknown"`); BOM; empty-result header-only.
+
+**AC:**
+- [ ] One row per dimension-tuple per bucket; documented stable headers matching the DTO.
+- [ ] Raw measures; empty NULL cell; BOM; empty-result tolerated.
+
+### T4: PDF report renderer (AC 3, 12)
+
+**Pre-step (research):** WebSearch the current best server-side PDF option (QuestPDF license
+eligibility vs PuppeteerSharp HTML-to-PDF reusing dashboard chart markup); record in
+`.dev/decisions/`. Add the package to `Tamma.Api.csproj`.
+
+**Files:** new `Render/AnalyticsPdfReportRenderer.cs` — branded header (Tamma brand, tenant name,
+type, range, generated-at), summary, per-`groupBy` breakdown tables, chart image(s); "no data"
+path.
+
+**Tests (first):** `AnalyticsPdfReportRendererTests` — `%PDF-` magic, non-trivial size, contains
+summary + ≥1 breakdown table for populated spec; valid "no data" PDF for empty.
+
+**AC:**
+- [ ] Branded report with the same summary + breakdown tables + chart(s) as the dashboard view.
+- [ ] Rendered from the same query-service result as the CSV (one source of truth).
+
+### T5: export service + artifact store (AC 1, 3, 5, 8, 11)
+
+**Files:** new `IAnalyticsExportService.cs` + `AnalyticsExportService.cs` (calls 36-3/4/5 query
+services by `spec.Type`, dispatches to CSV/PDF, persists via `IExportArtifactStore`, emits audit,
+threshold estimator); `IExportArtifactStore.cs` + `DbExportArtifactStore.cs` (bytes on row).
+
+**Tests (first):** `AnalyticsExportServiceTests` — correct query service per type (mocked 36-3/4/5);
+renders requested format; persists artifact; emits REQUESTED+COMPLETED with documented tags;
+threshold routes small→inline / large→enqueue; renderer throw → failed + FAILED; empty result →
+COMPLETED rowCount 0; **structure test: depends on query-service abstractions, NOT `DomainEvent`/
+`ProviderDiagnostic`** (AC11).
+
+**AC:**
+- [ ] Reads 36-3/4/5; never re-aggregates raw events (structure test pins it).
+- [ ] Persists artifact; emits the three audit events with correct tags.
+- [ ] Threshold estimator decides sync vs async.
+
+### T6: async path — `QueuedTask` handler (AC 6, 12)
+
+**Files:** new `Services/TaskQueue/Handlers/AnalyticsExportTaskHandler.cs`
+(`ITaskHandler`, `TypePrefix = "analytics.export"`): deserialize spec+userId, `RenderAsync`,
+persist, emit COMPLETED/FAILED, idempotent (completed job id → no-op); register in the
+task-handler registry wiring.
+
+**Tests (first):** `AnalyticsExportTaskHandlerTests` — payload renders+persists+COMPLETED; second
+delivery of completed job → no-op; render failure → failed + FAILED (processor retry budget
+applies).
+
+**AC:**
+- [ ] Renders the same way the sync path does; idempotent on re-delivery.
+- [ ] Enqueues a tenant-scoped `QueuedTask` (`TenantId` non-null), not `PlatformQueuedTask`.
+
+### T7: signed download (AC 7)
+
+**Files:** new `ExportDownloadSigner.cs` — HMAC-SHA256 over `(tenantId, jobId, expiresAt)`,
+constant-time verify (`CryptographicOperations.FixedTimeEquals`); secret from config.
+
+**Tests (first):** `ExportDownloadSignerTests` — sign→verify round-trip; tampered
+sig/jobId/tenantId reject; expired `expiresAt` rejects.
+
+**AC:**
+- [ ] Sign on status read; verify on download (403 on tamper/expiry); constant-time compare.
+- [ ] Secret never logged.
+
+### T8: endpoints + wiring (AC 1, 4, 6, 7, 9)
+
+**Files:** new `Tamma.Api/Endpoints/AnalyticsExportEndpoints.cs` (POST exports, GET `{jobId}`,
+GET `{jobId}/download`); new `Extensions/AnalyticsExportServiceCollectionExtensions.cs`; map under
+the orgs group in `Program.cs` each with `.AddEndpointFilter<RequireTenantMembershipFilter>()`;
+register services + handler.
+
+**Tests (first):** `AnalyticsExportEndpointsTests` (WebApplicationFactory) — 401 unauth; 403
+non-member; small→200 file (`Content-Disposition: attachment`); large→202 `{jobId}`; GET `{jobId}`→
+status+signed URL; download valid sig→bytes; cross-tenant request/job/download→403/404; tenant-A
+signature→403 on tenant-B.
+
+**AC:**
+- [ ] Endpoints behind membership filter; hard tenant scope; cross-tenant 403/404.
+- [ ] Endpoint shape identical across modes (filter + per-tenant context resolve scope).
+
+### T9: retention sweep (AC 8)
+
+**Files:** best-effort purge of `analytics_exports` past `ExpiresAt` (mirror
+`PurgeStaleAnalyticsActivity` tolerance — never rethrow a transient failure).
+
+**Tests (first):** purge deletes expired rows, leaves live rows, swallows transient failure.
+
+**AC:**
+- [ ] Expired artifacts swept per the configured TTL; best-effort.
+
+---
+
+## Task order & dependencies
+
+T1 → T2 → (T3 ∥ T4 ∥ T7) → T5 (needs T2/T3/T4 + 36-3/4/5 query services) → T6 (needs T5) →
+T8 (needs T5/T6/T7) → T9. T3/T4/T7 are parallel-safe after T2.
+
+**Hard external prerequisite:** Stories 36-3/36-4/36-5 query services must be merged before T5 —
+they define the read contract + the CSV/PDF column shape. T1–T4/T7 (entity, spec, CSV scaffolding,
+PDF lib decision, signer) can start before they land, but the DTO-shaped golden tests (T3) and the
+service (T5) are blocked on the merged DTOs.
+
+## Risks
+
+- **Query-service contract drift (T3/T5):** the CSV golden header + PDF tables are defined by the
+  36-3/4/5 DTOs, which aren't authored yet. Mitigation: pin the DTO names/shape against the merged
+  stories before writing the golden test; keep the column map in one place so a DTO change is a
+  single edit. Don't invent a DTO — block on the real one.
+- **PDF library choice:** no PDF lib exists; QuestPDF's license (Community vs Professional) must be
+  confirmed for this project, or use PuppeteerSharp HTML-to-PDF (heavier runtime, but reuses
+  dashboard chart markup). Decide + record in `.dev/decisions/` before adding the package
+  (CLAUDE.md: research latest before using a new dependency).
+- **Large artifact on the row (`bytea`):** a multi-MB export on the tenant row is acceptable for v1
+  behind the size bound + 7-day TTL sweep, but the `IExportArtifactStore` seam must stay clean so a
+  future S3 backend is a drop-in — don't leak `bytea` assumptions into the endpoint or signer.
+- **Audit event must not block the export:** `DATA.EXPORT.*` emission is best-effort (wrapped, never
+  throws) per the `PromptEventsService`/`AlertEndpoints.TryEmitAsync` precedent — a broken event
+  store must not turn a successful export into a 500.
+- **Async idempotency:** the processor can re-deliver a task (visibility-timeout reap / retry); the
+  handler must no-op a completed job id and never produce a partial artifact — whole-bucket
+  re-render makes this safe.
+- **Migration discipline:** `analytics_exports` is additive on the Tenant graph; still verify
+  `has-pending-model-changes -c TenantDbContext` reports none and mirror entity config only in
+  `TammaModelConfiguration.cs` (single source).
+- **Event-store topology (Story 28-1 / Epic 30):** `DATA.EXPORT.*` events carry `TenantId` so they
+  already route to the tenant's own `domain_events` — no change needed when per-tenant event
+  routing tightens.
+
+## Verification
+
+- `sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~Analytics"`
+  green (CSV golden, PDF smoke, service, handler, endpoints, signer, migration isolation).
+- `dotnet ef migrations has-pending-model-changes -c TenantDbContext` → none.
+- Full suite stays green; no new lint/build warnings.
+- Manual smoke: POST a small usage CSV export → 200 attachment; POST a >92-day range → 202 +
+  jobId → GET `{jobId}` → signed URL → download streams identical bytes; cross-tenant download →
+  403; check the tenant's `domain_events` has `DATA.EXPORT.REQUESTED/COMPLETED`.

--- a/docs/superpowers/plans/2026-06-17-36-9-scheduled-reports-and-delivery-plan.md
+++ b/docs/superpowers/plans/2026-06-17-36-9-scheduled-reports-and-delivery-plan.md
@@ -1,0 +1,274 @@
+# Story 36-9 — Scheduled Reports & Delivery (implementation plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation. **Read [BEFORE_YOU_CODE.md](../../guides/BEFORE_YOU_CODE.md) first.**
+
+**Goal:** Let tenant owners/admins (and, in single-user mode, the sole user) configure recurring
+analytics reports (daily/weekly/monthly) that Tamma generates server-side via the 36-8 export
+pipeline and emails to chosen recipients through the existing outbox — plus an optional
+platform-owner-only business digest (MRR/churn from 36-10). Schedules are stored per-mode
+(`user_id` single-user / `tenant_id` SaaS), RBAC-gated for edit (owner/admin), executed by a
+recurring Elsa scheduler, idempotent per period, and tenant-isolated.
+
+**Story:** [`docs/stories/epic-36/story-36-9/36-9-scheduled-reports-and-delivery.md`](../../stories/epic-36/story-36-9/36-9-scheduled-reports-and-delivery.md)
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql + Elsa workflows in `apps/tamma-elsa`. Tests in
+`apps/tamma-elsa/tests/` (xUnit; docker-bound suites run `sg docker -c "dotnet test ..."`).
+**`packages/api` is DELETED — never add to it.**
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO new email transport.** `OutboxSmtpSender` already drains the per-tenant `email_outbox` AND the
+  CP `platform_email_outbox` with retry/backoff + `EMAIL.SENT.SUCCESS`. This story only ENQUEUES.
+- **NO new export engine.** Report bodies come from `AnalyticsExportService` (Story 36-8). If 36-8
+  has not landed, this story is blocked — do not stub a parallel exporter.
+- **NO Elsa cron-trigger package.** Follow Story 28-10's `BackgroundService` + advisory-lock pattern.
+- **NO per-user override layer in SaaS** (per CLAUDE.md prompt-store precedent) — tenant schedules are
+  owned by tenant_owner/tenant_admin; members read only.
+- **NO synchronous on-demand "run now" endpoint in v1.** The scheduler + ledger cover recurring runs;
+  a manual re-run can be a cheap follow-up via the `TaskQueueProcessor` escape hatch.
+- **NO change to analytics query semantics or the 36-3 tenant-scope guard** — reuse them.
+- **NO per-tenant detail in the platform digest** — aggregates only; SaaS-only; `OwnerAccess`.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+| Capability | Verified location | Use |
+|---|---|---|
+| Recurring scheduler | `src/Tamma.ElsaServer/Workflows/HourlyAnalyticsRollupScheduler.cs` — `BackgroundService`, poll + cron offset, `pg_try_advisory_lock` leader lock (`IRollupSchedulerLeaderLock` / `PostgresAdvisoryLeaderLock`), `Enabled` gate, `InvokeTickForTestsAsync`. | Template for `ScheduledReportsScheduler`. |
+| Recurring workflow | `src/Tamma.ElsaServer/Workflows/HourlyAnalyticsRollupWorkflow.cs` — `WorkflowBase`, fan-out, per-item failure isolation, terminal `HOUR_COMPLETED` event. | Template for `ScheduledReportsWorkflow`. |
+| Fan-out isolation | `src/Tamma.Activities/Analytics/FanOutTenantRollupsActivity.cs` (per-tenant try/catch, continue on failure). | Pattern for per-report isolation (AC9). |
+| Event helper | `src/Tamma.Activities/Analytics/AnalyticsRollupEvents.cs` (`AGGREGATE.ACTION.STATUS`, tag dict, `BuildEvent`). | Pattern for `ScheduledReportEventTypes` + DCB tags. |
+| DCB append | `src/Tamma.Data/Repositories/IEventRepository.cs` (`AppendAsync`). | Emit `ANALYTICS.REPORT.*`. |
+| Per-tenant outbox | `src/Tamma.Data/Entities/EmailOutboxMessage.cs` + `IEmailOutboxRepository.EnqueueAsync` (`src/Tamma.Data/Repositories/IEmailOutboxRepository.cs`). | Enqueue tenant report deliveries. |
+| Platform outbox | `src/Tamma.Data/Entities/PlatformEmailOutboxMessage.cs` + `IPlatformEmailOutboxRepository`. | Enqueue platform digest. |
+| Outbox sender (transport) | `src/Tamma.Api/Services/Email/OutboxSmtpSender.cs` — drains BOTH tables, retry/backoff, `EMAIL.SENT.SUCCESS`. | Reuse unchanged — delivery is free. |
+| Email templates | `src/Tamma.Api/Services/Email/EmailTemplates.cs`. | Add `scheduled-report`. |
+| Per-mode XOR / dedup | `prompt_overrides` in `src/Tamma.Data/TammaModelConfiguration.cs` ~714: `ck_prompt_overrides_principal_xor` + `.AreNullsDistinct(false)` unique. | Mirror for `scheduled_reports` + `scheduled_report_runs`. |
+| Tenant RBAC (member→403) | `src/Tamma.Api/Endpoints/ConventionStoreEndpoints.cs` ~248 (`ConventionManage` policy, `TenantScope` via `ITenantContext` + `ITammaModeProvider`). | Mirror for report-CRUD mutating routes. |
+| Export service (36-8) | `src/Tamma.Api/Services/Analytics/AnalyticsExportService.cs` — **NEW in 36-8**. | Hard dependency — call to render artifacts. |
+| Migration baseline | `src/Tamma.Data/Migrations/ControlPlane/` collapsed to `InitialControlPlane`. | Additive `dotnet ef migrations add`; verify `has-pending-model-changes` = none. |
+
+**Key gap closed for free:** because the outbox sender already drains both tables, the only delivery
+work is enqueue. The only genuinely new logic is (a) due-selection/period math and (b) per-period
+idempotency — both are pure and testable.
+
+### Per-mode ownership (two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Schedule key | `user_id` set, `tenant_id` NULL | `tenant_id` set, `user_id` NULL |
+| Create/edit/delete | sole user (no role check) | `tenant_owner`/`tenant_admin`; `member` → 403 |
+| Read | sole user | any tenant member |
+| Report delivery | per-tenant `email_outbox` | per-tenant `email_outbox` (`TenantId` set) |
+| Platform digest | N/A (skip) | platform owner only, platform outbox, aggregates only |
+| Mode source | `ITammaModeProvider` | same |
+
+---
+
+## Architecture
+
+**Configure → schedule → due-select → generate (36-8) → enqueue (existing outbox) → audit.**
+
+```
+ScheduledReportEndpoints  ── CRUD (per-mode RBAC) ──▶  scheduled_reports (user_id XOR tenant_id)
+                                                              │
+ScheduledReportsScheduler (BackgroundService, advisory lock) ─┤ dispatches every PollInterval
+                                                              ▼
+ScheduledReportsWorkflow (Elsa)
+   ├─ SelectDueReports        (ScheduledReportCadence.IsDue → periodKey)
+   ├─ fan-out per report ▶ GenerateScheduledReportActivity
+   │     ├─ INSERT scheduled_report_runs (report_id, period_key)  ── unique → idempotent gate
+   │     ├─ AnalyticsExportService.Generate(...)        (36-8)
+   │     ├─ emit ANALYTICS.REPORT.GENERATED
+   │     ├─ IEmailOutboxRepository.EnqueueAsync(scheduled-report)  ── store outbox_msg_id
+   │     └─ emit ANALYTICS.REPORT.SENT   (try/catch → ANALYTICS.REPORT.FAILED, continue)
+   ├─ [SaaS + 36-10] GeneratePlatformDigest ▶ IPlatformEmailOutboxRepository (aggregates only)
+   └─ EmitReportsTickCompleted (counts)
+
+OutboxSmtpSender (UNCHANGED) drains email_outbox + platform_email_outbox → SMTP → EMAIL.SENT.SUCCESS
+```
+
+**Idempotency contract (AC7):** `(report_id, period_key)` unique on `scheduled_report_runs`.
+Insert-if-absent owns the period; a unique violation = already handled = skip. Replay / restart /
+multi-pod all collapse to one send.
+
+---
+
+## Task breakdown
+
+### T1 — Entities + EF config + migration (foundation)
+
+**Scope:** `ScheduledReport` + `ScheduledReportRun` entities; DbSets; `TammaModelConfiguration`
+entity config (XOR CHECK, enum CHECKs, `NULLS NOT DISTINCT` uniques); additive migration. No
+behaviour yet.
+
+**Files:** new `src/Tamma.Data/Entities/ScheduledReport.cs`, `ScheduledReportRun.cs`; modify
+`ControlPlaneDbContext.cs` (DbSets), `TammaModelConfiguration.cs` (config blocks mirroring
+`prompt_overrides`); new migration under `Migrations/ControlPlane/`.
+
+**Tests first:** `tests/Tamma.Api.Tests/Analytics/ScheduledReportRepositoryTests.cs` (with T2 repo)
+asserts XOR rejects both-null/both-set, enum CHECKs reject bad values, unique blocks duplicate
+schedule + duplicate `(report_id, period_key)`.
+
+**Acceptance:**
+- [ ] `ck_scheduled_reports_principal_xor` enforces exactly-one principal key.
+- [ ] `cadence`/`report_type`/`format` CHECKs pin closed enums.
+- [ ] `NULLS NOT DISTINCT` uniques on both tables behave (schedule de-dup + run de-dup).
+- [ ] `dotnet ef migrations has-pending-model-changes` reports none; migration applies + rolls back.
+
+### T2 — Repository (CRUD + due-select + run-ledger upsert)
+
+**Scope:** `IScheduledReportRepository` / `ScheduledReportRepository` — create/get/list/update/delete
+(scoped by principal), `ListEnabledDueAsync`, and `TryClaimRunAsync(reportId, periodKey)` returning
+true only on a fresh insert (catch 23505 → false).
+
+**Files:** new `src/Tamma.Data/Repositories/IScheduledReportRepository.cs`, `ScheduledReportRepository.cs`;
+register in `Program.cs`.
+
+**Tests first:** extend `ScheduledReportRepositoryTests` — CRUD round-trip; cross-principal isolation
+(single-user row invisible to a tenant query and vice-versa); `TryClaimRunAsync` returns true once,
+false on the second concurrent call.
+
+**Acceptance:**
+- [ ] `TryClaimRunAsync` is the single idempotency primitive (fresh insert = own period).
+- [ ] List/get/update/delete are principal-scoped; no cross-tenant leakage.
+
+### T3 — Cadence + period-key math (pure, the risky logic)
+
+**Scope:** `ScheduledReportCadence` static helper: `(isDue, periodKey) Evaluate(cadence, timeZone,
+lastRunAt, now)`. Daily/weekly(ISO,Mon)/monthly; period_key formats `yyyy-MM-dd` / `yyyy-Www` /
+`yyyy-MM`; computes the export period range for 36-8.
+
+**Files:** new `src/Tamma.Api/Services/Analytics/ScheduledReportCadence.cs`.
+
+**Tests first:** `tests/Tamma.Api.Tests/Analytics/ScheduledReportCadenceTests.cs` — DST boundary,
+month rollover, ISO-week start, never-run schedule, already-run-this-period (not due), time-zone
+offsets. No DB.
+
+**Acceptance:**
+- [ ] Each cadence is due exactly once per period; `periodKey` is stable and matches the export range.
+- [ ] Pure (no DB / no clock dependency beyond injected `now`).
+
+### T4 — Event types + email template
+
+**Scope:** `ScheduledReportEventTypes` (`ANALYTICS.REPORT.GENERATED|SENT|FAILED|TICK_COMPLETED`) +
+tag-dict builder (mirror `AnalyticsRollupEvents.BuildEvent`); add `scheduled-report` template to
+`EmailTemplates.cs` (subject + html/text wrapping the export; no recipient/body leakage).
+
+**Files:** new `src/Tamma.Api/Services/Analytics/ScheduledReportEventTypes.cs`; modify
+`src/Tamma.Api/Services/Email/EmailTemplates.cs`.
+
+**Tests first:** `EmailTemplatesTests` extension — `scheduled-report` renders subject + both bodies;
+event-type constants are stable.
+
+**Acceptance:**
+- [ ] Event names follow `AGGREGATE.ACTION.STATUS`; tags carry reportId/type/format/periodKey/tenantId.
+- [ ] Template renders; no PII in event `data`.
+
+### T5 — Generate activity (render via 36-8 + enqueue outbox + emit events)
+
+**Scope:** `GenerateScheduledReportActivity` (Elsa `CodeActivity`): claim run (T2) → on fresh claim,
+call `AnalyticsExportService.Generate` (36-8) → emit GENERATED → build `EmailOutboxMessage` (template
+`scheduled-report`) → `EnqueueAsync` → store `outbox_msg_id`, flip run `sent`, emit SENT. Wrapped in
+try/catch → FAILED + mark run failed + continue (AC9).
+
+**Files:** new `src/Tamma.Activities/Analytics/GenerateScheduledReportActivity.cs`.
+
+**Tests first:** `tests/Tamma.Activities.Tests/Analytics/GenerateScheduledReportActivityTests.cs` —
+mocked export service: enqueues exactly one outbox row, emits GENERATED+SENT; already-claimed period
+→ no-op (idempotent); export throws → FAILED emitted, run marked failed, no enqueue; recipients never
+appear in event data.
+
+**Acceptance:**
+- [ ] One fresh period → one generate, one enqueue, GENERATED+SENT pair.
+- [ ] Failure path emits FAILED and never throws out of the per-report loop.
+- [ ] `ANALYTICS.REPORT.SENT` means "enqueued," not "SMTP delivered" (documented).
+
+### T6 — Workflow (select due → fan out → optional digest → terminal event)
+
+**Scope:** `ScheduledReportsWorkflow` (`WorkflowBase`, model on `HourlyAnalyticsRollupWorkflow`):
+`SelectDueReports` → fan out `GenerateScheduledReportActivity` per due report (isolated) →
+optional `GeneratePlatformDigest` (SaaS + 36-10) → `EmitReportsTickCompleted`.
+
+**Files:** new `src/Tamma.ElsaServer/Workflows/ScheduledReportsWorkflow.cs`; register in
+`src/Tamma.ElsaServer/Program.cs`.
+
+**Tests first:** `tests/Tamma.Activities.Tests/Analytics/ScheduledReportsWorkflowTests.cs` — two due
+reports, one throws → the other still delivered + TICK_COMPLETED counts (1 sent, 1 failed); replay
+the instance → no duplicate sends (AC7); platform digest uses platform outbox + aggregates only;
+digest skipped when single-user or 36-10 absent.
+
+**Acceptance:**
+- [ ] Per-report failure isolation holds (sibling delivered).
+- [ ] Replay is a no-op (idempotent end-to-end).
+- [ ] Platform digest gated SaaS + OwnerAccess + 36-10-available; aggregates only.
+
+### T7 — Scheduler (BackgroundService + advisory leader lock)
+
+**Scope:** `ScheduledReportsScheduler` modelled on `HourlyAnalyticsRollupScheduler`:
+`ScheduledReportsSchedulerOptions { Enabled=true, PollInterval=5m }`, advisory leader lock per tick
+(reuse `IRollupSchedulerLeaderLock` / `PostgresAdvisoryLeaderLock` — extract to shared helper if
+cheap, else mirror), dispatch failure → WARN + continue, `InvokeTickForTestsAsync`.
+
+**Files:** new `src/Tamma.ElsaServer/Workflows/ScheduledReportsScheduler.cs`; register in
+`src/Tamma.ElsaServer/Program.cs`.
+
+**Tests first:** scheduler test — `InvokeTickForTestsAsync` dispatches once; `Enabled=false` → no
+dispatch; second pod (lock held) → no double dispatch.
+
+**Acceptance:**
+- [ ] Multi-pod safe (one dispatch per tick).
+- [ ] `Enabled=false` gates the loop for unrelated tests.
+- [ ] Dispatch failure does not kill the loop.
+
+### T8 — Endpoints (CRUD, per-mode RBAC, tenant-scoped)
+
+**Scope:** `ScheduledReportEndpoints` — `GET/GET{id}/POST/PATCH/DELETE
+/api/v1/orgs/{tenantId}/analytics/reports`. Mutating routes gated by the tenant_owner/tenant_admin
+policy (mirror `ConventionStoreEndpoints`); GET allowed for any member / sole user; hard tenant-scope
+guard (36-3); recipient validation (RFC-5322, non-empty).
+
+**Files:** new `src/Tamma.Api/Endpoints/ScheduledReportEndpoints.cs`; map in `src/Tamma.Api/Program.cs`.
+
+**Tests first:** `tests/Tamma.Api.Tests/Analytics/ScheduledReportEndpointsTests.cs` — RBAC matrix
+(owner/admin CUD; member 403 on CUD, 200 GET; cross-tenant 403/404; single-user full access);
+recipient validation; identical route shape both modes.
+
+**Acceptance:**
+- [ ] Endpoint shape identical between modes; auth middleware picks principal key.
+- [ ] Member → 403 on mutate, 200 on read; cross-tenant blocked.
+- [ ] Empty/malformed recipients → 400.
+
+---
+
+## Task order & dependencies
+
+T1 → T2 → T3 (parallel-safe with T4) → T4 → T5 → T6 → T7 → T8.
+T1/T2/T3 are the foundation; T5 depends on **Story 36-8 having landed** (`AnalyticsExportService`).
+T8 can be built any time after T2 but its tests need T1.
+
+## Risks
+
+- **36-8 not landed:** hard block — T5 calls `AnalyticsExportService`. Confirm 36-8 first; do not
+  stub a parallel exporter (non-goal).
+- **Idempotency is the spec's hard AC (AC7):** the `(report_id, period_key)` unique + insert-if-absent
+  is load-bearing. A bug here double-sends emails to customers. The replay test (T6) is mandatory.
+- **Email PII / CodeQL taint:** recipient/subject/body must never reach logs or DCB event `data` —
+  reference `outbox_msg_id` only. The outbox entities are already CodeQL-tainted; preserve that.
+- **Multi-pod double-dispatch:** mitigated by the advisory leader lock (T7) AND the per-period
+  idempotency (T6) as belt-and-suspenders — keep both.
+- **Time-zone / DST edge cases:** the cadence math (T3) is the subtle part; pin DST + month-rollover +
+  ISO-week tests before wiring it into the workflow.
+- **Platform digest leakage:** the digest must be aggregates-only and SaaS+OwnerAccess-gated;
+  feature-flag it off when 36-10 is absent so 36-9 ships independently.
+- **Migration discipline:** additive tables → normal `migrations add`, but verify
+  `has-pending-model-changes` = none and keep config in `TammaModelConfiguration.cs` only.
+- **Delivery semantics confusion:** `ANALYTICS.REPORT.SENT` = enqueued, not SMTP-accepted. Final
+  delivery status lives in `EMAIL.SENT.SUCCESS` / the outbox `failed` row keyed by `outbox_msg_id`.
+  Document this so ops don't misread the event.

--- a/docs/superpowers/plans/2026-06-17-37-1-sensitive-action-audit-taxonomy-and-curated-audit-record-pro-plan.md
+++ b/docs/superpowers/plans/2026-06-17-37-1-sensitive-action-audit-taxonomy-and-curated-audit-record-pro-plan.md
@@ -1,0 +1,265 @@
+# Plan — Story 37-1: Sensitive-Action Audit Taxonomy & Curated Audit-Record Projection
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development for every
+> phase below — this is a test-first (TDD) project; write the failing test before the implementation.
+> Use superpowers:executing-plans (or subagent-driven-development) to work the phases in order.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> Story file: `docs/stories/epic-37/story-37-1/37-1-sensitive-action-audit-taxonomy-and-curated-audit-record-pro.md`
+> MANDATORY first read: `docs/guides/BEFORE_YOU_CODE.md` + `.dev/{spikes,bugs,findings,decisions}/`.
+
+**Goal:** Define the canonical catalog of compliance-relevant sensitive actions and build a curated,
+queryable `audit_records` read-model materialized FROM the existing Epic 4 DCB event stream — a
+read-optimized product layer ON TOP OF the event store (not a replacement). Tenant-scope rows in
+the per-tenant schema, platform-scope rows in the control plane, per-mode ownership (`user_id` in
+single-user, `tenant_id` in SaaS), redacted payloads, idempotent + replayable from a sequence
+cursor, with the tamper-evidence hook (deterministic order + reserved hash columns) that Story 37-2
+will chain.
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane API + Elsa engine).
+Tests are xUnit under `apps/tamma-elsa/tests/Tamma.Api.Tests/` (+ `Tamma.Data.Tests`); docker-bound
+suites run via `sg docker -c "dotnet test ..."` (session docker group is stale — see project
+memory `reference_dotnet_test_docker`).
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO new event store.** Raw `DomainEvent` / `PlatformEvent` rows remain the immutable source of
+  truth. We READ them and project into `audit_records`. We never append/mutate/delete raw events
+  (story AC15). If `audit_records` is wrong, the fix is truncate-and-replay, never patch.
+- **NO re-emitting existing events.** `SECRET.*`, `IMPERSONATION.*`, `USER.ROLE_CHANGED.SUCCESS`,
+  `TENANT.MEMBER_ROLE_CHANGED.SUCCESS` are already emitted today; the catalog MAPS them. We add no
+  new emit call-sites for already-emitted types in this story.
+- **NO query/search/export API.** That is Story 37-10. This story ships only catalog + projection +
+  tables.
+- **NO hash chaining / tamper-evidence computation.** That is Story 37-2. We ship the deterministic
+  insertion order + the reserved nullable `record_hash` / `prev_record_hash` columns, left null.
+- **NO per-request hot-path coupling.** Projection is eventual (background cursor pass), never on
+  the request path (story AC9). A broken projector must not slow or fail a live action.
+- **NO change to resolution/emit semantics anywhere.** Detection is read-only over events already
+  flowing.
+- **NO targeting `packages/api`.** It is DELETED. Target `apps/tamma-elsa` only.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### The DCB substrate (READ source — do not modify the write path)
+
+| Artifact | Verified path | Notes |
+|---|---|---|
+| `DomainEvent` (tenant + CP DbSet) | `src/Tamma.Data/Entities/DomainEvent.cs` | `Id, Type, TenantId?, IssueNumber?, Tags(JSONB), Metadata, Data, CreatedAt, SequenceNumber(BIGSERIAL)`. `SequenceNumber` is the total-order cursor — the doc-comment explicitly names `AlertRuleEvaluator` as the precedent consumer. |
+| `PlatformEvent` (CP) | `src/Tamma.Data/Entities/PlatformEvent.cs` | Same shape + `UserId?`. Cross-tenant / platform-only events (`TENANT.*`, `ORCHESTRATOR.TICK.*`, pre-resolution installs). `TenantId` null = platform-only. |
+| `IEventRepository` / `EventRepository` | `src/Tamma.Data/Repositories/{IEventRepository,EventRepository}.cs` | `AppendAsync`, `QueryAsync`, `QueryWithPaginationAsync`, `ListByTenantAsync` (tenant audit, prefix match, global-query-filter defence-in-depth). Use the READ methods only. |
+| `TenantDbContext` | `src/Tamma.Data/TenantDbContext.cs` | Per-tenant schema. `DomainEvents` DbSet lives HERE → tenant `audit_records` go here. |
+| `ControlPlaneDbContext` | `src/Tamma.Data/ControlPlaneDbContext.cs` | CP context. Has both `DomainEvents` AND `PlatformEvents` DbSets → platform `audit_records` go here. |
+| `TammaModelConfiguration` | `src/Tamma.Data/TammaModelConfiguration.cs` | Single source for entity config across both contexts. New `AuditRecord` config goes here. |
+| Migrations | `src/Tamma.Data/Migrations/{Tenant,ControlPlane}/` | Both have separate migration trees — `audit_records` needs one in each. |
+
+### The cursor-projection precedent to clone (do NOT invent a new mechanism)
+
+- `src/Tamma.Api/Services/Alerts/Rules/AlertRuleEvaluator.cs` — background poller that reads new
+  `DomainEvent` + `PlatformEvent` rows BY `SequenceNumber`, persists progress, resumes on restart,
+  crash-isolates per tick. Cursor crash-safety + dual-stream (`cp.DomainEvents` + `cp.PlatformEvents`)
+  fetch + `LoadCursorAsync`/`SaveCursorAsync` are all there — the `AuditProjector` is structurally a
+  near-clone with a different "what to do per matched event" body.
+- `AlertEvaluatorCursor` (`src/Tamma.Data/Entities/AlertEvaluatorCursor.cs`) — `EvaluatorId`,
+  `LastDomainSequenceNumber`, `LastPlatformSequenceNumber`, `UpdatedAt`. Copy this shape into
+  `AuditProjectorCursor`.
+- Background-service options precedent: `AlertRuleEvaluatorOptions` / `NotificationDispatcherOptions`
+  have a `RunOnStartup` gate (so unrelated tests can disable the loop) — mirror for `AuditProjectorOptions`.
+- Other `BackgroundService` hosts to match the registration style: `TaskQueueProcessor`,
+  `NotificationDispatcher`, `RevealTokenSweeper`, `PlatformTaskWorker`.
+
+### Existing emitters the catalog must MAP (verified — not re-emitted)
+
+| Family | Verified source | Constants/codes |
+|---|---|---|
+| SECRET | `src/Tamma.Api/Services/Secrets/ISecretAccessAuditor.cs` → `SecretAuditEventTypes` | `SECRET.READ/WRITE/REVEAL/ROTATE.{STARTED,SUCCESS,FAILED}/VERSION.REVOKED/MIGRATED.*` |
+| IMPERSONATION | `src/Tamma.Api/Endpoints/Admin/AdminImpersonationsEndpoints.cs` | `IMPERSONATION.STARTED`, `IMPERSONATION.ENDED` (platform events) |
+| RBAC (platform role) | `src/Tamma.Api/Endpoints/AdminEndpoints.cs` (~215) | `USER.ROLE_CHANGED.SUCCESS` |
+| RBAC (tenant role) | `src/Tamma.Api/Endpoints/OrgEndpoints.cs` (~227) | `TENANT.MEMBER_ROLE_CHANGED.SUCCESS` (+ member add/remove, invite emitters in same file) |
+
+> The catalog-completeness test reflects over `SecretAuditEventTypes` and asserts each is present in
+> `SensitiveActionCatalog.ByCode`, so renaming/dropping an emitter without updating the catalog fails CI.
+
+### Redaction + mode seams (reuse)
+
+- `src/Tamma.Core/Redaction/CredentialRedactor.cs` — `public static string Clean(string?)`,
+  `Placeholder = "[REDACTED]"`; regexes for bearer tokens, `key=value` assignments, `tamma_sk_`
+  prefix, URL basic-auth, control chars. Use for `payload_json` before persist.
+- `src/Tamma.Api/Services/PromptStore/TammaMode.cs` — `ITammaModeProvider` (SingleUser | SaaS),
+  process-stable. Drives per-mode ownership key selection.
+- Per-mode XOR precedent: `prompt_overrides` `principal_xor` CHECK + `UNIQUE NULLS NOT DISTINCT`
+  (CLAUDE.md "Prompt Store Architecture" / "Storage").
+
+### Auth/policy seams (for later stories, noted now)
+
+- `OwnerAccess` / `PlatformOwnerAccess` policies registered in `src/Tamma.Api/Program.cs` (~971/986);
+  tenant scoping via `RequireTenantMembershipFilter` (`src/Tamma.Api/Authorization/`). Not needed in
+  37-1 (no endpoint), but 37-10 will use these.
+
+### Per-mode ownership — the mandatory two-scoping-model answer (per CLAUDE.md)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Who owns a curated **tenant-scoped** action record? | The sole user — keyed `user_id`, `tenant_id` NULL (no tenant dimension exists). | The tenant — keyed `tenant_id`, `user_id` NULL; lands in the tenant schema. |
+| Where does a **platform-scoped** event (TenantId null) materialize? | Single-user store, keyed `user_id`. | Control-plane `audit_records`, `tenant_id` null (platform row, never in a tenant's view). |
+| XOR invariant | `user_id` set / `tenant_id` null. | `tenant_id` set / `user_id` null. CHECK rejects both/neither. |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`). | same. |
+
+---
+
+## Architecture (detection-free; pure projection)
+
+**Raw DCB events → cursor scan → catalog match → classify + redact + key by mode → insert-if-absent
+into `audit_records`.** Mirrors `AlertRuleEvaluator` end-to-end for the cursor/background mechanics.
+
+1. **`SensitiveActionCatalog`** (`Tamma.Core/Audit/`) — pure const-class + immutable `ByCode` lookup
+   (mirrors `SecretAuditEventTypes`). The single source of "is this sensitive + how is it classified"
+   (category, severity, SOC2 control, target-type hint).
+2. **`AuditRecord`** entity + `audit_records` table in BOTH `TenantDbContext` (tenant schema) and
+   `ControlPlaneDbContext` (platform). XOR CHECK on (`user_id`,`tenant_id`), UNIQUE on
+   `source_event_id` (idempotency), `source_sequence_number` index (replay order / 37-2 chain),
+   reserved nullable `record_hash`/`prev_record_hash`.
+3. **`AuditProjectorCursor`** entity (clone of `AlertEvaluatorCursor`) — `LastDomainSequenceNumber`
+   (tenant) + `LastPlatformSequenceNumber` (platform).
+4. **`AuditProjector`** — cursor-tracked, idempotent, redacting projection. Skips non-catalog events,
+   inserts exactly one row per matched event in strict `SequenceNumber` order.
+5. **`AuditProjectorBackgroundService`** — `BackgroundService` host (poll interval + `RunOnStartup`
+   gate + crash-isolation per tick) + `AuditProjectionMetrics` (`tamma.audit.projection_lag` gauge).
+6. **DI:** `AuditServiceCollectionExtensions.AddTammaAudit(...)` wired in `Program.cs`.
+
+---
+
+## Phased TDD tasks
+
+### Phase 0 — Read & confirm (no code)
+
+- [ ] Read `BEFORE_YOU_CODE.md` + scan `.dev/{spikes,bugs,findings,decisions}/` for prior audit/event
+  projection work.
+- [ ] Read `AlertRuleEvaluator.cs` + `AlertEvaluatorCursor.cs` fully — confirm the cursor read +
+  dual-stream fetch + crash-isolation contract the projector will clone.
+- [ ] Read `SecretAuditEventTypes` (`ISecretAccessAuditor.cs`) — confirm const-class shape to mirror.
+- [ ] Confirm `dotnet build` is green at HEAD before starting (baseline).
+
+### Phase 1 — Taxonomy catalog (`Tamma.Core`, pure, no DB) — story AC1–AC3, AC13a
+
+- [ ] **RED:** `tests/Tamma.Api.Tests/Audit/SensitiveActionCatalogTests.cs` — assert ≥30 codes, all
+  11 `AuditCategory` values populated, every descriptor has a non-empty SOC2 control id, and every
+  constant in `SecretAuditEventTypes` (+ `IMPERSONATION.STARTED/ENDED`, `USER.ROLE_CHANGED.SUCCESS`,
+  `TENANT.MEMBER_ROLE_CHANGED.SUCCESS`) is a key in `SensitiveActionCatalog.ByCode`.
+- [ ] **GREEN:** add `AuditCategory.cs`, `AuditSeverity.cs`, `SensitiveActionDescriptor.cs`,
+  `SensitiveActionCatalog.cs` under `src/Tamma.Core/Audit/`. Populate `ByCode`.
+- [ ] **REFACTOR:** ensure `IsSensitive(eventType)` + `ByCode` are the only lookup path.
+
+### Phase 2 — `AuditRecord` + `AuditProjectorCursor` entities, EF config, migrations — AC4–AC6, AC12
+
+- [ ] **RED:** `tests/Tamma.Data.Tests/Audit/AuditRecordModelTests.cs` — XOR CHECK rejects both/neither
+  set; UNIQUE `source_event_id` rejects a duplicate; tenant global query filter scopes reads;
+  `has-pending-model-changes` → none (model-config completeness test).
+- [ ] **GREEN:** add `AuditRecord.cs` + `AuditProjectorCursor.cs` entities; register DbSets in both
+  contexts; add entity config (CHECK, unique index, `SourceSequenceNumber` index, query filter,
+  reserved hash columns) in `TammaModelConfiguration.cs`.
+- [ ] `dotnet ef migrations add AddAuditRecords` for BOTH Tenant + ControlPlane trees; verify
+  `has-pending-model-changes` reports none; apply + roll back cleanly (docker-bound → `sg docker -c`).
+
+### Phase 3 — `AuditRecordRepository` (insert-if-absent + cursor) — AC8 plumbing
+
+- [ ] **RED:** `tests/Tamma.Data.Tests/Audit/AuditRecordRepositoryTests.cs` — `InsertIfAbsentAsync`
+  returns true on first insert, false (no second row) on duplicate `source_event_id`; cursor
+  load/save round-trips.
+- [ ] **GREEN:** `IAuditRecordRepository` + `AuditRecordRepository` over the appropriate context
+  (tenant vs CP selected by caller/mode). Insert-if-absent via unique-index catch (mirror
+  `prompt_overrides` upsert handling).
+
+### Phase 4 — `AuditProjector` (classify + redact + key by mode + skip) — AC7, AC8, AC10, AC11, AC15
+
+- [ ] **RED:** `tests/Tamma.Api.Tests/Audit/AuditProjectorTests.cs`:
+  - idempotency — run twice over a mixed batch → one row per catalog match, zero for non-catalog;
+    truncate + cursor 0 → identical replay.
+  - non-catalog skip — `WORKFLOW.STEP_COMPLETED` → zero rows.
+  - per-mode key — SaaS tenant event → `tenant_id` set; single-user → `user_id` set.
+  - redaction — `SECRET.WRITE` with fake `tamma_sk_`/`Bearer`/`password=` in `Data` → `payload_json`
+    has `[REDACTED]`, never plaintext.
+  - no-write-path — spy `IEventRepository` asserts only read methods called (no append/mutate/delete).
+- [ ] **GREEN:** `IAuditProjector` + `AuditProjector` — `ProjectBatchAsync`: load cursor → read new
+  events ordered by `SequenceNumber` → for each, `SensitiveActionCatalog.ByCode.TryGetValue` (skip
+  miss) → `BuildAuditRecord` (map actor/target/outcome from `Tags`+`Data`) → `CredentialRedactor.Clean`
+  payload → `AssignOwnership` by `_mode.Current` → `InsertIfAbsentAsync` → save cursor. Strict
+  `SequenceNumber` order (37-2 needs it).
+- [ ] **REFACTOR:** extract `BuildAuditRecord` / `AssignOwnership` / `ProjectPayload` as testable units.
+
+### Phase 5 — Background host + lag metric + scope isolation — AC9, AC14
+
+- [ ] **RED:** `tests/Tamma.Api.Tests/Audit/AuditRecordScopeIsolationTests.cs` — tenant-A event never
+  in tenant-B schema; tenant-scoped event never in CP `audit_records` (and vice-versa); tenant global
+  filter rejects cross-tenant read. Plus a lag-metric test (M un-projected → gauge M; after pass → 0)
+  and a `RunOnStartup=false` gating test.
+- [ ] **GREEN:** `AuditProjectorBackgroundService` (poll loop + `RunOnStartup` gate + per-tick
+  crash-isolation, cloning `AlertRuleEvaluator`); `AuditProjectorOptions`; `AuditProjectionMetrics`
+  (OTel gauge `tamma.audit.projection_lag`). Tenant fan-out per active tenant context; platform reads
+  CP `PlatformEvents`.
+
+### Phase 6 — DI wiring + full suite green — AC6, AC13, AC15
+
+- [ ] **GREEN:** `AuditServiceCollectionExtensions.AddTammaAudit(...)`; wire in `Program.cs` (mirror
+  `AlertServiceCollectionExtensions`). Register repo, projector, background service, metrics.
+- [ ] Run the full xUnit suite (`sg docker -c "dotnet test ..."`) — green; `has-pending-model-changes`
+  → none; `dotnet build` warning-clean for new files.
+
+---
+
+## Sequencing
+
+Phase 0 → 1 → 2 → 3 → 4 → 5 → 6, strictly in order (each phase's tests depend on the prior phase's
+types). Phase 1 (catalog) is the only phase with zero DB dependency and can be reviewed/merged on its
+own if the wave is split. Phases 2–3 are pure data layer; 4–5 are the projection engine; 6 is wiring.
+
+---
+
+## Risks
+
+- **"Rebuild the event store" temptation.** Highest-impact failure mode. Mitigation: the projector is
+  read-only over `DomainEvent`/`PlatformEvent`; AC15's no-write-path test is load-bearing; `audit_records`
+  is rebuildable (truncate + cursor 0). Keep the back-reference (`source_event_id`/`source_sequence_number`)
+  on every row.
+- **Scope-derivation bug (tenant vs platform vs single-user).** A platform-internal event leaking into
+  a tenant's audit view is a confidentiality breach. Mitigation: AC11/AC13c/AC14 pin the matrix; route
+  on raw `TenantId` AND `_mode.Current`; tenant global query filter as defence-in-depth (same as
+  `EventRepository.ListByTenantAsync`).
+- **Un-redacted payload leak.** `payload_json` is the only field that can carry secrets. Mitigation:
+  redact BEFORE persist (never on read); AC10 test; ERROR-and-skip (don't advance cursor) if the
+  redactor throws — never persist an un-redacted payload.
+- **Idempotency under concurrency / replay.** Mitigation: UNIQUE `source_event_id` + insert-if-absent
+  (catch unique violation → treat as already-projected). Cursor crash mid-batch may re-scan — the
+  unique index makes re-scan a no-op (same guarantee `AlertRuleEvaluator` relies on for its sink-side
+  dedup).
+- **Catalog drift from emitters.** A future rename of an emitted type silently drops it from the audit
+  trail. Mitigation: catalog-completeness reflection test (AC13a) over `SecretAuditEventTypes` fails CI.
+- **Event-store topology shift (Story 28-1 / Epic 30).** Tenant events are moving per-tenant. Mitigation:
+  read tenant events via the tenant context and platform events via CP explicitly (don't assume one
+  table); the projector's tenant fan-out mirrors the direction `AlertRuleEvaluator`'s doc-comment
+  describes for its own migration.
+- **Migration discipline.** `audit_records` is additive on both trees, but a missed `TammaModelConfiguration`
+  entry leaves `has-pending-model-changes` dirty. Mitigation: config in `TammaModelConfiguration.cs`
+  only; verify pending-changes → none in Phase 2 and again in Phase 6.
+- **Hot-path coupling regression.** If projection ever runs inline, a live action could block on it.
+  Mitigation: projection is ONLY in the background service; no projector call from any request handler
+  (AC9). No DI of `IAuditProjector` into endpoint code.
+
+## Acceptance criteria (plan-level — maps to story ACs)
+
+- [ ] `SensitiveActionCatalog` ships ≥30 codes across all 11 categories, each with severity + SOC2
+  control; catalog-completeness test green over existing emitters (story AC1–3, AC13a).
+- [ ] `audit_records` exists in BOTH tenant schema and control plane with the full column set + XOR
+  CHECK + unique `source_event_id` + reserved hash columns; migrations apply/rollback; `has-pending-model-changes`
+  → none (story AC4–6, AC12).
+- [ ] `AuditProjector` materializes exactly one redacted row per catalog-matched event, skips
+  non-catalog, keys by mode, routes tenant vs platform correctly, is idempotent/replayable, and never
+  writes to the raw event store (story AC7–8, AC10–11, AC15).
+- [ ] Background projection is eventual + non-blocking with a working lag gauge and `RunOnStartup`
+  gate (story AC9).
+- [ ] Cross-scope isolation holds (no cross-tenant / no tenant↔platform bleed) (story AC14).
+- [ ] Full xUnit suite green via `sg docker -c "dotnet test ..."`; `dotnet build` clean.

--- a/docs/superpowers/plans/2026-06-17-37-10-sensitive-action-audit-emission-coverage-plan.md
+++ b/docs/superpowers/plans/2026-06-17-37-10-sensitive-action-audit-emission-coverage-plan.md
@@ -1,0 +1,287 @@
+# Story 37-10: Sensitive-Action Audit Emission Coverage — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan step-by-step. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every step writes the
+> assertion before the emission code.
+
+**Goal:** Close the emission gaps so the Story 37-1 sensitive-action **catalog** is actually fed.
+Instrument the action sites that today mutate sensitive state without an audit event — BYOK/provider
+keys, billing/plan/subscription, auth/login + token refresh + API-key auth, agent actions, persona/
+config edits, data export — mapping each onto the 37-1 catalog and routing each event to the correct
+scope (tenant `domain_events` vs control-plane `platform_events`). Reuse the existing single-source
+emitters (`SECRET.*`, `IMPERSONATION.*`, `TENANT.MEMBER_*`, `AUTH.REFRESH_REUSE_DETECTED`) by mapping
+them into the catalog — never by re-emitting.
+
+**Story file:** `docs/stories/epic-37/story-37-10/37-10-sensitive-action-audit-emission-coverage.md`
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane API + Elsa engine).
+Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/` (xUnit; docker-bound suites run via
+`sg docker -c "dotnet test ..."`). **`packages/api` is DELETED — never a target.**
+
+**Required reading before code:** `docs/guides/BEFORE_YOU_CODE.md`, Story 37-1 (catalog +
+`audit_records` projection), this story file.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO new catalog model.** Story 37-1 owns `SensitiveActionCatalog` + the `audit_records` projection.
+  37-10 only **adds entries** to the catalog and **wires emissions**. If 37-1 is not merged, this plan
+  is blocked on it (see Dependencies).
+- **NO re-emission of already-audited actions.** `SECRET.*`, `IMPERSONATION.*`, `TENANT.MEMBER_*`,
+  `AUTH.REFRESH_REUSE_DETECTED` keep their one emission; 37-10 maps them into the catalog and tests
+  the single emission. Adding a second event for these is a defect, not a feature.
+- **NO change to auth/billing/secret behaviour.** Login still logs in, a secret write still writes,
+  a plan change still changes the plan. Emission is a side effect that must never alter, delay, or
+  roll back the action (never-throws contract, mirrors `ISecretAccessAuditor`).
+- **NO new delivery / alerting.** This story feeds the audit trail; alert rules over these event types
+  are a separate concern (Story 5.6 / missing-config alert pipeline already exists if needed).
+- **NO secret material in events.** Metadata only — provider, mode, version number, key prefix.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main)
+
+### Already-emitting sites (reuse — map into catalog, do NOT re-emit)
+
+| Site | Event(s) today | Emission mechanism |
+|---|---|---|
+| `src/Tamma.Api/Services/Secrets/Query/SecretQueryService.cs` (~195), `Reveal/SecretRevealService.cs`, `Stopgap/StopgapSecretMigrator.cs` | `SECRET.WRITE`, `SECRET.ROTATE.*`, `SECRET.REVEAL`, `SECRET.VERSION.REVOKED`, `SECRET.MIGRATED.*` (`SecretAuditEventTypes`) | `ISecretAccessAuditor.EmitAsync` |
+| `src/Tamma.Api/Endpoints/OrgEndpoints.cs` (~227, 278, 367, 507, 618) | `TENANT.MEMBER_ROLE_CHANGED/REMOVED/INVITED/INVITE_RESENT/JOINED.SUCCESS` | `EmitTenantEvent(IEventRepository, ...)` → `domain_events` |
+| Impersonation | `IMPERSONATION.STARTED` / `IMPERSONATION.ENDED` | DomainEvent/PlatformEvent |
+| `src/Tamma.Api/Endpoints/AuthEndpoints.cs` (~1123) | `AUTH.REFRESH_REUSE_DETECTED` | `PlatformEvent` |
+
+### Silent sites (NEW emission needed)
+
+| Site | Today | Add |
+|---|---|---|
+| Secret cabinet, `SecretPurpose.ApiKey` + `SecretScope.Tenant` writes | `SECRET.WRITE`/`ROTATE` only | curated `BYOK.PROVIDER_KEY.SET/ROTATED/REMOVED` + `BILLING.BYOK_MODE_CHANGED` |
+| `AuthEndpoints.Login` (~543) | no login audit event | `AUTH.LOGIN.SUCCESS` / `AUTH.LOGIN.FAILURE(reason)` |
+| `AuthEndpoints.Refresh` (~653) | reuse event only | `AUTH.TOKEN.REFRESHED` |
+| `Auth/ApiKeyAuthHandler.cs` `BuildSuccessTicket` (~526) | no auth-usage event | `AUTH.APIKEY.USED` (throttled) |
+| `Endpoints/Admin/AdminTenantsEndpoints.cs` (~629) | `PLAN.UPDATED` | re-type → `BILLING.PLAN_CHANGED`; `SUBSCRIPTION.*` |
+| `Endpoints/AgentEndpoints.cs` (~93) + `AGENT.DISPATCH.*`/`AGENT.RESULTS.*` | `AGENT_CONFIG.UPDATED.SUCCESS` (no `agentId`) | add `agentId` tag; catalog `AGENT.ACTION.*` |
+| Prompt-store / convention-store admin write endpoints | persona/config edits unaudited | `CONFIG.PERSONA_CHANGED` |
+| Audit/DSAR export endpoint(s) (37-1/37-x) | — | `DATA.EXPORT.REQUESTED/COMPLETED` |
+
+### Emission primitives (reuse)
+
+- `IEventRepository.AppendAsync(DomainEvent)` — `src/Tamma.Data/Repositories/IEventRepository.cs`.
+  `DomainEvent` has `Type`, `TenantId`, `Tags` (JSON), `Metadata` (JSON), `Data` (JSON), `CreatedAt`.
+- `IPlatformEventPublisher.AppendAndPublishAsync(PlatformEvent)` —
+  `src/Tamma.Data/Abstractions/IPlatformEventPublisher.cs`. Platform/control-plane scope.
+- Established shape: `OrgEndpoints.EmitTenantEvent` (domain), `AuthEndpoints.BuildRefreshReuseEvent`
+  (platform). Metadata convention: `{"workflowVersion":"1.0.0","eventSource":"system"}`.
+- `ITammaModeProvider` (`src/Tamma.Api/Services/PromptStore/TammaMode.cs`) — process-stable mode.
+- `ApiKeyAuthHandler` resolves services from an injected `IServiceProvider` — so it can resolve the
+  emitter without a ctor change.
+
+### NOT present yet (from 37-1 — prerequisite)
+
+- `src/Tamma.Core/Audit/SensitiveActionCatalog.cs` — does not exist at HEAD; comes from Story 37-1.
+- No `audit_records` table/projection yet. **This plan is blocked until 37-1 lands those.**
+
+---
+
+## Architecture
+
+**One emitter, one scope-routing decision, catalog-validated.**
+
+```
+call site ──► ISensitiveActionEmitter.EmitAsync(SensitiveAction{ Type, TenantId, Actor, Tags, Data })
+                         │  (Type must be in SensitiveActionCatalog — else log+drop, never throw)
+                         ▼
+            TenantId != null ──► IEventRepository.AppendAsync(DomainEvent)        (tenant scope)
+            TenantId == null ──► IPlatformEventPublisher.AppendAndPublish(...)    (control-plane)
+                         │
+                         ▼
+            Story 37-1 projection ──► audit_records  (correct scope)
+```
+
+- The emitter is the single place that decides tenant vs platform, runs the catalog typo-guard, and
+  runs the defensive redaction strip. Never throws to the caller.
+- Curated `BYOK.*` events are derived **alongside** the existing `SECRET.*` emission (a decorator on
+  `ISecretAccessAuditor`, or an emitter call in the secret facade gated on `ApiKey`+`Tenant`), so one
+  cabinet write yields one `SECRET.*` + one `BYOK.*` — never a second secret write.
+
+### Per-mode ownership (mandatory two-scoping-model answer)
+
+| Action class | single-user | SaaS |
+|---|---|---|
+| BYOK, plan/subscription, persona/config (tenant), tenant agent action, tenant export | Sole user's personal tenant → `TenantId` set, lands in their feed | Tenant → `TenantId` set, `domain_events`, visible to tenant_owner/admin |
+| Platform-owner login, impersonation, system-scope persona/config, API-key auth at platform edge | Sole user (one principal) | Platform owner → `platform_events`, `TenantId` null, never exposed to tenants |
+| Login failure | User's feed | Platform-scoped (no trusted tenant yet); email + reason only |
+
+---
+
+## Story breakdown
+
+### S1: `ISensitiveActionEmitter` + catalog extension (core, no call-site wiring)
+
+**Scope:** The single emission seam + the catalog entries. No site instrumentation yet.
+
+**Files:**
+- New: `src/Tamma.Api/Services/Audit/ISensitiveActionEmitter.cs`, `SensitiveActionEmitter.cs`,
+  `SensitiveAction.cs` (record + tag/data dictionaries; scope derived from `TenantId`).
+- Modify: `src/Tamma.Core/Audit/SensitiveActionCatalog.cs` (NEW from 37-1) — add catalog entries for
+  reused types (`SECRET.*`, `IMPERSONATION.*`, `TENANT.MEMBER_*`, `AUTH.REFRESH_REUSE_DETECTED`) and
+  new types (`BYOK.PROVIDER_KEY.SET/ROTATED/REMOVED`, `BILLING.PLAN_CHANGED`, `BILLING.BYOK_MODE_CHANGED`,
+  `SUBSCRIPTION.CREATED/UPDATED/CANCELED`, `AUTH.LOGIN.SUCCESS/FAILURE`, `AUTH.TOKEN.REFRESHED`,
+  `AUTH.APIKEY.USED`, `AGENT.ACTION.*`, `CONFIG.PERSONA_CHANGED`, `DATA.EXPORT.REQUESTED/COMPLETED`).
+- New: `src/Tamma.Api/Extensions/AuditEmissionServiceCollectionExtensions.cs`; wire in `Program.cs`.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Audit/SensitiveActionEmitterTests.cs` —
+`TenantId` set → `IEventRepository.AppendAsync` called with that `TenantId`, `IPlatformEventPublisher`
+NOT called; `TenantId` null → `IPlatformEventPublisher.AppendAndPublishAsync` called, repo NOT called;
+un-cataloged `Type` → dropped + WARN, neither sink called; sink throws → swallowed, EmitAsync returns
+without throwing; redaction guard strips a `tamma_sk_`-shaped value from `Data`; metadata shape
+matches the repo convention.
+
+**Acceptance criteria:**
+- [ ] Every reused + new event type is in `SensitiveActionCatalog`.
+- [ ] Scope routing: `TenantId` non-null → domain stream; null → platform stream.
+- [ ] `EmitAsync` never throws to the caller; un-cataloged type is logged + dropped.
+- [ ] Redaction guard removes secret-shaped values; full suite stays green.
+
+### S2: BYOK / provider-key emission (depends S1)
+
+**Scope:** Derive `BYOK.PROVIDER_KEY.*` + `BILLING.BYOK_MODE_CHANGED` from the secret-cabinet
+`ApiKey`+`Tenant` write path, alongside the existing `SECRET.*` emission.
+
+**Files:**
+- Modify: secret facade / a decorator on `ISecretAccessAuditor` (`src/Tamma.Api/Services/Secrets/`)
+  — on `SECRET.WRITE`/`ROTATE`/version-revoke for `Reference.Purpose == ApiKey &&
+  Reference.Scope == Tenant`, call `ISensitiveActionEmitter` with `BYOK.PROVIDER_KEY.SET/ROTATED/REMOVED`,
+  tags `provider`, `tenantId`, `actor`, `mode` (`byok`|`platform-provided`, from 32-3 resolution).
+- BYOK-mode toggle site (provider config flip byok↔platform-provided) → `BILLING.BYOK_MODE_CHANGED`.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Audit/ByokEmissionTests.cs` — a tenant ApiKey write emits
+exactly one `SECRET.WRITE` AND one `BYOK.PROVIDER_KEY.SET` (not two cabinet writes); rotate →
+`ROTATED`; revoke → `REMOVED`; a platform-scope or non-ApiKey secret write does NOT emit a `BYOK.*`;
+redaction: stored `audit_record` carries provider/mode/version only, zero key bytes; mode toggle emits
+`BILLING.BYOK_MODE_CHANGED` with old/new mode.
+
+**Acceptance criteria:**
+- [ ] One cabinet write → one `SECRET.*` + one `BYOK.*`; no double secret write.
+- [ ] `BYOK.*` only for `ApiKey`+`Tenant` secrets; tagged provider/tenant/actor/mode.
+- [ ] Redaction test passes (no key material in the audit record).
+
+### S3: Auth/login emission (depends S1)
+
+**Scope:** Login success/failure, token refresh, API-key auth.
+
+**Files:**
+- Modify: `src/Tamma.Api/Endpoints/AuthEndpoints.cs` — `Login` emits `AUTH.LOGIN.SUCCESS` (success
+  path ~644) / `AUTH.LOGIN.FAILURE(reason)` (all failure returns: bad creds, lockout via
+  `ILoginLockoutService`, unverified email); `Refresh` emits `AUTH.TOKEN.REFRESHED` on success.
+  `ip`/`user_agent` from `HttpContext`. Add `[FromServices] ISensitiveActionEmitter`.
+- Modify: `src/Tamma.Api/Auth/ApiKeyAuthHandler.cs` — `BuildSuccessTicket` (~526) emits
+  `AUTH.APIKEY.USED` (throttled per `(apiKeyId, time bucket)` using the existing throttle pattern),
+  tags `tenantId`, `apiKeyPrefix`, `scope`, `ip`. Resolve emitter from injected `IServiceProvider`.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Audit/AuthEmissionTests.cs` — successful login →
+`AUTH.LOGIN.SUCCESS` (userId, ip, userAgent, no password); each failure reason →
+`AUTH.LOGIN.FAILURE` with that `reason` + email, no password; lockout → `reason=locked_out`; refresh
+→ `AUTH.TOKEN.REFRESHED`; reuse path still emits ONLY `AUTH.REFRESH_REUSE_DETECTED` (no duplicate);
+100 API-key auths in one bucket → one (or sampled-N) `AUTH.APIKEY.USED`; scope: login success
+tenant/platform per resolved active tenant, login failure platform-scoped.
+
+**Acceptance criteria:**
+- [ ] Login success + every failure reason emit the right catalog code with ip/user_agent.
+- [ ] Token refresh emits `AUTH.TOKEN.REFRESHED`; reuse path unchanged (no double).
+- [ ] `AUTH.APIKEY.USED` is throttled (no per-request flood); prefix only, never the key.
+
+### S4: Billing / plan / subscription (depends S1)
+
+**Scope:** Re-type plan-update to the catalog; add subscription lifecycle events.
+
+**Files:**
+- Modify: `src/Tamma.Api/Endpoints/Admin/AdminTenantsEndpoints.cs` (~629) — `PLAN.UPDATED` →
+  `BILLING.PLAN_CHANGED` (keep `PLAN.UPDATED` as a legacy catalog alias if dashboards depend on it),
+  tags `tenantId`, `actor`, data `{ oldPlanSlug, newPlanSlug }`. Subscription create/update/cancel →
+  `SUBSCRIPTION.*`. If no subscription entity exists, wire at the `Plan`/`BudgetConfig` change site
+  that stands in for subscription state and note the gap in Dev Notes.
+
+**Tests (first):** extend `tests/Tamma.Api.Tests/` billing/admin tests — plan change emits
+`BILLING.PLAN_CHANGED` with old/new slug (no card data); subscription mutations emit the matching
+`SUBSCRIPTION.*`; events land tenant-scoped.
+
+**Acceptance criteria:**
+- [ ] Plan change emits `BILLING.PLAN_CHANGED`; the silent Epic 20 TS path is replaced.
+- [ ] Subscription mutations emit `SUBSCRIPTION.CREATED/UPDATED/CANCELED`, tenant-scoped, no PII.
+
+### S5: Agent actions + persona/config + data export (depends S1)
+
+**Scope:** `agentId` tagging + catalog `AGENT.ACTION.*`; persona/config edit events; export events.
+
+**Files:**
+- Modify: `src/Tamma.Api/Endpoints/AgentEndpoints.cs` (~93) — add `agentId` to
+  `AGENT_CONFIG.UPDATED.SUCCESS` tags; map into catalog. Thread `agentId` into `AGENT.DISPATCH.*` /
+  `AGENT.RESULTS.*` tags at their emission sites (32-6 trail).
+- Modify: prompt-store / convention-store admin write endpoints — emit `CONFIG.PERSONA_CHANGED`
+  (scope system/tenant, role, action, actor, tenantId) on persona/template edits.
+- Modify: audit/DSAR export endpoint(s) (37-1/37-x) — emit `DATA.EXPORT.REQUESTED` on accept and
+  `DATA.EXPORT.COMPLETED` on finish (counts only).
+
+**Tests (first):** extend agent/prompt/convention/export tests — agent dispatch/results/config carry
+`agentId`; per-tenant agent trail reconstructable from `audit_records`; persona edit emits
+`CONFIG.PERSONA_CHANGED`; export emits paired `DATA.EXPORT.*` with counts, no payload bytes.
+
+**Acceptance criteria:**
+- [ ] Agent actions carry `agent_id`; `AGENT.ACTION.*` in catalog; tenant-scoped trail visible.
+- [ ] Persona/config edits and data exports emit their catalog events, scope-correct, redaction-safe.
+
+### S6: Coverage test + catalog mapping assertions (depends S1-S5)
+
+**Scope:** The AC15 enumerated coverage test + the AC1/AC14 no-double-emission assertions.
+
+**Files:**
+- New: `tests/Tamma.Api.Tests/Audit/SensitiveActionCoverageTests.cs` — one parameterized case per
+  site (BYOK set/rotate/remove, BYOK-mode, plan, subscription ×3, login success, login failure ×reasons,
+  token refresh, API-key auth, agent dispatch+results, persona/config, data export): assert catalog
+  code, required tags (`actor`, `tenantId`/null, site-specific), and that the 37-1 projection writes
+  the `audit_record` to the correct scope.
+- No-double-emission: membership role change → exactly one `TENANT.MEMBER_ROLE_CHANGED.SUCCESS`;
+  secret write → exactly one `SECRET.WRITE` + one `BYOK.PROVIDER_KEY.SET`.
+- Cross-tenant leakage: a tenant audit query never returns another tenant's sensitive rows.
+- Mode matrix: single-user vs SaaS placement of a system-scope action.
+
+**Acceptance criteria:**
+- [ ] The coverage test enumerates every site and is green.
+- [ ] No reused site double-emits; scope routing + redaction asserted end-to-end.
+- [ ] `sg docker -c "dotnet test ..."` full suite green.
+
+---
+
+## Story order & dependencies
+
+S1 → (S2, S3, S4, S5 in parallel) → S6. S1 is the only hard prerequisite for the wiring stories; S6
+needs them all. **The whole plan is blocked on Story 37-1** (the `SensitiveActionCatalog` type and the
+`audit_records` projection must exist first — verified absent at HEAD).
+
+External deps: Epic 29 (secret cabinet — S2), Epic 32 / 32-3 / 32-6 (BYOK mode resolution + agent
+trail — S2/S5), Epic 20 re-targeted to C# billing (S4), Epic 16/18 auth (S3), Epic 34/35 billing
+surface (S4).
+
+## Risks
+
+- **37-1 not merged.** Hard blocker — `SensitiveActionCatalog` and `audit_records` don't exist yet.
+  Confirm 37-1 is in before starting; if implementing the wave together, S1 depends on 37-1's S-final.
+- **Double-emission.** The classic defect: adding a second event for an already-audited action, or
+  re-writing a secret to derive a `BYOK.*` payload. Mitigation: the reuse-vs-new table is authoritative;
+  S6 asserts exactly-one per reused site, and S2 asserts one cabinet write → one `SECRET.*` + one
+  `BYOK.*`.
+- **Wrong-scope leak.** A tenant event in `platform_events` (invisible to the tenant) or a
+  platform-owner action in a tenant stream (leaks operator activity). Mitigation: one emitter makes the
+  decision in one tested place; S6 has a cross-tenant leakage test.
+- **API-key auth flood.** Emitting `AUTH.APIKEY.USED` on every request floods the trail. Mitigation:
+  throttle keyed on `(apiKeyId, time bucket)`; S3 asserts a 100-request burst yields one/sampled-N.
+- **Redaction regression.** A caller passes a raw key in `Data`. Mitigation: defensive strip in the
+  emitter (belt-and-suspenders), plus the S2/S3/S4 redaction assertions that feed real-looking secrets
+  and assert zero key bytes land.
+- **Never-throws contract is load-bearing.** A broken event sink must not 500 a login or roll back a
+  secret write. Mitigation: emitter swallows + logs (mirrors `ISecretAccessAuditor`); S1 tests the
+  sink-throws path.
+- **Subscription entity may not exist on the C# surface.** S4 falls back to `Plan`/`BudgetConfig`
+  change sites and documents the gap rather than inventing a new entity in this story.

--- a/docs/superpowers/plans/2026-06-17-37-11-soc2-aligned-control-mapping-and-evidence-pack-plan.md
+++ b/docs/superpowers/plans/2026-06-17-37-11-soc2-aligned-control-mapping-and-evidence-pack-plan.md
@@ -1,0 +1,290 @@
+# Story 37-11 — SOC2-Aligned Control Mapping & Evidence Pack
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation. Read `docs/guides/BEFORE_YOU_CODE.md` first.
+
+**Goal:** Turn the Epic 37 audit substrate into an auditor-facing compliance product. Ship a
+code-resident **ControlCatalog** that maps SOC2 Trust Services Criteria (CC6 access, CC7 monitoring,
+CC8 change management, CC1/CC2 governance, A1 availability — plus ISO 27001 Annex A overlaps) to the
+real Tamma controls that satisfy them (auth/RBAC, secret cabinet encryption, audit logging, access
+reviews, backups, change management), evaluate each control to **satisfied / gap** against the audit
+read-model, and generate an **on-demand, signed, encrypted, expiring evidence pack** (control→evidence
+map + chain verification + retention snapshot + legal-hold state + config attestations + coverage
+summary) — platform-level for Tamma's own SOC2 and per-tenant for tenants under their own attestation.
+
+**Story file:** `docs/stories/epic-37/story-37-11/37-11-soc2-aligned-control-mapping-and-evidence-pack.md`
+(Status: drafted; 14 ACs).
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` — control-plane API + Elsa engine.
+Catalog domain logic in `Tamma.Core/Compliance/`; evidence collection + endpoints in
+`Tamma.Api/Services/Compliance/` + `Endpoints/ComplianceEndpoints.cs`; persistence in `Tamma.Data`.
+Tests in `apps/tamma-elsa/tests/Tamma.Core.Tests/Compliance/` and `tests/Tamma.Api.Tests/Compliance/`
+(xUnit; docker-bound suites run via `sg docker -c "dotnet test ..."`).
+
+**`packages/api` is DELETED — never a target.** All code is C#.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO new audit events, retention machinery, hash-chain, export crypto, or legal-hold logic.** This
+  story READS the Epic 37 substrate and MAPS it. It owns exactly two new event types
+  (`COMPLIANCE.EVIDENCE_PACK.GENERATED` / `.DOWNLOADED`) and the evidence-pack artifact metadata —
+  nothing else in the audit pipeline.
+- **NO bespoke signing/encryption.** The evidence pack is produced through 37-4 `AuditExportService`,
+  inheriting its sign/encrypt/expiry guarantees. If a byte of crypto is written in this story, it is
+  wrong.
+- **NO DB-resident control framework.** The catalog is policy-as-code (mirrors `SystemPrompts.cs` /
+  `BuiltInAlertRules.cs`) — version-controlled, PR-reviewed; only generated artifacts + evidence live
+  in the DB.
+- **NO secret exfiltration via attestations.** Config attestations prove POSTURE (booleans/counts/
+  cadence), never secret values, connection strings, or API keys.
+- **NO per-user override layer in SaaS.** Compliance posture is tenant- or platform-owned; members get
+  read-only views (mirrors prompt-store RBAC).
+- **NO heavy dashboard UI.** This story ships the control-status data + DTOs; the visual tab is a thin
+  add in 37-10.
+- **NO re-implementation of unmerged dependencies.** Where 37-1/37-3/37-4/37-5/37-6 are not yet on
+  disk, code against narrow consumer interfaces + test doubles and bind to the real impl when it lands.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main)
+
+### What exists on disk (real evidence sources the catalog maps to)
+
+| Control area | Verified artifact |
+|---|---|
+| Auth / RBAC | `src/Tamma.Api/Program.cs` policies `OwnerAccess` (~971), `PlatformOwnerAccess` (~986), `MemberAccess` (~991); `src/Tamma.Api/Auth/Permissions.cs`; `src/Tamma.Api/Authorization/TenantRoleHierarchy.cs`, `RequireTenantMembershipFilter.cs` (`TenantRole` item key, `IsAtLeast(role, Admin)`). |
+| Encryption / secret cabinet (Epic 29) | `src/Tamma.Api/Services/Secrets/` — `KekProvider`, `KekRotationCoordinator`, `KekRotationMetrics`, `SecretRow`/`SecretVersionRow` entities; AES-GCM at rest via `Services/Provisioning/TenantSecretProtector.cs`. |
+| Audit logging | `src/Tamma.Data/Entities/DomainEvent.cs` (Type/TenantId/Tags/Metadata/Data/CreatedAt/`SequenceNumber`); `IEventRepository.AppendAsync(DomainEvent)`; `ISecretAccessAuditor` codes (`SECRET.READ/WRITE/ROTATE.STARTED/ROTATE.SUCCESS/ROTATE.FAILED/REVEAL/VERSION.REVOKED/MIGRATED.*`). |
+| Monitoring / alerting | `src/Tamma.Api/Services/Alerts/IAlertSink.RaiseAsync(AlertPayload)`; `AlertRuleEvaluator` (polls `DomainEvents`); `ALERT.RAISED` event. |
+| Access review / change | `AdminImpersonation` entity + `AdminImpersonationService`; `WorkflowDefinition`/`WorkflowInstance` entities; `KekRotation` entity. |
+| Backups (Epic 28) | `src/Tamma.Api/Services/Provisioning/TenantMoveService.cs`; tenant-database pool placement; Cranl backup capability flags. |
+| Async job pattern | `Services/PlatformTasks/PlatformTaskWorker.cs` + `IPlatformTaskHandler`; `Results.Accepted` 202 precedent in `AdminEndpoints.cs` (~442), `KekRotationEndpoints.cs` (~54). |
+| Mode seam | `src/Tamma.Api/Services/PromptStore/TammaMode.cs` (`ITammaModeProvider`, SingleUser \| SaaS). |
+| Per-mode endpoint precedent | `src/Tamma.Api/Endpoints/AlertEndpoints.cs` (admin section under `/api/v1/admin/...` + tenant section under `/api/v1/orgs/{tenantId}/...`; paging 50/500; `TenantRoleHierarchy.IsAtLeast` mutation gate). |
+| Org route group | `Program.cs` ~1505–1513: `/api/v1/orgs` group with path-tenant gate. |
+
+### What is NEW (does not exist on disk — dependency seams)
+
+- **No `AuditRecord` / audit read-model entity** in `Tamma.Data/Entities/` → 37-1/37-3 (`IAuditQuery`).
+- **No hash-chain verifier** → 37-2 (`IChainVerifier`).
+- **No `AuditExportService`** → 37-4 (sign/encrypt/expiring export).
+- **No retention-policy reader** → 37-5 (`IRetentionPolicyReader`).
+- **No legal-hold reader / entity** → 37-6 (`ILegalHoldReader`).
+- **No `Compliance` directory** in `Tamma.Core` or `Tamma.Api/Services` → this story creates it.
+- **No `EvidencePackArtifact` entity** → this story creates it.
+
+**Implication:** the catalog + per-mode RBAC + endpoints are buildable today against real controls;
+the evidence-*collection* paths bind to consumer interfaces + test doubles until the deps merge. The
+catalog-integrity test (AC2) cross-checks against the real on-disk event codes (`ISecretAccessAuditor`,
+`ALERT.RAISED`, auth events) plus the 37-1 declared known-codes set (pending until 37-1 lands).
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Who sees **platform-scope** controls/evidence (KEK, backups, seed config)? | The sole user — one feed, `tenantId` null. | Platform owner ONLY (`PlatformOwnerAccess`). Never leaked to tenants. |
+| Who sees **tenant-scope** controls? | The sole user (`tenantId` null). | `tenant_owner`/`tenant_admin` via `/api/v1/orgs/{id}/...`; `member` read-only. |
+| Who generates a pack? | The user. | Platform pack: platform owner. Tenant pack: tenant_owner/admin (or platform owner). |
+| Pack-generated event tag | `tenantId` null. | Platform → null (admin feed); tenant → set (tenant feed). |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`). | same |
+
+---
+
+## Architecture
+
+**Catalog (policy-as-code) → evaluate against substrate → status report → async signed evidence pack.**
+
+1. **`ControlCatalog`** (`Tamma.Core/Compliance/`, NEW) — immutable `ControlDefinition[]` mapping each
+   SOC2 criterion to `{ RequiredActionCodes[], RetentionFloorDays, RequiresChainVerification,
+   RbacPolicy, Scope (Platform|Tenant), IsoXref }`. Reviewed in PRs; a catalog change is itself a
+   change-management artifact.
+2. **`ControlEvaluator`** (`Tamma.Api/Services/Compliance/`, NEW) — for a `(control, scopeKey)`,
+   reads supporting records via `IAuditQuery` (37-1/37-3), effective retention via
+   `IRetentionPolicyReader` (37-5), and chain result via `IChainVerifier` (37-2) → produces
+   `ControlStatus { status, lastEvidenceAt, supportingRecordCount, finding?, remediationHint? }`.
+   **Gap** when: no evidence in lookback window, OR retention < floor, OR chain required + failed.
+3. **`EvidencePackService` + `EvidencePackTaskHandler`** (NEW) — `POST` returns `202` + artifact id,
+   persists `EvidencePackArtifact{status=pending}`, enqueues a `PlatformQueuedTask`; the handler runs
+   on `PlatformTaskWorker`: `collecting` (control→evidence map via `IAuditQuery` excerpts + chain
+   result + retention snapshot + legal-hold state + config attestation + coverage summary) → `signing`
+   (hand bundle to 37-4 `AuditExportService` for sign/encrypt/expiry) → `ready` (append
+   `COMPLIANCE.EVIDENCE_PACK.GENERATED`, sensitive/audited).
+4. **`ConfigAttestationCollector`** (NEW) — point-in-time redacted posture snapshot (encryption-at-rest
+   on, KEK cadence, retention floors, alert-channel count, mode); booleans/counts only, never secrets.
+5. **`ComplianceEndpoints`** (NEW) — admin section (`PlatformOwnerAccess`) + tenant section
+   (`/api/v1/orgs/{tenantId}` group), mirroring `AlertEndpoints.cs`. Tenant view filters catalog to
+   `Scope == Tenant` and tenant-scoped evidence ONLY.
+6. **`EvidencePackArtifact`** (NEW entity) — pack metadata (scope, tenant_id, period, status, coverage
+   counts, signature_ref, expires_at); additive EF migration; entity config in
+   `TammaModelConfiguration.cs` only.
+
+---
+
+## Task breakdown
+
+### T1 — ControlCatalog + control domain types (Core, no DB)
+
+**Scope:** Code-resident catalog and value types. No evaluation logic yet.
+
+**Files (NEW):** `Tamma.Core/Compliance/ControlDefinition.cs`, `ControlScope.cs`, `ControlStatus.cs`,
+`TrustServiceCriteria.cs`, `ControlCatalog.cs`.
+
+**Tests first:** `tests/Tamma.Core.Tests/Compliance/ControlCatalogTests.cs` — unique criterion ids;
+every control carries a non-empty `RequiredActionCodes`, a valid `RbacPolicy`, and a `Scope`; **AC2
+no-orphan check**: every referenced action code resolves to a known/emitted event type (cross-check
+against `ISecretAccessAuditor` constants ∪ `ALERT.RAISED` ∪ auth events ∪ the 37-1 declared
+known-codes seam — mark the 37-1 portion pending until 37-1 lands); platform controls carry
+`Scope == Platform`, tenant controls `Scope == Tenant`.
+
+**Acceptance:**
+- [ ] Catalog covers CC6.x, CC7.x, CC8.x at minimum, each with real action codes + retention floor +
+      chain flag + RBAC policy + ISO xref.
+- [ ] No orphan action-code references (AC2) for codes that exist on disk today.
+- [ ] `Tamma.Core` builds; catalog test green.
+
+### T2 — Consumer-interface seams for dependencies (Api, no live wiring)
+
+**Scope:** Define the narrow interfaces this story consumes from unmerged deps, plus test doubles, so
+T3+ is buildable independent of 37-1/37-2/37-4/37-5/37-6 merge order.
+
+**Files (NEW):** `Tamma.Api/Services/Compliance/IAuditQuery.cs` (or import 37-1's if present — verify
+first), `IChainVerifier.cs`, `IRetentionPolicyReader.cs`, `ILegalHoldReader.cs`,
+`IComplianceEvidenceExporter.cs` (thin facade over 37-4 `AuditExportService`); test doubles under
+`tests/Tamma.Api.Tests/Compliance/TestDoubles/`.
+
+> **Verify-first:** if any dependency interface already exists on disk (a dep merged ahead of this
+> story), import and bind to it instead of redeclaring. Do NOT duplicate dependency logic.
+
+**Tests first:** seam contracts only (a test double satisfies each interface; no behavior yet).
+
+**Acceptance:**
+- [ ] Each consumer seam is a small interface this story owns the *consumption* of, not the *impl*.
+- [ ] Test doubles compile and are usable by T3/T4 tests.
+
+### T3 — ControlEvaluator + gap detection (Api)
+
+**Scope:** Evaluate a control against the substrate via the T2 seams; per-mode scope key from
+`ITammaModeProvider`.
+
+**Files (NEW):** `Tamma.Api/Services/Compliance/IControlEvaluator.cs`, `ControlEvaluator.cs`,
+`ComplianceOptions.cs` (`EvidenceLookbackDays`, defaults).
+
+**Tests first:** `tests/Tamma.Api.Tests/Compliance/ControlEvaluatorTests.cs` — no evidence in window →
+`gap` + finding + remediationHint; evidence present, retention < floor → `gap`; chain required + verify
+failed → `gap`; chain not required → chain ignored; all satisfied → `satisfied` with `lastEvidenceAt` +
+`supportingRecordCount`; mode matrix (single-user vs SaaS scope key).
+
+**Acceptance:**
+- [ ] Three gap reasons each produce a distinct, human-readable finding.
+- [ ] Evaluator reads mode from `ITammaModeProvider`; never queries cross-tenant evidence for a tenant
+      scope key.
+- [ ] Suite green.
+
+### T4 — Evidence pack: artifact entity, service, async task handler, attestation (Api + Data)
+
+**Scope:** Persist pack metadata; orchestrate async collection → 37-4 sign/encrypt/expiry; emit
+audited events; redacted config attestation.
+
+**Files (NEW):** `Tamma.Data/Entities/EvidencePackArtifact.cs`; DbSet in `ControlPlaneDbContext.cs` +
+config in `TammaModelConfiguration.cs`; additive migration under `Migrations/ControlPlane/`.
+`Tamma.Api/Services/Compliance/IEvidencePackService.cs`, `EvidencePackService.cs`, `EvidencePackJob.cs`,
+`EvidencePackTaskHandler.cs` (`IPlatformTaskHandler`), `ConfigAttestationCollector.cs`,
+`ComplianceEventTypes.cs` (`COMPLIANCE.EVIDENCE_PACK.GENERATED` / `.DOWNLOADED`).
+
+**Tests first:** `tests/Tamma.Api.Tests/Compliance/EvidencePackServiceTests.cs` — request persists
+`pending` + enqueues task; handler transitions `collecting → signing → ready`; bundle goes through the
+37-4 exporter stub (sign/encrypt); signature round-trip (verify passes; tamper → verify fails);
+`GENERATED` event appended exactly once with correct tags (scope, tenantId?, period, coverage, mode);
+download appends `DOWNLOADED`; failure path → `failed`, not downloadable; **attestation redaction**:
+no connection-string / API-key-shaped values present (AC13).
+
+**Acceptance:**
+- [ ] Pack produced ONLY via 37-4 exporter — zero bespoke crypto in this story.
+- [ ] `EvidencePackArtifact` migration applies; `has-pending-model-changes` reports none.
+- [ ] Attestation contains posture booleans/counts only.
+
+### T5 — ComplianceEndpoints (admin + tenant) with per-mode RBAC (Api)
+
+**Scope:** Read + generation endpoints; mirror `AlertEndpoints.cs` admin/tenant split; map in
+`Program.cs`; DI extension.
+
+**Files (NEW):** `Tamma.Api/Endpoints/ComplianceEndpoints.cs`,
+`Tamma.Api/Extensions/ComplianceServiceCollectionExtensions.cs`; **modify** `Program.cs` (map routes,
+register services, register `EvidencePackTaskHandler` with the platform task worker).
+
+```
+GET  /api/admin/compliance/controls                  (PlatformOwnerAccess)
+GET  /api/admin/compliance/controls/summary          (PlatformOwnerAccess)
+POST /api/admin/compliance/evidence-pack             (PlatformOwnerAccess) -> 202
+GET  /api/admin/compliance/evidence-pack/{id}        (PlatformOwnerAccess)
+GET  /api/admin/compliance/evidence-packs            (PlatformOwnerAccess; paged 50/500)
+GET  /api/v1/orgs/{tenantId}/compliance/controls     (tenant member; Scope==Tenant ONLY)
+POST /api/v1/orgs/{tenantId}/compliance/evidence-pack(tenant_owner/admin; member 403) -> 202
+GET  /api/v1/orgs/{tenantId}/compliance/evidence-pack/{id}
+```
+
+**Tests first:** `tests/Tamma.Api.Tests/Compliance/ComplianceEndpointsTests.cs` — RBAC matrix
+(platform_admin / tenant_owner / tenant_admin / member / cross-tenant 404); tenant `controls` never
+returns a `Scope==Platform` control nor another tenant's evidence; `POST` returns 202 + id, subsequent
+`GET` reflects status; single-user mode: sole user sees platform + tenant controls in one list; summary
+rollup counts by category/status.
+
+**Acceptance:**
+- [ ] Endpoint shape identical between modes; auth middleware decides scope (prompt-store/alert
+      precedent).
+- [ ] Cross-tenant → 404 (never reveal existence); member mutation → 403.
+- [ ] Tenant view isolation holds (no platform-scope leakage).
+
+### T6 (thin) — control-status DTO for the 37-10 dashboard widget
+
+**Scope:** Expose the `controls/summary` rollup DTO in a shape the 37-10 audit dashboard can render as a
+compliance-posture widget. No new UI in this story (37-10 owns the tab); ship the data contract + a
+contract test.
+
+**Files:** finalize the summary DTO in `ComplianceEndpoints.cs` / a `ComplianceSummaryDto.cs`; document
+the contract in the story.
+
+**Tests first:** summary endpoint returns category rollup, satisfied/gap counts, oldest-gap age, last
+evidence-pack timestamp.
+
+**Acceptance:**
+- [ ] `GET /api/admin/compliance/controls/summary` returns a stable, dashboard-ready rollup.
+
+---
+
+## Task order & dependencies
+
+T1 → T2 → T3 → T4 → T5 → T6.
+T1 (catalog) is standalone and the first red test. T2 unblocks T3/T4 from dependency merge order. T5
+needs T3 (status) + T4 (pack). T6 is a thin add on T5.
+
+**External dep merge order is independent** of this plan thanks to T2 seams; live wiring of
+37-1/37-2/37-4/37-5/37-6 is a one-line DI swap when each lands.
+
+## Risks
+
+- **Dependency not yet merged (37-1/37-2/37-4/37-5/37-6):** mitigated by T2 consumer-interface seams +
+  test doubles. Risk: redeclaring an interface a dep already ships — mitigation: T2 starts by grepping
+  for an existing impl and binding to it.
+- **Catalog drift / orphan codes:** as new audit events land or are renamed, the catalog can point at
+  a dead code. Mitigation: the AC2 no-orphan test runs in CI and fails the build on drift.
+- **Secret exfiltration via attestation (AC13):** highest-severity risk — an evidence pack handed to an
+  external auditor must never contain secret material. Mitigation: `ConfigAttestationCollector` reads
+  only non-sensitive config + a redaction test asserting no secret-shaped strings; the secret cabinet
+  is *attested to*, never *exported*.
+- **Bespoke crypto creep:** signing/encryption belongs to 37-4. Mitigation: T4 routes the bundle
+  through the 37-4 exporter facade only; review rejects any in-story crypto.
+- **Tenant-view leakage:** a platform-scope control surfacing in the tenant endpoint pages tenants for
+  platform internals. Mitigation: T5 filters strictly to `Scope == Tenant`; isolation test is
+  load-bearing.
+- **Event-store topology shift (Story 28-1 / Epic 30):** `COMPLIANCE.EVIDENCE_PACK.*` append to CP
+  `DomainEvents` today (what `AlertRuleEvaluator` polls). Platform-scope events must stay CP-resident;
+  tenant-scope follow per-tenant fan-out later. Mitigation: recorder is explicit about scope so the
+  Epic 30 migration only touches tenant routing.
+- **Migration discipline:** `EvidencePackArtifact` is additive — verify `has-pending-model-changes`
+  reports none after the migration; mirror entity config in `TammaModelConfiguration.cs` only (single
+  source per repo convention).

--- a/docs/superpowers/plans/2026-06-17-37-12-admin-and-tenant-audit-dashboard-ui-plan.md
+++ b/docs/superpowers/plans/2026-06-17-37-12-admin-and-tenant-audit-dashboard-ui-plan.md
@@ -1,0 +1,299 @@
+# Story 37-12 — Admin & Tenant Audit Dashboard UI (implementation plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes the
+> component/client test before implementation.
+
+**Story file:** `docs/stories/epic-37/story-37-12/37-12-admin-and-tenant-audit-dashboard-ui.md`
+(read it first — it carries the full ACs, the per-mode ownership matrix, and the
+why-React-not-Tamma.Studio architecture note).
+
+**Goal:** Ship the operator-facing UI of the Epic 37 audit product on the two React dashboards.
+`packages/dashboard-user` gets a tenant audit page (own records, filters, facets, keyset paging,
+chain badge, export) plus Compliance settings (retention, legal holds, DSAR/erasure, consent).
+`packages/dashboard` (admin panel) gets a platform Audit & Compliance surface (platform audit log,
+impersonation active+history, chain verify, evidence-pack, cross-tenant legal holds). RBAC is enforced
+per mode; a tenant never sees another tenant's audit; downloads always go through 37-4 signed URLs.
+
+**Tech stack:** React 19 + Vite 8 + Tailwind 4 + react-router-dom 7, tested with Vitest 4 +
+@testing-library/react. Two SPAs: `packages/dashboard` (admin, `fetchJSON` admin clients,
+`AdminGuard`/`PlatformOwnerAccess`) and `packages/dashboard-user` (tenant, shared `ApiClient` with
+refresh-on-401, `AuthGuard`/`TenantAdminGuard`). The backing audit/compliance HTTP API is owned by
+`apps/tamma-elsa/src/Tamma.Api` and shipped by the dependency stories — this plan touches **only** the
+two React packages.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main)
+
+| Thing | State today |
+|---|---|
+| `packages/dashboard/src/pages/admin/AuditLogTab.tsx` | **Stub.** Feature-flagged on `VITE_FEATURE_ADMIN_AUDIT_LOG`; `AuditLogViewer` says "API integration pending". This story wires it. |
+| `packages/dashboard/src/pages/admin/AdminLayout.tsx` | Tabbed admin shell; `AdminTab` union + `TABS` array already include `audit-log`. Whole admin panel is behind `AdminGuard`. |
+| `packages/dashboard/src/guards/AdminGuard.tsx` | Redirects non-admin to `/account`; exports `ForbiddenPage` (403). Role from `useCurrentUser().isAdmin`. Server is `PlatformOwnerAccess`. |
+| `packages/dashboard/src/services/admin/admin-api-client.ts` | `fetchJSON` helper, `credentials: 'include'`, `API_BASE = VITE_API_BASE_URL ?? '/api'`. New admin clients mirror this. |
+| `packages/dashboard-user/src/App.tsx` | Router; routes under `AuthGuard → AppLayout`; admin-only routes wrap `TenantAdminGuard`. Add `/audit` + `/settings/compliance/*` here. |
+| `packages/dashboard-user/src/layouts/AppLayout.tsx` | Sidebar nav (Dashboard/Repositories/Runs/Settings). Add "Audit" + "Compliance" entries. |
+| `packages/dashboard-user/src/guards/TenantAdminGuard.tsx` | Admits `admin`+`owner`; renders inline "Admin-only" for `member`. Owner-only split is done in-page (see `TenantAlertFeed`). |
+| `packages/dashboard-user/src/api/client.ts` | Shared `ApiClient` (get/post/put/delete) with refresh-on-401; `apiClient` singleton. |
+| `packages/dashboard-user/src/api/alerts.ts` | **The structural exemplar** for the new tenant clients: typed DTOs, `tenantId`-keyed `/api/v1/orgs/{tenantId}/...` calls over `apiClient`, plaintext-credential pre-flight guard. |
+| `packages/dashboard-user/src/pages/alerts/TenantAlertFeed.tsx` | **The UX exemplar**: filter bar, `role`-gated action buttons, `Modal`, `SeverityPill`, `role="alert"` error banner, `useCallback` refresh. Crib heavily. |
+| `packages/dashboard-user/src/hooks/useAuth.tsx` | `AuthUser` = `{ id, email, displayName, tenantId?, role? }` from `/api/auth/me`. The only source of `tenantId` — load-bearing for isolation. |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminImpersonationsEndpoints.cs` | **Shipped.** `GET /api/admin/impersonations/active` (`PlatformOwnerAccess`); `IMPERSONATION.STARTED/ENDED` events carry impersonator+target+`impersonationId` in tags+data. Reuse for AC7. |
+| Audit/export/chain/retention/legal-hold/DSAR/evidence endpoints | **NOT built yet** — owned by 37-2..37-9 / 37-11. The clients here are written against the contract in the story file and reconciled when those land. |
+
+**Two cross-package facts that shape the plan:** (1) the two SPAs do not import each other — the
+shared table/filter/badge components are authored in `dashboard-user` and re-implemented in
+`dashboard` (≈150 lines duplicated, same as `alerts.ts` is duplicated today); (2) feature flags
+(`VITE_FEATURE_*`) are the deploy kill-switch so the UI ships ahead of the backing endpoints.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- NO changes to `apps/tamma-elsa` (the C# API) — endpoints are dependency-story scope. If a client
+  needs a field the endpoint doesn't return, that is a 37-3..37-11 gap, not work for this story.
+- NO `Tamma.Studio` (Blazor) pages — admin audit is React `packages/dashboard` (see story
+  architecture note). `packages/api` is deleted and never a target.
+- NO cross-package shared component library / new shared package — duplicate the ~150 lines.
+- NO new heavy charting/data-grid dependency unless one is already in the dep tree (verify with
+  `pnpm why`); hand-roll windowing otherwise.
+- NO real-time SSE audit stream — polling/refresh is enough for v1 (SSE can be a follow-up).
+- NO per-user audit personalization, saved-search persistence, or column customization in v1.
+- NO offset pagination / `COUNT(*)` — keyset only (the 100k-row AC forbids it).
+- NO mode-branching UI code — branch on `role`/`tenantId`, never on SaaS-vs-single-user.
+
+---
+
+## Architecture (UI shape)
+
+```
+TENANT (packages/dashboard-user)                ADMIN (packages/dashboard)
+  /audit  → TenantAuditPage                        admin panel → "Audit & Compliance" tab
+    AuditFilters ─ AuditTable ─ ChainStatusBadge     PlatformAuditPanel (table + filters + chain)
+    [Export] → exportTenantAudit → signed URL        ImpersonationPanel (active + history)
+                                                      EvidencePackPanel (generate/poll/signed URL)
+  /settings/compliance/                              LegalHoldAdminPanel (cross-tenant)
+    retention      → RetentionPolicyPage (37-5)
+    legal-holds    → LegalHoldsPage      (37-6)     services/admin/audit-api-client.ts
+    data-requests  → DataRequestsPage    (37-7/8)   services/admin/compliance-api-client.ts
+    consent        → ConsentHistoryPage  (37-9)
+  api/audit.ts (37-3/37-4/37-2)
+  api/compliance.ts (37-5..37-9)
+```
+
+Data flow per surface: client (typed, `tenantId`/admin-scoped) → page (filters/state/poll) →
+presentational table/badge/form. The fetch seam is the test boundary — mock the client, never `fetch`.
+
+---
+
+## Task breakdown
+
+### T1 — Tenant audit API client (`api/audit.ts`) + tests  [foundation]
+
+**Scope:** Typed client for 37-3 query, 37-2 chain verify, 37-4 export, over the shared `apiClient`,
+all keyed to `tenantId`. DTOs per the story-file contract (`AuditRecordDto`, `AuditQuery` with
+`cursor`, `AuditPage` with `nextCursor`, `ChainVerifyResult`, `ExportTicket`).
+
+**Files:** New `packages/dashboard-user/src/api/audit.ts`, `audit.test.ts`.
+
+**Tests first:** query builds the right `/api/v1/orgs/{tenantId}/audit?...` querystring from filters
+(omits empty); `verifyTenantChain` hits `.../audit/chain/verify`; `exportTenantAudit` POSTs the filter
+set and returns the `ExportTicket`; the client never accepts a `tenantId` other than the one passed by
+the caller (it's a parameter, and the page only ever passes `user.tenantId`).
+
+**Done when:** `pnpm test --filter @tamma/dashboard-user` green for the new file; typecheck clean.
+
+- [ ] Write `audit.test.ts` (querystring, endpoints, export ticket).
+- [ ] Implement `audit.ts` mirroring `api/alerts.ts`.
+- [ ] Tests green; typecheck clean.
+
+### T2 — Audit presentational components: `AuditTable`, `AuditFilters`, `ChainStatusBadge`
+
+**Scope:** The shared presentational pieces (authored in dashboard-user). `AuditTable` = virtualized,
+keyset "Load more", loading/empty/error states. `AuditFilters` = filter bar + severity/category facet
+chips + date range. `ChainStatusBadge` = verified/tampered/pending + "Re-verify".
+
+**Files:** New `components/audit/AuditTable.tsx`, `AuditFilters.tsx`, `ChainStatusBadge.tsx` + tests.
+`JobStatusPoller.tsx` (shared poll-until-terminal hook/component) added here too.
+
+**Decisions to make in-task:** virtualization approach — `pnpm why @tanstack/react-virtual` in the
+dashboard packages; if present, use it; else hand-roll a windowing hook (fixed row height +
+`IntersectionObserver` sentinel that drives the next keyset fetch). Keep the bundle lean.
+
+**Tests first:** table renders mocked rows; "Load more" appends next page, stops on `null` nextCursor;
+windowed render keeps DOM small for a 100k-row source; filters emit the right query object; facet chips
+toggle; badge renders three states accessibly and re-verify re-requests; poller transitions
+`pending→running→completed` and flips a callback.
+
+- [ ] `pnpm why` the virtualization lib in both packages; decide approach.
+- [ ] Write component tests (table/filters/badge/poller).
+- [ ] Implement components (crib `TenantAlertFeed` for table/filter/error idioms).
+- [ ] Tests green; typecheck clean.
+
+### T3 — `TenantAuditPage` + route + nav (AC1-4, AC10-12)
+
+**Scope:** Compose T1+T2 into the tenant audit page: load `user.tenantId` from `useAuth`, wire
+filters→query→table, chain badge, Export button (signed-URL download), member read-only behavior. Add
+`/audit` route in `App.tsx` (under `AuthGuard → AppLayout`) and an "Audit" nav entry in `AppLayout`.
+
+**Files:** New `pages/audit/TenantAuditPage.tsx` + test. Modify `App.tsx`, `AppLayout.tsx`.
+
+**Signed-URL contract:** Export → `exportTenantAudit` → `{ downloadUrl }` → anchor-click/`window.open`
+→ discard. Never store/log the URL; expired/403 → retryable error. Assert in test the export request
+body equals the shown filters and that no raw artifact URL is rendered.
+
+**Isolation:** the page passes ONLY `user.tenantId`; there is no foreign-tenant input. Add the
+isolation test here (spy `apiClient`/`fetch`; every URL contains `user.tenantId`).
+
+**Tests first:** renders rows for the active tenant; filter change re-queries; chain badge reflects
+result; Export posts current filters + downloads via signed URL; member sees read-only (no export? —
+decide: members CAN read+export own-tenant audit? Per AC10 members get a read-only audit view; export
+of own-tenant data is a read — allow it, but no mutate controls exist on this page anyway); no-tenant
+state renders the "no active organization" message (crib `TenantAlertFeed`).
+
+- [ ] Write `TenantAuditPage.test.tsx` + isolation test.
+- [ ] Implement page; wire route + nav.
+- [ ] Tests green; typecheck clean.
+
+### T4 — Compliance client (`api/compliance.ts`) + tests (37-5..37-9)
+
+**Scope:** Tenant-keyed client: retention get/put (37-5), legal-hold list/place/release (37-6), DSAR
+submit + erasure submit + job status (37-7/37-8), consent history list (37-9). All over `apiClient`,
+all `/api/v1/orgs/{tenantId}/...`.
+
+**Files:** New `packages/dashboard-user/src/api/compliance.ts`, `compliance.test.ts`.
+
+**Tests first:** each call hits the right endpoint with the right method/body; job-status returns the
+terminal-state shape; everything is `tenantId`-keyed.
+
+- [ ] Write `compliance.test.ts`.
+- [ ] Implement `compliance.ts`.
+- [ ] Tests green; typecheck clean.
+
+### T5 — Tenant Compliance pages + routes (AC5, AC10)
+
+**Scope:** Four pages under `/settings/compliance/*`, all behind `TenantAdminGuard`, with owner-only
+splits in-page (retention edit, legal-hold place/release):
+- `RetentionPolicyPage` (37-5) — read for admin, edit for owner.
+- `LegalHoldsPage` (37-6) — list + place + release; place/release owner-only.
+- `DataRequestsPage` (37-7/37-8) — DSAR export + erasure request forms + `JobStatusPoller` + signed-URL
+  download of the completed DSAR.
+- `ConsentHistoryPage` (37-9) — read-only consent timeline.
+
+**Files:** New four pages + four tests under `pages/settings/compliance/`. Modify `App.tsx` (4 routes),
+`AppLayout.tsx` (a "Compliance" nav group/entry).
+
+**Tests first:** form validation; owner-only gating (admin → read-only, no place/release/edit; member →
+the guard's "Admin-only" screen); DSAR/erasure submit kicks a job and polling enables the download;
+download uses signed URL; consent timeline renders.
+
+- [ ] Write the four page tests.
+- [ ] Implement the four pages + routes + nav (crib `TenantAlertFeed` Modal + role gating).
+- [ ] Tests green; typecheck clean.
+
+### T6 — Admin audit + compliance clients (`services/admin/audit-api-client.ts`, `compliance-api-client.ts`)
+
+**Scope:** Platform-scoped clients over `fetchJSON` (admin pattern): `queryPlatformAudit`,
+`verifyPlatformChain` (37-2), `listActiveImpersonations` (reuse `GET /api/admin/impersonations/active`),
+`generateEvidencePack`+`getEvidencePackStatus` (37-11); cross-tenant `listLegalHolds`/`placeLegalHold`/
+`releaseLegalHold` (37-6).
+
+**Files:** New `packages/dashboard/src/services/admin/audit-api-client.ts`,
+`compliance-api-client.ts`, `audit-api-client.test.ts`.
+
+**Tests first:** each call hits the right `/api/admin/...` endpoint; evidence-pack status returns the
+terminal shape; impersonation-active maps to the existing endpoint's DTO.
+
+- [ ] Write `audit-api-client.test.ts`.
+- [ ] Implement both admin clients (mirror `admin-api-client.ts` `fetchJSON`).
+- [ ] Tests green; typecheck clean.
+
+### T7 — Platform audit panels + wire `AuditLogTab` (AC6-9, AC10-12)
+
+**Scope:** Build the four admin panels and replace the `AuditLogViewer` stub with a real
+`PlatformAuditPanel` composition:
+- `PlatformAuditPanel` — platform audit table + filters + chain verify (re-implements T2's shape
+  against the admin client).
+- `ImpersonationPanel` — active sessions (`listActiveImpersonations`) + history filtered from the audit
+  log (`IMPERSONATION.STARTED/ENDED`); impersonator→target, reason, timestamps, `impersonationId`.
+- `EvidencePackPanel` — date-range/scope form → generate → `JobStatusPoller` → signed-URL download.
+- `LegalHoldAdminPanel` — cross-tenant legal-hold list + place/release.
+
+**Files:** New `pages/admin/audit/PlatformAuditPanel.tsx`, `ImpersonationPanel.tsx`,
+`EvidencePackPanel.tsx`, `LegalHoldAdminPanel.tsx` + tests. Modify `AuditLogTab.tsx` (compose panels;
+keep `VITE_FEATURE_ADMIN_AUDIT_LOG` as kill-switch, flip default to enabled once 37-3 admin endpoint
+confirmed live), extend `AuditLogTab.test.tsx`, optionally relabel the tab in `AdminLayout.tsx`.
+
+**RBAC:** the whole admin route is `AdminGuard`/`PlatformOwnerAccess`; the test asserts a non-admin
+deep-link renders `ForbiddenPage` / redirect (existing guard behavior — just assert it still holds with
+the new content).
+
+**Tests first:** panels render mocked data; chain badge; impersonation active+history rows; evidence
+pack generate→poll→signed-URL download (no raw URL in DOM); legal-hold place/release; `AuditLogTab`
+renders panels when flag on, "Coming soon" when off.
+
+- [ ] Write panel tests + extend `AuditLogTab.test.tsx`.
+- [ ] Implement panels; wire `AuditLogTab`; relabel tab.
+- [ ] Tests green; typecheck clean.
+
+### T8 — RBAC-per-mode + isolation + e2e tests, polish
+
+**Scope:** The cross-cutting test sweep + final polish. (Much is co-located in T3/T5/T7; T8 fills the
+matrix gaps and the e2e walks.)
+
+**Tests:**
+- RBAC-per-mode: mock `useAuth`/`useCurrentUser` for owner / tenant_admin / member / single-user;
+  assert nav entries, route guards (member → no admin nav + 403; member tenant → read-only/no nav),
+  owner-only control visibility.
+- Isolation: tenant client only ever issues `user.tenantId` URLs; forced cross-tenant 404 surfaces
+  cleanly.
+- e2e (mocked API — MSW or fetch-mock): tenant audit→filter→export→signed download; admin
+  audit→chain→evidence generate/poll/download; assert no raw artifact URL appears in DOM or logs.
+- Large-table: 100k-row mocked source → windowed DOM, non-blocking "Load more".
+
+**Done when:** `pnpm test --filter @tamma/dashboard-user` AND `pnpm test --filter @tamma/dashboard`
+green; `pnpm typecheck` clean for both; no new ESLint errors; the story's 13 ACs each map to a passing
+test.
+
+- [ ] Fill the RBAC matrix + isolation + e2e + large-table tests.
+- [ ] Map each AC → a test; close gaps.
+- [ ] Both packages green; typecheck + lint clean.
+
+---
+
+## Task order & dependencies
+
+T1 → T2 → T3 (tenant audit MVP) ; T4 → T5 (tenant compliance) ; T6 → T7 (admin) ; T8 last.
+T1/T2 are prerequisites for T3 and (shape-wise) T7. T4 precedes T5. T6 precedes T7. T8 is the
+cross-cutting sweep. T3, T5, T7 are independently shippable behind feature flags.
+
+External: hard-blocked on **37-3** (audit query) and **37-4** (export/signed URLs) being live before
+the story is *done*; can be fully scaffolded + unit-tested against mocks before then. Chain (37-2),
+retention (37-5), legal hold (37-6), DSAR/erasure (37-7/8), consent (37-9), evidence (37-11) gate their
+respective sub-features only.
+
+## Risks
+
+- **Endpoint contract drift:** the client DTOs are written ahead of the real 37-3..37-11 endpoints.
+  Mitigation: keep all field-mapping in the clients (single place to fix); reconcile against the
+  as-built `apps/tamma-elsa` endpoints as each lands; the feature flags keep an unfinished surface
+  dark.
+- **Tenant isolation regression:** the headline invariant. Mitigation: `tenantId` comes only from
+  `useAuth`, no foreign-tenant input on tenant pages, an explicit isolation test, and server-side 404
+  as the real boundary. Never relax this for "admin convenience" — the cross-tenant view is
+  admin-package-only behind `PlatformOwnerAccess`.
+- **Signed-URL leakage:** a raw artifact URL in the DOM/logs is a compliance defect. Mitigation: only
+  ever use the 37-4 ticket URL, discard after click, never log it, e2e asserts no raw URL appears.
+- **Virtualization vs bundle size:** adding a data-grid lib bloats the SPA. Mitigation: `pnpm why`
+  first; hand-roll windowing if nothing's already there.
+- **Keyset paging mismatch:** if 37-3 ships offset paging instead of keyset, the 100k-row AC is at
+  risk. Mitigation: this story's client assumes `cursor`/`nextCursor`; flag a contract conflict to the
+  37-3 owner early rather than fall back to offset.
+- **Meta-audit accidental suppression:** request de-dup/caching could hide reads from `AUDIT.QUERIED`.
+  Mitigation: don't cache audit GETs in a way that skips the network; the meta-audit is a feature, not
+  overhead.
+- **Two-package duplication drift:** the table/badge shape exists twice. Mitigation: accept the
+  duplication (precedent: `alerts.ts`); if it grows, a future shared package is a clean follow-up — out
+  of scope here.

--- a/docs/superpowers/plans/2026-06-17-37-2-tamper-evident-hash-chain-over-audit-records-plan.md
+++ b/docs/superpowers/plans/2026-06-17-37-2-tamper-evident-hash-chain-over-audit-records-plan.md
@@ -1,0 +1,294 @@
+# Story 37-2 — Tamper-Evident Hash-Chain over Audit Records (implementation plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan step-by-step. Steps use
+> checkbox (`- [ ]`) syntax. Project is test-first (TDD) — every step writes tests before
+> implementation. Read [BEFORE_YOU_CODE.md](../../guides/BEFORE_YOU_CODE.md) first.
+
+**Story:** [37-2](../../stories/epic-37/story-37-2/37-2-tamper-evident-hash-chain-over-audit-records.md)
+
+**Goal:** Make Tamma's curated `audit_records` projection (from Story 37-1) tamper-evident. Each
+record carries `record_hash = SHA-256(prev_hash ‖ canonical(record))` linking it to the prior
+record in its scope, forming an append-only hash-chain — one chain per tenant (`TenantDbContext`) and
+one platform chain (`ControlPlaneDbContext`). A verifier detects insertion, deletion, reordering, and
+mutation and localizes the first broken link. Signed checkpoints (key from the Epic 29 cabinet, not a
+plaintext env key) anchor the chain head on a schedule + on demand so even an attacker with DB write
+access cannot silently rewrite history. Tamper detection raises a critical alert through the existing
+Story 5.6 pipeline.
+
+**Tech stack:** .NET 8 / EF Core 8 / Npgsql in `apps/tamma-elsa`. Crypto via
+`System.Security.Cryptography` (SHA-256 + HMAC; `TenantSecretProtector` AES-GCM is the existing
+at-rest envelope). Tests in `apps/tamma-elsa/tests/Tamma.Core.Tests/` and
+`apps/tamma-elsa/tests/Tamma.Api.Tests/` (xUnit; docker-bound suites via
+`sg docker -c "dotnet test ..."`). `packages/api` is DELETED — never a target.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+| Seam | Where | State |
+|---|---|---|
+| Raw DCB event | `src/Tamma.Data/Entities/DomainEvent.cs` | EXISTS — `Type`/`TenantId`/`Tags`/`Data` + BIGSERIAL `SequenceNumber`. This story does NOT touch it; it works on the 37-1 curated read-model. |
+| Event append + plane routing | `src/Tamma.Data/Repositories/IEventRepository.cs`, `src/Tamma.Api/Services/Alerts/AlertEventEmitter.cs` | EXISTS — `IEventRepository.AppendAsync` (tenant) vs `IPlatformEventPublisher.AppendAndPublishAsync` (platform). Copy this tenant-vs-platform routing for `AUDIT.CHAIN.*` events. |
+| Alert raise + built-ins | `src/Tamma.Api/Services/Alerts/IAlertSink.cs`, `AlertPayload.cs`, `Rules/BuiltInAlertRules.cs`, `BuiltInAlertRuleSeeder` | EXISTS — `RaiseAsync(AlertPayload)`; severities `critical`/`warning`/`info`; built-ins seeded idempotently. Add `audit-chain-tamper` (critical). |
+| Crypto envelope | `src/Tamma.Api/Services/Provisioning/TenantSecretProtector.cs` | EXISTS — AES-GCM (12-byte nonce ‖ ct ‖ 16-byte tag), key from cabinet. Reuse as the at-rest envelope; do NOT invent new key handling. |
+| Secret cabinet | `src/Tamma.Api/Services/Secrets/ISecretStore.cs` (+ `ISecretAccessAuditor`) | EXISTS — typed cabinet; plaintext only via out-of-band path; every read audited. Source of the checkpoint signing key. |
+| Scheduled workflow template | `src/Tamma.ElsaServer/Workflows/HourlyAnalyticsRollupScheduler.cs` (+ `HourlyAnalyticsRollupWorkflow.cs`) | EXISTS — `BackgroundService` with `Enabled`/`FireAtMinute`/`PollInterval`, `pg_try_advisory_lock` leader election, `_lastFired` dedup, WARN-and-continue. Copy structure for the checkpoint scheduler. |
+| Tenant audit endpoint + RBAC | `src/Tamma.Api/Endpoints/OrgEndpoints.cs` `ListTenantAudit` (~527) | EXISTS — reads role from `RequireTenantMembershipFilter.TenantRoleItemKey`, requires `TenantRoleHierarchy.Admin`, sets ambient `ITenantContext`. Mirror for `audit/verify`. |
+| Authz policies | `src/Tamma.Api/Program.cs` (~966–991) | EXISTS — `OwnerAccess`, `PlatformOwnerAccess`, `MemberAccess`, etc. Admin verify uses `PlatformOwnerAccess`. |
+| Entity model config | `src/Tamma.Data/TammaModelConfiguration.cs` | EXISTS — single source for EF model config; mirror new columns + checkpoint entity here. |
+| Migrations | `src/Tamma.Data/Migrations/{Tenant,ControlPlane}/` | EXISTS — both stores have migration trees. Chain columns are additive on both; checkpoint table + append-only trigger via raw SQL in the migration. |
+| Mode provider | `Tamma.Api` `ITammaModeProvider` (SingleUser/SaaS) | EXISTS — drives per-mode RBAC. |
+| **37-1 `audit_records` + `AuditProjector`** | `docs/stories/epic-37/story-37-1/` | **EMPTY — 37-1 not yet written.** This story HARD-depends on it. The projector transaction boundary and the curated-record field set are 37-1's deliverable; 37-2 chains inside that transaction. |
+| `Tamma.Core` project | `src/Tamma.Core/` | EXISTS — home for the pure crypto/verify logic (`Tamma.Core/Audit/`, NEW). |
+
+**Spec-path reconciliation:** the spec's `Tamma.Core/Audit/AuditChainVerifier.cs`,
+`Tamma.Data/Audit/AuditProjector.cs`, `Tamma.Data/Entities/AuditChainCheckpoint.cs` are TARGETS that
+don't exist yet (AuditProjector ships in 37-1; the rest are NEW here). `ISecretStore.cs`,
+`OrgEndpoints.cs`, `AdminEndpoints.cs` EXIST and are consumed/extended.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- NO change to the raw DCB `domain_events` store or its semantics — integrity there is already
+  covered by `SequenceNumber`; this layer is the curated read-model's independent proof.
+- NO Merkle tree / blockchain / external timestamp-authority anchoring in v1. A linear hash-chain +
+  internally-signed checkpoints is the scope. (External RFC-3161 / transparency-log anchoring is a
+  documented future follow-up, not this story.)
+- NO re-hashing or back-fill UI. Existing pre-37-2 records (if any from a 37-1 ship without chaining)
+  get a one-time genesis-anchored backfill in the migration; no ongoing re-chain tooling.
+- NO plaintext signing key in `appsettings`/env (explicitly forbidden by AC5).
+- NO per-record online verification on the read path — verification is on-demand / scheduled, not in
+  the audit-query hot path.
+- NO cross-tenant or global "one big chain" — per-scope chains only (rationale in the story Dev Notes).
+
+---
+
+## Architecture
+
+**Write path (insert-time chaining):** `AuditProjector` (37-1) → acquire per-scope
+`pg_advisory_xact_lock` → read chain head → set `prev_hash`/`chain_sequence` → `record_hash =
+AuditChainHasher.Compose(prev, AuditRecordCanonicalizer.ToBytes(record))` → persist atomically inside
+the 37-1 projection transaction.
+
+**Anchor path (checkpoints):** `AuditChainCheckpointScheduler` (BackgroundService, copy of
+`HourlyAnalyticsRollupScheduler`) → dispatch `AuditChainCheckpointWorkflow` → per active scope, read
+head → `SecretCabinetAuditChainSigner` signs `canonical(scope ‖ head_sequence ‖ head_hash ‖
+signed_at)` with the cabinet key → write `audit_chain_checkpoints` row with `key_version`. On-demand
+checkpoint = same per-scope routine called from the admin endpoint.
+
+**Verify path:** `AuditChainVerifier.VerifyAsync(scope, from, to)` streams records, recomputes hashes,
+checks `prev_hash` linkage + `chain_sequence` contiguity, then validates the covering checkpoint's
+signature + head-hash → returns `Ok` or first broken link `{recordId, chainSequence, reason}`. Verify
+emits `AUDIT.CHAIN.VERIFIED` / `AUDIT.CHAIN.TAMPER_DETECTED` (plane-routed); tamper raises a `critical`
+alert via `IAlertSink`.
+
+**Per-mode ownership (mandatory two-scoping answer):**
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Who owns/verifies a **tenant** chain? | The sole user (their one chain). | `tenant_owner`/`tenant_admin` via `/api/v1/orgs/{tenantId}/audit/verify`; `member` → 403. |
+| Who owns/verifies the **platform** chain? | The sole user (their instance). | Platform owner only (`PlatformOwnerAccess`); never exposed to tenants. |
+| Where do tamper alerts fan out? | The user's feed (`TenantId` null). | Tenant-scope tamper → `TenantId` set (tenant feed); platform-scope → null (admin feed). |
+| Mode source | `ITammaModeProvider` | same |
+
+---
+
+## Story breakdown
+
+### 37-2-A: Pure crypto core — canonicalizer + hasher + genesis (no DB)
+
+**Scope:** The deterministic, allocation-careful primitives the whole chain rests on. Pure
+`Tamma.Core`, no EF, no I/O.
+
+**Files (new):** `src/Tamma.Core/Audit/AuditChainGenesis.cs` (well-known 32-byte constant +
+`canonicalVersion`), `AuditRecordCanonicalizer.cs` (fixed field order, UTC ISO-8601 ms, invariant
+culture, no `Dictionary` order dependence), `AuditChainHasher.cs` (`Compose(prev, canon)` → 32-byte
+SHA-256), `AuditChainScope.cs` (tenant/platform discriminated value).
+
+**Tests (first):** `tests/Tamma.Core.Tests/Audit/AuditRecordCanonicalizerTests.cs`,
+`AuditChainHasherTests.cs` — byte-stability across two runs + across `Dictionary` insertion orders;
+locale invariance (run under a non-invariant culture); single-bit-flip avalanche; genesis constant is
+reproducible from its documented preimage.
+
+**Acceptance criteria:**
+- [ ] `canonical(record)` is byte-identical across runs/cultures/key-orderings; differing payloads differ.
+- [ ] `Compose` returns 32 deterministic bytes; flipping one bit of either input changes output.
+- [ ] Genesis constant matches `SHA-256("tamma.audit.chain.genesis.v1")` (documented inline).
+- [ ] Full `Tamma.Core` suite green.
+
+### 37-2-B: Chain columns + checkpoint entity + append-only trigger (schema)
+
+**Scope:** Additive schema on both stores. Depends on 37-1's `AuditRecord` entity existing.
+
+**Files:** modify `src/Tamma.Data/Entities/AuditRecord.cs` (add `ChainSequence`/`PrevHash`/`RecordHash`),
+new `src/Tamma.Data/Entities/AuditChainCheckpoint.cs`, modify `TammaModelConfiguration.cs` (columns,
+unique index on `chain_sequence`, checkpoint entity + `scope_tenant_consistency` CHECK + index). New
+EF migrations under `Migrations/Tenant/` (chain columns + append-only trigger) and
+`Migrations/ControlPlane/` (chain columns + `audit_chain_checkpoints` + trigger; append-only trigger
+raw SQL in `migrationBuilder.Sql`). One-time genesis backfill for any pre-existing rows.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Audit/AuditChainSchemaTests.cs` (docker-bound) — migration
+applies + rolls back cleanly; `has-pending-model-changes` reports none; append-only trigger rejects
+`UPDATE`/`DELETE` on chain columns; checkpoint CHECK rejects `scope='platform' AND tenant_id NOT NULL`.
+
+**Acceptance criteria:**
+- [ ] Both migrations apply + roll back; no pending model changes.
+- [ ] Direct `UPDATE`/`DELETE` of an `audit_records` chain column is rejected by the trigger.
+- [ ] Checkpoint CHECK enforces scope↔tenant_id consistency.
+
+### 37-2-C: Insert-time chaining in AuditProjector + chain repository
+
+**Scope:** Hook chaining into 37-1's `AuditProjector` transaction; add the streaming/advisory-lock
+repo. Per-scope serialization via `pg_advisory_xact_lock`.
+
+**Files:** modify `src/Tamma.Data/Audit/AuditProjector.cs` (37-1 file — head read, prev/seq/hash
+assignment within the existing projection transaction); new
+`src/Tamma.Data/Repositories/IAuditChainRepository.cs` + `AuditChainRepository.cs` (head read,
+`StreamRecordsAsync(scope, from, to)`, `AcquireScopeAdvisoryLockAsync`, checkpoint read/write).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Audit/AuditProjectorChainingTests.cs` (docker-bound) —
+sequential appends give `chain_sequence` 1..N with `prev_hash[i]==record_hash[i-1]`; first record's
+`prev_hash==genesis`; N parallel appends to one scope → N rows, strictly monotonic, no fork;
+tenant-A appends never affect tenant-B / platform chain.
+
+**Acceptance criteria:**
+- [ ] Appended records form a valid chain (prev linkage + contiguous sequence).
+- [ ] Concurrent same-scope appends stay strictly monotonic (advisory lock holds).
+- [ ] Chaining is atomic with the 37-1 projection (rollback leaves no orphan sequence).
+
+### 37-2-D: Verifier — tamper detection + localization
+
+**Scope:** `AuditChainVerifier` over the repo's stream; structured first-broken-link result.
+
+**Files:** new `src/Tamma.Core/Audit/IAuditChainVerifier.cs`, `AuditChainVerifier.cs`,
+`ChainVerificationResult.cs` (`Ok` / `Mutated` / `Missing` / `Reordered` / `PrevHashMismatch` /
+`CheckpointSignatureInvalid` / `CheckpointHeadMismatch`, each carrying `recordId` + `chainSequence`).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Audit/AuditChainVerifierTests.cs` (the AC14 matrix) — clean
+→ `Ok`; mutate a payload → `Mutated` at its seq; delete a middle record → `Missing` gap; swap two
+sequences → `Reordered`/`PrevHashMismatch`; clip tail → detected at truncation. (Checkpoint-boundary
+cases land in 37-2-E once checkpoints exist.)
+
+**Acceptance criteria:**
+- [ ] Each tamper class is detected and localized to the exact `chain_sequence`.
+- [ ] Verify is O(n) streaming (no whole-chain materialization); 100k verify within budget (perf test in 37-2-H).
+
+### 37-2-E: Signed checkpoints — signer + entity wiring + boundary verify
+
+**Scope:** Cabinet-backed signer + checkpoint write/read; extend verifier to confirm checkpoint
+signature + head-hash across a boundary.
+
+**Files:** new `src/Tamma.Api/Services/Audit/IAuditChainSigner.cs`,
+`SecretCabinetAuditChainSigner.cs` (resolve signing key via `ISecretStore`; HMAC-SHA256 over canonical
+checkpoint preimage; cache active version w/ short TTL; record `key_version`); checkpoint
+read/write on `AuditChainRepository`; verifier checkpoint-confirmation branch.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Audit/AuditChainSignerTests.cs` +
+`CheckpointBoundaryVerifyTests.cs` — sign/verify round-trips against a fake cabinet; corrupt stored
+`signature` → `CheckpointSignatureInvalid` (distinct from body break); mutate a record between two
+checkpoints → break localized + head-hash mismatch; rotated key (new `key_version`) still validates
+historical checkpoints; signing key is read via `ISecretStore` out-of-band path (never logged/returned).
+
+**Acceptance criteria:**
+- [ ] Checkpoint signature validates against the cabinet key for its `key_version`.
+- [ ] Verify across a checkpoint confirms `head_hash` matches the recomputed head.
+- [ ] Tampered signature reported distinctly from a chain-body break.
+- [ ] No plaintext env/appsettings signing key exists anywhere (grep-clean).
+
+### 37-2-F: Checkpoint scheduler + Elsa workflow
+
+**Scope:** Periodic + on-demand checkpoint writing. Copy `HourlyAnalyticsRollupScheduler` structure
+verbatim.
+
+**Files:** new `src/Tamma.ElsaServer/Workflows/AuditChainCheckpointScheduler.cs` (BackgroundService,
+`Enabled`/`FireAtMinute`/`PollInterval`, `pg_try_advisory_lock` leader, `_lastFired` dedup,
+WARN-and-continue) + `AuditChainCheckpointWorkflow.cs` (enumerate active scopes → write one signed
+checkpoint each, emit `AUDIT.CHAIN.CHECKPOINTED`).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Audit/AuditChainCheckpointSchedulerTests.cs` — `Enabled=false`
+gates the loop; single tick writes one checkpoint per active scope; multi-pod advisory lock yields one
+leader (mirror `HourlyAnalyticsRollupSchedulerTests`).
+
+**Acceptance criteria:**
+- [ ] Scheduler writes one checkpoint per active scope per cadence; idempotent within an hour.
+- [ ] Multi-pod safe (one leader); failure-isolated (one tick failure doesn't kill the loop).
+- [ ] On-demand routine reused by the admin endpoint (37-2-G).
+
+### 37-2-G: Verify endpoints + events + critical alert + built-in rule
+
+**Scope:** HTTP surface, DCB events, alert raise, built-in rule. Per-mode RBAC.
+
+**Files:** modify `src/Tamma.Api/Endpoints/OrgEndpoints.cs` (tenant `GET .../audit/verify`, mirror
+`ListTenantAudit` RBAC), modify `AdminEndpoints.cs` (`GET /api/admin/audit/verify` +
+`POST /api/admin/audit/checkpoint`, `PlatformOwnerAccess`); new
+`src/Tamma.Api/Services/Audit/AuditChainEventEmitter.cs` + `AuditChainEventTypes.cs`
+(`AUDIT.CHAIN.VERIFIED|TAMPER_DETECTED|CHECKPOINTED`, plane-routed via `IEventRepository` /
+`IPlatformEventPublisher`, tamper → `IAlertSink.RaiseAsync` critical); modify
+`Services/Alerts/Rules/BuiltInAlertRules.cs` (`audit-chain-tamper`, critical, EventType
+`AUDIT.CHAIN.TAMPER_DETECTED`, throttle 300); new
+`src/Tamma.Api/Extensions/AuditChainServiceCollectionExtensions.cs`; wire in `Program.cs`.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Audit/AuditChainEndpointsTests.cs` +
+`AuditChainAlertTests.cs` — RBAC matrix (member 403 / tenant_admin 200 / cross-tenant 404 / non-owner
+rejected on admin / single-user sole-user OK); tenant verify never reads other tenants/platform;
+`from`/`to` bounding; clean verify emits `AUDIT.CHAIN.VERIFIED`; tamper emits
+`AUDIT.CHAIN.TAMPER_DETECTED` + raises a `critical` alert (`IAlertSink` invoked, correct plane/tags);
+seeder creates `audit-chain-tamper`; on-demand checkpoint endpoint returns 202 + writes a checkpoint.
+
+**Acceptance criteria:**
+- [ ] Endpoint shape identical between modes; auth middleware decides scope.
+- [ ] Tamper produces a `critical` alert visible at `/api/v1/admin/alerts` (+ tenant feed for tenant scope) with no manual setup.
+- [ ] Events carry `scope`/`tenantId`/`chainSequence`/`reason` tags; no record payloads in event data.
+
+### 37-2-H: Performance + hardening pass
+
+**Scope:** Perf budget proof + edge hardening.
+
+**Files:** `tests/Tamma.Api.Tests/Audit/AuditChainPerfTests.cs`; tighten streaming batch sizes;
+document budgets in the story Dev Notes / runbook.
+
+**Tests:** 100k-record verify within the documented budget (target < 10s on reference VPS); per-append
+chaining overhead under the documented threshold.
+
+**Acceptance criteria:**
+- [ ] Verify perf within budget; append overhead within threshold.
+- [ ] Full suite green; no new lint/analyzer warnings.
+
+---
+
+## Story order & dependencies
+
+37-2-A → 37-2-B → 37-2-C → 37-2-D → 37-2-E → 37-2-F → 37-2-G → 37-2-H.
+
+- **37-1 is the hard gate for everything from 37-2-B onward** (needs `AuditRecord` + `AuditProjector`).
+  37-2-A (pure crypto) can start immediately and in parallel with 37-1.
+- 37-2-D depends on 37-2-A (+ a repo from 37-2-C for live tests, but logic is unit-testable on fakes first).
+- 37-2-E checkpoint-boundary verify extends 37-2-D and needs the signer (Epic 29 cabinet).
+- 37-2-G needs A–F (verifier + signer + checkpoints + events/alerts).
+
+## Risks
+
+- **Canonicalization drift** — the single highest risk. If `canonical(record)` ever changes shape,
+  every historical record fails verification. Mitigation: pin field order + invariant culture + UTC
+  ms, add a `canonicalVersion` byte, and freeze the canonicalizer behind exhaustive byte-stability
+  tests (37-2-A). Any future format change is a new version, never an edit.
+- **37-1 not yet written** — `audit_records`/`AuditProjector` are this story's foundation and don't
+  exist (`story-37-1/` empty). Do NOT start 37-2-B+ until 37-1's projection transaction boundary and
+  record field set are stable; an unstable 37-1 schema churns the canonicalizer + migrations.
+- **Per-scope lock on the projection hot path** — `pg_advisory_xact_lock` serializes appends within a
+  scope. Audit appends are not ultra-high-frequency, but hold the lock for the minimum window (head
+  read + insert only) and keep it transaction-scoped so it auto-releases. Measure in 37-2-H.
+- **Signing-key rotation** — checkpoints must survive Epic 28/29 KEK rotation. `key_version` on every
+  checkpoint + the signer keeping access to prior versions for verification is load-bearing; coordinate
+  with the KEK rotation lifecycle (`project_epic28_kek_decision`).
+- **Append-only trigger is not a security boundary** — a DBA can `DISABLE TRIGGER`. The cryptographic
+  chain + externally-keyed signed checkpoints are the actual proof. State this in the runbook so the
+  trigger isn't mistaken for the guarantee.
+- **Two stores, two migration trees** — chain columns are additive on both Tenant + ControlPlane; the
+  checkpoint table + trigger live in the right store per scope. Verify `has-pending-model-changes`
+  reports none on BOTH after migrations, and mirror entity config only in `TammaModelConfiguration.cs`.
+- **Event-store topology shift (Story 28-1 / Epic 30)** — `AUDIT.CHAIN.*` events route tenant-scope →
+  tenant store, platform-scope → CP store today (copy `AlertEventEmitter`). When events move
+  per-tenant, platform-scope chain events must stay CP-resident — keep the emitter routing explicit.

--- a/docs/superpowers/plans/2026-06-17-37-3-audit-query-search-and-filter-api-plan.md
+++ b/docs/superpowers/plans/2026-06-17-37-3-audit-query-search-and-filter-api-plan.md
@@ -1,0 +1,315 @@
+# Story 37-3: Audit Query, Search & Filter API — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation.
+
+**Goal:** Replace the thin type-prefix tenant audit read (`OrgEndpoints.ListTenantAudit` over raw
+`domain_events`) with a rich, filterable, **keyset-paginated** query API over the curated audit
+read-model from Story 37-1 — per-tenant `audit_records` and control-plane `platform_records`.
+Filter by `category`, `action`, `actorUserId`, `targetType`/`targetId`, `severity`, `outcome`,
+`ipAddress`, and a `[from, to)` time range; search (`q`) over actor/target/payload; paginate by
+`source_sequence_number` (stable under concurrent inserts). Enforce per-mode RBAC (SaaS
+`tenant_admin+` for own-tenant tenant audit; `PlatformOwnerAccess` for platform audit; single-user
+sole user sees everything) with cross-tenant non-leakage as defence-in-depth. Every read emits an
+`AUDIT.QUERIED` meta-audit event. Re-targets the stale Epic 23-10 / 23-4 specs onto the C# stack.
+
+**Story:** [37-3-audit-query-search-and-filter-api.md](../../stories/epic-37/story-37-3/37-3-audit-query-search-and-filter-api.md)
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (`Tamma.Api` endpoints + query
+service; `Tamma.Data` repositories + indexes + migrations). Tests in
+`apps/tamma-elsa/tests/Tamma.Api.Tests/` (xUnit; docker-bound suites run via
+`sg docker -c "dotnet test ..."` — the session docker group is stale, see
+`reference_dotnet_test_docker`). The build itself needs no `sg` wrapper.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO target in `packages/api`.** It is DELETED. All artifacts land in the C# `apps/tamma-elsa`
+  solution. Do not create or cite a TypeScript audit module.
+- **NO write/projection changes.** The curated `audit_records` / `platform_records` tables, their
+  columns, and the projector that populates `source_sequence_number` etc. are owned by Story 37-1.
+  37-3 is read-only over them. If a needed column is missing, surface it as a 37-1 gap — do not
+  bolt projection logic onto the query path.
+- **NO new RBAC primitives.** Reuse `RequireTenantMembershipFilter`, `TenantRoleHierarchy`,
+  `PlatformOwnerAccess`, `ITenantContext`, and the per-tenant global query filter verbatim.
+- **NO offset pagination as the new contract.** Keyset on `source_sequence_number` only. `offset`
+  is accepted-but-ignored-with-WARN for one release for backward compat with `AuditLogTab`.
+- **NO `pg_trgm` GIN index in this story.** B-tree composites satisfy the structured-filter p95;
+  trigram payload search is a documented follow-up.
+- **NO dashboard work.** The admin/tenant audit dashboard consuming these endpoints is separate
+  Epic 37 scope. This story keeps the existing `AuditLogTab` working via the compat shim only.
+- **NO meta-audit recursion.** `AUDIT.QUERIED` is a DCB event, not an `audit_records` row.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+| Site | State today |
+|---|---|
+| `src/Tamma.Api/Endpoints/OrgEndpoints.cs:527` `ListTenantAudit` | Thin read: `IEventRepository.ListByTenantAsync(tenantId, type, limit, offset)` over `domain_events`. Enforces `RequireTenantMembershipFilter` role item + `TenantRoleHierarchy.IsAtLeast(role, Admin)` (line 539); pins `ITenantContext.SetTenantId` for the global-query-filter wall; offset paging clamped `[1,200]`. Projects `AuditEventResponse`. **This is the handler 37-3 rewrites.** |
+| `src/Tamma.Api/Dtos/Orgs/OrgDtos.cs:71` `AuditEventResponse` | `(Id, Type, CreatedAt, Tags, Data)` — Tags/Data as raw JSON strings. The new `AuditRecordResponse` follows this raw-JSON-payload precedent. |
+| `src/Tamma.Api/Program.cs:1512` `orgs` group | `MapGroup("/api/v1/orgs").RequireAuthorization("MemberAccess")`; `1550: orgs.MapGet("/{tenantId:guid}/audit", OrgEndpoints.ListTenantAudit)`. Existing route is reused (richer handler). |
+| `src/Tamma.Api/Program.cs:1442` `v1Admin` group | `MapGroup("/api/v1/admin").RequireAuthorization("AdminAccess")`; per-route `PlatformOwnerAccess` (alerts/alert-rules pattern, lines 1443+). **The new platform audit route follows this convention** → `/api/v1/admin/audit` (spec said `/api/admin/audit`; live convention is `/api/v1/admin/*` — story documents the choice). |
+| `src/Tamma.Api/Program.cs:986` `PlatformOwnerAccess` policy | `PlatformPermissionRequirement("platform_admin")` — the platform gate. |
+| `src/Tamma.Data/Repositories/IEventRepository.cs:46` `ListByTenantAsync` + `PlatformEventRepository.QueryAsync` | The current event-store reads; **NOT** the curated read-model. 37-1 introduces `audit_records`/`platform_records`. |
+| `src/Tamma.Data/TenantDbContext.cs`, `TammaModelConfiguration.cs` | Per-tenant global query filter lives here; `audit_records` mapping is owned by 37-1 (37-3 adds query indexes via migration). |
+| `packages/dashboard/src/pages/admin/AuditLogTab.tsx` | Existing consumer of `?type=&limit=&offset=` — must not break (compat shim). |
+
+**Verified-absent (all NEW in this work):** `audit_records`, `platform_records`,
+`source_sequence_number`/`SourceSequenceNumber` (grep: zero hits), any `AUDIT.*` event type,
+`AuditQueryService`, `IAuditRecordRepository`, `/api/v1/admin/audit` route. The first two +
+`source_sequence_number` are introduced by **Story 37-1** (its `story-37-1/` dir is currently empty
+— 37-1 is an un-authored hard dependency; confirm its entity/column names before coding 37-3).
+
+---
+
+## Architecture
+
+**Parse → query (keyset) → project → meta-audit**, two physically separate scopes:
+
+1. **`AuditQueryFilter`** (`Services/Audit/`) — immutable record + `TryParse(IQueryCollection)`
+   that validates enums (`severity`/`outcome`/`category`/`action`), enforces `from < to`, clamps
+   `limit` to `[1,200]`, and decodes the opaque base64url `cursor` (a single `long`
+   `source_sequence_number`). Parse failure → `400` with a descriptive message (never a silent
+   empty list).
+2. **`AuditQueryService` / `IAuditQueryService`** — builds the EF `IQueryable`, applies each filter
+   conditionally (AND-combined), applies `q` via parameterized `EF.Functions.ILike` over
+   `ActorLabel` / `TargetId` / `PayloadText`, applies the keyset predicate
+   (`SourceSequenceNumber < cursor`), orders `DESC` (unique monotonic key = its own tiebreak),
+   `Take(limit + 1)` to compute `nextCursor`, and returns an estimated `total`.
+3. **Repositories** — `AuditRecordRepository` (TenantDbContext-bound, global-query-filter aware)
+   and `PlatformAuditRecordRepository` (ControlPlaneDbContext-bound). Created here or extended from
+   37-1's seam.
+4. **Endpoints** — `OrgEndpoints.ListTenantAudit` rewritten to delegate to the service (keeping the
+   exact RBAC gate it already has); new `AdminEndpoints.ListPlatformAudit` gated `PlatformOwnerAccess`.
+5. **Meta-audit** — `AUDIT.QUERIED` appended best-effort after a successful read (tenant store for
+   tenant scope, CP store for platform scope); tags `tenantId`/`actorUserId`/`scope`/`mode`, data
+   = applied filter set + result count (NOT rows). 403s emit nothing.
+6. **Indexes + migrations** — composite B-trees on `audit_records` (Tenant migration) and
+   `platform_records` (ControlPlane migration) to hit p95 < 300ms over 1M rows.
+
+### Per-mode ownership (the two-scoping-model answer)
+
+| | single-user | SaaS |
+|---|---|---|
+| Tenant audit read | sole user (owns everything) | `tenant_owner`/`tenant_admin`, **own tenant only**; `member` → 403; cross-tenant → 403 |
+| Platform audit read | sole user (operator) | `PlatformOwnerAccess` only; tenants never see it |
+| Cross-tenant wall | n/a | `ITenantContext.SetTenantId` + global query filter (2nd wall behind explicit `WHERE tenant_id`) |
+| Meta-audit fan-out | user feed (`tenantId` null) | tenant scope → `tenantId` set; platform scope → `tenantId` null |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`) | same |
+
+---
+
+## Task breakdown
+
+### T1: `AuditQueryFilter` — parse, validate, cursor codec (pure, no DB)
+
+**Scope:** The typed filter record + `TryParse` + base64url cursor encode/decode. Pure unit-testable.
+
+**Files:**
+- New: `src/Tamma.Api/Services/Audit/AuditQueryFilter.cs` (record + `TryParse` returning
+  `(AuditQueryFilter?, string? error)`; `ToAuditableShape()` for the meta-audit data; static
+  `EncodeCursor(long)` / `TryDecodeCursor(string)`).
+- New: `src/Tamma.Api/Services/Audit/AuditQueryEventTypes.cs` (`public const string Queried = "AUDIT.QUERIED";`).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Audit/AuditQueryFilterTests.cs` — valid combos parse;
+invalid `severity`/`outcome`/`category`/`action` → error; `from > to` → error; `limit` clamps to
+`[1,200]` (0→1, 999→200, non-int→default 50); cursor round-trips (`EncodeCursor` ∘ `TryDecodeCursor`
+== identity); garbage cursor → error; whitespace `q` normalized to null.
+
+**Acceptance:**
+- [ ] Parsing is total: every bad input yields a descriptive error string, never an exception.
+- [ ] Cursor is opaque (base64url) and round-trips a `long` exactly.
+- [ ] `ToAuditableShape()` excludes nothing sensitive beyond raw search term handling per logging rules.
+
+### T2: Confirm/define the 37-1 read-model seam + repositories
+
+**Scope:** Pin the `audit_records` / `platform_records` entity + column names from Story 37-1
+(assume `SourceSequenceNumber:long`, `ActionCategory`, `ActionCode`, `ActorUserId:Guid`,
+`ActorLabel`, `TargetType`, `TargetId`, `Severity`, `Outcome`, `IpAddress`, `OccurredAt:DateTime`,
+`PayloadText`/`Payload`, `TenantId` on tenant rows). Create the keyset/filter repositories.
+
+**Files:**
+- New or extend: `src/Tamma.Data/Repositories/IAuditRecordRepository.cs` +
+  `AuditRecordRepository.cs` (TenantDbContext-bound; exposes
+  `Task<(IReadOnlyList<AuditRecord> Rows, long? NextCursor, int Total)> QueryAsync(Guid tenantId, AuditQuerySpec spec, CancellationToken)` —
+  spec is the DB-facing shape derived from `AuditQueryFilter`).
+- New: `src/Tamma.Data/Repositories/IPlatformAuditRecordRepository.cs` +
+  `PlatformAuditRecordRepository.cs` (ControlPlaneDbContext-bound; no `tenant_id` predicate).
+
+> **Blocking check:** if Story 37-1 already ships `IAuditRecordRepository`, extend it rather than
+> duplicate. If 37-1 has not landed, this task is gated — either land 37-1 first or stub the entity
+> with a CLEARLY-marked `// OWNED BY 37-1` note and coordinate.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Audit/AuditRecordRepositoryTests.cs` (Testcontainers
+Postgres) — seed rows, assert `QueryAsync` keyset seek returns correct ordered subset; assert the
+TenantDbContext global query filter blocks foreign-tenant rows even with a tampered explicit
+predicate.
+
+**Acceptance:**
+- [ ] Repos read ONLY their own table (tenant repo never touches `platform_records`, vice-versa).
+- [ ] Keyset seek uses `WHERE source_sequence_number < cursor ORDER BY source_sequence_number DESC`.
+
+### T3: Composite indexes + migrations (p95 < 300ms)
+
+**Scope:** Add the supporting indexes via additive EF migrations.
+
+**Files:**
+- New Tenant migration `src/Tamma.Data/Migrations/Tenant/*_AuditRecordsQueryIndexes.cs`:
+  `(tenant_id, action_category, occurred_at DESC)`, `(tenant_id, actor_user_id, occurred_at DESC)`,
+  `(tenant_id, source_sequence_number DESC)`.
+- New ControlPlane migration `src/Tamma.Data/Migrations/ControlPlane/*_PlatformRecordsQueryIndexes.cs`:
+  `(action_category, occurred_at DESC)`, `(source_sequence_number DESC)`.
+- Mirror index config in `TammaModelConfiguration.cs` (single source of truth) if 37-1 maps these
+  entities there.
+
+**Tests / verification:** after generating each migration, run `dotnet ef migrations has-pending-model-changes`
+→ must report none; apply + roll back cleanly on a Testcontainers DB. The p95 perf assertion lives
+in T7.
+
+**Acceptance:**
+- [ ] `has-pending-model-changes` reports none after both migrations.
+- [ ] Index names match the story; migrations apply and roll back on a clean DB.
+
+### T4: `AuditQueryService` — the query orchestrator
+
+**Scope:** `IAuditQueryService` with `QueryTenantAsync(tenantId, filter, ct)` and
+`QueryPlatformAsync(filter, ct)`. Pins `ITenantContext.SetTenantId(tenantId)` for the tenant path
+(2nd-wall), delegates to the repo, projects `AuditRecordResponse`, computes `nextCursor`, returns
+an estimated `total` (planner estimate or capped exact count), and emits `AUDIT.QUERIED`
+best-effort after materialization.
+
+**Files:**
+- New: `src/Tamma.Api/Services/Audit/IAuditQueryService.cs`, `AuditQueryService.cs`.
+- New: `src/Tamma.Api/Dtos/Audit/AuditRecordResponse.cs` (AC-11 shape; payload as raw JSON string),
+  `AuditQueryResponse.cs` (`{ records, nextCursor, total }`).
+- DI: register in `Program.cs` (scoped), alongside the repos.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Audit/AuditQueryServiceTests.cs` — each filter dimension
+isolates the right subset; AND-combination narrows; `q` matches `ActorLabel`/`TargetId`/`PayloadText`
+case-insensitively; injection-shaped `q` returns only legit matches (parameterization);
+`nextCursor` null on last page, set otherwise; `total` returned; `AUDIT.QUERIED` appended once on
+success with filter set + count in `Data`; append-failure logs WARN and does NOT fail the read;
+tenant path pins ambient context.
+
+**Acceptance:**
+- [ ] All AC-3 filters + AC-4 search behave per spec; `q` is parameterized.
+- [ ] Meta-audit emitted exactly once per successful read; never recurses; never fails the read.
+- [ ] `total` is an estimate (documented), not a blocking full COUNT over millions of rows.
+
+### T5: Endpoints — tenant rewrite + platform new
+
+**Scope:** Rewrite `OrgEndpoints.ListTenantAudit` to parse `AuditQueryFilter` and delegate to
+`QueryTenantAsync`, **keeping the existing RBAC gate verbatim** (membership role item +
+`TenantRoleHierarchy.IsAtLeast(role, Admin)`); keep `type`/`offset` accepted-but-shimmed for compat.
+Add `AdminEndpoints.ListPlatformAudit` → `QueryPlatformAsync`, wired on `v1Admin` with
+`PlatformOwnerAccess`.
+
+**Files:**
+- Modify: `src/Tamma.Api/Endpoints/OrgEndpoints.cs` (`ListTenantAudit`).
+- Modify: `src/Tamma.Api/Endpoints/AdminEndpoints.cs` (add `ListPlatformAudit`).
+- Modify: `src/Tamma.Api/Program.cs` (`v1Admin.MapGet("/audit", AdminEndpoints.ListPlatformAudit).RequireAuthorization("PlatformOwnerAccess");`).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Audit/AuditEndpointsTests.cs` — invalid filter → 400;
+valid filter → 200 with `{records, nextCursor, total}`; legacy `?type=&offset=` still returns rows
+(compat shim, WARN on `offset`); platform route present and shaped identically.
+
+**Acceptance:**
+- [ ] Tenant route keeps its existing membership + admin gate (byte-for-byte RBAC behaviour where
+      a `member` still gets 403).
+- [ ] Platform route is `PlatformOwnerAccess`-gated and reads `platform_records` only.
+- [ ] Backward-compat: existing `AuditLogTab` request shape still returns rows.
+
+### T6: RBAC matrix + cross-tenant non-leakage (integration)
+
+**Scope:** The full security matrix and the isolation wall, end-to-end through the HTTP pipeline.
+
+**Files:**
+- New: `tests/Tamma.Api.Tests/Audit/AuditRbacTests.cs`,
+  `tests/Tamma.Api.Tests/Audit/AuditCrossTenantTests.cs`,
+  `tests/Tamma.Api.Tests/Audit/AuditMetaAuditTests.cs`.
+
+**Tests:**
+- RBAC per mode (single-user, SaaS): member→403, tenant_admin own→200, tenant_admin foreign→403,
+  non-platform-owner on `/api/v1/admin/audit`→403, platform owner→200, single-user→200 on both.
+- Cross-tenant: tenant-A admin with a predicate tampered to tenant B (ambient pinned to A) → zero
+  B rows (global query filter). Tenant query never returns `platform_records` rows; platform query
+  never returns tenant rows.
+- Meta-audit: success → one `AUDIT.QUERIED` (`scope=tenant`/`platform`, correct `tenantId`); 403 →
+  none.
+
+**Acceptance:**
+- [ ] Entire AC-7 / AC-8 / AC-10 matrix is green.
+- [ ] A deliberately-broken explicit `WHERE tenant_id` predicate still leaks nothing (2nd wall proven).
+
+### T7: Keyset correctness + performance (integration)
+
+**Scope:** Page-boundary correctness, concurrent-insert stability, and the p95 budget.
+
+**Files:**
+- New: `tests/Tamma.Api.Tests/Audit/AuditKeysetPaginationTests.cs`,
+  `tests/Tamma.Api.Tests/Audit/AuditPerformanceTests.cs` (gated/`[Trait("perf")]` so it's
+  opt-in locally but runnable in CI).
+
+**Tests:**
+- 250 rows @ `limit=100` → 3 pages, no overlap/gap, `nextCursor` null on page 3.
+- Concurrent-insert stability: snapshot page-1 cursor, append 10 newer rows, fetch page 2 → exactly
+  the originally-expected rows (boundary unmoved).
+- `from > to` → 400; undecodable cursor → 400.
+- Perf: ~1M `audit_records` for one tenant → representative filtered + keyset query p95 < 300ms
+  with indexes; regression canary: drop `(tenant_id, source_sequence_number DESC)` → query degrades
+  sharply (asserts the index is load-bearing).
+
+**Acceptance:**
+- [ ] Keyset is provably stable under concurrent inserts.
+- [ ] p95 < 300ms with the composite indexes over 1M rows.
+
+### T8: Full-suite green + verification
+
+**Scope:** Run the whole C# suite, confirm no regressions, confirm migrations clean.
+
+**Steps:**
+- [ ] `sg docker -c "dotnet test apps/tamma-elsa/Tamma.sln"` (or the project-scoped equivalent) green.
+- [ ] `dotnet ef migrations has-pending-model-changes` → none for both contexts.
+- [ ] Verify `AuditLogTab` request shape still returns rows (compat shim) — manual or e2e.
+
+**Acceptance:**
+- [ ] Full suite green; no pending model changes; no regression in existing org/admin tests.
+
+---
+
+## Task order & dependencies
+
+T1 (pure) → T2 (repos, **gated on 37-1 seam**) → T3 (indexes) → T4 (service) → T5 (endpoints) →
+T6 + T7 (parallel-safe integration suites) → T8 (verify). T1 and the 37-1 seam confirmation can
+proceed immediately; T4 needs T1+T2; T5 needs T4; T6/T7 need T5.
+
+## Risks
+
+- **Story 37-1 not landed / column names differ.** Hardest dependency. T2 is gated on confirming
+  the exact `audit_records`/`platform_records` schema and the `source_sequence_number` column
+  name/type. Mitigation: confirm the seam before T2; if 37-1 lags, do not invent the projection —
+  coordinate or stub with `// OWNED BY 37-1` markers.
+- **Keyset assumes `source_sequence_number` is unique + monotonic.** If 37-1's sequence is
+  per-tenant-reset or non-unique, the single-key keyset breaks (needs a `(occurred_at, id)`
+  composite tiebreak). Mitigation: assert uniqueness/monotonicity in T2; fall back to a composite
+  keyset only if 37-1's sequence is not globally unique.
+- **`total` cost.** A naive `COUNT(*)` over filtered millions blows p95. Mitigation: estimate
+  (planner) or cap; T4 must not gate the page on an exact count. Document "~N"/"N+" semantics.
+- **`q` payload search at scale.** `ILIKE '%...%'` is a scan; fine within narrowed filters,
+  expensive for `q`-only. Mitigation: documented `pg_trgm` follow-up; keep it out of the p95 AC.
+- **Cross-tenant regression.** The explicit `WHERE tenant_id` could drift. Mitigation: the ambient
+  `ITenantContext` + global query filter is the load-bearing 2nd wall; T6 asserts a tampered
+  predicate still leaks nothing — do NOT remove the global filter "because the explicit one exists".
+- **Meta-audit recursion / failure coupling.** `AUDIT.QUERIED` must be a DCB event (not an
+  `audit_records` row) and append best-effort. Mitigation: T4 asserts append-failure does not fail
+  the read and that the event never re-enters this query surface.
+- **Route convention drift.** Spec said `/api/admin/audit`; live convention is `/api/v1/admin/*`
+  (`v1Admin` group, `PlatformOwnerAccess` per-route, alerts precedent). Story documents the choice;
+  add a `/api/admin/audit` alias only if Epic 37 lead requires parity.
+- **Migration discipline.** Indexes are additive, but still run `has-pending-model-changes` (none)
+  after each migration and mirror config in `TammaModelConfiguration.cs` if 37-1 maps the entities
+  there (single source of truth).

--- a/docs/superpowers/plans/2026-06-17-37-4-signed-audit-export-with-integrity-manifest-plan.md
+++ b/docs/superpowers/plans/2026-06-17-37-4-signed-audit-export-with-integrity-manifest-plan.md
@@ -1,0 +1,293 @@
+# Story 37-4 — Signed Audit Export (JSON/CSV) with Integrity Manifest — Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation. Before any code, read
+> [BEFORE_YOU_CODE.md](../../guides/BEFORE_YOU_CODE.md).
+
+**Story:** `docs/stories/epic-37/story-37-4/37-4-signed-audit-export-with-integrity-manifest.md`
+(Status: drafted). Epic 37 — Audit, Compliance & Data Governance.
+
+**Goal:** Let admins export a time/filter-bounded slice of the tamper-evident audit trail
+(`audit_records` read-model + hash chain from 37-1/37-2, queried with the 37-3 filter) in JSON and
+CSV, packaged with an **integrity manifest** (record count, chain head hash + checkpoint ref, and a
+cabinet-key signature) so a recipient can verify **offline** that the export was not altered and
+corresponds to the chain. Large exports run **asynchronously** (`QueuedTask` + downloadable,
+encrypted, auto-expiring artifact), mirroring tenant provisioning. The export is itself an audited
+action (`AUDIT.EXPORTED`).
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane API + Elsa engine).
+Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/` (xUnit; docker-bound suites run via
+`sg docker -c "dotnet test ..."`; the build itself needs no wrapper). **Target is the C# app only —
+the deleted `packages/api` TypeScript API is NOT a target.**
+
+---
+
+## Non-goals (YAGNI guard)
+
+- NO change to the audit read-model, redaction, or hash-chain semantics. 37-1 owns redaction, 37-2
+  owns the chain, 37-3 owns the filter. This story READS their public surfaces and packages/signs —
+  it never re-derives or un-redacts a field, and never recomputes the canonical chain definition.
+- NO new signing/crypto primitive. Signing uses the **Epic 29 cabinet key** via
+  `ISecretStore`/`KekProvider`; at-rest encryption reuses the AES-GCM layout from
+  `TenantSecretProtector` / `AesGcmConnectionStringDecryptor`. Do not hand-roll a scheme.
+- NO new async infrastructure. Reuse `QueuedTask` + `ITaskHandler` (`TypePrefix "audit.export."`) +
+  `TaskQueueProcessor`; platform-scope rides `PlatformTaskWorker` like provisioning.
+- NO object-store dependency in v1. The encrypted artifact lives as `bytea` on `audit_export_jobs`
+  behind a tiny interface so swapping to S3/MinIO later is a one-class change.
+- NO per-user export sharing / ACL beyond scope ownership. A job is owned by its scope; cross-scope
+  fetch is a 404. No long-lived public links — download is time-limited + single-scope.
+- NO streaming-zip-over-HTTP for the async path. Async builds the full bundle then serves it; the
+  sync fast path may stream a small bundle inline.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### What exists and is reused
+
+| Capability | Where (verified) |
+|---|---|
+| Tenant audit read (DCB) + admin-role gate + tenant-scope defence-in-depth | `src/Tamma.Api/Endpoints/OrgEndpoints.cs` `ListTenantAudit` (~527); DTO `src/Tamma.Api/Dtos/Orgs/OrgDtos.cs` `AuditEventResponse` (~71) |
+| RBAC policies | `Program.cs`: `OwnerAccess` (~971), `PlatformOwnerAccess` (~986); `RequireTenantMembershipFilter` registered (~352) |
+| Async job queue | `src/Tamma.Data/Entities/QueuedTask.cs` (status pending/processing/completed/failed, TenantId, Payload jsonb, ClaimedAt reaper); `src/Tamma.Api/Services/TaskQueue/{ITaskHandler,TaskQueueProcessor,DbTaskQueue}.cs`; registration `Extensions/TaskQueueServiceCollectionExtensions.cs` (`AddTaskQueue`, DI-resolved `ITaskHandlerRegistry`, exact-then-longest-prefix match) |
+| Platform-scope async | `src/Tamma.Api/Services/PlatformTasks/{PlatformTaskWorker,IPlatformTaskHandler}.cs` (provisioning precedent) |
+| AES-GCM at rest | `src/Tamma.Api/Services/Provisioning/TenantSecretProtector.cs` (12-byte nonce ‖ ct ‖ 16-byte tag; key from cabinet/config); `src/Tamma.Api/Services/Secrets/AesGcmConnectionStringDecryptor.cs` |
+| Epic 29 secret cabinet | `src/Tamma.Api/Services/Secrets/ISecretStore.cs`, `KekProvider.cs`, `SecretScope.cs`, `SecretPurpose.cs`; rotation precedent `KekRotationCoordinator.cs` / Story 28-12 |
+| DCB / audit append | `src/Tamma.Data/Repositories/{IEventRepository,EventRepository}.cs` `AppendAsync` (tenant-required; platform via `IPlatformEventRepository`) |
+| Crypto primitives in-repo | `System.Security.Cryptography` already used: `HMACSHA256` (`Tamma.Platforms/Webhooks/HmacWebhookSignatureVerifier.cs`, `OnboardingEndpoints.cs`), AES-GCM (above) |
+| Model config single source | `src/Tamma.Data/TammaModelConfiguration.cs` + `ControlPlaneDbContext.cs`; migrations under `src/Tamma.Data/Migrations/ControlPlane/` |
+
+### What this story DEPENDS on (not yet merged at plan time)
+
+- **37-1** curated `audit_records` read-model + field-level redaction — the export reads
+  already-redacted rows. **37-2** hash chain (`head_hash`) + checkpoints. **37-3** the shared filter
+  DTO. The `Services/Audit/` directory does NOT exist yet (it is created by this story; 37-1..37-3
+  add their own files alongside). Sequence 37-4 after 37-1/37-2/37-3 land; depend on their public
+  types, not internals.
+- **Epic 29** signing key — coordinate a dedicated `SecretPurpose` (e.g. `AuditExportSigning`)
+  rather than reusing a KEK so rotation domains stay separate.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Export the **tenant** slice | sole user (authn only) | `tenant_owner`/`tenant_admin` of route tenant; member → 403 |
+| Export the **platform** slice | sole user | `PlatformOwnerAccess` only |
+| Rows in a tenant export | user's records | route tenant's `audit_records` ONLY (read-model scoping = defence in depth) |
+| Fetch/download a job | the user | the export's scope owner only; other scope/tenant → 404 (no existence leak) |
+| Mode source | `ITammaModeProvider` (process-stable) | same |
+
+---
+
+## Architecture
+
+**query (37-3 filter) → serialize (redacted rows, JSON/CSV) → digest (`data_sha256`) → manifest
+(chain head + checkpoint + counts) → sign (cabinet key) → zip → encrypt at rest (AES-GCM) →
+persist job → ready → time-limited encrypted download.** Large slices run on the `QueuedTask`
+handler; small slices may build inline. Initiation emits `AUDIT.EXPORTED`.
+
+Key seams (all NEW, under `src/Tamma.Api/Services/Audit/` unless noted):
+
+1. **`IAuditExportService` / `AuditExportService`** — orchestrator. `RequestExportAsync(scope,
+   tenantId?, format, filter, actor)` → resolves row count, decides sync vs async, persists an
+   `AuditExportJob`, emits `AUDIT.EXPORTED`, returns `{ jobId, status }`. `BuildBundleAsync(jobId)`
+   is the pure-ish build path called by the sync path AND the task handler.
+2. **`AuditJsonWriter` / `AuditCsvWriter`** — deterministic serializers over the redacted
+   read-model rows. CSV neutralizes formula injection (`= + - @` / tab / CR) + RFC-4180 quoting.
+3. **`AuditExportManifest` + `AuditExportSigner`** — manifest record, canonical (sorted-key,
+   no-whitespace, UTC-ms) serialization of signed fields incl. `data_sha256` + `chain.head_hash` +
+   `checkpoint_id`; sign/verify via the Epic 29 cabinet key (`ISecretStore`/`KekProvider`),
+   recording `alg` + `key_version`.
+4. **`AuditExportArtifactProtector`** — AES-GCM wrap/unwrap of the `.zip`, mirroring
+   `TenantSecretProtector`.
+5. **`AuditExportTaskHandler : ITaskHandler`** (`TypePrefix "audit.export."`) — drives a queued job
+   `generating → ready`/`failed`, idempotent on retry.
+6. **`AuditExportJob` entity + additive migration** — job + artifact metadata + ciphertext +
+   expiry, scope XOR check.
+7. **Endpoints** on `OrgEndpoints.cs` (tenant) + `AdminEndpoints.cs` (platform): export / status /
+   download, scope-namespaced jobIds, cross-scope → 404.
+8. **`AddAuditExport()` extension** wired once from `Program.cs`; routes mapped in `Program.cs`.
+
+---
+
+## Task breakdown (TDD — tests first in every task)
+
+### T1: `AuditExportJob` entity + additive migration + model config
+
+**Scope:** New entity, DbSet, `TammaModelConfiguration` mapping, additive EF migration. No service
+logic yet.
+
+- [ ] Write `AuditExportJobModelTests` (CHECK enforced: scope XOR tenant_id; status enum;
+      round-trip insert/read; expiry index present).
+- [ ] `src/Tamma.Data/Entities/AuditExportJob.cs` (fields per story migration: scope, tenant_id,
+      requested_by, format, filter jsonb, status, record_count, manifest jsonb,
+      artifact_ciphertext bytea, error, timestamps, expires_at).
+- [ ] DbSet on `ControlPlaneDbContext.cs`; config in `TammaModelConfiguration.cs` (CHECK constraints,
+      indexes). `dotnet ef migrations add AddAuditExportJobs` under
+      `src/Tamma.Data/Migrations/ControlPlane/`; verify `has-pending-model-changes` → none.
+
+**AC covered:** 4 (job model), 5 (expiry column), 10/11 (scope XOR for isolation).
+**Done when:** migration applies + rolls back; full suite green.
+
+### T2: `AuditCsvWriter` + `AuditJsonWriter` (pure serializers)
+
+**Scope:** Deterministic serialization of redacted read-model rows; CSV safety.
+
+- [ ] `AuditCsvWriterTests`: formula-injection neutralization for `= + - @`, tab, CR; RFC-4180
+      quoting of `" , \n \r`; round-trip through a CSV parser yields the safe value; redacted field
+      stays redacted; stable column order.
+- [ ] `AuditJsonWriterTests`: deterministic JSON array of redacted rows; stable key order; redacted
+      field stays redacted; UTC-ms timestamps.
+- [ ] Implement both writers (stream-friendly: write to a `Stream`/`TextWriter`).
+
+**AC covered:** 8 (CSV injection), 9 (redaction preserved both formats).
+**Done when:** writer tests green; no un-redaction path exists.
+
+### T3: `AuditExportManifest` + `AuditExportSigner` (canonical sign/verify)
+
+**Scope:** Manifest model, canonical serialization, sign/verify against the Epic 29 cabinet key.
+
+- [ ] `AuditExportSignerTests`: sign→verify round-trip with a fixture cabinet key; flip a signed
+      manifest field → verify fails; flip `data_sha256` (data tampered) → verify fails; tamper
+      `export_signature` → verify fails; wrong `key_version` → verify fails; canonical form is
+      byte-stable across runs (sorted keys, no whitespace, UTC ms).
+- [ ] `AuditExportManifest.cs` (record + signed-field set incl. `chain.head_hash`,
+      `checkpoint_id`, `data_sha256`, counts, scope, filter, generated_*); canonical serializer.
+- [ ] `AuditExportSigner.cs` resolving the signing key via `ISecretStore`/`KekProvider`
+      (dedicated `SecretPurpose`); `Sign(manifest)` + `Verify(manifest, key)`; record `alg` +
+      `key_version`. Prefer asymmetric (ECDSA) if a cabinet asymmetric key is available (offline
+      verify without sharing a secret); HMAC-SHA-256 is the minimum bar.
+
+**AC covered:** 2 (manifest contents), 3 (signature over canonical manifest), 6 (offline verify of
+signature + digest).
+**Done when:** signer tests green; canonical form documented (matches the bundle verify recipe).
+
+### T4: `AuditExportArtifactProtector` (AES-GCM at rest)
+
+**Scope:** Encrypt/decrypt the `.zip` bytes, mirroring `TenantSecretProtector`.
+
+- [ ] `AuditExportArtifactProtectorTests`: encrypt→decrypt round-trip; ciphertext ≠ plaintext;
+      single-byte flip on ciphertext fails AES-GCM auth; nonce uniqueness across two encrypts.
+- [ ] `AuditExportArtifactProtector.cs` (12-byte nonce ‖ ct ‖ 16-byte tag; key from Epic 29
+      cabinet).
+
+**AC covered:** 5 (encrypted at rest).
+**Done when:** protector tests green; reuses the existing AES-GCM layout (no new scheme).
+
+### T5: `AuditExportService` — build path + sync/async decision + `AUDIT.EXPORTED`
+
+**Scope:** Orchestrate query → serialize → digest → manifest → sign → zip → encrypt → persist;
+decide sync vs async on `record_count` vs `SyncRowThreshold`; emit `AUDIT.EXPORTED`.
+
+- [ ] `AuditExportServiceTests`: sub-threshold → built inline, job `ready` immediately; over-
+      threshold → job `pending` + a `QueuedTask` enqueued (type `audit.export.{scope}`, payload
+      `{ jobId }`); `AUDIT.EXPORTED` written exactly once (tags actor/scope/record_count/filter/
+      format) and sorts AFTER the exported chain head (not in the slice); manifest binds the chain
+      head/checkpoint captured for the slice; build failure → job `failed` + non-leaky error +
+      partial artifact purged.
+- [ ] `IAuditExportService.cs` / `AuditExportService.cs`; `AuditExportOptions.cs`
+      (`SyncRowThreshold` default 10_000, `ArtifactTtl` default 24h, `MaxRows`). Read the 37-3
+      filter + 37-1 redacted rows + 37-2 chain head/checkpoint via their public surfaces.
+
+**AC covered:** 1 (sync vs async decision), 2/3 (manifest + signature), 6 (chain binding), 7
+(`AUDIT.EXPORTED`), 12 (graceful failure).
+**Done when:** service tests green; `AUDIT.EXPORTED` ordering pinned by test.
+
+### T6: `AuditExportTaskHandler` (async generation)
+
+**Scope:** `ITaskHandler` for `audit.export.` driving the queued build idempotently.
+
+- [ ] `AuditExportTaskHandlerTests`: `TypePrefix` resolves via `DiTaskHandlerRegistry`; happy path
+      `pending → generating → ready`; retry on a `generating`/`ready` job is a safe no-op/regen;
+      exception counts against retry budget and terminal failure flips job `failed`; tenant-scope
+      task carries `QueuedTask.TenantId`.
+- [ ] `AuditExportTaskHandler.cs` (loads `AuditExportJob` by payload `jobId`; calls
+      `AuditExportService.BuildBundleAsync`). Platform-scope rides `PlatformTaskWorker` per the
+      provisioning precedent (or the unified queue if scope is encoded in `TenantId` null).
+
+**AC covered:** 4 (async lifecycle), 12 (failure path).
+**Done when:** handler tests green; idempotent retry proven.
+
+### T7: Endpoints (tenant + platform) — export / status / download + RBAC
+
+**Scope:** Wire the HTTP surface with per-mode RBAC + scope isolation.
+
+- [ ] `AuditExportEndpointsTests`:
+  - `POST .../export` returns `202` + `jobId` (tenant + platform); body reuses the 37-3 filter +
+    `format`.
+  - RBAC: SaaS member → 403 on tenant export; non-platform-owner → 403 on platform export; tenant
+    export rows exclude platform/other-tenant (defence in depth); single-user sole user → both
+    slices.
+  - `GET .../export/{id}` reflects state; `downloadUrl` only when `ready`.
+  - download: `ready` → `200 application/zip`; `expired` → `410`; cross-scope/cross-tenant `{jobId}`
+    → `404` (no existence leak); tampered ciphertext → ERROR-logged failure.
+- [ ] Add handlers to `OrgEndpoints.cs` (mirror `ListTenantAudit` membership+admin gate) and
+      `AdminEndpoints.cs` (`PlatformOwnerAccess`); scope-namespaced job resolution.
+
+**AC covered:** 1, 4, 5 (410 on expiry), 10, 11.
+**Done when:** endpoint tests green; RBAC matrix + isolation pinned.
+
+### T8: Expiry reaper + DI wiring + route mapping
+
+**Scope:** Auto-expire artifacts; wire everything once from `Program.cs`.
+
+- [ ] Reaper test: a `ready` job past `expires_at` flips to `expired` and `artifact_ciphertext` is
+      scrubbed; download then 410. (Reuse the `QueuedTask` ClaimedAt-reaper pattern, or a small
+      hosted service / periodic sweep.)
+- [ ] `AuditExportServiceCollectionExtensions.cs` `AddAuditExport()` (TryAdd* idempotent; registers
+      service, signer, protector, options, task handler, reaper). Call once from `Program.cs`; map
+      the new routes there.
+
+**AC covered:** 5 (auto-expiry), wiring for 1/4.
+**Done when:** reaper test green; `AddAuditExport()` called once; routes reachable.
+
+### T9: Offline verify helper + bundle README
+
+**Scope:** Make the "verifiable offline" claim concrete + executable.
+
+- [ ] Verify-helper test: a valid bundle verifies (digest + signature + chain reconstruction over
+      exported rows == `head_hash`/`checkpoint_id`); remove/insert one exported row → chain
+      reconstruction mismatch; flip the data file → digest mismatch; flip the manifest → signature
+      mismatch.
+- [ ] `tamma audit verify-export <bundle.zip>` helper (or a documented standalone script) running
+      the three-step recipe and exiting non-zero on any failure; include a `README` in the bundle
+      describing the recipe.
+
+**AC covered:** 6 (offline verifiability — full three-step), reinforces 2/3.
+**Done when:** verify-helper test green; recipe matches the manifest canonical form from T3.
+
+---
+
+## Task order & dependencies
+
+T1 (entity/migration) → T2 (writers) ‖ T3 (manifest/signer) ‖ T4 (protector) — T2/T3/T4 are pure
+and parallel-safe after T1 — → T5 (service ties T2-T4 + 37-1/37-2/37-3 reads) → T6 (task handler) →
+T7 (endpoints) → T8 (reaper + wiring) → T9 (verify helper). T5 is the integration crux and the only
+task that needs all three dependency stories merged.
+
+## Risks
+
+- **Dependency story drift (37-1/37-2/37-3):** their read-model/chain/filter surfaces are consumed
+  here. Pin to their public types; sequence 37-4 after they merge. If a surface is still in flux,
+  stub the read behind a thin port (`IAuditReadModel`) so T2-T4 proceed against a fixture.
+- **Canonical-form divergence:** the signer's canonical serialization MUST match the offline verify
+  helper byte-for-byte, or every verify fails. T3 and T9 share one canonicalizer — do NOT duplicate
+  the logic; expose it as a single internal method and test both against the same fixture.
+- **Key rotation breaks old bundles:** record `key_version` in the manifest (Story 28-12 rotation
+  precedent) and have `Verify` select the right cabinet key version; test verify against a rotated
+  cabinet.
+- **CSV injection regression:** neutralization must apply to the VALUE (not display) and survive a
+  real parser round-trip; the OWASP cases (`= + - @`, tab, CR) are table-tested.
+- **`AUDIT.EXPORTED` self-reference:** writing the export record BEFORE capturing the slice head
+  would put the export inside its own slice and make `head_hash` unreproducible. Capture head first,
+  then write `AUDIT.EXPORTED` — pinned by a T5 ordering test.
+- **Artifact storage bloat:** `bytea` artifacts + expiry reaper keep the table bounded; cap with
+  `MaxRows` and `ArtifactTtl`. The protector interface allows an object-store backend later with no
+  caller change.
+- **Migration discipline:** `audit_export_jobs` is additive — standard `dotnet ef migrations add`,
+  confirm `has-pending-model-changes` → none, mirror config in `TammaModelConfiguration.cs` only.
+- **Async on the shared processor:** the build path runs on `TaskQueueProcessor` /
+  `PlatformTaskWorker` threads (same as provisioning's long polls) — keep the build cancellable and
+  chunk large row reads so one big export does not starve other queued tasks.

--- a/docs/superpowers/plans/2026-06-17-37-5-audit-retention-policies-and-tamper-aware-pruning-plan.md
+++ b/docs/superpowers/plans/2026-06-17-37-5-audit-retention-policies-and-tamper-aware-pruning-plan.md
@@ -1,0 +1,294 @@
+# Story 37-5 — Audit Retention Policies & Tamper-Aware Pruning (Implementation Plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation. Read [BEFORE_YOU_CODE.md](../../guides/BEFORE_YOU_CODE.md) first.
+
+**Goal:** Give the curated audit trail configurable, per-mode, per-category **retention windows**
+with platform-enforced compliance **minimums**, and a **daily scheduled pruning job** that deletes
+expired `audit_records` WITHOUT (a) breaking the 37-2 tamper-evident hash chain, (b) deleting records
+under an active 37-6 legal hold, or (c) ever dropping below the platform minimum. Pruning re-anchors
+the chain via a signed boundary checkpoint so `AuditChainVerifier` still returns OK afterward, and the
+prune itself is an audited sensitive action.
+
+**Seed note (story spec):** `/tmp/pab_stories/37-5.json` — P1, est 4-5 days, epic 37 (Audit,
+Compliance & Data Governance). boundaryNote empty. Distinct from the existing Story 28-10
+`PurgeStaleAnalyticsActivity` (which only prunes analytics rollups, no chain, no holds) — that code
+is the **pattern exemplar**, not the thing extended.
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane API + Elsa engine).
+**`packages/api` is DELETED — never a target.** Tests in `apps/tamma-elsa/tests/` (xUnit;
+docker-bound suites run via `sg docker -c "dotnet test ..."`; build needs no wrapper).
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO** change to how `audit_records` are created — that's 37-1's projector. This story only
+  *deletes* expired rows and writes a re-anchor checkpoint.
+- **NO** new hash-chain or checkpoint mechanism — reuse 37-2's `AuditChainCheckpoint` + envelope
+  signing key; the prune path just sets `is_prune_boundary = true`.
+- **NO** legal-hold UI or hold CRUD — that's 37-6; this story *consults* `ILegalHoldService`.
+- **NO** right-to-erasure — that's 37-8 (shares the consult-hold path; do not implement here).
+- **NO** "prune by actor/subject" (would punch holes mid-chain). Retention is strictly age-based →
+  always a contiguous prefix → trivially re-anchorable. Hole-punching is explicitly out of scope.
+- **NO** second scheduler infra — clone the `HourlyAnalyticsRollupScheduler` advisory-lock pattern;
+  do not invent a new leader-election primitive.
+- **NO** per-user override layer in SaaS (CLAUDE.md prompt-store rule analog): one policy set per
+  tenant, configured by tenant_owner/admin.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### Dependency artifacts NOT yet present (this story consumes them)
+
+37-1 / 37-2 / 37-6 have not landed. Confirmed absent:
+
+| Expected (from dep) | Path | Status |
+|---|---|---|
+| `Tamma.Data/Audit/` (AuditProjector) | `apps/tamma-elsa/src/Tamma.Data/Audit/` | **does not exist** (37-1) |
+| `Tamma.Core/Audit/` (catalog, verifier) | `apps/tamma-elsa/src/Tamma.Core/Audit/` | **does not exist** (37-1/37-2) |
+| `AuditRecord` / `AuditChainCheckpoint` / `LegalHold` entities | `Tamma.Data/Entities/Audit*.cs` | **none** (37-1/37-2/37-6) |
+| `Tamma.Api/Services/Audit/` | `apps/tamma-elsa/src/Tamma.Api/Services/Audit/` | **does not exist** (37-2/37-6) |
+
+⇒ Sequence is **37-1 → 37-2 → 37-6 → 37-5**. If implementing 37-5 against in-flight deps, code to
+the contracts in those specs (`IAuditRecordRepository`, `AuditChainVerifier.VerifyAsync`,
+`AuditChainCheckpoint`, `ILegalHoldService`).
+
+### Reusable patterns confirmed present (the load-bearing exemplars)
+
+| Concern | File | What to copy |
+|---|---|---|
+| Best-effort retention prune | `src/Tamma.Activities/Analytics/PurgeStaleAnalyticsActivity.cs` (Story 28-10) | `[Activity]` shape; `RunAsync` try/catch (rethrow only `OperationCanceledException` on shutdown); static pure-DI `PruneAsync(...)` entry point; `ComputeCutoff(nowUtc, window)` clamp helper; `ExecuteDeleteAsync`; terminal event emit via `IPlatformEventPublisher`. |
+| Daily scheduler + multi-pod safety | `src/Tamma.ElsaServer/Workflows/HourlyAnalyticsRollupScheduler.cs` | `BackgroundService`; `Options` with `Enabled` gate (tests set false); `FireAtMinute`/poll loop; `IRollupSchedulerLeaderLock` + `pg_try_advisory_lock`; idempotent last-fired tracking; WARN-and-continue. |
+| Recurring workflow definition | `src/Tamma.ElsaServer/Workflows/HourlyAnalyticsRollupWorkflow.cs` | `DefinitionId` + `CronExpression` constants; single-activity workflow body. |
+| Per-mode `user_id` XOR `tenant_id` entity | `src/Tamma.Data/Entities/PromptOverride.cs` | nullable `UserId`/`TenantId`; XOR + unique-nulls-not-distinct config goes in `TammaModelConfiguration.cs`. |
+| Tenant RBAC (owner/admin/member 403) | `src/Tamma.Api/Endpoints/OrgEndpoints.cs` | `RequireTenantMembershipFilter.TenantRoleItemKey`; `TenantRoleHierarchy.IsAtLeast(role, Admin)`; `Results.Json({error}, 403)`; cross-tenant → 404. |
+| Platform-owner gate | `src/Tamma.Api/Program.cs` (`PlatformOwnerAccess` / `OwnerAccess` policies, ~966-996) | `.RequireAuthorization("PlatformOwnerAccess")` on admin routes. |
+| Tenant-vs-owner write gate analog | `PromptManage` / `ConventionManage` policies (Program.cs ~1012/1024) | the prompt/convention precedent: owner-only `settings:manage` would 403 tenant_admin, so dedicated gates exist — retention writes use the OrgEndpoints `RoleAtLeast(Admin)` inline check (matches member-role-write pattern). |
+| Mode source | `src/Tamma.Api/Services/PromptStore/TammaMode.cs` (`ITammaModeProvider`) | process-stable SingleUser/SaaS. |
+| Migration split | `src/Tamma.Data/Migrations/{ControlPlane,Tenant}/` | additive new-table migration both contexts; verify `has-pending-model-changes` reports none. |
+| Endpoints to extend | `src/Tamma.Api/Endpoints/OrgEndpoints.cs`, `AdminEndpoints.cs` | both exist. |
+
+**Key gap this story closes:** age-based pruning of an append-only hash chain naively breaks
+verification (the first survivor's `prev_hash` points at a deleted row). The re-anchor boundary
+checkpoint is the novel piece; everything else is composition of existing patterns.
+
+---
+
+## Architecture
+
+**Policy → schedule → prune (hold-aware) → re-anchor → audit**, reusing the analytics-retention and
+hash-chain machinery end-to-end:
+
+1. **`AuditRetentionPolicy`** (new entity, `Tamma.Data/Entities/`) — per-mode (`user_id` XOR
+   `tenant_id`), per-category `retention_days`. Lives in BOTH `TenantDbContext` (per-tenant) and
+   `ControlPlaneDbContext` (platform / single-user). Missing row ⇒ platform default.
+2. **`AuditRetentionDefaults`** (new, `Tamma.Core/Audit/`) — static `(MinDays, DefaultDays)` per
+   37-1 category; compliance floor 365d for SECRET/RBAC/BYOK/BILLING/AUTH/IMPERSONATION/TENANT.
+   The minimum is the hard write-time floor; the default is used when no row exists.
+3. **`AuditRetentionService`** (new, `Tamma.Api/Services/Audit/`) — resolve effective policy
+   (row → default, clamped to min); upsert with 422-below-floor; platform-default admin path;
+   emits `AUDIT.RETENTION.POLICY_CHANGED` (sensitive → projected by 37-1).
+4. **`PruneExpiredAuditRecordsActivity`** (new, `Tamma.Activities/Audit/`) — per scope, per
+   category: cutoff = now − effectiveDays; candidates = `occurred_at < cutoff`; **subtract active
+   legal-hold matches** (`ILegalHoldService`); **write a signed prune-boundary
+   `AuditChainCheckpoint`** at the last contiguous pruned sequence; `ExecuteDeleteAsync`; emit
+   `AUDIT.RETENTION.PRUNED` (+ `BLOCKED_BY_HOLD` when a hold spared records). Best-effort per scope.
+5. **`AuditRetentionWorkflow` + `AuditRetentionScheduler`** (new, `Tamma.ElsaServer/Workflows/`) —
+   daily, advisory-lock leader-elected clone of the analytics scheduler; iterates tenant schemas +
+   control plane.
+6. **Endpoints** — tenant `GET/PUT /api/v1/orgs/{tenantId}/audit/retention`; platform
+   `GET/PUT /api/admin/audit/retention`.
+
+### Chain re-anchor (the novel piece)
+
+Pruning removes a **contiguous prefix** of the per-scope chain (age-based ⇒ always oldest first ⇒
+never a hole). Before deleting, write/update an `AuditChainCheckpoint { scope, head_sequence =
+lastPrunedSeq, head_hash = hash(lastPrunedRecord), is_prune_boundary = true, signed_at, signature }`
+(signature via 37-2 envelope key). `AuditChainVerifier.VerifyAsync` (37-2) must, when a record's
+`prev_hash` references a missing row, accept a matching prune-boundary checkpoint at that sequence as
+a valid anchor. ⇒ surviving range verifies OK. If a held record sits inside the expired range, prune
+only up to it this run (preserves the contiguous-prefix invariant); the rest waits for hold release.
+**If the boundary checkpoint write fails, ABORT the delete for that scope** (never delete without a
+valid re-anchor) → ERROR log.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Owns the retention policy? | sole user (`user_id`, `tenant_id` NULL) | tenant (`tenant_id`, `user_id` NULL) |
+| Configures (PUT)? | the user | `tenant_owner`/`tenant_admin`; `member` → 403 |
+| Sets platform defaults/minimums? | the user (their instance) | platform owner only (`PlatformOwnerAccess`) |
+| Prune scopes over? | the single user/CP chain | each tenant schema chain + the CP platform chain |
+| Mode source | `ITammaModeProvider` | same |
+
+---
+
+## Task breakdown
+
+### T1 — `AuditRetentionPolicy` entity + `AuditRetentionDefaults` + migrations
+
+**Scope:** Entity (per-mode XOR), the static minimum/default map, EF config, additive migrations for
+both contexts. No service/endpoint/prune wiring yet.
+
+**Files:**
+- New: `src/Tamma.Data/Entities/AuditRetentionPolicy.cs` (mirror `PromptOverride` XOR shape).
+- New: `src/Tamma.Core/Audit/AuditRetentionDefaults.cs` (`ComplianceFloorDays = 365`; per-category
+  `(MinDays, DefaultDays)`; `For(category)`).
+- Modify: `src/Tamma.Data/TammaModelConfiguration.cs` (principal XOR CHECK, `retention_days > 0`
+  CHECK, `UNIQUE NULLS NOT DISTINCT (user_id, tenant_id, category)`).
+- Modify: `src/Tamma.Data/TenantDbContext.cs` + `ControlPlaneDbContext.cs` (`DbSet<AuditRetentionPolicy>`).
+- New: migrations `src/Tamma.Data/Migrations/Tenant/*_AddAuditRetentionPolicies.cs` and
+  `.../ControlPlane/*_AddAuditRetentionPolicies.cs` (`dotnet ef migrations add`).
+
+**Tests first:** `tests/Tamma.Data.Tests/Audit/AuditRetentionPolicyEntityTests.cs` (or
+Api.Tests) — XOR CHECK rejects both-set/both-null; unique constraint; `retention_days > 0` CHECK;
+`AuditRetentionDefaults` covers every 37-1 `SensitiveActionCatalog` category; every default
+`>= minimum`; floor categories `>= 365`.
+
+**Acceptance criteria:**
+- [ ] Migration applies + rolls back cleanly on both contexts; `has-pending-model-changes` → none.
+- [ ] XOR + unique + `> 0` CHECKs enforced at DB level.
+- [ ] `AuditRetentionDefaults` is complete vs the 37-1 catalog and never sets a default below its minimum.
+
+### T2 — `AuditRetentionService` (resolve + upsert + platform defaults)
+
+**Scope:** Effective-policy resolution (row → default, clamp to min), validated upsert (422 below
+floor), platform-default read/set, `AUDIT.RETENTION.POLICY_CHANGED` emission. Mode-aware principal
+selection via `ITammaModeProvider`.
+
+**Files:** new `src/Tamma.Api/Services/Audit/IAuditRetentionService.cs` +
+`AuditRetentionService.cs`; new `src/Tamma.Activities/Audit/AuditRetentionEventTypes.cs`
+(`AUDIT.RETENTION.PRUNED|BLOCKED_BY_HOLD|FAILED|POLICY_CHANGED`); register in `Program.cs`.
+
+**Tests first:** `tests/Tamma.Api.Tests/Audit/AuditRetentionServiceTests.cs` — resolution order
+(row beats default), clamp to min for a stale sub-min row, upsert below floor throws
+`TammaError("AUDIT.RETENTION.BELOW_MINIMUM")` carrying category/requested/min, upsert at/above floor
+persists + emits POLICY_CHANGED, single-user vs SaaS principal selection, completeness vs catalog.
+
+**Acceptance criteria:**
+- [ ] `GetEffectivePolicyAsync` returns per-category `{ effectiveDays, minimumDays, source }`.
+- [ ] Upsert below minimum throws the 422-mapped error with an actionable message; no DB write.
+- [ ] Lowering retention writes the row only; deletes nothing.
+
+### T3 — `PruneExpiredAuditRecordsActivity` (hold-aware, chain re-anchoring, best-effort)
+
+**Scope:** The core sweep. Per scope, per category: cutoff, candidate select, legal-hold subtraction,
+boundary-checkpoint write, `ExecuteDeleteAsync`, event emission. Best-effort isolation copied from
+`PurgeStaleAnalyticsActivity`. Static pure-DI `PruneScopeAsync(...)` entry point for an admin
+force-prune + tests.
+
+**Files:** new `src/Tamma.Activities/Audit/PruneExpiredAuditRecordsActivity.cs`. Consumes
+`IAuditRecordRepository` (37-1), `AuditChainVerifier`/`AuditChainCheckpoint`/envelope key (37-2),
+`ILegalHoldService` (37-6).
+
+**Tests first (the load-bearing suite):**
+- `tests/Tamma.Activities.Tests/Audit/PruneExpiredAuditRecordsActivityTests.cs` — per-category
+  cutoffs honored; only past-cutoff rows deleted; clamp to minimum even with a stale sub-min policy;
+  `OperationCanceledException` propagates on shutdown; one scope failing → `AUDIT.RETENTION.FAILED`,
+  others still run.
+- `.../PruneRespectsLegalHoldTests.cs` — active hold spares in-scope expired records,
+  `AUDIT.RETENTION.BLOCKED_BY_HOLD` emitted with hold id + spared count; release → next run deletes.
+- `.../PruneChainReanchorTests.cs` — **after a prefix prune + boundary checkpoint,
+  `AuditChainVerifier.VerifyAsync` returns OK**; negative control: prune WITHOUT the boundary
+  checkpoint → verifier reports a broken link; held-record-in-the-middle → only contiguous prefix
+  pruned, chain still verifies; boundary-checkpoint write failure → delete ABORTED for that scope.
+- `.../AuditRetentionEventsTests.cs` — `AUDIT.RETENTION.PRUNED` carries
+  `{ scope, category, deleted, retainedByHold, cutoff, boundarySeq }`.
+
+**Acceptance criteria:**
+- [ ] Prune never deletes below the platform minimum or an active hold.
+- [ ] Post-prune `AuditChainVerifier.VerifyAsync(scope, ...)` = OK (re-anchor works); no-checkpoint negative control fails.
+- [ ] Per-scope failure isolated; `OperationCanceledException` not swallowed.
+- [ ] `AUDIT.RETENTION.PRUNED` emitted with correct per-category counts; projected into `audit_records` by 37-1.
+
+### T4 — `AuditRetentionWorkflow` + `AuditRetentionScheduler` (daily, advisory-locked)
+
+**Scope:** Clone the analytics scheduler+workflow pair for a daily audit prune across all scopes
+(tenant schemas via the tenant registry + control plane).
+
+**Files:** new `src/Tamma.ElsaServer/Workflows/AuditRetentionWorkflow.cs` (DefinitionId +
+`CronExpression` e.g. `0 30 3 * * *`) and `AuditRetentionScheduler.cs` (`BackgroundService` with
+`AuditRetention` options section: `Enabled`, `FireAtHourUtc`, `PollInterval`; reuse
+`IRollupSchedulerLeaderLock` or a parallel `pg_try_advisory_lock` lease); wire in
+`Tamma.ElsaServer/Program.cs`.
+
+**Tests first:** `tests/Tamma.Activities.Tests/Audit/AuditRetentionSchedulerTests.cs` (mirror
+`HourlyAnalyticsRollupSchedulerTests`) — fires once/day at configured hour; advisory lock skips
+non-leaders; `Enabled=false` suppresses the loop; dispatch failure → WARN + continue + next-day
+recovery.
+
+**Acceptance criteria:**
+- [ ] Daily dispatch; multi-pod safe (one leader/day); `Enabled=false` for non-Elsa/test roots.
+- [ ] Iterates every tenant schema + the control plane; a failing scope doesn't abort the rest.
+
+### T5 — Retention endpoints (tenant + platform) + Program wiring
+
+**Scope:** Read/configure surfaces with per-mode RBAC.
+
+```
+GET  /api/v1/orgs/{tenantId}/audit/retention   (any member)              — effective policy + minimums
+PUT  /api/v1/orgs/{tenantId}/audit/retention   (tenant_owner/admin; 403 member; 422 below floor)
+GET  /api/admin/audit/retention                (PlatformOwnerAccess)     — platform defaults + minimums
+PUT  /api/admin/audit/retention                (PlatformOwnerAccess; 422 below floor)
+```
+
+**Files:** modify `src/Tamma.Api/Endpoints/OrgEndpoints.cs` (tenant pair; reuse
+`RequireTenantMembershipFilter` + `RoleAtLeast(Admin)`), `AdminEndpoints.cs` (admin pair), and
+`Program.cs` (map + register service/scheduler).
+
+**Tests first:** `tests/Tamma.Api.Tests/Audit/AuditRetentionEndpointsTests.cs` — RBAC matrix
+(tenant_owner ✓, tenant_admin ✓, member 403, cross-tenant 404; admin route requires
+`PlatformOwnerAccess`); single-user sole user can PUT; PUT below floor → 422 with category/
+requested/min; GET returns effective + minimums.
+
+**Acceptance criteria:**
+- [ ] Endpoint shape identical between modes; auth middleware/mode picks the principal.
+- [ ] Member → 403 on PUT; below-floor → 422; cross-tenant → 404.
+
+---
+
+## Task order & dependencies
+
+T1 → T2 → T3 → T4 (parallel-safe with T5 once T3 lands) → T5. T1 is the only hard intra-story
+prerequisite. External hard prerequisites: 37-1, 37-2, 37-6 must be merged (or their contracts
+stable) before T3.
+
+## Risks
+
+- **False tamper alarm after prune (the headline risk).** Mitigation: the prune-boundary checkpoint
+  + verifier honoring it (AC 9 / T3). The `PruneChainReanchorTests` negative control (prune without
+  checkpoint → verifier fails) is the regression guard. If 37-2's `AuditChainVerifier` lands without
+  prune-boundary awareness, T3 is blocked until 37-2 is amended — flag early.
+- **Hole-punching creep.** A future "prune by subject/actor" would break the contiguous-prefix
+  invariant and the O(1) re-anchor. Documented as a non-goal; if it's ever wanted it needs a
+  different (per-segment) re-anchor design. Don't let it sneak in via 37-8 erasure reuse.
+- **Legal-hold race (flapping).** A hold placed mid-prune must spare records; a hold released between
+  candidate-select and delete must not cause an under-retain. Consult `ILegalHoldService` inside the
+  same logical pass and re-check immediately before `ExecuteDeleteAsync`; on doubt, retain (next run
+  reconsiders). A held record in the middle caps this run at the prefix before it.
+- **Deleting without a valid re-anchor.** If the boundary-checkpoint write fails, ABORT the scope's
+  delete (ERROR log) — never delete first and re-anchor after.
+- **Best-effort contract drift.** Copy `PurgeStaleAnalyticsActivity` exactly: per-scope try/catch,
+  WARN + `AUDIT.RETENTION.FAILED`, rethrow only `OperationCanceledException` on shutdown. A retention
+  hiccup must never crash the daily workflow or starve other tenants.
+- **Migration discipline.** Additive new table both contexts; still verify `has-pending-model-changes`
+  → none and mirror entity config only in `TammaModelConfiguration.cs` (the single source).
+- **Per-mode regressions.** Pin the SaaS-tenant vs single-user-user principal selection in T2/T5
+  tests; the wrong default (ship single-user, assume SaaS works) is the CLAUDE.md anti-pattern.
+- **Event-store topology (Story 28-1 / Epic 30).** `AUDIT.RETENTION.*` events follow 37-1's
+  projection routing — system/platform-scope prune events stay control-plane-resident; tenant-scope
+  events route per-tenant. Emit through the same publisher 37-1/37-2 use so a later per-tenant
+  fan-out needs no change here.
+
+## Out of scope / deferred
+
+- Right-to-erasure (37-8) — shares the consult-hold path; not built here.
+- Retention/audit dashboard surfaces — separate Epic 37 dashboard story.
+- Admin "force prune now" endpoint — the static `PruneScopeAsync` entry point makes it a trivial
+  follow-up, but it is not in this story's ACs.
+- OpenBao-backed signing key — 37-2 owns the signing key source (envelope key / TenantSecretProtector);
+  the OpenBao migration is Story 28-13.

--- a/docs/superpowers/plans/2026-06-17-37-6-legal-hold-plan.md
+++ b/docs/superpowers/plans/2026-06-17-37-6-legal-hold-plan.md
@@ -1,0 +1,256 @@
+# Story 37-6 — Legal Hold (implementation plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation.
+
+**Goal:** Ship a **legal-hold** capability that freezes audit records (and optionally related
+per-tenant data) matching a hold scope (category / actor / subject / time-range / case-ref) so that
+retention pruning (Story 37-5) and right-to-erasure (Story 37-8) cannot delete them while a hold is
+active. Holds are owned per mode with elevated RBAC; placing/releasing a hold is itself a sensitive,
+immutable, audited action. The single enforcement seam is `ILegalHoldGuard`, which 37-5 and 37-8 must
+consult before any delete.
+
+**Story file:** `docs/stories/epic-37/story-37-6/37-6-legal-hold.md`
+**Spec:** `/tmp/pab_stories/37-6.json` (boundaryNote: empty).
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane API + Elsa engine).
+Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/` (xUnit; docker-bound suites run via
+`sg docker -c "dotnet test ..."` — session docker group is stale, build needs no wrapper).
+
+**Target architecture (verified 2026-06-17, repo @ main 98cfb1c2):**
+- `Tamma.Data` — audit read-model (Story 37-1), per-tenant `TenantDbContext`, platform
+  `ControlPlaneDbContext`. The `legal_holds` registry + `LegalHold` entity live here.
+- `Tamma.Api` — HTTP surface (`OrgEndpoints` tenant scope, `AdminEndpoints` platform scope) + hold
+  service/guard.
+- The legacy TypeScript `packages/api` is **DELETED** — never a target.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- NO new audit read-model. 37-1 owns it; this story attaches a hold-aware candidate query and the
+  guard call sites to whatever 37-1 actually exposes. Do not invent a parallel read-model.
+- NO hard-delete of holds. Release is a status flip (`active` → `released`); rows persist forever for
+  compliance. No purge endpoint.
+- NO per-record "hold flag" denormalization. Coverage is computed by the guard against the registry
+  at evaluation time — a record is held iff an active hold's scope matches it. This keeps holds
+  retroactive (a hold placed today protects records written last year) with zero backfill.
+- NO new delivery/notification channel. PLACED/RELEASED/BLOCKED_BY_HOLD are DCB events; if an
+  operator wants alerts on them, the existing Story 5.6 alert pipeline picks them up via an
+  `alert_rules` row — out of scope here.
+- NO change to 37-5/37-8 deletion semantics beyond the guard gate. The guard says held/not-held;
+  those stories own everything else about pruning and erasure.
+
+---
+
+## Current-state findings (verified 2026-06-17)
+
+| Seam | Location | Note |
+|---|---|---|
+| Audit read-model | created in **Story 37-1** | `story-37-5` dir is empty → Epic 37 is being authored fresh; 37-1/37-5/37-8 are siblings. `IAuditRecordRepository.cs` is the spec's assumed name — **verify** at impl time. |
+| DCB event append | `Tamma.Data/Repositories/EventRepository.cs` → `IEventRepository.AppendAsync(DomainEvent)` | `DomainEvent { Id, Type, TenantId?, Tags, Metadata, Data, CreatedAt, SequenceNumber }`. `AlertEndpoints` already appends lifecycle events this way. |
+| Mode | `Tamma.Api/Services/PromptStore/TammaMode.cs` → `ITammaModeProvider.Mode` (`SingleUser`/`SaaS`) | process-stable singleton. |
+| Tenant RBAC | `Authorization/RequireTenantMembershipFilter.cs` (+ `TenantRoleHierarchy.cs`) | filter stashes role in `HttpContext.Items[RequireTenantMembershipFilter.TenantRoleItemKey]`; mutations inline-gate via the `AlertEndpoints.RequireTenantAdmin` pattern. |
+| Platform RBAC | `PlatformOwnerAccess` policy (`Program.cs` ~986) | platform-owner only — distinct from `OwnerAccess` (which admits every personal-tenant owner). Admin audit routes MUST use `PlatformOwnerAccess`. |
+| Existing tenant-audit endpoint precedent | `OrgEndpoints.ListTenantAudit` (~527, Story 18-7) + `IEventRepository.ListByTenantAsync` | confirms `/api/v1/orgs/{tenantId}/audit*` is the right mount + cross-tenant 404 discipline. |
+| Endpoint tenant/admin split + cross-tenant 404 + body-tenant-mismatch 400 | `Endpoints/AlertEndpoints.cs` | THE pattern to copy (`ListTenantAlerts`/`CreateTenantChannel`/`RequireTenantAdmin`). |
+| EF model config conventions | `Tamma.Data/TammaModelConfiguration.cs` | `ToTable(... t => t.HasCheckConstraint(...))`, `HasIndex(...).HasFilter(...)`. Migrations under `Migrations/ControlPlane/`. |
+
+**Key gap closed by this story:** there is currently NO legal-hold / retention / erasure code in
+`Tamma.Api` or `Tamma.Data` (grep confirms only unrelated "prune" usages in rate-limit/KEK/alert
+windows). This story introduces the hold registry + guard + lifecycle, and the enforcement hooks for
+the two destructive sibling stories.
+
+---
+
+## Architecture: registry → guard → enforcement
+
+1. **`legal_holds` table** (CP-resident; `LegalHold` entity) — the registry. One of three ownership
+   shapes (principal XOR CHECK): tenant-scope (`tenant_id` set), single-user (`user_id` set),
+   platform-wide (`is_platform_wide = true`, both null). Scope predicate columns: `scope_category`,
+   `scope_actor_id`, `scope_subject_id`, `scope_time_from`, `scope_time_to`, `case_ref`. Lifecycle:
+   `status` (`active`/`released`), `placed_by/at`, `released_by/at`. Partial index on
+   `(tenant_id, status) WHERE status='active'` for the hot guard query.
+2. **`ILegalHoldGuard.EvaluateAsync(LegalHoldQuery)` → `HoldDecision(IsHeld, MatchingHoldIds)`** —
+   the single seam. Coverage = ownership match AND every non-null scope predicate matches (NULL =
+   wildcard). Overlapping holds additive. **Fail-closed**: query failure ⇒ treated as held.
+3. **Lifecycle service** (`LegalHoldService`) — place/release/list with per-mode scope derivation,
+   emitting `AUDIT.LEGAL_HOLD.PLACED` / `AUDIT.LEGAL_HOLD.RELEASED` via `IEventRepository`.
+4. **Endpoints** — tenant (`/api/v1/orgs/{tenantId}/audit/legal-holds`, owner-only mutate in SaaS,
+   member 403) + platform (`/api/v1/admin/audit/legal-holds`, `PlatformOwnerAccess`).
+5. **Enforcement hooks** — guard call sites in the 37-5 pruner (skip + `AUDIT.RETENTION.BLOCKED_BY_HOLD`)
+   and 37-8 erasure (fail closed + `AUDIT.ERASURE.BLOCKED_BY_HOLD`).
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Place/release tenant-scope hold | sole user (no RBAC) | `tenant_owner` (member → 403) |
+| Place/release platform-wide hold | sole user | `PlatformOwnerAccess` only |
+| Ownership storage | `user_id` set, `tenant_id` NULL | `tenant_id` set (tenant) or both NULL + `is_platform_wide` (platform) |
+| List visibility | sole user sees all their holds | tenant sees tenant-scope rows only; platform owner sees all |
+| Mode source | `ITammaModeProvider` | same |
+
+---
+
+## Task breakdown
+
+### LH-1: `legal_holds` registry + `LegalHold` entity + migration (core, no behaviour yet)
+
+**Scope:** entity, EF config, DbSet, additive migration. No service/endpoints.
+
+**Files:**
+- New: `src/Tamma.Data/Entities/LegalHold.cs` (+ `LegalHoldStatus`, `LegalHoldScopeCategory` consts).
+- Modify: `src/Tamma.Data/TammaModelConfiguration.cs` — `legal_holds` table: principal-XOR CHECK,
+  status CHECK, scope-category CHECK; partial index `(TenantId, Status) WHERE Status='active'`;
+  indexes on `CaseRef`, `ScopeSubjectId`.
+- Modify: `src/Tamma.Data/ControlPlaneDbContext.cs` — `DbSet<LegalHold> LegalHolds`.
+- New: `src/Tamma.Data/Migrations/ControlPlane/<ts>_AddLegalHolds.cs` (`dotnet ef migrations add AddLegalHolds`).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Audit/LegalHoldEntityTests.cs` — insert tenant/single-user/
+platform-wide rows succeed; principal-XOR violation (both tenant_id + user_id) rejected by Postgres;
+invalid status / scope_category rejected; `has-pending-model-changes` reports none.
+
+**Acceptance:**
+- [ ] Migration applies + rolls back cleanly; snapshot updated; no pending model changes.
+- [ ] All three ownership shapes insert; every XOR/CHECK violation is rejected at the DB.
+
+### LH-2: `ILegalHoldGuard` + `LegalHoldGuard` (the enforcement seam)
+
+**Scope:** read-only coverage evaluation against `legal_holds WHERE status='active'`. Fail-closed.
+
+**Files:**
+- New: `src/Tamma.Api/Services/Audit/ILegalHoldGuard.cs` (+ `LegalHoldQuery`, `HoldDecision`).
+- New: `src/Tamma.Api/Services/Audit/LegalHoldGuard.cs`.
+- Wire DI in `Program.cs` (or a small `AddTammaAudit` extension mirroring the alert wiring).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Audit/LegalHoldGuardTests.cs` —
+no active hold → not held; tenant-scope matches own tenant, not other tenant; platform-wide matches
+all; scope matching (actor / subject / time-range inclusive bounds / case-ref / combined; NULL =
+wildcard); released hold never matches; **overlapping**: two holds cover one record, release one →
+still held, release both → not held; **fail-closed**: guard query throws → decision = held.
+
+**Acceptance:**
+- [ ] `EvaluateAsync` returns `IsHeld=true` + matching ids while any active hold covers the candidate.
+- [ ] Overlapping holds additive; releasing one does not unfreeze a still-covered record.
+- [ ] Registry-query failure yields a held decision (never delete-open) and logs ERROR.
+
+### LH-3: `LegalHoldService` + lifecycle events
+
+**Scope:** place/release/list; per-mode scope derivation; emit `AUDIT.LEGAL_HOLD.PLACED`/`RELEASED`.
+
+**Files:**
+- New: `src/Tamma.Api/Services/Audit/LegalHoldService.cs`, `LegalHoldEventTypes.cs`
+  (`AUDIT.LEGAL_HOLD.PLACED`/`RELEASED`, `AUDIT.RETENTION.BLOCKED_BY_HOLD`,
+  `AUDIT.ERASURE.BLOCKED_BY_HOLD`), command/filter records.
+- Wire DI in `Program.cs`.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Audit/LegalHoldServiceTests.cs` —
+place emits exactly one PLACED event with correct tags; release flips status + stamps
+`released_by/at` + emits exactly one RELEASED; release of already-released → conflict + NO second
+event; per-mode scope derivation (single-user → user_id; SaaS tenant → tenant_id; SaaS platform →
+tenant_id-or-platform-wide); list filters by tenant/status/caseRef.
+
+**Acceptance:**
+- [ ] PLACED/RELEASED appended via `IEventRepository` exactly once each; immutable (no update path).
+- [ ] Released rows persist (status flip, never hard delete).
+
+### LH-4: Endpoints (tenant + platform) + RBAC
+
+**Scope:** the four route variants, per-mode RBAC, cross-tenant 404, body-tenant-mismatch 400.
+
+**Files:**
+- Modify: `src/Tamma.Api/Endpoints/OrgEndpoints.cs` — `ListTenantLegalHolds`, `PlaceTenantLegalHold`,
+  `ReleaseTenantLegalHold` (owner gate via the `AlertEndpoints.RequireTenantAdmin` pattern, tightened
+  to owner for place/release per AC3; member → 403).
+- Modify: `src/Tamma.Api/Endpoints/AdminEndpoints.cs` — `ListLegalHolds`, `PlaceLegalHold`,
+  `ReleaseLegalHold`.
+- Modify: `src/Tamma.Api/Program.cs` — tenant routes on the `orgs` group with
+  `RequireTenantMembershipFilter` (mirror the `/{tenantId}/alerts` block); admin routes with
+  `.RequireAuthorization("PlatformOwnerAccess")`.
+
+```
+GET    /api/v1/orgs/{tenantId}/audit/legal-holds          (members; tenant rows only)
+POST   /api/v1/orgs/{tenantId}/audit/legal-holds          (tenant_owner; member 403)
+DELETE /api/v1/orgs/{tenantId}/audit/legal-holds/{id}     (tenant_owner; cross-tenant 404)
+GET    /api/v1/admin/audit/legal-holds                    (PlatformOwnerAccess)
+POST   /api/v1/admin/audit/legal-holds                    (PlatformOwnerAccess)
+DELETE /api/v1/admin/audit/legal-holds/{id}               (PlatformOwnerAccess)
+```
+
+**Tests (first):** `tests/Tamma.Api.Tests/Audit/LegalHoldEndpointsTests.cs` —
+single-user: any user place/release/list. SaaS tenant: owner OK; member 403 on place/release,
+read-only list OK; cross-tenant id → 404; body `tenantId` ≠ path → 400; tenant list never leaks
+platform-wide/other-tenant rows. SaaS platform: `PlatformOwnerAccess` enforced; tenant member on
+admin route → 403. Place→list→release→list round-trip reflects status.
+
+**Acceptance:**
+- [ ] Endpoint shape identical across modes; auth middleware + mode decide ownership (prompt-store precedent).
+- [ ] Tenant surface never exposes platform-wide or other-tenant holds.
+
+### LH-5: Enforcement hooks in 37-5 pruner + 37-8 erasure
+
+**Scope:** add `ILegalHoldGuard` call sites; emit BLOCKED_BY_HOLD events. Depends on 37-1; integrates
+with 37-5/37-8 (NEW call sites — sibling stories).
+
+**Files:**
+- Modify: the 37-5 pruner — before each delete batch, `EvaluateAsync` per candidate; skip held rows,
+  emit `AUDIT.RETENTION.BLOCKED_BY_HOLD` once per affected hold with skipped count, continue with
+  unheld rows.
+- Modify: the 37-8 erasure flow — before deleting a subject's records, `EvaluateAsync`; if held, emit
+  `AUDIT.ERASURE.BLOCKED_BY_HOLD` and reject the whole request (fail closed, no partial delete).
+- Modify (if 37-1 exposes the prune surface here): `IAuditRecordRepository.cs` — hold-aware
+  candidate query. **Verify the real 37-1 read-model name first.**
+
+> **Merge-order tolerance:** if 37-5/37-8 land after this story, ship the hooks as guarded
+> no-ops against the (absent) delete loop + leave the integration tests `[Trait("pending",...)]`;
+> wire them fully when those stories merge. The guard + registry + lifecycle are complete and
+> independently testable regardless of order.
+
+**Tests (first):**
+- `LegalHoldRetentionTests.cs` — seed past-window audit rows; place hold over a subset; run pruner;
+  in-scope survive, out-of-scope deleted, exactly one `AUDIT.RETENTION.BLOCKED_BY_HOLD` per hold;
+  release → re-run → now deleted, no BLOCKED event.
+- `LegalHoldErasureTests.cs` — place hold over a subject; run erasure; nothing deleted, request
+  rejected, one `AUDIT.ERASURE.BLOCKED_BY_HOLD`; release → re-run → erased, no BLOCKED event.
+
+**Acceptance:**
+- [ ] An active hold blocks BOTH prune and erasure of in-scope records.
+- [ ] Releasing the last covering hold re-enables both; standard 37-5/37-8 success events fire.
+- [ ] Erasure of a held subject is all-or-nothing (no partial delete).
+
+---
+
+## Task order & dependencies
+
+LH-1 → LH-2 → LH-3 → LH-4 ; LH-5 depends on LH-2 (guard) + Story 37-1 (read-model) + Story 37-5/37-8
+(delete loops). LH-1 is the only hard prerequisite for everything else in this story.
+
+External hard prerequisite: **Story 37-1** (audit read-model + audit event path). LH-5 consumers:
+**37-5**, **37-8**.
+
+## Risks
+
+- **Fail-open deletion (highest):** a guard bug or swallowed exception that returns "not held" on
+  failure would let a court-ordered record be pruned/erased. Mitigation: fail-closed contract in
+  LH-2 (query failure ⇒ held), asserted by a dedicated test; ERROR-log when suppressing deletes so
+  the unreachable-registry condition is visible.
+- **Retroactivity:** holds must protect records written before the hold was placed. Computing
+  coverage from the registry per evaluation (no per-record flag, no backfill) handles this — but it
+  means the guard runs on the prune/erasure hot path. Mitigation: partial index on active holds;
+  holds are few (litigation-scale), candidates are batched.
+- **Scope-match correctness:** an over-broad match freezes too much (retention never reclaims space);
+  an under-broad match leaks a record past a hold. Mitigation: the LH-2 scope-matrix tests pin every
+  predicate (actor/subject/time-range/case-ref/combined/NULL-wildcard) and the inclusive time bounds.
+- **Per-mode ownership leak:** wrong scope derivation exposes a tenant hold on the platform surface
+  or vice-versa. Mitigation: derive from `ITammaModeProvider` + route, force `tenant_id` server-side
+  on the tenant path (body mismatch 400), and pin the matrix in LH-4 tests.
+- **Merge order with 37-1/37-5/37-8:** siblings may not all exist when this lands. Mitigation: the
+  registry + guard + lifecycle ship + test independently; LH-5 hooks degrade to guarded no-ops with
+  pending integration tests until the delete loops exist. Verify the real 37-1 read-model name before
+  wiring `IAuditRecordRepository`.
+- **Migration discipline:** additive table, but still run `has-pending-model-changes` after
+  `AddLegalHolds`, keep entity config solely in `TammaModelConfiguration.cs` (single source), and
+  verify clean apply + rollback.

--- a/docs/superpowers/plans/2026-06-17-37-7-gdpr-dsar-data-subject-access-export-plan.md
+++ b/docs/superpowers/plans/2026-06-17-37-7-gdpr-dsar-data-subject-access-export-plan.md
@@ -1,0 +1,302 @@
+# Story 37-7 — GDPR DSAR (Data Subject Access Export) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan phase-by-phase. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every phase writes tests
+> before implementation. DB-bound xUnit suites run via `sg docker -c "dotnet test ..."`.
+
+**Goal:** Implement the GDPR Art. 15 / Art. 20 (and CCPA right-to-know) **Data Subject Access
+Request** flow: given a subject (a `User` by `userId` or `email`), gather **all** personal data
+Tamma holds about them across the control plane and the relevant tenant schema(s), and produce a
+portable, machine-readable + human-readable export bundle. The job runs async on the existing
+`TaskQueueProcessor`, is RBAC-gated and identity-verified, is itself audited (`GDPR.DSAR.*`), and
+**never** emits secret values.
+
+**Story file:** `docs/stories/epic-37/story-37-7/37-7-gdpr-dsar-data-subject-access-export.md`
+
+**Seed/spec:** `/tmp/pab_stories/37-7.json` (P1, Epic 37 "Audit, Compliance & Data Governance",
+est 5-6 days). boundaryNote: *(none)*.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO right-to-erasure / deletion.** This story is read/export only. Erasure is a separate Epic 37
+  story — DSAR must not delete or anonymize anything.
+- **NO new async-job framework.** Reuse `PlatformQueuedTask` + `TaskQueueProcessor` +
+  `IPlatformTaskHandler` (the 37-4 / Cranl-provisioning machinery). No bespoke threads/timers.
+- **NO new artifact-storage / token primitive if 37-4 ships first.** Reuse its encrypted-at-rest
+  artifact + single-use time-limited download token (`SecretRevealTokenRow`-style). If this story
+  lands first, factor a shared helper so 37-4 consumes it.
+- **NO change to resolution/secret semantics.** Secret values are excluded by default-deny
+  redaction; nothing in DSAR reveals a protected value, hash, or ciphertext.
+- **NO `packages/api` (TypeScript) work.** That package is deleted. All work is in `apps/tamma-elsa`
+  (`Tamma.Api` + `Tamma.Data`).
+- **NO per-request mode branching beyond `ITammaModeProvider`.** A deployment is one mode for the
+  process lifetime.
+- **NO dashboard UI in this story.** Endpoints only; a DSAR admin/tenant UI is a follow-up.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### Where the personal data lives
+
+| Scope | DbContext | Subject-bearing entities (verified) |
+|---|---|---|
+| Control plane | `Tamma.Data/ControlPlaneDbContext.cs` | `User` (`Email`, `PasswordHash`, `*TokenHash`, `Settings`), `TenantMembership` (`UserId`), `UserInvite`, `RefreshToken`, `ApiKey`, `AdminImpersonation` (`TargetUserId`/`ImpersonatorUserId`), `PlatformEvent`, `DomainEvent`, `SecretRow` (`OwnerUserId`) |
+| Per-tenant | `Tamma.Data/TenantDbContext.cs` via `ITenantDbContextFactory.CreateAsync(tenantId)` | `PromptOverride` (`CreatedBy`/`UserId`), `Convention` (`CreatedBy`), `AgentConfig` (`CreatedBy`), `SanitizationRule`, `Alert`, `DomainEvent` |
+
+- `User` (`Tamma.Data/Entities/User.cs`): `Email` NOT NULL, case-insensitive unique via
+  `LOWER(email) WHERE deleted_at IS NULL`. Has `PasswordHash`, `EmailVerificationTokenHash`,
+  `Settings` (JSON) — all PII / secret-adjacent.
+- `TenantMembership` (`Entities/TenantMembership.cs`): `{ TenantId, UserId, Role }` — the subject's
+  tenant set (drives multi-tenant coverage in AC12).
+- `AdminImpersonation` (`Entities/AdminImpersonation.cs`): subject as `TargetUserId` or
+  `ImpersonatorUserId`.
+- `SecretRow` (`Entities/SecretRow.cs`): `OwnerUserId` — include metadata only.
+- `PromptOverride`/`Convention`/`AgentConfig` all carry `CreatedBy` (Guid?) — authored-by key.
+
+### Reusable infrastructure (verified present)
+
+- **Event write side:** `IEventRepository.AppendAsync(DomainEvent)`
+  (`Tamma.Data/Repositories/EventRepository.cs`); `DomainEvent` = `{ Id, Type, TenantId?, Tags,
+  Metadata, Data, ... }`. Emission pattern: `OrgEndpoints.EmitTenantEvent` (line ~1036).
+- **Async jobs:** `PlatformQueuedTask` (`Entities/PlatformQueuedTask.cs`) +
+  `Services/TaskQueue/TaskQueueProcessor.cs` + `Services/PlatformTasks/IPlatformTaskHandler.cs`
+  (`TaskType` routing, retry/terminal/dead-letter semantics, cancellation-aware) registered via
+  `services.AddPlatformTaskHandler<T>()`.
+- **RBAC policies** (`Program.cs` ~966-996): `OwnerAccess` (tenant owner — tenant-scoped),
+  `PlatformOwnerAccess` (platform admin — keys off `User.PlatformRole == "platform_admin"`),
+  `MemberAccess`, `AuthenticatedAny`. Tenant membership enforced by `RequireTenantMembershipFilter`.
+- **Tenant access:** `ITenantDbContextFactory.CreateAsync(tenantId, ct)`
+  (`Tamma.Data/TenantDbContextFactory.cs`) → `TenantDbContext` scoped to the tenant's schema via
+  `LruPooledTenantConnectionResolver` (unconditionally wired per the tenancy plan).
+- **Mode:** `ITammaModeProvider` (`Services/PromptStore/TammaMode.cs`) — process-stable
+  SingleUser | SaaS.
+- **Time-limited single-use token precedent:** `SecretRevealTokenRow`
+  (`Entities/SecretRevealTokenRow.cs`): `TokenHash` (unique index), `ExpiresAt`, `Status`,
+  `ConsumedAt` — exactly the download-token shape DSAR needs.
+
+### Gaps (NEW, must be built)
+
+- `Services/Compliance/` directory does **not** exist.
+- No `DsarJob` entity / table.
+- Sibling stories **37-1** and **37-4** dirs exist but are **empty** (not yet authored). Treat their
+  contracts (sensitive-event taxonomy; async-export artifact + token) as integration points; if they
+  land first, consume their seams; otherwise build the artifact/token helper here so they reuse it.
+
+---
+
+## Architecture
+
+**Resolve subject → collect (data-map-driven) → package (json + html, encrypted) → audited async
+job → time-limited download.**
+
+```
+POST /dsar  ──202──►  DsarJob(pending) + enqueue PlatformQueuedTask("compliance.dsar.export")
+                                   │
+                       TaskQueueProcessor picks it up
+                                   ▼
+            DsarExportTaskHandler.HandleAsync
+              ├─ collecting: DsarCollector.CollectAsync
+              │     ├─ ControlPlaneDbContext: run every ControlPlane SubjectDataSource
+              │     └─ for each in-scope tenant: TenantDbContext via factory → Tenant sources
+              ├─ packaging:  DsarBundlePackager  (export.json + export.html → encrypted zip)
+              └─ ready:      DsarJobStore.MarkReady(artifactRef, downloadTokenHash, expiresAt)
+                                   │
+              GDPR.DSAR.REQUESTED / COMPLETED / FAILED  (IEventRepository, sensitive=true)
+                                   ▼
+GET /dsar/{jobId}/download?token=  ──single-use, TTL──►  artifact  (else 410)
+```
+
+**Data-map-driven collection (AC3/AC4):** `SubjectDataMap` is the single registry; each
+`SubjectDataSource` declares `{ Category, Scope, EntityType, PiiFields, Collect }`. The collector is
+generic over the map. A `[ContainsPersonalData]` marker (or `KnownPiiEntities` list) + a completeness
+test guarantees no PII entity is silently omitted.
+
+**Secret exclusion (AC7):** `DsarRedactionPolicy` is the single chokepoint, default-deny — a field
+ships only if explicitly listed in the source's non-secret projection. Secrets/keys/hashes/tokens →
+`{ exists: true, ...metadata }`.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who can **initiate** a DSAR? | The sole user, for **themselves only** (`/api/v1/dsar/self`). A non-self subject ref → 403. | Tenant owner/admin for subjects **in their tenant** (`/api/v1/orgs/{tenantId}/dsar`, `OwnerAccess`); platform owner for **any** subject (`/api/admin/dsar`, `PlatformOwnerAccess`). `member` → 403. |
+| Whose data is in scope? | The sole user's CP + their tenant. | Tenant-initiated: CP + **that one tenant only**. Platform-owner: CP + **every** tenant the subject is a member of. |
+| What `TenantId` on the `DsarJob`/events? | null (system-scope = the user's feed). | Tenant-initiated: `{tenantId}`. Admin: null (platform-scope). |
+| Identity verification | caller == subject (claims). | subject existence + `TenantMembership` in `{tenantId}` (tenant route) verified independently of the request body. |
+| Mode source | `ITammaModeProvider` | same |
+
+---
+
+## Phase breakdown
+
+### DSAR-1: `DsarJob` entity + job store + DCB event types (core, no collection yet)
+
+**Scope:** Persist the job lifecycle; emit `GDPR.DSAR.*`; no collection/packaging yet.
+
+**Files:**
+- New: `Tamma.Data/Entities/DsarJob.cs` (fields per story Technical Design); `DbSet<DsarJob>` in
+  `ControlPlaneDbContext.cs`; mapping + CHECK on `status`
+  (`pending|collecting|packaging|ready|failed`) + indices in `TammaModelConfiguration.cs`; additive
+  EF migration under `Migrations/ControlPlane/` (verify `has-pending-model-changes` reports none
+  after).
+- New: `Services/Compliance/IDsarJobStore.cs`, `DsarJobStore.cs` (create/transition/mark-ready/
+  mark-failed/register-download-token/consume-token).
+- New: `Services/Compliance/DsarEventTypes.cs`
+  (`GDPR.DSAR.REQUESTED/COMPLETED/FAILED/DOWNLOADED`).
+- New: `Extensions/ComplianceServiceCollectionExtensions.cs`; wire in `Program.cs`.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Compliance/DsarJobStoreTests.cs` — create→pending;
+transitions enforce CHECK; mark-ready stamps artifact ref + token hash + expiry; mark-failed stamps
+reasonCode; token consume single-use; events appended on request/complete/fail; migration
+applies/rolls back.
+
+**Acceptance criteria:**
+- [ ] `DsarJob` table created additively; `has-pending-model-changes` → none.
+- [ ] Status transitions reject invalid states (CHECK).
+- [ ] `GDPR.DSAR.REQUESTED/COMPLETED/FAILED` appended via `IEventRepository` with no subject values
+      in payload.
+- [ ] Full suite stays green.
+
+### DSAR-2: `SubjectDataMap` + completeness guard + redaction policy
+
+**Scope:** The declarative registry of PII sources, the marker attribute, the build-failing
+completeness test, and the default-deny redaction chokepoint. No DB queries in collectors yet
+(stub `Collect` delegates wired to the map shape, real queries in DSAR-3).
+
+**Files:**
+- New: `Services/Compliance/SubjectDataSource.cs`, `ISubjectDataMap.cs`, `SubjectDataMap.cs`,
+  `ContainsPersonalDataAttribute.cs` (+ `KnownPiiEntities` fallback list),
+  `DsarRedactionPolicy.cs`, `DsarRecord.cs` / `DsarBundle.cs` (model with provenance).
+- Annotate PII entities with `[ContainsPersonalData]` (or populate `KnownPiiEntities`): `User`,
+  `TenantMembership`, `UserInvite`, `RefreshToken`, `ApiKey`, `AdminImpersonation`, `SecretRow`,
+  `PromptOverride`, `Convention`, `AgentConfig`, `SanitizationRule`, `Alert`, `DomainEvent`,
+  `PlatformEvent`.
+
+**Tests (first):** `Compliance/SubjectDataMapCompletenessTests.cs` — reflect over
+`[ContainsPersonalData]` entities; assert each is a `SubjectDataSource` in the map (a missing one
+fails the build). `Compliance/DsarRedactionTests.cs` — feed rows containing secret/hash/token
+material; assert default-deny strips them and emits `{ exists: true }` metadata.
+
+**Acceptance criteria:**
+- [ ] Every PII-marked entity is registered in `SubjectDataMap` (guard test red→green by adding a
+      missing registration).
+- [ ] Redaction is default-deny: a field appears only if explicitly projected; no secret value /
+      hash / token / ciphertext survives.
+
+### DSAR-3: `DsarCollector` — CP + per-tenant collection
+
+**Scope:** Real `Collect` delegates; the collector partitions the map (CP vs Tenant), queries
+`ControlPlaneDbContext` once and each in-scope tenant via `ITenantDbContextFactory`, assembles a
+provenance-tagged `DsarBundle`. Implements subject resolution (email/userId → exactly one user;
+ambiguous/unknown → not-found signal) and in-scope-tenant computation (tenant-initiated = one;
+platform-owner = all of subject's memberships).
+
+**Files:**
+- New: `Services/Compliance/IDsarCollector.cs`, `DsarCollector.cs`.
+- Flesh out each `SubjectDataSource.Collect` (the 14 categories in the story's data-map table),
+  each routed through `DsarRedactionPolicy`.
+
+**Tests (first):** `Compliance/DsarCollectorTests.cs` — seed a subject across CP + two tenant
+schemas; assert one section per category, correct counts, provenance tags; platform-owner covers
+both tenants, tenant-initiated covers only one (AC12); subject resolution by email (case-insensitive)
+and userId; ambiguous → not-found.
+
+**Acceptance criteria:**
+- [ ] Bundle has one provenance-tagged section per `SubjectDataMap` category present.
+- [ ] Multi-tenant coverage matches caller scope (AC12).
+- [ ] Subject resolution exact for userId, case-insensitive for email, not-found on ambiguity.
+
+### DSAR-4: `DsarBundlePackager` + `DsarExportTaskHandler` (async job)
+
+**Scope:** Render `export.json` (manifest + sections) + `export.html` (human-readable), zip,
+encrypt at rest, register a single-use TTL download token on the `DsarJob`. Wire the
+`IPlatformTaskHandler` that drives collecting→packaging→ready and emits `GDPR.DSAR.COMPLETED` /
+`FAILED`, with idempotent retry.
+
+**Files:**
+- New: `Services/Compliance/DsarBundlePackager.cs` (reuse 37-4 artifact-encryption + token seam if
+  present; else implement and factor for reuse), `DsarExportTaskHandler.cs`
+  (`TaskType = "compliance.dsar.export"`).
+- Register handler via `AddPlatformTaskHandler<DsarExportTaskHandler>()` in the compliance extension.
+
+**Tests (first):** `Compliance/DsarExportTaskHandlerTests.cs` — pending→collecting→packaging→ready;
+failure → failed + `GDPR.DSAR.FAILED`; idempotent retry (ready job re-run no-op); terminal vs
+retryable exception routing; manifest fields present; both `export.json` + `export.html` in the zip;
+end-to-end `DsarRedactionTests` against the **packaged** bundle (no secret material anywhere).
+
+**Acceptance criteria:**
+- [ ] Job reaches `ready` with an encrypted artifact + single-use TTL token.
+- [ ] Bundle contains machine-readable JSON + human-readable HTML + manifest.
+- [ ] Retry is idempotent; bad payload → terminal → dead-letter.
+- [ ] No secret value/hash/token in the packaged artifact.
+
+### DSAR-5: Endpoints + RBAC + identity verification + download
+
+**Scope:** The three initiation surfaces, status, and time-limited download, with per-mode RBAC and
+independent subject verification.
+
+```
+POST /api/v1/orgs/{tenantId}/dsar                 OwnerAccess          -> 202 {jobId}
+GET  /api/v1/orgs/{tenantId}/dsar/{jobId}         OwnerAccess          -> status
+GET  /api/v1/orgs/{tenantId}/dsar/{jobId}/download?token=   OwnerAccess -> artifact | 410
+POST /api/admin/dsar                               PlatformOwnerAccess  -> 202 {jobId}
+GET  /api/admin/dsar/{jobId}                       PlatformOwnerAccess  -> status
+GET  /api/admin/dsar/{jobId}/download?token=       PlatformOwnerAccess  -> artifact | 410
+POST /api/v1/dsar/self                             AuthenticatedAny (SingleUser only) -> 202 {jobId}
+GET  /api/v1/dsar/self/{jobId}                     AuthenticatedAny (SingleUser only) -> status
+```
+
+**Files:**
+- New: `Endpoints/ComplianceDsarEndpoints.cs` (mirror `AlertEndpoints.cs`/`OrgEndpoints.cs`
+  structure: admin + org + self sections); map in `Program.cs`. (Optionally thin shims in
+  `OrgEndpoints.cs`/`AdminEndpoints.cs` that delegate.)
+- In-handler subject verification: tenant route asserts subject ∈ `{tenantId}` via
+  `TenantMembership` (cross-tenant → 404); admin route allows any; self route pins subject to caller
+  (non-self ref → 403). Self route gated on `ITammaModeProvider == SingleUser`.
+
+**Tests (first):** `Compliance/ComplianceDsarEndpointsTests.cs` — full RBAC matrix (member 403;
+tenant owner/admin scoped; cross-tenant subject 404; unknown/ambiguous 404; platform-owner any;
+single-user self-only with non-self 403); 202 + jobId shape; status endpoint reflects lifecycle;
+download single-use (second 410), expiry (410), tamper (401); `GDPR.DSAR.REQUESTED` on enqueue,
+`GDPR.DSAR.DOWNLOADED` on consume.
+
+**Acceptance criteria:**
+- [ ] Endpoint shape consistent; auth stack + in-handler subject check enforce the RBAC matrix.
+- [ ] Tenant-initiated DSAR never returns other-tenant data.
+- [ ] Download is single-use and TTL-bounded; expired/consumed → 410, tampered → 401.
+
+---
+
+## Phase order & dependencies
+
+DSAR-1 → DSAR-2 → DSAR-3 → DSAR-4 → DSAR-5.
+DSAR-1 (job store + events) and DSAR-2 (map + redaction) are independent and can be parallelized;
+DSAR-3 needs DSAR-2; DSAR-4 needs DSAR-1+DSAR-3; DSAR-5 needs DSAR-4. External deps 37-1
+(audit taxonomy) and 37-4 (artifact/token seam) are integration points — if unbuilt, build the
+seam in DSAR-4 and factor it for reuse.
+
+## Risks
+
+- **Secret leak (highest):** any new PII source could accidentally serialize a secret. Mitigation:
+  `DsarRedactionPolicy` default-deny + a redaction test that scans the **packaged** artifact, not
+  just the in-memory model. Treat a redaction-test failure as a release blocker.
+- **Cross-tenant leak:** a tenant-initiated DSAR must never touch another tenant's schema. Mitigation:
+  in-scope-tenant computation is `{tenantId}` for tenant routes, enforced + tested (AC12); the
+  collector only opens tenant contexts in the computed set.
+- **Subject-existence oracle:** returning 403 vs 404 can confirm a subject exists in another tenant.
+  Use 404 for cross-tenant/unknown subjects (do not distinguish), 403 only for role/self failures.
+- **Data-map drift:** a future PII entity added without a map entry would silently miss a category.
+  Mitigation: `[ContainsPersonalData]` marker + build-failing completeness guard (AC4).
+- **Async-job topology / 37-4 ordering:** if 37-4's artifact+token seam isn't merged, DSAR-4 must
+  build a self-contained encrypted-artifact + single-use-token helper and factor it so 37-4 reuses
+  it — avoid two divergent token implementations.
+- **Migration discipline:** `DsarJob` is additive; still verify `has-pending-model-changes` → none
+  and mirror entity config in `TammaModelConfiguration.cs` (the single source). DB suites run via
+  `sg docker -c "dotnet test ..."`.
+- **Event-store topology shift (28-1/Epic 30):** system-scope (`TenantId = null`)
+  `GDPR.DSAR.*` events must stay CP-resident via `IEventRepository`; only tenant-scope routing moves
+  later.

--- a/docs/superpowers/plans/2026-06-17-37-8-gdpr-right-to-erasure-with-crypto-shredding-and-audit-preser-plan.md
+++ b/docs/superpowers/plans/2026-06-17-37-8-gdpr-right-to-erasure-with-crypto-shredding-and-audit-preser-plan.md
@@ -1,0 +1,300 @@
+# Story 37-8 — GDPR Right-to-Erasure with Crypto-Shredding & Audit Preservation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation. Read [BEFORE_YOU_CODE.md](../../guides/BEFORE_YOU_CODE.md) first.
+
+**Goal:** On a verified right-to-erasure request, irreversibly remove or anonymize a data
+subject's personal data across the control-plane and that subject's tenant schema, using
+**crypto-shredding** (destroying the subject's envelope-encryption key version in the Epic 29
+cabinet) for envelope-encrypted PII, while **preserving the tamper-evident audit chain** (37-2 —
+audit identity fields are anonymized + re-anchored, never deleted) and **respecting active legal
+holds** (37-6). Reconcile with the existing `TENANT.PURGED` lifecycle so subject erasure and tenant
+purge share machinery.
+
+**Story file:** `docs/stories/epic-37/story-37-8/37-8-gdpr-right-to-erasure-with-crypto-shredding-and-audit-preser.md`
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane API + Elsa engine).
+Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/` (xUnit; docker-bound suites run via
+`sg docker -c "dotnet test ..."`; build needs no wrapper). **`packages/api` is deleted — never a
+target.**
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO mutation of the append-only event store.** `DomainEvent`
+  (`src/Tamma.Data/Entities/DomainEvent.cs`) stays immutable — its `BIGSERIAL SequenceNumber` is the
+  `AlertRuleEvaluator` cursor. PII in events is killed by crypto-shred + curated-audit anonymization,
+  never by row edits/deletes.
+- **NO new key hierarchy.** The Epic 29 per-version envelope (`SecretVersionRow.KekId` + per-version
+  ciphertext + `revoked` status) is the per-subject shred granularity. A subject-scoped DEK scheme
+  is a future Epic 29 story, not this one.
+- **NO UI.** Admin/tenant dashboard surfaces for erasure status are Story 37-12.
+- **NO subject-discovery crawler.** Erasure walks the 37-7 `SubjectDataMap`; finding subjects is
+  37-7's job.
+- **NO sub-processor erasure fan-out.** Third-party processor erasure is a documented manual runbook
+  step, not code here.
+- **NO change to resolution/auth semantics** beyond adding the erasure routes + their RBAC gates.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### Crypto-shred substrate already exists (Epic 29) — reuse, don't reinvent
+
+| Seam | File | What it gives erasure |
+|---|---|---|
+| `SecretVersionRow` | `src/Tamma.Data/Entities/SecretVersionRow.cs` | Per-version AES-256-GCM envelope, **per-version `KekId`**, `Status` incl. `revoked`, nullable `Ciphertext` ("Null when the version row has been scrubbed ... the row is retained so audit queries still see that a version existed"). |
+| `ISecretStoreBackend.DeleteVersionAsync` | `src/Tamma.Api/Services/Secrets/ISecretStoreBackend.cs` | "Scrub the ciphertext for a version (the version row is kept for audit history; only the bytes are zeroed). **Idempotent**." — this is crypto-shred. |
+| `ISecretStore.RetireVersionAsync` | `src/Tamma.Api/Services/Secrets/ISecretStore.cs` | "Force-revoke a specific version: scrub the ciphertext, flip status to Revoked." |
+| `GetVersionPlaintextAsync` | `ISecretStoreBackend` | "Returns null when the version row exists but its ciphertext has been scrubbed" — the verification probe for AC9. |
+
+### Append-only + immutability constraint
+
+- `DomainEvent` (`src/Tamma.Data/Entities/DomainEvent.cs`): no update path; `SequenceNumber`
+  `BIGSERIAL` total-order cursor consumed by `AlertRuleEvaluator`. **Hard constraint: erasure must
+  not UPDATE/DELETE this table** (AC4).
+
+### Tenant-purge machinery to reconcile with
+
+- `src/Tamma.Activities/TenantLifecycle/TenantLifecycleEvents.cs` — `TENANT.DELETE.*` /
+  `TENANT.DELETED.SUCCESS` constants + `BuildEvent(...)` helper (the canonical
+  `AGGREGATE.ACTION.STATUS` event shape: `tenantId` tag, `eventSource=system` metadata). Subject
+  erasure mirrors this shape for `GDPR.ERASURE.*` and shares the secret-scrub primitive a full purge
+  uses.
+
+### PII surface (the things erasure destroys)
+
+- `src/Tamma.Data/Entities/User.cs` — `Email` (NOT NULL, case-insensitive unique index on
+  `LOWER(email) WHERE deleted_at IS NULL`), `DisplayName`, `AvatarUrl`, `GitHubLogin`,
+  `PasswordHash`, `Settings` (JSON), soft-delete `DeletedAt`. Anonymizable fields ⇒ stable tombstone;
+  `PasswordHash`/tokens ⇒ hard delete.
+
+### Async + RBAC + events plumbing (all exist)
+
+- **Async:** `IPlatformQueuedTaskRepository` (`src/Tamma.Data/Repositories/IPlatformQueuedTaskRepository.cs`)
+  for platform-scope tasks; processed by `src/Tamma.Api/Services/TaskQueue/TaskQueueProcessor.cs`.
+  (`ITaskQueue` is tenant-scoped-only by Story 28-1 — use the platform repo for `GDPR_ERASURE`.)
+- **Events:** `IEventRepository.AppendAsync(DomainEvent)`
+  (`src/Tamma.Data/Repositories/IEventRepository.cs`).
+- **RBAC:** `Program.cs` ~971 `OwnerAccess` (tenant-role, `users:manage`), ~986
+  `PlatformOwnerAccess` (`platform_admin` claim). Tenant-route precedent:
+  `OrgEndpoints.ReprovisionOrg` (~859) — `RequireTenantMembershipFilter` (cross-tenant 404) +
+  `RoleAtLeast(httpContext, TenantRoleHierarchy.Admin)`; tighten to owner for erasure.
+- **Mode:** `ITammaModeProvider` (`src/Tamma.Api/Services/PromptStore/TammaMode.cs`).
+
+### NEW dependencies — not yet authored at draft time (mock until they land)
+
+| Dep | Provides | Status |
+|---|---|---|
+| 37-2 | audit hash chain, `VerifyChainAsync`, re-anchor seam (`IAuditChainAnonymizer`) | **NEW** — empty `docs/stories/epic-37/story-37-2/` |
+| 37-6 | `ILegalHoldService` — is subject/record under active hold? | **NEW** — empty `docs/stories/epic-37/story-37-6/` |
+| 37-7 | `SubjectDataMap` + `SubjectRef` + per-field `ErasurePolicy` | **NEW** — empty `docs/stories/epic-37/story-37-7/` |
+
+This story defines local stub interfaces for these in `Services/Compliance/`, mocks them in tests,
+and consumes the real implementations once their stories ship.
+
+---
+
+## Architecture
+
+**request → enqueue → executor walks map → per-class destroy → audit-of-erasure**, reusing the
+secret cabinet for irreversibility and the platform task queue for async:
+
+1. **Endpoint** (`OrgEndpoints` tenant + `AdminTenantsEndpoints` platform): RBAC + scope check →
+   generate `erasureRequestId` → append `GDPR.ERASURE.REQUESTED` → enqueue `GDPR_ERASURE`
+   platform task → `202 Accepted`.
+2. **`GdprErasureTaskHandler`** (on `TaskQueueProcessor`): deserialize payload → call
+   `ErasureExecutor.ExecuteAsync` → mark task terminal.
+3. **`ErasureExecutor`**: walk the 37-7 `SubjectDataMap`; per entry consult 37-6
+   `ILegalHoldService` (skip held); apply per-policy action —
+   - plaintext `deletable` ⇒ hard delete / NULL,
+   - plaintext `must-retain-anonymized` ⇒ tombstone overwrite,
+   - `encrypted-secret` ⇒ **crypto-shred** via `ISecretStore.RetireVersionAsync` /
+     `DeleteVersionAsync` (record `(SecretId, Version, KekId)`),
+   - audit identity field ⇒ 37-2 `IAuditChainAnonymizer.AnonymizeAndReanchorAsync`.
+   Persist a per-map cursor on the task for resume. Apply chain re-anchor last, per-row atomic.
+4. **Terminal event**: `GDPR.ERASURE.COMPLETED` or `...PARTIAL` (if any held) with per-category
+   counts + destroyed key-version tuples; `GDPR.ERASURE.BLOCKED_BY_HOLD` for held items;
+   `GDPR.ERASURE.FAILED` on unrecoverable error. Request/actor/reason/tuples retained as evidence.
+5. **Verify**: `VerifyErasureAsync` re-walks the map — no plaintext PII remains, every
+   `encrypted-secret` scrubbed (`GetVersionPlaintextAsync` → null, `Status=revoked`).
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who may request? | the sole user (their instance) | `tenant_owner` only via tenant route (admin/member 403); `platform_admin` via admin route |
+| Subject scope | the user themselves | a data subject inside the named tenant |
+| Data location | control-plane (single instance) | control-plane (identity) + tenant schema (`TenantDbContext`) |
+| Audit-of-erasure feed | sole user's feed (`TenantId` null) | tenant feed (`TenantId` set) + platform feed for admin path |
+| Mode source | `ITammaModeProvider` | same |
+
+---
+
+## Task breakdown
+
+### E8-1: Compliance contracts + event types + DTOs + DI (core, no behaviour yet)
+
+**Scope:** Define the local seams and wire DI. No destruction logic yet.
+
+**Files:**
+- New: `src/Tamma.Api/Services/Compliance/ErasureRequest.cs` (records: `ErasureRequest`,
+  `ErasureResult`, `ShreddedKeyVersion(SecretId, Version, KekId)`, `HeldBackItem(MapEntryId, HoldId,
+  Reason)`, `ErasureStatus`, `ErasureScope`).
+- New: `src/Tamma.Api/Services/Compliance/ErasureEventTypes.cs`
+  (`GDPR.ERASURE.REQUESTED|COMPLETED|PARTIAL|BLOCKED_BY_HOLD|FAILED`).
+- New stub seams (consumed from 37-2/6/7; mocked in tests):
+  `Services/Compliance/IAuditChainAnonymizer.cs` (37-2),
+  `Services/Compliance/ISubjectDataMapProvider.cs` + `SubjectRef`/`SubjectDataMapEntry`/`ErasurePolicy`
+  (37-7), `Services/Compliance/ILegalHoldService.cs` (37-6). Mark each clearly "OWNED BY 37-x; this
+  is a transitional contract to be replaced when that story lands."
+- New: `src/Tamma.Api/Services/Compliance/ErasureOptions.cs` (`Gdpr:ErasureSlaDays`, default 30).
+- New: `src/Tamma.Api/Dtos/Compliance/ErasureDtos.cs` (request body `{ subjectRef, reason }`,
+  status response).
+- New: `src/Tamma.Api/Extensions/ComplianceServiceCollectionExtensions.cs`; wire in `Program.cs`
+  (mirror an existing `*ServiceCollectionExtensions` pattern).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Compliance/ErasureContractsTests.cs` — record shapes /
+event-type constants stable; options bind from config; DI resolves `ErasureExecutor` (once E8-2
+exists, this becomes the resolution smoke test).
+
+**Acceptance:**
+- [ ] Event-type constants + records compile and are referenced nowhere-else-by-string.
+- [ ] `Gdpr:ErasureSlaDays` binds (default 30).
+- [ ] Full suite stays green.
+
+### E8-2: `ErasureExecutor` — map walk, per-policy destroy, crypto-shred, counts
+
+**Scope:** The core. Walk `ISubjectDataMapProvider`, apply per-entry policy, crypto-shred encrypted
+entries, accumulate per-category counts + destroyed key tuples. No endpoints/queue yet; drive
+directly in tests.
+
+**Files:**
+- New: `src/Tamma.Api/Services/Compliance/ErasureExecutor.cs` — `ExecuteAsync(ErasureRequest)` +
+  `VerifyErasureAsync(SubjectRef)`. Inject `ISubjectDataMapProvider`, `ILegalHoldService`,
+  `IAuditChainAnonymizer`, `ISecretStore`, `ControlPlaneDbContext`/`TenantDbContext` accessors,
+  `IEventRepository`, `ITammaModeProvider`, `ILogger`.
+- Destruction primitives: hard-delete/NULL (deletable), tombstone overwrite
+  (`erased:{hashedSubjectId}`, must-retain-anonymized), crypto-shred via
+  `ISecretStore.RetireVersionAsync` for each live version of each subject-scoped secret (record
+  `(SecretId, Version, KekId)`), audit anonymize via `IAuditChainAnonymizer`.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Compliance/ErasureExecutorTests.cs` —
+- policy application: deletes deletable, anonymizes must-retain to stable tombstone, counts correct;
+- crypto-shred: post-run `GetVersionPlaintextAsync` → null, `Status=revoked`, tuple recorded
+  (story AC2/AC3/AC9);
+- idempotent re-run: no double-count, no throw, shredded stays revoked (AC10);
+- append-only untouched: spy/interceptor asserts zero `UPDATE`/`DELETE` on `domain_events` (AC4);
+- mid-walk throw: partial work durable, cursor recorded, resume completes (AC13).
+
+**Acceptance:**
+- [ ] Each policy class destroyed by its correct strategy; counts match the map.
+- [ ] Crypto-shredded ciphertext unrecoverable; destroyed tuples recorded.
+- [ ] Idempotent; `domain_events` never mutated.
+
+### E8-3: Legal-hold gating + partial results + GDPR.ERASURE.* emission
+
+**Scope:** Wrap the walk with 37-6 hold checks and emit the lifecycle events.
+
+**Files:** modify `ErasureExecutor.cs` — pre-check `ILegalHoldService` per entry; skip held, collect
+`HeldBackItem`s; emit `GDPR.ERASURE.BLOCKED_BY_HOLD` (per batch of held), and exactly one terminal
+`COMPLETED`/`PARTIAL` (held>0 ⇒ PARTIAL) carrying per-category counts + tuples via
+`IEventRepository.AppendAsync` using the `TenantLifecycleEvents.BuildEvent`-style shape; subject id
+**hashed** in tags. `REQUESTED` is emitted by the endpoint (E8-4) but assert its tags here too.
+
+**Tests (first):** extend `ErasureExecutorTests` —
+- held records skipped + listed with hold id/reason; remainder erased; terminal = PARTIAL;
+  `BLOCKED_BY_HOLD` emitted (AC6);
+- no-held ⇒ exactly one `COMPLETED`, counts correct (AC7);
+- subject id hashed in every event tag; reason/actor/tuples present in terminal `data` (AC7);
+- failure ⇒ `GDPR.ERASURE.FAILED` with cursor.
+
+**Acceptance:**
+- [ ] Legal hold blocks held records; partial result accurate; remainder still erased.
+- [ ] Exactly one terminal event; per-category counts correct; subject hashed everywhere.
+
+### E8-4: Endpoints (tenant + platform) + RBAC + async enqueue + status
+
+**Scope:** HTTP surface and async wiring. Validate → `REQUESTED` event → enqueue `GDPR_ERASURE`
+platform task → 202; plus status read-back.
+
+**Files:**
+- Modify `src/Tamma.Api/Endpoints/OrgEndpoints.cs` — `RequestErasure` (tenant_owner; mirror
+  `ReprovisionOrg`'s membership filter + role gate, tightened to owner) +
+  `GetErasureStatus` (`GET /api/v1/orgs/{tenantId}/erasure/{id}`).
+- Modify `src/Tamma.Api/Endpoints/Admin/AdminTenantsEndpoints.cs` — platform `RequestErasure` +
+  `GetErasureStatus` under `.RequireAuthorization("PlatformOwnerAccess")`.
+- New: `src/Tamma.Api/Services/Compliance/GdprErasureTaskHandler.cs` — registered with
+  `TaskQueueProcessor`; deserialize payload, call `ErasureExecutor.ExecuteAsync`, mark terminal,
+  WARN if past `Gdpr:ErasureSlaDays`.
+- Modify `Program.cs` — map the four routes; register handler + services via the E8-1 extension.
+- Enqueue via `IPlatformQueuedTaskRepository` (platform-scope; NOT `ITaskQueue`).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Compliance/ErasureEndpointsTests.cs` —
+- RBAC matrix: tenant_owner ✓, tenant_admin 403, member 403, cross-tenant 404, platform_admin ✓ on
+  admin route / non-platform 403, out-of-scope subject 404 (AC8);
+- accept ⇒ 202 + `erasureRequestId` + `REQUESTED` event + a `GDPR_ERASURE` task enqueued (AC1/AC11);
+- status endpoint reports `requested→in_progress→completed|partial|failed` (AC11);
+- handler invokes executor and marks task terminal; SLA WARN past threshold.
+
+**Acceptance:**
+- [ ] Endpoint shape consistent; auth middleware decides scope (prompt-store/org precedent).
+- [ ] 202 + async execution via existing `TaskQueueProcessor`; status reflects progress.
+
+### E8-5: Chain preservation + verification + tenant-purge reconciliation
+
+**Scope:** Prove the load-bearing compliance invariants and reconcile with `TENANT.PURGED`.
+
+**Files:** modify `ErasureExecutor.cs` (call `IAuditChainAnonymizer.AnonymizeAndReanchorAsync`
+**last**, per affected row atomically; expose `VerifyErasureAsync`); doc note in the story's
+Dev Notes already covers the purge-share — add a thin shared helper if the secret-scrub call needs
+factoring so purge and erasure call one method.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Compliance/ErasureChainPreservationTests.cs` —
+- seed a 37-2 chain incl. the subject; erase; `VerifyChainAsync` passes (re-anchored) (AC5);
+- positive-control: a manual byte edit to a chained row still FAILS verification (chain is real,
+  not bypassed);
+- `VerifyErasureAsync` re-walk: no plaintext PII remains, every encrypted entry scrubbed (AC9);
+- tenant-purge reconciliation: a full purge crypto-shreds every subject's keys via the same
+  primitive; single-subject erasure is the subset (AC12);
+- crash mid-walk ⇒ resume ⇒ chain still verifies (AC13).
+
+**Acceptance:**
+- [ ] Chain verifies after erasure; tamper still detected.
+- [ ] Verification confirms PII unrecoverable; purge ↔ erasure share the shred primitive.
+
+---
+
+## Task order & dependencies
+
+E8-1 → E8-2 → E8-3 → E8-4 → E8-5. E8-1 is the only hard prerequisite for the rest. E8-5's chain
+tests depend on the 37-2 anonymizer contract from E8-1 (mocked) and the real impl once 37-2 ships.
+
+## Risks
+
+- **Story 37-2/6/7 not yet authored.** Their contracts are mocked behind transitional interfaces in
+  `Services/Compliance/`. Risk: their real shapes differ. Mitigation: keep the stub interfaces
+  minimal (only the methods erasure calls) and clearly marked "OWNED BY 37-x"; a follow-up swaps the
+  mock for the real DI registration with no `ErasureExecutor` change.
+- **Accidentally breaking the audit chain.** A silent in-place edit of a chained audit row looks
+  like tampering to `VerifyChainAsync`. Mitigation: anonymization MUST go through the 37-2
+  re-anchor seam (re-hash + re-sign as an explicit step), applied last and per-row atomic; the
+  positive-control tamper test guards against bypass.
+- **Mutating the append-only event store.** Easy to reach for "just delete the PII events."
+  Mitigation: AC4 interceptor test fails the build if any `UPDATE`/`DELETE` hits `domain_events`;
+  PII is killed only by crypto-shred + curated-audit anonymization.
+- **Irreversibility correctness.** Crypto-shred must leave NO key path. Mitigation: lean on the
+  existing `DeleteVersionAsync` scrub (already idempotent, already keeps the tombstone row) and
+  `VerifyErasureAsync` re-probe; do not invent a parallel deletion path.
+- **PII leakage in logs/events.** Mitigation: subject identity is always a salted hash in tags +
+  logs; only reason/actor/key-tuples (evidence) are retained in clear.
+- **Tenant-purge drift.** Erasure and purge could grow divergent shred logic. Mitigation: factor the
+  secret-scrub into one shared helper both call (E8-5).
+- **Async failure leaving a half-erased subject.** Mitigation: per-map cursor on the queued task,
+  idempotent primitives, resume-from-cursor; chain re-anchor applied last so a partial run is still
+  verifiable.
+- **SLA breach invisibility.** Mitigation: `Gdpr:ErasureSlaDays` (default 30) + WARN log + status
+  endpoint surface `failed`/non-terminal.

--- a/docs/superpowers/plans/2026-06-17-37-9-consent-and-data-processing-logging-plan.md
+++ b/docs/superpowers/plans/2026-06-17-37-9-consent-and-data-processing-logging-plan.md
@@ -1,0 +1,297 @@
+# Story 37-9: Consent & Data-Processing Logging — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation.
+
+**Story:** [docs/stories/epic-37/story-37-9/37-9-consent-and-data-processing-logging.md](../../stories/epic-37/story-37-9/37-9-consent-and-data-processing-logging.md)
+
+**Goal:** Record and serve a tamper-evident, append-only log of consent and data-processing
+decisions (TOS/DPA acceptance, BYOK vs platform data handling, telemetry opt-in/out, AI-training-
+data usage) plus a Records-of-Processing-Activities (ROPA) registry. Each consent change captures
+who/what/when/version, emits a sensitive `CONSENT.*` audit event (hash-chained via 37-2, ingested
+by 37-1), and is queryable as current effective state + immutable history. Per-mode owned; RBAC.
+
+**Tech stack:** .NET 9 / EF Core 9 / Npgsql in `apps/tamma-elsa` (control-plane API + Elsa engine).
+Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/Compliance/` (docker-bound suites run via
+`sg docker -c "dotnet test ..."`; build needs no wrapper).
+
+---
+
+## Non-goals (YAGNI guard)
+
+- NO per-user override layer in SaaS. Consent is tenant-owned (tenant_owner/tenant_admin), mirroring
+  the prompt-store decision in CLAUDE.md. Members read; they do not write.
+- NO in-place mutation of consent rows. Append-only is the invariant — a withdrawal is a NEW row.
+  No update/delete method exists on the service or repository.
+- NO DB-level immutability triggers. The service/repository API surface is the enforcement boundary
+  (same as the DCB event store, which is append-only by API, not by trigger).
+- NO consent-collection UI. This story is the API + storage + audit substrate. Dashboard surfacing
+  is a separate follow-up (out of scope, like the alert-pipeline dashboard split).
+- NO change to resolution semantics elsewhere. `IConsentGate` is a read-only hard-error gate; it
+  never auto-grants and never silently degrades (`feedback_resolution_no_empty_fallback`).
+- NO new audit substrate. `CONSENT.*` events flow through Story 37-1's `IAuditTrail` (or, until that
+  merges, `IEventRepository.AppendAsync` tagged `sensitive`). This story does not build its own.
+- NO TS-side code. `packages/api` is DELETED. All targets are the C# `apps/tamma-elsa` solution.
+
+---
+
+## Current-state findings (verified 2026-06-17, repo @ main 98cfb1c2)
+
+### What exists (reuse it)
+
+| Concern | Verified anchor |
+|---|---|
+| Subject identity | `src/Tamma.Data/Entities/User.cs` — `Id`, `TenantId`, per-tenant `Role`, `PlatformRole` |
+| Audit event row | `src/Tamma.Data/Entities/DomainEvent.cs` — `Type`, `TenantId`, `Tags`, `Data`, `SequenceNumber` (BIGSERIAL total-order tiebreak) |
+| Audit write seam | `src/Tamma.Data/Repositories/IEventRepository.cs` — `AppendAsync`, `ListByTenantAsync`, `QueryWithPaginationAsync` |
+| Dual-scoping precedent | `src/Tamma.Data/Entities/PromptOverride.cs` + `TammaModelConfiguration.cs` ~714: `ck_prompt_overrides_principal_xor`, `.AreNullsDistinct(false)` unique index, `gen_random_uuid()` default |
+| Mode | `src/Tamma.Api/Services/PromptStore/TammaMode.cs` — `ITammaModeProvider` (SingleUser \| SaaS), process-stable |
+| Tenant RBAC | `src/Tamma.Api/Authorization/TenantRoleHierarchy.cs` (`Owner`/`Admin`/`Member`, `IsAtLeast`) + `RequireTenantMembershipFilter` (path-tenant gate sets `HttpContext.Items[TenantRoleItemKey]`) |
+| Org endpoints (target) | `src/Tamma.Api/Endpoints/OrgEndpoints.cs` — `ListTenantAudit` (line ~527) is the read precedent; role check via `RoleAtLeast`/`TenantRoleHierarchy.IsAtLeast(..., Admin)` |
+| Org route mapping | `src/Tamma.Api/Program.cs` ~1550: `orgs.MapGet("/{tenantId:guid}/audit", OrgEndpoints.ListTenantAudit).AddEndpointFilter<RequireTenantMembershipFilter>()` |
+| Platform-owner gate | `OwnerAccess` policy (used by `/api/v1/admin/*` endpoints) |
+| Seed-defaults precedent | `src/Tamma.Api/Services/Conventions/ConventionSeedSpecs.cs` + `ConventionStoreSeeder` (insert-missing-only, never reverts edits) |
+| Migrations | `src/Tamma.Data/Migrations/ControlPlane/` (current baseline `20260609205701_InitialControlPlane`) |
+| Entity-config single source | `src/Tamma.Data/TammaModelConfiguration.cs` (1302 lines; all `HasCheckConstraint` live here) |
+| Test layout | `tests/Tamma.Api.Tests/` (per-area folders; `Orgs/TenantAuditEndpointTests.cs` is the endpoint-test precedent — direct-handler invocation + `ApiTestFixture.ResetDatabaseAsync`) |
+
+### What does NOT exist yet (NEW)
+
+- **No consent or ROPA implementation anywhere** (grep for `consent`/`processing.activit`/`ropa`
+  returns only unrelated substring hits, e.g. "operator consent via env" in `AgentResolverService`).
+- **No `audit_records` table, no hash-chain, no `IAuditTrail`** — those are delivered by Stories
+  37-1 and 37-2, which are NOT yet written (their `docs/stories/epic-37/story-37-1|2/` folders are
+  empty). **Decision:** depend on 37-1's `IAuditTrail` if merged; otherwise fall back to
+  `IEventRepository.AppendAsync` with a `sensitive: "true"` tag so 37-1 can backfill `audit_records`
+  from the DCB stream. Confirm 37-1/37-2 state as task 0.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Owns a consent record | sole user (`user_id`, `tenant_id` NULL) | tenant (`tenant_id`, `user_id` NULL) |
+| May grant/withdraw | the user (no RBAC) | `tenant_owner`/`tenant_admin`; `member` → 403 |
+| May read effective + history | the user | any member of own tenant; cross-tenant rejected |
+| Owns ROPA registry | system defaults + user's view | system defaults (platform owner CRUD); members read-only |
+| Mode source | `ITammaModeProvider` | same |
+
+---
+
+## Architecture
+
+**record → emit audit event → store append-only → resolve effective → gate**, reusing the audit and
+RBAC substrate end-to-end:
+
+1. **`ConsentRecord` + `ProcessingActivity` entities** (CP DB). Consent is append-only, XOR-scoped
+   (`user_id`/`tenant_id`), with a `BIGSERIAL SequenceNumber` total-order tiebreak mirroring
+   `DomainEvent`. ROPA is system-scoped, seeded insert-missing-only, unique on `ActivityKey`.
+2. **`ConsentTypeCatalog`** (code) — canonical types + active versions. A version bump forces
+   re-consent via read-time staleness, never a delete.
+3. **`ConsentService`** — `RecordAsync` (append + emit `CONSENT.GRANTED`/`CONSENT.WITHDRAWN`
+   atomically), `GetEffectiveAsync` (latest per `(scope, type)` + `granted`/`stale` flags),
+   `GetHistoryAsync` (immutable timeline). Scope derived from `ITammaModeProvider` + caller.
+4. **`CONSENT.*` audit events** (AGGREGATE.ACTION.STATUS) through 37-1's `IAuditTrail` (fallback
+   `IEventRepository`), flagged sensitive, hash-chained by 37-2. Row id stored on
+   `consent_records.source_event_id`.
+5. **`IConsentGate.RequireAsync`** — read-only hard-error gate for consent-dependent paths; wired
+   at one demonstrative call site.
+6. **Endpoints** — tenant-scoped `POST/GET /api/v1/orgs/{tenantId}/consent` + ROPA read on
+   `OrgEndpoints` (the spec target); single-user self-service `POST/GET /api/v1/consent`;
+   platform-owner ROPA CRUD under `/api/v1/admin/processing-activities` (`OwnerAccess`).
+
+---
+
+## Task breakdown
+
+### T0: Confirm audit-substrate state (deps 37-1 / 37-2)
+
+**Scope:** Determine whether `audit_records` + `IAuditTrail` (37-1) and the hash-chain (37-2) are
+merged. This decides the `ConsentService` emit path.
+
+- [ ] `grep -rl "IAuditTrail\|audit_records\|AuditRecord" apps/tamma-elsa/src` — if present, target
+      `IAuditTrail`; if absent, target `IEventRepository.AppendAsync` + `sensitive:"true"` tag.
+- [ ] Note the chosen seam in the `ConsentService` doc-comment so a later 37-1 merge is a one-line
+      swap.
+
+**Acceptance:** the emit path is decided and documented; no guessing at a non-existent API.
+
+### T1: `ConsentRecord` + `ProcessingActivity` entities, model config, migration (core)
+
+**Scope:** New entities, DbSets, `TammaModelConfiguration` blocks, additive EF migration. No service
+wiring yet.
+
+**Files:**
+- New: `src/Tamma.Data/Entities/ConsentRecord.cs`, `src/Tamma.Data/Entities/ProcessingActivity.cs`.
+- Modify: `src/Tamma.Data/ControlPlaneDbContext.cs` (add `DbSet<ConsentRecord>`,
+  `DbSet<ProcessingActivity>`); `src/Tamma.Data/TenantDbContext.cs` (ignore/scope per the
+  established dual-context pattern — follow how `PromptOverride` is treated in each context).
+- Modify: `src/Tamma.Data/TammaModelConfiguration.cs` — mirror the PromptOverride block:
+  - ConsentRecord: `Id` default `gen_random_uuid()`; `ck_consent_records_principal_xor`
+    (exactly-one of `UserId`/`TenantId`); index `(UserId, TenantId, ConsentType, SequenceNumber DESC)`
+    (NON-unique — history); `SequenceNumber` as `BIGSERIAL`/identity (mirror `DomainEvent`); apply
+    `ApplyTenantFilter` like PromptOverride for defence-in-depth.
+  - ProcessingActivity: `Id` default `gen_random_uuid()`; unique on `ActivityKey`;
+    `DataCategories`/`Recipients` as `text[]`; `CreatedAt`/`UpdatedAt` default `now()`.
+- New: `src/Tamma.Data/Migrations/ControlPlane/*_AddConsentAndProcessingActivities.cs` via
+  `dotnet ef migrations add AddConsentAndProcessingActivities` (run from the Data project).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Compliance/ConsentEntityTests.cs` — XOR CHECK rejects
+both-null and both-set; a `(scope, type)` accepts multiple rows (no unique violation); `BIGSERIAL`
+assigns strictly increasing `SequenceNumber`; ROPA `ActivityKey` uniqueness enforced.
+
+**Acceptance criteria:**
+- [ ] Migration applies + rolls back cleanly; `dotnet ef migrations has-pending-model-changes`
+      reports none afterwards.
+- [ ] Entity config lives ONLY in `TammaModelConfiguration.cs`.
+- [ ] Full suite stays green.
+
+### T2: `ConsentType` catalog + `ConsentEventTypes` + repository (append + query only)
+
+**Scope:** Code-shipped consent-type catalog with active versions; event-type constants; the
+append-only repository surface.
+
+**Files:**
+- New: `src/Tamma.Api/Services/Compliance/ConsentType.cs` (constants) + `ConsentTypeCatalog.cs`
+  (active versions: `terms_of_service`, `data_processing_agreement`, `byok_data_handling`,
+  `telemetry_opt_in`, `ai_training_data_usage`).
+- New: `src/Tamma.Api/Services/Compliance/ConsentEventTypes.cs` (`CONSENT.GRANTED`,
+  `CONSENT.WITHDRAWN`).
+- New: `src/Tamma.Data/Repositories/IConsentRepository.cs` + `ConsentRepository.cs` — methods:
+  `AppendAsync(ConsentRecord)`, `GetLatestPerTypeAsync(scope)`, `GetHistoryAsync(scope, type?)`.
+  **No update/delete method** — append + query only.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Compliance/ConsentAppendOnlyTests.cs` — assert the
+`IConsentRepository` surface exposes only append + query (no Update/Delete/Remove member);
+catalog returns the expected active version per type; missing type lookup is handled.
+
+**Acceptance criteria:**
+- [ ] `IConsentRepository` has no mutation-other-than-append method (reflection assertion).
+- [ ] Catalog is the single source of active versions.
+
+### T3: `ConsentService` — record (atomic emit) + effective + history
+
+**Scope:** The write/read service. `RecordAsync` emits the `CONSENT.*` audit event and inserts the
+row atomically (a failed emit aborts the insert); `GetEffectiveAsync` computes `granted`/`stale`;
+`GetHistoryAsync` returns the immutable timeline. Scope from `ITammaModeProvider` + caller.
+
+**Files:**
+- New: `src/Tamma.Api/Services/Compliance/ConsentService.cs`, `ConsentScope.cs` (record:
+  `UserId?`/`TenantId?` + factory from mode+caller).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Compliance/ConsentServiceTests.cs`:
+- grant → one row + `CONSENT.GRANTED` (tags `consentType`/`version`/`scope`/`tenantId`/`actorUserId`/
+  `mode`) + `source_event_id` round-trips.
+- withdraw → second row (`granted=false`) + `CONSENT.WITHDRAWN`; grant row untouched.
+- grant→withdraw→re-grant → 3 ordered rows; effective = latest.
+- staleness: bump `ConsentTypeCatalog` active version above consented → effective `stale=true`.
+- type with no record → `granted=false, stale=false, consentedVersion=null`.
+- emit failure → record NOT inserted (atomicity) + ERROR logged.
+
+**Acceptance criteria:**
+- [ ] Effective resolution orders by `(OccurredAt, SequenceNumber)` and returns one entry per known
+      type.
+- [ ] Withdrawal never edits the prior grant row (append-only).
+- [ ] `source_event_id` references the emitted audit/DCB row.
+
+### T4: `IConsentGate` + one demonstrative call site
+
+**Scope:** Read-only hard-error gate; wire at one consent-dependent site (telemetry emit OR
+AI-training-data path).
+
+**Files:**
+- New: `src/Tamma.Api/Services/Compliance/IConsentGate.cs` + `ConsentGate.cs`.
+- Modify: one demonstrative call site (choose telemetry emit or AI-training-data usage) to call
+  `RequireAsync` before the gated action.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Compliance/ConsentGateTests.cs` — throws
+`CONSENT.REQUIRED.MISSING` (severity High) on absent/withdrawn/stale; passes on a fresh active-
+version grant; never grants; never silently passes.
+
+**Acceptance criteria:**
+- [ ] Gate is read-only and hard-errors (no empty/plain fallback).
+- [ ] The demonstrative site is gated and tested.
+
+### T5: ROPA seed + admin CRUD + tenant read
+
+**Scope:** System-default processing activities seeded insert-missing-only; platform-owner CRUD;
+tenant read-only surface.
+
+**Files:**
+- New: `src/Tamma.Api/Services/Compliance/ProcessingActivitySeedSpecs.cs` + seeder (mirror
+  `ConventionSeedSpecs`/`ConventionStoreSeeder`: insert-missing-only, never reverts edits).
+- New: `src/Tamma.Api/Endpoints/Admin/AdminProcessingActivityEndpoints.cs`
+  (`GET/POST/PATCH /api/v1/admin/processing-activities`, `OwnerAccess`).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Compliance/ProcessingActivityTests.cs` — seed adds
+defaults once (re-run adds nothing, never reverts an edited row); admin CRUD gated by `OwnerAccess`
+(non-owner 403); tenant read returns active activities.
+
+**Acceptance criteria:**
+- [ ] Seeder is insert-missing-only.
+- [ ] Admin CRUD is platform-owner-only; tenant read is members-only.
+
+### T6: Endpoints + route mapping + DI wiring
+
+**Scope:** Consent + ROPA-read endpoints on `OrgEndpoints`; single-user self-service variant;
+route mapping + DI.
+
+**Files:**
+- Modify: `src/Tamma.Api/Endpoints/OrgEndpoints.cs` — `RecordConsent` (admin+ via
+  `TenantRoleHierarchy.IsAtLeast(..., Admin)`; member → 403, mirroring `ListTenantAudit`'s role
+  gate), `GetConsent` (any member; `?history=true`), `ListProcessingActivities` (any member).
+- New: single-user `POST/GET /api/v1/consent` handlers (no path-tenant; principal = the user).
+- New: `src/Tamma.Api/Dtos/Orgs/ConsentDtos.cs` (request/response shapes).
+- New: `src/Tamma.Api/Extensions/ComplianceServiceCollectionExtensions.cs` (DI: repository,
+  service, gate, seeder — mirror `AlertServiceCollectionExtensions`).
+- Modify: `src/Tamma.Api/Program.cs` — map org consent routes alongside the `/{tenantId:guid}/audit`
+  block (~1550), each attaching `RequireTenantMembershipFilter`; map single-user + admin routes;
+  call the compliance extension.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Compliance/ConsentEndpointsTests.cs` (direct-handler,
+`ApiTestFixture.ResetDatabaseAsync` precedent from `TenantAuditEndpointTests`):
+- single-user: user read+write.
+- SaaS: `tenant_owner`/`tenant_admin` write; `member` → 403 on POST; member read OK.
+- cross-tenant path rejected by the membership filter.
+- effective vs `?history=true` shapes; ROPA read.
+
+**Acceptance criteria:**
+- [ ] Endpoint shape identical between modes; auth middleware decides the principal key
+      (prompt-store API precedent).
+- [ ] RBAC matrix green incl. SaaS member 403 + cross-tenant rejection.
+
+### T7 (verification): full suite + migration round-trip
+
+- [ ] `sg docker -c "dotnet test apps/tamma-elsa/Tamma.sln"` (or the Compliance filter for the inner
+      loop) green.
+- [ ] Migration apply + rollback clean; `has-pending-model-changes` → none.
+- [ ] No new analyzer/lint warnings introduced.
+
+---
+
+## Task order & dependencies
+
+T0 → T1 → T2 → T3 → (T4 ∥ T5) → T6 → T7.
+T1 is the hard prerequisite for everything. T4 (gate) and T5 (ROPA) are parallel-safe after T3/T1.
+T6 needs T3+T5.
+
+## Risks
+
+- **Audit-substrate timing (T0):** 37-1/37-2 may not be merged. Mitigation: the
+  `IEventRepository.AppendAsync` + `sensitive:"true"` fallback keeps this story shippable; a later
+  37-1 merge is a one-line emit-seam swap. Pin the chosen seam in a doc-comment.
+- **Atomicity of emit + insert (T3):** the audit event and the consent row must both persist or
+  neither. Use a single DB transaction (or emit-then-insert with the insert as the commit point and
+  the event id captured first). A consent row without its audit event breaks the evidentiary trail.
+- **Append-only erosion:** a future "edit consent" convenience method would silently destroy the
+  compliance invariant. The repository-surface assertion test (T2) is the guardrail — keep it.
+- **Scope-derivation correctness:** writing a `user_id`-scoped row in SaaS (or vice versa) corrupts
+  ownership. Derive scope ONLY from `ITammaModeProvider` + caller, never from request body; the XOR
+  CHECK is the backstop and the RBAC tests pin the matrix.
+- **Migration discipline:** `consent_records` / `processing_activities` are additive (no baseline
+  CHECK edit), so a normal `dotnet ef migrations add` applies — but still verify
+  `has-pending-model-changes` and keep all entity config in `TammaModelConfiguration.cs`.
+- **Event-store topology shift (Story 28-1 / Epic 30):** `CONSENT.*` events append to the CP store
+  the evaluator polls today. System/tenant routing must follow whatever 37-1 does; keep the emit
+  going through the shared seam so a per-tenant fan-out migration touches one place.

--- a/docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md
+++ b/docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md
@@ -1,0 +1,97 @@
+# Design Spec — Agent Entities, Personas, Benchmarking & Learning (Epic 32)
+
+**Date:** 2026-06-17
+**Status:** Approved (brainstorm converged with user)
+**Epic:** 32
+**Related epics:** 1 (providers), 4 (DCB event sourcing), 6 (RAG/context), 9 (unified agent API), 27 (prompt store), 28 (tenancy), 29 (secret cabinet), 34 (pricing), 35 (billing), 36 (analytics), 37 (audit)
+
+## Problem
+
+Tamma's workflows invoke a single agent per phase, keyed only by a static **role** (architect, reviewer, …). There is no first-class, persisted **agent entity** whose configuration, actions, and performance can be tracked and compared over time. We want:
+
+- Multiple named dev-agents to participate in **design and review** steps of workflows.
+- Agents with **dynamic config** but **stable identity**, so performance can be tracked and benchmarked by configuration (provider, prompt, model, …).
+- **Learning and outcome tracking**: successes/failures, iterations-to-done, and bug classes (visual vs functional vs …).
+- **Context management + RAG** wired into agent execution.
+- A **customization layer above LLM API providers**, distinct from CLI agent providers.
+
+## Core concept: the Agent is the entity
+
+An **Agent** is a first-class, persisted entity — a saved configuration given a stable identity — tracked along two dimensions: **what it did** (actions) and **how well it did** (performance).
+
+- **Identity**: immutable `agent_id` + stable `name` (e.g., `atlas`). The join key for all metrics, so history survives config edits.
+- **Saved config (versioned)**: provider chain, prompt overrides, budget, allowed tools, temperature, RAG settings. Each version is pinned so any action/metric ties to the exact config that produced it.
+- **Role attribute**: architect/reviewer/tester/… — retained so like-vs-like benchmarking is possible (reviewer A vs reviewer B), but the Agent, not the role, is the tracked entity.
+- **Backing execution layer**: either the managed-LLM-agent layer (over `ILLMProvider`) or a CLI agent provider — but the *entity* is independent of what runs it.
+
+## Ownership, visibility & data scoping (the key tenancy rule)
+
+Definition ownership and **data** ownership are separate:
+
+| Concern | Scope |
+|---|---|
+| **Agent definition** | **Public/system-wide** (owned & edited by platform admin; available to every tenant) **OR** **private/tenant-owned** (owned & edited by a tenant; available only to it). Shipped defaults are public. |
+| **Performance + action data** | **ALWAYS tenant-scoped** — belongs to the tenant that generated it; never system-wide, never cross-tenant. |
+
+→ A tenant's usable agent set = **all public agents ∪ its own private agents**.
+→ **One-to-many**: one agent definition → many independent per-tenant performance/action datasets. Two tenants running public agent `atlas` build *separate, private* profiles; neither sees the other's; the platform admin who owns `atlas` sees **none** of it.
+→ Leaderboards/benchmarks are computed **within a tenant's own data**.
+
+This maps cleanly onto the unified schema-per-tenant model:
+- **Public agent definitions** live in the **control-plane** (shared), referenced by `agent_id`.
+- **Private agent definitions + all performance/action data** live in the **tenant's `t_<hex>` schema** — isolation is structural.
+
+**Single-user mode:** "public" = shipped system agents; the sole user owns/creates private ones; performance is the user's.
+
+**RBAC** (mirrors the Prompt Store): public agent CRUD → platform owner/admin (`OwnerAccess`); private agent CRUD → tenant owner/admin; members read. Performance/action read → tenant members (own tenant only); platform admin **cannot** read any tenant's performance.
+
+## Provider credential & auth model
+
+- **BYOK per tenant**: a tenant configures their own API key per provider, stored encrypted in the Epic 29 secret cabinet. BYOK usage hits the tenant's own provider account.
+- **Platform-provided otherwise**: usage-metered and billed by us (Epic 34/35). Resolution order per tenant: **BYOK key (cabinet) → else platform-provided**.
+- **SaaS = API-key auth only.** The managed-LLM-agent layer (`ILLMProvider`) is the sole execution path in SaaS. **Token-based / CLI agent providers (`ICLIAgentProvider`) are NOT available in SaaS** — they remain single-user/self-hosted only.
+- Agent definitions are **credential-agnostic** (provider + model + prompt + settings, never raw keys); credentials resolve at execution from the principal's secret source. So a public agent run by a tenant executes with *that tenant's* key/budget → cost & performance are genuinely the tenant's.
+
+## Managed-LLM-agent layer (above the LLM API, distinct from CLI)
+
+`IManagedAgent` composed over `ILLMProvider`, adding: context assembly (RAG) → prompt rendering (agent config + Prompt Store) → tool loop (`executeToolLoop`) → sanitization (`SecureAgentProvider`) → instrumentation (cost/diagnostics) → outcome capture. The resolver returns an `IManagedAgent` whether backed by an LLM-API provider (this layer) or a CLI provider, so workflows treat them identically. SaaS exposes only the LLM-API path.
+
+## Multi-agent design/review steps (C# Elsa + Epic 9 unified API)
+
+- **`RunAgentPanelActivity`** fans a step out to N agents of the relevant role(s); **`AggregatePanelActivity`** combines results. Strategies: `single`, `consensus/vote`, `lead+critics`, `llm-judge-merge`. Defaults: `lead+critics` (design), `consensus` (review).
+- **Design step**: architect agents propose → aggregate to a chosen/synthesized design. **Review step**: reviewer agents incl. specialized **security / performance / visual** reviewers → aggregate to verdict + classified findings.
+- Workflow tracks `iteration_count` and loops until gates pass or max iterations; every iteration emits events.
+
+## Tracking: actions + performance + learning
+
+- **Action trail** (DCB events tagged `agent_id`, config version, role, provider, model, prompt key/version, issueId, iteration) in the **tenant** event store. Event families: `AGENT.TASK.SUCCEEDED/FAILED/PARTIAL`, `AGENT.ITERATION.COMPLETED`, `REVIEW.BUG.RECORDED` (`bugType: visual|functional|regression|security|perf|style`), `AGENT.PANEL.AGGREGATED`, plus usage/cost emission (tokens + provider/model cost basis) consumed by Epics 34/35/36.
+- **Performance projections**: per-tenant leaderboards — success rate, avg iterations-to-done, bug counts by type, cost, latency — sliceable by agent / provider / prompt / version.
+- **Learning**: persist `LearningCapture`/`KnowledgeEntry`; auto-generate learnings from outcomes; feed into the KB so RAG retrieves them in future runs.
+- **Phase 2**: A/B experiment framework — cohorts, config-variant assignment, statistical significance, auto rollout/rollback on regression.
+
+## Story breakdown (Epic 32, 14 stories)
+
+1. `32-1` Agent entity model & versioned saved config (public/private)
+2. `32-2` Agent registry, resolution & RBAC API
+3. `32-3` Per-tenant provider credential resolution (BYOK → platform) — **canonical owner of cabinet key wiring**
+4. `32-4` SaaS provider auth gating — API-key only (CLI/token providers single-user only)
+5. `32-5` Managed agent execution layer (`IManagedAgent` over `ILLMProvider`)
+6. `32-6` Agent action trail (DCB events tagged `agent_id`) in tenant store
+7. `32-7` Multi-agent design/review panels in Elsa (strategy-driven)
+8. `32-8` Outcome capture & bug taxonomy at review/gate
+9. `32-9` Agent usage & cost emission (producer; consumed by Epics 34/35/36 — **markup engine is 34-5, not here**)
+10. `32-10` Benchmark projections & leaderboards (per agent/provider/prompt, per-tenant)
+11. `32-11` Learning persistence & auto-learning into RAG
+12. `32-12` Agent personas & persona-aware benchmarking
+13. `32-13` Agent management & benchmark dashboards (admin public + tenant private)
+14. `32-14` A/B experiment framework (Phase 2: cohorts, significance, rollout/rollback)
+
+## Non-goals
+- Pricing/markup engine (Epic 34), invoicing/payment (Epic 35), business analytics (Epic 36), audit product features (Epic 37) — Epic 32 *produces* the data these consume.
+- New provider implementations (Epic 1-10).
+- Implementing the Epic 9 unified API itself (dependency).
+
+## Risks
+- **Global provider keys today**: cost isn't truly per-tenant until BYOK/platform per-tenant keys land (32-3 + Epic 29 wiring). Tracking works regardless; cost attribution is the gap.
+- **Panel cost**: multi-agent panels multiply token spend — budget clamps + max-iteration caps required.
+- **Cross-tenant leakage**: performance/action data must never escape the tenant schema — enforce via the per-tenant connection/role; covered by isolation tests.


### PR DESCRIPTION
## What
Adds **5 new epics / 59 stories** for a complete **pricing · analytics · billing · auditing** system plus first-class **agent entities**, each authored as an implementation-plan-grade story file (`docs/stories/epic-N/story-N-M/`) with a separate detailed plan (`docs/superpowers/plans/2026-06-17-*`). All target the **current C# `apps/tamma-elsa` architecture** (not the deleted TS `packages/api`).

| Epic | Title | Stories |
|---|---|---|
| **32** | Agents — entities, managed execution, benchmarking & learning | 14 |
| **34** | Pricing, Plans & Entitlements | 10 |
| **35** | Billing & Payments (C#) — Stripe, BYOK-aware metering, invoicing, dunning — **supersedes Epic 20** | 12 |
| **36** | Analytics & Reporting Platform | 11 |
| **37** | Audit, Compliance & Data Governance | 12 |

## Key design decisions (from brainstorming with the user)
- **Agent = first-class entity** (immutable id + versioned saved config). **Definitions** are public (system, platform-admin-owned) or private (tenant-owned); **performance/action data is ALWAYS tenant-scoped** (one definition → many per-tenant datasets; platform admin can't see tenant perf).
- **BYOK per tenant** (key in the Epic 29 secret cabinet) vs **platform-provided** (priced by us). **SaaS = API-key providers only**; CLI/token agents stay single-user/self-hosted.
- **Managed-LLM-agent layer** over `ILLMProvider` (context/RAG → prompt → tool loop → sanitize → instrument → outcome), distinct from CLI providers.

## Cross-epic ownership boundaries (adversarially verified)
Each responsibility owned once: **32-3** BYOK key resolution · **32-4** SaaS gating · **34-3** pricing-mode selection · **34-5** cost→price markup engine (32-9 produces usage; 35/36 consume). The verification pass caught and **fixed** two violations where 34-3/35-2 had re-implemented 32-3's key resolution and a parallel mode store.

## Also
- Epic 20's 5 stories marked **superseded** (mapped to their Epic 34/35 replacements).
- `docs/sprint-status.yaml` (+59 drafted) and `docs/stories/README.md` updated.
- Epic 32 design of record: `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`.

## Notes
- Docs-only — does not trigger a VPS deploy (per the qa-tag gate).
- **Stacked on #349** (the sprint-status audit) — merge #349 first, or rebase this after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)