### PR TITLE
feat(exec): Wave 2 (partial) — 32-2 agent registry + 32-3 BYOK resolution + Epic-32 architecture revision

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/CallLlmInlineActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/CallLlmInlineActivity.cs
@@ -8,10 +8,12 @@ using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Tamma.Activities.LlmCall.Credentials;
 using Tamma.Activities.LlmCall.Models;
 using Tamma.Activities.LlmCall.Tools;
 using Tamma.Activities.Security;
 using Tamma.Activities.ToolExecution;
+using Tamma.Core;
 
 namespace Tamma.Activities.LlmCall;
 
@@ -53,6 +55,15 @@ public class CallLlmInlineActivity : CodeActivity
     [Input(Description = "Tool loop configuration JSON (serialized ToolLoopConfig)")]
     public Input<string?> ToolLoopConfigJsonProp { get; set; } = default!;
 
+    /// <summary>
+    /// Story 32-3 (AC3) — tenant id (GUID string) for BYOK credential
+    /// resolution. Threaded from <c>LlmCallWorkflow</c>'s existing
+    /// <c>TenantId</c> variable. Empty / whitespace ⇒ single-user / platform
+    /// scope (<c>tenantId == null</c>).
+    /// </summary>
+    [Input(Description = "Tenant id (GUID string) for BYOK credential resolution; empty = single-user/platform")]
+    public Input<string?> TenantIdProp { get; set; } = new((string?)null);
+
     private readonly IHttpClientFactory? _httpClientFactory;
     private readonly IConfiguration? _configuration;
     private readonly ILogger<CallLlmInlineActivity>? _logger;
@@ -62,9 +73,10 @@ public class CallLlmInlineActivity : CodeActivity
     private readonly ContextCompactor? _contextCompactor;
     private readonly ToolLoopEventEmitter? _eventEmitter;
     private readonly ParallelToolExecutor? _parallelExecutor;
+    private readonly IProviderCredentialResolver? _credentialResolver;
 
     [JsonConstructor]
-    public CallLlmInlineActivity() : this(null, null, null, null, null, null, null, null, null)
+    public CallLlmInlineActivity() : this(null, null, null, null, null, null, null, null, null, null)
     {
     }
 
@@ -77,7 +89,8 @@ public class CallLlmInlineActivity : CodeActivity
         IToolCallValidator? toolCallValidator = null,
         ContextCompactor? contextCompactor = null,
         ToolLoopEventEmitter? eventEmitter = null,
-        ParallelToolExecutor? parallelExecutor = null)
+        ParallelToolExecutor? parallelExecutor = null,
+        IProviderCredentialResolver? credentialResolver = null)
     {
         _logger = logger;
         _httpClientFactory = httpClientFactory;
@@ -88,6 +101,7 @@ public class CallLlmInlineActivity : CodeActivity
         _contextCompactor = contextCompactor;
         _eventEmitter = eventEmitter;
         _parallelExecutor = parallelExecutor;
+        _credentialResolver = credentialResolver;
     }
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
@@ -102,6 +116,9 @@ public class CallLlmInlineActivity : CodeActivity
 
         var input = ParseInput(inputJson);
 
+        // Story 32-3 (AC3) — tenant context for BYOK credential resolution.
+        var tenantId = ParseTenantId(TenantIdProp.Get(context));
+
         // Sanitize prompts before LLM call (defense-in-depth against prompt injection)
         var systemPrompt = SanitizePrompts(context, providerName, systemPromptRaw, input);
 
@@ -112,7 +129,7 @@ public class CallLlmInlineActivity : CodeActivity
             var model = input.ModelOverrides.TryGetValue(providerName, out var mo)
                 ? mo
                 : GetDefaultModel(providerName);
-            await SingleTurnCall(context, input, providerName, systemPrompt, toolsJson, attemptNumber, model);
+            await SingleTurnCall(context, input, providerName, systemPrompt, toolsJson, attemptNumber, model, tenantId);
             return;
         }
 
@@ -120,7 +137,6 @@ public class CallLlmInlineActivity : CodeActivity
         var loopModel = input.ModelOverrides.TryGetValue(providerName, out var mo2)
             ? mo2
             : GetDefaultModel(providerName);
-        var providerConfig = LoadProviderConfig(providerName);
         var loopConfig = ParseToolLoopConfig(toolLoopConfigJson);
         var tools = DeserializeResolvedTools(toolsJson);
 
@@ -144,8 +160,20 @@ public class CallLlmInlineActivity : CodeActivity
             context.WorkflowExecutionContext.Id, providerName, loopModel, loopConfig.MaxSteps,
             loopConfig.AllowedTools?.Length ?? 0);
 
+        // Story 32-3 — resolved BYOK/platform source for the diagnostic tag.
+        // Set inside the try (after resolution) so a fail-closed credential
+        // error surfaces as a failed diagnostic, never a leaked exception.
+        string? credentialSource = null;
+
         try
         {
+            // Resolve provider config + the API key (BYOK→platform) just before
+            // the call. A PROVIDER_CREDENTIAL_UNAVAILABLE TammaError thrown here
+            // is caught below as a failed attempt so the provider chain advances.
+            var (providerConfig, source) =
+                await LoadProviderConfigWithKeyAsync(providerName, tenantId, context.CancellationToken);
+            credentialSource = source;
+
             var (response, totalTokens, turns, exhausted) = await AgenticToolLoop(
                 context, providerName, providerConfig, loopModel, systemPrompt,
                 input.UserPrompt, input.MaxTokens, input.Temperature, tools, loopConfig);
@@ -170,7 +198,8 @@ public class CallLlmInlineActivity : CodeActivity
                 DurationMs = sw.ElapsedMilliseconds,
                 StartedAtUtc = startedAt,
                 PromptTokens = response.PromptTokens,
-                CompletionTokens = response.CompletionTokens
+                CompletionTokens = response.CompletionTokens,
+                CredentialSource = credentialSource
             };
 
             context.SetVariable("LastDiagnostic", JsonSerializer.Serialize(diagnostic));
@@ -186,6 +215,7 @@ public class CallLlmInlineActivity : CodeActivity
         catch (Exception ex)
         {
             sw.Stop();
+            // NOTE: never log ex with a key — TammaError messages are key-free.
             _logger?.LogError(ex, "Agentic tool loop failed for {Provider}", providerName);
 
             var diagnostic = new ProviderAttemptDiagnostic
@@ -194,9 +224,12 @@ public class CallLlmInlineActivity : CodeActivity
                 Model = loopModel,
                 AttemptNumber = attemptNumber,
                 Succeeded = false,
-                ErrorMessage = $"Tool loop error: {ex.Message}",
+                ErrorMessage = ex is TammaError te
+                    ? $"{te.Code}: {te.Message}"
+                    : $"Tool loop error: {ex.Message}",
                 DurationMs = sw.ElapsedMilliseconds,
-                StartedAtUtc = startedAt
+                StartedAtUtc = startedAt,
+                CredentialSource = credentialSource
             };
 
             context.SetVariable("LastDiagnostic", JsonSerializer.Serialize(diagnostic));
@@ -273,10 +306,12 @@ public class CallLlmInlineActivity : CodeActivity
         string systemPrompt,
         string? toolsJson,
         int attemptNumber,
-        string model)
+        string model,
+        Guid? tenantId)
     {
         var startedAt = DateTime.UtcNow;
         var sw = System.Diagnostics.Stopwatch.StartNew();
+        string? credentialSource = null;
 
         // Apply exponential backoff delay for retry attempts (skip first attempt)
         if (attemptNumber > 1)
@@ -295,7 +330,12 @@ public class CallLlmInlineActivity : CodeActivity
             var httpClient = _httpClientFactory?.CreateClient($"llm-{providerName}")
                              ?? new HttpClient();
 
-            var providerConfig = LoadProviderConfig(providerName);
+            // Resolve provider config + the API key (BYOK→platform) just before
+            // the call. A PROVIDER_CREDENTIAL_UNAVAILABLE TammaError thrown here
+            // is caught below as a failed attempt so the provider chain advances.
+            var (providerConfig, source) =
+                await LoadProviderConfigWithKeyAsync(providerName, tenantId, context.CancellationToken);
+            credentialSource = source;
             httpClient.Timeout = TimeSpan.FromSeconds(providerConfig.TimeoutSeconds);
 
             NormalizedLlmResponse response;
@@ -353,7 +393,8 @@ public class CallLlmInlineActivity : CodeActivity
                 DurationMs = sw.ElapsedMilliseconds,
                 StartedAtUtc = startedAt,
                 PromptTokens = response.PromptTokens,
-                CompletionTokens = response.CompletionTokens
+                CompletionTokens = response.CompletionTokens,
+                CredentialSource = credentialSource
             };
 
             context.SetVariable("LastDiagnostic", JsonSerializer.Serialize(diagnostic));
@@ -370,11 +411,16 @@ public class CallLlmInlineActivity : CodeActivity
                 AttemptNumber = attemptNumber,
                 Succeeded = false,
                 HttpStatusCode = 0,
+                // TammaError messages (incl. PROVIDER_CREDENTIAL_UNAVAILABLE) are
+                // key-free by construction — safe to surface here.
                 ErrorMessage = ex is TaskCanceledException
                     ? "Request timed out"
-                    : $"Error: {ex.Message}",
+                    : ex is TammaError te
+                        ? $"{te.Code}: {te.Message}"
+                        : $"Error: {ex.Message}",
                 DurationMs = sw.ElapsedMilliseconds,
-                StartedAtUtc = startedAt
+                StartedAtUtc = startedAt,
+                CredentialSource = credentialSource
             };
 
             context.SetVariable("LastDiagnostic", JsonSerializer.Serialize(diagnostic));
@@ -1260,7 +1306,7 @@ public class CallLlmInlineActivity : CodeActivity
     // Single-Turn LLM Call Methods (preserved from original)
     // =======================================================================
 
-    private async Task<NormalizedLlmResponse> CallAnthropicMessages(
+    internal async Task<NormalizedLlmResponse> CallAnthropicMessages(
         HttpClient httpClient, LlmProviderConfig config, string model,
         string systemPrompt, string userPrompt, int maxTokens, double temperature,
         string? toolsJson)
@@ -1321,7 +1367,7 @@ public class CallLlmInlineActivity : CodeActivity
         return ParseAnthropicResponse(result, statusCode, model);
     }
 
-    private async Task<NormalizedLlmResponse> CallOpenAiCompatible(
+    internal async Task<NormalizedLlmResponse> CallOpenAiCompatible(
         HttpClient httpClient, LlmProviderConfig config, string model,
         string systemPrompt, string userPrompt, int maxTokens, double temperature,
         string? toolsJson)
@@ -1395,6 +1441,13 @@ public class CallLlmInlineActivity : CodeActivity
     // Helpers
     // =======================================================================
 
+    /// <summary>
+    /// Load the provider's NON-secret config (BaseUrl / DefaultModel /
+    /// TimeoutSeconds). Story 32-3 (AC3): this NO LONGER reads the API key —
+    /// the key is resolved separately via <see cref="IProviderCredentialResolver"/>
+    /// in <see cref="LoadProviderConfigWithKeyAsync"/>. <see cref="LlmProviderConfig.ApiKey"/>
+    /// is always left empty here so the resolver is the single key source.
+    /// </summary>
     private LlmProviderConfig LoadProviderConfig(string providerName)
     {
         // Validate provider name against allowlist
@@ -1409,7 +1462,7 @@ public class CallLlmInlineActivity : CodeActivity
         {
             var config = new LlmProviderConfig { Name = providerName };
             config.BaseUrl = section["BaseUrl"] ?? "";
-            config.ApiKey = section["ApiKey"] ?? "";
+            // ApiKey deliberately NOT read here — resolved via IProviderCredentialResolver.
             config.DefaultModel = section["DefaultModel"] ?? "";
             if (int.TryParse(section["TimeoutSeconds"], out var t)) config.TimeoutSeconds = t;
             return config;
@@ -1421,25 +1474,67 @@ public class CallLlmInlineActivity : CodeActivity
             {
                 Name = providerName,
                 BaseUrl = "https://api.anthropic.com",
-                ApiKey = _configuration?["Anthropic:ApiKey"] ?? "",
                 DefaultModel = _configuration?["Anthropic:Model"] ?? "claude-sonnet-4-20250514"
             },
             "openai" => new LlmProviderConfig
             {
                 Name = providerName,
                 BaseUrl = "https://api.openai.com",
-                ApiKey = _configuration?["OpenAI:ApiKey"] ?? "",
                 DefaultModel = "gpt-4o"
             },
             "openrouter" => new LlmProviderConfig
             {
                 Name = providerName,
                 BaseUrl = "https://openrouter.ai/api",
-                ApiKey = _configuration?["OpenRouter:ApiKey"] ?? "",
                 DefaultModel = "anthropic/claude-sonnet-4-20250514"
             },
             _ => new LlmProviderConfig { Name = providerName }
         };
+    }
+
+    /// <summary>
+    /// Story 32-3 (AC3) — load the provider config and populate its API key via
+    /// the <see cref="IProviderCredentialResolver"/> (BYOK→platform). Returns
+    /// the config plus the resolved <c>credentialSource</c> tag
+    /// (<c>"byok"</c> | <c>"platform"</c>) for the diagnostic.
+    ///
+    /// <para>When the resolver is not wired (e.g. the standalone Elsa engine
+    /// with no cabinet) the config's ApiKey is left empty and the source is
+    /// null — the legacy platform/config call path (AC12) where the operator's
+    /// config supplies the key directly. The fail-closed
+    /// <c>PROVIDER_CREDENTIAL_UNAVAILABLE</c> guarantee applies whenever the
+    /// resolver IS wired.</para>
+    /// </summary>
+    internal async Task<(LlmProviderConfig Config, string? CredentialSource)>
+        LoadProviderConfigWithKeyAsync(
+            string providerName, Guid? tenantId, CancellationToken ct)
+    {
+        var config = LoadProviderConfig(providerName); // BaseUrl / DefaultModel / Timeout only
+
+        if (_credentialResolver is null)
+        {
+            // No resolver wired — legacy platform path. The HTTP callers treat an
+            // empty ApiKey as "no auth header"; behaviour is identical to today
+            // for deployments that never set a per-tenant key.
+            return (config, null);
+        }
+
+        var cred = await _credentialResolver.ResolveAsync(tenantId, providerName, ct)
+            .ConfigureAwait(false);
+
+        // Plaintext used immediately for the outbound header; never stored/logged.
+        config.ApiKey = cred.ApiKey;
+        return (config, cred.Source.ToString().ToLowerInvariant());
+    }
+
+    /// <summary>
+    /// Parse the <c>TenantIdProp</c> string into a <see cref="Guid"/>. Empty /
+    /// whitespace / unparseable ⇒ null (single-user / platform scope).
+    /// </summary>
+    private static Guid? ParseTenantId(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        return Guid.TryParse(raw.Trim(), out var g) ? g : null;
     }
 
     private string GetDefaultModel(string providerName)

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Credentials/ConfigEnginePlatformFallbackPolicy.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Credentials/ConfigEnginePlatformFallbackPolicy.cs
@@ -1,0 +1,90 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Tamma.Activities.LlmCall.Credentials;
+
+/// <summary>
+/// Story 32-3 — <see cref="IPlatformFallbackPolicy"/> for the standalone Elsa
+/// workflow host (<c>Tamma.ElsaServer</c>), which cannot reference the
+/// <c>Tamma.Api</c> <c>ITammaModeProvider</c>. Mirrors
+/// <c>ConfigPlatformFallbackPolicy</c>'s rules but derives the operating mode
+/// from configuration directly (same detection as
+/// <c>TammaModeProvider.Resolve</c>):
+///
+/// <list type="bullet">
+///   <item><description><b>single-user</b> (or any <c>tenantId == null</c>) ⇒
+///     always allowed — the local platform/config key is the expected
+///     source.</description></item>
+///   <item><description><b>SaaS</b> ⇒ allowed unless explicitly disabled via
+///     <c>Providers:&lt;provider&gt;:PlatformFallbackDisabled</c> or
+///     <c>Providers:PlatformFallbackDisabled</c>.</description></item>
+/// </list>
+/// </summary>
+public sealed class ConfigEnginePlatformFallbackPolicy : IPlatformFallbackPolicy
+{
+    private readonly IConfiguration _configuration;
+    private readonly bool _isSaaS;
+
+    public ConfigEnginePlatformFallbackPolicy(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        _configuration = configuration;
+        _isSaaS = ResolveIsSaaS(configuration);
+    }
+
+    /// <inheritdoc />
+    public bool IsPlatformFallbackAllowed(Guid? tenantId, string providerName)
+    {
+        // Single-user / platform scope: always fall back to the local key.
+        if (!_isSaaS || tenantId is null)
+        {
+            return true;
+        }
+
+        var provider = providerName.Trim().ToLowerInvariant();
+        if (ReadBool($"Providers:{provider}:PlatformFallbackDisabled"))
+        {
+            return false;
+        }
+
+        if (ReadBool("Providers:PlatformFallbackDisabled"))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// SaaS-mode detection — identical contract to
+    /// <c>Tamma.Api.Services.PromptStore.TammaModeProvider.Resolve</c>:
+    /// explicit <c>Tamma:Mode</c> wins, else presence of
+    /// <c>Tamma:TenantSharedSecret</c> or the <c>ControlPlane</c> connection
+    /// string signals SaaS; default single-user.
+    /// </summary>
+    private static bool ResolveIsSaaS(IConfiguration configuration)
+    {
+        var explicitMode = configuration["Tamma:Mode"];
+        if (!string.IsNullOrWhiteSpace(explicitMode))
+        {
+            return explicitMode.Trim().ToLowerInvariant() switch
+            {
+                "saas" => true,
+                "single-user" or "singleuser" or "single_user" => false,
+                _ => false,
+            };
+        }
+
+        var hasSharedSecret = !string.IsNullOrWhiteSpace(
+            configuration["Tamma:TenantSharedSecret"]);
+        var hasControlPlane = !string.IsNullOrWhiteSpace(
+            configuration.GetConnectionString("ControlPlane"));
+        return hasSharedSecret || hasControlPlane;
+    }
+
+    private bool ReadBool(string key)
+    {
+        var raw = _configuration[key];
+        return !string.IsNullOrWhiteSpace(raw)
+            && bool.TryParse(raw, out var v) && v;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Credentials/ConfigPlatformProviderCredentialResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Credentials/ConfigPlatformProviderCredentialResolver.cs
@@ -1,0 +1,281 @@
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Security;
+using Tamma.Core;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Activities.LlmCall.Credentials;
+
+/// <summary>
+/// Story 32-3 — config-backed <see cref="IProviderCredentialResolver"/> for the
+/// standalone Elsa workflow host (<c>Tamma.ElsaServer</c>).
+///
+/// <para><b>Why this exists.</b> <see cref="CallLlmInlineActivity"/> executes in
+/// the <c>Tamma.ElsaServer</c> process, which deliberately does NOT reference
+/// <c>Tamma.Api</c> (see <c>Tamma.ElsaServer/Program.cs</c> agent-dispatch note).
+/// The cabinet-backed <c>DefaultProviderCredentialResolver</c> and its Epic 29
+/// secret-cabinet dependencies (<c>SecretsDbContext</c>,
+/// <c>ISecretStoreBackend</c>, <c>IRuntimeSecretResolver</c>, ...) all live in
+/// <c>Tamma.Api</c> and are not reachable here. Without a resolver registered in
+/// this host the activity bound a <c>null</c> resolver and sent an empty
+/// <c>ApiKey</c> — a hard regression to no-auth. This resolver restores the
+/// platform-key path (AC12 backward-compat) while keeping the
+/// <see cref="IProviderCredentialResolver"/> seam intact, so the key read lives
+/// in a resolver (not back in the activity, which AC2 forbids).</para>
+///
+/// <para><b>Resolution order</b> for <c>(tenantId, provider)</c>:</para>
+/// <list type="number">
+///   <item><description>Platform key from configuration — gated by
+///     <see cref="IPlatformFallbackPolicy"/>. Read from
+///     <c>LlmProviders:&lt;provider&gt;:ApiKey</c> first, then the legacy
+///     per-provider slot (e.g. <c>Anthropic:ApiKey</c>) for back-compat.
+///     Returns <see cref="CredentialSource.Platform"/>.</description></item>
+///   <item><description>Otherwise fail-closed: emit
+///     <c>AGENT.CREDENTIAL.DENIED</c> (when an event sink is available) and
+///     throw <c>TammaError("PROVIDER_CREDENTIAL_UNAVAILABLE")</c> — NEVER a
+///     silent empty/wrong key (AC6).</description></item>
+/// </list>
+///
+/// <para><b>No BYOK layer.</b> Tenant BYOK keys live in the Epic 29 cabinet,
+/// which this host cannot reach. A tenant id is accepted (so the seam is
+/// identical) but only the platform leg applies — this is the single-user /
+/// standalone-engine behaviour. SaaS BYOK resolution is owned by the
+/// API-hosted <c>DefaultProviderCredentialResolver</c>.</para>
+///
+/// <para><b>Credential safety (AC5):</b> the plaintext key lives only on the
+/// returned <see cref="ProviderCredential.ApiKey"/>; only the tag-safe
+/// projection (<see cref="ProviderCredential.ToTag"/>) ever reaches an event or
+/// a log line.</para>
+/// </summary>
+public sealed class ConfigPlatformProviderCredentialResolver : IProviderCredentialResolver
+{
+    private readonly IConfiguration _configuration;
+    private readonly IPlatformFallbackPolicy _fallbackPolicy;
+    private readonly ProviderAllowlist _allowlist;
+    private readonly ILogger<ConfigPlatformProviderCredentialResolver> _logger;
+    private readonly IEventRepository? _events;
+
+    public ConfigPlatformProviderCredentialResolver(
+        IConfiguration configuration,
+        IPlatformFallbackPolicy fallbackPolicy,
+        ProviderAllowlist allowlist,
+        ILogger<ConfigPlatformProviderCredentialResolver> logger,
+        IEventRepository? events = null)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(fallbackPolicy);
+        ArgumentNullException.ThrowIfNull(allowlist);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _configuration = configuration;
+        _fallbackPolicy = fallbackPolicy;
+        _allowlist = allowlist;
+        _logger = logger;
+        _events = events;
+    }
+
+    /// <inheritdoc />
+    public async Task<ProviderCredential> ResolveAsync(
+        Guid? tenantId, string providerName, CancellationToken ct = default)
+    {
+        var provider = Normalize(providerName);
+
+        // Platform key — gated by the policy (single-user always allowed).
+        if (_fallbackPolicy.IsPlatformFallbackAllowed(tenantId, provider))
+        {
+            var platformKey = ReadPlatformKey(provider);
+            if (!string.IsNullOrWhiteSpace(platformKey))
+            {
+                var cred = new ProviderCredential(
+                    platformKey,
+                    CredentialSource.Platform,
+                    $"platform:{ProviderCabinetNames.Platform(provider)}",
+                    VersionNumber: null);
+                _logger.LogDebug(
+                    "Platform key resolved from config for provider {Provider} (tenant {TenantId}).",
+                    provider, tenantId);
+                await EmitResolvedAsync(tenantId, provider, cred, ct).ConfigureAwait(false);
+                return cred;
+            }
+
+            _logger.LogWarning(
+                "Platform fallback allowed for provider {Provider} (tenant {TenantId}) " +
+                "but no platform key is configured (LlmProviders:{Provider}:ApiKey).",
+                provider, tenantId, provider);
+        }
+
+        // Fail-closed — never a wrong/empty key.
+        var reason = tenantId is null
+            ? "platform_key_unset"
+            : "no_byok_in_engine_host_and_platform_key_unavailable";
+        await EmitDeniedAsync(tenantId, provider, reason, ct).ConfigureAwait(false);
+
+        _logger.LogError(
+            "Provider credential unavailable in engine host: provider={Provider}, " +
+            "tenant={TenantId}, reason={Reason}.",
+            provider, tenantId, reason);
+
+        throw new TammaError(
+            "PROVIDER_CREDENTIAL_UNAVAILABLE",
+            $"No usable credential for provider '{provider}' " +
+            "(platform key unset in the workflow engine host).",
+            new Dictionary<string, object?>
+            {
+                ["tenantId"] = tenantId,
+                ["provider"] = provider,
+                ["reason"] = reason,
+            },
+            retryable: false,
+            severity: TammaErrorSeverity.High);
+    }
+
+    /// <inheritdoc />
+    public void Invalidate(Guid? tenantId, string providerName)
+    {
+        // Config-backed resolver holds no cache — nothing to invalidate.
+    }
+
+    /// <summary>
+    /// Read the platform key for <paramref name="provider"/> from configuration.
+    /// Primary slot: <c>LlmProviders:&lt;provider&gt;:ApiKey</c> (the existing
+    /// engine appsettings shape). Falls back to the legacy per-provider slot
+    /// (<c>Anthropic:ApiKey</c> / <c>OpenAI:ApiKey</c> / <c>OpenRouter:ApiKey</c>)
+    /// that pre-32-3 <c>LoadProviderConfig</c> used to read — so a deployment
+    /// that supplied platform keys the old way still authenticates (AC12).
+    /// </summary>
+    private string? ReadPlatformKey(string provider)
+    {
+        var fromSection = _configuration[$"LlmProviders:{provider}:ApiKey"];
+        if (!string.IsNullOrWhiteSpace(fromSection))
+        {
+            return fromSection;
+        }
+
+        // Legacy per-provider slots (the exact keys 32-3 stopped reading in the
+        // activity). Only the providers that had a legacy slot are mapped.
+        var legacyKey = provider switch
+        {
+            "anthropic" => "Anthropic:ApiKey",
+            "openai" => "OpenAI:ApiKey",
+            "openrouter" => "OpenRouter:ApiKey",
+            _ => null,
+        };
+        if (legacyKey is not null)
+        {
+            var legacy = _configuration[legacyKey];
+            if (!string.IsNullOrWhiteSpace(legacy))
+            {
+                return legacy;
+            }
+        }
+
+        return null;
+    }
+
+    private string Normalize(string providerName)
+    {
+        if (string.IsNullOrWhiteSpace(providerName))
+        {
+            throw new TammaError(
+                "PROVIDER_CREDENTIAL_UNAVAILABLE",
+                "Provider name must be non-empty.",
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+        }
+
+        var provider = providerName.Trim().ToLowerInvariant();
+        if (!_allowlist.IsAllowed(provider))
+        {
+            throw new TammaError(
+                "PROVIDER_CREDENTIAL_UNAVAILABLE",
+                $"Provider '{provider}' is not in the allowlist.",
+                new Dictionary<string, object?> { ["provider"] = provider },
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+        }
+        return provider;
+    }
+
+    private async Task EmitResolvedAsync(
+        Guid? tenantId, string provider, ProviderCredential cred, CancellationToken ct)
+    {
+        if (_events is null)
+        {
+            return; // engine host may run without a durable event sink
+        }
+
+        var tag = cred.ToTag(); // tag-safe — NEVER the ApiKey
+        try
+        {
+            await _events.AppendAsync(new DomainEvent
+            {
+                Id = Guid.NewGuid(),
+                Type = "AGENT.CREDENTIAL_RESOLVED.SUCCESS",
+                TenantId = tenantId,
+                Tags = JsonSerializer.Serialize(new
+                {
+                    tenantId = tenantId?.ToString(),
+                    provider,
+                    source = tag.Source,
+                    secretRef = tag.SecretRef,
+                    host = "elsa-engine",
+                }),
+                Metadata = JsonSerializer.Serialize(new
+                {
+                    workflowVersion = "1.0.0",
+                    eventSource = "system",
+                }),
+                Data = JsonSerializer.Serialize(new { version = tag.Version }),
+                CreatedAt = DateTime.UtcNow,
+            }).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Audit-emit failure must not block a valid resolution.
+            _logger.LogWarning(ex,
+                "Failed to emit AGENT.CREDENTIAL_RESOLVED.SUCCESS for provider {Provider}.",
+                provider);
+        }
+    }
+
+    private async Task EmitDeniedAsync(
+        Guid? tenantId, string provider, string reason, CancellationToken ct)
+    {
+        if (_events is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _events.AppendAsync(new DomainEvent
+            {
+                Id = Guid.NewGuid(),
+                Type = "AGENT.CREDENTIAL.DENIED",
+                TenantId = tenantId,
+                Tags = JsonSerializer.Serialize(new
+                {
+                    tenantId = tenantId?.ToString(),
+                    provider,
+                    reason,
+                    host = "elsa-engine",
+                }),
+                Metadata = JsonSerializer.Serialize(new
+                {
+                    workflowVersion = "1.0.0",
+                    eventSource = "system",
+                }),
+                Data = "{}",
+                CreatedAt = DateTime.UtcNow,
+            }).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to emit AGENT.CREDENTIAL.DENIED for provider {Provider}.",
+                provider);
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Credentials/EngineProviderCredentialServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Credentials/EngineProviderCredentialServiceCollectionExtensions.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Tamma.Activities.Security;
+
+namespace Tamma.Activities.LlmCall.Credentials;
+
+/// <summary>
+/// Story 32-3 — DI registration of the provider-credential resolver for the
+/// standalone Elsa workflow host (<c>Tamma.ElsaServer</c>), which executes
+/// <see cref="CallLlmInlineActivity"/> and does NOT reference <c>Tamma.Api</c>.
+///
+/// <para>Wires <see cref="ConfigPlatformProviderCredentialResolver"/> (the
+/// config-backed platform-key resolver) so the activity binds a NON-null
+/// <see cref="IProviderCredentialResolver"/>. Without this the activity sent an
+/// empty <c>ApiKey</c> — a hard regression to no-auth. The API process keeps its
+/// own cabinet-backed <c>DefaultProviderCredentialResolver</c> (BYOK) via
+/// <c>AddProviderCredentialResolution()</c>; this is the engine-host
+/// counterpart that owns the platform-key path (AC2/AC12).</para>
+///
+/// <para>The resolver picks up an <c>IEventRepository</c> for audit emission
+/// only if one is registered in the host (optional dependency) — the engine
+/// host may run without a durable event sink.</para>
+/// </summary>
+public static class EngineProviderCredentialServiceCollectionExtensions
+{
+    public static IServiceCollection AddEngineProviderCredentialResolution(
+        this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        // Provider allowlist (shared with the activity's fail-closed guards).
+        services.TryAddSingleton<ProviderAllowlist>();
+
+        // Fallback policy — config-driven mode detection (no Tamma.Api dep).
+        services.TryAddSingleton<IPlatformFallbackPolicy, ConfigEnginePlatformFallbackPolicy>();
+
+        // The resolver — singleton. IEventRepository is OPTIONAL: the engine
+        // host may not register one, so resolve it via GetService and pass
+        // through (the resolver tolerates null and simply skips audit emit).
+        services.TryAddSingleton<IProviderCredentialResolver>(sp =>
+            new ConfigPlatformProviderCredentialResolver(
+                sp.GetRequiredService<Microsoft.Extensions.Configuration.IConfiguration>(),
+                sp.GetRequiredService<IPlatformFallbackPolicy>(),
+                sp.GetRequiredService<ProviderAllowlist>(),
+                sp.GetRequiredService<
+                    Microsoft.Extensions.Logging.ILogger<
+                        ConfigPlatformProviderCredentialResolver>>(),
+                sp.GetService<Tamma.Data.Repositories.IEventRepository>()));
+
+        return services;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Credentials/IPlatformFallbackPolicy.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Credentials/IPlatformFallbackPolicy.cs
@@ -1,0 +1,19 @@
+namespace Tamma.Activities.LlmCall.Credentials;
+
+/// <summary>
+/// Decides whether the platform-provided key may be used as a fallback when a
+/// tenant has no BYOK key (Story 32-3 AC6.1). The plan-level / per-provider
+/// gating that Epics 34/35 will drive plugs in here without changing the
+/// resolver.
+///
+/// <para>v1 default (<c>ConfigPlatformFallbackPolicy</c>): single-user ⇒ always
+/// allowed; SaaS ⇒ allowed unless explicitly disabled by config.</para>
+/// </summary>
+public interface IPlatformFallbackPolicy
+{
+    /// <summary>
+    /// True when the platform key may be used for <c>(tenantId, providerName)</c>.
+    /// <paramref name="tenantId"/> == null ⇒ single-user / platform scope.
+    /// </summary>
+    bool IsPlatformFallbackAllowed(Guid? tenantId, string providerName);
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Credentials/IProviderCredentialResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Credentials/IProviderCredentialResolver.cs
@@ -1,0 +1,96 @@
+namespace Tamma.Activities.LlmCall.Credentials;
+
+/// <summary>
+/// Where a resolved provider API key came from. Consumed by Epics 34/35
+/// (pricing/billing) and 32-9/32-10 (usage/benchmarking) as the
+/// <c>credentialSource</c> tag — never the key itself.
+/// </summary>
+public enum CredentialSource
+{
+    /// <summary>The tenant's own bring-your-own-key, read from the Epic 29 cabinet.</summary>
+    Byok,
+
+    /// <summary>The platform-provided key, read through the cabinet runtime path.</summary>
+    Platform,
+}
+
+/// <summary>
+/// Resolved provider credential. <see cref="ApiKey"/> is plaintext for the
+/// immediate outbound HTTP call ONLY — it MUST NEVER be serialized into a
+/// <c>DomainEvent</c>, a <c>ProviderAttemptDiagnostic</c>, an exception
+/// message, or any log line (Story 32-3 AC5, redaction test is the gate).
+/// Only <see cref="ToTag"/> — the tag-safe projection — ever reaches an
+/// event / diagnostic / log.
+/// </summary>
+/// <param name="ApiKey">Plaintext key. Request-scoped; dropped after the
+/// HTTP header is set.</param>
+/// <param name="Source">BYOK vs platform.</param>
+/// <param name="SecretRefStorageKey">Stable storage-key for the secret
+/// (e.g. <c>tenant:&lt;guid&gt;:provider/anthropic/api-key</c> or
+/// <c>platform:anthropic/api-key</c>). Safe to log / tag.</param>
+/// <param name="VersionNumber">Active cabinet version number for BYOK; null
+/// for the platform leg.</param>
+public sealed record ProviderCredential(
+    string ApiKey,
+    CredentialSource Source,
+    string? SecretRefStorageKey,
+    int? VersionNumber)
+{
+    /// <summary>
+    /// Tag-safe projection. NEVER includes <see cref="ApiKey"/>. This is the
+    /// only thing handed to diagnostics / DCB events / logs.
+    /// </summary>
+    public ProviderCredentialTag ToTag() => new(
+        Source.ToString().ToLowerInvariant(),
+        SecretRefStorageKey,
+        VersionNumber);
+}
+
+/// <summary>
+/// Tag-safe projection of a <see cref="ProviderCredential"/> — explicitly
+/// free of any plaintext. Serialized into diagnostics / DCB-event tags.
+/// </summary>
+/// <param name="Source">"byok" | "platform".</param>
+/// <param name="SecretRef">Storage-key for the secret (never the value).</param>
+/// <param name="Version">Active version number (BYOK) or null (platform).</param>
+public sealed record ProviderCredentialTag(
+    string Source,
+    string? SecretRef,
+    int? Version);
+
+/// <summary>
+/// Resolves the API key for an LLM call from the per-tenant BYOK cabinet
+/// (Epic 29), falling back to the platform-provided key. The single seam that
+/// owns ALL "where does the provider key come from at execution time?" logic
+/// (Story 32-3 — canonical ownership).
+///
+/// <para>The interface lives in <c>Tamma.Activities</c> so
+/// <see cref="CallLlmInlineActivity"/> can depend on it without referencing
+/// <c>Tamma.Api</c> (the cabinet-backed implementation,
+/// <c>DefaultProviderCredentialResolver</c>, lives in <c>Tamma.Api</c> where
+/// the Epic 29 services are reachable and is wired in the API-hosted process).
+/// When the resolver is absent (e.g. the standalone Elsa engine with no
+/// cabinet) the activity falls back to the existing platform/config path —
+/// the single-user behaviour AC6 prescribes.</para>
+/// </summary>
+public interface IProviderCredentialResolver
+{
+    /// <summary>
+    /// Resolve the API key for <c>(tenantId, providerName)</c>.
+    /// <paramref name="tenantId"/> == null ⇒ single-user / platform scope.
+    /// Order: tenant BYOK cabinet key → platform-provided key (gated by the
+    /// fallback policy). Fail-closed in SaaS when neither is available/allowed:
+    /// emits <c>AGENT.CREDENTIAL.DENIED</c> and throws
+    /// <c>TammaError("PROVIDER_CREDENTIAL_UNAVAILABLE", retryable:false,
+    /// severity:High)</c> — NEVER a silent wrong/empty key.
+    /// </summary>
+    Task<ProviderCredential> ResolveAsync(
+        Guid? tenantId, string providerName, CancellationToken ct = default);
+
+    /// <summary>
+    /// Invalidate the cached BYOK entry for <c>(tenantId, provider)</c>.
+    /// Called on register / rotate / remove (AC7) and on a matching
+    /// <c>SECRET.ROTATE.ACTIVATED</c> (AC9).
+    /// </summary>
+    void Invalidate(Guid? tenantId, string providerName);
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Credentials/ProviderCabinetNames.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Credentials/ProviderCabinetNames.cs
@@ -1,0 +1,64 @@
+namespace Tamma.Activities.LlmCall.Credentials;
+
+/// <summary>
+/// Canonical cabinet names for provider API keys, kept as one source of truth
+/// so the BYOK management API (Story 32-3 AC7) and the resolver (AC1/AC2)
+/// cannot drift apart on the slug.
+///
+/// <para><b>BYOK</b> (tenant-scoped) keys live under
+/// <c>provider/&lt;name&gt;/api-key</c>. <b>Platform</b> keys reuse the
+/// Story 29-9 stopgap cabinet names (<c>&lt;name&gt;/api-key</c>) so the
+/// platform leg goes through the one existing platform-key source of truth
+/// (<c>IRuntimeSecretResolver</c>) — see AC2.</para>
+/// </summary>
+public static class ProviderCabinetNames
+{
+    /// <summary>
+    /// Tenant-scoped BYOK cabinet name for <paramref name="provider"/>, e.g.
+    /// <c>provider/anthropic/api-key</c>. <paramref name="provider"/> is
+    /// expected to already be normalized (lower-invariant, allowlist-checked).
+    /// </summary>
+    public static string Byok(string provider)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(provider);
+        return $"provider/{provider.Trim().ToLowerInvariant()}/api-key";
+    }
+
+    /// <summary>
+    /// Platform cabinet name for <paramref name="provider"/>, e.g.
+    /// <c>anthropic/api-key</c>. Matches the Story 29-9
+    /// <c>StopgapSecretMap.Platform*ApiKey</c> constants where they exist
+    /// (anthropic); providers with no stopgap entry (openai, openrouter) simply
+    /// have no platform cabinet row yet → the platform leg returns null and the
+    /// resolver fails closed / loud, which is correct.
+    /// </summary>
+    public static string Platform(string provider)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(provider);
+        return $"{provider.Trim().ToLowerInvariant()}/api-key";
+    }
+
+    private const string ByokPrefix = "provider/";
+    private const string ByokSuffix = "/api-key";
+
+    /// <summary>
+    /// Reverse of <see cref="Byok"/>: extract the provider name from a
+    /// <c>provider/&lt;name&gt;/api-key</c> cabinet name, or null when the name
+    /// is not a BYOK provider-key slug.
+    /// </summary>
+    public static string? TryParse(string? cabinetName)
+    {
+        if (string.IsNullOrWhiteSpace(cabinetName)
+            || !cabinetName.StartsWith(ByokPrefix, StringComparison.Ordinal)
+            || !cabinetName.EndsWith(ByokSuffix, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var inner = cabinetName.Substring(
+            ByokPrefix.Length,
+            cabinetName.Length - ByokPrefix.Length - ByokSuffix.Length);
+
+        return string.IsNullOrWhiteSpace(inner) ? null : inner;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Models/LlmCallModels.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Models/LlmCallModels.cs
@@ -147,6 +147,16 @@ public class ProviderAttemptDiagnostic
 
     /// <summary>Whether this attempt was skipped due to budget exhaustion.</summary>
     public bool BudgetExhausted { get; set; }
+
+    /// <summary>
+    /// Story 32-3 (AC4) — where the provider API key came from for this attempt:
+    /// <c>"byok"</c> (the tenant's own key) or <c>"platform"</c> (the
+    /// platform-provided key). Null when the resolver was not wired (legacy
+    /// platform/config path) or the attempt never reached credential
+    /// resolution. NEVER the key itself — pricing/billing/benchmarking
+    /// (Epics 34/35, 32-9/32-10) branch on this tag.
+    /// </summary>
+    public string? CredentialSource { get; set; }
 }
 
 // ============================================================

--- a/apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/AgentRegistryDtos.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/AgentRegistryDtos.cs
@@ -1,0 +1,39 @@
+namespace Tamma.Api.Dtos.Agents;
+
+// Story 32-2 — DTOs for the entity-aware registry/resolution surface
+// (/api/agents). The first-class agent CRUD DTOs (CreateAgentRequest,
+// PublishVersionRequest, AgentSummary, AgentDetail, ...) ship in
+// AgentDtos.cs (Story 32-1) and are reused; these add only the role-selection
+// + list-filter shapes 32-2 introduces.
+
+/// <summary>
+/// Filter for <c>GET /api/agents</c>. All optional; absent = no filter on that
+/// dimension. Visibility/status are wire strings (<c>public</c>/<c>private</c>,
+/// <c>active</c>/<c>archived</c>); role is a canonical
+/// <c>RolePhaseMap.ValidRoles</c> wire string.
+/// </summary>
+public sealed record AgentListFilter(
+    string? Role = null,
+    string? Visibility = null,
+    string? Status = null);
+
+/// <summary>
+/// Body for <c>PUT /api/agents/role-selections/{role}</c> — which agent (public
+/// OR own private) serves the role for the calling principal.
+/// </summary>
+public sealed record SelectRoleRequest(Guid AgentId);
+
+/// <summary>
+/// Body for <c>POST /api/agents/{id}/rollback</c> — re-activate an EXISTING
+/// prior version (repoint the active-version pointer; AC 13).
+/// </summary>
+public sealed record RollbackVersionRequest(int Version);
+
+/// <summary>
+/// One role→agent selection projection for <c>GET</c> responses. <c>Visibility</c>
+/// is the provenance recomputed at read time.
+/// </summary>
+public sealed record AgentRoleSelectionResponse(
+    string Role,
+    Guid AgentId,
+    string Visibility);

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs
@@ -485,6 +485,148 @@ public static class AgentEndpoints
     }
 
     // -----------------------------------------------------------------------
+    // Story 32-2 — entity-aware registry / resolution surface (/api/agents)
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// GET <c>/api/agents/resolve?role=&amp;phase=</c> — resolve the EFFECTIVE
+    /// first-class agent for the calling principal + role via the 32-2
+    /// precedence chain. Returns the enriched <see cref="ResolvedAgentConfig"/>
+    /// (carrying <c>AgentId</c>/<c>AgentVersion</c>/extended <c>Source</c>).
+    /// Unknown role/phase → 400; unresolvable (no selection + no system default)
+    /// → 404 with code <c>agent_resolve_no_default</c> (the fail-loud branch
+    /// NEVER returns a blank config).
+    /// </summary>
+    public static async Task<IResult> Resolve(
+        string? role,
+        string? phase,
+        IAgentResolverService resolver)
+    {
+        if (string.IsNullOrWhiteSpace(role))
+        {
+            return Results.BadRequest(new { error = "invalid_request", detail = "role is required." });
+        }
+
+        try
+        {
+            var resolved = string.IsNullOrWhiteSpace(phase)
+                ? await resolver.ResolveForRoleAsync(role)
+                : await resolver.ResolveForRoleAndPhaseAsync(phase, role);
+            return Results.Ok(resolved);
+        }
+        catch (ArgumentException ex)
+        {
+            return Results.BadRequest(new { error = "invalid_role", detail = ex.Message });
+        }
+        catch (TammaError ex) when (ex.Code == "AGENT.RESOLVE.NO_DEFAULT")
+        {
+            // No blank config — fail loud. 404: no agent resolvable for the role.
+            return Results.Json(
+                new { error = "agent_resolve_no_default", detail = ex.Message },
+                statusCode: StatusCodes.Status404NotFound);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Results.Problem(ex.Message, statusCode: 500);
+        }
+    }
+
+    /// <summary>
+    /// PUT <c>/api/agents/role-selections/{role}</c> — select which agent serves
+    /// a role for the calling principal. The target must be in (public ∪ own
+    /// private) — a cross-tenant/non-existent target returns 404 (no existence
+    /// leak). Member-role callers are 403'd by the <c>AgentManage</c> route
+    /// policy before reaching here.
+    /// </summary>
+    public static async Task<IResult> SelectForRole(
+        string role,
+        SelectRoleRequest req,
+        IAgentRegistryService registry,
+        ClaimsPrincipal principal)
+    {
+        var canonicalRole = RolePhaseMap.NormalizeRole(role);
+        if (!RolePhaseMap.ValidRoles.Contains(canonicalRole))
+        {
+            return Results.BadRequest(new
+            {
+                error = "invalid_role",
+                detail = $"Unknown role '{role}'.",
+            });
+        }
+
+        try
+        {
+            var selection = await registry.SelectForRoleAsync(
+                canonicalRole, req.AgentId, principal.GetUserId());
+            return Results.Ok(new AgentRoleSelectionResponse(
+                selection.Role, selection.AgentId, selection.Visibility));
+        }
+        catch (TammaError ex) when (ex.Code == "AGENT.SELECT.NOT_FOUND")
+        {
+            // 404 (not 403) — never leak the existence of another tenant's agent.
+            return Results.NotFound(new { error = "agent_not_found", detail = ex.Message });
+        }
+        catch (TammaError ex)
+        {
+            return Results.BadRequest(new { error = ex.Code, detail = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// GET <c>/api/agents/role-selections</c> — the calling principal's current
+    /// role→agent selection map.
+    /// </summary>
+    public static async Task<IResult> GetRoleSelections(IAgentRegistryService registry)
+    {
+        var selections = await registry.GetRoleSelectionsAsync();
+        var response = selections.Values
+            .Select(s => new AgentRoleSelectionResponse(s.Role, s.AgentId, s.Visibility))
+            .OrderBy(s => s.Role, StringComparer.Ordinal)
+            .ToList();
+        return Results.Ok(response);
+    }
+
+    /// <summary>
+    /// POST <c>/api/agents/{id}/rollback</c> — rollback (AC 13): repoint the
+    /// agent's active version at an EXISTING prior version (no new snapshot). The
+    /// subsequent resolve returns that version's config. RBAC matches the agent's
+    /// ownership (public → platform admin; private → owning tenant/user); same
+    /// 404/403 discipline as publish.
+    /// </summary>
+    public static async Task<IResult> RollbackVersion(
+        Guid id,
+        RollbackVersionRequest req,
+        IAgentRepository agents,
+        ClaimsPrincipal principal,
+        ITenantContext tenantContext,
+        ITammaModeProvider modeProvider)
+    {
+        var agent = await agents.GetByIdAsync(id);
+        if (agent is null || !CanSeeAgent(agent, principal, tenantContext, modeProvider))
+        {
+            return Results.NotFound();
+        }
+        if (!CanWriteAgent(agent, principal, tenantContext, modeProvider))
+        {
+            return Results.Json(
+                new { error = "forbidden", detail = "not permitted to roll back this agent." },
+                statusCode: StatusCodes.Status403Forbidden);
+        }
+
+        var version = await agents.SetActiveVersionAsync(id, req.Version, principal.GetUserId());
+        if (version is null)
+        {
+            // Agent exists (checked above) ⇒ the target version doesn't.
+            return Results.NotFound(new
+            {
+                error = "version_not_found",
+                detail = $"agent {id} has no version {req.Version}.",
+            });
+        }
+        return Results.Ok(new PublishVersionResponse(version.Id, version.Version, version.CreatedAt));
+    }
+
+    // -----------------------------------------------------------------------
     // Story 32-1 — visibility / RBAC helpers
     // -----------------------------------------------------------------------
 

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs
@@ -398,18 +398,93 @@ public static class AgentEndpoints
     }
 
     /// <summary>
-    /// GET <c>/api/v1/agents</c> — list visible agents (all public ∪ the
-    /// caller's own private). Cross-tenant private agents are never returned.
+    /// GET <c>/api/agents</c> (and legacy <c>/api/v1/agents</c>) — list visible
+    /// agents (all public ∪ the caller's own private). Cross-tenant private
+    /// agents are never returned.
+    ///
+    /// <para>Story 32-2 AC5 — optional <c>?role=&amp;visibility=&amp;status=</c>
+    /// filters NARROW the visibility-scoped set; they never widen it. The
+    /// visibility scoping (<see cref="ResolvePrincipalScope"/> →
+    /// <see cref="IAgentRepository.ListVisibleAsync"/>) runs FIRST, so a filter
+    /// can only ever subset a tenant's own public ∪ own-private rows — another
+    /// tenant's private agent can never surface, even with <c>visibility=private</c>.
+    /// An absent/empty parameter means "no filter on that dimension". An unknown
+    /// <c>role</c> → 400 (consistent with AC12's role validation); an unknown
+    /// <c>visibility</c>/<c>status</c> wire string → 400.</para>
     /// </summary>
     public static async Task<IResult> ListAgents(
         IAgentRepository agents,
         ClaimsPrincipal principal,
         ITenantContext tenantContext,
-        ITammaModeProvider modeProvider)
+        ITammaModeProvider modeProvider,
+        string? role = null,
+        string? visibility = null,
+        string? status = null)
     {
+        // Bind the wire params into the documented filter DTO + validate. Absent
+        // / empty dimensions stay null (no filter). Validation mirrors the write
+        // surface: unknown role/visibility/status → 400 before any DB read.
+        var filter = new AgentListFilter(
+            Role: string.IsNullOrWhiteSpace(role) ? null : role,
+            Visibility: string.IsNullOrWhiteSpace(visibility) ? null : visibility,
+            Status: string.IsNullOrWhiteSpace(status) ? null : status);
+
+        string? roleFilter = null;
+        if (filter.Role is not null)
+        {
+            // Normalize legacy aliases then validate against the canonical set —
+            // same discipline as AC12's SelectForRole role validation.
+            var canonicalRole = RolePhaseMap.NormalizeRole(filter.Role);
+            if (!RolePhaseMap.ValidRoles.Contains(canonicalRole))
+            {
+                return Results.BadRequest(new
+                {
+                    error = "invalid_role",
+                    detail = $"Unknown role '{filter.Role}'.",
+                });
+            }
+            roleFilter = canonicalRole;
+        }
+
+        AgentVisibility? visibilityFilter = null;
+        if (filter.Visibility is not null)
+        {
+            if (!TryParseVisibility(filter.Visibility, out var v))
+            {
+                return Results.BadRequest(new
+                {
+                    error = "invalid_visibility",
+                    detail = "visibility must be 'public' or 'private'.",
+                });
+            }
+            visibilityFilter = v;
+        }
+
+        AgentStatus? statusFilter = null;
+        if (filter.Status is not null)
+        {
+            if (!TryParseStatus(filter.Status, out var s))
+            {
+                return Results.BadRequest(new
+                {
+                    error = "invalid_status",
+                    detail = "status must be 'active' or 'archived'.",
+                });
+            }
+            statusFilter = s;
+        }
+
         var (tenantId, userId) = ResolvePrincipalScope(principal, tenantContext, modeProvider);
+        // Visibility scoping FIRST — the filters below only NARROW this set, so
+        // cross-tenant isolation is structurally preserved.
         var visible = await agents.ListVisibleAsync(tenantId, userId);
-        var summaries = visible.Select(ToSummary).ToList();
+
+        var filtered = visible.Where(a =>
+            (roleFilter is null || string.Equals(a.Role, roleFilter, StringComparison.Ordinal)) &&
+            (visibilityFilter is null || a.Visibility == visibilityFilter) &&
+            (statusFilter is null || a.Status == statusFilter));
+
+        var summaries = filtered.Select(ToSummary).ToList();
         return Results.Ok(summaries);
     }
 
@@ -647,6 +722,16 @@ public static class AgentEndpoints
             case "public": visibility = AgentVisibility.Public; return true;
             case "private": visibility = AgentVisibility.Private; return true;
             default: visibility = default; return false;
+        }
+    }
+
+    private static bool TryParseStatus(string? raw, out AgentStatus status)
+    {
+        switch (raw?.Trim().ToLowerInvariant())
+        {
+            case "active": status = AgentStatus.Active; return true;
+            case "archived": status = AgentStatus.Archived; return true;
+            default: status = default; return false;
         }
     }
 

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/ProviderCredentialEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/ProviderCredentialEndpoints.cs
@@ -1,0 +1,321 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Mvc;
+using Tamma.Activities.LlmCall.Credentials;
+using Tamma.Activities.Security;
+using Tamma.Api.Auth;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Services.Providers;
+using Tamma.Api.Services.Secrets;
+using Tamma.Api.Services.Secrets.Query;
+using Tamma.Api.Services.Secrets.Reveal;
+using Tamma.Data;
+
+namespace Tamma.Api.Endpoints;
+
+/// <summary>
+/// Story 32-3 (AC7) — tenant-admin BYOK provider-credential management API.
+///
+/// <list type="bullet">
+///   <item><c>GET    /api/v1/agents/providers</c> — list configured BYOK
+///     providers (metadata only, NEVER the key).</item>
+///   <item><c>POST   /api/v1/agents/providers/{provider}/credential</c> —
+///     register a BYOK key (reveal-once token via Story 29-3).</item>
+///   <item><c>POST   /api/v1/agents/providers/{provider}/credential/rotate</c>
+///     — rotate the BYOK key (reveal-once).</item>
+///   <item><c>DELETE /api/v1/agents/providers/{provider}/credential</c> —
+///     retire the active BYOK version (falls back to platform on next resolve).</item>
+/// </list>
+///
+/// <para>RBAC: writes are gated to <c>tenant_owner</c> / <c>tenant_admin</c> by
+/// the <c>AgentManage</c> route policy (member → 403). Cross-tenant / absent
+/// targets return 404 (never leak existence). Every mutation calls
+/// <c>resolver.Invalidate</c> so the next call re-resolves. Response bodies
+/// NEVER contain the raw key — create/rotate return the reveal-once token
+/// metadata only.</para>
+///
+/// <para>BYOK is tenant-scoped only (no per-user layer, mirroring the Prompt
+/// Store). In single-user mode the sole user owns their personal tenant, so
+/// the tenant-context guard still resolves to "their" scope.</para>
+/// </summary>
+public static class ProviderCredentialEndpoints
+{
+    private const int MinKeyLength = 8;
+    private const int MaxKeyLength = 8192;
+
+    /// <summary>
+    /// <c>GET /api/v1/agents/providers</c> — list the tenant's configured BYOK
+    /// providers. Metadata only (provider, version, last-rotated) — NO key.
+    /// </summary>
+    public static async Task<IResult> ListProviders(
+        ITenantContext tenantContext,
+        [FromServices] ISecretQueryService query,
+        HttpContext http)
+    {
+        var tenantId = tenantContext.TenantId;
+        if (tenantId is null)
+        {
+            return Results.Ok(new { providers = Array.Empty<object>() });
+        }
+
+        var rows = await query.ListAsync(SecretScope.Tenant, tenantId, http.RequestAborted)
+            .ConfigureAwait(false);
+
+        var providers = rows
+            .Select(r => new { name = ProviderCabinetNames.TryParse(r.Name), metadata = r })
+            .Where(x => x.name is not null)
+            .Select(x => new ProviderCredentialMetadata(
+                x.name!,
+                x.metadata.ActiveVersionNumber,
+                x.metadata.LastRotatedAt,
+                x.metadata.UpdatedAt))
+            .ToList();
+
+        return Results.Ok(new { providers });
+    }
+
+    /// <summary>
+    /// <c>POST /api/v1/agents/providers/{provider}/credential</c> — register a
+    /// BYOK key for the tenant. Reveal-once: the response carries the token +
+    /// metadata, NEVER the key.
+    /// </summary>
+    public static async Task<IResult> RegisterCredential(
+        string provider,
+        SetProviderCredentialRequest body,
+        ClaimsPrincipal principal,
+        ITenantContext tenantContext,
+        [FromServices] ISecretRevealService reveal,
+        [FromServices] IProviderCredentialResolver resolver,
+        HttpContext http)
+    {
+        var (norm, err) = NormalizeProvider(provider);
+        if (err is not null) return err;
+        var keyError = ValidateKey(body?.ApiKey);
+        if (keyError is not null) return keyError;
+
+        if (tenantContext.TenantId is not Guid tid)
+        {
+            return Results.BadRequest(new
+            {
+                error = "no_tenant_context",
+                detail = "registering a BYOK key requires tenant context.",
+            });
+        }
+
+        try
+        {
+            var result = await reveal.IssueCreateAsync(
+                name: ProviderCabinetNames.Byok(norm!),
+                scope: SecretScope.Tenant,
+                tenantId: tid,
+                purpose: SecretPurpose.ApiKey,
+                initialPlaintext: body!.ApiKey!,
+                consumerRefs: new[] { new ConsumerRef(norm!, "api-key") },
+                ownerUserId: principal.GetUserId() ?? Guid.Empty,
+                rotationSchedule: null,
+                ct: http.RequestAborted)
+                .ConfigureAwait(false);
+
+            resolver.Invalidate(tid, norm!);
+
+            return Results.Created(
+                $"/api/v1/agents/providers/{norm}/credential",
+                new SetProviderCredentialResponse(
+                    norm!, result.Metadata.ActiveVersionNumber,
+                    result.RevealToken, result.ExpiresAt));
+        }
+        catch (ArgumentException ex)
+        {
+            return Results.BadRequest(new { error = ex.Message });
+        }
+        catch (Exception ex) when (IsDuplicate(ex))
+        {
+            return Results.Conflict(new
+            {
+                error = "credential_exists",
+                detail = "a BYOK key for this provider already exists; use rotate.",
+            });
+        }
+    }
+
+    /// <summary>
+    /// <c>POST /api/v1/agents/providers/{provider}/credential/rotate</c> —
+    /// rotate the BYOK key to a new version. Reveal-once response; never the key.
+    /// </summary>
+    public static async Task<IResult> RotateCredential(
+        string provider,
+        SetProviderCredentialRequest body,
+        ClaimsPrincipal principal,
+        ITenantContext tenantContext,
+        [FromServices] ISecretQueryService query,
+        [FromServices] ISecretRevealService reveal,
+        [FromServices] IProviderCredentialResolver resolver,
+        HttpContext http)
+    {
+        var (norm, err) = NormalizeProvider(provider);
+        if (err is not null) return err;
+        var keyError = ValidateKey(body?.ApiKey);
+        if (keyError is not null) return keyError;
+
+        if (tenantContext.TenantId is not Guid tid)
+        {
+            return Results.NotFound();
+        }
+
+        var secretId = await FindSecretIdAsync(query, tid, norm!, http.RequestAborted)
+            .ConfigureAwait(false);
+        if (secretId is null)
+        {
+            // No existing key for this tenant/provider — nothing to rotate.
+            // 404 (never leak another tenant's existence).
+            return Results.NotFound(new
+            {
+                error = "credential_not_found",
+                detail = "no BYOK key for this provider; register one first.",
+            });
+        }
+
+        try
+        {
+            var result = await reveal.IssueRotateAsync(
+                secretId.Value, body!.ApiKey!, principal.GetUserId() ?? Guid.Empty,
+                http.RequestAborted).ConfigureAwait(false);
+
+            resolver.Invalidate(tid, norm!);
+
+            return Results.Ok(new SetProviderCredentialResponse(
+                norm!, result.Metadata.ActiveVersionNumber,
+                result.RevealToken, result.ExpiresAt));
+        }
+        catch (KeyNotFoundException)
+        {
+            return Results.NotFound();
+        }
+        catch (ArgumentException ex)
+        {
+            return Results.BadRequest(new { error = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// <c>DELETE /api/v1/agents/providers/{provider}/credential</c> — retire the
+    /// active BYOK version so the next resolve falls back to the platform key.
+    /// </summary>
+    public static async Task<IResult> DeleteCredential(
+        string provider,
+        ClaimsPrincipal principal,
+        ITenantContext tenantContext,
+        [FromServices] ISecretQueryService query,
+        [FromServices] IProviderCredentialResolver resolver,
+        HttpContext http)
+    {
+        var (norm, err) = NormalizeProvider(provider);
+        if (err is not null) return err;
+
+        if (tenantContext.TenantId is not Guid tid)
+        {
+            return Results.NotFound();
+        }
+
+        var meta = await FindMetadataAsync(query, tid, norm!, http.RequestAborted)
+            .ConfigureAwait(false);
+        if (meta is null || meta.ActiveVersionNumber <= 0)
+        {
+            return Results.NotFound(new
+            {
+                error = "credential_not_found",
+                detail = "no active BYOK key for this provider.",
+            });
+        }
+
+        try
+        {
+            await query.RetireVersionAsync(
+                meta.Id, meta.ActiveVersionNumber, SecretScope.Tenant, tid,
+                principal.GetUserId() ?? Guid.Empty, http.RequestAborted)
+                .ConfigureAwait(false);
+        }
+        catch (KeyNotFoundException)
+        {
+            return Results.NotFound();
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Refused to retire the active version without a successor — but for
+            // BYOK "remove" we WANT to drop the active key. Surface a clear 409.
+            return Results.Conflict(new { error = "retire_blocked", detail = ex.Message });
+        }
+
+        resolver.Invalidate(tid, norm!);
+        return Results.NoContent();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+
+    private static async Task<Guid?> FindSecretIdAsync(
+        ISecretQueryService query, Guid tenantId, string provider, CancellationToken ct)
+    {
+        var meta = await FindMetadataAsync(query, tenantId, provider, ct).ConfigureAwait(false);
+        return meta?.Id;
+    }
+
+    private static async Task<SecretMetadata?> FindMetadataAsync(
+        ISecretQueryService query, Guid tenantId, string provider, CancellationToken ct)
+    {
+        var name = ProviderCabinetNames.Byok(provider);
+        var rows = await query.ListAsync(SecretScope.Tenant, tenantId, ct).ConfigureAwait(false);
+        return rows.FirstOrDefault(r => r.Name == name);
+    }
+
+    private static (string? Provider, IResult? Error) NormalizeProvider(string provider)
+    {
+        if (string.IsNullOrWhiteSpace(provider))
+        {
+            return (null, Results.BadRequest(new { error = "invalid_provider" }));
+        }
+        var norm = provider.Trim().ToLowerInvariant();
+        if (!ProviderAllowlist.IsAllowedDefault(norm))
+        {
+            // Unknown provider — 404 (do not enumerate the allowlist).
+            return (null, Results.NotFound(new { error = "unknown_provider" }));
+        }
+        return (norm, null);
+    }
+
+    private static IResult? ValidateKey(string? apiKey)
+    {
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            return Results.BadRequest(new { error = "invalid_key", detail = "apiKey is required." });
+        }
+        if (apiKey.Length is < MinKeyLength or > MaxKeyLength)
+        {
+            return Results.BadRequest(new
+            {
+                error = "invalid_key",
+                detail = $"apiKey must be between {MinKeyLength} and {MaxKeyLength} chars.",
+            });
+        }
+        return null;
+    }
+
+    private static bool IsDuplicate(Exception ex) =>
+        ex is InvalidOperationException
+        || (ex.InnerException is not null && ex.InnerException is Npgsql.PostgresException pg
+            && pg.SqlState == "23505")
+        || ex is Microsoft.EntityFrameworkCore.DbUpdateException due
+            && due.InnerException is Npgsql.PostgresException ipg && ipg.SqlState == "23505";
+}
+
+/// <summary>Request body for register / rotate. Key is write-only; never echoed.</summary>
+public sealed record SetProviderCredentialRequest(string? ApiKey);
+
+/// <summary>
+/// Reveal-once response for register / rotate. Carries the token + metadata —
+/// NEVER the raw key (Story 32-3 AC5/AC7).
+/// </summary>
+public sealed record SetProviderCredentialResponse(
+    string Provider, int Version, string RevealToken, DateTimeOffset ExpiresAt);
+
+/// <summary>Metadata-only list item (NO key).</summary>
+public sealed record ProviderCredentialMetadata(
+    string Provider, int Version, DateTimeOffset? LastRotatedAt, DateTimeOffset UpdatedAt);

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/AgentResolverServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/AgentResolverServiceCollectionExtensions.cs
@@ -1,5 +1,8 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Tamma.Api.Services.Agents;
+using Tamma.Data.Repositories;
 
 namespace Tamma.Api.Extensions;
 
@@ -14,13 +17,28 @@ namespace Tamma.Api.Extensions;
 public static class AgentResolverServiceCollectionExtensions
 {
     /// <summary>
-    /// Register <see cref="IAgentResolverService"/> and its default
-    /// implementation. The underlying <c>IAgentConfigRepository</c> is
-    /// expected to be registered by <c>Tamma.Data.DependencyInjection</c>.
+    /// Register <see cref="IAgentResolverService"/> + the Story 32-2
+    /// <see cref="IAgentRegistryService"/>. The underlying repositories
+    /// (<c>IAgentConfigRepository</c>, <c>IAgentRepository</c>,
+    /// <c>IAgentSelectionRepository</c>, <c>IEventRepository</c>) are registered
+    /// by <c>Tamma.Data.DependencyInjection</c>; mode/tenant/http-context come
+    /// from <c>Program.cs</c>.
     /// </summary>
     public static IServiceCollection AddAgentResolverServices(this IServiceCollection services)
     {
-        services.AddScoped<IAgentResolverService, AgentResolverService>();
+        services.AddScoped<IAgentRegistryService, AgentRegistryService>();
+
+        // Use the Story 32-2 full constructor so the entity-aware resolve
+        // methods have their collaborators. The missing-config recorder is
+        // optional (the epic may not be merged) — resolved as null if unregistered.
+        services.AddScoped<IAgentResolverService>(sp => new AgentResolverService(
+            sp.GetRequiredService<IAgentConfigRepository>(),
+            sp.GetService<IConfiguration>(),
+            sp.GetRequiredService<ILogger<AgentResolverService>>(),
+            sp.GetRequiredService<IAgentRegistryService>(),
+            sp.GetRequiredService<IAgentRepository>(),
+            sp.GetRequiredService<IEventRepository>(),
+            sp.GetService<IMissingConfigRecorder>()));
         return services;
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/ProviderCredentialServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/ProviderCredentialServiceCollectionExtensions.cs
@@ -1,0 +1,75 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.LlmCall.Credentials;
+using Tamma.Activities.Security;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Services.Providers;
+using Tamma.Api.Services.Secrets.Postgres;
+using Tamma.Api.Services.Secrets.Stopgap;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Extensions;
+
+/// <summary>
+/// Story 32-3 — DI registration for the BYOK→platform provider-credential
+/// resolver, its cache invalidator, and the BYOK read seam. Only wires the
+/// cabinet-backed BYOK reader when the Story 29-2 <see cref="SecretsDbContext"/>
+/// factory is present (production / secrets-enabled tests); otherwise a Null
+/// reader is registered so the resolver degrades to the platform path without
+/// a DI-validation failure on hosts with no secret store.
+///
+/// <para>The <see cref="IProviderCredentialResolver"/> is a singleton so its
+/// in-process BYOK cache survives across requests (TTL + explicit invalidate
+/// keep it coherent). It depends on the singleton
+/// <see cref="Tamma.Api.Services.Secrets.Stopgap.IRuntimeSecretResolver"/>
+/// (platform key path) — resolved as optional so single-user / no-secrets
+/// hosts still build.</para>
+/// </summary>
+public static class ProviderCredentialServiceCollectionExtensions
+{
+    public static IServiceCollection AddProviderCredentialResolution(
+        this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        // Provider allowlist (shared with the activity's fail-closed guards).
+        services.TryAddSingleton<ProviderAllowlist>();
+
+        // Fallback policy (mode + config driven).
+        services.TryAddSingleton<IPlatformFallbackPolicy, ConfigPlatformFallbackPolicy>();
+
+        // BYOK read seam. Cabinet-backed when the secrets DbContext factory is
+        // wired; a Null reader otherwise so the resolver degrades cleanly.
+        if (services.Any(d => d.ServiceType
+                == typeof(IDbContextFactory<SecretsDbContext>)))
+        {
+            services.TryAddSingleton<ITenantProviderKeyReader, CabinetTenantProviderKeyReader>();
+        }
+        else
+        {
+            services.TryAddSingleton<ITenantProviderKeyReader, NullTenantProviderKeyReader>();
+        }
+
+        // The resolver — singleton so the BYOK cache is process-wide. Factory
+        // shape so IRuntimeSecretResolver (the platform-key leg) is OPTIONAL:
+        // single-user / no-secrets hosts may not have it registered, and the
+        // resolver tolerates null (degrading the platform leg to "unset").
+        services.TryAddSingleton<IProviderCredentialResolver>(sp =>
+            new DefaultProviderCredentialResolver(
+                sp.GetRequiredService<ITenantProviderKeyReader>(),
+                sp.GetService<IRuntimeSecretResolver>(),
+                sp.GetRequiredService<IPlatformFallbackPolicy>(),
+                sp.GetRequiredService<IEventRepository>(),
+                sp.GetRequiredService<ITammaModeProvider>(),
+                sp.GetRequiredService<ProviderAllowlist>(),
+                sp.GetRequiredService<ILogger<DefaultProviderCredentialResolver>>(),
+                sp.GetService<TimeProvider>()));
+
+        // Cache invalidator (SECRET.ROTATE.ACTIVATED handler + mutation hook).
+        services.TryAddSingleton<ProviderCredentialCacheInvalidator>();
+
+        return services;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -1767,6 +1767,9 @@ var agentsV2 = app.MapGroup("/api/agents")
     .RequireAuthorization("MemberAccess")
     .RequireRateLimiting("ConfigRead");
 // Reads
+// AC5 — optional ?role=&visibility=&status= query filters bind automatically
+// onto ListAgents' trailing string? params; they NARROW the visibility-scoped
+// set (never widen it). Unknown role/visibility/status → 400.
 agentsV2.MapGet("/", AgentEndpoints.ListAgents);
 agentsV2.MapGet("/resolve", AgentEndpoints.Resolve);
 agentsV2.MapGet("/role-selections", AgentEndpoints.GetRoleSelections);

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -451,6 +451,13 @@ if (!string.IsNullOrWhiteSpace(
     builder.Services.AddTammaSecretReveal(builder.Configuration);
 }
 
+// Story 32-3 — BYOK→platform provider-credential resolver + cache invalidator.
+// Registered AFTER the secrets wiring so the cabinet-backed BYOK reader is
+// chosen when the SecretsDbContext factory is present (else the Null reader
+// degrades cleanly to the platform path). The resolver is the canonical owner
+// of provider-key resolution into the LLM call path (CallLlmInlineActivity).
+builder.Services.AddProviderCredentialResolution();
+
 // Story 31-2: platform routing resolver. Exposes IPlatformResolver as a
 // scoped service over a singleton driver cache and the Epic 29 secret
 // store seam. Drivers themselves (GitHub 31-3, Gitea 31-4, ...) ship in
@@ -1755,6 +1762,18 @@ agents.MapGet("/{id:guid}/versions/{version:int}", AgentEndpoints.GetVersion);
 agents.MapPost("/{id:guid}/versions", AgentEndpoints.PublishVersion)
     .RequireAuthorization("AgentManage").RequireRateLimiting("ConfigWrite");
 agents.MapPost("/{id:guid}/archive", AgentEndpoints.ArchiveAgent)
+    .RequireAuthorization("AgentManage").RequireRateLimiting("ConfigWrite");
+
+// ── Story 32-3 — tenant-admin BYOK provider-credential management ──
+// GET list (metadata only) inherits the group's SettingsView gate; the
+// register/rotate/delete mutations are AgentManage (tenant_owner/tenant_admin →
+// member 403). Response bodies never carry the raw key (reveal-once token only).
+agents.MapGet("/providers", ProviderCredentialEndpoints.ListProviders);
+agents.MapPost("/providers/{provider}/credential", ProviderCredentialEndpoints.RegisterCredential)
+    .RequireAuthorization("AgentManage").RequireRateLimiting("ConfigWrite");
+agents.MapPost("/providers/{provider}/credential/rotate", ProviderCredentialEndpoints.RotateCredential)
+    .RequireAuthorization("AgentManage").RequireRateLimiting("ConfigWrite");
+agents.MapDelete("/providers/{provider}/credential", ProviderCredentialEndpoints.DeleteCredential)
     .RequireAuthorization("AgentManage").RequireRateLimiting("ConfigWrite");
 
 // ── Story 32-2 — entity-aware registry / resolution surface (/api/agents) ──

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -1757,6 +1757,34 @@ agents.MapPost("/{id:guid}/versions", AgentEndpoints.PublishVersion)
 agents.MapPost("/{id:guid}/archive", AgentEndpoints.ArchiveAgent)
     .RequireAuthorization("AgentManage").RequireRateLimiting("ConfigWrite");
 
+// ── Story 32-2 — entity-aware registry / resolution surface (/api/agents) ──
+// Distinct from the legacy /api/v1/agents group above (which stays byte-for-byte
+// working). Reads (list / get-one / resolve / role-selection reads) under
+// MemberAccess (any member); writes (create / version / archive / rollback /
+// role-selection upsert) under AgentManage (admin+owner → member 403). Public-
+// agent mutation is additionally gated in-handler by the platform-admin claim.
+var agentsV2 = app.MapGroup("/api/agents")
+    .RequireAuthorization("MemberAccess")
+    .RequireRateLimiting("ConfigRead");
+// Reads
+agentsV2.MapGet("/", AgentEndpoints.ListAgents);
+agentsV2.MapGet("/resolve", AgentEndpoints.Resolve);
+agentsV2.MapGet("/role-selections", AgentEndpoints.GetRoleSelections);
+agentsV2.MapGet("/{id:guid}", AgentEndpoints.GetAgent);
+agentsV2.MapGet("/{id:guid}/versions", AgentEndpoints.ListVersions);
+agentsV2.MapGet("/{id:guid}/versions/{version:int}", AgentEndpoints.GetVersion);
+// Writes
+agentsV2.MapPost("/", AgentEndpoints.CreateAgent)
+    .RequireAuthorization("AgentManage").RequireRateLimiting("ConfigWrite");
+agentsV2.MapPost("/{id:guid}/versions", AgentEndpoints.PublishVersion)
+    .RequireAuthorization("AgentManage").RequireRateLimiting("ConfigWrite");
+agentsV2.MapPost("/{id:guid}/archive", AgentEndpoints.ArchiveAgent)
+    .RequireAuthorization("AgentManage").RequireRateLimiting("ConfigWrite");
+agentsV2.MapPost("/{id:guid}/rollback", AgentEndpoints.RollbackVersion)
+    .RequireAuthorization("AgentManage").RequireRateLimiting("ConfigWrite");
+agentsV2.MapPut("/role-selections/{role}", AgentEndpoints.SelectForRole)
+    .RequireAuthorization("AgentManage").RequireRateLimiting("ConfigWrite");
+
 // ── Prompts ──
 // CLAUDE.md "Prompt Store Architecture > API" defines /defaults as the canonical
 // read-only system-default URL. Both /system (legacy TS naming) and /defaults
@@ -2060,7 +2088,7 @@ using (var scope = app.Services.CreateScope())
             dbContext.Database.ExecuteSqlRaw(@"
                 DROP TABLE IF EXISTS
                     admin_impersonations,
-                    agents, agent_versions,
+                    agents, agent_versions, agent_role_selections,
                     audit_records, audit_projector_cursor,
                     billing_customers, billing_plan_prices,
                     alert_delivery_attempts, alert_channels, alerts,

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentEventTypes.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentEventTypes.cs
@@ -1,0 +1,20 @@
+namespace Tamma.Api.Services.Agents;
+
+/// <summary>
+/// Story 32-2 — DCB event-type constants for the agent registry/resolution
+/// surface (pattern <c>AGGREGATE.ACTION.STATUS</c>, per CLAUDE.md "Event
+/// Types"). The lifecycle events (<c>CREATED</c>/<c>VERSION_PUBLISHED</c>/
+/// <c>ARCHIVED</c>) are emitted by <c>AgentRepository</c> (Story 32-1); 32-2
+/// adds the selection + resolve-failure events. Kept here as the single source
+/// so endpoint/service code never hand-types a literal that could drift from
+/// the audit/projector expectations.
+/// </summary>
+public static class AgentEventTypes
+{
+    /// <summary>A principal chose which agent serves a role.</summary>
+    public const string SelectedForRole = "AGENT.SELECTED_FOR_ROLE.SUCCESS";
+
+    /// <summary>No agent resolvable for a taxonomy-valid role — the fail-loud
+    /// branch (AC 9). Fires even when the missing-config recorder is absent.</summary>
+    public const string ResolveFailed = "AGENT.RESOLVE.FAILED";
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRegistryService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRegistryService.cs
@@ -1,0 +1,228 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Tamma.Api.Auth;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Core;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Agents;
+
+/// <summary>
+/// Default <see cref="IAgentRegistryService"/>. Layers selection + system-default
+/// resolution over the Story 32-1 <see cref="IAgentRepository"/> (CP-resident
+/// agent identities) and the dual-scoped <see cref="IAgentSelectionRepository"/>
+/// (CP for single-user, tenant schema for SaaS). The process mode
+/// (<see cref="ITammaModeProvider"/>) settles the principal: SaaS ⇒ ambient
+/// tenant id; single-user ⇒ the calling user id.
+/// </summary>
+public sealed class AgentRegistryService : IAgentRegistryService
+{
+    private const string WorkflowVersion = "1.0.0";
+
+    private readonly IAgentRepository _agents;
+    private readonly IAgentSelectionRepository _selections;
+    private readonly IEventRepository _events;
+    private readonly ITammaModeProvider _mode;
+    private readonly ITenantContext _tenantContext;
+    private readonly IHttpContextAccessor _httpContext;
+    private readonly ILogger<AgentRegistryService>? _logger;
+
+    public AgentRegistryService(
+        IAgentRepository agents,
+        IAgentSelectionRepository selections,
+        IEventRepository events,
+        ITammaModeProvider mode,
+        ITenantContext tenantContext,
+        IHttpContextAccessor httpContext,
+        ILogger<AgentRegistryService>? logger = null)
+    {
+        _agents = agents;
+        _selections = selections;
+        _events = events;
+        _mode = mode;
+        _tenantContext = tenantContext;
+        _httpContext = httpContext;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public (Guid? TenantId, Guid? UserId) ResolvePrincipal()
+        => _mode.Mode == TammaMode.SaaS
+            ? (_tenantContext.TenantId, (Guid?)null)
+            : ((Guid?)null, CurrentUserId());
+
+    /// <inheritdoc />
+    public async Task<Agent?> ResolveUsableAgentAsync(Guid agentId, CancellationToken ct = default)
+    {
+        var agent = await _agents.GetByIdAsync(agentId, ct);
+        if (agent is null)
+        {
+            return null;
+        }
+        return CanUse(agent) ? agent : null;
+    }
+
+    /// <inheritdoc />
+    public async Task<Agent?> GetSystemDefaultPublicAsync(string role, CancellationToken ct = default)
+    {
+        // The system default for a role is the shipped public agent whose Role
+        // matches (one per role from AgentEntitySeeder, handle "tamma-<role>").
+        // Public agents are visible to every principal; pass null scope.
+        var visible = await _agents.ListVisibleAsync(tenantId: null, userId: null, ct);
+        return visible.FirstOrDefault(a =>
+            a.Visibility == AgentVisibility.Public &&
+            a.Status == AgentStatus.Active &&
+            string.Equals(a.Role, role, StringComparison.Ordinal));
+    }
+
+    /// <inheritdoc />
+    public async Task<AgentRoleSelection> SelectForRoleAsync(
+        string role, Guid agentId, Guid? actingUserId, CancellationToken ct = default)
+    {
+        // Target must be in (public ∪ own private). A cross-scope private target
+        // (or a non-existent id) is "not found" — never selectable, never leaked.
+        var agent = await ResolveUsableAgentAsync(agentId, ct);
+        if (agent is null)
+        {
+            throw new TammaError(
+                "AGENT.SELECT.NOT_FOUND",
+                $"Agent '{agentId}' is not selectable for role '{role}' (not public and not owned by the caller).",
+                new Dictionary<string, object?> { ["agentId"] = agentId, ["role"] = role },
+                retryable: false,
+                severity: TammaErrorSeverity.Medium);
+        }
+
+        var visibility = ProvenanceFor(agent);
+        var (tenantId, userId) = ResolvePrincipal();
+
+        AgentRoleSelection saved;
+        bool wasCreated;
+        if (_mode.Mode == TammaMode.SaaS)
+        {
+            if (tenantId is not Guid tid)
+            {
+                throw new TammaError(
+                    "AGENT.SELECT.NO_TENANT",
+                    "A role selection in SaaS mode requires tenant context.",
+                    severity: TammaErrorSeverity.Medium);
+            }
+            (saved, wasCreated) = await _selections.UpsertByTenantAsync(
+                tid, role, agentId, visibility, actingUserId, ct);
+        }
+        else
+        {
+            if (userId is not Guid uid)
+            {
+                throw new TammaError(
+                    "AGENT.SELECT.NO_USER",
+                    "A role selection in single-user mode requires a user id.",
+                    severity: TammaErrorSeverity.Medium);
+            }
+            (saved, wasCreated) = await _selections.UpsertByUserAsync(
+                uid, role, agentId, visibility, actingUserId, ct);
+        }
+
+        _logger?.LogInformation(
+            "agent.selected_for_role role={Role} agentId={AgentId} source={Source} created={Created}",
+            role, agentId, visibility, wasCreated);
+
+        await AppendSelectionEventAsync(saved, visibility, ct);
+        return saved;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyDictionary<string, AgentRoleSelection>> GetRoleSelectionsAsync(
+        CancellationToken ct = default)
+    {
+        var (tenantId, userId) = ResolvePrincipal();
+        IReadOnlyList<AgentRoleSelection> rows;
+        if (_mode.Mode == TammaMode.SaaS)
+        {
+            rows = tenantId is Guid tid
+                ? await _selections.ListByTenantAsync(tid, ct)
+                : Array.Empty<AgentRoleSelection>();
+        }
+        else
+        {
+            rows = userId is Guid uid
+                ? await _selections.ListByUserAsync(uid, ct)
+                : Array.Empty<AgentRoleSelection>();
+        }
+
+        // One selection per (principal, role) by the unique index — but defend
+        // against a duplicate by taking the most recent.
+        return rows
+            .GroupBy(r => r.Role, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.OrderByDescending(r => r.UpdatedAt).First(),
+                StringComparer.Ordinal);
+    }
+
+    // ── helpers ──
+
+    private Guid? CurrentUserId()
+        => _httpContext.HttpContext?.User?.GetUserId();
+
+    /// <summary>
+    /// True if the calling principal may USE the agent: any public agent, or a
+    /// private agent owned by the caller's scope.
+    /// </summary>
+    private bool CanUse(Agent agent)
+    {
+        if (agent.Visibility == AgentVisibility.Public)
+        {
+            return true;
+        }
+        var (tenantId, userId) = ResolvePrincipal();
+        return (tenantId is not null && agent.OwnerTenantId == tenantId) ||
+               (userId is not null && agent.OwnerUserId == userId);
+    }
+
+    /// <summary>
+    /// Recompute provenance at resolve/select time — never trust a stored hint.
+    /// A public agent ⇒ <c>system-public</c>; an own-private agent ⇒
+    /// <c>tenant-private</c>. (<c>tenant-public</c> is the wire term for a
+    /// principal SELECTING a public agent; the resolver stamps that variant.)
+    /// </summary>
+    private string ProvenanceFor(Agent agent)
+        => agent.Visibility == AgentVisibility.Public ? "system-public" : "tenant-private";
+
+    private async Task AppendSelectionEventAsync(
+        AgentRoleSelection sel, string source, CancellationToken ct)
+    {
+        _ = ct;
+        var mode = _mode.Mode == TammaMode.SaaS ? "saas" : "single-user";
+        var tags = new Dictionary<string, object?>
+        {
+            ["agentId"] = sel.AgentId.ToString(),
+            ["role"] = sel.Role,
+            ["source"] = source,
+            ["mode"] = mode,
+        };
+        if (sel.TenantId is Guid tid) tags["tenantId"] = tid.ToString();
+        if (sel.UserId is Guid uid) tags["userId"] = uid.ToString();
+
+        await _events.AppendAsync(new DomainEvent
+        {
+            Id = Guid.NewGuid(),
+            Type = AgentEventTypes.SelectedForRole,
+            // SaaS selection events land in the tenant store (ambient TenantId);
+            // single-user selection is a platform-feed row (TenantId null).
+            TenantId = sel.TenantId,
+            Tags = JsonSerializer.Serialize(tags),
+            Metadata = JsonSerializer.Serialize(new
+            {
+                workflowVersion = WorkflowVersion,
+                eventSource = "system",
+            }),
+            Data = JsonSerializer.Serialize(new Dictionary<string, object?>
+            {
+                ["role"] = sel.Role,
+                ["agentId"] = sel.AgentId.ToString(),
+            }),
+            CreatedAt = DateTime.UtcNow,
+        });
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRegistryService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRegistryService.cs
@@ -72,10 +72,34 @@ public sealed class AgentRegistryService : IAgentRegistryService
         // matches (one per role from AgentEntitySeeder, handle "tamma-<role>").
         // Public agents are visible to every principal; pass null scope.
         var visible = await _agents.ListVisibleAsync(tenantId: null, userId: null, ct);
-        return visible.FirstOrDefault(a =>
-            a.Visibility == AgentVisibility.Public &&
-            a.Status == AgentStatus.Active &&
-            string.Equals(a.Role, role, StringComparison.Ordinal));
+        var candidates = visible
+            .Where(a =>
+                a.Visibility == AgentVisibility.Public &&
+                a.Status == AgentStatus.Active &&
+                string.Equals(a.Role, role, StringComparison.Ordinal))
+            .OrderBy(a => a.Name, StringComparer.Ordinal)
+            .ToList();
+
+        var chosen = candidates.FirstOrDefault();
+        if (candidates.Count > 1)
+        {
+            // The seeder ships exactly one tamma-<role> public agent, so this is
+            // unambiguous today. A platform owner adding a second public agent
+            // for the same role would silently shift the default — make the
+            // ambiguity observable rather than picking blind.
+            _logger?.LogWarning(
+                "agent.system_default.ambiguous role={Role} count={Count} chosenAgentId={ChosenAgentId} — "
+                + "more than one active public agent matches this role; picked the first by name (ordinal)",
+                role, candidates.Count, chosen?.Id);
+        }
+        else if (chosen is not null)
+        {
+            _logger?.LogDebug(
+                "agent.system_default.chosen role={Role} chosenAgentId={ChosenAgentId}",
+                role, chosen.Id);
+        }
+
+        return chosen;
     }
 
     /// <inheritdoc />
@@ -181,13 +205,15 @@ public sealed class AgentRegistryService : IAgentRegistryService
     }
 
     /// <summary>
-    /// Recompute provenance at resolve/select time — never trust a stored hint.
-    /// A public agent ⇒ <c>system-public</c>; an own-private agent ⇒
-    /// <c>tenant-private</c>. (<c>tenant-public</c> is the wire term for a
-    /// principal SELECTING a public agent; the resolver stamps that variant.)
+    /// Provenance hint stored on a role selection. Must match the source the
+    /// resolver (<c>AgentResolverService</c>) stamps for that same selection so
+    /// the two read surfaces agree: a principal SELECTING a public agent ⇒
+    /// <c>tenant-public</c> (NOT <c>system-public</c> — that label is reserved
+    /// for the system-default fallback, which is not a selection); an own-private
+    /// agent ⇒ <c>tenant-private</c>.
     /// </summary>
     private string ProvenanceFor(Agent agent)
-        => agent.Visibility == AgentVisibility.Public ? "system-public" : "tenant-private";
+        => agent.Visibility == AgentVisibility.Public ? "tenant-public" : "tenant-private";
 
     private async Task AppendSelectionEventAsync(
         AgentRoleSelection sel, string source, CancellationToken ct)

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentResolverService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentResolverService.cs
@@ -2,6 +2,8 @@ using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Tamma.Api.Dtos.Agents;
+using Tamma.Core;
+using Tamma.Data.Entities;
 using Tamma.Data.Repositories;
 
 namespace Tamma.Api.Services.Agents;
@@ -13,12 +15,26 @@ namespace Tamma.Api.Services.Agents;
 /// Port of <c>RoleBasedAgentResolver</c> from the deleted TS providers
 /// package (Story 9-8), plus the 3-level config merge from
 /// <c>ConfigService.ts</c> (Epic 19 Phase 3 deletion).
+///
+/// <para>Story 32-2 adds the entity-aware resolve methods
+/// (<see cref="ResolveForRoleAsync"/> / <see cref="ResolveForRoleAndPhaseAsync"/>)
+/// over the Story 32-1 agent entities. The legacy JSONB path
+/// (<see cref="ResolveAsync"/> + <see cref="ResolveForPhaseAsync"/>) is
+/// UNTOUCHED — the registry/agent collaborators are optional so the legacy
+/// constructors (and their tests) keep compiling and running.</para>
 /// </summary>
 public sealed class AgentResolverService : IAgentResolverService
 {
     private readonly IAgentConfigRepository _repo;
     private readonly IConfiguration? _configuration;
     private readonly ILogger<AgentResolverService> _logger;
+
+    // Story 32-2 — entity-aware resolution collaborators. Null on the legacy
+    // constructors (the JSONB path never touches them).
+    private readonly IAgentRegistryService? _registry;
+    private readonly IAgentRepository? _agents;
+    private readonly IEventRepository? _events;
+    private readonly IMissingConfigRecorder? _missingConfig;
 
     public AgentResolverService(
         IAgentConfigRepository repo,
@@ -33,6 +49,26 @@ public sealed class AgentResolverService : IAgentResolverService
         _repo = repo;
         _configuration = configuration;
         _logger = logger;
+    }
+
+    /// <summary>
+    /// Story 32-2 — full constructor wiring the entity-aware resolution chain.
+    /// The missing-config recorder is optional (the epic may not be merged).
+    /// </summary>
+    public AgentResolverService(
+        IAgentConfigRepository repo,
+        IConfiguration? configuration,
+        ILogger<AgentResolverService> logger,
+        IAgentRegistryService registry,
+        IAgentRepository agents,
+        IEventRepository events,
+        IMissingConfigRecorder? missingConfig = null)
+        : this(repo, configuration, logger)
+    {
+        _registry = registry;
+        _agents = agents;
+        _events = events;
+        _missingConfig = missingConfig;
     }
 
     // -----------------------------------------------------------------------
@@ -185,6 +221,232 @@ public sealed class AgentResolverService : IAgentResolverService
             PermissionMode = clampedPermissionMode,
             AllowedTools = clampedTools,
         };
+    }
+
+    // -----------------------------------------------------------------------
+    // Story 32-2 — entity-aware resolution chain
+    // -----------------------------------------------------------------------
+
+    /// <inheritdoc />
+    public async Task<ResolvedAgentConfig> ResolveForRoleAsync(
+        string role, CancellationToken ct = default)
+        => await ResolveEntityAsync(role, phase: null, ct);
+
+    /// <inheritdoc />
+    public async Task<ResolvedAgentConfig> ResolveForRoleAndPhaseAsync(
+        string phase, string role, CancellationToken ct = default)
+    {
+        phase = RolePhaseMap.NormalizePhase(phase);
+        role = RolePhaseMap.NormalizeRole(role);
+        RolePhaseMap.AssertValidPhase(phase);
+        RolePhaseMap.AssertValidRole(role);
+
+        if (!RolePhaseMap.IsRoleEligibleForPhase(phase, role))
+        {
+            throw new ArgumentException(
+                $"Role '{role}' is not eligible for phase '{phase}'. Eligible roles: " +
+                string.Join(", ", RolePhaseMap.GetEligibleRolesForPhase(phase)) + ".",
+                nameof(role));
+        }
+
+        return await ResolveEntityAsync(role, phase, ct);
+    }
+
+    /// <summary>
+    /// The 4-branch precedence chain (AC 3). NEVER returns an empty/plain
+    /// config: the 4th branch emits <c>AGENT.RESOLVE.FAILED</c>, best-effort
+    /// records a <c>MISSING_CONFIG</c> gap, then throws.
+    /// </summary>
+    private async Task<ResolvedAgentConfig> ResolveEntityAsync(
+        string role, string? phase, CancellationToken ct)
+    {
+        role = RolePhaseMap.NormalizeRole(role);
+        RolePhaseMap.AssertValidRole(role);
+
+        if (_registry is null || _agents is null || _events is null)
+        {
+            throw new InvalidOperationException(
+                "Entity-aware agent resolution requires the Story 32-2 collaborators "
+                + "(IAgentRegistryService / IAgentRepository / IEventRepository). Use the "
+                + "full AgentResolverService constructor.");
+        }
+
+        // Branches 1+2: the principal's selection (private OR public target).
+        var selections = await _registry.GetRoleSelectionsAsync(ct);
+        if (selections.TryGetValue(role, out var sel))
+        {
+            // Recompute provenance at resolve time — a stale/archived/cross-scope
+            // target degrades to the system default rather than resolving stale.
+            var selected = await _registry.ResolveUsableAgentAsync(sel.AgentId, ct);
+            if (selected is { Status: AgentStatus.Active })
+            {
+                var source = selected.Visibility == AgentVisibility.Public
+                    ? "tenant-public"   // principal SELECTED a public agent
+                    : "tenant-private"; // principal's own private agent
+                var materialised = await MaterialiseAsync(selected, role, phase, source, ct);
+                if (materialised is not null)
+                {
+                    _logger.LogDebug(
+                        "agent.resolve.selection role={Role} agentId={AgentId} source={Source}",
+                        role, selected.Id, source);
+                    return materialised;
+                }
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "agent.resolve.stale_selection role={Role} staleAgentId={StaleAgentId} — degrading to system default",
+                    role, sel.AgentId);
+            }
+        }
+
+        // Branch 3: system-default public agent for the role.
+        var systemDefault = await _registry.GetSystemDefaultPublicAsync(role, ct);
+        if (systemDefault is not null)
+        {
+            var materialised = await MaterialiseAsync(systemDefault, role, phase, "system-public", ct);
+            if (materialised is not null)
+            {
+                _logger.LogDebug(
+                    "agent.resolve.system_default role={Role} agentId={AgentId}",
+                    role, systemDefault.Id);
+                return materialised;
+            }
+        }
+
+        // Branch 4: NO empty/plain fallback — fail loud.
+        await FailLoudAsync(role, phase, ct);
+        // Unreachable — FailLoudAsync always throws.
+        throw new InvalidOperationException("unreachable");
+    }
+
+    /// <summary>
+    /// Materialise an agent's ACTIVE version config into a
+    /// <see cref="ResolvedAgentConfig"/>, reusing the legacy merge + validation
+    /// so <c>CallLlmActivity</c> sees the same shape. The agent's saved-config
+    /// JSON is treated as an override on top of the role's platform default;
+    /// <see cref="ResolvedAgentConfig.AgentId"/>/<c>AgentVersion</c>/<c>Source</c>
+    /// are stamped. Returns <c>null</c> if the agent has no active version (so
+    /// the caller can degrade to the next branch).
+    /// </summary>
+    private async Task<ResolvedAgentConfig?> MaterialiseAsync(
+        Agent agent, string role, string? phase, string source, CancellationToken ct)
+    {
+        var version = await _agents!.GetActiveVersionAsync(agent.Id, ct);
+        if (version is null)
+        {
+            return null;
+        }
+
+        var resolved = DefaultAgentConfig.ForRole(role);
+
+        try
+        {
+            using var doc = JsonDocument.Parse(version.ConfigJson);
+            if (doc.RootElement.ValueKind == JsonValueKind.Object)
+            {
+                resolved = MergeOverride(resolved, doc.RootElement);
+            }
+        }
+        catch (JsonException)
+        {
+            // A corrupt snapshot is a real fault — fall through to validation,
+            // which fails loud on the (now-default) required fields if needed.
+        }
+
+        // The agent's stable handle wins over the merged handle (identity).
+        var enriched = new ResolvedAgentConfig
+        {
+            Role = role,
+            Handle = string.IsNullOrWhiteSpace(agent.Name) ? resolved.Handle : agent.Name,
+            Provider = resolved.Provider,
+            Model = resolved.Model,
+            Temperature = resolved.Temperature,
+            MaxTokens = resolved.MaxTokens,
+            TokenBudget = resolved.TokenBudget,
+            Tools = resolved.Tools,
+            SystemPrompt = resolved.SystemPrompt,
+            Source = source,
+            Phase = phase,
+            MaxBudgetUsd = resolved.MaxBudgetUsd,
+            PermissionMode = resolved.PermissionMode,
+            AllowedTools = resolved.AllowedTools,
+            AgentId = agent.Id,
+            AgentVersion = version.Version,
+        };
+
+        ValidateResolved(enriched);
+        return enriched;
+    }
+
+    /// <summary>
+    /// AC 9 — the no-empty-fallback path. Emits <c>AGENT.RESOLVE.FAILED</c>
+    /// (mandatory), best-effort records a <c>MISSING_CONFIG</c> gap (optional),
+    /// then throws <see cref="TammaError"/>. Mirrors
+    /// <c>PromptStoreService.NoPromptError</c> / <c>ConventionStore</c>.
+    /// </summary>
+    private async Task FailLoudAsync(string role, string? phase, CancellationToken ct)
+    {
+        var (tenantId, _) = _registry!.ResolvePrincipal();
+        var tags = new Dictionary<string, object?>
+        {
+            ["role"] = role,
+            ["phase"] = phase,
+            ["source"] = "none",
+            ["mode"] = tenantId is not null ? "saas" : "single-user",
+        };
+
+        await _events!.AppendAsync(new DomainEvent
+        {
+            Id = Guid.NewGuid(),
+            Type = AgentEventTypes.ResolveFailed,
+            // A missing SYSTEM default is platform-scope (TenantId null); a
+            // tenant-scope resolve carries the ambient tenant.
+            TenantId = tenantId,
+            Tags = JsonSerializer.Serialize(tags),
+            Metadata = JsonSerializer.Serialize(new
+            {
+                workflowVersion = "1.0.0",
+                eventSource = "system",
+            }),
+            Data = JsonSerializer.Serialize(new Dictionary<string, object?>
+            {
+                ["role"] = role,
+                ["phase"] = phase,
+            }),
+            CreatedAt = DateTime.UtcNow,
+        });
+
+        if (_missingConfig is not null)
+        {
+            try
+            {
+                await _missingConfig.RecordAsync(
+                    domain: "agent",
+                    configKey: $"role:{role}",
+                    scope: "system",
+                    context: new Dictionary<string, object?> { ["role"] = role, ["phase"] = phase },
+                    ct);
+            }
+            catch (Exception ex)
+            {
+                // Best-effort — a recorder failure must not mask the TammaError.
+                _logger.LogWarning(ex,
+                    "agent.resolve.missing_config_record_failed role={Role}", role);
+            }
+        }
+
+        _logger.LogError(
+            "AGENT.RESOLVE.FAILED role={Role} phase={Phase} — no agent resolvable", role, phase);
+
+        throw new TammaError(
+            "AGENT.RESOLVE.NO_DEFAULT",
+            $"No agent resolvable for role '{role}': no selection and no system-default public agent. "
+            + "Resolution is private-selection → public-selection → system-default → error; "
+            + "there is no empty/plain fallback.",
+            new Dictionary<string, object?> { ["role"] = role, ["phase"] = phase },
+            retryable: false,
+            severity: TammaErrorSeverity.High);
     }
 
     // -----------------------------------------------------------------------

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/IAgentRegistryService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/IAgentRegistryService.cs
@@ -1,0 +1,58 @@
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Agents;
+
+/// <summary>
+/// Story 32-2 — the entity-aware agent registry seam over the Story 32-1
+/// <see cref="Data.Repositories.IAgentRepository"/>. Owns:
+/// <list type="bullet">
+///   <item>resolving the calling principal's scope from the process mode
+///     (SaaS ⇒ tenant id; single-user ⇒ user id);</item>
+///   <item>visibility-scoped membership checks — is a target agent in
+///     (public ∪ own private)? — for selection validation;</item>
+///   <item>per-principal role→agent selection persistence (emits
+///     <c>AGENT.SELECTED_FOR_ROLE.SUCCESS</c>);</item>
+///   <item>resolving the SYSTEM-DEFAULT public agent for a role (the shipped
+///     <c>tamma-&lt;role&gt;</c> public agent — Story 32-1 seeder).</item>
+/// </list>
+/// CRUD (create/version/archive/get/list) flows through the existing
+/// <see cref="Data.Repositories.IAgentRepository"/>; this service is the
+/// resolution/selection layer 32-2 adds. Provider credentials are NEVER
+/// resolved here (that is Story 32-3) — agent configs stay credential-agnostic.
+/// </summary>
+public interface IAgentRegistryService
+{
+    /// <summary>The calling principal derived from the process mode: SaaS ⇒
+    /// (tenantId, null); single-user ⇒ (null, userId).</summary>
+    (Guid? TenantId, Guid? UserId) ResolvePrincipal();
+
+    /// <summary>
+    /// Resolve an agent the caller may USE: a public agent (any), or a private
+    /// agent owned by the caller's scope. Returns <c>null</c> for a
+    /// non-existent id OR a cross-scope private id (caller can't see it) — the
+    /// endpoint maps null → 404 to avoid an existence leak.
+    /// </summary>
+    Task<Agent?> ResolveUsableAgentAsync(Guid agentId, CancellationToken ct = default);
+
+    /// <summary>
+    /// The system-default public agent for a role: the active, public agent
+    /// whose <see cref="Agent.Role"/> matches (the <c>tamma-&lt;role&gt;</c>
+    /// shipped seed). Returns <c>null</c> when none is seeded — the resolver's
+    /// fail-loud branch (AC 9) then fires.
+    /// </summary>
+    Task<Agent?> GetSystemDefaultPublicAsync(string role, CancellationToken ct = default);
+
+    /// <summary>
+    /// Persist which agent serves <paramref name="role"/> for the calling
+    /// principal. Validates the target is in (public ∪ own private); a
+    /// cross-scope/non-existent target throws
+    /// <see cref="Tamma.Core.TammaError"/> <c>AGENT.SELECT.NOT_FOUND</c> (mapped
+    /// to 404). Emits <c>AGENT.SELECTED_FOR_ROLE.SUCCESS</c> on a real upsert.
+    /// </summary>
+    Task<AgentRoleSelection> SelectForRoleAsync(
+        string role, Guid agentId, Guid? actingUserId, CancellationToken ct = default);
+
+    /// <summary>The principal's current role→selection map (role ⇒ selection).</summary>
+    Task<IReadOnlyDictionary<string, AgentRoleSelection>> GetRoleSelectionsAsync(
+        CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/IAgentResolverService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/IAgentResolverService.cs
@@ -54,4 +54,35 @@ public interface IAgentResolverService
     Task<ResolvedAgentConfig> ResolveForPhaseAsync(
         Guid? tenantId, string phase, string role,
         Dtos.Agents.TaskOverrides? overrides);
+
+    /// <summary>
+    /// Story 32-2 — resolve the EFFECTIVE first-class agent for the calling
+    /// principal + <paramref name="role"/> via the deterministic precedence
+    /// chain (private selection → public selection → system-default public →
+    /// FAIL LOUD). Returns an enriched <see cref="ResolvedAgentConfig"/> carrying
+    /// <see cref="ResolvedAgentConfig.AgentId"/>,
+    /// <see cref="ResolvedAgentConfig.AgentVersion"/> and an extended
+    /// <see cref="ResolvedAgentConfig.Source"/> (<c>tenant-private</c> /
+    /// <c>tenant-public</c> / <c>system-public</c>).
+    ///
+    /// <para><b>Never returns a blank/empty config.</b> The fourth branch emits
+    /// <c>AGENT.RESOLVE.FAILED</c>, best-effort records a <c>MISSING_CONFIG</c>
+    /// gap, then throws <see cref="Tamma.Core.TammaError"/>
+    /// <c>AGENT.RESOLVE.NO_DEFAULT</c> (severity High) — mirroring the
+    /// prompt/convention fail-loud rule.</para>
+    /// </summary>
+    /// <exception cref="ArgumentException">Unknown role.</exception>
+    /// <exception cref="Tamma.Core.TammaError">No agent resolvable
+    /// (<c>AGENT.RESOLVE.NO_DEFAULT</c>).</exception>
+    Task<ResolvedAgentConfig> ResolveForRoleAsync(string role, CancellationToken ct = default);
+
+    /// <summary>
+    /// Story 32-2 — same precedence chain as <see cref="ResolveForRoleAsync"/>
+    /// plus phase-eligibility validation
+    /// (<see cref="RolePhaseMap.IsRoleEligibleForPhase"/>). Unknown phase or an
+    /// ineligible (phase, role) pair throws <see cref="ArgumentException"/>
+    /// before any resolution attempt.
+    /// </summary>
+    Task<ResolvedAgentConfig> ResolveForRoleAndPhaseAsync(
+        string phase, string role, CancellationToken ct = default);
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/IMissingConfigRecorder.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/IMissingConfigRecorder.cs
@@ -1,0 +1,29 @@
+namespace Tamma.Api.Services.Agents;
+
+/// <summary>
+/// Story 32-2 — soft-dependency seam for the Missing-Config Notifications epic
+/// (not yet merged). When a taxonomy-valid role resolves past every precedence
+/// branch with no system default (AC 9), the resolver best-effort records a
+/// <c>MISSING_CONFIG</c> gap so the future notifications pipeline can surface it.
+///
+/// <para><b>Injected OPTIONALLY</b> (<c>IMissingConfigRecorder?</c>): no default
+/// registration ships in this story, so the constructor receives <c>null</c> and
+/// the gap record is skipped. The mandatory side of the fail-loud path — the
+/// <c>AGENT.RESOLVE.FAILED</c> DCB event PLUS the <c>TammaError</c> throw — fires
+/// regardless. When the Missing-Config epic lands it registers an implementation
+/// and the gap record begins flowing with zero changes here.</para>
+/// </summary>
+public interface IMissingConfigRecorder
+{
+    /// <summary>
+    /// Record a missing-config gap. <paramref name="domain"/> is the feature
+    /// area (<c>"agent"</c>), <paramref name="configKey"/> the specific missing
+    /// key (<c>"role:{role}"</c>), <paramref name="scope"/> the owner scope
+    /// (<c>"system"</c> for a missing system default). Best-effort — a recorder
+    /// failure must never mask the originating <c>TammaError</c>.
+    /// </summary>
+    Task RecordAsync(
+        string domain, string configKey, string scope,
+        IReadOnlyDictionary<string, object?>? context = null,
+        CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/ResolvedAgentConfig.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/ResolvedAgentConfig.cs
@@ -37,8 +37,27 @@ public class ResolvedAgentConfig
     /// <summary>System prompt / role identity preamble.</summary>
     public string SystemPrompt { get; init; } = string.Empty;
 
-    /// <summary>Provenance: "platform-default" or "tenant-override".</summary>
+    /// <summary>
+    /// Provenance. Legacy JSONB path: <c>"platform-default"</c> |
+    /// <c>"tenant-override"</c>. Story 32-2 entity-aware path extends the value
+    /// set with <c>"tenant-private"</c> | <c>"tenant-public"</c> |
+    /// <c>"system-public"</c> (which agent in the precedence chain produced the
+    /// config). Both legacy values remain valid.
+    /// </summary>
     public string Source { get; init; } = "platform-default";
+
+    /// <summary>
+    /// Story 32-2 — stable identity of the agent that produced this config.
+    /// Null only on the legacy JSONB path (backward compatibility) — the
+    /// entity-aware resolve methods always stamp it.
+    /// </summary>
+    public Guid? AgentId { get; init; }
+
+    /// <summary>
+    /// Story 32-2 — the pinned/active config version of the resolved agent.
+    /// Null only on the legacy JSONB path.
+    /// </summary>
+    public int? AgentVersion { get; init; }
 
     /// <summary>Optional phase context (set by <see cref="IAgentResolverService.ResolveForPhaseAsync"/>).</summary>
     public string? Phase { get; init; }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Providers/CabinetTenantProviderKeyReader.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Providers/CabinetTenantProviderKeyReader.cs
@@ -1,0 +1,93 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Tamma.Api.Services.Secrets;
+using Tamma.Api.Services.Secrets.Postgres;
+
+namespace Tamma.Api.Services.Providers;
+
+/// <summary>
+/// Cabinet-backed <see cref="ITenantProviderKeyReader"/> (Story 32-3 AC5).
+/// The tenant-scoped sibling of
+/// <c>Tamma.Api.Services.Secrets.Stopgap.RuntimeSecretResolver.TryReadCabinetAsync</c>:
+/// queries <see cref="SecretsDbContext"/> for a <c>Scope == "tenant"</c> row
+/// with the caller's <c>TenantId</c> and the provider's cabinet name, then
+/// reads the active version's plaintext via
+/// <see cref="ISecretStoreBackend.GetVersionPlaintextAsync"/>.
+///
+/// <para>Tenant isolation (AC11): the EF predicate pins
+/// <c>TenantId == tenantId</c>, so a BYOK row belonging to another tenant can
+/// never be returned for this caller.</para>
+///
+/// <para>Cabinet probe failures degrade to a null result (logged WARN) so the
+/// resolver treats them as "BYOK absent" and proceeds to the platform
+/// fallback — never leaking the failure as a 500 and never substituting a
+/// wrong key.</para>
+/// </summary>
+public sealed class CabinetTenantProviderKeyReader : ITenantProviderKeyReader
+{
+    private readonly IDbContextFactory<SecretsDbContext> _secretsFactory;
+    private readonly ISecretStoreBackend _backend;
+    private readonly ILogger<CabinetTenantProviderKeyReader> _logger;
+
+    public CabinetTenantProviderKeyReader(
+        IDbContextFactory<SecretsDbContext> secretsFactory,
+        ISecretStoreBackend backend,
+        ILogger<CabinetTenantProviderKeyReader> logger)
+    {
+        ArgumentNullException.ThrowIfNull(secretsFactory);
+        ArgumentNullException.ThrowIfNull(backend);
+        ArgumentNullException.ThrowIfNull(logger);
+        _secretsFactory = secretsFactory;
+        _backend = backend;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<TenantProviderKey?> TryReadAsync(
+        Guid tenantId, string cabinetName, CancellationToken ct = default)
+    {
+        try
+        {
+            await using var ctx = await _secretsFactory
+                .CreateDbContextAsync(ct).ConfigureAwait(false);
+
+            var row = await ctx.Secrets
+                .AsNoTracking()
+                .FirstOrDefaultAsync(
+                    s => s.Name == cabinetName
+                         && s.Scope == "tenant"
+                         && s.TenantId == tenantId,
+                    ct)
+                .ConfigureAwait(false);
+
+            if (row is null || row.ActiveVersionNumber <= 0)
+            {
+                return null;
+            }
+
+            var plaintext = await _backend
+                .GetVersionPlaintextAsync(row.Id, row.ActiveVersionNumber, ct)
+                .ConfigureAwait(false);
+
+            if (string.IsNullOrWhiteSpace(plaintext))
+            {
+                return null;
+            }
+
+            return new TenantProviderKey(plaintext, row.ActiveVersionNumber);
+        }
+        catch (KeyNotFoundException)
+        {
+            return null;
+        }
+        catch (Exception ex)
+        {
+            // Degrade-to-absent — never leak the probe failure or any bytes.
+            _logger.LogWarning(ex,
+                "BYOK cabinet probe for tenant {TenantId} secret {CabinetName} " +
+                "threw; treating as BYOK-absent and falling through to platform " +
+                "fallback.", tenantId, cabinetName);
+            return null;
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Providers/ConfigPlatformFallbackPolicy.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Providers/ConfigPlatformFallbackPolicy.cs
@@ -1,0 +1,73 @@
+using Microsoft.Extensions.Configuration;
+using Tamma.Activities.LlmCall.Credentials;
+using Tamma.Api.Services.PromptStore;
+
+namespace Tamma.Api.Services.Providers;
+
+/// <summary>
+/// v1 <see cref="IPlatformFallbackPolicy"/> (Story 32-3 AC6.1).
+///
+/// <list type="bullet">
+///   <item><description><b>single-user</b> ⇒ always allowed (the sole user
+///     owns everything; falling back to the local platform/env key is the
+///     expected behaviour).</description></item>
+///   <item><description><b>SaaS</b> ⇒ allowed unless explicitly disabled by
+///     config:
+///     <list type="bullet">
+///       <item><description><c>Providers:PlatformFallbackDisabled = true</c>
+///         (global), or</description></item>
+///       <item><description><c>Providers:&lt;provider&gt;:PlatformFallbackDisabled = true</c>
+///         (per-provider override).</description></item>
+///     </list></description></item>
+/// </list>
+///
+/// <para>The plan-level / per-provider gating that Epics 34/35 will drive plugs
+/// in here without changing the resolver.</para>
+/// </summary>
+public sealed class ConfigPlatformFallbackPolicy : IPlatformFallbackPolicy
+{
+    private readonly IConfiguration _configuration;
+    private readonly ITammaModeProvider _mode;
+
+    public ConfigPlatformFallbackPolicy(
+        IConfiguration configuration, ITammaModeProvider mode)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(mode);
+        _configuration = configuration;
+        _mode = mode;
+    }
+
+    /// <inheritdoc />
+    public bool IsPlatformFallbackAllowed(Guid? tenantId, string providerName)
+    {
+        // Single-user: the sole user owns everything — always fall back to the
+        // platform/local key. (A null tenant id is the single-user signal.)
+        if (_mode.Mode == TammaMode.SingleUser || tenantId is null)
+        {
+            return true;
+        }
+
+        // SaaS: allowed by default, disabled only when config says so.
+        var provider = providerName.Trim().ToLowerInvariant();
+
+        if (ReadBool($"Providers:{provider}:PlatformFallbackDisabled"))
+        {
+            return false;
+        }
+
+        if (ReadBool("Providers:PlatformFallbackDisabled"))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool ReadBool(string key)
+    {
+        var raw = _configuration[key];
+        return !string.IsNullOrWhiteSpace(raw)
+            && bool.TryParse(raw, out var v) && v;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Providers/DefaultProviderCredentialResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Providers/DefaultProviderCredentialResolver.cs
@@ -1,0 +1,290 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.LlmCall.Credentials;
+using Tamma.Activities.Security;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Services.Secrets.Stopgap;
+using Tamma.Core;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Providers;
+
+/// <summary>
+/// Story 32-3 — the canonical BYOK→platform provider-credential resolver.
+///
+/// <para>Resolution order for <c>(tenantId, provider)</c>:</para>
+/// <list type="number">
+///   <item><description>Tenant BYOK cabinet key
+///     (<see cref="ITenantProviderKeyReader"/>) — only when a tenant is
+///     present. In-process cached by <c>(tenantId, provider)</c> for a short
+///     TTL (AC9).</description></item>
+///   <item><description>Platform-provided key via
+///     <see cref="IRuntimeSecretResolver"/> (the one platform-key source of
+///     truth, AC2), gated by <see cref="IPlatformFallbackPolicy"/>.</description></item>
+///   <item><description>Otherwise fail-closed: emit
+///     <c>AGENT.CREDENTIAL.DENIED</c> and throw
+///     <c>TammaError("PROVIDER_CREDENTIAL_UNAVAILABLE")</c> — never a silent
+///     wrong/empty key (AC6).</description></item>
+/// </list>
+///
+/// <para><b>Credential safety (AC5):</b> the plaintext key lives only on the
+/// returned <see cref="ProviderCredential.ApiKey"/> and is never serialized
+/// into a <c>DomainEvent</c>, log line, or exception. Only the tag-safe
+/// projection (<see cref="ProviderCredential.ToTag"/>) reaches events / logs.</para>
+/// </summary>
+public sealed class DefaultProviderCredentialResolver : IProviderCredentialResolver
+{
+    /// <summary>Default cache TTL — 60s, matching <see cref="RuntimeSecretResolver.DefaultCacheTtl"/>.</summary>
+    public static readonly TimeSpan DefaultCacheTtl = RuntimeSecretResolver.DefaultCacheTtl;
+
+    private readonly ITenantProviderKeyReader _byokReader;
+    private readonly IRuntimeSecretResolver? _platformKeys;
+    private readonly IPlatformFallbackPolicy _fallbackPolicy;
+    private readonly IEventRepository _events;
+    private readonly ITammaModeProvider _mode;
+    private readonly ProviderAllowlist _allowlist;
+    private readonly ILogger<DefaultProviderCredentialResolver> _logger;
+    private readonly TimeProvider _timeProvider;
+    private readonly TimeSpan _cacheTtl;
+
+    private readonly ConcurrentDictionary<(Guid TenantId, string Provider), CacheEntry> _cache = new();
+
+    public DefaultProviderCredentialResolver(
+        ITenantProviderKeyReader byokReader,
+        IRuntimeSecretResolver? platformKeys,
+        IPlatformFallbackPolicy fallbackPolicy,
+        IEventRepository events,
+        ITammaModeProvider mode,
+        ProviderAllowlist allowlist,
+        ILogger<DefaultProviderCredentialResolver> logger,
+        TimeProvider? timeProvider = null,
+        TimeSpan? cacheTtl = null)
+    {
+        ArgumentNullException.ThrowIfNull(byokReader);
+        ArgumentNullException.ThrowIfNull(fallbackPolicy);
+        ArgumentNullException.ThrowIfNull(events);
+        ArgumentNullException.ThrowIfNull(mode);
+        ArgumentNullException.ThrowIfNull(allowlist);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _byokReader = byokReader;
+        _platformKeys = platformKeys;
+        _fallbackPolicy = fallbackPolicy;
+        _events = events;
+        _mode = mode;
+        _allowlist = allowlist;
+        _logger = logger;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _cacheTtl = cacheTtl ?? DefaultCacheTtl;
+    }
+
+    /// <inheritdoc />
+    public async Task<ProviderCredential> ResolveAsync(
+        Guid? tenantId, string providerName, CancellationToken ct = default)
+    {
+        var provider = Normalize(providerName);
+
+        // 1) BYOK — only when a tenant is present (SaaS). Single-user
+        //    (tenantId == null) has no separate BYOK layer.
+        if (tenantId is { } tid)
+        {
+            var key = (tid, provider);
+            var now = _timeProvider.GetUtcNow();
+            if (_cache.TryGetValue(key, out var cached) && cached.ExpiresAt > now)
+            {
+                _logger.LogDebug(
+                    "BYOK cache hit for tenant {TenantId} provider {Provider}.",
+                    tid, provider);
+                return await EmitResolvedAsync(tenantId, provider, cached.Credential, ct)
+                    .ConfigureAwait(false);
+            }
+
+            var byok = await _byokReader
+                .TryReadAsync(tid, ProviderCabinetNames.Byok(provider), ct)
+                .ConfigureAwait(false);
+            if (byok is not null)
+            {
+                var cred = new ProviderCredential(
+                    byok.Plaintext,
+                    CredentialSource.Byok,
+                    $"tenant:{tid}:{ProviderCabinetNames.Byok(provider)}",
+                    byok.VersionNumber);
+                _cache[key] = new CacheEntry(cred, now.Add(_cacheTtl));
+                _logger.LogDebug(
+                    "BYOK resolved for tenant {TenantId} provider {Provider} (version {Version}).",
+                    tid, provider, byok.VersionNumber);
+                return await EmitResolvedAsync(tenantId, provider, cred, ct).ConfigureAwait(false);
+            }
+
+            _logger.LogDebug(
+                "No BYOK key for tenant {TenantId} provider {Provider}; evaluating platform fallback.",
+                tid, provider);
+        }
+
+        // 2) Platform fallback — gated by the policy.
+        if (_fallbackPolicy.IsPlatformFallbackAllowed(tenantId, provider))
+        {
+            var platformKey = await TryReadPlatformKeyAsync(provider, ct).ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(platformKey))
+            {
+                var cred = new ProviderCredential(
+                    platformKey,
+                    CredentialSource.Platform,
+                    $"platform:{ProviderCabinetNames.Platform(provider)}",
+                    VersionNumber: null);
+                _logger.LogDebug(
+                    "Platform key resolved for provider {Provider} (tenant {TenantId}).",
+                    provider, tenantId);
+                return await EmitResolvedAsync(tenantId, provider, cred, ct).ConfigureAwait(false);
+            }
+
+            _logger.LogWarning(
+                "Platform fallback allowed for provider {Provider} (tenant {TenantId}) " +
+                "but the platform key is unset.", provider, tenantId);
+        }
+
+        // 3) Fail-closed — never a wrong/empty key.
+        var reason = tenantId is null
+            ? "platform_key_unset"
+            : "no_byok_and_platform_fallback_unavailable";
+        await EmitDeniedAsync(tenantId, provider, reason, ct).ConfigureAwait(false);
+
+        _logger.LogError(
+            "Provider credential unavailable: provider={Provider}, tenant={TenantId}, " +
+            "reason={Reason}, mode={Mode}.",
+            provider, tenantId, reason, _mode.Mode);
+
+        throw new TammaError(
+            "PROVIDER_CREDENTIAL_UNAVAILABLE",
+            $"No usable credential for provider '{provider}'" +
+            (tenantId is null
+                ? " (platform key unset)."
+                : " (no tenant BYOK key and platform fallback unavailable)."),
+            new Dictionary<string, object?>
+            {
+                ["tenantId"] = tenantId,
+                ["provider"] = provider,
+                ["reason"] = reason,
+            },
+            retryable: false,
+            severity: TammaErrorSeverity.High);
+    }
+
+    /// <inheritdoc />
+    public void Invalidate(Guid? tenantId, string providerName)
+    {
+        if (tenantId is not { } tid)
+        {
+            return; // single-user / platform has no per-tenant BYOK cache entry
+        }
+        var provider = Normalize(providerName);
+        _cache.TryRemove((tid, provider), out _);
+        _logger.LogInformation(
+            "BYOK cache invalidated for tenant {TenantId} provider {Provider}.",
+            tid, provider);
+    }
+
+    private async Task<string?> TryReadPlatformKeyAsync(string provider, CancellationToken ct)
+    {
+        if (_platformKeys is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return await _platformKeys
+                .GetAsync(ProviderCabinetNames.Platform(provider), ct)
+                .ConfigureAwait(false);
+        }
+        catch (MissingSecretException)
+        {
+            // Story 29-10 fail-fast mode: no cabinet row. Treat as unset for the
+            // platform leg — the resolver's own fail-closed path handles it.
+            return null;
+        }
+    }
+
+    private string Normalize(string providerName)
+    {
+        if (string.IsNullOrWhiteSpace(providerName))
+        {
+            throw new TammaError(
+                "PROVIDER_CREDENTIAL_UNAVAILABLE",
+                "Provider name must be non-empty.",
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+        }
+
+        var provider = providerName.Trim().ToLowerInvariant();
+        if (!_allowlist.IsAllowed(provider))
+        {
+            throw new TammaError(
+                "PROVIDER_CREDENTIAL_UNAVAILABLE",
+                $"Provider '{provider}' is not in the allowlist.",
+                new Dictionary<string, object?> { ["provider"] = provider },
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+        }
+        return provider;
+    }
+
+    private async Task<ProviderCredential> EmitResolvedAsync(
+        Guid? tenantId, string provider, ProviderCredential cred, CancellationToken ct)
+    {
+        var tag = cred.ToTag(); // tag-safe — NEVER the ApiKey
+        await _events.AppendAsync(new DomainEvent
+        {
+            Id = Guid.NewGuid(),
+            Type = "AGENT.CREDENTIAL_RESOLVED.SUCCESS",
+            TenantId = tenantId,
+            Tags = JsonSerializer.Serialize(new
+            {
+                tenantId = tenantId?.ToString(),
+                provider,
+                source = tag.Source,
+                secretRef = tag.SecretRef,
+                mode = _mode.Mode.ToString(),
+            }),
+            Metadata = JsonSerializer.Serialize(new
+            {
+                workflowVersion = "1.0.0",
+                eventSource = "system",
+            }),
+            // Data carries only the version — NEVER the key.
+            Data = JsonSerializer.Serialize(new { version = tag.Version }),
+            CreatedAt = DateTime.UtcNow,
+        }).ConfigureAwait(false);
+
+        return cred;
+    }
+
+    private async Task EmitDeniedAsync(
+        Guid? tenantId, string provider, string reason, CancellationToken ct)
+    {
+        await _events.AppendAsync(new DomainEvent
+        {
+            Id = Guid.NewGuid(),
+            Type = "AGENT.CREDENTIAL.DENIED",
+            TenantId = tenantId,
+            Tags = JsonSerializer.Serialize(new
+            {
+                tenantId = tenantId?.ToString(),
+                provider,
+                reason,
+                mode = _mode.Mode.ToString(),
+            }),
+            Metadata = JsonSerializer.Serialize(new
+            {
+                workflowVersion = "1.0.0",
+                eventSource = "system",
+            }),
+            Data = "{}",
+            CreatedAt = DateTime.UtcNow,
+        }).ConfigureAwait(false);
+    }
+
+    private readonly record struct CacheEntry(ProviderCredential Credential, DateTimeOffset ExpiresAt);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Providers/ITenantProviderKeyReader.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Providers/ITenantProviderKeyReader.cs
@@ -1,0 +1,33 @@
+namespace Tamma.Api.Services.Providers;
+
+/// <summary>
+/// Reads a tenant's BYOK provider key plaintext from the Epic 29 secret
+/// cabinet at runtime. The tenant-scoped sibling of
+/// <c>RuntimeSecretResolver</c> (which is platform-scoped only): it queries
+/// the cabinet for a <c>SecretScope.Tenant</c> row named by the provider and
+/// reads its active version's plaintext via
+/// <c>ISecretStoreBackend.GetVersionPlaintextAsync</c> — honouring the
+/// "<c>ISecretStore</c> never surfaces plaintext" boundary.
+///
+/// <para>Pulled out behind an interface so the resolver's precedence / cache /
+/// event / fail-closed algorithm is unit-testable without a Postgres
+/// container; the real implementation
+/// (<see cref="CabinetTenantProviderKeyReader"/>) is integration-tested
+/// against the cabinet.</para>
+/// </summary>
+public interface ITenantProviderKeyReader
+{
+    /// <summary>
+    /// Resolve a tenant BYOK key. Returns the plaintext + active version when a
+    /// usable tenant-scoped row exists, or null when absent / scrubbed. NEVER
+    /// throws on "absent" — a cabinet probe failure degrades to a null result
+    /// (logged WARN) so the resolver proceeds to the platform fallback.
+    /// </summary>
+    Task<TenantProviderKey?> TryReadAsync(
+        Guid tenantId, string cabinetName, CancellationToken ct = default);
+}
+
+/// <summary>A resolved BYOK key plaintext + the version it came from.</summary>
+/// <param name="Plaintext">The raw key — request-scoped; never logged/emitted.</param>
+/// <param name="VersionNumber">Active cabinet version number.</param>
+public sealed record TenantProviderKey(string Plaintext, int VersionNumber);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Providers/NullTenantProviderKeyReader.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Providers/NullTenantProviderKeyReader.cs
@@ -1,0 +1,14 @@
+namespace Tamma.Api.Services.Providers;
+
+/// <summary>
+/// No-cabinet <see cref="ITenantProviderKeyReader"/> — always reports "no BYOK
+/// key". Wired when the Story 29-2 secret store is not configured (single-user
+/// / dev hosts), so the resolver cleanly degrades to the platform leg without a
+/// DI-validation failure. There is never a BYOK key to leak.
+/// </summary>
+public sealed class NullTenantProviderKeyReader : ITenantProviderKeyReader
+{
+    public Task<TenantProviderKey?> TryReadAsync(
+        Guid tenantId, string cabinetName, CancellationToken ct = default) =>
+        Task.FromResult<TenantProviderKey?>(null);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderCredentialCacheInvalidator.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderCredentialCacheInvalidator.cs
@@ -1,0 +1,63 @@
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.LlmCall.Credentials;
+using Tamma.Api.Services.Secrets;
+
+namespace Tamma.Api.Services.Providers;
+
+/// <summary>
+/// Story 32-3 (AC9) — evicts a stale BYOK entry from the
+/// <see cref="IProviderCredentialResolver"/> cache when a provider key is
+/// rotated. The canonical invalidation trigger is the cabinet's
+/// <c>SECRET.ROTATE.ACTIVATED</c> signal (the same event
+/// <c>RuntimeSecretResolver</c> documents for its own invalidation); the
+/// management API also calls it directly on register / rotate / remove.
+///
+/// <para>The cabinet does not currently publish <c>SECRET.ROTATE.ACTIVATED</c>
+/// as an in-process bus event, so this handler exposes
+/// <see cref="HandleRotateActivated(SecretRef)"/> as the single choke point —
+/// callers on the rotation / mutation path invoke it, and tests drive it
+/// directly to prove the eviction. When the bus event lands, its dispatcher
+/// calls the same method.</para>
+/// </summary>
+public sealed class ProviderCredentialCacheInvalidator
+{
+    private readonly IProviderCredentialResolver _resolver;
+    private readonly ILogger<ProviderCredentialCacheInvalidator> _logger;
+
+    public ProviderCredentialCacheInvalidator(
+        IProviderCredentialResolver resolver,
+        ILogger<ProviderCredentialCacheInvalidator> logger)
+    {
+        ArgumentNullException.ThrowIfNull(resolver);
+        ArgumentNullException.ThrowIfNull(logger);
+        _resolver = resolver;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Handle a <c>SECRET.ROTATE.ACTIVATED</c> for <paramref name="reference"/>.
+    /// When the ref is a tenant-scoped <c>provider/&lt;name&gt;/api-key</c> row,
+    /// evict the matching <c>(tenantId, provider)</c> resolver-cache entry so
+    /// the next resolve picks up the rotated version. No-op otherwise.
+    /// </summary>
+    public void HandleRotateActivated(SecretRef reference)
+    {
+        ArgumentNullException.ThrowIfNull(reference);
+
+        if (reference.Scope != SecretScope.Tenant || reference.TenantId is not { } tid)
+        {
+            return; // platform-scoped rotations are handled by RuntimeSecretResolver
+        }
+
+        var provider = ProviderCabinetNames.TryParse(reference.Name);
+        if (provider is null)
+        {
+            return; // not a BYOK provider-key ref
+        }
+
+        _resolver.Invalidate(tid, provider);
+        _logger.LogInformation(
+            "Provider credential cache invalidated on SECRET.ROTATE.ACTIVATED for " +
+            "tenant {TenantId} provider {Provider}.", tid, provider);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
@@ -533,6 +533,14 @@ public class ControlPlaneDbContext : DbContext
     /// </summary>
     public DbSet<AgentVersion> AgentVersions => Set<AgentVersion>();
 
+    /// <summary>
+    /// Story 32-2 — role→agent selections. On the CP context this holds the
+    /// single-user (user-keyed) rows; the SAME table also lives in every tenant
+    /// schema for SaaS (tenant-keyed) rows. See
+    /// <see cref="Entities.AgentRoleSelection"/>.
+    /// </summary>
+    public DbSet<AgentRoleSelection> AgentRoleSelections => Set<AgentRoleSelection>();
+
     // ── Story 35-1 — billing foundation (Epic 35) ──
     //
     // The tenant→Stripe customer mapping + the slug→Stripe-ids catalog are
@@ -641,6 +649,12 @@ public class ControlPlaneDbContext : DbContext
         // Story 32-1 — first-class agent entities. CP-resident, configured in
         // the shared single source so the model graph + migration stay aligned.
         TammaModelConfiguration.ConfigureAgentEntities(modelBuilder);
+
+        // Story 32-2 — agent_role_selections. Dual-resident (CP for single-user
+        // user-keyed rows; tenant schema for SaaS tenant-keyed rows — same SAME
+        // shape on both, mirroring audit_records). fixedTenantId: null = the CP
+        // build.
+        TammaModelConfiguration.ConfigureAgentRoleSelections(modelBuilder, fixedTenantId: null);
 
         // Story 35-1 — billing customer mapping + Stripe catalog. CP-resident,
         // configured in the shared single source so the model graph + migration

--- a/apps/tamma-elsa/src/Tamma.Data/DependencyInjection.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/DependencyInjection.cs
@@ -148,6 +148,10 @@ public static class DependencyInjection
         // distinct from the tenant-scoped IAgentConfigRepository below.
         services.AddScoped<IAgentRepository, AgentRepository>();
 
+        // Story 32-2 — role→agent selections. Dual-scoped (CP for single-user;
+        // tenant schema for SaaS), routed internally by the ambient principal.
+        services.AddScoped<IAgentSelectionRepository, AgentSelectionRepository>();
+
         // Tenant-scoped repositories (use ITenantDbContextFactory internally).
         services.AddScoped<IAgentConfigRepository, AgentConfigRepository>();
         services.AddScoped<IPromptRepository, PromptRepository>();

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/AgentRoleSelection.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/AgentRoleSelection.cs
@@ -1,0 +1,64 @@
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 32-2 — which <see cref="Agent"/> serves a given role for a principal.
+/// One row per <c>(principal, role)</c>. The <see cref="AgentResolverService"/>
+/// entity-aware resolution chain reads this first (precedence branches 1+2);
+/// absent a selection it falls to the system-default public agent for the role
+/// (branch 3), then fails loud (branch 4) — never an empty/plain config.
+///
+/// <para><b>Dual-resident, mode-keyed (mirrors <c>prompt_overrides</c>).</b> Per
+/// CLAUDE.md "Universal rule for any tenant-aware feature" the principal is
+/// answered separately per mode:
+/// <list type="bullet">
+///   <item>SaaS ⇒ <see cref="TenantId"/> set, <see cref="UserId"/> NULL; the row
+///     lives in the tenant's <c>t_&lt;hex&gt;</c> schema
+///     (<c>TenantDbContext</c>).</item>
+///   <item>single-user ⇒ <see cref="UserId"/> set, <see cref="TenantId"/> NULL;
+///     the row lives on the control plane (<c>ControlPlaneDbContext</c>).</item>
+/// </list>
+/// Exactly one of the two is non-null — enforced by the
+/// <c>ck_agent_role_selections_principal_xor</c> CHECK (mirrors
+/// <c>ck_prompt_overrides_principal_xor</c>) and the
+/// <c>UNIQUE NULLS NOT DISTINCT (TenantId, UserId, Role)</c> index.</para>
+///
+/// <para><b>Cross-schema reference, not a DB FK.</b> The selected
+/// <see cref="Agent"/> is CP-resident (both public and own-private), so there is
+/// no DB FK from this row to <c>agents</c>. The registry validates the target is
+/// in (public ∪ own private) at write time, and the resolver RE-validates at
+/// resolve time so an archived/deleted target degrades to the system default
+/// rather than resolving stale. The stored <see cref="Visibility"/> is a hint
+/// only — provenance is recomputed, never trusted.</para>
+/// </summary>
+public class AgentRoleSelection
+{
+    public Guid Id { get; set; }
+
+    /// <summary>SaaS principal — set iff <see cref="UserId"/> is NULL.</summary>
+    public Guid? TenantId { get; set; }
+
+    /// <summary>single-user principal — set iff <see cref="TenantId"/> is NULL.</summary>
+    public Guid? UserId { get; set; }
+
+    /// <summary>One of <c>RolePhaseMap.ValidRoles</c> (canonical wire string).</summary>
+    public string Role { get; set; } = null!;
+
+    /// <summary>
+    /// The selected agent (public OR own private). Logical reference only — the
+    /// target is CP-resident; cross-schema FKs are not modelled.
+    /// </summary>
+    public Guid AgentId { get; set; }
+
+    /// <summary>
+    /// Provenance hint captured at selection time: <c>tenant-private</c> |
+    /// <c>tenant-public</c> | <c>system-public</c>. Recomputed on resolve, never
+    /// trusted.
+    /// </summary>
+    public string Visibility { get; set; } = null!;
+
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+
+    /// <summary>User id that performed the most recent upsert (audit).</summary>
+    public Guid? UpdatedBy { get; set; }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260619194513_AddAgentRoleSelectionsCp.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260619194513_AddAgentRoleSelectionsCp.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.ControlPlane
 {
     [DbContext(typeof(ControlPlaneDbContext))]
-    partial class ControlPlaneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260619194513_AddAgentRoleSelectionsCp")]
+    partial class AddAgentRoleSelectionsCp
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260619194513_AddAgentRoleSelectionsCp.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260619194513_AddAgentRoleSelectionsCp.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.ControlPlane
+{
+    /// <inheritdoc />
+    public partial class AddAgentRoleSelectionsCp : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "agent_role_selections",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: true),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: true),
+                    Role = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    AgentId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Visibility = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    UpdatedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_agent_role_selections", x => x.Id);
+                    table.CheckConstraint("ck_agent_role_selections_principal_xor", "(\"UserId\" IS NOT NULL AND \"TenantId\" IS NULL) OR (\"UserId\" IS NULL AND \"TenantId\" IS NOT NULL)");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_agent_role_selections_TenantId_UserId_Role",
+                table: "agent_role_selections",
+                columns: new[] { "TenantId", "UserId", "Role" },
+                unique: true)
+                .Annotation("Npgsql:NullsDistinct", false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "agent_role_selections");
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260619194542_AddAgentRoleSelections.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260619194542_AddAgentRoleSelections.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.Tenant
 {
     [DbContext(typeof(TenantDbContext))]
-    partial class TenantDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260619194542_AddAgentRoleSelections")]
+    partial class AddAgentRoleSelections
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260619194542_AddAgentRoleSelections.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260619194542_AddAgentRoleSelections.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.Tenant
+{
+    /// <inheritdoc />
+    public partial class AddAgentRoleSelections : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "agent_role_selections",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: true),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: true),
+                    Role = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    AgentId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Visibility = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    UpdatedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_agent_role_selections", x => x.Id);
+                    table.CheckConstraint("ck_agent_role_selections_principal_xor", "(\"UserId\" IS NOT NULL AND \"TenantId\" IS NULL) OR (\"UserId\" IS NULL AND \"TenantId\" IS NOT NULL)");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_agent_role_selections_TenantId_UserId_Role",
+                table: "agent_role_selections",
+                columns: new[] { "TenantId", "UserId", "Role" },
+                unique: true)
+                .Annotation("Npgsql:NullsDistinct", false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "agent_role_selections");
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/AgentRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/AgentRepository.cs
@@ -198,6 +198,44 @@ public sealed class AgentRepository : IAgentRepository
         return agent;
     }
 
+    public async Task<AgentVersion?> SetActiveVersionAsync(
+        Guid agentId, int version, Guid? updatedBy, CancellationToken ct = default)
+    {
+        var agent = await _db.Agents.FirstOrDefaultAsync(a => a.Id == agentId, ct);
+        if (agent is null)
+        {
+            return null;
+        }
+
+        var target = await _db.AgentVersions
+            .FirstOrDefaultAsync(v => v.AgentId == agentId && v.Version == version, ct);
+        if (target is null)
+        {
+            return null;
+        }
+
+        // Idempotent — re-activating the already-active version is a no-op with
+        // no event (events only on real transitions).
+        if (agent.CurrentVersionId == target.Id)
+        {
+            return target;
+        }
+
+        agent.CurrentVersionId = target.Id;
+        agent.UpdatedAt = DateTime.UtcNow;
+        agent.UpdatedBy = updatedBy;
+        await _db.SaveChangesAsync(ct);
+
+        _logger?.LogInformation(
+            "agent.version_rollback agentId={AgentId} reactivatedVersion={Version}",
+            agentId, target.Version);
+
+        await AppendAgentEventAsync(
+            "AGENT.VERSION_PUBLISHED.SUCCESS", agent, target.Version, ct, activated: "rollback");
+
+        return target;
+    }
+
     public Task<Agent?> GetByIdAsync(Guid agentId, CancellationToken ct = default)
         => _db.Agents.FirstOrDefaultAsync(a => a.Id == agentId, ct);
 
@@ -205,6 +243,19 @@ public sealed class AgentRepository : IAgentRepository
         Guid agentId, int version, CancellationToken ct = default)
         => _db.AgentVersions
             .FirstOrDefaultAsync(v => v.AgentId == agentId && v.Version == version, ct);
+
+    public async Task<AgentVersion?> GetActiveVersionAsync(
+        Guid agentId, CancellationToken ct = default)
+    {
+        var agent = await _db.Agents
+            .FirstOrDefaultAsync(a => a.Id == agentId, ct);
+        if (agent?.CurrentVersionId is not Guid versionId)
+        {
+            return null;
+        }
+        return await _db.AgentVersions
+            .FirstOrDefaultAsync(v => v.Id == versionId, ct);
+    }
 
     public async Task<IReadOnlyList<AgentVersion>> ListVersionsAsync(
         Guid agentId, CancellationToken ct = default)
@@ -272,7 +323,7 @@ public sealed class AgentRepository : IAgentRepository
     /// (<c>platform_events</c>). Tags carry the agent shape per the design.
     /// </summary>
     private async Task AppendAgentEventAsync(
-        string type, Agent agent, int? version, CancellationToken ct)
+        string type, Agent agent, int? version, CancellationToken ct, string? activated = null)
     {
         _ = ct;
         // Public agents are platform-owned (both owner columns NULL) — tag them
@@ -289,6 +340,7 @@ public sealed class AgentRepository : IAgentRepository
             ["mode"] = mode,
         };
         if (version is int v) tags["version"] = v;
+        if (activated is not null) tags["activated"] = activated;
         if (agent.OwnerTenantId is Guid otid) tags["ownerTenantId"] = otid.ToString();
         if (agent.OwnerUserId is Guid ouid) tags["ownerUserId"] = ouid.ToString();
 

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/AgentSelectionRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/AgentSelectionRepository.cs
@@ -1,0 +1,120 @@
+using Microsoft.EntityFrameworkCore;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+
+namespace Tamma.Data.Repositories;
+
+/// <summary>
+/// Story 32-2 — default <see cref="IAgentSelectionRepository"/>. Routes by mode:
+/// the single-user (user-keyed) rows live on <see cref="ControlPlaneDbContext"/>;
+/// the SaaS (tenant-keyed) rows live in the tenant schema, reached via
+/// <see cref="ITenantDbContextFactory"/> + the ambient <see cref="ITenantContext"/>.
+/// Same dual-scoping discipline as <see cref="PromptRepository"/>: every read/
+/// write carries an explicit principal predicate; no method joins both planes.
+/// </summary>
+public sealed class AgentSelectionRepository(
+    ControlPlaneDbContext cpDb,
+    ITenantDbContextFactory tenantDbFactory,
+    ITenantContext tenantContext) : IAgentSelectionRepository
+{
+    // ───────────────────────── single-user mode ─────────────────────────
+
+    public Task<AgentRoleSelection?> GetByUserAsync(
+        Guid userId, string role, CancellationToken ct = default)
+        => cpDb.AgentRoleSelections.AsNoTracking()
+            .FirstOrDefaultAsync(
+                s => s.UserId == userId && s.TenantId == default(Guid?) && s.Role == role, ct);
+
+    public async Task<IReadOnlyList<AgentRoleSelection>> ListByUserAsync(
+        Guid userId, CancellationToken ct = default)
+        => await cpDb.AgentRoleSelections.AsNoTracking()
+            .Where(s => s.UserId == userId && s.TenantId == default(Guid?))
+            .ToListAsync(ct);
+
+    public async Task<(AgentRoleSelection Entity, bool WasCreated)> UpsertByUserAsync(
+        Guid userId, string role, Guid agentId, string visibility,
+        Guid? updatedBy, CancellationToken ct = default)
+    {
+        var existing = await cpDb.AgentRoleSelections
+            .FirstOrDefaultAsync(
+                s => s.UserId == userId && s.TenantId == default(Guid?) && s.Role == role, ct);
+        var result = ApplyUpsert(
+            cpDb.AgentRoleSelections, existing,
+            tenantId: null, userId: userId, role, agentId, visibility, updatedBy);
+        await cpDb.SaveChangesAsync(ct);
+        return result;
+    }
+
+    // ───────────────────────── SaaS mode ────────────────────────────────
+
+    public async Task<AgentRoleSelection?> GetByTenantAsync(
+        Guid tenantId, string role, CancellationToken ct = default)
+    {
+        await using var db = await tenantDbFactory.CreateAsync(RequireAmbient(), ct);
+        return await db.AgentRoleSelections.AsNoTracking().IgnoreQueryFilters()
+            .FirstOrDefaultAsync(
+                s => s.TenantId == tenantId && s.UserId == default(Guid?) && s.Role == role, ct);
+    }
+
+    public async Task<IReadOnlyList<AgentRoleSelection>> ListByTenantAsync(
+        Guid tenantId, CancellationToken ct = default)
+    {
+        await using var db = await tenantDbFactory.CreateAsync(RequireAmbient(), ct);
+        return await db.AgentRoleSelections.AsNoTracking().IgnoreQueryFilters()
+            .Where(s => s.TenantId == tenantId && s.UserId == default(Guid?))
+            .ToListAsync(ct);
+    }
+
+    public async Task<(AgentRoleSelection Entity, bool WasCreated)> UpsertByTenantAsync(
+        Guid tenantId, string role, Guid agentId, string visibility,
+        Guid? updatedBy, CancellationToken ct = default)
+    {
+        await using var db = await tenantDbFactory.CreateAsync(RequireAmbient(), ct);
+        var existing = await db.AgentRoleSelections.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(
+                s => s.TenantId == tenantId && s.UserId == default(Guid?) && s.Role == role, ct);
+        var result = ApplyUpsert(
+            db.AgentRoleSelections, existing,
+            tenantId: tenantId, userId: null, role, agentId, visibility, updatedBy);
+        await db.SaveChangesAsync(ct);
+        return result;
+    }
+
+    // ── helpers ──
+
+    private Guid RequireAmbient() => tenantContext.TenantId
+        ?? throw new InvalidOperationException(
+            "AgentSelectionRepository (SaaS path) requires an ambient tenant id to "
+            + "route the per-tenant connection.");
+
+    private static (AgentRoleSelection Entity, bool WasCreated) ApplyUpsert(
+        DbSet<AgentRoleSelection> set,
+        AgentRoleSelection? existing,
+        Guid? tenantId, Guid? userId, string role, Guid agentId, string visibility,
+        Guid? updatedBy)
+    {
+        var now = DateTime.UtcNow;
+        if (existing is not null)
+        {
+            existing.AgentId = agentId;
+            existing.Visibility = visibility;
+            existing.UpdatedAt = now;
+            existing.UpdatedBy = updatedBy;
+            return (existing, false);
+        }
+        var row = new AgentRoleSelection
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            UserId = userId,
+            Role = role,
+            AgentId = agentId,
+            Visibility = visibility,
+            CreatedAt = now,
+            UpdatedAt = now,
+            UpdatedBy = updatedBy,
+        };
+        set.Add(row);
+        return (row, true);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/AgentSelectionRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/AgentSelectionRepository.cs
@@ -31,19 +31,14 @@ public sealed class AgentSelectionRepository(
             .Where(s => s.UserId == userId && s.TenantId == default(Guid?))
             .ToListAsync(ct);
 
-    public async Task<(AgentRoleSelection Entity, bool WasCreated)> UpsertByUserAsync(
+    public Task<(AgentRoleSelection Entity, bool WasCreated)> UpsertByUserAsync(
         Guid userId, string role, Guid agentId, string visibility,
         Guid? updatedBy, CancellationToken ct = default)
-    {
-        var existing = await cpDb.AgentRoleSelections
-            .FirstOrDefaultAsync(
-                s => s.UserId == userId && s.TenantId == default(Guid?) && s.Role == role, ct);
-        var result = ApplyUpsert(
-            cpDb.AgentRoleSelections, existing,
-            tenantId: null, userId: userId, role, agentId, visibility, updatedBy);
-        await cpDb.SaveChangesAsync(ct);
-        return result;
-    }
+        => UpsertAsync(
+            cpDb,
+            () => cpDb.AgentRoleSelections.FirstOrDefaultAsync(
+                s => s.UserId == userId && s.TenantId == default(Guid?) && s.Role == role, ct),
+            tenantId: null, userId: userId, role, agentId, visibility, updatedBy, ct);
 
     // ───────────────────────── SaaS mode ────────────────────────────────
 
@@ -70,14 +65,11 @@ public sealed class AgentSelectionRepository(
         Guid? updatedBy, CancellationToken ct = default)
     {
         await using var db = await tenantDbFactory.CreateAsync(RequireAmbient(), ct);
-        var existing = await db.AgentRoleSelections.IgnoreQueryFilters()
-            .FirstOrDefaultAsync(
-                s => s.TenantId == tenantId && s.UserId == default(Guid?) && s.Role == role, ct);
-        var result = ApplyUpsert(
-            db.AgentRoleSelections, existing,
-            tenantId: tenantId, userId: null, role, agentId, visibility, updatedBy);
-        await db.SaveChangesAsync(ct);
-        return result;
+        return await UpsertAsync(
+            db,
+            () => db.AgentRoleSelections.IgnoreQueryFilters().FirstOrDefaultAsync(
+                s => s.TenantId == tenantId && s.UserId == default(Guid?) && s.Role == role, ct),
+            tenantId: tenantId, userId: null, role, agentId, visibility, updatedBy, ct);
     }
 
     // ── helpers ──
@@ -86,6 +78,50 @@ public sealed class AgentSelectionRepository(
         ?? throw new InvalidOperationException(
             "AgentSelectionRepository (SaaS path) requires an ambient tenant id to "
             + "route the per-tenant connection.");
+
+    /// <summary>
+    /// Read-then-write upsert that is resilient to a concurrent first-time
+    /// insert race. Two concurrent first-time selects for the same
+    /// <c>(principal, role)</c> both read <c>null</c>; one INSERT wins, the loser
+    /// hits the unique <c>(TenantId, UserId, Role)</c> violation as a
+    /// <see cref="DbUpdateException"/>. We catch the Postgres unique-violation
+    /// (scoped precisely to <see cref="Npgsql.PostgresErrorCodes.UniqueViolation"/>,
+    /// same as <c>AgentRepository.PublishVersionAsync</c>), detach the failed
+    /// insert, re-read the now-present row, and UPDATE it. Selection is
+    /// idempotent: last-writer-wins is the correct outcome.
+    /// </summary>
+    private static async Task<(AgentRoleSelection Entity, bool WasCreated)> UpsertAsync(
+        DbContext db,
+        Func<Task<AgentRoleSelection?>> readExisting,
+        Guid? tenantId, Guid? userId, string role, Guid agentId, string visibility,
+        Guid? updatedBy, CancellationToken ct)
+    {
+        var existing = await readExisting();
+        var (entity, wasCreated) = ApplyUpsert(
+            db.Set<AgentRoleSelection>(), existing,
+            tenantId, userId, role, agentId, visibility, updatedBy);
+
+        try
+        {
+            await db.SaveChangesAsync(ct);
+            return (entity, wasCreated);
+        }
+        catch (DbUpdateException ex) when (wasCreated && IsUniqueViolation(ex))
+        {
+            // We lost a first-time-insert race; the winner's row now exists.
+            // Detach our orphaned insert, re-read the winner, and update it.
+            db.Entry(entity).State = EntityState.Detached;
+            var winner = await readExisting()
+                ?? throw new InvalidOperationException(
+                    "AgentSelectionRepository upsert hit a unique-violation but the "
+                    + "conflicting selection row could not be re-read.");
+            ApplyUpsert(
+                db.Set<AgentRoleSelection>(), winner,
+                tenantId, userId, role, agentId, visibility, updatedBy);
+            await db.SaveChangesAsync(ct);
+            return (winner, false);
+        }
+    }
 
     private static (AgentRoleSelection Entity, bool WasCreated) ApplyUpsert(
         DbSet<AgentRoleSelection> set,
@@ -117,4 +153,8 @@ public sealed class AgentSelectionRepository(
         set.Add(row);
         return (row, true);
     }
+
+    private static bool IsUniqueViolation(DbUpdateException ex)
+        => ex.InnerException is Npgsql.PostgresException pg &&
+           pg.SqlState == Npgsql.PostgresErrorCodes.UniqueViolation;
 }

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/IAgentRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/IAgentRepository.cs
@@ -51,9 +51,28 @@ public interface IAgentRepository
     /// </summary>
     Task<Agent?> ArchiveAsync(Guid agentId, Guid? updatedBy, CancellationToken ct = default);
 
+    /// <summary>
+    /// Story 32-2 — rollback: repoint <see cref="Agent.CurrentVersionId"/> at an
+    /// EXISTING prior version (no new snapshot is inserted; history stays
+    /// immutable). Appends <c>AGENT.VERSION_PUBLISHED.SUCCESS</c> tagged
+    /// <c>activated=rollback</c> only on a real pointer move. Returns the
+    /// re-activated <see cref="AgentVersion"/>, or <c>null</c> if the agent or
+    /// the target version does not exist.
+    /// </summary>
+    Task<AgentVersion?> SetActiveVersionAsync(
+        Guid agentId, int version, Guid? updatedBy, CancellationToken ct = default);
+
     Task<Agent?> GetByIdAsync(Guid agentId, CancellationToken ct = default);
 
     Task<AgentVersion?> GetVersionAsync(Guid agentId, int version, CancellationToken ct = default);
+
+    /// <summary>
+    /// Story 32-2 — the agent's CURRENTLY-ACTIVE version (the one
+    /// <see cref="Agent.CurrentVersionId"/> points at). After a rollback this is
+    /// the re-activated prior version, not the highest version number. Returns
+    /// <c>null</c> if the agent has no active-version pointer.
+    /// </summary>
+    Task<AgentVersion?> GetActiveVersionAsync(Guid agentId, CancellationToken ct = default);
 
     Task<IReadOnlyList<AgentVersion>> ListVersionsAsync(Guid agentId, CancellationToken ct = default);
 

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/IAgentSelectionRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/IAgentSelectionRepository.cs
@@ -1,0 +1,47 @@
+using Tamma.Data.Entities;
+
+namespace Tamma.Data.Repositories;
+
+/// <summary>
+/// Story 32-2 — persistence port for <see cref="AgentRoleSelection"/> (which
+/// agent serves a role for a principal). Dual-scoping mirrors
+/// <see cref="IPromptRepository"/>:
+/// <list type="bullet">
+///   <item>single-user ⇒ rows keyed by <c>user_id</c> (<c>tenant_id</c> NULL),
+///     persisted on the control plane.</item>
+///   <item>SaaS ⇒ rows keyed by <c>tenant_id</c> (<c>user_id</c> NULL),
+///     persisted in the tenant's <c>t_&lt;hex&gt;</c> schema.</item>
+/// </list>
+/// The methods are parallel — the caller picks the right one based on mode; no
+/// method silently joins both planes. The <c>principal_xor</c> CHECK +
+/// <c>UNIQUE NULLS NOT DISTINCT (tenant_id, user_id, role)</c> index keep the
+/// two row-spaces disjoint and at most one row per <c>(principal, role)</c>.
+/// </summary>
+public interface IAgentSelectionRepository
+{
+    // ── single-user mode (user-keyed; control-plane resident) ──
+
+    Task<AgentRoleSelection?> GetByUserAsync(
+        Guid userId, string role, CancellationToken ct = default);
+
+    Task<IReadOnlyList<AgentRoleSelection>> ListByUserAsync(
+        Guid userId, CancellationToken ct = default);
+
+    /// <summary>Insert or update the user's selection for a role. Returns the
+    /// persisted row + whether it was created (vs updated).</summary>
+    Task<(AgentRoleSelection Entity, bool WasCreated)> UpsertByUserAsync(
+        Guid userId, string role, Guid agentId, string visibility,
+        Guid? updatedBy, CancellationToken ct = default);
+
+    // ── SaaS mode (tenant-keyed; tenant-schema resident) ──
+
+    Task<AgentRoleSelection?> GetByTenantAsync(
+        Guid tenantId, string role, CancellationToken ct = default);
+
+    Task<IReadOnlyList<AgentRoleSelection>> ListByTenantAsync(
+        Guid tenantId, CancellationToken ct = default);
+
+    Task<(AgentRoleSelection Entity, bool WasCreated)> UpsertByTenantAsync(
+        Guid tenantId, string role, Guid agentId, string visibility,
+        Guid? updatedBy, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
@@ -839,6 +839,59 @@ internal static class TammaModelConfiguration
     }
 
     /// <summary>
+    /// Story 32-2 — configure the <c>agent_role_selections</c> table (which
+    /// <see cref="Agent"/> serves a role for a principal). Dual-resident: this
+    /// SAME table shape is configured on BOTH the CP context (single-user
+    /// user-keyed rows) and every tenant context (SaaS tenant-keyed rows),
+    /// mirroring <see cref="ConfigureAuditEntities"/> and the
+    /// <c>prompt_overrides</c> dual-scoping model. <paramref name="fixedTenantId"/>
+    /// is the tenant-context discriminator (NULL on the CP build); it only feeds
+    /// the no-op <see cref="ApplyTenantFilter{T}"/> seam — isolation is the
+    /// per-tenant connection, not a baked-in filter.
+    ///
+    /// <para>The <c>ck_agent_role_selections_principal_xor</c> CHECK ties exactly
+    /// one of (<c>UserId</c>, <c>TenantId</c>) to non-null (mirrors
+    /// <c>ck_prompt_overrides_principal_xor</c>). The unique index on
+    /// <c>(TenantId, UserId, Role)</c> uses NULLS NOT DISTINCT so the
+    /// (null, uid, role) and (tid, null, role) row spaces are disjoint and both
+    /// halves dedupe on null — one selection per <c>(principal, role)</c>.</para>
+    /// </summary>
+    public static void ConfigureAgentRoleSelections(
+        ModelBuilder modelBuilder, Guid? fixedTenantId = null)
+    {
+        modelBuilder.Entity<AgentRoleSelection>(entity =>
+        {
+            entity.ToTable("agent_role_selections", t =>
+            {
+                // Exactly one of user_id / tenant_id is non-null (mirrors
+                // ck_prompt_overrides_principal_xor).
+                t.HasCheckConstraint(
+                    "ck_agent_role_selections_principal_xor",
+                    "(\"UserId\" IS NOT NULL AND \"TenantId\" IS NULL) " +
+                    "OR (\"UserId\" IS NULL AND \"TenantId\" IS NOT NULL)");
+            });
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+            entity.Property(e => e.Role).IsRequired().HasMaxLength(64);
+            entity.Property(e => e.AgentId).IsRequired();
+            entity.Property(e => e.Visibility).IsRequired().HasMaxLength(32);
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("now()");
+
+            // One selection per (principal, role). NULLS NOT DISTINCT (PG15+;
+            // production runs PG17) so a single (null, uid, role) or
+            // (tid, null, role) row is unique across the repeated NULL halves —
+            // same pattern as prompt_overrides / conventions.
+            entity.HasIndex(e => new { e.TenantId, e.UserId, e.Role })
+                .IsUnique()
+                .AreNullsDistinct(false)
+                .HasDatabaseName("IX_agent_role_selections_TenantId_UserId_Role");
+
+            ApplyTenantFilter(entity, fixedTenantId, e => e.TenantId);
+        });
+    }
+
+    /// <summary>
     /// Story 35-1 — billing foundation entities. The tenant→Stripe customer
     /// mapping (<c>billing_customers</c>, unique <c>TenantId</c>) and the
     /// slug→Stripe-ids catalog (<c>billing_plan_prices</c>, unique
@@ -1516,6 +1569,12 @@ internal static class TammaModelConfiguration
         // domain_events stream. The SAME table shape is also configured on the
         // CP context for platform-scope rows — one physical schema, two homes.
         ConfigureAuditEntities(modelBuilder, fixedTenantId);
+
+        // ── Agent role selections (Story 32-2) ──
+        // SaaS tenant-keyed role→agent selections. The SAME table shape is also
+        // configured on the CP context for single-user user-keyed rows — one
+        // physical schema, two homes (mirrors audit_records / prompt_overrides).
+        ConfigureAgentRoleSelections(modelBuilder, fixedTenantId);
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs
@@ -51,6 +51,9 @@ public class TenantDbContext : DbContext
     // ── Tenant-scoped entities ──
     public DbSet<AgentConfig> AgentConfigs => Set<AgentConfig>();
     public DbSet<PromptOverride> PromptOverrides => Set<PromptOverride>();
+    // Story 32-2 — SaaS tenant-keyed role→agent selections (the single-user
+    // user-keyed rows live on the CP context). Same table shape, two homes.
+    public DbSet<AgentRoleSelection> AgentRoleSelections => Set<AgentRoleSelection>();
     public DbSet<Convention> Conventions => Set<Convention>();
     public DbSet<ProviderHealth> ProviderHealths => Set<ProviderHealth>();
     public DbSet<ProviderDiagnostic> ProviderDiagnostics => Set<ProviderDiagnostic>();

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore;
 using Serilog;
 using Serilog.Sinks.OpenSearch;
 using Tamma.Activities.AI;
+using Tamma.Activities.LlmCall.Credentials;
 using Tamma.Activities.Security;
 using Tamma.ElsaServer.Workflows;
 
@@ -261,6 +262,19 @@ builder.Services.AddSingleton<IErrorRedactor, ErrorRedactor>();
 builder.Services.Configure<ProviderAllowlistOptions>(
     builder.Configuration.GetSection("Security:ProviderAllowlist"));
 builder.Services.AddSingleton<ProviderAllowlist>();
+
+// Story 32-3 — provider-credential resolution for CallLlmInlineActivity.
+// CRITICAL: the activity executes in THIS (Elsa engine) process, which does
+// NOT reference Tamma.Api, so the cabinet-backed DefaultProviderCredential
+// Resolver (BYOK) is unreachable here. Without a resolver registered, the
+// activity bound a null resolver and sent an EMPTY ApiKey — a hard regression
+// to no-auth. AddEngineProviderCredentialResolution wires the config-backed
+// platform-key resolver (ConfigPlatformProviderCredentialResolver) so the
+// platform key from LlmProviders:<provider>:ApiKey (or the legacy
+// <Provider>:ApiKey slot) flows through to the outbound call (AC12), and the
+// resolver fails closed (never an empty key) when no key is configured.
+// SaaS BYOK resolution stays owned by Tamma.Api's cabinet-backed resolver.
+builder.Services.AddEngineProviderCredentialResolution();
 
 // Tool call validation (Story 11.3 — allowlist enforcement, ActionGate)
 builder.Services.Configure<ActionGateOptions>(

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/LlmCallWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/LlmCallWorkflow.cs
@@ -529,7 +529,8 @@ public class LlmCallWorkflow : WorkflowBase
                                                             budgetStateVar,
                                                             workflowOutputVar,
                                                             enableToolLoopVar,
-                                                            toolLoopConfigJsonVar)
+                                                            toolLoopConfigJsonVar,
+                                                            tenantIdVar)
                                                     }
                                                 }, "Budget OK")
                                             }, "Budget Exhausted?")
@@ -752,7 +753,8 @@ public class LlmCallWorkflow : WorkflowBase
         Variable<string> budgetStateVar,
         Variable<string> workflowOutputVar,
         Variable<bool> enableToolLoopVar,
-        Variable<string> toolLoopConfigJsonVar)
+        Variable<string> toolLoopConfigJsonVar,
+        Variable<string> tenantIdVar)
     {
         var whileLoop = new While((string?)null);
         whileLoop.Id = "RetryLoop";
@@ -890,7 +892,10 @@ public class LlmCallWorkflow : WorkflowBase
                     ToolsJsonProp = new(context => resolvedToolsJsonVar.Get(context)),
                     AttemptNumberProp = new(context => attemptNumberVar.Get(context)),
                     EnableToolLoopProp = new(context => enableToolLoopVar.Get(context)),
-                    ToolLoopConfigJsonProp = new(context => toolLoopConfigJsonVar.Get(context))
+                    ToolLoopConfigJsonProp = new(context => toolLoopConfigJsonVar.Get(context)),
+                    // Story 32-3 (AC3) — thread the tenant id for BYOK credential
+                    // resolution (same pattern as the prompt/convention steps).
+                    TenantIdProp = new(context => tenantIdVar.Get(context))
                 }, "Call LLM"),
                 WithLabel(new RecordDiagnosticsInlineActivity
                 {

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/LlmCall/CallLlmInlineCredentialTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/LlmCall/CallLlmInlineCredentialTests.cs
@@ -1,0 +1,286 @@
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Primitives;
+using NUnit.Framework;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Credentials;
+using Tamma.Activities.LlmCall.Models;
+
+namespace Tamma.Activities.Tests.LlmCall;
+
+/// <summary>
+/// Story 32-3 Phase 3 / Phase 5 — credential resolution wired into
+/// <see cref="CallLlmInlineActivity"/>, including the load-bearing redaction
+/// test (AC5): the resolved BYOK key reaches the outbound HTTP header ONLY and
+/// is absent from the resulting diagnostic.
+/// </summary>
+[TestFixture]
+public class CallLlmInlineCredentialTests
+{
+    private const string Sentinel = "SENTINEL-BYOK-XYZ";
+
+    // ── AC12: LoadProviderConfig returns empty ApiKey (resolver is sole source) ──
+
+    [Test]
+    public async Task LoadProviderConfigWithKey_NoResolver_LeavesApiKeyEmpty_LegacyPath()
+    {
+        var activity = new CallLlmInlineActivity(); // no resolver
+
+        var (config, source) = await activity.LoadProviderConfigWithKeyAsync(
+            "anthropic", tenantId: null, CancellationToken.None);
+
+        config.ApiKey.Should().BeEmpty("the resolver is the only key source; legacy path leaves it blank");
+        config.BaseUrl.Should().Be("https://api.anthropic.com");
+        source.Should().BeNull();
+    }
+
+    [Test]
+    public async Task LoadProviderConfigWithKey_NeverReadsApiKeyFromConfigSection()
+    {
+        // Regression guard (Story 32-3 Risk: "_configuration read sneaks back in").
+        // Even with a populated LlmProviders config section AND legacy
+        // Anthropic:ApiKey, the activity must NOT surface a key from config — the
+        // resolver is the only key source. No resolver wired ⇒ empty key.
+        var config = new DictionaryConfiguration(new Dictionary<string, string?>
+        {
+            ["LlmProviders:anthropic:BaseUrl"] = "https://example.test",
+            ["LlmProviders:anthropic:ApiKey"] = "SHOULD-NEVER-BE-READ",
+            ["Anthropic:ApiKey"] = "SHOULD-NEVER-BE-READ-EITHER",
+        });
+        var activity = new CallLlmInlineActivity(
+            NullLogger<CallLlmInlineActivity>.Instance, null, config, null);
+
+        var (cfg, source) = await activity.LoadProviderConfigWithKeyAsync(
+            "anthropic", tenantId: null, CancellationToken.None);
+
+        cfg.ApiKey.Should().BeEmpty();
+        cfg.BaseUrl.Should().Be("https://example.test", "non-secret config still flows");
+        source.Should().BeNull();
+    }
+
+    // ── AC3/AC4: resolver populates the key + surfaces credentialSource ──
+
+    [Test]
+    public async Task LoadProviderConfigWithKey_ByokResolver_PopulatesKey_SourceByok()
+    {
+        var resolver = new FakeResolver(new ProviderCredential(
+            Sentinel, CredentialSource.Byok, "tenant:abc:provider/anthropic/api-key", 1));
+        var activity = NewActivity(resolver);
+        var tenant = Guid.NewGuid();
+
+        var (config, source) = await activity.LoadProviderConfigWithKeyAsync(
+            "anthropic", tenant, CancellationToken.None);
+
+        config.ApiKey.Should().Be(Sentinel);
+        source.Should().Be("byok");
+        resolver.LastTenantId.Should().Be(tenant);
+        resolver.LastProvider.Should().Be("anthropic");
+    }
+
+    [Test]
+    public async Task LoadProviderConfigWithKey_PlatformResolver_SourcePlatform()
+    {
+        var resolver = new FakeResolver(new ProviderCredential(
+            "PLATFORM-KEY", CredentialSource.Platform, "platform:anthropic/api-key", null));
+        var activity = NewActivity(resolver);
+
+        var (config, source) = await activity.LoadProviderConfigWithKeyAsync(
+            "anthropic", tenantId: null, CancellationToken.None);
+
+        config.ApiKey.Should().Be("PLATFORM-KEY");
+        source.Should().Be("platform");
+    }
+
+    // ── AC6: resolver fail-closed propagates (caught by the activity as a failed attempt) ──
+
+    [Test]
+    public async Task LoadProviderConfigWithKey_ResolverThrows_PropagatesTammaError()
+    {
+        var resolver = new ThrowingResolver();
+        var activity = NewActivity(resolver);
+
+        var act = async () => await activity.LoadProviderConfigWithKeyAsync(
+            "anthropic", Guid.NewGuid(), CancellationToken.None);
+
+        await act.Should().ThrowAsync<Tamma.Core.TammaError>()
+            .Where(e => e.Code == "PROVIDER_CREDENTIAL_UNAVAILABLE");
+    }
+
+    // ── AC5: REDACTION GATE — sentinel reaches the header ONLY ──────────────
+
+    [Test]
+    public async Task Redaction_ByokKey_ReachesAnthropicHeaderOnly_NeverDiagnostic()
+    {
+        var resolver = new FakeResolver(new ProviderCredential(
+            Sentinel, CredentialSource.Byok, "tenant:abc:provider/anthropic/api-key", 1));
+        var capture = new CapturingHandler(AnthropicSuccessBody());
+        var activity = NewActivity(resolver);
+        var tenant = Guid.NewGuid();
+
+        // 1) Resolve (BYOK) → config carries the sentinel.
+        var (config, source) = await activity.LoadProviderConfigWithKeyAsync(
+            "anthropic", tenant, CancellationToken.None);
+        source.Should().Be("byok");
+
+        // 2) Make the call with a capturing handler.
+        using var http = new HttpClient(capture);
+        var response = await activity.CallAnthropicMessages(
+            http, config, "claude-sonnet-4-20250514", "system", "user", 256, 0.7, null);
+
+        // 3) Sentinel is in x-api-key ONLY.
+        capture.SentApiKeyHeader.Should().Be(Sentinel);
+        capture.SentAuthorizationHeader.Should().BeNull();
+        capture.SentBody.Should().NotContain(Sentinel, "the key is a header, never the body");
+
+        // 4) Build a diagnostic exactly as the activity does and assert the
+        //    sentinel never appears in the serialized diagnostic.
+        var diag = new ProviderAttemptDiagnostic
+        {
+            ProviderName = "anthropic",
+            Model = "claude-sonnet-4-20250514",
+            Succeeded = response.Success,
+            CredentialSource = source,
+        };
+        var serializedDiag = JsonSerializer.Serialize(diag);
+        serializedDiag.Should().NotContain(Sentinel);
+        serializedDiag.Should().Contain("byok"); // the tag-safe source survives
+    }
+
+    [Test]
+    public async Task Redaction_ByokKey_ReachesOpenAiBearerHeaderOnly()
+    {
+        var resolver = new FakeResolver(new ProviderCredential(
+            Sentinel, CredentialSource.Byok, "tenant:abc:provider/openai/api-key", 1));
+        var capture = new CapturingHandler(OpenAiSuccessBody());
+        var activity = NewActivity(resolver);
+
+        var (config, _) = await activity.LoadProviderConfigWithKeyAsync(
+            "openai", Guid.NewGuid(), CancellationToken.None);
+
+        using var http = new HttpClient(capture);
+        await activity.CallOpenAiCompatible(
+            http, config, "gpt-4o", "system", "user", 256, 0.7, null);
+
+        capture.SentAuthorizationHeader.Should().Be($"Bearer {Sentinel}");
+        capture.SentApiKeyHeader.Should().BeNull();
+        capture.SentBody.Should().NotContain(Sentinel);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+
+    private static CallLlmInlineActivity NewActivity(IProviderCredentialResolver resolver) =>
+        new(NullLogger<CallLlmInlineActivity>.Instance, null, null, null,
+            null, null, null, null, null, resolver);
+
+    private static string AnthropicSuccessBody() => """
+        {"content":[{"type":"text","text":"ok"}],"model":"claude-sonnet-4-20250514",
+         "stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}
+        """;
+
+    private static string OpenAiSuccessBody() => """
+        {"choices":[{"finish_reason":"stop","message":{"content":"ok"}}],
+         "model":"gpt-4o","usage":{"prompt_tokens":1,"completion_tokens":1}}
+        """;
+
+    private sealed class FakeResolver(ProviderCredential cred) : IProviderCredentialResolver
+    {
+        public Guid? LastTenantId { get; private set; }
+        public string? LastProvider { get; private set; }
+
+        public Task<ProviderCredential> ResolveAsync(
+            Guid? tenantId, string providerName, CancellationToken ct = default)
+        {
+            LastTenantId = tenantId;
+            LastProvider = providerName;
+            return Task.FromResult(cred);
+        }
+
+        public void Invalidate(Guid? tenantId, string providerName) { }
+    }
+
+    private sealed class ThrowingResolver : IProviderCredentialResolver
+    {
+        public Task<ProviderCredential> ResolveAsync(
+            Guid? tenantId, string providerName, CancellationToken ct = default) =>
+            throw new Tamma.Core.TammaError(
+                "PROVIDER_CREDENTIAL_UNAVAILABLE", "no key",
+                retryable: false, severity: Tamma.Core.TammaErrorSeverity.High);
+
+        public void Invalidate(Guid? tenantId, string providerName) { }
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IConfiguration"/> over a flat key dictionary —
+    /// supports the indexer + <c>GetSection().Exists()</c> path that
+    /// <c>LoadProviderConfig</c> uses, without pulling an extra package ref.
+    /// </summary>
+    private sealed class DictionaryConfiguration(IDictionary<string, string?> data) : IConfiguration
+    {
+        public string? this[string key]
+        {
+            get => data.TryGetValue(key, out var v) ? v : null;
+            set => data[key] = value;
+        }
+
+        public IConfigurationSection GetSection(string key) => new Section(this, key, data);
+
+        public IEnumerable<IConfigurationSection> GetChildren() => Array.Empty<IConfigurationSection>();
+
+        public IChangeToken GetReloadToken() => new CancellationChangeToken(CancellationToken.None);
+
+        private sealed class Section(DictionaryConfiguration root, string path, IDictionary<string, string?> data)
+            : IConfigurationSection
+        {
+            public string? this[string key]
+            {
+                get => root[$"{path}:{key}"];
+                set => root[$"{path}:{key}"] = value;
+            }
+
+            public string Key => path.Split(':').Last();
+            public string Path => path;
+            public string? Value
+            {
+                get => root[path];
+                set => root[path] = value;
+            }
+
+            public IConfigurationSection GetSection(string key) => root.GetSection($"{path}:{key}");
+            public IEnumerable<IConfigurationSection> GetChildren() =>
+                data.Keys.Where(k => k.StartsWith($"{path}:", StringComparison.Ordinal))
+                    .Select(k => k[(path.Length + 1)..].Split(':')[0])
+                    .Distinct()
+                    .Select(child => (IConfigurationSection)new Section(root, $"{path}:{child}", data));
+            public IChangeToken GetReloadToken() => new CancellationChangeToken(CancellationToken.None);
+        }
+    }
+
+    private sealed class CapturingHandler(string responseBody) : HttpMessageHandler
+    {
+        public string? SentApiKeyHeader { get; private set; }
+        public string? SentAuthorizationHeader { get; private set; }
+        public string? SentBody { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Headers.TryGetValues("x-api-key", out var apiKey))
+                SentApiKeyHeader = string.Join(",", apiKey);
+            if (request.Headers.Authorization is { } auth)
+                SentAuthorizationHeader = $"{auth.Scheme} {auth.Parameter}";
+            else if (request.Headers.TryGetValues("Authorization", out var authVals))
+                SentAuthorizationHeader = string.Join(",", authVals);
+
+            if (request.Content is not null)
+                SentBody = await request.Content.ReadAsStringAsync(cancellationToken);
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseBody, System.Text.Encoding.UTF8, "application/json"),
+            };
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/LlmCall/Credentials/EngineProviderCredentialWiringTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/LlmCall/Credentials/EngineProviderCredentialWiringTests.cs
@@ -1,0 +1,144 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Credentials;
+
+namespace Tamma.Activities.Tests.LlmCall.Credentials;
+
+/// <summary>
+/// Story 32-3 review fix — Program-level wiring test for the standalone Elsa
+/// workflow host (<c>Tamma.ElsaServer</c>), which executes
+/// <see cref="CallLlmInlineActivity"/>.
+///
+/// <para><b>The defect this guards.</b> The credential resolver was registered
+/// ONLY in <c>Tamma.Api/Program.cs</c>, but the activity runs in the
+/// <c>Tamma.ElsaServer</c> process (which never references <c>Tamma.Api</c>). So
+/// at runtime the activity bound a <c>null</c> resolver and sent an EMPTY
+/// ApiKey. These tests assert that the SAME registration <c>Program.cs</c> now
+/// calls — <see cref="EngineProviderCredentialServiceCollectionExtensions
+/// .AddEngineProviderCredentialResolution"/> — produces a NON-null
+/// <see cref="IProviderCredentialResolver"/> in the engine host's DI container,
+/// and that the activity, when handed that resolver, resolves the platform key
+/// (never an empty key).</para>
+/// </summary>
+[TestFixture]
+public class EngineProviderCredentialWiringTests
+{
+    /// <summary>
+    /// Builds the engine host's DI container the way <c>Program.cs</c> does:
+    /// register <see cref="IConfiguration"/> + call
+    /// <c>AddEngineProviderCredentialResolution()</c>.
+    /// </summary>
+    private static ServiceProvider BuildEngineContainer(
+        IDictionary<string, string?>? config = null)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(config ?? new Dictionary<string, string?>())
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IConfiguration>(configuration);
+
+        // The exact call Tamma.ElsaServer/Program.cs makes.
+        services.AddEngineProviderCredentialResolution();
+
+        return services.BuildServiceProvider();
+    }
+
+    [Test]
+    public void EngineHostContainer_ResolvesNonNullCredentialResolver()
+    {
+        // THIS is the test that would have caught the defect: the engine host's
+        // container, wired by AddEngineProviderCredentialResolution(), MUST be
+        // able to resolve a non-null IProviderCredentialResolver.
+        using var provider = BuildEngineContainer();
+
+        var resolver = provider.GetService<IProviderCredentialResolver>();
+
+        resolver.Should().NotBeNull(
+            "the activity executes in the Elsa engine host and binds whatever " +
+            "IProviderCredentialResolver that host's container provides — a null " +
+            "resolver means an empty ApiKey is sent (the 32-3 regression).");
+        resolver.Should().BeOfType<ConfigPlatformProviderCredentialResolver>();
+    }
+
+    [Test]
+    public async Task EngineHostResolver_ResolvesPlatformKeyFromLlmProvidersConfig()
+    {
+        // AC12 — a deployment that supplies the platform key via the existing
+        // LlmProviders:<provider>:ApiKey appsettings slot still authenticates.
+        using var provider = BuildEngineContainer(new Dictionary<string, string?>
+        {
+            ["LlmProviders:anthropic:ApiKey"] = "PLATFORM-ANTHROPIC-KEY",
+        });
+        var resolver = provider.GetRequiredService<IProviderCredentialResolver>();
+
+        var cred = await resolver.ResolveAsync(
+            tenantId: null, "anthropic", CancellationToken.None);
+
+        cred.ApiKey.Should().Be("PLATFORM-ANTHROPIC-KEY", "the platform key flows through (AC12)");
+        cred.Source.Should().Be(CredentialSource.Platform);
+    }
+
+    [Test]
+    public async Task EngineHostResolver_ResolvesPlatformKeyFromLegacySlot()
+    {
+        // AC12 — the pre-32-3 per-provider slot (Anthropic:ApiKey) that the
+        // activity used to read directly must still produce a key.
+        using var provider = BuildEngineContainer(new Dictionary<string, string?>
+        {
+            ["Anthropic:ApiKey"] = "LEGACY-ANTHROPIC-KEY",
+        });
+        var resolver = provider.GetRequiredService<IProviderCredentialResolver>();
+
+        var cred = await resolver.ResolveAsync(
+            tenantId: null, "anthropic", CancellationToken.None);
+
+        cred.ApiKey.Should().Be("LEGACY-ANTHROPIC-KEY");
+        cred.Source.Should().Be(CredentialSource.Platform);
+    }
+
+    [Test]
+    public void EngineHostResolver_NoPlatformKey_FailsClosed_NeverEmptyKey()
+    {
+        // AC6 — when no platform key is configured the resolver throws the
+        // fail-closed TammaError; it must NEVER hand back an empty key.
+        using var provider = BuildEngineContainer();
+        var resolver = provider.GetRequiredService<IProviderCredentialResolver>();
+
+        var act = async () => await resolver.ResolveAsync(
+            tenantId: null, "anthropic", CancellationToken.None);
+
+        act.Should().ThrowAsync<Tamma.Core.TammaError>()
+            .Where(e => e.Code == "PROVIDER_CREDENTIAL_UNAVAILABLE");
+    }
+
+    [Test]
+    public async Task ActivityBoundToEngineResolver_GetsPlatformKey_NotEmpty()
+    {
+        // End-to-end: the activity, constructed with the engine host's resolver,
+        // populates a NON-empty ApiKey. This proves the fix at the seam the
+        // defect lived at (LoadProviderConfigWithKeyAsync's null-resolver branch
+        // sent an empty key in production).
+        using var provider = BuildEngineContainer(new Dictionary<string, string?>
+        {
+            ["LlmProviders:openai:ApiKey"] = "PLATFORM-OPENAI-KEY",
+        });
+        var resolver = provider.GetRequiredService<IProviderCredentialResolver>();
+
+        var activity = new CallLlmInlineActivity(
+            logger: null, httpClientFactory: null, configuration: null, sanitizer: null,
+            toolRegistry: null, toolCallValidator: null, contextCompactor: null,
+            eventEmitter: null, parallelExecutor: null, credentialResolver: resolver);
+
+        var (config, source) = await activity.LoadProviderConfigWithKeyAsync(
+            "openai", tenantId: null, CancellationToken.None);
+
+        config.ApiKey.Should().Be("PLATFORM-OPENAI-KEY",
+            "with the engine resolver wired the activity no longer sends an empty key");
+        source.Should().Be("platform");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/LlmCall/Credentials/ProviderCabinetNamesTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/LlmCall/Credentials/ProviderCabinetNamesTests.cs
@@ -1,0 +1,56 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.LlmCall.Credentials;
+
+namespace Tamma.Activities.Tests.LlmCall.Credentials;
+
+/// <summary>
+/// Story 32-3 Phase 1 — name-mapping is a single source of truth so the BYOK
+/// management API and the resolver can never drift on the slug.
+/// </summary>
+[TestFixture]
+public class ProviderCabinetNamesTests
+{
+    [TestCase("anthropic", "provider/anthropic/api-key")]
+    [TestCase("openai", "provider/openai/api-key")]
+    [TestCase("openrouter", "provider/openrouter/api-key")]
+    public void Byok_MapsProviderToTenantSlug(string provider, string expected)
+    {
+        ProviderCabinetNames.Byok(provider).Should().Be(expected);
+    }
+
+    [TestCase("anthropic", "anthropic/api-key")]
+    [TestCase("openai", "openai/api-key")]
+    [TestCase("openrouter", "openrouter/api-key")]
+    public void Platform_MapsProviderToPlatformSlug(string provider, string expected)
+    {
+        ProviderCabinetNames.Platform(provider).Should().Be(expected);
+    }
+
+    [Test]
+    public void Byok_NormalizesCasingAndWhitespace()
+    {
+        ProviderCabinetNames.Byok("  Anthropic  ").Should().Be("provider/anthropic/api-key");
+    }
+
+    [Test]
+    public void Platform_AnthropicMatchesStopgapConstant()
+    {
+        // The platform leg must reuse the Story 29-9 platform cabinet name.
+        ProviderCabinetNames.Platform("anthropic").Should().Be("anthropic/api-key");
+    }
+
+    [Test]
+    public void Byok_RejectsEmpty()
+    {
+        var act = () => ProviderCabinetNames.Byok("");
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void Platform_RejectsNull()
+    {
+        var act = () => ProviderCabinetNames.Platform(null!);
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentEndpointsTests.cs
@@ -310,6 +310,280 @@ public class AgentEndpointsTests
         }
     }
 
+    // ── Story 32-2 AC5 — list filters (?role=&visibility=&status=) ──
+
+    /// <summary>
+    /// Seed a fixed mix for the filter tests: one public + several own-private
+    /// (different roles, one archived) for tenant A, plus a tenant-B private the
+    /// caller must NEVER see. Returns the tenant-A admin principal.
+    /// </summary>
+    private async Task<ClaimsPrincipal> SeedFilterFixtureAsync(IAgentRepository repo)
+    {
+        var pa = Principal(Guid.NewGuid(), platformAdmin: true);
+        var adminA = Principal(Guid.NewGuid());
+
+        // public architect (visible to everyone)
+        await ExecuteAsync(await AgentEndpoints.CreateAgent(
+            new CreateAgentRequest("pub-architect", "architect", "public", ValidConfig, null),
+            repo, pa, TenantCtx(), Mode(TammaMode.SaaS)));
+
+        // own-private architect (active)
+        await ExecuteAsync(await AgentEndpoints.CreateAgent(
+            new CreateAgentRequest("a-architect", "architect", "private", ValidConfig, null),
+            repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS)));
+
+        // own-private developer (active)
+        await ExecuteAsync(await AgentEndpoints.CreateAgent(
+            new CreateAgentRequest("a-developer", "developer", "private", ValidConfig, null),
+            repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS)));
+
+        // own-private tester, then archived
+        var testerCreated = await ExecuteAsync(await AgentEndpoints.CreateAgent(
+            new CreateAgentRequest("a-tester", "tester", "private", ValidConfig, null),
+            repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS)));
+        await ExecuteAsync(await AgentEndpoints.ArchiveAgent(
+            testerCreated.Body.GetProperty("id").GetGuid(), repo, adminA,
+            TenantCtx(TenantA), Mode(TammaMode.SaaS)));
+
+        // tenant-B private architect — must never surface for tenant A
+        await ExecuteAsync(await AgentEndpoints.CreateAgent(
+            new CreateAgentRequest("b-architect", "architect", "private", ValidConfig, null),
+            repo, Principal(Guid.NewGuid()), TenantCtx(TenantB), Mode(TammaMode.SaaS)));
+
+        return adminA;
+    }
+
+    private static List<string> Names(JsonElement body)
+        => body.EnumerateArray().Select(e => e.GetProperty("name").GetString()!).ToList();
+
+    [Test]
+    public async Task ListAgents_NoFilters_StillReturns_Public_Union_OwnPrivate()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var adminA = await SeedFilterFixtureAsync(repo);
+            var list = await AgentEndpoints.ListAgents(
+                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS));
+            var (status, body) = await ExecuteAsync(list);
+
+            status.Should().Be(StatusCodes.Status200OK);
+            var names = Names(body);
+            names.Should().BeEquivalentTo(
+                new[] { "pub-architect", "a-architect", "a-developer", "a-tester" });
+            names.Should().NotContain("b-architect");
+        }
+    }
+
+    [Test]
+    public async Task ListAgents_FilterByRole_ReturnsOnlyThatRole()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var adminA = await SeedFilterFixtureAsync(repo);
+            var list = await AgentEndpoints.ListAgents(
+                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), role: "developer");
+            var (status, body) = await ExecuteAsync(list);
+
+            status.Should().Be(StatusCodes.Status200OK);
+            Names(body).Should().BeEquivalentTo(new[] { "a-developer" });
+        }
+    }
+
+    [Test]
+    public async Task ListAgents_FilterByRole_NeverSurfacesAnotherTenantsPrivate()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var adminA = await SeedFilterFixtureAsync(repo);
+            // architect role matches a-architect (own private), pub-architect
+            // (public), AND b-architect (tenant B private) — but B must be scoped out.
+            var list = await AgentEndpoints.ListAgents(
+                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), role: "architect");
+            var (status, body) = await ExecuteAsync(list);
+
+            status.Should().Be(StatusCodes.Status200OK);
+            var names = Names(body);
+            names.Should().BeEquivalentTo(new[] { "pub-architect", "a-architect" });
+            names.Should().NotContain("b-architect",
+                "role filter must apply AFTER visibility scoping — never widen to another tenant");
+        }
+    }
+
+    [Test]
+    public async Task ListAgents_FilterByVisibilityPrivate_ReturnsOnlyOwnPrivate()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var adminA = await SeedFilterFixtureAsync(repo);
+            var list = await AgentEndpoints.ListAgents(
+                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), visibility: "private");
+            var (status, body) = await ExecuteAsync(list);
+
+            status.Should().Be(StatusCodes.Status200OK);
+            var names = Names(body);
+            // own private only — never public, never tenant B's private.
+            names.Should().BeEquivalentTo(new[] { "a-architect", "a-developer", "a-tester" });
+            names.Should().NotContain("pub-architect");
+            names.Should().NotContain("b-architect");
+        }
+    }
+
+    [Test]
+    public async Task ListAgents_FilterByVisibilityPublic_ReturnsOnlyPublic()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var adminA = await SeedFilterFixtureAsync(repo);
+            var list = await AgentEndpoints.ListAgents(
+                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), visibility: "public");
+            var (status, body) = await ExecuteAsync(list);
+
+            status.Should().Be(StatusCodes.Status200OK);
+            Names(body).Should().BeEquivalentTo(new[] { "pub-architect" });
+        }
+    }
+
+    [Test]
+    public async Task ListAgents_FilterByStatusArchived_ReturnsOnlyArchived()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var adminA = await SeedFilterFixtureAsync(repo);
+            var list = await AgentEndpoints.ListAgents(
+                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), status: "archived");
+            var (status, body) = await ExecuteAsync(list);
+
+            status.Should().Be(StatusCodes.Status200OK);
+            Names(body).Should().BeEquivalentTo(new[] { "a-tester" });
+        }
+    }
+
+    [Test]
+    public async Task ListAgents_FilterByStatusActive_ExcludesArchived()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var adminA = await SeedFilterFixtureAsync(repo);
+            var list = await AgentEndpoints.ListAgents(
+                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), status: "active");
+            var (status, body) = await ExecuteAsync(list);
+
+            status.Should().Be(StatusCodes.Status200OK);
+            var names = Names(body);
+            names.Should().BeEquivalentTo(new[] { "pub-architect", "a-architect", "a-developer" });
+            names.Should().NotContain("a-tester");
+        }
+    }
+
+    [Test]
+    public async Task ListAgents_CombinedFilters_AndTogether()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var adminA = await SeedFilterFixtureAsync(repo);
+            // private AND architect AND active → only a-architect.
+            var list = await AgentEndpoints.ListAgents(
+                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS),
+                role: "architect", visibility: "private", status: "active");
+            var (status, body) = await ExecuteAsync(list);
+
+            status.Should().Be(StatusCodes.Status200OK);
+            Names(body).Should().BeEquivalentTo(new[] { "a-architect" });
+        }
+    }
+
+    [Test]
+    public async Task ListAgents_UnknownRole_Returns400()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var adminA = await SeedFilterFixtureAsync(repo);
+            var list = await AgentEndpoints.ListAgents(
+                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), role: "wizard");
+            var (status, body) = await ExecuteAsync(list);
+
+            status.Should().Be(StatusCodes.Status400BadRequest);
+            body.GetProperty("error").GetString().Should().Be("invalid_role");
+        }
+    }
+
+    [Test]
+    public async Task ListAgents_UnknownVisibility_Returns400()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var adminA = await SeedFilterFixtureAsync(repo);
+            var list = await AgentEndpoints.ListAgents(
+                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), visibility: "secret");
+            var (status, body) = await ExecuteAsync(list);
+
+            status.Should().Be(StatusCodes.Status400BadRequest);
+            body.GetProperty("error").GetString().Should().Be("invalid_visibility");
+        }
+    }
+
+    [Test]
+    public async Task ListAgents_UnknownStatus_Returns400()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var adminA = await SeedFilterFixtureAsync(repo);
+            var list = await AgentEndpoints.ListAgents(
+                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), status: "deleted");
+            var (status, body) = await ExecuteAsync(list);
+
+            status.Should().Be(StatusCodes.Status400BadRequest);
+            body.GetProperty("error").GetString().Should().Be("invalid_status");
+        }
+    }
+
+    [Test]
+    public async Task ListAgents_EmptyFilterStrings_TreatedAsNoFilter()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var adminA = await SeedFilterFixtureAsync(repo);
+            // Empty/whitespace params must NOT 400 and must NOT narrow.
+            var list = await AgentEndpoints.ListAgents(
+                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS),
+                role: "", visibility: "  ", status: null);
+            var (status, body) = await ExecuteAsync(list);
+
+            status.Should().Be(StatusCodes.Status200OK);
+            Names(body).Should().BeEquivalentTo(
+                new[] { "pub-architect", "a-architect", "a-developer", "a-tester" });
+        }
+    }
+
+    [Test]
+    public async Task ListAgents_FilterByRole_NormalizesLegacyAlias()
+    {
+        var (repo, ctx) = BuildRepo();
+        await using (ctx)
+        {
+            var adminA = await SeedFilterFixtureAsync(repo);
+            // 'implementer' is a legacy alias for 'developer' (RolePhaseMap).
+            var list = await AgentEndpoints.ListAgents(
+                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), role: "implementer");
+            var (status, body) = await ExecuteAsync(list);
+
+            status.Should().Be(StatusCodes.Status200OK);
+            Names(body).Should().BeEquivalentTo(new[] { "a-developer" });
+        }
+    }
+
     // ── Cross-tenant isolation: GET {id} for another tenant's private → 404 ──
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentRegistryEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentRegistryEndpointsTests.cs
@@ -1,0 +1,359 @@
+using System.Collections.Concurrent;
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Dtos.Agents;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Services.Agents;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Core;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Agents;
+
+/// <summary>
+/// Story 32-2 — endpoint-level tests for the /api/agents resolution + selection
+/// surface. Drives the <see cref="AgentEndpoints"/> handlers directly (the same
+/// delegates Program.cs maps) against a real Postgres testcontainer, with the
+/// real registry/resolver/selection stack. Covers: resolve → enriched config,
+/// bad role → 400, unresolvable → 404 (no blank), select round-trip, cross-tenant
+/// select → 404, rollback endpoint, and the public-write 403 gate.
+/// </summary>
+[TestFixture]
+public class AgentRegistryEndpointsTests
+{
+    private static readonly Guid TenantA = Guid.Parse("aaaaaaaa-32e2-32e2-32e2-aaaaaaaaaaaa");
+    private static readonly Guid TenantB = Guid.Parse("bbbbbbbb-32e2-32e2-32e2-bbbbbbbbbbbb");
+
+    private PostgreSqlContainer _postgres = null!;
+    private string _connectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("agent_registry_ep_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _connectionString = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE agent_role_selections, agent_versions, agents CASCADE;");
+    }
+
+    private ControlPlaneDbContext NewContext()
+        => new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseNpgsql(_connectionString).Options);
+
+    private const string Cfg = """{ "provider": "anthropic", "model": "claude-sonnet-4" }""";
+
+    private Stack BuildStack(TammaMode mode, Guid? tenantId, Guid? userId, bool platformAdmin = false)
+    {
+        var cpCtx = NewContext();
+        var events = new CapturingEvents();
+        var agentRepo = new AgentRepository(cpCtx, events);
+
+        var tenantContext = new TenantContext();
+        if (tenantId is Guid tid) tenantContext.SetTenantId(tid);
+
+        var factory = new SameDbTenantFactory(_connectionString);
+        var selectionRepo = new AgentSelectionRepository(cpCtx, factory, tenantContext);
+        var modeProvider = new StubMode(mode);
+        var principal = Principal(userId, platformAdmin);
+        var httpAccessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext { User = principal },
+        };
+
+        var registry = new AgentRegistryService(
+            agentRepo, selectionRepo, events, modeProvider, tenantContext, httpAccessor,
+            NullLogger<AgentRegistryService>.Instance);
+        var resolver = new AgentResolverService(
+            new AgentConfigRepository(factory), null, NullLogger<AgentResolverService>.Instance,
+            registry, agentRepo, events);
+
+        return new Stack(
+            agentRepo, registry, resolver, principal, tenantContext, modeProvider, cpCtx);
+    }
+
+    private sealed record Stack(
+        AgentRepository Agents,
+        AgentRegistryService Registry,
+        AgentResolverService Resolver,
+        ClaimsPrincipal Principal,
+        TenantContext TenantContext,
+        ITammaModeProvider Mode,
+        ControlPlaneDbContext Ctx);
+
+    private static ClaimsPrincipal Principal(Guid? userId, bool platformAdmin = false)
+    {
+        var claims = new List<Claim>();
+        if (userId is Guid uid) claims.Add(new Claim(ClaimTypes.NameIdentifier, uid.ToString()));
+        if (platformAdmin) claims.Add(new Claim("platformRole", "platform_admin"));
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
+    }
+
+    private static async Task<(int Status, JsonElement Body)> ExecuteAsync(IResult result)
+    {
+        var services = new ServiceCollection().AddLogging().AddOptions().BuildServiceProvider();
+        var ctx = new DefaultHttpContext
+        {
+            RequestServices = services,
+            Response = { Body = new MemoryStream() },
+        };
+        await result.ExecuteAsync(ctx);
+        ctx.Response.Body.Seek(0, SeekOrigin.Begin);
+        if (ctx.Response.Body.Length == 0)
+        {
+            return (ctx.Response.StatusCode, default);
+        }
+        using var doc = await JsonDocument.ParseAsync(ctx.Response.Body);
+        return (ctx.Response.StatusCode, doc.RootElement.Clone());
+    }
+
+    private async Task<Agent> SeedPublicAsync(AgentRepository repo, string role, string handle)
+        => await repo.CreateAsync(
+            new Agent { Name = handle, Role = role, Visibility = AgentVisibility.Public }, Cfg, null, null);
+
+    private async Task<Agent> SeedTenantPrivateAsync(AgentRepository repo, Guid tenantId, string role, string name)
+        => await repo.CreateAsync(
+            new Agent { Name = name, Role = role, Visibility = AgentVisibility.Private, OwnerTenantId = tenantId },
+            Cfg, null, null);
+
+    // ── Resolve endpoint ──
+
+    [Test]
+    public async Task Resolve_NoRole_Returns400()
+    {
+        var s = BuildStack(TammaMode.SaaS, TenantA, null);
+        await using (s.Ctx)
+        {
+            var (status, _) = await ExecuteAsync(await AgentEndpoints.Resolve(null, null, s.Resolver));
+            status.Should().Be(StatusCodes.Status400BadRequest);
+        }
+    }
+
+    [Test]
+    public async Task Resolve_BadRole_Returns400()
+    {
+        var s = BuildStack(TammaMode.SaaS, TenantA, null);
+        await using (s.Ctx)
+        {
+            var (status, _) = await ExecuteAsync(await AgentEndpoints.Resolve("wizard", null, s.Resolver));
+            status.Should().Be(StatusCodes.Status400BadRequest);
+        }
+    }
+
+    [Test]
+    public async Task Resolve_Unresolvable_Returns404_NoBlankConfig()
+    {
+        var s = BuildStack(TammaMode.SaaS, TenantA, null);
+        await using (s.Ctx)
+        {
+            // No agent seeded — fail-loud path → 404 with code, no config body.
+            var (status, body) = await ExecuteAsync(await AgentEndpoints.Resolve("tester", null, s.Resolver));
+            status.Should().Be(StatusCodes.Status404NotFound);
+            body.GetProperty("error").GetString().Should().Be("agent_resolve_no_default");
+        }
+    }
+
+    [Test]
+    public async Task Resolve_SystemDefault_ReturnsEnrichedConfig()
+    {
+        var s = BuildStack(TammaMode.SaaS, TenantA, null);
+        await using (s.Ctx)
+        {
+            var pub = await SeedPublicAsync(s.Agents, "developer", "tamma-developer");
+            var (status, body) = await ExecuteAsync(await AgentEndpoints.Resolve("developer", null, s.Resolver));
+            status.Should().Be(StatusCodes.Status200OK);
+            body.GetProperty("source").GetString().Should().Be("system-public");
+            body.GetProperty("agentId").GetGuid().Should().Be(pub.Id);
+            body.GetProperty("agentVersion").GetInt32().Should().Be(1);
+        }
+    }
+
+    // ── Select round-trip + respected by resolve ──
+
+    [Test]
+    public async Task SelectForRole_Persists_And_RespectedByResolve()
+    {
+        var s = BuildStack(TammaMode.SaaS, TenantA, null);
+        await using (s.Ctx)
+        {
+            await SeedPublicAsync(s.Agents, "developer", "tamma-developer");
+            var priv = await SeedTenantPrivateAsync(s.Agents, TenantA, "developer", "atlas");
+
+            var sel = await AgentEndpoints.SelectForRole(
+                "developer", new SelectRoleRequest(priv.Id), s.Registry, s.Principal);
+            var (selStatus, _) = await ExecuteAsync(sel);
+            selStatus.Should().Be(StatusCodes.Status200OK);
+
+            var (resStatus, body) = await ExecuteAsync(
+                await AgentEndpoints.Resolve("developer", null, s.Resolver));
+            resStatus.Should().Be(StatusCodes.Status200OK);
+            body.GetProperty("agentId").GetGuid().Should().Be(priv.Id);
+            body.GetProperty("source").GetString().Should().Be("tenant-private");
+        }
+    }
+
+    [Test]
+    public async Task SelectForRole_BadRole_Returns400()
+    {
+        var s = BuildStack(TammaMode.SaaS, TenantA, null);
+        await using (s.Ctx)
+        {
+            var sel = await AgentEndpoints.SelectForRole(
+                "wizard", new SelectRoleRequest(Guid.NewGuid()), s.Registry, s.Principal);
+            var (status, _) = await ExecuteAsync(sel);
+            status.Should().Be(StatusCodes.Status400BadRequest);
+        }
+    }
+
+    [Test]
+    public async Task SelectForRole_CrossTenantPrivateTarget_Returns404()
+    {
+        var s = BuildStack(TammaMode.SaaS, TenantA, null);
+        await using (s.Ctx)
+        {
+            // Agent owned by TenantB; TenantA's principal must get 404, not 403.
+            var foreign = await SeedTenantPrivateAsync(s.Agents, TenantB, "developer", "their-atlas");
+            var sel = await AgentEndpoints.SelectForRole(
+                "developer", new SelectRoleRequest(foreign.Id), s.Registry, s.Principal);
+            var (status, body) = await ExecuteAsync(sel);
+            status.Should().Be(StatusCodes.Status404NotFound);
+            body.GetProperty("error").GetString().Should().Be("agent_not_found");
+        }
+    }
+
+    // ── Rollback endpoint (AC 13) ──
+
+    [Test]
+    public async Task Rollback_RepointsActiveVersion_ResolvesPrior()
+    {
+        var s = BuildStack(TammaMode.SaaS, TenantA, null);
+        await using (s.Ctx)
+        {
+            var priv = await s.Agents.CreateAsync(
+                new Agent { Name = "atlas", Role = "developer", Visibility = AgentVisibility.Private, OwnerTenantId = TenantA },
+                """{ "provider": "anthropic", "model": "v1" }""", "v1", null);
+            await s.Agents.PublishVersionAsync(priv.Id, """{ "provider": "openai", "model": "v2" }""", "v2", null);
+
+            var rb = await AgentEndpoints.RollbackVersion(
+                priv.Id, new RollbackVersionRequest(1), s.Agents, s.Principal, s.TenantContext, s.Mode);
+            var (status, body) = await ExecuteAsync(rb);
+            status.Should().Be(StatusCodes.Status200OK);
+            body.GetProperty("version").GetInt32().Should().Be(1);
+
+            var reloaded = await s.Agents.GetActiveVersionAsync(priv.Id);
+            reloaded!.Version.Should().Be(1);
+        }
+    }
+
+    [Test]
+    public async Task Rollback_UnknownVersion_Returns404()
+    {
+        var s = BuildStack(TammaMode.SaaS, TenantA, null);
+        await using (s.Ctx)
+        {
+            var priv = await SeedTenantPrivateAsync(s.Agents, TenantA, "developer", "atlas");
+            var rb = await AgentEndpoints.RollbackVersion(
+                priv.Id, new RollbackVersionRequest(99), s.Agents, s.Principal, s.TenantContext, s.Mode);
+            var (status, _) = await ExecuteAsync(rb);
+            status.Should().Be(StatusCodes.Status404NotFound);
+        }
+    }
+
+    [Test]
+    public async Task Rollback_PublicAgent_AsNonPlatformAdmin_Returns403()
+    {
+        var s = BuildStack(TammaMode.SaaS, TenantA, null);
+        await using (s.Ctx)
+        {
+            var pub = await SeedPublicAsync(s.Agents, "developer", "tamma-developer");
+            await s.Agents.PublishVersionAsync(pub.Id, Cfg, "v2", null);
+            // Caller is a tenant admin (no platformRole claim) — public write forbidden.
+            var rb = await AgentEndpoints.RollbackVersion(
+                pub.Id, new RollbackVersionRequest(1), s.Agents, s.Principal, s.TenantContext, s.Mode);
+            var (status, _) = await ExecuteAsync(rb);
+            status.Should().Be(StatusCodes.Status403Forbidden);
+        }
+    }
+
+    // ── Public-create 403 gate via /api/agents (in-handler IsPlatformAdmin) ──
+
+    [Test]
+    public async Task Create_PublicAsTenantAdmin_Returns403_NoRow()
+    {
+        var s = BuildStack(TammaMode.SaaS, TenantA, null);
+        await using (s.Ctx)
+        {
+            var req = new CreateAgentRequest("tamma-architect", "architect", "public",
+                JsonDocument.Parse(Cfg).RootElement.Clone(), null);
+            var create = await AgentEndpoints.CreateAgent(
+                req, s.Agents, s.Principal, s.TenantContext, s.Mode);
+            var (status, body) = await ExecuteAsync(create);
+            status.Should().Be(StatusCodes.Status403Forbidden);
+            body.GetProperty("error").GetString().Should().Be("forbidden");
+            (await s.Ctx.Agents.CountAsync()).Should().Be(0);
+        }
+    }
+
+    // ── test doubles ──
+
+    private sealed class StubMode(TammaMode mode) : ITammaModeProvider
+    {
+        public TammaMode Mode { get; } = mode;
+    }
+
+    private sealed class SameDbTenantFactory(string conn) : ITenantDbContextFactory
+    {
+        public ValueTask<TenantDbContext> CreateAsync(
+            Guid tenantId, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(new TenantDbContext(
+                new DbContextOptionsBuilder<TenantDbContext>().UseNpgsql(conn).Options, tenantId));
+    }
+
+    private sealed class CapturingEvents : IEventRepository
+    {
+        public ConcurrentQueue<DomainEvent> Captured { get; } = new();
+        public Task<DomainEvent> AppendAsync(DomainEvent evt) { Captured.Enqueue(evt); return Task.FromResult(evt); }
+        public Task<DomainEvent?> GetByIdAsync(Guid id) => Task.FromResult<DomainEvent?>(null);
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit) =>
+            Task.FromResult(Captured.ToList());
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type) =>
+            Task.FromResult<DomainEvent?>(null);
+        public Task ClearAsync(Guid tenantId) => Task.CompletedTask;
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(
+            Guid? tenantId, string? type, int? issueNumber, int limit, int offset) =>
+            Task.FromResult(((IReadOnlyList<DomainEvent>)Captured.ToList(), Captured.Count));
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(
+            Guid tenantId, string? typePrefix, int limit, int offset) =>
+            Task.FromResult(((IReadOnlyList<DomainEvent>)Captured.ToList(), Captured.Count));
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentRegistryEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentRegistryEndpointsTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 using Tamma.Api.Dtos.Agents;
@@ -223,6 +224,152 @@ public class AgentRegistryEndpointsTests
     }
 
     [Test]
+    public async Task SelectForRole_PublicAgent_StoredHintMatchesResolvedSource_TenantPublic()
+    {
+        // Review follow-up (32-2 #2): a principal SELECTING a public agent must
+        // store the SAME provenance the resolver stamps for it — "tenant-public"
+        // — so GET /role-selections and Resolve agree (not "system-public").
+        var s = BuildStack(TammaMode.SaaS, TenantA, null);
+        await using (s.Ctx)
+        {
+            var pub = await SeedPublicAsync(s.Agents, "developer", "tamma-developer");
+
+            var sel = await AgentEndpoints.SelectForRole(
+                "developer", new SelectRoleRequest(pub.Id), s.Registry, s.Principal);
+            var (selStatus, selBody) = await ExecuteAsync(sel);
+            selStatus.Should().Be(StatusCodes.Status200OK);
+            // PUT response carries the stored hint.
+            selBody.GetProperty("visibility").GetString().Should().Be("tenant-public");
+
+            // GET /role-selections reports the stored hint.
+            var (listStatus, listBody) = await ExecuteAsync(
+                await AgentEndpoints.GetRoleSelections(s.Registry));
+            listStatus.Should().Be(StatusCodes.Status200OK);
+            var stored = listBody.EnumerateArray()
+                .Single(e => e.GetProperty("role").GetString() == "developer")
+                .GetProperty("visibility").GetString();
+
+            // Resolve reports the live source.
+            var (resStatus, resBody) = await ExecuteAsync(
+                await AgentEndpoints.Resolve("developer", null, s.Resolver));
+            resStatus.Should().Be(StatusCodes.Status200OK);
+            var resolvedSource = resBody.GetProperty("source").GetString();
+
+            resolvedSource.Should().Be("tenant-public");
+            stored.Should().Be(resolvedSource,
+                "the stored selection hint must match the resolved source for the same selection");
+        }
+    }
+
+    [Test]
+    public async Task SelectForRole_LoserOfFirstTimeRace_ReReadsAndUpdates_NoConflict_LastWriterWins()
+    {
+        // Review follow-up (32-2 #1), DETERMINISTIC half: the loser path is forced
+        // by hand. repoB reads null (no row yet), THEN a competing writer commits
+        // the winner row, THEN repoB saves → unique (TenantId,UserId,Role)
+        // violation. The repo must catch it, re-read the winner, and UPDATE it
+        // (no raw DbUpdateException → no 500). Final value = repoB's later write.
+        Guid agentWinner, agentLoserWrite;
+        await using (var seed = NewContext())
+        {
+            var repo = new AgentRepository(seed, new CapturingEvents());
+            agentWinner = (await repo.CreateAsync(
+                new Agent { Name = "atlas-w", Role = "developer", Visibility = AgentVisibility.Private, OwnerTenantId = TenantA },
+                Cfg, null, null)).Id;
+            agentLoserWrite = (await repo.CreateAsync(
+                new Agent { Name = "atlas-l", Role = "developer", Visibility = AgentVisibility.Private, OwnerTenantId = TenantA },
+                Cfg, null, null)).Id;
+        }
+
+        var tenantContext = new TenantContext();
+        tenantContext.SetTenantId(TenantA);
+
+        // A factory that, on its FIRST CreateAsync, hands back a context whose
+        // SaveChanges is guaranteed to lose: we pre-commit the winner row through
+        // a SEPARATE connection AFTER the repo's read but BEFORE its save, by
+        // wrapping the read so the insert lands in between.
+        var factory = new BarrierTenantFactory(_connectionString, async () =>
+        {
+            // Competing writer commits the winner row while repoB sits between its
+            // read (already returned null) and its save.
+            await using var competitor = NewContext();
+            competitor.AgentRoleSelections.Add(new AgentRoleSelection
+            {
+                Id = Guid.NewGuid(), TenantId = TenantA, UserId = null, Role = "developer",
+                AgentId = agentWinner, Visibility = "tenant-private",
+                CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow,
+            });
+            await competitor.SaveChangesAsync();
+        });
+
+        await using var ctxB = NewContext();
+        var repoB = new AgentSelectionRepository(ctxB, factory, tenantContext);
+
+        var (entity, wasCreated) = await repoB.UpsertByTenantAsync(
+            TenantA, "developer", agentLoserWrite, "tenant-private", null);
+
+        wasCreated.Should().BeFalse("the loser re-reads and updates the winner's existing row");
+        entity.AgentId.Should().Be(agentLoserWrite, "last-writer-wins: repoB's value survives");
+
+        await using var verify = NewContext();
+        var rows = await verify.AgentRoleSelections.IgnoreQueryFilters()
+            .Where(s => s.TenantId == TenantA && s.Role == "developer").ToListAsync();
+        rows.Should().ContainSingle("exactly one selection per (tenant, role) survives the race");
+        rows.Single().AgentId.Should().Be(agentLoserWrite);
+    }
+
+    [Test]
+    public async Task SelectForRole_ConcurrentFirstTimeSelects_SameRole_OneRow_NoConflict()
+    {
+        // Review follow-up (32-2 #1), STRESS half: two genuinely concurrent
+        // first-time selects for the same (principal, role). Whichever loses the
+        // INSERT race re-reads→updates rather than throwing. Looped to make the
+        // race reliably surface; the invariant (one row, no throw) holds every run.
+        Guid agentA, agentB;
+        await using (var seed = NewContext())
+        {
+            var repo = new AgentRepository(seed, new CapturingEvents());
+            agentA = (await repo.CreateAsync(
+                new Agent { Name = "atlas-a", Role = "developer", Visibility = AgentVisibility.Private, OwnerTenantId = TenantA },
+                Cfg, null, null)).Id;
+            agentB = (await repo.CreateAsync(
+                new Agent { Name = "atlas-b", Role = "developer", Visibility = AgentVisibility.Private, OwnerTenantId = TenantA },
+                Cfg, null, null)).Id;
+        }
+
+        var tenantContext = new TenantContext();
+        tenantContext.SetTenantId(TenantA);
+        var factory = new SameDbTenantFactory(_connectionString);
+
+        for (var i = 0; i < 5; i++)
+        {
+            await using (var reset = NewContext())
+            {
+                await reset.Database.ExecuteSqlRawAsync("TRUNCATE agent_role_selections CASCADE;");
+            }
+
+            await using var ctxA = NewContext();
+            await using var ctxB = NewContext();
+            var repoA = new AgentSelectionRepository(ctxA, factory, tenantContext);
+            var repoB = new AgentSelectionRepository(ctxB, factory, tenantContext);
+
+            var taskA = repoA.UpsertByTenantAsync(TenantA, "developer", agentA, "tenant-private", null);
+            var taskB = repoB.UpsertByTenantAsync(TenantA, "developer", agentB, "tenant-private", null);
+
+            Func<Task> act = async () => await Task.WhenAll(taskA, taskB);
+            await act.Should().NotThrowAsync(
+                "the upsert must absorb the unique-violation race rather than surfacing a 500");
+
+            await using var verify = NewContext();
+            var rows = await verify.AgentRoleSelections.IgnoreQueryFilters()
+                .Where(s => s.TenantId == TenantA && s.Role == "developer").ToListAsync();
+            rows.Should().ContainSingle("exactly one selection per (tenant, role) survives the race");
+            new[] { agentA, agentB }.Should().Contain(rows.Single().AgentId,
+                "the surviving row holds one of the two concurrently-written agents");
+        }
+    }
+
+    [Test]
     public async Task SelectForRole_BadRole_Returns400()
     {
         var s = BuildStack(TammaMode.SaaS, TenantA, null);
@@ -248,6 +395,47 @@ public class AgentRegistryEndpointsTests
             var (status, body) = await ExecuteAsync(sel);
             status.Should().Be(StatusCodes.Status404NotFound);
             body.GetProperty("error").GetString().Should().Be("agent_not_found");
+        }
+    }
+
+    [Test]
+    public async Task GetSystemDefaultPublic_MultipleActivePublicForRole_PicksFirstByName_WarnsOnAmbiguity()
+    {
+        // Review follow-up (32-2 #3): adding a second active public agent for the
+        // same role must NOT silently shift the default — keep the deterministic
+        // first-by-name pick, but log a WARN so the ambiguity is observable.
+        var logProvider = new Infrastructure.CapturingLoggerProvider();
+        using var loggerFactory = LoggerFactory.Create(b => b.AddProvider(logProvider));
+
+        var cpCtx = NewContext();
+        var events = new CapturingEvents();
+        var agentRepo = new AgentRepository(cpCtx, events);
+        var tenantContext = new TenantContext();
+        tenantContext.SetTenantId(TenantA);
+        var factory = new SameDbTenantFactory(_connectionString);
+        var selectionRepo = new AgentSelectionRepository(cpCtx, factory, tenantContext);
+        var registry = new AgentRegistryService(
+            agentRepo, selectionRepo, events, new StubMode(TammaMode.SaaS),
+            tenantContext, new HttpContextAccessor { HttpContext = new DefaultHttpContext() },
+            loggerFactory.CreateLogger<AgentRegistryService>());
+
+        await using (cpCtx)
+        {
+            // Two active public agents for the same role; "alpha" < "tamma" ordinal.
+            await SeedPublicAsync(agentRepo, "developer", "tamma-developer");
+            var alpha = await SeedPublicAsync(agentRepo, "developer", "alpha-developer");
+
+            var chosen = await registry.GetSystemDefaultPublicAsync("developer");
+
+            chosen.Should().NotBeNull("ambiguity must not throw — keep a deterministic pick");
+            chosen!.Id.Should().Be(alpha.Id, "first-by-name (ordinal) is the deterministic winner");
+
+            var warn = logProvider.Entries.Should().ContainSingle(e =>
+                e.Level == LogLevel.Warning &&
+                e.Message.Contains("agent.system_default.ambiguous")).Subject;
+            warn.Message.Should().Contain("developer");
+            warn.Message.Should().Contain("count=2");
+            warn.Message.Should().Contain(alpha.Id.ToString());
         }
     }
 
@@ -337,6 +525,46 @@ public class AgentRegistryEndpointsTests
             Guid tenantId, CancellationToken cancellationToken = default)
             => ValueTask.FromResult(new TenantDbContext(
                 new DbContextOptionsBuilder<TenantDbContext>().UseNpgsql(conn).Options, tenantId));
+    }
+
+    /// <summary>
+    /// Factory whose context fires <paramref name="afterFirstRead"/> exactly once,
+    /// right after the FIRST reader (SELECT) completes — i.e. between the upsert's
+    /// existing-row read and its INSERT save. Used to deterministically interleave
+    /// a competing writer so the upsert's unique-violation catch path is exercised.
+    /// </summary>
+    private sealed class BarrierTenantFactory(string conn, Func<Task> afterFirstRead)
+        : ITenantDbContextFactory
+    {
+        public ValueTask<TenantDbContext> CreateAsync(
+            Guid tenantId, CancellationToken cancellationToken = default)
+        {
+            var options = new DbContextOptionsBuilder<TenantDbContext>()
+                .UseNpgsql(conn)
+                .AddInterceptors(new FirstReadBarrierInterceptor(afterFirstRead))
+                .Options;
+            return ValueTask.FromResult(new TenantDbContext(options, tenantId));
+        }
+
+        private sealed class FirstReadBarrierInterceptor(Func<Task> afterFirstRead)
+            : Microsoft.EntityFrameworkCore.Diagnostics.DbCommandInterceptor
+        {
+            private int _fired;
+
+            public override async ValueTask<System.Data.Common.DbDataReader>
+                ReaderExecutedAsync(
+                    System.Data.Common.DbCommand command,
+                    Microsoft.EntityFrameworkCore.Diagnostics.CommandExecutedEventData eventData,
+                    System.Data.Common.DbDataReader result,
+                    CancellationToken cancellationToken = default)
+            {
+                if (Interlocked.Exchange(ref _fired, 1) == 0)
+                {
+                    await afterFirstRead();
+                }
+                return result;
+            }
+        }
     }
 
     private sealed class CapturingEvents : IEventRepository

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentResolverChainTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentResolverChainTests.cs
@@ -1,0 +1,430 @@
+using System.Collections.Concurrent;
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Auth;
+using Tamma.Api.Services.Agents;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Core;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Agents;
+
+/// <summary>
+/// Story 32-2 — the entity-aware resolution chain (AC 2, 3, 9, 10, 13). Drives
+/// <see cref="AgentResolverService.ResolveForRoleAsync"/> /
+/// <see cref="AgentResolverService.ResolveForRoleAndPhaseAsync"/> against a real
+/// Postgres testcontainer with the real <see cref="AgentRepository"/> +
+/// <see cref="AgentSelectionRepository"/> + <see cref="AgentRegistryService"/>,
+/// proving all four precedence branches including the no-empty-fallback throw.
+/// </summary>
+[TestFixture]
+public class AgentResolverChainTests
+{
+    private static readonly Guid TenantA = Guid.Parse("aaaaaaaa-3202-3202-3202-aaaaaaaaaaaa");
+    private static readonly Guid TenantB = Guid.Parse("bbbbbbbb-3202-3202-3202-bbbbbbbbbbbb");
+    private static readonly Guid UserA = Guid.Parse("cccccccc-3202-3202-3202-cccccccccccc");
+
+    private PostgreSqlContainer _postgres = null!;
+    private string _connectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("agent_resolve_chain_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _connectionString = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE agent_role_selections, agent_versions, agents CASCADE;");
+    }
+
+    private ControlPlaneDbContext NewContext()
+        => new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseNpgsql(_connectionString).Options);
+
+    private const string Cfg = """{ "provider": "anthropic", "model": "claude-sonnet-4" }""";
+
+    /// <summary>
+    /// Builds the full resolver stack. The SaaS selection path routes through a
+    /// tenant context — for these tests we point the tenant factory at the SAME
+    /// physical DB (the per-tenant connection is the production isolation plane;
+    /// here we validate the discriminator-column routing, mirroring how
+    /// audit/prompt repos test the shared-DB transitional phase).
+    /// </summary>
+    private Harness BuildHarness(TammaMode mode, Guid? tenantId, Guid? userId)
+    {
+        var cpCtx = NewContext();
+        var events = new CapturingEvents();
+        var agentRepo = new AgentRepository(cpCtx, events);
+
+        var tenantContext = new TenantContext();
+        if (tenantId is Guid tid) tenantContext.SetTenantId(tid);
+
+        var factory = new SameDbTenantFactory(_connectionString);
+        var selectionRepo = new AgentSelectionRepository(cpCtx, factory, tenantContext);
+
+        var modeProvider = new StubMode(mode);
+        var httpAccessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext { User = Principal(userId) },
+        };
+
+        var registry = new AgentRegistryService(
+            agentRepo, selectionRepo, events, modeProvider, tenantContext, httpAccessor,
+            NullLogger<AgentRegistryService>.Instance);
+
+        // The legacy JSONB repo is never exercised by the entity-aware chain; a
+        // real instance is wired so the full constructor is satisfied.
+        var legacyRepo = new AgentConfigRepository(factory);
+        var resolver = new AgentResolverService(
+            legacyRepo, null, NullLogger<AgentResolverService>.Instance,
+            registry, agentRepo, events);
+
+        return new Harness(resolver, registry, agentRepo, events, cpCtx);
+    }
+
+    private sealed record Harness(
+        AgentResolverService Resolver,
+        AgentRegistryService Registry,
+        AgentRepository Agents,
+        CapturingEvents Events,
+        ControlPlaneDbContext Ctx);
+
+    private static ClaimsPrincipal Principal(Guid? userId)
+    {
+        var claims = new List<Claim>();
+        if (userId is Guid uid) claims.Add(new Claim(ClaimTypes.NameIdentifier, uid.ToString()));
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
+    }
+
+    // ── seed helpers ──
+
+    private async Task<Agent> SeedPublicAsync(AgentRepository repo, string role, string handle)
+        => await repo.CreateAsync(
+            new Agent { Name = handle, Role = role, Visibility = AgentVisibility.Public },
+            Cfg, "seed", null);
+
+    private async Task<Agent> SeedTenantPrivateAsync(AgentRepository repo, Guid tenantId, string role, string name)
+        => await repo.CreateAsync(
+            new Agent { Name = name, Role = role, Visibility = AgentVisibility.Private, OwnerTenantId = tenantId },
+            Cfg, "seed", null);
+
+    private async Task<Agent> SeedUserPrivateAsync(AgentRepository repo, Guid userId, string role, string name)
+        => await repo.CreateAsync(
+            new Agent { Name = name, Role = role, Visibility = AgentVisibility.Private, OwnerUserId = userId },
+            Cfg, "seed", null);
+
+    // ── Branch (c): no selection ⇒ system-default public ──
+
+    [Test]
+    public async Task Resolve_NoSelection_FallsToSystemDefaultPublic()
+    {
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null);
+        await using (h.Ctx)
+        {
+            var pub = await SeedPublicAsync(h.Agents, "architect", "tamma-architect");
+
+            var resolved = await h.Resolver.ResolveForRoleAsync("architect");
+
+            resolved.Source.Should().Be("system-public");
+            resolved.AgentId.Should().Be(pub.Id);
+            resolved.AgentVersion.Should().Be(1);
+            resolved.Role.Should().Be("architect");
+            resolved.Provider.Should().NotBeNullOrEmpty();
+        }
+    }
+
+    // ── Branch (b): tenant-selected public wins over system default ──
+
+    [Test]
+    public async Task Resolve_SelectedPublic_Wins_Source_TenantPublic()
+    {
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null);
+        await using (h.Ctx)
+        {
+            // Two public agents for the role; selecting one must override the
+            // "first matching" system default.
+            await SeedPublicAsync(h.Agents, "developer", "tamma-developer");
+            var chosen = await SeedPublicAsync(h.Agents, "developer", "acme-public-dev");
+
+            await h.Registry.SelectForRoleAsync("developer", chosen.Id, null);
+
+            var resolved = await h.Resolver.ResolveForRoleAsync("developer");
+
+            resolved.AgentId.Should().Be(chosen.Id);
+            resolved.Source.Should().Be("tenant-public");
+        }
+    }
+
+    // ── Branch (a): tenant-selected private wins over everything ──
+
+    [Test]
+    public async Task Resolve_SelectedPrivate_Wins_Source_TenantPrivate()
+    {
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null);
+        await using (h.Ctx)
+        {
+            await SeedPublicAsync(h.Agents, "developer", "tamma-developer");
+            var priv = await SeedTenantPrivateAsync(h.Agents, TenantA, "developer", "atlas");
+
+            await h.Registry.SelectForRoleAsync("developer", priv.Id, null);
+
+            var resolved = await h.Resolver.ResolveForRoleAsync("developer");
+
+            resolved.AgentId.Should().Be(priv.Id);
+            resolved.Source.Should().Be("tenant-private");
+            resolved.Handle.Should().Be("atlas");
+        }
+    }
+
+    // ── Branch (d): NO system default ⇒ fail loud, no blank config ──
+
+    [Test]
+    public async Task Resolve_NoSelection_NoSystemDefault_FailsLoud_NoBlankConfig()
+    {
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null);
+        await using (h.Ctx)
+        {
+            // No agent seeded for "tester" at all.
+            Func<Task> act = async () => await h.Resolver.ResolveForRoleAsync("tester");
+
+            (await act.Should().ThrowAsync<TammaError>())
+                .Which.Code.Should().Be("AGENT.RESOLVE.NO_DEFAULT");
+
+            // The mandatory AGENT.RESOLVE.FAILED event fired (even without a
+            // missing-config recorder) — and NO config object was produced.
+            h.Events.Captured.Should().ContainSingle(e => e.Type == "AGENT.RESOLVE.FAILED");
+        }
+    }
+
+    [Test]
+    public async Task Resolve_FailLoud_Event_CarriesRoleAndMode()
+    {
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null);
+        await using (h.Ctx)
+        {
+            try { await h.Resolver.ResolveForRoleAsync("security"); }
+            catch (TammaError) { /* expected */ }
+
+            var evt = h.Events.Captured.Single(e => e.Type == "AGENT.RESOLVE.FAILED");
+            using var tags = JsonDocument.Parse(evt.Tags!);
+            tags.RootElement.GetProperty("role").GetString().Should().Be("security");
+            tags.RootElement.GetProperty("source").GetString().Should().Be("none");
+            tags.RootElement.GetProperty("mode").GetString().Should().Be("saas");
+        }
+    }
+
+    // ── Stale selection ⇒ degrade to system default (not error) ──
+
+    [Test]
+    public async Task Resolve_StaleArchivedSelection_DegradesToSystemDefault()
+    {
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null);
+        await using (h.Ctx)
+        {
+            var pub = await SeedPublicAsync(h.Agents, "developer", "tamma-developer");
+            var priv = await SeedTenantPrivateAsync(h.Agents, TenantA, "developer", "atlas");
+            await h.Registry.SelectForRoleAsync("developer", priv.Id, null);
+
+            // Archive the selected private agent — the selection is now stale.
+            await h.Agents.ArchiveAsync(priv.Id, null);
+
+            var resolved = await h.Resolver.ResolveForRoleAsync("developer");
+
+            resolved.AgentId.Should().Be(pub.Id, "stale selection degrades to system default");
+            resolved.Source.Should().Be("system-public");
+        }
+    }
+
+    // ── Rollback-to-prior-version resolution (AC 13) ──
+
+    [Test]
+    public async Task Resolve_AfterRollbackToPriorVersion_ReturnsPriorVersionConfig()
+    {
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null);
+        await using (h.Ctx)
+        {
+            var priv = await h.Agents.CreateAsync(
+                new Agent { Name = "atlas", Role = "developer", Visibility = AgentVisibility.Private, OwnerTenantId = TenantA },
+                """{ "provider": "anthropic", "model": "v1-model" }""", "v1", null);
+            await h.Agents.PublishVersionAsync(
+                priv.Id, """{ "provider": "openai", "model": "v2-model" }""", "v2", null);
+            await h.Registry.SelectForRoleAsync("developer", priv.Id, null);
+
+            // Active is v2 now.
+            var v2Resolved = await h.Resolver.ResolveForRoleAsync("developer");
+            v2Resolved.AgentVersion.Should().Be(2);
+            v2Resolved.Model.Should().Be("v2-model");
+
+            // Rollback to v1.
+            await h.Agents.SetActiveVersionAsync(priv.Id, 1, null);
+
+            var v1Resolved = await h.Resolver.ResolveForRoleAsync("developer");
+            v1Resolved.AgentVersion.Should().Be(1);
+            v1Resolved.Model.Should().Be("v1-model");
+        }
+    }
+
+    // ── Mode-parameterized principal (AC 10) ──
+
+    [Test]
+    public async Task Resolve_SingleUserMode_UsesUserPrincipal_PrivateSelection()
+    {
+        var h = BuildHarness(TammaMode.SingleUser, null, UserA);
+        await using (h.Ctx)
+        {
+            await SeedPublicAsync(h.Agents, "developer", "tamma-developer");
+            var priv = await SeedUserPrivateAsync(h.Agents, UserA, "developer", "myagent");
+            await h.Registry.SelectForRoleAsync("developer", priv.Id, UserA);
+
+            var resolved = await h.Resolver.ResolveForRoleAsync("developer");
+
+            resolved.AgentId.Should().Be(priv.Id);
+            resolved.Source.Should().Be("tenant-private");
+        }
+    }
+
+    // ── Unknown role / phase → ArgumentException before resolution ──
+
+    [Test]
+    public async Task Resolve_UnknownRole_Throws_ArgumentException()
+    {
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null);
+        await using (h.Ctx)
+        {
+            Func<Task> act = async () => await h.Resolver.ResolveForRoleAsync("wizard");
+            await act.Should().ThrowAsync<ArgumentException>();
+        }
+    }
+
+    [Test]
+    public async Task ResolveForPhase_IneligibleRole_Throws_BeforeResolution()
+    {
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null);
+        await using (h.Ctx)
+        {
+            Func<Task> act = async () =>
+                await h.Resolver.ResolveForRoleAndPhaseAsync("plan-system-design", "tester");
+            await act.Should().ThrowAsync<ArgumentException>();
+            // No event should have been emitted on an invalid-input rejection.
+            h.Events.Captured.Should().NotContain(e => e.Type == "AGENT.RESOLVE.FAILED");
+        }
+    }
+
+    // ── Cross-tenant: selecting another tenant's private agent → not found ──
+
+    [Test]
+    public async Task SelectForRole_CrossTenantPrivateTarget_ThrowsNotFound_NoSelectionRow()
+    {
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null);
+        await using (h.Ctx)
+        {
+            // A private agent owned by TenantB — TenantA must not be able to select it.
+            var foreign = await SeedTenantPrivateAsync(h.Agents, TenantB, "developer", "their-atlas");
+
+            Func<Task> act = async () =>
+                await h.Registry.SelectForRoleAsync("developer", foreign.Id, null);
+
+            (await act.Should().ThrowAsync<TammaError>())
+                .Which.Code.Should().Be("AGENT.SELECT.NOT_FOUND");
+
+            var selections = await h.Registry.GetRoleSelectionsAsync();
+            selections.Should().NotContainKey("developer");
+        }
+    }
+
+    // ── Selection emits exactly one DCB event (AC 11) ──
+
+    [Test]
+    public async Task SelectForRole_EmitsOne_SelectedForRole_Event()
+    {
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null);
+        await using (h.Ctx)
+        {
+            var pub = await SeedPublicAsync(h.Agents, "developer", "tamma-developer");
+            h.Events.Captured.Clear();
+
+            await h.Registry.SelectForRoleAsync("developer", pub.Id, null);
+
+            var selectEvents = h.Events.Captured
+                .Where(e => e.Type == "AGENT.SELECTED_FOR_ROLE.SUCCESS").ToList();
+            selectEvents.Should().HaveCount(1);
+            using var tags = JsonDocument.Parse(selectEvents[0].Tags!);
+            tags.RootElement.GetProperty("agentId").GetString().Should().Be(pub.Id.ToString());
+            tags.RootElement.GetProperty("role").GetString().Should().Be("developer");
+            tags.RootElement.GetProperty("source").GetString().Should().Be("system-public");
+        }
+    }
+
+    // ── test doubles ──
+
+    private sealed class StubMode(TammaMode mode) : ITammaModeProvider
+    {
+        public TammaMode Mode { get; } = mode;
+    }
+
+    /// <summary>Tenant factory that hands back a TenantDbContext bound to the
+    /// same physical DB (shared-DB transitional phase). The selection rows are
+    /// discriminated by tenant_id, mirroring how prompt/audit repos test.</summary>
+    private sealed class SameDbTenantFactory(string conn) : ITenantDbContextFactory
+    {
+        public ValueTask<TenantDbContext> CreateAsync(
+            Guid tenantId, CancellationToken cancellationToken = default)
+        {
+            var ctx = new TenantDbContext(
+                new DbContextOptionsBuilder<TenantDbContext>().UseNpgsql(conn).Options,
+                tenantId);
+            return ValueTask.FromResult(ctx);
+        }
+    }
+
+    private sealed class CapturingEvents : IEventRepository
+    {
+        public ConcurrentQueue<DomainEvent> Captured { get; } = new();
+        public Task<DomainEvent> AppendAsync(DomainEvent evt)
+        {
+            Captured.Enqueue(evt);
+            return Task.FromResult(evt);
+        }
+        public Task<DomainEvent?> GetByIdAsync(Guid id) => Task.FromResult<DomainEvent?>(null);
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit) =>
+            Task.FromResult(Captured.ToList());
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type) =>
+            Task.FromResult<DomainEvent?>(null);
+        public Task ClearAsync(Guid tenantId) => Task.CompletedTask;
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(
+            Guid? tenantId, string? type, int? issueNumber, int limit, int offset) =>
+            Task.FromResult(((IReadOnlyList<DomainEvent>)Captured.ToList(), Captured.Count));
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(
+            Guid tenantId, string? typePrefix, int limit, int offset) =>
+            Task.FromResult(((IReadOnlyList<DomainEvent>)Captured.ToList(), Captured.Count));
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentResolverChainTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentResolverChainTests.cs
@@ -380,7 +380,10 @@ public class AgentResolverChainTests
             using var tags = JsonDocument.Parse(selectEvents[0].Tags!);
             tags.RootElement.GetProperty("agentId").GetString().Should().Be(pub.Id.ToString());
             tags.RootElement.GetProperty("role").GetString().Should().Be("developer");
-            tags.RootElement.GetProperty("source").GetString().Should().Be("system-public");
+            // 32-2 review #2: SELECTING a public agent stores/emits the provenance
+            // the resolver stamps for it — "tenant-public" — not "system-public"
+            // (which is reserved for the unselected system-default fallback).
+            tags.RootElement.GetProperty("source").GetString().Should().Be("tenant-public");
         }
     }
 

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentRoleSelectionConstraintTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentRoleSelectionConstraintTests.cs
@@ -1,0 +1,146 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Agents;
+
+/// <summary>
+/// Story 32-2 — DB-level constraint tests for <c>agent_role_selections</c>:
+/// the principal-XOR CHECK and the UNIQUE NULLS NOT DISTINCT
+/// <c>(TenantId, UserId, Role)</c> index. Runs against a real Postgres
+/// testcontainer (the CHECK + nulls-not-distinct semantics are PG-specific).
+/// </summary>
+[TestFixture]
+public class AgentRoleSelectionConstraintTests
+{
+    private static readonly Guid TenantA = Guid.Parse("aaaaaaaa-32c1-32c1-32c1-aaaaaaaaaaaa");
+    private static readonly Guid TenantB = Guid.Parse("bbbbbbbb-32c1-32c1-32c1-bbbbbbbbbbbb");
+    private static readonly Guid UserA = Guid.Parse("cccccccc-32c1-32c1-32c1-cccccccccccc");
+
+    private PostgreSqlContainer _postgres = null!;
+    private string _connectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("agent_sel_constraint_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _connectionString = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync("TRUNCATE agent_role_selections CASCADE;");
+    }
+
+    private ControlPlaneDbContext NewContext()
+        => new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseNpgsql(_connectionString).Options);
+
+    private static AgentRoleSelection Row(Guid? tenantId, Guid? userId, string role = "developer")
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            UserId = userId,
+            Role = role,
+            AgentId = Guid.NewGuid(),
+            Visibility = "system-public",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+
+    [Test]
+    public async Task PrincipalXor_BothSet_IsRejected()
+    {
+        await using var ctx = NewContext();
+        ctx.AgentRoleSelections.Add(Row(TenantA, UserA));
+        Func<Task> act = async () => await ctx.SaveChangesAsync();
+        await act.Should().ThrowAsync<DbUpdateException>();
+    }
+
+    [Test]
+    public async Task PrincipalXor_NeitherSet_IsRejected()
+    {
+        await using var ctx = NewContext();
+        ctx.AgentRoleSelections.Add(Row(null, null));
+        Func<Task> act = async () => await ctx.SaveChangesAsync();
+        await act.Should().ThrowAsync<DbUpdateException>();
+    }
+
+    [Test]
+    public async Task PrincipalXor_TenantOnly_Accepted()
+    {
+        await using var ctx = NewContext();
+        ctx.AgentRoleSelections.Add(Row(TenantA, null));
+        await ctx.SaveChangesAsync();
+        (await ctx.AgentRoleSelections.CountAsync()).Should().Be(1);
+    }
+
+    [Test]
+    public async Task PrincipalXor_UserOnly_Accepted()
+    {
+        await using var ctx = NewContext();
+        ctx.AgentRoleSelections.Add(Row(null, UserA));
+        await ctx.SaveChangesAsync();
+        (await ctx.AgentRoleSelections.CountAsync()).Should().Be(1);
+    }
+
+    [Test]
+    public async Task Unique_DuplicateTenantRole_IsRejected()
+    {
+        await using var ctx = NewContext();
+        ctx.AgentRoleSelections.Add(Row(TenantA, null, "developer"));
+        await ctx.SaveChangesAsync();
+
+        await using var ctx2 = NewContext();
+        ctx2.AgentRoleSelections.Add(Row(TenantA, null, "developer"));
+        Func<Task> act = async () => await ctx2.SaveChangesAsync();
+        await act.Should().ThrowAsync<DbUpdateException>("one selection per (tenant, role)");
+    }
+
+    [Test]
+    public async Task Unique_NullsNotDistinct_UserHalf_DedupesOnNullTenant()
+    {
+        // Two user-keyed rows (tenant_id NULL both) for the same (user, role)
+        // must collide — NULLS NOT DISTINCT treats the NULL tenant halves equal.
+        await using var ctx = NewContext();
+        ctx.AgentRoleSelections.Add(Row(null, UserA, "developer"));
+        await ctx.SaveChangesAsync();
+
+        await using var ctx2 = NewContext();
+        ctx2.AgentRoleSelections.Add(Row(null, UserA, "developer"));
+        Func<Task> act = async () => await ctx2.SaveChangesAsync();
+        await act.Should().ThrowAsync<DbUpdateException>();
+    }
+
+    [Test]
+    public async Task Unique_DifferentTenants_SameRole_BothAllowed()
+    {
+        await using var ctx = NewContext();
+        ctx.AgentRoleSelections.Add(Row(TenantA, null, "developer"));
+        ctx.AgentRoleSelections.Add(Row(TenantB, null, "developer"));
+        await ctx.SaveChangesAsync();
+        (await ctx.AgentRoleSelections.CountAsync()).Should().Be(2,
+            "two tenants select independently for the same role");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/ProviderCredentialEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/ProviderCredentialEndpointsTests.cs
@@ -1,0 +1,278 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using NUnit.Framework;
+using Tamma.Activities.LlmCall.Credentials;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Services.Secrets;
+using Tamma.Api.Services.Secrets.Query;
+using Tamma.Api.Services.Secrets.Reveal;
+using Tamma.Data;
+
+namespace Tamma.Api.Tests.Agents;
+
+/// <summary>
+/// Story 32-3 (AC7) — BYOK management API: register / rotate / delete / list,
+/// driven directly against the static endpoint handlers with cabinet fakes.
+/// Pins reveal-once (no raw key in the response), cache invalidation on every
+/// mutation, whitespace-key rejection, unknown-provider 404, and
+/// no-tenant-context handling. (Member-role 403 is enforced by the
+/// <c>AgentManage</c> route policy and pinned by <c>AgentManagePermissionTests</c>.)
+/// </summary>
+[TestFixture]
+public class ProviderCredentialEndpointsTests
+{
+    private const string Key = "sk-tenant-byok-123456";
+    private static readonly Guid Tenant = Guid.NewGuid();
+
+    private FakeReveal _reveal = null!;
+    private FakeQuery _query = null!;
+    private RecordingResolver _resolver = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _reveal = new FakeReveal();
+        _query = new FakeQuery();
+        _resolver = new RecordingResolver();
+    }
+
+    private static ClaimsPrincipal Principal() =>
+        new(new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()),
+        }, "test"));
+
+    private static HttpContext Http() => new DefaultHttpContext();
+
+    private static ITenantContext TenantCtx(Guid? id) => new StubTenant(id);
+
+    // ── Register ──────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Register_CreatesViaReveal_ReturnsTokenNotKey_InvalidatesCache()
+    {
+        var result = await ProviderCredentialEndpoints.RegisterCredential(
+            "anthropic", new SetProviderCredentialRequest(Key),
+            Principal(), TenantCtx(Tenant), _reveal, _resolver, Http());
+
+        result.Should().BeOfType<Microsoft.AspNetCore.Http.HttpResults.Created<SetProviderCredentialResponse>>();
+        var body = ((Microsoft.AspNetCore.Http.HttpResults.Created<SetProviderCredentialResponse>)result).Value!;
+        body.Provider.Should().Be("anthropic");
+        body.RevealToken.Should().NotBeNullOrEmpty();
+        // The raw key must NEVER round-trip in the response.
+        System.Text.Json.JsonSerializer.Serialize(body).Should().NotContain(Key);
+
+        _reveal.CreatedName.Should().Be("provider/anthropic/api-key");
+        _reveal.CreatedTenantId.Should().Be(Tenant);
+        _reveal.CreatedScope.Should().Be(SecretScope.Tenant);
+        _reveal.CreatedPurpose.Should().Be(SecretPurpose.ApiKey);
+        _resolver.Invalidated.Should().ContainSingle().Which.Should().Be((Tenant, "anthropic"));
+    }
+
+    [Test]
+    public async Task Register_WhitespaceKey_Rejected()
+    {
+        var result = await ProviderCredentialEndpoints.RegisterCredential(
+            "anthropic", new SetProviderCredentialRequest("   "),
+            Principal(), TenantCtx(Tenant), _reveal, _resolver, Http());
+
+        result.GetType().Name.Should().Contain("BadRequest");
+        _reveal.CreatedName.Should().BeNull();
+    }
+
+    [Test]
+    public async Task Register_UnknownProvider_404()
+    {
+        var result = await ProviderCredentialEndpoints.RegisterCredential(
+            "not-a-provider", new SetProviderCredentialRequest(Key),
+            Principal(), TenantCtx(Tenant), _reveal, _resolver, Http());
+
+        result.GetType().Name.Should().Contain("NotFound");
+    }
+
+    [Test]
+    public async Task Register_NoTenantContext_BadRequest()
+    {
+        var result = await ProviderCredentialEndpoints.RegisterCredential(
+            "anthropic", new SetProviderCredentialRequest(Key),
+            Principal(), TenantCtx(null), _reveal, _resolver, Http());
+
+        result.GetType().Name.Should().Contain("BadRequest");
+    }
+
+    // ── Rotate ────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Rotate_ExistingKey_RotatesAndInvalidates()
+    {
+        _query.Seed(Tenant, "provider/anthropic/api-key", id: Guid.NewGuid(), version: 1);
+
+        var result = await ProviderCredentialEndpoints.RotateCredential(
+            "anthropic", new SetProviderCredentialRequest("sk-rotated-9999"),
+            Principal(), TenantCtx(Tenant), _query, _reveal, _resolver, Http());
+
+        result.GetType().Name.Should().Contain("Ok");
+        _reveal.RotatedSecretId.Should().NotBeNull();
+        _resolver.Invalidated.Should().Contain((Tenant, "anthropic"));
+    }
+
+    [Test]
+    public async Task Rotate_NoExistingKey_404()
+    {
+        var result = await ProviderCredentialEndpoints.RotateCredential(
+            "anthropic", new SetProviderCredentialRequest("sk-rotated-9999"),
+            Principal(), TenantCtx(Tenant), _query, _reveal, _resolver, Http());
+
+        result.GetType().Name.Should().Contain("NotFound");
+        _reveal.RotatedSecretId.Should().BeNull();
+        _resolver.Invalidated.Should().BeEmpty();
+    }
+
+    // ── Delete ────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Delete_ExistingKey_RetiresAndInvalidates()
+    {
+        var id = Guid.NewGuid();
+        _query.Seed(Tenant, "provider/anthropic/api-key", id, version: 2);
+
+        var result = await ProviderCredentialEndpoints.DeleteCredential(
+            "anthropic", Principal(), TenantCtx(Tenant), _query, _resolver, Http());
+
+        result.GetType().Name.Should().Contain("NoContent");
+        _query.RetiredSecretId.Should().Be(id);
+        _query.RetiredVersion.Should().Be(2);
+        _resolver.Invalidated.Should().Contain((Tenant, "anthropic"));
+    }
+
+    [Test]
+    public async Task Delete_NoKey_404()
+    {
+        var result = await ProviderCredentialEndpoints.DeleteCredential(
+            "anthropic", Principal(), TenantCtx(Tenant), _query, _resolver, Http());
+
+        result.GetType().Name.Should().Contain("NotFound");
+        _resolver.Invalidated.Should().BeEmpty();
+    }
+
+    // ── List ──────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task List_ReturnsMetadataOnly_NoKey()
+    {
+        _query.Seed(Tenant, "provider/anthropic/api-key", Guid.NewGuid(), version: 1);
+        _query.Seed(Tenant, "provider/openai/api-key", Guid.NewGuid(), version: 3);
+        // A non-provider secret must be filtered out.
+        _query.Seed(Tenant, "db/app-role", Guid.NewGuid(), version: 1);
+
+        var result = await ProviderCredentialEndpoints.ListProviders(
+            TenantCtx(Tenant), _query, Http());
+
+        // Ok<anonymous> — extract Value via reflection and serialize it.
+        var value = result.GetType().GetProperty("Value")!.GetValue(result);
+        var json = System.Text.Json.JsonSerializer.Serialize(value);
+        json.Should().Contain("anthropic");
+        json.Should().Contain("openai");
+        json.Should().NotContain("db/app-role");
+        json.Should().NotContain(Key);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Fakes
+    // ─────────────────────────────────────────────────────────────────────
+
+    private sealed class StubTenant(Guid? id) : ITenantContext
+    {
+        public Guid? TenantId { get; private set; } = id;
+        public void SetTenantId(Guid tenantId) => TenantId = tenantId;
+        public void ClearTenantId() => TenantId = null;
+    }
+
+    private sealed class RecordingResolver : IProviderCredentialResolver
+    {
+        public List<(Guid?, string)> Invalidated { get; } = new();
+        public Task<ProviderCredential> ResolveAsync(Guid? tenantId, string providerName, CancellationToken ct = default) =>
+            Task.FromResult(new ProviderCredential("x", CredentialSource.Platform, null, null));
+        public void Invalidate(Guid? tenantId, string providerName) => Invalidated.Add((tenantId, providerName));
+    }
+
+    private sealed class FakeReveal : ISecretRevealService
+    {
+        public string? CreatedName { get; private set; }
+        public Guid? CreatedTenantId { get; private set; }
+        public SecretScope? CreatedScope { get; private set; }
+        public SecretPurpose? CreatedPurpose { get; private set; }
+        public Guid? RotatedSecretId { get; private set; }
+
+        public Task<RevealTokenIssueResult> IssueCreateAsync(
+            string name, SecretScope scope, Guid? tenantId, SecretPurpose purpose,
+            string initialPlaintext, IReadOnlyList<ConsumerRef>? consumerRefs,
+            Guid ownerUserId, RotationSchedule? rotationSchedule, CancellationToken ct = default)
+        {
+            CreatedName = name;
+            CreatedTenantId = tenantId;
+            CreatedScope = scope;
+            CreatedPurpose = purpose;
+            return Task.FromResult(new RevealTokenIssueResult(
+                Meta(Guid.NewGuid(), name, tenantId, version: 1),
+                "REVEAL-TOKEN", DateTimeOffset.UtcNow.AddSeconds(60)));
+        }
+
+        public Task<RevealTokenIssueResult> IssueRotateAsync(
+            Guid secretId, string newPlaintext, Guid actorUserId, CancellationToken ct = default)
+        {
+            RotatedSecretId = secretId;
+            return Task.FromResult(new RevealTokenIssueResult(
+                Meta(secretId, "provider/anthropic/api-key", null, version: 2),
+                "REVEAL-TOKEN-2", DateTimeOffset.UtcNow.AddSeconds(60)));
+        }
+
+        public Task<RevealTokenConsumeResult> ConsumeAsync(
+            string rawToken, RevealCallerContext caller, CancellationToken ct = default) =>
+            Task.FromResult(new RevealTokenConsumeResult(
+                RevealTokenConsumeOutcome.NotFound, null, null, null, null, null));
+
+        public Task<int> SweepExpiredAsync(CancellationToken ct = default) => Task.FromResult(0);
+    }
+
+    private sealed class FakeQuery : ISecretQueryService
+    {
+        private readonly List<SecretMetadata> _rows = new();
+        public Guid? RetiredSecretId { get; private set; }
+        public int? RetiredVersion { get; private set; }
+
+        public void Seed(Guid tenantId, string name, Guid id, int version) =>
+            _rows.Add(Meta(id, name, tenantId, version));
+
+        public Task<IReadOnlyList<SecretMetadata>> ListAsync(
+            SecretScope scope, Guid? tenantId, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<SecretMetadata>>(
+                _rows.Where(r => r.Scope == scope && r.TenantId == tenantId).ToList());
+
+        public Task<SecretMetadata?> GetAsync(
+            Guid secretId, SecretScope scope, Guid? tenantId, CancellationToken ct = default) =>
+            Task.FromResult(_rows.FirstOrDefault(r =>
+                r.Id == secretId && r.Scope == scope && r.TenantId == tenantId));
+
+        public Task<IReadOnlyList<SecretVersion>> ListVersionsAsync(
+            Guid secretId, SecretScope scope, Guid? tenantId, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<SecretVersion>>(new List<SecretVersion>());
+
+        public Task<SecretVersionStatus> RetireVersionAsync(
+            Guid secretId, int versionNumber, SecretScope scope, Guid? tenantId,
+            Guid actorUserId, CancellationToken ct = default)
+        {
+            RetiredSecretId = secretId;
+            RetiredVersion = versionNumber;
+            return Task.FromResult(SecretVersionStatus.RetiredGrace);
+        }
+    }
+
+    private static SecretMetadata Meta(Guid id, string name, Guid? tenantId, int version) =>
+        new(id, name, SecretScope.Tenant, tenantId, SecretPurpose.ApiKey,
+            Array.Empty<ConsumerRef>(), Guid.Empty, RotationSchedule.None,
+            LastRotatedAt: null, NextRotationDueAt: null,
+            ActiveVersionNumber: version, CreatedAt: DateTimeOffset.UtcNow,
+            UpdatedAt: DateTimeOffset.UtcNow);
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
@@ -102,6 +102,10 @@ public class ControlPlaneDbContextModelTests
             // (no performance columns — those stay tenant-scoped).
             "agents",
             "agent_versions",
+            // Story 32-2 — role→agent selections. Mapped on BOTH contexts (CP
+            // build holds single-user user-keyed rows; tenant build holds SaaS
+            // tenant-keyed rows). Same dual-resident pattern as audit_records.
+            "agent_role_selections",
             // Story 35-1 — Epic 35 billing foundation. CP-resident: the
             // tenant→Stripe customer mapping (keyed by tenant) + the
             // slug→Stripe-ids catalog (platform-global). Definition/binding
@@ -121,6 +125,7 @@ public class ControlPlaneDbContextModelTests
             + "tenant_platform_installations; Story 31-7 adds "
             + "platform_webhook_deliveries. Unified-tenancy Phase 0 adds "
             + "tenant_databases. Story 32-1 adds agents + agent_versions. "
+            + "Story 32-2 adds agent_role_selections. "
             + "Story 34-1 adds plan_features + plan_entitlements + plan_prices. "
             + "Story 35-1 adds billing_customers + billing_plan_prices. "
             + "Story 37-1 adds audit_records + audit_projector_cursor.");

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/TenantDbContextModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/TenantDbContextModelTests.cs
@@ -37,6 +37,9 @@ public class TenantDbContextModelTests
         tableNames.Should().Contain(new[]
         {
             "agent_configs",
+            // Story 32-2 — SaaS tenant-keyed role→agent selections (dual-resident
+            // with the CP single-user rows).
+            "agent_role_selections",
             "prompt_overrides",
             "conventions",
             "provider_health",

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Providers/ConfigPlatformFallbackPolicyTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Providers/ConfigPlatformFallbackPolicyTests.cs
@@ -1,0 +1,83 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Services.Providers;
+
+namespace Tamma.Api.Tests.Providers;
+
+/// <summary>
+/// Story 32-3 Phase 1 (AC6.1) — the platform-fallback gating matrix.
+/// </summary>
+[TestFixture]
+public class ConfigPlatformFallbackPolicyTests
+{
+    private static IConfiguration Config(params (string Key, string Value)[] kv) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(kv.ToDictionary(p => p.Key, p => (string?)p.Value))
+            .Build();
+
+    private static ConfigPlatformFallbackPolicy Policy(
+        TammaMode mode, params (string, string)[] kv) =>
+        new(Config(kv), new StubMode(mode));
+
+    private static readonly Guid Tenant = Guid.NewGuid();
+
+    [Test]
+    public void SingleUser_AlwaysAllowed()
+    {
+        Policy(TammaMode.SingleUser)
+            .IsPlatformFallbackAllowed(null, "anthropic")
+            .Should().BeTrue();
+    }
+
+    [Test]
+    public void SingleUser_AllowedEvenWhenConfigDisablesIt()
+    {
+        // Disable flags are SaaS-only knobs; single-user ignores them.
+        Policy(TammaMode.SingleUser, ("Providers:PlatformFallbackDisabled", "true"))
+            .IsPlatformFallbackAllowed(null, "anthropic")
+            .Should().BeTrue();
+    }
+
+    [Test]
+    public void Saas_AllowedByDefault()
+    {
+        Policy(TammaMode.SaaS)
+            .IsPlatformFallbackAllowed(Tenant, "anthropic")
+            .Should().BeTrue();
+    }
+
+    [Test]
+    public void Saas_NullTenant_TreatedAsSingleUserScope_Allowed()
+    {
+        // A null tenant id in SaaS means no tenant in context — platform scope.
+        Policy(TammaMode.SaaS)
+            .IsPlatformFallbackAllowed(null, "anthropic")
+            .Should().BeTrue();
+    }
+
+    [Test]
+    public void Saas_DisabledGlobally_Denied()
+    {
+        Policy(TammaMode.SaaS, ("Providers:PlatformFallbackDisabled", "true"))
+            .IsPlatformFallbackAllowed(Tenant, "anthropic")
+            .Should().BeFalse();
+    }
+
+    [Test]
+    public void Saas_DisabledPerProvider_DeniesOnlyThatProvider()
+    {
+        var policy = Policy(
+            TammaMode.SaaS,
+            ("Providers:anthropic:PlatformFallbackDisabled", "true"));
+
+        policy.IsPlatformFallbackAllowed(Tenant, "anthropic").Should().BeFalse();
+        policy.IsPlatformFallbackAllowed(Tenant, "openai").Should().BeTrue();
+    }
+
+    private sealed class StubMode(TammaMode mode) : ITammaModeProvider
+    {
+        public TammaMode Mode { get; } = mode;
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Providers/ProviderCredentialCacheInvalidatorTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Providers/ProviderCredentialCacheInvalidatorTests.cs
@@ -1,0 +1,73 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Activities.LlmCall.Credentials;
+using Tamma.Api.Services.Providers;
+using Tamma.Api.Services.Secrets;
+
+namespace Tamma.Api.Tests.Providers;
+
+/// <summary>
+/// Story 32-3 (AC9) — the SECRET.ROTATE.ACTIVATED → resolver-cache eviction.
+/// </summary>
+[TestFixture]
+public class ProviderCredentialCacheInvalidatorTests
+{
+    private static readonly Guid Tenant = Guid.NewGuid();
+
+    [Test]
+    public void RotateActivated_ForByokTenantRef_InvalidatesMatchingEntry()
+    {
+        var resolver = new RecordingResolver();
+        var invalidator = new ProviderCredentialCacheInvalidator(
+            resolver, NullLogger<ProviderCredentialCacheInvalidator>.Instance);
+
+        invalidator.HandleRotateActivated(
+            SecretRef.ForTenant(Tenant, "provider/anthropic/api-key"));
+
+        resolver.Invalidated.Should().ContainSingle().Which.Should().Be((Tenant, "anthropic"));
+    }
+
+    [Test]
+    public void RotateActivated_ForNonProviderTenantRef_NoOp()
+    {
+        var resolver = new RecordingResolver();
+        var invalidator = new ProviderCredentialCacheInvalidator(
+            resolver, NullLogger<ProviderCredentialCacheInvalidator>.Instance);
+
+        invalidator.HandleRotateActivated(SecretRef.ForTenant(Tenant, "db/app-role"));
+
+        resolver.Invalidated.Should().BeEmpty();
+    }
+
+    [Test]
+    public void RotateActivated_ForPlatformRef_NoOp()
+    {
+        var resolver = new RecordingResolver();
+        var invalidator = new ProviderCredentialCacheInvalidator(
+            resolver, NullLogger<ProviderCredentialCacheInvalidator>.Instance);
+
+        // Platform rotations are RuntimeSecretResolver's concern, not ours.
+        invalidator.HandleRotateActivated(SecretRef.ForPlatform("anthropic/api-key"));
+
+        resolver.Invalidated.Should().BeEmpty();
+    }
+
+    [TestCase("provider/anthropic/api-key", "anthropic")]
+    [TestCase("provider/openrouter/api-key", "openrouter")]
+    [TestCase("db/app-role", null)]
+    [TestCase("provider//api-key", null)]
+    [TestCase("anthropic/api-key", null)]
+    public void TryParse_ExtractsProviderFromByokSlug(string name, string? expected)
+    {
+        ProviderCabinetNames.TryParse(name).Should().Be(expected);
+    }
+
+    private sealed class RecordingResolver : IProviderCredentialResolver
+    {
+        public List<(Guid?, string)> Invalidated { get; } = new();
+        public Task<ProviderCredential> ResolveAsync(Guid? tenantId, string providerName, CancellationToken ct = default) =>
+            Task.FromResult(new ProviderCredential("x", CredentialSource.Platform, null, null));
+        public void Invalidate(Guid? tenantId, string providerName) => Invalidated.Add((tenantId, providerName));
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Providers/ProviderCredentialResolverTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Providers/ProviderCredentialResolverTests.cs
@@ -1,0 +1,316 @@
+using System.Collections.Concurrent;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Activities.LlmCall.Credentials;
+using Tamma.Activities.Security;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Services.Providers;
+using Tamma.Api.Services.Secrets.Stopgap;
+using Tamma.Core;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Providers;
+
+/// <summary>
+/// Story 32-3 Phase 2 — the resolver algorithm (AC1/2/5/6/9/10/11/13). Uses
+/// plain in-memory fakes for the cabinet read, platform key, events, mode, and
+/// fallback policy so the precedence / cache / fail-closed / redaction logic is
+/// exercised without a Postgres container.
+/// </summary>
+[TestFixture]
+public class ProviderCredentialResolverTests
+{
+    private const string Sentinel = "SENTINEL-BYOK-XYZ";
+    private static readonly Guid TenantA = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid TenantB = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private FakeByokReader _byok = null!;
+    private FakePlatformKeys _platform = null!;
+    private FakeFallbackPolicy _policy = null!;
+    private RecordingEventRepository _events = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _byok = new FakeByokReader();
+        _platform = new FakePlatformKeys();
+        _policy = new FakeFallbackPolicy(true);
+        _events = new RecordingEventRepository();
+    }
+
+    private DefaultProviderCredentialResolver Resolver(
+        TammaMode mode = TammaMode.SaaS, TimeProvider? clock = null, TimeSpan? ttl = null) =>
+        new(
+            _byok, _platform, _policy, _events, new StubMode(mode),
+            new ProviderAllowlist(), NullLogger<DefaultProviderCredentialResolver>.Instance,
+            clock, ttl);
+
+    // ── AC1/AC13: BYOK present → tenant key, source=byok ──────────────────
+
+    [Test]
+    public async Task ByokPresent_ReturnsTenantKey_SourceByok()
+    {
+        _byok.Seed(TenantA, "provider/anthropic/api-key", Sentinel, version: 1);
+
+        var cred = await Resolver().ResolveAsync(TenantA, "anthropic");
+
+        cred.ApiKey.Should().Be(Sentinel);
+        cred.Source.Should().Be(CredentialSource.Byok);
+        cred.SecretRefStorageKey.Should().Be($"tenant:{TenantA}:provider/anthropic/api-key");
+        cred.VersionNumber.Should().Be(1);
+        _events.Types.Should().ContainSingle().Which.Should().Be("AGENT.CREDENTIAL_RESOLVED.SUCCESS");
+    }
+
+    // ── AC2/AC13: BYOK absent + platform present → source=platform ────────
+
+    [Test]
+    public async Task ByokAbsent_PlatformPresent_ReturnsPlatformKey_SourcePlatform()
+    {
+        _platform.Set("anthropic/api-key", "PLATFORM-KEY");
+
+        var cred = await Resolver().ResolveAsync(TenantA, "anthropic");
+
+        cred.ApiKey.Should().Be("PLATFORM-KEY");
+        cred.Source.Should().Be(CredentialSource.Platform);
+        cred.SecretRefStorageKey.Should().Be("platform:anthropic/api-key");
+        cred.VersionNumber.Should().BeNull();
+    }
+
+    // ── AC6: SaaS + both absent + fallback disabled → fail-closed ─────────
+
+    [Test]
+    public async Task Saas_NoByok_FallbackDisabled_ThrowsAndEmitsDenied()
+    {
+        _policy = new FakeFallbackPolicy(false);
+
+        var act = async () => await Resolver(TammaMode.SaaS).ResolveAsync(TenantA, "anthropic");
+
+        var ex = (await act.Should().ThrowAsync<TammaError>()).Which;
+        ex.Code.Should().Be("PROVIDER_CREDENTIAL_UNAVAILABLE");
+        ex.Retryable.Should().BeFalse();
+        ex.Severity.Should().Be(TammaErrorSeverity.High);
+        _events.Types.Should().ContainSingle().Which.Should().Be("AGENT.CREDENTIAL.DENIED");
+        _events.Types.Should().NotContain("AGENT.CREDENTIAL_RESOLVED.SUCCESS");
+    }
+
+    [Test]
+    public async Task Saas_NoByok_FallbackAllowedButPlatformUnset_ThrowsAndEmitsDenied()
+    {
+        // policy allows fallback, but no platform key is set → still loud.
+        var act = async () => await Resolver(TammaMode.SaaS).ResolveAsync(TenantA, "anthropic");
+
+        await act.Should().ThrowAsync<TammaError>()
+            .Where(e => e.Code == "PROVIDER_CREDENTIAL_UNAVAILABLE");
+        _events.Types.Should().ContainSingle().Which.Should().Be("AGENT.CREDENTIAL.DENIED");
+    }
+
+    // ── AC6/AC10: single-user falls back to platform; loud only if unset ──
+
+    [Test]
+    public async Task SingleUser_PlatformPresent_ReturnsPlatform()
+    {
+        _platform.Set("anthropic/api-key", "PLATFORM-KEY");
+
+        var cred = await Resolver(TammaMode.SingleUser).ResolveAsync(tenantId: null, "anthropic");
+
+        cred.Source.Should().Be(CredentialSource.Platform);
+        cred.ApiKey.Should().Be("PLATFORM-KEY");
+    }
+
+    [Test]
+    public async Task SingleUser_PlatformUnset_StillThrowsLoud()
+    {
+        var act = async () =>
+            await Resolver(TammaMode.SingleUser).ResolveAsync(tenantId: null, "anthropic");
+
+        await act.Should().ThrowAsync<TammaError>()
+            .Where(e => e.Code == "PROVIDER_CREDENTIAL_UNAVAILABLE");
+        _events.Types.Should().Contain("AGENT.CREDENTIAL.DENIED");
+    }
+
+    // ── AC11: tenant isolation ────────────────────────────────────────────
+
+    [Test]
+    public async Task TenantIsolation_TenantBNeverGetsTenantAByokKey()
+    {
+        _byok.Seed(TenantA, "provider/anthropic/api-key", Sentinel, version: 1);
+        _platform.Set("anthropic/api-key", "PLATFORM-KEY");
+
+        var a = await Resolver().ResolveAsync(TenantA, "anthropic");
+        var b = await Resolver().ResolveAsync(TenantB, "anthropic");
+
+        a.ApiKey.Should().Be(Sentinel);
+        a.Source.Should().Be(CredentialSource.Byok);
+
+        // Tenant B has no BYOK → platform key, NEVER tenant A's sentinel.
+        b.ApiKey.Should().Be("PLATFORM-KEY");
+        b.ApiKey.Should().NotBe(Sentinel);
+        b.Source.Should().Be(CredentialSource.Platform);
+    }
+
+    // ── AC5: redaction — sentinel never reaches any emitted event ─────────
+
+    [Test]
+    public async Task Redaction_SentinelByokKeyNeverAppearsInAnyEvent()
+    {
+        _byok.Seed(TenantA, "provider/anthropic/api-key", Sentinel, version: 3);
+
+        await Resolver().ResolveAsync(TenantA, "anthropic");
+
+        _events.Appended.Should().NotBeEmpty();
+        foreach (var e in _events.Appended)
+        {
+            e.Tags.Should().NotContain(Sentinel);
+            e.Data.Should().NotContain(Sentinel);
+            e.Metadata.Should().NotContain(Sentinel);
+            e.Type.Should().NotContain(Sentinel);
+        }
+        // The tag-safe projection carries source + ref + version, never the key.
+        _events.Appended[0].Tags.Should().Contain("byok");
+        _events.Appended[0].Data.Should().Contain("3");
+    }
+
+    // ── AC9: cache + rotation invalidation ────────────────────────────────
+
+    [Test]
+    public async Task Cache_SecondResolveDoesNotReReadCabinet_UntilInvalidate()
+    {
+        _byok.Seed(TenantA, "provider/anthropic/api-key", "KEY-V1", version: 1);
+        var resolver = Resolver();
+
+        var first = await resolver.ResolveAsync(TenantA, "anthropic");
+        first.ApiKey.Should().Be("KEY-V1");
+        _byok.ReadCount.Should().Be(1);
+
+        // Rotate the underlying cabinet to v2 — but the cache still serves v1.
+        _byok.Seed(TenantA, "provider/anthropic/api-key", "KEY-V2", version: 2);
+        var cachedAgain = await resolver.ResolveAsync(TenantA, "anthropic");
+        cachedAgain.ApiKey.Should().Be("KEY-V1"); // stale-but-cached
+        _byok.ReadCount.Should().Be(1);
+
+        // Invalidate (AC7 mutate path) → next resolve re-reads → v2.
+        resolver.Invalidate(TenantA, "anthropic");
+        var afterInvalidate = await resolver.ResolveAsync(TenantA, "anthropic");
+        afterInvalidate.ApiKey.Should().Be("KEY-V2");
+        afterInvalidate.VersionNumber.Should().Be(2);
+        _byok.ReadCount.Should().Be(2);
+    }
+
+    [Test]
+    public async Task Cache_TtlExpiry_ReReadsNewKey()
+    {
+        _byok.Seed(TenantA, "provider/anthropic/api-key", "KEY-V1", version: 1);
+        var clock = new FakeClock(DateTimeOffset.UtcNow);
+        var resolver = Resolver(clock: clock, ttl: TimeSpan.FromSeconds(60));
+
+        (await resolver.ResolveAsync(TenantA, "anthropic")).ApiKey.Should().Be("KEY-V1");
+        _byok.Seed(TenantA, "provider/anthropic/api-key", "KEY-V2", version: 2);
+
+        clock.Advance(TimeSpan.FromSeconds(61)); // past TTL
+        var afterTtl = await resolver.ResolveAsync(TenantA, "anthropic");
+        afterTtl.ApiKey.Should().Be("KEY-V2");
+    }
+
+    // ── Edge: unknown provider rejected ──────────────────────────────────
+
+    [Test]
+    public async Task UnknownProvider_Throws()
+    {
+        var act = async () => await Resolver().ResolveAsync(TenantA, "not-a-provider");
+        await act.Should().ThrowAsync<TammaError>()
+            .Where(e => e.Code == "PROVIDER_CREDENTIAL_UNAVAILABLE");
+    }
+
+    // ── Edge: cabinet probe throws → degrade to platform fallback ────────
+
+    [Test]
+    public async Task CabinetProbeThrows_DegradesToPlatformFallback()
+    {
+        _byok.ThrowOnRead = true; // reader contract: it returns null on failure,
+        _byok.SwallowToNull = true; // so model the degrade-to-absent behaviour
+        _platform.Set("anthropic/api-key", "PLATFORM-KEY");
+
+        var cred = await Resolver().ResolveAsync(TenantA, "anthropic");
+        cred.Source.Should().Be(CredentialSource.Platform);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Fakes
+    // ─────────────────────────────────────────────────────────────────────
+
+    private sealed class FakeByokReader : ITenantProviderKeyReader
+    {
+        private readonly ConcurrentDictionary<(Guid, string), TenantProviderKey> _store = new();
+        public int ReadCount { get; private set; }
+        public bool ThrowOnRead { get; set; }
+        public bool SwallowToNull { get; set; }
+
+        public void Seed(Guid tenantId, string cabinetName, string plaintext, int version) =>
+            _store[(tenantId, cabinetName)] = new TenantProviderKey(plaintext, version);
+
+        public Task<TenantProviderKey?> TryReadAsync(
+            Guid tenantId, string cabinetName, CancellationToken ct = default)
+        {
+            ReadCount++;
+            if (ThrowOnRead && !SwallowToNull)
+                throw new InvalidOperationException("cabinet down");
+            if (ThrowOnRead && SwallowToNull)
+                return Task.FromResult<TenantProviderKey?>(null);
+            _store.TryGetValue((tenantId, cabinetName), out var v);
+            return Task.FromResult(v);
+        }
+    }
+
+    private sealed class FakePlatformKeys : IRuntimeSecretResolver
+    {
+        private readonly Dictionary<string, string> _keys = new(StringComparer.Ordinal);
+        public void Set(string cabinetName, string value) => _keys[cabinetName] = value;
+
+        public Task<string?> GetAsync(string cabinetName, CancellationToken ct = default) =>
+            Task.FromResult(_keys.TryGetValue(cabinetName, out var v) ? v : null);
+    }
+
+    private sealed class FakeFallbackPolicy(bool allowed) : IPlatformFallbackPolicy
+    {
+        public bool IsPlatformFallbackAllowed(Guid? tenantId, string providerName) => allowed;
+    }
+
+    private sealed class RecordingEventRepository : IEventRepository
+    {
+        public List<DomainEvent> Appended { get; } = new();
+        public IEnumerable<string> Types => Appended.Select(e => e.Type);
+
+        public Task<DomainEvent> AppendAsync(DomainEvent evt)
+        {
+            Appended.Add(evt);
+            return Task.FromResult(evt);
+        }
+
+        public Task<DomainEvent?> GetByIdAsync(Guid id) => Task.FromResult<DomainEvent?>(null);
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit) =>
+            Task.FromResult(new List<DomainEvent>());
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type) =>
+            Task.FromResult<DomainEvent?>(null);
+        public Task ClearAsync(Guid tenantId) => Task.CompletedTask;
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(
+            Guid? tenantId, string? type, int? issueNumber, int limit, int offset) =>
+            Task.FromResult(((IReadOnlyList<DomainEvent>)new List<DomainEvent>(), 0));
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(
+            Guid tenantId, string? typePrefix, int limit, int offset) =>
+            Task.FromResult(((IReadOnlyList<DomainEvent>)new List<DomainEvent>(), 0));
+    }
+
+    private sealed class StubMode(TammaMode mode) : ITammaModeProvider
+    {
+        public TammaMode Mode { get; } = mode;
+    }
+
+    private sealed class FakeClock(DateTimeOffset start) : TimeProvider
+    {
+        private DateTimeOffset _now = start;
+        public void Advance(TimeSpan by) => _now = _now.Add(by);
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+}

--- a/docs/sprint-status.yaml
+++ b/docs/sprint-status.yaml
@@ -417,7 +417,7 @@ development_status:
 
   epic-32: contexted   # NEW Agents — entities, managed execution, benchmarking & learning (added 2026-06-17; all stories drafted)
   32-1-agent-entity-model-and-versioned-saved-config: done # Agent Entity Model & Versioned Saved Config (public/private) [P0]
-  32-2-agent-registry-resolution-and-rbac-api: drafted # Agent Registry, Resolution & RBAC API [P0]
+  32-2-agent-registry-resolution-and-rbac-api: done # Agent Registry, Resolution & RBAC API [P0]
   32-3-per-tenant-provider-credential-resolution: done # Per-Tenant Provider Credential Resolution (BYOK → platform) [P0]
   32-4-saas-provider-auth-gating-api-key-only: drafted # SaaS Provider Auth Gating — API-key only (CLI/token providers single-user only) [P0]
   32-5-managed-agent-execution-layer: drafted         # Managed Agent Execution Layer (IManagedAgent over IAIProvider) [P0]

--- a/docs/sprint-status.yaml
+++ b/docs/sprint-status.yaml
@@ -418,7 +418,7 @@ development_status:
   epic-32: contexted   # NEW Agents — entities, managed execution, benchmarking & learning (added 2026-06-17; all stories drafted)
   32-1-agent-entity-model-and-versioned-saved-config: done # Agent Entity Model & Versioned Saved Config (public/private) [P0]
   32-2-agent-registry-resolution-and-rbac-api: drafted # Agent Registry, Resolution & RBAC API [P0]
-  32-3-per-tenant-provider-credential-resolution: drafted # Per-Tenant Provider Credential Resolution (BYOK → platform) [P0]
+  32-3-per-tenant-provider-credential-resolution: done # Per-Tenant Provider Credential Resolution (BYOK → platform) [P0]
   32-4-saas-provider-auth-gating-api-key-only: drafted # SaaS Provider Auth Gating — API-key only (CLI/token providers single-user only) [P0]
   32-5-managed-agent-execution-layer: drafted         # Managed Agent Execution Layer (IManagedAgent over IAIProvider) [P0]
   32-6-agent-action-trail-in-tenant-store: drafted    # Agent Action Trail (DCB events tagged agent_id) in Tenant Store [P0]

--- a/docs/superpowers/plans/2026-06-20-epic-32-37-replan.md
+++ b/docs/superpowers/plans/2026-06-20-epic-32-37-replan.md
@@ -1,0 +1,74 @@
+# Epic 32/34/36 Re-plan — impact of the revised agent architecture
+
+**Date:** 2026-06-20 · **Companion to:** `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` · **Status:** proposed re-plan for review
+
+> Captures what the corrected model (steps never call providers; call-LLM endpoint; personas = system agents; provider cost entity; per-tenant enablement; BYOK-per-provider) changes for already-built and drafted stories, and the recommended sequence. **No code changed yet.** Wave 1 is merged to `main`; Wave 2 (32-2, 32-3) is on `feat/exec-wave-02`, **unmerged**.
+
+---
+
+## 1. Disposition of the already-built work
+
+| Story | Built state | Verdict under new model | Action |
+|---|---|---|---|
+| **32-1** Agent entity model (DONE, on `main`) | Public agents seeded as per-role `tamma-<role>`, single provider chain, no explicit `model`, `Role` is a required identity column. | **Entity model is sound and KEPT.** The seeding + `Role`-as-identity is what changes (personas are cross-role named agents). | **Amend** (new story): `Agent.Role` nullable/non-identity for Public; public unique index `(Name,Role)`→`(Name)`; rewrite `AgentEntitySeeder` to named cross-role personas (`claude`/`gemini`/`codegpt`) with explicit `provider`+`model`; `ConfigJson` adds `model` + optional `prompts` block. |
+| **32-2** Registry/resolution/RBAC (DONE, on `feat/exec-wave-02`) | 4-branch resolve; `GetSystemDefaultPublicAsync` matches `Agent.Role==role`; `CanUse` allows any public agent; no enablement; prompt comes from agent config/default. | **Resolver + RBAC are KEPT.** Default lookup, the "any public" rule, and the prompt source change. | **Amend** (new story): default = tenant's **enabled** default persona (delete per-role ambiguity warning); add **enablement gate** to `CanUse`/`SelectForRoleAsync`/`ResolveUsableAgentAsync`; resolver pulls the **prompt from Epic 27** for personas (own prompts for custom agents). |
+| **32-3** BYOK credential resolution (DONE, on `feat/exec-wave-02`) | Cabinet-backed `DefaultProviderCredentialResolver` (correct) **+ an engine-side `ConfigPlatformProviderCredentialResolver` wired into `CallLlmInlineActivity`** (the wrong-place fix we already flagged). | **The resolver SEAM + cabinet logic are KEPT.** The engine-side wiring is **superseded** — credential resolution moves behind the call-LLM endpoint. | **Re-aim**: keep `DefaultProviderCredentialResolver` (now invoked by `ManagedAgent` in the API); **delete** `ConfigPlatformProviderCredentialResolver` + `AddEngineProviderCredentialResolution` from `ElsaServer/Program.cs`; the engine holds no key. |
+
+**Net on the branch:** 32-1/32-2 are ~90% salvageable (entity + registry kept; seeder + Role + enablement + prompt-source change). 32-3's *engine wiring* is dead-on-arrival under the new model, but its cabinet resolver is the keeper that the call-LLM endpoint will use.
+
+---
+
+## 2. Affected drafted stories
+
+| Story | Current | Change under new model | Action |
+|---|---|---|---|
+| **32-4** SaaS provider auth gating | drafted | Becomes the **gate inside the call-LLM endpoint** (`ISaaSProviderGate`: CLI/token providers can't execute in SaaS; unknown denied fail-closed). | **Reframe** scope → the endpoint's gate stage. |
+| **32-5** Managed agent execution layer | drafted | Becomes **`POST /api/v1/llm/call` + `ManagedAgent.RunAsync`** — the composition root (gate→resolve→credential→render→loop→meter→return) and the home for the extracted tool loop. **This is the lynchpin story.** | **Reframe/expand** → owns the endpoint + `IInlineToolLoopRunner` extraction + the thin-client cutover of `CallLlm*`/`ClaudeAnalysisActivity`. |
+| **32-12** Agent personas | drafted | Current "persona = style overlay within a role" **contradicts** the model (persona = named cross-role system agent). | **Rewrite** as "persona = system agent"; split the style/tone overlay into a separate optional **style-variant** story (don't call it a persona). |
+| **34-3** BYOK-vs-platform pricing mode | drafted | No change — owns mode selection + `ProviderDiagnostic.BillingMode`; consumes `credentialSource`. | Keep. |
+| **34-5** Cost→price markup engine | drafted | No code/AC change — keeps calling `IProviderPricingService`. | **One-line dependency edit**: prerequisite becomes the new Provider Cost Price-Book story. |
+| **36-7** Pricing/cost-basis margin view | drafted | No change — reads persisted `CostUsd`/`PlatformBilledUsd`. | Keep. |
+| **32-9** Usage/cost metering | drafted | No change — sources `costBasisUsd` from the diagnostic. Now produced by the call-LLM endpoint. | Keep (producer). |
+
+---
+
+## 3. New stories / entities needed
+
+1. **NEW (Epic 34) "Provider Cost Price-Book"** — `Provider` + `ProviderModelPrice` CP entities (immutable-versioned, alias-normalized, insert-missing-only seeder) behind the **unchanged** `IProviderPricingService` seam (swap the frozen table for `DbProviderPricingService`). **Sequence before 34-5.**
+2. **NEW (Epic 32) "Call-LLM endpoint + managed execution"** — = the reframed 32-5: `POST /api/v1/llm/call`, `ManagedAgent`, the extracted `IInlineToolLoopRunner`, and the thin-client cutover of `CallLlmInlineActivity`/`CallLlmActivity`/`ClaudeAnalysisActivity`. Absorbs 32-4's gate.
+3. **NEW (Epic 32) "Persona reframe + seeding"** — the 32-1 amendments (Role nullable, named-persona seeder, explicit model, Epic-27 prompt wiring).
+4. **NEW (Epic 32) "Per-tenant agent/persona enablement"** — `TenantAgentEnablement` entity + enable/disable API (`tenant_owner`/`tenant_admin`; `PlatformOwnerAccess` for the public catalog) + the enablement gate in registry/resolver + `AGENT.ENABLED/DISABLED` events. (The genuinely missing layer.)
+5. **NEW (Epic 32) "Custom-agent prompts"** — `ConfigJson.prompts` block + resolver prompt-source branch for private agents (custom prompts ⇔ custom agent), fail-loud.
+6. **32-12 rewrite** (persona = system agent) + a separate **style-variant** story.
+7. **NEW Epic 38 "Step → internal-API mediation (non-LLM)"** — tamma-api controllers for git (Class A), agent-dispatch (Class C), Slack (Class D); re-point those activities to `TammaApiClient`; the build-time guardrail; outbox for fire-and-forget; enforce Class E (billing) by design when Epic 35 lands. Reuses the `/llm/call` template; does NOT block Epic 32.
+
+---
+
+## 4. Recommended sequence
+
+```
+A. Provider Cost Price-Book (Epic 34, new)        ── unblocks metering; before 34-5
+B. Persona reframe + seeding (32-1 amend)         ── personas exist as named cross-role agents
+C. Per-tenant enablement (new)        ┐
+D. Custom-agent prompts (new)         ├─ the agent model the endpoint resolves
+E. 32-2 amend (enablement gate + Epic-27 prompt)  ┘
+F. Call-LLM endpoint + managed execution (32-5 reframed, absorbs 32-4 gate, uses 32-3 resolver)
+        ── the lynchpin: steps stop calling providers; 32-3 engine wiring deleted here
+G. 32-12 rewrite + style-variant (later)
+H. Epic 38 non-LLM mediation (follow-up; parallelizable)
+```
+
+A–E are entity/data work that can proceed in parallel lanes; **F is the integration lynchpin** and depends on B–E + the kept 32-3 resolver + A's cost entity.
+
+---
+
+## 5. What to do RIGHT NOW
+
+**Recommendation:**
+1. **Land the design** (this re-plan + the spec) so the corrected model is the reference. Update `sprint-status.yaml`: 32-4/32-5/32-12 reframed; add the 5 new stories as `drafted`; mark 32-3's engine-wiring portion superseded.
+2. **Decide the `feat/exec-wave-02` branch.** 32-2 is sound and mergeable; 32-3's *cabinet resolver* is sound but its *engine wiring* will be deleted by story F. Two clean choices:
+   - **(a, recommended)** Merge `feat/exec-wave-02` as-is (32-2 + 32-3) to `main` — it's green and the engine wiring is harmless-but-dormant (it only supplies the platform key, which still works) — then do the redesign stories A–F, where F deletes the dormant engine wiring. Keeps history linear, no rebase churn.
+   - **(b)** Hold the branch, rework 32-3 first. Slower; not worth it since (a)'s dormant wiring is safe.
+3. **Re-author the affected stories** (32-4, 32-5, 32-12) and write the 5 new story specs, then resume implementation at sequence step A.
+
+**Do NOT** resume the old Wave 2/3 plan as written — 32-4/32-5 in their current form assume the old direct-call model.

--- a/docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md
+++ b/docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md
@@ -1,0 +1,644 @@
+# Epic 32 — Revised Agent Architecture (Design of Record)
+
+**Status:** Authoritative. Supersedes the persona/agent and credential portions of
+`docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md` where they conflict.
+**Date:** 2026-06-20
+**Author:** Lead architect (synthesis of one step-audit + four design analyses, reconciled)
+**Scope:** Agents, personas, custom agents, per-tenant enablement, the provider cost-pricing
+entity, the tamma-api `call-LLM` mediation endpoint, and the cross-cutting "steps never call
+external APIs directly" rule. Companion re-plan: `docs/superpowers/plans/2026-06-20-epic-32-37-replan.md`.
+
+---
+
+## 0. The locked model (non-negotiable source of truth)
+
+These seven rules are the architecture. Everything else in this document derives from them.
+
+1. **A workflow STEP MUST NEVER call an external API/provider directly.** A step that needs an LLM
+   call (or any external integration) calls an **internal tamma-api endpoint**, passing params.
+   `Tamma.Api` is the single place that holds credentials, decides if the call is allowed, performs
+   the external call, and meters it. The Elsa engine (`Tamma.ElsaServer`) **never holds a provider
+   key and never hits an external endpoint.**
+
+2. **The LLM path is mediated by a `call-LLM` endpoint.** The step calls a tamma-api `call-LLM`
+   endpoint with `{ tenantId, agentId/persona, role, prompt, params }`. That endpoint, in order:
+   (a) **gates** (mode/SaaS auth, entitlement, budget);
+   (b) **resolves the agent config**;
+   (c) **resolves the credential** BYOK→platform from the Epic 29 cabinet;
+   (d) **makes the provider call**;
+   (e) **meters usage** (cost from provider pricing; price = markup when platform, none when BYOK);
+   (f) **returns result + `credentialSource`**.
+
+3. **PROVIDER is a system entity carrying COST PRICING** (per-token, per model) — the platform's
+   cost basis. It is the *cost* primitive; it is not the *sell* price.
+
+4. **PERSONA = a system-defined named AGENT** (Claude, Gemini, CodeGPT, …) = a preset system
+   provider + model + config (params/tools). Its **PROMPTS come from the existing role/system prompt
+   store (Epic 27)** — personas have **NO custom prompts**. Personas work for **ALL roles**, not just
+   dev.
+
+5. **CUSTOM AGENT: custom prompts ⇔ custom agent.** A tenant that wants different prompts creates a
+   custom (private) agent carrying its own prompts + config.
+
+6. **ENABLEMENT is PER-TENANT.** The tenant enables which personas/agents exist for it; its users
+   simply use Tamma with what's enabled. There is **NO per-user enablement layer.**
+
+7. **BYOK is PER-TENANT, PER-PROVIDER.** A tenant sets a key for a provider → used for that tenant's
+   calls (`credentialSource=byok`, no platform markup). Otherwise the platform key is used + markup
+   priced off the provider's cost.
+
+**Mode reminder (from CLAUDE.md):** "principal" = the tenant in SaaS mode, the sole user in
+single-user mode. Every entity below is keyed by `(tenantId XOR userId)` exactly like
+`prompt_overrides` and `AgentRoleSelection`. There is no per-user layer in SaaS for prompts,
+enablement, or agent selection.
+
+---
+
+## 1. Cross-cutting principle: steps never call external APIs directly
+
+### 1.1 The principle
+
+The Elsa engine is a **deterministic orchestrator that holds no secrets**. Any activity that needs an
+external effect (LLM, git platform, CI dispatch, Slack, billing) **delegates over HTTP to a
+`Tamma.Api` endpoint** through `TammaApiClient` (the engine→API callback already used for
+agent-resolve, budget, diagnostics, and provider-session). The credential-holding code, the
+authorization decision, the external HTTP call, and the metering/audit emission **all live in
+`Tamma.Api`**.
+
+The reference for "right" already exists in the tree three times and should be the template:
+- **`TammaApiClient`** — engine→API HTTP delegation with `Authorization: Bearer <Tamma:ApiToken>`
+  (via `TammaEngineAuthHandler`) + `X-Tenant-Id`. Already routes agent-resolve / budget /
+  diagnostics / provider-session.
+- **`QueueWelcomeEmailActivity`** — the **outbox pattern**: the step writes intent to
+  `platform_email_outbox`; an out-of-band sender (in the API) holds the SMTP credential and performs
+  transport. This is the model for fire-and-forget external effects.
+- **`TriggerCIActivity`** — already POSTs to an internal `Engine:CallbackUrl/api/engine/trigger-ci`;
+  it holds no CI-vendor credential.
+
+> **Co-hosting is NOT compliance.** Today many activities resolve a credential-holding *service from
+> the same DI container* (because, in the current single-process deploy, the engine activities and
+> the API services are co-hosted). Rule #1 forbids this: the step must call an internal endpoint
+> **over the wire**, not resolve an injected vendor service. This matters the moment the engine runs
+> as per-tenant dedicated compute (the Cranl path), because then the token would have to be pushed
+> into the engine process — exactly what we must prevent.
+
+### 1.2 Audit table — every externally-acting activity
+
+Audited against `apps/tamma-elsa/src/Tamma.Activities` on `feat/exec-wave-02`. "Direct?" = does the
+activity itself perform the external HTTPS call and/or hold/transit the credential in the engine
+process. "Compliant" = already routes through an internal `Tamma.Api`/engine-callback endpoint and
+holds no external credential.
+
+| Activity | External target | How it reaches it today | Holds/transits a key in-engine? | Verdict |
+|---|---|---|---|---|
+| `LlmCall/CallLlmActivity` | Anthropic / OpenAI | `httpClient.PostAsync($"{baseUrl}/v1/messages")`; reads `Anthropic:ApiKey` directly (line ~601) | **YES** | **VIOLATION — worst** |
+| `LlmCall/CallLlmInlineActivity` | Anthropic / OpenAI | builds body + `PostAsync(.../v1/messages` & `/v1/chat/completions`); key via `IProviderCredentialResolver` → `config.ApiKey` | **YES** | **VIOLATION — primary path (~1592 LOC, 22 parent workflows)** |
+| `AI/ClaudeAnalysisActivity` (Mentorship) | Anthropic | 3-way branch: mock → engine-callback → **direct `CallClaudeApi` reading `Anthropic:ApiKey`** | **YES (fallback path)** | **VIOLATION (easily missed)** |
+| `TDD/WriteTestsActivity` | Anthropic | mock → engine-callback → **`CallLlm` via `CreateClient("anthropic")` (keyed handler)** | **YES (fallback path)** | **VIOLATION (fallback)** |
+| `TDD/WriteImplementationActivity` | Anthropic | same 3-way branch | **YES (fallback path)** | **VIOLATION (fallback)** |
+| `TDD/AnalyzeCodeActivity` | Anthropic | same 3-way branch | **YES (fallback path)** | **VIOLATION (fallback)** |
+| `TDD/ApplyRefactoringActivity` | Anthropic | same 3-way branch | **YES (fallback path)** | **VIOLATION (fallback)** |
+| `ADL/ApplyReviewFixesActivity` | Anthropic | same 3-way branch (`PostAsJsonAsync("/v1/messages")`) | **YES (fallback path)** | **VIOLATION (fallback)** |
+| `Debug/AIDiagnosisActivity` | Anthropic | engine-callback → **direct `/v1/messages`** (no simulated fallback) | **YES (fallback path)** | **VIOLATION (fallback)** |
+| `ADL/CreateBranchActivity` | Git platform | `IGitHubIntegrationService` (impl + `GitHub:Token` in `Tamma.Api`; **unregistered/null in engine**) | only if co-hosted | **VIOLATION-by-co-hosting** |
+| `ADL/CreatePullRequestActivity` | Git platform | `IGitHubIntegrationService` | only if co-hosted | **VIOLATION-by-co-hosting** |
+| `ADL/MergePullRequestActivity` | Git platform | `IGitHubIntegrationService` | only if co-hosted | **VIOLATION-by-co-hosting** |
+| `ADL/UpdateIssueStatusActivity` | Git platform | `IGitHubIntegrationService` | only if co-hosted | **VIOLATION-by-co-hosting** |
+| `ADL/AnalyzeReviewActivity` | Git platform | `IGitHubIntegrationService` (read PR comments) | only if co-hosted | **VIOLATION-by-co-hosting** |
+| `AgentDispatch/DispatchAgentWorkflowActivity` / `GitHubActionsExecutor` | GitHub Actions | `IGitHubActionsClient` (`OctokitGitHubActionsClient` in API; `NullGitHubActionsClient` in engine) | only if co-hosted | **VIOLATION-by-co-hosting** |
+| `AgentDispatch/MonitorAgentWorkflowActivity` / `CollectAgentResultsActivity` | GitHub Actions | `IGitHubActionsClient` | only if co-hosted | **VIOLATION-by-co-hosting** |
+| `Integration/SlackActivity` | Slack | `IIntegrationService` (impl + Slack token in API; unregistered in engine) | only if co-hosted | **VIOLATION-by-co-hosting (low blast radius)** |
+| `Testing/TriggerCIActivity` | CI (internal) | POSTs to `Engine:CallbackUrl/api/engine/trigger-ci` | **NO** | **Compliant (formalize under `/api/v1`)** |
+| `TenantLifecycle/QueueWelcomeEmailActivity` | SMTP | outbox row → out-of-band `OutboxSmtpSender` (API) | **NO** | **Compliant (reference pattern)** |
+| `AgentDispatch/WebhookSignalRegistry` | (inbound) | in-process bookmark wakeup from API-received webhook | n/a | **Not a violator (inbound)** |
+| (future) Billing / Stripe | Stripe | none yet (Epic 35 unbuilt) | n/a | **Enforce by design** |
+
+> **Correction to prior analysis:** the LLM violator set is NOT just `CallLlm*` + `ClaudeAnalysis`.
+> The TDD and ADL activities (`WriteTests`, `WriteImplementation`, `AnalyzeCode`, `ApplyRefactoring`,
+> `ApplyReviewFixes`) and `AIDiagnosis` each carry a **direct keyed LLM fallback** (`CallLlm` /
+> `CallClaudeApi` / direct `/v1/messages`) behind the engine-callback branch. Their engine-callback
+> mode is acceptable, but the direct fallback must be removed and routed through `call-LLM`. **Nine
+> in-engine direct-LLM callers total**, not three.
+
+### 1.3 Prioritized violator list
+
+- **P0 — active in-engine key holders (LLM):** `CallLlmInlineActivity` (primary), `CallLlmActivity`
+  (worst single offender — reads `Anthropic:ApiKey` directly), then `ClaudeAnalysisActivity`,
+  `WriteTestsActivity`, `WriteImplementationActivity`, `AnalyzeCodeActivity`,
+  `ApplyRefactoringActivity`, `ApplyReviewFixesActivity`, `AIDiagnosisActivity` (all have a direct
+  keyed fallback). These are the metering chokepoint and the only steps that, in any deploy topology,
+  put a live external key in the engine. **Fixed by Epic 32 now.**
+- **P0/P1 — git-platform writes + agent-dispatch:** `CreateBranch`, `CreatePullRequest`,
+  `MergePullRequest`, `UpdateIssueStatus`, `AnalyzeReview`, `DispatchAgentWorkflow` /
+  `GitHubActionsExecutor`, `Monitor`/`CollectAgentResults`. High the moment the engine is not
+  co-hosted with `Tamma.Api`: a mis-scoped platform token = cross-tenant write/merge. **Follow-up
+  epic (see §6).**
+- **P2 — Slack:** `SlackActivity`. Token-holding but read-no-tenant-data, low blast radius.
+  **Follow-up epic.**
+- **Formalize-only:** `TriggerCIActivity` (already internal). **Enforce-by-design:** Stripe/billing
+  (Epic 35).
+
+---
+
+## 2. The tamma-api `call-LLM` endpoint (the LLM mediation)
+
+### 2.1 Route, auth, ownership
+
+```
+POST /api/v1/llm/call        (internal, engine-only)
+```
+- **Auth:** same plane as the other `TammaApiClient` callbacks — `Authorization: Bearer
+  <Tamma:ApiToken>` (via `TammaEngineAuthHandler`) + `X-Tenant-Id`. Missing/invalid bearer → **401**.
+- **Home:** new `Tamma.Api/Endpoints/LlmCallEndpoints.cs`, delegating to `IManagedAgent.RunAsync`
+  (Story 32-5, `Tamma.Api/Services/Agents/`).
+
+### 2.2 Request (`LlmCallRequest`)
+
+```jsonc
+{
+  "tenantId":   "guid|null",        // null => single-user/platform scope (also from X-Tenant-Id)
+  "agentId":    "guid|null",        // explicit custom/persona agent; else resolved by role
+  "persona":    "string|null",      // system persona name (claude/gemini/codegpt) — preset provider+model+config
+  "role":       "string",           // one of the 8 valid roles — drives Epic 27 prompt resolution
+  "action":     "string|null",      // role+action prompt key (Epic 27)
+  "phase":      "string|null",      // workflow phase for ResolveForPhaseAsync (32-2)
+  "prompt":     "string",           // task/user prompt (variables merged server-side)
+  "variables":  { },                // template vars for Epic 27 render
+  "model":      "string|null",      // optional model override (clamped to persona/agent allowance)
+  "tools":      ["name", …] | null, // requested tools (intersected with the agent's allowed set)
+  "enableToolLoop": false,
+  "toolLoopConfig": { } | null,
+  "params":     { "maxTokens": 4096, "temperature": 0.7, "budgetCapUsd": 0.0 },
+  "correlationId": "string"         // workflow instance id — ties run to audit + outcome
+}
+```
+
+### 2.3 Response (`LlmCallResponse`, success — HTTP 200)
+
+Superset of today's `NormalizedLlmResponse` + the 32-5 `AgentRunResult` fields. **`credentialSource`
+is returned; the key is NEVER returned.**
+
+```jsonc
+{
+  "success": true,
+  "text": "…assistant response…",
+  "usage": { "promptTokens": 0, "completionTokens": 0, "totalTokens": 0,
+             "toolLoopTokens": 0, "toolLoopTurns": 0, "toolLoopExhausted": false },
+  "credentialSource": "byok" | "platform",   // from ProviderCredential.Source (32-3) — never the key
+  "providerUsed": "anthropic",                 // the chain entry that succeeded
+  "modelUsed": "claude-sonnet-4-…",
+  "cost": { "providerCostUsd": 0.0,            // IProviderPricingService.Compute — provider cost basis (§4)
+            "priceUsd": 0.0,                   // markup applied when platform; 0 token-price when byok (Epic 34-5)
+            "currency": "USD" },
+  "toolCalls": [ { "toolName": "…", "success": true, "durationMs": 0 } ],
+  "agentId": "guid", "agentVersion": 3, "role": "implementer",
+  "correlationId": "…", "durationMs": 0
+}
+```
+
+### 2.4 Error / gating semantics (fail-closed)
+
+The endpoint always returns a **typed, key-free body** — never a leaked provider error or key.
+
+- **HTTP 200 with `success:false`** for *expected execution failures*, so the engine's
+  provider-chain/retry logic stays intact. `httpStatusCode` MUST be preserved so the engine's
+  `RetryCheck` (429/502/503/504/0 → retry) and circuit breaker keep working:
+  ```jsonc
+  { "success": false,
+    "failureCode": "PROVIDER_ERROR" | "PROVIDER_CREDENTIAL_UNAVAILABLE"
+        | "BUDGET_EXCEEDED" | "LOOP_EXHAUSTED",
+    "failureReason": "…key-free message…", "httpStatusCode": 429,
+    "credentialSource": "platform", "providerUsed": "anthropic",
+    "usage": { …accrued-before-failure… } }
+  ```
+- **HTTP 400 `SAAS_PROVIDER_NOT_ALLOWED`** when 32-4's `ISaaSProviderGate` denies a CLI-token
+  provider in SaaS (selection/execution backstop).
+- **HTTP 403** when SaaS auth/entitlement (32-4) rejects the tenant.
+- **HTTP 401** when the engine bearer token is absent/invalid.
+- **Fail-closed rule:** if the credential, gate, or budget cannot be evaluated, **deny** — never
+  silently call the provider with an empty/wrong key. Preserves the existing
+  `PROVIDER_CREDENTIAL_UNAVAILABLE` (`retryable:false, severity:High`) and the budget/circuit-breaker
+  "fail closed → deny" guarantees. (Consistent with `feedback_resolution_no_empty_fallback`: never
+  fall back to an empty/plain credential or prompt.)
+
+### 2.5 What `CallLlmInlineActivity` becomes — a thin client
+
+`CallLlmInlineActivity` collapses from ~1592 lines to a ~80-line shim that **owns no provider logic,
+no key, no HTTP-to-provider, no tool loop**:
+
+- **Sends** an `LlmCallRequest` to `POST /api/v1/llm/call` via a **new
+  `TammaApiClient.CallLlmAsync(LlmCallRequest, tenantId, ct)`** (following the existing
+  `PostAsync<T>` + `AddTenantHeader` + `RecordHealthAsync` pattern). It maps its current `Input<>`
+  props (`InputJsonProp`, `ProviderNameProp`, `SystemPromptProp`, `ToolsJsonProp`,
+  `AttemptNumberProp`, `EnableToolLoopProp`, `ToolLoopConfigJsonProp`, `TenantIdProp`) into the request.
+- **Receives** `LlmCallResponse`, then writes the **same workflow variables it writes today** so the
+  retry loop, success/failure check, and output builders in `LlmCallWorkflow.cs` are unchanged:
+  `LastDiagnostic` (a `ProviderAttemptDiagnostic` carrying `CredentialSource`, `HttpStatusCode`,
+  token counts), `LastResponse` (a `NormalizedLlmResponse`), and
+  `ToolLoopTokens`/`ToolLoopTurns`/`ToolLoopExhausted`.
+- **Provider-chain & retry semantics stay at the workflow boundary, not in the activity.** The
+  activity is still invoked once per provider per attempt inside `BuildRetryLoop` →
+  `ForEach<provider>`. The endpoint runs the tool loop server-side per call; the activity just
+  propagates `success`/`httpStatusCode` into `LastDiagnostic` so `RetryCheck` /
+  `SkipIfSucceeded` / circuit-breaker advance the chain exactly as today. `enableToolLoop` +
+  `toolLoopConfig` are passed through to the endpoint instead of executed locally.
+- **Removed from the engine:** the injected provider-side deps (`IHttpClientFactory`,
+  `IContentSanitizer`, `IToolExecutorRegistry`, `IToolCallValidator`, `ContextCompactor`,
+  `ToolLoopEventEmitter`, `ParallelToolExecutor`, and crucially **`IProviderCredentialResolver`** —
+  the engine no longer resolves keys).
+
+`CallLlmActivity` becomes a thin client the same way **or is deleted** in favour of the inline path
+(it is the most severe rule-1 violator). The TDD/ADL/Debug/Mentorship activities (§1.2) have their
+direct-LLM fallback **deleted** and route through `call-LLM` (or keep only their engine-callback
+mode, which itself terminates at the mediated path).
+
+### 2.6 Where credential resolution / provider call / metering / gating now live
+
+All of it moves into **`Tamma.Api`**, composed by **`ManagedAgent.RunAsync` (32-5)**, invoked by the
+`/api/v1/llm/call` handler. Composition order is the locked rule #2 sequence:
+
+1. **Gate (32-4)** — `ISaaSProviderGate.InspectAsync` (`Tamma.Api/Services/Security/`) + SaaS
+   auth/entitlement. CLI-token providers excluded in SaaS; unknown providers denied fail-closed.
+2. **Resolve agent config (32-2)** — `IManagedAgentResolver`/`AgentResolverService` resolves
+   persona/custom-agent → provider + model + params + allowed tools, **after applying the per-tenant
+   enablement gate (§5)**.
+3. **Resolve credential BYOK→platform (32-3)** — the **cabinet-backed
+   `DefaultProviderCredentialResolver`** (`Tamma.Api/Services/Providers/`), which can reach the Epic
+   29 cabinet (`ITenantProviderKeyReader`, runtime secret resolver). **This is the canonical home.**
+   The engine-side `ConfigPlatformProviderCredentialResolver` (platform-only, no BYOK leg) becomes
+   vestigial and is removed from the call path; the engine no longer resolves credentials at all.
+4. **Render prompt (Epic 27)** — tenant→system→error resolution. Personas have **no** custom prompts
+   (prompt comes from Epic 27 keyed `(principal, role, action)`); custom agents carry their own
+   prompts. **Never fall back to empty/plain** (fail-loud).
+5. **Provider call** — the extracted tool loop (`IInlineToolLoopRunner`/`InlineToolLoopRunner`, 32-5
+   AC3, moved verbatim from `CallLlmInlineActivity.AgenticToolLoop`) makes the actual external HTTPS
+   call **inside `Tamma.Api`**, using the plaintext key request-scoped (set on the header, dropped
+   after — 32-3 AC5). The sanitizer/registry/validator/compactor are injected here, in the API process.
+6. **Meter** — `IProviderPricingService.Compute(provider, model, in, out)` gives the **provider cost
+   basis** (rule #3); Epic 34-5's markup engine derives `priceUsd` (markup when
+   `credentialSource==platform`, none when `byok` — rule #7); 32-9 emits the usage record consumed by
+   Epic 35 billing / Epic 36 analytics.
+7. **Return** `text`, `usage`, `credentialSource`, `providerUsed`, `cost` + the `AgentRunResult` fields.
+
+DCB events (`AGENT.CREDENTIAL_RESOLVED.SUCCESS`/`DENIED`, `AGENT.PROVIDER.GATED`,
+`AGENT.RUN.STARTED/SUCCESS/FAILED`) are emitted from `Tamma.Api`, where the tenant `IEventRepository`
+and the cabinet live — not from the engine's optional-sink path.
+
+> **Why the inline tool loop lives in `Tamma.Activities` but runs in `Tamma.Api`:** `Tamma.Api`
+> references `Tamma.Activities`, so the extracted `InlineToolLoopRunner` can be shared verbatim
+> (no fork — 32-5 AC3). The *provider HTTP call* executes in the API process, where the key is
+> resolved; the engine activity never touches the runner.
+
+---
+
+## 3. The agent model: persona / custom agent / enablement
+
+### 3.0 The core reframe
+
+The locked model redefines two words that the shipped 32-1/drafted 32-12 used differently:
+
+| Term | 32-1/32-12 as built/drafted | Locked model (rules 4–6) |
+|---|---|---|
+| **Public agent** | per-role `tamma-<role>`, role IS its identity, single provider chain | a **named PERSONA** (claude/gemini/codegpt) that PRESETS provider+model+config, usable across **ALL roles**; role is NOT its identity |
+| **Persona (32-12)** | a style/tone overlay within one role (`atlas`/`nova` in `reviewer`) | the **system agent itself** — the preset provider+model+config; prompts from Epic 27, **no custom prompts** |
+| **Custom agent** | any private `Agent` (config blob, role-keyed) | private agent whose differentiator is **custom prompts** (custom prompts ⇔ custom agent) |
+| **Selection** | per-`(principal,role)` pick of any visible agent | per-`(principal,role)` pick, **constrained to the tenant's enabled set** |
+| **Enablement** | (missing) | a **per-tenant** layer: which personas/agents exist for a tenant |
+
+**Biggest structural change:** public agents stop being per-role `tamma-<role>` and become
+**cross-role named personas**. Role becomes a *selection-time* concern (which persona serves which
+role for a principal), not a baked-in attribute of the public agent.
+
+### 3.1 PERSONA = system-agent entity
+
+**Definition.** A persona is a Public/system `Agent` that presets `{ provider, model,
+config(params/tools/budget/temperature/RAG) }` with a stable named identity (`claude`, `gemini`,
+`codegpt`). It is **cross-role** and **prompt-free**: at call time the role/system prompt comes from
+the Epic 27 store keyed `(principal, role, action)`.
+
+**Changes to the shipped `Agent` (32-1):**
+- **`Agent.Role` is no longer identity for Public personas.** Make `Role` nullable: public personas
+  have `Role = NULL` (cross-role). The `ConfigJson` may still carry per-role hints (e.g. a `roles`
+  map of temperature), but the persona is selectable for any role.
+- **Public unique index `(Name, Role) WHERE Public` → `(Name) WHERE Public`** (persona handles are
+  globally unique among public agents). `Role` drops out of the seeder idempotency key.
+- **`AgentEntitySeeder` rewritten:** instead of 8 `tamma-<role>` rows on one provider chain, seed
+  **N named cross-role personas**, each presetting a real provider+model and carrying an **explicit
+  `model`** in `ConfigJson` (today the seed omits `model` and relies on `DefaultAgentConfig.ForRole`
+  → `claude-sonnet-4` — fine for one provider, wrong when personas differ by provider):
+  - `claude` → `{ provider: anthropic, model: claude-sonnet-4-… }`
+  - `gemini` → `{ provider: google, model: gemini-… }`
+  - `codegpt`/`gpt` → `{ provider: openai, model: gpt-… }`
+  - (optionally OpenRouter-backed personas)
+- **`GetSystemDefaultPublicAsync(role)` rewritten:** it can no longer find "the public agent whose
+  `Role==role`." It returns the platform's configured **default persona** (e.g. `DefaultPersonaName =
+  claude`) regardless of role. The per-role ">1 public agent" ambiguity warning is deleted.
+- **`AgentResolverService.MaterialiseAsync`** keeps merging the agent's `ConfigJson` onto
+  `DefaultAgentConfig.ForRole(role)` and stamping `AgentId`/`AgentVersion`, but **the system/role
+  prompt now comes from Epic 27**, not from the persona config. This is the key wiring change.
+
+### 3.2 CUSTOM AGENT = custom prompts (rule 5)
+
+A tenant that wants *different prompts* creates a **custom (private) agent** carrying its own prompts
++ config. The private-`Agent` from 32-1 becomes the home for tenant-authored prompts — exactly the
+layer Epic 27 deliberately does NOT expose as per-tenant persona-prompt editing in SaaS. The custom
+agent is the sanctioned escape hatch: instead of editing the shared role/action prompt store, the
+tenant authors a self-contained private agent (provider+model+config **+ its own prompt set**).
+
+**Changes:**
+- `AgentVersion.ConfigJson` gains an **optional `prompts` block** for private agents:
+  `{ provider, model, params, prompts: { system?, byRoleAction?: {...} } }`. Personas (public) MUST
+  leave it empty (prompt-free by contract).
+- `MaterialiseAsync` prompt source becomes a **documented conditional branch**: persona/public →
+  Epic 27 store `(principal, role, action)`; custom/private with embedded prompts → the agent's own
+  prompts. Both fail-loud, never empty/plain.
+- No new entity: a custom agent is just a `Visibility=Private` `Agent`. The only schema delta is the
+  optional `prompts` block + the resolver's prompt-source branch. The existing visibility/ownership
+  XOR CHECK and per-owner partial indexes are reused.
+
+### 3.3 PER-TENANT ENABLEMENT (rule 6) — the genuinely missing layer
+
+Neither 32-1 nor 32-2 has this. `AgentRoleSelection` answers "which agent serves role X for principal
+P" but lets a principal select **any** visible agent. The locked model requires: the tenant **enables**
+which personas/agents exist for it; its users just use what's enabled; no per-user enablement.
+
+**New entity — `TenantAgentEnablement`** (CP-resident in SaaS, user-keyed in single-user, same
+XOR/index discipline as `AgentRoleSelection` / `prompt_overrides`):
+
+```sql
+TenantAgentEnablement (
+  Id          UUID PK,
+  TenantId    UUID NULL,   -- set in SaaS  (XOR)
+  UserId      UUID NULL,   -- set in single-user (XOR)
+  AgentId     UUID NOT NULL, -- a public persona OR an own private/custom agent
+  Enabled     BOOLEAN NOT NULL,
+  CreatedAt/By, UpdatedAt/By,
+  CHECK ((TenantId IS NOT NULL AND UserId IS NULL) OR (TenantId IS NULL AND UserId IS NOT NULL)),
+  UNIQUE NULLS NOT DISTINCT (TenantId, UserId, AgentId)
+)
+```
+
+**Semantics (per-tenant, NOT per-user):**
+- The tenant's **usable** set tightens the design-of-record's `public ∪ own-private` to
+  **`enabled(public) ∪ own-private`**. Own private agents are implicitly enabled (you authored them);
+  enablement is primarily about which **public personas** the tenant exposes.
+- **No per-user layer** (matches CLAUDE.md's "no per-user override layer in SaaS"). Members see
+  exactly the tenant's enabled set and cannot enable/disable. Single-user mode: the sole user is the
+  tenant-equivalent (keyed by `UserId`).
+- **Enablement = catalog membership; selection (`AgentRoleSelection`) = role binding.** Enablement is
+  the gate that constrains selection.
+
+**Changes to 32-2:**
+- `IAgentRegistryService.SelectForRoleAsync` / `ResolveUsableAgentAsync` add the enablement gate: a
+  public persona not enabled for the tenant is NOT selectable (→ `AGENT.SELECT.NOT_ENABLED`,
+  404/409). Today `CanUse()` returns true for *any* public agent — that becomes
+  `IsPublic && IsEnabledForPrincipal`.
+- `ListVisibleAsync` (or new `ListEnabledAsync`) returns `enabled(public) ∪ own-private`.
+- `GetSystemDefaultPublicAsync` returns the tenant's **enabled** default persona; fail-loud if the
+  tenant has enabled nothing (no empty fallback).
+
+**RBAC:** enable/disable a persona for the tenant requires `tenant_owner`/`tenant_admin` (member →
+403). Public-catalog management (which personas exist platform-wide) stays `PlatformOwnerAccess`
+(NOT `OwnerAccess`, which admits every personal-tenant owner).
+
+**New events:** `AGENT.ENABLED.SUCCESS` / `AGENT.DISABLED.SUCCESS`
+(tags `agentId, personaName, mode, tenantId|userId`).
+
+### 3.4 Disposition of 32-12
+
+32-12 ("persona = style overlay within a role") **directly contradicts** the locked model
+(persona = named cross-role system agent). **Rewrite 32-12** so "persona" = the public/system named
+agent (renaming the `tamma-<role>` concept). The style/voice overlay idea (`atlas`/`nova` tone /
+verbosity) is still valuable but is a **different, optional feature** — split it out as a separate
+**"style/voice variant"** story (a *variant* or *style profile*, not a *persona*) so the vocabulary
+matches the source of truth. The variant reuses the same visibility/XOR/index discipline.
+
+### 3.5 BYOK ∘ persona at call time (rule 7)
+
+32-3's `IProviderCredentialResolver.ResolveAsync(tenantId?, providerName)` is keyed by
+`(tenant, provider)` and is BYOK→platform with `credentialSource`. The persona supplies the
+`providerName` (and model); 32-3 resolves the key. End-to-end (all inside `call-LLM`; the step never
+touches a provider):
+
+1. Step → `call-LLM` `{ tenantId, role, (optional) agentId/persona, prompt, params }`.
+2. **Gate** (mode/SaaS auth, entitlement, budget) — 32-4 / Epic 34.
+3. **Resolve agent**: `ResolveForRoleAsync(role)` or explicit `agentId` → **enablement gate** (§3.3)
+   → `ResolvedAgentConfig` with `Provider` + `Model` + `AgentId`/`AgentVersion` stamped.
+4. **Resolve prompt**: Epic 27 `(principal, role, action)` (persona) OR the custom agent's own
+   prompts (custom agent).
+5. **Resolve credential**: `ResolveAsync(tenantId, resolvedConfig.Provider)` →
+   `{ ApiKey, Source ∈ {byok, platform} }`. The persona only names the provider; the key is the
+   tenant's BYOK-for-that-provider if present, else platform.
+6. **Provider call → meter** (cost from provider pricing; price = markup when `platform`, none when
+   `byok` — Epic 34-5) → return `result + credentialSource`.
+
+`credentialSource` is decided by `(tenant, persona.provider)`, persona-independent: tenant A with a
+BYOK Anthropic key running persona `claude` → `byok`, no markup; the same tenant running `gemini`
+with no Google BYOK → `platform`, markup. Persona/enablement is orthogonal to credential source.
+
+---
+
+## 4. The PROVIDER entity (cost pricing) and its relation to Epic 34 / 36-7
+
+### 4.1 What exists today
+
+A cost-pricing layer already exists as the single cost-basis source of truth:
+`Tamma.Api/Services/Providers/IProviderPricingService` / `ProviderPricingService` — a **hard-coded
+`FrozenDictionary<provider, FrozenDictionary<model, Rate(InputPerToken, OutputPerToken)>>`** ported
+from `packages/cost-monitor`. There is **no DB-backed PROVIDER entity** today. Stories 34-5, 36-2,
+36-7, and 32-9 all reference `IProviderPricingService.Compute/IsKnown` as THE cost basis and forbid
+re-deriving it.
+
+### 4.2 The new PROVIDER entity (cost)
+
+Promote the cost rate sheet to a first-class, admin-editable, **versioned control-plane entity** —
+**behind the existing `IProviderPricingService` seam** (the interface is the contract; the entity is
+an implementation detail). It is platform-global (NOT tenant-scoped — cost is the provider's
+published rate, identical for every tenant), and immutable-versioned like `Plan`/`MarginPolicy` so
+historical usage re-prices under the rate effective at call time.
+
+```
+Provider (system entity — the cost identity)
+  Id            UUIDv7
+  Key           string   -- canonical: "anthropic","openai","google","openrouter","local","claude-code"
+  DisplayName   string
+  AuthModel     string   -- "api-key" | "cli-token"   (feeds 32-4 SaaS-eligibility)
+  Status        string   -- "active" | "retired"
+  CreatedAt/UpdatedAt
+
+ProviderModelPrice (the COST pricing — per model, versioned)
+  Id              UUIDv7
+  ProviderKey     string   -- canonical, alias-normalized on write
+  Model           string   -- e.g. "claude-sonnet-4-20250514", "gpt-4o"
+  InputUsdPer1M   decimal  -- provider's published input rate
+  OutputUsdPer1M  decimal  -- provider's published output rate
+  -- (nullable room for cache-read / cache-write / per-request later)
+  EffectiveFrom   timestamptz (UTC)
+  Status          string   -- "active" | "superseded"
+  Source          string   -- "seed" | "admin"  (insert-missing-only seeder; never reverts admin edits)
+  CreatedAt/UpdatedAt
+```
+
+**Load-bearing behaviours preserved** (34-5's `IsKnown` gate and the diagnostic write path depend on
+these — they move into the entity-backed resolver, not get dropped):
+- alias normalization (`anthropic-claude`→`anthropic`, `claude`→`anthropic`, `gemini`→`google`,
+  `github-copilot`→`openai`, `ollama`/`lmstudio`→`local`);
+- loose prefix match (`claude-sonnet-4` matches `claude-sonnet-4-20250514`);
+- `null`/`"default"` → first-model rule.
+
+**Versioning:** an edit **supersedes** rather than mutates — partial unique index `(ProviderKey,
+Model) WHERE status='active'` + `EffectiveFrom`-windowed resolution so a usage event prices under the
+cost rate active at its `OccurredAt`. This makes the pricing chain byte-stable/reproducible (34-5 AC7)
+on the cost side too.
+
+**Seeding:** a `ProviderPricingSeeder` (insert-missing-only, deterministic UUIDv7) ports the current
+frozen table verbatim as v1 rows — mirrors `PlansSeeder`/`MarginPolicySeeder` (admin edits never
+reverted). The frozen table is retained as seed/fallback.
+
+### 4.3 COST vs PRICE — the three layers
+
+| Layer | Owns | Entity / seam | Scope | Answers |
+|---|---|---|---|---|
+| **COST (NEW)** | provider's published per-token rate | `Provider` + `ProviderModelPrice` behind `IProviderPricingService` | CP, platform-global | "What did this call cost us at the provider?" |
+| **PRICE — subscription** | recurring/seat/metered sell price per plan version, split by `PricingMode` | `Plan` / `PlanPrice` (34-1, DONE) | CP, platform-global | "What does the plan cost the tenant?" |
+| **PRICE — markup** | margin policy: `cost × MarkupMultiplier (+ FixedUsdPer1M)`; BYOK token markup = 0 | `MarginPolicy` + `IUsagePricingEngine`/`IMarginPolicyResolver` (34-5) | CP, platform-global | "What sell price for platform-provided tokens?" |
+| **VIEW** | `Σ PlatformBilledUsd − Σ CostUsd` per tenant + fleet | `MarginAnalyticsService` (36-7) — pure read, no recompute | tenant schema + CP fan-out | "Are we making money?" |
+
+- **`ProviderModelPrice` is the input to 34-5.** `CostBasisUsd = ProviderPricingService.Compute(...)`;
+  `SellPriceUsd = CostBasisUsd × MarkupMultiplier (+ FixedUsdPer1M × tokens/1M)`. Cost comes from the
+  PROVIDER entity; price is cost × MarginPolicy. `MarginPolicy.Scope='provider'` can override *margin*
+  per provider — never the *cost rate*.
+- **`PlanPrice` ≠ `ProviderModelPrice`.** `PlanPrice` is subscription/seat sell price keyed by
+  `(PlanId, PricingMode)`; `ProviderModelPrice` is per-token cost keyed by `(ProviderKey, Model)`.
+  No overlap.
+- **36-7 reads neither cost nor markup config.** It reads the already-persisted `CostUsd`
+  (= provider cost basis) and `PlatformBilledUsd` (= 34-5 sell price) columns that 36-2 wrote, and
+  reports `revenue − cost`.
+
+### 4.4 Cost→price flow (platform markup vs BYOK no-token-markup)
+
+`credentialSource` (32-3's `ProviderCredential.Source`, persisted by 34-3 as
+`ProviderDiagnostic.BillingMode`) branches the flow. **Cost basis is computed identically in both
+modes; only the sell price differs.**
+
+```
+LLM call (via /api/v1/llm/call — never the step directly)
+   │  (input/output tokens, provider, model from the diagnostic)
+   ▼
+ProviderModelPrice.Compute(provider, model, in, out)  ──► costBasisUsd   [NEW entity; same for byok & platform]
+   │
+   ├─ credentialSource = PLATFORM
+   │     MarginPolicy.Resolve(provider→plan→global) → markup
+   │     sellPriceUsd = round6( costBasisUsd × MarkupMultiplier + FixedUsdPer1M × totalTokens/1M )
+   │     marginUsd    = sellPriceUsd − costBasisUsd            [34-5, PricingMode.PlatformProvided]
+   │
+   └─ credentialSource = BYOK  (tenant's own key)
+         costBasisUsd STILL computed (for analytics/reporting)
+         sellPriceUsd (token component) = 0
+         marginUsd     = 0                                     [34-5, PricingMode.Byok]
+         (tenant pays the provider directly; we bill only plan/seat via Epic 35)
+   ▼
+ProviderDiagnostic { Cost = costBasisUsd, BillingMode } → 32-9 DCB usage event
+   → 36-2 persists CostUsd (cost) + PlatformBilledUsd (sell; 0 for BYOK)
+   → 36-7 reports Σ revenue − Σ cost  (BYOK ⇒ revenue 0, margin = −cost)
+```
+
+### 4.5 New story, not an extension
+
+This is a **NEW entity and a NEW story** ("Provider Cost Price-Book"), introduced as a control-plane
+data model behind the existing `IProviderPricingService` seam (swap the frozen table for a DB read;
+keep the interface). It is NOT an extension of `Plan`/`PlanPrice` (sell-side), NOT `MarginPolicy`
+(markup), NOT 36-7 (read-only view). It fills a gap: 34-1 owns the *price* book, 34-5 owns *markup*,
+but no story owns the *cost* book. Sequence it **before 34-5** (its cost-basis input), alongside 34-1
+(reuse the CP-entity + versioning + insert-missing-only seeder patterns). Downstream stories need at
+most a one-line dependency edit; none need AC or code changes (the whole point of preserving the seam).
+
+---
+
+## 5. Non-LLM step mediation + phasing
+
+### 5.1 Endpoints (follow-up epic; see the audit table §1.2)
+
+- **Class A — Git platform** (`CreateBranch`/`CreatePullRequest`/`MergePullRequest`/`UpdateIssueStatus`/`AnalyzeReview`):
+  ```
+  POST  /api/v1/git/{repo}/branches
+  POST  /api/v1/git/{repo}/pull-requests
+  PUT   /api/v1/git/{repo}/pull-requests/{n}/merge
+  GET   /api/v1/git/{repo}/pull-requests/{n}/comments
+  PATCH /api/v1/git/{repo}/issues/{n}
+  ```
+  API holds the PAT/installation token (+ per-tenant tokens via Epic 28/29 cabinet), authorizes that
+  *this* tenant may act on *this* repo (cross-tenant guard), emits the audit event.
+- **Class C — Agent dispatch** (`DispatchAgentWorkflow`/`CollectAgentResults`):
+  ```
+  POST /api/v1/agent-dispatch/{repo}/runs
+  GET  /api/v1/agent-dispatch/{repo}/runs/{id}
+  ```
+- **Class D — Slack** (`SlackActivity`): `POST /api/v1/notifications/slack`.
+- **Class E — Billing/Stripe (Epic 35, future):** the activity emits an intent
+  (`POST /api/v1/billing/...` or an outbox row); the API holds the Stripe key, performs the
+  charge/invoice, and meters. **Prohibited at design time** to call Stripe from an activity.
+- **Already compliant:** `TriggerCIActivity` (formalize under `/api/v1`); `QueueWelcomeEmailActivity`
+  (outbox — the model for fire-and-forget effects).
+
+### 5.2 Phasing
+
+**Now — Epic 32 (LLM path only):**
+1. Build `POST /api/v1/llm/call` (gate → resolve agent/persona+enablement → resolve credential
+   BYOK→platform via Epic 29 cabinet → provider call → meter → return `{ result, usage,
+   credentialSource }`).
+2. Re-point `CallLlmActivity` + `CallLlmInlineActivity` to it via `TammaApiClient`; **delete the
+   engine's credential resolver registration** (`ConfigPlatformProviderCredentialResolver` /
+   `AddEngineProviderCredentialResolution` in `ElsaServer/Program.cs`) so the engine holds no LLM key.
+   Move the per-provider HTTP logic out of the activities into the API.
+3. **Redirect the remaining in-engine direct-LLM callers** (`ClaudeAnalysisActivity`,
+   `WriteTests`/`WriteImplementation`/`AnalyzeCode`/`ApplyRefactoring`/`ApplyReviewFixes`,
+   `AIDiagnosis`): delete their direct keyed fallback and route through `call-LLM` (their
+   engine-callback mode terminates at the mediated path).
+
+**Follow-up epic — "Step → internal-API mediation for non-LLM integrations" (new sibling, e.g. Epic 38):**
+- Add `Tamma.Api` controllers for Class A (git), Class C (agent-dispatch), Class D (Slack). Re-point
+  the activities to `TammaApiClient` calls. Remove the engine's reliance on co-located credential
+  services entirely. Centralize per-tenant credential resolution + cross-tenant authorization + audit
+  emission, mirroring `/llm/call`. Adopt the outbox pattern for fire-and-forget effects. Enforce the
+  rule for Class E when Epic 35 lands.
+- Add a **guardrail analyzer/test:** fail the build if any class under `Tamma.Activities` references
+  `HttpClient`/`PostAsync`/`PostAsJsonAsync` to a non-`TammaApiClient` host, or injects a
+  credential-holding vendor service — so violations can't reappear.
+
+### 5.3 What legitimately CANNOT be (fully) mediated
+
+- **Inbound webhooks** (`WebhookSignalRegistry`, the GitHub `workflow_run.completed` receiver behind
+  `TriggerCIActivity`/agent-dispatch): received by `Tamma.Api`, signalled to the engine in-process —
+  no outbound external call to mediate. Signature verification + secret stay in the API. Out of scope
+  by nature.
+- **Local CLI agent providers (`ICLIAgentProvider`) in single-user/self-hosted mode:** spawn local
+  processes and shell out to local git, not an external HTTP API. No remote credential to centralize,
+  no SaaS multi-tenancy. Routing through an endpoint adds a hop with no security benefit. Per the Epic
+  32 design these are single-user-only and legitimately exempt (the rule targets *external
+  API/provider* calls — a local process is not one).
+- **In-engine local tools** (`FileReadTool`, `ShellExecuteTool`, `GitOperationsTool`): operate on the
+  local checkout/filesystem, not an external provider. Out of scope. When they run under SaaS via the
+  managed LLM path, the LLM call itself is mediated by `/llm/call`; the local tools execute against
+  the tenant's own sandbox.
+
+---
+
+## 6. Summary of changes by area
+
+- **Engine (`Tamma.ElsaServer` / `Tamma.Activities`):** holds no keys; activities become thin
+  `TammaApiClient` clients. Delete the engine credential resolver registration; gut
+  `CallLlmInlineActivity`'s provider logic; delete `CallLlmActivity`'s direct path and the
+  TDD/ADL/Debug/Mentorship direct-LLM fallbacks.
+- **`Tamma.Api`:** new `LlmCallEndpoints` → `IManagedAgent.RunAsync` (32-5) composing gate (32-4) →
+  resolve+enablement (32-2/§3.3) → credential (32-3) → prompt (Epic 27) → tool loop → meter (32-9 +
+  34-5 + new provider-cost entity). New `TenantAgentEnablement` entity + endpoints. New
+  `Provider`/`ProviderModelPrice` cost entity behind `IProviderPricingService`.
+- **Agent model:** `Agent.Role` nullable for public personas; seeder rewritten to named cross-role
+  personas with explicit `model`; `ConfigJson.prompts` for custom agents; resolver pulls persona
+  prompts from Epic 27; enablement gate added to selection.
+- **Pricing:** cost (new entity) is mode-independent; markup (34-5) applies only when `platform`;
+  BYOK zeroes the token sell price but keeps cost for reporting.
+
+See `docs/superpowers/plans/2026-06-20-epic-32-37-replan.md` for the per-story impact map and the
+"what to do right now" recommendation.

--- a/docs/superpowers/specs/2026-06-20-managed-llm-execution-deep-dive.md
+++ b/docs/superpowers/specs/2026-06-20-managed-llm-execution-deep-dive.md
@@ -1,0 +1,128 @@
+# Managed LLM Execution — deep dive (provider duality · resilience · streaming · tools/MCP/RAG/cache · interactive question-back)
+
+**Date:** 2026-06-20 · **Companion to:** `2026-06-20-epic-32-revised-agent-architecture.md` (§3 the call-LLM endpoint) · **Status:** design detail, grounded in a 3-track code audit
+
+> The user's clarification: *"llm calls are not simple API calls… two types of providers (API call and harness/SDK), error handling, retrying, RAG, cache, tools, MCPs, plugins, backoff, logging, monitoring… it should be a stream, not just a call, and if it asks a question back then depending on context something should respond — the orch? a team of agents?"* This doc designs the `POST /api/v1/llm/call` endpoint as a **managed agent execution layer**, not a proxy. Every claim below is file-referenced against the real tree.
+
+---
+
+## 1. Provider duality — two hierarchies, but only one runs server-side
+
+| | API providers | Harness / SDK providers |
+|---|---|---|
+| Interface | `ILLMProvider`/`IAIProvider` (`packages/providers/src/types.ts:162,311`), `type:'llm-api'` | `IAgentProvider`/`ICLIAgentProvider` (`agent-types.ts:23`, `types.ts:182`), `type:'cli-agent'` |
+| Execution | Tamma owns request/tool-loop/streaming/retries; HTTP to provider | Provider owns its **own** loop/auth/streaming/retries: `ClaudeAgentProvider` `spawn('claude', -p --output-format stream-json)` (`claude-agent-provider.ts:136,280`); `OpenCodeProvider` SDK session (`opencode-provider.ts:229`) |
+| Cost | per-token via `IProviderPricingService` | aggregate `costUsd` only (`AgentTaskResult.costUsd`, `claude-agent-provider.ts:342`) — no token split |
+| In the C# engine today | **the only path** | **rejected** — `HttpProviderClient.NonHttpProviders = {claude-code, opencode, zen-mcp, …}` throws `ProviderNotSupportedException` (`HttpProviderClient.cs:59-86`) |
+
+**Design.** `ManagedAgent.RunAsync` branches on the resolved provider's `AuthModel` (`api-key`|`cli-token` — the new `Provider` entity field, main spec §4.2):
+- **API-provider path** = the endpoint's real job (gate → resolve agent → resolve credential BYOK→platform → render → **Tamma's own tool loop server-side** → meter). **The only path in SaaS.**
+- **Harness-provider path** = single-user **local** affordance. Per main spec §5.3 these are *exempt* from `/llm/call` mediation (they spawn a local process, hold their own auth, run their own loop — routing them through the endpoint adds a hop with no security benefit). In SaaS the 32-4 gate makes them structurally unreachable (`400 SAAS_PROVIDER_NOT_ALLOWED`). So the **endpoint stays API-provider-only**; harness execution is a deployment-mode-gated local path that never traverses `/llm/call`. This keeps "SaaS has exactly one execution path" literally true.
+
+> Consequence: there is **no C# harness adapter today**. Single-user harness execution needs either a retained TS execution path or a future ported C# CLI/MCP adapter — a deferred single-user story, not a blocker for the SaaS endpoint.
+
+---
+
+## 2. Resilience — what moves server-side, what stays at the workflow boundary
+
+All resilience primitives already exist; the move relocates the *call*, not the machinery. (`LlmCallWorkflow.cs`, `Tamma.Api/Services/Providers/*`.)
+
+| Concern | Today | After 32-5 |
+|---|---|---|
+| Credential resolution | engine `ConfigPlatformProviderCredentialResolver` (`ElsaServer/Program.cs:277`) | **→ API** `DefaultProviderCredentialResolver` (BYOK→platform); delete engine registration (engine holds no key) |
+| Provider HTTP + tool loop | `CallLlmInlineActivity.AgenticToolLoop` (`:443`) in-engine | **→ API** `InlineToolLoopRunner` with request-scoped key |
+| Circuit breaker | read from workflow var; state already in API (`CircuitBreakerService`→`provider_health`, per-tenant) | **authoritative state already API-side**; endpoint records success/failure |
+| Provider-chain advance | `ForEach<provider>` in workflow (`:360`) | **stays at workflow boundary** (thin step called once per provider per attempt) — minimal blast radius. (Richer `ProviderChainResolver` exists API-side but is currently bypassed — open decision to adopt) |
+| Retry (429/502/503/504) | `RetryCheck` reads `LastDiagnostic.HttpStatusCode` (`:781`); **NO backoff delay today** | **stays at workflow boundary** — *only works if the endpoint returns `HTTP 200 + success:false + preserved httpStatusCode`* for expected provider failures (the load-bearing §2.4 contract; a raw 5xx would be nulled by `TammaApiClient.PostAsync`) |
+| Budget | `CheckBudgetActivity` (API-first, fail-closed) | **→ endpoint gate** (server-side, before the call) |
+| Concurrency | counts Elsa `Running` `llm-call` instances (`CheckLlmConcurrencyActivity`) | **open decision** — counting workflow instances is meaningless once the call runs in the API; a server-side per-tenant limiter is the more correct home |
+| Metering | post-call cost (partly engine) | **→ endpoint**, emitted from API where `IEventRepository`+cabinet live |
+
+Fail-closed posture is preserved end-to-end (credential-unavailable / breaker-open / budget-exhausted all **deny**, never call with an empty key) and surfaces as typed `success:false` codes.
+
+---
+
+## 3. Streaming — buffered for the engine, SSE for humans
+
+**Correction to a prior assumption:** the current call does **not** stream tokens — `CallAnthropicMultiTurn`/`CallOpenAiMultiTurn` do a single blocking `PostAsync` + `ReadFromJsonAsync` (`CallLlmInlineActivity.cs:889,920,927`). "Streaming" today = tool-loop progress events, and even those are inert: `ToolLoopEventEmitter` → `IToolLoopEventSink` is wired only to `NullToolLoopEventSink` (events dropped), gated behind `EnableStreaming`. The seam exists; no live sink.
+
+**Design — two response modes off one route, selected by `Accept`:**
+- `application/json` → **buffered** (the engine step's default). The endpoint runs the tool loop to completion server-side and returns one `LlmCallResponse`. **The workflow stays request/response**, so `ForEach`/`RetryCheck`/`SkipIfSucceeded` are byte-for-byte unchanged. The thin `CallLlmInlineActivity` calls `TammaApiClient.CallLlmAsync(...)`, gets the result, writes the same `LastDiagnostic`/`LastResponse`/`ToolLoop*` variables.
+- `text/event-stream` → **SSE** for human-facing clients (dashboard, `tamma` CLI). Wire a **real `IToolLoopEventSink` that writes each event as an SSE frame** (turning the inert seam live), reusing the existing SSE infra (`AdminTenantEventsSseEndpoint`/`EngineEndpoints` — `Response.ContentType=text/event-stream`, `FlushAsync`, `X-Accel-Buffering: no`, heartbeats). Frames: `token`, `tool_call`, `tool_result`, `question`, `answer`, `final`; correlated by `correlationId` (= workflow instance id, already threaded).
+
+**Why the engine doesn't need SSE:** Elsa activities are durable-checkpointed request/response; holding an open socket across `MaxSteps` turns fights persistence + the `ForEach`-per-provider boundary. So: **engine = buffered; dashboard = SSE.** Provider token streaming (`stream:true`) can run *inside the runner* in the API to cut TTFB / allow mid-turn cancel, collapsed to a buffered turn result before the buffered response returns — invisible to the step. **Recommended:** a separate `GET /api/v1/llm/runs/{correlationId}/stream` tap fed by an in-process bus, so human observers are decoupled from the engine's buffered call.
+
+---
+
+## 4. Tools / MCP / plugins / cache / RAG / observability — all server-side
+
+All of this moves into `Tamma.Api`, composed by `ManagedAgent.RunAsync`. The engine holds no key, runs no tool, opens no provider socket.
+
+- **Tool loop** — extract `AgenticToolLoop` verbatim into `IInlineToolLoopRunner` (32-5 AC3); the registry/validator/parallel-executor/compactor/sanitizer all DI-registered in the API. **Delete** the engine-side tool/sanitizer/http registrations so the engine can't run tools. Local tools (`FileRead`/`ShellExecute`/`GitOperations`) execute against the tenant's sandbox *from inside the managed run*.
+- **MCP + plugins** — **net-new for C#** (today only in TS `packages/mcp-client`; C# `ProviderSession.cs:87` says "MCP transport not yet ported"). The runner's tool catalog = built-in executors ∪ **MCP server tools** ∪ plugin tools, unioned through one `IToolExecutorRegistry.GetAllowed(allowlist)`, intersected with the agent's allowed-tool set (32-2), every invocation through the `ToolHookRegistry` pre/post sanitization hooks + `IContentSanitizer`/`RedactSecrets`. **Open:** port `mcp-client` to C# vs host the TS client as an API-managed sidecar vs a .NET MCP SDK; and MCP-server-per-tenant config + credentials (Epic 29 cabinet, enablement-gated like agents).
+- **Cache** — two server-side layers (both new): (1) **provider prompt cache** — Anthropic `cache_control: ephemeral` on the stable prefix (system prompt + persona config + RAG/conventions block); the returned `cache_read`/`cache_write` token counts feed the meter (the `ProviderModelPrice` entity reserves nullable cache-rate columns). (2) optional **response cache** keyed by `(tenantId, agentVersion, renderedPromptHash, model, toolset)` — strictly **after** gate/budget so a hit still meters/audits (or records a `cache_hit` zero-cost usage event); tool-loop runs are likely *not* cacheable (non-deterministic side effects).
+- **RAG** — keep `AssembleContextActivity`/`FetchSimilarPatternsActivity` as **pre-call workflow stages** that build `AssembledContext` and pass it as prompt variables in the `LlmCallRequest` (the existing `{{conventions}}`/variables merge is the template). The endpoint renders Epic 27 prompts (persona) or the custom agent's own prompts and merges the RAG block. **Open:** optionally move last-mile retrieval (`IntelligenceHttpClient`) into the managed run so RAG is also gated/metered — default keeps it a pre-call step.
+- **Observability** — emitted from the API: a new OTel meter (`tamma.llm.call`/`.tokens`/`.cost`/`.toolloop.turns`), the server-authored `ProviderAttemptDiagnostic` (carrying `CredentialSource`/`BillingMode`), and DCB events `AGENT.RUN.STARTED/SUCCESS/FAILED`. `RecordDiagnosticsInlineActivity` collapses — the API writes the usage record directly.
+
+---
+
+## 5. Interactive question-back — who answers, and how the run pauses/resumes
+
+**The gap (confirmed):** the tool loop **cannot ask a question back today** — the registry has 6 tools (`git_operations`/`shell_execute`/`file_read`/`file_write`/`run_tests`/`search_code`), none of them `ask_user`; the loop just ends the turn on a non-`ToolUse` stop reason, so a question becomes the run's final "answer" with nothing answering it. But the repo has **every primitive** to fix it.
+
+### 5.1 The agent signals a question via a first-class `request_input` tool (a tool call, not a stop reason)
+```jsonc
+// tool: request_input — the agent's ONLY way to ask back
+{ "question": "…", "kind": "fact"|"decision"|"judgment"|"approval",
+  "options": [...] | null, "schema": {} | null,
+  "blocking": true, "default_assumption": "…"|null, "confidence": 0.0 }
+```
+A tool call (not a parsed `end_turn`) means the answer returns as a **tool-result message**, so the model resumes its own reasoning with the answer in-context — no new conversation-shaping code; it flows through the existing validate→execute→append cycle. Executed server-side inside `/llm/call`, so **the step still never calls a provider**.
+
+### 5.2 `IQuestionRouter` routes by `kind` + context (escalating cost/latency)
+| `kind` | Answerer | Mechanism | Latency class |
+|---|---|---|---|
+| `fact` (system already knows) | **Orchestrator / workflow state** | synchronous lookup vs workflow vars + Epic-27 conventions + issue/PR context — **zero LLM, zero human** | in-stream (sub-second) |
+| `judgment` (design/trade-off) | **Agent team / panel (32-7)** | `RunAgentPanelActivity`+`AggregatePanelActivity`, tenant-scoped, budget-clamped | in-stream / short in-process signal (seconds–min) |
+| `decision` w/ closed options + confident default | **Orchestrator policy**, fallback panel | policy first, panel second | in-stream |
+| `approval` / irreversible (merge/deploy/spend/schema) | **Human-in-the-loop** | durable Elsa bookmark + signal | **workflow-suspend** (hours–days) |
+
+**The decision of *who answers* is a server-side `QuestionRoutingPolicy`** keyed `(principal, role, action, kind)` (tenant→system→error, fail-loud, never empty), with inputs: `kind`, **reversibility/blast-radius of the pending action**, the run's **autonomy level** (ADL limits config), and **budget**. `blocking:false` ⇒ orchestrator may auto-answer with `default_assumption` and record it as an audited assumption, never pausing.
+
+**Security (load-bearing):** the model's `kind`/`blocking` are **hints**; the server **re-derives** the human-gate decision from the pending action's reversibility (which the orchestrator owns). The model can *raise* a question but **cannot downgrade** its routing below what the blast radius mandates — so a misclassifying/adversarial model can't tag a `merge`-approval as a `fact` to dodge human gating.
+
+### 5.3 The pause/resume boundary — the core tension
+A streaming HTTP request **cannot** stay open for an hours-long human answer. Split by latency class:
+- **Fast (orchestrator-fact, agent-panel)** → resolved **inside the same `/llm/call` invocation**, on the server, bounded by an `inStreamAnswerTimeout` (e.g. 90s, tenant-tunable) with SSE heartbeats holding the connection. The turn never leaves the stream. Reuses the **`WebhookSignalRegistry` TCS** fast-signal model.
+- **Slow (human)** → the turn ends and returns `success:false`, `failureCode = "INPUT_REQUIRED"` + the question + accrued `usage` (rides the existing fail-closed envelope; key never leaked). The thin step **does not retry** — it routes the *workflow* into a new **`WaitForAgentQuestionActivity`** (modeled byte-for-byte on `EscalateToSeniorActivity`): notify the human, `CreateBookmark("agent-question-{correlationId}")`, **suspend durably**. The human answers via `POST /api/v1/agents/questions/{correlationId}/answer` → `ElsaWorkflowService.SendSignalAsync`/resume → the workflow **re-invokes `/llm/call`** with the prior messages + the human answer re-primed as the `request_input` tool result, so the model resumes where it paused. The endpoint stays **stateless across the human gap** (conversation rehydrated from the request or the action-trail by `correlationId`).
+
+**Boundary rule:** the durable wait lives in the **workflow** (Elsa bookmark), never in an HTTP connection. Fast answers resolve in-stream; slow answers cross engine→bookmark→signal→re-call. Cost: one extra LLM call to re-prime after the human gap — the only correct shape given a streaming request can't survive an hours-long wait.
+
+**Audit:** `AGENT.QUESTION.RAISED` / `.ANSWERED` (tagged `answerer ∈ {orchestrator,panel,human}`) / `.ASSUMED` emitted from the API where the tenant store lives — full trail, time-travel-debuggable.
+
+---
+
+## 6. What this means for the stories
+
+The endpoint is a **build-out**, not just a relocation. New/grown scope beyond the main re-plan:
+
+1. **32-5 grows** — it owns: the buffered endpoint + `InlineToolLoopRunner` extraction + the resilience relocation (credential/breaker-record/budget/metering) + the buffered/SSE response modes + the live `IToolLoopEventSink`.
+2. **NEW "MCP & plugin tool sourcing (C#)"** — port/host the MCP client + plugin tools into the API tool catalog with hooks + per-tenant MCP config (cabinet creds, enablement-gated). (Resolves the `ProviderSession.cs:87` gap; ties to Epic 6/9.)
+3. **NEW "Prompt + response cache"** — Anthropic prompt-cache prefix + optional gated response cache + cache-rate metering columns.
+4. **NEW "Streaming run tap"** — `GET /api/v1/llm/runs/{correlationId}/stream` SSE + the live sink for dashboard/CLI.
+5. **NEW "Interactive question-back"** (Epic 32, depends on 32-5 + 32-7 panels) — the `request_input` tool + `IQuestionRouter` + `QuestionRoutingPolicy` + `WaitForAgentQuestionActivity` + the reversibility classifier + the question DCB events. **The single most novel piece.**
+6. **DEFERRED single-user "C# harness/CLI adapter"** — port a `claude-code`/`opencode`/MCP harness path for single-user local execution (today TS-only; C# rejects it). Not needed for SaaS.
+
+---
+
+## 7. Consolidated open decisions (need a human call)
+
+1. **Concurrency limiter** — server-side per-tenant limiter vs engine instance gate (current counts Elsa instances → meaningless after the move).
+2. **Provider-chain ownership** — keep `ForEach` at the workflow (min blast radius) vs fold into the endpoint via the richer (currently-bypassed) `ProviderChainResolver` (CB-aware, half-open tail, budget-marked).
+3. **MCP strategy** — port `mcp-client` to C# vs TS sidecar vs .NET MCP SDK; + per-tenant MCP config/credentials.
+4. **Response-cache policy** — cacheable at all for tool-loop runs? key shape; metering of cache hits.
+5. **In-stream timeout → escalation** for `judgment` — promote to human bookmark vs proceed-on-assumption vs fail (default is contentious vs the 70% autonomy target).
+6. **Conversation-state rehydration across the human gap** — workflow variable vs action-trail (32-6) keyed by `correlationId` (leaning action-trail).
+7. **`request_input` budgeting** — panel-answer tokens charged to the asking agent's budget vs a separate "clarification" line (affects 32-9/34-5).
+8. **Harness execution in single-user** — retain a TS path vs port a C# adapter.
+9. **HTTP-status fidelity guardrail** — a test/analyzer enforcing the endpoint returns `success:false`+`httpStatusCode` (not a raw 5xx) so `RetryCheck`/breaker keep working.


### PR DESCRIPTION
## Wave 2 (partial) + Epic-32 architecture revision

Two P0 stories from Epic 32 plus a **revised agent-architecture design** that emerged mid-wave (and pauses the rest of Wave 2).

### Code (green, full suite 4986/0, both EF contexts clean)
- **32-2 — Agent Registry, Resolution & RBAC API** — registry service, 4-branch resolution precedence with **fail-loud no-empty-fallback**, per-mode RBAC (reuses 32-1's `agents:manage`), cross-tenant 404 isolation, `agent_role_selections` on both contexts, AC5 list filters. Spec + quality reviewed; minor fixes applied (upsert race → clean retry, provenance label, multi-default warn).
- **32-3 — Per-Tenant Provider Credential Resolution (BYOK→platform)** — cabinet-backed resolver behind a single seam, redaction gate (sentinel key reaches the HTTP header only), fail-closed in SaaS, per-`(tenant,provider)` cache + rotation invalidation, BYOK management API. Reviewed; CRITICAL wiring fix applied (resolver registered in the ElsaServer host that actually runs the activity).

### Design docs (the pivot)
- `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md`
- `docs/superpowers/plans/2026-06-20-epic-32-37-replan.md`

**The correction:** a workflow step must never call an external provider directly. LLM calls route through a tamma-api **call-LLM endpoint** (the reframed 32-5, using the existing `TammaApiClient` pattern) that gates → resolves the credential → calls the provider → meters. Personas become **named cross-role system agents** (prompts from Epic 27); **provider cost** becomes a DB entity behind `IProviderPricingService`; a new **per-tenant enablement** layer is added; BYOK stays per-tenant-per-provider.

### Disposition note for reviewers
- 32-2's entity/registry and 32-3's **cabinet resolver** are kept by the new design.
- 32-3's **engine-side wiring** (`ConfigPlatformProviderCredentialResolver` in `ElsaServer`) is **dormant-safe** today (only supplies the platform key, which works) and is **superseded** — it will be deleted by the call-LLM endpoint story. Merging this PR is safe; the redesign stories follow.

### Deploy
Merge does not auto-deploy (qa-tag gate). The per-tenant-cursor / DROP-list / `PlatformOwnerAccess` lessons from Wave 1 carried forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)