### PR TITLE
docs(epic-32/34/38): architecture-pivot story specs — call-LLM endpoint, personas, enablement, provider cost

### DIFF
--- a/docs/sprint-status.yaml
+++ b/docs/sprint-status.yaml
@@ -419,17 +419,28 @@ development_status:
   32-1-agent-entity-model-and-versioned-saved-config: done # Agent Entity Model & Versioned Saved Config (public/private) [P0]
   32-2-agent-registry-resolution-and-rbac-api: done # Agent Registry, Resolution & RBAC API [P0]
   32-3-per-tenant-provider-credential-resolution: done # Per-Tenant Provider Credential Resolution (BYOK → platform) [P0]
-  32-4-saas-provider-auth-gating-api-key-only: drafted # SaaS Provider Auth Gating — API-key only (CLI/token providers single-user only) [P0]
-  32-5-managed-agent-execution-layer: drafted         # Managed Agent Execution Layer (IManagedAgent over IAIProvider) [P0]
+  32-4-saas-provider-auth-gating-api-key-only: drafted # SaaS Provider Gate — now the gate STAGE of the call-LLM endpoint (REFRAMED 2026-06-21) [P0]
+  32-5-managed-agent-execution-layer: drafted         # Call-LLM Endpoint + Managed Execution (POST /api/v1/llm/call; lynchpin) (REFRAMED 2026-06-21) [P0]
   32-6-agent-action-trail-in-tenant-store: drafted    # Agent Action Trail (DCB events tagged agent_id) in Tenant Store [P0]
   32-7-multi-agent-design-review-panels-in-elsa: drafted # Multi-Agent Design/Review Panels in Elsa (strategy-driven) [P1]
   32-8-outcome-capture-and-bug-taxonomy-at-review-gate: drafted # Outcome Capture & Bug Taxonomy at Review/Gate [P1]
   32-9-cost-basis-plus-margin-metering-and-byok-pricing-model: drafted # Cost-Basis-Plus-Margin Metering & BYOK Pricing Model (re-targets Epic 20) [P1]
   32-10-benchmark-projections-and-leaderboards: drafted # Benchmark Projections & Leaderboards (per agent/provider/prompt, per-tenant) [P1]
   32-11-learning-persistence-and-auto-learning-into-rag: drafted # Learning Persistence & Auto-Learning into RAG [P1]
-  32-12-agent-personas-and-persona-aware-benchmarking: drafted # Agent Personas & Persona-Aware Benchmarking [P2]
+  32-12-agent-personas-and-persona-aware-benchmarking: drafted # Persona-Aware Benchmarking (persona = named system agent; style overlay split to 32-19) (REFRAMED 2026-06-21) [P2]
   32-13-agent-management-and-benchmark-dashboards: drafted # Agent Management & Benchmark Dashboards (admin public + tenant private) [P2]
   32-14-a-b-experiment-framework-for-agents: drafted  # A/B Experiment Framework for Agents (Phase 2: cohorts, significance, rollout/rollback) [P2]
+  # --- Architecture-pivot stories (added 2026-06-21; see docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md) ---
+  32-15-persona-reframe-and-seeding: drafted          # Persona Reframe & Seeding (named cross-role personas; amends 32-1) [P0]
+  32-16-per-tenant-agent-enablement: drafted          # Per-Tenant Agent/Persona Enablement (TenantAgentEnablement) [P0]
+  32-17-custom-agent-prompts: drafted                 # Custom-Agent Prompts (ConfigJson.prompts; custom prompts ⇔ custom agent) [P0]
+  32-18-registry-enablement-gate-and-prompt-source: drafted # Registry Enablement Gate & Epic-27 Prompt Source (amends 32-2) [P0]
+  32-19-agent-style-voice-variants: drafted           # Agent Style/Voice Variants (optional overlay; split from 32-12) [P2]
+  32-20-interactive-question-back: drafted            # Interactive Question-Back (request_input tool + IQuestionRouter) [P1]
+  32-21-mcp-and-plugin-tool-sourcing: drafted         # MCP & Plugin Tool Sourcing (C#) [P1]
+  32-22-prompt-and-response-cache: drafted            # Prompt & Response Cache (server-side) [P2]
+  32-23-streaming-run-tap: drafted                    # Streaming Run Tap (SSE for dashboard/CLI) [P1]
+  32-24-csharp-harness-cli-adapter: drafted           # C# Harness/CLI Agent Adapter (single-user local, DEFERRED) [P3]
   epic-32-retrospective: optional
 
   epic-34: contexted   # NEW Pricing, Plans & Entitlements (added 2026-06-17; all stories drafted)
@@ -443,6 +454,7 @@ development_status:
   34-8-pricing-audit-events-and-reproducibility: drafted # Pricing Audit, Events & Reproducibility [P1]
   34-9-pricing-and-plan-management-dashboards: drafted # Pricing & Plan Management Dashboards [P1]
   34-10-epic-20-decommission-and-pricing-contract-migration: drafted # Epic 20 Decommission & Pricing Contract Migration [P0]
+  34-11-provider-cost-price-book: drafted             # Provider Cost Price-Book (Provider + ProviderModelPrice cost entities behind IProviderPricingService; before 34-5) (added 2026-06-21) [P0]
   epic-34-retrospective: optional
 
   epic-35: contexted   # NEW Billing & Payments (C#) — supersedes Epic 20 (added 2026-06-17; all stories drafted)
@@ -488,4 +500,11 @@ development_status:
   37-11-soc2-aligned-control-mapping-and-evidence-pack: drafted # SOC2-Aligned Control Mapping & Evidence Pack [P2]
   37-12-admin-and-tenant-audit-dashboard-ui: drafted  # Admin & Tenant Audit Dashboard UI [P1]
   epic-37-retrospective: optional
+
+  epic-38: contexted   # NEW Step → Internal-API Mediation (non-LLM) — Epic-32 follow-up (added 2026-06-21; all stories drafted)
+  38-1-git-platform-step-mediation: drafted           # Git-Platform Step Mediation (Class A) [P1]
+  38-2-agent-dispatch-step-mediation: drafted         # Agent-Dispatch Step Mediation (Class C) [P1]
+  38-3-slack-notifications-step-mediation: drafted    # Slack/Notifications Step Mediation (Class D) + Billing enforce-by-design [P2]
+  38-4-build-time-guardrail-analyzer: drafted         # Build-Time Guardrail Analyzer (rule-1 enforcement) [P1]
+  epic-38-retrospective: optional
 

--- a/docs/stories/epic-32/README.md
+++ b/docs/stories/epic-32/README.md
@@ -35,11 +35,11 @@ Epic 32 is the canonical owner of the agent entity, execution, and tracking mode
 
 | Story | Title | Priority | Status | Est. Effort |
 |-------|-------|----------|--------|-------------|
-| 32-1 | Agent Entity Model & Versioned Saved Config (public/private) | P0 | drafted | 4-5 days |
-| 32-2 | Agent Registry, Resolution & RBAC API | P0 | drafted | 4-5 days |
-| 32-3 | Per-Tenant Provider Credential Resolution (BYOK → platform) | P0 | drafted | 4-5 days |
+| 32-1 | Agent Entity Model & Versioned Saved Config (public/private) | P0 | done | 4-5 days |
+| 32-2 | Agent Registry, Resolution & RBAC API | P0 | done | 4-5 days |
+| 32-3 | Per-Tenant Provider Credential Resolution (BYOK → platform) | P0 | done | 4-5 days |
 | 32-4 | SaaS Provider Gate — gate STAGE of the call-LLM endpoint *(reframed 2026-06-21)* | P0 | drafted | 2-3 days |
-| 32-5 | Call-LLM Endpoint + Managed Execution (`POST /api/v1/llm/call`; lynchpin) *(reframed 2026-06-21)* | P0 | drafted | 6-8 days |
+| 32-5 | Call-LLM Endpoint + Managed Execution (`POST /api/v1/llm/call`; lynchpin) *(reframed 2026-06-21)* | P0 | drafted | 8-10 days |
 | 32-6 | Agent Action Trail (DCB events tagged `agent_id`) in Tenant Store | P0 | drafted | 4-5 days |
 | 32-7 | Multi-Agent Design/Review Panels in Elsa (strategy-driven) | P1 | drafted | 5-6 days |
 | 32-8 | Outcome Capture & Bug Taxonomy at Review/Gate | P1 | drafted | 3-4 days |

--- a/docs/stories/epic-32/README.md
+++ b/docs/stories/epic-32/README.md
@@ -38,17 +38,27 @@ Epic 32 is the canonical owner of the agent entity, execution, and tracking mode
 | 32-1 | Agent Entity Model & Versioned Saved Config (public/private) | P0 | drafted | 4-5 days |
 | 32-2 | Agent Registry, Resolution & RBAC API | P0 | drafted | 4-5 days |
 | 32-3 | Per-Tenant Provider Credential Resolution (BYOK → platform) | P0 | drafted | 4-5 days |
-| 32-4 | SaaS Provider Auth Gating — API-key only (CLI/token providers single-user only) | P0 | drafted | 2-3 days |
-| 32-5 | Managed Agent Execution Layer (`IManagedAgent` over `IAIProvider`) | P0 | drafted | 5-6 days |
+| 32-4 | SaaS Provider Gate — gate STAGE of the call-LLM endpoint *(reframed 2026-06-21)* | P0 | drafted | 2-3 days |
+| 32-5 | Call-LLM Endpoint + Managed Execution (`POST /api/v1/llm/call`; lynchpin) *(reframed 2026-06-21)* | P0 | drafted | 6-8 days |
 | 32-6 | Agent Action Trail (DCB events tagged `agent_id`) in Tenant Store | P0 | drafted | 4-5 days |
 | 32-7 | Multi-Agent Design/Review Panels in Elsa (strategy-driven) | P1 | drafted | 5-6 days |
 | 32-8 | Outcome Capture & Bug Taxonomy at Review/Gate | P1 | drafted | 3-4 days |
 | 32-9 | Cost-Basis-Plus-Margin Metering & BYOK Pricing Model (re-targets Epic 20) | P1 | drafted | 4-5 days |
 | 32-10 | Benchmark Projections & Leaderboards (per agent/provider/prompt, per-tenant) | P1 | drafted | 4-5 days |
 | 32-11 | Learning Persistence & Auto-Learning into RAG | P1 | drafted | 4-5 days |
-| 32-12 | Agent Personas & Persona-Aware Benchmarking | P2 | drafted | 3-4 days |
+| 32-12 | Persona-Aware Benchmarking *(reframed 2026-06-21: persona = named system agent)* | P2 | drafted | 3-4 days |
 | 32-13 | Agent Management & Benchmark Dashboards (admin public + tenant private) | P2 | drafted | 4-5 days |
 | 32-14 | A/B Experiment Framework for Agents (Phase 2: cohorts, significance, rollout/rollback) | P2 | drafted | 5-6 days |
+| 32-15 | Persona Reframe & Seeding (named cross-role personas; amends 32-1) *(2026-06-21)* | P0 | drafted | 3-4 days |
+| 32-16 | Per-Tenant Agent/Persona Enablement (`TenantAgentEnablement`) *(2026-06-21)* | P0 | drafted | 3-4 days |
+| 32-17 | Custom-Agent Prompts (`ConfigJson.prompts`; custom prompts ⇔ custom agent) *(2026-06-21)* | P0 | drafted | 2-3 days |
+| 32-18 | Registry Enablement Gate & Epic-27 Prompt Source (amends 32-2) *(2026-06-21)* | P0 | drafted | 3-4 days |
+| 32-19 | Agent Style/Voice Variants (optional overlay; split from 32-12) *(2026-06-21)* | P2 | drafted | 3-4 days |
+| 32-20 | Interactive Question-Back (`request_input` + `IQuestionRouter`) *(2026-06-21)* | P1 | drafted | 5-6 days |
+| 32-21 | MCP & Plugin Tool Sourcing (C#) *(2026-06-21)* | P1 | drafted | 5-6 days |
+| 32-22 | Prompt & Response Cache (server-side) *(2026-06-21)* | P2 | drafted | 3-4 days |
+| 32-23 | Streaming Run Tap (SSE for dashboard/CLI) *(2026-06-21)* | P1 | drafted | 3-4 days |
+| 32-24 | C# Harness/CLI Agent Adapter (single-user local, **DEFERRED**) *(2026-06-21)* | P3 | drafted | 5-6 days |
 
 ## Architecture
 
@@ -270,7 +280,8 @@ Estimated: 12-15 days
 
 ## Reference Documents
 
-- [Epic 32 Design of Record — Agent Entities, Personas, Benchmarking & Learning](../../superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md)
+- **[Epic 32 Revised Agent Architecture (Design of Record, 2026-06-20)](../../superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md)** — supersedes the persona/agent + credential portions below: steps never call providers (call-LLM endpoint), persona = named cross-role system agent, provider cost entity, per-tenant enablement, BYOK-per-provider. See also the [managed-LLM execution deep dive](../../superpowers/specs/2026-06-20-managed-llm-execution-deep-dive.md) and the [re-plan](../../superpowers/plans/2026-06-20-epic-32-37-replan.md).
+- [Epic 32 Design of Record — Agent Entities, Personas, Benchmarking & Learning (2026-06-17, partially superseded)](../../superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md)
 - [Story 32-1 — Agent Entity Model & Versioned Saved Config](./story-32-1/32-1-agent-entity-model-and-versioned-saved-config.md)
 - [Story 32-2 — Agent Registry, Resolution & RBAC API](./story-32-2/32-2-agent-registry-resolution-and-rbac-api.md)
 - [Story 32-3 — Per-Tenant Provider Credential Resolution (BYOK → platform)](./story-32-3/32-3-per-tenant-provider-credential-resolution.md)

--- a/docs/stories/epic-32/story-32-12/32-12-agent-personas-and-persona-aware-benchmarking.md
+++ b/docs/stories/epic-32/story-32-12/32-12-agent-personas-and-persona-aware-benchmarking.md
@@ -1,4 +1,4 @@
-# Story 32-12: Agent Personas & Persona-Aware Benchmarking
+# Story 32-12: Persona-Aware Benchmarking
 
 Status: drafted
 
@@ -6,7 +6,7 @@ Status: drafted
 
 **ALL contributors MUST read and follow the comprehensive development process:**
 
-[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
 
 This mandatory guide includes the 7-Phase Development Workflow (Read → Research → Break Down → TDD → Quality Gates → Failure Handling), Knowledge Base usage (`.dev/` directory), TRACE/DEBUG logging requirements, Test-Driven Development, 100% critical-path coverage, and build-success enforcement.
 
@@ -14,60 +14,80 @@ This mandatory guide includes the 7-Phase Development Workflow (Read → Researc
 
 ## User Story
 
-As a **tenant owner/admin (SaaS) or self-hosted user (single-user)**,
-I want **named, reusable personas — styling/behavior variants (tone, verbosity, risk-tolerance, review-strictness) that compose onto an existing agent without forking its provider config — and the ability to benchmark personas like-vs-like within a role**,
-So that **a single agent definition (e.g. the public `tamma-reviewer`) can be run under two personas (`atlas` and `nova`) on my own work, and my per-tenant leaderboards tell me which *style* performs best for my context — finding the right voice for the job without cloning a dozen near-identical agents**.
+As a **tenant owner/admin (SaaS) or self-hosted user (single-user) choosing which named system persona to trust with a given role**,
+I want **per-tenant benchmark leaderboards keyed by the named cross-role PERSONA-agent (`claude`/`gemini`/`codegpt`) — paired with its provider, model, prompt-version, and `credentialSource` — so I can compare, on my own work, "which persona is the best reviewer for me?" like-vs-like within a role**,
+So that **I can pick the best-performing persona for each role on real downstream quality and cost (success rate, iterations-to-done, defect rate, latency, cost basis), certain my per-persona performance data never leaks to another tenant or to the platform owner who curates the public persona catalogue**.
+
+> **Vocabulary reframe (v2.0.0, 2026-06-21).** In the locked agent model (`docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` §3.0), **PERSONA = the named, cross-role public/system agent** (`claude`/`gemini`/`codegpt`) that presets `{provider, model, config}` — the entity reframed by **Story 32-15** (the former per-role `tamma-<role>` concept). It is **NOT** a style/tone overlay. The old style/voice idea (`atlas`/`nova` tone/verbosity within a role) is split out to optional sibling **Story 32-19 "Agent style/voice variants"** (a *variant*/style profile, never a *persona*). This story therefore **adds no new entity** and introduces **no style-overlay framing** — it is purely the persona-aware *benchmarking* dimension over the named persona-agent identity.
 
 ## Priority
 
-P2 — A refinement layer on top of the first-class agent stack. Agents (32-1), resolution (32-2), and the action trail (32-6) must exist first; personas add a second benchmarking *dimension* (style) orthogonal to the agent/provider/prompt/version dimensions 32-10 already slices. Valuable, not foundational: workflows run fine without personas; personas make style a measurable, tunable knob.
+P1 — the persona-aware read-model payoff of the Epic 32 tracking stack, riding directly on the 32-10 benchmark projection. 32-6 captures the action trail, 32-8 scores outcomes + classifies defects, 32-9 emits usage/cost, 32-10 folds them into per-agent/provider/prompt/**persona** leaderboards; this story makes the **persona dimension** correct under the locked model (keyed by the 32-15 persona-agent `AgentId`/`AgentName`, not a style row) and adds the persona-comparison facets a tenant reads to pick a persona per role. Valuable, not foundational: 32-10 already ships a `persona` dimension; this story populates it with the right identity + facets and the comparison API.
+
+## Context
+
+### What 32-10 already ships (the substrate)
+
+Story 32-10 (`docs/stories/epic-32/story-32-10/32-10-benchmark-projections-and-leaderboards.md`) ships `BenchmarkProjectionService` — an idempotent, `SequenceNumber`-cursor-tracked fold over the resolving tenant's `domain_events` that materialises **per-agent / per-provider / per-prompt / per-persona** `BenchmarkProjection` rows in the tenant's own `t_<hex>` schema, plus a member-readable leaderboard API (`GET /api/v1/orgs/{tenantId}/agents/leaderboard?dimension=…`). Its `persona` dimension already exists with `DimensionKey = personaId`, but 32-10 explicitly defers the *semantics* to this story: "Story 32-12 enriches persona attribution. This story ships the dimension; 32-12 populates richer persona semantics."
+
+### What "persona" means now (the reframe this story implements)
+
+Under the locked model, the `persona` dimension's `DimensionKey` is the **named persona-agent's identity** — the public `Agent` (`claude`/`gemini`/`codegpt`) that 32-15 seeds with `Role = NULL`, an explicit `provider`+`model`, and prompts from the Epic 27 store. So:
+
+| | Old 32-12 (superseded) | This rewrite (locked model) |
+|---|---|---|
+| **Persona** | a style/tone overlay (`atlas`/`nova`) *within* one role | the **named cross-role system agent** (`claude`/`gemini`/`codegpt`) from 32-15 |
+| **New entity** | a `Persona` table (style + prompt-fragment) | **none** — persona IS the public `Agent`; benchmark rides 32-10's projection |
+| **Benchmark key** | `(role, personaId)` where persona = style | `(role, personaAgentId)` where persona = the public agent + its provider/model/prompt-version/credentialSource |
+| **Style/voice** | conflated into "persona" | split out → **32-19** style/voice variants |
+
+The **action trail (32-6)** already tags each `AGENT.TASK.*` / `AGENT.ITERATION.COMPLETED` / `AGENT.PANEL.AGGREGATED` event with `agentId`/`agentVersion`/`provider`/`promptRef` (32-6/32-15). For a public persona, `agentId` **is** the persona's identity. This story makes the **persona-aware view** of that data first-class: it pins the persona dimension to the persona-agent identity (not a style row), adds `credentialSource` and prompt-version as benchmark facets, and exposes the persona-comparison query so "`claude` vs `gemini` as my reviewer" is answerable like-vs-like.
+
+### Explicitly out of scope (referenced, not implemented)
+
+- **The persona entity + seeding** (`Agent.Role` nullable, named cross-role personas, Epic-27 prompt wiring) — **Story 32-15**. This story consumes the persona-agent identity; it does not define personas.
+- **Per-tenant persona enablement** (`TenantAgentEnablement`) — **Story 32-16**. Only enabled personas appear in a tenant's leaderboard (a persona the tenant never enabled has no runs).
+- **The base benchmark projection + leaderboard API + tenant isolation + k-anonymity admin rollup** — **Story 32-10**. This story extends its `persona` dimension; it does not rebuild the fold.
+- **Agent style/voice variants** (the `atlas`/`nova` tone/verbosity overlay, formerly mis-modelled as "persona") — **Story 32-19** (NEW optional sibling). A *variant* is a style profile composed onto a persona-agent; it is a different feature with its own visibility/XOR/index discipline and (eventually) its own benchmark facet. **Not built here.**
 
 ## Acceptance Criteria
 
-1. **Persona entity.** A new EF Core entity `Persona` exists in `apps/tamma-elsa/src/Tamma.Data/Entities/Persona.cs` with: `Id` (Guid PK), `Name` (stable handle, e.g. `atlas`), `Role` (the `AgentRole` wire string the persona is scoped to — a persona is a *named variant within a role*, mirroring the design-of-record's "personas are named variants within a role"), `Visibility` (reuses the `AgentVisibility` enum from 32-1: `public|private`), `OwnerTenantId` (Guid?), `OwnerUserId` (Guid?), `Status` (reuses `AgentStatus`: `active|archived`), `StyleJson` (jsonb — the style/behavior trait bag: `tone`, `verbosity`, `riskTolerance`, `reviewStrictness`, …), `SystemPromptFragmentRef` (string? — a Prompt-Store fragment key, never inline secret content), `CreatedAt`/`CreatedBy`, `UpdatedAt`/`UpdatedBy`. It is **control-plane-resident** for public personas and tenant-owned for private personas, exactly mirroring the `Agent` ownership model from 32-1.
+1. **Persona = the named persona-agent identity (no new entity).** The benchmark `persona` dimension's `DimensionKey` is the **public persona-agent's identity** — `AgentId` (immutable) with `AgentName` (the stable handle `claude`/`gemini`/`codegpt` from 32-15) as the human-readable label. This story adds **no** `Persona` table, no `PersonaComposer`, and no style-overlay row. It rides 32-10's existing `BenchmarkProjection`/`BenchmarkProjectionCursor` tenant entities. (If 32-10's `persona` dimension still keyed a style row, this story corrects it to the persona-agent identity; if it is already keyed by `agentId`, this story leaves the shape and adds the facets in AC2/AC5.)
 
-2. **Ownership invariants mirror Agent (32-1).** A `CHECK` constraint `ck_personas_visibility_ownership` enforces: `Visibility='public' ⇒ OwnerTenantId IS NULL AND OwnerUserId IS NULL`; `Visibility='private'` in SaaS ⇒ `OwnerTenantId IS NOT NULL AND OwnerUserId IS NULL`; `Visibility='private'` in single-user ⇒ `OwnerUserId IS NOT NULL AND OwnerTenantId IS NULL` — the same exactly-one-principal XOR pattern as `ck_agents_visibility_ownership` / `ck_prompt_overrides_principal_xor`. A unique partial index `IX_personas_public_name_role` on `(Name, Role) WHERE Visibility='public'` and per-owner private indexes (`(OwnerTenantId, Name, Role)` and `(OwnerUserId, Name, Role)` filtered on `Visibility='private'`) let two tenants each own a private persona named `atlas` for the same role without collision. Configured **only** in `TammaModelConfiguration.cs` (the single source of model config), with one additive migration under `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/`.
+2. **Persona benchmark facets include provider, model, prompt-version, and credentialSource.** A persona's benchmark row (or its readable detail) carries, alongside the 32-10 metrics, the **dimensions that disambiguate a persona's runs**: `provider` and `model` (from the persona-agent's resolved config — 32-15), `agentVersion` (the pinned persona version), `promptRef`/prompt-version (the Epic-27 prompt that produced the run — 32-6), and **`credentialSource ∈ {byok, platform}`** (from 32-3, surfaced on the run by 32-5/32-9). These ride as **flat-string sub-keys / facets on the persona projection** so "`claude` on BYOK Anthropic vs `claude` on platform Anthropic" and "`claude` under prompt v3 vs v4" are distinguishable within the persona. No raw config, prompt body, or key is ever a facet value.
 
-3. **Multiple personas per role with the *same* agent.** Two distinct active personas (e.g. `atlas` and `nova`) may both target `role=reviewer` and both compose onto the same resolved reviewer agent, each producing a different `ResolvedAgentConfig` (different style params + prompt fragment) **without forking the underlying agent definition or provider config**. A test seeds one reviewer agent + two reviewer personas and asserts both resolve to the same `AgentId`/`AgentVersion` but distinct effective system prompts / style.
+3. **Per-tenant scoping is absolute (design ownership rule).** Persona performance/action data is **ALWAYS tenant-scoped** — every persona benchmark row lives in the resolving tenant's `t_<hex>` schema, written/read only through `ITenantDbContextFactory` (32-10's isolation backbone), and carries `TenantId` = the resolving tenant. Two tenants both running public persona `claude` build **separate, private** persona profiles; the platform owner who curates `claude` sees neither. There is **no cross-tenant and no platform-admin read path** for a tenant's per-persona rows (the only admin view is 32-10's k-anonymous, public-agent-only fleet rollup — owned there, not extended here). **Explicitly tested.**
 
-4. **Stable persona name is the benchmark join key.** `Persona.Id` is the immutable identity and `Persona.Name` (within a role) is the stable, human-readable handle used as the join key for all per-persona metrics — exactly as `Agent.Id`/`Name` is for agents. Editing a persona's `StyleJson` or `SystemPromptFragmentRef` does **not** create a new persona identity, so a persona's benchmark history survives style edits (consistent with 32-1's "stable identity, dynamic config" premise). Persona edits are captured as an audit event (AC 8), not a new entity.
+4. **Persona-comparison is like-vs-like within a role.** The leaderboard's `persona` dimension ranks personas **within a single role** for the calling tenant: "which persona has the best success rate / fewest functional defects / lowest cost basis as my **reviewer**?" compares `claude` vs `gemini` vs `codegpt` **scoped to `role=reviewer`**, never a reviewer-run against an architect-run. The query pairs the persona key with its `role` so cross-role comparison is structurally impossible (a persona used for two roles yields two separate per-role rows). Ranking reuses 32-10's deterministic tie-break chain (`successRate` desc → `avgIterationsToDone` asc → `avgCostBasisUsd` asc → key asc) and its `minRuns` min-sample guard (provisional rows in `belowThreshold`, never silently ranked).
 
-5. **Persona composes at resolution time (no agent mutation).** `IAgentResolverService` gains an optional `personaId` parameter — `ResolveForRoleAsync(string role, Guid? personaId = null, …)` (and the phase variant). When a `personaId` is supplied, the resolver: (a) loads the persona and validates it is visible to the principal (public ∪ own private) AND its `Role` matches the requested role; (b) merges the persona's `StyleJson` (temperature/verbosity/etc.) and prompt fragment **onto** the already-resolved `ResolvedAgentConfig` returning a **new** object (never mutating the agent's pinned version, per CLAUDE.md state-immutability rule); (c) stamps `PersonaId`/`PersonaName` onto the returned config. A persona that does not match the role, or is not visible, is rejected (400/404) — it is **never** silently dropped.
+5. **Persona-aware leaderboard query facets.** The 32-10 leaderboard endpoint `GET /api/v1/orgs/{tenantId}/agents/leaderboard` accepts the persona dimension plus role + facet filters: `?dimension=persona&role=reviewer&window=30d` ranks personas as that role; optional `?personaId=` returns one persona's detail (its facet breakdown across provider/model/promptVersion/credentialSource); optional `&credentialSource=byok|platform` and `&promptVersion=` narrow the comparison. The response is **member-readable** (any tenant member); there is no tenant mutation surface for persona benchmark rows (they are derived). The endpoint shape is identical between modes — the auth/tenant filter (`RequireTenantMembershipFilter`) scopes the read to the caller's tenant.
 
-6. **Prompt composition reuses Epic 27 layering and never falls back to empty/plain.** The persona's `SystemPromptFragmentRef` is resolved through the existing Prompt Store (`PromptStoreService.ResolveRoleActionAsync` for single-user / `ResolveRoleActionForTenantAsync` for SaaS) and the resolved fragment is **appended** to the agent's system prompt in a deterministic order: `system role identity → role+action template → persona fragment`. The persona fragment layers *on top of* the existing prompt resolution; it never replaces it. If a non-null `SystemPromptFragmentRef` cannot be resolved, the resolver fails loud with a `TammaError` (mirroring `PromptStoreService.NoPromptError` / `feedback_resolution_no_empty_fallback`) — it must **never** fall back to an empty or plain persona fragment.
+6. **The fold consumes only existing trail tags — no new source event family.** This story adds **no** new `AGENT.*` source event. It folds the same 32-6/32-8/32-9 events 32-10 already folds; the persona dimension's `dimensionKeyFor` reads `agentId` (the persona-agent identity) from the event `Tags`, and the facet sub-keys (`provider`, `model`, `agentVersion`, `promptRef`, `credentialSource`) from the same flat tags 32-6/32-9 already emit. Where a trail tag is missing (e.g. `credentialSource` on a pre-32-5 run), the facet degrades to an explicit `unknown`/`null` bucket — **never silently merged** into a populated facet (no-empty-fallback discipline; fail-loud on a malformed key, degrade-explicitly on an absent one).
 
-7. **Persona is recorded on every run + action-trail entry as a tag.** The 32-6 action-trail tag builder is extended so every `AGENT.TASK.*` / `AGENT.ITERATION.COMPLETED` / `AGENT.PANEL.AGGREGATED` / `REVIEW.BUG.RECORDED` event (and the `AgentRunResult` it derives from) carries a `personaId` and `personaName` tag (flat string values, empty/absent when no persona was applied — agents run persona-free by default). This is the substrate that lets 32-10 compute per-persona leaderboards; the tag is populated from the same shared trail-tag builder so every emission site is consistent, with no raw `StyleJson` or prompt content in the tag.
+7. **Idempotent, cursor-tracked, replayable (32-10 contract preserved).** Persona projection folds are idempotent with the **per-`(dimension, dimensionKey, window)` `SequenceNumber` cursor** 32-10 defines; re-folding the same events is a no-op; a full `RebuildAsync` (cursor reset → replay from 0) produces byte-identical persona rows to the incremental path. **Per-tenant cursor rule:** the cursor is the tenant-schema `domain_events.SequenceNumber` (an independent per-schema `BIGSERIAL`); the persona projection cursor is composite-keyed including `TenantId` — there is **no shared global cursor across tenants** (compliance/billing/audit-grade isolation). Adding the persona facets does **not** change the cursor mechanics.
 
-8. **DCB lifecycle + application events.** Events follow `AGGREGATE.ACTION.STATUS` and are appended via `IEventRepository.AppendAsync`: `PERSONA.CREATED.SUCCESS` (on create), `PERSONA.UPDATED.SUCCESS` (on style/fragment edit), `PERSONA.ARCHIVED.SUCCESS` (on archive), and `AGENT.PERSONA_APPLIED.SUCCESS` (each time a persona is composed onto an agent at resolution) with `Tags` `{ personaId, personaName, agentId, agentVersion, role, mode }`. `Metadata` carries `{ workflowVersion: "1.0.0", eventSource: "system" }`. Events fire only after a real state transition / real composition (no "lie" events). For private/SaaS personas `DomainEvent.TenantId` is the `OwnerTenantId` (or the resolving tenant for `AGENT.PERSONA_APPLIED`); for public personas it is NULL (platform feed).
+8. **DCB lifecycle events for the persona projection (no source events).** Persona-projection lifecycle reuses 32-10's `BENCHMARK.PROJECTION.UPDATED` / `BENCHMARK.PROJECTION.REBUILT` event family (tagged `{ tenantId, dimension: "persona", window }`); this story emits **no new** persona-specific source event and **no** "lie" event for an empty fold. Events land in the resolving tenant's store (`TenantId` set); persona-projection events are never cross-tenant and never on the control plane.
 
-9. **Persona-aware leaderboards compare personas within a role.** The 32-10 benchmark projection gains a **persona slice**: per-tenant leaderboards can group by `(role, personaId)` so the question "which reviewer *persona* has the best success rate / fewest functional bugs / lowest cost on my work?" is answerable, comparing `atlas` vs `nova` **like-vs-like within the reviewer role** (never reviewer-persona vs architect-persona). Since 32-10's story file does not yet exist, this story defines the persona dimension contract (the `personaId`/`personaName` trail tags from AC 7 + a `groupBy=persona` / `?personaId=` query facet) that 32-10 consumes; the projection slice is delivered here against the 32-6 trail, and 32-10 surfaces it in its leaderboard API.
+9. **No new control-plane table; no DROP-list / model-contract churn.** This story adds **no** control-plane table (the persona IS the 32-15 public `Agent`, already in the CP DROP list + `ControlPlaneDbContextModelTests`). The persona benchmark rows are the 32-10 **tenant-schema** `BenchmarkProjection`/`BenchmarkProjectionCursor` entities (owned by the per-tenant `EfTenantDbMigrator`, NOT the CP DROP list). So: **nothing** is appended to `Program.cs`'s startup-reset "Wiping Tamma-managed public-schema tables" DROP list, and `ControlPlaneDbContextModelTests.Model_Has_ExpectedControlPlaneEntities` is **not** touched. If facets require a column on the tenant `BenchmarkProjection` entity, it is an additive **Tenant** migration (single linear snapshot), `has-pending-model-changes` reports none.
 
-10. **Per-mode public/private ownership (mandatory two-scoping-model answer).** In **single-user** mode "public" personas are the shipped system personas (read-only); the sole user owns/creates private personas (`OwnerUserId` set, `OwnerTenantId` NULL); their persona benchmarks are the user's. In **SaaS** mode public personas are platform-owned (control-plane resident, every tenant may *use* but not edit), and private personas are tenant-owned (`OwnerTenantId` set, in the tenant's `t_<hex>` data plane for benchmark data). A tenant's usable persona set = **all public personas ∪ its own private personas**. Performance/benchmark data per persona is **always tenant-scoped** — two tenants running public persona `atlas` build separate, private profiles; the platform owner who owns `atlas` sees neither.
+10. **No regression on the base leaderboard.** The agent/provider/prompt dimensions and their leaderboard shape are byte-for-byte unchanged; a non-persona leaderboard query returns exactly what 32-10 returns. The persona dimension's metric values (successRate, iterations, defect-by-category, p50/p95, cost basis / billable) are computed by the **same 32-10 reducer** — this story only refines the dimension key + adds facets, never re-derives the metrics or re-implements the fold. The full `Tamma.Api.Tests` suite stays green.
 
-11. **RBAC mirrors agents.** Persona reads (`GET`) are allowed to any tenant member (SaaS) / the sole user (single-user). Private-persona create/update/archive/select require `tenant_owner`/`tenant_admin` (the existing `AgentManage` = `agents:manage` policy, or a sibling `personas:manage`); a SaaS `member` gets **403**. Public-persona mutation requires `PlatformOwnerAccess`; a tenant attempting `visibility:public` create/version gets **403** (`persona_public_write_forbidden`). Cross-tenant private read returns **404** (not 403, to avoid existence leak), mirroring 32-1/32-2.
-
-12. **Persona CRUD endpoints wired + RBAC-gated.** New handlers on `AgentEndpoints.cs` (or a colocated `PersonaEndpoints.cs`) mapped in `Program.cs` under `/api/personas`: `GET /api/personas` (list public ∪ own private; filters `?role=&visibility=&status=`), `POST /api/personas` (create; private ⇒ `AgentManage`/owner, public ⇒ `PlatformOwnerAccess`), `GET /api/personas/{id}` (get one | 404), `PUT /api/personas/{id}` (edit style/fragment), `POST /api/personas/{id}/archive`. The `resolve` surface from 32-2 (`GET /api/agents/resolve?role=&phase=`) accepts an optional `&personaId=` so workflows can request a persona-composed config. The endpoint shape is identical between modes — the auth middleware decides which owner column (`OwnerUserId` vs `OwnerTenantId`) applies based on mode + caller identity (Prompt Store precedent).
-
-13. **No empty/plain fallback, ever.** A requested persona that is unresolvable (unknown id, archived, role-mismatch, cross-tenant, or unresolvable prompt fragment) is a hard `TammaError` / 4xx — the resolver **never** returns the bare agent config "as if no persona were requested" and **never** returns a blank persona fragment (`feedback_resolution_no_empty_fallback`). Requesting *no* persona (`personaId == null`) is the legitimate persona-free path and returns the plain resolved agent config unchanged.
-
-14. **No regression.** Persona-free resolution is byte-for-byte unchanged: `IAgentResolverService.ResolveForRoleAsync(role)` / `ResolveForPhaseAsync(phase, role)` with no `personaId` return exactly what they returned before; the legacy `/api/v1/agents/*` routes and JSONB path are untouched. The new migration applies cleanly, `dotnet ef migrations has-pending-model-changes` reports **none**, and the full `Tamma.Api.Tests` suite stays green.
-
-15. **Tests** cover: persona composition into the resolved config (style merge + fragment append order, agent version unchanged); two personas / one agent / same role producing distinct configs; persona tagging on the action trail; the per-persona benchmark dimension (group-by-persona leaderboard within a role); RBAC/visibility matrix (member 403 on write, tenant public-write 403, cross-tenant 404); the no-empty-fallback failures (unknown persona, role mismatch, unresolvable fragment); per-mode principal derivation; and DCB event emission / no-emission-on-failure.
+11. **Tests** cover: persona dimension key = the persona-agent `AgentId`/`AgentName` (NOT a style row); facet breakdown by provider/model/promptVersion/credentialSource (BYOK vs platform `claude` distinguished; prompt v3 vs v4 distinguished); like-vs-like within-a-role comparison (a persona used as reviewer and architect yields two separate per-role rows; an architect-role persona never appears in the reviewer leaderboard); per-tenant isolation (tenant B's persona rows never appear in tenant A's leaderboard; platform admin denied per-tenant); incremental-vs-rebuild equivalence on the persona dimension; absent-facet explicit-`unknown` bucketing (no silent merge); min-sample guard on persona rows; and `BENCHMARK.PROJECTION.*` emission with `dimension:"persona"` (no new source event, no-emission-on-empty-fold).
 
 ## Technical Design
 
-### Architectural placement (per the Epic 32 design of record)
+### Architectural placement (per the locked model)
 
-Per `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`: **the Agent is the entity**; personas are a *named styling/behavior layer above* an agent, scoped to a role, that composes at resolution time. A persona is NOT a new provider config and NOT a fork of an agent — it is a thin, reusable overlay (style params + a prompt fragment) that rides on top of an already-resolved `ResolvedAgentConfig`. Benchmarking is like-vs-like: persona `atlas` vs persona `nova` **within the reviewer role**, on the tenant's own data, never cross-role and never cross-tenant.
+Per `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` §3.0/§3.4: **persona = the named cross-role public/system `Agent`** (32-15). Benchmarking is a **read model derived from the tenant's DCB event stream**, owned by **32-10**; this story is the **persona-aware refinement** of that read model. It introduces no entity, no provider config, no style overlay — it keys the `persona` dimension on the persona-agent identity and adds the facets that make a persona's runs comparable like-vs-like within a role, on the tenant's own data.
 
-Ownership & data scoping reuse the design's key rule verbatim, one layer up:
+Ownership & data scoping (the design's load-bearing rule, applied to persona benchmarks):
 
 | Concern | Scope |
 |---|---|
-| **Persona definition** | Public/system (platform-owned, control-plane, usable by every tenant) **OR** private/tenant-owned (control-plane row keyed to the owner; usable only by it). Shipped defaults are public. |
-| **Persona performance/benchmark data** | **ALWAYS tenant-scoped** — the tenant that generated it owns it; never cross-tenant; platform admin who owns a public persona sees none of any tenant's per-persona metrics. |
+| **Persona definition** | Public/system — the named cross-role `Agent` curated by the platform owner (`PlatformOwnerAccess`), seeded by 32-15, usable by every tenant that **enables** it (32-16). Not owned/edited by tenants. |
+| **Persona performance/benchmark data** | **ALWAYS tenant-scoped** — the tenant that generated it owns it; lives in its `t_<hex>` schema; never cross-tenant; the platform owner who curates a public persona sees **none** of any tenant's per-persona metrics. |
 
-Story 32-1 (Agent/AgentVersion entities, `AgentVisibility`/`AgentStatus` enums, `IAgentRepository`, the visibility/ownership CHECK + per-owner partial-index pattern) and Story 32-2 (`IAgentResolverService.ResolveForRoleAsync`, the enriched `ResolvedAgentConfig` with `AgentId`/`AgentVersion`/`Source`, the `AgentManage` policy, the `/api/agents` route group) are **prerequisites**; the Agent entity is in-flight, so it is referenced **by interface** here. Every place a 32-1/32-2 field is depended on but not yet confirmed shipped is marked **(coordinate with 32-1/32-2)**.
+Story 32-10 (the `BenchmarkProjectionService`, the `persona` dimension, the leaderboard API, the `SequenceNumber` cursor, tenant isolation, and the k-anonymous admin rollup) and Story 32-15 (the persona-agent identity — `AgentId`/`AgentName`, `provider`/`model`) are **hard prerequisites**; both are referenced **by interface** and **by event-tag contract**.
 
 ### C# namespace / file structure
 
@@ -75,271 +95,191 @@ Story 32-1 (Agent/AgentVersion entities, `AgentVisibility`/`AgentStatus` enums, 
 apps/tamma-elsa/src/
   Tamma.Data/
     Entities/
-      Persona.cs                       # NEW — control-plane entity (style overlay, role-scoped)
-                                       #   reuses AgentVisibility / AgentStatus enums (32-1)
-    ControlPlaneDbContext.cs           # MODIFY — add DbSet<Persona>
-    TammaModelConfiguration.cs         # MODIFY — Persona config: CHECK + partial unique indexes
-    Repositories/
-      IPersonaRepository.cs            # NEW — Create/Update/Archive/GetById/ListVisible
-      PersonaRepository.cs             # NEW
-    Migrations/ControlPlane/
-      <ts>_AddPersonaEntity.cs         # NEW — additive migration (+ Designer + snapshot)
+      BenchmarkProjection.cs            # REUSE (32-10) — persona dimension row; OPTIONAL additive facet cols
+                                        #   (Provider, Model, AgentVersion, PromptRef, CredentialSource)
+      BenchmarkProjectionCursor.cs      # REUSE (32-10) — per-(dimension,key,window) SequenceNumber cursor
+    TammaModelConfiguration.cs          # MODIFY (only if AC2 facets need additive tenant columns)
+    Migrations/Tenant/
+      <ts>_AddPersonaBenchmarkFacets.cs # NEW (only if AC2 facets are persisted columns; additive, Tenant ctx)
   Tamma.Api/
     Services/Agents/
-      AgentResolverService.cs          # MODIFY — personaId overload: compose style + fragment
-      IAgentResolverService.cs         # MODIFY — add optional personaId param
-      ResolvedAgentConfig.cs           # MODIFY — add PersonaId/PersonaName (additive)
-      PersonaComposer.cs               # NEW — pure merge: persona StyleJson + fragment → config
-      PersonaEventTypes.cs             # NEW — PERSONA.* / AGENT.PERSONA_APPLIED.* constants
-    Services/PromptStore/
-      PromptStoreService.cs            # REUSE — resolve SystemPromptFragmentRef (no change to API)
+      BenchmarkProjectionService.cs     # MODIFY — persona dimensionKeyFor = agentId; facet sub-keys;
+                                        #   GetLeaderboardAsync persona role+facet filters
+      IBenchmarkProjectionService.cs    # MODIFY (only if the persona-comparison read needs a new method)
+      PersonaBenchmarkFacets.cs         # NEW — pure facet extraction from flat trail Tags (provider/model/
+                                        #   agentVersion/promptRef/credentialSource); unknown-bucket policy
     Endpoints/
-      AgentEndpoints.cs                # MODIFY — persona CRUD handlers (or new PersonaEndpoints.cs)
+      AgentLeaderboardEndpoints.cs      # MODIFY (32-10) — persona dimension: ?role=, ?personaId=,
+                                        #   &credentialSource=, &promptVersion= facets
     Dtos/Agents/
-      PersonaDtos.cs                   # NEW — request/response records
-    Program.cs                         # MODIFY — map /api/personas, RBAC, DI, &personaId= on resolve
+      BenchmarkDtos.cs                  # MODIFY (32-10) — PersonaLeaderboardRow + facet breakdown DTO
+    Program.cs                          # MODIFY — (no new route group; facet query params on the 32-10 route)
 ```
 
-### `Persona` entity (sketch)
+> **No new entity, no new service.** The persona-aware view is a **refinement of 32-10's `persona` dimension** plus a pure facet-extraction helper. If the facets (provider/model/promptVersion/credentialSource) are computed at query time from the folded sub-keys, even the additive tenant columns are unnecessary — prefer the no-schema-change path and persist facets only if query-time aggregation is too costly.
+
+### Persona dimension key + facets (the only genuinely new logic)
 
 ```csharp
-// Tamma.Data/Entities/Persona.cs — control-plane entity; reuses 32-1 enums
-public class Persona
+// In BenchmarkProjectionService.dimensionKeyFor — persona = the persona-AGENT identity.
+// (Locked model: persona = the named public Agent from 32-15, NOT a style row.)
+string DimensionKeyFor(string dimension, IReadOnlyDictionary<string, string> tags) => dimension switch
 {
-    public Guid Id { get; set; }
-    public string Name { get; set; } = null!;             // stable handle, e.g. "atlas"
-    public string Role { get; set; } = null!;             // AgentRole wire string — persona is role-scoped
-    public AgentVisibility Visibility { get; set; }        // reuse 32-1 enum: Public | Private
-    public Guid? OwnerTenantId { get; set; }               // set iff Private + SaaS
-    public Guid? OwnerUserId { get; set; }                 // set iff Private + SingleUser
-    public AgentStatus Status { get; set; } = AgentStatus.Active;  // reuse 32-1 enum
-    public string StyleJson { get; set; } = "{}";          // jsonb: tone, verbosity, riskTolerance, reviewStrictness
-    public string? SystemPromptFragmentRef { get; set; }   // Prompt-Store fragment key (never inline secrets)
-    public DateTime CreatedAt { get; set; }
-    public Guid? CreatedBy { get; set; }
-    public DateTime UpdatedAt { get; set; }
-    public Guid? UpdatedBy { get; set; }
-}
+    "agent"    => tags["agentId"],
+    "provider" => tags["provider"],
+    "prompt"   => tags["promptRef"],
+    "persona"  => tags["agentId"],   // a public persona's agentId IS its persona identity (32-15)
+    _ => throw new TammaError("BENCHMARK.DIMENSION.INVALID", $"Unknown dimension '{dimension}'.",
+                              retryable: false, severity: Severity.High)
+};
 ```
-
-> The persona carries **no** provider/model/credential fields — those are the agent's. A persona is purely a style overlay + an optional prompt fragment, by design credential-agnostic and provider-agnostic, so the same persona can ride any agent of the matching role.
-
-### EF model configuration (in `TammaModelConfiguration.cs`, mirroring `Agent` from 32-1)
 
 ```csharp
-modelBuilder.Entity<Persona>(entity =>
-{
-    entity.ToTable("personas", t =>
-    {
-        t.HasCheckConstraint(
-            "ck_personas_visibility_ownership",
-            "(\"Visibility\" = 0 AND \"OwnerTenantId\" IS NULL AND \"OwnerUserId\" IS NULL) " +     // 0 = Public
-            "OR (\"Visibility\" = 1 AND \"OwnerTenantId\" IS NOT NULL AND \"OwnerUserId\" IS NULL) " + // 1 = Private/SaaS
-            "OR (\"Visibility\" = 1 AND \"OwnerUserId\" IS NOT NULL AND \"OwnerTenantId\" IS NULL)");
-    });
-    entity.HasKey(e => e.Id);
-    entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
-    entity.Property(e => e.Name).IsRequired().HasMaxLength(128);
-    entity.Property(e => e.Role).IsRequired().HasMaxLength(64);
-    entity.Property(e => e.Visibility).HasConversion<int>();
-    entity.Property(e => e.Status).HasConversion<int>().HasDefaultValue(AgentStatus.Active);
-    entity.Property(e => e.StyleJson).HasColumnType("jsonb").HasDefaultValueSql("'{}'::jsonb");
-    entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
-    entity.Property(e => e.UpdatedAt).HasDefaultValueSql("now()");
+// PersonaBenchmarkFacets — pure extraction of the disambiguating facets from the SAME flat trail tags.
+// Absent facet => explicit "unknown" bucket (never silently merged into a populated facet).
+public sealed record PersonaFacets(
+    string Provider, string Model, int AgentVersion, string PromptRef, string CredentialSource);
 
-    // Public persona handles unique on (Name, Role)
-    entity.HasIndex(e => new { e.Name, e.Role })
-        .IsUnique().HasFilter("\"Visibility\" = 0")
-        .HasDatabaseName("IX_personas_public_name_role");
-    // Private persona handles unique per owner within a role
-    entity.HasIndex(e => new { e.OwnerTenantId, e.Name, e.Role })
-        .IsUnique().HasFilter("\"Visibility\" = 1 AND \"OwnerTenantId\" IS NOT NULL")
-        .HasDatabaseName("IX_personas_private_tenant_name_role");
-    entity.HasIndex(e => new { e.OwnerUserId, e.Name, e.Role })
-        .IsUnique().HasFilter("\"Visibility\" = 1 AND \"OwnerUserId\" IS NOT NULL")
-        .HasDatabaseName("IX_personas_private_user_name_role");
-});
+public static PersonaFacets Extract(IReadOnlyDictionary<string, string> tags) => new(
+    Provider:         tags.GetValueOrDefault("provider",         "unknown"),
+    Model:            tags.GetValueOrDefault("model",            "unknown"),
+    AgentVersion:     int.TryParse(tags.GetValueOrDefault("agentVersion"), out var v) ? v : 0,
+    PromptRef:        tags.GetValueOrDefault("promptRef",        "unknown"),
+    CredentialSource: tags.GetValueOrDefault("credentialSource", "unknown"));   // byok | platform | unknown
 ```
 
-### Resolver extension — persona composition
+The persona row's **identity** is `(role, agentId)` (like-vs-like within a role, AC4); the **facets** sub-slice that identity so a tenant can ask "is `claude` better for me on BYOK Anthropic than on the platform key?" or "did prompt v4 regress `claude`'s defect rate?" without ever comparing across roles or tenants.
 
-`IAgentResolverService` (extend; `personaId` is optional and defaults to today's behaviour):
+### Persona-comparison leaderboard (extends the 32-10 endpoint)
 
-```csharp
-// Add an optional personaId to the 32-2 resolve methods (additive, non-breaking).
-Task<ResolvedAgentConfig> ResolveForRoleAsync(
-    string role, Guid? personaId = null, CancellationToken ct = default);
+```
+GET /api/v1/orgs/{tenantId}/agents/leaderboard?dimension=persona&role=reviewer&window=30d
+      -> 200 { dimension:"persona", role:"reviewer", window:"30d",
+               ranked:[ { personaId, personaName, provider, model, successRate, avgIterationsToDone,
+                          defectRateByCategory, latencyP50Ms, latencyP95Ms, avgCostBasisUsd,
+                          avgBillableUsd, runCount } ... ],   // ordered by 32-10 tie-break chain
+               belowThreshold:[ ... ] }                       // runCount < minRuns (32-10 guard)
 
-Task<ResolvedAgentConfig> ResolveForRoleAndPhaseAsync(
-    string phase, string role, Guid? personaId = null, CancellationToken ct = default);
+GET …?dimension=persona&personaId={agentId}&role=reviewer&window=30d
+      -> 200 { personaId, personaName, role:"reviewer",
+               facets:[ { provider, model, promptVersion, credentialSource, ...metrics, runCount } ... ] }
+
+GET …?dimension=persona&role=reviewer&credentialSource=byok            // facet filter
+GET …?dimension=persona&role=reviewer&promptVersion=v4                 // facet filter
 ```
 
-Composition flow (no agent mutation — returns a new object):
+All reads are member-scoped by `RequireTenantMembershipFilter` to the caller's tenant (32-10). A tenant requesting another tenant's path → 403/404 (32-10's isolation, unchanged). The platform owner has **no** per-tenant persona route (the only cross-tenant view is 32-10's k-anonymous public-agent fleet rollup).
 
-```csharp
-public async Task<ResolvedAgentConfig> ResolveForRoleAsync(
-    string role, Guid? personaId, CancellationToken ct)
-{
-    // 1. Resolve the agent exactly as 32-2 does (precedence chain; fail-loud on no agent).
-    var resolved = await ResolveAgentForRoleAsync(role, ct);
-    if (personaId is null) return resolved;          // legitimate persona-free path (unchanged)
+### Source events (consumed, not produced)
 
-    // 2. Load + validate the persona (visible to principal AND role matches).
-    var persona = await _personas.GetVisibleAsync(personaId.Value, _principal.Resolve(), ct)
-        ?? throw new TammaError("PERSONA.RESOLVE.NOT_FOUND", ..., severity: High);   // 404, not silent
-    if (!string.Equals(persona.Role, role, StringComparison.Ordinal))
-        throw new TammaError("PERSONA.ROLE_MISMATCH", ..., severity: High);          // 400, not silent
+This story produces **no** source event. It folds the persona dimension from the same families 32-10 folds:
 
-    // 3. Resolve the prompt fragment via Epic 27 store; fail-loud if non-null & unresolvable.
-    var fragment = persona.SystemPromptFragmentRef is null
-        ? null
-        : await ResolveFragmentOrThrow(persona.SystemPromptFragmentRef, role, ct);  // NEVER empty fallback
+| Source event | Producer | Persona-fold contribution |
+|---|---|---|
+| `AGENT.TASK.SUCCESS`/`.FAILED`/`.PARTIAL` | 32-6 | persona key = `agentId`; run latency; success numerator/denominator; provider/model/credentialSource facets |
+| `AGENT.OUTCOME.RECORDED` | 32-8 | `iterationsToDone` for the persona's `avgIterationsToDone` |
+| `AGENT.DEFECT.RECORDED` | 32-8 | per-category defect rate for the persona (`BugCategory` wire strings) |
+| `AGENT.ITERATION.COMPLETED` / `AGENT.PANEL.AGGREGATED` | 32-6/32-7 | iteration fallback; panel persona attribution |
+| `AGENT.USAGE.RECORDED` | 32-9 / 32-5 | `costBasisUsd`/`billableUsd`; **`credentialSource`** facet; provider/model facets |
 
-    // 4. Pure merge: style params + appended fragment → NEW ResolvedAgentConfig.
-    var composed = PersonaComposer.Compose(resolved, persona, fragment);
-    composed = composed with { PersonaId = persona.Id, PersonaName = persona.Name };
+> The `credentialSource` facet (AC2) is the only facet that depends on 32-5/32-9 (the call-LLM endpoint surfaces `credentialSource` on the run, 32-9 tags it on `AGENT.USAGE.RECORDED`). Until those land, the facet degrades to the explicit `unknown` bucket (AC6), backfilled on the next rebuild once the tag exists — **never** silently merged.
 
-    // 5. Audit the composition (real event, after a real compose).
-    await _events.AppendAsync(AgentPersonaApplied(persona, resolved, role), ct);
-    return composed;
-}
-```
-
-`PersonaComposer.Compose` is pure and deterministic:
-- **Style merge:** persona `StyleJson` overrides the agent's style-adjacent fields it explicitly sets (e.g. `temperature`, verbosity hints), leaving provider/model/budget/tools untouched (a persona styles, it does not re-provider).
-- **Prompt append order:** `system role identity → role+action template → persona fragment` — the persona fragment is *appended* to the already-resolved `SystemPrompt`, never replacing it (AC 6). Order is fixed and tested.
-- Returns a brand-new `ResolvedAgentConfig`; the input is never mutated (CLAUDE.md state-immutability rule).
-
-### `ResolvedAgentConfig` (additive)
-
-```csharp
-// Tamma.Api/Services/Agents/ResolvedAgentConfig.cs — ADDITIVE fields only
-public class ResolvedAgentConfig
-{
-    // ... all existing fields unchanged (Role, Handle, Provider, Model, Temperature,
-    //     MaxTokens, TokenBudget, Tools, SystemPrompt, Source, Phase, MaxBudgetUsd,
-    //     PermissionMode, AllowedTools, and the 32-2 AgentId/AgentVersion) ...
-
-    /// <summary>Persona composed onto this config (32-12). Null = persona-free run.</summary>
-    public Guid? PersonaId { get; init; }
-
-    /// <summary>Stable persona handle — the benchmark join key (e.g. "atlas").</summary>
-    public string? PersonaName { get; init; }
-}
-```
-
-### Benchmark slice (the persona dimension)
-
-The action trail (32-6) is the substrate. This story:
-1. Extends the **shared trail-tag builder** so every trail event + `AgentRunResult` carries `personaId`/`personaName` (flat strings; absent ⇒ persona-free). This is the join key 32-10 groups on.
-2. Delivers a **per-persona projection facet** over the 32-6 trail: aggregate success rate, avg iterations-to-done, bug-counts-by-type, cost, and latency grouped by `(role, personaId)` for the calling tenant only. This answers "best reviewer *persona* on my work."
-3. Defines the **dimension contract** 32-10 consumes (the leaderboard API gains `?groupBy=persona` / `?personaId=` facets). 32-10's story file does not yet exist; this story owns the persona tags + the projection slice, and 32-10 surfaces them in its leaderboard endpoint. Like-vs-like is enforced by always pairing `personaId` with its `role` — persona comparisons are scoped within a role, never across roles, never across tenants.
-
-### DCB events (NEW)
+### DCB lifecycle (reuses 32-10's family)
 
 | Event | When | Tags |
 |---|---|---|
-| `PERSONA.CREATED.SUCCESS` | new `Persona` committed | `personaId, personaName, role, visibility, ownerTenantId?, ownerUserId?, mode` |
-| `PERSONA.UPDATED.SUCCESS` | style/fragment edited | `personaId, personaName, role, visibility, mode` |
-| `PERSONA.ARCHIVED.SUCCESS` | `Status` → archived | `personaId, personaName, role, visibility, mode` |
-| `AGENT.PERSONA_APPLIED.SUCCESS` | persona composed onto an agent at resolution | `personaId, personaName, agentId, agentVersion, role, mode` |
+| `BENCHMARK.PROJECTION.UPDATED` | persona fold advances the cursor | `{ tenantId, dimension: "persona", window, rowsUpdated }` |
+| `BENCHMARK.PROJECTION.REBUILT` | persona dimension rebuilt (cursor reset → replay) | `{ tenantId, dimension: "persona", window }` |
 
-Appended via `IEventRepository.AppendAsync(DomainEvent { Type, TenantId, Tags, Metadata, Data, CreatedAt })` into the same store the rest of Epic 32 uses (`SequenceNumber` total-order cursor is server-assigned). Private/SaaS persona lifecycle events carry `TenantId = OwnerTenantId`; public-persona lifecycle events carry `TenantId = NULL` (platform feed); `AGENT.PERSONA_APPLIED` carries the *resolving* tenant's id (the run is the tenant's, even for a public persona — consistent with the design's "data is always tenant-scoped").
-
-### API shape
-
-```
-GET    /api/personas                  → 200 [PersonaSummary]   (public ∪ own private; ?role=&visibility=&status=)
-POST   /api/personas                  → 201 PersonaResponse     (private ⇒ AgentManage/owner; public ⇒ PlatformOwnerAccess; member ⇒ 403)
-GET    /api/personas/{id}             → 200 PersonaDetail | 404 (cross-tenant private ⇒ 404)
-PUT    /api/personas/{id}             → 200 PersonaResponse      (same ownership rule; emits PERSONA.UPDATED.SUCCESS)
-POST   /api/personas/{id}/archive     → 200 { id, status: "archived" }
-GET    /api/agents/resolve?role=&phase=&personaId=   → 200 ResolvedAgentConfig (persona composed) | 400 role-mismatch | 404 persona-not-found
-```
-
-Per-mode + per-tenant handling reuses the 32-2 endpoint conventions: public-scope writes gated by `PlatformOwnerAccess`; private-scope writes derive principal columns from `ITammaModeProvider` + `ITenantContext`/`ClaimsPrincipal` (SaaS ⇒ `OwnerTenantId`; single-user ⇒ `OwnerUserId`); member-role SaaS callers get 403 on writes; cross-tenant private read ⇒ 404.
+No persona-specific source event; no event on an empty fold. Appended via the tenant `IEventRepository` into the resolving tenant's store (`TenantId` set) — never the control plane, never cross-tenant.
 
 ### Per-mode ownership (mandatory two-scoping-model answer)
 
 | Question | single-user | SaaS |
 |---|---|---|
-| Who owns a **private** persona? | The sole user (`OwnerUserId`; `OwnerTenantId` NULL). | The tenant (`OwnerTenantId`); `tenant_owner`/`tenant_admin` edit, `member` read-only. |
-| Who owns a **public** persona? | Shipped system personas (read-only to the user). | Platform owner (`PlatformOwnerAccess`); CP-resident; every tenant may *use* but not edit. |
-| Who can apply a persona to a run? | The user. | Any member (apply ≈ read of the persona + resolve); editing the persona needs owner/admin. |
-| Where do per-persona benchmarks live? | The user's data — `user_id`-keyed. | The tenant's `t_<hex>` data plane; never cross-tenant. |
-| Resolution / benchmark principal | `user_id` | `tenant_id` |
-| Mode source | `ITammaModeProvider` (process-stable) | same |
+| Who owns a **persona** (the definition)? | The platform — personas are public `Agent`s (`PlatformOwnerAccess` to curate); the sole user uses an enabled subset. | The platform — same public personas, shared cross-tenant; tenants enable a subset (32-16), never edit. |
+| Who owns the **per-persona benchmark data**? | The sole user — their instance, their dataset (`UserId`-keyed tenant). | The tenant that generated it — **always** tenant-scoped; one persona definition → many independent per-tenant datasets. |
+| Who reads the persona leaderboard? | The user (member-read). | Any tenant member (`MemberAccess` + `RequireTenantMembershipFilter`) for their own tenant only. |
+| Can a platform admin read a tenant's persona benchmark? | N/A (sole user). | **No.** Per-persona rows are structurally unreachable cross-tenant; the only admin view is 32-10's k-anonymous **public-agent** fleet rollup — never a single tenant's persona row, never a tenant id. |
+| Where do persona projection rows + cursors live? | The single tenant store (`t_<hex>`). | The originating tenant's `t_<hex>` schema (per-tenant routing via `ITenantDbContextFactory`); per-tenant `SequenceNumber` cursor. |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`) — process-stable. | same |
 
 ### Integration points
 
-- **`Agent` / `AgentVersion` / `AgentVisibility` / `AgentStatus` / `IAgentRepository`** (32-1, in-flight) — persona reuses the enums + the visibility/ownership CHECK + per-owner partial-index pattern; referenced **by interface**.
-- **`IAgentResolverService` / `ResolvedAgentConfig`** (`Tamma.Api/Services/Agents/`) — the resolver gains the optional `personaId`; `ResolvedAgentConfig` gains `PersonaId`/`PersonaName` (additive).
-- **`AgentEndpoints.cs`** (`apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs`) — persona CRUD handlers + `&personaId=` on resolve.
-- **`PromptStoreService`** (`apps/tamma-elsa/src/Tamma.Api/Services/PromptStore/PromptStoreService.cs`) — `ResolveRoleActionAsync` / `ResolveRoleActionForTenantAsync` resolve the persona fragment through the existing Epic 27 layering; no Prompt-Store API change.
-- **`RolePhaseMap` / `AgentRole`** (`Tamma.Core/Agents/`) — persona `Role` validated on create/resolve.
-- **`IEventRepository`** (`Tamma.Data/Repositories/EventRepository.cs`) + **`DomainEvent`** (`Tamma.Data/Entities/DomainEvent.cs`) — DCB emission.
-- **`ITammaModeProvider`** (`Tamma.Api/Services/PromptStore/TammaMode.cs`) + **`ITenantContext`** + `ClaimsPrincipal` — per-mode principal derivation.
-- **Action trail (32-6)** (`AGENT.TASK.*` etc.) — extended tag builder carries `personaId`/`personaName`.
-- **Benchmark leaderboards (32-10)** — consumes the persona dimension contract defined here.
-- **Auth policies** (`Program.cs`): `PlatformOwnerAccess`, `AgentManage` (`agents:manage`), member read access — the 32-2 precedent.
+- **Story 32-10** (`BenchmarkProjectionService`, `BenchmarkProjection`/`BenchmarkProjectionCursor`, the leaderboard API, the `SequenceNumber` cursor, tenant isolation, the k-anonymous admin rollup) — this story refines its `persona` dimension key and adds facets + the persona-comparison query. **Hard prerequisite; by interface.**
+- **Story 32-15** (persona reframe + seeding) — supplies the persona-agent identity (`AgentId`/`AgentName`, nullable `Role`, explicit `provider`/`model`); for a public persona, `agentId` (trail tag) **is** the persona identity. **Hard prerequisite; by event-tag contract.**
+- **Story 32-16** (per-tenant enablement) — only enabled personas have runs in a tenant; the persona leaderboard naturally reflects the enabled set.
+- **Story 32-6** (action trail) — the `agentId`/`agentVersion`/`provider`/`promptRef` flat tags this story keys + facets on. **By tag contract.**
+- **Story 32-9 / 32-5** (usage/cost + call-LLM) — surface `credentialSource` + `costBasisUsd`/`billableUsd` on `AGENT.USAGE.RECORDED`; the `credentialSource` facet (AC2) consumes them, degrading to `unknown` until they land.
+- **`ITenantDbContextFactory` / `IEventRepository`** — the structural isolation plane + the cursor-paged, tenant-scoped, null-tenant-guarded read (32-10).
+- **`RequireTenantMembershipFilter` + `/api/v1/orgs/{tenantId}`** — the member-readable tenant-path the leaderboard rides (32-10).
+- **`ITammaModeProvider`** (`Tamma.Api/Services/PromptStore/TammaMode.cs`) — per-mode principal derivation.
 
 ## Dependencies
 
-- **Prerequisite**: Story 32-1 (Agent entity model & versioned saved config) — provides `Agent`/`AgentVersion`, the `AgentVisibility`/`AgentStatus` enums the persona reuses, and the visibility/ownership CHECK + per-owner partial-index pattern. **In-flight — reference by interface.**
-- **Prerequisite**: Story 32-2 (Agent registry, resolution & RBAC API) — provides `IAgentResolverService.ResolveForRoleAsync`, the enriched `ResolvedAgentConfig` (`AgentId`/`AgentVersion`/`Source`), the `AgentManage` policy, the `/api/agents` route group, and the no-empty-fallback resolution discipline this story extends.
-- **Prerequisite / consumer**: Story 32-10 (Benchmark projections & leaderboards) — defines the leaderboard surface; this story supplies the **persona dimension** (trail tags + group-by-persona projection) it slices on. 32-10's story file does not yet exist; coordinate the leaderboard query facet (`?groupBy=persona` / `?personaId=`) at integration.
-- **Reuses**: Story 32-6 (action trail — extended with persona tags), Epic 27 (Prompt Store — fragment resolution + the RBAC/per-mode model mirrored), Epic 28 (schema-per-tenant — structural isolation of private personas + per-persona benchmark data).
-- **Design of record**: `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md` (Epic 32 design — "the Agent is the entity; personas are named variants within a role; benchmark like-vs-like").
-- **Related project rule**: `feedback_resolution_no_empty_fallback` — persona/fragment resolution is fail-loud, never empty/plain.
+**Internal (hard prerequisites):**
+
+- **Story 32-10** (Benchmark projections & leaderboards) — owns the fold, the `persona` dimension, the leaderboard API, the `SequenceNumber` cursor, tenant isolation, and the k-anonymous admin rollup. This story extends its persona dimension; it does **not** rebuild the projection engine.
+- **Story 32-15** (Persona reframe + seeding) — defines the persona-agent identity (`AgentId`/`AgentName`, `provider`/`model`) this story keys on. Without it there is no "persona" to benchmark.
+
+**Internal (consumed by tag contract / soft-degrade):**
+
+- **Story 32-6** (Agent action trail) — the `agentId`/`agentVersion`/`provider`/`promptRef` tags the persona fold reads.
+- **Story 32-8** (Outcome capture & bug taxonomy) — outcome/defect events the persona metrics fold.
+- **Story 32-9** (Agent usage & cost emission) + **Story 32-5** (Call-LLM endpoint) — surface `credentialSource` + cost on the run; the `credentialSource` facet degrades to `unknown` until they land (no parallel event invented).
+- **Story 32-16** (Per-tenant enablement) — constrains which personas a tenant runs (and thus benchmarks).
+
+**Consumers / related (downstream, not blockers):**
+
+- **Story 32-13** (Agent management & benchmark dashboards) — surfaces the persona-comparison leaderboard + facet breakdown in the UI.
+- **Story 32-14** (A/B experiment framework) — may compare two personas as an experiment arm using this dimension.
+
+**Related sibling (split-out, NOT a dependency):**
+
+- **Story 32-19** (Agent style/voice variants — NEW) — the `atlas`/`nova` style/voice overlay formerly mis-modelled as "persona." A *variant* is a style profile composed onto a persona-agent (its own visibility/XOR/index discipline). If 32-19 ships its own variant benchmark facet, it aligns with this dimension; **not built or assumed here**.
+
+**Design of record:** `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§3.0 reframe table, §3.1 persona = system-agent entity, §3.4 disposition of 32-12).
+
+**Related project rule:** `feedback_resolution_no_empty_fallback` — facet/dimension resolution fails loud on a malformed key and degrades to an **explicit** `unknown` bucket on an absent one; it never silently merges into a populated facet.
 
 ## Testing Strategy
 
-Tests are xUnit under `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/` (and `Personas/`). Docker-bound suites run via `sg docker -c "dotnet test ..."` (see `reference_dotnet_test_docker`). TDD: write the failing test first.
+Tests are xUnit under `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/`. Docker-bound suites run via `sg docker -c "dotnet test ..."` (see `reference_dotnet_test_docker`). TDD: write the failing test first.
 
-1. **Composition** (`PersonaComposerTests` / `AgentResolverServiceTests`): a persona's `StyleJson` overrides only style-adjacent fields (temperature/verbosity), leaving provider/model/budget/tools untouched; the fragment is *appended* to the agent system prompt in the fixed order `role identity → role+action → persona fragment`; the input `ResolvedAgentConfig` and the agent's pinned version are unmodified (immutability); `PersonaId`/`PersonaName` stamped on the output.
-2. **Two personas / one agent / same role** (`AgentResolverServiceTests`): seed one reviewer agent + personas `atlas` and `nova` (both `role=reviewer`); resolve under each — both return the same `AgentId`/`AgentVersion`, distinct effective `SystemPrompt`/style. Proves no agent fork.
-3. **Persona tagging on the trail** (`PersonaTrailTaggingTests`): a persona-composed run's `AGENT.TASK.*` / `AGENT.ITERATION.COMPLETED` / `REVIEW.BUG.RECORDED` events carry `personaId`/`personaName`; a persona-free run carries empty/absent persona tags; no raw `StyleJson`/prompt content in tags (redaction).
-4. **Per-persona benchmark dimension** (`PersonaLeaderboardProjectionTests`): seed trail rows for `atlas` and `nova` under `role=reviewer`; the group-by-`(role, personaId)` projection ranks them within the reviewer role on success rate / bug counts / cost; an architect-role persona never appears in the reviewer leaderboard (like-vs-like); tenant B's rows never appear in tenant A's projection (isolation).
-5. **RBAC / visibility matrix** (`PersonaEndpointsTests`, in-process `WebApplicationFactory`): member create/update/archive → 403; tenant `POST /api/personas {visibility:public}` → 403 `persona_public_write_forbidden`; platform owner public create → 201; cross-tenant `GET /api/personas/{B-private-id}` → 404; `GET /api/personas` from A never returns B's private rows.
-6. **No empty/plain fallback** (`AgentResolverServiceTests`): unknown `personaId` → `PERSONA.RESOLVE.NOT_FOUND` 404; persona role-mismatch → `PERSONA.ROLE_MISMATCH` 400; non-null `SystemPromptFragmentRef` that the Prompt Store can't resolve → `TammaError` (no blank fragment); `personaId == null` → plain resolved config (legitimate persona-free path).
-7. **Per-mode principal derivation** (`[Theory]` over `TammaMode.SingleUser`/`SaaS`): single-user private create sets `OwnerUserId`/null tenant; SaaS sets `OwnerTenantId`/null user; CHECK rejects public-with-owner / private-with-no-owner / private-with-both.
-8. **DCB events** (`PersonaEventsTests`): create/update/archive emit exactly one `PERSONA.*` event each with correct tags; a composed resolution emits one `AGENT.PERSONA_APPLIED.SUCCESS` with `{personaId, agentId, role}`; a validation/resolution failure leaves the event store untouched (no-emission-on-failure).
-9. **Migration + no regression** (`ControlPlaneDbContextModelTests` extended): migration applies, `has-pending-model-changes` → none, the `personas` table/indexes/CHECK exist; persona-free resolution and the legacy `/api/v1/agents/*` routes stay byte-for-byte green.
+1. **Persona dimension key = persona-agent identity** (`BenchmarkProjectionServiceTests`): a fold over a fixture stream where `agentId` is the public `claude` persona produces a persona row keyed by that `agentId`/`AgentName` — **not** a style row; assert the key equals the 32-15 persona-agent identity, never a tone/verbosity value.
+2. **Facet breakdown** (`PersonaBenchmarkFacetsTests` / `BenchmarkProjectionServiceTests`): runs of persona `claude` split by `credentialSource` (`byok` vs `platform`) yield distinct facet buckets with the same `personaId`; prompt v3 vs v4 (`promptRef`) split distinctly; same for provider/model; no raw config/prompt/key appears in any facet value.
+3. **Like-vs-like within a role** (`BenchmarkLeaderboardEndpointsTests`): persona `claude` used as `reviewer` and as `architect` yields two separate per-role rows; `?dimension=persona&role=reviewer` ranks `claude`/`gemini`/`codegpt` only as reviewer; an architect-role persona row never appears in the reviewer leaderboard.
+4. **Per-tenant isolation** (`BenchmarkIsolationTests`, docker-bound): seed persona rows for tenant A and B; `GET …/orgs/{B}/…?dimension=persona` returns only B's; a member of A hitting B's path → 403/404; a platform owner has no per-tenant persona route; a public persona run by A leaves persona rows only in A's schema.
+5. **Incremental-vs-rebuild equivalence on the persona dimension** (`BenchmarkProjectionServiceTests`): fold persona events, fold again (cursor skip → no double-count), then `RebuildAsync` (reset → replay) → byte-identical persona rows + facets; the per-tenant composite cursor never crosses tenants.
+6. **Absent-facet explicit bucketing** (`PersonaBenchmarkFacetsTests`): a pre-32-5 run with no `credentialSource` tag lands in an explicit `unknown` facet, **never** merged into `byok`/`platform`; a malformed `dimension` throws `BENCHMARK.DIMENSION.INVALID` (no silent fallback).
+7. **Min-sample guard on persona rows** (`BenchmarkLeaderboardEndpointsTests`): a persona with `runCount < minRuns` lands in `belowThreshold`, never `ranked` (32-10 guard reused).
+8. **DCB lifecycle** (`BenchmarkProjectionServiceTests`): a persona fold emits `BENCHMARK.PROJECTION.UPDATED` with `dimension:"persona"`; a rebuild emits `BENCHMARK.PROJECTION.REBUILT`; an empty fold emits nothing; **no** new persona-specific source event exists (grep proves it).
+9. **No regression** (`BenchmarkProjectionServiceTests` / `BenchmarkLeaderboardEndpointsTests`): agent/provider/prompt dimensions + their leaderboard shape unchanged; persona metric values come from the same 32-10 reducer (assert identical numbers for the same runs); no CP table added; `has-pending-model-changes` reports none; the `Tamma.Api.Tests` suite stays green.
 
-**Coverage**: critical paths (composition merge, fragment-fail-loud, ownership guard, event emission, persona tagging) → 100%; entity/repository line ≥ 80%.
+**Coverage**: critical paths (persona dimension key, facet extraction + unknown-bucket, like-vs-like role scoping, tenant isolation, cursor idempotency) → 100%; supporting line ≥ 80%.
 
 ## Estimated Effort
 
-4-5 days
+2-3 days (a refinement of 32-10's persona dimension + facet extraction + the comparison query — no new entity, no new fold, no new service).
 
 ## Files Created / Modified
 
 | File | Action |
 |------|--------|
-| `apps/tamma-elsa/src/Tamma.Data/Entities/Persona.cs` | Create |
-| `apps/tamma-elsa/src/Tamma.Data/Repositories/IPersonaRepository.cs` | Create |
-| `apps/tamma-elsa/src/Tamma.Data/Repositories/PersonaRepository.cs` | Create |
-| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_AddPersonaEntity.cs` (+ `.Designer.cs`, snapshot) | Create |
-| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/PersonaComposer.cs` | Create |
-| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/PersonaEventTypes.cs` | Create |
-| `apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/PersonaDtos.cs` | Create |
-| `apps/tamma-elsa/tests/Tamma.Api.Tests/Personas/PersonaComposerTests.cs` | Create |
-| `apps/tamma-elsa/tests/Tamma.Api.Tests/Personas/PersonaEndpointsTests.cs` | Create |
-| `apps/tamma-elsa/tests/Tamma.Api.Tests/Personas/PersonaEventsTests.cs` | Create |
-| `apps/tamma-elsa/tests/Tamma.Api.Tests/Personas/PersonaLeaderboardProjectionTests.cs` | Create |
-| `apps/tamma-elsa/tests/Tamma.Api.Tests/Personas/PersonaTrailTaggingTests.cs` | Create |
-| `apps/tamma-elsa/src/Tamma.Data/Entities/Persona.cs` style/visibility reuse of `AgentVisibility`/`AgentStatus` (32-1) | Reference (coordinate with 32-1) |
-| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (add `DbSet<Persona>`) |
-| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (Persona entity config: CHECK + partial indexes) |
-| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentResolverService.cs` | Modify (personaId compose path) |
-| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/IAgentResolverService.cs` | Modify (optional `personaId` param) |
-| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ResolvedAgentConfig.cs` | Modify (add `PersonaId`/`PersonaName`) |
-| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs` | Modify (persona CRUD handlers + `&personaId=` on resolve) |
-| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map `/api/personas`, RBAC, DI `IPersonaRepository`) |
-| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentResolverServiceTests.cs` | Modify (persona composition + no-fallback cases) |
-| `apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs` | Modify (assert `personas` table/indexes/CHECK) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/PersonaBenchmarkFacets.cs` | Create (pure facet extraction + unknown-bucket policy) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/PersonaBenchmarkFacetsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/PersonaLeaderboardTests.cs` | Create (persona key, like-vs-like, facets, min-sample) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/BenchmarkProjectionService.cs` | Modify (32-10) — persona `dimensionKeyFor` = `agentId`; facet sub-keys; persona role+facet read |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/IBenchmarkProjectionService.cs` | Modify (32-10) — only if the persona-comparison read needs a new method signature |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentLeaderboardEndpoints.cs` | Modify (32-10) — persona `?role=`, `?personaId=`, `&credentialSource=`, `&promptVersion=` facets |
+| `apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/BenchmarkDtos.cs` | Modify (32-10) — `PersonaLeaderboardRow` + facet-breakdown DTO |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/BenchmarkProjection.cs` | Modify (32-10) — ONLY if AC2 facets are persisted columns (else query-time; no change) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify — ONLY if persisted facet columns are added (additive, tenant entity) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/<ts>_AddPersonaBenchmarkFacets.cs` | Create — ONLY if persisted facet columns are added (additive **Tenant** migration) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/BenchmarkIsolationTests.cs` | Modify (32-10) — add persona-dimension isolation case |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/BenchmarkProjectionServiceTests.cs` | Modify (32-10) — add persona key + equivalence + lifecycle cases |
 
-> The 32-6 shared trail-tag builder is extended to carry `personaId`/`personaName`; the exact file lands when 32-6 is implemented — coordinate so the persona tags are added to the single shared builder rather than per emission site.
+> **Prefer the no-schema-change path:** compute the facets at query time from the folded sub-keys. Persist facet columns (the last three rows) **only** if query-time aggregation proves too costly. Either way, this is a **Tenant** migration (owned by `EfTenantDbMigrator`), never a control-plane table — so the `Program.cs` DROP list and `ControlPlaneDbContextModelTests` are untouched.
 
 ## Dev Notes
 
@@ -347,48 +287,86 @@ Tests are xUnit under `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/` (and `Pers
 
 Before implementing this story, ensure you have:
 
-1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
 2. Searched `.dev/` for related spikes, bugs, findings, decisions (esp. `feedback_resolution_no_empty_fallback`)
-3. Read the Epic 32 design of record: `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`
-4. Confirmed which `Agent`/`AgentVersion` fields and which enums (`AgentVisibility`/`AgentStatus`) Story 32-1 actually shipped, and which resolve methods + `ResolvedAgentConfig` fields Story 32-2 shipped — every **(coordinate with 32-1/32-2)** marker must be reconciled before coding
-5. Reviewed the Prompt Store RBAC + per-mode precedent (`PromptEndpoints.cs`, `PromptManage`) and the 32-1/32-2 agent ownership/visibility pattern this mirrors
+3. Read the design of record §3.0 (the reframe table — persona = named cross-role system agent) and §3.4 (disposition of 32-12 — rewrite + split the style overlay to 32-19) IN FULL
+4. Read **32-10** (the benchmark projection + leaderboard + `persona` dimension + cursor + isolation you extend) and **32-15** (the persona-agent identity you key on) — confirm 32-10's `persona` dimension key and `BenchmarkProjection` shape before refining them
+5. Confirmed which trail tags 32-6/32-9 actually emit (`agentId`/`agentVersion`/`provider`/`promptRef`/`credentialSource`) so the facet extraction reads real keys
 6. Planned the TDD approach (Red-Green-Refactor)
 
 ### Key design decisions
 
-- **A persona is an overlay, not a fork.** The whole point is one agent definition, many styles — so the persona carries no provider/model/credential fields and composes at resolution time into a *new* `ResolvedAgentConfig`. Cloning an agent to change its tone would defeat the benchmark ("which style?" becomes unanswerable like-vs-like). This is the design-of-record's "personas are named variants within a role."
-- **Stable name is the join key.** Persona benchmark history must survive style edits, exactly as agent history survives config edits (32-1). Edit ⇒ `PERSONA.UPDATED.SUCCESS` audit event, never a new identity.
-- **Role-scoped so comparisons are like-vs-like.** A persona is bound to a role; leaderboards group by `(role, personaId)`. Comparing a reviewer persona to an architect persona is meaningless, so the model forbids it structurally.
-- **Fail loud, never plain.** A requested-but-unresolvable persona (or fragment) is a hard error — the load-bearing project rule. The only "no persona" path is an explicit `personaId == null`, which returns the plain agent config unchanged.
-- **Reuse 32-1 enums + the ownership/visibility pattern wholesale.** Personas mirror agents byte-for-byte on visibility, ownership XOR CHECK, per-owner partial indexes, and 404-not-403 cross-tenant reads. Do not invent a parallel ownership model.
-- **Data is always tenant-scoped.** Even running a *public* persona, the per-persona benchmark data belongs to the resolving tenant — the platform owner who authored the public persona sees none of any tenant's per-persona metrics.
+- **Persona = the named system agent, NOT a style overlay.** This is the whole reframe (design §3.0/§3.4). The persona dimension keys on the 32-15 persona-agent identity (`AgentId`/`AgentName` = `claude`/`gemini`/`codegpt`). The old "style/tone variant within a role" is a **different** feature, split out to 32-19. No `Persona` table, no `PersonaComposer`, no `StyleJson` here.
+- **No new entity; ride 32-10.** Benchmarking already exists; this is a persona-aware *refinement* of 32-10's `persona` dimension + facets + the comparison query. Building a parallel projection would fork the read model — forbidden.
+- **Facets disambiguate a persona's runs.** Provider/model/promptVersion/`credentialSource` are flat-string facets so "`claude` on BYOK vs platform" and "`claude` under prompt v3 vs v4" are answerable within one persona, without comparing across roles or tenants.
+- **Like-vs-like within a role.** A persona is cross-role (32-15), but a comparison is always scoped to **one role** — `(role, agentId)` — so "best reviewer persona" is meaningful and "reviewer vs architect" is structurally impossible.
+- **Data is always tenant-scoped.** Even for a *public* persona, the per-persona benchmark belongs to the resolving tenant; the platform owner who curates the persona sees none of any tenant's per-persona metrics (design ownership rule). The only cross-tenant view is 32-10's k-anonymous public-agent fleet rollup — owned there.
+- **Fail loud on malformed, explicit-unknown on absent.** A bad `dimension` throws; an absent facet tag buckets to an explicit `unknown` (never silently merged) — `feedback_resolution_no_empty_fallback`, applied to projection facets.
 
-### Migration discipline (Epic 28 conventions)
+### Codebase gotchas (baked into the AC)
 
-- `personas` is an **additive** table — a normal `dotnet ef migrations add AddPersonaEntity --context ControlPlaneDbContext`, not a baseline CHECK edit.
-- After adding, run `dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext` → must report none.
-- Mirror entity config **only** in `TammaModelConfiguration.cs` (the single source); the snapshot/Designer are generated, not hand-edited.
-- Run C# tests with `sg docker -c "dotnet test ..."` (session docker group is stale; build needs no wrapper).
+- **No control-plane table → no DROP list / no model-contract churn.** The persona is the 32-15 public `Agent` (already CP-registered); the benchmark rows are 32-10's **tenant-schema** entities (owned by `EfTenantDbMigrator`). So nothing is appended to `Program.cs`'s "Wiping Tamma-managed public-schema tables" DROP list, and `ControlPlaneDbContextModelTests` is not edited (AC9).
+- **Per-tenant cursor rule.** The fold cursor is the tenant-schema `domain_events.SequenceNumber` (an independent per-schema `BIGSERIAL`); the persona projection cursor is composite-keyed including `TenantId` — **no shared global cursor across tenants** (32-10's rule, reaffirmed for the persona dimension). Compliance/billing/audit-grade isolation depends on it.
+- **`PlatformOwnerAccess`, never `OwnerAccess`.** Persona-catalogue curation (32-15) is `PlatformOwnerAccess`; persona *benchmark reads* are tenant-member (`MemberAccess` + `RequireTenantMembershipFilter`). There is no platform-global persona-benchmark admin route here (the k-anonymous public-agent rollup is 32-10's).
+- **Sequential migration discipline.** If facets are persisted, it is a single additive **Tenant** migration on the existing linear snapshot (not a branch); `has-pending-model-changes` → none.
 
 ### Edge cases
 
-- Persona whose `Role` differs from the requested role → `PERSONA.ROLE_MISMATCH` 400 (never composed onto a mismatched agent).
-- Archived persona requested at resolve → treat as not-found (404); a persona archived mid-flight does not retroactively rewrite past trail tags.
-- `SystemPromptFragmentRef = null` → no fragment append; style merge still applies (a style-only persona is valid).
-- Public persona name collision with an existing handle → 409 (partial unique index), no event.
-- Two tenants each own a private persona `atlas`/`reviewer` → allowed (per-owner partial index); benchmarks stay separate.
+- A persona used for two roles (cross-role by design) → two separate per-role rows; a comparison always names a role, so the rows never collide.
+- A run with no `credentialSource` tag (pre-32-5) → explicit `unknown` facet bucket; backfilled on the next rebuild once 32-5/32-9 land (never silently merged into `byok`/`platform`).
+- A persona a tenant never enabled (32-16) → zero runs → absent from the tenant's leaderboard (no synthetic row).
+- Two tenants both running public persona `claude` → separate per-tenant rows; neither sees the other; the platform owner sees neither (only the k-anonymous fleet rollup, 32-10).
+- A persona archived in 32-15 mid-window → its historical persona rows are unchanged (the fold is over immutable trail events); no retroactive rewrite.
+
+### Migration discipline (Epic 28 conventions, only if facets are persisted)
+
+- Facet columns (if added) are an **additive Tenant** migration: `dotnet ef migrations add AddPersonaBenchmarkFacets` against the **Tenant** context (the `InitialTenant` baseline exists — additive, not a baseline edit), `has-pending-model-changes` → none.
+- Mirror entity config **only** in `TammaModelConfiguration.cs`; the snapshot/Designer are generated, not hand-edited.
+- Tenant-schema tables do **not** go in the `Program.cs` DROP list (the per-tenant `EfTenantDbMigrator` owns them) and do **not** touch `ControlPlaneDbContextModelTests`.
+- Run C# tests with `sg docker -c "dotnet test ..."` (session docker group is stale; build needs no wrapper).
+
+## Risks & Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Persona dimension still keyed by a style row (old model leaks through) | High | AC1 pins the key to the 32-15 persona-agent `AgentId`; explicit test asserts the key is the persona-agent identity, never a tone/verbosity value; no `Persona`/`StyleJson` type exists. |
+| Cross-tenant leakage of per-persona performance data | Critical | Reuse 32-10's structural isolation (`ITenantDbContextFactory`, null-tenant-guarded reads, no cross-tenant route, per-tenant composite cursor); explicit isolation test incl. platform-admin-denied. |
+| A facet silently merges absent values (no-empty-fallback regression) | High | Absent facet → explicit `unknown` bucket; malformed dimension → throw; facet-bucketing test asserts no silent merge. |
+| Reimplementing the 32-10 fold/metrics (drift) | High | This story keys + facets only; metrics come from the same 32-10 reducer; assert identical numbers for the same runs; no second fold. |
+| `credentialSource` facet depends on un-landed 32-5/32-9 | Medium | Facet degrades to explicit `unknown`, backfilled on rebuild once the tag exists; align the tag name with 32-9 before merge; never invent a parallel usage event. |
+| Cross-role persona comparison sneaks in | Medium | Persona key is `(role, agentId)`; the comparison query always names a role; test asserts an architect-role persona never appears in the reviewer leaderboard. |
+| Accidental CP table / DROP-list churn | Medium | AC9: no CP table (persona = 32-15 public `Agent`; rows are tenant-schema 32-10 entities); facets (if persisted) are a Tenant migration; `ControlPlaneDbContextModelTests` untouched. |
+
+## Success Metrics
+
+- [ ] The persona benchmark dimension is keyed by the 32-15 persona-agent identity (`AgentId`/`AgentName`); grep finds no `Persona`/`StyleJson`/`PersonaComposer` type introduced by this story.
+- [ ] A tenant can rank `claude`/`gemini`/`codegpt` as a reviewer (like-vs-like within a role) and drill into one persona's provider/model/promptVersion/`credentialSource` facets — on its own data only.
+- [ ] Persona benchmark data is provably tenant-scoped (isolation suite green; platform admin denied per-tenant; the only cross-tenant view is 32-10's k-anonymous public-agent rollup).
+- [ ] Incremental and full-rebuild persona rows are byte-identical; the per-tenant composite cursor never crosses tenants.
+- [ ] No control-plane table added; `has-pending-model-changes` reports none; the `Tamma.Api.Tests` suite is green.
+
+## Related
+
+- Design of record: `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§3.0 reframe table; §3.1 persona = named cross-role system agent; §3.4 disposition of 32-12 — rewrite + split style overlay to 32-19)
+- Re-plan: `docs/superpowers/plans/2026-06-20-epic-32-37-replan.md` (story disposition + sequence)
+- Implementation plan: `docs/superpowers/plans/2026-06-21-32-12-persona-aware-benchmarking-plan.md`
+- Prerequisites: `docs/stories/epic-32/story-32-10/32-10-benchmark-projections-and-leaderboards.md` (the projection + leaderboard + persona dimension + cursor + isolation this story extends), `docs/stories/epic-32/story-32-15/32-15-persona-reframe-and-seeding.md` (the persona-agent identity)
+- Sibling stories: 32-6 (action trail), 32-8 (outcome/defect), 32-9 (usage/cost), 32-5 (call-LLM), 32-16 (enablement), 32-13 (dashboards), 32-14 (A/B), **32-19** (style/voice variants — the split-out style overlay; NOT a dependency)
 
 ## Logging Requirements
 
-- **INFO**: persona created / updated / archived (`personaId, personaName, role, visibility`), persona applied at resolution (`personaId, agentId, role, mode`).
-- **DEBUG**: composition merge summary (which style fields overridden, fragment appended yes/no — never the fragment body), visibility-scoped persona list resolved (`count, mode, tenantId?`).
-- **WARN**: requested persona not visible / role-mismatch surfaced as 404/400 (`personaId, requestedRole, personaRole`), member-role 403 on write, tenant public-write 403.
-- **ERROR**: non-null `SystemPromptFragmentRef` unresolvable (fail-loud — `personaId, fragmentRef`), event append failure after a real compose, migration/DB write failure.
-- **Structured context**: include `{ personaId, personaName, agentId, agentVersion, role, mode, tenantId }` where applicable.
-- **Credential safety**: personas are credential-agnostic and provider-agnostic by design (style + fragment ref only); never log raw `StyleJson` if it could carry sensitive hints and never log resolved fragment bodies.
+- **INFO**: persona projection fold completed (`tenantId, dimension:"persona", window, rowsUpdated, lastSequenceNumber`); persona leaderboard served (`tenantId, role, window, rankedCount, belowThresholdCount`); persona detail served (`tenantId, personaId, role, facetCount`).
+- **DEBUG**: per-persona fold step (`personaId, role, facet sub-key, sequenceNumber`); facet bucketing (which facet, `unknown`-bucket yes/no — never the underlying value if sensitive).
+- **WARN**: absent facet tag bucketed to `unknown` (`personaId, facet` — surfaced, not silently dropped); persona leaderboard requested with an unknown dimension/role; min-sample-suppressed persona row (`personaId, runCount, minRuns`).
+- **ERROR**: malformed dimension key (`BENCHMARK.DIMENSION.INVALID`), projection-write failure after retries (the run is unaffected — 32-10 non-blocking contract), repository/migration failure.
+- **Structured context**: include `{ tenantId, dimension:"persona", personaId, personaName, role, provider, model, promptRef, credentialSource, window, sequenceNumber, runCount }` where applicable.
+- **Credential / privacy safety**: persona benchmarking is **credential-agnostic** — `credentialSource` is the **label** `byok`/`platform`/`unknown` only; **never** log, store, or surface a raw API key, prompt body, or `ConfigJson`. NEVER log a tenant id inside any cross-tenant path (there is none for persona benchmarks); the persona leaderboard payload is key-free and prompt-body-free by contract.
 
 ## Change Log
 
 | Date       | Version | Changes                | Author |
 | ---------- | ------- | ---------------------- | ------ |
-| 2026-06-17 | 1.0.0   | Initial story creation | Claude |
+| 2026-06-17 | 1.0.0   | Initial story creation — "persona = style/tone overlay within a role" (`atlas`/`nova`), a new `Persona` entity + `PersonaComposer` + style-aware benchmarking. | Claude |
+| 2026-06-21 | 2.0.0   | **Vocabulary reframe to the locked model** (design §3.0/§3.4). "Persona" everywhere now = the **named cross-role public/system agent** (`claude`/`gemini`/`codegpt`) from sibling **32-15** — keyed by the persona-agent `AgentId`/`AgentName`, NOT a style overlay. The style/voice overlay (`atlas`/`nova` tone/verbosity) is **split out to new optional sibling 32-19 "Agent style/voice variants"** (a *variant*, not a persona) and all style-overlay-as-persona framing is removed. **No new entity** — the persona-aware benchmark now **rides 32-10's** existing `persona` dimension: refines its dimension key to the persona-agent identity, adds **provider/model/prompt-version/`credentialSource` facets**, and exposes the like-vs-like-within-a-role persona-comparison query. Per-tenant scoping (data ALWAYS tenant-scoped), the per-tenant `SequenceNumber` cursor rule, the no-CP-table/no-DROP-list/no-model-contract-churn gotchas, and the no-empty-fallback (explicit-`unknown` bucket) discipline are made explicit. The dropped `Persona` table, `PersonaComposer`, `StyleJson`, persona CRUD endpoints, and the persona-composition resolver path are removed (those belonged to the superseded style model / now 32-15 + 32-19). | Claude |
+</content>
+</invoke>

--- a/docs/stories/epic-32/story-32-15/32-15-persona-reframe-and-seeding.md
+++ b/docs/stories/epic-32/story-32-15/32-15-persona-reframe-and-seeding.md
@@ -1,0 +1,409 @@
+# Story 32-15: Persona Reframe + Seeding (Role-nullable cross-role personas)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-Phase Development Workflow (Read → Research → Break Down → TDD → Quality Gates → Failure Handling), Knowledge Base usage (`.dev/` directory), TRACE/DEBUG logging requirements, Test-Driven Development, 100% critical-path coverage, and build-success enforcement.
+
+**Failure to follow this process will result in rework.**
+
+## User Story
+
+As a **platform owner (who curates the public agent catalogue) and a tenant whose users pick an agent for any role**,
+I want **public/system agents to be named, cross-role PERSONAS (`claude`/`gemini`/`codegpt`) that preset a real provider + an explicit model, with prompts coming from the Epic 27 prompt store rather than the persona config**,
+So that **one persona serves every role (no more 8 `tamma-<role>` rows on a single provider chain), each persona pins its own provider+model so they no longer all collapse to `claude-sonnet-4`, and the role/system prompt stays the single Epic 27-owned source of truth (personas are prompt-free) — implementing rules 4 and the "public agent → cross-role persona" reframe of the locked agent model.**
+
+## Priority
+
+P0 — Sequence step **B** in the Epic 32 redesign (`docs/superpowers/plans/2026-06-20-epic-32-37-replan.md` §4). This is the amendment that makes public agents *exist as personas at all*; the per-tenant enablement (32-16), custom-agent prompts (32-17), the registry enablement gate (32-18), and the call-LLM endpoint (32-5, lynchpin F) all resolve against the persona shape this story establishes. It directly amends the **shipped** 32-1 entity model (on `main`).
+
+## Context
+
+The shipped 32-1 (`docs/stories/epic-32/story-32-1/32-1-agent-entity-model-and-versioned-saved-config.md`) created the `Agent` / `AgentVersion` control-plane entities and seeded **one public agent per role** as `tamma-<role>` handles (`tamma-architect`, `tamma-tester`, …) on a single provider chain, with `Agent.Role` a **required identity column** and a public unique index on `(Name, Role)`. The seeded `AgentVersion.ConfigJson` **omits `model`** and relies on `DefaultAgentConfig.ForRole(role)` to fill in `claude-sonnet-4` — fine when every public agent is Anthropic, wrong the moment personas differ by provider.
+
+The locked model (`docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` §3.0–§3.1) redefines "public agent":
+
+| Term | 32-1 as built | Locked model (rule 4) |
+|---|---|---|
+| **Public agent** | per-role `tamma-<role>`, role IS its identity, one provider chain | a **named PERSONA** (`claude`/`gemini`/`codegpt`) presetting provider+model+config, usable across **ALL roles**; role is NOT its identity |
+| **Persona** | (the style-overlay idea in old 32-12) | the **system agent itself** — preset provider+model+config; prompts from Epic 27, **no custom prompts** |
+| **Selection** | per-`(principal,role)` pick of any visible agent | per-`(principal,role)` pick, constrained to the tenant's enabled set (32-16) |
+
+**The entity model from 32-1 is sound and KEPT.** What changes is (1) `Role` stops being identity for public personas (becomes nullable), (2) the public unique index drops `Role`, (3) the seeder produces named cross-role personas with explicit provider+model, (4) `GetSystemDefaultPublicAsync(role)` stops looking up "the public agent whose `Role==role`" and returns the platform-configured **default persona**, and (5) `AgentResolverService.MaterialiseAsync` pulls the persona's system/role prompt from the **Epic 27 store** keyed `(principal, role, action)` instead of from the persona config (personas are prompt-free).
+
+**Scope boundaries (cross-referenced siblings — NOT owned here):**
+- The **per-tenant enablement** gate (`TenantAgentEnablement` + `IsEnabledForPrincipal`) is **32-16**.
+- The **custom-agent prompt branch** (`ConfigJson.prompts` for private agents + the resolver's private-prompt path) is **32-17**.
+- The **registry-side enablement gate** in `IAgentRegistryService.SelectForRoleAsync`/`ResolveUsableAgentAsync`/`CanUse` is **32-18** (amends 32-2).
+
+This story owns the **entity schema amendment** (Role nullable + index change), the **seeder rewrite** (named cross-role personas, explicit model, `DefaultPersonaName`), the **`GetSystemDefaultPublicAsync` rewrite** (configured default persona, delete the per-role ambiguity warning), and the **persona-prompt-source seam `IPersonaPromptResolver`** (public/persona → Epic 27) plus the wiring of `MaterialiseAsync`'s public branch to that seam. It does NOT add a new table.
+
+## Acceptance Criteria
+
+1. **`Agent.Role` becomes nullable.** The entity property `Role` changes from `string` (required) to `string?` (`Tamma.Data/Entities/Agent.cs`), and the EF config in `TammaModelConfiguration.cs` drops `.IsRequired()` on `Role` (keeps `HasMaxLength(64)`). A new additive migration under `Migrations/ControlPlane/` alters the `agents.Role` column to `NULL`-able. Public personas are seeded with `Role = NULL` (cross-role). Private/custom agents MAY keep a non-null `Role` (their role-binding is unchanged).
+
+2. **The public unique index drops `Role`.** `IX_agents_public_name_role` on `(Name, Role) WHERE Visibility='public'` is replaced by **`IX_agents_public_name` on `(Name) WHERE Visibility='public'`** (persona handles are globally unique among public agents). The two private partial indexes (`IX_agents_private_tenant_name`, `IX_agents_private_user_name`) are **unchanged**. The migration drops the old index and creates the new one. `Role` is removed from the seeder's idempotency/skip-by-existing key (now keyed by `Name` alone for public rows).
+
+3. **`AgentEntitySeeder` is rewritten to seed named cross-role personas.** Instead of 8 `tamma-<role>` rows on one provider chain, it seeds **N named cross-role personas** (`claude`, `gemini`, `codegpt`/`gpt`, optionally an OpenRouter-backed persona), each `Visibility='public'`, `Role=NULL`, `OwnerTenantId/OwnerUserId NULL`, with a `Version=1` `AgentVersion` whose `ConfigJson` carries an **explicit `provider` AND `model`**:
+   - `claude` → `{ provider: "anthropic", model: "claude-sonnet-4-20250514", … }`
+   - `gemini` → `{ provider: "google", model: "gemini-2.5-pro", … }`
+   - `codegpt` (alias `gpt`) → `{ provider: "openai", model: "gpt-4o", … }`
+   - (optional) `openrouter-*` → `{ provider: "openrouter", model: "…", … }`
+   The model strings MUST be ones `IProviderPricingService.IsKnown(provider, model)` accepts (cost basis must resolve — depends on **34-11** the Provider Cost Price-Book). The seeded `ConfigJson` carries **no prompts** (personas are prompt-free by contract). `ConfigJson` MAY carry a per-role hint block (e.g. `{ roles: { reviewer: { temperature: 0.2 } } }`), but the persona is selectable for any role.
+
+4. **Seeder is insert-missing-only (idempotent), keyed by persona name.** Mirroring `ConventionStoreSeeder`, re-running the seeder inserts nothing for a persona whose `Name` already exists as a public agent (skip-by-existing-handle), and **never reverts an admin edit** to an existing persona's config or version. A first run creates each persona + its `Version=1`; a second run is a no-op (0 created, N skipped). The seeder no longer creates `tamma-<role>` rows; migrating/retiring any previously-seeded `tamma-<role>` rows is handled per AC11.
+
+5. **`GetSystemDefaultPublicAsync(role)` is rewritten.** It no longer searches for "the public agent whose `Role==role`." It returns the platform's configured **default persona** identified by a new config value **`DefaultPersonaName`** (e.g. `Tamma:Agents:DefaultPersonaName = "claude"`), resolved by persona `Name` among `Visibility='public'` agents, **regardless of `role`**. The per-role ">1 public agent for this role" ambiguity warning is **deleted** (it is meaningless once public agents are cross-role). If the configured default persona does not exist, the method **fails loud** (no empty/plain fallback, per `feedback_resolution_no_empty_fallback`).
+
+6. **`AgentResolverService.MaterialiseAsync` keeps its merge + stamp, but the prompt source changes — shipped as an injectable seam.** It still merges the resolved agent's `ConfigJson` onto `DefaultAgentConfig.ForRole(role)` and stamps `AgentId`/`AgentVersion` onto the materialised `ResolvedAgentConfig`. **The system/role prompt for public/persona agents now comes from the Epic 27 prompt store** keyed `(principal, role, action)` — NOT from the persona config. This story ships that as an explicit injectable seam: a new interface **`IPersonaPromptResolver`** with `Task<RenderedPrompt> ResolveAsync(Principal principal, string role, string? action, CancellationToken ct)` that reads the Epic 27 prompt store `(principal, role, action)` and is **fail-loud, never empty/plain** (tenant → system → error). `MaterialiseAsync`'s PUBLIC branch calls this seam (NOT an inline `_promptStore.ResolveAsync`). This is the key wiring change of the story — it ships the SEAM, not an inline resolve.
+
+7. **Persona-prompt-source branch is documented and tested as the public path via the `IPersonaPromptResolver` seam; the custom-agent (private) prompt path is delegated to 32-17.** `MaterialiseAsync` resolves the prompt source by visibility: `Visibility='public'` (persona) → `IPersonaPromptResolver.ResolveAsync(principal, role, action)` (32-15, this story; reads the Epic 27 store). The `Visibility='private'` branch (custom agent's own embedded prompts) is the parallel seam **`ICustomAgentPromptResolver`** owned by **32-17** and wired there; this story leaves a clearly-marked seam/extension point and does not implement the private-prompt branch. Both branches fail loud.
+
+8. **No new table; the changed schema stays in sync with the 32-1 contracts.** `Agent`/`AgentVersion` remain the control-plane tables introduced by 32-1 (already in the `Program.cs` startup-reset DROP list and in `ControlPlaneDbContextModelTests`). This story adds **no** table, so it adds nothing to the DROP list, but the **nullable `Role` column and the renamed index MUST be reflected** in `ControlPlaneDbContextModelTests.Model_Has_ExpectedControlPlaneEntities` / the index assertions so the strict model contract test stays green.
+
+9. **Migration applies cleanly** and `dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext` reports **none** after it is added. The migration is a single additive amendment on the existing linear snapshot (alter `Role` to nullable + drop `IX_agents_public_name_role` + create `IX_agents_public_name`); it does NOT branch or rewrite the 32-1 baseline. The full `Tamma.Api.Tests` suite stays green.
+
+10. **RBAC is unchanged for persona CRUD.** Public-catalogue writes (creating/editing/seeding personas) remain `PlatformOwnerAccess` (NOT `OwnerAccess`, which admits every personal-tenant owner). No tenant- or member-level write path to public personas is introduced. Reads of public personas remain available to any principal.
+
+11. **Disposition of legacy `tamma-<role>` rows is explicit and idempotent.** Because 32-1 already seeded 8 `tamma-<role>` public rows on `main`, the seeder/migration documents and applies a deterministic disposition: the new persona seeder does NOT create `tamma-<role>` rows; any pre-existing `tamma-<role>` public rows are left in place (archive, never destructive-delete — versions are immutable history) OR archived via `Status='archived'` so the default-persona resolution and enablement (32-16) operate over the named personas. The chosen disposition is insert-missing-only safe and re-runnable. (No-migration-anxiety per CLAUDE.md applies — app is pre-production — but the seeder must still be idempotent.)
+
+12. **DCB events are emitted on real state transitions only.** The persona seeder emits `AGENT.CREATED.SUCCESS` per newly-created persona (tags `{ agentId, version: 1, visibility: "public", role: null, personaName, provider, model, mode }`) and `AGENT.VERSION_PUBLISHED.SUCCESS` only when a version is actually written — never a "lie" event for a skipped (already-existing) persona. Archiving a legacy `tamma-<role>` row (AC11) emits `AGENT.ARCHIVED.SUCCESS`. Events go to the control-plane `DomainEvents` store with `TenantId = NULL` (platform feed, mirroring 32-1).
+
+13. **Unit + integration tests** cover: nullable-`Role` round-trip (insert a `Role=NULL` public persona, read it back); the public unique index now rejects a duplicate `Name` across any/no role and **allows** what `(Name,Role)` formerly required to differ; seeder creates N named personas with explicit provider+model and `Role=NULL`; seeder idempotency (2nd run = 0 created); seeder never reverts an admin-edited persona; `GetSystemDefaultPublicAsync` returns the `DefaultPersonaName` persona regardless of `role` and fails loud when it is absent; the deleted ambiguity warning no longer fires; `MaterialiseAsync` sources the prompt from Epic 27 for a public persona (and fails loud when Epic 27 returns nothing); the model-contract test reflects the nullable column + renamed index.
+
+14. **Logging**: structured `ILogger<>` logs at INFO for seeder summary (`created, skipped` + persona names) and default-persona resolution (`personaName, role`), DEBUG for prompt-source selection (`visibility, role, action`), WARN for a missing configured default persona / a persona whose model is not `IsKnown` (surfaced before write), ERROR for migration/transaction failure — never logging raw `ConfigJson`. Credential-agnostic by design: persona config carries provider+model, **never a key**; nothing in this path logs a credential (see Logging Requirements).
+
+## Technical Design
+
+### C# namespace / file structure
+
+```
+apps/tamma-elsa/src/
+  Tamma.Data/
+    Entities/
+      Agent.cs                              # MODIFY — Role: string -> string?
+    TammaModelConfiguration.cs              # MODIFY — Role drops .IsRequired(); index (Name,Role)->(Name)
+    Migrations/ControlPlane/
+      <ts>_PersonaReframeRoleNullable.cs     # NEW — alter Role nullable + swap public index
+  Tamma.Api/
+    Services/Agents/
+      IPersonaPromptResolver.cs             # NEW — persona/public prompt seam (reads Epic 27 (principal, role, action), fail-loud)
+      PersonaPromptResolver.cs              # NEW — impl over the Epic 27 IPromptStore
+      AgentResolverService.cs               # MODIFY — MaterialiseAsync PUBLIC branch calls IPersonaPromptResolver
+      AgentRegistryService.cs               # MODIFY — GetSystemDefaultPublicAsync rewrite; delete ambiguity warning
+      DefaultPersonaOptions.cs              # NEW — bind Tamma:Agents:DefaultPersonaName
+    Program.cs                              # MODIFY — bind DefaultPersonaOptions; (no new routes)
+  Tamma.ElsaServer/  (or Tamma.Api seeding host — same host 32-1 used)
+    AgentEntitySeeder.cs                    # MODIFY (rewrite) — named cross-role personas, explicit model
+```
+
+> The `AgentEntitySeeder` rewritten here is the **same** class 32-1 introduced (CP-resident, insert-missing-only). It stops producing `tamma-<role>` rows and produces named personas instead. The legacy `Tamma.ElsaServer/AgentSeeder.cs` (the Elsa Agents store) is untouched by this story.
+
+### Entity change (`Agent.cs`)
+
+```csharp
+public class Agent
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;     // persona handle, globally unique among public agents
+    public string? Role { get; set; }             // CHANGED: nullable — NULL for cross-role public personas
+    public AgentVisibility Visibility { get; set; }
+    public Guid? OwnerTenantId { get; set; }
+    public Guid? OwnerUserId { get; set; }
+    public AgentStatus Status { get; set; } = AgentStatus.Active;
+    public Guid? CurrentVersionId { get; set; }
+    // … CreatedAt/By, UpdatedAt/By, Versions unchanged …
+}
+```
+
+### EF config change (`TammaModelConfiguration.cs`)
+
+```csharp
+modelBuilder.Entity<Agent>(entity =>
+{
+    // … ToTable + ck_agents_visibility_ownership CHECK unchanged …
+    entity.Property(e => e.Name).IsRequired().HasMaxLength(128);
+    entity.Property(e => e.Role).HasMaxLength(64);          // CHANGED: no .IsRequired()
+
+    // CHANGED: public handles unique on (Name) alone — personas are cross-role
+    entity.HasIndex(e => e.Name)
+        .IsUnique().HasFilter("\"Visibility\" = 0")          // 0 = Public
+        .HasDatabaseName("IX_agents_public_name");
+    // Private partial indexes UNCHANGED
+    entity.HasIndex(e => new { e.OwnerTenantId, e.Name })
+        .IsUnique().HasFilter("\"Visibility\" = 1 AND \"OwnerTenantId\" IS NOT NULL")
+        .HasDatabaseName("IX_agents_private_tenant_name");
+    entity.HasIndex(e => new { e.OwnerUserId, e.Name })
+        .IsUnique().HasFilter("\"Visibility\" = 1 AND \"OwnerUserId\" IS NOT NULL")
+        .HasDatabaseName("IX_agents_private_user_name");
+});
+```
+
+> The `ck_agents_visibility_ownership` CHECK is **unaffected** — it constrains `Visibility`/owner columns, not `Role`. A public persona with `Role=NULL` still satisfies `Visibility='public' ⇒ OwnerTenantId IS NULL AND OwnerUserId IS NULL`.
+
+### Migration (additive amendment, single snapshot)
+
+```
+ALTER TABLE agents ALTER COLUMN "Role" DROP NOT NULL;
+DROP INDEX  "IX_agents_public_name_role";
+CREATE UNIQUE INDEX "IX_agents_public_name" ON agents ("Name") WHERE "Visibility" = 0;
+-- (legacy tamma-<role> disposition handled by the seeder at startup, not in DDL — AC11)
+```
+
+`dotnet ef migrations add PersonaReframeRoleNullable --context ControlPlaneDbContext` against the existing 32-1 snapshot; then `has-pending-model-changes` → none. **No baseline rewrite, no branch** — this extends the linear chain (EF parallel-migration hazard: stories are implemented sequentially on one snapshot).
+
+### Seeder rewrite (`AgentEntitySeeder`)
+
+```csharp
+// Deterministic UUIDv7 per persona name; insert-missing-only (skip if a public agent named X exists).
+private static readonly IReadOnlyList<PersonaSeed> Personas = new[]
+{
+    new PersonaSeed("claude",  "anthropic", "claude-sonnet-4-20250514"),
+    new PersonaSeed("gemini",  "google",    "gemini-2.5-pro"),
+    new PersonaSeed("codegpt", "openai",    "gpt-4o"),          // alias: gpt
+    // new PersonaSeed("openrouter-claude", "openrouter", "anthropic/claude-3.5-sonnet"),  // optional
+};
+
+// For each persona:
+//   if exists public agent with Name == persona.Name  -> skip (no event)         [AC4]
+//   else create Agent { Name, Role = null, Visibility = Public, owners = null }   [AC1/AC3]
+//        + AgentVersion v1 { ConfigJson = { provider, model, params, /* NO prompts */ } }
+//        validate provider+model via IProviderPricingService.IsKnown (warn+skip-write if unknown) [AC3/AC14]
+//        emit AGENT.CREATED.SUCCESS { agentId, version:1, visibility:"public", role:null,
+//                                     personaName, provider, model, mode }          [AC12]
+```
+
+`PersonaSeed.ConfigJson` is built from the existing `AgentConfigValidator` shape (provider regex, budget range, ReDoS guard, prototype-pollution rejection) extended in 32-1, with an **explicit `model`** and **no `prompts`** block. Validation runs before any write.
+
+### `GetSystemDefaultPublicAsync` rewrite (`AgentRegistryService`)
+
+```csharp
+// BEFORE (32-2): find the public agent whose Role == role; warn if >1.
+// AFTER (this story): return the configured default persona, role-independent.
+public async Task<Agent> GetSystemDefaultPublicAsync(string role, CancellationToken ct)
+{
+    var name = _defaultPersona.Value.DefaultPersonaName;        // "claude" by default
+    var persona = await _agents.GetPublicByNameAsync(name, ct);  // Visibility='public' AND Name==name
+    if (persona is null)
+        throw new TammaError("AGENT_DEFAULT_PERSONA_MISSING",
+            $"Configured default persona '{name}' is not seeded; cannot resolve a default for role '{role}'.",
+            retryable: false, severity: Severity.High);          // FAIL LOUD — no empty fallback [AC5]
+    // NOTE: the ">1 public agent for role" ambiguity warning is DELETED — public agents are cross-role.
+    return persona;
+}
+```
+
+`DefaultPersonaName` is bound from `Tamma:Agents:DefaultPersonaName` (default `"claude"`). In 32-16 this method additionally constrains to the tenant's **enabled** personas; that constraint is added there, not here.
+
+### `IPersonaPromptResolver` seam + `MaterialiseAsync` wiring (`AgentResolverService`)
+
+This story ships the persona/public prompt branch as an **explicit injectable seam** — `IPersonaPromptResolver` — rather than an inline `_promptStore.ResolveAsync` call inside `MaterialiseAsync`. The custom/private branch is the parallel `ICustomAgentPromptResolver` seam owned by 32-17.
+
+```csharp
+// NEW seam (this story owns it). The PUBLIC/persona prompt leg.
+public interface IPersonaPromptResolver
+{
+    /// <summary>Resolve a persona's system/role prompt from the Epic 27 store keyed
+    /// (principal, role, action). Tenant -> system -> ERROR; fail-loud, NEVER empty/plain.</summary>
+    Task<RenderedPrompt> ResolveAsync(Principal principal, string role, string? action, CancellationToken ct);
+}
+
+// PersonaPromptResolver impl reads the Epic 27 IPromptStore and fails loud on a miss:
+//   var rendered = await _promptStore.ResolveAsync(principal, role, action, ct)
+//       ?? throw new TammaError("PROMPT_UNRESOLVED",            // tenant->system->error
+//              $"No Epic 27 prompt for ({role},{action}); personas carry no prompts.",
+//              retryable: false, severity: Severity.High);
+//   return rendered;
+```
+
+```csharp
+// AgentResolverService.MaterialiseAsync — merge + stamp are KEPT (32-1/32-2); the PROMPT SOURCE is the seam.
+var merged = DefaultAgentConfig.ForRole(role).MergeWith(agent.CurrentVersion.ConfigJson);
+merged.AgentId      = agent.Id;          // stamp (unchanged)
+merged.AgentVersion = agent.CurrentVersion.Version;
+
+// KEY CHANGE: prompt no longer comes from persona config — it comes from the IPersonaPromptResolver seam.
+if (agent.Visibility == AgentVisibility.Public)               // PERSONA -> IPersonaPromptResolver -> Epic 27
+{
+    merged.SystemPrompt = (await _personaPrompts.ResolveAsync(principal, role, action, ct)).Text;
+    // _personaPrompts is fail-loud internally (PROMPT_UNRESOLVED); no empty/plain fallback here.
+}
+else
+{
+    // Private/custom agent's own embedded prompts — owned by Story 32-17 via ICustomAgentPromptResolver.
+    // SEAM: 32-17 wires merged.SystemPrompt from agent ConfigJson.prompts here. (Not implemented in 32-15.)
+}
+```
+
+> `_personaPrompts` is the `IPersonaPromptResolver` seam this story ships; its impl wraps the Epic 27 prompt-store seam (`IPromptStore`/prompt+convention resolution), already round-tripped through `Tamma.Api`. `principal` = `(tenantId XOR userId)` from `ITammaModeProvider` + `ITenantContext` — the same principal `prompt_overrides`/`AgentRoleSelection` use. 32-18 wires the same `IPersonaPromptResolver` for its persona branch (the dispatch lives in 32-18; the resolve body lives here).
+
+### Integration points
+
+- **Story 34-11** (Provider Cost Price-Book) — `IProviderPricingService.IsKnown(provider, model)` must accept the personas' explicit `(provider, model)` pairs; the seeded models must price. **Hard prerequisite** (sequence A before B).
+- **Story 32-1** (shipped) — the `Agent`/`AgentVersion` entities, `AgentEntitySeeder`, `AgentConfigValidator`, `IAgentRepository`, the DROP list, and `ControlPlaneDbContextModelTests` this story amends.
+- **Story 32-2** (on `feat/exec-wave-02`) — `AgentRegistryService.GetSystemDefaultPublicAsync` and `AgentResolverService.MaterialiseAsync` this story rewrites.
+- **Epic 27 prompt store** — `IPromptStore` resolution `(principal, role, action)`, tenant → system → error; the new prompt source for personas.
+- **`ITammaModeProvider`** (`Tamma.Api/Services/PromptStore/TammaMode.cs`) — principal derivation for the Epic 27 key.
+
+## Dependencies
+
+**Internal:**
+
+- **Story 34-11** (Provider Cost Price-Book) — the personas' explicit `(provider, model)` must be `IsKnown`/priceable. Hard prerequisite (sequence A).
+- **Story 32-1** (Agent entity model — shipped on `main`) — the entity, seeder, validator, repository, DROP list, and model-contract test this story amends.
+- **Story 32-2** (Registry/resolution/RBAC — on `feat/exec-wave-02`) — owner of `GetSystemDefaultPublicAsync` + `MaterialiseAsync` this story rewrites.
+- **Epic 27 prompt store** — the new persona prompt source (`(principal, role, action)`, tenant → system → error).
+
+**Consumers (downstream, not blockers):**
+
+- **Story 32-16** (Per-tenant agent/persona enablement) — adds the enablement constraint over the personas this story seeds; constrains `GetSystemDefaultPublicAsync` to the tenant's enabled set.
+- **Story 32-17** (Custom-agent prompts) — owns the **private** branch as the parallel `ICustomAgentPromptResolver` seam, and points its persona-leg delegation at this story's `IPersonaPromptResolver` by that exact name.
+- **Story 32-18** (Registry enablement gate + Epic 27 prompt source) — the registry-side `CanUse`/`SelectForRoleAsync` enablement gate over these personas.
+- **Story 32-5** (Call-LLM endpoint + managed execution — lynchpin F) — resolves these personas at call time.
+
+**External:** none new.
+
+## Testing Strategy
+
+**Unit tests** (`tests/Tamma.Api.Tests/Agents/`, Postgres fixture per `Infrastructure/InMemoryDbFixture.cs` / `Epic28/ControlPlaneDbContextModelTests.cs` precedent):
+
+1. **Nullable-`Role` round-trip:** insert a `Visibility='public'`, `Role=NULL` persona; read it back; `Role` is null; the `ck_agents_visibility_ownership` CHECK still passes (public + no owners).
+2. **Public unique index swap:** two public agents may NOT share a `Name` (even with different/no `Role`) → second insert hits `IX_agents_public_name`; a public agent named `claude` with `Role=NULL` and a *private* agent named `claude` coexist (private partial indexes unchanged).
+3. **Seeder creates named personas:** first run creates `claude`/`gemini`/`codegpt` (+ optional), each `Visibility='public'`, `Role=NULL`, `Version=1`, with explicit `provider`+`model` in `ConfigJson` and **no** `prompts` block.
+4. **Seeder idempotency:** second run creates 0, skips N; no `AGENT.CREATED.SUCCESS` emitted on the skip run.
+5. **Seeder never reverts an admin edit:** after an admin publishes `claude` `Version=2`, re-running the seeder leaves `Version=2` intact and writes nothing.
+6. **`IsKnown` guard:** a persona whose `(provider, model)` is not `IProviderPricingService.IsKnown` is WARN-logged and not written (no half-seeded row).
+7. **`GetSystemDefaultPublicAsync` returns the default persona:** with `DefaultPersonaName="claude"`, the method returns the `claude` persona for **any** `role` (architect, tester, reviewer); never role-matches.
+8. **`GetSystemDefaultPublicAsync` fails loud:** with the configured persona absent, it throws `AGENT_DEFAULT_PERSONA_MISSING` (no empty/plain fallback).
+9. **Ambiguity warning deleted:** seeding multiple public personas no longer logs the per-role ">1 public agent" warning (assert absence).
+10. **`MaterialiseAsync` prompt source = `IPersonaPromptResolver` for personas:** a public persona resolves its system prompt via the `IPersonaPromptResolver` seam (over a fake `IPromptStore` keyed `(principal, role, action)`); the persona's `ConfigJson` carries no prompt and is NOT used as the prompt source. `MaterialiseAsync`'s public branch invokes the seam, not an inline `_promptStore.ResolveAsync`.
+11. **`IPersonaPromptResolver` fails loud:** Epic 27 returns null for `(role, action)` → `PROMPT_UNRESOLVED` thrown from the seam (never empty/plain).
+12. **Stamp preserved:** `MaterialiseAsync` still stamps `AgentId`/`AgentVersion` and merges onto `DefaultAgentConfig.ForRole(role)`.
+13. **Legacy `tamma-<role>` disposition (AC11):** with pre-seeded `tamma-<role>` rows present, the seeder is re-runnable and applies the chosen disposition (left/archived) deterministically; archive emits `AGENT.ARCHIVED.SUCCESS` once.
+
+**Integration tests** (Postgres-bound, `sg docker -c "dotnet test ..."`):
+
+14. **Migration applies + `has-pending-model-changes` reports none;** `ControlPlaneDbContextModelTests.Model_Has_ExpectedControlPlaneEntities` (and the index assertions) extended to reflect the nullable `Role` column + the renamed `IX_agents_public_name`.
+15. **End-to-end seed → resolve:** seed personas, set `DefaultPersonaName="gemini"`, call `GetSystemDefaultPublicAsync("architect")` → returns `gemini`; `MaterialiseAsync` produces a config whose `Provider="google"`, `Model="gemini-2.5-pro"`, prompt from Epic 27.
+
+**Coverage**: critical paths (Role-nullable migration, seeder idempotency, default-persona resolution, prompt-source wiring, fail-loud) → 100%; entity/seeder line ≥ 80%.
+
+Docker-bound C# suites run via `sg docker -c "dotnet test apps/tamma-elsa/..."` (session docker group is stale; plain `dotnet build` needs no wrapper).
+
+## Estimated Effort
+
+3-4 days
+
+## Files Created / Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/Agent.cs` | Modify (`Role`: `string` → `string?`) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (drop `Role.IsRequired()`; swap public index `(Name,Role)`→`(Name)`) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_PersonaReframeRoleNullable.cs` (+ `.Designer.cs`, snapshot) | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/IPersonaPromptResolver.cs` | Create (persona/public prompt seam — reads Epic 27 `(principal, role, action)`, fail-loud) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/PersonaPromptResolver.cs` | Create (impl over the Epic 27 `IPromptStore`) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentResolverService.cs` | Modify (`MaterialiseAsync` PUBLIC branch calls `IPersonaPromptResolver`; private branch = `ICustomAgentPromptResolver` seam owned by 32-17) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRegistryService.cs` | Modify (`GetSystemDefaultPublicAsync` rewrite; delete ambiguity warning) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/DefaultPersonaOptions.cs` | Create (bind `Tamma:Agents:DefaultPersonaName`) |
+| `apps/tamma-elsa/src/Tamma.ElsaServer/AgentEntitySeeder.cs` | Modify (rewrite: named cross-role personas, explicit model, no prompts, legacy disposition) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (bind `DefaultPersonaOptions`) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentEntitySeederTests.cs` | Modify (persona seeding, idempotency, no-revert, IsKnown guard, legacy disposition) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentRegistryServiceTests.cs` | Modify/Create (default-persona resolution, fail-loud, no ambiguity warning) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentResolverServiceTests.cs` | Modify/Create (prompt source = Epic 27, fail-loud, stamp preserved) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs` | Modify (nullable `Role`, renamed `IX_agents_public_name`) |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, decisions
+3. Read the design of record: `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§3.0–§3.1) + the re-plan `docs/superpowers/plans/2026-06-20-epic-32-37-replan.md` (§1)
+4. Re-read shipped 32-1 (the entity/seeder you amend) and 32-2 (the resolver/registry you rewrite)
+5. Reviewed the closest existing patterns: `ConventionStoreSeeder` (insert-missing-only idempotency), `PromptOverride` (XOR CHECK + principal resolution), the Epic 27 `IPromptStore` resolution
+6. Planned the TDD approach (Red-Green-Refactor)
+
+### Key design decisions
+
+- **Persona = system agent, not style overlay.** Public agents stop being per-role `tamma-<role>` and become named cross-role personas (`claude`/`gemini`/`codegpt`). `Role` becomes a *selection-time* concern, not a baked-in identity column — hence nullable for public personas. (The old 32-12 "style overlay within a role" is a different, optional story — not this one.)
+- **Explicit model per persona.** Today the seed omits `model` and leans on `DefaultAgentConfig.ForRole` → `claude-sonnet-4`. That collapses every persona to Anthropic. Each persona now pins its own `provider`+`model` so `gemini`/`codegpt` actually run on Google/OpenAI; the models must price under 34-11.
+- **Personas are prompt-free.** The role/system prompt is the Epic 27 store's job, keyed `(principal, role, action)`, tenant → system → error. A persona never carries a prompt — that keeps SaaS audit/compliance simple (no per-persona prompt fork). Custom prompts ⇔ custom agent (32-17).
+- **Fail loud, never empty.** Both the default-persona resolution and the persona-prompt resolution fail loud when their source is absent (`feedback_resolution_no_empty_fallback`). No silent fallback to a plain/empty prompt or a wrong-provider default.
+- **Amend, don't rebuild.** The 32-1 entity model is sound; this is a schema *amendment* (nullable column + index swap) on the existing linear migration snapshot — not a baseline rewrite. Sequential implementation keeps the EF snapshot consistent.
+- **Sibling boundaries are firm.** Enablement (32-16), the private-prompt branch (32-17), and the registry enablement gate (32-18) are explicitly NOT in scope; this story leaves the `MaterialiseAsync` private branch as a marked seam for 32-17.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns the public personas? | The platform — personas are `Visibility='public'`, `OwnerTenantId/OwnerUserId NULL`; the sole user uses them as-is. | The platform — same public personas, shared cross-tenant. Tenants do not own/edit personas (they enable a subset via 32-16). |
+| Who may create/edit a persona? | `PlatformOwnerAccess` (platform-owner only). The sole user is NOT a platform owner by virtue of owning their data. | `PlatformOwnerAccess` (platform-owner only; NOT `OwnerAccess`, which admits every personal-tenant owner). Tenant owner/admin/member cannot edit public personas. |
+| What principal keys the persona's prompt (Epic 27)? | The sole user (`OwnerUserId` / user principal) — `(userId, role, action)`. | The tenant (`OwnerTenantId` / tenant principal) — `(tenantId, role, action)`. No per-user prompt layer in SaaS. |
+| Who picks the default persona? | The platform config `DefaultPersonaName`; the sole user's selection (32-2 `AgentRoleSelection`) may override per role. | The platform config `DefaultPersonaName`, then constrained to the tenant's **enabled** set (32-16); tenant selection (`AgentRoleSelection`) overrides per role within the enabled set. |
+| Where do persona seeding events land? | Control-plane `DomainEvents`, `TenantId = NULL` (platform feed). | Control-plane `DomainEvents`, `TenantId = NULL` (platform feed). Persona definitions are platform-global; no tenant-scoped persona data here. |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`) — process-stable. | same |
+
+### Migration discipline (Epic 28 conventions)
+
+- The migration is **additive amendment** on the existing 32-1 snapshot: `ALTER COLUMN "Role" DROP NOT NULL` + drop/create the public partial index. Not a baseline CHECK edit, not a branch.
+- After adding, `dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext` → must report none.
+- Mirror entity config **only** in `TammaModelConfiguration.cs`; the snapshot/Designer are generated, not hand-edited.
+- `Agent`/`AgentVersion` are already in the `Program.cs` startup-reset DROP list (32-1) — **no new table**, so nothing is added to the DROP list; but the **renamed index + nullable column** must be reflected in `ControlPlaneDbContextModelTests` so the strict `BeEquivalentTo` model contract test stays green.
+- Run C# tests with `sg docker -c "dotnet test ..."` (session docker group is stale; build needs no wrapper).
+
+### Edge cases
+
+- A persona whose configured model is not `IProviderPricingService.IsKnown` (34-11 not yet seeded that model) → WARN + skip-write (no half-seeded persona); fix is to seed the price first.
+- `DefaultPersonaName` points at a persona that is archived/absent → `GetSystemDefaultPublicAsync` fails loud (AC5/AC8).
+- A pre-existing `tamma-<role>` row (from 32-1 on `main`) → AC11 disposition (left-in-place or archived), idempotent on re-run; never destructive-delete (immutable history).
+- Two public personas with the same `Name` (e.g. a re-seed race) → second hits `IX_agents_public_name` → 409/skip; the seeder's skip-by-existing-name avoids the race.
+- A private agent named `claude` (a tenant's custom agent) coexists with the public `claude` persona — private partial indexes are unchanged and scope by owner.
+
+## Risks & Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Nullable-`Role` migration breaks the strict model-contract test | High | Update `ControlPlaneDbContextModelTests` in the same change; assert `Role` nullable + `IX_agents_public_name` present and `IX_agents_public_name_role` absent. |
+| A persona's model isn't priceable (34-11 gap) → seeded persona can't meter | High | `IsKnown` guard before write (WARN + skip); 34-11 is a hard prerequisite; integration test asserts every seeded model prices. |
+| Prompt source silently empties (regression of the no-empty-fallback rule) | High | `MaterialiseAsync` and `GetSystemDefaultPublicAsync` both fail loud; explicit fail-loud tests; never substitute a plain/empty prompt. |
+| Legacy `tamma-<role>` rows shadow the named-persona default resolution | Medium | AC11 deterministic disposition (archive or leave) applied idempotently by the seeder; default resolves over named personas only. |
+| Rewriting `MaterialiseAsync` collides with 32-17's private-prompt branch | Medium | This story implements ONLY the public/persona branch via the `IPersonaPromptResolver` seam and leaves the parallel `ICustomAgentPromptResolver` seam for the private branch; 32-17 fills it; tests scope to the public branch. |
+| Branch/snapshot drift (32-2 lives on `feat/exec-wave-02`, 32-1 on `main`) | Medium | Sequential implementation on a single linear snapshot; the re-plan recommends merging `feat/exec-wave-02` before the redesign stories; this story amends whichever snapshot is current. |
+
+## Success Metrics
+
+- [ ] Public agents are named cross-role personas (`claude`/`gemini`/`codegpt`) with `Role=NULL` and explicit `provider`+`model`; zero `tamma-<role>` rows are created by the rewritten seeder.
+- [ ] `GetSystemDefaultPublicAsync(role)` returns the configured `DefaultPersonaName` persona for every role; the per-role ambiguity warning is gone.
+- [ ] Every persona run's system prompt comes from the Epic 27 store (grep confirms no prompt is sourced from persona `ConfigJson`); fail-loud on absence.
+- [ ] `has-pending-model-changes` reports none; the model-contract test reflects the nullable column + renamed index; the `Tamma.Api.Tests` suite is green.
+
+## Related
+
+- Design of record: `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§3.0 reframe table, §3.1 persona entity)
+- Re-plan: `docs/superpowers/plans/2026-06-20-epic-32-37-replan.md` (§1 disposition of 32-1; §4 sequence step B)
+- Implementation plan: `docs/superpowers/plans/2026-06-21-32-15-persona-reframe-and-seeding-plan.md`
+- Amends: `docs/stories/epic-32/story-32-1/32-1-agent-entity-model-and-versioned-saved-config.md` (entity + seeder), `docs/stories/epic-32/story-32-2/` (registry/resolver)
+- Sibling stories: 34-11 (Provider Cost Price-Book — prereq), 32-16 (enablement), 32-17 (custom-agent prompts), 32-18 (registry enablement gate), 32-5 (call-LLM endpoint)
+
+## Logging Requirements
+
+- **INFO**: seeder summary (`created, skipped` + persona names), each persona created (`personaName, agentId, provider, model`), default-persona resolution (`personaName, role`), legacy `tamma-<role>` disposition (`disposition, count`).
+- **DEBUG**: prompt-source selection in `MaterialiseAsync` (`visibility, role, action` — never the prompt body), config-validation pass (`personaName`).
+- **WARN**: configured default persona missing (before failing loud), a persona whose `(provider, model)` is not `IProviderPricingService.IsKnown` (skip-write), persona name collision on re-seed.
+- **ERROR**: migration/transaction failure (`migration`), event-append failure after a state transition.
+- **Structured context**: include `{ agentId, personaName, version, visibility, role, provider, model, mode }` where applicable.
+- **Credential safety**: persona `ConfigJson` carries `provider`+`model` only — **never an API key** (BYOK/platform keys are resolved at call time in `Tamma.Api` by 32-3, never on a persona). Never log raw `ConfigJson`; never log a prompt body; nothing on this path holds or logs a credential.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-21 | 1.0.0   | Initial story creation | Claude |
+| 2026-06-21 | 1.0.1   | Cross-spec reconciliation (C1): this story now OWNS the persona/public prompt leg as an explicit injectable seam — interface `IPersonaPromptResolver.ResolveAsync(Principal, role, action?, ct)` (reads the Epic 27 store, fail-loud). AC6/AC7 reworded so `MaterialiseAsync`'s PUBLIC branch calls the seam (not an inline `_promptStore.ResolveAsync`); the private branch points at 32-17's parallel `ICustomAgentPromptResolver`. | Claude |

--- a/docs/stories/epic-32/story-32-16/32-16-per-tenant-agent-enablement.md
+++ b/docs/stories/epic-32/story-32-16/32-16-per-tenant-agent-enablement.md
@@ -1,0 +1,411 @@
+# Story 32-16: Per-Tenant Agent/Persona Enablement (`TenantAgentEnablement`)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **tenant owner/admin (SaaS) or self-hosted user (single-user)**,
+I want to control **which public personas** (and my own private/custom agents) are part of my tenant's usable catalog — enabling and disabling them for the whole tenant,
+So that my tenant's members only ever select and run from a curated set of agents, the usable set is `enabled(public) ∪ own-private` rather than every public persona on the platform, and that catalog decision is made **once per tenant** (not per user) with a full audit trail.
+
+## Priority
+
+P0 — This is the **genuinely missing layer** of the locked agent model (design of record rule 6, §3.3). Neither the shipped 32-1 (`Agent`/`AgentVersion`) nor the drafted 32-2 (registry/resolution/selection) has it: `AgentRoleSelection` answers "which agent serves role X for principal P" but lets a principal select **any** visible public agent. Without enablement, "the tenant enables which personas exist for it" has no home, and selection (32-2) has no gate to constrain it. Enablement is the **catalog-membership** primitive that 32-18 (the registry enablement gate) consumes; sequenced step C, ahead of 32-18 (step E) and the call-LLM resolution path (32-5, step F).
+
+## Context
+
+The Epic 32 architecture pivot (`docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md`) reframes public agents as **named cross-role personas** (`claude`, `gemini`, `codegpt`) that preset provider+model+config and work for all roles (32-15). The locked model adds a constraint the original 32-1/32-2 never modelled: **enablement is per-tenant** (rule 6). The tenant decides which personas exist for it; its users simply use Tamma with what's enabled; there is **no per-user enablement layer** — exactly mirroring CLAUDE.md's "no per-user override layer in SaaS" for prompts.
+
+Two distinct concepts must not be conflated:
+
+- **Enablement** (this story) = *catalog membership*. Which personas/agents are part of this tenant's usable set. Per-tenant. Owns `TenantAgentEnablement`.
+- **Selection** (`AgentRoleSelection`, 32-2) = *role binding*. Which agent (from the enabled set) serves a given role for the principal.
+
+Enablement is the **gate that constrains selection**: a public persona that is not enabled for the tenant is not selectable, not resolvable, and not visible in the tenant's catalog. The tenant's usable set tightens the design-of-record's `public ∪ own-private` to **`enabled(public) ∪ own-private`**. Own private/custom agents (32-17) are **implicitly enabled** (you authored them); enablement is primarily about which **public personas** the tenant exposes.
+
+This story owns the **entity**, the **enable/disable API**, the **events**, and — critically — the **`IsEnabledForPrincipal` query primitive**. It does **not** own the registry/resolver wiring of the gate (`CanUse` → `IsPublic && IsEnabledForPrincipal`, the enablement-aware `SelectForRoleAsync`/`ResolveUsableAgentAsync`/`ListVisibleAsync`/`GetSystemDefaultPublicAsync`). That wiring is the **sibling story 32-18** (a 32-2 amendment), which **consumes** the primitive this story defines. Keeping the boundary precise prevents the two stories from overlap-implementing the gate. See **Dev Notes → Boundary with 32-18**.
+
+`TenantAgentEnablement` is **CP-resident in SaaS** (control-plane, like the public `Agent` catalog it gates and like every cross-tenant-shared decision) and **user-keyed in single-user** mode, following the same XOR/index discipline as `AgentRoleSelection` (32-2) and `prompt_overrides` (Epic 27). Because it is a NEW control-plane / public-schema table, it MUST be added to the `Program.cs` startup-reset DROP list and the `ControlPlaneDbContextModelTests` strict entity list (see AC8, AC9 and Dev Notes).
+
+## Acceptance Criteria
+
+1. **New entity `TenantAgentEnablement`** (`apps/tamma-elsa/src/Tamma.Data/Entities/TenantAgentEnablement.cs`) with fields: `Id` (UUID PK), `TenantId` (UUID, NULL in single-user), `UserId` (UUID, NULL in SaaS), `AgentId` (UUID NOT NULL — a public persona OR an own private/custom agent), `Enabled` (BOOLEAN NOT NULL), `CreatedAt`/`CreatedBy`, `UpdatedAt`/`UpdatedBy`. EF config carries the **principal XOR** CHECK constraint and the **`UNIQUE NULLS NOT DISTINCT (TenantId, UserId, AgentId)`** index, mirroring `AgentRoleSelection` exactly.
+
+2. **`IsEnabledForPrincipalAsync(agentId, principal)` query primitive** is exposed by a new **read seam `ITenantAgentEnablementReader`** (`Tamma.Api/Services/Agents/`), which the write/admin `ITenantAgentEnablementService : ITenantAgentEnablementReader` extends (see AC2a for the ISP split). Semantics:
+   - An **own private/custom agent** is **implicitly enabled** (returns `true` without requiring a row) — you authored it.
+   - A **public persona** is enabled **iff** an enablement row exists for the principal `(tenantId XOR userId, agentId)` with `Enabled = true`. Absent a row, a public persona is **NOT enabled** (default-deny for catalog membership — see AC10 for the seeded-default carve-out).
+   - A `ListEnabledPublicAgentIdsAsync(principal)` companion returns the set of public agent ids enabled for the principal (for the consumer in 32-18's `ListVisibleAsync`).
+   - A `GetEnabledDefaultPersonaIdAsync(principal)` companion returns the principal's **enabled default persona id** — the configured `DefaultPersonaName` (32-15) if it is enabled, else the single enabled persona if unambiguous, else `null` — for the consumer in 32-18's `GetSystemDefaultPublicAsync` (which 32-18 CONSUMES, never redefines).
+
+2a. **ISP split — read seam vs write/admin service.** The enablement contract is split per the Interface Segregation Principle into:
+   - **`ITenantAgentEnablementReader`** (read-only): `Task<bool> IsEnabledForPrincipalAsync(Guid agentId, Principal principal, CancellationToken ct)`, `Task<IReadOnlyList<Guid>> ListEnabledPublicAgentIdsAsync(Principal principal, CancellationToken ct)`, `Task<Guid?> GetEnabledDefaultPersonaIdAsync(Principal principal, CancellationToken ct)`. This is the seam **32-18 injects and consumes** (it never sees the write methods).
+   - **`ITenantAgentEnablementService : ITenantAgentEnablementReader`** (write/admin): adds `EnableAsync`/`DisableAsync`/`ListAsync`.
+   - **One implementation** (`TenantAgentEnablementService`) implements both interfaces. The read methods are async and take an explicit `Principal` argument (matching the signatures 32-18 calls).
+
+3. **Enable API** — `PUT /api/agents/{agentId}/enablement` (body `{ "enabled": true }` or a dedicated `POST .../enable`) upserts an enablement row for the **current principal's tenant** (SaaS) or **user** (single-user), sets `Enabled = true`, and emits `AGENT.ENABLED.SUCCESS`. Returns `200` with the resolved enablement state. Enabling an agent the tenant cannot see (not public and not its own private) → `404` (existence-leak-safe, matching 32-2's cross-tenant rule).
+
+4. **Disable API** — `DELETE /api/agents/{agentId}/enablement` (or `POST .../disable`) sets `Enabled = false` (or removes the row) for the principal, and emits `AGENT.DISABLED.SUCCESS`. Returns `200`. Disabling a public persona removes it from the tenant's usable set; the consumer gate (32-18) makes it non-selectable/non-resolvable. **Disabling an own private/custom agent is a no-op / `409`** (private agents are implicitly enabled by authorship and cannot be removed from your own catalog this way — they are removed by archiving the agent, 32-2).
+
+5. **List API** — `GET /api/agents/enablement` returns the tenant's enablement view: every visible public persona with its `enabled` flag (true/false) plus own-private agents marked implicitly-enabled. This is the catalog-management surface; **any tenant member may read it** (reads are not gated).
+
+6. **Per-mode RBAC** mirrors the Prompt Store / 32-2:
+   - SaaS `member` → **403** on the enable/disable writes (`PUT`/`DELETE` / enable / disable). Reads (`GET /api/agents/enablement`) allowed.
+   - SaaS `tenant_owner` / `tenant_admin` → may enable/disable for **their own tenant only**.
+   - **Single-user** mode → the sole user (auto-owner) may enable/disable for themselves; no member gate; principal is `UserId`.
+   - **Public-catalog management** (which personas exist platform-wide) is explicitly **out of scope** here and stays `PlatformOwnerAccess` (NOT `OwnerAccess`, which admits every personal-tenant owner). This story only touches per-tenant enablement of an already-existing public persona.
+
+7. **DCB events** `AGENT.ENABLED.SUCCESS` and `AGENT.DISABLED.SUCCESS` are emitted via `IEventRepository.AppendAsync`, tagged `{ agentId, personaName, mode, tenantId | userId }`. Exactly one event per successful write. Tenant-scope events carry the ambient `TenantId`; single-user/platform-scope events resolve via the platform-events path (`TenantId == null`, principal recorded as `userId`).
+
+8. **`Program.cs` startup-reset DROP list** is amended: the new public-schema/control-plane table `tenant_agent_enablements` is appended to the destructive test-host wipe list ("Wiping Tamma-managed public-schema tables") so a second host boot does not fail with `relation "tenant_agent_enablements" already exists`. (Tenant-schema `t_<hex>` tables do NOT go in that list; this table is CP-resident — see AC9.)
+
+9. **`ControlPlaneDbContextModelTests.Model_Has_ExpectedControlPlaneEntities`** strict `BeEquivalentTo` list is updated to include `TenantAgentEnablement`, and the entity is registered as a `DbSet` on **`ControlPlaneDbContext`** (CP-resident; SaaS rows keyed by `TenantId`, single-user rows keyed by `UserId`), with its EF config in the single `TammaModelConfiguration` source. `dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext` reports none after the new migration.
+
+10. **No-empty-fallback alignment + seeded default**: enablement does NOT silently fall back to "all public personas enabled." A tenant that has enabled nothing has an empty enabled-public set, and 32-18's `GetSystemDefaultPublicAsync` fails loud (no empty fallback) — **except** that a fresh tenant is seeded with the platform default persona enabled (the `DefaultPersonaName`, e.g. `claude`), so a brand-new tenant is usable out of the box. The seeder is **insert-missing-only** (never reverts an explicit disable). This story provides the seeding hook; the resolve-time fail-loud lives in 32-18.
+
+11. **Cross-tenant isolation**: a tenant cannot enable/disable for another tenant; an enablement write/read scopes to the ambient principal only. Targeting another tenant's private agent → `404`. Enabling a public persona for tenant A never affects tenant B's enabled set.
+
+12. **Unit + integration tests** cover: enable/disable upsert + events; `IsEnabledForPrincipalAsync` for (own-private implicit-true, enabled-public true, no-row-public false); `GetEnabledDefaultPersonaIdAsync` (returns the configured `DefaultPersonaName` id when enabled, the single enabled persona when unambiguous, and `null` when nothing/ambiguous is enabled); member 403 on writes; reads allowed for member; single-user vs SaaS principal keying (mode-parameterized); cross-tenant isolation (A's enablement never affects B); disable-own-private → 409 no-op; seeded-default tenant has its default persona enabled; the XOR check + unique-nulls-not-distinct constraint; and `has-pending-model-changes` → none.
+
+## Technical Design
+
+### Where it lives
+
+```
+apps/tamma-elsa/src/Tamma.Data/Entities/
+  TenantAgentEnablement.cs                 # NEW — the enablement entity (CP-resident; user-keyed single-user)
+
+apps/tamma-elsa/src/Tamma.Data/
+  TammaModelConfiguration.cs               # MODIFY — entity config: XOR check + unique-nulls-not-distinct index
+  ControlPlaneDbContext.cs                 # MODIFY — DbSet<TenantAgentEnablement>
+  Migrations/ControlPlane/*_AddTenantAgentEnablements.cs   # NEW (generated)
+
+apps/tamma-elsa/src/Tamma.Api/Services/Agents/
+  ITenantAgentEnablementReader.cs          # NEW — read seam (IsEnabledForPrincipalAsync / ListEnabledPublicAgentIdsAsync / GetEnabledDefaultPersonaIdAsync); 32-18 injects this
+  ITenantAgentEnablementService.cs         # NEW — : ITenantAgentEnablementReader; adds Enable/Disable/List
+  TenantAgentEnablementService.cs          # NEW — impl of BOTH (upsert, events, implicit-private rule, the three read primitives)
+  AgentEnablementEventTypes.cs             # NEW — AGENT.ENABLED.SUCCESS / AGENT.DISABLED.SUCCESS constants
+
+apps/tamma-elsa/src/Tamma.Api/Endpoints/
+  AgentEndpoints.cs                        # MODIFY — add Enable/Disable/ListEnablement handlers under /api/agents
+
+apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/
+  AgentEnablementResponse.cs, SetEnablementRequest.cs      # NEW — request/response DTOs
+
+apps/tamma-elsa/src/Tamma.Api/Program.cs   # MODIFY — DI registration; route mapping; STARTUP-RESET DROP-LIST amend (AC8)
+
+apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentEntitySeeder.cs (or a small TenantEnablementSeeder)
+                                           # MODIFY/NEW — seed DefaultPersonaName enabled for a fresh tenant (AC10, insert-missing-only)
+```
+
+### `TenantAgentEnablement` entity (NEW)
+
+```csharp
+// Tamma.Data/Entities/TenantAgentEnablement.cs
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Per-tenant agent/persona enablement (Epic 32, rule 6 / design §3.3).
+/// Catalog membership: which PUBLIC personas a tenant exposes. Own private/custom
+/// agents are implicitly enabled (no row required). CP-resident in SaaS (keyed by
+/// TenantId); user-keyed in single-user (keyed by UserId). Exactly one of
+/// TenantId/UserId is non-null (principal XOR), mirroring AgentRoleSelection /
+/// prompt_overrides. There is NO per-user enablement layer in SaaS.
+/// </summary>
+public class TenantAgentEnablement
+{
+    public Guid Id { get; set; }
+
+    /// <summary>Set in SaaS; NULL in single-user. XOR with UserId.</summary>
+    public Guid? TenantId { get; set; }
+
+    /// <summary>Set in single-user; NULL in SaaS. XOR with TenantId.</summary>
+    public Guid? UserId { get; set; }
+
+    /// <summary>A public persona OR an own private/custom agent. Logical FK only —
+    /// public agents live in the CP catalog; no cross-schema DB FK. The service
+    /// validates the target is in (public ∪ own-private) at write time.</summary>
+    public Guid AgentId { get; set; }
+
+    /// <summary>True = part of the tenant's usable catalog. A disable sets false
+    /// (or removes the row). Absent row for a public persona = not enabled.</summary>
+    public bool Enabled { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+    public Guid? CreatedBy { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public Guid? UpdatedBy { get; set; }
+}
+```
+
+EF model config (in `TammaModelConfiguration.cs`, the single source — **identical discipline to `AgentRoleSelection`**):
+
+```csharp
+modelBuilder.Entity<TenantAgentEnablement>(b =>
+{
+    b.ToTable("tenant_agent_enablements");
+    b.HasKey(x => x.Id);
+    b.Property(x => x.AgentId).IsRequired();
+    b.Property(x => x.Enabled).IsRequired();
+
+    // principal XOR (mirrors prompt_overrides / agent_role_selections)
+    b.ToTable(t => t.HasCheckConstraint(
+        "ck_tenant_agent_enablements_principal_xor",
+        "((tenant_id IS NOT NULL AND user_id IS NULL) OR (tenant_id IS NULL AND user_id IS NOT NULL))"));
+
+    // UNIQUE NULLS NOT DISTINCT (tenant_id, user_id, agent_id) — one row per (principal, agent)
+    b.HasIndex(x => new { x.TenantId, x.UserId, x.AgentId })
+        .IsUnique()
+        .AreNullsDistinct(false);
+});
+```
+
+> **CP-resident, not tenant-schema.** Like the public `Agent` catalog it gates, `tenant_agent_enablements` lives in the **control plane** (`ControlPlaneDbContext`), with SaaS rows scoped by `TenantId` and single-user rows by `UserId`. This is the same dual-keying that `prompt_overrides`/`AgentRoleSelection` use for their CP-resident single-user path; here the SaaS path is ALSO CP-resident because enablement is a cross-tenant-shared catalog decision keyed by tenant id, not a `t_<hex>` tenant-private row. Therefore it joins the **CP DROP list (AC8)** and the **`ControlPlaneDbContextModelTests` strict list (AC9)** — and does NOT go through the per-tenant `EfTenantDbMigrator`.
+
+### `ITenantAgentEnablementReader` + `ITenantAgentEnablementService` (NEW) — ISP split: read seam + write/admin
+
+```csharp
+// Tamma.Api/Services/Agents/ITenantAgentEnablementReader.cs
+// The READ-ONLY seam 32-18 injects + consumes (it never touches the write methods).
+public interface ITenantAgentEnablementReader
+{
+    /// <summary>True iff the agent is part of the principal's usable catalog:
+    /// own private/custom => implicitly true; public persona => an enabled row exists.
+    /// Absent row for a public persona => false (default-deny; seeded-default carve-out
+    /// in AC10). This is the gate 32-18 calls from CanUse / SelectForRoleAsync /
+    /// ResolveUsableAgentAsync.</summary>
+    Task<bool> IsEnabledForPrincipalAsync(Guid agentId, Principal principal, CancellationToken ct);
+
+    /// <summary>The set of PUBLIC agent ids enabled for the principal — for 32-18's
+    /// ListVisibleAsync (enabled(public) ∪ own-private).</summary>
+    Task<IReadOnlyList<Guid>> ListEnabledPublicAgentIdsAsync(Principal principal, CancellationToken ct);
+
+    /// <summary>The principal's enabled DEFAULT persona id: the configured DefaultPersonaName
+    /// (32-15) if enabled, else the single enabled persona if unambiguous, else null. The
+    /// enabled-default primitive 32-18's GetSystemDefaultPublicAsync CONSUMES (never redefines).</summary>
+    Task<Guid?> GetEnabledDefaultPersonaIdAsync(Principal principal, CancellationToken ct);
+}
+
+// Tamma.Api/Services/Agents/ITenantAgentEnablementService.cs
+// The WRITE/ADMIN service — extends the read seam; one impl implements both.
+public interface ITenantAgentEnablementService : ITenantAgentEnablementReader
+{
+    /// <summary>Enable a public persona (or confirm an own private/custom agent)
+    /// for the current principal. Validates target ∈ (public ∪ own-private) else 404.
+    /// Emits AGENT.ENABLED.SUCCESS. Idempotent upsert.</summary>
+    Task<AgentEnablementState> EnableAsync(Guid agentId, CancellationToken ct = default);
+
+    /// <summary>Disable a public persona for the current principal (sets Enabled=false
+    /// or removes the row). Emits AGENT.DISABLED.SUCCESS. Disabling an OWN private/custom
+    /// agent is a no-op/409 (it is implicitly enabled; remove via archive, 32-2).</summary>
+    Task<AgentEnablementState> DisableAsync(Guid agentId, CancellationToken ct = default);
+
+    /// <summary>Catalog view: every visible public persona with its enabled flag,
+    /// plus own-private agents (implicitly enabled). Any member may read.</summary>
+    Task<IReadOnlyList<AgentEnablementState>> ListAsync(CancellationToken ct = default);
+}
+
+public sealed record AgentEnablementState(
+    Guid AgentId,
+    string? PersonaName,
+    bool Enabled,
+    bool ImplicitlyEnabled);   // true for own-private (cannot be toggled here)
+```
+
+> **One implementation, two interfaces.** `TenantAgentEnablementService` implements `ITenantAgentEnablementService` (and therefore `ITenantAgentEnablementReader`). 32-18 depends only on `ITenantAgentEnablementReader` (registered to the same singleton/scoped instance) — it gets the three async read methods (`IsEnabledForPrincipalAsync`, `ListEnabledPublicAgentIdsAsync`, `GetEnabledDefaultPersonaIdAsync`) and never the write methods. The read methods take an explicit `Principal` argument so 32-18 passes its already-resolved principal; the write methods derive the principal from the ambient request.
+
+The implementation derives the principal from `ITammaModeProvider` + `ITenantContext`/`ClaimsPrincipal` (SaaS ⇒ `TenantId`; single-user ⇒ `UserId`), reads/writes `ControlPlaneDbContext.TenantAgentEnablements`, validates the target id is in (public CP catalog ∪ ambient principal's own-private agents), and appends the DCB event.
+
+### Endpoints (`AgentEndpoints.cs`, extend the existing `/api/agents` group from 32-2)
+
+```csharp
+// Reads — any member
+public static async Task<IResult> ListEnablement(
+    ITenantAgentEnablementService svc, ClaimsPrincipal user)
+    => Results.Ok(await svc.ListAsync());   // 200 catalog view
+
+// Writes — tenant_owner/tenant_admin (member → 403 via AgentManage policy)
+public static async Task<IResult> SetEnablement(
+    Guid agentId, SetEnablementRequest req,
+    ITenantAgentEnablementService svc)
+{
+    var state = req.Enabled
+        ? await svc.EnableAsync(agentId)
+        : await svc.DisableAsync(agentId);     // 404 unseen / 409 disable-own-private
+    return Results.Ok(AgentEnablementResponse.From(state));
+}
+```
+
+`Program.cs` route mapping (reusing 32-2's `/api/agents` group, `AgentManage` policy = `agents:manage` = admin+owner):
+
+```csharp
+agentsV2.MapGet("/enablement", AgentEndpoints.ListEnablement);                  // MemberAccess (reads)
+agentsV2.MapPut("/{agentId:guid}/enablement", AgentEndpoints.SetEnablement)     // PUT {enabled:true|false}
+    .RequireAuthorization("AgentManage").RequireRateLimiting("ConfigWrite");
+agentsV2.MapDelete("/{agentId:guid}/enablement", AgentEndpoints.DisableEnablement)
+    .RequireAuthorization("AgentManage").RequireRateLimiting("ConfigWrite");
+```
+
+> Public-catalog management (creating/retiring the personas themselves) is **not** here — it stays under `PlatformOwnerAccess` per 32-15/32-2. This route group only toggles an existing public persona's membership in *this* tenant's catalog.
+
+### DCB events
+
+| Event | Tags | When |
+|---|---|---|
+| `AGENT.ENABLED.SUCCESS` | `{ agentId, personaName, mode, tenantId \| userId }` | enable upsert (`Enabled=true`) |
+| `AGENT.DISABLED.SUCCESS` | `{ agentId, personaName, mode, tenantId \| userId }` | disable (`Enabled=false`/removed) |
+
+Appended via `IEventRepository.AppendAsync`; tenant-scope events carry ambient `TenantId`; single-user events carry `userId` (`TenantId == null`).
+
+### Startup-reset DROP list (AC8) — explicit codebase gotcha
+
+`tenant_agent_enablements` is a NEW control-plane / public-schema table. Append it to the destructive test-host wipe list in `Program.cs` (the "Wiping Tamma-managed public-schema tables" block) alongside `agent_role_selections`, `prompt_overrides`, the public `Agent`/`AgentVersion` catalog, etc. Without this, a second test-host boot fails with `relation "tenant_agent_enablements" already exists`. It is CP-resident, so it goes in the CP wipe list — **not** the per-tenant `EfTenantDbMigrator` path (which owns `t_<hex>` tables only).
+
+### Boundary with 32-18 (do NOT implement the gate here)
+
+This story owns: the **entity**, its EF config + migration, the **enable/disable/list API**, the **events**, the **seeding hook**, and the **`ITenantAgentEnablementReader` read seam** with its three async primitives (`IsEnabledForPrincipalAsync`, `ListEnabledPublicAgentIdsAsync`, `GetEnabledDefaultPersonaIdAsync`).
+
+Story **32-18** (the 32-2 amendment) owns the **consumption**: rewriting `CanUse()` to `IsPublic && IsEnabledForPrincipalAsync`, and threading the primitives through `SelectForRoleAsync` / `ResolveUsableAgentAsync` / `ListVisibleAsync` / `GetSystemDefaultPublicAsync` (including the resolve-time fail-loud when a tenant has enabled nothing — AC10, and consuming `GetEnabledDefaultPersonaIdAsync` for the enabled-default lookup). 32-18 injects **`ITenantAgentEnablementReader`** (the read-only seam this story ships) and uses it; this story MUST NOT modify the registry/resolver selection or resolution code. The seam is the `ITenantAgentEnablementReader` interface.
+
+## Dependencies
+
+**Internal:**
+
+- **Story 32-1** (Agent entity model & versioned saved config) — establishes `Agent`/`AgentVersion` and the public-vs-private visibility; enablement references `Agent.Id` and reads visibility to apply the implicit-private rule. Hard prerequisite.
+- **Story 32-2** (Agent registry, resolution & RBAC API) — provides the `/api/agents` route group, the `AgentManage` policy (`agents:manage` = admin+owner), `IsPlatformOwner()`, the `AgentRoleSelection` XOR/index precedent this story mirrors, and the cross-tenant 404 convention. Hard prerequisite.
+- **Story 32-15** (Persona reframe + seeding) — public personas (cross-role named agents) are what enablement primarily toggles; supplies `personaName` for event tags and the `DefaultPersonaName` seeded-default (AC10). Hard prerequisite for meaningful semantics.
+- **Epic 27** (Prompt Store) — the per-mode RBAC + dual-keying model this mirrors (`prompt_overrides`).
+- **Epic 28** (schema-per-tenant) — the CP-vs-tenant placement decision (this table is CP-resident, like the public catalog it gates).
+
+**Consumers (downstream, not blockers):**
+
+- **Story 32-18** (Agent registry enablement gate + Epic-27 prompt source — a 32-2 amendment) — injects `ITenantAgentEnablementReader` and consumes `IsEnabledForPrincipalAsync` / `ListEnabledPublicAgentIdsAsync` / `GetEnabledDefaultPersonaIdAsync` to gate selection/resolution/visibility and to resolve the enabled default. The **primary** consumer.
+- **Story 32-5** (Call-LLM endpoint + managed execution) — resolution inside `/api/v1/llm/call` runs through 32-18's enablement-aware resolver, so an un-enabled persona cannot be executed.
+- **Story 32-17** (Custom-agent prompts) — own private/custom agents are implicitly enabled by this story's rule; no enablement row needed.
+
+**External:** none new (reuses EF Core, `IEventRepository`, the existing auth/policy stack).
+
+## Testing Strategy
+
+Tests are xUnit under `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/`. Docker-bound suites run via `sg docker -c "dotnet test ..."` (session docker group is stale; see `reference_dotnet_test_docker`). TDD: write the failing test first.
+
+1. **Enable/disable upsert + events** (`TenantAgentEnablementServiceTests`): `EnableAsync(publicId)` creates a row `Enabled=true` and appends exactly one `AGENT.ENABLED.SUCCESS` tagged `{ agentId, personaName, mode, tenantId|userId }`; `DisableAsync(publicId)` flips to false (or removes) and appends one `AGENT.DISABLED.SUCCESS`. Re-enable is idempotent (single row, no duplicate event family explosion).
+2. **`IsEnabledForPrincipalAsync` truth table**: own-private/custom agent ⇒ `true` with no row; enabled public persona ⇒ `true`; public persona with no row ⇒ `false`; disabled public persona ⇒ `false`.
+3. **`ListEnabledPublicAgentIdsAsync`**: returns exactly the set of enabled public ids for the principal; excludes disabled and no-row public; excludes private (private handled separately by the consumer).
+3a. **`GetEnabledDefaultPersonaIdAsync`**: returns the configured `DefaultPersonaName` persona id when that persona is enabled; returns the single enabled persona's id when `DefaultPersonaName` is not enabled but exactly one other persona is; returns `null` when nothing is enabled or the choice is ambiguous (multiple enabled, none the configured default). Pure-read, no writes/events.
+4. **RBAC matrix** (`AgentEnablementEndpointsTests`, in-process `WebApplicationFactory`): SaaS `member` → 403 on `PUT`/`DELETE /api/agents/{id}/enablement`; member `GET /api/agents/enablement` → 200; `tenant_owner`/`tenant_admin` enable/disable → 200; **public-catalog mutation is not exposed here** (asserted absent / 404 on any platform-catalog write attempt through this group).
+5. **Mode-parameterized principal** (`[Theory]` over `TammaMode.SingleUser`/`SaaS`): enable keyed by `UserId` (single-user) vs `TenantId` (SaaS); the correct column is set, the other is NULL (XOR holds); events tag the correct principal.
+6. **Cross-tenant isolation** (`TenantAgentEnablementIsolationTests`): tenant A enabling persona X never appears in tenant B's `ListAsync`/`IsEnabledForPrincipal`; A cannot enable/disable targeting B's private agent (404); A's disable does not affect B.
+7. **Disable-own-private** ⇒ `409`/no-op (own private/custom agent stays implicitly enabled; not removable via this API).
+8. **404 on unseen target**: enabling an agent that is neither public nor the principal's own private ⇒ 404 (existence-leak-safe).
+9. **Seeded default** (`TenantEnablementSeederTests`): a fresh tenant has the platform `DefaultPersonaName` (e.g. `claude`) enabled out of the box; the seeder is insert-missing-only (running it again does NOT revert an explicit disable of the default).
+10. **Constraint tests**: the XOR CHECK rejects a row with both/neither principal set; the unique-nulls-not-distinct index rejects a duplicate `(TenantId, UserId, AgentId)`.
+11. **CP model contract**: `ControlPlaneDbContextModelTests.Model_Has_ExpectedControlPlaneEntities` includes `TenantAgentEnablement`; `dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext` → none; a second test-host boot succeeds (DROP-list amendment proven).
+
+## Estimated Effort
+
+3-4 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/TenantAgentEnablement.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (entity config: XOR check + unique-nulls-not-distinct index) |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (DbSet) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/*_AddTenantAgentEnablements.cs` | Create (generated) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ITenantAgentEnablementReader.cs` | Create (read seam: `IsEnabledForPrincipalAsync` / `ListEnabledPublicAgentIdsAsync` / `GetEnabledDefaultPersonaIdAsync`; injected by 32-18) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ITenantAgentEnablementService.cs` | Create (`: ITenantAgentEnablementReader`; adds `EnableAsync`/`DisableAsync`/`ListAsync`) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/TenantAgentEnablementService.cs` | Create (implements both interfaces) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentEnablementEventTypes.cs` | Create (`AGENT.ENABLED.SUCCESS` / `AGENT.DISABLED.SUCCESS`) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs` | Modify (add ListEnablement/SetEnablement/DisableEnablement handlers) |
+| `apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/AgentEnablementResponse.cs`, `SetEnablementRequest.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentEntitySeeder.cs` (or new `TenantEnablementSeeder.cs`) | Modify/Create (seed `DefaultPersonaName` enabled, insert-missing-only) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (DI registration; `/api/agents/enablement` routes; **STARTUP-RESET DROP-LIST amend**) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/TenantAgentEnablementServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentEnablementEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/TenantAgentEnablementIsolationTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/TenantEnablementSeederTests.cs` | Create |
+| `apps/tamma-elsa/tests/.../Epic28/ControlPlaneDbContextModelTests.cs` | Modify (add `TenantAgentEnablement` to strict entity list) |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` directory for related spikes, bugs, findings, and decisions (esp. `feedback_resolution_no_empty_fallback`)
+3. Reviewed the `AgentRoleSelection` entity + `TammaModelConfiguration` config (32-2) — this story mirrors its XOR/index discipline **exactly**
+4. Reviewed `ControlPlaneDbContextModelTests` (the strict `BeEquivalentTo` list) and the `Program.cs` "Wiping Tamma-managed public-schema tables" block — **both must be amended** (AC8, AC9)
+5. Confirmed the 32-1/32-2/32-15 contracts (Agent visibility, `/api/agents` group, `AgentManage` policy, `DefaultPersonaName`) are landed before wiring
+6. Planned TDD approach (Red-Green-Refactor cycle)
+
+### Key design decisions
+
+- **Enablement = catalog membership; selection = role binding.** Two separate entities, two separate concerns. `TenantAgentEnablement` says "this persona is part of my tenant's set"; `AgentRoleSelection` (32-2) says "this (already-enabled) agent serves this role." Enablement gates selection — never the reverse.
+- **Per-tenant, NOT per-user.** Members see and use the tenant's enabled set; they cannot enable/disable. This matches CLAUDE.md's "no per-user override layer in SaaS" exactly. Single-user mode keys by `UserId` because the sole user *is* the tenant-equivalent.
+- **Own private/custom agents are implicitly enabled.** You authored a private agent; it is in your catalog by construction. No enablement row is required; `IsEnabledForPrincipal` short-circuits to `true`. Disabling one via this API is a no-op/409 — you remove it by archiving (32-2), not by toggling membership.
+- **Default-deny for public personas, with a seeded default.** Catalog membership is opt-in: an un-enabled public persona is not in the set. To keep a fresh tenant usable, the seeder enables the platform `DefaultPersonaName` (insert-missing-only — never reverts an explicit disable). The resolve-time fail-loud (no empty fallback) lives in 32-18.
+- **CP-resident in both modes.** Unlike `AgentRoleSelection` (tenant-schema in SaaS, CP for single-user), enablement is CP-resident in *both* modes because it gates the CP-resident public catalog and is keyed by tenant id, not stored per `t_<hex>`. Hence the DROP-list + CP-model-test amendments.
+- **Own the primitive, not the gate.** This story ships the `ITenantAgentEnablementReader` read seam (`IsEnabledForPrincipalAsync` / `ListEnabledPublicAgentIdsAsync` / `GetEnabledDefaultPersonaIdAsync`); 32-18 injects that reader and wires it into `CanUse`/resolution/the enabled-default lookup. The boundary is the read interface — keeps the two stories from both editing the resolver.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns the enablement decision? | The sole user (`user_id`-keyed CP row; `tenant_id` NULL). | The tenant (`tenant_id`-keyed CP row; `user_id` NULL). `tenant_owner`/`tenant_admin` write; `member` read-only. |
+| Is there a per-user layer? | N/A — the sole user *is* the principal. | **No.** Members see/use the tenant's enabled set; they cannot enable/disable (403 on writes). |
+| Where does the enablement row live? | `ControlPlaneDbContext.tenant_agent_enablements`, keyed by `UserId`. | `ControlPlaneDbContext.tenant_agent_enablements`, keyed by `TenantId` (CP-resident, not `t_<hex>`). |
+| What does the usable set become? | `enabled(public) ∪ own-private`, keyed by the user. | `enabled(public) ∪ own-private`, keyed by the tenant — identical for every member. |
+| Who manages the public catalog itself? | Shipped system personas (read-only to the user; the user enables/disables membership). | Platform owner (`PlatformOwnerAccess`) — out of scope here; this story only toggles per-tenant membership. |
+| Where do `AGENT.ENABLED/DISABLED.SUCCESS` land? | The user's (platform-events) feed; `TenantId == null`, principal = `userId`. | The tenant's event store via tenant-scoped `IEventRepository`; `TenantId` set. |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`) — process-stable. | same |
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| New CP table breaks the second test-host boot (`relation already exists`) | High | Amend the `Program.cs` "Wiping Tamma-managed public-schema tables" DROP list (AC8); test asserts a second boot succeeds. |
+| `ControlPlaneDbContextModelTests` strict list fails after adding the entity | High | Update the `BeEquivalentTo` list in the same PR (AC9); it is a known gotcha, not a regression. |
+| Overlap-implementing the gate with 32-18 | High | Hard boundary: this story ships the **interface + primitive**, 32-18 consumes it. No registry/resolver edits here. Cross-referenced both ways. |
+| Default-deny locks a fresh tenant out (no persona usable) | Medium | Seeded default persona enabled out of the box (AC10); resolve-time fail-loud only when a tenant explicitly disables everything (32-18). |
+| Disabling an own private agent surprises the user | Medium | Implicit-enabled rule + 409/no-op on disable-own-private; documented; removal is via archive (32-2). |
+| XOR/keying drift from `AgentRoleSelection` | Medium | Mirror `TammaModelConfiguration` config byte-for-byte (XOR check name pattern, unique-nulls-not-distinct); constraint tests (AC12). |
+| Stale enablement after a persona is retired platform-wide | Low | `IsEnabledForPrincipal` re-validates the target is still a live public agent at read time; a retired persona resolves out (consumer 32-18 degrades to default). |
+
+### Success Metrics
+
+- [ ] A tenant's usable set is `enabled(public) ∪ own-private` — proven by an integration test where a disabled public persona is non-selectable via 32-18.
+- [ ] 100% of enable/disable writes emit exactly one `AGENT.ENABLED/DISABLED.SUCCESS` event tagged with the principal.
+- [ ] Member write attempts are 403; reads are 200 — RBAC matrix green.
+- [ ] Second test-host boot succeeds (DROP-list amendment) and `has-pending-model-changes` → none.
+
+## Related
+
+- Design of record: `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§3.3 per-tenant enablement, §3.0 reframe, §3.5 BYOK ∘ persona)
+- Re-plan / sequence: `docs/superpowers/plans/2026-06-20-epic-32-37-replan.md`
+- Implementation plan: `docs/superpowers/plans/2026-06-21-32-16-per-tenant-agent-enablement-plan.md`
+- Sibling stories: `docs/stories/epic-32/story-32-15/` (persona reframe + seeding), `story-32-18/` (registry enablement gate — the consumer), `story-32-17/` (custom-agent prompts), `story-32-2/` (registry/selection — the XOR/index precedent), `story-32-5/` (call-LLM endpoint — runs the enablement-aware resolver)
+- Reused precedent: `apps/tamma-elsa/src/Tamma.Data/Entities/AgentRoleSelection.cs`, `prompt_overrides` (Epic 27)
+
+## Logging Requirements
+
+- **INFO**: persona enabled / disabled for the principal (agentId, personaName, mode, tenantId|userId); catalog view requested (count enabled/disabled).
+- **DEBUG**: `IsEnabledForPrincipalAsync` branch taken (implicit-private / enabled-public / no-row), `GetEnabledDefaultPersonaIdAsync` outcome (configured-default / single-enabled / none), enablement upsert duration, seeded-default applied (or skipped because a row exists).
+- **WARN**: enable/disable target no longer a live public agent ⇒ ignored/degraded (agentId); disable-own-private rejected (409); cross-tenant target ⇒ 404 (caller principal, target id).
+- **ERROR**: DCB event append failure (the write still committed; the append failure is logged, not swallowed silently); migration / DB write failure; XOR/unique-constraint violation surfaced from EF.
+- **Structured context**: include `{ agentId, personaName, mode, tenantId, userId }` where applicable.
+- **Credential safety**: enablement data is credential-agnostic (it references agent ids + persona names, never provider keys). NEVER log provider credentials — keys resolve later in 32-3 from the secret cabinet; enablement never touches them.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-21 | 1.0.0   | Initial story creation | Claude |
+| 2026-06-21 | 1.0.1   | Cross-spec reconciliation (C2/C3): split the enablement contract into a read-only `ITenantAgentEnablementReader` (the seam 32-18 injects) + write/admin `ITenantAgentEnablementService : ITenantAgentEnablementReader`; standardized the three read primitives on async signatures with an explicit `Principal` arg (`IsEnabledForPrincipalAsync`, `ListEnabledPublicAgentIdsAsync`); **defined `GetEnabledDefaultPersonaIdAsync(principal) -> Task<Guid?>`** (configured default if enabled, else single unambiguous enabled persona, else null) for 32-18 to consume. | Claude |

--- a/docs/stories/epic-32/story-32-17/32-17-custom-agent-prompts.md
+++ b/docs/stories/epic-32/story-32-17/32-17-custom-agent-prompts.md
@@ -1,0 +1,346 @@
+# Story 32-17: Custom-Agent Prompts (`ConfigJson.prompts` + resolver prompt-source branch)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide includes the 7-Phase Development Workflow (Read → Research → Break Down → TDD → Quality Gates → Failure Handling), Knowledge Base usage (`.dev/` directory), TRACE/DEBUG logging requirements, Test-Driven Development, 100% critical-path coverage, and build-success enforcement.
+
+**Failure to follow this process will result in rework.**
+
+## User Story
+
+As a **tenant owner/admin (SaaS) or the sole user (single-user) who needs prompts different from the system defaults**,
+I want **to author a self-contained private (custom) agent that carries its OWN prompts alongside its provider+model+config**,
+So that **I can customize agent behaviour without editing the shared role/action prompt store** — the sanctioned escape hatch that Epic 27 deliberately does NOT expose as per-tenant persona-prompt editing in SaaS, and so that the managed execution path resolves a custom agent's prompts from the agent itself (fail-loud) while public personas keep resolving prompts from the Epic 27 store.
+
+## Priority
+
+P0 — This is **sequence step D** of the Epic 32 architecture pivot (locked-model **rule 5: custom prompts ⇔ custom agent**). It establishes the only sanctioned way a tenant gets different prompts under the revised model, and it owns the **custom/private branch** of `MaterialiseAsync` that the managed `call-LLM` path (32-5) depends on for prompt resolution. Without it, a tenant has no prompt-customization story at all in SaaS, and `MaterialiseAsync` has only the persona/public branch (32-15) — leaving private agents prompt-less and the no-empty-fallback invariant unenforced.
+
+## Context
+
+Under the revised agent architecture (`docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` §3.2, rule 5), the locked model redefines a **custom agent** as *a private `Agent` whose differentiator is its own prompts*. The private-`Agent` entity already shipped in **32-1** (`Visibility=Private`, owner-keyed, versioned `AgentVersion.ConfigJson` jsonb, the `ck_agents_visibility_ownership` XOR CHECK, and the per-owner partial indexes `IX_agents_private_tenant_name` / `IX_agents_private_user_name`). What 32-1 did **not** give it is a place to carry tenant-authored prompts, and what the revised model forbids is editing the shared Epic 27 role/action prompt store on a per-tenant basis in SaaS (CLAUDE.md: "No per-user override layer in SaaS … per-user personalization on top of tenant prompts is intentionally NOT a feature"). The custom agent **is** that missing prompt layer — a self-contained, owner-scoped artifact.
+
+This story adds the **optional `prompts` block** to the `AgentVersion.ConfigJson` shape (no new entity, no new column — a JSON sub-object inside the existing jsonb column), the **validation invariant** that public personas reject a non-empty `prompts` block (prompt-free by contract, rule 4), and the **custom/private branch** of `AgentResolverService.MaterialiseAsync` that sources the rendered prompt from the agent's own `prompts` instead of the Epic 27 store. Both branches **fail loud, never empty/plain** (`feedback_resolution_no_empty_fallback`).
+
+**Branch ownership is split across three sibling stories and MUST NOT be double-implemented:**
+
+| Concern | Owner | Seam |
+|---|---|---|
+| `MaterialiseAsync` **persona/public** branch → Epic 27 store `(principal, role, action)` | **32-15** (persona reframe + Epic-27 wiring) | `IPersonaPromptResolver` |
+| `MaterialiseAsync` **custom/private** branch → the agent's own embedded `prompts` + the `ConfigJson.prompts` schema + the public-must-be-empty invariant | **THIS story (32-17)** | `ICustomAgentPromptResolver` |
+| Registry **enablement gate** in selection (`SelectForRoleAsync`/`ResolveUsableAgentAsync`) | **32-18** (amends 32-2) | `ITenantAgentEnablementReader` |
+
+This story therefore introduces a single, documented `if (agent is custom/private with embedded prompts) → own prompts via this story's `ICustomAgentPromptResolver`; else → delegate to 32-15's `IPersonaPromptResolver`` conditional. 32-15 owns the `else` leg (the `IPersonaPromptResolver` seam by that exact name); this story owns the `if` leg (the parallel `ICustomAgentPromptResolver` seam) and the schema/validation. The branch contract is defined here so the two compose into one `MaterialiseAsync` without either re-implementing the other's leg.
+
+## Acceptance Criteria
+
+1. **`ConfigJson.prompts` schema is defined and documented.** The `AgentVersion.ConfigJson` saved-config shape (32-1) gains an **optional** top-level `prompts` block: `{ provider, model, params, prompts?: { system?: string, byRoleAction?: { "<role>:<action>": string, ... } } }`. The block is **absent by default**; only private/custom agents may carry it. A typed C# model `AgentPromptSet { string? System; IReadOnlyDictionary<string,string>? ByRoleAction; }` (`apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentPromptSet.cs`) deserializes it. `byRoleAction` keys are `"<role>:<action>"` using the Epic 27 `AgentRole`/`AgentAction` wire forms (validated, not free-form).
+
+2. **Public personas reject a non-empty `prompts` block (the prompt-free invariant, rule 4).** `AgentConfigValidator.Validate` (extended from 32-1) is amended so that when the agent being created/published is `Visibility=public`, a `ConfigJson` carrying a **non-empty** `prompts` block (any `system` or any `byRoleAction` entry) is **rejected** with a clear validation error (`PROMPTS_NOT_ALLOWED_ON_PUBLIC`). Public agents may omit `prompts` entirely or carry an empty/null block; a populated one is a hard error → 400, no row written, no event emitted. Private agents may carry a populated `prompts` block (or none).
+
+3. **`prompts` content is validated when present.** When a `prompts` block is non-empty: each `byRoleAction` key parses as `"<role>:<action>"` with `role`/`action` valid per `RolePhaseMap.NormalizeRole` / the Epic 27 `AgentAction` taxonomy (invalid key → reject `PROMPTS_INVALID_KEY`); each template value is a non-empty string after trim (empty/whitespace value → reject `PROMPTS_EMPTY_TEMPLATE`, consistent with no-empty-fallback); prototype-pollution keys (`__proto__`, `constructor`, `prototype`) are rejected (reusing the existing 32-1 guard). Validation runs **before any write** in both the create and publish-version paths.
+
+4. **`MaterialiseAsync` gains the custom/private prompt-source branch as the `ICustomAgentPromptResolver` seam.** `AgentResolverService.MaterialiseAsync` (extended jointly with 32-15) resolves the system/role prompt via a **single documented conditional**: if the resolved agent is **private/custom AND its `ConfigJson.prompts` is non-empty**, the prompt is sourced from the agent's own `AgentPromptSet` via this story's **`ICustomAgentPromptResolver.ResolveAsync(...)`** seam; otherwise control flows to the persona/public branch via 32-15's **`IPersonaPromptResolver`** seam (→ Epic 27 store). This story implements **only** the `if` (custom/private) leg + the `ICustomAgentPromptResolver` seam and the branch selector; it MUST NOT re-implement the Epic 27 persona leg (32-15's `IPersonaPromptResolver` owns it).
+
+5. **Custom prompt resolution order is `byRoleAction[role:action] → system → ERROR` (fail-loud, never empty/plain).** For a custom agent at call time with `(role, action)`: (a) if `prompts.byRoleAction["<role>:<action>"]` exists, use it; (b) else if `prompts.system` exists, use it as the system prompt; (c) else — if the custom branch was entered (non-empty `prompts`) but neither a matching role:action nor a system entry resolves for the requested `(role, action)` — **fail loud** with a typed error (`CUSTOM_PROMPT_UNRESOLVED`), **never** fall back to an empty/plain prompt and **never** silently fall through to the Epic 27 store. (A custom agent with an *empty* `prompts` block does not enter the custom branch at all — it is treated as a persona-style agent and resolves via 32-15; only a *non-empty* `prompts` block commits the agent to the custom branch and its fail-loud contract.)
+
+6. **No schema migration beyond validation/CHECK; no new entity.** A custom agent remains a `Visibility=Private` `Agent`/`AgentVersion` from 32-1. `prompts` lives **inside** the existing `ConfigJson` jsonb column — there is **no new table, no new column**. The only persistence-layer delta is **validation logic** (AC2/AC3) and, optionally, a lightweight DB `CHECK` (or application-level guard) asserting public agents carry no populated `prompts`; the existing `ck_agents_visibility_ownership` CHECK and per-owner partial indexes are **reused unchanged**. If a DB `CHECK` is added it is an additive amendment to the existing `agents`/`agent_versions` config in `TammaModelConfiguration.cs` (single source) on the existing migration snapshot — it does NOT branch the snapshot.
+
+7. **DCB events reflect the prompt source, without leaking template content.** When a managed run resolves a custom prompt, the existing `AGENT.RUN.*` (32-5) / resolution events are tagged `promptSource = "custom-agent"` (vs `"epic27-store"` for the persona branch, owned by 32-15); `agentId`/`version` already identify which custom agent. **Prompt template bodies are NEVER placed in event `Data`/`Tags` or logs** — only the source label and the resolved key (`<role>:<action>`). A `CUSTOM_PROMPT_UNRESOLVED` failure surfaces as a typed failure on the managed-run result (32-5 `FailureCode`), not a thrown bare exception, and emits the standard terminal failed event.
+
+8. **Unit + integration tests** cover: schema deserialization (full block, `system`-only, `byRoleAction`-only, absent); public-with-populated-prompts rejected on create AND publish (AC2); invalid `byRoleAction` key, empty template value, prototype-pollution key rejected (AC3); private-with-prompts accepted; `MaterialiseAsync` custom branch picks `byRoleAction` over `system` over ERROR; `CUSTOM_PROMPT_UNRESOLVED` is fail-loud (no empty fallback, no fall-through to Epic 27); a custom agent with an empty `prompts` block delegates to the persona branch (32-15) and does NOT enter the custom branch; `promptSource` tag is `custom-agent`; no template body appears in any emitted event or log line.
+
+## Technical Design
+
+### Where it lives
+
+```
+apps/tamma-elsa/src/Tamma.Api/Services/Agents/
+  AgentPromptSet.cs              # NEW — typed model for ConfigJson.prompts { System, ByRoleAction }
+  ICustomAgentPromptResolver.cs  # NEW — custom/private prompt seam (byRoleAction -> system -> ERROR, fail-loud)
+  CustomAgentPromptResolver.cs   # NEW — impl reading the agent's ConfigJson.prompts
+  AgentConfigValidator.cs        # MODIFY (from 32-1) — public-must-be-empty invariant + prompts shape rules
+  AgentResolverService.cs        # MODIFY (jointly with 32-15) — custom branch = ICustomAgentPromptResolver; persona branch = 32-15 IPersonaPromptResolver
+  IAgentResolverService.cs       # MODIFY (only if a prompt-source enum/return field is surfaced)
+  AgentPromptSource.cs           # NEW — enum { Epic27Store, CustomAgent } for the resolved-prompt provenance tag
+
+apps/tamma-elsa/src/Tamma.Data/
+  TammaModelConfiguration.cs     # MODIFY (optional) — additive CHECK ck_agents_public_no_prompts (or app-level guard)
+  Migrations/ControlPlane/
+    <ts>_AddPublicAgentNoPromptsCheck.cs  # NEW (optional) — additive CHECK only, no column/table
+```
+
+> No new entity, no `DbSet`, no `ControlPlaneDbContext` change → **no `ControlPlaneDbContextModelTests` strict-list edit and no Program.cs startup-reset DROP-list edit** (those are required only when adding a *table*; this story adds at most a CHECK on the existing `agents` table). If the public-no-prompts guard is enforced purely in `AgentConfigValidator` (recommended, see Risks), there is **no migration at all**.
+
+### The `prompts` block — `ConfigJson` shape (AC1)
+
+```jsonc
+// AgentVersion.ConfigJson for a PRIVATE/CUSTOM agent (the new optional "prompts" block):
+{
+  "provider": "anthropic",
+  "model": "claude-sonnet-4-20250514",
+  "params": { "temperature": 0.4, "maxTokens": 4096, "tokenBudget": 200000 },
+  "tools": ["file-read", "shell-execute"],
+  "prompts": {                                   // OPTIONAL — private agents only
+    "system": "You are ACME's house implementer. Always cite the ADR.",
+    "byRoleAction": {
+      "implementer:write-implementation": "Implement per ACME conventions: ...",
+      "reviewer:review-pr": "Review against ACME's security checklist: ..."
+    }
+  }
+}
+
+// AgentVersion.ConfigJson for a PUBLIC PERSONA (rule 4 — prompts MUST be absent/empty):
+{
+  "provider": "anthropic",
+  "model": "claude-sonnet-4-20250514",
+  "params": { "temperature": 0.3, "maxTokens": 4096 }
+  // NO "prompts" key (a populated one => PROMPTS_NOT_ALLOWED_ON_PUBLIC)
+}
+```
+
+### Typed model (C#)
+
+```csharp
+namespace Tamma.Api.Services.Agents;
+
+/// <summary>
+/// The optional embedded prompt set carried by a CUSTOM (private) agent inside
+/// AgentVersion.ConfigJson["prompts"] (Epic 32 rule 5: custom prompts ⇔ custom agent).
+/// Public personas are prompt-free by contract and MUST leave this null/empty —
+/// their prompts come from the Epic 27 store (resolved by sibling story 32-15).
+/// </summary>
+public sealed record AgentPromptSet
+{
+    /// <summary>Fallback system prompt used when no role:action template matches.</summary>
+    public string? System { get; init; }
+
+    /// <summary>Templates keyed by "&lt;role&gt;:&lt;action&gt;" (Epic 27 wire forms).</summary>
+    public IReadOnlyDictionary<string, string>? ByRoleAction { get; init; }
+
+    public bool IsEmpty =>
+        string.IsNullOrWhiteSpace(System) && (ByRoleAction is null || ByRoleAction.Count == 0);
+}
+
+/// <summary>Provenance of a resolved agent prompt — emitted as the promptSource tag.</summary>
+public enum AgentPromptSource { Epic27Store, CustomAgent }
+```
+
+### Validation invariant (AC2/AC3) — extends 32-1's `AgentConfigValidator`
+
+`AgentConfigValidator.Validate(configJson, visibility)` is extended (32-1 introduced the validator; this story adds the `visibility` discriminator and the `prompts` rules — both `CreateAsync`- and `PublishVersionAsync`-backing endpoints call it):
+
+```csharp
+// pseudo — additive rules layered onto the existing 32-1 shape validation
+var prompts = TryReadPromptSet(configJson);   // null if "prompts" key absent
+
+if (visibility == AgentVisibility.Public && prompts is { IsEmpty: false })
+    errors.Add("PROMPTS_NOT_ALLOWED_ON_PUBLIC: public personas are prompt-free (Epic 32 rule 4)");
+
+if (prompts is { IsEmpty: false })
+{
+    foreach (var kvp in prompts.ByRoleAction ?? Empty)
+    {
+        if (IsPrototypePollutionKey(kvp.Key)) errors.Add("PROMPTS_PROTO_POLLUTION");          // reuse 32-1 guard
+        else if (!TryParseRoleAction(kvp.Key, out _, out _)) errors.Add("PROMPTS_INVALID_KEY"); // RolePhaseMap.NormalizeRole + AgentAction
+        if (string.IsNullOrWhiteSpace(kvp.Value)) errors.Add("PROMPTS_EMPTY_TEMPLATE");        // no-empty-fallback
+    }
+    // a "prompts" object that parses but is wholly empty is allowed (treated as absent) for private agents
+}
+```
+
+> Reuses the existing 32-1 prototype-pollution / ReDoS / shape guards; this story adds only the `visibility`-conditional rejection and the role:action key + non-empty-template rules.
+
+### `MaterialiseAsync` — the documented conditional branch (AC4/AC5)
+
+The single branch selector. **This story owns the `if` (custom) leg + the `ICustomAgentPromptResolver` seam + the selector; 32-15 owns the `else` (persona/Epic 27) leg via `IPersonaPromptResolver`.** Neither re-implements the other.
+
+```csharp
+// NEW seam (this story owns it). The CUSTOM/PRIVATE prompt leg.
+public interface ICustomAgentPromptResolver
+{
+    /// <summary>Resolve a custom (private) agent's prompt from its own ConfigJson.prompts:
+    /// byRoleAction["<role>:<action>"] -> system -> ERROR. Fail-loud, NEVER empty/plain,
+    /// NEVER fall through to the Epic 27 store.</summary>
+    Task<RenderedPrompt> ResolveAsync(Agent agent, string role, string? action, CancellationToken ct);
+}
+```
+
+```csharp
+// AgentResolverService.MaterialiseAsync(...) — prompt-source section (joint with 32-15)
+//
+//   resolved = base config merged onto DefaultAgentConfig.ForRole(role)  // (existing 32-1/32-2)
+//
+// PROMPT SOURCE — single documented conditional (Epic 32 §3.2):
+var promptSet = (resolved.Visibility == AgentVisibility.Private)
+    ? TryReadPromptSet(resolved.ConfigJson)
+    : null;
+
+if (promptSet is { IsEmpty: false })
+{
+    // ── CUSTOM / PRIVATE branch (THIS story 32-17, via ICustomAgentPromptResolver) ──────
+    //    byRoleAction["<role>:<action>"] -> system -> ERROR. The resolver fails loud
+    //    (CustomPromptUnresolvedException) — NEVER empty/plain, NEVER fall through to Epic 27.
+    resolved = resolved with {
+        SystemPrompt = (await _customAgentPrompts.ResolveAsync(resolved.Agent, role, action, ct)).Text,
+        PromptSource = AgentPromptSource.CustomAgent
+    };
+}
+else
+{
+    // ── PERSONA / PUBLIC branch (sibling story 32-15, via IPersonaPromptResolver) ───────
+    //    persona/public → Epic 27 store (principal, role, action); tenant→system→ERROR.
+    //    (Owned by 32-15 — this story does NOT implement this leg.)
+    resolved = resolved with {
+        SystemPrompt = (await _personaPrompts.ResolveAsync(principal, role, action, ct)).Text,
+        PromptSource = AgentPromptSource.Epic27Store
+    };  // _personaPrompts is the 32-15 IPersonaPromptResolver seam
+}
+```
+
+> `_customAgentPrompts` is this story's `ICustomAgentPromptResolver`; `_personaPrompts` is 32-15's `IPersonaPromptResolver`. The selector body (`byRoleAction → system → ERROR`) lives **inside** `ICustomAgentPromptResolver.ResolveAsync`, which throws `CustomPromptUnresolvedException` on no-resolve. That exception (or a typed result, depending on the `RenderedPrompt` contract 32-15 settles on) is caught by the managed `call-LLM` path (32-5) and mapped to `AgentRunResult { Success=false, FailureCode="CUSTOM_PROMPT_UNRESOLVED" }` — it never propagates as a bare exception out of a managed run (AC7).
+
+### Provenance tagging (AC7)
+
+The resolved config carries `PromptSource ∈ { CustomAgent, Epic27Store }`. The managed run (32-5) tags its `AGENT.RUN.*` / resolution events `promptSource = "custom-agent" | "epic27-store"` and the resolved key `<role>:<action>`. **Template bodies never enter `Tags`, `Data`, or logs** — only the source label and the key. (Consistent with 32-1's "never log raw `ConfigJson` if it could carry sensitive content".)
+
+### What this story does NOT do (boundary, for unambiguous composition)
+
+- It does **not** implement the persona/public → Epic 27 prompt branch (that is **32-15**); it only defines the branch selector and calls the persona leg via 32-15's `IPersonaPromptResolver` seam.
+- It does **not** add the registry **enablement gate** to selection (`SelectForRoleAsync`/`ResolveUsableAgentAsync`) — that is **32-18**.
+- It does **not** add a new entity, table, or column, and does **not** touch `TenantAgentEnablement` (32-16).
+- It does **not** change the credential resolution (32-3), the gate (32-4), or the cost/metering (32-9/34) — only the prompt-source leg of agent resolution.
+
+## Dependencies
+
+**Internal:**
+
+- **Story 32-1** (Agent entity model & versioned saved config) — provides `Agent`/`AgentVersion`, the `ConfigJson` jsonb column, `AgentConfigValidator`, the `ck_agents_visibility_ownership` CHECK, the per-owner partial indexes, and `Visibility`. **Hard prerequisite** — this story extends the validator and the config shape it owns.
+- **Story 32-15** (Persona reframe + seeding + `MaterialiseAsync` persona/Epic-27 branch) — owns the **persona/public** leg of the same `MaterialiseAsync` conditional and the **`IPersonaPromptResolver`** seam this story's selector calls. **Hard prerequisite / co-author of `MaterialiseAsync`** — the two stories must land the branch together; sequence 32-15 (step B) before this (step D).
+- **Epic 27** (prompt/convention store, `AgentRole`/`AgentAction` taxonomy) — provides `RolePhaseMap.NormalizeRole` + the `AgentAction` wire forms used to validate `byRoleAction` keys; the persona branch (via 32-15) resolves against its store. The custom branch deliberately does NOT write to or read from the Epic 27 store (it is the escape hatch *around* it).
+- **Story 32-2** (Agent registry/resolution) — owns `AgentResolverService`/`IAgentResolverService` and `MaterialiseAsync`; this story modifies it (custom-branch leg). 
+- **Story 32-5** (Managed execution / `call-LLM`) — **consumer**: maps `CUSTOM_PROMPT_UNRESOLVED` to a typed `FailureCode` and emits the `promptSource`-tagged events. Not a blocker for authoring; the resolved-config contract (`PromptSource`, fail-loud) is what 32-5 consumes.
+
+**Consumers (downstream, not blockers):**
+
+- **Story 32-5** — uses the custom-resolved `SystemPrompt` + `PromptSource` in the managed run.
+- **Story 32-18** (enablement gate) — composes with the same `MaterialiseAsync`; orthogonal to the prompt-source leg.
+
+**External:** none new.
+
+## Testing Strategy
+
+1. **Schema deserialization** (`AgentPromptSetTests`): `prompts` absent → null; full block → `System` + `ByRoleAction` populated; `system`-only and `byRoleAction`-only round-trip; a `prompts: {}` object → `IsEmpty == true`.
+2. **Public-must-be-empty, create path** (`AgentConfigValidatorTests`): `Visibility=public` + populated `prompts` (any `system` or any `byRoleAction`) → rejected `PROMPTS_NOT_ALLOWED_ON_PUBLIC`; no row, no event. Public + absent/empty `prompts` → accepted.
+3. **Public-must-be-empty, publish-version path**: same rejection when publishing a new version of an existing public persona (AC2 applies to both endpoints).
+4. **Private accepts prompts**: `Visibility=private` + populated `prompts` → accepted; `Visibility=private` + absent `prompts` → accepted (a custom agent may carry no prompts and behave persona-like).
+5. **`prompts` content validation** (AC3): invalid `byRoleAction` key (`"bogus:nope"`, missing colon, unknown action) → `PROMPTS_INVALID_KEY`; empty/whitespace template value → `PROMPTS_EMPTY_TEMPLATE`; `__proto__`/`constructor`/`prototype` key → `PROMPTS_PROTO_POLLUTION`.
+6. **`MaterialiseAsync` custom branch — selection order** (`AgentResolverServicePromptBranchTests`): custom agent with both → `byRoleAction[role:action]` wins; with only `system` and a non-matching `(role, action)` → `system` used; with neither matching → `CUSTOM_PROMPT_UNRESOLVED` (fail-loud), and the Epic 27 store is **never** consulted (assert the `IPersonaPromptResolver` seam is NOT invoked).
+7. **Empty-prompts delegates to persona branch**: custom/private agent with an empty `prompts` block → custom branch NOT entered → 32-15's `IPersonaPromptResolver.ResolveAsync` is invoked; `PromptSource == Epic27Store`.
+8. **No-empty-fallback invariant**: assert no code path returns an empty/plain prompt for a custom agent — `CUSTOM_PROMPT_UNRESOLVED` is the only outcome when nothing resolves (mirrors `feedback_resolution_no_empty_fallback`).
+9. **Provenance tag / no-leak** (AC7): a resolved custom prompt sets `PromptSource=CustomAgent`; the managed run's emitted event carries `promptSource="custom-agent"` and the key `"<role>:<action>"` but **no template body** appears in any event `Data`/`Tags` or log line (assert via a fake `IEventRepository` + a captured-log assertion).
+10. **(Optional, if a DB CHECK is added)** integration: inserting a public `agent_versions` row with populated `prompts` violates `ck_agents_public_no_prompts` against a real Postgres fixture; `has-pending-model-changes` reports none after the additive CHECK migration.
+
+Docker-bound C# suites run via `sg docker -c "dotnet test apps/tamma-elsa/..."` (session docker group is stale; plain `dotnet build` needs no wrapper).
+
+## Estimated Effort
+
+2-3 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentPromptSet.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentPromptSource.cs` | Create (enum) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ICustomAgentPromptResolver.cs` | Create (custom/private prompt seam — `byRoleAction → system → ERROR`, fail-loud) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/CustomAgentPromptResolver.cs` | Create (impl reading the agent's `ConfigJson.prompts`) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/CustomPromptUnresolvedException.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentConfigValidator.cs` | Modify (public-must-be-empty + prompts shape rules) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentResolverService.cs` | Modify (custom branch = `ICustomAgentPromptResolver`; persona branch = 32-15 `IPersonaPromptResolver` — joint with 32-15) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/IAgentResolverService.cs` | Modify (surface `PromptSource` on resolved config, if not already from 32-15) |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (optional additive CHECK `ck_agents_public_no_prompts`) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_AddPublicAgentNoPromptsCheck.cs` (+ `.Designer.cs`, snapshot) | Create (optional — CHECK only, no column/table) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentPromptSetTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentConfigValidatorPromptsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentResolverServicePromptBranchTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, decisions (especially `feedback_resolution_no_empty_fallback`)
+3. Read the design of record §3.0, §3.1, §3.2 (`docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md`) and the companion 32-15 story (the co-author of `MaterialiseAsync`)
+4. Reviewed 32-1's `AgentConfigValidator`, `AgentVersion.ConfigJson` shape, the `ck_agents_visibility_ownership` CHECK, and the per-owner partial indexes — this story extends them, it does not redefine them
+5. Confirmed with the 32-15 author exactly where the `MaterialiseAsync` conditional lives and the shape of the `IPersonaPromptResolver` seam (so the two legs compose without a merge conflict or a double-implemented branch)
+6. Planned the TDD approach (Red-Green-Refactor)
+
+### Key Design Decisions
+
+- **Custom prompts ⇔ custom agent (rule 5).** Tenants never edit the shared Epic 27 store in SaaS; they author a private agent that carries its own prompts. This keeps audit/compliance simple (one artifact, owner-scoped, versioned) and avoids "one user's customization broke an agent run" support cases (CLAUDE.md Prompt Store rationale).
+- **The `prompts` block is a JSON sub-object, not a new entity.** A custom agent is *just* a `Visibility=Private` `Agent` (32-1). The whole schema delta is an optional key inside the existing `ConfigJson` jsonb + a validation rule — deliberately minimal, no migration anxiety, reuses every 32-1 invariant.
+- **One documented conditional, two owners.** `MaterialiseAsync` has exactly one prompt-source `if/else`. This story owns the `if` (custom) leg + the selector; 32-15 owns the `else` (persona/Epic 27) leg. Documenting the boundary here is what lets the two stories land without either re-implementing `MaterialiseAsync`.
+- **Fail loud, never empty/plain (both branches).** A non-empty `prompts` block commits the agent to the custom branch and its `byRoleAction → system → ERROR` contract — it must never silently fall through to the Epic 27 store, and never resolve to an empty prompt. An *empty* `prompts` block is treated as absent and delegates to the persona branch. This is the `feedback_resolution_no_empty_fallback` rule applied to the new escape hatch.
+- **Prompt-free public personas (rule 4).** The public-must-be-empty invariant is the structural enforcement that personas have no custom prompts — without it, a public persona could smuggle prompts and break the "personas resolve from Epic 27" guarantee.
+- **Validation, not a column.** Enforcing public-no-prompts in `AgentConfigValidator` (recommended) keeps the migration footprint at zero. A DB `CHECK` is offered as belt-and-suspenders but is optional; if added, it is an additive CHECK on the existing table, never a snapshot branch.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who may author a custom agent (and thus custom prompts)? | The sole user (the principal). The private `Agent` is keyed `OwnerUserId` (32-1). | The `tenant_owner`/`tenant_admin`. The private `Agent` is keyed `OwnerTenantId`. A **member** cannot create/publish a custom agent → 403 (mirrors 32-1 RBAC + Prompt Store RBAC). |
+| Whose `ConfigJson.prompts` does a run use? | The user's own custom agent's embedded prompts (when a populated `prompts` block is present and the run resolves it). | The tenant's own custom agent's embedded prompts. **No per-user prompt layer** — members run the tenant's custom agents as-authored, no personal override (CLAUDE.md: per-user personalization is intentionally NOT a feature). |
+| Where do public personas get prompts? | Epic 27 store keyed `(userId, role, action)` via the 32-15 persona branch. | Epic 27 store keyed `(tenantId, role, action)` via the 32-15 persona branch. Custom prompts are the only per-tenant prompt customization; the shared store is not per-tenant editable in SaaS. |
+| What is the prompt-source provenance? | `PromptSource=CustomAgent` for a resolved custom prompt; `Epic27Store` for a persona. | Same. Tagged on `AGENT.RUN.*`; performance/prompt-source data is tenant-scoped, never cross-tenant. |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`) — process-stable; also drives the 32-1 owner-column derivation. | same |
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `MaterialiseAsync` branch double-implemented by 32-15 and 32-17 (merge conflict / two `if`s) | High | This story documents the single conditional + the exact leg ownership; sequence 32-15 (B) before 32-17 (D); co-author the one `if/else` against the `IPersonaPromptResolver` (32-15) + `ICustomAgentPromptResolver` (32-17) seams; a test asserts the custom branch never calls the persona seam and vice-versa. |
+| Custom agent silently falls through to Epic 27 / empty prompt (no-empty-fallback violation) | High | A non-empty `prompts` block commits to the custom branch; `CUSTOM_PROMPT_UNRESOLVED` is the only no-resolve outcome; explicit test asserts the persona seam is NOT consulted and no empty/plain prompt is returned. |
+| Public persona smuggles prompts → breaks "personas resolve from Epic 27" | High | `PROMPTS_NOT_ALLOWED_ON_PUBLIC` rejected at create AND publish; optional DB `CHECK` as backstop; tested on both endpoints. |
+| Prompt template body leaks into events/logs | Medium | Only `promptSource` + the `<role>:<action>` key are tagged/logged; a test asserts no body appears in event `Data`/`Tags` or captured logs (extends 32-1's no-raw-ConfigJson rule). |
+| Optional DB CHECK adds a migration that branches the snapshot | Low | Prefer validator-only enforcement (zero migration). If a CHECK is added it is an additive amendment to the existing `agents`/`agent_versions` config on the single snapshot — never a baseline/branch edit; `has-pending-model-changes` must report none. |
+| `byRoleAction` key taxonomy drifts from Epic 27 | Medium | Validate keys via the same `RolePhaseMap.NormalizeRole` / `AgentAction` taxonomy Epic 27 uses; reuse 32-1's role-normalization path on write. |
+
+### Success Metrics
+
+- [ ] A tenant can author a private custom agent with prompts and have a managed run resolve them — without any edit to the shared Epic 27 prompt store.
+- [ ] 100% of public-persona create/publish attempts carrying a populated `prompts` block are rejected.
+- [ ] `MaterialiseAsync` has exactly one prompt-source conditional (grep), with the custom leg owned here (`ICustomAgentPromptResolver`) and the persona leg owned by 32-15 (`IPersonaPromptResolver`) — no duplicate branch.
+- [ ] Zero custom-prompt resolutions fall back to empty/plain (every no-resolve is a typed `CUSTOM_PROMPT_UNRESOLVED`).
+
+## Related
+
+- Design of record: `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§3.0, §3.1, §3.2 — rule 5)
+- Re-plan / story disposition + sequence: `docs/superpowers/plans/2026-06-20-epic-32-37-replan.md`
+- Implementation plan: `docs/superpowers/plans/2026-06-21-32-17-custom-agent-prompts-plan.md`
+- Sibling stories: `docs/stories/epic-32/story-32-1/` (Agent entity + validator + CHECK/indexes — extended here), 32-15 (persona/Epic-27 branch — co-author of `MaterialiseAsync`), 32-16 (per-tenant enablement), 32-18 (registry enablement gate), 32-5 (managed `call-LLM` consumer)
+- Resolution discipline: `.dev/findings/feedback_resolution_no_empty_fallback` (tenant→system→ERROR; NEVER empty/plain)
+
+## Logging Requirements
+
+- **INFO**: custom prompt resolved for a managed run (`agentId, version, role, action, promptSource="custom-agent"`); public-no-prompts validation rejected on create/publish (`agentId|name, visibility`).
+- **DEBUG**: prompt-source branch selected (`custom-agent` vs `epic27-store`), `byRoleAction` key matched vs `system` fallback used (key only, never the template body).
+- **WARN**: `CUSTOM_PROMPT_UNRESOLVED` (a non-empty `prompts` block resolved neither `<role>:<action>` nor `system` — `agentId, role, action`); `prompts` validation rejections (`PROMPTS_NOT_ALLOWED_ON_PUBLIC`, `PROMPTS_INVALID_KEY`, `PROMPTS_EMPTY_TEMPLATE`, `PROMPTS_PROTO_POLLUTION`) with the offending key, **never** the template body.
+- **ERROR**: unexpected deserialization failure of a `prompts` block already validated at write time (a should-not-happen invariant breach).
+- **Structured context**: include `{ agentId, version, role, action, visibility, promptSource }` where applicable.
+- **Credential / content safety**: **NEVER** log a prompt template body, the full `ConfigJson`, or any `byRoleAction` value — only the source label and the `<role>:<action>` key. Prompts may carry tenant-proprietary instructions; treat them as sensitive content (extends 32-1's no-raw-ConfigJson rule). No credentials are involved in this story, but the same redaction discipline applies to prompt bodies.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-21 | 1.0.0   | Initial story creation | Claude |
+| 2026-06-21 | 1.0.1   | Cross-spec reconciliation (C1): the custom/private prompt leg is now an explicit parallel seam `ICustomAgentPromptResolver.ResolveAsync(agent, role, action?, ct)` (was the unnamed `if` leg); the persona-leg delegation points at 32-15's `IPersonaPromptResolver` by that exact name (replacing the phantom `_personaPromptBranch`). | Claude |

--- a/docs/stories/epic-32/story-32-18/32-18-registry-enablement-gate-and-prompt-source.md
+++ b/docs/stories/epic-32/story-32-18/32-18-registry-enablement-gate-and-prompt-source.md
@@ -1,0 +1,411 @@
+# Story 32-18: Agent Registry Enablement Gate + Epic-27 Prompt Source (amends 32-2)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **tenant owner/admin (SaaS) or self-hosted user (single-user)**,
+I want the agent registry to select and resolve only the personas/agents my tenant has **enabled**, and to pull a persona's system/role prompt from the **Epic 27 prompt store** keyed `(principal, role, action)` instead of from the agent's config,
+So that the shipped 32-2 resolution chain enforces per-tenant enablement (a public persona nobody enabled is not silently usable), the persona reframe (cross-role named personas from 32-15) actually drives prompt selection, and BYOK∘persona credential resolution at call time stays clean — all without forking the registry/resolver or adding a new table.
+
+## Priority
+
+P0 — This is sequence step **E** of the Epic-32 architecture pivot (re-plan §4). The shipped 32-2 `CanUse()` returns `true` for **any** public agent, so the per-tenant enablement layer added by 32-16 is inert until the registry/resolver consume it. Likewise, 32-15's persona reframe makes `Agent.Role` nullable and prompt-free, so `MaterialiseAsync` must pull prompts from Epic 27 — otherwise personas resolve with no prompt. Without this story the call-LLM endpoint (32-5) would resolve un-enabled personas and render empty prompts. It is a hard prerequisite for **F** (the call-LLM lynchpin).
+
+## Context
+
+Story 32-2 (shipped on `feat/exec-wave-02`) built the registry/resolution/RBAC API: a four-branch `ResolveForRoleAsync` precedence chain (tenant-private selection → tenant-public selection → system-default public → fail-loud), `GetSystemDefaultPublicAsync(role)` that matched `Agent.Role == role`, a `CanUse()` predicate that admitted **any** public agent, and a `MaterialiseAsync` that sourced the system prompt from the agent's pinned `ConfigJson`. That was correct under the **old** model (per-role `tamma-<role>` public agents, no enablement layer, prompts baked into agent config).
+
+The revised architecture (`docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` §3) changes three things the registry/resolver must consume:
+
+1. **Personas are cross-role named agents** (32-15): `Agent.Role` is nullable for public personas; `GetSystemDefaultPublicAsync` can no longer find "the public agent whose `Role == role`" — it must return the tenant's **enabled default persona** regardless of role.
+2. **Enablement is per-tenant** (32-16): the new `TenantAgentEnablement` entity records which public personas a tenant exposes. The usable set tightens from `public ∪ own-private` to **`enabled(public) ∪ own-private`**.
+3. **Personas are prompt-free** (§3.1/§3.5): a persona's system/role prompt comes from the **Epic 27** store keyed `(principal, role, action)`; only **custom (private) agents** carry their own prompts (that branch is owned by 32-17).
+
+This story owns the **registry/resolver consumption** of those three changes. It does **not** own the `TenantAgentEnablement` entity/API/events (32-16), the persona seeder / `Agent.Role`-nullable migration / `ConfigJson.prompts` schema (32-15/32-17), nor the credential resolver (32-3). It amends the **existing** 32-2 services in place — no new table, no new migration snapshot branch.
+
+> **Boundary discipline (avoid double-implementation).** The `ITenantAgentEnablementReader` read seam (`IsEnabledForPrincipalAsync` / `ListEnabledPublicAgentIdsAsync` / `GetEnabledDefaultPersonaIdAsync`), the enable/disable endpoints, and `AGENT.ENABLED/DISABLED.SUCCESS` events are **32-16**. The persona seeder, the nullable-`Role` migration, and the **`IPersonaPromptResolver`** seam (the Epic-27 persona-prompt resolution body) are **32-15**. The custom-agent (`ConfigJson.prompts`) prompt branch — the **`ICustomAgentPromptResolver`** seam — is **32-17**. **This story (32-18)** applies the enablement gate inside selection/resolution, returns the `enabled ∪ own-private` visible set, rewrites the enabled-default lookup (consuming `GetEnabledDefaultPersonaIdAsync`), wires the `MaterialiseAsync` prompt-source **PRECEDENCE/dispatch** (public → `IPersonaPromptResolver`, private → `ICustomAgentPromptResolver`) **without re-inlining either resolution body**, and adds `AGENT.SELECT.NOT_ENABLED`.
+
+## Acceptance Criteria
+
+1. **Enablement gate in selection (`SelectForRoleAsync`).** `IAgentRegistryService.SelectForRoleAsync(role, agentId)` rejects a target that is a **public persona NOT enabled for the principal**: it emits `AGENT.SELECT.NOT_ENABLED` and returns/throws a typed failure mapping to **409 Conflict** (`agent_not_enabled`) — selecting a disabled persona is a state conflict, not a missing resource. A target that is the caller's **own private/custom agent** is implicitly enabled (you authored it) and is accepted. A cross-tenant private target still resolves to 404 (existing 32-2 behaviour, unchanged).
+2. **Enablement gate in resolution (`ResolveUsableAgentAsync` / the resolve precedence).** The resolver's "is this selected agent usable?" check changes from `IsPublic` (today: any public ⇒ usable) to **`(IsPublic && IsEnabledForPrincipalAsync) || IsOwnPrivate`** using 32-16's `ITenantAgentEnablementReader.IsEnabledForPrincipalAsync(agentId, principal, ct)` primitive (async). A selection pointing at a persona the tenant has since **disabled** degrades to the next precedence branch (system-default enabled persona), never resolves the disabled persona, and logs a WARN. The `feedback_resolution_no_empty_fallback` rule is preserved end-to-end.
+3. **`CanUseAsync()` rewritten.** The 32-2 `CanUse(agent, principal)` predicate becomes the async `CanUseAsync(agent, principal, ct)` ⇒ `agent.IsPublic ? await _enablement.IsEnabledForPrincipalAsync(agent.Id, principal, ct) : agent.IsOwnedBy(principal)`. No code path treats a public persona as usable solely because it is public.
+4. **Visible/enabled listing.** `ListAsync` (the existing `/api/agents` list) — or a new `ListEnabledAsync` it delegates to — returns **`enabled(public) ∪ own-private`** for the principal, NOT all public ∪ own-private. The filter set (`?role=&visibility=&status=`) still applies on top. A `?includeDisabled=true` query (owner/admin only) MAY return the full catalog with an `enabled` flag per row so admins can see what they could enable; members never see disabled public personas.
+5. **Enabled-default lookup rewritten (`GetSystemDefaultPublicAsync`).** It no longer matches `Agent.Role == role`. It returns the tenant's configured **default persona** (the platform `DefaultPersonaName`, e.g. `claude`) **only if it is enabled for the principal**; if the configured default is not enabled, it returns the principal's enabled default per the tenant's enablement (32-16's notion of "the enabled default"). If the tenant has enabled **no** persona and has no own-private agent for the role, resolution **fails loud** — emits `AGENT.RESOLVE.FAILED` (existing) and throws `TammaError("AGENT.RESOLVE.NO_ENABLED_DEFAULT", severity: High)`. The old per-role ">1 public agent" ambiguity warning is deleted. **No empty/plain fallback.**
+6. **`MaterialiseAsync` prompt-source PRECEDENCE/dispatch only (no inline persona resolve).** This story wires the `MaterialiseAsync` prompt-source PRECEDENCE to dispatch **public personas → `IPersonaPromptResolver` (32-15)** and **private/custom agents → `ICustomAgentPromptResolver` (32-17)**; **this story adds no prompt-resolution body of its own.** It does NOT re-inline the Epic-27 persona resolve (`IPromptStoreService.ResolveAsync`) — that body lives inside 32-15's `IPersonaPromptResolver`. When the resolved agent is a **public persona** (`IsPublic`), `MaterialiseAsync` calls `_personaPrompts.ResolveAsync(principal, role, action, ct)` (the 32-15 seam, which reads the Epic 27 store `(principal, role, action)` tenant→system→error). When the resolved agent is **private/custom**, it calls `_customAgentPrompts.ResolveAsync(agent, role, action, ct)` (the 32-17 seam). Both seams are fail-loud internally (`PROMPT_UNRESOLVED` / `CUSTOM_PROMPT_UNRESOLVED`); **never fall back to empty/plain**. The persona's `ConfigJson` supplies provider/model/params/tools but **MUST NOT** supply the prompt (personas are prompt-free by contract).
+7. **Action key plumbed through resolution.** `ResolveForRoleAsync` / `ResolveForRoleAndPhaseAsync` accept (or derive) the Epic-27 `action` key alongside `role`, so the persona prompt is resolved at `(principal, role, action)` — matching the `LlmCallRequest.action` field the call-LLM endpoint (32-5) passes. When `action` is absent, the action-default Epic-27 branch is used (still tenant→system→error, never empty).
+8. **BYOK∘persona resolve order documented + tied to the resolver.** The resolved `ResolvedAgentConfig` carries `Provider` + `Model` (from the persona, 32-15). The **credential** is resolved separately and later by 32-3's `IProviderCredentialResolver.ResolveAsync(tenantId, resolvedConfig.Provider)` (BYOK→platform) **inside the call-LLM endpoint** — NOT in the registry/resolver. `credentialSource` is decided by `(tenant, persona.provider)`, persona-independent; the registry/resolver never touch a key. This story documents the end-to-end resolve order (enablement gate → resolve config → Epic-27 prompt → 32-3 credential) so 32-5 composes it correctly, and asserts (test) that no registry/resolver code path resolves or logs a credential.
+9. **DCB events.** New: `AGENT.SELECT.NOT_ENABLED` (tags `{ agentId, personaName, role, mode, tenantId|userId }`) on a blocked selection. Existing `AGENT.SELECTED_FOR_ROLE.SUCCESS` / `AGENT.RESOLVE.FAILED` keep firing. A resolution that degrades past a now-disabled selection emits an `AGENT.RESOLVE.DEGRADED` (tags `{ role, staleAgentId, fallbackSource, mode }`) WARN-level event so the disablement is auditable. `AGENT.ENABLED/DISABLED.SUCCESS` are owned by 32-16 (NOT emitted here).
+10. **Per-mode RBAC + principal unchanged from 32-2.** Reads (list/resolve) allowed for any member. Role selection requires `tenant_owner`/`tenant_admin` (member → 403). Principal is `tenant_id` in SaaS, `user_id` in single-user, sourced from `ITammaModeProvider` + `ITenantContext`/`ClaimsPrincipal`. The enablement gate is evaluated against the **same principal** — no per-user enablement layer (matches CLAUDE.md and 32-16).
+11. **No-regression + clean migration graph.** This story **adds no table and no migration**. The 32-2/32-15/32-16 entities and migrations are reused as-is. The legacy `/api/v1/agents/*` JSONB path and `AgentResolverService.ResolveAsync(tenantId, role)` stay byte-for-byte working. `dotnet ef migrations has-pending-model-changes` reports **none** (this story makes service/resolver edits only). The full `dotnet test` suite stays green.
+12. **Unit + integration tests** cover: the enablement gate on selection (enabled persona accepted; disabled persona → 409 + `AGENT.SELECT.NOT_ENABLED`; own-private accepted; cross-tenant private → 404); resolution degrading past a disabled selection to the enabled default; `GetSystemDefaultPublicAsync` returning the enabled default (via the configured default, else `GetEnabledDefaultPersonaIdAsync`) and failing loud when nothing is enabled (`AGENT.RESOLVE.NO_ENABLED_DEFAULT`); persona prompt **dispatched to `IPersonaPromptResolver`** (and the custom branch to `ICustomAgentPromptResolver`) — asserting this story calls neither resolution body directly nor `IPromptStoreService`; the no-empty-fallback propagation; the mode-parameterized principal; and an assertion that no resolver/registry path resolves a credential.
+
+## Technical Design
+
+### Architectural placement (per the Epic 32 design of record)
+
+Per `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` §3.3 ("Changes to 32-2") + §3.1 (prompt source) + §3.5 (BYOK∘persona at call time):
+
+- The **entity + enable/disable API + events** for `TenantAgentEnablement` are **32-16**; this story injects + consumes its `ITenantAgentEnablementReader` read seam (`IsEnabledForPrincipalAsync` / `ListEnabledPublicAgentIdsAsync` / `GetEnabledDefaultPersonaIdAsync`).
+- The **persona seeder**, `Agent.Role`-nullable migration, the public unique index `(Name) WHERE Public`, the explicit `model` in `ConfigJson`, and the **`IPersonaPromptResolver`** seam (the persona/Epic-27 prompt resolution body) are **32-15**.
+- The **custom-agent prompt branch** (`ConfigJson.prompts` + the **`ICustomAgentPromptResolver`** seam) is **32-17**.
+- The **credential resolution** (BYOK→platform, `credentialSource`) is **32-3**, invoked by the call-LLM endpoint (32-5), never by the registry/resolver.
+
+This story (32-18) edits the **existing** 32-2 services — `AgentRegistryService`, `AgentResolverService` — plus a small event-types addition. No new entity, no new table, no new migration.
+
+### What changes in the registry (`AgentRegistryService`)
+
+```csharp
+// Tamma.Api/Services/Agents/AgentRegistryService.cs — MODIFY
+
+// Injected (NEW): the 32-16 enablement read seam. Interface owned by 32-16.
+private readonly ITenantAgentEnablementReader _enablement;   // 32-16
+
+/// <summary>
+/// The usability predicate. CHANGED from "any public agent is usable" to
+/// "public personas are usable only when enabled for the principal;
+/// own-private agents are always usable (you authored them)".
+/// </summary>
+private async Task<bool> CanUseAsync(Agent agent, Principal principal, CancellationToken ct)
+    => agent.IsPublic
+        ? await _enablement.IsEnabledForPrincipalAsync(agent.Id, principal, ct)   // 32-16 (async)
+        : agent.IsOwnedBy(principal);                                            // own-private => implicit
+
+public async Task SelectForRoleAsync(string role, Guid agentId, CancellationToken ct = default)
+{
+    var principal = _principal.Resolve();
+    var agent = await ResolveTargetAsync(agentId, principal, ct);  // public CP ∪ own private; cross-tenant => null
+    if (agent is null)
+        return NotFound(agentId);                                  // 404 — existing 32-2 behaviour
+
+    if (agent.IsPublic && !await _enablement.IsEnabledForPrincipalAsync(agent.Id, principal, ct))   // NEW gate (async)
+    {
+        await _events.AppendAsync(new DomainEvent {
+            Type = AgentEventTypes.SelectNotEnabled,               // "AGENT.SELECT.NOT_ENABLED"
+            Tags = Json(new { agentId, personaName = agent.Name, role, mode = principal.Mode, tenantId = principal.TenantId, userId = principal.UserId }),
+        }, ct);
+        throw new TammaError("AGENT.SELECT.NOT_ENABLED",
+            $"Persona '{agent.Name}' is not enabled for this {principal.ModeLabel}.",
+            severity: Medium, retryable: false);                   // → 409 agent_not_enabled at endpoint
+    }
+    // ... existing upsert + AGENT.SELECTED_FOR_ROLE.SUCCESS ...
+}
+
+/// <summary>enabled(public) ∪ own-private (was: public ∪ own-private).</summary>
+public async Task<IReadOnlyList<AgentSummary>> ListAsync(AgentListFilter filter, CancellationToken ct = default)
+{
+    var principal = _principal.Resolve();
+    var ownPrivate = await ReadOwnPrivateAsync(principal, filter, ct);          // tenant schema
+    var publicAgents = await ReadPublicAsync(filter, ct);                       // CP
+    // batch the enabled-public set in one read (avoids per-row async calls)
+    var enabledIds = (await _enablement.ListEnabledPublicAgentIdsAsync(principal, ct)).ToHashSet();
+    var enabledPublic = publicAgents.Where(a => enabledIds.Contains(a.Id));
+    var rows = enabledPublic.Concat(ownPrivate);
+    // ?includeDisabled=true (owner/admin only) returns the full catalog with an `Enabled` flag.
+    if (filter.IncludeDisabled && _principal.IsTenantAdminOrOwner())
+        rows = publicAgents.Select(a => a.WithEnabled(enabledIds.Contains(a.Id))).Concat(ownPrivate);
+    return ApplyFilters(rows, filter).ToList();
+}
+
+/// <summary>
+/// The tenant's ENABLED default persona — was: the public agent whose Role==role.
+/// Personas are cross-role (Agent.Role is NULL, 32-15), so role is no longer the key.
+/// </summary>
+public async Task<Agent?> GetSystemDefaultPublicAsync(string role, CancellationToken ct = default)
+{
+    var principal = _principal.Resolve();
+    // 1. the platform-configured default persona, IF the tenant enabled it
+    var configuredDefault = await ReadPersonaByNameAsync(_options.DefaultPersonaName, ct);   // e.g. "claude"
+    if (configuredDefault is not null && await _enablement.IsEnabledForPrincipalAsync(configuredDefault.Id, principal, ct))
+        return configuredDefault;
+    // 2. the principal's enabled default per 32-16 (its notion of "the enabled default persona")
+    var enabledDefaultId = await _enablement.GetEnabledDefaultPersonaIdAsync(principal, ct);  // 32-16 (defined there, consumed here)
+    if (enabledDefaultId is { } id)
+        return await ReadPersonaByIdAsync(id, ct);
+    // 3. nothing enabled => caller fails loud (NO empty fallback). Returns null; resolver throws.
+    return null;
+}
+```
+
+> `Principal`, `_principal.Resolve()`, `ResolveTargetAsync`, and the `IsOwnedBy`/`IsOwnExpr` helpers are the 32-2 shapes (renamed here for clarity). `ITenantAgentEnablementReader` (`IsEnabledForPrincipalAsync`, `ListEnabledPublicAgentIdsAsync`, `GetEnabledDefaultPersonaIdAsync` — all async, explicit `Principal` arg) is the **read seam owned by 32-16**; this story **injects and consumes** it, does not define the entity or the primitives. `GetEnabledDefaultPersonaIdAsync` is **defined in 32-16** and matches the signature 32-16 ships (open question resolved — see Dev Notes).
+
+### What changes in the resolver (`AgentResolverService`)
+
+```csharp
+// Tamma.Api/Services/Agents/AgentResolverService.cs — MODIFY
+
+public async Task<ResolvedAgentConfig> ResolveForRoleAsync(
+    string role, string? action = null, CancellationToken ct = default)
+{
+    if (!RolePhaseMap.ValidRoles.Contains(role))
+        throw new ArgumentException($"Unknown role '{role}'");
+
+    var principal = _principal.Resolve();
+    var selection = await _registry.GetRoleSelectionsAsync(ct);
+
+    // 1 + 2: tenant/user-selected agent — but ONLY if still usable (enabled public OR own private)
+    if (selection.TryGetValue(role, out var sel))
+    {
+        var agent = await _registry.ResolveSelectedAgentAsync(sel.AgentId, ct);   // public ∪ own private
+        if (agent is not null && await _registry.CanUseAsync(agent, principal, ct)) // NEW: enablement-aware (async)
+            return await MaterialiseAsync(agent, role, action, source: SourceFor(agent), ct);
+
+        if (agent is not null)   // selection points at a now-DISABLED persona => degrade, don't resolve it
+        {
+            _logger.LogWarning("Selection for role {Role} points at disabled persona {AgentId}; degrading to enabled default",
+                role, sel.AgentId);
+            await _events.AppendAsync(Degraded(role, sel.AgentId, "system-public-enabled", principal), ct);
+        }
+    }
+
+    // 3: the tenant's ENABLED default persona
+    var enabledDefault = await _registry.GetSystemDefaultPublicAsync(role, ct);
+    if (enabledDefault is not null)
+        return await MaterialiseAsync(enabledDefault, role, action, source: "system-public", ct);
+
+    // 4: NO empty fallback — fail loud
+    await _events.AppendAsync(ResolveFailed(role, principal), ct);
+    await _missingConfig?.RecordAsync(new MissingConfigGap("agent", $"role:{role}", "system"), ct);  // best-effort
+    throw new TammaError("AGENT.RESOLVE.NO_ENABLED_DEFAULT",
+        $"No enabled agent resolvable for role '{role}'", severity: High, context: new { role });
+}
+```
+
+### `MaterialiseAsync` — prompt-source PRECEDENCE/dispatch only (no inline resolve body)
+
+This story owns the **dispatch/selector** in `MaterialiseAsync`: public personas → 32-15's `IPersonaPromptResolver`, private/custom → 32-17's `ICustomAgentPromptResolver`. **It adds no prompt-resolution body of its own** — neither the Epic-27 persona resolve (that lives inside `IPersonaPromptResolver`, 32-15) nor the custom resolve (inside `ICustomAgentPromptResolver`, 32-17). There is no inline `_promptStore.ResolveAsync` for the persona branch in this story.
+
+```csharp
+// Tamma.Api/Services/Agents/AgentResolverService.cs — MODIFY MaterialiseAsync (DISPATCH ONLY)
+
+private async Task<ResolvedAgentConfig> MaterialiseAsync(
+    Agent agent, string role, string? action, string source, CancellationToken ct)
+{
+    // provider/model/params/tools come from the agent config merged onto DefaultAgentConfig.ForRole(role)
+    var cfg = MergeConfig(DefaultAgentConfig.ForRole(role), agent.ActiveVersion.ConfigJson);
+
+    // PROMPT SOURCE — PRECEDENCE/DISPATCH only (this story adds NO resolution body):
+    var principal = _principal.Resolve();
+    var systemPrompt = agent.IsPublic
+        // PERSONA => 32-15 IPersonaPromptResolver (reads Epic 27 (principal, role, action); fail-loud internally)
+        ? (await _personaPrompts.ResolveAsync(principal, role, action, ct)).Text
+        // CUSTOM/PRIVATE => 32-17 ICustomAgentPromptResolver (reads ConfigJson.prompts; fail-loud internally)
+        : (await _customAgentPrompts.ResolveAsync(agent, role, action, ct)).Text;
+
+    return cfg.ToResolvedConfig() with
+    {
+        SystemPrompt = systemPrompt,
+        AgentId = agent.Id,
+        AgentVersion = agent.ActiveVersion.Version,
+        Provider = cfg.Provider,     // persona-supplied (32-15) — drives 32-3 credential resolve downstream
+        Model = cfg.Model,
+        Source = source,
+    };
+}
+```
+
+> `_personaPrompts` is **32-15's `IPersonaPromptResolver`** (its body reads the Epic 27 `IPromptStoreService` `(principal, role, action)`, tenant→system→error, and throws `PROMPT_UNRESOLVED`/`NoPromptError` on miss). `_customAgentPrompts` is the **32-17 `ICustomAgentPromptResolver`** seam. This story only **dispatches** to them and tests that personas take the persona seam and never the custom one (and vice-versa) — it implements neither body. The **credential** is intentionally absent here: it is resolved by 32-3 at call time from `ResolvedAgentConfig.Provider`.
+
+### End-to-end resolve order (BYOK∘persona) — for the call-LLM endpoint (32-5)
+
+This story does not call a provider; it produces the `ResolvedAgentConfig` the call-LLM endpoint composes. The documented order the endpoint (32-5) follows, with this story owning steps 2 and 4 (prompt) and the enablement gate inside step 2:
+
+```
+Step (engine) → POST /api/v1/llm/call { tenantId, role, action, agentId/persona?, prompt, params }
+  1. Gate (32-4) — SaaS auth / entitlement / budget
+  2. Resolve agent config (THIS STORY, 32-18 over 32-2):
+       - ResolveForRoleAsync(role, action) / explicit agentId
+       - ENABLEMENT GATE: CanUseAsync = (IsPublic && IsEnabledForPrincipalAsync) || IsOwnPrivate   (32-16 read seam)
+       - => ResolvedAgentConfig { Provider, Model, AgentId, AgentVersion, ... }   (persona supplies Provider+Model, 32-15)
+  3. Resolve PROMPT — DISPATCH ONLY (THIS STORY, 32-18 adds no resolution body):
+       - persona (IsPublic) => IPersonaPromptResolver (32-15) → Epic 27 store (principal, role, action)   [tenant→system→ERROR]
+       - custom agent       => ICustomAgentPromptResolver (32-17) → its own ConfigJson.prompts
+  4. Resolve CREDENTIAL (32-3): IProviderCredentialResolver.ResolveAsync(tenantId, config.Provider)
+       - BYOK-for-that-provider if present => credentialSource = byok (no markup)
+       - else platform key                 => credentialSource = platform (markup off provider cost, 34-5)
+       - credentialSource decided by (tenant, persona.provider) — persona-INDEPENDENT
+  5. Provider call → meter (cost via IProviderPricingService / 34-11) → return { result, usage, credentialSource }
+```
+
+`credentialSource` is orthogonal to persona/enablement: tenant A with a BYOK Anthropic key running persona `claude` → `byok`; the same tenant running `gemini` with no Google BYOK → `platform`.
+
+### Where it lives (files touched — all EXISTING 32-2/32-15/32-16 files)
+
+```
+apps/tamma-elsa/src/Tamma.Api/Services/Agents/
+  AgentRegistryService.cs        # MODIFY — CanUseAsync enablement-aware (ITenantAgentEnablementReader); ListAsync enabled∪own-private;
+                                 #          SelectForRoleAsync gate (AGENT.SELECT.NOT_ENABLED);
+                                 #          GetSystemDefaultPublicAsync => enabled default (consumes GetEnabledDefaultPersonaIdAsync)
+  IAgentRegistryService.cs       # MODIFY — CanUseAsync made part of the contract (or kept internal + tested via Select/Resolve);
+                                 #          ListAsync filter gains IncludeDisabled (owner/admin only)
+  AgentResolverService.cs        # MODIFY — resolve precedence uses CanUseAsync; degrade-on-disabled;
+                                 #          MaterialiseAsync prompt-source DISPATCH ONLY (public→IPersonaPromptResolver 32-15,
+                                 #          private→ICustomAgentPromptResolver 32-17; no inline resolve body); action plumbed
+  IAgentResolverService.cs       # MODIFY — ResolveForRoleAsync/ResolveForRoleAndPhaseAsync gain `action` param
+  AgentEventTypes.cs             # MODIFY — add SelectNotEnabled, ResolveDegraded, NoEnabledDefault constants
+  ResolvedAgentConfig.cs         # (unchanged — already carries AgentId/AgentVersion/Provider/Model from 32-2/32-15)
+
+apps/tamma-elsa/src/Tamma.Api/Endpoints/
+  AgentEndpoints.cs              # MODIFY — SelectForRole maps AGENT.SELECT.NOT_ENABLED TammaError => 409 agent_not_enabled;
+                                 #          Resolve maps AGENT.RESOLVE.NO_ENABLED_DEFAULT => 404/409; List honours ?includeDisabled
+```
+
+### EF migrations
+
+**None.** This story adds no entity and no column. It edits service/resolver logic only. The `TenantAgentEnablement` table is owned by **32-16**; the nullable-`Agent.Role` migration + persona seeder are owned by **32-15**. `dotnet ef migrations has-pending-model-changes` MUST report none after this story (AC 11). Because no public/control-plane table is added here, the **Program.cs startup-reset DROP list** does NOT change (32-16 appends `tenant_agent_enablement` to it if it is CP-resident).
+
+### DCB events
+
+| Event | Tags | When | Owner |
+|---|---|---|---|
+| `AGENT.SELECT.NOT_ENABLED` | `{ agentId, personaName, role, mode, tenantId\|userId }` | selection blocked by enablement gate | **32-18 (this)** |
+| `AGENT.RESOLVE.DEGRADED` | `{ role, staleAgentId, fallbackSource, mode }` | selection pointed at a now-disabled persona; degraded to enabled default | **32-18 (this)** |
+| `AGENT.SELECTED_FOR_ROLE.SUCCESS` | `{ agentId, role, source, mode }` | successful role selection | 32-2 (kept) |
+| `AGENT.RESOLVE.FAILED` | `{ role, phase, source, mode }` | nothing enabled/own resolvable → fail loud | 32-2 (kept) |
+| `AGENT.ENABLED.SUCCESS` / `AGENT.DISABLED.SUCCESS` | `{ agentId, personaName, mode, … }` | enable/disable a persona | **32-16 (NOT here)** |
+
+All appended via `IEventRepository.AppendAsync` (tenant-scoped in SaaS; platform-events path in single-user, `TenantId == null`).
+
+### Per-mode / per-tenant ownership (mandatory two-scoping-model answer)
+
+| Question | single-user | SaaS |
+|---|---|---|
+| Who owns **enablement** (which personas exist)? | The sole user (`user_id`-keyed `TenantAgentEnablement` row; CP-resident — owned by 32-16). The gate is evaluated against `user_id`. | The tenant (`tenant_id`-keyed). `tenant_owner`/`tenant_admin` enable/disable; `member` sees the enabled set, cannot change it. Gate evaluated against `tenant_id`. |
+| Whose enabled set constrains **selection**? | The sole user's. `SelectForRoleAsync` rejects a public persona the user has not enabled. | The tenant's. `member` users select only within `enabled(public) ∪ own-private`; no per-user enablement layer. |
+| Where does the **persona prompt** come from? | Epic 27 store keyed `(user_id, role, action)` — user override → system default → ERROR. | Epic 27 store keyed `(tenant_id, role, action)` — tenant override → system default → ERROR. No per-user prompt layer in SaaS (CLAUDE.md). |
+| Where does the **enabled-default persona** come from? | The user's enabled default (32-16) or the platform `DefaultPersonaName` if the user enabled it. | The tenant's enabled default or `DefaultPersonaName` if the tenant enabled it. Fail loud if nothing enabled. |
+| Who resolves the **credential** for the persona's provider? | 32-3 at call time: user BYOK-for-provider → platform. Never the registry/resolver. | 32-3 at call time: tenant BYOK-for-provider → platform. `credentialSource` decided by `(tenant, provider)`. |
+| Mode source | `ITammaModeProvider` (process-stable). | same |
+
+## Dependencies
+
+**Internal (hard prerequisites):**
+
+- **Story 32-2** (Agent registry, resolution & RBAC API) — the services this story amends in place (`AgentRegistryService`, `AgentResolverService`, `AgentEndpoints`, `AgentEventTypes`, `ResolvedAgentConfig`). Shipped on `feat/exec-wave-02`.
+- **Story 32-15** (Persona reframe + seeding) — makes `Agent.Role` nullable, seeds named cross-role personas with explicit `provider`+`model`, provides the **`IPersonaPromptResolver`** seam (the persona→Epic-27 resolution body) and `DefaultPersonaName`. This story DISPATCHES the public branch to that seam; it does not re-inline the Epic-27 resolve.
+- **Story 32-16** (Per-tenant agent/persona enablement) — owns the `TenantAgentEnablement` entity, the enable/disable API, `AGENT.ENABLED/DISABLED.SUCCESS`, and the `ITenantAgentEnablementReader` read seam (`IsEnabledForPrincipalAsync`, `ListEnabledPublicAgentIdsAsync`, `GetEnabledDefaultPersonaIdAsync` — all async) this story injects + consumes.
+- **Story 32-17** (Custom-agent prompts) — owns the `ConfigJson.prompts` schema + the private-agent prompt-source seam (**`ICustomAgentPromptResolver`**); this story dispatches the private branch to it only.
+- **Epic 27** (Prompt store) — `IPromptStoreService.ResolveAsync(principal, role, action)` (tenant→system→error, NEVER empty/plain) is the persona prompt source, reached **through 32-15's `IPersonaPromptResolver` seam** (this story does not call `IPromptStoreService` directly).
+
+**Consumers (downstream, not blockers):**
+
+- **Story 32-5 (rewrite)** — the call-LLM endpoint composes the resolve order documented above (enablement gate → config → Epic-27 prompt → 32-3 credential → provider call → meter).
+- **Story 32-3** — its `IProviderCredentialResolver.ResolveAsync(tenantId, config.Provider)` consumes `ResolvedAgentConfig.Provider` at call time; this story guarantees `Provider` is persona-supplied and never resolves a credential itself.
+- **Story 32-4** — SaaS provider gate runs before resolution in the endpoint.
+
+**External:** none.
+
+## Testing Strategy
+
+Tests are xUnit under `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/`. Docker-bound suites run via `sg docker -c "dotnet test ..."` (see `reference_dotnet_test_docker`). TDD: write the failing test first. `ITenantAgentEnablementReader` (32-16), `IPersonaPromptResolver` (32-15), and `ICustomAgentPromptResolver` (32-17) are faked — this story dispatches to them and never re-implements a resolution body.
+
+1. **Enablement gate on selection** (`AgentRegistryServiceTests`): (a) selecting an **enabled** public persona → 200 + `AGENT.SELECTED_FOR_ROLE.SUCCESS`; (b) selecting a **disabled** public persona → `TammaError("AGENT.SELECT.NOT_ENABLED")` → endpoint 409 `agent_not_enabled`, exactly one `AGENT.SELECT.NOT_ENABLED` event; (c) selecting the caller's **own private** agent → 200 (implicitly enabled); (d) cross-tenant private target → 404 (unchanged).
+2. **`CanUseAsync` predicate** (`AgentRegistryServiceTests`): public+enabled → usable; public+disabled → not usable; own-private → usable; other-tenant-private → not usable (via the faked `ITenantAgentEnablementReader.IsEnabledForPrincipalAsync`). Asserts the predicate no longer returns true for a public persona solely because it is public.
+3. **Resolution degrades past a disabled selection** (`AgentResolverServiceTests`): selection points at persona later disabled → resolve returns the **enabled default**, emits `AGENT.RESOLVE.DEGRADED` (WARN), never materialises the disabled persona.
+4. **Enabled-default lookup** (`AgentResolverServiceTests`): (a) `DefaultPersonaName` enabled → returned; (b) `DefaultPersonaName` not enabled but another persona is the enabled default → that one returned; (c) nothing enabled and no own-private for the role → `AGENT.RESOLVE.FAILED` + `TammaError("AGENT.RESOLVE.NO_ENABLED_DEFAULT")`, **no blank config**.
+5. **Persona prompt dispatched to `IPersonaPromptResolver`** (`AgentResolverServiceTests`): a resolved **public persona** has its system prompt resolved via the faked **`IPersonaPromptResolver`** seam (32-15) — assert `MaterialiseAsync` calls that seam and does NOT call `IPromptStoreService` directly (no inline persona resolve in 32-18); assert the persona's `ConfigJson` prompt (if any test fixture sets one) is **NOT** used; a seam miss (`PROMPT_UNRESOLVED`) propagates (no empty/plain).
+6. **Action key plumbing** (`AgentResolverServiceTests`): `ResolveForRoleAsync(role, action)` passes `action` to the prompt store; absent `action` → action-default branch (still tenant→system→error).
+7. **Custom-agent branch untouched** (`AgentResolverServiceTests`): a resolved **private** agent dispatches to the 32-17 **`ICustomAgentPromptResolver`** seam, NOT the persona seam / Epic-27 store — proves the boundary; this story does not implement either branch's body.
+8. **Mode-parameterized principal** (`[Theory]` over `TammaMode.SingleUser`/`SaaS`): the enablement gate + prompt resolution evaluate against `user_id` vs `tenant_id`; no per-user enablement layer.
+9. **No credential in the resolve path** (`AgentResolverServiceNoCredentialTests`): a resolve never calls any `IProviderCredentialResolver`/cabinet seam and never logs a key; `ResolvedAgentConfig` carries `Provider`/`Model` but no `ApiKey`.
+10. **Endpoint mapping** (`AgentEndpointsTests`, `WebApplicationFactory`): `PUT role-selections/{role}` at a disabled persona → 409 `agent_not_enabled`; `GET /api/agents` returns only enabled∪own-private for a member; `?includeDisabled=true` from an admin returns the full catalog with `enabled` flags; from a member → ignored/forbidden.
+11. **No-regression**: existing 32-2 `AgentEndpointsTests`/`AgentResolverServiceTests`, the legacy `/api/v1/agents/*` JSONB path, and `has-pending-model-changes` → none stay green.
+
+## Estimated Effort
+
+3-4 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRegistryService.cs` | Modify (`CanUseAsync` enablement-aware via `ITenantAgentEnablementReader`; `ListAsync` enabled∪own-private; `SelectForRoleAsync` gate; `GetSystemDefaultPublicAsync` → enabled default, consumes `GetEnabledDefaultPersonaIdAsync`) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/IAgentRegistryService.cs` | Modify (`ListAsync` filter `IncludeDisabled`; expose `CanUseAsync` or document internal) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentResolverService.cs` | Modify (resolve precedence uses `CanUseAsync`; degrade-on-disabled; `MaterialiseAsync` prompt-source DISPATCH ONLY → public:`IPersonaPromptResolver` (32-15) / private:`ICustomAgentPromptResolver` (32-17), no inline resolve body; `action` plumbed) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/IAgentResolverService.cs` | Modify (`ResolveForRoleAsync`/`ResolveForRoleAndPhaseAsync` gain `action`) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentEventTypes.cs` | Modify (add `SelectNotEnabled`, `ResolveDegraded`, `NoEnabledDefault`) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs` | Modify (`SelectForRole` → 409 `agent_not_enabled`; `Resolve` → 404/409 on no-enabled-default; `List` honours `?includeDisabled`) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentRegistryServiceTests.cs` | Create/Modify (gate, `CanUseAsync`, enabled-default) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentResolverServiceTests.cs` | Create/Modify (degrade, Epic-27 prompt, action plumbing, custom-branch boundary, fail-loud) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentResolverServiceNoCredentialTests.cs` | Create (no credential in resolve path) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentEndpointsTests.cs` | Create/Modify (409 mapping, enabled-listing, `?includeDisabled`) |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` directory for related spikes, bugs, findings, and decisions (esp. `feedback_resolution_no_empty_fallback`)
+3. Confirmed **32-15** (`Agent.Role` nullable + persona seeder + the `IPersonaPromptResolver` seam + `DefaultPersonaName`), **32-16** (`ITenantAgentEnablementReader` with async `IsEnabledForPrincipalAsync` + `ListEnabledPublicAgentIdsAsync` + `GetEnabledDefaultPersonaIdAsync`), and **32-17** (`ICustomAgentPromptResolver`) have landed — this story consumes their seams and must not re-implement them
+4. Reviewed the shipped 32-2 `AgentRegistryService`/`AgentResolverService` and the Epic 27 `IPromptStoreService.ResolveAsync(principal, role, action)` precedence
+5. Planned TDD approach (Red-Green-Refactor cycle)
+
+### Key design decisions
+
+- **Amend in place, no new table** — this is a logic change to shipped 32-2 services. No entity, no migration, no DROP-list edit, no migration-snapshot branch. Keeps the linear EF snapshot intact (sequential impl).
+- **Consume, don't define** — `IsEnabledForPrincipalAsync`/`ListEnabledPublicAgentIdsAsync`/`GetEnabledDefaultPersonaIdAsync` (the `ITenantAgentEnablementReader` seam) are 32-16's; the `IPersonaPromptResolver` resolution body is 32-15's; the `ICustomAgentPromptResolver` body is 32-17's; `Agent.Role`-nullable + persona seeder are 32-15's. This story is purely the **registry/resolver consumer + prompt-source dispatcher** of those. The boundary is load-bearing: re-implementing any of them here (including re-inlining the Epic-27 persona resolve) would double-implement and corrupt ownership (and, for entities, the migration graph).
+- **409 for disabled-persona selection, 404 for cross-tenant** — selecting a persona that exists but is disabled is a state conflict (the persona is visible in the catalog), so 409; a cross-tenant private agent must not even be acknowledged, so 404 (existence-leak guard, unchanged from 32-2).
+- **Degrade, never resolve a disabled selection** — a stale selection (persona disabled after it was selected) degrades to the enabled default with an `AGENT.RESOLVE.DEGRADED` audit event, exactly like 32-2's "selection target no longer in (public ∪ own private)" WARN — but the trigger is now "no longer enabled," not "no longer visible."
+- **Persona = `IPersonaPromptResolver`, never config; dispatch only** — personas are prompt-free by contract (rule #4). `MaterialiseAsync` for a public persona **dispatches** to 32-15's `IPersonaPromptResolver` (whose body reads `(principal, role, action)` from Epic 27); this story adds no resolution body and re-inlines nothing. If the persona `ConfigJson` somehow carries a prompt it is ignored (and a seeding invariant in 32-15 forbids it). Custom agents dispatch to 32-17's `ICustomAgentPromptResolver`. Both seams fail loud, never empty/plain.
+- **Credential stays out of the resolver** — the persona only names provider+model; the key is 32-3's job at call time, decided by `(tenant, provider)`. The resolver carries `Provider`/`Model` so 32-3 can resolve BYOK→platform; it must never touch a key (tested in AC 12 / test 9).
+
+### Resolved coordination items
+
+- **32-16 read-seam shape (RESOLVED).** 32-16 ships `ITenantAgentEnablementReader` with `Task<bool> IsEnabledForPrincipalAsync(Guid agentId, Principal principal, CancellationToken ct)`, `Task<IReadOnlyList<Guid>> ListEnabledPublicAgentIdsAsync(Principal principal, CancellationToken ct)`, and `Task<Guid?> GetEnabledDefaultPersonaIdAsync(Principal principal, CancellationToken ct)`. These are the exact async signatures this story calls (`GetEnabledDefaultPersonaIdAsync` is **defined in 32-16, consumed here, never redefined**). `ListAsync` uses the batch `ListEnabledPublicAgentIdsAsync` for set-membership (avoids per-row calls).
+
+### Open coordination items
+
+- **`DefaultPersonaName` source** — confirm whether 32-15 exposes it as a config option (`AgentOptions.DefaultPersonaName`) or a CP `agent_default_selections` row; `GetSystemDefaultPublicAsync` reads whichever 32-15 ships.
+- **`action` derivation** — confirm how `action` is derived when the call-LLM request omits it (phase→action map vs the Epic-27 action-default). Default to the action-default branch (still fail-loud).
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Double-implementing the enablement entity / persona-prompt body / custom-prompt body | High | Strict boundary: consume `ITenantAgentEnablementReader` (32-16), dispatch to `IPersonaPromptResolver` (32-15) and `ICustomAgentPromptResolver` (32-17); add NO entity/migration and NO inline resolve body. Coordination checklist in Dev Notes; AC 11 asserts no pending model changes; test 5 asserts no direct `IPromptStoreService` call. |
+| A disabled persona still resolves (gate not applied on a path) | High | Gate centralised in `CanUseAsync`; both `SelectForRoleAsync` and the resolve precedence call it; test 2 asserts the predicate; test 3 asserts degrade-on-disabled. |
+| Empty/plain prompt fallback sneaks in | High | `MaterialiseAsync` dispatches the persona branch to `IPersonaPromptResolver` (whose body fails loud, tenant→system→error/`NoPromptError`); a miss propagates; test 5 asserts the seam is invoked (not an inline resolve) and a miss propagates. Mirrors `feedback_resolution_no_empty_fallback`. |
+| Credential leaks into the resolver | High | `ResolvedAgentConfig` carries `Provider`/`Model` only; dedicated no-credential test (test 9) asserts no resolver path resolves or logs a key. Credential is 32-3 at call time. |
+| `GetSystemDefaultPublicAsync` returns nothing when the tenant enabled nothing | Medium | That is the **correct** fail-loud behaviour (AC 5): resolver throws `NO_ENABLED_DEFAULT`; test 4(c) asserts it, never a blank config. |
+| 32-15/16/17 land late | Medium | Code to their interfaces (`ITenantAgentEnablementReader`, the `MaterialiseAsync` branch, `_customAgentPrompts`, `IPromptStoreService`); use fakes; this story is the integrator, gated behind them. |
+| Listing perf — per-row `IsEnabledForPrincipalAsync` | Low | `ListAsync` uses 32-16's batch `ListEnabledPublicAgentIdsAsync` (one read → a set membership check); the public catalog is small (N personas) regardless. |
+
+## Success Metrics
+
+- [ ] No code path treats a public persona as usable solely because it is public (grep + test 2).
+- [ ] 100% of persona resolutions are dispatched to `IPersonaPromptResolver` (32-15) and custom resolutions to `ICustomAgentPromptResolver` (32-17); this story calls neither resolution body directly nor `IPromptStoreService`; neither ever empty/plain.
+- [ ] A tenant that has enabled nothing fails loud (`AGENT.RESOLVE.NO_ENABLED_DEFAULT`) rather than resolving an un-enabled persona or a blank config.
+- [ ] Zero new tables/migrations; `has-pending-model-changes` → none; full suite green.
+
+## Related
+
+- Design of record: `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§3.1 prompt source, §3.3 changes to 32-2, §3.5 BYOK∘persona)
+- Re-plan: `docs/superpowers/plans/2026-06-20-epic-32-37-replan.md` (§1 disposition of 32-2; §4 sequence step E)
+- Amended story: `docs/stories/epic-32/story-32-2/32-2-agent-registry-resolution-and-rbac-api.md`
+- Implementation plan: `docs/superpowers/plans/2026-06-21-32-18-registry-enablement-gate-and-prompt-source-plan.md`
+- Sibling stories: `story-32-15/` (persona reframe), `story-32-16/` (enablement entity/API/events), `story-32-17/` (custom-agent prompts), `story-32-3/` (credential resolver), `story-32-5/` (call-LLM endpoint — consumer)
+
+## Logging Requirements
+
+- **INFO**: role selection upserted (role, agentId, source, mode); resolution succeeded (role, action, agentId, version, source, promptSource∈`epic27`|`custom-agent`); enabled-default resolved (role, personaName).
+- **DEBUG**: which precedence branch was taken; enablement gate decision per candidate (agentId, enabled); prompt-store resolution layer hit (tenant-override | system-default).
+- **WARN**: selection target no longer **enabled** ⇒ degrading to enabled default (role, staleAgentId) → `AGENT.RESOLVE.DEGRADED`; selection blocked by enablement gate (agentId, personaName, role) → `AGENT.SELECT.NOT_ENABLED`.
+- **ERROR**: `AGENT.RESOLVE.FAILED` / `AGENT.RESOLVE.NO_ENABLED_DEFAULT` — nothing enabled/own resolvable for a taxonomy-valid role (role, mode); prompt-store miss (`NoPromptError`) on a persona (role, action).
+- **Structured context**: include `{ agentId, personaName, role, action, source, mode, tenantId }` where applicable.
+- **Credential safety**: the registry/resolver are **credential-agnostic** (provider+model+settings only). NEVER log or resolve a provider API key here — credentials resolve later in 32-3 from the Epic 29 cabinet inside the call-LLM endpoint. `credentialSource` is not even known at resolve time and must not be inferred or logged here.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-21 | 1.0.0   | Initial story creation (amends 32-2: enablement gate + Epic-27 persona prompt source) | Claude |
+| 2026-06-21 | 1.0.1   | Cross-spec reconciliation (C1/C2/C3): AC6 reworded to **PRECEDENCE/dispatch only** — public personas → `IPersonaPromptResolver` (32-15), private/custom → `ICustomAgentPromptResolver` (32-17); removed the duplicate inline Epic-27 persona-resolve body from `MaterialiseAsync` (this story adds no prompt-resolution body, no phantom `_personaPromptBranch`). Standardized on the 32-16 read seam `ITenantAgentEnablementReader` with **async** `IsEnabledForPrincipalAsync` / `ListEnabledPublicAgentIdsAsync` / `GetEnabledDefaultPersonaIdAsync`; `CanUse` → async `CanUseAsync`. Resolved the open question — `GetEnabledDefaultPersonaIdAsync` signature now matches what 32-16 defines (consumed here, never redefined). | Claude |

--- a/docs/stories/epic-32/story-32-18/32-18-registry-enablement-gate-and-prompt-source.md
+++ b/docs/stories/epic-32/story-32-18/32-18-registry-enablement-gate-and-prompt-source.md
@@ -259,7 +259,7 @@ apps/tamma-elsa/src/Tamma.Api/Endpoints/
 
 ### EF migrations
 
-**None.** This story adds no entity and no column. It edits service/resolver logic only. The `TenantAgentEnablement` table is owned by **32-16**; the nullable-`Agent.Role` migration + persona seeder are owned by **32-15**. `dotnet ef migrations has-pending-model-changes` MUST report none after this story (AC 11). Because no public/control-plane table is added here, the **Program.cs startup-reset DROP list** does NOT change (32-16 appends `tenant_agent_enablement` to it if it is CP-resident).
+**None.** This story adds no entity and no column. It edits service/resolver logic only. The `TenantAgentEnablement` table is owned by **32-16**; the nullable-`Agent.Role` migration + persona seeder are owned by **32-15**. `dotnet ef migrations has-pending-model-changes` MUST report none after this story (AC 11). Because no public/control-plane table is added here, the **Program.cs startup-reset DROP list** does NOT change (32-16 appends its CP-resident `tenant_agent_enablements` table to it).
 
 ### DCB events
 

--- a/docs/stories/epic-32/story-32-19/32-19-agent-style-voice-variants.md
+++ b/docs/stories/epic-32/story-32-19/32-19-agent-style-voice-variants.md
@@ -1,0 +1,441 @@
+# Story 32-19: Agent Style/Voice Variants (`AgentStyleVariant`)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **tenant owner/admin (SaaS) or self-hosted user (single-user)**,
+I want to define optional **style/voice variants** — small tone/verbosity overlays (e.g. _terse_ vs _verbose_, _formal_ vs _casual_ review voice) — and bind at most one to a given role, so that a run keeps the **same persona/custom agent, provider, model, and credential** but speaks in my preferred voice,
+So that the **style/tone overlay** (the `atlas`/`nova` idea split out of the old 32-12) becomes a first-class, **orthogonal** dimension that the call-LLM endpoint (32-5) merges **on top of** the Epic-27/custom prompt — additively, never replacing it, never empty-fallback — without being confused with a persona (the named system agent) or a custom agent (own prompts).
+
+## Priority
+
+P2 — This is an **optional, additive** overlay split out of 32-12 per design §3.4. The locked model reserves the word **persona** for the named cross-role system agent (provider+model+config — 32-15) and **custom agent** for own-prompt private agents (32-17); the old 32-12 "persona = style/tone overlay within a role" (`atlas`/`nova`) **directly contradicts** that vocabulary. Rather than discard the still-valuable tone/verbosity idea, this story re-homes it as a **separate, optional `AgentStyleVariant`** — explicitly **NOT a persona**. It is orthogonal to the whole agent pivot (a run may apply zero or one variant; default = none = no behaviour change), so it sequences **after** the lynchpin (sequence **G**, post-F): the 32-5 endpoint must already render the base prompt before a variant can ride on top of it. Nothing in the pivot blocks on this story.
+
+## Context
+
+The Epic 32 architecture pivot (`docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md`) locks three distinct concepts that the old wording blurred (design §3.0 table, §3.4):
+
+| Concept | What it is | Owned by | Changes provider/model/cred? |
+|---|---|---|---|
+| **Persona** | a **named cross-role system agent** presetting `{ provider, model, config }`; prompt-free (prompt from Epic 27) | 32-15 | yes — it _is_ the provider+model |
+| **Custom agent** | a private `Agent` carrying **its own prompts** + config | 32-17 | yes — it carries provider+model+prompts |
+| **Style/voice variant** (this story) | an **optional tone/verbosity overlay** applied on top of a resolved agent at call time | **32-19** | **no** — voice only |
+
+A **style/voice variant** is a small, declarative **style descriptor** — tone/verbosity knobs (`tone`, `verbosity`, `format`, `audience`) and/or a short free-text **style-prompt fragment** — that says _how_ the resolved agent should speak, not _what_ provider/model/prompt it uses. It is the `atlas`/`nova` "review voice" idea from the old 32-12, correctly named and decoupled. Key invariants:
+
+- **It is NOT a persona and NOT a custom agent.** It never selects or changes the provider, the model, the credential (`credentialSource` is untouched), or the base prompt. It carries no `provider`/`model`/key fields. The 32-5 endpoint resolves the agent (32-18) and credential (32-3) **exactly as it does today**, renders the base prompt (Epic 27 for personas / the custom agent's own prompts), and only **then** applies the variant as an **additive** overlay to the rendered prompt.
+- **Additive, after base resolution, never empty-fallback.** The variant is merged **after** the Epic-27/custom-prompt resolution (design §2.6 step 4 → a new step 4b), as a deterministic suffix/section appended to the resolved system prompt. It can only **add** style guidance; it can never replace, blank, or short-circuit the base prompt. A bound-but-missing/disabled variant resolves to **no overlay** (silently — a variant is optional by definition), but the **base** prompt resolution still obeys tenant→system→**error** (32-5 AC3 / `feedback_resolution_no_empty_fallback`); the variant never weakens that.
+- **Optional + orthogonal.** Zero or one variant per `(principal, role)`. **Default = none** → the rendered prompt is byte-for-byte what 32-5 produces without this story. Binding is per-`(principal, role)` (like agent selection in 32-2's `AgentRoleSelection`), constrained to the principal's **enabled** variants.
+
+This story owns the **entity** (`AgentStyleVariant` + the per-role binding `AgentStyleVariantSelection`), the **CRUD + enable/bind API**, the **events**, and the **`ResolveActiveVariantAsync` / `ComposeOverlay` primitives** the 32-5 endpoint calls. It mirrors the same **visibility / principal-XOR / unique-nulls-not-distinct index discipline** as `prompt_overrides` (Epic 27), `AgentRoleSelection` (32-2), and `TenantAgentEnablement` (32-16). Because both tables are NEW control-plane / public-schema tables in SaaS, they MUST be added to the `Program.cs` startup-reset DROP list and the `ControlPlaneDbContextModelTests` strict entity list (see AC8, AC9 and Dev Notes).
+
+### Boundary with sibling stories (do NOT cross these lines)
+
+- **vs 32-12 (rewrite):** 32-12 is rewritten so "persona" = the named system agent. **Benchmarking (32-12 family / 32-10) keys on the persona-agent identity** (`AgentId`/persona name), NOT on a variant. A variant is a **separate optional dimension**; this story does **not** add a variant axis to benchmarking. If a future story wants to A/B a variant, it does so on top of 32-10's agent-keyed harness — out of scope here.
+- **vs 32-15 (persona seeder):** the persona seeder seeds the named cross-role public personas (provider+model+config). This story seeds an **optional** shipped-default style-variant catalog (e.g. `terse`, `verbose`, `formal`) **separately**; a persona is never a variant and a variant never appears in the persona catalog.
+- **vs 32-17 (custom-agent prompts):** a custom agent carries its **own base prompts**. A variant overlays voice on top of **any** resolved agent — persona or custom. The variant is not a substitute for, and does not edit, a custom agent's prompts; it is appended after them.
+- **vs 32-5 (the endpoint that applies the overlay):** 32-5 owns the call-LLM composition. This story **does not** modify the gate/agent-resolve/credential/loop/meter sequence. It adds **one optional step (4b)** between "render base prompt" (step 4) and "emit `AGENT.RUN.STARTED`" (step 5): resolve the active variant and compose the overlay onto the rendered system prompt. The wiring point is the `IAgentStyleVariantService` interface this story ships; 32-5 (or a tiny follow-on amendment to it) calls it.
+- **vs Epic 27 (the base prompt the overlay rides on):** Epic 27 owns the tenant→system→error base prompt. A variant is **never** an Epic-27 prompt override and never enters the prompt store. It is a thin, additive style layer on the rendered output of Epic 27 — it cannot blank or replace what Epic 27 resolved.
+
+## Acceptance Criteria
+
+1. **New entity `AgentStyleVariant`** (`apps/tamma-elsa/src/Tamma.Data/Entities/AgentStyleVariant.cs`) with fields: `Id` (UUID PK), `TenantId` (UUID, NULL in single-user), `UserId` (UUID, NULL in SaaS), `Visibility` (`Public` | `Private`), `Name` (e.g. `terse`, `formal-review`), `Description?`, a **style descriptor** `StyleJson` (`{ tone?, verbosity?, format?, audience?, stylePrompt? }` — knobs and/or a short free-text fragment), `Enabled` (BOOLEAN), `CreatedAt`/`CreatedBy`, `UpdatedAt`/`UpdatedBy`. EF config carries the **principal XOR** CHECK and a **`UNIQUE NULLS NOT DISTINCT (TenantId, UserId, Name)`** index for private variants, exactly mirroring `AgentRoleSelection` / `TenantAgentEnablement`. It carries **NO** `provider`, `model`, `credential`, or base-prompt fields — a variant cannot change those.
+
+2. **New binding entity `AgentStyleVariantSelection`** (per-`(principal, role)`, at most one variant) with fields: `Id`, `TenantId?`, `UserId?` (principal XOR), `Role` (one of the 8 valid roles), `VariantId` (UUID NOT NULL), audit columns. **`UNIQUE NULLS NOT DISTINCT (TenantId, UserId, Role)`** — one bound variant per role per principal — mirroring `AgentRoleSelection`'s `(principal, role)` uniqueness. Binding a variant the principal cannot see (not public, not its own private) or that is disabled → `404`/`409` (existence-leak-safe, matching 32-2's cross-tenant rule).
+
+3. **`ResolveActiveVariantAsync(role)` query primitive** is exposed by a new `IAgentStyleVariantService` (`Tamma.Api/Services/Agents/`). Semantics: returns the **single** variant bound for the current principal's `(principal, role)` **iff** it exists, is visible, **and is enabled**; otherwise returns **`null`** (no variant — the default, silent, no behaviour change). A disabled or retired bound variant resolves to `null` (the binding is not an error; a variant is optional by definition). This primitive is what 32-5 calls at step 4b.
+
+4. **`ComposeOverlay(renderedSystemPrompt, variant)` is additive and deterministic.** A companion `ComposeOverlay` (pure, no I/O) appends the variant's style guidance to the already-rendered system prompt as a clearly-delimited **style section** (e.g. a trailing `\n\n## Response style\n<rendered knobs + stylePrompt>`). It **MUST** be a pure suffix: given `null` variant → returns the input unchanged; given a variant → returns `base + overlay`, with the base **substring-preserved verbatim** (no edit, no truncation, no reordering). It can **only add**; a test asserts the base prompt is a prefix of the result. The knobs render to stable, human-readable directives (`tone=formal` → "Use a formal tone."); an empty/whitespace `stylePrompt` contributes nothing (but never blanks the base).
+
+5. **CRUD API** for variants under a new `/api/style-variants` group: `GET` (list visible — public ∪ own-private), `GET /{id}`, `POST` (create own-private variant), `PUT /{id}` (update own variant), `DELETE /{id}` (archive own variant). Public shipped variants are read-only to tenants (managed by `PlatformOwnerAccess`, NOT `OwnerAccess`). Create/update/delete of an **own-private** variant requires `tenant_owner`/`tenant_admin` (SaaS) / the sole user (single-user); SaaS `member` → **403** on writes, reads allowed.
+
+6. **Enable + bind API.** `PUT /api/style-variants/{id}/enablement` (`{ "enabled": true|false }`) toggles a variant's membership in the principal's usable set (same per-tenant catalog-membership pattern as 32-16; own-private variants are implicitly enabled). `PUT /api/style-variants/bindings/{role}` (`{ "variantId": guid|null }`) binds at most one **enabled** variant to a role for the principal (`variantId:null` clears the binding → back to no overlay). Binding an un-enabled/unseen variant → `404`/`409`. Reads of bindings allowed for any member; writes are owner/admin (member → 403).
+
+7. **Per-mode RBAC** mirrors the Prompt Store / 32-2 / 32-16:
+   - SaaS `member` → **403** on variant create/update/delete, enablement writes, and bind writes; reads (`GET` list/bindings) allowed.
+   - SaaS `tenant_owner` / `tenant_admin` → manage own-private variants, enablement, and bindings for **their own tenant only**.
+   - **Single-user** mode → the sole user (auto-owner) manages variants/enablement/bindings for themselves; no member gate; principal is `UserId`.
+   - **Public-catalog management** of shipped variants (creating/retiring the platform-wide `terse`/`verbose`/… set) stays `PlatformOwnerAccess` and is the seeder's domain (AC10), not exposed on the tenant route.
+
+8. **`Program.cs` startup-reset DROP list** is amended: the two new public-schema/control-plane tables `agent_style_variants` and `agent_style_variant_selections` are appended to the destructive test-host wipe list ("Wiping Tamma-managed public-schema tables") so a second host boot does not fail with `relation "agent_style_variants" already exists`. Both are CP-resident (keyed by `TenantId` in SaaS, `UserId` in single-user); they do **not** go through the per-tenant `EfTenantDbMigrator` (which owns `t_<hex>` tables only).
+
+9. **`ControlPlaneDbContextModelTests.Model_Has_ExpectedControlPlaneEntities`** strict `BeEquivalentTo` list is updated to include `AgentStyleVariant` and `AgentStyleVariantSelection`, and both are registered as `DbSet`s on **`ControlPlaneDbContext`** with their EF config in the single `TammaModelConfiguration` source. `dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext` reports none after the new migration.
+
+10. **Seeded optional default catalog.** A small set of shipped **public** style variants (e.g. `terse`, `verbose`, `formal`, `casual`) is seeded via an `AgentStyleVariantSeeder` (insert-missing-only; never reverts a tenant edit). **No variant is bound by default** — a brand-new principal has zero bindings, so the default behaviour is **no overlay** (orthogonality preserved). The seeded variants are merely _available_ to bind; they change nothing until a principal explicitly binds one.
+
+11. **Orthogonality + no-fallback proof (the load-bearing contract).**
+    - **Default = none:** with no binding, the rendered system prompt the loop sees is **identical** to the 32-5 output without this story (a golden test asserts byte-for-byte equality vs `ComposeOverlay(base, null)`).
+    - **Additive only:** with a binding, the base prompt is a **verbatim prefix** of the composed prompt; the variant never edits/blanks/replaces the base.
+    - **Never weakens base resolution:** the variant overlay is applied **after** Epic-27/custom-prompt resolution; if the **base** prompt fails to resolve (tenant→system→error), 32-5 still fails loud — the variant cannot rescue or mask an empty base (consistent with `feedback_resolution_no_empty_fallback`). A missing/disabled **variant** is _not_ an error (optional) and resolves to no overlay.
+    - **Provider/model/credential untouched:** an integration test asserts `providerUsed`/`modelUsed`/`credentialSource` are identical with and without a bound variant for the same agent.
+
+12. **DCB events.** `AGENT.STYLE_VARIANT.CREATED/UPDATED/DELETED.SUCCESS`, `AGENT.STYLE_VARIANT.ENABLED/DISABLED.SUCCESS`, and `AGENT.STYLE_VARIANT.BOUND.SUCCESS` / `AGENT.STYLE_VARIANT.UNBOUND.SUCCESS` are emitted via `IEventRepository.AppendAsync`, tagged `{ variantId, variantName, role?, mode, tenantId | userId }`. Exactly one event per successful write. Additionally, when 32-5 applies a variant, the run's `AGENT.RUN.STARTED` (owned by 32-5) gains an optional `styleVariantId` tag (a tag addition only — this story does not own the event); when no variant applies, the tag is absent.
+
+13. **Unit + integration tests** cover: entity XOR + unique-nulls-not-distinct constraints; `ResolveActiveVariantAsync` truth table (bound+enabled→variant, bound+disabled→null, unbound→null, retired→null); `ComposeOverlay` purity (null→identity; variant→base-is-prefix; empty stylePrompt→no contribution; knob rendering stable); per-mode principal keying (single-user `UserId` vs SaaS `TenantId`); member 403 on writes / reads allowed; cross-tenant isolation; the orthogonality golden test (default=none byte-for-byte); provider/model/credential-unchanged integration test against 32-5; DROP-list second-boot + CP model-test + `has-pending-model-changes` → none.
+
+## Technical Design
+
+### Where it lives
+
+```
+apps/tamma-elsa/src/Tamma.Data/Entities/
+  AgentStyleVariant.cs                     # NEW — the style/voice variant entity (CP-resident; user-keyed single-user)
+  AgentStyleVariantSelection.cs            # NEW — per-(principal,role) binding (at most one variant)
+
+apps/tamma-elsa/src/Tamma.Data/
+  TammaModelConfiguration.cs               # MODIFY — both entities: XOR check + unique-nulls-not-distinct index
+  ControlPlaneDbContext.cs                 # MODIFY — DbSet<AgentStyleVariant>, DbSet<AgentStyleVariantSelection>
+  Migrations/ControlPlane/*_AddAgentStyleVariants.cs   # NEW (generated)
+
+apps/tamma-elsa/src/Tamma.Api/Services/Agents/
+  IAgentStyleVariantService.cs             # NEW — CRUD/enable/bind + ResolveActiveVariantAsync + ComposeOverlay
+  AgentStyleVariantService.cs              # NEW — impl (upsert, events, visibility/XOR, additive compose)
+  AgentStyleVariantEventTypes.cs           # NEW — AGENT.STYLE_VARIANT.* constants
+  AgentStyleVariantSeeder.cs               # NEW — seed shipped public variants (insert-missing-only); NO default binding
+
+apps/tamma-elsa/src/Tamma.Api/Endpoints/
+  StyleVariantEndpoints.cs                 # NEW — /api/style-variants CRUD + enablement + bindings
+
+apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/
+  StyleVariantResponse.cs, StyleVariantRequest.cs, SetVariantBindingRequest.cs   # NEW — DTOs
+
+apps/tamma-elsa/src/Tamma.Api/Program.cs   # MODIFY — DI; /api/style-variants routes; STARTUP-RESET DROP-LIST amend (AC8)
+```
+
+> **The 32-5 call site (4b) is owned by 32-5, wired via the interface.** This story ships `IAgentStyleVariantService` and does NOT edit `ManagedAgent.RunAsync`. 32-5 (or a tiny amendment to it) injects the service and inserts step 4b. The contract is the interface — this keeps 32-19 from touching the call-LLM composition.
+
+### `AgentStyleVariant` entity (NEW)
+
+```csharp
+// Tamma.Data/Entities/AgentStyleVariant.cs
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// An OPTIONAL tone/voice/verbosity overlay applied on top of a resolved agent
+/// (persona OR custom) at call time (Epic 32, design §3.4 — the style/voice idea
+/// split out of the old 32-12). It is NOT a persona (= the named system agent,
+/// 32-15) and NOT a custom agent (= own prompts, 32-17): it never changes
+/// provider/model/credential/base-prompt. It only ADDS style guidance, merged by
+/// 32-5 AFTER Epic-27/custom-prompt resolution. CP-resident in SaaS (keyed by
+/// TenantId); user-keyed in single-user (keyed by UserId). Principal XOR, same
+/// discipline as AgentRoleSelection / prompt_overrides.
+/// </summary>
+public class AgentStyleVariant
+{
+    public Guid Id { get; set; }
+
+    /// <summary>Set in SaaS; NULL in single-user. XOR with UserId. NULL for Public shipped variants.</summary>
+    public Guid? TenantId { get; set; }
+
+    /// <summary>Set in single-user; NULL in SaaS. XOR with TenantId.</summary>
+    public Guid? UserId { get; set; }
+
+    /// <summary>Public (shipped, read-only to tenants) or Private (own).</summary>
+    public AgentVisibility Visibility { get; set; }
+
+    /// <summary>Stable handle, e.g. "terse", "formal-review".</summary>
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+
+    /// <summary>The STYLE DESCRIPTOR — tone/verbosity knobs and/or a short style-prompt
+    /// fragment: { tone?, verbosity?, format?, audience?, stylePrompt? }. NO provider,
+    /// model, credential, or base-prompt fields — a variant cannot change those.</summary>
+    public string StyleJson { get; set; } = "{}";
+
+    /// <summary>Catalog membership for the principal (per-tenant), like 32-16.</summary>
+    public bool Enabled { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+    public Guid? CreatedBy { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public Guid? UpdatedBy { get; set; }
+}
+```
+
+```csharp
+// Tamma.Data/Entities/AgentStyleVariantSelection.cs — per-(principal, role), at most one variant.
+public class AgentStyleVariantSelection
+{
+    public Guid Id { get; set; }
+    public Guid? TenantId { get; set; }   // XOR
+    public Guid? UserId { get; set; }     // XOR
+    public string Role { get; set; } = string.Empty;   // one of the 8 valid roles
+    public Guid VariantId { get; set; }   // the single bound variant
+    public DateTime CreatedAt { get; set; }
+    public Guid? CreatedBy { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public Guid? UpdatedBy { get; set; }
+}
+```
+
+EF model config (in `TammaModelConfiguration.cs`, the single source — **identical discipline to `AgentRoleSelection` / `TenantAgentEnablement`**):
+
+```csharp
+modelBuilder.Entity<AgentStyleVariant>(b =>
+{
+    b.ToTable("agent_style_variants");
+    b.HasKey(x => x.Id);
+    b.Property(x => x.Name).IsRequired();
+    b.Property(x => x.StyleJson).IsRequired();
+    b.Property(x => x.Enabled).IsRequired();
+
+    // principal XOR (mirrors prompt_overrides / agent_role_selections / tenant_agent_enablements)
+    b.ToTable(t => t.HasCheckConstraint(
+        "ck_agent_style_variants_principal_xor",
+        "((tenant_id IS NOT NULL AND user_id IS NULL) OR (tenant_id IS NULL AND user_id IS NOT NULL))"));
+
+    // one private variant name per principal
+    b.HasIndex(x => new { x.TenantId, x.UserId, x.Name })
+        .IsUnique().AreNullsDistinct(false);
+});
+
+modelBuilder.Entity<AgentStyleVariantSelection>(b =>
+{
+    b.ToTable("agent_style_variant_selections");
+    b.HasKey(x => x.Id);
+    b.Property(x => x.Role).IsRequired();
+    b.Property(x => x.VariantId).IsRequired();
+
+    b.ToTable(t => t.HasCheckConstraint(
+        "ck_agent_style_variant_selections_principal_xor",
+        "((tenant_id IS NOT NULL AND user_id IS NULL) OR (tenant_id IS NULL AND user_id IS NOT NULL))"));
+
+    // at most one bound variant per (principal, role)
+    b.HasIndex(x => new { x.TenantId, x.UserId, x.Role })
+        .IsUnique().AreNullsDistinct(false);
+});
+```
+
+> **CP-resident, not tenant-schema.** Like the public `Agent`/persona catalog and `TenantAgentEnablement`, both variant tables live in the **control plane** (`ControlPlaneDbContext`), SaaS rows scoped by `TenantId`, single-user rows by `UserId`. They join the **CP DROP list (AC8)** and the **`ControlPlaneDbContextModelTests` strict list (AC9)** and do NOT go through the per-tenant `EfTenantDbMigrator`.
+
+### `IAgentStyleVariantService` (NEW) — owns the entities + the resolve/compose primitives
+
+```csharp
+// Tamma.Api/Services/Agents/IAgentStyleVariantService.cs
+public interface IAgentStyleVariantService
+{
+    // ---- CRUD (own-private; public shipped variants are read-only) ----
+    Task<IReadOnlyList<StyleVariantState>> ListAsync(CancellationToken ct = default);     // public ∪ own-private
+    Task<StyleVariantState?> GetAsync(Guid id, CancellationToken ct = default);
+    Task<StyleVariantState> CreateAsync(StyleVariantInput input, CancellationToken ct = default);
+    Task<StyleVariantState> UpdateAsync(Guid id, StyleVariantInput input, CancellationToken ct = default);
+    Task DeleteAsync(Guid id, CancellationToken ct = default);                              // archive own-private
+
+    // ---- catalog membership + per-role binding ----
+    Task<StyleVariantState> SetEnabledAsync(Guid id, bool enabled, CancellationToken ct = default);
+    Task BindAsync(string role, Guid? variantId, CancellationToken ct = default);          // null clears (no overlay)
+
+    // ---- The primitives 32-5 calls at step 4b ----
+
+    /// <summary>The single variant bound for (current principal, role) IFF it exists,
+    /// is visible, and is enabled; else null (no overlay — the default). A disabled or
+    /// retired bound variant resolves to null (optional, never an error).</summary>
+    Task<ResolvedStyleVariant?> ResolveActiveVariantAsync(string role, CancellationToken ct = default);
+
+    /// <summary>PURE, additive. Appends the variant's style guidance to an ALREADY-RENDERED
+    /// system prompt as a delimited style section. variant==null => returns base unchanged.
+    /// Otherwise base is a verbatim PREFIX of the result. NEVER edits/blanks/replaces base.</summary>
+    string ComposeOverlay(string renderedSystemPrompt, ResolvedStyleVariant? variant);
+}
+
+public sealed record StyleVariantState(
+    Guid Id, string Name, string? Description, AgentVisibility Visibility,
+    StyleDescriptor Style, bool Enabled, bool ImplicitlyEnabled);
+
+public sealed record StyleDescriptor(
+    string? Tone, string? Verbosity, string? Format, string? Audience, string? StylePrompt);
+
+public sealed record ResolvedStyleVariant(Guid VariantId, string Name, StyleDescriptor Style);
+```
+
+The impl derives the principal from `ITammaModeProvider` + `ITenantContext`/`ClaimsPrincipal` (SaaS ⇒ `TenantId`; single-user ⇒ `UserId`), reads/writes `ControlPlaneDbContext.AgentStyleVariants` / `…Selections`, validates targets are in (public ∪ own-private), and appends the DCB events.
+
+### The 32-5 call-site (step 4b — owned by 32-5, wired here via the interface)
+
+```
+... 32-5 ManagedAgent.RunAsync composition (design §2.6) ...
+ 4. prompt = await _promptRenderer.RenderAsync(principal, role, action, resolved, variables) // Epic 27 / custom — tenant→system→ERROR
+ 4b. variant = await _styleVariants.ResolveActiveVariantAsync(role, ct)        // 32-19 — null = no overlay (default)
+     systemPrompt = _styleVariants.ComposeOverlay(prompt.System, variant)       // additive; base is a verbatim prefix
+ 5. emit AGENT.RUN.STARTED { ..., styleVariantId = variant?.VariantId }         // optional tag only (event owned by 32-5)
+ 6. loop = await _toolLoop.RunAsync(..., systemPrompt: systemPrompt, ...)       // unchanged otherwise
+ ... provider/model/credential/cost path UNCHANGED ...
+```
+
+The base prompt resolution (step 4) keeps its tenant→system→**error** contract; step 4b can only **add**. A `null` variant makes the systemPrompt identical to step 4's output — the orthogonality guarantee (AC11).
+
+### `ComposeOverlay` — additive style section (pure)
+
+```csharp
+// variant == null  => return base verbatim (no overlay; the default).
+// variant != null  => base + "\n\n## Response style\n" + RenderDirectives(style)
+//   RenderDirectives: stable knob lines ("Use a formal tone.", "Be terse.") + the
+//   trimmed stylePrompt fragment. Empty/whitespace stylePrompt contributes nothing.
+//   Invariant (tested): base is a PREFIX of the returned string; never edits the base.
+```
+
+### DCB events
+
+| Event | Tags | When |
+|---|---|---|
+| `AGENT.STYLE_VARIANT.CREATED/UPDATED/DELETED.SUCCESS` | `{ variantId, variantName, mode, tenantId \| userId }` | own-private CRUD |
+| `AGENT.STYLE_VARIANT.ENABLED/DISABLED.SUCCESS` | `{ variantId, variantName, mode, tenantId \| userId }` | catalog-membership toggle |
+| `AGENT.STYLE_VARIANT.BOUND/UNBOUND.SUCCESS` | `{ variantId?, variantName?, role, mode, tenantId \| userId }` | per-role bind/clear |
+
+Appended via `IEventRepository.AppendAsync`; tenant-scope events carry the ambient `TenantId`; single-user events carry `userId` (`TenantId == null`). The run-level `AGENT.RUN.STARTED` `styleVariantId` tag is owned by 32-5 (tag addition only).
+
+### Startup-reset DROP list (AC8) — explicit codebase gotcha
+
+`agent_style_variants` and `agent_style_variant_selections` are NEW control-plane / public-schema tables. Append both to the destructive test-host wipe list in `Program.cs` (the "Wiping Tamma-managed public-schema tables" block) alongside `agent_role_selections`, `tenant_agent_enablements`, `prompt_overrides`, the public `Agent`/`AgentVersion` catalog, etc. Without this, a second test-host boot fails with `relation "agent_style_variants" already exists`. Both are CP-resident → CP wipe list, **not** the per-tenant `EfTenantDbMigrator` path.
+
+## Dependencies
+
+**Internal:**
+
+- **Story 32-12 (rewrite)** — establishes the locked vocabulary (persona = named system agent); this story is the **split-out** of 32-12's old style/tone overlay idea per design §3.4. Benchmarking stays agent-keyed (this story adds no variant axis to it). Conceptual prerequisite; cross-referenced both ways.
+- **Story 32-15** (Persona reframe + seeding) — supplies the persona/agent catalog a variant overlays. A persona is never a variant; the variant seeder is separate. Hard conceptual prerequisite.
+- **Story 32-16** (Per-tenant agent/persona enablement) — the catalog-membership + per-tenant + XOR/index precedent this story mirrors for variant enablement (`Enabled` + implicit-private). Pattern source.
+- **Story 32-17** (Custom-agent prompts) — a variant overlays on top of a custom agent's own prompts too (after them); it does not edit them. Boundary cross-reference.
+- **Story 32-5** (Call-LLM endpoint + managed execution) — the **consumer** that calls `ResolveActiveVariantAsync` + `ComposeOverlay` at step 4b. This story ships the interface; 32-5 wires it. Primary consumer.
+- **Story 32-2** (Agent registry/selection) — the `AgentRoleSelection` `(principal, role)` binding + XOR/index precedent the variant **binding** mirrors; the `/api/agents` policy conventions reused for `/api/style-variants`.
+- **Epic 27** (Prompt Store) — the **base** prompt the overlay rides on top of (tenant→system→error). A variant is never an Epic-27 override and never enters the prompt store. Boundary cross-reference + the no-empty-fallback discipline this story preserves.
+- **Epic 28** (schema-per-tenant) — the CP-vs-tenant placement decision (these tables are CP-resident, like the catalog they style).
+
+**Consumers (downstream, not blockers):**
+
+- **Story 32-5** — applies the overlay (primary consumer).
+- **Story 32-6 / 32-8 / 32-9** (action trail / outcome / usage) — observe the optional `styleVariantId` tag on `AGENT.RUN.*` if present; they do not key on it.
+
+**External:** none new (reuses EF Core, `IEventRepository`, the existing auth/policy stack).
+
+## Testing Strategy
+
+Tests are xUnit under `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/`. Docker-bound suites run via `sg docker -c "dotnet test ..."` (session docker group is stale; see `reference_dotnet_test_docker`). TDD: write the failing test first.
+
+1. **Entity constraints** (`AgentStyleVariantModelTests`): XOR CHECK rejects both/neither principal; unique-nulls-not-distinct rejects a duplicate `(TenantId, UserId, Name)` variant and a duplicate `(TenantId, UserId, Role)` binding (one variant per role).
+2. **`ResolveActiveVariantAsync` truth table** (`AgentStyleVariantServiceTests`): bound+enabled+visible → the variant; bound+disabled → `null`; unbound → `null`; bound-but-variant-retired → `null`; cross-tenant binding target → not visible → `null`/404 at bind time.
+3. **`ComposeOverlay` purity** (`StyleOverlayComposeTests`, pure unit, no DB): `null` → base unchanged (reference-equal or value-equal); a variant → base is a **prefix** of the result; empty/whitespace `stylePrompt` contributes nothing; knob rendering is stable/deterministic; never mutates or truncates the base (property-style: `result.StartsWith(base)`).
+4. **Orthogonality golden test (AC11)**: for a fixed agent + rendered base prompt, **no binding** ⇒ the systemPrompt 32-5 would feed the loop equals `ComposeOverlay(base, null)` byte-for-byte (== the base). Default = none = no behaviour change.
+5. **Provider/model/credential-unchanged integration test (AC11)**: run 32-5 (or a 32-5-shaped harness over `IAgentStyleVariantService`) for the same agent with and without a bound variant; assert `providerUsed`/`modelUsed`/`credentialSource` identical; only the system prompt differs (and only additively).
+6. **Never weakens base resolution (AC11)**: if the base prompt fails to resolve (tenant→system→error), the presence of a bound variant does NOT rescue/mask it — the run still fails loud; a disabled/missing **variant** is not an error.
+7. **CRUD + enablement + bind APIs + events** (`StyleVariantServiceTests`): create/update/delete own-private; enable/disable (own-private implicitly enabled, disable-own ⇒ 409/no-op like 32-16); bind/clear; each write emits exactly one `AGENT.STYLE_VARIANT.*` event tagged `{ variantId, variantName, role?, mode, tenantId|userId }`.
+8. **RBAC matrix** (`StyleVariantEndpointsTests`, in-process `WebApplicationFactory`): SaaS `member` → 403 on create/update/delete/enable/bind; member reads (`GET` list/bindings) → 200; `tenant_owner`/`tenant_admin` writes → 200; public-catalog mutation not exposed on the tenant route (asserted absent / 404).
+9. **Mode-parameterized principal** (`[Theory]` over `TammaMode.SingleUser`/`SaaS`): variant + binding keyed by `UserId` (single-user) vs `TenantId` (SaaS); the correct column set, the other NULL (XOR holds); events tag the correct principal.
+10. **Cross-tenant isolation** (`StyleVariantIsolationTests`): tenant A's private variant/binding never appears in tenant B's list/resolve; A cannot bind/enable B's private variant (404); A's changes never affect B.
+11. **Seeded catalog, no default binding** (`AgentStyleVariantSeederTests`): a fresh principal has the shipped public variants available but **zero bindings** (default = no overlay); the seeder is insert-missing-only (rerun does not revert a tenant edit).
+12. **CP model contract + DROP-list**: `ControlPlaneDbContextModelTests.Model_Has_ExpectedControlPlaneEntities` includes both entities; `dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext` → none; a second test-host boot succeeds (DROP-list amendment proven for both tables).
+
+## Estimated Effort
+
+3-4 days (two CP entities + service + CRUD/enable/bind API + the pure `ComposeOverlay` + seeder + the 32-5 wiring seam; no provider/credential/cost surface touched).
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/AgentStyleVariant.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/AgentStyleVariantSelection.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs` | Modify (both entities: XOR check + unique-nulls-not-distinct indexes) |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (two DbSets) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/*_AddAgentStyleVariants.cs` | Create (generated) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/IAgentStyleVariantService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentStyleVariantService.cs` | Create (CRUD, enable, bind, resolve, ComposeOverlay) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentStyleVariantEventTypes.cs` | Create (`AGENT.STYLE_VARIANT.*` constants) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentStyleVariantSeeder.cs` | Create (shipped public variants, insert-missing-only; no default binding) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/StyleVariantEndpoints.cs` | Create (`/api/style-variants` CRUD + enablement + bindings) |
+| `apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/StyleVariantResponse.cs`, `StyleVariantRequest.cs`, `SetVariantBindingRequest.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (DI; `/api/style-variants` routes; **STARTUP-RESET DROP-LIST amend** — both tables) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentStyleVariantServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/StyleOverlayComposeTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/StyleVariantEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/StyleVariantIsolationTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentStyleVariantSeederTests.cs` | Create |
+| `apps/tamma-elsa/tests/.../Epic28/ControlPlaneDbContextModelTests.cs` | Modify (add both entities to the strict list) |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` directory for related spikes, bugs, findings, and decisions (esp. `feedback_resolution_no_empty_fallback`).
+3. Reviewed `AgentRoleSelection` + `TenantAgentEnablement` (32-16) + `TammaModelConfiguration` — this story mirrors their XOR/index discipline **exactly** (two entities + the per-role binding).
+4. Reviewed `ControlPlaneDbContextModelTests` (the strict `BeEquivalentTo` list) and the `Program.cs` "Wiping Tamma-managed public-schema tables" block — **both must be amended** for the two new tables (AC8, AC9).
+5. Read design §3.4 (the 32-12 split: variant ≠ persona) and 32-5's §2.6 composition (the step-4 prompt render this overlay rides on top of) IN FULL, so the overlay stays **additive and after** base resolution.
+6. Planned the TDD approach; treat `ComposeOverlay` as a pure function with a base-is-prefix property test, and the orthogonality "default = none" golden test as the load-bearing guard.
+
+### Key design decisions
+
+- **A variant is NOT a persona and NOT a custom agent.** This is the entire point of the §3.4 split. The entity carries no provider/model/credential/base-prompt — it cannot change any of them. It is a thin, optional **voice** layer. Naming, route (`/api/style-variants`, never `/api/personas`), event family (`AGENT.STYLE_VARIANT.*`), and the strict "no provider/model fields" entity shape all enforce the distinction.
+- **Additive, after base resolution, never empty-fallback.** The overlay is applied at step **4b**, after Epic-27/custom-prompt resolution (step 4), as a pure suffix. It can only **add** style guidance. The base prompt keeps its tenant→system→**error** contract (32-5 AC3); the variant never rescues, blanks, or replaces it. A missing/disabled variant is silently "no overlay" (optional), but it can never weaken the base resolution.
+- **Optional + orthogonal; default = none.** Zero or one variant per `(principal, role)`; an unbound principal sees byte-for-byte the 32-5 output without this story (golden test). Provider/model/credential are identical with and without a variant for the same agent (integration test).
+- **Catalog-membership + per-role binding, mirroring 32-16 + 32-2.** Variants are enabled per-tenant (like personas in 32-16) and bound per-`(principal, role)` (like agents in 32-2's `AgentRoleSelection`) — but to at most one variant. Same XOR/unique-nulls-not-distinct discipline; own-private variants implicitly enabled.
+- **CP-resident in both modes.** Like `TenantAgentEnablement`, both variant tables are CP-resident (SaaS keyed by `TenantId`, single-user by `UserId`) because they style the CP-resident catalog and are keyed by principal id, not stored per `t_<hex>`. Hence the DROP-list + CP-model-test amendments for **both** tables.
+- **Benchmarking stays agent-keyed.** 32-12/32-10 benchmark the persona-agent identity. A variant is a separate optional dimension; this story does **not** add a variant axis to benchmarking. Any future variant A/B rides on the agent-keyed harness — out of scope.
+- **Own the primitive, not the call site.** This story ships `ResolveActiveVariantAsync` + `ComposeOverlay`; 32-5 wires step 4b. The boundary is the interface — keeps this story from editing the call-LLM composition.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns a style variant + its bindings? | The sole user (`user_id`-keyed CP rows; `tenant_id` NULL). | The tenant (`tenant_id`-keyed CP rows; `user_id` NULL). `tenant_owner`/`tenant_admin` write; `member` read-only. |
+| Is there a per-user layer? | N/A — the sole user *is* the principal. | **No.** Members see/use the tenant's variants + bindings; they cannot create/enable/bind (403 on writes) — mirrors "no per-user override layer in SaaS." |
+| Where do the variant rows live? | `ControlPlaneDbContext.agent_style_variants` / `…_selections`, keyed by `UserId`. | Same tables, keyed by `TenantId` (CP-resident, not `t_<hex>`). |
+| Does a variant change provider/model/credential? | **No** (in either mode). It is a voice overlay only; `credentialSource` is untouched. | **No.** Same. |
+| What is the default (no binding)? | No overlay — the rendered prompt is exactly the 32-5 output. | No overlay — identical for every member. |
+| Who manages the shipped public variant catalog? | Shipped system variants (read-only to the user; the user enables/binds). | Platform owner (`PlatformOwnerAccess`) — out of scope here; tenants only enable/bind existing ones + author own-private. |
+| Where do `AGENT.STYLE_VARIANT.*` events land? | The user's (platform-events) feed; `TenantId == null`, principal = `userId`. | The tenant's event store via tenant-scoped `IEventRepository`; `TenantId` set. |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`) — process-stable. | same |
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Variant treated/named as a persona → vocabulary regression (the §3.4 mistake) | High | Strict entity shape (no provider/model fields), distinct route (`/api/style-variants`), distinct event family (`AGENT.STYLE_VARIANT.*`); cross-referenced vs 32-15/32-12; story title says "NOT a persona." |
+| Overlay replaces/blanks the base prompt → empty-fallback regression | High | `ComposeOverlay` is a pure **suffix**; base-is-prefix property test; null-variant→identity; the base keeps its tenant→system→error contract in 32-5 (the variant never touches step 4). |
+| Default behaviour changes when nobody bound a variant | High | Seeder binds nothing; orthogonality golden test asserts byte-for-byte equality vs the no-variant 32-5 output. |
+| Variant accidentally changes provider/model/credential/cost | High | Entity carries none of those fields; integration test asserts `providerUsed`/`modelUsed`/`credentialSource` identical with/without a variant. |
+| New CP tables break the second test-host boot (`relation already exists`) | High | Amend the `Program.cs` DROP list for **both** tables (AC8); test asserts a second boot succeeds. |
+| `ControlPlaneDbContextModelTests` strict list fails after adding the entities | High | Update the `BeEquivalentTo` list in the same PR for both (AC9); known gotcha, not a regression. |
+| This story edits the 32-5 composition (overlap) | Medium | Hard boundary: ship the interface + primitives; 32-5 owns step 4b. No `ManagedAgent.RunAsync` edits here. |
+| XOR/keying drift from `AgentRoleSelection`/`TenantAgentEnablement` | Medium | Mirror `TammaModelConfiguration` config (XOR check name pattern, unique-nulls-not-distinct); constraint tests (AC13.1). |
+| Style fragment used as a prompt-injection vector | Medium | The fragment is appended to the **system** prompt of a run the principal already controls; it is owner/admin-authored, not user content; sanitization remains in 32-5's loop; the overlay adds no tool/credential surface. |
+
+### Success Metrics
+
+- [ ] With no binding, the system prompt 32-5 feeds the loop is **byte-for-byte** the no-variant output (orthogonality golden test green).
+- [ ] For the same agent, `providerUsed`/`modelUsed`/`credentialSource` are identical with and without a bound variant.
+- [ ] `ComposeOverlay` is provably additive (base is a prefix of the result; null → identity) across the property tests.
+- [ ] 100% of variant writes emit exactly one `AGENT.STYLE_VARIANT.*` event tagged with the principal.
+- [ ] Second test-host boot succeeds (DROP-list amendment, both tables) and `has-pending-model-changes` → none.
+
+## Related
+
+- Design of record: `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§3.4 the 32-12 split — variant ≠ persona; §3.0 reframe; §2.6 composition step 4 the overlay rides on)
+- Re-plan / sequence: `docs/superpowers/plans/2026-06-20-epic-32-37-replan.md` (sequence step G)
+- Implementation plan: `docs/superpowers/plans/2026-06-21-32-19-agent-style-voice-variants-plan.md`
+- Sibling stories: `docs/stories/epic-32/story-32-12/` (persona rewrite — benchmarking stays agent-keyed), `story-32-15/` (persona seeder), `story-32-16/` (per-tenant enablement — the catalog-membership/XOR precedent), `story-32-17/` (custom-agent prompts — base prompts the overlay rides on), `story-32-5/` (call-LLM endpoint — applies the overlay at step 4b), `story-32-2/` (`AgentRoleSelection` binding precedent)
+- Reused precedent: `apps/tamma-elsa/src/Tamma.Data/Entities/AgentRoleSelection.cs`, `TenantAgentEnablement` (32-16), `prompt_overrides` (Epic 27)
+
+## Logging Requirements
+
+- **INFO**: variant created/updated/deleted/enabled/disabled (variantId, variantName, mode, tenantId|userId); variant bound/cleared for a role (role, variantId?); call-LLM applied a variant (correlationId, role, variantId) — emitted by 32-5 at step 4b.
+- **DEBUG**: `ResolveActiveVariantAsync` branch taken (bound-enabled / bound-disabled→null / unbound→null / retired→null); `ComposeOverlay` invoked (base length, overlay length, no-overlay short-circuit); seeded shipped variants applied (or skipped, row exists).
+- **WARN**: bind/enable target no longer a live/visible variant ⇒ ignored/degraded (variantId); disable-own-private rejected (409); cross-tenant target ⇒ 404; a variant style fragment exceeding a sane length cap ⇒ truncated-for-overlay (never blanks the base).
+- **ERROR**: DCB event append failure (the write still committed; the append failure is logged, not swallowed); migration / DB write failure; XOR/unique-constraint violation surfaced from EF.
+- **Structured context**: include `{ variantId, variantName, role, mode, tenantId, userId, correlationId }` where applicable.
+- **Credential safety (LOAD-BEARING)**: a style variant is **credential-agnostic** — it references variant ids/names + tone/verbosity knobs + a style fragment, NEVER a provider key. NEVER log provider credentials; the variant path never touches `credentialSource` resolution (that stays in 32-3, invoked by 32-5). The style fragment is owner/admin-authored config text, not a secret, but is still logged at length-summary granularity (not verbatim) to avoid leaking inadvertently-pasted secrets.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-21 | 1.0.0   | Initial story creation — optional style/voice variant overlay split out of 32-12 per design §3.4 (explicitly NOT a persona); additive, after base resolution, never empty-fallback; CP-resident dual-keyed entities; applied by 32-5 at step 4b. | Claude |

--- a/docs/stories/epic-32/story-32-20/32-20-interactive-question-back.md
+++ b/docs/stories/epic-32/story-32-20/32-20-interactive-question-back.md
@@ -1,0 +1,414 @@
+# Story 32-20: Interactive Question-Back (`request_input` tool + `IQuestionRouter` + durable human gate)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **platform engineer running agent-driven workflows through the managed `/api/v1/llm/call` endpoint**,
+I want an agent to be able to **ask a question back mid-run** via a first-class `request_input` tool — and have the answer come from the cheapest competent source (the orchestrator's own facts, an agent panel, or a human) routed by a server-side policy that the model cannot fool —
+So that an agent that hits an ambiguity, a trade-off, or an irreversible decision **stops guessing**: facts are answered in-stream for free, judgment calls go to a budget-clamped agent panel, and merge/deploy/spend/schema approvals durably suspend the workflow for a human — all key-free, fully audited, and time-travel-debuggable, without the thin engine step ever calling a provider.
+
+## Priority
+
+P1 — The **single most novel piece** of the Epic 32 pivot (deep-dive §5, §6 item 5). It turns the managed agent from a one-shot generator into an interactive collaborator and is the structural fix for the 70%-autonomous-completion goal: an agent that can ask the *right* source the *right* way (instead of fabricating or failing) is the difference between a run that lands and a run that derails. It depends on the call-LLM endpoint (32-5) being the single execution path and on the agent-panel primitives (32-7) being the `judgment` answerer.
+
+## Context
+
+### What exists today (the gap, confirmed — deep-dive §5)
+
+The agentic tool loop (extracted into `IInlineToolLoopRunner`/`InlineToolLoopRunner` by 32-5) has **six** tools (`git_operations`, `shell_execute`, `file_read`, `file_write`, `run_tests`, `search_code`) — **none** of them lets the agent ask a question. When the model has nothing more to call it ends the turn on a non-`ToolUse` stop reason, so a question the model *wants to ask* becomes the run's final "answer" with **nothing answering it**. The agent's only options today are to guess or to stop — both corrosive to the autonomy target.
+
+But the repo already has **every primitive** to close the gap:
+
+- the **tool loop** (32-5) — a question can be a *tool call* that returns a *tool-result message*, so the model resumes its own reasoning in-context through the existing validate→execute→append cycle (no new conversation-shaping code);
+- the **agent panel** (32-7) — `RunAgentPanelActivity` + `AggregatePanelActivity` (`apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/`), tenant-scoped, budget-clamped, SaaS-gated per member — the natural answerer for `judgment` questions;
+- the **fast-signal model** — `WebhookSignalRegistry`'s in-process `TaskCompletionSource` wakeups (the inbound-webhook→bookmark path) — the model for resolving a fast answer **inside** an open request;
+- the **durable human gate** — `EscalateToSeniorActivity` (`apps/tamma-elsa/src/Tamma.Activities/Blocker/EscalateToSeniorActivity.cs`): notify a human, `context.CreateBookmark(...)` with an `OnResumeAsync` callback + `AutoBurn`, **suspend durably**, resume on a signal. This story's human path is modeled **byte-for-byte** on it.
+
+### What this story does (deep-dive §5)
+
+Adds **interactive question-back** to the managed run as five cooperating pieces, all behind the existing `/api/v1/llm/call` boundary (32-5) so **the step still never calls a provider**:
+
+1. A first-class **`request_input` tool** — the agent's ONLY way to ask back (a tool call, not a stop reason), executed **server-side inside the runner**.
+2. **`IQuestionRouter`** — routes a raised question by `kind` + context to the cheapest competent answerer (orchestrator-fact → agent-panel → human), escalating cost/latency.
+3. **`QuestionRoutingPolicy`** — a server-side, fail-loud, never-empty policy keyed `(principal, role, action, kind)` (tenant→system→error) that **re-derives** the human-gate decision from the pending action's blast radius — the load-bearing security control.
+4. The **in-stream resolution path** for fast answers (orchestrator-fact, agent-panel), bounded by `inStreamAnswerTimeout` with SSE heartbeats, reusing the `WebhookSignalRegistry` TCS model.
+5. The **durable human gate**: a new **`WaitForAgentQuestionActivity`** (modeled on `EscalateToSeniorActivity`) + the human-answer endpoint + the stateless re-invoke of `/llm/call` with the human answer re-primed as the `request_input` tool result.
+
+### Why a tool call, not a stop reason (deep-dive §5.1)
+
+A `request_input` **tool call** means the answer comes back as a **tool-result message** appended to the conversation, so the model resumes its own reasoning with the answer in-context — it flows through the runner's existing validate→execute→append cycle with no new conversation-shaping code. A parsed `end_turn` "question" would require bespoke re-prompting and would lose the model's mid-turn state. The tool executes **inside `Tamma.Api`** (where the runner runs after 32-5), so the engine step still owns no provider logic and never calls out.
+
+### Explicitly out of scope (referenced, not implemented here)
+
+- **The call-LLM endpoint, `InlineToolLoopRunner`, the resilience relocation, the thin-client cutover** — that is **32-5** (the hard prerequisite). This story adds a tool + a router + a wait-activity *on top of* the landed endpoint.
+- **The agent-panel primitives** (`RunAgentPanelActivity`/`AggregatePanelActivity`, the strategies) — that is **32-7** (the `judgment` answerer this story *calls*, not builds).
+- **The SSE response mode + live `IToolLoopEventSink` + run tap** — the **"Streaming run tap"** follow-on (deep-dive §3, §6.4). This story's in-stream wait reuses the buffered path's heartbeat seam; the `question`/`answer` SSE frames are wired by the run-tap story.
+- **The reversibility/blast-radius classifier as a standalone, richly-configured ADL feature** — this story ships the *minimal* server-owned reversibility derivation needed for the human-gate security control; a fuller blast-radius model is an ADL concern (referenced, not owned).
+- **MCP/plugin tools, prompt/response cache, harness adapter, non-LLM mediation** — separate follow-ons / Epic 38.
+
+## Acceptance Criteria
+
+1. **`request_input` is a first-class tool in the managed run.** A new tool `request_input` is registered in the `IToolExecutorRegistry` catalog used by `InlineToolLoopRunner` (32-5), with the schema `{ question:string, kind:"fact"|"decision"|"judgment"|"approval", options?:string[]|null, schema?:object|null, blocking:bool, default_assumption?:string|null, confidence:number }`. It is **executed server-side inside `Tamma.Api`** (where the runner runs), and its result is appended to the conversation as a **tool-result message** so the model resumes its own reasoning in-context through the existing validate→execute→append cycle. The step never calls a provider; `enableToolLoop` runs gain the tool when the agent's allowed-tool set (32-2) includes it.
+
+2. **`IQuestionRouter` routes by `kind` + context (deep-dive §5.2).** A new `IQuestionRouter.RouteAsync(RaisedQuestion, QuestionContext, ct)` (`Tamma.Api/Services/Agents/Questions/`) returns a `QuestionRouting { Answerer ∈ {orchestrator, panel, human}, Mechanism, Resolution }`. The decision uses the `QuestionRoutingPolicy` (AC4) and the escalating cost/latency map: `fact`→**orchestrator/workflow-state** (synchronous lookup over workflow vars + Epic-27 conventions + issue/PR context — zero LLM, zero human, in-stream); `judgment`→**agent panel (32-7)** (`RunAgentPanelActivity`+`AggregatePanelActivity`, tenant-scoped, budget-clamped, in-stream/short signal); `decision` with closed `options` + a confident `default_assumption`→**orchestrator policy first, panel fallback**; `approval`/irreversible (merge/deploy/spend/schema)→**human-in-the-loop** (durable bookmark + signal).
+
+3. **`QuestionRoutingPolicy` is server-side, keyed, and fail-loud-never-empty (deep-dive §5.2).** A policy keyed `(principal, role, action, kind)` resolves **tenant→system→ERROR** (never empty/plain — `feedback_resolution_no_empty_fallback`), with inputs: `kind`, the **reversibility/blast-radius of the pending action** (orchestrator-owned), the run's **autonomy level** (ADL limits config), and **budget**. If no policy resolves, the router **fails loud** (`AGENT.QUESTION.ROUTE_DENIED`), never silently auto-answers. The policy lives in `Tamma.Api` where the tenant store lives; in single-user mode it is keyed by `UserId`, in SaaS by `TenantId` — same XOR/index discipline as `prompt_overrides`/`AgentRoleSelection`.
+
+4. **Security (LOAD-BEARING) — the model cannot downgrade routing (deep-dive §5.2).** The model-supplied `kind` and `blocking` are treated as **hints**. The server **re-derives** the human-gate decision from the pending action's reversibility, which the orchestrator owns — **a question whose pending action is irreversible (merge/deploy/spend/schema) routes to the human gate regardless of the model's `kind`**. A misclassifying or adversarial model that tags a `merge`-approval as `fact` (to dodge human gating) is **upgraded** to the human gate by the server; the model can **raise** a question and can route it *more* conservatively, but **cannot route below what blast radius mandates**. Tested with an adversarial fixture: `kind:"fact"` + an irreversible pending action ⇒ human gate, never an in-stream auto-answer.
+
+5. **`blocking:false` ⇒ audited assumption, never a pause (deep-dive §5.2).** When the model sets `blocking:false` and supplies a `default_assumption`, and the policy permits (reversible action, within autonomy + budget), the orchestrator **auto-answers with the `default_assumption`**, records it as an **audited assumption** (`AGENT.QUESTION.ASSUMED`), and the run **never pauses**. The assumed answer is returned as the `request_input` tool result so the model proceeds. If the policy does NOT permit (irreversible / out of autonomy), `blocking:false` is **ignored** and the question is gated per AC4 (a non-blocking hint cannot waive a human gate).
+
+6. **In-stream resolution for fast answers (deep-dive §5.3).** `fact` and `panel` answers resolve **inside the same `/llm/call` invocation**, on the server, bounded by an `inStreamAnswerTimeout` (default ~90s, **tenant-tunable**) with SSE heartbeats holding the connection (reusing the buffered path's flush seam). The turn never leaves the stream; the resolution reuses the **`WebhookSignalRegistry` `TaskCompletionSource`** fast-signal model. On in-stream timeout the router applies the configured escalation (AC11 open decision) — default for `judgment` is to fail the turn into the human gate (AC7) rather than silently assume.
+
+7. **Slow (human) answers cross engine→bookmark→signal→re-call (deep-dive §5.3).** When the policy routes to a human, the turn **ends** returning the 32-5 fail-closed envelope: **HTTP 200 `success:false`, `failureCode = "INPUT_REQUIRED"`**, the **question** (key-free), and the **accrued `usage`** (key never leaked). The thin step **does NOT retry**; it routes the **workflow** into a new **`WaitForAgentQuestionActivity`** (`apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/WaitForAgentQuestionActivity.cs`), modeled **byte-for-byte on `EscalateToSeniorActivity`**: notify the human (channel/integration as `EscalateToSeniorActivity` does), `context.CreateBookmark(new CreateBookmarkArgs { BookmarkName = $"agent-question-{correlationId}", Callback = OnResumeAsync, AutoBurn = true })`, **suspend durably**. The durable wait lives in the **workflow** (Elsa bookmark), **never** in an HTTP connection.
+
+8. **The human-answer endpoint resumes the workflow (deep-dive §5.3).** A new **`POST /api/v1/agents/questions/{correlationId}/answer`** (`Tamma.Api/Endpoints/AgentQuestionEndpoints.cs`) accepts `{ answer, answeredBy }`, authorizes the answerer (tenant member for a tenant run; `tenant_owner`/`tenant_admin` where the pending action requires elevated approval — never a cross-tenant or platform-admin answer for another tenant's run), and calls `ElsaWorkflowService.SendSignalAsync` (resume the `agent-question-{correlationId}` bookmark). On resume, the workflow **re-invokes `/llm/call`** (via the thin `CallLlmInlineActivity`, 32-5) with the **prior messages + the human answer re-primed as the `request_input` tool result**, so the model resumes where it paused. The endpoint stays **stateless across the human gap** (AC9).
+
+9. **Endpoint statelessness + conversation rehydration (deep-dive §5.3, §7 open #6).** `/api/v1/llm/call` holds **no per-run conversation state across the human gap**. On the re-invoke, the prior conversation is **rehydrated** either from the request (the workflow carries the messages) **or** from the **action trail (32-6) keyed by `correlationId`** (the leaning design — open decision AC11.2). The human answer is re-primed as the `request_input` tool result before the runner continues. No sticky server session; the only durable state is the Elsa bookmark + the action trail.
+
+10. **Audit — from the API where the tenant store lives (deep-dive §5.3).** The managed run emits, via the tenant `IEventRepository` (32-6 trail, tenant-scoped — never the control plane): `AGENT.QUESTION.RAISED` (the model asked: `kind`, `blocking`, `confidence`, `correlationId`, `questionId`), exactly one `AGENT.QUESTION.ANSWERED` per resolved question **tagged `answerer ∈ {orchestrator, panel, human}`** (+ `latencyMs`, `routingReason`), and `AGENT.QUESTION.ASSUMED` for the AC5 auto-answer path. A routed-but-denied question emits `AGENT.QUESTION.ROUTE_DENIED`. The question text and answer are **key-free**; no provider key, `BaseUrl` auth, or raw header ever appears in any event, log, or response.
+
+11. **Open decisions are documented as Risks/Open-Questions (deep-dive §7), not silently resolved:** (1) **in-stream timeout → escalation for `judgment`** — promote to human bookmark vs proceed-on-assumption vs fail-the-turn (default contentious vs the 70% autonomy target); the chosen default is the human gate, configurable. (2) **conversation-state rehydration** — workflow variable vs action-trail (32-6) keyed by `correlationId` (leaning action-trail). (3) **`request_input` budgeting** — panel-answer tokens charged to the asking agent's budget vs a separate "clarification" line (affects 32-9/34-5). Each is called out, not pre-decided in code.
+
+12. **Tests cover the tool, the router, the security control, the in-stream path, and the durable human path.** `request_input` appears as a tool-result message and the model resumes (runner test); router maps each `kind` to its answerer; the policy resolves tenant→system→ERROR (no empty fallback); the **adversarial `kind:"fact"`-on-irreversible-action upgrade to human** holds; `blocking:false`+reversible auto-answers (`ASSUMED`) without pausing; `blocking:false`+irreversible is **ignored** and gated; the in-stream fast path resolves within timeout and times out into the human gate; the human path returns `success:false`/`INPUT_REQUIRED`, creates the `agent-question-{correlationId}` bookmark, and the answer endpoint resumes + re-invokes with the answer re-primed; exactly one `AGENT.QUESTION.ANSWERED` per question tagged with the right `answerer`; and **no key leaks** in any event/log/response.
+
+## Technical Design
+
+### Where it lives
+
+```
+apps/tamma-elsa/src/Tamma.Api/Services/Agents/Questions/
+  RequestInputTool.cs              # NEW — the server-side request_input tool executor (IToolExecutor)
+  RaisedQuestion.cs                # NEW — parsed tool args { Question, Kind, Options?, Schema?, Blocking, DefaultAssumption?, Confidence }
+  IQuestionRouter.cs               # NEW — RouteAsync(RaisedQuestion, QuestionContext, ct) -> QuestionRouting
+  QuestionRouter.cs                # NEW — policy + escalating-cost map; re-derives human gate from blast radius
+  QuestionRouting.cs               # NEW — { Answerer, Mechanism, Resolution(InStreamAnswer? | HumanGate | Assumed) }
+  IQuestionRoutingPolicyResolver.cs# NEW — (principal, role, action, kind) -> RoutingPolicy; tenant->system->ERROR
+  QuestionRoutingPolicyResolver.cs # NEW — fail-loud-never-empty resolution (Epic 27-style)
+  IReversibilityClassifier.cs      # NEW — server-owned: pending-action -> { Reversible, BlastRadius }  (the security control)
+  ReversibilityClassifier.cs       # NEW — minimal merge/deploy/spend/schema -> irreversible derivation
+  AgentQuestionEventTypes.cs       # NEW — AGENT.QUESTION.RAISED/ANSWERED/ASSUMED/ROUTE_DENIED constants
+  OrchestratorFactResolver.cs      # NEW — synchronous fact lookup over workflow vars + Epic-27 conventions + issue/PR ctx
+  PanelAnswerResolver.cs           # NEW — adapts a judgment question to RunAgentPanelActivity (32-7), budget-clamped
+
+apps/tamma-elsa/src/Tamma.Api/Endpoints/
+  AgentQuestionEndpoints.cs        # NEW — POST /api/v1/agents/questions/{correlationId}/answer -> SendSignalAsync
+
+apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/
+  WaitForAgentQuestionActivity.cs  # NEW — modeled byte-for-byte on EscalateToSeniorActivity: notify + CreateBookmark + suspend + OnResumeAsync
+
+apps/tamma-elsa/src/Tamma.Api/Services/Agents/
+  ManagedAgent.cs                  # MODIFY (32-5) — wire IQuestionRouter into the run; emit INPUT_REQUIRED on human-gate
+  LlmCallResponse.cs               # MODIFY (32-5) — add INPUT_REQUIRED failureCode + Question payload (key-free)
+  InlineToolLoopRunner.cs (Tamma.Activities/LlmCall) # MODIFY — execute request_input via IQuestionRouter; append tool-result; or end turn with INPUT_REQUIRED
+
+apps/tamma-elsa/src/Tamma.Activities/LlmCall/
+  CallLlmInlineActivity.cs         # MODIFY (32-5 thin shim) — on INPUT_REQUIRED do NOT retry; surface the question to the workflow
+```
+
+### The `request_input` tool (AC1)
+
+```jsonc
+// tool: request_input — the agent's ONLY way to ask back (a tool call, not a stop reason)
+{ "question": "Should the migration drop the legacy column, or keep it nullable?",
+  "kind": "decision",                 // fact | decision | judgment | approval  (HINT — server re-derives gating)
+  "options": ["drop", "keep-nullable"] | null,
+  "schema": { } | null,               // optional JSON schema the answer must satisfy
+  "blocking": true,                   // false => orchestrator may auto-answer with default_assumption (AC5)
+  "default_assumption": "keep-nullable" | null,
+  "confidence": 0.4 }
+```
+
+```csharp
+// Server-side executor — runs INSIDE Tamma.Api (where InlineToolLoopRunner runs after 32-5).
+public sealed class RequestInputTool : IToolExecutor   // registered in IToolExecutorRegistry (32-5 catalog)
+{
+    public string Name => "request_input";
+    public async Task<ToolResult> ExecuteAsync(ToolInvocation inv, ToolExecutionContext ctx, CancellationToken ct)
+    {
+        var q = RaisedQuestion.Parse(inv.Arguments);                 // validated against the schema above
+        var routing = await _router.RouteAsync(q, QuestionContext.From(ctx), ct);   // AC2/AC3/AC4
+        return routing.Resolution switch
+        {
+            InStreamAnswer a => ToolResult.Text(a.Answer),           // fact/panel/assumed -> tool-result message (model resumes)
+            Assumed a        => ToolResult.Text(a.Assumption),       // AC5 — recorded AGENT.QUESTION.ASSUMED
+            HumanGate _      => ToolResult.Suspend(q),               // AC7 — bubble up: end turn, INPUT_REQUIRED
+            _                => throw new TammaError("AGENT.QUESTION.ROUTE_DENIED", ...)   // AC3 fail-loud
+        };
+    }
+}
+```
+
+### `IQuestionRouter` + the escalating-cost map (AC2)
+
+```csharp
+public interface IQuestionRouter
+{
+    Task<QuestionRouting> RouteAsync(RaisedQuestion q, QuestionContext ctx, CancellationToken ct);
+}
+
+// Composition order inside QuestionRouter.RouteAsync:
+// 0. policy   = await _policy.ResolveAsync(ctx.Principal, ctx.Role, ctx.Action, q.Kind);   // tenant->system->ERROR (AC3)
+// 1. radius   = _reversibility.Classify(ctx.PendingAction);                                // SERVER-OWNED (AC4)
+// 2. gate     = radius.Irreversible || policy.RequiresHuman(q.Kind, ctx.Autonomy);         // re-derive — model can't downgrade
+//    if (gate) return QuestionRouting.Human(q);                                            // AC4/AC7 — upgrade wins
+// 3. non-blocking auto-answer (AC5):
+//    if (!q.Blocking && q.DefaultAssumption is not null && policy.AllowsAssumption(radius, ctx.Autonomy, ctx.Budget))
+//        return QuestionRouting.Assumed(q.DefaultAssumption);                              // AGENT.QUESTION.ASSUMED, never pauses
+// 4. by kind (escalating cost/latency):
+//    fact      -> _orchestratorFacts.TryAnswer(q, ctx)   // zero LLM/human, in-stream
+//    decision  -> policy.TryDecide(q) ?? _panel.Answer(q, ctx)   // policy first, panel fallback
+//    judgment  -> _panel.Answer(q, ctx)                  // 32-7 panel, budget-clamped, in-stream/short signal
+//    approval  -> QuestionRouting.Human(q)               // always human (already caught by gate)
+// 5. in-stream answers bounded by ctx.InStreamAnswerTimeout (~90s, tenant-tunable); on timeout -> escalate (AC6/AC11)
+```
+
+| `kind` | Answerer | Mechanism | Latency class |
+|---|---|---|---|
+| `fact` | **Orchestrator / workflow state** | sync lookup vs workflow vars + Epic-27 conventions + issue/PR context — zero LLM, zero human | in-stream (sub-second) |
+| `judgment` | **Agent panel (32-7)** | `RunAgentPanelActivity`+`AggregatePanelActivity`, tenant-scoped, budget-clamped | in-stream / short in-process signal |
+| `decision` w/ closed options + confident default | **Orchestrator policy**, fallback panel | policy first, panel second | in-stream |
+| `approval` / irreversible (merge/deploy/spend/schema) | **Human-in-the-loop** | durable Elsa bookmark + signal | **workflow-suspend** (hours–days) |
+
+### The security control — server re-derives the gate (AC4, LOAD-BEARING)
+
+```csharp
+// IReversibilityClassifier is SERVER-OWNED — the model never feeds it.
+// The pending action (the orchestrator's current step intent: merge / deploy / spend / schema-change)
+// is supplied by the workflow context, NOT by the model's request_input args.
+public sealed record BlastRadius(bool Irreversible, string Class);  // "merge" | "deploy" | "spend" | "schema" | "reversible"
+
+// In QuestionRouter: the human gate is the MAX of (model hint, server derivation).
+// model says kind:"fact" + pending action == merge  ==>  Irreversible ==>  HUMAN GATE.
+// The model can RAISE the question and can ask for MORE caution; it can NEVER route below blast radius.
+```
+
+A test fixture asserts: `RaisedQuestion { kind="fact", blocking=false }` with `ctx.PendingAction = Merge` ⇒ `QuestionRouting.Answerer == human`, the in-stream/assume paths are **never taken**, and `AGENT.QUESTION.RAISED` records the model's (untrusted) `kind` alongside the server's (authoritative) routing.
+
+### The durable human gate — `WaitForAgentQuestionActivity` (AC7), modeled on `EscalateToSeniorActivity`
+
+```csharp
+[Activity("Tamma.AgentDispatch", "Wait For Agent Question",
+          "Notify a human and suspend until the agent's question is answered", Kind = ActivityKind.Task)]
+public class WaitForAgentQuestionActivity : Activity
+{
+    [Input] public Input<string> CorrelationId { get; set; } = default!;
+    [Input] public Input<string> Question { get; set; } = default!;
+    [Input] public Input<string> Kind { get; set; } = default!;
+    [Output] public Output<string?> Answer { get; set; } = default!;
+    [Output] public Output<string?> AnsweredBy { get; set; } = default!;
+
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var correlationId = CorrelationId.Get(context);
+        await NotifyHuman(correlationId, Question.Get(context), Kind.Get(context));   // same channel/integration as EscalateToSenior
+        context.CreateBookmark(new CreateBookmarkArgs
+        {
+            BookmarkName = $"agent-question-{correlationId}",   // <-- the signal name the answer endpoint resumes
+            Callback = OnResumeAsync,
+            AutoBurn = true
+        });
+    }
+
+    private async ValueTask OnResumeAsync(ActivityExecutionContext context)
+    {
+        var input = context.WorkflowInput;
+        context.Set(Answer, input.TryGetValue("Answer", out var a) ? a?.ToString() : null);
+        context.Set(AnsweredBy, input.TryGetValue("AnsweredBy", out var b) ? b?.ToString() : null);
+        await context.CompleteActivityAsync();   // workflow re-invokes /llm/call with the answer re-primed
+    }
+}
+```
+
+### The human-answer endpoint (AC8) → resume + re-invoke
+
+```csharp
+// POST /api/v1/agents/questions/{correlationId}/answer   body: { answer, answeredBy }
+app.MapPost("/api/v1/agents/questions/{correlationId}/answer", async (
+        string correlationId, AgentQuestionAnswer body, HttpContext http,
+        IElsaWorkflowService elsa, IAgentQuestionAuthorizer authz, CancellationToken ct) =>
+{
+    await authz.EnsureCanAnswerAsync(http, correlationId, body, ct);   // tenant member; elevated where the action demands; never cross-tenant
+    await elsa.SendSignalAsync($"agent-question-{correlationId}",       // resume the bookmark
+        new { Answer = body.Answer, AnsweredBy = body.AnsweredBy }, ct);
+    return Results.Accepted();
+})
+.RequireAuthorization(/* tenant-member policy */);
+```
+
+On resume, `WaitForAgentQuestionActivity` completes; the workflow re-invokes `/llm/call` (thin `CallLlmInlineActivity`, 32-5) with the **prior messages + the human answer re-primed as the `request_input` tool result**. The endpoint stays stateless across the gap; the conversation is rehydrated from the request or the action trail (32-6) keyed by `correlationId` (AC9).
+
+### The fail-closed envelope for the human path (AC7) — rides 32-5's §2.4 contract
+
+```jsonc
+// 32-5 LlmCallResponse, extended with INPUT_REQUIRED — HTTP 200, key never leaked:
+{ "success": false,
+  "failureCode": "INPUT_REQUIRED",
+  "question": { "questionId": "…", "text": "…key-free…", "kind": "approval",
+                "options": [...]|null, "blocking": true },
+  "usage": { …accrued-before-pause… },        // tokens accrued so far are preserved (AC7)
+  "credentialSource": "platform", "correlationId": "…" }
+```
+
+The thin step does **not** treat `INPUT_REQUIRED` as a retryable provider failure (distinct from `PROVIDER_ERROR`/`httpStatusCode`); it routes the workflow to `WaitForAgentQuestionActivity` instead of advancing the provider chain.
+
+## Dependencies
+
+**Internal (hard prerequisites):**
+
+- **32-5** (Call-LLM endpoint + managed execution) — the single execution path: `IInlineToolLoopRunner` (where `request_input` is executed), `ManagedAgent.RunAsync` (where the router is wired), the `LlmCallResponse` fail-closed envelope (extended with `INPUT_REQUIRED`), and the thin `CallLlmInlineActivity` (which routes to the wait-activity). **Sequence F.**
+- **32-7** (Multi-agent design-review panels) — `RunAgentPanelActivity` + `AggregatePanelActivity` (`Tamma.Activities/AgentDispatch/`), the `judgment` answerer (`PanelAnswerResolver` adapts to it, budget-clamped per 32-7 AC9).
+- **32-6** (Agent action trail) — the tenant `IEventRepository` for `AGENT.QUESTION.*` events; the leaning rehydration substrate keyed by `correlationId` (AC9).
+- **Epic 27** (prompt/convention store) — the orchestrator-fact resolver reads conventions; the policy resolver reuses the tenant→system→error discipline.
+- **`EscalateToSeniorActivity`** (`Tamma.Activities/Blocker/`) — the byte-for-byte model for `WaitForAgentQuestionActivity` (bookmark + notify + `OnResumeAsync` + `AutoBurn`).
+- **`WebhookSignalRegistry`** — the in-process `TaskCompletionSource` fast-signal model reused for the in-stream wait.
+- **`ElsaWorkflowService.SendSignalAsync`** — the resume mechanism the answer endpoint calls.
+
+**Consumers (downstream, not blockers):**
+
+- **32-9** (usage & cost metering) / **34-5** (markup) — consume the panel-answer token attribution (AC11.3 open decision: asking-agent budget vs separate "clarification" line).
+- **Streaming run tap** follow-on — adds the `question`/`answer` SSE frames over this story's in-stream seam.
+- **32-8** (outcome capture) — a run that paused for and resumed from a human answer is a distinguishable outcome.
+
+**External:** none new (reuses the existing notification/integration stack used by `EscalateToSeniorActivity`).
+
+## Testing Strategy
+
+1. **`request_input` round-trips as a tool-result (AC1).** A runner test: the model emits a `request_input` tool call → the executor returns an answer → the answer is appended as a tool-result message → the model resumes its own reasoning (one extra turn). `grep` confirms `request_input` is registered in the single `IToolExecutorRegistry` catalog (no fork).
+2. **Router `kind` map (AC2).** Fakes for orchestrator-facts/panel/human: `fact`→orchestrator, `judgment`→panel, `decision`(closed options+default)→policy-then-panel, `approval`→human; each routed exactly once.
+3. **Policy fail-loud-never-empty (AC3).** No policy resolves → `AGENT.QUESTION.ROUTE_DENIED`, never a silent auto-answer; tenant override beats system default; system default beats absence; single-user keyed by `UserId`, SaaS by `TenantId`.
+4. **Security upgrade — the load-bearing test (AC4).** `kind:"fact"`+`blocking:false` with `PendingAction=Merge` ⇒ `Answerer==human`; in-stream/assume paths never taken; the model's `kind` recorded but not honored for gating. Repeat for deploy/spend/schema.
+5. **`blocking:false` assumption vs ignore (AC5).** reversible action + `default_assumption` ⇒ `AGENT.QUESTION.ASSUMED`, no pause, assumption returned as tool result; irreversible action ⇒ `blocking:false` ignored, human-gated.
+6. **In-stream fast path + timeout (AC6).** panel answers within `inStreamAnswerTimeout` resolve in-stream (TCS-signaled); exceeding the timeout escalates per the configured default (human gate for `judgment`); the timeout is tenant-tunable.
+7. **Human gate envelope + bookmark (AC7).** human routing ⇒ `success:false`/`INPUT_REQUIRED` + the question + accrued usage; the workflow creates `agent-question-{correlationId}`; the step does NOT retry (distinct from `PROVIDER_ERROR`).
+8. **Answer endpoint resume + re-invoke (AC8/AC9).** `POST .../answer` authorizes the answerer (member; elevated where required; cross-tenant → 403/404), calls `SendSignalAsync`, resumes the bookmark, and the workflow re-invokes `/llm/call` with the answer re-primed as the `request_input` tool result; endpoint holds no per-run state across the gap; rehydration from action trail (32-6) by `correlationId`.
+9. **Audit (AC10).** exactly one `AGENT.QUESTION.RAISED` per ask; exactly one `AGENT.QUESTION.ANSWERED` per resolved question tagged with the correct `answerer ∈ {orchestrator, panel, human}` (+ `latencyMs`); `AGENT.QUESTION.ASSUMED` on the AC5 path; all tenant-scoped (never CP); question/answer key-free.
+10. **Credential safety (AC10/AC12).** the resolved API key never appears in any `AGENT.QUESTION.*` event, log line, `request_input` tool result, or the `INPUT_REQUIRED` response body.
+
+Docker-bound C# suites run via `sg docker -c "dotnet test apps/tamma-elsa/..."` (session docker group is stale; plain `dotnet build` needs no wrapper).
+
+## Estimated Effort
+
+7-9 days (the `request_input` tool + the router/policy/reversibility-classifier triad + the in-stream TCS wait + the durable `WaitForAgentQuestionActivity` + the answer endpoint + the stateless re-invoke/rehydration + the audit events — gated behind 32-5 and 32-7).
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Questions/RequestInputTool.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Questions/RaisedQuestion.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Questions/IQuestionRouter.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Questions/QuestionRouter.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Questions/QuestionRouting.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Questions/IQuestionRoutingPolicyResolver.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Questions/QuestionRoutingPolicyResolver.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Questions/IReversibilityClassifier.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Questions/ReversibilityClassifier.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Questions/OrchestratorFactResolver.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Questions/PanelAnswerResolver.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Questions/AgentQuestionEventTypes.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentQuestionEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/WaitForAgentQuestionActivity.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ManagedAgent.cs` | Modify (wire `IQuestionRouter`; emit `INPUT_REQUIRED`) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/LlmCallResponse.cs` | Modify (add `INPUT_REQUIRED` + key-free `question` payload) |
+| `apps/tamma-elsa/src/Tamma.Activities/LlmCall/InlineToolLoopRunner.cs` | Modify (execute `request_input`; end turn with `INPUT_REQUIRED` on human gate) |
+| `apps/tamma-elsa/src/Tamma.Activities/LlmCall/CallLlmInlineActivity.cs` | Modify (on `INPUT_REQUIRED` route to wait-activity, do not retry) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map answer endpoint; register router/policy/classifier/resolvers + `RequestInputTool` in the catalog) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/Questions/QuestionRouterTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/Questions/ReversibilitySecurityTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/AgentQuestionEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/AgentDispatch/WaitForAgentQuestionActivityTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/LlmCall/RequestInputToolTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, and decisions (esp. `feedback_resolution_no_empty_fallback`).
+3. Read the deep-dive §5 (interactive question-back) IN FULL + §6 item 5 + §7 open decisions, and the design of record §2 (the call-LLM endpoint).
+4. Reviewed `EscalateToSeniorActivity.cs` (the byte-for-byte model for the wait-activity), `WebhookSignalRegistry` (the TCS fast-signal model), `RunAgentPanelActivity`/`AggregatePanelActivity` (32-7, the panel answerer), `InlineToolLoopRunner`/`ManagedAgent` (32-5, where the tool + router are wired), and `IEventRepository` (32-6, the tenant-scoped trail).
+5. Confirmed 32-5 (endpoint) and 32-7 (panels) are landed before wiring them; code to the 32-6 trail interface.
+6. Planned the TDD approach; the **security re-derivation test (AC4) is written FIRST** — it is the load-bearing control.
+
+### Key Design Decisions
+
+- **A tool call, not a stop reason (deep-dive §5.1).** `request_input` is a tool so the answer returns as a tool-result message and the model resumes in-context — no bespoke conversation-shaping. Executed server-side inside `Tamma.Api`, so the step still never calls a provider.
+- **The server re-derives the gate; the model only RAISES (AC4, deep-dive §5.2).** `kind`/`blocking` are hints. The human-gate decision is the MAX of (model hint, server-owned reversibility). A model cannot tag a merge-approval as `fact` to dodge human gating. This is the single load-bearing security control of the story.
+- **Pause/resume boundary (deep-dive §5.3).** Fast answers (orchestrator-fact, panel) resolve **in-stream** within `inStreamAnswerTimeout` (TCS-signaled, SSE heartbeats). Slow (human) answers **end the turn** with `INPUT_REQUIRED` and cross engine→bookmark→signal→re-call. **The durable wait lives in the workflow (Elsa bookmark), never in an HTTP connection.** Cost: one extra LLM call to re-prime after the human gap — the only correct shape given a streaming request can't survive an hours-long wait.
+- **Stateless endpoint across the human gap (AC9, deep-dive §7 open #6).** No sticky server session; the conversation is rehydrated from the request or the action trail (32-6) keyed by `correlationId` (leaning action-trail). The only durable state is the Elsa bookmark.
+- **Audit from the API (AC10, deep-dive §5.3).** `AGENT.QUESTION.*` emitted via the tenant `IEventRepository` where the tenant store lives — never the control plane. Performance/question data is ALWAYS tenant-scoped (design ownership rule).
+- **No new control-plane table.** This story adds **no CP table** (the routing policy follows the prompt-override pattern — tenant- or user-keyed in the appropriate store; the action trail is tenant-schema-resident). So: no entry in `Program.cs`'s startup-reset DROP list and no `ControlPlaneDbContextModelTests` edit. If a future revision persists policy as a CP entity, both MUST be updated.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who is the principal of a question-back? | The sole user (keyed by `UserId`; `TenantId` may be null). | The tenant (keyed by `TenantId` from `X-Tenant-Id`). No per-user layer. |
+| Whose `QuestionRoutingPolicy` applies? | The sole user's policy → system default → ERROR (keyed by `UserId`). | The tenant's policy → system default → ERROR (keyed by `TenantId`; members can't edit it — `tenant_owner`/`tenant_admin` only). |
+| Who can answer a human-gated question? | The sole user. | A tenant member; elevated (`tenant_owner`/`tenant_admin`) where the pending action demands approval. **Never** a cross-tenant or platform-admin answer for another tenant's run. |
+| Who provides the `judgment` panel? | The user's enabled agents (32-16) run the panel locally. | The tenant's enabled agents (32-16), budget-clamped, SaaS-gated per member (32-7). |
+| Where do `AGENT.QUESTION.*` events land? | The user's (sole) tenant event store (`IEventRepository`). | The tenant's `t_<hex>` event store via the tenant-scoped `IEventRepository`; `TenantId` set. Never cross-tenant. |
+| Who owns the question/answer data? | The user. | The tenant — platform admin sees none of it (design ownership rule). |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`) — process-stable. | same |
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Adversarial/misclassifying model downgrades a merge-approval to `fact` to dodge the human gate (AC4) | **Critical** | The server **re-derives** the gate from server-owned reversibility; routing is the MAX of (model hint, blast radius); the model can only RAISE/escalate. Load-bearing adversarial test written FIRST. |
+| The endpoint holds conversation state across the human gap → a leaked/stale session breaks isolation (AC9) | High | Endpoint is **stateless across the gap**; rehydrate from the action trail (32-6) by `correlationId`; the only durable state is the Elsa bookmark. |
+| In-stream wait holds the request too long / blocks a worker (AC6) | High | `inStreamAnswerTimeout` (~90s, tenant-tunable) with SSE heartbeats; only fast (fact/panel) answers wait in-stream; on timeout escalate to the human gate (default for `judgment`). |
+| A question is lost (raised, never answered, never paused) → silent stall | High | Every `request_input` resolves to exactly one of {in-stream answer, assumed, human-gate}; `AGENT.QUESTION.RAISED` always pairs with an `ANSWERED`/`ASSUMED`/`ROUTE_DENIED`; tested invariant. |
+| `INPUT_REQUIRED` mistaken for a retryable provider failure → workflow retries instead of pausing (AC7) | High | `INPUT_REQUIRED` is a **distinct** `failureCode` (no `httpStatusCode`); the thin step routes to `WaitForAgentQuestionActivity`, never the provider-chain retry; explicit test. |
+| `blocking:false` used to waive a human gate (AC5) | High | A non-blocking hint **cannot** waive a gate: when the policy forbids assumption (irreversible / out-of-autonomy), `blocking:false` is ignored and the question is human-gated. |
+| Policy resolves to empty/plain → silent wrong routing (AC3) | Medium | tenant→system→**ERROR** (`feedback_resolution_no_empty_fallback`); no empty fallback; `AGENT.QUESTION.ROUTE_DENIED` on no-policy. |
+| Panel-answer cost double-counted or mis-attributed (AC11.3) | Medium | Open decision documented (asking-agent budget vs separate clarification line); until decided, attribute to the asking agent's budget and tag the panel sub-run distinctly so 32-9/34-5 can split later. |
+| Depends on 32-5 + 32-7 not yet landed | Medium | Code to their interfaces (`IInlineToolLoopRunner`, `RunAgentPanelActivity`); gate behind them; use fakes in tests until they land. |
+
+### Open Questions (from deep-dive §7 — documented, not pre-decided)
+
+1. **In-stream timeout → escalation for `judgment` (open #5):** promote to human bookmark vs proceed-on-assumption vs fail-the-turn. **Chosen default:** escalate to the human gate (configurable per tenant) — conservative vs the 70% autonomy target; revisit if it pauses too aggressively.
+2. **Conversation-state rehydration across the human gap (open #6):** workflow variable vs action-trail (32-6) keyed by `correlationId`. **Leaning:** action-trail (durable, already tenant-scoped, time-travel-debuggable).
+3. **`request_input` budgeting (open #7):** panel-answer tokens charged to the asking agent's budget vs a separate "clarification" line (affects 32-9 usage + 34-5 markup). **Until decided:** asking-agent budget, panel sub-run tagged distinctly.
+
+### Success Metrics
+
+- [ ] An agent that hits an ambiguity asks via `request_input` instead of guessing/stopping — measurable as `AGENT.QUESTION.RAISED` events on real runs.
+- [ ] **Zero** cases where a model's `kind`/`blocking` downgrades a merge/deploy/spend/schema below the human gate (adversarial test + invariant hold).
+- [ ] Every `request_input` resolves to exactly one terminal outcome (answered / assumed / human-gated / route-denied) — no silent stalls.
+- [ ] Human-gated runs durably suspend (Elsa bookmark) and resume on answer with the conversation re-primed — survives a process restart.
+- [ ] `grep` finds no API key in any `AGENT.QUESTION.*` event payload, log, or `INPUT_REQUIRED` response.
+
+## Related
+
+- Design of record: `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§2 the call-LLM endpoint; §5.3 what cannot be mediated)
+- Managed-LLM deep dive: `docs/superpowers/specs/2026-06-20-managed-llm-execution-deep-dive.md` (§5 interactive question-back — the source of record; §6 item 5; §7 open decisions 5/6/7)
+- Re-plan: `docs/superpowers/plans/2026-06-20-epic-32-37-replan.md`
+- Implementation plan: `docs/superpowers/plans/2026-06-21-32-20-interactive-question-back-plan.md`
+- Sibling stories: `story-32-5/` (call-LLM endpoint + `InlineToolLoopRunner`/`ManagedAgent`), `story-32-7/` (agent panels — the `judgment` answerer), `story-32-6/` (action trail — events + rehydration substrate), `story-32-9/` (usage metering — panel-answer cost)
+- Reused code: `apps/tamma-elsa/src/Tamma.Activities/Blocker/EscalateToSeniorActivity.cs` (the byte-for-byte model for `WaitForAgentQuestionActivity`), `WebhookSignalRegistry` (TCS fast-signal), `ElsaWorkflowService.SendSignalAsync` (resume)
+
+## Logging Requirements
+
+- **INFO**: question raised (`correlationId`, `questionId`, model-supplied `kind`/`blocking`/`confidence` — **never the prompt body verbatim if it may contain secrets**); routing decision (`answerer`, `routingReason`, server-derived `blastRadius`); question answered (`answerer`, `latencyMs`); human gate opened (`correlationId`, bookmark name); answer received (`answeredBy`, `correlationId`).
+- **DEBUG**: policy resolution chain (tenant→system), in-stream wait start/signal/timeout, panel sub-run start/aggregate, conversation rehydration source (request vs action-trail).
+- **WARN**: in-stream timeout → escalation; `blocking:false` ignored because the action is irreversible; route-denied (no policy).
+- **ERROR**: `AGENT.QUESTION.ROUTE_DENIED` (fail-loud, no policy); a raised question that reaches a terminal turn with no resolution (invariant violation); DCB append failure (the run still surfaces its result; the append failure is logged, not swallowed).
+- **Structured context**: `{ correlationId, questionId, kind(model), answerer, blastRadius, tenantId, role, action }` where applicable.
+- **Credential safety (LOAD-BEARING)**: NEVER log, return, or persist the resolved API key, `BaseUrl` auth, or raw provider headers. The `request_input` tool result, the `INPUT_REQUIRED` response body, every `AGENT.QUESTION.*` event payload, and the action trail are **key-free by contract**. The question/answer text is tenant data — log identifiers, not the verbatim body, where it may carry secrets.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-21 | 1.0.0   | Initial story creation — interactive question-back for the managed agent run: the first-class `request_input` tool (server-side, tool-result-resumes), `IQuestionRouter` + `QuestionRoutingPolicy` (fail-loud tenant→system→error) + the load-bearing server-side reversibility re-derivation (model can RAISE but not DOWNGRADE the human gate), the in-stream fast path (orchestrator-fact / 32-7 panel, TCS-signaled, `inStreamAnswerTimeout`), and the durable human gate (`WaitForAgentQuestionActivity` modeled on `EscalateToSeniorActivity` + `POST /api/v1/agents/questions/{correlationId}/answer` → `SendSignalAsync` resume → stateless re-invoke with the answer re-primed). `AGENT.QUESTION.RAISED/ANSWERED/ASSUMED/ROUTE_DENIED` audit from the API. Depends on 32-5 + 32-7. Open decisions (in-stream timeout escalation, rehydration substrate, request_input budgeting) documented, not pre-decided. | Claude |

--- a/docs/stories/epic-32/story-32-21/32-21-mcp-and-plugin-tool-sourcing.md
+++ b/docs/stories/epic-32/story-32-21/32-21-mcp-and-plugin-tool-sourcing.md
@@ -1,0 +1,422 @@
+# Story 32-21: MCP & Plugin Tool Sourcing (C#)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **tenant building agent-driven workflows on the managed `call-LLM` path**,
+I want the managed run's tool catalog to include **MCP-server tools and plugin tools** — sourced per-tenant from servers/plugins the tenant has enabled, with their credentials read from the Epic 29 cabinet — unioned with the built-in tool executors through the single `IToolExecutorRegistry.GetAllowed(allowlist)` seam, intersected with the agent's allowed-tool set, and every invocation routed through the same `ToolHookRegistry` pre/post sanitization hooks,
+So that **the managed run can use my MCP integrations** (filesystem, search, internal APIs, third-party MCP servers) and plugin tools **without the engine ever holding a key, running a tool, or opening an MCP socket** — all tool execution happens inside `Tamma.Api`'s `InlineToolLoopRunner`, server-side, key-free by contract, with the same enablement gate and sanitization that govern the rest of the agent model.
+
+## Priority
+
+P1 — This is the **tool-catalog build-out** for the managed execution layer (deep-dive §4 MCP+plugins; §6 item 2; §7 item 3). 32-5 ships the `InlineToolLoopRunner` with the **built-in catalog only** and explicitly scopes MCP/plugins out to this follow-on. Net-new for C#: MCP/plugins exist today only in the TypeScript `packages/mcp-client`; the C# `ProviderSession.cs:87` records *"MCP transport not yet ported."* This story closes that gap by making MCP-server tools and plugin tools first-class members of the API tool catalog the managed run consumes. It depends on 32-5 (the runner/endpoint that consumes the catalog) and ties to Epic 6 (intelligence/RAG tooling) and Epic 9 (the unified agent API surface).
+
+## Context
+
+### What exists today
+
+- **TypeScript only.** `packages/mcp-client` is a complete MCP client: a `ConnectionPool` + `HealthChecker`, transports for `stdio`/`sse`/`websocket` (`transports/{stdio,sse,websocket}.ts`), a `ToolRegistry`/`ResourceRegistry`/`PromptRegistry` (`registry.ts`), a `RateLimiterRegistry` + config/command/url validators (`security/`), capability + resource caches (`cache/`), an `audit.ts` trail, and request/response `interceptors.ts`. **None of it is reachable from the C# engine or API.**
+- **C# has no MCP.** `ProviderSession.cs:87` says *"MCP transport not yet ported."* The C# tool catalog is built-in-only: `IToolExecutorRegistry` (`Tamma.Activities/LlmCall/Tools/IToolExecutorRegistry.cs`) registers six local executors (`file_read`/`file_write`/`shell_execute`/`git_operations`/`run_tests`/`search_code`) and exposes `GetAllowed(string[]? allowlist)` — the single seam through which the tool loop selects tools.
+- **The managed run already routes every tool through sanitization.** 32-5's `InlineToolLoopRunner` (extracted verbatim from `CallLlmInlineActivity.AgenticToolLoop`) runs sanitize → multi-turn call → tool-call validation → tool execution → tool-output sanitization + `RedactSecrets` → compaction. Sanitization is via `IContentSanitizer` (`Tamma.Activities/Security/IContentSanitizer.cs`). **This story does not change that pipeline — it makes MCP/plugin tools flow through it identically.**
+- **The agent model already has the enablement + cabinet primitives.** 32-16 ships `ITenantAgentEnablementReader.IsEnabledForPrincipalAsync(agentId, principal, ct)` (the per-tenant catalog-membership gate, keyed by `AgentId`). Epic 29's cabinet exposes `IRuntimeSecretResolver` (`Tamma.Api/Services/Secrets/Stopgap/IRuntimeSecretResolver.cs`) for runtime secret reads. This story **mirrors the 32-16 PATTERN** for **MCP servers** as a per-tenant resource — but with its **own separate entity** (`McpServerEnablement`, keyed by `McpServerId`, in the tenant schema), NOT the agent enablement reader (different schema residency + a different target id). It reuses the cabinet's `IRuntimeSecretResolver` shape directly.
+
+### What this story does (deep-dive §4 MCP+plugins)
+
+This story sources **MCP server tools** and **plugin tools** into the API tool catalog used by the managed run, **inside `Tamma.Api`**, where the key lives and the loop runs:
+
+> **The runner's tool catalog = built-in executors ∪ MCP server tools ∪ plugin tools**, unioned through **one** `IToolExecutorRegistry.GetAllowed(allowlist)`, **intersected** with the agent's allowed-tool set (32-2/32-18), with **every** invocation routed through the `ToolHookRegistry` pre/post sanitization hooks + `IContentSanitizer`/`RedactSecrets`.
+
+Concretely:
+
+- A **composite tool source** is assembled per managed run: built-in executors (today's registry), plus MCP-server tools discovered from the tenant's enabled MCP servers, plus plugin tools from the tenant's enabled plugins. They are exposed to the runner as `IToolExecutor` instances behind the **unchanged** `IToolExecutorRegistry` interface — the runner sees one catalog, calls `GetAllowed(allowlist)` once, and is **oblivious** to a tool's origin.
+- **MCP servers are a per-tenant resource.** Per-tenant MCP-server config (`name`, transport, command/url, declared tool prefixes) lives in a tenant-scoped store; **credentials live in the Epic 29 cabinet** (read via `IRuntimeSecretResolver`, never in config), and a server is usable in a run only if it is **enabled** for the principal — mirroring the 32-16 enablement **pattern** but with its **own separate `McpServerEnablement` entity keyed by `McpServerId`** (not the agent enablement reader): the tenant enables which MCP servers exist for it; member users just use what's enabled.
+- **Plugin tools** are sourced from the tenant's enabled plugins through the same composite source and the same hook/sanitization path.
+- **Every invocation** — built-in, MCP, or plugin — is routed through the `ToolHookRegistry` pre/post hooks and `IContentSanitizer`/`RedactSecrets`, so MCP/plugin tool outputs are sanitized and secret-redacted exactly like built-in tool outputs. No tool bypasses the hooks.
+- **The allowlist + agent-allowed intersection is preserved.** The union catalog is filtered by `GetAllowed(allowlist)` (the engine's per-call allowlist) **and** intersected with the resolved agent's allowed-tool set (32-2/32-18) — an MCP/plugin tool the agent is not allowed to use is never offered to the model, even if the server is enabled.
+
+### The strategy decision (presented as a first-class design choice — deep-dive §7.3)
+
+Deep-dive §7.3 leaves the MCP transport strategy **open**: *port `mcp-client` to C# vs host the TS client as an API-managed sidecar vs a .NET MCP SDK.* This spec resolves it (see **Technical Design → Strategy decision**) with a recommendation and the trade-offs, because the choice drives the deployment surface, the dependency footprint, and the SaaS isolation story.
+
+### Server-side only (the locked rule 1)
+
+The engine holds no key, runs no tool, and **opens no MCP/provider socket**. MCP connections, plugin loading, and all tool execution happen in `Tamma.Api`, inside the managed run. **Local** tools (`file_read`/`shell_execute`/`git_operations`) execute against the **tenant's sandbox** from inside the managed run — exactly as the built-in executors do today (this story does not change their sandboxing; it only widens the catalog around them).
+
+### Explicitly out of scope (referenced, not implemented here)
+
+- **The endpoint / runner / resilience relocation** — 32-5. This story plugs a wider catalog into the runner 32-5 ships; it does not touch the endpoint, the credential resolver, metering, or the thin-client cutover.
+- **Per-tenant MCP-server credentials at rest** beyond reading them via Epic 29's `IRuntimeSecretResolver` — the cabinet's storage/rotation is Epic 29; this story is a **consumer**.
+- **MCP resources / prompts (the non-tool MCP capabilities).** The TS client exposes `ResourceRegistry`/`PromptRegistry`; this story sources **tools** only. MCP resources (as a RAG source) are an Epic 6 follow-on; MCP prompts are out of scope (prompts come from Epic 27).
+- **Streaming MCP tool progress to the dashboard** — that rides the "Streaming run tap" follow-on (deep-dive §6.4); this story emits buffered tool results into the buffered run.
+- **Prompt/response cache** — the capability/resource caches here are MCP-discovery caches, not the LLM prompt/response cache ("Prompt + response cache" follow-on, deep-dive §6.3).
+
+## Acceptance Criteria
+
+1. **One catalog, three sources, one seam.** The managed run's tool catalog is **built-in executors ∪ enabled-MCP-server tools ∪ enabled-plugin tools**, assembled into a single set of `IToolExecutor` instances exposed behind the **unchanged** `IToolExecutorRegistry` interface. The runner calls `GetAllowed(allowlist)` exactly **once** and is agnostic to a tool's origin. No second registry interface, no second `GetAllowed` path.
+
+2. **MCP-server tools are sourced per-tenant, enabled-gated.** An `IMcpToolSource` resolves the tenant's **enabled** MCP servers (via the per-tenant MCP-server store + this story's own `IMcpServerEnablementReader.IsEnabledForPrincipalAsync(mcpServerId, principal, ct)` gate — keyed by `McpServerId`, mirroring the 32-16 PATTERN as a SEPARATE entity, NOT the agent reader), connects over the chosen transport, discovers each server's tools, and wraps each as an `IToolExecutor` (`mcp__<server>__<tool>` naming, mirroring the TS client convention). A server that is **not enabled** for the principal contributes **zero** tools to the catalog — even if configured. Member users cannot enable/disable MCP servers (tenant_owner/tenant_admin only; member → 403 on writes, read allowed).
+
+3. **MCP credentials come from the Epic 29 cabinet, never from config.** Each MCP-server config carries a **secret reference**, not a secret. At connect time the source reads the credential via `IRuntimeSecretResolver` (Epic 29) and injects it into the transport (header/env/arg per transport). The credential is **request-scoped, never logged, never returned, never persisted** in a tool result. Config rows store references only; a config with a literal secret is rejected at write time.
+
+4. **Plugin tools are sourced through the same composite source.** An `IPluginToolSource` resolves the tenant's enabled plugins and wraps each plugin tool as an `IToolExecutor`, joining the same union and the same enablement/hook/sanitization path as MCP tools. Plugin enablement follows the per-tenant model (32-16 shape).
+
+5. **Every invocation routes through the hooks + sanitizer (no bypass).** Built-in, MCP, and plugin tool invocations all pass through the `ToolHookRegistry` pre-hook (argument sanitization/validation) and post-hook (output sanitization), and tool output is run through `IContentSanitizer` + `RedactSecrets` before re-entering the model context — **identical** to the built-in path. A test proves an MCP tool's output is sanitized and secret-redacted exactly like a built-in tool's output. No code path executes a tool outside the hook pipeline.
+
+6. **Allowlist ∩ agent-allowed is enforced.** The union catalog is filtered by the engine's per-call `allowlist` via `GetAllowed(allowlist)` **and** intersected with the resolved agent's allowed-tool set (32-2/32-18). An MCP/plugin tool the agent is not allowed to use is **never** advertised to the model nor executable — even if its server/plugin is enabled and the allowlist permits it. Fail-closed: an unknown/un-enabled tool name resolves to "no executor," not to a silent built-in.
+
+7. **The engine holds no MCP socket or key (rule 1).** All MCP connections, plugin loading, credential reads, and tool execution happen in `Tamma.Api` inside the managed run. `ElsaServer` opens **no** MCP socket and reads **no** MCP credential. A grep over `Tamma.ElsaServer` finds zero MCP transport/connection types and zero `IRuntimeSecretResolver` MCP reads. Local tools (`file_read`/`shell_execute`/`git_operations`) still execute against the **tenant's sandbox** from inside the managed run.
+
+8. **Connection lifecycle is bounded and fail-soft per server.** MCP server connections are pooled/health-checked (mirroring the TS `ConnectionPool`/`HealthChecker`), rate-limited per server, and **connect failures are isolated**: an unreachable or failing MCP server contributes **zero** tools and is logged at WARN with `{ server, tenantId, correlationId }` — it does **not** fail the managed run (the run proceeds with the remaining catalog). A per-server connect/discovery timeout is enforced. Tool-discovery results are cached per `(tenantId, server, configHash)` with a short TTL (the capability cache), invalidated on config/enablement change.
+
+9. **Per-tenant config CRUD + events, enablement-gated.** MCP-server config is created/updated/deleted via tenant-scoped admin endpoints (tenant_owner/tenant_admin; member → 403), and enable/disable goes through this story's **own `McpServerEnablement` entity** (keyed by `McpServerId`; same XOR/unique-index discipline as 32-16's `TenantAgentEnablement`, but a SEPARATE entity — different schema residency + target id). DCB events `MCP.SERVER.REGISTERED` / `MCP.SERVER.ENABLED` / `MCP.SERVER.DISABLED` / `MCP.SERVER.CONNECT.FAILED` and `AGENT.TOOL.SOURCED` (per managed run: counts of built-in/MCP/plugin tools offered) are emitted from `Tamma.Api` via the tenant `IEventRepository`, tagged `{ tenantId, server?, correlationId }`. Tool **invocations** continue to be audited by 32-5/32-6's existing `toolCalls` trail — this story does not duplicate per-invocation events.
+
+10. **Strategy decision is recorded and implemented.** The spec records the chosen MCP transport strategy (port to C# vs TS sidecar vs .NET MCP SDK) with justification and trade-offs (Technical Design → Strategy decision), and the implementation follows the recommended path. The chosen transports cover at least `stdio` and `http`/`sse` (the two the managed API process can host); `websocket` is optional/deferred if the SDK/path doesn't cover it.
+
+11. **No new control-plane DROP-list / model-test churn unless a CP table is added.** If the per-tenant MCP-server config + enablement are **tenant-schema** resident (the default — performance/config data is tenant-scoped), they do **not** go in the `Program.cs` startup-reset DROP list and require **no** `ControlPlaneDbContextModelTests` edit. If any new table is **control-plane** resident, it MUST be appended to both (called out in Dev Notes; the default is tenant-schema, mirroring the agent config/data ownership rule).
+
+12. **Tests cover sourcing, gating, sanitization, isolation, and fail-soft.** Union catalog (built-in ∪ MCP ∪ plugin) behind one `GetAllowed`; enablement gate (un-enabled server → zero tools); cabinet credential read (reference-only config; secret never in config/log/result); hook+sanitizer applied to MCP output identically to built-in; allowlist ∩ agent-allowed intersection; member-403 on MCP-config writes; connect-failure isolation (run proceeds, WARN logged, other tools intact); discovery-cache hit/invalidation; cross-tenant isolation (tenant A's MCP server never visible to tenant B); the strategy-path's transport adapters; and a grep proving zero MCP socket/credential reads in `ElsaServer`.
+
+## Technical Design
+
+### Where it lives
+
+```
+apps/tamma-elsa/src/Tamma.Api/Services/Agents/Tools/
+  ICompositeToolCatalog.cs          # NEW — assembles built-in ∪ MCP ∪ plugin into one IToolExecutorRegistry
+  CompositeToolCatalog.cs           # NEW — impl; calls the three sources, dedupes, exposes GetAllowed
+  IMcpToolSource.cs                 # NEW — resolves enabled MCP servers -> IToolExecutor[] (tenant-scoped)
+  McpToolSource.cs                  # NEW — connect/discover/wrap; cabinet creds; pool/health/rate-limit; cache
+  IPluginToolSource.cs              # NEW — resolves enabled plugins -> IToolExecutor[]
+  PluginToolSource.cs               # NEW — wrap plugin tools as IToolExecutor
+  McpToolExecutor.cs                # NEW — IToolExecutor wrapping one MCP tool (invoke over transport)
+  PluginToolExecutor.cs            # NEW — IToolExecutor wrapping one plugin tool
+
+apps/tamma-elsa/src/Tamma.Api/Services/Mcp/
+  IMcpConnectionPool.cs / McpConnectionPool.cs   # NEW — pooled connections + HealthChecker (mirrors TS pool)
+  Transports/IMcpTransport.cs                    # NEW — transport abstraction
+  Transports/StdioMcpTransport.cs                # NEW — stdio (local server process)
+  Transports/HttpSseMcpTransport.cs              # NEW — http/sse (remote server)
+  McpServerConfig.cs                             # NEW — per-tenant config record (secret REFERENCE, not secret)
+  IMcpToolDiscoveryCache.cs / McpToolDiscoveryCache.cs  # NEW — (tenantId, server, configHash) -> tools, short TTL
+  McpServerRateLimiter.cs                        # NEW — per-server rate limiter (mirrors TS RateLimiterRegistry)
+
+apps/tamma-elsa/src/Tamma.Api/Services/Mcp/
+  IMcpServerEnablementReader.cs                  # NEW — IsEnabledForPrincipalAsync(mcpServerId, principal, ct); mirrors the 32-16 PATTERN, SEPARATE entity
+  McpServerEnablementService.cs                  # NEW — impl + enable/disable over McpServerEnablement (keyed by McpServerId)
+
+apps/tamma-elsa/src/Tamma.Data/Entities/
+  McpServer.cs                                   # NEW — per-tenant MCP-server config entity (tenant-schema)
+  McpServerEnablement.cs                         # NEW — per-tenant enablement of a server, keyed by McpServerId (OWN entity, NOT TenantAgentEnablement)
+
+apps/tamma-elsa/src/Tamma.Api/Endpoints/
+  McpServerEndpoints.cs                          # NEW — tenant CRUD + enable/disable (owner/admin; member 403)
+
+apps/tamma-elsa/src/Tamma.Api/Program.cs
+  Program.cs                                     # MODIFY — register ICompositeToolCatalog as the runner's
+                                                 #          IToolExecutorRegistry in the API; map MCP endpoints
+
+apps/tamma-elsa/src/Tamma.Activities/LlmCall/Tools/IToolExecutorRegistry.cs
+  IToolExecutorRegistry.cs                       # UNCHANGED — the single seam the runner already uses
+```
+
+> **No second seam.** `ICompositeToolCatalog` **is an `IToolExecutorRegistry`** — it implements the existing interface so the runner's `GetAllowed(allowlist)` call site (`InlineToolLoopRunner`, 32-5) is unchanged. The composite is registered **in the API** as the `IToolExecutorRegistry` the managed run resolves; the engine keeps no registry (it runs no tools — 32-5 deleted the engine-side tool registrations).
+
+### The composite catalog (AC1, AC6)
+
+```csharp
+// Tamma.Api/Services/Agents/Tools/ICompositeToolCatalog.cs
+public interface ICompositeToolCatalog : IToolExecutorRegistry { }
+
+// CompositeToolCatalog.cs — assembled per managed run (scoped), then handed to the runner as IToolExecutorRegistry.
+public sealed class CompositeToolCatalog : ICompositeToolCatalog
+{
+    // built-in registry (the existing six executors) + the two dynamic sources
+    public CompositeToolCatalog(
+        IToolExecutorRegistry builtIn,                 // today's ToolExecutorRegistry
+        IMcpToolSource mcp,
+        IPluginToolSource plugins,
+        ToolCatalogScope scope);                       // { TenantId, Principal, AgentAllowedTools, CorrelationId }
+
+    // GetAllowed = (builtIn ∪ enabled-MCP ∪ enabled-plugin) filtered by allowlist
+    //              AND intersected with scope.AgentAllowedTools (32-2/32-18).
+    public IReadOnlyList<IToolExecutor> GetAllowed(string[]? allowlist);
+    public IToolExecutor? GetExecutor(string toolName);     // null when not enabled / not allowed (fail-closed)
+    // ...IsAllowed / GetAll mirror the union
+}
+```
+
+The union is built once per run; MCP/plugin tools are discovered through their sources (with the discovery cache). `GetAllowed` applies **both** the engine allowlist **and** the agent-allowed intersection, so the model is only ever offered tools that are (enabled) ∧ (allowlisted) ∧ (agent-allowed). Unknown/un-enabled names → `GetExecutor` returns `null` (no silent fallback — `feedback_resolution_no_empty_fallback`).
+
+### MCP tool source (AC2, AC3, AC8)
+
+```csharp
+public interface IMcpToolSource
+{
+    // Enabled servers for this principal -> their discovered tools as IToolExecutor[].
+    Task<IReadOnlyList<IToolExecutor>> ResolveAsync(ToolCatalogScope scope, CancellationToken ct);
+}
+
+// McpToolSource flow (per scope):
+//  1. servers = store.ListForTenant(scope.TenantId)
+//  2. enabled = servers.WhereAsync(s => mcpEnablement.IsEnabledForPrincipalAsync(s.Id, scope.Principal, ct))  // OWN reader, keyed by McpServerId
+//  3. for each enabled server (fail-soft, isolated):
+//       cred  = await secrets.GetAsync(server.CredentialRef, ct)        // Epic 29 cabinet — reference -> secret
+//       conn  = await pool.ConnectAsync(server, cred, timeout, ct)      // stdio/http-sse; rate-limited
+//       tools = cache.GetOrAdd((tenantId, server, configHash),
+//                   () => conn.ListToolsAsync(ct))                      // capability cache, short TTL
+//       yield tools.Select(t => new McpToolExecutor(server, t, conn))   // name: mcp__<server>__<tool>
+//     catch connect/discovery error => emit MCP.SERVER.CONNECT.FAILED; log WARN; contribute 0 tools (run continues)
+```
+
+`McpToolExecutor.ExecuteAsync(args, ct)` invokes the MCP tool over the pooled transport and returns the result; the **runner** (not this executor) then applies the `ToolHookRegistry` post-hook + `IContentSanitizer` + `RedactSecrets` — identical to the built-in path (AC5). The credential is held only for the connect and never travels into the tool result.
+
+### MCP server config — secret reference, not secret (AC3)
+
+```csharp
+// Tamma.Data/Entities/McpServer.cs — tenant-schema (per-tenant); performance/config data is tenant-scoped.
+public sealed class McpServer
+{
+    public Guid Id { get; init; }
+    public Guid? TenantId { get; init; }          // set in SaaS; NULL in single-user
+    public Guid? UserId { get; init; }            // set in single-user; NULL in SaaS  (principal XOR)
+    public required string Name { get; init; }    // catalog name; tool prefix mcp__<Name>__*
+    public required McpTransportKind Transport { get; init; }   // Stdio | HttpSse
+    public string? Command { get; init; }         // stdio: command + args (no secret)
+    public string? Url { get; init; }             // http/sse: endpoint (no secret)
+    public required string CredentialRef { get; init; }   // Epic 29 cabinet REFERENCE — NEVER a literal secret
+    public string[]? ToolAllowPrefixes { get; init; }     // optional server-side narrowing
+    public DateTimeOffset CreatedAt { get; init; }
+    // EF: principal-XOR CHECK + UNIQUE NULLS NOT DISTINCT (TenantId, UserId, Name), mirroring AgentRoleSelection.
+}
+```
+
+Write-time validation rejects any config whose `Command`/`Url`/args embed a literal secret pattern; only `CredentialRef` carries auth, resolved at connect via `IRuntimeSecretResolver`.
+
+### MCP-server enablement — OWN entity keyed by `McpServerId` (NOT the agent reader)
+
+MCP-server enablement **mirrors the 32-16 PATTERN** (per-tenant catalog membership, principal-XOR, `UNIQUE NULLS NOT DISTINCT`, member→403 on writes) but is a **SEPARATE entity** — different schema residency (tenant-schema vs 32-16's CP) and a different target id (`McpServerId` vs `AgentId`). It does **not** reuse `TenantAgentEnablement` or `ITenantAgentEnablementReader`.
+
+```csharp
+// Tamma.Data/Entities/McpServerEnablement.cs — tenant-schema; OWN entity (not TenantAgentEnablement).
+public sealed class McpServerEnablement
+{
+    public Guid Id { get; init; }
+    public Guid? TenantId { get; init; }          // set in SaaS; NULL in single-user  (principal XOR)
+    public Guid? UserId { get; init; }            // set in single-user; NULL in SaaS
+    public required Guid McpServerId { get; init; }   // the enabled target — an McpServer.Id (NOT an AgentId)
+    public bool Enabled { get; init; }
+    public DateTimeOffset CreatedAt { get; init; }
+    public DateTimeOffset UpdatedAt { get; init; }
+    // EF: principal-XOR CHECK (ck_mcp_server_enablements_principal_xor)
+    //     + UNIQUE NULLS NOT DISTINCT (TenantId, UserId, McpServerId), mirroring 32-16's TenantAgentEnablement discipline.
+}
+
+// Tamma.Api/Services/Mcp/IMcpServerEnablementReader.cs — OWN reader (NOT ITenantAgentEnablementReader).
+public interface IMcpServerEnablementReader
+{
+    /// <summary>True iff the MCP server is enabled for the principal. Keyed by McpServerId.
+    /// Same XOR/index discipline as 32-16's TenantAgentEnablement, SEPARATE entity.</summary>
+    Task<bool> IsEnabledForPrincipalAsync(Guid mcpServerId, Principal principal, CancellationToken ct);
+}
+```
+
+`McpToolSource` injects `IMcpServerEnablementReader` (its own reader), NOT `ITenantAgentEnablementReader`; there is no `AgentId`/`AgentSurfaceId` on an MCP server.
+
+### Strategy decision (deep-dive §7.3) — **RECOMMENDED: .NET MCP SDK (`ModelContextProtocol`), TS `mcp-client` as the behavioural reference**
+
+Three options were weighed; the recommendation is **option (c) with a thin in-house adapter layer** that preserves the TS client's hardening:
+
+| Option | What it is | Pros | Cons | Verdict |
+|---|---|---|---|---|
+| **(a) Port `mcp-client` to C#** | Re-implement the TS client (pool, transports, registry, cache, rate-limiter, validators) in C#. | Full control; verbatim parity with the TS hardening (validators, rate-limiter, audit); no new external dep; runs fully in-process in `Tamma.Api` (no extra socket/process). | High effort (largest LOC); we'd re-own protocol-level transport correctness and track MCP spec churn ourselves. | Fallback if SDK is immature. |
+| **(b) Host the TS client as an API-managed sidecar** | Run `mcp-client` as a child process/sidecar the API drives over IPC. | Reuse the *exact* shipped TS client unchanged. | Adds a process + IPC hop **inside** the trust boundary; two runtimes to deploy/observe; key would cross the IPC boundary (more places a secret lives); fights SaaS isolation + the "engine holds no socket, API owns one process" model. | **Rejected** — adds surface for no security benefit. |
+| **(c) .NET MCP SDK** | Use the official `ModelContextProtocol` .NET SDK for protocol/transport; wrap its client behind `IMcpTransport`/`IMcpConnectionPool`; **layer our own** validators, rate-limiter, capability cache, and audit (the TS client's value-adds) on top. | Lowest protocol-maintenance burden; idiomatic C# in-process in `Tamma.Api`; no extra runtime/process; we keep ownership of the security layer (validators/rate-limit/sanitization-hooks) where it must live. | New external dependency; SDK surface may lag the spec — mitigated by the adapter seam (`IMcpTransport`) so we can swap to (a) per-transport without touching the catalog. | **RECOMMENDED.** |
+
+> **Recommendation rationale:** the protocol transport is commodity and churny — owning it (option a) is cost with no differentiation. The differentiated security work (per-tenant enablement, cabinet creds, allowlist ∩ agent-allowed, the sanitization hooks, rate-limiting, audit) is **ours regardless of transport** and we keep it in `Tamma.Api`. The sidecar (option b) is rejected because it multiplies where a tenant secret lives and breaks the one-process API model. The `IMcpTransport` seam keeps the strategy reversible: if the .NET SDK proves insufficient for a transport, that single transport can fall back to a hand-rolled port (option a) without disturbing the catalog or the security layer. The TS `mcp-client` (`security/validator.ts`, `security/rate-limiter.ts`, `audit.ts`, `cache/`) is the **behavioural reference** for the layers we re-implement in C#.
+
+> **Always research latest docs before pinning the SDK** — confirm the current `ModelContextProtocol` .NET package name, version, and transport coverage (stdio/http-sse/websocket) via WebSearch/Context7 before adding the dependency; do not assume API shape.
+
+### Wiring (Program.cs, API)
+
+```csharp
+// Tamma.Api/Program.cs — the managed run resolves the composite as its IToolExecutorRegistry.
+builder.Services.AddSingleton<IToolExecutorRegistry, ToolExecutorRegistry>();   // built-in (unchanged)
+builder.Services.AddScoped<IMcpToolSource, McpToolSource>();
+builder.Services.AddScoped<IPluginToolSource, PluginToolSource>();
+builder.Services.AddScoped<ICompositeToolCatalog, CompositeToolCatalog>();      // wraps built-in ∪ MCP ∪ plugin
+// InlineToolLoopRunner (32-5) is constructed with ICompositeToolCatalog as its IToolExecutorRegistry.
+builder.Services.AddSingleton<IMcpConnectionPool, McpConnectionPool>();
+builder.Services.AddSingleton<IMcpToolDiscoveryCache, McpToolDiscoveryCache>();
+app.MapMcpServerEndpoints();   // tenant CRUD + enable/disable (owner/admin; member 403)
+```
+
+The engine registers **no** tool registry and **no** MCP type (32-5 already removed the engine-side tool/sanitizer registrations).
+
+## Dependencies
+
+**Internal (hard prerequisites):**
+
+- **32-5** (Call-LLM endpoint + managed execution) — ships the `InlineToolLoopRunner` and the `IToolExecutorRegistry` seam this story plugs the wider catalog into; the runner/endpoint **consumes** this catalog. (Sequence F.) **This story does not exist without 32-5.**
+- **32-16** (Per-tenant agent/persona enablement) — the per-tenant catalog-membership **PATTERN** (XOR/unique-index discipline, member→403 RBAC) this story **mirrors** for MCP servers via its **own separate `McpServerEnablement` entity + `IMcpServerEnablementReader`** keyed by `McpServerId`. It does NOT consume `ITenantAgentEnablementReader` (different schema residency + target id).
+- **32-2 / 32-18** (agent registry + enablement-aware resolution) — supplies the resolved agent's **allowed-tool set** that the union catalog is intersected with (AC6).
+- **Epic 29** (cabinet) — `IRuntimeSecretResolver` reads MCP-server credentials from the cabinet by reference (AC3). This story is a **consumer**; storage/rotation is Epic 29.
+- **Epic 27** (prompt store) — unchanged; referenced only to note MCP **prompts** are out of scope (prompts come from Epic 27, not MCP).
+
+**Ties / collaborators (not hard blockers, confirm per Epic 9):**
+
+- **Epic 6** (intelligence/RAG) — MCP **resources** as a future RAG source, and Epic 6 tools join the same catalog via the plugin/built-in path; the boundary is "tools here, resources/RAG in Epic 6."
+- **Epic 9** (unified agent API) — the engine↔API callback + endpoint conventions (`TammaApiClient`, `TammaEngineAuthHandler`) the MCP-config endpoints follow; confirm the C# surface per story.
+
+**Consumers (downstream, not blockers):**
+
+- **32-6** (action trail) — consumes the per-run `toolCalls` (now spanning MCP/plugin tools) + `AGENT.TOOL.SOURCED`.
+- **Streaming run tap** follow-on (deep-dive §6.4) — streams MCP/plugin tool progress once the live sink lands.
+
+**External:** the chosen **.NET MCP SDK** (`ModelContextProtocol`, per the strategy decision) — version/transport coverage confirmed via WebSearch/Context7 before pinning.
+
+## Testing Strategy
+
+1. **Union catalog, one seam (AC1).** A `CompositeToolCatalog` over fakes of built-in/MCP/plugin sources returns built-in ∪ MCP ∪ plugin through a single `GetAllowed(allowlist)`; the runner's call site is unchanged (it sees only `IToolExecutorRegistry`).
+2. **Enablement gate (AC2).** An MCP server **not enabled** for the principal (per the OWN `IMcpServerEnablementReader.IsEnabledForPrincipalAsync(mcpServerId, principal, ct)`, keyed by `McpServerId`) contributes **zero** tools even when configured; enabling it (an `McpServerEnablement` row) makes its tools appear. Member-role write → 403; member read allowed. Assert the gate uses the OWN reader, not `ITenantAgentEnablementReader`.
+3. **Cabinet credential read (AC3).** Config carries a `CredentialRef`; the source reads the secret via a fake `IRuntimeSecretResolver` at connect; a config with a literal secret in `Command`/`Url`/args is rejected at write. Assert the secret never appears in config rows, logs, the tool result, or any event payload.
+4. **Hook + sanitizer parity (AC5).** An MCP tool returning content with a secret and an injection pattern is sanitized + `RedactSecrets`'d **identically** to a built-in tool returning the same content (golden-equality test); no tool path bypasses `ToolHookRegistry`.
+5. **Allowlist ∩ agent-allowed (AC6).** A tool that is enabled + allowlisted but **not** in the agent's allowed set is neither advertised nor executable; an un-enabled/unknown name → `GetExecutor` returns `null` (no silent built-in).
+6. **Engine holds nothing (AC7).** Grep `Tamma.ElsaServer` → zero MCP transport/connection types and zero MCP `IRuntimeSecretResolver` reads; the composite + MCP types are registered only in `Tamma.Api`.
+7. **Fail-soft isolation (AC8).** One MCP server times out / refuses connection → it contributes zero tools, `MCP.SERVER.CONNECT.FAILED` is emitted, WARN is logged, **the run proceeds** with the remaining catalog; the other servers' tools are intact.
+8. **Discovery cache (AC8).** Repeated resolution within TTL hits the cache (no re-`ListTools`); a config/enablement change invalidates `(tenantId, server, configHash)`.
+9. **Cross-tenant isolation.** Tenant A's MCP server is never visible/usable in tenant B's run (config + enablement keyed by principal; tenant-schema resident).
+10. **Transports (AC10).** `StdioMcpTransport` and `HttpSseMcpTransport` adapters connect + list + invoke against a fake MCP server; the `IMcpTransport` seam is honoured (strategy-reversible).
+11. **Plugin source (AC4).** Enabled-plugin tools join the union and the same hook/sanitization/intersection path.
+12. **Events (AC9).** `MCP.SERVER.REGISTERED/ENABLED/DISABLED/CONNECT.FAILED` + `AGENT.TOOL.SOURCED` emitted from `Tamma.Api` via the tenant `IEventRepository`, key-free, correctly tagged.
+
+Docker-bound C# suites run via `sg docker -c "dotnet test apps/tamma-elsa/..."` (session docker group is stale; plain `dotnet build` needs no wrapper).
+
+## Estimated Effort
+
+8-10 days (the MCP transport layer + connection pool/health/rate-limit/cache + the per-tenant config/enablement/CRUD + the cabinet-credential wiring + the composite catalog + the plugin source + the .NET MCP SDK adapter + tests — net-new for C#).
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Tools/ICompositeToolCatalog.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Tools/CompositeToolCatalog.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Tools/IMcpToolSource.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Tools/McpToolSource.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Tools/IPluginToolSource.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Tools/PluginToolSource.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Tools/McpToolExecutor.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Tools/PluginToolExecutor.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Mcp/IMcpConnectionPool.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Mcp/McpConnectionPool.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Mcp/Transports/IMcpTransport.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Mcp/Transports/StdioMcpTransport.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Mcp/Transports/HttpSseMcpTransport.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Mcp/McpServerConfig.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Mcp/IMcpToolDiscoveryCache.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Mcp/McpToolDiscoveryCache.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Mcp/McpServerRateLimiter.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/McpServer.cs` | Create (tenant-schema) |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/McpServerEnablement.cs` | Create (OWN entity keyed by `McpServerId`; mirrors the 32-16 PATTERN, NOT `TenantAgentEnablement`) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Mcp/IMcpServerEnablementReader.cs` | Create (`IsEnabledForPrincipalAsync(mcpServerId, principal, ct)`) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Mcp/McpServerEnablementService.cs` | Create (enable/disable + reader over `McpServerEnablement`) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/McpServerEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (register composite + sources + pool + cache; map MCP endpoints) |
+| `apps/tamma-elsa/src/Tamma.Activities/LlmCall/Tools/IToolExecutorRegistry.cs` | Unchanged (the single seam) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/Tools/CompositeToolCatalogTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/Tools/McpToolSourceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Mcp/McpTransportTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/McpServerEndpointsTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, and decisions (esp. `feedback_resolution_no_empty_fallback`).
+3. Read 32-5 IN FULL (the runner + `IToolExecutorRegistry` seam you plug into), the deep-dive §4 (tools/MCP/plugins) and §7.3 (the strategy decision), and 32-16 (the enablement PATTERN you mirror — XOR/index/RBAC — in your OWN `McpServerEnablement` entity keyed by `McpServerId`, NOT the agent reader).
+4. Reviewed `Tamma.Activities/LlmCall/Tools/IToolExecutorRegistry.cs` (the seam — DON'T change it), `Tamma.Activities/LlmCall/Tools/ToolExecutorRegistry.cs` (the built-in source you union with), `IContentSanitizer` + `RedactSecrets` (the post-hook path every tool must traverse), `IRuntimeSecretResolver` (Epic 29 cabinet read), and the TS `packages/mcp-client` (`client.ts`, `transports/*`, `security/{validator,rate-limiter}.ts`, `cache/*`, `audit.ts`) as the behavioural reference for the layers you re-implement in C#.
+5. **Researched the current `ModelContextProtocol` .NET SDK** (name, version, transport coverage) via WebSearch/Context7 before pinning the dependency — do not assume the API shape.
+6. Confirmed 32-5 / 32-16 / 32-2-18 / Epic-29 contracts are landed before wiring them; use fakes in tests until then.
+
+### Key Design Decisions
+
+- **One catalog, one seam (AC1).** `ICompositeToolCatalog : IToolExecutorRegistry`. The runner is oblivious to a tool's origin; there is no second `GetAllowed` path. This is the whole point — MCP/plugin tools are first-class members of the existing catalog, not a parallel system.
+- **MCP servers are a per-tenant resource, enablement-gated by an OWN entity (mirrors the 32-16 PATTERN).** Enablement is this story's own `McpServerEnablement` entity + `IMcpServerEnablementReader` keyed by `McpServerId` — the SAME XOR/index/RBAC discipline as 32-16's `TenantAgentEnablement`, but a SEPARATE entity (tenant-schema, not CP; targets `McpServerId`, not `AgentId`). The tenant enables which MCP servers exist for it; members use what's enabled (member → 403 on writes). An un-enabled server contributes zero tools, fail-closed.
+- **Credentials by reference, from the cabinet (AC3).** Config rows carry a `CredentialRef`, never a secret. The secret is read at connect via `IRuntimeSecretResolver` (Epic 29), held request-scoped, and never logged/returned/persisted in a tool result.
+- **Every tool goes through the hooks (AC5).** MCP/plugin tool outputs are sanitized + secret-redacted **identically** to built-in tool outputs — the runner's existing `ToolHookRegistry`/`IContentSanitizer`/`RedactSecrets` path is the single chokepoint; no executor bypasses it.
+- **Fail-soft per server (AC8).** A broken MCP server degrades the catalog, never the run. Connect failures are isolated, logged WARN, and emit `MCP.SERVER.CONNECT.FAILED`; the run proceeds with the rest of the catalog.
+- **Strategy = .NET MCP SDK behind `IMcpTransport`, security layer kept in-house (AC10).** Recommended over a hand port (cost, no differentiation) and over a TS sidecar (multiplies where secrets live, breaks the one-process API model). The transport seam keeps the choice reversible per-transport.
+- **No empty fallback (`feedback_resolution_no_empty_fallback`).** An unknown/un-enabled tool name resolves to "no executor," never to a silent built-in. Credential reads are cabinet→error, never empty.
+- **Tenant-schema by default → no DROP-list / model-test churn (AC11).** MCP-server config + enablement are tenant-scoped (performance/config data ownership rule), so they live in the `t_<hex>` schema owned by `EfTenantDbMigrator`, NOT in `Program.cs`'s control-plane startup-reset DROP list, and require **no** `ControlPlaneDbContextModelTests` edit. If a reviewer decides the MCP catalog must be CP-resident, it MUST then be appended to **both** the DROP list and the strict `Model_Has_ExpectedControlPlaneEntities` `BeEquivalentTo` list (called out here so it isn't missed). The default keeps the surface tenant-isolated.
+- **EF: this story extends the single migration snapshot, not a branch.** Stories are implemented sequentially against one `TammaModelConfiguration` / migration snapshot; the new tenant-schema tables amend it.
+- **Admin route policy.** Tenant-scoped MCP enable/disable + CRUD = `tenant_owner`/`tenant_admin` (member → 403). There is no platform-global `/api/admin/*` route here, so `PlatformOwnerAccess` does not apply; if a platform-global MCP registry is ever added it would use `PlatformOwnerAccess` (NEVER `OwnerAccess`).
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns an MCP-server config / enablement? | The sole user (keyed by `UserId`; `TenantId` NULL). | The tenant (keyed by `TenantId`). No per-user layer; members can't add/enable. |
+| Who can enable/disable an MCP server? | The sole user (owns everything). | `tenant_owner` / `tenant_admin` only; member → 403 (read allowed). |
+| Whose credential does an MCP connection use? | The sole user's cabinet secret (Epic 29), read by reference at connect. | The tenant's cabinet secret (Epic 29), read by reference at connect. Never cross-tenant. |
+| Which MCP servers / plugin tools are in a run's catalog? | The sole user's enabled set. | The tenant's enabled set (∩ the agent's allowed tools, ∩ allowlist). |
+| Where do MCP config / discovery / tools live? | The user's (sole) tenant schema; tenant-isolated. | The tenant's `t_<hex>` schema; never visible to another tenant or to platform admin. |
+| Where do `MCP.SERVER.*` / `AGENT.TOOL.SOURCED` events land? | The user's (sole) tenant event store. | The tenant's `t_<hex>` event store via the tenant-scoped `IEventRepository`. Never cross-tenant. |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`) — process-stable. | same |
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| A tool bypasses the sanitization hooks → unsanitized MCP output re-enters the model (AC5) | Critical | Single chokepoint: the runner applies `ToolHookRegistry`/`IContentSanitizer`/`RedactSecrets` to **every** `IToolExecutor` output; MCP/plugin executors return raw content only — they never apply (or skip) sanitization themselves. Golden-equality test vs a built-in tool. |
+| MCP secret leaks into config / logs / tool result (AC3) | Critical | Config carries `CredentialRef` only; literal-secret configs rejected at write; secret read request-scoped via `IRuntimeSecretResolver`, never logged/returned/persisted; credential-safety test asserts absence everywhere. |
+| The engine opens an MCP socket / reads a key (rule 1) | High | All MCP types/registrations live in `Tamma.Api`; grep `Tamma.ElsaServer` proves zero MCP transport/credential references; the engine runs no tools (32-5 removed its tool registrations). |
+| A broken MCP server fails the whole run (AC8) | High | Fail-soft isolation: per-server connect/discovery timeout, contribute-zero-tools-on-error, `MCP.SERVER.CONNECT.FAILED` + WARN, run proceeds. |
+| An un-enabled/disallowed MCP tool reaches the model (AC2/AC6) | High | Union filtered by enablement gate **and** `GetAllowed(allowlist)` **and** agent-allowed intersection; unknown name → `null` executor (no silent fallback). |
+| .NET MCP SDK is immature for a transport (AC10) | Medium | `IMcpTransport` seam isolates the SDK; a single transport can fall back to a hand-rolled port without touching the catalog/security layer. Research the SDK before pinning. |
+| Cross-tenant tool leakage | Medium | Config + enablement keyed by principal (XOR), tenant-schema resident; discovery cache keyed by `(tenantId, server, configHash)`; isolation test. |
+| Discovery latency on every run | Medium | Capability cache with short TTL keyed `(tenantId, server, configHash)`, invalidated on config/enablement change; pooled connections + health checks. |
+| Mis-scoping MCP config as control-plane → DROP-list/model-test churn missed (AC11) | Medium | Default is tenant-schema (no churn); if changed to CP, append to both the `Program.cs` DROP list and the strict `Model_Has_ExpectedControlPlaneEntities` list (Dev Notes flag). |
+
+### Success Metrics
+
+- [ ] The managed run's catalog provably equals built-in ∪ enabled-MCP ∪ enabled-plugin, behind one `GetAllowed`.
+- [ ] `grep` over `Tamma.ElsaServer` finds **zero** MCP transport/connection/credential references (engine holds no socket/key).
+- [ ] 100% of MCP/plugin tool invocations traverse the `ToolHookRegistry`/`IContentSanitizer`/`RedactSecrets` path (parity with built-in).
+- [ ] An un-enabled or disallowed MCP/plugin tool is **never** advertised or executable.
+- [ ] A failing MCP server never fails a managed run (fail-soft); it degrades the catalog and logs WARN.
+- [ ] No MCP secret appears in any config row, log line, tool result, or DCB event payload.
+
+## Related
+
+- Design of record: `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§1 steps-never-call-providers; §2.6 step 5 the provider call / tool loop home)
+- Managed-LLM deep dive: `docs/superpowers/specs/2026-06-20-managed-llm-execution-deep-dive.md` (§4 tools/MCP/plugins/cache/RAG; §6 item 2 the NEW MCP & plugin sourcing story; §7.3 the MCP strategy open decision)
+- Re-plan: `docs/superpowers/plans/2026-06-20-epic-32-37-replan.md` (sequence; follow-ons after step F)
+- Implementation plan: `docs/superpowers/plans/2026-06-21-32-21-mcp-and-plugin-tool-sourcing-plan.md`
+- Sibling stories: `story-32-5/` (the endpoint/runner that consumes this catalog), `story-32-16/` (the per-tenant enablement model reused for MCP servers), `story-32-2/` + `story-32-18/` (the agent allowed-tool set the catalog is intersected with), `story-32-6/` (action trail consuming the per-run tool calls); Epic 29 (cabinet creds), Epic 6 (intelligence/RAG tools + MCP resources), Epic 9 (unified agent API surface)
+- Reference code: `packages/mcp-client/` (TS client — behavioural reference: `client.ts`, `transports/{stdio,sse,websocket}.ts`, `registry.ts`, `security/{validator,rate-limiter}.ts`, `cache/*`, `audit.ts`); `apps/tamma-elsa/src/Tamma.Activities/LlmCall/Tools/IToolExecutorRegistry.cs` (the seam); `apps/tamma-elsa/src/Tamma.Activities/Security/IContentSanitizer.cs`; `apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Stopgap/IRuntimeSecretResolver.cs`
+
+## Logging Requirements
+
+- **INFO**: MCP server registered/enabled/disabled (server name, tenantId — **never the credential**); managed run tool catalog assembled (`AGENT.TOOL.SOURCED` counts: builtIn/mcp/plugin offered, correlationId); MCP connection established (server, transport — no auth material).
+- **DEBUG**: per-server discovery (tool names listed), cache hit/miss for `(tenantId, server, configHash)`, allowlist ∩ agent-allowed narrowing result, rate-limit decisions.
+- **WARN**: MCP server connect/discovery failure (server, tenantId, correlationId, error class — key-free) with the run proceeding fail-soft; a configured-but-un-enabled server skipped; a write rejected for embedding a literal secret.
+- **ERROR**: composite-catalog assembly failure that cannot degrade fail-soft (the run's catalog cannot be built), and DCB append failure (logged, not swallowed).
+- **Structured context**: `{ tenantId, server, transport, correlationId }` where applicable; tool counts on `AGENT.TOOL.SOURCED`.
+- **Credential safety (LOAD-BEARING)**: NEVER log, return, or persist an MCP-server credential, transport auth header/env/arg, or any secret read from the cabinet. Only the **reference** (`CredentialRef`) and non-secret config (name, transport, url/command sans secrets) are safe. Tool results are sanitized + secret-redacted before re-entering the model context; the `MCP.SERVER.*` and `AGENT.TOOL.SOURCED` event payloads are key-free by contract.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-21 | 1.0.0   | Initial story creation — MCP-server + plugin tool sourcing into the C# managed-run tool catalog (deep-dive §4 MCP+plugins / §6 item 2 / §7.3). Composite catalog `ICompositeToolCatalog : IToolExecutorRegistry` (built-in ∪ MCP ∪ plugin behind the single `GetAllowed` seam, ∩ agent-allowed); per-tenant MCP-server config (cabinet creds by reference, enablement-gated like agents 32-16); every invocation through `ToolHookRegistry`/`IContentSanitizer`/`RedactSecrets`; engine holds no MCP socket/key (rule 1); fail-soft per-server isolation + discovery cache; **strategy decision resolved — .NET MCP SDK behind `IMcpTransport`, security layer kept in-house** (sidecar rejected, hand-port as fallback). Consumed by 32-5's `InlineToolLoopRunner`; ties to Epic 6/9. | Claude |
+| 2026-06-21 | 1.0.1   | Cross-spec reconciliation (I4): MCP enablement is now its **OWN** tenant-schema `McpServerEnablement` entity keyed by `McpServerId`, gated by an OWN `IMcpServerEnablementReader.IsEnabledForPrincipalAsync(mcpServerId, principal, ct)` — it **mirrors the 32-16 PATTERN** (XOR/unique-index/RBAC) as a SEPARATE entity (different schema residency + target id), and no longer keys on `AgentId`/`AgentSurfaceId` or consumes `ITenantAgentEnablementReader`. Removed the "reuse 32-16 shape" wording. | Claude |

--- a/docs/stories/epic-32/story-32-22/32-22-prompt-and-response-cache.md
+++ b/docs/stories/epic-32/story-32-22/32-22-prompt-and-response-cache.md
@@ -1,0 +1,370 @@
+# Story 32-22: Prompt + Response Cache (provider prompt cache + gated response cache)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **platform operator paying per-token for managed LLM execution**,
+I want two server-side cache layers composed inside the managed run — (1) an **Anthropic provider prompt cache** that marks the stable prompt prefix (system prompt + persona config + RAG/conventions block) `cache_control: ephemeral` so repeated runs re-read the prefix cheaply, and (2) an **optional response cache** keyed by the rendered run identity that returns a prior completion **without re-calling the provider** — both wired so the returned `cache_read`/`cache_write` token counts meter against the cache-rate columns reserved on `ProviderModelPrice` (34-11), and so a response-cache hit **still runs gate → budget → metering → audit** (never bypassing billing),
+So that **stable-prefix and deterministic single-turn runs cost less** while every call remains gated, metered, and auditable — the engine sees an unchanged buffered request/response and the API key never leaves `Tamma.Api`.
+
+## Priority
+
+P2 — A **cost-reduction layer**, not a correctness prerequisite. It rides entirely inside the `ManagedAgent.RunAsync` / `IInlineToolLoopRunner` composition built by **32-5** and consumes the cache-rate columns + `IProviderPricingService` seam reserved by **34-11**. Both layers are **off-by-default-safe**: with the prompt cache disabled the run behaves exactly as 32-5 ships it, and with the response cache disabled every call is a live metered run. Sequenced **after** 32-5 (the endpoint/runner) and 34-11 (the cache-rate cost columns); does not block any sibling pivot story.
+
+## Context
+
+### Where this sits (deep-dive §4 "Cache")
+
+The managed-LLM deep dive (§4) specifies **two server-side cache layers, both new**, composed inside `ManagedAgent.RunAsync` / `IInlineToolLoopRunner` in `Tamma.Api`:
+
+> **Cache** — two server-side layers (both new): (1) **provider prompt cache** — Anthropic `cache_control: ephemeral` on the stable prefix (system prompt + persona config + RAG/conventions block); the returned `cache_read`/`cache_write` token counts feed the meter (the `ProviderModelPrice` entity reserves nullable cache-rate columns). (2) optional **response cache** keyed by `(tenantId, agentVersion, renderedPromptHash, model, toolset)` — strictly **after** gate/budget so a hit still meters/audits (or records a `cache_hit` zero-cost usage event); tool-loop runs are likely *not* cacheable (non-deterministic side effects).
+
+This story builds both layers and resolves the deep-dive **§7.4 open decision** (response-cache policy) with a recommended default.
+
+### What exists after 32-5 / 34-11 (the seams this story extends)
+
+- **32-5** ships `ManagedAgent.RunAsync` with the locked rule-2 compose order: gate (32-4) → resolve agent + enablement (32-18/32-16) → resolve credential BYOK→platform (32-3) → **render prompt (Epic 27)** → **provider call via `IInlineToolLoopRunner`** (request-scoped key, server-side) → **meter (`IProviderPricingService.Compute` + 32-9 usage event)** → return. The rendered prompt's **stable prefix** (Epic-27 system prompt + persona/agent config + RAG/conventions block assembled by the pre-call `AssembleContextActivity`) is exactly the span the prompt cache marks.
+- **34-11** promotes the cost rate sheet to the `ProviderModelPrice` control-plane entity behind the unchanged `IProviderPricingService` seam and **reserves two nullable columns** — `CacheReadUsdPer1M (decimal?)` and `CacheWriteUsdPer1M (decimal?)` — explicitly "reserved" for exactly this story. `IProviderPricingService.Compute(provider, model?, in, out)` does **not** yet account for cache tokens; this story adds the cache-aware cost path.
+- **32-9** is the usage/cost emitter; this story extends the usage record with `cache_read`/`cache_write` token splits and emits a `cache_hit` flavour for response-cache hits.
+- **Epic 27** owns the prompt store — the resolved system prompt + persona/agent config that form the cacheable prefix.
+
+### What this story does NOT do (out of scope — referenced, not built)
+
+- **No streaming.** The SSE response mode / live `IToolLoopEventSink` / run tap are the "Streaming run tap" follow-on. This story is buffered request/response only; the engine is unaffected.
+- **No markup math.** Cache-token cost feeds the **provider cost basis** only (`IProviderPricingService`); the 34-5 markup engine derives sell price downstream. This story does not price the sell side.
+- **No new control-plane table.** The response cache is a **tenant-schema** store (`t_<hex>`), not a control-plane table — so it does **not** enter `Program.cs`'s startup-reset DROP list and does **not** touch `ControlPlaneDbContextModelTests`. The cache-rate columns live on `ProviderModelPrice`, owned by 34-11.
+- **No cross-provider prompt cache.** Provider prompt caching is Anthropic-specific (`cache_control: ephemeral`); for non-Anthropic providers the prompt-cache layer is a no-op (the `cacheable?` predicate returns false), and the response cache is provider-agnostic.
+
+## Acceptance Criteria
+
+1. **Provider prompt cache — Anthropic only, on the stable prefix.** When the resolved provider is Anthropic (alias-normalized — `anthropic`/`anthropic-claude`/`claude` → `anthropic`), `IInlineToolLoopRunner` adds `cache_control: { type: "ephemeral" }` to the **stable prefix** of the request: the Epic-27 system prompt block + the persona/agent config block + the RAG/conventions block (`{{conventions}}` + assembled-context variables). The volatile task/user prompt is **never** marked cacheable. The cache breakpoint is placed at the boundary between the stable prefix and the volatile suffix. For all non-Anthropic providers this is a **no-op** (request unchanged).
+
+2. **Prompt-cache config + default.** A new `PromptCacheOptions` (config-bound) controls the layer: `Enabled` (default **true** for Anthropic), and a `MinPrefixTokens` floor (default 1024 — below it, marking a breakpoint is not worthwhile). A persona/agent may opt out via its config. With `Enabled=false` the run is byte-for-byte the 32-5 baseline request.
+
+3. **Cache-token metering wired to 34-11's reserved columns.** The Anthropic response's usage fields `cache_creation_input_tokens` (→ `cacheWriteTokens`) and `cache_read_input_tokens` (→ `cacheReadTokens`) are parsed and threaded through `InlineToolLoopResult` → `AgentRunResult` → the 32-9 usage record. A **new cache-aware cost path** on `IProviderPricingService` (`ComputeWithCache(provider, model?, inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens)` or an additive overload) prices `cacheReadTokens` at `CacheReadUsdPer1M` and `cacheWriteTokens` at `CacheWriteUsdPer1M` when those columns are non-null, falling back to the plain input rate when a column is null (so an unpopulated cache rate never overcharges or throws). The plain `Compute(...)` from 34-11 is **unchanged**; cache pricing is additive.
+
+4. **Response cache — keyed exactly per the design.** An optional response cache stores a completed run's `text` + `usage` keyed by `(tenantId, agentVersion, renderedPromptHash, model, toolset)` where `renderedPromptHash` is a SHA-256 of the fully-rendered prompt (system + merged variables + user prompt, post-Epic-27 render), `model` is the resolved model, and `toolset` is the canonical-sorted allowed-tool set. The cache is a tenant-schema store (`t_<hex>.agent_response_cache`), per-tenant (never cross-tenant — a key from tenant A can never hit tenant B's entry). Entries carry a TTL (`ResponseCacheOptions.Ttl`, default 24h) and are bounded (LRU / count cap per tenant).
+
+5. **The response cache is applied STRICTLY AFTER gate + budget — never bypassing billing or audit.** The cache lookup happens **after** compose steps 1 (gate/32-4) and the budget guard, and **before** the provider call. On a hit, the run **still**: passes the gate, passes the budget check, **emits a metered usage event** (`cache_hit` flavour) and the terminal `AGENT.RUN.SUCCESS` DCB event. A cache hit **never** skips gating, entitlement, budget, metering, or audit. The provider is not called; the cached `text`/`usage` is returned.
+
+6. **Cache-hit usage is metered at zero provider cost but fully recorded.** A response-cache hit records a usage event with `cacheHit=true`, `providerCostUsd=0` (no provider tokens were spent), the cached token counts preserved for reporting, and `BillingMode` from `credentialSource`. Whether a hit is billed to the tenant at all is a **34-5/35 policy decision** (default: a cache hit is a zero-cost-basis usage event → zero sell price); this story only guarantees the hit is **recorded and audited**, never silent.
+
+7. **Tool-loop runs are NOT response-cached (documented policy + predicate).** A `IResponseCacheabilityPolicy.IsCacheable(req, resolved)` predicate returns **false** when `enableToolLoop == true` (tool calls have non-deterministic side effects — file writes, shell, git — that a cached replay would skip), when `temperature > 0` beyond a configurable determinism threshold (default: cacheable only at `temperature <= 0`), or when the agent/persona opts out. Single-turn deterministic renders (`enableToolLoop==false`, `temperature<=threshold`) are cacheable. The predicate is the single documented gate; its reasons are logged.
+
+8. **Recommended defaults (resolving deep-dive §7.4).** Ship: **prompt cache ON** for Anthropic (AC1/AC2); **response cache OFF for tool-loop runs** (AC7), **ON for single-turn deterministic renders** (`enableToolLoop==false && temperature<=0`); response-cache default **disabled globally** until a tenant/operator opts in via `ResponseCacheOptions.Enabled` (conservative — a stale or wrong cached answer is worse than a re-spend). All four knobs (`PromptCacheOptions.Enabled`, `ResponseCacheOptions.Enabled`, `Ttl`, the determinism threshold) are config-bound and per-tenant-overridable where the platform supports it.
+
+9. **Buffered-only; engine unaffected.** Both layers live entirely inside `Tamma.Api`. The `CallLlmInlineActivity` thin client, the `LlmCallRequest`/`LlmCallResponse` wire contract, `LlmCallWorkflow.cs`'s `ForEach`/`RetryCheck`/circuit-breaker boundary, and the engine's buffered request/response are **byte-for-byte unchanged**. The `LlmCallResponse.usage` gains `cacheReadTokens`/`cacheWriteTokens`/`cacheHit` fields (additive, defaulting to 0/false), so a workflow that ignores them is unaffected.
+
+10. **Fail-open on cache failure, fail-closed on gate/budget (no-empty-fallback respected).** A response-cache **read** error (store unavailable, deserialize failure) → **fall through to a live provider call** (the cache is an optimization, never a correctness dependency) and log a WARN — but the gate/budget/credential resolution upstream remain **fail-closed** (an unevaluable gate/budget/credential still denies, per `feedback_resolution_no_empty_fallback`; the cache fail-open applies ONLY to the cache layer itself, never to gating). A cache **write** error never fails the run.
+
+11. **Credential safety.** Neither cache layer ever stores, logs, or keys on the provider API key. The `renderedPromptHash` is a hash, not the prompt plaintext; the cache value stores completion text + token counts only. No key, no `BaseUrl` auth, no provider header appears in any cache entry, log line, or DCB event.
+
+12. **Tests cover both layers + the policy + the metering.** Prompt-cache prefix marking (Anthropic adds `cache_control` to the stable prefix only / non-Anthropic no-op / disabled = baseline request); cache-token parse → meter wiring (cache_read/write tokens priced at the reserved columns, null-column fallback, plain `Compute` unchanged); response-cache hit path (after gate+budget, emits metered `cache_hit` usage + terminal DCB event, provider not called); cacheability predicate (tool-loop → not cacheable, temperature>threshold → not cacheable, single-turn deterministic → cacheable); per-tenant isolation (tenant A key never hits tenant B); fail-open on cache read error → live call; credential-never-in-cache; the `LlmCallResponse.usage` additive fields default to 0/false.
+
+## Acceptance Criteria — non-goals (YAGNI guard)
+
+- No distributed cache backend selection (Redis/etc.) — the response cache is a tenant-schema table with an in-process snapshot; a distributed backend is a later optimization.
+- No semantic/embedding-similarity cache — exact `renderedPromptHash` match only.
+- No prompt-cache support for non-Anthropic providers (their APIs differ; out of scope until a provider needs it).
+
+## Technical Design
+
+### Where it lives
+
+```
+apps/tamma-elsa/src/Tamma.Api/Services/Agents/
+  ManagedAgent.cs                       # MODIFY (32-5) — compose the response-cache lookup AFTER gate+budget, BEFORE the loop; thread cache-token usage into the meter
+  ResponseCacheOptions.cs               # NEW — { Enabled(false), Ttl(24h), MaxEntriesPerTenant, DeterminismTemperatureThreshold(0) }
+  PromptCacheOptions.cs                 # NEW — { Enabled(true), MinPrefixTokens(1024) }
+  IResponseCache.cs                     # NEW — TryGet / Set, keyed by ResponseCacheKey, tenant-scoped
+  ResponseCache.cs                      # NEW — tenant-schema store (t_<hex>.agent_response_cache) + in-process LRU snapshot
+  ResponseCacheKey.cs                   # NEW — record { TenantId, AgentVersion, RenderedPromptHash, Model, Toolset }
+  IResponseCacheabilityPolicy.cs        # NEW — IsCacheable(req, resolved) -> (bool, reason)
+  ResponseCacheabilityPolicy.cs         # NEW — tool-loop / temperature / opt-out gate (AC7/AC8)
+
+apps/tamma-elsa/src/Tamma.Activities/LlmCall/
+  IInlineToolLoopRunner.cs              # MODIFY (32-5) — InlineToolLoopResult gains CacheReadTokens / CacheWriteTokens
+  InlineToolLoopRunner.cs               # MODIFY (32-5) — Anthropic prompt-cache prefix marking (AC1/AC2); parse cache_creation/cache_read usage (AC3)
+
+apps/tamma-elsa/src/Tamma.Api/Services/Providers/
+  IProviderPricingService.cs            # UNCHANGED seam (34-11) — Compute / IsKnown stay; add the additive cache path on the impl
+  DbProviderPricingService.cs           # MODIFY (34-11) — ComputeWithCache(...) prices CacheReadUsdPer1M / CacheWriteUsdPer1M; null-column fallback
+
+apps/tamma-elsa/src/Tamma.Api/Services/Agents/
+  LlmCallResponse.cs                    # MODIFY (32-5) — UsageDto gains CacheReadTokens / CacheWriteTokens / CacheHit (additive)
+
+apps/tamma-elsa/src/Tamma.ElsaServer/migrations  (per-tenant EfTenantDbMigrator)
+  <timestamp>_AddAgentResponseCache.cs  # NEW — t_<hex>.agent_response_cache (tenant-schema, NOT control-plane)
+
+apps/tamma-elsa/src/Tamma.Api/Program.cs
+  Program.cs                            # MODIFY — register IResponseCache, IResponseCacheabilityPolicy, bind PromptCacheOptions/ResponseCacheOptions
+```
+
+### Layer 1 — provider prompt cache (Anthropic `cache_control: ephemeral`)
+
+`InlineToolLoopRunner` builds the Anthropic request. When `PromptCacheOptions.Enabled` and the alias-normalized provider is `anthropic` and the prefix exceeds `MinPrefixTokens`, the stable-prefix blocks are marked:
+
+```jsonc
+// Anthropic /v1/messages — cache breakpoint at the stable/volatile boundary
+{
+  "model": "claude-sonnet-4-20250514",
+  "system": [
+    { "type": "text", "text": "<Epic-27 system prompt + persona config>",
+      "cache_control": { "type": "ephemeral" } }     // STABLE PREFIX — cached
+  ],
+  "messages": [
+    { "role": "user", "content": [
+      { "type": "text", "text": "<RAG/conventions block>",
+        "cache_control": { "type": "ephemeral" } },   // STABLE PREFIX — cached
+      { "type": "text", "text": "<volatile task/user prompt>" }   // NOT cached
+    ]}
+  ]
+}
+```
+
+The response usage is parsed:
+
+```csharp
+// Anthropic response.usage:
+//   input_tokens, output_tokens,
+//   cache_creation_input_tokens  -> cacheWriteTokens   (first-write of the prefix)
+//   cache_read_input_tokens      -> cacheReadTokens     (subsequent cheap re-reads)
+public sealed record InlineToolLoopResult(
+    NormalizedLlmResponse Response,
+    int InputTokens, int OutputTokens,
+    int CacheReadTokens, int CacheWriteTokens,   // NEW — threaded to the meter
+    int Turns, bool Exhausted,
+    IReadOnlyList<ToolCallSummary> ToolCalls);
+```
+
+> **Note (research before implementing):** Anthropic's prompt-cache API shape (`cache_control` placement, the `cache_creation_input_tokens`/`cache_read_input_tokens` usage fields, 1024-token minimums, cache-write vs cache-read pricing multipliers) must be re-confirmed against the **latest** Anthropic docs at implementation time — do not assume the field names/limits from memory.
+
+### Cache-aware cost (additive over 34-11's seam)
+
+```csharp
+// IProviderPricingService stays unchanged (34-11). The DB impl gains an additive cache path:
+public decimal ComputeWithCache(
+    string provider, string? model,
+    int inputTokens, int outputTokens,
+    int cacheReadTokens, int cacheWriteTokens)
+{
+    var baseCost = Compute(provider, model, inputTokens, outputTokens); // 34-11, unchanged
+    var price = ResolveActiveRow(provider, model);                       // ProviderModelPrice row
+    var cacheReadCost  = price?.CacheReadUsdPer1M  is { } r ? cacheReadTokens  / 1_000_000m * r
+                                                            : 0m;        // null column => no cache surcharge
+    var cacheWriteCost = price?.CacheWriteUsdPer1M is { } w ? cacheWriteTokens / 1_000_000m * w
+                                                            : 0m;
+    return baseCost + cacheReadCost + cacheWriteCost;
+}
+```
+
+When a cache-rate column is null (34-11 ships them nullable/unseeded), the cache tokens contribute **zero** surcharge — they are still **reported** in the usage record, just not yet priced. Populating those columns later (admin write, 34-11 `PUT .../prices`) starts pricing them with no code change.
+
+### Layer 2 — response cache (composed in `ManagedAgent.RunAsync`)
+
+```
+ManagedAgent.RunAsync (32-5 order, with the cache spliced in):
+1. gate           (32-4)                                       # unchanged
+2. resolve agent + enablement (32-18/32-16)                    # unchanged
+3. resolve credential BYOK->platform (32-3)                    # unchanged
+4. render prompt  (Epic 27)                                    # unchanged -> produces the rendered prompt
+   budget guard   (fail-closed)                                # unchanged
+   --- response cache splices in HERE: after gate+budget, before the call ---
+4b. if ResponseCacheOptions.Enabled
+       && _cacheability.IsCacheable(req, resolved).Cacheable:    # AC7 predicate (tool-loop => false)
+       key = ResponseCacheKey(tenantId, resolved.AgentVersion,
+                              Sha256(renderedPrompt), resolved.Model, SortedToolset)
+       if _cache.TryGet(tenantId, key) is { } hit:
+           emit usage (32-9) { CacheHit=true, ProviderCostUsd=0, tokens=hit.Usage, BillingMode=credentialSource }   # AC5/AC6
+           emit AGENT.RUN.SUCCESS { ..., cacheHit:true }
+           return AgentRunResult.FromCache(hit)                  # provider NOT called
+5. loop           IInlineToolLoopRunner (request-scoped key)    # cache MISS -> live call
+6. costBasis      _pricing.ComputeWithCache(...)                # AC3 cache-aware
+   emit usage (32-9) { ..., CacheReadTokens, CacheWriteTokens, CacheHit=false }
+7. if IsCacheable: _cache.Set(tenantId, key, { text, usage }, Ttl)   # write-through (errors swallowed, AC10)
+8. emit AGENT.RUN.SUCCESS | FAILED
+9. return AgentRunResult
+```
+
+The lookup is **strictly after** gate (step 1) and budget (step 4) so a hit cannot dodge gating/billing. The write-through (step 7) is best-effort — a write failure logs WARN and the run still returns.
+
+### Tenant-schema cache store
+
+```sql
+-- t_<hex>.agent_response_cache  (per-tenant schema — owned by EfTenantDbMigrator, NOT control-plane)
+CREATE TABLE agent_response_cache (
+  cache_key          TEXT PRIMARY KEY,        -- Sha256 of the ResponseCacheKey tuple
+  agent_version      INTEGER NOT NULL,
+  rendered_prompt_hash TEXT NOT NULL,
+  model              TEXT NOT NULL,
+  toolset            TEXT NOT NULL,           -- canonical-sorted allowed-tool set
+  response_text      TEXT NOT NULL,
+  usage_json         JSONB NOT NULL,          -- token counts (key-free)
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at         TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX idx_agent_response_cache_expires ON agent_response_cache (expires_at);
+```
+
+This is a **tenant-schema** table created by the per-tenant `EfTenantDbMigrator` — it does **NOT** go in `Program.cs`'s startup-reset public-schema DROP list, and it does **NOT** alter `ControlPlaneDbContextModelTests`. No `tenantId` column is needed: the schema **is** the tenant boundary (per-tenant isolation, AC4).
+
+### Cacheability policy
+
+```csharp
+public interface IResponseCacheabilityPolicy
+{
+    (bool Cacheable, string Reason) IsCacheable(ManagedAgentRequest req, ResolvedAgentConfig resolved);
+}
+// ResponseCacheabilityPolicy:
+//   enableToolLoop == true               -> (false, "tool-loop: non-deterministic side effects")
+//   temperature  >  threshold (def 0)    -> (false, "non-deterministic temperature")
+//   agent/persona opted out              -> (false, "agent opt-out")
+//   else                                 -> (true,  "single-turn deterministic")
+```
+
+## Dependencies
+
+**Internal (hard prerequisites):**
+
+- **32-5** (Call-LLM endpoint + managed execution) — supplies `ManagedAgent.RunAsync`, `IInlineToolLoopRunner`/`InlineToolLoopResult`, `LlmCallResponse`/`UsageDto`, the buffered request/response, and the compose order this story splices into. (Sequence F.)
+- **34-11** (Provider Cost Price-Book) — supplies the `ProviderModelPrice` entity with the reserved nullable `CacheReadUsdPer1M`/`CacheWriteUsdPer1M` columns and the `IProviderPricingService` seam the cache-aware cost path extends. (Sequence A.)
+- **32-9** (usage & cost metering) — the usage emitter this story extends with cache-token splits + the `cache_hit` flavour.
+- **Epic 27** (prompt/convention render) — produces the stable prompt prefix (system prompt + persona config + RAG/conventions block) that the prompt cache marks and that the `renderedPromptHash` covers.
+
+**Consumers (downstream, not blockers):**
+
+- **34-5** (markup) / **35** (billing) — decide whether/how a `cache_hit` usage event bills the tenant (default: zero cost basis → zero sell).
+- **36** (analytics) — reports cache-hit rate, cache-read/write token splits, and cache-driven cost savings from the metered fields.
+
+**External:** Anthropic Messages API prompt-caching feature (`cache_control: ephemeral`, the `cache_creation_input_tokens`/`cache_read_input_tokens` usage fields) — re-confirm the latest API shape at implementation time.
+
+## Testing Strategy
+
+1. **Prompt-cache prefix marking (AC1/AC2).** Anthropic provider + `Enabled=true` → `cache_control:{type:ephemeral}` appears on the system-prompt block and the RAG/conventions block, **not** on the volatile user prompt; a fake captures the outgoing request body and asserts the breakpoint position.
+2. **Non-Anthropic no-op + disabled baseline (AC1/AC2).** OpenAI provider → request has no `cache_control`; Anthropic + `Enabled=false` → request is byte-for-byte the 32-5 baseline.
+3. **Cache-token parse → meter (AC3).** A fake Anthropic response with `cache_creation_input_tokens`/`cache_read_input_tokens` → `InlineToolLoopResult.CacheWriteTokens`/`CacheReadTokens` populated → `ComputeWithCache` prices them at `CacheReadUsdPer1M`/`CacheWriteUsdPer1M`; null columns → zero surcharge (still reported); plain `Compute` output unchanged from 34-11.
+4. **Response-cache hit after gate+budget (AC5/AC6).** Seed a cache entry; a matching request → gate + budget evaluated, provider runner **never invoked** (spy), a `cache_hit` usage event emitted (`providerCostUsd=0`, tokens preserved), exactly one `AGENT.RUN.SUCCESS` (`cacheHit:true`).
+5. **Cacheability predicate (AC7/AC8).** `enableToolLoop=true` → not cacheable (no `Set`, no lookup-hit path); `temperature>threshold` → not cacheable; `enableToolLoop=false, temperature=0` → cacheable; opt-out → not cacheable; reasons logged.
+6. **Per-tenant isolation (AC4).** Same `(agentVersion, promptHash, model, toolset)` for tenant A and tenant B → A's entry never returned to B (separate `t_<hex>` schemas).
+7. **Fail-open on cache read error (AC10).** Cache store throws on `TryGet` → run falls through to a live provider call, WARN logged, result correct; gate/budget remain fail-closed (an unevaluable budget still denies).
+8. **Write-through best-effort (AC10).** `Set` throws → run still returns its result; WARN logged.
+9. **Additive wire fields (AC9).** `LlmCallResponse.usage` gains `cacheReadTokens`/`cacheWriteTokens`/`cacheHit` defaulting to 0/0/false; a workflow ignoring them is unaffected; `LlmCallWorkflow.cs` diff is empty.
+10. **Credential safety (AC11).** Assert no API key / `BaseUrl` auth / provider header appears in any cache entry, the `usage_json` payload, any log line, or DCB event; the cache key is a hash, never the prompt plaintext.
+
+Docker-bound C# suites run via `sg docker -c "dotnet test apps/tamma-elsa/..."` (session docker group is stale; plain `dotnet build` needs no wrapper).
+
+## Estimated Effort
+
+4-6 days (two cache layers + the cache-aware cost path + the tenant-schema migration + the cacheability policy + the metering wiring + tests). Smaller than 32-5 because it rides the existing compose order and seams rather than building them.
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/PromptCacheOptions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ResponseCacheOptions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/IResponseCache.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ResponseCache.cs` | Create (tenant-schema store + in-process LRU) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ResponseCacheKey.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/IResponseCacheabilityPolicy.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ResponseCacheabilityPolicy.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ManagedAgent.cs` | Modify (splice cache lookup after gate+budget; cache-aware meter) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/LlmCallResponse.cs` | Modify (UsageDto += CacheReadTokens/CacheWriteTokens/CacheHit) |
+| `apps/tamma-elsa/src/Tamma.Activities/LlmCall/IInlineToolLoopRunner.cs` | Modify (InlineToolLoopResult += cache tokens) |
+| `apps/tamma-elsa/src/Tamma.Activities/LlmCall/InlineToolLoopRunner.cs` | Modify (Anthropic prefix marking + cache-usage parse) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Providers/DbProviderPricingService.cs` | Modify (ComputeWithCache additive path) |
+| `apps/tamma-elsa/src/Tamma.ElsaServer/.../<timestamp>_AddAgentResponseCache.cs` | Create (tenant-schema migration via EfTenantDbMigrator) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (register cache + policy; bind options) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/ResponseCacheTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/ResponseCacheabilityPolicyTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/ManagedAgentCacheCompositionTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/LlmCall/PromptCachePrefixTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Providers/CacheAwarePricingTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, and decisions (esp. `feedback_resolution_no_empty_fallback`).
+3. Read the managed-LLM deep dive §4 (cache), §6 item 3, and §7 item 4 (the open decision this story resolves) IN FULL, plus 32-5 (the compose order/seams you splice into) and 34-11 (the reserved cache-rate columns).
+4. Re-confirmed the **latest** Anthropic prompt-cache API shape (`cache_control` placement, `cache_creation_input_tokens`/`cache_read_input_tokens` usage fields, the 1024-token minimum, cache-write/cache-read pricing multipliers) against current Anthropic docs — never from memory.
+5. Confirmed 32-5 and 34-11 are landed (their seams — `ManagedAgent.RunAsync`, `IInlineToolLoopRunner`, `ProviderModelPrice` cache columns, `IProviderPricingService`) before wiring.
+6. Planned the TDD approach: the response-cache splice is an **additive composition** around the 32-5 order — assert the lookup runs after gate+budget and a hit still meters/audits.
+
+### Key Design Decisions
+
+- **Two independent layers, independently disable-able.** Prompt cache (Layer 1, Anthropic-only, ON by default) reduces the cost of a *single live call*; response cache (Layer 2, provider-agnostic, OFF by default) avoids the call entirely for deterministic repeats. They share nothing but the meter; either can ship/disable without the other.
+- **Response cache is after gate + budget, never before (AC5).** This is the load-bearing rule from the deep-dive §4: a cache hit must still pass gating and **emit a metered, audited usage event**. A cache that bypassed billing would be a compliance hole (silent unbilled runs) and an audit gap (runs with no DCB trail). The hit is zero *provider* cost, not zero *record*.
+- **Tool-loop runs are not cacheable (AC7) — resolving deep-dive §7.4.** Tool calls have non-deterministic side effects (file writes, shell, git); replaying a cached completion would skip the side effects, corrupting state. The recommended default: **response cache OFF for tool-loop runs, ON for single-turn deterministic renders (`temperature<=0`); prompt cache always ON for Anthropic.** The cacheability predicate is the single documented gate; its decision is logged.
+- **Cache-rate columns are nullable and may be unseeded (34-11).** The cache-aware cost path treats a null column as a zero surcharge (cache tokens reported but unpriced) so an unpopulated rate never overcharges or throws; populating the column later (admin `PUT .../prices`) starts pricing with no code change.
+- **Cache fail-open, gate fail-closed (AC10).** The cache is an *optimization* — a read/write error falls through to a live metered call. This does **not** weaken the upstream fail-closed posture: an unevaluable gate/budget/credential still denies (`feedback_resolution_no_empty_fallback`). The fail-open boundary is the cache layer only.
+- **No new control-plane table.** The response cache is tenant-schema (`t_<hex>.agent_response_cache`), owned by the per-tenant `EfTenantDbMigrator` — so it does **not** enter `Program.cs`'s startup-reset DROP list and does **not** edit `ControlPlaneDbContextModelTests`. The cache-rate columns live on `ProviderModelPrice` (34-11's control-plane entity, its DROP-list/CP-test obligations, not this story's).
+- **Buffered-only; engine unaffected.** Both layers are server-side inside `Tamma.Api`; the engine sees an unchanged buffered request/response. The additive `LlmCallResponse.usage` fields default to 0/false so the engine and any workflow ignoring them are byte-for-byte unaffected.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns the response-cache entries? | The sole user (the entries live in the user's sole tenant schema; keyed `TenantId` may be the implicit user scope). | The tenant — entries live in the tenant's `t_<hex>.agent_response_cache`. No per-user cache layer. |
+| Can a cache entry cross principals? | N/A (one user). | **Never** — the cache key includes `TenantId` and the store is the tenant schema; tenant A's entry can never hit tenant B (AC4). |
+| Who configures prompt/response cache on/off + TTL? | The sole user (their settings own `PromptCacheOptions`/`ResponseCacheOptions`). | The tenant (`tenant_owner`/`tenant_admin`); members cannot toggle. Platform ships the conservative defaults (prompt ON / response OFF). |
+| Whose cost do cache-read/write tokens reduce? | The sole user's provider cost basis (their BYOK or platform key). | The tenant's provider cost basis (`credentialSource` decides BYOK vs platform + 34-5 markup). |
+| Where does a `cache_hit` usage event land? | The user's (sole) tenant event store. | The tenant's `t_<hex>` event store via the tenant-scoped emitter (32-9). Never cross-tenant. |
+| Who reads cache-hit-rate analytics? | The user. | The tenant — platform admin sees none of the tenant's cache/cost data (design ownership rule). |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`) — process-stable. | same |
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| A cache hit silently bypasses billing/audit (compliance hole) | Critical | AC5 — the lookup is strictly after gate+budget; a hit emits a metered `cache_hit` usage event + terminal DCB event; test asserts the meter/audit fire on a hit (provider never called). |
+| A tool-loop run is cached → replay skips side effects, corrupting state | Critical | AC7 — `IResponseCacheabilityPolicy` returns false for `enableToolLoop==true`; default response-cache OFF for tool-loop runs; predicate test. |
+| Cross-tenant cache leak | Critical | AC4 — key includes `TenantId`; the store IS the tenant schema (`t_<hex>`); per-tenant-isolation test (A's key never hits B). |
+| Stale cached answer returned after a prompt/agent change | High | The key includes `agentVersion` + `renderedPromptHash` + `model` + `toolset`, so any change to the agent, prompt render, model, or tools is a cache miss; TTL bounds staleness; response cache defaults OFF. |
+| Cache-rate columns unseeded → cache tokens mispriced | Medium | Null column → zero surcharge (reported, not priced); never overcharges/throws; admin populates later with no code change (34-11). |
+| Cache store failure breaks a run | Medium | AC10 — fail-open: read/write errors fall through to a live metered call; WARN logged; gate/budget stay fail-closed. |
+| Anthropic prompt-cache API drift (field names/limits) | Medium | Re-confirm the latest Anthropic docs at implementation time (Dev Notes step 4); the parse is isolated in `InlineToolLoopRunner` behind `PromptCacheOptions`. |
+| New tenant-schema table forgotten in DROP list | Low | It's a tenant-schema (`t_<hex>`) table owned by `EfTenantDbMigrator` — it deliberately does NOT go in the public-schema DROP list; Dev Notes calls this out. |
+
+### Success Metrics
+
+- [ ] Anthropic runs mark `cache_control:ephemeral` on the stable prefix only; non-Anthropic runs are unchanged.
+- [ ] `cache_read`/`cache_write` token counts appear in 100% of Anthropic usage records and price at the reserved columns when populated.
+- [ ] 100% of response-cache hits emit a metered `cache_hit` usage event + a terminal `AGENT.RUN.SUCCESS` (zero silent/unbilled hits).
+- [ ] Zero tool-loop runs are response-cached (predicate enforced).
+- [ ] Zero cross-tenant cache hits; zero API keys in any cache entry/log/event.
+- [ ] `LlmCallWorkflow.cs` diff is empty (engine unaffected).
+
+## Related
+
+- Managed-LLM deep dive: `docs/superpowers/specs/2026-06-20-managed-llm-execution-deep-dive.md` (§4 cache — the two layers; §6 item 3 — "Prompt + response cache" scope; §7 item 4 — the response-cache-policy open decision this story resolves)
+- Design of record: `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§4 the Provider/`ProviderModelPrice` cost entity reserving the cache-rate columns)
+- Re-plan: `docs/superpowers/plans/2026-06-20-epic-32-37-replan.md`
+- Implementation plan: `docs/superpowers/plans/2026-06-21-32-22-prompt-and-response-cache-plan.md`
+- Sibling stories: `story-32-5/` (call-LLM endpoint + managed execution — the compose order/seams this splices into), `story-32-9/` (usage & cost metering — the emitter extended with cache tokens + `cache_hit`); `docs/stories/epic-34/story-34-11/` (Provider Cost Price-Book — the reserved `CacheReadUsdPer1M`/`CacheWriteUsdPer1M` columns + `IProviderPricingService`); `story-32-15/`/`story-32-17/` (persona/custom-agent prompts that form the cacheable prefix); Epic 27 (prompt store)
+- Reused code: `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ManagedAgent.cs`, `apps/tamma-elsa/src/Tamma.Activities/LlmCall/InlineToolLoopRunner.cs`, `apps/tamma-elsa/src/Tamma.Api/Services/Providers/DbProviderPricingService.cs`
+
+## Logging Requirements
+
+- **INFO**: prompt-cache marked (correlationId, provider=anthropic, prefixTokensEstimate); response-cache hit (correlationId, agentVersion, model — **never the prompt plaintext or hash-preimage**); response-cache write-through (correlationId, ttlSeconds); cache-aware cost computed (providerCostUsd incl. cache surcharge, cacheReadTokens, cacheWriteTokens).
+- **DEBUG**: cacheability decision (`cacheable`, `reason` — tool-loop / temperature / opt-out / single-turn-deterministic); cache key components (agentVersion, model, toolset, **hash only — never the prompt plaintext**); prompt-cache breakpoint position.
+- **WARN**: response-cache read error → fell through to live call (correlationId, error class — no payload); write-through error; cache-rate column null while cache tokens > 0 (cost under-reported until the column is seeded).
+- **ERROR**: cacheability predicate threw (run proceeds uncached — never blocks the call); usage/DCB append failure on a cache hit (the hit still returns its result; the append failure is logged, not swallowed).
+- **Structured context**: `{ correlationId, tenantId, agentVersion, provider, model, cacheHit, cacheReadTokens, cacheWriteTokens }` where applicable.
+- **Credential safety (LOAD-BEARING)**: NEVER log, store, or key on the provider API key, `BaseUrl` auth, or raw provider headers. The cache key is a **hash** of the rendered prompt, never the plaintext; the cache value stores completion text + token counts only. No cache entry, `usage_json` payload, log line, or DCB event payload contains a key.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-21 | 1.0.0   | Initial story creation — two server-side cache layers (Anthropic `cache_control:ephemeral` prompt cache on the stable prefix + optional gated response cache) composed inside 32-5's `ManagedAgent.RunAsync`/`IInlineToolLoopRunner`; cache-token metering wired to 34-11's reserved `CacheReadUsdPer1M`/`CacheWriteUsdPer1M` columns; response cache applied strictly after gate+budget (a hit still meters/audits via a `cache_hit` usage event); tool-loop runs documented as non-cacheable via `IResponseCacheabilityPolicy`; resolves deep-dive §7.4 with recommended defaults (prompt cache ON for Anthropic; response cache OFF for tool-loop, ON for single-turn deterministic, globally OFF until opted in). Buffered-only; engine unaffected. | Claude |

--- a/docs/stories/epic-32/story-32-23/32-23-streaming-run-tap.md
+++ b/docs/stories/epic-32/story-32-23/32-23-streaming-run-tap.md
@@ -1,0 +1,363 @@
+# Story 32-23: Streaming Run Tap (SSE for dashboard / CLI)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **developer watching an autonomous run from the Tamma dashboard or the `tamma` CLI**,
+I want a `GET /api/v1/llm/runs/{correlationId}/stream` SSE endpoint that emits each token, tool call, tool result, question, answer, and final frame of a managed LLM run **as it happens** — fed by an in-process bus that 32-5's `ManagedAgent.RunAsync` publishes to while it runs the buffered tool loop server-side —
+So that **humans get a live view of a run WITHOUT changing the engine's buffered `/llm/call` contract**: the Elsa step still issues one durable request/response call (so `ForEach`/`RetryCheck`/`SkipIfSucceeded` are untouched), while observers subscribe to a decoupled tap correlated by the workflow instance id.
+
+## Priority
+
+P1 — This turns the **inert streaming seam LIVE**. 32-5 ships `/llm/call` buffered-only and deliberately wires `ToolLoopEventEmitter` → `NullToolLoopEventSink` (events dropped, gated behind `EnableStreaming`). This story replaces the null sink with a real one and adds the human-facing tap. It is a **non-blocking enhancement** of the lynchpin: it adds observability without touching the engine boundary, the credential path, or the metering path. It depends on 32-5 (buffered endpoint + the sink seam) and cross-references 32-20 (interactive question-back, which produces the `question`/`answer` frames) and the dashboard/CLI consumers.
+
+## Context
+
+### What 32-5 ships (the buffered baseline this story builds on)
+
+32-5 builds `POST /api/v1/llm/call` as **buffered (`application/json`) ONLY** (32-5 AC2, deep-dive §3). `ManagedAgent.RunAsync` runs the agentic tool loop to completion server-side via the extracted `IInlineToolLoopRunner` (32-5 AC4) and returns one `LlmCallResponse`. The thin `CallLlmInlineActivity` calls `TammaApiClient.CallLlmAsync(...)`, gets the buffered result, and writes the same `LastDiagnostic`/`LastResponse`/`ToolLoop*` variables — so `LlmCallWorkflow.cs`'s `BuildRetryLoop` → `ForEach<provider>` boundary is byte-for-byte unchanged. **That contract does not move in this story.**
+
+### The inert seam (the gap this story closes)
+
+The streaming machinery exists but is dead:
+
+- `ToolLoopEventEmitter` (`Tamma.Activities/ToolExecution/ToolLoopEventEmitter.cs`) emits structured progress events (`TOOL_LOOP.TURN_STARTED`, `TOOL_LOOP.TOOL_EXECUTING`, `TOOL_LOOP.TOOL_COMPLETED`, `TOOL_LOOP.TURN_COMPLETED`, `TOOL_LOOP.COMPLETED`) to an injected `IToolLoopEventSink`.
+- The only registered sink is `NullToolLoopEventSink.Instance` — every event is silently discarded (`IToolLoopEventSink.cs:23`). The emitter even threads `workflowInstanceId` through every call, but with nowhere to send it.
+- The current provider call does **not** stream tokens — `CallAnthropicMultiTurn`/`CallOpenAiMultiTurn` do a single blocking `PostAsync` + `ReadFromJsonAsync` (deep-dive §3). So "streaming" today = tool-loop progress, and even that is dropped.
+
+The SSE infrastructure to deliver it also already exists and is the template:
+
+- `AdminTenantEventsSseEndpoint` (`Tamma.Api/Endpoints/Admin/AdminTenantEventsSseEndpoint.cs`) — the canonical SSE handler: `ContentType=text/event-stream`, `X-Accel-Buffering: no`, 30s `: keepalive` heartbeats, `MaxStreamDurationSeconds` ceiling, `Last-Event-ID` resumption, per-tick error budget, body scrub allowlist.
+- `SseWriter` (`Tamma.Api/Services/Engine/Lifecycle/SseWriter.cs`) — `WriteHeaders` / `WriteEventAsync(eventName, payload)` / `WriteCommentAsync` — the exact frame writer to reuse.
+
+### What this story does (deep-dive §3, §6.4)
+
+Turn the seam live and add a decoupled human tap, **without changing the engine's buffered call**:
+
+1. **A real `IToolLoopEventSink`** — `BusToolLoopEventSink` — that, instead of dropping events, publishes them onto an **in-process run bus** (`ILlmRunStreamBus`) keyed by `correlationId` (= the workflow instance id, already threaded through the emitter and the `LlmCallRequest`). Registered in `Tamma.Api` (where the runner now executes per 32-5), gated behind the existing `EnableStreaming` flag.
+2. **`GET /api/v1/llm/runs/{correlationId}/stream`** (`Tamma.Api/Endpoints/LlmRunStreamEndpoints.cs`) — a human-facing SSE endpoint that subscribes to the bus for that `correlationId` and writes each event as an SSE frame, reusing `SseWriter` and the `AdminTenantEventsSseEndpoint` hardening (headers, heartbeats, max-duration, error budget). Observers (dashboard, `tamma` CLI) are fully **decoupled** from the engine's buffered `/llm/call` — they never hold up, retry, or influence the buffered call.
+3. **Frame vocabulary** — `token`, `tool_call`, `tool_result`, `question`, `answer`, `final` — correlated by `correlationId`. The `tool_call`/`tool_result` frames are produced by `ToolLoopEventEmitter` events bridged through the bus; `token` frames come from optional provider token streaming inside the runner; `question`/`answer` frames are produced by 32-20's interactive question-back (this story defines the frame shape + transport, 32-20 produces the content); `final` carries the buffered turn summary the engine already received.
+4. **Optional `Accept: text/event-stream` on `/llm/call` itself** (deep-dive §3, the second response mode) for **direct human callers** — noted and wired as a thin opt-in that runs the same bus subscription against the in-flight run. **The engine path stays `application/json` and is unaffected** (the thin step never sends `Accept: text/event-stream`).
+5. **Provider token streaming (optional, inside the runner)** — `stream:true` MAY run inside `IInlineToolLoopRunner` in the API to cut TTFB and allow mid-turn cancel; it is **collapsed to a buffered turn result before the buffered `/llm/call` response returns** — invisible to the step. When enabled it emits `token` frames onto the bus; when disabled the tap still works (turn-granular `tool_call`/`tool_result`/`final` frames). This story does not require token streaming to land — it makes the bus carry tokens *if* the runner produces them.
+
+### Why the engine doesn't get SSE (the load-bearing decision)
+
+Elsa activities are durable-checkpointed request/response. Holding an open socket across `MaxSteps` turns fights persistence and the `ForEach`-per-provider boundary (deep-dive §3). So: **engine = buffered; dashboard/CLI = SSE via the tap.** The tap is read-only observability fed by an in-process bus; it can never break `RetryCheck`/`SkipIfSucceeded`/the circuit breaker because it is not on the engine's call path.
+
+### Explicitly out of scope (referenced, not implemented here)
+
+- **The buffered endpoint, `ManagedAgent` composition, credential resolution, metering, the thin-client cutover** — all **32-5**. This story consumes 32-5's run, it does not re-implement it.
+- **Producing `question`/`answer` content** (the `request_input` tool + `IQuestionRouter` + `WaitForAgentQuestionActivity`) — **32-20** (interactive question-back, deep-dive §5). This story defines the `question`/`answer` SSE frame shape + transport so 32-20 plugs in.
+- **A distributed (cross-process) bus.** The bus is **in-process** (one `Tamma.Api` instance fans run events to its own subscribers). Multi-instance fan-out (Redis/Postgres `LISTEN/NOTIFY`) is an explicit open decision, deferred — single-instance covers the dashboard/CLI use case today and is consistent with `WebhookSignalRegistry`'s in-process model.
+- **Persisting the stream.** The durable audit trail is the DCB `AGENT.RUN.*`/`TOOL_LOOP.*` events 32-5 already emits to the tenant store; the tap is **live-only** (an observer that connects mid-run sees events from connect time forward, plus an optional replay of the run's DCB events — see AC8). It does not become a second event store.
+
+## Acceptance Criteria
+
+1. **The tap endpoint exists.** `GET /api/v1/llm/runs/{correlationId}/stream` is served by a new `Tamma.Api/Endpoints/LlmRunStreamEndpoints.cs`. It sets SSE headers via `SseWriter.WriteHeaders` (`ContentType=text/event-stream`, `Cache-Control: no-cache`, `X-Accel-Buffering: no`), subscribes to `ILlmRunStreamBus` for the route `correlationId`, and writes one SSE frame per published run event until the run completes, the client disconnects, or `MaxStreamDurationSeconds` elapses. It emits `: keepalive` heartbeats every 30s (reusing the `AdminTenantEventsSseEndpoint` cadence) so proxies don't drop the connection during quiet turns.
+
+2. **Auth is the human plane, NOT the engine plane.** The tap is consumed by humans (dashboard JWT, `tamma` CLI `ApiKey`), so it requires `RequireAuthorization` on the standard authenticated policy (`AuthenticatedAny` / `MemberAccess` — JWT + ApiKey schemes), **not** the engine bearer (`Tamma:ApiToken`). In **SaaS** the caller's `tenantId` is derived from their auth context and a run is only streamable if its `correlationId` belongs to a run the caller's tenant owns — a `correlationId` for another tenant → **404** (never confirm existence cross-tenant). In **single-user** the sole user may stream any local run. Missing/invalid auth → **401**.
+
+3. **A real `IToolLoopEventSink` replaces the null sink.** A new `BusToolLoopEventSink : IToolLoopEventSink` publishes each `WriteEventAsync(eventType, data, ct)` to `ILlmRunStreamBus.PublishAsync(correlationId, frame, ct)`, mapping the `TOOL_LOOP.*` event types to the run-tap frame vocabulary (`tool_call`/`tool_result`/`final`). It is registered in `Tamma.Api` (where 32-5 moved the runner + its DI) **behind the existing `EnableStreaming` flag**; when `EnableStreaming` is false the registration stays `NullToolLoopEventSink` and the tap returns an immediate `final`/`event: end` with no live frames (graceful no-op, never an error). `grep` confirms `NullToolLoopEventSink` is no longer the only registered sink when streaming is enabled.
+
+4. **The frame vocabulary is exactly `{ token, tool_call, tool_result, question, answer, final }`, correlated by `correlationId`.** Each SSE frame is `event: <type>\ndata: <json>\n\n` where the payload carries `{ correlationId, seq, ... }`. `seq` is a per-run monotonic counter (NOT the per-tenant `domain_events.SequenceNumber`, which is a separate per-schema BIGSERIAL — see Dev Notes). `tool_call` carries `{ toolName, toolCallId, turn }`; `tool_result` carries `{ toolName, toolCallId, success, durationMs }`; `token` carries `{ delta }`; `question`/`answer` carry the 32-20 shape (`{ question, kind, options?, answerer? }` / `{ answer, answerer }`); `final` carries the buffered turn summary (`{ success, totalTurns, totalTokens, exhausted, durationMs }`). Payloads are **key-free** (credential-safety, AC9).
+
+5. **The bus is in-process and decoupled.** `ILlmRunStreamBus` (`Tamma.Api/Services/Streaming/`) is a singleton supporting `PublishAsync(correlationId, frame, ct)` (non-blocking, never throws into the producer) and `Subscribe(correlationId)` → an `IAsyncEnumerable<RunStreamFrame>` (or a bounded `Channel<RunStreamFrame>` per subscriber). Publishing when there are **zero subscribers is a no-op** — the buffered run is never blocked, slowed, or failed by the absence/slowness of observers. A slow/disconnected subscriber's bounded channel drops oldest frames (back-pressure) rather than stalling the run (modeled on `AdminTenantEventsSseEndpoint`'s 50-row per-tick cap). The producer side (`ManagedAgent`/runner) treats the bus as fire-and-forget.
+
+6. **The engine's buffered contract is byte-for-byte unchanged.** No change to `LlmCallEndpoints` buffered response, `ManagedAgent.RunAsync`'s return value, `CallLlmInlineActivity`'s variable writes, or `LlmCallWorkflow.cs`. The only producer-side change is that `ManagedAgent`/the runner publish to the bus **alongside** the existing flow (a side-effect, not a control-flow change). A test asserts the buffered `LlmCallResponse` is identical whether 0 or N subscribers are attached.
+
+7. **Optional `Accept: text/event-stream` on `/llm/call` (deep-dive §3, second response mode).** When a **non-engine** caller hits `POST /api/v1/llm/call` with `Accept: text/event-stream`, the endpoint streams the same bus frames for the run inline and ends with `final`, instead of returning buffered JSON. The **engine path is explicitly excluded**: the thin `CallLlmInlineActivity` sends `Accept: application/json` (the default), so `ForEach`/`RetryCheck`/`SkipIfSucceeded` see the unchanged buffered response. A test asserts the engine-shaped request (engine bearer + `application/json`) always gets buffered JSON regardless of any `Accept` munging.
+
+8. **Mid-run connect + replay.** An observer connecting after a run started receives frames **from connect time forward** (live tail). Optionally (gated by `?replay=true`), the handler first replays the run's already-emitted `TOOL_LOOP.*`/`AGENT.RUN.*` DCB events for that `correlationId` from the tenant store (scrubbed, key-free) as catch-up frames, then switches to the live tail — reusing the `AdminTenantEventsSseEndpoint` resume idiom. Without `?replay`, only live frames are sent. Either way the stream terminates with `event: end\ndata: {"reason":"run_complete"}\n\n` when the run's `final` frame is published, matching `AdminTenantEventsSseEndpoint`'s clean-close convention.
+
+9. **Credential safety (load-bearing).** No frame, log line, or bus payload EVER carries an API key, `BaseUrl` auth, raw provider header, or raw prompt body that may contain secrets. `token` deltas are model output (safe); `tool_call`/`tool_result` carry only `toolName`/`toolCallId`/`success`/`durationMs` (the tool **arguments/outputs are NOT streamed** — they may contain secrets and are sanitized/redacted only on the buffered path). The frame builder runs every payload through the same allowlist discipline as `AdminTenantEventsSseEndpoint.ScrubEvent`.
+
+10. **Tests cover the tap, the sink, the bus, and the non-regression of the buffered path.** Endpoint auth (401 missing, 404 cross-tenant); SSE headers + heartbeat + clean close; `BusToolLoopEventSink` maps `TOOL_LOOP.*` → the frame vocabulary; the bus is a no-op with zero subscribers and drops-oldest under back-pressure; the buffered `LlmCallResponse` is identical with 0 vs N subscribers (AC6); the engine-shaped `/llm/call` request always gets buffered JSON (AC7); `EnableStreaming=false` degrades gracefully; no frame/log/payload contains a key (AC9); mid-run connect sees live frames and `?replay=true` catches up from the DCB store (AC8).
+
+## Technical Design
+
+### Where it lives
+
+```
+apps/tamma-elsa/src/Tamma.Api/Endpoints/
+  LlmRunStreamEndpoints.cs           # NEW — GET /api/v1/llm/runs/{correlationId}/stream (human SSE tap)
+
+apps/tamma-elsa/src/Tamma.Api/Services/Streaming/
+  ILlmRunStreamBus.cs                # NEW — in-process pub/sub keyed by correlationId
+  LlmRunStreamBus.cs                 # NEW — singleton; bounded per-subscriber channels; publish = no-op w/ 0 subs
+  RunStreamFrame.cs                  # NEW — { Type, CorrelationId, Seq, Payload } (frame vocabulary)
+  RunStreamFrameType.cs              # NEW — token|tool_call|tool_result|question|answer|final constants
+  BusToolLoopEventSink.cs            # NEW — IToolLoopEventSink that publishes to the bus (replaces Null sink)
+  RunStreamFrameScrubber.cs          # NEW — allowlist scrub (mirrors AdminTenantEventsSseEndpoint.ScrubEvent)
+
+apps/tamma-elsa/src/Tamma.Api/Services/Agents/
+  ManagedAgent.cs                    # MODIFY (32-5-owned) — publish `final` (and `question`/`answer` via 32-20) to the bus; side-effect only
+
+apps/tamma-elsa/src/Tamma.Api/Endpoints/
+  LlmCallEndpoints.cs                # MODIFY (32-5-owned) — Accept: text/event-stream branch for direct human callers (engine stays application/json)
+
+apps/tamma-elsa/src/Tamma.Api/Program.cs
+                                     # MODIFY — map the tap endpoint; register ILlmRunStreamBus (singleton) +
+                                     #          swap NullToolLoopEventSink → BusToolLoopEventSink behind EnableStreaming
+```
+
+> Reuse, don't reinvent: `SseWriter` (`WriteHeaders`/`WriteEventAsync`/`WriteCommentAsync`) and the `AdminTenantEventsSseEndpoint` hardening (heartbeats, `MaxStreamDurationSeconds`, error budget, `Last-Event-ID`/replay, scrub allowlist) are copied/factored, not rebuilt.
+
+### The tap endpoint (`LlmRunStreamEndpoints.cs`)
+
+```csharp
+// GET /api/v1/llm/runs/{correlationId}/stream — human-facing SSE tap.
+// Auth: AuthenticatedAny (JWT + ApiKey) — NOT the engine bearer.
+public static async Task StreamRun(
+    string correlationId,
+    [FromServices] ILlmRunStreamBus bus,
+    [FromServices] ITenantContext tc,
+    [FromServices] IEventRepository eventRepo,   // for ?replay=true catch-up
+    [FromServices] TimeProvider timeProvider,
+    HttpContext http,
+    CancellationToken ct)
+{
+    // SaaS ownership guard: a correlationId not owned by this tenant => 404 (no cross-tenant existence oracle).
+    if (!await OwnsRunAsync(tc, eventRepo, correlationId, ct)) { http.Response.StatusCode = 404; return; }
+
+    SseWriter.WriteHeaders(http.Response);
+
+    using var streamCts = CancellationTokenSource.CreateLinkedTokenSource(ct, http.RequestAborted);
+    streamCts.CancelAfter(TimeSpan.FromSeconds(MaxStreamDurationSeconds));   // reuse the admin SSE ceiling
+    var token = streamCts.Token;
+
+    if (IsReplayRequested(http))                                   // AC8 — catch up from the DCB store first
+        await ReplayDcbFramesAsync(eventRepo, tc, correlationId, http, token);
+
+    await foreach (var frame in bus.Subscribe(correlationId).WithCancellation(token))   // AC1/AC5 — live tail
+    {
+        var safe = RunStreamFrameScrubber.Scrub(frame);            // AC9 — key-free
+        await SseWriter.WriteEventAsync(http.Response, frame.Type, safe, token);
+        if (frame.Type == RunStreamFrameType.Final) break;         // AC8 — clean close on `final`
+        // heartbeat cadence handled by a 30s timer race (AdminTenantEventsSseEndpoint idiom)
+    }
+
+    await SseWriter.WriteCommentAsync(http.Response, "stream-closing", CancellationToken.None);
+    // event: end\ndata: {"reason":"run_complete"}\n\n
+}
+```
+
+### The in-process bus (`ILlmRunStreamBus` / `LlmRunStreamBus`)
+
+```csharp
+public interface ILlmRunStreamBus
+{
+    // Producer side (ManagedAgent/runner): fire-and-forget. No-op when there are 0 subscribers.
+    // NEVER throws into the caller — a streaming failure must never fail the buffered run (AC5/AC6).
+    ValueTask PublishAsync(string correlationId, RunStreamFrame frame, CancellationToken ct = default);
+
+    // Consumer side (the tap endpoint): a bounded channel per subscriber; drops oldest under back-pressure.
+    IAsyncEnumerable<RunStreamFrame> Subscribe(string correlationId);
+}
+
+// Singleton. correlationId -> set of bounded Channel<RunStreamFrame> (capacity ~256, DropOldest).
+// Mirrors WebhookSignalRegistry's in-process registry discipline (ConcurrentDictionary, per-key fan-out).
+```
+
+```csharp
+public sealed record RunStreamFrame(
+    string Type,              // RunStreamFrameType.*
+    string CorrelationId,
+    long Seq,                 // per-run monotonic — NOT domain_events.SequenceNumber (per-schema BIGSERIAL)
+    object Payload);          // key-free, scrubbed before write
+
+public static class RunStreamFrameType
+{
+    public const string Token      = "token";
+    public const string ToolCall   = "tool_call";
+    public const string ToolResult = "tool_result";
+    public const string Question   = "question";   // produced by 32-20
+    public const string Answer     = "answer";     // produced by 32-20
+    public const string Final      = "final";
+}
+```
+
+### The live sink (`BusToolLoopEventSink`) — replacing the null sink
+
+```csharp
+// Registered in Tamma.Api behind EnableStreaming (else stays NullToolLoopEventSink — graceful no-op).
+public sealed class BusToolLoopEventSink : IToolLoopEventSink
+{
+    private readonly ILlmRunStreamBus _bus;
+
+    public async Task WriteEventAsync(string eventType, object data, CancellationToken ct = default)
+    {
+        // The emitter threads workflowInstanceId == correlationId already (ToolLoopEventEmitter).
+        var (correlationId, frameType, payload) = MapToolLoopEvent(eventType, data);   // TOOL_LOOP.* -> tool_call/tool_result/final
+        if (frameType is null) return;                                                 // unmapped events ignored
+        await _bus.PublishAsync(correlationId, new RunStreamFrame(frameType, correlationId, NextSeq(correlationId), payload), ct);
+    }
+}
+```
+
+`MapToolLoopEvent`: `TOOL_LOOP.TOOL_EXECUTING` → `tool_call`; `TOOL_LOOP.TOOL_COMPLETED` → `tool_result`; `TOOL_LOOP.COMPLETED` → `final`. `TURN_STARTED`/`TURN_COMPLETED` are turn-progress (optionally surfaced as `token`-less progress or ignored). `token` frames are published directly by the runner if provider token streaming is enabled; `question`/`answer` by 32-20.
+
+### The `Accept: text/event-stream` second mode on `/llm/call` (deep-dive §3)
+
+```csharp
+// In LlmCallEndpoints (32-5-owned file; this story adds the branch):
+if (WantsEventStream(http) && !IsEngineCaller(http))   // engine bearer + application/json => buffered (unchanged)
+    return await StreamInlineAsync(request, bus, managed, http, ct);   // subscribe to the in-flight run, end on `final`
+// else: existing buffered path — byte-for-byte unchanged for the engine.
+```
+
+The engine never sets `Accept: text/event-stream` (the thin `CallLlmInlineActivity` uses `TammaApiClient.CallLlmAsync` → `application/json`), so this branch is dormant for the engine and the buffered contract (AC6) is untouched.
+
+### Producer-side hooks (side-effects only, in `ManagedAgent`)
+
+`ManagedAgent.RunAsync` (32-5) gains **non-control-flow** publish calls: after the buffered loop returns, publish a `final` frame (`{ success, totalTurns, totalTokens, exhausted, durationMs }`); when 32-20 raises/answers a question, publish `question`/`answer`. These wrap in try/catch that logs-and-swallows (a streaming failure must never fail the run — AC5/AC6). The tool-loop `tool_call`/`tool_result` frames flow automatically through `BusToolLoopEventSink` because the runner already calls `ToolLoopEventEmitter`.
+
+## Dependencies
+
+**Internal (hard prerequisites):**
+
+- **32-5** (Call-LLM endpoint + managed execution) — supplies `POST /api/v1/llm/call`, `ManagedAgent.RunAsync`, the `IInlineToolLoopRunner` (now in the API), and the `IToolLoopEventSink` seam this story makes live. The buffered contract this story must not break. **Hard prerequisite.**
+
+**Internal (soft / co-evolving):**
+
+- **32-20** (Interactive question-back) — produces the `question`/`answer` frame **content** (`request_input` tool + `IQuestionRouter`); this story owns the `question`/`answer` frame **shape + transport** so 32-20 plugs into the bus. Co-evolving; the tap ships with the other four frame types even if 32-20 lands later.
+- **Epic 27** (prompt/convention render) — only transitively (via 32-5); not called here.
+- **Epic 29** (cabinet) — only transitively (via 32-5 credential path); not reached by the tap.
+
+**Reused infra (not blockers — already in the tree):**
+
+- `SseWriter` (`Tamma.Api/Services/Engine/Lifecycle/SseWriter.cs`) — the SSE frame writer.
+- `AdminTenantEventsSseEndpoint` — the hardening template (heartbeats, max-duration, error budget, scrub allowlist, `Last-Event-ID`/replay).
+- `ToolLoopEventEmitter` + `IToolLoopEventSink` (`Tamma.Activities/ToolExecution/`) — the emitter whose null sink this story replaces.
+- `WebhookSignalRegistry` (`Tamma.Activities/AgentDispatch/`) — the in-process registry discipline the bus mirrors.
+
+**Consumers (downstream, not blockers):**
+
+- **Dashboard** (`apps/dashboard` / the React observability dashboard) — subscribes to the tap to render a live run view.
+- **`tamma` CLI** — `tamma` watch/tail command consumes the tap over the same JWT/ApiKey plane.
+- **32-20** — its panel/human answerer surfaces `question`/`answer` frames in the same stream.
+
+**External:** none new (SSE over the existing HTTP stack; in-process bus).
+
+## Testing Strategy
+
+1. **Endpoint auth.** Missing/invalid JWT+ApiKey → 401; valid auth + a `correlationId` owned by another tenant → 404 (no cross-tenant existence oracle); valid auth + own run → 200 + `text/event-stream`.
+2. **SSE protocol.** Headers set via `SseWriter.WriteHeaders` (`text/event-stream`, `X-Accel-Buffering: no`); `: keepalive` emitted every 30s during a quiet run; clean close `event: end\ndata: {"reason":"run_complete"}` on `final`; `MaxStreamDurationSeconds` ceiling kicks an abandoned tab.
+3. **Sink mapping (AC3).** `BusToolLoopEventSink.WriteEventAsync` maps `TOOL_LOOP.TOOL_EXECUTING`→`tool_call`, `TOOL_LOOP.TOOL_COMPLETED`→`tool_result`, `TOOL_LOOP.COMPLETED`→`final`; unmapped events ignored; `correlationId` threaded from `workflowInstanceId`.
+4. **Bus semantics (AC5).** `PublishAsync` with 0 subscribers is a no-op and never throws; N subscribers each receive every frame; a slow subscriber's bounded channel drops oldest (no stall); `PublishAsync` never blocks the producer.
+5. **Buffered non-regression (AC6).** The buffered `LlmCallResponse` from a `ManagedAgent.RunAsync` is byte-for-byte identical with 0 vs N subscribers attached; `LlmCallWorkflow.cs` `ForEach`/`RetryCheck` advance unchanged.
+6. **`Accept` second mode (AC7).** A non-engine caller with `Accept: text/event-stream` gets a live SSE stream ending in `final`; the engine-shaped request (engine bearer + `application/json`) always gets buffered JSON, regardless of any `Accept` header munging.
+7. **`EnableStreaming=false` (AC3).** The registration stays `NullToolLoopEventSink`; the tap returns an immediate clean close with no live frames (graceful, never an error).
+8. **Mid-run connect + replay (AC8).** An observer connecting after start sees live frames from connect time; `?replay=true` first replays the run's `TOOL_LOOP.*`/`AGENT.RUN.*` DCB events (scrubbed) then switches to the live tail.
+9. **Credential safety (AC9).** No frame, log, or bus payload contains a key / `BaseUrl` auth / raw provider header / raw prompt body / tool arguments or outputs; `token`/`tool_call`/`tool_result`/`final` payloads are asserted key-free; the scrub allowlist drops anything off-list.
+10. **Frame vocabulary (AC4).** Each frame is `event: <type>\ndata: <json>` with `{ correlationId, seq, ... }`; `seq` is per-run monotonic (NOT the per-tenant `domain_events.SequenceNumber`); payload shapes per type asserted.
+
+Docker-bound C# suites run via `sg docker -c "dotnet test apps/tamma-elsa/..."` (session docker group is stale; plain `dotnet build` needs no wrapper).
+
+## Estimated Effort
+
+3-4 days (the tap endpoint + the in-process bus + the live sink + the `Accept` second-mode branch + the replay catch-up; all SSE infra and the emitter already exist, so this is wiring + careful decoupling tests, not new subsystems).
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/LlmRunStreamEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Streaming/ILlmRunStreamBus.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Streaming/LlmRunStreamBus.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Streaming/RunStreamFrame.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Streaming/RunStreamFrameType.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Streaming/BusToolLoopEventSink.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Streaming/RunStreamFrameScrubber.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ManagedAgent.cs` | Modify (32-5-owned — add side-effect publish of `final`/`question`/`answer`) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/LlmCallEndpoints.cs` | Modify (32-5-owned — `Accept: text/event-stream` branch; engine stays buffered) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map tap endpoint; register `ILlmRunStreamBus`; swap `NullToolLoopEventSink`→`BusToolLoopEventSink` behind `EnableStreaming`) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/LlmRunStreamEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Streaming/LlmRunStreamBusTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Streaming/BusToolLoopEventSinkTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Streaming/BufferedNonRegressionTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, and decisions (esp. SSE/streaming notes).
+3. Read the managed-LLM deep-dive §3 (Streaming — buffered for the engine, SSE for humans) IN FULL and §6 item 4 (the "Streaming run tap" follow-on), and the call-LLM endpoint design §2.
+4. Reviewed `AdminTenantEventsSseEndpoint.cs` (the hardening template), `SseWriter.cs` (the frame writer), `ToolLoopEventEmitter.cs` + `IToolLoopEventSink.cs` (the seam you make live), and `WebhookSignalRegistry.cs` (the in-process registry discipline).
+5. Confirmed 32-5 has landed (buffered endpoint + the `IToolLoopEventSink` seam + the runner in the API) before wiring the bus.
+6. Planned the TDD approach: the load-bearing invariant is **AC6 — the buffered contract is identical with 0 vs N subscribers.** Write that test first; it is the guardrail that the tap can never break the engine.
+
+### Key Design Decisions
+
+- **The tap is observability, never control flow.** The bus is fire-and-forget; publishing is a no-op with 0 subscribers and never throws into the producer. The buffered `/llm/call` path is the source of truth for the engine; the tap is a decoupled mirror. This is why the engine never needs SSE (deep-dive §3) and why `RetryCheck`/`SkipIfSucceeded`/the circuit breaker are structurally safe.
+- **Human plane, not engine plane (AC2).** Unlike `/llm/call` (engine bearer), the tap is consumed by humans (dashboard JWT, CLI ApiKey). It rides `AuthenticatedAny`, with a SaaS ownership guard that 404s cross-tenant `correlationId`s — never a cross-tenant existence oracle.
+- **In-process bus, single instance (open decision).** The bus mirrors `WebhookSignalRegistry`'s in-process model. Multi-instance fan-out (a tap connecting to instance B for a run on instance A) needs a distributed transport (Redis pub/sub or Postgres `LISTEN/NOTIFY`) — deferred as an explicit open decision (deep-dive §3 leaves this to the tap follow-on). Single-instance covers today's dashboard/CLI use.
+- **Per-run `seq`, NOT `domain_events.SequenceNumber` (AC4).** The per-tenant `domain_events.SequenceNumber` is an independent per-schema BIGSERIAL — using it as a stream sequence would be wrong (and meaningless across tenants). The tap's `seq` is a per-run monotonic counter the bus assigns.
+- **No new table; no Program.cs DROP-list entry.** This story adds **no** control-plane or tenant-schema table — the bus is in-memory, and the durable audit is the DCB `AGENT.RUN.*`/`TOOL_LOOP.*` events 32-5 already writes. So **no entry in `Program.cs`'s startup-reset "Wiping Tamma-managed public-schema tables" DROP list** and **no `ControlPlaneDbContextModelTests` edit** (the strict `BeEquivalentTo` list is untouched).
+- **No-empty-fallback applies to ownership, not content.** The SaaS ownership guard fails closed (cross-tenant → 404, never a fall-through that leaks a foreign run). Consistent with `feedback_resolution_no_empty_fallback`.
+- **`EnableStreaming` is the master switch.** When false, the sink stays `NullToolLoopEventSink` and the tap is a graceful no-op — never an error. The flag already gates the inert seam; this story makes it gate a live one.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who may open a run tap? | The sole user (keyed by `UserId`); any local run is streamable. | Any authenticated tenant member (JWT/ApiKey) — but only for runs the **tenant** owns. No per-user layer. |
+| How is the run's owner determined? | The sole user owns all runs. | The `correlationId`'s run must belong to the caller's tenant (`X-Tenant-Id`/JWT tenant claim); a foreign `correlationId` → 404. |
+| Where do the tapped events originate? | The user's (sole) run on the in-process bus; DCB replay from the user's event store. | The tenant's run on the in-process bus; `?replay` reads the tenant's `t_<hex>` event store via the tenant-scoped `IEventRepository`. Never cross-tenant. |
+| Who can see another principal's run? | N/A (single user). | No one — members see only their tenant's runs; platform admin sees none (performance/action data is ALWAYS tenant-scoped, design ownership rule). |
+| Does the engine ever consume the tap? | No — the engine uses the buffered `/llm/call`; the tap is human-only. | Same. |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`) — process-stable. | same |
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| A streaming failure breaks the buffered run (AC6) | Critical | The bus is fire-and-forget; `PublishAsync` never throws into the producer; all producer-side publishes wrap log-and-swallow; the **0-vs-N-subscribers identical-buffered-response** test is written first as the guardrail. |
+| The `Accept: text/event-stream` branch leaks into the engine path (AC7) | High | `IsEngineCaller` (engine bearer) forces buffered `application/json`; the thin `CallLlmInlineActivity` never sets the SSE Accept; explicit engine-shaped-request test. |
+| A slow/abandoned subscriber stalls the run (AC5) | High | Bounded per-subscriber channel (DropOldest, ~256); `MaxStreamDurationSeconds` ceiling; back-pressure drops frames, never blocks the producer (mirrors the admin SSE 50-row per-tick cap). |
+| A frame leaks a secret (AC9) | High | `RunStreamFrameScrubber` allowlist (mirrors `AdminTenantEventsSseEndpoint.ScrubEvent`); tool **arguments/outputs are NOT streamed**, only names/ids/durations; key-free assertions in tests. |
+| Cross-tenant run visibility (AC2) | High | SaaS ownership guard → 404 on foreign `correlationId`; tenant-scoped `IEventRepository` for replay; cross-tenant test. |
+| Multi-instance: a tap can't see a run on another API instance | Medium | Documented open decision; single-instance is the supported topology today; distributed transport deferred to a follow-on. |
+| `domain_events.SequenceNumber` misused as stream seq | Medium | Per-run monotonic `seq` assigned by the bus; never the per-schema BIGSERIAL; AC4 test. |
+| 32-20 not yet landed → `question`/`answer` frames absent | Low | The tap ships with the other four frame types; `question`/`answer` shapes are defined and dormant until 32-20 produces content. |
+
+### Success Metrics
+
+- [ ] The buffered `LlmCallResponse` is byte-for-byte identical with 0 vs N tap subscribers (the engine boundary is untouched).
+- [ ] `NullToolLoopEventSink` is no longer the registered sink when `EnableStreaming=true`; the live `BusToolLoopEventSink` carries `tool_call`/`tool_result`/`final` frames.
+- [ ] A dashboard/CLI client can open `GET /api/v1/llm/runs/{correlationId}/stream` and observe a live run, ending cleanly on `final`.
+- [ ] `grep` confirms zero secrets / tool arguments / prompt bodies in any SSE frame payload.
+- [ ] No new DB table; `Program.cs` DROP list and `ControlPlaneDbContextModelTests` are unchanged.
+
+## Related
+
+- Managed-LLM deep dive: `docs/superpowers/specs/2026-06-20-managed-llm-execution-deep-dive.md` (§3 Streaming — buffered for the engine, SSE for humans; §6.4 the "Streaming run tap" follow-on; §5 interactive question-back for the `question`/`answer` frames)
+- Design of record: `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§2 the call-LLM endpoint — buffered contract this tap mirrors)
+- Re-plan: `docs/superpowers/plans/2026-06-20-epic-32-37-replan.md`
+- Implementation plan: `docs/superpowers/plans/2026-06-21-32-23-streaming-run-tap-plan.md`
+- Sibling stories: `story-32-5/` (buffered endpoint + the `IToolLoopEventSink` seam this story makes live — **hard prerequisite**), `story-32-20/` (interactive question-back — produces the `question`/`answer` frame content)
+- Reused infra: `apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminTenantEventsSseEndpoint.cs` (hardening template), `apps/tamma-elsa/src/Tamma.Api/Services/Engine/Lifecycle/SseWriter.cs` (frame writer), `apps/tamma-elsa/src/Tamma.Activities/ToolExecution/ToolLoopEventEmitter.cs` + `IToolLoopEventSink.cs` (the seam), `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/WebhookSignalRegistry.cs` (in-process registry discipline)
+
+## Logging Requirements
+
+- **INFO**: tap opened (correlationId, tenantId, replay?); tap closed (correlationId, framesSent, durationMs, reason); live sink swapped in at startup (EnableStreaming=true).
+- **DEBUG**: per-frame publish (frameType, correlationId, seq — **never the frame payload verbatim if it could carry model text**); subscriber attach/detach; back-pressure drop count.
+- **WARN**: cross-tenant tap denial (404, correlationId, callerTenantId); subscriber channel saturated (drops occurring); a publish that hit a transient error (swallowed — never propagated to the run).
+- **ERROR**: the tap endpoint failing to set SSE headers; a producer-side publish that threw despite the swallow guard (a bug — must be logged, never reach the run).
+- **Structured context**: `{ correlationId, tenantId, frameType, seq, subscriberCount }` where applicable.
+- **Credential safety (LOAD-BEARING)**: NEVER log, stream, or buffer the resolved API key, `BaseUrl` auth, raw provider headers, raw prompt body, or tool arguments/outputs. `token` deltas (model output), `toolName`/`toolCallId`/`success`/`durationMs`, and `correlationId`/`seq` are safe; everything else is dropped by `RunStreamFrameScrubber`. Frame payloads, SSE wire bytes, and all logs are key-free by contract.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-21 | 1.0.0   | Initial story creation — the human-facing **streaming run tap** (`GET /api/v1/llm/runs/{correlationId}/stream` SSE) over an in-process `ILlmRunStreamBus`, fed by a live `BusToolLoopEventSink` replacing `NullToolLoopEventSink` (gated by `EnableStreaming`). Frame vocabulary `token`/`tool_call`/`tool_result`/`question`/`answer`/`final` correlated by `correlationId`. Reuses `SseWriter` + `AdminTenantEventsSseEndpoint` hardening. Optional `Accept: text/event-stream` second mode on `/llm/call` for direct human callers — engine stays buffered `application/json`, so the 32-5 buffered contract (and `ForEach`/`RetryCheck`/`SkipIfSucceeded`) is byte-for-byte unchanged. Depends on 32-5; cross-references 32-20 for the `question`/`answer` frame content. | Claude |

--- a/docs/stories/epic-32/story-32-24/32-24-csharp-harness-cli-adapter.md
+++ b/docs/stories/epic-32/story-32-24/32-24-csharp-harness-cli-adapter.md
@@ -1,0 +1,367 @@
+# Story 32-24: C# Harness / CLI Agent Adapter (single-user local — DEFERRED)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **self-hosted / single-user Tamma operator who runs harness-style agents (`claude-code`, `opencode`, `zen-mcp`) on my own machine**,
+I want a C# harness/CLI agent execution path that spawns the local agent process (or drives its local SDK session), captures its self-reported aggregate cost, and slots into the single-user managed-run surface **without** round-tripping through `POST /api/v1/llm/call`,
+So that single-user mode regains the harness/CLI parity it already has in the TypeScript `packages/providers` path — where the agent owns its own tool loop, auth, streaming, and retries — while SaaS keeps exactly one execution path (the API-provider path) and harness providers stay structurally unreachable there.
+
+## Priority
+
+**P3 — DEFERRED.** This story is explicitly **not** needed for SaaS and is **not** a blocker for the call-LLM endpoint (32-5), the SaaS gate (32-4), or any Wave-F / billing / analytics story. It restores single-user harness parity that today exists only in the TypeScript path; the C# engine currently **rejects** harness providers outright (`HttpProviderClient.NonHttpProviders` → `ProviderNotSupportedException`). Sequence it **after** the LLM-API path (32-5) and the gate (32-4) are landed — they define the seams this adapter plugs into without traversing the endpoint. It can ship at any later point single-user harness execution is wanted; nothing downstream waits on it.
+
+> **DEFERRED NOTE (read first).** Per the managed-LLM deep dive §1 + §6 item 6 and the revised-agent design §5.3, harness/CLI providers are a **single-user-only LOCAL affordance** and are **legitimately exempt** from `/llm/call` mediation: they spawn a local process, hold their own auth, and run their own loop, so routing them through the central endpoint adds a hop with **no security benefit** (the cross-cutting rule targets *external API/provider* calls — a local process is not one). In SaaS the 32-4 gate makes them unreachable (`400 SAAS_PROVIDER_NOT_ALLOWED`). This adapter therefore **never calls `POST /api/v1/llm/call`** and **never resolves a remote credential** — it is the local counterpart to 32-5's API path, not a second client of it.
+
+## Context
+
+Tamma has **two provider hierarchies** (deep dive §1):
+
+| | API providers | Harness / SDK providers |
+|---|---|---|
+| Interface (TS) | `ILLMProvider`/`IAIProvider`, `type:'llm-api'` | `IAgentProvider`/`ICLIAgentProvider`, `type:'cli-agent'` |
+| Execution | Tamma owns request / tool-loop / streaming / retries; HTTPS to provider | Provider owns its **own** loop / auth / streaming / retries — `ClaudeAgentProvider` `spawn('claude', -p --output-format stream-json)`; `OpenCodeProvider` SDK session |
+| Cost | per-token via `IProviderPricingService` | **aggregate `costUsd` only** — no input/output token split |
+| In the C# engine today | **the only path** (32-5) | **rejected** — `HttpProviderClient.NonHttpProviders = { claude-code, claude-code-cli, opencode, opencode-cli, zen-mcp, zen }` throws `ProviderNotSupportedException` (`HttpProviderClient.cs:57-92`) |
+
+So there is **no C# harness adapter today**. The TypeScript implementations are mature and are the porting source:
+
+- `packages/providers/src/claude-agent-provider.ts` — `ClaudeAgentProvider implements IAgentProvider, ICLIAgentProvider` (`name = 'claude-code'`). Spawns `claude -p --output-format stream-json`, parses the stream-json message protocol for progress + the final `result.cost_usd`, supports `--resume <sessionId>`, `--dangerously-skip-permissions`, `--allowedTools`, returns an `AgentTaskResult { success, output, costUsd, durationMs, error? }`.
+- `packages/providers/src/opencode-provider.ts` — `OpenCodeProvider implements IAgentProvider, ICLIAgentProvider` (`name = 'opencode'`). Lazily imports `@opencode-ai/sdk`, connects to a **local** OpenCode server, creates/resumes a `session`, calls `client.session.prompt(...)`, returns the same `AgentTaskResult` shape (`sessionResume: true`).
+- `packages/providers/src/zen-mcp-provider.ts` — MCP-transport harness (the `zen`/`zen-mcp` keys).
+- Contracts: `packages/providers/src/agent-types.ts` (`IAgentProvider.executeTask(config, onProgress)`, `AgentTaskConfig`, `AgentProgressEvent`), and `AgentTaskResult` in `packages/shared/src/types/index.ts:245` (`{ success, output, costUsd, durationMs, error? }`).
+
+This story ports a single-user **local** execution path for these into C#. It does **not** introduce harness execution to SaaS, does **not** change `/llm/call`, and does **not** change the API-provider path. It is the local sibling of 32-5: where 32-5's `IManagedAgent` resolves the **LLM-API-backed** backend, this story provides the **harness-backed** backend that the *single-user* resolver may return, so that single-user workflows treat all agents uniformly while SaaS sees only the one API path.
+
+## Acceptance Criteria
+
+1. An **`ICliAgentExecutor`** contract and concrete C# harness adapters exist under `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Cli/`:
+   - `ClaudeCodeAgentExecutor` — spawns `claude -p --output-format stream-json …` via `System.Diagnostics.Process`, parses the stream-json line protocol, captures the final `result.cost_usd` and `session_id`, supports resume/allowed-tools/permission-mode flags. Ports `claude-agent-provider.ts` semantics 1:1.
+   - `OpenCodeAgentExecutor` — drives the local OpenCode server (create/resume `session` → `session.prompt`) via its local HTTP/SDK surface, returning the aggregate result. Ports `opencode-provider.ts` semantics.
+   - (Stub-acceptable for v1) `ZenMcpAgentExecutor` — the MCP-transport harness; may be a documented `NotImplemented` placeholder behind the same contract if the C# MCP client (deep dive §4 / `ProviderSession.cs:87`) is not yet ported, **but** it MUST register and resolve so the surface is complete.
+2. The adapters return a typed **`CliAgentRunResult`** carrying at minimum: `Provider`, `Model`, `Success`, `Output`/`ResponseText`, **`CostUsd` (aggregate only — see AC4)**, `DurationMs`, `SessionId?`, `ExitCode?`, and on failure `FailureCode` + `FailureReason`. The shape is convertible to the 32-5 `AgentRunResult` so single-user callers consume one result type (see AC6).
+3. **This path NEVER traverses `POST /api/v1/llm/call`** and **NEVER resolves a remote provider credential.** The adapter holds no API key; the local agent process owns its own auth (e.g. the user's local `claude` login, the local OpenCode server). A unit/architecture test asserts the executor injects **no** `TammaApiClient`, **no** `IProviderCredentialResolver`, and **no** `HttpClient`-to-`/llm/call`.
+4. **Cost is aggregate-only.** `CliAgentRunResult.CostUsd` is the harness's self-reported total (`result.cost_usd` for claude-code; the session total for opencode). There is **no input/output token split**, so **`IProviderPricingService.Compute(...)` is NOT used on this path** — metering differs from the API path. `InputTokens`/`OutputTokens` on the converted `AgentRunResult` are `0` (or `null` where the type allows) and a flag/marker (`CostBasis = "harness-aggregate"`) records that the cost is the harness aggregate, not a price-book computation. Downstream (32-9 / 34-5 / 36) MUST treat a harness run as `CredentialSource = "local-harness"` with no platform markup (markup applies only to platform-key API runs — rule 7).
+5. **Single-user-only enforcement (defence in depth).** The adapter is registered/usable **only when `ITammaModeProvider` reports single-user mode.** In SaaS the adapter is never wired into the resolver, AND independently the 32-4 `ISaaSProviderGate` already denies any `AuthModel = "cli-token"` provider (`SAAS_PROVIDER_NOT_ALLOWED`). A test asserts: (a) in single-user mode a `claude-code` agent resolves to a harness executor; (b) in SaaS mode the same resolution is refused (gate-denied / never-wired) — the harness executor is structurally unreachable.
+6. **Single-user resolver integration without `/llm/call`.** The single-user agent resolution path (32-2 / `IManagedAgentResolver`) returns a harness-backed `IManagedAgent` (or an `IManagedAgent` adapter wrapping `ICliAgentExecutor`) when the resolved provider's `AuthModel == "cli-token"`. `IManagedAgent.RunAsync(...)` for a harness-backed agent delegates to the `ICliAgentExecutor` and maps `CliAgentRunResult → AgentRunResult` (Success, ResponseText, CostUsd, DurationMs, CredentialSource=`local-harness`, FailureCode/Reason), so workflow callers and the 32-6 action trail / 32-8 outcome capture get the **same** `AgentRunResult` record regardless of backend — exactly as 32-5's "callers never branch on backend" contract states, but with the LLM call replaced by a local process spawn.
+7. **`HttpProviderClient` rejection is no longer the single answer for single-user.** The `NonHttpProviders` reject path (`ProviderNotSupportedException`) remains the correct behaviour for the **HTTP** dispatch layer and for **SaaS**, and is **unchanged**; harness providers are simply routed to the new executor *before* reaching `HttpProviderClient` on the single-user managed path. A test asserts SaaS still throws/denies, while single-user routes to the executor.
+8. **DCB events** mirror 32-5's run lifecycle so the action trail is uniform: `AGENT.RUN.STARTED`, and exactly one terminal `AGENT.RUN.SUCCESS` / `AGENT.RUN.FAILED`, emitted via the (single-user) `IEventRepository`, tagged `{ agentId, version, provider, model, role, correlationId, credentialSource:"local-harness", backend:"cli-harness" }`; `AGENT.RUN.FAILED` adds `failureCode`. No new event types are introduced — harness runs reuse the 32-5 lifecycle.
+9. **Failures never lose the run record** (same posture as 32-5 AC7). A spawn failure (binary missing / non-zero exit), a local-SDK connection failure, a malformed stream-json line, a budget-exceeded (`maxBudgetUsd`), or a cancellation produces a typed `CliAgentRunResult { Success=false, FailureCode, FailureReason }` (with whatever aggregate cost the harness reported before failure) — never an unhandled exception that drops the run. The only allowable throw is a contract violation (e.g. null request).
+10. **Security / sandboxing.** The spawned process is constrained to the tenant's (sole user's) checkout / working directory; the prompt and any agent stdout that re-enters Tamma context pass through the existing `IContentSanitizer` / secret-redaction path before being persisted or logged. Process args, env, and the rendered prompt are **never** logged verbatim if they could contain secrets; only the safe summary (provider, model, sessionId, exit code, cost, duration) is logged.
+11. **Unit tests** cover: claude-code happy path (stream-json parsed → cost captured), opencode happy path (session create + prompt), spawn-failure, non-zero exit, malformed stream-json line, budget-exceeded, cancellation, single-user-allowed vs SaaS-denied (AC5), no-`/llm/call`-traversal + no-credential-injection (AC3), and `CliAgentRunResult → AgentRunResult` mapping (AC6) including `CostBasis = "harness-aggregate"` + `CredentialSource = "local-harness"`.
+
+## Technical Design
+
+### Where it lives
+
+```
+apps/tamma-elsa/src/Tamma.Api/Services/Agents/Cli/
+  ICliAgentExecutor.cs              # NEW — the harness execution contract (the local sibling of the inline tool loop)
+  CliAgentRunResult.cs             # NEW — harness outcome record (aggregate cost; convertible to AgentRunResult)
+  CliAgentRunRequest.cs            # NEW — input (prompt, cwd, model, allowedTools, permissionMode, maxBudgetUsd, sessionId, correlationId)
+  ClaudeCodeAgentExecutor.cs       # NEW — port of claude-agent-provider.ts (spawn + stream-json)
+  OpenCodeAgentExecutor.cs         # NEW — port of opencode-provider.ts (local SDK session)
+  ZenMcpAgentExecutor.cs           # NEW — MCP-transport harness (stub-acceptable behind contract for v1)
+  StreamJsonMessageParser.cs       # NEW — parses `claude -p --output-format stream-json` line protocol
+  HarnessAgentBackend.cs           # NEW — IManagedAgent adapter wrapping ICliAgentExecutor (single-user resolver target)
+  CliAgentExecutorRegistry.cs      # NEW — provider-key → ICliAgentExecutor, single-user-gated registration
+
+apps/tamma-elsa/src/Tamma.Api/Extensions/
+  HarnessAgentServiceCollectionExtensions.cs   # NEW — DI wiring, registered ONLY in single-user mode
+```
+
+> **No new control-plane / public-schema table is created by this story.** The harness path persists only through the existing tenant `IEventRepository` (`domain_events`) and the 32-6 action trail. There is therefore **nothing to append to the `Program.cs` startup-reset DROP list** ("Wiping Tamma-managed public-schema tables"). If a later revision adds a CP table (e.g. a harness session registry), it MUST be appended to that wipe list and to the `ControlPlaneDbContextModelTests.Model_Has_ExpectedControlPlaneEntities` strict `BeEquivalentTo` list — but v1 adds neither.
+
+### `ICliAgentExecutor` contract (C#)
+
+```csharp
+namespace Tamma.Api.Services.Agents.Cli;
+
+/// <summary>
+/// Single-user LOCAL harness/CLI agent execution. The local counterpart to the
+/// API-provider path in <c>IManagedAgent</c> (32-5): the agent owns its OWN loop,
+/// auth, streaming, and retries by spawning a local process / driving a local SDK
+/// session. This path NEVER calls POST /api/v1/llm/call and NEVER resolves a remote
+/// provider credential — there is no remote credential to centralize (design §5.3).
+///
+/// In SaaS this is structurally unreachable: the 32-4 gate denies AuthModel="cli-token"
+/// (SAAS_PROVIDER_NOT_ALLOWED) and the executor is never wired into the SaaS resolver.
+/// </summary>
+public interface ICliAgentExecutor
+{
+    /// <summary>Canonical provider key this executor handles ("claude-code" | "opencode" | "zen-mcp").</summary>
+    string ProviderKey { get; }
+
+    /// <summary>True if the local harness binary / server is present and usable (ports isAvailable()).</summary>
+    Task<bool> IsAvailableAsync(CancellationToken ct);
+
+    /// <summary>
+    /// Run the local harness end-to-end. NEVER throws on an expected failure
+    /// (spawn failure, non-zero exit, SDK connect failure, malformed output,
+    /// budget exceeded, cancellation): returns a typed CliAgentRunResult with
+    /// Success=false + FailureCode/Reason so the run record is always captured.
+    /// Cost is the harness AGGREGATE only — no per-token split.
+    /// </summary>
+    Task<CliAgentRunResult> RunAsync(CliAgentRunRequest request, CancellationToken ct);
+}
+```
+
+### `CliAgentRunRequest` (input — mirrors TS `AgentTaskConfig`)
+
+```csharp
+public sealed record CliAgentRunRequest
+{
+    public required string Provider { get; init; }       // "claude-code" | "opencode" | "zen-mcp"
+    public string? Model { get; init; }
+    public required string Prompt { get; init; }         // already rendered (Epic 27) + sanitized
+    public required string WorkingDirectory { get; init; } // the tenant/sole-user checkout (sandbox)
+    public IReadOnlyList<string>? AllowedTools { get; init; }
+    public string? PermissionMode { get; init; }         // "default" | "bypassPermissions"
+    public decimal? MaxBudgetUsd { get; init; }          // harness-enforced ceiling
+    public string? SessionId { get; init; }              // resume (--resume / session.id)
+    public required string CorrelationId { get; init; }  // workflow instance id (event/audit tag)
+}
+```
+
+### `CliAgentRunResult` (output — aggregate cost)
+
+```csharp
+public sealed record CliAgentRunResult
+{
+    public required string Provider { get; init; }
+    public string? Model { get; init; }
+    public required bool Success { get; init; }
+    public string? ResponseText { get; init; }           // the harness "output"
+
+    public decimal CostUsd { get; init; }                // AGGREGATE ONLY (result.cost_usd / session total)
+    public long DurationMs { get; init; }
+    public string? SessionId { get; init; }              // for resume
+    public int? ExitCode { get; init; }
+
+    public required string CorrelationId { get; init; }
+
+    // Populated only when Success == false:
+    public string? FailureCode { get; init; }   // SPAWN_FAILED | NON_ZERO_EXIT | SDK_CONNECT_FAILED
+                                                 // | MALFORMED_OUTPUT | BUDGET_EXCEEDED | CANCELLED | NOT_AVAILABLE
+    public string? FailureReason { get; init; } // key-free, secret-free message
+}
+```
+
+### Conversion to the shared `AgentRunResult` (32-5) — uniform consumer surface
+
+`HarnessAgentBackend` adapts an `ICliAgentExecutor` into an `IManagedAgent` so the **single-user** resolver returns one type. The mapping makes the aggregate-vs-per-token difference explicit:
+
+```csharp
+// inside HarnessAgentBackend.RunAsync(ManagedAgentRequest req, CancellationToken ct):
+//   1. emit AGENT.RUN.STARTED { ..., backend="cli-harness", credentialSource="local-harness" }
+//   2. var cli = await _executor.RunAsync(MapRequest(req), ct);     // local spawn / SDK — NO /llm/call
+//   3. var result = new AgentRunResult {
+//          AgentId, Version, Provider = cli.Provider, Model = cli.Model ?? "",
+//          Role = req.Role,
+//          InputTokens = 0, OutputTokens = 0,            // harness gives no split
+//          CostUsd = cli.CostUsd,                        // AGGREGATE — NOT IProviderPricingService.Compute(...)
+//          DurationMs = cli.DurationMs,
+//          Success = cli.Success, ResponseText = cli.ResponseText,
+//          ToolCalls = Array.Empty<ToolCallSummary>(),   // harness owns its own loop; tool calls not surfaced per-call
+//          CorrelationId = req.CorrelationId,
+//          CredentialSource = "local-harness",           // distinct from "byok" | "platform" → no markup (rule 7)
+//          FailureCode = cli.FailureCode, FailureReason = cli.FailureReason,
+//      };
+//   4. emit AGENT.RUN.SUCCESS / FAILED (exactly one terminal event)
+//   5. return result;
+```
+
+> **Cost metering divergence (AC4) — load-bearing.** The API path computes cost from a per-token price book (`IProviderPricingService.Compute(provider, model, in, out)`). The harness path has **only an aggregate** `costUsd` from the agent itself. So this path **skips the price book entirely**, sets `InputTokens/OutputTokens = 0`, tags `CredentialSource = "local-harness"`, and records `CostBasis = "harness-aggregate"`. Markup (34-5) applies only to `platform` API runs; BYOK API runs zero the token sell price but still compute cost; **harness runs are neither** — they are local, user-paid, and reported at face value. 32-9 / 36 must branch on `CredentialSource`/`CostBasis` so a harness run is not double-priced or markup-applied.
+
+### `ClaudeCodeAgentExecutor` — porting `claude-agent-provider.ts`
+
+```csharp
+// args mirror claude-agent-provider.ts buildArgs():
+//   claude -p --output-format stream-json
+//          [ --model <model> ]
+//          [ --allowedTools "<csv>" ]
+//          [ --dangerously-skip-permissions ]   // only when PermissionMode == bypassPermissions
+//          [ --resume <sessionId> ]
+// spawn via System.Diagnostics.Process (RedirectStandardOutput/Error, WorkingDirectory = req.WorkingDirectory).
+// Read stdout line-by-line → StreamJsonMessageParser:
+//   - "assistant"/"text" frames → progress (sanitized before any persist/log)
+//   - terminal "result" frame → capture result.cost_usd (setCost) + session_id
+// On exit: Success = (exitCode == 0 && result frame seen); CostUsd = totalCost; SessionId captured.
+// Failure mapping: process start throws → SPAWN_FAILED; exit != 0 → NON_ZERO_EXIT;
+//   no/garbled result frame → MALFORMED_OUTPUT; budget breach → BUDGET_EXCEEDED; ct → CANCELLED.
+```
+
+### `OpenCodeAgentExecutor` — porting `opencode-provider.ts`
+
+```csharp
+// Connects to the LOCAL OpenCode server (the SDK connects to a local process — opencode-provider.ts:66).
+//   session = SessionId is null ? create() : resume(SessionId);
+//   response = await session.prompt({ prompt, model?, allowedTools? });
+//   CostUsd = response session total (aggregate); SessionId = session.id (sessionResume: true).
+// Connection failure → SDK_CONNECT_FAILED; not running / unavailable → NOT_AVAILABLE.
+// NOTE: the local OpenCode server's own auth is the user's — Tamma holds no key here.
+```
+
+### Single-user-only DI wiring
+
+```csharp
+// HarnessAgentServiceCollectionExtensions.AddHarnessAgentExecution(services, mode):
+//   if (mode.IsSingleUser) {           // ITammaModeProvider — process-stable (TammaMode.cs)
+//       services.AddSingleton<ICliAgentExecutor, ClaudeCodeAgentExecutor>();
+//       services.AddSingleton<ICliAgentExecutor, OpenCodeAgentExecutor>();
+//       services.AddSingleton<ICliAgentExecutor, ZenMcpAgentExecutor>();
+//       services.AddSingleton<CliAgentExecutorRegistry>();
+//       services.AddSingleton<HarnessAgentBackend>();   // IManagedAgent adapter the single-user resolver may return
+//   }
+//   // In SaaS: NOTHING is registered. The 32-4 gate is the independent backstop.
+```
+
+The single-user resolver (32-2) selects the harness backend when the resolved provider's `AuthModel == "cli-token"`; in SaaS that branch is never taken because such providers are gate-denied at selection.
+
+## Dependencies
+
+**Internal:**
+
+- **Story 32-5** (Managed agent execution layer) — defines `AgentRunResult`, `IManagedAgent`, and the `AGENT.RUN.*` lifecycle this story maps onto. This story is the **local harness counterpart** to 32-5's API path; same result type, different backend. Hard prerequisite (for the shared `AgentRunResult`/event shape).
+- **Story 32-4** (SaaS provider auth gating — API-key only) — provides `ISaaSProviderGate` that denies `AuthModel="cli-token"` providers (`SAAS_PROVIDER_NOT_ALLOWED`); the independent backstop that keeps this adapter unreachable in SaaS. Hard prerequisite.
+- **Story 32-2** (Agent registry, resolution & RBAC API) — the single-user resolver returns a harness-backed `IManagedAgent` for `cli-token` providers. Prerequisite for the resolver integration (AC6).
+- **Story 34-11** (Provider Cost Price-Book) — defines the `Provider` entity carrying `AuthModel` (`api-key` | `cli-token`), the field this path keys on. Note: this path deliberately does **not** use `ProviderModelPrice`/`IProviderPricingService.Compute` (aggregate cost only — AC4).
+- **Epic 27** (prompt/convention render) — the prompt fed to the harness is still rendered tenant→system→error (never empty/plain); harness execution does not bypass prompt resolution.
+- **`IContentSanitizer` / secret redaction** (existing) — prompt in + agent stdout out pass through sanitization (AC10).
+- **`ITammaModeProvider`** (`TammaMode.cs`) — single-user vs SaaS gate for registration (AC5).
+
+**Consumers (downstream, not blockers):**
+
+- **Story 32-6** (action trail) — consumes the shared `AGENT.RUN.*` events; harness runs are indistinguishable in shape (`backend="cli-harness"` tag aside).
+- **Story 32-8** (outcome capture) — consumes the `AgentRunResult` from a harness run.
+- **Story 32-9** (usage & cost emission) — must branch on `CredentialSource="local-harness"` / `CostBasis="harness-aggregate"` so harness cost is reported at face value (no price-book recompute, no markup).
+
+**External:**
+
+- Local `claude` CLI (claude-code), a local OpenCode server + `@opencode-ai/sdk`-equivalent surface, and (deferred) a C# MCP client for zen-mcp. All are the **user's local** tools — Tamma holds none of their credentials. Porting source: `packages/providers/src/{claude-agent-provider,opencode-provider,zen-mcp-provider}.ts` + `agent-types.ts`.
+
+## Testing Strategy
+
+1. **Unit — claude-code happy path:** fake/seam over `System.Diagnostics.Process`; feed a recorded stream-json transcript ending in a `result` frame with `cost_usd` + `session_id`; assert `Success=true`, `CostUsd` = the frame value, `SessionId` captured, `ExitCode=0`.
+2. **Unit — opencode happy path:** fake local SDK session; `create` then `prompt`; assert aggregate `CostUsd` + `SessionId` (resume) captured.
+3. **Unit — spawn failure:** process start throws → `Success=false, FailureCode=SPAWN_FAILED`; no throw.
+4. **Unit — non-zero exit:** exit code 1 → `FailureCode=NON_ZERO_EXIT`, any accrued cost preserved.
+5. **Unit — malformed stream-json:** garbled / missing `result` frame → `FailureCode=MALFORMED_OUTPUT`.
+6. **Unit — budget exceeded:** `MaxBudgetUsd` breached mid-run → `FailureCode=BUDGET_EXCEEDED`, accrued cost preserved.
+7. **Unit — cancellation:** `ct` cancelled → `FailureCode=CANCELLED`; process killed; no orphan.
+8. **Unit — `NOT_AVAILABLE`:** `IsAvailableAsync` false (binary/server absent) → typed failure, no throw.
+9. **Mode gate (AC5):** single-user → `claude-code` resolves to `ClaudeCodeAgentExecutor`; SaaS → resolution refused (gate-denied) / executor never registered. Both asserted.
+10. **No-`/llm/call` + no-credential (AC3):** architecture/DI test asserts the executor type injects **no** `TammaApiClient`, `IProviderCredentialResolver`, or `/llm/call` `HttpClient`. A behavioural test asserts a harness run makes zero calls to the call-LLM endpoint.
+11. **`HttpProviderClient` unchanged (AC7):** SaaS still throws `ProviderNotSupportedException` for `claude-code`/`opencode`/`zen-mcp`; single-user routes to the executor *before* reaching `HttpProviderClient`.
+12. **Mapping (AC6):** `CliAgentRunResult → AgentRunResult` sets `InputTokens=OutputTokens=0`, `CostUsd` = aggregate, `CredentialSource="local-harness"`, `CostBasis="harness-aggregate"`, and `IProviderPricingService.Compute` is **never** invoked (verified via a strict mock).
+13. **Event lifecycle (AC8):** exactly one `AGENT.RUN.STARTED` + one terminal `AGENT.RUN.SUCCESS`/`FAILED` per run via a fake single-user `IEventRepository`, tagged `backend="cli-harness"`, `credentialSource="local-harness"`; FAILED adds `failureCode`.
+14. **Sanitization (AC10):** an agent stdout line containing a secret-shaped token is redacted before persist/log; process args/prompt are not logged verbatim.
+
+Docker-bound C# suites run via `sg docker -c "dotnet test apps/tamma-elsa/..."` (session docker group is stale).
+
+## Estimated Effort
+
+5-6 days (claude-code spawn + stream-json parser is the bulk; opencode SDK seam is moderate; zen-mcp stub-acceptable for v1). **Deferred — schedule only when single-user harness parity is wanted; not on the Wave-F critical path.**
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Cli/ICliAgentExecutor.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Cli/CliAgentRunRequest.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Cli/CliAgentRunResult.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Cli/ClaudeCodeAgentExecutor.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Cli/OpenCodeAgentExecutor.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Cli/ZenMcpAgentExecutor.cs` | Create (stub-acceptable v1) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Cli/StreamJsonMessageParser.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Cli/HarnessAgentBackend.cs` | Create (IManagedAgent adapter) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Cli/CliAgentExecutorRegistry.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/HarnessAgentServiceCollectionExtensions.cs` | Create (single-user-only DI) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (call `AddHarnessAgentExecution(mode)` — registers nothing in SaaS) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/Cli/ClaudeCodeAgentExecutorTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/Cli/OpenCodeAgentExecutorTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/Cli/HarnessAgentBackendTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/Cli/HarnessModeGateTests.cs` | Create |
+
+> No EF migration, no new control-plane entity → **no `Program.cs` startup-reset DROP-list change** and **no `ControlPlaneDbContextModelTests` change** for v1. This story does not touch the single shared EF migration snapshot.
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` directory for related spikes, bugs, findings, and decisions (esp. any prior subprocess/spawn findings)
+3. Reviewed the porting source: `packages/providers/src/claude-agent-provider.ts`, `opencode-provider.ts`, `zen-mcp-provider.ts`, `agent-types.ts`, and `AgentTaskResult` (`packages/shared/src/types/index.ts:245`)
+4. Reviewed `HttpProviderClient.NonHttpProviders` (the current reject path) and confirmed it stays the correct SaaS/HTTP behaviour
+5. Confirmed 32-5 (`AgentRunResult`/`IManagedAgent`/`AGENT.RUN.*`) and 32-4 (`ISaaSProviderGate`) are landed before wiring
+6. Planned TDD approach (Red-Green-Refactor) — write the stream-json parser tests first
+
+### Key Design Decisions
+
+- **DEFERRED, single-user-only, never `/llm/call`.** This is the most important constraint: the adapter is the **local** counterpart to 32-5's API path. It spawns a process / drives a local SDK and **does not mediate through the endpoint** — by design §5.3, mediating a local process adds a hop with no security benefit. SaaS is unaffected (gate-denied + never wired).
+- **Port, don't reinvent.** The TS `claude-agent-provider`/`opencode-provider` are mature (stream-json protocol, session resume, cost capture, permission flags). The C# adapter ports their semantics 1:1; the stream-json parser is the trickiest piece and is unit-tested against recorded transcripts.
+- **Aggregate cost, not the price book.** Harness providers report only a total `costUsd` — there is no token split, so `IProviderPricingService.Compute` is deliberately **not** called here, and the cost is recorded as `CostBasis="harness-aggregate"` / `CredentialSource="local-harness"`. Downstream metering must branch on this so a harness run is reported at face value with no markup (rule 7) and no double-pricing.
+- **Two independent SaaS backstops.** (1) The adapter is not registered in SaaS (`ITammaModeProvider`). (2) Even if it were, the 32-4 gate denies `AuthModel="cli-token"`. Defence in depth — neither alone is relied upon.
+- **Uniform result type.** `HarnessAgentBackend` maps `CliAgentRunResult → AgentRunResult` so 32-6/32-8/32-9 consume harness and API runs identically (one record, `backend`/`CredentialSource` tags distinguish provenance).
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Is the harness/CLI path available? | **Yes** — the legitimate use case. `ICliAgentExecutor` registered; the resolver may return a harness-backed `IManagedAgent` for `AuthModel="cli-token"` providers. | **No** — never registered; the 32-4 gate denies `cli-token` providers (`SAAS_PROVIDER_NOT_ALLOWED`). Structurally unreachable. |
+| Whose credential / auth does a run use? | The **sole user's local** agent auth (their `claude` login, their local OpenCode server). Tamma holds **no** key; nothing to centralize. | N/A — path unreachable. (SaaS uses only the mediated API path: BYOK cabinet key → platform key, 32-3.) |
+| How is cost recorded? | Aggregate `costUsd` from the harness; `CredentialSource="local-harness"`, `CostBasis="harness-aggregate"`, no price-book compute, no markup. | N/A. (SaaS API runs: `byok` no token markup / `platform` cost × markup — 34-5.) |
+| Where do `AGENT.RUN.*` events land, and who owns the data? | The user's (sole) tenant event store via the single-user `IEventRepository`; the user owns all performance/cost data. | N/A — no harness run occurs; SaaS run data is the tenant's, tenant-scoped, never cross-tenant. |
+| Process sandbox | The user's own checkout/working directory; local tools shell out to the local filesystem. | N/A — no local process spawned in SaaS. |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`) — process-stable. | same |
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Harness path accidentally reachable in SaaS | High | Two independent backstops (not registered in SaaS + 32-4 gate denies `cli-token`); explicit SaaS-denied test (AC5). |
+| Cost double-counted or markup-applied to a harness run | High | `CredentialSource="local-harness"` + `CostBasis="harness-aggregate"`; `IProviderPricingService.Compute` never called (strict-mock test); 32-9 branches on these tags. |
+| stream-json protocol drift breaks cost/session capture | Medium | Parser unit-tested against recorded `claude -p --output-format stream-json` transcripts; failure → `MALFORMED_OUTPUT` (typed, not a throw). |
+| Spawned process leaks secrets to logs/persisted context | Medium | Prompt in + stdout out through `IContentSanitizer`/redaction (AC10); args/prompt never logged verbatim; only safe summary logged. |
+| Orphaned child process on cancel/crash | Medium | `ct`-bound process lifetime; kill-on-cancel; `CANCELLED` typed result; test asserts no orphan. |
+| Local binary/server absent | Low | `IsAvailableAsync` → `NOT_AVAILABLE` typed failure, never a throw; clear operator message. |
+| Depends on 32-5/32-4/32-2 not yet landed | Low (deferred) | Code to the interfaces; this story is explicitly sequenced after them; fakes in tests until they land. |
+
+### Success Metrics
+
+- [ ] In single-user mode, a `claude-code` / `opencode` agent runs locally and produces an `AgentRunResult` + exactly one terminal `AGENT.RUN.*` event — with **zero** calls to `POST /api/v1/llm/call` and **zero** credential resolution.
+- [ ] In SaaS mode, the harness path is unreachable (gate-denied) — proven by test; `HttpProviderClient` reject behaviour unchanged.
+- [ ] Harness runs are reported at face value (`CostBasis="harness-aggregate"`, no markup) — confirmed `IProviderPricingService.Compute` is never invoked on this path.
+- [ ] TS↔C# parity: the C# claude-code/opencode adapters reproduce the `packages/providers` semantics (cost capture, session resume, permission flags).
+
+## Related
+
+- Managed-LLM deep dive: `docs/superpowers/specs/2026-06-20-managed-llm-execution-deep-dive.md` (§1 provider duality; §6 item 6 — DEFERRED single-user C# harness/CLI adapter)
+- Design of record: `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§5.3 local CLI agent providers legitimately exempt; §4.2 `Provider.AuthModel`)
+- Sibling stories: `docs/stories/epic-32/story-32-5/` (the API-path counterpart), `story-32-4/` (the SaaS gate), `story-32-2/` (resolver), `docs/stories/epic-34/story-34-11/` (Provider entity + `AuthModel`), `story-32-9/` (usage emission must branch on `local-harness`)
+- Porting source (TS): `packages/providers/src/claude-agent-provider.ts`, `opencode-provider.ts`, `zen-mcp-provider.ts`, `agent-types.ts`; `packages/shared/src/types/index.ts:245` (`AgentTaskResult`)
+- Reject path retained: `apps/tamma-elsa/src/Tamma.Api/Services/Providers/HttpProviderClient.cs:57-92` (`NonHttpProviders`)
+
+## Logging Requirements
+
+- **INFO**: harness run started (provider, model, role, correlationId, sessionId?, cwd, mode=single-user), run completed (success, durationMs, costUsd, exitCode, sessionId), availability checks.
+- **DEBUG**: spawn argv **summary** (flag names only, never secret-bearing values), stream-json frame counts, session create/resume.
+- **WARN**: typed failure paths (`SPAWN_FAILED`, `NON_ZERO_EXIT`, `SDK_CONNECT_FAILED`, `MALFORMED_OUTPUT`, `BUDGET_EXCEEDED`, `CANCELLED`, `NOT_AVAILABLE`) with `failureCode` + correlationId.
+- **ERROR**: contract violations (null request), DCB event append failure (the run still returns its result; the append failure is logged, not swallowed silently).
+- **Structured context**: include `{ provider, model, role, correlationId, sessionId, mode, credentialSource:"local-harness", backend:"cli-harness" }` where applicable.
+- **Credential / process safety**: NEVER log the rendered prompt verbatim, the spawned process's environment, or any agent stdout that has not passed `IContentSanitizer`/secret redaction. The local agent's own auth/login is never seen by Tamma; there is no API key on this path to log. Log only the safe summary (provider, model, sessionId, exit code, cost, duration).
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-21 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-32/story-32-4/32-4-saas-provider-auth-gating-api-key-only.md
+++ b/docs/stories/epic-32/story-32-4/32-4-saas-provider-auth-gating-api-key-only.md
@@ -1,4 +1,4 @@
-# Story 32-4: SaaS Provider Auth Gating — API-key only (CLI/token providers single-user only)
+# Story 32-4: SaaS Provider Gate (call-LLM endpoint stage)
 
 Status: drafted
 
@@ -6,128 +6,101 @@ Status: drafted
 
 **ALL contributors MUST read and follow the comprehensive development process:**
 
-[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
 
 ## User Story
 
 As a **platform operator running Tamma in SaaS mode**,
-I want every agent definition, selection, and execution to be restricted to API-key (`ILLMProvider`) providers — never CLI/token (`ICLIAgentProvider`) providers,
-So that a tenant can never select or run a local-binary / token-auth agent (e.g. the Claude Code CLI) inside the managed multi-tenant service, where there is no host shell, no per-tenant local credential store, and no isolation boundary for a subprocess agent.
+I want the very first composition stage inside the `call-LLM` endpoint (`POST /api/v1/llm/call`) to inspect the resolved provider's auth model and refuse CLI/token (harness) providers before any agent resolution, credential lookup, or provider call happens,
+So that a tenant can never select or run a local-binary / token-auth agent (e.g. the Claude Code CLI, OpenCode, Zen MCP) inside the managed multi-tenant service — where there is no host shell, no per-tenant local credential store, and no isolation boundary for a subprocess agent — while a self-hosted single-user keeps full local harness access.
 
 ## Priority
 
-P0 — Required guardrail before the managed-execution layer (32-5) goes live; a SaaS tenant selecting a CLI/token provider is a correctness and security defect, not a degraded experience.
+P0 — The fail-closed gate stage of the 32-5 lynchpin endpoint. Without it, `ManagedAgent.RunAsync` would proceed to resolve a credential for, and dispatch, a `cli-token` provider in SaaS — a correctness and security defect, not a degraded experience. This story is sequenced as **gate stage of sequence F** (the call-LLM endpoint), implemented just before 32-5.
+
+## Context
+
+This story is a **REWRITE**. The previous framing (a standalone gating story with its own selection-boundary activity, its own provider-auth registry, and resolver-side skip logic in `ProviderChainResolver`) is **superseded** by the locked agent architecture (`docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md`). Under the locked model:
+
+- A workflow STEP never calls a provider directly; the LLM path is mediated by a single internal endpoint `POST /api/v1/llm/call`, composed by `ManagedAgent.RunAsync` (Story 32-5). That endpoint's **composition step 1 is the gate** (design §2.6: "Gate (32-4) — `ISaaSProviderGate.InspectAsync` … CLI-token providers excluded in SaaS; unknown providers denied fail-closed").
+- So 32-4 is no longer a free-standing activity/endpoint. It is **the gate stage**: a small, pure-ish service `ISaaSProviderGate` in `Tamma.Api/Services/Security/` that the endpoint invokes **before** agent resolution (step 2), credential resolution (step 3), and the provider call (step 5). It returns a **typed decision**; the endpoint maps that decision to the §2.4 error envelope. The gate never throws a bare exception that would leak a 500.
+- Provider SaaS-eligibility is no longer a hard-coded `CliTokenProviders` set inside this story. It is driven by the new **`Provider` entity's `AuthModel` field** (`api-key` | `cli-token`) introduced by sibling story **34-11** (Provider Cost Price-Book, design §4.2: "`AuthModel` … feeds 32-4 SaaS-eligibility"). `cli-token` ⇒ not SaaS-eligible. **Until 34-11 lands**, a static allowlist of API-key providers is the interim source of truth (documented below) — this story is buildable and testable against the interim source and flips to the entity read with no AC change.
+
+The provider duality this gate enforces is the deep-dive's §1 invariant: API providers (`ILLMProvider`/`IAIProvider`, `type:'llm-api'`) run server-side inside the endpoint; harness providers (`ICLIAgentProvider`, `type:'cli-agent'` — `claude-code`, `opencode`, `zen-mcp`) "spawn local processes … run their own loop … routing them through the endpoint adds a hop with no security benefit … In SaaS the 32-4 gate makes them structurally unreachable (`400 SAAS_PROVIDER_NOT_ALLOWED`)." This story delivers exactly that structural unreachability.
 
 ## Acceptance Criteria
 
-1. A **provider capability registry** (`IProviderAuthRegistry`) classifies every known provider by its auth model — `ApiKey` vs `CliToken` — and exposes whether it is **SaaS-eligible** (`ApiKey` ⇒ eligible; `CliToken` ⇒ ineligible). The known-provider source of truth stays the existing `ProviderAllowlist.DefaultProviders` list; this story adds the auth-model dimension, it does not duplicate the allowlist.
-2. In **SaaS mode**, creating, versioning, or selecting an agent whose resolved provider is `CliToken` returns **HTTP 400** with code `SAAS_PROVIDER_NOT_ALLOWED`, the offending provider named in the message and `TammaError.Context`, and the agent is **not** persisted/selected.
-3. In **single-user mode**, `CliToken` providers remain fully usable end-to-end — the gate is a no-op (no rejection, no event, no telemetry counter increment).
-4. The managed-execution entrypoint (32-5) **and** the existing provider-chain resolver (`ProviderChainResolver`) consult the registry. In SaaS mode the resolver **skips** `CliToken` entries from a chain (treats them as ineligible, not merely unhealthy); if a chain resolves to *only* ineligible entries, resolution fails closed with `SAAS_PROVIDER_NOT_ALLOWED` and emits `AGENT.PROVIDER.GATED`.
-5. Mode is read **once** from the existing process-wide `ITammaModeProvider` (`TammaMode.cs`) — no new per-request mode plumbing, no per-request mode ambiguity. The gate is a pure function of `(mode, providerName)`.
-6. The gate **reuses** the existing `ProviderAllowlist` / `ActionGate` seams in `Tamma.Activities/Security/` rather than duplicating them; new logic is **additive and fail-closed** — an unknown provider name (not in the registry) is treated as ineligible in SaaS mode (deny), and the existing allowlist rejection still runs first.
-7. A DCB event **`AGENT.PROVIDER.GATED`** is appended (via `IEventRepository`) on every gated rejection, with `Data` = `{ provider, authModel, mode, reason, role?, action? }` and tenant-scoped `Tags`. Single-user mode never emits it.
-8. An OpenTelemetry counter `tamma.provider.gated` is incremented on each gating decision, tagged `provider`, `auth_model`, `reason`. (Mirrors the `KekRotationMetrics` / existing-metrics pattern.)
-9. **Tests** cover: SaaS rejects a `CliToken` provider at **selection** (agent create/version) and at **execution** (resolver / managed entrypoint); single-user allows the same `CliToken` provider in both paths; an `ApiKey` provider passes in **both** modes; an unknown provider is denied (fail-closed) in SaaS and (per existing allowlist) rejected in single-user; the gate is pure and emits exactly one event + one counter increment per gated decision.
+1. An **`ISaaSProviderGate`** interface and a **`SaaSProviderGate`** implementation exist in `apps/tamma-elsa/src/Tamma.Api/Services/Security/`. `InspectAsync(ProviderGateContext, CancellationToken)` returns a typed `ProviderGateDecision` (`{ Allowed, Outcome, Reason?, AuthModel?, HttpStatusHint }`) — it does **not** throw to signal a denial.
+2. **Mode is read once** from the process-stable `ITammaModeProvider` (`Tamma.Api/Services/PromptStore/TammaMode.cs`). In **single-user / self-hosted mode** the gate is a hard no-op: every provider (including `cli-token` harness providers) ⇒ `Allowed`, **zero** events, **zero** metric increments — harness providers are a legitimate local affordance (design §5.3).
+3. In **SaaS mode**, a provider whose resolved `AuthModel == cli-token` (harness providers: `claude-code`, `opencode`, `zen-mcp`, …) ⇒ **denied** with `Outcome = SaasProviderNotAllowed` and `HttpStatusHint = 400`; the endpoint maps this to **HTTP 400** body `{ "success": false, "failureCode": "SAAS_PROVIDER_NOT_ALLOWED", … }` per design §2.4. This is the selection/execution backstop.
+4. In **SaaS mode**, an **unknown** provider (no `Provider` entity / not in the interim allowlist) ⇒ **denied fail-closed** with `Outcome = SaasProviderNotAllowed`, `HttpStatusHint = 400`. Eligibility that cannot be determined (entity read fails, mode-source unavailable) ⇒ **DENY** — never a silent allow (consistent with `feedback_resolution_no_empty_fallback`: never fall back to an empty/permissive default).
+5. In **SaaS mode**, a SaaS **auth / entitlement** rejection of the tenant (the caller is not authorized to use the managed LLM path for this tenant) ⇒ denied with `Outcome = TenantNotEntitled`, `HttpStatusHint = 403`; the endpoint maps it to **HTTP 403** (design §2.4). Entitlement evaluation is delegated to the existing SaaS auth/entitlement seam (Epic 34 gating) — this story owns only the provider-auth-model branch and the typed surfacing of the entitlement result; it does not re-implement entitlement.
+6. In **SaaS mode**, an **`api-key`** provider (`anthropic`, `openai`, `openrouter`, `google`/`gemini`, …) that is entitled ⇒ `Allowed`, **no event**, no `failure` metric.
+7. **Eligibility source of truth:** the gate consults the `Provider` entity's `AuthModel` via the 34-11 `IProviderPricingService`-adjacent provider read (`IProviderAuthLookup` — a thin read seam this story defines and 34-11 backs). **Interim (pre-34-11):** `IProviderAuthLookup` is implemented by a static `StaticProviderAuthLookup` keyed off the existing `ProviderAllowlist.DefaultProviders` set, classifying `claude-code`/`opencode`/`zen-mcp` as `cli-token` and everything else as `api-key`. Swapping to the entity-backed lookup when 34-11 lands is a DI registration change only — no AC/contract change. Provider-name matching is case-insensitive and trimmed.
+8. On a **SaaS denial**, the gate emits **exactly one** DCB event `AGENT.PROVIDER.GATED` via the tenant `IEventRepository` (`Data` = `{ provider, authModel, mode, reason, role?, action? }`, tenant-scoped `Tags`) and increments **exactly one** OpenTelemetry counter `tamma.provider.gated` (tags `provider`, `auth_model`, `reason`). Event-append failure is logged and swallowed so it never converts a clean typed decision into a 500. Single-user mode emits neither.
+9. The decision is **idempotent and side-effect-bounded**: `InspectAsync` is called once per `call-LLM` invocation by `ManagedAgent.RunAsync` (step 1); an `Allowed` decision has zero side effects; a denial has exactly one event + one metric increment. The gate touches **provider names and the mode only** — never a key, token, or secret.
+10. **Tests** cover the full mode × auth-model × known/unknown matrix (see Testing Strategy): single-user allows all; SaaS allows entitled `api-key`, denies `cli-token` (400), denies unknown fail-closed (400), denies un-entitled tenant (403); exactly one event + one metric per SaaS denial; zero side effects on allow; the typed decision maps to the §2.4 envelope codes; credential safety (no secret ever reaches the gate).
 
 ## Technical Design
 
-### Where gating is enforced (two seams)
+### Where the gate sits in the endpoint (composition step 1)
 
-The constraint is enforced at the **two boundaries a `CliToken` provider can enter the system in SaaS**:
+The gate is the first stage of `ManagedAgent.RunAsync`, invoked by the `POST /api/v1/llm/call` handler (`LlmCallEndpoints.cs`, Story 32-5). It runs **before** agent resolution, credential resolution, and the provider call — the design §2.6 order:
 
 ```
-                        ┌─────────────────────────────────────────────┐
-                        │  ITammaModeProvider.Mode  (process-stable)   │
-                        └───────────────────────┬─────────────────────┘
-                                                 │
-  (A) SELECTION boundary                         │      (B) EXECUTION boundary
-  AgentRegistryService (32-2) /                  │      ProviderChainResolver  +
-  AgentEndpoints create/version  ───────────────▶│◀───  managed-execution entrypoint (32-5)
-                                                 │
-                                   ┌─────────────▼─────────────┐
-                                   │  ISaaSProviderGate         │  ← NEW, the single seam
-                                   │  .Inspect(provider, role?, │
-                                   │           action?)         │
-                                   └─────────────┬─────────────┘
-                                                 │ consults
-                          ┌──────────────────────┴───────────────────────┐
-                          │ IProviderAuthRegistry (NEW)                   │
-                          │   AuthModel(provider) → ApiKey | CliToken     │
-                          │   IsSaaSEligible(provider) → bool             │
-                          │   (known set = ProviderAllowlist.Default...)  │
-                          └───────────────────────────────────────────────┘
+POST /api/v1/llm/call   (LlmCallEndpoints -> ManagedAgent.RunAsync)
+  │
+  ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│ STEP 1  ── ISaaSProviderGate.InspectAsync(ctx)            ◄── THIS STORY  │
+│            mode = ITammaModeProvider.Mode  (process-stable)               │
+│            single-user → Allowed (no event, no metric)                    │
+│            SaaS:                                                          │
+│              authModel = IProviderAuthLookup.AuthModel(provider)          │
+│                cli-token → DENY  (Outcome=SaasProviderNotAllowed, 400)    │
+│                unknown   → DENY fail-closed (400)                         │
+│                api-key + not entitled → DENY (Outcome=TenantNotEntitled,  │
+│                                                403)                       │
+│                api-key + entitled → Allowed                              │
+└───────────────────────────────┬─────────────────────────────────────────┘
+                                 │ ProviderGateDecision (typed)
+                                 ▼
+   denied → handler maps to §2.4 envelope (400 SAAS_PROVIDER_NOT_ALLOWED / 403)
+   allowed → STEP 2 resolve agent (32-2) → STEP 3 credential (32-3)
+             → STEP 4 prompt (Epic 27) → STEP 5 provider call (32-5) → meter
 ```
 
-- **(A) Selection** is the *primary* gate — reject at create/version/select so a bad config never lands in `agent_configs`. This is where users get the actionable 400.
-- **(B) Execution** is the *fail-closed backstop* — a config that predates the gate, or a default chain that still lists a CLI provider, must not silently execute a `CliToken` provider in SaaS. The resolver skips it; if nothing eligible remains, it fails closed.
+The provider name available at step 1 comes from the request's `persona`/`agentId`/explicit `model`+`provider` hint. When the request names a `persona`/`agentId` whose provider is only known after resolution, the endpoint performs a **lightweight provider lookup ahead of full resolution** (the resolver exposes the provider for a persona without materialising the full config), so the gate still runs first. The gate is a pure function of `(mode, providerName, tenantEntitlement)` and never resolves a credential.
 
-Single-user mode short-circuits both: `ISaaSProviderGate.Inspect` returns `Allowed` immediately when `Mode == SingleUser`.
+### `ISaaSProviderGate` (the gate stage contract)
 
-### Provider auth registry — `IProviderAuthRegistry`
-
-New file `apps/tamma-elsa/src/Tamma.Activities/Security/IProviderAuthRegistry.cs` + `ProviderAuthRegistry.cs` (co-located with `ProviderAllowlist.cs` — same seam, same project).
+New files `apps/tamma-elsa/src/Tamma.Api/Services/Security/ISaaSProviderGate.cs` + `SaaSProviderGate.cs` (Api-side: it needs `ITammaModeProvider`, the entitlement seam, and emits DCB events via the tenant `IEventRepository`).
 
 ```csharp
-namespace Tamma.Activities.Security;
+namespace Tamma.Api.Services.Security;
 
-/// <summary>Auth model a provider uses to authenticate. Drives SaaS eligibility.</summary>
+/// <summary>Auth model a provider authenticates with — drives SaaS eligibility.
+/// Mirrors the Provider entity AuthModel field (34-11, design §4.2).</summary>
 public enum ProviderAuthModel
 {
     /// <summary>Cloud/local LLM API authenticated by an API key (ILLMProvider).
     /// SaaS-eligible — the key resolves from the principal's secret source (32-3).</summary>
     ApiKey,
 
-    /// <summary>Headless CLI / token-based coding agent (ICLIAgentProvider, e.g.
-    /// claude-code, opencode). Requires a host shell + local credential — NOT
-    /// available in SaaS; single-user/self-hosted only.</summary>
+    /// <summary>Headless CLI / token-based harness agent (ICLIAgentProvider, e.g.
+    /// claude-code, opencode, zen-mcp). Needs a host shell + local credential —
+    /// NOT reachable in SaaS; single-user / self-hosted only (deep-dive §1).</summary>
     CliToken,
 }
 
-public interface IProviderAuthRegistry
+/// <summary>The reason a gate decision resolves the way it does — maps 1:1 to the
+/// §2.4 call-LLM error envelope.</summary>
+public enum ProviderGateOutcome
 {
-    /// <summary>Auth model for a known provider; <c>null</c> if the provider is unknown.</summary>
-    ProviderAuthModel? AuthModel(string? providerName);
-
-    /// <summary>True iff the provider is API-key (and therefore SaaS-eligible).
-    /// Unknown providers return <c>false</c> (fail-closed).</summary>
-    bool IsSaaSEligible(string? providerName);
+    Allowed,                 // pass to step 2
+    SaasProviderNotAllowed,  // cli-token in SaaS, or unknown (fail-closed) -> HTTP 400
+    TenantNotEntitled,       // SaaS auth/entitlement rejection           -> HTTP 403
 }
-```
-
-`ProviderAuthRegistry` classifies the `ProviderAllowlist.DefaultProviders` set. The `CliToken` members are the providers backed by `ICLIAgentProvider` in `packages/providers`: **`claude-code`**, **`opencode`** (and `zen-mcp` is treated per its backing factory — verify at impl time against `BUILTIN_PROVIDER_NAMES`). Everything else in the allowlist (`anthropic`, `openai`, `openrouter`, `google`/`gemini`, `github-copilot`, `azure-openai`, `local-llm`, `ollama`, `lmstudio`, `together`, `groq`, `z-ai`) is `ApiKey`.
-
-```csharp
-public sealed class ProviderAuthRegistry : IProviderAuthRegistry
-{
-    // CLI/token-backed providers (ICLIAgentProvider). The complement of this
-    // set within ProviderAllowlist.DefaultProviders is ApiKey.
-    private static readonly HashSet<string> CliTokenProviders =
-        new(StringComparer.OrdinalIgnoreCase) { "claude-code", "opencode" };
-
-    public ProviderAuthModel? AuthModel(string? providerName)
-    {
-        if (string.IsNullOrWhiteSpace(providerName)) return null;
-        var name = providerName.Trim();
-        if (!ProviderAllowlist.IsAllowedDefault(name)) return null; // unknown
-        return CliTokenProviders.Contains(name)
-            ? ProviderAuthModel.CliToken
-            : ProviderAuthModel.ApiKey;
-    }
-
-    public bool IsSaaSEligible(string? providerName) =>
-        AuthModel(providerName) == ProviderAuthModel.ApiKey; // null/CliToken ⇒ false
-}
-```
-
-> **Design note — single source of known providers.** The registry does not re-list every provider; it derives the `ApiKey` set as `ProviderAllowlist.DefaultProviders \ CliTokenProviders`. Adding a future provider to the allowlist auto-classifies it `ApiKey` unless it is also added to `CliTokenProviders`. A unit test asserts every allowlist entry has a deterministic auth model so a new provider can't be silently miscategorised.
-
-### The gate — `ISaaSProviderGate`
-
-New file `apps/tamma-elsa/src/Tamma.Api/Services/Security/ISaaSProviderGate.cs` + `SaaSProviderGate.cs` (Api-side because it needs `ITammaModeProvider` and emits DCB events; the registry stays in Activities so engine activities can reuse the classification).
-
-```csharp
-namespace Tamma.Api.Services.Security;
 
 public sealed record ProviderGateContext(
     string ProviderName,
@@ -137,50 +110,109 @@ public sealed record ProviderGateContext(
 
 public sealed record ProviderGateDecision(
     bool Allowed,
-    string? Reason,                 // null when Allowed
-    ProviderAuthModel? AuthModel);
+    ProviderGateOutcome Outcome,
+    string? Reason,                 // null when Allowed; key-free otherwise
+    ProviderAuthModel? AuthModel,   // resolved model; null when provider unknown
+    int HttpStatusHint)             // 200 allow / 400 not-allowed / 403 not-entitled
+{
+    public static ProviderGateDecision Allow(ProviderAuthModel? model) =>
+        new(true, ProviderGateOutcome.Allowed, null, model, 200);
+}
 
 public interface ISaaSProviderGate
 {
     /// <summary>
-    /// Pure-ish decision: single-user ⇒ always Allowed (no event, no metric).
-    /// SaaS ⇒ Allowed only when the provider is SaaS-eligible (API-key).
-    /// On a SaaS denial this emits AGENT.PROVIDER.GATED + the metric as a side
-    /// effect (fire-and-forget, never throws back into the decision).
+    /// Composition step 1 of the call-LLM endpoint. Single-user ⇒ always Allow
+    /// (no event, no metric). SaaS ⇒ Allow only when the provider is api-key AND
+    /// the tenant is entitled; cli-token / unknown ⇒ SaasProviderNotAllowed (400,
+    /// fail-closed); un-entitled tenant ⇒ TenantNotEntitled (403). On a SaaS denial
+    /// emits AGENT.PROVIDER.GATED + the metric as a swallowed side effect. NEVER
+    /// throws to signal a denial — returns a typed decision the endpoint maps to the
+    /// §2.4 envelope.
     /// </summary>
     Task<ProviderGateDecision> InspectAsync(ProviderGateContext ctx, CancellationToken ct = default);
-
-    /// <summary>
-    /// Convenience for selection paths: throws TammaError(SAAS_PROVIDER_NOT_ALLOWED,
-    /// severity High) when denied, so the endpoint's existing TammaError→400 mapping
-    /// produces the response with no extra branching.
-    /// </summary>
-    Task EnsureAllowedAsync(ProviderGateContext ctx, CancellationToken ct = default);
 }
 ```
 
-`EnsureAllowedAsync` throws:
+> **Why a typed decision, not a throw (design §2.4).** The call-LLM endpoint owns the error envelope: it returns a typed, key-free body, never a leaked provider error or a bare exception → 500. The gate hands back `ProviderGateDecision`; `LlmCallEndpoints`/`ManagedAgent` translate `Outcome`+`HttpStatusHint` into the §2.4 response. This keeps the fail-closed contract (`PROVIDER_CREDENTIAL_UNAVAILABLE`-style guarantees) intact and consistent with 32-5's "typed failures, never lost runs."
+
+### Provider auth lookup — `IProviderAuthLookup` (34-11 seam, interim static impl)
+
+New `apps/tamma-elsa/src/Tamma.Api/Services/Security/IProviderAuthLookup.cs`. This is the single read seam the gate consults; 34-11 backs it with the `Provider` entity's `AuthModel` field.
 
 ```csharp
-throw new TammaError(
-    code: "SAAS_PROVIDER_NOT_ALLOWED",
-    message: $"Provider '{ctx.ProviderName}' uses CLI/token authentication and is not " +
-             "available in SaaS mode. Use an API-key provider (e.g. anthropic, openai).",
-    context: new Dictionary<string, object?>
+namespace Tamma.Api.Services.Security;
+
+public interface IProviderAuthLookup
+{
+    /// <summary>Auth model for a known provider; <c>null</c> if the provider is unknown
+    /// (drives the fail-closed DENY in SaaS).</summary>
+    Task<ProviderAuthModel?> AuthModelAsync(string? providerName, CancellationToken ct = default);
+}
+```
+
+**Interim implementation (pre-34-11)** — `StaticProviderAuthLookup`, keyed off the existing `ProviderAllowlist.DefaultProviders` set (single source of known providers; do not re-list providers):
+
+```csharp
+public sealed class StaticProviderAuthLookup : IProviderAuthLookup
+{
+    // Harness providers (ICLIAgentProvider). The complement within
+    // ProviderAllowlist.DefaultProviders is ApiKey. Verify against
+    // BUILTIN_PROVIDER_NAMES / agent-provider-factory.ts at impl time.
+    private static readonly HashSet<string> CliTokenProviders =
+        new(StringComparer.OrdinalIgnoreCase) { "claude-code", "opencode", "zen-mcp" };
+
+    public Task<ProviderAuthModel?> AuthModelAsync(string? providerName, CancellationToken ct = default)
     {
-        ["provider"]  = ctx.ProviderName,
-        ["authModel"] = "cli-token",
-        ["mode"]      = "saas",
-        ["role"]      = ctx.Role,
-        ["action"]    = ctx.Action,
-    },
-    retryable: false,
-    severity: TammaErrorSeverity.High);
+        if (string.IsNullOrWhiteSpace(providerName)) return Task.FromResult<ProviderAuthModel?>(null);
+        var name = providerName.Trim();
+        if (!ProviderAllowlist.IsAllowedDefault(name)) return Task.FromResult<ProviderAuthModel?>(null); // unknown
+        return Task.FromResult<ProviderAuthModel?>(
+            CliTokenProviders.Contains(name) ? ProviderAuthModel.CliToken : ProviderAuthModel.ApiKey);
+    }
+}
+```
+
+**34-11 implementation** — `EntityProviderAuthLookup` reads `Provider.AuthModel` (`api-key` | `cli-token`) for the provider key (alias-normalised on write per design §4.2), returning `null` for an unknown key. **Swapping is a DI registration change only** (`AddSingleton<IProviderAuthLookup, StaticProviderAuthLookup>()` → `AddScoped<IProviderAuthLookup, EntityProviderAuthLookup>()`). The `ProviderGateDecision` contract is identical.
+
+> **Cross-reference 34-11.** This story does NOT define the `Provider`/`ProviderModelPrice` entities or the `AuthModel` column — 34-11 owns them (sequence A, before 34-5). 32-4 defines only the read seam `IProviderAuthLookup` and the interim static impl, so it is buildable independently and flips to the entity with no contract change.
+
+### `SaaSProviderGate.InspectAsync` flow
+
+```csharp
+public async Task<ProviderGateDecision> InspectAsync(ProviderGateContext ctx, CancellationToken ct = default)
+{
+    // 1. single-user / self-hosted: hard no-op (harness providers are legitimate locally).
+    if (_mode.Mode != TammaMode.SaaS)
+        return ProviderGateDecision.Allow(model: null);   // no lookup, no event, no metric
+
+    // 2. SaaS: classify the provider (fail-closed on unknown).
+    var authModel = await _authLookup.AuthModelAsync(ctx.ProviderName, ct);
+    if (authModel is null || authModel == ProviderAuthModel.CliToken)
+    {
+        var reason = authModel is null ? "PROVIDER_UNKNOWN" : "CLI_TOKEN_PROVIDER";
+        await EmitGatedAsync(ctx, authModel, reason, ct);   // event + metric, swallowed on failure
+        return new ProviderGateDecision(false, ProviderGateOutcome.SaasProviderNotAllowed,
+            Reason: $"Provider '{ctx.ProviderName}' is not available in SaaS mode (api-key providers only).",
+            AuthModel: authModel, HttpStatusHint: 400);
+    }
+
+    // 3. SaaS auth / entitlement (Epic 34 seam) — provider is api-key; is the tenant entitled?
+    if (!await _entitlement.IsTenantEntitledAsync(ctx.TenantId, ctx.ProviderName, ct))
+    {
+        await EmitGatedAsync(ctx, authModel, "TENANT_NOT_ENTITLED", ct);
+        return new ProviderGateDecision(false, ProviderGateOutcome.TenantNotEntitled,
+            Reason: "Tenant is not entitled to the managed LLM path for this provider.",
+            AuthModel: authModel, HttpStatusHint: 403);
+    }
+
+    return ProviderGateDecision.Allow(authModel);           // api-key + entitled
+}
 ```
 
 ### DCB event — `AGENT.PROVIDER.GATED`
 
-Appended via `IEventRepository.AppendAsync` (same pattern as `AgentEndpoints` `AGENT_CONFIG.UPDATED.SUCCESS`, ~line 93). Emitted **only** in SaaS on a denial.
+Appended via `IEventRepository.AppendAsync` (same pattern as `AgentEndpoints` `AGENT_CONFIG.UPDATED.SUCCESS`). Emitted **only** in SaaS on a denial. Append failure is logged and swallowed — a clean typed decision must never become a 500.
 
 ```csharp
 await _events.AppendAsync(new DomainEvent
@@ -190,95 +222,104 @@ await _events.AppendAsync(new DomainEvent
     TenantId = ctx.TenantId,
     Tags = JsonSerializer.Serialize(new
     {
-        tenantId = ctx.TenantId?.ToString(),
-        provider = ctx.ProviderName,
-        authModel = "cli-token",
-        mode = "saas",
-        role = ctx.Role,
-        action = ctx.Action,
+        tenantId  = ctx.TenantId?.ToString(),
+        provider  = ctx.ProviderName,
+        authModel = authModel is null ? "unknown" : (authModel == ProviderAuthModel.CliToken ? "cli-token" : "api-key"),
+        mode      = "saas",
+        role      = ctx.Role,
+        action    = ctx.Action,
     }),
     Metadata = JsonSerializer.Serialize(new { workflowVersion = "1.0.0", eventSource = "system" }),
     Data = JsonSerializer.Serialize(new
     {
-        provider = ctx.ProviderName,
-        authModel = "cli-token",
-        mode = "saas",
-        reason = "SAAS_PROVIDER_NOT_ALLOWED",
-        role = ctx.Role,
-        action = ctx.Action,
+        provider  = ctx.ProviderName,
+        authModel = authModel is null ? "unknown" : (authModel == ProviderAuthModel.CliToken ? "cli-token" : "api-key"),
+        mode      = "saas",
+        reason,                       // CLI_TOKEN_PROVIDER | PROVIDER_UNKNOWN | TENANT_NOT_ENTITLED
+        role      = ctx.Role,
+        action    = ctx.Action,
     }),
     CreatedAt = DateTime.UtcNow,
 });
 ```
 
-Event-store note: appended via the CP/tenant `IEventRepository` exactly as sibling endpoints do; no new event topology. Failure to append is logged and swallowed so it never converts a clean 400 into a 500.
-
-### Resolver integration (execution boundary)
-
-`ProviderChainResolver.ResolveAsync` gains an injected `IProviderAuthRegistry?` (null-tolerant ctor overload, matching the existing optional `IDiagnosticsService?` pattern) **plus** an `ITammaModeProvider`. In the per-entry loop, before the circuit-breaker switch:
-
-```csharp
-// SaaS gating — exclude CLI/token providers entirely (not "unhealthy",
-// "ineligible"). Single-user: registry/mode null-check makes this a no-op.
-if (_mode?.Mode == TammaMode.SaaS && _authRegistry is not null
-    && !_authRegistry.IsSaaSEligible(handle.Provider))
-{
-    skipped.Add(new ChainEntry(handle, ChainReason.SaaSIneligible,
-        Healthy: false, CircuitOpen: false, CircuitOpenUntil: null,
-        BudgetAllowed: budgetAllowed, BudgetSpent: budgetSpent, Recommended: false));
-    continue;
-}
-```
-
-A new `ChainReason.SaaSIneligible` is added to `ProviderChainTypes.cs`. When the ordered set is empty *because of* gating, the existing "all exhausted" return is reused but with `ErrorCode: "SAAS_PROVIDER_NOT_ALLOWED"`, and the gate's `InspectAsync` is called once for the first gated entry so the `AGENT.PROVIDER.GATED` event + metric fire. (Existing `EMPTY_PROVIDER_CHAIN` / `NO_AVAILABLE_PROVIDER` returns are unchanged when no gating occurred.)
-
-### Selection integration (selection boundary)
-
-`AgentRegistryService` (32-2 — **NEW**, dependency) and the agent create/version path in `AgentEndpoints` call `ISaaSProviderGate.EnsureAllowedAsync` for **each** provider referenced by the submitted agent config (primary + every fallback in the chain) before persisting. The existing `TammaError`→400 endpoint mapping handles the response. Where 32-2 is not yet merged, this story wires the gate into the existing `AgentEndpoints` create/version write (`configRepo.UpsertAsync`, ~line 89) and leaves a documented hook for `AgentRegistryService`.
-
 ### OpenTelemetry metric
 
-New `ProviderGatingMetrics` (mirrors `KekRotationMetrics`): a `Meter`-registered `Counter<long> tamma.provider.gated`, incremented in `InspectAsync` on a SaaS denial with tags `provider`, `auth_model`, `reason`.
+New `ProviderGatingMetrics` (mirrors `KekRotationMetrics`): a `Meter`-registered `Counter<long> tamma.provider.gated`, incremented in `InspectAsync` on every SaaS denial with tags `provider`, `auth_model` (`cli-token`|`unknown`|`api-key`), `reason`.
+
+### Endpoint mapping (consumed by 32-5)
+
+`LlmCallEndpoints` / `ManagedAgent.RunAsync` (32-5) call `InspectAsync` as step 1 and map the decision:
+
+```csharp
+var gate = await _saasGate.InspectAsync(new ProviderGateContext(provider, role, action, tenantId), ct);
+if (!gate.Allowed)
+{
+    return gate.Outcome switch
+    {
+        ProviderGateOutcome.SaasProviderNotAllowed =>
+            Results.Json(new { success = false, failureCode = "SAAS_PROVIDER_NOT_ALLOWED",
+                               failureReason = gate.Reason }, statusCode: 400),
+        ProviderGateOutcome.TenantNotEntitled =>
+            Results.Json(new { success = false, failureCode = "TENANT_NOT_ENTITLED",
+                               failureReason = gate.Reason }, statusCode: 403),
+        _ => Results.Json(new { success = false, failureCode = "SAAS_PROVIDER_NOT_ALLOWED" }, statusCode: 400),
+    };
+}
+// gate.Allowed → proceed to step 2 (resolve agent), step 3 (credential), …
+```
+
+> **Ownership boundary with 32-5.** 32-5 owns the endpoint, the mapping, and `ManagedAgent.RunAsync`. 32-4 owns `ISaaSProviderGate`, `IProviderAuthLookup` (+ interim static impl), `ProviderGatingMetrics`, and the `AGENT.PROVIDER.GATED` event. The mapping snippet above is illustrative of the consumption contract; 32-5 implements it.
 
 ## Dependencies
 
-- **Prerequisite**: Story **32-2** (Agent registry, resolution & RBAC API) — provides the selection seam (`AgentRegistryService`) the gate hooks into. If 32-2 is not yet merged, the selection gate attaches to the existing `AgentEndpoints` create/version write and the resolver gate (execution boundary) ships fully regardless.
-- **Prerequisite**: Story **32-3** (Per-tenant provider credential resolution, BYOK → platform) — defines the API-key credential model the `ApiKey` classification presumes; gating runs *before* credential resolution.
-- **Reuses (no change required)**: `ProviderAllowlist` / `ActionGate` (`Tamma.Activities/Security/`), `ITammaModeProvider` (`Services/PromptStore/TammaMode.cs`), `IEventRepository` (`Tamma.Data/Repositories/`), `ProviderChainResolver` + `ProviderChainTypes` (`Services/Providers/`), `TammaError` (`Tamma.Core/`).
-- **Blocks**: Story **32-5** (Managed agent execution layer) — its `IManagedAgent` entrypoint must call the execution-boundary gate before dispatching; this story delivers the gate it consumes.
-- **Design alignment**: `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md` §"Provider credential & auth model" ("SaaS = API-key auth only … `ICLIAgentProvider` are NOT available in SaaS").
+**Internal:**
+
+- **Story 34-11** (Provider Cost Price-Book) — owns the `Provider` entity + `AuthModel` field (`api-key` | `cli-token`, design §4.2) that backs `IProviderAuthLookup`. **Soft prerequisite:** this story ships with `StaticProviderAuthLookup` (interim) and flips to the entity-backed lookup via DI when 34-11 lands — no contract/AC change. Sequence A (34-11) precedes; this gate stage ships in sequence F.
+- **Story 32-5** (Call-LLM endpoint + managed execution) — the **consumer**. Its `ManagedAgent.RunAsync` invokes `ISaaSProviderGate.InspectAsync` as composition step 1 and maps the decision to the §2.4 envelope. This story delivers the gate it consumes; 32-5 is implemented immediately after.
+- **Story 32-3** (Per-tenant provider credential resolution, BYOK → platform) — the `api-key` classification presumes 32-3's credential model; gating runs **before** credential resolution (so a `cli-token` provider never reaches the cabinet).
+- **Reuses (no change required):** `ITammaModeProvider` (`Services/PromptStore/TammaMode.cs`), `ProviderAllowlist` (`Tamma.Activities/Security/` — interim known-set source), `IEventRepository` (`Tamma.Data/Repositories/`), the SaaS auth/entitlement seam (Epic 34 gating), `TammaError` (`Tamma.Core/`, only if a contract-violation throw is needed — null context).
+
+**External:** none new.
+
+**Design alignment:** `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` §2.4 (error/gating semantics), §2.6 step 1 (gate stage), §4.2 (`AuthModel` feeds SaaS-eligibility); `docs/superpowers/specs/2026-06-20-managed-llm-execution-deep-dive.md` §1 (provider duality — harness providers unreachable in SaaS).
 
 ## Testing Strategy
 
-1. **Registry unit tests** (`tests/Tamma.Activities.Tests/Security/ProviderAuthRegistryTests.cs`): every `ProviderAllowlist.DefaultProviders` entry has a deterministic `AuthModel` (no `null`); `claude-code`/`opencode` ⇒ `CliToken` / not SaaS-eligible; `anthropic`/`openai`/`openrouter`/`gemini` ⇒ `ApiKey` / SaaS-eligible; unknown provider ⇒ `AuthModel == null` and `IsSaaSEligible == false` (fail-closed); case-insensitivity.
-2. **Gate unit tests** (`tests/Tamma.Api.Tests/Security/SaaSProviderGateTests.cs`): **single-user** — every provider (incl. `claude-code`) ⇒ `Allowed`, **zero** events, **zero** counter increments; **SaaS** — `ApiKey` provider ⇒ `Allowed` (no event); `CliToken` provider ⇒ denied, **exactly one** `AGENT.PROVIDER.GATED` event with the right `Data`/`Tags`, **exactly one** counter increment; unknown provider ⇒ denied (fail-closed); `EnsureAllowedAsync` throws `TammaError("SAAS_PROVIDER_NOT_ALLOWED", severity High)` with the provider named in `Context`.
-3. **Resolver mode-gating tests** (`tests/Tamma.Api.Tests/Providers/ProviderChainResolverSaaSGatingTests.cs`): SaaS — chain `[claude-code, anthropic]` ⇒ `claude-code` in `Skipped` with `ChainReason.SaaSIneligible`, `anthropic` recommended; chain `[claude-code]` only ⇒ `ErrorCode == "SAAS_PROVIDER_NOT_ALLOWED"`, `AllExhausted`, one event; single-user — same chains resolve `claude-code` normally, no event, no skip-for-gating; the existing `EMPTY_PROVIDER_CHAIN` / `NO_AVAILABLE_PROVIDER` / budget paths are unchanged (regression assertions on existing resolver tests).
-4. **Selection endpoint tests** (`tests/Tamma.Api.Tests/Agents/` or extend `AgentEndpoints` tests): SaaS create/version with a `CliToken` provider in the chain ⇒ **400** `SAAS_PROVIDER_NOT_ALLOWED`, **not** persisted, one event; SaaS with all-`ApiKey` chain ⇒ persists; single-user with a `CliToken` chain ⇒ persists, no event.
-5. **Mode-matrix table test**: parameterise `(mode ∈ {SingleUser, SaaS}) × (provider ∈ {anthropic, claude-code, unknown})` over both boundaries and assert the 12-cell allow/deny/event/metric matrix — the canonical guard against regressions.
-6. **C# suites run** via `sg docker -c "dotnet test ..."` (session docker group is stale — see `reference_dotnet_test_docker.md`). TDD: tests authored red before implementation per `superpowers:test-driven-development`.
+1. **Gate unit tests** (`tests/Tamma.Api.Tests/Security/SaaSProviderGateTests.cs`):
+   - **single-user** — every provider (incl. `claude-code`, `opencode`, `zen-mcp`, an unknown name) ⇒ `Allowed`, **zero** events, **zero** counter increments (no lookup even attempted is acceptable; assert zero side effects).
+   - **SaaS, api-key + entitled** (`anthropic`, `openai`, `openrouter`, `gemini`) ⇒ `Allowed`, no event, no metric.
+   - **SaaS, cli-token** (`claude-code`/`opencode`/`zen-mcp`) ⇒ denied `Outcome=SaasProviderNotAllowed`, `HttpStatusHint=400`, **exactly one** `AGENT.PROVIDER.GATED` event with `reason=CLI_TOKEN_PROVIDER` and the right `Data`/`Tags`, **exactly one** counter increment.
+   - **SaaS, unknown provider** ⇒ denied fail-closed `Outcome=SaasProviderNotAllowed`, `HttpStatusHint=400`, `reason=PROVIDER_UNKNOWN`, one event, one metric.
+   - **SaaS, api-key + NOT entitled** (entitlement seam returns false) ⇒ denied `Outcome=TenantNotEntitled`, `HttpStatusHint=403`, `reason=TENANT_NOT_ENTITLED`, one event, one metric.
+   - **Event-append failure** is swallowed: the typed decision is still returned (assert no throw escapes `InspectAsync`).
+   - **Case-insensitivity / trimming**: `"Claude-Code "` classifies as `cli-token`.
+2. **Lookup unit tests** (`tests/Tamma.Api.Tests/Security/StaticProviderAuthLookupTests.cs`): every `ProviderAllowlist.DefaultProviders` entry returns a deterministic `AuthModel` (no `null` for a known provider — guards against a new provider being silently mis-classified); `claude-code`/`opencode`/`zen-mcp` ⇒ `CliToken`; everything else ⇒ `ApiKey`; unknown name ⇒ `null`.
+3. **Mode × auth-model matrix table test**: parameterise `(mode ∈ {SingleUser, SaaS}) × (provider ∈ {anthropic, claude-code, unknown}) × (entitled ∈ {true,false})` and assert the allow/deny/outcome/status/event/metric for each cell — the canonical regression guard, including the §2.4 status-hint mapping.
+4. **Endpoint-mapping contract test** (lives with 32-5 but referenced here): a denied `ProviderGateDecision` with `Outcome=SaasProviderNotAllowed` ⇒ HTTP 400 `SAAS_PROVIDER_NOT_ALLOWED`; `TenantNotEntitled` ⇒ HTTP 403 — proving the typed decision drives the §2.4 envelope.
+5. **34-11 swap test**: with `EntityProviderAuthLookup` registered (fake `Provider` rows: `anthropic`=api-key, `claude-code`=cli-token), the same matrix passes — proving the DI swap is contract-neutral.
+6. **Credential-safety assertion**: a test passes a `ProviderGateContext` carrying only a provider name and asserts no code path on the gate reads a credential/secret service (gate dependencies are mode + lookup + entitlement + events + metrics only).
+7. **C# suites run** via `sg docker -c "dotnet test ..."` (session docker group is stale — `reference_dotnet_test_docker.md`). TDD: tests authored red before implementation per `superpowers:test-driven-development`.
 
 ## Estimated Effort
 
-2-3 days
+1.5-2 days (smaller than the prior standalone framing — no resolver-skip logic, no selection-endpoint hooks; the gate is one service consumed by 32-5).
 
 ## Files Created/Modified
 
 | File | Action |
 |------|--------|
-| `apps/tamma-elsa/src/Tamma.Activities/Security/IProviderAuthRegistry.cs` | Create |
-| `apps/tamma-elsa/src/Tamma.Activities/Security/ProviderAuthRegistry.cs` | Create |
 | `apps/tamma-elsa/src/Tamma.Api/Services/Security/ISaaSProviderGate.cs` | Create |
 | `apps/tamma-elsa/src/Tamma.Api/Services/Security/SaaSProviderGate.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Security/IProviderAuthLookup.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Security/StaticProviderAuthLookup.cs` | Create (interim; 34-11 adds `EntityProviderAuthLookup`) |
 | `apps/tamma-elsa/src/Tamma.Api/Services/Security/ProviderGatingMetrics.cs` | Create |
-| `apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderChainResolver.cs` | Modify (inject registry + mode; skip ineligible; fail-closed return) |
-| `apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderChainTypes.cs` | Modify (add `ChainReason.SaaSIneligible`) |
-| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs` | Modify (call `EnsureAllowedAsync` on create/version) |
-| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRegistryService.cs` | Modify (gate at selection — **NEW from 32-2; hook only if merged**) |
-| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (DI: register registry, gate, metrics) |
-| `apps/tamma-elsa/tests/Tamma.Activities.Tests/Security/ProviderAuthRegistryTests.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (DI: register gate, `IProviderAuthLookup` → `StaticProviderAuthLookup`, metrics) |
 | `apps/tamma-elsa/tests/Tamma.Api.Tests/Security/SaaSProviderGateTests.cs` | Create |
-| `apps/tamma-elsa/tests/Tamma.Api.Tests/Providers/ProviderChainResolverSaaSGatingTests.cs` | Create |
-| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentSelectionGatingTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Security/StaticProviderAuthLookupTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Security/SaaSProviderGateMatrixTests.cs` | Create |
+
+> No new control-plane / public-schema **table** is added by this story (no `Program.cs` startup-reset DROP-list change needed — the DROP-list note applies only to new tables; the `Provider` table is owned by 34-11). No EF migration is added here; the gate is a pure service over existing seams.
 
 ## Dev Notes
 
@@ -286,43 +327,88 @@ New `ProviderGatingMetrics` (mirrors `KekRotationMetrics`): a `Meter`-registered
 
 Before implementing this story, ensure you have:
 
-1. Read [BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md) (real path: `docs/guides/BEFORE_YOU_CODE.md`)
 2. Searched `.dev/` directory for related spikes, bugs, findings, and decisions
-3. Reviewed the Epic 32 design spec (`docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`), §"Provider credential & auth model"
-4. Confirmed the two provider hierarchies in `packages/providers/src/types.ts`: `ILLMProvider` (`type: 'llm-api'`, API-key) vs `ICLIAgentProvider` (`type: 'cli-agent'`, CLI/token)
-5. Planned TDD approach (Red-Green-Refactor) — write the mode-matrix test first
+3. Reviewed the locked design spec `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` §2.4, §2.6 step 1, §4.2, and the deep-dive §1 (provider duality)
+4. Confirmed the consumer contract with 32-5 (`ManagedAgent.RunAsync` step 1 calls `InspectAsync`; the endpoint maps the typed decision) and the 34-11 `AuthModel` source
+5. Confirmed the two provider hierarchies in `packages/providers/src/types.ts`: `ILLMProvider` (`type:'llm-api'`, api-key) vs `ICLIAgentProvider` (`type:'cli-agent'`, cli-token)
+6. Planned TDD approach (Red-Green-Refactor) — write the mode × auth-model matrix test first
 
-### Why two seams, not one
+### Reframe note (what changed from v1.0.0)
 
-The selection gate alone is insufficient: default provider chains and pre-gate configs already in `agent_configs` can name a CLI provider. The resolver/execution gate is the fail-closed backstop required by AC4 — without it, a stale config would silently dispatch a `CliToken` provider in SaaS. The selection gate alone would also be insufficient because 32-5's managed entrypoint can be reached by paths other than a fresh create. Both boundaries consult the *same* `IProviderAuthRegistry`, so classification is single-sourced.
+The previous v1 framing was a **standalone gating story** with its own `IProviderAuthRegistry`, a selection-boundary hook in `AgentEndpoints`, and execution-boundary skip logic inside `ProviderChainResolver` (a `ChainReason.SaaSIneligible`). Under the locked model the LLM path is mediated by a single endpoint and the provider chain/resolver concerns move server-side into 32-5's `ManagedAgent`. So this rewrite:
 
-### Fail-closed semantics (AC6)
+- **Removes** the resolver-skip integration and the selection-endpoint hook — those belonged to the old "two seams" topology. The single seam now is **the gate stage of the call-LLM endpoint**.
+- **Replaces** the in-story hard-coded `CliTokenProviders` registry with the `IProviderAuthLookup` read seam backed by 34-11's `Provider.AuthModel` (static interim impl until 34-11 lands).
+- **Returns a typed decision** the endpoint maps to the §2.4 envelope (400/403) rather than throwing a `TammaError` from a convenience `EnsureAllowedAsync`.
+- **Adds the 403 entitlement outcome** (design §2.4) alongside the 400 provider-not-allowed outcome.
 
-In SaaS, the order at every boundary is: (1) existing `ProviderAllowlist.IsAllowed` (rejects junk/injection names — unchanged), then (2) `IProviderAuthRegistry.IsSaaSEligible`. An *unknown* provider is rejected by (1) already; a *known CliToken* provider passes (1) but is denied by (2). The registry returning `false` for unknown names is belt-and-suspenders so a future code path that bypasses (1) still denies in SaaS.
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Does the gate run? | Yes, but it is a hard **no-op** — `InspectAsync` returns `Allowed` for every provider before any lookup. Harness (`cli-token`) providers are a legitimate local affordance (spawn a local process; no remote credential to centralise — design §5.3). | Yes, and it is **load-bearing**: `cli-token` and unknown providers are denied (400), un-entitled tenants denied (403), only entitled `api-key` providers pass. |
+| Who is the principal the decision is scoped to? | The sole user (the tenant-equivalent). No event is emitted, so no per-user record is written. | The tenant. `ProviderGateContext.TenantId` is set; the `AGENT.PROVIDER.GATED` event is tenant-scoped (lands in the tenant `t_<hex>` event store via the tenant `IEventRepository`). |
+| Who owns the gating audit data? | N/A (no gating events in single-user — nothing to own). | The tenant — gating events are tenant-scoped, never cross-tenant; platform admin sees none of it (design ownership rule). |
+| Where does provider eligibility come from? | Irrelevant (no-op) — but the same `IProviderAuthLookup`/`Provider.AuthModel` source is wired; it simply isn't consulted because mode short-circuits first. | The `Provider` entity's `AuthModel` (34-11) via `IProviderAuthLookup`; interim static allowlist until 34-11. Platform-global (cost/auth model is the provider's, identical for every tenant). |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`) — process-stable, read once. | same |
+
+### Fail-closed semantics (AC4, design §2.4)
+
+In SaaS the order is: (1) classify via `IProviderAuthLookup` → `cli-token` or `null` (unknown) ⇒ DENY (400); (2) `api-key` ⇒ check entitlement → not entitled ⇒ DENY (403); else ALLOW. If the lookup itself fails (entity read error) or the mode source is unavailable, **DENY** — never a permissive default. This honours `feedback_resolution_no_empty_fallback` (never fall back to an empty/permissive credential or eligibility) and the §2.4 fail-closed rule ("if the credential, gate, or budget cannot be evaluated, deny").
 
 ### Single-user is a hard no-op
 
-`InspectAsync` checks `Mode == SingleUser` first and returns `Allowed` with no event and no metric increment — verified by tests asserting zero side effects. This keeps self-hosted users' Claude Code CLI usage completely untouched and avoids polluting their event stream / metrics.
+`InspectAsync` checks `Mode != SaaS` first and returns `Allowed` with no lookup, no event, no metric — verified by tests asserting zero side effects. This keeps self-hosted users' Claude Code / OpenCode / Zen MCP usage completely untouched and avoids polluting their event stream / metrics.
 
 ### Reuse, don't duplicate
 
-`ProviderAuthRegistry` derives its known set from `ProviderAllowlist.DefaultProviders` (does not re-declare provider names beyond the small `CliTokenProviders` set). `SaaSProviderGate` reads mode from the existing `ITammaModeProvider` and emits via the existing `IEventRepository`. No new allowlist, no new mode plumbing, no new event store.
+The gate reads mode from the existing `ITammaModeProvider`, classifies via the 34-11 `Provider.AuthModel` (through `IProviderAuthLookup`; interim static off `ProviderAllowlist.DefaultProviders`), emits via the existing `IEventRepository`, and delegates entitlement to the existing Epic 34 SaaS auth seam. No new allowlist of provider names beyond the small interim `CliTokenProviders` set, no new mode plumbing, no new event store, no new entitlement engine.
 
 ### Provider classification source of truth
 
-`claude-code` and `opencode` are the `ICLIAgentProvider` implementations in `packages/providers` (`claude-agent-provider.ts` `name = 'claude-code'`, `opencode-provider.ts` `name = 'opencode'`; both registered via `BUILTIN_PROVIDER_NAMES`). At implementation time, cross-check `BUILTIN_PROVIDER_NAMES` / `agent-provider-factory.ts` for any additional CLI-agent registrations (e.g. `zen-mcp`) and add them to `CliTokenProviders` — the registry test that asserts a deterministic auth model for every allowlist entry will surface any miss.
+`claude-code`, `opencode`, `zen-mcp` are the `ICLIAgentProvider` implementations in `packages/providers` (`claude-agent-provider.ts` `name='claude-code'`, `opencode-provider.ts` `name='opencode'`; both registered via `BUILTIN_PROVIDER_NAMES`). At implementation time cross-check `BUILTIN_PROVIDER_NAMES` / `agent-provider-factory.ts` for any additional CLI-agent registrations and add them to the interim `CliTokenProviders` set; once 34-11 lands, the `Provider.AuthModel` column is the canonical source and the interim set is retired. The lookup unit test (every allowlist entry resolves to a deterministic model) surfaces any miss.
+
+## Risks & Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| A `cli-token` provider leaks into SaaS execution | High | Gate is composition **step 1** of the endpoint — runs before agent resolution / credential / provider call; explicit SaaS+`cli-token` test asserts denial (400) and that no credential is resolved. |
+| Unknown / future provider silently allowed in SaaS | High | Fail-closed: `IProviderAuthLookup` returns `null` for unknown ⇒ DENY (400); lookup unit test asserts every known provider has a deterministic model so a new provider can't be `null`-by-accident. |
+| 34-11 not yet landed blocks this story | Medium | Ships against `StaticProviderAuthLookup` (interim); swap to `EntityProviderAuthLookup` is a DI-registration change with a contract-neutral test (Testing Strategy #5). |
+| Gate throws and the endpoint returns a leaked 500 | Medium | `InspectAsync` returns a typed decision; only a contract violation (null context) may throw; event-append failure is swallowed; endpoint maps the typed decision to the §2.4 envelope. |
+| 403 entitlement logic drifts from Epic 34 | Medium | Entitlement is **delegated** to the existing Epic 34 SaaS auth seam; this story owns only the typed surfacing of its result, not the entitlement rules. |
+| Event/metric double-count or miss | Low | `EmitGatedAsync` is called once per denial path; tests assert exactly one event + one metric per SaaS denial and zero on allow. |
+
+## Success Metrics
+
+- [ ] In SaaS, 100% of `cli-token` and unknown providers are denied at endpoint step 1 (400) before any credential resolution; 0 `cli-token` provider calls reach a provider in SaaS.
+- [ ] In single-user, the gate is a verified no-op (zero `AGENT.PROVIDER.GATED` events, zero `tamma.provider.gated` increments).
+- [ ] Every SaaS denial emits exactly one `AGENT.PROVIDER.GATED` event + one metric increment; every allow has zero side effects.
+- [ ] DI swap from `StaticProviderAuthLookup` to `EntityProviderAuthLookup` (34-11) passes the matrix with no AC/contract change.
+
+## Related
+
+- Design of record: `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§2.4 error/gating, §2.6 step 1 gate stage, §4.2 `AuthModel` → SaaS-eligibility)
+- Deep dive: `docs/superpowers/specs/2026-06-20-managed-llm-execution-deep-dive.md` (§1 provider duality — harness providers unreachable in SaaS)
+- Re-plan: `docs/superpowers/plans/2026-06-20-epic-32-37-replan.md`
+- Implementation plan: `docs/superpowers/plans/2026-06-21-32-4-saas-provider-gate-plan.md`
+- Consumer: `docs/stories/epic-32/story-32-5/` (call-LLM endpoint + `ManagedAgent.RunAsync` step 1)
+- AuthModel source: `docs/stories/epic-34/story-34-11/` (Provider Cost Price-Book — `Provider.AuthModel`)
+- Credential model: `docs/stories/epic-32/story-32-3/` (BYOK → platform; runs after the gate)
 
 ## Logging Requirements
 
-- **INFO**: SaaS provider gated (provider, authModel, role, action, tenantId) — one line per denial.
-- **DEBUG**: Gate inspected and allowed (provider, mode); resolver skipped a SaaS-ineligible entry (provider).
-- **WARN**: Unknown provider denied in SaaS (provider) — signals a config referencing a provider not in the allowlist.
-- **ERROR**: `AGENT.PROVIDER.GATED` event append failed (the decision still returns; the throw/deny is never masked by an event-store failure).
-- **Structured context**: include `{ provider, authModel, mode, role, action, tenantId, reason }` where applicable.
-- **Credential safety**: NEVER log API keys, tokens, or CLI credentials — the gate operates on provider *names* only and must never touch secret material.
+- **INFO**: SaaS provider gated (provider, authModel, outcome, reason, role, action, tenantId) — one line per denial.
+- **DEBUG**: gate inspected and allowed (provider, mode); single-user no-op short-circuit (mode).
+- **WARN**: unknown provider denied fail-closed in SaaS (provider) — signals a request naming a provider with no `Provider` entity / not in the allowlist.
+- **ERROR**: `AGENT.PROVIDER.GATED` event append failed (the typed decision still returns; the deny/allow is never masked by an event-store failure).
+- **Structured context**: include `{ provider, authModel, mode, outcome, reason, role, action, tenantId }` where applicable.
+- **Credential safety**: NEVER log API keys, tokens, or CLI credentials. The gate operates on provider **names** and the mode only and must never touch, read, or resolve secret material — assert this in tests (the gate has no credential-resolver dependency).
 
 ## Change Log
 
-| Date       | Version | Changes                | Author |
-| ---------- | ------- | ---------------------- | ------ |
-| 2026-06-17 | 1.0.0   | Initial story creation | Claude |
+| Date       | Version | Changes                                                                                                                                                                                                 | Author |
+| ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| 2026-06-17 | 1.0.0   | Initial story creation (standalone two-seam gating: `IProviderAuthRegistry` + selection hook in `AgentEndpoints` + `ProviderChainResolver` skip)                                                          | Claude |
+| 2026-06-21 | 2.0.0   | **Rewrite to the gate-stage model.** Reframed from a standalone gating story to the GATE STAGE (composition step 1) consumed by 32-5's `call-LLM` endpoint. `ISaaSProviderGate.InspectAsync` returns a TYPED `ProviderGateDecision` (no bare throw) the endpoint maps to the §2.4 envelope (400 `SAAS_PROVIDER_NOT_ALLOWED` / 403 `TENANT_NOT_ENTITLED`). Eligibility now sourced from 34-11's `Provider.AuthModel` via `IProviderAuthLookup` (interim `StaticProviderAuthLookup`); removed resolver-skip + selection-endpoint hooks. Added 403 entitlement outcome and fail-closed unknown-provider deny. | Claude |

--- a/docs/stories/epic-32/story-32-5/32-5-managed-agent-execution-layer.md
+++ b/docs/stories/epic-32/story-32-5/32-5-managed-agent-execution-layer.md
@@ -1,4 +1,4 @@
-# Story 32-5: Managed Agent Execution Layer (IManagedAgent over IAIProvider)
+# Story 32-5: Call-LLM Endpoint + Managed Execution (`POST /api/v1/llm/call`)
 
 Status: drafted
 
@@ -10,265 +10,336 @@ Status: drafted
 
 ## User Story
 
-As a **platform engineer building agent-driven workflows**,
-I want a single managed-LLM-agent execution abstraction (`IManagedAgent`) that turns a resolved agent + the existing inline LLM/tool-loop HTTP path into one coherent, instrumented agent run,
-So that every managed run carries a stable agent identity, resolves its own credential, sanitizes and instruments uniformly, and produces a structured `AgentRunResult` that the action-trail (32-6), outcome-capture (32-8) and cost-emission (32-9) stories can consume — and so that SaaS has exactly **one** execution path (the LLM-API path), with CLI/token providers excluded by the 32-4 gate.
+As a **platform engineer building agent-driven workflows on the Tamma engine**,
+I want a single internal `POST /api/v1/llm/call` endpoint in `Tamma.Api` that holds the credential, gates the call, runs the agentic tool loop server-side, meters cost, and returns a structured key-free result — and a thin `CallLlmInlineActivity` shim in the engine that delegates to it,
+So that **a workflow step NEVER calls an external provider directly** (the engine holds no provider key), SaaS has exactly **one** managed execution path, and every run carries a stable agent identity, a `credentialSource`, a metered cost basis, and a DCB audit trail — while the existing provider-chain/retry/circuit-breaker machinery in `LlmCallWorkflow.cs` keeps working byte-for-byte.
 
 ## Priority
 
-P0 - The managed execution seam that every later Epic 32 story (action trail, panels, outcome capture, benchmarking, learning) builds on. Without it, agent runs stay ad-hoc role→LLM-call dispatch with no run record, no uniform credential/gate path, and no clean producer for the tracking dataset.
+P0 — This is the **lynchpin** of the Epic 32 architecture pivot (sequence step **F**). It is the integration point where steps stop calling providers: it relocates credential resolution, the provider HTTP call, the tool loop, and metering from the Elsa engine into `Tamma.Api`, deletes the engine's credential-resolver wiring shipped by 32-3, and is the producer of the run dataset that 32-6 (action trail), 32-8 (outcome capture) and 32-9 (usage/cost emission) consume. Nothing else in the pivot can land cleanly until the mediated endpoint exists.
 
 ## Context
 
-Today, agent-driven workflow steps dispatch an LLM call through `CallLlmActivity` → the inline `CallLlmInlineActivity`, which already contains a complete agentic tool loop (sanitization → multi-turn LLM call → tool-call validation → tool execution → context compaction → output sanitization). Agent config is resolved separately via `IAgentResolverService`; prompt/convention rendering happens in separate Context/LlmCall activities; budget/circuit-breaker/concurrency are separate guard activities. **There is no single object that represents "run this agent end-to-end and give me a structured result."** Consequently there is no natural place to attach the stable `agent_id` + config version (32-1), the per-tenant credential source (32-3), the SaaS gate (32-4), or the run record that 32-6/32-8/32-9 need.
+### What exists today (the violation)
 
-This story introduces `IManagedAgent` / `ManagedAgent` as the **orchestration seam over** the existing inline path — it **reuses, does not fork**, the tool loop, `ContentSanitizer`, `ToolExecutorRegistry`, and `ContextCompactor` already living in `CallLlmInlineActivity`. The resolver (32-2) returns an `IManagedAgent` regardless of whether the backing executor is the LLM-API path (this story) or a CLI provider, so workflows treat all agents identically; **SaaS resolves only the LLM-API-backed `IManagedAgent`** because the 32-4 gate excludes `ICLIAgentProvider` outside single-user mode.
+Agent-driven steps dispatch an LLM call through `CallLlmActivity` → `CallLlmInlineActivity` (~1592 LOC, 22 parent workflows). That inline activity **reads a provider key inside the engine process** (via `IProviderCredentialResolver` → `config.ApiKey`), builds the Anthropic/OpenAI request body, performs the external `PostAsync(.../v1/messages` & `/v1/chat/completions`), and runs a complete agentic tool loop (`AgenticToolLoop`): sanitize → multi-turn call → tool-call validation → sequential/parallel tool execution → tool-output sanitization + secret redaction → context compaction → token accounting. It is the **worst rule-1 violator** in the audit (design §1.2): the only step that, in any deploy topology, puts a live external key in the engine. `CallLlmActivity` is worse still — it reads `Anthropic:ApiKey` directly. Eight further activities (`ClaudeAnalysisActivity`, `WriteTests`/`WriteImplementation`/`AnalyzeCode`/`ApplyRefactoring`/`ApplyReviewFixes`, `AIDiagnosis`) each carry a **direct keyed LLM fallback** behind an engine-callback branch — **nine in-engine direct-LLM callers total**.
 
-> **Architecture note — distinct from CLI providers.** `IManagedAgent` is the customization layer *above* the LLM API (provider + model + prompt + tools + RAG + budget), and is **not** an `ICLIAgentProvider`. The two execution backends converge on the same `AgentRunResult` so callers never branch on backend. Per the Epic 32 design spec, SaaS = API-key auth only → managed path only.
+The retry / provider-chain / circuit-breaker machinery, by contrast, is **correct and stays put**: `LlmCallWorkflow.cs`'s `BuildRetryLoop` → `ForEach<provider>` invokes the step once per provider per attempt; `RetryCheck` reads `LastDiagnostic.HttpStatusCode` (429/502/503/504/0 → retry); `SkipIfSucceeded` and the circuit breaker advance the chain. That boundary is durable-checkpointed and must not move.
+
+### What this story does (the locked model, rules 1 & 2)
+
+This story builds the **`call-LLM` mediation endpoint** (design §2) and the managed execution layer behind it:
+
+- A new `POST /api/v1/llm/call` endpoint (`Tamma.Api/Endpoints/LlmCallEndpoints.cs`), internal/engine-only, authenticated on the **same plane** as the other `TammaApiClient` callbacks (Bearer `Tamma:ApiToken` via `TammaEngineAuthHandler` + `X-Tenant-Id`), delegating to **`IManagedAgent.RunAsync`** in `Tamma.Api/Services/Agents/`.
+- `ManagedAgent.RunAsync` composes the locked rule-2 sequence **inside the API**: gate (32-4) → resolve agent + per-tenant enablement (32-18/32-16) → resolve credential BYOK→platform via the cabinet-backed `DefaultProviderCredentialResolver` (32-3) → render prompt (Epic 27 for personas / own prompts for custom agents — 32-15/32-17) → provider call via the extracted `IInlineToolLoopRunner` (AC3, moved **verbatim** from `CallLlmInlineActivity.AgenticToolLoop`, run with a request-scoped key) → meter (`IProviderPricingService.Compute` cost basis from the 34-11 Provider entity; 34-5 markup when platform / none when byok; 32-9 usage event) → return `text` + `usage` + `credentialSource` (never the key).
+- `CallLlmInlineActivity` collapses from ~1592 lines to a **~80-line thin client** that owns no provider logic, no key, no HTTP-to-provider, and no tool loop. It sends an `LlmCallRequest` via a **new `TammaApiClient.CallLlmAsync(...)`**, receives an `LlmCallResponse`, and writes the **same workflow variables it writes today** (`LastDiagnostic`, `LastResponse`, `ToolLoopTokens`/`Turns`/`Exhausted`) so `LlmCallWorkflow.cs` is unchanged.
+- The engine's credential resolver (`ConfigPlatformProviderCredentialResolver` + `AddEngineProviderCredentialResolution` in `ElsaServer/Program.cs`, shipped by 32-3) is **deleted from the call path** — the engine no longer resolves keys at all. The provider-side deps that the activity injected (`IHttpClientFactory`, `IContentSanitizer`, `IToolExecutorRegistry`, `IToolCallValidator`, `ContextCompactor`, `ToolLoopEventEmitter`, `ParallelToolExecutor`, `IProviderCredentialResolver`) are removed from the engine and injected in the API process instead.
+
+> **Architecture note — `IManagedAgent` is distinct from CLI providers.** `IManagedAgent` is the customization layer *above* the LLM API (provider + model + prompt + tools + budget). It is **not** an `ICLIAgentProvider`. Per the deep-dive (§1), the endpoint is **API-provider-only**: harness/CLI providers spawn a local process, hold their own auth, and run their own loop — they are single-user-local and exempt from `/llm/call` (design §5.3), and in SaaS the 32-4 gate makes them structurally unreachable (`400 SAAS_PROVIDER_NOT_ALLOWED`). So SaaS has exactly **one** execution path: this endpoint.
+
+### Explicitly out of scope (follow-on stories — referenced, not implemented here)
+
+- **Response mode is buffered (`application/json`) ONLY.** The SSE response mode, the live `IToolLoopEventSink`, and the `GET /api/v1/llm/runs/{correlationId}/stream` run tap are deferred to the **"Streaming run tap"** follow-on (deep-dive §3, §6.4).
+- **MCP / plugin tool sourcing (C#)** — the runner uses only the existing built-in `IToolExecutorRegistry` catalog; per-tenant MCP servers/plugins are the **"MCP & plugin tool sourcing"** follow-on (deep-dive §4, §6.2).
+- **Prompt + response cache** — Anthropic prompt-cache prefix and the optional gated response cache are the **"Prompt + response cache"** follow-on (deep-dive §4, §6.3).
+- **Interactive question-back** — the `request_input` tool + `IQuestionRouter` + `WaitForAgentQuestionActivity` are the **"Interactive question-back"** follow-on (deep-dive §5, §6.5).
+- **C# harness/CLI adapter** for single-user local harness execution (deep-dive §6.6) — deferred single-user story.
+- **Non-LLM step mediation** (git/agent-dispatch/Slack) — **Epic 38** (design §5).
+- **The Provider Cost Price-Book entity** is **34-11** (a hard prerequisite consumed via `IProviderPricingService`); this story does not build it.
 
 ## Acceptance Criteria
 
-1. An **`IManagedAgent`** interface and a **`ManagedAgent`** implementation exist (`apps/tamma-elsa/src/Tamma.Api/Services/Agents/`). `RunAsync(ManagedAgentRequest, CancellationToken)` orchestrates, in order: **resolve agent (32-2)** → **resolve credential (32-3)** → **SaaS gate (32-4)** → **context + RAG assembly** → **prompt render (Epic 27 prompt/convention stores)** → **agentic tool loop (the existing `CallLlmInlineActivity` path)** → **sanitize** → **instrument** → **outcome capture**, and returns a structured `AgentRunResult`.
-2. `AgentRunResult` is a typed record carrying at minimum: `AgentId`, `Version`, `Provider`, `Model`, `Role`, `InputTokens`, `OutputTokens`, `CostUsd`, `DurationMs`, `Success`, `ToolCalls` (count + per-call summaries), `CorrelationId`, `CredentialSource` (`byok` | `platform`), `ResponseText`, and on failure a `FailureReason` + `FailureCode`. The same record shape is returned whether the run succeeded, failed, was budget-exceeded, or gate-denied.
-3. `ManagedAgent` **reuses (does NOT fork)** the existing inline tool loop, `ContentSanitizer` (input/output/tool-output sanitization), `IToolExecutorRegistry`, `IToolCallValidator`, and `ContextCompactor` in `CallLlmInlineActivity`. No second copy of the tool loop, sanitizer, or compactor is created; the loop body is factored into a reusable seam invoked by both the legacy activity and `ManagedAgent`.
-4. Clear separation is enforced: **`IManagedAgent` is the only execution path used by SaaS.** In SaaS mode the resolver never returns a CLI/token-backed agent (`ICLIAgentProvider` implementations are excluded by the 32-4 gate); attempting to resolve a CLI-backed agent in SaaS yields a typed gate-denied `AgentRunResult` (not a thrown bare exception).
-5. An Elsa activity **`RunManagedAgentActivity`** (`apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/`) exposes `IManagedAgent` to workflows, replacing ad-hoc role→llm-call dispatch in agent-driven steps. It accepts the agent/role + phase + issue context + per-task overrides, calls `IManagedAgent.RunAsync`, and writes the serialized `AgentRunResult` to a workflow variable.
-6. Token/cost accounting in `AgentRunResult.CostUsd` is computed via the existing **`IProviderPricingService.Compute(provider, model, inputTokens, outputTokens)`** (cost basis), and the result is tagged with `CredentialSource` so downstream pricing/markup (Epic 34) and billing (Epic 35) can attribute it. BYOK runs are tagged `byok`; platform-key runs are tagged `platform`.
-7. **Failures never lose the run record.** A provider error, budget-exceeded, gate denial, missing-credential, or tool-loop exception produces a typed `AgentRunResult { Success = false, FailureCode, FailureReason }` (with whatever token/cost was accrued before failure), never an unhandled exception that drops the run. The single exception is a programmer/contract error (e.g., null request), which may throw.
-8. **DCB events** `AGENT.RUN.STARTED`, `AGENT.RUN.SUCCESS`, and `AGENT.RUN.FAILED` are emitted (one STARTED before the loop; exactly one terminal SUCCESS or FAILED) via the tenant `IEventRepository`, tagged `{ agentId, version, provider, model, role, correlationId, credentialSource, tenantId }`. `AGENT.RUN.FAILED` additionally tags `failureCode`.
-9. **Unit + workflow tests** cover: happy path (all fields populated end-to-end), budget-exceeded, gate-denied (CLI-backed agent in SaaS), provider-failure, missing-credential, and tool-loop-exhausted; plus a test asserting every `AgentRunResult` field is populated on the happy path and that exactly one terminal DCB event is emitted per run.
+1. **The endpoint exists.** `POST /api/v1/llm/call` is served by a new `Tamma.Api/Endpoints/LlmCallEndpoints.cs`, internal/engine-only, authenticated by **Bearer `Tamma:ApiToken` (via `TammaEngineAuthHandler`) + `X-Tenant-Id`** — the same plane as the existing `TammaApiClient` callbacks (agent-resolve / budget / diagnostics / provider-session). A missing/invalid bearer → **HTTP 401**. The handler binds an `LlmCallRequest`, derives `tenantId` from `X-Tenant-Id` when the body omits it, and delegates to `IManagedAgent.RunAsync`.
+
+2. **`LlmCallRequest` / `LlmCallResponse` match the design (§2.2/§2.3).** The request record carries `{ tenantId?, agentId?, persona?, role, action?, phase?, prompt, variables, model?, tools?, enableToolLoop, toolLoopConfig?, params{maxTokens,temperature,budgetCapUsd}, correlationId }`. The success response (HTTP 200) carries `{ success:true, text, usage{promptTokens,completionTokens,totalTokens,toolLoopTokens,toolLoopTurns,toolLoopExhausted}, credentialSource("byok"|"platform"), providerUsed, modelUsed, cost{providerCostUsd,priceUsd,currency}, toolCalls[], agentId, agentVersion, role, correlationId, durationMs }`. **`credentialSource` is returned; the API key is NEVER in the response body, logs, or events.**
+
+3. **`ManagedAgent.RunAsync` composition order is exactly the locked rule-2 sequence (design §2.6), all inside `Tamma.Api`:** (1) **gate** — 32-4 `ISaaSProviderGate.InspectAsync` + SaaS auth/entitlement; (2) **resolve agent config + per-tenant enablement** — 32-2/32-18 resolver applying the 32-16 `TenantAgentEnablement` gate → `Provider` + `Model` + `AgentId`/`AgentVersion` + allowed tools; (3) **resolve credential BYOK→platform** — the cabinet-backed `DefaultProviderCredentialResolver` (32-3) yielding `{ ApiKey, Source }`; (4) **render prompt** — Epic 27 `(principal, role, action)` for personas (32-15) / the custom agent's own prompts for custom agents (32-17), tenant→system→**error** (never empty/plain); (5) **provider call** — the extracted `IInlineToolLoopRunner` makes the external HTTPS call **inside `Tamma.Api`** with the request-scoped key; (6) **meter** — `IProviderPricingService.Compute` cost basis + 34-5 markup (platform) / none (byok) + 32-9 usage event; (7) **return**.
+
+4. **The agentic tool loop is reused, NOT forked (AC3 of the original story, preserved).** `CallLlmInlineActivity.AgenticToolLoop(...)` and its private helpers (multi-turn builders/parsers, `LoadProviderConfig`, sanitize/redact calls, compaction) are **extracted verbatim** into `InlineToolLoopRunner : IInlineToolLoopRunner` under `Tamma.Activities/LlmCall/`. `Tamma.Api` references `Tamma.Activities`, so the runner is shared (no second copy). The provider HTTP call executes in the API process where the key is resolved; the engine activity never touches the runner. The existing **`CallLlmInlineActivitySanitizationTests` must pass unchanged** as the regression net proving no behaviour drift. The sanitizer/registry/validator/compactor/parallel-executor are DI-registered **in the API**.
+
+5. **The thin-client cutover (design §2.5).** `CallLlmInlineActivity` is reduced to a ~80-line shim that: (a) maps its current `Input<>` props (`InputJsonProp`, `ProviderNameProp`, `SystemPromptProp`, `ToolsJsonProp`, `AttemptNumberProp`, `EnableToolLoopProp`, `ToolLoopConfigJsonProp`, `TenantIdProp`) into an `LlmCallRequest`; (b) sends it via the **new** `TammaApiClient.CallLlmAsync(LlmCallRequest, tenantId, ct)` (following the existing `PostAsync<T>` + `AddTenantHeader` + `RecordHealthAsync` pattern); (c) maps the `LlmCallResponse` back into the **same workflow variables it writes today** — `LastDiagnostic` (a `ProviderAttemptDiagnostic` carrying `CredentialSource`, `HttpStatusCode`, token counts), `LastResponse` (a `NormalizedLlmResponse`), and `ToolLoopTokens`/`ToolLoopTurns`/`ToolLoopExhausted`. The shim owns **no** provider logic, key, HTTP-to-provider, or tool loop. `enableToolLoop` + `toolLoopConfig` are passed through to the endpoint, not executed locally.
+
+6. **The workflow boundary is byte-for-byte unchanged.** `LlmCallWorkflow.cs`'s `BuildRetryLoop` → `ForEach<provider>` / `RetryCheck` / `SkipIfSucceeded` / circuit-breaker are not modified. The step is still invoked **once per provider per attempt**; provider-chain advance and retry stay at the workflow boundary. This works **only because** the endpoint honours AC7's status-preservation contract.
+
+7. **Error / gating semantics — the load-bearing contract (design §2.4), fail-closed.** The endpoint always returns a **typed, key-free body**:
+   - **HTTP 200 + `success:false`** for *expected execution failures*, with `httpStatusCode` **preserved** (e.g. 429/502/503/504/0) so the engine's `RetryCheck` + circuit breaker keep working. `failureCode ∈ { PROVIDER_ERROR, PROVIDER_CREDENTIAL_UNAVAILABLE, BUDGET_EXCEEDED, LOOP_EXHAUSTED }`, plus a key-free `failureReason`, `credentialSource`, `providerUsed`, and `usage` accrued before failure.
+   - **HTTP 400 `SAAS_PROVIDER_NOT_ALLOWED`** when 32-4's `ISaaSProviderGate` denies a CLI-token provider in SaaS.
+   - **HTTP 403** when SaaS auth/entitlement (32-4) rejects the tenant.
+   - **HTTP 401** when the engine bearer is absent/invalid.
+   - **Fail-closed:** if the credential, gate, or budget cannot be evaluated, **deny** — never call the provider with an empty/wrong key (consistent with `feedback_resolution_no_empty_fallback`). `PROVIDER_CREDENTIAL_UNAVAILABLE` stays `retryable:false, severity:High`. A raw 5xx must never leak (it would be nulled by `TammaApiClient.PostAsync`, breaking `RetryCheck`).
+
+8. **DCB events from the API.** `AGENT.RUN.STARTED` (one, before the loop) and exactly one terminal `AGENT.RUN.SUCCESS` or `AGENT.RUN.FAILED` are emitted from **`Tamma.Api`** via the tenant `IEventRepository` (where the tenant store + cabinet live), tagged `{ agentId, version, provider, model, role, correlationId, credentialSource, tenantId }`; `AGENT.RUN.FAILED` additionally tags `failureCode`. Credential/gate decisions also surface as `AGENT.CREDENTIAL_RESOLVED.SUCCESS|DENIED` / `AGENT.PROVIDER.GATED` where applicable.
+
+9. **The nine in-engine direct-LLM callers stop calling providers.** `CallLlmActivity` becomes a thin client the same way as `CallLlmInlineActivity` **or is deleted** in favour of the inline path (it is the most severe violator). The TDD/ADL/Debug/Mentorship activities' **direct keyed LLM fallback is deleted** — `ClaudeAnalysisActivity`, `WriteTestsActivity`, `WriteImplementationActivity`, `AnalyzeCodeActivity`, `ApplyRefactoringActivity`, `ApplyReviewFixesActivity`, `AIDiagnosisActivity` route through `call-LLM` (their engine-callback mode terminates at the mediated path). The engine's `ConfigPlatformProviderCredentialResolver` + `AddEngineProviderCredentialResolution` registration are removed from `ElsaServer/Program.cs`.
+
+10. **`AgentRunResult` is preserved and is the producer record.** `ManagedAgent.RunAsync` internally produces an `AgentRunResult` (the typed record from the original 32-5: `AgentId, Version, Provider, Model, Role, InputTokens, OutputTokens, CostUsd, DurationMs, Success, ToolCalls, CorrelationId, CredentialSource, ResponseText, FailureCode?, FailureReason?`), which the endpoint projects to `LlmCallResponse`. Cost stays at the **provider cost basis** (`IProviderPricingService.Compute`); markup is 34-5, not this story. The same shape is returned whether the run succeeded, failed, was budget-exceeded, credential-unavailable, or gate-denied — **failures never lose the run record**.
+
+11. **Tests cover the endpoint + composition + cutover.** Endpoint auth (401 missing bearer, 403 entitlement, 400 SAAS_PROVIDER_NOT_ALLOWED); composition order + happy path (every response field populated, exactly one terminal DCB event); each typed failure (`PROVIDER_ERROR` with preserved `httpStatusCode`, `PROVIDER_CREDENTIAL_UNAVAILABLE`, `BUDGET_EXCEEDED`, `LOOP_EXHAUSTED`); BYOK vs platform `credentialSource` + markup-on-platform-only; the thin shim maps `LlmCallResponse` → the same `LastDiagnostic`/`LastResponse`/`ToolLoop*` variables; and `CallLlmInlineActivitySanitizationTests` passes unchanged (no-fork proof).
 
 ## Technical Design
 
 ### Where it lives
 
 ```
+apps/tamma-elsa/src/Tamma.Api/Endpoints/
+  LlmCallEndpoints.cs              # NEW — POST /api/v1/llm/call; engine-only auth; delegates to IManagedAgent
+
 apps/tamma-elsa/src/Tamma.Api/Services/Agents/
-  IManagedAgent.cs                 # NEW — the managed execution contract
-  ManagedAgent.cs                  # NEW — orchestrator over the inline LLM/tool-loop seam
-  ManagedAgentRequest.cs           # NEW — input record (role/agentId, phase, issue ctx, overrides, correlationId)
-  AgentRunResult.cs                # NEW — structured outcome record (the producer for 32-6/32-8/32-9)
-  AgentRunEventTypes.cs            # NEW — AGENT.RUN.STARTED/SUCCESS/FAILED constants
-  IManagedAgentResolver.cs         # NEW (or extends 32-2 resolver) — returns IManagedAgent for (tenant, role/agentId)
+  IManagedAgent.cs                 # KEEP — the managed execution contract
+  ManagedAgent.cs                  # KEEP/REWORK — composes the rule-2 sequence (gate→resolve→cred→render→loop→meter)
+  ManagedAgentRequest.cs           # KEEP — internal input record (maps from LlmCallRequest)
+  AgentRunResult.cs                # KEEP — internal structured outcome (projected to LlmCallResponse)
+  AgentRunEventTypes.cs            # KEEP — AGENT.RUN.STARTED/SUCCESS/FAILED constants
+  LlmCallRequest.cs                # NEW — wire request record (design §2.2)
+  LlmCallResponse.cs               # NEW — wire response record (design §2.3) + UsageDto/CostDto/ToolCallDto
 
 apps/tamma-elsa/src/Tamma.Activities/LlmCall/
-  CallLlmInlineActivity.cs         # MODIFY — extract the agentic tool loop into a reusable seam (no behaviour change)
   IInlineToolLoopRunner.cs         # NEW — the extracted, reusable tool-loop seam (interface)
-  InlineToolLoopRunner.cs          # NEW — the extracted loop body (moved verbatim from the activity)
+  InlineToolLoopRunner.cs          # NEW — the loop body, moved VERBATIM from CallLlmInlineActivity
+  CallLlmInlineActivity.cs         # GUT — ~1592 → ~80-line thin client; no key/HTTP/loop; calls TammaApiClient.CallLlmAsync
+  CallLlmActivity.cs               # GUT or DELETE — thin client, or removed in favour of the inline path
 
-apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/
-  RunManagedAgentActivity.cs       # NEW — Elsa activity exposing IManagedAgent to workflows
+apps/tamma-elsa/src/Tamma.Activities/<TDD|ADL|Debug|AI>/
+  WriteTestsActivity.cs … AIDiagnosisActivity.cs   # MODIFY — delete the direct keyed LLM fallback; route through call-LLM
+
+apps/tamma-elsa/src/Tamma.ElsaServer/
+  Program.cs                       # MODIFY — DELETE ConfigPlatformProviderCredentialResolver + AddEngineProviderCredentialResolution
+
+apps/tamma-elsa/src/Tamma.Api/Clients/  (or wherever TammaApiClient lives)
+  TammaApiClient.cs                # MODIFY — add CallLlmAsync(LlmCallRequest, tenantId, ct) (PostAsync<T> + AddTenantHeader + RecordHealthAsync)
 ```
 
-### IManagedAgent contract (C#)
+### The endpoint (`LlmCallEndpoints.cs`)
 
 ```csharp
-namespace Tamma.Api.Services.Agents;
-
-/// <summary>
-/// The managed-LLM-agent execution layer (Epic 32). Composes a resolved agent +
-/// credential + the existing inline tool loop into one instrumented run that
-/// returns a structured <see cref="AgentRunResult"/>.
-///
-/// Distinct from <c>ICLIAgentProvider</c> (CLI/token providers, single-user only).
-/// In SaaS mode this is the ONLY execution path; CLI-backed agents are excluded by
-/// the 32-4 provider-auth gate.
-/// </summary>
-public interface IManagedAgent
+// POST /api/v1/llm/call — internal, engine-only.
+// Auth: [Authorize] on the engine-token scheme (TammaEngineAuthHandler) + X-Tenant-Id.
+app.MapPost("/api/v1/llm/call", async (
+        LlmCallRequest request,
+        HttpContext http,
+        IManagedAgent managed,
+        ILlmCallResponseMapper mapper,
+        CancellationToken ct) =>
 {
-    /// <summary>Stable agent identity + the pinned config version this instance runs.</summary>
-    Guid AgentId { get; }
-    int Version { get; }
+    // Bearer validated by the engine auth scheme; missing/invalid -> 401 before this runs.
+    var tenantId = request.TenantId ?? ResolveTenant(http);     // from X-Tenant-Id when body omits it
 
-    /// <summary>
-    /// Run the agent end-to-end. Composition:
-    ///   resolve agent (32-2) -> resolve credential (32-3) -> SaaS gate (32-4)
-    ///   -> assemble context + RAG (Epic 6) -> render prompt (Epic 27)
-    ///   -> agentic tool loop (reused CallLlmInlineActivity seam)
-    ///   -> sanitize -> instrument (cost via IProviderPricingService) -> capture outcome.
-    ///
-    /// NEVER throws on an expected failure (provider error, budget exceeded, gate
-    /// denial, missing credential, loop exhaustion): returns a typed
-    /// <see cref="AgentRunResult"/> with Success=false and a FailureCode/Reason so
-    /// the run record is always captured. Emits exactly one terminal DCB event.
-    /// </summary>
-    Task<AgentRunResult> RunAsync(ManagedAgentRequest request, CancellationToken ct);
+    var run = await managed.RunAsync(ManagedAgentRequest.From(request, tenantId), ct);
+
+    // Map AgentRunResult -> LlmCallResponse, applying the §2.4 status discipline:
+    return mapper.ToHttpResult(run);   // 200 success | 200 success:false (+httpStatusCode) | 400 | 403
+})
+.RequireAuthorization(EngineAuthPolicy)   // same plane as the other TammaApiClient callbacks
+.WithName("CallLlm");
+```
+
+The mapper enforces AC7: gate denial (CLI in SaaS) → **400 SAAS_PROVIDER_NOT_ALLOWED**; entitlement rejection → **403**; expected execution failures → **200 `success:false`** with the preserved `httpStatusCode`; success → **200**. It NEVER returns a raw 5xx (that would null the engine's `LastDiagnostic.HttpStatusCode`).
+
+### `LlmCallRequest` / `LlmCallResponse` (the wire contract — design §2.2/§2.3)
+
+```csharp
+public sealed record LlmCallRequest
+{
+    public Guid? TenantId { get; init; }            // null => single-user/platform; also from X-Tenant-Id
+    public Guid? AgentId { get; init; }             // explicit custom/persona agent; else resolved by role
+    public string? Persona { get; init; }           // system persona name (claude/gemini/codegpt)
+    public required string Role { get; init; }      // one of the 8 valid roles (drives Epic 27 prompt resolution)
+    public string? Action { get; init; }            // role+action prompt key (Epic 27)
+    public string? Phase { get; init; }             // workflow phase for ResolveForPhaseAsync (32-2)
+    public required string Prompt { get; init; }    // task/user prompt
+    public Dictionary<string, object?> Variables { get; init; } = new();
+    public string? Model { get; init; }             // optional override (clamped to persona/agent allowance)
+    public IReadOnlyList<string>? Tools { get; init; }
+    public bool EnableToolLoop { get; init; }
+    public ToolLoopConfig? ToolLoopConfig { get; init; }
+    public LlmCallParams Params { get; init; } = new();   // { MaxTokens=4096, Temperature=0.7, BudgetCapUsd=0 }
+    public required string CorrelationId { get; init; }   // workflow instance id
 }
-```
 
-### ManagedAgentRequest (input)
-
-```csharp
-public sealed record ManagedAgentRequest
+public sealed record LlmCallResponse
 {
-    public required Guid? TenantId { get; init; }      // null => single-user / platform default
-    public required string Role { get; init; }         // 8 valid roles (RolePhaseMap.ValidRoles)
-    public Guid? AgentId { get; init; }                // explicit agent (32-1); else resolver picks for role
-    public string? Phase { get; init; }                // workflow phase, for ResolveForPhaseAsync
-    public required string UserPrompt { get; init; }   // task prompt (pre-render variables)
-    public int? IssueNumber { get; init; }             // issue/PR context for RAG + event tags
-    public TaskOverrides? Overrides { get; init; }     // clamped per resolver (budget min, tools intersect)
-    public required string CorrelationId { get; init; } // ties the run to the workflow instance / dispatch
-}
-```
-
-### AgentRunResult (output — the producer record)
-
-```csharp
-public sealed record AgentRunResult
-{
-    public required Guid AgentId { get; init; }
-    public required int Version { get; init; }
-    public required string Provider { get; init; }
-    public required string Model { get; init; }
-    public required string Role { get; init; }
-
-    public int InputTokens { get; init; }
-    public int OutputTokens { get; init; }
-    public decimal CostUsd { get; init; }              // IProviderPricingService.Compute(...)
+    public required bool Success { get; init; }
+    public string? Text { get; init; }
+    public UsageDto Usage { get; init; } = new();          // prompt/completion/total + toolLoopTokens/Turns/Exhausted
+    public string? CredentialSource { get; init; }         // "byok" | "platform" — NEVER the key
+    public string? ProviderUsed { get; init; }
+    public string? ModelUsed { get; init; }
+    public CostDto Cost { get; init; } = new();            // { ProviderCostUsd, PriceUsd, Currency }
+    public IReadOnlyList<ToolCallDto> ToolCalls { get; init; } = Array.Empty<ToolCallDto>();
+    public Guid? AgentId { get; init; }
+    public int AgentVersion { get; init; }
+    public string? Role { get; init; }
+    public required string CorrelationId { get; init; }
     public long DurationMs { get; init; }
 
-    public required bool Success { get; init; }
-    public string? ResponseText { get; init; }
-    public IReadOnlyList<ToolCallSummary> ToolCalls { get; init; } = Array.Empty<ToolCallSummary>();
-
-    public required string CorrelationId { get; init; }
-    public required string CredentialSource { get; init; }  // "byok" | "platform"
-
-    // Populated only when Success == false:
-    public string? FailureCode { get; init; }    // e.g. BUDGET_EXCEEDED | GATE_DENIED | PROVIDER_ERROR | NO_CREDENTIAL | LOOP_EXHAUSTED
-    public string? FailureReason { get; init; }
+    // failure-only (Success == false):
+    public string? FailureCode { get; init; }              // PROVIDER_ERROR | PROVIDER_CREDENTIAL_UNAVAILABLE | BUDGET_EXCEEDED | LOOP_EXHAUSTED
+    public string? FailureReason { get; init; }            // key-free
+    public int? HttpStatusCode { get; init; }              // preserved so RetryCheck/circuit-breaker work
 }
-
-public sealed record ToolCallSummary(string ToolName, bool Success, long DurationMs);
 ```
 
-### Composition inside ManagedAgent.RunAsync
+### `ManagedAgent.RunAsync` composition (inside `Tamma.Api`)
 
 ```
-1. resolved   = await _resolver.ResolveForPhaseAsync(tenantId, phase, role, overrides)   // 32-2
-                 -> ResolvedAgentConfig { Provider, Model, Temperature, MaxTokens, TokenBudget, Tools, ... }
-2. credential = await _credentialResolver.ResolveAsync(tenantId, resolved.Provider)      // 32-3 (BYOK -> platform)
-                 -> { ApiKey, BaseUrl, Source }; if null => FAILED(NO_CREDENTIAL)
-3. gate       = _saasGate.Check(mode, resolved)                                           // 32-4
-                 -> CLI-backed agent in SaaS => FAILED(GATE_DENIED)  (typed result, no throw)
-4. budget     = _budgetGuard.Check(resolved, tenantId)                                    // reuses CheckBudgetActivity logic
-                 -> over budget => FAILED(BUDGET_EXCEEDED)
-5. context    = await _contextAssembler.AssembleAsync(role, issueNumber, ...)             // Epic 6: AssembleContextActivity / RAG pipeline
-6. prompt     = await _promptRenderer.RenderAsync(role, phase/action, config, context)    // Epic 27 prompt + convention render (tenant->system->error)
-7. emit AGENT.RUN.STARTED { agentId, version, provider, model, role, correlationId, credentialSource, tenantId }
-8. loop       = await _toolLoop.RunAsync(provider=resolved.Provider, model=resolved.Model,
-                     systemPrompt=prompt.System, userPrompt=prompt.User, tools=resolved.Tools,
-                     credential, loopConfig)                                              // REUSED inline seam (sanitize+compact+validate inside)
-9. cost       = _pricing.Compute(resolved.Provider, resolved.Model, loop.InputTokens, loop.OutputTokens)  // IProviderPricingService
-10. result    = AgentRunResult { ... mapped from resolved + loop + cost + credential.Source ... }
-11. emit AGENT.RUN.SUCCESS or AGENT.RUN.FAILED (exactly one terminal event)
-12. return result
+0. req = ManagedAgentRequest.From(LlmCallRequest, tenantId)
+1. gate       = await _saasGate.InspectAsync(mode, req.Persona/agentId, req.Provider?)        // 32-4
+                  -> CLI-token provider in SaaS  => 400 SAAS_PROVIDER_NOT_ALLOWED
+                  -> entitlement reject          => 403
+1b. budget    = await _budgetGuard.CheckAsync(tenantId, req.Params.BudgetCapUsd, ct)          // server-side, the existing CheckBudgetActivity logic, fail-closed
+                  -> over budget / cannot evaluate => 200 success:false BUDGET_EXCEEDED (deny, never call provider)
+                  (this is the named owner of the budget gate; 32-22's response cache lookup runs strictly AFTER this step)
+2. resolved   = await _resolver.ResolveForPhaseAsync(tenantId, phase, role, agentId, overrides) // 32-2/32-18
+                  -> applies 32-16 TenantAgentEnablement gate (persona not enabled => denied)
+                  -> ResolvedAgentConfig { Provider, Model, Temperature, MaxTokens, TokenBudget, Tools, AgentId, Version }
+3. credential = await _credentialResolver.ResolveAsync(tenantId, resolved.Provider)            // 32-3 cabinet, BYOK->platform
+                  -> { ApiKey, BaseUrl, Source }; if null => 200 success:false PROVIDER_CREDENTIAL_UNAVAILABLE (retryable:false)
+4. prompt     = await _promptRenderer.RenderAsync(principal, role, action, resolved, variables) // Epic 27 (persona) / agent prompts (custom)
+                  -> tenant -> system -> ERROR (never empty/plain)
+5. emit AGENT.RUN.STARTED { agentId, version, provider, model, role, correlationId, credentialSource, tenantId }
+6. loop       = await _toolLoop.RunAsync(provider=resolved.Provider, providerConfig with credential.ApiKey,
+                     model=resolved.Model, systemPrompt=prompt.System, userPrompt=merged,
+                     tools=resolved.Tools, enableToolLoop, toolLoopConfig, correlationId, ct)   // IInlineToolLoopRunner (server-side, request-scoped key)
+                  -> provider error          => 200 success:false PROVIDER_ERROR + preserved httpStatusCode
+                  -> exhausted, no response  => 200 success:false LOOP_EXHAUSTED
+7. costBasis  = _pricing.Compute(resolved.Provider, resolved.Model, loop.InputTokens, loop.OutputTokens)  // 34-11 entity via IProviderPricingService
+   price      = credentialSource == "platform" ? _markup.Apply(costBasis, ...) : 0   // 34-5; byok => token price 0
+   emit usage (32-9) { CostUsd=costBasis, PlatformBilledUsd=price, BillingMode=credentialSource }
+8. emit AGENT.RUN.SUCCESS | AGENT.RUN.FAILED  (exactly one terminal event)
+9. return AgentRunResult -> projected to LlmCallResponse
 ```
 
-Steps 2–4, 8 each have a typed-failure exit that maps to `AgentRunResult { Success=false }` and emits `AGENT.RUN.FAILED` — never a propagated exception.
+The request-scoped key is set on the provider request header and dropped after the call (32-3 AC5); it is never logged, returned, or persisted.
 
-### Reusing (not forking) the inline tool loop
+### Reuse, not fork — the extracted runner (AC4)
 
-The agentic loop currently lives privately inside `CallLlmInlineActivity.AgenticToolLoop(...)` (sanitize prompts → multi-turn call → tool-call validation → sequential/parallel tool execution → tool-output sanitization + secret redaction → context compaction → token accounting). To satisfy AC3 the loop body is **extracted verbatim** into `InlineToolLoopRunner` behind `IInlineToolLoopRunner`, and:
-
-- `CallLlmInlineActivity` delegates to the runner (behaviour and outputs unchanged — its existing sanitization tests `CallLlmInlineActivitySanitizationTests` must still pass byte-for-byte).
-- `ManagedAgent` calls the **same** runner. No second copy of the loop, sanitizer, validator, compactor, or parallel executor.
-
-This is a pure refactor-extract: same `ContentSanitizer`, `IToolExecutorRegistry`, `IToolCallValidator`, `ContextCompactor`, `ParallelToolExecutor`, and `ToolLoopEventEmitter` instances are injected into the runner.
-
-### Integration with the C# Elsa workflow (Epic 9 unified API)
-
-`RunManagedAgentActivity` is the new call site for agent-driven steps. It replaces the `ResolveAgentConfig → ResolveLlmPrompt → ResolveTools → CheckBudget → CallLlm` ad-hoc chain for managed agents with a single activity that delegates the full composition to `IManagedAgent`:
+The `AgenticToolLoop` body moves **verbatim** into `InlineToolLoopRunner : IInlineToolLoopRunner`:
 
 ```csharp
-[Activity("Tamma.AgentDispatch", "Run Managed Agent",
-    "Execute a managed LLM agent end-to-end and capture a structured AgentRunResult",
-    Kind = ActivityKind.Task)]
-public class RunManagedAgentActivity : CodeActivity
+public interface IInlineToolLoopRunner
 {
-    public Input<string> RoleProp { get; set; } = default!;
-    public Input<string?> PhaseProp { get; set; } = default!;
-    public Input<string> UserPromptProp { get; set; } = default!;
-    public Input<int?> IssueNumberProp { get; set; } = default!;
-    public Input<string?> OverridesJsonProp { get; set; } = default!;
-
-    // Resolves IManagedAgent via IManagedAgentResolver (32-2), runs it, and
-    // writes JsonSerializer.Serialize(AgentRunResult) to "AgentRunResult" variable.
+    Task<InlineToolLoopResult> RunAsync(
+        string provider, LlmProviderConfig providerConfig, string model,
+        string systemPrompt, string userPrompt, int maxTokens, double temperature,
+        IReadOnlyList<ResolvedTool>? tools, bool enableToolLoop, ToolLoopConfig loopConfig,
+        string correlationId, CancellationToken ct);
 }
+// InlineToolLoopResult { NormalizedLlmResponse Response, int InputTokens, int OutputTokens,
+//                        int Turns, bool Exhausted, IReadOnlyList<ToolCallSummary> ToolCalls }
 ```
 
-The existing single-turn `CallLlmActivity`/`CallLlmInlineActivity` path remains for non-agent inline LLM calls; managed agent steps move to `RunManagedAgentActivity`. Per Epic 9, all agent resolution/credential/prompt access round-trips through the central API, so the engine activity stays thin.
+`Tamma.Api` references `Tamma.Activities`, so the runner is shared with **no fork**. The DI registrations for `IContentSanitizer`, `IToolExecutorRegistry`, `IToolCallValidator`, `ContextCompactor`, `ParallelToolExecutor` move to the **API** process; they are removed from the engine. `CallLlmInlineActivitySanitizationTests` is the unchanged regression net.
 
-### Cost basis
+### The thin `CallLlmInlineActivity` shim (AC5)
 
 ```csharp
-// IProviderPricingService already exists (apps/tamma-elsa/src/Tamma.Api/Services/Providers/):
-//   decimal Compute(string provider, string? model, int inputTokens, int outputTokens);
-result.CostUsd = _pricing.Compute(resolved.Provider, resolved.Model,
-                                  loop.InputTokens, loop.OutputTokens);
+// ~80 lines: map props -> LlmCallRequest -> TammaApiClient.CallLlmAsync -> write the SAME variables.
+var req = new LlmCallRequest {
+    TenantId = tenantId, Role = role, Persona = providerName /* or agentId */,
+    Prompt = userPrompt, Variables = vars, Tools = tools,
+    EnableToolLoop = enableToolLoop, ToolLoopConfig = toolLoopConfig,
+    Params = new(){ MaxTokens = maxTokens, Temperature = temperature },
+    CorrelationId = context.WorkflowExecutionContext.Id
+};
+var resp = await _api.CallLlmAsync(req, tenantId, ct);   // NEW client method (PostAsync<T> + AddTenantHeader + RecordHealthAsync)
+
+context.SetVariable("LastDiagnostic", new ProviderAttemptDiagnostic {
+    CredentialSource = resp.CredentialSource, HttpStatusCode = resp.HttpStatusCode ?? (resp.Success ? 200 : 0),
+    InputTokens = resp.Usage.PromptTokens, OutputTokens = resp.Usage.CompletionTokens, Success = resp.Success });
+context.SetVariable("LastResponse", NormalizedLlmResponse.From(resp));
+context.SetVariable("ToolLoopTokens", resp.Usage.ToolLoopTokens);
+context.SetVariable("ToolLoopTurns",  resp.Usage.ToolLoopTurns);
+context.SetVariable("ToolLoopExhausted", resp.Usage.ToolLoopExhausted);
 ```
 
-`AgentRunResult` is a **producer** record: 32-9 emits the usage/cost events from these fields; 34/35/36 consume them. The markup engine is 34-5, NOT this story — `CostUsd` here is the raw provider cost basis only.
+`LlmCallWorkflow.cs`'s `ForEach<provider>` invokes this once per provider per attempt; `RetryCheck` reads `LastDiagnostic.HttpStatusCode`; the chain advances exactly as today (AC6).
+
+### Cost basis (producer record only)
+
+```csharp
+// 34-11 Provider entity behind the unchanged IProviderPricingService seam:
+costBasisUsd = _pricing.Compute(resolved.Provider, resolved.Model, loop.InputTokens, loop.OutputTokens);
+```
+
+`AgentRunResult.CostUsd` / `LlmCallResponse.cost.providerCostUsd` is the **raw provider cost basis**. The 34-5 markup engine derives `priceUsd` (markup when `platform`, 0 token-price when `byok` — rule 7); 32-9 emits the usage record; 35/36 consume it. No markup math lives in this story.
 
 ## Dependencies
 
-**Internal:**
+**Internal (hard prerequisites):**
 
-- **Story 32-2** (Agent registry, resolution & RBAC API) — provides `IAgentResolverService` / `IManagedAgentResolver` returning the agent config (and, in this story, an `IManagedAgent`). Hard prerequisite.
-- **Story 32-3** (Per-tenant provider credential resolution, BYOK → platform) — canonical owner of cabinet key wiring; provides the credential + `CredentialSource`. Hard prerequisite.
-- **Story 32-4** (SaaS provider auth gating — API-key only) — provides the gate that excludes `ICLIAgentProvider` in SaaS; consumed at step 3. Hard prerequisite.
-- **Epic 1** (provider abstraction) — `IProviderPricingService`, provider config/allowlist, normalized LLM responses.
-- **Epic 6** (RAG/context) — `AssembleContextActivity` + the RAG pipeline supply the assembled context fed to prompt render.
-- **Epic 27** (prompt/convention render) — prompt + convention resolution (tenant → system → error; NEVER empty/plain fallback).
-- **Epic 9** (unified agent API) — engine ↔ central-API round-trips for resolution/credential/prompt; the call-site convention.
+- **34-11** (Provider Cost Price-Book) — supplies the cost basis behind `IProviderPricingService.Compute`. Consumed at compose step 7. (Sequence A.)
+- **32-15** (Persona reframe + seeding) — named cross-role personas with explicit `model`; Epic-27 prompt wiring. (Sequence B.)
+- **32-16** (Per-tenant agent/persona enablement) — `TenantAgentEnablement` gate applied during resolution. (Sequence C.)
+- **32-17** (Custom-agent prompts) — `ConfigJson.prompts` + resolver prompt-source branch (custom agent). (Sequence D.)
+- **32-18** (Agent registry enablement gate + Epic-27 prompt source) — the amended `IAgentRegistryService`/resolver this story calls at step 2. (Sequence E.)
+- **32-4** (REWRITE — SaaS provider gate inside the endpoint) — `ISaaSProviderGate.InspectAsync`, the gate stage (step 1). (Co-stage of F.)
+- **32-3** (BYOK credential resolution) — the **cabinet-backed `DefaultProviderCredentialResolver`** invoked at step 3 (this story **deletes** 32-3's engine-side `ConfigPlatformProviderCredentialResolver` wiring).
+- **Epic 27** (prompt/convention render) — tenant→system→error resolution at step 4 (never empty/plain).
+- **Epic 29** (cabinet) — `ITenantProviderKeyReader` / runtime secret resolver reached by 32-3.
+- **Epic 9** (unified agent API) — the engine↔API callback convention (`TammaApiClient`, `TammaEngineAuthHandler`); confirm per story (the endpoint builds against the C# `CallLlm*` seam).
 
 **Consumers (downstream, not blockers):**
 
-- **Story 32-6** (action trail) — consumes `AGENT.RUN.*` events + `AgentRunResult`.
-- **Story 32-8** (outcome capture & bug taxonomy) — consumes the run outcome.
-- **Story 32-9** (usage & cost emission) — emits usage/cost events from `AgentRunResult` fields.
+- **32-6** (action trail) — consumes `AGENT.RUN.*` + the run record.
+- **32-8** (outcome capture & bug taxonomy) — consumes the run outcome.
+- **32-9** (usage & cost metering) — emits the usage record from the metered fields.
+- **34-5** (markup), **35** (billing), **36** (analytics) — consume `credentialSource` + cost.
 
-**External:** none new (reuses existing HTTP/provider stack).
+**Follow-ons (referenced, separate stories):** Streaming run tap; MCP & plugin tool sourcing (C#); Prompt + response cache; Interactive question-back; C# harness/CLI adapter (single-user); Epic 38 non-LLM mediation.
+
+**External:** none new (reuses the existing provider HTTP stack — now in the API process).
 
 ## Testing Strategy
 
-1. **Unit — happy path:** mock resolver/credential/gate/context/prompt/tool-loop/pricing; assert `RunAsync` returns `AgentRunResult` with **every** field populated (agentId, version, provider, model, role, input/output tokens, costUsd, durationMs, success=true, toolCalls, correlationId, credentialSource), and that the composition calls each collaborator exactly once in order.
-2. **Unit — budget-exceeded:** budget guard reports over-budget → result `Success=false, FailureCode=BUDGET_EXCEEDED`; tool loop NOT invoked; `AGENT.RUN.FAILED` emitted once; no throw.
-3. **Unit — gate-denied:** SaaS mode + CLI-backed agent → `FailureCode=GATE_DENIED`; tool loop NOT invoked; typed result, no throw. Mirror test in single-user mode: CLI-backed agent is allowed (gate passes).
-4. **Unit — provider-failure:** tool-loop seam returns an unsuccessful `NormalizedLlmResponse` → `FailureCode=PROVIDER_ERROR`, accrued tokens/cost preserved, `AGENT.RUN.FAILED` emitted.
-5. **Unit — missing-credential:** credential resolver returns null → `FailureCode=NO_CREDENTIAL`; provider never called.
-6. **Unit — loop-exhausted:** tool loop returns `exhausted=true` → result still captured (`Success` per response), `AGENT.RUN.*` reflects it.
-7. **Unit — credentialSource tagging:** BYOK credential → result + event tagged `byok`; platform credential → `platform`.
-8. **Refactor-safety:** the existing `CallLlmInlineActivitySanitizationTests` (and the inline tool-loop tests) pass unchanged after the loop is extracted into `InlineToolLoopRunner` — proving AC3 (no fork, no behaviour drift).
-9. **Workflow/integration:** `RunManagedAgentActivity` inside a minimal Elsa workflow writes a serialized `AgentRunResult` variable; assert one `AGENT.RUN.STARTED` + one terminal event per run via a fake `IEventRepository`.
-10. **Event-shape:** assert `AGENT.RUN.*` tags include `{ agentId, version, provider, model, role, correlationId, credentialSource, tenantId }` and that FAILED adds `failureCode`.
+1. **Endpoint auth.** Missing/invalid bearer → 401; valid bearer + `X-Tenant-Id` → request bound, `tenantId` derived from header when body omits it.
+2. **Endpoint gating (AC7).** CLI-token provider in SaaS → 400 `SAAS_PROVIDER_NOT_ALLOWED`; entitlement reject → 403; both via fakes of `ISaaSProviderGate`.
+3. **Composition order + happy path (AC2/AC3).** Mock gate/resolver/credential/prompt/loop/pricing; assert collaborators called once in order; assert **every** `LlmCallResponse` field populated; exactly one `AGENT.RUN.STARTED` + one terminal event.
+4. **`PROVIDER_ERROR` status preservation (AC7/AC6).** Loop returns an unsuccessful `NormalizedLlmResponse` with `httpStatusCode=429` → endpoint returns **200 `success:false`** with `httpStatusCode=429` preserved; assert a raw 5xx is never produced.
+5. **`PROVIDER_CREDENTIAL_UNAVAILABLE`.** Credential resolver returns null → 200 `success:false`, `retryable:false`, provider never called.
+6. **`BUDGET_EXCEEDED`.** Budget guard over-budget → 200 `success:false`; loop never invoked.
+7. **`LOOP_EXHAUSTED`.** Loop returns `exhausted=true` with no usable response → 200 `success:false`, accrued tokens preserved.
+8. **`credentialSource` + markup branch.** BYOK → `credentialSource="byok"`, `cost.priceUsd==0`; platform → `"platform"`, `priceUsd==markup(costBasis)`; `cost.providerCostUsd` identical in both.
+9. **Thin-shim mapping (AC5/AC6).** Given an `LlmCallResponse`, `CallLlmInlineActivity` writes `LastDiagnostic`/`LastResponse`/`ToolLoopTokens`/`Turns`/`Exhausted` identical to the legacy variables; a minimal `LlmCallWorkflow` `ForEach`/`RetryCheck` run advances the chain unchanged.
+10. **No-fork proof (AC4).** `CallLlmInlineActivitySanitizationTests` passes **unchanged** after the loop is extracted into `InlineToolLoopRunner`; `grep` confirms exactly one tool-loop implementation.
+11. **Cutover (AC9).** `ClaudeAnalysisActivity` / `WriteTests` / … / `AIDiagnosis` no longer contain a direct keyed LLM call (assert via test + grep for `Anthropic:ApiKey` / `/v1/messages` under `Tamma.Activities` → zero non-`TammaApiClient` hits); `ElsaServer/Program.cs` no longer registers `AddEngineProviderCredentialResolution`.
+12. **Credential safety.** Assert the API key never appears in any `LlmCallResponse`, log line, or DCB event payload.
 
-Docker-bound C# suites run via `sg docker -c "dotnet test apps/tamma-elsa/..."` (session docker group is stale).
+Docker-bound C# suites run via `sg docker -c "dotnet test apps/tamma-elsa/..."` (session docker group is stale; plain `dotnet build` needs no wrapper).
 
 ## Estimated Effort
 
-5-6 days
+8-10 days (the lynchpin: endpoint + records + the verbatim loop extraction + the resilience relocation + the thin-client cutover of nine activities + the engine-wiring deletion).
 
 ## Files Created/Modified
 
 | File | Action |
 |------|--------|
-| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/IManagedAgent.cs` | Create |
-| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ManagedAgent.cs` | Create |
-| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ManagedAgentRequest.cs` | Create |
-| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRunResult.cs` | Create |
-| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRunEventTypes.cs` | Create |
-| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/IManagedAgentResolver.cs` | Create (or extend 32-2 resolver) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/LlmCallEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/LlmCallRequest.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/LlmCallResponse.cs` | Create (+ UsageDto/CostDto/ToolCallDto) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/IManagedAgent.cs` | Keep |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ManagedAgent.cs` | Create/Rework (rule-2 composition + endpoint projection) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/ManagedAgentRequest.cs` | Keep (add `From(LlmCallRequest, tenantId)`) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRunResult.cs` | Keep |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRunEventTypes.cs` | Keep |
 | `apps/tamma-elsa/src/Tamma.Activities/LlmCall/IInlineToolLoopRunner.cs` | Create |
-| `apps/tamma-elsa/src/Tamma.Activities/LlmCall/InlineToolLoopRunner.cs` | Create (loop extracted from activity) |
-| `apps/tamma-elsa/src/Tamma.Activities/LlmCall/CallLlmInlineActivity.cs` | Modify (delegate to runner; no behaviour change) |
-| `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/RunManagedAgentActivity.cs` | Create |
-| `apps/tamma-elsa/src/Tamma.Api/Extensions/ManagedAgentServiceCollectionExtensions.cs` | Create (DI wiring) |
-| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (register IManagedAgent + activity) |
-| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/ManagedAgentTests.cs` | Create |
-| `apps/tamma-elsa/tests/Tamma.Activities.Tests/AgentDispatch/RunManagedAgentActivityTests.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/LlmCall/InlineToolLoopRunner.cs` | Create (loop extracted verbatim) |
+| `apps/tamma-elsa/src/Tamma.Activities/LlmCall/CallLlmInlineActivity.cs` | Gut → ~80-line thin client |
+| `apps/tamma-elsa/src/Tamma.Activities/LlmCall/CallLlmActivity.cs` | Gut (thin client) or Delete |
+| `apps/tamma-elsa/src/Tamma.Activities/AI/ClaudeAnalysisActivity.cs` | Modify (delete direct keyed fallback) |
+| `apps/tamma-elsa/src/Tamma.Activities/TDD/WriteTestsActivity.cs` | Modify (delete direct keyed fallback) |
+| `apps/tamma-elsa/src/Tamma.Activities/TDD/WriteImplementationActivity.cs` | Modify (delete direct keyed fallback) |
+| `apps/tamma-elsa/src/Tamma.Activities/TDD/AnalyzeCodeActivity.cs` | Modify (delete direct keyed fallback) |
+| `apps/tamma-elsa/src/Tamma.Activities/TDD/ApplyRefactoringActivity.cs` | Modify (delete direct keyed fallback) |
+| `apps/tamma-elsa/src/Tamma.Activities/ADL/ApplyReviewFixesActivity.cs` | Modify (delete direct keyed fallback) |
+| `apps/tamma-elsa/src/Tamma.Activities/Debug/AIDiagnosisActivity.cs` | Modify (delete direct keyed fallback) |
+| `apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs` | Modify (delete `ConfigPlatformProviderCredentialResolver` + `AddEngineProviderCredentialResolution`) |
+| `apps/tamma-elsa/src/Tamma.Api/Clients/TammaApiClient.cs` | Modify (add `CallLlmAsync(LlmCallRequest, tenantId, ct)`) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map endpoint; register `IManagedAgent`, `IInlineToolLoopRunner`, sanitizer/registry/validator/compactor in the API) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/LlmCallEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/ManagedAgentTests.cs` | Create/Extend |
 | `apps/tamma-elsa/tests/Tamma.Activities.Tests/LlmCall/InlineToolLoopRunnerTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/LlmCall/CallLlmInlineActivityThinClientTests.cs` | Create |
 
 ## Dev Notes
 
@@ -277,64 +348,77 @@ Docker-bound C# suites run via `sg docker -c "dotnet test apps/tamma-elsa/..."` 
 Before implementing this story, ensure you have:
 
 1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
-2. Searched `.dev/` directory for related spikes, bugs, findings, and decisions
-3. Reviewed `CallLlmInlineActivity.cs` (the existing tool loop you are reusing) and `IAgentResolverService` / `ResolvedAgentConfig`
-4. Confirmed the 32-2/32-3/32-4 contracts (resolver, credential resolver, gate) are landed before wiring them in
-5. Planned TDD approach (Red-Green-Refactor cycle)
+2. Searched `.dev/` for related spikes, bugs, findings, and decisions (esp. `feedback_resolution_no_empty_fallback`).
+3. Read the design of record §1 (steps never call providers), §2 (the call-LLM endpoint) IN FULL, and the deep-dive §1–§5.
+4. Reviewed `CallLlmInlineActivity.cs` (the loop you are extracting), `TammaApiClient` (the callback pattern), `LlmCallWorkflow.cs` (the `BuildRetryLoop`/`ForEach`/`RetryCheck` boundary you must NOT touch), and `ElsaServer/Program.cs:277` (the resolver registration you are deleting).
+5. Confirmed 34-11 / 32-15 / 32-16 / 32-17 / 32-18 / 32-4 / 32-3 contracts are landed (sequence A–E + the gate) before wiring them.
+6. Planned the TDD approach; remember the loop extraction is a **pure move** with `CallLlmInlineActivitySanitizationTests` as the net.
 
 ### Key Design Decisions
 
-- **Reuse, don't fork (AC3).** The tool loop is mature (sanitization, validation, parallel execution, compaction, token accounting). `ManagedAgent` must call the *same* code via an extracted `InlineToolLoopRunner`. The extraction is a pure move with the existing sanitization/loop tests as the regression net — if those change, the extraction is wrong.
-- **Typed failures, never lost runs (AC7).** Expected failures (provider/budget/gate/credential/loop) are *data*, not exceptions. The only allowable throw is a contract violation (null request). Every `RunAsync` path that returns must have emitted exactly one terminal DCB event first.
-- **`AgentRunResult` is a producer, not a consumer.** Keep cost at provider basis (`IProviderPricingService.Compute`); markup (34-5), invoicing (35), analytics (36) are downstream. Do not embed markup here.
-- **Resolver returns `IManagedAgent` uniformly.** Per the design spec, the resolver hands back an `IManagedAgent` whether LLM-API- or CLI-backed; workflows never branch on backend. SaaS exclusion is enforced at the gate (step 3), so a CLI-backed agent in SaaS returns a typed `GATE_DENIED` result rather than being unrepresentable.
-- **Credential source flows to the result (AC6).** `CredentialSource` from 32-3 (`byok`/`platform`) is copied onto `AgentRunResult` and the DCB tags so cost attribution is genuinely the tenant's (BYOK hits their account; platform is metered/billed).
+- **The endpoint is a managed execution layer, not a proxy (deep-dive §preamble).** It gates, resolves agent + credential, renders the prompt, runs the loop, and meters — all server-side. The step is a dumb shim.
+- **Status preservation is load-bearing (AC6/AC7).** Provider failures return **200 `success:false` + preserved `httpStatusCode`**, never a raw 5xx, because `TammaApiClient.PostAsync` would null a raw 5xx body and break `RetryCheck`/circuit-breaker. This is THE reason the workflow boundary stays unchanged. Add the HTTP-status-fidelity guardrail test (deep-dive §7.9).
+- **Provider-chain + retry stay at the workflow boundary (deep-dive §2).** The richer API-side `ProviderChainResolver` exists but is bypassed — folding the chain into the endpoint is an explicit **open decision**, deferred. Minimal blast radius: the step is called once per provider per attempt.
+- **Reuse, don't fork (AC4).** `Tamma.Api` references `Tamma.Activities`, so the extracted `InlineToolLoopRunner` is shared verbatim — the provider HTTP call runs in the API where the key is resolved; the engine activity never touches the runner. If the sanitization tests need edits, the extraction is wrong — stop and redo it as a move.
+- **Fail-closed, never empty (AC7).** Credential/gate/budget that cannot be evaluated → deny; `PROVIDER_CREDENTIAL_UNAVAILABLE` stays `retryable:false, severity:High`. Consistent with `feedback_resolution_no_empty_fallback` — prompt and credential resolution are tenant→system→error.
+- **Buffered only (this story).** SSE / live `IToolLoopEventSink` / the run tap are deferred — the engine is durable-checkpointed request/response and does not need a held-open socket (deep-dive §3).
+- **DCB events from the API.** Emitted where the tenant `IEventRepository` + cabinet live, not from the engine's optional sink. Performance/action data is ALWAYS tenant-scoped (design ownership rule).
+- **No new control-plane table.** This story adds no CP table → no entry in `Program.cs`'s startup-reset DROP list, and no `ControlPlaneDbContextModelTests` edit. (`TenantAgentEnablement` / `Provider` / `ProviderModelPrice` tables are owned by 32-16 / 34-11 respectively.)
 
 ### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
 
 | Question | single-user mode | SaaS mode |
 |---|---|---|
-| Which execution backends are available? | LLM-API-backed `IManagedAgent` **and** CLI/token-backed agents (`ICLIAgentProvider`). | **Only** LLM-API-backed `IManagedAgent`. CLI/token providers excluded by the 32-4 gate. |
-| Whose credential does a run use? | The sole user's configured key (BYOK) → else platform default. | The tenant's BYOK key (Epic 29 cabinet) → else platform-provided (metered). `CredentialSource` records which. |
-| Where do `AGENT.RUN.*` events land? | The user's (sole) tenant event store; `TenantId` may be null/the implicit user scope. | The tenant's `t_<hex>` event store via the tenant-scoped `IEventRepository`; `TenantId` set. Performance/action data is ALWAYS tenant-scoped, never cross-tenant. |
-| Who owns the run's performance data? | The user. | The tenant — platform admin sees none of it (design spec ownership rule). |
+| Who is the principal of a `call-LLM` request? | The sole user (keyed by `UserId`; `TenantId` may be null). | The tenant (keyed by `TenantId` from `X-Tenant-Id`). No per-user layer. |
+| Which execution backends are reachable? | LLM-API path **and** local harness/CLI providers (exempt, local, never traverse `/llm/call` — design §5.3). | **Only** the LLM-API path via `/llm/call`. CLI-token providers → 400 `SAAS_PROVIDER_NOT_ALLOWED` (32-4 gate). |
+| Whose credential does a run use? | The sole user's BYOK key → else platform default; resolved by 32-3 in the API. | The tenant's BYOK key (Epic 29 cabinet) → else platform-provided (metered + 34-5 markup). `credentialSource` records which. |
+| Whose agent/persona enablement applies? | The sole user's enabled set (`TenantAgentEnablement` keyed by `UserId`). | The tenant's enabled set (keyed by `TenantId`; members can't enable/disable). |
+| Where do `AGENT.RUN.*` events land? | The user's (sole) tenant event store; `TenantId` may be the implicit user scope. | The tenant's `t_<hex>` event store via the tenant-scoped `IEventRepository`; `TenantId` set. Never cross-tenant. |
+| Who owns the run's performance/cost data? | The user. | The tenant — platform admin sees none of it (design ownership rule). |
 | Mode source | `ITammaModeProvider` (`TammaMode.cs`) — process-stable. | same |
 
 ### Risks and Mitigations
 
 | Risk | Severity | Mitigation |
 |------|----------|------------|
-| Loop-extraction drifts behaviour (AC3) | High | Pure move; the existing `CallLlmInlineActivitySanitizationTests` + inline-loop tests are the unchanged regression net; no logic edits during extraction. |
-| A failure path throws and drops the run record (AC7) | High | Wrap each composition step; map exceptions to `AgentRunResult { Success=false }`; assert "exactly one terminal event per run" in tests. |
-| CLI agent leaks into SaaS (AC4) | High | Gate check at step 3 before any provider call; explicit SaaS+CLI test; resolver never returns CLI-backed agent in SaaS. |
-| Cost attribution wrong (BYOK vs platform) | Medium | `CredentialSource` is set by 32-3 and copied verbatim; unit test both branches; never re-derive it here. |
-| Double-counting events when reused activity also emits | Medium | `ManagedAgent` owns `AGENT.RUN.*`; the reused tool-loop seam emits only its existing tool-loop streaming events, not run-level events. |
-| Depends on 32-2/3/4 not yet landed | Medium | Code to the interfaces; gate the story behind those three; use fakes in tests until they land. |
+| Endpoint returns a raw 5xx → `RetryCheck`/breaker silently break (AC6/AC7) | Critical | The mapper always returns 200 `success:false` + preserved `httpStatusCode` for expected provider failures; HTTP-status-fidelity guardrail test (deep-dive §7.9); 400/403/401 only for gate/entitlement/auth. |
+| Loop-extraction drifts behaviour (AC4) | High | Pure verbatim move; `CallLlmInlineActivitySanitizationTests` unchanged as the regression net; `grep` proves one tool-loop copy. |
+| A failure path throws and drops the run record (AC10) | High | Wrap each compose step → `AgentRunResult{Success=false}` + one terminal `AGENT.RUN.FAILED`; "exactly one terminal event per run" test. |
+| Engine still holds a key after cutover (AC9) | High | Delete `ConfigPlatformProviderCredentialResolver` + `AddEngineProviderCredentialResolution`; grep `Tamma.Activities` for `Anthropic:ApiKey` / `/v1/messages` / non-`TammaApiClient` `PostAsync` → zero. |
+| Thin shim writes different variables → workflow breaks (AC5/AC6) | High | Map `LlmCallResponse` → the exact `LastDiagnostic`/`LastResponse`/`ToolLoop*` shapes; a minimal `LlmCallWorkflow` `ForEach`/`RetryCheck` integration test. |
+| Cost attribution wrong (BYOK vs platform) | Medium | `credentialSource` from 32-3 copied verbatim; markup only when `platform`; `providerCostUsd` identical both branches; both-branch test. |
+| Depends on sequence A–E + 32-4/32-3 not yet landed | Medium | Code to the interfaces; gate behind A–E; use fakes in tests until they land. |
+| Co-hosting hides the violation (design §1.1) | Medium | The shim calls over the wire via `TammaApiClient`, never resolves an injected vendor service — verified the moment the engine runs as per-tenant dedicated compute (Cranl). |
 
 ### Success Metrics
 
-- [ ] Every agent-driven workflow step routes through `RunManagedAgentActivity` → `IManagedAgent` (no remaining ad-hoc role→llm-call dispatch for managed agents).
-- [ ] 100% of managed runs produce an `AgentRunResult` and exactly one terminal `AGENT.RUN.*` event (success or failure).
+- [ ] `grep` over `Tamma.Activities` finds **zero** direct provider HTTP calls / `Anthropic:ApiKey` reads (all nine callers cut over).
+- [ ] `ElsaServer/Program.cs` registers **no** provider credential resolver (engine holds no LLM key).
+- [ ] 100% of mediated runs produce one `AGENT.RUN.STARTED` + exactly one terminal `AGENT.RUN.*`, and a metered usage record.
 - [ ] Zero forks of the tool loop / sanitizer / compactor (single source confirmed by grep).
+- [ ] `LlmCallWorkflow.cs` diff is empty (the workflow boundary is byte-for-byte unchanged).
 
 ## Related
 
-- Design spec: `docs/superpowers/specs/2026-06-17-agent-entities-benchmarking-design.md`
-- Implementation plan: `docs/superpowers/plans/2026-06-17-32-5-managed-agent-execution-layer-plan.md`
-- Sibling stories: `docs/stories/epic-32/story-32-2/`, `story-32-3/`, `story-32-4/`, `story-32-6/`, `story-32-8/`, `story-32-9/`
-- Reused code: `apps/tamma-elsa/src/Tamma.Activities/LlmCall/CallLlmInlineActivity.cs`
+- Design of record: `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§1 steps-never-call-providers; §2 the call-LLM endpoint; §5.2 phasing)
+- Managed-LLM deep dive: `docs/superpowers/specs/2026-06-20-managed-llm-execution-deep-dive.md` (§1 provider duality; §2 resilience relocation; §3 buffered/SSE; §4 tools/MCP/cache/RAG)
+- Re-plan: `docs/superpowers/plans/2026-06-20-epic-32-37-replan.md` (sequence step F)
+- Implementation plan: `docs/superpowers/plans/2026-06-21-32-5-call-llm-endpoint-and-managed-execution-plan.md`
+- Sibling stories: `story-32-3/` (credential resolver), `story-32-4/` (SaaS gate), `story-32-15/` (persona reframe), `story-32-16/` (enablement), `story-32-17/` (custom-agent prompts), `story-32-18/` (registry enablement gate + Epic-27 prompt source), `story-32-6/`, `story-32-8/`, `story-32-9/`; `docs/stories/epic-34/story-34-11/` (Provider Cost Price-Book)
+- Reused code: `apps/tamma-elsa/src/Tamma.Activities/LlmCall/CallLlmInlineActivity.cs` (the loop being extracted), `TammaApiClient`, `LlmCallWorkflow.cs`
 
 ## Logging Requirements
 
-- **INFO**: managed run started (agentId, version, provider, model, role, correlationId, credentialSource), run completed (success, durationMs, inputTokens, outputTokens, costUsd, toolCalls), gate decision (allow/deny + mode).
-- **DEBUG**: composition step boundaries (resolve → credential → gate → context → prompt → loop → cost), assembled-context size, rendered-prompt token estimate.
-- **WARN**: typed failure paths (budget-exceeded, gate-denied, provider-error, no-credential, loop-exhausted) with `failureCode` + correlationId.
-- **ERROR**: contract violations (null request), DCB event append failure (the run still returns its result; the append failure is logged, not swallowed silently).
-- **Structured context**: include `{ agentId, version, provider, model, role, correlationId, tenantId, credentialSource }` where applicable.
-- **Credential safety**: NEVER log the resolved API key, BaseUrl auth, or raw provider headers. `CredentialSource` (the label) is safe to log; the key is not.
+- **INFO**: call-LLM received (correlationId, role, persona/agentId, tenantId — **never the prompt body verbatim if it may contain secrets**); managed run started (agentId, version, provider, model, role, credentialSource); run completed (success, durationMs, inputTokens, outputTokens, providerCostUsd, toolCalls); gate decision (allow/deny + mode).
+- **DEBUG**: composition step boundaries (gate → resolve → credential → render → loop → meter), rendered-prompt token estimate, tool-loop turns.
+- **WARN**: typed failure paths (`PROVIDER_ERROR` + `httpStatusCode`, `PROVIDER_CREDENTIAL_UNAVAILABLE`, `BUDGET_EXCEEDED`, `LOOP_EXHAUSTED`) and gate denials (400/403) with `failureCode` + `correlationId`.
+- **ERROR**: contract violations (null request), DCB append failure (the run still returns its result; the append failure is logged, not swallowed), and any attempt to return a raw 5xx (guardrail).
+- **Structured context**: `{ agentId, version, provider, model, role, correlationId, tenantId, credentialSource }` where applicable.
+- **Credential safety (LOAD-BEARING)**: NEVER log, return, or persist the resolved API key, `BaseUrl` auth, or raw provider headers. `credentialSource` (the label `byok`/`platform`) is safe; the key is not. The `LlmCallResponse` body, all DCB event payloads, and the action trail are key-free by contract.
 
 ## Change Log
 
 | Date       | Version | Changes                | Author |
 | ---------- | ------- | ---------------------- | ------ |
-| 2026-06-17 | 1.0.0   | Initial story creation | Claude |
+| 2026-06-17 | 1.0.0   | Initial story creation — `IManagedAgent` orchestration seam over the inline path. | Claude |
+| 2026-06-21 | 2.0.0   | **Rewrite to the call-LLM endpoint model** (architecture pivot, sequence F). Reframed from an in-engine orchestration seam to `POST /api/v1/llm/call` in `Tamma.Api`: thin-client cutover of `CallLlmInlineActivity`/`CallLlmActivity` + the eight other direct-LLM callers; `IInlineToolLoopRunner` extraction now executes in the API with a request-scoped key; resilience relocation (credential/breaker-record/budget/metering moves server-side); deletion of the engine's `ConfigPlatformProviderCredentialResolver`/`AddEngineProviderCredentialResolution`; `LlmCallRequest`/`LlmCallResponse` wire contract with the load-bearing 200-`success:false`+`httpStatusCode` semantics; buffered-only (SSE/MCP/cache/question-back scoped out to follow-ons). `AgentRunResult`/reuse-not-fork/typed-failures-never-lost preserved. | Claude |

--- a/docs/stories/epic-34/README.md
+++ b/docs/stories/epic-34/README.md
@@ -78,7 +78,7 @@ USD credits, and promo codes (Story 34-7) layer on top of the resolved plan pric
 | 34-8 | Pricing Audit, Events & Reproducibility | P1 | drafted | 3-4 days |
 | 34-9 | Pricing & Plan Management Dashboards | P1 | drafted | 4-5 days |
 | 34-10 | Epic 20 Decommission & Pricing Contract Migration | P0 | drafted | 3-4 days |
-| 34-11 | Provider Cost Price-Book (`Provider` + `ProviderModelPrice` cost entities behind `IProviderPricingService`; before 34-5) *(2026-06-21)* | P0 | drafted | 3-4 days |
+| 34-11 | Provider Cost Price-Book (`Provider` + `ProviderModelPrice` cost entities behind `IProviderPricingService`; before 34-5) *(2026-06-21)* | P0 | drafted | 4-5 days |
 
 ## Architecture
 

--- a/docs/stories/epic-34/README.md
+++ b/docs/stories/epic-34/README.md
@@ -78,6 +78,7 @@ USD credits, and promo codes (Story 34-7) layer on top of the resolved plan pric
 | 34-8 | Pricing Audit, Events & Reproducibility | P1 | drafted | 3-4 days |
 | 34-9 | Pricing & Plan Management Dashboards | P1 | drafted | 4-5 days |
 | 34-10 | Epic 20 Decommission & Pricing Contract Migration | P0 | drafted | 3-4 days |
+| 34-11 | Provider Cost Price-Book (`Provider` + `ProviderModelPrice` cost entities behind `IProviderPricingService`; before 34-5) *(2026-06-21)* | P0 | drafted | 3-4 days |
 
 ## Architecture
 

--- a/docs/stories/epic-34/story-34-11/34-11-provider-cost-price-book.md
+++ b/docs/stories/epic-34/story-34-11/34-11-provider-cost-price-book.md
@@ -1,0 +1,404 @@
+# Story 34-11: Provider Cost Price-Book (DB-backed `Provider` + `ProviderModelPrice` behind `IProviderPricingService`)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+This mandatory guide covers the 7-phase workflow (Read → Research → Break Down → TDD → Quality Gates → Failure Handling), the `.dev/` knowledge base, TRACE/DEBUG logging, test-first development, 100% coverage on critical paths, and build-success enforcement.
+
+## User Story
+
+As a **platform owner**,
+I want the provider COST rate-sheet — today a hard-coded `FrozenDictionary` in `ProviderPricingService` — promoted to a first-class, admin-editable, immutable-versioned control-plane entity model (`Provider` + `ProviderModelPrice`) **behind the unchanged `IProviderPricingService` seam**,
+so that the platform's cost basis is a single canonical, auditable, time-windowed source of truth that the markup engine (34-5), usage metering (32-9), and analytics (36-2/36-7) all read without re-deriving rates — and so a usage event always prices under the cost rate that was effective when the call actually happened, even after a provider re-prices its models.
+
+## Priority
+
+P0 — Sequence step **A** of the Epic-34 pivot. This is the *cost* book; 34-1 owns the *price* book (sell) and 34-5 owns *markup* (cost × margin). 34-5's markup math (`CostBasisUsd = ProviderPricingService.Compute(...)`) and its `IsKnown` unknown-model gate consume this story's output. Without a DB-backed, versioned cost entity the cost basis is frozen at deploy time, cannot be re-priced without a code release, and provides no `EffectiveFrom` window for reproducible historical pricing. **Sequenced BEFORE 34-5** (its cost-basis input), alongside 34-1 (reuses its CP-entity + versioning + insert-missing-only-seeder patterns).
+
+## Context
+
+A cost-pricing layer already exists as the single cost-basis source of truth:
+`apps/tamma-elsa/src/Tamma.Api/Services/Providers/IProviderPricingService` / `ProviderPricingService` — a hard-coded `FrozenDictionary<provider, FrozenDictionary<model, Rate(InputPerToken, OutputPerToken)>>` ported verbatim from `packages/cost-monitor/src/pricing-config.ts` (commit `9e9a57c~1`). It carries the alias map, loose prefix match, and `null`/`"default"`→first-model rule that **34-5's `IsKnown` gate and the diagnostic write path depend on**. There is **no DB-backed `Provider` entity today**; the rate sheet is immutable at deploy time.
+
+The revised agent architecture (design §3, §4) requires the cost basis to be:
+- **first-class** (admin-editable, auditable) — a provider re-prices a model without a code release;
+- **versioned/immutable** — an edit *supersedes* rather than mutates, like `Plan` (34-1) and `MarginPolicy` (34-5), so a historical usage event re-prices under the rate active at its `OccurredAt` (byte-stable / reproducible — the cost-side companion of 34-5 AC7);
+- **platform-global, NOT tenant-scoped** — cost is the *provider's published rate*, identical for every tenant (`PricingMode`/BYOK affects only the *sell* side, never the cost basis — design §4.4).
+
+This story promotes the frozen table to two control-plane entities — `Provider` (the cost identity + `AuthModel` that feeds 32-4's SaaS-eligibility) and `ProviderModelPrice` (the per-model versioned cost) — **behind the existing `IProviderPricingService` seam**. The interface is the contract; the entity is the implementation detail. The frozen `ProviderPricingService` is retained as the deterministic seed/fallback source; a new `DbProviderPricingService` reads the entity table. **Downstream stories (34-5, 36-2, 36-7, 32-9) need at most a one-line DI dependency edit; none need AC or code changes** — that is the whole point of preserving the seam.
+
+> **COST vs PRICE — the three layers (design §4.3).** This story owns **COST only**. It is **NOT** `Plan`/`PlanPrice` (the subscription/seat *sell* price — 34-1), **NOT** `MarginPolicy` (the *markup* applied to cost — 34-5), and **NOT** 36-7 (the read-only margin *view*). `ProviderModelPrice` is per-token cost keyed by `(ProviderKey, Model)`; `PlanPrice` is subscription sell price keyed by `(PlanId, PricingMode)` — no overlap. 34-5 reads this entity for its cost basis and applies `MarginPolicy` on top; 36-7 reads neither — it reports the already-persisted `CostUsd` (this story's basis) minus revenue.
+
+## Acceptance Criteria
+
+1. New control-plane entity **`Provider`** (`Tamma.Data.Entities.Provider`) added to `ControlPlaneDbContext`: `Id` (UUIDv7), `Key` (canonical string — `anthropic|openai|google|openrouter|local|claude-code`), `DisplayName` (string), `AuthModel` (`api-key|cli-token` — feeds 32-4 SaaS-eligibility), `Status` (`active|retired`), `CreatedAt`, `UpdatedAt`. `Key` is unique. A CHECK pins `AuthModel ∈ ('api-key','cli-token')` and `Status ∈ ('active','retired')`.
+
+2. New control-plane entity **`ProviderModelPrice`** (`Tamma.Data.Entities.ProviderModelPrice`) added to `ControlPlaneDbContext`: `Id` (UUIDv7), `ProviderKey` (canonical, **alias-normalized on write**), `Model` (e.g. `claude-sonnet-4-20250514`, `gpt-4o`), `InputUsdPer1M` (`decimal`), `OutputUsdPer1M` (`decimal`), `CacheReadUsdPer1M` (`decimal?` — nullable, reserved), `CacheWriteUsdPer1M` (`decimal?` — nullable, reserved), `EffectiveFrom` (`timestamptz`, UTC), `Status` (`active|superseded`), `Source` (`seed|admin`), `CreatedAt`, `UpdatedAt`. CHECK constraints pin `Status ∈ ('active','superseded')` and `Source ∈ ('seed','admin')`.
+
+3. **Platform-global, not tenant-scoped.** Neither entity carries a `TenantId`/`UserId` column or a tenant query filter. Cost is the provider's published rate — identical for every tenant in both modes. (BYOK vs platform-provided is a *sell-side* concern owned by 34-3/34-5, never a cost-basis concern.) A model test asserts no `TenantId` property exists on either entity.
+
+4. **Immutable-versioned like `Plan`/`MarginPolicy`.** An edit **supersedes** rather than mutates: a partial unique index `UX_provider_model_prices_OneActivePerModel` on `(ProviderKey, Model) WHERE "Status" = 'active'` enforces exactly one `active` row per `(ProviderKey, Model)` at the DB level. A `PUT` that changes an existing `active` price flips the prior row to `superseded` and inserts a new `active` row with a later `EffectiveFrom` — never an in-place rate mutation. Attempting to mutate a `superseded` row throws `TammaError("PROVIDER.PRICE.IMMUTABLE", ...)`.
+
+5. **`EffectiveFrom`-windowed resolution.** A usage event prices under the cost rate that was `active`/`superseded` with `EffectiveFrom <= OccurredAt` and is the most-recent such row for `(ProviderKey, Model)`. This makes the cost chain byte-stable/reproducible (the cost-side companion of 34-5 AC7): given the same `(provider, model, in, out, occurredAt)` the cost is identical across runs. A `Compute(...)` overload (or the resolver) accepts an `atTimestamp` and selects the effective row; the existing no-timestamp `Compute` resolves against the current `active` row.
+
+6. **Load-bearing behaviours from the frozen table are preserved verbatim** in the DB-backed resolver (34-5's `IsKnown` gate and the diagnostic write path depend on these — they move into the entity-backed lookup, they are NOT dropped):
+   - **alias normalization** — `anthropic-claude`→`anthropic`, `claude`→`anthropic`, `gemini`→`google`, `github-copilot`→`openai`, `ollama`/`lmstudio`→`local` (the existing `s_aliases` map), applied to the lookup key AND on write to `ProviderModelPrice.ProviderKey`;
+   - **loose prefix match** — a request for `claude-sonnet-4` matches the stored `claude-sonnet-4-20250514` (first row whose `Model` starts with the requested id);
+   - **`null`/`"default"` → first-model rule** — resolves to the provider's first known model;
+   - **unknown `(provider, model)` returns `0m` from `Compute` and `false` from `IsKnown`** (the existing robustness contract — `Compute` never throws on an unpriced model so the diagnostic write path stays robust).
+
+7. **`DbProviderPricingService : IProviderPricingService`** (`Tamma.Api/Services/Providers/`) implements `Compute`/`IsKnown` over the entity table (with a short-lived in-memory snapshot cache invalidated on admin write), and is registered **in place of** the frozen `ProviderPricingService` in `Program.cs`. The `IProviderPricingService` interface is **unchanged** (`Compute(provider, model?, in, out)` + `IsKnown(provider, model?)`); the only addition is an optional `atTimestamp`-aware path on the concrete impl / a sibling resolver. Downstream consumers keep their `IProviderPricingService` dependency — a one-line registration swap, no consumer code change.
+
+8. **`ProviderPricingSeeder`** (`Tamma.Data/Seeders/ProviderPricingSeeder.cs`) ports the current frozen table **verbatim as v1 rows** (`Source = seed`, `Status = active`, `EffectiveFrom = <fixed seed epoch>`) with **deterministic UUIDv7 ids**, **insert-missing-only** (never reverts admin edits — mirrors `PlansSeeder`/`MarginPolicySeeder` and the convention system-defaults ownership rule). Each provider in `s_pricing` becomes a `Provider` row (with its `AuthModel`: `anthropic|openai|google|openrouter` = `api-key`, `claude-code` = `cli-token`, `local` = `api-key`/n-a) and each `(model, Rate)` becomes a `ProviderModelPrice` row (USD-per-token re-expressed as USD-per-1M). The frozen `ProviderPricingService` is **retained** as the seed source / boot fallback. The seeder is invoked in `Program.cs` alongside `PlansSeeder.SeedAsync` / `AgentEntitySeeder.SeedAsync`.
+
+9. **Admin CRUD endpoints** (`AdminProviderPricingEndpoints` in `Tamma.Api/Endpoints/Admin/`), gated by the **`PlatformOwnerAccess`** policy (NOT `OwnerAccess`, which admits every personal-tenant owner):
+   - `GET  /api/admin/providers` — list providers;
+   - `GET  /api/admin/providers/{key}/prices` — list (active + superseded) price rows for a provider;
+   - `PUT  /api/admin/providers/{key}/prices` — create/version a model price (supersede + insert, per AC4);
+   - `POST /api/admin/providers` — register a provider; `PATCH /api/admin/providers/{key}` — set `Status`/`DisplayName`/`AuthModel`.
+   Mutations emit DCB events to the control-plane store via `IEventRepository.AppendAsync`: `PROVIDER.PRICE.VERSIONED` (tags `providerKey, model, effectiveFrom, supersededPriceId, source=admin, actorUserId`) and `PROVIDER.REGISTERED` / `PROVIDER.STATUS_CHANGED`. A non-platform-owner gets **403** on every `/api/admin/providers*` route.
+
+10. **DB wiring + migration.** An EF Core migration under `Tamma.Data/Migrations/ControlPlane/` adds `providers` and `provider_model_prices` (purely additive), and `dotnet ef migrations has-pending-model-changes` reports none afterward. **Both new tables are appended to the `Program.cs` startup-reset DROP list** ("Wiping Tamma-managed public-schema tables", ~line 2110) AND to the strict `ControlPlaneDbContextModelTests.Model_Has_ExpectedControlPlaneEntities` `BeEquivalentTo` list — a second test-host boot otherwise fails with `relation "providers" already exists`, and the model test otherwise fails its strict equivalence assertion.
+
+11. **Per-mode handling.** The cost book is **platform-owned in both modes** — global control-plane rows, never tenant-scoped. Single-user mode: the sole user reads the cost book (no overrides; no per-user cost layer). SaaS mode: only platform owners (`PlatformOwnerAccess`) may register providers or version prices; tenant members get no read access to the admin routes (cost is internal). There is no per-tenant cost-rate override layer.
+
+12. **Unit + integration tests** cover: alias normalization (all five aliases resolve to the canonical rate), loose prefix match, `null`/`"default"`→first-model, unknown-model → `Compute=0m` + `IsKnown=false` (no throw), the supersede/version chain (v1 → v2 with correct `Status` flip + one-active invariant rejected by the partial unique index), `EffectiveFrom`-windowed selection (an event at `t` prices under the row effective at `t`, NOT the latest), seeder idempotency (second `SeedAsync` is a no-op and does not revert an admin-edited row), DB-vs-frozen **parity** (the seeded `DbProviderPricingService` produces byte-identical `Compute` output to the frozen `ProviderPricingService` for every seeded `(provider, model)`), `PlatformOwnerAccess` 403 for non-owners, and event emission with correct tags.
+
+## Technical Design
+
+### Namespace & file structure
+
+```
+apps/tamma-elsa/src/
+  Tamma.Data/Entities/
+    Provider.cs                              # NEW (Tamma.Data.Entities) — cost identity + AuthModel
+    ProviderModelPrice.cs                    # NEW — per-model versioned cost (USD-per-1M)
+  Tamma.Data/
+    ControlPlaneDbContext.cs                 # MODIFIED — 2 new DbSets + ConfigureProviders / ConfigureProviderModelPrices
+    Seeders/ProviderPricingSeeder.cs         # NEW — ports frozen table verbatim as v1 rows (insert-missing-only)
+    Migrations/ControlPlane/
+      <timestamp>_ProviderCostPriceBook.cs   # NEW EF migration (additive)
+  Tamma.Api/Services/Providers/
+    IProviderPricingService.cs               # UNCHANGED (the seam — Compute / IsKnown)
+    ProviderPricingService.cs                # KEPT — now the seed source / boot fallback (frozen table)
+    DbProviderPricingService.cs              # NEW — IProviderPricingService over the entity table (+ EffectiveFrom-aware path)
+    IProviderCostResolver.cs                 # NEW — EffectiveFrom-windowed row resolution (impure, DB-backed)
+    ProviderCostResolver.cs                  # NEW
+    ProviderPricingEventTypes.cs             # NEW — PROVIDER.PRICE.VERSIONED / PROVIDER.REGISTERED / PROVIDER.STATUS_CHANGED
+  Tamma.Api/Endpoints/Admin/
+    AdminProviderPricingEndpoints.cs         # NEW — /api/admin/providers* (PlatformOwnerAccess)
+  Tamma.Api/Extensions/
+    ProviderPricingServiceCollectionExtensions.cs  # NEW — DI wiring (swap registration)
+  Tamma.Api/Program.cs                       # MODIFIED — DROP list (+2 tables); seed call; endpoint map; DI swap
+```
+
+### Entities
+
+```csharp
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Control-plane PROVIDER entity (Story 34-11): the platform's COST identity
+/// for an external LLM provider. Platform-global — NOT tenant-scoped (cost is
+/// the provider's published rate, identical for every tenant). AuthModel feeds
+/// 32-4 SaaS-eligibility. This is the *cost* primitive; sell price is 34-1
+/// (PlanPrice) and markup is 34-5 (MarginPolicy).
+/// </summary>
+public class Provider
+{
+    public Guid Id { get; set; }                      // UUIDv7
+    public string Key { get; set; } = null!;          // canonical: anthropic|openai|google|openrouter|local|claude-code
+    public string DisplayName { get; set; } = null!;
+    public string AuthModel { get; set; } = "api-key"; // api-key | cli-token (feeds 32-4)
+    public string Status { get; set; } = "active";     // active | retired
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+
+    public ICollection<ProviderModelPrice> Prices { get; set; } = [];
+}
+
+/// <summary>
+/// The COST pricing — per model, versioned. An edit SUPERSEDES rather than
+/// mutates (partial unique index on (ProviderKey, Model) WHERE Status='active');
+/// EffectiveFrom-windowed so a usage event prices under the rate active at its
+/// OccurredAt (reproducible/byte-stable). USD-per-1M tokens.
+/// </summary>
+public class ProviderModelPrice
+{
+    public Guid Id { get; set; }                      // UUIDv7
+    public string ProviderKey { get; set; } = null!;  // canonical, alias-normalized on write
+    public string Model { get; set; } = null!;        // e.g. claude-sonnet-4-20250514
+    public decimal InputUsdPer1M { get; set; }
+    public decimal OutputUsdPer1M { get; set; }
+    public decimal? CacheReadUsdPer1M { get; set; }   // reserved (nullable)
+    public decimal? CacheWriteUsdPer1M { get; set; }  // reserved (nullable)
+    public DateTime EffectiveFrom { get; set; }       // UTC
+    public string Status { get; set; } = "active";    // active | superseded
+    public string Source { get; set; } = "seed";      // seed | admin (insert-missing-only seeder)
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}
+```
+
+### EF model config (in `ControlPlaneDbContext.OnModelCreating`)
+
+Mirrors the `ConfigurePlans` / `ConfigureAlertRules` style. `Provider` gets a unique index on `Key` and CHECKs on `AuthModel` / `Status`. `ProviderModelPrice` gets the immutability invariant in SQL:
+
+```csharp
+modelBuilder.Entity<Provider>(e =>
+{
+    e.ToTable("providers", t =>
+    {
+        t.HasCheckConstraint("ck_providers_auth_model", "\"AuthModel\" IN ('api-key','cli-token')");
+        t.HasCheckConstraint("ck_providers_status", "\"Status\" IN ('active','retired')");
+    });
+    e.HasKey(x => x.Id);
+    e.Property(x => x.Id).HasDefaultValueSql("gen_random_uuid()");
+    e.Property(x => x.Key).IsRequired().HasMaxLength(50);
+    e.HasIndex(x => x.Key).IsUnique().HasDatabaseName("UX_providers_Key");
+});
+
+modelBuilder.Entity<ProviderModelPrice>(e =>
+{
+    e.ToTable("provider_model_prices", t =>
+    {
+        t.HasCheckConstraint("ck_provider_model_prices_status", "\"Status\" IN ('active','superseded')");
+        t.HasCheckConstraint("ck_provider_model_prices_source", "\"Source\" IN ('seed','admin')");
+    });
+    e.HasKey(x => x.Id);
+    e.Property(x => x.Id).HasDefaultValueSql("gen_random_uuid()");
+    e.Property(x => x.ProviderKey).IsRequired().HasMaxLength(50);
+    e.Property(x => x.Model).IsRequired().HasMaxLength(200);
+    e.Property(x => x.InputUsdPer1M).HasColumnType("decimal(20,8)");
+    e.Property(x => x.OutputUsdPer1M).HasColumnType("decimal(20,8)");
+
+    // Exactly one active price per (ProviderKey, Model) — the immutability
+    // invariant in SQL (mirrors UX_plans_OneActivePerSlug / MarginPolicy).
+    e.HasIndex(x => new { x.ProviderKey, x.Model })
+        .HasDatabaseName("UX_provider_model_prices_OneActivePerModel")
+        .HasFilter("\"Status\" = 'active'").IsUnique();
+
+    // Resolution-window lookup (provider+model, ordered by EffectiveFrom).
+    e.HasIndex(x => new { x.ProviderKey, x.Model, x.EffectiveFrom })
+        .HasDatabaseName("IX_provider_model_prices_Window");
+
+    e.HasOne<Provider>().WithMany(p => p.Prices)
+        .HasForeignKey(x => x.ProviderKey).HasPrincipalKey(p => p.Key)
+        .OnDelete(DeleteBehavior.Restrict);
+});
+```
+
+### The `IProviderPricingService` seam (UNCHANGED) + the DB impl
+
+```csharp
+// IProviderPricingService.cs — NO CHANGE. The contract stays:
+//   decimal Compute(string provider, string? model, int inputTokens, int outputTokens);
+//   bool    IsKnown(string provider, string? model);
+
+// DbProviderPricingService.cs — NEW. Reads the entity table; preserves the
+// frozen table's alias map, loose prefix match, null/"default" rule, and the
+// unknown→0m / IsKnown=false robustness contract — verbatim, just sourced from
+// rows instead of a FrozenDictionary. Holds a short-lived snapshot cache
+// (active rows) invalidated on admin write.
+public sealed class DbProviderPricingService : IProviderPricingService
+{
+    public decimal Compute(string provider, string? model, int inputTokens, int outputTokens) { /* active-row lookup */ }
+    public bool IsKnown(string provider, string? model) { /* active-row lookup */ }
+
+    // EffectiveFrom-windowed overload used by the metering path (34-5 / 32-9):
+    public decimal ComputeAt(string provider, string? model, int inputTokens, int outputTokens, DateTime atTimestamp);
+}
+```
+
+The alias normalization map (`s_aliases`) and the `TryGetRate` algorithm (canonicalize → model-map → `null`/`"default"`→first → exact → loose-prefix) move into a shared static helper consumed by BOTH the frozen `ProviderPricingService` (seed source) and `DbProviderPricingService` (over rows), so the two cannot drift. AC12's parity test pins this.
+
+### Cost vs price boundary (design §4.3 — explicit)
+
+| Layer | This story owns? | Entity / seam | Answers |
+|---|---|---|---|
+| **COST** | **YES** | `Provider` + `ProviderModelPrice` behind `IProviderPricingService` | "What did this call cost us at the provider?" |
+| PRICE — subscription | NO (34-1) | `Plan` / `PlanPrice` | "What does the plan cost the tenant?" |
+| PRICE — markup | NO (34-5) | `MarginPolicy` / `IUsagePricingEngine` | "What sell price for platform-provided tokens?" |
+| VIEW | NO (36-7) | `MarginAnalyticsService` (pure read) | "Are we making money?" |
+
+`CostBasisUsd = ProviderPricingService.Compute(provider, model, in, out)` is the **input to 34-5**; `SellPriceUsd = CostBasisUsd × MarkupMultiplier (+ FixedUsdPer1M)`. `MarginPolicy.Scope='provider'` can override the *margin* per provider — **never** the *cost rate* (which lives here). 36-7 reads neither: it reads the already-persisted `CostUsd` (this basis) + `PlatformBilledUsd` (34-5 sell) columns 36-2 wrote.
+
+### Seeder (insert-missing-only, verbatim port)
+
+```csharp
+// ProviderPricingSeeder.SeedAsync(ControlPlaneDbContext)
+//   For each provider in ProviderPricingService.s_pricing:
+//     upsert-if-missing a Provider row { Key, DisplayName, AuthModel, Status='active' }
+//   For each (model, Rate) under that provider:
+//     upsert-if-missing a ProviderModelPrice row {
+//       ProviderKey = canonical, Model, EffectiveFrom = SEED_EPOCH,
+//       Status='active', Source='seed',
+//       InputUsdPer1M  = Rate.InputPerToken  * 1_000_000m,
+//       OutputUsdPer1M = Rate.OutputPerToken * 1_000_000m }
+//   Deterministic UUIDv7 per (key)/(key,model). Second run = no-op; never
+//   reverts a Source='admin' row.
+```
+
+The frozen `ProviderPricingService` is retained verbatim (the seed source + a boot fallback if the table is empty). AuthModel mapping: `claude-code` → `cli-token` (CLI harness); all of `anthropic|openai|google|openrouter|local` → `api-key` (feeds 32-4's SaaS-eligibility — only `api-key` providers are SaaS-eligible).
+
+### Admin endpoints (`PlatformOwnerAccess`)
+
+```
+GET    /api/admin/providers                      # list providers
+POST   /api/admin/providers                      # register provider
+PATCH  /api/admin/providers/{key}                # set Status / DisplayName / AuthModel
+GET    /api/admin/providers/{key}/prices         # list active + superseded prices
+PUT    /api/admin/providers/{key}/prices         # version a model price (supersede + insert)
+```
+
+`PUT .../prices` body `{ model, inputUsdPer1M, outputUsdPer1M, cacheReadUsdPer1M?, cacheWriteUsdPer1M?, effectiveFrom }`: normalize `ProviderKey` via the alias map, flip the current `active` row for `(key, model)` to `superseded`, insert a new `active` row (`Source='admin'`), emit `PROVIDER.PRICE.VERSIONED`. All routes gated by `PlatformOwnerAccess`; non-owner → 403.
+
+### Migration sketch
+
+```csharp
+// <timestamp>_ProviderCostPriceBook.cs (Tamma.Data.Migrations.ControlPlane) — additive
+migrationBuilder.CreateTable("providers", ...);            // Id, Key (UX), DisplayName, AuthModel, Status, timestamps
+migrationBuilder.CreateTable("provider_model_prices", ...); // Id, ProviderKey FK→providers.Key, Model, In/Out + cache nullables, EffectiveFrom, Status, Source, timestamps
+// CHECK + partial-unique (UX_provider_model_prices_OneActivePerModel) + window index per the model config above.
+```
+
+`has-pending-model-changes` must report none after generation.
+
+## Dependencies
+
+**Internal:**
+
+- **Story 34-1** (Plan & Price-Book Catalog Data Model) — the CP-entity + immutable-versioning + insert-missing-only-seeder + `PlatformOwnerAccess` admin patterns this story reuses (sibling, not a hard blocker; both are sequence-A foundations).
+- **Epic 1 / providers** — `IProviderPricingService` / `ProviderPricingService` (the seam being promoted) and the `s_aliases` map / `s_pricing` table being ported.
+- **Epic 28** — `ControlPlaneDbContext`, the CP migration chain, `ControlPlaneDbContextModelTests`, and the `Program.cs` startup-reset DROP list this story extends.
+- **`IEventRepository` (DCB)** — control-plane event store for `PROVIDER.*` admin events.
+- **`PlatformOwnerAccess` policy** — platform-owner RBAC for `/api/admin/providers*`.
+
+**Consumers (downstream — one-line DI dependency edit at most, NO AC/code change):**
+
+- **Story 34-5** (Cost→Price Markup Engine) — `CostBasisUsd = IProviderPricingService.Compute(...)` and its `IsKnown` unknown-model gate; gains the `EffectiveFrom`-aware `ComputeAt` for reproducible historical pricing (34-5 AC7 cost side). **Sequenced after this story.**
+- **Story 32-9** (cost-basis + margin metering) — emits the usage/cost event whose `CostUsd` comes from this seam.
+- **Story 32-5** (managed agent execution) — `AgentRunResult.CostUsd = _pricing.Compute(...)` (the producer).
+- **Story 36-2 / 36-7** (analytics) — read the persisted `CostUsd` written from this basis (36-7 does NOT re-read this entity).
+
+**External:** none new.
+
+## Testing Strategy
+
+1. **Parity (AC12, the load-bearing one):** for every seeded `(provider, model)`, assert `DbProviderPricingService.Compute(...)` equals the frozen `ProviderPricingService.Compute(...)` byte-for-byte (input/output rates, integer-token math). Proves the promotion is behaviour-preserving.
+2. **Alias normalization:** `anthropic-claude`, `claude` → anthropic rate; `gemini` → google; `github-copilot` → openai; `ollama`/`lmstudio` → local; both for lookup AND for `ProviderModelPrice.ProviderKey` on write.
+3. **Loose prefix + default rules:** `claude-sonnet-4` matches stored `claude-sonnet-4-20250514`; `null`/`"default"` → first model; unknown → `Compute=0m`, `IsKnown=false`, no throw.
+4. **Versioning / supersede:** `PUT` an edited price → prior row `superseded`, new row `active`; the partial unique index rejects a second `active` row for one `(ProviderKey, Model)`; mutating a `superseded` row throws `PROVIDER.PRICE.IMMUTABLE`.
+5. **`EffectiveFrom`-windowed selection:** seed v1 at `t0`, version v2 at `t1`; `ComputeAt(..., t)` for `t0 <= t < t1` uses v1, for `t >= t1` uses v2 (priced under the rate active at the event time, not the latest).
+6. **Seeder idempotency:** second `SeedAsync` is a no-op; an admin-edited (`Source='admin'`) row is NOT reverted.
+7. **RBAC:** every `/api/admin/providers*` route returns 403 for a non-`PlatformOwnerAccess` caller; a platform owner succeeds.
+8. **Events:** `PROVIDER.PRICE.VERSIONED` / `PROVIDER.REGISTERED` / `PROVIDER.STATUS_CHANGED` appended with the AC9 tags.
+9. **Model-shape (AC3/AC10):** `Provider`/`ProviderModelPrice` carry no `TenantId`; `ControlPlaneDbContextModelTests.Model_Has_ExpectedControlPlaneEntities` includes `providers` + `provider_model_prices`; the partial unique index + CHECKs are present on the design-time model.
+10. **Migration:** `dotnet ef migrations has-pending-model-changes` reports none; a second test-host boot does not fail with `relation already exists` (DROP-list extension verified).
+
+Docker-bound C# suites run via `sg docker -c "dotnet test apps/tamma-elsa/..."` (session docker group is stale; plain `dotnet build` needs no wrapper).
+
+## Estimated Effort
+
+4-5 days
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Data/Entities/Provider.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/ProviderModelPrice.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs` | Modify (2 DbSets + Configure* methods) |
+| `apps/tamma-elsa/src/Tamma.Data/Seeders/ProviderPricingSeeder.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/<ts>_ProviderCostPriceBook.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Providers/DbProviderPricingService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Providers/IProviderCostResolver.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderCostResolver.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderPricingEventTypes.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderPricingService.cs` | Modify (extract shared alias/lookup helper; retain as seed/fallback) |
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminProviderPricingEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/ProviderPricingServiceCollectionExtensions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (DROP list +2 tables; seed call; endpoint map; DI swap) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs` | Modify (add `providers` + `provider_model_prices` to strict list) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Providers/DbProviderPricingServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Providers/ProviderPricingParityTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Providers/ProviderPricingSeederTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/AdminProviderPricingEndpointsTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, and decisions
+3. Reviewed `ProviderPricingService.cs` (the frozen table + alias map + `TryGetRate` you are porting), `Plan`/`PlansSeeder` and `MarginPolicy`/`MarginPolicySeeder` (the CP-entity + versioning + insert-missing-only patterns you mirror), and the `Program.cs` DROP list + `ControlPlaneDbContextModelTests` (the two lists you MUST extend)
+4. Confirmed `PlatformOwnerAccess` (NOT `OwnerAccess`) is the policy for the admin routes
+5. Planned TDD approach (Red-Green-Refactor; write the parity + versioning tests first)
+
+### Key Design Decisions
+
+- **Promote behind the seam, don't replace the seam.** `IProviderPricingService` (`Compute`/`IsKnown`) is the contract every downstream story already depends on. Swapping `ProviderPricingService` → `DbProviderPricingService` is a one-line DI edit; no consumer changes. The frozen table stays as the deterministic seed source + boot fallback. This is the explicit design §4.5 instruction: "swap the frozen table for a DB read; keep the interface."
+- **Cost is mode-independent and tenant-independent.** The most important boundary: BYOK vs platform-provided (32-3 `credentialSource`) changes only the *sell* price (34-5: markup when platform, 0 token price when BYOK) — the cost basis is computed identically. There is therefore NO tenant column on either entity (design §4.4).
+- **Immutable-versioned = reproducible cost.** Reuse 34-1/34-5's exact pattern: partial unique index for one-active, `EffectiveFrom` window for time-travel. A re-priced model must not retroactively change historical invoices — the cost-side companion of 34-5 AC7.
+- **Don't drop the load-bearing quirks.** The alias map, loose prefix match, and `null`/`"default"`→first rule are not incidental — 34-5's `IsKnown` gate and the diagnostic write path depend on them. They move into the entity-backed resolver verbatim (shared helper), proven by the parity test.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who owns the cost book? | The platform (the engine ships it); the **sole user reads it**. It is global, not user-scoped — there is no per-user cost-rate override. | The platform (control-plane rows). It is global across all tenants — there is no per-tenant cost-rate override. |
+| Who may register a provider / version a price? | The sole user (acting as platform owner). | **`PlatformOwnerAccess` only** (NOT `OwnerAccess`). Tenant owners/admins/members cannot — cost config is internal. |
+| Where do the entities live? | `ControlPlaneDbContext` public-schema (`providers` / `provider_model_prices`). | Same — control-plane, never the tenant `t_<hex>` schema. |
+| Where do `PROVIDER.*` admin events land? | Control-plane DCB store (`IEventRepository`). | Same control-plane store; tagged with `actorUserId`. |
+| Does BYOK/tenant affect the cost? | No — cost is the provider's published rate. | No — cost is identical for every tenant; only the *sell* price (34-5) differs by `credentialSource`. |
+| Mode source | `ITammaModeProvider` — process-stable. | same |
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Forgetting to add `providers`/`provider_model_prices` to the `Program.cs` DROP list → 2nd test-host boot fails `relation already exists` | High | Explicit AC10 + a test that boots the host twice; checklist item; cite the exact line (~2110). |
+| Forgetting to update `ControlPlaneDbContextModelTests` strict `BeEquivalentTo` list → CP model test fails | High | Explicit AC10; the model test is part of the suite; add the two tables in the same commit as the entities. |
+| DB resolver drifts from the frozen behaviour (alias / prefix / default / unknown→0) | High | Extract ONE shared alias+lookup helper consumed by both impls; the parity test (AC12.1) asserts byte-identical `Compute` for every seeded pair. |
+| Tenant accidentally scoped onto a cost entity | High | AC3 model test asserts no `TenantId`/`UserId` property; cost is global by design §4.4. |
+| Using `OwnerAccess` instead of `PlatformOwnerAccess` (admits every personal-tenant owner) | High | AC9 pins `PlatformOwnerAccess`; RBAC test asserts 403 for a non-platform-owner. |
+| Mutating cost retroactively breaks historical invoices | Medium | Immutable-versioning (supersede + `EffectiveFrom` window); `ComputeAt` used by the metering path; windowed-selection test. |
+| Seeder reverts admin edits on redeploy | Medium | Insert-missing-only (mirrors `PlansSeeder`); idempotency test asserts a `Source='admin'` row survives a re-seed. |
+| Decimal precision drift (USD-per-token ↔ USD-per-1M round-trip) | Medium | Store `decimal(20,8)` USD-per-1M; integer-token math at `Compute`; parity test covers every seeded model including sub-cent rates (`gemini-1.5-flash` @ $0.075/1M). |
+
+### Success Metrics
+
+- [ ] `IProviderPricingService` interface unchanged; `DbProviderPricingService` registered in place of the frozen impl with a one-line DI swap; zero downstream consumer code edits.
+- [ ] Parity test green for 100% of seeded `(provider, model)` pairs (DB == frozen).
+- [ ] `dotnet ef migrations has-pending-model-changes` reports none; the test host boots twice without `relation already exists`.
+- [ ] `ControlPlaneDbContextModelTests.Model_Has_ExpectedControlPlaneEntities` passes with `providers` + `provider_model_prices` added.
+
+## Related
+
+- Design of record: `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§3 PROVIDER cost entity, §4 cost-vs-price three layers + §4.5 "new story behind the seam")
+- Re-plan: `docs/superpowers/plans/2026-06-20-epic-32-37-replan.md`
+- Implementation plan: `docs/superpowers/plans/2026-06-21-34-11-provider-cost-price-book-plan.md`
+- Sibling stories: `docs/stories/epic-34/story-34-1/` (price book — sell), `story-34-5/` (markup engine — consumer), `docs/stories/epic-32/story-32-5/` (managed execution — consumer), `story-32-9/` (metering — consumer)
+- Promoted seam: `apps/tamma-elsa/src/Tamma.Api/Services/Providers/IProviderPricingService.cs` + `ProviderPricingService.cs`
+
+## Logging Requirements
+
+- **INFO**: provider registered (`providerKey`, `authModel`), price versioned (`providerKey`, `model`, `effectiveFrom`, `supersededPriceId`), seeder summary (providers/prices inserted vs skipped).
+- **DEBUG**: cost resolution (`providerKey`, `model`, `atTimestamp`, resolved `priceId`, `effectiveFrom`), alias normalization (`requested` → `canonical`), snapshot-cache hit/miss + invalidation on admin write.
+- **WARN**: unknown `(provider, model)` lookups (returns `0m` — visible misconfiguration signal, same as `IsKnown=false`); a `ComputeAt` with no row effective at the timestamp (returns `0m`); seeder skip of an admin-edited row.
+- **ERROR**: immutability violation (`PROVIDER.PRICE.IMMUTABLE` attempt on a `superseded` row); DCB event append failure (operation still returns; the append failure is logged, not silently swallowed); migration / DROP-list mismatch at boot.
+- **Structured context**: include `{ providerKey, model, effectiveFrom, status, source, actorUserId }` where applicable.
+- **Credential safety**: this story handles COST RATES, not credentials — but never log API keys, tokens, or BYOK material (the cost entity carries none; the credential resolver is 32-3). The `AuthModel` label (`api-key`/`cli-token`) is safe to log; no key ever touches this path.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-21 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-38/README.md
+++ b/docs/stories/epic-38/README.md
@@ -1,0 +1,181 @@
+# Epic 38: Step → Internal-API Mediation for Non-LLM Integrations
+
+## Overview
+
+Epic 32 closed the **LLM** rule-1 violation: a workflow step no longer calls Anthropic/OpenAI from inside the Elsa engine — it calls `POST /api/v1/llm/call`, and `Tamma.Api` holds the credential, gates the call, performs the external HTTP, meters, and audits. Epic 38 finishes the job for **every other external effect** the engine still reaches (or reaches *only because* it is co-hosted with `Tamma.Api` in the current single-process deploy).
+
+The locked principle (design §1.1): the Elsa engine (`Tamma.ElsaServer` / `Tamma.Activities`) is a **deterministic orchestrator that holds no secrets**. Any activity needing an external effect **delegates over HTTP to a `Tamma.Api` endpoint** through `TammaApiClient` (Bearer `Tamma:ApiToken` via `TammaEngineAuthHandler` + `X-Tenant-Id`). The credential-holding code, the authorization decision, the external HTTP call, and the metering/audit emission **all live in `Tamma.Api`**.
+
+> **Co-hosting is NOT compliance.** Many activities today resolve a credential-holding *service from the same DI container* (`IGitHubIntegrationService`, `IGitHubActionsClient`, `IIntegrationService`) because, in the single-process deploy, the engine activities and the API services share a container. Rule #1 forbids this: the step must call an internal endpoint **over the wire**, not resolve an injected vendor service. This matters the moment the engine runs as **per-tenant dedicated compute** (the Cranl path) — then the token would have to be pushed *into the engine process*, exactly what Epic 38 prevents.
+
+Epic 38 reuses the **`/llm/call` template** verbatim: engine activity → `TammaApiClient` → an internal `/api/v1` endpoint that holds the credential, authorizes the `tenant ↔ resource` relationship, performs the call, and emits the audit event. The activities collapse into thin clients that hold **no token**.
+
+### The compliant references already in-tree (the template — design §1.1)
+
+| Reference | Pattern | What Epic 38 borrows |
+|---|---|---|
+| **`TammaApiClient`** | Engine→API HTTP delegation: `Authorization: Bearer <Tamma:ApiToken>` + `X-Tenant-Id`; `PostAsync<T>` + `AddTenantHeader` + `RecordHealthAsync`. Already routes agent-resolve / budget / diagnostics / provider-session / **`/llm/call`**. | The transport + auth plane for every Epic 38 endpoint. |
+| **`TriggerCIActivity`** | Already POSTs to an internal `Engine:CallbackUrl/api/engine/trigger-ci`; holds no CI-vendor credential. | The "internal POST, no key in engine" shape for synchronous request/response. |
+| **`QueueWelcomeEmailActivity`** | The **outbox pattern**: the step writes intent to `platform_email_outbox`; an out-of-band `OutboxSmtpSender` in the API holds the SMTP credential and performs transport. | The model for **fire-and-forget** external effects (Class D Slack). |
+
+## Relationship to Epic 32 (this epic does NOT block it)
+
+Epic 32 mediated the **LLM path only** (design §5.2 "Now"). Epic 38 is the explicitly-named **follow-up sibling** ("Step → internal-API mediation for non-LLM integrations", design §5.2/§6) for everything else. The LLM violators were P0 — the only steps that, in **any** deploy topology, put a live external key in the engine — and were fixed in Epic 32 (Story 32-5). The non-LLM violators are **VIOLATION-by-co-hosting**: latent today (the credential service is unregistered/null in the standalone engine), but live the moment the engine is per-tenant dedicated compute. Epic 38 closes them on its own schedule and adds a build-time guardrail so they cannot reappear.
+
+## The violator classes (derived from the §1.2 audit table)
+
+| Class | Activities (engine) | External target | How it reaches it today | Verdict (§1.2) | Epic 38 story |
+|---|---|---|---|---|---|
+| **A — Git platform** | `ADL/CreateBranchActivity`, `ADL/CreatePullRequestActivity`, `ADL/MergePullRequestActivity`, `ADL/UpdateIssueStatusActivity`, `ADL/AnalyzeReviewActivity` | GitHub / GitLab / … | `IGitHubIntegrationService` (impl + `GitHub:Token` in `Tamma.Api`; **unregistered/null in engine**) | VIOLATION-by-co-hosting — **high blast radius**: a mis-scoped platform token = cross-tenant write/merge | **38-1** |
+| **C — Agent dispatch** | `AgentDispatch/DispatchAgentWorkflowActivity` / `GitHubActionsExecutor`, `AgentDispatch/MonitorAgentWorkflowActivity`, `AgentDispatch/CollectAgentResultsActivity` | GitHub Actions | `IGitHubActionsClient` (`OctokitGitHubActionsClient` in API; `NullGitHubActionsClient` in engine) | VIOLATION-by-co-hosting | **38-2** |
+| **D — Slack / notifications** | `Integration/SlackActivity` | Slack | `IIntegrationService` (impl + Slack token in API; unregistered in engine) | VIOLATION-by-co-hosting — **low blast radius** (token-holding but reads no tenant data) | **38-3** |
+| **E — Billing / Stripe** | (future — Epic 35 unbuilt) | Stripe | none yet | **Enforce-by-design**: the activity emits an intent / outbox row; the API holds the Stripe key, charges/invoices, meters. **Prohibited at design time** to call Stripe from an activity. | covered by the 38-4 guardrail; enforced when Epic 35 lands |
+
+### Already compliant (no story — referenced as the template)
+
+- **`Testing/TriggerCIActivity`** — already POSTs to an internal engine callback; holds no CI-vendor credential. Epic 38 only *formalizes* it under `/api/v1` opportunistically; it is not a violator.
+- **`TenantLifecycle/QueueWelcomeEmailActivity`** — the outbox reference pattern (Class D borrows it).
+- **`AgentDispatch/WebhookSignalRegistry`** — the inbound `workflow_run.completed` receiver. **Not a violator** (inbound): received by `Tamma.Api`, signalled to the engine in-process; there is **no outbound external call to mediate**. Out of scope by nature (design §5.3) — see Story 38-2.
+
+## Stories
+
+| Story | Title | Class | Priority | Status | Est. Effort |
+|-------|-------|-------|----------|--------|-------------|
+| 38-1 | Git-platform step mediation (Class A) | A | P1 | drafted | 5-6 days |
+| 38-2 | Agent-dispatch step mediation (Class C) | C | P1 | drafted | 4-5 days |
+| 38-3 | Slack / notifications step mediation (Class D) | D | P2 | drafted | 2-3 days |
+| 38-4 | Build-time guardrail analyzer (no in-engine external calls) | — | P1 | drafted | 3-4 days |
+
+## Architecture
+
+```
++-----------------------------------------------------------------------------+
+|     EPIC 38: STEP → INTERNAL-API MEDIATION FOR NON-LLM INTEGRATIONS          |
++-----------------------------------------------------------------------------+
+|                                                                             |
+|   ENGINE (Tamma.ElsaServer / Tamma.Activities) — HOLDS NO SECRETS           |
+|   +----------------------+   +----------------------+   +----------------+   |
+|   | ADL/* git activities |   | AgentDispatch/*      |   | Integration/   |   |
+|   | (thin clients)       |   | (thin clients)       |   | SlackActivity  |   |
+|   +----------+-----------+   +----------+-----------+   +-------+--------+   |
+|              |                          |                       |            |
+|              |  TammaApiClient (Bearer Tamma:ApiToken + X-Tenant-Id)        |
+|              v                          v                       v            |
+|   ......................................................................... |
+|   :  Tamma.Api  — HOLDS CREDENTIALS, AUTHORIZES, CALLS, METERS, AUDITS    : |
+|   :  +------------------------+  +-----------------------+  +-----------+  : |
+|   :  | GitEndpoints (38-1)    |  | AgentDispatchEndpoints |  | Notif-    |  : |
+|   :  | /api/v1/git/{repo}/... |  | (38-2)                 |  | ications  |  : |
+|   :  |  - PAT/installation    |  | /api/v1/agent-dispatch |  | (38-3)    |  : |
+|   :  |  - per-tenant token    |  |  - dispatch/poll runs  |  | /slack    |  : |
+|   :  |    (Epic 28/29 cabinet)|  +-----------------------+  | (outbox)  |  : |
+|   :  |  - tenant↔repo guard   |                             +-----------+  : |
+|   :  |  - audit event         |   Class E (Stripe): enforce-by-design     : |
+|   :  +------------------------+                                            : |
+|   ......................................................................... |
+|                                                                             |
+|   BUILD-TIME GUARDRAIL (38-4): fail the build if any Tamma.Activities class  |
+|   references HttpClient/PostAsync to a non-TammaApiClient host, or injects   |
+|   a credential-holding vendor service. Violations cannot reappear.          |
+|                                                                             |
++-----------------------------------------------------------------------------+
+```
+
+## Key Technical Decisions
+
+### Mirror `/llm/call`, do not invent a new pattern
+
+Every Epic 38 endpoint mirrors `LlmCallEndpoints` (Story 32-5): same auth plane (`TammaEngineAuthHandler` Bearer + `X-Tenant-Id`), same engine-only authorization policy, same "the credential is resolved *inside* the API, request-scoped, never logged/returned" discipline, same DCB-audit-from-the-API contract. The activity becomes a thin `TammaApiClient` shim that holds no token and owns no vendor logic.
+
+### The cross-tenant guard is the load-bearing control (Class A/C)
+
+The §1.3 risk: "high the moment the engine is not co-hosted with `Tamma.Api`: a **mis-scoped platform token = cross-tenant write/merge**." The API endpoint MUST authorize that *this* tenant (from `X-Tenant-Id`) may act on *this* `{repo}` before it resolves a token or calls the platform — deny → key-free typed failure, never an external call. Resolution is **tenant→system→error** (`feedback_resolution_no_empty_fallback`): never fall back to a default/empty token.
+
+### Per-tenant tokens via the Epic 28/29 cabinet
+
+A tenant's own platform PAT / installation token resolves from the Epic 29 secret cabinet (BYOK), keyed per-tenant (Epic 28 tenancy), falling back to the platform-provided token where allowed — exactly the BYOK→platform shape Story 32-3 established for LLM keys. The resolved token is request-scoped and dropped after the call.
+
+### Outbox for fire-and-forget; request/response for synchronous
+
+Class D (Slack) is fire-and-forget → the `QueueWelcomeEmailActivity` **outbox** model (write intent, out-of-band sender holds the token). Class A (git) and Class C (agent dispatch) need a result back synchronously → the `TriggerCIActivity` **internal-POST** model. (38-3 / the outbox detail is owned by the separately-authored 38-3.)
+
+### Inbound webhooks are out of scope (design §5.3)
+
+The GitHub `workflow_run.completed` receiver + `WebhookSignalRegistry` are **inbound**: received by `Tamma.Api`, signature-verified there, signalled to the engine in-process. There is no outbound external call to mediate — signature verification + secret already live in the API. Story 38-2 explicitly excludes them.
+
+### Build-time guardrail so it cannot regress (38-4)
+
+A Roslyn analyzer / architecture test fails the build if any class under `Tamma.Activities` references `HttpClient`/`PostAsync`/`PostAsJsonAsync` to a non-`TammaApiClient` host, or injects a credential-holding vendor service. This makes rule #1 structural, not a review convention. (38-4 is authored separately.)
+
+## Dependencies
+
+### On Other Epics
+
+- **Epic 32** (Story 32-5): the `/llm/call` mediation **template** every Epic 38 endpoint mirrors (endpoint shape, `TammaApiClient` cutover, request-scoped-credential discipline, DCB-audit-from-API). Not a hard blocker — Epic 38 can proceed in parallel once 32-5's pattern is settled.
+- **Epic 28** (tenancy): `ControlPlaneDbContext` / `TenantDbContext`, schema-per-tenant, `ITenantContext` — the per-tenant token keying and the `tenant ↔ repo` authorization data.
+- **Epic 29** (secret cabinet): encrypted per-tenant platform tokens (BYOK PAT / installation token), resolved BYOK→platform inside the API.
+- **Epic 9** (unified agent API): the `TammaApiClient` / `TammaEngineAuthHandler` engine↔API callback convention reused by every endpoint.
+- **Epic 4** (DCB event sourcing): `DomainEvent` / `IEventRepository`, tenant-scoped, for the audit events each endpoint emits.
+- **Epic 35** (billing — future): Class E is enforced-by-design when Epic 35 lands; the 38-4 guardrail forbids an in-activity Stripe call before then.
+
+### External Dependencies
+
+- None new. All work is in the C# `apps/tamma-elsa` stack (`Tamma.Api`, `Tamma.Activities`, `Tamma.ElsaServer`, `Tamma.Data`). Reuses the existing `IGitHubIntegrationService` / `IGitHubActionsClient` / `IIntegrationService` implementations (Octokit etc.) — but only **inside `Tamma.Api`**, never in the engine. **`packages/api` is deleted — never referenced.**
+
+## Endpoints (design §5.1)
+
+```
+# Class A — git platform (38-1)
+POST  /api/v1/git/{repo}/branches
+POST  /api/v1/git/{repo}/pull-requests
+PUT   /api/v1/git/{repo}/pull-requests/{n}/merge
+GET   /api/v1/git/{repo}/pull-requests/{n}/comments
+PATCH /api/v1/git/{repo}/issues/{n}
+
+# Class C — agent dispatch (38-2)
+POST  /api/v1/agent-dispatch/{repo}/runs
+GET   /api/v1/agent-dispatch/{repo}/runs/{id}
+
+# Class D — Slack / notifications (38-3, authored separately)
+POST  /api/v1/notifications/slack
+```
+
+All endpoints are internal/engine-only (Bearer `Tamma:ApiToken` via `TammaEngineAuthHandler` + `X-Tenant-Id`); a missing/invalid bearer → 401, and the tenant↔resource guard → key-free typed failure on denial.
+
+## Implementation Phases
+
+### Phase 1: High-blast-radius writes (38-1, 38-2) — P1
+
+The git-platform writes (branch/PR/merge/issue) and the agent-dispatch (Actions run + poll) are the highest-risk surfaces once the engine is per-tenant dedicated compute — a mis-scoped token here is a cross-tenant write/merge. Mediate them first, behind the cross-tenant guard.
+Estimated: 9-11 days
+
+### Phase 2: Low-blast-radius effects + guardrail (38-3, 38-4) — P2/P1
+
+Slack/notification mediation (low blast radius, fire-and-forget via outbox) and the build-time guardrail analyzer that makes rule #1 structural and prevents regression of the whole epic (and pre-enforces Class E Stripe).
+Estimated: 5-7 days
+
+## Success Metrics
+
+- 100% of Class A/C/D activities are thin `TammaApiClient` clients holding **no** external token; `grep` over `Tamma.Activities` finds **zero** injections of `IGitHubIntegrationService` / `IGitHubActionsClient` / `IIntegrationService` and zero non-`TammaApiClient` `HttpClient`/`PostAsync` hosts.
+- Every mediated endpoint authorizes the `tenant ↔ repo` relationship before resolving a token; a cross-tenant request is denied with a key-free typed failure and **never** reaches the platform.
+- Every mediated call emits exactly one terminal DCB audit event from `Tamma.Api`, tagged with `tenantId` + `repo` + the operation; no token appears in any log, response body, or event payload.
+- The 38-4 guardrail fails the build on a re-introduced direct external call or injected vendor service (verified by a deliberately-violating fixture).
+- Inbound webhook handling (`WebhookSignalRegistry`) is unchanged (out of scope by nature — design §5.3).
+
+## Reference Documents
+
+- [Epic 32 Revised Agent Architecture — Design of Record](../../superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md) — §1 (steps never call external APIs; §1.2 audit table; §1.3 prioritized violators), §5 (non-LLM step mediation: §5.1 endpoints, §5.2 phasing, §5.3 what cannot be mediated)
+- [Epic 32 → 37 Re-plan](../../superpowers/plans/2026-06-20-epic-32-37-replan.md)
+- [Story 32-5 — Call-LLM Endpoint + Managed Execution](../epic-32/story-32-5/32-5-managed-agent-execution-layer.md) — the `/llm/call` template Epic 38 mirrors
+- [Story 38-1 — Git-platform step mediation (Class A)](./story-38-1/38-1-git-platform-step-mediation.md)
+- [Story 38-2 — Agent-dispatch step mediation (Class C)](./story-38-2/38-2-agent-dispatch-step-mediation.md)
+- [Story 38-3 — Slack / notifications step mediation (Class D)](./story-38-3/38-3-slack-notifications-step-mediation.md)
+- [Story 38-4 — Build-time guardrail analyzer](./story-38-4/38-4-build-time-guardrail-analyzer.md)
+- [CLAUDE.md](../../../CLAUDE.md) — operating modes + per-mode two-scoping-model rule; the unified schema-per-tenant tenancy model
+
+---
+
+**Last Updated**: 2026-06-21
+**Epic Owner**: TBD
+**Implementation Start**: TBD (does NOT block Epic 32)
+**Total Estimated Effort**: 14-18 days

--- a/docs/stories/epic-38/story-38-1/38-1-git-platform-step-mediation.md
+++ b/docs/stories/epic-38/story-38-1/38-1-git-platform-step-mediation.md
@@ -1,0 +1,365 @@
+# Story 38-1: Git-platform step mediation (Class A)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **platform engineer running the Tamma engine as per-tenant dedicated compute (the Cranl path)**,
+I want the git-platform write/read steps (`CreateBranch` / `CreatePullRequest` / `MergePullRequest` / `UpdateIssueStatus` / `AnalyzeReview`) to stop resolving the co-hosted `IGitHubIntegrationService` and instead call internal `Tamma.Api` git endpoints that hold the platform token, authorize that *this* tenant may act on *this* repo, perform the call, and audit it,
+So that **a workflow step never holds a git-platform token in the engine process** — closing the highest-blast-radius rule-1 violation (a mis-scoped token = cross-tenant write/merge), exactly the way Story 32-5's `/llm/call` closed it for LLM keys.
+
+## Priority
+
+P1 — Class A is the **high-blast-radius** non-LLM violator (design §1.3): "high the moment the engine is not co-hosted with `Tamma.Api`: a mis-scoped platform token = cross-tenant write/merge." It is the first Epic 38 story because git writes (branch/PR/**merge**/issue) are the most dangerous surface to leave co-hosted. It mirrors the 32-5 `/llm/call` template and is the proof-of-pattern the rest of Epic 38 (38-2 agent-dispatch, 38-3 Slack) follows.
+
+## Context
+
+### What exists today (the violation — design §1.2)
+
+Five ADL activities perform git-platform effects by resolving **`IGitHubIntegrationService`** from the DI container:
+
+| Activity | Operation | Notes |
+|---|---|---|
+| `ADL/CreateBranchActivity` | create a branch | write |
+| `ADL/CreatePullRequestActivity` | open a PR | write |
+| `ADL/MergePullRequestActivity` | merge a PR | **write — highest risk** |
+| `ADL/UpdateIssueStatusActivity` | label/close/transition an issue | write |
+| `ADL/AnalyzeReviewActivity` | read PR review comments | read |
+
+`IGitHubIntegrationService` is **implemented in `Tamma.Api`** and holds `GitHub:Token` (the PAT / installation token). In the standalone engine it is **unregistered/null** — so today the call only succeeds because the engine and the API are **co-hosted** in one process. Per design §1.1, *co-hosting is not compliance*: rule #1 forbids the step resolving a credential-holding vendor service; it must call an internal endpoint **over the wire**. The moment the engine runs as per-tenant dedicated compute, the token would have to be pushed into the engine process — exactly what this story prevents.
+
+### What this story does (mirror `/llm/call` — design §5.1 Class A)
+
+Re-point the five activities to new `Tamma.Api` git endpoints (design §5.1):
+
+```
+POST  /api/v1/git/{repo}/branches                  # CreateBranch
+POST  /api/v1/git/{repo}/pull-requests             # CreatePullRequest
+PUT   /api/v1/git/{repo}/pull-requests/{n}/merge   # MergePullRequest
+GET   /api/v1/git/{repo}/pull-requests/{n}/comments# AnalyzeReview (read)
+PATCH /api/v1/git/{repo}/issues/{n}                # UpdateIssueStatus
+```
+
+The API endpoints:
+1. **Authorize** that the tenant from `X-Tenant-Id` may act on `{repo}` — the **cross-tenant guard** (the load-bearing control; deny → key-free typed failure, never a platform call).
+2. **Resolve the token** for that tenant: the tenant's BYOK PAT / installation token from the **Epic 29 cabinet** (keyed per-tenant via Epic 28) → else the platform-provided token where allowed — **tenant→system→error**, never empty/default (`feedback_resolution_no_empty_fallback`). The token is request-scoped and dropped after the call.
+3. **Perform the platform call** via the existing `IGitHubIntegrationService` impl, **inside `Tamma.Api`** (the only place the token lives).
+4. **Emit the audit event** from the API via the tenant `IEventRepository`.
+
+The five activities collapse into **thin `TammaApiClient` clients** holding no token and no Octokit/vendor dependency. This is the same cutover shape as Story 32-5's thin `CallLlmInlineActivity`.
+
+### Explicitly out of scope (referenced, not implemented here)
+
+- **Class C — agent dispatch** (`DispatchAgentWorkflow` / `Monitor` / `CollectAgentResults`) → **Story 38-2**.
+- **Class D — Slack/notifications** (`SlackActivity`) → **Story 38-3** (authored separately).
+- **The build-time guardrail analyzer** (fail the build on a re-introduced direct git call / injected vendor service) → **Story 38-4** (authored separately) — this story leaves the regression net to 38-4 but proves the cutover by `grep`.
+- **Inbound webhooks** (`workflow_run.completed` / `WebhookSignalRegistry`) are inbound, not an outbound effect — out of scope by nature (design §5.3); they belong to Story 38-2's exclusion list, not here.
+- **Multi-platform fan-out** (GitLab/Gitea/Bitbucket/etc.) beyond the existing `IGitHubIntegrationService` abstraction — this story mediates the existing service; broadening the platform set is a separate concern.
+
+## Acceptance Criteria
+
+1. **The five endpoints exist.** `Tamma.Api/Endpoints/GitEndpoints.cs` serves `POST /api/v1/git/{repo}/branches`, `POST /api/v1/git/{repo}/pull-requests`, `PUT /api/v1/git/{repo}/pull-requests/{n}/merge`, `GET /api/v1/git/{repo}/pull-requests/{n}/comments`, and `PATCH /api/v1/git/{repo}/issues/{n}`. All are internal/engine-only, authenticated on the **same plane as `/llm/call`**: Bearer `Tamma:ApiToken` (via `TammaEngineAuthHandler`) + `X-Tenant-Id`. A missing/invalid bearer → **HTTP 401**. `{repo}` is bound from the route; the acting `tenantId` is derived from `X-Tenant-Id`.
+
+2. **The cross-tenant guard runs first and is fail-closed.** Before any token resolution or platform call, the endpoint authorizes that the `X-Tenant-Id` tenant owns/may act on `{repo}` (via an `IGitRepoAuthorizer` over the tenant↔repo registry). A denied or unevaluable relationship → **HTTP 403** `REPO_NOT_AUTHORIZED` with a **key-free** body; the platform is **never** called and no token is resolved. Resolution is **tenant→system→error**, never a default/empty token (`feedback_resolution_no_empty_fallback`).
+
+3. **Token resolution is per-tenant, BYOK→platform, request-scoped, never leaked.** The endpoint resolves the git token via the Epic 29 cabinet (the tenant's BYOK PAT / installation token, keyed per-tenant per Epic 28) → else the platform-provided token where allowed. The resolved token is set on the platform request, used for that one call, and dropped; it **NEVER** appears in any response body, log line, or DCB event. The decision stamps a `credentialSource` (`byok` | `platform`) onto the audit event and response — never the token.
+
+4. **The platform call happens inside `Tamma.Api` only.** Each endpoint delegates to the existing `IGitHubIntegrationService` impl (Octokit etc.), which is DI-registered **in the API process** and is **removed from / never reachable in the engine**. The endpoint maps the request DTO → the service call → a normalized response DTO (`{ branchRef }` / `{ prNumber, prUrl }` / `{ merged, mergeSha }` / `{ comments[] }` / `{ issueNumber, status }`).
+
+5. **The five activities become thin `TammaApiClient` clients.** `CreateBranchActivity`, `CreatePullRequestActivity`, `MergePullRequestActivity`, `UpdateIssueStatusActivity`, and `AnalyzeReviewActivity` no longer inject `IGitHubIntegrationService`. Each maps its `Input<>` props into a request record, calls a **new `TammaApiClient` method** (`CreateBranchAsync` / `CreatePullRequestAsync` / `MergePullRequestAsync` / `UpdateIssueStatusAsync` / `GetPullRequestCommentsAsync`) following the existing `PostAsync<T>`/`PatchAsync<T>` + `AddTenantHeader` + `RecordHealthAsync` pattern, and writes the **same workflow variables it writes today** (e.g. `BranchRef`, `PrNumber`, `MergeResult`, `IssueStatus`, `ReviewComments`) so the surrounding ADL workflows are unchanged. Each holds **no** token, no Octokit, and no platform HTTP.
+
+6. **Error semantics — typed, key-free, fail-closed (mirrors 32-5 AC7).** The endpoints always return a typed, key-free body:
+   - **HTTP 403** `REPO_NOT_AUTHORIZED` — the tenant↔repo guard denied (AC2). The platform is never called.
+   - **HTTP 200 + `success:false`** for *expected platform failures* (e.g. branch already exists, PR not mergeable, 404 issue), with `platformStatusCode` preserved and a key-free `failureReason`, so the ADL workflow can branch on the outcome the way it does today. `failureCode ∈ { GIT_CONFLICT, NOT_MERGEABLE, NOT_FOUND, PLATFORM_ERROR }`.
+   - **HTTP 401** — the engine bearer is absent/invalid.
+   - **HTTP 503** `GIT_TOKEN_UNAVAILABLE` only when the credential genuinely cannot be resolved (fail-closed) — never call the platform with an empty token.
+   A raw provider 5xx must never leak (it would null the `TammaApiClient` body and break the activity's outcome mapping).
+
+7. **DCB audit from the API (exactly one terminal event).** Each endpoint emits exactly one terminal DCB event from `Tamma.Api` via the tenant `IEventRepository`, tagged `{ tenantId, repo, operation, credentialSource, correlationId }`; the event family is `GIT.<OPERATION>.SUCCESS|FAILED` (e.g. `GIT.BRANCH_CREATED.SUCCESS`, `GIT.PR_MERGED.SUCCESS`, `GIT.PR_MERGE.FAILED`, `GIT.ISSUE_UPDATED.SUCCESS`, `GIT.PR_COMMENTS_READ.SUCCESS`). `FAILED` events additionally tag `failureCode`. The event payload is **key-free** and references PR/issue numbers + repo, never the token or auth header.
+
+8. **No control-plane table added.** This story adds **no** new control-plane table (it reuses the Epic 28/29 tenant↔repo registry + cabinet and the existing tenant `domain_events` stream). Therefore: **no** entry in `ElsaServer`/`Program.cs`'s startup-reset DROP list and **no** `ControlPlaneDbContextModelTests` edit. If a tenant↔repo mapping table proves necessary and lives in the control plane, it MUST be appended to the DROP list and the model contract test — call this out in the plan.
+
+9. **Tests cover endpoints + guard + cutover.** Endpoint auth (401 missing bearer); the cross-tenant guard (403 `REPO_NOT_AUTHORIZED`, platform never called); BYOK vs platform `credentialSource`; each typed platform failure (`GIT_CONFLICT`, `NOT_MERGEABLE`, `NOT_FOUND`, `PLATFORM_ERROR` with preserved `platformStatusCode`); `GIT_TOKEN_UNAVAILABLE` fail-closed; the thin activities map responses to the same workflow variables; exactly one terminal DCB event per call; and a credential-safety assertion that the token never appears in any response/log/event. A `grep` over `Tamma.Activities` confirms **zero** `IGitHubIntegrationService` injections remain.
+
+## Technical Design
+
+### Where it lives
+
+```
+apps/tamma-elsa/src/Tamma.Api/Endpoints/
+  GitEndpoints.cs                  # NEW — the 5 routes; engine-only auth; guard → token → service → audit
+
+apps/tamma-elsa/src/Tamma.Api/Services/Git/
+  IGitRepoAuthorizer.cs            # NEW — tenant↔repo cross-tenant guard
+  GitRepoAuthorizer.cs             # NEW — checks the Epic 28/29 tenant↔repo registry
+  IGitTokenResolver.cs             # NEW — BYOK→platform git token resolution (cabinet-backed)
+  GitTokenResolver.cs              # NEW — Epic 29 cabinet → platform fallback; { Token, Source }
+  GitMediationService.cs           # NEW — composes guard → token → IGitHubIntegrationService → audit
+  GitRequests.cs / GitResponses.cs # NEW — wire records (CreateBranchRequest, MergePrRequest, … + DTOs)
+  GitEventTypes.cs                 # NEW — GIT.BRANCH_CREATED.* / GIT.PR_MERGED.* / … constants
+
+apps/tamma-elsa/src/Tamma.Activities/ADL/
+  CreateBranchActivity.cs          # GUT — thin TammaApiClient client; drop IGitHubIntegrationService
+  CreatePullRequestActivity.cs     # GUT — thin client
+  MergePullRequestActivity.cs      # GUT — thin client
+  UpdateIssueStatusActivity.cs     # GUT — thin client
+  AnalyzeReviewActivity.cs         # GUT — thin client (read comments)
+
+apps/tamma-elsa/src/Tamma.Api/Clients/   (wherever TammaApiClient lives)
+  TammaApiClient.cs                # MODIFY — add CreateBranchAsync / CreatePullRequestAsync /
+                                   #          MergePullRequestAsync / UpdateIssueStatusAsync /
+                                   #          GetPullRequestCommentsAsync (PostAsync<T>/PatchAsync<T>
+                                   #          + AddTenantHeader + RecordHealthAsync)
+
+apps/tamma-elsa/src/Tamma.Api/Program.cs        # MODIFY — map GitEndpoints; register guard/token/service
+apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs # MODIFY — ensure IGitHubIntegrationService is NOT
+                                                #          registered/reachable in the engine
+```
+
+### The endpoint (`GitEndpoints.cs`)
+
+```csharp
+// All routes: internal, engine-only. Auth: Bearer Tamma:ApiToken (TammaEngineAuthHandler) + X-Tenant-Id.
+app.MapPost("/api/v1/git/{repo}/branches", async (
+        string repo, CreateBranchRequest body, HttpContext http,
+        IGitMediationService git, CancellationToken ct) =>
+{
+    var tenantId = ResolveTenant(http);                  // from X-Tenant-Id; 401 already enforced by the scheme
+    var result   = await git.CreateBranchAsync(tenantId, repo, body, ct);
+    return result.ToHttpResult();                         // 200 success | 200 success:false | 403 | 503
+})
+.RequireAuthorization(EngineAuthPolicy)
+.WithName("CreateBranch");
+
+// PUT /api/v1/git/{repo}/pull-requests/{n}/merge — the highest-risk write
+app.MapPut("/api/v1/git/{repo}/pull-requests/{n:int}/merge", async (
+        string repo, int n, MergePrRequest body, HttpContext http,
+        IGitMediationService git, CancellationToken ct) =>
+{
+    var tenantId = ResolveTenant(http);
+    var result   = await git.MergePullRequestAsync(tenantId, repo, n, body, ct);
+    return result.ToHttpResult();
+})
+.RequireAuthorization(EngineAuthPolicy)
+.WithName("MergePullRequest");
+// … POST pull-requests, GET pull-requests/{n}/comments, PATCH issues/{n} likewise.
+```
+
+### `GitMediationService.CreateBranchAsync` composition (inside `Tamma.Api`)
+
+```
+1. authz = await _authorizer.AuthorizeAsync(tenantId, repo, ct)          // CROSS-TENANT GUARD, first
+             -> denied/unevaluable => 403 REPO_NOT_AUTHORIZED  (platform NEVER called, no token resolved)
+2. cred  = await _tokenResolver.ResolveAsync(tenantId, repo, ct)         // Epic 29 cabinet BYOK -> platform
+             -> { Token, Source }; null => 503 GIT_TOKEN_UNAVAILABLE (fail-closed, retryable:false)
+3. res   = await _github.CreateBranchAsync(repo, body, cred.Token, ct)   // IGitHubIntegrationService, request-scoped token
+             -> platform error => 200 success:false { failureCode, platformStatusCode preserved }
+4. emit GIT.BRANCH_CREATED.SUCCESS|FAILED  { tenantId, repo, operation, credentialSource, correlationId }
+5. return GitMediationResult -> { success, branchRef?, credentialSource, failureCode?, platformStatusCode? }
+```
+
+The token (`cred.Token`) is passed to the service call and dropped; it is never logged, returned, or persisted. `credentialSource` (the label) is safe to surface; the token is not.
+
+### Wire records (`GitRequests.cs` / `GitResponses.cs`)
+
+```csharp
+public sealed record CreateBranchRequest   { public required string BranchName { get; init; }
+                                              public required string BaseRef { get; init; }
+                                              public required string CorrelationId { get; init; } }
+public sealed record CreatePullRequestRequest { public required string HeadRef { get; init; }
+                                                public required string BaseRef { get; init; }
+                                                public required string Title { get; init; }
+                                                public string? Body { get; init; }
+                                                public required string CorrelationId { get; init; } }
+public sealed record MergePrRequest         { public string? MergeMethod { get; init; }  // merge|squash|rebase
+                                              public string? CommitMessage { get; init; }
+                                              public required string CorrelationId { get; init; } }
+public sealed record UpdateIssueRequest     { public string? Status { get; init; }       // open|closed
+                                              public IReadOnlyList<string>? Labels { get; init; }
+                                              public required string CorrelationId { get; init; } }
+
+public sealed record GitMediationResult
+{
+    public required bool Success { get; init; }
+    public string? CredentialSource { get; init; }       // "byok" | "platform" — NEVER the token
+    public string? BranchRef { get; init; }
+    public int? PrNumber { get; init; }
+    public string? PrUrl { get; init; }
+    public bool? Merged { get; init; }
+    public string? MergeSha { get; init; }
+    public IReadOnlyList<PrCommentDto>? Comments { get; init; }
+    public string? IssueStatus { get; init; }
+    // failure-only:
+    public string? FailureCode { get; init; }            // GIT_CONFLICT | NOT_MERGEABLE | NOT_FOUND | PLATFORM_ERROR
+    public string? FailureReason { get; init; }          // key-free
+    public int? PlatformStatusCode { get; init; }        // preserved
+}
+```
+
+### The thin `MergePullRequestActivity` shim (the cutover shape)
+
+```csharp
+// no IGitHubIntegrationService; no Octokit; no platform HTTP. Same workflow variables out.
+var req = new MergePrRequest {
+    MergeMethod = mergeMethod, CommitMessage = commitMessage,
+    CorrelationId = context.WorkflowExecutionContext.Id
+};
+var resp = await _api.MergePullRequestAsync(repo, prNumber, req, tenantId, ct);   // NEW client method
+
+context.SetVariable("MergeResult", new MergeResultVar {
+    Merged = resp.Merged ?? false, MergeSha = resp.MergeSha,
+    Success = resp.Success, FailureCode = resp.FailureCode });
+```
+
+The surrounding ADL workflow reads `MergeResult` exactly as today (AC5).
+
+## Dependencies
+
+**Internal (hard prerequisites):**
+
+- **Story 32-5** (the `/llm/call` template) — the endpoint shape, `TammaApiClient` cutover convention, request-scoped-credential discipline, and DCB-audit-from-API contract this story mirrors. Not a code dependency, a *pattern* dependency; settle 32-5's pattern first.
+- **Epic 28** (tenancy) — the tenant↔repo registry data + per-tenant keying for the cross-tenant guard and token resolution; `ITenantContext`.
+- **Epic 29** (secret cabinet) — encrypted per-tenant git PAT / installation token (BYOK), resolved BYOK→platform inside the API (the git analogue of Story 32-3's LLM credential resolver).
+- **Epic 9** (unified agent API) — the `TammaApiClient` / `TammaEngineAuthHandler` engine↔API callback convention reused by `GitEndpoints`.
+- **Epic 4** (DCB) — `DomainEvent` / `IEventRepository`, tenant-scoped, for the `GIT.*` audit events.
+- **`IGitHubIntegrationService`** — the existing in-API platform service the endpoints delegate to (now API-only).
+
+**Consumers (downstream, not blockers):**
+
+- **Story 38-4** (guardrail analyzer) — proves this cutover stays cut (zero `IGitHubIntegrationService` injections in the engine).
+- The ADL workflows that already consume `BranchRef` / `PrNumber` / `MergeResult` / `IssueStatus` / `ReviewComments` — unchanged.
+
+**Follow-ons (referenced, separate stories):** 38-2 (agent-dispatch mediation), 38-3 (Slack/notifications mediation), 38-4 (build-time guardrail).
+
+**External:** none new (reuses the existing Octokit-backed `IGitHubIntegrationService` — now only in the API process).
+
+## Testing Strategy
+
+1. **Endpoint auth.** Missing/invalid bearer → 401; valid bearer + `X-Tenant-Id` → request bound, `tenantId` derived from header, `{repo}` from route.
+2. **Cross-tenant guard (AC2).** A tenant requesting a repo it does not own → **403 `REPO_NOT_AUTHORIZED`**; assert `IGitHubIntegrationService` is **never** invoked and no token is resolved (fakes record calls).
+3. **BYOK vs platform `credentialSource` (AC3).** Cabinet has a tenant PAT → `credentialSource="byok"`; absent → platform token → `"platform"`; both reach the service with a non-empty token; the token never appears in the response/log/event.
+4. **`GIT_TOKEN_UNAVAILABLE` fail-closed (AC6).** Token resolver returns null → **503**, `retryable:false`; the platform is never called.
+5. **Typed platform failures (AC6).** `IGitHubIntegrationService` reports branch-exists / not-mergeable / 404 / 5xx → **200 `success:false`** with the right `failureCode` and **preserved** `platformStatusCode`; assert a raw 5xx is never produced.
+6. **Each operation happy path (AC4).** Branch/PR/merge/issue/comments → correct response DTO populated; exactly one terminal `GIT.*.SUCCESS` DCB event with the right tags.
+7. **Thin-activity mapping (AC5).** Given each `GitMediationResult`, the activity writes the same `BranchRef` / `PrNumber` / `MergeResult` / `IssueStatus` / `ReviewComments` workflow variables as today; a minimal ADL workflow branches on them unchanged.
+8. **Cutover proof (AC5/AC9).** `grep` over `Tamma.Activities` for `IGitHubIntegrationService` → **zero** injections; the five activities hold no Octokit/platform-HTTP reference.
+9. **Credential safety (AC3/AC7).** Assert the token never appears in any `GitMediationResult`, response body, log line, or DCB event payload.
+10. **Audit invariant (AC7).** Exactly one terminal `GIT.*` event per call (success or failure) via a fake `IEventRepository`; tags match AC7; `FAILED` carries `failureCode`.
+
+Docker-bound C# suites run via `sg docker -c "dotnet test apps/tamma-elsa/..."` (session docker group is stale; plain `dotnet build` needs no wrapper).
+
+## Estimated Effort
+
+5-6 days (five endpoints + the cross-tenant guard + BYOK→platform token resolver + the five thin-activity cutovers + the audit wiring + the engine-registration removal).
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/GitEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Git/IGitRepoAuthorizer.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Git/GitRepoAuthorizer.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Git/IGitTokenResolver.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Git/GitTokenResolver.cs` | Create (Epic 29 cabinet → platform) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Git/IGitMediationService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Git/GitMediationService.cs` | Create (guard→token→service→audit) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Git/GitRequests.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Git/GitResponses.cs` | Create (+ `PrCommentDto`, `GitMediationResult`) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Git/GitEventTypes.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/ADL/CreateBranchActivity.cs` | Gut → thin client |
+| `apps/tamma-elsa/src/Tamma.Activities/ADL/CreatePullRequestActivity.cs` | Gut → thin client |
+| `apps/tamma-elsa/src/Tamma.Activities/ADL/MergePullRequestActivity.cs` | Gut → thin client |
+| `apps/tamma-elsa/src/Tamma.Activities/ADL/UpdateIssueStatusActivity.cs` | Gut → thin client |
+| `apps/tamma-elsa/src/Tamma.Activities/ADL/AnalyzeReviewActivity.cs` | Gut → thin client |
+| `apps/tamma-elsa/src/Tamma.Api/Clients/TammaApiClient.cs` | Modify (add 5 git client methods) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map `GitEndpoints`; register guard/token/mediation; `IGitHubIntegrationService` stays API-only) |
+| `apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs` | Modify (ensure `IGitHubIntegrationService` not registered/reachable in the engine) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/GitEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Git/GitMediationServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/GitActivityThinClientTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, and decisions (esp. `feedback_resolution_no_empty_fallback`).
+3. Read the design of record §1 (steps never call external APIs; §1.2 audit table — the five Class-A rows; §1.3 cross-tenant-token risk) and §5 (§5.1 Class-A endpoints; §5.3 webhooks are out of scope) IN FULL.
+4. Read **Story 32-5** as the template (`LlmCallEndpoints` shape, the thin `CallLlmInlineActivity` cutover, request-scoped-credential discipline, DCB-audit-from-API), and reviewed `TammaApiClient` (the `PostAsync<T>`/`AddTenantHeader`/`RecordHealthAsync` pattern) + `IGitHubIntegrationService` (the service you delegate to, now API-only).
+5. Confirmed the Epic 28 tenant↔repo registry + Epic 29 cabinet contracts you authorize/resolve against are landed (or code to their interfaces with fakes).
+6. Planned the TDD approach; remember the cross-tenant guard MUST run **before** token resolution and platform call.
+
+### Key Design Decisions
+
+- **Mirror `/llm/call`, do not invent.** Same auth plane, same engine-only policy, same request-scoped-credential discipline, same DCB-audit-from-API contract as Story 32-5. The activity is a dumb shim.
+- **The cross-tenant guard is the load-bearing control (design §1.3).** "A mis-scoped platform token = cross-tenant write/merge." Authorize the `tenant ↔ repo` relationship FIRST; deny → 403 `REPO_NOT_AUTHORIZED`, platform never called, no token resolved. Fail-closed.
+- **Fail-closed, never empty (`feedback_resolution_no_empty_fallback`).** Token resolution is tenant→system→error; an unresolvable token → 503 `GIT_TOKEN_UNAVAILABLE`, never a call with an empty/default token.
+- **Status preservation for expected failures.** Platform failures (branch-exists, not-mergeable, 404) return **200 `success:false` + preserved `platformStatusCode`**, never a raw 5xx, so the ADL workflow branches on the outcome the way it does today (the same load-bearing discipline as 32-5 AC7).
+- **DCB audit from the API.** Emitted where the tenant `IEventRepository` + cabinet live, not from the engine. Performance/action data is ALWAYS tenant-scoped (Epic 32 ownership rule); the `GIT.*` audit lands in the tenant's `t_<hex>` store.
+- **No new control-plane table (AC8).** Reuses the Epic 28/29 tenant↔repo registry + cabinet + the tenant `domain_events` stream. No DROP-list entry, no `ControlPlaneDbContextModelTests` edit. *If* a CP-resident tenant↔repo mapping table is unavoidable, append it to `Program.cs`'s startup-reset "Wiping Tamma-managed public-schema tables" DROP list AND the strict `Model_Has_ExpectedControlPlaneEntities` contract test — flagged in the plan.
+- **`PlatformOwnerAccess`, not `OwnerAccess`** — these are engine-callback routes (engine bearer), not `/api/admin/*`; no platform-owner policy applies. The relevant control is the per-request tenant↔repo guard, not RBAC.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who is the principal of a git-mediation request? | The sole user (keyed by `UserId`; `TenantId` may be null). | The tenant (keyed by `TenantId` from `X-Tenant-Id`). No per-user layer. |
+| Who may act on `{repo}`? | The sole user — the guard verifies the user owns the configured repo(s). | Only the tenant whose `X-Tenant-Id` owns `{repo}` in the tenant↔repo registry; a cross-tenant request → 403 `REPO_NOT_AUTHORIZED`. |
+| Whose git token does the call use? | The sole user's BYOK PAT / installation token → else platform default; resolved in the API. | The tenant's BYOK token (Epic 29 cabinet, keyed by `TenantId`) → else platform-provided (where allowed). `credentialSource` records which. |
+| Where do `GIT.*` audit events land? | The user's (sole) tenant event store. | The tenant's `t_<hex>` event store via the tenant-scoped `IEventRepository`; `TenantId` set. Never cross-tenant. |
+| Who owns the git operation's audit data? | The user. | The tenant — platform admin sees none of it (Epic 32 ownership rule). |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`) — process-stable. | same |
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| **Mis-scoped token → cross-tenant write/merge** (design §1.3 — THE Class-A risk) | Critical | The `IGitRepoAuthorizer` cross-tenant guard runs FIRST, before any token resolution or platform call; deny → 403 `REPO_NOT_AUTHORIZED`; dedicated cross-tenant test asserting the platform is never reached; token is per-tenant from the cabinet, never a shared default. |
+| Endpoint returns a raw 5xx → ADL outcome mapping silently breaks | High | The result mapper always returns 200 `success:false` + preserved `platformStatusCode` for expected platform failures; 403/401/503 only for guard/auth/credential; HTTP-status-fidelity test. |
+| Engine still holds a git token after cutover | High | `IGitHubIntegrationService` stays API-only; `grep` `Tamma.Activities` for `IGitHubIntegrationService` / Octokit / `api.github.com` → zero; 38-4 guardrail makes it permanent. |
+| Token leaks into a log / response / event | High | Token is request-scoped, dropped after the call; `credentialSource` is the only credential field surfaced; explicit credential-safety test over response/log/event. |
+| Thin activity writes different variables → ADL workflow breaks | High | Map each `GitMediationResult` to the exact `BranchRef`/`PrNumber`/`MergeResult`/`IssueStatus`/`ReviewComments` shapes; minimal ADL workflow integration test. |
+| Empty/default token fallback on resolution failure | Medium | Fail-closed: 503 `GIT_TOKEN_UNAVAILABLE`, `retryable:false`; never call with an empty token (`feedback_resolution_no_empty_fallback`). |
+| Co-hosting hides the violation (design §1.1) | Medium | The activity calls over the wire via `TammaApiClient`, never resolves an injected vendor service — verified the moment the engine runs as per-tenant dedicated compute (Cranl). |
+| Depends on 32-5 pattern / Epic 28-29 registry+cabinet not yet settled | Medium | Code to the interfaces; mirror 32-5; use fakes in tests until they land. |
+
+### Success Metrics
+
+- [ ] `grep` over `Tamma.Activities` finds **zero** `IGitHubIntegrationService` injections (all five activities cut over).
+- [ ] Every git-mediation request authorizes the `tenant ↔ repo` relationship before resolving a token; a cross-tenant request is 403'd and never reaches the platform (isolation test).
+- [ ] 100% of mediated git calls emit exactly one terminal `GIT.*` event from `Tamma.Api`, tagged `{ tenantId, repo, operation, credentialSource, correlationId }`.
+- [ ] The git token never appears in any response body, log line, or DCB event payload (credential-safety test green).
+- [ ] The five ADL activities hold no Octokit/platform-HTTP reference; the surrounding ADL workflows are unchanged.
+
+## Related
+
+- Design of record: `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§1 steps-never-call-external-APIs; §1.2 audit table — Class-A rows; §1.3 cross-tenant-token risk; §5.1 Class-A endpoints; §5.3 webhooks out of scope)
+- Epic 38 README: `docs/stories/epic-38/README.md`
+- Template story: `docs/stories/epic-32/story-32-5/32-5-managed-agent-execution-layer.md` (the `/llm/call` mediation this mirrors)
+- Implementation plan: `docs/superpowers/plans/2026-06-21-38-1-git-platform-step-mediation-plan.md`
+- Sibling stories: `story-38-2/` (agent-dispatch mediation), `story-38-3/` (Slack/notifications mediation), `story-38-4/` (build-time guardrail analyzer)
+- Cross-epic: `docs/stories/epic-32/story-32-3/` (the LLM BYOK→platform credential resolver this story's git token resolver mirrors); Epic 28 (tenancy / tenant↔repo registry); Epic 29 (secret cabinet — per-tenant git tokens)
+- Reused code: `IGitHubIntegrationService` (now API-only), `TammaApiClient`, the ADL workflows consuming `BranchRef`/`PrNumber`/`MergeResult`/`IssueStatus`/`ReviewComments`
+
+## Logging Requirements
+
+- **INFO**: git-mediation received (correlationId, repo, operation, tenantId — never the token); authorization decision (allow/deny); operation completed (success, operation, prNumber/issueNumber, durationMs, credentialSource).
+- **DEBUG**: composition step boundaries (guard → token → service → audit); request DTO shape (no token).
+- **WARN**: typed failure paths (`REPO_NOT_AUTHORIZED`, `GIT_CONFLICT`, `NOT_MERGEABLE`, `NOT_FOUND`, `PLATFORM_ERROR` + `platformStatusCode`, `GIT_TOKEN_UNAVAILABLE`) with `failureCode` + `correlationId`.
+- **ERROR**: contract violations (null body), DCB append failure (the call still returns its result; the append failure is logged, not swallowed), and any attempt to return a raw 5xx (guardrail).
+- **Structured context**: `{ tenantId, repo, operation, correlationId, credentialSource }` where applicable.
+- **Credential safety (LOAD-BEARING)**: NEVER log, return, or persist the resolved git PAT / installation token or any `Authorization` header. `credentialSource` (the label `byok`/`platform`) is safe; the token is not. The `GitMediationResult` body, all DCB event payloads, and the audit trail are token-free by contract — mirroring Story 32-5's credential-safety rule for LLM keys.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-21 | 1.0.0   | Initial story creation — Class-A git-platform step mediation. Re-points the five ADL git activities (`CreateBranch`/`CreatePullRequest`/`MergePullRequest`/`UpdateIssueStatus`/`AnalyzeReview`) from the co-hosted `IGitHubIntegrationService` to new `Tamma.Api` `/api/v1/git/{repo}/...` endpoints that hold the per-tenant token (Epic 28/29 cabinet, BYOK→platform), authorize the `tenant ↔ repo` relationship (the cross-tenant guard — the high-blast-radius control), perform the call, and audit it. Activities become thin `TammaApiClient` clients holding no token. Mirrors the Story 32-5 `/llm/call` template. | Claude |

--- a/docs/stories/epic-38/story-38-2/38-2-agent-dispatch-step-mediation.md
+++ b/docs/stories/epic-38/story-38-2/38-2-agent-dispatch-step-mediation.md
@@ -1,0 +1,362 @@
+# Story 38-2: Agent-dispatch step mediation (Class C)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **platform engineer running the Tamma engine as per-tenant dedicated compute (the Cranl path)**,
+I want the agent-dispatch steps (`DispatchAgentWorkflowActivity` / `GitHubActionsExecutor`, `MonitorAgentWorkflowActivity`, `CollectAgentResultsActivity`) to stop resolving the co-hosted `IGitHubActionsClient` and instead call internal `Tamma.Api` agent-dispatch endpoints that hold the GitHub Actions token, authorize that *this* tenant may dispatch into *this* repo, dispatch/poll the run, and audit it,
+So that **a workflow step never holds a GitHub Actions token in the engine process** — closing the Class-C rule-1 violation the same way Story 38-1 closed the git-platform writes and Story 32-5's `/llm/call` closed the LLM keys.
+
+## Priority
+
+P1 — Class C is a high-blast-radius non-LLM violator alongside Class A (design §1.3): "high the moment the engine is not co-hosted with `Tamma.Api`: a mis-scoped platform token = cross-tenant write/merge." Agent dispatch triggers GitHub Actions **workflow runs** in a repo — a cross-tenant dispatch is a cross-tenant code execution. It is Phase 1 of Epic 38 with Story 38-1, mirrors the same `/llm/call` template, and reuses the cross-tenant guard 38-1 introduces.
+
+## Context
+
+### What exists today (the violation — design §1.2)
+
+Three AgentDispatch activities reach GitHub Actions through **`IGitHubActionsClient`** resolved from the DI container:
+
+| Activity | Operation | Notes |
+|---|---|---|
+| `AgentDispatch/DispatchAgentWorkflowActivity` (via `GitHubActionsExecutor`) | trigger an Actions workflow run | **write — triggers code execution** |
+| `AgentDispatch/MonitorAgentWorkflowActivity` | poll a run's status | read |
+| `AgentDispatch/CollectAgentResultsActivity` | fetch a completed run's outputs/artifacts | read |
+
+`IGitHubActionsClient` has two impls: **`OctokitGitHubActionsClient` in `Tamma.Api`** (holds the Actions token) and **`NullGitHubActionsClient` in the engine** (no-op). So today the dispatch only does real work when the engine and the API are **co-hosted** — and would silently no-op (or, worse, need a token pushed in) the moment the engine is per-tenant dedicated compute. Per design §1.1, *co-hosting is not compliance*: the step must call an internal endpoint **over the wire**, not resolve an injected vendor service.
+
+### The inbound side is explicitly OUT of scope (design §5.3)
+
+`DispatchAgentWorkflowActivity` suspends the workflow on a durable bookmark; when the GitHub `workflow_run.completed` webhook arrives, **`Tamma.Api` receives it, verifies the signature, and signals the engine in-process** via `WebhookSignalRegistry`. This inbound path is **NOT a violator** and is **NOT mediated by this story**: it is *inbound* — there is no outbound external call to centralize. The signature-verification secret already lives in the API. Per design §5.3, inbound webhooks "received by `Tamma.Api`, signalled to the engine in-process — no outbound external call to mediate. Signature verification + secret stay in the API. Out of scope by nature." This story mediates only the **outbound** dispatch + poll + collect.
+
+### What this story does (mirror `/llm/call` — design §5.1 Class C)
+
+Re-point the outbound activities to new `Tamma.Api` agent-dispatch endpoints (design §5.1):
+
+```
+POST /api/v1/agent-dispatch/{repo}/runs        # DispatchAgentWorkflow — trigger a run
+GET  /api/v1/agent-dispatch/{repo}/runs/{id}   # Monitor (status) + CollectAgentResults (outputs)
+```
+
+The API endpoints:
+1. **Authorize** that the tenant from `X-Tenant-Id` may dispatch into / read `{repo}` — the **cross-tenant guard** (reuses Story 38-1's `IGitRepoAuthorizer`; deny → key-free typed failure, never a platform call).
+2. **Resolve the Actions token** for that tenant: the tenant's BYOK token from the **Epic 29 cabinet** (keyed per-tenant via Epic 28) → else the platform-provided token where allowed — **tenant→system→error**, never empty/default (`feedback_resolution_no_empty_fallback`). Request-scoped, dropped after the call.
+3. **Perform the dispatch/poll** via the existing `IGitHubActionsClient` (`OctokitGitHubActionsClient`), **inside `Tamma.Api`** only.
+4. **Emit the audit event** from the API via the tenant `IEventRepository`.
+
+The three activities collapse into **thin `TammaApiClient` clients** holding no token and no Octokit/vendor dependency — the same cutover shape as Story 32-5 and Story 38-1.
+
+### Explicitly out of scope (referenced, not implemented here)
+
+- **The inbound `workflow_run.completed` webhook + `WebhookSignalRegistry`** — inbound, not an outbound effect; out of scope by nature (design §5.3). This story does **not** touch the bookmark/signal path; `DispatchAgentWorkflowActivity` still suspends and is still signalled in-process.
+- **Class A — git platform** (`CreateBranch`/`CreatePullRequest`/`MergePullRequest`/`UpdateIssueStatus`/`AnalyzeReview`) → **Story 38-1** (this story reuses 38-1's `IGitRepoAuthorizer`).
+- **Class D — Slack/notifications** (`SlackActivity`) → **Story 38-3** (authored separately).
+- **The build-time guardrail analyzer** → **Story 38-4** (authored separately) — this story proves its cutover by `grep`.
+- **A new CI dispatch backend** beyond the existing `IGitHubActionsClient` abstraction — this story mediates the existing client; broadening the CI backend set is a separate concern.
+
+## Acceptance Criteria
+
+1. **The two endpoints exist.** `Tamma.Api/Endpoints/AgentDispatchEndpoints.cs` serves `POST /api/v1/agent-dispatch/{repo}/runs` and `GET /api/v1/agent-dispatch/{repo}/runs/{id}`. Both are internal/engine-only, authenticated on the **same plane as `/llm/call`**: Bearer `Tamma:ApiToken` (via `TammaEngineAuthHandler`) + `X-Tenant-Id`. A missing/invalid bearer → **HTTP 401**. `{repo}` and `{id}` bind from the route; the acting `tenantId` is derived from `X-Tenant-Id`.
+
+2. **The cross-tenant guard runs first and is fail-closed.** Before any token resolution or platform call, the endpoint authorizes that the `X-Tenant-Id` tenant may dispatch into / read `{repo}` (via the **shared `IGitRepoAuthorizer` from Story 38-1**). A denied or unevaluable relationship → **HTTP 403** `REPO_NOT_AUTHORIZED` with a **key-free** body; the platform is **never** called and no token is resolved. Resolution is **tenant→system→error**, never a default/empty token.
+
+3. **Token resolution is per-tenant, BYOK→platform, request-scoped, never leaked.** The endpoint resolves the GitHub Actions token via the Epic 29 cabinet (the tenant's BYOK token, keyed per-tenant per Epic 28) → else the platform-provided token where allowed. The resolved token is set on the dispatch/poll request, used for that one call, and dropped; it **NEVER** appears in any response body, log line, or DCB event. The decision stamps a `credentialSource` (`byok` | `platform`) — never the token.
+
+4. **The dispatch/poll happens inside `Tamma.Api` only.** Each endpoint delegates to the existing `IGitHubActionsClient` impl (`OctokitGitHubActionsClient`), DI-registered **in the API process** and **removed from / never reachable in the engine** (the engine's `NullGitHubActionsClient` registration is removed). `POST .../runs` maps `{ workflowRef, ref, inputs }` → a triggered run → `{ runId, runUrl, status }`; `GET .../runs/{id}` maps the run id → `{ runId, status, conclusion, outputs, artifacts }`.
+
+5. **The three activities become thin `TammaApiClient` clients.** `DispatchAgentWorkflowActivity` (`GitHubActionsExecutor`), `MonitorAgentWorkflowActivity`, and `CollectAgentResultsActivity` no longer inject `IGitHubActionsClient`. Each maps its `Input<>` props into a request record, calls a **new `TammaApiClient` method** (`DispatchAgentRunAsync` / `GetAgentRunAsync`) following the existing `PostAsync<T>`/`GetAsync<T>` + `AddTenantHeader` + `RecordHealthAsync` pattern, and writes the **same workflow variables it writes today** (e.g. `DispatchedRunId`, `RunStatus`, `AgentResults`) so the surrounding dispatch workflow — **including the durable bookmark suspend/resume on `workflow_run.completed`** — is unchanged. Each holds **no** token, no Octokit, and no platform HTTP.
+
+6. **Error semantics — typed, key-free, fail-closed (mirrors 32-5 AC7 / 38-1 AC6).** The endpoints always return a typed, key-free body:
+   - **HTTP 403** `REPO_NOT_AUTHORIZED` — the tenant↔repo guard denied (AC2). The platform is never called.
+   - **HTTP 200 + `success:false`** for *expected platform failures* (e.g. workflow not found, run not found, dispatch rejected), with `platformStatusCode` preserved and a key-free `failureReason`, so the dispatch workflow can branch on the outcome the way it does today. `failureCode ∈ { WORKFLOW_NOT_FOUND, RUN_NOT_FOUND, DISPATCH_REJECTED, PLATFORM_ERROR }`.
+   - **HTTP 401** — the engine bearer is absent/invalid.
+   - **HTTP 503** `ACTIONS_TOKEN_UNAVAILABLE` only when the credential genuinely cannot be resolved (fail-closed) — never call the platform with an empty token.
+   A raw provider 5xx must never leak (it would null the `TammaApiClient` body and break the activity's outcome mapping + the durable bookmark contract).
+
+7. **DCB audit from the API (exactly one terminal event).** Each endpoint emits exactly one terminal DCB event from `Tamma.Api` via the tenant `IEventRepository`, tagged `{ tenantId, repo, operation, runId?, credentialSource, correlationId }`; the event family is `AGENT_DISPATCH.RUN_TRIGGERED.SUCCESS|FAILED` and `AGENT_DISPATCH.RUN_POLLED.SUCCESS|FAILED`. `FAILED` events additionally tag `failureCode`. The event payload is **key-free** and references run id + repo, never the token. (This is distinct from any inbound `WebhookSignalRegistry` signalling, which this story leaves unchanged.)
+
+8. **No control-plane table added.** This story adds **no** new control-plane table (it reuses the Epic 28/29 tenant↔repo registry + cabinet and the existing tenant `domain_events` stream). Therefore: **no** entry in `Program.cs`'s startup-reset DROP list and **no** `ControlPlaneDbContextModelTests` edit. (If 38-1's tenant↔repo data lives in a CP table, that table is owned by 38-1, not duplicated here.)
+
+9. **Tests cover endpoints + guard + cutover + the inbound-unchanged invariant.** Endpoint auth (401 missing bearer); the cross-tenant guard (403 `REPO_NOT_AUTHORIZED`, platform never called); BYOK vs platform `credentialSource`; each typed platform failure (`WORKFLOW_NOT_FOUND`, `RUN_NOT_FOUND`, `DISPATCH_REJECTED`, `PLATFORM_ERROR` with preserved `platformStatusCode`); `ACTIONS_TOKEN_UNAVAILABLE` fail-closed; the thin activities map responses to the same workflow variables; exactly one terminal DCB event per call; the token never appears in any response/log/event; and the **inbound `workflow_run.completed` / `WebhookSignalRegistry` bookmark suspend/resume is unchanged** (an integration test proves dispatch → suspend → in-process signal → resume still works). A `grep` over `Tamma.Activities` confirms **zero** `IGitHubActionsClient` injections remain.
+
+## Technical Design
+
+### Where it lives
+
+```
+apps/tamma-elsa/src/Tamma.Api/Endpoints/
+  AgentDispatchEndpoints.cs        # NEW — POST .../runs + GET .../runs/{id}; engine-only auth
+
+apps/tamma-elsa/src/Tamma.Api/Services/AgentDispatch/
+  IAgentDispatchMediationService.cs# NEW — composes guard → token → IGitHubActionsClient → audit
+  AgentDispatchMediationService.cs # NEW
+  IActionsTokenResolver.cs         # NEW — BYOK→platform Actions token resolution (cabinet-backed)
+  ActionsTokenResolver.cs          # NEW — Epic 29 cabinet → platform fallback; { Token, Source }
+  AgentDispatchRequests.cs         # NEW — DispatchRunRequest (+ DTOs)
+  AgentDispatchResponses.cs        # NEW — AgentRunResult (run id/status/outputs) — NOTE: not the LLM AgentRunResult
+  AgentDispatchEventTypes.cs       # NEW — AGENT_DISPATCH.RUN_TRIGGERED.* / RUN_POLLED.* constants
+  # reuses Story 38-1's Tamma.Api/Services/Git/IGitRepoAuthorizer for the cross-tenant guard
+
+apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/
+  DispatchAgentWorkflowActivity.cs # GUT — thin TammaApiClient client; drop IGitHubActionsClient
+  GitHubActionsExecutor.cs         # GUT/REMOVE — replaced by the thin client call
+  MonitorAgentWorkflowActivity.cs  # GUT — thin client (GET run)
+  CollectAgentResultsActivity.cs   # GUT — thin client (GET run outputs)
+  WebhookSignalRegistry.cs         # UNCHANGED — inbound, out of scope (design §5.3)
+
+apps/tamma-elsa/src/Tamma.Api/Clients/   (wherever TammaApiClient lives)
+  TammaApiClient.cs                # MODIFY — add DispatchAgentRunAsync / GetAgentRunAsync
+                                   #          (PostAsync<T>/GetAsync<T> + AddTenantHeader + RecordHealthAsync)
+
+apps/tamma-elsa/src/Tamma.Api/Program.cs        # MODIFY — map AgentDispatchEndpoints; register service/token
+apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs # MODIFY — remove NullGitHubActionsClient registration
+```
+
+### The endpoint (`AgentDispatchEndpoints.cs`)
+
+```csharp
+// Internal, engine-only. Auth: Bearer Tamma:ApiToken (TammaEngineAuthHandler) + X-Tenant-Id.
+app.MapPost("/api/v1/agent-dispatch/{repo}/runs", async (
+        string repo, DispatchRunRequest body, HttpContext http,
+        IAgentDispatchMediationService dispatch, CancellationToken ct) =>
+{
+    var tenantId = ResolveTenant(http);                  // from X-Tenant-Id; 401 enforced by the scheme
+    var result   = await dispatch.TriggerRunAsync(tenantId, repo, body, ct);
+    return result.ToHttpResult();                         // 200 success | 200 success:false | 403 | 503
+})
+.RequireAuthorization(EngineAuthPolicy)
+.WithName("DispatchAgentRun");
+
+app.MapGet("/api/v1/agent-dispatch/{repo}/runs/{id}", async (
+        string repo, string id, HttpContext http,
+        IAgentDispatchMediationService dispatch, CancellationToken ct) =>
+{
+    var tenantId = ResolveTenant(http);
+    var result   = await dispatch.GetRunAsync(tenantId, repo, id, ct);
+    return result.ToHttpResult();
+})
+.RequireAuthorization(EngineAuthPolicy)
+.WithName("GetAgentRun");
+```
+
+### `AgentDispatchMediationService.TriggerRunAsync` composition (inside `Tamma.Api`)
+
+```
+1. authz = await _authorizer.AuthorizeAsync(tenantId, repo, ct)             // SHARED 38-1 cross-tenant guard, FIRST
+             -> denied/unevaluable => 403 REPO_NOT_AUTHORIZED  (platform NEVER called, no token resolved)
+2. cred  = await _tokenResolver.ResolveAsync(tenantId, repo, ct)            // Epic 29 cabinet BYOK -> platform
+             -> { Token, Source }; null => 503 ACTIONS_TOKEN_UNAVAILABLE (fail-closed, retryable:false)
+3. run   = await _actions.DispatchAsync(repo, body, cred.Token, ct)         // IGitHubActionsClient, request-scoped token
+             -> platform error => 200 success:false { failureCode, platformStatusCode preserved }
+4. emit AGENT_DISPATCH.RUN_TRIGGERED.SUCCESS|FAILED  { tenantId, repo, operation, runId, credentialSource, correlationId }
+5. return AgentDispatchResult -> { success, runId?, runUrl?, status?, credentialSource, failureCode?, platformStatusCode? }
+```
+
+`GetRunAsync` is the same shape with `_actions.GetRunAsync(...)` and `AGENT_DISPATCH.RUN_POLLED.*`. The token is request-scoped, dropped after the call; never logged, returned, or persisted.
+
+### Wire records (`AgentDispatchRequests.cs` / `AgentDispatchResponses.cs`)
+
+```csharp
+public sealed record DispatchRunRequest
+{
+    public required string WorkflowRef { get; init; }     // workflow file / id to dispatch
+    public required string Ref { get; init; }             // branch/tag/sha to run against
+    public Dictionary<string, string> Inputs { get; init; } = new();
+    public required string CorrelationId { get; init; }   // workflow instance id — ties to bookmark + audit
+}
+
+public sealed record AgentDispatchResult
+{
+    public required bool Success { get; init; }
+    public string? CredentialSource { get; init; }        // "byok" | "platform" — NEVER the token
+    public string? RunId { get; init; }
+    public string? RunUrl { get; init; }
+    public string? Status { get; init; }                  // queued|in_progress|completed
+    public string? Conclusion { get; init; }              // success|failure|cancelled (poll only)
+    public Dictionary<string, string>? Outputs { get; init; }
+    public IReadOnlyList<ArtifactDto>? Artifacts { get; init; }
+    // failure-only:
+    public string? FailureCode { get; init; }             // WORKFLOW_NOT_FOUND | RUN_NOT_FOUND | DISPATCH_REJECTED | PLATFORM_ERROR
+    public string? FailureReason { get; init; }           // key-free
+    public int? PlatformStatusCode { get; init; }         // preserved
+}
+```
+
+> **Naming note:** this `AgentDispatchResult` is the **CI-run** record (run id / status / outputs). It is **distinct from** the Story 32-5 LLM `AgentRunResult` (provider/model/tokens/cost). Keep the namespaces separate (`Tamma.Api/Services/AgentDispatch` vs `Tamma.Api/Services/Agents`) so they don't collide.
+
+### The thin `DispatchAgentWorkflowActivity` shim (the cutover shape)
+
+```csharp
+// no IGitHubActionsClient; no Octokit; no platform HTTP. Same variables out; bookmark suspend unchanged.
+var req = new DispatchRunRequest {
+    WorkflowRef = workflowRef, Ref = gitRef, Inputs = inputs,
+    CorrelationId = context.WorkflowExecutionContext.Id
+};
+var resp = await _api.DispatchAgentRunAsync(repo, req, tenantId, ct);   // NEW client method
+
+context.SetVariable("DispatchedRunId", resp.RunId);
+context.SetVariable("DispatchStatus", new DispatchStatusVar {
+    Success = resp.Success, Status = resp.Status, FailureCode = resp.FailureCode });
+// ... then the EXISTING durable bookmark suspend on workflow_run.completed — UNCHANGED (inbound, §5.3).
+```
+
+`MonitorAgentWorkflowActivity` / `CollectAgentResultsActivity` call `GetAgentRunAsync` and write the same `RunStatus` / `AgentResults` variables as today (AC5).
+
+## Dependencies
+
+**Internal (hard prerequisites):**
+
+- **Story 38-1** (git-platform mediation) — supplies the **shared `IGitRepoAuthorizer`** cross-tenant guard and establishes the Class-A/C endpoint pattern + the per-tenant token resolver shape. (Sequenced first in Epic 38 Phase 1.)
+- **Story 32-5** (the `/llm/call` template) — the endpoint shape, `TammaApiClient` cutover convention, request-scoped-credential discipline, and DCB-audit-from-API contract this story mirrors.
+- **Epic 28** (tenancy) — the tenant↔repo registry data + per-tenant keying for the guard and token resolution; `ITenantContext`.
+- **Epic 29** (secret cabinet) — encrypted per-tenant GitHub Actions token (BYOK), resolved BYOK→platform inside the API.
+- **Epic 9** (unified agent API) — the `TammaApiClient` / `TammaEngineAuthHandler` engine↔API callback convention; **and the inbound `WebhookSignalRegistry` signalling contract this story must NOT break** (design §5.3).
+- **Epic 4** (DCB) — `DomainEvent` / `IEventRepository`, tenant-scoped, for the `AGENT_DISPATCH.*` audit events.
+- **`IGitHubActionsClient`** — the existing in-API Octokit-backed client the endpoints delegate to (now API-only; the engine `NullGitHubActionsClient` registration is removed).
+
+**Consumers (downstream, not blockers):**
+
+- **Story 38-4** (guardrail analyzer) — proves this cutover stays cut (zero `IGitHubActionsClient` injections in the engine).
+- The dispatch workflow that consumes `DispatchedRunId` / `RunStatus` / `AgentResults` and suspends on the `workflow_run.completed` bookmark — unchanged.
+
+**Follow-ons (referenced, separate stories):** 38-3 (Slack/notifications mediation), 38-4 (build-time guardrail).
+
+**External:** none new (reuses the existing Octokit-backed `IGitHubActionsClient` — now only in the API process).
+
+## Testing Strategy
+
+1. **Endpoint auth.** Missing/invalid bearer → 401; valid bearer + `X-Tenant-Id` → request bound, `tenantId` derived from header, `{repo}`/`{id}` from route.
+2. **Cross-tenant guard (AC2).** A tenant dispatching into a repo it does not own → **403 `REPO_NOT_AUTHORIZED`**; assert `IGitHubActionsClient` is **never** invoked and no token is resolved (fakes record calls). Reuses the 38-1 `IGitRepoAuthorizer` (test it is the same guard).
+3. **BYOK vs platform `credentialSource` (AC3).** Cabinet has a tenant Actions token → `credentialSource="byok"`; absent → platform token → `"platform"`; both reach the client with a non-empty token; the token never appears in the response/log/event.
+4. **`ACTIONS_TOKEN_UNAVAILABLE` fail-closed (AC6).** Token resolver returns null → **503**, `retryable:false`; the platform is never called.
+5. **Typed platform failures (AC6).** `IGitHubActionsClient` reports workflow-not-found / run-not-found / dispatch-rejected / 5xx → **200 `success:false`** with the right `failureCode` and **preserved** `platformStatusCode`; assert a raw 5xx is never produced.
+6. **Dispatch + poll happy path (AC4).** `POST .../runs` → `{ runId, status }`; `GET .../runs/{id}` → `{ status, conclusion, outputs, artifacts }`; exactly one terminal `AGENT_DISPATCH.*` event with the right tags.
+7. **Thin-activity mapping (AC5).** Given each `AgentDispatchResult`, the activity writes the same `DispatchedRunId` / `RunStatus` / `AgentResults` variables as today; a minimal dispatch workflow branches on them unchanged.
+8. **Inbound unchanged (AC9 — the load-bearing invariant).** An integration test exercises dispatch → durable bookmark suspend → simulated in-process `WebhookSignalRegistry` signal (`workflow_run.completed`) → resume; assert the bookmark path is byte-for-byte unchanged and no outbound call is added to it.
+9. **Cutover proof (AC5/AC9).** `grep` over `Tamma.Activities` for `IGitHubActionsClient` → **zero** injections; the three activities hold no Octokit/platform-HTTP reference; `NullGitHubActionsClient` registration removed from the engine.
+10. **Credential safety (AC3/AC7).** Assert the token never appears in any `AgentDispatchResult`, response body, log line, or DCB event payload.
+11. **Audit invariant (AC7).** Exactly one terminal `AGENT_DISPATCH.*` event per call (success or failure) via a fake `IEventRepository`; tags match AC7; `FAILED` carries `failureCode`; distinct from inbound signalling.
+
+Docker-bound C# suites run via `sg docker -c "dotnet test apps/tamma-elsa/..."` (session docker group is stale; plain `dotnet build` needs no wrapper).
+
+## Estimated Effort
+
+4-5 days (two endpoints + the BYOK→platform Actions-token resolver + the three thin-activity cutovers + the audit wiring + the engine-registration removal + the inbound-unchanged regression test; reuses 38-1's `IGitRepoAuthorizer`).
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentDispatchEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/AgentDispatch/IAgentDispatchMediationService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/AgentDispatch/AgentDispatchMediationService.cs` | Create (guard→token→client→audit) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/AgentDispatch/IActionsTokenResolver.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/AgentDispatch/ActionsTokenResolver.cs` | Create (Epic 29 cabinet → platform) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/AgentDispatch/AgentDispatchRequests.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/AgentDispatch/AgentDispatchResponses.cs` | Create (+ `ArtifactDto`, `AgentDispatchResult`) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/AgentDispatch/AgentDispatchEventTypes.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/DispatchAgentWorkflowActivity.cs` | Gut → thin client |
+| `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/GitHubActionsExecutor.cs` | Gut/Remove |
+| `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/MonitorAgentWorkflowActivity.cs` | Gut → thin client |
+| `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/CollectAgentResultsActivity.cs` | Gut → thin client |
+| `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/WebhookSignalRegistry.cs` | Unchanged (inbound — design §5.3) |
+| `apps/tamma-elsa/src/Tamma.Api/Clients/TammaApiClient.cs` | Modify (add `DispatchAgentRunAsync` / `GetAgentRunAsync`) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map `AgentDispatchEndpoints`; register service/token; `IGitHubActionsClient` stays API-only) |
+| `apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs` | Modify (remove `NullGitHubActionsClient` registration) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/AgentDispatchEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/AgentDispatch/AgentDispatchMediationServiceTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/AgentDispatch/AgentDispatchThinClientTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/AgentDispatch/InboundSignalUnchangedTests.cs` | Create |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, and decisions (esp. `feedback_resolution_no_empty_fallback`).
+3. Read the design of record §1 (steps never call external APIs; §1.2 audit table — the Class-C rows; §1.3 cross-tenant-token risk) and §5 (§5.1 Class-C endpoints; §5.3 **inbound webhooks are out of scope**) IN FULL.
+4. Read **Story 38-1** (the shared `IGitRepoAuthorizer` + endpoint pattern you reuse) and **Story 32-5** (the `/llm/call` template), and reviewed `TammaApiClient`, `IGitHubActionsClient` (`OctokitGitHubActionsClient` / `NullGitHubActionsClient`), and the `WebhookSignalRegistry` bookmark suspend/resume path you must NOT touch.
+5. Confirmed the Epic 28 tenant↔repo registry + Epic 29 cabinet contracts are landed (or code to their interfaces with fakes), and that Story 38-1's `IGitRepoAuthorizer` is available.
+6. Planned the TDD approach; remember the guard runs **before** token resolution/dispatch, and the inbound signal path stays unchanged.
+
+### Key Design Decisions
+
+- **Mirror `/llm/call` + reuse 38-1's guard.** Same auth plane, same engine-only policy, same request-scoped-credential discipline, same DCB-audit-from-API contract; reuse Story 38-1's `IGitRepoAuthorizer` so there is one cross-tenant guard, not two.
+- **Only the OUTBOUND dispatch/poll is mediated.** The inbound `workflow_run.completed` webhook + `WebhookSignalRegistry` are inbound (design §5.3) — received and signature-verified by `Tamma.Api`, signalled in-process. There is no outbound external call to mediate; this story leaves the bookmark suspend/resume untouched and proves it with a regression test.
+- **The cross-tenant guard is load-bearing (design §1.3).** Dispatch triggers Actions code execution; a cross-tenant dispatch is cross-tenant execution. Authorize `tenant ↔ repo` FIRST; deny → 403, platform never called, no token resolved. Fail-closed.
+- **Fail-closed, never empty (`feedback_resolution_no_empty_fallback`).** Token resolution is tenant→system→error; unresolvable → 503 `ACTIONS_TOKEN_UNAVAILABLE`, never a call with an empty/default token.
+- **Status preservation for expected failures.** Platform failures (workflow/run not found, dispatch rejected) return **200 `success:false` + preserved `platformStatusCode`**, never a raw 5xx, so the dispatch workflow branches the way it does today (the same discipline as 32-5 AC7 / 38-1 AC6) — and the durable bookmark contract is not corrupted.
+- **DCB audit from the API.** Emitted where the tenant `IEventRepository` + cabinet live; the `AGENT_DISPATCH.*` family is **distinct from** inbound signalling and from the LLM `AGENT.RUN.*` family — no double counting.
+- **No new control-plane table (AC8).** Reuses Epic 28/29 + the tenant `domain_events` stream. No DROP-list entry, no `ControlPlaneDbContextModelTests` edit. (Story 38-1 owns any CP tenant↔repo table.)
+- **Name collision guard.** The CI-run `AgentDispatchResult` (this story) is distinct from the LLM `AgentRunResult` (32-5) — separate namespaces, no shared type.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who is the principal of an agent-dispatch request? | The sole user (keyed by `UserId`; `TenantId` may be null). | The tenant (keyed by `TenantId` from `X-Tenant-Id`). No per-user layer. |
+| Who may dispatch into / read `{repo}`? | The sole user — the guard verifies the user owns the configured repo(s). | Only the tenant whose `X-Tenant-Id` owns `{repo}` in the tenant↔repo registry; a cross-tenant dispatch → 403 `REPO_NOT_AUTHORIZED`. |
+| Whose Actions token does the dispatch use? | The sole user's BYOK token → else platform default; resolved in the API. | The tenant's BYOK token (Epic 29 cabinet, keyed by `TenantId`) → else platform-provided (where allowed). `credentialSource` records which. |
+| Where do `AGENT_DISPATCH.*` audit events land? | The user's (sole) tenant event store. | The tenant's `t_<hex>` event store via the tenant-scoped `IEventRepository`; `TenantId` set. Never cross-tenant. |
+| Where does the inbound `workflow_run.completed` signal go? | The user's engine instance (in-process via `WebhookSignalRegistry`); unchanged by this story. | The tenant's engine instance (in-process); unchanged by this story. |
+| Who owns the dispatch's audit/run data? | The user. | The tenant — platform admin sees none of it (Epic 32 ownership rule). |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`) — process-stable. | same |
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| **Mis-scoped token → cross-tenant Actions dispatch (code execution)** (design §1.3 — THE Class-C risk) | Critical | The shared `IGitRepoAuthorizer` cross-tenant guard runs FIRST, before token resolution or dispatch; deny → 403 `REPO_NOT_AUTHORIZED`; dedicated cross-tenant test asserting the client is never reached; token is per-tenant from the cabinet, never a shared default. |
+| **Breaking the inbound bookmark suspend/resume** (design §5.3) | Critical | This story does NOT touch `WebhookSignalRegistry` or the `workflow_run.completed` path; the `InboundSignalUnchangedTests` integration test proves dispatch→suspend→signal→resume is byte-for-byte unchanged and no outbound call is added. |
+| Endpoint returns a raw 5xx → dispatch outcome mapping / bookmark contract silently breaks | High | The result mapper always returns 200 `success:false` + preserved `platformStatusCode` for expected platform failures; 403/401/503 only for guard/auth/credential; HTTP-status-fidelity test. |
+| Engine still holds an Actions token after cutover | High | `IGitHubActionsClient` stays API-only; remove `NullGitHubActionsClient` registration; `grep` `Tamma.Activities` for `IGitHubActionsClient` → zero; 38-4 guardrail makes it permanent. |
+| Token leaks into a log / response / event | High | Token request-scoped, dropped after the call; `credentialSource` is the only credential field surfaced; explicit credential-safety test. |
+| Thin activity writes different variables → dispatch workflow breaks | High | Map each `AgentDispatchResult` to the exact `DispatchedRunId`/`RunStatus`/`AgentResults` shapes; minimal dispatch workflow integration test. |
+| `AgentDispatchResult` vs LLM `AgentRunResult` name collision | Medium | Separate namespaces (`Services/AgentDispatch` vs `Services/Agents`); no shared type; compile-time disambiguation. |
+| Empty/default token fallback on resolution failure | Medium | Fail-closed: 503 `ACTIONS_TOKEN_UNAVAILABLE`, `retryable:false`; never call with an empty token (`feedback_resolution_no_empty_fallback`). |
+| Co-hosting hides the violation (design §1.1) | Medium | The activity calls over the wire via `TammaApiClient`, never resolves an injected vendor service — verified the moment the engine runs as per-tenant dedicated compute (Cranl). |
+| Depends on 38-1 guard / 32-5 pattern / Epic 28-29 not yet landed | Medium | Code to the interfaces; reuse 38-1's guard; mirror 32-5; use fakes in tests until they land. |
+
+### Success Metrics
+
+- [ ] `grep` over `Tamma.Activities` finds **zero** `IGitHubActionsClient` injections (all three activities cut over).
+- [ ] Every agent-dispatch request authorizes the `tenant ↔ repo` relationship before resolving a token; a cross-tenant dispatch is 403'd and never reaches the platform (isolation test).
+- [ ] 100% of mediated dispatch/poll calls emit exactly one terminal `AGENT_DISPATCH.*` event from `Tamma.Api`, tagged `{ tenantId, repo, operation, runId, credentialSource, correlationId }`.
+- [ ] The Actions token never appears in any response body, log line, or DCB event payload (credential-safety test green).
+- [ ] The inbound `workflow_run.completed` / `WebhookSignalRegistry` bookmark suspend/resume is unchanged (regression test green).
+- [ ] The three activities hold no Octokit/platform-HTTP reference; the dispatch workflow is unchanged.
+
+## Related
+
+- Design of record: `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§1 steps-never-call-external-APIs; §1.2 audit table — Class-C rows; §1.3 cross-tenant-token risk; §5.1 Class-C endpoints; §5.3 inbound webhooks out of scope)
+- Epic 38 README: `docs/stories/epic-38/README.md`
+- Template story: `docs/stories/epic-32/story-32-5/32-5-managed-agent-execution-layer.md` (the `/llm/call` mediation this mirrors)
+- Sibling story (prerequisite): `story-38-1/` (git-platform mediation — supplies the shared `IGitRepoAuthorizer` cross-tenant guard)
+- Implementation plan: `docs/superpowers/plans/2026-06-21-38-2-agent-dispatch-step-mediation-plan.md`
+- Sibling stories: `story-38-3/` (Slack/notifications mediation), `story-38-4/` (build-time guardrail analyzer)
+- Cross-epic: Epic 28 (tenancy / tenant↔repo registry); Epic 29 (secret cabinet — per-tenant Actions tokens); Epic 9 (`TammaApiClient` + the inbound `WebhookSignalRegistry` signalling contract)
+- Reused code: `IGitHubActionsClient` (`OctokitGitHubActionsClient`, now API-only), `TammaApiClient`, `WebhookSignalRegistry` (unchanged), the dispatch workflow consuming `DispatchedRunId`/`RunStatus`/`AgentResults`
+
+## Logging Requirements
+
+- **INFO**: agent-dispatch received (correlationId, repo, operation, tenantId — never the token); authorization decision (allow/deny); dispatch/poll completed (success, operation, runId, status, durationMs, credentialSource).
+- **DEBUG**: composition step boundaries (guard → token → client → audit); request DTO shape (no token).
+- **WARN**: typed failure paths (`REPO_NOT_AUTHORIZED`, `WORKFLOW_NOT_FOUND`, `RUN_NOT_FOUND`, `DISPATCH_REJECTED`, `PLATFORM_ERROR` + `platformStatusCode`, `ACTIONS_TOKEN_UNAVAILABLE`) with `failureCode` + `correlationId`.
+- **ERROR**: contract violations (null body), DCB append failure (the call still returns its result; the append failure is logged, not swallowed), and any attempt to return a raw 5xx (guardrail).
+- **Structured context**: `{ tenantId, repo, operation, runId, correlationId, credentialSource }` where applicable.
+- **Credential safety (LOAD-BEARING)**: NEVER log, return, or persist the resolved GitHub Actions token or any `Authorization` header. `credentialSource` (the label `byok`/`platform`) is safe; the token is not. The `AgentDispatchResult` body, all DCB event payloads, and the audit trail are token-free by contract — mirroring Story 32-5's credential-safety rule for LLM keys and Story 38-1's for git tokens.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-21 | 1.0.0   | Initial story creation — Class-C agent-dispatch step mediation. Re-points `DispatchAgentWorkflowActivity`/`GitHubActionsExecutor` + `MonitorAgentWorkflowActivity`/`CollectAgentResultsActivity` from the co-hosted `IGitHubActionsClient` (Octokit in API, Null in engine) to new `Tamma.Api` `POST /api/v1/agent-dispatch/{repo}/runs` + `GET /api/v1/agent-dispatch/{repo}/runs/{id}` endpoints that hold the per-tenant Actions token (Epic 28/29 cabinet, BYOK→platform), reuse Story 38-1's `IGitRepoAuthorizer` cross-tenant guard, dispatch/poll, and audit. Activities become thin `TammaApiClient` clients holding no token. The inbound `workflow_run.completed` webhook + `WebhookSignalRegistry` are explicitly OUT of scope (inbound, no outbound call to mediate — design §5.3) and unchanged. Mirrors the Story 32-5 `/llm/call` template. | Claude |

--- a/docs/stories/epic-38/story-38-3/38-3-slack-notifications-step-mediation.md
+++ b/docs/stories/epic-38/story-38-3/38-3-slack-notifications-step-mediation.md
@@ -1,0 +1,405 @@
+# Story 38-3: Slack / Notifications Step Mediation (Class D)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **platform engineer responsible for the rule-1 "steps never call external APIs directly" invariant**,
+I want `Integration/SlackActivity` re-pointed from the co-hosted, Slack-token-holding `IIntegrationService` to an internal **`POST /api/v1/notifications/slack`** endpoint that takes the post intent, holds the Slack token in `Tamma.Api`, performs the transport out-of-band (the outbox pattern), and audits it,
+So that **a workflow step never holds or transits the Slack credential in the engine process** (closing the last `VIOLATION-by-co-hosting` token-holder in the Class-D row of the design §1.2 audit table) — even when the engine runs as per-tenant dedicated compute (the Cranl path), where the token would otherwise have to be pushed into the engine.
+
+## Priority
+
+P2 — Slack is the **low-blast-radius** rule-1 violator (design §1.3: "Token-holding but reads no tenant data"). It is not a data-exfiltration vector like the Class-A git writes (38-1) or the Class-C agent-dispatch (38-2), but it is still a **`VIOLATION-by-co-hosting`**: `SlackActivity` injects `IIntegrationService`, whose Slack-posting implementation reads the Slack token. That implementation is registered in `Tamma.Api` and is **unregistered/null in the engine**, so today it only "works" because the single-process deploy co-hosts the two — exactly the co-hosting that rule 1 forbids. This story removes the token from the engine's reach permanently and sets the **outbox pattern as the template for fire-and-forget external effects**, which the forward-looking Class-E (Stripe/billing, Epic 35) tie-in then inherits by design.
+
+## Context
+
+### What exists today (the violation-by-co-hosting)
+
+`Tamma.Activities/Integration/SlackActivity.cs` is a `CodeActivity<SlackOperationResult>` that injects **`IIntegrationService`** (`Tamma.Core.Interfaces`) — the composite integration service whose concrete implementation holds the Slack bot token. The activity branches on an `Input<SlackAction>` (`SendChannel`, `SendDirect`, `SendAssessment`, `SendGuidance`, `SendNotification`) and calls `_integrationService.SendSlackMessageAsync(channel, message)` / `SendSlackDirectMessageAsync(userId, message)` **inside the engine process**. Per the design §1.2 audit table:
+
+| Activity | External target | How it reaches it today | Holds/transits a key in-engine? | Verdict |
+|---|---|---|---|---|
+| `Integration/SlackActivity` | Slack | `IIntegrationService` (impl + Slack token in API; unregistered in engine) | only if co-hosted | **VIOLATION-by-co-hosting (low blast radius)** |
+
+> **Co-hosting is NOT compliance (design §1.1).** Resolving a credential-holding service from the same DI container is allowed only by accident of the current single-process deploy. Rule 1 requires the step to call an internal endpoint **over the wire** via `TammaApiClient`, never to resolve an injected vendor service. The moment the engine runs as per-tenant dedicated compute (Cranl), the co-hosted `IIntegrationService` impl is **null** in the engine — and the Slack token must NOT be pushed there to "fix" it.
+
+### What this story does (rule 1, Class D — the outbox variant)
+
+This story applies the **outbox pattern** (the design §1.1 reference, embodied by `QueueWelcomeEmailActivity`) to the Slack effect, because a Slack post is a **fire-and-forget** external effect with no return value the workflow needs to branch on:
+
+1. A new internal endpoint **`POST /api/v1/notifications/slack`** (`Tamma.Api/Endpoints/NotificationEndpoints.cs`), engine-only, authenticated on the **same plane** as the other `TammaApiClient` callbacks (Bearer `Tamma:ApiToken` via the engine auth handler + `X-Tenant-Id`). The endpoint writes the post **intent** to a control-plane **`slack_outbox`** table and returns **202 Accepted** — it does NOT call Slack synchronously.
+2. A new out-of-band sender **`OutboxSlackSender`** (in `Tamma.Api`, mirroring `OutboxSmtpSender`) **holds the Slack token**, scans `slack_outbox` for `pending` rows, performs the actual Slack HTTPS post (`chat.postMessage`), records delivery / `LastError`, and emits the DCB audit event.
+3. `SlackActivity` collapses to a **thin client**: it maps its `Input<>` props into a `SlackNotificationRequest` and sends it via a **new `TammaApiClient.QueueSlackNotificationAsync(...)`** (following the existing `PostVoidAsync` + `AddTenantHeader` + `RecordHealthAsync` pattern). It **injects no `IIntegrationService`** and holds no token. Its `SlackOperationResult` reports "queued" (`WaitingForResponse=false`), preserving the activity's existing output contract for the 1-2 mentorship workflows that read it.
+
+The Slack token, the post, the audit, and any retry now live **entirely in `Tamma.Api`**. The engine's `IIntegrationService` Slack registration is removed from the engine composition (the git/agent-dispatch members of that composite interface are handled by 38-1 / 38-2; this story owns only the Slack methods).
+
+### Forward-looking: Class E (Billing / Stripe, Epic 35) — ENFORCE BY DESIGN
+
+The same outbox-vs-endpoint shape this story establishes is the **mandatory pattern for Class E** (design §1.2 final row + §5.1 Class-E): when Epic 35 lands, a billing step **emits an intent** (`POST /api/v1/billing/...` or a `billing_outbox` row) and the API — which alone holds the **Stripe key** — performs the charge/invoice, meters it, and audits. **Calling Stripe from an activity is PROHIBITED at design time.** This story includes a non-implemented `## Forward-looking: Class E (Billing / Stripe) enforce-by-design` subsection so the pattern is set **before** Epic 35 writes a single line, and so 38-4's guardrail analyzer (which this story is a sibling of) already covers a future `BillingActivity` that tries to inject a Stripe client.
+
+### Explicitly out of scope (sibling stories / future epics)
+
+- **Class A — git platform mediation** (`CreateBranch`/`CreatePullRequest`/`MergePullRequest`/`UpdateIssueStatus`/`AnalyzeReview` → `/api/v1/git/...`) is **38-1**.
+- **Class C — agent-dispatch mediation** (`DispatchAgentWorkflow`/`MonitorAgentWorkflow`/`CollectAgentResults` → `/api/v1/agent-dispatch/...`) is **38-2**.
+- **The build-time guardrail analyzer** that fails the build if any `Tamma.Activities` class re-introduces a direct `HttpClient`/vendor-service call is **38-4** (this story's effect is one of the violations 38-4 permanently protects).
+- **Actual Stripe/billing implementation** is **Epic 35**; this story only fixes the pattern in stone (the Class-E subsection is documentation-only).
+- **The LLM path** (`/api/v1/llm/call`) is Epic 32 (**32-5**); this story reuses its mediation template, not its endpoint.
+
+## Acceptance Criteria
+
+1. **The endpoint exists and is engine-only.** `POST /api/v1/notifications/slack` is served by a new `Tamma.Api/Endpoints/NotificationEndpoints.cs`, authenticated by **Bearer `Tamma:ApiToken` (engine auth handler) + `X-Tenant-Id`** — the same plane as the existing `TammaApiClient` callbacks (agent-resolve / budget / diagnostics / provider-session / `llm/call`). Missing/invalid bearer → **HTTP 401**. The handler binds a `SlackNotificationRequest`, derives `tenantId` from `X-Tenant-Id` when the body omits it, and persists an outbox row.
+
+2. **The endpoint writes intent, not transport (the outbox pattern).** The endpoint **never calls Slack synchronously**. It validates the request, inserts a `slack_outbox` row (`Status="pending"`), and returns **HTTP 202 Accepted** with `{ outboxId }`. The Slack token is **not read** in the request path. (Mirrors `QueueWelcomeEmailActivity` → `platform_email_outbox` + `OutboxSmtpSender`, design §1.1 reference pattern.)
+
+3. **`SlackNotificationRequest` matches the activity's surface.** The wire record carries `{ tenantId?, action ("SendChannel"|"SendDirect"|"SendAssessment"|"SendGuidance"|"SendNotification"), channel?, userId?, message, messageType ("Info"|"Warning"|"Success"|"Error"|"Celebration"), sessionId?, correlationId }`. Server-side message formatting (the emoji-prefix + assessment/guidance templating currently in `SlackActivity.FormatMessage`/`SendAssessmentRequest`/`SendGuidanceMessage`) **moves into the API** so the engine carries no presentation logic and posts no raw token-bearing call.
+
+4. **`OutboxSlackSender` holds the token and performs the post out-of-band.** A new `Tamma.Api/Services/Notifications/OutboxSlackSender.cs` (a hosted/background scanner mirroring `OutboxSmtpSender`) reads the Slack bot token from configuration (`Slack:BotToken`), scans `slack_outbox` for `pending` rows whose `NextAttemptAt <= now`, posts to the Slack Web API (`chat.postMessage` for a channel / opening a DM for a user), and on success marks `Status="sent"` + `SentAt`. On a transient failure it sets `LastError`, increments `Attempts`, and backs off `NextAttemptAt`; on terminal failure (`Attempts >= MaxAttempts`) it marks `Status="failed"`. **The token is read only here, never returned to the engine, never logged.**
+
+5. **`SlackActivity` becomes a thin client holding no token.** `SlackActivity` is reduced to map its `Input<SlackAction> Action` / `Channel` / `UserId` / `Message` / `MessageType` / `SessionId` props into a `SlackNotificationRequest` and send it via the **new `TammaApiClient.QueueSlackNotificationAsync(request, tenantId, ct)`** (returning `bool`, via `PostVoidAsync`). It **no longer injects `IIntegrationService`** and contains **no** `SendSlackMessageAsync`/`SendSlackDirectMessageAsync` call, no token, no Slack HTTP. Its `SlackOperationResult` reports `Success` = the queue result and `WaitingForResponse=false` (queued, fire-and-forget), preserving the output variable the mentorship workflows read. The `MentorshipEvent` session logging it does today stays — it is a local repository write, not an external call.
+
+6. **The engine holds no Slack token after cutover.** The engine's `IIntegrationService` **Slack-method registration** is removed from the engine DI composition; `SlackActivity` resolves no Slack-credential-holding service. A `grep` over `Tamma.Activities` for `IIntegrationService` Slack usage / a Slack token / `chat.postMessage` / `slack.com` returns **zero** non-`TammaApiClient` hits. (38-4's analyzer makes this permanent.)
+
+7. **DCB audit from the API, never the engine.** The post is audited from **`Tamma.Api`** (where the token + tenant store live): `NOTIFICATION.SLACK.QUEUED.SUCCESS` (from the endpoint, tags `{ action, channel?, userId?, sessionId?, correlationId, tenantId|userId }`) and exactly one terminal `NOTIFICATION.SLACK.SENT.SUCCESS` or `NOTIFICATION.SLACK.SENT.FAILED` (from `OutboxSlackSender`, the latter additionally tagging a key-free `failureReason`). The **message body is recorded as a redacted/length-bounded preview**, never raw secrets; the **token never appears** in any event payload.
+
+8. **New control-plane table is registered in the destructive DROP list + the model contract test.** `slack_outbox` is a **control-plane / public-schema** table (it must deliver regardless of tenant-DB routing — same rationale as `platform_email_outbox`). It MUST be appended to `Program.cs`'s startup-reset "Wiping Tamma-managed public-schema tables" DROP list (else a 2nd test-host boot fails with `relation already exists`), and the new CP entity MUST be added to `ControlPlaneDbContextModelTests.Model_Has_ExpectedControlPlaneEntities`'s strict `BeEquivalentTo` list. It is **not** a tenant-schema (`t_<hex>`) table.
+
+9. **Exactly-once-per-intent on replay.** Because Elsa replays activities, `SlackActivity` calling the endpoint twice for the same `(correlationId, action, target)` must enqueue **one** row. The endpoint de-duplicates on `(correlationId, action, channel|userId)` via a partial unique index `WHERE Status <> 'failed'` (mirroring `EnqueueWelcomeOnceAsync`'s `(TenantId, Template) WHERE Status <> 'failed'` + in-code pre-check). A replayed enqueue returns the existing `outboxId`, inserting nothing.
+
+10. **Fail-soft like the existing activity.** Today `SlackActivity` catches and returns `SlackOperationResult{Success=false}` rather than failing the workflow (a missing Slack post must not break a mentorship session). The thin client preserves this: an unreachable API / non-2xx response → `Success=false`, logged, workflow continues. (Consistent with `TammaApiClient`'s null-on-failure convention.)
+
+11. **Forward-looking Class-E pattern documented (no code).** The story carries a `## Forward-looking: Class E (Billing / Stripe) enforce-by-design` subsection stating that a future billing step MUST emit an intent (`POST /api/v1/billing/...` or a `billing_outbox` row) and that calling Stripe from an activity is prohibited at design time — so Epic 35 inherits this shape and 38-4's analyzer already guards it. **No Stripe/billing code is written in this story.**
+
+12. **Tests cover endpoint + outbox + thin-client + audit + dedup.** Endpoint auth (401 missing bearer); 202 + outbox-row-written + Slack-not-called-synchronously; `OutboxSlackSender` happy path (token read, post performed, `sent`) and failure/backoff (`LastError`, `Attempts`, terminal `failed`); the thin `SlackActivity` maps props → request and writes the same `SlackOperationResult` shape with `WaitingForResponse=false`; fail-soft on API-down; replay dedup (one row for two enqueues); one terminal `NOTIFICATION.SLACK.SENT.*` event; and the token never appears in any response/log/event (credential-safety assertion).
+
+## Technical Design
+
+### Where it lives
+
+```
+apps/tamma-elsa/src/Tamma.Api/Endpoints/
+  NotificationEndpoints.cs              # NEW — POST /api/v1/notifications/slack; engine-only auth; writes slack_outbox row; returns 202
+
+apps/tamma-elsa/src/Tamma.Api/Services/Notifications/
+  SlackNotificationRequest.cs           # NEW — wire request record (AC3)
+  ISlackNotificationService.cs          # NEW — enqueue + format seam (called by the endpoint)
+  SlackNotificationService.cs           # NEW — formats message (moved from SlackActivity), de-dupes, inserts outbox row
+  OutboxSlackSender.cs                  # NEW — out-of-band background sender; HOLDS the Slack token; chat.postMessage; audits
+
+apps/tamma-elsa/src/Tamma.Data/Entities/
+  SlackOutboxMessage.cs                 # NEW — CP outbox entity (mirrors PlatformEmailOutboxMessage)
+
+apps/tamma-elsa/src/Tamma.Data/Repositories/
+  ISlackOutboxRepository.cs             # NEW — EnqueueOnceAsync + ClaimPendingAsync + MarkSent/MarkFailed
+  SlackOutboxRepository.cs              # NEW — partial-unique-index-backed exactly-once enqueue
+
+apps/tamma-elsa/src/Tamma.Activities/Integration/
+  SlackActivity.cs                      # GUT — drop IIntegrationService; thin client over TammaApiClient.QueueSlackNotificationAsync
+
+apps/tamma-elsa/src/Tamma.Activities/LlmCall/
+  TammaApiClient.cs                     # MODIFY — add QueueSlackNotificationAsync(SlackNotificationRequest, tenantId, ct) (PostVoidAsync pattern)
+
+apps/tamma-elsa/src/Tamma.ElsaServer/
+  Program.cs                            # MODIFY — remove the engine's Slack IIntegrationService registration (Slack methods only)
+  Program.cs                            # MODIFY — append "slack_outbox" to the public-schema DROP list (AC8)
+
+apps/tamma-elsa/src/Tamma.Api/
+  Program.cs                            # MODIFY — map NotificationEndpoints; register ISlackNotificationService + OutboxSlackSender (hosted); EF model for SlackOutboxMessage
+
+apps/tamma-elsa/src/Tamma.Data/Migrations/
+  <timestamp>_AddSlackOutbox.cs         # NEW — amends the existing snapshot (sequential; does NOT branch it)
+```
+
+### The endpoint (`NotificationEndpoints.cs`)
+
+```csharp
+// POST /api/v1/notifications/slack — internal, engine-only. Same auth plane as the other TammaApiClient callbacks.
+app.MapPost("/api/v1/notifications/slack", async (
+        SlackNotificationRequest request,
+        HttpContext http,
+        ISlackNotificationService notifications,
+        CancellationToken ct) =>
+{
+    // Bearer validated by the engine auth scheme; missing/invalid -> 401 before this runs.
+    var tenantId = request.TenantId ?? ResolveTenant(http);     // from X-Tenant-Id when body omits it
+
+    // Writes intent ONLY — never calls Slack here. The token is NOT read in this path.
+    var outboxId = await notifications.EnqueueAsync(request with { TenantId = tenantId }, ct);  // de-dupes (AC9)
+
+    // NOTIFICATION.SLACK.QUEUED.SUCCESS emitted inside EnqueueAsync (tenant IEventRepository).
+    return Results.Accepted($"/api/v1/notifications/slack/{outboxId}", new { outboxId });        // 202
+})
+.RequireAuthorization(EngineAuthPolicy)   // same plane as agent-resolve / budget / llm/call
+.WithName("QueueSlackNotification");
+```
+
+### `SlackNotificationRequest` (the wire contract — AC3)
+
+```csharp
+public sealed record SlackNotificationRequest
+{
+    public Guid? TenantId { get; init; }            // null => single-user/platform; also from X-Tenant-Id
+    public required string Action { get; init; }    // SendChannel|SendDirect|SendAssessment|SendGuidance|SendNotification
+    public string? Channel { get; init; }           // for channel posts
+    public string? UserId { get; init; }            // for DMs
+    public required string Message { get; init; }    // raw content; formatting applied server-side
+    public string MessageType { get; init; } = "Info";  // Info|Warning|Success|Error|Celebration
+    public Guid? SessionId { get; init; }           // mentorship session context (logged, not transmitted to Slack)
+    public required string CorrelationId { get; init; } // workflow instance id — drives dedup + audit
+}
+```
+
+### The CP outbox entity (`SlackOutboxMessage.cs`) — mirrors `PlatformEmailOutboxMessage`
+
+```csharp
+public sealed class SlackOutboxMessage
+{
+    public Guid Id { get; set; }
+    public Guid? TenantId { get; set; }      // XOR with UserId, same discipline as platform_email_outbox
+    public Guid? UserId { get; set; }
+    public string Action { get; set; } = null!;     // SendChannel|SendDirect|...
+    public string? Channel { get; set; }
+    public string? UserHandle { get; set; }         // Slack user id for DMs (NOT a Tamma UserId)
+    public string FormattedMessage { get; set; } = null!;  // already emoji/templated server-side
+    public Guid? SessionId { get; set; }
+    public string CorrelationId { get; set; } = null!;
+    public string Status { get; set; } = "pending"; // pending|sent|failed
+    public int Attempts { get; set; }
+    public int MaxAttempts { get; set; } = 5;
+    public DateTime NextAttemptAt { get; set; }
+    public string? LastError { get; set; }          // key-free
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public DateTime? SentAt { get; set; }
+}
+// Partial unique index: (CorrelationId, Action, COALESCE(Channel, UserHandle)) WHERE Status <> 'failed'  (AC9)
+```
+
+### `OutboxSlackSender` (holds the token; out-of-band; AC4/AC7)
+
+```csharp
+// Mirrors OutboxSmtpSender: a background scanner in Tamma.Api. THE token-holder.
+public sealed class OutboxSlackSender   // BackgroundService / hosted scanner
+{
+    private readonly string _botToken;          // from Slack:BotToken — read ONLY here
+    private readonly ISlackOutboxRepository _repo;
+    private readonly IHttpClientFactory _http;
+    private readonly IEventRepository _events;  // tenant-scoped audit
+
+    public async Task RunOnceAsync(CancellationToken ct)
+    {
+        foreach (var row in await _repo.ClaimPendingAsync(batch: 25, ct))
+        {
+            try
+            {
+                await PostToSlackAsync(row, _botToken, ct);   // chat.postMessage / DM-open — the ONLY Slack call
+                await _repo.MarkSentAsync(row.Id, ct);
+                await _events.AppendAsync(SlackSent(row), ct);          // NOTIFICATION.SLACK.SENT.SUCCESS
+            }
+            catch (Exception ex)
+            {
+                await _repo.MarkFailedAsync(row.Id, KeyFree(ex), ct);   // backoff or terminal 'failed'
+                await _events.AppendAsync(SlackFailed(row, KeyFree(ex)), ct); // NOTIFICATION.SLACK.SENT.FAILED
+            }
+        }
+    }
+}
+```
+
+### The thin `SlackActivity` shim (AC5/AC10)
+
+```csharp
+// No IIntegrationService. No token. No Slack HTTP. Maps props -> request -> queue.
+var req = new SlackNotificationRequest {
+    TenantId = tenantId, Action = action.ToString(),
+    Channel = channel, UserId = userId, Message = message,
+    MessageType = messageType.ToString(), SessionId = sessionId,
+    CorrelationId = context.WorkflowExecutionContext.Id
+};
+var queued = await _api.QueueSlackNotificationAsync(req, tenantId?.ToString(), ct);  // NEW client method (PostVoidAsync)
+
+if (sessionId.HasValue && queued)
+    await _repository!.LogEventAsync(/* MentorshipEvent — local write, kept */);
+
+context.SetResult(new SlackOperationResult {
+    Success = queued,
+    Message = queued ? "Notification queued" : "Notification queue failed",
+    Destination = channel ?? userId ?? "unknown",
+    WaitingForResponse = false        // fire-and-forget; nothing to await
+});
+// Fail-soft (AC10): queued==false does NOT throw; the workflow continues.
+```
+
+### `TammaApiClient.QueueSlackNotificationAsync` (AC5)
+
+```csharp
+public Task<bool> QueueSlackNotificationAsync(
+    SlackNotificationRequest request, string? tenantId = null, CancellationToken ct = default)
+{
+    var url = $"{_baseUrl}/api/v1/notifications/slack";
+    return PostVoidAsync(url, request, tenantId, ct);   // AddTenantHeader + RecordHealthAsync, null/false on failure
+}
+```
+
+## Forward-looking: Class E (Billing / Stripe) enforce-by-design
+
+> **Documentation-only in this story. No Stripe/billing code is written here.** This subsection fixes the pattern in stone *before* Epic 35 lands, so billing inherits the same mediation shape this story establishes for Slack and 38-4's analyzer already guards it.
+
+Per design §1.2 (final row, "Enforce by design") and §5.1 (Class E):
+
+- **A workflow step MUST NOT call Stripe (or any billing vendor) directly.** A billing step emits an **intent** — either `POST /api/v1/billing/...` (request/response, like `/llm/call`) for operations the workflow must branch on, or a **`billing_outbox` row** (fire-and-forget, like this story's `slack_outbox`) for charges/invoices that can be performed out-of-band.
+- **`Tamma.Api` alone holds the Stripe key.** It performs the charge/invoice, meters it (Epic 35 / 36), and audits it. The engine never holds the Stripe key, never hits `api.stripe.com`.
+- **Outbox vs endpoint by effect shape:** a synchronous "is this card valid / what is the price" → endpoint; an asynchronous "charge this usage / send this invoice" → `billing_outbox` + an `OutboxStripeSender` mirroring this story's `OutboxSlackSender`.
+- **38-4 already covers it:** a future `BillingActivity` that injects a `StripeClient` or POSTs to `api.stripe.com` from `Tamma.Activities` would **fail the build** under 38-4's guardrail analyzer. This is the cheapest possible enforcement: the violation can never compile.
+
+When Epic 35 is authored, its billing-effect stories cite this subsection as the binding pattern.
+
+## Dependencies
+
+**Internal (siblings / prerequisites):**
+
+- **38-1** (git platform mediation) — sibling Class-A mediation; both re-point `Tamma.Activities` activities to `TammaApiClient` and both deregister members of the same co-hosted `IIntegrationService` composite (38-1 owns the GitHub methods; this story owns the Slack methods). Coordinate the engine-side deregistration so neither leaves a dangling registration.
+- **38-2** (agent-dispatch mediation) — sibling Class-C mediation; same `TammaApiClient`/endpoint template.
+- **38-4** (build-time guardrail analyzer) — the permanent backstop; this story's cutover is one of the violations 38-4 protects. Land 38-4's allowlist *after* this story's `QueueSlackNotificationAsync` exists so `TammaApiClient` is on the allowed host list.
+- **32-5** (`POST /api/v1/llm/call`) — the mediation **template** this story copies (engine-only auth plane, `TammaApiClient` callback convention, DCB-from-the-API, `feedback_resolution_no_empty_fallback` discipline). Not a runtime dependency.
+- **Epic 28 / 29** (control-plane outbox + cabinet) — `slack_outbox` is a CP table reusing the `platform_email_outbox` + `OutboxSmtpSender` pattern; the Slack `Slack:BotToken` is a platform credential (single Slack workspace today; per-tenant Slack BYOK is a future extension via the Epic 29 cabinet, not in this story).
+
+**Reference patterns (compliant exemplars — design §1.1):**
+
+- `QueueWelcomeEmailActivity` + `platform_email_outbox` + `OutboxSmtpSender` — the **outbox** template this story mirrors for fire-and-forget effects.
+- `TriggerCIActivity` — the engine-callback template (POSTs to an internal endpoint, holds no vendor credential).
+- `TammaApiClient` — the engine→API HTTP delegation seam (Bearer `Tamma:ApiToken` + `X-Tenant-Id`, `PostVoidAsync`/`AddTenantHeader`/`RecordHealthAsync`).
+
+**Consumers (downstream, not blockers):**
+
+- **Epic 36** (analytics) / **Epic 37** (audit) — consume `NOTIFICATION.SLACK.*` events.
+- **Epic 35** (billing) — inherits the enforce-by-design Class-E pattern documented above.
+
+**External:** Slack Web API (`chat.postMessage`) — now reached **only** from `OutboxSlackSender` in `Tamma.Api`, never from the engine.
+
+## Testing Strategy
+
+1. **Endpoint auth.** Missing/invalid bearer → 401; valid bearer + `X-Tenant-Id` → request bound, `tenantId` derived from header when body omits it.
+2. **Endpoint writes intent, returns 202 (AC2).** A valid request inserts exactly one `slack_outbox` row (`Status="pending"`) and returns 202 + `{ outboxId }`; assert (via a fake/spy on the Slack HTTP path) that **Slack is NOT called synchronously** and the token is **not read** in the request path.
+3. **Server-side formatting (AC3).** `SendAssessment`/`SendGuidance`/`MessageType` produce the same emoji-prefixed/templated body the legacy `SlackActivity.FormatMessage` produced — assert the formatted body is persisted, not the raw message.
+4. **`OutboxSlackSender` happy path (AC4/AC7).** A `pending` row → token read from `Slack:BotToken`, `chat.postMessage` performed (faked HTTP), row → `sent` + `SentAt`, one `NOTIFICATION.SLACK.SENT.SUCCESS`.
+5. **`OutboxSlackSender` failure/backoff (AC4).** Transient post failure → `LastError` set (key-free), `Attempts++`, `NextAttemptAt` backed off, `Status` stays `pending`; after `MaxAttempts` → `Status="failed"` + one `NOTIFICATION.SLACK.SENT.FAILED`.
+6. **Thin-client mapping (AC5).** `SlackActivity` maps `Action`/`Channel`/`UserId`/`Message`/`MessageType`/`SessionId` → `SlackNotificationRequest` and writes `SlackOperationResult{ Success=queued, WaitingForResponse=false }`; the `MentorshipEvent` session log still fires on success.
+7. **Fail-soft (AC10).** `QueueSlackNotificationAsync` returns false (API down) → `SlackOperationResult{Success=false}`, no throw, workflow continues.
+8. **Replay dedup (AC9).** Two enqueues with the same `(correlationId, action, target)` → one `slack_outbox` row; the second returns the existing `outboxId`. Partial unique index `WHERE Status <> 'failed'` enforced at the DB level.
+9. **Engine holds no token (AC6).** `grep` over `Tamma.Activities` for `IIntegrationService` Slack methods / `chat.postMessage` / `slack.com` / a Slack token → zero non-`TammaApiClient` hits; `SlackActivity` constructor injects no `IIntegrationService`.
+10. **CP-table registration (AC8).** A 2nd test-host boot succeeds (no `relation already exists`) — proves `slack_outbox` is in the DROP list; `ControlPlaneDbContextModelTests.Model_Has_ExpectedControlPlaneEntities` includes `SlackOutboxMessage`.
+11. **Credential safety (AC7).** Assert the Slack token never appears in any `slack_outbox` row, `LastError`, log line, HTTP response, or DCB event payload; the message body in events is redacted/length-bounded.
+
+Docker-bound C# suites run via `sg docker -c "dotnet test apps/tamma-elsa/..."` (session docker group is stale; plain `dotnet build` needs no wrapper).
+
+## Estimated Effort
+
+3-4 days (one endpoint + CP outbox entity/repo/migration + out-of-band sender + the thin-client cutover of a single activity + the DROP-list/model-test registration). Lower than 38-1/38-2 (one activity, fire-and-forget, no cross-tenant authorization decision).
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Endpoints/NotificationEndpoints.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Notifications/SlackNotificationRequest.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Notifications/ISlackNotificationService.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Notifications/SlackNotificationService.cs` | Create (formatting moved from `SlackActivity`; dedup; enqueue) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Notifications/OutboxSlackSender.cs` | Create (token-holder; out-of-band; audit) |
+| `apps/tamma-elsa/src/Tamma.Data/Entities/SlackOutboxMessage.cs` | Create (CP outbox entity) |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/ISlackOutboxRepository.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Data/Repositories/SlackOutboxRepository.cs` | Create (partial-unique-index exactly-once) |
+| `apps/tamma-elsa/src/Tamma.Data/Migrations/<ts>_AddSlackOutbox.cs` | Create (amends existing snapshot) |
+| `apps/tamma-elsa/src/Tamma.Activities/Integration/SlackActivity.cs` | Gut → thin client; drop `IIntegrationService` |
+| `apps/tamma-elsa/src/Tamma.Activities/LlmCall/TammaApiClient.cs` | Modify (add `QueueSlackNotificationAsync`) |
+| `apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs` | Modify (remove engine Slack registration; append `slack_outbox` to DROP list) |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (map endpoint; register service + `OutboxSlackSender`; EF model) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Notifications/NotificationEndpointsTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Notifications/OutboxSlackSenderTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/Integration/SlackActivityThinClientTests.cs` | Create |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs` | Modify (add `SlackOutboxMessage`) |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, and decisions (esp. `feedback_resolution_no_empty_fallback` and the outbox-pattern notes around Story 28-5/28-6).
+3. Read the design of record §1 (steps never call providers), §1.2 (the Class-D Slack audit row), §5.1 (Class-D + Class-E endpoints), and §5.2 (the follow-up-epic phasing) IN FULL.
+4. Reviewed `QueueWelcomeEmailActivity.cs` + `PlatformEmailOutboxMessage` + `OutboxSmtpSender` (the outbox template you are copying), `SlackActivity.cs` (the activity you are gutting + the formatting you are moving), and `TammaApiClient` (the callback pattern + `PostVoidAsync`).
+5. Confirmed with 38-1's author who deregisters which methods of the shared `IIntegrationService` composite so the engine has no dangling Slack/GitHub registration.
+6. Planned the TDD approach — write the endpoint-202/no-sync-call test and the dedup test first.
+
+### Key Design Decisions
+
+- **Outbox, not request/response (deliberate).** A Slack post is fire-and-forget with no value the workflow branches on, so it follows `QueueWelcomeEmailActivity` (intent → out-of-band sender) rather than `/llm/call` (synchronous mediation). This also makes the post resilient to the Slack API being briefly down — the row stays `pending` and retries — which the synchronous shape could not give cheaply.
+- **The token lives in `OutboxSlackSender` only.** The endpoint writes intent and never reads `Slack:BotToken`; the sender is the single token-holder. This is the design §1.1 invariant: credential-holding code lives only in `Tamma.Api`.
+- **Server-side formatting.** The emoji/assessment/guidance templating moves out of the engine so the engine carries no presentation coupling to Slack and the message is fully resolved before it touches the token-holding path.
+- **CP table, not tenant table.** `slack_outbox` is control-plane (must deliver regardless of tenant-DB routing — same rationale as `platform_email_outbox`), so it goes in the `Program.cs` DROP list and the CP model contract test, **not** the per-tenant `EfTenantDbMigrator`.
+- **Sequential migration.** This story amends the existing EF snapshot (one `AddSlackOutbox` migration); it does not branch it. 38-1/38-2/38-3/38-4 are implemented sequentially per the EF parallel-migration hazard.
+- **Class-E is design-only here.** The Stripe pattern is fixed in stone via the subsection above so Epic 35 inherits it and 38-4 guards it — but no billing code ships in this story.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who is the principal of a Slack notification? | The sole user (keyed by `UserId`; `TenantId` may be null). | The tenant (keyed by `TenantId` from `X-Tenant-Id`). No per-user layer. |
+| Whose Slack credential performs the post? | The platform `Slack:BotToken` (single workspace today); per-tenant Slack BYOK is a future Epic-29-cabinet extension, not this story. | Same platform `Slack:BotToken`; if/when per-tenant Slack BYOK lands it resolves from the tenant cabinet — never pushed to the engine. |
+| Where does the `slack_outbox` row's owner scoping land? | `UserId` set, `TenantId` null (XOR, like `platform_email_outbox`). | `TenantId` set, `UserId` null. |
+| Where do `NOTIFICATION.SLACK.*` events land? | The user's (sole) tenant event store. | The tenant's `t_<hex>` event store via the tenant-scoped `IEventRepository`. Never cross-tenant. |
+| Who owns the notification audit data? | The user. | The tenant — platform admin sees none of it (design ownership rule). |
+| Who may deregister/manage the Slack integration? | The sole user (it is their instance). | Platform-owner (`PlatformOwnerAccess`) for the platform workspace; tenant cannot mint a new bot token. |
+| Mode source | `ITammaModeProvider` (`TammaMode.cs`) — process-stable. | same |
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Engine still resolves a Slack-token service after cutover (AC6) | High | Remove the engine's Slack `IIntegrationService` registration; `grep` `Tamma.Activities` for Slack methods / `chat.postMessage` → zero; 38-4's analyzer makes it permanent. |
+| New CP table breaks the 2nd test-host boot (AC8) | High | Append `slack_outbox` to the `Program.cs` "Wiping Tamma-managed public-schema tables" DROP list **and** to `ControlPlaneDbContextModelTests`'s strict list; the 2nd-boot test proves it. |
+| Replay double-posts (AC9) | Medium | Partial unique index `(CorrelationId, Action, target) WHERE Status <> 'failed'` + in-code pre-check (mirrors `EnqueueWelcomeOnceAsync`); dedup test. |
+| Token leaks into a row / event / log (AC7) | High | Token read only in `OutboxSlackSender`; `LastError` is key-free; events carry a redacted/length-bounded message preview; credential-safety test asserts zero token occurrences. |
+| Output-contract drift breaks the mentorship workflows that read `SlackOperationResult` (AC5) | Medium | Preserve the `SlackOperationResult` shape (`Success`/`Message`/`Destination`/`WaitingForResponse=false`); keep the `MentorshipEvent` local log; thin-client mapping test. |
+| Slack briefly down loses the notification | Low | Outbox `pending` + backoff retry (the reason for choosing the outbox shape over synchronous mediation). |
+| Dangling shared-composite registration with 38-1 | Medium | Coordinate the `IIntegrationService` deregistration split (Slack here, GitHub in 38-1) before either lands. |
+
+### Success Metrics
+
+- [ ] `grep` over `Tamma.Activities` finds **zero** Slack-token / `chat.postMessage` / Slack `IIntegrationService` usage (the engine holds no Slack credential).
+- [ ] 100% of Slack effects go through `POST /api/v1/notifications/slack` → `slack_outbox` → `OutboxSlackSender`; the endpoint never calls Slack synchronously.
+- [ ] Every delivered post produces one `NOTIFICATION.SLACK.QUEUED.SUCCESS` + exactly one terminal `NOTIFICATION.SLACK.SENT.*`.
+- [ ] The 2nd test-host boot succeeds and `ControlPlaneDbContextModelTests` is green (CP table registered).
+- [ ] The Class-E enforce-by-design subsection is present so Epic 35 inherits the pattern (verified by 38-4's coverage of a hypothetical `BillingActivity`).
+
+## Related
+
+- Design of record: `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§1 steps-never-call-providers; §1.2 audit table — Class-D Slack row + Class-E billing row; §5.1 Class-D/Class-E endpoints; §5.2 follow-up-epic phasing)
+- Re-plan: `docs/superpowers/plans/2026-06-20-epic-32-37-replan.md`
+- Implementation plan: `docs/superpowers/plans/2026-06-21-38-3-slack-notifications-step-mediation-plan.md`
+- Sibling stories: `story-38-1/` (git platform mediation), `story-38-2/` (agent-dispatch mediation), `story-38-4/` (build-time guardrail analyzer); `docs/stories/epic-32/story-32-5/` (the `/llm/call` mediation template)
+- Forward tie-in: **Epic 35** (billing) — inherits the Class-E enforce-by-design pattern documented here.
+- Reference patterns: `apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/QueueWelcomeEmailActivity.cs` + `Tamma.Data/Entities/PlatformEmailOutboxMessage.cs` + `OutboxSmtpSender` (outbox); `apps/tamma-elsa/src/Tamma.Activities/Testing/TriggerCIActivity.cs` (engine-callback); `apps/tamma-elsa/src/Tamma.Activities/LlmCall/TammaApiClient.cs` (callback seam)
+- Code being changed: `apps/tamma-elsa/src/Tamma.Activities/Integration/SlackActivity.cs` (the activity being gutted)
+
+## Logging Requirements
+
+- **INFO**: slack-notification queued (correlationId, action, channel/userId target, sessionId, tenantId — **never the raw token**); outbox sender delivered (outboxId, action, target, durationMs); engine thin-client queue result (success/false).
+- **DEBUG**: server-side message formatting (action → formatted-body length, not the secret-bearing content verbatim), dedup hit (existing `outboxId` returned on replay), outbox claim/batch size.
+- **WARN**: queue failure (API unreachable → `SlackOperationResult{Success=false}`, fail-soft), outbox post transient failure (`Attempts`, backoff `NextAttemptAt`, key-free `LastError`).
+- **ERROR**: outbox terminal failure (`Status="failed"` after `MaxAttempts`), DCB append failure (the post still completes; the append failure is logged, not swallowed), and any attempt by the engine to resolve a Slack-credential service (guardrail — should be impossible after cutover).
+- **Structured context**: `{ correlationId, action, channel?, userId?, sessionId?, tenantId|userId, outboxId, status }` where applicable.
+- **Credential safety (LOAD-BEARING)**: NEVER log, return, or persist the Slack bot token (`Slack:BotToken`), raw Slack auth headers, or webhook secrets. The token is read **only** inside `OutboxSlackSender`. `LastError` is sanitized to be key-free; event payloads carry a **redacted, length-bounded** message preview (never the raw message if it may contain secrets); the `slack_outbox` row, HTTP responses, and all DCB events are token-free by contract.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-21 | 1.0.0   | Initial story creation — Class-D Slack/notifications step mediation. Re-points `Integration/SlackActivity` from the co-hosted `IIntegrationService` (Slack token in API, unregistered in engine) to `POST /api/v1/notifications/slack`, adopting the outbox pattern (`slack_outbox` CP table + `OutboxSlackSender` token-holder, mirroring `QueueWelcomeEmailActivity`/`platform_email_outbox`/`OutboxSmtpSender`) for the fire-and-forget post; thin-client `SlackActivity` over a new `TammaApiClient.QueueSlackNotificationAsync`; CP DROP-list + model-contract-test registration; DCB audit from the API; never-log-token credential safety; and a forward-looking Class-E (Billing/Stripe, Epic 35) enforce-by-design subsection (documentation-only) so the mediation pattern is set before Epic 35 lands. Sibling of 38-1/38-2 (Class A/C) and protected by 38-4's guardrail analyzer. | Claude |

--- a/docs/stories/epic-38/story-38-4/38-4-build-time-guardrail-analyzer.md
+++ b/docs/stories/epic-38/story-38-4/38-4-build-time-guardrail-analyzer.md
@@ -1,0 +1,339 @@
+# Story 38-4: Build-Time Guardrail Analyzer (rule-1 enforcement)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+
+## User Story
+
+As a **platform maintainer responsible for the permanence of the "steps never call external APIs directly" rule**,
+I want a build-failing guardrail — a Roslyn analyzer plus a reflection-backed architecture test — that **fails the build** if any class under `Tamma.Activities` references `HttpClient`/`PostAsync`/`PostAsJsonAsync`/`SendAsync` to a non-`TammaApiClient` host, or injects a credential-holding vendor service (Octokit, a Slack/Stripe client, `IIntegrationService` vendor members, a raw `IProviderCredentialResolver`),
+So that **the rule-1 invariant cannot silently regress** after Epics 32 and 38 have done the one-time cutover work — a re-introduced direct external call (or a co-hosted vendor-service injection) can never compile, so no future story, refactor, or merge can put a live external credential back into the engine process.
+
+## Priority
+
+P0 (permanence) — This is the **permanent backstop** for the entire "steps never call external APIs" rule across Epics 32 and 38. The cutover stories (32-5 for LLM, 38-1 git, 38-2 agent-dispatch, 38-3 Slack) each remove the *current* violations once; **38-4 stops them from ever coming back.** Without it, the invariant is enforced only by reviewer vigilance and grep — both of which fail silently the moment someone adds a convenient `httpClient.PostAsJsonAsync(vendorUrl)` "just for this one activity." The design mandates it explicitly (§5.2): *"Add a guardrail analyzer/test: fail the build if any class under `Tamma.Activities` references `HttpClient`/`PostAsync`/`PostAsJsonAsync` to a non-`TammaApiClient` host, or injects a credential-holding vendor service — so violations can't reappear."* It is cheap to add and pays compounding returns forever.
+
+## Context
+
+### What the rule is (and why grep is not enough)
+
+Rule 1 (design §0/§1): **a workflow STEP MUST NEVER call an external API/provider directly.** A step that needs an external effect delegates over HTTP to a `Tamma.Api` endpoint through **`TammaApiClient`**; the credential-holding code, the authorization decision, the external HTTP call, and the metering/audit emission all live in `Tamma.Api`. The engine (`Tamma.ElsaServer` / `Tamma.Activities`) holds **no** external credential and hits **no** external endpoint.
+
+The cutover stories enforce this once: 32-5 routes the nine in-engine direct-LLM callers through `/api/v1/llm/call`; 38-1/38-2/38-3 route the git/agent-dispatch/Slack `VIOLATION-by-co-hosting` activities through their endpoints. After they land, the audit table (design §1.2) should show **zero** in-engine credential holders. But nothing prevents a future PR from re-adding one — the violation compiles fine, passes tests in the co-hosted single-process deploy (where the injected vendor service happens to resolve), and only fails catastrophically the moment the engine runs as per-tenant dedicated compute (Cranl), where the token would have to be pushed into the engine process. **Grep in CI is brittle** (string-only, no semantic model, easily evaded by an alias or a helper indirection). The correct enforcement is a **compile-time** check with the Roslyn semantic model.
+
+### What this story builds
+
+Two complementary mechanisms (belt-and-suspenders — see AC-level rationale):
+
+1. **A Roslyn `DiagnosticAnalyzer`** (`Tamma.Activities.Guardrails`, a `netstandard2.0` analyzer project) referenced by `Tamma.Activities` (and the other engine projects) as an `Analyzer`. It walks the semantic model of every type whose containing project is the engine surface and **reports a build error** (diagnostic id **`TAMMA001`**) when it finds:
+   - a member access / invocation of `HttpClient.PostAsync` / `PostAsJsonAsync` / `GetAsync`-family / `SendAsync` whose target host is **not** `TammaApiClient` and not the engine-callback host (`Engine:CallbackUrl`-rooted internal endpoints, as `TriggerCIActivity` uses); or
+   - a constructor parameter / injected field whose type is a **credential-holding vendor service** on the denylist (`Octokit.*`, a Slack/Stripe SDK client, the Slack/GitHub vendor members of `IIntegrationService`, `IProviderCredentialResolver`, `IGitHubActionsClient`, …).
+   `TreatWarningsAsErrors` is `false` repo-wide, so the diagnostic is declared at **`DiagnosticSeverity.Error`** to fail the build regardless.
+
+2. **A reflection-backed architecture test** (`ActivitiesGuardrailTests`, in the existing test suite) that loads the `Tamma.Activities` assembly and asserts the same allowlist at test time — a defense-in-depth net that catches anything the analyzer's syntactic patterns miss (e.g. an `HttpClient` obtained via an unusual factory path, or a vendor type referenced only through a transitively-injected field). It also asserts the analyzer itself is wired (a known-bad fixture type triggers `TAMMA001`).
+
+### The allowlist (the only sanctioned outbound seams)
+
+A type under the engine surface may reach "outside the process" **only** through:
+
+- **`TammaApiClient`** — the engine→API delegation seam (Bearer `Tamma:ApiToken` + `X-Tenant-Id`). All mediated effects (LLM via 32-5, git via 38-1, agent-dispatch via 38-2, Slack via 38-3) go through it.
+- **The engine-callback host** — internal endpoints rooted at `Engine:CallbackUrl` (the pattern `TriggerCIActivity` already uses: `PostAsJsonAsync($"{callbackUrl}/api/engine/...")`). These terminate inside Tamma's own API plane, not at an external vendor.
+- **`IHttpClientFactory` is permitted ONLY when the resulting client is used by `TammaApiClient` or to call an `Engine:CallbackUrl` host.** A raw `_httpClientFactory.CreateClient()` followed by a `PostAsJsonAsync` to a vendor URL is a violation. (The analyzer resolves the call target host where statically determinable; the reflection test backstops the dynamic cases.)
+
+Everything else — `api.anthropic.com`, `api.openai.com`, `api.github.com`/Octokit, `slack.com`, `api.stripe.com`, or any injected vendor-credential service — is **denied**.
+
+### Explicitly out of scope
+
+- **Fixing the current violations** — that is the cutover work of 32-5 / 38-1 / 38-2 / 38-3. This story assumes those have landed (or codes the allowlist so that, until they land, the *known-and-tracked* in-flight violations are the only failures). The analyzer is the **backstop**, not the migrator.
+- **Enforcing the rule on `Tamma.Api`** — the API is *supposed* to hold credentials and call vendors; the analyzer targets the **engine surface only** (`Tamma.Activities` + `Tamma.ElsaServer`), never `Tamma.Api`.
+- **`ICLIAgentProvider` local CLI agents, in-engine local tools (`FileReadTool`/`ShellExecuteTool`/`GitOperationsTool`), and inbound webhook receivers** — these are legitimately exempt (design §5.3): a local process / local filesystem / inbound signal is **not** an external API call. The allowlist must NOT flag them.
+
+## Acceptance Criteria
+
+1. **A Roslyn analyzer project exists and is referenced by the engine surface.** A new `apps/tamma-elsa/src/Tamma.Activities.Guardrails/` analyzer project (`netstandard2.0`, references `Microsoft.CodeAnalysis.CSharp.Workspaces` at the repo-pinned Roslyn version) is added to `Tamma.sln` and referenced by `Tamma.Activities` (and `Tamma.ElsaServer`) via an `<Analyzer>` / `OutputItemType="Analyzer"` `ProjectReference`. It runs during `dotnet build Tamma.sln`.
+
+2. **`TAMMA001` fails the build on a direct external HTTP call from the engine surface.** When a type whose containing assembly is `Tamma.Activities` or `Tamma.ElsaServer` invokes `HttpClient.PostAsync`/`PostAsJsonAsync`/`PutAsJsonAsync`/`SendAsync`/`GetAsync`(-family) where the statically-resolvable target host is **not** `TammaApiClient` and **not** an `Engine:CallbackUrl`-rooted internal endpoint, the analyzer reports **`TAMMA001`** at **`DiagnosticSeverity.Error`**, failing the build (independent of `TreatWarningsAsErrors`, which is `false` repo-wide).
+
+3. **`TAMMA001` fails the build on a credential-holding vendor-service injection.** When a type under the engine surface has a **constructor parameter or DI-injected field** whose type is on the vendor denylist — `Octokit.*` clients, a Slack SDK client, a Stripe SDK client, `IGitHubActionsClient`, the Slack/GitHub vendor members of `IIntegrationService`, and a raw `IProviderCredentialResolver` (the engine must not resolve credentials post-32-5) — the analyzer reports `TAMMA001` (Error) with a message naming the offending type and pointing to the mediation pattern.
+
+4. **The allowlist is precise — no false positives on the sanctioned seams.** `TammaApiClient` itself (which legitimately owns the engine→API `HttpClient`), `TriggerCIActivity`'s `Engine:CallbackUrl` POST, and any thin-client activity that calls only `TammaApiClient.*` (the cutover outputs of 32-5/38-1/38-2/38-3) MUST NOT be flagged. The analyzer's allowlist explicitly exempts: the `TammaApiClient` type, calls to `Engine:CallbackUrl`-rooted hosts, and `IHttpClientFactory` usage that feeds those two.
+
+5. **The exempt categories (design §5.3) are NOT flagged.** Local CLI agent providers (`ICLIAgentProvider` implementations), in-engine local tools (`FileReadTool`/`ShellExecuteTool`/`GitOperationsTool` — local process/filesystem, not external HTTP), and inbound webhook receivers (`WebhookSignalRegistry` — inbound, no outbound call) MUST NOT trigger `TAMMA001`. The analyzer targets **outbound external HTTP + vendor-credential injection**, nothing else.
+
+6. **A clear diagnostic id, category, and message.** Id **`TAMMA001`**, title "Engine step makes a direct external call or injects a vendor credential", category **`Tamma.Architecture`**, default severity **Error**, with a message of the form: ``"`{TypeName}` performs a direct external call / injects credential-holding `{VendorType}`. Engine steps must delegate to `Tamma.Api` via `TammaApiClient` (rule 1; design §1). See the `/api/v1/llm/call` (32-5) / `/api/v1/git/*` (38-1) / `/api/v1/notifications/slack` (38-3) mediation pattern."`` plus a `helpLinkUri` to the design doc. The id is documented (a `## TAMMA001` reference) so a developer who hits it knows the fix.
+
+7. **A reflection-backed architecture test backstops the analyzer (defense in depth).** A new `ActivitiesGuardrailTests` (in the existing C# test suite) loads the `Tamma.Activities` assembly via reflection and asserts: no public/internal type's constructors take a denylisted vendor-credential type; no type holds a non-`TammaApiClient` `HttpClient` field used for a vendor call (to the extent statically assertable); and a **positive control** — a deliberately-bad fixture type compiled into a test asset triggers `TAMMA001` (proving the analyzer is actually wired, not silently disabled). The test runs in `dotnet test Tamma.sln`.
+
+8. **Wired into the CI gate.** Because the analyzer is referenced by `Tamma.Activities`/`Tamma.ElsaServer`, the existing CI step `dotnet build Tamma.sln --no-restore -c Release` (`.github/workflows/ci.yml`, `working-directory: apps/tamma-elsa`) **already fails** on a `TAMMA001` Error — no new CI job is required, but the story documents that the build step is the gate and that the analyzer must not be suppressed (no blanket `<NoWarn>TAMMA001</NoWarn>` / `#pragma warning disable TAMMA001` is permitted; a per-line suppression requires a justification comment and is itself flagged by the reflection test if applied under the engine surface).
+
+9. **Mode-independent (no per-mode scoping).** This is a **build-time** static guardrail. It does not read tenant state, does not run at request time, and has **no single-user vs SaaS scoping** — it applies identically to every build of the engine surface regardless of deployment mode. The story's per-mode section states this explicitly (the rule it enforces is *why* the modes stay safe, but the analyzer itself is mode-independent).
+
+10. **No new control-plane table, no runtime entity.** This story adds **no** database table, no EF migration, no CP entity → **no** `Program.cs` DROP-list entry and **no** `ControlPlaneDbContextModelTests` change. It is pure build tooling (an analyzer project + a test + project-reference wiring).
+
+11. **Tests cover positive controls, negative controls, and exemptions.** The analyzer's own unit tests (using `Microsoft.CodeAnalysis.CSharp.Analyzer.Testing`) assert: a direct `PostAsJsonAsync(vendorUrl)` → `TAMMA001`; an Octokit/`IGitHubActionsClient`/`IProviderCredentialResolver`/Slack-client injection → `TAMMA001`; a `TammaApiClient.*` call → **no diagnostic**; a `TriggerCIActivity`-style `Engine:CallbackUrl` POST → **no diagnostic**; an `ICLIAgentProvider`/local-tool/inbound-webhook type → **no diagnostic**. The reflection test asserts the real `Tamma.Activities` assembly is clean (post-cutover) and the positive-control fixture fails.
+
+## Technical Design
+
+### Where it lives
+
+```
+apps/tamma-elsa/src/Tamma.Activities.Guardrails/        # NEW analyzer project (netstandard2.0)
+  Tamma.Activities.Guardrails.csproj                    # references Microsoft.CodeAnalysis.CSharp.Workspaces (repo-pinned)
+  EngineExternalCallAnalyzer.cs                         # the DiagnosticAnalyzer — reports TAMMA001
+  GuardrailDiagnostics.cs                               # DiagnosticDescriptor for TAMMA001 (id/title/category/severity/helpLink)
+  Allowlist.cs                                          # allowed seams (TammaApiClient, Engine:CallbackUrl) + vendor denylist
+
+apps/tamma-elsa/src/Tamma.Activities/
+  Tamma.Activities.csproj                               # MODIFY — <ProjectReference OutputItemType="Analyzer" ReferenceOutputAssembly="false" .../>
+apps/tamma-elsa/src/Tamma.ElsaServer/
+  Tamma.ElsaServer.csproj                               # MODIFY — same analyzer reference
+
+apps/tamma-elsa/Tamma.sln                               # MODIFY — add the analyzer project
+
+apps/tamma-elsa/tests/Tamma.Activities.Tests/Guardrails/
+  ActivitiesGuardrailTests.cs                           # NEW — reflection backstop + positive-control assertion
+apps/tamma-elsa/tests/Tamma.Activities.Guardrails.Tests/   # NEW — analyzer unit tests
+  EngineExternalCallAnalyzerTests.cs                    # NEW — Roslyn analyzer test cases (positive + negative + exempt)
+  Fixtures/                                             # NEW — known-bad + known-good source fixtures
+```
+
+### The diagnostic (`GuardrailDiagnostics.cs`)
+
+```csharp
+public static class GuardrailDiagnostics
+{
+    public const string Id = "TAMMA001";
+
+    public static readonly DiagnosticDescriptor EngineDirectExternalCall = new(
+        id: Id,
+        title: "Engine step makes a direct external call or injects a vendor credential",
+        messageFormat:
+            "'{0}' performs a direct external call / injects credential-holding '{1}'. " +
+            "Engine steps must delegate to Tamma.Api via TammaApiClient (rule 1; design §1). " +
+            "See the /api/v1/llm/call (32-5) / /api/v1/git/* (38-1) / /api/v1/notifications/slack (38-3) pattern.",
+        category: "Tamma.Architecture",
+        defaultSeverity: DiagnosticSeverity.Error,     // Error so it fails the build (TreatWarningsAsErrors is false repo-wide)
+        isEnabledByDefault: true,
+        description: "A workflow step must never call an external API/provider directly or hold an external credential.",
+        helpLinkUri: "https://github.com/meywd/tamma/blob/main/docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md");
+}
+```
+
+### The analyzer (`EngineExternalCallAnalyzer.cs`) — detection strategy
+
+```csharp
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class EngineExternalCallAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(GuardrailDiagnostics.EngineDirectExternalCall);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        // Only the ENGINE surface — skip Tamma.Api (it is SUPPOSED to call vendors).
+        context.RegisterCompilationStartAction(start =>
+        {
+            if (!Allowlist.IsEngineSurface(start.Compilation.AssemblyName)) return;   // Tamma.Activities / Tamma.ElsaServer only
+
+            // (a) outbound HTTP calls to a non-allowlisted host
+            start.RegisterOperationAction(ctx => InspectInvocation(ctx), OperationKind.Invocation);
+            // (b) credential-holding vendor-service injection (ctor params + injected fields)
+            start.RegisterSymbolAction(ctx => InspectConstructor(ctx), SymbolKind.Method);   // ctors
+            start.RegisterSymbolAction(ctx => InspectField(ctx), SymbolKind.Field);
+        });
+    }
+    // InspectInvocation: target is HttpClient.PostAsync/PostAsJsonAsync/SendAsync/GetAsync-family
+    //   AND the receiver is not a TammaApiClient-owned client AND the URL arg host is not Engine:CallbackUrl
+    //   -> report TAMMA001 (Error). Exempt ICLIAgentProvider / local tools / inbound webhook types.
+    // InspectConstructor/InspectField: parameter/field type ∈ Allowlist.VendorDenylist -> report TAMMA001.
+}
+```
+
+**Detection strategy — analyzer AND reflection test (both, deliberately):**
+
+| Layer | Catches | Why both |
+|---|---|---|
+| **Roslyn analyzer (primary)** | Statically-resolvable direct vendor HTTP calls + denylisted-type ctor/field injections, at **compile time** — the violation never builds. | Compile-time is the strongest gate; uses the semantic model (not strings), so an alias or `using` rename can't evade it. |
+| **Reflection architecture test (backstop)** | Denylisted vendor types reachable via reflection on the built `Tamma.Activities` assembly, plus the **positive control** that proves the analyzer is wired (not suppressed). | Catches dynamically-obtained `HttpClient` paths the syntactic analyzer can't statically resolve, and detects if someone disables/suppresses `TAMMA001`. |
+
+### The allowlist (`Allowlist.cs`)
+
+```csharp
+internal static class Allowlist
+{
+    // The ONLY sanctioned outbound seams from the engine surface.
+    public static bool IsEngineSurface(string? assemblyName) =>
+        assemblyName is "Tamma.Activities" or "Tamma.ElsaServer";
+
+    public const string ApiClientType = "Tamma.Activities.LlmCall.TammaApiClient";   // the engine→API seam
+    public const string CallbackHostConfigKey = "Engine:CallbackUrl";                 // internal-endpoint host
+
+    // Credential-holding vendor services the engine may NEVER inject (design §1.2):
+    public static readonly ImmutableHashSet<string> VendorDenylist = ImmutableHashSet.Create(
+        "Octokit.IGitHubClient", "Octokit.GitHubClient",
+        "Tamma.Core.Interfaces.IGitHubActionsClient",
+        "Tamma.Core.Interfaces.IIntegrationService",          // its Slack/GitHub vendor members hold tokens
+        "Tamma.Api.Services.Providers.IProviderCredentialResolver",  // engine must not resolve creds post-32-5
+        /* Slack SDK client, Stripe SDK client when added */ );
+
+    // Exempt (design §5.3) — NOT external API calls:
+    public static readonly ImmutableHashSet<string> ExemptBaseTypes = ImmutableHashSet.Create(
+        "Tamma.Providers.ICLIAgentProvider",                  // local process, single-user
+        /* local tools: FileReadTool/ShellExecuteTool/GitOperationsTool — local fs/process */
+        "Tamma.Activities.AgentDispatch.WebhookSignalRegistry" /* inbound */ );
+}
+```
+
+### Project-reference wiring (the gate)
+
+```xml
+<!-- Tamma.Activities.csproj / Tamma.ElsaServer.csproj -->
+<ItemGroup>
+  <ProjectReference Include="..\Tamma.Activities.Guardrails\Tamma.Activities.Guardrails.csproj"
+                    OutputItemType="Analyzer"
+                    ReferenceOutputAssembly="false" />
+</ItemGroup>
+```
+
+Because the analyzer is referenced this way, the existing CI step `dotnet build Tamma.sln --no-restore -c Release` (`.github/workflows/ci.yml`) is the gate — a `TAMMA001` Error fails the build with no new job. The analyzer is declared at `DiagnosticSeverity.Error` precisely because `Directory.Build.props` sets `TreatWarningsAsErrors=false`, so a `Warning`-severity diagnostic would not fail the build.
+
+## Dependencies
+
+**Internal (sequencing — the violations this protects):**
+
+- **32-5** (`/api/v1/llm/call`) — removes the nine in-engine direct-LLM callers. 38-4's allowlist assumes those are gone; **land 38-4 after 32-5** so the engine surface is already clean (else the analyzer fails on the pre-cutover violations — which is *correct* but blocks the build for the wrong story).
+- **38-1** (git platform mediation) / **38-2** (agent-dispatch mediation) / **38-3** (Slack/notifications mediation) — the sibling Class-A/C/D cutovers. 38-4 is the **last** story in Epic 38: it locks the door after 38-1/38-2/38-3 have moved everything through `TammaApiClient`. Its allowlist references `TammaApiClient` and the new `QueueSlackNotificationAsync`/git/agent-dispatch client methods those stories add.
+- **Epic 35** (billing) — 38-4's vendor denylist is **forward-compatible**: when Epic 35 adds a Stripe client, a `BillingActivity` injecting it (instead of emitting a `/api/v1/billing/*` intent or a `billing_outbox` row per 38-3's enforce-by-design subsection) **fails the build** under `TAMMA001`. Add the Stripe SDK type to the denylist when the SDK is referenced.
+
+**Reference (the sanctioned seams the allowlist encodes):**
+
+- `TammaApiClient` (`Tamma.Activities/LlmCall/TammaApiClient.cs`) — the allowed engine→API seam.
+- `TriggerCIActivity` (`Tamma.Activities/Testing/TriggerCIActivity.cs`) — the allowed `Engine:CallbackUrl` internal-endpoint pattern.
+- `QueueWelcomeEmailActivity` (`Tamma.Activities/TenantLifecycle/QueueWelcomeEmailActivity.cs`) — the outbox pattern (no external call from the engine; the out-of-band sender in the API holds the credential).
+
+**External:** `Microsoft.CodeAnalysis.CSharp.Workspaces` + `Microsoft.CodeAnalysis.CSharp.Analyzer.Testing` (test) at the repo-pinned Roslyn version. No runtime external dependency.
+
+**Consumers:** none — this is build tooling. Every future Epic-32/38 story is implicitly "protected" by it.
+
+## Testing Strategy
+
+1. **Positive control — direct vendor HTTP call.** A fixture type under a `Tamma.Activities`-named compilation that does `httpClient.PostAsJsonAsync("https://api.github.com/...")` → analyzer reports exactly one `TAMMA001` at `Error`.
+2. **Positive control — vendor-service injection.** A fixture ctor taking `Octokit.IGitHubClient` / `IGitHubActionsClient` / `IProviderCredentialResolver` / a Slack client → `TAMMA001`.
+3. **Negative control — `TammaApiClient` call.** A thin-client activity calling only `TammaApiClient.QueueSlackNotificationAsync(...)` / `CallLlmAsync(...)` → **no** diagnostic.
+4. **Negative control — engine callback.** A `TriggerCIActivity`-shaped `PostAsJsonAsync($"{callbackUrl}/api/engine/...")` where `callbackUrl` is `Engine:CallbackUrl` → **no** diagnostic.
+5. **Exemptions (design §5.3).** An `ICLIAgentProvider` impl, a local tool (`FileReadTool`/`ShellExecuteTool`/`GitOperationsTool`), and `WebhookSignalRegistry` → **no** diagnostic.
+6. **Non-engine surface.** The same direct call inside a `Tamma.Api`-named compilation → **no** diagnostic (the API is allowed to call vendors).
+7. **Severity / build-failure.** Assert the descriptor's `DefaultSeverity == Error` and that a compilation with a violation reports a build-failing error even with `TreatWarningsAsErrors=false`.
+8. **Reflection backstop (AC7).** `ActivitiesGuardrailTests` loads the real built `Tamma.Activities` assembly: no ctor/field of any type is a denylisted vendor type (asserts the post-cutover assembly is clean); and a positive-control fixture assembly triggers `TAMMA001` (proves the analyzer is wired, not suppressed).
+9. **Suppression-resistance (AC8).** A test asserts no `#pragma warning disable TAMMA001` / `<NoWarn>` for `TAMMA001` exists under the engine surface (grep + reflection assertion), so the gate can't be quietly turned off.
+10. **Help/id stability.** Assert the diagnostic id is `TAMMA001`, category `Tamma.Architecture`, and the message names the offending type and the mediation pattern (so a developer who hits it can self-serve the fix).
+
+Analyzer unit tests use `Microsoft.CodeAnalysis.CSharp.Analyzer.Testing`. Docker-bound suites run via `sg docker -c "dotnet test apps/tamma-elsa/..."` (session docker group is stale; plain `dotnet build` needs no wrapper — and `dotnet build` is itself the primary check here).
+
+## Estimated Effort
+
+3-4 days (one analyzer with two detection passes + the allowlist/denylist + analyzer unit tests with fixtures + the reflection backstop + the project-reference wiring across two engine projects + the diagnostic documentation). The Roslyn analyzer-testing harness setup is the main cost; the rules themselves are small.
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Activities.Guardrails/Tamma.Activities.Guardrails.csproj` | Create (netstandard2.0 analyzer project) |
+| `apps/tamma-elsa/src/Tamma.Activities.Guardrails/GuardrailDiagnostics.cs` | Create (`TAMMA001` descriptor) |
+| `apps/tamma-elsa/src/Tamma.Activities.Guardrails/EngineExternalCallAnalyzer.cs` | Create (the analyzer) |
+| `apps/tamma-elsa/src/Tamma.Activities.Guardrails/Allowlist.cs` | Create (allowed seams + vendor denylist + exemptions) |
+| `apps/tamma-elsa/src/Tamma.Activities/Tamma.Activities.csproj` | Modify (analyzer `ProjectReference`) |
+| `apps/tamma-elsa/src/Tamma.ElsaServer/Tamma.ElsaServer.csproj` | Modify (analyzer `ProjectReference`) |
+| `apps/tamma-elsa/Tamma.sln` | Modify (add analyzer project + its test project) |
+| `apps/tamma-elsa/tests/Tamma.Activities.Guardrails.Tests/EngineExternalCallAnalyzerTests.cs` | Create (analyzer unit tests) |
+| `apps/tamma-elsa/tests/Tamma.Activities.Guardrails.Tests/Fixtures/` | Create (known-bad + known-good source fixtures) |
+| `apps/tamma-elsa/tests/Tamma.Activities.Tests/Guardrails/ActivitiesGuardrailTests.cs` | Create (reflection backstop + positive control) |
+
+## Dev Notes
+
+### Development Process Reminder
+
+Before implementing this story, ensure you have:
+
+1. Read [BEFORE_YOU_CODE.md](../../BEFORE_YOU_CODE.md)
+2. Searched `.dev/` for related spikes, bugs, findings, and decisions.
+3. Read the design of record §1 (steps never call providers), §1.2 (the audit table the denylist is derived from), §5.2 (the explicit guardrail mandate), and §5.3 (the exempt categories the allowlist must NOT flag) IN FULL.
+4. Confirmed 32-5 / 38-1 / 38-2 / 38-3 have landed so the engine surface is already clean (the analyzer should pass on `main`; if it fails, it is catching a real un-migrated violation — fix the violation, not the analyzer).
+5. Reviewed `TammaApiClient`, `TriggerCIActivity`, and `QueueWelcomeEmailActivity` (the three sanctioned-seam exemplars the allowlist encodes) plus the WebSearch'd latest Roslyn `DiagnosticAnalyzer` + `Microsoft.CodeAnalysis.CSharp.Analyzer.Testing` API (never assume the analyzer-testing API shape — verify against the repo-pinned Roslyn version).
+6. Planned the TDD approach — write the analyzer test fixtures (positive, negative, exempt) first; the analyzer is correct when all three classes of fixture assert as specified.
+
+### Key Design Decisions
+
+- **Analyzer (compile-time) AND reflection test (defense-in-depth).** The analyzer is the strong gate — the violation never compiles. The reflection test backstops dynamic `HttpClient` paths the syntactic analyzer can't statically resolve, and — crucially — proves the analyzer is **wired and not suppressed** via a positive-control fixture. Either alone is weaker.
+- **`DiagnosticSeverity.Error`, not `Warning`.** `Directory.Build.props` sets `TreatWarningsAsErrors=false` repo-wide, so a `Warning` would not fail the build. The descriptor is declared at `Error` so the existing `dotnet build Tamma.sln` CI step is the gate with no new job.
+- **Engine surface only.** The analyzer's `CompilationStartAction` early-returns unless the assembly is `Tamma.Activities` / `Tamma.ElsaServer`. `Tamma.Api` is *supposed* to hold credentials and call vendors — flagging it would be wrong.
+- **Allowlist by sanctioned seam, denylist by vendor type.** Outbound HTTP is allowed only to `TammaApiClient`-owned clients and `Engine:CallbackUrl` hosts; injection is denied for the specific credential-holding vendor types in the §1.2 audit table. This pair maps directly onto the design's "right vs wrong" reference set.
+- **The exempt categories are first-class.** `ICLIAgentProvider`, local tools, and inbound webhooks (design §5.3) are explicitly exempted so the guardrail does not punish the legitimately-local single-user path or inbound signals — a false positive there would push contributors to disable the analyzer, defeating its purpose.
+- **Forward-compatible denylist.** The vendor denylist is data, not logic — Epic 35 adds the Stripe SDK type and a future `BillingActivity` that injects it fails the build, with no analyzer rewrite. This is the §1.2 "Enforce by design" row made real.
+- **No runtime footprint (AC10).** Pure build tooling: no DB table, no migration, no CP entity → no `Program.cs` DROP-list entry and no `ControlPlaneDbContextModelTests` change.
+
+### Per-mode ownership (mandatory two-scoping-model answer, per CLAUDE.md)
+
+This guardrail is **mode-independent.** It is a build-time static analyzer plus a test; it does not read tenant or user state, does not run at request time, and has no principal. The single-user vs SaaS distinction does not apply to it.
+
+| Question | single-user mode | SaaS mode |
+|---|---|---|
+| Who is the principal of the guardrail? | None — it is a compile-time/test-time check with no request principal. | None — same. |
+| Does scoping (`TenantId`/`UserId`) apply? | No. The analyzer inspects source/IL, not tenant data. | No — identical. |
+| What does it protect, per mode? | It enforces rule 1 so the engine holds no external credential — which is *why* the single-user local-harness path and the SaaS API-only path both stay safe. The enforcement is the same build for both. | Same build, same rule. The invariant it guards is mode-sensitive (SaaS dedicated compute is where a leaked engine token is most dangerous), but the **check** is not. |
+| Mode source | N/A (build time — `ITammaModeProvider` is not consulted). | N/A. |
+
+The exempt category `ICLIAgentProvider` is *single-user-relevant* (those providers are single-user-only per design §5.3), but the analyzer exempts the **type**, not the runtime mode — it never consults `ITammaModeProvider`.
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Analyzer declared `Warning` → does not fail the build (`TreatWarningsAsErrors=false`) | Critical | Declare `DefaultSeverity = Error`; a test asserts the descriptor severity; CI `dotnet build` proves a violation fails. |
+| False positive on a sanctioned seam → contributors disable the analyzer | High | Precise allowlist (`TammaApiClient` + `Engine:CallbackUrl` + `IHttpClientFactory` feeding them) and explicit §5.3 exemptions; negative-control + exemption tests; help message points to the fix. |
+| Someone suppresses `TAMMA001` (`#pragma`/`<NoWarn>`) to bypass the gate (AC8) | High | The reflection test asserts no `TAMMA001` suppression exists under the engine surface; the positive-control fixture proves the analyzer is active. |
+| Dynamic `HttpClient` path evades the syntactic analyzer | Medium | The reflection architecture test backstops the cases the semantic model can't statically resolve; the denylist also blocks the *injection* of the vendor client, which is the usual entry point. |
+| Roslyn analyzer-testing API drift across versions | Medium | WebSearch the latest `Microsoft.CodeAnalysis.CSharp.Analyzer.Testing` API before coding; pin to the repo's Roslyn version; fixtures-first TDD surfaces API breaks early. |
+| Analyzer lands before the cutover → fails the build on pre-existing violations | Medium | Sequence 38-4 **last** in Epic 38 (after 32-5/38-1/38-2/38-3); on `main` the engine surface must already be clean, so the analyzer passes from day one. |
+| Epic 35 adds Stripe and a billing step injects it | Low (by design) | The denylist is forward-compatible — add the Stripe SDK type when referenced; the violation then fails the build automatically (the §1.2 "enforce by design" guarantee). |
+
+### Success Metrics
+
+- [ ] `dotnet build Tamma.sln -c Release` **fails** when a fixture re-introduces a direct vendor call or a vendor-credential injection under the engine surface, and **passes** on the clean `main`.
+- [ ] The analyzer flags **zero** false positives on `TammaApiClient`, `TriggerCIActivity`, the §5.3 exempt categories, and the thin-client outputs of 32-5/38-1/38-2/38-3.
+- [ ] The reflection backstop asserts the real `Tamma.Activities` assembly is clean **and** the positive-control fixture trips `TAMMA001` (analyzer proven wired).
+- [ ] No `TAMMA001` suppression exists anywhere under the engine surface.
+- [ ] A future `BillingActivity` injecting a Stripe client would fail the build (verified by a denylist-extension test fixture).
+
+## Related
+
+- Design of record: `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§0/§1 rule 1; §1.2 audit table → the vendor denylist; §5.2 the explicit guardrail-analyzer mandate; §5.3 the exempt categories)
+- Re-plan: `docs/superpowers/plans/2026-06-20-epic-32-37-replan.md`
+- Implementation plan: `docs/superpowers/plans/2026-06-21-38-4-build-time-guardrail-analyzer-plan.md`
+- Sibling stories (the violations this protects): `story-38-1/` (git platform mediation), `story-38-2/` (agent-dispatch mediation), `story-38-3/` (Slack/notifications mediation); `docs/stories/epic-32/story-32-5/` (the LLM mediation that removes the nine direct-LLM callers)
+- Forward tie-in: **Epic 35** (billing) — the denylist extension that makes the Class-E "enforce by design" guarantee (design §1.2) real.
+- Sanctioned-seam exemplars the allowlist encodes: `apps/tamma-elsa/src/Tamma.Activities/LlmCall/TammaApiClient.cs` (the allowed engine→API seam), `apps/tamma-elsa/src/Tamma.Activities/Testing/TriggerCIActivity.cs` (allowed `Engine:CallbackUrl` host), `apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/QueueWelcomeEmailActivity.cs` (the outbox pattern — no engine-side external call)
+- Build wiring: `apps/tamma-elsa/Directory.Build.props` (`TreatWarningsAsErrors=false` → why `Error` severity), `.github/workflows/ci.yml` (`dotnet build Tamma.sln -c Release` — the gate)
+
+## Logging Requirements
+
+> This is a build-time analyzer, not a runtime service — it has no application logging. The "logging" here is the **build diagnostic output** the developer sees.
+
+- **Build diagnostic (the only "log")**: `TAMMA001` Error at the offending source location, with the message naming the offending type and the mediation pattern to use (so the fix is self-serve). Emitted by the C# compiler / `dotnet build`, surfaced in CI build output.
+- **Analyzer-test output**: standard xUnit assertions; the positive-control test names the fixture that should trip `TAMMA001`.
+- **No structured runtime logging**: the analyzer reads source/IL only; it logs nothing at runtime.
+- **Credential safety (LOAD-BEARING)**: the analyzer **must never read, embed, or emit any credential** — it operates purely on source/symbol shape. Diagnostic messages name **types** (`Octokit.IGitHubClient`, `IProviderCredentialResolver`), never values, URLs-with-tokens, or secrets. There is no path by which the guardrail itself could leak a key (it exists precisely to prevent keys from reaching the engine).
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-21 | 1.0.0   | Initial story creation — build-time guardrail analyzer (rule-1 enforcement). A Roslyn `DiagnosticAnalyzer` (`TAMMA001`, `Tamma.Architecture`, `DiagnosticSeverity.Error`) plus a reflection-backed `ActivitiesGuardrailTests` that **fail the build** if any class under the engine surface (`Tamma.Activities`/`Tamma.ElsaServer`) references `HttpClient`/`PostAsync`/`PostAsJsonAsync`/`SendAsync` to a non-`TammaApiClient`/non-`Engine:CallbackUrl` host, or injects a credential-holding vendor service (Octokit / `IGitHubActionsClient` / Slack/Stripe client / vendor `IIntegrationService` members / raw `IProviderCredentialResolver`). Allowlist (`TammaApiClient` + engine-callback hosts), denylist (the §1.2 audit-table vendor types), and explicit §5.3 exemptions (`ICLIAgentProvider`, local tools, inbound webhooks). Wired via an `OutputItemType="Analyzer"` `ProjectReference` so the existing `dotnet build Tamma.sln -c Release` CI step is the gate (no new job); `Error` severity chosen because `TreatWarningsAsErrors=false` repo-wide. Mode-independent (build-time, no per-mode scoping); no CP table/migration. The permanent backstop for the whole "steps never call external APIs" rule across Epics 32 + 38, forward-compatible with the Epic 35 Class-E (Stripe) enforce-by-design tie-in. Sequenced last in Epic 38, after 32-5/38-1/38-2/38-3. | Claude |

--- a/docs/superpowers/plans/2026-06-21-32-12-persona-aware-benchmarking-plan.md
+++ b/docs/superpowers/plans/2026-06-21-32-12-persona-aware-benchmarking-plan.md
@@ -1,0 +1,278 @@
+# Story 32-12 — Persona-Aware Benchmarking
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation.
+
+**Date:** 2026-06-21
+
+**Goal:** Make the benchmark `persona` dimension correct under the **locked agent model** and add the
+persona-comparison facets a tenant reads to pick a persona per role. Concretely: key the `persona`
+dimension on the **named cross-role persona-agent identity** (`AgentId`/`AgentName` = `claude`/`gemini`/
+`codegpt` from **32-15**) instead of a style row; add **provider / model / prompt-version /
+`credentialSource`** facets so a persona's runs are comparable like-vs-like **within a role**; and
+expose the persona-comparison query on **32-10's** existing leaderboard endpoint. This is a *refinement*
+of 32-10's persona dimension — **no new entity, no new fold, no new service**.
+
+**Story file:** `docs/stories/epic-32/story-32-12/32-12-agent-personas-and-persona-aware-benchmarking.md`
+**Design of record:** `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§3.0 reframe table, §3.1 persona = system-agent entity, §3.4 disposition of 32-12)
+**Re-plan:** `docs/superpowers/plans/2026-06-20-epic-32-37-replan.md` (story disposition + sequence)
+
+**Tech stack:** .NET 9 / Elsa 3 in `apps/tamma-elsa` (`Tamma.Api` services + endpoints, `Tamma.Data`
+tenant entities + EF migrations). Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/` (xUnit).
+Docker-bound suites run via `sg docker -c "dotnet test ..."` (session docker group is stale; plain
+`dotnet build` needs no wrapper). **There is no TypeScript path — all C#.**
+
+---
+
+## The reframe (why this is a rewrite, not a new feature)
+
+The shipped/drafted v1.0.0 of 32-12 modelled **persona = a style/tone overlay** (`atlas`/`nova`) within
+one role, with a new `Persona` table + `PersonaComposer` + style-aware benchmarking. The locked model
+(design §3.0) redefines the word:
+
+| Term | v1.0.0 (superseded) | Locked model (this plan) |
+|---|---|---|
+| **Persona** | style/tone overlay within a role | the **named cross-role system agent** (`claude`/`gemini`/`codegpt`) from 32-15 |
+| **New entity** | `Persona` table + `PersonaComposer` + `StyleJson` | **none** — persona IS the public `Agent`; benchmark rides 32-10 |
+| **Benchmark key** | `(role, personaId)` where persona = style | `(role, personaAgentId)` + provider/model/promptVersion/credentialSource facets |
+| **Style/voice** | conflated into "persona" | **split out → 32-19** "Agent style/voice variants" (a *variant*, not a persona) |
+
+So this plan **deletes** the persona-entity/composer/CRUD work and **adds** a persona-aware view over
+32-10's existing read model. The style/voice overlay is a separate optional story (**32-19**) — not here.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO new entity.** No `Persona` table, no `PersonaComposer`, no `StyleJson`, no persona CRUD endpoints,
+  no resolver persona-composition path. The persona IS the 32-15 public `Agent`. (All of that v1.0.0
+  scope is dropped.)
+- **NO new control-plane table.** The persona is the 32-15 public `Agent` (already CP-registered); the
+  benchmark rows are 32-10's **tenant-schema** entities (owned by `EfTenantDbMigrator`). Nothing is
+  appended to the `Program.cs` startup-reset DROP list; `ControlPlaneDbContextModelTests` is untouched.
+- **NO new fold / projection engine.** The metrics come from 32-10's `BenchmarkProjectionService`
+  reducer; this story keys + facets only. No second projection.
+- **NO new source event.** It folds the same 32-6/32-8/32-9 events 32-10 folds; persona lifecycle reuses
+  32-10's `BENCHMARK.PROJECTION.*` family.
+- **NO style/voice variant.** `atlas`/`nova` tone/verbosity is **32-19**. Not built or assumed here.
+- **NO cross-tenant persona-benchmark admin route.** The only cross-tenant view is 32-10's k-anonymous
+  public-agent fleet rollup — owned there, not extended.
+- **NO baseline rewrite / migration branch.** If facets are persisted, it is a single additive **Tenant**
+  migration on the existing linear snapshot.
+
+---
+
+## Current-state findings (verify in-repo before coding)
+
+| Seam | Where it is today (32-10 / 32-15) | How 32-12 uses/refines it |
+|---|---|---|
+| **Projection engine** | `Tamma.Api/Services/Agents/BenchmarkProjectionService.cs` — idempotent, `SequenceNumber`-cursor fold; `dimensionKeyFor` maps agent/provider/prompt/**persona** from `Tags`. | Refine the `persona` branch: key = `agentId` (the persona-agent identity); add facet sub-keys (provider/model/agentVersion/promptRef/credentialSource). |
+| **Projection entities** | `Tamma.Data/Entities/BenchmarkProjection.cs` + `BenchmarkProjectionCursor.cs` — tenant-schema, `UNIQUE (TenantId, Dimension, DimensionKey, Window)`; `persona` dimension `DimensionKey=personaId`. | Reuse. Persist facet columns **only** if query-time aggregation is too costly (else compute on read). |
+| **Leaderboard API** | `Tamma.Api/Endpoints/AgentLeaderboardEndpoints.cs` — `GET /api/v1/orgs/{tenantId}/agents/leaderboard?dimension=…&window=…&minRuns=…`; tie-break chain + `belowThreshold` guard; `RequireTenantMembershipFilter`. | Add persona facets: `?dimension=persona&role=&personaId=&credentialSource=&promptVersion=`. Member-read; tenant-scoped. |
+| **Persona identity** | 32-15 — public `Agent` `claude`/`gemini`/`codegpt`, `Role=NULL`, explicit `provider`+`model`; `agentId` is the persona identity. | The persona dimension key + the provider/model facets come from these. |
+| **Trail tags** | 32-6 — `agentId`/`agentVersion`/`provider`/`promptRef` flat tags on `AGENT.TASK.*` / `AGENT.ITERATION.COMPLETED` / `AGENT.PANEL.AGGREGATED`. | The persona key + facets read these flat tags. |
+| **credentialSource** | 32-5/32-9 — surfaced on the run + tagged on `AGENT.USAGE.RECORDED`. | The `credentialSource` facet; degrades to explicit `unknown` until those land. |
+| **Isolation** | 32-10 — `ITenantDbContextFactory`, null-tenant-guarded `IEventRepository`, per-tenant `SequenceNumber` composite cursor; k-anonymous public-agent admin rollup. | Reused wholesale; persona rows inherit the isolation. |
+| **Mode** | `Tamma.Api/Services/PromptStore/TammaMode.cs` — `ITammaModeProvider` (SingleUser | SaaS). | Per-mode principal derivation (single-user keyed by `UserId`, SaaS by `TenantId`). |
+
+**Key insight:** the read model already exists (32-10) and already has a `persona` dimension. The only
+genuinely new code is (1) keying that dimension on the persona-agent identity, (2) a pure facet
+extractor (provider/model/promptVersion/credentialSource with an explicit `unknown` bucket), and (3) the
+persona-comparison query params on the existing 32-10 endpoint. No entity, no fold, no service.
+
+---
+
+## Architecture
+
+```
+BenchmarkProjectionService (32-10, tenant-scoped, idempotent, SequenceNumber cursor)
+   dimensionKeyFor("persona", tags) -> tags["agentId"]        // persona = the 32-15 public Agent identity
+   PersonaBenchmarkFacets.Extract(tags) -> { provider, model, agentVersion, promptRef, credentialSource }
+        absent facet tag -> explicit "unknown" bucket          // NEVER silently merged (no-empty-fallback)
+        malformed dimension -> throw BENCHMARK.DIMENSION.INVALID
+
+Read (member-scoped to the caller's tenant by RequireTenantMembershipFilter):
+   GET /orgs/{tenantId}/agents/leaderboard?dimension=persona&role=reviewer&window=30d
+        -> rank claude/gemini/codegpt AS reviewer (like-vs-like within a role)   [32-10 tie-break + minRuns]
+   GET …?dimension=persona&personaId={agentId}&role=reviewer
+        -> one persona's facet breakdown (provider/model/promptVersion/credentialSource)
+   GET …?dimension=persona&role=reviewer&credentialSource=byok | &promptVersion=v4
+        -> facet-filtered comparison
+
+Per-tenant scoping (design ownership rule): every persona benchmark row lives in the resolving tenant's
+t_<hex> schema; two tenants running public persona `claude` build separate private profiles; the platform
+owner sees neither (only 32-10's k-anonymous public-agent rollup). Cursor is the per-schema BIGSERIAL,
+composite-keyed incl. TenantId — no shared global cursor.
+```
+
+Per-mode ownership (CLAUDE.md two-scoping-model): the persona *definition* is platform-global
+(`PlatformOwnerAccess` to curate, NOT `OwnerAccess`); the persona *benchmark data* is the tenant's
+(SaaS) / the sole user's (single-user) — member-read, never cross-tenant. Mode from `ITammaModeProvider`.
+
+---
+
+## Task breakdown
+
+Order: T1 (persona dimension key) → T2 (facet extractor + unknown-bucket) → T3 (persona-comparison query)
+→ T4 (optional persisted facet columns) → T5 (isolation + equivalence + lifecycle + no-regression).
+T1 must land first (everything keys on the persona-agent identity). T2 feeds T3/T4. T4 is OPTIONAL —
+take it only if query-time facet aggregation (T3) proves too costly.
+
+### T1 — Persona dimension key = the persona-agent identity (AC1)
+
+**Scope:** Refine `BenchmarkProjectionService.dimensionKeyFor`'s `persona` branch to key on
+`tags["agentId"]` (the 32-15 public-persona `Agent` identity), with `AgentName` as the label — NOT a
+style row. If 32-10 already keys `persona` by `agentId`, confirm and leave; if it keys a style value,
+correct it.
+
+**Files:** modify `Tamma.Api/Services/Agents/BenchmarkProjectionService.cs`; modify
+`tests/Tamma.Api.Tests/Agents/BenchmarkProjectionServiceTests.cs`.
+
+**Tests (first):**
+- a fold over a fixture stream whose `agentId` is the public `claude` persona produces a persona row keyed by that `agentId`/`AgentName` — assert the key is the persona-agent identity, **never** a tone/verbosity value.
+- a malformed `dimension` throws `BENCHMARK.DIMENSION.INVALID` (no silent fallback).
+
+**Acceptance:**
+- [ ] `persona` dimension key = `agentId` (persona-agent identity); `AgentName` is the label.
+- [ ] No `Persona`/`StyleJson`/`PersonaComposer` type introduced (grep proves it).
+
+### T2 — Facet extractor + explicit `unknown` bucket (AC2/AC6)
+
+**Scope:** New pure `PersonaBenchmarkFacets.Extract(tags)` returning
+`{ provider, model, agentVersion, promptRef, credentialSource }` from the **same flat trail tags**.
+Absent facet tag → explicit `"unknown"` bucket; **never** silently merged into a populated facet.
+
+**Files:** new `Tamma.Api/Services/Agents/PersonaBenchmarkFacets.cs`; new
+`tests/Tamma.Api.Tests/Agents/PersonaBenchmarkFacetsTests.cs`.
+
+**Tests (first):**
+- runs of persona `claude` split by `credentialSource` (`byok` vs `platform`) → distinct facet buckets, same `personaId`.
+- prompt v3 vs v4 (`promptRef`) split distinctly; provider/model split distinctly.
+- a run with no `credentialSource` tag (pre-32-5) → explicit `unknown` bucket, NOT merged into `byok`/`platform`.
+- no raw config/prompt/key appears in any facet value.
+
+**Acceptance:**
+- [ ] Facets extracted from flat tags; absent → explicit `unknown` (no silent merge).
+- [ ] Facet values are flat strings only — never a raw config/prompt/key.
+
+### T3 — Persona-comparison query (like-vs-like within a role) (AC4/AC5)
+
+**Scope:** Extend the 32-10 leaderboard endpoint for the persona dimension:
+`?dimension=persona&role=&window=` ranks personas as that role (like-vs-like, scoped to one role);
+`?personaId=` returns one persona's facet breakdown; `&credentialSource=`/`&promptVersion=` narrow the
+comparison. Reuse 32-10's tie-break chain + `minRuns` guard. Member-read; tenant-scoped by
+`RequireTenantMembershipFilter`.
+
+**Files:** modify `Tamma.Api/Endpoints/AgentLeaderboardEndpoints.cs`; modify
+`Tamma.Api/Services/Agents/BenchmarkProjectionService.cs` (`GetLeaderboardAsync` persona role+facet
+read; new method on `IBenchmarkProjectionService` ONLY if a new signature is needed); modify
+`Tamma.Api/Dtos/Agents/BenchmarkDtos.cs` (`PersonaLeaderboardRow` + facet-breakdown DTO); new
+`tests/Tamma.Api.Tests/Agents/PersonaLeaderboardTests.cs`.
+
+**Tests (first):**
+- persona `claude` used as `reviewer` and as `architect` → two separate per-role rows.
+- `?dimension=persona&role=reviewer` ranks `claude`/`gemini`/`codegpt` only as reviewer; an architect-role persona never appears in the reviewer leaderboard.
+- `?personaId={claude}&role=reviewer` → facet breakdown across provider/model/promptVersion/credentialSource.
+- a persona with `runCount < minRuns` → `belowThreshold`, never `ranked` (32-10 guard reused).
+- tie-break chain (`successRate` desc → `avgIterationsToDone` asc → `avgCostBasisUsd` asc → key asc) holds.
+
+**Acceptance:**
+- [ ] Persona comparison is like-vs-like within a single role; cross-role is structurally impossible.
+- [ ] Member-read, tenant-scoped; facet filters work; min-sample guard + tie-break reused from 32-10.
+
+### T4 — (OPTIONAL) persisted facet columns (AC9, Tenant migration only)
+
+**Scope:** ONLY if query-time facet aggregation (T3) is too costly: add additive facet columns
+(`Provider`, `Model`, `AgentVersion`, `PromptRef`, `CredentialSource`) to 32-10's **tenant-schema**
+`BenchmarkProjection`. Single additive **Tenant** migration on the existing linear snapshot.
+
+**Files (only if taken):** modify `Tamma.Data/Entities/BenchmarkProjection.cs`; modify
+`Tamma.Data/TammaModelConfiguration.cs`; new
+`Tamma.Data/Migrations/Tenant/<ts>_AddPersonaBenchmarkFacets.cs` (+ Designer + snapshot).
+
+**Tests (first):**
+- migration applies; `dotnet ef migrations has-pending-model-changes` (Tenant context) → none.
+- the facet columns round-trip; the tenant `EfTenantDbMigrator` owns them.
+
+**Acceptance:**
+- [ ] (If taken) additive **Tenant** migration; NOT a CP table; `Program.cs` DROP list + `ControlPlaneDbContextModelTests` untouched.
+- [ ] Default path is **no schema change** (compute facets at query time) — take T4 only on a measured need.
+
+### T5 — Isolation, equivalence, lifecycle, no-regression (AC3/AC7/AC8/AC10)
+
+**Scope:** Reuse 32-10's tenant isolation for the persona dimension; assert incremental-vs-rebuild
+equivalence on persona rows; assert `BENCHMARK.PROJECTION.*` lifecycle (no new source event); assert no
+regression on agent/provider/prompt dimensions and no CP churn.
+
+**Files:** modify `tests/Tamma.Api.Tests/Agents/BenchmarkIsolationTests.cs` (persona-dimension case);
+modify `tests/Tamma.Api.Tests/Agents/BenchmarkProjectionServiceTests.cs` (equivalence + lifecycle +
+no-regression).
+
+**Tests (first):**
+- seed persona rows for tenant A and B; `GET …/orgs/{B}/…?dimension=persona` returns only B's; a member of A hitting B's path → 403/404; platform owner has no per-tenant persona route; a public persona run by A leaves persona rows only in A's schema.
+- fold persona events, fold again (cursor skip → no double-count), `RebuildAsync` → byte-identical persona rows + facets; the per-tenant composite cursor never crosses tenants.
+- a persona fold emits `BENCHMARK.PROJECTION.UPDATED` (`dimension:"persona"`); rebuild emits `BENCHMARK.PROJECTION.REBUILT`; an empty fold emits nothing; grep confirms no new persona-specific source event.
+- agent/provider/prompt dimensions + leaderboard shape unchanged; persona metric numbers equal the 32-10 reducer's for the same runs; `has-pending-model-changes` → none; suite green.
+
+**Acceptance:**
+- [ ] Per-tenant isolation holds for the persona dimension; platform admin denied per-tenant.
+- [ ] Incremental and full-rebuild persona rows are byte-identical; per-tenant cursor never crosses tenants.
+- [ ] No new source event; lifecycle reuses 32-10's family; no CP churn; full `Tamma.Api.Tests` green.
+
+---
+
+## Story order & dependencies
+
+External prereqs (must land first): **32-10** (the benchmark projection + leaderboard + `persona`
+dimension + `SequenceNumber` cursor + isolation this story extends) and **32-15** (the persona-agent
+identity this story keys on). Consumed by tag contract / soft-degrade: **32-6** (trail tags), **32-8**
+(outcome/defect), **32-9** + **32-5** (`credentialSource` + cost — facet degrades to `unknown` until
+they land), **32-16** (enablement constrains which personas a tenant runs). Internal: T1 → T2 → T3 →
+(T4 optional) → T5. Downstream consumers (32-13 dashboards, 32-14 A/B) depend on this; not blockers.
+Sibling **32-19** (style/voice variants — the split-out style overlay) is **NOT** a dependency.
+
+## Verification
+
+```bash
+# build (no docker wrapper needed)
+dotnet build apps/tamma-elsa/Tamma.sln
+# persona dimension key + facets + comparison
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~PersonaBenchmark"
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~PersonaLeaderboard"
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~BenchmarkIsolation"
+# no new persona entity / style overlay introduced by this story
+! grep -rn "class Persona\b\|PersonaComposer\|StyleJson" apps/tamma-elsa/src/Tamma.Api apps/tamma-elsa/src/Tamma.Data
+# persona dimension keys on agentId (the persona-agent identity), not a style row
+grep -rn "\"persona\"" apps/tamma-elsa/src/Tamma.Api/Services/Agents/BenchmarkProjectionService.cs
+# no CP table added -> Program.cs DROP list unchanged; if facets persisted, Tenant migration only
+sg docker -c "dotnet ef migrations has-pending-model-changes --context TenantDbContext --project apps/tamma-elsa/src/Tamma.Data"
+```
+
+## Risks
+
+- **Old style model leaks through (T1):** the persona dimension must key on the 32-15 persona-agent
+  `AgentId`, not a tone/verbosity row. Mitigation: AC1 + an explicit test asserting the key is the
+  persona-agent identity; grep proves no `Persona`/`StyleJson`/`PersonaComposer` type is introduced.
+- **Facet silently merges absent values (T2):** dropping the no-empty-fallback rule on facets would
+  mis-attribute runs. Mitigation: absent facet → explicit `unknown` bucket; malformed dimension →
+  throw; facet-bucketing test asserts no silent merge (`feedback_resolution_no_empty_fallback`).
+- **Reimplementing the 32-10 fold/metrics (T1/T3):** a second fold would drift. Mitigation: this story
+  keys + facets only; metrics come from the same 32-10 reducer; assert identical numbers for the same
+  runs; no second projection.
+- **Cross-tenant leakage of per-persona data (T5):** Mitigation: reuse 32-10's structural isolation
+  (`ITenantDbContextFactory`, null-tenant-guarded reads, no cross-tenant route, per-tenant composite
+  cursor); explicit isolation test incl. platform-admin-denied; the only cross-tenant view is 32-10's
+  k-anonymous public-agent rollup (owned there).
+- **`credentialSource` facet depends on un-landed 32-5/32-9 (T2):** Mitigation: degrade to explicit
+  `unknown`, backfill on rebuild once the tag exists; align the tag name with 32-9 before merge; never
+  invent a parallel usage event.
+- **Accidental CP table / DROP-list churn (T4):** Mitigation: AC9 — the persona is the 32-15 public
+  `Agent` (CP-registered); benchmark rows are tenant-schema 32-10 entities (owned by
+  `EfTenantDbMigrator`); facets (if persisted) are a **Tenant** migration; `ControlPlaneDbContextModelTests`
+  untouched. Prefer the no-schema-change path (query-time facets).
+- **Cross-role persona comparison sneaks in (T3):** Mitigation: persona key is `(role, agentId)`; the
+  comparison query always names a role; test asserts an architect-role persona never appears in the
+  reviewer leaderboard.
+</content>

--- a/docs/superpowers/plans/2026-06-21-32-15-persona-reframe-and-seeding-plan.md
+++ b/docs/superpowers/plans/2026-06-21-32-15-persona-reframe-and-seeding-plan.md
@@ -1,0 +1,274 @@
+# Story 32-15 — Persona Reframe + Seeding (Role-nullable cross-role personas)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation.
+
+**Date:** 2026-06-21
+
+**Goal:** Amend the **shipped** 32-1 `Agent`/`AgentVersion` entity model so public agents become
+named, cross-role **PERSONAS** (`claude`/`gemini`/`codegpt`) instead of per-role `tamma-<role>` rows.
+Concretely: make `Agent.Role` nullable (NULL for public personas), swap the public unique index
+`(Name, Role)` → `(Name)`, rewrite `AgentEntitySeeder` to seed named cross-role personas each with an
+**explicit** `provider`+`model` (no longer leaning on `DefaultAgentConfig.ForRole` → `claude-sonnet-4`),
+rewrite `GetSystemDefaultPublicAsync(role)` to return the platform-configured **default persona**
+(`DefaultPersonaName`, role-independent) and delete the per-role ambiguity warning, and wire
+`AgentResolverService.MaterialiseAsync` so the persona's system/role prompt comes from the **Epic 27
+prompt store** keyed `(principal, role, action)` — personas are prompt-free.
+
+**Story file:** `docs/stories/epic-32/story-32-15/32-15-persona-reframe-and-seeding.md`
+**Design of record:** `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§3.0–§3.1)
+**Re-plan:** `docs/superpowers/plans/2026-06-20-epic-32-37-replan.md` (§1, §4 sequence step B)
+
+**Tech stack:** .NET 9 / Elsa 3 in `apps/tamma-elsa` (`Tamma.Data` entities + EF migrations, `Tamma.Api`
+services, `Tamma.ElsaServer` seeding host). Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/`
+(xUnit). Docker-bound suites run via `sg docker -c "dotnet test ..."` (session docker group is stale;
+plain `dotnet build` needs no wrapper). **There is no TypeScript path — all C#.**
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO new table.** This is a schema *amendment* of the existing 32-1 `agents`/`agent_versions`
+  tables (nullable `Role` + index swap). Nothing is added to the `Program.cs` startup-reset DROP list.
+- **NO per-tenant enablement.** `TenantAgentEnablement` + `IsEnabledForPrincipal` is **32-16**. This
+  story seeds personas; it does not gate which tenant sees which.
+- **NO custom-agent (private) prompt branch.** `ConfigJson.prompts` + the private path in
+  `MaterialiseAsync` is **32-17**. This story implements ONLY the public/persona prompt branch and
+  leaves a marked seam for the private one.
+- **NO registry enablement gate.** `CanUse`/`SelectForRoleAsync`/`ResolveUsableAgentAsync` enablement
+  is **32-18** (amends 32-2). This story rewrites only `GetSystemDefaultPublicAsync` + the prompt source.
+- **NO new provider, NO pricing logic.** The personas' `(provider, model)` must already be
+  `IProviderPricingService.IsKnown` (owned by **34-11**). This story only *consumes* `IsKnown`.
+- **NO new REST routes.** `DefaultPersonaName` is config; persona CRUD already exists from 32-1.
+- **NO baseline rewrite / migration branch.** Sequential implementation on the single linear snapshot.
+
+---
+
+## Current-state findings (verify in-repo before coding)
+
+| Seam | Where it is today (32-1/32-2) | How 32-15 amends it |
+|---|---|---|
+| **`Agent` entity** | `Tamma.Data/Entities/Agent.cs` — `Role` is `string` (required identity). | `Role` → `string?` (NULL for public personas). |
+| **EF model config** | `Tamma.Data/TammaModelConfiguration.cs` — `Role.IsRequired().HasMaxLength(64)`; `IX_agents_public_name_role` on `(Name, Role) WHERE Visibility=0`. | Drop `.IsRequired()`; replace public index with `IX_agents_public_name` on `(Name) WHERE Visibility=0`. Private indexes unchanged. |
+| **Seeder** | `Tamma.ElsaServer/AgentEntitySeeder.cs` — 8 `tamma-<role>` rows on one provider chain; `ConfigJson` omits `model`; insert-missing-only keyed by `(Name, Role)`. | Rewrite to N named cross-role personas (`claude`/`gemini`/`codegpt`), `Role=NULL`, explicit `provider`+`model`, no prompts; idempotency keyed by `Name`; legacy disposition (AC11). |
+| **Default lookup** | `Tamma.Api/Services/Agents/AgentRegistryService.cs` — `GetSystemDefaultPublicAsync` matches `Agent.Role==role`, warns on >1. | Return `DefaultPersonaName` persona, role-independent; delete the ambiguity warning; fail loud if absent. |
+| **Materialise** | `Tamma.Api/Services/Agents/AgentResolverService.cs` — `MaterialiseAsync` merges `ConfigJson` onto `DefaultAgentConfig.ForRole(role)`, stamps `AgentId`/`AgentVersion`; prompt from config/default. | Keep merge + stamp; **prompt source for personas = the new `IPersonaPromptResolver` seam** (reads Epic 27 `(principal, role, action)`), fail loud; private branch = `ICustomAgentPromptResolver` seam for 32-17. |
+| **Cost basis** | `Tamma.Api/Services/Providers/IProviderPricingService` — `IsKnown(provider, model)` / `Compute(...)`. (34-11 promotes the frozen table to a DB entity behind the same seam.) | Seeder validates each persona's `(provider, model)` is `IsKnown` before write. |
+| **Prompt store** | Epic 27 `IPromptStore` — `(principal, role, action)` resolution, tenant → system → error. | New prompt source for personas in `MaterialiseAsync`. |
+| **Mode** | `Tamma.Api/Services/PromptStore/TammaMode.cs` — `ITammaModeProvider` (SingleUser | SaaS). | Principal derivation `(tenantId XOR userId)` for the Epic 27 key. |
+| **Model contract test** | `tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs` — strict `BeEquivalentTo`. | Update to reflect nullable `Role` + renamed index. |
+
+**Key insight:** the entity model is sound — the only genuinely new code is the *nullable-Role migration*,
+the *index swap*, the *seeder rewrite* (named personas + explicit model + legacy disposition), the
+*default-persona resolution rewrite*, and the *prompt-source wiring* in `MaterialiseAsync`. No new table,
+no new routes, no new provider.
+
+---
+
+## Architecture
+
+```
+AgentEntitySeeder (CP, insert-missing-only)
+   seeds:  claude  -> { provider: anthropic, model: claude-sonnet-4-20250514 }   Role=NULL, Public
+           gemini  -> { provider: google,    model: gemini-2.5-pro }             Role=NULL, Public
+           codegpt -> { provider: openai,     model: gpt-4o }                     Role=NULL, Public
+   guard:  IProviderPricingService.IsKnown(provider, model)  (else WARN + skip)   [34-11]
+   event:  AGENT.CREATED.SUCCESS per new persona; skip => no event
+
+Resolution path (consumed by 32-5 lynchpin):
+   GetSystemDefaultPublicAsync(role)
+        -> persona = GetPublicByName(DefaultPersonaName)   role-INDEPENDENT
+        -> null => FAIL LOUD (AGENT_DEFAULT_PERSONA_MISSING)
+   MaterialiseAsync(agent, role, action, principal)
+        -> merge ConfigJson onto DefaultAgentConfig.ForRole(role)   (kept)
+        -> stamp AgentId / AgentVersion                              (kept)
+        -> if Public (persona): SystemPrompt = IPersonaPromptResolver.ResolveAsync(principal, role, action)
+                                 (the seam THIS story ships; reads Epic 27, fail-loud PROMPT_UNRESOLVED)
+           else (private):       SEAM for 32-17 (ICustomAgentPromptResolver — custom agent's own prompts)
+```
+
+Per-mode ownership (CLAUDE.md two-scoping-model): personas are platform-global `Visibility='public'`
+(`PlatformOwnerAccess` to edit, NOT `OwnerAccess`) in both modes; the Epic 27 prompt key principal is
+the sole user (`userId`) in single-user and the tenant (`tenantId`) in SaaS — never a per-user layer in
+SaaS. Mode from `ITammaModeProvider`.
+
+---
+
+## Task breakdown
+
+Order: T1 (entity + migration) → T2 (seeder rewrite) → T3 (default-persona resolution) →
+T4 (MaterialiseAsync prompt source) → T5 (model-contract test + legacy disposition + wiring).
+T1 must land first (everything reads the nullable column). T2/T3/T4 are independent given T1.
+
+### T1 — Nullable `Role` + public-index swap (entity + migration)
+
+**Scope:** Make `Agent.Role` nullable; replace the public unique index `(Name, Role)` → `(Name)`.
+Single additive migration on the existing 32-1 snapshot.
+
+**Files:** modify `Tamma.Data/Entities/Agent.cs` (`Role` → `string?`); modify
+`Tamma.Data/TammaModelConfiguration.cs` (drop `Role.IsRequired()`; `IX_agents_public_name_role` →
+`IX_agents_public_name`); new `Migrations/ControlPlane/<ts>_PersonaReframeRoleNullable.cs`
+(+ `.Designer.cs`, snapshot).
+
+**Migration DDL (generated, verify):**
+```sql
+ALTER TABLE agents ALTER COLUMN "Role" DROP NOT NULL;
+DROP INDEX  "IX_agents_public_name_role";
+CREATE UNIQUE INDEX "IX_agents_public_name" ON agents ("Name") WHERE "Visibility" = 0;
+```
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/` (Postgres fixture) —
+- insert a `Visibility='public'`, `Role=NULL` persona; read back; `Role` is null; `ck_agents_visibility_ownership` still passes.
+- two public agents may NOT share a `Name` (with different/no `Role`) → second hits `IX_agents_public_name`.
+- a public `claude` (Role=NULL) and a private `claude` coexist (private indexes unchanged).
+
+**Acceptance:**
+- [ ] `Agent.Role` is `string?`; EF config drops `.IsRequired()`, keeps `HasMaxLength(64)`.
+- [ ] `IX_agents_public_name` exists on `(Name) WHERE Visibility=0`; `IX_agents_public_name_role` is gone.
+- [ ] `dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext` → none.
+- [ ] No new table → DROP list unchanged.
+
+### T2 — Seeder rewrite: named cross-role personas with explicit model (AC3/AC4/AC12)
+
+**Scope:** Rewrite `AgentEntitySeeder` to seed `claude`/`gemini`/`codegpt` (+ optional OpenRouter),
+each `Visibility='public'`, `Role=NULL`, explicit `provider`+`model`, **no prompts**, insert-missing-only
+keyed by `Name`, deterministic UUIDv7. Validate `(provider, model)` via `IProviderPricingService.IsKnown`
+before write. Emit `AGENT.CREATED.SUCCESS` per new persona only.
+
+**Files:** modify `Tamma.ElsaServer/AgentEntitySeeder.cs`; modify
+`tests/Tamma.Api.Tests/Agents/AgentEntitySeederTests.cs`.
+
+**Persona table (verify model strings price under 34-11):**
+```csharp
+("claude",  "anthropic", "claude-sonnet-4-20250514")
+("gemini",  "google",    "gemini-2.5-pro")
+("codegpt", "openai",    "gpt-4o")            // alias: gpt
+// optional: ("openrouter-claude", "openrouter", "anthropic/claude-3.5-sonnet")
+```
+
+**ConfigJson built via the 32-1 `AgentConfigValidator`** (provider regex, budget range, ReDoS,
+prototype-pollution) **with explicit `model` and NO `prompts`**. Validate before any write.
+
+**Tests (first):**
+- first run creates N personas (`Visibility='public'`, `Role=NULL`, `Version=1`, explicit `provider`+`model`, no `prompts`).
+- second run creates 0, skips N; no `AGENT.CREATED.SUCCESS` on the skip run.
+- after an admin publishes `claude` `Version=2`, re-run leaves `Version=2` intact, writes nothing (no-revert).
+- a persona whose `(provider, model)` is not `IsKnown` → WARN + skip-write (no half-seeded row).
+- each `AGENT.CREATED.SUCCESS` tags `{ agentId, version:1, visibility:"public", role:null, personaName, provider, model, mode }`.
+
+**Acceptance:**
+- [ ] Seeder creates named cross-role personas with explicit provider+model; zero `tamma-<role>` rows.
+- [ ] Idempotent (2nd run = 0 created); never reverts an admin edit; `IsKnown` guard enforced.
+
+### T3 — `GetSystemDefaultPublicAsync` rewrite + delete ambiguity warning (AC5/AC9)
+
+**Scope:** Replace the `Role==role` lookup with a `DefaultPersonaName` (config) lookup, role-independent;
+fail loud if absent; delete the per-role ">1 public agent" ambiguity warning.
+
+**Files:** modify `Tamma.Api/Services/Agents/AgentRegistryService.cs`; new
+`Tamma.Api/Services/Agents/DefaultPersonaOptions.cs` (bind `Tamma:Agents:DefaultPersonaName`, default
+`"claude"`); modify `Tamma.Api/Program.cs` (bind the options); add a `GetPublicByNameAsync` to the
+agent repository if not present; modify/create `tests/Tamma.Api.Tests/Agents/AgentRegistryServiceTests.cs`.
+
+**Tests (first):**
+- with `DefaultPersonaName="claude"`, `GetSystemDefaultPublicAsync` returns `claude` for architect/tester/reviewer (any role).
+- with the configured persona absent → throws `AGENT_DEFAULT_PERSONA_MISSING` (no empty/plain fallback).
+- seeding multiple public personas does NOT log the per-role ambiguity warning (assert absence).
+
+**Acceptance:**
+- [ ] Default persona resolution is role-independent and config-driven; fails loud on absence.
+- [ ] The ambiguity warning is deleted.
+
+### T4 — `IPersonaPromptResolver` seam + `MaterialiseAsync` wiring (AC6/AC7)
+
+**Scope:** Ship the persona/public prompt leg as an explicit injectable seam, NOT an inline resolve.
+New interface `IPersonaPromptResolver.ResolveAsync(Principal principal, string role, string? action,
+CancellationToken ct)` + `PersonaPromptResolver` impl over the Epic 27 `IPromptStore` (fail-loud on
+null, `PROMPT_UNRESOLVED`). Keep the merge onto `DefaultAgentConfig.ForRole(role)` and the
+`AgentId`/`AgentVersion` stamp. Wire `MaterialiseAsync`'s `Visibility='public'` (persona) branch to call
+`_personaPrompts.ResolveAsync(...)`. Leave the `Visibility='private'` branch as a clearly-marked seam for
+32-17's `ICustomAgentPromptResolver` (do NOT implement it).
+
+**Files:** new `Tamma.Api/Services/Agents/IPersonaPromptResolver.cs` + `PersonaPromptResolver.cs`; modify
+`Tamma.Api/Services/Agents/AgentResolverService.cs` (inject + call the seam); modify/create
+`tests/Tamma.Api.Tests/Agents/AgentResolverServiceTests.cs` + `PersonaPromptResolverTests.cs`.
+
+**Tests (first):**
+- a public persona resolves its system prompt via the `IPersonaPromptResolver` seam (over a fake `IPromptStore` keyed `(principal, role, action)`); the persona's `ConfigJson` carries no prompt and is NOT used as the prompt source; `MaterialiseAsync` invokes the seam, not an inline `_promptStore.ResolveAsync`.
+- the seam returns null/miss from Epic 27 for `(role, action)` → `PROMPT_UNRESOLVED` thrown (never empty/plain).
+- merge + stamp preserved: `MaterialiseAsync` still stamps `AgentId`/`AgentVersion` and merges onto `DefaultAgentConfig.ForRole(role)`.
+- principal derivation: single-user → `(userId, role, action)`; SaaS → `(tenantId, role, action)` (via `ITammaModeProvider`).
+
+**Acceptance:**
+- [ ] `IPersonaPromptResolver` ships; `MaterialiseAsync`'s public branch calls it (no inline `_promptStore.ResolveAsync` in `MaterialiseAsync`).
+- [ ] Persona system prompt comes from Epic 27 via the seam, never from persona `ConfigJson`; fails loud on absence.
+- [ ] Private branch is a marked seam (32-17's `ICustomAgentPromptResolver`); merge + stamp unchanged.
+
+### T5 — Model-contract test, legacy disposition, final wiring (AC8/AC11/AC13/AC14)
+
+**Scope:** Update `ControlPlaneDbContextModelTests` for the nullable column + renamed index; implement
+the legacy `tamma-<role>` disposition (AC11) in the seeder (archive or leave, idempotent,
+`AGENT.ARCHIVED.SUCCESS` once on archive); finalize logging.
+
+**Files:** modify `tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs`; modify
+`Tamma.ElsaServer/AgentEntitySeeder.cs` (legacy disposition); confirm `Program.cs` wiring.
+
+**Tests (first):**
+- `Model_Has_ExpectedControlPlaneEntities` / index assertions reflect nullable `Role` + `IX_agents_public_name` (present) and `IX_agents_public_name_role` (absent).
+- with pre-seeded `tamma-<role>` rows present, the seeder is re-runnable and applies the chosen disposition deterministically; archive emits `AGENT.ARCHIVED.SUCCESS` once.
+- end-to-end: seed personas, set `DefaultPersonaName="gemini"`, `GetSystemDefaultPublicAsync("architect")` → `gemini`; `MaterialiseAsync` → `Provider="google"`, `Model="gemini-2.5-pro"`, prompt from Epic 27.
+
+**Acceptance:**
+- [ ] Model-contract test green with the amended schema.
+- [ ] Legacy `tamma-<role>` disposition is idempotent and non-destructive (immutable history preserved).
+- [ ] Full `Tamma.Api.Tests` suite green.
+
+---
+
+## Story order & dependencies
+
+External prereqs (must land first): **34-11** (Provider Cost Price-Book — personas' `(provider, model)`
+must be `IsKnown`/priceable), the shipped **32-1** (entity/seeder/validator/repository/DROP-list/model
+test), **32-2** (registry/resolver this story rewrites), **Epic 27** (prompt store — new persona prompt
+source). Internal: T1 → (T2 ∥ T3 ∥ T4) → T5. Downstream consumers (32-16 enablement, 32-17 custom-agent
+prompts, 32-18 registry gate, 32-5 call-LLM lynchpin) depend on this; they are NOT blockers.
+
+## Verification
+
+```bash
+# build (no docker wrapper needed)
+dotnet build apps/tamma-elsa/Tamma.sln
+# migration is clean / no pending model changes
+sg docker -c "dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext --project apps/tamma-elsa/src/Tamma.Data"
+# tests (docker-bound suites need the sg wrapper; session docker group is stale)
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~Agents"
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~ControlPlaneDbContextModel"
+# no prompt sourced from persona config (persona = prompt-free); public branch calls the seam, not an inline store
+grep -rn "ConfigJson\|_personaPrompts\|IPersonaPromptResolver" apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentResolverService.cs   # prompt must come from IPersonaPromptResolver, not config or an inline _promptStore
+# no tamma-<role> rows produced by the rewritten seeder
+grep -rn "tamma-" apps/tamma-elsa/src/Tamma.ElsaServer/AgentEntitySeeder.cs
+```
+
+## Risks
+
+- **Model-contract test drift (T1/T5):** the strict `BeEquivalentTo` list breaks on the nullable
+  column + renamed index. Mitigation: update the test in the same change; assert both the new index's
+  presence and the old index's absence.
+- **Persona model not priceable (T2):** a seeded `(provider, model)` not `IsKnown` under 34-11 can't
+  meter. Mitigation: `IsKnown` guard before write (WARN + skip); 34-11 is a hard prerequisite; the
+  end-to-end test asserts every seeded model prices.
+- **Empty-prompt regression (T4):** dropping the persona-config prompt source must not silently empty
+  the prompt. Mitigation: `MaterialiseAsync` + `GetSystemDefaultPublicAsync` both fail loud
+  (`feedback_resolution_no_empty_fallback`); explicit fail-loud tests; never a plain/empty fallback.
+- **Legacy `tamma-<role>` shadowing (T5):** the 8 rows 32-1 seeded on `main` could shadow the named
+  default resolution. Mitigation: AC11 deterministic disposition (archive or leave), idempotent on
+  re-run, never destructive-delete (immutable history); default resolves over named personas only.
+- **Sibling-branch collision (T4):** the private-prompt branch is 32-17's `ICustomAgentPromptResolver`;
+  implementing it here would collide. Mitigation: implement ONLY the public/persona branch via the
+  `IPersonaPromptResolver` seam; leave the parallel `ICustomAgentPromptResolver` seam for 32-17; scope
+  tests to the public branch.
+- **Snapshot drift (32-1 on `main`, 32-2 on `feat/exec-wave-02`):** Mitigation: sequential
+  implementation on a single linear snapshot; per the re-plan, merge `feat/exec-wave-02` before the
+  redesign stories; amend whichever snapshot is current — never branch it.

--- a/docs/superpowers/plans/2026-06-21-32-16-per-tenant-agent-enablement-plan.md
+++ b/docs/superpowers/plans/2026-06-21-32-16-per-tenant-agent-enablement-plan.md
@@ -1,0 +1,297 @@
+# Story 32-16 — Per-Tenant Agent/Persona Enablement (`TenantAgentEnablement`)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation.
+
+**Goal:** Add the **genuinely missing** per-tenant agent/persona enablement layer (locked model rule
+6, design §3.3). Introduce the `TenantAgentEnablement` entity (CP-resident; user-keyed in
+single-user; XOR/index discipline identical to `AgentRoleSelection`/`prompt_overrides`), the
+enable/disable/list API (`tenant_owner`/`tenant_admin`; member → 403), the `AGENT.ENABLED.SUCCESS` /
+`AGENT.DISABLED.SUCCESS` events, the seeded-default hook, and — the load-bearing deliverable — the
+read-only **`ITenantAgentEnablementReader`** seam exposing `IsEnabledForPrincipalAsync` /
+`ListEnabledPublicAgentIdsAsync` / `GetEnabledDefaultPersonaIdAsync` **query primitives** (all async,
+explicit `Principal` arg) that the sibling story **32-18** injects + consumes to gate
+selection/resolution and to resolve the enabled default. The write/admin
+`ITenantAgentEnablementService : ITenantAgentEnablementReader` adds `EnableAsync`/`DisableAsync`/`ListAsync`
+(one impl implements both). This story owns the ENTITY + API + events + read seam + primitives; it does
+**NOT** wire the gate into the registry/resolver (that is 32-18).
+
+**Story file:** `docs/stories/epic-32/story-32-16/32-16-per-tenant-agent-enablement.md`
+**Design of record:** `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§3.3, §3.0, §3.5)
+**Re-plan / sequence:** `docs/superpowers/plans/2026-06-20-epic-32-37-replan.md` (sequence step C)
+
+**Tech stack:** .NET 9 / Elsa 3 in `apps/tamma-elsa` (central API `Tamma.Api` + data `Tamma.Data`).
+Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/` (xUnit). Docker-bound suites run via
+`sg docker -c "dotnet test ..."` (session docker group is stale; plain `dotnet build` /
+`dotnet ef` need no wrapper). **`packages/api` is DELETED — all of this is C#.**
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO registry/resolver gate wiring.** `CanUse()` → `IsPublic && IsEnabledForPrincipal`, and the
+  enablement-aware `SelectForRoleAsync` / `ResolveUsableAgentAsync` / `ListVisibleAsync` /
+  `GetSystemDefaultPublicAsync` (incl. resolve-time fail-loud) are **story 32-18**. This story ships
+  the interface + primitive ONLY. Do not touch `AgentRegistryService`/`AgentResolverService`.
+- **NO per-user enablement layer.** Members use the tenant's enabled set; no per-user rows in SaaS
+  (CLAUDE.md "no per-user override layer"). Single-user keys by `UserId` because the sole user *is*
+  the tenant-equivalent.
+- **NO public-catalog management.** Creating/retiring the personas themselves stays `PlatformOwnerAccess`
+  (32-15/32-2). This story only toggles per-tenant membership of an already-existing persona.
+- **NO new migration baseline branch.** Extend the existing EF snapshot (stories are implemented
+  SEQUENTIALLY against one migration snapshot — an additive table, not a CHECK edit on the baseline).
+- **NO markup/billing/analytics.** Enablement is a gate, not a metering surface.
+
+---
+
+## Current-state findings (the seams this story plugs into)
+
+| Seam | Where it is today | How 32-16 uses it |
+|---|---|---|
+| **XOR/dual-keying precedent** | `Tamma.Data/Entities/AgentRoleSelection.cs` + its `TammaModelConfiguration` block (XOR check `ck_agent_role_selections_principal_xor`, `HasIndex(...).IsUnique().AreNullsDistinct(false)`). | Mirror EXACTLY for `tenant_agent_enablements` (`ck_tenant_agent_enablements_principal_xor`, unique-nulls-not-distinct on `(TenantId, UserId, AgentId)`). |
+| **CP DbContext** | `Tamma.Data/ControlPlaneDbContext.cs` (public `Agent`/`AgentVersion`, `prompt_overrides` single-user rows, etc.). | Add `DbSet<TenantAgentEnablement>` — CP-resident in BOTH modes. |
+| **CP model contract test** | `tests/.../Epic28/ControlPlaneDbContextModelTests.cs` — strict `Model_Has_ExpectedControlPlaneEntities` `BeEquivalentTo`. | **Append `TenantAgentEnablement`** or the test fails (known gotcha). |
+| **Startup-reset DROP list** | `Tamma.Api/Program.cs` — "Wiping Tamma-managed public-schema tables" block. | **Append `tenant_agent_enablements`** or 2nd host boot fails `relation already exists`. |
+| **Agent catalog + visibility** | 32-1 `Agent` (Visibility public/private), 32-2 `/api/agents` group + `AgentManage` policy (`agents:manage`=admin+owner) + `IsPlatformOwner()` + cross-tenant 404. | Validate target ∈ (public ∪ own-private); reuse the route group + policy + 404 convention. |
+| **Persona default** | 32-15 `DefaultPersonaName` (e.g. `claude`) + persona seeding. | Seed it enabled for a fresh tenant (insert-missing-only). Supplies `personaName` for event tags. |
+| **DCB events** | `Tamma.Data/Repositories/IEventRepository.cs` — `AppendAsync(DomainEvent)`, tenant-scoped; existing `AGENT.*` family. | Emit `AGENT.ENABLED/DISABLED.SUCCESS` tagged `{ agentId, personaName, mode, tenantId|userId }`. |
+| **Mode + principal** | `ITammaModeProvider` (`TammaMode.cs`), `ITenantContext`/`ClaimsPrincipal`. | Derive principal (SaaS ⇒ `TenantId`; single-user ⇒ `UserId`) for every read/write. |
+
+**Key insight:** the only genuinely new code is the **entity**, its **EF config + CP migration**, the
+**`TenantAgentEnablementService`** (upsert + implicit-private rule + the two primitives + events), the
+**three endpoints**, the **DTOs**, the **seeded-default hook**, and the two mandatory amendments
+(DROP list + CP model test). Everything else is wiring existing collaborators.
+
+---
+
+## Architecture
+
+```
+PUT/DELETE /api/agents/{agentId}/enablement   GET /api/agents/enablement   (AgentEndpoints, reuses 32-2 group)
+        |                                              |
+        v                                              v
+ITenantAgentEnablementService  (Tamma.Api/Services/Agents/)
+  Enable/Disable  -> validate target ∈ (public ∪ own-private)         [404 unseen / 409 disable-own-private]
+                  -> upsert CP row (principal = TenantId XOR UserId)
+                  -> emit AGENT.ENABLED|DISABLED.SUCCESS
+  List            -> catalog view (public-with-flag ∪ own-private implicit)
+  --- read seam ITenantAgentEnablementReader (consumed by 32-18, the gate) ---
+  IsEnabledForPrincipalAsync(agentId, principal)   own-private => true; public => enabled-row exists; else false
+  ListEnabledPublicAgentIdsAsync(principal)        set of enabled public ids for the principal
+  GetEnabledDefaultPersonaIdAsync(principal)       configured DefaultPersonaName if enabled, else single
+                                                   enabled persona if unambiguous, else null
+        |
+        v
+ControlPlaneDbContext.tenant_agent_enablements   (XOR check + unique-nulls-not-distinct; CP-resident both modes)
+```
+
+Per-mode (CLAUDE.md two-scoping rule): single-user = `UserId`-keyed CP rows, sole user writes;
+SaaS = `TenantId`-keyed CP rows, `tenant_owner`/`tenant_admin` write, members read-only. Mode from
+`ITammaModeProvider`. No per-user layer in SaaS.
+
+---
+
+## Task breakdown
+
+Order: T1 (entity + EF + migration + both mandatory amendments) → T2 (service: upsert + implicit rule
++ events) → T3 (the two primitives) → T4 (endpoints + DTOs + RBAC) → T5 (seeded default) → T6
+(isolation + mode matrix + constraint tests). T1 must land first (everything depends on the schema).
+
+### T1 — Entity, EF config, CP migration, DROP-list + CP-model-test amendments
+
+**Scope:** The schema and the two known-gotcha amendments. No behaviour yet.
+
+**Files (new/modify):**
+- new `Tamma.Data/Entities/TenantAgentEnablement.cs` (fields per story AC1).
+- modify `Tamma.Data/TammaModelConfiguration.cs` — `ToTable("tenant_agent_enablements")`, XOR check
+  `ck_tenant_agent_enablements_principal_xor`, `HasIndex(x => new { x.TenantId, x.UserId, x.AgentId })
+  .IsUnique().AreNullsDistinct(false)` (mirror `AgentRoleSelection`).
+- modify `Tamma.Data/ControlPlaneDbContext.cs` — `DbSet<TenantAgentEnablement>`.
+- **modify `Tamma.Api/Program.cs`** — append `tenant_agent_enablements` to the "Wiping Tamma-managed
+  public-schema tables" DROP list (AC8).
+- **modify `tests/.../Epic28/ControlPlaneDbContextModelTests.cs`** — add `TenantAgentEnablement` to the
+  strict `BeEquivalentTo` list (AC9).
+- new `Migrations/ControlPlane/*_AddTenantAgentEnablements.cs` (generated).
+
+**Generate the migration:**
+```bash
+dotnet ef migrations add AddTenantAgentEnablements \
+  --context ControlPlaneDbContext --output-dir Migrations/ControlPlane \
+  --project apps/tamma-elsa/src/Tamma.Data
+dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext   # → none
+```
+
+**Tests (first):**
+- `ControlPlaneDbContextModelTests` updated list passes (the entity is in the CP model).
+- A "second host boot succeeds" assertion (the DROP-list amendment) — reuse the existing test-host
+  bootstrap pattern; first boot creates, wipe runs, second boot does not throw `relation already exists`.
+- Constraint tests (can be in T6): XOR check rejects both/neither principal; unique index rejects a
+  duplicate `(TenantId, UserId, AgentId)`.
+
+**Acceptance:**
+- [ ] `TenantAgentEnablement` has all AC1 fields; EF config matches `AgentRoleSelection` discipline.
+- [ ] `has-pending-model-changes --context ControlPlaneDbContext` → none.
+- [ ] CP model test green; second test-host boot succeeds.
+
+### T2 — `TenantAgentEnablementService` core (upsert + implicit-private rule + events)
+
+**Scope:** `EnableAsync` / `DisableAsync` / `ListAsync`. Principal from `ITammaModeProvider` +
+`ITenantContext`/`ClaimsPrincipal`. Validate target ∈ (public CP catalog ∪ principal's own-private).
+Own-private/custom ⇒ implicitly enabled (disable ⇒ 409/no-op). Emit the DCB events.
+
+**Files (new):** `Services/Agents/ITenantAgentEnablementReader.cs` (read seam — the three async
+primitives 32-18 consumes), `Services/Agents/ITenantAgentEnablementService.cs`
+(`: ITenantAgentEnablementReader`; adds `EnableAsync`/`DisableAsync`/`ListAsync`),
+`Services/Agents/TenantAgentEnablementService.cs` (implements BOTH),
+`Services/Agents/AgentEnablementEventTypes.cs` (`AGENT.ENABLED.SUCCESS`, `AGENT.DISABLED.SUCCESS`).
+
+**Collaborators (constructor-injected — fakes in tests):** `ControlPlaneDbContext` (or a thin
+repository), an agent-catalog reader (to resolve visibility + `personaName`; reuse 32-2's registry
+read seam), `ITammaModeProvider`, `ITenantContext`/principal accessor, `IEventRepository`,
+`ILogger<TenantAgentEnablementService>`.
+
+**Tests (first):** `TenantAgentEnablementServiceTests`:
+- `EnableAsync(publicId)` ⇒ row `Enabled=true` + exactly one `AGENT.ENABLED.SUCCESS` tagged
+  `{ agentId, personaName, mode, tenantId|userId }`; idempotent re-enable (single row).
+- `DisableAsync(publicId)` ⇒ `Enabled=false`/removed + one `AGENT.DISABLED.SUCCESS`.
+- `DisableAsync(ownPrivateId)` ⇒ 409/no-op (still implicitly enabled).
+- `EnableAsync(unseenId)` ⇒ 404 (existence-leak-safe).
+
+**Acceptance:**
+- [ ] Enable/disable upsert correctly per principal; XOR holds (one column set).
+- [ ] Exactly one event per successful write, correctly tagged.
+- [ ] Own-private disable is rejected; unseen target is 404.
+
+### T3 — The read seam + query primitives (`ITenantAgentEnablementReader`)
+
+**Scope:** The deliverables 32-18 consumes, on the read-only `ITenantAgentEnablementReader` seam (one
+impl shared with the write service). All async, explicit `Principal` arg.
+- `IsEnabledForPrincipalAsync(agentId, principal)`: own-private/custom ⇒ `true` (no row); enabled-public
+  ⇒ `true`; no-row-public / disabled ⇒ `false`.
+- `ListEnabledPublicAgentIdsAsync(principal)` ⇒ set of enabled public ids for the principal.
+- `GetEnabledDefaultPersonaIdAsync(principal)` ⇒ the configured `DefaultPersonaName` (32-15) id if
+  enabled, else the single enabled persona id if unambiguous, else `null`. (32-18 CONSUMES this for
+  `GetSystemDefaultPublicAsync`; it never redefines it.)
+
+**Files:** new `ITenantAgentEnablementReader.cs`; extend `ITenantAgentEnablementService`
+(`: ITenantAgentEnablementReader`) / `TenantAgentEnablementService` (T2) to implement the seam.
+
+**Tests (first):** extend `TenantAgentEnablementServiceTests`:
+- truth table for `IsEnabledForPrincipalAsync` (own-private true / enabled-public true / no-row-public
+  false / disabled-public false / retired-public false).
+- `ListEnabledPublicAgentIdsAsync` returns exactly the enabled public set; excludes disabled, no-row,
+  and private ids.
+- `GetEnabledDefaultPersonaIdAsync`: configured-default-enabled → that id; default-not-enabled +
+  exactly-one-other-enabled → that id; nothing/ambiguous enabled → `null`.
+
+**Acceptance:**
+- [ ] Truth table passes; primitives are pure-read (no writes/events).
+- [ ] `ListEnabledPublicAgentIdsAsync` set is correct and principal-scoped.
+- [ ] `GetEnabledDefaultPersonaIdAsync` returns the documented id/null per the rules.
+
+### T4 — Endpoints + DTOs + RBAC (reuse 32-2 `/api/agents` group)
+
+**Scope:** `GET /api/agents/enablement` (any member), `PUT /api/agents/{agentId}/enablement`
+(`{enabled:true|false}`), `DELETE /api/agents/{agentId}/enablement` — both writes gated by
+`AgentManage` (`agents:manage` = admin+owner; member → 403).
+
+**Files:** modify `Tamma.Api/Endpoints/AgentEndpoints.cs` (handlers); new
+`Tamma.Api/Dtos/Agents/AgentEnablementResponse.cs`, `SetEnablementRequest.cs`; modify
+`Tamma.Api/Program.cs` (DI register `ITenantAgentEnablementService` Scoped; map the three routes onto
+the existing `agentsV2` group with `MemberAccess` for the read and `AgentManage` for the writes).
+
+**Tests (first):** `AgentEnablementEndpointsTests` (in-process `WebApplicationFactory`):
+- SaaS `member` → 403 on `PUT`/`DELETE`; member `GET` → 200.
+- `tenant_owner`/`tenant_admin` enable/disable → 200.
+- platform-catalog write through this group → absent/404 (this group does not expose catalog mutation).
+
+**Acceptance:**
+- [ ] RBAC matrix green; DI resolves the chain at host startup (smoke).
+- [ ] PUT/DELETE produce `AgentEnablementResponse`; 404 unseen / 409 disable-own-private surfaced.
+
+### T5 — Seeded default (fresh tenant usable out of the box)
+
+**Scope:** Seed the platform `DefaultPersonaName` (32-15, e.g. `claude`) enabled for a fresh tenant.
+Insert-missing-only (NEVER reverts an explicit disable). Hook into the existing agent/tenant seeding
+path (`AgentEntitySeeder` or a small `TenantEnablementSeeder`).
+
+**Files:** modify `Services/Agents/AgentEntitySeeder.cs` or new `TenantEnablementSeeder.cs`; wire into
+the tenant-bootstrap seeding sequence.
+
+**Tests (first):** `TenantEnablementSeederTests`:
+- fresh tenant ⇒ `DefaultPersonaName` enabled.
+- re-run seeder ⇒ an explicit disable of the default is NOT reverted (insert-missing-only).
+
+**Acceptance:**
+- [ ] Fresh tenant has the default persona enabled; usable without manual enablement.
+- [ ] Seeder is idempotent and never reverts an admin disable.
+
+### T6 — Isolation, mode matrix, constraint tests
+
+**Scope:** Prove per-tenant scoping, mode keying, and the DB constraints.
+
+**Files:** `TenantAgentEnablementIsolationTests`; extend service tests with a `[Theory]` over
+`TammaMode.SingleUser`/`SaaS`; constraint tests (can fold into T1).
+
+**Tests (first):**
+- isolation: A enabling persona X never appears in B's `ListAsync`/`IsEnabledForPrincipal`; A cannot
+  enable/disable B's private agent (404); A's disable does not affect B.
+- mode-parameterized: single-user keys `UserId` (TenantId NULL); SaaS keys `TenantId` (UserId NULL);
+  events tag the correct principal.
+- constraints: XOR check rejects both/neither; unique-nulls-not-distinct rejects a duplicate
+  `(TenantId, UserId, AgentId)`.
+
+**Acceptance:**
+- [ ] Cross-tenant isolation holds; mode matrix passes; constraint tests pass.
+
+---
+
+## Story order & dependencies
+
+External prereqs (must land first): **32-1** (Agent + visibility), **32-2** (`/api/agents` group,
+`AgentManage`, `IsPlatformOwner`, `AgentRoleSelection` XOR precedent, cross-tenant 404), **32-15**
+(persona reframe + `DefaultPersonaName`). Code to their interfaces; use fakes until landed.
+
+Internal: T1 → T2 → T3 → (T4 ∥ T5) → T6. Downstream consumer **32-18** depends on the primitives this
+story ships (it is the only story allowed to wire the gate into the registry/resolver); **32-5** runs
+the enablement-aware resolver inside `/api/v1/llm/call`. Neither is a blocker for THIS story.
+
+## Verification
+
+```bash
+# build (no docker wrapper needed)
+dotnet build apps/tamma-elsa/Tamma.sln
+
+# migration is clean (no docker wrapper needed)
+dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext \
+  --project apps/tamma-elsa/src/Tamma.Data   # → none
+
+# tests (docker-bound suites need the sg wrapper; session docker group is stale)
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~Enablement"
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~ControlPlaneDbContextModel"
+
+# boundary check: this story must NOT edit the registry/resolver gate (that is 32-18)
+git diff --name-only | grep -E 'AgentRegistryService|AgentResolverService' && echo "BOUNDARY VIOLATION (32-18 owns the gate)" || echo "boundary ok"
+```
+
+## Risks
+
+- **CP DROP list / model test (T1):** the two recurring gotchas. Amend both in the same change; the
+  "second host boot" + CP-model tests are the net. Skipping either fails CI deterministically.
+- **Overlap with 32-18 (boundary):** this story ships the interface + primitive ONLY. Any edit to
+  `AgentRegistryService`/`AgentResolverService` selection/resolution belongs to 32-18 — the
+  verification grep guards it. Cross-referenced both ways in the story.
+- **Default-deny locks out a fresh tenant:** mitigated by the seeded default (T5, insert-missing-only).
+  The resolve-time fail-loud (no empty fallback) is 32-18's concern, not this story's.
+- **Disable-own-private confusion:** own private/custom agents are implicitly enabled; disable via this
+  API is a no-op/409. Removal is by archive (32-2). Documented + tested (T2).
+- **XOR/keying drift from `AgentRoleSelection`:** mirror the `TammaModelConfiguration` block exactly
+  (check-name pattern, unique-nulls-not-distinct). Constraint tests prove it (T6).
+- **CP-resident placement (both modes):** unlike `AgentRoleSelection` (tenant-schema in SaaS), this
+  table is CP-resident in BOTH modes because it gates the CP catalog and is keyed by tenant id, not
+  per `t_<hex>`. Confirm with the Epic 28 team before coding; it drives the DROP-list/CP-model-test
+  choice (vs the per-tenant `EfTenantDbMigrator` path).
+- **Dependency timing:** 32-1/32-2/32-15 may land just before; code to their interfaces, fakes until
+  landed; this story is the entity+primitive owner, not the resolver owner.

--- a/docs/superpowers/plans/2026-06-21-32-17-custom-agent-prompts-plan.md
+++ b/docs/superpowers/plans/2026-06-21-32-17-custom-agent-prompts-plan.md
@@ -1,0 +1,268 @@
+# Story 32-17 — Custom-Agent Prompts (`ConfigJson.prompts` + resolver prompt-source branch)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation.
+
+**Date:** 2026-06-21
+
+**Goal:** Make the locked-model **rule 5 — custom prompts ⇔ custom agent** real. A tenant that wants
+different prompts authors a private (custom) `Agent` (32-1) carrying its OWN prompts inside the
+existing `AgentVersion.ConfigJson` jsonb (`prompts` block). Add (a) the optional `prompts` schema +
+typed `AgentPromptSet`, (b) the **public-must-be-empty** validation invariant (rule 4: personas are
+prompt-free), and (c) the **custom/private branch** of `AgentResolverService.MaterialiseAsync` that
+sources prompts from the agent itself — fail-loud, never empty/plain, never falling through to the
+Epic 27 store. **No new entity, no new column** — a JSON sub-object + validation + one resolver leg.
+
+**Story file:** `docs/stories/epic-32/story-32-17/32-17-custom-agent-prompts.md`
+**Design of record:** `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§3.0, §3.1, §3.2)
+**Sequence:** step **D** (after 34-11/A, 32-15/B, 32-16/C; before 32-18/E and 32-4/32-5 rewrite/F)
+
+**Tech stack:** .NET 9 / Elsa 3 in `apps/tamma-elsa` (`Tamma.Api` services + `Tamma.Data` EF). Tests
+in `apps/tamma-elsa/tests/Tamma.Api.Tests/` (xUnit). Docker-bound suites run via
+`sg docker -c "dotnet test ..."` (session docker group is stale; plain `dotnet build` needs no
+wrapper). **`packages/api` is DELETED — there is no TypeScript path; all of this is C#.**
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO new entity / table / column.** A custom agent is *just* a `Visibility=Private` `Agent` (32-1).
+  `prompts` lives inside the existing `ConfigJson` jsonb. Therefore **no `DbSet`, no
+  `ControlPlaneDbContext` change, no `ControlPlaneDbContextModelTests` strict-list edit, and no
+  Program.cs startup-reset DROP-list edit** (those are required only when adding a *table*).
+- **NO persona/public → Epic 27 prompt branch.** That `else` leg of `MaterialiseAsync` is **32-15**.
+  This story defines the branch selector + the `if` (custom) leg (the `ICustomAgentPromptResolver` seam)
+  only, and calls 32-15's **`IPersonaPromptResolver`** seam for the `else`. Do NOT re-implement the Epic 27 leg.
+- **NO enablement gate.** Selection gating (`SelectForRoleAsync`/`ResolveUsableAgentAsync`) is **32-18**.
+- **NO credential / gate / cost changes.** 32-3 / 32-4 / 32-9 / 34 are untouched — only the prompt-source
+  leg of agent resolution.
+- **NO per-user prompt override layer.** Members run the tenant's custom agents as-authored (CLAUDE.md:
+  per-user personalization is intentionally NOT a feature).
+- **NO new providers, NO change to the Epic 27 store contents or schema.** The custom agent is the
+  escape hatch *around* the store, not an edit to it.
+
+---
+
+## Current-state findings (from 32-1, design §3.2)
+
+| Seam | Where it is | How 32-17 uses it |
+|---|---|---|
+| **`Agent` / `AgentVersion`** | `Tamma.Data/Entities/Agent.cs`, `AgentVersion.cs` (32-1) — `Visibility` enum, `ConfigJson` jsonb, versioned. | Unchanged. `prompts` is a sub-object of the existing `ConfigJson`; `Visibility` drives the public-must-be-empty rule and the resolver branch. |
+| **`ck_agents_visibility_ownership` CHECK + partial indexes** | `TammaModelConfiguration.cs` (32-1). | **Reused unchanged.** Custom agent = private agent; XOR/ownership/index discipline already correct. |
+| **`AgentConfigValidator`** | `Tamma.Api/Services/Agents/AgentConfigValidator.cs` (32-1) — provider regex, budget range, ReDoS/prototype-pollution guards; called before every write. | **Extended:** add a `visibility` discriminator + the `prompts` rules (public-must-be-empty, role:action key, non-empty template). Reuse the existing prototype-pollution guard. |
+| **`AgentResolverService.MaterialiseAsync`** | `Tamma.Api/Services/Agents/AgentResolverService.cs` (32-2; persona leg added by 32-15 via `IPersonaPromptResolver`). | **Extended (joint with 32-15):** add the custom/private `if` leg as the `ICustomAgentPromptResolver` seam + the one branch selector; call 32-15's `IPersonaPromptResolver` seam in the `else`. |
+| **Role/action taxonomy** | `Tamma.Core/Agents/AgentRole.cs`, `RolePhaseMap.cs`, `AgentAction` (Epic 27). | Validate `byRoleAction` keys (`"<role>:<action>"`) against it on write. |
+| **Mode** | `Tamma.Api/Services/PromptStore/TammaMode.cs` — `ITammaModeProvider`. | Owner-column derivation (32-1) + per-mode ownership of custom prompts. |
+| **No-empty-fallback** | `.dev/findings/feedback_resolution_no_empty_fallback`. | The custom branch is `byRoleAction → system → ERROR`; never empty/plain, never fall through. |
+
+**Key insight:** the only genuinely new code is `AgentPromptSet` (a record), the validator's
+`visibility`-conditional rules, and ONE `if/else` leg in `MaterialiseAsync`. Everything else reuses
+32-1/32-2 seams. **Coordinate the `MaterialiseAsync` edit with 32-15** so the two legs share one
+conditional.
+
+---
+
+## Architecture
+
+```
+WRITE PATH (create / publish version):
+  AgentEndpoints.Create|PublishVersion
+      └─ AgentConfigValidator.Validate(configJson, visibility)     [32-1 extended — THIS story]
+            ├─ public + populated prompts  → reject PROMPTS_NOT_ALLOWED_ON_PUBLIC   (rule 4)
+            └─ populated prompts           → validate keys/templates (AC3)
+      (+ optional DB CHECK ck_agents_public_no_prompts as backstop)
+
+READ / RESOLVE PATH (managed run, via 32-5 call-LLM):
+  AgentResolverService.MaterialiseAsync(resolved, role, action)
+      └─ promptSet = (Visibility==Private) ? read ConfigJson.prompts : null
+         if promptSet non-empty:                         ── CUSTOM branch (THIS story 32-17) ──
+             resolved.SystemPrompt = await _customAgentPrompts.ResolveAsync(agent, role, action)
+                 (ICustomAgentPromptResolver: byRoleAction["role:action"] ?? system; blank → throw
+                  CustomPromptUnresolvedException → 32-5 FailureCode)   [fail-loud]
+             PromptSource = CustomAgent
+         else:                                            ── PERSONA branch (32-15) ──
+             resolved = await _personaPrompts.ResolveAsync(...)   (IPersonaPromptResolver → Epic 27 store)
+             PromptSource = Epic27Store
+```
+
+Per-mode ownership (CLAUDE.md two-scoping-model rule): single-user = the sole user authors custom
+agents (`OwnerUserId`); SaaS = `tenant_owner`/`tenant_admin` author them (`OwnerTenantId`), members
+run them as-authored (no per-user override). Mode from `ITammaModeProvider`.
+
+---
+
+## Task breakdown
+
+Order: **T1** (records/enum/exception) → **T2** (validator invariant) → **T3** (resolver custom
+branch, joint with 32-15) → **T4** (provenance tag + no-leak) → **T5** (optional DB CHECK). T1 is a
+prerequisite for T2/T3. T5 is optional and last.
+
+### T1 — Typed models: `AgentPromptSet`, `AgentPromptSource`, `CustomPromptUnresolvedException`
+
+**Scope:** The data shapes + the typed fail-loud signal. No behaviour.
+
+**Files (new):**
+- `Tamma.Api/Services/Agents/AgentPromptSet.cs` — `record { string? System; IReadOnlyDictionary<string,string>? ByRoleAction; bool IsEmpty }`.
+- `Tamma.Api/Services/Agents/AgentPromptSource.cs` — `enum { Epic27Store, CustomAgent }`.
+- `Tamma.Api/Services/Agents/CustomPromptUnresolvedException.cs` — carries `AgentId` + the `<role>:<action>` key (no template body).
+- `Tamma.Api/Services/Agents/ICustomAgentPromptResolver.cs` — the custom/private prompt seam `Task<RenderedPrompt> ResolveAsync(Agent agent, string role, string? action, CancellationToken ct)`.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/AgentPromptSetTests.cs` — deserialize from a
+`ConfigJson` string: absent `prompts` → null set; full block → both populated; `system`-only;
+`byRoleAction`-only; `prompts: {}` → `IsEmpty == true`. Round-trip equality.
+
+**Acceptance:**
+- [ ] `AgentPromptSet` deserializes all four shapes; `IsEmpty` correct for empty/null.
+- [ ] Builds clean; no analyzer warnings.
+
+### T2 — `AgentConfigValidator` invariant: public-must-be-empty + prompts shape (AC2, AC3)
+
+**Scope:** Extend the 32-1 validator with a `visibility` discriminator and the `prompts` rules. Runs
+before every write (create + publish-version).
+
+**Files:** modify `Tamma.Api/Services/Agents/AgentConfigValidator.cs` (add
+`Validate(configJson, AgentVisibility visibility)`; keep the existing 32-1 overload/behaviour for the
+shape rules). Wire the new overload into the `AgentEndpoints` create + publish paths (they already
+call the validator — pass `visibility`).
+
+**Rules added:**
+- `Visibility==Public` + non-empty `prompts` → `PROMPTS_NOT_ALLOWED_ON_PUBLIC` (reject, 400, no row, no event).
+- non-empty `prompts`: each `byRoleAction` key parses `"<role>:<action>"` via `RolePhaseMap.NormalizeRole` + `AgentAction` taxonomy (else `PROMPTS_INVALID_KEY`); each template non-empty after trim (else `PROMPTS_EMPTY_TEMPLATE`); prototype-pollution keys rejected (reuse 32-1 guard → `PROMPTS_PROTO_POLLUTION`).
+- a `prompts` object that parses but is wholly empty is allowed for private agents (treated as absent).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/AgentConfigValidatorPromptsTests.cs` —
+public+populated rejected (create & publish); private+populated accepted; private+absent accepted;
+invalid key / empty template / proto-pollution key each rejected with the right code; public+empty
+accepted.
+
+**Acceptance:**
+- [ ] Public + populated `prompts` rejected on BOTH create and publish endpoints.
+- [ ] All AC3 content rules enforced with the documented error codes.
+- [ ] Existing 32-1 validator tests still pass (shape rules unchanged).
+
+### T3 — `MaterialiseAsync` custom/private prompt-source branch (AC4, AC5) — joint with 32-15
+
+**Scope:** Add the single documented prompt-source conditional + ship the `ICustomAgentPromptResolver`
+seam (`CustomAgentPromptResolver` impl). **This story owns the `if` (custom) leg + the seam + the
+selector; 32-15 owns the `else` (persona/Epic 27) leg via `IPersonaPromptResolver`.** Coordinate so
+there is exactly one `if/else`.
+
+**Files:** new `Tamma.Api/Services/Agents/CustomAgentPromptResolver.cs` (the `ICustomAgentPromptResolver`
+impl); modify `Tamma.Api/Services/Agents/AgentResolverService.cs`; `IAgentResolverService.cs` (surface
+`PromptSource` on the resolved config if 32-15 hasn't already).
+
+**Logic:**
+```
+promptSet = (resolved.Visibility == Private) ? TryReadPromptSet(resolved.ConfigJson) : null;
+if (promptSet is { IsEmpty: false }) {                     // CUSTOM branch (32-17)
+    resolved = resolved with {                             // ICustomAgentPromptResolver: byRoleAction -> system -> ERROR
+        SystemPrompt = (await _customAgentPrompts.ResolveAsync(resolved.Agent, role, action, ct)).Text,
+        PromptSource = CustomAgent };                       // resolver throws CustomPromptUnresolvedException on no-resolve (fail-loud)
+} else {                                                   // PERSONA branch (32-15)
+    resolved = resolved with {
+        SystemPrompt = (await _personaPrompts.ResolveAsync(principal, role, action, ct)).Text,   // 32-15 IPersonaPromptResolver
+        PromptSource = Epic27Store };
+}
+```
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/AgentResolverServicePromptBranchTests.cs` +
+`CustomAgentPromptResolverTests.cs` —
+- both present → `byRoleAction` wins;
+- only `system`, non-matching `(role,action)` → `system` used;
+- neither matches → `CustomPromptUnresolvedException` AND the persona seam is **never** called (assert fake `IPersonaPromptResolver` not invoked);
+- empty `prompts` block → custom branch NOT entered → 32-15's `IPersonaPromptResolver.ResolveAsync` invoked, `PromptSource==Epic27Store`;
+- no-empty-fallback: no path returns an empty/plain prompt for a custom agent.
+
+**Acceptance:**
+- [ ] Custom branch resolution order is `byRoleAction → system → ERROR` (inside `ICustomAgentPromptResolver`).
+- [ ] `CUSTOM_PROMPT_UNRESOLVED` is fail-loud; Epic 27 store NEVER consulted on the custom path.
+- [ ] Empty-prompts custom agent delegates to 32-15's `IPersonaPromptResolver` branch.
+- [ ] Exactly ONE prompt-source conditional in `MaterialiseAsync` (grep; co-verified with 32-15).
+
+### T4 — Provenance tag + no-leak (AC7)
+
+**Scope:** The resolved config carries `PromptSource`. Ensure the managed run (32-5) can tag
+`promptSource="custom-agent"|"epic27-store"` + the `<role>:<action>` key, and that **no template body**
+enters events/logs. (32-5 owns the event emission; this story guarantees the *resolved-config carries
+the provenance* and that the validator/resolver logs never include the body.)
+
+**Files:** confirm `PromptSource` on the resolved-config record (T3); audit `AgentResolverService` +
+`AgentConfigValidator` log statements — log only the source label + the key, never the template body
+or the full `ConfigJson`.
+
+**Tests (first):** extend `AgentResolverServicePromptBranchTests` — captured-log assertion: a resolved
+custom prompt logs `promptSource=custom-agent` + key but no body; a fake `IEventRepository` (if the
+resolver emits any resolution event) carries no template body in `Data`/`Tags`.
+
+**Acceptance:**
+- [ ] `PromptSource` set correctly on both branches.
+- [ ] No template body appears in any log line or emitted event from the validator/resolver.
+
+### T5 — (Optional) DB CHECK backstop `ck_agents_public_no_prompts`
+
+**Scope:** Belt-and-suspenders DB enforcement of public-must-be-empty. **Optional** — prefer
+validator-only (T2) to keep the migration footprint at zero. Only add if a reviewer wants a structural
+backstop.
+
+**Files (if added):** modify `Tamma.Data/TammaModelConfiguration.cs` (additive CHECK on the existing
+`agent_versions`/`agents` config — a jsonb predicate asserting public rows have no populated
+`prompts`); new additive migration `Migrations/ControlPlane/<ts>_AddPublicAgentNoPromptsCheck.cs`
+(CHECK only — **no column, no table**).
+
+**Tests (first):** integration (Postgres fixture, `sg docker`): inserting a public `agent_versions`
+row with populated `prompts` violates the CHECK; `dotnet ef migrations has-pending-model-changes
+--context ControlPlaneDbContext` reports none after the migration.
+
+**Acceptance (only if T5 is taken):**
+- [ ] CHECK rejects public+populated-prompts at the DB layer.
+- [ ] `has-pending-model-changes` reports none; additive amendment to the single snapshot (not a branch).
+- [ ] No `ControlPlaneDbContextModelTests` strict-list edit needed (no new entity), and no Program.cs
+      startup-reset DROP-list edit (no new table).
+
+---
+
+## Story order & dependencies
+
+External prereqs (must land first): **32-1** (Agent entity, validator, CHECK, indexes, `ConfigJson`),
+**32-15** (persona/Epic-27 `MaterialiseAsync` leg + the `IPersonaPromptResolver` seam — **co-author of
+the conditional**; land it before T3). **Sequence:** A (34-11) → B (32-15) → C (32-16) → **D (this)** →
+E (32-18) → F (32-4/32-5). Internal: T1 → T2 ∥ T3 → T4 → (optional) T5. Downstream consumer: **32-5**
+maps `CUSTOM_PROMPT_UNRESOLVED` to a typed `FailureCode` and emits the `promptSource`-tagged events
+(not a blocker for this story).
+
+> **EF parallel-migration hazard:** stories are implemented **sequentially** on one migration snapshot.
+> If T5 is taken, it **amends** the existing snapshot (additive CHECK), it does not branch it. Most
+> likely this story ships with **zero migration** (validator-only enforcement).
+
+## Verification
+
+```bash
+# build (no docker wrapper needed)
+dotnet build apps/tamma-elsa/Tamma.sln
+# tests (docker-bound suites need the sg wrapper; session docker group is stale)
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~Agents"
+# AC4 single-conditional check: exactly one prompt-source branch in MaterialiseAsync
+grep -n "PromptSource\|_personaPrompts\|IPersonaPromptResolver\|_customAgentPrompts\|ICustomAgentPromptResolver\|CustomPromptUnresolved" apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentResolverService.cs
+# (only if T5 taken) confirm no pending model changes after the additive CHECK
+sg docker -c "dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext --project apps/tamma-elsa/src/Tamma.Data"
+```
+
+## Risks
+
+- **Double-implemented `MaterialiseAsync` branch (32-15 ∥ 32-17):** High. Mitigation: one documented
+  `if/else`; this story owns the `if` (`ICustomAgentPromptResolver`), 32-15 the `else`
+  (`IPersonaPromptResolver`); land 32-15 first; a test asserts each branch does not invoke the other's
+  seam; grep confirms one conditional.
+- **Silent fall-through to Epic 27 / empty prompt (no-empty-fallback breach):** High. Mitigation: a
+  non-empty `prompts` block commits to the custom branch; `CustomPromptUnresolvedException` is the only
+  no-resolve outcome; test asserts the persona seam is NOT consulted and no empty/plain prompt returns.
+- **Public persona smuggles prompts:** High. Mitigation: `PROMPTS_NOT_ALLOWED_ON_PUBLIC` at create AND
+  publish; optional DB CHECK (T5) as backstop; tested on both endpoints.
+- **Prompt body leaks into events/logs:** Medium. Mitigation: log/tag only the source label + the
+  `<role>:<action>` key; captured-log + fake-repo assertions; extends 32-1's no-raw-ConfigJson rule.
+- **`byRoleAction` key taxonomy drift from Epic 27:** Medium. Mitigation: validate keys via the same
+  `RolePhaseMap.NormalizeRole` / `AgentAction` taxonomy on write; reuse 32-1's normalization path.
+- **Unnecessary migration:** Low. Mitigation: prefer validator-only (zero migration); T5's CHECK is
+  optional and additive on the single snapshot if taken.

--- a/docs/superpowers/plans/2026-06-21-32-18-registry-enablement-gate-and-prompt-source-plan.md
+++ b/docs/superpowers/plans/2026-06-21-32-18-registry-enablement-gate-and-prompt-source-plan.md
@@ -1,0 +1,279 @@
+# Story 32-18 — Agent Registry Enablement Gate + Epic-27 Prompt Source (amends 32-2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation.
+
+**Date:** 2026-06-21 · **Sequence:** step **E** of the Epic-32 pivot (re-plan §4)
+
+**Goal:** Amend the **shipped** 32-2 registry/resolver so it (1) enforces the per-tenant **enablement
+gate** in selection and resolution — a public persona NOT enabled for the principal is not selectable
+(`AGENT.SELECT.NOT_ENABLED`, 409) and not resolvable (degrade to the enabled default); (2) returns the
+`enabled(public) ∪ own-private` visible set; (3) rewrites `GetSystemDefaultPublicAsync` to return the
+tenant's **enabled default persona** (cross-role, since `Agent.Role` is now nullable) and fail loud if
+nothing is enabled; and (4) sources a **persona's** system/role prompt from the **Epic 27** store keyed
+`(principal, role, action)` in `MaterialiseAsync` (custom-agent prompts stay 32-17's branch).
+
+**This story is a logic amendment only — NO new entity, NO new table, NO new migration.** It consumes
+32-16's `ITenantAgentEnablementReader` (async `IsEnabledForPrincipalAsync` / `ListEnabledPublicAgentIdsAsync` /
+`GetEnabledDefaultPersonaIdAsync`), 32-15's `IPersonaPromptResolver` seam + persona seeder +
+`DefaultPersonaName`, and 32-17's `ICustomAgentPromptResolver` seam. For the persona prompt it
+**dispatches** to `IPersonaPromptResolver` (which reads Epic 27 internally) — it does **NOT** re-inline
+`IPromptStoreService` and adds no prompt-resolution body of its own.
+
+**Story file:** `docs/stories/epic-32/story-32-18/32-18-registry-enablement-gate-and-prompt-source.md`
+**Design of record:** `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§3.1, §3.3, §3.5)
+**Re-plan:** `docs/superpowers/plans/2026-06-20-epic-32-37-replan.md` (§1 disposition of 32-2)
+
+**Tech stack:** .NET 9 / Elsa 3 in `apps/tamma-elsa` (central API `Tamma.Api`). Tests in
+`apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/` (xUnit). Docker-bound suites run via
+`sg docker -c "dotnet test ..."` (session docker group is stale; plain `dotnet build` needs no wrapper).
+**`packages/api` is DELETED — all of this is C#.**
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO `TenantAgentEnablement` entity / enable-disable API / `AGENT.ENABLED/DISABLED` events.** Those
+  are **32-16**. This story only *reads* `ITenantAgentEnablementReader`.
+- **NO new table, column, migration, or DROP-list edit.** The nullable-`Agent.Role` migration + persona
+  seeder are **32-15**; the `ConfigJson.prompts` column is **32-17**. `has-pending-model-changes` MUST
+  stay clean (AC 11).
+- **NO prompt-resolution body — dispatch only.** This story wires the `MaterialiseAsync` prompt-source
+  PRECEDENCE only: public persona → `IPersonaPromptResolver` (32-15, which reads Epic 27 internally),
+  private/custom → `ICustomAgentPromptResolver` (32-17). It implements **neither** body and does **not**
+  re-inline `IPromptStoreService`. Both seams are called, never implemented here.
+- **NO credential resolution.** The persona names provider+model; the key is **32-3**'s job at call time
+  inside the call-LLM endpoint (**32-5**). The resolver must never touch or log a key.
+- **NO change to the legacy `/api/v1/agents/*` JSONB path** or `AgentResolverService.ResolveAsync`.
+- **NO style/voice variant** (that's the split-out 32-12-rewrite follow-on, not this).
+
+---
+
+## Current-state findings (verified against the shipped 32-2 spec + design of record)
+
+| Seam | Where it is today (post-32-2/15/16/17) | How 32-18 uses it |
+|---|---|---|
+| **`CanUse(agent)`** | 32-2 `AgentRegistryService` — returns `true` for **any** public agent | Rewrite → async `CanUseAsync(agent, principal, ct)` ⇒ `agent.IsPublic ? await IsEnabledForPrincipalAsync(agent.Id, principal, ct) : agent.IsOwnedBy(principal)` |
+| **`SelectForRoleAsync`** | 32-2 — upserts a selection for any visible target | Add enablement gate before upsert → `AGENT.SELECT.NOT_ENABLED` / 409 for disabled public persona |
+| **`ListAsync`** | 32-2 — `public ∪ own-private` | Tighten → `enabled(public) ∪ own-private` (via batch `ListEnabledPublicAgentIdsAsync`); `?includeDisabled=true` (admin) returns full catalog + `enabled` flag |
+| **`GetSystemDefaultPublicAsync(role)`** | 32-2 — matched `Agent.Role == role` | Rewrite → tenant's **enabled default persona** (cross-role; consumes `GetEnabledDefaultPersonaIdAsync`); null ⇒ resolver fails loud |
+| **resolve precedence** | 32-2 — selection usable if `IsPublic` | Use enablement-aware `CanUseAsync`; degrade past a now-disabled selection with `AGENT.RESOLVE.DEGRADED` |
+| **`MaterialiseAsync`** | 32-2 sourced prompt from agent config; 32-15 owns the `IPersonaPromptResolver` body | **Dispatch only**: public → `IPersonaPromptResolver` (32-15); private → `ICustomAgentPromptResolver` (32-17). No inline resolve body. |
+| **`ITenantAgentEnablementReader`** | **32-16** — async `IsEnabledForPrincipalAsync(agentId, principal, ct)`, `ListEnabledPublicAgentIdsAsync(principal, ct)`, `GetEnabledDefaultPersonaIdAsync(principal, ct)` | Inject + consume; do NOT define |
+| **`IPersonaPromptResolver`** | **32-15** — persona/public prompt body (reads Epic 27 `(principal, role, action)`, fail-loud) | Dispatch the public branch to it; do NOT re-inline Epic 27 |
+| **`ICustomAgentPromptResolver`** | **32-17** — private-agent prompt seam | Dispatch the private branch to it; body not owned here |
+| **`AgentEventTypes`** | 32-2 constants | Add `SelectNotEnabled`, `ResolveDegraded`, `NoEnabledDefault` |
+
+**Key insight:** the only genuinely new code is the *enablement-aware predicate* (async, consuming the
+32-16 reader) + the *prompt-source dispatch* (public → `IPersonaPromptResolver` 32-15, private →
+`ICustomAgentPromptResolver` 32-17 — NO resolution body here) + three event constants + the endpoint
+status mappings. No data model work, no inline Epic-27 resolve. Everything else is consuming existing
+seams in the existing 32-2 services.
+
+---
+
+## Architecture
+
+```
+SelectForRoleAsync(role, agentId)
+   target = ResolveTarget(agentId, principal)            -- public CP ∪ own-private; cross-tenant => null => 404
+   if target.IsPublic && !await enablement.IsEnabledForPrincipalAsync(target.Id, principal, ct):
+        emit AGENT.SELECT.NOT_ENABLED  -> throw TammaError("AGENT.SELECT.NOT_ENABLED") -> 409 agent_not_enabled
+   else: upsert selection + AGENT.SELECTED_FOR_ROLE.SUCCESS
+
+ResolveForRoleAsync(role, action)
+   1+2 selection? -> agent -> if await CanUseAsync(agent, principal, ct): Materialise(...)   -- enabled public OR own-private
+                          else (disabled): AGENT.RESOLVE.DEGRADED (WARN), fall through
+   3   GetSystemDefaultPublicAsync(role) -> enabled default persona -> Materialise(..., "system-public")
+            (configured DefaultPersonaName if enabled, else await enablement.GetEnabledDefaultPersonaIdAsync(principal))
+   4   none -> AGENT.RESOLVE.FAILED + TammaError("AGENT.RESOLVE.NO_ENABLED_DEFAULT")   -- NO empty fallback
+
+Materialise(agent, role, action, source)   -- PROMPT SOURCE = DISPATCH ONLY (no resolution body here)
+   cfg = merge(DefaultAgentConfig.ForRole(role), agent.ActiveVersion.ConfigJson)     -- provider/model/params
+   if agent.IsPublic:  systemPrompt = await _personaPrompts.ResolveAsync(principal, role, action)  -- IPersonaPromptResolver (32-15) -> Epic 27
+   else:               systemPrompt = await _customAgentPrompts.ResolveAsync(agent, role, action)  -- ICustomAgentPromptResolver (32-17)
+   return ResolvedAgentConfig { SystemPrompt, Provider, Model, AgentId, AgentVersion, Source }
+        -- credential resolved LATER by 32-3 at call time from Provider; resolver NEVER touches a key
+```
+
+Per-mode (CLAUDE.md two-scoping rule): single-user gate/prompt keyed by `user_id`; SaaS by `tenant_id`;
+no per-user enablement or per-user prompt layer; mode from `ITammaModeProvider`.
+
+---
+
+## Task breakdown
+
+Order: T1 (event constants + endpoint status map) → T2 (`CanUseAsync` + selection gate) → T3 (resolve
+precedence: degrade + enabled default) → T4 (prompt-source dispatch + action plumbing) →
+T5 (listing `enabled ∪ own-private`) → T6 (mode matrix + no-credential + no-regression). T2 and T4 are
+independent of each other (both depend on the seams existing); T3 depends on T2's `CanUseAsync`.
+
+### T1 — Event constants + endpoint status mapping
+
+**Scope:** Add the three DCB event-type constants and wire the endpoint error mappings. No behaviour yet.
+
+**Files:** modify `Services/Agents/AgentEventTypes.cs` (`SelectNotEnabled = "AGENT.SELECT.NOT_ENABLED"`,
+`ResolveDegraded = "AGENT.RESOLVE.DEGRADED"`, `NoEnabledDefault = "AGENT.RESOLVE.NO_ENABLED_DEFAULT"`);
+modify `Endpoints/AgentEndpoints.cs` (map `TammaError("AGENT.SELECT.NOT_ENABLED")` → 409
+`agent_not_enabled`; `TammaError("AGENT.RESOLVE.NO_ENABLED_DEFAULT")` → 404/409 with code).
+
+**Tests (first):** `AgentEndpointsTests` — status-code mapping asserts (a fake registry that throws the
+typed errors; assert 409 body `{ "error": "agent_not_enabled" }`).
+
+**Acceptance:**
+- [ ] Constants present; builds clean.
+- [ ] Endpoint maps the typed errors to the documented status codes.
+
+### T2 — `CanUseAsync` enablement-aware + selection gate (AC1–AC3, AC9)
+
+**Scope:** Inject `ITenantAgentEnablementReader` (32-16). Rewrite `CanUse` → async
+`CanUseAsync(agent, principal, ct)` calling `await _enablement.IsEnabledForPrincipalAsync(...)`. Add the
+gate in `SelectForRoleAsync` before upsert (also async). Emit `AGENT.SELECT.NOT_ENABLED`.
+
+**Files:** modify `Services/Agents/AgentRegistryService.cs`, `IAgentRegistryService.cs` (expose/keep
+`CanUseAsync`; document).
+
+**Tests (first):** `AgentRegistryServiceTests` (faking `ITenantAgentEnablementReader`) — enabled public →
+select OK + `AGENT.SELECTED_FOR_ROLE.SUCCESS`; disabled public → `TammaError("AGENT.SELECT.NOT_ENABLED")`
++ exactly one `AGENT.SELECT.NOT_ENABLED` event; own-private → OK (implicit enable); cross-tenant private →
+404; `CanUseAsync` truth table (public+enabled/disabled, own-private, other-tenant-private).
+
+**Acceptance:**
+- [ ] `CanUseAsync` no longer returns true for a public persona solely because it is public; calls `IsEnabledForPrincipalAsync`.
+- [ ] Disabled-persona selection blocked with the typed error + event; own-private accepted.
+
+### T3 — Resolve precedence: degrade-on-disabled + enabled default (AC2, AC5, AC9)
+
+**Scope:** In `AgentResolverService.ResolveForRoleAsync`, use the enablement-aware `CanUseAsync`; a
+selection pointing at a now-disabled persona degrades (WARN + `AGENT.RESOLVE.DEGRADED`) instead of
+resolving it. Rewrite `GetSystemDefaultPublicAsync` → tenant's enabled default persona (via
+`DefaultPersonaName` enabled, else 32-16's `GetEnabledDefaultPersonaIdAsync` — defined in 32-16,
+consumed here). Null ⇒ fail loud `AGENT.RESOLVE.NO_ENABLED_DEFAULT`.
+
+**Files:** modify `Services/Agents/AgentResolverService.cs`, `AgentRegistryService.cs`
+(`GetSystemDefaultPublicAsync`).
+
+**Tests (first):** `AgentResolverServiceTests` — (a) selection→disabled ⇒ resolves enabled default +
+`AGENT.RESOLVE.DEGRADED`, disabled persona never materialised; (b) `DefaultPersonaName` enabled ⇒
+returned; (c) `DefaultPersonaName` disabled but another is the enabled default ⇒ that one; (d) nothing
+enabled + no own-private ⇒ `AGENT.RESOLVE.FAILED` + `TammaError("AGENT.RESOLVE.NO_ENABLED_DEFAULT")`,
+**no blank config**.
+
+**Acceptance:**
+- [ ] Disabled selection degrades, never resolves.
+- [ ] Enabled-default lookup is cross-role (no `Role==role` match); fails loud when nothing enabled.
+
+### T4 — Prompt-source DISPATCH only + `action` plumbing (AC6, AC7; boundary with 32-15/32-17)
+
+**Scope:** Wire the `MaterialiseAsync` prompt-source PRECEDENCE/dispatch ONLY — this story adds **no**
+prompt-resolution body. Public persona → `await _personaPrompts.ResolveAsync(principal, role, action)`
+(32-15's `IPersonaPromptResolver`, which reads Epic 27 internally, fail-loud). Private/custom →
+`await _customAgentPrompts.ResolveAsync(agent, role, action)` (32-17's `ICustomAgentPromptResolver`).
+**Do NOT call `IPromptStoreService` directly** (32-15 owns that body). Plumb `action` through
+`ResolveForRoleAsync`/`ResolveForRoleAndPhaseAsync`. Persona `ConfigJson` prompt is ignored.
+
+**Files:** modify `Services/Agents/AgentResolverService.cs` (`MaterialiseAsync` dispatch),
+`IAgentResolverService.cs` (`action` param on the resolve methods).
+
+**Tests (first):** `AgentResolverServiceTests` — public persona dispatches to the faked
+`IPersonaPromptResolver` seam (assert `MaterialiseAsync` does NOT call `IPromptStoreService` directly,
+nor read the persona `ConfigJson` prompt); a seam miss (`PROMPT_UNRESOLVED`) propagates (no empty/plain);
+`action` absent ⇒ still passed through to the seam; a **private** agent dispatches to
+`ICustomAgentPromptResolver`, NOT the persona seam (boundary proof).
+
+**Acceptance:**
+- [ ] Persona prompt is **dispatched** to `IPersonaPromptResolver` (32-15); no inline `IPromptStoreService` call here; fail-loud propagates.
+- [ ] Custom-agent branch is dispatched to 32-17's `ICustomAgentPromptResolver`, not implemented here.
+
+### T5 — Listing `enabled(public) ∪ own-private` (AC4)
+
+**Scope:** `ListAsync` returns `enabled(public) ∪ own-private`; `?includeDisabled=true` (owner/admin
+only) returns the full catalog with an `enabled` flag per row; members never see disabled public
+personas. Use 32-16's batch `ListEnabledPublicAgentIdsAsync(principal, ct)` (one read → set membership;
+avoids per-row async calls).
+
+**Files:** modify `Services/Agents/AgentRegistryService.cs` (`ListAsync`), `IAgentRegistryService.cs`
+(`AgentListFilter.IncludeDisabled`), `Endpoints/AgentEndpoints.cs` (List honours `?includeDisabled`,
+admin-only).
+
+**Tests (first):** `AgentRegistryServiceTests` + `AgentEndpointsTests` — member list = enabled∪own-private;
+admin `?includeDisabled=true` = full catalog + `enabled` flags; member `?includeDisabled=true` ignored.
+
+**Acceptance:**
+- [ ] Member listing excludes disabled public personas; admin can see the full catalog with flags.
+
+### T6 — Mode matrix, no-credential, no-regression (AC8, AC10, AC11, AC12)
+
+**Scope:** Mode-parameterized principal (`user_id` vs `tenant_id`) for gate + prompt; no per-user
+enablement layer. Assert no resolver/registry path resolves or logs a credential. Confirm the legacy
+JSONB path + existing 32-2 tests stay green and `has-pending-model-changes` → none.
+
+**Files:** extend `AgentRegistryServiceTests`/`AgentResolverServiceTests`; new
+`AgentResolverServiceNoCredentialTests`.
+
+**Tests (first):**
+- `[Theory]` over `TammaMode.SingleUser`/`SaaS`: gate + prompt keyed by the right principal.
+- No-credential: a resolve never invokes any `IProviderCredentialResolver`/cabinet seam, never logs a
+  key; `ResolvedAgentConfig` carries `Provider`/`Model` but no key field.
+- No-regression: existing 32-2 endpoint/resolver tests + legacy `/api/v1/agents/*` green;
+  `dotnet ef migrations has-pending-model-changes` → none.
+
+**Acceptance:**
+- [ ] Mode matrix passes; no per-user enablement.
+- [ ] No credential ever resolved/logged in the registry/resolver.
+- [ ] Full suite green; zero pending model changes.
+
+---
+
+## Story order & dependencies
+
+External prereqs (must land first): **32-2** (the services amended), **32-15** (persona seeder +
+`Agent.Role` nullable + the `IPersonaPromptResolver` seam + `DefaultPersonaName`), **32-16**
+(`ITenantAgentEnablementReader` — async `IsEnabledForPrincipalAsync` / `ListEnabledPublicAgentIdsAsync` /
+`GetEnabledDefaultPersonaIdAsync`), **32-17** (`ICustomAgentPromptResolver`). Epic 27's `IPromptStoreService`
+is reached **through** 32-15's `IPersonaPromptResolver`, not directly. Code to their interfaces; use fakes
+until landed. Internal: T1 → (T2 ∥ T4) → T3 (needs T2) → T5 → T6.
+Downstream consumer: **32-5** (call-LLM endpoint) composes the resolve order this story documents; it is
+NOT a blocker.
+
+## Verification
+
+```bash
+# build (no docker wrapper needed)
+dotnet build apps/tamma-elsa/Tamma.sln
+# tests (docker-bound suites need the sg wrapper; session docker group is stale)
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~Agents"
+# AC11 — no schema drift from this story
+sg docker -c "dotnet ef migrations has-pending-model-changes --project apps/tamma-elsa/src/Tamma.Data --context TenantDbContext"
+sg docker -c "dotnet ef migrations has-pending-model-changes --project apps/tamma-elsa/src/Tamma.Data --context ControlPlaneDbContext"
+# boundary check — this story adds NO entity/migration of its own
+git -C apps/tamma-elsa diff --name-only | grep -i 'Migrations/' && echo "UNEXPECTED migration — 32-18 adds none" || echo "OK: no migration"
+# credential-safety grep — registry/resolver hold no key
+grep -rn "ApiKey\|IProviderCredentialResolver\|cabinet" apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentResolverService.cs apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRegistryService.cs || echo "OK: no credential in registry/resolver"
+```
+
+## Risks
+
+- **Double-implementation (HIGH):** the easiest failure mode is re-creating the `TenantAgentEnablement`
+  entity, the persona seeder, or re-inlining the Epic-27 persona-resolve / custom-prompt body here.
+  Mitigation: this story adds NO entity/migration; it injects `ITenantAgentEnablementReader` (32-16),
+  dispatches to 32-15's `IPersonaPromptResolver` and 32-17's `ICustomAgentPromptResolver` (calls, never
+  implements), and uses the 32-15 persona seeder. The `git diff` migration check +
+  `has-pending-model-changes` + a test asserting no direct `IPromptStoreService` call are the guard.
+- **A disabled persona still resolves (HIGH):** if the gate is applied on selection but not on resolve.
+  Mitigation: centralise the predicate in `CanUseAsync`; both `SelectForRoleAsync` and the resolve
+  precedence call it; T3 tests the degrade path explicitly.
+- **Empty/plain prompt fallback (HIGH):** mitigation — persona branch dispatches to 32-15's
+  `IPersonaPromptResolver` (whose body resolves Epic 27 tenant→system→error and throws `PROMPT_UNRESOLVED`/
+  `NoPromptError` on a miss); a miss propagates; T4 asserts the seam is invoked (not an inline resolve)
+  and the miss propagates. `feedback_resolution_no_empty_fallback`.
+- **Credential leak into resolver (HIGH):** mitigation — dedicated no-credential test (T6); the resolver
+  carries only `Provider`/`Model`; credential is 32-3 at call time.
+- **Seam-shape drift (MEDIUM, mostly RESOLVED):** 32-16 ships the read seam `ITenantAgentEnablementReader`
+  with async `IsEnabledForPrincipalAsync` + batch `ListEnabledPublicAgentIdsAsync` + `GetEnabledDefaultPersonaIdAsync`
+  (the exact signatures this story calls); `ListAsync` uses the batch read. Remaining open item: 32-15
+  may expose `DefaultPersonaName` as config vs a CP row — code to whichever 32-15 ships.
+- **Dependency timing (MEDIUM):** 32-15/16/17 land before this (sequence B/C/D before E). Mitigation:
+  interfaces + fakes; this story is the integrator, gated behind them.

--- a/docs/superpowers/plans/2026-06-21-32-19-agent-style-voice-variants-plan.md
+++ b/docs/superpowers/plans/2026-06-21-32-19-agent-style-voice-variants-plan.md
@@ -1,0 +1,305 @@
+# Story 32-19 — Agent Style/Voice Variants (`AgentStyleVariant`, the 32-12 overlay split-out)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation.
+
+**Goal:** Re-home the still-valuable tone/voice/verbosity idea from the OLD 32-12 (`atlas`/`nova`
+"review voice") as a **separate, optional `AgentStyleVariant`** — explicitly **NOT a persona**
+(persona = the named system agent, 32-15) and **NOT a custom agent** (= own prompts, 32-17). A
+variant is a small style descriptor (tone/verbosity knobs and/or a short style-prompt fragment) that
+the call-LLM endpoint (32-5) merges **on top of** the resolved base prompt — **additively, after**
+Epic-27/custom-prompt resolution (a new step 4b), never replacing it, never empty-fallback. It changes
+**no** provider/model/credential. A run applies **zero or one** variant; default = none = no behaviour
+change. Binding is per-`(principal, role)`, constrained to the principal's **enabled** variants, with
+the same visibility/XOR/unique-nulls-not-distinct discipline as `prompt_overrides` /
+`AgentRoleSelection` / `TenantAgentEnablement`.
+
+**Story file:** `docs/stories/epic-32/story-32-19/32-19-agent-style-voice-variants.md`
+**Design spec:** `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§3.4 the
+split — variant ≠ persona; §3.0 reframe; §2.6 the composition step 4 this overlay rides on)
+
+**Tech stack:** .NET 9 / Elsa 3 in `apps/tamma-elsa` (central API `Tamma.Api` + data `Tamma.Data`).
+Tests live in `apps/tamma-elsa/tests/Tamma.Api.Tests/` (xUnit). Docker-bound suites run via
+`sg docker -c "dotnet test ..."` (session docker group is stale; plain `dotnet build` needs no
+wrapper). **`packages/api` is DELETED — there is no TypeScript path; all C#.**
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO change to provider/model/credential/cost.** A variant is a voice overlay only. The entity
+  carries no `provider`/`model`/key/base-prompt fields; `credentialSource` (32-3) is untouched; the
+  cost path (34-11/34-5) is untouched. If your change makes `providerUsed`/`modelUsed`/
+  `credentialSource` differ with vs without a variant, the design is wrong — stop.
+- **NO replacing/blanking the base prompt.** `ComposeOverlay` is a **pure additive suffix**. The base
+  keeps its tenant→system→**error** contract (owned by 32-5 step 4). The variant never rescues, blanks,
+  or short-circuits an empty base (`feedback_resolution_no_empty_fallback`).
+- **NO persona/custom-agent semantics.** This is NOT a persona and NOT a custom agent. No
+  `/api/personas` route, no provider preset, no own-prompt editing. Distinct route
+  (`/api/style-variants`), distinct event family (`AGENT.STYLE_VARIANT.*`).
+- **NO edit to the 32-5 call-LLM composition here.** This story ships `IAgentStyleVariantService`;
+  32-5 (or a tiny amendment to it) inserts step 4b. Code to the interface; do not touch
+  `ManagedAgent.RunAsync`.
+- **NO variant axis on benchmarking.** 32-12/32-10 key benchmarking on the persona-agent identity. A
+  variant is an orthogonal dimension; adding it to the harness is a future story, out of scope.
+- **NO per-user layer in SaaS.** Variants + bindings are per-tenant (members read, can't write),
+  mirroring "no per-user override layer in SaaS." Single-user keys by `UserId`.
+
+---
+
+## Current-state findings (verify at implementation time, repo @ the worktree HEAD)
+
+| Seam | Where it is today | How 32-19 uses it |
+|---|---|---|
+| **Principal-XOR + index discipline** | `Tamma.Data/Entities/AgentRoleSelection.cs` + `TenantAgentEnablement` (32-16) configured in `TammaModelConfiguration.cs` (XOR CHECK + `UNIQUE NULLS NOT DISTINCT`). | Mirror **exactly** for `AgentStyleVariant` (per-principal name uniqueness) and `AgentStyleVariantSelection` (one variant per `(principal, role)`). |
+| **Catalog membership** | `TenantAgentEnablement` + `ITenantAgentEnablementService` (32-16): `Enabled` flag, own-private implicit-enabled, per-tenant, `DefaultPersonaName` seeded. | Reuse the pattern for variant enablement (`SetEnabledAsync`, implicit-private, disable-own ⇒ 409). |
+| **Per-(principal, role) binding** | `AgentRoleSelection` (32-2): one agent bound per role per principal. | Mirror for `AgentStyleVariantSelection`: at most one variant per role per principal; `variantId:null` clears. |
+| **Base prompt render** | 32-5 `ManagedAgent.RunAsync` step 4: Epic 27 `(principal, role, action)` for personas / custom agent's own prompts; tenant→system→**error**. | The overlay rides **on top of** the rendered system prompt at a new step 4b; never edits step 4. |
+| **CP placement** | `ControlPlaneDbContext` + `ControlPlaneDbContextModelTests` strict `BeEquivalentTo` list + `Program.cs` "Wiping Tamma-managed public-schema tables" DROP list. | Both new tables are CP-resident → add 2 DbSets, 2 strict-list entries, 2 DROP-list entries. NOT `EfTenantDbMigrator`. |
+| **DCB events** | `IEventRepository.AppendAsync`, tenant-scoped; `AGENT.ENABLED/DISABLED.SUCCESS` family (32-16). | Emit `AGENT.STYLE_VARIANT.*`; tenant-scope carries `TenantId`, single-user carries `userId`. |
+| **Mode** | `Tamma.Api/Services/PromptStore/TammaMode.cs` — `ITammaModeProvider` (SingleUser \| SaaS), process-stable. | Derive principal (`TenantId` in SaaS / `UserId` in single-user) for every read/write. |
+| **RBAC policies** | 32-2/32-16 `/api/agents` group: `AgentManage` (owner/admin), member read; `PlatformOwnerAccess` for platform catalog. | Reuse for `/api/style-variants`: writes owner/admin, reads member, shipped catalog `PlatformOwnerAccess`. |
+
+**Key insight:** the only genuinely new code is two CP entities, the `IAgentStyleVariantService`
+(CRUD/enable/bind + the resolve/compose primitives), the **pure `ComposeOverlay`** function, the
+seeder, and the route group. Everything else is mirroring the 32-16/32-2 discipline. The 32-5 wiring
+is a one-step (4b) insertion owned by 32-5, behind this story's interface.
+
+---
+
+## Architecture
+
+```
+StyleVariantEndpoints (/api/style-variants)           -- CRUD + enablement + per-role bindings
+        |
+        v
+IAgentStyleVariantService                             -- owns the entities + the primitives:
+  CreateAsync/UpdateAsync/DeleteAsync (own-private)      -- public shipped variants read-only
+  SetEnabledAsync(id, bool)                              -- catalog membership (per-tenant, 32-16 pattern)
+  BindAsync(role, variantId?)                            -- one variant per (principal, role); null clears
+  ResolveActiveVariantAsync(role) -> ResolvedStyleVariant? -- the primitive 32-5 calls at step 4b
+  ComposeOverlay(baseSystemPrompt, variant?) -> string     -- PURE, additive suffix (base is a prefix)
+
+32-5 ManagedAgent.RunAsync (NOT edited here; wired via the interface):
+  4.  prompt = render base (Epic 27 / custom)  -- tenant->system->ERROR
+  4b. variant = ResolveActiveVariantAsync(role)            -- null = no overlay (default)
+      systemPrompt = ComposeOverlay(prompt.System, variant) -- additive; base verbatim prefix
+  5.  emit AGENT.RUN.STARTED { ..., styleVariantId? }       -- optional tag (event owned by 32-5)
+  6.  loop with systemPrompt                                -- provider/model/credential/cost UNCHANGED
+```
+
+Per-mode ownership (CLAUDE.md two-scoping-model rule): single-user = `UserId`-keyed CP rows, the sole
+user manages; SaaS = `TenantId`-keyed CP rows, owner/admin manage, members read-only. Default in both
+modes = **no overlay**. A variant never changes provider/model/credential. Mode from
+`ITammaModeProvider`.
+
+---
+
+## Task breakdown
+
+Order: T1 (entities + EF + migration + CP wiring) → T2 (service CRUD/enable/bind + events) →
+T3 (`ResolveActiveVariantAsync` + the pure `ComposeOverlay`) → T4 (endpoints + RBAC + DI) →
+T5 (seeder) → T6 (orthogonality + provider-unchanged + isolation + mode/CP tests). T2 and T3 both
+need T1; T3's `ComposeOverlay` is pure and can be built independently first.
+
+### T1 — Entities, EF config, migration, CP wiring (AC1, AC2, AC8, AC9)
+
+**Scope:** Two CP-resident entities with the XOR/index discipline; DbSets; the migration; the
+DROP-list + CP-model-test amendments.
+
+**Files (new/modify):** `Tamma.Data/Entities/AgentStyleVariant.cs`,
+`Tamma.Data/Entities/AgentStyleVariantSelection.cs`; `Tamma.Data/TammaModelConfiguration.cs`
+(both configs — XOR CHECK + `UNIQUE NULLS NOT DISTINCT`); `Tamma.Data/ControlPlaneDbContext.cs`
+(two DbSets); `Tamma.Data/Migrations/ControlPlane/*_AddAgentStyleVariants.cs` (generated);
+`Tamma.Api/Program.cs` (DROP-list amend — both tables);
+`tests/.../Epic28/ControlPlaneDbContextModelTests.cs` (strict list — both entities).
+
+**Tests (first):** `AgentStyleVariantModelTests` — XOR CHECK rejects both/neither principal;
+unique-nulls-not-distinct rejects a duplicate `(TenantId, UserId, Name)` variant and a duplicate
+`(TenantId, UserId, Role)` binding; `ControlPlaneDbContextModelTests.Model_Has_ExpectedControlPlaneEntities`
+includes both entities; `dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext`
+→ none; a second test-host boot succeeds (DROP-list proven for both tables).
+
+**Acceptance:**
+- [ ] Both entities have all AC1/AC2 fields; `AgentStyleVariant` has **NO** provider/model/credential/base-prompt fields.
+- [ ] EF config mirrors `AgentRoleSelection`/`TenantAgentEnablement` (XOR CHECK + unique-nulls-not-distinct) for both tables.
+- [ ] Both DROP-list entries + both strict-list entries added; second boot green; `has-pending-model-changes` → none.
+
+### T2 — `IAgentStyleVariantService` CRUD / enable / bind + events (AC5, AC6, AC12)
+
+**Scope:** Create/update/delete own-private variants; `SetEnabledAsync` (own-private implicit-enabled,
+disable-own ⇒ 409/no-op like 32-16); `BindAsync(role, variantId?)` (one variant per `(principal,
+role)`; null clears; un-enabled/unseen → 404/409). One DCB event per write.
+
+**Files (new):** `Tamma.Api/Services/Agents/IAgentStyleVariantService.cs`,
+`Tamma.Api/Services/Agents/AgentStyleVariantService.cs`,
+`Tamma.Api/Services/Agents/AgentStyleVariantEventTypes.cs`
+(`AGENT.STYLE_VARIANT.CREATED/UPDATED/DELETED/ENABLED/DISABLED/BOUND/UNBOUND.SUCCESS`).
+
+**Collaborators (constructor-injected; fakes in tests):** `ControlPlaneDbContext`,
+`ITammaModeProvider`, `ITenantContext`/`ClaimsPrincipal` accessor, `IEventRepository`,
+`ILogger<AgentStyleVariantService>`.
+
+**Tests (first):** `AgentStyleVariantServiceTests` — create/update/delete own-private; enable/disable
+(implicit-private, disable-own ⇒ 409); bind/clear; each write emits exactly one `AGENT.STYLE_VARIANT.*`
+event tagged `{ variantId, variantName, role?, mode, tenantId|userId }`; 404 on unseen target;
+cross-tenant target → 404.
+
+**Acceptance:**
+- [ ] CRUD/enable/bind upsert correctly; public shipped variants are read-only (write → 403/404 per RBAC).
+- [ ] Exactly one event per successful write; tags correct per mode.
+- [ ] Binding enforces one variant per `(principal, role)`; `variantId:null` clears.
+
+### T3 — `ResolveActiveVariantAsync` + the pure `ComposeOverlay` (AC3, AC4, AC11)
+
+**Scope:** The two primitives 32-5 calls. `ResolveActiveVariantAsync(role)` returns the single
+bound+enabled+visible variant else `null`. `ComposeOverlay(base, variant?)` is **pure** (no I/O):
+`null` → base verbatim; variant → `base + delimited style section`, base a verbatim **prefix**.
+
+**Files:** extend `AgentStyleVariantService.cs` (resolve); a pure helper
+`StyleOverlayComposer` (or a static method) for `ComposeOverlay` so it is independently testable.
+
+**`ComposeOverlay` contract:**
+```
+variant == null  => base                                         (no overlay; the default)
+variant != null  => base + "\n\n## Response style\n" + RenderDirectives(style)
+  RenderDirectives: stable knob lines (tone/verbosity/format/audience) + trimmed stylePrompt.
+  Empty/whitespace stylePrompt contributes nothing. Invariant: result.StartsWith(base).
+  NEVER edits/truncates/reorders the base.
+```
+
+**Tests (first):** `StyleOverlayComposeTests` (pure, no DB) — null → base unchanged;
+variant → base is a prefix; empty stylePrompt → no contribution; knob rendering stable/deterministic;
+property test `result.StartsWith(base)` over random base + variant. `AgentStyleVariantServiceTests`
+(resolve truth table) — bound+enabled→variant; bound+disabled→null; unbound→null; retired→null;
+cross-tenant target → null/404.
+
+**Acceptance:**
+- [ ] `ResolveActiveVariantAsync` truth table passes; disabled/retired/unbound all → `null` (optional, never an error).
+- [ ] `ComposeOverlay` is provably additive (base is a prefix; null → identity); never blanks the base.
+
+### T4 — Endpoints + RBAC + DI (AC5, AC6, AC7)
+
+**Scope:** `/api/style-variants` group: CRUD, `PUT /{id}/enablement`, `PUT /bindings/{role}`, `GET`
+list/bindings. Member 403 on writes; reads allowed; owner/admin write own-tenant; shipped catalog
+read-only (`PlatformOwnerAccess` for platform mutation, not exposed on the tenant route).
+
+**Files (new/modify):** `Tamma.Api/Endpoints/StyleVariantEndpoints.cs`;
+`Tamma.Api/Dtos/Agents/StyleVariantResponse.cs`, `StyleVariantRequest.cs`,
+`SetVariantBindingRequest.cs`; `Tamma.Api/Program.cs` (DI registration; route mapping; reuse the
+`AgentManage`/member/`PlatformOwnerAccess` policies + `ConfigWrite` rate limiter).
+
+**Tests (first):** `StyleVariantEndpointsTests` (in-process `WebApplicationFactory`) — RBAC matrix:
+SaaS member → 403 on create/update/delete/enable/bind; member reads → 200; owner/admin writes → 200;
+platform-catalog mutation not exposed (asserted absent/404); DI resolves the chain at host startup.
+
+**Acceptance:**
+- [ ] RBAC matrix green; member can read, cannot write; owner/admin write own-tenant.
+- [ ] DI resolves `IAgentStyleVariantService` + the endpoints at startup (smoke test).
+
+### T5 — Seeder (shipped public variants, no default binding) (AC10)
+
+**Scope:** `AgentStyleVariantSeeder` seeds a small shipped public catalog (`terse`, `verbose`,
+`formal`, `casual`) **insert-missing-only** (never reverts a tenant edit). **Bind nothing** — a fresh
+principal has zero bindings → default = no overlay (orthogonality preserved).
+
+**Files (new):** `Tamma.Api/Services/Agents/AgentStyleVariantSeeder.cs`; wire into the existing
+seeding startup path alongside `AgentEntitySeeder`/`TenantEnablementSeeder`.
+
+**Tests (first):** `AgentStyleVariantSeederTests` — a fresh principal has the shipped variants
+available but **zero bindings**; rerun is insert-missing-only (does not revert a tenant edit or add a
+binding).
+
+**Acceptance:**
+- [ ] Shipped public variants seeded; no default binding; rerun idempotent (insert-missing-only).
+
+### T6 — Orthogonality + provider-unchanged + isolation + mode tests (AC11, AC13)
+
+**Scope:** The load-bearing guards: default = none byte-for-byte; provider/model/credential identical
+with vs without a variant; never weakens base resolution; cross-tenant isolation; mode keying.
+
+**Files:** `tests/Tamma.Api.Tests/Agents/StyleVariantIsolationTests.cs`; extend
+`AgentStyleVariantServiceTests` (mode matrix) + an orthogonality golden test + a 32-5-shaped harness
+test (or an integration test against the 32-5 step-4b seam once 32-5 lands).
+
+**Tests (first):**
+- **Orthogonality golden test:** for a fixed agent + rendered base, **no binding** ⇒ the systemPrompt
+  fed to the loop == `ComposeOverlay(base, null)` == base, byte-for-byte.
+- **Provider/model/credential unchanged:** same agent, with vs without a bound variant ⇒
+  `providerUsed`/`modelUsed`/`credentialSource` identical; only the system prompt differs (additively).
+- **Never weakens base:** base prompt that fails to resolve (tenant→system→error) still fails loud
+  with a bound variant present; a disabled/missing **variant** is not an error.
+- **Cross-tenant isolation:** tenant A's private variant/binding never visible to B; A cannot
+  bind/enable B's private variant (404); A's changes never affect B.
+- **Mode-parameterized** (`[Theory]` over `TammaMode.SingleUser`/`SaaS`): variant + binding keyed by
+  `UserId` vs `TenantId`; the other column NULL (XOR); events tag the correct principal.
+
+**Acceptance:**
+- [ ] Default = none is byte-for-byte the no-variant output (golden test green).
+- [ ] Provider/model/credential identical with/without a variant.
+- [ ] Variant never rescues an empty base; isolation + mode matrix green.
+
+---
+
+## Story order & dependencies
+
+External prereqs (conceptual / interface-level): **32-12 rewrite** (locked vocabulary — variant ≠
+persona), **32-15** (persona catalog a variant overlays), **32-16** (catalog-membership/XOR pattern),
+**32-17** (custom-agent base prompts the overlay rides on after), **32-2** (`AgentRoleSelection`
+binding precedent + RBAC policies), **Epic 27** (the base prompt). **32-5** is the **consumer** that
+wires step 4b via this story's interface — sequence the 4b insertion in/after 32-5; this story can
+land its entity/service/API independently (gated only by the call-site wiring). Internal:
+T1 → (T2 ∥ T3) → T4 → T5 → T6.
+
+This is sequence **G** (post-F): optional + orthogonal, after the lynchpin (32-5) renders the base
+prompt the overlay rides on.
+
+## EF / migration note
+
+Stories are implemented **sequentially** (single migration snapshot). This story **amends/extends**
+the existing `ControlPlane` migration snapshot with one new migration adding `agent_style_variants`
+and `agent_style_variant_selections` — it does NOT branch the snapshot. Both tables are CP-resident
+(`ControlPlaneDbContext`); they are NOT added to the per-tenant `EfTenantDbMigrator` (which owns
+`t_<hex>` tables only). Append both to the `Program.cs` startup-reset DROP list and the
+`ControlPlaneDbContextModelTests` strict `BeEquivalentTo` list in the same change.
+
+## Verification
+
+```bash
+# build (no docker wrapper needed)
+dotnet build apps/tamma-elsa/Tamma.sln
+# tests (docker-bound suites need the sg wrapper; session docker group is stale)
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~StyleVariant|FullyQualifiedName~StyleOverlay"
+# CP model contract + pending-changes
+sg docker -c "dotnet test apps/tamma-elsa/tests/ --filter FullyQualifiedName~ControlPlaneDbContextModelTests"
+dotnet ef migrations has-pending-model-changes --context ControlPlaneDbContext --project apps/tamma-elsa/src/Tamma.Data
+# orthogonality proof: variant carries no provider/model fields
+grep -rn "Provider\|Model\|ApiKey\|credential" apps/tamma-elsa/src/Tamma.Data/Entities/AgentStyleVariant.cs   # expect: none
+```
+
+## Risks
+
+- **Vocabulary regression (a variant named/treated as a persona — the §3.4 mistake):** mitigated by a
+  strict entity shape (no provider/model fields — grep-proven), a distinct route (`/api/style-variants`),
+  a distinct event family (`AGENT.STYLE_VARIANT.*`), and the story title's "NOT a persona."
+- **Overlay replaces/blanks the base (empty-fallback regression):** `ComposeOverlay` is a pure suffix;
+  base-is-prefix property test; null → identity; the base keeps its tenant→system→error contract in
+  32-5 step 4 (the variant never touches it). If a test needs the base to be editable, the design is
+  wrong — stop.
+- **Default behaviour drift (something changes when nobody bound a variant):** the seeder binds
+  nothing; the orthogonality golden test asserts byte-for-byte equality with the no-variant output.
+- **Variant changes provider/model/credential/cost:** the entity carries none of those fields; the
+  provider-unchanged integration test asserts `providerUsed`/`modelUsed`/`credentialSource` identical.
+- **New CP tables break the second test-host boot (`relation already exists`):** amend the `Program.cs`
+  DROP list for **both** tables; second-boot test proves it.
+- **Strict CP model-test fails after adding the entities:** update the `BeEquivalentTo` list for both
+  in the same change (known gotcha, not a regression).
+- **Overlap with 32-5's composition:** hard boundary — ship the interface + primitives; 32-5 owns step
+  4b. No `ManagedAgent.RunAsync` edits here.
+- **XOR/keying drift from `AgentRoleSelection`/`TenantAgentEnablement`:** mirror the
+  `TammaModelConfiguration` config (XOR check name pattern, unique-nulls-not-distinct); constraint tests.
+- **Style fragment as an injection vector:** the fragment is appended to the **system** prompt of a run
+  the principal already controls; it is owner/admin-authored config, not user content; sanitization
+  stays in 32-5's loop; the overlay adds no tool/credential surface; log at length-summary granularity.

--- a/docs/superpowers/plans/2026-06-21-32-20-interactive-question-back-plan.md
+++ b/docs/superpowers/plans/2026-06-21-32-20-interactive-question-back-plan.md
@@ -1,0 +1,335 @@
+# Story 32-20 — Interactive Question-Back (`request_input` + `IQuestionRouter` + durable human gate)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation, and the security re-derivation test (T3) is written FIRST.
+
+**Date:** 2026-06-21
+
+**Goal:** Make a managed agent run able to **ask a question back mid-turn** and have it answered by the
+cheapest competent source — routed by a server-side policy the model cannot fool. Five pieces, all
+behind the landed `/api/v1/llm/call` boundary (32-5) so the engine step still never calls a provider:
+(1) a first-class **`request_input` tool** executed server-side inside `InlineToolLoopRunner`;
+(2) **`IQuestionRouter`** routing by `kind` + context (orchestrator-fact → 32-7 panel → human);
+(3) **`QuestionRoutingPolicy`** keyed `(principal, role, action, kind)`, tenant→system→ERROR, whose
+**server-owned reversibility re-derivation** is the load-bearing security control (model can RAISE but
+never DOWNGRADE the human gate); (4) the **in-stream** fast path (TCS-signaled, `inStreamAnswerTimeout`,
+SSE heartbeats) for fact/panel answers; (5) the **durable human gate** —
+`WaitForAgentQuestionActivity` (modeled byte-for-byte on `EscalateToSeniorActivity`) +
+`POST /api/v1/agents/questions/{correlationId}/answer` → `SendSignalAsync` resume → a **stateless
+re-invoke** of `/llm/call` with the human answer re-primed as the `request_input` tool result.
+
+**Story file:** `docs/stories/epic-32/story-32-20/32-20-interactive-question-back.md`
+**Design spec:** `docs/superpowers/specs/2026-06-20-managed-llm-execution-deep-dive.md` (§5 — source of record; §6 item 5; §7 open decisions 5/6/7)
+**Companion design:** `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§2 the call-LLM endpoint)
+
+**Tech stack:** .NET 9 / Elsa 3 in `apps/tamma-elsa` (`Tamma.Api` + `Tamma.Activities` + `Tamma.ElsaServer`).
+Tests in `apps/tamma-elsa/tests/Tamma.Api.Tests/` and `tests/Tamma.Activities.Tests/` (xUnit).
+Docker-bound suites run via `sg docker -c "dotnet test ..."` (session docker group is stale; plain
+`dotnet build` needs no wrapper). **`packages/api` is DELETED — all of this is C#.**
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO change to the call-LLM endpoint mechanics, the tool loop, the resilience relocation, or the
+  thin-client cutover** — that is **32-5**. This story adds a tool + a router + a wait-activity *on top
+  of* the landed endpoint and extends `LlmCallResponse` with one new `failureCode` (`INPUT_REQUIRED`).
+- **NO new panel primitives.** `judgment` answers go to **32-7**'s `RunAgentPanelActivity` +
+  `AggregatePanelActivity`; `PanelAnswerResolver` *adapts* to them, it does not reimplement them.
+- **NO new durable-suspend machinery.** `WaitForAgentQuestionActivity` is a byte-for-byte structural
+  clone of `EscalateToSeniorActivity` (`CreateBookmark` + `OnResumeAsync` + `AutoBurn`). The resume is
+  `ElsaWorkflowService.SendSignalAsync`. The in-stream wait reuses `WebhookSignalRegistry`'s TCS model.
+- **NO SSE frames / live `IToolLoopEventSink` / run tap** — the **"Streaming run tap"** follow-on owns
+  the `question`/`answer` SSE frames. This story reuses only the buffered path's heartbeat seam to hold
+  the in-stream wait.
+- **NO new control-plane table.** The routing policy follows the prompt-override pattern (tenant- or
+  user-keyed in the appropriate store); the action trail is tenant-schema-resident. → no `Program.cs`
+  DROP-list entry, no `ControlPlaneDbContextModelTests` edit. (Re-confirm if a future revision persists
+  policy as a CP entity.)
+- **NO markup / invoicing.** Panel-answer cost is the raw provider cost basis (32-9/34-5 consume it);
+  budgeting attribution is an explicit open decision, not resolved here.
+- **NO fuller blast-radius/ADL model.** Ship only the minimal server-owned reversibility derivation the
+  security control needs; a richer model is an ADL concern.
+
+---
+
+## Current-state findings (verified 2026-06-21, worktree @ epic32-specs)
+
+| Seam | Where it is today | How 32-20 uses it |
+|---|---|---|
+| **Tool loop** | `Tamma.Activities/LlmCall/InlineToolLoopRunner.cs` (extracted by 32-5; runs **inside `Tamma.Api`**). 6 built-in tools; no `ask_user`. | Register `RequestInputTool` in the same `IToolExecutorRegistry`; execute it server-side; append the answer as a tool-result message → model resumes (validate→execute→append). |
+| **Managed run** | `Tamma.Api/Services/Agents/ManagedAgent.cs` (32-5) composes gate→resolve→cred→render→loop→meter. | Wire `IQuestionRouter` into the loop; on a human-gate resolution, end the turn with `INPUT_REQUIRED`. |
+| **Fail-closed envelope** | `Tamma.Api/Services/Agents/LlmCallResponse.cs` (32-5): `success:false` + `failureCode` + preserved `httpStatusCode`. | Add a distinct `INPUT_REQUIRED` code + a key-free `question` payload (NO `httpStatusCode` — it must not be retried as a provider failure). |
+| **Durable human gate** | `Tamma.Activities/Blocker/EscalateToSeniorActivity.cs` — `CreateBookmark(BookmarkName, Callback=OnResumeAsync, AutoBurn=true)`, notify, suspend, resume on signal. | `WaitForAgentQuestionActivity` is its structural clone with bookmark `agent-question-{correlationId}`. |
+| **Fast in-process signal** | `WebhookSignalRegistry` (TCS wakeups for inbound webhook → bookmark). | The in-stream wait for fact/panel answers (TCS), bounded by `inStreamAnswerTimeout`. |
+| **Panel answerer** | `Tamma.Activities/AgentDispatch/RunAgentPanelActivity.cs` + `AggregatePanelActivity.cs` (32-7), tenant-scoped, budget-clamped, SaaS-gated per member. | `PanelAnswerResolver` adapts a `judgment` question to a panel run. |
+| **Resume mechanism** | `ElsaWorkflowService.SendSignalAsync(signalName, payload)`. | The answer endpoint resumes `agent-question-{correlationId}`. |
+| **Tenant trail** | `Tamma.Data/Repositories/IEventRepository.cs` — `AppendAsync(DomainEvent)`, tenant-scoped (32-6). | Emit `AGENT.QUESTION.RAISED/ANSWERED/ASSUMED/ROUTE_DENIED` from `Tamma.Api`; rehydration substrate keyed by `correlationId`. |
+| **Policy resolution discipline** | Epic 27 prompt store — tenant→system→ERROR, never empty/plain (`feedback_resolution_no_empty_fallback`). | `QuestionRoutingPolicyResolver` reuses the exact discipline, keyed `(principal, role, action, kind)`. |
+| **Mode** | `Tamma.Api/Services/PromptStore/TammaMode.cs` — `ITammaModeProvider` (SingleUser \| SaaS). | Policy keyed by `UserId` (single-user) / `TenantId` (SaaS); answerer auth by mode. |
+
+**Key insight:** the only genuinely new behaviour is (a) the `request_input` *tool*, (b) the *router +
+policy + reversibility classifier* triad (the security core), and (c) the *durable wait + answer
+endpoint + stateless re-invoke*. Everything else — the bookmark suspend, the TCS signal, the panel run,
+the trail append, the tenant→system→error policy resolution — is wiring **existing** patterns.
+
+---
+
+## Architecture
+
+```
+InlineToolLoopRunner (inside Tamma.Api, 32-5)
+   │  model emits tool call: request_input { question, kind, blocking, default_assumption, confidence }
+   ▼
+RequestInputTool.ExecuteAsync          -- server-side; NEVER calls a provider
+   │
+   ▼
+IQuestionRouter.RouteAsync(q, ctx)
+   0. policy   = QuestionRoutingPolicyResolver.Resolve(principal, role, action, kind)   tenant→system→ERROR (fail-loud)
+   1. radius   = ReversibilityClassifier.Classify(ctx.PendingAction)   ── SERVER-OWNED (model never feeds it)
+   2. gate     = radius.Irreversible || policy.RequiresHuman(kind, autonomy)   ── re-derive (MAX of hint, blast radius)
+        gate ──► QuestionRouting.Human(q)                              [model can RAISE, never DOWNGRADE]  (AC4)
+   3. !blocking && default_assumption && policy.AllowsAssumption ──► Assumed(default_assumption)  (AC5, AGENT.QUESTION.ASSUMED)
+   4. by kind (escalating cost/latency):
+        fact      ─► OrchestratorFactResolver   (workflow vars + Epic-27 conventions + issue/PR ctx; zero LLM/human)  in-stream
+        decision  ─► policy.TryDecide ?? PanelAnswerResolver                                                          in-stream
+        judgment  ─► PanelAnswerResolver  ─► RunAgentPanelActivity + AggregatePanelActivity (32-7)   in-stream / short signal
+        approval  ─► Human (already caught by gate)
+   5. in-stream answers bounded by inStreamAnswerTimeout (~90s, tenant-tunable, TCS-signaled, SSE heartbeats);
+        timeout ─► escalate (default: human gate for judgment)   (AC6/AC11)
+   ▼
+ ┌─ InStreamAnswer / Assumed ─► ToolResult.Text(answer) ─► appended as tool-result ─► model resumes      (fast path)
+ └─ HumanGate ─► turn ends ─► LlmCallResponse{ success:false, failureCode:"INPUT_REQUIRED", question, usage }   (slow path)
+                                   │
+                                   ▼  thin CallLlmInlineActivity: do NOT retry — route the WORKFLOW:
+                              WaitForAgentQuestionActivity   (notify human + CreateBookmark "agent-question-{correlationId}" + suspend)
+                                   │  …hours–days…
+                                   ▼  POST /api/v1/agents/questions/{correlationId}/answer { answer, answeredBy }
+                              authorize answerer ─► ElsaWorkflowService.SendSignalAsync("agent-question-{correlationId}", …)
+                                   │
+                                   ▼  workflow resumes ─► re-invoke /llm/call with prior messages + human answer
+                                      re-primed as the request_input tool result   (endpoint STATELESS across the gap; AC9)
+```
+
+Per-mode ownership (CLAUDE.md two-scoping-model): single-user = sole user is principal, owns the
+policy, answers human gates, runs the panel locally; SaaS = tenant is principal, `tenant_owner`/
+`tenant_admin` own the policy + elevated answers, panel members SaaS-gated/budget-clamped, events in the
+tenant `t_<hex>` store, never cross-tenant. Mode from `ITammaModeProvider`.
+
+---
+
+## Task breakdown
+
+Order: **T1 (records + event types) → T2 (`request_input` tool + parse) → T3 (reversibility classifier
++ the security test FIRST) → T4 (policy resolver) → T5 (router) → T6 (in-stream fast path:
+orchestrator-fact + panel) → T7 (human gate: response envelope + `WaitForAgentQuestionActivity` + answer
+endpoint + stateless re-invoke) → T8 (audit events) → T9 (mode/RBAC + isolation + wiring)**. T1∥T2 are
+parallel-safe; T3 must precede T5 (the router consumes the classifier and the security test is its
+acceptance gate).
+
+### T1 — Records + event-type constants
+
+**Scope:** the data shapes; no behaviour.
+**Files (new):** `Services/Agents/Questions/RaisedQuestion.cs`
+(`{ Question, Kind(fact|decision|judgment|approval), Options?, Schema?, Blocking, DefaultAssumption?, Confidence }`
++ `Parse(args)` with schema validation), `QuestionRouting.cs`
+(`{ Answerer(orchestrator|panel|human), Mechanism, Resolution: InStreamAnswer|Assumed|HumanGate }`),
+`AgentQuestionEventTypes.cs` (`AGENT.QUESTION.RAISED/ANSWERED/ASSUMED/ROUTE_DENIED`).
+**Tests (first):** `RaisedQuestionTests` — `Parse` rejects an unknown `kind`, enforces
+`options`/`schema` shape, defaults `blocking` per the schema, `confidence ∈ [0,1]`.
+**Acceptance:** records build clean; `Parse` is total (bad args → typed parse error, never a silent default).
+
+### T2 — The `request_input` tool (server-side executor)
+
+**Scope:** `RequestInputTool : IToolExecutor` registered in the 32-5 `IToolExecutorRegistry` catalog.
+Parses args → calls `IQuestionRouter` (fake until T5) → returns `ToolResult.Text` (in-stream/assumed) or
+signals a human gate (`ToolResult.Suspend`/a typed bubble-up the runner maps to `INPUT_REQUIRED`).
+**Files:** new `Services/Agents/Questions/RequestInputTool.cs`; modify
+`Tamma.Activities/LlmCall/InlineToolLoopRunner.cs` (execute `request_input`; append the tool-result so
+the model resumes; on a human-gate result, end the turn cleanly so `ManagedAgent` emits `INPUT_REQUIRED`).
+**Tests (first):** `RequestInputToolTests` — a `request_input` call returns a tool-result message and
+the runner appends it (model resumes one extra turn); a human-gate result ends the turn without calling
+the provider again; `grep` confirms one registration (no fork of the tool catalog).
+**Acceptance:** the tool round-trips as a tool-result; the runner never calls a provider for the tool;
+`enableToolLoop` runs gain it only when the agent's allowed-tool set (32-2) includes it.
+
+### T3 — Reversibility classifier + the LOAD-BEARING security test (written FIRST)
+
+**Scope:** `IReversibilityClassifier.Classify(pendingAction) -> BlastRadius { Irreversible, Class }`,
+server-owned (the model never feeds it). Minimal mapping: `merge`/`deploy`/`spend`/`schema` → irreversible;
+everything else → reversible. This is the single load-bearing control.
+**Files:** new `Services/Agents/Questions/IReversibilityClassifier.cs`, `ReversibilityClassifier.cs`.
+**Tests (FIRST — the security acceptance gate):** `ReversibilitySecurityTests` —
+- `RaisedQuestion{ kind="fact", blocking=false }` + `PendingAction=Merge` ⇒ classifier reports
+  irreversible (and, once T5 lands, the router routes to **human**, never in-stream/assume);
+- repeat for `deploy`/`spend`/`schema`;
+- a reversible action with `kind="approval"` may still be human-gated by policy (model can RAISE), but a
+  reversible action with `kind="fact"` is **not** force-gated by the classifier.
+**Acceptance:** the classifier is pure + deterministic; the security test compiles and asserts the
+irreversible set (it goes green end-to-end after T5 wires it into the router).
+
+### T4 — `QuestionRoutingPolicy` resolver (tenant→system→ERROR)
+
+**Scope:** `IQuestionRoutingPolicyResolver.ResolveAsync(principal, role, action, kind) -> RoutingPolicy`
+with `{ RequiresHuman(kind, autonomy), AllowsAssumption(radius, autonomy, budget), TryDecide(q) }`.
+Resolution order **tenant→system→ERROR**, never empty/plain. Keyed `(principal, role, action, kind)`;
+`UserId` in single-user, `TenantId` in SaaS (XOR/index discipline like `prompt_overrides`).
+**Files:** new `Services/Agents/Questions/IQuestionRoutingPolicyResolver.cs`,
+`QuestionRoutingPolicyResolver.cs`.
+**Tests (first):** `QuestionRoutingPolicyResolverTests` — tenant override beats system default; system
+default beats absence; **no policy ⇒ throws/route-denied (no empty fallback)**; single-user keyed by
+`UserId`, SaaS by `TenantId`.
+**Acceptance:** fail-loud-never-empty; correct key per mode.
+
+### T5 — `IQuestionRouter` (composition + the kind-map + the gate re-derivation)
+
+**Scope:** `QuestionRouter.RouteAsync` composes: resolve policy (T4) → classify reversibility (T3) →
+**gate = MAX(model hint, blast radius)** (human always wins) → non-blocking auto-answer (AC5) → kind-map
+(fact/decision/judgment/approval) → bound in-stream by `inStreamAnswerTimeout`. The T3 security test
+goes **green** here.
+**Files:** new `Services/Agents/Questions/IQuestionRouter.cs`, `QuestionRouter.cs`.
+**Collaborators (injected, fakes in tests):** `IQuestionRoutingPolicyResolver` (T4),
+`IReversibilityClassifier` (T3), `OrchestratorFactResolver` (T6), `PanelAnswerResolver` (T6),
+`IEventRepository` (T8), `ITammaModeProvider`, `ILogger<QuestionRouter>`.
+**Tests (first):** `QuestionRouterTests` — each `kind` → its answerer once; `decision` with closed
+options+default → policy-then-panel; **adversarial `kind="fact"`-on-irreversible ⇒ human** (the T3 test,
+now end-to-end); `blocking:false`+reversible ⇒ `Assumed`; `blocking:false`+irreversible ⇒ ignored +
+human-gated; no-policy ⇒ `ROUTE_DENIED`.
+**Acceptance:** the gate re-derivation holds (model can RAISE, never DOWNGRADE); every question resolves
+to exactly one terminal outcome.
+
+### T6 — In-stream fast path: orchestrator-fact + panel answerers
+
+**Scope:** `OrchestratorFactResolver` (synchronous lookup over workflow vars + Epic-27 conventions +
+issue/PR context — zero LLM/human) and `PanelAnswerResolver` (adapts a `judgment`/`decision` question to
+a 32-7 `RunAgentPanelActivity` + `AggregatePanelActivity` run, tenant-scoped + budget-clamped). Both
+resolve **inside** the same `/llm/call` invocation, bounded by `inStreamAnswerTimeout` (~90s,
+tenant-tunable), TCS-signaled (reusing the `WebhookSignalRegistry` model), with SSE heartbeats holding
+the connection. On timeout → escalate (default: human gate for `judgment`).
+**Files:** new `Services/Agents/Questions/OrchestratorFactResolver.cs`, `PanelAnswerResolver.cs`.
+**Tests (first):** fact answered from workflow vars/conventions with no LLM call; a panel answer
+resolves within the timeout (fake panel) and is returned as a tool-result; a timeout escalates per the
+configured default; the timeout value is read per-tenant.
+**Acceptance:** fast answers never leave the stream; the timeout is tenant-tunable; panel cost is
+attributed to the asking agent's budget (open decision tagged distinctly for 32-9/34-5).
+
+### T7 — The durable human gate (envelope + wait-activity + answer endpoint + stateless re-invoke)
+
+**Scope:**
+1. **Response envelope (AC7):** extend `LlmCallResponse` (32-5) with `failureCode="INPUT_REQUIRED"` + a
+   key-free `question` payload + accrued `usage`, **no `httpStatusCode`** (so it is NOT retried as a
+   provider failure). `ManagedAgent` emits it on a human-gate resolution.
+2. **`WaitForAgentQuestionActivity` (AC7):** a structural clone of `EscalateToSeniorActivity` —
+   `NotifyHuman(...)` (same channel/integration) then
+   `CreateBookmark(new CreateBookmarkArgs { BookmarkName = $"agent-question-{correlationId}",
+   Callback = OnResumeAsync, AutoBurn = true })`; `OnResumeAsync` reads `Answer`/`AnsweredBy` from
+   `WorkflowInput` and `CompleteActivityAsync()`.
+3. **Thin-step routing (AC7):** `CallLlmInlineActivity` (32-5 shim) detects `INPUT_REQUIRED` and routes
+   the **workflow** to `WaitForAgentQuestionActivity` (does NOT advance the provider chain / retry).
+4. **Answer endpoint (AC8):** `POST /api/v1/agents/questions/{correlationId}/answer { answer, answeredBy }`
+   → `IAgentQuestionAuthorizer` (tenant member; elevated where the action demands; **never cross-tenant /
+   platform-admin for another tenant's run**) → `ElsaWorkflowService.SendSignalAsync("agent-question-{correlationId}", …)`.
+5. **Stateless re-invoke (AC9):** on resume, the workflow re-invokes `/llm/call` with the prior messages
+   + the human answer **re-primed as the `request_input` tool result**. The endpoint holds no per-run
+   state across the gap; the conversation is rehydrated from the request or the action trail (32-6) by
+   `correlationId` (leaning action-trail — open decision).
+**Files:** modify `LlmCallResponse.cs`, `ManagedAgent.cs`, `CallLlmInlineActivity.cs`; new
+`Tamma.Activities/AgentDispatch/WaitForAgentQuestionActivity.cs`,
+`Tamma.Api/Endpoints/AgentQuestionEndpoints.cs` (+ `IAgentQuestionAuthorizer`).
+**Tests (first):** human routing ⇒ `success:false`/`INPUT_REQUIRED` + question + accrued usage; the step
+does NOT retry; `WaitForAgentQuestionActivity` creates `agent-question-{correlationId}` and suspends
+(survives a host restart in an Elsa integration test); the answer endpoint authorizes (cross-tenant →
+403/404), resumes, and the re-invoke carries the answer re-primed as the tool result; the endpoint holds
+no state across the gap.
+**Acceptance:** the durable wait lives in the **workflow** (bookmark), never an HTTP connection; resume +
+re-prime work end-to-end; cross-tenant answer is rejected.
+
+### T8 — Audit events (from the API, tenant-scoped)
+
+**Scope:** emit, via the tenant `IEventRepository` (32-6, never CP): `AGENT.QUESTION.RAISED` (per ask,
+records the model's untrusted `kind`/`blocking`/`confidence`); exactly one `AGENT.QUESTION.ANSWERED` per
+resolved question, **tagged `answerer ∈ {orchestrator, panel, human}`** (+ `latencyMs`, `routingReason`,
+server `blastRadius`); `AGENT.QUESTION.ASSUMED` for the AC5 path; `AGENT.QUESTION.ROUTE_DENIED` for no-policy.
+All payloads **key-free**.
+**Tests (first):** exactly one RAISED per ask; exactly one ANSWERED per resolved question with the right
+`answerer`; ASSUMED on the non-blocking-reversible path; ROUTE_DENIED on no-policy; events tenant-scoped
+(`TenantId` set, never CP); **no key in any payload**.
+**Acceptance:** the RAISED↔(ANSWERED|ASSUMED|ROUTE_DENIED) invariant holds; tenant isolation holds.
+
+### T9 — Mode separation, RBAC posture, isolation & DI wiring
+
+**Scope:** prove single-user (sole user owns policy + answers) vs SaaS (tenant policy,
+`tenant_owner`/`tenant_admin` elevated answers, members can't edit policy, panel SaaS-gated); prove
+`AGENT.QUESTION.*` land in the resolving tenant's store and never cross-tenant; register all services +
+the answer endpoint + `RequestInputTool` in the catalog at host startup.
+**Files:** modify `Tamma.Api/Program.cs` (map endpoint; register router/policy/classifier/resolvers +
+`RequestInputTool`); extend the router/policy tests with the mode matrix + a 2-tenant isolation test.
+**Tests (first):** SaaS member cannot edit the policy (403); cross-tenant answer rejected; two tenants'
+`AGENT.QUESTION.*` events carry their own `TenantId`; DI resolves the whole chain
+(`WebApplicationFactory` smoke).
+**Acceptance:** mode matrix passes; cross-tenant isolation holds; host boots with everything registered.
+
+---
+
+## Story order & dependencies
+
+External prereqs (must land first): **32-5** (the call-LLM endpoint + `InlineToolLoopRunner` +
+`ManagedAgent` + `LlmCallResponse` + the thin `CallLlmInlineActivity`) and **32-7** (the panel
+primitives — the `judgment` answerer). Code to the **32-6** trail interface (`IEventRepository`).
+Use fakes for 32-5/32-7/32-6 until landed. Internal: T1∥T2 → T3 (security test first) → T4 → T5 →
+T6 → T7 → T8 → T9. Downstream consumers (32-9 cost, the streaming run tap, 32-8 outcome) depend on this;
+they are NOT blockers.
+
+## Verification
+
+```bash
+# build (no docker wrapper needed)
+dotnet build apps/tamma-elsa/Tamma.sln
+# tests (docker-bound suites need the sg wrapper; session docker group is stale)
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~Questions"
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Activities.Tests/ --filter FullyQualifiedName~AgentDispatch|FullyQualifiedName~LlmCall"
+# the load-bearing security gate (must be GREEN before merge)
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~ReversibilitySecurity"
+# no-fork / no-key-leak checks
+grep -rn "class RequestInputTool\|\"request_input\"" apps/tamma-elsa/src        # one tool registration
+grep -rn "Anthropic:ApiKey\|ApiKey" apps/tamma-elsa/src/Tamma.Api/Services/Agents/Questions  # zero — key-free by contract
+```
+
+## Risks
+
+- **Security downgrade (T3/T5, AC4) — Critical:** an adversarial model tags a merge-approval as `fact`
+  to dodge the human gate. Mitigation: the server **re-derives** the gate from server-owned reversibility;
+  routing is `MAX(model hint, blast radius)`; the security test is written FIRST and is a merge gate.
+- **Lost/stalled question (T5/T8) — High:** a question raised but never resolved. Mitigation: every
+  `request_input` resolves to exactly one of {in-stream, assumed, human-gate, route-denied}; the
+  RAISED↔terminal invariant test.
+- **`INPUT_REQUIRED` retried as a provider failure (T7, AC7) — High:** the workflow retries instead of
+  pausing. Mitigation: `INPUT_REQUIRED` is a **distinct** code with **no `httpStatusCode`**; the thin step
+  routes to `WaitForAgentQuestionActivity`, never the provider chain; explicit test.
+- **State leak across the human gap (T7, AC9) — High:** a sticky/stale server session breaks isolation.
+  Mitigation: endpoint **stateless across the gap**; rehydrate from the action trail (32-6) by
+  `correlationId`; only durable state is the Elsa bookmark; restart-survival integration test.
+- **In-stream wait blocks a worker (T6, AC6) — High:** Mitigation: `inStreamAnswerTimeout` (~90s,
+  tenant-tunable) + heartbeats; only fast answers wait in-stream; timeout → human gate.
+- **`blocking:false` waives a human gate (T5, AC5) — High:** Mitigation: a non-blocking hint cannot waive
+  a gate — when the policy forbids assumption (irreversible/out-of-autonomy), `blocking:false` is ignored
+  and the question is human-gated; explicit test.
+- **Empty-policy silent routing (T4, AC3) — Medium:** Mitigation: tenant→system→**ERROR**
+  (`feedback_resolution_no_empty_fallback`); `ROUTE_DENIED` on no-policy.
+- **Panel-answer cost mis-attribution (T6, AC11.3) — Medium:** Mitigation: open decision documented;
+  attribute to the asking agent's budget for now, tag the panel sub-run distinctly so 32-9/34-5 can split.
+- **Dependency timing (32-5/32-7) — Medium:** Mitigation: interfaces + fakes; this story is the
+  integrator, gated behind them.
+
+## Open decisions (deep-dive §7 — surfaced, not pre-decided)
+
+1. **In-stream timeout → escalation for `judgment` (§7 #5):** human bookmark vs proceed-on-assumption vs
+   fail-the-turn. **Default chosen:** escalate to the human gate (tenant-configurable) — conservative vs
+   the 70% autonomy target.
+2. **Conversation-state rehydration across the human gap (§7 #6):** workflow variable vs action-trail
+   (32-6) keyed by `correlationId`. **Leaning:** action-trail.
+3. **`request_input` budgeting (§7 #7):** panel-answer tokens charged to the asking agent's budget vs a
+   separate "clarification" line (affects 32-9/34-5). **Until decided:** asking-agent budget, panel
+   sub-run tagged distinctly.

--- a/docs/superpowers/plans/2026-06-21-32-21-mcp-and-plugin-tool-sourcing-plan.md
+++ b/docs/superpowers/plans/2026-06-21-32-21-mcp-and-plugin-tool-sourcing-plan.md
@@ -1,0 +1,201 @@
+# Story 32-21 — MCP & Plugin Tool Sourcing (C#) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation.
+
+**Date:** 2026-06-21
+
+**Goal:** Source **MCP-server tools** and **plugin tools** into the C# managed-run tool catalog so the
+32-5 `InlineToolLoopRunner` can use them, with the catalog = **built-in executors ∪ enabled-MCP-server
+tools ∪ enabled-plugin tools** behind the **single** `IToolExecutorRegistry.GetAllowed(allowlist)`
+seam, intersected with the agent's allowed-tool set (32-2/32-18), every invocation routed through the
+existing `ToolHookRegistry`/`IContentSanitizer`/`RedactSecrets` path. Per-tenant MCP-server config +
+credentials (Epic 29 cabinet, by reference) are **enablement-gated** by this story's OWN
+`McpServerEnablement` entity + `IMcpServerEnablementReader` keyed by `McpServerId` (mirrors the 32-16
+PATTERN, SEPARATE entity — NOT the agent reader). The engine holds no key, runs no tool, and opens no
+MCP socket — all of it lives in `Tamma.Api`.
+
+**Story file:** `docs/stories/epic-32/story-32-21/32-21-mcp-and-plugin-tool-sourcing.md`
+**Design specs:** `docs/superpowers/specs/2026-06-20-managed-llm-execution-deep-dive.md` (§4, §6 item 2, §7.3),
+`docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§1, §2.6 step 5)
+
+**Tech stack:** .NET 9 / Elsa 3 in `apps/tamma-elsa` (`Tamma.Api` + `Tamma.Activities` + `Tamma.Data`).
+Tests in `apps/tamma-elsa/tests/Tamma.Api.Tests/` (xUnit). Docker-bound suites run via
+`sg docker -c "dotnet test ..."` (session docker group is stale; plain `dotnet build` needs no wrapper).
+**All C# — there is no TypeScript execution path** (`packages/api` is deleted; `packages/mcp-client` is a
+**behavioural reference** only, not a runtime dependency).
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO change to the runner / endpoint / resilience (32-5).** This plan plugs a wider catalog into the
+  **unchanged** `IToolExecutorRegistry` seam the runner already calls. It does not touch the endpoint,
+  the credential resolver, metering, retry, or the thin-client cutover.
+- **NO second tool-loop / sanitizer / validator.** Reuse the runner's existing
+  `ToolHookRegistry`/`IContentSanitizer`/`RedactSecrets` path; MCP/plugin executors return raw content
+  and the runner sanitizes — exactly like built-in executors.
+- **NO MCP resources or prompts.** This story sources **tools** only. MCP resources (RAG) are Epic 6;
+  MCP prompts are out of scope (prompts come from Epic 27).
+- **NO cabinet storage/rotation.** Epic 29 owns the cabinet; this story **reads** credentials by
+  reference via `IRuntimeSecretResolver`.
+- **NO streaming of MCP tool progress.** Buffered results only; live streaming is the "Streaming run
+  tap" follow-on.
+- **NO new control-plane table by default.** MCP config + enablement are tenant-schema. Only if a
+  reviewer mandates CP-residency do the DROP-list + `ControlPlaneDbContextModelTests` edits apply.
+
+---
+
+## Current-state findings (verified 2026-06-21, worktree @ epic32-specs)
+
+| Seam | Where it is today | How 32-21 uses it |
+|---|---|---|
+| **Tool registry seam** | `Tamma.Activities/LlmCall/Tools/IToolExecutorRegistry.cs` — `GetExecutor`/`IsAllowed`/`GetAll`/`GetAllowed(string[]?)`. Built-in impl `ToolExecutorRegistry.cs` (six executors). | `ICompositeToolCatalog : IToolExecutorRegistry` wraps built-in ∪ MCP ∪ plugin; runner's `GetAllowed` call site unchanged. |
+| **Tool loop / sanitization** | 32-5 `InlineToolLoopRunner` (extracted from `CallLlmInlineActivity.AgenticToolLoop`) — `ToolHookRegistry` + `IContentSanitizer` (`Tamma.Activities/Security/IContentSanitizer.cs`) + `RedactSecrets`. | Unchanged chokepoint; MCP/plugin tool outputs traverse it identically. |
+| **Per-tenant enablement** | 32-16 `ITenantAgentEnablementReader.IsEnabledForPrincipalAsync(agentId, principal, ct)` (catalog membership, principal-XOR, `UNIQUE NULLS NOT DISTINCT`; CP-resident, keyed by `AgentId`). | Mirror the **PATTERN** in an OWN tenant-schema `McpServerEnablement` entity + `IMcpServerEnablementReader` keyed by `McpServerId` — SEPARATE entity (different schema residency + target id), NOT the agent reader. |
+| **Cabinet secret read** | Epic 29 `IRuntimeSecretResolver` (`Tamma.Api/Services/Secrets/Stopgap/IRuntimeSecretResolver.cs`) — `GetAsync(ref)`. | Read MCP credential by reference at connect; request-scoped, never logged/returned. |
+| **Agent allowed-tool set** | 32-2/32-18 resolver → `ResolvedAgentConfig { … AllowedTools }`. | The union catalog is intersected with this. |
+| **TS MCP client (reference)** | `packages/mcp-client/` — `client.ts`, `ConnectionPool`/`HealthChecker`, transports `stdio/sse/websocket`, `registry.ts`, `security/{validator,rate-limiter}.ts`, `cache/*`, `audit.ts`. | Behavioural reference for the C# pool/transports/validators/rate-limiter/cache we re-implement on top of the .NET MCP SDK. |
+| **C# MCP gap** | `ProviderSession.cs:87` "MCP transport not yet ported." | Closed by this story. |
+| **Mode** | `ITammaModeProvider` (`TammaMode.cs`), process-stable. | Drives principal keying (UserId vs TenantId) for config/enablement. |
+
+**Pre-work (do before Phase 1):** research the current `ModelContextProtocol` .NET SDK (package name,
+version, transport coverage stdio/http-sse/websocket) via WebSearch/Context7 — **do not assume the API
+shape**. Confirm 32-5 / 32-16 / 32-2-18 / Epic-29 interfaces are landed (or stub against them with fakes).
+
+---
+
+## Phase 0 — Strategy spike + dependency confirmation
+
+- [ ] Confirm the recommended strategy (story §Strategy decision): **.NET MCP SDK behind `IMcpTransport`,
+      security layer kept in-house.** Validate the SDK covers `stdio` + `http/sse`; `websocket` optional.
+- [ ] If the SDK is insufficient for a required transport, fall back to a hand-rolled port of that single
+      transport (TS `transports/*` as reference) behind the same `IMcpTransport` seam — no catalog change.
+- [ ] Confirm 32-5's `IToolExecutorRegistry` seam + runner sanitization path; review 32-16's
+      enablement PATTERN (XOR/index/RBAC) as the shape to mirror in this story's OWN `McpServerEnablement`
+      entity (keyed by `McpServerId`); confirm Epic 29 `IRuntimeSecretResolver`.
+
+## Phase 1 — Transport + connection layer (`Tamma.Api/Services/Mcp/`)
+
+- [ ] **Test first:** `McpTransportTests` — `StdioMcpTransport` + `HttpSseMcpTransport` connect, list tools,
+      invoke a tool against a fake MCP server; `IMcpTransport` honoured.
+- [ ] `IMcpTransport` (connect / list-tools / invoke / dispose); `StdioMcpTransport` (local process),
+      `HttpSseMcpTransport` (remote endpoint). Inject credential at connect (header/env/arg per transport).
+- [ ] `IMcpConnectionPool` / `McpConnectionPool` + health check (mirror TS `ConnectionPool`/`HealthChecker`):
+      pooled, per-server connect/discovery **timeout**, fail-soft on connect error.
+- [ ] `McpServerRateLimiter` (mirror TS `RateLimiterRegistry`) — per-server rate limiting.
+- [ ] **Credential safety test:** no auth material logged/returned by transports or the pool.
+
+## Phase 2 — Per-tenant MCP-server config + enablement (`Tamma.Data` + endpoints)
+
+- [ ] **Test first:** `McpServerEndpointsTests` — CRUD (owner/admin create/update/delete; **member → 403**);
+      enable/disable via this story's OWN `McpServerEnablement` (keyed by `McpServerId`, mirrors the 32-16
+      PATTERN); literal-secret config **rejected** at write; cross-tenant isolation.
+- [ ] `McpServer` entity (`Tamma.Data/Entities/`) — **tenant-schema** (performance/config data is
+      tenant-scoped): `TenantId`/`UserId` principal-XOR, `Name`, `Transport`, `Command`/`Url` (no secret),
+      **`CredentialRef`** (cabinet reference — NEVER a literal secret), `ToolAllowPrefixes?`. EF config:
+      principal-XOR CHECK + `UNIQUE NULLS NOT DISTINCT (TenantId, UserId, Name)`, mirroring `AgentRoleSelection`.
+- [ ] `McpServerEnablement` — this story's **OWN** tenant-schema entity keyed by `McpServerId` (mirrors
+      the 32-16 `TenantAgentEnablement` PATTERN — principal-XOR CHECK + `UNIQUE NULLS NOT DISTINCT
+      (TenantId, UserId, McpServerId)` — but a SEPARATE entity, NOT `TenantAgentEnablement`). Expose an
+      OWN `IMcpServerEnablementReader.IsEnabledForPrincipalAsync(mcpServerId, principal, ct)` +
+      `McpServerEnablementService` (enable/disable). Do NOT consume `ITenantAgentEnablementReader` or key
+      on `AgentId`/`AgentSurfaceId`.
+- [ ] `McpServerEndpoints` — tenant-scoped CRUD + enable/disable (`tenant_owner`/`tenant_admin`; member 403,
+      read allowed). Write-time literal-secret rejection.
+- [ ] **DROP-list note:** tables are **tenant-schema** → NOT in `Program.cs` startup-reset DROP list, NO
+      `ControlPlaneDbContextModelTests` edit. (Only if reviewer mandates CP-residency: append to **both**.)
+- [ ] Extend the **single** EF migration snapshot (do not branch it) with the new tenant-schema tables.
+
+## Phase 3 — Tool sources + executors (`Tamma.Api/Services/Agents/Tools/`)
+
+- [ ] **Test first:** `McpToolSourceTests` — enabled servers → `IToolExecutor[]` (`mcp__<server>__<tool>`);
+      un-enabled server → **zero tools**; cabinet credential read via fake `IRuntimeSecretResolver`;
+      connect failure → zero tools + `MCP.SERVER.CONNECT.FAILED` + WARN, **run proceeds**; discovery cache
+      hit/invalidation.
+- [ ] `IMcpToolSource` / `McpToolSource` — flow: list tenant servers → filter by `IMcpServerEnablementReader.IsEnabledForPrincipalAsync(server.Id, principal, ct)` (OWN reader, keyed by `McpServerId`) → per server
+      (fail-soft, isolated): read cred by ref → pool-connect → list/cache tools → wrap as `McpToolExecutor`.
+- [ ] `McpToolExecutor : IToolExecutor` — invokes one MCP tool over the pooled transport, returns **raw**
+      content (the runner sanitizes). `IMcpToolDiscoveryCache` keyed `(tenantId, server, configHash)`, short
+      TTL, invalidated on config/enablement change.
+- [ ] `IPluginToolSource` / `PluginToolSource` + `PluginToolExecutor` — enabled plugins → `IToolExecutor[]`,
+      same enablement/hook/intersection path. (Plugin loading mechanism per Epic 9; stub if not landed.)
+
+## Phase 4 — Composite catalog + runner wiring
+
+- [ ] **Test first:** `CompositeToolCatalogTests` — union behind one `GetAllowed`; allowlist ∩ agent-allowed
+      intersection; unknown/un-enabled name → `null` executor (no silent built-in); `GetExecutor` resolves
+      MCP/plugin tools by name.
+- [ ] `ICompositeToolCatalog : IToolExecutorRegistry` / `CompositeToolCatalog` — assembled per run with
+      `ToolCatalogScope { TenantId, Principal, AgentAllowedTools, CorrelationId }`; `GetAllowed` =
+      (built-in ∪ enabled-MCP ∪ enabled-plugin) filtered by allowlist **and** intersected with
+      `AgentAllowedTools`.
+- [ ] `Program.cs` (API) — register `IMcpToolSource`/`IPluginToolSource`/`ICompositeToolCatalog` (scoped),
+      `IMcpConnectionPool`/`IMcpToolDiscoveryCache` (singleton); construct the 32-5 `InlineToolLoopRunner`
+      with `ICompositeToolCatalog` as its `IToolExecutorRegistry`; `app.MapMcpServerEndpoints()`. Engine
+      registers **nothing** MCP.
+
+## Phase 5 — Sanitization parity + events + isolation tests
+
+- [ ] **Sanitization parity (AC5):** golden-equality test — an MCP tool output with a secret + injection
+      pattern is sanitized + `RedactSecrets`'d **identically** to a built-in tool's same output; no path
+      bypasses `ToolHookRegistry`.
+- [ ] **Events (AC9):** `MCP.SERVER.REGISTERED/ENABLED/DISABLED/CONNECT.FAILED` + `AGENT.TOOL.SOURCED`
+      (builtIn/mcp/plugin counts) emitted from `Tamma.Api` via tenant `IEventRepository`, key-free, tagged.
+- [ ] **Engine-holds-nothing (AC7):** grep `Tamma.ElsaServer` → zero MCP transport/connection/credential
+      refs; composite + MCP types registered only in `Tamma.Api`.
+- [ ] **Cross-tenant isolation:** tenant A's MCP server never visible/usable in tenant B's run.
+- [ ] **Credential safety (AC3):** secret never in config rows, logs, tool results, or event payloads.
+
+## Phase 6 — Hardening + docs
+
+- [ ] Per-server connect/discovery timeouts tuned; rate-limit defaults sane; cache TTL/invalidation verified.
+- [ ] Mode-parameterized tests (single-user UserId-keyed vs SaaS TenantId-keyed) for config/enablement.
+- [ ] Update MCP setup docs (how a tenant registers an MCP server, sets a `CredentialRef`, enables it).
+- [ ] Final grep gates: one `GetAllowed` seam; zero engine MCP refs; zero secret in payloads.
+
+---
+
+## Test list (xUnit, `Tamma.Api.Tests`)
+
+1. `CompositeToolCatalogTests` — union behind one `GetAllowed`; allowlist ∩ agent-allowed; unknown → null.
+2. `McpToolSourceTests` — enabled→tools; un-enabled→zero; cabinet cred read; connect-fail fail-soft; cache.
+3. `McpTransportTests` — stdio + http/sse connect/list/invoke against a fake server; `IMcpTransport` honoured.
+4. `McpServerEndpointsTests` — CRUD owner/admin; member 403; literal-secret rejected; cross-tenant isolation.
+5. Sanitization-parity test — MCP output sanitized + redacted identically to built-in (golden equality).
+6. Engine-holds-nothing grep test — zero MCP transport/credential refs in `Tamma.ElsaServer`.
+7. Credential-safety test — secret absent from config/logs/results/events.
+8. Events test — `MCP.SERVER.*` + `AGENT.TOOL.SOURCED` emitted from API, key-free, tagged.
+9. Plugin-source test — enabled-plugin tools join the union + same hook/intersection path.
+10. Mode-parameterized config/enablement (single-user UserId vs SaaS TenantId).
+
+---
+
+## Risks (carried from the story)
+
+- **Tool bypasses sanitization** → MCP/plugin executors return raw content only; the runner is the single
+  sanitization chokepoint; golden-equality test vs built-in.
+- **Secret leak** → config by `CredentialRef` only; literal-secret writes rejected; request-scoped cabinet
+  read; safety test asserts absence everywhere.
+- **Engine opens a socket/key** → all MCP types in `Tamma.Api`; grep gate on `Tamma.ElsaServer`.
+- **Broken server fails the run** → fail-soft per-server isolation + timeout + WARN + `CONNECT.FAILED`.
+- **Un-enabled/disallowed tool reaches the model** → enablement gate ∧ allowlist ∧ agent-allowed; unknown
+  → null (no silent fallback, `feedback_resolution_no_empty_fallback`).
+- **.NET MCP SDK immature** → `IMcpTransport` seam isolates it; per-transport hand-port fallback.
+- **Mis-scoping config as CP** → default tenant-schema (no DROP-list/model-test churn); flagged in Dev Notes.
+- **EF parallel-migration hazard** → extend the single migration snapshot, never branch it.
+
+---
+
+## Definition of done
+
+- [ ] Managed-run catalog = built-in ∪ enabled-MCP ∪ enabled-plugin behind one `GetAllowed`, ∩ agent-allowed.
+- [ ] Per-tenant MCP-server config (cabinet creds by reference) enablement-gated by the OWN `McpServerEnablement` entity + `IMcpServerEnablementReader` keyed by `McpServerId` (mirrors the 32-16 PATTERN, SEPARATE entity); member 403.
+- [ ] Every MCP/plugin invocation traverses `ToolHookRegistry`/`IContentSanitizer`/`RedactSecrets`.
+- [ ] Engine holds no MCP socket/key (grep clean); all MCP lives in `Tamma.Api`.
+- [ ] Fail-soft per server; discovery cache; cross-tenant isolation; no secret in any payload.
+- [ ] Strategy decision implemented (.NET MCP SDK behind `IMcpTransport`); stdio + http/sse covered.
+- [ ] All Phase 1–6 tests green via `sg docker -c "dotnet test apps/tamma-elsa/..."`.
+- [ ] No `sprint-status.yaml` / git / build changes in this story's commits (controller owns those).

--- a/docs/superpowers/plans/2026-06-21-32-22-prompt-and-response-cache-plan.md
+++ b/docs/superpowers/plans/2026-06-21-32-22-prompt-and-response-cache-plan.md
@@ -1,0 +1,245 @@
+# Story 32-22 — Prompt + Response Cache (provider prompt cache + gated response cache)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation.
+
+**Date:** 2026-06-21
+
+**Goal:** Add two server-side cache layers inside the managed-LLM run built by 32-5, both composed in
+`Tamma.Api` so the engine sees an unchanged buffered request/response:
+1. **Provider prompt cache** — mark the stable prompt prefix (Epic-27 system prompt + persona/agent
+   config + RAG/conventions block) with Anthropic `cache_control: ephemeral`; parse the returned
+   `cache_creation_input_tokens`/`cache_read_input_tokens` and price them at 34-11's reserved
+   nullable `CacheReadUsdPer1M`/`CacheWriteUsdPer1M` columns.
+2. **Optional response cache** keyed `(tenantId, agentVersion, renderedPromptHash, model, toolset)`,
+   applied **strictly after** gate+budget so a hit still meters + audits (a `cache_hit` usage event),
+   never bypassing billing. Tool-loop runs are **not** cacheable (documented policy + predicate).
+
+Resolves the deep-dive **§7.4** open decision with recommended defaults: prompt cache ON for
+Anthropic; response cache OFF for tool-loop runs, ON for single-turn deterministic renders
+(`temperature<=0`), globally OFF until a tenant/operator opts in.
+
+**Story file:** `docs/stories/epic-32/story-32-22/32-22-prompt-and-response-cache.md`
+**Design specs:** `docs/superpowers/specs/2026-06-20-managed-llm-execution-deep-dive.md` (§4 cache,
+§6.3, §7.4) · `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§4 the
+Provider/`ProviderModelPrice` cost entity reserving the cache-rate columns)
+
+**Tech stack:** .NET 9 / Elsa 3 in `apps/tamma-elsa` (central API `Tamma.Api` + activities
+`Tamma.Activities` + engine `Tamma.ElsaServer`). Tests in `apps/tamma-elsa/tests/Tamma.Api.Tests/`
+and `apps/tamma-elsa/tests/Tamma.Activities.Tests/` (xUnit). Docker-bound suites run via
+`sg docker -c "dotnet test ..."` (session docker group is stale; plain `dotnet build` needs no
+wrapper). **`packages/api` is DELETED — all C#.**
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO distributed cache backend (Redis/etc.).** The response cache is a tenant-schema table
+  (`t_<hex>.agent_response_cache`) + an in-process LRU snapshot. A distributed backend is a later
+  optimization, not this story.
+- **NO semantic / embedding-similarity cache.** Exact `renderedPromptHash` match only.
+- **NO non-Anthropic prompt cache.** Provider prompt caching is Anthropic-specific; for every other
+  provider the prompt-cache layer is a no-op. (The response cache is provider-agnostic.)
+- **NO markup / billing decision.** Cache tokens feed the **provider cost basis** only
+  (`IProviderPricingService`); whether a `cache_hit` bills the tenant is 34-5/35. This story only
+  guarantees the hit is **recorded + audited**.
+- **NO change to 32-5's compose order, the `LlmCallRequest`/`LlmCallResponse` contract semantics, or
+  the `LlmCallWorkflow.cs` boundary.** This story is **additive**: a cache lookup spliced after
+  gate+budget, cache-token usage fields added to the meter + wire usage (defaulting to 0/false).
+- **NO new control-plane table.** The response cache is tenant-schema; the cache-rate columns belong
+  to 34-11's `ProviderModelPrice`. → no `Program.cs` DROP-list entry, no `ControlPlaneDbContextModelTests` edit.
+
+---
+
+## Prerequisites (must be landed first)
+
+- **32-5** — `ManagedAgent.RunAsync` (the compose order), `IInlineToolLoopRunner`/`InlineToolLoopResult`,
+  `LlmCallResponse`/`UsageDto`, the buffered request/response. **This story modifies these files.**
+- **34-11** — `ProviderModelPrice` with reserved nullable `CacheReadUsdPer1M`/`CacheWriteUsdPer1M`,
+  `DbProviderPricingService : IProviderPricingService` (`Compute`/`IsKnown`). **This story adds the
+  additive `ComputeWithCache` path.**
+- **32-9** — the usage emitter, extended here with cache-token splits + the `cache_hit` flavour.
+- **Epic 27** — the prompt store producing the cacheable stable prefix + the rendered prompt hashed
+  into the response-cache key.
+
+If any prerequisite isn't landed, code to its interface and gate behind it (use fakes in tests).
+
+---
+
+## Architecture (where the two layers splice in)
+
+```
+ManagedAgent.RunAsync (32-5 order — cache splices are additive):
+  1. gate (32-4)                                   unchanged
+  2. resolve agent + enablement (32-18/32-16)      unchanged
+  3. resolve credential BYOK->platform (32-3)      unchanged
+  4. render prompt (Epic 27)  + budget guard       unchanged
+  ── RESPONSE CACHE (Layer 2) splices in HERE: after gate+budget, before the call ──
+  4b. if ResponseCacheOptions.Enabled
+        && IResponseCacheabilityPolicy.IsCacheable(req, resolved):     # tool-loop => false
+          key = (tenantId, agentVersion, Sha256(renderedPrompt), model, sortedToolset)
+          if IResponseCache.TryGet(tenantId, key) => HIT:
+              emit metered cache_hit usage (32-9, providerCostUsd=0)   # still meters + audits
+              emit AGENT.RUN.SUCCESS { cacheHit:true }
+              return AgentRunResult.FromCache(hit)                     # provider NOT called
+  5. loop  IInlineToolLoopRunner (request-scoped key)                  # cache MISS -> live call
+     ── PROMPT CACHE (Layer 1) lives INSIDE the runner: Anthropic cache_control on the stable prefix;
+        parse cache_creation/cache_read usage -> InlineToolLoopResult.CacheWrite/ReadTokens
+  6. costBasis = IProviderPricingService.ComputeWithCache(..., cacheReadTokens, cacheWriteTokens)
+     emit usage (32-9) { CacheReadTokens, CacheWriteTokens, CacheHit=false }
+  7. if IsCacheable: IResponseCache.Set(tenantId, key, {text, usage}, Ttl)   # write-through, errors swallowed
+  8. emit AGENT.RUN.SUCCESS | FAILED
+  9. return AgentRunResult
+```
+
+**Layer 1 (prompt cache)** is inside `IInlineToolLoopRunner` (one place that builds the provider
+request). **Layer 2 (response cache)** is in `ManagedAgent.RunAsync` (the only place that owns
+gate+budget order). They share only the meter.
+
+---
+
+## Task breakdown
+
+### T1 — Prompt-cache prefix marking + usage parse in the runner (AC1–AC3) — TDD
+
+- [ ] **Test first** (`Tamma.Activities.Tests/LlmCall/PromptCachePrefixTests.cs`): a fake provider
+      transport captures the outgoing Anthropic request body; assert `cache_control:{type:ephemeral}`
+      is on the system-prompt block + the RAG/conventions block, **not** on the volatile user prompt;
+      assert a breakpoint at the stable/volatile boundary. Non-Anthropic provider → no `cache_control`.
+      `PromptCacheOptions.Enabled=false` → byte-for-byte the 32-5 baseline request.
+- [ ] **Test first**: a fake Anthropic response with `cache_creation_input_tokens=N`,
+      `cache_read_input_tokens=M` → `InlineToolLoopResult.CacheWriteTokens==N`, `CacheReadTokens==M`.
+- [ ] Add `PromptCacheOptions` (`Enabled` default true, `MinPrefixTokens` default 1024).
+- [ ] Modify `InlineToolLoopResult` to add `CacheReadTokens`/`CacheWriteTokens` (default 0).
+- [ ] In `InlineToolLoopRunner`: when alias-normalized provider == `anthropic` &&
+      `PromptCacheOptions.Enabled` && prefix estimate >= `MinPrefixTokens`, mark the stable-prefix
+      blocks `cache_control:ephemeral`; parse the cache-usage fields from the response.
+- [ ] **Research gate:** re-confirm the latest Anthropic prompt-cache API shape (field names, the
+      1024-token minimum, cache-write/cache-read pricing multipliers) against current Anthropic docs
+      before implementing — never from memory. Isolate the parse behind `PromptCacheOptions`.
+
+### T2 — Cache-aware cost path over 34-11's seam (AC3) — TDD
+
+- [ ] **Test first** (`Tamma.Api.Tests/Providers/CacheAwarePricingTests.cs`): seed a `ProviderModelPrice`
+      row with `CacheReadUsdPer1M`/`CacheWriteUsdPer1M` populated → `ComputeWithCache` prices cache
+      tokens at those rates additively over `Compute`; a row with **null** cache columns → cache
+      tokens add **zero** surcharge (reported, not priced), no throw; assert plain `Compute` output is
+      **unchanged** from 34-11.
+- [ ] Add `ComputeWithCache(provider, model?, inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens)`
+      to `DbProviderPricingService` (additive — `Compute` + null-safe cache surcharge). Keep the
+      `IProviderPricingService` interface stable; expose the cache path on the concrete impl (or a
+      sibling resolver) so downstream consumers are unaffected.
+
+### T3 — Response cache store + key + cacheability policy (AC4, AC7, AC8) — TDD
+
+- [ ] **Test first** (`Tamma.Api.Tests/Agents/ResponseCacheabilityPolicyTests.cs`): `enableToolLoop=true`
+      → not cacheable (reason "tool-loop"); `temperature>threshold` → not cacheable; opt-out → not
+      cacheable; `enableToolLoop=false, temperature=0` → cacheable; reasons returned + logged.
+- [ ] **Test first** (`Tamma.Api.Tests/Agents/ResponseCacheTests.cs`): `Set` then `TryGet` round-trips
+      `text`+`usage`; TTL expiry → miss; per-tenant isolation — same key tuple for tenant A and B,
+      A's entry never returned to B (separate `t_<hex>` schemas); `TryGet` on a missing key → miss.
+- [ ] Add `ResponseCacheKey` (record), `ResponseCacheabilityPolicy` (the predicate), `ResponseCacheOptions`
+      (`Enabled` default false, `Ttl` default 24h, `MaxEntriesPerTenant`, `DeterminismTemperatureThreshold` default 0).
+- [ ] Add `IResponseCache` + `ResponseCache` (tenant-schema `agent_response_cache` store + in-process
+      LRU snapshot, bounded per tenant, TTL-evicting).
+- [ ] **Tenant-schema migration** (`EfTenantDbMigrator`): `<timestamp>_AddAgentResponseCache.cs` creates
+      `t_<hex>.agent_response_cache` (`cache_key` PK, `agent_version`, `rendered_prompt_hash`, `model`,
+      `toolset`, `response_text`, `usage_json` JSONB, `created_at`, `expires_at` + an `expires_at` index).
+      **NOTE:** tenant-schema — does **NOT** go in `Program.cs`'s public-schema DROP list; does **NOT**
+      touch `ControlPlaneDbContextModelTests` (the `EfTenantDbMigrator` owns `t_<hex>` tables).
+
+### T4 — Splice the response cache into `ManagedAgent.RunAsync` (AC5, AC6, AC9, AC10) — TDD
+
+- [ ] **Test first** (`Tamma.Api.Tests/Agents/ManagedAgentCacheCompositionTests.cs`):
+      - **Hit after gate+budget:** seed an entry; a matching request → gate + budget evaluated, the
+        `IInlineToolLoopRunner` (spy) **never invoked**, a metered `cache_hit` usage event emitted
+        (`providerCostUsd=0`, tokens preserved), exactly one `AGENT.RUN.SUCCESS` (`cacheHit:true`).
+      - **Miss → live call → write-through:** no entry → runner invoked, cache-aware cost computed,
+        `cache_hit=false` usage emitted, `Set` called.
+      - **Not cacheable (tool-loop):** `enableToolLoop=true` → no lookup, no `Set`, live call.
+      - **Fail-open read error:** cache `TryGet` throws → falls through to a live metered call, WARN
+        logged; **gate/budget stay fail-closed** (an unevaluable budget still denies).
+      - **Write-through best-effort:** `Set` throws → run still returns its result; WARN logged.
+- [ ] Splice the lookup into `ManagedAgent.RunAsync` **after** gate(step 1) + budget(step 4), **before**
+      the runner. Compute `renderedPromptHash = Sha256(renderedPrompt)`; build `ResponseCacheKey`.
+- [ ] On a hit: emit the metered `cache_hit` usage event (32-9) + `AGENT.RUN.SUCCESS`; return
+      `AgentRunResult.FromCache(hit)`. On a miss: live run, then `ComputeWithCache`, emit usage with
+      cache tokens, write-through if cacheable.
+- [ ] Wire the meter to `ComputeWithCache` and pass `CacheReadTokens`/`CacheWriteTokens` to 32-9.
+
+### T5 — Additive wire/usage fields + DI registration (AC9) — TDD
+
+- [ ] **Test first**: `LlmCallResponse.usage` gains `cacheReadTokens`/`cacheWriteTokens`/`cacheHit`
+      defaulting to 0/0/false; a workflow ignoring them is unaffected; assert `LlmCallWorkflow.cs`
+      diff is empty (no engine change).
+- [ ] Add the three additive fields to `UsageDto`; project them from `AgentRunResult`.
+- [ ] `Program.cs` (`Tamma.Api`): register `IResponseCache`, `IResponseCacheabilityPolicy`; bind
+      `PromptCacheOptions`/`ResponseCacheOptions` (defaults: prompt ON, response OFF).
+
+### T6 — Credential safety + recommended-default verification (AC8, AC11) — TDD
+
+- [ ] **Test first**: assert no API key / `BaseUrl` auth / provider header appears in any cache entry,
+      the `usage_json` payload, any log line, or DCB event; assert the cache key/`rendered_prompt_hash`
+      is a **hash**, never the prompt plaintext.
+- [ ] **Test first**: defaults shipped match AC8 — `PromptCacheOptions.Enabled` true (Anthropic),
+      `ResponseCacheOptions.Enabled` false, tool-loop never cached, single-turn deterministic cacheable.
+- [ ] Audit logs: cache key components logged as **hash only**; cache hit logs `agentVersion`/`model`,
+      never the prompt plaintext.
+
+---
+
+## Test list (consolidated)
+
+1. Prompt-cache prefix marking — Anthropic stable prefix only / non-Anthropic no-op / disabled = baseline (T1).
+2. Cache-usage parse — `cache_creation`/`cache_read` → `InlineToolLoopResult` fields (T1).
+3. Cache-aware cost — priced at reserved columns / null-column zero surcharge / plain `Compute` unchanged (T2).
+4. Cacheability predicate — tool-loop / temperature / opt-out / single-turn-deterministic + reasons (T3).
+5. Response-cache round-trip + TTL expiry + **per-tenant isolation** (T3).
+6. Hit after gate+budget — runner not invoked, metered `cache_hit` usage + terminal DCB event (T4).
+7. Miss → live call → `ComputeWithCache` → write-through (T4).
+8. Fail-open on cache read error → live call; gate/budget stay fail-closed; write-through best-effort (T4, T10).
+9. Additive wire fields default 0/false; `LlmCallWorkflow.cs` diff empty (T5).
+10. Credential safety — no key/auth/header in cache/usage/log/event; key is a hash (T6).
+11. Recommended defaults shipped (T6).
+
+---
+
+## Verification
+
+- [ ] `sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests"` green.
+- [ ] `sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Activities.Tests"` green.
+- [ ] `dotnet build apps/tamma-elsa` clean (no wrapper needed for build).
+- [ ] `grep` confirms no API key / provider header is ever written to `agent_response_cache` or logged.
+- [ ] `grep` confirms the response cache is a tenant-schema table — **not** added to `Program.cs`'s
+      public-schema DROP list and **not** in `ControlPlaneDbContextModelTests`.
+- [ ] `LlmCallWorkflow.cs` diff is empty (engine untouched).
+- [ ] Plain `Compute` parity from 34-11 still holds (cache pricing is purely additive).
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| A cache hit silently bypasses billing/audit | Lookup is **strictly after** gate+budget; a hit emits a metered `cache_hit` usage + terminal DCB event; T4 asserts both fire (provider never called). |
+| Tool-loop run cached → replay skips side effects | `IResponseCacheabilityPolicy` returns false for `enableToolLoop==true`; response cache OFF for tool-loop by default; T3 predicate test. |
+| Cross-tenant cache leak | Key includes `TenantId`; the store IS the tenant schema; T3 isolation test. |
+| Stale cached answer after agent/prompt change | Key includes `agentVersion`+`renderedPromptHash`+`model`+`toolset` → any change is a miss; TTL bounds staleness; response cache defaults OFF. |
+| Cache-rate columns unseeded → mispriced | Null column → zero surcharge (reported, not priced); never overcharges/throws; T2 null-column test. |
+| Cache store failure breaks a run | Fail-open: read/write errors → live metered call; WARN; gate/budget stay fail-closed; T4 tests. |
+| Anthropic API drift (field names/limits) | Re-confirm latest docs before T1; parse isolated behind `PromptCacheOptions`. |
+| EF parallel-migration hazard | This story **amends/extends** the existing tenant-schema migration snapshot (one sequential snapshot — do not branch it); the `agent_response_cache` table is owned by `EfTenantDbMigrator`. |
+| Forgotten DROP-list entry | Deliberate — tenant-schema (`t_<hex>`) table is NOT a public-schema table; called out in T3 + Verification. |
+
+---
+
+## Story order & dependencies
+
+- **After 32-5** (the compose order + `IInlineToolLoopRunner` + `LlmCallResponse` this modifies) and
+  **34-11** (the reserved cache-rate columns + `IProviderPricingService` seam).
+- **Feeds 32-9** (cache-token splits + `cache_hit` usage), **34-5/35** (billing decision on a hit),
+  **36** (cache-hit-rate / cost-savings analytics).
+- Implemented **sequentially** w.r.t. other Epic-32/34 stories (one EF migration snapshot — extend,
+  don't branch).

--- a/docs/superpowers/plans/2026-06-21-32-23-streaming-run-tap-plan.md
+++ b/docs/superpowers/plans/2026-06-21-32-23-streaming-run-tap-plan.md
@@ -1,0 +1,289 @@
+# Story 32-23 — Streaming Run Tap (SSE for dashboard / CLI)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation.
+
+**Date:** 2026-06-21
+
+**Goal:** Add a human-facing **streaming run tap** — `GET /api/v1/llm/runs/{correlationId}/stream`
+(SSE) — fed by an in-process `ILlmRunStreamBus` that 32-5's `ManagedAgent.RunAsync` and the
+`IInlineToolLoopRunner` publish to **as a side-effect** while they run the buffered tool loop
+server-side. Turn the inert `IToolLoopEventSink` seam LIVE by replacing `NullToolLoopEventSink` with a
+`BusToolLoopEventSink` (gated by `EnableStreaming`). Frame vocabulary: `token`, `tool_call`,
+`tool_result`, `question`, `answer`, `final`, correlated by `correlationId` (= workflow instance id).
+**The engine's buffered `/llm/call` contract does NOT change** — observers are fully decoupled from the
+engine's request/response call, so `ForEach`/`RetryCheck`/`SkipIfSucceeded` stay byte-for-byte
+unchanged.
+
+**Story file:** `docs/stories/epic-32/story-32-23/32-23-streaming-run-tap.md`
+**Design specs:** `docs/superpowers/specs/2026-06-20-managed-llm-execution-deep-dive.md` (§3 Streaming;
+§6.4 the tap follow-on; §5 question-back) · `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§2 the call-LLM endpoint)
+
+**Tech stack:** .NET 9 / Elsa 3 in `apps/tamma-elsa` (`Tamma.Api` + `Tamma.Activities`). Tests in
+`apps/tamma-elsa/tests/Tamma.Api.Tests/` (xUnit). Docker-bound suites run via
+`sg docker -c "dotnet test ..."` (session docker group is stale; plain `dotnet build` needs no
+wrapper). `packages/api` is DELETED — all of this is C#.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO change to the buffered `/llm/call` contract.** The engine path stays `application/json`
+  request/response. The tap is an additive, decoupled observer. The single load-bearing invariant is
+  **the buffered `LlmCallResponse` is identical with 0 vs N subscribers** (AC6).
+- **NO new DB table, no migration, no Program.cs DROP-list entry, no `ControlPlaneDbContextModelTests`
+  edit.** The bus is in-memory; the durable audit is the DCB `AGENT.RUN.*`/`TOOL_LOOP.*` events 32-5
+  already writes.
+- **NO distributed/multi-instance bus.** In-process only (mirrors `WebhookSignalRegistry`).
+  Cross-instance fan-out (Redis/Postgres LISTEN-NOTIFY) is a documented deferred open decision.
+- **NO new SSE infra.** Reuse `SseWriter` + the `AdminTenantEventsSseEndpoint` hardening (headers,
+  heartbeats, max-duration, error budget, scrub allowlist, `Last-Event-ID`/replay).
+- **NO production of `question`/`answer` content.** That is 32-20 (`request_input` + `IQuestionRouter`).
+  This story defines the `question`/`answer` frame **shape + transport** so 32-20 plugs in.
+- **NO new tool loop / sanitizer / metering.** All owned by 32-5. This story only publishes side-effect
+  frames from the existing emitter + runner.
+
+---
+
+## Current-state findings (verified 2026-06-21, worktree @ epic32-specs)
+
+| Seam | Where it is today | How 32-23 uses it |
+|---|---|---|
+| **Tool-loop event emitter** | `Tamma.Activities/ToolExecution/ToolLoopEventEmitter.cs` — emits `TOOL_LOOP.TURN_STARTED/TOOL_EXECUTING/TOOL_COMPLETED/TURN_COMPLETED/COMPLETED` to an injected `IToolLoopEventSink`; threads `workflowInstanceId` (= correlationId) through every call. | Unchanged. Its sink becomes `BusToolLoopEventSink` (was `NullToolLoopEventSink`). |
+| **The inert sink** | `Tamma.Activities/ToolExecution/IToolLoopEventSink.cs` — only `NullToolLoopEventSink.Instance` registered; all events dropped; gated behind `EnableStreaming`. | Replaced (behind `EnableStreaming`) by `BusToolLoopEventSink` that publishes to the bus. |
+| **SSE writer** | `Tamma.Api/Services/Engine/Lifecycle/SseWriter.cs` — `WriteHeaders` (`text/event-stream`, `no-cache`, `X-Accel-Buffering: no`) / `WriteEventAsync(eventName, payload)` / `WriteCommentAsync(comment)`. | Reused verbatim by the tap endpoint. |
+| **SSE hardening template** | `Tamma.Api/Endpoints/Admin/AdminTenantEventsSseEndpoint.cs` — 30s keepalive, `MaxStreamDurationSeconds` (30m), `MaxConsecutiveErrors`, `Last-Event-ID` resume, `ScrubEvent` allowlist, clean `event: end`. | Copy/factor the heartbeat + max-duration + scrub + resume idioms into the tap. |
+| **In-process registry discipline** | `Tamma.Activities/AgentDispatch/WebhookSignalRegistry.cs` — `ConcurrentDictionary` per-key in-process fan-out (TCS signal model). | The bus mirrors this (per-correlationId set of bounded channels). |
+| **Buffered endpoint + runner + sink seam** | 32-5: `Tamma.Api/Endpoints/LlmCallEndpoints.cs`, `Services/Agents/ManagedAgent.cs`, `Tamma.Activities/LlmCall/InlineToolLoopRunner.cs`. | Hard prerequisite. This story adds side-effect publishes + the `Accept` branch. |
+| **Tenant event store (replay)** | `Tamma.Data/Repositories/IEventRepository.cs` (tenant-scoped `QueryAsync`). | `?replay=true` reads the run's `TOOL_LOOP.*`/`AGENT.RUN.*` DCB events (scrubbed) for catch-up. |
+| **Human auth plane** | `AuthenticatedAny` / `MemberAccess` policies (JWT + `ApiKey` schemes) in `Tamma.Api/Program.cs`. | The tap requires this, **not** the engine bearer. |
+| **Mode** | `Tamma.Api/Services/PromptStore/TammaMode.cs` — `ITammaModeProvider`. | SaaS ownership guard vs single-user "any local run". |
+
+**Key insight:** the only genuinely new code is the **bus** (`ILlmRunStreamBus`/`LlmRunStreamBus`),
+the **live sink** (`BusToolLoopEventSink`), the **tap endpoint** (`LlmRunStreamEndpoints`), the
+**frame records + scrubber**, and a few **side-effect publish calls** in `ManagedAgent` + the `Accept`
+branch in `LlmCallEndpoints`. All SSE plumbing and the emitter already exist.
+
+---
+
+## Architecture
+
+```
+                 (engine path — UNCHANGED)
+CallLlmInlineActivity --TammaApiClient.CallLlmAsync--> POST /api/v1/llm/call (Accept: application/json)
+                                                              |
+                                                    ManagedAgent.RunAsync (32-5, buffered)
+                                                       |          \
+                                          IInlineToolLoopRunner    \ side-effect publishes (fire-and-forget)
+                                          (ToolLoopEventEmitter)     \
+                                                   |                  v
+                                          BusToolLoopEventSink ---> ILlmRunStreamBus  (in-process, per-correlationId
+                                          (was NullToolLoopEventSink)      |           bounded channels, drop-oldest)
+                                                                           |
+              (human path — NEW, decoupled)                               |
+  dashboard / tamma CLI --JWT/ApiKey--> GET /api/v1/llm/runs/{cid}/stream --subscribe--> live SSE frames
+                                          (SseWriter + AdminTenantEventsSseEndpoint hardening)
+                                          [?replay=true => DCB catch-up first, then live tail]
+```
+
+Producer side never blocks on, retries for, or fails because of observers. Publishing with 0
+subscribers is a no-op. The buffered response the engine receives is identical regardless of taps.
+
+Per-mode ownership (CLAUDE.md two-scoping-model): single-user = the sole user taps any local run, replay
+from the user's store; SaaS = tenant member taps only the tenant's runs (foreign `correlationId` →
+404), replay from the tenant `t_<hex>` store via the tenant-scoped `IEventRepository`, never
+cross-tenant. Mode from `ITammaModeProvider`.
+
+---
+
+## Task breakdown
+
+Order: T1 (frames + bus) → T2 (live sink) → T3 (tap endpoint + auth) → T4 (buffered non-regression +
+producer publishes) → T5 (`Accept` second mode) → T6 (replay + mode/isolation). T1 is the foundation;
+T4 is the load-bearing guardrail — write its 0-vs-N test before T2/T3 wiring if practical.
+
+### T1 — Frame records + the in-process bus (`RunStreamFrame`, `ILlmRunStreamBus`)
+
+**Scope:** The data shapes + the decoupled pub/sub. No SSE, no endpoint yet.
+
+**Files (new):** `Services/Streaming/RunStreamFrame.cs`, `Services/Streaming/RunStreamFrameType.cs`
+(`token`/`tool_call`/`tool_result`/`question`/`answer`/`final` constants),
+`Services/Streaming/ILlmRunStreamBus.cs`, `Services/Streaming/LlmRunStreamBus.cs` (singleton;
+`ConcurrentDictionary<correlationId, ConcurrentBag<Channel<RunStreamFrame>>>`; bounded channel
+capacity ~256, `BoundedChannelFullMode.DropOldest`; per-run monotonic `seq`).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Streaming/LlmRunStreamBusTests.cs` —
+- `PublishAsync` with 0 subscribers is a no-op and never throws.
+- N subscribers each receive every published frame, in order.
+- a slow subscriber's bounded channel drops oldest (no producer stall); `PublishAsync` returns
+  promptly even when a channel is full.
+- `seq` is per-run monotonic and independent per `correlationId`.
+
+**Acceptance:**
+- [ ] `RunStreamFrame { Type, CorrelationId, Seq, Payload }`; `RunStreamFrameType` has the six
+      constants.
+- [ ] Bus: publish never throws into the producer; 0-subscriber no-op; drop-oldest back-pressure;
+      monotonic per-run `seq`.
+- [ ] Builds clean; no analyzer warnings.
+
+### T2 — Live sink (`BusToolLoopEventSink`) replacing the null sink (AC3)
+
+**Scope:** `BusToolLoopEventSink : IToolLoopEventSink` that maps `TOOL_LOOP.*` event types to the frame
+vocabulary and publishes to the bus. Registered in `Tamma.Api` behind `EnableStreaming`.
+
+**Files:** new `Services/Streaming/BusToolLoopEventSink.cs`,
+`Services/Streaming/RunStreamFrameScrubber.cs` (allowlist scrub mirroring
+`AdminTenantEventsSseEndpoint.ScrubEvent`); modify `Tamma.Api/Program.cs` DI:
+`if (EnableStreaming) AddSingleton<IToolLoopEventSink, BusToolLoopEventSink>(); else keep
+NullToolLoopEventSink`.
+
+**Mapping:** `TOOL_LOOP.TOOL_EXECUTING`→`tool_call {toolName,toolCallId,turn}`;
+`TOOL_LOOP.TOOL_COMPLETED`→`tool_result {toolName,toolCallId,success,durationMs}`;
+`TOOL_LOOP.COMPLETED`→`final {success?,totalTurns,totalTokens,exhausted,durationMs}`;
+`TURN_STARTED`/`TURN_COMPLETED` ignored (or surfaced as no-payload progress). `correlationId` =
+`workflowInstanceId` from the emitter event.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Streaming/BusToolLoopEventSinkTests.cs` — each `TOOL_LOOP.*`
+maps to the right frame type + key-free payload; unmapped events publish nothing; `EnableStreaming=false`
+path keeps `NullToolLoopEventSink` (graceful no-op).
+
+**Acceptance:**
+- [ ] `BusToolLoopEventSink` publishes `tool_call`/`tool_result`/`final` with correct payloads.
+- [ ] DI swaps the sink only when `EnableStreaming=true`; `grep` confirms `Null` sink is no longer the
+      sole registration in that branch.
+- [ ] Payloads are key-free (scrubber applied).
+
+### T3 — The tap endpoint + auth + SSE protocol (AC1, AC2)
+
+**Scope:** `GET /api/v1/llm/runs/{correlationId}/stream`. `SseWriter.WriteHeaders`; subscribe to the
+bus; write one frame per event; 30s `: keepalive`; `MaxStreamDurationSeconds` ceiling; clean
+`event: end` on `final`. Auth on `AuthenticatedAny` (JWT + ApiKey) — NOT the engine bearer. SaaS
+ownership guard → 404 on foreign `correlationId`.
+
+**Files:** new `Tamma.Api/Endpoints/LlmRunStreamEndpoints.cs`; modify `Tamma.Api/Program.cs` (map
+`app.MapGet("/api/v1/llm/runs/{correlationId}/stream", ...).RequireAuthorization("AuthenticatedAny")`).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Endpoints/LlmRunStreamEndpointsTests.cs` —
+- missing/invalid auth → 401.
+- valid auth + foreign-tenant `correlationId` → 404 (no cross-tenant existence oracle).
+- valid auth + own run → 200 + `text/event-stream` + `X-Accel-Buffering: no`.
+- `: keepalive` emitted during a quiet run; clean close `event: end {"reason":"run_complete"}` on
+  `final`; `MaxStreamDurationSeconds` kicks an abandoned stream.
+
+**Acceptance:**
+- [ ] Endpoint streams live frames for an owned run; ends cleanly on `final`.
+- [ ] Auth + ownership matrix passes (401 / 404 / 200).
+- [ ] SSE headers + heartbeat + max-duration reused from the admin SSE template.
+
+### T4 — Buffered non-regression + producer-side publishes (AC5, AC6)
+
+**Scope:** Prove the buffered contract is untouched, then wire the side-effect publishes in
+`ManagedAgent` (32-5-owned file): after the buffered loop returns, publish `final`; (32-20 will publish
+`question`/`answer`). All wrapped log-and-swallow so a publish failure NEVER fails the run.
+
+**Files:** modify `Services/Agents/ManagedAgent.cs` (add fire-and-forget publish calls — NOT control
+flow).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Streaming/BufferedNonRegressionTests.cs` —
+- the buffered `LlmCallResponse` from `ManagedAgent.RunAsync` is byte-for-byte identical with **0 vs N**
+  subscribers attached (the guardrail).
+- a publish that throws (injected failing bus) does NOT fail or alter the buffered run; it is logged.
+- a minimal `LlmCallWorkflow` `ForEach`/`RetryCheck` run advances identically with taps attached.
+
+**Acceptance:**
+- [ ] 0-vs-N-subscribers identical-buffered-response test green (THE load-bearing invariant).
+- [ ] Producer publishes are side-effects only; injected publish failure is swallowed + logged, never
+      reaches the run.
+- [ ] `final` frame carries the buffered turn summary.
+
+### T5 — Optional `Accept: text/event-stream` second mode on `/llm/call` (AC7)
+
+**Scope:** In `LlmCallEndpoints` (32-5-owned), add: when a **non-engine** caller sends
+`Accept: text/event-stream`, stream the same bus frames inline and end on `final`, instead of buffered
+JSON. The engine path (engine bearer + `application/json`) is explicitly excluded — buffered, unchanged.
+
+**Files:** modify `Tamma.Api/Endpoints/LlmCallEndpoints.cs` (the `WantsEventStream && !IsEngineCaller`
+branch).
+
+**Tests (first):** extend `LlmRunStreamEndpointsTests` / a small `LlmCallAcceptModeTests` —
+- non-engine caller + `Accept: text/event-stream` → live SSE ending in `final`.
+- engine-shaped request (engine bearer + `application/json`) → buffered JSON, regardless of any `Accept`
+  munging (AC7 guardrail).
+
+**Acceptance:**
+- [ ] Second mode works for direct human callers; engine always gets buffered JSON.
+
+### T6 — Replay catch-up + mode/isolation (AC8, AC2)
+
+**Scope:** `?replay=true` replays the run's `TOOL_LOOP.*`/`AGENT.RUN.*` DCB events (scrubbed) from the
+tenant store as catch-up frames, then switches to the live tail. Prove SaaS isolation (foreign run →
+404; replay reads only the tenant store) and single-user "any local run".
+
+**Files:** extend `LlmRunStreamEndpoints.cs` (replay branch reusing the `AdminTenantEventsSseEndpoint`
+resume idiom against `IEventRepository`); extend tests.
+
+**Tests (first):** extend `LlmRunStreamEndpointsTests` —
+- mid-run connect (no replay) sees only live frames from connect time.
+- `?replay=true` replays the run's DCB events (scrubbed, key-free) then live frames.
+- SaaS: two tenants — each can only tap its own run; replay reads its own `t_<hex>` store; no leakage.
+- single-user: the sole user taps any local run.
+
+**Acceptance:**
+- [ ] Mid-run connect + `?replay` behaviours pass; replay is scrubbed + tenant-scoped.
+- [ ] Cross-tenant isolation holds (404 + tenant-scoped replay).
+
+---
+
+## Story order & dependencies
+
+External prereq (must land first): **32-5** (buffered `/llm/call` + `ManagedAgent.RunAsync` + the
+`IInlineToolLoopRunner` in the API + the `IToolLoopEventSink` seam). Soft/co-evolving: **32-20**
+(produces `question`/`answer` frame content; the tap ships the shape + transport dormant until then).
+Internal: T1 → T2 → T3 → T4 (guardrail) → T5 → T6. Downstream consumers (dashboard, `tamma` CLI) are
+NOT blockers.
+
+## Verification
+
+```bash
+# build (no docker wrapper needed)
+dotnet build apps/tamma-elsa/Tamma.sln
+# tests (docker-bound suites need the sg wrapper; session docker group is stale)
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~Streaming"
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~LlmRunStream"
+# AC9 credential-safety check: no key/prompt/tool-args in any frame payload path
+grep -rn "ApiKey\|BaseUrl\|/v1/messages\|prompt" apps/tamma-elsa/src/Tamma.Api/Services/Streaming
+# AC3 sink-swap check: BusToolLoopEventSink is registered (not only the Null sink)
+grep -rn "BusToolLoopEventSink\|NullToolLoopEventSink" apps/tamma-elsa/src/Tamma.Api/Program.cs
+```
+
+## Risks
+
+- **Breaking the buffered contract (T4, AC6):** any control-flow coupling between the bus and the run
+  fails the engine boundary. Mitigation: bus is fire-and-forget; publishes wrap log-and-swallow; the
+  **0-vs-N-subscribers identical-response** test is the guardrail — write it first.
+- **`Accept` second mode leaking into the engine path (T5, AC7):** Mitigation: `IsEngineCaller` (engine
+  bearer) forces buffered; the thin step never sends the SSE Accept; explicit engine-shaped-request test.
+- **Slow subscriber stalls the run (T1/T4, AC5):** Mitigation: bounded DropOldest channels +
+  `MaxStreamDurationSeconds`; publish never blocks.
+- **Secret leak in a frame (T2, AC9):** Mitigation: `RunStreamFrameScrubber` allowlist; tool
+  args/outputs NOT streamed (only names/ids/durations); key-free assertions.
+- **Cross-tenant run visibility (T3/T6, AC2):** Mitigation: SaaS ownership guard → 404; tenant-scoped
+  `IEventRepository` for replay; two-tenant isolation test.
+- **Multi-instance gap:** documented deferred open decision; single-instance is today's topology.
+- **32-20 not landed:** the tap ships the other four frame types; `question`/`answer` dormant until
+  32-20 produces content.
+
+## Notes for the implementer
+
+- **No new table.** The bus is in-memory; durable audit is the existing DCB events. Do **not** touch
+  `Program.cs`'s startup-reset DROP list or `ControlPlaneDbContextModelTests` — adding either is a sign
+  you over-scoped.
+- **Reuse, don't rebuild.** `SseWriter` + the `AdminTenantEventsSseEndpoint` hardening are the template
+  — copy the heartbeat/max-duration/scrub/resume idioms; don't invent a parallel SSE stack.
+- **`seq` ≠ `domain_events.SequenceNumber`.** Use a per-run monotonic counter the bus assigns; the
+  per-tenant BIGSERIAL is a separate concept and meaningless as a stream cursor.
+- **Producer side is a side-effect.** `ManagedAgent`/runner publish to the bus; they never read from it
+  or wait on it. If a test needs the run to behave differently when a subscriber is attached, the
+  decoupling is wrong — stop and fix it.

--- a/docs/superpowers/plans/2026-06-21-32-24-csharp-harness-cli-adapter-plan.md
+++ b/docs/superpowers/plans/2026-06-21-32-24-csharp-harness-cli-adapter-plan.md
@@ -1,0 +1,243 @@
+# Story 32-24 — C# Harness / CLI Agent Adapter (single-user local — DEFERRED)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation.
+
+**Goal:** Port the TypeScript harness/CLI agent providers (`claude-code`, `opencode`, `zen-mcp`) into
+a **single-user / self-hosted LOCAL** C# execution path that spawns the local agent process (or drives
+its local SDK session), captures the harness's self-reported **aggregate** `costUsd`, and slots into
+the single-user managed-run surface **without ever calling `POST /api/v1/llm/call`** and **without
+resolving any remote credential**. This restores the harness parity single-user mode has today only in
+the TS path; SaaS is untouched (the 32-4 gate denies `AuthModel="cli-token"` and the adapter is never
+registered there).
+
+**Story file:** `docs/stories/epic-32/story-32-24/32-24-csharp-harness-cli-adapter.md`
+**Design refs:** `docs/superpowers/specs/2026-06-20-managed-llm-execution-deep-dive.md` (§1 provider
+duality; §6 item 6 — DEFERRED single-user C# harness/CLI adapter) + `2026-06-20-epic-32-revised-agent-architecture.md`
+(§5.3 local CLI agent providers legitimately exempt; §4.2 `Provider.AuthModel`).
+
+**Tech stack:** .NET 9 / Elsa 3 in `apps/tamma-elsa` (central API `Tamma.Api`). Tests live in
+`apps/tamma-elsa/tests/Tamma.Api.Tests/` (xUnit). Docker-bound suites run via
+`sg docker -c "dotnet test ..."` (session docker group is stale; plain `dotnet build` needs no
+wrapper). **`packages/api` is DELETED — the TS code under `packages/providers` is the PORTING SOURCE,
+not a live path.**
+
+---
+
+## ⚠️ DEFERRED — read before scheduling
+
+This story is **P3 / DEFERRED**. It is **not** needed for SaaS and is **not** a blocker for the
+call-LLM endpoint (32-5), the gate (32-4), billing, or analytics. Schedule it only when single-user
+harness execution parity is wanted. It depends on 32-5 / 32-4 / 32-2 being landed (it reuses their
+`AgentRunResult` / gate / resolver seams), so it sequences **after** them — never before.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO `/llm/call` traversal.** The whole point (design §5.3) is that a local harness process is
+  exempt from endpoint mediation — routing it through `/llm/call` adds a hop with no security benefit.
+  The adapter spawns a local process / drives a local SDK; it never builds an `LlmCallRequest` and
+  never calls `TammaApiClient.CallLlmAsync`.
+- **NO remote credential resolution.** The local agent owns its own auth (the user's `claude` login,
+  the local OpenCode server). The adapter injects **no** `IProviderCredentialResolver`, **no** API key,
+  **no** cabinet reader. There is nothing to centralize.
+- **NO price-book cost.** Harness providers report only an aggregate `costUsd` (no token split), so
+  `IProviderPricingService.Compute(...)` is **never** called on this path. Cost is recorded as
+  `CostBasis="harness-aggregate"`, `CredentialSource="local-harness"` — no markup (rule 7), no
+  double-pricing.
+- **NO SaaS reachability.** The adapter is registered ONLY in single-user mode (`ITammaModeProvider`),
+  and the 32-4 gate independently denies `cli-token` providers in SaaS. Two backstops; never one.
+- **NO new tool loop / sanitizer.** The harness owns its OWN loop. Reuse the existing
+  `IContentSanitizer`/secret redaction only for prompt-in / stdout-out boundary safety.
+- **NO new control-plane / public-schema table, NO EF migration.** v1 persists only through the
+  existing tenant `IEventRepository` (`domain_events`) + the 32-6 action trail. → **No `Program.cs`
+  startup-reset DROP-list change; no `ControlPlaneDbContextModelTests` change; no touch to the shared
+  EF migration snapshot.** If a later revision adds a CP table, append it to BOTH the
+  "Wiping Tamma-managed public-schema tables" wipe list AND the strict `BeEquivalentTo` model test.
+- **NO change to `HttpProviderClient.NonHttpProviders`.** Its `ProviderNotSupportedException` reject
+  stays correct for the HTTP dispatch layer and for SaaS. Single-user routes to the new executor
+  *before* reaching `HttpProviderClient`.
+- **NO implementation of 32-5/32-4/32-2 here.** Code to their interfaces; use fakes in tests.
+
+---
+
+## Current-state findings (verified 2026-06-21, repo @ main)
+
+| Seam | Where it is today | How 32-24 uses it |
+|---|---|---|
+| **Harness reject path** | `apps/tamma-elsa/src/Tamma.Api/Services/Providers/HttpProviderClient.cs:57-92` — `NonHttpProviders = { claude-code, claude-code-cli, opencode, opencode-cli, zen-mcp, zen }` → `ProviderNotSupportedException` ("not yet ported to C#"). | Unchanged. Single-user managed path routes harness providers to the new executor BEFORE this; SaaS still hits this reject. |
+| **TS porting source — claude-code** | `packages/providers/src/claude-agent-provider.ts` — `ClaudeAgentProvider implements IAgentProvider, ICLIAgentProvider` (`name='claude-code'`). `spawn('claude', ['-p','--output-format','stream-json', …])`; parses stream-json frames; captures `result.cost_usd` + `session_id`; flags `--model`, `--allowedTools`, `--dangerously-skip-permissions`, `--resume`. Returns `AgentTaskResult`. | Port semantics 1:1 → `ClaudeCodeAgentExecutor` + `StreamJsonMessageParser`. |
+| **TS porting source — opencode** | `packages/providers/src/opencode-provider.ts` — `OpenCodeProvider implements IAgentProvider, ICLIAgentProvider` (`name='opencode'`, `sessionResume:true`). Lazy `@opencode-ai/sdk`; connects to LOCAL server; `session.create()`/resume → `session.prompt(...)`. | Port → `OpenCodeAgentExecutor` (local SDK/HTTP seam). |
+| **TS porting source — zen-mcp** | `packages/providers/src/zen-mcp-provider.ts` — MCP-transport harness. C# MCP client not yet ported (`ProviderSession.cs:87` "MCP transport not yet ported"). | `ZenMcpAgentExecutor` stub-acceptable for v1 (typed `NOT_AVAILABLE`/`NotImplemented` behind the contract; still registers/resolves). |
+| **Result contracts (TS)** | `packages/providers/src/agent-types.ts` (`IAgentProvider.executeTask(config, onProgress)`, `AgentTaskConfig`, `AgentProgressEvent`); `AgentTaskResult` in `packages/shared/src/types/index.ts:245` (`{ success, output, costUsd, durationMs, error? }`). | Shapes `CliAgentRunRequest` / `CliAgentRunResult`. |
+| **Shared run record (C#)** | 32-5 `AgentRunResult` + `IManagedAgent` + `AGENT.RUN.STARTED/SUCCESS/FAILED` (`Tamma.Api/Services/Agents/`). | `HarnessAgentBackend` maps `CliAgentRunResult → AgentRunResult`; reuses the same event lifecycle. |
+| **SaaS gate** | 32-4 `ISaaSProviderGate` (`Tamma.Api/Services/Security/`) — denies `AuthModel="cli-token"` (`SAAS_PROVIDER_NOT_ALLOWED`). | The independent SaaS backstop (AC5/AC7). |
+| **Provider entity / AuthModel** | 34-11 `Provider.AuthModel` (`api-key` | `cli-token`). | The resolver keys on `cli-token` to select the harness backend. |
+| **Mode** | `Tamma.Api/Services/PromptStore/TammaMode.cs` — `ITammaModeProvider` (SingleUser | SaaS), process-stable. | Gate for DI registration (single-user only). |
+| **Sanitizer** | `Tamma.Api/Services/Sanitization/ContentSanitizer.cs` + `IContentSanitizer`; `ToolOutputHelper.RedactSecrets`. | Prompt-in / stdout-out boundary safety (AC10). |
+| **Resolver** | 32-2 `IAgentResolverService`/`IManagedAgentResolver` (`Tamma.Api/Services/Agents/`). | Single-user resolution returns the harness-backed `IManagedAgent` for `cli-token`. |
+
+---
+
+## Phase 0 — Prep & guardrails (no code)
+
+- [ ] Read `BEFORE_YOU_CODE.md`, search `.dev/{spikes,bugs,findings,decisions}` for prior subprocess /
+      `Process` / stream-json / harness findings.
+- [ ] Read the three TS porting sources end-to-end; record a recorded `claude -p --output-format
+      stream-json` transcript (happy path + a non-zero-exit + a malformed line) as test fixtures.
+- [ ] Confirm 32-5 (`AgentRunResult`, `IManagedAgent`, `AGENT.RUN.*`), 32-4 (`ISaaSProviderGate`),
+      32-2 (resolver), 34-11 (`Provider.AuthModel`) seams are landed; if not, code to interfaces + fake.
+- [ ] Confirm **no EF migration / no CP entity** is needed (it is not, for v1) — so the snapshot,
+      DROP-list, and model test are untouched.
+
+## Phase 1 — Contracts & records (TDD: shapes first)
+
+- [ ] **Test:** `CliAgentRunResultTests` — `Success=false` requires `FailureCode`; aggregate `CostUsd`
+      preserved on failure; round-trips through `JsonSerializer`.
+- [ ] Implement `ICliAgentExecutor.cs`, `CliAgentRunRequest.cs`, `CliAgentRunResult.cs` (records per the
+      story Technical Design). Add `FailureCode` constants (`SPAWN_FAILED`, `NON_ZERO_EXIT`,
+      `SDK_CONNECT_FAILED`, `MALFORMED_OUTPUT`, `BUDGET_EXCEEDED`, `CANCELLED`, `NOT_AVAILABLE`).
+
+## Phase 2 — Stream-json parser (the trickiest piece, TDD)
+
+- [ ] **Test:** `StreamJsonMessageParserTests` against the recorded fixtures —
+      (a) happy: progress/text frames + terminal `result` frame → `cost_usd` + `session_id` captured;
+      (b) malformed line → typed parse error (mapped to `MALFORMED_OUTPUT`, not a throw);
+      (c) missing `result` frame → `MALFORMED_OUTPUT`.
+- [ ] Implement `StreamJsonMessageParser.cs` — line-by-line JSON frame parse; expose `OnProgress`,
+      `Cost`, `SessionId`, `ResultSeen`. Ports the `processStreamMessage` logic from
+      `claude-agent-provider.ts`.
+
+## Phase 3 — `ClaudeCodeAgentExecutor` (TDD, behind a process seam)
+
+- [ ] Introduce a thin `IProcessRunner` seam (wrap `System.Diagnostics.Process`) so spawning is fakeable.
+- [ ] **Tests:** `ClaudeCodeAgentExecutorTests` — happy path (fixture transcript → `Success=true`,
+      `CostUsd`, `SessionId`, `ExitCode=0`); spawn-throws → `SPAWN_FAILED`; exit=1 → `NON_ZERO_EXIT`
+      (accrued cost preserved); malformed → `MALFORMED_OUTPUT`; `MaxBudgetUsd` breach → `BUDGET_EXCEEDED`;
+      `ct` cancel → `CANCELLED` + process killed (no orphan); `IsAvailableAsync` false → `NOT_AVAILABLE`.
+- [ ] Implement `ClaudeCodeAgentExecutor.cs` — build argv (`-p --output-format stream-json [--model]
+      [--allowedTools] [--dangerously-skip-permissions] [--resume]`), `WorkingDirectory =
+      req.WorkingDirectory` (sandbox), stream stdout → parser, map exit/parse to `CliAgentRunResult`.
+      **No `TammaApiClient`, no `IProviderCredentialResolver`, no `/llm/call` `HttpClient` injected.**
+
+## Phase 4 — `OpenCodeAgentExecutor` + `ZenMcpAgentExecutor`
+
+- [ ] Introduce an `IOpenCodeSessionClient` seam over the local OpenCode server (create/resume/prompt).
+- [ ] **Tests:** `OpenCodeAgentExecutorTests` — happy (create→prompt→aggregate cost + sessionId);
+      resume path; connect-fail → `SDK_CONNECT_FAILED`; not-running → `NOT_AVAILABLE`.
+- [ ] Implement `OpenCodeAgentExecutor.cs` (local session client).
+- [ ] Implement `ZenMcpAgentExecutor.cs` — v1 stub: registers, `IsAvailableAsync→false` /
+      `RunAsync→NOT_AVAILABLE`, documented TODO referencing the C# MCP-client gap (`ProviderSession.cs:87`).
+
+## Phase 5 — `HarnessAgentBackend` (IManagedAgent adapter) + mapping
+
+- [ ] **Tests:** `HarnessAgentBackendTests` — `CliAgentRunResult → AgentRunResult` sets
+      `InputTokens=OutputTokens=0`, `CostUsd` = aggregate, `CredentialSource="local-harness"`,
+      `CostBasis="harness-aggregate"`; `IProviderPricingService.Compute` **never** invoked (strict mock);
+      exactly one `AGENT.RUN.STARTED` + one terminal `SUCCESS`/`FAILED` via a fake single-user
+      `IEventRepository`, tagged `backend="cli-harness"`; FAILED adds `failureCode`; prompt-in /
+      stdout-out pass through `IContentSanitizer` (secret redacted before persist/log).
+- [ ] Implement `HarnessAgentBackend.cs` (`IManagedAgent`): emit STARTED → `_executor.RunAsync` →
+      map → emit terminal → return. Implement `CliAgentExecutorRegistry.cs` (provider-key → executor).
+
+## Phase 6 — DI wiring (single-user-only) + resolver integration
+
+- [ ] **Tests:** `HarnessModeGateTests` — single-user: `claude-code` resolves to the harness executor;
+      SaaS: resolution refused (gate-denied) / executor never registered (AC5). Architecture test:
+      executor types inject no `TammaApiClient` / `IProviderCredentialResolver` / `/llm/call`
+      `HttpClient` (AC3). `HttpProviderClient` SaaS reject unchanged (AC7).
+- [ ] Implement `HarnessAgentServiceCollectionExtensions.AddHarnessAgentExecution(services, mode)` —
+      register the executors + registry + backend **only when `mode.IsSingleUser`**; SaaS registers nothing.
+- [ ] Wire 32-2 single-user resolver to return `HarnessAgentBackend` when resolved
+      `Provider.AuthModel == "cli-token"`. In SaaS that branch is unreachable (gate-denied at selection).
+- [ ] Modify `Program.cs` to call `AddHarnessAgentExecution(mode)` (registers nothing in SaaS). **No
+      DROP-list / model-test change** (no CP table).
+
+## Phase 7 — Verify & document
+
+- [ ] `sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~Cli"`
+      green; full `Tamma.Api.Tests` green; `dotnet build` clean (no wrapper).
+- [ ] Confirm via grep: zero `/llm/call` / `CallLlmAsync` / credential-resolver references under
+      `Services/Agents/Cli/`; `IProviderPricingService.Compute` not referenced on the harness path.
+- [ ] Update the story Change Log / mark ACs satisfied (controller updates `sprint-status.yaml`).
+
+---
+
+## Test list (consolidated)
+
+| # | Test | Asserts AC |
+|---|---|---|
+| 1 | `CliAgentRunResultTests` | record/JSON shape; failure preserves cost | 2, 9 |
+| 2 | `StreamJsonMessageParserTests` (happy/malformed/missing-result) | cost + session capture; typed parse failure | 1, 9 |
+| 3 | `ClaudeCodeAgentExecutorTests.HappyPath` | stream-json → cost/session/exit | 1, 2 |
+| 4 | `ClaudeCodeAgentExecutorTests.SpawnFailed/NonZeroExit/Malformed/BudgetExceeded/Cancelled/NotAvailable` | typed failures, no throw, no orphan | 9 |
+| 5 | `OpenCodeAgentExecutorTests` (happy/resume/connect-fail/not-running) | local SDK session; aggregate cost | 1 |
+| 6 | `HarnessAgentBackendTests.Mapping` | `local-harness`/`harness-aggregate`; `Compute` never called | 4, 6 |
+| 7 | `HarnessAgentBackendTests.Events` | one STARTED + one terminal; `backend`/`credentialSource` tags | 8 |
+| 8 | `HarnessAgentBackendTests.Sanitization` | prompt-in / stdout-out redacted | 10 |
+| 9 | `HarnessModeGateTests.SingleUserAllowed` | resolves to harness executor | 5, 6 |
+| 10 | `HarnessModeGateTests.SaaSDenied` | refused / never wired | 5, 7 |
+| 11 | `HarnessModeGateTests.NoLlmCallNoCredential` (architecture + behavioural) | no `TammaApiClient`/credential/`/llm/call` | 3 |
+| 12 | `HttpProviderClientSaaSRejectUnchangedTests` | SaaS still throws `ProviderNotSupportedException` | 7 |
+
+---
+
+## Files created / modified
+
+| File | Action |
+|------|--------|
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Cli/ICliAgentExecutor.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Cli/CliAgentRunRequest.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Cli/CliAgentRunResult.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Cli/StreamJsonMessageParser.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Cli/ClaudeCodeAgentExecutor.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Cli/OpenCodeAgentExecutor.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Cli/ZenMcpAgentExecutor.cs` | Create (stub-acceptable v1) |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Cli/HarnessAgentBackend.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Cli/CliAgentExecutorRegistry.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Services/Agents/Cli/IProcessRunner.cs` (+ default impl) | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Extensions/HarnessAgentServiceCollectionExtensions.cs` | Create |
+| `apps/tamma-elsa/src/Tamma.Api/Program.cs` | Modify (call `AddHarnessAgentExecution(mode)`) |
+| 32-2 single-user resolver (`Tamma.Api/Services/Agents/…Resolver…`) | Modify (return harness backend for `cli-token`) |
+| `apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/Cli/*` (per test list) | Create |
+
+> **No `Program.cs` startup-reset DROP-list change, no `ControlPlaneDbContextModelTests` change, no EF
+> migration** — v1 adds no control-plane / public-schema table and does not touch the shared snapshot.
+
+---
+
+## Risks & mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Harness path reachable in SaaS | High | Two independent backstops (not registered in SaaS + 32-4 gate denies `cli-token`); explicit SaaS-denied + no-wire test. |
+| Cost double-counted / markup applied | High | `CredentialSource="local-harness"` + `CostBasis="harness-aggregate"`; `Compute` never called (strict-mock test); 32-9 must branch on these tags. |
+| stream-json drift breaks cost/session capture | Medium | Parser unit-tested against recorded transcripts; failure → `MALFORMED_OUTPUT` (typed, not a throw). |
+| Secret leak via spawned-process stdout/args | Medium | `IContentSanitizer`/redaction on prompt-in + stdout-out; never log args/prompt/env verbatim; only safe summary. |
+| Orphan child process on cancel/crash | Medium | `ct`-bound process lifetime; kill-on-cancel; `CANCELLED` typed result; orphan-free test. |
+| Accidental `/llm/call` / credential coupling creeps in | Medium | Architecture test forbids `TammaApiClient`/`IProviderCredentialResolver`/`/llm/call` `HttpClient` injection on the harness path. |
+| zen-mcp blocked on un-ported C# MCP client | Low | v1 stub behind the contract (typed `NOT_AVAILABLE`); full impl tracked with the MCP-porting story (deep dive §6 item 2). |
+| Implemented before 32-5/32-4/32-2 land | Low (deferred) | Code to interfaces; this story is explicitly sequenced after them; fakes until they land. |
+
+---
+
+## Definition of done
+
+- [ ] All Phase 1–6 tests green via `sg docker -c "dotnet test ..."`; `dotnet build` clean.
+- [ ] Single-user: `claude-code`/`opencode` run locally → `AgentRunResult` + one terminal `AGENT.RUN.*`,
+      **zero** `/llm/call` calls, **zero** credential resolution (grep-verified).
+- [ ] SaaS: harness path unreachable (gate-denied test) + `HttpProviderClient` reject unchanged.
+- [ ] Harness runs reported at face value (`CostBasis="harness-aggregate"`, no markup); `Compute` never
+      invoked on this path.
+- [ ] No EF migration / CP-table / DROP-list / model-test change.
+- [ ] Logging never emits the rendered prompt, process env, or un-sanitized agent stdout; credential
+      safety: there is no API key on this path to log.
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-06-21 | 1.0.0   | Initial plan creation  | Claude |

--- a/docs/superpowers/plans/2026-06-21-32-4-saas-provider-gate-plan.md
+++ b/docs/superpowers/plans/2026-06-21-32-4-saas-provider-gate-plan.md
@@ -1,0 +1,279 @@
+# Story 32-4 — SaaS Provider Gate (call-LLM endpoint stage)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation.
+
+**Date:** 2026-06-21
+**Goal:** Deliver `ISaaSProviderGate` — the **gate stage** (composition step 1) of the 32-5 `call-LLM`
+endpoint (`POST /api/v1/llm/call`). In SaaS mode it denies `cli-token` (harness) providers and unknown
+providers fail-closed (typed → HTTP 400 `SAAS_PROVIDER_NOT_ALLOWED`), denies un-entitled tenants
+(typed → HTTP 403), and passes entitled `api-key` providers. In single-user/self-hosted mode it is a
+hard no-op (harness providers are a legitimate local affordance). The gate returns a **typed
+`ProviderGateDecision`** the endpoint maps to the design §2.4 envelope — it never throws a bare
+exception. Eligibility is sourced from 34-11's `Provider.AuthModel` via `IProviderAuthLookup`, with a
+`StaticProviderAuthLookup` interim impl until 34-11 lands.
+
+**Story file:** `docs/stories/epic-32/story-32-4/32-4-saas-provider-auth-gating-api-key-only.md`
+**Design of record:** `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md`
+(§2.4 error/gating, §2.6 step 1 gate stage, §4.2 `AuthModel` → SaaS-eligibility)
+**Deep dive:** `docs/superpowers/specs/2026-06-20-managed-llm-execution-deep-dive.md` §1 (provider duality)
+
+**Tech stack:** .NET 9 / Elsa 3 in `apps/tamma-elsa` (central API `Tamma.Api`). Tests live in
+`apps/tamma-elsa/tests/Tamma.Api.Tests/` (xUnit). Docker-bound suites run via
+`sg docker -c "dotnet test ..."` (session docker group is stale; plain `dotnet build` needs no
+wrapper). `packages/api` is DELETED — all of this is C#.
+
+---
+
+## Reframe context (why this is a v2 rewrite)
+
+The v1 story was standalone two-seam gating: `IProviderAuthRegistry` (in `Tamma.Activities`) +
+a selection hook in `AgentEndpoints` create/version + an execution-boundary skip in
+`ProviderChainResolver` (`ChainReason.SaaSIneligible`). The locked model (§0–§2) mediates the LLM path
+through one endpoint, so the provider-chain/resolver concerns move server-side into 32-5's
+`ManagedAgent`. **This plan drops the resolver-skip + selection-endpoint hooks entirely** and delivers
+a single `ISaaSProviderGate` service that the 32-5 endpoint calls as step 1. Result: smaller surface,
+one seam, typed decision → §2.4 envelope.
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO resolver-skip logic.** `ProviderChainResolver` is NOT touched — the chain/retry concern is
+  32-5's, server-side. No `ChainReason.SaaSIneligible`.
+- **NO selection-endpoint hook.** `AgentEndpoints` create/version is NOT modified — selection
+  constraint is enablement (32-16/32-18), not provider-auth gating.
+- **NO `Provider` entity / `AuthModel` column / EF migration.** 34-11 owns those. This story defines
+  only the `IProviderAuthLookup` read seam + the interim static impl. **No migration is added here**,
+  so the `Program.cs` startup-reset DROP-list is untouched (that note applies only to new tables).
+- **NO entitlement engine.** The 403 path delegates to the existing Epic 34 SaaS auth/entitlement
+  seam; this story surfaces its result as a typed `Outcome`, it does not implement entitlement rules.
+- **NO bare throw on denial.** Denials are typed `ProviderGateDecision`; only a contract violation
+  (null context) may throw. The endpoint (32-5) maps the decision to the envelope.
+- **NO credential / secret access.** The gate touches provider names + mode only.
+
+---
+
+## Current-state findings (verify at impl time, repo @ feat/exec-wave-02)
+
+| Seam | Where it is today | How 32-4 uses it |
+|---|---|---|
+| **Mode** | `Tamma.Api/Services/PromptStore/TammaMode.cs` — `ITammaModeProvider` (`SingleUser`\|`SaaS`), process-stable. | Read once at the top of `InspectAsync`; `!= SaaS` ⇒ no-op `Allow`. |
+| **Known-provider set (interim)** | `Tamma.Activities/Security/ProviderAllowlist.cs` — `DefaultProviders` + `IsAllowedDefault(name)`. | `StaticProviderAuthLookup` derives `api-key = DefaultProviders \ CliTokenProviders`. |
+| **CLI-agent provider names** | `packages/providers` — `claude-agent-provider.ts` (`claude-code`), `opencode-provider.ts` (`opencode`), zen-mcp; registered via `BUILTIN_PROVIDER_NAMES` / `agent-provider-factory.ts`. | The interim `CliTokenProviders` set; cross-check at impl time. |
+| **DCB events** | `Tamma.Data/Repositories/IEventRepository.cs` — `Task<DomainEvent> AppendAsync(DomainEvent)`, tenant-scoped; pattern in `AgentEndpoints` (`AGENT_CONFIG.UPDATED.SUCCESS`, ~line 93). | Emit `AGENT.PROVIDER.GATED` on SaaS denial; swallow append failure. |
+| **OTel metrics** | `KekRotationMetrics` (`Meter` + `Counter<long>`) pattern. | New `ProviderGatingMetrics` → `Counter<long> tamma.provider.gated`. |
+| **SaaS auth / entitlement** | Epic 34 gating seam (entitlement check for tenant × managed-LLM path). | Delegated for the 403 `TenantNotEntitled` outcome; injected behind a thin interface, faked in tests. |
+| **34-11 AuthModel** | `Provider.AuthModel` (`api-key`\|`cli-token`) — design §4.2; NOT yet built. | `EntityProviderAuthLookup` (34-11) backs `IProviderAuthLookup`; interim static impl until then. |
+| **Consumer** | 32-5 `ManagedAgent.RunAsync` step 1 / `LlmCallEndpoints.cs`. | Calls `InspectAsync`, maps `Outcome`+`HttpStatusHint` → §2.4 envelope. |
+
+**Key insight:** the only genuinely new code is one service (`SaaSProviderGate`), one read seam +
+interim impl (`IProviderAuthLookup` / `StaticProviderAuthLookup`), one metrics class, one DI block,
+and the tests. No EF, no resolver edits, no endpoint edits (the endpoint is 32-5's).
+
+---
+
+## Architecture
+
+```
+POST /api/v1/llm/call  (32-5: LlmCallEndpoints -> ManagedAgent.RunAsync)
+   │  step 1
+   ▼
+ISaaSProviderGate.InspectAsync(ProviderGateContext{ provider, role?, action?, tenantId? })
+   │
+   ├─ mode = ITammaModeProvider.Mode
+   │     != SaaS  ──────────────────────────────────► Allow (no lookup, no event, no metric)
+   │
+   └─ SaaS:
+        authModel = IProviderAuthLookup.AuthModelAsync(provider)   // 34-11 entity / interim static
+          null (unknown)  ─► EmitGated(PROVIDER_UNKNOWN)   ─► Deny  Outcome=SaasProviderNotAllowed (400)
+          CliToken        ─► EmitGated(CLI_TOKEN_PROVIDER) ─► Deny  Outcome=SaasProviderNotAllowed (400)
+          ApiKey:
+            entitled? (Epic 34 seam)
+              false ─► EmitGated(TENANT_NOT_ENTITLED)      ─► Deny  Outcome=TenantNotEntitled (403)
+              true  ─────────────────────────────────────► Allow
+   │
+   ▼  ProviderGateDecision (typed)
+32-5 endpoint maps: SaasProviderNotAllowed→400 SAAS_PROVIDER_NOT_ALLOWED ; TenantNotEntitled→403
+```
+
+Per-mode ownership (CLAUDE.md two-scoping-model): single-user = hard no-op, no events (harness
+providers legitimate locally); SaaS = load-bearing, tenant-scoped `AGENT.PROVIDER.GATED` events in the
+tenant `t_<hex>` store, eligibility from the platform-global `Provider.AuthModel`. Mode from
+`ITammaModeProvider`.
+
+---
+
+## Task breakdown
+
+Order: T1 (lookup seam + interim impl) → T2 (gate contract records) → T3 (gate core + no-op/SaaS
+branches) → T4 (events + metric) → T5 (DI wiring + 34-11 swap-readiness) → T6 (matrix + contract +
+credential-safety tests). T1 and T2 are parallel-safe; T3 needs both.
+
+### T1 — `IProviderAuthLookup` + `StaticProviderAuthLookup` (interim 34-11 seam)
+
+**Scope:** The single eligibility read seam. Interim static impl keyed off `ProviderAllowlist.DefaultProviders`.
+
+**Files (new):** `Services/Security/IProviderAuthLookup.cs`, `Services/Security/StaticProviderAuthLookup.cs`
+(+ the `ProviderAuthModel` enum, co-located in `IProviderAuthLookup.cs` or `ISaaSProviderGate.cs`).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Security/StaticProviderAuthLookupTests.cs`
+- every `ProviderAllowlist.DefaultProviders` entry resolves to a non-null `AuthModel` (guards a new
+  provider being silently mis-classified);
+- `claude-code` / `opencode` / `zen-mcp` ⇒ `CliToken`;
+- `anthropic` / `openai` / `openrouter` / `gemini` ⇒ `ApiKey`;
+- unknown name ⇒ `null`;
+- case-insensitivity + trimming (`"Claude-Code "` ⇒ `CliToken`).
+
+**Acceptance:**
+- [ ] Interim lookup derives `api-key = DefaultProviders \ {claude-code,opencode,zen-mcp}`; does not
+      re-list providers.
+- [ ] Builds clean; no analyzer warnings.
+
+### T2 — Gate contract records (`ProviderGateContext`, `ProviderGateDecision`, enums)
+
+**Scope:** The typed surface the endpoint consumes. No behaviour.
+
+**Files (new):** `Services/Security/ISaaSProviderGate.cs` (interface + `ProviderGateContext`,
+`ProviderGateDecision`, `ProviderGateOutcome`; `ProviderAuthModel` if not in T1).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Security/ProviderGateDecisionTests.cs` — record equality;
+`Allow(model)` factory ⇒ `Allowed=true, Outcome=Allowed, Reason=null, HttpStatusHint=200`; a denial
+record carries a non-null `Reason` + the right `HttpStatusHint` (400/403).
+
+**Acceptance:**
+- [ ] `ProviderGateDecision` has `{ Allowed, Outcome, Reason?, AuthModel?, HttpStatusHint }`.
+- [ ] `ProviderGateOutcome` has `Allowed | SaasProviderNotAllowed | TenantNotEntitled`.
+
+### T3 — `SaaSProviderGate.InspectAsync` core (mode no-op + SaaS branches)
+
+**Scope:** `SaaSProviderGate : ISaaSProviderGate`. Single-user ⇒ `Allow` (no lookup). SaaS ⇒ classify
+→ `cli-token`/unknown deny (400), `api-key` + not-entitled deny (403), else allow. **No throw on
+denial.** Inject `ITammaModeProvider`, `IProviderAuthLookup`, the entitlement seam, `IEventRepository`,
+`ProviderGatingMetrics`, `ILogger<SaaSProviderGate>`. (Events/metric wired fully in T4 but the call
+sites land here.)
+
+**Files (new):** `Services/Security/SaaSProviderGate.cs`.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Security/SaaSProviderGateTests.cs` (branch coverage; events
+asserted in T4):
+- single-user: `claude-code` / `anthropic` / unknown ⇒ `Allowed`, no lookup consulted (assert the
+  fake lookup is never called), zero side effects;
+- SaaS `anthropic` + entitled ⇒ `Allowed`;
+- SaaS `claude-code` ⇒ denied `SaasProviderNotAllowed`, `HttpStatusHint=400`;
+- SaaS unknown ⇒ denied `SaasProviderNotAllowed`, `HttpStatusHint=400` (fail-closed);
+- SaaS `anthropic` + not-entitled ⇒ denied `TenantNotEntitled`, `HttpStatusHint=403`;
+- no path throws (assert `InspectAsync` never throws for any valid context).
+
+**Acceptance:**
+- [ ] Mode short-circuit is first (no lookup in single-user).
+- [ ] All four SaaS outcomes produce the correct `Outcome` + `HttpStatusHint`; none throw.
+
+### T4 — `AGENT.PROVIDER.GATED` event + `tamma.provider.gated` metric (AC8)
+
+**Scope:** `EmitGatedAsync(ctx, authModel, reason, ct)` — append one `AGENT.PROVIDER.GATED` event via
+the tenant `IEventRepository` (Data/Tags per the story) and increment `tamma.provider.gated` once;
+**swallow** append failure (log ERROR, never rethrow). Wire it into each SaaS-denial branch.
+`ProviderGatingMetrics` is a new `Meter`+`Counter<long>` class (mirror `KekRotationMetrics`).
+
+**Files (new):** `Services/Security/ProviderGatingMetrics.cs`. **Modify:** `SaaSProviderGate.cs`
+(call `EmitGatedAsync` in the three denial branches).
+
+**Tests (first):** extend `SaaSProviderGateTests`:
+- each SaaS denial (cli-token / unknown / not-entitled) emits **exactly one** `AGENT.PROVIDER.GATED`
+  event (fake `IEventRepository` records appends) with the right `Data.reason`
+  (`CLI_TOKEN_PROVIDER` / `PROVIDER_UNKNOWN` / `TENANT_NOT_ENTITLED`), `authModel`, `mode=saas`,
+  tenant-scoped `Tags`, and **exactly one** counter increment (tags `provider`, `auth_model`, `reason`);
+- an `Allowed` decision emits zero events / zero increments;
+- single-user emits zero events / zero increments;
+- event-append failure (fake repo throws) is swallowed — `InspectAsync` still returns the typed
+  decision, ERROR logged.
+
+**Acceptance:**
+- [ ] Exactly one event + one metric per SaaS denial; zero on allow / single-user.
+- [ ] Append failure never escapes `InspectAsync`.
+
+### T5 — DI wiring + 34-11 swap-readiness (AC7)
+
+**Scope:** Register `ISaaSProviderGate → SaaSProviderGate`, `IProviderAuthLookup →
+StaticProviderAuthLookup`, `ProviderGatingMetrics` in `Program.cs` (mirror existing service
+registrations). Document the one-line swap to `EntityProviderAuthLookup` when 34-11 lands.
+
+**Files:** modify `Tamma.Api/Program.cs`. (No `Tamma.Activities` change; no Elsa activity.)
+
+**Tests (first):** a host smoke test (`WebApplicationFactory`) resolves `ISaaSProviderGate` and
+`IProviderAuthLookup` at startup. (If a full host boot is heavy, assert the DI registrations via the
+service-collection directly.)
+
+**Acceptance:**
+- [ ] DI resolves the gate + lookup + metrics at host startup.
+- [ ] The swap to `EntityProviderAuthLookup` (34-11) is a single registration line — documented in a
+      `Program.cs` comment next to the registration.
+
+### T6 — Matrix, endpoint-mapping contract, 34-11 swap, credential-safety tests (AC10)
+
+**Scope:** The canonical regression guards.
+
+**Files (new):** `tests/Tamma.Api.Tests/Security/SaaSProviderGateMatrixTests.cs`.
+
+**Tests:**
+- **Mode × auth-model × entitlement matrix**: `(mode ∈ {SingleUser, SaaS}) × (provider ∈ {anthropic,
+  claude-code, unknown}) × (entitled ∈ {true,false})` → assert `Allowed`/`Outcome`/`HttpStatusHint`/
+  event-count/metric-count for each cell.
+- **Endpoint-mapping contract** (referenced by 32-5; assert at the decision level here): a denied
+  decision with `Outcome=SaasProviderNotAllowed` ⇒ `HttpStatusHint=400`; `TenantNotEntitled` ⇒ 403 —
+  proving the typed decision drives the §2.4 envelope.
+- **34-11 swap**: register `EntityProviderAuthLookup` (fake `Provider` rows: `anthropic`=api-key,
+  `claude-code`=cli-token) and re-run the matrix — passes unchanged (contract-neutral swap).
+- **Credential-safety**: assert `SaaSProviderGate`'s constructor dependencies contain **no**
+  credential-resolver / secret seam; a context carrying only a provider name produces a decision
+  without any secret access.
+
+**Acceptance:**
+- [ ] Matrix passes for every cell; SaaS never allows `cli-token`/unknown; single-user allows all.
+- [ ] 34-11 swap test passes (DI-only change is contract-neutral).
+- [ ] Credential-safety assertion holds.
+
+---
+
+## Story order & dependencies
+
+External: **34-11** (`Provider.AuthModel`) — *soft* prereq (interim static impl until it lands; swap
+is DI-only). **32-5** (call-LLM endpoint) is the **consumer**, implemented immediately after this gate.
+**32-3** credential model presumed by the `api-key` classification (gate runs before credential
+resolution). Reuses `ITammaModeProvider`, `ProviderAllowlist`, `IEventRepository`, the Epic 34
+entitlement seam. Internal: T1 ∥ T2 → T3 → T4 → T5 → T6.
+
+**EF / migration note:** this story adds **no** EF entity or migration, so it does not amend the
+single migration snapshot and does not touch the `Program.cs` startup-reset DROP-list (the `Provider`
+table is 34-11's). Implemented sequentially with the rest of the wave regardless.
+
+## Verification
+
+```bash
+# build (no docker wrapper needed)
+dotnet build apps/tamma-elsa/Tamma.sln
+# tests (docker-bound suites need the sg wrapper; session docker group is stale)
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~Security"
+# confirm no resolver / selection-endpoint edits crept in (v1 topology must NOT return)
+grep -rn "SaaSIneligible\|EnsureAllowedAsync" apps/tamma-elsa/src || echo "OK: no v1 seams"
+# confirm the gate has no credential dependency
+grep -n "CredentialResolver\|ITenantProviderKeyReader\|cabinet" apps/tamma-elsa/src/Tamma.Api/Services/Security/SaaSProviderGate.cs || echo "OK: gate is secret-free"
+```
+
+## Risks
+
+- **`cli-token` leak into SaaS** (High): gate is step 1 of the endpoint, before credential/provider
+  call; explicit SaaS+`cli-token` test asserts 400 and no credential resolution.
+- **Unknown provider silently allowed** (High): fail-closed `null` ⇒ DENY; lookup test asserts every
+  known provider resolves deterministically.
+- **34-11 not landed** (Medium): interim `StaticProviderAuthLookup`; swap is DI-only with a
+  contract-neutral test.
+- **Bare throw → leaked 500** (Medium): typed decision only; event-append failure swallowed; only a
+  null context may throw.
+- **403 entitlement drift from Epic 34** (Medium): delegate entitlement to the Epic 34 seam; surface
+  only its result as `Outcome=TenantNotEntitled`.
+- **v1 topology resurfacing** (Low): `grep` guard in Verification ensures no resolver-skip /
+  `EnsureAllowedAsync` returns.

--- a/docs/superpowers/plans/2026-06-21-32-5-call-llm-endpoint-and-managed-execution-plan.md
+++ b/docs/superpowers/plans/2026-06-21-32-5-call-llm-endpoint-and-managed-execution-plan.md
@@ -1,0 +1,335 @@
+# Story 32-5 (v2) — Call-LLM Endpoint + Managed Execution (`POST /api/v1/llm/call`)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax. Project is test-first (TDD) — every task writes tests before
+> implementation. Docker-bound suites run via `sg docker -c "dotnet test ..."` (session docker group
+> is stale; plain `dotnet build` needs no wrapper).
+
+**Date:** 2026-06-21 · **Supersedes** `2026-06-17-32-5-managed-agent-execution-layer-plan.md` (the
+pre-pivot in-engine-seam plan; left in place for history).
+
+**Goal:** Build the **`call-LLM` mediation endpoint** (the lynchpin, sequence step **F**). After this
+story a workflow STEP never calls an external provider: `POST /api/v1/llm/call` in `Tamma.Api` holds
+the credential, gates, runs the agentic tool loop server-side, meters cost, and returns a structured
+**key-free** `LlmCallResponse`. `CallLlmInlineActivity` collapses to a ~80-line thin client over
+`TammaApiClient.CallLlmAsync`; the eight other in-engine direct-LLM callers cut over; the engine's
+`ConfigPlatformProviderCredentialResolver` wiring (shipped by 32-3) is deleted. The retry /
+provider-chain / circuit-breaker boundary in `LlmCallWorkflow.cs` stays **byte-for-byte unchanged**.
+
+**Story file:** `docs/stories/epic-32/story-32-5/32-5-managed-agent-execution-layer.md`
+**Design of record:** `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md`
+(§1, §2, §5.2) · **Deep dive:** `docs/superpowers/specs/2026-06-20-managed-llm-execution-deep-dive.md`
+(§1–§5)
+
+**Tech stack:** .NET 9 / Elsa 3 in `apps/tamma-elsa`. Two processes: `Tamma.ElsaServer` (engine, no
+secrets) + `Tamma.Api` (holds creds/gates/meters). Engine→API over HTTP via `TammaApiClient` (Bearer
+`Tamma:ApiToken` via `TammaEngineAuthHandler` + `X-Tenant-Id`). `Tamma.Api` references
+`Tamma.Activities`, so the extracted tool-loop runner is shared verbatim. **`packages/api` is DELETED
+— there is no TypeScript path; all of this is C#.**
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **Buffered (`application/json`) response ONLY.** No SSE response mode, no live `IToolLoopEventSink`,
+  no `GET /api/v1/llm/runs/{correlationId}/stream` → follow-on **"Streaming run tap"** (deep-dive §3).
+- **NO MCP / plugin tool sourcing.** The runner uses the existing built-in `IToolExecutorRegistry`
+  catalog only → follow-on **"MCP & plugin tool sourcing (C#)"** (deep-dive §4).
+- **NO prompt/response cache** → follow-on **"Prompt + response cache"** (deep-dive §4).
+- **NO interactive question-back** (`request_input`/`IQuestionRouter`/`WaitForAgentQuestionActivity`)
+  → follow-on **"Interactive question-back"** (deep-dive §5).
+- **NO new tool loop/sanitizer/validator/compactor.** AC4 is "reuse, don't fork": EXTRACT the existing
+  `AgenticToolLoop` verbatim and call it from the API. No reimplementation.
+- **NO markup / invoicing / analytics.** `providerCostUsd` = raw `IProviderPricingService.Compute`
+  cost basis. Markup is 34-5; invoicing 35; analytics 36. This story is a producer.
+- **NO Provider Cost Price-Book entity** — that's 34-11 (consumed via the unchanged seam).
+- **NO change to `LlmCallWorkflow.cs`.** The `BuildRetryLoop`/`ForEach<provider>`/`RetryCheck`/
+  `SkipIfSucceeded`/circuit-breaker boundary must not move; its diff is empty.
+- **NO new control-plane table** → no `Program.cs` DROP-list edit, no `ControlPlaneDbContextModelTests`
+  edit (those belong to 32-16 / 34-11).
+- **NO non-LLM mediation** (git/agent-dispatch/Slack) — Epic 38.
+
+---
+
+## Current-state findings (from the design audit, repo @ `feat/exec-wave-02`)
+
+| Seam | Where it is today | What 32-5 does |
+|---|---|---|
+| **Agentic tool loop** | `Tamma.Activities/LlmCall/CallLlmInlineActivity.cs` — private `AgenticToolLoop(...)` (~line 443): multi-turn Anthropic/OpenAI calls (`CallAnthropicMultiTurn`/`CallOpenAiMultiTurn`, single blocking `PostAsync` + `ReadFromJsonAsync`), `IToolCallValidator`, `IToolExecutorRegistry`, `ParallelToolExecutor`, `ContextCompactor`, `ToolLoopEventEmitter`, token accounting; sanitize via `IContentSanitizer` + `ToolOutputHelper.RedactSecrets`. | **Extract** verbatim into `IInlineToolLoopRunner`/`InlineToolLoopRunner`; run **in the API** with the request-scoped key. |
+| **Credential resolution** | engine `ConfigPlatformProviderCredentialResolver` registered via `AddEngineProviderCredentialResolution` (`ElsaServer/Program.cs:~277`); plus the cabinet-backed `DefaultProviderCredentialResolver` in `Tamma.Api/Services/Providers/`. | **DELETE** the engine registration; `ManagedAgent` invokes `DefaultProviderCredentialResolver` (BYOK→platform) in the API. |
+| **Provider HTTP call** | `CallLlmInlineActivity.CallAnthropicMultiTurn`/`CallOpenAiMultiTurn` (`:889,920,927`) — `PostAsync(.../v1/messages` & `/v1/chat/completions`); also `CallLlmActivity` reads `Anthropic:ApiKey` directly. | **Move** into the runner, executed in the API; the activity becomes a thin client; `CallLlmActivity` gutted or deleted. |
+| **Retry / provider-chain / breaker** | `LlmCallWorkflow.cs` — `BuildRetryLoop` → `ForEach<provider>`; `RetryCheck` reads `LastDiagnostic.HttpStatusCode` (429/502/503/504/0); `SkipIfSucceeded`; circuit breaker. | **Unchanged.** Works only because the endpoint returns 200 `success:false` + preserved `httpStatusCode`. |
+| **Budget guard** | `Tamma.Activities/LlmCall/CheckBudgetActivity.cs` (API-first, fail-closed). | Budget check moves into the endpoint gate (server-side, before the call). |
+| **Cost basis** | `Tamma.Api/Services/Providers/IProviderPricingService.Compute(provider, model, in, out)`. | Used at meter step; backed by 34-11's Provider entity (seam unchanged). |
+| **DCB events** | `Tamma.Data/Repositories/IEventRepository.AppendAsync` (tenant-scoped). | `AGENT.RUN.STARTED/SUCCESS/FAILED` emitted from the **API**. |
+| **Engine→API client** | `TammaApiClient` — `PostAsync<T>` + `AddTenantHeader` + `RecordHealthAsync`; Bearer via `TammaEngineAuthHandler` + `X-Tenant-Id`. Routes agent-resolve / budget / diagnostics / provider-session. | **Add** `CallLlmAsync(LlmCallRequest, tenantId, ct)`. |
+| **Nine direct-LLM callers** | `CallLlmInlineActivity`, `CallLlmActivity`, `ClaudeAnalysisActivity`, `WriteTests`/`WriteImplementation`/`AnalyzeCode`/`ApplyRefactoring` (TDD), `ApplyReviewFixes` (ADL), `AIDiagnosis` (Debug). | All cut over / direct fallback deleted → route through `call-LLM`. |
+
+**Key insight:** the genuinely new code is the *endpoint* (`LlmCallEndpoints`), the *wire records*
+(`LlmCallRequest`/`LlmCallResponse`), the `TammaApiClient.CallLlmAsync` method, the *thin shims*, and
+the *extraction* of the existing loop into a runner. The composition shell (`ManagedAgent`),
+`AgentRunResult`, and the failure semantics are kept from v1. The hard part is the **status-preservation
+contract** and the **verbatim move**.
+
+---
+
+## Architecture
+
+```
+ENGINE (Tamma.ElsaServer — holds NO key)              API (Tamma.Api — holds the key, gates, meters)
+─────────────────────────────────────────            ─────────────────────────────────────────────
+LlmCallWorkflow.cs  (UNCHANGED)
+  BuildRetryLoop → ForEach<provider>
+     │  (once per provider per attempt)
+     ▼
+CallLlmInlineActivity  (~80-line THIN CLIENT)
+  map Input<> props → LlmCallRequest
+     │  TammaApiClient.CallLlmAsync(req, tenantId)  ───────►  POST /api/v1/llm/call  (LlmCallEndpoints)
+     │  (Bearer Tamma:ApiToken + X-Tenant-Id)                      │  401 if bearer bad
+     │                                                             ▼
+     │                                              IManagedAgent.RunAsync (ManagedAgent):
+     │                                                1 gate (32-4 ISaaSProviderGate)      → 400/403
+     │                                                2 resolve agent + enablement (32-18/16)
+     │                                                3 credential BYOK→platform (32-3 cabinet)
+     │                                                4 render prompt (Epic 27 / custom-agent 32-17)
+     │                                                5 emit AGENT.RUN.STARTED
+     │                                                6 InlineToolLoopRunner (server-side, scoped key)
+     │                                                7 meter (34-11 cost + 34-5 markup + 32-9 usage)
+     │                                                8 one terminal AGENT.RUN.SUCCESS|FAILED
+     ◄── LlmCallResponse (key-free) ──────────────────9 project AgentRunResult → LlmCallResponse
+  write LastDiagnostic / LastResponse / ToolLoop*           (200 | 200 success:false +httpStatusCode | 400 | 403)
+  (SAME variables as today)
+     ▼
+RetryCheck reads LastDiagnostic.HttpStatusCode  (UNCHANGED — chain advances exactly as today)
+```
+
+Per-mode (CLAUDE.md two-scoping rule): single-user principal = sole user (`UserId`), LLM-API + local
+harness backends, user's BYOK→platform key, events in the user store; SaaS principal = tenant
+(`X-Tenant-Id`), LLM-API path only (CLI → 400), tenant BYOK→platform, events in `t_<hex>`, never
+cross-tenant. Mode from `ITammaModeProvider`.
+
+---
+
+## Task breakdown
+
+Order: **T1** (wire records) → **T2** (extract loop, pure refactor) → **T3** (`ManagedAgent`
+rule-2 composition + projection) → **T4** (endpoint + auth + status mapper) → **T5**
+(`TammaApiClient.CallLlmAsync` + thin shim cutover) → **T6** (delete engine resolver + cut over the
+8 other callers) → **T7** (mode/RBAC/credential-safety + the status-fidelity guardrail). T1 ∥ T2 are
+parallel-safe; T3 needs both; T4 needs T3; T5 needs T4; T6 needs T5.
+
+### T1 — Wire records (`LlmCallRequest`, `LlmCallResponse`) + keep the internal records
+
+**Scope:** the §2.2/§2.3 wire contract + the `ManagedAgentRequest.From(LlmCallRequest, tenantId)` and
+`AgentRunResult → LlmCallResponse` projection shapes. No behaviour.
+
+**Files (new):** `Tamma.Api/Services/Agents/LlmCallRequest.cs`,
+`Tamma.Api/Services/Agents/LlmCallResponse.cs` (+ `UsageDto`/`CostDto`/`ToolCallDto`/`LlmCallParams`).
+**Files (keep):** `IManagedAgent.cs`, `ManagedAgentRequest.cs` (add `From`), `AgentRunResult.cs`,
+`AgentRunEventTypes.cs`.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/LlmCallContractTests.cs` — required fields enforced;
+`Success=false` always carries `failureCode`+`failureReason`+`httpStatusCode`; success carries none;
+`credentialSource ∈ {byok,platform}`; the key field does not exist on the response type.
+
+**Acceptance:**
+- [ ] `LlmCallRequest`/`LlmCallResponse` match design §2.2/§2.3 field-for-field.
+- [ ] `ManagedAgentRequest.From(...)` derives `tenantId` from the body or the header arg.
+- [ ] Builds clean; no analyzer warnings; no API-key property anywhere on the response.
+
+### T2 — Extract the agentic tool loop into a reusable runner (pure refactor, AC4)
+
+**Scope:** Move `CallLlmInlineActivity.AgenticToolLoop(...)` + its private helpers
+(`CallAnthropicMultiTurn`/`CallOpenAiMultiTurn`, body builders/parsers, `LoadProviderConfig`,
+sanitize/redact, compaction) **verbatim** into `InlineToolLoopRunner : IInlineToolLoopRunner`. No
+logic change. (At this task the activity still calls the runner *locally*; the cutover to the API is
+T5/T6.)
+
+**Files:** new `Tamma.Activities/LlmCall/IInlineToolLoopRunner.cs`,
+`Tamma.Activities/LlmCall/InlineToolLoopRunner.cs`; modify `CallLlmInlineActivity.cs` to delegate; DI
+registration. **Move the sanitizer/registry/validator/compactor/parallel-executor DI to the API**
+(they stop being engine-registered — staged so the engine build stays green; final removal in T6).
+
+**Seam shape:** as in the story Technical Design (`provider, providerConfig, model, systemPrompt,
+userPrompt, maxTokens, temperature, tools, enableToolLoop, loopConfig, correlationId, ct →
+InlineToolLoopResult { Response, InputTokens, OutputTokens, Turns, Exhausted, ToolCalls }`).
+
+**Tests (first):** `tests/Tamma.Activities.Tests/LlmCall/InlineToolLoopRunnerTests.cs` (port the
+existing loop assertions); **and `CallLlmInlineActivitySanitizationTests` MUST pass unchanged** —
+the regression net proving no drift.
+
+**Acceptance:**
+- [ ] `CallLlmInlineActivity` delegates to the runner; tool-loop outputs (token totals, turns,
+      exhausted, sanitized output) byte-for-byte identical.
+- [ ] `grep -rn "AgenticToolLoop\|class InlineToolLoopRunner" apps/tamma-elsa/src` → exactly one loop.
+- [ ] Activities suite green via `sg docker -c "dotnet test .../Tamma.Activities.Tests/ --filter ...LlmCall"`.
+
+### T3 — `ManagedAgent` rule-2 composition + projection (AC3, AC10)
+
+**Scope:** `ManagedAgent.RunAsync` composes gate → resolve+enablement → credential → render → STARTED
+→ runner → meter → terminal event, builds `AgentRunResult`, and projects it to `LlmCallResponse`. All
+in the API.
+
+**Files:** `Tamma.Api/Services/Agents/ManagedAgent.cs` (create/rework),
+`Tamma.Api/Services/Agents/ILlmCallResponseMapper.cs` + impl (AgentRunResult → LlmCallResponse +
+HTTP-result decision).
+
+**Collaborators (constructor-injected; fakes in tests):** `ISaaSProviderGate` (32-4),
+`IAgentResolverService`/`IManagedAgentResolver` (32-2/32-18, applies 32-16 enablement),
+`DefaultProviderCredentialResolver`/`IProviderCredentialResolver` (32-3), prompt renderer (Epic 27 /
+32-17), `IInlineToolLoopRunner` (T2), budget guard (reuse `CheckBudgetActivity` logic behind a small
+interface), `IProviderPricingService` (34-11), markup engine (34-5), usage emitter (32-9),
+`IEventRepository`, `ITammaModeProvider`, `ILogger<ManagedAgent>`.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Agents/ManagedAgentTests.cs` — happy path (every
+`LlmCallResponse` field populated; collaborators called once in order; `providerCostUsd ==
+_pricing.Compute(...)`; `credentialSource` copied); BYOK → `priceUsd==0`, platform →
+`priceUsd==markup(costBasis)`; exactly one `AGENT.RUN.STARTED` + one terminal event.
+
+**Acceptance:**
+- [ ] Happy-path `RunAsync` → `AgentRunResult{Success=true}`, projected to a full `LlmCallResponse`.
+- [ ] Markup applied only when `credentialSource=="platform"`; `providerCostUsd` identical both branches.
+
+### T4 — The endpoint + auth + the status mapper (AC1, AC7)
+
+**Scope:** `POST /api/v1/llm/call` (engine-only auth) → `IManagedAgent.RunAsync` →
+`ILlmCallResponseMapper.ToHttpResult`. The mapper enforces §2.4: 200 success / 200 `success:false` +
+preserved `httpStatusCode` / 400 `SAAS_PROVIDER_NOT_ALLOWED` / 403 entitlement / 401 bad bearer.
+**Never a raw 5xx.**
+
+**Files:** new `Tamma.Api/Endpoints/LlmCallEndpoints.cs`; modify `Tamma.Api/Program.cs` (map the
+endpoint under the engine-auth policy; register `IManagedAgent`, `IInlineToolLoopRunner`, the mapper,
+and the sanitizer/registry/validator/compactor in the API).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Endpoints/LlmCallEndpointsTests.cs` (via
+`WebApplicationFactory`) — 401 missing/invalid bearer; `tenantId` derived from `X-Tenant-Id`; 400
+SAAS_PROVIDER_NOT_ALLOWED (gate denies CLI in SaaS); 403 entitlement; 200 success; **200 `success:false`
++ `httpStatusCode=429` for a provider failure** (assert no raw 5xx ever returned).
+
+**Acceptance:**
+- [ ] All five HTTP outcomes covered; expected provider failures are 200 `success:false` with the
+      `httpStatusCode` preserved.
+- [ ] Endpoint resolves the whole DI chain at host startup.
+
+### T5 — `TammaApiClient.CallLlmAsync` + the thin `CallLlmInlineActivity` shim (AC5, AC6)
+
+**Scope:** Add `CallLlmAsync(LlmCallRequest, tenantId, ct)` to `TammaApiClient` (existing
+`PostAsync<T>` + `AddTenantHeader` + `RecordHealthAsync` pattern). Gut `CallLlmInlineActivity` to a
+~80-line shim: map `Input<>` props → `LlmCallRequest`, call `CallLlmAsync`, write the **same**
+`LastDiagnostic`/`LastResponse`/`ToolLoopTokens`/`Turns`/`Exhausted` variables. Pass
+`enableToolLoop`+`toolLoopConfig` through (not executed locally).
+
+**Files:** modify `TammaApiClient.cs`, `CallLlmInlineActivity.cs`.
+
+**Tests (first):** `tests/Tamma.Activities.Tests/LlmCall/CallLlmInlineActivityThinClientTests.cs` —
+given an `LlmCallResponse`, the shim writes variables identical to the legacy shapes; a minimal
+`LlmCallWorkflow` `ForEach`/`RetryCheck` integration test advances the chain unchanged for a
+`success:false`+`httpStatusCode=429` response.
+
+**Acceptance:**
+- [ ] The shim owns no key/HTTP-to-provider/tool loop; it calls `CallLlmAsync` only.
+- [ ] `LlmCallWorkflow.cs` is unmodified (empty diff); `RetryCheck`/`SkipIfSucceeded`/breaker advance
+      exactly as before.
+
+### T6 — Delete the engine resolver + cut over the eight other callers (AC9)
+
+**Scope:** Remove `ConfigPlatformProviderCredentialResolver` + `AddEngineProviderCredentialResolution`
+from `ElsaServer/Program.cs`; remove the now-unused provider-side DI from the engine
+(`IHttpClientFactory` provider use, `IContentSanitizer`, `IToolExecutorRegistry`, `IToolCallValidator`,
+`ContextCompactor`, `ToolLoopEventEmitter`, `ParallelToolExecutor`, `IProviderCredentialResolver`).
+Gut `CallLlmActivity` to a thin client **or delete it**. Delete the direct keyed LLM fallback from
+`ClaudeAnalysisActivity`, `WriteTests`/`WriteImplementation`/`AnalyzeCode`/`ApplyRefactoring`,
+`ApplyReviewFixes`, `AIDiagnosis` — route through `call-LLM` (engine-callback mode terminates at the
+mediated path).
+
+**Files:** modify `ElsaServer/Program.cs`, `CallLlmActivity.cs` (or delete), and the seven TDD/ADL/
+Debug/Mentorship activities.
+
+**Tests (first):** `tests/Tamma.Activities.Tests/.../NoDirectLlmCallTests.cs` — assert (and grep) that
+under `Tamma.Activities` there is **zero** `Anthropic:ApiKey` read, **zero** `/v1/messages`/
+`/v1/chat/completions` `PostAsync`, and **zero** non-`TammaApiClient` provider HTTP call; assert
+`ElsaServer/Program.cs` registers no provider credential resolver.
+
+**Acceptance:**
+- [ ] Nine in-engine direct-LLM callers eliminated; engine holds no LLM key.
+- [ ] Engine + API build green; full suite green.
+
+### T7 — Mode/RBAC, credential safety & the status-fidelity guardrail (AC7, AC8, AC11)
+
+**Scope:** Prove the two-scoping ownership, the key never leaks, and the load-bearing
+status-preservation contract holds.
+
+**Files:** extend `ManagedAgentTests` + `LlmCallEndpointsTests`; add
+`tests/Tamma.Api.Tests/Endpoints/LlmCallStatusFidelityTests.cs`.
+
+**Tests (first):**
+- SaaS + CLI-token provider → 400 SAAS_PROVIDER_NOT_ALLOWED; single-user CLI → not reached by the
+  endpoint (local, exempt).
+- BYOK → `credentialSource="byok"`, no markup; platform → `"platform"`, markup; `providerCostUsd` same.
+- `AGENT.RUN.*` tags `{ agentId, version, provider, model, role, correlationId, credentialSource,
+  tenantId }`; FAILED adds `failureCode`; events land in the tenant-scoped repo; two tenants → no leak.
+- **Credential safety:** the API key appears in no `LlmCallResponse`, no log line, no DCB payload.
+- **Status fidelity guardrail (deep-dive §7.9):** for every expected provider failure the endpoint
+  returns 200 `success:false` + a non-null `httpStatusCode`, never a raw 5xx.
+
+**Acceptance:**
+- [ ] Mode matrix passes; SaaS never reaches a CLI provider via `/llm/call`.
+- [ ] Key-leak assertions hold; status-fidelity guardrail green.
+
+---
+
+## Story order & dependencies
+
+External prereqs (sequence A–E + the gate): **34-11** (cost price-book), **32-15** (persona
+reframe), **32-16** (enablement), **32-17** (custom-agent prompts), **32-18** (registry enablement
+gate + Epic-27 prompt source), **32-4** (SaaS gate), **32-3** (cabinet credential resolver — this
+story deletes its engine wiring), **Epic 27** (prompt render), **Epic 29** (cabinet). Code to the
+interfaces; use fakes until landed. Internal: T1 ∥ T2 → T3 → T4 → T5 → T6 → T7. Downstream consumers
+(32-6/8/9, 34-5, 35, 36) depend on this; they are NOT blockers.
+
+EF note: this story adds **no** migration / CP table (the loop relocation + endpoint are code-only).
+`TenantAgentEnablement` and `Provider`/`ProviderModelPrice` migrations belong to 32-16 / 34-11; this
+plan amends no migration snapshot.
+
+## Verification
+
+```bash
+# build (no docker wrapper needed)
+dotnet build apps/tamma-elsa/Tamma.sln
+# tests (docker-bound suites need the sg wrapper; session docker group is stale)
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~Agents|FullyQualifiedName~Endpoints"
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Activities.Tests/ --filter FullyQualifiedName~LlmCall"
+# AC4 no-fork:
+grep -rn "AgenticToolLoop\|class InlineToolLoopRunner" apps/tamma-elsa/src
+# AC9 engine holds no key:
+grep -rn "Anthropic:ApiKey\|/v1/messages\|/v1/chat/completions" apps/tamma-elsa/src/Tamma.Activities
+grep -rn "AddEngineProviderCredentialResolution\|ConfigPlatformProviderCredentialResolver" apps/tamma-elsa/src/Tamma.ElsaServer
+# AC6 workflow boundary unchanged:
+git diff --stat apps/tamma-elsa/src/Tamma.ElsaServer/.../LlmCallWorkflow.cs   # expect: empty
+```
+
+## Risks
+
+- **Raw 5xx leak breaks retry (T4, AC6/AC7) — CRITICAL.** A raw 5xx is nulled by
+  `TammaApiClient.PostAsync` → `RetryCheck`/breaker silently stop working. Mitigation: the mapper
+  always returns 200 `success:false` + preserved `httpStatusCode` for expected provider failures; the
+  T7 status-fidelity guardrail enforces it; only gate/entitlement/auth use 400/403/401.
+- **Extraction drift (T2, AC4) — HIGH.** The loop is large and security-critical (sanitization at
+  every boundary). Mitigation: pure verbatim move, zero logic edits, `CallLlmInlineActivitySanitizationTests`
+  unchanged. If those tests need edits, the extraction is wrong — stop and redo as a move.
+- **Thin shim writes different variables (T5, AC5/AC6) — HIGH.** Map `LlmCallResponse` → the exact
+  `LastDiagnostic`/`LastResponse`/`ToolLoop*` shapes; the minimal `ForEach`/`RetryCheck` integration
+  test is the proof; keep `LlmCallWorkflow.cs` diff empty.
+- **Engine still holds a key after cutover (T6, AC9) — HIGH.** Grep gates in the verification block +
+  the `NoDirectLlmCallTests`; delete the resolver registration and the provider-side DI.
+- **Lost run records (T3, AC10) — HIGH.** Each compose step → typed `AgentRunResult{Success=false}` +
+  one terminal `AGENT.RUN.FAILED`; "exactly one terminal event per run" invariant test; only a null
+  request may throw.
+- **Cost mis-attribution (T3) — MEDIUM.** `credentialSource` copied from 32-3, never re-derived;
+  markup only when `platform`; both-branch test; `providerCostUsd` from the unchanged seam.
+- **Dependency timing (A–E + 32-4/32-3) — MEDIUM.** Interfaces + fakes; this story is the integrator,
+  not the owner, of those seams.
+- **Co-hosting masks the violation (design §1.1) — MEDIUM.** The shim calls over the wire via
+  `TammaApiClient`, never resolves an injected vendor service — the rule holds the moment the engine
+  runs as per-tenant dedicated compute (Cranl).

--- a/docs/superpowers/plans/2026-06-21-34-11-provider-cost-price-book-plan.md
+++ b/docs/superpowers/plans/2026-06-21-34-11-provider-cost-price-book-plan.md
@@ -1,0 +1,271 @@
+# Story 34-11 — Provider Cost Price-Book (`Provider` + `ProviderModelPrice` behind `IProviderPricingService`)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation.
+
+**Date:** 2026-06-21
+**Sequence:** Epic-34 pivot step **A** — implement BEFORE 34-5 (its cost-basis input).
+
+**Goal:** Promote the hard-coded provider COST rate-sheet (`FrozenDictionary` in
+`ProviderPricingService`) to a DB-backed, admin-editable, immutable-versioned control-plane entity
+model (`Provider` + `ProviderModelPrice`) **behind the UNCHANGED `IProviderPricingService` seam**.
+Swap the frozen impl for `DbProviderPricingService`; preserve the alias map / loose-prefix / default
+rules verbatim; add `EffectiveFrom`-windowed resolution so a usage event prices under the cost rate
+active at its `OccurredAt`. Downstream (34-5, 36-2, 36-7, 32-9) needs at most a one-line DI edit.
+
+**Story file:** `docs/stories/epic-34/story-34-11/34-11-provider-cost-price-book.md`
+**Design of record:** `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§3, §4)
+
+**Tech stack:** .NET 9 / EF Core in `apps/tamma-elsa`. Entities + migrations + seeder in `Tamma.Data`;
+services + endpoints in `Tamma.Api`. Tests in `apps/tamma-elsa/tests/Tamma.Api.Tests/` (NUnit +
+FluentAssertions). Docker-bound suites run via `sg docker -c "dotnet test ..."` (session docker group
+is stale; plain `dotnet build` / `dotnet ef` need no wrapper). **There is no TypeScript path — all C#.**
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO change to the `IProviderPricingService` interface.** `Compute(provider, model?, in, out)` +
+  `IsKnown(provider, model?)` stay byte-identical. The only addition is an `EffectiveFrom`-aware
+  `ComputeAt` on the concrete impl / a sibling resolver — additive, not a contract change.
+- **NO markup / sell price / margin.** That is 34-5 (`MarginPolicy`, `IUsagePricingEngine`). This
+  story produces ONLY the cost basis. `MarginPolicy.Scope='provider'` overrides margin, never cost.
+- **NO subscription/seat price.** That is 34-1 (`PlanPrice`). `ProviderModelPrice` ≠ `PlanPrice`.
+- **NO per-tenant / per-user cost rows.** Cost is the provider's published rate — global in both
+  modes (design §4.4). No `TenantId`/`UserId` column on either entity.
+- **NO tenant-schema tables.** Both entities are CONTROL-PLANE (`ControlPlaneDbContext`), so they go
+  in the `Program.cs` DROP list + the strict CP model test — NOT the per-tenant `EfTenantDbMigrator`.
+- **NO consumer rewiring.** 34-5 / 32-9 / 36-2 keep their `IProviderPricingService` dependency; the
+  swap is a registration change in `Program.cs` only.
+
+---
+
+## Current-state findings (verified 2026-06-21, in the `epic32-specs` worktree)
+
+| Seam | Where it is today | How 34-11 uses it |
+|---|---|---|
+| **Cost rate sheet** | `Tamma.Api/Services/Providers/ProviderPricingService.cs` — `FrozenDictionary<provider, FrozenDictionary<model, Rate(InputPerToken, OutputPerToken)>>` ported from `packages/cost-monitor` @ `9e9a57c~1`; `s_aliases` map; `TryGetRate` (canonicalize → model-map → null/"default"→first → exact → loose-prefix); unknown→`0m`. | **Port verbatim** as v1 seed rows; **extract** the alias+lookup helper for sharing; **retain** the frozen class as seed source / boot fallback. |
+| **Seam** | `Tamma.Api/Services/Providers/IProviderPricingService.cs` — `Compute` / `IsKnown`. | **Unchanged.** New `DbProviderPricingService` implements it over rows. |
+| **CP entity + versioning pattern** | `Tamma.Data/Entities/Plan.cs` + `Tamma.Data/Seeders/PlansSeeder.cs` (34-1); `MarginPolicy` + `MarginPolicySeeder` (34-5): UUIDv7, `Status` flip on edit, partial unique `WHERE active`, insert-missing-only. | **Mirror exactly** for `Provider`/`ProviderModelPrice`. |
+| **CP context** | `Tamma.Data/ControlPlaneDbContext.cs` — `OnModelCreating` with `Configure*` methods (`ConfigurePlans`, `ConfigureAlertRules`). | Add `ConfigureProviders` / `ConfigureProviderModelPrices` + 2 DbSets. |
+| **DROP list** | `Tamma.Api/Program.cs` ~line 2110 — `DROP TABLE IF EXISTS ... plan_features, plan_entitlements, plan_prices, plans, ... CASCADE`. | **Append** `providers, provider_model_prices`. |
+| **Strict CP model test** | `tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs` — `Model_Has_ExpectedControlPlaneEntities` strict `BeEquivalentTo`. | **Add** `providers` + `provider_model_prices` to the list. |
+| **Seed call site** | `Program.cs` ~line 2154 — `await PlansSeeder.SeedAsync(dbContext);` then `AgentEntitySeeder.SeedAsync`. | Add `await ProviderPricingSeeder.SeedAsync(dbContext);`. |
+| **RBAC** | `PlatformOwnerAccess` policy (NOT `OwnerAccess`) for platform-global admin routes. | Gate `/api/admin/providers*`. |
+| **DCB** | `IEventRepository.AppendAsync(DomainEvent)` (control-plane store for admin events). | Emit `PROVIDER.PRICE.VERSIONED` / `PROVIDER.REGISTERED` / `PROVIDER.STATUS_CHANGED`. |
+
+**Key insight:** the genuinely new code is two entities, the EF config + migration, a verbatim-porting
+seeder, a `DbProviderPricingService` that reuses an EXTRACTED copy of the existing lookup algorithm,
+and admin CRUD. The risk surface is the two list-extensions (DROP + model test) and behaviour parity.
+
+---
+
+## Architecture
+
+```
+                  IProviderPricingService  (UNCHANGED seam: Compute / IsKnown)
+                          ▲
+          ┌───────────────┴────────────────┐
+   ProviderPricingService            DbProviderPricingService   ← registered impl (DI swap)
+   (frozen — SEED SOURCE + fallback)  reads providers/provider_model_prices
+          │  shared static helper: alias map + TryGetRate (canonicalize→default→exact→prefix)
+          ▼                                   │  + ComputeAt(atTimestamp)  → EffectiveFrom window
+   ProviderPricingSeeder  ──(insert-missing-only, UUIDv7, v1 rows)──►  ControlPlaneDbContext
+                                                                          providers
+                                                                          provider_model_prices
+   AdminProviderPricingEndpoints (/api/admin/providers*, PlatformOwnerAccess)
+       PUT prices → supersede active + insert new active → PROVIDER.PRICE.VERSIONED (IEventRepository)
+```
+
+COST only. Sell price (34-1 `PlanPrice`) and markup (34-5 `MarginPolicy`) sit ABOVE this; 36-7 reads
+the persisted `CostUsd` written from this basis. No tenant scoping — global in both modes.
+
+---
+
+## Task breakdown
+
+Order: **T1** (entities + EF config) → **T2** (migration + DROP list + model test) → **T3** (extract
+shared lookup helper) → **T4** (`DbProviderPricingService` + `ComputeAt` + parity) → **T5** (seeder) →
+**T6** (admin endpoints + events + RBAC) → **T7** (DI swap + Program.cs wiring). T1→T2 are sequential
+(migration follows the model). T3 is independent and can land before T4. Implemented SEQUENTIALLY —
+one EF migration snapshot; this plan **amends/extends the existing CP migration chain, it does not
+branch the snapshot**.
+
+### T1 — Entities + EF model config
+
+**Scope:** `Provider` + `ProviderModelPrice` (`Tamma.Data.Entities`); `ConfigureProviders` /
+`ConfigureProviderModelPrices` + 2 DbSets in `ControlPlaneDbContext`. Unique `Key`; CHECKs on
+`AuthModel`/`Status`/`Source`; partial unique `UX_provider_model_prices_OneActivePerModel`
+(`WHERE "Status" = 'active'`); window index `(ProviderKey, Model, EffectiveFrom)`; FK
+`ProviderKey → providers.Key` `OnDelete(Restrict)`.
+
+**Tests (first):** extend `ControlPlaneDbContextModelTests` — `Provider` has unique `Key` index + the
+two CHECKs; `ProviderModelPrice` has the partial unique index with filter `"Status" = 'active'` and
+the window index; **neither entity has a `TenantId`/`UserId` property** (AC3); the FK is `Restrict`.
+
+**Acceptance:**
+- [ ] Both entities map; indexes/CHECKs/FK present on the design-time model.
+- [ ] No `TenantId`/`UserId` on either entity (global-by-design assertion passes).
+- [ ] Builds clean; no analyzer warnings.
+
+### T2 — Migration + DROP list + strict model-test list (the two gotchas)
+
+**Scope:** `dotnet ef migrations add ProviderCostPriceBook -c ControlPlaneDbContext`
+(`Tamma.Data/Migrations/ControlPlane/`) — additive `CreateTable` for both. Append
+`providers, provider_model_prices` to the `Program.cs` DROP list (~line 2110). Add both table names
+to `ControlPlaneDbContextModelTests.Model_Has_ExpectedControlPlaneEntities`'s `BeEquivalentTo`.
+
+**Tests (first):** `Model_Has_ExpectedControlPlaneEntities` now lists the two tables (RED → GREEN). A
+boot-twice host test (or reuse the existing harness) asserts the second boot does NOT throw
+`relation "providers" already exists`.
+
+**Acceptance:**
+- [ ] `dotnet ef migrations has-pending-model-changes -c ControlPlaneDbContext` reports none.
+- [ ] DROP list contains both tables; second test-host boot succeeds.
+- [ ] Strict CP model test passes with the two tables added.
+
+### T3 — Extract the shared alias + lookup helper (pure refactor, no behaviour change)
+
+**Scope:** Move `ProviderPricingService.s_aliases` + the `TryGetRate` algorithm (canonicalize →
+model-map → `null`/`"default"`→first → exact → loose-prefix) into a shared static helper
+(`ProviderRateLookup`) consumed by BOTH the frozen `ProviderPricingService` (unchanged outputs) and
+the new `DbProviderPricingService`. The frozen class delegates to the helper over its
+`FrozenDictionary`; the DB class delegates over a row snapshot.
+
+**Tests (first):** the **existing** `ProviderPricingService` tests must pass unchanged (regression net
+proving the extraction is a pure move). Add a small unit test of the helper directly (alias map,
+prefix, default, unknown).
+
+**Acceptance:**
+- [ ] Existing frozen-service tests green, unedited.
+- [ ] One copy of the alias map + lookup algorithm (grep confirms no fork).
+
+### T4 — `DbProviderPricingService` + `ComputeAt` + parity
+
+**Scope:** `DbProviderPricingService : IProviderPricingService` over `provider_model_prices` (active
+rows), using `ProviderRateLookup`. Holds a short-lived snapshot cache invalidated on admin write. Add
+`ComputeAt(provider, model?, in, out, atTimestamp)` — selects the row where `EffectiveFrom <=
+atTimestamp` and is the most-recent for `(ProviderKey, Model)` (active or superseded). No-timestamp
+`Compute`/`IsKnown` resolve against the current `active` row.
+
+**Tests (first):** `DbProviderPricingServiceTests` — alias/prefix/default/unknown→`0m`+`IsKnown=false`;
+`ComputeAt` windowed selection (event at `t` prices under the row effective at `t`, not latest).
+`ProviderPricingParityTests` — **for every seeded `(provider, model)`, `DbProviderPricingService.Compute`
+== frozen `ProviderPricingService.Compute` byte-for-byte** (depends on T5's seed; write the test, seed
+in-test, assert parity).
+
+**Acceptance:**
+- [ ] DB impl reproduces the frozen behaviour for every quirk.
+- [ ] `ComputeAt` selects the time-correct row.
+- [ ] Parity test green for 100% of seeded pairs (incl. sub-cent rates).
+
+### T5 — `ProviderPricingSeeder` (verbatim port, insert-missing-only)
+
+**Scope:** `ProviderPricingSeeder.SeedAsync(ControlPlaneDbContext)` — for each provider in the frozen
+`s_pricing`, upsert-if-missing a `Provider` row (with `AuthModel`: `claude-code`→`cli-token`, else
+`api-key`); for each `(model, Rate)`, upsert-if-missing a `ProviderModelPrice` v1 row
+(`Status='active'`, `Source='seed'`, `EffectiveFrom=SEED_EPOCH`,
+`InputUsdPer1M = Rate.InputPerToken * 1_000_000m`, `OutputUsdPer1M = Rate.OutputPerToken * 1_000_000m`).
+Deterministic UUIDv7 per `(key)`/`(key, model)`. Never reverts a `Source='admin'` row.
+
+**Tests (first):** `ProviderPricingSeederTests` — first run seeds all providers/models; second run is a
+no-op (counts unchanged); an admin-edited (`Source='admin'`) row is NOT reverted; UUIDv7 ids are
+deterministic across runs; the USD-per-token → USD-per-1M conversion round-trips to byte-identical
+`Compute` (feeds T4 parity).
+
+**Acceptance:**
+- [ ] Idempotent; admin edits survive a re-seed.
+- [ ] All frozen-table entries become rows; AuthModel mapping correct.
+
+### T6 — Admin CRUD endpoints + events + RBAC
+
+**Scope:** `AdminProviderPricingEndpoints` (`Tamma.Api/Endpoints/Admin/`), `PlatformOwnerAccess`:
+`GET /api/admin/providers`, `POST /api/admin/providers`, `PATCH /api/admin/providers/{key}`,
+`GET /api/admin/providers/{key}/prices`, `PUT /api/admin/providers/{key}/prices`. `PUT prices`:
+normalize `ProviderKey` via the alias helper, flip current `active` → `superseded`, insert new
+`active` (`Source='admin'`), emit `PROVIDER.PRICE.VERSIONED`. Mutating a `superseded` row throws
+`TammaError("PROVIDER.PRICE.IMMUTABLE", ...)`. `ProviderPricingEventTypes` constants.
+
+**Tests (first):** `AdminProviderPricingEndpointsTests` — `PlatformOwnerAccess` 403 for a non-owner on
+every route; a platform owner succeeds; `PUT prices` versions (prior `superseded`, new `active`, the
+partial unique index rejects a 2nd active); `PROVIDER.PRICE.VERSIONED` appended with tags
+`{ providerKey, model, effectiveFrom, supersededPriceId, source='admin', actorUserId }`; immutability
+violation throws `PROVIDER.PRICE.IMMUTABLE`.
+
+**Acceptance:**
+- [ ] All routes gated by `PlatformOwnerAccess`; non-owner → 403.
+- [ ] Versioning produces supersede + insert; one-active invariant holds; events tagged per AC9.
+
+### T7 — DI swap + `Program.cs` wiring
+
+**Scope:** `ProviderPricingServiceCollectionExtensions` registers `DbProviderPricingService` as
+`IProviderPricingService` (in place of the frozen impl), `IProviderCostResolver`, and the admin
+endpoints. `Program.cs`: register the seeder call (`await ProviderPricingSeeder.SeedAsync(dbContext);`
+~line 2154), map the admin endpoint group, and swap the `IProviderPricingService` registration. Keep
+the frozen `ProviderPricingService` available as the seed source + boot fallback (if the table is empty
+at boot, fall back to frozen and log a WARN — fail-LOUD, never silently price at 0).
+
+**Tests (first):** DI smoke test (`WebApplicationFactory`) resolves `IProviderPricingService` → the DB
+impl and the admin endpoints at host startup; a boot-with-empty-table test logs the fallback WARN.
+
+**Acceptance:**
+- [ ] `IProviderPricingService` resolves to `DbProviderPricingService`; consumers unchanged.
+- [ ] Seeder runs at startup; endpoints mapped; DI resolves the whole chain.
+
+---
+
+## Story order & dependencies
+
+**Sibling pattern source (not a hard blocker):** 34-1 (`Plan`/`PlanPrice`/`PlansSeeder`) and 34-5
+(`MarginPolicy`/`MarginPolicySeeder`) — reuse their CP-entity + immutable-versioning +
+insert-missing-only + `PlatformOwnerAccess` patterns. **Implement BEFORE 34-5** (34-5's
+`CostBasisUsd = IProviderPricingService.Compute(...)` consumes this seam). Downstream consumers
+(34-5, 32-5, 32-9, 36-2/36-7) need at most a one-line DI dependency edit — the seam preservation is
+the contract.
+
+Internal task order: T1 → T2 → (T3 ∥) → T4 → T5 → T6 → T7. SEQUENTIAL EF snapshot: this plan amends
+the existing CP migration chain; do NOT run alongside another EF-touching story.
+
+## Verification
+
+```bash
+# build (no docker wrapper needed)
+dotnet build apps/tamma-elsa/Tamma.sln
+# migration is additive + complete
+dotnet ef migrations has-pending-model-changes -c ControlPlaneDbContext \
+  -p apps/tamma-elsa/src/Tamma.Data -s apps/tamma-elsa/src/Tamma.Api
+# tests (docker-bound suites need the sg wrapper; session docker group is stale)
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~Providers"
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~ControlPlaneDbContextModelTests"
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~AdminProviderPricing"
+# no-fork check: exactly one alias map + lookup algorithm
+grep -rn "anthropic-claude\|TryGetRate\|class ProviderRateLookup" apps/tamma-elsa/src/Tamma.Api/Services/Providers
+# DROP-list extension present
+grep -n "providers, provider_model_prices\|provider_model_prices" apps/tamma-elsa/src/Tamma.Api/Program.cs
+```
+
+## Risks
+
+- **DROP-list omission (T2):** the #1 recurring CP-table gotcha — a second test-host boot fails with
+  `relation "providers" already exists`. Mitigation: AC10 + boot-twice test + the explicit `grep`
+  verification; add the two tables to the DROP list in the SAME commit as the migration.
+- **Strict model-test omission (T2):** `Model_Has_ExpectedControlPlaneEntities` uses a strict
+  `BeEquivalentTo` — adding CP entities without updating it fails the suite. Mitigation: write the
+  list edit as the RED step of T2.
+- **Behaviour parity drift (T3/T4):** the alias map / loose-prefix / default / unknown→0 quirks are
+  load-bearing for 34-5's `IsKnown` gate. Mitigation: ONE extracted helper consumed by both impls; the
+  parity test asserts byte-identical `Compute` for every seeded pair; the existing frozen-service tests
+  stay unedited as the regression net for the extraction.
+- **Tenant scoping leak:** cost must be global (design §4.4). Mitigation: AC3 model test asserts no
+  `TenantId`/`UserId` on either entity.
+- **`OwnerAccess` vs `PlatformOwnerAccess`:** `OwnerAccess` admits every personal-tenant owner.
+  Mitigation: AC9 pins `PlatformOwnerAccess`; RBAC test asserts 403 for a non-platform-owner.
+- **Retroactive cost mutation:** re-pricing a model must not change historical invoices. Mitigation:
+  immutable-versioning (supersede + `EffectiveFrom` window) + `ComputeAt` on the metering path +
+  windowed-selection test.
+- **Seeder reverting admin edits:** Mitigation: insert-missing-only (mirrors `PlansSeeder`);
+  idempotency test asserts a `Source='admin'` row survives a re-seed.
+- **Empty-table boot:** if the DB has no rows at boot, NEVER price at 0 silently. Mitigation: fall back
+  to the retained frozen table + WARN (fail-loud, consistent with `feedback_resolution_no_empty_fallback`).

--- a/docs/superpowers/plans/2026-06-21-38-1-git-platform-step-mediation-plan.md
+++ b/docs/superpowers/plans/2026-06-21-38-1-git-platform-step-mediation-plan.md
@@ -1,0 +1,286 @@
+# Story 38-1 — Git-platform step mediation (Class A) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation.
+
+**Date:** 2026-06-21
+
+**Goal:** Re-point the five Class-A ADL git activities (`CreateBranch` / `CreatePullRequest` /
+`MergePullRequest` / `UpdateIssueStatus` / `AnalyzeReview`) from the co-hosted
+`IGitHubIntegrationService` to new `Tamma.Api` endpoints (`/api/v1/git/{repo}/...`) that hold the
+per-tenant git token (Epic 28/29 cabinet, BYOK→platform), authorize the `tenant ↔ repo` relationship
+(the cross-tenant guard — the load-bearing control), perform the platform call, and emit a DCB audit
+event. The activities collapse into thin `TammaApiClient` clients holding no token. This mirrors the
+Story 32-5 `/llm/call` template verbatim and is the proof-of-pattern for the rest of Epic 38.
+
+**Story file:** `docs/stories/epic-38/story-38-1/38-1-git-platform-step-mediation.md`
+**Design spec:** `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§1.2 Class-A
+rows, §1.3 cross-tenant-token risk, §5.1 Class-A endpoints, §5.3 webhooks out of scope)
+**Template story:** `docs/stories/epic-32/story-32-5/32-5-managed-agent-execution-layer.md`
+
+**Tech stack:** .NET 9 / Elsa 3 in `apps/tamma-elsa` (central API `Tamma.Api` + activities
+`Tamma.Activities` + engine `Tamma.ElsaServer`). Tests live in
+`apps/tamma-elsa/tests/Tamma.Api.Tests/` and `apps/tamma-elsa/tests/Tamma.Activities.Tests/` (xUnit).
+Docker-bound suites run via `sg docker -c "dotnet test ..."` (session docker group is stale; plain
+`dotnet build` needs no wrapper). **`packages/api` is DELETED — all of this is C#.**
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO new git/platform client.** Reuse the existing `IGitHubIntegrationService` impl (Octokit) — only
+  move *where it is called from* (into `Tamma.Api`, never the engine). Do not reimplement branch/PR
+  logic.
+- **NO multi-platform broadening.** This story mediates the existing service; GitLab/Gitea/Bitbucket
+  fan-out beyond the current abstraction is out of scope.
+- **NO agent-dispatch / Slack mediation.** Those are 38-2 / 38-3.
+- **NO guardrail analyzer.** That is 38-4; this story proves the cutover by `grep`, not by a build gate.
+- **NO inbound-webhook changes.** `workflow_run.completed` / `WebhookSignalRegistry` are inbound, out
+  of scope by nature (design §5.3).
+- **NO new control-plane table.** Reuse the Epic 28/29 tenant↔repo registry + cabinet + the tenant
+  `domain_events` stream. (If a CP-resident tenant↔repo table proves unavoidable, it must be appended
+  to `Program.cs`'s startup-reset DROP list AND `ControlPlaneDbContextModelTests` — see Risks.)
+- **NO markup/billing.** Git operations are not metered for cost here; the audit event is the only
+  emission.
+
+---
+
+## Current-state findings (verify against the worktree before coding)
+
+| Seam | Where it is today | How 38-1 uses it |
+|---|---|---|
+| **Git platform service** | `Tamma.Api` `IGitHubIntegrationService` (impl + `GitHub:Token`); **unregistered/null in the engine**. | Delegated to **inside `Tamma.Api`** only; the endpoints call it with a request-scoped per-tenant token. |
+| **Git activities** | `Tamma.Activities/ADL/{CreateBranch,CreatePullRequest,MergePullRequest,UpdateIssueStatus,AnalyzeReview}Activity.cs` — inject `IGitHubIntegrationService`. | Gutted to thin `TammaApiClient` clients; drop the injection. |
+| **Engine→API callback** | `TammaApiClient` (Bearer `Tamma:ApiToken` via `TammaEngineAuthHandler` + `X-Tenant-Id`; `PostAsync<T>`/`PatchAsync<T>` + `AddTenantHeader` + `RecordHealthAsync`). Routes agent-resolve/budget/diagnostics/provider-session/`/llm/call`. | The transport + auth plane for the 5 git endpoints; add 5 client methods. |
+| **Per-tenant token** | Epic 29 cabinet (the git analogue of Story 32-3's LLM credential resolver), keyed per-tenant per Epic 28. | `GitTokenResolver` resolves BYOK→platform inside the API. |
+| **Tenant↔repo registry** | Epic 28 tenancy data (the tenant's configured repo(s)). | `GitRepoAuthorizer` checks ownership BEFORE token/platform. |
+| **DCB events** | `Tamma.Data` `IEventRepository.AppendAsync(DomainEvent)`, tenant-scoped. | Emit `GIT.*.SUCCESS|FAILED` from the API. |
+| **Mode** | `Tamma.Api/Services/PromptStore/TammaMode.cs` — `ITammaModeProvider` (SingleUser | SaaS), process-stable. | Principal keying (user vs tenant) for the guard + token + audit. |
+
+**Key insight:** the only genuinely new code is the *endpoint shell* (`GitEndpoints`), the
+*composition service* (`GitMediationService`), the *guard* (`GitRepoAuthorizer`), the *token resolver*
+(`GitTokenResolver`), the *wire records*, and the *thin-client cutover* of five activities + five new
+`TammaApiClient` methods. The platform call itself is the existing `IGitHubIntegrationService`.
+
+---
+
+## Architecture
+
+```
+Engine: {CreateBranch,CreatePullRequest,MergePullRequest,UpdateIssueStatus,AnalyzeReview}Activity
+   |  (thin TammaApiClient client — NO token, NO Octokit)
+   v
+TammaApiClient.{CreateBranch,CreatePullRequest,MergePullRequest,UpdateIssueStatus,GetPullRequestComments}Async
+   |  Bearer Tamma:ApiToken + X-Tenant-Id
+   v
+Tamma.Api  GitEndpoints  ->  GitMediationService.<Op>Async:
+   1 authorize tenant↔repo   (IGitRepoAuthorizer)   -- CROSS-TENANT GUARD, FIRST  -> 403 on deny
+   2 resolve token           (IGitTokenResolver)    -- Epic 29 cabinet BYOK->platform -> 503 on null
+   3 call platform           (IGitHubIntegrationService, request-scoped token, API-only)
+   4 emit GIT.*.SUCCESS|FAILED  (tenant IEventRepository)   -- exactly one terminal event
+   5 return GitMediationResult -> ToHttpResult (200 | 200 success:false | 403 | 503)
+```
+
+Per-mode ownership (CLAUDE.md two-scoping-model): single-user = the sole user's repo(s) + the user's
+token + events in the user's store; SaaS = only the `X-Tenant-Id` tenant's repo(s) + the tenant's BYOK
+token → platform + events in the tenant `t_<hex>` store, never cross-tenant. Mode from
+`ITammaModeProvider`.
+
+---
+
+## Task breakdown
+
+Order: T1 (wire records + event types) → T2 (guard) → T3 (token resolver) → T4 (mediation service:
+happy path) → T5 (typed failures + audit) → T6 (endpoints) → T7 (thin-activity cutover + client
+methods) → T8 (engine-registration removal + DI wiring). T1 is parallel-safe with T2/T3.
+
+### T1 — Wire records + event-type constants
+
+**Scope:** The request/response shapes and `GIT.*` event constants. No behaviour.
+
+**Files (new):** `Services/Git/GitRequests.cs` (`CreateBranchRequest`, `CreatePullRequestRequest`,
+`MergePrRequest`, `UpdateIssueRequest`), `Services/Git/GitResponses.cs` (`GitMediationResult`,
+`PrCommentDto`), `Services/Git/GitEventTypes.cs` (`GIT.BRANCH_CREATED.*`, `GIT.PR_OPENED.*`,
+`GIT.PR_MERGED.*` / `GIT.PR_MERGE.FAILED`, `GIT.ISSUE_UPDATED.*`, `GIT.PR_COMMENTS_READ.*`).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Git/GitMediationResultTests.cs` — record equality; `Success=false`
+always carries `FailureCode`+`FailureReason`; `CredentialSource` is `byok|platform`; no token field exists.
+
+**Acceptance:**
+- [ ] Records compile; `GitMediationResult` has all AC fields; **no field can carry the raw token**.
+
+### T2 — Cross-tenant guard (`IGitRepoAuthorizer`) — the load-bearing control
+
+**Scope:** `GitRepoAuthorizer : IGitRepoAuthorizer` — `AuthorizeAsync(tenantId, repo, ct)` against the
+Epic 28 tenant↔repo registry. Deny/unevaluable → not authorized (NEVER a default-allow).
+
+**Files (new):** `Services/Git/IGitRepoAuthorizer.cs`, `Services/Git/GitRepoAuthorizer.cs`.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Git/GitRepoAuthorizerTests.cs` — tenant owns repo → allow;
+tenant does not own repo → deny; unevaluable (registry error / missing mapping) → deny (fail-closed);
+single-user mode → the sole user's configured repo allowed.
+
+**Acceptance:**
+- [ ] No default-allow path exists; deny is the safe default.
+- [ ] Mode matrix (single-user user-owned vs SaaS tenant-owned) passes.
+
+### T3 — Per-tenant token resolver (`IGitTokenResolver`) — BYOK→platform, fail-closed
+
+**Scope:** `GitTokenResolver : IGitTokenResolver` — `ResolveAsync(tenantId, repo, ct)` → `{ Token,
+Source }`. Epic 29 cabinet (tenant BYOK PAT / installation token) → else platform-provided where
+allowed → else **null** (NEVER an empty/default token). Mirrors Story 32-3.
+
+**Files (new):** `Services/Git/IGitTokenResolver.cs`, `Services/Git/GitTokenResolver.cs`.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Git/GitTokenResolverTests.cs` — cabinet has tenant token →
+`Source="byok"`; absent + platform allowed → `Source="platform"`; absent + not allowed → null
+(fail-closed); the returned `Token` is never logged.
+
+**Acceptance:**
+- [ ] BYOK→platform→null order; null when unresolvable (no empty/default fallback).
+- [ ] `Source` is `byok|platform`; token never surfaces in logs.
+
+### T4 — `GitMediationService` core composition (happy path, per operation)
+
+**Scope:** `GitMediationService : IGitMediationService` with one method per operation
+(`CreateBranchAsync`, `CreatePullRequestAsync`, `MergePullRequestAsync`, `UpdateIssueStatusAsync`,
+`GetPullRequestCommentsAsync`). Compose guard(1) → token(2) → `IGitHubIntegrationService`(3) → audit(4)
+→ result(5). Token is request-scoped, dropped after the call.
+
+**Files (new):** `Services/Git/IGitMediationService.cs`, `Services/Git/GitMediationService.cs`.
+
+**Collaborators (constructor-injected — fakes in tests):** `IGitRepoAuthorizer`, `IGitTokenResolver`,
+`IGitHubIntegrationService`, `IEventRepository`, `ITammaModeProvider`, `ILogger<GitMediationService>`.
+
+**Tests (first):** `tests/Tamma.Api.Tests/Git/GitMediationServiceTests.cs` — each operation happy path:
+guard→token→service→audit called once in order; correct response DTO populated; `credentialSource`
+copied from the resolver; exactly one terminal `GIT.*.SUCCESS` event with the right tags.
+
+**Acceptance:**
+- [ ] Each operation returns a fully-populated `GitMediationResult{Success=true}`.
+- [ ] Guard runs BEFORE token; token BEFORE platform; one terminal event per call.
+
+### T5 — Typed failures + audit discipline (fail-closed, status preservation)
+
+**Scope:** Each step gets a typed-failure exit:
+- guard deny → 403 `REPO_NOT_AUTHORIZED` (platform never called, token never resolved);
+- token null → 503 `GIT_TOKEN_UNAVAILABLE` (`retryable:false`);
+- platform error → **200 `success:false`** with `failureCode ∈ {GIT_CONFLICT, NOT_MERGEABLE,
+  NOT_FOUND, PLATFORM_ERROR}` and **preserved** `platformStatusCode`.
+No expected failure throws; a raw 5xx is never produced. Exactly one terminal `GIT.*.FAILED` event
+(except guard-deny, which emits a `GIT.*.DENIED` or `FAILED` with `failureCode=REPO_NOT_AUTHORIZED` —
+pin in a test).
+
+**Files:** extend `GitMediationService`; add a `ToHttpResult()` mapper (in `GitEndpoints` or a small
+mapper type).
+
+**Tests (first):** extend `GitMediationServiceTests` — one test per failure code; guard-deny → service
+never invoked; token-null → platform never invoked; platform 5xx → 200 `success:false` +
+`platformStatusCode` preserved (assert no raw 5xx); "exactly one terminal event per call" invariant.
+
+**Acceptance:**
+- [ ] All failure codes produce typed results; none throw; raw 5xx never leaks.
+- [ ] Guard-deny and token-null short-circuit before the platform call.
+
+### T6 — Endpoints (`GitEndpoints.cs`)
+
+**Scope:** Map the five routes; engine-only auth (`EngineAuthPolicy` — same plane as `/llm/call`);
+bind `{repo}` + body; derive `tenantId` from `X-Tenant-Id`; delegate to `GitMediationService`;
+`ToHttpResult`.
+
+**Files (new):** `Endpoints/GitEndpoints.cs`; modify `Tamma.Api/Program.cs` (map endpoints; register
+guard/token/mediation; ensure `IGitHubIntegrationService` registered in the API).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Endpoints/GitEndpointsTests.cs` — 401 missing/invalid bearer;
+valid bearer + `X-Tenant-Id` → bound + delegated; 403 on guard deny; 200 `success:false` +
+`platformStatusCode` on platform failure; happy 200 per route. Use `WebApplicationFactory` + fakes.
+
+**Acceptance:**
+- [ ] All five routes served, engine-only, 401 on missing bearer; DI resolves at host startup.
+
+### T7 — Thin-activity cutover + `TammaApiClient` methods (AC5)
+
+**Scope:** Gut the five ADL activities to thin `TammaApiClient` clients (drop
+`IGitHubIntegrationService`); add five client methods (`CreateBranchAsync`/`CreatePullRequestAsync`/
+`MergePullRequestAsync`/`UpdateIssueStatusAsync`/`GetPullRequestCommentsAsync`) following the existing
+`PostAsync<T>`/`PatchAsync<T>` + `AddTenantHeader` + `RecordHealthAsync` pattern. Each activity writes
+the **same** workflow variables it writes today.
+
+**Files:** modify `Tamma.Activities/ADL/{CreateBranch,CreatePullRequest,MergePullRequest,
+UpdateIssueStatus,AnalyzeReview}Activity.cs`; modify `Tamma.Api/Clients/TammaApiClient.cs`.
+
+**Tests (first):** `tests/Tamma.Activities.Tests/ADL/GitActivityThinClientTests.cs` — given each
+`GitMediationResult`, the activity writes the same `BranchRef`/`PrNumber`/`MergeResult`/`IssueStatus`/
+`ReviewComments` variables as the legacy path; a minimal ADL workflow branches on them unchanged; the
+activity holds no `IGitHubIntegrationService`.
+
+**Acceptance:**
+- [ ] Five activities cut over; same variables out; no Octokit/platform-HTTP reference.
+- [ ] `grep` over `Tamma.Activities` for `IGitHubIntegrationService` → zero.
+
+### T8 — Engine-registration removal + credential-safety sweep
+
+**Scope:** Ensure `IGitHubIntegrationService` is NOT registered/reachable in `Tamma.ElsaServer`;
+confirm no git token can be pushed into the engine process. Credential-safety sweep: token never in
+any response/log/event.
+
+**Files:** modify `Tamma.ElsaServer/Program.cs` (remove any git-service registration).
+
+**Tests (first):** a credential-safety test over response/log/event payloads (no token substring); a
+host-boot smoke test asserting the engine resolves the activities **without** any git-service
+registration.
+
+**Acceptance:**
+- [ ] Engine holds no git token / git-service registration.
+- [ ] Credential-safety test green: token absent from every response, log, and event.
+
+---
+
+## Story order & dependencies
+
+External/pattern prereqs: **Story 32-5** (the `/llm/call` template to mirror), **Epic 28** (tenant↔repo
+registry + per-tenant keying), **Epic 29** (cabinet — per-tenant git token), **Epic 9** (`TammaApiClient`
+plane), **Epic 4** (DCB). Code to their interfaces with fakes until landed. Internal order:
+T1 ∥ T2 ∥ T3 → T4 → T5 → T6 → T7 → T8. Downstream: 38-4 guardrail proves the cutover stays cut (not a
+blocker).
+
+## Verification
+
+```bash
+# build (no docker wrapper needed)
+dotnet build apps/tamma-elsa/Tamma.sln
+# tests (docker-bound suites need the sg wrapper; session docker group is stale)
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~Git|FullyQualifiedName~GitEndpoints"
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Activities.Tests/ --filter FullyQualifiedName~ADL"
+# cutover proof: zero IGitHubIntegrationService injections in the engine activities
+grep -rn "IGitHubIntegrationService" apps/tamma-elsa/src/Tamma.Activities
+# credential-safety: no token substring leaks (manual review + the safety test)
+```
+
+## Risks
+
+- **Cross-tenant write/merge via a mis-scoped token (design §1.3 — THE Class-A risk):** Critical. The
+  guard (`IGitRepoAuthorizer`) runs FIRST, before token resolution or platform call; deny → 403, never
+  a call. Dedicated cross-tenant test asserts the platform is unreachable on deny. Token is per-tenant
+  from the cabinet, never a shared default.
+- **Raw 5xx leak breaks ADL outcome mapping:** High. The mapper always returns 200 `success:false` +
+  preserved `platformStatusCode` for expected platform failures; 403/401/503 only for
+  guard/auth/credential; HTTP-status-fidelity test.
+- **Engine still holds a git token after cutover:** High. `IGitHubIntegrationService` stays API-only;
+  `grep` confirms zero injections; T8 host-boot smoke test; 38-4 makes it permanent.
+- **Token leak into log/response/event:** High. Request-scoped token dropped after the call;
+  `credentialSource` is the only credential field surfaced; explicit credential-safety test.
+- **Thin activity writes different variables → ADL workflow breaks:** High. Map each result to the
+  exact legacy variable shapes; minimal ADL workflow integration test.
+- **Empty/default token fallback:** Medium. Fail-closed: 503 `GIT_TOKEN_UNAVAILABLE`,
+  `retryable:false`; never call with an empty token (`feedback_resolution_no_empty_fallback`).
+- **EF / control-plane table (only if a CP tenant↔repo table is unavoidable):** Medium. Default is **no
+  new CP table** (reuse Epic 28/29 registry + cabinet). IF one is added: append it to `Program.cs`'s
+  startup-reset "Wiping Tamma-managed public-schema tables" DROP list (else a 2nd host boot fails with
+  `relation already exists`) AND update the strict `Model_Has_ExpectedControlPlaneEntities`
+  `BeEquivalentTo` contract test. This plan **amends/extends the existing EF migration snapshot**, it
+  does not branch it (stories are implemented sequentially on one snapshot).
+- **Dependency timing (32-5 pattern / Epic 28-29):** Medium. Mirror 32-5; code to interfaces; fakes
+  until landed.

--- a/docs/superpowers/plans/2026-06-21-38-2-agent-dispatch-step-mediation-plan.md
+++ b/docs/superpowers/plans/2026-06-21-38-2-agent-dispatch-step-mediation-plan.md
@@ -1,0 +1,291 @@
+# Story 38-2 — Agent-dispatch step mediation (Class C) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation.
+
+**Date:** 2026-06-21
+
+**Goal:** Re-point the three Class-C AgentDispatch activities (`DispatchAgentWorkflowActivity` /
+`GitHubActionsExecutor`, `MonitorAgentWorkflowActivity`, `CollectAgentResultsActivity`) from the
+co-hosted `IGitHubActionsClient` (Octokit in API, Null in engine) to new `Tamma.Api` endpoints
+(`POST /api/v1/agent-dispatch/{repo}/runs` + `GET /api/v1/agent-dispatch/{repo}/runs/{id}`) that hold
+the per-tenant GitHub Actions token (Epic 28/29 cabinet, BYOK→platform), reuse Story 38-1's
+`IGitRepoAuthorizer` cross-tenant guard, dispatch/poll the run, and emit a DCB audit event. The
+activities collapse into thin `TammaApiClient` clients holding no token. The **inbound**
+`workflow_run.completed` webhook + `WebhookSignalRegistry` are explicitly OUT of scope (inbound, no
+outbound call to mediate — design §5.3) and must stay byte-for-byte unchanged.
+
+**Story file:** `docs/stories/epic-38/story-38-2/38-2-agent-dispatch-step-mediation.md`
+**Design spec:** `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§1.2 Class-C
+rows, §1.3 cross-tenant-token risk, §5.1 Class-C endpoints, §5.3 inbound webhooks out of scope)
+**Template story:** `docs/stories/epic-32/story-32-5/32-5-managed-agent-execution-layer.md`
+**Prerequisite story:** `docs/stories/epic-38/story-38-1/38-1-git-platform-step-mediation.md` (shared
+`IGitRepoAuthorizer`)
+
+**Tech stack:** .NET 9 / Elsa 3 in `apps/tamma-elsa` (central API `Tamma.Api` + activities
+`Tamma.Activities` + engine `Tamma.ElsaServer`). Tests live in
+`apps/tamma-elsa/tests/Tamma.Api.Tests/` and `apps/tamma-elsa/tests/Tamma.Activities.Tests/` (xUnit).
+Docker-bound suites run via `sg docker -c "dotnet test ..."` (session docker group is stale; plain
+`dotnet build` needs no wrapper). **`packages/api` is DELETED — all of this is C#.**
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO new Actions/CI client.** Reuse the existing `OctokitGitHubActionsClient` impl — only move *where
+  it is called from* (into `Tamma.Api`, never the engine). Do not reimplement dispatch/poll.
+- **NO inbound-webhook change.** `workflow_run.completed` / `WebhookSignalRegistry` / the durable
+  bookmark suspend/resume are inbound, out of scope by nature (design §5.3). This plan must NOT touch
+  them — it adds a regression test proving they are unchanged.
+- **NO duplicate cross-tenant guard.** Reuse Story 38-1's `IGitRepoAuthorizer` — do not author a second.
+- **NO git-platform / Slack mediation.** Those are 38-1 / 38-3.
+- **NO guardrail analyzer.** That is 38-4; this story proves the cutover by `grep`.
+- **NO new control-plane table.** Reuse Epic 28/29 + the tenant `domain_events` stream (38-1 owns any
+  CP tenant↔repo table).
+- **NO LLM-`AgentRunResult` reuse.** The CI-run record here is a distinct type in a distinct namespace.
+
+---
+
+## Current-state findings (verify against the worktree before coding)
+
+| Seam | Where it is today | How 38-2 uses it |
+|---|---|---|
+| **Actions client** | `IGitHubActionsClient` — `OctokitGitHubActionsClient` in `Tamma.Api` (holds the Actions token); `NullGitHubActionsClient` in the engine (no-op). | Delegated to **inside `Tamma.Api`** only, with a request-scoped per-tenant token; the engine `Null` registration is removed. |
+| **Dispatch activities** | `Tamma.Activities/AgentDispatch/{DispatchAgentWorkflow,MonitorAgentWorkflow,CollectAgentResults}Activity.cs` + `GitHubActionsExecutor` — inject `IGitHubActionsClient`. | Gutted to thin `TammaApiClient` clients; drop the injection. |
+| **Inbound signal** | `AgentDispatch/WebhookSignalRegistry` — `Tamma.Api` receives `workflow_run.completed`, verifies the signature, signals the engine in-process; the dispatch activity suspends on a durable bookmark. | **UNCHANGED** (inbound, §5.3). A regression test proves suspend/resume still works. |
+| **Cross-tenant guard** | Story 38-1's `IGitRepoAuthorizer` (tenant↔repo registry, fail-closed). | **Reused** as the guard, FIRST, before token/dispatch. |
+| **Per-tenant token** | Epic 29 cabinet (the Actions analogue of 38-1's git token / 32-3's LLM key). | `ActionsTokenResolver` resolves BYOK→platform inside the API. |
+| **Engine→API callback** | `TammaApiClient` (Bearer `Tamma:ApiToken` + `X-Tenant-Id`; `PostAsync<T>`/`GetAsync<T>` + `AddTenantHeader` + `RecordHealthAsync`). | The transport + auth plane for the 2 endpoints; add 2 client methods. |
+| **DCB events** | `Tamma.Data` `IEventRepository.AppendAsync(DomainEvent)`, tenant-scoped. | Emit `AGENT_DISPATCH.RUN_TRIGGERED.*` / `RUN_POLLED.*` from the API. |
+| **Mode** | `Tamma.Api/Services/PromptStore/TammaMode.cs` — `ITammaModeProvider` (SingleUser | SaaS). | Principal keying for guard + token + audit. |
+
+**Key insight:** the only genuinely new code is the *endpoint shell* (`AgentDispatchEndpoints`), the
+*composition service* (`AgentDispatchMediationService`), the *token resolver* (`ActionsTokenResolver`),
+the *wire records*, and the *thin-client cutover* of three activities + two new `TammaApiClient`
+methods. The dispatch/poll itself is the existing `OctokitGitHubActionsClient`; the guard is 38-1's;
+the inbound signal path is untouched.
+
+---
+
+## Architecture
+
+```
+Engine: {DispatchAgentWorkflow(+GitHubActionsExecutor),MonitorAgentWorkflow,CollectAgentResults}Activity
+   |  (thin TammaApiClient client — NO token, NO Octokit)        ... then EXISTING bookmark suspend (unchanged)
+   v
+TammaApiClient.{DispatchAgentRun,GetAgentRun}Async
+   |  Bearer Tamma:ApiToken + X-Tenant-Id
+   v
+Tamma.Api  AgentDispatchEndpoints  ->  AgentDispatchMediationService.{TriggerRun,GetRun}Async:
+   1 authorize tenant↔repo   (IGitRepoAuthorizer — SHARED with 38-1)  -- CROSS-TENANT GUARD, FIRST -> 403 on deny
+   2 resolve token           (IActionsTokenResolver)  -- Epic 29 cabinet BYOK->platform -> 503 on null
+   3 dispatch/poll           (IGitHubActionsClient, request-scoped token, API-only)
+   4 emit AGENT_DISPATCH.*   (tenant IEventRepository)  -- exactly one terminal event
+   5 return AgentDispatchResult -> ToHttpResult (200 | 200 success:false | 403 | 503)
+
+INBOUND (UNCHANGED, §5.3):  GitHub workflow_run.completed -> Tamma.Api (verify sig) -> WebhookSignalRegistry
+                            -> in-process signal -> engine bookmark resume.   NO outbound call to mediate.
+```
+
+Per-mode ownership (CLAUDE.md two-scoping-model): single-user = the sole user's repo(s) + the user's
+token + events/signal in the user's instance; SaaS = only the `X-Tenant-Id` tenant's repo(s) + the
+tenant's BYOK token → platform + events in the tenant `t_<hex>` store, never cross-tenant; inbound
+signal in-process to that tenant's engine, unchanged. Mode from `ITammaModeProvider`.
+
+---
+
+## Task breakdown
+
+Order: T1 (wire records + event types) → T2 (token resolver) → T3 (mediation service: happy path)
+→ T4 (typed failures + audit) → T5 (endpoints) → T6 (thin-activity cutover + client methods) →
+T7 (engine-registration removal + inbound-unchanged regression). T1 ∥ T2.
+
+### T1 — Wire records + event-type constants
+
+**Scope:** The request/response shapes and `AGENT_DISPATCH.*` event constants. No behaviour.
+
+**Files (new):** `Services/AgentDispatch/AgentDispatchRequests.cs` (`DispatchRunRequest`),
+`Services/AgentDispatch/AgentDispatchResponses.cs` (`AgentDispatchResult`, `ArtifactDto`),
+`Services/AgentDispatch/AgentDispatchEventTypes.cs` (`AGENT_DISPATCH.RUN_TRIGGERED.*`,
+`AGENT_DISPATCH.RUN_POLLED.*`).
+
+**Tests (first):** `tests/Tamma.Api.Tests/AgentDispatch/AgentDispatchResultTests.cs` — record equality;
+`Success=false` always carries `FailureCode`+`FailureReason`; `CredentialSource` is `byok|platform`; no
+token field exists; the type is distinct from the LLM `AgentRunResult` (namespace check).
+
+**Acceptance:**
+- [ ] Records compile; `AgentDispatchResult` has all AC fields; **no field can carry the raw token**.
+- [ ] No name/namespace collision with `Tamma.Api/Services/Agents/AgentRunResult`.
+
+### T2 — Per-tenant Actions-token resolver (`IActionsTokenResolver`) — BYOK→platform, fail-closed
+
+**Scope:** `ActionsTokenResolver : IActionsTokenResolver` — `ResolveAsync(tenantId, repo, ct)` →
+`{ Token, Source }`. Epic 29 cabinet (tenant BYOK Actions token) → else platform-provided where
+allowed → else **null** (NEVER empty/default). Mirrors 38-1's `GitTokenResolver` / Story 32-3.
+
+**Files (new):** `Services/AgentDispatch/IActionsTokenResolver.cs`,
+`Services/AgentDispatch/ActionsTokenResolver.cs`.
+
+**Tests (first):** `tests/Tamma.Api.Tests/AgentDispatch/ActionsTokenResolverTests.cs` — cabinet has
+tenant token → `Source="byok"`; absent + platform allowed → `Source="platform"`; absent + not allowed
+→ null (fail-closed); the returned `Token` is never logged.
+
+**Acceptance:**
+- [ ] BYOK→platform→null order; null when unresolvable (no empty/default fallback).
+- [ ] `Source` is `byok|platform`; token never surfaces in logs.
+
+### T3 — `AgentDispatchMediationService` core composition (happy path)
+
+**Scope:** `AgentDispatchMediationService : IAgentDispatchMediationService` with `TriggerRunAsync` and
+`GetRunAsync`. Compose guard(1, reuse 38-1's `IGitRepoAuthorizer`) → token(2) → `IGitHubActionsClient`(3)
+→ audit(4) → result(5). Token request-scoped, dropped after the call.
+
+**Files (new):** `Services/AgentDispatch/IAgentDispatchMediationService.cs`,
+`Services/AgentDispatch/AgentDispatchMediationService.cs`.
+
+**Collaborators (constructor-injected — fakes in tests):** `IGitRepoAuthorizer` (38-1),
+`IActionsTokenResolver`, `IGitHubActionsClient`, `IEventRepository`, `ITammaModeProvider`,
+`ILogger<AgentDispatchMediationService>`.
+
+**Tests (first):** `tests/Tamma.Api.Tests/AgentDispatch/AgentDispatchMediationServiceTests.cs` —
+trigger + poll happy paths: guard→token→client→audit called once in order; correct response DTO
+populated; `credentialSource` copied from the resolver; exactly one terminal `AGENT_DISPATCH.*`
+event with the right tags.
+
+**Acceptance:**
+- [ ] Trigger + poll return a fully-populated `AgentDispatchResult{Success=true}`.
+- [ ] Guard runs BEFORE token; token BEFORE dispatch; one terminal event per call.
+
+### T4 — Typed failures + audit discipline (fail-closed, status preservation)
+
+**Scope:** Each step gets a typed-failure exit: guard deny → 403 `REPO_NOT_AUTHORIZED` (client never
+called, token never resolved); token null → 503 `ACTIONS_TOKEN_UNAVAILABLE` (`retryable:false`);
+platform error → **200 `success:false`** with `failureCode ∈ {WORKFLOW_NOT_FOUND, RUN_NOT_FOUND,
+DISPATCH_REJECTED, PLATFORM_ERROR}` and **preserved** `platformStatusCode`. No expected failure throws;
+no raw 5xx. Exactly one terminal `AGENT_DISPATCH.*.FAILED` event.
+
+**Files:** extend `AgentDispatchMediationService`; add a `ToHttpResult()` mapper.
+
+**Tests (first):** extend `AgentDispatchMediationServiceTests` — one test per failure code; guard-deny →
+client never invoked; token-null → client never invoked; platform 5xx → 200 `success:false` +
+`platformStatusCode` preserved (assert no raw 5xx); "exactly one terminal event per call" invariant.
+
+**Acceptance:**
+- [ ] All failure codes produce typed results; none throw; raw 5xx never leaks.
+- [ ] Guard-deny and token-null short-circuit before the dispatch.
+
+### T5 — Endpoints (`AgentDispatchEndpoints.cs`)
+
+**Scope:** Map `POST /api/v1/agent-dispatch/{repo}/runs` + `GET /api/v1/agent-dispatch/{repo}/runs/{id}`;
+engine-only auth (`EngineAuthPolicy` — same plane as `/llm/call`); bind `{repo}`/`{id}`/body; derive
+`tenantId` from `X-Tenant-Id`; delegate; `ToHttpResult`.
+
+**Files (new):** `Endpoints/AgentDispatchEndpoints.cs`; modify `Tamma.Api/Program.cs` (map endpoints;
+register service/token; `IGitHubActionsClient` stays API-only).
+
+**Tests (first):** `tests/Tamma.Api.Tests/Endpoints/AgentDispatchEndpointsTests.cs` — 401 missing/invalid
+bearer; valid bearer + `X-Tenant-Id` → bound + delegated; 403 on guard deny; 200 `success:false` +
+`platformStatusCode` on platform failure; happy 200 per route. `WebApplicationFactory` + fakes.
+
+**Acceptance:**
+- [ ] Both routes served, engine-only, 401 on missing bearer; DI resolves at host startup.
+
+### T6 — Thin-activity cutover + `TammaApiClient` methods (AC5)
+
+**Scope:** Gut `DispatchAgentWorkflowActivity` (+ `GitHubActionsExecutor`),
+`MonitorAgentWorkflowActivity`, `CollectAgentResultsActivity` to thin `TammaApiClient` clients (drop
+`IGitHubActionsClient`); add two client methods (`DispatchAgentRunAsync` / `GetAgentRunAsync`)
+following the existing `PostAsync<T>`/`GetAsync<T>` + `AddTenantHeader` + `RecordHealthAsync` pattern.
+Each activity writes the **same** workflow variables it writes today; the **dispatch activity's durable
+bookmark suspend is left exactly as-is** after the thin dispatch call.
+
+**Files:** modify `Tamma.Activities/AgentDispatch/{DispatchAgentWorkflow,MonitorAgentWorkflow,
+CollectAgentResults}Activity.cs` + `GitHubActionsExecutor.cs`; modify `Tamma.Api/Clients/TammaApiClient.cs`.
+
+**Tests (first):** `tests/Tamma.Activities.Tests/AgentDispatch/AgentDispatchThinClientTests.cs` — given
+each `AgentDispatchResult`, the activity writes the same `DispatchedRunId`/`RunStatus`/`AgentResults`
+variables as the legacy path; a minimal dispatch workflow branches on them unchanged; the activity
+holds no `IGitHubActionsClient`.
+
+**Acceptance:**
+- [ ] Three activities cut over; same variables out; no Octokit/platform-HTTP reference.
+- [ ] `grep` over `Tamma.Activities` for `IGitHubActionsClient` → zero.
+
+### T7 — Engine-registration removal + inbound-unchanged regression + credential-safety sweep
+
+**Scope:** Remove the engine's `NullGitHubActionsClient` registration in `Tamma.ElsaServer/Program.cs`;
+confirm no Actions token can be pushed into the engine process. Prove the inbound
+`workflow_run.completed` / `WebhookSignalRegistry` bookmark suspend/resume is unchanged. Credential-
+safety sweep: token never in any response/log/event.
+
+**Files:** modify `Tamma.ElsaServer/Program.cs`; add the inbound regression + credential-safety tests.
+
+**Tests (first):** `tests/Tamma.Activities.Tests/AgentDispatch/InboundSignalUnchangedTests.cs` —
+dispatch → durable bookmark suspend → simulated in-process `WebhookSignalRegistry` signal → resume;
+assert the path is unchanged and no outbound call is added to it. A credential-safety test over
+response/log/event payloads (no token substring). A host-boot smoke test asserting the engine resolves
+the activities **without** any Actions-client registration.
+
+**Acceptance:**
+- [ ] Engine holds no Actions token / Actions-client registration.
+- [ ] Inbound suspend→signal→resume unchanged (regression green).
+- [ ] Credential-safety test green: token absent from every response, log, and event.
+
+---
+
+## Story order & dependencies
+
+External/pattern prereqs: **Story 38-1** (the shared `IGitRepoAuthorizer` + the Class-A/C endpoint
+pattern — sequenced first in Epic 38 Phase 1), **Story 32-5** (the `/llm/call` template), **Epic 28**
+(tenant↔repo registry + per-tenant keying), **Epic 29** (cabinet — per-tenant Actions token),
+**Epic 9** (`TammaApiClient` plane + the inbound `WebhookSignalRegistry` signalling contract to
+preserve), **Epic 4** (DCB). Code to their interfaces with fakes until landed. Internal order:
+T1 ∥ T2 → T3 → T4 → T5 → T6 → T7. Downstream: 38-4 guardrail proves the cutover stays cut (not a
+blocker).
+
+## Verification
+
+```bash
+# build (no docker wrapper needed)
+dotnet build apps/tamma-elsa/Tamma.sln
+# tests (docker-bound suites need the sg wrapper; session docker group is stale)
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~AgentDispatch"
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Activities.Tests/ --filter FullyQualifiedName~AgentDispatch"
+# cutover proof: zero IGitHubActionsClient injections in the engine activities
+grep -rn "IGitHubActionsClient" apps/tamma-elsa/src/Tamma.Activities
+# inbound path untouched: WebhookSignalRegistry unchanged (review diff = empty for that file)
+git diff --stat -- apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/WebhookSignalRegistry.cs
+```
+
+## Risks
+
+- **Mis-scoped token → cross-tenant Actions dispatch (code execution)** (design §1.3 — THE Class-C
+  risk): Critical. The shared `IGitRepoAuthorizer` guard runs FIRST, before token resolution or
+  dispatch; deny → 403, never a call. Dedicated cross-tenant test asserts the client is unreachable on
+  deny. Token is per-tenant from the cabinet, never a shared default.
+- **Breaking the inbound bookmark suspend/resume** (design §5.3): Critical. This story does NOT touch
+  `WebhookSignalRegistry` or the `workflow_run.completed` path; the `InboundSignalUnchangedTests`
+  integration test proves dispatch→suspend→signal→resume is unchanged and no outbound call is added;
+  the `git diff --stat` for `WebhookSignalRegistry.cs` is empty.
+- **Raw 5xx leak breaks dispatch outcome mapping / bookmark contract:** High. The mapper always returns
+  200 `success:false` + preserved `platformStatusCode` for expected platform failures; 403/401/503 only
+  for guard/auth/credential; HTTP-status-fidelity test.
+- **Engine still holds an Actions token after cutover:** High. `IGitHubActionsClient` stays API-only;
+  remove `NullGitHubActionsClient` registration; `grep` confirms zero injections; T7 host-boot smoke
+  test; 38-4 makes it permanent.
+- **Token leak into log/response/event:** High. Request-scoped token dropped after the call;
+  `credentialSource` is the only credential field surfaced; explicit credential-safety test.
+- **Thin activity writes different variables → dispatch workflow breaks:** High. Map each result to the
+  exact legacy variable shapes; minimal dispatch workflow integration test.
+- **`AgentDispatchResult` vs LLM `AgentRunResult` collision:** Medium. Separate namespaces
+  (`Services/AgentDispatch` vs `Services/Agents`); no shared type; T1 namespace check.
+- **Empty/default token fallback:** Medium. Fail-closed: 503 `ACTIONS_TOKEN_UNAVAILABLE`,
+  `retryable:false`; never call with an empty token (`feedback_resolution_no_empty_fallback`).
+- **EF / control-plane table:** Low. This story adds **no** CP table (reuses Epic 28/29 + the tenant
+  `domain_events` stream; 38-1 owns any tenant↔repo CP table). No DROP-list entry, no
+  `ControlPlaneDbContextModelTests` edit. This plan **amends/extends the existing EF migration
+  snapshot**, it does not branch it (sequential implementation on one snapshot).
+- **Dependency timing (38-1 guard / 32-5 pattern / Epic 28-29):** Medium. Reuse 38-1's guard; mirror
+  32-5; code to interfaces; fakes until landed.

--- a/docs/superpowers/plans/2026-06-21-38-3-slack-notifications-step-mediation-plan.md
+++ b/docs/superpowers/plans/2026-06-21-38-3-slack-notifications-step-mediation-plan.md
@@ -1,0 +1,261 @@
+# Story 38-3 — Slack / Notifications Step Mediation (Class D) — Implementation Plan
+
+> **Date:** 2026-06-21
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — every task writes tests
+> before implementation.
+
+**Goal:** Re-point `Integration/SlackActivity` from the co-hosted, Slack-token-holding
+`IIntegrationService` to an internal **`POST /api/v1/notifications/slack`** endpoint that writes a
+post *intent* to a control-plane `slack_outbox` table, and an out-of-band **`OutboxSlackSender`** in
+`Tamma.Api` that alone holds the Slack token, performs the post (`chat.postMessage`), and audits it.
+This closes the last Class-D `VIOLATION-by-co-hosting` (design §1.2) and sets the **outbox pattern as
+the template for fire-and-forget external effects**, which the forward-looking Class-E (Stripe/billing,
+Epic 35) tie-in then inherits by design. The engine ends the story holding **no Slack token**.
+
+**Story file:** `docs/stories/epic-38/story-38-3/38-3-slack-notifications-step-mediation.md`
+**Design spec:** `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§1, §1.2 Class-D/E, §5.1, §5.2)
+
+**Tech stack:** .NET 9 / Elsa 3 in `apps/tamma-elsa`. Two processes: `Tamma.ElsaServer` (engine, no
+secrets) + `Tamma.Api` (holds creds, audits). EF Core migrations (one snapshot — sequential, do NOT
+branch). Tests via `sg docker -c "dotnet test ..."` (session docker group is stale; plain
+`dotnet build` needs no wrapper). xUnit. **`packages/api` is DELETED — all of this is C#.**
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO synchronous Slack mediation.** A Slack post is fire-and-forget; it uses the outbox shape
+  (`QueueWelcomeEmailActivity`), not the request/response shape (`/llm/call`). Do not add a "call
+  Slack and return the result" path.
+- **NO Stripe / billing code.** The Class-E tie-in is **documentation-only** in the story; this plan
+  writes zero billing code. (38-4's analyzer will later guard a hypothetical `BillingActivity`.)
+- **NO per-tenant Slack BYOK.** Today there is one platform `Slack:BotToken`. Per-tenant Slack keys via
+  the Epic 29 cabinet are a future extension; the entity carries the XOR scoping room but the resolver
+  uses the platform token.
+- **NO change to the GitHub/JIRA/CI members of the `IIntegrationService` composite.** Only the Slack
+  methods are deregistered from the engine here; GitHub is 38-1's job. Coordinate the split.
+- **NO new tool loop / sanitizer.** Out of scope; this is a notification effect.
+
+---
+
+## Current-state findings (verified 2026-06-21, `feat/exec-wave-02`)
+
+| Seam | Where it is today | How 38-3 uses it |
+|---|---|---|
+| **Slack activity** | `Tamma.Activities/Integration/SlackActivity.cs` — `CodeActivity<SlackOperationResult>`, injects `IIntegrationService`, branches on `Input<SlackAction>` (`SendChannel`/`SendDirect`/`SendAssessment`/`SendGuidance`/`SendNotification`), calls `SendSlackMessageAsync`/`SendSlackDirectMessageAsync` **in-engine**; formats via `FormatMessage`/`SendAssessmentRequest`/`SendGuidanceMessage`; logs a `MentorshipEvent` on success. | **Gut** to a thin client; move the formatting to the API; drop `IIntegrationService`; keep the `MentorshipEvent` local write. |
+| **Composite integration service** | `Tamma.Core/Interfaces/IIntegrationService.cs` — composite with `SendSlackMessageAsync(channel,msg)` / `SendSlackDirectMessageAsync(userId,msg)` (token-holding impl in `Tamma.Api`, unregistered/null in engine). | **Deregister the Slack methods from the engine**; the API keeps its impl for `OutboxSlackSender`. |
+| **Outbox template** | `Tamma.Activities/TenantLifecycle/QueueWelcomeEmailActivity.cs` → CP `platform_email_outbox` (`PlatformEmailOutboxMessage`) via `IPlatformEmailOutboxRepository.EnqueueWelcomeOnceAsync` (in-code pre-check + partial unique index `(TenantId, Template) WHERE Status <> 'failed'`); delivered out-of-band by `OutboxSmtpSender`; enqueue is non-fatal. | **Mirror verbatim** for `slack_outbox` / `SlackOutboxMessage` / `OutboxSlackSender` / exactly-once enqueue. |
+| **Engine→API seam** | `Tamma.Activities/LlmCall/TammaApiClient.cs` — Bearer `Tamma:ApiToken` + `X-Tenant-Id`; `PostAsync<T>` / `PostVoidAsync` (null/false on failure) / `AddTenantHeader` / `RecordHealthAsync`. | **Add `QueueSlackNotificationAsync`** via `PostVoidAsync`. |
+| **Engine-callback template** | `Tamma.Activities/Testing/TriggerCIActivity.cs` — POSTs to an internal `Engine:CallbackUrl/api/engine/trigger-ci`, holds no vendor key. | Reference for "step holds no external credential". |
+| **CP DROP list + model test** | `Tamma.ElsaServer/Program.cs` "Wiping Tamma-managed public-schema tables"; `tests/.../Epic28/ControlPlaneDbContextModelTests.cs` `Model_Has_ExpectedControlPlaneEntities` (strict `BeEquivalentTo`). | **Append `slack_outbox` / `SlackOutboxMessage`** to both (AC8) — otherwise 2nd-boot fails. |
+
+**Key insight:** the only genuinely new code is the *endpoint*, the *CP outbox entity/repo/migration*,
+the *out-of-band sender* (token-holder), and the *thin-client gut* of one activity. Everything else is
+copying the `platform_email_outbox`/`OutboxSmtpSender` pattern and the `TammaApiClient` callback pattern.
+
+---
+
+## Architecture
+
+```
+SlackActivity (Elsa, engine)                       -- thin client; NO token, NO IIntegrationService
+        |  TammaApiClient.QueueSlackNotificationAsync(req)  (Bearer Tamma:ApiToken + X-Tenant-Id)
+        v
+POST /api/v1/notifications/slack  (Tamma.Api)      -- engine-only auth; writes INTENT only; 202
+        |  ISlackNotificationService.EnqueueAsync   (formats server-side; de-dupes; inserts row)
+        v
+slack_outbox (CP table)  Status=pending            -- token NOT read here
+        |
+        v  (out-of-band)
+OutboxSlackSender (Tamma.Api hosted)               -- THE token-holder (Slack:BotToken)
+        |  chat.postMessage / DM-open  (the ONLY Slack HTTPS call)
+        v
+Slack  ->  row Status=sent + SentAt                -- NOTIFICATION.SLACK.SENT.SUCCESS (tenant IEventRepository)
+           or backoff/failed                       -- NOTIFICATION.SLACK.SENT.FAILED (key-free)
+```
+
+Per-mode (CLAUDE.md two-scoping-model): single-user = `UserId`-scoped outbox row + user event store;
+SaaS = `TenantId`-scoped row + tenant `t_<hex>` event store; data never cross-tenant. Token is the
+platform `Slack:BotToken` in both modes (per-tenant Slack BYOK is a future extension). Mode from
+`ITammaModeProvider`.
+
+---
+
+## Task breakdown
+
+Order: T1 (records + CP entity) → T2 (repo + migration + DROP-list/model-test) → T3 (endpoint +
+service + formatting) → T4 (`OutboxSlackSender` + audit) → T5 (thin `SlackActivity` + client method +
+engine deregistration) → T6 (mode/credential-safety/dedup isolation). T1 is a prerequisite for all;
+T3 needs T2; T5 needs T3.
+
+### T1 — Records + CP outbox entity (`SlackNotificationRequest`, `SlackOutboxMessage`)
+
+**Scope:** The wire request and the CP outbox row shape. No behaviour.
+
+**Files (new):** `Tamma.Api/Services/Notifications/SlackNotificationRequest.cs`,
+`Tamma.Data/Entities/SlackOutboxMessage.cs` (mirror `PlatformEmailOutboxMessage`: `Id`, `TenantId?`,
+`UserId?` XOR, `Action`, `Channel?`, `UserHandle?`, `FormattedMessage`, `SessionId?`, `CorrelationId`,
+`Status`, `Attempts`, `MaxAttempts`, `NextAttemptAt`, `LastError?`, `CreatedAt`, `UpdatedAt`, `SentAt?`).
+
+**Tests (first):** `Tamma.Api.Tests/Notifications/SlackNotificationRequestTests.cs` — required fields
+enforced (`Action`, `Message`, `CorrelationId`); `MessageType` defaults to `Info`; record equality.
+
+**Acceptance:**
+- [ ] `SlackNotificationRequest` carries the AC3 fields.
+- [ ] `SlackOutboxMessage` mirrors `PlatformEmailOutboxMessage` shape with Slack-specific columns.
+- [ ] Builds clean; no analyzer warnings.
+
+### T2 — Repository + migration + CP registration (AC8/AC9)
+
+**Scope:** EF mapping for `SlackOutboxMessage`, the exactly-once `EnqueueOnceAsync`, the partial unique
+index, and the destructive-DROP-list + model-contract-test registration.
+
+**Files:** new `Tamma.Data/Repositories/ISlackOutboxRepository.cs` (`EnqueueOnceAsync`,
+`ClaimPendingAsync`, `MarkSentAsync`, `MarkFailedAsync`), `Tamma.Data/Repositories/SlackOutboxRepository.cs`;
+new `Tamma.Data/Migrations/<ts>_AddSlackOutbox.cs` (amends the existing snapshot — sequential, do NOT
+branch); modify `Tamma.ElsaServer/Program.cs` (append `slack_outbox` to the public-schema DROP list);
+modify `tests/.../Epic28/ControlPlaneDbContextModelTests.cs` (add `SlackOutboxMessage` to the strict
+`BeEquivalentTo` list); EF model config in `Tamma.Api/Program.cs` (or the CP DbContext config).
+
+**Partial unique index:** `(CorrelationId, Action, COALESCE(Channel, UserHandle)) WHERE Status <> 'failed'`
+(mirrors `(TenantId, Template) WHERE Status <> 'failed'`).
+
+**Tests (first):** `Tamma.Api.Tests/Notifications/SlackOutboxRepositoryTests.cs` — `EnqueueOnceAsync`
+inserts one row; a second enqueue with the same `(correlationId, action, target)` returns the existing
+id, inserts nothing; `ClaimPendingAsync` returns only `pending` rows past `NextAttemptAt`;
+`MarkSent`/`MarkFailed` transition state. **2nd-test-host-boot test** (no `relation already exists`) and
+`ControlPlaneDbContextModelTests` green.
+
+**Acceptance:**
+- [ ] Exactly-once enqueue on replay (DB-enforced + in-code pre-check).
+- [ ] `slack_outbox` is in the DROP list (2nd boot succeeds) and the CP model test passes.
+- [ ] Docker-bound repo tests green via `sg docker -c "dotnet test ..."`.
+
+### T3 — Endpoint + notification service (formatting + enqueue) (AC1/AC2/AC3)
+
+**Scope:** `POST /api/v1/notifications/slack` (engine-only auth), `ISlackNotificationService.EnqueueAsync`
+that formats the message server-side (move `FormatMessage`/assessment/guidance templating from
+`SlackActivity`), de-dupes, inserts the row, emits `NOTIFICATION.SLACK.QUEUED.SUCCESS`, returns 202.
+**Never reads the token; never calls Slack.**
+
+**Files:** new `Tamma.Api/Endpoints/NotificationEndpoints.cs`,
+`Tamma.Api/Services/Notifications/ISlackNotificationService.cs` +
+`SlackNotificationService.cs`; modify `Tamma.Api/Program.cs` (map endpoint; register service).
+
+**Tests (first):** `Tamma.Api.Tests/Notifications/NotificationEndpointsTests.cs` — 401 missing bearer;
+202 + `{ outboxId }` + one `slack_outbox` row + **Slack-HTTP-never-called** (spy) + **token-not-read**
+(the sender's token source is untouched); `tenantId` derived from `X-Tenant-Id`; server-side formatting
+matches the legacy `SlackActivity.FormatMessage` output; one QUEUED event.
+
+**Acceptance:**
+- [ ] Endpoint writes intent, returns 202, never calls Slack synchronously.
+- [ ] Formatting moved server-side; raw token never read in the request path.
+- [ ] DI resolves the endpoint at host startup (smoke / `WebApplicationFactory`).
+
+### T4 — `OutboxSlackSender` (token-holder, out-of-band, audit) (AC4/AC7)
+
+**Scope:** The single token-holder. A hosted/background scanner mirroring `OutboxSmtpSender`: read
+`Slack:BotToken`, `ClaimPendingAsync`, post (`chat.postMessage` / DM-open), `MarkSent` + audit
+`NOTIFICATION.SLACK.SENT.SUCCESS`, or backoff/`MarkFailed` + `NOTIFICATION.SLACK.SENT.FAILED`
+(key-free `failureReason`).
+
+**Files:** new `Tamma.Api/Services/Notifications/OutboxSlackSender.cs`; modify `Tamma.Api/Program.cs`
+(register hosted; inject `IHttpClientFactory`, `ISlackOutboxRepository`, tenant `IEventRepository`).
+
+**Tests (first):** `Tamma.Api.Tests/Notifications/OutboxSlackSenderTests.cs` — happy path (token read,
+faked HTTP post, `sent` + `SentAt`, one SUCCESS event); transient failure (`LastError` key-free,
+`Attempts++`, `NextAttemptAt` backoff, stays `pending`); terminal failure (`>= MaxAttempts` → `failed`
++ one FAILED event); **credential-safety**: token never appears in row/`LastError`/log/event; event
+message preview is redacted/length-bounded.
+
+**Acceptance:**
+- [ ] Sender is the only token-holder; performs the only Slack HTTPS call.
+- [ ] Failure path backs off then terminates; events emitted from the tenant `IEventRepository`.
+- [ ] Token never leaks (credential-safety test passes).
+
+### T5 — Thin `SlackActivity` + client method + engine deregistration (AC5/AC6/AC10)
+
+**Scope:** Gut `SlackActivity` to a thin client; add `TammaApiClient.QueueSlackNotificationAsync`;
+remove the engine's Slack `IIntegrationService` registration (coordinate the composite split with 38-1).
+
+**Files:** modify `Tamma.Activities/Integration/SlackActivity.cs` (drop `IIntegrationService`; map
+props → request; `QueueSlackNotificationAsync`; `SlackOperationResult{ WaitingForResponse=false }`;
+keep `MentorshipEvent` local log; fail-soft); modify `Tamma.Activities/LlmCall/TammaApiClient.cs` (add
+`QueueSlackNotificationAsync` via `PostVoidAsync`); modify `Tamma.ElsaServer/Program.cs` (remove engine
+Slack registration).
+
+**Tests (first):** `Tamma.Activities.Tests/Integration/SlackActivityThinClientTests.cs` — prop→request
+mapping for each `SlackAction`; `SlackOperationResult{ Success=queued, WaitingForResponse=false }`;
+`MentorshipEvent` logged on success; **fail-soft** (API down → `Success=false`, no throw); constructor
+injects **no `IIntegrationService`**. **AC6 grep test:** zero `chat.postMessage`/`slack.com`/Slack
+`IIntegrationService` usage under `Tamma.Activities` outside `TammaApiClient`.
+
+**Acceptance:**
+- [ ] `SlackActivity` holds no token and no `IIntegrationService`; queues via the client method.
+- [ ] Engine registers no Slack-credential service.
+- [ ] Fail-soft preserved; output contract unchanged for the mentorship workflows.
+
+### T6 — Mode separation, dedup & credential-safety isolation
+
+**Scope:** Prove per-mode scoping (`UserId` vs `TenantId`), replay dedup end-to-end, and zero token
+leakage across the whole path; prove events land in the right store and never cross-tenant.
+
+**Files:** extend the notification/sender tests with a mode matrix + a two-tenant isolation assertion.
+
+**Tests (first):**
+- single-user → outbox row `UserId` set / `TenantId` null; events in the user store.
+- SaaS → `TenantId` set / `UserId` null; events in the tenant `t_<hex>` store.
+- two tenants → rows + events tagged with their own scope; no leakage.
+- replay → two enqueues for the same `(correlationId, action, target)` yield one row (end-to-end).
+- token never appears in any row/response/log/event across the full path.
+
+**Acceptance:**
+- [ ] Mode matrix passes; scoping correct in both modes.
+- [ ] Cross-tenant isolation holds; replay dedup holds end-to-end.
+
+---
+
+## Story order & dependencies
+
+External siblings to coordinate (not hard blockers, but they touch the same shared composite /
+template): **38-1** (deregisters the GitHub members of `IIntegrationService`; split the engine
+deregistration cleanly), **38-2** (same `TammaApiClient`/endpoint template), **38-4** (lands its
+allowlist after `QueueSlackNotificationAsync` exists so `TammaApiClient` is allowed). Internal:
+T1 → T2 → T3 → T4 → T5 → T6. Downstream consumers (36 analytics, 37 audit, 35 billing-via-Class-E
+pattern) are NOT blockers.
+
+## Verification
+
+```bash
+# build (no docker wrapper needed)
+dotnet build apps/tamma-elsa/Tamma.sln
+# tests (docker-bound suites need the sg wrapper; session docker group is stale)
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~Notifications"
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Activities.Tests/ --filter FullyQualifiedName~Integration"
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests/ --filter FullyQualifiedName~ControlPlaneDbContextModelTests"
+# AC6 no-violation check: engine holds no Slack token / makes no Slack call
+grep -rn "chat.postMessage\|slack.com\|SendSlackMessageAsync\|SendSlackDirectMessageAsync" apps/tamma-elsa/src/Tamma.Activities
+```
+
+## Risks
+
+- **CP-table 2nd-boot break (T2, AC8):** any new public-schema table not in the `Program.cs` DROP list
+  fails the 2nd test-host boot with `relation already exists`, and the strict `ControlPlaneDbContextModelTests`
+  list rejects the new entity. Mitigation: append `slack_outbox`/`SlackOutboxMessage` to both in T2;
+  the 2nd-boot test is the net.
+- **Engine still holds a token (T5, AC6):** mitigation: remove the engine Slack registration; grep the
+  activities for Slack calls → zero; 38-4 makes it permanent.
+- **Replay double-post (T2/T6, AC9):** mitigation: partial unique index `WHERE Status <> 'failed'` +
+  in-code pre-check (mirrors `EnqueueWelcomeOnceAsync`); end-to-end dedup test.
+- **Token leak into a row/event/log (T4, AC7):** mitigation: token read only in `OutboxSlackSender`;
+  `LastError` key-free; event message preview redacted/length-bounded; credential-safety test asserts
+  zero occurrences.
+- **Dangling shared-composite registration with 38-1:** mitigation: coordinate the `IIntegrationService`
+  deregistration split (Slack here, GitHub in 38-1) before either lands.
+- **EF parallel-migration hazard:** mitigation: this story amends the existing snapshot (one
+  `AddSlackOutbox` migration), implemented sequentially relative to 38-1/38-2/38-4 — never branch the
+  snapshot.
+- **Output-contract drift breaks mentorship workflows (T5, AC5):** mitigation: preserve `SlackOperationResult`
+  shape + the `MentorshipEvent` local log; thin-client mapping test.

--- a/docs/superpowers/plans/2026-06-21-38-4-build-time-guardrail-analyzer-plan.md
+++ b/docs/superpowers/plans/2026-06-21-38-4-build-time-guardrail-analyzer-plan.md
@@ -1,0 +1,251 @@
+# Story 38-4 — Build-Time Guardrail Analyzer (rule-1 enforcement) — Implementation Plan
+
+> **Date:** 2026-06-21
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Project is test-first (TDD) — write the analyzer test
+> fixtures (positive / negative / exempt) BEFORE the analyzer.
+
+**Goal:** A permanent, build-failing backstop for the "steps never call external APIs directly" rule
+(design §0/§1) across Epics 32 + 38. A Roslyn `DiagnosticAnalyzer` (**`TAMMA001`**, severity **Error**)
+plus a reflection-backed architecture test that **fail the build** if any class under the engine
+surface (`Tamma.Activities` / `Tamma.ElsaServer`) references `HttpClient`/`PostAsync`/`PostAsJsonAsync`/
+`SendAsync` to a non-`TammaApiClient`, non-`Engine:CallbackUrl` host, or injects a credential-holding
+vendor service (Octokit / `IGitHubActionsClient` / Slack/Stripe client / vendor `IIntegrationService`
+members / raw `IProviderCredentialResolver`). So a re-introduced direct external call can never compile.
+
+**Story file:** `docs/stories/epic-38/story-38-4/38-4-build-time-guardrail-analyzer.md`
+**Design spec:** `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md` (§1, §1.2, §5.2, §5.3)
+
+**Tech stack:** .NET 9 / Elsa 3 in `apps/tamma-elsa`. Solution `Tamma.sln`. Central props
+`Directory.Build.props` (`TreatWarningsAsErrors=false`, `EnforceCodeStyleInBuild=true`). CI:
+`.github/workflows/ci.yml` runs `dotnet build Tamma.sln --no-restore -c Release` then
+`dotnet test Tamma.sln` with `working-directory: apps/tamma-elsa`. The analyzer is a separate
+`netstandard2.0` project referenced as an `Analyzer`. Tests via `sg docker -c "dotnet test ..."` where
+docker-bound; the **primary check here is `dotnet build`** (needs no wrapper). **`packages/api` is
+DELETED — all C#.**
+
+---
+
+## Non-goals (YAGNI guard)
+
+- **NO fixing of current violations.** That is the cutover work of 32-5 / 38-1 / 38-2 / 38-3. This
+  story is the **backstop**; sequence it **last** so the engine surface is already clean.
+- **NO enforcement on `Tamma.Api`.** The API is *supposed* to hold credentials and call vendors — the
+  analyzer's `CompilationStartAction` early-returns unless the assembly is the engine surface.
+- **NO flagging of the §5.3 exempt categories.** `ICLIAgentProvider`, local tools
+  (`FileReadTool`/`ShellExecuteTool`/`GitOperationsTool`), and inbound webhook receivers
+  (`WebhookSignalRegistry`) are local/inbound, not external API calls — they must NOT trip `TAMMA001`.
+- **NO runtime footprint.** No DB table, no EF migration, no CP entity → no `Program.cs` DROP-list
+  entry, no `ControlPlaneDbContextModelTests` change.
+- **NO Stripe/billing code.** The denylist is forward-compatible (add the Stripe type when Epic 35
+  references the SDK), but this story writes no billing code.
+
+---
+
+## Current-state findings (verified 2026-06-21, `feat/exec-wave-02`)
+
+| Fact | Detail | Plan impact |
+|---|---|---|
+| **No existing analyzer infra** | `grep -rl "DiagnosticAnalyzer\|Microsoft.CodeAnalysis" *.csproj` → none. Clean slate. | New `Tamma.Activities.Guardrails` analyzer project from scratch. |
+| **Solution + projects** | `apps/tamma-elsa/Tamma.sln`; engine surface = `src/Tamma.Activities` + `src/Tamma.ElsaServer`; `src/Tamma.Api` is the allowed-to-call-vendors side. | Reference the analyzer from the two engine projects only. |
+| **Central props** | `Directory.Build.props`: `TreatWarningsAsErrors=false`, `EnforceCodeStyleInBuild=true`, `AnalysisLevel=latest`. | Declare `TAMMA001` at `DiagnosticSeverity.Error` (a `Warning` would NOT fail the build). |
+| **CI gate** | `.github/workflows/ci.yml`: `dotnet build Tamma.sln --no-restore -c Release` then `dotnet test Tamma.sln`, `working-directory: apps/tamma-elsa`. | The build step is the gate — analyzer-as-Error fails it; **no new CI job needed**. |
+| **Sanctioned seams** | `TammaApiClient` (`Tamma.Activities/LlmCall/TammaApiClient.cs`, Bearer `Tamma:ApiToken` + `X-Tenant-Id`); `TriggerCIActivity` (`Tamma.Activities/Testing/TriggerCIActivity.cs`, POST to `Engine:CallbackUrl/api/engine/trigger-ci`); `QueueWelcomeEmailActivity` (outbox — no engine-side external call). | Encode these in the allowlist; assert no false positive on them. |
+| **Vendor denylist source** | design §1.2 audit table: `Octokit`/`IGitHubIntegrationService`, `IGitHubActionsClient`, `IIntegrationService` Slack/GitHub members, `IProviderCredentialResolver`, (future) Slack/Stripe clients. | The denylist is data derived directly from the table. |
+| **Exempt categories** | design §5.3: `ICLIAgentProvider` (local process), local tools, `WebhookSignalRegistry` (inbound). | Encode as `ExemptBaseTypes`; assert no diagnostic. |
+
+**Key insight:** the only new code is one analyzer (two detection passes — invocation + symbol), the
+allow/deny/exempt data, the analyzer unit tests with fixtures, the reflection backstop, and the
+project-reference wiring. No runtime code, no DB.
+
+---
+
+## Architecture
+
+```
+dotnet build Tamma.sln -c Release  (CI gate — ci.yml)
+        |
+        v
+Tamma.Activities / Tamma.ElsaServer  --(ProjectReference OutputItemType="Analyzer")-->  Tamma.Activities.Guardrails
+        |                                                                                       |
+        |  every type in the engine-surface compilation                                        v
+        |                                                                  EngineExternalCallAnalyzer
+        |                                                                    (a) InspectInvocation: HttpClient.Post*/Send*/Get*
+        |                                                                        target host ∉ {TammaApiClient, Engine:CallbackUrl}? -> TAMMA001 (Error)
+        |                                                                    (b) InspectConstructor/Field: type ∈ VendorDenylist? -> TAMMA001 (Error)
+        |                                                                    exempt: ICLIAgentProvider / local tools / WebhookSignalRegistry
+        v
+build FAILS on TAMMA001  <-- a re-introduced direct external call can never compile
+
+dotnet test Tamma.sln
+        |
+        +-- EngineExternalCallAnalyzerTests   (Roslyn analyzer test cases: positive/negative/exempt)
+        +-- ActivitiesGuardrailTests          (reflection backstop on real Tamma.Activities + positive-control proof analyzer is wired)
+```
+
+**Mode-independent:** build-time only; no `ITammaModeProvider`, no tenant/user scoping, no request
+principal. (The rule it enforces is *why* both modes stay safe, but the check is the same build for both.)
+
+---
+
+## Task breakdown
+
+Order: T1 (analyzer project + descriptor + allowlist data) → T2 (invocation pass) → T3 (injection
+pass) → T4 (exemptions + non-engine-surface skip) → T5 (project-reference wiring + sln) → T6
+(reflection backstop + suppression-resistance). TDD: each detection task writes its fixtures first.
+
+### T1 — Analyzer project scaffold + `TAMMA001` descriptor + allow/deny data
+
+**Scope:** The `netstandard2.0` analyzer project, the `DiagnosticDescriptor` (Error severity), and the
+allowlist/denylist/exempt data. No detection logic yet.
+
+**Files (new):** `src/Tamma.Activities.Guardrails/Tamma.Activities.Guardrails.csproj`
+(references `Microsoft.CodeAnalysis.CSharp.Workspaces` at the repo-pinned Roslyn version;
+`<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>`),
+`GuardrailDiagnostics.cs` (`TAMMA001`, title, `category="Tamma.Architecture"`,
+`DiagnosticSeverity.Error`, `helpLinkUri` → design doc), `Allowlist.cs`
+(`IsEngineSurface`, `ApiClientType`, `CallbackHostConfigKey`, `VendorDenylist`, `ExemptBaseTypes`).
+
+**Tests (first):** `tests/Tamma.Activities.Guardrails.Tests/GuardrailDiagnosticsTests.cs` — id is
+`TAMMA001`; category `Tamma.Architecture`; `DefaultSeverity == Error`; `IsEnabledByDefault`.
+
+**Acceptance:**
+- [ ] Analyzer project builds as `netstandard2.0`; descriptor severity is `Error`.
+- [ ] Allow/deny/exempt sets encode the §1.2 / §5.3 data.
+
+### T2 — Detection pass (a): direct external HTTP call (AC2/AC4)
+
+**Scope:** `RegisterOperationAction(OperationKind.Invocation)` (gated by `RegisterCompilationStartAction`
++ `IsEngineSurface`). Flag `HttpClient.PostAsync`/`PostAsJsonAsync`/`PutAsJsonAsync`/`SendAsync`/
+`GetAsync`-family where the receiver is not a `TammaApiClient`-owned client and the URL arg host is not
+`Engine:CallbackUrl`-rooted. Allow `IHttpClientFactory` usage feeding those two.
+
+**Files:** `EngineExternalCallAnalyzer.cs` (invocation pass).
+
+**Tests (first):** `tests/Tamma.Activities.Guardrails.Tests/EngineExternalCallAnalyzerTests.cs` +
+`Fixtures/`:
+- positive: `httpClient.PostAsJsonAsync("https://api.github.com/...")` in a `Tamma.Activities`-named
+  compilation → one `TAMMA001`.
+- negative: `_api.QueueSlackNotificationAsync(...)` / `_api.CallLlmAsync(...)` (TammaApiClient) → none.
+- negative: `PostAsJsonAsync($"{callbackUrl}/api/engine/...")` (Engine:CallbackUrl) → none.
+
+**Acceptance:**
+- [ ] Direct vendor HTTP call → `TAMMA001` Error.
+- [ ] `TammaApiClient` + engine-callback calls → no diagnostic.
+
+### T3 — Detection pass (b): credential-holding vendor-service injection (AC3)
+
+**Scope:** `RegisterSymbolAction(SymbolKind.Method)` for constructors + `SymbolKind.Field` for injected
+fields. Flag a parameter/field whose type ∈ `VendorDenylist`
+(`Octokit.IGitHubClient`, `IGitHubActionsClient`, `IIntegrationService`, `IProviderCredentialResolver`,
+future Slack/Stripe clients).
+
+**Files:** `EngineExternalCallAnalyzer.cs` (injection pass).
+
+**Tests (first):** extend `EngineExternalCallAnalyzerTests` — ctor taking `Octokit.IGitHubClient` /
+`IGitHubActionsClient` / `IProviderCredentialResolver` / a Slack client → `TAMMA001`; a ctor taking
+`TammaApiClient` / `ILogger` / `IHttpClientFactory` → none.
+
+**Acceptance:**
+- [ ] Denylisted vendor-service injection → `TAMMA001` Error.
+- [ ] Sanctioned dependencies → no diagnostic.
+
+### T4 — Exemptions + non-engine-surface skip (AC5/AC6)
+
+**Scope:** Ensure the §5.3 exempt categories never trip, and that the analyzer does nothing on a
+non-engine-surface compilation (e.g. `Tamma.Api`).
+
+**Files:** `EngineExternalCallAnalyzer.cs` (exempt check on the containing type's base/interface set);
+`Allowlist.ExemptBaseTypes`.
+
+**Tests (first):** extend the analyzer tests —
+- `ICLIAgentProvider` impl with a local-process call → none.
+- local tool (`FileReadTool`/`ShellExecuteTool`/`GitOperationsTool`) → none.
+- `WebhookSignalRegistry` (inbound) → none.
+- the *same* direct vendor call inside a `Tamma.Api`-named compilation → none (API is allowed).
+
+**Acceptance:**
+- [ ] Exempt categories never flagged; non-engine-surface never flagged.
+
+### T5 — Project-reference wiring + solution (AC1/AC8)
+
+**Scope:** Reference the analyzer from `Tamma.Activities` and `Tamma.ElsaServer` as an `Analyzer`; add
+the analyzer + its test project to `Tamma.sln`. Confirm a violation fails `dotnet build Tamma.sln -c Release`.
+
+**Files:** modify `src/Tamma.Activities/Tamma.Activities.csproj` +
+`src/Tamma.ElsaServer/Tamma.ElsaServer.csproj`
+(`<ProjectReference ... OutputItemType="Analyzer" ReferenceOutputAssembly="false" />`); modify
+`Tamma.sln`.
+
+**Tests (first):** a CI-shaped smoke — `dotnet build Tamma.sln -c Release` is clean on the real (post-cutover)
+engine surface; a temporary bad fixture compiled into `Tamma.Activities` would fail it (proven via the
+analyzer test, not by polluting the real tree).
+
+**Acceptance:**
+- [ ] Analyzer runs during `dotnet build Tamma.sln`; clean `main` passes.
+- [ ] A re-introduced violation fails the build (no new CI job).
+
+### T6 — Reflection backstop + suppression-resistance (AC7/AC8)
+
+**Scope:** Defense-in-depth: a reflection test on the built `Tamma.Activities` assembly + a
+positive-control proving the analyzer is wired + a check that no `TAMMA001` suppression exists under the
+engine surface.
+
+**Files:** new `tests/Tamma.Activities.Tests/Guardrails/ActivitiesGuardrailTests.cs`;
+`Fixtures/` known-bad assembly for the positive control.
+
+**Tests (first):**
+- the real `Tamma.Activities` assembly has no ctor/field of a denylisted vendor type (post-cutover clean).
+- a positive-control fixture type trips `TAMMA001` (analyzer active, not suppressed).
+- no `#pragma warning disable TAMMA001` / `<NoWarn>TAMMA001</NoWarn>` exists under the engine surface
+  (grep + assertion).
+
+**Acceptance:**
+- [ ] Reflection backstop green on the clean assembly; positive control trips.
+- [ ] No suppression of `TAMMA001` anywhere under the engine surface.
+
+---
+
+## Story order & dependencies
+
+**Sequence 38-4 LAST in Epic 38** — after 32-5 (removes the nine direct-LLM callers) and 38-1/38-2/38-3
+(git/agent-dispatch/Slack cutovers), so the engine surface is already clean and the analyzer passes from
+day one. The allowlist references `TammaApiClient` + the client methods those stories add
+(`CallLlmAsync`, the git/agent-dispatch methods, `QueueSlackNotificationAsync`). Forward-compatible with
+**Epic 35** (add the Stripe SDK type to the denylist when referenced). No runtime consumers — every
+future Epic-32/38 story is implicitly protected.
+
+## Verification
+
+```bash
+# build is the PRIMARY check — the analyzer-as-Error fails it on a violation
+dotnet build apps/tamma-elsa/Tamma.sln --no-restore -c Release
+# analyzer unit tests + reflection backstop
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Activities.Guardrails.Tests/"
+sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Activities.Tests/ --filter FullyQualifiedName~Guardrails"
+# suppression-resistance: no one turned the gate off
+grep -rn "TAMMA001" apps/tamma-elsa/src/Tamma.Activities apps/tamma-elsa/src/Tamma.ElsaServer | grep -i "disable\|NoWarn"   # expect: none
+# the rule it backstops, also as a raw grep (the analyzer is the real gate; this is a sanity check)
+grep -rn "api.anthropic.com\|api.openai.com\|api.github.com\|chat.postMessage\|api.stripe.com" apps/tamma-elsa/src/Tamma.Activities   # expect: none
+```
+
+## Risks
+
+- **`Warning` severity → does not fail the build** (`TreatWarningsAsErrors=false` repo-wide).
+  Mitigation: `DefaultSeverity = Error`; descriptor-severity test; CI `dotnet build` proves failure.
+- **False positive on a sanctioned seam → contributors disable the analyzer.** Mitigation: precise
+  allowlist (`TammaApiClient` + `Engine:CallbackUrl` + `IHttpClientFactory` feeding them) + explicit
+  §5.3 exemptions; negative-control + exemption tests; help message points to the fix.
+- **Suppression bypass (`#pragma`/`<NoWarn>`).** Mitigation: T6 reflection/grep assertion that no
+  `TAMMA001` suppression exists under the engine surface; positive-control fixture proves it is active.
+- **Dynamic `HttpClient` path evades the syntactic analyzer.** Mitigation: the reflection backstop +
+  the *injection* denylist (the usual entry point for a vendor client is being injected).
+- **Roslyn analyzer-testing API drift.** Mitigation: WebSearch the latest
+  `Microsoft.CodeAnalysis.CSharp.Analyzer.Testing` API before coding; pin to the repo Roslyn version;
+  fixtures-first TDD surfaces breaks early. (Per global instruction: research latest docs before using
+  analyzer/CLI APIs — never assume.)
+- **Lands before the cutover → fails the build on pre-existing violations.** Mitigation: sequence last;
+  if it fails on `main`, it is catching a real un-migrated violation — fix the violation, not the analyzer.
+- **Epic 35 Stripe (by design).** Adding the Stripe SDK type to the denylist makes a `BillingActivity`
+  injecting it fail the build automatically — the §1.2 "enforce by design" guarantee; no analyzer rewrite.


### PR DESCRIPTION
## What

Authors the **redesign story specs** for the Epic-32 architecture pivot (locked design of record: `docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md`, the [managed-LLM deep dive](docs/superpowers/specs/2026-06-20-managed-llm-execution-deep-dive.md), and the [re-plan](docs/superpowers/plans/2026-06-20-epic-32-37-replan.md) — all merged in #353).

**The locked model:** a workflow STEP never calls an external provider directly. It calls a tamma-api **`POST /api/v1/llm/call`** endpoint that gates → resolves the agent/persona (+ per-tenant enablement) → resolves the BYOK→platform credential → runs the tool loop → meters → returns `{ result, usage, credentialSource }`. The Elsa engine holds no keys.

## Stories authored (16 stories + Epic 38)

**Critical path (sequence A–F):**
| Story | Scope |
|---|---|
| **34-11** | Provider Cost Price-Book (`Provider` + `ProviderModelPrice` cost entities behind the unchanged `IProviderPricingService` seam) |
| **32-15** | Persona reframe + seeding (named cross-role personas `claude`/`gemini`/`codegpt`; amends shipped 32-1) |
| **32-16** | Per-tenant agent/persona enablement (`TenantAgentEnablement`) |
| **32-17** | Custom-agent prompts (`ConfigJson.prompts`; custom prompts ⇔ custom agent) |
| **32-18** | Registry enablement gate + Epic-27 prompt source (amends shipped 32-2) |
| **32-4** *(rewrite)* | SaaS provider gate — now the call-LLM endpoint's gate stage |
| **32-5** *(rewrite)* | Call-LLM endpoint + managed execution (`POST /api/v1/llm/call`; the lynchpin) |

**Follow-ons (G–H + deep-dive):** 32-12 *(rewrite, persona-aware benchmarking)*, 32-19 (style/voice variants), 32-20 (interactive question-back), 32-21 (MCP & plugin tool sourcing C#), 32-22 (prompt + response cache), 32-23 (streaming run tap SSE), 32-24 (C# harness adapter, deferred), and **Epic 38** (non-LLM step mediation: README + 38-1 git, 38-2 agent-dispatch, 38-3 Slack, 38-4 build-time guardrail).

Each story ships a dated implementation plan under `docs/superpowers/plans/2026-06-21-*`. `sprint-status.yaml` + the epic-32/34 READMEs are updated; Epic 38 added.

## Quality

An adversarial cross-spec review caught 3 critical seam collisions in the independently-authored 32-15/16/17/18 agent-resolution carve; all fixed in this branch:
- One `IPersonaPromptResolver` (32-15) / `ICustomAgentPromptResolver` (32-17); 32-18 dispatches to both (no duplicate `MaterialiseAsync` body).
- `ITenantAgentEnablementReader` + `GetEnabledDefaultPersonaIdAsync` defined in 32-16, consumed (not redefined) by 32-18.
- MCP enablement decoupled into its own `McpServerEnablement` entity (32-21).

**Docs-only — no code, no migrations, no deploy.** Merging does not deploy (qa-tag gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)