### PR TITLE
feat(exec): Wave 1 — Epics 32/34/35/36/37 foundation (5 P0 stories)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Auth/Permissions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Auth/Permissions.cs
@@ -49,6 +49,17 @@ public static class Permissions
         // with admin+owner reach keeps the picker accessible to
         // tenant admins per the Epic 31 RBAC plan.
         ["platforms:manage"] = ["admin", "owner"],
+        // Story 32-1 — first-class agent entity management. Mirrors
+        // prompts:manage / conventions:manage: CLAUDE.md "Prompt Store
+        // Architecture / RBAC" (agents follow the same tenant-scoped RBAC)
+        // requires create/publish/archive of a PRIVATE agent to be reachable
+        // by tenant_owner OR tenant_admin (member → 403). Public-agent writes
+        // are additionally gated by the platform-admin claim in the handler.
+        // The owner-only settings:manage would 403 every tenant_admin, so the
+        // dedicated agents:manage permission grants admin+owner reach.
+        // Single-user mode is unaffected — every signed-up user is auto-owner
+        // of their personal tenant.
+        ["agents:manage"] = ["admin", "owner"],
     };
 
     public static bool HasPermission(string? role, string? permission)

--- a/apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/AgentDtos.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/AgentDtos.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace Tamma.Api.Dtos.Agents;
 
 public record UpdateAgentConfigRequest(object Config);
@@ -34,3 +36,81 @@ public record ResolveForPhaseRequest(
 
 public record AgentConfigResponse(object Config, string Source, int Version);
 public record ResolvedAgentResponse(string Provider, string Model, object Config);
+
+// ── Story 32-1 — first-class agent entity DTOs ──
+// Distinct from the legacy agent_configs DTOs above; the new /api/v1/agents
+// surface manages identity-bearing, versioned agent definitions.
+
+/// <summary>
+/// Create-agent request. <c>Visibility</c> is <c>"public"</c> or
+/// <c>"private"</c>; the owner columns are derived server-side from the process
+/// mode (SaaS → tenant; single-user → user). <c>Config</c> is the saved-config
+/// snapshot validated before any write.
+/// </summary>
+public sealed record CreateAgentRequest(
+    string Name,
+    string Role,
+    string Visibility,
+    JsonElement Config,
+    string? Notes);
+
+/// <summary>Publish a new immutable version of an existing agent.</summary>
+public sealed record PublishVersionRequest(
+    JsonElement Config,
+    string? Notes);
+
+/// <summary>List/summary projection of an <c>Agent</c>.</summary>
+public sealed record AgentSummary(
+    Guid Id,
+    string Name,
+    string Role,
+    string Visibility,
+    string Status,
+    Guid? OwnerTenantId,
+    Guid? OwnerUserId,
+    Guid? CurrentVersionId);
+
+/// <summary>Full agent detail (summary + version list).</summary>
+public sealed record AgentDetail(
+    Guid Id,
+    string Name,
+    string Role,
+    string Visibility,
+    string Status,
+    Guid? OwnerTenantId,
+    Guid? OwnerUserId,
+    Guid? CurrentVersionId,
+    DateTime CreatedAt,
+    DateTime UpdatedAt,
+    IReadOnlyList<AgentVersionSummary> Versions);
+
+/// <summary>Lightweight version row (no config body).</summary>
+public sealed record AgentVersionSummary(
+    Guid Id,
+    int Version,
+    string? Notes,
+    DateTime CreatedAt);
+
+/// <summary>Full version detail including the config snapshot.</summary>
+public sealed record AgentVersionDetail(
+    Guid Id,
+    Guid AgentId,
+    int Version,
+    JsonElement Config,
+    string? Notes,
+    DateTime CreatedAt);
+
+/// <summary>201 response for create.</summary>
+public sealed record CreateAgentResponse(
+    Guid Id,
+    string Name,
+    string Role,
+    string Visibility,
+    string Status,
+    int CurrentVersion);
+
+/// <summary>200 response for publish-version.</summary>
+public sealed record PublishVersionResponse(
+    Guid Id,
+    int Version,
+    DateTime CreatedAt);

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminTenantsEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminTenantsEndpoints.cs
@@ -131,8 +131,12 @@ public static class AdminTenantsEndpoints
 
         if (!string.IsNullOrWhiteSpace(plan))
         {
+            // Story 34-1: a slug is now a multi-version chain (active +
+            // deprecated). Pin Status == "active" so the slug→Id resolution
+            // is deterministic (UX_plans_OneActivePerSlug guarantees one
+            // active row) and tenant filtering keys off the live version's Id.
             var planId = await db.Plans
-                .Where(p => p.Slug == plan)
+                .Where(p => p.Slug == plan && p.Status == "active")
                 .Select(p => (Guid?)p.Id)
                 .FirstOrDefaultAsync(ct);
             if (planId is null)

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/PlanCatalogEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/PlanCatalogEndpoints.cs
@@ -1,0 +1,53 @@
+using Tamma.Api.Services.Pricing;
+
+namespace Tamma.Api.Endpoints.Admin;
+
+/// <summary>
+/// Story 34-1 — read-only plan price-book endpoints under
+/// <c>/api/admin/plans*</c>. Every endpoint here MUST be gated behind the
+/// <c>OwnerAccess</c> policy at the wiring site: the catalog is platform-owned
+/// in both single-user and SaaS modes (no per-tenant override layer), and in
+/// SaaS only platform owners administer it.
+///
+/// <para>Write (create/deprecate version) endpoints are explicitly deferred to
+/// Story 34-2 — this story ships only the three reads plus the tested
+/// <see cref="PlanVersionEditor"/> service + its DCB events.</para>
+/// </summary>
+public static class PlanCatalogEndpoints
+{
+    /// <summary>GET /api/admin/plans — list all active plan snapshots.</summary>
+    public static async Task<IResult> ListActive(
+        IPlanCatalogService catalog,
+        CancellationToken ct)
+    {
+        var plans = await catalog.ListActiveAsync(ct);
+        return Results.Ok(new { plans });
+    }
+
+    /// <summary>GET /api/admin/plans/{slug} — the active version for a slug.</summary>
+    public static async Task<IResult> GetActiveBySlug(
+        string slug,
+        IPlanCatalogService catalog,
+        CancellationToken ct)
+    {
+        var snapshot = await catalog.GetActiveBySlugAsync(slug, ct);
+        return snapshot is null
+            ? Results.NotFound(new { error = "plan_not_found", slug })
+            : Results.Ok(snapshot);
+    }
+
+    /// <summary>
+    /// GET /api/admin/plans/{slug}/versions — the active + deprecated version
+    /// chain for a slug (descending by version). Unknown slug → 404.
+    /// </summary>
+    public static async Task<IResult> GetVersions(
+        string slug,
+        IPlanCatalogService catalog,
+        CancellationToken ct)
+    {
+        var versions = await catalog.GetVersionsBySlugAsync(slug, ct);
+        return versions.Count == 0
+            ? Results.NotFound(new { error = "plan_not_found", slug })
+            : Results.Ok(new { slug, versions });
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/PlanCatalogEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/PlanCatalogEndpoints.cs
@@ -5,9 +5,11 @@ namespace Tamma.Api.Endpoints.Admin;
 /// <summary>
 /// Story 34-1 — read-only plan price-book endpoints under
 /// <c>/api/admin/plans*</c>. Every endpoint here MUST be gated behind the
-/// <c>OwnerAccess</c> policy at the wiring site: the catalog is platform-owned
-/// in both single-user and SaaS modes (no per-tenant override layer), and in
-/// SaaS only platform owners administer it.
+/// <c>PlatformOwnerAccess</c> policy at the wiring site: the catalog is
+/// platform-GLOBAL (incl. BYOK-vs-platform pricing) in both single-user and
+/// SaaS modes (no per-tenant override layer), so it is platform-scoped admin
+/// work. <c>OwnerAccess</c> would let every personal-tenant owner read the
+/// whole platform price book (Finding C1) — only platform admins may.
 ///
 /// <para>Write (create/deprecate version) endpoints are explicitly deferred to
 /// Story 34-2 — this story ships only the three reads plus the tested

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs
@@ -1,10 +1,10 @@
 using System.Security.Claims;
 using Tamma.Api.Auth;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using Tamma.Api.Dtos.Agents;
 using Tamma.Api.Services.Agents;
-using Tamma.Api.Services.Security;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Core;
 using Tamma.Data;
 using Tamma.Data.Repositories;
 using Tamma.Data.Entities;
@@ -194,255 +194,387 @@ public static class AgentEndpoints
     }
 
     // -----------------------------------------------------------------------
+    // Story 32-1 — first-class agent entity CRUD (/api/v1/agents)
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// POST <c>/api/v1/agents</c> — create a first-class agent + its Version=1
+    /// snapshot. <c>visibility</c> drives the gate: <c>public</c> requires the
+    /// platform-admin claim (else 403); <c>private</c> derives the owner from
+    /// the process mode (SaaS → tenant; single-user → user). Member-role
+    /// callers are rejected by the <c>AgentManage</c> policy before reaching
+    /// here; the public-write gate is enforced in-handler.
+    /// </summary>
+    public static async Task<IResult> CreateAgent(
+        CreateAgentRequest req,
+        IAgentRepository agents,
+        ClaimsPrincipal principal,
+        ITenantContext tenantContext,
+        ITammaModeProvider modeProvider)
+    {
+        if (string.IsNullOrWhiteSpace(req.Name))
+        {
+            return Results.BadRequest(new { error = "invalid_request", detail = "name is required." });
+        }
+
+        // Role must be a taxonomy-valid wire string (normalize legacy aliases).
+        string canonicalRole;
+        try
+        {
+            canonicalRole = AgentRoleExtensions.Parse(req.Role).ToWire();
+        }
+        catch (ArgumentException ex)
+        {
+            return Results.BadRequest(new { error = "invalid_role", detail = ex.Message });
+        }
+
+        if (!TryParseVisibility(req.Visibility, out var visibility))
+        {
+            return Results.BadRequest(new
+            {
+                error = "invalid_visibility",
+                detail = "visibility must be 'public' or 'private'.",
+            });
+        }
+
+        var configJson = req.Config.ValueKind == JsonValueKind.Undefined
+            ? "{}"
+            : req.Config.GetRawText();
+        var (valid, errors) = AgentConfigValidator.Validate(configJson);
+        if (!valid)
+        {
+            return Results.BadRequest(new { valid = false, errors });
+        }
+
+        var agent = new Agent
+        {
+            Name = req.Name,
+            Role = canonicalRole,
+            Visibility = visibility,
+        };
+
+        if (visibility == AgentVisibility.Public)
+        {
+            // Public agents are platform-owned. Defence-in-depth: the route is
+            // gated, but a private-owner could otherwise sneak a public create
+            // through the AgentManage policy. Require platform-admin here.
+            if (!IsPlatformAdmin(principal))
+            {
+                return Results.Json(
+                    new { error = "forbidden", detail = "public agents require platform admin." },
+                    statusCode: StatusCodes.Status403Forbidden);
+            }
+        }
+        else
+        {
+            // Private — derive the owner from the process mode (CLAUDE.md
+            // "Universal rule"). SaaS → tenant; single-user → user.
+            if (modeProvider.Mode == TammaMode.SaaS)
+            {
+                if (tenantContext.TenantId is not Guid tid)
+                {
+                    return Results.BadRequest(new
+                    {
+                        error = "no_tenant_context",
+                        detail = "a private agent in SaaS mode requires tenant context.",
+                    });
+                }
+                agent.OwnerTenantId = tid;
+            }
+            else
+            {
+                if (principal.GetUserId() is not Guid uid)
+                {
+                    return Results.BadRequest(new
+                    {
+                        error = "no_user_context",
+                        detail = "a private agent in single-user mode requires a user id.",
+                    });
+                }
+                agent.OwnerUserId = uid;
+            }
+        }
+
+        try
+        {
+            var created = await agents.CreateAsync(
+                agent, configJson, req.Notes, principal.GetUserId());
+
+            return Results.Created($"/api/v1/agents/{created.Id}", new CreateAgentResponse(
+                created.Id, created.Name, created.Role,
+                VisibilityWire(created.Visibility), StatusWire(created.Status),
+                CurrentVersion: 1));
+        }
+        catch (TammaError ex)
+        {
+            return Results.BadRequest(new { error = ex.Code, detail = ex.Message });
+        }
+        catch (Microsoft.EntityFrameworkCore.DbUpdateException ex) when (IsUniqueViolation(ex))
+        {
+            return Results.Conflict(new
+            {
+                error = "agent_name_conflict",
+                detail = "an agent with this name/role already exists for this scope.",
+            });
+        }
+    }
+
+    /// <summary>
+    /// POST <c>/api/v1/agents/{id}/versions</c> — publish a new immutable
+    /// version. RBAC matches the agent's ownership (public → platform admin;
+    /// private → owning tenant/user).
+    /// </summary>
+    public static async Task<IResult> PublishVersion(
+        Guid id,
+        PublishVersionRequest req,
+        IAgentRepository agents,
+        ClaimsPrincipal principal,
+        ITenantContext tenantContext,
+        ITammaModeProvider modeProvider)
+    {
+        var agent = await agents.GetByIdAsync(id);
+        if (agent is null || !CanSeeAgent(agent, principal, tenantContext, modeProvider))
+        {
+            // 404 (not 403) for an agent the caller cannot see — avoid leaking existence.
+            return Results.NotFound();
+        }
+        if (!CanWriteAgent(agent, principal, tenantContext, modeProvider))
+        {
+            return Results.Json(
+                new { error = "forbidden", detail = "not permitted to publish for this agent." },
+                statusCode: StatusCodes.Status403Forbidden);
+        }
+
+        var configJson = req.Config.ValueKind == JsonValueKind.Undefined
+            ? "{}"
+            : req.Config.GetRawText();
+        var (valid, errors) = AgentConfigValidator.Validate(configJson);
+        if (!valid)
+        {
+            return Results.BadRequest(new { valid = false, errors });
+        }
+
+        try
+        {
+            var version = await agents.PublishVersionAsync(
+                id, configJson, req.Notes, principal.GetUserId());
+            if (version is null)
+            {
+                return Results.NotFound();
+            }
+            return Results.Ok(new PublishVersionResponse(
+                version.Id, version.Version, version.CreatedAt));
+        }
+        catch (TammaError ex)
+        {
+            return Results.BadRequest(new { error = ex.Code, detail = ex.Message });
+        }
+    }
+
+    /// <summary>POST <c>/api/v1/agents/{id}/archive</c>.</summary>
+    public static async Task<IResult> ArchiveAgent(
+        Guid id,
+        IAgentRepository agents,
+        ClaimsPrincipal principal,
+        ITenantContext tenantContext,
+        ITammaModeProvider modeProvider)
+    {
+        var agent = await agents.GetByIdAsync(id);
+        if (agent is null || !CanSeeAgent(agent, principal, tenantContext, modeProvider))
+        {
+            return Results.NotFound();
+        }
+        if (!CanWriteAgent(agent, principal, tenantContext, modeProvider))
+        {
+            return Results.Json(
+                new { error = "forbidden", detail = "not permitted to archive this agent." },
+                statusCode: StatusCodes.Status403Forbidden);
+        }
+
+        var archived = await agents.ArchiveAsync(id, principal.GetUserId());
+        return archived is null
+            ? Results.NotFound()
+            : Results.Ok(new { id = archived.Id, status = StatusWire(archived.Status) });
+    }
+
+    /// <summary>
+    /// GET <c>/api/v1/agents</c> — list visible agents (all public ∪ the
+    /// caller's own private). Cross-tenant private agents are never returned.
+    /// </summary>
+    public static async Task<IResult> ListAgents(
+        IAgentRepository agents,
+        ClaimsPrincipal principal,
+        ITenantContext tenantContext,
+        ITammaModeProvider modeProvider)
+    {
+        var (tenantId, userId) = ResolvePrincipalScope(principal, tenantContext, modeProvider);
+        var visible = await agents.ListVisibleAsync(tenantId, userId);
+        var summaries = visible.Select(ToSummary).ToList();
+        return Results.Ok(summaries);
+    }
+
+    /// <summary>
+    /// GET <c>/api/v1/agents/{id}</c> — a private agent not owned by the caller
+    /// returns 404 (not 403, to avoid leaking existence).
+    /// </summary>
+    public static async Task<IResult> GetAgent(
+        Guid id,
+        IAgentRepository agents,
+        ClaimsPrincipal principal,
+        ITenantContext tenantContext,
+        ITammaModeProvider modeProvider)
+    {
+        var agent = await agents.GetByIdAsync(id);
+        if (agent is null || !CanSeeAgent(agent, principal, tenantContext, modeProvider))
+        {
+            return Results.NotFound();
+        }
+
+        var versions = await agents.ListVersionsAsync(id);
+        return Results.Ok(new AgentDetail(
+            agent.Id, agent.Name, agent.Role,
+            VisibilityWire(agent.Visibility), StatusWire(agent.Status),
+            agent.OwnerTenantId, agent.OwnerUserId, agent.CurrentVersionId,
+            agent.CreatedAt, agent.UpdatedAt,
+            versions.Select(v => new AgentVersionSummary(v.Id, v.Version, v.Notes, v.CreatedAt)).ToList()));
+    }
+
+    /// <summary>GET <c>/api/v1/agents/{id}/versions</c>.</summary>
+    public static async Task<IResult> ListVersions(
+        Guid id,
+        IAgentRepository agents,
+        ClaimsPrincipal principal,
+        ITenantContext tenantContext,
+        ITammaModeProvider modeProvider)
+    {
+        var agent = await agents.GetByIdAsync(id);
+        if (agent is null || !CanSeeAgent(agent, principal, tenantContext, modeProvider))
+        {
+            return Results.NotFound();
+        }
+        var versions = await agents.ListVersionsAsync(id);
+        return Results.Ok(versions
+            .Select(v => new AgentVersionSummary(v.Id, v.Version, v.Notes, v.CreatedAt))
+            .ToList());
+    }
+
+    /// <summary>GET <c>/api/v1/agents/{id}/versions/{version}</c>.</summary>
+    public static async Task<IResult> GetVersion(
+        Guid id,
+        int version,
+        IAgentRepository agents,
+        ClaimsPrincipal principal,
+        ITenantContext tenantContext,
+        ITammaModeProvider modeProvider)
+    {
+        var agent = await agents.GetByIdAsync(id);
+        if (agent is null || !CanSeeAgent(agent, principal, tenantContext, modeProvider))
+        {
+            return Results.NotFound();
+        }
+        var ver = await agents.GetVersionAsync(id, version);
+        if (ver is null)
+        {
+            return Results.NotFound();
+        }
+
+        using var doc = JsonDocument.Parse(ver.ConfigJson);
+        return Results.Ok(new AgentVersionDetail(
+            ver.Id, ver.AgentId, ver.Version, doc.RootElement.Clone(),
+            ver.Notes, ver.CreatedAt));
+    }
+
+    // -----------------------------------------------------------------------
+    // Story 32-1 — visibility / RBAC helpers
+    // -----------------------------------------------------------------------
+
+    private static AgentSummary ToSummary(Agent a) => new(
+        a.Id, a.Name, a.Role, VisibilityWire(a.Visibility), StatusWire(a.Status),
+        a.OwnerTenantId, a.OwnerUserId, a.CurrentVersionId);
+
+    private static string VisibilityWire(AgentVisibility v)
+        => v == AgentVisibility.Public ? "public" : "private";
+
+    private static string StatusWire(AgentStatus s)
+        => s == AgentStatus.Archived ? "archived" : "active";
+
+    private static bool TryParseVisibility(string? raw, out AgentVisibility visibility)
+    {
+        switch (raw?.Trim().ToLowerInvariant())
+        {
+            case "public": visibility = AgentVisibility.Public; return true;
+            case "private": visibility = AgentVisibility.Private; return true;
+            default: visibility = default; return false;
+        }
+    }
+
+    private static bool IsPlatformAdmin(ClaimsPrincipal principal)
+        => string.Equals(
+            principal.FindFirst("platformRole")?.Value, "platform_admin", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Resolve the caller's private-agent principal scope from the process
+    /// mode. SaaS → (tenantId, null); single-user → (null, userId).
+    /// </summary>
+    private static (Guid? TenantId, Guid? UserId) ResolvePrincipalScope(
+        ClaimsPrincipal principal, ITenantContext tenantContext, ITammaModeProvider modeProvider)
+        => modeProvider.Mode == TammaMode.SaaS
+            ? (tenantContext.TenantId, (Guid?)null)
+            : ((Guid?)null, principal.GetUserId());
+
+    /// <summary>
+    /// Visibility check for reads: any public agent, or a private agent owned
+    /// by the caller's scope. Mirrors <c>IAgentRepository.ListVisibleAsync</c>.
+    /// </summary>
+    private static bool CanSeeAgent(
+        Agent agent, ClaimsPrincipal principal,
+        ITenantContext tenantContext, ITammaModeProvider modeProvider)
+    {
+        if (agent.Visibility == AgentVisibility.Public)
+        {
+            return true;
+        }
+        var (tenantId, userId) = ResolvePrincipalScope(principal, tenantContext, modeProvider);
+        return (tenantId is not null && agent.OwnerTenantId == tenantId) ||
+               (userId is not null && agent.OwnerUserId == userId);
+    }
+
+    /// <summary>
+    /// Write check: public agents require platform admin; private agents
+    /// require the caller to own the agent in the current scope. (Member-role
+    /// callers are already 403'd by the AgentManage route policy.)
+    /// </summary>
+    private static bool CanWriteAgent(
+        Agent agent, ClaimsPrincipal principal,
+        ITenantContext tenantContext, ITammaModeProvider modeProvider)
+    {
+        if (agent.Visibility == AgentVisibility.Public)
+        {
+            return IsPlatformAdmin(principal);
+        }
+        var (tenantId, userId) = ResolvePrincipalScope(principal, tenantContext, modeProvider);
+        return (tenantId is not null && agent.OwnerTenantId == tenantId) ||
+               (userId is not null && agent.OwnerUserId == userId);
+    }
+
+    private static bool IsUniqueViolation(Microsoft.EntityFrameworkCore.DbUpdateException ex)
+        => ex.InnerException is Npgsql.PostgresException pg &&
+           pg.SqlState == Npgsql.PostgresErrorCodes.UniqueViolation;
+
+    // -----------------------------------------------------------------------
     // Private helpers
     // -----------------------------------------------------------------------
 
     /// <summary>
-    /// Provider name regex from Story 9-1 AC 6 / TS validateAgentsConfig:
-    /// <c>^[a-z0-9][a-z0-9_-]{0,63}$</c>.
-    /// </summary>
-    private static readonly Regex ProviderNameRegex =
-        new("^[a-z0-9][a-z0-9_-]{0,63}$",
-            RegexOptions.Compiled | RegexOptions.CultureInvariant);
-
-    /// <summary>
     /// Schema- AND semantic-level validation. Returns (valid, errors).
     /// Tolerant of empty configs (valid — fall through to platform defaults).
-    /// Finding 014: enforces provider regex, budget range [0,100], ReDoS
-    /// guard on blockedCommandPatterns, maxFetchSizeBytes range [0, 1 GiB],
-    /// and prototype-pollution rejection on every key.
+    ///
+    /// <para>Story 32-1 — the rules were extracted into the shared
+    /// <see cref="AgentConfigValidator"/> so the legacy <c>config</c> surface
+    /// and the new Epic 32 agent-version surface validate identically (Finding
+    /// 014 provider regex / budget range / ReDoS / prototype-pollution guards
+    /// apply to both). This thin shim preserves the existing call sites.</para>
     /// </summary>
     private static (bool Valid, string[] Errors) ValidateConfigShape(string configJson)
-    {
-        var errors = new List<string>();
-
-        JsonDocument doc;
-        try
-        {
-            doc = JsonDocument.Parse(configJson);
-        }
-        catch (JsonException ex)
-        {
-            return (false, new[] { $"Invalid JSON: {ex.Message}" });
-        }
-
-        using (doc)
-        {
-            var root = doc.RootElement;
-            if (root.ValueKind != JsonValueKind.Object)
-            {
-                errors.Add("Root must be a JSON object.");
-                return (false, errors.ToArray());
-            }
-
-            // ── Roles ────────────────────────────────────────────────────────
-            if (root.TryGetProperty("roles", out var roles))
-            {
-                if (roles.ValueKind != JsonValueKind.Object)
-                {
-                    errors.Add("'roles' must be an object.");
-                    return (false, errors.ToArray());
-                }
-
-                foreach (var prop in roles.EnumerateObject())
-                {
-                    if (RolePhaseMap.ForbiddenKeys.Contains(prop.Name))
-                    {
-                        errors.Add($"Forbidden role key: '{prop.Name}'.");
-                        continue;
-                    }
-                    var roleKnown = RolePhaseMap.ValidRoles.Contains(prop.Name) ||
-                                    RolePhaseMap.LegacyRoleAliases.ContainsKey(prop.Name);
-                    if (!roleKnown)
-                    {
-                        errors.Add(
-                            $"Unknown role '{prop.Name}'. Valid: " +
-                            string.Join(", ", RolePhaseMap.ValidRoles) + ".");
-                        continue;
-                    }
-                    if (prop.Value.ValueKind != JsonValueKind.Object) continue;
-
-                    ValidateRoleSemantics(prop.Name, prop.Value, errors);
-                }
-            }
-
-            // ── defaults.providerChain (legacy TS shape) ────────────────────
-            if (root.TryGetProperty("defaults", out var defaults) &&
-                defaults.ValueKind == JsonValueKind.Object &&
-                defaults.TryGetProperty("providerChain", out var defChain))
-            {
-                ValidateProviderChain("defaults.providerChain", defChain, errors);
-            }
-
-            // ── chains (canonical 2D shape) ─────────────────────────────────
-            if (root.TryGetProperty("chains", out var chains) &&
-                chains.ValueKind == JsonValueKind.Object)
-            {
-                foreach (var prop in chains.EnumerateObject())
-                {
-                    if (RolePhaseMap.ForbiddenKeys.Contains(prop.Name))
-                    {
-                        errors.Add($"Forbidden chain key: '{prop.Name}'.");
-                        continue;
-                    }
-                    if (prop.Value.ValueKind == JsonValueKind.Array)
-                    {
-                        ValidateProviderChain($"chains.{prop.Name}", prop.Value, errors);
-                    }
-                    else if (prop.Value.ValueKind == JsonValueKind.Object)
-                    {
-                        foreach (var actionProp in prop.Value.EnumerateObject())
-                        {
-                            if (actionProp.Value.ValueKind != JsonValueKind.Array) continue;
-                            ValidateProviderChain(
-                                $"chains.{prop.Name}.{actionProp.Name}",
-                                actionProp.Value, errors);
-                        }
-                    }
-                }
-            }
-
-            // ── security branch (blockedCommandPatterns + maxFetchSizeBytes) ─
-            if (root.TryGetProperty("security", out var security) &&
-                security.ValueKind == JsonValueKind.Object)
-            {
-                ValidateSecurity(security, errors);
-            }
-        }
-
-        return (errors.Count == 0, errors.ToArray());
-    }
-
-    private static void ValidateRoleSemantics(string role, JsonElement obj, List<string> errors)
-    {
-        // provider name regex
-        if (obj.TryGetProperty("provider", out var prov) &&
-            prov.ValueKind == JsonValueKind.String)
-        {
-            var name = prov.GetString() ?? string.Empty;
-            if (!ProviderNameRegex.IsMatch(name))
-            {
-                errors.Add(
-                    $"roles.{role}.provider '{name}' must match /^[a-z0-9][a-z0-9_-]{{0,63}}$/.");
-            }
-        }
-
-        // maxBudgetUsd range [0, 100], finite
-        if (obj.TryGetProperty("maxBudgetUsd", out var budget) &&
-            budget.ValueKind == JsonValueKind.Number)
-        {
-            if (!budget.TryGetDouble(out var budgetVal) || double.IsNaN(budgetVal) ||
-                double.IsInfinity(budgetVal))
-            {
-                errors.Add($"roles.{role}.maxBudgetUsd must be a finite number.");
-            }
-            else if (budgetVal < 0 || budgetVal > 100)
-            {
-                errors.Add($"roles.{role}.maxBudgetUsd must be in [0, 100] (got {budgetVal}).");
-            }
-        }
-
-        // permissionMode whitelist
-        if (obj.TryGetProperty("permissionMode", out var mode) &&
-            mode.ValueKind == JsonValueKind.String)
-        {
-            var modeVal = mode.GetString();
-            if (modeVal is not ("default" or "acceptEdits" or "bypassPermissions"))
-            {
-                errors.Add(
-                    $"roles.{role}.permissionMode must be one of " +
-                    "default | acceptEdits | bypassPermissions.");
-            }
-        }
-
-        // providerChain shape
-        if (obj.TryGetProperty("providerChain", out var chain) &&
-            chain.ValueKind == JsonValueKind.Array)
-        {
-            ValidateProviderChain($"roles.{role}.providerChain", chain, errors);
-        }
-    }
-
-    private static void ValidateProviderChain(string label, JsonElement arr, List<string> errors)
-    {
-        if (arr.GetArrayLength() == 0)
-        {
-            errors.Add($"{label}: chain must not be empty.");
-            return;
-        }
-        var i = 0;
-        foreach (var entry in arr.EnumerateArray())
-        {
-            if (entry.ValueKind != JsonValueKind.Object)
-            {
-                errors.Add($"{label}[{i}]: entry must be an object.");
-                i++;
-                continue;
-            }
-            if (!entry.TryGetProperty("provider", out var prov) ||
-                prov.ValueKind != JsonValueKind.String)
-            {
-                errors.Add($"{label}[{i}]: missing 'provider' string field.");
-                i++;
-                continue;
-            }
-            var name = prov.GetString() ?? string.Empty;
-            if (!ProviderNameRegex.IsMatch(name))
-            {
-                errors.Add(
-                    $"{label}[{i}].provider '{name}' must match " +
-                    "/^[a-z0-9][a-z0-9_-]{0,63}$/.");
-            }
-            i++;
-        }
-    }
-
-    private static void ValidateSecurity(JsonElement sec, List<string> errors)
-    {
-        if (sec.TryGetProperty("maxFetchSizeBytes", out var fetch))
-        {
-            if (fetch.ValueKind != JsonValueKind.Number ||
-                !fetch.TryGetInt64(out var bytes))
-            {
-                errors.Add("security.maxFetchSizeBytes must be a number.");
-            }
-            else if (bytes < 0 || bytes > 1L * 1024 * 1024 * 1024)
-            {
-                errors.Add(
-                    $"security.maxFetchSizeBytes must be in [0, 1 GiB] (got {bytes}).");
-            }
-        }
-
-        if (sec.TryGetProperty("blockedCommandPatterns", out var patterns) &&
-            patterns.ValueKind == JsonValueKind.Array)
-        {
-            if (patterns.GetArrayLength() > ReDosGuard.MaxPatternCount)
-            {
-                errors.Add(
-                    $"security.blockedCommandPatterns count {patterns.GetArrayLength()} " +
-                    $"exceeds max {ReDosGuard.MaxPatternCount}.");
-            }
-            var i = 0;
-            foreach (var entry in patterns.EnumerateArray())
-            {
-                if (entry.ValueKind != JsonValueKind.String)
-                {
-                    errors.Add($"security.blockedCommandPatterns[{i}]: must be a string.");
-                    i++;
-                    continue;
-                }
-                try
-                {
-                    ReDosGuard.Validate(
-                        $"security.blockedCommandPatterns[{i}]",
-                        entry.GetString() ?? string.Empty);
-                }
-                catch (ArgumentException ex)
-                {
-                    errors.Add(ex.Message);
-                }
-                i++;
-            }
-        }
-    }
+        => AgentConfigValidator.Validate(configJson);
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/AuthEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/AuthEndpoints.cs
@@ -217,7 +217,9 @@ public static class AuthEndpoints
         IPlatformBootstrapRepository bootstrapRepo,
         [FromServices] IEmailService emailService,
         [FromServices] IConfiguration config,
-        [FromServices] ILoggerFactory loggerFactory)
+        [FromServices] ILoggerFactory loggerFactory,
+        [FromServices] Tamma.Api.Services.Billing.IBillingProvider billing,
+        [FromServices] Tamma.Data.Repositories.IPlatformQueuedTaskRepository platformTasks)
     {
         if (string.IsNullOrWhiteSpace(req.Email) || string.IsNullOrWhiteSpace(req.Password))
             return Results.BadRequest(new { error = "Email and password are required" });
@@ -281,6 +283,13 @@ public static class AuthEndpoints
         });
         await membershipRepo.AddAsync(tenant.Id, user.Id, "owner");
         await userRepo.UpdateActiveTenantAsync(user.Id, tenant.Id);
+
+        // Story 35-1 (AC6) — non-blocking Stripe customer mapping on the
+        // registration tenant-create path (same hook as OrgEndpoints.CreateOrg).
+        // Single-user → no-op; SaaS Stripe failure → enqueue retry, never block
+        // registration.
+        await Tamma.Api.Services.Billing.BillingTenantCreateHook.RunAsync(
+            billing, platformTasks, loggerFactory, tenant, user.Email);
 
         var verifyUrl = BuildVerificationUrl(config, verificationToken);
         // Story 28-1 PR B — registration verification email is

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs
@@ -34,6 +34,9 @@ public static class OrgEndpoints
         IUserRepository userRepo,
         IEventRepository events,
         Tamma.Data.Abstractions.ITenantProvisioningService provisioning,
+        Tamma.Api.Services.Billing.IBillingProvider billing,
+        IPlatformQueuedTaskRepository platformTasks,
+        ILoggerFactory loggerFactory,
         ClaimsPrincipal principal)
     {
         var userId = ResolveUserId(principal);
@@ -83,6 +86,15 @@ public static class OrgEndpoints
             slug = tenant.Slug,
             name = tenant.Name,
         });
+
+        // Story 35-1 (AC6) — non-blocking Stripe customer mapping. SaaS only:
+        // NullBillingProvider.IsEnabled is false in single-user so this is a
+        // complete no-op (no row, no event, no Stripe call). On Stripe failure
+        // we DO NOT block tenant creation — a billing.customer.create retry task
+        // is enqueued and the BillingCustomer row persists (null id) on retry.
+        var owner = await userRepo.GetByIdAsync(userId.Value);
+        await Tamma.Api.Services.Billing.BillingTenantCreateHook.RunAsync(
+            billing, platformTasks, loggerFactory, tenant, owner?.Email);
 
         return Results.Created($"/api/v1/orgs/{tenant.Id}",
             BuildOrgResponse(tenant));

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs
@@ -87,11 +87,15 @@ public static class OrgEndpoints
             name = tenant.Name,
         });
 
-        // Story 35-1 (AC6) — non-blocking Stripe customer mapping. SaaS only:
-        // NullBillingProvider.IsEnabled is false in single-user so this is a
-        // complete no-op (no row, no event, no Stripe call). On Stripe failure
-        // we DO NOT block tenant creation — a billing.customer.create retry task
-        // is enqueued and the BillingCustomer row persists (null id) on retry.
+        // Story 35-1 (AC6) — non-blocking Stripe customer mapping. This runs
+        // AFTER the tenant-create commit and the TENANT.CREATED.SUCCESS event
+        // above, with NO enclosing transaction, so a billing failure can never
+        // roll the tenant back. SaaS only: NullBillingProvider.IsEnabled is false
+        // in single-user so this is a complete no-op (no row, no event, no Stripe
+        // call). Happy path persists a BillingCustomer row with a non-null
+        // StripeCustomerId. On Stripe failure we DO NOT block tenant creation — a
+        // billing.customer.create retry task is enqueued and the retry handler
+        // creates/fills the row on a later attempt.
         var owner = await userRepo.GetByIdAsync(userId.Value);
         await Tamma.Api.Services.Billing.BillingTenantCreateHook.RunAsync(
             billing, platformTasks, loggerFactory, tenant, owner?.Email);

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/AuditServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/AuditServiceCollectionExtensions.cs
@@ -1,0 +1,42 @@
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Tamma.Api.Services.Audit;
+using Tamma.Data.Audit;
+
+namespace Tamma.Api.Extensions;
+
+/// <summary>
+/// Story 37-1 — DI registration for the curated audit projection. Single
+/// entry-point so Program.cs wires it with one call (mirrors
+/// <c>AddTammaAlertRuleEngine</c>).
+/// </summary>
+public static class AuditServiceCollectionExtensions
+{
+    /// <summary>
+    /// Register the catalog-driven audit projector, its insert-if-absent
+    /// repository, the lag metric, and the background host. Idempotent.
+    /// </summary>
+    public static IServiceCollection AddTammaAuditProjection(
+        this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton(TimeProvider.System);
+
+        // Projector + repository are stateless — singletons.
+        services.TryAddSingleton<IAuditProjector, AuditProjector>();
+        services.TryAddSingleton<IAuditRecordRepository, AuditRecordRepository>();
+
+        // Options — tests post-configure; defaults are production-safe
+        // (RunOnStartup defaults FALSE so the loop is opt-in).
+        services.TryAddSingleton<AuditProjectorOptions>();
+
+        // Self-registering OTel meter (singleton).
+        services.TryAddSingleton<AuditProjectionMetrics>();
+
+        // Background host — spawns a per-tick DI scope for the scoped
+        // ControlPlaneDbContext / tenant factory dependencies.
+        services.AddHostedService<AuditProjectorBackgroundService>();
+
+        return services;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/BillingServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/BillingServiceCollectionExtensions.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Tamma.Api.Services.Billing;
+using Tamma.Api.Services.Billing.Tasks;
+using Tamma.Api.Services.PlatformTasks;
+using Tamma.Api.Services.PromptStore;
+
+namespace Tamma.Api.Extensions;
+
+/// <summary>
+/// Story 35-1 — mode-aware billing DI. Registers <see cref="IBillingProvider"/>
+/// as <see cref="StripeBillingProvider"/> in SaaS and
+/// <see cref="NullBillingProvider"/> in single-user, plus the catalog reader,
+/// Stripe client factory, options, and the customer-create retry handler.
+///
+/// <para>Mode is read once from <see cref="ITammaModeProvider"/> at composition
+/// time (process-stable), so the binding never varies per request. In
+/// single-user the Stripe-touching services are still registered but
+/// unreachable — the no-op provider short-circuits before any of them is used.</para>
+/// </summary>
+public static class BillingServiceCollectionExtensions
+{
+    public static IServiceCollection AddTammaBilling(
+        this IServiceCollection services, IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services.AddOptions<BillingOptions>()
+            .Configure(opts =>
+                configuration.GetSection(BillingOptions.SectionName).Bind(opts));
+
+        services.TryAddSingleton<TimeProvider>(TimeProvider.System);
+
+        // Catalog reader + Stripe client factory are mode-agnostic singletons
+        // (the catalog is platform-global; the factory caches the resolved key).
+        services.TryAddSingleton<IBillingCatalog, BillingCatalog>();
+        services.TryAddScoped<IStripeServicesFactory, StripeClientFactory>();
+
+        // Mode-gated provider selection. Resolve the mode from the registered
+        // ITammaModeProvider so detection stays in one place.
+        var mode = ResolveMode(services, configuration);
+        if (mode == TammaMode.SaaS)
+        {
+            services.AddScoped<IBillingProvider, StripeBillingProvider>();
+        }
+        else
+        {
+            services.AddScoped<IBillingProvider, NullBillingProvider>();
+        }
+
+        // Retry handler for the non-blocking tenant-create hook. Registered in
+        // both modes — in single-user it dead-letters cleanly (handler guards on
+        // IsEnabled) but the hook never enqueues a task there anyway.
+        services.AddPlatformTaskHandler<CreateBillingCustomerTaskHandler>();
+
+        return services;
+    }
+
+    private static TammaMode ResolveMode(
+        IServiceCollection services, IConfiguration configuration)
+    {
+        // Prefer an already-registered provider so a test/host override wins;
+        // fall back to the pure config-driven resolver otherwise.
+        var registered = services
+            .FirstOrDefault(d => d.ServiceType == typeof(ITammaModeProvider))?
+            .ImplementationInstance as ITammaModeProvider;
+        return registered?.Mode ?? TammaModeProvider.Resolve(configuration);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/BillingServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/BillingServiceCollectionExtensions.cs
@@ -32,9 +32,16 @@ public static class BillingServiceCollectionExtensions
         services.TryAddSingleton<TimeProvider>(TimeProvider.System);
 
         // Catalog reader + Stripe client factory are mode-agnostic singletons
-        // (the catalog is platform-global; the factory caches the resolved key).
+        // (the catalog is platform-global; the factory caches the resolved key
+        // ONCE per process). The factory MUST be a singleton so its in-process key
+        // cache and SemaphoreSlim gate live for the whole process — at a scoped
+        // lifetime the key would be re-resolved every request and the gate would
+        // be pointless. Lifetime-safe: the factory captures only the root
+        // IServiceProvider + singletons (BillingOptions, IHostEnvironment, logger)
+        // and lazily resolves the singleton IRuntimeSecretResolver — nothing scoped
+        // is captured.
         services.TryAddSingleton<IBillingCatalog, BillingCatalog>();
-        services.TryAddScoped<IStripeServicesFactory, StripeClientFactory>();
+        services.TryAddSingleton<IStripeServicesFactory, StripeClientFactory>();
 
         // Mode-gated provider selection. Resolve the mode from the registered
         // ITammaModeProvider so detection stays in one place.

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/PricingServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/PricingServiceCollectionExtensions.cs
@@ -6,9 +6,11 @@ namespace Tamma.Api.Extensions;
 /// <summary>
 /// Story 34-1 — DI registration for the plan price-book catalog. Single
 /// entry-point so <c>Program.cs</c> wires it with one call. Both services are
-/// scoped (they depend on the scoped <c>ControlPlaneDbContext</c>); the read
-/// service is registered behind its interface, the version editor as a
-/// concrete type (Story 34-2 resolves it directly from the admin endpoint).
+/// scoped (they depend on the scoped <c>ControlPlaneDbContext</c>) and are
+/// registered behind their interfaces — the read service as
+/// <see cref="IPlanCatalogService"/> and the version editor as
+/// <see cref="IPlanVersionEditor"/> (Story 34-2 resolves the latter from the
+/// admin write endpoint).
 /// </summary>
 public static class PricingServiceCollectionExtensions
 {
@@ -21,7 +23,7 @@ public static class PricingServiceCollectionExtensions
         services.TryAddSingleton(TimeProvider.System);
 
         services.TryAddScoped<IPlanCatalogService, PlanCatalogService>();
-        services.TryAddScoped<PlanVersionEditor>();
+        services.TryAddScoped<IPlanVersionEditor, PlanVersionEditor>();
 
         return services;
     }

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/PricingServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/PricingServiceCollectionExtensions.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Tamma.Api.Services.Pricing;
+
+namespace Tamma.Api.Extensions;
+
+/// <summary>
+/// Story 34-1 — DI registration for the plan price-book catalog. Single
+/// entry-point so <c>Program.cs</c> wires it with one call. Both services are
+/// scoped (they depend on the scoped <c>ControlPlaneDbContext</c>); the read
+/// service is registered behind its interface, the version editor as a
+/// concrete type (Story 34-2 resolves it directly from the admin endpoint).
+/// </summary>
+public static class PricingServiceCollectionExtensions
+{
+    public static IServiceCollection AddPlanCatalog(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        // TimeProvider is registered by Program.cs already; fall back to the
+        // system provider for tests that haven't staged one.
+        services.TryAddSingleton(TimeProvider.System);
+
+        services.TryAddScoped<IPlanCatalogService, PlanCatalogService>();
+        services.TryAddScoped<PlanVersionEditor>();
+
+        return services;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -897,6 +897,13 @@ builder.Services.AddSingleton<
 // worker itself is hosted-service singleton + registry singleton.
 builder.Services.AddPlatformTaskWorker(builder.Configuration);
 
+// Story 35-1 — Epic 35 billing foundation. Mode-aware: StripeBillingProvider
+// in SaaS, NullBillingProvider in single-user. Registers the catalog reader,
+// the cabinet-resolving Stripe client factory, BillingOptions, and the
+// billing.customer.create retry handler (IPlatformTaskHandler). The Stripe key
+// resolves through the Epic 29 cabinet — never raw env in production (AC5).
+builder.Services.AddTammaBilling(builder.Configuration);
+
 // Unified-tenancy Phase 4 — `tenant.move` platform-task handler. Drives
 // ITenantMoveService.MoveAsync for tasks enqueued by
 // POST /api/admin/tenants/{tenantId}/move; on failure it stamps the
@@ -1160,6 +1167,16 @@ if (Tamma.Api.Services.Secrets.Stopgap.MigrateSecretsCommand.ShouldRun(args))
 {
     var exitCode = await Tamma.Api.Services.Secrets.Stopgap
         .MigrateSecretsCommand.RunAsync(app.Services);
+    return exitCode;
+}
+
+// Story 35-1 — `dotnet run --project Tamma.Api -- seed-billing` idempotently
+// syncs the Stripe Product/Price/Meter catalog into billing_plan_prices and
+// exits. Single-user prints "billing is SaaS-only" and exits 0.
+if (Tamma.Api.Services.Billing.SeedBillingCommand.ShouldRun(args))
+{
+    var exitCode = await Tamma.Api.Services.Billing
+        .SeedBillingCommand.RunAsync(app.Services);
     return exitCode;
 }
 
@@ -2038,6 +2055,7 @@ using (var scope = app.Services.CreateScope())
                 DROP TABLE IF EXISTS
                     admin_impersonations,
                     agents, agent_versions,
+                    billing_customers, billing_plan_prices,
                     alert_delivery_attempts, alert_channels, alerts,
                     alert_evaluator_cursor, alert_rules,
                     api_keys, agent_configs, budget_configs, domain_events,

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -1365,16 +1365,19 @@ admin.MapGet("/analytics/tenants", AdminAnalyticsEndpoints.GetTopTenants)
 admin.MapGet("/analytics/events", AdminAnalyticsEndpoints.GetEventHistogram)
     .RequireAuthorization("PlatformOwnerAccess");
 
-// Story 34-1 — read-only plan price-book endpoints. OwnerAccess per the story
-// (the catalog is platform-owned in both modes; in SaaS only platform owners
-// administer it). The write (create/deprecate version) endpoints are Story
-// 34-2 — this story ships only the three reads + the tested PlanVersionEditor.
+// Story 34-1 — read-only plan price-book endpoints. PlatformOwnerAccess: the
+// price book is platform-GLOBAL (incl. BYOK-vs-platform pricing) in both modes
+// with no per-tenant override layer, so it is platform-scoped admin work — like
+// the adjacent /analytics routes above. OwnerAccess would let every
+// personal-tenant owner read the whole platform price book (Finding C1). The
+// write (create/deprecate version) endpoints are Story 34-2 — this story ships
+// only the three reads + the tested PlanVersionEditor.
 admin.MapGet("/plans", Tamma.Api.Endpoints.Admin.PlanCatalogEndpoints.ListActive)
-    .RequireAuthorization("OwnerAccess");
+    .RequireAuthorization("PlatformOwnerAccess");
 admin.MapGet("/plans/{slug}", Tamma.Api.Endpoints.Admin.PlanCatalogEndpoints.GetActiveBySlug)
-    .RequireAuthorization("OwnerAccess");
+    .RequireAuthorization("PlatformOwnerAccess");
 admin.MapGet("/plans/{slug}/versions", Tamma.Api.Endpoints.Admin.PlanCatalogEndpoints.GetVersions)
-    .RequireAuthorization("OwnerAccess");
+    .RequireAuthorization("PlatformOwnerAccess");
 
 // Story 28-11 — platform-admin tenant-status UX. List + detail surface the
 // Epic-28 shadow columns on tenants (Status, PlanId, KekVersion,

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -1036,6 +1036,16 @@ if (!string.IsNullOrEmpty(jwtSecret))
             p.AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme, "ApiKey");
             p.AddRequirements(new PermissionRequirement("platforms:manage"));
         });
+        // Story 32-1 — first-class agent entity writes (create/publish/archive).
+        // Mirrors PromptManage/ConventionManage: tenant_owner OR tenant_admin
+        // reach so member-role SaaS callers hit 403 at the policy. Public-agent
+        // writes are additionally gated by the platform-admin claim inside the
+        // handler (CreateAgent / CanWriteAgent).
+        options.AddPolicy("AgentManage", p =>
+        {
+            p.AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme, "ApiKey");
+            p.AddRequirements(new PermissionRequirement("agents:manage"));
+        });
         options.AddPolicy("WorkflowsView", p =>
         {
             p.AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme, "ApiKey");
@@ -1112,7 +1122,7 @@ else if (builder.Environment.IsDevelopment())
             .Build();
         // Register all named policies with permissive default
         foreach (var name in new[] { "AdminAccess", "OwnerAccess", "PlatformOwnerAccess", "MemberAccess", "SettingsView",
-            "SettingsManage", "PromptManage", "ConventionManage", "PlatformsManage", "WorkflowsView", "WorkflowsManage", "WorkflowsDelete", "DashboardView", "ApiKeysManage",
+            "SettingsManage", "PromptManage", "ConventionManage", "PlatformsManage", "AgentManage", "WorkflowsView", "WorkflowsManage", "WorkflowsDelete", "DashboardView", "ApiKeysManage",
             "SelfOrApiKeysManage", "SelfOrUsersView", "AuthenticatedAny" })
         {
             options.AddPolicy(name, p => p.AddRequirements(new Tamma.Api.Infrastructure.AllowAnonymousRequirement()));
@@ -1687,6 +1697,24 @@ agents.MapPost("/config/validate", AgentEndpoints.ValidateConfig);
 agents.MapGet("/{role}/resolve", AgentEndpoints.ResolveAgent);
 agents.MapPost("/resolve-for-phase", AgentEndpoints.ResolveForPhase);
 
+// ── Story 32-1 — first-class agent entities (/api/v1/agents) ──
+// Reads inherit the group's SettingsView gate; writes use AgentManage
+// (tenant_owner/tenant_admin → member 403). Public-agent writes are
+// additionally gated by the platform-admin claim inside the handlers. The
+// legacy GET/PUT /config endpoints above are untouched (cutover is later in
+// the epic). :guid constraints keep the {id} routes from colliding with the
+// {role}/resolve route.
+agents.MapGet("/", AgentEndpoints.ListAgents);
+agents.MapPost("/", AgentEndpoints.CreateAgent)
+    .RequireAuthorization("AgentManage").RequireRateLimiting("ConfigWrite");
+agents.MapGet("/{id:guid}", AgentEndpoints.GetAgent);
+agents.MapGet("/{id:guid}/versions", AgentEndpoints.ListVersions);
+agents.MapGet("/{id:guid}/versions/{version:int}", AgentEndpoints.GetVersion);
+agents.MapPost("/{id:guid}/versions", AgentEndpoints.PublishVersion)
+    .RequireAuthorization("AgentManage").RequireRateLimiting("ConfigWrite");
+agents.MapPost("/{id:guid}/archive", AgentEndpoints.ArchiveAgent)
+    .RequireAuthorization("AgentManage").RequireRateLimiting("ConfigWrite");
+
 // ── Prompts ──
 // CLAUDE.md "Prompt Store Architecture > API" defines /defaults as the canonical
 // read-only system-default URL. Both /system (legacy TS naming) and /defaults
@@ -1990,6 +2018,7 @@ using (var scope = app.Services.CreateScope())
             dbContext.Database.ExecuteSqlRaw(@"
                 DROP TABLE IF EXISTS
                     admin_impersonations,
+                    agents, agent_versions,
                     alert_delivery_attempts, alert_channels, alerts,
                     alert_evaluator_cursor, alert_rules,
                     api_keys, agent_configs, budget_configs, domain_events,
@@ -2028,6 +2057,11 @@ using (var scope = app.Services.CreateScope())
         // doc contract says "invoked once at API startup after migrations
         // apply" — this is that call site.
         await Tamma.Data.Seeders.PlansSeeder.SeedAsync(dbContext);
+
+        // Story 32-1 — public/system agent definitions (one per role with the
+        // tamma-<role> handle + Version=1). Insert-missing-only; no-op on
+        // re-run. CP-resident; coexists with the Elsa-store AgentSeeder.
+        await Tamma.Data.Seeders.AgentEntitySeeder.SeedAsync(dbContext);
 
         // tenant_databases: register the central DB as pool member #1
         // (unified-tenancy Phase 2) so single-user/dev and SaaS share one

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -809,6 +809,12 @@ builder.Services.AddTammaAlerts();
 // DCB event stream and emits AlertPayloads through IAlertSink.
 builder.Services.AddTammaAlertRuleEngine();
 
+// Story 37-1 — curated audit-record projection: catalog-driven projector,
+// insert-if-absent repository, lag metric, and the background host. READS the
+// DCB stream and materializes audit_records (never writes raw events). The
+// background loop is opt-in (AuditProjectorOptions.RunOnStartup defaults false).
+builder.Services.AddTammaAuditProjection();
+
 // Story 34-1 — plan price-book catalog: read-only IPlanCatalogService +
 // the PlanVersionEditor (immutable, versioned plan management). CP-resident;
 // platform-owned in both modes.
@@ -2055,6 +2061,7 @@ using (var scope = app.Services.CreateScope())
                 DROP TABLE IF EXISTS
                     admin_impersonations,
                     agents, agent_versions,
+                    audit_records, audit_projector_cursor,
                     billing_customers, billing_plan_prices,
                     alert_delivery_attempts, alert_channels, alerts,
                     alert_evaluator_cursor, alert_rules,

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -809,6 +809,11 @@ builder.Services.AddTammaAlerts();
 // DCB event stream and emits AlertPayloads through IAlertSink.
 builder.Services.AddTammaAlertRuleEngine();
 
+// Story 34-1 — plan price-book catalog: read-only IPlanCatalogService +
+// the PlanVersionEditor (immutable, versioned plan management). CP-resident;
+// platform-owned in both modes.
+builder.Services.AddPlanCatalog();
+
 // Wave C.4 §4 — per-process health monitor for TammaApiClient.
 // Singleton so the rolling 5-min failure window is shared across every
 // call site. Fires PLATFORM.API.UNHEALTHY via IAlertEventEmitter when
@@ -1359,6 +1364,17 @@ admin.MapGet("/analytics/tenants", AdminAnalyticsEndpoints.GetTopTenants)
     .RequireAuthorization("PlatformOwnerAccess");
 admin.MapGet("/analytics/events", AdminAnalyticsEndpoints.GetEventHistogram)
     .RequireAuthorization("PlatformOwnerAccess");
+
+// Story 34-1 — read-only plan price-book endpoints. OwnerAccess per the story
+// (the catalog is platform-owned in both modes; in SaaS only platform owners
+// administer it). The write (create/deprecate version) endpoints are Story
+// 34-2 — this story ships only the three reads + the tested PlanVersionEditor.
+admin.MapGet("/plans", Tamma.Api.Endpoints.Admin.PlanCatalogEndpoints.ListActive)
+    .RequireAuthorization("OwnerAccess");
+admin.MapGet("/plans/{slug}", Tamma.Api.Endpoints.Admin.PlanCatalogEndpoints.GetActiveBySlug)
+    .RequireAuthorization("OwnerAccess");
+admin.MapGet("/plans/{slug}/versions", Tamma.Api.Endpoints.Admin.PlanCatalogEndpoints.GetVersions)
+    .RequireAuthorization("OwnerAccess");
 
 // Story 28-11 — platform-admin tenant-status UX. List + detail surface the
 // Epic-28 shadow columns on tenants (Status, PlanId, KekVersion,
@@ -2028,7 +2044,8 @@ using (var scope = app.Services.CreateScope())
                     platform_webhook_deliveries,
                     junior_developers, kek_rotations,
                     mentorship_events, mentorship_sessions,
-                    password_reset_tokens, plans,
+                    password_reset_tokens,
+                    plan_features, plan_entitlements, plan_prices, plans,
                     platform_analytics_hourly,
                     platform_api_key_index,
                     platform_bootstrap,

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentConfigValidator.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentConfigValidator.cs
@@ -1,0 +1,381 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Tamma.Api.Services.Security;
+
+namespace Tamma.Api.Services.Agents;
+
+/// <summary>
+/// Story 32-1 — shared saved-config validator for agent definitions. Extracted
+/// from the private <c>AgentEndpoints.ValidateConfigShape</c> (so the rules are
+/// shared, not duplicated) and extended for the Epic 32 saved-config fields the
+/// design names (<c>provider</c>, <c>model</c>, <c>temperature</c>,
+/// <c>maxTokens</c>, <c>tokenBudget</c>, <c>tools[]</c>, <c>systemPromptRef</c>,
+/// <c>rag{}</c>).
+///
+/// <para>The battle-tested legacy guards are kept verbatim (Finding 014):
+/// provider name regex <c>^[a-z0-9][a-z0-9_-]{0,63}$</c>, <c>maxBudgetUsd</c>
+/// range [0,100], non-empty provider chains, prototype-pollution rejection on
+/// role/chain keys, ReDoS guard on <c>blockedCommandPatterns</c>, and
+/// <c>maxFetchSizeBytes</c> range [0, 1 GiB]. Tolerant of an empty config
+/// (valid — falls through to defaults).</para>
+///
+/// <para>Configs are credential-agnostic by design (no raw keys), so error
+/// messages reference field names only, never values that could carry secrets.</para>
+/// </summary>
+public static class AgentConfigValidator
+{
+    /// <summary>Provider name regex (Story 9-1 AC 6 / TS validateAgentsConfig).</summary>
+    private static readonly Regex ProviderNameRegex =
+        new("^[a-z0-9][a-z0-9_-]{0,63}$",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// Validate the shape + semantics of a proposed saved config. Returns
+    /// <c>(valid, errors)</c>. Empty config is valid.
+    /// </summary>
+    public static (bool Valid, string[] Errors) Validate(string configJson)
+    {
+        var errors = new List<string>();
+
+        JsonDocument doc;
+        try
+        {
+            doc = JsonDocument.Parse(configJson);
+        }
+        catch (JsonException ex)
+        {
+            return (false, new[] { $"Invalid JSON: {ex.Message}" });
+        }
+
+        using (doc)
+        {
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                errors.Add("Root must be a JSON object.");
+                return (false, errors.ToArray());
+            }
+
+            // ── Epic 32 saved-config top-level fields ─────────────────────────
+            ValidateSavedConfigFields(root, errors);
+
+            // ── Roles (legacy 2D shape) ──────────────────────────────────────
+            if (root.TryGetProperty("roles", out var roles))
+            {
+                if (roles.ValueKind != JsonValueKind.Object)
+                {
+                    errors.Add("'roles' must be an object.");
+                    return (false, errors.ToArray());
+                }
+
+                foreach (var prop in roles.EnumerateObject())
+                {
+                    if (RolePhaseMap.ForbiddenKeys.Contains(prop.Name))
+                    {
+                        errors.Add($"Forbidden role key: '{prop.Name}'.");
+                        continue;
+                    }
+                    var roleKnown = RolePhaseMap.ValidRoles.Contains(prop.Name) ||
+                                    RolePhaseMap.LegacyRoleAliases.ContainsKey(prop.Name);
+                    if (!roleKnown)
+                    {
+                        errors.Add(
+                            $"Unknown role '{prop.Name}'. Valid: " +
+                            string.Join(", ", RolePhaseMap.ValidRoles) + ".");
+                        continue;
+                    }
+                    if (prop.Value.ValueKind != JsonValueKind.Object) continue;
+
+                    ValidateRoleSemantics(prop.Name, prop.Value, errors);
+                }
+            }
+
+            // ── defaults.providerChain (legacy TS shape) ─────────────────────
+            if (root.TryGetProperty("defaults", out var defaults) &&
+                defaults.ValueKind == JsonValueKind.Object &&
+                defaults.TryGetProperty("providerChain", out var defChain))
+            {
+                ValidateProviderChain("defaults.providerChain", defChain, errors);
+            }
+
+            // ── chains (canonical 2D shape) ──────────────────────────────────
+            if (root.TryGetProperty("chains", out var chains) &&
+                chains.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var prop in chains.EnumerateObject())
+                {
+                    if (RolePhaseMap.ForbiddenKeys.Contains(prop.Name))
+                    {
+                        errors.Add($"Forbidden chain key: '{prop.Name}'.");
+                        continue;
+                    }
+                    if (prop.Value.ValueKind == JsonValueKind.Array)
+                    {
+                        ValidateProviderChain($"chains.{prop.Name}", prop.Value, errors);
+                    }
+                    else if (prop.Value.ValueKind == JsonValueKind.Object)
+                    {
+                        foreach (var actionProp in prop.Value.EnumerateObject())
+                        {
+                            if (actionProp.Value.ValueKind != JsonValueKind.Array) continue;
+                            ValidateProviderChain(
+                                $"chains.{prop.Name}.{actionProp.Name}",
+                                actionProp.Value, errors);
+                        }
+                    }
+                }
+            }
+
+            // ── security branch (blockedCommandPatterns + maxFetchSizeBytes) ──
+            if (root.TryGetProperty("security", out var security) &&
+                security.ValueKind == JsonValueKind.Object)
+            {
+                ValidateSecurity(security, errors);
+            }
+        }
+
+        return (errors.Count == 0, errors.ToArray());
+    }
+
+    /// <summary>
+    /// Validate the Epic 32 saved-config top-level fields. Each is optional;
+    /// only present-and-wrong-typed/out-of-range values are rejected.
+    /// </summary>
+    private static void ValidateSavedConfigFields(JsonElement root, List<string> errors)
+    {
+        // provider (top-level) — same regex as the legacy role.provider.
+        if (root.TryGetProperty("provider", out var provider))
+        {
+            if (provider.ValueKind != JsonValueKind.String)
+            {
+                errors.Add("provider must be a string.");
+            }
+            else
+            {
+                var name = provider.GetString() ?? string.Empty;
+                if (!ProviderNameRegex.IsMatch(name))
+                {
+                    errors.Add(
+                        $"provider '{name}' must match /^[a-z0-9][a-z0-9_-]{{0,63}}$/.");
+                }
+            }
+        }
+
+        // model — non-empty string.
+        if (root.TryGetProperty("model", out var model) &&
+            model.ValueKind != JsonValueKind.String)
+        {
+            errors.Add("model must be a string.");
+        }
+
+        // temperature ∈ [0, 2], finite.
+        if (root.TryGetProperty("temperature", out var temp))
+        {
+            if (temp.ValueKind != JsonValueKind.Number ||
+                !temp.TryGetDouble(out var t) || double.IsNaN(t) || double.IsInfinity(t))
+            {
+                errors.Add("temperature must be a finite number.");
+            }
+            else if (t < 0 || t > 2)
+            {
+                errors.Add($"temperature must be in [0, 2] (got {t}).");
+            }
+        }
+
+        // maxTokens > 0.
+        if (root.TryGetProperty("maxTokens", out var maxTokens))
+        {
+            if (maxTokens.ValueKind != JsonValueKind.Number ||
+                !maxTokens.TryGetInt64(out var mt))
+            {
+                errors.Add("maxTokens must be an integer.");
+            }
+            else if (mt <= 0)
+            {
+                errors.Add($"maxTokens must be > 0 (got {mt}).");
+            }
+        }
+
+        // tokenBudget >= 0.
+        if (root.TryGetProperty("tokenBudget", out var tokenBudget))
+        {
+            if (tokenBudget.ValueKind != JsonValueKind.Number ||
+                !tokenBudget.TryGetInt64(out var tb))
+            {
+                errors.Add("tokenBudget must be an integer.");
+            }
+            else if (tb < 0)
+            {
+                errors.Add($"tokenBudget must be >= 0 (got {tb}).");
+            }
+        }
+
+        // tools[] — array of strings.
+        if (root.TryGetProperty("tools", out var tools))
+        {
+            if (tools.ValueKind != JsonValueKind.Array)
+            {
+                errors.Add("tools must be an array of strings.");
+            }
+            else
+            {
+                var i = 0;
+                foreach (var entry in tools.EnumerateArray())
+                {
+                    if (entry.ValueKind != JsonValueKind.String)
+                    {
+                        errors.Add($"tools[{i}] must be a string.");
+                    }
+                    i++;
+                }
+            }
+        }
+
+        // systemPromptRef — string.
+        if (root.TryGetProperty("systemPromptRef", out var promptRef) &&
+            promptRef.ValueKind != JsonValueKind.String)
+        {
+            errors.Add("systemPromptRef must be a string.");
+        }
+
+        // rag{} — object.
+        if (root.TryGetProperty("rag", out var rag) &&
+            rag.ValueKind != JsonValueKind.Object)
+        {
+            errors.Add("rag must be an object.");
+        }
+    }
+
+    private static void ValidateRoleSemantics(string role, JsonElement obj, List<string> errors)
+    {
+        // provider name regex
+        if (obj.TryGetProperty("provider", out var prov) &&
+            prov.ValueKind == JsonValueKind.String)
+        {
+            var name = prov.GetString() ?? string.Empty;
+            if (!ProviderNameRegex.IsMatch(name))
+            {
+                errors.Add(
+                    $"roles.{role}.provider '{name}' must match /^[a-z0-9][a-z0-9_-]{{0,63}}$/.");
+            }
+        }
+
+        // maxBudgetUsd range [0, 100], finite
+        if (obj.TryGetProperty("maxBudgetUsd", out var budget) &&
+            budget.ValueKind == JsonValueKind.Number)
+        {
+            if (!budget.TryGetDouble(out var budgetVal) || double.IsNaN(budgetVal) ||
+                double.IsInfinity(budgetVal))
+            {
+                errors.Add($"roles.{role}.maxBudgetUsd must be a finite number.");
+            }
+            else if (budgetVal < 0 || budgetVal > 100)
+            {
+                errors.Add($"roles.{role}.maxBudgetUsd must be in [0, 100] (got {budgetVal}).");
+            }
+        }
+
+        // permissionMode whitelist
+        if (obj.TryGetProperty("permissionMode", out var mode) &&
+            mode.ValueKind == JsonValueKind.String)
+        {
+            var modeVal = mode.GetString();
+            if (modeVal is not ("default" or "acceptEdits" or "bypassPermissions"))
+            {
+                errors.Add(
+                    $"roles.{role}.permissionMode must be one of " +
+                    "default | acceptEdits | bypassPermissions.");
+            }
+        }
+
+        // providerChain shape
+        if (obj.TryGetProperty("providerChain", out var chain) &&
+            chain.ValueKind == JsonValueKind.Array)
+        {
+            ValidateProviderChain($"roles.{role}.providerChain", chain, errors);
+        }
+    }
+
+    private static void ValidateProviderChain(string label, JsonElement arr, List<string> errors)
+    {
+        if (arr.GetArrayLength() == 0)
+        {
+            errors.Add($"{label}: chain must not be empty.");
+            return;
+        }
+        var i = 0;
+        foreach (var entry in arr.EnumerateArray())
+        {
+            if (entry.ValueKind != JsonValueKind.Object)
+            {
+                errors.Add($"{label}[{i}]: entry must be an object.");
+                i++;
+                continue;
+            }
+            if (!entry.TryGetProperty("provider", out var prov) ||
+                prov.ValueKind != JsonValueKind.String)
+            {
+                errors.Add($"{label}[{i}]: missing 'provider' string field.");
+                i++;
+                continue;
+            }
+            var name = prov.GetString() ?? string.Empty;
+            if (!ProviderNameRegex.IsMatch(name))
+            {
+                errors.Add(
+                    $"{label}[{i}].provider '{name}' must match " +
+                    "/^[a-z0-9][a-z0-9_-]{0,63}$/.");
+            }
+            i++;
+        }
+    }
+
+    private static void ValidateSecurity(JsonElement sec, List<string> errors)
+    {
+        if (sec.TryGetProperty("maxFetchSizeBytes", out var fetch))
+        {
+            if (fetch.ValueKind != JsonValueKind.Number ||
+                !fetch.TryGetInt64(out var bytes))
+            {
+                errors.Add("security.maxFetchSizeBytes must be a number.");
+            }
+            else if (bytes < 0 || bytes > 1L * 1024 * 1024 * 1024)
+            {
+                errors.Add(
+                    $"security.maxFetchSizeBytes must be in [0, 1 GiB] (got {bytes}).");
+            }
+        }
+
+        if (sec.TryGetProperty("blockedCommandPatterns", out var patterns) &&
+            patterns.ValueKind == JsonValueKind.Array)
+        {
+            if (patterns.GetArrayLength() > ReDosGuard.MaxPatternCount)
+            {
+                errors.Add(
+                    $"security.blockedCommandPatterns count {patterns.GetArrayLength()} " +
+                    $"exceeds max {ReDosGuard.MaxPatternCount}.");
+            }
+            var i = 0;
+            foreach (var entry in patterns.EnumerateArray())
+            {
+                if (entry.ValueKind != JsonValueKind.String)
+                {
+                    errors.Add($"security.blockedCommandPatterns[{i}]: must be a string.");
+                    i++;
+                    continue;
+                }
+                try
+                {
+                    ReDosGuard.Validate(
+                        $"security.blockedCommandPatterns[{i}]",
+                        entry.GetString() ?? string.Empty);
+                }
+                catch (ArgumentException ex)
+                {
+                    errors.Add(ex.Message);
+                }
+                i++;
+            }
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditProjectionMetrics.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditProjectionMetrics.cs
@@ -1,0 +1,48 @@
+using System.Diagnostics.Metrics;
+
+namespace Tamma.Api.Services.Audit;
+
+/// <summary>
+/// Story 37-1 (AC9) — OpenTelemetry surface for the audit projector.
+///
+/// <list type="bullet">
+///   <item><description><c>tamma.audit.projection_lag</c> — observable gauge of
+///     how many raw DCB events are still un-projected (max raw
+///     <c>SequenceNumber</c> − last projected <c>SequenceNumber</c>, summed
+///     across the two streams). Reports the last value the projector recorded
+///     after its most recent batch; <c>0</c> means the curated trail is fully
+///     caught up.</description></item>
+/// </list>
+///
+/// <para>Self-registering meter (see <c>KekRotationMetrics</c> /
+/// <c>TenantConnectionPoolMetrics</c>): constructing a <see cref="Meter"/> with
+/// <see cref="MeterName"/> makes the gauge discoverable; registering this class
+/// as a singleton is sufficient. Thread-safe — the gauge reads a volatile long.</para>
+/// </summary>
+public sealed class AuditProjectionMetrics : IDisposable
+{
+    /// <summary>Public meter name — pin so dashboards stay stable.</summary>
+    public const string MeterName = "Tamma.AuditProjection";
+
+    private readonly Meter _meter;
+    private long _lag;
+
+    public AuditProjectionMetrics()
+    {
+        _meter = new Meter(MeterName, "1.0.0");
+        _meter.CreateObservableGauge(
+            "tamma.audit.projection_lag",
+            () => Interlocked.Read(ref _lag),
+            unit: "{event}",
+            description: "Raw DCB events not yet materialized into audit_records "
+                + "(0 when the curated trail is fully caught up).");
+    }
+
+    /// <summary>Current lag (raw events still awaiting projection).</summary>
+    public long Lag => Interlocked.Read(ref _lag);
+
+    /// <summary>Record the projector's latest lag after a batch.</summary>
+    public void RecordLag(long lag) => Interlocked.Exchange(ref _lag, lag < 0 ? 0 : lag);
+
+    public void Dispose() => _meter.Dispose();
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditProjectionMetrics.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditProjectionMetrics.cs
@@ -25,6 +25,7 @@ public sealed class AuditProjectionMetrics : IDisposable
     public const string MeterName = "Tamma.AuditProjection";
 
     private readonly Meter _meter;
+    private readonly Counter<long> _projectionFailures;
     private long _lag;
 
     public AuditProjectionMetrics()
@@ -36,6 +37,16 @@ public sealed class AuditProjectionMetrics : IDisposable
             unit: "{event}",
             description: "Raw DCB events not yet materialized into audit_records "
                 + "(0 when the curated trail is fully caught up).");
+
+        // C2 — counts events whose normal projection (redaction / build) failed
+        // and were QUARANTINED (a safe placeholder row written, cursor advanced).
+        // A non-zero rate means ops should inspect a poison-pill / pathological
+        // payload — the action was still recorded, never silently dropped.
+        _projectionFailures = _meter.CreateCounter<long>(
+            "tamma.audit.projection_failures",
+            unit: "{event}",
+            description: "Raw DCB events that failed normal projection and were "
+                + "quarantined (safe placeholder row written; action still audited).");
     }
 
     /// <summary>Current lag (raw events still awaiting projection).</summary>
@@ -43,6 +54,9 @@ public sealed class AuditProjectionMetrics : IDisposable
 
     /// <summary>Record the projector's latest lag after a batch.</summary>
     public void RecordLag(long lag) => Interlocked.Exchange(ref _lag, lag < 0 ? 0 : lag);
+
+    /// <summary>C2 — count one quarantined (failed-redaction) event.</summary>
+    public void RecordProjectionFailure() => _projectionFailures.Add(1);
 
     public void Dispose() => _meter.Dispose();
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditProjectorBackgroundService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditProjectorBackgroundService.cs
@@ -20,6 +20,22 @@ namespace Tamma.Api.Services.Audit;
 /// NEVER appends, mutates, or deletes a raw event. The only writes are the
 /// curated <c>audit_records</c> rows and the projector cursor.</para>
 ///
+/// <para><b>Per-tenant domain cursor (C1):</b> each tenant's <c>domain_events</c>
+/// is an INDEPENDENT per-schema BIGSERIAL stream, so each tenant is scanned with
+/// <c>WHERE SequenceNumber &gt; &lt;that tenant's own last&gt;</c> and advances
+/// ONLY that tenant's cursor row. The global CP <c>platform_events</c> stream
+/// uses the distinguished <see cref="AuditProjectorCursor.PlatformSentinel"/>
+/// row, which also carries the single-user / shared-DB <c>cp.domain_events</c>
+/// fallback. The batch cap is applied PER TENANT (I1) so one busy tenant cannot
+/// starve the others.</para>
+///
+/// <para><b>Failed-redaction quarantine (C2):</b> if classification/redaction
+/// throws for one event, the host writes a minimal QUARANTINE row (safe
+/// placeholder payload, <c>outcome = failure</c>, same <c>source_event_id</c>)
+/// and emits a WARN + a failure counter — then, and only then, advances the
+/// cursor past it. The action is still recorded (never silently dropped) and the
+/// trail is never stalled forever on a poison-pill payload.</para>
+///
 /// <para><b>Scope routing (AC11):</b> SaaS tenant-scoped events (TenantId set)
 /// materialize into the tenant schema keyed by <c>tenant_id</c>; SaaS
 /// platform-only events (TenantId null) materialize into the CP
@@ -98,7 +114,7 @@ public sealed class AuditProjectorBackgroundService : BackgroundService
     /// <summary>
     /// Run a single projection tick. Public so tests can drive the projector
     /// deterministically without the background loop. Returns the number of
-    /// curated rows inserted this tick.
+    /// curated rows inserted this tick (including quarantine rows).
     /// </summary>
     public async Task<int> ProcessOnceAsync(CancellationToken ct)
     {
@@ -114,78 +130,219 @@ public sealed class AuditProjectorBackgroundService : BackgroundService
             : AuditOwnershipMode.SingleUser;
 
         var factory = sp.GetService<ITenantDbContextFactory>();
-        var cursor = await repo.LoadCursorAsync(cp, _options.ProjectorId, ct).ConfigureAwait(false);
-
-        // ── READ-ONLY scan of both streams, ordered by SequenceNumber (AC15) ──
-        //
-        // Domain (tenant-scoped) events: per-tenant fan-out via the factory
-        // mirrors AlertRuleEvaluator's PR-D shape — tenant domain_events live in
-        // each tenant's schema. The domain cursor is shared across tenants
-        // (per-stream-but-monotonic BIGSERIAL identity). When no factory is
-        // wired (single-user / transitional shared-DB), fall back to cp.DomainEvents.
-        var domain = await ReadDomainEventsAsync(cp, factory, cursor.LastDomainSequenceNumber, ct)
-            .ConfigureAwait(false);
-
-        // Platform (cross-tenant / platform-only) events: always CP-resident.
-        var platform = await cp.PlatformEvents.AsNoTracking()
-            .Where(e => e.SequenceNumber > cursor.LastPlatformSequenceNumber)
-            .OrderBy(e => e.SequenceNumber)
-            .Take(_options.BatchSize)
-            .ToListAsync(ct)
-            .ConfigureAwait(false);
 
         Guid? singleUserOwnerId = mode == AuditOwnershipMode.SingleUser
             ? await ResolveSingleUserOwnerAsync(cp, ct).ConfigureAwait(false)
             : null;
 
         var inserted = 0;
-        long maxDomainSeq = cursor.LastDomainSequenceNumber;
-        long maxPlatformSeq = cursor.LastPlatformSequenceNumber;
+        long totalScanned = 0;
+        // Lag (I2): compute the domain head from the scan we already did, plus the
+        // residual (events still beyond the per-tenant batch cap) so a long backlog
+        // still reports lag without a second full MAX(SequenceNumber) fan-out.
+        long domainHeadFromScan = 0;
+        long domainResidual = 0;
 
-        // Domain events first, in strict SequenceNumber order (37-2 needs it).
-        foreach (var raw in domain)
+        // ── Per-tenant domain projection (C1 + I1) ──────────────────────────────
+        // Each tenant has an independent BIGSERIAL stream and its own cursor row;
+        // the batch cap is applied PER TENANT so one busy tenant can't starve others.
+        if (factory is null)
         {
-            if (ct.IsCancellationRequested) break;
-            if (await ProjectOneAsync(
-                    RawAuditEvent.From(raw), projector, repo, cp, factory,
-                    mode, singleUserOwnerId, ct).ConfigureAwait(false))
+            // Single-user / transitional shared-DB: one stream, tracked on the
+            // platform-sentinel row's domain field. No tenant fan-out.
+            var sentinel = AuditProjectorCursor.PlatformSentinel;
+            var cursor = await repo.LoadCursorAsync(cp, _options.ProjectorId, sentinel, ct)
+                .ConfigureAwait(false);
+            var domain = await cp.DomainEvents.AsNoTracking()
+                .Where(e => e.SequenceNumber > cursor.LastDomainSequenceNumber)
+                .OrderBy(e => e.SequenceNumber)
+                .Take(_options.BatchSize)
+                .ToListAsync(ct)
+                .ConfigureAwait(false);
+
+            var (insertedHere, maxSeq) = await ProjectStreamAsync(
+                domain.Select(RawAuditEvent.From), projector, repo, cp, factory,
+                mode, singleUserOwnerId, cursor.LastDomainSequenceNumber, ct)
+                .ConfigureAwait(false);
+            inserted += insertedHere;
+            totalScanned += domain.Count;
+            if (maxSeq > domainHeadFromScan) domainHeadFromScan = maxSeq;
+            if (domain.Count >= _options.BatchSize)
             {
-                inserted++;
+                // A full batch implies there may be more beyond the cap — sample
+                // the head once so lag is not under-reported on a backlog.
+                var head = await cp.DomainEvents.AsNoTracking()
+                    .MaxAsync(e => (long?)e.SequenceNumber, ct).ConfigureAwait(false) ?? 0L;
+                domainResidual += Math.Max(0, head - maxSeq);
+                if (head > domainHeadFromScan) domainHeadFromScan = head;
             }
-            if (raw.SequenceNumber > maxDomainSeq) maxDomainSeq = raw.SequenceNumber;
+
+            // Persist the (single) domain cursor on the sentinel row.
+            if (domain.Count > 0)
+            {
+                await repo.SaveCursorAsync(
+                    cp, _options.ProjectorId, sentinel, maxSeq,
+                    cursor.LastPlatformSequenceNumber,
+                    _timeProvider.GetUtcNow().UtcDateTime, ct).ConfigureAwait(false);
+            }
+        }
+        else
+        {
+            var tenantIds = await cp.Tenants.AsNoTracking()
+                .Where(t => t.DeletedAt == null)
+                .OrderBy(t => t.Id)
+                .Select(t => t.Id)
+                .ToListAsync(ct)
+                .ConfigureAwait(false);
+
+            foreach (var tid in tenantIds)
+            {
+                if (ct.IsCancellationRequested) break;
+                try
+                {
+                    var cursor = await repo.LoadCursorAsync(cp, _options.ProjectorId, tid, ct)
+                        .ConfigureAwait(false);
+
+                    await using var tdb = await factory.CreateAsync(tid, ct).ConfigureAwait(false);
+                    var rows = await tdb.DomainEvents.AsNoTracking()
+                        .Where(e => e.SequenceNumber > cursor.LastDomainSequenceNumber)
+                        .OrderBy(e => e.SequenceNumber)
+                        .Take(_options.BatchSize)
+                        .ToListAsync(ct)
+                        .ConfigureAwait(false);
+
+                    var (insertedHere, maxSeq) = await ProjectStreamAsync(
+                        rows.Select(RawAuditEvent.From), projector, repo, cp, factory,
+                        mode, singleUserOwnerId, cursor.LastDomainSequenceNumber, ct)
+                        .ConfigureAwait(false);
+                    inserted += insertedHere;
+                    totalScanned += rows.Count;
+                    if (maxSeq > domainHeadFromScan) domainHeadFromScan = maxSeq;
+
+                    if (rows.Count >= _options.BatchSize)
+                    {
+                        // This tenant has a backlog beyond the cap — sample its head
+                        // so per-tenant lag is reflected without a blanket fan-out.
+                        var head = await tdb.DomainEvents.AsNoTracking()
+                            .MaxAsync(e => (long?)e.SequenceNumber, ct).ConfigureAwait(false) ?? 0L;
+                        var residual = Math.Max(0, head - maxSeq);
+                        domainResidual += residual;
+                        if (head > domainHeadFromScan) domainHeadFromScan = head;
+                        if (residual > 0)
+                        {
+                            _logger.LogInformation(
+                                "AuditProjector: tenant {TenantId} has {Residual} domain events "
+                                + "still beyond this tick's batch cap.", tid, residual);
+                        }
+                    }
+
+                    // Advance ONLY this tenant's cursor row.
+                    if (rows.Count > 0)
+                    {
+                        await repo.SaveCursorAsync(
+                            cp, _options.ProjectorId, tid, maxSeq, 0L,
+                            _timeProvider.GetUtcNow().UtcDateTime, ct).ConfigureAwait(false);
+                    }
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    _logger.LogWarning(ex,
+                        "AuditProjector: tenant {TenantId} domain projection failed; "
+                        + "continuing with the remaining tenants.", tid);
+                }
+            }
         }
 
-        foreach (var raw in platform)
+        // ── Platform (cross-tenant / platform-only) projection — sentinel row ──
+        var platformCursor = await repo.LoadCursorAsync(
+            cp, _options.ProjectorId, AuditProjectorCursor.PlatformSentinel, ct).ConfigureAwait(false);
+        var platform = await cp.PlatformEvents.AsNoTracking()
+            .Where(e => e.SequenceNumber > platformCursor.LastPlatformSequenceNumber)
+            .OrderBy(e => e.SequenceNumber)
+            .Take(_options.BatchSize)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        var (platInserted, maxPlatformSeq) = await ProjectStreamAsync(
+            platform.Select(RawAuditEvent.From), projector, repo, cp, factory,
+            mode, singleUserOwnerId, platformCursor.LastPlatformSequenceNumber, ct)
+            .ConfigureAwait(false);
+        inserted += platInserted;
+        totalScanned += platform.Count;
+
+        long platformResidual = 0;
+        if (platform.Count >= _options.BatchSize)
         {
-            if (ct.IsCancellationRequested) break;
-            if (await ProjectOneAsync(
-                    RawAuditEvent.From(raw), projector, repo, cp, factory,
-                    mode, singleUserOwnerId, ct).ConfigureAwait(false))
-            {
-                inserted++;
-            }
-            if (raw.SequenceNumber > maxPlatformSeq) maxPlatformSeq = raw.SequenceNumber;
+            var head = await cp.PlatformEvents.AsNoTracking()
+                .MaxAsync(e => (long?)e.SequenceNumber, ct).ConfigureAwait(false) ?? 0L;
+            platformResidual = Math.Max(0, head - maxPlatformSeq);
         }
 
-        var scanned = domain.Count + platform.Count;
-        if (scanned > 0)
+        if (platform.Count > 0)
         {
+            // Preserve the sentinel row's domain-fallback mark (set above for the
+            // shared-DB path); only the platform-stream mark changes here.
             await repo.SaveCursorAsync(
-                cp, _options.ProjectorId, maxDomainSeq, maxPlatformSeq,
+                cp, _options.ProjectorId, AuditProjectorCursor.PlatformSentinel,
+                platformCursor.LastDomainSequenceNumber, maxPlatformSeq,
                 _timeProvider.GetUtcNow().UtcDateTime, ct).ConfigureAwait(false);
         }
 
-        await RecordLagAsync(cp, factory, maxDomainSeq, maxPlatformSeq, ct).ConfigureAwait(false);
+        // Lag (I2) — derived from the heads we already touched + the sampled
+        // residual, with no second blanket MAX(SequenceNumber) fan-out on the
+        // common (fully-caught-up) path.
+        var lag = domainResidual + platformResidual;
+        _metrics.RecordLag(lag);
+        if (lag > _options.LagWarnThreshold)
+        {
+            _logger.LogWarning(
+                "AuditProjector lag {Lag} exceeds threshold {Threshold}.",
+                lag, _options.LagWarnThreshold);
+        }
 
         var durationMs = (_timeProvider.GetUtcNow().UtcDateTime - startedAt).TotalMilliseconds;
         _logger.LogInformation(
-            "AuditProjector batch complete — projectorId={ProjectorId} domainCursor={DomainCursor} "
+            "AuditProjector batch complete — projectorId={ProjectorId} domainHead={DomainHead} "
             + "platformCursor={PlatformCursor} eventsScanned={Scanned} recordsInserted={Inserted} "
-            + "recordsSkipped={Skipped} batchDurationMs={DurationMs}",
-            _options.ProjectorId, maxDomainSeq, maxPlatformSeq, scanned, inserted,
-            scanned - inserted, (long)durationMs);
+            + "lag={Lag} batchDurationMs={DurationMs}",
+            _options.ProjectorId, domainHeadFromScan, maxPlatformSeq, totalScanned, inserted,
+            lag, (long)durationMs);
 
         return inserted;
+    }
+
+    /// <summary>
+    /// Project one ordered stream (a single tenant's domain events, or the
+    /// platform stream). Returns the rows inserted and the max sequence number
+    /// reached (the new high-water mark for THAT stream's cursor). Every scanned
+    /// event advances the mark — including non-catalog skips (AC7) and quarantine
+    /// rows (C2) — so the cursor never stalls and never re-scans a handled event.
+    /// </summary>
+    private async Task<(int Inserted, long MaxSeq)> ProjectStreamAsync(
+        IEnumerable<RawAuditEvent> events,
+        IAuditProjector projector,
+        IAuditRecordRepository repo,
+        ControlPlaneDbContext cp,
+        ITenantDbContextFactory? factory,
+        AuditOwnershipMode mode,
+        Guid? singleUserOwnerId,
+        long startSeq,
+        CancellationToken ct)
+    {
+        var inserted = 0;
+        var maxSeq = startSeq;
+        foreach (var raw in events)
+        {
+            if (ct.IsCancellationRequested) break;
+            if (await ProjectOneAsync(
+                    raw, projector, repo, cp, factory, mode, singleUserOwnerId, ct)
+                .ConfigureAwait(false))
+            {
+                inserted++;
+            }
+            if (raw.SequenceNumber > maxSeq) maxSeq = raw.SequenceNumber;
+        }
+        return (inserted, maxSeq);
     }
 
     private async Task<bool> ProjectOneAsync(
@@ -205,14 +362,35 @@ public sealed class AuditProjectorBackgroundService : BackgroundService
         }
         catch (Exception ex)
         {
-            // AC10 / Logging — if classification or redaction throws, FAIL the
-            // row and do NOT advance past it silently. We log ERROR; the row is
-            // not persisted. (The cursor still advances over the batch's max
-            // sequence; a re-run re-attempts via the un-inserted source id.)
-            _logger.LogError(ex,
+            // C2 — classification / redaction threw. QUARANTINE: do NOT drop and
+            // do NOT halt. Build a minimal placeholder row keyed by the same
+            // source_event_id (idempotency holds), with a SAFE payload + outcome
+            // "failure", then let the cursor advance past it. The action stays
+            // recorded; a poison-pill payload (e.g. RegexMatchTimeoutException
+            // from a pathological string) cannot stall the whole trail.
+            _logger.LogWarning(ex,
                 "AuditProjector failed to build/redact record for event {SourceEventId} ({Type}); "
-                + "row NOT persisted.", raw.Id, raw.Type);
-            return false;
+                + "writing a QUARANTINE row (safe placeholder payload) and advancing.",
+                raw.Id, raw.Type);
+            _metrics.RecordProjectionFailure();
+            try
+            {
+                var quarantine = projector.BuildQuarantineRecord(raw, mode, singleUserOwnerId);
+                return await InsertRoutedAsync(quarantine, mode, factory, repo, cp, raw, ct)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception qex)
+            {
+                // The quarantine write itself failed. Returning false here means
+                // the cursor still advances over the batch's max sequence (the
+                // event is not re-scanned), but the failure is loudly recorded so
+                // ops can replay it (truncate + reset cursor rebuilds the trail).
+                _logger.LogError(qex,
+                    "AuditProjector quarantine write FAILED for event {SourceEventId} ({Type}); "
+                    + "the curated trail is missing this event until a rebuild.",
+                    raw.Id, raw.Type);
+                return false;
+            }
         }
 
         if (record is null)
@@ -225,13 +403,8 @@ public sealed class AuditProjectorBackgroundService : BackgroundService
         // platform rows + all single-user rows go to the CP store.
         try
         {
-            if (mode == AuditOwnershipMode.SaaS && record.TenantId is Guid tenantId && factory is not null)
-            {
-                await using var tenantCtx = await factory.CreateAsync(tenantId, ct).ConfigureAwait(false);
-                return await repo.InsertIfAbsentAsync(tenantCtx, record, ct).ConfigureAwait(false);
-            }
-
-            return await repo.InsertIfAbsentAsync(cp, record, ct).ConfigureAwait(false);
+            return await InsertRoutedAsync(record, mode, factory, repo, cp, raw, ct)
+                .ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -243,64 +416,26 @@ public sealed class AuditProjectorBackgroundService : BackgroundService
     }
 
     /// <summary>
-    /// Read new tenant-scoped domain events strictly after the shared domain
-    /// cursor, ordered by <c>SequenceNumber</c>. Fans out across active tenants
-    /// via the factory (PR-D shape); falls back to <c>cp.DomainEvents</c> when no
-    /// factory is wired (single-user / transitional shared-DB). Read-only (AC15).
+    /// AC11 routing — write the record into the correct store. SaaS tenant-scoped
+    /// rows (TenantId set) go to the tenant schema via the factory; SaaS platform
+    /// rows + all single-user rows go to the CP store.
     /// </summary>
-    private async Task<List<DomainEvent>> ReadDomainEventsAsync(
-        ControlPlaneDbContext cp, ITenantDbContextFactory? factory, long afterSeq, CancellationToken ct)
+    private static async Task<bool> InsertRoutedAsync(
+        AuditRecord record,
+        AuditOwnershipMode mode,
+        ITenantDbContextFactory? factory,
+        IAuditRecordRepository repo,
+        ControlPlaneDbContext cp,
+        RawAuditEvent raw,
+        CancellationToken ct)
     {
-        if (factory is null)
+        if (mode == AuditOwnershipMode.SaaS && record.TenantId is Guid tenantId && factory is not null)
         {
-            return await cp.DomainEvents.AsNoTracking()
-                .Where(e => e.SequenceNumber > afterSeq)
-                .OrderBy(e => e.SequenceNumber)
-                .Take(_options.BatchSize)
-                .ToListAsync(ct)
-                .ConfigureAwait(false);
+            await using var tenantCtx = await factory.CreateAsync(tenantId, ct).ConfigureAwait(false);
+            return await repo.InsertIfAbsentAsync(tenantCtx, record, ct).ConfigureAwait(false);
         }
 
-        var tenantIds = await cp.Tenants.AsNoTracking()
-            .Where(t => t.DeletedAt == null)
-            .OrderBy(t => t.Id)
-            .Select(t => t.Id)
-            .ToListAsync(ct)
-            .ConfigureAwait(false);
-
-        var merged = new List<DomainEvent>();
-        foreach (var tid in tenantIds)
-        {
-            if (ct.IsCancellationRequested) break;
-            try
-            {
-                await using var tdb = await factory.CreateAsync(tid, ct).ConfigureAwait(false);
-                var rows = await tdb.DomainEvents.AsNoTracking()
-                    .Where(e => e.SequenceNumber > afterSeq)
-                    .OrderBy(e => e.SequenceNumber)
-                    .Take(_options.BatchSize)
-                    .ToListAsync(ct)
-                    .ConfigureAwait(false);
-                merged.AddRange(rows);
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                _logger.LogWarning(ex,
-                    "AuditProjector: tenant {TenantId} domain_events scan failed; "
-                    + "continuing with the remaining tenants.", tid);
-            }
-        }
-
-        // Global order across tenants: the BIGSERIAL identity is per-stream, so
-        // sort by SequenceNumber then CreatedAt for a deterministic interleave.
-        merged.Sort((a, b) =>
-        {
-            var c = a.SequenceNumber.CompareTo(b.SequenceNumber);
-            return c != 0 ? c : a.CreatedAt.CompareTo(b.CreatedAt);
-        });
-        if (merged.Count > _options.BatchSize)
-            merged.RemoveRange(_options.BatchSize, merged.Count - _options.BatchSize);
-        return merged;
+        return await repo.InsertIfAbsentAsync(cp, record, ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -308,66 +443,30 @@ public sealed class AuditProjectorBackgroundService : BackgroundService
     /// non-deleted user owns the instance. Returns null when no user exists yet
     /// (a fresh instance) — the projector then falls back to the event actor.
     /// </summary>
-    private static async Task<Guid?> ResolveSingleUserOwnerAsync(
+    private async Task<Guid?> ResolveSingleUserOwnerAsync(
         ControlPlaneDbContext cp, CancellationToken ct)
     {
-        return await cp.Users.AsNoTracking()
+        var owner = await cp.Users.AsNoTracking()
             .OrderBy(u => u.CreatedAt)
             .Select(u => (Guid?)u.Id)
             .FirstOrDefaultAsync(ct)
             .ConfigureAwait(false);
-    }
 
-    /// <summary>
-    /// AC9 — record the projection lag = (max raw SequenceNumber across both
-    /// streams) − (last projected). Reads the current stream heads read-only.
-    /// Domain head is the max across tenant schemas when fanning out.
-    /// </summary>
-    private async Task RecordLagAsync(
-        ControlPlaneDbContext cp, ITenantDbContextFactory? factory,
-        long projectedDomain, long projectedPlatform, CancellationToken ct)
-    {
-        long maxDomain;
-        if (factory is null)
+        // M3 — the "oldest user owns the instance" heuristic is only safe when
+        // there is exactly one user. If somehow >1 exists in single-user mode,
+        // ownership attribution may be wrong; surface it so ops can investigate.
+        if (owner is not null)
         {
-            maxDomain = await cp.DomainEvents.AsNoTracking()
-                .MaxAsync(e => (long?)e.SequenceNumber, ct).ConfigureAwait(false) ?? 0L;
-        }
-        else
-        {
-            maxDomain = 0L;
-            var tenantIds = await cp.Tenants.AsNoTracking()
-                .Where(t => t.DeletedAt == null).Select(t => t.Id)
-                .ToListAsync(ct).ConfigureAwait(false);
-            foreach (var tid in tenantIds)
+            var count = await cp.Users.AsNoTracking().CountAsync(ct).ConfigureAwait(false);
+            if (count > 1)
             {
-                try
-                {
-                    await using var tdb = await factory.CreateAsync(tid, ct).ConfigureAwait(false);
-                    var head = await tdb.DomainEvents.AsNoTracking()
-                        .MaxAsync(e => (long?)e.SequenceNumber, ct).ConfigureAwait(false) ?? 0L;
-                    if (head > maxDomain) maxDomain = head;
-                }
-                catch (Exception ex) when (ex is not OperationCanceledException)
-                {
-                    _logger.LogWarning(ex,
-                        "AuditProjector: lag scan for tenant {TenantId} failed; continuing.", tid);
-                }
+                _logger.LogWarning(
+                    "AuditProjector single-user owner resolution found {Count} users; "
+                    + "attributing audit rows to the oldest ({OwnerId}) may mis-attribute. "
+                    + "single-user mode expects exactly one user.", count, owner);
             }
         }
 
-        var maxPlatform = await cp.PlatformEvents.AsNoTracking()
-            .MaxAsync(e => (long?)e.SequenceNumber, ct).ConfigureAwait(false) ?? 0L;
-
-        var lag = Math.Max(0, maxDomain - projectedDomain)
-            + Math.Max(0, maxPlatform - projectedPlatform);
-        _metrics.RecordLag(lag);
-
-        if (lag > _options.LagWarnThreshold)
-        {
-            _logger.LogWarning(
-                "AuditProjector lag {Lag} exceeds threshold {Threshold}.",
-                lag, _options.LagWarnThreshold);
-        }
+        return owner;
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditProjectorBackgroundService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditProjectorBackgroundService.cs
@@ -1,0 +1,373 @@
+using Microsoft.EntityFrameworkCore;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Audit;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Audit;
+
+/// <summary>
+/// Story 37-1 (AC7–AC11, AC15) — background host that materializes the curated
+/// <c>audit_records</c> read-model from the immutable DCB stream. Structurally
+/// a near-clone of <c>AlertRuleEvaluator</c>: a cursor-tracked poll loop with a
+/// <see cref="AuditProjectorOptions.RunOnStartup"/> gate and per-tick
+/// crash-isolation.
+///
+/// <para><b>Read-only against the event store (AC15):</b> the loop only READS
+/// <c>cp.DomainEvents</c> / <c>cp.PlatformEvents</c> (and per-tenant
+/// <c>domain_events</c> via the factory) ordered by <c>SequenceNumber</c>; it
+/// NEVER appends, mutates, or deletes a raw event. The only writes are the
+/// curated <c>audit_records</c> rows and the projector cursor.</para>
+///
+/// <para><b>Scope routing (AC11):</b> SaaS tenant-scoped events (TenantId set)
+/// materialize into the tenant schema keyed by <c>tenant_id</c>; SaaS
+/// platform-only events (TenantId null) materialize into the CP
+/// <c>audit_records</c> with <c>tenant_id</c> null. Single-user events all
+/// materialize into the single CP store keyed by <c>user_id</c>.</para>
+/// </summary>
+public sealed class AuditProjectorBackgroundService : BackgroundService
+{
+    private readonly IServiceProvider _services;
+    private readonly AuditProjectorOptions _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly AuditProjectionMetrics _metrics;
+    private readonly ILogger<AuditProjectorBackgroundService> _logger;
+
+    public AuditProjectorBackgroundService(
+        IServiceProvider services,
+        AuditProjectorOptions options,
+        TimeProvider timeProvider,
+        AuditProjectionMetrics metrics,
+        ILogger<AuditProjectorBackgroundService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentNullException.ThrowIfNull(metrics);
+        ArgumentNullException.ThrowIfNull(logger);
+        _services = services;
+        _options = options;
+        _timeProvider = timeProvider;
+        _metrics = metrics;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_options.RunOnStartup)
+        {
+            _logger.LogDebug(
+                "AuditProjector gated off (RunOnStartup=false); polling loop will not start.");
+            return;
+        }
+
+        _logger.LogInformation(
+            "AuditProjector starting — poll every {Interval}s, batch {Batch}, projectorId '{Id}'.",
+            _options.PollInterval.TotalSeconds, _options.BatchSize, _options.ProjectorId);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await ProcessOnceAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                // Crash-isolate per tick — one bad batch logs and the loop survives.
+                _logger.LogWarning(ex, "AuditProjector tick threw and was crash-isolated; continuing.");
+            }
+
+            try
+            {
+                await Task.Delay(_options.PollInterval, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+
+        _logger.LogInformation("AuditProjector shut down.");
+    }
+
+    /// <summary>
+    /// Run a single projection tick. Public so tests can drive the projector
+    /// deterministically without the background loop. Returns the number of
+    /// curated rows inserted this tick.
+    /// </summary>
+    public async Task<int> ProcessOnceAsync(CancellationToken ct)
+    {
+        var startedAt = _timeProvider.GetUtcNow().UtcDateTime;
+        using var scope = _services.CreateScope();
+        var sp = scope.ServiceProvider;
+        var cp = sp.GetRequiredService<ControlPlaneDbContext>();
+        var projector = sp.GetRequiredService<IAuditProjector>();
+        var repo = sp.GetRequiredService<IAuditRecordRepository>();
+        var modeProvider = sp.GetRequiredService<ITammaModeProvider>();
+        var mode = modeProvider.Mode == TammaMode.SaaS
+            ? AuditOwnershipMode.SaaS
+            : AuditOwnershipMode.SingleUser;
+
+        var factory = sp.GetService<ITenantDbContextFactory>();
+        var cursor = await repo.LoadCursorAsync(cp, _options.ProjectorId, ct).ConfigureAwait(false);
+
+        // ── READ-ONLY scan of both streams, ordered by SequenceNumber (AC15) ──
+        //
+        // Domain (tenant-scoped) events: per-tenant fan-out via the factory
+        // mirrors AlertRuleEvaluator's PR-D shape — tenant domain_events live in
+        // each tenant's schema. The domain cursor is shared across tenants
+        // (per-stream-but-monotonic BIGSERIAL identity). When no factory is
+        // wired (single-user / transitional shared-DB), fall back to cp.DomainEvents.
+        var domain = await ReadDomainEventsAsync(cp, factory, cursor.LastDomainSequenceNumber, ct)
+            .ConfigureAwait(false);
+
+        // Platform (cross-tenant / platform-only) events: always CP-resident.
+        var platform = await cp.PlatformEvents.AsNoTracking()
+            .Where(e => e.SequenceNumber > cursor.LastPlatformSequenceNumber)
+            .OrderBy(e => e.SequenceNumber)
+            .Take(_options.BatchSize)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        Guid? singleUserOwnerId = mode == AuditOwnershipMode.SingleUser
+            ? await ResolveSingleUserOwnerAsync(cp, ct).ConfigureAwait(false)
+            : null;
+
+        var inserted = 0;
+        long maxDomainSeq = cursor.LastDomainSequenceNumber;
+        long maxPlatformSeq = cursor.LastPlatformSequenceNumber;
+
+        // Domain events first, in strict SequenceNumber order (37-2 needs it).
+        foreach (var raw in domain)
+        {
+            if (ct.IsCancellationRequested) break;
+            if (await ProjectOneAsync(
+                    RawAuditEvent.From(raw), projector, repo, cp, factory,
+                    mode, singleUserOwnerId, ct).ConfigureAwait(false))
+            {
+                inserted++;
+            }
+            if (raw.SequenceNumber > maxDomainSeq) maxDomainSeq = raw.SequenceNumber;
+        }
+
+        foreach (var raw in platform)
+        {
+            if (ct.IsCancellationRequested) break;
+            if (await ProjectOneAsync(
+                    RawAuditEvent.From(raw), projector, repo, cp, factory,
+                    mode, singleUserOwnerId, ct).ConfigureAwait(false))
+            {
+                inserted++;
+            }
+            if (raw.SequenceNumber > maxPlatformSeq) maxPlatformSeq = raw.SequenceNumber;
+        }
+
+        var scanned = domain.Count + platform.Count;
+        if (scanned > 0)
+        {
+            await repo.SaveCursorAsync(
+                cp, _options.ProjectorId, maxDomainSeq, maxPlatformSeq,
+                _timeProvider.GetUtcNow().UtcDateTime, ct).ConfigureAwait(false);
+        }
+
+        await RecordLagAsync(cp, factory, maxDomainSeq, maxPlatformSeq, ct).ConfigureAwait(false);
+
+        var durationMs = (_timeProvider.GetUtcNow().UtcDateTime - startedAt).TotalMilliseconds;
+        _logger.LogInformation(
+            "AuditProjector batch complete — projectorId={ProjectorId} domainCursor={DomainCursor} "
+            + "platformCursor={PlatformCursor} eventsScanned={Scanned} recordsInserted={Inserted} "
+            + "recordsSkipped={Skipped} batchDurationMs={DurationMs}",
+            _options.ProjectorId, maxDomainSeq, maxPlatformSeq, scanned, inserted,
+            scanned - inserted, (long)durationMs);
+
+        return inserted;
+    }
+
+    private async Task<bool> ProjectOneAsync(
+        RawAuditEvent raw,
+        IAuditProjector projector,
+        IAuditRecordRepository repo,
+        ControlPlaneDbContext cp,
+        ITenantDbContextFactory? factory,
+        AuditOwnershipMode mode,
+        Guid? singleUserOwnerId,
+        CancellationToken ct)
+    {
+        AuditRecord? record;
+        try
+        {
+            record = projector.TryBuildRecord(raw, mode, singleUserOwnerId);
+        }
+        catch (Exception ex)
+        {
+            // AC10 / Logging — if classification or redaction throws, FAIL the
+            // row and do NOT advance past it silently. We log ERROR; the row is
+            // not persisted. (The cursor still advances over the batch's max
+            // sequence; a re-run re-attempts via the un-inserted source id.)
+            _logger.LogError(ex,
+                "AuditProjector failed to build/redact record for event {SourceEventId} ({Type}); "
+                + "row NOT persisted.", raw.Id, raw.Type);
+            return false;
+        }
+
+        if (record is null)
+        {
+            _logger.LogDebug("AuditProjector skipped non-catalog event {Type}.", raw.Type);
+            return false; // AC7 — non-catalog skip.
+        }
+
+        // AC11 routing: SaaS tenant-scoped rows go to the tenant schema; SaaS
+        // platform rows + all single-user rows go to the CP store.
+        try
+        {
+            if (mode == AuditOwnershipMode.SaaS && record.TenantId is Guid tenantId && factory is not null)
+            {
+                await using var tenantCtx = await factory.CreateAsync(tenantId, ct).ConfigureAwait(false);
+                return await repo.InsertIfAbsentAsync(tenantCtx, record, ct).ConfigureAwait(false);
+            }
+
+            return await repo.InsertIfAbsentAsync(cp, record, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "AuditProjector insert failed for event {SourceEventId} ({Type}); continuing.",
+                raw.Id, raw.Type);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Read new tenant-scoped domain events strictly after the shared domain
+    /// cursor, ordered by <c>SequenceNumber</c>. Fans out across active tenants
+    /// via the factory (PR-D shape); falls back to <c>cp.DomainEvents</c> when no
+    /// factory is wired (single-user / transitional shared-DB). Read-only (AC15).
+    /// </summary>
+    private async Task<List<DomainEvent>> ReadDomainEventsAsync(
+        ControlPlaneDbContext cp, ITenantDbContextFactory? factory, long afterSeq, CancellationToken ct)
+    {
+        if (factory is null)
+        {
+            return await cp.DomainEvents.AsNoTracking()
+                .Where(e => e.SequenceNumber > afterSeq)
+                .OrderBy(e => e.SequenceNumber)
+                .Take(_options.BatchSize)
+                .ToListAsync(ct)
+                .ConfigureAwait(false);
+        }
+
+        var tenantIds = await cp.Tenants.AsNoTracking()
+            .Where(t => t.DeletedAt == null)
+            .OrderBy(t => t.Id)
+            .Select(t => t.Id)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        var merged = new List<DomainEvent>();
+        foreach (var tid in tenantIds)
+        {
+            if (ct.IsCancellationRequested) break;
+            try
+            {
+                await using var tdb = await factory.CreateAsync(tid, ct).ConfigureAwait(false);
+                var rows = await tdb.DomainEvents.AsNoTracking()
+                    .Where(e => e.SequenceNumber > afterSeq)
+                    .OrderBy(e => e.SequenceNumber)
+                    .Take(_options.BatchSize)
+                    .ToListAsync(ct)
+                    .ConfigureAwait(false);
+                merged.AddRange(rows);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex,
+                    "AuditProjector: tenant {TenantId} domain_events scan failed; "
+                    + "continuing with the remaining tenants.", tid);
+            }
+        }
+
+        // Global order across tenants: the BIGSERIAL identity is per-stream, so
+        // sort by SequenceNumber then CreatedAt for a deterministic interleave.
+        merged.Sort((a, b) =>
+        {
+            var c = a.SequenceNumber.CompareTo(b.SequenceNumber);
+            return c != 0 ? c : a.CreatedAt.CompareTo(b.CreatedAt);
+        });
+        if (merged.Count > _options.BatchSize)
+            merged.RemoveRange(_options.BatchSize, merged.Count - _options.BatchSize);
+        return merged;
+    }
+
+    /// <summary>
+    /// Resolve the sole user's id in single-user mode. The first (oldest)
+    /// non-deleted user owns the instance. Returns null when no user exists yet
+    /// (a fresh instance) — the projector then falls back to the event actor.
+    /// </summary>
+    private static async Task<Guid?> ResolveSingleUserOwnerAsync(
+        ControlPlaneDbContext cp, CancellationToken ct)
+    {
+        return await cp.Users.AsNoTracking()
+            .OrderBy(u => u.CreatedAt)
+            .Select(u => (Guid?)u.Id)
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// AC9 — record the projection lag = (max raw SequenceNumber across both
+    /// streams) − (last projected). Reads the current stream heads read-only.
+    /// Domain head is the max across tenant schemas when fanning out.
+    /// </summary>
+    private async Task RecordLagAsync(
+        ControlPlaneDbContext cp, ITenantDbContextFactory? factory,
+        long projectedDomain, long projectedPlatform, CancellationToken ct)
+    {
+        long maxDomain;
+        if (factory is null)
+        {
+            maxDomain = await cp.DomainEvents.AsNoTracking()
+                .MaxAsync(e => (long?)e.SequenceNumber, ct).ConfigureAwait(false) ?? 0L;
+        }
+        else
+        {
+            maxDomain = 0L;
+            var tenantIds = await cp.Tenants.AsNoTracking()
+                .Where(t => t.DeletedAt == null).Select(t => t.Id)
+                .ToListAsync(ct).ConfigureAwait(false);
+            foreach (var tid in tenantIds)
+            {
+                try
+                {
+                    await using var tdb = await factory.CreateAsync(tid, ct).ConfigureAwait(false);
+                    var head = await tdb.DomainEvents.AsNoTracking()
+                        .MaxAsync(e => (long?)e.SequenceNumber, ct).ConfigureAwait(false) ?? 0L;
+                    if (head > maxDomain) maxDomain = head;
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    _logger.LogWarning(ex,
+                        "AuditProjector: lag scan for tenant {TenantId} failed; continuing.", tid);
+                }
+            }
+        }
+
+        var maxPlatform = await cp.PlatformEvents.AsNoTracking()
+            .MaxAsync(e => (long?)e.SequenceNumber, ct).ConfigureAwait(false) ?? 0L;
+
+        var lag = Math.Max(0, maxDomain - projectedDomain)
+            + Math.Max(0, maxPlatform - projectedPlatform);
+        _metrics.RecordLag(lag);
+
+        if (lag > _options.LagWarnThreshold)
+        {
+            _logger.LogWarning(
+                "AuditProjector lag {Lag} exceeds threshold {Threshold}.",
+                lag, _options.LagWarnThreshold);
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditProjectorOptions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditProjectorOptions.cs
@@ -1,0 +1,34 @@
+namespace Tamma.Api.Services.Audit;
+
+/// <summary>
+/// Story 37-1 — options for <see cref="AuditProjectorBackgroundService"/>.
+/// Mirrors <c>AlertRuleEvaluatorOptions</c>.
+/// </summary>
+public sealed class AuditProjectorOptions
+{
+    /// <summary>How often the projector polls for new DCB events. Default 5s —
+    /// audit materialization is eventual (AC9), not real-time.</summary>
+    public TimeSpan PollInterval { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>Rows scanned per stream per tick.</summary>
+    public int BatchSize { get; set; } = 500;
+
+    /// <summary>Stable id for this logical projector — one row per id in
+    /// <c>audit_projector_cursor</c>.</summary>
+    public string ProjectorId { get; set; } = "default";
+
+    /// <summary>
+    /// When <c>true</c> the projector's polling loop runs once the host starts.
+    /// <b>Default is <c>false</c></b> so the background loop does NOT run during
+    /// the test suite (and during deployments that have not opted in) and cause
+    /// interference/flakiness. Production opts in explicitly. Tests that drive
+    /// <see cref="AuditProjectorBackgroundService.ProcessOnceAsync"/> directly
+    /// never need the loop. Mirrors the <c>RunOnStartup</c> gate on
+    /// <c>AlertRuleEvaluatorOptions</c> (which defaults true), but flipped to a
+    /// safe-off default per the Story 37-1 brief.
+    /// </summary>
+    public bool RunOnStartup { get; set; }
+
+    /// <summary>Lag (in events) above which a WARN is logged. Default 10 000.</summary>
+    public long LagWarnThreshold { get; set; } = 10_000;
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingCatalog.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingCatalog.cs
@@ -1,0 +1,74 @@
+using System.Collections.Concurrent;
+using Microsoft.EntityFrameworkCore;
+using Tamma.Core;
+using Tamma.Data;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-1 — EF-backed <see cref="IBillingCatalog"/> with a short in-process
+/// cache. The catalog is platform-global and slug-keyed, so a process-wide cache
+/// is safe (no per-tenant leakage). Entries expire after a minute so a fresh
+/// <c>seed-billing</c> run is observed promptly.
+/// </summary>
+public sealed class BillingCatalog : IBillingCatalog
+{
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(1);
+
+    private readonly IDbContextFactory<ControlPlaneDbContext> _dbFactory;
+    private readonly TimeProvider _timeProvider;
+    private readonly ConcurrentDictionary<string, CacheEntry> _cache =
+        new(StringComparer.Ordinal);
+
+    public BillingCatalog(
+        IDbContextFactory<ControlPlaneDbContext> dbFactory,
+        TimeProvider? timeProvider = null)
+    {
+        ArgumentNullException.ThrowIfNull(dbFactory);
+        _dbFactory = dbFactory;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    /// <inheritdoc />
+    public async Task<BillingPlanPrice> GetBySlugAsync(
+        string planSlug, CancellationToken ct = default)
+    {
+        var row = await TryGetBySlugAsync(planSlug, ct).ConfigureAwait(false);
+        if (row is null)
+        {
+            throw new TammaError(
+                "BILLING.CATALOG.UNKNOWN_SLUG",
+                $"No billing catalog row for plan slug '{planSlug}'. "
+                + "Run `seed-billing` to populate the Stripe catalog, or check the slug.",
+                new Dictionary<string, object?> { ["planSlug"] = planSlug },
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+        }
+        return row;
+    }
+
+    /// <inheritdoc />
+    public async Task<BillingPlanPrice?> TryGetBySlugAsync(
+        string planSlug, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(planSlug);
+
+        var now = _timeProvider.GetUtcNow();
+        if (_cache.TryGetValue(planSlug, out var cached) && cached.ExpiresAt > now)
+        {
+            return cached.Row;
+        }
+
+        await using var db = await _dbFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+        var row = await db.BillingPlanPrices
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.PlanSlug == planSlug, ct)
+            .ConfigureAwait(false);
+
+        _cache[planSlug] = new CacheEntry(row, now.Add(CacheTtl));
+        return row;
+    }
+
+    private readonly record struct CacheEntry(BillingPlanPrice? Row, DateTimeOffset ExpiresAt);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingEvents.cs
@@ -1,0 +1,79 @@
+using System.Text.Json;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-1 (AC8) — builds the DCB <see cref="DomainEvent"/> rows for the two
+/// billing events, in the same shape as <c>OrgEndpoints.EmitTenantEvent</c>
+/// (Metadata <c>{"workflowVersion":"1.0.0","eventSource":"system"}</c>; Tags +
+/// Data JSON-serialized). Event types follow the
+/// <c>AGGREGATE.ACTION.STATUS</c> convention.
+///
+/// <para>Routing is handled by <c>IEventRepository.AppendAsync</c>:
+/// <c>BILLING.CUSTOMER.CREATED</c> carries a non-null <c>TenantId</c> so it
+/// lands in the tenant's event store; <c>BILLING.PLAN_CATALOG.SYNCED</c> is
+/// platform-scoped (<c>TenantId</c> null) so it routes to
+/// <c>platform_events</c>.</para>
+/// </summary>
+public static class BillingEvents
+{
+    public const string CustomerCreatedType = "BILLING.CUSTOMER.CREATED";
+    public const string PlanCatalogSyncedType = "BILLING.PLAN_CATALOG.SYNCED";
+
+    private const string SystemMetadata =
+        """{"workflowVersion":"1.0.0","eventSource":"system"}""";
+
+    /// <summary>
+    /// <c>BILLING.CUSTOMER.CREATED</c> — emitted only on a real success (Stripe
+    /// customer created + row persisted). Tags <c>{ tenantId, stripeCustomerId,
+    /// billingMode }</c>; <c>TenantId</c> set.
+    /// </summary>
+    public static DomainEvent CustomerCreated(
+        Guid tenantId, string? stripeCustomerId, string billingMode) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Type = CustomerCreatedType,
+            TenantId = tenantId,
+            Tags = JsonSerializer.Serialize(new
+            {
+                tenantId = tenantId.ToString("D"),
+                stripeCustomerId,
+                billingMode,
+            }),
+            Metadata = SystemMetadata,
+            Data = JsonSerializer.Serialize(new
+            {
+                stripeCustomerId,
+                billingMode,
+            }),
+            CreatedAt = DateTime.UtcNow,
+        };
+
+    /// <summary>
+    /// <c>BILLING.PLAN_CATALOG.SYNCED</c> — emitted per slug after a successful
+    /// catalog sync. Tags <c>{ planSlug, source: "seed" }</c>; platform-scoped
+    /// (<c>TenantId</c> null).
+    /// </summary>
+    public static DomainEvent PlanCatalogSynced(string planSlug, int created, int reused) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Type = PlanCatalogSyncedType,
+            TenantId = null,
+            Tags = JsonSerializer.Serialize(new
+            {
+                planSlug,
+                source = "seed",
+            }),
+            Metadata = SystemMetadata,
+            Data = JsonSerializer.Serialize(new
+            {
+                planSlug,
+                created,
+                reused,
+            }),
+            CreatedAt = DateTime.UtcNow,
+        };
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingOptions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingOptions.cs
@@ -1,0 +1,33 @@
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-1 — bound billing configuration. The Stripe secret key and the
+/// webhook signing secret are resolved at runtime through the Epic 29 cabinet
+/// (<c>IRuntimeSecretResolver</c>) by the cabinet names below — never read raw
+/// from <c>IConfiguration</c> in production. Only non-secret knobs (cabinet
+/// names, default currency) bind from config.
+///
+/// <para>Bound from the <c>Billing</c> configuration section in
+/// <c>BillingServiceCollectionExtensions.AddTammaBilling</c>.</para>
+/// </summary>
+public sealed class BillingOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "Billing";
+
+    /// <summary>
+    /// Cabinet name for the Stripe secret API key — a platform-scoped
+    /// (<c>SecretScope.Platform</c>, <c>SecretPurpose.ApiKey</c>) cabinet row.
+    /// </summary>
+    public string StripeSecretKeyCabinetName { get; set; } = "billing/stripe-secret-key";
+
+    /// <summary>
+    /// Cabinet name for the Stripe webhook signing secret — a platform-scoped
+    /// (<c>SecretScope.Platform</c>, <c>SecretPurpose.Webhook</c>) cabinet row.
+    /// This story only stores the <i>reference</i>; webhook ingestion is 35-5.
+    /// </summary>
+    public string StripeWebhookSecretCabinetName { get; set; } = "billing/stripe-webhook-secret";
+
+    /// <summary>Default ISO-4217 settlement currency for new customers/prices.</summary>
+    public string DefaultCurrency { get; set; } = "usd";
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingSeeder.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingSeeder.cs
@@ -1,0 +1,308 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Stripe;
+using Stripe.Billing;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-1 (AC7) — idempotently syncs the Stripe catalog for every plan slug:
+/// one Product + base Price per slug, three shared Billing Meters
+/// (<c>tamma.platform_tokens_input</c> SUM, <c>tamma.platform_tokens_output</c>
+/// SUM, <c>tamma.seats</c> LAST/gauge) created once and referenced by every
+/// slug, and a metered Price per slug per meter. The ids are written into
+/// <c>billing_plan_prices</c> (insert-if-absent / update-existing).
+///
+/// <para>Re-running is a no-op (AC7): the seeder reuses ids already stored in
+/// <c>billing_plan_prices</c> (lookup-by-stored-id) and otherwise mints objects
+/// with deterministic <see cref="RequestOptions.IdempotencyKey"/>s
+/// (<c>billing-catalog-{slug}-{resource}</c>) so a retry never creates a
+/// duplicate. The three meters are created once and shared — their event names
+/// are globally unique so a second run reuses the stored ids.</para>
+///
+/// <para>Lives in <c>Tamma.Api</c> (not <c>Tamma.Data/Seeders</c>) because it
+/// needs the Stripe SDK + the DCB event helper, neither of which the data layer
+/// references. Plain class — not auto-run at startup; the <c>seed-billing</c>
+/// CLI command is the only trigger (Stripe calls must be operator-initiated).</para>
+/// </summary>
+public sealed class BillingSeeder
+{
+    // The three platform-wide meter definitions (shared across all slugs).
+    private const string TokensInputEventName = "tamma.platform_tokens_input";
+    private const string TokensOutputEventName = "tamma.platform_tokens_output";
+    private const string SeatsEventName = "tamma.seats";
+
+    private static readonly string[] s_planSlugs = ["free", "team", "enterprise"];
+
+    private readonly IStripeServices _stripe;
+    private readonly ControlPlaneDbContext _db;
+    private readonly IEventRepository _events;
+    private readonly BillingOptions _options;
+    private readonly ILogger _logger;
+
+    public BillingSeeder(
+        IStripeServices stripe,
+        ControlPlaneDbContext db,
+        IEventRepository events,
+        BillingOptions options,
+        ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(stripe);
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(events);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _stripe = stripe;
+        _db = db;
+        _events = events;
+        _options = options;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Sync the catalog for all plan slugs. Returns per-slug created/reused
+    /// counts; emits one <c>BILLING.PLAN_CATALOG.SYNCED</c> per slug.
+    /// </summary>
+    public async Task<CatalogSyncResult> SyncAsync(CancellationToken ct = default)
+    {
+        // Meters are platform-wide — create once, reuse across slugs. The first
+        // existing catalog row that already carries meter ids supplies them; a
+        // fresh install creates them once here.
+        var (meters, metersCreated) = await EnsureMetersAsync(ct).ConfigureAwait(false);
+
+        var slugResults = new List<CatalogSlugResult>();
+        var first = true;
+        foreach (var slug in s_planSlugs)
+        {
+            // Charge the one-time meter creation against the first slug's count
+            // so the platform-wide objects are reflected somewhere.
+            var meterCreateBudget = first ? metersCreated : 0;
+            first = false;
+
+            var result = await SyncSlugAsync(slug, meters, meterCreateBudget, ct)
+                .ConfigureAwait(false);
+            slugResults.Add(result);
+
+            await _events.AppendAsync(
+                BillingEvents.PlanCatalogSynced(slug, result.Created, result.Reused))
+                .ConfigureAwait(false);
+        }
+
+        await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Billing catalog synced: {Slugs} slugs, created={Created}, reused={Reused}.",
+            slugResults.Count, slugResults.Sum(s => s.Created), slugResults.Sum(s => s.Reused));
+
+        return new CatalogSyncResult(slugResults);
+    }
+
+    /// <summary>
+    /// Resolve the three shared meter ids — reuse ids already stored on any
+    /// catalog row; otherwise create them once. Returns the meter ids + how many
+    /// were newly created.
+    /// </summary>
+    private async Task<(MeterIds Ids, int Created)> EnsureMetersAsync(CancellationToken ct)
+    {
+        var anyRow = await _db.BillingPlanPrices
+            .FirstOrDefaultAsync(
+                r => r.TokensInputMeterId != null
+                     && r.TokensOutputMeterId != null
+                     && r.SeatsMeterId != null,
+                ct)
+            .ConfigureAwait(false);
+        if (anyRow is not null)
+        {
+            return (new MeterIds(
+                anyRow.TokensInputMeterId!,
+                anyRow.TokensOutputMeterId!,
+                anyRow.SeatsMeterId!), 0);
+        }
+
+        var tokensIn = await CreateMeterAsync(
+            TokensInputEventName, "Tamma platform input tokens", "sum", ct).ConfigureAwait(false);
+        var tokensOut = await CreateMeterAsync(
+            TokensOutputEventName, "Tamma platform output tokens", "sum", ct).ConfigureAwait(false);
+        var seats = await CreateMeterAsync(
+            SeatsEventName, "Tamma seats", "last", ct).ConfigureAwait(false);
+
+        return (new MeterIds(tokensIn, tokensOut, seats), 3);
+    }
+
+    private async Task<string> CreateMeterAsync(
+        string eventName, string displayName, string formula, CancellationToken ct)
+    {
+        var options = new MeterCreateOptions
+        {
+            DisplayName = displayName,
+            EventName = eventName,
+            DefaultAggregation = new MeterDefaultAggregationOptions { Formula = formula },
+        };
+        // 'count' takes no value settings; 'sum'/'last' read a payload value.
+        if (formula is "sum" or "last")
+        {
+            options.ValueSettings = new MeterValueSettingsOptions { EventPayloadKey = "value" };
+        }
+
+        var idempotencyKey = $"billing-catalog-meter-{eventName}";
+        _logger.LogDebug(
+            "Creating Stripe meter event={EventName} formula={Formula} (idempotencyKey set).",
+            eventName, formula);
+
+        var meter = await _stripe.Meters
+            .CreateAsync(options, new RequestOptions { IdempotencyKey = idempotencyKey }, ct)
+            .ConfigureAwait(false);
+        return meter.Id;
+    }
+
+    private async Task<CatalogSlugResult> SyncSlugAsync(
+        string slug, MeterIds meters, int meterCreateBudget, CancellationToken ct)
+    {
+        var row = await _db.BillingPlanPrices
+            .FirstOrDefaultAsync(r => r.PlanSlug == slug, ct)
+            .ConfigureAwait(false);
+
+        var now = DateTime.UtcNow;
+        var isNewRow = row is null;
+        row ??= new BillingPlanPrice
+        {
+            Id = Guid.NewGuid(),
+            PlanSlug = slug,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+
+        var created = meterCreateBudget;
+        var reused = 0;
+
+        // Shared meter ids on every row (idempotent assignment).
+        row.TokensInputMeterId = meters.TokensInput;
+        row.TokensOutputMeterId = meters.TokensOutput;
+        row.SeatsMeterId = meters.Seats;
+
+        // Product — deterministic id so a re-run reuses it.
+        if (string.IsNullOrEmpty(row.StripeProductId))
+        {
+            row.StripeProductId = await CreateProductAsync(slug, ct).ConfigureAwait(false);
+            created++;
+        }
+        else
+        {
+            reused++;
+        }
+
+        // Base flat (per-seat / platform) recurring price.
+        if (string.IsNullOrEmpty(row.StripePriceId))
+        {
+            row.StripePriceId = await CreateBasePriceAsync(slug, row.StripeProductId!, ct)
+                .ConfigureAwait(false);
+            created++;
+        }
+        else
+        {
+            reused++;
+        }
+
+        // Three metered prices (one per meter), each pointing at the shared meter.
+        (row.TokensInputPriceId, var tic, var tir) = await EnsureMeteredPriceAsync(
+            slug, "tokens-input", row.StripeProductId!, meters.TokensInput,
+            row.TokensInputPriceId, ct).ConfigureAwait(false);
+        created += tic; reused += tir;
+
+        (row.TokensOutputPriceId, var toc, var tor) = await EnsureMeteredPriceAsync(
+            slug, "tokens-output", row.StripeProductId!, meters.TokensOutput,
+            row.TokensOutputPriceId, ct).ConfigureAwait(false);
+        created += toc; reused += tor;
+
+        (row.SeatsPriceId, var sc, var sr) = await EnsureMeteredPriceAsync(
+            slug, "seats", row.StripeProductId!, meters.Seats,
+            row.SeatsPriceId, ct).ConfigureAwait(false);
+        created += sc; reused += sr;
+
+        row.UpdatedAt = now;
+        if (isNewRow) _db.BillingPlanPrices.Add(row);
+
+        return new CatalogSlugResult(slug, created, reused);
+    }
+
+    private async Task<string> CreateProductAsync(string slug, CancellationToken ct)
+    {
+        var options = new ProductCreateOptions
+        {
+            Id = $"tamma-plan-{slug}",
+            Name = $"Tamma {char.ToUpperInvariant(slug[0])}{slug[1..]}",
+            Description = $"Tamma {slug} plan",
+            Metadata = new Dictionary<string, string> { ["tammaPlanSlug"] = slug },
+        };
+        var product = await _stripe.Products
+            .CreateAsync(options,
+                new RequestOptions { IdempotencyKey = $"billing-catalog-{slug}-product" }, ct)
+            .ConfigureAwait(false);
+        return product.Id;
+    }
+
+    private async Task<string> CreateBasePriceAsync(string slug, string productId, CancellationToken ct)
+    {
+        var options = new PriceCreateOptions
+        {
+            Product = productId,
+            Currency = _options.DefaultCurrency,
+            // Base price amount is owned by Story 34-1's price-book; 0 here is a
+            // placeholder recurring line — this story wires the binding, not the
+            // rate. Recurring monthly licensed seat line.
+            UnitAmount = 0,
+            Recurring = new PriceRecurringOptions
+            {
+                Interval = "month",
+                UsageType = "licensed",
+            },
+            Nickname = $"tamma-{slug}-base",
+            Metadata = new Dictionary<string, string> { ["tammaPlanSlug"] = slug },
+        };
+        var price = await _stripe.Prices
+            .CreateAsync(options,
+                new RequestOptions { IdempotencyKey = $"billing-catalog-{slug}-price-base" }, ct)
+            .ConfigureAwait(false);
+        return price.Id;
+    }
+
+    private async Task<(string Id, int Created, int Reused)> EnsureMeteredPriceAsync(
+        string slug, string resource, string productId, string meterId,
+        string? existingPriceId, CancellationToken ct)
+    {
+        if (!string.IsNullOrEmpty(existingPriceId))
+        {
+            return (existingPriceId, 0, 1);
+        }
+
+        var options = new PriceCreateOptions
+        {
+            Product = productId,
+            Currency = _options.DefaultCurrency,
+            UnitAmount = 0,
+            Recurring = new PriceRecurringOptions
+            {
+                Interval = "month",
+                UsageType = "metered",
+                Meter = meterId,
+            },
+            Nickname = $"tamma-{slug}-{resource}",
+            Metadata = new Dictionary<string, string>
+            {
+                ["tammaPlanSlug"] = slug,
+                ["tammaMeteredResource"] = resource,
+            },
+        };
+        var price = await _stripe.Prices
+            .CreateAsync(options,
+                new RequestOptions { IdempotencyKey = $"billing-catalog-{slug}-price-{resource}" }, ct)
+            .ConfigureAwait(false);
+        return (price.Id, 1, 0);
+    }
+
+    private readonly record struct MeterIds(string TokensInput, string TokensOutput, string Seats);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingSeeder.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingSeeder.cs
@@ -231,9 +231,29 @@ public sealed class BillingSeeder
 
     private async Task<string> CreateProductAsync(string slug, CancellationToken ct)
     {
+        var productId = $"tamma-plan-{slug}";
+
+        // Get-or-create. The Product uses a FIXED id, so if the control-plane DB
+        // was reset but Stripe still holds the product (and the 24h idempotency
+        // window has lapsed), a bare CreateAsync would 400 "resource already
+        // exists" instead of replaying. Probe by id first and reuse it if present;
+        // only create when Stripe reports it absent (404 / resource_missing).
+        try
+        {
+            var existing = await _stripe.Products.GetAsync(productId, null, null, ct)
+                .ConfigureAwait(false);
+            _logger.LogDebug(
+                "Reusing existing Stripe product {ProductId} for slug {Slug}.", productId, slug);
+            return existing.Id;
+        }
+        catch (StripeException ex) when (ex.HttpStatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            // Not present in Stripe — fall through to create.
+        }
+
         var options = new ProductCreateOptions
         {
-            Id = $"tamma-plan-{slug}",
+            Id = productId,
             Name = $"Tamma {char.ToUpperInvariant(slug[0])}{slug[1..]}",
             Description = $"Tamma {slug} plan",
             Metadata = new Dictionary<string, string> { ["tammaPlanSlug"] = slug },

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingTenantCreateHook.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingTenantCreateHook.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Tamma.Api.Services.Billing.Tasks;
+using Tamma.Core.Billing;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-1 (AC6) — the shared, non-blocking tenant-create billing hook,
+/// invoked by both <c>OrgEndpoints.CreateOrg</c> and the registration path in
+/// <c>AuthEndpoints</c>. Centralising it keeps the two call sites identical and
+/// the failure policy in one place.
+///
+/// <para>Behaviour:</para>
+/// <list type="bullet">
+///   <item>Single-user (<c>IBillingProvider.IsEnabled == false</c>): complete
+///     no-op — no row, no event, no Stripe call.</item>
+///   <item>SaaS happy path: creates the Stripe customer + <c>BillingCustomer</c>
+///     row and emits <c>BILLING.CUSTOMER.CREATED</c> (done inside the
+///     provider).</item>
+///   <item>SaaS Stripe failure: tenant creation is NEVER blocked — a
+///     <c>billing.customer.create</c> <see cref="PlatformQueuedTask"/> is
+///     enqueued for retry and a WARN is logged. The customer row is filled in by
+///     the retry handler on a later attempt.</item>
+/// </list>
+/// </summary>
+public static class BillingTenantCreateHook
+{
+    /// <summary>
+    /// Try to create the Stripe customer for a freshly-created tenant. Never
+    /// throws back to the caller on a Stripe failure — enqueues a retry instead.
+    /// </summary>
+    public static async Task RunAsync(
+        IBillingProvider billing,
+        IPlatformQueuedTaskRepository platformTasks,
+        ILoggerFactory loggerFactory,
+        Tenant tenant,
+        string? ownerEmail,
+        BillingMode mode = BillingMode.PlatformProvided,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(billing);
+        ArgumentNullException.ThrowIfNull(platformTasks);
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+        ArgumentNullException.ThrowIfNull(tenant);
+
+        if (!billing.IsEnabled)
+        {
+            // Single-user — billing is SaaS-only; nothing to do.
+            return;
+        }
+
+        var logger = loggerFactory.CreateLogger(typeof(BillingTenantCreateHook).FullName!);
+        try
+        {
+            await billing.CreateCustomerAsync(
+                tenant.Id,
+                new CustomerDescriptor(tenant.Name, tenant.Slug, ownerEmail, mode),
+                ct)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Stripe unreachable / rate-limited / transient. DO NOT block tenant
+            // creation — enqueue a retry. Never log the exception's full detail
+            // at this site (could carry config); the error class is enough.
+            await platformTasks.EnqueueAsync(new PlatformQueuedTask
+            {
+                Type = CreateBillingCustomerTaskHandler.TaskTypeName,
+                TenantId = tenant.Id,
+                Payload = JsonSerializer.Serialize(
+                    new CreateBillingCustomerTaskPayload(tenant.Id)),
+            }, ct)
+                .ConfigureAwait(false);
+
+            logger.LogWarning(
+                "Stripe customer create failed for tenant {TenantId} ({ErrorClass}); "
+                + "enqueued billing.customer.create retry — tenant creation not blocked.",
+                tenant.Id, ex.GetType().Name);
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingTenantCreateHook.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingTenantCreateHook.cs
@@ -1,5 +1,7 @@
+using System.Net.Http;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Stripe;
 using Tamma.Api.Services.Billing.Tasks;
 using Tamma.Core.Billing;
 using Tamma.Data.Entities;
@@ -24,6 +26,21 @@ namespace Tamma.Api.Services.Billing;
 ///     <c>billing.customer.create</c> <see cref="PlatformQueuedTask"/> is
 ///     enqueued for retry and a WARN is logged. The customer row is filled in by
 ///     the retry handler on a later attempt.</item>
+/// </list>
+///
+/// <para>Error scoping (deliberate — this hook is copied into later billing
+/// stories, so it must not launder errors):</para>
+/// <list type="bullet">
+///   <item><see cref="OperationCanceledException"/> (request aborted / shutdown)
+///     is rethrown untouched — it is NOT a Stripe failure and must not become a
+///     misleading WARN or a spurious retry.</item>
+///   <item>Expected/transient Stripe failures
+///     (<see cref="StripeException"/>, <see cref="TimeoutException"/>,
+///     <see cref="HttpRequestException"/>) → enqueue retry + WARN.</item>
+///   <item>Any other unexpected exception (e.g. a real bug in the row-persist)
+///     still enqueues the retry so tenant-create is never blocked, but is logged
+///     at ERROR with a DISTINCT message so the defect is surfaced rather than
+///     buried under a Stripe-shaped WARN.</item>
 /// </list>
 /// </summary>
 public static class BillingTenantCreateHook
@@ -61,24 +78,67 @@ public static class BillingTenantCreateHook
                 ct)
                 .ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (OperationCanceledException)
         {
-            // Stripe unreachable / rate-limited / transient. DO NOT block tenant
-            // creation — enqueue a retry. Never log the exception's full detail
-            // at this site (could carry config); the error class is enough.
-            await platformTasks.EnqueueAsync(new PlatformQueuedTask
-            {
-                Type = CreateBillingCustomerTaskHandler.TaskTypeName,
-                TenantId = tenant.Id,
-                Payload = JsonSerializer.Serialize(
-                    new CreateBillingCustomerTaskPayload(tenant.Id)),
-            }, ct)
-                .ConfigureAwait(false);
+            // Request aborted / shutdown — NOT a Stripe failure. Never launder a
+            // cancellation into a "Stripe failed" WARN + retry: it would bury the
+            // real cause and enqueue a spurious task. Propagate it untouched so the
+            // caller's cancellation contract holds. (Stripe's SDK rethrows
+            // OperationCanceledException raw rather than wrapping it in a
+            // StripeException, so it never reaches the catch blocks below.)
+            throw;
+        }
+        catch (Exception ex) when (IsExpectedStripeFailure(ex))
+        {
+            // Expected Stripe failure: unreachable / rate-limited / transient
+            // network. DO NOT block tenant creation — enqueue a retry. Never log
+            // the exception's full detail at this site (could carry config); the
+            // error class is enough.
+            await EnqueueRetryAsync(platformTasks, tenant.Id, ct).ConfigureAwait(false);
 
             logger.LogWarning(
                 "Stripe customer create failed for tenant {TenantId} ({ErrorClass}); "
                 + "enqueued billing.customer.create retry — tenant creation not blocked.",
                 tenant.Id, ex.GetType().Name);
         }
+        catch (Exception ex)
+        {
+            // Unexpected (non-Stripe) error — e.g. a NullReferenceException or a
+            // bug in the row-persist. The "tenant-create is never blocked"
+            // guarantee still holds (we enqueue the retry), but we log at ERROR
+            // with a DISTINCT message so a real defect is surfaced, not buried
+            // under a Stripe-shaped WARN. This is the silent-failure trap this
+            // hook (which later billing stories copy) must avoid.
+            await EnqueueRetryAsync(platformTasks, tenant.Id, ct).ConfigureAwait(false);
+
+            logger.LogError(
+                ex,
+                "Unexpected (non-Stripe) error in billing customer hook for tenant "
+                + "{TenantId} ({ErrorClass}); enqueued billing.customer.create retry so "
+                + "tenant creation is not blocked, but THIS IS LIKELY A DEFECT — investigate.",
+                tenant.Id, ex.GetType().Name);
+        }
+    }
+
+    /// <summary>
+    /// True for failures that are an expected, transient Stripe/network problem
+    /// (the customer create can simply be retried later): a Stripe API error, a
+    /// timeout, or a raw transport failure. Anything else is treated as an
+    /// unexpected defect by the caller.
+    /// </summary>
+    private static bool IsExpectedStripeFailure(Exception ex) =>
+        ex is StripeException or TimeoutException or HttpRequestException;
+
+    private static async Task EnqueueRetryAsync(
+        IPlatformQueuedTaskRepository platformTasks, Guid tenantId, CancellationToken ct)
+    {
+        await platformTasks.EnqueueAsync(new PlatformQueuedTask
+        {
+            Type = CreateBillingCustomerTaskHandler.TaskTypeName,
+            TenantId = tenantId,
+            Payload = JsonSerializer.Serialize(
+                new CreateBillingCustomerTaskPayload(tenantId)),
+        }, ct)
+            .ConfigureAwait(false);
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/IBillingCatalog.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/IBillingCatalog.cs
@@ -1,0 +1,22 @@
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-1 — read side of the billing catalog: resolve the
+/// <see cref="BillingPlanPrice"/> (Stripe Product/Price/Meter ids) for a plan
+/// slug. Backs the downstream Epic 35 stories (subscriptions, metering) that
+/// need the slug→Stripe-ids binding. Platform-global; never tenant-scoped.
+/// </summary>
+public interface IBillingCatalog
+{
+    /// <summary>
+    /// Resolve the catalog row for a slug. Throws
+    /// <c>BILLING.CATALOG.UNKNOWN_SLUG</c> when no row exists (the seed has not
+    /// run, or the slug is invalid) — never a silent null.
+    /// </summary>
+    Task<BillingPlanPrice> GetBySlugAsync(string planSlug, CancellationToken ct = default);
+
+    /// <summary>Resolve the catalog row for a slug, or null when absent.</summary>
+    Task<BillingPlanPrice?> TryGetBySlugAsync(string planSlug, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/IBillingProvider.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/IBillingProvider.cs
@@ -1,0 +1,58 @@
+using Tamma.Core.Billing;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-1 — the single billing seam. In SaaS this is
+/// <see cref="StripeBillingProvider"/> (creates Stripe customers, syncs the
+/// catalog); in single-user it is <see cref="NullBillingProvider"/>
+/// (<see cref="IsEnabled"/> = false, no Stripe calls, no rows). DI picks one
+/// based on <c>ITammaModeProvider.Mode</c>.
+/// </summary>
+public interface IBillingProvider
+{
+    /// <summary>
+    /// True only when billing is active (SaaS). The tenant-create hook and the
+    /// seed command short-circuit when this is false — single-user makes ZERO
+    /// Stripe calls.
+    /// </summary>
+    bool IsEnabled { get; }
+
+    /// <summary>
+    /// Create (or resolve the existing) Stripe customer for a tenant and
+    /// persist the <see cref="BillingCustomer"/> mapping. Idempotent: a second
+    /// call for the same tenant resolves the existing row (no duplicate Stripe
+    /// customer) via the unique <c>TenantId</c> + a deterministic idempotency
+    /// key. Throws on a single-user (disabled) provider.
+    /// </summary>
+    Task<BillingCustomer> CreateCustomerAsync(
+        Guid tenantId, CustomerDescriptor descriptor, CancellationToken ct = default);
+
+    /// <summary>
+    /// Idempotently sync the Stripe catalog (Products, base + metered Prices,
+    /// the three Billing Meters) for every plan slug and write the ids into
+    /// <c>billing_plan_prices</c>. Re-running is a no-op (existing ids reused).
+    /// </summary>
+    Task<CatalogSyncResult> SyncCatalogAsync(CancellationToken ct = default);
+}
+
+/// <summary>
+/// The tenant-shaped inputs for a Stripe customer create. No payment details —
+/// only identifying metadata that is safe to log at DEBUG.
+/// </summary>
+public sealed record CustomerDescriptor(
+    string TenantName,
+    string TenantSlug,
+    string? OwnerEmail,
+    BillingMode Mode);
+
+/// <summary>Per-slug catalog sync outcome (counts of created vs reused Stripe objects).</summary>
+public sealed record CatalogSyncResult(IReadOnlyList<CatalogSlugResult> Slugs)
+{
+    public int TotalCreated => Slugs.Sum(s => s.Created);
+    public int TotalReused => Slugs.Sum(s => s.Reused);
+}
+
+/// <summary>One slug's catalog sync result.</summary>
+public sealed record CatalogSlugResult(string PlanSlug, int Created, int Reused);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/IStripeServices.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/IStripeServices.cs
@@ -1,0 +1,43 @@
+using Stripe;
+using Stripe.Billing;
+
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-1 — the narrow Stripe service surface this story touches, bundled
+/// behind one seam so the <see cref="StripeBillingProvider"/> and
+/// <c>BillingSeeder</c> are testable without a live Stripe account. Every Stripe
+/// service class (<see cref="Stripe.CustomerService"/>,
+/// <see cref="Stripe.ProductService"/>, <see cref="Stripe.PriceService"/>,
+/// <see cref="Stripe.Billing.MeterService"/>) is non-sealed with <c>virtual</c>
+/// <c>*Async</c> methods, so tests mock these properties directly with Moq.
+///
+/// <para>The concrete bundle (<see cref="StripeServices"/>) is built lazily from
+/// the cabinet-resolved secret key by <see cref="IStripeServicesFactory"/> — the
+/// key is read at most once per process and never logged.</para>
+/// </summary>
+public interface IStripeServices
+{
+    CustomerService Customers { get; }
+    ProductService Products { get; }
+    PriceService Prices { get; }
+    MeterService Meters { get; }
+}
+
+/// <summary>Concrete bundle wrapping the four service classes over one client.</summary>
+public sealed class StripeServices : IStripeServices
+{
+    public StripeServices(IStripeClient client)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        Customers = new CustomerService(client);
+        Products = new ProductService(client);
+        Prices = new PriceService(client);
+        Meters = new MeterService(client);
+    }
+
+    public CustomerService Customers { get; }
+    public ProductService Products { get; }
+    public PriceService Prices { get; }
+    public MeterService Meters { get; }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/NullBillingProvider.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/NullBillingProvider.cs
@@ -1,0 +1,36 @@
+using Tamma.Core;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-1 (AC9) — the single-user no-op billing provider. Registered when
+/// <c>ITammaModeProvider.Mode == TammaMode.SingleUser</c>. Reports
+/// <see cref="IsEnabled"/> = false so the tenant-create hook and the seed
+/// command short-circuit before touching Stripe. The mutating methods throw a
+/// clear "billing is SaaS-only" error if a caller ignores <see cref="IsEnabled"/>
+/// — but in single-user the hook never calls them, so ZERO Stripe SDK calls
+/// occur (asserted in tests).
+/// </summary>
+public sealed class NullBillingProvider : IBillingProvider
+{
+    /// <inheritdoc />
+    public bool IsEnabled => false;
+
+    /// <inheritdoc />
+    public Task<BillingCustomer> CreateCustomerAsync(
+        Guid tenantId, CustomerDescriptor descriptor, CancellationToken ct = default) =>
+        throw SaasOnly();
+
+    /// <inheritdoc />
+    public Task<CatalogSyncResult> SyncCatalogAsync(CancellationToken ct = default) =>
+        throw SaasOnly();
+
+    private static TammaError SaasOnly() => new(
+        "BILLING.SAAS_ONLY",
+        "Billing is SaaS-only. The NullBillingProvider is active because this "
+        + "Tamma instance runs in single-user mode — there is no Stripe coupling. "
+        + "Check IBillingProvider.IsEnabled before calling.",
+        retryable: false,
+        severity: TammaErrorSeverity.Medium);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/SeedBillingCommand.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/SeedBillingCommand.cs
@@ -1,0 +1,77 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-1 (AC7) — CLI entrypoint for
+/// <c>dotnet run --project Tamma.Api -- seed-billing</c>. Mirrors
+/// <c>MigrateSecretsCommand</c>: resolves <see cref="IBillingProvider"/> from
+/// the built DI graph and runs an idempotent Stripe catalog sync.
+///
+/// <para>Single-user mode: prints "billing is SaaS-only" and exits 0 (the
+/// <see cref="NullBillingProvider"/> is registered, so no Stripe call is made).
+/// SaaS: runs the catalog sync, prints a per-slug created/reused report, and
+/// exits 0 on success / 1 on failure. Re-running is a no-op.</para>
+/// </summary>
+public static class SeedBillingCommand
+{
+    /// <summary>True when the first positional arg is <c>seed-billing</c>.</summary>
+    public static bool ShouldRun(string[] args) =>
+        args is { Length: > 0 } && string.Equals(
+            args[0], "seed-billing", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Execute the catalog sync using the supplied DI <paramref name="services"/>.
+    /// Opens a scope so the scoped provider + CP context resolve correctly.
+    /// </summary>
+    public static async Task<int> RunAsync(
+        IServiceProvider services, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        await using var scope = services.CreateAsyncScope();
+        var sp = scope.ServiceProvider;
+
+        var provider = sp.GetService<IBillingProvider>()
+            ?? throw new InvalidOperationException(
+                "IBillingProvider is not registered. Call AddTammaBilling() during startup wiring.");
+        var logger = sp.GetService<ILogger<StripeBillingProvider>>();
+
+        if (!provider.IsEnabled)
+        {
+            Console.WriteLine(
+                "seed-billing: billing is SaaS-only — this Tamma instance runs in "
+                + "single-user mode (NullBillingProvider). No Stripe catalog to sync.");
+            return 0;
+        }
+
+        try
+        {
+            var result = await provider.SyncCatalogAsync(ct);
+
+            Console.WriteLine(
+                "seed-billing: catalog synced. created={0} reused={1}",
+                result.TotalCreated, result.TotalReused);
+            foreach (var slug in result.Slugs)
+            {
+                Console.WriteLine(
+                    "  {0,-12} created={1} reused={2}", slug.PlanSlug, slug.Created, slug.Reused);
+            }
+
+            logger?.LogInformation(
+                "seed-billing CLI completed: created={Created} reused={Reused} over {Slugs} slugs.",
+                result.TotalCreated, result.TotalReused, result.Slugs.Count);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            // Never echo the exception detail blindly (could carry config
+            // context). The structured log gets the full error; stdout stays terse.
+            Console.Error.WriteLine(
+                "seed-billing: FAILED — see logs. ({0})", ex.GetType().Name);
+            logger?.LogError(ex, "seed-billing CLI failed.");
+            return 1;
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/StripeBillingProvider.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/StripeBillingProvider.cs
@@ -1,0 +1,146 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Stripe;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-1 — the SaaS billing provider. Resolves the Stripe key through the
+/// Epic 29 cabinet (via <see cref="IStripeServicesFactory"/>), maps each tenant
+/// to a Stripe customer, and persists the <see cref="BillingCustomer"/> row.
+/// Catalog sync is delegated to <see cref="BillingSeeder"/>.
+///
+/// <para>Idempotency is layered: a deterministic
+/// <see cref="RequestOptions.IdempotencyKey"/> (<c>billing-customer-{tenantId}</c>)
+/// makes the Stripe create itself replay-safe, and a lookup-by-stored-id before
+/// the call means a second create for the same tenant returns the existing row
+/// without a second Stripe call (AC12, AC13).</para>
+/// </summary>
+public sealed class StripeBillingProvider : IBillingProvider
+{
+    private readonly IStripeServicesFactory _stripeFactory;
+    private readonly ControlPlaneDbContext _db;
+    private readonly IEventRepository _events;
+    private readonly BillingOptions _options;
+    private readonly ILogger<StripeBillingProvider> _logger;
+
+    public StripeBillingProvider(
+        IStripeServicesFactory stripeFactory,
+        ControlPlaneDbContext db,
+        IEventRepository events,
+        IOptions<BillingOptions> options,
+        ILogger<StripeBillingProvider> logger)
+    {
+        ArgumentNullException.ThrowIfNull(stripeFactory);
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(events);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _stripeFactory = stripeFactory;
+        _db = db;
+        _events = events;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public bool IsEnabled => true;
+
+    /// <summary>Deterministic Stripe idempotency key for a tenant's customer create.</summary>
+    public static string CustomerIdempotencyKey(Guid tenantId) => $"billing-customer-{tenantId:D}";
+
+    /// <inheritdoc />
+    public async Task<BillingCustomer> CreateCustomerAsync(
+        Guid tenantId, CustomerDescriptor descriptor, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        // Idempotency layer 1 — if a fully-acked row already exists for this
+        // tenant, return it and make NO Stripe call (AC12).
+        var existing = await _db.BillingCustomers
+            .FirstOrDefaultAsync(c => c.TenantId == tenantId, ct)
+            .ConfigureAwait(false);
+        if (existing is not null && !string.IsNullOrEmpty(existing.StripeCustomerId))
+        {
+            _logger.LogDebug(
+                "BillingCustomer already mapped for tenant {TenantId}; skipping Stripe create.",
+                tenantId);
+            return existing;
+        }
+
+        var stripe = await _stripeFactory.CreateAsync(ct).ConfigureAwait(false);
+
+        var idempotencyKey = CustomerIdempotencyKey(tenantId);
+        _logger.LogDebug(
+            "Creating Stripe customer for tenant {TenantId} (idempotencyKey set).", tenantId);
+
+        var options = new CustomerCreateOptions
+        {
+            Name = descriptor.TenantName,
+            Email = descriptor.OwnerEmail,
+            Description = $"Tamma tenant {descriptor.TenantSlug}",
+            Metadata = new Dictionary<string, string>
+            {
+                ["tammaTenantId"] = tenantId.ToString("D"),
+                ["tammaTenantSlug"] = descriptor.TenantSlug,
+                ["billingMode"] = descriptor.Mode.ToString(),
+            },
+        };
+
+        // Idempotency layer 2 — deterministic key so a retry never mints a
+        // duplicate Stripe customer.
+        var customer = await stripe.Customers
+            .CreateAsync(options, new RequestOptions { IdempotencyKey = idempotencyKey }, ct)
+            .ConfigureAwait(false);
+
+        var now = DateTime.UtcNow;
+        BillingCustomer row;
+        if (existing is not null)
+        {
+            // A null-id retry row from a prior failed attempt — fill it in.
+            existing.StripeCustomerId = customer.Id;
+            existing.BillingMode = descriptor.Mode.ToString();
+            existing.UpdatedAt = now;
+            row = existing;
+        }
+        else
+        {
+            row = new BillingCustomer
+            {
+                Id = Guid.NewGuid(),
+                TenantId = tenantId,
+                StripeCustomerId = customer.Id,
+                BillingMode = descriptor.Mode.ToString(),
+                DefaultCurrency = _options.DefaultCurrency,
+                TaxStatus = "none",
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+            _db.BillingCustomers.Add(row);
+        }
+
+        await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        await _events.AppendAsync(
+            BillingEvents.CustomerCreated(tenantId, row.StripeCustomerId, row.BillingMode))
+            .ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "BillingCustomer created for tenant {TenantId} (stripeCustomerPresent={Present}, mode={Mode}).",
+            tenantId, !string.IsNullOrEmpty(row.StripeCustomerId), row.BillingMode);
+
+        return row;
+    }
+
+    /// <inheritdoc />
+    public async Task<CatalogSyncResult> SyncCatalogAsync(CancellationToken ct = default)
+    {
+        var stripe = await _stripeFactory.CreateAsync(ct).ConfigureAwait(false);
+        var seeder = new BillingSeeder(stripe, _db, _events, _options, _logger);
+        return await seeder.SyncAsync(ct).ConfigureAwait(false);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/StripeClientFactory.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/StripeClientFactory.cs
@@ -15,8 +15,11 @@ namespace Tamma.Api.Services.Billing;
 /// production a null/blank key (e.g. dev fallback enabled but no value present)
 /// is a hard boot error rather than serving 500s on first request.
 ///
-/// <para>The resolved key is cached in-process for the lifetime of the factory
-/// and is NEVER logged.</para>
+/// <para>The factory is registered as a SINGLETON (see
+/// <c>BillingServiceCollectionExtensions</c>) so the resolved key is cached
+/// in-process and read at most once per process; the <see cref="SemaphoreSlim"/>
+/// gate then serialises the one-time resolve across concurrent first callers.
+/// The key value is NEVER logged.</para>
 /// </summary>
 public interface IStripeServicesFactory
 {

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/StripeClientFactory.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/StripeClientFactory.cs
@@ -1,0 +1,127 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Stripe;
+using Tamma.Api.Services.Secrets.Stopgap;
+using Tamma.Core;
+
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-1 (AC5, AC13) — builds the Stripe <see cref="IStripeServices"/>
+/// bundle from the cabinet-resolved secret key. The key is resolved through the
+/// Epic 29 cabinet (<see cref="IRuntimeSecretResolver"/>) by the configured
+/// cabinet name — cabinet-first, with the resolver's own Story-29-10 prod
+/// fail-fast semantics. This factory adds a defence-in-depth AC5 guard: in
+/// production a null/blank key (e.g. dev fallback enabled but no value present)
+/// is a hard boot error rather than serving 500s on first request.
+///
+/// <para>The resolved key is cached in-process for the lifetime of the factory
+/// and is NEVER logged.</para>
+/// </summary>
+public interface IStripeServicesFactory
+{
+    /// <summary>
+    /// Resolve the Stripe key from the cabinet and build the service bundle.
+    /// Throws <see cref="TammaError"/> (<c>BILLING.STRIPE.NO_KEY</c>) in
+    /// production when no key is available.
+    /// </summary>
+    Task<IStripeServices> CreateAsync(CancellationToken ct = default);
+}
+
+/// <inheritdoc />
+public sealed class StripeClientFactory : IStripeServicesFactory
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly BillingOptions _options;
+    private readonly IHostEnvironment _environment;
+    private readonly ILogger<StripeClientFactory> _logger;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    private IStripeServices? _cached;
+
+    public StripeClientFactory(
+        IServiceProvider serviceProvider,
+        IOptions<BillingOptions> options,
+        IHostEnvironment environment,
+        ILogger<StripeClientFactory> logger)
+    {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(environment);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        // The runtime secret resolver is resolved lazily (see CreateAsync) so the
+        // DI graph validates even in hosts that don't wire the Epic 29 cabinet
+        // (e.g. test fixtures, single-user dev). Billing only needs it on the
+        // first real Stripe call (SaaS).
+        _serviceProvider = serviceProvider;
+        _options = options.Value;
+        _environment = environment;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<IStripeServices> CreateAsync(CancellationToken ct = default)
+    {
+        if (_cached is not null) return _cached;
+
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (_cached is not null) return _cached;
+
+            var cabinetName = _options.StripeSecretKeyCabinetName;
+            var resolver = _serviceProvider.GetService<IRuntimeSecretResolver>()
+                ?? throw new TammaError(
+                    "BILLING.STRIPE.NO_SECRET_RESOLVER",
+                    "Billing requires the Epic 29 runtime secret resolver "
+                    + "(IRuntimeSecretResolver) to read the Stripe key from the cabinet, "
+                    + "but it is not registered. Configure ConnectionStrings:SecretStore "
+                    + "or :ControlPlane so the resolver is wired.",
+                    new Dictionary<string, object?> { ["cabinetName"] = cabinetName },
+                    retryable: false,
+                    severity: TammaErrorSeverity.Critical);
+            var key = await resolver.GetAsync(cabinetName, ct).ConfigureAwait(false);
+
+            // AC5 — production must NOT run billing on a missing key. Never log
+            // the key value; only whether it resolved.
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                if (!_environment.IsDevelopment())
+                {
+                    _logger.LogError(
+                        "Billing boot refused: no Stripe secret key in cabinet "
+                        + "'{CabinetName}' (SecretScope.Platform). Import it via "
+                        + "`migrate-secrets` or the secret-store admin before "
+                        + "enabling billing in production.",
+                        cabinetName);
+                    throw new TammaError(
+                        "BILLING.STRIPE.NO_KEY",
+                        $"No Stripe secret key resolved from cabinet '{cabinetName}'. "
+                        + "Production refuses to run billing without a cabinet key.",
+                        new Dictionary<string, object?> { ["cabinetName"] = cabinetName },
+                        retryable: false,
+                        severity: TammaErrorSeverity.Critical);
+                }
+
+                _logger.LogWarning(
+                    "No Stripe secret key resolved from cabinet '{CabinetName}'. "
+                    + "Billing SDK calls will fail until a key is configured "
+                    + "(development only — production fails fast).",
+                    cabinetName);
+            }
+
+            _logger.LogDebug(
+                "Resolved Stripe secret key from cabinet '{CabinetName}' (found={Found}).",
+                cabinetName, !string.IsNullOrWhiteSpace(key));
+
+            var client = new StripeClient(key);
+            _cached = new StripeServices(client);
+            return _cached;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/Tasks/CreateBillingCustomerTaskHandler.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/Tasks/CreateBillingCustomerTaskHandler.cs
@@ -1,0 +1,114 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Tamma.Api.Services.PlatformTasks;
+using Tamma.Core.Billing;
+using Tamma.Data;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Billing.Tasks;
+
+/// <summary>
+/// Story 35-1 (AC6) — retry seam for a tenant-create-time Stripe customer
+/// failure. When the non-blocking hook in <c>OrgEndpoints</c>/<c>AuthEndpoints</c>
+/// catches a Stripe error it enqueues a <c>billing.customer.create</c>
+/// <see cref="PlatformQueuedTask"/>; this handler re-drives
+/// <see cref="IBillingProvider.CreateCustomerAsync"/> (which fills
+/// <c>StripeCustomerId</c> and emits <c>BILLING.CUSTOMER.CREATED</c>).
+///
+/// <para>Failure semantics: a malformed payload or unknown tenant →
+/// <see cref="PlatformTaskTerminalException"/> (dead-letter, never succeeds); a
+/// transient Stripe error rethrows so the worker retries per its budget.</para>
+/// </summary>
+public sealed class CreateBillingCustomerTaskHandler : IPlatformTaskHandler
+{
+    public const string TaskTypeName = "billing.customer.create";
+
+    private readonly IBillingProvider _billing;
+    private readonly ControlPlaneDbContext _db;
+    private readonly ILogger<CreateBillingCustomerTaskHandler> _logger;
+
+    public CreateBillingCustomerTaskHandler(
+        IBillingProvider billing,
+        ControlPlaneDbContext db,
+        ILogger<CreateBillingCustomerTaskHandler> logger)
+    {
+        ArgumentNullException.ThrowIfNull(billing);
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _billing = billing;
+        _db = db;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public string TaskType => TaskTypeName;
+
+    /// <inheritdoc />
+    public async Task HandleAsync(PlatformQueuedTask task, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+
+        // Single-user safety: a disabled provider should never receive this
+        // task, but if it does, dead-letter cleanly rather than throw SaaS-only.
+        if (!_billing.IsEnabled)
+        {
+            throw new PlatformTaskTerminalException(
+                "Billing provider is disabled (single-user mode); "
+                + "billing.customer.create cannot run.");
+        }
+
+        CreateBillingCustomerTaskPayload payload;
+        try
+        {
+            payload = JsonSerializer.Deserialize<CreateBillingCustomerTaskPayload>(task.Payload)
+                ?? throw new PlatformTaskTerminalException(
+                    "billing.customer.create payload deserialized to null.");
+        }
+        catch (JsonException ex)
+        {
+            throw new PlatformTaskTerminalException(
+                "billing.customer.create payload is malformed JSON.", ex);
+        }
+
+        if (payload.TenantId == Guid.Empty)
+        {
+            throw new PlatformTaskTerminalException(
+                "billing.customer.create payload has an empty tenant id.");
+        }
+
+        var tenant = await _db.Tenants
+            .AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == payload.TenantId, ct)
+            .ConfigureAwait(false);
+        if (tenant is null)
+        {
+            throw new PlatformTaskTerminalException(
+                $"billing.customer.create: tenant {payload.TenantId} not found.");
+        }
+
+        string? ownerEmail = null;
+        if (tenant.OwnerId is Guid ownerId)
+        {
+            ownerEmail = await _db.Users
+                .AsNoTracking()
+                .Where(u => u.Id == ownerId)
+                .Select(u => u.Email)
+                .FirstOrDefaultAsync(ct)
+                .ConfigureAwait(false);
+        }
+
+        // BillingMode default: this story records PlatformProvided. (BYOK
+        // detection is wired by a later story; the retry preserves the default.)
+        // Transient Stripe failures propagate so the worker retries.
+        await _billing.CreateCustomerAsync(
+            tenant.Id,
+            new CustomerDescriptor(
+                tenant.Name, tenant.Slug, ownerEmail, BillingMode.PlatformProvided),
+            ct)
+            .ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "billing.customer.create retry succeeded for tenant {TenantId}.", tenant.Id);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/Tasks/CreateBillingCustomerTaskPayload.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/Tasks/CreateBillingCustomerTaskPayload.cs
@@ -1,0 +1,8 @@
+namespace Tamma.Api.Services.Billing.Tasks;
+
+/// <summary>
+/// Story 35-1 — payload for the <c>billing.customer.create</c> retry task. The
+/// tenant id is the only thing needed; the handler re-reads the tenant's name /
+/// slug / owner email from the control plane so the retry sees fresh data.
+/// </summary>
+public sealed record CreateBillingCustomerTaskPayload(Guid TenantId);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Email/OutboxSmtpSender.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Email/OutboxSmtpSender.cs
@@ -33,8 +33,10 @@ public sealed class OutboxSmtpSenderOptions
     /// that assert outbox-row state (e.g. <c>AuthRegisterTxnIdIntegrationTests
     /// .Register_OutboxRowPersistedWithMatchingTxnId</c>) flake when the
     /// loop races the test and flips <c>status="pending"</c> to
-    /// <c>"sent"</c> / <c>"failed"</c> before the assertion runs. The
-    /// shared <c>ApiTestFixture</c> opts out via <see cref="HostedServiceGateExtensions.DisableRacyHostedServices"/>.
+    /// <c>"sent"</c> / <c>"failed"</c> before the assertion runs. The shared
+    /// test fixture (and <c>AuthRegisterTxnIdIntegrationTests</c>'s own derived
+    /// host) opt out via the <c>AlertHostedServiceTestExtensions
+    /// .DisableAlertHostedServices</c> helper, which sets this flag false.
     /// Mirrors the existing <c>BuiltInAlertRuleSeederOptions.RunOnStartup</c>
     /// gate pattern.
     /// </summary>

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IPlanCatalogService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IPlanCatalogService.cs
@@ -1,0 +1,39 @@
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-1 — read seam for the plan price-book catalog. All catalog reads go
+/// through this service so callers always get a fully-resolved, immutable
+/// <see cref="PlanSnapshot"/> (header + features + entitlements + prices) rather
+/// than touching the entity rows directly. Read-only and never throws on a
+/// missing plan — returns <c>null</c>. The catalog is platform-global in both
+/// single-user and SaaS modes (no per-tenant override layer).
+/// </summary>
+public interface IPlanCatalogService
+{
+    /// <summary>The single <c>active</c> version for a slug, or <c>null</c> if none.</summary>
+    Task<PlanSnapshot?> GetActiveBySlugAsync(string slug, CancellationToken ct = default);
+
+    /// <summary>
+    /// A specific plan version by id (active OR deprecated). A deprecated
+    /// version's snapshot is frozen — this is the historical-reproducibility
+    /// read for a tenant still assigned an older version.
+    /// </summary>
+    Task<PlanSnapshot?> GetByIdAsync(Guid planId, CancellationToken ct = default);
+
+    /// <summary>
+    /// The snapshot for the plan version assigned to a tenant. Resolves the
+    /// tenant's <c>PlanId</c> shadow column then snapshots that exact version.
+    /// Returns <c>null</c> when the tenant has no assigned plan or doesn't exist.
+    /// </summary>
+    Task<PlanSnapshot?> GetForTenantAsync(Guid tenantId, CancellationToken ct = default);
+
+    /// <summary>Every <c>active</c> version across all slugs.</summary>
+    Task<IReadOnlyList<PlanSnapshot>> ListActiveAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// The full version chain for a slug — the active version plus all
+    /// deprecated versions, ordered by <c>Version</c> descending. Empty when
+    /// the slug is unknown.
+    /// </summary>
+    Task<IReadOnlyList<PlanSnapshot>> GetVersionsBySlugAsync(string slug, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IPlanVersionEditor.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IPlanVersionEditor.cs
@@ -1,0 +1,37 @@
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-1 — the ONLY write path into the plan price-book. Plans are
+/// immutable, versioned rows: editing never mutates an <c>active</c>/
+/// <c>deprecated</c> row in place. Extracted as an interface (Story 34-2 prep)
+/// so consumers depend on the abstraction and the concrete
+/// <see cref="PlanVersionEditor"/> is substitutable in tests.
+/// </summary>
+public interface IPlanVersionEditor
+{
+    /// <summary>
+    /// Optional pre-flight immutability check. A <c>Plan</c> whose status is
+    /// <c>active</c> or <c>deprecated</c> may NOT be mutated in place — only a
+    /// <c>draft</c> row is writable (plus the controlled active→deprecated flip
+    /// performed inside <see cref="CreateNewVersionAsync"/>). Throws
+    /// <c>PLAN.VERSION.IMMUTABLE</c> (severity High) otherwise. This is a
+    /// convenience that lets a caller reject early; it is NOT the authoritative
+    /// guard — the <c>ControlPlaneDbContext</c> <c>SaveChanges</c> interceptor
+    /// enforces the same invariant for every save path.
+    /// </summary>
+    void EnsureMutableOrThrow(Plan plan);
+
+    /// <summary>
+    /// Supersede the current <c>active</c> version of <paramref name="slug"/>
+    /// with a new immutable version built from <paramref name="draft"/>. Returns
+    /// the newly-created active <see cref="Plan"/> (with children attached).
+    /// Throws <c>PLAN.VERSION.NO_ACTIVE</c> if the slug has no active version.
+    /// </summary>
+    Task<Plan> CreateNewVersionAsync(
+        string slug,
+        PlanDraftSpec draft,
+        PlanEditorPrincipal principal,
+        CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanCatalogEventTypes.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanCatalogEventTypes.cs
@@ -1,0 +1,17 @@
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-1 — DCB event type names emitted by <see cref="PlanVersionEditor"/>
+/// to the control-plane <c>platform_events</c> store. CP-resident (the
+/// <c>AlertRuleEvaluator</c> already polls that table, so a later story can
+/// alert on catalog drift with no new plumbing). Pattern:
+/// <c>AGGREGATE.ACTION.STATUS</c>.
+/// </summary>
+public static class PlanCatalogEventTypes
+{
+    /// <summary>A new immutable plan version was activated.</summary>
+    public const string VersionCreated = "PLAN.VERSION.CREATED";
+
+    /// <summary>A prior plan version was flipped to <c>deprecated</c>.</summary>
+    public const string Deprecated = "PLAN.DEPRECATED";
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanCatalogService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanCatalogService.cs
@@ -1,0 +1,124 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Tamma.Data;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-1 — read-only implementation of <see cref="IPlanCatalogService"/>
+/// over <see cref="ControlPlaneDbContext"/>. Eager-loads the typed children and
+/// projects them into an immutable <see cref="PlanSnapshot"/>. Never mutates;
+/// never throws on a missing plan (returns <c>null</c>). Scoped lifetime (the
+/// <see cref="ControlPlaneDbContext"/> dependency is scoped).
+/// </summary>
+public sealed class PlanCatalogService : IPlanCatalogService
+{
+    private readonly ControlPlaneDbContext _db;
+    private readonly ILogger<PlanCatalogService> _logger;
+
+    public PlanCatalogService(ControlPlaneDbContext db, ILogger<PlanCatalogService> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<PlanSnapshot?> GetActiveBySlugAsync(string slug, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(slug);
+
+        var plan = await BaseQuery()
+            .FirstOrDefaultAsync(p => p.Slug == slug && p.Status == "active", ct);
+
+        return plan is null ? null : ToSnapshot(plan);
+    }
+
+    public async Task<PlanSnapshot?> GetByIdAsync(Guid planId, CancellationToken ct = default)
+    {
+        var plan = await BaseQuery().FirstOrDefaultAsync(p => p.Id == planId, ct);
+        return plan is null ? null : ToSnapshot(plan);
+    }
+
+    public async Task<PlanSnapshot?> GetForTenantAsync(Guid tenantId, CancellationToken ct = default)
+    {
+        // The tenant's plan assignment lives in the Epic 28 PlanId shadow
+        // column (a Guid? pointing at a specific plan version row). Read it via
+        // a projection so we don't have to materialize the tenant entity.
+        var planId = await _db.Tenants
+            .IgnoreQueryFilters()
+            .Where(t => t.Id == tenantId && t.DeletedAt == null)
+            .Select(t => EF.Property<Guid?>(t, "PlanId"))
+            .FirstOrDefaultAsync(ct);
+
+        if (planId is null || planId == Guid.Empty)
+        {
+            _logger.LogWarning(
+                "GetForTenantAsync: tenant {TenantId} has no assigned PlanId", tenantId);
+            return null;
+        }
+
+        var snapshot = await GetByIdAsync(planId.Value, ct);
+        _logger.LogDebug(
+            "GetForTenantAsync resolved tenant {TenantId} → plan {PlanId} ({Slug} v{Version})",
+            tenantId, planId, snapshot?.Slug, snapshot?.Version);
+        return snapshot;
+    }
+
+    public async Task<IReadOnlyList<PlanSnapshot>> ListActiveAsync(CancellationToken ct = default)
+    {
+        var plans = await BaseQuery()
+            .Where(p => p.Status == "active")
+            .OrderBy(p => p.Slug)
+            .ToListAsync(ct);
+
+        return plans.Select(ToSnapshot).ToList();
+    }
+
+    public async Task<IReadOnlyList<PlanSnapshot>> GetVersionsBySlugAsync(string slug, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(slug);
+
+        var plans = await BaseQuery()
+            .Where(p => p.Slug == slug)
+            .OrderByDescending(p => p.Version)
+            .ToListAsync(ct);
+
+        return plans.Select(ToSnapshot).ToList();
+    }
+
+    private IQueryable<Plan> BaseQuery() =>
+        _db.Plans
+            .AsNoTracking()
+            .Include(p => p.Features)
+            .Include(p => p.Entitlements)
+            .Include(p => p.Prices);
+
+    private PlanSnapshot ToSnapshot(Plan plan)
+    {
+        _logger.LogDebug(
+            "Assembling snapshot for {Slug} v{Version}: {Features}f/{Entitlements}e/{Prices}p",
+            plan.Slug, plan.Version, plan.Features.Count, plan.Entitlements.Count, plan.Prices.Count);
+
+        return new PlanSnapshot(
+            plan.Id,
+            plan.Slug,
+            plan.DisplayName,
+            plan.Version,
+            plan.Status,
+            plan.IsCustom,
+            plan.BillingInterval,
+            plan.SupersedesPlanId,
+            plan.Features
+                .OrderBy(f => f.FeatureKey)
+                .Select(f => new PlanFeatureView(f.FeatureKey, f.BoolValue, f.StringValue))
+                .ToList(),
+            plan.Entitlements
+                .OrderBy(e => e.MetricKey)
+                .Select(e => new PlanEntitlementView(e.MetricKey, e.LimitValue, e.Period, e.OverageMode))
+                .ToList(),
+            plan.Prices
+                .OrderBy(pr => pr.PricingMode)
+                .Select(pr => new PlanPriceView(pr.PricingMode, pr.RecurringUsd, pr.SeatUsd, pr.MeteredComponent))
+                .ToList());
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanSnapshot.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanSnapshot.cs
@@ -1,0 +1,40 @@
+using Tamma.Core.Enums;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-1 — fully-resolved, immutable read DTO for a single
+/// <c>Plan</c> version: header + typed features + entitlements + prices. Returned
+/// by <see cref="IPlanCatalogService"/>. A snapshot is a value (record) — once
+/// assembled it never changes, which mirrors the immutability of the underlying
+/// versioned rows (a deprecated version's snapshot is frozen forever).
+/// </summary>
+public sealed record PlanSnapshot(
+    Guid PlanId,
+    string Slug,
+    string DisplayName,
+    int Version,
+    string Status,
+    bool IsCustom,
+    string BillingInterval,
+    Guid? SupersedesPlanId,
+    IReadOnlyList<PlanFeatureView> Features,
+    IReadOnlyList<PlanEntitlementView> Entitlements,
+    IReadOnlyList<PlanPriceView> Prices);
+
+/// <summary>A typed feature flag projection.</summary>
+public sealed record PlanFeatureView(string FeatureKey, bool? BoolValue, string? StringValue);
+
+/// <summary>A typed quota entitlement projection (<c>LimitValue == null</c> ⇒ unlimited).</summary>
+public sealed record PlanEntitlementView(
+    EntitlementMetricKey MetricKey,
+    long? LimitValue,
+    string Period,
+    string OverageMode);
+
+/// <summary>A pricing-row projection. <c>MeteredComponent</c> is the raw jsonb string (stored verbatim).</summary>
+public sealed record PlanPriceView(
+    string PricingMode,
+    decimal RecurringUsd,
+    decimal SeatUsd,
+    string MeteredComponent);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanVersionEditor.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanVersionEditor.cs
@@ -1,0 +1,319 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Tamma.Core;
+using Tamma.Core.Enums;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-1 — the ONLY write path into the plan price-book. Plans are
+/// immutable, versioned rows: editing never mutates an <c>active</c>/
+/// <c>deprecated</c> row in place. <see cref="CreateNewVersionAsync"/> inserts a
+/// new <c>Version = prior + 1</c> row (<see cref="Plan.SupersedesPlanId"/>
+/// pointing at the prior, <c>Status = active</c>), flips the prior to
+/// <c>deprecated</c>, all in ONE transaction, then emits
+/// <c>PLAN.VERSION.CREATED</c> + <c>PLAN.DEPRECATED</c> to <c>platform_events</c>.
+///
+/// <para>The partial unique index <c>UX_plans_OneActivePerSlug</c> is the
+/// load-bearing backstop — the DB rejects a second <c>active</c> row per slug
+/// regardless of app logic, so a flip-then-insert race can never leave two
+/// active versions. <see cref="EnsureMutableOrThrow"/> is the application-level
+/// guard that rejects any direct mutation of an immutable row with
+/// <c>PLAN.VERSION.IMMUTABLE</c>.</para>
+///
+/// <para>This story ships the editor as a tested SERVICE METHOD; wiring it
+/// behind admin create/deprecate ENDPOINTS is Story 34-2. The catalog is
+/// platform-owned in both modes — there is no per-tenant override layer; in
+/// SaaS the endpoint (34-2) gates this on <c>OwnerAccess</c>.</para>
+/// </summary>
+public sealed class PlanVersionEditor
+{
+    private const string WorkflowVersion = "1.0.0";
+
+    private readonly ControlPlaneDbContext _db;
+    private readonly IPlatformEventPublisher _publisher;
+    private readonly TimeProvider _time;
+    private readonly ILogger<PlanVersionEditor> _logger;
+
+    public PlanVersionEditor(
+        ControlPlaneDbContext db,
+        IPlatformEventPublisher publisher,
+        TimeProvider time,
+        ILogger<PlanVersionEditor> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
+        _time = time ?? throw new ArgumentNullException(nameof(time));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Application-level immutability guard. A <c>Plan</c> whose status is
+    /// <c>active</c> or <c>deprecated</c> may NOT be mutated in place — only a
+    /// <c>draft</c> row is writable (plus the controlled active→deprecated flip
+    /// performed inside <see cref="CreateNewVersionAsync"/>). Throws
+    /// <c>PLAN.VERSION.IMMUTABLE</c> (severity High) otherwise.
+    /// </summary>
+    public void EnsureMutableOrThrow(Plan plan)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+
+        if (plan.Status is "active" or "deprecated")
+        {
+            _logger.LogWarning(
+                "Rejected mutation of immutable plan {Slug} v{Version} (status={Status})",
+                plan.Slug, plan.Version, plan.Status);
+
+            throw new TammaError(
+                "PLAN.VERSION.IMMUTABLE",
+                $"Plan '{plan.Slug}' v{plan.Version} is {plan.Status} and immutable. " +
+                "Create a new version instead of editing it.",
+                new Dictionary<string, object?>
+                {
+                    ["slug"] = plan.Slug,
+                    ["version"] = plan.Version,
+                    ["status"] = plan.Status,
+                    ["planId"] = plan.Id.ToString("D"),
+                },
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+        }
+    }
+
+    /// <summary>
+    /// Supersede the current <c>active</c> version of <paramref name="slug"/>
+    /// with a new immutable version built from <paramref name="draft"/>. Returns
+    /// the newly-created active <see cref="Plan"/> (with children attached).
+    /// Throws <c>PLAN.VERSION.NO_ACTIVE</c> if the slug has no active version.
+    /// </summary>
+    public async Task<Plan> CreateNewVersionAsync(
+        string slug,
+        PlanDraftSpec draft,
+        PlanEditorPrincipal principal,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(slug);
+        ArgumentNullException.ThrowIfNull(draft);
+        ArgumentNullException.ThrowIfNull(principal);
+
+        var prior = await _db.Plans
+            .Include(p => p.Features)
+            .Include(p => p.Entitlements)
+            .Include(p => p.Prices)
+            .FirstOrDefaultAsync(p => p.Slug == slug && p.Status == "active", ct);
+
+        if (prior is null)
+        {
+            throw new TammaError(
+                "PLAN.VERSION.NO_ACTIVE",
+                $"No active version exists for plan slug '{slug}'.",
+                new Dictionary<string, object?> { ["slug"] = slug },
+                retryable: false,
+                severity: TammaErrorSeverity.Medium);
+        }
+
+        var now = _time.GetUtcNow().UtcDateTime;
+        var newPlanId = Guid.NewGuid();
+        var newVersion = prior.Version + 1;
+
+        var newPlan = new Plan
+        {
+            Id = newPlanId,
+            Slug = slug,
+            DisplayName = draft.DisplayName ?? prior.DisplayName,
+            Version = newVersion,
+            Status = "active",
+            IsCustom = draft.IsCustom ?? prior.IsCustom,
+            BillingInterval = draft.BillingInterval ?? prior.BillingInterval,
+            SupersedesPlanId = prior.Id,
+            MonthlyPriceUsd = draft.MonthlyPriceUsd ?? prior.MonthlyPriceUsd,
+            Quotas = prior.Quotas,
+            IsActive = prior.IsActive,
+            PlacementPolicy = draft.PlacementPolicy ?? prior.PlacementPolicy,
+            CreatedAt = now,
+            UpdatedAt = now,
+            Features = (draft.Features ?? ToFeatureDrafts(prior.Features))
+                .Select(f => new PlanFeature
+                {
+                    Id = Guid.NewGuid(),
+                    PlanId = newPlanId,
+                    FeatureKey = f.FeatureKey,
+                    BoolValue = f.BoolValue,
+                    StringValue = f.StringValue,
+                }).ToList(),
+            Entitlements = (draft.Entitlements ?? ToEntitlementDrafts(prior.Entitlements))
+                .Select(e => new PlanEntitlement
+                {
+                    Id = Guid.NewGuid(),
+                    PlanId = newPlanId,
+                    MetricKey = e.MetricKey,
+                    LimitValue = e.LimitValue,
+                    Period = e.Period,
+                    OverageMode = e.OverageMode,
+                }).ToList(),
+            Prices = (draft.Prices ?? ToPriceDrafts(prior.Prices))
+                .Select(p => new PlanPrice
+                {
+                    Id = Guid.NewGuid(),
+                    PlanId = newPlanId,
+                    PricingMode = p.PricingMode,
+                    RecurringUsd = p.RecurringUsd,
+                    SeatUsd = p.SeatUsd,
+                    MeteredComponent = p.MeteredComponent,
+                }).ToList(),
+        };
+
+        _logger.LogDebug(
+            "Plan version-create transaction begin: {Slug} v{Prior} → v{New}",
+            slug, prior.Version, newVersion);
+
+        // Flip-then-insert in one transaction. The partial unique index means
+        // the prior MUST be deprecated before the new active row commits, or
+        // the insert is rejected — the DB is the final arbiter of "one active
+        // per slug". InMemory tests don't enforce indexes; the relational
+        // tests (Postgres) cover that invariant.
+        var ownsTx = _db.Database.CurrentTransaction is null
+            && _db.Database.IsRelational();
+        var tx = ownsTx ? await _db.Database.BeginTransactionAsync(ct) : null;
+        try
+        {
+            prior.Status = "deprecated";
+            prior.UpdatedAt = now;
+            _db.Plans.Add(newPlan);
+            await _db.SaveChangesAsync(ct);
+
+            if (tx is not null)
+            {
+                await tx.CommitAsync(ct);
+            }
+        }
+        catch
+        {
+            if (tx is not null)
+            {
+                await tx.RollbackAsync(ct);
+            }
+
+            _logger.LogError(
+                "Plan version-create transaction rolled back: {Slug} v{Prior} → v{New}",
+                slug, prior.Version, newVersion);
+            throw;
+        }
+        finally
+        {
+            if (tx is not null)
+            {
+                await tx.DisposeAsync();
+            }
+        }
+
+        _logger.LogInformation(
+            "Plan version created: {Slug} v{Version} ({PlanId}); v{PriorVersion} deprecated",
+            slug, newVersion, newPlanId, prior.Version);
+
+        // Events only AFTER the real state transition committed.
+        await _publisher.AppendAndPublishAsync(
+            BuildPlanEvent(
+                PlanCatalogEventTypes.VersionCreated,
+                principal,
+                new Dictionary<string, string?>
+                {
+                    ["slug"] = slug,
+                    ["version"] = newVersion.ToString(),
+                    ["planId"] = newPlanId.ToString("D"),
+                    ["supersedesPlanId"] = prior.Id.ToString("D"),
+                }),
+            ct);
+
+        await _publisher.AppendAndPublishAsync(
+            BuildPlanEvent(
+                PlanCatalogEventTypes.Deprecated,
+                principal,
+                new Dictionary<string, string?>
+                {
+                    ["slug"] = slug,
+                    ["version"] = prior.Version.ToString(),
+                    ["planId"] = prior.Id.ToString("D"),
+                    ["supersededByPlanId"] = newPlanId.ToString("D"),
+                }),
+            ct);
+
+        return newPlan;
+    }
+
+    private PlatformEvent BuildPlanEvent(
+        string type,
+        PlanEditorPrincipal principal,
+        IReadOnlyDictionary<string, string?> extraTags)
+    {
+        var tags = new Dictionary<string, string?>
+        {
+            ["source"] = "admin",
+        };
+        foreach (var (k, v) in extraTags)
+        {
+            if (v is not null) tags[k] = v;
+        }
+        if (!string.IsNullOrEmpty(principal.UserId)) tags["actorUserId"] = principal.UserId;
+        if (!string.IsNullOrEmpty(principal.Email)) tags["actorEmail"] = principal.Email;
+
+        // Defence-in-depth: the canonical record also carries the tag data so a
+        // future tag refactor can't drop the audit breadcrumb.
+        var data = new Dictionary<string, object?>(
+            tags.ToDictionary(kv => kv.Key, kv => (object?)kv.Value));
+
+        return new PlatformEvent
+        {
+            Type = type,
+            Tags = JsonSerializer.Serialize(tags),
+            Metadata = """{"workflowVersion":"1.0.0","eventSource":"system"}""",
+            Data = JsonSerializer.Serialize(data),
+        };
+    }
+
+    private static IReadOnlyList<PlanFeatureDraft> ToFeatureDrafts(IEnumerable<PlanFeature> src) =>
+        src.Select(f => new PlanFeatureDraft(f.FeatureKey, f.BoolValue, f.StringValue)).ToList();
+
+    private static IReadOnlyList<PlanEntitlementDraft> ToEntitlementDrafts(IEnumerable<PlanEntitlement> src) =>
+        src.Select(e => new PlanEntitlementDraft(e.MetricKey, e.LimitValue, e.Period, e.OverageMode)).ToList();
+
+    private static IReadOnlyList<PlanPriceDraft> ToPriceDrafts(IEnumerable<PlanPrice> src) =>
+        src.Select(p => new PlanPriceDraft(p.PricingMode, p.RecurringUsd, p.SeatUsd, p.MeteredComponent)).ToList();
+}
+
+/// <summary>
+/// Story 34-1 — the new-version content. Header fields are optional overrides
+/// (null ⇒ copy from the prior version); child collections are full
+/// replacements when non-null (null ⇒ copy the prior version's children).
+/// </summary>
+public sealed record PlanDraftSpec(
+    string? DisplayName = null,
+    bool? IsCustom = null,
+    string? BillingInterval = null,
+    decimal? MonthlyPriceUsd = null,
+    string? PlacementPolicy = null,
+    IReadOnlyList<PlanFeatureDraft>? Features = null,
+    IReadOnlyList<PlanEntitlementDraft>? Entitlements = null,
+    IReadOnlyList<PlanPriceDraft>? Prices = null);
+
+/// <summary>A feature row to write into a new version.</summary>
+public sealed record PlanFeatureDraft(string FeatureKey, bool? BoolValue, string? StringValue);
+
+/// <summary>An entitlement row to write into a new version.</summary>
+public sealed record PlanEntitlementDraft(
+    EntitlementMetricKey MetricKey, long? LimitValue, string Period, string OverageMode);
+
+/// <summary>A price row to write into a new version.</summary>
+public sealed record PlanPriceDraft(
+    string PricingMode, decimal RecurringUsd, decimal SeatUsd, string MeteredComponent);
+
+/// <summary>
+/// Minimal actor identity stamped onto the DCB events. The endpoint layer
+/// (Story 34-2) derives this from the <c>ClaimsPrincipal</c>; tests pass it
+/// directly. Mode-agnostic — the catalog is platform-owned in both modes.
+/// </summary>
+public sealed record PlanEditorPrincipal(string? UserId, string? Email);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanVersionEditor.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanVersionEditor.cs
@@ -21,14 +21,19 @@ namespace Tamma.Api.Services.Pricing;
 /// <para>The partial unique index <c>UX_plans_OneActivePerSlug</c> is the
 /// load-bearing backstop — the DB rejects a second <c>active</c> row per slug
 /// regardless of app logic, so a flip-then-insert race can never leave two
-/// active versions. <see cref="EnsureMutableOrThrow"/> is the application-level
-/// guard that rejects any direct mutation of an immutable row with
-/// <c>PLAN.VERSION.IMMUTABLE</c>.</para>
+/// active versions. The AUTHORITATIVE immutability enforcement is the
+/// <c>SaveChanges</c> interceptor on <c>ControlPlaneDbContext</c>, which throws
+/// <c>PLAN.VERSION.IMMUTABLE</c> for ANY mutation of an active/deprecated plan
+/// row OR its child feature/entitlement/price rows — including raw EF mutations
+/// that never go through this editor. <see cref="EnsureMutableOrThrow"/> is an
+/// optional pre-flight convenience that surfaces the same rejection early
+/// (before a write is attempted); it does NOT replace the interceptor.</para>
 ///
 /// <para>This story ships the editor as a tested SERVICE METHOD; wiring it
 /// behind admin create/deprecate ENDPOINTS is Story 34-2. The catalog is
-/// platform-owned in both modes — there is no per-tenant override layer; in
-/// SaaS the endpoint (34-2) gates this on <c>OwnerAccess</c>.</para>
+/// platform-GLOBAL in both modes — there is no per-tenant override layer; in
+/// SaaS the endpoint (34-2) gates this on <c>PlatformOwnerAccess</c> (the
+/// price book is platform-scoped admin work, not a per-tenant owner gate).</para>
 /// </summary>
 public sealed class PlanVersionEditor
 {
@@ -52,11 +57,17 @@ public sealed class PlanVersionEditor
     }
 
     /// <summary>
-    /// Application-level immutability guard. A <c>Plan</c> whose status is
+    /// Optional pre-flight immutability check. A <c>Plan</c> whose status is
     /// <c>active</c> or <c>deprecated</c> may NOT be mutated in place — only a
     /// <c>draft</c> row is writable (plus the controlled active→deprecated flip
     /// performed inside <see cref="CreateNewVersionAsync"/>). Throws
     /// <c>PLAN.VERSION.IMMUTABLE</c> (severity High) otherwise.
+    ///
+    /// <para>This is a convenience that lets a caller reject early, with a
+    /// friendly message, BEFORE attempting a write. It is NOT the authoritative
+    /// guard: the <c>ControlPlaneDbContext</c> <c>SaveChanges</c> interceptor
+    /// enforces the same invariant (incl. child rows) for every save path,
+    /// even raw EF mutations that bypass this editor entirely.</para>
     /// </summary>
     public void EnsureMutableOrThrow(Plan plan)
     {
@@ -171,11 +182,21 @@ public sealed class PlanVersionEditor
             "Plan version-create transaction begin: {Slug} v{Prior} → v{New}",
             slug, prior.Version, newVersion);
 
-        // Flip-then-insert in one transaction. The partial unique index means
-        // the prior MUST be deprecated before the new active row commits, or
-        // the insert is rejected — the DB is the final arbiter of "one active
-        // per slug". InMemory tests don't enforce indexes; the relational
-        // tests (Postgres) cover that invariant.
+        // Flip-then-insert in one transaction with DETERMINISTIC ordering:
+        // deprecate the prior (SaveChanges), THEN add the new active row
+        // (SaveChanges), then commit. EF's single-SaveChanges UPDATE-before-
+        // INSERT topological sort keys off DECLARED index columns and does NOT
+        // reliably account for FILTERED indexes (the determining Status column
+        // lives in the UX_plans_OneActivePerSlug WHERE predicate, not the index
+        // key) — see dotnet/efcore#7193. If EF emitted INSERT-before-UPDATE the
+        // new active row would collide with the still-active prior and the
+        // create would spuriously fail. Two explicit SaveChanges inside ONE
+        // transaction make the ordering unconditional; the partial unique index
+        // remains the final DB-level arbiter of "one active per slug".
+        //
+        // Compatible with the ControlPlaneDbContext immutability interceptor:
+        // the first save is the controlled active→deprecated flip (allowed);
+        // the second adds a freshly-Added active plan + its children (allowed).
         var ownsTx = _db.Database.CurrentTransaction is null
             && _db.Database.IsRelational();
         var tx = ownsTx ? await _db.Database.BeginTransactionAsync(ct) : null;
@@ -183,6 +204,8 @@ public sealed class PlanVersionEditor
         {
             prior.Status = "deprecated";
             prior.UpdatedAt = now;
+            await _db.SaveChangesAsync(ct);
+
             _db.Plans.Add(newPlan);
             await _db.SaveChangesAsync(ct);
 

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanVersionEditor.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanVersionEditor.cs
@@ -35,7 +35,7 @@ namespace Tamma.Api.Services.Pricing;
 /// SaaS the endpoint (34-2) gates this on <c>PlatformOwnerAccess</c> (the
 /// price book is platform-scoped admin work, not a per-tenant owner gate).</para>
 /// </summary>
-public sealed class PlanVersionEditor
+public sealed class PlanVersionEditor : IPlanVersionEditor
 {
     private const string WorkflowVersion = "1.0.0";
 

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/TenantMoveService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/TenantMoveService.cs
@@ -460,10 +460,14 @@ public sealed class TenantMoveService : ITenantMoveService
 
         // Tier eligibility/capacity — the SAME predicate placement uses
         // (TenantPlacementService.EligibleFor), evaluated in-memory on the
-        // loaded target row.
-        var plan = await db.Plans.FirstOrDefaultAsync(p => p.Slug == tenant.Plan, ct)
+        // loaded target row. Story 34-1: pin Status == "active" so a multi-
+        // version slug resolves the live PlacementPolicy, not a deprecated
+        // row picked in undefined order. UX_plans_OneActivePerSlug keeps it
+        // deterministic.
+        var plan = await db.Plans
+                .FirstOrDefaultAsync(p => p.Slug == tenant.Plan && p.Status == "active", ct)
             ?? throw new InvalidOperationException(
-                $"No plans row for slug '{tenant.Plan}' (tenant '{tenantId}') — move "
+                $"No active plans row for slug '{tenant.Plan}' (tenant '{tenantId}') — move "
                 + "requires plans.PlacementPolicy; seed or repair the plans table.");
         if (!TenantPlacementService.EligibleFor(plan.Slug, plan.PlacementPolicy)
                 .Compile()(target))

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/TenantPlacementService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/TenantPlacementService.cs
@@ -56,9 +56,15 @@ public sealed class TenantPlacementService : ITenantPlacementService
 
         // Plan lookup is tenant→system→error: a tenant whose plan slug has
         // no plans row is a configuration fault — never default silently.
-        var plan = await db.Plans.FirstOrDefaultAsync(p => p.Slug == tenant.Plan, ct)
+        // Story 34-1 made a slug a multi-version chain (active + deprecated
+        // rows), so the lookup MUST pin Status == "active" — otherwise it can
+        // return a deprecated row with a stale PlacementPolicy in undefined
+        // order. The partial unique index UX_plans_OneActivePerSlug guarantees
+        // exactly one active row per slug.
+        var plan = await db.Plans
+                .FirstOrDefaultAsync(p => p.Slug == tenant.Plan && p.Status == "active", ct)
             ?? throw new InvalidOperationException(
-                $"No plans row for slug '{tenant.Plan}' (tenant '{tenantId}') — placement "
+                $"No active plans row for slug '{tenant.Plan}' (tenant '{tenantId}') — placement "
                 + "requires plans.PlacementPolicy; seed or repair the plans table.");
 
         var slug = plan.Slug;

--- a/apps/tamma-elsa/src/Tamma.Api/Tamma.Api.csproj
+++ b/apps/tamma-elsa/src/Tamma.Api/Tamma.Api.csproj
@@ -39,6 +39,13 @@
          ConnectionStrings:Redis is configured, the Redis-backed backend
          kicks in so multi-pod deployments share a window counter. -->
     <PackageReference Include="StackExchange.Redis" Version="2.12.14" />
+    <!-- Story 35-1 (Epic 35 billing foundation): Stripe customer mapping +
+         Product/Price/Meter catalog. v51.2.0 is the latest stable and supports
+         .NET 8 (netstandard2.0 / netcore). All Stripe service classes
+         (CustomerService / ProductService / PriceService / Billing.MeterService)
+         are non-sealed with virtual *Async methods, so tests mock at the
+         service-interface boundary — no live Stripe in CI. -->
+    <PackageReference Include="Stripe.net" Version="51.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/tamma-elsa/src/Tamma.Core/Audit/AuditCategory.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Audit/AuditCategory.cs
@@ -1,0 +1,44 @@
+namespace Tamma.Core.Audit;
+
+/// <summary>
+/// Story 37-1 — the 11 compliance-relevant categories every catalogued
+/// sensitive action falls under. Stored on <c>audit_records.category</c> as
+/// the member name (lowercased) so the curated trail reads as
+/// <c>secret</c>/<c>rbac</c>/… in ad-hoc SQL. Every value MUST have ≥1
+/// catalogued action code (asserted by the catalog-completeness test).
+/// </summary>
+public enum AuditCategory
+{
+    /// <summary>Prompt / persona / convention / agent-config / sanitization-rule edits.</summary>
+    Config,
+
+    /// <summary>Role / membership / invite changes.</summary>
+    Rbac,
+
+    /// <summary>Secret read / write / reveal / rotate / revoke.</summary>
+    Secret,
+
+    /// <summary>Provider-key / provider-chain (bring-your-own-key) changes.</summary>
+    Byok,
+
+    /// <summary>Plan / subscription / budget changes.</summary>
+    Billing,
+
+    /// <summary>Data export / DSAR (data-subject-access-request).</summary>
+    Export,
+
+    /// <summary>Login success/failure, logout, password reset, token refresh/reuse.</summary>
+    Auth,
+
+    /// <summary>Platform-admin impersonation start/end.</summary>
+    Impersonation,
+
+    /// <summary>Tenant provision / deprovision / move / lifecycle.</summary>
+    Tenant,
+
+    /// <summary>Agent dispatch / autonomous code action.</summary>
+    Agent,
+
+    /// <summary>Persona / system-prompt changes.</summary>
+    Persona,
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Audit/AuditSeverity.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Audit/AuditSeverity.cs
@@ -1,0 +1,22 @@
+namespace Tamma.Core.Audit;
+
+/// <summary>
+/// Story 37-1 — coarse severity carried on every curated audit record so a
+/// compliance feed can triage ("show me every <c>critical</c> action last
+/// quarter") without re-deriving from the action code. Stored on
+/// <c>audit_records.severity</c> as the member name (lowercased).
+/// </summary>
+public enum AuditSeverity
+{
+    /// <summary>Routine, expected activity (e.g. login success).</summary>
+    Info,
+
+    /// <summary>Noteworthy but not alarming (e.g. config / persona edits).</summary>
+    Notice,
+
+    /// <summary>Privilege- or money-affecting (e.g. role change, plan change).</summary>
+    Warning,
+
+    /// <summary>Highest-sensitivity (e.g. secret reveal, impersonation).</summary>
+    Critical,
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Audit/SensitiveActionCatalog.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Audit/SensitiveActionCatalog.cs
@@ -1,0 +1,220 @@
+namespace Tamma.Core.Audit;
+
+/// <summary>
+/// Story 37-1 — the canonical catalog of compliance-relevant sensitive
+/// actions. Shape mirrors <c>SecretAuditEventTypes</c> (a const-class of
+/// canonical event-type strings) plus an immutable <see cref="ByCode"/>
+/// lookup that classifies each into a category / severity / SOC2 control.
+///
+/// <para><b>This catalog MAPS already-emitted DCB events; it does NOT
+/// re-emit them.</b> The <see cref="AuditProjector"/> (Story 37-1) observes
+/// the events already flowing into <c>domain_events</c> / <c>platform_events</c>
+/// and materialises a curated <c>audit_records</c> row for each catalogued
+/// match. Adding a code here does not add an emit call-site.</para>
+///
+/// <para>Codes flagged <see cref="SensitiveActionDescriptor.MapsExistingEmitter"/>
+/// <c>= true</c> were verified by grep at authoring (2026-06-17) against the
+/// real emitters: <c>SecretAuditEventTypes</c> (Epic 29 secret cabinet),
+/// <c>AdminImpersonationsEndpoints</c> (28-R2 impersonation platform events),
+/// <c>OrgEndpoints</c> (tenant membership/lifecycle), <c>AuthEndpoints</c>
+/// (logout-all / org-switch / refresh-reuse platform events),
+/// <c>ConventionEventsService</c> / <c>PromptEventsService</c> (config edits),
+/// <c>AgentRepository</c> / <c>AgentEndpoints</c> (agent entity + config),
+/// <c>BillingEvents</c> (billing), and the Story 4-x autonomous-loop emitters.
+/// Codes flagged <c>false</c> are forward-looking taxonomy entries (the
+/// catalog is the future taxonomy too) for sensitive actions Tamma does not
+/// yet emit; the projector will start materialising them the day an emitter
+/// lands, with zero catalog change.</para>
+/// </summary>
+public static class SensitiveActionCatalog
+{
+    // ── SECRET (maps existing Epic 29 SecretAuditEventTypes — NOT re-emitted) ──
+    public const string SecretRead = "SECRET.READ";
+    public const string SecretWrite = "SECRET.WRITE";
+    public const string SecretReveal = "SECRET.REVEAL";
+    public const string SecretRotateStarted = "SECRET.ROTATE.STARTED";
+    public const string SecretRotateSucceeded = "SECRET.ROTATE.SUCCESS";
+    public const string SecretRotateFailed = "SECRET.ROTATE.FAILED";
+    public const string SecretVersionRevoked = "SECRET.VERSION.REVOKED";
+
+    // ── RBAC (maps existing OrgEndpoints emitters) ──
+    public const string TenantMemberRoleChanged = "TENANT.MEMBER_ROLE_CHANGED.SUCCESS";
+    public const string TenantMemberInvited = "TENANT.MEMBER_INVITED.SUCCESS";
+    public const string TenantMemberJoined = "TENANT.MEMBER_JOINED.SUCCESS";
+    public const string TenantMemberRemoved = "TENANT.MEMBER_REMOVED.SUCCESS";
+    public const string TenantOwnershipTransferred = "TENANT.OWNERSHIP_TRANSFERRED.SUCCESS";
+
+    /// <summary>Forward-looking: a platform-admin changing a user's platform role
+    /// (AdminEndpoints logs <c>USER.ROLE_CHANGED.SUCCESS</c> today but does NOT
+    /// append it as a DCB event — when it starts emitting, this catalogs it).</summary>
+    public const string UserRoleChanged = "USER.ROLE_CHANGED.SUCCESS";
+
+    // ── IMPERSONATION (maps existing 28-R2 platform-event emitters) ──
+    public const string ImpersonationStarted = "IMPERSONATION.STARTED";
+    public const string ImpersonationEnded = "IMPERSONATION.ENDED";
+
+    // ── CONFIG (maps existing convention/prompt/agent-config emitters) ──
+    public const string ConventionCreated = "CONVENTION.CREATED.SUCCESS";
+    public const string ConventionUpdated = "CONVENTION.UPDATED.SUCCESS";
+    public const string ConventionDeleted = "CONVENTION.DELETED.SUCCESS";
+    public const string ConventionReset = "CONVENTION.RESET.SUCCESS";
+    public const string AgentConfigUpdated = "AGENT_CONFIG.UPDATED.SUCCESS";
+
+    /// <summary>Forward-looking: an edit to the tenant content-sanitization ruleset.</summary>
+    public const string SanitizationRuleChanged = "SANITIZATION_RULE.CHANGED.SUCCESS";
+
+    // ── PERSONA (maps existing prompt-store emitters; system prompts are personas) ──
+    public const string PromptCreated = "PROMPT.CREATED.SUCCESS";
+    public const string PromptUpdated = "PROMPT.UPDATED.SUCCESS";
+    public const string PromptDeleted = "PROMPT.DELETED.SUCCESS";
+    public const string PromptReset = "PROMPT.RESET.SUCCESS";
+
+    // ── BYOK (forward-looking — provider-key / provider-chain edits) ──
+    public const string ProviderKeyChanged = "PROVIDER_KEY.CHANGED.SUCCESS";
+    public const string ProviderChainChanged = "PROVIDER_CHAIN.CHANGED.SUCCESS";
+
+    // ── BILLING (maps existing BillingEvents; budget edits forward-looking) ──
+    public const string BillingCustomerCreated = "BILLING.CUSTOMER.CREATED";
+    public const string PlanUpdated = "PLAN.UPDATED";
+    public const string PlanVersionCreated = "PLAN.VERSION.CREATED";
+
+    /// <summary>Forward-looking: a tenant changing its spend budget config.</summary>
+    public const string BudgetChanged = "BUDGET.CONFIG.CHANGED.SUCCESS";
+
+    // ── EXPORT (forward-looking — Story 37-10/37-11 data export + GDPR DSAR) ──
+    public const string DataExported = "DATA.EXPORTED.SUCCESS";
+    public const string DsarRequested = "GDPR.DSAR.REQUESTED";
+
+    // ── AUTH (maps existing AuthEndpoints emitters; login/reset forward-looking) ──
+    public const string LogoutAll = "USER.LOGOUT_ALL.SUCCESS";
+    public const string OrgSwitched = "USER.ORG_SWITCHED.SUCCESS";
+    public const string RefreshReuseDetected = "AUTH.REFRESH_REUSE_DETECTED";
+
+    /// <summary>Forward-looking: an interactive login succeeded.</summary>
+    public const string LoginSuccess = "AUTH.LOGIN.SUCCESS";
+
+    /// <summary>Forward-looking: an interactive login failed (brute-force signal).</summary>
+    public const string LoginFailure = "AUTH.LOGIN.FAILURE";
+
+    /// <summary>Forward-looking: a password-reset completed.</summary>
+    public const string PasswordReset = "AUTH.PASSWORD_RESET.SUCCESS";
+
+    // ── TENANT lifecycle (maps existing OrgEndpoints / provisioning emitters) ──
+    public const string TenantCreated = "TENANT.CREATED.SUCCESS";
+    public const string TenantProvisioned = "TENANT.PROVISIONED.SUCCESS";
+    public const string TenantDeleted = "TENANT.DELETED.SUCCESS";
+    public const string TenantPurged = "TENANT.PURGED.SUCCESS";
+    public const string TenantMoveRequested = "TENANT.MOVE.REQUESTED";
+
+    // ── AGENT (maps existing AgentRepository / AgentEndpoints / loop emitters) ──
+    public const string AgentCreated = "AGENT.CREATED.SUCCESS";
+    public const string AgentArchived = "AGENT.ARCHIVED.SUCCESS";
+    public const string AgentVersionPublished = "AGENT.VERSION_PUBLISHED.SUCCESS";
+    public const string AgentDispatchSucceeded = "AGENT.DISPATCH.SUCCESS";
+    public const string AgentDispatchFailed = "AGENT.DISPATCH.FAILED";
+    public const string CodeGeneratedFailed = "CODE.GENERATED.FAILED";
+
+    /// <summary>
+    /// Immutable code → descriptor lookup. The single source of truth for
+    /// "is this raw event a sensitive action, and how is it classified". The
+    /// projector keys exclusively off this dictionary; nothing else decides
+    /// what is auditable.
+    /// </summary>
+    public static readonly IReadOnlyDictionary<string, SensitiveActionDescriptor> ByCode;
+
+    /// <summary>
+    /// True when the projector should materialise an <c>audit_record</c> for a
+    /// raw event of this type. O(1) dictionary containment check.
+    /// </summary>
+    public static bool IsSensitive(string? eventType) =>
+        !string.IsNullOrEmpty(eventType) && ByCode.ContainsKey(eventType);
+
+    /// <summary>Resolve the descriptor for a raw event type, or <c>null</c> if not sensitive.</summary>
+    public static SensitiveActionDescriptor? Resolve(string? eventType) =>
+        !string.IsNullOrEmpty(eventType) && ByCode.TryGetValue(eventType, out var d) ? d : null;
+
+    static SensitiveActionCatalog()
+    {
+        // Local builder helper keeps each entry to one terse line and pins
+        // the ActionCode to the dictionary key (no drift).
+        var map = new Dictionary<string, SensitiveActionDescriptor>(StringComparer.Ordinal);
+
+        void Add(string code, AuditCategory cat, AuditSeverity sev, string soc2,
+            string targetHint, bool mapsExisting) =>
+            map[code] = new SensitiveActionDescriptor(code, cat, sev, soc2, targetHint, mapsExisting);
+
+        // ── SECRET — CC6.1 (logical access to sensitive resources) ──
+        Add(SecretRead, AuditCategory.Secret, AuditSeverity.Notice, "CC6.1", "secret", true);
+        Add(SecretWrite, AuditCategory.Secret, AuditSeverity.Warning, "CC6.1", "secret", true);
+        Add(SecretReveal, AuditCategory.Secret, AuditSeverity.Critical, "CC6.1", "secret", true);
+        Add(SecretRotateStarted, AuditCategory.Secret, AuditSeverity.Notice, "CC6.1", "secret", true);
+        Add(SecretRotateSucceeded, AuditCategory.Secret, AuditSeverity.Notice, "CC6.1", "secret", true);
+        Add(SecretRotateFailed, AuditCategory.Secret, AuditSeverity.Warning, "CC6.1", "secret", true);
+        Add(SecretVersionRevoked, AuditCategory.Secret, AuditSeverity.Warning, "CC6.1", "secret", true);
+
+        // ── RBAC — CC6.3 (role-based access / least privilege) ──
+        Add(TenantMemberRoleChanged, AuditCategory.Rbac, AuditSeverity.Warning, "CC6.3", "user", true);
+        Add(TenantMemberInvited, AuditCategory.Rbac, AuditSeverity.Notice, "CC6.3", "user", true);
+        Add(TenantMemberJoined, AuditCategory.Rbac, AuditSeverity.Notice, "CC6.3", "user", true);
+        Add(TenantMemberRemoved, AuditCategory.Rbac, AuditSeverity.Warning, "CC6.3", "user", true);
+        Add(TenantOwnershipTransferred, AuditCategory.Rbac, AuditSeverity.Critical, "CC6.3", "tenant", true);
+        Add(UserRoleChanged, AuditCategory.Rbac, AuditSeverity.Warning, "CC6.3", "user", false);
+
+        // ── IMPERSONATION — CC6.1 (privileged-access monitoring) ──
+        Add(ImpersonationStarted, AuditCategory.Impersonation, AuditSeverity.Critical, "CC6.1", "tenant", true);
+        Add(ImpersonationEnded, AuditCategory.Impersonation, AuditSeverity.Notice, "CC6.1", "tenant", true);
+
+        // ── CONFIG — CC8.1 (change management) ──
+        Add(ConventionCreated, AuditCategory.Config, AuditSeverity.Notice, "CC8.1", "convention", true);
+        Add(ConventionUpdated, AuditCategory.Config, AuditSeverity.Notice, "CC8.1", "convention", true);
+        Add(ConventionDeleted, AuditCategory.Config, AuditSeverity.Warning, "CC8.1", "convention", true);
+        Add(ConventionReset, AuditCategory.Config, AuditSeverity.Notice, "CC8.1", "convention", true);
+        Add(AgentConfigUpdated, AuditCategory.Config, AuditSeverity.Notice, "CC8.1", "agent_config", true);
+        Add(SanitizationRuleChanged, AuditCategory.Config, AuditSeverity.Warning, "CC8.1", "sanitization_rule", false);
+
+        // ── PERSONA — CC8.1 (prompt/persona are the agent's behavioural config) ──
+        Add(PromptCreated, AuditCategory.Persona, AuditSeverity.Notice, "CC8.1", "prompt", true);
+        Add(PromptUpdated, AuditCategory.Persona, AuditSeverity.Notice, "CC8.1", "prompt", true);
+        Add(PromptDeleted, AuditCategory.Persona, AuditSeverity.Warning, "CC8.1", "prompt", true);
+        Add(PromptReset, AuditCategory.Persona, AuditSeverity.Notice, "CC8.1", "prompt", true);
+
+        // ── BYOK — CC6.1 (provider credential / chain configuration) ──
+        Add(ProviderKeyChanged, AuditCategory.Byok, AuditSeverity.Warning, "CC6.1", "provider", false);
+        Add(ProviderChainChanged, AuditCategory.Byok, AuditSeverity.Notice, "CC6.1", "provider", false);
+
+        // ── BILLING — A1.1 (commitments affecting availability/spend) ──
+        Add(BillingCustomerCreated, AuditCategory.Billing, AuditSeverity.Notice, "A1.1", "tenant", true);
+        Add(PlanUpdated, AuditCategory.Billing, AuditSeverity.Warning, "A1.1", "plan", true);
+        Add(PlanVersionCreated, AuditCategory.Billing, AuditSeverity.Notice, "A1.1", "plan", true);
+        Add(BudgetChanged, AuditCategory.Billing, AuditSeverity.Warning, "A1.1", "budget", false);
+
+        // ── EXPORT — P (privacy / GDPR data-subject access) + C1.1 (confidentiality) ──
+        Add(DataExported, AuditCategory.Export, AuditSeverity.Warning, "C1.1", "export", false);
+        Add(DsarRequested, AuditCategory.Export, AuditSeverity.Warning, "P6.1", "user", false);
+
+        // ── AUTH — CC6.1 (authentication events) ──
+        Add(LogoutAll, AuditCategory.Auth, AuditSeverity.Notice, "CC6.1", "user", true);
+        Add(OrgSwitched, AuditCategory.Auth, AuditSeverity.Info, "CC6.1", "user", true);
+        Add(RefreshReuseDetected, AuditCategory.Auth, AuditSeverity.Critical, "CC6.1", "user", true);
+        Add(LoginSuccess, AuditCategory.Auth, AuditSeverity.Info, "CC6.1", "user", false);
+        Add(LoginFailure, AuditCategory.Auth, AuditSeverity.Notice, "CC6.1", "user", false);
+        Add(PasswordReset, AuditCategory.Auth, AuditSeverity.Warning, "CC6.1", "user", false);
+
+        // ── TENANT lifecycle — A1.2 (provisioning/de-provisioning) ──
+        Add(TenantCreated, AuditCategory.Tenant, AuditSeverity.Notice, "A1.2", "tenant", true);
+        Add(TenantProvisioned, AuditCategory.Tenant, AuditSeverity.Notice, "A1.2", "tenant", true);
+        Add(TenantDeleted, AuditCategory.Tenant, AuditSeverity.Warning, "A1.2", "tenant", true);
+        Add(TenantPurged, AuditCategory.Tenant, AuditSeverity.Critical, "A1.2", "tenant", true);
+        Add(TenantMoveRequested, AuditCategory.Tenant, AuditSeverity.Notice, "A1.2", "tenant", true);
+
+        // ── AGENT — CC8.1 (autonomous code actions are change-management evidence) ──
+        Add(AgentCreated, AuditCategory.Agent, AuditSeverity.Notice, "CC8.1", "agent", true);
+        Add(AgentArchived, AuditCategory.Agent, AuditSeverity.Notice, "CC8.1", "agent", true);
+        Add(AgentVersionPublished, AuditCategory.Agent, AuditSeverity.Notice, "CC8.1", "agent", true);
+        Add(AgentDispatchSucceeded, AuditCategory.Agent, AuditSeverity.Info, "CC8.1", "agent", true);
+        Add(AgentDispatchFailed, AuditCategory.Agent, AuditSeverity.Warning, "CC8.1", "agent", true);
+        Add(CodeGeneratedFailed, AuditCategory.Agent, AuditSeverity.Warning, "CC8.1", "issue", true);
+
+        ByCode = map;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Audit/SensitiveActionDescriptor.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Audit/SensitiveActionDescriptor.cs
@@ -1,0 +1,31 @@
+namespace Tamma.Core.Audit;
+
+/// <summary>
+/// Story 37-1 — the classification record for one catalogued sensitive
+/// action. The <see cref="SensitiveActionCatalog"/> maps every catalogued
+/// DCB event-type string to exactly one of these. It is the single source of
+/// truth for "is this raw event a sensitive action, and how is it classified".
+/// </summary>
+/// <param name="ActionCode">Canonical DCB event-type string, e.g.
+/// <c>SECRET.REVEAL</c>. This is the key the projector matches a raw
+/// <c>DomainEvent</c>/<c>PlatformEvent</c>'s <c>Type</c> against.</param>
+/// <param name="Category">Compliance category.</param>
+/// <param name="Severity">Coarse triage severity.</param>
+/// <param name="Soc2ControlId">SOC2 Trust-Services-Criteria control id this
+/// action provides evidence for, e.g. <c>CC6.1</c>. Never empty.</param>
+/// <param name="TargetTypeHint">Default target-type label written to the
+/// curated record when the raw event doesn't carry one, e.g. <c>secret</c>,
+/// <c>user</c>, <c>tenant</c>.</param>
+/// <param name="MapsExistingEmitter"><c>true</c> when this code maps an event
+/// type a real emitter already appends to the DCB store today (verified by
+/// grep at authoring time); <c>false</c> when it is a forward-looking
+/// taxonomy entry for an action not yet emitted. The catalog-completeness
+/// test pins the <c>true</c> set against the actual emitter constants so a
+/// future rename that drops an emitted type from the catalog fails CI.</param>
+public sealed record SensitiveActionDescriptor(
+    string ActionCode,
+    AuditCategory Category,
+    AuditSeverity Severity,
+    string Soc2ControlId,
+    string TargetTypeHint,
+    bool MapsExistingEmitter);

--- a/apps/tamma-elsa/src/Tamma.Core/Billing/BillingMode.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Billing/BillingMode.cs
@@ -1,0 +1,28 @@
+namespace Tamma.Core.Billing;
+
+/// <summary>
+/// Story 35-1 — how a tenant's AI usage is billed. Lives in
+/// <c>Tamma.Core</c> so both the data layer (text column on
+/// <c>billing_customers</c>) and the API layer (the billing provider) reference
+/// a single enum.
+///
+/// <para>This story only stores and defaults the flag. The metering /
+/// token-markup-suppression behaviour that reads it is Story 35-3's scope — a
+/// BYOK tenant must not be charged the platform token markup, but that logic is
+/// NOT implemented here.</para>
+/// </summary>
+public enum BillingMode
+{
+    /// <summary>
+    /// Default — Tamma supplies the AI provider credentials and bills the
+    /// tenant for metered token usage (with the platform markup).
+    /// </summary>
+    PlatformProvided,
+
+    /// <summary>
+    /// Bring-your-own-key — the tenant supplies their own AI provider
+    /// credentials. Recorded so Story 35-3 metering can suppress the token
+    /// markup. (No suppression logic in this story.)
+    /// </summary>
+    Byok,
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Enums/CostBasis.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Enums/CostBasis.cs
@@ -1,0 +1,23 @@
+namespace Tamma.Core.Enums;
+
+/// <summary>
+/// Story 36-1 — discriminates whether the LLM/agent cost on an analytics
+/// fact row was paid against the tenant's own provider key (BYOK — Tamma
+/// never bills it) or against a Tamma-platform key (Tamma fronts the cost and
+/// may bill the tenant via the row's <c>PlatformBilledUsd</c> measure).
+///
+/// <para>Persisted as lowercase text (<c>byok</c> / <c>platform</c>) by the
+/// analytics EF model config (mirrors the
+/// <see cref="MentorshipState"/>/<c>SessionStatus</c>
+/// <c>HasConversion&lt;string&gt;()</c> enum-to-text precedent, but
+/// lower-cased so the discriminator is uniform in ad-hoc SQL). The ordinals
+/// are part of the contract — do not renumber.</para>
+/// </summary>
+public enum CostBasis
+{
+    /// <summary>Cost paid against the tenant's own provider key — Tamma never bills it.</summary>
+    Byok = 0,
+
+    /// <summary>Cost fronted by a Tamma-platform key — billable to the tenant via PlatformBilledUsd.</summary>
+    Platform = 1,
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Enums/EntitlementMetricKey.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Enums/EntitlementMetricKey.cs
@@ -1,0 +1,38 @@
+namespace Tamma.Core.Enums;
+
+/// <summary>
+/// Story 34-1 — closed set of meterable/limitable quota dimensions. Shared by
+/// <c>PlanEntitlement</c> (limits), <c>PlanPrice</c> metered components
+/// (pricing), usage metering (Epic 35), and enforcement (later Epic 34
+/// stories) so a quota key is identical across every layer. Persisted as the
+/// snake_case string (see <see cref="EntitlementMetricKeyExtensions"/>), never
+/// the numeric ordinal — ordinals are not a stable wire/DB contract.
+///
+/// <para>Adding a member here is a breaking change: every member MUST have a
+/// matching snake_case mapping in <see cref="EntitlementMetricKeyExtensions"/>
+/// (the enum-tests assert the map has exactly one entry per member, so a new
+/// member without a mapping fails the suite).</para>
+/// </summary>
+public enum EntitlementMetricKey
+{
+    /// <summary>Number of agent identities a tenant may own.</summary>
+    Agents,
+
+    /// <summary>Workflow run executions (per period).</summary>
+    WorkflowRuns,
+
+    /// <summary>LLM tokens consumed (per period).</summary>
+    LlmTokens,
+
+    /// <summary>Seats / member users.</summary>
+    Seats,
+
+    /// <summary>Connected repositories.</summary>
+    Repos,
+
+    /// <summary>RAG document storage in megabytes.</summary>
+    RagStorageMb,
+
+    /// <summary>Benchmark/leaderboard result retention in days.</summary>
+    BenchmarkRetentionDays,
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Enums/EntitlementMetricKeyExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Enums/EntitlementMetricKeyExtensions.cs
@@ -1,0 +1,80 @@
+using Tamma.Core;
+
+namespace Tamma.Core.Enums;
+
+/// <summary>
+/// Story 34-1 — the snake_case string contract for
+/// <see cref="EntitlementMetricKey"/>. EF persists the metric key via a
+/// <c>HasConversion</c> value converter built on these methods so the DB
+/// column stores <c>text</c> (e.g. <c>llm_tokens</c>), never the unstable
+/// numeric ordinal. Metering / pricing / enforcement all key off the same
+/// string so a quota key can never drift between layers.
+/// </summary>
+public static class EntitlementMetricKeyExtensions
+{
+    /// <summary>
+    /// Canonical snake_case wire/DB form per member. The single source of
+    /// truth for the persisted string. Kept in sync with
+    /// <see cref="EntitlementMetricKey"/> (enum-tests assert one entry per
+    /// member with no duplicates).
+    /// </summary>
+    private static readonly IReadOnlyDictionary<EntitlementMetricKey, string> s_toString =
+        new Dictionary<EntitlementMetricKey, string>
+        {
+            [EntitlementMetricKey.Agents] = "agents",
+            [EntitlementMetricKey.WorkflowRuns] = "workflow_runs",
+            [EntitlementMetricKey.LlmTokens] = "llm_tokens",
+            [EntitlementMetricKey.Seats] = "seats",
+            [EntitlementMetricKey.Repos] = "repos",
+            [EntitlementMetricKey.RagStorageMb] = "rag_storage_mb",
+            [EntitlementMetricKey.BenchmarkRetentionDays] = "benchmark_retention_days",
+        };
+
+    private static readonly IReadOnlyDictionary<string, EntitlementMetricKey> s_fromString =
+        s_toString.ToDictionary(kv => kv.Value, kv => kv.Key, StringComparer.Ordinal);
+
+    /// <summary>
+    /// The complete set of canonical snake_case strings — exposed for tests
+    /// and any consumer that needs to enumerate every valid metric key.
+    /// </summary>
+    public static IReadOnlyCollection<string> AllMetricStrings => s_fromString.Keys.ToArray();
+
+    /// <summary>Map a metric key to its canonical snake_case persisted form.</summary>
+    public static string ToMetricString(this EntitlementMetricKey key)
+    {
+        if (s_toString.TryGetValue(key, out var s))
+        {
+            return s;
+        }
+
+        // An enum member with no mapping is a programming error — fail loud.
+        throw new TammaError(
+            "PLAN.METRIC_KEY.UNMAPPED",
+            $"EntitlementMetricKey '{key}' has no snake_case mapping.",
+            new Dictionary<string, object?> { ["metricKey"] = key.ToString() },
+            retryable: false,
+            severity: TammaErrorSeverity.High);
+    }
+
+    /// <summary>
+    /// Parse a snake_case string back to its <see cref="EntitlementMetricKey"/>.
+    /// Throws <see cref="TammaError"/> (<c>PLAN.METRIC_KEY.UNKNOWN</c>) on an
+    /// unmapped string — never silently coerces to a default member.
+    /// </summary>
+    public static EntitlementMetricKey Parse(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        if (s_fromString.TryGetValue(value, out var key))
+        {
+            return key;
+        }
+
+        throw new TammaError(
+            "PLAN.METRIC_KEY.UNKNOWN",
+            $"Unknown entitlement metric key '{value}'.",
+            new Dictionary<string, object?> { ["value"] = value },
+            retryable: false,
+            severity: TammaErrorSeverity.High);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Audit/AuditProjector.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Audit/AuditProjector.cs
@@ -35,6 +35,15 @@ public sealed class AuditProjector : IAuditProjector
     /// classification could not be resolved at all (no catalog descriptor).</summary>
     public const string UnclassifiedTargetType = "unclassified";
 
+    /// <summary>Dedicated marker for the <c>category</c> of a quarantine row whose
+    /// event has no catalog descriptor (so the real <see cref="AuditCategory"/>
+    /// cannot be derived). Distinct from <see cref="UnclassifiedTargetType"/> —
+    /// the category and target-type columns are different dimensions and must not
+    /// share one sentinel constant, even though their fallback spelling is the
+    /// same. Not an <see cref="AuditCategory"/> member: it is a sentinel reserved
+    /// for the descriptor-missing quarantine path only.</summary>
+    public const string UnclassifiedCategory = "unclassified";
+
     /// <inheritdoc />
     public AuditRecord? TryBuildRecord(
         RawAuditEvent rawEvent, AuditOwnershipMode mode, Guid? singleUserOwnerId)
@@ -114,7 +123,7 @@ public sealed class AuditProjector : IAuditProjector
             ActionCode = descriptor?.ActionCode ?? rawEvent.Type,
             Category = descriptor is not null
                 ? descriptor.Category.ToString().ToLowerInvariant()
-                : UnclassifiedTargetType,
+                : UnclassifiedCategory,
             Severity = descriptor is not null
                 ? descriptor.Severity.ToString().ToLowerInvariant()
                 : "warning",

--- a/apps/tamma-elsa/src/Tamma.Data/Audit/AuditProjector.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Audit/AuditProjector.cs
@@ -1,0 +1,255 @@
+using System.Text.Json;
+using Tamma.Core.Audit;
+using Tamma.Core.Redaction;
+using Tamma.Data.Entities;
+
+namespace Tamma.Data.Audit;
+
+/// <summary>
+/// Story 37-1 — pure projection of a raw DCB event into a curated, redacted,
+/// per-mode-owned <see cref="AuditRecord"/>. No I/O: classification keys off
+/// <see cref="SensitiveActionCatalog"/>; the payload is redacted via
+/// <see cref="CredentialRedactor"/> BEFORE the row leaves this class (AC10);
+/// ownership is assigned per <see cref="AuditOwnershipMode"/> (AC11). The
+/// background host does the reading + writing.
+/// </summary>
+public sealed class AuditProjector : IAuditProjector
+{
+    // Tag/data keys actor identity may travel under across the various
+    // emitters (verified by grep): impersonation uses actorUserId/actorEmail;
+    // tenant membership uses userId; some carry callerId. Probed in order.
+    private static readonly string[] ActorIdKeys =
+        { "actorUserId", "userId", "callerId", "callerSub", "actorId" };
+    private static readonly string[] ActorEmailKeys =
+        { "actorEmail", "email", "userEmail" };
+    private static readonly string[] TargetIdKeys =
+        { "targetUserId", "targetId", "secretId", "agentId", "planId", "tenantId" };
+    private static readonly string[] IpKeys = { "ipAddress", "ip", "clientIp" };
+    private static readonly string[] UserAgentKeys = { "userAgent", "ua" };
+
+    /// <inheritdoc />
+    public AuditRecord? TryBuildRecord(
+        RawAuditEvent rawEvent, AuditOwnershipMode mode, Guid? singleUserOwnerId)
+    {
+        ArgumentNullException.ThrowIfNull(rawEvent);
+
+        var descriptor = SensitiveActionCatalog.Resolve(rawEvent.Type);
+        if (descriptor is null) return null; // AC7 — non-catalog events are skipped.
+
+        var tags = ParseObject(rawEvent.Tags);
+        var data = ParseObject(rawEvent.Data);
+
+        var record = new AuditRecord
+        {
+            Id = Guid.NewGuid(),
+            ActionCode = descriptor.ActionCode,
+            Category = descriptor.Category.ToString().ToLowerInvariant(),
+            Severity = descriptor.Severity.ToString().ToLowerInvariant(),
+            ActorUserId = ResolveGuid(tags, data, ActorIdKeys),
+            ActorEmailSnapshot = ResolveString(tags, data, ActorEmailKeys),
+            TargetType = ResolveTargetType(tags, data, descriptor.TargetTypeHint),
+            TargetId = ResolveString(tags, data, TargetIdKeys),
+            Outcome = ResolveOutcome(rawEvent.Type, tags, data),
+            IpAddress = ResolveString(tags, data, IpKeys),
+            UserAgent = ResolveString(tags, data, UserAgentKeys),
+            OccurredAt = DateTime.SpecifyKind(rawEvent.CreatedAt, DateTimeKind.Utc),
+            SourceEventId = rawEvent.Id,
+            SourceSequenceNumber = rawEvent.SequenceNumber,
+            // AC10 — redact the projected payload BEFORE it ever becomes a row.
+            // If the redactor throws, the exception propagates so the host
+            // fails the row and does NOT advance the cursor past it.
+            PayloadJson = CredentialRedactor.Clean(ProjectPayload(rawEvent)),
+            // Reserved for Story 37-2 — left null here (AC12).
+            RecordHash = null,
+            PrevRecordHash = null,
+        };
+
+        AssignOwnership(record, rawEvent, mode, singleUserOwnerId);
+        return record;
+    }
+
+    /// <summary>
+    /// AC11 — per-mode ownership routing. single-user → key by <c>user_id</c>;
+    /// SaaS → key by <c>tenant_id</c> (null for platform-only actions, which the
+    /// host routes to the control plane). Exactly one of the two is set so the
+    /// XOR CHECK holds.
+    /// </summary>
+    private static void AssignOwnership(
+        AuditRecord record, RawAuditEvent rawEvent,
+        AuditOwnershipMode mode, Guid? singleUserOwnerId)
+    {
+        if (mode == AuditOwnershipMode.SingleUser)
+        {
+            // In single-user mode there is no tenant dimension; every row is
+            // keyed by the sole user. Prefer the explicit owner id; fall back to
+            // the event's actor so a self-hosted instance still keys the row.
+            record.TenantId = null;
+            record.UserId = singleUserOwnerId
+                ?? record.ActorUserId
+                ?? throw new InvalidOperationException(
+                    "single-user audit projection requires a user id to own the row " +
+                    $"(event {rawEvent.Id} '{rawEvent.Type}' carried no resolvable actor).");
+        }
+        else
+        {
+            // SaaS — key by tenant. A platform-only event (TenantId null) is a
+            // platform row: tenant_id stays null and the host writes it to the
+            // control-plane store (never a tenant's view). The XOR CHECK permits
+            // tenant_id null only with user_id null — exactly the platform case.
+            record.UserId = null;
+            record.TenantId = rawEvent.TenantId;
+        }
+    }
+
+    /// <summary>
+    /// AC10 — build the JSON payload to persist. Combines the raw event's tags +
+    /// data into one object; the caller redacts it. Kept small + deterministic.
+    /// </summary>
+    private static string ProjectPayload(RawAuditEvent rawEvent)
+    {
+        var payload = new Dictionary<string, object?>
+        {
+            ["tags"] = RawJson(rawEvent.Tags),
+            ["data"] = RawJson(rawEvent.Data),
+        };
+        return JsonSerializer.Serialize(payload);
+    }
+
+    // Embed the raw tag/data JSON as nested objects when parseable, else as a
+    // string — so the redactor sees the secret-shaped substrings either way.
+    private static object? RawJson(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            return JsonSerializer.Deserialize<JsonElement>(json);
+        }
+        catch (JsonException)
+        {
+            return json;
+        }
+    }
+
+    private static Dictionary<string, JsonElement> ParseObject(string json)
+    {
+        var result = new Dictionary<string, JsonElement>(StringComparer.OrdinalIgnoreCase);
+        if (string.IsNullOrWhiteSpace(json)) return result;
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object) return result;
+            foreach (var prop in doc.RootElement.EnumerateObject())
+            {
+                result[prop.Name] = prop.Value.Clone();
+            }
+        }
+        catch (JsonException)
+        {
+            // Malformed JSONB — projector treats it as "no fields"; the raw
+            // payload still lands (redacted) so nothing is lost.
+        }
+        return result;
+    }
+
+    private static string? ResolveString(
+        IReadOnlyDictionary<string, JsonElement> tags,
+        IReadOnlyDictionary<string, JsonElement> data,
+        string[] keys)
+    {
+        foreach (var key in keys)
+        {
+            if (TryGetString(tags, key, out var v) || TryGetString(data, key, out v))
+            {
+                if (!string.IsNullOrWhiteSpace(v)) return v;
+            }
+        }
+        return null;
+    }
+
+    private static Guid? ResolveGuid(
+        IReadOnlyDictionary<string, JsonElement> tags,
+        IReadOnlyDictionary<string, JsonElement> data,
+        string[] keys)
+    {
+        var s = ResolveString(tags, data, keys);
+        return Guid.TryParse(s, out var g) ? g : null;
+    }
+
+    private static string ResolveTargetType(
+        IReadOnlyDictionary<string, JsonElement> tags,
+        IReadOnlyDictionary<string, JsonElement> data,
+        string hint)
+    {
+        var explicitType = ResolveString(tags, data, new[] { "targetType" });
+        return string.IsNullOrWhiteSpace(explicitType) ? hint : explicitType;
+    }
+
+    /// <summary>
+    /// Derive outcome from the event-type suffix + any explicit outcome field.
+    /// <c>*.FAILED</c> → failure; <c>*.DENIED</c> → denied; an explicit
+    /// <c>outcome</c>/<c>success=false</c> field wins; default success.
+    /// </summary>
+    private static string ResolveOutcome(
+        string type,
+        IReadOnlyDictionary<string, JsonElement> tags,
+        IReadOnlyDictionary<string, JsonElement> data)
+    {
+        var explicitOutcome = ResolveString(tags, data, new[] { "outcome" });
+        if (!string.IsNullOrWhiteSpace(explicitOutcome))
+        {
+            var normalized = explicitOutcome.Trim().ToLowerInvariant();
+            if (normalized is "success" or "failure" or "denied") return normalized;
+        }
+
+        if (TryGetBool(data, "success", out var success) ||
+            TryGetBool(tags, "success", out success))
+        {
+            if (!success) return "failure";
+        }
+
+        if (type.EndsWith(".FAILED", StringComparison.Ordinal) ||
+            type.EndsWith(".FAILURE", StringComparison.Ordinal))
+        {
+            return "failure";
+        }
+        if (type.EndsWith(".DENIED", StringComparison.Ordinal) ||
+            type.Contains("REUSE_DETECTED", StringComparison.Ordinal))
+        {
+            return "denied";
+        }
+        return "success";
+    }
+
+    private static bool TryGetString(
+        IReadOnlyDictionary<string, JsonElement> map, string key, out string? value)
+    {
+        value = null;
+        if (!map.TryGetValue(key, out var el)) return false;
+        value = el.ValueKind switch
+        {
+            JsonValueKind.String => el.GetString(),
+            JsonValueKind.Number => el.ToString(),
+            JsonValueKind.True => "true",
+            JsonValueKind.False => "false",
+            JsonValueKind.Null => null,
+            _ => el.ToString(),
+        };
+        return value is not null;
+    }
+
+    private static bool TryGetBool(
+        IReadOnlyDictionary<string, JsonElement> map, string key, out bool value)
+    {
+        value = false;
+        if (!map.TryGetValue(key, out var el)) return false;
+        switch (el.ValueKind)
+        {
+            case JsonValueKind.True: value = true; return true;
+            case JsonValueKind.False: value = false; return true;
+            case JsonValueKind.String when bool.TryParse(el.GetString(), out var b):
+                value = b; return true;
+            default: return false;
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Audit/AuditProjector.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Audit/AuditProjector.cs
@@ -27,6 +27,14 @@ public sealed class AuditProjector : IAuditProjector
     private static readonly string[] IpKeys = { "ipAddress", "ip", "clientIp" };
     private static readonly string[] UserAgentKeys = { "userAgent", "ua" };
 
+    /// <summary>Safe placeholder payload written on the quarantine row (C2) —
+    /// NEVER the raw / un-redacted <c>Data</c>/<c>Tags</c>.</summary>
+    public const string QuarantinePayload = "{\"_projection_error\":\"redaction_failed\"}";
+
+    /// <summary>Generic marker for the <c>target_type</c> when an event's
+    /// classification could not be resolved at all (no catalog descriptor).</summary>
+    public const string UnclassifiedTargetType = "unclassified";
+
     /// <inheritdoc />
     public AuditRecord? TryBuildRecord(
         RawAuditEvent rawEvent, AuditOwnershipMode mode, Guid? singleUserOwnerId)
@@ -56,8 +64,10 @@ public sealed class AuditProjector : IAuditProjector
             SourceEventId = rawEvent.Id,
             SourceSequenceNumber = rawEvent.SequenceNumber,
             // AC10 — redact the projected payload BEFORE it ever becomes a row.
-            // If the redactor throws, the exception propagates so the host
-            // fails the row and does NOT advance the cursor past it.
+            // If the redactor throws, the exception propagates; the host then
+            // builds a QUARANTINE row (BuildQuarantineRecord) keyed by the same
+            // source_event_id with a safe placeholder payload, so the action is
+            // still recorded (never dropped) and the cursor can advance (C2).
             PayloadJson = CredentialRedactor.Clean(ProjectPayload(rawEvent)),
             // Reserved for Story 37-2 — left null here (AC12).
             RecordHash = null,
@@ -66,6 +76,94 @@ public sealed class AuditProjector : IAuditProjector
 
         AssignOwnership(record, rawEvent, mode, singleUserOwnerId);
         return record;
+    }
+
+    /// <inheritdoc />
+    public AuditRecord BuildQuarantineRecord(
+        RawAuditEvent rawEvent, AuditOwnershipMode mode, Guid? singleUserOwnerId)
+    {
+        ArgumentNullException.ThrowIfNull(rawEvent);
+
+        // C2 — quarantine, do NOT drop and do NOT halt. Classification keys off
+        // the (already-parsed) event type + tags/data, which is the part that did
+        // NOT throw — the redaction of the PAYLOAD is what failed. So we reuse the
+        // known-safe classifiable fields and substitute a SAFE placeholder payload;
+        // the raw Data/Tags NEVER reach the row. If even the descriptor is missing
+        // (a build failure with no classification), fall back to a generic marker.
+        var descriptor = SensitiveActionCatalog.Resolve(rawEvent.Type);
+
+        // Field extraction parses JSON only; it does not run the redactor, so it
+        // is safe to retry here. Guard it anyway so a pathological-JSON throw can't
+        // turn the quarantine itself into a poison pill — degrade to empty maps.
+        Dictionary<string, JsonElement> tags;
+        Dictionary<string, JsonElement> data;
+        try
+        {
+            tags = ParseObject(rawEvent.Tags);
+            data = ParseObject(rawEvent.Data);
+        }
+        catch
+        {
+            tags = new Dictionary<string, JsonElement>(StringComparer.OrdinalIgnoreCase);
+            data = new Dictionary<string, JsonElement>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        var record = new AuditRecord
+        {
+            Id = Guid.NewGuid(),
+            ActionCode = descriptor?.ActionCode ?? rawEvent.Type,
+            Category = descriptor is not null
+                ? descriptor.Category.ToString().ToLowerInvariant()
+                : UnclassifiedTargetType,
+            Severity = descriptor is not null
+                ? descriptor.Severity.ToString().ToLowerInvariant()
+                : "warning",
+            ActorUserId = SafeResolveGuid(tags, data, ActorIdKeys),
+            ActorEmailSnapshot = SafeResolveString(tags, data, ActorEmailKeys),
+            TargetType = descriptor is not null
+                ? SafeResolveTargetType(tags, data, descriptor.TargetTypeHint)
+                : UnclassifiedTargetType,
+            TargetId = SafeResolveString(tags, data, TargetIdKeys),
+            // The action could not be fully materialized — record it as a failure.
+            Outcome = "failure",
+            IpAddress = SafeResolveString(tags, data, IpKeys),
+            UserAgent = SafeResolveString(tags, data, UserAgentKeys),
+            OccurredAt = DateTime.SpecifyKind(rawEvent.CreatedAt, DateTimeKind.Utc),
+            SourceEventId = rawEvent.Id,
+            SourceSequenceNumber = rawEvent.SequenceNumber,
+            // SAFE placeholder — never the raw/un-redacted payload (C2).
+            PayloadJson = QuarantinePayload,
+            RecordHash = null,
+            PrevRecordHash = null,
+        };
+
+        AssignOwnership(record, rawEvent, mode, singleUserOwnerId);
+        return record;
+    }
+
+    // Quarantine field extraction must never itself throw — wrap the resolvers.
+    private static string? SafeResolveString(
+        IReadOnlyDictionary<string, JsonElement> tags,
+        IReadOnlyDictionary<string, JsonElement> data, string[] keys)
+    {
+        try { return ResolveString(tags, data, keys); }
+        catch { return null; }
+    }
+
+    private static Guid? SafeResolveGuid(
+        IReadOnlyDictionary<string, JsonElement> tags,
+        IReadOnlyDictionary<string, JsonElement> data, string[] keys)
+    {
+        try { return ResolveGuid(tags, data, keys); }
+        catch { return null; }
+    }
+
+    private static string SafeResolveTargetType(
+        IReadOnlyDictionary<string, JsonElement> tags,
+        IReadOnlyDictionary<string, JsonElement> data, string hint)
+    {
+        try { return ResolveTargetType(tags, data, hint); }
+        catch { return hint; }
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Data/Audit/AuditRecordRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Audit/AuditRecordRepository.cs
@@ -1,0 +1,96 @@
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Tamma.Data.Entities;
+
+namespace Tamma.Data.Audit;
+
+/// <summary>
+/// Story 37-1 — default <see cref="IAuditRecordRepository"/>. Insert-if-absent
+/// on the UNIQUE <c>source_event_id</c> index makes the projection idempotent
+/// and replay-safe; cursor load/save mirrors <c>AlertRuleEvaluator</c>.
+/// Stateless — safe as a singleton; the caller supplies the per-call context.
+/// </summary>
+public sealed class AuditRecordRepository : IAuditRecordRepository
+{
+    /// <inheritdoc />
+    public async Task<bool> InsertIfAbsentAsync(
+        DbContext context, AuditRecord record, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(record);
+
+        // Pre-check keeps the common (already-projected) path off the
+        // exception machinery; the UNIQUE index is the actual guarantee that
+        // closes the concurrent-insert race below.
+        var exists = await context.Set<AuditRecord>().AsNoTracking()
+            .AnyAsync(r => r.SourceEventId == record.SourceEventId, ct)
+            .ConfigureAwait(false);
+        if (exists) return false;
+
+        context.Set<AuditRecord>().Add(record);
+        try
+        {
+            await context.SaveChangesAsync(ct).ConfigureAwait(false);
+            return true;
+        }
+        catch (DbUpdateException ex) when (IsUniqueViolation(ex))
+        {
+            // A concurrent projector won the race — already projected. Detach
+            // the rejected entry so the context can be reused cleanly.
+            context.Entry(record).State = EntityState.Detached;
+            return false;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<AuditProjectorCursor> LoadCursorAsync(
+        ControlPlaneDbContext cp, string projectorId, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(cp);
+        var row = await cp.AuditProjectorCursors.AsNoTracking()
+            .FirstOrDefaultAsync(c => c.ProjectorId == projectorId, ct)
+            .ConfigureAwait(false);
+        return row ?? new AuditProjectorCursor
+        {
+            ProjectorId = projectorId,
+            LastDomainSequenceNumber = 0L,
+            LastPlatformSequenceNumber = 0L,
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task SaveCursorAsync(
+        ControlPlaneDbContext cp,
+        string projectorId,
+        long lastDomainSeq,
+        long lastPlatformSeq,
+        DateTime updatedAt,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(cp);
+        var existing = await cp.AuditProjectorCursors
+            .FirstOrDefaultAsync(c => c.ProjectorId == projectorId, ct)
+            .ConfigureAwait(false);
+        if (existing is null)
+        {
+            cp.AuditProjectorCursors.Add(new AuditProjectorCursor
+            {
+                ProjectorId = projectorId,
+                LastDomainSequenceNumber = lastDomainSeq,
+                LastPlatformSequenceNumber = lastPlatformSeq,
+                UpdatedAt = updatedAt,
+            });
+        }
+        else
+        {
+            existing.LastDomainSequenceNumber = lastDomainSeq;
+            existing.LastPlatformSequenceNumber = lastPlatformSeq;
+            existing.UpdatedAt = updatedAt;
+        }
+        await cp.SaveChangesAsync(ct).ConfigureAwait(false);
+    }
+
+    private static bool IsUniqueViolation(DbUpdateException ex) =>
+        ex.InnerException is PostgresException pg &&
+        pg.SqlState == PostgresErrorCodes.UniqueViolation;
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Audit/AuditRecordRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Audit/AuditRecordRepository.cs
@@ -44,15 +44,18 @@ public sealed class AuditRecordRepository : IAuditRecordRepository
 
     /// <inheritdoc />
     public async Task<AuditProjectorCursor> LoadCursorAsync(
-        ControlPlaneDbContext cp, string projectorId, CancellationToken ct = default)
+        ControlPlaneDbContext cp, string projectorId, Guid tenantId,
+        CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(cp);
         var row = await cp.AuditProjectorCursors.AsNoTracking()
-            .FirstOrDefaultAsync(c => c.ProjectorId == projectorId, ct)
+            .FirstOrDefaultAsync(
+                c => c.ProjectorId == projectorId && c.TenantId == tenantId, ct)
             .ConfigureAwait(false);
         return row ?? new AuditProjectorCursor
         {
             ProjectorId = projectorId,
+            TenantId = tenantId,
             LastDomainSequenceNumber = 0L,
             LastPlatformSequenceNumber = 0L,
         };
@@ -62,6 +65,7 @@ public sealed class AuditRecordRepository : IAuditRecordRepository
     public async Task SaveCursorAsync(
         ControlPlaneDbContext cp,
         string projectorId,
+        Guid tenantId,
         long lastDomainSeq,
         long lastPlatformSeq,
         DateTime updatedAt,
@@ -69,13 +73,15 @@ public sealed class AuditRecordRepository : IAuditRecordRepository
     {
         ArgumentNullException.ThrowIfNull(cp);
         var existing = await cp.AuditProjectorCursors
-            .FirstOrDefaultAsync(c => c.ProjectorId == projectorId, ct)
+            .FirstOrDefaultAsync(
+                c => c.ProjectorId == projectorId && c.TenantId == tenantId, ct)
             .ConfigureAwait(false);
         if (existing is null)
         {
             cp.AuditProjectorCursors.Add(new AuditProjectorCursor
             {
                 ProjectorId = projectorId,
+                TenantId = tenantId,
                 LastDomainSequenceNumber = lastDomainSeq,
                 LastPlatformSequenceNumber = lastPlatformSeq,
                 UpdatedAt = updatedAt,

--- a/apps/tamma-elsa/src/Tamma.Data/Audit/IAuditProjector.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Audit/IAuditProjector.cs
@@ -1,0 +1,67 @@
+using Tamma.Core.Audit;
+using Tamma.Data.Entities;
+
+namespace Tamma.Data.Audit;
+
+/// <summary>
+/// Story 37-1 — the operating mode that drives per-record ownership routing
+/// (Story 37-1 AC11). Mirrors <c>Tamma.Api.Services.PromptStore.TammaMode</c>
+/// without taking a dependency on the Api layer (the projector lives in
+/// <c>Tamma.Data</c>).
+/// </summary>
+public enum AuditOwnershipMode
+{
+    /// <summary>Single-user — every curated row is keyed by <c>user_id</c>.</summary>
+    SingleUser,
+
+    /// <summary>SaaS — rows are keyed by <c>tenant_id</c> (platform-only rows by
+    /// neither, i.e. <c>tenant_id = null</c> in the control plane).</summary>
+    SaaS,
+}
+
+/// <summary>
+/// Story 37-1 — projects raw DCB events into curated <see cref="AuditRecord"/>
+/// rows. PURE classification + redaction + ownership routing — NO I/O. The
+/// background host owns reading the event streams (read-only) and writing the
+/// resulting rows into the correct (tenant vs CP) store; this keeps the
+/// projector trivially unit-testable and guarantees it never touches the raw
+/// event-store write path (AC15).
+/// </summary>
+public interface IAuditProjector
+{
+    /// <summary>
+    /// Build a curated audit record from a raw event, or <c>null</c> when the
+    /// event type is not in <see cref="SensitiveActionCatalog"/> (AC7 skip).
+    /// The returned record's <c>PayloadJson</c> is already redacted (AC10) and
+    /// its ownership column is set per <paramref name="mode"/> (AC11).
+    /// </summary>
+    /// <param name="rawEvent">The raw DCB event (a <see cref="DomainEvent"/> or
+    /// a <see cref="PlatformEvent"/> projected into the same shape).</param>
+    /// <param name="mode">Process ownership mode.</param>
+    /// <param name="singleUserOwnerId">The sole user's id — required in
+    /// <see cref="AuditOwnershipMode.SingleUser"/> so the row can be keyed.</param>
+    AuditRecord? TryBuildRecord(
+        RawAuditEvent rawEvent, AuditOwnershipMode mode, Guid? singleUserOwnerId);
+}
+
+/// <summary>
+/// Story 37-1 — a uniform, read-only view of a raw DCB event for the projector.
+/// Carries exactly what the projector needs (id, type, tenant, JSONB tags/data,
+/// occurred-at, sequence) so a <see cref="DomainEvent"/> and a
+/// <see cref="PlatformEvent"/> classify through one code path.
+/// </summary>
+public sealed record RawAuditEvent(
+    Guid Id,
+    string Type,
+    Guid? TenantId,
+    string Tags,
+    string Data,
+    DateTime CreatedAt,
+    long SequenceNumber)
+{
+    public static RawAuditEvent From(DomainEvent e) =>
+        new(e.Id, e.Type, e.TenantId, e.Tags, e.Data, e.CreatedAt, e.SequenceNumber);
+
+    public static RawAuditEvent From(PlatformEvent e) =>
+        new(e.Id, e.Type, e.TenantId, e.Tags, e.Data, e.CreatedAt, e.SequenceNumber);
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Audit/IAuditProjector.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Audit/IAuditProjector.cs
@@ -42,6 +42,19 @@ public interface IAuditProjector
     /// <see cref="AuditOwnershipMode.SingleUser"/> so the row can be keyed.</param>
     AuditRecord? TryBuildRecord(
         RawAuditEvent rawEvent, AuditOwnershipMode mode, Guid? singleUserOwnerId);
+
+    /// <summary>
+    /// C2 — build a <b>quarantine</b> record for an event whose normal projection
+    /// (redaction / build) FAILED. The row carries the known-safe classifiable
+    /// fields (action_code / category / severity when resolvable, else a generic
+    /// "unclassified" marker), the same <c>source_event_id</c> (so idempotency
+    /// holds), <c>outcome = "failure"</c>, correct per-mode ownership, and a SAFE
+    /// placeholder payload — NEVER the raw / un-redacted <c>Data</c>/<c>Tags</c>.
+    /// Persisting this row lets the cursor advance past a poison-pill event so the
+    /// audit trail progresses, while still recording that the action occurred.
+    /// </summary>
+    AuditRecord BuildQuarantineRecord(
+        RawAuditEvent rawEvent, AuditOwnershipMode mode, Guid? singleUserOwnerId);
 }
 
 /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Data/Audit/IAuditRecordRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Audit/IAuditRecordRepository.cs
@@ -23,20 +23,29 @@ public interface IAuditRecordRepository
         DbContext context, AuditRecord record, CancellationToken ct = default);
 
     /// <summary>
-    /// Load the projector cursor from the control-plane store (creating an
-    /// at-zero in-memory default when no row exists yet). Cursor is always
-    /// CP-resident (mirrors <c>alert_evaluator_cursor</c>).
+    /// Load one projector cursor row from the control-plane store, keyed by
+    /// <c>(projectorId, tenantId)</c>. Pass
+    /// <see cref="AuditProjectorCursor.PlatformSentinel"/> for the platform /
+    /// shared-DB row, or a real tenant id for that tenant's per-schema domain
+    /// stream. Creates an at-zero in-memory default when no row exists yet. The
+    /// cursor table is always CP-resident (C1: one domain high-water mark per
+    /// tenant, the platform stream on the sentinel row).
     /// </summary>
     Task<AuditProjectorCursor> LoadCursorAsync(
-        ControlPlaneDbContext cp, string projectorId, CancellationToken ct = default);
+        ControlPlaneDbContext cp, string projectorId, Guid tenantId,
+        CancellationToken ct = default);
 
     /// <summary>
-    /// Upsert the projector cursor's per-stream high-water marks into the
-    /// control-plane store.
+    /// Upsert one projector cursor row's high-water marks into the control-plane
+    /// store, keyed by <c>(projectorId, tenantId)</c>. For a per-tenant row only
+    /// <paramref name="lastDomainSeq"/> advances; for the
+    /// <see cref="AuditProjectorCursor.PlatformSentinel"/> row both the
+    /// platform-stream and shared-DB domain-fallback marks advance.
     /// </summary>
     Task SaveCursorAsync(
         ControlPlaneDbContext cp,
         string projectorId,
+        Guid tenantId,
         long lastDomainSeq,
         long lastPlatformSeq,
         DateTime updatedAt,

--- a/apps/tamma-elsa/src/Tamma.Data/Audit/IAuditRecordRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Audit/IAuditRecordRepository.cs
@@ -1,0 +1,44 @@
+using Microsoft.EntityFrameworkCore;
+using Tamma.Data.Entities;
+
+namespace Tamma.Data.Audit;
+
+/// <summary>
+/// Story 37-1 — insert-if-absent writer for the curated <c>audit_records</c>
+/// read-model, plus the projector-cursor load/save. The same contract serves
+/// the control-plane and per-tenant stores; the caller selects the context
+/// (CP vs tenant) and passes it in, so routing (Story 37-1 AC11) stays in the
+/// projector while the dedup + cursor mechanics live here.
+/// </summary>
+public interface IAuditRecordRepository
+{
+    /// <summary>
+    /// Insert one curated row if no row with the same
+    /// <see cref="AuditRecord.SourceEventId"/> exists yet. Returns <c>true</c>
+    /// when a row was inserted, <c>false</c> when the source event was already
+    /// projected (idempotent — a re-scan after a crash is a no-op, AC8). A
+    /// unique-violation race resolves to <c>false</c> (already projected).
+    /// </summary>
+    Task<bool> InsertIfAbsentAsync(
+        DbContext context, AuditRecord record, CancellationToken ct = default);
+
+    /// <summary>
+    /// Load the projector cursor from the control-plane store (creating an
+    /// at-zero in-memory default when no row exists yet). Cursor is always
+    /// CP-resident (mirrors <c>alert_evaluator_cursor</c>).
+    /// </summary>
+    Task<AuditProjectorCursor> LoadCursorAsync(
+        ControlPlaneDbContext cp, string projectorId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Upsert the projector cursor's per-stream high-water marks into the
+    /// control-plane store.
+    /// </summary>
+    Task SaveCursorAsync(
+        ControlPlaneDbContext cp,
+        string projectorId,
+        long lastDomainSeq,
+        long lastPlatformSeq,
+        DateTime updatedAt,
+        CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
@@ -74,6 +74,24 @@ public class ControlPlaneDbContext : DbContext
     // and system-scope mail that must flow before or after a tenant DB
     // exists. The Plans table owns the subscription-plan catalogue.
     public DbSet<Plan> Plans => Set<Plan>();
+
+    /// <summary>
+    /// Story 34-1 — typed feature flags per plan version (replaces the opaque
+    /// <c>Plan.Quotas</c> JSON for capability flags). CP-resident.
+    /// </summary>
+    public DbSet<PlanFeature> PlanFeatures => Set<PlanFeature>();
+
+    /// <summary>
+    /// Story 34-1 — typed quota entitlements per plan version. CP-resident.
+    /// </summary>
+    public DbSet<PlanEntitlement> PlanEntitlements => Set<PlanEntitlement>();
+
+    /// <summary>
+    /// Story 34-1 — recurring + per-seat + metered pricing per plan version,
+    /// split by BYOK vs platform-provided pricing mode. CP-resident.
+    /// </summary>
+    public DbSet<PlanPrice> PlanPrices => Set<PlanPrice>();
+
     public DbSet<PlatformEvent> PlatformEvents => Set<PlatformEvent>();
     public DbSet<PlatformQueuedTask> PlatformQueuedTasks => Set<PlatformQueuedTask>();
     public DbSet<PlatformEmailOutboxMessage> PlatformEmailOutbox => Set<PlatformEmailOutboxMessage>();

--- a/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
@@ -444,6 +444,19 @@ public class ControlPlaneDbContext : DbContext
     /// </summary>
     public DbSet<BillingPlanPrice> BillingPlanPrices => Set<BillingPlanPrice>();
 
+    /// <summary>
+    /// Story 37-1 — platform-scope curated audit trail. Tenant-scope rows live
+    /// in the per-tenant schema's <c>audit_records</c>; these are the
+    /// platform/lifecycle rows (impersonation, tenant provision/move, etc.).
+    /// </summary>
+    public DbSet<AuditRecord> AuditRecords => Set<AuditRecord>();
+
+    /// <summary>
+    /// Story 37-1 — the audit projector's resume cursor (mirrors
+    /// <see cref="AlertEvaluatorCursor"/>). CP-resident; one row per projector.
+    /// </summary>
+    public DbSet<AuditProjectorCursor> AuditProjectorCursors => Set<AuditProjectorCursor>();
+
     // Story 28-1 PR D: the 11 + 4 mentorship tenant-resident entities
     // (AgentConfig, PromptOverride, ProviderHealth, ProviderDiagnostic,
     // SanitizationRule, WorkflowDefinition, WorkflowInstance, DomainEvent,
@@ -525,6 +538,14 @@ public class ControlPlaneDbContext : DbContext
         // configured in the shared single source so the model graph + migration
         // stay aligned (same convention as the agent entities above).
         TammaModelConfiguration.ConfigureBillingEntities(modelBuilder);
+
+        // Story 37-1 — platform-scope curated audit trail + the projector cursor.
+        // audit_records carries the SAME shape as the tenant-schema table; the
+        // CP build hosts platform-scope rows (impersonation, tenant lifecycle).
+        // The cursor is CP-resident (mirrors alert_evaluator_cursor) — the single
+        // projector resumes both streams from one row.
+        TammaModelConfiguration.ConfigureAuditEntities(modelBuilder, fixedTenantId: null);
+        TammaModelConfiguration.ConfigureAuditProjectorCursor(modelBuilder);
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
@@ -167,6 +167,26 @@ public class ControlPlaneDbContext : DbContext
     public DbSet<AlertEvaluatorCursor> AlertEvaluatorCursors =>
         Set<AlertEvaluatorCursor>();
 
+    // ── Story 32-1 — first-class agent entities (Epic 32 foundation) ──
+    //
+    // Agent definitions (public/system + private/tenant-or-user-owned) are
+    // CP-resident: visibility/identity is a control-plane concern and public
+    // agents are shared cross-tenant. ALL performance/action data stays
+    // tenant-scoped in later Epic 32 stories — these tables are definition-only.
+
+    /// <summary>
+    /// Story 32-1 — first-class agent identities (replaces the anonymous
+    /// role-keyed <see cref="AgentConfig"/> blob as the canonical Epic 32
+    /// join key). CP-resident; see <see cref="Entities.Agent"/>.
+    /// </summary>
+    public DbSet<Agent> Agents => Set<Agent>();
+
+    /// <summary>
+    /// Story 32-1 — immutable, monotonically-versioned saved-config snapshots
+    /// per agent. Insert-only; see <see cref="Entities.AgentVersion"/>.
+    /// </summary>
+    public DbSet<AgentVersion> AgentVersions => Set<AgentVersion>();
+
     // Story 28-1 PR D: the 11 + 4 mentorship tenant-resident entities
     // (AgentConfig, PromptOverride, ProviderHealth, ProviderDiagnostic,
     // SanitizationRule, WorkflowDefinition, WorkflowInstance, DomainEvent,
@@ -239,6 +259,10 @@ public class ControlPlaneDbContext : DbContext
         ConfigureTenantPlatformInstallations(modelBuilder);
         ConfigurePlatformWebhookDeliveries(modelBuilder);
         ConfigureTenantDatabases(modelBuilder);
+
+        // Story 32-1 — first-class agent entities. CP-resident, configured in
+        // the shared single source so the model graph + migration stay aligned.
+        TammaModelConfiguration.ConfigureAgentEntities(modelBuilder);
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
@@ -42,26 +42,125 @@ public class ControlPlaneDbContext : DbContext
     // version editor performs is allowed; children of a freshly-Added active
     // plan (the new version's rows) are allowed.
 
+    // Story 34-1 follow-up — leak-proof immutability-guard suppression.
+    //
+    // The context is POOLED in production (AddPooledDbContextFactory /
+    // AddTenantConnectionPool). EF's pool reset only clears state it knows about
+    // (the ChangeTracker, the connection, IResettableService services) — it does
+    // NOT clear a custom bool field on the derived context. A plain settable
+    // `SuppressPlanImmutabilityGuard = true` left dangling (e.g. by a caller that
+    // forgot a finally, or an exception that skipped the reset) would silently
+    // ride the pooled instance into the NEXT lease and disable the guard for an
+    // unrelated caller. So the suppression is exposed ONLY as a disposable scope:
+    // the caller writes `using var _ = ctx.SuppressPlanImmutabilityGuard();` and
+    // the scope's Dispose ALWAYS restores the prior value — even on exception,
+    // because `using` is a try/finally — so a caller physically cannot leave it
+    // set and it can never ride a pooled instance into the next lease. There is
+    // no public setter at all: the only way to flip the flag is to open (and
+    // therefore, via `using`, automatically close) a scope.
+    private bool _suppressPlanImmutabilityGuard;
+
     /// <summary>
     /// Story 34-1 — escape hatch for the trusted <c>PlansSeeder</c> system-
-    /// defaults populate path ONLY. The seeder does insert-missing-only
-    /// backfill of children onto an already-active v1 plan (Story 28-1 shipped
-    /// the bare plan rows; 34-1 backfills the typed children), which the
-    /// immutability interceptor would otherwise (correctly) reject. The seeder
-    /// sets this for the duration of its save and resets it in a finally. No
-    /// user-facing or request-handling code should ever set it.
+    /// defaults populate path ONLY. The seeder does insert-missing-only backfill
+    /// of children onto an already-active v1 plan (Story 28-1 shipped the bare
+    /// plan rows; 34-1 backfills the typed children), which the immutability
+    /// interceptor would otherwise (correctly) reject.
+    ///
+    /// <para>Returns a disposable scope that suppresses the guard for its
+    /// lifetime and restores the prior value on <see cref="IDisposable.Dispose"/>
+    /// — guaranteed, even on exception, via <c>using</c>. There is intentionally
+    /// no public setter: a caller physically cannot leave the flag stuck on,
+    /// which keeps the guard leak-proof across pooled-context reuse. No
+    /// user-facing or request-handling code should ever open this scope.</para>
     /// </summary>
-    public bool SuppressPlanImmutabilityGuard { get; set; }
+    public IDisposable SuppressPlanImmutabilityGuard()
+        => new PlanImmutabilityGuardSuppressionScope(this);
+
+    private sealed class PlanImmutabilityGuardSuppressionScope : IDisposable
+    {
+        private readonly ControlPlaneDbContext _ctx;
+        private readonly bool _previous;
+        private bool _disposed;
+
+        public PlanImmutabilityGuardSuppressionScope(ControlPlaneDbContext ctx)
+        {
+            _ctx = ctx;
+            _previous = ctx._suppressPlanImmutabilityGuard;
+            ctx._suppressPlanImmutabilityGuard = true;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _ctx._suppressPlanImmutabilityGuard = _previous;
+        }
+    }
+
+    /// <summary>
+    /// Story 35-1 follow-up — resolve the
+    /// <c>PossibleIncorrectRequiredNavigationWithQueryFilterInteractionWarning</c>
+    /// advisory cleanly. Apply this from EVERY <see cref="DbContextOptions{TContext}"/>
+    /// builder seam that constructs a <see cref="ControlPlaneDbContext"/>: the DI
+    /// factory (<c>AddTammaData</c>), the pooled factory (<c>AddTenantConnectionPool</c>),
+    /// and the design-time factory used by <c>ef migrations</c>.
+    ///
+    /// <para><b>What fires it.</b> <c>Tenant</c> and <c>User</c> carry a
+    /// soft-delete query filter (<c>DeletedAt == null</c>). Their REQUIRED
+    /// dependents — <c>BillingCustomer</c> (Story 35-1), plus the pre-existing
+    /// <c>TenantMembership</c>, <c>UserInvite</c>, <c>RefreshToken</c>,
+    /// <c>PasswordResetToken</c> — have a non-nullable FK (so EF marks the nav
+    /// <c>IsRequired()</c>) but NO soft-delete column of their own, so they carry
+    /// no matching filter. EF warns that an <c>Include</c> of the filtered
+    /// principal could yield a null required navigation. That is an ACCEPTED
+    /// pattern here: the dependents are hard-deleted on cascade when the tenant/
+    /// user is HARD-deleted; while a principal is merely SOFT-deleted the
+    /// dependent legitimately still exists and an <c>Include</c> returning null is
+    /// the correct, intended behaviour.</para>
+    ///
+    /// <para><b>Why suppress, and why on the OPTIONS builder (not
+    /// <c>OnModelCreating</c>/<c>TammaModelConfiguration</c>, and NOT
+    /// <c>OnConfiguring</c>).</b> The two model-level alternatives both fail the
+    /// Wave-1 constraints: (1) adding a matching query filter is impossible —
+    /// these dependents have no <c>DeletedAt</c> column; (2) marking the
+    /// navigation <c>.IsRequired(false)</c> would make the FK column nullable, i.e.
+    /// a SCHEMA change + a new migration, which the cascade-preservation
+    /// constraint forbids. So the only constraint-satisfying resolution is to
+    /// ignore this one advisory. <c>ConfigureWarnings</c> is a
+    /// <see cref="DbContextOptionsBuilder"/> API — a <c>ModelBuilder</c> has no
+    /// warning surface, so it CANNOT live in <c>TammaModelConfiguration</c>. It
+    /// also CANNOT live in an <c>OnConfiguring</c> override: this context is
+    /// registered through <c>AddPooledDbContextFactory</c> in production, and EF
+    /// throws <c>"'OnConfiguring' cannot be used to modify DbContextOptions when
+    /// DbContext pooling is enabled"</c>. The options-builder seam is the only
+    /// place that is both pooling-safe AND applies uniformly to all five
+    /// relationships. Schema, cascade behaviour, and query semantics are
+    /// untouched; <c>has-pending-model-changes</c> stays clean.</para>
+    /// </summary>
+    public static void ConfigureControlPlaneWarnings(DbContextOptionsBuilder optionsBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(optionsBuilder);
+        optionsBuilder.ConfigureWarnings(w =>
+            w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.CoreEventId
+                .PossibleIncorrectRequiredNavigationWithQueryFilterInteractionWarning));
+    }
 
     public override int SaveChanges(bool acceptAllChangesOnSuccess)
     {
-        if (!SuppressPlanImmutabilityGuard)
+        if (!_suppressPlanImmutabilityGuard)
         {
-            EnforcePlanImmutability(resolveUntrackedPlanStatus: ids =>
-                Plans.AsNoTracking()
-                    .Where(p => ids.Contains(p.Id))
+            // Compute the untracked-owning-plan id set ONCE, then resolve its
+            // statuses synchronously and pass both through to the enforcer.
+            var untrackedIds = CollectUntrackedOwningPlanIds();
+            var untrackedStatus = untrackedIds.Count == 0
+                ? new Dictionary<Guid, string>()
+                : Plans.AsNoTracking()
+                    .Where(p => untrackedIds.Contains(p.Id))
                     .Select(p => new { p.Id, p.Status })
-                    .ToDictionary(x => x.Id, x => x.Status));
+                    .ToDictionary(x => x.Id, x => x.Status);
+
+            EnforcePlanImmutability(untrackedStatus);
         }
         return base.SaveChanges(acceptAllChangesOnSuccess);
     }
@@ -70,28 +169,35 @@ public class ControlPlaneDbContext : DbContext
         bool acceptAllChangesOnSuccess,
         CancellationToken cancellationToken = default)
     {
-        if (!SuppressPlanImmutabilityGuard)
+        if (!_suppressPlanImmutabilityGuard)
         {
-            var untracked = await ResolvePlanGuardUntrackedAsync(cancellationToken);
-            EnforcePlanImmutability(resolveUntrackedPlanStatus: _ => untracked);
+            // Compute the untracked-owning-plan id set ONCE here (the async path
+            // previously computed it both in the pre-pass AND again inside
+            // EnforcePlanImmutability). Resolve statuses via the async DB lookup,
+            // then pass the SAME id set + status map into the synchronous enforcer
+            // so it never recomputes or blocks on the DB.
+            var untrackedIds = CollectUntrackedOwningPlanIds();
+            var untrackedStatus = await ResolveUntrackedPlanStatusAsync(
+                untrackedIds, cancellationToken);
+
+            EnforcePlanImmutability(untrackedStatus);
         }
         return await base.SaveChangesAsync(acceptAllChangesOnSuccess, cancellationToken);
     }
 
     /// <summary>
-    /// Async pre-pass for <see cref="SaveChangesAsync(bool, CancellationToken)"/>:
-    /// loads the status of any owning plan referenced by a changed child row
-    /// that isn't already in the ChangeTracker, so the synchronous
-    /// <see cref="EnforcePlanImmutability"/> body never blocks on the DB.
+    /// Async resolution of the owning-plan statuses for a pre-computed set of
+    /// untracked plan ids — used by <see cref="SaveChangesAsync(bool, CancellationToken)"/>
+    /// so the synchronous <see cref="EnforcePlanImmutability"/> body never blocks
+    /// on the DB. Empty input ⇒ no query.
     /// </summary>
-    private async Task<Dictionary<Guid, string>> ResolvePlanGuardUntrackedAsync(
-        CancellationToken ct)
+    private async Task<Dictionary<Guid, string>> ResolveUntrackedPlanStatusAsync(
+        HashSet<Guid> untrackedIds, CancellationToken ct)
     {
-        var ids = CollectUntrackedOwningPlanIds();
-        if (ids.Count == 0) return new Dictionary<Guid, string>();
+        if (untrackedIds.Count == 0) return new Dictionary<Guid, string>();
 
         var rows = await Plans.AsNoTracking()
-            .Where(p => ids.Contains(p.Id))
+            .Where(p => untrackedIds.Contains(p.Id))
             .Select(p => new { p.Id, p.Status })
             .ToListAsync(ct);
         return rows.ToDictionary(x => x.Id, x => x.Status);
@@ -131,11 +237,15 @@ public class ControlPlaneDbContext : DbContext
     /// Story 34-1 AC6 — throws <c>PLAN.VERSION.IMMUTABLE</c> (High) when the
     /// pending change set mutates an immutable plan version or its children.
     /// </summary>
-    /// <param name="resolveUntrackedPlanStatus">
-    /// Resolves the DB status of owning plans not in the ChangeTracker.
+    /// <param name="untrackedStatus">
+    /// DB status of the owning plans of changed child rows that are NOT
+    /// represented by a tracked <see cref="Plan"/> entry. The caller computes the
+    /// id set ONCE (<see cref="CollectUntrackedOwningPlanIds"/>) and resolves the
+    /// statuses (synchronously for <see cref="SaveChanges"/>, via an async DB
+    /// lookup for <see cref="SaveChangesAsync(bool, CancellationToken)"/>).
     /// </param>
     private void EnforcePlanImmutability(
-        Func<HashSet<Guid>, IReadOnlyDictionary<Guid, string>> resolveUntrackedPlanStatus)
+        IReadOnlyDictionary<Guid, string> untrackedStatus)
     {
         // 1. Direct Plan mutations.
         foreach (var entry in ChangeTracker.Entries<Plan>())
@@ -157,14 +267,12 @@ public class ControlPlaneDbContext : DbContext
                 originalStatus, entry.Entity.Id, "plan");
         }
 
-        // 2. Child mutations (insert / update / delete).
+        // 2. Child mutations (insert / update / delete). The untracked-owning-plan
+        // ids + their DB statuses were computed ONCE by the caller and passed in
+        // as untrackedStatus (the async path used to recompute the id set here as
+        // well — see Fix #4).
         var trackedPlanStatus = ChangeTracker.Entries<Plan>()
             .ToDictionary(e => e.Entity.Id, e => (e.State, e.Entity.Status));
-
-        var untrackedIds = CollectUntrackedOwningPlanIds();
-        var untrackedStatus = untrackedIds.Count == 0
-            ? new Dictionary<Guid, string>()
-            : resolveUntrackedPlanStatus(untrackedIds);
 
         EnforceChildren<PlanFeature>(e => e.PlanId, trackedPlanStatus, untrackedStatus);
         EnforceChildren<PlanEntitlement>(e => e.PlanId, trackedPlanStatus, untrackedStatus);

--- a/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
@@ -1,4 +1,6 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Tamma.Core;
 using Tamma.Core.Entities;
 using Tamma.Core.Enums;
 using Tamma.Data.Entities;
@@ -27,6 +29,224 @@ public class ControlPlaneDbContext : DbContext
     public ControlPlaneDbContext(DbContextOptions<ControlPlaneDbContext> options)
         : base(options)
     {
+    }
+
+    // ── Story 34-1 (AC6) — plan-immutability SaveChanges interceptor ──
+    //
+    // EnforcePlanImmutability scans the ChangeTracker before EVERY save and
+    // throws PLAN.VERSION.IMMUTABLE for any mutation of an active/deprecated
+    // Plan row or its child PlanFeature/PlanEntitlement/PlanPrice rows. The
+    // application-level guard in PlanVersionEditor is no longer the only line
+    // of defence: a raw db.Plans.First(active).MonthlyPriceUsd = 999; SaveChanges
+    // now fails LOUD here. The single controlled active→deprecated flip the
+    // version editor performs is allowed; children of a freshly-Added active
+    // plan (the new version's rows) are allowed.
+
+    /// <summary>
+    /// Story 34-1 — escape hatch for the trusted <c>PlansSeeder</c> system-
+    /// defaults populate path ONLY. The seeder does insert-missing-only
+    /// backfill of children onto an already-active v1 plan (Story 28-1 shipped
+    /// the bare plan rows; 34-1 backfills the typed children), which the
+    /// immutability interceptor would otherwise (correctly) reject. The seeder
+    /// sets this for the duration of its save and resets it in a finally. No
+    /// user-facing or request-handling code should ever set it.
+    /// </summary>
+    public bool SuppressPlanImmutabilityGuard { get; set; }
+
+    public override int SaveChanges(bool acceptAllChangesOnSuccess)
+    {
+        if (!SuppressPlanImmutabilityGuard)
+        {
+            EnforcePlanImmutability(resolveUntrackedPlanStatus: ids =>
+                Plans.AsNoTracking()
+                    .Where(p => ids.Contains(p.Id))
+                    .Select(p => new { p.Id, p.Status })
+                    .ToDictionary(x => x.Id, x => x.Status));
+        }
+        return base.SaveChanges(acceptAllChangesOnSuccess);
+    }
+
+    public override async Task<int> SaveChangesAsync(
+        bool acceptAllChangesOnSuccess,
+        CancellationToken cancellationToken = default)
+    {
+        if (!SuppressPlanImmutabilityGuard)
+        {
+            var untracked = await ResolvePlanGuardUntrackedAsync(cancellationToken);
+            EnforcePlanImmutability(resolveUntrackedPlanStatus: _ => untracked);
+        }
+        return await base.SaveChangesAsync(acceptAllChangesOnSuccess, cancellationToken);
+    }
+
+    /// <summary>
+    /// Async pre-pass for <see cref="SaveChangesAsync(bool, CancellationToken)"/>:
+    /// loads the status of any owning plan referenced by a changed child row
+    /// that isn't already in the ChangeTracker, so the synchronous
+    /// <see cref="EnforcePlanImmutability"/> body never blocks on the DB.
+    /// </summary>
+    private async Task<Dictionary<Guid, string>> ResolvePlanGuardUntrackedAsync(
+        CancellationToken ct)
+    {
+        var ids = CollectUntrackedOwningPlanIds();
+        if (ids.Count == 0) return new Dictionary<Guid, string>();
+
+        var rows = await Plans.AsNoTracking()
+            .Where(p => ids.Contains(p.Id))
+            .Select(p => new { p.Id, p.Status })
+            .ToListAsync(ct);
+        return rows.ToDictionary(x => x.Id, x => x.Status);
+    }
+
+    /// <summary>
+    /// Owning-plan ids of changed child rows that are NOT represented by a
+    /// tracked <see cref="Plan"/> entry — these need a DB status lookup.
+    /// </summary>
+    private HashSet<Guid> CollectUntrackedOwningPlanIds()
+    {
+        var trackedPlanIds = new HashSet<Guid>(
+            ChangeTracker.Entries<Plan>().Select(e => e.Entity.Id));
+
+        var needed = new HashSet<Guid>();
+        foreach (var planId in EnumerateChangedChildOwningPlanIds())
+        {
+            if (!trackedPlanIds.Contains(planId)) needed.Add(planId);
+        }
+        return needed;
+    }
+
+    private IEnumerable<Guid> EnumerateChangedChildOwningPlanIds()
+    {
+        foreach (var e in ChangeTracker.Entries<PlanFeature>())
+            if (e.State is EntityState.Added or EntityState.Modified or EntityState.Deleted)
+                yield return e.Entity.PlanId;
+        foreach (var e in ChangeTracker.Entries<PlanEntitlement>())
+            if (e.State is EntityState.Added or EntityState.Modified or EntityState.Deleted)
+                yield return e.Entity.PlanId;
+        foreach (var e in ChangeTracker.Entries<PlanPrice>())
+            if (e.State is EntityState.Added or EntityState.Modified or EntityState.Deleted)
+                yield return e.Entity.PlanId;
+    }
+
+    /// <summary>
+    /// Story 34-1 AC6 — throws <c>PLAN.VERSION.IMMUTABLE</c> (High) when the
+    /// pending change set mutates an immutable plan version or its children.
+    /// </summary>
+    /// <param name="resolveUntrackedPlanStatus">
+    /// Resolves the DB status of owning plans not in the ChangeTracker.
+    /// </param>
+    private void EnforcePlanImmutability(
+        Func<HashSet<Guid>, IReadOnlyDictionary<Guid, string>> resolveUntrackedPlanStatus)
+    {
+        // 1. Direct Plan mutations.
+        foreach (var entry in ChangeTracker.Entries<Plan>())
+        {
+            if (entry.State != EntityState.Modified) continue;
+
+            var originalStatus = entry.OriginalValues.GetValue<string>(nameof(Plan.Status));
+            if (originalStatus is not ("active" or "deprecated")) continue;
+
+            // The ONLY permitted change to an immutable row is the controlled
+            // active→deprecated flip the version editor performs: Status flips
+            // active→deprecated and nothing else changes except UpdatedAt.
+            if (IsControlledDeprecationFlip(entry, originalStatus))
+            {
+                continue;
+            }
+
+            ThrowImmutable(entry.Entity.Slug, entry.Entity.Version,
+                originalStatus, entry.Entity.Id, "plan");
+        }
+
+        // 2. Child mutations (insert / update / delete).
+        var trackedPlanStatus = ChangeTracker.Entries<Plan>()
+            .ToDictionary(e => e.Entity.Id, e => (e.State, e.Entity.Status));
+
+        var untrackedIds = CollectUntrackedOwningPlanIds();
+        var untrackedStatus = untrackedIds.Count == 0
+            ? new Dictionary<Guid, string>()
+            : resolveUntrackedPlanStatus(untrackedIds);
+
+        EnforceChildren<PlanFeature>(e => e.PlanId, trackedPlanStatus, untrackedStatus);
+        EnforceChildren<PlanEntitlement>(e => e.PlanId, trackedPlanStatus, untrackedStatus);
+        EnforceChildren<PlanPrice>(e => e.PlanId, trackedPlanStatus, untrackedStatus);
+    }
+
+    private void EnforceChildren<TChild>(
+        Func<TChild, Guid> planIdSelector,
+        IReadOnlyDictionary<Guid, (EntityState State, string Status)> trackedPlanStatus,
+        IReadOnlyDictionary<Guid, string> untrackedStatus)
+        where TChild : class
+    {
+        foreach (var entry in ChangeTracker.Entries<TChild>())
+        {
+            if (entry.State is not (EntityState.Added or EntityState.Modified or EntityState.Deleted))
+                continue;
+
+            var planId = planIdSelector(entry.Entity);
+
+            // The new version's children attach to a freshly-Added active plan
+            // — those are part of creating a new immutable version, so allow.
+            if (trackedPlanStatus.TryGetValue(planId, out var tracked))
+            {
+                if (tracked.State == EntityState.Added) continue;
+                if (tracked.Status is "active" or "deprecated")
+                {
+                    ThrowImmutable("(child)", null, tracked.Status, planId, typeof(TChild).Name);
+                }
+                continue;
+            }
+
+            // Owning plan not tracked — use the DB status. A child of an
+            // already-persisted active/deprecated plan is immutable.
+            if (untrackedStatus.TryGetValue(planId, out var dbStatus)
+                && dbStatus is "active" or "deprecated")
+            {
+                ThrowImmutable("(child)", null, dbStatus, planId, typeof(TChild).Name);
+            }
+        }
+    }
+
+    /// <summary>
+    /// True iff this Modified Plan entry is the controlled active→deprecated
+    /// flip the version editor performs: Status changes from <c>active</c> to
+    /// <c>deprecated</c> and no other property changes except <c>UpdatedAt</c>.
+    /// </summary>
+    private static bool IsControlledDeprecationFlip(
+        EntityEntry<Plan> entry, string originalStatus)
+    {
+        if (originalStatus != "active") return false;
+        if (entry.Entity.Status != "deprecated") return false;
+
+        foreach (var prop in entry.Properties)
+        {
+            if (!prop.IsModified) continue;
+            var name = prop.Metadata.Name;
+            if (name is nameof(Plan.Status) or nameof(Plan.UpdatedAt)) continue;
+            // Any other modified column means this is NOT a pure flip.
+            return false;
+        }
+        return true;
+    }
+
+    private static void ThrowImmutable(
+        string slug, int? version, string status, Guid planId, string entityKind)
+    {
+        var versionLabel = version is null ? string.Empty : $" v{version}";
+        throw new TammaError(
+            "PLAN.VERSION.IMMUTABLE",
+            $"Plan '{slug}'{versionLabel} is {status} and immutable — its {entityKind} rows "
+            + "cannot be inserted, updated, or deleted in place. Create a new version "
+            + "via PlanVersionEditor instead.",
+            new Dictionary<string, object?>
+            {
+                ["slug"] = slug,
+                ["version"] = version,
+                ["status"] = status,
+                ["planId"] = planId.ToString("D"),
+                ["entityKind"] = entityKind,
+            },
+            retryable: false,
+            severity: TammaErrorSeverity.High);
     }
 
     // ── Control-plane entities (Doc 01 §1.2 — exactly 14 tables) ──

--- a/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
@@ -425,6 +425,25 @@ public class ControlPlaneDbContext : DbContext
     /// </summary>
     public DbSet<AgentVersion> AgentVersions => Set<AgentVersion>();
 
+    // ── Story 35-1 — billing foundation (Epic 35) ──
+    //
+    // The tenant→Stripe customer mapping + the slug→Stripe-ids catalog are
+    // CP-resident: billing is a cross-cutting platform concern, the catalog is
+    // platform-global, and the customer binding is keyed by tenant (not
+    // tenant-resident business data). SaaS only — single-user never writes here.
+
+    /// <summary>
+    /// Story 35-1 — one row per tenant binding it to its Stripe customer.
+    /// Unique <c>TenantId</c>; see <see cref="Entities.BillingCustomer"/>.
+    /// </summary>
+    public DbSet<BillingCustomer> BillingCustomers => Set<BillingCustomer>();
+
+    /// <summary>
+    /// Story 35-1 — slug→Stripe Product/Price/Meter id catalog. Unique
+    /// <c>PlanSlug</c>; platform-global. See <see cref="Entities.BillingPlanPrice"/>.
+    /// </summary>
+    public DbSet<BillingPlanPrice> BillingPlanPrices => Set<BillingPlanPrice>();
+
     // Story 28-1 PR D: the 11 + 4 mentorship tenant-resident entities
     // (AgentConfig, PromptOverride, ProviderHealth, ProviderDiagnostic,
     // SanitizationRule, WorkflowDefinition, WorkflowInstance, DomainEvent,
@@ -501,6 +520,11 @@ public class ControlPlaneDbContext : DbContext
         // Story 32-1 — first-class agent entities. CP-resident, configured in
         // the shared single source so the model graph + migration stay aligned.
         TammaModelConfiguration.ConfigureAgentEntities(modelBuilder);
+
+        // Story 35-1 — billing customer mapping + Stripe catalog. CP-resident,
+        // configured in the shared single source so the model graph + migration
+        // stay aligned (same convention as the agent entities above).
+        TammaModelConfiguration.ConfigureBillingEntities(modelBuilder);
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDesignTimeDbContextFactory.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDesignTimeDbContextFactory.cs
@@ -16,11 +16,14 @@ public class ControlPlaneDesignTimeDbContextFactory : IDesignTimeDbContextFactor
         var connectionString = Environment.GetEnvironmentVariable("ConnectionStrings__ControlPlane")
             ?? "Host=localhost;Port=5432;Database=tamma_control;Username=tamma;Password=tamma";
 
-        var options = new DbContextOptionsBuilder<ControlPlaneDbContext>()
+        var optionsBuilder = new DbContextOptionsBuilder<ControlPlaneDbContext>()
             .UseNpgsql(connectionString, npgsql =>
-                npgsql.MigrationsHistoryTable("__ControlPlaneMigrationsHistory"))
-            .Options;
+                npgsql.MigrationsHistoryTable("__ControlPlaneMigrationsHistory"));
+        // Story 35-1 follow-up — keep `ef migrations has-pending-model-changes`
+        // output clean by suppressing the required-navigation/query-filter
+        // advisory on the design-time options too (same seam as runtime DI).
+        ControlPlaneDbContext.ConfigureControlPlaneWarnings(optionsBuilder);
 
-        return new ControlPlaneDbContext(options);
+        return new ControlPlaneDbContext(optionsBuilder.Options);
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Data/DependencyInjection.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/DependencyInjection.cs
@@ -77,6 +77,10 @@ public static class DependencyInjection
                 // Must match ControlPlaneDesignTimeDbContextFactory — one history table
                 // for design-time and runtime (unified-tenancy Phase 0 reconciliation).
                 npgsql.MigrationsHistoryTable("__ControlPlaneMigrationsHistory"));
+            // Story 35-1 follow-up — suppress the required-navigation/query-filter
+            // advisory at the options-builder seam (pooling-safe; see
+            // ControlPlaneDbContext.ConfigureControlPlaneWarnings).
+            ControlPlaneDbContext.ConfigureControlPlaneWarnings(options);
         });
         services.AddScoped(sp =>
             sp.GetRequiredService<IDbContextFactory<ControlPlaneDbContext>>()

--- a/apps/tamma-elsa/src/Tamma.Data/DependencyInjection.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/DependencyInjection.cs
@@ -139,6 +139,11 @@ public static class DependencyInjection
         // Scoped because it leans on ControlPlaneDbContext.
         services.AddScoped<IPlatformBootstrapRepository, PlatformBootstrapRepository>();
 
+        // Story 32-1 — CP-resident agent identity + versioning repository.
+        // Resolves against ControlPlaneDbContext (definitions are CP-resident);
+        // distinct from the tenant-scoped IAgentConfigRepository below.
+        services.AddScoped<IAgentRepository, AgentRepository>();
+
         // Tenant-scoped repositories (use ITenantDbContextFactory internally).
         services.AddScoped<IAgentConfigRepository, AgentConfigRepository>();
         services.AddScoped<IPromptRepository, PromptRepository>();

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/Agent.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/Agent.cs
@@ -1,0 +1,71 @@
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 32-1 — a first-class, identity-bearing agent definition. Replaces the
+/// anonymous, role-keyed <see cref="AgentConfig"/> JSONB blob as the canonical
+/// entity the rest of Epic 32 joins on. The <see cref="Id"/> is the immutable
+/// join key for all later action/performance metrics, so an agent's history
+/// survives config edits.
+///
+/// <para><b>Control-plane-resident.</b> Both public (cross-tenant) and private
+/// (tenant/user-owned) agent definitions live on
+/// <see cref="ControlPlaneDbContext"/> because visibility/identity is a CP
+/// concern. ALL performance/action data is tenant-scoped and lands in the
+/// tenant schema in later Epic 32 stories — no performance column belongs
+/// here; this entity is definition-only.</para>
+///
+/// <para><b>Mode-aware ownership.</b> Per CLAUDE.md "Universal rule for any
+/// tenant-aware feature", ownership is answered separately for each mode:
+/// <list type="bullet">
+///   <item><see cref="AgentVisibility.Public"/> ⇒ both owner columns NULL.</item>
+///   <item><see cref="AgentVisibility.Private"/> in SaaS ⇒
+///     <see cref="OwnerTenantId"/> set, <see cref="OwnerUserId"/> NULL.</item>
+///   <item><see cref="AgentVisibility.Private"/> in single-user ⇒
+///     <see cref="OwnerUserId"/> set, <see cref="OwnerTenantId"/> NULL.</item>
+/// </list>
+/// This invariant is enforced both by the DB <c>ck_agents_visibility_ownership</c>
+/// CHECK (structural backstop) and by an entity-level guard in
+/// <c>AgentRepository.CreateAsync</c> (fail-fast before the DB).</para>
+/// </summary>
+public class Agent
+{
+    public Guid Id { get; set; }
+
+    /// <summary>Stable handle, e.g. <c>"tamma-architect"</c> or <c>"atlas"</c>.</summary>
+    public string Name { get; set; } = null!;
+
+    /// <summary>
+    /// The agent's role as an <c>AgentRole</c> wire string (validated via
+    /// <c>RolePhaseMap.NormalizeRole</c> / <c>AgentRoleExtensions.Parse</c> on
+    /// create). A benchmarking attribute, NOT a primary key — the Agent, not
+    /// the role, is the tracked entity.
+    /// </summary>
+    public string Role { get; set; } = null!;
+
+    /// <summary>Public (system) vs private (tenant/user-owned). See <see cref="AgentVisibility"/>.</summary>
+    public AgentVisibility Visibility { get; set; }
+
+    /// <summary>Owner tenant — set iff <see cref="AgentVisibility.Private"/> in SaaS mode.</summary>
+    public Guid? OwnerTenantId { get; set; }
+
+    /// <summary>Owner user — set iff <see cref="AgentVisibility.Private"/> in single-user mode.</summary>
+    public Guid? OwnerUserId { get; set; }
+
+    public AgentStatus Status { get; set; } = AgentStatus.Active;
+
+    /// <summary>
+    /// Pointer to the active <see cref="AgentVersion"/>. A bare nullable Guid
+    /// (no DB FK back to <c>agent_versions</c>) to dodge a circular FK on the
+    /// create-then-publish-first-version flow; pointer integrity is enforced in
+    /// the repository transaction.
+    /// </summary>
+    public Guid? CurrentVersionId { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+    public Guid? CreatedBy { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public Guid? UpdatedBy { get; set; }
+
+    /// <summary>Immutable, monotonically-versioned config snapshots for this agent.</summary>
+    public ICollection<AgentVersion> Versions { get; set; } = new List<AgentVersion>();
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/AgentStatus.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/AgentStatus.cs
@@ -1,0 +1,17 @@
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 32-1 — lifecycle state for an <see cref="Agent"/>. Stored as an
+/// <c>int</c> (<see cref="Active"/> = 0, <see cref="Archived"/> = 1) via
+/// <c>HasConversion&lt;int&gt;()</c>. Archive is the terminal state — agent
+/// definitions and their version history are never hard-deleted (versions are
+/// immutable audit history; the FK uses <c>OnDelete(Restrict)</c>).
+/// </summary>
+public enum AgentStatus
+{
+    /// <summary>The agent is live and resolvable.</summary>
+    Active = 0,
+
+    /// <summary>The agent has been retired. History stays queryable; no new versions.</summary>
+    Archived = 1,
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/AgentVersion.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/AgentVersion.cs
@@ -1,0 +1,34 @@
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 32-1 — an immutable, monotonically-versioned saved-config snapshot for
+/// an <see cref="Agent"/>. Insert-only: never <c>UPDATE</c>d after insert. Any
+/// action/metric ties to the exact config version that produced it, so
+/// benchmarking can slice by version. Rollback = repoint
+/// <see cref="Agent.CurrentVersionId"/>, never delete-and-recreate; the
+/// <c>(AgentId, Version)</c> unique index guarantees monotonic, non-duplicated
+/// versions, and the FK uses <c>OnDelete(Restrict)</c> to protect history.
+/// </summary>
+public class AgentVersion
+{
+    public Guid Id { get; set; }
+
+    public Guid AgentId { get; set; }
+
+    /// <summary>1-based, monotonic per <see cref="AgentId"/>. Unique on <c>(AgentId, Version)</c>.</summary>
+    public int Version { get; set; }
+
+    /// <summary>
+    /// The saved-config snapshot (jsonb). Credential-agnostic by design
+    /// (provider + model + prompt + settings, never raw keys). Validated by
+    /// <c>AgentConfigValidator</c> before any write.
+    /// </summary>
+    public string ConfigJson { get; set; } = "{}";
+
+    public string? Notes { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+    public Guid? CreatedBy { get; set; }
+
+    public Agent? Agent { get; set; }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/AgentVisibility.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/AgentVisibility.cs
@@ -1,0 +1,29 @@
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 32-1 — ownership/visibility discriminator for an <see cref="Agent"/>.
+///
+/// <para>Stored as an <c>int</c> (<see cref="Public"/> = 0,
+/// <see cref="Private"/> = 1) via <c>HasConversion&lt;int&gt;()</c> so the
+/// <c>ck_agents_visibility_ownership</c> CHECK can compare the numeric
+/// discriminator. The ordinal values are load-bearing — the CHECK constraint
+/// SQL in <c>TammaModelConfiguration</c> hard-codes <c>= 0</c> / <c>= 1</c>.
+/// Do NOT reorder.</para>
+/// </summary>
+public enum AgentVisibility
+{
+    /// <summary>
+    /// Platform-owned / system-wide agent. Available to every tenant; owned and
+    /// edited by the platform admin. Both owner columns are NULL. Shipped
+    /// default agents are public.
+    /// </summary>
+    Public = 0,
+
+    /// <summary>
+    /// Tenant-owned (SaaS) or user-owned (single-user) agent. Available only to
+    /// its principal. Exactly one owner column is set, picked by the process
+    /// mode: SaaS → <see cref="Agent.OwnerTenantId"/>; single-user →
+    /// <see cref="Agent.OwnerUserId"/>.
+    /// </summary>
+    Private = 1,
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/AnalyticsUsageDaily.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/AnalyticsUsageDaily.cs
@@ -1,0 +1,86 @@
+using Tamma.Core.Enums;
+
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 36-1 — per-tenant <b>daily</b> roll-up of <see cref="AnalyticsUsageHourly"/>.
+///
+/// <para>Carries the <b>identical</b> dimension + measure contract as the
+/// hourly grain — the ONLY difference is the time bucket is <see cref="Day"/>
+/// (UTC midnight) instead of <c>Hour</c>. Keeping the shape byte-for-byte
+/// identical makes the daily roll-up (Story 36-2) a pure
+/// <c>GROUP BY date_trunc('day', Hour), &lt;dims&gt;</c> — a lossless
+/// aggregation of the hourly rows, no measure dropped.</para>
+///
+/// <para>Lives in the tenant schema (see <see cref="AnalyticsUsageHourly"/> for
+/// the full tenancy, population-source, and measure-type rationale). No
+/// <c>TenantId</c> column; no events emitted by this story.</para>
+/// </summary>
+public class AnalyticsUsageDaily
+{
+    /// <summary>
+    /// Surrogate PK — Postgres <c>gen_random_uuid()</c> default. The
+    /// <c>UX_analytics_usage_daily_dims</c> unique index over the full
+    /// dimension tuple is the business/idempotency key (Story 36-2's upsert
+    /// target).
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// UTC midnight bucket — e.g. <c>2026-06-17T00:00:00Z</c> for the whole of
+    /// 2026-06-17. Stored as <c>timestamp with time zone</c>.
+    /// </summary>
+    public DateTime Day { get; set; }
+
+    // ── Dimensions (identical to AnalyticsUsageHourly) ──
+
+    /// <summary>AI provider key (e.g. <c>anthropic-claude</c>). Required.</summary>
+    public string Provider { get; set; } = null!;
+
+    /// <summary>Agent handle/id this usage is attributed to; <c>null</c> = unattributed.</summary>
+    public string? AgentId { get; set; }
+
+    /// <summary>Workflow definition this usage rolls up under; <c>null</c> = none.</summary>
+    public Guid? WorkflowDefinitionId { get; set; }
+
+    /// <summary>Repository this usage is attributed to; <c>null</c> = unattributed.</summary>
+    public string? RepoId { get; set; }
+
+    /// <summary>
+    /// Whether the cost was BYOK (tenant key, unbilled) or platform-fronted
+    /// (billable). Persisted as lowercase text (<c>byok</c>/<c>platform</c>).
+    /// </summary>
+    public CostBasis CostBasis { get; set; }
+
+    // ── Measures (identical to AnalyticsUsageHourly) ──
+
+    /// <summary>Sum of <c>LLM.CALL.SUCCESS.data.inputTokens</c> in the bucket.</summary>
+    public long TokensIn { get; set; }
+
+    /// <summary>Sum of <c>LLM.CALL.SUCCESS.data.outputTokens</c> in the bucket.</summary>
+    public long TokensOut { get; set; }
+
+    /// <summary>Sum of <c>LLM.CALL.SUCCESS.data.costUsd</c> in the bucket, 4-decimal precision.</summary>
+    public decimal CostUsd { get; set; }
+
+    /// <summary>
+    /// Portion of <see cref="CostUsd"/> Tamma billed the tenant (only
+    /// <see cref="CostBasis.Platform"/> rows are non-zero). 4-decimal precision.
+    /// </summary>
+    public decimal PlatformBilledUsd { get; set; }
+
+    /// <summary>Number of workflow instances created in this bucket.</summary>
+    public long WorkflowsStarted { get; set; }
+
+    /// <summary>Number of workflow instances that reached <c>completed</c> in this bucket.</summary>
+    public long WorkflowsCompleted { get; set; }
+
+    /// <summary>Number of workflow instances that reached <c>failed</c> in this bucket.</summary>
+    public long WorkflowsFailed { get; set; }
+
+    /// <summary>Number of <c>AGENT.DISPATCH.*</c> events in this bucket.</summary>
+    public long AgentDispatches { get; set; }
+
+    /// <summary>Wall-clock write/last-update timestamp; defaults to <c>now()</c>.</summary>
+    public DateTime ComputedAt { get; set; }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/AnalyticsUsageHourly.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/AnalyticsUsageHourly.cs
@@ -1,0 +1,104 @@
+using Tamma.Core.Enums;
+
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 36-1 — per-tenant <b>hourly</b> usage/cost/performance fact row.
+///
+/// <para>Lives in the tenant schema (the per-tenant <c>t_&lt;hex&gt;</c>
+/// search-path schema reached through <see cref="TenantDbContext"/>), NOT the
+/// control-plane <c>platform_analytics_hourly</c> table — that one stays the
+/// owner-only fleet-wide store (Story 28-10). This per-tenant grain adds the
+/// dimensions the single-grain CP row deliberately omits: <see cref="Provider"/>,
+/// <see cref="AgentId"/>, <see cref="WorkflowDefinitionId"/>,
+/// <see cref="RepoId"/>, and a BYOK-vs-platform <see cref="CostBasis"/>.</para>
+///
+/// <para><b>Tenancy:</b> no <c>TenantId</c> column — isolation is the schema +
+/// connection string (Doc 01 §1.4 target shape), not a column. A row in one
+/// tenant's schema is physically unreachable from another tenant's context.</para>
+///
+/// <para><b>Population (future, Story 36-2 — NOT this story):</b> the projection
+/// pipeline fills these tables from the existing DCB source events
+/// <c>LLM.CALL.SUCCESS</c> (<c>data.inputTokens</c>/<c>outputTokens</c>/<c>costUsd</c>),
+/// <c>AGENT.DISPATCH.SUCCESS|FAILED</c>, and <c>WORKFLOW.STEP_COMPLETED</c> —
+/// the same prefixes <c>PlatformAnalyticsService</c> already tracks. This story
+/// emits and consumes NO events; the <c>ANALYTICS.PROJECTION.*</c> catalogue is
+/// Story 36-2's.</para>
+///
+/// <para><b>Measure types</b> mirror <see cref="PlatformAnalyticsHourly"/>
+/// (counters <c>long</c>, costs <c>decimal(20,4)</c>) so an owner-side
+/// reconciliation join across the two stores is lossless.</para>
+/// </summary>
+public class AnalyticsUsageHourly
+{
+    /// <summary>
+    /// Surrogate PK — Postgres <c>gen_random_uuid()</c> default. The
+    /// <c>UX_analytics_usage_hourly_dims</c> unique index over the full
+    /// dimension tuple is the business/idempotency key (Story 36-2's upsert
+    /// target); the PK stays stable so a row updates in place on re-projection.
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// UTC top-of-hour bucket — e.g. <c>2026-06-17T12:00:00Z</c> for the
+    /// 12:00–13:00 window. Always truncated to the hour by the (future)
+    /// projection. Stored as <c>timestamp with time zone</c>.
+    /// </summary>
+    public DateTime Hour { get; set; }
+
+    // ── Dimensions ──
+
+    /// <summary>AI provider key (e.g. <c>anthropic-claude</c>). Required.</summary>
+    public string Provider { get; set; } = null!;
+
+    /// <summary>Agent handle/id this usage is attributed to; <c>null</c> = unattributed.</summary>
+    public string? AgentId { get; set; }
+
+    /// <summary>Workflow definition this usage rolls up under; <c>null</c> = none.</summary>
+    public Guid? WorkflowDefinitionId { get; set; }
+
+    /// <summary>Repository this usage is attributed to; <c>null</c> = unattributed.</summary>
+    public string? RepoId { get; set; }
+
+    /// <summary>
+    /// Whether the cost was BYOK (tenant key, unbilled) or platform-fronted
+    /// (billable). Persisted as lowercase text (<c>byok</c>/<c>platform</c>).
+    /// </summary>
+    public CostBasis CostBasis { get; set; }
+
+    // ── Measures (counters: long; cost: decimal(20,4)) ──
+
+    /// <summary>Sum of <c>LLM.CALL.SUCCESS.data.inputTokens</c> in the bucket.</summary>
+    public long TokensIn { get; set; }
+
+    /// <summary>Sum of <c>LLM.CALL.SUCCESS.data.outputTokens</c> in the bucket.</summary>
+    public long TokensOut { get; set; }
+
+    /// <summary>Sum of <c>LLM.CALL.SUCCESS.data.costUsd</c> in the bucket, 4-decimal precision.</summary>
+    public decimal CostUsd { get; set; }
+
+    /// <summary>
+    /// Portion of <see cref="CostUsd"/> Tamma billed the tenant (only
+    /// <see cref="CostBasis.Platform"/> rows are non-zero). 4-decimal precision.
+    /// </summary>
+    public decimal PlatformBilledUsd { get; set; }
+
+    /// <summary>Number of workflow instances created in this bucket.</summary>
+    public long WorkflowsStarted { get; set; }
+
+    /// <summary>Number of workflow instances that reached <c>completed</c> in this bucket.</summary>
+    public long WorkflowsCompleted { get; set; }
+
+    /// <summary>Number of workflow instances that reached <c>failed</c> in this bucket.</summary>
+    public long WorkflowsFailed { get; set; }
+
+    /// <summary>Number of <c>AGENT.DISPATCH.*</c> events in this bucket.</summary>
+    public long AgentDispatches { get; set; }
+
+    /// <summary>
+    /// Wall-clock timestamp when this row was written (or last updated on a
+    /// re-projection). Useful for the runbook — ops can see which buckets were
+    /// backfilled late. Defaults to <c>now()</c>.
+    /// </summary>
+    public DateTime ComputedAt { get; set; }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/AuditProjectorCursor.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/AuditProjectorCursor.cs
@@ -1,29 +1,62 @@
 namespace Tamma.Data.Entities;
 
 /// <summary>
-/// Story 37-1 — one row per logical audit projector. Tracks the last DCB
-/// event (per stream) the projector successfully materialized so a restart
-/// resumes instead of re-scanning from scratch. Structurally a clone of
-/// <see cref="AlertEvaluatorCursor"/> — same cursor mechanism, different sink.
+/// Story 37-1 — one row per <c>(ProjectorId, TenantId)</c> high-water mark.
+/// Tracks the last DCB event the projector successfully materialized so a
+/// restart resumes instead of re-scanning from scratch.
 ///
-/// <para><b>Crash safety</b>: the cursor is persisted after each batch. A
-/// process kill mid-batch may re-scan a handful of events on restart; the
-/// <c>audit_records.source_event_id</c> UNIQUE index makes the re-scan a
-/// no-op (insert-if-absent), so the projection is idempotent (AC8).</para>
+/// <para><b>Why a composite key (C1 fix)</b>: each tenant's
+/// <c>domain_events.SequenceNumber</c> is an INDEPENDENT per-schema BIGSERIAL —
+/// tenant B's stream starts at 1 regardless of how far tenant A has advanced. A
+/// single shared domain cursor therefore loses tenant B's audit data the moment
+/// the shared cursor passes tenant A's high-water mark (B is read with
+/// <c>WHERE SequenceNumber &gt; &lt;A's max&gt;</c> and never projected). So the
+/// domain high-water mark is tracked PER TENANT, keyed by <see cref="TenantId"/>.</para>
+///
+/// <para>The control-plane <c>platform_events</c> stream is a single global
+/// BIGSERIAL stream, so it is tracked on one distinguished row whose
+/// <see cref="TenantId"/> = <see cref="PlatformSentinel"/> (a Postgres primary
+/// key column cannot be NULL, so the all-zero Guid is the "platform" sentinel).
+/// That same sentinel row also tracks the single-user / transitional shared-DB
+/// <c>cp.domain_events</c> fallback (one stream, no tenant fan-out).</para>
+///
+/// <para><b>Crash safety</b>: each tenant's cursor is persisted after its batch.
+/// A process kill mid-batch may re-scan a handful of events on restart; the
+/// <c>audit_records.source_event_id</c> UNIQUE index makes the re-scan a no-op
+/// (insert-if-absent), so the projection is idempotent (AC8).</para>
 /// </summary>
 public class AuditProjectorCursor
 {
-    /// <summary>Stable id for the logical projector. One row per id; the single
+    /// <summary>The distinguished <see cref="TenantId"/> value for the row that
+    /// tracks the global CP <c>platform_events</c> stream (and the shared-DB
+    /// <c>cp.domain_events</c> fallback). A real tenant id is never the all-zero
+    /// Guid, so this never collides with a per-tenant row.</summary>
+    public static readonly Guid PlatformSentinel = Guid.Empty;
+
+    /// <summary>Stable id for the logical projector. The single
     /// <c>"default"</c> projector is used today.</summary>
     public string ProjectorId { get; set; } = "default";
 
-    /// <summary>Last-processed <see cref="DomainEvent.SequenceNumber"/> from the
-    /// tenant <c>domain_events</c> stream. Zero = start from the beginning.</summary>
+    /// <summary>
+    /// The tenant this cursor row tracks. <see cref="PlatformSentinel"/>
+    /// (all-zero Guid) is the distinguished "platform" row that tracks the CP
+    /// <c>platform_events</c> stream (and the single-user / transitional shared-DB
+    /// <c>cp.domain_events</c> fallback). A real tenant id tracks one tenant's
+    /// per-schema <c>domain_events</c> stream. Part of the composite primary key
+    /// together with <see cref="ProjectorId"/>.
+    /// </summary>
+    public Guid TenantId { get; set; } = PlatformSentinel;
+
+    /// <summary>Last-processed <see cref="DomainEvent.SequenceNumber"/> from THIS
+    /// row's <c>domain_events</c> stream (this tenant's per-schema stream, or the
+    /// shared-DB <c>cp.domain_events</c> on the sentinel/platform row). Zero =
+    /// start from the beginning.</summary>
     public long LastDomainSequenceNumber { get; set; }
 
     /// <summary>Last-processed <see cref="PlatformEvent.SequenceNumber"/> from the
-    /// control-plane <c>platform_events</c> stream. Tracked independently because
-    /// the two streams each have their own BIGSERIAL identity.</summary>
+    /// control-plane <c>platform_events</c> stream. Only meaningful on the
+    /// distinguished <see cref="PlatformSentinel"/> platform row (the platform
+    /// stream is global, not per-tenant). Stays zero on per-tenant rows.</summary>
     public long LastPlatformSequenceNumber { get; set; }
 
     public DateTime UpdatedAt { get; set; }

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/AuditProjectorCursor.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/AuditProjectorCursor.cs
@@ -1,0 +1,30 @@
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 37-1 — one row per logical audit projector. Tracks the last DCB
+/// event (per stream) the projector successfully materialized so a restart
+/// resumes instead of re-scanning from scratch. Structurally a clone of
+/// <see cref="AlertEvaluatorCursor"/> — same cursor mechanism, different sink.
+///
+/// <para><b>Crash safety</b>: the cursor is persisted after each batch. A
+/// process kill mid-batch may re-scan a handful of events on restart; the
+/// <c>audit_records.source_event_id</c> UNIQUE index makes the re-scan a
+/// no-op (insert-if-absent), so the projection is idempotent (AC8).</para>
+/// </summary>
+public class AuditProjectorCursor
+{
+    /// <summary>Stable id for the logical projector. One row per id; the single
+    /// <c>"default"</c> projector is used today.</summary>
+    public string ProjectorId { get; set; } = "default";
+
+    /// <summary>Last-processed <see cref="DomainEvent.SequenceNumber"/> from the
+    /// tenant <c>domain_events</c> stream. Zero = start from the beginning.</summary>
+    public long LastDomainSequenceNumber { get; set; }
+
+    /// <summary>Last-processed <see cref="PlatformEvent.SequenceNumber"/> from the
+    /// control-plane <c>platform_events</c> stream. Tracked independently because
+    /// the two streams each have their own BIGSERIAL identity.</summary>
+    public long LastPlatformSequenceNumber { get; set; }
+
+    public DateTime UpdatedAt { get; set; }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/AuditRecord.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/AuditRecord.cs
@@ -1,0 +1,102 @@
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 37-1 — one curated, normalized, compliance-relevant audit row,
+/// materialized FROM the immutable DCB stream by the <c>AuditProjector</c>.
+///
+/// <para><b>This is a derived read-model, NOT a new event store.</b> The raw
+/// <see cref="DomainEvent"/> / <see cref="PlatformEvent"/> rows remain the
+/// authoritative source of truth; this table is rebuildable at any time
+/// (truncate + reset cursor + re-project). Every row back-references its
+/// origin via <see cref="SourceEventId"/> (the idempotency key) +
+/// <see cref="SourceSequenceNumber"/> (the deterministic replay/chain order).</para>
+///
+/// <para><b>Scope routing</b> (Story 37-1 AC11): tenant-scoped rows live in the
+/// per-tenant schema keyed by <see cref="TenantId"/> (SaaS); platform-scoped
+/// rows live in the control plane (also keyed by <see cref="TenantId"/>, or
+/// <c>null</c> for platform-only actions); single-user rows are keyed by
+/// <see cref="UserId"/>. Exactly one of <see cref="TenantId"/> /
+/// <see cref="UserId"/> is non-null (XOR CHECK, mirrors
+/// <c>prompt_overrides.principal_xor</c>).</para>
+/// </summary>
+public class AuditRecord
+{
+    /// <summary>Surrogate PK — Postgres <c>gen_random_uuid()</c> default.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Canonical DCB event-type string this row was projected from,
+    /// e.g. <c>SECRET.REVEAL</c>. Always a key in <c>SensitiveActionCatalog.ByCode</c>.</summary>
+    public string ActionCode { get; set; } = null!;
+
+    /// <summary>Compliance category (the lowercased <c>AuditCategory</c> member name).</summary>
+    public string Category { get; set; } = null!;
+
+    /// <summary>Coarse triage severity (the lowercased <c>AuditSeverity</c> member name).</summary>
+    public string Severity { get; set; } = null!;
+
+    // ── Who ──
+
+    /// <summary>The acting user (resolved from the raw event's tags/data). Null
+    /// for system-initiated actions with no resolvable actor.</summary>
+    public Guid? ActorUserId { get; set; }
+
+    /// <summary>Point-in-time actor email snapshot (the user row may later change
+    /// or be deleted; the audit row outlives the actor — SOC2 requirement).</summary>
+    public string? ActorEmailSnapshot { get; set; }
+
+    // ── What / target ──
+
+    /// <summary>Target object type, e.g. <c>secret</c> / <c>user</c> / <c>tenant</c>.</summary>
+    public string? TargetType { get; set; }
+
+    /// <summary>Target object id (free-form string — may be a Guid, slug, or number).</summary>
+    public string? TargetId { get; set; }
+
+    /// <summary>Outcome — <c>success</c> | <c>failure</c> | <c>denied</c>.</summary>
+    public string Outcome { get; set; } = "success";
+
+    // ── Context ──
+
+    /// <summary>Source IP, when the raw event carried one.</summary>
+    public string? IpAddress { get; set; }
+
+    /// <summary>User-agent, when the raw event carried one.</summary>
+    public string? UserAgent { get; set; }
+
+    /// <summary>When the audited action actually occurred (the raw event's
+    /// <c>CreatedAt</c>), stored as <c>timestamp with time zone</c>.</summary>
+    public DateTime OccurredAt { get; set; }
+
+    // ── Back-reference to the raw DCB event (immutable source of truth) ──
+
+    /// <summary>The originating raw event id. UNIQUE — the idempotency key that
+    /// makes the projection insert-if-absent and replay-safe (AC8).</summary>
+    public Guid SourceEventId { get; set; }
+
+    /// <summary>The originating raw event's DCB <c>SequenceNumber</c>. Preserves
+    /// total order for deterministic replay and for Story 37-2's hash chain.</summary>
+    public long SourceSequenceNumber { get; set; }
+
+    /// <summary>Redacted JSON projection of the raw event's <c>Data</c>/<c>Tags</c>.
+    /// Passed through <c>CredentialRedactor.Clean</c> BEFORE persistence — never
+    /// "redacted on read" (AC10).</summary>
+    public string PayloadJson { get; set; } = "{}";
+
+    // ── Per-mode ownership — exactly one is non-null (XOR CHECK) ──
+
+    /// <summary>SaaS-mode owner (the tenant). Null in single-user mode.</summary>
+    public Guid? TenantId { get; set; }
+
+    /// <summary>Single-user-mode owner (the sole user). Null in SaaS mode.</summary>
+    public Guid? UserId { get; set; }
+
+    // ── Reserved for Story 37-2 tamper-evidence (this story leaves both null) ──
+
+    /// <summary>Reserved for Story 37-2 — the hash of this record in the chain.
+    /// Story 37-1 leaves this null; 37-2 populates it. Do NOT compute here.</summary>
+    public string? RecordHash { get; set; }
+
+    /// <summary>Reserved for Story 37-2 — the previous record's hash, linking the
+    /// chain. Story 37-1 leaves this null; 37-2 populates it.</summary>
+    public string? PrevRecordHash { get; set; }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/BillingCustomer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/BillingCustomer.cs
@@ -1,0 +1,50 @@
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 35-1 — the tenant → Stripe customer mapping. Exactly one row per
+/// tenant (unique <see cref="TenantId"/>); created inside the tenant-create
+/// transaction (SaaS only). When Stripe is unreachable at create time the row
+/// still persists with <see cref="StripeCustomerId"/> = null and a
+/// <c>billing.customer.create</c> retry task is enqueued — tenant creation is
+/// never blocked on Stripe.
+///
+/// <para>CP-resident (control plane): the customer binding is a cross-cutting
+/// billing concern keyed by tenant, not tenant-resident business data. In
+/// single-user mode no row is ever written (<c>NullBillingProvider</c>).</para>
+/// </summary>
+public class BillingCustomer
+{
+    /// <summary>Stable id (server default <c>gen_random_uuid()</c>).</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Owning tenant — unique FK to <c>tenants.Id</c>.</summary>
+    public Guid TenantId { get; set; }
+
+    /// <summary>
+    /// Stripe customer id (<c>cus_...</c>). Null until Stripe acknowledges the
+    /// create — the retry handler fills it in on a later attempt.
+    /// </summary>
+    public string? StripeCustomerId { get; set; }
+
+    /// <summary>
+    /// Billing mode persisted as the <see cref="Core.Billing.BillingMode"/>
+    /// member name (<c>PlatformProvided</c> | <c>Byok</c>). Text domain pinned
+    /// by a CHECK constraint. Defaults to <c>PlatformProvided</c>.
+    /// </summary>
+    public string BillingMode { get; set; } = "PlatformProvided";
+
+    /// <summary>ISO-4217 default settlement currency. Defaults to <c>usd</c>.</summary>
+    public string DefaultCurrency { get; set; } = "usd";
+
+    /// <summary>
+    /// Tax handling marker (<c>none</c> | <c>taxable</c> | <c>reverse_charge</c>).
+    /// Stored verbatim; tax computation is a later Epic 35 story.
+    /// </summary>
+    public string TaxStatus { get; set; } = "none";
+
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+
+    /// <summary>Navigation to the owning tenant.</summary>
+    public Tenant? Tenant { get; set; }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/BillingCustomer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/BillingCustomer.cs
@@ -2,11 +2,19 @@ namespace Tamma.Data.Entities;
 
 /// <summary>
 /// Story 35-1 — the tenant → Stripe customer mapping. Exactly one row per
-/// tenant (unique <see cref="TenantId"/>); created inside the tenant-create
-/// transaction (SaaS only). When Stripe is unreachable at create time the row
-/// still persists with <see cref="StripeCustomerId"/> = null and a
-/// <c>billing.customer.create</c> retry task is enqueued — tenant creation is
-/// never blocked on Stripe.
+/// tenant (unique <see cref="TenantId"/>), SaaS only. The mapping is written by
+/// <c>BillingTenantCreateHook</c>, which runs AFTER the tenant-create commit and
+/// the <c>TENANT.CREATED.SUCCESS</c> event — NOT inside the tenant-create
+/// transaction — so a billing failure can never roll the tenant back. On the
+/// happy path the row is created with a non-null <see cref="StripeCustomerId"/>.
+/// When Stripe is unreachable at create time no row is written here; a
+/// <c>billing.customer.create</c> retry task is enqueued and the retry handler
+/// creates (or fills in) the row on a later attempt — tenant creation is never
+/// blocked on Stripe.
+///
+/// <para>The <see cref="StripeCustomerId"/> can still be null for a row created
+/// by a retry attempt that itself reached Stripe but had not yet acked the
+/// customer id; the next retry fills it in.</para>
 ///
 /// <para>CP-resident (control plane): the customer binding is a cross-cutting
 /// billing concern keyed by tenant, not tenant-resident business data. In
@@ -21,8 +29,10 @@ public class BillingCustomer
     public Guid TenantId { get; set; }
 
     /// <summary>
-    /// Stripe customer id (<c>cus_...</c>). Null until Stripe acknowledges the
-    /// create — the retry handler fills it in on a later attempt.
+    /// Stripe customer id (<c>cus_...</c>). Non-null on the happy path (the row
+    /// is only written after Stripe acks the customer). Nullable so a row created
+    /// by a partially-failed retry can persist without an id; the retry handler
+    /// fills it in on a later attempt.
     /// </summary>
     public string? StripeCustomerId { get; set; }
 

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/BillingPlanPrice.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/BillingPlanPrice.cs
@@ -1,0 +1,54 @@
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 35-1 — the billing catalog row mapping a <c>Plan.Slug</c>
+/// (<c>free</c> | <c>team</c> | <c>enterprise</c>) to its Stripe Product, base
+/// Price, and the three metered prices + their backing Billing Meters. One row
+/// per slug (unique <see cref="PlanSlug"/>); platform-global (never
+/// tenant-scoped).
+///
+/// <para>Deliberately a separate table from <see cref="PlanPrice"/> (Story
+/// 34-1): <c>PlanPrice</c> stores tenancy/pricing-policy data keyed by
+/// <c>(PlanId, PricingMode)</c>; this row stores the external-Stripe-id binding
+/// keyed by slug. Overloading <see cref="Plan"/> columns would couple tenancy
+/// placement to Stripe.</para>
+///
+/// <para>Populated idempotently by the <c>seed-billing</c> CLI command, which
+/// upserts the Stripe objects (deterministic idempotency keys) and writes their
+/// ids here. Re-running the seed is a no-op: existing ids are reused.</para>
+/// </summary>
+public class BillingPlanPrice
+{
+    /// <summary>Stable id (server default <c>gen_random_uuid()</c>).</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Plan slug this catalog row maps (unique). <c>free</c> | <c>team</c> | <c>enterprise</c>.</summary>
+    public string PlanSlug { get; set; } = null!;
+
+    /// <summary>Stripe Product id (<c>prod_...</c> / our deterministic <c>tamma-plan-{slug}</c>).</summary>
+    public string? StripeProductId { get; set; }
+
+    /// <summary>Base flat (per-seat / platform) recurring Price id (<c>price_...</c>).</summary>
+    public string? StripePriceId { get; set; }
+
+    /// <summary>Billing Meter id for input-token usage (SUM aggregation).</summary>
+    public string? TokensInputMeterId { get; set; }
+
+    /// <summary>Metered Price id charging against the input-token meter.</summary>
+    public string? TokensInputPriceId { get; set; }
+
+    /// <summary>Billing Meter id for output-token usage (SUM aggregation).</summary>
+    public string? TokensOutputMeterId { get; set; }
+
+    /// <summary>Metered Price id charging against the output-token meter.</summary>
+    public string? TokensOutputPriceId { get; set; }
+
+    /// <summary>Billing Meter id for seat usage (LAST / gauge aggregation).</summary>
+    public string? SeatsMeterId { get; set; }
+
+    /// <summary>Metered Price id charging against the seats meter.</summary>
+    public string? SeatsPriceId { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/Plan.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/Plan.cs
@@ -24,7 +24,7 @@ namespace Tamma.Data.Entities;
 /// </summary>
 public class Plan
 {
-    /// <summary>Stable UUIDv7 baked into the seed so FK targets stay deterministic across environments.</summary>
+    /// <summary>Stable sentinel UUID baked into the seed so FK targets stay deterministic across environments.</summary>
     public Guid Id { get; set; }
 
     /// <summary>Human-friendly slug — <c>free</c>, <c>team</c>, <c>enterprise</c>.</summary>

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/Plan.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/Plan.cs
@@ -2,14 +2,25 @@ namespace Tamma.Data.Entities;
 
 /// <summary>
 /// Subscription plan referenced by <see cref="Tenant.PlanId"/>. Seeded with
-/// three rows by <c>PlansSeeder</c>: <c>plan_free</c>, <c>plan_team</c>,
-/// <c>plan_enterprise</c>. Lives in the control plane.
+/// three slugs by <c>PlansSeeder</c>: <c>free</c>, <c>team</c>,
+/// <c>enterprise</c>. Lives in the control plane.
 ///
 /// <para>Doc 01 §4.1 — the Tenant row references a plan via <c>PlanId</c>;
 /// pricing, quotas, and billing cycles are derived from this row at the
-/// service layer. Plans are immutable in the seed; runtime changes are an
-/// admin-only operation that emits <c>PLAN.UPDATED</c> to
-/// <c>platform_events</c>.</para>
+/// service layer.</para>
+///
+/// <para>Story 34-1 — plans are <b>immutable, versioned</b> rows. Editing a
+/// plan never mutates an <c>active</c>/<c>deprecated</c> row in place; instead
+/// <c>PlanVersionEditor</c> inserts a new <see cref="Version"/> (with
+/// <see cref="SupersedesPlanId"/> pointing at the prior) and flips the prior to
+/// <c>deprecated</c>, emitting <c>PLAN.VERSION.CREATED</c> /
+/// <c>PLAN.DEPRECATED</c> to <c>platform_events</c>. A tenant assigned a
+/// specific version keeps that version's pricing/quotas forever. The legacy
+/// PATCH <c>/plan</c> path still emits <c>PLAN.UPDATED</c> for the assignment
+/// itself. Canonical pricing/quotas now live on the typed child rows
+/// (<see cref="Features"/> / <see cref="Entitlements"/> / <see cref="Prices"/>);
+/// <see cref="Quotas"/> + <see cref="MonthlyPriceUsd"/> are kept for one
+/// deprecation window so not-yet-migrated readers compile.</para>
 /// </summary>
 public class Plan
 {
@@ -22,12 +33,39 @@ public class Plan
     /// <summary>Display name shown in the billing UI.</summary>
     public string DisplayName { get; set; } = null!;
 
-    /// <summary>Monthly cost in USD. Zero for the free tier.</summary>
+    /// <summary>
+    /// Story 34-1 — monotonic version per <see cref="Slug"/>. A new version
+    /// supersedes rather than mutates the prior. <c>UNIQUE (Slug, Version)</c>.
+    /// </summary>
+    public int Version { get; set; } = 1;
+
+    /// <summary>
+    /// Story 34-1 — lifecycle: <c>draft</c> (mutable, not yet live) |
+    /// <c>active</c> (immutable, the current version assignable to tenants) |
+    /// <c>deprecated</c> (immutable, superseded but still referenced by
+    /// existing tenants). A partial unique index enforces exactly one
+    /// <c>active</c> row per slug.
+    /// </summary>
+    public string Status { get; set; } = "draft";
+
+    /// <summary>Story 34-1 — bespoke (per-customer) enterprise plan flag. Still a platform-owned row.</summary>
+    public bool IsCustom { get; set; }
+
+    /// <summary>Story 34-1 — billing cadence: <c>monthly</c> | <c>annual</c>.</summary>
+    public string BillingInterval { get; set; } = "monthly";
+
+    /// <summary>Story 34-1 — id of the prior version this row supersedes (NULL for v1).</summary>
+    public Guid? SupersedesPlanId { get; set; }
+
+    /// <summary>
+    /// Monthly cost in USD. Kept for one deprecation window (display
+    /// convenience); the canonical price now lives in <see cref="Prices"/>.
+    /// </summary>
     public decimal MonthlyPriceUsd { get; set; }
 
     /// <summary>
-    /// Per-tenant quotas (LLM tokens/month, concurrent workflows, seat
-    /// caps, etc.) — opaque JSON consumed by the billing layer.
+    /// Per-tenant quotas — opaque JSON. Legacy column kept for one deprecation
+    /// window; new code reads <see cref="Entitlements"/>.
     /// </summary>
     public string Quotas { get; set; } = "{}";
 
@@ -44,4 +82,13 @@ public class Plan
 
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
+
+    /// <summary>Story 34-1 — typed feature flags for this plan version.</summary>
+    public ICollection<PlanFeature> Features { get; set; } = new List<PlanFeature>();
+
+    /// <summary>Story 34-1 — typed quota entitlements for this plan version.</summary>
+    public ICollection<PlanEntitlement> Entitlements { get; set; } = new List<PlanEntitlement>();
+
+    /// <summary>Story 34-1 — pricing rows (one per <c>PricingMode</c>) for this plan version.</summary>
+    public ICollection<PlanPrice> Prices { get; set; } = new List<PlanPrice>();
 }

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/PlanEntitlement.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/PlanEntitlement.cs
@@ -1,0 +1,36 @@
+using Tamma.Core.Enums;
+
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 34-1 — one typed quota row per <see cref="EntitlementMetricKey"/> per
+/// <see cref="Plan"/> version. <see cref="LimitValue"/> = <c>NULL</c> means
+/// unlimited. <see cref="MetricKey"/> is persisted as the snake_case string
+/// via a value converter (never the ordinal) so metering / pricing /
+/// enforcement key off the same wire form. CP-resident; immutable once the
+/// owning plan version is active/deprecated.
+///
+/// <para>This story <b>stores</b> the limit; it does NOT enforce it — quota
+/// enforcement is a later Epic 34 story that reads
+/// <c>PlanSnapshot.Entitlements</c>.</para>
+/// </summary>
+public class PlanEntitlement
+{
+    /// <summary>Stable id (server default <c>gen_random_uuid()</c>).</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Owning plan version.</summary>
+    public Guid PlanId { get; set; }
+
+    /// <summary>Quota dimension — value-converted to snake_case text.</summary>
+    public EntitlementMetricKey MetricKey { get; set; }
+
+    /// <summary>The limit for this metric; <c>NULL</c> = unlimited.</summary>
+    public long? LimitValue { get; set; }
+
+    /// <summary>Reset window: <c>monthly</c> | <c>total</c>.</summary>
+    public string Period { get; set; } = "monthly";
+
+    /// <summary>Behaviour at the limit: <c>block</c> | <c>allow</c> | <c>meter</c>.</summary>
+    public string OverageMode { get; set; } = "block";
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/PlanFeature.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/PlanFeature.cs
@@ -1,0 +1,27 @@
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 34-1 — a single typed feature flag on a <see cref="Plan"/> version.
+/// Either a boolean capability flag (e.g. <c>byok_allowed = true</c>) or a
+/// string feature value (e.g. <c>support_tier = priority</c>). One row per
+/// <c>(PlanId, FeatureKey)</c>. CP-resident; immutable once its plan version
+/// is <c>active</c>/<c>deprecated</c> (the immutability guard lives in
+/// <c>PlanVersionEditor</c>).
+/// </summary>
+public class PlanFeature
+{
+    /// <summary>Stable id (server default <c>gen_random_uuid()</c>).</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Owning plan version.</summary>
+    public Guid PlanId { get; set; }
+
+    /// <summary>Feature key (e.g. <c>byok_allowed</c>, <c>support_tier</c>).</summary>
+    public string FeatureKey { get; set; } = null!;
+
+    /// <summary>Boolean value for capability flags; NULL when string-valued.</summary>
+    public bool? BoolValue { get; set; }
+
+    /// <summary>String value for non-boolean features; NULL when bool-valued.</summary>
+    public string? StringValue { get; set; }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/PlanPrice.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/PlanPrice.cs
@@ -1,0 +1,39 @@
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 34-1 — recurring + per-seat + metered pricing for a <see cref="Plan"/>
+/// version, split by <see cref="PricingMode"/> so BYOK tenants
+/// (bring-your-own AI keys) get a distinct price row from platform-provided
+/// tenants under the same plan version. One row per <c>(PlanId, PricingMode)</c>.
+///
+/// <para>This story stores pricing verbatim. It does NOT charge (Epic 35 owns
+/// Stripe), it does NOT compute cost→price markup (a separate Epic 34 story
+/// reads <see cref="MeteredComponent"/>), and it does NOT resolve which mode
+/// applies to a tenant (Story 34-3) — both rows are stored; the consumer
+/// picks.</para>
+/// </summary>
+public class PlanPrice
+{
+    /// <summary>Stable id (server default <c>gen_random_uuid()</c>).</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Owning plan version.</summary>
+    public Guid PlanId { get; set; }
+
+    /// <summary>Pricing mode: <c>platform_provided</c> | <c>byok</c>.</summary>
+    public string PricingMode { get; set; } = "platform_provided";
+
+    /// <summary>Flat recurring (per billing interval) charge in USD.</summary>
+    public decimal RecurringUsd { get; set; }
+
+    /// <summary>Per-seat charge in USD.</summary>
+    public decimal SeatUsd { get; set; }
+
+    /// <summary>
+    /// Metered / overage pricing components — opaque jsonb stored verbatim
+    /// (e.g. per-1k-token rates keyed by <c>EntitlementMetricKey</c>). The
+    /// markup engine (separate story) and billing (Epic 35) interpret it;
+    /// this story never computes it. Defaults to <c>'{}'</c>.
+    /// </summary>
+    public string MeteredComponent { get; set; } = "{}";
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260618181415_AddAgentEntities.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260618181415_AddAgentEntities.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.ControlPlane
 {
     [DbContext(typeof(ControlPlaneDbContext))]
-    partial class ControlPlaneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260618181415_AddAgentEntities")]
+    partial class AddAgentEntities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260618181415_AddAgentEntities.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260618181415_AddAgentEntities.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.ControlPlane
+{
+    /// <inheritdoc />
+    public partial class AddAgentEntities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "agents",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    Name = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    Role = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    Visibility = table.Column<int>(type: "integer", nullable: false),
+                    OwnerTenantId = table.Column<Guid>(type: "uuid", nullable: true),
+                    OwnerUserId = table.Column<Guid>(type: "uuid", nullable: true),
+                    Status = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    CurrentVersionId = table.Column<Guid>(type: "uuid", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    UpdatedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_agents", x => x.Id);
+                    table.CheckConstraint("ck_agents_visibility_ownership", "(\"Visibility\" = 0 AND \"OwnerTenantId\" IS NULL AND \"OwnerUserId\" IS NULL) OR (\"Visibility\" = 1 AND \"OwnerTenantId\" IS NOT NULL AND \"OwnerUserId\" IS NULL) OR (\"Visibility\" = 1 AND \"OwnerUserId\" IS NOT NULL AND \"OwnerTenantId\" IS NULL)");
+                });
+
+            migrationBuilder.CreateTable(
+                name: "agent_versions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    AgentId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Version = table.Column<int>(type: "integer", nullable: false),
+                    ConfigJson = table.Column<string>(type: "jsonb", nullable: false, defaultValueSql: "'{}'::jsonb"),
+                    Notes = table.Column<string>(type: "text", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_agent_versions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_agent_versions_agents_AgentId",
+                        column: x => x.AgentId,
+                        principalTable: "agents",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_agent_versions_agent_version",
+                table: "agent_versions",
+                columns: new[] { "AgentId", "Version" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_agents_private_tenant_name",
+                table: "agents",
+                columns: new[] { "OwnerTenantId", "Name" },
+                unique: true,
+                filter: "\"Visibility\" = 1 AND \"OwnerTenantId\" IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_agents_private_user_name",
+                table: "agents",
+                columns: new[] { "OwnerUserId", "Name" },
+                unique: true,
+                filter: "\"Visibility\" = 1 AND \"OwnerUserId\" IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_agents_public_name_role",
+                table: "agents",
+                columns: new[] { "Name", "Role" },
+                unique: true,
+                filter: "\"Visibility\" = 0");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "agent_versions");
+
+            migrationBuilder.DropTable(
+                name: "agents");
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260618192337_PlanPriceBookCatalog.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260618192337_PlanPriceBookCatalog.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.ControlPlane
 {
     [DbContext(typeof(ControlPlaneDbContext))]
-    partial class ControlPlaneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260618192337_PlanPriceBookCatalog")]
+    partial class PlanPriceBookCatalog
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260618192337_PlanPriceBookCatalog.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260618192337_PlanPriceBookCatalog.cs
@@ -1,0 +1,258 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.ControlPlane
+{
+    /// <inheritdoc />
+    public partial class PlanPriceBookCatalog : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_plans_Slug",
+                table: "plans");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "Id",
+                table: "plans",
+                type: "uuid",
+                nullable: false,
+                defaultValueSql: "gen_random_uuid()",
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+
+            migrationBuilder.AddColumn<string>(
+                name: "BillingInterval",
+                table: "plans",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: false,
+                defaultValue: "monthly");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsCustom",
+                table: "plans",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Status",
+                table: "plans",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: false,
+                defaultValue: "active");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "SupersedesPlanId",
+                table: "plans",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Version",
+                table: "plans",
+                type: "integer",
+                nullable: false,
+                defaultValue: 1);
+
+            migrationBuilder.CreateTable(
+                name: "plan_entitlements",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    PlanId = table.Column<Guid>(type: "uuid", nullable: false),
+                    MetricKey = table.Column<string>(type: "text", nullable: false),
+                    LimitValue = table.Column<long>(type: "bigint", nullable: true),
+                    Period = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false, defaultValue: "monthly"),
+                    OverageMode = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false, defaultValue: "block")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_plan_entitlements", x => x.Id);
+                    table.CheckConstraint("ck_plan_entitlements_overage", "\"OverageMode\" IN ('block','allow','meter')");
+                    table.CheckConstraint("ck_plan_entitlements_period", "\"Period\" IN ('monthly','total')");
+                    table.ForeignKey(
+                        name: "FK_plan_entitlements_plans_PlanId",
+                        column: x => x.PlanId,
+                        principalTable: "plans",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "plan_features",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    PlanId = table.Column<Guid>(type: "uuid", nullable: false),
+                    FeatureKey = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    BoolValue = table.Column<bool>(type: "boolean", nullable: true),
+                    StringValue = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_plan_features", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_plan_features_plans_PlanId",
+                        column: x => x.PlanId,
+                        principalTable: "plans",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "plan_prices",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    PlanId = table.Column<Guid>(type: "uuid", nullable: false),
+                    PricingMode = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false, defaultValue: "platform_provided"),
+                    RecurringUsd = table.Column<decimal>(type: "numeric(20,4)", precision: 20, scale: 4, nullable: false),
+                    SeatUsd = table.Column<decimal>(type: "numeric(20,4)", precision: 20, scale: 4, nullable: false),
+                    MeteredComponent = table.Column<string>(type: "jsonb", nullable: false, defaultValueSql: "'{}'::jsonb")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_plan_prices", x => x.Id);
+                    table.CheckConstraint("ck_plan_prices_mode", "\"PricingMode\" IN ('platform_provided','byok')");
+                    table.ForeignKey(
+                        name: "FK_plan_prices_plans_PlanId",
+                        column: x => x.PlanId,
+                        principalTable: "plans",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_plans_SupersedesPlanId",
+                table: "plans",
+                column: "SupersedesPlanId");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_plans_OneActivePerSlug",
+                table: "plans",
+                column: "Slug",
+                unique: true,
+                filter: "\"Status\" = 'active'");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_plans_Slug_Version",
+                table: "plans",
+                columns: new[] { "Slug", "Version" },
+                unique: true);
+
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_plans_billing_interval",
+                table: "plans",
+                sql: "\"BillingInterval\" IN ('monthly','annual')");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_plans_status",
+                table: "plans",
+                sql: "\"Status\" IN ('active','deprecated','draft')");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_plan_entitlements_PlanId_MetricKey",
+                table: "plan_entitlements",
+                columns: new[] { "PlanId", "MetricKey" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "UX_plan_features_PlanId_FeatureKey",
+                table: "plan_features",
+                columns: new[] { "PlanId", "FeatureKey" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "UX_plan_prices_PlanId_PricingMode",
+                table: "plan_prices",
+                columns: new[] { "PlanId", "PricingMode" },
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_plans_plans_SupersedesPlanId",
+                table: "plans",
+                column: "SupersedesPlanId",
+                principalTable: "plans",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_plans_plans_SupersedesPlanId",
+                table: "plans");
+
+            migrationBuilder.DropTable(
+                name: "plan_entitlements");
+
+            migrationBuilder.DropTable(
+                name: "plan_features");
+
+            migrationBuilder.DropTable(
+                name: "plan_prices");
+
+            migrationBuilder.DropIndex(
+                name: "IX_plans_SupersedesPlanId",
+                table: "plans");
+
+            migrationBuilder.DropIndex(
+                name: "UX_plans_OneActivePerSlug",
+                table: "plans");
+
+            migrationBuilder.DropIndex(
+                name: "UX_plans_Slug_Version",
+                table: "plans");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_plans_billing_interval",
+                table: "plans");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_plans_status",
+                table: "plans");
+
+            migrationBuilder.DropColumn(
+                name: "BillingInterval",
+                table: "plans");
+
+            migrationBuilder.DropColumn(
+                name: "IsCustom",
+                table: "plans");
+
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "plans");
+
+            migrationBuilder.DropColumn(
+                name: "SupersedesPlanId",
+                table: "plans");
+
+            migrationBuilder.DropColumn(
+                name: "Version",
+                table: "plans");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "Id",
+                table: "plans",
+                type: "uuid",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldDefaultValueSql: "gen_random_uuid()");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_plans_Slug",
+                table: "plans",
+                column: "Slug",
+                unique: true);
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260618212532_AddBillingCustomerAndPlanPrices.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260618212532_AddBillingCustomerAndPlanPrices.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.ControlPlane
 {
     [DbContext(typeof(ControlPlaneDbContext))]
-    partial class ControlPlaneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260618212532_AddBillingCustomerAndPlanPrices")]
+    partial class AddBillingCustomerAndPlanPrices
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260618212532_AddBillingCustomerAndPlanPrices.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260618212532_AddBillingCustomerAndPlanPrices.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.ControlPlane
+{
+    /// <inheritdoc />
+    public partial class AddBillingCustomerAndPlanPrices : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "billing_customers",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    StripeCustomerId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    BillingMode = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false, defaultValue: "PlatformProvided"),
+                    DefaultCurrency = table.Column<string>(type: "character varying(3)", maxLength: 3, nullable: false, defaultValue: "usd"),
+                    TaxStatus = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false, defaultValue: "none"),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_billing_customers", x => x.Id);
+                    table.CheckConstraint("ck_billing_customers_mode", "\"BillingMode\" IN ('PlatformProvided','Byok')");
+                    table.ForeignKey(
+                        name: "FK_billing_customers_tenants_TenantId",
+                        column: x => x.TenantId,
+                        principalTable: "tenants",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "billing_plan_prices",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    PlanSlug = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    StripeProductId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    StripePriceId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    TokensInputMeterId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    TokensInputPriceId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    TokensOutputMeterId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    TokensOutputPriceId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    SeatsMeterId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    SeatsPriceId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_billing_plan_prices", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "UX_billing_customers_StripeCustomerId",
+                table: "billing_customers",
+                column: "StripeCustomerId",
+                unique: true,
+                filter: "\"StripeCustomerId\" IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_billing_customers_TenantId",
+                table: "billing_customers",
+                column: "TenantId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "UX_billing_plan_prices_PlanSlug",
+                table: "billing_plan_prices",
+                column: "PlanSlug",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "billing_customers");
+
+            migrationBuilder.DropTable(
+                name: "billing_plan_prices");
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260619003618_AddAuditRecords.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260619003618_AddAuditRecords.Designer.cs
@@ -609,6 +609,9 @@ namespace Tamma.Data.Migrations.ControlPlane
                         .HasMaxLength(64)
                         .HasColumnType("character varying(64)");
 
+                    b.Property<Guid>("TenantId")
+                        .HasColumnType("uuid");
+
                     b.Property<long>("LastDomainSequenceNumber")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint")
@@ -624,7 +627,7 @@ namespace Tamma.Data.Migrations.ControlPlane
                         .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("now()");
 
-                    b.HasKey("ProjectorId");
+                    b.HasKey("ProjectorId", "TenantId");
 
                     b.ToTable("audit_projector_cursor", (string)null);
                 });

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260619003618_AddAuditRecords.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260619003618_AddAuditRecords.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.ControlPlane
 {
     [DbContext(typeof(ControlPlaneDbContext))]
-    partial class ControlPlaneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260619003618_AddAuditRecords")]
+    partial class AddAuditRecords
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260619003618_AddAuditRecords.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260619003618_AddAuditRecords.cs
@@ -16,13 +16,14 @@ namespace Tamma.Data.Migrations.ControlPlane
                 columns: table => new
                 {
                     ProjectorId = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
                     LastDomainSequenceNumber = table.Column<long>(type: "bigint", nullable: false, defaultValue: 0L),
                     LastPlatformSequenceNumber = table.Column<long>(type: "bigint", nullable: false, defaultValue: 0L),
                     UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()")
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_audit_projector_cursor", x => x.ProjectorId);
+                    table.PrimaryKey("PK_audit_projector_cursor", x => new { x.ProjectorId, x.TenantId });
                 });
 
             migrationBuilder.CreateTable(

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260619003618_AddAuditRecords.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260619003618_AddAuditRecords.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.ControlPlane
+{
+    /// <inheritdoc />
+    public partial class AddAuditRecords : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "audit_projector_cursor",
+                columns: table => new
+                {
+                    ProjectorId = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    LastDomainSequenceNumber = table.Column<long>(type: "bigint", nullable: false, defaultValue: 0L),
+                    LastPlatformSequenceNumber = table.Column<long>(type: "bigint", nullable: false, defaultValue: 0L),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_audit_projector_cursor", x => x.ProjectorId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "audit_records",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    ActionCode = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    Category = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    Severity = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    ActorUserId = table.Column<Guid>(type: "uuid", nullable: true),
+                    ActorEmailSnapshot = table.Column<string>(type: "character varying(320)", maxLength: 320, nullable: true),
+                    TargetType = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    TargetId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    Outcome = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false, defaultValue: "success"),
+                    IpAddress = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    UserAgent = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    OccurredAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    SourceEventId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SourceSequenceNumber = table.Column<long>(type: "bigint", nullable: false),
+                    PayloadJson = table.Column<string>(type: "jsonb", nullable: false, defaultValueSql: "'{}'::jsonb"),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: true),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: true),
+                    RecordHash = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    PrevRecordHash = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_audit_records", x => x.Id);
+                    table.CheckConstraint("ck_audit_records_outcome", "\"Outcome\" IN ('success','failure','denied')");
+                    table.CheckConstraint("ck_audit_records_principal_xor", "NOT (\"UserId\" IS NOT NULL AND \"TenantId\" IS NOT NULL)");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_audit_records_Category_OccurredAt",
+                table: "audit_records",
+                columns: new[] { "Category", "OccurredAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_audit_records_SourceSequenceNumber",
+                table: "audit_records",
+                column: "SourceSequenceNumber");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_audit_records_TenantId_OccurredAt",
+                table: "audit_records",
+                columns: new[] { "TenantId", "OccurredAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_audit_records_UserId_OccurredAt",
+                table: "audit_records",
+                columns: new[] { "UserId", "OccurredAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "UX_audit_records_SourceEventId",
+                table: "audit_records",
+                column: "SourceEventId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "audit_projector_cursor");
+
+            migrationBuilder.DropTable(
+                name: "audit_records");
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/ControlPlaneDbContextModelSnapshot.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/ControlPlaneDbContextModelSnapshot.cs
@@ -606,6 +606,9 @@ namespace Tamma.Data.Migrations.ControlPlane
                         .HasMaxLength(64)
                         .HasColumnType("character varying(64)");
 
+                    b.Property<Guid>("TenantId")
+                        .HasColumnType("uuid");
+
                     b.Property<long>("LastDomainSequenceNumber")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint")
@@ -621,7 +624,7 @@ namespace Tamma.Data.Migrations.ControlPlane
                         .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("now()");
 
-                    b.HasKey("ProjectorId");
+                    b.HasKey("ProjectorId", "TenantId");
 
                     b.ToTable("audit_projector_cursor", (string)null);
                 });

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260618232930_AddAnalyticsUsageFactTables.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260618232930_AddAnalyticsUsageFactTables.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.Tenant
 {
     [DbContext(typeof(TenantDbContext))]
-    partial class TenantDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260618232930_AddAnalyticsUsageFactTables")]
+    partial class AddAnalyticsUsageFactTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260618232930_AddAnalyticsUsageFactTables.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260618232930_AddAnalyticsUsageFactTables.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.Tenant
+{
+    /// <inheritdoc />
+    public partial class AddAnalyticsUsageFactTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "analytics_usage_daily",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    Day = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Provider = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    AgentId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    WorkflowDefinitionId = table.Column<Guid>(type: "uuid", nullable: true),
+                    RepoId = table.Column<string>(type: "character varying(400)", maxLength: 400, nullable: true),
+                    CostBasis = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    TokensIn = table.Column<long>(type: "bigint", nullable: false, defaultValue: 0L),
+                    TokensOut = table.Column<long>(type: "bigint", nullable: false, defaultValue: 0L),
+                    CostUsd = table.Column<decimal>(type: "numeric(20,4)", precision: 20, scale: 4, nullable: false, defaultValue: 0m),
+                    PlatformBilledUsd = table.Column<decimal>(type: "numeric(20,4)", precision: 20, scale: 4, nullable: false, defaultValue: 0m),
+                    WorkflowsStarted = table.Column<long>(type: "bigint", nullable: false, defaultValue: 0L),
+                    WorkflowsCompleted = table.Column<long>(type: "bigint", nullable: false, defaultValue: 0L),
+                    WorkflowsFailed = table.Column<long>(type: "bigint", nullable: false, defaultValue: 0L),
+                    AgentDispatches = table.Column<long>(type: "bigint", nullable: false, defaultValue: 0L),
+                    ComputedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_analytics_usage_daily", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "analytics_usage_hourly",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    Hour = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Provider = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    AgentId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    WorkflowDefinitionId = table.Column<Guid>(type: "uuid", nullable: true),
+                    RepoId = table.Column<string>(type: "character varying(400)", maxLength: 400, nullable: true),
+                    CostBasis = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    TokensIn = table.Column<long>(type: "bigint", nullable: false, defaultValue: 0L),
+                    TokensOut = table.Column<long>(type: "bigint", nullable: false, defaultValue: 0L),
+                    CostUsd = table.Column<decimal>(type: "numeric(20,4)", precision: 20, scale: 4, nullable: false, defaultValue: 0m),
+                    PlatformBilledUsd = table.Column<decimal>(type: "numeric(20,4)", precision: 20, scale: 4, nullable: false, defaultValue: 0m),
+                    WorkflowsStarted = table.Column<long>(type: "bigint", nullable: false, defaultValue: 0L),
+                    WorkflowsCompleted = table.Column<long>(type: "bigint", nullable: false, defaultValue: 0L),
+                    WorkflowsFailed = table.Column<long>(type: "bigint", nullable: false, defaultValue: 0L),
+                    AgentDispatches = table.Column<long>(type: "bigint", nullable: false, defaultValue: 0L),
+                    ComputedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_analytics_usage_hourly", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_analytics_usage_daily_breakdown",
+                table: "analytics_usage_daily",
+                columns: new[] { "Day", "Provider", "AgentId", "WorkflowDefinitionId", "CostBasis" });
+
+            migrationBuilder.CreateIndex(
+                name: "UX_analytics_usage_daily_dims",
+                table: "analytics_usage_daily",
+                columns: new[] { "Day", "Provider", "AgentId", "WorkflowDefinitionId", "RepoId", "CostBasis" },
+                unique: true)
+                .Annotation("Npgsql:NullsDistinct", false);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_analytics_usage_hourly_breakdown",
+                table: "analytics_usage_hourly",
+                columns: new[] { "Hour", "Provider", "AgentId", "WorkflowDefinitionId", "CostBasis" });
+
+            migrationBuilder.CreateIndex(
+                name: "UX_analytics_usage_hourly_dims",
+                table: "analytics_usage_hourly",
+                columns: new[] { "Hour", "Provider", "AgentId", "WorkflowDefinitionId", "RepoId", "CostBasis" },
+                unique: true)
+                .Annotation("Npgsql:NullsDistinct", false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "analytics_usage_daily");
+
+            migrationBuilder.DropTable(
+                name: "analytics_usage_hourly");
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260619003624_AddAuditRecords.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260619003624_AddAuditRecords.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.Tenant
 {
     [DbContext(typeof(TenantDbContext))]
-    partial class TenantDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260619003624_AddAuditRecords")]
+    partial class AddAuditRecords
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260619003624_AddAuditRecords.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260619003624_AddAuditRecords.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.Tenant
+{
+    /// <inheritdoc />
+    public partial class AddAuditRecords : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "audit_records",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    ActionCode = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    Category = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    Severity = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    ActorUserId = table.Column<Guid>(type: "uuid", nullable: true),
+                    ActorEmailSnapshot = table.Column<string>(type: "character varying(320)", maxLength: 320, nullable: true),
+                    TargetType = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    TargetId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    Outcome = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false, defaultValue: "success"),
+                    IpAddress = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    UserAgent = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    OccurredAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    SourceEventId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SourceSequenceNumber = table.Column<long>(type: "bigint", nullable: false),
+                    PayloadJson = table.Column<string>(type: "jsonb", nullable: false, defaultValueSql: "'{}'::jsonb"),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: true),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: true),
+                    RecordHash = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    PrevRecordHash = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_audit_records", x => x.Id);
+                    table.CheckConstraint("ck_audit_records_outcome", "\"Outcome\" IN ('success','failure','denied')");
+                    table.CheckConstraint("ck_audit_records_principal_xor", "NOT (\"UserId\" IS NOT NULL AND \"TenantId\" IS NOT NULL)");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_audit_records_Category_OccurredAt",
+                table: "audit_records",
+                columns: new[] { "Category", "OccurredAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_audit_records_SourceSequenceNumber",
+                table: "audit_records",
+                column: "SourceSequenceNumber");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_audit_records_TenantId_OccurredAt",
+                table: "audit_records",
+                columns: new[] { "TenantId", "OccurredAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_audit_records_UserId_OccurredAt",
+                table: "audit_records",
+                columns: new[] { "UserId", "OccurredAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "UX_audit_records_SourceEventId",
+                table: "audit_records",
+                column: "SourceEventId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "audit_records");
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Pooling/TenantConnectionPoolServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Pooling/TenantConnectionPoolServiceCollectionExtensions.cs
@@ -120,6 +120,10 @@ public static class TenantConnectionPoolServiceCollectionExtensions
                     // Must match ControlPlaneDesignTimeDbContextFactory and DependencyInjection.cs
                     // (unified-tenancy Phase 0 reconciliation).
                     npgsql.MigrationsHistoryTable("__ControlPlaneMigrationsHistory"));
+                // Story 35-1 follow-up — suppress the required-navigation/query-filter
+                // advisory on the POOLED options too. Must be on the options builder,
+                // never OnConfiguring (EF forbids OnConfiguring when pooling is on).
+                ControlPlaneDbContext.ConfigureControlPlaneWarnings(opts);
             });
         }
 

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/AgentRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/AgentRepository.cs
@@ -275,7 +275,11 @@ public sealed class AgentRepository : IAgentRepository
         string type, Agent agent, int? version, CancellationToken ct)
     {
         _ = ct;
-        var mode = agent.OwnerUserId is not null ? "single-user" : "saas";
+        // Public agents are platform-owned (both owner columns NULL) — tag them
+        // "platform", not "saas". Private agents: OwnerUserId → single-user, else SaaS.
+        var mode = agent.Visibility == AgentVisibility.Public
+            ? "platform"
+            : (agent.OwnerUserId is not null ? "single-user" : "saas");
 
         var tags = new Dictionary<string, object?>
         {

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/AgentRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/AgentRepository.cs
@@ -1,0 +1,313 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Tamma.Core;
+using Tamma.Data.Entities;
+
+namespace Tamma.Data.Repositories;
+
+/// <summary>
+/// Story 32-1 — CP-resident agent repository. Owns the agent identity +
+/// versioning lifecycle (<see cref="Agent"/> / <see cref="AgentVersion"/>) and
+/// emits the Epic 32 DCB audit events. Resolves against
+/// <see cref="ControlPlaneDbContext"/>; DCB events are appended via
+/// <see cref="IEventRepository"/> only after a real state transition.
+///
+/// <para>Event routing follows the design: <c>DomainEvent.TenantId =
+/// OwnerTenantId</c> for private/SaaS agents (lands in the tenant store) and
+/// NULL for public/system agents (lands in <c>platform_events</c>) — the
+/// <see cref="IEventRepository"/> handles the split.</para>
+///
+/// <para>Never logs raw <see cref="AgentVersion.ConfigJson"/> — configs are
+/// credential-agnostic by design but a <c>systemPromptRef</c> could resolve to
+/// sensitive content, so only field-level diagnostics are logged.</para>
+/// </summary>
+public sealed class AgentRepository : IAgentRepository
+{
+    private const string WorkflowVersion = "1.0.0";
+
+    /// <summary>Bounded retry budget for the concurrent-publish race.</summary>
+    private const int MaxPublishRetries = 5;
+
+    private readonly ControlPlaneDbContext _db;
+    private readonly IEventRepository _events;
+    private readonly ILogger<AgentRepository>? _logger;
+
+    public AgentRepository(
+        ControlPlaneDbContext db,
+        IEventRepository events,
+        ILogger<AgentRepository>? logger = null)
+    {
+        _db = db;
+        _events = events;
+        _logger = logger;
+    }
+
+    public async Task<Agent> CreateAsync(
+        Agent agent,
+        string firstVersionConfigJson,
+        string? notes,
+        Guid? createdBy,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(agent);
+
+        // Entity-level ownership guard (fail-fast before the DB CHECK). Mirrors
+        // CLAUDE.md "Universal rule for any tenant-aware feature": public ⇒ no
+        // owner; private ⇒ exactly one owner column. The endpoint layer derives
+        // WHICH owner column from the process mode; here we enforce the XOR.
+        AssertOwnershipInvariant(agent);
+
+        if (string.IsNullOrWhiteSpace(firstVersionConfigJson))
+        {
+            throw new TammaError(
+                "AGENT.CREATE.EMPTY_CONFIG",
+                "First version config must not be empty.",
+                severity: TammaErrorSeverity.Medium);
+        }
+
+        var now = DateTime.UtcNow;
+        agent.Id = agent.Id == Guid.Empty ? Guid.NewGuid() : agent.Id;
+        agent.Status = AgentStatus.Active;
+        agent.CreatedAt = now;
+        agent.CreatedBy = createdBy;
+        agent.UpdatedAt = now;
+        agent.UpdatedBy = createdBy;
+
+        var version = new AgentVersion
+        {
+            Id = Guid.NewGuid(),
+            AgentId = agent.Id,
+            Version = 1,
+            ConfigJson = firstVersionConfigJson,
+            Notes = notes,
+            CreatedAt = now,
+            CreatedBy = createdBy,
+        };
+        agent.CurrentVersionId = version.Id;
+
+        await using var tx = await _db.Database.BeginTransactionAsync(ct);
+        _db.Agents.Add(agent);
+        _db.AgentVersions.Add(version);
+        await _db.SaveChangesAsync(ct);
+        await tx.CommitAsync(ct);
+
+        _logger?.LogInformation(
+            "agent.created agentId={AgentId} name={Name} role={Role} visibility={Visibility} version=1",
+            agent.Id, agent.Name, agent.Role, agent.Visibility);
+
+        await AppendAgentEventAsync(
+            "AGENT.CREATED.SUCCESS", agent, version.Version, ct);
+
+        return agent;
+    }
+
+    public async Task<AgentVersion?> PublishVersionAsync(
+        Guid agentId,
+        string configJson,
+        string? notes,
+        Guid? updatedBy,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(configJson))
+        {
+            throw new TammaError(
+                "AGENT.PUBLISH.EMPTY_CONFIG",
+                "Published config must not be empty.",
+                severity: TammaErrorSeverity.Medium);
+        }
+
+        var agent = await _db.Agents.FirstOrDefaultAsync(a => a.Id == agentId, ct);
+        if (agent is null)
+        {
+            return null;
+        }
+
+        for (var attempt = 1; ; attempt++)
+        {
+            var nextVersion = await NextVersionAsync(agentId, ct);
+            var version = new AgentVersion
+            {
+                Id = Guid.NewGuid(),
+                AgentId = agentId,
+                Version = nextVersion,
+                ConfigJson = configJson,
+                Notes = notes,
+                CreatedAt = DateTime.UtcNow,
+                CreatedBy = updatedBy,
+            };
+
+            try
+            {
+                await using var tx = await _db.Database.BeginTransactionAsync(ct);
+                _db.AgentVersions.Add(version);
+                agent.CurrentVersionId = version.Id;
+                agent.UpdatedAt = DateTime.UtcNow;
+                agent.UpdatedBy = updatedBy;
+                await _db.SaveChangesAsync(ct);
+                await tx.CommitAsync(ct);
+
+                _logger?.LogInformation(
+                    "agent.version_published agentId={AgentId} version={Version}",
+                    agentId, version.Version);
+
+                await AppendAgentEventAsync(
+                    "AGENT.VERSION_PUBLISHED.SUCCESS", agent, version.Version, ct);
+
+                return version;
+            }
+            catch (DbUpdateException ex) when (IsUniqueViolation(ex) && attempt < MaxPublishRetries)
+            {
+                // Concurrent double-publish: another writer took (AgentId,
+                // nextVersion). Detach the failed insert, recompute max+1, retry.
+                _db.Entry(version).State = EntityState.Detached;
+                _db.Entry(agent).State = EntityState.Unchanged;
+                _logger?.LogWarning(
+                    "agent.version_published.retry agentId={AgentId} attempt={Attempt} contendedVersion={Version}",
+                    agentId, attempt, nextVersion);
+            }
+        }
+    }
+
+    public async Task<Agent?> ArchiveAsync(
+        Guid agentId, Guid? updatedBy, CancellationToken ct = default)
+    {
+        var agent = await _db.Agents.FirstOrDefaultAsync(a => a.Id == agentId, ct);
+        if (agent is null)
+        {
+            return null;
+        }
+
+        // Idempotent — archiving an already-archived agent is a no-op with no
+        // second AGENT.ARCHIVED.SUCCESS (events only on real transitions).
+        if (agent.Status == AgentStatus.Archived)
+        {
+            return agent;
+        }
+
+        agent.Status = AgentStatus.Archived;
+        agent.UpdatedAt = DateTime.UtcNow;
+        agent.UpdatedBy = updatedBy;
+        await _db.SaveChangesAsync(ct);
+
+        _logger?.LogInformation(
+            "agent.archived agentId={AgentId} visibility={Visibility} role={Role}",
+            agent.Id, agent.Visibility, agent.Role);
+
+        await AppendAgentEventAsync("AGENT.ARCHIVED.SUCCESS", agent, version: null, ct);
+        return agent;
+    }
+
+    public Task<Agent?> GetByIdAsync(Guid agentId, CancellationToken ct = default)
+        => _db.Agents.FirstOrDefaultAsync(a => a.Id == agentId, ct);
+
+    public Task<AgentVersion?> GetVersionAsync(
+        Guid agentId, int version, CancellationToken ct = default)
+        => _db.AgentVersions
+            .FirstOrDefaultAsync(v => v.AgentId == agentId && v.Version == version, ct);
+
+    public async Task<IReadOnlyList<AgentVersion>> ListVersionsAsync(
+        Guid agentId, CancellationToken ct = default)
+        => await _db.AgentVersions
+            .Where(v => v.AgentId == agentId)
+            .OrderBy(v => v.Version)
+            .ToListAsync(ct);
+
+    public async Task<IReadOnlyList<Agent>> ListVisibleAsync(
+        Guid? tenantId, Guid? userId, CancellationToken ct = default)
+    {
+        var query = _db.Agents.Where(a =>
+            a.Visibility == AgentVisibility.Public ||
+            (a.Visibility == AgentVisibility.Private &&
+                ((tenantId != null && a.OwnerTenantId == tenantId) ||
+                 (userId != null && a.OwnerUserId == userId))));
+
+        var result = await query.OrderBy(a => a.Name).ToListAsync(ct);
+
+        _logger?.LogDebug(
+            "agent.list_visible count={Count} tenantId={TenantId} userId={UserId}",
+            result.Count, tenantId, userId);
+
+        return result;
+    }
+
+    // ── helpers ──
+
+    private async Task<int> NextVersionAsync(Guid agentId, CancellationToken ct)
+    {
+        var max = await _db.AgentVersions
+            .Where(v => v.AgentId == agentId)
+            .Select(v => (int?)v.Version)
+            .MaxAsync(ct);
+        return (max ?? 0) + 1;
+    }
+
+    private static void AssertOwnershipInvariant(Agent agent)
+    {
+        var hasTenant = agent.OwnerTenantId is not null;
+        var hasUser = agent.OwnerUserId is not null;
+
+        switch (agent.Visibility)
+        {
+            case AgentVisibility.Public when hasTenant || hasUser:
+                throw new TammaError(
+                    "AGENT.OWNERSHIP.PUBLIC_WITH_OWNER",
+                    "A public agent must not have an owner (tenant or user).",
+                    new Dictionary<string, object?> { ["agentName"] = agent.Name },
+                    severity: TammaErrorSeverity.High);
+            case AgentVisibility.Private when hasTenant == hasUser:
+                // both set OR both null
+                throw new TammaError(
+                    "AGENT.OWNERSHIP.PRIVATE_PRINCIPAL",
+                    "A private agent must have exactly one owner — OwnerTenantId "
+                    + "(SaaS) XOR OwnerUserId (single-user).",
+                    new Dictionary<string, object?> { ["agentName"] = agent.Name },
+                    severity: TammaErrorSeverity.High);
+        }
+    }
+
+    /// <summary>
+    /// Append an Epic 32 agent DCB event. <c>TenantId = OwnerTenantId</c> for
+    /// private/SaaS agents (tenant store), NULL for public agents
+    /// (<c>platform_events</c>). Tags carry the agent shape per the design.
+    /// </summary>
+    private async Task AppendAgentEventAsync(
+        string type, Agent agent, int? version, CancellationToken ct)
+    {
+        _ = ct;
+        var mode = agent.OwnerUserId is not null ? "single-user" : "saas";
+
+        var tags = new Dictionary<string, object?>
+        {
+            ["agentId"] = agent.Id.ToString(),
+            ["visibility"] = agent.Visibility == AgentVisibility.Public ? "public" : "private",
+            ["role"] = agent.Role,
+            ["mode"] = mode,
+        };
+        if (version is int v) tags["version"] = v;
+        if (agent.OwnerTenantId is Guid otid) tags["ownerTenantId"] = otid.ToString();
+        if (agent.OwnerUserId is Guid ouid) tags["ownerUserId"] = ouid.ToString();
+
+        await _events.AppendAsync(new DomainEvent
+        {
+            Id = Guid.NewGuid(),
+            Type = type,
+            // Public agents → null tenant (platform feed); private → owner tenant.
+            TenantId = agent.OwnerTenantId,
+            Tags = JsonSerializer.Serialize(tags),
+            Metadata = JsonSerializer.Serialize(new
+            {
+                workflowVersion = WorkflowVersion,
+                eventSource = "system",
+            }),
+            Data = JsonSerializer.Serialize(version is int dv
+                ? new Dictionary<string, object?> { ["version"] = dv }
+                : new Dictionary<string, object?>()),
+            CreatedAt = DateTime.UtcNow,
+        });
+    }
+
+    private static bool IsUniqueViolation(DbUpdateException ex)
+        => ex.InnerException is Npgsql.PostgresException pg &&
+           pg.SqlState == Npgsql.PostgresErrorCodes.UniqueViolation;
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/IAgentRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/IAgentRepository.cs
@@ -1,0 +1,68 @@
+using Tamma.Data.Entities;
+
+namespace Tamma.Data.Repositories;
+
+/// <summary>
+/// Story 32-1 — persistence port for the CP-resident <see cref="Agent"/> /
+/// <see cref="AgentVersion"/> entities. The canonical owner of the agent
+/// identity + versioning lifecycle the rest of Epic 32 joins on.
+///
+/// <para>Resolves against <see cref="ControlPlaneDbContext"/> (definitions are
+/// control-plane-resident). DCB events are appended via
+/// <see cref="IEventRepository"/> only after a real state transition.</para>
+/// </summary>
+public interface IAgentRepository
+{
+    /// <summary>
+    /// Create a new agent + its <c>Version=1</c> immutable snapshot in a single
+    /// transaction, set <see cref="Agent.CurrentVersionId"/>, and append
+    /// <c>AGENT.CREATED.SUCCESS</c>. The entity-level ownership guard rejects a
+    /// private create whose principal columns contradict the process mode
+    /// (belt to the DB CHECK's suspenders).
+    /// </summary>
+    Task<Agent> CreateAsync(
+        Agent agent,
+        string firstVersionConfigJson,
+        string? notes,
+        Guid? createdBy,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Publish a new immutable version: insert <c>Version = max(existing)+1</c>,
+    /// atomically repoint <see cref="Agent.CurrentVersionId"/> +
+    /// <c>UpdatedAt/By</c>, append <c>AGENT.VERSION_PUBLISHED.SUCCESS</c>.
+    /// Concurrent double-publish is safe — the second INSERT loses the
+    /// <c>(AgentId, Version)</c> unique index and is retried with a fresh
+    /// <c>max+1</c>. Prior versions stay queryable for rollback. Returns
+    /// <c>null</c> if the agent does not exist.
+    /// </summary>
+    Task<AgentVersion?> PublishVersionAsync(
+        Guid agentId,
+        string configJson,
+        string? notes,
+        Guid? updatedBy,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Set <see cref="Agent.Status"/> to <see cref="AgentStatus.Archived"/> and
+    /// append <c>AGENT.ARCHIVED.SUCCESS</c>. Idempotent — archiving an
+    /// already-archived agent is a no-op with no second event. Returns
+    /// <c>null</c> if the agent does not exist.
+    /// </summary>
+    Task<Agent?> ArchiveAsync(Guid agentId, Guid? updatedBy, CancellationToken ct = default);
+
+    Task<Agent?> GetByIdAsync(Guid agentId, CancellationToken ct = default);
+
+    Task<AgentVersion?> GetVersionAsync(Guid agentId, int version, CancellationToken ct = default);
+
+    Task<IReadOnlyList<AgentVersion>> ListVersionsAsync(Guid agentId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Visibility-scoped list: all public agents ∪ the caller's own private
+    /// agents. In SaaS mode the principal is <paramref name="tenantId"/>; in
+    /// single-user mode it is <paramref name="userId"/>. A null principal sees
+    /// public agents only.
+    /// </summary>
+    Task<IReadOnlyList<Agent>> ListVisibleAsync(
+        Guid? tenantId, Guid? userId, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Seeders/AgentEntitySeeder.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Seeders/AgentEntitySeeder.cs
@@ -64,12 +64,16 @@ public static class AgentEntitySeeder
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        // Existing public handles for this seed set — skip those.
+        // Existing public (Name, Role) pairs for this seed set — skip those. The
+        // key must match the partial unique index on (Name, Role) so the
+        // idempotency check and the DB constraint can't diverge.
         var existing = await context.Agents
             .Where(a => a.Visibility == AgentVisibility.Public)
-            .Select(a => a.Name)
+            .Select(a => new { a.Name, a.Role })
             .ToListAsync(cancellationToken);
-        var existingSet = existing.ToHashSet(StringComparer.Ordinal);
+        var existingSet = existing
+            .Select(a => (a.Name, a.Role))
+            .ToHashSet();
 
         var now = DateTime.UtcNow;
         var inserted = 0;
@@ -77,7 +81,7 @@ public static class AgentEntitySeeder
         foreach (var seed in s_seedAgents)
         {
             var handle = $"tamma-{seed.Role}";
-            if (existingSet.Contains(handle))
+            if (existingSet.Contains((handle, seed.Role)))
             {
                 continue;
             }

--- a/apps/tamma-elsa/src/Tamma.Data/Seeders/AgentEntitySeeder.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Seeders/AgentEntitySeeder.cs
@@ -1,0 +1,144 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Tamma.Data.Entities;
+
+namespace Tamma.Data.Seeders;
+
+/// <summary>
+/// Story 32-1 — idempotently seeds the CP-resident <c>agents</c> /
+/// <c>agent_versions</c> tables with one <b>public</b> agent per canonical
+/// <c>AgentRole</c>, using the <c>tamma-&lt;role&gt;</c> handle and the shipped
+/// config values (provider chain / temperature / maxTokens / maxBudgetUsd)
+/// currently produced by <c>Tamma.ElsaServer/AgentSeeder.cs</c>. This is the
+/// source of truth for Epic 32; it coexists with the Elsa-store seeder (which
+/// populates Elsa's own <c>IAgentManager</c> store) until that is retired in a
+/// later story.
+///
+/// <para>Insert-missing-only (mirrors <see cref="PlansSeeder"/> /
+/// ConventionStoreSeeder): each agent is skipped if a public agent with the
+/// same <c>(Name, Role)</c> already exists, so re-running on every startup is a
+/// no-op. Owner columns are NULL (public). The seeder does NOT emit DCB events
+/// — seeding system defaults is not a user-driven state transition (consistent
+/// with PlansSeeder); the AGENT.CREATED.SUCCESS event family is reserved for
+/// real create/publish operations via the repository/API.</para>
+/// </summary>
+public static class AgentEntitySeeder
+{
+    /// <summary>
+    /// The shipped public-agent catalogue. Keyed by canonical
+    /// <c>AgentRole</c> wire string; values mirror the legacy
+    /// <c>AgentSeeder.GetDefaultAgents()</c> config. All share the default
+    /// provider chain + budget; temperature varies per role.
+    /// </summary>
+    private static readonly IReadOnlyList<SeedAgent> s_seedAgents = new[]
+    {
+        new SeedAgent("developer", 0.4,
+            "Expert software developer for code generation and fixes."),
+        new SeedAgent("tester", 0.3,
+            "QA engineer for test strategy and generation."),
+        new SeedAgent("security", 0.2,
+            "Security reviewer for vulnerabilities, secrets, and compliance."),
+        new SeedAgent("devops", 0.3,
+            "DevOps engineer for infrastructure, CI/CD, and deployment."),
+        new SeedAgent("architect", 0.3,
+            "Software architect for system design decisions."),
+        new SeedAgent("product_owner", 0.4,
+            "Product owner for intake, requirements, and prioritisation."),
+        new SeedAgent("senior_developer", 0.2,
+            "Tech lead for decomposition, code review, and mentorship."),
+        new SeedAgent("tech_writer", 0.4,
+            "Technical writer for documentation."),
+    };
+
+    private static readonly string[] s_providerChainNames = ["anthropic", "openai", "openrouter"];
+    private const int DefaultMaxTokens = 4096;
+    private const double DefaultMaxBudgetUsd = 10.0;
+
+    /// <summary>
+    /// Insert any missing public agents + their <c>Version=1</c> snapshots.
+    /// Safe to call on every startup — skip-by-existing-handle makes re-runs a
+    /// no-op. Returns the number of agents inserted.
+    /// </summary>
+    public static async Task<int> SeedAsync(
+        ControlPlaneDbContext context, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        // Existing public handles for this seed set — skip those.
+        var existing = await context.Agents
+            .Where(a => a.Visibility == AgentVisibility.Public)
+            .Select(a => a.Name)
+            .ToListAsync(cancellationToken);
+        var existingSet = existing.ToHashSet(StringComparer.Ordinal);
+
+        var now = DateTime.UtcNow;
+        var inserted = 0;
+
+        foreach (var seed in s_seedAgents)
+        {
+            var handle = $"tamma-{seed.Role}";
+            if (existingSet.Contains(handle))
+            {
+                continue;
+            }
+
+            var agentId = Guid.NewGuid();
+            var versionId = Guid.NewGuid();
+
+            context.Agents.Add(new Agent
+            {
+                Id = agentId,
+                Name = handle,
+                Role = seed.Role,
+                Visibility = AgentVisibility.Public,
+                OwnerTenantId = null,
+                OwnerUserId = null,
+                Status = AgentStatus.Active,
+                CurrentVersionId = versionId,
+                CreatedAt = now,
+                UpdatedAt = now,
+            });
+            context.AgentVersions.Add(new AgentVersion
+            {
+                Id = versionId,
+                AgentId = agentId,
+                Version = 1,
+                ConfigJson = BuildConfigJson(seed),
+                Notes = "Shipped default (Story 32-1 seed).",
+                CreatedAt = now,
+            });
+            inserted++;
+        }
+
+        if (inserted > 0)
+        {
+            await context.SaveChangesAsync(cancellationToken);
+        }
+
+        return inserted;
+    }
+
+    /// <summary>
+    /// Build a saved-config snapshot that validates against
+    /// <c>AgentConfigValidator</c> and mirrors the shipped values: primary
+    /// <c>provider</c>, full <c>providerChain</c>, <c>temperature</c>,
+    /// <c>maxTokens</c>, <c>maxBudgetUsd</c>.
+    /// </summary>
+    private static string BuildConfigJson(SeedAgent seed)
+    {
+        var config = new
+        {
+            provider = s_providerChainNames[0],
+            temperature = seed.Temperature,
+            maxTokens = DefaultMaxTokens,
+            maxBudgetUsd = DefaultMaxBudgetUsd,
+            providerChain = s_providerChainNames
+                .Select(p => new { provider = p })
+                .ToArray(),
+            description = seed.Description,
+        };
+        return JsonSerializer.Serialize(config);
+    }
+
+    private readonly record struct SeedAgent(string Role, double Temperature, string Description);
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Seeders/PlansSeeder.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Seeders/PlansSeeder.cs
@@ -1,21 +1,30 @@
 using Microsoft.EntityFrameworkCore;
+using Tamma.Core.Enums;
 using Tamma.Data.Entities;
 
 namespace Tamma.Data.Seeders;
 
 /// <summary>
-/// Idempotently seeds the <c>plans</c> table with the three default plans
-/// referenced by <c>tenants.PlanId</c>: <c>plan_free</c>, <c>plan_team</c>,
-/// <c>plan_enterprise</c>. Story 28-1 ships the seed; later stories may
-/// extend with additional plans via admin UI (Story 28-11).
+/// Idempotently seeds the <c>plans</c> price-book referenced by
+/// <c>tenants.PlanId</c>: <c>free</c>, <c>team</c>, <c>enterprise</c>. Story
+/// 28-1 shipped the bare plan rows; Story 34-1 extends the seed with the typed
+/// <see cref="PlanFeature"/> / <see cref="PlanEntitlement"/> /
+/// <see cref="PlanPrice"/> children and the versioning columns
+/// (<c>Version = 1</c>, <c>Status = active</c>).
 ///
-/// <para>Stable UUIDs — baked into the seed so FK targets stay
-/// deterministic across environments and integration tests can assert
-/// against known IDs.</para>
+/// <para>Stable UUIDs — baked into the seed so FK targets stay deterministic
+/// across environments and integration tests can assert against known IDs.</para>
 ///
-/// <para>Run pattern: <see cref="SeedAsync"/> is invoked once at API
-/// startup (or by Story 28-2's hosted service) after migrations apply.
-/// The <c>EXISTS</c> short-circuit makes re-runs a no-op.</para>
+/// <para><b>Insert-missing-only, per row</b> (mirrors
+/// <see cref="AgentEntitySeeder"/> + the convention system-defaults ownership
+/// rule): each plan/feature/entitlement/price is inserted only when absent.
+/// A re-run is a no-op and NEVER reverts an admin-edited row — the old
+/// whole-table <c>AnyAsync</c> short-circuit is gone so children backfill onto
+/// a DB that already had the bare v1 plan rows. The seeder does NOT emit DCB
+/// events — seeding system defaults is not a user-driven state transition
+/// (consistent with the agent seeder); <c>PLAN.VERSION.CREATED</c> /
+/// <c>PLAN.DEPRECATED</c> are reserved for real edits via
+/// <c>PlanVersionEditor</c>.</para>
 /// </summary>
 public static class PlansSeeder
 {
@@ -32,8 +41,9 @@ public static class PlansSeeder
         Guid.Parse("aaaaaaaa-0000-0000-0000-000000000003");
 
     /// <summary>
-    /// Inserts the three default plan rows if absent. Safe to call on every
-    /// startup — the row count check makes re-runs a no-op.
+    /// Inserts any missing plan rows + their typed children. Safe to call on
+    /// every startup — per-row existence checks make re-runs a no-op and never
+    /// revert admin edits.
     /// </summary>
     public static async Task SeedAsync(
         ControlPlaneDbContext context,
@@ -41,55 +51,203 @@ public static class PlansSeeder
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        var anyExisting = await context.Plans.AnyAsync(cancellationToken);
-        if (anyExisting)
+        var now = DateTime.UtcNow;
+        var changed = false;
+
+        foreach (var spec in s_seed)
         {
-            return;
+            changed |= await SeedPlanAsync(context, spec, now, cancellationToken);
         }
 
-        var now = DateTime.UtcNow;
-
-        var seed = new[]
+        if (changed)
         {
-            new Plan
-            {
-                Id = FreePlanId,
-                Slug = "free",
-                DisplayName = "Free",
-                MonthlyPriceUsd = 0m,
-                Quotas = "{\"llmTokensPerMonth\":100000,\"concurrentWorkflows\":1,\"seats\":1}",
-                IsActive = true,
-                PlacementPolicy = "shared",
-                CreatedAt = now,
-                UpdatedAt = now,
-            },
-            new Plan
-            {
-                Id = TeamPlanId,
-                Slug = "team",
-                DisplayName = "Team",
-                MonthlyPriceUsd = 49m,
-                Quotas = "{\"llmTokensPerMonth\":2000000,\"concurrentWorkflows\":10,\"seats\":10}",
-                IsActive = true,
-                PlacementPolicy = "shared",
-                CreatedAt = now,
-                UpdatedAt = now,
-            },
-            new Plan
-            {
-                Id = EnterprisePlanId,
-                Slug = "enterprise",
-                DisplayName = "Enterprise",
-                MonthlyPriceUsd = 499m,
-                Quotas = "{\"llmTokensPerMonth\":50000000,\"concurrentWorkflows\":100,\"seats\":-1}",
-                IsActive = true,
-                PlacementPolicy = "dedicated",
-                CreatedAt = now,
-                UpdatedAt = now,
-            },
-        };
-
-        await context.Plans.AddRangeAsync(seed, cancellationToken);
-        await context.SaveChangesAsync(cancellationToken);
+            await context.SaveChangesAsync(cancellationToken);
+        }
     }
+
+    private static async Task<bool> SeedPlanAsync(
+        ControlPlaneDbContext context,
+        PlanSeed spec,
+        DateTime now,
+        CancellationToken ct)
+    {
+        var changed = false;
+
+        var planExists = await context.Plans
+            .AsNoTracking()
+            .AnyAsync(p => p.Id == spec.Id, ct);
+
+        if (!planExists)
+        {
+            context.Plans.Add(new Plan
+            {
+                Id = spec.Id,
+                Slug = spec.Slug,
+                DisplayName = spec.DisplayName,
+                Version = 1,
+                Status = "active",
+                IsCustom = false,
+                BillingInterval = "monthly",
+                SupersedesPlanId = null,
+                MonthlyPriceUsd = spec.MonthlyPriceUsd,
+                Quotas = spec.QuotasJson,
+                IsActive = true,
+                PlacementPolicy = spec.PlacementPolicy,
+                CreatedAt = now,
+                UpdatedAt = now,
+            });
+            changed = true;
+        }
+
+        // Children backfill independently — they may be missing on a DB that
+        // already had the bare v1 plan row from Story 28-1's seed.
+        foreach (var f in spec.Features)
+        {
+            if (!await context.PlanFeatures.AsNoTracking().AnyAsync(x => x.Id == f.Id, ct))
+            {
+                context.PlanFeatures.Add(new PlanFeature
+                {
+                    Id = f.Id,
+                    PlanId = spec.Id,
+                    FeatureKey = f.FeatureKey,
+                    BoolValue = f.BoolValue,
+                    StringValue = f.StringValue,
+                });
+                changed = true;
+            }
+        }
+
+        foreach (var e in spec.Entitlements)
+        {
+            if (!await context.PlanEntitlements.AsNoTracking().AnyAsync(x => x.Id == e.Id, ct))
+            {
+                context.PlanEntitlements.Add(new PlanEntitlement
+                {
+                    Id = e.Id,
+                    PlanId = spec.Id,
+                    MetricKey = e.MetricKey,
+                    LimitValue = e.LimitValue,
+                    Period = e.Period,
+                    OverageMode = e.OverageMode,
+                });
+                changed = true;
+            }
+        }
+
+        foreach (var p in spec.Prices)
+        {
+            if (!await context.PlanPrices.AsNoTracking().AnyAsync(x => x.Id == p.Id, ct))
+            {
+                context.PlanPrices.Add(new PlanPrice
+                {
+                    Id = p.Id,
+                    PlanId = spec.Id,
+                    PricingMode = p.PricingMode,
+                    RecurringUsd = p.RecurringUsd,
+                    SeatUsd = p.SeatUsd,
+                    MeteredComponent = p.MeteredComponent,
+                });
+                changed = true;
+            }
+        }
+
+        return changed;
+    }
+
+    // Deterministic child ids: aaaaaaaa-<plan>-<kind>-…  so test fixtures and
+    // the insert-missing-only check can both key off a known UUID.
+    private static Guid ChildId(int plan, int kind, int seq) =>
+        Guid.Parse($"aaaaaaaa-0000-0000-{plan:D4}-{kind:D8}{seq:D4}");
+
+    private static readonly IReadOnlyList<PlanSeed> s_seed = BuildSeed();
+
+    private static IReadOnlyList<PlanSeed> BuildSeed() =>
+    [
+        new PlanSeed(
+            FreePlanId, "free", "Free", 0m, "shared",
+            "{\"llmTokensPerMonth\":100000,\"concurrentWorkflows\":1,\"seats\":1}",
+            Features:
+            [
+                new FeatureSeed(ChildId(1, 1, 1), "byok_allowed", BoolValue: false, StringValue: null),
+                new FeatureSeed(ChildId(1, 1, 2), "support_tier", BoolValue: null, StringValue: "community"),
+            ],
+            Entitlements:
+            [
+                new EntitlementSeed(ChildId(1, 2, 1), EntitlementMetricKey.Seats, 1, "total", "block"),
+                new EntitlementSeed(ChildId(1, 2, 2), EntitlementMetricKey.Agents, 2, "total", "block"),
+                new EntitlementSeed(ChildId(1, 2, 3), EntitlementMetricKey.Repos, 1, "total", "block"),
+                new EntitlementSeed(ChildId(1, 2, 4), EntitlementMetricKey.WorkflowRuns, 50, "monthly", "block"),
+                new EntitlementSeed(ChildId(1, 2, 5), EntitlementMetricKey.LlmTokens, 100_000, "monthly", "block"),
+            ],
+            Prices:
+            [
+                new PriceSeed(ChildId(1, 3, 1), "platform_provided", 0m, 0m, "{}"),
+                new PriceSeed(ChildId(1, 3, 2), "byok", 0m, 0m, "{}"),
+            ]),
+
+        new PlanSeed(
+            TeamPlanId, "team", "Team", 49m, "shared",
+            "{\"llmTokensPerMonth\":2000000,\"concurrentWorkflows\":10,\"seats\":10}",
+            Features:
+            [
+                new FeatureSeed(ChildId(2, 1, 1), "byok_allowed", BoolValue: true, StringValue: null),
+                new FeatureSeed(ChildId(2, 1, 2), "support_tier", BoolValue: null, StringValue: "standard"),
+            ],
+            Entitlements:
+            [
+                new EntitlementSeed(ChildId(2, 2, 1), EntitlementMetricKey.Seats, 10, "total", "block"),
+                new EntitlementSeed(ChildId(2, 2, 2), EntitlementMetricKey.Agents, 20, "total", "block"),
+                new EntitlementSeed(ChildId(2, 2, 3), EntitlementMetricKey.Repos, 25, "total", "block"),
+                new EntitlementSeed(ChildId(2, 2, 4), EntitlementMetricKey.WorkflowRuns, 2_000, "monthly", "meter"),
+                new EntitlementSeed(ChildId(2, 2, 5), EntitlementMetricKey.LlmTokens, 2_000_000, "monthly", "meter"),
+            ],
+            Prices:
+            [
+                new PriceSeed(ChildId(2, 3, 1), "platform_provided", 49m, 15m, "{}"),
+                new PriceSeed(ChildId(2, 3, 2), "byok", 29m, 10m, "{}"),
+            ]),
+
+        new PlanSeed(
+            EnterprisePlanId, "enterprise", "Enterprise", 499m, "dedicated",
+            "{\"llmTokensPerMonth\":50000000,\"concurrentWorkflows\":100,\"seats\":-1}",
+            Features:
+            [
+                new FeatureSeed(ChildId(3, 1, 1), "byok_allowed", BoolValue: true, StringValue: null),
+                new FeatureSeed(ChildId(3, 1, 2), "support_tier", BoolValue: null, StringValue: "priority"),
+            ],
+            Entitlements:
+            [
+                // NULL limit = unlimited.
+                new EntitlementSeed(ChildId(3, 2, 1), EntitlementMetricKey.Seats, null, "total", "allow"),
+                new EntitlementSeed(ChildId(3, 2, 2), EntitlementMetricKey.Agents, null, "total", "allow"),
+                new EntitlementSeed(ChildId(3, 2, 3), EntitlementMetricKey.Repos, null, "total", "allow"),
+                new EntitlementSeed(ChildId(3, 2, 4), EntitlementMetricKey.WorkflowRuns, null, "monthly", "meter"),
+                new EntitlementSeed(ChildId(3, 2, 5), EntitlementMetricKey.LlmTokens, 50_000_000, "monthly", "meter"),
+            ],
+            Prices:
+            [
+                new PriceSeed(ChildId(3, 3, 1), "platform_provided", 499m, 25m, "{}"),
+                new PriceSeed(ChildId(3, 3, 2), "byok", 299m, 20m, "{}"),
+            ]),
+    ];
+
+    private sealed record PlanSeed(
+        Guid Id,
+        string Slug,
+        string DisplayName,
+        decimal MonthlyPriceUsd,
+        string PlacementPolicy,
+        string QuotasJson,
+        IReadOnlyList<FeatureSeed> Features,
+        IReadOnlyList<EntitlementSeed> Entitlements,
+        IReadOnlyList<PriceSeed> Prices);
+
+    private sealed record FeatureSeed(
+        Guid Id, string FeatureKey, bool? BoolValue, string? StringValue);
+
+    private sealed record EntitlementSeed(
+        Guid Id, EntitlementMetricKey MetricKey, long? LimitValue, string Period, string OverageMode);
+
+    private sealed record PriceSeed(
+        Guid Id, string PricingMode, decimal RecurringUsd, decimal SeatUsd, string MeteredComponent);
 }

--- a/apps/tamma-elsa/src/Tamma.Data/Seeders/PlansSeeder.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Seeders/PlansSeeder.cs
@@ -66,15 +66,13 @@ public static class PlansSeeder
             // v1 plan (Story 28-1 shipped the bare plan rows; 34-1 backfills
             // the typed children). The Story 34-1 immutability interceptor on
             // ControlPlaneDbContext would otherwise (correctly) reject adding a
-            // child to an active plan, so suppress it for just this save.
-            context.SuppressPlanImmutabilityGuard = true;
-            try
+            // child to an active plan, so suppress it for just this save. The
+            // disposable scope guarantees the suppression is restored on exit
+            // (even on exception) and can never leak across a pooled-context
+            // lease — there is no settable flag to leave dangling.
+            using (context.SuppressPlanImmutabilityGuard())
             {
                 await context.SaveChangesAsync(cancellationToken);
-            }
-            finally
-            {
-                context.SuppressPlanImmutabilityGuard = false;
             }
         }
     }

--- a/apps/tamma-elsa/src/Tamma.Data/Seeders/PlansSeeder.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Seeders/PlansSeeder.cs
@@ -28,15 +28,15 @@ namespace Tamma.Data.Seeders;
 /// </summary>
 public static class PlansSeeder
 {
-    /// <summary>Stable UUIDv4 for the free plan — never change.</summary>
+    /// <summary>Stable sentinel UUID for the free plan — never change.</summary>
     public static readonly Guid FreePlanId =
         Guid.Parse("aaaaaaaa-0000-0000-0000-000000000001");
 
-    /// <summary>Stable UUIDv4 for the team plan — never change.</summary>
+    /// <summary>Stable sentinel UUID for the team plan — never change.</summary>
     public static readonly Guid TeamPlanId =
         Guid.Parse("aaaaaaaa-0000-0000-0000-000000000002");
 
-    /// <summary>Stable UUIDv4 for the enterprise plan — never change.</summary>
+    /// <summary>Stable sentinel UUID for the enterprise plan — never change.</summary>
     public static readonly Guid EnterprisePlanId =
         Guid.Parse("aaaaaaaa-0000-0000-0000-000000000003");
 
@@ -61,7 +61,21 @@ public static class PlansSeeder
 
         if (changed)
         {
-            await context.SaveChangesAsync(cancellationToken);
+            // The seeder is the trusted system-defaults populate path: it does
+            // insert-missing-only backfill of children onto an already-active
+            // v1 plan (Story 28-1 shipped the bare plan rows; 34-1 backfills
+            // the typed children). The Story 34-1 immutability interceptor on
+            // ControlPlaneDbContext would otherwise (correctly) reject adding a
+            // child to an active plan, so suppress it for just this save.
+            context.SuppressPlanImmutabilityGuard = true;
+            try
+            {
+                await context.SaveChangesAsync(cancellationToken);
+            }
+            finally
+            {
+                context.SuppressPlanImmutabilityGuard = false;
+            }
         }
     }
 

--- a/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
@@ -839,6 +839,81 @@ internal static class TammaModelConfiguration
     }
 
     /// <summary>
+    /// Story 35-1 — billing foundation entities. The tenant→Stripe customer
+    /// mapping (<c>billing_customers</c>, unique <c>TenantId</c>) and the
+    /// slug→Stripe-ids catalog (<c>billing_plan_prices</c>, unique
+    /// <c>PlanSlug</c>). CP-resident; configured in the shared single source so
+    /// the model graph and the additive migration stay aligned.
+    /// </summary>
+    public static void ConfigureBillingEntities(ModelBuilder modelBuilder)
+    {
+        // ── BillingCustomer (tenant → Stripe customer) ──
+        modelBuilder.Entity<BillingCustomer>(entity =>
+        {
+            entity.ToTable("billing_customers", t =>
+            {
+                // Text domain for the persisted BillingMode member name.
+                t.HasCheckConstraint(
+                    "ck_billing_customers_mode",
+                    "\"BillingMode\" IN ('PlatformProvided','Byok')");
+            });
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+            entity.Property(e => e.BillingMode)
+                .IsRequired().HasMaxLength(32).HasDefaultValue("PlatformProvided");
+            entity.Property(e => e.DefaultCurrency)
+                .IsRequired().HasMaxLength(3).HasDefaultValue("usd");
+            entity.Property(e => e.TaxStatus)
+                .IsRequired().HasMaxLength(32).HasDefaultValue("none");
+            entity.Property(e => e.StripeCustomerId).HasMaxLength(255);
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("now()");
+
+            // Exactly one customer mapping per tenant (AC1 / AC12).
+            entity.HasIndex(e => e.TenantId)
+                .HasDatabaseName("UX_billing_customers_TenantId")
+                .IsUnique();
+
+            // Stripe customer ids are globally unique once assigned. Partial so
+            // the null-until-acked retry rows don't collide on NULL.
+            entity.HasIndex(e => e.StripeCustomerId)
+                .HasDatabaseName("UX_billing_customers_StripeCustomerId")
+                .HasFilter("\"StripeCustomerId\" IS NOT NULL")
+                .IsUnique();
+
+            // Tenant purge cascades the billing mapping.
+            entity.HasOne(e => e.Tenant)
+                .WithMany()
+                .HasForeignKey(e => e.TenantId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        // ── BillingPlanPrice (slug → Stripe ids catalog) ──
+        modelBuilder.Entity<BillingPlanPrice>(entity =>
+        {
+            entity.ToTable("billing_plan_prices");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+            entity.Property(e => e.PlanSlug).IsRequired().HasMaxLength(64);
+            entity.Property(e => e.StripeProductId).HasMaxLength(255);
+            entity.Property(e => e.StripePriceId).HasMaxLength(255);
+            entity.Property(e => e.TokensInputMeterId).HasMaxLength(255);
+            entity.Property(e => e.TokensInputPriceId).HasMaxLength(255);
+            entity.Property(e => e.TokensOutputMeterId).HasMaxLength(255);
+            entity.Property(e => e.TokensOutputPriceId).HasMaxLength(255);
+            entity.Property(e => e.SeatsMeterId).HasMaxLength(255);
+            entity.Property(e => e.SeatsPriceId).HasMaxLength(255);
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("now()");
+
+            // One catalog row per slug — the seed upserts on this key.
+            entity.HasIndex(e => e.PlanSlug)
+                .HasDatabaseName("UX_billing_plan_prices_PlanSlug")
+                .IsUnique();
+        });
+    }
+
+    /// <summary>
     /// Configure the per-tenant entity graph. <paramref name="fixedTenantId"/>
     /// is non-null when invoked from <see cref="TenantDbContext"/> — the
     /// query filter binds directly to that tenant (fail-closed, no ambient

--- a/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
@@ -1384,6 +1384,125 @@ internal static class TammaModelConfiguration
             // No query filter — the outbox is shared infra; tenant scoping is
             // explicit in the repository APIs.
         });
+
+        // ── Analytics usage fact tables (Story 36-1) ──
+        // Per-tenant dimensional usage/cost/performance store. Schema-only here
+        // (Story 36-2 owns population). Mirrors ConfigurePlatformAnalyticsHourly
+        // (Story 28-10) for defaults/precision; uses the prompt_overrides /
+        // conventions NULLS NOT DISTINCT pattern for the idempotent business key.
+        ConfigureAnalyticsUsageEntities(modelBuilder, fixedTenantId);
+    }
+
+    /// <summary>
+    /// Story 36-1 — maps the two per-tenant dimensional analytics fact tables
+    /// (<c>analytics_usage_hourly</c> + <c>analytics_usage_daily</c>). The two
+    /// share an identical dimension + measure contract; only the time bucket
+    /// column differs (<c>Hour</c> vs <c>Day</c>), so a single shared inner
+    /// configurator is applied to both — no drift.
+    ///
+    /// <para>Defaults/precision mirror <c>ConfigurePlatformAnalyticsHourly</c>
+    /// (Story 28-10): <c>gen_random_uuid()</c> PK, <c>timestamp with time
+    /// zone</c> bucket, <c>HasDefaultValue(0L)</c> counters,
+    /// <c>HasPrecision(20,4).HasDefaultValue(0m)</c> costs, <c>now()</c> write
+    /// timestamp. <see cref="CostBasis"/> is persisted as lowercase text
+    /// (<c>byok</c>/<c>platform</c>). The breakdown index and the NULLS NOT
+    /// DISTINCT unique business-key index follow the prompt_overrides /
+    /// conventions precedent.</para>
+    ///
+    /// <para>No <c>TenantId</c> column — tenancy is the schema (Doc 01 §1.4);
+    /// <see cref="ApplyTenantFilter{T}"/> is the deliberate no-op (the accessor
+    /// lambda returns <c>null</c> because there is nothing to filter on).</para>
+    /// </summary>
+    private static void ConfigureAnalyticsUsageEntities(
+        ModelBuilder modelBuilder, Guid? fixedTenantId)
+    {
+        // Lowercase byok/platform text — keeps the discriminator uniform in
+        // ad-hoc SQL and round-trips identically on InMemory and Npgsql.
+        var costBasisConverter = new ValueConverter<CostBasis, string>(
+            v => v.ToString().ToLowerInvariant(),
+            s => Enum.Parse<CostBasis>(s, true));
+
+        modelBuilder.Entity<AnalyticsUsageHourly>(entity =>
+        {
+            entity.ToTable("analytics_usage_hourly");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+            entity.Property(e => e.Hour).HasColumnType("timestamp with time zone");
+            ConfigureAnalyticsUsageShared(entity, costBasisConverter);
+
+            // Breakdown index (AC6) — "by provider / agent / workflow / cost-basis".
+            entity.HasIndex(e => new
+                { e.Hour, e.Provider, e.AgentId, e.WorkflowDefinitionId, e.CostBasis })
+                .HasDatabaseName("IX_analytics_usage_hourly_breakdown");
+
+            // Idempotent business key (AC7) — full dimension tuple,
+            // NULLS NOT DISTINCT so NULL AgentId/WorkflowDefinitionId/RepoId
+            // dedupe to one row per bucket (same pattern as prompt_overrides /
+            // conventions; PG15+, production PG17).
+            entity.HasIndex(e => new
+                { e.Hour, e.Provider, e.AgentId, e.WorkflowDefinitionId, e.RepoId, e.CostBasis })
+                .IsUnique()
+                .AreNullsDistinct(false)
+                .HasDatabaseName("UX_analytics_usage_hourly_dims");
+
+            // No TenantId column — schema is the isolation plane. The filter is
+            // the established no-op; the accessor returns null (nothing to filter).
+            ApplyTenantFilter<AnalyticsUsageHourly>(entity, fixedTenantId, _ => null);
+        });
+
+        modelBuilder.Entity<AnalyticsUsageDaily>(entity =>
+        {
+            entity.ToTable("analytics_usage_daily");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+            entity.Property(e => e.Day).HasColumnType("timestamp with time zone");
+            ConfigureAnalyticsUsageShared(entity, costBasisConverter);
+
+            entity.HasIndex(e => new
+                { e.Day, e.Provider, e.AgentId, e.WorkflowDefinitionId, e.CostBasis })
+                .HasDatabaseName("IX_analytics_usage_daily_breakdown");
+
+            entity.HasIndex(e => new
+                { e.Day, e.Provider, e.AgentId, e.WorkflowDefinitionId, e.RepoId, e.CostBasis })
+                .IsUnique()
+                .AreNullsDistinct(false)
+                .HasDatabaseName("UX_analytics_usage_daily_dims");
+
+            ApplyTenantFilter<AnalyticsUsageDaily>(entity, fixedTenantId, _ => null);
+        });
+    }
+
+    /// <summary>
+    /// Story 36-1 — the dimension + measure mapping shared verbatim by
+    /// <c>analytics_usage_hourly</c> and <c>analytics_usage_daily</c>. The
+    /// bucket column (<c>Hour</c>/<c>Day</c>) and the indexes are configured by
+    /// each caller; everything else (dimensions, measures, defaults, CostBasis
+    /// conversion) lives here so the two tables can never drift.
+    /// </summary>
+    private static void ConfigureAnalyticsUsageShared<T>(
+        Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<T> entity,
+        ValueConverter<CostBasis, string> costBasisConverter)
+        where T : class
+    {
+        // Dimensions.
+        entity.Property("Provider").IsRequired().HasMaxLength(100);
+        entity.Property("AgentId").HasMaxLength(200);
+        entity.Property("RepoId").HasMaxLength(400);
+        entity.Property(typeof(CostBasis), "CostBasis")
+            .HasConversion(costBasisConverter)
+            .IsRequired()
+            .HasMaxLength(20);
+
+        // Measures — counters default 0L, costs decimal(20,4) default 0m.
+        entity.Property("TokensIn").HasDefaultValue(0L);
+        entity.Property("TokensOut").HasDefaultValue(0L);
+        entity.Property("WorkflowsStarted").HasDefaultValue(0L);
+        entity.Property("WorkflowsCompleted").HasDefaultValue(0L);
+        entity.Property("WorkflowsFailed").HasDefaultValue(0L);
+        entity.Property("AgentDispatches").HasDefaultValue(0L);
+        entity.Property("CostUsd").HasPrecision(20, 4).HasDefaultValue(0m);
+        entity.Property("PlatformBilledUsd").HasPrecision(20, 4).HasDefaultValue(0m);
+        entity.Property("ComputedAt").HasDefaultValueSql("now()");
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
@@ -914,6 +914,115 @@ internal static class TammaModelConfiguration
     }
 
     /// <summary>
+    /// Story 37-1 — configure the curated <c>audit_records</c> read-model table.
+    /// Called from BOTH <see cref="ControlPlaneDbContext"/> (platform-scope
+    /// audit) and <see cref="TenantDbContext"/> (tenant-scope audit) so the
+    /// single config source applies to both model builds — there is exactly one
+    /// physical <c>audit_records</c> shape, materialized into either the CP or a
+    /// tenant schema by the projector.
+    ///
+    /// <para>Mirrors <c>prompt_overrides</c>: the
+    /// <c>ck_audit_records_principal_xor</c> CHECK ties exactly one of
+    /// (<c>UserId</c>, <c>TenantId</c>) to non-null. The UNIQUE
+    /// <c>SourceEventId</c> index is the idempotency key (one curated row per raw
+    /// event — AC8). The <c>SourceSequenceNumber</c> index gives Story 37-2 a
+    /// deterministic chain order. The reserved <c>RecordHash</c>/<c>PrevRecordHash</c>
+    /// columns are nullable and left null by this story.</para>
+    /// </summary>
+    public static void ConfigureAuditEntities(
+        ModelBuilder modelBuilder, Guid? fixedTenantId = null)
+    {
+        modelBuilder.Entity<AuditRecord>(entity =>
+        {
+            entity.ToTable("audit_records", t =>
+            {
+                // Per-mode ownership invariant (mirrors ck_prompt_overrides_principal_xor):
+                // UserId and TenantId are mutually exclusive — never BOTH set.
+                //   single-user → UserId set, TenantId null;
+                //   SaaS tenant-scope → TenantId set, UserId null;
+                //   SaaS platform-scope → BOTH null (a control-plane platform row,
+                //     e.g. impersonation against the platform — AC11). This third
+                //     case is why the CHECK is "not both" rather than strict XOR:
+                //     a platform action has no tenant AND no single-user owner, yet
+                //     AC11 mandates it land in the CP audit_records with tenant_id
+                //     null. The "never a tenant's view" isolation (AC14) is then
+                //     enforced by physical placement (CP schema) + the TenantId
+                //     filter on tenant reads, not by the ownership columns.
+                t.HasCheckConstraint(
+                    "ck_audit_records_principal_xor",
+                    "NOT (\"UserId\" IS NOT NULL AND \"TenantId\" IS NOT NULL)");
+                // Outcome is a closed enum — a buggy projector can't stash junk.
+                t.HasCheckConstraint(
+                    "ck_audit_records_outcome",
+                    "\"Outcome\" IN ('success','failure','denied')");
+            });
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+            entity.Property(e => e.ActionCode).IsRequired().HasMaxLength(128);
+            entity.Property(e => e.Category).IsRequired().HasMaxLength(32);
+            entity.Property(e => e.Severity).IsRequired().HasMaxLength(16);
+            entity.Property(e => e.ActorEmailSnapshot).HasMaxLength(320);
+            entity.Property(e => e.TargetType).HasMaxLength(64);
+            entity.Property(e => e.TargetId).HasMaxLength(255);
+            entity.Property(e => e.Outcome)
+                .IsRequired().HasMaxLength(16).HasDefaultValue("success");
+            entity.Property(e => e.IpAddress).HasMaxLength(64);
+            entity.Property(e => e.UserAgent).HasMaxLength(512);
+            entity.Property(e => e.OccurredAt).HasColumnType("timestamp with time zone");
+            entity.Property(e => e.PayloadJson)
+                .HasColumnType("jsonb").HasDefaultValueSql("'{}'::jsonb");
+            // Reserved for Story 37-2 — nullable, never populated here.
+            entity.Property(e => e.RecordHash).HasMaxLength(128);
+            entity.Property(e => e.PrevRecordHash).HasMaxLength(128);
+
+            // Idempotency key — one curated row per raw event (AC8). The
+            // projector inserts-if-absent; a re-scan after a crash is a no-op.
+            entity.HasIndex(e => e.SourceEventId)
+                .IsUnique()
+                .HasDatabaseName("UX_audit_records_SourceEventId");
+            // Replay / 37-2 chain order.
+            entity.HasIndex(e => e.SourceSequenceNumber)
+                .HasDatabaseName("IX_audit_records_SourceSequenceNumber");
+            // Tenant query hot path (Story 37-10).
+            entity.HasIndex(e => new { e.TenantId, e.OccurredAt })
+                .HasDatabaseName("IX_audit_records_TenantId_OccurredAt");
+            // Single-user query hot path.
+            entity.HasIndex(e => new { e.UserId, e.OccurredAt })
+                .HasDatabaseName("IX_audit_records_UserId_OccurredAt");
+            // Category/severity compliance filter (Story 37-10).
+            entity.HasIndex(e => new { e.Category, e.OccurredAt })
+                .HasDatabaseName("IX_audit_records_Category_OccurredAt");
+
+            // Tenant-context defence-in-depth: same no-op filter seam every
+            // tenant-resident table uses. The per-tenant schema + connection is
+            // the real isolation plane (Doc 01 §1.4); the explicit TenantId
+            // predicate in the repository carries the transitional shared-DB
+            // phase. AC14's isolation proof is the schema + the UserId/TenantId
+            // routing, not a query filter.
+            ApplyTenantFilter(entity, fixedTenantId, e => e.TenantId);
+        });
+    }
+
+    /// <summary>
+    /// Story 37-1 — configure the <c>audit_projector_cursor</c> table. Lives in
+    /// the control plane only (mirrors <see cref="AlertEvaluatorCursor"/>): the
+    /// single projector resumes both the tenant-domain and platform streams
+    /// from one CP-resident cursor row.
+    /// </summary>
+    public static void ConfigureAuditProjectorCursor(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<AuditProjectorCursor>(entity =>
+        {
+            entity.ToTable("audit_projector_cursor");
+            entity.HasKey(e => e.ProjectorId);
+            entity.Property(e => e.ProjectorId).IsRequired().HasMaxLength(64);
+            entity.Property(e => e.LastDomainSequenceNumber).HasDefaultValue(0L);
+            entity.Property(e => e.LastPlatformSequenceNumber).HasDefaultValue(0L);
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("now()");
+        });
+    }
+
+    /// <summary>
     /// Configure the per-tenant entity graph. <paramref name="fixedTenantId"/>
     /// is non-null when invoked from <see cref="TenantDbContext"/> — the
     /// query filter binds directly to that tenant (fail-closed, no ambient
@@ -1391,6 +1500,12 @@ internal static class TammaModelConfiguration
         // (Story 28-10) for defaults/precision; uses the prompt_overrides /
         // conventions NULLS NOT DISTINCT pattern for the idempotent business key.
         ConfigureAnalyticsUsageEntities(modelBuilder, fixedTenantId);
+
+        // ── Curated audit records (Story 37-1) ──
+        // Tenant-scope curated audit trail materialized from the tenant
+        // domain_events stream. The SAME table shape is also configured on the
+        // CP context for platform-scope rows — one physical schema, two homes.
+        ConfigureAuditEntities(modelBuilder, fixedTenantId);
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
@@ -440,7 +440,7 @@ internal static class TammaModelConfiguration
             entity.HasIndex(e => new { e.InstallationId, e.ReceivedAt });
         });
 
-        // ── Plan (Story 28-1) ──
+        // ── Plan (Story 28-1; extended by Story 34-1 — versioned price-book) ──
         modelBuilder.Entity<Plan>(entity =>
         {
             entity.ToTable("plans", t =>
@@ -448,8 +448,18 @@ internal static class TammaModelConfiguration
                 t.HasCheckConstraint(
                     "ck_plans_placement_policy",
                     "\"PlacementPolicy\" IN ('shared','dedicated')");
+                // Story 34-1 — pin the version-lifecycle + billing cadence to
+                // their closed enums so a buggy write path can't stash an
+                // unknown value the catalog can't reason about.
+                t.HasCheckConstraint(
+                    "ck_plans_status",
+                    "\"Status\" IN ('active','deprecated','draft')");
+                t.HasCheckConstraint(
+                    "ck_plans_billing_interval",
+                    "\"BillingInterval\" IN ('monthly','annual')");
             });
             entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
             entity.Property(e => e.Slug).IsRequired().HasMaxLength(64);
             entity.Property(e => e.DisplayName).IsRequired().HasMaxLength(255);
             entity.Property(e => e.MonthlyPriceUsd).HasPrecision(18, 2);
@@ -457,10 +467,123 @@ internal static class TammaModelConfiguration
             entity.Property(e => e.IsActive).HasDefaultValue(true);
             entity.Property(e => e.PlacementPolicy)
                 .IsRequired().HasMaxLength(20).HasDefaultValue("shared");
+
+            // Story 34-1 — versioning columns. Defaults backfill the 3 seeded
+            // rows on migrate: Version=1, Status='active'.
+            entity.Property(e => e.Version).HasDefaultValue(1);
+            entity.Property(e => e.Status)
+                .IsRequired().HasMaxLength(20).HasDefaultValue("active");
+            entity.Property(e => e.IsCustom).HasDefaultValue(false);
+            entity.Property(e => e.BillingInterval)
+                .IsRequired().HasMaxLength(20).HasDefaultValue("monthly");
+
             entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
             entity.Property(e => e.UpdatedAt).HasDefaultValueSql("now()");
 
-            entity.HasIndex(e => e.Slug).IsUnique();
+            // Story 34-1 — the legacy single-column UNIQUE(Slug) is replaced
+            // by UNIQUE(Slug, Version) (a slug now has multiple version rows)
+            // plus a partial unique index pinning exactly one 'active' version
+            // per slug — the immutability invariant in SQL.
+            entity.HasIndex(e => new { e.Slug, e.Version })
+                .HasDatabaseName("UX_plans_Slug_Version").IsUnique();
+            entity.HasIndex(e => e.Slug)
+                .HasDatabaseName("UX_plans_OneActivePerSlug")
+                .HasFilter("\"Status\" = 'active'").IsUnique();
+
+            // Self-referencing version chain. RESTRICT — a superseded version
+            // must not be hard-deleted out from under its successor's pointer.
+            entity.HasOne<Plan>()
+                .WithMany()
+                .HasForeignKey(e => e.SupersedesPlanId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        // ── PlanFeature / PlanEntitlement / PlanPrice (Story 34-1) ──
+        //
+        // The typed price-book children. Configured here (alongside Plan) so
+        // the whole plan aggregate's mapping lives in one place — splitting a
+        // single aggregate's config across files is the failure mode the
+        // story explicitly forbids. All FK to plans(Id) with RESTRICT (a plan
+        // version a tenant references must never be hard-deleted), each with a
+        // natural-key unique index.
+        modelBuilder.Entity<PlanFeature>(entity =>
+        {
+            entity.ToTable("plan_features");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+            entity.Property(e => e.FeatureKey).IsRequired().HasMaxLength(128);
+            entity.Property(e => e.StringValue).HasMaxLength(512);
+
+            entity.HasIndex(e => new { e.PlanId, e.FeatureKey })
+                .HasDatabaseName("UX_plan_features_PlanId_FeatureKey").IsUnique();
+
+            entity.HasOne<Plan>()
+                .WithMany(p => p.Features)
+                .HasForeignKey(e => e.PlanId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        modelBuilder.Entity<PlanEntitlement>(entity =>
+        {
+            entity.ToTable("plan_entitlements", t =>
+            {
+                t.HasCheckConstraint(
+                    "ck_plan_entitlements_period",
+                    "\"Period\" IN ('monthly','total')");
+                t.HasCheckConstraint(
+                    "ck_plan_entitlements_overage",
+                    "\"OverageMode\" IN ('block','allow','meter')");
+            });
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+
+            // Persist the metric key as its snake_case text — never the
+            // unstable ordinal (Story 34-1 AC5). The converter is the single
+            // source of the wire/DB contract shared with metering/enforcement.
+            entity.Property(e => e.MetricKey)
+                .HasConversion(
+                    k => k.ToMetricString(),
+                    s => EntitlementMetricKeyExtensions.Parse(s))
+                .HasColumnType("text")
+                .IsRequired();
+            entity.Property(e => e.Period)
+                .IsRequired().HasMaxLength(20).HasDefaultValue("monthly");
+            entity.Property(e => e.OverageMode)
+                .IsRequired().HasMaxLength(20).HasDefaultValue("block");
+
+            entity.HasIndex(e => new { e.PlanId, e.MetricKey })
+                .HasDatabaseName("UX_plan_entitlements_PlanId_MetricKey").IsUnique();
+
+            entity.HasOne<Plan>()
+                .WithMany(p => p.Entitlements)
+                .HasForeignKey(e => e.PlanId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        modelBuilder.Entity<PlanPrice>(entity =>
+        {
+            entity.ToTable("plan_prices", t =>
+            {
+                t.HasCheckConstraint(
+                    "ck_plan_prices_mode",
+                    "\"PricingMode\" IN ('platform_provided','byok')");
+            });
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+            entity.Property(e => e.PricingMode)
+                .IsRequired().HasMaxLength(32).HasDefaultValue("platform_provided");
+            entity.Property(e => e.RecurringUsd).HasPrecision(20, 4);
+            entity.Property(e => e.SeatUsd).HasPrecision(20, 4);
+            entity.Property(e => e.MeteredComponent)
+                .HasColumnType("jsonb").HasDefaultValueSql("'{}'::jsonb");
+
+            entity.HasIndex(e => new { e.PlanId, e.PricingMode })
+                .HasDatabaseName("UX_plan_prices_PlanId_PricingMode").IsUnique();
+
+            entity.HasOne<Plan>()
+                .WithMany(p => p.Prices)
+                .HasForeignKey(e => e.PlanId)
+                .OnDelete(DeleteBehavior.Restrict);
         });
 
         // ── PlatformEvent (Story 28-6) ──
@@ -753,6 +876,12 @@ internal static class TammaModelConfiguration
             modelBuilder.Ignore<GitHubInstallationRepo>();
             modelBuilder.Ignore<GitHubWebhookDelivery>();
             modelBuilder.Ignore<Plan>();
+            // Story 34-1 — the typed price-book children are CP-resident; keep
+            // them out of the tenant model graph (Plan's navigations would
+            // otherwise pull them in via convention).
+            modelBuilder.Ignore<PlanFeature>();
+            modelBuilder.Ignore<PlanEntitlement>();
+            modelBuilder.Ignore<PlanPrice>();
             modelBuilder.Ignore<PlatformEvent>();
             modelBuilder.Ignore<PlatformQueuedTask>();
             modelBuilder.Ignore<PlatformEmailOutboxMessage>();

--- a/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
@@ -1005,17 +1005,27 @@ internal static class TammaModelConfiguration
 
     /// <summary>
     /// Story 37-1 — configure the <c>audit_projector_cursor</c> table. Lives in
-    /// the control plane only (mirrors <see cref="AlertEvaluatorCursor"/>): the
-    /// single projector resumes both the tenant-domain and platform streams
-    /// from one CP-resident cursor row.
+    /// the control plane only.
+    ///
+    /// <para><b>C1 fix — per-tenant domain cursor</b>: the key is the composite
+    /// <c>(ProjectorId, TenantId)</c>. Each tenant's <c>domain_events</c> stream
+    /// is an independent per-schema BIGSERIAL, so each tenant tracks its OWN
+    /// <c>LastDomainSequenceNumber</c> on its own row. The global CP
+    /// <c>platform_events</c> stream is tracked on the distinguished
+    /// <see cref="AuditProjectorCursor.PlatformSentinel"/> row (all-zero
+    /// <c>TenantId</c>), which also carries the single-user / shared-DB
+    /// <c>cp.domain_events</c> fallback.</para>
     /// </summary>
     public static void ConfigureAuditProjectorCursor(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<AuditProjectorCursor>(entity =>
         {
             entity.ToTable("audit_projector_cursor");
-            entity.HasKey(e => e.ProjectorId);
+            // Composite key: one domain high-water mark per tenant; the platform
+            // stream lives on the all-zero sentinel row.
+            entity.HasKey(e => new { e.ProjectorId, e.TenantId });
             entity.Property(e => e.ProjectorId).IsRequired().HasMaxLength(64);
+            entity.Property(e => e.TenantId).IsRequired();
             entity.Property(e => e.LastDomainSequenceNumber).HasDefaultValue(0L);
             entity.Property(e => e.LastPlatformSequenceNumber).HasDefaultValue(0L);
             entity.Property(e => e.UpdatedAt).HasDefaultValueSql("now()");

--- a/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
@@ -630,6 +630,92 @@ internal static class TammaModelConfiguration
     }
 
     /// <summary>
+    /// Story 32-1 — configure the two CP-resident agent-entity tables
+    /// (<c>agents</c> + <c>agent_versions</c>). Called ONLY from
+    /// <see cref="ControlPlaneDbContext"/> (these are control-plane-resident;
+    /// they are NOT added to <see cref="TenantDbContext"/> — no
+    /// <c>omitTenantIdColumn</c>/<c>isTenantContext</c> branches).
+    ///
+    /// <para>The <c>ck_agents_visibility_ownership</c> CHECK mirrors
+    /// <c>ck_prompt_overrides_principal_xor</c>: it ties the
+    /// <see cref="Entities.AgentVisibility"/> discriminator (stored as int via
+    /// <c>HasConversion&lt;int&gt;()</c>) to the owner columns —
+    /// public (0) ⇒ no owner; private (1) ⇒ exactly one of tenant/user owner.
+    /// The numeric literals <c>0</c>/<c>1</c> are load-bearing and match the
+    /// enum ordinals.</para>
+    /// </summary>
+    public static void ConfigureAgentEntities(ModelBuilder modelBuilder)
+    {
+        // ── Agent (identity) ──
+        modelBuilder.Entity<Agent>(entity =>
+        {
+            entity.ToTable("agents", t =>
+            {
+                // Visibility ⇄ ownership invariant (mirrors
+                // ck_prompt_overrides_principal_xor). Visibility is stored as
+                // int: 0 = Public, 1 = Private. A private agent never has both
+                // owner columns set, and never both null; a public agent has
+                // neither.
+                t.HasCheckConstraint(
+                    "ck_agents_visibility_ownership",
+                    "(\"Visibility\" = 0 AND \"OwnerTenantId\" IS NULL AND \"OwnerUserId\" IS NULL) " +
+                    "OR (\"Visibility\" = 1 AND \"OwnerTenantId\" IS NOT NULL AND \"OwnerUserId\" IS NULL) " +
+                    "OR (\"Visibility\" = 1 AND \"OwnerUserId\" IS NOT NULL AND \"OwnerTenantId\" IS NULL)");
+            });
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+            entity.Property(e => e.Name).IsRequired().HasMaxLength(128);
+            entity.Property(e => e.Role).IsRequired().HasMaxLength(64);
+            entity.Property(e => e.Visibility).HasConversion<int>();
+            entity.Property(e => e.Status).HasConversion<int>().HasDefaultValue(AgentStatus.Active);
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("now()");
+
+            // Public handles unique on (Name, Role).
+            entity.HasIndex(e => new { e.Name, e.Role })
+                .IsUnique()
+                .HasFilter("\"Visibility\" = 0")
+                .HasDatabaseName("IX_agents_public_name_role");
+
+            // Private handles unique per owner — two tenants may each own a
+            // private agent named "atlas" without colliding.
+            entity.HasIndex(e => new { e.OwnerTenantId, e.Name })
+                .IsUnique()
+                .HasFilter("\"Visibility\" = 1 AND \"OwnerTenantId\" IS NOT NULL")
+                .HasDatabaseName("IX_agents_private_tenant_name");
+            entity.HasIndex(e => new { e.OwnerUserId, e.Name })
+                .IsUnique()
+                .HasFilter("\"Visibility\" = 1 AND \"OwnerUserId\" IS NOT NULL")
+                .HasDatabaseName("IX_agents_private_user_name");
+        });
+
+        // ── AgentVersion (immutable config snapshot) ──
+        modelBuilder.Entity<AgentVersion>(entity =>
+        {
+            entity.ToTable("agent_versions");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+            entity.Property(e => e.ConfigJson)
+                .HasColumnType("jsonb")
+                .HasDefaultValueSql("'{}'::jsonb");
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+
+            // Monotonic, non-duplicated versions per agent. Also the
+            // concurrency guard: a double-publish loses the second INSERT.
+            entity.HasIndex(e => new { e.AgentId, e.Version })
+                .IsUnique()
+                .HasDatabaseName("IX_agent_versions_agent_version");
+
+            // Versions are immutable audit history — archive, never
+            // cascade-delete.
+            entity.HasOne(e => e.Agent)
+                .WithMany(a => a.Versions)
+                .HasForeignKey(e => e.AgentId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+    }
+
+    /// <summary>
     /// Configure the per-tenant entity graph. <paramref name="fixedTenantId"/>
     /// is non-null when invoked from <see cref="TenantDbContext"/> — the
     /// query filter binds directly to that tenant (fail-closed, no ambient

--- a/apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs
@@ -67,6 +67,11 @@ public class TenantDbContext : DbContext
     public DbSet<AnalyticsUsageHourly> AnalyticsUsageHourly => Set<AnalyticsUsageHourly>();
     public DbSet<AnalyticsUsageDaily> AnalyticsUsageDaily => Set<AnalyticsUsageDaily>();
 
+    // Story 37-1 — tenant-scope curated audit trail, materialized from this
+    // tenant's domain_events stream by the AuditProjector. Platform-scope rows
+    // live in the CP audit_records.
+    public DbSet<AuditRecord> AuditRecords => Set<AuditRecord>();
+
     /// <summary>
     /// Tenant-scoped API keys (Story 28-7). The tenant DB api_keys table
     /// is locked to <c>Scope = 'tenant'</c> via a CHECK constraint; user /

--- a/apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs
@@ -62,6 +62,11 @@ public class TenantDbContext : DbContext
     public DbSet<EmailOutboxMessage> EmailOutbox => Set<EmailOutboxMessage>();
     public DbSet<BudgetConfig> BudgetConfigs => Set<BudgetConfig>();
 
+    // Story 36-1 — per-tenant dimensional analytics fact tables (hourly +
+    // daily roll-up). Schema-only; Story 36-2 owns population.
+    public DbSet<AnalyticsUsageHourly> AnalyticsUsageHourly => Set<AnalyticsUsageHourly>();
+    public DbSet<AnalyticsUsageDaily> AnalyticsUsageDaily => Set<AnalyticsUsageDaily>();
+
     /// <summary>
     /// Tenant-scoped API keys (Story 28-7). The tenant DB api_keys table
     /// is locked to <c>Scope = 'tenant'</c> via a CHECK constraint; user /

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentConfigValidatorTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentConfigValidatorTests.cs
@@ -219,4 +219,16 @@ public class AgentConfigValidatorTests
         valid.Should().BeFalse();
         errors.Should().ContainMatch("*maxFetchSizeBytes*");
     }
+
+    [Test]
+    public void Legacy_BlockedCommandPatterns_NestedQuantifier_IsRejected()
+    {
+        // ReDoS regression: a catastrophic-backtracking pattern "(a+)+" must be
+        // rejected by the ReDosGuard the validator routes blockedCommandPatterns
+        // through (finding 014).
+        var json = """{ "security": { "blockedCommandPatterns": ["(a+)+"] } }""";
+        var (valid, errors) = Validate(json);
+        valid.Should().BeFalse();
+        errors.Should().ContainMatch("*nested-quantifier*");
+    }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentConfigValidatorTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentConfigValidatorTests.cs
@@ -1,0 +1,222 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Api.Services.Agents;
+
+namespace Tamma.Api.Tests.Agents;
+
+/// <summary>
+/// Story 32-1 (Task 2) — unit tests for <see cref="AgentConfigValidator"/>,
+/// the saved-config validator extracted from the private
+/// <c>AgentEndpoints.ValidateConfigShape</c> and extended for the Epic 32
+/// saved-config fields. Covers:
+/// <list type="bullet">
+///   <item>each new rule's accept/reject (model, temperature, maxTokens,
+///     tokenBudget, tools[], systemPromptRef, rag{});</item>
+///   <item>regression on the lifted legacy rules (provider regex,
+///     maxBudgetUsd range, empty-chain, prototype-pollution, ReDoS).</item>
+/// </list>
+/// </summary>
+[TestFixture]
+public class AgentConfigValidatorTests
+{
+    private static (bool Valid, string[] Errors) Validate(string json)
+        => AgentConfigValidator.Validate(json);
+
+    // ── Empty / shape ──
+
+    [Test]
+    public void EmptyObject_IsValid()
+    {
+        Validate("{}").Valid.Should().BeTrue("an empty config falls through to defaults");
+    }
+
+    [Test]
+    public void MalformedJson_IsRejected()
+    {
+        var (valid, errors) = Validate("{ not json ");
+        valid.Should().BeFalse();
+        errors.Should().ContainMatch("*Invalid JSON*");
+    }
+
+    [Test]
+    public void NonObjectRoot_IsRejected()
+    {
+        Validate("[]").Valid.Should().BeFalse();
+    }
+
+    // ── New Epic 32 saved-config fields ──
+
+    [Test]
+    public void Valid_SavedConfig_AllNewFields_IsValid()
+    {
+        var json = """
+            {
+              "provider": "anthropic",
+              "model": "claude-sonnet-4",
+              "temperature": 0.7,
+              "maxTokens": 4096,
+              "tokenBudget": 100000,
+              "tools": ["read_file", "write_file"],
+              "systemPromptRef": "architect.system.v3",
+              "rag": { "enabled": true, "topK": 5 }
+            }
+            """;
+        Validate(json).Valid.Should().BeTrue();
+    }
+
+    [Test]
+    public void TopLevelProvider_BadName_IsRejected()
+    {
+        var (valid, errors) = Validate("""{ "provider": "BAD NAME!" }""");
+        valid.Should().BeFalse();
+        errors.Should().ContainMatch("*provider*");
+    }
+
+    [TestCase(-0.1)]
+    [TestCase(2.1)]
+    public void Temperature_OutOfRange_IsRejected(double t)
+    {
+        var (valid, errors) = Validate($$"""{ "temperature": {{t}} }""");
+        valid.Should().BeFalse();
+        errors.Should().ContainMatch("*temperature*");
+    }
+
+    [TestCase(0.0)]
+    [TestCase(1.0)]
+    [TestCase(2.0)]
+    public void Temperature_InRange_IsValid(double t)
+    {
+        Validate($$"""{ "temperature": {{t}} }""").Valid.Should().BeTrue();
+    }
+
+    [Test]
+    public void Temperature_NotANumber_IsRejected()
+    {
+        Validate("""{ "temperature": "hot" }""").Valid.Should().BeFalse();
+    }
+
+    [TestCase(0)]
+    [TestCase(-5)]
+    public void MaxTokens_NotPositive_IsRejected(int v)
+    {
+        var (valid, errors) = Validate($$"""{ "maxTokens": {{v}} }""");
+        valid.Should().BeFalse();
+        errors.Should().ContainMatch("*maxTokens*");
+    }
+
+    [Test]
+    public void MaxTokens_Positive_IsValid()
+    {
+        Validate("""{ "maxTokens": 1 }""").Valid.Should().BeTrue();
+    }
+
+    [Test]
+    public void TokenBudget_Negative_IsRejected()
+    {
+        var (valid, errors) = Validate("""{ "tokenBudget": -1 }""");
+        valid.Should().BeFalse();
+        errors.Should().ContainMatch("*tokenBudget*");
+    }
+
+    [Test]
+    public void TokenBudget_Zero_IsValid()
+    {
+        Validate("""{ "tokenBudget": 0 }""").Valid.Should().BeTrue();
+    }
+
+    [Test]
+    public void Tools_NotArray_IsRejected()
+    {
+        var (valid, errors) = Validate("""{ "tools": "read_file" }""");
+        valid.Should().BeFalse();
+        errors.Should().ContainMatch("*tools*");
+    }
+
+    [Test]
+    public void Tools_NonStringEntry_IsRejected()
+    {
+        var (valid, errors) = Validate("""{ "tools": ["ok", 42] }""");
+        valid.Should().BeFalse();
+        errors.Should().ContainMatch("*tools*");
+    }
+
+    [Test]
+    public void Model_NotString_IsRejected()
+    {
+        var (valid, errors) = Validate("""{ "model": 123 }""");
+        valid.Should().BeFalse();
+        errors.Should().ContainMatch("*model*");
+    }
+
+    [Test]
+    public void SystemPromptRef_NotString_IsRejected()
+    {
+        var (valid, errors) = Validate("""{ "systemPromptRef": [] }""");
+        valid.Should().BeFalse();
+        errors.Should().ContainMatch("*systemPromptRef*");
+    }
+
+    [Test]
+    public void Rag_NotObject_IsRejected()
+    {
+        var (valid, errors) = Validate("""{ "rag": "yes" }""");
+        valid.Should().BeFalse();
+        errors.Should().ContainMatch("*rag*");
+    }
+
+    // ── Regression: lifted legacy rules still fire ──
+
+    [Test]
+    public void Legacy_RoleProvider_BadName_IsRejected()
+    {
+        var json = """{ "roles": { "developer": { "provider": "BAD NAME" } } }""";
+        var (valid, errors) = Validate(json);
+        valid.Should().BeFalse();
+        errors.Should().ContainMatch("*provider*");
+    }
+
+    [Test]
+    public void Legacy_MaxBudgetUsd_OutOfRange_IsRejected()
+    {
+        var json = """{ "roles": { "developer": { "maxBudgetUsd": 250 } } }""";
+        var (valid, errors) = Validate(json);
+        valid.Should().BeFalse();
+        errors.Should().ContainMatch("*maxBudgetUsd*");
+    }
+
+    [Test]
+    public void Legacy_EmptyProviderChain_IsRejected()
+    {
+        var json = """{ "defaults": { "providerChain": [] } }""";
+        var (valid, errors) = Validate(json);
+        valid.Should().BeFalse();
+        errors.Should().ContainMatch("*empty*");
+    }
+
+    [Test]
+    public void Legacy_ForbiddenRoleKey_IsRejected()
+    {
+        var json = """{ "roles": { "__proto__": { "provider": "anthropic" } } }""";
+        var (valid, errors) = Validate(json);
+        valid.Should().BeFalse();
+        errors.Should().ContainMatch("*Forbidden*");
+    }
+
+    [Test]
+    public void Legacy_UnknownRole_IsRejected()
+    {
+        var json = """{ "roles": { "wizard": { "provider": "anthropic" } } }""";
+        var (valid, errors) = Validate(json);
+        valid.Should().BeFalse();
+        errors.Should().ContainMatch("*Unknown role*");
+    }
+
+    [Test]
+    public void Legacy_MaxFetchSizeBytes_OutOfRange_IsRejected()
+    {
+        var json = """{ "security": { "maxFetchSizeBytes": 9999999999 } }""";
+        var (valid, errors) = Validate(json);
+        valid.Should().BeFalse();
+        errors.Should().ContainMatch("*maxFetchSizeBytes*");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentEndpointsTests.cs
@@ -1,0 +1,449 @@
+using System.Collections.Concurrent;
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Tamma.Api.Auth;
+using Tamma.Api.Dtos.Agents;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Agents;
+
+/// <summary>
+/// Story 32-1 (Task 5) — endpoint + RBAC + cross-tenant-isolation tests for the
+/// first-class agent surface on <see cref="AgentEndpoints"/>. Drives the public
+/// endpoint methods directly against constructed
+/// <see cref="ClaimsPrincipal"/> / <see cref="ITammaModeProvider"/> stubs (the
+/// same delegates Program.cs wires into the minimal API) backed by a real
+/// Postgres testcontainer — dev-mode permissive auth short-circuits named
+/// policies, so HTTP-level RBAC is pinned via the <see cref="Permissions"/>
+/// matrix (see <see cref="AgentManagePermissionTests"/>) and per-mode + per-
+/// tenant handling is pinned by direct invocation.
+/// </summary>
+[TestFixture]
+public class AgentEndpointsTests
+{
+    private static readonly Guid TenantA = Guid.Parse("aaaaaaaa-32e1-32e1-32e1-aaaaaaaaaaaa");
+    private static readonly Guid TenantB = Guid.Parse("bbbbbbbb-32e1-32e1-32e1-bbbbbbbbbbbb");
+
+    private PostgreSqlContainer _postgres = null!;
+    private string _connectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("agent_endpoint_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _connectionString = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync("TRUNCATE agent_versions, agents CASCADE;");
+    }
+
+    private ControlPlaneDbContext NewContext()
+        => new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseNpgsql(_connectionString).Options);
+
+    private (IAgentRepository repo, ControlPlaneDbContext ctx) BuildRepo()
+    {
+        var ctx = NewContext();
+        return (new AgentRepository(ctx, new CapturingEventRepository()), ctx);
+    }
+
+    private static ITammaModeProvider Mode(TammaMode m) => new StubModeProvider(m);
+
+    private sealed class StubModeProvider(TammaMode mode) : ITammaModeProvider
+    {
+        public TammaMode Mode { get; } = mode;
+    }
+
+    private static TenantContext TenantCtx(Guid? tenantId = null)
+    {
+        var tc = new TenantContext();
+        if (tenantId is Guid t) tc.SetTenantId(t);
+        return tc;
+    }
+
+    private static ClaimsPrincipal Principal(Guid? userId = null, bool platformAdmin = false)
+    {
+        var claims = new List<Claim>();
+        if (userId is Guid uid) claims.Add(new Claim(ClaimTypes.NameIdentifier, uid.ToString()));
+        if (platformAdmin) claims.Add(new Claim("platformRole", "platform_admin"));
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
+    }
+
+    private static JsonElement Config(string json)
+        => JsonDocument.Parse(json).RootElement.Clone();
+
+    private static readonly JsonElement ValidConfig =
+        Config("""{ "provider": "anthropic", "model": "claude-sonnet-4" }""");
+
+    private static async Task<(int Status, JsonElement Body)> ExecuteAsync(IResult result)
+    {
+        var services = new ServiceCollection().AddLogging().AddOptions().BuildServiceProvider();
+        var ctx = new DefaultHttpContext
+        {
+            RequestServices = services,
+            Response = { Body = new MemoryStream() },
+        };
+        await result.ExecuteAsync(ctx);
+        ctx.Response.Body.Seek(0, SeekOrigin.Begin);
+        if (ctx.Response.Body.Length == 0)
+        {
+            return (ctx.Response.StatusCode, default);
+        }
+        using var doc = await JsonDocument.ParseAsync(ctx.Response.Body);
+        return (ctx.Response.StatusCode, doc.RootElement.Clone());
+    }
+
+    // ── Create + round-trip ──
+
+    [Test]
+    public async Task CreateAgent_Private_SaaS_SetsTenantOwner_RoundTrips()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var admin = Principal(Guid.NewGuid());
+            var req = new CreateAgentRequest("atlas", "architect", "private", ValidConfig, null);
+
+            var create = await AgentEndpoints.CreateAgent(
+                req, repo, admin, TenantCtx(TenantA), Mode(TammaMode.SaaS));
+            var (status, body) = await ExecuteAsync(create);
+
+            status.Should().Be(StatusCodes.Status201Created);
+            var id = body.GetProperty("id").GetGuid();
+            body.GetProperty("currentVersion").GetInt32().Should().Be(1);
+
+            var agent = await repo.GetByIdAsync(id);
+            agent!.OwnerTenantId.Should().Be(TenantA);
+            agent.OwnerUserId.Should().BeNull();
+            agent.Visibility.Should().Be(AgentVisibility.Private);
+        }
+    }
+
+    [Test]
+    public async Task CreateAgent_Private_SingleUser_SetsUserOwner()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var userId = Guid.NewGuid();
+            var req = new CreateAgentRequest("atlas", "architect", "private", ValidConfig, null);
+
+            var create = await AgentEndpoints.CreateAgent(
+                req, repo, Principal(userId), TenantCtx(), Mode(TammaMode.SingleUser));
+            var (status, body) = await ExecuteAsync(create);
+
+            status.Should().Be(StatusCodes.Status201Created);
+            var agent = await repo.GetByIdAsync(body.GetProperty("id").GetGuid());
+            agent!.OwnerUserId.Should().Be(userId);
+            agent.OwnerTenantId.Should().BeNull();
+        }
+    }
+
+    [Test]
+    public async Task CreateAgent_Public_AsPlatformAdmin_Succeeds()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var req = new CreateAgentRequest("tamma-architect", "architect", "public", ValidConfig, null);
+            var create = await AgentEndpoints.CreateAgent(
+                req, repo, Principal(Guid.NewGuid(), platformAdmin: true),
+                TenantCtx(), Mode(TammaMode.SaaS));
+            var (status, _) = await ExecuteAsync(create);
+            status.Should().Be(StatusCodes.Status201Created);
+        }
+    }
+
+    [Test]
+    public async Task CreateAgent_Public_AsNonPlatformAdmin_Returns403()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var req = new CreateAgentRequest("tamma-architect", "architect", "public", ValidConfig, null);
+            // tenant admin (no platformRole claim) — public create is platform-only.
+            var create = await AgentEndpoints.CreateAgent(
+                req, repo, Principal(Guid.NewGuid()), TenantCtx(TenantA), Mode(TammaMode.SaaS));
+            var (status, _) = await ExecuteAsync(create);
+            status.Should().Be(StatusCodes.Status403Forbidden);
+
+            (await ctx.Agents.CountAsync()).Should().Be(0, "no row on a rejected public create");
+        }
+    }
+
+    [Test]
+    public async Task CreateAgent_InvalidConfig_Returns400_NoRow()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var req = new CreateAgentRequest(
+                "atlas", "architect", "private",
+                Config("""{ "temperature": 9 }"""), null);
+            var create = await AgentEndpoints.CreateAgent(
+                req, repo, Principal(Guid.NewGuid()), TenantCtx(TenantA), Mode(TammaMode.SaaS));
+            var (status, _) = await ExecuteAsync(create);
+
+            status.Should().Be(StatusCodes.Status400BadRequest);
+            (await ctx.Agents.CountAsync()).Should().Be(0);
+        }
+    }
+
+    [Test]
+    public async Task CreateAgent_InvalidRole_Returns400()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var req = new CreateAgentRequest("x", "wizard", "private", ValidConfig, null);
+            var create = await AgentEndpoints.CreateAgent(
+                req, repo, Principal(Guid.NewGuid()), TenantCtx(TenantA), Mode(TammaMode.SaaS));
+            var (status, _) = await ExecuteAsync(create);
+            status.Should().Be(StatusCodes.Status400BadRequest);
+        }
+    }
+
+    [Test]
+    public async Task CreateAgent_DuplicatePublicHandle_Returns409()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var pa = Principal(Guid.NewGuid(), platformAdmin: true);
+            var req = new CreateAgentRequest("tamma-architect", "architect", "public", ValidConfig, null);
+
+            await ExecuteAsync(await AgentEndpoints.CreateAgent(req, repo, pa, TenantCtx(), Mode(TammaMode.SaaS)));
+            var (status, _) = await ExecuteAsync(
+                await AgentEndpoints.CreateAgent(req, repo, pa, TenantCtx(), Mode(TammaMode.SaaS)));
+
+            status.Should().Be(StatusCodes.Status409Conflict);
+        }
+    }
+
+    // ── Publish + Get round-trip ──
+
+    [Test]
+    public async Task PublishVersion_Then_GetVersion_RoundTrips()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var admin = Principal(Guid.NewGuid());
+            var created = await ExecuteAsync(await AgentEndpoints.CreateAgent(
+                new CreateAgentRequest("atlas", "architect", "private", ValidConfig, null),
+                repo, admin, TenantCtx(TenantA), Mode(TammaMode.SaaS)));
+            var id = created.Body.GetProperty("id").GetGuid();
+
+            var pub = await AgentEndpoints.PublishVersion(
+                id, new PublishVersionRequest(Config("""{ "model": "v2" }"""), "second"),
+                repo, admin, TenantCtx(TenantA), Mode(TammaMode.SaaS));
+            var (pubStatus, pubBody) = await ExecuteAsync(pub);
+            pubStatus.Should().Be(StatusCodes.Status200OK);
+            pubBody.GetProperty("version").GetInt32().Should().Be(2);
+
+            var get = await AgentEndpoints.GetVersion(
+                id, 2, repo, admin, TenantCtx(TenantA), Mode(TammaMode.SaaS));
+            var (getStatus, getBody) = await ExecuteAsync(get);
+            getStatus.Should().Be(StatusCodes.Status200OK);
+            getBody.GetProperty("config").GetProperty("model").GetString().Should().Be("v2");
+        }
+    }
+
+    // ── List = public ∪ own private ──
+
+    [Test]
+    public async Task ListAgents_Returns_Public_Union_OwnPrivate()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var pa = Principal(Guid.NewGuid(), platformAdmin: true);
+            var adminA = Principal(Guid.NewGuid());
+            await ExecuteAsync(await AgentEndpoints.CreateAgent(
+                new CreateAgentRequest("tamma-architect", "architect", "public", ValidConfig, null),
+                repo, pa, TenantCtx(), Mode(TammaMode.SaaS)));
+            await ExecuteAsync(await AgentEndpoints.CreateAgent(
+                new CreateAgentRequest("atlas-a", "architect", "private", ValidConfig, null),
+                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS)));
+            await ExecuteAsync(await AgentEndpoints.CreateAgent(
+                new CreateAgentRequest("atlas-b", "architect", "private", ValidConfig, null),
+                repo, Principal(Guid.NewGuid()), TenantCtx(TenantB), Mode(TammaMode.SaaS)));
+
+            var list = await AgentEndpoints.ListAgents(
+                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS));
+            var (status, body) = await ExecuteAsync(list);
+            status.Should().Be(StatusCodes.Status200OK);
+
+            var names = body.EnumerateArray().Select(e => e.GetProperty("name").GetString()).ToList();
+            names.Should().Contain("tamma-architect");
+            names.Should().Contain("atlas-a");
+            names.Should().NotContain("atlas-b", "tenant A must not see tenant B's private agent");
+        }
+    }
+
+    // ── Cross-tenant isolation: GET {id} for another tenant's private → 404 ──
+
+    [Test]
+    public async Task GetAgent_OtherTenantsPrivate_Returns404_NotForbidden()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var created = await ExecuteAsync(await AgentEndpoints.CreateAgent(
+                new CreateAgentRequest("atlas", "architect", "private", ValidConfig, null),
+                repo, Principal(Guid.NewGuid()), TenantCtx(TenantA), Mode(TammaMode.SaaS)));
+            var aAtlasId = created.Body.GetProperty("id").GetGuid();
+
+            // Tenant B fetches tenant A's private agent → 404 (not 403).
+            var get = await AgentEndpoints.GetAgent(
+                aAtlasId, repo, Principal(Guid.NewGuid()), TenantCtx(TenantB), Mode(TammaMode.SaaS));
+            var (status, _) = await ExecuteAsync(get);
+            status.Should().Be(StatusCodes.Status404NotFound);
+        }
+    }
+
+    [Test]
+    public async Task PublishVersion_OnOtherTenantsPrivate_Returns404()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var created = await ExecuteAsync(await AgentEndpoints.CreateAgent(
+                new CreateAgentRequest("atlas", "architect", "private", ValidConfig, null),
+                repo, Principal(Guid.NewGuid()), TenantCtx(TenantA), Mode(TammaMode.SaaS)));
+            var aAtlasId = created.Body.GetProperty("id").GetGuid();
+
+            var pub = await AgentEndpoints.PublishVersion(
+                aAtlasId, new PublishVersionRequest(ValidConfig, null),
+                repo, Principal(Guid.NewGuid()), TenantCtx(TenantB), Mode(TammaMode.SaaS));
+            var (status, _) = await ExecuteAsync(pub);
+            status.Should().Be(StatusCodes.Status404NotFound,
+                "an un-owned private agent must 404 (not 403) on write — don't leak existence");
+        }
+    }
+
+    [Test]
+    public async Task TwoTenants_MayEachOwn_PrivateAtlas_ViaEndpoint()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var a = await ExecuteAsync(await AgentEndpoints.CreateAgent(
+                new CreateAgentRequest("atlas", "architect", "private", ValidConfig, null),
+                repo, Principal(Guid.NewGuid()), TenantCtx(TenantA), Mode(TammaMode.SaaS)));
+            var b = await ExecuteAsync(await AgentEndpoints.CreateAgent(
+                new CreateAgentRequest("atlas", "architect", "private", ValidConfig, null),
+                repo, Principal(Guid.NewGuid()), TenantCtx(TenantB), Mode(TammaMode.SaaS)));
+
+            a.Status.Should().Be(StatusCodes.Status201Created);
+            b.Status.Should().Be(StatusCodes.Status201Created,
+                "the per-owner partial index allows both tenants to own a private 'atlas'");
+        }
+    }
+
+    // ── Archive ──
+
+    [Test]
+    public async Task ArchiveAgent_OwnPrivate_Returns200()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var admin = Principal(Guid.NewGuid());
+            var created = await ExecuteAsync(await AgentEndpoints.CreateAgent(
+                new CreateAgentRequest("atlas", "architect", "private", ValidConfig, null),
+                repo, admin, TenantCtx(TenantA), Mode(TammaMode.SaaS)));
+            var id = created.Body.GetProperty("id").GetGuid();
+
+            var arch = await AgentEndpoints.ArchiveAgent(
+                id, repo, admin, TenantCtx(TenantA), Mode(TammaMode.SaaS));
+            var (status, body) = await ExecuteAsync(arch);
+            status.Should().Be(StatusCodes.Status200OK);
+            body.GetProperty("status").GetString().Should().Be("archived");
+        }
+    }
+
+    /// <summary>Capturing event repo (no real tenant DB needed for endpoint tests).</summary>
+    private sealed class CapturingEventRepository : IEventRepository
+    {
+        private readonly ConcurrentQueue<DomainEvent> _events = new();
+        public Task<DomainEvent> AppendAsync(DomainEvent evt)
+        {
+            _events.Enqueue(evt);
+            return Task.FromResult(evt);
+        }
+        public Task<DomainEvent?> GetByIdAsync(Guid id) => Task.FromResult<DomainEvent?>(null);
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit) =>
+            Task.FromResult(_events.ToList());
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type) =>
+            Task.FromResult<DomainEvent?>(null);
+        public Task ClearAsync(Guid tenantId) => Task.CompletedTask;
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(
+            Guid? tenantId, string? type, int? issueNumber, int limit, int offset) =>
+            Task.FromResult(((IReadOnlyList<DomainEvent>)_events.ToList(), _events.Count));
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(
+            Guid tenantId, string? typePrefix, int limit, int offset) =>
+            Task.FromResult(((IReadOnlyList<DomainEvent>)_events.ToList(), _events.Count));
+    }
+}
+
+/// <summary>
+/// Story 32-1 — pins the <c>agents:manage</c> permission contract added to the
+/// role matrix. CLAUDE.md "Prompt Store Architecture / RBAC" (agents follow the
+/// same tenant-scoped RBAC) requires create/publish/archive of a PRIVATE agent
+/// to be reachable by tenant_owner OR tenant_admin; member-role callers get 403.
+/// </summary>
+[TestFixture]
+public class AgentManagePermissionTests
+{
+    [Test]
+    public void Owner_CanManageAgents()
+        => Permissions.HasPermission("owner", "agents:manage").Should().BeTrue();
+
+    [Test]
+    public void Admin_CanManageAgents()
+        => Permissions.HasPermission("admin", "agents:manage").Should().BeTrue(
+            "private agent create/publish/archive must be reachable by tenant_admin");
+
+    [Test]
+    public void Member_CannotManageAgents()
+        => Permissions.HasPermission("member", "agents:manage").Should().BeFalse(
+            "member users get 403 on agent writes in SaaS mode");
+
+    [Test]
+    public void GetRolePermissions_Member_ExcludesAgentsManage()
+        => Permissions.GetRolePermissions("member").Should().NotContain("agents:manage");
+
+    [Test]
+    public void GetRolePermissions_Admin_IncludesAgentsManage()
+        => Permissions.GetRolePermissions("admin").Should().Contain("agents:manage");
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentEntityMappingTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentEntityMappingTests.cs
@@ -1,0 +1,243 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using NUnit.Framework;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Agents;
+
+/// <summary>
+/// Story 32-1 (Task 1) — Postgres-bound mapping tests for the
+/// <see cref="Agent"/> / <see cref="AgentVersion"/> control-plane entities.
+/// Applies the real <see cref="ControlPlaneDbContext"/> migration to a fresh
+/// testcontainer so the <c>ck_agents_visibility_ownership</c> CHECK + partial
+/// unique indexes physically exist, then asserts:
+/// <list type="bullet">
+///   <item>a valid public row and a valid private row insert cleanly;</item>
+///   <item>the CHECK rejects public-with-owner, private-with-no-owner, and
+///     private-with-both-owners on <c>SaveChanges</c>;</item>
+///   <item>two tenants may each own a private agent named <c>atlas</c>
+///     (the partial unique index does not collide across owners).</item>
+/// </list>
+///
+/// <para>Why Postgres, not EF-InMemory: the InMemory provider does not enforce
+/// CHECK constraints or partial unique indexes, so the invariant under test
+/// would pass silently. A real Postgres connection is the only thing that
+/// exposes a CHECK violation as <see cref="DbUpdateException"/>.</para>
+/// </summary>
+[TestFixture]
+public class AgentEntityMappingTests
+{
+    private static readonly Guid TenantA = Guid.Parse("aaaaaaaa-3232-3232-3232-aaaaaaaaaaaa");
+    private static readonly Guid TenantB = Guid.Parse("bbbbbbbb-3232-3232-3232-bbbbbbbbbbbb");
+    private static readonly Guid UserA = Guid.Parse("cccccccc-3232-3232-3232-cccccccccccc");
+
+    private PostgreSqlContainer _postgres = null!;
+    private string _connectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("agent_entity_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _connectionString = _postgres.GetConnectionString();
+
+        // Apply the full CP migration bundle so the agents/agent_versions
+        // tables exist with the CHECK + indexes exactly as production ships.
+        await using var ctx = CreateContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "TRUNCATE agent_versions, agents CASCADE;";
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private ControlPlaneDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseNpgsql(_connectionString)
+            .Options;
+        return new ControlPlaneDbContext(options);
+    }
+
+    private static Agent NewAgent(
+        string name,
+        AgentVisibility visibility,
+        Guid? ownerTenantId = null,
+        Guid? ownerUserId = null,
+        string role = "architect") => new()
+    {
+        Id = Guid.NewGuid(),
+        Name = name,
+        Role = role,
+        Visibility = visibility,
+        OwnerTenantId = ownerTenantId,
+        OwnerUserId = ownerUserId,
+        Status = AgentStatus.Active,
+        CreatedAt = DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow,
+    };
+
+    // ── Valid inserts ──
+
+    [Test]
+    public async Task Insert_PublicAgent_WithNoOwner_Succeeds()
+    {
+        await using var ctx = CreateContext();
+        ctx.Agents.Add(NewAgent("tamma-architect", AgentVisibility.Public));
+
+        var act = async () => await ctx.SaveChangesAsync();
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Test]
+    public async Task Insert_PrivateAgent_WithTenantOwner_Succeeds()
+    {
+        await using var ctx = CreateContext();
+        ctx.Agents.Add(NewAgent("atlas", AgentVisibility.Private, ownerTenantId: TenantA));
+
+        var act = async () => await ctx.SaveChangesAsync();
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Test]
+    public async Task Insert_PrivateAgent_WithUserOwner_Succeeds()
+    {
+        await using var ctx = CreateContext();
+        ctx.Agents.Add(NewAgent("atlas", AgentVisibility.Private, ownerUserId: UserA));
+
+        var act = async () => await ctx.SaveChangesAsync();
+
+        await act.Should().NotThrowAsync();
+    }
+
+    // ── CHECK rejections ──
+
+    [Test]
+    public async Task Insert_PublicAgent_WithOwner_IsRejectedByCheck()
+    {
+        await using var ctx = CreateContext();
+        ctx.Agents.Add(NewAgent("bad-public", AgentVisibility.Public, ownerTenantId: TenantA));
+
+        await AssertSqlStateAsync(ctx, PostgresErrorCodes.CheckViolation);
+    }
+
+    [Test]
+    public async Task Insert_PrivateAgent_WithNoOwner_IsRejectedByCheck()
+    {
+        await using var ctx = CreateContext();
+        ctx.Agents.Add(NewAgent("orphan-private", AgentVisibility.Private));
+
+        await AssertSqlStateAsync(ctx, PostgresErrorCodes.CheckViolation);
+    }
+
+    [Test]
+    public async Task Insert_PrivateAgent_WithBothOwners_IsRejectedByCheck()
+    {
+        await using var ctx = CreateContext();
+        ctx.Agents.Add(NewAgent(
+            "double-owner", AgentVisibility.Private,
+            ownerTenantId: TenantA, ownerUserId: UserA));
+
+        await AssertSqlStateAsync(ctx, PostgresErrorCodes.CheckViolation);
+    }
+
+    /// <summary>
+    /// Save the context and assert it throws a <see cref="DbUpdateException"/>
+    /// whose inner <see cref="PostgresException"/> carries
+    /// <paramref name="expectedSqlState"/>. Captures the exception then asserts
+    /// on the inner exception directly (FluentAssertions' fluent
+    /// <c>WithInnerException</c> chaining is not available off an awaited
+    /// <c>ThrowAsync</c> result).
+    /// </summary>
+    private static Task AssertSqlStateAsync(
+        ControlPlaneDbContext ctx, string expectedSqlState)
+    {
+        var ex = Assert.CatchAsync<DbUpdateException>(
+            async () => await ctx.SaveChangesAsync());
+        ex.Should().NotBeNull();
+        ex!.InnerException.Should().BeOfType<PostgresException>()
+            .Which.SqlState.Should().Be(expectedSqlState);
+        return Task.CompletedTask;
+    }
+
+    // ── Partial unique index: two tenants may each own a private "atlas" ──
+
+    [Test]
+    public async Task TwoTenants_MayEachOwn_PrivateAgent_NamedAtlas()
+    {
+        await using (var ctx = CreateContext())
+        {
+            ctx.Agents.Add(NewAgent("atlas", AgentVisibility.Private, ownerTenantId: TenantA));
+            ctx.Agents.Add(NewAgent("atlas", AgentVisibility.Private, ownerTenantId: TenantB));
+            var act = async () => await ctx.SaveChangesAsync();
+            await act.Should().NotThrowAsync(
+                "the private per-owner partial index keys on (OwnerTenantId, Name) "
+                + "so two tenants' 'atlas' agents do not collide");
+        }
+
+        await using var verify = CreateContext();
+        var count = await verify.Agents.CountAsync(a => a.Name == "atlas");
+        count.Should().Be(2);
+    }
+
+    [Test]
+    public async Task SameTenant_CannotOwn_TwoPrivateAgents_WithSameName()
+    {
+        await using var ctx = CreateContext();
+        ctx.Agents.Add(NewAgent("atlas", AgentVisibility.Private, ownerTenantId: TenantA));
+        ctx.Agents.Add(NewAgent("atlas", AgentVisibility.Private, ownerTenantId: TenantA));
+
+        await AssertSqlStateAsync(ctx, PostgresErrorCodes.UniqueViolation);
+    }
+
+    // ── Version monotonicity guard (the (AgentId, Version) unique index) ──
+
+    [Test]
+    public async Task Duplicate_AgentVersion_IsRejectedByUniqueIndex()
+    {
+        var agentId = Guid.NewGuid();
+        await using (var seed = CreateContext())
+        {
+            var agent = NewAgent("tamma-tester", AgentVisibility.Public, role: "tester");
+            agent.Id = agentId;
+            seed.Agents.Add(agent);
+            seed.AgentVersions.Add(new AgentVersion
+            {
+                Id = Guid.NewGuid(), AgentId = agentId, Version = 1,
+                ConfigJson = "{}", CreatedAt = DateTime.UtcNow,
+            });
+            await seed.SaveChangesAsync();
+        }
+
+        await using var ctx = CreateContext();
+        ctx.AgentVersions.Add(new AgentVersion
+        {
+            Id = Guid.NewGuid(), AgentId = agentId, Version = 1,
+            ConfigJson = "{}", CreatedAt = DateTime.UtcNow,
+        });
+
+        await AssertSqlStateAsync(ctx, PostgresErrorCodes.UniqueViolation);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentEntitySeederTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentEntitySeederTests.cs
@@ -1,0 +1,167 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using Tamma.Api.Services.Agents;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Seeders;
+
+namespace Tamma.Api.Tests.Agents;
+
+/// <summary>
+/// Story 32-1 (Task 4) — idempotency + correctness tests for
+/// <see cref="AgentEntitySeeder"/>. The seeder creates one public agent per
+/// canonical role with the <c>tamma-&lt;role&gt;</c> handle + a <c>Version=1</c>
+/// snapshot, reusing the shipped config values. Re-running inserts nothing
+/// (skip-by-existing-handle).
+///
+/// <para>Runs against a Postgres testcontainer applying the real CP migration,
+/// so the partial unique index on public <c>(Name, Role)</c> is enforced — the
+/// idempotency contract is proven structurally, not just by the EXISTS check.</para>
+/// </summary>
+[TestFixture]
+public class AgentEntitySeederTests
+{
+    private Testcontainers.PostgreSql.PostgreSqlContainer _postgres = null!;
+    private string _connectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new Testcontainers.PostgreSql.PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("agent_seeder_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _connectionString = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync("TRUNCATE agent_versions, agents CASCADE;");
+    }
+
+    private ControlPlaneDbContext NewContext()
+        => new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseNpgsql(_connectionString).Options);
+
+    [Test]
+    public async Task FirstRun_Creates_OnePublicAgentPerRole_WithTammaHandles_AndVersion1()
+    {
+        await using (var ctx = NewContext())
+        {
+            await AgentEntitySeeder.SeedAsync(ctx);
+        }
+
+        await using var verify = NewContext();
+        var agents = await verify.Agents.ToListAsync();
+
+        // One per canonical role (8 roles in the AgentRole taxonomy).
+        agents.Should().HaveCount(RolePhaseMap.ValidRoles.Count);
+        agents.Should().OnlyContain(a => a.Visibility == AgentVisibility.Public);
+        agents.Should().OnlyContain(a => a.OwnerTenantId == null && a.OwnerUserId == null);
+
+        // Handles are tamma-<role>, one per valid role.
+        var names = agents.Select(a => a.Name).ToHashSet();
+        foreach (var role in RolePhaseMap.ValidRoles)
+        {
+            names.Should().Contain($"tamma-{role}");
+        }
+
+        // Each agent has exactly one Version=1 snapshot, and CurrentVersionId
+        // points at it.
+        foreach (var a in agents)
+        {
+            var versions = await verify.AgentVersions
+                .Where(v => v.AgentId == a.Id).ToListAsync();
+            versions.Should().ContainSingle();
+            versions[0].Version.Should().Be(1);
+            a.CurrentVersionId.Should().Be(versions[0].Id);
+        }
+    }
+
+    [Test]
+    public async Task SecondRun_IsNoop_CountUnchanged()
+    {
+        await using (var ctx = NewContext())
+        {
+            await AgentEntitySeeder.SeedAsync(ctx);
+        }
+
+        int agentCountAfterFirst;
+        await using (var verify1 = NewContext())
+        {
+            agentCountAfterFirst = await verify1.Agents.CountAsync();
+        }
+
+        // Second run.
+        await using (var ctx2 = NewContext())
+        {
+            await AgentEntitySeeder.SeedAsync(ctx2);
+        }
+
+        await using var verify2 = NewContext();
+        var agentCountAfterSecond = await verify2.Agents.CountAsync();
+        var versionCount = await verify2.AgentVersions.CountAsync();
+
+        agentCountAfterSecond.Should().Be(agentCountAfterFirst,
+            "re-running the seeder inserts nothing (skip-by-existing-handle)");
+        versionCount.Should().Be(agentCountAfterFirst,
+            "no duplicate Version=1 rows on re-run");
+    }
+
+    [Test]
+    public async Task SeededConfigs_AllValidate()
+    {
+        await using (var ctx = NewContext())
+        {
+            await AgentEntitySeeder.SeedAsync(ctx);
+        }
+
+        await using var verify = NewContext();
+        var versions = await verify.AgentVersions.ToListAsync();
+
+        versions.Should().NotBeEmpty();
+        foreach (var v in versions)
+        {
+            var (valid, errors) = AgentConfigValidator.Validate(v.ConfigJson);
+            valid.Should().BeTrue(
+                "every seeded public-agent config must pass the saved-config validator; "
+                + "errors: {0}", string.Join("; ", errors));
+        }
+    }
+
+    [Test]
+    public async Task SeededConfig_PreservesShippedValues()
+    {
+        await using (var ctx = NewContext())
+        {
+            await AgentEntitySeeder.SeedAsync(ctx);
+        }
+
+        await using var verify = NewContext();
+        var architect = await verify.Agents.FirstAsync(a => a.Name == "tamma-architect");
+        var version = await verify.AgentVersions.FirstAsync(v => v.AgentId == architect.Id);
+
+        using var doc = System.Text.Json.JsonDocument.Parse(version.ConfigJson);
+        var root = doc.RootElement;
+        // Shipped architect values from the legacy AgentSeeder: temperature 0.3,
+        // maxTokens 4096, provider chain anthropic→openai→openrouter.
+        root.GetProperty("temperature").GetDouble().Should().BeApproximately(0.3, 0.001);
+        root.GetProperty("maxTokens").GetInt32().Should().Be(4096);
+        root.GetProperty("providerChain").GetArrayLength().Should().BeGreaterThan(0);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentRepositoryTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentRepositoryTests.cs
@@ -119,6 +119,8 @@ public class AgentRepositoryTests
             tags["version"].GetInt32().Should().Be(1);
             tags["visibility"].GetString().Should().Be("public");
             tags["role"].GetString().Should().Be("architect");
+            tags["mode"].GetString().Should().Be(
+                "platform", "a public agent is platform-owned, not a saas tenant agent");
             evt.TenantId.Should().BeNull("public agents emit to the platform feed");
         }
     }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentRepositoryTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentRepositoryTests.cs
@@ -1,0 +1,447 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using Tamma.Core;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Agents;
+
+/// <summary>
+/// Story 32-1 (Task 3) — repository tests for <see cref="AgentRepository"/>
+/// against a real Postgres testcontainer (so the versioning transaction, the
+/// <c>(AgentId, Version)</c> unique index that guards concurrent publishes, and
+/// the ownership CHECK all behave like production). DCB emission is asserted
+/// via a capturing <see cref="IEventRepository"/> fake (the real routing is
+/// covered by EventRepository's own tests).
+///
+/// Covers: version increment 1→2→3 + monotonicity; rollback-pointer integrity;
+/// prior versions still fetchable; concurrent double-publish race → monotonic,
+/// no dup; archive idempotency; per-transition event emission; no event on
+/// validation/transaction failure; per-mode principal derivation; ownership
+/// guard rejection.
+/// </summary>
+[TestFixture]
+public class AgentRepositoryTests
+{
+    private static readonly Guid TenantA = Guid.Parse("aaaaaaaa-3201-3201-3201-aaaaaaaaaaaa");
+    private static readonly Guid UserA = Guid.Parse("cccccccc-3201-3201-3201-cccccccccccc");
+
+    private PostgreSqlContainer _postgres = null!;
+    private string _connectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("agent_repo_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _connectionString = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync("TRUNCATE agent_versions, agents CASCADE;");
+    }
+
+    private ControlPlaneDbContext NewContext()
+        => new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseNpgsql(_connectionString).Options);
+
+    private (AgentRepository repo, CapturingEventRepository events, ControlPlaneDbContext ctx)
+        BuildRepo()
+    {
+        var ctx = NewContext();
+        var events = new CapturingEventRepository();
+        return (new AgentRepository(ctx, events), events, ctx);
+    }
+
+    private static Agent NewPublicAgent(string name = "tamma-architect", string role = "architect")
+        => new() { Name = name, Role = role, Visibility = AgentVisibility.Public };
+
+    private static Agent NewTenantAgent(string name = "atlas", string role = "architect")
+        => new()
+        {
+            Name = name, Role = role, Visibility = AgentVisibility.Private,
+            OwnerTenantId = TenantA,
+        };
+
+    private static Agent NewUserAgent(string name = "atlas", string role = "architect")
+        => new()
+        {
+            Name = name, Role = role, Visibility = AgentVisibility.Private,
+            OwnerUserId = UserA,
+        };
+
+    private const string ValidConfig = """{ "provider": "anthropic", "model": "claude-sonnet-4" }""";
+
+    // ── CreateAsync ──
+
+    [Test]
+    public async Task CreateAsync_Writes_Agent_And_Version1_SetsPointer_EmitsOneEvent()
+    {
+        var (repo, events, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var created = await repo.CreateAsync(NewPublicAgent(), ValidConfig, "first", null);
+
+            created.CurrentVersionId.Should().NotBeNull();
+
+            var v1 = await repo.GetVersionAsync(created.Id, 1);
+            v1.Should().NotBeNull();
+            v1!.Version.Should().Be(1);
+            created.CurrentVersionId.Should().Be(v1.Id);
+
+            events.Events.Should().ContainSingle();
+            var evt = events.Events.Single();
+            evt.Type.Should().Be("AGENT.CREATED.SUCCESS");
+            var tags = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(evt.Tags)!;
+            tags["agentId"].GetString().Should().Be(created.Id.ToString());
+            tags["version"].GetInt32().Should().Be(1);
+            tags["visibility"].GetString().Should().Be("public");
+            tags["role"].GetString().Should().Be("architect");
+            evt.TenantId.Should().BeNull("public agents emit to the platform feed");
+        }
+    }
+
+    [Test]
+    public async Task CreateAsync_PrivateTenantAgent_EmitsEvent_WithOwnerTenant()
+    {
+        var (repo, events, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var created = await repo.CreateAsync(NewTenantAgent(), ValidConfig, null, null);
+
+            var evt = events.Events.Single();
+            evt.TenantId.Should().Be(TenantA);
+            var tags = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(evt.Tags)!;
+            tags["ownerTenantId"].GetString().Should().Be(TenantA.ToString());
+            tags["mode"].GetString().Should().Be("saas");
+            tags.Should().NotContainKey("ownerUserId");
+        }
+    }
+
+    [Test]
+    public async Task CreateAsync_PrivateUserAgent_EmitsEvent_SingleUserMode()
+    {
+        var (repo, events, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            await repo.CreateAsync(NewUserAgent(), ValidConfig, null, null);
+
+            var tags = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(
+                events.Events.Single().Tags)!;
+            tags["ownerUserId"].GetString().Should().Be(UserA.ToString());
+            tags["mode"].GetString().Should().Be("single-user");
+            tags.Should().NotContainKey("ownerTenantId");
+        }
+    }
+
+    [Test]
+    public async Task CreateAsync_EmptyConfig_Throws_NoRow_NoEvent()
+    {
+        var (repo, events, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var act = async () => await repo.CreateAsync(NewPublicAgent(), "  ", null, null);
+            await act.Should().ThrowAsync<TammaError>();
+
+            events.Events.Should().BeEmpty();
+            (await ctx.Agents.CountAsync()).Should().Be(0);
+        }
+    }
+
+    // ── Ownership guard (entity-level, before the DB CHECK) ──
+
+    [Test]
+    public async Task CreateAsync_PublicWithOwner_Throws_OwnershipGuard()
+    {
+        var (repo, events, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var bad = NewPublicAgent();
+            bad.OwnerTenantId = TenantA;
+            var act = async () => await repo.CreateAsync(bad, ValidConfig, null, null);
+
+            (await act.Should().ThrowAsync<TammaError>())
+                .Which.Code.Should().Be("AGENT.OWNERSHIP.PUBLIC_WITH_OWNER");
+            events.Events.Should().BeEmpty();
+            (await ctx.Agents.CountAsync()).Should().Be(0);
+        }
+    }
+
+    [Test]
+    public async Task CreateAsync_PrivateWithNoOwner_Throws_OwnershipGuard()
+    {
+        var (repo, events, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var bad = new Agent { Name = "x", Role = "architect", Visibility = AgentVisibility.Private };
+            var act = async () => await repo.CreateAsync(bad, ValidConfig, null, null);
+
+            (await act.Should().ThrowAsync<TammaError>())
+                .Which.Code.Should().Be("AGENT.OWNERSHIP.PRIVATE_PRINCIPAL");
+            events.Events.Should().BeEmpty();
+        }
+    }
+
+    [Test]
+    public async Task CreateAsync_PrivateWithBothOwners_Throws_OwnershipGuard()
+    {
+        var (repo, events, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var bad = new Agent
+            {
+                Name = "x", Role = "architect", Visibility = AgentVisibility.Private,
+                OwnerTenantId = TenantA, OwnerUserId = UserA,
+            };
+            var act = async () => await repo.CreateAsync(bad, ValidConfig, null, null);
+
+            (await act.Should().ThrowAsync<TammaError>())
+                .Which.Code.Should().Be("AGENT.OWNERSHIP.PRIVATE_PRINCIPAL");
+            events.Events.Should().BeEmpty();
+        }
+    }
+
+    // ── PublishVersionAsync ──
+
+    [Test]
+    public async Task PublishVersionAsync_Increments_Monotonically_1_2_3()
+    {
+        var (repo, events, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var agent = await repo.CreateAsync(NewPublicAgent(), ValidConfig, null, null);
+
+            var v2 = await repo.PublishVersionAsync(agent.Id, ValidConfig, "v2", null);
+            var v3 = await repo.PublishVersionAsync(agent.Id, ValidConfig, "v3", null);
+
+            v2!.Version.Should().Be(2);
+            v3!.Version.Should().Be(3);
+
+            var versions = await repo.ListVersionsAsync(agent.Id);
+            versions.Select(v => v.Version).Should().Equal(1, 2, 3);
+
+            // Pointer follows the highest version.
+            var reloaded = await repo.GetByIdAsync(agent.Id);
+            reloaded!.CurrentVersionId.Should().Be(v3.Id);
+
+            // One create + two publish events.
+            events.Events.Select(e => e.Type).Should().Equal(
+                "AGENT.CREATED.SUCCESS",
+                "AGENT.VERSION_PUBLISHED.SUCCESS",
+                "AGENT.VERSION_PUBLISHED.SUCCESS");
+        }
+    }
+
+    [Test]
+    public async Task PublishVersionAsync_PriorVersions_RemainFetchable()
+    {
+        var (repo, _, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var agent = await repo.CreateAsync(
+                NewPublicAgent(), """{ "model": "v1" }""", null, null);
+            await repo.PublishVersionAsync(agent.Id, """{ "model": "v2" }""", null, null);
+
+            var v1 = await repo.GetVersionAsync(agent.Id, 1);
+            v1!.ConfigJson.Should().Contain("v1", "the immutable v1 snapshot is untouched");
+        }
+    }
+
+    [Test]
+    public async Task RollbackPointer_RepointToOlderVersion_LeavesAllVersionsIntact()
+    {
+        var (repo, _, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var agent = await repo.CreateAsync(NewPublicAgent(), """{ "model": "v1" }""", null, null);
+            await repo.PublishVersionAsync(agent.Id, """{ "model": "v2" }""", null, null);
+
+            // Simulate a rollback: repoint CurrentVersionId back to v1.
+            var v1 = await repo.GetVersionAsync(agent.Id, 1);
+            var entity = await ctx.Agents.FirstAsync(a => a.Id == agent.Id);
+            entity.CurrentVersionId = v1!.Id;
+            await ctx.SaveChangesAsync();
+
+            // All versions remain.
+            (await repo.ListVersionsAsync(agent.Id)).Should().HaveCount(2);
+            var reloaded = await repo.GetByIdAsync(agent.Id);
+            reloaded!.CurrentVersionId.Should().Be(v1.Id);
+        }
+    }
+
+    [Test]
+    public async Task PublishVersionAsync_UnknownAgent_ReturnsNull_NoEvent()
+    {
+        var (repo, events, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var result = await repo.PublishVersionAsync(Guid.NewGuid(), ValidConfig, null, null);
+            result.Should().BeNull();
+            events.Events.Should().BeEmpty();
+        }
+    }
+
+    [Test]
+    public async Task PublishVersionAsync_ConcurrentDoublePublish_IsMonotonic_NoDuplicate()
+    {
+        // Seed once.
+        Guid agentId;
+        await using (var seed = NewContext())
+        {
+            var repo = new AgentRepository(seed, new CapturingEventRepository());
+            var agent = await repo.CreateAsync(NewPublicAgent(), ValidConfig, null, null);
+            agentId = agent.Id;
+        }
+
+        // Two repositories (each its own CP context) race to publish v2.
+        await using var ctxA = NewContext();
+        await using var ctxB = NewContext();
+        var repoA = new AgentRepository(ctxA, new CapturingEventRepository());
+        var repoB = new AgentRepository(ctxB, new CapturingEventRepository());
+
+        var taskA = repoA.PublishVersionAsync(agentId, ValidConfig, "A", null);
+        var taskB = repoB.PublishVersionAsync(agentId, ValidConfig, "B", null);
+        var results = await Task.WhenAll(taskA, taskB);
+
+        // Both succeed (retry resolves the (AgentId, Version) collision); the
+        // two published versions are distinct and monotonic.
+        results.Should().AllSatisfy(r => r.Should().NotBeNull());
+        var versions = results.Select(r => r!.Version).OrderBy(v => v).ToArray();
+        versions.Should().Equal(2, 3);
+
+        await using var verify = NewContext();
+        var rows = await verify.AgentVersions
+            .Where(v => v.AgentId == agentId).Select(v => v.Version).ToListAsync();
+        rows.Should().BeEquivalentTo(new[] { 1, 2, 3 });
+        rows.Should().OnlyHaveUniqueItems("the unique index forbids duplicate versions");
+    }
+
+    // ── ArchiveAsync ──
+
+    [Test]
+    public async Task ArchiveAsync_SetsArchived_EmitsOneEvent()
+    {
+        var (repo, events, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var agent = await repo.CreateAsync(NewPublicAgent(), ValidConfig, null, null);
+            events.Clear();
+
+            var archived = await repo.ArchiveAsync(agent.Id, null);
+
+            archived!.Status.Should().Be(AgentStatus.Archived);
+            events.Events.Should().ContainSingle()
+                .Which.Type.Should().Be("AGENT.ARCHIVED.SUCCESS");
+        }
+    }
+
+    [Test]
+    public async Task ArchiveAsync_AlreadyArchived_IsNoop_NoSecondEvent()
+    {
+        var (repo, events, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var agent = await repo.CreateAsync(NewPublicAgent(), ValidConfig, null, null);
+            await repo.ArchiveAsync(agent.Id, null);
+            events.Clear();
+
+            var again = await repo.ArchiveAsync(agent.Id, null);
+
+            again!.Status.Should().Be(AgentStatus.Archived);
+            events.Events.Should().BeEmpty(
+                "archiving an already-archived agent is a no-op — no second event");
+        }
+    }
+
+    [Test]
+    public async Task ArchiveAsync_UnknownAgent_ReturnsNull_NoEvent()
+    {
+        var (repo, events, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var result = await repo.ArchiveAsync(Guid.NewGuid(), null);
+            result.Should().BeNull();
+            events.Events.Should().BeEmpty();
+        }
+    }
+
+    // ── ListVisibleAsync ──
+
+    [Test]
+    public async Task ListVisibleAsync_Returns_Public_Union_OwnPrivate_NeverOthers()
+    {
+        var tenantB = Guid.NewGuid();
+        await using (var setup = NewContext())
+        {
+            var repo = new AgentRepository(setup, new CapturingEventRepository());
+            await repo.CreateAsync(NewPublicAgent("tamma-architect", "architect"), ValidConfig, null, null);
+            await repo.CreateAsync(NewTenantAgent("atlas-a"), ValidConfig, null, null);
+            await repo.CreateAsync(
+                new Agent { Name = "atlas-b", Role = "architect", Visibility = AgentVisibility.Private, OwnerTenantId = tenantB },
+                ValidConfig, null, null);
+        }
+
+        await using var ctx = NewContext();
+        var repoR = new AgentRepository(ctx, new CapturingEventRepository());
+        var visibleToA = await repoR.ListVisibleAsync(TenantA, null);
+
+        var names = visibleToA.Select(a => a.Name).ToList();
+        names.Should().Contain("tamma-architect");
+        names.Should().Contain("atlas-a");
+        names.Should().NotContain("atlas-b", "tenant A must never see tenant B's private agent");
+    }
+
+    /// <summary>
+    /// Capturing <see cref="IEventRepository"/> — records appended events so
+    /// tests can assert emission / no-emission / tags without a real tenant DB.
+    /// </summary>
+    private sealed class CapturingEventRepository : IEventRepository
+    {
+        private readonly ConcurrentQueue<DomainEvent> _events = new();
+        public IReadOnlyList<DomainEvent> Events => _events.ToList();
+        public void Clear() => _events.Clear();
+
+        public Task<DomainEvent> AppendAsync(DomainEvent evt)
+        {
+            evt.CreatedAt = evt.CreatedAt == default ? DateTime.UtcNow : evt.CreatedAt;
+            _events.Enqueue(evt);
+            return Task.FromResult(evt);
+        }
+
+        public Task<DomainEvent?> GetByIdAsync(Guid id) =>
+            Task.FromResult(_events.FirstOrDefault(e => e.Id == id));
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit) =>
+            Task.FromResult(_events.ToList());
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type) =>
+            Task.FromResult(_events.LastOrDefault(e => e.Type == type));
+        public Task ClearAsync(Guid tenantId) { Clear(); return Task.CompletedTask; }
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(
+            Guid? tenantId, string? type, int? issueNumber, int limit, int offset) =>
+            Task.FromResult(((IReadOnlyList<DomainEvent>)_events.ToList(), _events.Count));
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(
+            Guid tenantId, string? typePrefix, int limit, int offset) =>
+            Task.FromResult(((IReadOnlyList<DomainEvent>)_events.ToList(), _events.Count));
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/AnalyticsUsageMigrationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/AnalyticsUsageMigrationTests.cs
@@ -1,0 +1,196 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using NUnit.Framework;
+using Tamma.Core.Enums;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Pooling;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Analytics;
+
+/// <summary>
+/// Story 36-1 (AC11/AC12) — Postgres 17 Testcontainer proof for the per-tenant
+/// analytics fact tables. Follows <c>SchemaPerTenantMigrationTests</c> (two
+/// tenant schemas in one DB, search-path isolation) +
+/// <c>ConventionStoreMigrationTests</c> (NULLS NOT DISTINCT collision via raw
+/// SQL — EF InMemory honours neither, so a real Postgres is the only proof).
+///
+/// <para>Assertions:</para>
+/// <list type="number">
+///   <item>The Tenant migration graph (incl. <c>AddAnalyticsUsageFactTables</c>)
+///     applies into a <c>t_&lt;hex&gt;</c> search-path schema; both schemas
+///     carry their own <c>analytics_usage_hourly</c> + <c>analytics_usage_daily</c>
+///     + <c>__TenantMigrationsHistory</c>. Re-running the migrator for an
+///     already-migrated schema is a no-op (AC11 + AC12a).</item>
+///   <item>A row written through schema A's <see cref="TenantDbContext"/> is
+///     invisible through schema B's context — the search-path schema is the
+///     only isolation plane (no EF query filter) (AC12b).</item>
+///   <item>A second insert of the SAME full dimension tuple within one bucket —
+///     with NULL <c>AgentId</c>/<c>WorkflowDefinitionId</c>/<c>RepoId</c> —
+///     raises a unique violation, proving NULLS NOT DISTINCT (AC12c).</item>
+/// </list>
+/// </summary>
+[TestFixture]
+public class AnalyticsUsageMigrationTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _baseConnectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("analytics_usage_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _baseConnectionString = _postgres.GetConnectionString();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        await _postgres.DisposeAsync();
+    }
+
+    private string CsFor(string schema) =>
+        new NpgsqlConnectionStringBuilder(_baseConnectionString) { SearchPath = schema }
+            .ConnectionString;
+
+    [Test]
+    public async Task Migration_CreatesFactTables_InEachTenantSchema_AndIsolatesAndDedupes()
+    {
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+        var schemaA = TenantNaming.SchemaName(tenantA);
+        var schemaB = TenantNaming.SchemaName(tenantB);
+
+        var migrator = new EfTenantDbMigrator();
+        await migrator.MigrateTenantAppAsync(CsFor(schemaA));
+        await migrator.MigrateTenantAppAsync(CsFor(schemaB));
+        // AC11/AC12a — idempotency: re-running for A is a no-op, not a failure.
+        await migrator.MigrateTenantAppAsync(CsFor(schemaA));
+
+        // ── (a) both schemas carry both fact tables + their own history ──
+        await using (var conn = new NpgsqlConnection(_baseConnectionString))
+        {
+            await conn.OpenAsync();
+            foreach (var schema in new[] { schemaA, schemaB })
+            {
+                await using var cmd = conn.CreateCommand();
+                cmd.CommandText = """
+                    SELECT
+                      (SELECT count(*) FROM information_schema.tables
+                        WHERE table_schema = @s AND table_name = 'analytics_usage_hourly'),
+                      (SELECT count(*) FROM information_schema.tables
+                        WHERE table_schema = @s AND table_name = 'analytics_usage_daily'),
+                      (SELECT count(*) FROM information_schema.tables
+                        WHERE table_schema = @s AND table_name = '__TenantMigrationsHistory')
+                    """;
+                cmd.Parameters.AddWithValue("s", schema);
+                await using var r = await cmd.ExecuteReaderAsync();
+                (await r.ReadAsync()).Should().BeTrue();
+                r.GetInt64(0).Should().Be(1, $"analytics_usage_hourly must exist in schema {schema}");
+                r.GetInt64(1).Should().Be(1, $"analytics_usage_daily must exist in schema {schema}");
+                r.GetInt64(2).Should().Be(1, $"__TenantMigrationsHistory must exist in schema {schema}");
+            }
+        }
+
+        // ── (b) search-path isolation — a row in schema A is invisible in B ──
+        var optsA = new DbContextOptionsBuilder<TenantDbContext>().UseNpgsql(CsFor(schemaA)).Options;
+        var optsB = new DbContextOptionsBuilder<TenantDbContext>().UseNpgsql(CsFor(schemaB)).Options;
+
+        await using (var ctxA = new TenantDbContext(optsA, tenantA))
+        {
+            ctxA.AnalyticsUsageHourly.Add(new AnalyticsUsageHourly
+            {
+                Hour = new DateTime(2026, 6, 17, 12, 0, 0, DateTimeKind.Utc),
+                Provider = "anthropic-claude",
+                CostBasis = CostBasis.Byok,
+                // AgentId / WorkflowDefinitionId / RepoId left null on purpose.
+            });
+            await ctxA.SaveChangesAsync();
+        }
+
+        await using (var ctxB = new TenantDbContext(optsB, tenantB))
+        {
+            (await ctxB.AnalyticsUsageHourly.AnyAsync()).Should().BeFalse(
+                "schema B must not see rows written into schema A — search-path is the isolation plane");
+        }
+
+        // ── (c) NULLS NOT DISTINCT — duplicate full-NULL-dimension tuple collides ──
+        await using (var conn = new NpgsqlConnection(CsFor(schemaA)))
+        {
+            await conn.OpenAsync();
+
+            // The row above already occupies (Hour, 'anthropic-claude', NULL,
+            // NULL, NULL, 'byok'). A second insert of the identical tuple — with
+            // every nullable dimension NULL — must collide on UX_*_dims.
+            await using var dup = new NpgsqlCommand(
+                """
+                INSERT INTO analytics_usage_hourly ("Hour", "Provider", "CostBasis")
+                VALUES (TIMESTAMPTZ '2026-06-17T12:00:00Z', 'anthropic-claude', 'byok');
+                """, conn);
+
+            var act = async () => await dup.ExecuteNonQueryAsync();
+
+            var ex = await act.Should().ThrowAsync<PostgresException>();
+            ex.Which.SqlState.Should().Be("23505", // unique_violation
+                because: "NULLS NOT DISTINCT — two rows with the same (Hour, Provider, "
+                    + "NULL AgentId, NULL WorkflowDefinitionId, NULL RepoId, CostBasis) tuple "
+                    + "collide; exactly one row per dimension tuple per bucket");
+        }
+
+        // ── (c′) a DIFFERENT non-null dimension must NOT collide ──
+        await using (var conn = new NpgsqlConnection(CsFor(schemaA)))
+        {
+            await conn.OpenAsync();
+            await using var distinct = new NpgsqlCommand(
+                """
+                INSERT INTO analytics_usage_hourly ("Hour", "Provider", "AgentId", "CostBasis")
+                VALUES (TIMESTAMPTZ '2026-06-17T12:00:00Z', 'anthropic-claude', 'agent-x', 'byok');
+                """, conn);
+
+            var rows = await distinct.ExecuteNonQueryAsync();
+            rows.Should().Be(1,
+                "a non-null AgentId makes the dimension tuple distinct — it must insert cleanly");
+        }
+    }
+
+    [Test]
+    public async Task UniqueIndex_NullsNotDistinct_Is_Confirmed_In_PgCatalogue()
+    {
+        var tenant = Guid.NewGuid();
+        var schema = TenantNaming.SchemaName(tenant);
+        await new EfTenantDbMigrator().MigrateTenantAppAsync(CsFor(schema));
+
+        await using var conn = new NpgsqlConnection(CsFor(schema));
+        await conn.OpenAsync();
+
+        foreach (var indexName in new[]
+            { "UX_analytics_usage_hourly_dims", "UX_analytics_usage_daily_dims" })
+        {
+            await using var cmd = new NpgsqlCommand(
+                """
+                SELECT ix.indnullsnotdistinct
+                FROM pg_class       c
+                JOIN pg_index       ix ON ix.indrelid = c.oid
+                JOIN pg_class       ic ON ic.oid = ix.indexrelid
+                JOIN pg_namespace   n  ON n.oid = c.relnamespace
+                WHERE n.nspname = @schema
+                  AND ic.relname = @ix;
+                """, conn);
+            cmd.Parameters.AddWithValue("schema", schema);
+            cmd.Parameters.AddWithValue("ix", indexName);
+
+            var result = await cmd.ExecuteScalarAsync();
+            result.Should().NotBeNull($"the {indexName} index must exist");
+            result.Should().Be(true,
+                $"{indexName} must use NULLS NOT DISTINCT so NULL dimensions dedupe");
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/AnalyticsUsageModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/AnalyticsUsageModelTests.cs
@@ -1,0 +1,292 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using NUnit.Framework;
+using Tamma.Data;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Tests.Analytics;
+
+/// <summary>
+/// Story 36-1 — model-shape + InMemory/Npgsql parity tests for the per-tenant
+/// dimensional analytics fact tables (<c>analytics_usage_hourly</c> +
+/// <c>analytics_usage_daily</c>). Pure model-metadata inspection — no Postgres
+/// connection is opened. The Npgsql leg asserts the relational store types
+/// (text / bigint / numeric(20,4)); the InMemory leg asserts the same
+/// CLR-shape so the two providers agree on columns, nullability, and the
+/// <see cref="Tamma.Core.Enums.CostBasis"/>→text conversion (AC10).
+///
+/// <para>The constraint/idempotency proofs that InMemory cannot honour
+/// (NULLS NOT DISTINCT, search-path isolation) live in
+/// <see cref="AnalyticsUsageMigrationTests"/> against a real Postgres 17
+/// container.</para>
+/// </summary>
+[TestFixture]
+public class AnalyticsUsageModelTests
+{
+    private static TenantDbContext CreateNpgsqlContext() =>
+        new(new DbContextOptionsBuilder<TenantDbContext>()
+            .UseNpgsql("Host=localhost;Database=tenant_test;Username=tamma;Password=tamma")
+            .Options);
+
+    private static TenantDbContext CreateInMemoryContext() =>
+        new(new DbContextOptionsBuilder<TenantDbContext>()
+            .UseInMemoryDatabase($"analytics_usage_{Guid.NewGuid():N}")
+            .Options);
+
+    // ── AC4 — both fact tables are mapped on TenantDbContext ──
+
+    [Test]
+    public void TenantDbContext_Maps_BothFactTables()
+    {
+        using var ctx = CreateNpgsqlContext();
+        var tables = ctx.Model.GetEntityTypes()
+            .Select(t => t.GetTableName())
+            .ToHashSet();
+
+        tables.Should().Contain("analytics_usage_hourly");
+        tables.Should().Contain("analytics_usage_daily");
+    }
+
+    // ── AC1/AC2 — identical dimension + measure shape; only the bucket differs ──
+
+    [Test]
+    public void Hourly_And_Daily_Share_IdenticalShape_ExceptBucket()
+    {
+        using var ctx = CreateNpgsqlContext();
+        var hourly = ctx.Model.FindEntityType(typeof(AnalyticsUsageHourly))!
+            .GetProperties().Select(p => p.Name).ToHashSet();
+        var daily = ctx.Model.FindEntityType(typeof(AnalyticsUsageDaily))!
+            .GetProperties().Select(p => p.Name).ToHashSet();
+
+        // Drop the bucket column; everything else must match exactly.
+        hourly.Remove("Hour").Should().BeTrue();
+        daily.Remove("Day").Should().BeTrue();
+        hourly.Should().BeEquivalentTo(daily,
+            "the daily roll-up must be a lossless GROUP BY of the hourly grain");
+
+        // The shared (non-bucket) contract — pin it so a measure can't silently vanish.
+        hourly.Should().BeEquivalentTo(new[]
+        {
+            "Id", "Provider", "AgentId", "WorkflowDefinitionId", "RepoId", "CostBasis",
+            "TokensIn", "TokensOut", "CostUsd", "PlatformBilledUsd",
+            "WorkflowsStarted", "WorkflowsCompleted", "WorkflowsFailed", "AgentDispatches",
+            "ComputedAt",
+        });
+    }
+
+    // ── AC3/AC10 — CostBasis persists as text on BOTH providers ──
+
+    [TestCase(typeof(AnalyticsUsageHourly))]
+    [TestCase(typeof(AnalyticsUsageDaily))]
+    public void CostBasis_Is_Converted_To_Text_OnNpgsql(Type clr)
+    {
+        using var ctx = CreateNpgsqlContext();
+        var prop = ctx.Model.FindEntityType(clr)!.FindProperty("CostBasis")!;
+
+        prop.GetValueConverter().Should().NotBeNull(
+            "CostBasis must round-trip through a string converter, never the ordinal");
+        prop.ClrType.Should().Be(typeof(Tamma.Core.Enums.CostBasis));
+        prop.GetValueConverter()!.ProviderClrType.Should().Be(typeof(string),
+            "the store-facing type for CostBasis is string/text on Npgsql");
+        prop.GetRelationalTypeMapping().StoreType.Should().Be("character varying(20)",
+            "CostBasis is a 20-char text discriminator on Npgsql");
+        prop.IsNullable.Should().BeFalse("CostBasis is a required dimension");
+    }
+
+    [TestCase(typeof(AnalyticsUsageHourly))]
+    [TestCase(typeof(AnalyticsUsageDaily))]
+    public void CostBasis_Is_Converted_To_String_OnInMemory(Type clr)
+    {
+        using var ctx = CreateInMemoryContext();
+        var prop = ctx.Model.FindEntityType(clr)!.FindProperty("CostBasis")!;
+
+        prop.GetValueConverter().Should().NotBeNull(
+            "the same string conversion applies on InMemory — parity with Npgsql");
+        prop.GetValueConverter()!.ProviderClrType.Should().Be(typeof(string));
+    }
+
+    // ── AC1/AC2 — nullability of dimensions ──
+
+    [TestCase(typeof(AnalyticsUsageHourly))]
+    [TestCase(typeof(AnalyticsUsageDaily))]
+    public void NullableDimensions_AreNullable_RequiredDimensions_AreRequired(Type clr)
+    {
+        using var ctx = CreateNpgsqlContext();
+        var entity = ctx.Model.FindEntityType(clr)!;
+
+        entity.FindProperty("AgentId")!.IsNullable.Should().BeTrue();
+        entity.FindProperty("WorkflowDefinitionId")!.IsNullable.Should().BeTrue();
+        entity.FindProperty("RepoId")!.IsNullable.Should().BeTrue();
+
+        entity.FindProperty("Provider")!.IsNullable.Should().BeFalse("Provider is required");
+        entity.FindProperty("CostBasis")!.IsNullable.Should().BeFalse("CostBasis is required");
+    }
+
+    [TestCase(typeof(AnalyticsUsageHourly))]
+    [TestCase(typeof(AnalyticsUsageDaily))]
+    public void NullableDimensions_AreNullable_OnInMemory_Too(Type clr)
+    {
+        using var ctx = CreateInMemoryContext();
+        var entity = ctx.Model.FindEntityType(clr)!;
+
+        entity.FindProperty("AgentId")!.IsNullable.Should().BeTrue();
+        entity.FindProperty("WorkflowDefinitionId")!.IsNullable.Should().BeTrue();
+        entity.FindProperty("RepoId")!.IsNullable.Should().BeTrue();
+        entity.FindProperty("Provider")!.IsNullable.Should().BeFalse();
+    }
+
+    // ── AC8 — counter store types are bigint, costs are numeric(20,4) ──
+
+    [TestCase(typeof(AnalyticsUsageHourly))]
+    [TestCase(typeof(AnalyticsUsageDaily))]
+    public void Counters_Are_Bigint_And_Costs_Are_Numeric_20_4(Type clr)
+    {
+        using var ctx = CreateNpgsqlContext();
+        var entity = ctx.Model.FindEntityType(clr)!;
+
+        foreach (var counter in new[]
+            { "TokensIn", "TokensOut", "WorkflowsStarted", "WorkflowsCompleted",
+              "WorkflowsFailed", "AgentDispatches" })
+        {
+            entity.FindProperty(counter)!.GetRelationalTypeMapping().StoreType
+                .Should().Be("bigint", $"{counter} is a long counter");
+        }
+
+        foreach (var cost in new[] { "CostUsd", "PlatformBilledUsd" })
+        {
+            entity.FindProperty(cost)!.GetRelationalTypeMapping().StoreType
+                .Should().Be("numeric(20,4)",
+                    $"{cost} mirrors PlatformAnalyticsHourly precision for lossless owner-side joins");
+        }
+    }
+
+    // ── AC1/AC2 — the bucket column is timestamptz ──
+
+    [Test]
+    public void Hourly_BucketColumn_Is_TimestampTz()
+    {
+        using var ctx = CreateNpgsqlContext();
+        var prop = ctx.Model.FindEntityType(typeof(AnalyticsUsageHourly))!.FindProperty("Hour")!;
+        prop.GetColumnType().Should().Be("timestamp with time zone");
+    }
+
+    [Test]
+    public void Daily_BucketColumn_Is_TimestampTz()
+    {
+        using var ctx = CreateNpgsqlContext();
+        var prop = ctx.Model.FindEntityType(typeof(AnalyticsUsageDaily))!.FindProperty("Day")!;
+        prop.GetColumnType().Should().Be("timestamp with time zone");
+    }
+
+    // ── AC9 — measure defaults (0 counters, 0 costs, now(), gen_random_uuid()) ──
+
+    [TestCase(typeof(AnalyticsUsageHourly))]
+    [TestCase(typeof(AnalyticsUsageDaily))]
+    public void Measures_Default_To_Zero_And_Id_And_ComputedAt_HaveServerDefaults(Type clr)
+    {
+        using var ctx = CreateNpgsqlContext();
+        var entity = ctx.Model.FindEntityType(clr)!;
+
+        entity.FindProperty("Id")!.GetDefaultValueSql().Should().Be("gen_random_uuid()");
+        entity.FindProperty("ComputedAt")!.GetDefaultValueSql().Should().Be("now()");
+
+        foreach (var counter in new[]
+            { "TokensIn", "TokensOut", "WorkflowsStarted", "WorkflowsCompleted",
+              "WorkflowsFailed", "AgentDispatches" })
+        {
+            entity.FindProperty(counter)!.GetDefaultValue().Should().Be(0L,
+                $"{counter} must default to 0L so a partial upsert never writes NULL");
+        }
+
+        entity.FindProperty("CostUsd")!.GetDefaultValue().Should().Be(0m);
+        entity.FindProperty("PlatformBilledUsd")!.GetDefaultValue().Should().Be(0m);
+    }
+
+    // ── AC6 — breakdown index over (bucket, Provider, AgentId, WorkflowDefinitionId, CostBasis) ──
+
+    [Test]
+    public void Hourly_Has_BreakdownIndex()
+    {
+        using var ctx = CreateNpgsqlContext();
+        var index = ctx.Model.FindEntityType(typeof(AnalyticsUsageHourly))!
+            .GetIndexes().Single(i => i.GetDatabaseName() == "IX_analytics_usage_hourly_breakdown");
+
+        index.IsUnique.Should().BeFalse();
+        index.Properties.Select(p => p.Name).Should()
+            .Equal("Hour", "Provider", "AgentId", "WorkflowDefinitionId", "CostBasis");
+    }
+
+    [Test]
+    public void Daily_Has_BreakdownIndex()
+    {
+        using var ctx = CreateNpgsqlContext();
+        var index = ctx.Model.FindEntityType(typeof(AnalyticsUsageDaily))!
+            .GetIndexes().Single(i => i.GetDatabaseName() == "IX_analytics_usage_daily_breakdown");
+
+        index.IsUnique.Should().BeFalse();
+        index.Properties.Select(p => p.Name).Should()
+            .Equal("Day", "Provider", "AgentId", "WorkflowDefinitionId", "CostBasis");
+    }
+
+    // ── AC7 — unique business key over the FULL dimension tuple, NULLS NOT DISTINCT ──
+
+    [Test]
+    public void Hourly_Has_NullsNotDistinct_UniqueBusinessKey()
+    {
+        using var ctx = CreateNpgsqlContext();
+        // The runtime read-optimized model prunes the Npgsql:NullsDistinct
+        // annotation (same as CHECK constraints) — read it from the
+        // design-time model where it survives.
+        var index = DesignIndex(ctx, typeof(AnalyticsUsageHourly), "UX_analytics_usage_hourly_dims");
+
+        index.IsUnique.Should().BeTrue();
+        index.GetAreNullsDistinct().Should().BeFalse(
+            "NULL AgentId/WorkflowDefinitionId/RepoId must dedupe to one row per bucket (PG15+)");
+        index.Properties.Select(p => p.Name).Should()
+            .Equal("Hour", "Provider", "AgentId", "WorkflowDefinitionId", "RepoId", "CostBasis");
+    }
+
+    [Test]
+    public void Daily_Has_NullsNotDistinct_UniqueBusinessKey()
+    {
+        using var ctx = CreateNpgsqlContext();
+        var index = DesignIndex(ctx, typeof(AnalyticsUsageDaily), "UX_analytics_usage_daily_dims");
+
+        index.IsUnique.Should().BeTrue();
+        index.GetAreNullsDistinct().Should().BeFalse();
+        index.Properties.Select(p => p.Name).Should()
+            .Equal("Day", "Provider", "AgentId", "WorkflowDefinitionId", "RepoId", "CostBasis");
+    }
+
+    private static IReadOnlyIndex DesignIndex(TenantDbContext ctx, Type clr, string indexName)
+    {
+        var designModel = Microsoft.EntityFrameworkCore.Infrastructure.AccessorExtensions
+            .GetService<Microsoft.EntityFrameworkCore.Metadata.IDesignTimeModel>(ctx).Model;
+        return designModel.FindEntityType(clr)!
+            .GetIndexes().Single(i => i.GetDatabaseName() == indexName);
+    }
+
+    // ── Tenancy — NO TenantId column on either table (Doc 01 §1.4) ──
+
+    [TestCase(typeof(AnalyticsUsageHourly))]
+    [TestCase(typeof(AnalyticsUsageDaily))]
+    public void FactTables_Have_No_TenantId_Column(Type clr)
+    {
+        using var ctx = CreateNpgsqlContext();
+        ctx.Model.FindEntityType(clr)!.GetProperties().Select(p => p.Name)
+            .Should().NotContain("TenantId",
+                "isolation is the per-tenant schema, not a column (Doc 01 §1.4)");
+    }
+
+    // ── No EF query filter (search-path is the only isolation plane) ──
+
+    [TestCase(typeof(AnalyticsUsageHourly))]
+    [TestCase(typeof(AnalyticsUsageDaily))]
+    public void FactTables_Have_No_QueryFilter(Type clr)
+    {
+        using var ctx = CreateNpgsqlContext();
+        ctx.Model.FindEntityType(clr)!.GetQueryFilter().Should().BeNull(
+            "TenantDbContext carries no query filters — the search-path schema isolates");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditProjectorBackgroundServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditProjectorBackgroundServiceTests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Services.Audit;
+
+namespace Tamma.Api.Tests.Audit;
+
+/// <summary>
+/// Story 37-1 (AC9) — background-host gating + crash-isolation without a DB.
+/// The RunOnStartup gate keeps the loop idle during unrelated tests; the loop
+/// must not throw out of <c>StartAsync</c>.
+/// </summary>
+[TestFixture]
+public class AuditProjectorBackgroundServiceTests
+{
+    [Test]
+    public void RunOnStartup_Defaults_To_False()
+    {
+        // Critical — the loop must be opt-in so it never runs during the test
+        // suite or a deployment that has not enabled it.
+        new AuditProjectorOptions().RunOnStartup.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task Gated_Off_Loop_Does_Not_Touch_Services_On_Start()
+    {
+        // An empty service provider would throw if the loop tried to resolve the
+        // ControlPlaneDbContext — proving the gate short-circuits before any work.
+        var emptyServices = new ServiceCollection().BuildServiceProvider();
+        var svc = new AuditProjectorBackgroundService(
+            emptyServices,
+            new AuditProjectorOptions { RunOnStartup = false },
+            TimeProvider.System,
+            new AuditProjectionMetrics(),
+            NullLogger<AuditProjectorBackgroundService>.Instance);
+
+        using var cts = new CancellationTokenSource();
+        await svc.StartAsync(cts.Token);   // must not throw — loop is gated off
+        await svc.StopAsync(cts.Token);
+    }
+
+    [Test]
+    public void Metrics_RecordLag_Clamps_Negative_To_Zero()
+    {
+        using var metrics = new AuditProjectionMetrics();
+        metrics.RecordLag(42);
+        metrics.Lag.Should().Be(42);
+        metrics.RecordLag(-5);
+        metrics.Lag.Should().Be(0, "lag is never negative");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditProjectorIntegrationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditProjectorIntegrationTests.cs
@@ -1,0 +1,433 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using NUnit.Framework;
+using Tamma.Api.Services.Audit;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Audit;
+using Tamma.Data.Entities;
+using Tamma.Data.Pooling;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Audit;
+
+/// <summary>
+/// Story 37-1 (AC7, AC8, AC9, AC10, AC11, AC14, AC15) — end-to-end projection
+/// against a real Postgres 17 container. Drives
+/// <see cref="AuditProjectorBackgroundService.ProcessOnceAsync"/> over seeded
+/// raw DCB events and asserts the curated trail.
+///
+/// <para>Two tenant schemas are migrated so the cross-scope isolation proof
+/// (AC14) is real: a tenant-A event must never materialize into tenant-B's
+/// schema, and a platform-only event must land in the control plane, not a
+/// tenant view.</para>
+/// </summary>
+[TestFixture]
+public class AuditProjectorIntegrationTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+
+    private Guid _tenantA;
+    private Guid _tenantB;
+    private string _schemaA = null!;
+    private string _schemaB = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("audit_projector_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        // Migrate the control plane (public schema) — audit_records + cursor +
+        // domain_events + platform_events live here in the transitional topology.
+        await using (var cp = NewCp())
+            await cp.Database.MigrateAsync();
+
+        // Migrate two tenant schemas so tenant-scope audit_records exist.
+        _tenantA = Guid.NewGuid();
+        _tenantB = Guid.NewGuid();
+        _schemaA = TenantNaming.SchemaName(_tenantA);
+        _schemaB = TenantNaming.SchemaName(_tenantB);
+        var migrator = new EfTenantDbMigrator();
+        await migrator.MigrateTenantAppAsync(CsFor(_schemaA));
+        await migrator.MigrateTenantAppAsync(CsFor(_schemaB));
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    private string CsFor(string schema) =>
+        new NpgsqlConnectionStringBuilder(_cs) { SearchPath = schema }.ConnectionString;
+
+    private ControlPlaneDbContext NewCp() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    private TenantDbContext NewTenant(Guid tenantId, string schema) =>
+        new(new DbContextOptionsBuilder<TenantDbContext>().UseNpgsql(CsFor(schema)).Options, tenantId);
+
+    [SetUp]
+    public async Task ResetTables()
+    {
+        await using var conn = new NpgsqlConnection(_cs);
+        await conn.OpenAsync();
+        // Truncate everything the projector touches so each test starts clean
+        // (AC8's "truncate + reset cursor reproduces identical trail" relies on it).
+        await Exec(conn, "TRUNCATE audit_records, audit_projector_cursor, platform_events, users RESTART IDENTITY CASCADE;");
+        foreach (var schema in new[] { _schemaA, _schemaB })
+        {
+            await Exec(conn, $"TRUNCATE \"{schema}\".audit_records RESTART IDENTITY;");
+            await Exec(conn, $"TRUNCATE \"{schema}\".domain_events RESTART IDENTITY;");
+        }
+        // Register both tenants in the CP so the projector's per-tenant fan-out
+        // discovers them (a fresh slate seeds the rows it needs each test).
+        await SeedTenant(_tenantA, _schemaA);
+        await SeedTenant(_tenantB, _schemaB);
+    }
+
+    private async Task SeedTenant(Guid id, string schema)
+    {
+        await using var cp = NewCp();
+        if (await cp.Tenants.AnyAsync(t => t.Id == id)) return;
+        cp.Tenants.Add(new Tenant
+        {
+            Id = id,
+            Name = schema,
+            Slug = schema,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        await cp.SaveChangesAsync();
+    }
+
+    // ── Build a DI scope wired with the projector + a per-test mode ──
+
+    private ServiceProvider BuildServices(
+        TammaMode mode, bool runOnStartup = false, Guid? singleUserId = null)
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<ControlPlaneDbContext>(o => o.UseNpgsql(_cs));
+        services.AddSingleton<ITammaModeProvider>(new FixedModeProvider(mode));
+        services.AddSingleton<ITenantDbContextFactory>(new SearchPathTenantFactory(_cs));
+        services.AddSingleton<IAuditProjector, AuditProjector>();
+        services.AddSingleton<IAuditRecordRepository, AuditRecordRepository>();
+        services.AddSingleton(TimeProvider.System);
+        services.AddSingleton<AuditProjectionMetrics>();
+        services.AddSingleton(new AuditProjectorOptions { RunOnStartup = runOnStartup });
+        services.AddSingleton<AuditProjectorBackgroundService>();
+        return services.BuildServiceProvider();
+    }
+
+    private static AuditProjectorBackgroundService Svc(ServiceProvider sp) =>
+        new(sp, sp.GetRequiredService<AuditProjectorOptions>(),
+            sp.GetRequiredService<TimeProvider>(),
+            sp.GetRequiredService<AuditProjectionMetrics>(),
+            NullLogger<AuditProjectorBackgroundService>.Instance);
+
+    // ── Seeding helpers (write the RAW source events the projector reads) ──
+
+    // Domain (tenant-scoped) events live in the tenant's schema — that is where
+    // the projector reads them via the per-tenant fan-out. Seed accordingly.
+    private async Task SeedDomainEvent(string type, Guid tenantId, object? data = null, object? tags = null)
+    {
+        var schema = TenantNaming.SchemaName(tenantId);
+        await using var t = NewTenant(tenantId, schema);
+        t.DomainEvents.Add(new DomainEvent
+        {
+            Id = Guid.NewGuid(),
+            Type = type,
+            TenantId = tenantId,
+            Tags = JsonSerializer.Serialize(tags ?? new { }),
+            Data = JsonSerializer.Serialize(data ?? new { }),
+            CreatedAt = DateTime.UtcNow,
+        });
+        await t.SaveChangesAsync();
+    }
+
+    private async Task SeedPlatformEvent(string type, Guid? tenantId, object? data = null)
+    {
+        await using var cp = NewCp();
+        cp.PlatformEvents.Add(new PlatformEvent
+        {
+            Id = Guid.NewGuid(),
+            Type = type,
+            TenantId = tenantId,
+            Data = JsonSerializer.Serialize(data ?? new { }),
+            CreatedAt = DateTime.UtcNow,
+        });
+        await cp.SaveChangesAsync();
+    }
+
+    private async Task<int> CountCp()
+    {
+        await using var cp = NewCp();
+        return await cp.AuditRecords.CountAsync();
+    }
+
+    private async Task<int> CountTenant(Guid tenantId, string schema)
+    {
+        await using var t = NewTenant(tenantId, schema);
+        return await t.AuditRecords.CountAsync();
+    }
+
+    // ════════════════════ AC7 — non-catalog skip ════════════════════
+
+    [Test]
+    public async Task NonCatalog_Event_Produces_Zero_Rows()
+    {
+        await SeedDomainEvent("WORKFLOW.STEP_COMPLETED", _tenantA);
+
+        await using var sp = BuildServices(TammaMode.SaaS);
+        var inserted = await Svc(sp).ProcessOnceAsync(default);
+
+        inserted.Should().Be(0);
+        (await CountCp()).Should().Be(0);
+        (await CountTenant(_tenantA, _schemaA)).Should().Be(0);
+    }
+
+    // ════════════════════ AC11/AC14 — scope routing + isolation ════════════════════
+
+    [Test]
+    public async Task Saas_TenantScoped_Event_Lands_In_That_Tenant_Schema_Only()
+    {
+        await SeedDomainEvent("SECRET.REVEAL", _tenantA);
+
+        await using var sp = BuildServices(TammaMode.SaaS);
+        await Svc(sp).ProcessOnceAsync(default);
+
+        (await CountTenant(_tenantA, _schemaA)).Should().Be(1, "tenant-A's event lands in schema A");
+        (await CountTenant(_tenantB, _schemaB)).Should().Be(0, "tenant-B must never see tenant-A's event");
+        (await CountCp()).Should().Be(0, "a tenant-scoped event must not land in the control plane");
+
+        await using var ta = NewTenant(_tenantA, _schemaA);
+        var row = await ta.AuditRecords.SingleAsync();
+        row.TenantId.Should().Be(_tenantA);
+        row.UserId.Should().BeNull();
+        row.ActionCode.Should().Be("SECRET.REVEAL");
+    }
+
+    [Test]
+    public async Task Saas_PlatformOnly_Event_Lands_In_ControlPlane_Not_A_Tenant()
+    {
+        // Impersonation against the platform — TenantId null on the platform event.
+        await SeedPlatformEvent("IMPERSONATION.STARTED", tenantId: null);
+
+        await using var sp = BuildServices(TammaMode.SaaS);
+        await Svc(sp).ProcessOnceAsync(default);
+
+        (await CountCp()).Should().Be(1, "platform-only events materialize into the CP store");
+        (await CountTenant(_tenantA, _schemaA)).Should().Be(0);
+        (await CountTenant(_tenantB, _schemaB)).Should().Be(0);
+
+        await using var cp = NewCp();
+        var row = await cp.AuditRecords.SingleAsync();
+        row.TenantId.Should().BeNull();
+        row.UserId.Should().BeNull();
+    }
+
+    // ════════════════════ AC11 — single-user keys by user_id ════════════════════
+
+    [Test]
+    public async Task SingleUser_Event_Keys_UserId_In_ControlPlane()
+    {
+        var ownerId = Guid.NewGuid();
+        await SeedUser(ownerId, "owner@example.com");
+        // Even though the raw event carries a TenantId (the personal tenant),
+        // single-user mode keys every row by the sole user.
+        await SeedDomainEvent("SECRET.REVEAL", _tenantA);
+
+        await using var sp = BuildServices(TammaMode.SingleUser);
+        await Svc(sp).ProcessOnceAsync(default);
+
+        (await CountCp()).Should().Be(1);
+        await using var cp = NewCp();
+        var row = await cp.AuditRecords.SingleAsync();
+        row.UserId.Should().Be(ownerId);
+        row.TenantId.Should().BeNull("single-user rows have no tenant dimension");
+    }
+
+    // ════════════════════ AC8 — idempotency + replay ════════════════════
+
+    [Test]
+    public async Task Projection_Is_Idempotent_Across_Reruns()
+    {
+        await SeedDomainEvent("SECRET.REVEAL", _tenantA);
+        await SeedDomainEvent("WORKFLOW.STEP_COMPLETED", _tenantA); // non-catalog
+        await SeedPlatformEvent("IMPERSONATION.STARTED", tenantId: null);
+
+        await using var sp = BuildServices(TammaMode.SaaS);
+        var svc = Svc(sp);
+
+        var first = await svc.ProcessOnceAsync(default);
+        var second = await svc.ProcessOnceAsync(default);
+
+        first.Should().Be(2, "two catalog events, one non-catalog skipped");
+        second.Should().Be(0, "re-running over the same range double-inserts nothing");
+
+        (await CountTenant(_tenantA, _schemaA)).Should().Be(1);
+        (await CountCp()).Should().Be(1);
+    }
+
+    [Test]
+    public async Task Truncate_And_Reset_Cursor_Reproduces_Identical_Trail()
+    {
+        await SeedDomainEvent("SECRET.REVEAL", _tenantA);
+        await SeedPlatformEvent("IMPERSONATION.STARTED", tenantId: null);
+
+        await using var sp = BuildServices(TammaMode.SaaS);
+        await Svc(sp).ProcessOnceAsync(default);
+
+        var tenantBefore = await SnapshotTenant(_tenantA, _schemaA);
+        var cpBefore = await SnapshotCp();
+
+        // Truncate the curated trail + reset the cursor; re-project from zero.
+        await using (var conn = new NpgsqlConnection(_cs))
+        {
+            await conn.OpenAsync();
+            await Exec(conn, "TRUNCATE audit_records, audit_projector_cursor RESTART IDENTITY;");
+            await Exec(conn, $"TRUNCATE \"{_schemaA}\".audit_records RESTART IDENTITY;");
+        }
+
+        await using var sp2 = BuildServices(TammaMode.SaaS);
+        await Svc(sp2).ProcessOnceAsync(default);
+
+        (await SnapshotTenant(_tenantA, _schemaA)).Should().BeEquivalentTo(tenantBefore);
+        (await SnapshotCp()).Should().BeEquivalentTo(cpBefore);
+    }
+
+    // ════════════════════ AC10 — redaction persisted; never plaintext ════════════════════
+
+    [Test]
+    public async Task SecretWrite_Persists_Redacted_Payload_Never_Plaintext()
+    {
+        const string plaintext = "tamma_sk_LIVEDEADBEEF0123456789";
+        await SeedDomainEvent("SECRET.WRITE", _tenantA,
+            data: new { apiKey = plaintext, header = "Bearer zzzzzzzzzzzzzzzzzzzz" });
+
+        await using var sp = BuildServices(TammaMode.SaaS);
+        await Svc(sp).ProcessOnceAsync(default);
+
+        await using var ta = NewTenant(_tenantA, _schemaA);
+        var row = await ta.AuditRecords.SingleAsync();
+        row.PayloadJson.Should().Contain("[REDACTED]");
+        row.PayloadJson.Should().NotContain(plaintext);
+        row.PayloadJson.Should().NotContain("zzzzzzzzzzzzzzzzzzzz");
+    }
+
+    // ════════════════════ AC15 — read-only; raw events untouched ════════════════════
+
+    [Test]
+    public async Task Projector_Never_Mutates_Raw_Event_Store()
+    {
+        await SeedDomainEvent("SECRET.REVEAL", _tenantA);
+        await SeedPlatformEvent("IMPERSONATION.STARTED", tenantId: null);
+
+        var (domBefore, platBefore) = await RawCounts();
+
+        await using var sp = BuildServices(TammaMode.SaaS);
+        await Svc(sp).ProcessOnceAsync(default);
+
+        var (domAfter, platAfter) = await RawCounts();
+        domAfter.Should().Be(domBefore, "the projector must not append/delete domain_events");
+        platAfter.Should().Be(platBefore, "the projector must not append/delete platform_events");
+    }
+
+    // ════════════════════ AC9 — lag metric ════════════════════
+
+    [Test]
+    public async Task Lag_Metric_Is_Unprojected_Count_Then_Zero_After_Pass()
+    {
+        await SeedDomainEvent("SECRET.REVEAL", _tenantA);
+        await SeedDomainEvent("WORKFLOW.STEP_COMPLETED", _tenantA); // still raw lag
+        await SeedPlatformEvent("IMPERSONATION.STARTED", tenantId: null);
+
+        await using var sp = BuildServices(TammaMode.SaaS);
+        var metrics = sp.GetRequiredService<AuditProjectionMetrics>();
+
+        await Svc(sp).ProcessOnceAsync(default);
+
+        // After a full pass the cursor caught up to the stream heads — lag is 0
+        // (lag counts UN-projected raw events, including non-catalog ones the
+        // cursor still advanced past).
+        metrics.Lag.Should().Be(0);
+    }
+
+    // ── snapshot/raw helpers ──
+
+    private async Task<List<string>> SnapshotTenant(Guid tenantId, string schema)
+    {
+        await using var t = NewTenant(tenantId, schema);
+        return await t.AuditRecords.OrderBy(r => r.SourceSequenceNumber)
+            .Select(r => r.ActionCode + "|" + r.Category + "|" + (r.TenantId.ToString() ?? "")
+                + "|" + r.SourceEventId)
+            .ToListAsync();
+    }
+
+    private async Task<List<string>> SnapshotCp()
+    {
+        await using var cp = NewCp();
+        return await cp.AuditRecords.OrderBy(r => r.SourceSequenceNumber)
+            .Select(r => r.ActionCode + "|" + r.Category + "|" + r.SourceEventId)
+            .ToListAsync();
+    }
+
+    private async Task<(int Domain, int Platform)> RawCounts()
+    {
+        int domain = 0;
+        foreach (var (id, schema) in new[] { (_tenantA, _schemaA), (_tenantB, _schemaB) })
+        {
+            await using var t = NewTenant(id, schema);
+            domain += await t.DomainEvents.CountAsync();
+        }
+        await using var cp = NewCp();
+        return (domain, await cp.PlatformEvents.CountAsync());
+    }
+
+    private async Task SeedUser(Guid id, string email)
+    {
+        await using var cp = NewCp();
+        cp.Users.Add(new User { Id = id, Email = email, CreatedAt = DateTime.UtcNow });
+        await cp.SaveChangesAsync();
+    }
+
+    private static async Task Exec(NpgsqlConnection conn, string sql)
+    {
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    // ── test doubles ──
+
+    private sealed class FixedModeProvider(TammaMode mode) : ITammaModeProvider
+    {
+        public TammaMode Mode { get; } = mode;
+    }
+
+    /// <summary>A factory that builds a TenantDbContext bound to the tenant's
+    /// search-path schema in the shared test container.</summary>
+    private sealed class SearchPathTenantFactory(string baseCs) : ITenantDbContextFactory
+    {
+        public ValueTask<TenantDbContext> CreateAsync(Guid tenantId, CancellationToken ct = default)
+        {
+            var schema = TenantNaming.SchemaName(tenantId);
+            var cs = new NpgsqlConnectionStringBuilder(baseCs) { SearchPath = schema }.ConnectionString;
+            var ctx = new TenantDbContext(
+                new DbContextOptionsBuilder<TenantDbContext>().UseNpgsql(cs).Options, tenantId);
+            return ValueTask.FromResult(ctx);
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditProjectorIntegrationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditProjectorIntegrationTests.cs
@@ -117,13 +117,17 @@ public class AuditProjectorIntegrationTests
     // ── Build a DI scope wired with the projector + a per-test mode ──
 
     private ServiceProvider BuildServices(
-        TammaMode mode, bool runOnStartup = false, Guid? singleUserId = null)
+        TammaMode mode, bool runOnStartup = false, Guid? singleUserId = null,
+        IAuditProjector? projectorOverride = null)
     {
         var services = new ServiceCollection();
         services.AddDbContext<ControlPlaneDbContext>(o => o.UseNpgsql(_cs));
         services.AddSingleton<ITammaModeProvider>(new FixedModeProvider(mode));
         services.AddSingleton<ITenantDbContextFactory>(new SearchPathTenantFactory(_cs));
-        services.AddSingleton<IAuditProjector, AuditProjector>();
+        if (projectorOverride is not null)
+            services.AddSingleton(projectorOverride);
+        else
+            services.AddSingleton<IAuditProjector, AuditProjector>();
         services.AddSingleton<IAuditRecordRepository, AuditRecordRepository>();
         services.AddSingleton(TimeProvider.System);
         services.AddSingleton<AuditProjectionMetrics>();
@@ -366,6 +370,95 @@ public class AuditProjectorIntegrationTests
         metrics.Lag.Should().Be(0);
     }
 
+    // ════════════════════ C1 — per-tenant cursor (regression) ════════════════════
+
+    [Test]
+    public async Task TenantB_FirstEvent_Is_Projected_After_TenantA_Advances_The_Cursor()
+    {
+        // Reproduces the C1 data-loss bug: each tenant's domain_events is an
+        // INDEPENDENT per-schema BIGSERIAL. Tenant A emits several events so the
+        // OLD shared cursor would advance well past 1; then tenant B emits its
+        // FIRST sensitive event (sequence 1 in B's schema). Under the old shared
+        // cursor, B's event would be read with WHERE SequenceNumber > <A's max>
+        // and NEVER projected. With per-tenant cursors, B's event MUST project.
+
+        // Tenant A: 5 catalog events → advances A's stream to sequence 5.
+        for (var i = 0; i < 5; i++)
+            await SeedDomainEvent("SECRET.REVEAL", _tenantA);
+
+        await using (var sp1 = BuildServices(TammaMode.SaaS))
+            await Svc(sp1).ProcessOnceAsync(default);
+
+        (await CountTenant(_tenantA, _schemaA)).Should().Be(5, "tenant-A's five events projected");
+
+        // Now tenant B emits its FIRST event (sequence 1 in B's schema).
+        await SeedDomainEvent("SECRET.REVEAL", _tenantB);
+
+        await using (var sp2 = BuildServices(TammaMode.SaaS))
+            await Svc(sp2).ProcessOnceAsync(default);
+
+        (await CountTenant(_tenantB, _schemaB)).Should().Be(1,
+            "tenant-B's low-sequence first event MUST project — the per-tenant cursor "
+            + "tracks B independently of how far A advanced (C1 regression)");
+
+        // Sanity: the per-tenant cursor rows are tracked separately.
+        await using var cp = NewCp();
+        var aCursor = await cp.AuditProjectorCursors.AsNoTracking()
+            .SingleOrDefaultAsync(c => c.TenantId == _tenantA);
+        var bCursor = await cp.AuditProjectorCursors.AsNoTracking()
+            .SingleOrDefaultAsync(c => c.TenantId == _tenantB);
+        aCursor.Should().NotBeNull();
+        bCursor.Should().NotBeNull();
+        aCursor!.LastDomainSequenceNumber.Should().BeGreaterThan(0);
+        bCursor!.LastDomainSequenceNumber.Should().BeGreaterThan(0);
+    }
+
+    // ════════════════════ C2 — failed-redaction quarantine ════════════════════
+
+    [Test]
+    public async Task Failed_Redaction_Quarantines_The_Event_And_The_Cursor_Advances()
+    {
+        // Seed three catalog events in order; the projector for the MIDDLE one
+        // throws on build/redact (injected failing projector). The middle event
+        // must be QUARANTINED (a failure-outcome row with a SAFE placeholder
+        // payload, NO plaintext), the failure metric must fire, the cursor must
+        // advance past it, and the events AFTER it must still project (no stall).
+        const string plaintext = "tamma_sk_POISONPILL0123456789";
+        await SeedDomainEvent("SECRET.WRITE", _tenantA, data: new { apiKey = "first" });
+        await SeedDomainEvent("SECRET.REVEAL", _tenantA, data: new { apiKey = plaintext });
+        await SeedDomainEvent("SECRET.READ", _tenantA, data: new { apiKey = "third" });
+
+        // Inject a projector that throws on the SECRET.REVEAL event only (it
+        // delegates the quarantine build to the REAL projector so the safe-payload
+        // path is exercised end to end).
+        var failing = new FailingOnTypeProjector("SECRET.REVEAL");
+        await using var sp = BuildServices(TammaMode.SaaS, projectorOverride: failing);
+
+        var inserted = await Svc(sp).ProcessOnceAsync(default);
+
+        // All three rows present: two normal + one quarantine.
+        (await CountTenant(_tenantA, _schemaA)).Should().Be(3,
+            "the failing event is quarantined (not dropped); the others project normally");
+        inserted.Should().Be(3);
+
+        await using var ta = NewTenant(_tenantA, _schemaA);
+        var rows = await ta.AuditRecords.OrderBy(r => r.SourceSequenceNumber).ToListAsync();
+
+        var quarantined = rows.Single(r => r.ActionCode == "SECRET.REVEAL");
+        quarantined.Outcome.Should().Be("failure", "a failed projection is recorded as a failure");
+        quarantined.PayloadJson.Should().NotContain(plaintext,
+            "the raw/un-redacted payload must NEVER reach the quarantine row");
+        quarantined.PayloadJson.Should().Contain("redaction_failed",
+            "the quarantine row carries the safe placeholder payload");
+
+        // The good neighbours are normal success rows.
+        rows.Where(r => r.ActionCode != "SECRET.REVEAL")
+            .Should().OnlyContain(r => r.Outcome == "success");
+
+        // The failure counter fired exactly once.
+        failing.ThrowCount.Should().Be(1);
+    }
+
     // ── snapshot/raw helpers ──
 
     private async Task<List<string>> SnapshotTenant(Guid tenantId, string schema)
@@ -415,6 +508,31 @@ public class AuditProjectorIntegrationTests
     private sealed class FixedModeProvider(TammaMode mode) : ITammaModeProvider
     {
         public TammaMode Mode { get; } = mode;
+    }
+
+    /// <summary>A projector that throws on a chosen event type to force the C2
+    /// quarantine path; everything else (including the quarantine build) delegates
+    /// to the REAL projector so the safe-payload behaviour is exercised genuinely.</summary>
+    private sealed class FailingOnTypeProjector(string failOnType) : IAuditProjector
+    {
+        private readonly AuditProjector _real = new();
+        public int ThrowCount { get; private set; }
+
+        public AuditRecord? TryBuildRecord(
+            RawAuditEvent rawEvent, AuditOwnershipMode mode, Guid? singleUserOwnerId)
+        {
+            if (string.Equals(rawEvent.Type, failOnType, StringComparison.Ordinal))
+            {
+                ThrowCount++;
+                throw new InvalidOperationException(
+                    "simulated redaction failure (e.g. RegexMatchTimeoutException)");
+            }
+            return _real.TryBuildRecord(rawEvent, mode, singleUserOwnerId);
+        }
+
+        public AuditRecord BuildQuarantineRecord(
+            RawAuditEvent rawEvent, AuditOwnershipMode mode, Guid? singleUserOwnerId) =>
+            _real.BuildQuarantineRecord(rawEvent, mode, singleUserOwnerId);
     }
 
     /// <summary>A factory that builds a TenantDbContext bound to the tenant's

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditProjectorTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditProjectorTests.cs
@@ -195,4 +195,44 @@ public class AuditProjectorTests
         rec.OccurredAt.Should().Be(raw.CreatedAt);
         rec.OccurredAt.Kind.Should().Be(DateTimeKind.Utc);
     }
+
+    // ── C2 — quarantine record: safe placeholder, never plaintext ──
+
+    [Test]
+    public void Quarantine_Record_Has_Failure_Outcome_Safe_Payload_And_Same_SourceId()
+    {
+        const string plaintext = "tamma_sk_DEADBEEF0123456789";
+        var raw = Raw("SECRET.REVEAL", tenantId: Guid.NewGuid(),
+            data: new { apiKey = plaintext });
+
+        var rec = _projector.BuildQuarantineRecord(raw, AuditOwnershipMode.SaaS, null);
+
+        // Idempotency key preserved so a quarantine row dedups like any other.
+        rec.SourceEventId.Should().Be(raw.Id);
+        rec.SourceSequenceNumber.Should().Be(raw.SequenceNumber);
+        // Classifiable fields survive (the redaction of the PAYLOAD is what failed).
+        rec.ActionCode.Should().Be("SECRET.REVEAL");
+        rec.Category.Should().Be("secret");
+        rec.Outcome.Should().Be("failure");
+        // The raw/un-redacted payload must NEVER appear; only the safe placeholder.
+        rec.PayloadJson.Should().Be(AuditProjector.QuarantinePayload);
+        rec.PayloadJson.Should().NotContain(plaintext);
+        rec.PayloadJson.Should().Contain("redaction_failed");
+    }
+
+    [Test]
+    public void Quarantine_Record_Routes_Ownership_Per_Mode()
+    {
+        var tenantId = Guid.NewGuid();
+        var saas = _projector.BuildQuarantineRecord(
+            Raw("SECRET.REVEAL", tenantId: tenantId), AuditOwnershipMode.SaaS, null);
+        saas.TenantId.Should().Be(tenantId);
+        saas.UserId.Should().BeNull();
+
+        var ownerId = Guid.NewGuid();
+        var single = _projector.BuildQuarantineRecord(
+            Raw("SECRET.REVEAL", tenantId: tenantId), AuditOwnershipMode.SingleUser, ownerId);
+        single.UserId.Should().Be(ownerId);
+        single.TenantId.Should().BeNull();
+    }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditProjectorTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditProjectorTests.cs
@@ -1,0 +1,198 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core.Audit;
+using Tamma.Data.Audit;
+
+namespace Tamma.Api.Tests.Audit;
+
+/// <summary>
+/// Story 37-1 (AC7, AC10, AC11) — pure unit tests for <see cref="AuditProjector"/>.
+/// No DB: the projector is pure classification + redaction + ownership routing.
+/// </summary>
+[TestFixture]
+public class AuditProjectorTests
+{
+    private readonly AuditProjector _projector = new();
+
+    private static RawAuditEvent Raw(
+        string type, Guid? tenantId = null,
+        object? tags = null, object? data = null, long seq = 1) =>
+        new(
+            Guid.NewGuid(), type, tenantId,
+            JsonSerializer.Serialize(tags ?? new { }),
+            JsonSerializer.Serialize(data ?? new { }),
+            new DateTime(2026, 6, 18, 10, 0, 0, DateTimeKind.Utc),
+            seq);
+
+    // ── AC7 — non-catalog events produce no record ──
+
+    [Test]
+    public void NonCatalog_Event_Yields_Null()
+    {
+        var raw = Raw("WORKFLOW.STEP_COMPLETED", tenantId: Guid.NewGuid());
+        _projector.TryBuildRecord(raw, AuditOwnershipMode.SaaS, null).Should().BeNull();
+    }
+
+    [Test]
+    public void Catalog_Event_Yields_Record_With_Classification()
+    {
+        var raw = Raw("SECRET.REVEAL", tenantId: Guid.NewGuid());
+        var rec = _projector.TryBuildRecord(raw, AuditOwnershipMode.SaaS, null);
+
+        rec.Should().NotBeNull();
+        rec!.ActionCode.Should().Be("SECRET.REVEAL");
+        rec.Category.Should().Be("secret");
+        rec.Severity.Should().Be("critical");
+        rec.SourceEventId.Should().Be(raw.Id);
+        rec.SourceSequenceNumber.Should().Be(raw.SequenceNumber);
+        // AC12 — reserved hash columns left null.
+        rec.RecordHash.Should().BeNull();
+        rec.PrevRecordHash.Should().BeNull();
+    }
+
+    // ── AC11 — per-mode ownership routing ──
+
+    [Test]
+    public void Saas_TenantScoped_Event_Keys_TenantId_Only()
+    {
+        var tenantId = Guid.NewGuid();
+        var raw = Raw("TENANT.MEMBER_ROLE_CHANGED.SUCCESS", tenantId: tenantId);
+
+        var rec = _projector.TryBuildRecord(raw, AuditOwnershipMode.SaaS, null)!;
+
+        rec.TenantId.Should().Be(tenantId);
+        rec.UserId.Should().BeNull();
+    }
+
+    [Test]
+    public void Saas_PlatformOnly_Event_Has_Neither_Owner_Set()
+    {
+        // TenantId null = platform-only (e.g. impersonation against the
+        // platform); the host routes it to the CP store with tenant_id null.
+        var raw = Raw("IMPERSONATION.STARTED", tenantId: null);
+        var rec = _projector.TryBuildRecord(raw, AuditOwnershipMode.SaaS, null)!;
+
+        rec.TenantId.Should().BeNull();
+        rec.UserId.Should().BeNull();
+    }
+
+    [Test]
+    public void SingleUser_Event_Keys_UserId_Only()
+    {
+        var ownerId = Guid.NewGuid();
+        var raw = Raw("SECRET.REVEAL", tenantId: Guid.NewGuid());
+
+        var rec = _projector.TryBuildRecord(raw, AuditOwnershipMode.SingleUser, ownerId)!;
+
+        rec.UserId.Should().Be(ownerId);
+        rec.TenantId.Should().BeNull("single-user rows have no tenant dimension");
+    }
+
+    [Test]
+    public void SingleUser_Falls_Back_To_Actor_When_No_Owner_Provided()
+    {
+        var actorId = Guid.NewGuid();
+        var raw = Raw("SECRET.REVEAL", tenantId: Guid.NewGuid(),
+            tags: new { actorUserId = actorId.ToString() });
+
+        var rec = _projector.TryBuildRecord(raw, AuditOwnershipMode.SingleUser, null)!;
+
+        rec.UserId.Should().Be(actorId);
+        rec.TenantId.Should().BeNull();
+    }
+
+    [Test]
+    public void SingleUser_With_No_Owner_And_No_Actor_Throws()
+    {
+        var raw = Raw("SECRET.REVEAL", tenantId: Guid.NewGuid());
+        var act = () => _projector.TryBuildRecord(raw, AuditOwnershipMode.SingleUser, null);
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    // ── AC10 — redaction BEFORE persistence; plaintext never lands ──
+
+    [Test]
+    public void SecretWrite_Payload_Is_Redacted_Never_Plaintext()
+    {
+        const string plaintext = "tamma_sk_DEADBEEF0123456789";
+        var raw = Raw("SECRET.WRITE", tenantId: Guid.NewGuid(),
+            data: new
+            {
+                apiKey = plaintext,
+                authHeader = "Bearer abcdefghijklmnopqrstuvwxyz",
+                connection = "password=hunter2supersecret",
+            });
+
+        var rec = _projector.TryBuildRecord(raw, AuditOwnershipMode.SaaS, null)!;
+
+        rec.PayloadJson.Should().Contain("[REDACTED]");
+        rec.PayloadJson.Should().NotContain(plaintext);
+        rec.PayloadJson.Should().NotContain("hunter2supersecret");
+        rec.PayloadJson.Should().NotContain("abcdefghijklmnopqrstuvwxyz");
+    }
+
+    [Test]
+    public void Bearer_Token_In_Tags_Is_Redacted()
+    {
+        var raw = Raw("SECRET.REVEAL", tenantId: Guid.NewGuid(),
+            tags: new { note = "Authorization: Bearer ghp_0123456789abcdefABCDEF" });
+
+        var rec = _projector.TryBuildRecord(raw, AuditOwnershipMode.SaaS, null)!;
+
+        rec.PayloadJson.Should().Contain("[REDACTED]");
+        rec.PayloadJson.Should().NotContain("ghp_0123456789abcdefABCDEF");
+    }
+
+    // ── Actor / target / outcome resolution ──
+
+    [Test]
+    public void Resolves_Actor_And_Target_From_Tags()
+    {
+        var actorId = Guid.NewGuid();
+        var targetId = Guid.NewGuid();
+        var raw = Raw("TENANT.MEMBER_ROLE_CHANGED.SUCCESS", tenantId: Guid.NewGuid(),
+            tags: new { userId = actorId.ToString(), actorEmail = "admin@example.com" },
+            data: new { targetUserId = targetId.ToString() });
+
+        var rec = _projector.TryBuildRecord(raw, AuditOwnershipMode.SaaS, null)!;
+
+        rec.ActorUserId.Should().Be(actorId);
+        rec.ActorEmailSnapshot.Should().Be("admin@example.com");
+        rec.TargetId.Should().Be(targetId.ToString());
+        rec.TargetType.Should().Be("user");
+    }
+
+    [Test]
+    public void Failure_Suffix_Sets_Outcome_Failure()
+    {
+        var raw = Raw("AGENT.DISPATCH.FAILED", tenantId: Guid.NewGuid());
+        _projector.TryBuildRecord(raw, AuditOwnershipMode.SaaS, null)!
+            .Outcome.Should().Be("failure");
+    }
+
+    [Test]
+    public void ReuseDetected_Sets_Outcome_Denied()
+    {
+        var raw = Raw("AUTH.REFRESH_REUSE_DETECTED", tenantId: null);
+        _projector.TryBuildRecord(raw, AuditOwnershipMode.SaaS, null)!
+            .Outcome.Should().Be("denied");
+    }
+
+    [Test]
+    public void Default_Outcome_Is_Success()
+    {
+        var raw = Raw("SECRET.READ", tenantId: Guid.NewGuid());
+        _projector.TryBuildRecord(raw, AuditOwnershipMode.SaaS, null)!
+            .Outcome.Should().Be("success");
+    }
+
+    [Test]
+    public void OccurredAt_Mirrors_RawEvent_CreatedAt_Utc()
+    {
+        var raw = Raw("SECRET.READ", tenantId: Guid.NewGuid());
+        var rec = _projector.TryBuildRecord(raw, AuditOwnershipMode.SaaS, null)!;
+        rec.OccurredAt.Should().Be(raw.CreatedAt);
+        rec.OccurredAt.Kind.Should().Be(DateTimeKind.Utc);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditProjectorTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditProjectorTests.cs
@@ -235,4 +235,35 @@ public class AuditProjectorTests
         single.UserId.Should().Be(ownerId);
         single.TenantId.Should().BeNull();
     }
+
+    // ── C2 — quarantine of an event with NO catalog descriptor ──
+    //
+    // When the descriptor itself is missing (a build failure with no
+    // classification), Category must use its OWN dedicated sentinel constant
+    // (UnclassifiedCategory) — NOT the target-type sentinel. The two columns are
+    // different dimensions and must not be wired to one constant, even though
+    // both currently spell "unclassified": a future divergence in either spelling
+    // must not silently desync the other. This test pins the two constants to the
+    // two columns independently so the cosmetic reuse can't creep back.
+    [Test]
+    public void Quarantine_Record_NoDescriptor_Uses_Dedicated_Category_And_TargetType_Constants()
+    {
+        // WORKFLOW.STEP_COMPLETED is intentionally NOT in SensitiveActionCatalog
+        // (see NonCatalog_Event_Yields_Null), so the descriptor resolves to null
+        // and the quarantine builder takes its fallback branch.
+        var raw = Raw("WORKFLOW.STEP_COMPLETED", tenantId: Guid.NewGuid());
+
+        var rec = _projector.BuildQuarantineRecord(raw, AuditOwnershipMode.SaaS, null);
+
+        // Category comes from the category-dimension constant — proven by binding
+        // the assertion to that exact constant, not the target-type one.
+        rec.Category.Should().Be(AuditProjector.UnclassifiedCategory);
+        // TargetType comes from the target-type-dimension constant.
+        rec.TargetType.Should().Be(AuditProjector.UnclassifiedTargetType);
+        // No catalog descriptor → ActionCode degrades to the raw event type.
+        rec.ActionCode.Should().Be("WORKFLOW.STEP_COMPLETED");
+        // Still a quarantine row: failure outcome + safe placeholder payload.
+        rec.Outcome.Should().Be("failure");
+        rec.PayloadJson.Should().Be(AuditProjector.QuarantinePayload);
+    }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditRecordMigrationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditRecordMigrationTests.cs
@@ -1,0 +1,198 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql;
+using NUnit.Framework;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Audit;
+
+/// <summary>
+/// Story 37-1 (AC5, AC6, AC8) — applies the ControlPlane migration bundle to a
+/// clean Postgres 17 testcontainer and asserts the audit schema landed: both
+/// new tables, the principal-XOR + outcome CHECK constraints, the unique
+/// <c>source_event_id</c> idempotency index, and that the XOR + unique
+/// constraints actually reject the bad rows. Mirrors <c>BillingMigrationTests</c>.
+/// </summary>
+[TestFixture]
+public class AuditRecordMigrationTests
+{
+    private const string ThisMigration = "20260619003618_AddAuditRecords";
+    private const string PrevMigration = "20260618212532_AddBillingCustomerAndPlanPrices";
+
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("audit_migration_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    private ControlPlaneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    private async Task<NpgsqlConnection> OpenAsync()
+    {
+        var conn = new NpgsqlConnection(_cs);
+        await conn.OpenAsync();
+        return conn;
+    }
+
+    private async Task<HashSet<string>> QueryStringsAsync(NpgsqlConnection conn, string sql)
+    {
+        var result = new HashSet<string>(StringComparer.Ordinal);
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+            if (!reader.IsDBNull(0)) result.Add(reader.GetString(0));
+        return result;
+    }
+
+    [Test]
+    public async Task Migration_Creates_Both_Audit_Tables()
+    {
+        await using var conn = await OpenAsync();
+        var tables = await QueryStringsAsync(conn,
+            "SELECT table_name FROM information_schema.tables WHERE table_schema='public';");
+
+        tables.Should().Contain("audit_records");
+        tables.Should().Contain("audit_projector_cursor");
+    }
+
+    [Test]
+    public async Task Migration_Creates_The_XOR_And_Outcome_Check_Constraints()
+    {
+        await using var conn = await OpenAsync();
+        var checks = await QueryStringsAsync(conn,
+            "SELECT conname FROM pg_constraint WHERE contype='c';");
+
+        checks.Should().Contain("ck_audit_records_principal_xor");
+        checks.Should().Contain("ck_audit_records_outcome");
+    }
+
+    [Test]
+    public async Task Migration_Creates_The_Unique_SourceEventId_Index()
+    {
+        await using var conn = await OpenAsync();
+        var idx = await QueryStringsAsync(conn,
+            "SELECT indexname FROM pg_indexes WHERE tablename='audit_records';");
+
+        idx.Should().Contain("UX_audit_records_SourceEventId");
+        idx.Should().Contain("IX_audit_records_SourceSequenceNumber");
+    }
+
+    // ── AC5 — the XOR CHECK rejects both-set and neither-set ──
+
+    [Test]
+    public async Task XorCheck_Rejects_BothOwners_Set()
+    {
+        await using var conn = await OpenAsync();
+        var act = async () => await InsertRow(conn,
+            tenantId: Guid.NewGuid(), userId: Guid.NewGuid(), sourceId: Guid.NewGuid());
+        var ex = await act.Should().ThrowAsync<PostgresException>();
+        ex.Which.SqlState.Should().Be("23514"); // check_violation
+    }
+
+    [Test]
+    public async Task XorCheck_Accepts_Neither_Owner_Set_For_PlatformRow()
+    {
+        // AC11 — a SaaS platform-scope row (impersonation against the platform)
+        // legitimately has neither owner; it lives in the CP store. The CHECK is
+        // "not both", so this is accepted (it is NOT a strict exactly-one XOR).
+        await using var conn = await OpenAsync();
+        (await InsertRow(conn, tenantId: null, userId: null, sourceId: Guid.NewGuid()))
+            .Should().Be(1);
+    }
+
+    [Test]
+    public async Task XorCheck_Accepts_TenantOnly_And_UserOnly()
+    {
+        await using var conn = await OpenAsync();
+        (await InsertRow(conn, tenantId: Guid.NewGuid(), userId: null, sourceId: Guid.NewGuid()))
+            .Should().Be(1);
+        (await InsertRow(conn, tenantId: null, userId: Guid.NewGuid(), sourceId: Guid.NewGuid()))
+            .Should().Be(1);
+    }
+
+    // ── AC8 — the unique source_event_id index rejects a duplicate ──
+
+    [Test]
+    public async Task Unique_SourceEventId_Rejects_Duplicate()
+    {
+        await using var conn = await OpenAsync();
+        var sourceId = Guid.NewGuid();
+        (await InsertRow(conn, tenantId: Guid.NewGuid(), userId: null, sourceId: sourceId))
+            .Should().Be(1);
+
+        var act = async () =>
+            await InsertRow(conn, tenantId: Guid.NewGuid(), userId: null, sourceId: sourceId);
+        var ex = await act.Should().ThrowAsync<PostgresException>();
+        ex.Which.SqlState.Should().Be("23505"); // unique_violation
+    }
+
+    // ── AC6 — migration rolls back + forward cleanly ──
+
+    [Test]
+    public async Task Migration_Down_Drops_Both_Tables_Then_Up_Restores()
+    {
+        await using (var down = NewContext())
+            await down.GetService<IMigrator>().MigrateAsync(PrevMigration);
+
+        await using (var conn = await OpenAsync())
+        {
+            var tables = await QueryStringsAsync(conn,
+                "SELECT table_name FROM information_schema.tables WHERE table_schema='public';");
+            tables.Should().NotContain("audit_records");
+            tables.Should().NotContain("audit_projector_cursor");
+        }
+
+        await using (var up = NewContext())
+            await up.GetService<IMigrator>().MigrateAsync(ThisMigration);
+
+        await using (var conn = await OpenAsync())
+        {
+            var tables = await QueryStringsAsync(conn,
+                "SELECT table_name FROM information_schema.tables WHERE table_schema='public';");
+            tables.Should().Contain("audit_records");
+            tables.Should().Contain("audit_projector_cursor");
+        }
+    }
+
+    private static async Task<int> InsertRow(
+        NpgsqlConnection conn, Guid? tenantId, Guid? userId, Guid sourceId)
+    {
+        await using var cmd = new NpgsqlCommand(
+            """
+            INSERT INTO audit_records
+              ("ActionCode","Category","Severity","Outcome","OccurredAt",
+               "SourceEventId","SourceSequenceNumber","PayloadJson","TenantId","UserId")
+            VALUES
+              ('SECRET.REVEAL','secret','critical','success', now(),
+               @src, 1, '{}'::jsonb, @tid, @uid);
+            """, conn);
+        cmd.Parameters.AddWithValue("src", sourceId);
+        cmd.Parameters.AddWithValue("tid", (object?)tenantId ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("uid", (object?)userId ?? DBNull.Value);
+        return await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditRecordMigrationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditRecordMigrationTests.cs
@@ -79,6 +79,65 @@ public class AuditRecordMigrationTests
         tables.Should().Contain("audit_projector_cursor");
     }
 
+    // ── C1 — the cursor table is keyed per-(ProjectorId, TenantId) ──
+
+    [Test]
+    public async Task Cursor_Table_Has_TenantId_Column_In_Composite_PrimaryKey()
+    {
+        await using var conn = await OpenAsync();
+
+        // The TenantId column exists (uuid, not null — it is a key column).
+        var cols = await QueryStringsAsync(conn,
+            "SELECT column_name FROM information_schema.columns "
+            + "WHERE table_schema='public' AND table_name='audit_projector_cursor';");
+        cols.Should().Contain("TenantId",
+            "C1 — the domain cursor is tracked per tenant");
+
+        // The primary key is the composite (ProjectorId, TenantId).
+        var pkCols = await QueryStringsAsync(conn,
+            """
+            SELECT a.attname
+            FROM   pg_index i
+            JOIN   pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+            WHERE  i.indrelid = 'public.audit_projector_cursor'::regclass AND i.indisprimary;
+            """);
+        pkCols.Should().BeEquivalentTo(new[] { "ProjectorId", "TenantId" },
+            "the cursor primary key must be the composite (ProjectorId, TenantId)");
+    }
+
+    [Test]
+    public async Task Cursor_Table_Allows_One_Row_Per_Tenant_Same_Projector()
+    {
+        await using var conn = await OpenAsync();
+        var ta = Guid.NewGuid();
+        var tb = Guid.NewGuid();
+
+        // Two tenants under the same projector id — both rows must be accepted
+        // (independent per-tenant domain high-water marks).
+        (await InsertCursorRow(conn, "default", ta, 5)).Should().Be(1);
+        (await InsertCursorRow(conn, "default", tb, 1)).Should().Be(1);
+
+        // The same (projector, tenant) twice violates the composite PK.
+        var act = async () => await InsertCursorRow(conn, "default", ta, 9);
+        var ex = await act.Should().ThrowAsync<PostgresException>();
+        ex.Which.SqlState.Should().Be("23505"); // unique_violation
+    }
+
+    private static async Task<int> InsertCursorRow(
+        NpgsqlConnection conn, string projectorId, Guid tenantId, long lastDomainSeq)
+    {
+        await using var cmd = new NpgsqlCommand(
+            """
+            INSERT INTO audit_projector_cursor
+              ("ProjectorId","TenantId","LastDomainSequenceNumber","LastPlatformSequenceNumber","UpdatedAt")
+            VALUES (@pid, @tid, @seq, 0, now());
+            """, conn);
+        cmd.Parameters.AddWithValue("pid", projectorId);
+        cmd.Parameters.AddWithValue("tid", tenantId);
+        cmd.Parameters.AddWithValue("seq", lastDomainSeq);
+        return await cmd.ExecuteNonQueryAsync();
+    }
+
     [Test]
     public async Task Migration_Creates_The_XOR_And_Outcome_Check_Constraints()
     {

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditRecordModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditRecordModelTests.cs
@@ -1,0 +1,138 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using Tamma.Data;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Tests.Audit;
+
+/// <summary>
+/// Story 37-1 (AC4–AC6, AC12) — model-shape tests for <see cref="AuditRecord"/>
+/// + <see cref="AuditProjectorCursor"/>. Pure model-metadata inspection (no
+/// Postgres connection opened). The constraint/idempotency proofs InMemory
+/// cannot honour (XOR CHECK, UNIQUE, search-path isolation) live in
+/// <see cref="AuditRecordMigrationTests"/> against a real Postgres 17 container.
+/// </summary>
+[TestFixture]
+public class AuditRecordModelTests
+{
+    private static ControlPlaneDbContext Cp() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseNpgsql("Host=localhost;Database=cp_test;Username=tamma;Password=tamma")
+            .Options);
+
+    private static TenantDbContext Tenant() =>
+        new(new DbContextOptionsBuilder<TenantDbContext>()
+            .UseNpgsql("Host=localhost;Database=tenant_test;Username=tamma;Password=tamma")
+            .Options);
+
+    // ── AC4 — audit_records mapped on BOTH contexts ──
+
+    [Test]
+    public void AuditRecords_Mapped_On_ControlPlane()
+    {
+        using var ctx = Cp();
+        ctx.Model.GetEntityTypes().Select(t => t.GetTableName())
+            .Should().Contain("audit_records");
+    }
+
+    [Test]
+    public void AuditRecords_Mapped_On_Tenant()
+    {
+        using var ctx = Tenant();
+        ctx.Model.GetEntityTypes().Select(t => t.GetTableName())
+            .Should().Contain("audit_records");
+    }
+
+    // ── AC4 — the projector cursor lives ONLY on the control plane ──
+
+    [Test]
+    public void ProjectorCursor_Mapped_On_ControlPlane_Only()
+    {
+        using var cp = Cp();
+        cp.Model.GetEntityTypes().Select(t => t.GetTableName())
+            .Should().Contain("audit_projector_cursor");
+
+        using var tenant = Tenant();
+        tenant.Model.GetEntityTypes().Select(t => t.GetTableName())
+            .Should().NotContain("audit_projector_cursor",
+                "the single projector resumes from one CP-resident cursor row");
+    }
+
+    // ── AC4 — the full column set ──
+
+    [Test]
+    public void AuditRecord_Has_The_Full_Column_Set()
+    {
+        using var ctx = Cp();
+        var props = ctx.Model.FindEntityType(typeof(AuditRecord))!
+            .GetProperties().Select(p => p.Name).ToHashSet();
+
+        props.Should().BeEquivalentTo(new[]
+        {
+            "Id", "ActionCode", "Category", "Severity",
+            "ActorUserId", "ActorEmailSnapshot",
+            "TargetType", "TargetId", "Outcome",
+            "IpAddress", "UserAgent", "OccurredAt",
+            "SourceEventId", "SourceSequenceNumber", "PayloadJson",
+            "TenantId", "UserId",
+            "RecordHash", "PrevRecordHash",
+        });
+    }
+
+    // ── AC12 — reserved 37-2 hash columns exist and are nullable ──
+
+    [Test]
+    public void Reserved_Hash_Columns_Are_Nullable()
+    {
+        using var ctx = Cp();
+        var entity = ctx.Model.FindEntityType(typeof(AuditRecord))!;
+        entity.FindProperty("RecordHash")!.IsNullable.Should().BeTrue();
+        entity.FindProperty("PrevRecordHash")!.IsNullable.Should().BeTrue();
+    }
+
+    // ── AC4 — payload is jsonb; occurred_at is timestamptz ──
+
+    [Test]
+    public void Payload_Is_Jsonb_And_OccurredAt_Is_TimestampTz()
+    {
+        using var ctx = Cp();
+        var entity = ctx.Model.FindEntityType(typeof(AuditRecord))!;
+        entity.FindProperty("PayloadJson")!.GetColumnType().Should().Be("jsonb");
+        entity.FindProperty("OccurredAt")!.GetColumnType().Should().Be("timestamp with time zone");
+    }
+
+    // ── AC5 — the ownership columns are nullable (XOR enforced by CHECK, not NOT NULL) ──
+
+    [Test]
+    public void Ownership_Columns_Are_Nullable()
+    {
+        using var ctx = Cp();
+        var entity = ctx.Model.FindEntityType(typeof(AuditRecord))!;
+        entity.FindProperty("TenantId")!.IsNullable.Should().BeTrue();
+        entity.FindProperty("UserId")!.IsNullable.Should().BeTrue();
+    }
+
+    // ── AC5/AC8 — the unique source_event_id index (idempotency key) ──
+
+    [Test]
+    public void Has_Unique_SourceEventId_Index()
+    {
+        using var ctx = Cp();
+        var index = ctx.Model.FindEntityType(typeof(AuditRecord))!
+            .GetIndexes().Single(i => i.GetDatabaseName() == "UX_audit_records_SourceEventId");
+        index.IsUnique.Should().BeTrue("one curated row per raw event (idempotency)");
+        index.Properties.Select(p => p.Name).Should().Equal("SourceEventId");
+    }
+
+    // ── AC12 — the deterministic-order index for 37-2's chain ──
+
+    [Test]
+    public void Has_SourceSequenceNumber_Index()
+    {
+        using var ctx = Cp();
+        ctx.Model.FindEntityType(typeof(AuditRecord))!
+            .GetIndexes().Should().Contain(i =>
+                i.GetDatabaseName() == "IX_audit_records_SourceSequenceNumber");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/SensitiveActionCatalogTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/SensitiveActionCatalogTests.cs
@@ -142,4 +142,39 @@ public class SensitiveActionCatalogTests
         SensitiveActionCatalog.Resolve("WORKFLOW.STEP_COMPLETED").Should().BeNull();
         SensitiveActionCatalog.Resolve(null).Should().BeNull();
     }
+
+    // ── M1 — duplicate const VALUE detection ──
+
+    [Test]
+    public void Const_Event_Type_Values_Are_All_Distinct()
+    {
+        // The static ctor builds ByCode via map[code] = ... (indexer), so two
+        // public const fields that accidentally carry the SAME string value would
+        // SILENTLY overwrite / mis-classify with no signal. Reflect over the public
+        // const string fields and assert there are no duplicate values, AND that
+        // the built dictionary's Count equals the distinct code count (i.e. the
+        // map was built without a silent collision).
+        var constValues = typeof(SensitiveActionCatalog)
+            .GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+            .Where(f => f.IsLiteral && !f.IsInitOnly && f.FieldType == typeof(string))
+            .Select(f => (string)f.GetRawConstantValue()!)
+            .ToList();
+
+        constValues.Should().NotBeEmpty("the catalog defines its codes as public consts");
+
+        var distinct = constValues.Distinct(StringComparer.Ordinal).ToList();
+        constValues.Should().HaveCount(distinct.Count,
+            "no two const action-code values may collide (the static ctor's indexer "
+            + "would silently overwrite the earlier classification)");
+
+        // Every distinct const value is a key, and the dictionary has exactly that
+        // many entries — proof the indexer never silently merged two codes into one.
+        SensitiveActionCatalog.ByCode.Count.Should().Be(distinct.Count,
+            "ByCode.Count must equal the distinct const code count — no silent collision");
+        foreach (var value in distinct)
+        {
+            SensitiveActionCatalog.ByCode.Should().ContainKey(value,
+                $"every const code '{value}' must be catalogued");
+        }
+    }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/SensitiveActionCatalogTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/SensitiveActionCatalogTests.cs
@@ -1,0 +1,145 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Api.Services.Secrets;
+using Tamma.Core.Audit;
+
+namespace Tamma.Api.Tests.Audit;
+
+/// <summary>
+/// Story 37-1 (AC1–AC3, AC13a) — pure catalog completeness + classification
+/// tests for <see cref="SensitiveActionCatalog"/>. No DB. Reflects over the
+/// REAL emitter constants (<see cref="SecretAuditEventTypes"/>) and the known
+/// DCB event-type strings so a future rename that drops an emitted type from
+/// the catalog fails CI.
+/// </summary>
+[TestFixture]
+public class SensitiveActionCatalogTests
+{
+    // ── AC1 — ≥30 codes ──
+
+    [Test]
+    public void Catalog_Has_At_Least_30_Codes()
+    {
+        SensitiveActionCatalog.ByCode.Count.Should().BeGreaterThanOrEqualTo(30,
+            "the taxonomy must be a meaningful catalogue, not a stub");
+    }
+
+    // ── AC2 — every one of the 11 categories has ≥1 code ──
+
+    [Test]
+    public void Catalog_Covers_All_Eleven_Categories()
+    {
+        var present = SensitiveActionCatalog.ByCode.Values
+            .Select(d => d.Category).Distinct().ToHashSet();
+
+        foreach (var cat in Enum.GetValues<AuditCategory>())
+        {
+            present.Should().Contain(cat,
+                $"category {cat} must have at least one catalogued action code");
+        }
+
+        present.Count.Should().Be(11, "there are exactly 11 audit categories");
+    }
+
+    // ── AC1 — every descriptor is well-formed ──
+
+    [Test]
+    public void Every_Descriptor_Has_NonEmpty_Soc2_Control_And_TargetHint()
+    {
+        foreach (var (code, desc) in SensitiveActionCatalog.ByCode)
+        {
+            desc.ActionCode.Should().Be(code, "the descriptor's ActionCode must equal its dictionary key");
+            desc.Soc2ControlId.Should().NotBeNullOrWhiteSpace(
+                $"{code} must map a SOC2 control id for compliance evidence");
+            desc.TargetTypeHint.Should().NotBeNullOrWhiteSpace(
+                $"{code} must carry a target-type hint");
+        }
+    }
+
+    [Test]
+    public void Severity_Values_Are_Within_The_Closed_Enum()
+    {
+        foreach (var desc in SensitiveActionCatalog.ByCode.Values)
+        {
+            Enum.IsDefined(desc.Severity).Should().BeTrue(
+                $"{desc.ActionCode} severity must be a defined AuditSeverity");
+        }
+    }
+
+    // ── AC3 / AC13a — every REAL existing emitter is catalogued + matching ──
+
+    [Test]
+    public void Every_SecretAuditEventType_Is_Catalogued()
+    {
+        // Reflect over the real emitter const-class so a renamed/dropped
+        // SECRET.* type that isn't reflected in the catalog fails CI.
+        var secretTypes = typeof(SecretAuditEventTypes)
+            .GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+            .Where(f => f.IsLiteral && f.FieldType == typeof(string))
+            .Select(f => (string)f.GetRawConstantValue()!)
+            .ToList();
+
+        secretTypes.Should().NotBeEmpty("SecretAuditEventTypes defines the Epic 29 secret events");
+
+        // The migration/skipped variants (MIGRATED.*) are out of the
+        // compliance-sensitive surface; assert the core access events are
+        // catalogued. Every catalogued one MUST be classified Secret.
+        foreach (var t in new[]
+        {
+            SecretAuditEventTypes.Read, SecretAuditEventTypes.Write,
+            SecretAuditEventTypes.Reveal, SecretAuditEventTypes.RotateStarted,
+            SecretAuditEventTypes.RotateSucceeded, SecretAuditEventTypes.RotateFailed,
+            SecretAuditEventTypes.VersionRevoked,
+        })
+        {
+            SensitiveActionCatalog.ByCode.Should().ContainKey(t,
+                $"the secret-access emitter '{t}' must be catalogued");
+            SensitiveActionCatalog.ByCode[t].Category.Should().Be(AuditCategory.Secret);
+            SensitiveActionCatalog.ByCode[t].MapsExistingEmitter.Should().BeTrue(
+                $"'{t}' is a verified existing emitter");
+        }
+    }
+
+    [TestCase("IMPERSONATION.STARTED", AuditCategory.Impersonation)]
+    [TestCase("IMPERSONATION.ENDED", AuditCategory.Impersonation)]
+    [TestCase("TENANT.MEMBER_ROLE_CHANGED.SUCCESS", AuditCategory.Rbac)]
+    [TestCase("TENANT.MEMBER_REMOVED.SUCCESS", AuditCategory.Rbac)]
+    [TestCase("TENANT.OWNERSHIP_TRANSFERRED.SUCCESS", AuditCategory.Rbac)]
+    [TestCase("USER.LOGOUT_ALL.SUCCESS", AuditCategory.Auth)]
+    [TestCase("AUTH.REFRESH_REUSE_DETECTED", AuditCategory.Auth)]
+    [TestCase("CONVENTION.UPDATED.SUCCESS", AuditCategory.Config)]
+    [TestCase("PROMPT.UPDATED.SUCCESS", AuditCategory.Persona)]
+    [TestCase("AGENT_CONFIG.UPDATED.SUCCESS", AuditCategory.Config)]
+    [TestCase("AGENT.CREATED.SUCCESS", AuditCategory.Agent)]
+    [TestCase("BILLING.CUSTOMER.CREATED", AuditCategory.Billing)]
+    [TestCase("TENANT.PROVISIONED.SUCCESS", AuditCategory.Tenant)]
+    public void Verified_Existing_Emitter_Is_Catalogued_With_Matching_Category(
+        string eventType, AuditCategory expectedCategory)
+    {
+        SensitiveActionCatalog.ByCode.Should().ContainKey(eventType,
+            $"the verified existing emitter '{eventType}' must be in the catalog");
+        var desc = SensitiveActionCatalog.ByCode[eventType];
+        desc.Category.Should().Be(expectedCategory);
+        desc.MapsExistingEmitter.Should().BeTrue(
+            $"'{eventType}' is appended to the DCB store by a real emitter today");
+    }
+
+    // ── AC7 — IsSensitive / Resolve are the only lookup path ──
+
+    [Test]
+    public void IsSensitive_True_For_Catalogued_False_For_NonCatalogued()
+    {
+        SensitiveActionCatalog.IsSensitive("SECRET.REVEAL").Should().BeTrue();
+        SensitiveActionCatalog.IsSensitive("WORKFLOW.STEP_COMPLETED").Should().BeFalse();
+        SensitiveActionCatalog.IsSensitive(null).Should().BeFalse();
+        SensitiveActionCatalog.IsSensitive("").Should().BeFalse();
+    }
+
+    [Test]
+    public void Resolve_Returns_Descriptor_Or_Null()
+    {
+        SensitiveActionCatalog.Resolve("SECRET.REVEAL").Should().NotBeNull();
+        SensitiveActionCatalog.Resolve("WORKFLOW.STEP_COMPLETED").Should().BeNull();
+        SensitiveActionCatalog.Resolve(null).Should().BeNull();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Auth/PlatformOwnerAccessPolicyTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Auth/PlatformOwnerAccessPolicyTests.cs
@@ -160,6 +160,11 @@ public class PlatformOwnerAccessPolicyTests
         "/api/admin/api-keys",
         "/api/admin/analytics/summary",
         "/api/admin/tenants",
+        // Story 34-1 follow-up — the plan price-book is platform-global
+        // (incl. BYOK-vs-platform pricing). It MUST gate on
+        // PlatformOwnerAccess, not OwnerAccess (Finding C1): a tenant-owner
+        // who is not a platform admin must NOT be able to read it.
+        "/api/admin/plans",
     };
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/AddTammaBillingTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/AddTammaBillingTests.cs
@@ -1,0 +1,114 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using Tamma.Api.Extensions;
+using Tamma.Api.Services.Billing;
+using Tamma.Api.Services.Billing.Tasks;
+using Tamma.Api.Services.PlatformTasks;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Services.Secrets.Stopgap;
+using Tamma.Data;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-1 (AC9, AC11) — mode-aware DI. SaaS config resolves
+/// <see cref="StripeBillingProvider"/>; single-user resolves
+/// <see cref="NullBillingProvider"/>. The retry handler is registered in both.
+/// </summary>
+[TestFixture]
+public class AddTammaBillingTests
+{
+    private sealed class FakeHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "Development";
+        public string ApplicationName { get; set; } = "Tamma.Api";
+        public string ContentRootPath { get; set; } = "/";
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } = null!;
+    }
+
+    private static ServiceProvider BuildProvider(IDictionary<string, string?> config)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(config)
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddSingleton<IHostEnvironment>(new FakeHostEnvironment());
+        services.AddSingleton<ITammaModeProvider, TammaModeProvider>();
+
+        // Billing depends on a CP context + event repo + secret resolver for the
+        // SaaS provider; register lightweight in-memory / mock doubles so the
+        // graph resolves.
+        services.AddDbContextFactory<ControlPlaneDbContext>(
+            o => o.UseInMemoryDatabase($"billing-di-{Guid.NewGuid():N}"));
+        services.AddScoped(sp =>
+            sp.GetRequiredService<IDbContextFactory<ControlPlaneDbContext>>().CreateDbContext());
+        services.AddScoped(_ => Moq.Mock.Of<IEventRepository>());
+        services.AddScoped(_ => Moq.Mock.Of<IRuntimeSecretResolver>());
+        services.AddPlatformTaskWorker(configuration);
+
+        services.AddTammaBilling(configuration);
+        return services.BuildServiceProvider();
+    }
+
+    [Test]
+    public void Saas_Config_Resolves_StripeBillingProvider()
+    {
+        using var sp = BuildProvider(new Dictionary<string, string?>
+        {
+            ["Tamma:Mode"] = "saas",
+        });
+        using var scope = sp.CreateScope();
+
+        scope.ServiceProvider.GetRequiredService<IBillingProvider>()
+            .Should().BeOfType<StripeBillingProvider>();
+    }
+
+    [Test]
+    public void SingleUser_Config_Resolves_NullBillingProvider()
+    {
+        using var sp = BuildProvider(new Dictionary<string, string?>
+        {
+            ["Tamma:Mode"] = "single-user",
+        });
+        using var scope = sp.CreateScope();
+
+        var provider = scope.ServiceProvider.GetRequiredService<IBillingProvider>();
+        provider.Should().BeOfType<NullBillingProvider>();
+        provider.IsEnabled.Should().BeFalse();
+    }
+
+    [Test]
+    public void Retry_Handler_Is_Registered()
+    {
+        using var sp = BuildProvider(new Dictionary<string, string?>
+        {
+            ["Tamma:Mode"] = "saas",
+        });
+        using var scope = sp.CreateScope();
+
+        var handlers = scope.ServiceProvider.GetServices<IPlatformTaskHandler>();
+        handlers.Should().Contain(h => h is CreateBillingCustomerTaskHandler);
+    }
+
+    [Test]
+    public void Catalog_And_Factory_Are_Registered()
+    {
+        using var sp = BuildProvider(new Dictionary<string, string?>
+        {
+            ["Tamma:Mode"] = "saas",
+        });
+        using var scope = sp.CreateScope();
+
+        scope.ServiceProvider.GetService<IBillingCatalog>().Should().NotBeNull();
+        scope.ServiceProvider.GetService<IStripeServicesFactory>().Should().NotBeNull();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingCatalogTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingCatalogTests.cs
@@ -1,0 +1,103 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Tamma.Api.Services.Billing;
+using Tamma.Core;
+using Tamma.Data;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-1 — <see cref="BillingCatalog"/> resolves a <see cref="BillingPlanPrice"/>
+/// by slug, throws a fail-loud error on an unknown slug (never silent null on
+/// the strict path), and caches a hit.
+/// </summary>
+[TestFixture]
+public class BillingCatalogTests
+{
+    private ServiceProvider _sp = null!;
+    private IDbContextFactory<ControlPlaneDbContext> _factory = null!;
+    private string _dbName = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _dbName = $"billing-catalog-{Guid.NewGuid():N}";
+        var services = new ServiceCollection();
+        services.AddDbContextFactory<ControlPlaneDbContext>(
+            opts => opts.UseInMemoryDatabase(_dbName));
+        _sp = services.BuildServiceProvider();
+        _factory = _sp.GetRequiredService<IDbContextFactory<ControlPlaneDbContext>>();
+    }
+
+    [TearDown]
+    public void TearDown() => _sp.Dispose();
+
+    private async Task SeedAsync(string slug)
+    {
+        await using var db = await _factory.CreateDbContextAsync();
+        db.BillingPlanPrices.Add(new BillingPlanPrice
+        {
+            Id = Guid.NewGuid(),
+            PlanSlug = slug,
+            StripeProductId = $"prod_{slug}",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        await db.SaveChangesAsync();
+    }
+
+    [Test]
+    public async Task GetBySlugAsync_Returns_Known_Slug()
+    {
+        await SeedAsync("team");
+        var catalog = new BillingCatalog(_factory);
+
+        var row = await catalog.GetBySlugAsync("team");
+
+        row.PlanSlug.Should().Be("team");
+        row.StripeProductId.Should().Be("prod_team");
+    }
+
+    [Test]
+    public async Task GetBySlugAsync_Unknown_Slug_Throws()
+    {
+        var catalog = new BillingCatalog(_factory);
+
+        var act = async () => await catalog.GetBySlugAsync("nope");
+
+        var ex = await act.Should().ThrowAsync<TammaError>();
+        ex.Which.Code.Should().Be("BILLING.CATALOG.UNKNOWN_SLUG");
+    }
+
+    [Test]
+    public async Task TryGetBySlugAsync_Unknown_Slug_Returns_Null()
+    {
+        var catalog = new BillingCatalog(_factory);
+        (await catalog.TryGetBySlugAsync("nope")).Should().BeNull();
+    }
+
+    [Test]
+    public async Task GetBySlugAsync_Caches_Hit_No_Second_Db_Read()
+    {
+        await SeedAsync("free");
+        var catalog = new BillingCatalog(_factory);
+
+        var first = await catalog.GetBySlugAsync("free");
+
+        // Mutate the underlying row; a cached read must still return the old value
+        // within the TTL (proves the cache served the second call).
+        await using (var db = await _factory.CreateDbContextAsync())
+        {
+            var row = await db.BillingPlanPrices.SingleAsync(r => r.PlanSlug == "free");
+            row.StripeProductId = "prod_changed";
+            await db.SaveChangesAsync();
+        }
+
+        var second = await catalog.GetBySlugAsync("free");
+        second.StripeProductId.Should().Be(first.StripeProductId)
+            .And.Be("prod_free", "the cached entry is served within the TTL");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingEntityModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingEntityModelTests.cs
@@ -1,0 +1,99 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using NUnit.Framework;
+using Tamma.Data;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-1 (AC1, AC2) — model-shape assertions for the billing foundation
+/// entities. Pure design-time model metadata inspection (no Postgres
+/// connection). Confirms the two tables map, the column defaults
+/// (<c>BillingMode="PlatformProvided"</c>, <c>DefaultCurrency="usd"</c>,
+/// <c>TaxStatus="none"</c>), the unique indexes (tenant + slug), the partial
+/// unique on Stripe customer id, and the BillingMode CHECK constraint.
+/// </summary>
+[TestFixture]
+public class BillingEntityModelTests
+{
+    private static ControlPlaneDbContext CreateContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseNpgsql("Host=localhost;Database=cp_test;Username=tamma;Password=tamma")
+            .Options);
+
+    [Test]
+    public void Billing_Tables_Are_Mapped()
+    {
+        using var ctx = CreateContext();
+        var tables = ctx.Model.GetEntityTypes()
+            .Select(t => t.GetTableName())
+            .ToHashSet();
+
+        tables.Should().Contain("billing_customers");
+        tables.Should().Contain("billing_plan_prices");
+    }
+
+    [Test]
+    public void BillingCustomer_Has_Column_Defaults()
+    {
+        using var ctx = CreateContext();
+        var entity = ctx.Model.FindEntityType(typeof(BillingCustomer))!;
+
+        entity.FindProperty(nameof(BillingCustomer.BillingMode))!
+            .GetDefaultValue().Should().Be("PlatformProvided");
+        entity.FindProperty(nameof(BillingCustomer.DefaultCurrency))!
+            .GetDefaultValue().Should().Be("usd");
+        entity.FindProperty(nameof(BillingCustomer.TaxStatus))!
+            .GetDefaultValue().Should().Be("none");
+    }
+
+    [Test]
+    public void BillingCustomer_TenantId_Is_Unique()
+    {
+        using var ctx = CreateContext();
+        var entity = ctx.Model.FindEntityType(typeof(BillingCustomer))!;
+        var idx = entity.GetIndexes()
+            .Single(i => i.GetDatabaseName() == "UX_billing_customers_TenantId");
+
+        idx.IsUnique.Should().BeTrue();
+    }
+
+    [Test]
+    public void BillingCustomer_StripeCustomerId_Is_PartialUnique()
+    {
+        using var ctx = CreateContext();
+        var entity = ctx.Model.FindEntityType(typeof(BillingCustomer))!;
+        var idx = entity.GetIndexes()
+            .Single(i => i.GetDatabaseName() == "UX_billing_customers_StripeCustomerId");
+
+        idx.IsUnique.Should().BeTrue();
+        idx.GetFilter().Should().Contain("StripeCustomerId");
+    }
+
+    [Test]
+    public void BillingCustomer_Has_BillingMode_Check_Constraint()
+    {
+        using var ctx = CreateContext();
+        // Check constraints are only carried on the design-time model, not the
+        // read-optimized runtime model.
+        var model = ctx.GetService<IDesignTimeModel>().Model;
+        var entity = model.FindEntityType(typeof(BillingCustomer))!;
+        var checks = entity.GetCheckConstraints().Select(c => c.Name).ToList();
+
+        checks.Should().Contain("ck_billing_customers_mode");
+    }
+
+    [Test]
+    public void BillingPlanPrice_PlanSlug_Is_Unique()
+    {
+        using var ctx = CreateContext();
+        var entity = ctx.Model.FindEntityType(typeof(BillingPlanPrice))!;
+        var idx = entity.GetIndexes()
+            .Single(i => i.GetDatabaseName() == "UX_billing_plan_prices_PlanSlug");
+
+        idx.IsUnique.Should().BeTrue();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingMigrationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingMigrationTests.cs
@@ -1,0 +1,170 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql;
+using NUnit.Framework;
+using Tamma.Data;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-1 (AC3) — applies the ControlPlane migration bundle to a clean
+/// Postgres testcontainer and asserts the billing schema landed: the two new
+/// tables, the BillingMode CHECK constraint, the unique tenant index, the
+/// partial-unique Stripe-customer-id index, the unique slug index, and that
+/// the migration rolls back cleanly (down drops both tables). Raw Npgsql
+/// introspection — mirrors the existing migration suites.
+/// </summary>
+[TestFixture]
+public class BillingMigrationTests
+{
+    private const string ThisMigration = "20260618212532_AddBillingCustomerAndPlanPrices";
+
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("billing_migration_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    private ControlPlaneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    private async Task<NpgsqlConnection> OpenAsync()
+    {
+        var conn = new NpgsqlConnection(_cs);
+        await conn.OpenAsync();
+        return conn;
+    }
+
+    private async Task<HashSet<string>> QueryStringsAsync(NpgsqlConnection conn, string sql)
+    {
+        var result = new HashSet<string>(StringComparer.Ordinal);
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            if (!reader.IsDBNull(0)) result.Add(reader.GetString(0));
+        }
+        return result;
+    }
+
+    private async Task<string?> ScalarAsync(NpgsqlConnection conn, string sql)
+    {
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        var v = await cmd.ExecuteScalarAsync();
+        return v is null or DBNull ? null : v.ToString();
+    }
+
+    [Test]
+    public async Task Migration_Creates_The_Two_Billing_Tables()
+    {
+        await using var conn = await OpenAsync();
+        var tables = await QueryStringsAsync(conn,
+            "SELECT table_name FROM information_schema.tables WHERE table_schema='public';");
+
+        tables.Should().Contain("billing_customers");
+        tables.Should().Contain("billing_plan_prices");
+    }
+
+    [Test]
+    public async Task Migration_Creates_The_BillingMode_Check_Constraint()
+    {
+        await using var conn = await OpenAsync();
+        var checks = await QueryStringsAsync(conn,
+            "SELECT conname FROM pg_constraint WHERE contype='c';");
+
+        checks.Should().Contain("ck_billing_customers_mode");
+    }
+
+    [Test]
+    public async Task Migration_Creates_The_Unique_TenantId_Index()
+    {
+        await using var conn = await OpenAsync();
+        var def = await ScalarAsync(conn,
+            "SELECT indexdef FROM pg_indexes WHERE indexname='UX_billing_customers_TenantId';");
+
+        def.Should().NotBeNull();
+        def!.Should().Contain("UNIQUE");
+        def.Should().Contain("TenantId");
+    }
+
+    [Test]
+    public async Task Migration_Creates_The_Partial_Unique_StripeCustomerId_Index()
+    {
+        await using var conn = await OpenAsync();
+        var def = await ScalarAsync(conn,
+            "SELECT indexdef FROM pg_indexes WHERE indexname='UX_billing_customers_StripeCustomerId';");
+
+        def.Should().NotBeNull();
+        def!.Should().Contain("UNIQUE");
+        def.Should().Contain("StripeCustomerId");
+        def.Should().Contain("IS NOT NULL", "the index is partial — only acked customers");
+    }
+
+    [Test]
+    public async Task Migration_Creates_The_Unique_PlanSlug_Index()
+    {
+        await using var conn = await OpenAsync();
+        var def = await ScalarAsync(conn,
+            "SELECT indexdef FROM pg_indexes WHERE indexname='UX_billing_plan_prices_PlanSlug';");
+
+        def.Should().NotBeNull();
+        def!.Should().Contain("UNIQUE");
+        def.Should().Contain("PlanSlug");
+    }
+
+    [Test]
+    public async Task Migration_Down_Drops_Both_Billing_Tables_Then_Up_Restores()
+    {
+        // Roll the schema back to the migration just before ours, then forward
+        // again — proves the down() is correct and the migration is reversible.
+        await using (var down = NewContext())
+        {
+            await down.GetService<IMigrator>()
+                .MigrateAsync("20260618192337_PlanPriceBookCatalog");
+        }
+
+        await using (var conn = await OpenAsync())
+        {
+            var tables = await QueryStringsAsync(conn,
+                "SELECT table_name FROM information_schema.tables WHERE table_schema='public';");
+            tables.Should().NotContain("billing_customers");
+            tables.Should().NotContain("billing_plan_prices");
+        }
+
+        // Forward again so the container is left in the fully-migrated state.
+        await using (var up = NewContext())
+        {
+            await up.GetService<IMigrator>().MigrateAsync(ThisMigration);
+        }
+
+        await using (var conn = await OpenAsync())
+        {
+            var tables = await QueryStringsAsync(conn,
+                "SELECT table_name FROM information_schema.tables WHERE table_schema='public';");
+            tables.Should().Contain("billing_customers");
+            tables.Should().Contain("billing_plan_prices");
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingSeederTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingSeederTests.cs
@@ -1,0 +1,162 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Stripe;
+using Stripe.Billing;
+using Tamma.Api.Services.Billing;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-1 (AC7, AC8) — <see cref="BillingSeeder"/> idempotently syncs the
+/// Stripe catalog: first run creates Products / base + metered Prices / the
+/// three Billing Meters (with the right SUM/SUM/LAST aggregation) and writes
+/// their ids into <c>billing_plan_prices</c>; a second run finds existing ids
+/// and makes ZERO create calls (no row churn). One
+/// <c>BILLING.PLAN_CATALOG.SYNCED</c> is emitted per slug. All Stripe services
+/// are mocked at the service-interface boundary.
+/// </summary>
+[TestFixture]
+public class BillingSeederTests
+{
+    private sealed class Harness
+    {
+        public Mock<ProductService> Products { get; } = new();
+        public Mock<PriceService> Prices { get; } = new();
+        public Mock<MeterService> Meters { get; } = new();
+        public Mock<IEventRepository> Events { get; } = new();
+        public List<MeterCreateOptions> MeterCalls { get; } = new();
+
+        public int ProductCreates;
+        public int PriceCreates;
+        public int MeterCreates;
+
+        public IStripeServices Services { get; }
+
+        public Harness()
+        {
+            var bundle = new Mock<IStripeServices>();
+            bundle.SetupGet(s => s.Products).Returns(Products.Object);
+            bundle.SetupGet(s => s.Prices).Returns(Prices.Object);
+            bundle.SetupGet(s => s.Meters).Returns(Meters.Object);
+            // Customers unused by the seeder.
+            Services = bundle.Object;
+
+            Products.Setup(p => p.CreateAsync(
+                    It.IsAny<ProductCreateOptions>(), It.IsAny<RequestOptions>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ProductCreateOptions o, RequestOptions _, CancellationToken _) =>
+                {
+                    ProductCreates++;
+                    return new Product { Id = o.Id ?? $"prod_{Guid.NewGuid():N}" };
+                });
+
+            Prices.Setup(p => p.CreateAsync(
+                    It.IsAny<PriceCreateOptions>(), It.IsAny<RequestOptions>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() =>
+                {
+                    PriceCreates++;
+                    return new Price { Id = $"price_{Guid.NewGuid():N}" };
+                });
+
+            Meters.Setup(m => m.CreateAsync(
+                    It.IsAny<MeterCreateOptions>(), It.IsAny<RequestOptions>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((MeterCreateOptions o, RequestOptions _, CancellationToken _) =>
+                {
+                    MeterCreates++;
+                    MeterCalls.Add(o);
+                    return new Meter { Id = $"mtr_{Guid.NewGuid():N}" };
+                });
+
+            Events.Setup(e => e.AppendAsync(It.IsAny<DomainEvent>()))
+                .ReturnsAsync((DomainEvent d) => d);
+        }
+
+        public BillingSeeder NewSeeder(ControlPlaneDbContext db) =>
+            new(Services, db, Events.Object, new BillingOptions(),
+                NullLogger.Instance);
+    }
+
+    private static ControlPlaneDbContext NewDb(string name) =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseInMemoryDatabase(name)
+            .Options);
+
+    [Test]
+    public async Task FirstRun_Creates_Catalog_And_Three_Meters()
+    {
+        var h = new Harness();
+        await using var db = NewDb(nameof(FirstRun_Creates_Catalog_And_Three_Meters));
+
+        var result = await h.NewSeeder(db).SyncAsync();
+
+        // Three slugs each get a product + base price + 3 metered prices; the
+        // three meters are created once and shared.
+        result.Slugs.Select(s => s.PlanSlug).Should()
+            .BeEquivalentTo(new[] { "free", "team", "enterprise" });
+        h.MeterCreates.Should().Be(3, "the three platform meters are created once");
+        h.ProductCreates.Should().Be(3, "one product per slug");
+        h.PriceCreates.Should().Be(12, "one base + three metered prices per slug (4 × 3)");
+
+        var rows = await db.BillingPlanPrices.AsNoTracking().ToListAsync();
+        rows.Should().HaveCount(3);
+        rows.Should().OnlyContain(r =>
+            r.StripeProductId != null && r.StripePriceId != null
+            && r.TokensInputMeterId != null && r.TokensOutputMeterId != null && r.SeatsMeterId != null
+            && r.TokensInputPriceId != null && r.TokensOutputPriceId != null && r.SeatsPriceId != null);
+
+        h.Events.Verify(e => e.AppendAsync(
+                It.Is<DomainEvent>(d => d.Type == BillingEvents.PlanCatalogSyncedType)),
+            Times.Exactly(3), "one BILLING.PLAN_CATALOG.SYNCED per slug");
+    }
+
+    [Test]
+    public async Task Meters_Use_Correct_Aggregation_Formulas()
+    {
+        var h = new Harness();
+        await using var db = NewDb(nameof(Meters_Use_Correct_Aggregation_Formulas));
+
+        await h.NewSeeder(db).SyncAsync();
+
+        var byEvent = h.MeterCalls.ToDictionary(c => c.EventName, c => c.DefaultAggregation.Formula);
+        byEvent.Should().ContainKey("tamma.platform_tokens_input").WhoseValue.Should().Be("sum");
+        byEvent.Should().ContainKey("tamma.platform_tokens_output").WhoseValue.Should().Be("sum");
+        byEvent.Should().ContainKey("tamma.seats").WhoseValue.Should().Be("last");
+    }
+
+    [Test]
+    public async Task SecondRun_Is_NoOp_Reuses_Existing_Ids()
+    {
+        var dbName = nameof(SecondRun_Is_NoOp_Reuses_Existing_Ids);
+
+        // First run populates the catalog.
+        var first = new Harness();
+        await using (var db = NewDb(dbName))
+        {
+            await first.NewSeeder(db).SyncAsync();
+        }
+
+        // Second run against the SAME in-memory DB sees the populated rows.
+        var second = new Harness();
+        await using (var db = NewDb(dbName))
+        {
+            var result = await second.NewSeeder(db).SyncAsync();
+            result.TotalCreated.Should().Be(0, "everything is reused on the second run");
+            result.TotalReused.Should().BeGreaterThan(0);
+        }
+
+        second.ProductCreates.Should().Be(0);
+        second.PriceCreates.Should().Be(0);
+        second.MeterCreates.Should().Be(0, "the meters were stored — no re-create");
+
+        await using var verify = NewDb(dbName);
+        (await verify.BillingPlanPrices.CountAsync()).Should().Be(3, "no row churn");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingSeederTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingSeederTests.cs
@@ -33,6 +33,7 @@ public class BillingSeederTests
         public List<MeterCreateOptions> MeterCalls { get; } = new();
 
         public int ProductCreates;
+        public int ProductGets;
         public int PriceCreates;
         public int MeterCreates;
 
@@ -46,6 +47,18 @@ public class BillingSeederTests
             bundle.SetupGet(s => s.Meters).Returns(Meters.Object);
             // Customers unused by the seeder.
             Services = bundle.Object;
+
+            // Default: the product is NOT yet in Stripe → the get-or-create probe
+            // 404s and the seeder falls through to CreateAsync. (The "DB reset but
+            // Stripe still has the product" path overrides this per-test below.)
+            Products.Setup(p => p.GetAsync(
+                    It.IsAny<string>(), It.IsAny<ProductGetOptions>(),
+                    It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+                .Callback(() => ProductGets++)
+                .ThrowsAsync(new StripeException
+                {
+                    HttpStatusCode = System.Net.HttpStatusCode.NotFound,
+                });
 
             Products.Setup(p => p.CreateAsync(
                     It.IsAny<ProductCreateOptions>(), It.IsAny<RequestOptions>(),
@@ -129,6 +142,37 @@ public class BillingSeederTests
         byEvent.Should().ContainKey("tamma.platform_tokens_input").WhoseValue.Should().Be("sum");
         byEvent.Should().ContainKey("tamma.platform_tokens_output").WhoseValue.Should().Be("sum");
         byEvent.Should().ContainKey("tamma.seats").WhoseValue.Should().Be("last");
+    }
+
+    [Test]
+    public async Task DbReset_But_Stripe_Has_Product_Reuses_It_Does_Not_Throw()
+    {
+        var h = new Harness();
+        await using var db = NewDb(nameof(DbReset_But_Stripe_Has_Product_Reuses_It_Does_Not_Throw));
+
+        // Simulate a control-plane DB reset where Stripe STILL holds every
+        // tamma-plan-{slug} product but the 24h idempotency window has lapsed: the
+        // get-or-create probe FINDS the product, so the seeder reuses it instead
+        // of issuing a CreateAsync that would 400 "resource already exists".
+        h.Products.Setup(p => p.GetAsync(
+                It.IsAny<string>(), It.IsAny<ProductGetOptions>(),
+                It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string id, ProductGetOptions _, RequestOptions _, CancellationToken _) =>
+            {
+                h.ProductGets++;
+                return new Product { Id = id };
+            });
+
+        var act = async () => await h.NewSeeder(db).SyncAsync();
+        await act.Should().NotThrowAsync();
+
+        h.ProductGets.Should().Be(3, "the get-or-create probe runs once per slug");
+        h.ProductCreates.Should().Be(0, "the product is reused, never re-created");
+
+        var rows = await db.BillingPlanPrices.AsNoTracking().ToListAsync();
+        rows.Select(r => r.StripeProductId).Should()
+            .BeEquivalentTo(new[] { "tamma-plan-free", "tamma-plan-team", "tamma-plan-enterprise" },
+                "the reused product id is the fixed tamma-plan-{slug} id");
     }
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingTenantCreateHookTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingTenantCreateHookTests.cs
@@ -6,6 +6,7 @@ using Moq;
 using NUnit.Framework;
 using Tamma.Api.Services.Billing;
 using Tamma.Api.Services.Billing.Tasks;
+using Tamma.Api.Tests.Infrastructure;
 using Tamma.Core.Billing;
 using Tamma.Data;
 using Tamma.Data.Entities;
@@ -88,6 +89,65 @@ public class BillingTenantCreateHookTests
         enqueued.Should().NotBeNull();
         enqueued!.Type.Should().Be(CreateBillingCustomerTaskHandler.TaskTypeName);
         enqueued.TenantId.Should().Be(tenant.Id);
+    }
+
+    [Test]
+    public async Task Saas_Cancellation_Rethrows_Does_Not_Swallow_Or_Enqueue()
+    {
+        var tenant = NewTenant();
+        var billing = new Mock<IBillingProvider>();
+        billing.SetupGet(b => b.IsEnabled).Returns(true);
+        billing.Setup(b => b.CreateCustomerAsync(
+                tenant.Id, It.IsAny<CustomerDescriptor>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException("request aborted"));
+
+        // Strict — any enqueue would fail the test. A cancellation must NOT be
+        // laundered into a "Stripe failed" WARN + spurious retry.
+        var tasks = new Mock<IPlatformQueuedTaskRepository>(MockBehavior.Strict);
+
+        var act = async () => await BillingTenantCreateHook.RunAsync(
+            billing.Object, tasks.Object, LoggerFactory, tenant, "owner@example.com");
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        tasks.VerifyNoOtherCalls();
+    }
+
+    [Test]
+    public async Task Saas_Unexpected_NonStripe_Error_Enqueues_But_Logs_At_Error_Distinctly()
+    {
+        var tenant = NewTenant();
+        var billing = new Mock<IBillingProvider>();
+        billing.SetupGet(b => b.IsEnabled).Returns(true);
+        // A genuine defect (not a Stripe/transient failure).
+        billing.Setup(b => b.CreateCustomerAsync(
+                tenant.Id, It.IsAny<CustomerDescriptor>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new NullReferenceException("bug in row-persist"));
+
+        PlatformQueuedTask? enqueued = null;
+        var tasks = new Mock<IPlatformQueuedTaskRepository>();
+        tasks.Setup(t => t.EnqueueAsync(
+                It.IsAny<PlatformQueuedTask>(), It.IsAny<CancellationToken>()))
+            .Callback<PlatformQueuedTask, CancellationToken>((task, _) => enqueued = task)
+            .ReturnsAsync((PlatformQueuedTask task, CancellationToken _) => task);
+
+        using var captured = new CapturingLoggerProvider();
+        using var factory = Microsoft.Extensions.Logging.LoggerFactory.Create(b => b.AddProvider(captured));
+
+        // Tenant-create must STILL not be blocked — the guarantee holds for all
+        // errors — but the defect must be surfaced distinctly.
+        var act = async () => await BillingTenantCreateHook.RunAsync(
+            billing.Object, tasks.Object, factory, tenant, "owner@example.com");
+        await act.Should().NotThrowAsync();
+
+        enqueued.Should().NotBeNull("the never-block guarantee holds for unexpected errors too");
+
+        var errorEntries = captured.Entries.Where(e => e.Level == LogLevel.Error).ToList();
+        errorEntries.Should().ContainSingle(
+            "the unexpected error is surfaced at ERROR, not buried under a Stripe WARN");
+        errorEntries[0].Message.Should().Contain("Unexpected (non-Stripe) error");
+        captured.Entries.Should().NotContain(
+            e => e.Level == LogLevel.Warning && e.Message.Contains("Stripe customer create failed"),
+            "a real defect must NOT masquerade as a Stripe-shaped WARN");
     }
 }
 

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingTenantCreateHookTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingTenantCreateHookTests.cs
@@ -1,0 +1,141 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.Billing;
+using Tamma.Api.Services.Billing.Tasks;
+using Tamma.Core.Billing;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-1 (AC6, AC9, AC14) — the non-blocking tenant-create billing hook
+/// (shared by <c>OrgEndpoints.CreateOrg</c> and <c>AuthEndpoints.Register</c>):
+/// happy path creates the customer; a Stripe failure enqueues a retry task and
+/// does NOT throw (tenant creation is never blocked); single-user is a complete
+/// no-op (no Stripe call, no enqueue).
+/// </summary>
+[TestFixture]
+public class BillingTenantCreateHookTests
+{
+    private static readonly ILoggerFactory LoggerFactory = NullLoggerFactory.Instance;
+
+    private static Tenant NewTenant() =>
+        new() { Id = Guid.NewGuid(), Name = "Acme", Slug = "acme" };
+
+    [Test]
+    public async Task SingleUser_Is_Complete_NoOp()
+    {
+        var billing = new NullBillingProvider(); // IsEnabled == false
+        var tasks = new Mock<IPlatformQueuedTaskRepository>(MockBehavior.Strict);
+
+        await BillingTenantCreateHook.RunAsync(
+            billing, tasks.Object, LoggerFactory, NewTenant(), "owner@example.com");
+
+        // No enqueue, no Stripe — strict mock would throw on any call.
+        tasks.VerifyNoOtherCalls();
+    }
+
+    [Test]
+    public async Task Saas_HappyPath_Creates_Customer_No_Enqueue()
+    {
+        var tenant = NewTenant();
+        var billing = new Mock<IBillingProvider>();
+        billing.SetupGet(b => b.IsEnabled).Returns(true);
+        billing.Setup(b => b.CreateCustomerAsync(
+                tenant.Id, It.IsAny<CustomerDescriptor>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingCustomer { TenantId = tenant.Id, StripeCustomerId = "cus_ok" });
+
+        var tasks = new Mock<IPlatformQueuedTaskRepository>();
+
+        await BillingTenantCreateHook.RunAsync(
+            billing.Object, tasks.Object, LoggerFactory, tenant, "owner@example.com");
+
+        billing.Verify(b => b.CreateCustomerAsync(
+            tenant.Id, It.IsAny<CustomerDescriptor>(), It.IsAny<CancellationToken>()), Times.Once);
+        tasks.Verify(t => t.EnqueueAsync(
+            It.IsAny<PlatformQueuedTask>(), It.IsAny<CancellationToken>()), Times.Never,
+            "the happy path enqueues no retry");
+    }
+
+    [Test]
+    public async Task Saas_StripeFailure_Enqueues_Retry_Does_Not_Throw()
+    {
+        var tenant = NewTenant();
+        var billing = new Mock<IBillingProvider>();
+        billing.SetupGet(b => b.IsEnabled).Returns(true);
+        billing.Setup(b => b.CreateCustomerAsync(
+                tenant.Id, It.IsAny<CustomerDescriptor>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TimeoutException("stripe down"));
+
+        PlatformQueuedTask? enqueued = null;
+        var tasks = new Mock<IPlatformQueuedTaskRepository>();
+        tasks.Setup(t => t.EnqueueAsync(
+                It.IsAny<PlatformQueuedTask>(), It.IsAny<CancellationToken>()))
+            .Callback<PlatformQueuedTask, CancellationToken>((task, _) => enqueued = task)
+            .ReturnsAsync((PlatformQueuedTask task, CancellationToken _) => task);
+
+        // Must NOT throw — tenant creation is never blocked.
+        var act = async () => await BillingTenantCreateHook.RunAsync(
+            billing.Object, tasks.Object, LoggerFactory, tenant, "owner@example.com");
+        await act.Should().NotThrowAsync();
+
+        enqueued.Should().NotBeNull();
+        enqueued!.Type.Should().Be(CreateBillingCustomerTaskHandler.TaskTypeName);
+        enqueued.TenantId.Should().Be(tenant.Id);
+    }
+}
+
+/// <summary>
+/// Story 35-1 (AC12, AC14) — tenant isolation: each tenant gets exactly one
+/// <see cref="BillingCustomer"/> row, and a second create for the same tenant
+/// never inserts a duplicate.
+/// </summary>
+[TestFixture]
+public class BillingTenantIsolationTests
+{
+    private static ControlPlaneDbContext NewDb(string name) =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseInMemoryDatabase(name)
+            .Options);
+
+    [Test]
+    public async Task Two_Tenants_Get_Two_Distinct_Rows_One_Per_Tenant()
+    {
+        var dbName = nameof(Two_Tenants_Get_Two_Distinct_Rows_One_Per_Tenant);
+        await using var db = NewDb(dbName);
+
+        var customers = new Mock<Stripe.CustomerService>();
+        var seq = 0;
+        customers.Setup(c => c.CreateAsync(
+                It.IsAny<Stripe.CustomerCreateOptions>(), It.IsAny<Stripe.RequestOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new Stripe.Customer { Id = $"cus_{seq++}" });
+
+        var bundle = new Mock<IStripeServices>();
+        bundle.SetupGet(s => s.Customers).Returns(customers.Object);
+        var factory = new Mock<IStripeServicesFactory>();
+        factory.Setup(f => f.CreateAsync(It.IsAny<CancellationToken>())).ReturnsAsync(bundle.Object);
+
+        var provider = new StripeBillingProvider(
+            factory.Object, db, Mock.Of<IEventRepository>(),
+            Microsoft.Extensions.Options.Options.Create(new BillingOptions()),
+            NullLogger<StripeBillingProvider>.Instance);
+
+        var t1 = Guid.NewGuid();
+        var t2 = Guid.NewGuid();
+        await provider.CreateCustomerAsync(t1, new CustomerDescriptor("A", "a", null, BillingMode.PlatformProvided));
+        await provider.CreateCustomerAsync(t2, new CustomerDescriptor("B", "b", null, BillingMode.PlatformProvided));
+        // Re-create t1 — must NOT insert a duplicate.
+        await provider.CreateCustomerAsync(t1, new CustomerDescriptor("A", "a", null, BillingMode.PlatformProvided));
+
+        var rows = await db.BillingCustomers.AsNoTracking().ToListAsync();
+        rows.Should().HaveCount(2, "exactly one BillingCustomer per tenant");
+        rows.Select(r => r.TenantId).Should().BeEquivalentTo(new[] { t1, t2 });
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/CreateBillingCustomerTaskHandlerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/CreateBillingCustomerTaskHandlerTests.cs
@@ -1,0 +1,151 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.Billing;
+using Tamma.Api.Services.Billing.Tasks;
+using Tamma.Api.Services.PlatformTasks;
+using Tamma.Core.Billing;
+using Tamma.Data;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-1 (AC6) — the <c>billing.customer.create</c> retry handler re-drives
+/// <see cref="IBillingProvider.CreateCustomerAsync"/> on a queued task; a
+/// malformed payload / unknown tenant → <see cref="PlatformTaskTerminalException"/>
+/// (dead-letter); a transient Stripe error rethrows (retry).
+/// </summary>
+[TestFixture]
+public class CreateBillingCustomerTaskHandlerTests
+{
+    private static ControlPlaneDbContext NewDb(string name) =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseInMemoryDatabase(name)
+            .Options);
+
+    private static CreateBillingCustomerTaskHandler Build(
+        ControlPlaneDbContext db, IBillingProvider billing) =>
+        new(billing, db, NullLogger<CreateBillingCustomerTaskHandler>.Instance);
+
+    [Test]
+    public async Task HandleAsync_ReDrives_Create_For_Valid_Tenant()
+    {
+        await using var db = NewDb(nameof(HandleAsync_ReDrives_Create_For_Valid_Tenant));
+        var tenant = new Tenant { Id = Guid.NewGuid(), Name = "Acme", Slug = "acme", OwnerId = null };
+        db.Tenants.Add(tenant);
+        await db.SaveChangesAsync();
+
+        var billing = new Mock<IBillingProvider>();
+        billing.SetupGet(b => b.IsEnabled).Returns(true);
+        billing.Setup(b => b.CreateCustomerAsync(
+                tenant.Id, It.IsAny<CustomerDescriptor>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingCustomer { TenantId = tenant.Id, StripeCustomerId = "cus_x" });
+
+        var task = new PlatformQueuedTask
+        {
+            Type = CreateBillingCustomerTaskHandler.TaskTypeName,
+            TenantId = tenant.Id,
+            Payload = System.Text.Json.JsonSerializer.Serialize(
+                new CreateBillingCustomerTaskPayload(tenant.Id)),
+        };
+
+        await Build(db, billing.Object).HandleAsync(task, CancellationToken.None);
+
+        billing.Verify(b => b.CreateCustomerAsync(
+            tenant.Id, It.IsAny<CustomerDescriptor>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task HandleAsync_Malformed_Payload_Is_Terminal()
+    {
+        await using var db = NewDb(nameof(HandleAsync_Malformed_Payload_Is_Terminal));
+        var billing = new Mock<IBillingProvider>();
+        billing.SetupGet(b => b.IsEnabled).Returns(true);
+
+        var task = new PlatformQueuedTask
+        {
+            Type = CreateBillingCustomerTaskHandler.TaskTypeName,
+            Payload = "{ not json",
+        };
+
+        var act = async () => await Build(db, billing.Object).HandleAsync(task, CancellationToken.None);
+        await act.Should().ThrowAsync<PlatformTaskTerminalException>();
+    }
+
+    [Test]
+    public async Task HandleAsync_Unknown_Tenant_Is_Terminal()
+    {
+        await using var db = NewDb(nameof(HandleAsync_Unknown_Tenant_Is_Terminal));
+        var billing = new Mock<IBillingProvider>();
+        billing.SetupGet(b => b.IsEnabled).Returns(true);
+
+        var task = new PlatformQueuedTask
+        {
+            Type = CreateBillingCustomerTaskHandler.TaskTypeName,
+            Payload = System.Text.Json.JsonSerializer.Serialize(
+                new CreateBillingCustomerTaskPayload(Guid.NewGuid())),
+        };
+
+        var act = async () => await Build(db, billing.Object).HandleAsync(task, CancellationToken.None);
+        await act.Should().ThrowAsync<PlatformTaskTerminalException>();
+    }
+
+    [Test]
+    public async Task HandleAsync_Transient_Stripe_Error_Rethrows_For_Retry()
+    {
+        await using var db = NewDb(nameof(HandleAsync_Transient_Stripe_Error_Rethrows_For_Retry));
+        var tenant = new Tenant { Id = Guid.NewGuid(), Name = "Acme", Slug = "acme" };
+        db.Tenants.Add(tenant);
+        await db.SaveChangesAsync();
+
+        var billing = new Mock<IBillingProvider>();
+        billing.SetupGet(b => b.IsEnabled).Returns(true);
+        billing.Setup(b => b.CreateCustomerAsync(
+                tenant.Id, It.IsAny<CustomerDescriptor>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TimeoutException("stripe unreachable"));
+
+        var task = new PlatformQueuedTask
+        {
+            Type = CreateBillingCustomerTaskHandler.TaskTypeName,
+            TenantId = tenant.Id,
+            Payload = System.Text.Json.JsonSerializer.Serialize(
+                new CreateBillingCustomerTaskPayload(tenant.Id)),
+        };
+
+        var act = async () => await Build(db, billing.Object).HandleAsync(task, CancellationToken.None);
+        // A NON-terminal exception so the worker retries per its budget.
+        var ex = await act.Should().ThrowAsync<Exception>();
+        ex.And.Should().NotBeOfType<PlatformTaskTerminalException>();
+    }
+
+    [Test]
+    public async Task HandleAsync_Disabled_Provider_Is_Terminal()
+    {
+        await using var db = NewDb(nameof(HandleAsync_Disabled_Provider_Is_Terminal));
+        var billing = new Mock<IBillingProvider>();
+        billing.SetupGet(b => b.IsEnabled).Returns(false);
+
+        var task = new PlatformQueuedTask
+        {
+            Type = CreateBillingCustomerTaskHandler.TaskTypeName,
+            Payload = System.Text.Json.JsonSerializer.Serialize(
+                new CreateBillingCustomerTaskPayload(Guid.NewGuid())),
+        };
+
+        var act = async () => await Build(db, billing.Object).HandleAsync(task, CancellationToken.None);
+        await act.Should().ThrowAsync<PlatformTaskTerminalException>();
+    }
+
+    [Test]
+    public void TaskType_Is_Stable()
+    {
+        new CreateBillingCustomerTaskHandler(
+            Mock.Of<IBillingProvider>(),
+            NewDb(nameof(TaskType_Is_Stable)),
+            NullLogger<CreateBillingCustomerTaskHandler>.Instance)
+            .TaskType.Should().Be("billing.customer.create");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/NullBillingProviderTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/NullBillingProviderTests.cs
@@ -1,0 +1,45 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Api.Services.Billing;
+using Tamma.Core;
+using Tamma.Core.Billing;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-1 (AC9) — the single-user no-op provider reports disabled and never
+/// touches Stripe. The mutating methods throw a clear SaaS-only error if a
+/// caller ignores <c>IsEnabled</c> (defence-in-depth; the hook never calls them
+/// in single-user).
+/// </summary>
+[TestFixture]
+public class NullBillingProviderTests
+{
+    [Test]
+    public void IsEnabled_Is_False()
+    {
+        new NullBillingProvider().IsEnabled.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task CreateCustomerAsync_Throws_SaasOnly()
+    {
+        var provider = new NullBillingProvider();
+        var act = async () => await provider.CreateCustomerAsync(
+            Guid.NewGuid(),
+            new CustomerDescriptor("Acme", "acme", "owner@example.com", BillingMode.PlatformProvided));
+
+        var ex = await act.Should().ThrowAsync<TammaError>();
+        ex.Which.Code.Should().Be("BILLING.SAAS_ONLY");
+    }
+
+    [Test]
+    public async Task SyncCatalogAsync_Throws_SaasOnly()
+    {
+        var provider = new NullBillingProvider();
+        var act = async () => await provider.SyncCatalogAsync();
+
+        var ex = await act.Should().ThrowAsync<TammaError>();
+        ex.Which.Code.Should().Be("BILLING.SAAS_ONLY");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SeedBillingCommandTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SeedBillingCommandTests.cs
@@ -1,0 +1,86 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.Billing;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-1 (AC7, AC9) — <see cref="SeedBillingCommand"/> arg matching and the
+/// single-user no-op (prints SaaS-only, exits 0, makes no Stripe call).
+/// </summary>
+[TestFixture]
+public class SeedBillingCommandTests
+{
+    [TestCase("seed-billing", true)]
+    [TestCase("SEED-BILLING", true)]
+    [TestCase("migrate-secrets", false)]
+    [TestCase("", false)]
+    public void ShouldRun_Matches_First_Arg(string arg, bool expected)
+    {
+        var args = string.IsNullOrEmpty(arg) ? Array.Empty<string>() : new[] { arg };
+        SeedBillingCommand.ShouldRun(args).Should().Be(expected);
+    }
+
+    [Test]
+    public void ShouldRun_Empty_Args_Is_False()
+    {
+        SeedBillingCommand.ShouldRun(Array.Empty<string>()).Should().BeFalse();
+    }
+
+    [Test]
+    public async Task RunAsync_SingleUser_Is_NoOp_Exit0()
+    {
+        var billing = new Mock<IBillingProvider>();
+        billing.SetupGet(b => b.IsEnabled).Returns(false);
+
+        var services = new ServiceCollection();
+        services.AddScoped(_ => billing.Object);
+        await using var sp = services.BuildServiceProvider();
+
+        var exit = await SeedBillingCommand.RunAsync(sp);
+
+        exit.Should().Be(0);
+        billing.Verify(b => b.SyncCatalogAsync(It.IsAny<CancellationToken>()), Times.Never,
+            "single-user makes no Stripe catalog call");
+    }
+
+    [Test]
+    public async Task RunAsync_Saas_Runs_Sync_Exit0()
+    {
+        var billing = new Mock<IBillingProvider>();
+        billing.SetupGet(b => b.IsEnabled).Returns(true);
+        billing.Setup(b => b.SyncCatalogAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CatalogSyncResult(new[]
+            {
+                new CatalogSlugResult("free", 4, 0),
+            }));
+
+        var services = new ServiceCollection();
+        services.AddScoped(_ => billing.Object);
+        await using var sp = services.BuildServiceProvider();
+
+        var exit = await SeedBillingCommand.RunAsync(sp);
+
+        exit.Should().Be(0);
+        billing.Verify(b => b.SyncCatalogAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task RunAsync_Saas_Failure_Exit1()
+    {
+        var billing = new Mock<IBillingProvider>();
+        billing.SetupGet(b => b.IsEnabled).Returns(true);
+        billing.Setup(b => b.SyncCatalogAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("stripe boom"));
+
+        var services = new ServiceCollection();
+        services.AddScoped(_ => billing.Object);
+        await using var sp = services.BuildServiceProvider();
+
+        var exit = await SeedBillingCommand.RunAsync(sp);
+
+        exit.Should().Be(1);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/StripeBillingProviderTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/StripeBillingProviderTests.cs
@@ -1,0 +1,133 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Stripe;
+using Tamma.Api.Services.Billing;
+using Tamma.Core.Billing;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-1 (AC6, AC12, AC13) — <see cref="StripeBillingProvider"/> creates a
+/// Stripe customer with the deterministic idempotency key, persists the
+/// <see cref="BillingCustomer"/> row, emits <c>BILLING.CUSTOMER.CREATED</c>, and
+/// short-circuits a duplicate-tenant create (no second Stripe call). Stripe is
+/// mocked at the service-interface boundary — no live Stripe.
+/// </summary>
+[TestFixture]
+public class StripeBillingProviderTests
+{
+    private static ControlPlaneDbContext NewDb(string name) =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseInMemoryDatabase(name)
+            .Options);
+
+    private static (StripeBillingProvider Provider, Mock<CustomerService> Customers,
+        Mock<IEventRepository> Events, ControlPlaneDbContext Db) Build(string dbName)
+    {
+        var db = NewDb(dbName);
+
+        var customers = new Mock<CustomerService>(MockBehavior.Strict);
+        var stripeServices = new Mock<IStripeServices>();
+        stripeServices.SetupGet(s => s.Customers).Returns(customers.Object);
+
+        var factory = new Mock<IStripeServicesFactory>();
+        factory.Setup(f => f.CreateAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stripeServices.Object);
+
+        var events = new Mock<IEventRepository>();
+        events.Setup(e => e.AppendAsync(It.IsAny<DomainEvent>()))
+            .ReturnsAsync((DomainEvent d) => d);
+
+        var provider = new StripeBillingProvider(
+            factory.Object, db, events.Object,
+            Options.Create(new BillingOptions()),
+            NullLogger<StripeBillingProvider>.Instance);
+
+        return (provider, customers, events, db);
+    }
+
+    [Test]
+    public async Task CreateCustomerAsync_Creates_Stripe_Customer_With_Deterministic_Key()
+    {
+        var (provider, customers, events, db) =
+            Build(nameof(CreateCustomerAsync_Creates_Stripe_Customer_With_Deterministic_Key));
+        var tenantId = Guid.NewGuid();
+        var expectedKey = StripeBillingProvider.CustomerIdempotencyKey(tenantId);
+
+        RequestOptions? capturedOptions = null;
+        customers.Setup(c => c.CreateAsync(
+                It.IsAny<CustomerCreateOptions>(),
+                It.IsAny<RequestOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<CustomerCreateOptions, RequestOptions, CancellationToken>(
+                (_, ro, _) => capturedOptions = ro)
+            .ReturnsAsync(new Customer { Id = "cus_test_123" });
+
+        var row = await provider.CreateCustomerAsync(
+            tenantId,
+            new CustomerDescriptor("Acme", "acme", "owner@example.com", BillingMode.PlatformProvided));
+
+        capturedOptions.Should().NotBeNull();
+        capturedOptions!.IdempotencyKey.Should().Be(expectedKey);
+        row.StripeCustomerId.Should().Be("cus_test_123");
+        row.TenantId.Should().Be(tenantId);
+        row.BillingMode.Should().Be("PlatformProvided");
+
+        var persisted = await db.BillingCustomers.SingleAsync();
+        persisted.StripeCustomerId.Should().Be("cus_test_123");
+
+        events.Verify(e => e.AppendAsync(
+            It.Is<DomainEvent>(d => d.Type == BillingEvents.CustomerCreatedType
+                                    && d.TenantId == tenantId)),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task CreateCustomerAsync_Records_Byok_Mode()
+    {
+        var (provider, customers, _, db) =
+            Build(nameof(CreateCustomerAsync_Records_Byok_Mode));
+        customers.Setup(c => c.CreateAsync(
+                It.IsAny<CustomerCreateOptions>(), It.IsAny<RequestOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Customer { Id = "cus_byok" });
+
+        var row = await provider.CreateCustomerAsync(
+            Guid.NewGuid(),
+            new CustomerDescriptor("Beta", "beta", null, BillingMode.Byok));
+
+        row.BillingMode.Should().Be("Byok");
+        (await db.BillingCustomers.SingleAsync()).BillingMode.Should().Be("Byok");
+    }
+
+    [Test]
+    public async Task CreateCustomerAsync_Is_Idempotent_For_Same_Tenant()
+    {
+        var (provider, customers, _, db) =
+            Build(nameof(CreateCustomerAsync_Is_Idempotent_For_Same_Tenant));
+        var tenantId = Guid.NewGuid();
+        customers.Setup(c => c.CreateAsync(
+                It.IsAny<CustomerCreateOptions>(), It.IsAny<RequestOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Customer { Id = "cus_once" });
+
+        var first = await provider.CreateCustomerAsync(
+            tenantId, new CustomerDescriptor("Acme", "acme", null, BillingMode.PlatformProvided));
+        var second = await provider.CreateCustomerAsync(
+            tenantId, new CustomerDescriptor("Acme", "acme", null, BillingMode.PlatformProvided));
+
+        first.Id.Should().Be(second.Id, "the same tenant resolves the existing row");
+        (await db.BillingCustomers.CountAsync()).Should().Be(1, "one BillingCustomer per tenant");
+        customers.Verify(c => c.CreateAsync(
+                It.IsAny<CustomerCreateOptions>(), It.IsAny<RequestOptions>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once, "the second create makes NO Stripe call");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/StripeClientFactoryTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/StripeClientFactoryTests.cs
@@ -1,0 +1,81 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.Billing;
+using Tamma.Api.Services.Secrets.Stopgap;
+using Tamma.Core;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-1 (AC5, AC15) — <see cref="StripeClientFactory"/> resolves the
+/// Stripe key from the Epic 29 cabinet; in production a missing key is a hard
+/// boot error (fail-fast), while development tolerates it (so local dev can run
+/// without a Stripe account). The key value is never logged.
+/// </summary>
+[TestFixture]
+public class StripeClientFactoryTests
+{
+    private sealed class FakeEnv : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "Production";
+        public string ApplicationName { get; set; } = "Tamma.Api";
+        public string ContentRootPath { get; set; } = "/";
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } = null!;
+    }
+
+    private static StripeClientFactory Build(string? resolvedKey, string environment)
+    {
+        var resolver = new Mock<IRuntimeSecretResolver>();
+        resolver.Setup(r => r.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(resolvedKey);
+
+        var sp = new ServiceCollection()
+            .AddSingleton(resolver.Object)
+            .BuildServiceProvider();
+
+        return new StripeClientFactory(
+            sp,
+            Options.Create(new BillingOptions()),
+            new FakeEnv { EnvironmentName = environment },
+            NullLogger<StripeClientFactory>.Instance);
+    }
+
+    [Test]
+    public async Task CreateAsync_Resolves_Key_And_Builds_Services()
+    {
+        var factory = Build("sk_test_fake", "Production");
+
+        var services = await factory.CreateAsync();
+
+        services.Should().NotBeNull();
+        services.Customers.Should().NotBeNull();
+        services.Meters.Should().NotBeNull();
+    }
+
+    [Test]
+    public async Task CreateAsync_Production_Missing_Key_Fails_Fast()
+    {
+        var factory = Build(null, "Production");
+
+        var act = async () => await factory.CreateAsync();
+
+        var ex = await act.Should().ThrowAsync<TammaError>();
+        ex.Which.Code.Should().Be("BILLING.STRIPE.NO_KEY");
+    }
+
+    [Test]
+    public async Task CreateAsync_Development_Missing_Key_Does_Not_Throw()
+    {
+        var factory = Build(null, "Development");
+
+        // Development tolerates a missing key (returns a client that will fail
+        // on the first real SDK call — but boot is not blocked).
+        var services = await factory.CreateAsync();
+        services.Should().NotBeNull();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Email/AuthRegisterLogAssertionTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Email/AuthRegisterLogAssertionTests.cs
@@ -99,11 +99,15 @@ public class AuthRegisterLogAssertionTests
             DisplayName: "Test User");
 
         // ── Act ──
+        // Story 35-1 — billing hook deps. NullBillingProvider is a complete
+        // no-op (single-user), so registration behaviour is unchanged.
         await AuthEndpoints.Register(
             req, userRepo.Object, passwordSvc.Object,
             tenantRepo.Object, membershipRepo.Object,
             bootstrapRepo.Object,
-            emailSvc.Object, config, _loggerFactory);
+            emailSvc.Object, config, _loggerFactory,
+            new Tamma.Api.Services.Billing.NullBillingProvider(),
+            Mock.Of<Tamma.Data.Repositories.IPlatformQueuedTaskRepository>());
 
         // ── Assert ──
         _logProvider.Messages.Should().Contain(

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Email/AuthRegisterTxnIdIntegrationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Email/AuthRegisterTxnIdIntegrationTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Tamma.Api.Services.Email;
+using Tamma.Api.Tests.Infrastructure;
 using Tamma.Data;
 
 namespace Tamma.Api.Tests.Email;
@@ -50,6 +51,19 @@ public class AuthRegisterTxnIdIntegrationTests
     {
         return ApiTestFixture.Factory.WithWebHostBuilder(b =>
         {
+            // Determinism guard (Story 28-6 follow-up): explicitly gate the
+            // racy BackgroundService loops in THIS derived host instead of
+            // relying on the base fixture's DisableAlertHostedServices being
+            // inherited through WithWebHostBuilder. The OutboxSmtpSender poll
+            // loop, if live, claims the freshly-persisted pending row and
+            // mutates its Status / Attempts / NextAttemptAt (or deletes it on
+            // terminal failure) within the 5s poll window — exactly the
+            // active→pending→failed transition that flaked the Status
+            // assertion below. Gating it makes the producer the SOLE writer of
+            // the row for the lifetime of the assertion. ProcessOnceAsync stays
+            // public for the email tests that DO want to drive delivery.
+            b.DisableAlertHostedServices();
+
             b.ConfigureAppConfiguration((_, config) =>
             {
                 config.AddInMemoryCollection(new Dictionary<string, string?>
@@ -77,9 +91,10 @@ public class AuthRegisterTxnIdIntegrationTests
         });
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        // Give any scoped async work a moment to flush to Postgres.
-        await Task.Delay(50);
-
+        // The QUEUED event + outbox row are written synchronously inside the
+        // request (Register awaits emailService.SendAsync before 201), and the
+        // sender is gated off (CreateClient), so both are stable by now — no
+        // flush delay or background-loop race to wait out.
         using var scope = ApiTestFixture.Factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<ControlPlaneDbContext>();
 
@@ -124,8 +139,13 @@ public class AuthRegisterTxnIdIntegrationTests
             password = "Sup3rSecure!",
         });
         response.StatusCode.Should().Be(HttpStatusCode.Created);
-        await Task.Delay(50);
 
+        // No Task.Delay needed: AuthEndpoints.Register awaits
+        // emailService.SendAsync BEFORE it returns 201, so the platform-outbox
+        // row is durably persisted by the time the response is observed. With
+        // the OutboxSmtpSender gated off (see CreateClient), the producer is the
+        // SOLE writer of this row — so Status="pending" is a stable invariant,
+        // not a value we happened to read before a background loop flipped it.
         using var scope = ApiTestFixture.Factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<ControlPlaneDbContext>();
 

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
@@ -59,6 +59,10 @@ public class ControlPlaneDbContextModelTests
             "github_installation_repos",
             "github_webhook_deliveries",
             "plans",
+            // Story 34-1 — typed price-book children of plans.
+            "plan_features",
+            "plan_entitlements",
+            "plan_prices",
             "platform_events",
             "platform_queued_tasks",
             "platform_email_outbox",
@@ -103,7 +107,8 @@ public class ControlPlaneDbContextModelTests
             + "entities have moved to TenantDbContext. Story 31-2 adds "
             + "tenant_platform_installations; Story 31-7 adds "
             + "platform_webhook_deliveries. Unified-tenancy Phase 0 adds "
-            + "tenant_databases. Story 32-1 adds agents + agent_versions.");
+            + "tenant_databases. Story 32-1 adds agents + agent_versions. "
+            + "Story 34-1 adds plan_features + plan_entitlements + plan_prices.");
     }
 
     // ── Story 32-1 — agent entity model shape ──

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
@@ -108,6 +108,13 @@ public class ControlPlaneDbContextModelTests
             // only — usage/metering data is owned by later Epic 35 stories.
             "billing_customers",
             "billing_plan_prices",
+            // Story 37-1 — curated audit-record read-model + the per-(projector,
+            // tenant) cursor. audit_records is mapped on BOTH contexts (the CP
+            // build materializes platform-scope + single-user rows); the cursor
+            // is CP-only (the projector resumes per-tenant domain streams from
+            // CP-resident high-water marks).
+            "audit_records",
+            "audit_projector_cursor",
         }, because: "Story 28-1 PR D (Decision #4) — enumerate every "
             + "CP-resident table; the 11 + 4 mentorship tenant-resident "
             + "entities have moved to TenantDbContext. Story 31-2 adds "
@@ -115,7 +122,8 @@ public class ControlPlaneDbContextModelTests
             + "platform_webhook_deliveries. Unified-tenancy Phase 0 adds "
             + "tenant_databases. Story 32-1 adds agents + agent_versions. "
             + "Story 34-1 adds plan_features + plan_entitlements + plan_prices. "
-            + "Story 35-1 adds billing_customers + billing_plan_prices.");
+            + "Story 35-1 adds billing_customers + billing_plan_prices. "
+            + "Story 37-1 adds audit_records + audit_projector_cursor.");
     }
 
     // ── Story 32-1 — agent entity model shape ──

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
@@ -92,12 +92,110 @@ public class ControlPlaneDbContextModelTests
             // shared-pool and dedicated DB instances. Each tenant row
             // references one of these via DatabaseId.
             "tenant_databases",
+            // Story 32-1 — first-class agent entities (Epic 32 foundation).
+            // CP-resident: public agents are shared cross-tenant and
+            // visibility/identity is a control-plane concern. Definition-only
+            // (no performance columns — those stay tenant-scoped).
+            "agents",
+            "agent_versions",
         }, because: "Story 28-1 PR D (Decision #4) — enumerate every "
             + "CP-resident table; the 11 + 4 mentorship tenant-resident "
             + "entities have moved to TenantDbContext. Story 31-2 adds "
             + "tenant_platform_installations; Story 31-7 adds "
             + "platform_webhook_deliveries. Unified-tenancy Phase 0 adds "
-            + "tenant_databases.");
+            + "tenant_databases. Story 32-1 adds agents + agent_versions.");
+    }
+
+    // ── Story 32-1 — agent entity model shape ──
+
+    [Test]
+    public void Agents_Has_VisibilityOwnership_CheckConstraint()
+    {
+        using var ctx = CreateContext();
+
+        // CHECK constraints are stripped from the runtime read-optimized model;
+        // they only live on the design-time model.
+        var designModel = Microsoft.EntityFrameworkCore.Infrastructure.AccessorExtensions
+            .GetService<Microsoft.EntityFrameworkCore.Metadata.IDesignTimeModel>(ctx).Model;
+        var agent = designModel.FindEntityType(typeof(Agent))!;
+        var check = agent.GetCheckConstraints()
+            .FirstOrDefault(c => c.Name == "ck_agents_visibility_ownership");
+
+        check.Should().NotBeNull(
+            "Story 32-1 ties Visibility to the owner columns via a CHECK "
+            + "(mirrors ck_prompt_overrides_principal_xor)");
+        // Public = 0 ⇒ no owner; Private = 1 ⇒ exactly one owner.
+        check!.Sql.Should().Contain("\"Visibility\" = 0");
+        check.Sql.Should().Contain("\"Visibility\" = 1");
+    }
+
+    [Test]
+    public void Agents_Has_PublicAndPrivate_PartialUniqueIndexes()
+    {
+        using var ctx = CreateContext();
+
+        var agent = ctx.Model.FindEntityType(typeof(Agent))!;
+        var indexes = agent.GetIndexes().ToList();
+
+        var publicNameRole = indexes.Single(i =>
+            i.GetDatabaseName() == "IX_agents_public_name_role");
+        publicNameRole.IsUnique.Should().BeTrue();
+        publicNameRole.GetFilter().Should().Be("\"Visibility\" = 0");
+        publicNameRole.Properties.Select(p => p.Name)
+            .Should().Equal("Name", "Role");
+
+        var privateTenant = indexes.Single(i =>
+            i.GetDatabaseName() == "IX_agents_private_tenant_name");
+        privateTenant.IsUnique.Should().BeTrue();
+        privateTenant.GetFilter().Should()
+            .Be("\"Visibility\" = 1 AND \"OwnerTenantId\" IS NOT NULL");
+
+        var privateUser = indexes.Single(i =>
+            i.GetDatabaseName() == "IX_agents_private_user_name");
+        privateUser.IsUnique.Should().BeTrue();
+        privateUser.GetFilter().Should()
+            .Be("\"Visibility\" = 1 AND \"OwnerUserId\" IS NOT NULL");
+    }
+
+    [Test]
+    public void AgentVersions_Has_AgentVersion_UniqueIndex_And_RestrictFk()
+    {
+        using var ctx = CreateContext();
+
+        var version = ctx.Model.FindEntityType(typeof(AgentVersion))!;
+
+        var unique = version.GetIndexes()
+            .Single(i => i.GetDatabaseName() == "IX_agent_versions_agent_version");
+        unique.IsUnique.Should().BeTrue(
+            "monotonic, non-duplicated versions per agent + the concurrency guard");
+        unique.Properties.Select(p => p.Name).Should().Equal("AgentId", "Version");
+
+        var fk = version.GetForeignKeys()
+            .Single(k => k.PrincipalEntityType.ClrType == typeof(Agent));
+        fk.DeleteBehavior.Should().Be(DeleteBehavior.Restrict,
+            "versions are immutable audit history — archive, never cascade-delete");
+    }
+
+    [Test]
+    public void Agents_And_AgentVersions_HaveNo_PerformanceColumns()
+    {
+        using var ctx = CreateContext();
+
+        // Story 32-1 non-goal: performance/action data is ALWAYS tenant-scoped
+        // (later Epic 32 stories). These CP entities are definition-only.
+        var forbidden = new[]
+        {
+            "SuccessRate", "AvgIterations", "BugCount", "CostUsd", "Latency",
+            "TokensIn", "TokensOut", "SuccessCount", "FailureCount",
+        };
+
+        var agentProps = ctx.Model.FindEntityType(typeof(Agent))!
+            .GetProperties().Select(p => p.Name).ToHashSet();
+        var versionProps = ctx.Model.FindEntityType(typeof(AgentVersion))!
+            .GetProperties().Select(p => p.Name).ToHashSet();
+
+        agentProps.Should().NotIntersectWith(forbidden);
+        versionProps.Should().NotIntersectWith(forbidden);
     }
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
@@ -210,6 +210,35 @@ public class ControlPlaneDbContextModelTests
         versionProps.Should().NotIntersectWith(forbidden);
     }
 
+    // ── Story 36-1 — CP analytics table is untouched; the tenant-only
+    //    analytics_usage_* fact tables never leak onto the control plane. ──
+
+    [Test]
+    public void Cp_Still_Maps_PlatformAnalyticsHourly_AndNot_AnalyticsUsageTables()
+    {
+        using var ctx = CreateContext();
+
+        var tables = ctx.Model.GetEntityTypes()
+            .Select(t => t.GetTableName())
+            .Where(n => n is not null)
+            .ToHashSet()!;
+
+        // Story 28-10's owner-only fleet-wide fact table stays put.
+        tables.Should().Contain("platform_analytics_hourly",
+            "Story 36-1 leaves the control-plane analytics table entirely intact");
+
+        // Story 36-1's per-tenant fact tables are tenant-resident only — they
+        // must NOT appear on the control-plane model graph.
+        tables.Should().NotContain("analytics_usage_hourly",
+            "analytics_usage_* are per-tenant — they live only on TenantDbContext");
+        tables.Should().NotContain("analytics_usage_daily",
+            "analytics_usage_* are per-tenant — they live only on TenantDbContext");
+
+        // And the CP context never even knows the CLR types.
+        ctx.Model.FindEntityType(typeof(AnalyticsUsageHourly)).Should().BeNull();
+        ctx.Model.FindEntityType(typeof(AnalyticsUsageDaily)).Should().BeNull();
+    }
+
     [Test]
     public void Tenant_Carries_ShadowProperties_ForEpic28Columns()
     {

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
@@ -102,13 +102,20 @@ public class ControlPlaneDbContextModelTests
             // (no performance columns — those stay tenant-scoped).
             "agents",
             "agent_versions",
+            // Story 35-1 — Epic 35 billing foundation. CP-resident: the
+            // tenant→Stripe customer mapping (keyed by tenant) + the
+            // slug→Stripe-ids catalog (platform-global). Definition/binding
+            // only — usage/metering data is owned by later Epic 35 stories.
+            "billing_customers",
+            "billing_plan_prices",
         }, because: "Story 28-1 PR D (Decision #4) — enumerate every "
             + "CP-resident table; the 11 + 4 mentorship tenant-resident "
             + "entities have moved to TenantDbContext. Story 31-2 adds "
             + "tenant_platform_installations; Story 31-7 adds "
             + "platform_webhook_deliveries. Unified-tenancy Phase 0 adds "
             + "tenant_databases. Story 32-1 adds agents + agent_versions. "
-            + "Story 34-1 adds plan_features + plan_entitlements + plan_prices.");
+            + "Story 34-1 adds plan_features + plan_entitlements + plan_prices. "
+            + "Story 35-1 adds billing_customers + billing_plan_prices.");
     }
 
     // ── Story 32-1 — agent entity model shape ──

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Orgs/OrgEndpointHandlerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Orgs/OrgEndpointHandlerTests.cs
@@ -41,6 +41,14 @@ public class OrgEndpointHandlerTests
     private InMemoryEmailService _emailInbox = null!;
     private DeleteConfirmationService _confirmation = null!;
     private ITenantProvisioningService _provisioning = null!;
+    // Story 35-1 — the tenant-create hook deps. The fixture runs single-user
+    // (no Tamma:Mode/shared-secret), so billing is the NullBillingProvider no-op;
+    // these are wired so the (unchanged) tenant-create behaviour still holds.
+    private Tamma.Api.Services.Billing.IBillingProvider _billing = null!;
+    private IPlatformQueuedTaskRepository _platformTasks = null!;
+#pragma warning disable NUnit1032 // Owned by the DI scope (_scope), disposed there.
+    private ILoggerFactory _loggerFactory = null!;
+#pragma warning restore NUnit1032
 
     [SetUp]
     public async Task Setup()
@@ -55,6 +63,9 @@ public class OrgEndpointHandlerTests
         _events = _scope.ServiceProvider.GetRequiredService<IEventRepository>();
         _publisher = _scope.ServiceProvider.GetRequiredService<Tamma.Data.Abstractions.IPlatformEventPublisher>();
         _provisioning = _scope.ServiceProvider.GetRequiredService<ITenantProvisioningService>();
+        _billing = _scope.ServiceProvider.GetRequiredService<Tamma.Api.Services.Billing.IBillingProvider>();
+        _platformTasks = _scope.ServiceProvider.GetRequiredService<IPlatformQueuedTaskRepository>();
+        _loggerFactory = _scope.ServiceProvider.GetRequiredService<ILoggerFactory>();
         _emailInbox = new InMemoryEmailService();
         var config = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -104,7 +115,8 @@ public class OrgEndpointHandlerTests
         var user = await CreateUser();
         var result = await OrgEndpoints.CreateOrg(
             new CreateOrgRequest("Acme", "admin"),
-            _tenantRepo, _membershipRepo, _userRepo, _events, _provisioning, Principal(user.Id));
+            _tenantRepo, _membershipRepo, _userRepo, _events, _provisioning,
+            _billing, _platformTasks, _loggerFactory, Principal(user.Id));
 
         // BadRequest result type
         result.Should().BeAssignableTo<IResult>();
@@ -118,7 +130,8 @@ public class OrgEndpointHandlerTests
         var user = await CreateUser();
         var result = await OrgEndpoints.CreateOrg(
             new CreateOrgRequest("A", "acme-corp"),
-            _tenantRepo, _membershipRepo, _userRepo, _events, _provisioning, Principal(user.Id));
+            _tenantRepo, _membershipRepo, _userRepo, _events, _provisioning,
+            _billing, _platformTasks, _loggerFactory, Principal(user.Id));
         var status = await ExecuteAndGetStatus(result);
         status.Should().Be(StatusCodes.Status400BadRequest);
     }
@@ -129,7 +142,8 @@ public class OrgEndpointHandlerTests
         var user = await CreateUser();
         var result = await OrgEndpoints.CreateOrg(
             new CreateOrgRequest("Acme", "my.org"),  // '.' never valid in slug
-            _tenantRepo, _membershipRepo, _userRepo, _events, _provisioning, Principal(user.Id));
+            _tenantRepo, _membershipRepo, _userRepo, _events, _provisioning,
+            _billing, _platformTasks, _loggerFactory, Principal(user.Id));
         (await ExecuteAndGetStatus(result)).Should().Be(StatusCodes.Status400BadRequest);
     }
 
@@ -141,7 +155,8 @@ public class OrgEndpointHandlerTests
 
         var result = await OrgEndpoints.CreateOrg(
             new CreateOrgRequest("Acme Two", "acme-corp"),
-            _tenantRepo, _membershipRepo, _userRepo, _events, _provisioning, Principal(user.Id));
+            _tenantRepo, _membershipRepo, _userRepo, _events, _provisioning,
+            _billing, _platformTasks, _loggerFactory, Principal(user.Id));
         (await ExecuteAndGetStatus(result)).Should().Be(StatusCodes.Status409Conflict);
     }
 
@@ -151,7 +166,8 @@ public class OrgEndpointHandlerTests
         var user = await CreateUser();
         var result = await OrgEndpoints.CreateOrg(
             new CreateOrgRequest("Acme Inc.", "acme-corp"),
-            _tenantRepo, _membershipRepo, _userRepo, _events, _provisioning, Principal(user.Id));
+            _tenantRepo, _membershipRepo, _userRepo, _events, _provisioning,
+            _billing, _platformTasks, _loggerFactory, Principal(user.Id));
         (await ExecuteAndGetStatus(result)).Should().Be(StatusCodes.Status201Created);
 
         var refreshed = await _userRepo.GetByIdAsync(user.Id);

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanCatalogEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanCatalogEndpointsTests.cs
@@ -1,0 +1,146 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Endpoints.Admin;
+using Tamma.Api.Services.Pricing;
+using Tamma.Api.Tests.TestDoubles;
+using Tamma.Data;
+using Tamma.Data.Seeders;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-1 (Phase 5) — the three read-only <c>GET /api/admin/plans*</c>
+/// handlers on <see cref="PlanCatalogEndpoints"/>. Drives the handler methods
+/// directly against a real catalog service (Postgres testcontainer) and
+/// executes the <see cref="IResult"/> into an <see cref="HttpContext"/> to read
+/// the status code (the robust pattern the agent endpoint tests use). The
+/// <c>OwnerAccess</c> RBAC gate is applied at the Program.cs wiring site (the
+/// dev-mode test auth short-circuits named policies). Write endpoints are
+/// deferred to Story 34-2.
+/// </summary>
+[TestFixture]
+public class PlanCatalogEndpointsTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("plan_endpoint_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+        await PlansSeeder.SeedAsync(ctx);
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    private ControlPlaneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    private IPlanCatalogService BuildCatalog(ControlPlaneDbContext ctx) =>
+        new PlanCatalogService(ctx, NullLogger<PlanCatalogService>.Instance);
+
+    private static async Task<(int Status, JsonElement Body)> ExecuteAsync(IResult result)
+    {
+        var services = new ServiceCollection().AddLogging().AddOptions().BuildServiceProvider();
+        var ctx = new DefaultHttpContext
+        {
+            RequestServices = services,
+            Response = { Body = new MemoryStream() },
+        };
+        await result.ExecuteAsync(ctx);
+        ctx.Response.Body.Seek(0, SeekOrigin.Begin);
+        if (ctx.Response.Body.Length == 0)
+        {
+            return (ctx.Response.StatusCode, default);
+        }
+        using var doc = await JsonDocument.ParseAsync(ctx.Response.Body);
+        return (ctx.Response.StatusCode, doc.RootElement.Clone());
+    }
+
+    [Test]
+    public async Task ListActive_Returns_200_With_Active_Snapshots()
+    {
+        await using var ctx = NewContext();
+        var (status, body) = await ExecuteAsync(
+            await PlanCatalogEndpoints.ListActive(BuildCatalog(ctx), default));
+
+        status.Should().Be(StatusCodes.Status200OK);
+        body.GetProperty("plans").GetArrayLength().Should().Be(3);
+    }
+
+    [Test]
+    public async Task GetActiveBySlug_Known_Returns_200()
+    {
+        await using var ctx = NewContext();
+        var (status, body) = await ExecuteAsync(
+            await PlanCatalogEndpoints.GetActiveBySlug("team", BuildCatalog(ctx), default));
+
+        status.Should().Be(StatusCodes.Status200OK);
+        body.GetProperty("slug").GetString().Should().Be("team");
+    }
+
+    [Test]
+    public async Task GetActiveBySlug_Unknown_Returns_404()
+    {
+        await using var ctx = NewContext();
+        var (status, _) = await ExecuteAsync(
+            await PlanCatalogEndpoints.GetActiveBySlug("ghost", BuildCatalog(ctx), default));
+
+        status.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Test]
+    public async Task GetVersions_Known_Returns_200_With_Chain()
+    {
+        await using (var editCtx = NewContext())
+        {
+            var editor = new PlanVersionEditor(
+                editCtx, new RecordingPlatformEventPublisher(),
+                TimeProvider.System, NullLogger<PlanVersionEditor>.Instance);
+            // Idempotent for the suite: only supersede if still v1 active.
+            var active = await editCtx.Plans.FirstAsync(p => p.Slug == "enterprise" && p.Status == "active");
+            if (active.Version == 1)
+            {
+                await editor.CreateNewVersionAsync(
+                    "enterprise", new PlanDraftSpec(), new PlanEditorPrincipal("u", null));
+            }
+        }
+
+        await using var ctx = NewContext();
+        var (status, body) = await ExecuteAsync(
+            await PlanCatalogEndpoints.GetVersions("enterprise", BuildCatalog(ctx), default));
+
+        status.Should().Be(StatusCodes.Status200OK);
+        body.GetProperty("versions").GetArrayLength().Should().BeGreaterThanOrEqualTo(2);
+    }
+
+    [Test]
+    public async Task GetVersions_Unknown_Returns_404()
+    {
+        await using var ctx = NewContext();
+        var (status, _) = await ExecuteAsync(
+            await PlanCatalogEndpoints.GetVersions("ghost", BuildCatalog(ctx), default));
+
+        status.Should().Be(StatusCodes.Status404NotFound);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanCatalogMigrationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanCatalogMigrationTests.cs
@@ -1,0 +1,151 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using NUnit.Framework;
+using Tamma.Data;
+using Tamma.Data.Seeders;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-1 (AC7, AC8) — applies the ControlPlane migration bundle to a clean
+/// Postgres testcontainer and asserts the price-book schema landed: the three
+/// new tables, the new plan columns, the CHECK constraints, the partial unique
+/// "one active per slug" index, the <c>text</c> metric-key column, and that the
+/// seeded plan rows backfill to <c>Status='active'</c>/<c>Version=1</c>. Raw
+/// Npgsql introspection (no Dapper) — mirrors the existing migration suites.
+/// </summary>
+[TestFixture]
+public class PlanCatalogMigrationTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("plan_migration_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    private ControlPlaneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    private async Task<NpgsqlConnection> OpenAsync()
+    {
+        var conn = new NpgsqlConnection(_cs);
+        await conn.OpenAsync();
+        return conn;
+    }
+
+    private async Task<HashSet<string>> QueryStringsAsync(NpgsqlConnection conn, string sql)
+    {
+        var result = new HashSet<string>(StringComparer.Ordinal);
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            if (!reader.IsDBNull(0)) result.Add(reader.GetString(0));
+        }
+        return result;
+    }
+
+    private async Task<string?> ScalarAsync(NpgsqlConnection conn, string sql)
+    {
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        var v = await cmd.ExecuteScalarAsync();
+        return v is null or DBNull ? null : v.ToString();
+    }
+
+    [Test]
+    public async Task Migration_Creates_The_Three_PriceBook_Tables()
+    {
+        await using var conn = await OpenAsync();
+        var tables = await QueryStringsAsync(conn,
+            "SELECT table_name FROM information_schema.tables WHERE table_schema='public';");
+
+        tables.Should().Contain("plan_features");
+        tables.Should().Contain("plan_entitlements");
+        tables.Should().Contain("plan_prices");
+    }
+
+    [Test]
+    public async Task Migration_Adds_The_New_Plan_Columns()
+    {
+        await using var conn = await OpenAsync();
+        var cols = await QueryStringsAsync(conn,
+            "SELECT column_name FROM information_schema.columns WHERE table_name='plans';");
+
+        cols.Should().Contain(new[] { "Version", "Status", "IsCustom", "BillingInterval", "SupersedesPlanId" });
+    }
+
+    [Test]
+    public async Task Migration_Creates_The_Check_Constraints()
+    {
+        await using var conn = await OpenAsync();
+        var checks = await QueryStringsAsync(conn,
+            "SELECT conname FROM pg_constraint WHERE contype='c';");
+
+        checks.Should().Contain("ck_plans_status");
+        checks.Should().Contain("ck_plans_billing_interval");
+        checks.Should().Contain("ck_plan_entitlements_period");
+        checks.Should().Contain("ck_plan_entitlements_overage");
+        checks.Should().Contain("ck_plan_prices_mode");
+    }
+
+    [Test]
+    public async Task Migration_Creates_The_Partial_OneActivePerSlug_Index()
+    {
+        await using var conn = await OpenAsync();
+        var def = await ScalarAsync(conn,
+            "SELECT indexdef FROM pg_indexes WHERE indexname='UX_plans_OneActivePerSlug';");
+
+        def.Should().NotBeNull();
+        def!.Should().Contain("UNIQUE");
+        def.Should().Contain("Status");
+        def.Should().Contain("active", "the index is filtered WHERE Status = 'active'");
+    }
+
+    [Test]
+    public async Task MetricKey_Column_Is_Text_Not_Integer()
+    {
+        await using var conn = await OpenAsync();
+        var dataType = await ScalarAsync(conn,
+            "SELECT data_type FROM information_schema.columns "
+            + "WHERE table_name='plan_entitlements' AND column_name='MetricKey';");
+
+        dataType.Should().Be("text", "the metric key persists as snake_case text, never the ordinal");
+    }
+
+    [Test]
+    public async Task Seeded_Plans_Backfill_To_Active_Version_1()
+    {
+        await using (var ctx = NewContext())
+        {
+            await ctx.Database.ExecuteSqlRawAsync(
+                "TRUNCATE plan_prices, plan_entitlements, plan_features, plans CASCADE;");
+            await PlansSeeder.SeedAsync(ctx);
+        }
+
+        await using var verify = NewContext();
+        var plans = await verify.Plans.AsNoTracking().ToListAsync();
+        plans.Should().HaveCount(3);
+        plans.Should().OnlyContain(p => p.Version == 1 && p.Status == "active");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanCatalogModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanCatalogModelTests.cs
@@ -1,0 +1,101 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using Tamma.Data;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-1 — model-shape assertions for the price-book entities. Pure model
+/// metadata inspection (no Postgres connection). Confirms the three DbSets
+/// resolve, the <c>MetricKey</c> is value-converted to text (never the ordinal),
+/// the partial unique "one active per slug" index exists, and the CHECK
+/// constraints are configured on the design-time model.
+/// </summary>
+[TestFixture]
+public class PlanCatalogModelTests
+{
+    private static ControlPlaneDbContext CreateContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseNpgsql("Host=localhost;Database=cp_test;Username=tamma;Password=tamma")
+            .Options);
+
+    [Test]
+    public void PriceBook_Tables_Are_Mapped()
+    {
+        using var ctx = CreateContext();
+        var tables = ctx.Model.GetEntityTypes()
+            .Select(t => t.GetTableName())
+            .ToHashSet();
+
+        tables.Should().Contain("plan_features");
+        tables.Should().Contain("plan_entitlements");
+        tables.Should().Contain("plan_prices");
+    }
+
+    [Test]
+    public void MetricKey_Is_Persisted_As_Text_Via_Converter()
+    {
+        using var ctx = CreateContext();
+        var entity = ctx.Model.FindEntityType(typeof(PlanEntitlement))!;
+        var prop = entity.FindProperty(nameof(PlanEntitlement.MetricKey))!;
+
+        prop.GetValueConverter().Should().NotBeNull(
+            "MetricKey must round-trip through the snake_case value converter, "
+            + "never the unstable numeric ordinal");
+        prop.GetColumnType().Should().Be("text");
+    }
+
+    [Test]
+    public void Plans_Has_OneActivePerSlug_PartialUniqueIndex()
+    {
+        using var ctx = CreateContext();
+        var plan = ctx.Model.FindEntityType(typeof(Plan))!;
+        var index = plan.GetIndexes()
+            .Single(i => i.GetDatabaseName() == "UX_plans_OneActivePerSlug");
+
+        index.IsUnique.Should().BeTrue();
+        index.GetFilter().Should().Be("\"Status\" = 'active'");
+    }
+
+    [Test]
+    public void Plans_Has_SlugVersion_UniqueIndex()
+    {
+        using var ctx = CreateContext();
+        var plan = ctx.Model.FindEntityType(typeof(Plan))!;
+        var index = plan.GetIndexes()
+            .Single(i => i.GetDatabaseName() == "UX_plans_Slug_Version");
+
+        index.IsUnique.Should().BeTrue();
+        index.Properties.Select(p => p.Name).Should().Equal("Slug", "Version");
+    }
+
+    [Test]
+    public void Plans_Has_Status_And_BillingInterval_CheckConstraints()
+    {
+        using var ctx = CreateContext();
+        var designModel = Microsoft.EntityFrameworkCore.Infrastructure.AccessorExtensions
+            .GetService<Microsoft.EntityFrameworkCore.Metadata.IDesignTimeModel>(ctx).Model;
+        var plan = designModel.FindEntityType(typeof(Plan))!;
+        var checks = plan.GetCheckConstraints().Select(c => c.Name).ToList();
+
+        checks.Should().Contain("ck_plans_status");
+        checks.Should().Contain("ck_plans_billing_interval");
+    }
+
+    [Test]
+    public void Children_FK_To_Plans_Is_Restrict()
+    {
+        using var ctx = CreateContext();
+
+        foreach (var type in new[] { typeof(PlanFeature), typeof(PlanEntitlement), typeof(PlanPrice) })
+        {
+            var entity = ctx.Model.FindEntityType(type)!;
+            var fk = entity.GetForeignKeys()
+                .Single(f => f.PrincipalEntityType.ClrType == typeof(Plan));
+            fk.DeleteBehavior.Should().Be(DeleteBehavior.Restrict,
+                $"{type.Name} → plans must RESTRICT (a referenced version can't be hard-deleted)");
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanCatalogServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanCatalogServiceTests.cs
@@ -1,0 +1,257 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Services.Pricing;
+using Tamma.Api.Tests.TestDoubles;
+using Tamma.Core.Enums;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Seeders;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-1 (AC10, AC12, AC13) — <see cref="PlanCatalogService"/> against a
+/// real Postgres testcontainer (so the value converter, FK, and partial unique
+/// index behave like production). Covers snapshot resolution (features +
+/// entitlements + prices assembled per version), active-only by slug, frozen
+/// deprecated snapshot by id, the tenant <c>PlanId</c> shadow-column resolution
+/// + isolation, and the one-active-version DB invariant.
+/// </summary>
+[TestFixture]
+public class PlanCatalogServiceTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("plan_catalog_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE plan_prices, plan_entitlements, plan_features, plans, tenants CASCADE;");
+    }
+
+    private ControlPlaneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    private async Task SeedAsync()
+    {
+        await using var ctx = NewContext();
+        await PlansSeeder.SeedAsync(ctx);
+    }
+
+    private PlanCatalogService BuildService(ControlPlaneDbContext ctx) =>
+        new(ctx, NullLogger<PlanCatalogService>.Instance);
+
+    [Test]
+    public async Task GetActiveBySlug_Assembles_Full_Snapshot()
+    {
+        await SeedAsync();
+        await using var ctx = NewContext();
+        var svc = BuildService(ctx);
+
+        var snap = await svc.GetActiveBySlugAsync("team");
+
+        snap.Should().NotBeNull();
+        snap!.Slug.Should().Be("team");
+        snap.Version.Should().Be(1);
+        snap.Status.Should().Be("active");
+        snap.Features.Should().NotBeEmpty();
+        snap.Entitlements.Should().Contain(e => e.MetricKey == EntitlementMetricKey.LlmTokens);
+        snap.Prices.Select(p => p.PricingMode)
+            .Should().BeEquivalentTo(new[] { "platform_provided", "byok" });
+    }
+
+    [Test]
+    public async Task GetActiveBySlug_Unknown_Returns_Null()
+    {
+        await SeedAsync();
+        await using var ctx = NewContext();
+        var svc = BuildService(ctx);
+
+        (await svc.GetActiveBySlugAsync("nope")).Should().BeNull();
+    }
+
+    [Test]
+    public async Task GetById_Returns_Frozen_Deprecated_Snapshot()
+    {
+        await SeedAsync();
+
+        // Supersede team v1 → v2 (v1 becomes deprecated, frozen).
+        Guid v1Id;
+        await using (var editCtx = NewContext())
+        {
+            var editor = new PlanVersionEditor(
+                editCtx, new RecordingPlatformEventPublisher(),
+                TimeProvider.System, NullLogger<PlanVersionEditor>.Instance);
+            v1Id = (await editCtx.Plans.FirstAsync(p => p.Slug == "team" && p.Status == "active")).Id;
+            await editor.CreateNewVersionAsync(
+                "team",
+                new PlanDraftSpec(DisplayName: "Team v2"),
+                new PlanEditorPrincipal("u", "u@x.io"));
+        }
+
+        await using var ctx = NewContext();
+        var svc = BuildService(ctx);
+
+        var byId = await svc.GetByIdAsync(v1Id);
+        byId.Should().NotBeNull();
+        byId!.Version.Should().Be(1);
+        byId.Status.Should().Be("deprecated", "the prior version is frozen, still snapshot-able by id");
+
+        var active = await svc.GetActiveBySlugAsync("team");
+        active!.Version.Should().Be(2);
+        active.DisplayName.Should().Be("Team v2");
+    }
+
+    [Test]
+    public async Task GetForTenant_Resolves_Via_PlanId_ShadowColumn()
+    {
+        await SeedAsync();
+
+        var tenantId = Guid.NewGuid();
+        await using (var setup = NewContext())
+        {
+            var tenant = NewTenant(tenantId, "free");
+            setup.Tenants.Add(tenant);
+            setup.Entry(tenant).Property("PlanId").CurrentValue = PlansSeeder.FreePlanId;
+            await setup.SaveChangesAsync();
+        }
+
+        await using var ctx = NewContext();
+        var svc = BuildService(ctx);
+
+        var snap = await svc.GetForTenantAsync(tenantId);
+        snap.Should().NotBeNull();
+        snap!.Slug.Should().Be("free");
+    }
+
+    [Test]
+    public async Task GetForTenant_With_No_Plan_Returns_Null()
+    {
+        await SeedAsync();
+
+        var tenantId = Guid.NewGuid();
+        await using (var setup = NewContext())
+        {
+            setup.Tenants.Add(NewTenant(tenantId, "free"));
+            // Deliberately leave PlanId shadow column NULL.
+            await setup.SaveChangesAsync();
+        }
+
+        await using var ctx = NewContext();
+        var svc = BuildService(ctx);
+
+        (await svc.GetForTenantAsync(tenantId)).Should().BeNull();
+    }
+
+    [Test]
+    public async Task GetForTenant_Isolation_Two_Tenants_Resolve_Their_Own_Plan()
+    {
+        await SeedAsync();
+
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+        await using (var setup = NewContext())
+        {
+            var a = NewTenant(tenantA, "free");
+            var b = NewTenant(tenantB, "team");
+            setup.Tenants.Add(a);
+            setup.Tenants.Add(b);
+            setup.Entry(a).Property("PlanId").CurrentValue = PlansSeeder.FreePlanId;
+            setup.Entry(b).Property("PlanId").CurrentValue = PlansSeeder.TeamPlanId;
+            await setup.SaveChangesAsync();
+        }
+
+        await using var ctx = NewContext();
+        var svc = BuildService(ctx);
+
+        (await svc.GetForTenantAsync(tenantA))!.Slug.Should().Be("free");
+        (await svc.GetForTenantAsync(tenantB))!.Slug.Should().Be("team",
+            "the catalog is platform-global; each tenant resolves only its own assigned plan");
+    }
+
+    [Test]
+    public async Task ListActive_Returns_Only_Active_Versions()
+    {
+        await SeedAsync();
+
+        await using (var editCtx = NewContext())
+        {
+            var editor = new PlanVersionEditor(
+                editCtx, new RecordingPlatformEventPublisher(),
+                TimeProvider.System, NullLogger<PlanVersionEditor>.Instance);
+            await editor.CreateNewVersionAsync(
+                "team", new PlanDraftSpec(), new PlanEditorPrincipal("u", null));
+        }
+
+        await using var ctx = NewContext();
+        var svc = BuildService(ctx);
+
+        var list = await svc.ListActiveAsync();
+        list.Should().HaveCount(3, "still one active version per slug after the team supersede");
+        list.Should().OnlyContain(s => s.Status == "active");
+        list.Single(s => s.Slug == "team").Version.Should().Be(2);
+    }
+
+    [Test]
+    public async Task OneActiveVersion_Invariant_Rejects_Second_Active_Row()
+    {
+        await SeedAsync();
+
+        await using var ctx = NewContext();
+        var dup = new Plan
+        {
+            Id = Guid.NewGuid(),
+            Slug = "team",
+            DisplayName = "Rogue duplicate",
+            Version = 99,
+            Status = "active", // a SECOND active row for slug "team"
+            BillingInterval = "monthly",
+            PlacementPolicy = "shared",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        ctx.Plans.Add(dup);
+
+        var act = async () => await ctx.SaveChangesAsync();
+        await act.Should().ThrowAsync<DbUpdateException>(
+            "UX_plans_OneActivePerSlug forbids two active versions for one slug");
+    }
+
+    private static Tenant NewTenant(Guid id, string plan) => new()
+    {
+        Id = id,
+        Name = "T-" + id.ToString("N")[..6],
+        Slug = "t-" + id.ToString("N")[..6],
+        Type = "team",
+        Plan = plan,
+        CreatedAt = DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow,
+    };
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanImmutabilityInterceptorTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanImmutabilityInterceptorTests.cs
@@ -1,0 +1,297 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Services.Pricing;
+using Tamma.Api.Tests.TestDoubles;
+using Tamma.Core;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Seeders;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-1 follow-up (AC6) — the AUTHORITATIVE immutability enforcement: the
+/// <see cref="ControlPlaneDbContext"/> <c>SaveChanges</c> interceptor. Unlike
+/// <see cref="PlanImmutabilityTests"/> (which only exercise the optional
+/// pre-flight <c>EnsureMutableOrThrow</c> helper), these prove a raw EF mutation
+/// that bypasses <see cref="PlanVersionEditor"/> entirely STILL fails loud —
+/// for both an active/deprecated <c>Plan</c> row AND its child feature /
+/// entitlement / price rows. Runs against a real Postgres testcontainer so the
+/// untracked-owning-plan DB lookup and the editor's flip-then-insert
+/// transaction are exercised against the actual schema + partial unique index.
+/// </summary>
+[TestFixture]
+public class PlanImmutabilityInterceptorTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("plan_immutability_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE plan_prices, plan_entitlements, plan_features, plans CASCADE;");
+        await PlansSeeder.SeedAsync(ctx);
+    }
+
+    private ControlPlaneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    // (a) Direct mutation of an ACTIVE plan row throws.
+    [Test]
+    public async Task DirectMutation_Of_Active_Plan_Throws()
+    {
+        await using var ctx = NewContext();
+        var plan = await ctx.Plans.FirstAsync(p => p.Slug == "team" && p.Status == "active");
+
+        plan.MonthlyPriceUsd = 999m;
+
+        var act = async () => await ctx.SaveChangesAsync();
+        (await act.Should().ThrowAsync<TammaError>())
+            .Which.Code.Should().Be("PLAN.VERSION.IMMUTABLE");
+    }
+
+    [Test]
+    public async Task DirectMutation_Of_Active_Plan_Is_High_Severity()
+    {
+        await using var ctx = NewContext();
+        var plan = await ctx.Plans.FirstAsync(p => p.Slug == "team" && p.Status == "active");
+        plan.DisplayName = "Hacked";
+
+        var ex = Assert.ThrowsAsync<TammaError>(async () => await ctx.SaveChangesAsync());
+        ex!.Severity.Should().Be(TammaErrorSeverity.High);
+        ex.Context.Should().ContainKey("planId");
+    }
+
+    // (b) Direct mutation of a DEPRECATED plan row throws.
+    [Test]
+    public async Task DirectMutation_Of_Deprecated_Plan_Throws()
+    {
+        Guid v1Id;
+        // Make a deprecated row first via the editor (legitimate path).
+        await using (var ctx = NewContext())
+        {
+            v1Id = (await ctx.Plans.FirstAsync(p => p.Slug == "team" && p.Status == "active")).Id;
+            var editor = new PlanVersionEditor(
+                ctx, new RecordingPlatformEventPublisher(),
+                TimeProvider.System, NullLogger<PlanVersionEditor>.Instance);
+            await editor.CreateNewVersionAsync(
+                "team", new PlanDraftSpec(), new PlanEditorPrincipal("u", null));
+        }
+
+        await using var verify = NewContext();
+        var deprecated = await verify.Plans.FirstAsync(p => p.Id == v1Id);
+        deprecated.Status.Should().Be("deprecated");
+
+        deprecated.MonthlyPriceUsd = 1m;
+        var act = async () => await verify.SaveChangesAsync();
+        (await act.Should().ThrowAsync<TammaError>())
+            .Which.Code.Should().Be("PLAN.VERSION.IMMUTABLE");
+    }
+
+    // (c) Mutation / insert / delete of a CHILD row of an active plan throws.
+    [Test]
+    public async Task ChildMutation_Of_Active_Plan_Throws()
+    {
+        await using var ctx = NewContext();
+        var planId = (await ctx.Plans.FirstAsync(p => p.Slug == "team" && p.Status == "active")).Id;
+        var feature = await ctx.PlanFeatures.FirstAsync(f => f.PlanId == planId);
+
+        feature.StringValue = "tampered";
+
+        var act = async () => await ctx.SaveChangesAsync();
+        (await act.Should().ThrowAsync<TammaError>())
+            .Which.Code.Should().Be("PLAN.VERSION.IMMUTABLE");
+    }
+
+    [Test]
+    public async Task ChildInsert_Onto_Active_Plan_Throws()
+    {
+        await using var ctx = NewContext();
+        var planId = (await ctx.Plans.FirstAsync(p => p.Slug == "team" && p.Status == "active")).Id;
+
+        ctx.PlanFeatures.Add(new PlanFeature
+        {
+            Id = Guid.NewGuid(),
+            PlanId = planId,
+            FeatureKey = "smuggled_in",
+            BoolValue = true,
+        });
+
+        var act = async () => await ctx.SaveChangesAsync();
+        (await act.Should().ThrowAsync<TammaError>())
+            .Which.Code.Should().Be("PLAN.VERSION.IMMUTABLE");
+    }
+
+    [Test]
+    public async Task ChildDelete_From_Active_Plan_Throws()
+    {
+        await using var ctx = NewContext();
+        var planId = (await ctx.Plans.FirstAsync(p => p.Slug == "team" && p.Status == "active")).Id;
+        var price = await ctx.PlanPrices.FirstAsync(p => p.PlanId == planId);
+
+        ctx.PlanPrices.Remove(price);
+
+        var act = async () => await ctx.SaveChangesAsync();
+        (await act.Should().ThrowAsync<TammaError>())
+            .Which.Code.Should().Be("PLAN.VERSION.IMMUTABLE");
+    }
+
+    [Test]
+    public async Task ChildMutation_Of_Deprecated_Plan_Throws()
+    {
+        Guid v1Id;
+        await using (var ctx = NewContext())
+        {
+            v1Id = (await ctx.Plans.FirstAsync(p => p.Slug == "team" && p.Status == "active")).Id;
+            var editor = new PlanVersionEditor(
+                ctx, new RecordingPlatformEventPublisher(),
+                TimeProvider.System, NullLogger<PlanVersionEditor>.Instance);
+            await editor.CreateNewVersionAsync(
+                "team", new PlanDraftSpec(), new PlanEditorPrincipal("u", null));
+        }
+
+        await using var verify = NewContext();
+        var entitlement = await verify.PlanEntitlements.FirstAsync(e => e.PlanId == v1Id);
+        entitlement.LimitValue = 7777;
+
+        var act = async () => await verify.SaveChangesAsync();
+        (await act.Should().ThrowAsync<TammaError>())
+            .Which.Code.Should().Be("PLAN.VERSION.IMMUTABLE");
+    }
+
+    // (d) Editing a DRAFT plan + its children succeeds.
+    [Test]
+    public async Task DirectMutation_Of_Draft_Plan_And_Children_Succeeds()
+    {
+        var draftId = Guid.NewGuid();
+        var featureId = Guid.NewGuid();
+
+        await using (var seed = NewContext())
+        {
+            seed.Plans.Add(new Plan
+            {
+                Id = draftId,
+                Slug = "draft-only",
+                DisplayName = "Draft",
+                Version = 1,
+                Status = "draft",
+                BillingInterval = "monthly",
+                MonthlyPriceUsd = 1m,
+                PlacementPolicy = "shared",
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+                Features =
+                {
+                    new PlanFeature { Id = featureId, PlanId = draftId, FeatureKey = "x", BoolValue = true },
+                },
+            });
+            await seed.SaveChangesAsync();
+        }
+
+        await using var ctx = NewContext();
+        var draft = await ctx.Plans.FirstAsync(p => p.Id == draftId);
+        var feature = await ctx.PlanFeatures.FirstAsync(f => f.Id == featureId);
+        draft.MonthlyPriceUsd = 2m;
+        feature.BoolValue = false;
+
+        var act = async () => await ctx.SaveChangesAsync();
+        await act.Should().NotThrowAsync("a draft plan and its children are freely editable");
+    }
+
+    [Test]
+    public async Task ChildInsert_Onto_Draft_Plan_Succeeds()
+    {
+        var draftId = Guid.NewGuid();
+        await using (var seed = NewContext())
+        {
+            seed.Plans.Add(new Plan
+            {
+                Id = draftId,
+                Slug = "draft-child",
+                DisplayName = "Draft",
+                Version = 1,
+                Status = "draft",
+                BillingInterval = "monthly",
+                MonthlyPriceUsd = 1m,
+                PlacementPolicy = "shared",
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+            });
+            await seed.SaveChangesAsync();
+        }
+
+        await using var ctx = NewContext();
+        ctx.PlanFeatures.Add(new PlanFeature
+        {
+            Id = Guid.NewGuid(),
+            PlanId = draftId,
+            FeatureKey = "added_to_draft",
+            BoolValue = true,
+        });
+
+        var act = async () => await ctx.SaveChangesAsync();
+        await act.Should().NotThrowAsync("children of a draft plan are freely insertable");
+    }
+
+    // (e) The editor's version-create + deprecate-flip succeeds THROUGH the
+    // interceptor (the controlled active→deprecated flip + the new active
+    // plan's children are both allowed).
+    [Test]
+    public async Task EditorVersionCreate_Succeeds_Through_Interceptor()
+    {
+        var publisher = new RecordingPlatformEventPublisher();
+        Guid v1Id;
+
+        await using (var ctx = NewContext())
+        {
+            v1Id = (await ctx.Plans.FirstAsync(p => p.Slug == "team" && p.Status == "active")).Id;
+            var editor = new PlanVersionEditor(
+                ctx, publisher, TimeProvider.System, NullLogger<PlanVersionEditor>.Instance);
+
+            var act = async () => await editor.CreateNewVersionAsync(
+                "team",
+                new PlanDraftSpec(DisplayName: "Team v2", MonthlyPriceUsd: 59m),
+                new PlanEditorPrincipal("user-123", "owner@x.io"));
+
+            await act.Should().NotThrowAsync(
+                "the controlled active→deprecated flip + new active version's children "
+                + "must clear the immutability interceptor");
+        }
+
+        await using var verify = NewContext();
+        (await verify.Plans.FirstAsync(p => p.Id == v1Id)).Status.Should().Be("deprecated");
+        (await verify.Plans.CountAsync(p => p.Slug == "team" && p.Status == "active"))
+            .Should().Be(1, "exactly one active version per slug after the flip");
+        var v2 = await verify.Plans
+            .Include(p => p.Features)
+            .FirstAsync(p => p.Slug == "team" && p.Status == "active");
+        v2.Features.Should().NotBeEmpty("the new version's children committed through the interceptor");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanImmutabilityInterceptorTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanImmutabilityInterceptorTests.cs
@@ -260,6 +260,32 @@ public class PlanImmutabilityInterceptorTests
         await act.Should().NotThrowAsync("children of a draft plan are freely insertable");
     }
 
+    // (d2) The ONLY permitted change to an immutable active row is the pure
+    // active→deprecated flip (Status + UpdatedAt). A SaveChanges that flips the
+    // status AND piggy-backs another column change is NOT a controlled flip —
+    // it must throw so an attacker can't smuggle a price edit through the
+    // deprecation path. Single SaveChanges, both changes staged together.
+    [Test]
+    public async Task DeprecationFlip_With_Smuggled_Field_Change_Throws()
+    {
+        await using var ctx = NewContext();
+        var plan = await ctx.Plans.FirstAsync(p => p.Slug == "team" && p.Status == "active");
+
+        // Flip status active→deprecated AND also change another column in the
+        // SAME unit of work. The interceptor's IsControlledDeprecationFlip only
+        // tolerates Status + UpdatedAt, so this must be rejected.
+        plan.Status = "deprecated";
+        plan.MonthlyPriceUsd = 12345m;
+
+        var act = async () => await ctx.SaveChangesAsync();
+        var ex = (await act.Should().ThrowAsync<TammaError>(
+            "flipping status while also mutating another field is not a controlled "
+            + "deprecation flip — it must be rejected"))
+            .Which;
+        ex.Code.Should().Be("PLAN.VERSION.IMMUTABLE");
+        ex.Severity.Should().Be(TammaErrorSeverity.High);
+    }
+
     // (e) The editor's version-create + deprecate-flip succeeds THROUGH the
     // interceptor (the controlled active→deprecated flip + the new active
     // plan's children are both allowed).

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanImmutabilityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanImmutabilityTests.cs
@@ -1,0 +1,69 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Services.Pricing;
+using Tamma.Api.Tests.TestDoubles;
+using Tamma.Core;
+using Tamma.Data;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-1 (AC6, AC13) — the immutability guard. A plan version whose
+/// <c>Status</c> is <c>active</c> or <c>deprecated</c> is immutable; only a
+/// <c>draft</c> row is editable in place. The guard throws
+/// <c>PLAN.VERSION.IMMUTABLE</c>. Pure unit test — no DB required.
+/// </summary>
+[TestFixture]
+public class PlanImmutabilityTests
+{
+    private static PlanVersionEditor BuildEditor()
+    {
+        var options = new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        var db = new ControlPlaneDbContext(options);
+        return new PlanVersionEditor(
+            db,
+            new RecordingPlatformEventPublisher(),
+            TimeProvider.System,
+            NullLogger<PlanVersionEditor>.Instance);
+    }
+
+    [TestCase("active")]
+    [TestCase("deprecated")]
+    public void EnsureMutableOrThrow_Rejects_Immutable_Status(string status)
+    {
+        var editor = BuildEditor();
+        var plan = new Plan { Id = Guid.NewGuid(), Slug = "team", Version = 1, Status = status };
+
+        var act = () => editor.EnsureMutableOrThrow(plan);
+
+        act.Should().Throw<TammaError>()
+            .Which.Code.Should().Be("PLAN.VERSION.IMMUTABLE");
+    }
+
+    [Test]
+    public void EnsureMutableOrThrow_Allows_Draft()
+    {
+        var editor = BuildEditor();
+        var plan = new Plan { Id = Guid.NewGuid(), Slug = "team", Version = 2, Status = "draft" };
+
+        var act = () => editor.EnsureMutableOrThrow(plan);
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void EnsureMutableOrThrow_Immutable_Error_Is_High_Severity()
+    {
+        var editor = BuildEditor();
+        var plan = new Plan { Id = Guid.NewGuid(), Slug = "team", Version = 1, Status = "active" };
+
+        var ex = Assert.Throws<TammaError>(() => editor.EnsureMutableOrThrow(plan));
+        ex!.Severity.Should().Be(TammaErrorSeverity.High);
+        ex.Context.Should().ContainKey("slug");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanVersionEditorTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanVersionEditorTests.cs
@@ -1,0 +1,206 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Services.Pricing;
+using Tamma.Api.Tests.TestDoubles;
+using Tamma.Core;
+using Tamma.Core.Enums;
+using Tamma.Data;
+using Tamma.Data.Seeders;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-1 (AC6, AC11, AC13) — <see cref="PlanVersionEditor"/> against a real
+/// Postgres testcontainer. Covers the v1→v2→v3 supersede chain with correct
+/// <c>SupersedesPlanId</c> links, the prior version flipping to
+/// <c>deprecated</c>, the one-active-version invariant being preserved by the
+/// flip+insert transaction, and the <c>PLAN.VERSION.CREATED</c> /
+/// <c>PLAN.DEPRECATED</c> events being emitted with the spec'd tags.
+/// </summary>
+[TestFixture]
+public class PlanVersionEditorTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("plan_editor_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE plan_prices, plan_entitlements, plan_features, plans CASCADE;");
+        await PlansSeeder.SeedAsync(ctx);
+    }
+
+    private ControlPlaneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    [Test]
+    public async Task CreateNewVersion_Supersedes_Prior_And_Deprecates_It()
+    {
+        var publisher = new RecordingPlatformEventPublisher();
+        Guid v1Id;
+
+        await using (var ctx = NewContext())
+        {
+            v1Id = (await ctx.Plans.FirstAsync(p => p.Slug == "team" && p.Status == "active")).Id;
+            var editor = new PlanVersionEditor(
+                ctx, publisher, TimeProvider.System, NullLogger<PlanVersionEditor>.Instance);
+
+            var v2 = await editor.CreateNewVersionAsync(
+                "team",
+                new PlanDraftSpec(DisplayName: "Team v2", MonthlyPriceUsd: 59m),
+                new PlanEditorPrincipal("user-123", "owner@x.io"));
+
+            v2.Version.Should().Be(2);
+            v2.SupersedesPlanId.Should().Be(v1Id);
+            v2.Status.Should().Be("active");
+        }
+
+        await using var verify = NewContext();
+        var v1 = await verify.Plans.FirstAsync(p => p.Id == v1Id);
+        v1.Status.Should().Be("deprecated");
+
+        var active = await verify.Plans.CountAsync(p => p.Slug == "team" && p.Status == "active");
+        active.Should().Be(1, "exactly one active version per slug");
+    }
+
+    [Test]
+    public async Task CreateNewVersion_Emits_Created_And_Deprecated_Events_With_Tags()
+    {
+        var publisher = new RecordingPlatformEventPublisher();
+        Guid v1Id;
+
+        await using (var ctx = NewContext())
+        {
+            v1Id = (await ctx.Plans.FirstAsync(p => p.Slug == "team" && p.Status == "active")).Id;
+            var editor = new PlanVersionEditor(
+                ctx, publisher, TimeProvider.System, NullLogger<PlanVersionEditor>.Instance);
+            await editor.CreateNewVersionAsync(
+                "team", new PlanDraftSpec(), new PlanEditorPrincipal("user-123", "owner@x.io"));
+        }
+
+        publisher.Events.Should().HaveCount(2);
+
+        var created = publisher.Events.Single(e => e.Type == PlanCatalogEventTypes.VersionCreated);
+        var createdTags = ParseTags(created.Tags);
+        createdTags["slug"].Should().Be("team");
+        createdTags["version"].Should().Be("2");
+        createdTags["supersedesPlanId"].Should().Be(v1Id.ToString("D"));
+        createdTags["source"].Should().Be("admin");
+        createdTags["actorUserId"].Should().Be("user-123");
+
+        var deprecated = publisher.Events.Single(e => e.Type == PlanCatalogEventTypes.Deprecated);
+        var depTags = ParseTags(deprecated.Tags);
+        depTags["slug"].Should().Be("team");
+        depTags["version"].Should().Be("1");
+        depTags["planId"].Should().Be(v1Id.ToString("D"));
+        depTags.Should().ContainKey("supersededByPlanId");
+    }
+
+    [Test]
+    public async Task CreateNewVersion_Builds_A_Correct_3_Version_Chain()
+    {
+        var publisher = new RecordingPlatformEventPublisher();
+        var v2Id = Guid.Empty;
+        var v3Id = Guid.Empty;
+        Guid v1Id;
+
+        await using (var ctx = NewContext())
+        {
+            v1Id = (await ctx.Plans.FirstAsync(p => p.Slug == "team" && p.Status == "active")).Id;
+        }
+
+        await using (var ctx = NewContext())
+        {
+            var editor = new PlanVersionEditor(ctx, publisher, TimeProvider.System, NullLogger<PlanVersionEditor>.Instance);
+            v2Id = (await editor.CreateNewVersionAsync("team", new PlanDraftSpec(), new PlanEditorPrincipal("u", null))).Id;
+        }
+
+        await using (var ctx = NewContext())
+        {
+            var editor = new PlanVersionEditor(ctx, publisher, TimeProvider.System, NullLogger<PlanVersionEditor>.Instance);
+            v3Id = (await editor.CreateNewVersionAsync("team", new PlanDraftSpec(), new PlanEditorPrincipal("u", null))).Id;
+        }
+
+        await using var verify = NewContext();
+        var v2 = await verify.Plans.FirstAsync(p => p.Id == v2Id);
+        var v3 = await verify.Plans.FirstAsync(p => p.Id == v3Id);
+
+        v2.Version.Should().Be(2);
+        v2.SupersedesPlanId.Should().Be(v1Id);
+        v3.Version.Should().Be(3);
+        v3.SupersedesPlanId.Should().Be(v2Id);
+        v3.Status.Should().Be("active");
+
+        (await verify.Plans.CountAsync(p => p.Slug == "team")).Should().Be(3);
+        (await verify.Plans.CountAsync(p => p.Slug == "team" && p.Status == "active")).Should().Be(1);
+    }
+
+    [Test]
+    public async Task CreateNewVersion_Copies_Children_When_Draft_Omits_Them()
+    {
+        var publisher = new RecordingPlatformEventPublisher();
+
+        await using (var ctx = NewContext())
+        {
+            var editor = new PlanVersionEditor(ctx, publisher, TimeProvider.System, NullLogger<PlanVersionEditor>.Instance);
+            await editor.CreateNewVersionAsync("team", new PlanDraftSpec(), new PlanEditorPrincipal("u", null));
+        }
+
+        await using var verify = NewContext();
+        var v2 = await verify.Plans
+            .Include(p => p.Features)
+            .Include(p => p.Entitlements)
+            .Include(p => p.Prices)
+            .FirstAsync(p => p.Slug == "team" && p.Status == "active");
+
+        v2.Features.Should().NotBeEmpty("children copy forward when the draft omits them");
+        v2.Entitlements.Should().Contain(e => e.MetricKey == EntitlementMetricKey.LlmTokens);
+        v2.Prices.Select(p => p.PricingMode).Should().BeEquivalentTo(new[] { "platform_provided", "byok" });
+    }
+
+    [Test]
+    public async Task CreateNewVersion_Unknown_Slug_Throws()
+    {
+        var publisher = new RecordingPlatformEventPublisher();
+        await using var ctx = NewContext();
+        var editor = new PlanVersionEditor(ctx, publisher, TimeProvider.System, NullLogger<PlanVersionEditor>.Instance);
+
+        var act = async () => await editor.CreateNewVersionAsync(
+            "ghost", new PlanDraftSpec(), new PlanEditorPrincipal("u", null));
+
+        await act.Should().ThrowAsync<TammaError>()
+            .Where(e => e.Code == "PLAN.VERSION.NO_ACTIVE");
+        publisher.Events.Should().BeEmpty("no event on a failed (no-op) operation");
+    }
+
+    private static Dictionary<string, string?> ParseTags(string json) =>
+        JsonSerializer.Deserialize<Dictionary<string, string?>>(json)!;
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlansSeederStructuredTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlansSeederStructuredTests.cs
@@ -1,0 +1,172 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using Tamma.Core.Enums;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Seeders;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-1 (AC9, AC13) — the extended <see cref="PlansSeeder"/> seeds typed
+/// feature/entitlement/price children for free/team/enterprise with
+/// deterministic UUIDs, insert-missing-only per row, never reverting admin
+/// edits. Uses the EF in-memory provider (the seed is AddRange + per-row
+/// existence checks — the cheap provider catches idempotency + no-revert; the
+/// DB-level CHECK/partial-unique invariants are covered by the Postgres suite).
+/// </summary>
+[TestFixture]
+public class PlansSeederStructuredTests
+{
+    private static ControlPlaneDbContext CreateContext(string dbName) =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseInMemoryDatabase(dbName)
+            .Options);
+
+    [Test]
+    public async Task SeedAsync_Inserts_Structured_Children_For_All_Three_Slugs()
+    {
+        var dbName = nameof(SeedAsync_Inserts_Structured_Children_For_All_Three_Slugs);
+        await using var ctx = CreateContext(dbName);
+
+        await PlansSeeder.SeedAsync(ctx);
+
+        var plans = await ctx.Plans.AsNoTracking().ToListAsync();
+        plans.Should().HaveCount(3);
+        plans.Should().OnlyContain(p => p.Version == 1 && p.Status == "active",
+            "seeded v1 rows are the active version");
+
+        // Each slug gets features, entitlements, and both pricing-mode rows.
+        foreach (var planId in new[] { PlansSeeder.FreePlanId, PlansSeeder.TeamPlanId, PlansSeeder.EnterprisePlanId })
+        {
+            (await ctx.PlanFeatures.AsNoTracking().CountAsync(f => f.PlanId == planId))
+                .Should().BeGreaterThan(0);
+            (await ctx.PlanEntitlements.AsNoTracking().CountAsync(e => e.PlanId == planId))
+                .Should().BeGreaterThan(0);
+
+            var modes = await ctx.PlanPrices.AsNoTracking()
+                .Where(p => p.PlanId == planId)
+                .Select(p => p.PricingMode)
+                .ToListAsync();
+            modes.Should().BeEquivalentTo(new[] { "platform_provided", "byok" },
+                "every plan version stores a distinct price row per pricing mode");
+        }
+    }
+
+    [Test]
+    public async Task SeedAsync_MetricKeys_RoundTrip_Through_Converter()
+    {
+        var dbName = nameof(SeedAsync_MetricKeys_RoundTrip_Through_Converter);
+        await using var ctx = CreateContext(dbName);
+
+        await PlansSeeder.SeedAsync(ctx);
+
+        var ents = await ctx.PlanEntitlements.AsNoTracking()
+            .Where(e => e.PlanId == PlansSeeder.EnterprisePlanId)
+            .ToListAsync();
+
+        ents.Select(e => e.MetricKey).Should().Contain(EntitlementMetricKey.LlmTokens);
+        // Enterprise stores unlimited (NULL) seat/agent/repo limits.
+        ents.Should().Contain(e => e.MetricKey == EntitlementMetricKey.Seats && e.LimitValue == null);
+    }
+
+    [Test]
+    public async Task SeedAsync_SecondRun_Is_NoOp()
+    {
+        var dbName = nameof(SeedAsync_SecondRun_Is_NoOp);
+
+        await using (var first = CreateContext(dbName))
+        {
+            await PlansSeeder.SeedAsync(first);
+        }
+
+        int featuresAfterFirst, entitlementsAfterFirst, pricesAfterFirst;
+        await using (var read = CreateContext(dbName))
+        {
+            featuresAfterFirst = await read.PlanFeatures.CountAsync();
+            entitlementsAfterFirst = await read.PlanEntitlements.CountAsync();
+            pricesAfterFirst = await read.PlanPrices.CountAsync();
+        }
+
+        await using (var second = CreateContext(dbName))
+        {
+            await PlansSeeder.SeedAsync(second);
+        }
+
+        await using var verify = CreateContext(dbName);
+        (await verify.Plans.CountAsync()).Should().Be(3, "no duplicate plan rows");
+        (await verify.PlanFeatures.CountAsync()).Should().Be(featuresAfterFirst);
+        (await verify.PlanEntitlements.CountAsync()).Should().Be(entitlementsAfterFirst);
+        (await verify.PlanPrices.CountAsync()).Should().Be(pricesAfterFirst);
+    }
+
+    [Test]
+    public async Task SeedAsync_Does_Not_Revert_An_Edited_Row()
+    {
+        var dbName = nameof(SeedAsync_Does_Not_Revert_An_Edited_Row);
+
+        await using (var first = CreateContext(dbName))
+        {
+            await PlansSeeder.SeedAsync(first);
+        }
+
+        // Admin edits the free plan's display name (a v2 draft would normally
+        // do this; here we mutate the seeded row directly to model an admin
+        // edit the seeder must NOT clobber).
+        await using (var edit = CreateContext(dbName))
+        {
+            var free = await edit.Plans.FirstAsync(p => p.Id == PlansSeeder.FreePlanId);
+            free.DisplayName = "Free (admin-renamed)";
+            await edit.SaveChangesAsync();
+        }
+
+        await using (var reseed = CreateContext(dbName))
+        {
+            await PlansSeeder.SeedAsync(reseed);
+        }
+
+        await using var verify = CreateContext(dbName);
+        var reloaded = await verify.Plans.AsNoTracking()
+            .FirstAsync(p => p.Id == PlansSeeder.FreePlanId);
+        reloaded.DisplayName.Should().Be("Free (admin-renamed)",
+            "insert-missing-only seeder must never revert an admin-edited row");
+    }
+
+    [Test]
+    public async Task SeedAsync_Backfills_Children_Onto_A_BarePlanRow()
+    {
+        // Models a DB that already had the Story 28-1 bare v1 plan rows but no
+        // structured children — the seeder must backfill children without
+        // duplicating the plan.
+        var dbName = nameof(SeedAsync_Backfills_Children_Onto_A_BarePlanRow);
+
+        await using (var bare = CreateContext(dbName))
+        {
+            bare.Plans.Add(new Plan
+            {
+                Id = PlansSeeder.FreePlanId,
+                Slug = "free",
+                DisplayName = "Free",
+                Version = 1,
+                Status = "active",
+                MonthlyPriceUsd = 0m,
+                PlacementPolicy = "shared",
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+            });
+            await bare.SaveChangesAsync();
+        }
+
+        await using (var seed = CreateContext(dbName))
+        {
+            await PlansSeeder.SeedAsync(seed);
+        }
+
+        await using var verify = CreateContext(dbName);
+        (await verify.Plans.CountAsync(p => p.Id == PlansSeeder.FreePlanId)).Should().Be(1,
+            "no duplicate plan row");
+        (await verify.PlanFeatures.CountAsync(f => f.PlanId == PlansSeeder.FreePlanId))
+            .Should().BeGreaterThan(0, "children backfilled onto the pre-existing bare plan row");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlansSeederStructuredTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlansSeederStructuredTests.cs
@@ -111,14 +111,24 @@ public class PlansSeederStructuredTests
             await PlansSeeder.SeedAsync(first);
         }
 
-        // Admin edits the free plan's display name (a v2 draft would normally
-        // do this; here we mutate the seeded row directly to model an admin
-        // edit the seeder must NOT clobber).
+        // An admin "edits" the free plan — under the Story 34-1 immutability
+        // invariant that is a NEW VERSION (the active row can't be mutated in
+        // place; the SaveChanges interceptor enforces it), so the rename lands
+        // on a renamed v2 while v1 flips to deprecated. The seeder must NOT
+        // clobber either: its insert-missing-only check keys off the seed's
+        // stable FreePlanId, which now points at the deprecated v1.
         await using (var edit = CreateContext(dbName))
         {
-            var free = await edit.Plans.FirstAsync(p => p.Id == PlansSeeder.FreePlanId);
-            free.DisplayName = "Free (admin-renamed)";
-            await edit.SaveChangesAsync();
+            var editor = new Tamma.Api.Services.Pricing.PlanVersionEditor(
+                edit,
+                new Tamma.Api.Tests.TestDoubles.RecordingPlatformEventPublisher(),
+                TimeProvider.System,
+                Microsoft.Extensions.Logging.Abstractions.NullLogger<
+                    Tamma.Api.Services.Pricing.PlanVersionEditor>.Instance);
+            await editor.CreateNewVersionAsync(
+                "free",
+                new Tamma.Api.Services.Pricing.PlanDraftSpec(DisplayName: "Free (admin-renamed)"),
+                new Tamma.Api.Services.Pricing.PlanEditorPrincipal("admin", null));
         }
 
         await using (var reseed = CreateContext(dbName))
@@ -127,10 +137,20 @@ public class PlansSeederStructuredTests
         }
 
         await using var verify = CreateContext(dbName);
-        var reloaded = await verify.Plans.AsNoTracking()
-            .FirstAsync(p => p.Id == PlansSeeder.FreePlanId);
-        reloaded.DisplayName.Should().Be("Free (admin-renamed)",
-            "insert-missing-only seeder must never revert an admin-edited row");
+
+        // v1 (the seed's stable id) is untouched — still deprecated, still its
+        // original seeded "Free" name; the seeder never reverted/duplicated it.
+        var v1 = await verify.Plans.AsNoTracking().FirstAsync(p => p.Id == PlansSeeder.FreePlanId);
+        v1.Status.Should().Be("deprecated");
+        v1.DisplayName.Should().Be("Free", "the seeder must not revert the deprecated v1");
+
+        // The active v2 carries the admin rename and the seeder left it alone.
+        var activeFree = await verify.Plans.AsNoTracking()
+            .FirstAsync(p => p.Slug == "free" && p.Status == "active");
+        activeFree.DisplayName.Should().Be("Free (admin-renamed)",
+            "insert-missing-only seeder must never revert an admin's new active version");
+        (await verify.Plans.AsNoTracking().CountAsync(p => p.Slug == "free"))
+            .Should().Be(2, "exactly v1 (deprecated) + v2 (active); the re-seed added nothing");
     }
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Tenancy/TenantMoveServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Tenancy/TenantMoveServiceTests.cs
@@ -358,6 +358,57 @@ public class TenantMoveServiceTests
     }
 
     [Test]
+    public async Task Move_MultiVersionSlug_ResolvesActiveVersionsPlacementPolicy()
+    {
+        // Story 34-1 regression — tier-eligibility for a move must key off the
+        // ACTIVE plan version, not a deprecated one picked in undefined order.
+        // Setup: deprecate the seeded free v1 (stale PlacementPolicy='shared')
+        // and add an active free v2 with PlacementPolicy='dedicated'; make the
+        // target row dedicated-eligible. If the lookup resolved the deprecated
+        // v1 ('shared') the move would bounce off the eligibility check against
+        // the dedicated target; resolving the active v2 ('dedicated') lets it
+        // proceed. A completed move proves v2 was used.
+        var tenantId = await SeedAsync();
+
+        await using (var cp = await _factory.CreateDbContextAsync())
+        {
+            // Flip seeded free v1 → deprecated (the controlled flip the
+            // immutability interceptor allows). The seeded free plan already
+            // carries the STALE policy ('shared'), so the flip is Status-only.
+            var v1 = await cp.Plans.FirstAsync(p => p.Slug == "free" && p.Status == "active");
+            v1.PlacementPolicy.Should().Be("shared", "seeded free plan is the stale 'shared' policy");
+            v1.Status = "deprecated";
+            v1.UpdatedAt = DateTime.UtcNow;
+
+            // Add an active v2 carrying the LIVE policy.
+            cp.Plans.Add(new Plan
+            {
+                Id = Guid.NewGuid(), Slug = "free", DisplayName = "Free v2",
+                Version = v1.Version + 1, Status = "active", BillingInterval = "monthly",
+                MonthlyPriceUsd = 0m, PlacementPolicy = "dedicated",
+                SupersedesPlanId = v1.Id,
+                CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow,
+            });
+
+            // Make the target a dedicated, empty, dedicated-eligible row.
+            var target = await cp.TenantDatabases.SingleAsync(d => d.Id == TargetDbId);
+            target.PlacementClass = "dedicated";
+            target.TierEligibility = ["free", "team", "enterprise"];
+            target.TenantCount = 0;
+            await cp.SaveChangesAsync();
+        }
+
+        var act = async () => await CreateService().MoveAsync(tenantId, TargetDbId);
+        await act.Should().NotThrowAsync(
+            "the move must resolve the ACTIVE free v2 (PlacementPolicy='dedicated') and "
+            + "accept the dedicated target — not bounce off the deprecated v1 ('shared')");
+
+        var (status, databaseId, _) = await ReadTenantAsync(tenantId);
+        status.Should().Be("active");
+        databaseId.Should().Be(TargetDbId, "the move completed onto the dedicated target");
+    }
+
+    [Test]
     public async Task Move_Rejects_TargetNotActive()
     {
         var tenantId = await SeedAsync(targetStatus: "retired");

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Tenancy/TenantPlacementServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Tenancy/TenantPlacementServiceTests.cs
@@ -222,6 +222,66 @@ public class TenantPlacementServiceTests
     }
 
     [Test]
+    public async Task Assign_MultiVersionSlug_ResolvesActiveVersionsPlacementPolicy()
+    {
+        // Story 34-1 regression — a slug is now a version chain (a deprecated
+        // v1 + an active v2). The placement lookup must pin Status=="active":
+        // the live v2 says PlacementPolicy="shared", while the deprecated v1
+        // (stale) says "dedicated". With only a SHARED pool row available,
+        // placement succeeds ONLY if the lookup resolves v2's policy. Before
+        // the fix the slug lookup had no Status filter and could pick v1,
+        // failing placement against the shared row.
+        var dbName = nameof(Assign_MultiVersionSlug_ResolvesActiveVersionsPlacementPolicy);
+        var tenantId = Guid.NewGuid();
+
+        await using (var seed = CreateContext(dbName))
+        {
+            await PlansSeeder.SeedAsync(seed);
+
+            var v1Id = Guid.NewGuid();
+            var v2Id = Guid.NewGuid();
+            var now = DateTime.UtcNow;
+            // v1 (deprecated) carries the STALE policy.
+            seed.Plans.Add(new Plan
+            {
+                Id = v1Id, Slug = "versioned", DisplayName = "Versioned v1",
+                Version = 1, Status = "deprecated", BillingInterval = "monthly",
+                MonthlyPriceUsd = 10m, PlacementPolicy = "dedicated",
+                CreatedAt = now, UpdatedAt = now,
+            });
+            // v2 (active) carries the LIVE policy — the one placement must use.
+            seed.Plans.Add(new Plan
+            {
+                Id = v2Id, Slug = "versioned", DisplayName = "Versioned v2",
+                Version = 2, Status = "active", BillingInterval = "monthly",
+                MonthlyPriceUsd = 20m, PlacementPolicy = "shared",
+                SupersedesPlanId = v1Id, CreatedAt = now, UpdatedAt = now,
+            });
+
+            seed.Tenants.Add(new Tenant
+            {
+                Id = tenantId,
+                Name = "Versioned Plan Tenant",
+                Slug = $"versioned-{tenantId:N}"[..20],
+                Plan = "versioned",
+                CreatedAt = now,
+                UpdatedAt = now,
+            });
+            await seed.SaveChangesAsync();
+        }
+
+        var sharedRow = PoolRow("shared-central", placementClass: "shared",
+            tiers: ["versioned", "free", "team", "enterprise"]);
+        await AddPoolRowsAsync(dbName, sharedRow);
+
+        var placement = await CreateService(dbName).AssignAsync(tenantId);
+
+        placement.DatabaseId.Should().Be(sharedRow.Id,
+            "placement must resolve the ACTIVE v2 (PlacementPolicy='shared') and land on "
+            + "the shared pool row — not the deprecated v1 ('dedicated')");
+    }
+
+    [Test]
     public async Task Assign_CorruptState_OnePropSet_ReStamps()
     {
         var dbName = nameof(Assign_CorruptState_OnePropSet_ReStamps);

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Enums/CostBasisTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Enums/CostBasisTests.cs
@@ -1,0 +1,42 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core.Enums;
+
+namespace Tamma.Core.Tests.Enums;
+
+/// <summary>
+/// Story 36-1 (AC3) — pins the two-member shape of <see cref="CostBasis"/>
+/// and the lowercase <c>byok</c>/<c>platform</c> text form the analytics EF
+/// model persists (via <c>HasConversion</c>). The persisted string is the
+/// stable wire/DB discriminator shared by every Epic 36 dimension query — a
+/// guard against ordinal drift and against adding a member without a
+/// matching lowercase persistence form.
+/// </summary>
+[TestFixture]
+public class CostBasisTests
+{
+    [Test]
+    public void Has_Exactly_TwoMembers_Byok_And_Platform()
+    {
+        Enum.GetNames<CostBasis>().Should().BeEquivalentTo(new[] { "Byok", "Platform" });
+    }
+
+    [TestCase(CostBasis.Byok, 0)]
+    [TestCase(CostBasis.Platform, 1)]
+    public void Members_Pin_Their_Ordinals(CostBasis value, int ordinal)
+    {
+        ((int)value).Should().Be(ordinal,
+            "the ordinal is part of the persisted contract — drift would silently "
+            + "re-map historical analytics rows");
+    }
+
+    [TestCase(CostBasis.Byok, "byok")]
+    [TestCase(CostBasis.Platform, "platform")]
+    public void LowercaseName_Matches_PersistedTextForm(CostBasis value, string expected)
+    {
+        // The analytics model config persists CostBasis as lowercase text
+        // (HasConversion). This pins the expectation the config enforces so
+        // ad-hoc SQL and InMemory/Npgsql parity stay readable.
+        Enum.GetName(value)!.ToLowerInvariant().Should().Be(expected);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Enums/EntitlementMetricKeyTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Enums/EntitlementMetricKeyTests.cs
@@ -1,0 +1,69 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core;
+using Tamma.Core.Enums;
+
+namespace Tamma.Core.Tests.Enums;
+
+/// <summary>
+/// Story 34-1 (AC5) — pins the snake_case contract for
+/// <see cref="EntitlementMetricKey"/>. The persisted string is the stable
+/// wire/DB form shared by entitlement, pricing, metering, and enforcement —
+/// these tests guard against ordinal drift and against adding an enum member
+/// without a matching mapping.
+/// </summary>
+[TestFixture]
+public class EntitlementMetricKeyTests
+{
+    [TestCase(EntitlementMetricKey.Agents, "agents")]
+    [TestCase(EntitlementMetricKey.WorkflowRuns, "workflow_runs")]
+    [TestCase(EntitlementMetricKey.LlmTokens, "llm_tokens")]
+    [TestCase(EntitlementMetricKey.Seats, "seats")]
+    [TestCase(EntitlementMetricKey.Repos, "repos")]
+    [TestCase(EntitlementMetricKey.RagStorageMb, "rag_storage_mb")]
+    [TestCase(EntitlementMetricKey.BenchmarkRetentionDays, "benchmark_retention_days")]
+    public void ToMetricString_Pins_SnakeCase(EntitlementMetricKey key, string expected)
+    {
+        key.ToMetricString().Should().Be(expected);
+    }
+
+    [Test]
+    public void EveryMember_RoundTrips_Through_String()
+    {
+        foreach (EntitlementMetricKey key in Enum.GetValues<EntitlementMetricKey>())
+        {
+            var s = key.ToMetricString();
+            EntitlementMetricKeyExtensions.Parse(s).Should().Be(key,
+                "every member must round-trip through ToMetricString/Parse");
+        }
+    }
+
+    [Test]
+    public void Parse_Unknown_Throws_TammaError()
+    {
+        var act = () => EntitlementMetricKeyExtensions.Parse("not_a_metric");
+        act.Should().Throw<TammaError>()
+            .Which.Code.Should().Be("PLAN.METRIC_KEY.UNKNOWN");
+    }
+
+    [Test]
+    public void Parse_Null_Throws()
+    {
+        var act = () => EntitlementMetricKeyExtensions.Parse(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void SnakeCaseMap_Has_Exactly_OneEntry_Per_Member_NoDuplicates()
+    {
+        // Guards against adding an enum member without a mapping (or two
+        // members mapping to the same string).
+        var memberCount = Enum.GetValues<EntitlementMetricKey>().Length;
+        var strings = EntitlementMetricKeyExtensions.AllMetricStrings;
+
+        memberCount.Should().Be(7, "the closed enum has exactly 7 members");
+        strings.Should().HaveCount(memberCount,
+            "every member maps to exactly one distinct snake_case string");
+        strings.Distinct().Should().HaveCount(memberCount, "no duplicate mappings");
+    }
+}

--- a/docs/sprint-status.yaml
+++ b/docs/sprint-status.yaml
@@ -461,7 +461,7 @@ development_status:
   epic-35-retrospective: optional
 
   epic-36: contexted   # NEW Analytics & Reporting Platform (added 2026-06-17; all stories drafted)
-  36-1-dimensional-analytics-projection-schema-and-store: drafted # Dimensional Analytics Projection Schema & Store [P0]
+  36-1-dimensional-analytics-projection-schema-and-store: done # Dimensional Analytics Projection Schema & Store [P0]
   36-2-dcb-to-analytics-projection-pipeline: drafted  # DCB-to-Analytics Projection Pipeline (Dimensional Rollup) [P0]
   36-3-tenant-usage-analytics-api: drafted            # Tenant Usage Analytics API [P0]
   36-4-cost-and-spend-analytics-api: drafted          # Cost & Spend Analytics API (BYOK vs Platform) [P0]

--- a/docs/sprint-status.yaml
+++ b/docs/sprint-status.yaml
@@ -416,7 +416,7 @@ development_status:
 
 
   epic-32: contexted   # NEW Agents — entities, managed execution, benchmarking & learning (added 2026-06-17; all stories drafted)
-  32-1-agent-entity-model-and-versioned-saved-config: drafted # Agent Entity Model & Versioned Saved Config (public/private) [P0]
+  32-1-agent-entity-model-and-versioned-saved-config: done # Agent Entity Model & Versioned Saved Config (public/private) [P0]
   32-2-agent-registry-resolution-and-rbac-api: drafted # Agent Registry, Resolution & RBAC API [P0]
   32-3-per-tenant-provider-credential-resolution: drafted # Per-Tenant Provider Credential Resolution (BYOK → platform) [P0]
   32-4-saas-provider-auth-gating-api-key-only: drafted # SaaS Provider Auth Gating — API-key only (CLI/token providers single-user only) [P0]
@@ -433,7 +433,7 @@ development_status:
   epic-32-retrospective: optional
 
   epic-34: contexted   # NEW Pricing, Plans & Entitlements (added 2026-06-17; all stories drafted)
-  34-1-plan-and-price-book-catalog-data-model: drafted # Plan & Price-Book Catalog Data Model [P0]
+  34-1-plan-and-price-book-catalog-data-model: done # Plan & Price-Book Catalog Data Model [P0]
   34-2-plan-catalog-admin-api-and-custom-enterprise-plans: drafted # Plan Catalog Admin API & Custom Enterprise Plans [P0]
   34-3-byok-vs-platform-provided-pricing-mode: drafted # BYOK vs Platform-Provided Pricing Mode (per-provider, secret-cabinet wired) [P0]
   34-4-per-tenant-plan-assignment-and-lifecycle: drafted # Per-Tenant Plan Assignment & Lifecycle [P0]
@@ -446,7 +446,7 @@ development_status:
   epic-34-retrospective: optional
 
   epic-35: contexted   # NEW Billing & Payments (C#) — supersedes Epic 20 (added 2026-06-17; all stories drafted)
-  35-1-stripe-integration-foundation-billing-plan-catalog-and-custo: drafted # Stripe Integration Foundation, Billing Plan Catalog & Customer Mapping (C#) [P0]
+  35-1-stripe-integration-foundation-billing-plan-catalog-and-custo: done # Stripe Integration Foundation, Billing Plan Catalog & Customer Mapping (C#) [P0]
   35-2-byok-vs-platform-provided-billing-mode-and-per-tenant-provid: drafted # BYOK vs Platform-Provided Billing Mode & Per-Tenant Provider Key Cabinet Integration [P0]
   35-3-byok-aware-usage-metering-and-stripe-meter-event-reporting: drafted # BYOK-Aware Usage Metering & Stripe Meter Event Reporting [P0]
   35-4-subscription-lifecycle-create-upgrade-downgrade-cancel-trial: drafted # Subscription Lifecycle — Create, Upgrade/Downgrade, Cancel, Trial & Proration [P0]
@@ -475,7 +475,7 @@ development_status:
   epic-36-retrospective: optional
 
   epic-37: contexted   # NEW Audit, Compliance & Data Governance (added 2026-06-17; all stories drafted)
-  37-1-sensitive-action-audit-taxonomy-and-curated-audit-record-pro: drafted # Sensitive-Action Audit Taxonomy & Curated Audit-Record Projection [P0]
+  37-1-sensitive-action-audit-taxonomy-and-curated-audit-record-pro: done # Sensitive-Action Audit Taxonomy & Curated Audit-Record Projection [P0]
   37-2-tamper-evident-hash-chain-over-audit-records: drafted # Tamper-Evident Hash-Chain over Audit Records [P0]
   37-3-audit-query-search-and-filter-api: drafted     # Audit Query, Search & Filter API [P0]
   37-4-signed-audit-export-with-integrity-manifest: drafted # Signed Audit Export (JSON/CSV) with Integrity Manifest [P1]


### PR DESCRIPTION
## Wave 1 — Foundation (Epics 32/34/35/36/37 execution pathway)

First wave of the [parallel multi-agent execution pathway](docs/superpowers/plans/2026-06-18-epics-32-37-execution-pathway.md). The 5 P0 foundation stories everything else in these epics joins on. Implemented **sequentially** (not in parallel) because all 5 share the EF migration chains (4 ControlPlane, 2 Tenant) + `TammaModelConfiguration` + `Program.cs` — parallel agents would corrupt the migration graph.

Each story: TDD implement → independent **spec-compliance** review → independent **code-quality** review → fix loop → (for Critical fixes) re-review.

### Stories
| Story | What | Notes |
|---|---|---|
| **32-1** | Agent entity model & versioned saved config (public/private, CP-resident) | + 3 minor review fixes (audit mode tag, ReDoS test, seeder key) |
| **34-1** | Plan & price-book catalog data model (immutable versioned, entitlements, pricing-mode rows) | Code-quality caught: platform-RBAC leak (`OwnerAccess`→`PlatformOwnerAccess`), 3 broken slug lookups, AC6 immutability guard had no production callers → added a `SaveChanges` interceptor, EF filtered-index ordering fragility |
| **35-1** | Stripe foundation, billing catalog & customer mapping (Stripe.net 51.2.0) | Caught + fixed a silent-failure `catch(Exception)` on the tenant-create hook (cancellation/defects laundered as "Stripe retry") |
| **36-1** | Dimensional analytics projection schema & store (per-tenant, hourly+daily) | Schema-only; `CostBasis` lowercase-text converter |
| **37-1** | Sensitive-action audit taxonomy & curated audit-record projection | Code-quality caught two **Critical** defects: per-tenant cursor data-loss (shared global cursor across independent per-schema BIGSERIALs) + cursor advancing past a failed redaction (silent un-audited action) → per-tenant cursor + quarantine-on-failure |

### Cross-story ownership boundaries (held)
32-3 owns BYOK key wiring · 34-3 pricing mode · 34-5 markup engine · 32-4 SaaS gating · 35-5 webhook ingestion · 36-2 projection pipeline · 37-2 hash-chain — none implemented here (each story stays in its lane; verified by spec review).

### Verify gate
- `dotnet build Tamma.sln` → 0 errors
- Full suite (`sg docker -c "dotnet test Tamma.sln"`) → **exit 0, 0 failures** (Tamma.Api.Tests: 3144 passed / 6 skipped; ~4880 across all 10 projects)
- `has-pending-model-changes` → clean for **both** `ControlPlaneDbContext` and `TenantDbContext`

### Deploy
Docs/code merge to main does **not** auto-deploy (qa-tag gate). Cut a `qa-*` tag to ship this wave to the VPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)