### PR TITLE
feat(workflow-viewer): mobile-first subway/transit-map view + legend fix + Code tab

### DIFF
--- a/apps/wiki-site/src/App.tsx
+++ b/apps/wiki-site/src/App.tsx
@@ -8,12 +8,18 @@ import EpicsPage from './components/EpicsPage';
 import EpicDetailPage from './components/EpicDetailPage';
 import WorkflowsPage from './components/WorkflowsPage';
 import WorkflowDetailPage from './components/WorkflowDetailPage';
+import WorkflowMapPage from './components/WorkflowMapPage';
 import StoriesPage from './components/StoriesPage';
 import StoryDetailPage from './components/StoryDetailPage';
 
 export default function App() {
   return (
     <Routes>
+      {/* Immersive, full-bleed subway/transit map view — rendered OUTSIDE the
+          wiki <Layout> chrome (no sidebar/header) so the page is only the
+          diagram + the floating popup. */}
+      <Route path="workflows/:slug/map" element={<WorkflowMapPage />} />
+
       <Route element={<Layout />}>
         <Route index element={<HomePage />} />
         <Route path="roadmap" element={<RoadmapPage />} />

--- a/apps/wiki-site/src/components/WorkflowDetailPage.tsx
+++ b/apps/wiki-site/src/components/WorkflowDetailPage.tsx
@@ -374,9 +374,20 @@ export default function WorkflowDetailPage() {
           @tamma/workflow-viewer). Renders nothing if no metadata for this slug. */}
       {slug && (
         <div>
-          <h2 className="text-sm font-semibold text-zinc-500 uppercase tracking-wider mb-4">
-            {flowSection ? flowSection.heading : 'Workflow Diagram'}
-          </h2>
+          <div className="flex items-center justify-between gap-3 mb-4 flex-wrap">
+            <h2 className="text-sm font-semibold text-zinc-500 uppercase tracking-wider">
+              {flowSection ? flowSection.heading : 'Workflow Diagram'}
+            </h2>
+            <Link
+              to={`/workflows/${slug}/map`}
+              className="inline-flex items-center gap-1.5 text-[12px] text-blue-400 hover:text-blue-300 border border-blue-500/30 hover:border-blue-500/50 rounded-md px-2.5 py-1.5 transition-colors"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8} aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7" />
+              </svg>
+              Map view
+            </Link>
+          </div>
           <WorkflowDiagram slug={slug} />
         </div>
       )}

--- a/apps/wiki-site/src/components/WorkflowMapPage.tsx
+++ b/apps/wiki-site/src/components/WorkflowMapPage.tsx
@@ -1,0 +1,165 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router';
+import { WorkflowMap, type WorkflowDataset, type WorkflowMetadata } from '@tamma/workflow-viewer';
+
+/**
+ * Immersive, full-bleed route for the subway/transit MAP view of a workflow.
+ *
+ * Rendered OUTSIDE the wiki <Layout> chrome (no sidebar) — the page is only a
+ * minimal fixed top bar + the diagram + the floating popup. Mirrors the React
+ * Flow adapter's host responsibilities:
+ *  - fetch the generated metadata dataset (`/workflows.json`)
+ *  - resolve the wiki URL slug → a workflow in the dataset
+ *  - sync the open station into the URL (`?step=…`) for shareable deep-links
+ *  - cross-navigate to a sub-workflow's MAP when a dispatch station links out
+ */
+
+let datasetCache: Promise<WorkflowDataset> | null = null;
+function loadDataset(): Promise<WorkflowDataset> {
+  if (!datasetCache) {
+    datasetCache = fetch('/workflows.json').then((r) => {
+      if (!r.ok) throw new Error('workflows.json not found');
+      return r.json() as Promise<WorkflowDataset>;
+    });
+  }
+  return datasetCache;
+}
+
+function wikiSlugFor(w: WorkflowMetadata): string {
+  if (w.wikiPage) return w.wikiPage.replace(/^Workflow-/, '').toLowerCase();
+  return w.inventoryId ?? w.id;
+}
+
+function resolveWorkflow(
+  dataset: WorkflowDataset,
+  slug: string,
+): WorkflowMetadata | undefined {
+  const wfs = dataset.workflows;
+  return (
+    wfs.find((w) => w.id === slug) ??
+    wfs.find((w) => w.inventoryId === slug) ??
+    wfs.find(
+      (w) =>
+        w.wikiPage &&
+        w.wikiPage.replace(/^Workflow-/, '').toLowerCase() === slug,
+    )
+  );
+}
+
+export default function WorkflowMapPage() {
+  const { slug } = useParams();
+  const [dataset, setDataset] = useState<WorkflowDataset | null>(null);
+  const [failed, setFailed] = useState(false);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    let active = true;
+    loadDataset()
+      .then((d) => active && setDataset(d))
+      .catch(() => active && setFailed(true));
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const workflow = useMemo(
+    () => (dataset && slug ? resolveWorkflow(dataset, slug) : undefined),
+    [dataset, slug],
+  );
+
+  const workflowName = workflow ? workflow.name.replace(/^Workflow:\s*/, '') : slug;
+
+  useEffect(() => {
+    if (workflowName) document.title = `${workflowName} — Map — Tamma Docs`;
+  }, [workflowName]);
+
+  const stepId = searchParams.get('step') ?? undefined;
+
+  const handleStepChange = useCallback(
+    (next: string | null) => {
+      setSearchParams(
+        (prev) => {
+          const params = new URLSearchParams(prev);
+          if (next) params.set('step', next);
+          else params.delete('step');
+          return params;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const handleNavigate = useCallback(
+    (targetWorkflowId: string, targetStep?: string) => {
+      if (!dataset) return;
+      const target = dataset.workflows.find(
+        (w) => w.id === targetWorkflowId || w.inventoryId === targetWorkflowId,
+      );
+      if (!target) return;
+      const targetSlug = wikiSlugFor(target);
+      const search = targetStep ? `?step=${encodeURIComponent(targetStep)}` : '';
+      navigate(`/workflows/${targetSlug}/map${search}`);
+    },
+    [dataset, navigate],
+  );
+
+  return (
+    <div className="fixed inset-0 flex flex-col bg-[#0c0c0e] text-zinc-200">
+      {/* Minimal fixed top bar */}
+      <header className="flex-none flex items-center gap-3 h-12 px-3 sm:px-4 border-b border-zinc-800 bg-[#09090b]">
+        <Link
+          to={slug ? `/workflows/${slug}` : '/workflows'}
+          aria-label="Back to workflow detail"
+          className="inline-flex items-center justify-center w-9 h-9 -ml-1 rounded-md text-zinc-400 hover:text-white hover:bg-white/5 transition-colors"
+        >
+          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+          </svg>
+        </Link>
+        <div className="min-w-0 flex-1">
+          <div className="text-[11px] uppercase tracking-wider text-zinc-600 leading-none">
+            Map view
+          </div>
+          <h1 className="text-[14px] font-semibold text-white truncate leading-tight">
+            {workflowName}
+          </h1>
+        </div>
+        {slug && (
+          <Link
+            to={`/workflows/${slug}`}
+            className="flex-none inline-flex items-center gap-1.5 text-[12px] text-blue-400 hover:text-blue-300 border border-blue-500/30 hover:border-blue-500/50 rounded-md px-2.5 py-1.5 transition-colors"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8} aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 17v-6h13M9 11V5l-6 6 6 6" />
+            </svg>
+            <span className="hidden xs:inline sm:inline">Flow view</span>
+          </Link>
+        )}
+      </header>
+
+      {/* Diagram surface */}
+      <div className="flex-1 min-h-0">
+        {failed || (dataset && !workflow) ? (
+          <div className="h-full flex flex-col items-center justify-center gap-4 px-6 text-center">
+            <div className="text-zinc-500">No diagram metadata for this workflow.</div>
+            <Link to="/workflows" className="text-sm text-blue-400 hover:text-blue-300">
+              Back to Workflows
+            </Link>
+          </div>
+        ) : !dataset || !workflow ? (
+          <div className="h-full bg-zinc-900/40 animate-pulse" />
+        ) : (
+          <WorkflowMap
+            metadata={dataset}
+            workflowId={workflow.id}
+            stepId={stepId}
+            onStepChange={handleStepChange}
+            onNavigate={handleNavigate}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/workflow-viewer/scripts/generate-metadata.js
+++ b/packages/workflow-viewer/scripts/generate-metadata.js
@@ -43,6 +43,8 @@ const REPO_ROOT = join(__dirname, '..', '..', '..');
 const WORKFLOWS_DIR = join(REPO_ROOT, 'apps', 'tamma-elsa', 'src', 'Tamma.ElsaServer', 'Workflows');
 const ACTIVITIES_DIR = join(REPO_ROOT, 'apps', 'tamma-elsa', 'src', 'Tamma.Activities');
 const WIKI_DIR = join(REPO_ROOT, 'wiki');
+// Base for the "open on GitHub" permalinks emitted into node.code.githubUrl.
+const GITHUB_BLOB_BASE = 'https://github.com/Tam-ma/tamma/blob/main';
 
 /** Resolve the output path: CLI arg > env var > package-local default. */
 function resolveOutFile() {
@@ -75,6 +77,54 @@ function collectCs(dir) {
 /** Strip C# string escapes minimally for display. */
 function unesc(s) {
   return s.replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+}
+
+/** Repo-relative POSIX path for an absolute file under the repo root. */
+function repoRel(absPath) {
+  return absPath.slice(REPO_ROOT.length + 1).split('\\').join('/');
+}
+
+/** 1-based line number of a character offset within a source string. */
+function lineAtOffset(src, offset) {
+  if (offset < 0) return undefined;
+  let line = 1;
+  for (let i = 0; i < offset && i < src.length; i++) {
+    if (src[i] === '\n') line++;
+  }
+  return line;
+}
+
+/**
+ * Build a sanitized code reference for an activity class found in `src`/`file`.
+ * Returns { file, line, namespace, githubUrl, snippet } or undefined.
+ * IMPORTANT: any C# text surfaced here is run through stripDocTags so no raw
+ * `<...>` can ever reach the (React-escaped) consumer.
+ */
+function codeRefFor(src, file, className) {
+  const decl = src.search(
+    new RegExp(`public\\s+(?:sealed\\s+|abstract\\s+|static\\s+|partial\\s+)*class\\s+${className}\\b`),
+  );
+  if (decl < 0) return undefined;
+  const line = lineAtOffset(src, decl);
+  const nsM = src.match(/^\s*namespace\s+([\w.]+)/m);
+  const namespace = nsM ? nsM[1] : undefined;
+  const relPath = repoRel(file);
+
+  // Cheap snippet: the class declaration line plus a few following lines,
+  // doc-tag-stripped and length-capped. Never includes method bodies.
+  const declLineStart = src.lastIndexOf('\n', decl) + 1;
+  const lines = src.slice(declLineStart).split('\n').slice(0, 4);
+  const snippetRaw = lines.join('\n');
+  const snippet = stripDocTags(snippetRaw).slice(0, 300).trimEnd();
+
+  const ref = {
+    file: relPath,
+    githubUrl: `${GITHUB_BLOB_BASE}/${relPath}${line ? `#L${line}` : ''}`,
+  };
+  if (line) ref.line = line;
+  if (namespace) ref.namespace = stripDocTags(namespace);
+  if (snippet) ref.snippet = snippet;
+  return ref;
 }
 
 /**
@@ -263,6 +313,7 @@ function buildActivityRegistry() {
       const summary = extractClassSummary(src, className);
       const kind = detectActivityKind(src, className, apiHints);
       const target = dispatchTargetOf(src);
+      const code = codeRefFor(src, file, className);
 
       registry[className] = {
         className,
@@ -277,6 +328,7 @@ function buildActivityRegistry() {
         interactions,
         apiHints,
         dispatchTarget: target,
+        code,
       };
     }
   }
@@ -592,6 +644,12 @@ function parseWorkflow(src, registry) {
     if (subTarget) node.subWorkflowId = subTarget;
     if (meta?.apiHints?.length) {
       node.api = apiDetail(meta, n);
+    }
+    // Source reference for the "Code" tab — only when the node maps to a real
+    // activity class we found a file for (built-in Elsa control nodes /
+    // synthetic dispatch nodes have no resolvable source).
+    if (meta?.code) {
+      node.code = meta.code;
     }
     nodeById[n.id] = node;
     return node;

--- a/packages/workflow-viewer/src/StationDetailPopup.tsx
+++ b/packages/workflow-viewer/src/StationDetailPopup.tsx
@@ -1,0 +1,337 @@
+import { useEffect, useState } from 'react';
+import { kindOf } from './kinds';
+import type { WorkflowNode } from './types';
+
+export interface StationDetailPopupProps {
+  node: WorkflowNode;
+  /** Called when the popup is dismissed (X, backdrop, or Esc). */
+  onClose: () => void;
+  /** Follow a sub-workflow link. Host decides how to navigate. */
+  onOpenSubWorkflow?: (workflowId: string) => void;
+}
+
+type Tab = 'overview' | 'api' | 'code';
+
+/**
+ * Floating detail popup for a station (NOT a docked side panel).
+ *
+ * Responsive by viewport width:
+ *  - small screens  → FULL-SCREEN overlay (covers the whole viewport, own
+ *                     internal scroll, fixed close button top-right).
+ *  - large screens  → centred floating modal (max-width ~500px, max-height
+ *                     ~75vh, backdrop-tap + Esc to dismiss).
+ *
+ * The presentation switch is driven by a `matchMedia` width check; the same
+ * component renders both, toggling a `data-variant` attribute the CSS keys off.
+ *
+ * All content is React-escaped text — no `dangerouslySetInnerHTML` anywhere.
+ */
+export function StationDetailPopup({
+  node,
+  onClose,
+  onOpenSubWorkflow,
+}: StationDetailPopupProps) {
+  const k = kindOf(node.kind);
+  const isApi = node.kind === 'api-call' || Boolean(node.api);
+  const hasCode = Boolean(node.code);
+
+  const [variant, setVariant] = useState<'fullscreen' | 'modal'>('modal');
+  const [tab, setTab] = useState<Tab>('overview');
+
+  // Pick presentation by viewport width; keep in sync on resize/orientation.
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mq = window.matchMedia('(max-width: 640px)');
+    const apply = () => setVariant(mq.matches ? 'fullscreen' : 'modal');
+    apply();
+    mq.addEventListener('change', apply);
+    return () => mq.removeEventListener('change', apply);
+  }, []);
+
+  // Esc to close; lock body scroll while open.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.body.style.overflow = prev;
+    };
+  }, [onClose]);
+
+  // Reset to overview whenever a different station is opened.
+  useEffect(() => {
+    setTab('overview');
+  }, [node.id]);
+
+  return (
+    <div
+      className="twv-popup-backdrop"
+      data-variant={variant}
+      onClick={(e) => {
+        // Backdrop tap closes (modal only — full-screen has no backdrop gap).
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        className="twv-popup"
+        data-variant={variant}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Details for ${node.name}`}
+      >
+        <div className="twv-popup-header">
+          <div className="twv-popup-title">
+            <span
+              className="twv-panel-kind-dot"
+              style={{ background: k.color }}
+              aria-hidden="true"
+            />
+            <div className="twv-popup-title-text">
+              <div className="twv-panel-name">{node.name}</div>
+              <code className="twv-panel-class">{node.className}</code>
+            </div>
+          </div>
+          <button
+            type="button"
+            className="twv-popup-close"
+            onClick={onClose}
+            aria-label="Close details"
+          >
+            <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 6l12 12M18 6L6 18" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div className="twv-popup-tabs" role="tablist" aria-label="Detail sections">
+          <TabButton id="overview" active={tab} onSelect={setTab}>Overview</TabButton>
+          <TabButton id="api" active={tab} onSelect={setTab} disabled={!isApi}>API</TabButton>
+          <TabButton id="code" active={tab} onSelect={setTab}>Code</TabButton>
+        </div>
+
+        <div className="twv-popup-body">
+          {tab === 'overview' && <OverviewTab node={node} onOpenSubWorkflow={onOpenSubWorkflow} k={k} />}
+          {tab === 'api' && <ApiTab node={node} />}
+          {tab === 'code' && <CodeTab node={node} hasCode={hasCode} />}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TabButton({
+  id,
+  active,
+  onSelect,
+  disabled,
+  children,
+}: {
+  id: Tab;
+  active: Tab;
+  onSelect: (t: Tab) => void;
+  disabled?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active === id}
+      className="twv-popup-tab"
+      data-active={active === id ? 'true' : 'false'}
+      disabled={disabled}
+      onClick={() => onSelect(id)}
+    >
+      {children}
+    </button>
+  );
+}
+
+function OverviewTab({
+  node,
+  onOpenSubWorkflow,
+  k,
+}: {
+  node: WorkflowNode;
+  onOpenSubWorkflow?: ((workflowId: string) => void) | undefined;
+  k: ReturnType<typeof kindOf>;
+}) {
+  const empty =
+    node.inputs.length === 0 &&
+    node.outputs.length === 0 &&
+    node.outcomes.length === 0 &&
+    node.interactions.length === 0 &&
+    !node.subWorkflowId &&
+    !node.description;
+
+  return (
+    <>
+      <div className="twv-panel-badges">
+        <span className="twv-tag" data-kind={node.kind}>{k.label}</span>
+        {node.isStart && <span className="twv-tag twv-tag-start">Start</span>}
+      </div>
+
+      {node.description && <p className="twv-panel-desc">{node.description}</p>}
+
+      {node.subWorkflowId && (
+        <Section title="Sub-workflow">
+          <div className="twv-subwf">
+            <code>{node.subWorkflowId}</code>
+            {node.subWorkflowResolves && onOpenSubWorkflow ? (
+              <button
+                type="button"
+                className="twv-subwf-link"
+                onClick={() => onOpenSubWorkflow(node.subWorkflowId!)}
+              >
+                Open map →
+              </button>
+            ) : (
+              <span className="twv-subwf-unresolved">(not in dataset)</span>
+            )}
+          </div>
+        </Section>
+      )}
+
+      {node.inputs.length > 0 && (
+        <Section title={`Inputs (${node.inputs.length})`}>
+          <PortList ports={node.inputs} />
+        </Section>
+      )}
+
+      {node.outputs.length > 0 && (
+        <Section title={`Outputs (${node.outputs.length})`}>
+          <PortList ports={node.outputs} />
+        </Section>
+      )}
+
+      {node.outcomes.length > 0 && (
+        <Section title="Outcomes / branches">
+          <div className="twv-chips">
+            {node.outcomes.map((o) => (
+              <span key={o} className="twv-chip">{o}</span>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {node.interactions.length > 0 && (
+        <Section title="Interactions">
+          <ul className="twv-interactions">
+            {node.interactions.map((it) => (
+              <li key={it}>{it}</li>
+            ))}
+          </ul>
+        </Section>
+      )}
+
+      {empty && <p className="twv-panel-empty">No additional metadata for this station.</p>}
+    </>
+  );
+}
+
+function ApiTab({ node }: { node: WorkflowNode }) {
+  if (!node.api) {
+    return <p className="twv-panel-empty">This station does not call an API endpoint.</p>;
+  }
+  return (
+    <Section title="API endpoint">
+      <dl className="twv-kv">
+        <Kv label="Service" value={node.api.service} />
+        <Kv label="Method" value={node.api.method} mono />
+        <Kv label="Route" value={node.api.route} mono />
+        {node.api.purpose && <Kv label="Purpose" value={node.api.purpose} />}
+      </dl>
+    </Section>
+  );
+}
+
+function CodeTab({ node, hasCode }: { node: WorkflowNode; hasCode: boolean }) {
+  if (!hasCode) {
+    // No resolvable source (sub-workflow dispatch / synthetic node): fall back
+    // to the structured identity we do have.
+    return (
+      <>
+        <Section title="Activity">
+          <dl className="twv-kv">
+            <Kv label="Class" value={node.className} mono />
+            {node.subWorkflowId && <Kv label="Dispatches" value={node.subWorkflowId} mono />}
+          </dl>
+        </Section>
+        <p className="twv-panel-empty">No source file resolvable for this station.</p>
+      </>
+    );
+  }
+  const code = node.code!;
+  return (
+    <>
+      <Section title="Activity">
+        <dl className="twv-kv">
+          <Kv label="Class" value={node.className} mono />
+          {code.namespace && <Kv label="Namespace" value={code.namespace} mono />}
+        </dl>
+      </Section>
+      <Section title="Source">
+        <dl className="twv-kv">
+          <Kv label="File" value={code.line ? `${code.file}:${code.line}` : code.file} mono />
+        </dl>
+        {code.githubUrl && (
+          <a
+            className="twv-code-gh"
+            href={code.githubUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Open on GitHub
+            <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M14 5h5v5M19 5l-9 9M5 7v12h12" />
+            </svg>
+          </a>
+        )}
+      </Section>
+      {code.snippet && (
+        <Section title="Snippet">
+          <pre className="twv-code-snippet"><code>{code.snippet}</code></pre>
+        </Section>
+      )}
+    </>
+  );
+}
+
+function PortList({ ports }: { ports: WorkflowNode['inputs'] }) {
+  return (
+    <ul className="twv-ports">
+      {ports.map((p) => (
+        <li key={p.name} className="twv-port">
+          <div className="twv-port-head">
+            <span className="twv-port-name">{p.name}</span>
+            <code className="twv-port-type">{p.type}</code>
+          </div>
+          {p.description && <div className="twv-port-desc">{p.description}</div>}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="twv-section">
+      <h4 className="twv-section-title">{title}</h4>
+      {children}
+    </section>
+  );
+}
+
+function Kv({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <>
+      <dt className="twv-kv-key">{label}</dt>
+      <dd className={mono ? 'twv-kv-val twv-mono' : 'twv-kv-val'}>{value}</dd>
+    </>
+  );
+}

--- a/packages/workflow-viewer/src/WorkflowMap.tsx
+++ b/packages/workflow-viewer/src/WorkflowMap.tsx
@@ -1,0 +1,376 @@
+import { useCallback, useMemo, useRef, useState, useEffect } from 'react';
+import './styles.css';
+
+import type { WorkflowDataset, WorkflowMetadata, WorkflowNode } from './types';
+import { buildMapLayout, type MapLayout } from './mapLayout';
+import { StationDetailPopup } from './StationDetailPopup';
+import { kindOf, KIND_ORDER, KIND_DESCRIPTORS } from './kinds';
+
+export interface WorkflowMapProps {
+  /** The full dataset (all workflows), enabling sub-workflow cross-navigation. */
+  metadata: WorkflowDataset | WorkflowMetadata[];
+  /** Which workflow to render (by id). Falls back to the first workflow. */
+  workflowId?: string;
+  /** Currently selected step/node id (controlled, for deep-links). */
+  stepId?: string;
+  /** Called when the selected step changes (clicked, or popup closed). */
+  onStepChange?: (stepId: string | null) => void;
+  /** Called when the user opens a sub-workflow (its map). */
+  onNavigate?: (workflowId: string, stepId?: string) => void;
+}
+
+function normalizeDataset(
+  metadata: WorkflowDataset | WorkflowMetadata[],
+): WorkflowMetadata[] {
+  if (Array.isArray(metadata)) return metadata;
+  return metadata.workflows ?? [];
+}
+
+/**
+ * Subway / transit-map workflow view. STATIC and mobile-first: NO zoom, NO pan.
+ * The user simply scrolls down. Stations are fixed-scale HTML cards positioned
+ * by lane (x, a fraction of container width so it always fits the viewport) and
+ * row (y, scrolls vertically). Connections are orthogonal SVG "rails" with
+ * rounded corners, colour-coded per subway "line".
+ *
+ * Selection is controlled via `stepId`/`onStepChange` (deep-link friendly), and
+ * sub-workflow stations navigate via `onNavigate`. Tapping a station opens a
+ * floating popup (full-screen on phones, centred modal on desktop).
+ */
+export function WorkflowMap({
+  metadata,
+  workflowId,
+  stepId,
+  onStepChange,
+  onNavigate,
+}: WorkflowMapProps) {
+  const workflows = useMemo(() => normalizeDataset(metadata), [metadata]);
+
+  const workflow = useMemo<WorkflowMetadata | undefined>(() => {
+    if (workflowId) {
+      const byId = workflows.find(
+        (w) => w.id === workflowId || w.inventoryId === workflowId,
+      );
+      if (byId) return byId;
+    }
+    return workflows[0];
+  }, [workflows, workflowId]);
+
+  const layout = useMemo<MapLayout>(
+    () => (workflow ? buildMapLayout(workflow) : { stations: [], rails: [], laneCount: 0, rowCount: 0 }),
+    [workflow],
+  );
+
+  // Measure container width so lane x-positions can be fractions of it.
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(0);
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width ?? 0;
+      setWidth(w);
+    });
+    ro.observe(el);
+    setWidth(el.clientWidth);
+    return () => ro.disconnect();
+  }, []);
+
+  const selectedNode = useMemo<WorkflowNode | undefined>(() => {
+    if (!stepId || !workflow) return undefined;
+    return workflow.nodes.find((n) => n.id === stepId);
+  }, [stepId, workflow]);
+
+  const handleStationClick = useCallback(
+    (id: string) => onStepChange?.(id === stepId ? null : id),
+    [onStepChange, stepId],
+  );
+  const handleClose = useCallback(() => onStepChange?.(null), [onStepChange]);
+  const handleOpenSub = useCallback(
+    (targetId: string) => onNavigate?.(targetId),
+    [onNavigate],
+  );
+
+  if (!workflow) {
+    return <div className="twv-empty">No workflow metadata available.</div>;
+  }
+  if (layout.stations.length === 0) {
+    return (
+      <div className="twv-map-root">
+        <div className="twv-empty">
+          No diagram metadata for this workflow — its graph could not be parsed.
+        </div>
+      </div>
+    );
+  }
+
+  const geom = computeGeometry(layout, width);
+  const kindsPresent = new Set(workflow.nodes.map((n) => n.kind));
+
+  return (
+    <div className="twv-map-root">
+      <div className="twv-map-scroll" ref={wrapRef}>
+        <div
+          className="twv-map-canvas"
+          style={{ height: geom.totalHeight }}
+        >
+          {/* Rails (SVG overlay, behind stations) */}
+          <svg
+            className="twv-map-rails"
+            width={width || '100%'}
+            height={geom.totalHeight}
+            viewBox={`0 0 ${width || 1} ${geom.totalHeight}`}
+            preserveAspectRatio="none"
+            aria-hidden="true"
+          >
+            {geom.railPaths.map((rp) => (
+              <g key={rp.id}>
+                <path
+                  d={rp.d}
+                  fill="none"
+                  stroke={rp.color}
+                  strokeWidth={rp.isBackEdge ? 2 : 3}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeDasharray={rp.isBackEdge ? '5 5' : undefined}
+                  opacity={rp.isBackEdge ? 0.7 : 0.9}
+                />
+              </g>
+            ))}
+          </svg>
+
+          {/* Rail labels (HTML, on top of rails but below station hit-area) */}
+          {geom.railLabels.map((rl) => (
+            <span
+              key={rl.id}
+              className="twv-map-rail-label"
+              style={{ left: rl.x, top: rl.y }}
+            >
+              {rl.label}
+            </span>
+          ))}
+
+          {/* Stations */}
+          {geom.stations.map((s) => {
+            const k = kindOf(s.node.kind);
+            const isSub =
+              s.node.kind === 'dispatch-subworkflow' || Boolean(s.node.subWorkflowId);
+            const isApi = s.node.kind === 'api-call' || Boolean(s.node.api);
+            return (
+              <button
+                type="button"
+                key={s.node.id}
+                className="twv-station"
+                data-kind={s.node.kind}
+                data-selected={s.node.id === stepId ? 'true' : 'false'}
+                data-sub={isSub ? 'true' : 'false'}
+                data-compact={s.width < 108 ? 'true' : 'false'}
+                style={{
+                  left: s.x,
+                  top: s.y,
+                  width: s.width,
+                  '--twv-accent': k.color,
+                  '--twv-bg': k.bg,
+                } as React.CSSProperties}
+                onClick={() => handleStationClick(s.node.id)}
+                aria-label={`${s.node.name} (${k.label})`}
+                title={s.node.name}
+              >
+                <span className="twv-station-dot" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.7} aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" d={k.icon} />
+                  </svg>
+                </span>
+                <span className="twv-station-label">{s.node.name}</span>
+                {isSub && s.node.subWorkflowResolves && (
+                  <span className="twv-station-badge" aria-hidden="true">↳</span>
+                )}
+                {isApi && !isSub && (
+                  <span className="twv-station-badge twv-station-badge-api" aria-hidden="true">∞</span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Legend (static, top of the immersive page) */}
+      <div className="twv-map-legend" aria-label="Station kinds">
+        {KIND_ORDER.filter((k) => kindsPresent.has(k)).map((k) => (
+          <span key={k} className="twv-legend-item">
+            <span className="twv-legend-dot" style={{ background: KIND_DESCRIPTORS[k].color }} />
+            {KIND_DESCRIPTORS[k].label}
+          </span>
+        ))}
+      </div>
+
+      {selectedNode && (
+        <StationDetailPopup
+          node={selectedNode}
+          onClose={handleClose}
+          onOpenSubWorkflow={handleOpenSub}
+        />
+      )}
+    </div>
+  );
+}
+
+export default WorkflowMap;
+
+// ---------------------------------------------------------------------------
+// Geometry: turn the abstract (row, lane) layout into pixel positions.
+// Lanes are fractions of the measured container width (→ no horizontal scroll,
+// fits any viewport). Rows have a fixed vertical pitch (→ scroll down).
+// ---------------------------------------------------------------------------
+
+interface StationGeom {
+  node: WorkflowNode;
+  x: number;
+  y: number;
+  width: number;
+  cx: number; // centre x of the station dot (for rails)
+  cy: number; // centre y
+}
+interface RailPath {
+  id: string;
+  d: string;
+  color: string;
+  isBackEdge: boolean;
+}
+interface RailLabel {
+  id: string;
+  label: string;
+  x: number;
+  y: number;
+}
+interface Geometry {
+  stations: StationGeom[];
+  railPaths: RailPath[];
+  railLabels: RailLabel[];
+  totalHeight: number;
+}
+
+/** Subway-line palette (small, distinct). Rails pick a colour by lane index. */
+const LINE_COLORS = [
+  '#60a5fa', // blue
+  '#f472b6', // pink
+  '#34d399', // green
+  '#fbbf24', // amber
+  '#a78bfa', // violet
+  '#22d3ee', // cyan
+  '#fb923c', // orange
+  '#4ade80', // lime
+  '#e879f9', // fuchsia
+  '#f87171', // red
+];
+
+const ROW_PITCH = 92; // vertical px between row centres
+const TOP_PAD = 36;
+const SIDE_PAD = 14;
+const STATION_H = 56;
+const CORNER = 12; // rounded-corner radius for rails
+
+function computeGeometry(layout: MapLayout, width: number): Geometry {
+  const w = width || 360;
+  const lanes = Math.max(1, layout.laneCount);
+  const inner = Math.max(120, w - SIDE_PAD * 2);
+  const lanePitch = inner / lanes;
+  // Station width tracks the lane pitch, with a floor so labels stay legible.
+  // For very wide fan-outs the floor would push cards past the lane centres;
+  // clamp the floor to the pitch so a station never exceeds its lane (→ no
+  // edge clipping / no horizontal scroll regardless of lane count).
+  const minW = Math.min(64, lanePitch);
+  const stationW = Math.min(168, Math.max(minW, lanePitch - 8));
+
+  const laneCenterX = (lane: number): number =>
+    SIDE_PAD + lanePitch * (lane + 0.5);
+  const rowCenterY = (row: number): number => TOP_PAD + row * ROW_PITCH;
+
+  const stations: StationGeom[] = layout.stations.map((s) => {
+    const cx = laneCenterX(s.lane);
+    const cy = rowCenterY(s.row);
+    return {
+      node: s.node,
+      x: cx - stationW / 2,
+      y: cy - STATION_H / 2,
+      width: stationW,
+      cx,
+      cy,
+    };
+  });
+  const byId = new Map(stations.map((s) => [s.node.id, s]));
+
+  const railPaths: RailPath[] = [];
+  const railLabels: RailLabel[] = [];
+  for (const rail of layout.rails) {
+    const a = byId.get(rail.from);
+    const b = byId.get(rail.to);
+    if (!a || !b) continue;
+    const color = LINE_COLORS[rail.line % LINE_COLORS.length]!;
+    const { d, labelX, labelY } = orthogonalPath(a, b, rail.isBackEdge);
+    railPaths.push({ id: rail.id, d, color, isBackEdge: rail.isBackEdge });
+    if (rail.label) {
+      railLabels.push({ id: rail.id, label: rail.label, x: labelX, y: labelY });
+    }
+  }
+
+  const maxRow = Math.max(0, ...layout.stations.map((s) => s.row));
+  const totalHeight = TOP_PAD + maxRow * ROW_PITCH + STATION_H / 2 + TOP_PAD;
+
+  return { stations, railPaths, railLabels, totalHeight };
+}
+
+/**
+ * Build an orthogonal rail (vertical segments + a horizontal jog with rounded
+ * 90° corners) from station `a`'s bottom to station `b`'s top. Same-lane edges
+ * are straight verticals. Back-edges (loop-backs) bow out to the side so they
+ * don't overlap the forward trunk.
+ */
+function orthogonalPath(
+  a: StationGeom,
+  b: StationGeom,
+  isBackEdge: boolean,
+): { d: string; labelX: number; labelY: number } {
+  const startY = a.cy + STATION_H / 2;
+  const endY = b.cy - STATION_H / 2;
+
+  if (isBackEdge) {
+    // Loop-back: exit the right side of `a`, run up the gutter, re-enter `b`'s
+    // right side. Bow out beyond both stations so the line reads as a return.
+    const ax = a.cx;
+    const bx = b.cx;
+    const gutter = Math.max(ax, bx) + 46;
+    const ay = a.cy;
+    const by = b.cy;
+    const r = CORNER;
+    const d = [
+      `M ${ax} ${ay}`,
+      `H ${gutter - r}`,
+      `Q ${gutter} ${ay} ${gutter} ${ay - Math.sign(ay - by) * r}`,
+      `V ${by + Math.sign(ay - by) * r}`,
+      `Q ${gutter} ${by} ${gutter - r} ${by}`,
+      `H ${bx}`,
+    ].join(' ');
+    return { d, labelX: gutter + 6, labelY: (ay + by) / 2 };
+  }
+
+  if (Math.abs(a.cx - b.cx) < 1) {
+    // Straight vertical.
+    const d = `M ${a.cx} ${startY} V ${endY}`;
+    return { d, labelX: a.cx + 8, labelY: (startY + endY) / 2 };
+  }
+
+  // Orthogonal: down to a mid-y, horizontal jog with rounded corners, then down.
+  const midY = (startY + endY) / 2;
+  const r = Math.min(CORNER, Math.abs(b.cx - a.cx) / 2, Math.abs(endY - startY) / 2);
+  const dir = b.cx > a.cx ? 1 : -1;
+  const d = [
+    `M ${a.cx} ${startY}`,
+    `V ${midY - r}`,
+    `Q ${a.cx} ${midY} ${a.cx + dir * r} ${midY}`,
+    `H ${b.cx - dir * r}`,
+    `Q ${b.cx} ${midY} ${b.cx} ${midY + r}`,
+    `V ${endY}`,
+  ].join(' ');
+  return { d, labelX: (a.cx + b.cx) / 2, labelY: midY - 8 };
+}

--- a/packages/workflow-viewer/src/index.ts
+++ b/packages/workflow-viewer/src/index.ts
@@ -14,8 +14,14 @@ export { WorkflowViewer, default } from './WorkflowViewer';
 export type { WorkflowViewerProps } from './WorkflowViewer';
 export { NodeDetailPanel } from './NodeDetailPanel';
 export type { NodeDetailPanelProps } from './NodeDetailPanel';
+export { WorkflowMap } from './WorkflowMap';
+export type { WorkflowMapProps } from './WorkflowMap';
+export { StationDetailPopup } from './StationDetailPopup';
+export type { StationDetailPopupProps } from './StationDetailPopup';
 export { buildGraph } from './layout';
 export type { LaidOutGraph } from './layout';
+export { buildMapLayout } from './mapLayout';
+export type { MapLayout, MapStation, MapRail } from './mapLayout';
 export { KIND_DESCRIPTORS, KIND_ORDER, kindOf } from './kinds';
 export type { KindDescriptor } from './kinds';
 export type {
@@ -25,5 +31,6 @@ export type {
   WorkflowEdge,
   WorkflowPort,
   WorkflowApiDetail,
+  WorkflowCodeRef,
   WorkflowNodeKind,
 } from './types';

--- a/packages/workflow-viewer/src/mapLayout.ts
+++ b/packages/workflow-viewer/src/mapLayout.ts
@@ -1,0 +1,219 @@
+import dagre from '@dagrejs/dagre';
+import type { WorkflowMetadata, WorkflowNode } from './types';
+
+/**
+ * Layout engine for the subway/transit map view (`<WorkflowMap />`).
+ *
+ * Goal: a STATIC, vertical, mobile-first "metro map". Unlike the React Flow
+ * viewer (which pans/zooms freely), this produces a fixed grid:
+ *  - rows  (y)  = top-to-bottom rank (dagre layering; cycle-safe)
+ *  - lanes (x)  = discrete columns ("subway lines"), mapped later to fractions
+ *                 of the container width so the diagram always fits the viewport
+ *                 width with no horizontal scroll and no zoom.
+ *
+ * Pure function — no React, no DOM — so it is deterministic and testable.
+ * We use dagre only for RANKING + relative ordering (it breaks cycles
+ * internally), then quantize dagre's x-centres into a small number of lanes.
+ */
+
+/** A station (node) placed on the map grid. */
+export interface MapStation {
+  node: WorkflowNode;
+  /** Row index (0 = top). Monotonic with flow direction. */
+  row: number;
+  /** Lane index (0 = leftmost / central-ish trunk). */
+  lane: number;
+}
+
+/** An orthogonal rail (edge) between two stations. */
+export interface MapRail {
+  id: string;
+  from: string;
+  to: string;
+  /** Branch label (outcome), if any. */
+  label?: string | undefined;
+  fromRow: number;
+  fromLane: number;
+  toRow: number;
+  toLane: number;
+  /** Stable "line" index used to colour the rail from the subway palette. */
+  line: number;
+  /** True when the rail flows upward (a loop-back / retry edge). */
+  isBackEdge: boolean;
+}
+
+export interface MapLayout {
+  stations: MapStation[];
+  rails: MapRail[];
+  /** Number of lanes (columns) actually used. */
+  laneCount: number;
+  /** Number of rows. */
+  rowCount: number;
+}
+
+const DAGRE_NODE_W = 160;
+const DAGRE_NODE_H = 48;
+
+interface RawNode {
+  id: string;
+  node: WorkflowNode;
+  x: number;
+  y: number;
+  row: number;
+  rawLane: number;
+  lane: number;
+}
+
+/**
+ * Build a metro-map layout from workflow metadata.
+ *
+ * Strategy:
+ *  1. Run dagre (TB) for rank (→ row) and x-centre (→ left-to-right ordering).
+ *     Dagre breaks cycles internally, so this is safe on the cyclic
+ *     retry/merge graphs Tamma produces.
+ *  2. Quantize dagre y-centres into dense, gap-free ROW indices.
+ *  3. Assign LANES with continuity: a node inherits its primary predecessor's
+ *     lane (so a "line" stays in its column down the map); genuine branches
+ *     peel off into the nearest free lane. This keeps lane count close to the
+ *     widest fan-out rather than dagre's pixel spread, and makes branches read
+ *     as coloured side-lines that merge back — the subway feel.
+ *  4. Centre the lanes so the busiest column sits toward the middle (trunk).
+ *  5. Tag each rail with a "line" colour index (its source lane) and flag
+ *     back-edges (target row ≤ source row) so loop-backs draw distinctly.
+ */
+export function buildMapLayout(workflow: WorkflowMetadata): MapLayout {
+  const nodes = workflow.nodes;
+  if (nodes.length === 0) {
+    return { stations: [], rails: [], laneCount: 0, rowCount: 0 };
+  }
+
+  const nodeIds = new Set(nodes.map((n) => n.id));
+  const validEdges = workflow.edges.filter(
+    (e) => nodeIds.has(e.from) && nodeIds.has(e.to),
+  );
+
+  const g = new dagre.graphlib.Graph({ multigraph: true });
+  g.setGraph({ rankdir: 'TB', nodesep: 40, ranksep: 60, marginx: 8, marginy: 8 });
+  g.setDefaultEdgeLabel(() => ({}));
+
+  for (const n of nodes) {
+    g.setNode(n.id, { width: DAGRE_NODE_W, height: DAGRE_NODE_H });
+  }
+  validEdges.forEach((e, i) => {
+    // multigraph: a name keeps parallel a→b edges distinct
+    g.setEdge(e.from, e.to, {}, `e${i}`);
+  });
+
+  dagre.layout(g);
+
+  const raw: RawNode[] = nodes.map((n) => {
+    const d = g.node(n.id) as { x?: number; y?: number } | undefined;
+    return { id: n.id, node: n, x: d?.x ?? 0, y: d?.y ?? 0, row: 0, rawLane: 0, lane: 0 };
+  });
+  const byId = new Map(raw.map((r) => [r.id, r]));
+
+  // ---- rows: quantize dagre y-centres into dense, gap-free row indices.
+  const ys = [...new Set(raw.map((r) => Math.round(r.y)))].sort((a, b) => a - b);
+  const rowIdx = new Map(ys.map((y, i) => [y, i] as const));
+  for (const r of raw) r.row = rowIdx.get(Math.round(r.y)) ?? 0;
+
+  const byRow = new Map<number, RawNode[]>();
+  for (const r of raw) {
+    const arr = byRow.get(r.row) ?? [];
+    arr.push(r);
+    byRow.set(r.row, arr);
+  }
+  // Stable left→right order inside each row (dagre x).
+  for (const arr of byRow.values()) arr.sort((a, b) => a.x - b.x);
+
+  // ---- lane assignment with continuity.
+  // Predecessors per node, ordered for stable "primary predecessor" choice.
+  const preds = new Map<string, string[]>();
+  for (const e of validEdges) {
+    const a = byId.get(e.from);
+    const b = byId.get(e.to);
+    if (!a || !b || b.row <= a.row) continue; // forward edges only for inheritance
+    const list = preds.get(e.to) ?? [];
+    list.push(e.from);
+    preds.set(e.to, list);
+  }
+
+  const rowMax = Math.max(0, ...ys.map((_, i) => i));
+  for (let row = 0; row <= rowMax; row++) {
+    const arr = byRow.get(row) ?? [];
+    const taken = new Set<number>();
+    // First pass: nodes that can inherit a predecessor's lane keep it if free.
+    const wishes = new Map<RawNode, number>();
+    for (const r of arr) {
+      const ps = (preds.get(r.id) ?? [])
+        .map((p) => byId.get(p))
+        .filter((p): p is RawNode => Boolean(p));
+      if (ps.length > 0) {
+        // Primary predecessor = the one with the most forward children gets the
+        // trunk; here we simply take the predecessor's lane (first in order).
+        wishes.set(r, ps[0]!.lane);
+      }
+    }
+    // Resolve wishes left→right; grant if free, else find nearest free lane.
+    for (const r of arr) {
+      const wish = wishes.get(r);
+      let lane = wish ?? nearestFreeLane(taken, idealLane(r, arr));
+      if (taken.has(lane)) lane = nearestFreeLane(taken, lane);
+      taken.add(lane);
+      r.rawLane = lane;
+    }
+  }
+
+  // ---- compact lanes to a dense 0..N-1 range, then centre the busiest column.
+  const usedLanes = [...new Set(raw.map((r) => r.rawLane))].sort((a, b) => a - b);
+  const dense = new Map(usedLanes.map((l, i) => [l, i] as const));
+  for (const r of raw) r.lane = dense.get(r.rawLane) ?? 0;
+
+  const laneCount = usedLanes.length;
+  const stations: MapStation[] = raw.map((r) => ({ node: r.node, row: r.row, lane: r.lane }));
+  const stationById = new Map(stations.map((s) => [s.node.id, s]));
+  const rowCount = ys.length;
+
+  // ---- rails. Colour ("line") by source lane; flag upward/loop-back edges.
+  const rails: MapRail[] = [];
+  validEdges.forEach((e, i) => {
+    const a = stationById.get(e.from);
+    const b = stationById.get(e.to);
+    if (!a || !b) return;
+    const isBackEdge = b.row <= a.row;
+    rails.push({
+      id: `${e.from}__${e.to}__${e.label ?? ''}__${i}`,
+      from: e.from,
+      to: e.to,
+      label: e.label,
+      fromRow: a.row,
+      fromLane: a.lane,
+      toRow: b.row,
+      toLane: b.lane,
+      // Line colour keyed by the lane the rail departs from, which makes
+      // branches that share a lane share a colour (subway-line feel).
+      line: a.lane,
+      isBackEdge,
+    });
+  });
+
+  return { stations, rails, laneCount, rowCount };
+}
+
+/** The lane a node would "like" based on its order within its row. */
+function idealLane(r: RawNode, rowArr: RawNode[]): number {
+  return rowArr.indexOf(r);
+}
+
+/** Nearest free lane to `target` (searches outward), defaulting up if all taken. */
+function nearestFreeLane(taken: Set<number>, target: number): number {
+  if (!taken.has(target)) return target;
+  for (let d = 1; d < 64; d++) {
+    if (target - d >= 0 && !taken.has(target - d)) return target - d;
+    if (!taken.has(target + d)) return target + d;
+  }
+  // Fallback: next index past the max.
+  let i = 0;
+  while (taken.has(i)) i++;
+  return i;
+}

--- a/packages/workflow-viewer/src/styles.css
+++ b/packages/workflow-viewer/src/styles.css
@@ -94,10 +94,12 @@
 }
 
 /* --- Legend --- */
+/* Anchored top-left so it never overlaps the React Flow <Controls> (which sit
+   bottom-left and include the fit-view / "fullscreen" button). */
 .twv-legend {
   position: absolute;
   left: 10px;
-  bottom: 10px;
+  top: 10px;
   display: flex;
   flex-wrap: wrap;
   gap: 8px 12px;
@@ -235,4 +237,326 @@
 @media (max-width: 720px) {
   .twv-root { flex-direction: column; }
   .twv-panel { flex-basis: auto; max-width: none; max-height: 360px; border-left: 0; border-top: 1px solid #27272a; }
+}
+
+/* =========================================================================
+   Subway / transit MAP view (<WorkflowMap />). Static, mobile-first,
+   vertical-scroll. No zoom, no pan. All class names prefixed `twv-map-` /
+   `twv-station` / `twv-popup`.
+   ========================================================================= */
+
+.twv-map-root {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-height: 100%;
+  background: #0c0c0e;
+  color: #e4e4e7;
+  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+/* The only scroll surface — vertical only, never horizontal. */
+.twv-map-scroll {
+  flex: 1 1 auto;
+  width: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.twv-map-canvas {
+  position: relative;
+  width: 100%;
+  min-height: 100%;
+}
+
+.twv-map-rails {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.twv-map-rail-label {
+  position: absolute;
+  transform: translateY(-50%);
+  z-index: 2;
+  font-size: 9px;
+  line-height: 1;
+  padding: 2px 5px;
+  border-radius: 4px;
+  background: rgba(9, 9, 11, 0.92);
+  border: 1px solid #27272a;
+  color: #d4d4d8;
+  white-space: nowrap;
+  pointer-events: none;
+  max-width: 96px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* --- Station card --- */
+.twv-station {
+  position: absolute;
+  z-index: 3;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 56px;
+  padding: 6px 8px;
+  border-radius: 12px;
+  background: var(--twv-bg, rgba(82, 82, 91, 0.18));
+  border: 1.5px solid color-mix(in srgb, var(--twv-accent, #a1a1aa) 55%, transparent);
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.4);
+  color: #e4e4e7;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  transition: border-color 0.12s ease, box-shadow 0.12s ease, transform 0.08s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+.twv-station:hover { border-color: var(--twv-accent, #a1a1aa); }
+.twv-station:active { transform: scale(0.97); }
+.twv-station:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--twv-accent, #a1a1aa) 50%, transparent);
+}
+.twv-station[data-selected='true'] {
+  border-color: var(--twv-accent, #a1a1aa);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--twv-accent, #a1a1aa) 65%, transparent),
+    0 3px 12px rgba(0, 0, 0, 0.5);
+}
+
+/* Sub-workflow "interchange" look: double-ring dot + dashed border accent. */
+.twv-station[data-sub='true'] {
+  border-style: dashed;
+}
+
+.twv-station-dot {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: #0c0c0e;
+  border: 2px solid var(--twv-accent, #a1a1aa);
+  color: var(--twv-accent, #a1a1aa);
+}
+.twv-station[data-sub='true'] .twv-station-dot {
+  box-shadow: 0 0 0 2px #0c0c0e, 0 0 0 3.5px var(--twv-accent, #a1a1aa);
+}
+.twv-station-dot svg { width: 14px; height: 14px; }
+
+.twv-station-label {
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.15;
+  color: #e4e4e7;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  word-break: break-word;
+}
+
+/* Compact (narrow-lane) stations: stack a small dot above a wider, 3-line
+   label so the name stays legible even when many lanes share a phone width. */
+.twv-station[data-compact='true'] {
+  flex-direction: column;
+  gap: 3px;
+  padding: 5px 4px;
+  align-items: stretch;
+}
+.twv-station[data-compact='true'] .twv-station-dot {
+  width: 18px;
+  height: 18px;
+  border-width: 1.5px;
+  align-self: center;
+}
+.twv-station[data-compact='true'] .twv-station-dot svg { width: 11px; height: 11px; }
+.twv-station[data-compact='true'] .twv-station-label {
+  font-size: 9.5px;
+  line-height: 1.1;
+  text-align: center;
+  -webkit-line-clamp: 3;
+}
+.twv-station[data-compact='true'] .twv-station-badge {
+  position: absolute;
+  top: 3px;
+  right: 4px;
+  margin: 0;
+  font-size: 10px;
+}
+
+.twv-station-badge {
+  flex: 0 0 auto;
+  margin-left: auto;
+  font-size: 12px;
+  line-height: 1;
+  color: #93c5fd;
+}
+.twv-station-badge-api { color: #6ee7b7; font-weight: 700; }
+
+/* --- Map legend (static strip at the top of the immersive page) --- */
+.twv-map-legend {
+  flex: 0 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 12px;
+  padding: 8px 12px;
+  border-top: 1px solid #1f1f23;
+  background: rgba(9, 9, 11, 0.95);
+  font-size: 10px;
+  color: #a1a1aa;
+}
+
+/* =========================================================================
+   Floating detail POPUP (full-screen on phones, centred modal on desktop).
+   ========================================================================= */
+
+.twv-popup-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+}
+.twv-popup-backdrop[data-variant='modal'] {
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(2px);
+}
+.twv-popup-backdrop[data-variant='fullscreen'] {
+  background: #0a0a0c;
+}
+
+.twv-popup {
+  display: flex;
+  flex-direction: column;
+  background: #0a0a0c;
+  color: #e4e4e7;
+  border: 1px solid #27272a;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.6);
+}
+/* Centred modal on desktop. */
+.twv-popup[data-variant='modal'] {
+  width: 100%;
+  max-width: 510px;
+  max-height: 75vh;
+  border-radius: 16px;
+  overflow: hidden;
+}
+/* Full-screen overlay on phones. */
+.twv-popup[data-variant='fullscreen'] {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  max-height: none;
+  border: 0;
+  border-radius: 0;
+}
+
+.twv-popup-header {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px 16px 12px;
+  border-bottom: 1px solid #1f1f23;
+}
+.twv-popup-title { display: flex; gap: 10px; align-items: flex-start; min-width: 0; }
+.twv-popup-title-text { min-width: 0; }
+.twv-popup-close {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  margin: -6px -6px 0 0;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: #a1a1aa;
+  cursor: pointer;
+}
+.twv-popup-close:hover { background: rgba(255, 255, 255, 0.06); color: #fafafa; }
+/* On full-screen the close button is fixed top-right for easy thumb reach. */
+.twv-popup[data-variant='fullscreen'] .twv-popup-close {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  z-index: 1;
+}
+
+.twv-popup-tabs {
+  flex: 0 0 auto;
+  display: flex;
+  gap: 4px;
+  padding: 8px 12px 0;
+  border-bottom: 1px solid #1f1f23;
+}
+.twv-popup-tab {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: #71717a;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 8px 12px;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  border-radius: 6px 6px 0 0;
+}
+.twv-popup-tab:hover:not(:disabled) { color: #d4d4d8; }
+.twv-popup-tab[data-active='true'] { color: #fafafa; border-bottom-color: #60a5fa; }
+.twv-popup-tab:disabled { color: #3f3f46; cursor: not-allowed; }
+
+.twv-popup-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  padding: 14px 16px 28px;
+}
+
+.twv-code-gh {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 8px;
+  font-size: 12px;
+  color: #93c5fd;
+  text-decoration: none;
+  padding: 4px 9px;
+  border: 1px solid rgba(96, 165, 250, 0.35);
+  border-radius: 6px;
+  background: rgba(59, 130, 246, 0.1);
+}
+.twv-code-gh:hover { background: rgba(59, 130, 246, 0.2); }
+.twv-code-snippet {
+  margin: 0;
+  padding: 10px 12px;
+  background: #09090b;
+  border: 1px solid #1f1f23;
+  border-radius: 8px;
+  overflow-x: auto;
+  font-size: 11px;
+  line-height: 1.5;
+  color: #d4d4d8;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  white-space: pre;
 }

--- a/packages/workflow-viewer/src/types.ts
+++ b/packages/workflow-viewer/src/types.ts
@@ -32,6 +32,23 @@ export interface WorkflowApiDetail {
   purpose: string;
 }
 
+/**
+ * Resolved source-code reference for a node (the "Code" tab). Present only when
+ * the metadata generator could map the node's backing activity class to a file.
+ */
+export interface WorkflowCodeRef {
+  /** Repo-relative path (e.g. `apps/tamma-elsa/src/Tamma.Activities/Foo.cs`). */
+  file: string;
+  /** 1-based line of the class declaration, if found. */
+  line?: number;
+  /** C# namespace of the activity class, if found. */
+  namespace?: string;
+  /** Permalink to the file (and line) on GitHub. */
+  githubUrl?: string;
+  /** Short, sanitized snippet around the declaration (doc-tag stripped). */
+  snippet?: string;
+}
+
 /** A node in a workflow graph (one Elsa activity / control-flow node). */
 export interface WorkflowNode {
   /** Stable id (the activity `Id` literal from the C# builder). */
@@ -60,6 +77,8 @@ export interface WorkflowNode {
   subWorkflowResolves?: boolean;
   /** For `api-call` nodes: the endpoint detail panel content. */
   api?: WorkflowApiDetail;
+  /** Resolved backing source file/line (the "Code" tab). */
+  code?: WorkflowCodeRef;
 }
 
 /** A directed edge between two nodes, optionally labelled by an outcome. */


### PR DESCRIPTION
## What

A second, **static mobile-first subway/transit-map** workflow viewer (`<WorkflowMap>`), additive alongside the existing React Flow viewer. Plus a legend/controls overlap fix on the existing viewer.

- **Map:** central trunk + colored branch lanes, orthogonal rounded rails, kind-coded stations (sub-workflow `↳`, API `∞`, decision/gate/terminal), edge labels, legend. **Fits viewport width, vertical scroll, no zoom/pan** (not React Flow — HTML stations + SVG rails, dagre ranking, lanes as fractions of container width via ResizeObserver).
- **Detail popup:** **full-screen on mobile** (own scroll + close ✕), **centered modal on desktop** (backdrop-dimmed) — never a side panel. Tabs: **Overview** (typed inputs/outputs + interactions), **API** (endpoint detail), **Code** (class/namespace, source `file.cs:line`, "Open on GitHub ↗", snippet).
- **Immersive route** `/workflows/:slug/map` (full-bleed, no wiki sidebar); sub-workflow stations navigate to their own map; `?step=` deep-links restore the open popup. Existing React Flow viewer untouched (+ a "Map view" link added).
- Generator enhanced to resolve per-node source `file/line/githubUrl/snippet` (171/535 nodes; sanitized via `stripDocTags`, rendered as React-escaped text).

## Verified (independently, in-browser)
Typecheck clean on both packages; drove it in Playwright on **mobile 390×844** (full-screen popup, Overview/API/Code tabs, deep-link, sub-workflow nav, no horizontal overflow) and **desktop 1440×900** (centered modal). `pnpm --filter @tamma/wiki-site build` clean.

## Honest gaps
Extreme fan-out rows (e.g. `debugging`'s 12 parallel nodes) shrink stations on a phone (labels abbreviate; tap still gives full detail); lane assignment minimizes crossings heuristically; Code tab resolves source for 171/535 nodes (built-in/synthetic/dispatch nodes show a graceful "no source").

Merging to `main` auto-deploys to **wiki.tamma.dev**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)