### PR TITLE
feat(epic-34): 34-11 Provider Cost Price-Book (DB-backed Provider + ProviderModelPrice behind IProviderPricingService)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminProviderPricingEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminProviderPricingEndpoints.cs
@@ -1,0 +1,356 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Tamma.Api.Services.Providers;
+using Tamma.Core;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Endpoints.Admin;
+
+/// <summary>
+/// Story 34-11 — admin CRUD for the provider COST price-book under
+/// <c>/api/admin/providers*</c>. Every route MUST be gated behind the
+/// <c>PlatformOwnerAccess</c> policy at the wiring site (NOT <c>OwnerAccess</c>,
+/// which admits every personal-tenant owner): the cost book is platform-GLOBAL
+/// in both single-user and SaaS modes (no per-tenant override layer), so it is
+/// platform-scoped admin work.
+///
+/// <para>The write paths are immutable-versioned (mirrors
+/// <c>PlanVersionEditor</c>): a price <c>PUT</c> supersedes the prior
+/// <c>active</c> row and inserts a new one; a mutation of a <c>superseded</c>
+/// row throws <c>PROVIDER.PRICE.IMMUTABLE</c>. Mutations emit DCB events to the
+/// control-plane <c>platform_events</c> store via
+/// <see cref="IPlatformEventPublisher"/>.</para>
+/// </summary>
+public static class AdminProviderPricingEndpoints
+{
+    private const string WorkflowVersion = "1.0.0";
+
+    // ── GET /api/admin/providers ──
+    public static async Task<IResult> ListProviders(
+        ControlPlaneDbContext db,
+        CancellationToken ct)
+    {
+        var providers = await db.Providers
+            .AsNoTracking()
+            .OrderBy(p => p.Key)
+            .Select(p => new
+            {
+                p.Id,
+                p.Key,
+                p.DisplayName,
+                p.AuthModel,
+                p.Status,
+                p.CreatedAt,
+                p.UpdatedAt,
+            })
+            .ToListAsync(ct);
+
+        return Results.Ok(new { providers });
+    }
+
+    // ── GET /api/admin/providers/{key}/prices ──
+    public static async Task<IResult> ListPrices(
+        string key,
+        ControlPlaneDbContext db,
+        CancellationToken ct)
+    {
+        var canonical = ProviderRateLookup.Canonicalize(key);
+
+        var providerExists = await db.Providers
+            .AsNoTracking()
+            .AnyAsync(p => p.Key == canonical, ct);
+        if (!providerExists)
+        {
+            return Results.NotFound(new { error = "provider_not_found", key = canonical });
+        }
+
+        var prices = await db.ProviderModelPrices
+            .AsNoTracking()
+            .Where(p => p.ProviderKey == canonical)
+            .OrderBy(p => p.Model).ThenByDescending(p => p.EffectiveFrom)
+            .ToListAsync(ct);
+
+        return Results.Ok(new { key = canonical, prices });
+    }
+
+    // ── POST /api/admin/providers ──
+    public static async Task<IResult> RegisterProvider(
+        RegisterProviderRequest body,
+        ControlPlaneDbContext db,
+        IPlatformEventPublisher publisher,
+        ClaimsPrincipal principal,
+        TimeProvider time,
+        CancellationToken ct)
+    {
+        if (body is null || string.IsNullOrWhiteSpace(body.Key))
+        {
+            return Results.BadRequest(new { error = "key_required" });
+        }
+        if (body.AuthModel is not ("api-key" or "cli-token"))
+        {
+            return Results.BadRequest(new { error = "invalid_auth_model", authModel = body.AuthModel });
+        }
+
+        var canonical = ProviderRateLookup.Canonicalize(body.Key);
+        var exists = await db.Providers.AnyAsync(p => p.Key == canonical, ct);
+        if (exists)
+        {
+            return Results.Conflict(new { error = "provider_exists", key = canonical });
+        }
+
+        var now = time.GetUtcNow().UtcDateTime;
+        var provider = new Provider
+        {
+            Id = Guid.NewGuid(),
+            Key = canonical,
+            DisplayName = string.IsNullOrWhiteSpace(body.DisplayName) ? canonical : body.DisplayName,
+            AuthModel = body.AuthModel,
+            Status = "active",
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+        db.Providers.Add(provider);
+        await db.SaveChangesAsync(ct);
+
+        await publisher.AppendAndPublishAsync(
+            BuildEvent(ProviderPricingEventTypes.Registered, principal, new Dictionary<string, string?>
+            {
+                ["providerKey"] = canonical,
+                ["authModel"] = provider.AuthModel,
+            }),
+            ct);
+
+        return Results.Created($"/api/admin/providers/{canonical}", new { provider.Id, provider.Key });
+    }
+
+    // ── PATCH /api/admin/providers/{key} ──
+    public static async Task<IResult> UpdateProvider(
+        string key,
+        UpdateProviderRequest body,
+        ControlPlaneDbContext db,
+        IPlatformEventPublisher publisher,
+        ClaimsPrincipal principal,
+        TimeProvider time,
+        CancellationToken ct)
+    {
+        var canonical = ProviderRateLookup.Canonicalize(key);
+        var provider = await db.Providers.FirstOrDefaultAsync(p => p.Key == canonical, ct);
+        if (provider is null)
+        {
+            return Results.NotFound(new { error = "provider_not_found", key = canonical });
+        }
+
+        if (body?.AuthModel is { } am && am is not ("api-key" or "cli-token"))
+        {
+            return Results.BadRequest(new { error = "invalid_auth_model", authModel = am });
+        }
+        if (body?.Status is { } st && st is not ("active" or "retired"))
+        {
+            return Results.BadRequest(new { error = "invalid_status", status = st });
+        }
+
+        if (!string.IsNullOrWhiteSpace(body?.DisplayName)) provider.DisplayName = body!.DisplayName!;
+        if (!string.IsNullOrWhiteSpace(body?.AuthModel)) provider.AuthModel = body!.AuthModel!;
+        if (!string.IsNullOrWhiteSpace(body?.Status)) provider.Status = body!.Status!;
+        provider.UpdatedAt = time.GetUtcNow().UtcDateTime;
+
+        await db.SaveChangesAsync(ct);
+
+        await publisher.AppendAndPublishAsync(
+            BuildEvent(ProviderPricingEventTypes.StatusChanged, principal, new Dictionary<string, string?>
+            {
+                ["providerKey"] = canonical,
+                ["status"] = provider.Status,
+                ["authModel"] = provider.AuthModel,
+            }),
+            ct);
+
+        return Results.Ok(new { provider.Key, provider.DisplayName, provider.AuthModel, provider.Status });
+    }
+
+    // ── PUT /api/admin/providers/{key}/prices ──
+    public static async Task<IResult> VersionPrice(
+        string key,
+        VersionPriceRequest body,
+        ControlPlaneDbContext db,
+        IProviderCostResolver resolver,
+        IPlatformEventPublisher publisher,
+        ClaimsPrincipal principal,
+        TimeProvider time,
+        CancellationToken ct)
+    {
+        if (body is null || string.IsNullOrWhiteSpace(body.Model))
+        {
+            return Results.BadRequest(new { error = "model_required" });
+        }
+
+        var canonical = ProviderRateLookup.Canonicalize(key);
+
+        var providerExists = await db.Providers.AnyAsync(p => p.Key == canonical, ct);
+        if (!providerExists)
+        {
+            return Results.NotFound(new { error = "provider_not_found", key = canonical });
+        }
+
+        var now = time.GetUtcNow().UtcDateTime;
+        var effectiveFrom = (body.EffectiveFrom ?? now).ToUniversalTime();
+
+        // The prior active row for (canonical, model) — flipped to superseded.
+        var prior = await db.ProviderModelPrices
+            .FirstOrDefaultAsync(p =>
+                p.ProviderKey == canonical
+                && p.Model == body.Model
+                && p.Status == "active", ct);
+
+        var newId = Guid.NewGuid();
+
+        var ownsTx = db.Database.CurrentTransaction is null && db.Database.IsRelational();
+        var tx = ownsTx ? await db.Database.BeginTransactionAsync(ct) : null;
+        try
+        {
+            if (prior is not null)
+            {
+                // Flip-then-insert in two saves inside one tx (deterministic
+                // ordering, same rationale as PlanVersionEditor): the partial
+                // unique index rejects a second active row, so insert must
+                // follow the supersede.
+                prior.Status = "superseded";
+                prior.UpdatedAt = now;
+                await db.SaveChangesAsync(ct);
+            }
+
+            db.ProviderModelPrices.Add(new ProviderModelPrice
+            {
+                Id = newId,
+                ProviderKey = canonical,
+                Model = body.Model,
+                InputUsdPer1M = body.InputUsdPer1M,
+                OutputUsdPer1M = body.OutputUsdPer1M,
+                CacheReadUsdPer1M = body.CacheReadUsdPer1M,
+                CacheWriteUsdPer1M = body.CacheWriteUsdPer1M,
+                EffectiveFrom = effectiveFrom,
+                Status = "active",
+                Source = "admin",
+                CreatedAt = now,
+                UpdatedAt = now,
+            });
+            await db.SaveChangesAsync(ct);
+
+            if (tx is not null) await tx.CommitAsync(ct);
+        }
+        catch
+        {
+            if (tx is not null) await tx.RollbackAsync(ct);
+            throw;
+        }
+        finally
+        {
+            if (tx is not null) await tx.DisposeAsync();
+        }
+
+        resolver.Invalidate();
+
+        await publisher.AppendAndPublishAsync(
+            BuildEvent(ProviderPricingEventTypes.PriceVersioned, principal, new Dictionary<string, string?>
+            {
+                ["providerKey"] = canonical,
+                ["model"] = body.Model,
+                ["effectiveFrom"] = effectiveFrom.ToString("O"),
+                ["supersededPriceId"] = prior?.Id.ToString("D"),
+            }),
+            ct);
+
+        return Results.Ok(new
+        {
+            id = newId,
+            providerKey = canonical,
+            model = body.Model,
+            effectiveFrom,
+            supersededPriceId = prior?.Id,
+        });
+    }
+
+    /// <summary>
+    /// Story 34-11 — the authoritative immutability guard for a direct mutation
+    /// of an already-<c>superseded</c> cost row. The admin write path never
+    /// mutates superseded rows (it supersedes + inserts), but any code path that
+    /// tries must throw <c>PROVIDER.PRICE.IMMUTABLE</c>.
+    /// </summary>
+    public static void EnsureMutableOrThrow(ProviderModelPrice price)
+    {
+        ArgumentNullException.ThrowIfNull(price);
+
+        if (price.Status == "superseded")
+        {
+            throw new TammaError(
+                "PROVIDER.PRICE.IMMUTABLE",
+                $"Provider cost price {price.Id:D} ({price.ProviderKey}/{price.Model}) is "
+                + "superseded and immutable. Version a new price instead of editing it.",
+                new Dictionary<string, object?>
+                {
+                    ["priceId"] = price.Id.ToString("D"),
+                    ["providerKey"] = price.ProviderKey,
+                    ["model"] = price.Model,
+                    ["status"] = price.Status,
+                },
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+        }
+    }
+
+    private static PlatformEvent BuildEvent(
+        string type,
+        ClaimsPrincipal? principal,
+        IReadOnlyDictionary<string, string?> extraTags)
+    {
+        var tags = new Dictionary<string, string?> { ["source"] = "admin" };
+        foreach (var (k, v) in extraTags)
+        {
+            if (v is not null) tags[k] = v;
+        }
+
+        var userId = principal?.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
+            ?? principal?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        var email = principal?.FindFirst(JwtRegisteredClaimNames.Email)?.Value
+            ?? principal?.FindFirst(ClaimTypes.Email)?.Value
+            ?? principal?.FindFirst("email")?.Value;
+        if (!string.IsNullOrEmpty(userId)) tags["actorUserId"] = userId;
+        if (!string.IsNullOrEmpty(email)) tags["actorEmail"] = email;
+
+        var data = new Dictionary<string, object?>(
+            tags.ToDictionary(kv => kv.Key, kv => (object?)kv.Value));
+
+        return new PlatformEvent
+        {
+            Type = type,
+            Tags = JsonSerializer.Serialize(tags),
+            Metadata = $"{{\"workflowVersion\":\"{WorkflowVersion}\",\"eventSource\":\"system\"}}",
+            Data = JsonSerializer.Serialize(data),
+        };
+    }
+}
+
+/// <summary>Body for <c>POST /api/admin/providers</c>.</summary>
+public sealed record RegisterProviderRequest(
+    string Key,
+    string? DisplayName = null,
+    string AuthModel = "api-key");
+
+/// <summary>Body for <c>PATCH /api/admin/providers/{key}</c>.</summary>
+public sealed record UpdateProviderRequest(
+    string? DisplayName = null,
+    string? AuthModel = null,
+    string? Status = null);
+
+/// <summary>Body for <c>PUT /api/admin/providers/{key}/prices</c>.</summary>
+public sealed record VersionPriceRequest(
+    string Model,
+    decimal InputUsdPer1M,
+    decimal OutputUsdPer1M,
+    decimal? CacheReadUsdPer1M = null,
+    decimal? CacheWriteUsdPer1M = null,
+    DateTime? EffectiveFrom = null);

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminProviderPricingEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminProviderPricingEndpoints.cs
@@ -81,6 +81,7 @@ public static class AdminProviderPricingEndpoints
     public static async Task<IResult> RegisterProvider(
         RegisterProviderRequest body,
         ControlPlaneDbContext db,
+        IEnumerable<IProviderCostCacheInvalidator> costCaches,
         IPlatformEventPublisher publisher,
         ClaimsPrincipal principal,
         TimeProvider time,
@@ -116,6 +117,8 @@ public static class AdminProviderPricingEndpoints
         db.Providers.Add(provider);
         await db.SaveChangesAsync(ct);
 
+        InvalidateAll(costCaches);
+
         await publisher.AppendAndPublishAsync(
             BuildEvent(ProviderPricingEventTypes.Registered, principal, new Dictionary<string, string?>
             {
@@ -132,6 +135,7 @@ public static class AdminProviderPricingEndpoints
         string key,
         UpdateProviderRequest body,
         ControlPlaneDbContext db,
+        IEnumerable<IProviderCostCacheInvalidator> costCaches,
         IPlatformEventPublisher publisher,
         ClaimsPrincipal principal,
         TimeProvider time,
@@ -160,6 +164,10 @@ public static class AdminProviderPricingEndpoints
 
         await db.SaveChangesAsync(ct);
 
+        // A status flip (e.g. active→retired) changes provider eligibility — flush
+        // every cost cache so a downstream read never sees stale eligibility.
+        InvalidateAll(costCaches);
+
         await publisher.AppendAndPublishAsync(
             BuildEvent(ProviderPricingEventTypes.StatusChanged, principal, new Dictionary<string, string?>
             {
@@ -177,7 +185,7 @@ public static class AdminProviderPricingEndpoints
         string key,
         VersionPriceRequest body,
         ControlPlaneDbContext db,
-        IProviderCostResolver resolver,
+        IEnumerable<IProviderCostCacheInvalidator> costCaches,
         IPlatformEventPublisher publisher,
         ClaimsPrincipal principal,
         TimeProvider time,
@@ -188,12 +196,28 @@ public static class AdminProviderPricingEndpoints
             return Results.BadRequest(new { error = "model_required" });
         }
 
+        // I2 — never accept a negative rate (a malformed/typo'd admin write
+        // must not poison the cost basis with a negative cost).
+        if (HasNegativeRate(body, out var badField))
+        {
+            return Results.BadRequest(new { error = "negative_rate", field = badField });
+        }
+
         var canonical = ProviderRateLookup.Canonicalize(key);
 
-        var providerExists = await db.Providers.AnyAsync(p => p.Key == canonical, ct);
-        if (!providerExists)
+        var provider = await db.Providers
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Key == canonical, ct);
+        if (provider is null)
         {
             return Results.NotFound(new { error = "provider_not_found", key = canonical });
+        }
+
+        // I2 — refuse to version a price on a retired provider (its cost identity
+        // is no longer live; re-activate it via PATCH before re-pricing).
+        if (provider.Status == "retired")
+        {
+            return Results.Conflict(new { error = "provider_retired", key = canonical });
         }
 
         var now = time.GetUtcNow().UtcDateTime;
@@ -252,7 +276,7 @@ public static class AdminProviderPricingEndpoints
             if (tx is not null) await tx.DisposeAsync();
         }
 
-        resolver.Invalidate();
+        InvalidateAll(costCaches);
 
         await publisher.AppendAndPublishAsync(
             BuildEvent(ProviderPricingEventTypes.PriceVersioned, principal, new Dictionary<string, string?>
@@ -300,6 +324,32 @@ public static class AdminProviderPricingEndpoints
                 retryable: false,
                 severity: TammaErrorSeverity.High);
         }
+    }
+
+    /// <summary>
+    /// I2 — true if any provided rate is negative. Out-params the offending field
+    /// name for a precise 400 body. A <c>null</c> cache rate is allowed (reserved
+    /// columns); only a present-and-negative value is rejected.
+    /// </summary>
+    private static bool HasNegativeRate(VersionPriceRequest body, out string field)
+    {
+        if (body.InputUsdPer1M < 0m) { field = nameof(body.InputUsdPer1M); return true; }
+        if (body.OutputUsdPer1M < 0m) { field = nameof(body.OutputUsdPer1M); return true; }
+        if (body.CacheReadUsdPer1M is < 0m) { field = nameof(body.CacheReadUsdPer1M); return true; }
+        if (body.CacheWriteUsdPer1M is < 0m) { field = nameof(body.CacheWriteUsdPer1M); return true; }
+        field = string.Empty;
+        return false;
+    }
+
+    /// <summary>
+    /// C1 — flush every registered cost-cache snapshot (the live
+    /// <see cref="DbProviderPricingService"/> AND the
+    /// <see cref="IProviderCostResolver"/>) so an admin write is reflected
+    /// immediately with no TTL-length stale window.
+    /// </summary>
+    private static void InvalidateAll(IEnumerable<IProviderCostCacheInvalidator> caches)
+    {
+        foreach (var cache in caches) cache.Invalidate();
     }
 
     private static PlatformEvent BuildEvent(

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/ProviderPricingServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/ProviderPricingServiceCollectionExtensions.cs
@@ -25,24 +25,43 @@ public static class ProviderPricingServiceCollectionExtensions
         // deterministic seed source + DbProviderPricingService's boot fallback.
         services.TryAddSingleton<ProviderPricingService>();
 
-        // The EffectiveFrom-windowed resolver (used by the metering path).
-        services.TryAddSingleton<IProviderCostResolver, ProviderCostResolver>();
+        // The EffectiveFrom-windowed resolver (used by the metering path). Register
+        // the concrete singleton ONCE, then expose it on both interfaces so the
+        // SAME instance is the cost resolver AND a cost-cache invalidator (C1).
+        services.TryAddSingleton<ProviderCostResolver>();
+        services.TryAddSingleton<IProviderCostResolver>(
+            sp => sp.GetRequiredService<ProviderCostResolver>());
 
         // THE SWAP: replace any prior IProviderPricingService registration
         // (TryAddSingleton from AddProviderSessionServices) with the DB-backed
-        // impl. The interface contract is unchanged.
+        // impl. The interface contract is unchanged. Register the concrete
+        // singleton ONCE and project it onto IProviderPricingService so the SAME
+        // live instance is what an admin write invalidates (C1) — registering a
+        // second factory would invalidate a DIFFERENT instance than the one
+        // serving Compute.
         var existing = services.FirstOrDefault(d => d.ServiceType == typeof(IProviderPricingService));
         if (existing is not null)
         {
             services.Remove(existing);
         }
-        services.AddSingleton<IProviderPricingService>(sp =>
+        services.AddSingleton<DbProviderPricingService>(sp =>
             new DbProviderPricingService(
                 sp.GetRequiredService<IServiceScopeFactory>(),
                 sp.GetRequiredService<IProviderCostResolver>(),
                 sp.GetRequiredService<TimeProvider>(),
                 sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<DbProviderPricingService>>(),
                 sp.GetRequiredService<ProviderPricingService>()));
+        services.AddSingleton<IProviderPricingService>(
+            sp => sp.GetRequiredService<DbProviderPricingService>());
+
+        // C1 — both snapshot holders are cost-cache invalidators. The admin
+        // endpoints resolve IEnumerable<IProviderCostCacheInvalidator> and flush
+        // EVERY snapshot on a pricing/eligibility mutation, so a live Compute is
+        // never stale after a re-price.
+        services.AddSingleton<IProviderCostCacheInvalidator>(
+            sp => sp.GetRequiredService<ProviderCostResolver>());
+        services.AddSingleton<IProviderCostCacheInvalidator>(
+            sp => sp.GetRequiredService<DbProviderPricingService>());
 
         return services;
     }

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/ProviderPricingServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/ProviderPricingServiceCollectionExtensions.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Tamma.Api.Services.Providers;
+
+namespace Tamma.Api.Extensions;
+
+/// <summary>
+/// Story 34-11 — DI wiring for the DB-backed provider COST price-book. Swaps the
+/// frozen <see cref="ProviderPricingService"/> for
+/// <see cref="DbProviderPricingService"/> behind the unchanged
+/// <see cref="IProviderPricingService"/> seam (a one-line registration change;
+/// zero downstream consumer edits), and registers the EffectiveFrom-windowed
+/// <see cref="IProviderCostResolver"/>.
+///
+/// <para>Call this AFTER <c>AddProviderSessionServices</c> (which registers the
+/// frozen impl via <c>TryAddSingleton</c>) so this explicit registration wins:
+/// it removes the frozen <see cref="IProviderPricingService"/> descriptor and
+/// re-adds the DB-backed one. The frozen class is still resolvable on its own
+/// concrete type as the seed source / boot fallback.</para>
+/// </summary>
+public static class ProviderPricingServiceCollectionExtensions
+{
+    public static IServiceCollection AddDbProviderPricing(this IServiceCollection services)
+    {
+        // Keep the frozen impl available on its concrete type — it is the
+        // deterministic seed source + DbProviderPricingService's boot fallback.
+        services.TryAddSingleton<ProviderPricingService>();
+
+        // The EffectiveFrom-windowed resolver (used by the metering path).
+        services.TryAddSingleton<IProviderCostResolver, ProviderCostResolver>();
+
+        // THE SWAP: replace any prior IProviderPricingService registration
+        // (TryAddSingleton from AddProviderSessionServices) with the DB-backed
+        // impl. The interface contract is unchanged.
+        var existing = services.FirstOrDefault(d => d.ServiceType == typeof(IProviderPricingService));
+        if (existing is not null)
+        {
+            services.Remove(existing);
+        }
+        services.AddSingleton<IProviderPricingService>(sp =>
+            new DbProviderPricingService(
+                sp.GetRequiredService<IServiceScopeFactory>(),
+                sp.GetRequiredService<IProviderCostResolver>(),
+                sp.GetRequiredService<TimeProvider>(),
+                sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<DbProviderPricingService>>(),
+                sp.GetRequiredService<ProviderPricingService>()));
+
+        return services;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -847,6 +847,14 @@ builder.Services.AddScoped<
     Tamma.Api.Services.Analytics.IPlatformAnalyticsService,
     Tamma.Api.Services.Analytics.PlatformAnalyticsService>();
 
+// Story 34-11 — swap the frozen ProviderPricingService for the DB-backed
+// DbProviderPricingService behind the unchanged IProviderPricingService seam
+// (a one-line DI change; zero downstream consumer edits). Must run AFTER
+// AddProviderSessionServices (which TryAdds the frozen impl) so this explicit
+// registration wins. The frozen class stays resolvable as the seed source +
+// boot fallback.
+builder.Services.AddDbProviderPricing();
+
 // Story 28-8 AC3 — short-TTL tenant status cache (per-pod, in-memory).
 // Cuts CP round-trips in TenantContextMiddleware on hot tenant requests.
 // Cluster-wide invalidation (RabbitMQ pub/sub) is a future enhancement —
@@ -1407,6 +1415,26 @@ admin.MapGet("/plans", Tamma.Api.Endpoints.Admin.PlanCatalogEndpoints.ListActive
 admin.MapGet("/plans/{slug}", Tamma.Api.Endpoints.Admin.PlanCatalogEndpoints.GetActiveBySlug)
     .RequireAuthorization("PlatformOwnerAccess");
 admin.MapGet("/plans/{slug}/versions", Tamma.Api.Endpoints.Admin.PlanCatalogEndpoints.GetVersions)
+    .RequireAuthorization("PlatformOwnerAccess");
+
+// Story 34-11 — provider COST price-book admin CRUD. PlatformOwnerAccess: the
+// cost book is platform-GLOBAL in both modes (no per-tenant override layer), so
+// it is platform-scoped admin work — NOT OwnerAccess (which admits every
+// personal-tenant owner, Finding C1). Mutations emit PROVIDER.* DCB events.
+admin.MapGet("/providers",
+        Tamma.Api.Endpoints.Admin.AdminProviderPricingEndpoints.ListProviders)
+    .RequireAuthorization("PlatformOwnerAccess");
+admin.MapPost("/providers",
+        Tamma.Api.Endpoints.Admin.AdminProviderPricingEndpoints.RegisterProvider)
+    .RequireAuthorization("PlatformOwnerAccess");
+admin.MapPatch("/providers/{key}",
+        Tamma.Api.Endpoints.Admin.AdminProviderPricingEndpoints.UpdateProvider)
+    .RequireAuthorization("PlatformOwnerAccess");
+admin.MapGet("/providers/{key}/prices",
+        Tamma.Api.Endpoints.Admin.AdminProviderPricingEndpoints.ListPrices)
+    .RequireAuthorization("PlatformOwnerAccess");
+admin.MapPut("/providers/{key}/prices",
+        Tamma.Api.Endpoints.Admin.AdminProviderPricingEndpoints.VersionPrice)
     .RequireAuthorization("PlatformOwnerAccess");
 
 // Story 28-11 — platform-admin tenant-status UX. List + detail surface the
@@ -2124,6 +2152,7 @@ using (var scope = app.Services.CreateScope())
                     mentorship_events, mentorship_sessions,
                     password_reset_tokens,
                     plan_features, plan_entitlements, plan_prices, plans,
+                    provider_model_prices, providers,
                     platform_analytics_hourly,
                     platform_api_key_index,
                     platform_bootstrap,
@@ -2157,6 +2186,12 @@ using (var scope = app.Services.CreateScope())
         // tamma-<role> handle + Version=1). Insert-missing-only; no-op on
         // re-run. CP-resident; coexists with the Elsa-store AgentSeeder.
         await Tamma.Data.Seeders.AgentEntitySeeder.SeedAsync(dbContext);
+
+        // Story 34-11 — provider COST price-book. Ports the frozen
+        // ProviderPricingService rate sheet into providers + provider_model_prices
+        // as v1 seed rows (Source='seed', Status='active'). Insert-missing-only;
+        // no-op on re-run and never reverts a Source='admin' (re-priced) row.
+        await Tamma.Data.Seeders.ProviderPricingSeeder.SeedAsync(dbContext);
 
         // tenant_databases: register the central DB as pool member #1
         // (unified-tenancy Phase 2) so single-user/dev and SaaS share one

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Providers/DbProviderPricingService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Providers/DbProviderPricingService.cs
@@ -25,10 +25,16 @@ namespace Tamma.Api.Services.Providers;
 /// silently prices at 0 (consistent with <c>feedback_resolution_no_empty_fallback</c>).</para>
 ///
 /// <para>Holds a short-lived in-memory snapshot of active rows (per-provider
-/// per-token rate maps) invalidated on an admin write via
-/// <see cref="IProviderCostResolver.Invalidate"/> + its own TTL.</para>
+/// per-token rate maps). The snapshot is cleared in TWO ways: (1) its own TTL
+/// expiry on the next read, and (2) an explicit <see cref="Invalidate"/> call —
+/// this service implements <see cref="IProviderCostCacheInvalidator"/>, so the
+/// admin endpoints invalidate it (alongside the resolver's separate snapshot)
+/// on EVERY pricing/eligibility mutation. Before the C1 fix this service had no
+/// <c>Invalidate()</c> and the admin write only cleared the resolver's distinct
+/// snapshot, so a live <c>Compute</c> kept returning the OLD rate for up to the
+/// TTL after a re-price — that stale window is now closed.</para>
 /// </summary>
-public sealed class DbProviderPricingService : IProviderPricingService
+public sealed class DbProviderPricingService : IProviderPricingService, IProviderCostCacheInvalidator
 {
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IProviderCostResolver _resolver;
@@ -78,6 +84,23 @@ public sealed class DbProviderPricingService : IProviderPricingService
         if (string.IsNullOrWhiteSpace(provider)) return false;
         if (TryGetRate(provider, model, out _, out var usedFallback)) return true;
         return usedFallback && _frozenFallback.IsKnown(provider, model);
+    }
+
+    /// <summary>
+    /// C1 fix — clear the live active-row snapshot + reset its expiry under the
+    /// gate so the very next <see cref="Compute"/>/<see cref="IsKnown"/> re-reads
+    /// the table. Called by the admin endpoints on every pricing/eligibility
+    /// mutation so a re-priced model is reflected immediately (no TTL-length
+    /// stale window).
+    /// </summary>
+    public void Invalidate()
+    {
+        lock (_gate)
+        {
+            _snapshot = null;
+            _snapshotExpiresAt = default;
+        }
+        _logger.LogDebug("DbProviderPricingService cost snapshot invalidated");
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Providers/DbProviderPricingService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Providers/DbProviderPricingService.cs
@@ -1,0 +1,177 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Tamma.Data;
+
+namespace Tamma.Api.Services.Providers;
+
+/// <summary>
+/// Story 34-11 — the DB-backed <see cref="IProviderPricingService"/>. Reads the
+/// <c>provider_model_prices</c> table (active rows) and reproduces the frozen
+/// table's behaviour VERBATIM via the shared <see cref="ProviderRateLookup"/>:
+/// alias normalization, <c>null</c>/<c>"default"</c> → first model, exact then
+/// loose-prefix match, and the unknown → <c>0m</c> / <c>IsKnown=false</c>
+/// robustness contract (never throws on an unpriced model).
+///
+/// <para>Registered IN PLACE OF the frozen <see cref="ProviderPricingService"/>
+/// (a one-line DI swap). The <see cref="IProviderPricingService"/> interface is
+/// UNCHANGED; the EffectiveFrom-aware path lives on the sibling
+/// <see cref="IProviderCostResolver"/> (used by the metering path), not on this
+/// seam.</para>
+///
+/// <para><b>Fail-loud empty-table fallback.</b> If the cost table is empty at
+/// read time (e.g. a misconfigured boot before the seeder ran) this service
+/// falls back to the retained frozen rate sheet and logs a WARN — it NEVER
+/// silently prices at 0 (consistent with <c>feedback_resolution_no_empty_fallback</c>).</para>
+///
+/// <para>Holds a short-lived in-memory snapshot of active rows (per-provider
+/// per-token rate maps) invalidated on an admin write via
+/// <see cref="IProviderCostResolver.Invalidate"/> + its own TTL.</para>
+/// </summary>
+public sealed class DbProviderPricingService : IProviderPricingService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IProviderCostResolver _resolver;
+    private readonly ProviderPricingService _frozenFallback;
+    private readonly TimeProvider _time;
+    private readonly ILogger<DbProviderPricingService> _logger;
+    private readonly TimeSpan _snapshotTtl;
+
+    private readonly object _gate = new();
+    // canonical provider key → (model → per-token rate). Ordering of the inner
+    // dictionary follows the row order so default/prefix rules are deterministic.
+    private IReadOnlyDictionary<string, IReadOnlyDictionary<string, ProviderRateLookup.Rate>>? _snapshot;
+    private DateTimeOffset _snapshotExpiresAt;
+    private bool _warnedEmpty;
+
+    public DbProviderPricingService(
+        IServiceScopeFactory scopeFactory,
+        IProviderCostResolver resolver,
+        TimeProvider time,
+        ILogger<DbProviderPricingService> logger,
+        ProviderPricingService? frozenFallback = null,
+        TimeSpan? snapshotTtl = null)
+    {
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+        _frozenFallback = frozenFallback ?? new ProviderPricingService();
+        _time = time ?? throw new ArgumentNullException(nameof(time));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _snapshotTtl = snapshotTtl ?? TimeSpan.FromSeconds(30);
+    }
+
+    public decimal Compute(string provider, string? model, int inputTokens, int outputTokens)
+    {
+        if (string.IsNullOrWhiteSpace(provider)) return 0m;
+        if (!TryGetRate(provider, model, out var rate, out var usedFallback))
+        {
+            // Unknown (provider, model) — robustness contract: 0m, never throw.
+            return usedFallback
+                ? _frozenFallback.Compute(provider, model, inputTokens, outputTokens)
+                : 0m;
+        }
+        return ProviderRateLookup.Cost(rate, inputTokens, outputTokens);
+    }
+
+    public bool IsKnown(string provider, string? model)
+    {
+        if (string.IsNullOrWhiteSpace(provider)) return false;
+        if (TryGetRate(provider, model, out _, out var usedFallback)) return true;
+        return usedFallback && _frozenFallback.IsKnown(provider, model);
+    }
+
+    /// <summary>
+    /// Story 34-11 — the EffectiveFrom-windowed cost used by the metering path
+    /// (34-5 / 32-9). Selects the cost row effective at <paramref name="atTimestamp"/>
+    /// so a usage event prices under the rate active when the call happened.
+    /// Unknown / no-effective-row → <c>0m</c> (never throws).
+    /// </summary>
+    public async Task<decimal> ComputeAtAsync(
+        string provider, string? model, int inputTokens, int outputTokens,
+        DateTime atTimestamp, CancellationToken ct = default)
+    {
+        var row = await _resolver.ResolveAtAsync(provider, model, atTimestamp, ct);
+        if (row is null) return 0m;
+
+        var rate = ToPerToken(row.InputUsdPer1M, row.OutputUsdPer1M);
+        return ProviderRateLookup.Cost(rate, inputTokens, outputTokens);
+    }
+
+    private bool TryGetRate(
+        string provider, string? model, out ProviderRateLookup.Rate rate, out bool usedFallback)
+    {
+        rate = default;
+        usedFallback = false;
+
+        var snapshot = GetSnapshot();
+        if (snapshot.Count == 0)
+        {
+            // Empty table → fail-loud fallback to the frozen sheet.
+            usedFallback = true;
+            return false;
+        }
+
+        var canonical = ProviderRateLookup.Canonicalize(provider);
+        if (!snapshot.TryGetValue(canonical, out var modelMap))
+        {
+            return false;
+        }
+
+        return ProviderRateLookup.TryGetRate(provider, model, modelMap, out rate);
+    }
+
+    private static ProviderRateLookup.Rate ToPerToken(decimal in1M, decimal out1M) =>
+        new(in1M / 1_000_000m, out1M / 1_000_000m);
+
+    private IReadOnlyDictionary<string, IReadOnlyDictionary<string, ProviderRateLookup.Rate>> GetSnapshot()
+    {
+        var now = _time.GetUtcNow();
+        lock (_gate)
+        {
+            if (_snapshot is not null && now < _snapshotExpiresAt)
+            {
+                return _snapshot;
+            }
+        }
+
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ControlPlaneDbContext>();
+
+        var rows = db.ProviderModelPrices
+            .AsNoTracking()
+            .Where(r => r.Status == "active")
+            .OrderBy(r => r.ProviderKey).ThenBy(r => r.EffectiveFrom)
+            .ToList();
+
+        var map = new Dictionary<string, IReadOnlyDictionary<string, ProviderRateLookup.Rate>>(
+            StringComparer.OrdinalIgnoreCase);
+        foreach (var group in rows.GroupBy(r => r.ProviderKey, StringComparer.OrdinalIgnoreCase))
+        {
+            var inner = new Dictionary<string, ProviderRateLookup.Rate>(StringComparer.OrdinalIgnoreCase);
+            foreach (var r in group)
+            {
+                inner[r.Model] = ToPerToken(r.InputUsdPer1M, r.OutputUsdPer1M);
+            }
+            map[group.Key] = inner;
+        }
+
+        if (map.Count == 0 && !_warnedEmpty)
+        {
+            _logger.LogWarning(
+                "provider_model_prices is empty — falling back to the frozen cost rate sheet. "
+                + "Run ProviderPricingSeeder.SeedAsync to populate the cost book.");
+            _warnedEmpty = true;
+        }
+        else if (map.Count > 0)
+        {
+            _warnedEmpty = false;
+        }
+
+        lock (_gate)
+        {
+            _snapshot = map;
+            _snapshotExpiresAt = now + _snapshotTtl;
+        }
+        return map;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Providers/IProviderCostCacheInvalidator.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Providers/IProviderCostCacheInvalidator.cs
@@ -1,0 +1,21 @@
+namespace Tamma.Api.Services.Providers;
+
+/// <summary>
+/// Story 34-11 (C1 fix) — a cost-cache invalidation seam shared by EVERY
+/// component that holds a short-lived in-memory snapshot of the
+/// <c>provider_model_prices</c> table. Both the live
+/// <see cref="DbProviderPricingService"/> (which backs the unchanged
+/// <see cref="IProviderPricingService"/> <c>Compute</c>/<c>IsKnown</c> seam) and
+/// the EffectiveFrom-windowed <see cref="IProviderCostResolver"/> hold their OWN
+/// snapshot. An admin write that changes pricing/eligibility must clear ALL of
+/// them or a live <c>Compute</c> keeps returning the OLD rate for up to the TTL.
+///
+/// <para>The admin endpoints resolve <c>IEnumerable&lt;IProviderCostCacheInvalidator&gt;</c>
+/// and invalidate every registered snapshot in one shot, so there is no stale
+/// window after a re-price / register / status-change.</para>
+/// </summary>
+public interface IProviderCostCacheInvalidator
+{
+    /// <summary>Clear any cached snapshot of active cost rows (called on an admin write).</summary>
+    void Invalidate();
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Providers/IProviderCostResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Providers/IProviderCostResolver.cs
@@ -13,7 +13,7 @@ namespace Tamma.Api.Services.Providers;
 /// shared <see cref="ProviderRateLookup"/>: alias normalization,
 /// <c>null</c>/<c>"default"</c> → first model, exact then loose-prefix match.</para>
 /// </summary>
-public interface IProviderCostResolver
+public interface IProviderCostResolver : IProviderCostCacheInvalidator
 {
     /// <summary>
     /// Resolve the currently-<c>active</c> price row for <c>(provider, model)</c>,
@@ -31,6 +31,5 @@ public interface IProviderCostResolver
     Task<ProviderModelPrice?> ResolveAtAsync(
         string provider, string? model, DateTime atTimestamp, CancellationToken ct = default);
 
-    /// <summary>Invalidate any cached snapshot (called on an admin write).</summary>
-    void Invalidate();
+    // Invalidate() is inherited from IProviderCostCacheInvalidator.
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Providers/IProviderCostResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Providers/IProviderCostResolver.cs
@@ -1,0 +1,36 @@
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Providers;
+
+/// <summary>
+/// Story 34-11 — EffectiveFrom-windowed cost-row resolution over the
+/// <c>provider_model_prices</c> table. Impure / DB-backed (a sibling of the
+/// pure <see cref="IProviderPricingService"/> seam): given a
+/// <c>(provider, model)</c> request it returns the matching cost rows so a
+/// caller can price under the rate active at any point in time.
+///
+/// <para>The lookup preserves the frozen table's load-bearing quirks via the
+/// shared <see cref="ProviderRateLookup"/>: alias normalization,
+/// <c>null</c>/<c>"default"</c> → first model, exact then loose-prefix match.</para>
+/// </summary>
+public interface IProviderCostResolver
+{
+    /// <summary>
+    /// Resolve the currently-<c>active</c> price row for <c>(provider, model)</c>,
+    /// or <c>null</c> when the pair is unknown (caller treats null as 0m / unknown).
+    /// </summary>
+    Task<ProviderModelPrice?> ResolveActiveAsync(
+        string provider, string? model, CancellationToken ct = default);
+
+    /// <summary>
+    /// Resolve the price row effective at <paramref name="atTimestamp"/>: the
+    /// most-recent row (active OR superseded) for <c>(provider, model)</c> whose
+    /// <c>EffectiveFrom &lt;= atTimestamp</c>. <c>null</c> when no such row
+    /// exists (unknown pair, or the timestamp predates v1).
+    /// </summary>
+    Task<ProviderModelPrice?> ResolveAtAsync(
+        string provider, string? model, DateTime atTimestamp, CancellationToken ct = default);
+
+    /// <summary>Invalidate any cached snapshot (called on an admin write).</summary>
+    void Invalidate();
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderCostResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderCostResolver.cs
@@ -1,0 +1,170 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Tamma.Data;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Providers;
+
+/// <summary>
+/// Story 34-11 — EffectiveFrom-windowed cost-row resolution over
+/// <c>provider_model_prices</c>. Singleton; resolves a scoped
+/// <see cref="ControlPlaneDbContext"/> per call through
+/// <see cref="IServiceScopeFactory"/> (the established pattern for a singleton
+/// that needs EF — mirrors <c>PostgresBudgetConfigProvider</c>). Holds a
+/// short-lived snapshot of <c>active</c> rows invalidated on an admin write.
+/// </summary>
+public sealed class ProviderCostResolver : IProviderCostResolver
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly TimeProvider _time;
+    private readonly ILogger<ProviderCostResolver> _logger;
+    private readonly TimeSpan _snapshotTtl;
+
+    private readonly object _gate = new();
+    private IReadOnlyList<ProviderModelPrice>? _activeSnapshot;
+    private DateTimeOffset _snapshotExpiresAt;
+
+    public ProviderCostResolver(
+        IServiceScopeFactory scopeFactory,
+        TimeProvider time,
+        ILogger<ProviderCostResolver> logger,
+        TimeSpan? snapshotTtl = null)
+    {
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        _time = time ?? throw new ArgumentNullException(nameof(time));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _snapshotTtl = snapshotTtl ?? TimeSpan.FromSeconds(30);
+    }
+
+    public async Task<ProviderModelPrice?> ResolveActiveAsync(
+        string provider, string? model, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(provider)) return null;
+
+        var canonical = ProviderRateLookup.Canonicalize(provider);
+        var snapshot = await GetActiveSnapshotAsync(ct);
+
+        var rows = snapshot
+            .Where(r => string.Equals(r.ProviderKey, canonical, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(r => r.EffectiveFrom)
+            .ToList();
+        if (rows.Count == 0) return null;
+
+        var resolvedModel = ResolveModelKey(model, rows.Select(r => r.Model));
+        if (resolvedModel is null) return null;
+
+        return rows.FirstOrDefault(r =>
+            string.Equals(r.Model, resolvedModel, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public async Task<ProviderModelPrice?> ResolveAtAsync(
+        string provider, string? model, DateTime atTimestamp, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(provider)) return null;
+
+        var canonical = ProviderRateLookup.Canonicalize(provider);
+        var at = atTimestamp.Kind == DateTimeKind.Unspecified
+            ? DateTime.SpecifyKind(atTimestamp, DateTimeKind.Utc)
+            : atTimestamp.ToUniversalTime();
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ControlPlaneDbContext>();
+
+        // All rows (active + superseded) for this provider — the model-key
+        // resolution (default/prefix) needs the candidate model set first.
+        var providerRows = await db.ProviderModelPrices
+            .AsNoTracking()
+            .Where(r => r.ProviderKey == canonical)
+            .OrderBy(r => r.EffectiveFrom)
+            .ToListAsync(ct);
+        if (providerRows.Count == 0) return null;
+
+        // First-model resolution uses the EARLIEST-effective row per model (the
+        // seed v1 order) so null/"default" matches the frozen first-model rule.
+        var resolvedModel = ResolveModelKey(
+            model,
+            providerRows
+                .GroupBy(r => r.Model)
+                .OrderBy(g => g.Min(r => r.EffectiveFrom))
+                .Select(g => g.Key));
+        if (resolvedModel is null) return null;
+
+        // Most-recent row for the resolved model effective at-or-before the
+        // timestamp (active OR superseded) — the time-travel selection.
+        var match = providerRows
+            .Where(r => string.Equals(r.Model, resolvedModel, StringComparison.OrdinalIgnoreCase)
+                        && r.EffectiveFrom <= at)
+            .OrderByDescending(r => r.EffectiveFrom)
+            .FirstOrDefault();
+
+        if (match is null)
+        {
+            _logger.LogWarning(
+                "No provider cost row effective at {AtTimestamp} for {ProviderKey}/{Model} — pricing at 0",
+                at, canonical, resolvedModel);
+        }
+
+        return match;
+    }
+
+    public void Invalidate()
+    {
+        lock (_gate)
+        {
+            _activeSnapshot = null;
+            _snapshotExpiresAt = default;
+        }
+        _logger.LogDebug("Provider cost snapshot invalidated");
+    }
+
+    /// <summary>
+    /// Apply the shared model-key rule (<c>null</c>/<c>"default"</c> → first
+    /// model; exact then loose-prefix) over a candidate model set. The candidate
+    /// ordering follows the seed order (anthropic, openai, … each in declared
+    /// order) so the first-model + prefix rules are deterministic.
+    /// </summary>
+    private static string? ResolveModelKey(string? requested, IEnumerable<string> candidates)
+    {
+        var models = candidates.ToList();
+        if (models.Count == 0) return null;
+
+        if (string.IsNullOrWhiteSpace(requested) || requested == "default")
+        {
+            return models[0];
+        }
+
+        var exact = models.FirstOrDefault(m =>
+            string.Equals(m, requested, StringComparison.OrdinalIgnoreCase));
+        if (exact is not null) return exact;
+
+        return models.FirstOrDefault(m =>
+            m.StartsWith(requested, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private async Task<IReadOnlyList<ProviderModelPrice>> GetActiveSnapshotAsync(CancellationToken ct)
+    {
+        var now = _time.GetUtcNow();
+        lock (_gate)
+        {
+            if (_activeSnapshot is not null && now < _snapshotExpiresAt)
+            {
+                return _activeSnapshot;
+            }
+        }
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ControlPlaneDbContext>();
+        var rows = await db.ProviderModelPrices
+            .AsNoTracking()
+            .Where(r => r.Status == "active")
+            .ToListAsync(ct);
+
+        lock (_gate)
+        {
+            _activeSnapshot = rows;
+            _snapshotExpiresAt = now + _snapshotTtl;
+        }
+        return rows;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderPricingEventTypes.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderPricingEventTypes.cs
@@ -1,0 +1,18 @@
+namespace Tamma.Api.Services.Providers;
+
+/// <summary>
+/// Story 34-11 — DCB event type names emitted by the admin provider-pricing
+/// write paths to the control-plane <c>platform_events</c> store (mirrors
+/// <c>PlanCatalogEventTypes</c>). Pattern: <c>AGGREGATE.ACTION.STATUS</c>.
+/// </summary>
+public static class ProviderPricingEventTypes
+{
+    /// <summary>A new immutable model-price version was activated (supersede + insert).</summary>
+    public const string PriceVersioned = "PROVIDER.PRICE.VERSIONED";
+
+    /// <summary>A provider cost identity was registered.</summary>
+    public const string Registered = "PROVIDER.REGISTERED";
+
+    /// <summary>A provider's Status / DisplayName / AuthModel changed.</summary>
+    public const string StatusChanged = "PROVIDER.STATUS_CHANGED";
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderPricingService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderPricingService.cs
@@ -13,6 +13,15 @@ namespace Tamma.Api.Services.Providers;
 /// </para>
 ///
 /// <para>
+/// Story 34-11 — this class is RETAINED as the deterministic SEED SOURCE
+/// (consumed by <c>ProviderPricingSeeder</c>) and the boot fallback when the
+/// DB cost table is empty. The registered runtime impl is now
+/// <see cref="DbProviderPricingService"/>; both share the
+/// <see cref="ProviderRateLookup"/> alias-map + lookup algorithm so they
+/// cannot drift (the parity test pins byte-identical <c>Compute</c> output).
+/// </para>
+///
+/// <para>
 /// Lookup is case-insensitive on both provider key and model id. Provider
 /// keys are also normalised against a small alias map so callers using the
 /// older <c>anthropic-claude</c> handle still resolve to the same Anthropic
@@ -21,137 +30,117 @@ namespace Tamma.Api.Services.Providers;
 /// </summary>
 public sealed class ProviderPricingService : IProviderPricingService
 {
-    private readonly record struct Rate(decimal InputPerToken, decimal OutputPerToken);
+    /// <summary>Per-(provider, model) USD-per-token rates. Exposed to the seeder (Story 34-11).</summary>
+    public static readonly FrozenDictionary<string, FrozenDictionary<string, ProviderRateLookup.Rate>> Pricing =
+        BuildTable();
 
     /// <summary>
-    /// Provider alias normalisation. Maps every accepted handle to the
-    /// canonical provider key used in <see cref="s_pricing"/>. Unrecognised
-    /// keys are passed through untouched so explicit additions to the table
-    /// still resolve.
+    /// Story 34-11 — the AuthModel each seeded provider carries (feeds 32-4
+    /// SaaS-eligibility). <c>claude-code</c> is the CLI harness (<c>cli-token</c>);
+    /// every other provider authenticates with an API key.
     /// </summary>
-    private static readonly FrozenDictionary<string, string> s_aliases =
+    public static readonly FrozenDictionary<string, string> AuthModels =
         new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            ["anthropic"] = "anthropic",
-            ["anthropic-claude"] = "anthropic",
-            ["claude"] = "anthropic",
-            ["claude-code"] = "claude-code",
-            ["openai"] = "openai",
-            ["github-copilot"] = "openai",      // Copilot is an OpenAI front-end
-            ["gemini"] = "google",
-            ["google"] = "google",
-            ["openrouter"] = "openrouter",
-            ["local"] = "local",
-            ["ollama"] = "local",
-            ["lmstudio"] = "local",
+            ["anthropic"] = "api-key",
+            ["openai"] = "api-key",
+            ["google"] = "api-key",
+            ["openrouter"] = "api-key",
+            ["local"] = "api-key",
+            ["claude-code"] = "cli-token",
         }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
-    /// <summary>Per-(provider, model) USD-per-token rates.</summary>
-    private static readonly FrozenDictionary<string, FrozenDictionary<string, Rate>> s_pricing =
-        BuildTable();
+    /// <summary>Display names for the seeded providers (Story 34-11).</summary>
+    public static readonly FrozenDictionary<string, string> DisplayNames =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["anthropic"] = "Anthropic",
+            ["openai"] = "OpenAI",
+            ["google"] = "Google",
+            ["openrouter"] = "OpenRouter",
+            ["local"] = "Local",
+            ["claude-code"] = "Claude Code",
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
     public decimal Compute(string provider, string? model, int inputTokens, int outputTokens)
     {
         if (string.IsNullOrWhiteSpace(provider)) return 0m;
         if (!TryGetRate(provider, model, out var rate)) return 0m;
-
-        var inTok = inputTokens < 0 ? 0 : inputTokens;
-        var outTok = outputTokens < 0 ? 0 : outputTokens;
-
-        return (rate.InputPerToken * inTok) + (rate.OutputPerToken * outTok);
+        return ProviderRateLookup.Cost(rate, inputTokens, outputTokens);
     }
 
     public bool IsKnown(string provider, string? model)
         => TryGetRate(provider, model, out _);
 
-    private static bool TryGetRate(string provider, string? model, out Rate rate)
+    private static bool TryGetRate(string provider, string? model, out ProviderRateLookup.Rate rate)
     {
         rate = default;
-        var canonical = s_aliases.TryGetValue(provider, out var aliased) ? aliased : provider;
-        if (!s_pricing.TryGetValue(canonical, out var modelMap)) return false;
-
-        // Resolve "default" or null to the provider's first model.
-        var lookupModel = string.IsNullOrWhiteSpace(model) || model == "default"
-            ? modelMap.Keys.FirstOrDefault()
-            : model;
-        if (lookupModel is null) return false;
-
-        if (modelMap.TryGetValue(lookupModel, out rate)) return true;
-
-        // Loose match: if caller passed e.g. "claude-sonnet-4" and the table
-        // has "claude-sonnet-4-20250514", match on the prefix. Picks the first
-        // entry whose key starts with the requested model id.
-        foreach (var (key, value) in modelMap)
-        {
-            if (key.StartsWith(lookupModel, StringComparison.OrdinalIgnoreCase))
-            {
-                rate = value;
-                return true;
-            }
-        }
-        return false;
+        var canonical = ProviderRateLookup.Canonicalize(provider);
+        if (!Pricing.TryGetValue(canonical, out var modelMap)) return false;
+        return ProviderRateLookup.TryGetRate(provider, model, modelMap, out rate);
     }
 
-    private static FrozenDictionary<string, FrozenDictionary<string, Rate>> BuildTable()
+    private static FrozenDictionary<string, FrozenDictionary<string, ProviderRateLookup.Rate>> BuildTable()
     {
         // Helper: USD-per-1M tokens → USD-per-token.
-        static decimal Per(double per1M) => (decimal)(per1M / 1_000_000.0);
+        static ProviderRateLookup.Rate R(double in1M, double out1M) =>
+            new((decimal)(in1M / 1_000_000.0), (decimal)(out1M / 1_000_000.0));
 
-        var anthropic = new Dictionary<string, Rate>(StringComparer.OrdinalIgnoreCase)
+        var anthropic = new Dictionary<string, ProviderRateLookup.Rate>(StringComparer.OrdinalIgnoreCase)
         {
-            ["claude-sonnet-4-20250514"] = new(Per(3.00), Per(15.00)),
-            ["claude-opus-4-20250514"] = new(Per(15.00), Per(75.00)),
-            ["claude-3-5-sonnet-20241022"] = new(Per(3.00), Per(15.00)),
-            ["claude-3-5-haiku-20241022"] = new(Per(0.80), Per(4.00)),
-            ["claude-3-opus-20240229"] = new(Per(15.00), Per(75.00)),
-            ["claude-3-sonnet-20240229"] = new(Per(3.00), Per(15.00)),
-            ["claude-3-haiku-20240307"] = new(Per(0.25), Per(1.25)),
+            ["claude-sonnet-4-20250514"] = R(3.00, 15.00),
+            ["claude-opus-4-20250514"] = R(15.00, 75.00),
+            ["claude-3-5-sonnet-20241022"] = R(3.00, 15.00),
+            ["claude-3-5-haiku-20241022"] = R(0.80, 4.00),
+            ["claude-3-opus-20240229"] = R(15.00, 75.00),
+            ["claude-3-sonnet-20240229"] = R(3.00, 15.00),
+            ["claude-3-haiku-20240307"] = R(0.25, 1.25),
         }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
-        var openai = new Dictionary<string, Rate>(StringComparer.OrdinalIgnoreCase)
+        var openai = new Dictionary<string, ProviderRateLookup.Rate>(StringComparer.OrdinalIgnoreCase)
         {
-            ["gpt-4o"] = new(Per(2.50), Per(10.00)),
-            ["gpt-4o-mini"] = new(Per(0.15), Per(0.60)),
-            ["gpt-4-turbo"] = new(Per(10.00), Per(30.00)),
-            ["gpt-4"] = new(Per(30.00), Per(60.00)),
-            ["gpt-3.5-turbo"] = new(Per(0.50), Per(1.50)),
-            ["o1-preview"] = new(Per(15.00), Per(60.00)),
-            ["o1-mini"] = new(Per(3.00), Per(12.00)),
+            ["gpt-4o"] = R(2.50, 10.00),
+            ["gpt-4o-mini"] = R(0.15, 0.60),
+            ["gpt-4-turbo"] = R(10.00, 30.00),
+            ["gpt-4"] = R(30.00, 60.00),
+            ["gpt-3.5-turbo"] = R(0.50, 1.50),
+            ["o1-preview"] = R(15.00, 60.00),
+            ["o1-mini"] = R(3.00, 12.00),
         }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
-        var google = new Dictionary<string, Rate>(StringComparer.OrdinalIgnoreCase)
+        var google = new Dictionary<string, ProviderRateLookup.Rate>(StringComparer.OrdinalIgnoreCase)
         {
-            ["gemini-1.5-pro"] = new(Per(1.25), Per(5.00)),
-            ["gemini-1.5-flash"] = new(Per(0.075), Per(0.30)),
-            ["gemini-2.0-flash"] = new(Per(0.10), Per(0.40)),
+            ["gemini-1.5-pro"] = R(1.25, 5.00),
+            ["gemini-1.5-flash"] = R(0.075, 0.30),
+            ["gemini-2.0-flash"] = R(0.10, 0.40),
         }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
         // OpenRouter shares model identifiers with vendor/model paths.
-        var openrouter = new Dictionary<string, Rate>(StringComparer.OrdinalIgnoreCase)
+        var openrouter = new Dictionary<string, ProviderRateLookup.Rate>(StringComparer.OrdinalIgnoreCase)
         {
-            ["anthropic/claude-3.5-sonnet"] = new(Per(3.00), Per(15.00)),
-            ["anthropic/claude-3-opus"] = new(Per(15.00), Per(75.00)),
-            ["anthropic/claude-3-haiku"] = new(Per(0.25), Per(1.25)),
-            ["openai/gpt-4o"] = new(Per(2.50), Per(10.00)),
-            ["openai/gpt-4o-mini"] = new(Per(0.15), Per(0.60)),
-            ["meta-llama/llama-3.1-405b-instruct"] = new(Per(2.70), Per(2.70)),
-            ["meta-llama/llama-3.1-70b-instruct"] = new(Per(0.52), Per(0.75)),
-            ["meta-llama/llama-3.1-8b-instruct"] = new(Per(0.055), Per(0.055)),
-            ["mistralai/mistral-large"] = new(Per(2.00), Per(6.00)),
-            ["mistralai/mixtral-8x7b-instruct"] = new(Per(0.24), Per(0.24)),
+            ["anthropic/claude-3.5-sonnet"] = R(3.00, 15.00),
+            ["anthropic/claude-3-opus"] = R(15.00, 75.00),
+            ["anthropic/claude-3-haiku"] = R(0.25, 1.25),
+            ["openai/gpt-4o"] = R(2.50, 10.00),
+            ["openai/gpt-4o-mini"] = R(0.15, 0.60),
+            ["meta-llama/llama-3.1-405b-instruct"] = R(2.70, 2.70),
+            ["meta-llama/llama-3.1-70b-instruct"] = R(0.52, 0.75),
+            ["meta-llama/llama-3.1-8b-instruct"] = R(0.055, 0.055),
+            ["mistralai/mistral-large"] = R(2.00, 6.00),
+            ["mistralai/mixtral-8x7b-instruct"] = R(0.24, 0.24),
         }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
         // claude-code uses Anthropic pricing.
         var claudeCode = anthropic;
 
         // Local models bill at zero.
-        var local = new Dictionary<string, Rate>(StringComparer.OrdinalIgnoreCase)
+        var local = new Dictionary<string, ProviderRateLookup.Rate>(StringComparer.OrdinalIgnoreCase)
         {
             ["local"] = new(0m, 0m),
             ["default"] = new(0m, 0m),
         }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
-        return new Dictionary<string, FrozenDictionary<string, Rate>>(StringComparer.OrdinalIgnoreCase)
+        return new Dictionary<string, FrozenDictionary<string, ProviderRateLookup.Rate>>(StringComparer.OrdinalIgnoreCase)
         {
             ["anthropic"] = anthropic,
             ["openai"] = openai,

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderRateLookup.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderRateLookup.cs
@@ -1,0 +1,110 @@
+using System.Collections.Frozen;
+
+namespace Tamma.Api.Services.Providers;
+
+/// <summary>
+/// Story 34-11 — the SINGLE source of the provider-cost lookup algorithm,
+/// shared by both <see cref="ProviderPricingService"/> (the frozen seed source /
+/// boot fallback) and <see cref="DbProviderPricingService"/> (the DB-backed
+/// impl). Holds the load-bearing quirks the frozen table carried, ported
+/// VERBATIM so the two impls cannot drift (AC6 / the parity test pins this):
+/// <list type="bullet">
+///   <item>the <c>s_aliases</c> provider alias map (anthropic-claude/claude →
+///     anthropic, gemini → google, github-copilot → openai, ollama/lmstudio →
+///     local);</item>
+///   <item><c>null</c>/<c>"default"</c> → the provider's first model;</item>
+///   <item>exact match then loose prefix match (a request for
+///     <c>claude-sonnet-4</c> matches a stored <c>claude-sonnet-4-20250514</c>);</item>
+///   <item>unknown <c>(provider, model)</c> resolves to nothing — the caller
+///     returns <c>0m</c> / <c>false</c>, never throws.</item>
+/// </list>
+/// </summary>
+public static class ProviderRateLookup
+{
+    /// <summary>A per-token cost pair. USD per single token (not per 1M).</summary>
+    public readonly record struct Rate(decimal InputPerToken, decimal OutputPerToken);
+
+    /// <summary>
+    /// Provider alias normalisation. Maps every accepted handle to the canonical
+    /// provider key. Unrecognised keys pass through untouched so explicit table
+    /// additions still resolve. (Ported verbatim from <c>ProviderPricingService.s_aliases</c>.)
+    /// </summary>
+    public static readonly FrozenDictionary<string, string> Aliases =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["anthropic"] = "anthropic",
+            ["anthropic-claude"] = "anthropic",
+            ["claude"] = "anthropic",
+            ["claude-code"] = "claude-code",
+            ["openai"] = "openai",
+            ["github-copilot"] = "openai",      // Copilot is an OpenAI front-end
+            ["gemini"] = "google",
+            ["google"] = "google",
+            ["openrouter"] = "openrouter",
+            ["local"] = "local",
+            ["ollama"] = "local",
+            ["lmstudio"] = "local",
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Normalise a (possibly aliased / mixed-case) provider key to its canonical
+    /// form. Unknown keys pass through untouched. Used BOTH on the lookup path
+    /// and on the write path (so <see cref="ProviderModelPrice.ProviderKey"/> is
+    /// always stored canonical — AC6).
+    /// </summary>
+    public static string Canonicalize(string provider) =>
+        provider is not null && Aliases.TryGetValue(provider, out var aliased)
+            ? aliased
+            : provider!;
+
+    /// <summary>
+    /// Resolve a rate from an arbitrary per-model table. The
+    /// <paramref name="modelMap"/> is the resolved provider's models (key =
+    /// model id, ordered the same way the table was built so the
+    /// first-model / prefix rules are deterministic).
+    /// </summary>
+    /// <returns><c>true</c> + <paramref name="rate"/> on a hit; <c>false</c> otherwise.</returns>
+    public static bool TryGetRate(
+        string provider,
+        string? model,
+        IReadOnlyDictionary<string, Rate> modelMap,
+        out Rate rate)
+    {
+        rate = default;
+        if (modelMap is null || modelMap.Count == 0) return false;
+
+        // Resolve "default" or null to the provider's first model.
+        var lookupModel = string.IsNullOrWhiteSpace(model) || model == "default"
+            ? modelMap.Keys.FirstOrDefault()
+            : model;
+        if (lookupModel is null) return false;
+
+        if (modelMap.TryGetValue(lookupModel, out rate)) return true;
+
+        // Loose match: if caller passed e.g. "claude-sonnet-4" and the table
+        // has "claude-sonnet-4-20250514", match on the prefix. Picks the first
+        // entry whose key starts with the requested model id.
+        foreach (var (key, value) in modelMap)
+        {
+            if (key.StartsWith(lookupModel, StringComparison.OrdinalIgnoreCase))
+            {
+                rate = value;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Compute the USD cost for a single invocation given the resolved
+    /// <paramref name="rate"/>. Negative token counts are clamped to zero — no
+    /// upstream protocol legitimately reports negative usage but a malformed
+    /// response must not flip the cost negative. (Ported verbatim.)
+    /// </summary>
+    public static decimal Cost(Rate rate, int inputTokens, int outputTokens)
+    {
+        var inTok = inputTokens < 0 ? 0 : inputTokens;
+        var outTok = outputTokens < 0 ? 0 : outputTokens;
+        return (rate.InputPerToken * inTok) + (rate.OutputPerToken * outTok);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
@@ -573,6 +573,21 @@ public class ControlPlaneDbContext : DbContext
     /// </summary>
     public DbSet<AuditProjectorCursor> AuditProjectorCursors => Set<AuditProjectorCursor>();
 
+    /// <summary>
+    /// Story 34-11 — the provider COST identity (platform-global, NOT
+    /// tenant-scoped). Promotes the frozen <c>ProviderPricingService</c> rate
+    /// sheet to a first-class, admin-editable entity behind the unchanged
+    /// <c>IProviderPricingService</c> seam.
+    /// </summary>
+    public DbSet<Provider> Providers => Set<Provider>();
+
+    /// <summary>
+    /// Story 34-11 — per-model versioned COST rows (USD-per-1M). Immutable +
+    /// EffectiveFrom-windowed: an edit supersedes rather than mutates so a usage
+    /// event prices under the rate active at its OccurredAt (reproducible).
+    /// </summary>
+    public DbSet<ProviderModelPrice> ProviderModelPrices => Set<ProviderModelPrice>();
+
     // Story 28-1 PR D: the 11 + 4 mentorship tenant-resident entities
     // (AgentConfig, PromptOverride, ProviderHealth, ProviderDiagnostic,
     // SanitizationRule, WorkflowDefinition, WorkflowInstance, DomainEvent,
@@ -668,6 +683,105 @@ public class ControlPlaneDbContext : DbContext
         // projector resumes both streams from one row.
         TammaModelConfiguration.ConfigureAuditEntities(modelBuilder, fixedTenantId: null);
         TammaModelConfiguration.ConfigureAuditProjectorCursor(modelBuilder);
+
+        // Story 34-11 — provider COST price-book. CP-resident, platform-global
+        // (no TenantId): cost is the provider's published rate, identical for
+        // every tenant. Mirrors the ConfigurePlans versioning pattern.
+        ConfigureProviders(modelBuilder);
+        ConfigureProviderModelPrices(modelBuilder);
+    }
+
+    /// <summary>
+    /// Story 34-11 — <c>providers</c> table. Platform-global cost identity. The
+    /// unique <c>Key</c> is the canonical provider handle; CHECKs pin
+    /// <c>AuthModel</c>/<c>Status</c> to their closed enums. No tenant column —
+    /// cost is mode- and tenant-independent (design §4.4).
+    /// </summary>
+    private static void ConfigureProviders(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Provider>(entity =>
+        {
+            entity.ToTable("providers", t =>
+            {
+                t.HasCheckConstraint(
+                    "ck_providers_auth_model",
+                    "\"AuthModel\" IN ('api-key','cli-token')");
+                t.HasCheckConstraint(
+                    "ck_providers_status",
+                    "\"Status\" IN ('active','retired')");
+            });
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+            entity.Property(e => e.Key).IsRequired().HasMaxLength(50);
+            entity.Property(e => e.DisplayName).IsRequired().HasMaxLength(255);
+            entity.Property(e => e.AuthModel)
+                .IsRequired().HasMaxLength(20).HasDefaultValue("api-key");
+            entity.Property(e => e.Status)
+                .IsRequired().HasMaxLength(20).HasDefaultValue("active");
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("now()");
+
+            // Canonical provider key is the natural key the cost resolver
+            // (and the FK from provider_model_prices) joins on.
+            entity.HasIndex(e => e.Key)
+                .HasDatabaseName("UX_providers_Key").IsUnique();
+        });
+    }
+
+    /// <summary>
+    /// Story 34-11 — <c>provider_model_prices</c> table. The immutability
+    /// invariant lives in SQL: a partial unique index
+    /// <c>UX_provider_model_prices_OneActivePerModel</c> on
+    /// <c>(ProviderKey, Model) WHERE "Status" = 'active'</c> guarantees exactly
+    /// one active row per model (mirrors <c>UX_plans_OneActivePerSlug</c>). The
+    /// window index supports the EffectiveFrom-windowed resolution. FK
+    /// <c>ProviderKey → providers.Key</c> with RESTRICT (a referenced cost
+    /// identity must never be hard-deleted out from under its price rows).
+    /// </summary>
+    private static void ConfigureProviderModelPrices(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<ProviderModelPrice>(entity =>
+        {
+            entity.ToTable("provider_model_prices", t =>
+            {
+                t.HasCheckConstraint(
+                    "ck_provider_model_prices_status",
+                    "\"Status\" IN ('active','superseded')");
+                t.HasCheckConstraint(
+                    "ck_provider_model_prices_source",
+                    "\"Source\" IN ('seed','admin')");
+            });
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+            entity.Property(e => e.ProviderKey).IsRequired().HasMaxLength(50);
+            entity.Property(e => e.Model).IsRequired().HasMaxLength(200);
+            entity.Property(e => e.InputUsdPer1M).HasColumnType("decimal(20,8)");
+            entity.Property(e => e.OutputUsdPer1M).HasColumnType("decimal(20,8)");
+            entity.Property(e => e.CacheReadUsdPer1M).HasColumnType("decimal(20,8)");
+            entity.Property(e => e.CacheWriteUsdPer1M).HasColumnType("decimal(20,8)");
+            entity.Property(e => e.Status)
+                .IsRequired().HasMaxLength(20).HasDefaultValue("active");
+            entity.Property(e => e.Source)
+                .IsRequired().HasMaxLength(20).HasDefaultValue("seed");
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("now()");
+
+            // Exactly one active price per (ProviderKey, Model) — the
+            // immutability invariant in SQL (mirrors UX_plans_OneActivePerSlug).
+            entity.HasIndex(e => new { e.ProviderKey, e.Model })
+                .HasDatabaseName("UX_provider_model_prices_OneActivePerModel")
+                .HasFilter("\"Status\" = 'active'").IsUnique();
+
+            // Resolution-window lookup (provider+model, ordered by EffectiveFrom).
+            entity.HasIndex(e => new { e.ProviderKey, e.Model, e.EffectiveFrom })
+                .HasDatabaseName("IX_provider_model_prices_Window");
+
+            entity.HasOne<Provider>()
+                .WithMany(p => p.Prices)
+                .HasForeignKey(e => e.ProviderKey)
+                .HasPrincipalKey(p => p.Key)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
@@ -161,6 +161,7 @@ public class ControlPlaneDbContext : DbContext
                     .ToDictionary(x => x.Id, x => x.Status);
 
             EnforcePlanImmutability(untrackedStatus);
+            EnforceProviderPriceImmutability();
         }
         return base.SaveChanges(acceptAllChangesOnSuccess);
     }
@@ -181,6 +182,7 @@ public class ControlPlaneDbContext : DbContext
                 untrackedIds, cancellationToken);
 
             EnforcePlanImmutability(untrackedStatus);
+            EnforceProviderPriceImmutability();
         }
         return await base.SaveChangesAsync(acceptAllChangesOnSuccess, cancellationToken);
     }
@@ -352,6 +354,83 @@ public class ControlPlaneDbContext : DbContext
                 ["status"] = status,
                 ["planId"] = planId.ToString("D"),
                 ["entityKind"] = entityKind,
+            },
+            retryable: false,
+            severity: TammaErrorSeverity.High);
+    }
+
+    /// <summary>
+    /// Story 34-11 (I1) — the AUTHORITATIVE provider-cost immutability guard,
+    /// mirroring <see cref="EnforcePlanImmutability"/>. Throws
+    /// <c>PROVIDER.PRICE.IMMUTABLE</c> for ANY content mutation of an
+    /// already-<c>superseded</c> <see cref="ProviderModelPrice"/> row — a raw EF
+    /// <c>UPDATE</c> that bypasses the admin endpoint must STILL fail loud, not
+    /// succeed silently. The ONLY permitted change to an immutable row is the
+    /// controlled <c>active → superseded</c> flip the <c>VersionPrice</c> path
+    /// performs (Status + UpdatedAt only); anything else is rejected.
+    /// <para>No DB lookup needed — <see cref="ProviderModelPrice"/> has no child
+    /// rows and the original status is available from the change-tracker.</para>
+    /// </summary>
+    private void EnforceProviderPriceImmutability()
+    {
+        foreach (var entry in ChangeTracker.Entries<ProviderModelPrice>())
+        {
+            if (entry.State != EntityState.Modified) continue;
+
+            var originalStatus = entry.OriginalValues.GetValue<string>(nameof(ProviderModelPrice.Status));
+
+            // An already-superseded row is fully immutable: any modification throws.
+            if (originalStatus == "superseded")
+            {
+                ThrowPriceImmutable(entry.Entity, originalStatus);
+                continue;
+            }
+
+            // An active row may ONLY undergo the controlled active→superseded flip
+            // (Status + UpdatedAt). Any other field change — including smuggling a
+            // rate edit through the supersede path — is rejected.
+            if (originalStatus == "active")
+            {
+                if (IsControlledSupersedeFlip(entry)) continue;
+                ThrowPriceImmutable(entry.Entity, originalStatus);
+            }
+        }
+    }
+
+    /// <summary>
+    /// True iff this Modified <see cref="ProviderModelPrice"/> entry is the
+    /// controlled <c>active → superseded</c> flip: Status changes from
+    /// <c>active</c> to <c>superseded</c> and no other property changes except
+    /// <c>UpdatedAt</c> (mirrors <see cref="IsControlledDeprecationFlip"/>).
+    /// </summary>
+    private static bool IsControlledSupersedeFlip(EntityEntry<ProviderModelPrice> entry)
+    {
+        if (entry.Entity.Status != "superseded") return false;
+
+        foreach (var prop in entry.Properties)
+        {
+            if (!prop.IsModified) continue;
+            var name = prop.Metadata.Name;
+            if (name is nameof(ProviderModelPrice.Status) or nameof(ProviderModelPrice.UpdatedAt))
+                continue;
+            // Any other modified column means this is NOT a pure flip.
+            return false;
+        }
+        return true;
+    }
+
+    private static void ThrowPriceImmutable(ProviderModelPrice price, string status)
+    {
+        throw new TammaError(
+            "PROVIDER.PRICE.IMMUTABLE",
+            $"Provider cost price {price.Id:D} ({price.ProviderKey}/{price.Model}) is "
+            + $"{status} and immutable — version a new price instead of editing it in place.",
+            new Dictionary<string, object?>
+            {
+                ["priceId"] = price.Id.ToString("D"),
+                ["providerKey"] = price.ProviderKey,
+                ["model"] = price.Model,
+                ["status"] = status,
             },
             retryable: false,
             severity: TammaErrorSeverity.High);

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/Provider.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/Provider.cs
@@ -14,7 +14,12 @@ namespace Tamma.Data.Entities;
 /// </summary>
 public class Provider
 {
-    /// <summary>UUIDv7 — server default <c>gen_random_uuid()</c>; the seeder bakes deterministic ids.</summary>
+    /// <summary>
+    /// Primary key. New rows get a v4 GUID — the DB default is
+    /// <c>gen_random_uuid()</c> (UUIDv4) and admin inserts use
+    /// <c>Guid.NewGuid()</c> (UUIDv4). ONLY the seeder bakes deterministic,
+    /// UUIDv7-shaped ids (for insert-missing-only idempotency).
+    /// </summary>
     public Guid Id { get; set; }
 
     /// <summary>Canonical provider key: <c>anthropic|openai|google|openrouter|local|claude-code</c>. Unique.</summary>

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/Provider.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/Provider.cs
@@ -1,0 +1,40 @@
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Control-plane PROVIDER entity (Story 34-11): the platform's COST identity
+/// for an external LLM provider. Platform-global — NOT tenant-scoped (cost is
+/// the provider's published rate, identical for every tenant). AuthModel feeds
+/// 32-4 SaaS-eligibility. This is the *cost* primitive; sell price is 34-1
+/// (PlanPrice) and markup is 34-5 (MarginPolicy).
+///
+/// <para>There is deliberately NO <c>TenantId</c>/<c>UserId</c> column: cost is
+/// the provider's published rate — identical for every tenant in both modes
+/// (design §4.4). BYOK vs platform-provided is a *sell-side* concern owned by
+/// 34-3/34-5, never a cost-basis concern.</para>
+/// </summary>
+public class Provider
+{
+    /// <summary>UUIDv7 — server default <c>gen_random_uuid()</c>; the seeder bakes deterministic ids.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Canonical provider key: <c>anthropic|openai|google|openrouter|local|claude-code</c>. Unique.</summary>
+    public string Key { get; set; } = null!;
+
+    /// <summary>Display name shown in the admin UI.</summary>
+    public string DisplayName { get; set; } = null!;
+
+    /// <summary>
+    /// Auth model: <c>api-key</c> | <c>cli-token</c>. Feeds 32-4 SaaS-eligibility
+    /// (only <c>api-key</c> providers are SaaS-eligible). A CHECK pins the enum.
+    /// </summary>
+    public string AuthModel { get; set; } = "api-key";
+
+    /// <summary>Lifecycle: <c>active</c> | <c>retired</c>. A CHECK pins the enum.</summary>
+    public string Status { get; set; } = "active";
+
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+
+    /// <summary>The per-model versioned cost rows for this provider.</summary>
+    public ICollection<ProviderModelPrice> Prices { get; set; } = new List<ProviderModelPrice>();
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/ProviderModelPrice.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/ProviderModelPrice.cs
@@ -12,7 +12,12 @@ namespace Tamma.Data.Entities;
 /// </summary>
 public class ProviderModelPrice
 {
-    /// <summary>UUIDv7 — server default <c>gen_random_uuid()</c>; the seeder bakes deterministic ids.</summary>
+    /// <summary>
+    /// Primary key. New rows get a v4 GUID — the DB default is
+    /// <c>gen_random_uuid()</c> (UUIDv4) and admin inserts use
+    /// <c>Guid.NewGuid()</c> (UUIDv4). ONLY the seeder bakes deterministic,
+    /// UUIDv7-shaped ids (for insert-missing-only idempotency).
+    /// </summary>
     public Guid Id { get; set; }
 
     /// <summary>Canonical provider key (alias-normalized on write). FK → <c>providers.Key</c>.</summary>

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/ProviderModelPrice.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/ProviderModelPrice.cs
@@ -1,0 +1,48 @@
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// The COST pricing — per model, versioned (Story 34-11). An edit SUPERSEDES
+/// rather than mutates (partial unique index on (ProviderKey, Model)
+/// WHERE Status='active'); EffectiveFrom-windowed so a usage event prices under
+/// the rate active at its OccurredAt (reproducible/byte-stable — the cost-side
+/// companion of 34-5 AC7). USD-per-1M tokens.
+///
+/// <para>Platform-global — NO <c>TenantId</c>/<c>UserId</c>. The cost basis is
+/// identical for every tenant; BYOK only changes the *sell* price (34-5).</para>
+/// </summary>
+public class ProviderModelPrice
+{
+    /// <summary>UUIDv7 — server default <c>gen_random_uuid()</c>; the seeder bakes deterministic ids.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Canonical provider key (alias-normalized on write). FK → <c>providers.Key</c>.</summary>
+    public string ProviderKey { get; set; } = null!;
+
+    /// <summary>Model id — e.g. <c>claude-sonnet-4-20250514</c>, <c>gpt-4o</c>.</summary>
+    public string Model { get; set; } = null!;
+
+    /// <summary>Input cost in USD per 1,000,000 tokens.</summary>
+    public decimal InputUsdPer1M { get; set; }
+
+    /// <summary>Output cost in USD per 1,000,000 tokens.</summary>
+    public decimal OutputUsdPer1M { get; set; }
+
+    /// <summary>Reserved (nullable) — cache-read cost USD per 1M tokens.</summary>
+    public decimal? CacheReadUsdPer1M { get; set; }
+
+    /// <summary>Reserved (nullable) — cache-write cost USD per 1M tokens.</summary>
+    public decimal? CacheWriteUsdPer1M { get; set; }
+
+    /// <summary>UTC instant this rate became effective (the resolution-window key).</summary>
+    public DateTime EffectiveFrom { get; set; }
+
+    /// <summary>Lifecycle: <c>active</c> | <c>superseded</c>. A CHECK pins the enum.</summary>
+    public string Status { get; set; } = "active";
+
+    /// <summary>Provenance: <c>seed</c> | <c>admin</c>. A CHECK pins the enum.
+    /// The seeder is insert-missing-only and NEVER reverts a <c>Source='admin'</c> row.</summary>
+    public string Source { get; set; } = "seed";
+
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260621180309_ProviderCostPriceBook.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260621180309_ProviderCostPriceBook.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.ControlPlane
 {
     [DbContext(typeof(ControlPlaneDbContext))]
-    partial class ControlPlaneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260621180309_ProviderCostPriceBook")]
+    partial class ProviderCostPriceBook
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260621180309_ProviderCostPriceBook.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260621180309_ProviderCostPriceBook.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.ControlPlane
+{
+    /// <inheritdoc />
+    public partial class ProviderCostPriceBook : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "providers",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    Key = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    DisplayName = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    AuthModel = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false, defaultValue: "api-key"),
+                    Status = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false, defaultValue: "active"),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_providers", x => x.Id);
+                    table.UniqueConstraint("AK_providers_Key", x => x.Key);
+                    table.CheckConstraint("ck_providers_auth_model", "\"AuthModel\" IN ('api-key','cli-token')");
+                    table.CheckConstraint("ck_providers_status", "\"Status\" IN ('active','retired')");
+                });
+
+            migrationBuilder.CreateTable(
+                name: "provider_model_prices",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    ProviderKey = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    Model = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    InputUsdPer1M = table.Column<decimal>(type: "numeric(20,8)", nullable: false),
+                    OutputUsdPer1M = table.Column<decimal>(type: "numeric(20,8)", nullable: false),
+                    CacheReadUsdPer1M = table.Column<decimal>(type: "numeric(20,8)", nullable: true),
+                    CacheWriteUsdPer1M = table.Column<decimal>(type: "numeric(20,8)", nullable: true),
+                    EffectiveFrom = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Status = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false, defaultValue: "active"),
+                    Source = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false, defaultValue: "seed"),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_provider_model_prices", x => x.Id);
+                    table.CheckConstraint("ck_provider_model_prices_source", "\"Source\" IN ('seed','admin')");
+                    table.CheckConstraint("ck_provider_model_prices_status", "\"Status\" IN ('active','superseded')");
+                    table.ForeignKey(
+                        name: "FK_provider_model_prices_providers_ProviderKey",
+                        column: x => x.ProviderKey,
+                        principalTable: "providers",
+                        principalColumn: "Key",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_provider_model_prices_Window",
+                table: "provider_model_prices",
+                columns: new[] { "ProviderKey", "Model", "EffectiveFrom" });
+
+            migrationBuilder.CreateIndex(
+                name: "UX_provider_model_prices_OneActivePerModel",
+                table: "provider_model_prices",
+                columns: new[] { "ProviderKey", "Model" },
+                unique: true,
+                filter: "\"Status\" = 'active'");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_providers_Key",
+                table: "providers",
+                column: "Key",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "provider_model_prices");
+
+            migrationBuilder.DropTable(
+                name: "providers");
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Seeders/ProviderPricingSeeder.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Seeders/ProviderPricingSeeder.cs
@@ -1,0 +1,230 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Tamma.Data.Entities;
+
+namespace Tamma.Data.Seeders;
+
+/// <summary>
+/// Story 34-11 — idempotently ports the frozen provider COST rate sheet
+/// (<c>ProviderPricingService</c>'s <c>FrozenDictionary</c>) into the
+/// control-plane <c>providers</c> + <c>provider_model_prices</c> tables as v1
+/// seed rows. Each provider becomes a <see cref="Provider"/> row (carrying its
+/// <c>AuthModel</c>); each <c>(model, Rate)</c> becomes a v1
+/// <see cref="ProviderModelPrice"/> row (<c>Status='active'</c>,
+/// <c>Source='seed'</c>, <c>EffectiveFrom = SEED_EPOCH</c>), with USD-per-token
+/// re-expressed as USD-per-1M.
+///
+/// <para><b>Insert-missing-only, per row</b> (mirrors <see cref="PlansSeeder"/>
+/// and the convention system-defaults ownership rule): a row is inserted only
+/// when absent. A re-run is a no-op and NEVER reverts a <c>Source='admin'</c>
+/// row — re-pricing happens through the admin write path, not the seeder.</para>
+///
+/// <para><b>Deterministic UUIDv7-shaped ids.</b> .NET 8 lacks
+/// <c>Guid.CreateVersion7</c>, so seed ids are derived deterministically from a
+/// stable namespace + name (SHA-256), with the RFC-4122 version nibble forced
+/// to 7 and the variant bits set. Deterministic ids let the insert-missing-only
+/// check key off a known id and keep FK targets stable across environments.</para>
+///
+/// <para><b>This seeder reads <c>ProviderPricingService</c> as data ONLY.</b>
+/// The static frozen table is the seed source; the seeder lives in
+/// <c>Tamma.Data</c> and cannot reference the <c>Tamma.Api</c> service, so the
+/// frozen rate sheet is mirrored here as a private snapshot that the
+/// ProviderPricingParityTests pin byte-identical to the live service.</para>
+/// </summary>
+public static class ProviderPricingSeeder
+{
+    /// <summary>
+    /// The fixed seed epoch every v1 row carries as <c>EffectiveFrom</c>. A
+    /// stable past instant so the EffectiveFrom window always selects a v1 row
+    /// for any realistic <c>OccurredAt</c>. NEVER change — it is the version-1
+    /// boundary the time-travel resolver anchors on.
+    /// </summary>
+    public static readonly DateTime SeedEpoch =
+        new(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>DNS-style namespace for deterministic seed ids. NEVER change.</summary>
+    private const string IdNamespace = "tamma.provider-cost.v1";
+
+    /// <summary>
+    /// Inserts any missing provider + price rows. Safe to call on every startup
+    /// — per-row existence checks make re-runs a no-op and never revert admin
+    /// edits. Returns the number of price rows inserted.
+    /// </summary>
+    public static async Task<int> SeedAsync(
+        ControlPlaneDbContext context,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var now = DateTime.UtcNow;
+        var insertedPrices = 0;
+
+        var existingProviderKeys = await context.Providers
+            .AsNoTracking()
+            .Select(p => p.Key)
+            .ToListAsync(cancellationToken);
+        var providerKeySet = existingProviderKeys.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        // Per-row idempotency keyed off the deterministic id — never a
+        // whole-table short-circuit (so a partially-seeded DB backfills).
+        var existingPriceIds = await context.ProviderModelPrices
+            .AsNoTracking()
+            .Select(p => p.Id)
+            .ToListAsync(cancellationToken);
+        var priceIdSet = existingPriceIds.ToHashSet();
+
+        foreach (var spec in s_seed)
+        {
+            if (!providerKeySet.Contains(spec.Key))
+            {
+                context.Providers.Add(new Provider
+                {
+                    Id = DeterministicId($"provider:{spec.Key}"),
+                    Key = spec.Key,
+                    DisplayName = spec.DisplayName,
+                    AuthModel = spec.AuthModel,
+                    Status = "active",
+                    CreatedAt = now,
+                    UpdatedAt = now,
+                });
+            }
+
+            // Stamp each model with a deterministic sub-millisecond offset off
+            // the seed epoch, in the frozen-table declaration order. This makes
+            // ORDER BY EffectiveFrom reproduce the frozen insertion order so the
+            // null/"default"→first-model rule resolves to the SAME model in the
+            // DB-backed resolver as in the frozen table (the parity contract).
+            // The offsets are tiny (1 tick = 100ns each) and stay within the
+            // seed epoch — well before any admin re-price, so the EffectiveFrom
+            // resolution window is unaffected.
+            var ordinal = 0;
+            foreach (var (model, in1M, out1M) in spec.Models)
+            {
+                // 1 microsecond (10 ticks) per step — Postgres `timestamptz` is
+                // microsecond-precision, so a sub-microsecond offset would round
+                // away and collapse the ordering.
+                var effectiveFrom = SeedEpoch.AddTicks(ordinal * 10L);
+                ordinal++;
+
+                var id = DeterministicId($"price:{spec.Key}:{model}");
+                if (priceIdSet.Contains(id))
+                {
+                    continue;
+                }
+
+                context.ProviderModelPrices.Add(new ProviderModelPrice
+                {
+                    Id = id,
+                    ProviderKey = spec.Key,
+                    Model = model,
+                    InputUsdPer1M = in1M,
+                    OutputUsdPer1M = out1M,
+                    CacheReadUsdPer1M = null,
+                    CacheWriteUsdPer1M = null,
+                    EffectiveFrom = effectiveFrom,
+                    Status = "active",
+                    Source = "seed",
+                    CreatedAt = now,
+                    UpdatedAt = now,
+                });
+                insertedPrices++;
+            }
+        }
+
+        if (insertedPrices > 0 || context.ChangeTracker.HasChanges())
+        {
+            await context.SaveChangesAsync(cancellationToken);
+        }
+
+        return insertedPrices;
+    }
+
+    /// <summary>
+    /// Derive a stable, deterministic UUIDv7-shaped GUID from a name. SHA-256 of
+    /// <c>"{namespace}:{name}"</c>, version nibble forced to 7, RFC-4122 variant.
+    /// </summary>
+    public static Guid DeterministicId(string name)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes($"{IdNamespace}:{name}"));
+        Span<byte> guid = stackalloc byte[16];
+        bytes.AsSpan(0, 16).CopyTo(guid);
+
+        // RFC-4122: version 7 in the high nibble of byte 6.
+        guid[6] = (byte)((guid[6] & 0x0F) | 0x70);
+        // RFC-4122 variant (10xx) in the high bits of byte 8.
+        guid[8] = (byte)((guid[8] & 0x3F) | 0x80);
+
+        // Construct from the BIG-ENDIAN field layout so the canonical string
+        // form shows the version nibble (7) and variant in the standard RFC-4122
+        // positions — i.e. a true UUIDv7-shaped id, not the mixed-endian default
+        // Guid(ReadOnlySpan<byte>) would produce.
+        return new Guid(guid, bigEndian: true);
+    }
+
+    // The frozen rate sheet mirrored here as USD-per-1M (the storage unit). The
+    // ProviderPricingParityTests assert byte-for-byte parity between this seed
+    // and the live ProviderPricingService.Compute output for every pair.
+    private sealed record ProviderSeed(
+        string Key,
+        string DisplayName,
+        string AuthModel,
+        IReadOnlyList<(string Model, decimal In1M, decimal Out1M)> Models);
+
+    private static readonly IReadOnlyList<ProviderSeed> s_seed = BuildSeed();
+
+    private static IReadOnlyList<ProviderSeed> BuildSeed()
+    {
+        var anthropic = new (string, decimal, decimal)[]
+        {
+            ("claude-sonnet-4-20250514", 3.00m, 15.00m),
+            ("claude-opus-4-20250514", 15.00m, 75.00m),
+            ("claude-3-5-sonnet-20241022", 3.00m, 15.00m),
+            ("claude-3-5-haiku-20241022", 0.80m, 4.00m),
+            ("claude-3-opus-20240229", 15.00m, 75.00m),
+            ("claude-3-sonnet-20240229", 3.00m, 15.00m),
+            ("claude-3-haiku-20240307", 0.25m, 1.25m),
+        };
+
+        return
+        [
+            new ProviderSeed("anthropic", "Anthropic", "api-key", anthropic),
+            new ProviderSeed("openai", "OpenAI", "api-key", new (string, decimal, decimal)[]
+            {
+                ("gpt-4o", 2.50m, 10.00m),
+                ("gpt-4o-mini", 0.15m, 0.60m),
+                ("gpt-4-turbo", 10.00m, 30.00m),
+                ("gpt-4", 30.00m, 60.00m),
+                ("gpt-3.5-turbo", 0.50m, 1.50m),
+                ("o1-preview", 15.00m, 60.00m),
+                ("o1-mini", 3.00m, 12.00m),
+            }),
+            new ProviderSeed("google", "Google", "api-key", new (string, decimal, decimal)[]
+            {
+                ("gemini-1.5-pro", 1.25m, 5.00m),
+                ("gemini-1.5-flash", 0.075m, 0.30m),
+                ("gemini-2.0-flash", 0.10m, 0.40m),
+            }),
+            new ProviderSeed("openrouter", "OpenRouter", "api-key", new (string, decimal, decimal)[]
+            {
+                ("anthropic/claude-3.5-sonnet", 3.00m, 15.00m),
+                ("anthropic/claude-3-opus", 15.00m, 75.00m),
+                ("anthropic/claude-3-haiku", 0.25m, 1.25m),
+                ("openai/gpt-4o", 2.50m, 10.00m),
+                ("openai/gpt-4o-mini", 0.15m, 0.60m),
+                ("meta-llama/llama-3.1-405b-instruct", 2.70m, 2.70m),
+                ("meta-llama/llama-3.1-70b-instruct", 0.52m, 0.75m),
+                ("meta-llama/llama-3.1-8b-instruct", 0.055m, 0.055m),
+                ("mistralai/mistral-large", 2.00m, 6.00m),
+                ("mistralai/mixtral-8x7b-instruct", 0.24m, 0.24m),
+            }),
+            // claude-code uses Anthropic pricing (CLI harness — cli-token).
+            new ProviderSeed("claude-code", "Claude Code", "cli-token", anthropic),
+            new ProviderSeed("local", "Local", "api-key", new (string, decimal, decimal)[]
+            {
+                ("local", 0m, 0m),
+                ("default", 0m, 0m),
+            }),
+        ];
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Auth/PlatformOwnerAccessPolicyTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Auth/PlatformOwnerAccessPolicyTests.cs
@@ -165,6 +165,10 @@ public class PlatformOwnerAccessPolicyTests
         // PlatformOwnerAccess, not OwnerAccess (Finding C1): a tenant-owner
         // who is not a platform admin must NOT be able to read it.
         "/api/admin/plans",
+        // Story 34-11 — the provider COST price-book is platform-global in both
+        // modes (no per-tenant override layer). Same Finding-C1 gate: a
+        // tenant-owner who is not a platform admin must NOT read or edit it.
+        "/api/admin/providers",
     };
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/AdminProviderPricingEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/AdminProviderPricingEndpointsTests.cs
@@ -1,0 +1,273 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Endpoints.Admin;
+using Tamma.Api.Services.Providers;
+using Tamma.Api.Tests.TestDoubles;
+using Tamma.Core;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Seeders;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Endpoints;
+
+/// <summary>
+/// Story 34-11 (AC4, AC9) — <see cref="AdminProviderPricingEndpoints"/> against a
+/// real Postgres testcontainer. Covers the supersede/version chain + the
+/// one-active partial-unique-index invariant, the immutability throw, and the
+/// PROVIDER.* DCB event tags. (The PlatformOwnerAccess 403 gate is pinned by
+/// <c>PlatformOwnerAccessPolicyTests</c>, which adds the /api/admin/providers
+/// route to its gated-route list.)
+/// </summary>
+[TestFixture]
+public class AdminProviderPricingEndpointsTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+    private ServiceProvider _sp = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("admin_provider_pricing_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        var services = new ServiceCollection();
+        services.AddDbContext<ControlPlaneDbContext>(o => o.UseNpgsql(_cs));
+        _sp = services.BuildServiceProvider();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_sp is not null) await _sp.DisposeAsync();
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE provider_model_prices, providers CASCADE;");
+        await ProviderPricingSeeder.SeedAsync(ctx);
+    }
+
+    private ControlPlaneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    private IProviderCostResolver NewResolver() =>
+        new ProviderCostResolver(
+            _sp.GetRequiredService<IServiceScopeFactory>(), TimeProvider.System,
+            NullLogger<ProviderCostResolver>.Instance, TimeSpan.Zero);
+
+    private static ClaimsPrincipal Actor(string userId = "user-34-11", string email = "owner@tamma.dev") =>
+        new(new ClaimsIdentity(new[]
+        {
+            new Claim(JwtRegisteredClaimNames.Sub, userId),
+            new Claim(JwtRegisteredClaimNames.Email, email),
+            new Claim("platformRole", "platform_admin"),
+        }, "test"));
+
+    // The handlers return Results.Ok(anonymousObject) → Ok<TAnon>; assert via
+    // the IStatusCodeHttpResult facet rather than the closed generic type.
+    private static void AssertStatus(IResult result, int expected)
+    {
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>();
+        ((IStatusCodeHttpResult)result).StatusCode.Should().Be(expected);
+    }
+
+    [Test]
+    public async Task VersionPrice_Supersedes_Prior_And_Inserts_New_Active()
+    {
+        var publisher = new RecordingPlatformEventPublisher();
+
+        await using (var db = NewContext())
+        {
+            var result = await AdminProviderPricingEndpoints.VersionPrice(
+                "anthropic",
+                new VersionPriceRequest("claude-sonnet-4-20250514", 6.00m, 18.00m),
+                db, NewResolver(), publisher, Actor(), TimeProvider.System, default);
+
+            AssertStatus(result, StatusCodes.Status200OK);
+        }
+
+        await using var verify = NewContext();
+        var rows = await verify.ProviderModelPrices.AsNoTracking()
+            .Where(p => p.ProviderKey == "anthropic" && p.Model == "claude-sonnet-4-20250514")
+            .ToListAsync();
+
+        rows.Should().HaveCount(2, "v1 seed + v2 admin");
+        rows.Count(r => r.Status == "active").Should().Be(1, "exactly one active per (provider, model)");
+        var active = rows.Single(r => r.Status == "active");
+        active.Source.Should().Be("admin");
+        active.InputUsdPer1M.Should().Be(6.00m);
+        rows.Single(r => r.Status == "superseded").Source.Should().Be("seed");
+    }
+
+    [Test]
+    public async Task VersionPrice_Emits_PriceVersioned_Event_WithTags()
+    {
+        var publisher = new RecordingPlatformEventPublisher();
+        Guid seedId;
+        await using (var db = NewContext())
+        {
+            seedId = (await db.ProviderModelPrices.AsNoTracking().SingleAsync(p =>
+                p.ProviderKey == "anthropic"
+                && p.Model == "claude-sonnet-4-20250514"
+                && p.Status == "active")).Id;
+
+            await AdminProviderPricingEndpoints.VersionPrice(
+                "anthropic",
+                new VersionPriceRequest("claude-sonnet-4-20250514", 6.00m, 18.00m),
+                db, NewResolver(), publisher, Actor(), TimeProvider.System, default);
+        }
+
+        var evt = publisher.Events.Should().ContainSingle(e =>
+            e.Type == ProviderPricingEventTypes.PriceVersioned).Subject;
+        var tags = JsonSerializer.Deserialize<Dictionary<string, string>>(evt.Tags)!;
+        tags["providerKey"].Should().Be("anthropic");
+        tags["model"].Should().Be("claude-sonnet-4-20250514");
+        tags["source"].Should().Be("admin");
+        tags["actorUserId"].Should().Be("user-34-11");
+        tags["supersededPriceId"].Should().Be(seedId.ToString("D"));
+        tags.Should().ContainKey("effectiveFrom");
+    }
+
+    [Test]
+    public async Task VersionPrice_NormalizesAliasKey_OnWrite()
+    {
+        var publisher = new RecordingPlatformEventPublisher();
+        await using (var db = NewContext())
+        {
+            // "claude" is an alias for "anthropic" — the new row must store the
+            // canonical key so the FK resolves and the cost lookup hits.
+            await AdminProviderPricingEndpoints.VersionPrice(
+                "claude",
+                new VersionPriceRequest("claude-3-haiku-20240307", 0.30m, 1.50m),
+                db, NewResolver(), publisher, Actor(), TimeProvider.System, default);
+        }
+
+        await using var verify = NewContext();
+        // Note: claude-3-haiku-20240307 is also seeded under claude-code (which
+        // reuses the anthropic model list), so filter on the canonical key the
+        // alias resolved to.
+        var active = await verify.ProviderModelPrices.AsNoTracking().SingleAsync(p =>
+            p.ProviderKey == "anthropic"
+            && p.Model == "claude-3-haiku-20240307"
+            && p.Status == "active"
+            && p.Source == "admin");
+        active.ProviderKey.Should().Be("anthropic");
+    }
+
+    [Test]
+    public async Task EnsureMutableOrThrow_OnSupersededRow_Throws_Immutable()
+    {
+        await using var db = NewContext();
+        // Version once so a superseded row exists.
+        await AdminProviderPricingEndpoints.VersionPrice(
+            "anthropic",
+            new VersionPriceRequest("claude-sonnet-4-20250514", 6.00m, 18.00m),
+            db, NewResolver(), new RecordingPlatformEventPublisher(),
+            Actor(), TimeProvider.System, default);
+
+        var superseded = await db.ProviderModelPrices.AsNoTracking()
+            .FirstAsync(p => p.Status == "superseded");
+
+        var act = () => AdminProviderPricingEndpoints.EnsureMutableOrThrow(superseded);
+        act.Should().Throw<TammaError>()
+            .Which.Code.Should().Be("PROVIDER.PRICE.IMMUTABLE");
+    }
+
+    [Test]
+    public async Task OneActiveInvariant_PartialUniqueIndex_Rejects_Second_Active()
+    {
+        // Insert a second active row for the same (ProviderKey, Model) directly
+        // (bypassing the supersede path) — the partial unique index must reject it.
+        await using var db = NewContext();
+        db.ProviderModelPrices.Add(new ProviderModelPrice
+        {
+            Id = Guid.NewGuid(),
+            ProviderKey = "anthropic",
+            Model = "claude-sonnet-4-20250514", // already has an active seed row
+            InputUsdPer1M = 1m,
+            OutputUsdPer1M = 1m,
+            EffectiveFrom = DateTime.UtcNow,
+            Status = "active",
+            Source = "admin",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+
+        var act = async () => await db.SaveChangesAsync();
+        await act.Should().ThrowAsync<DbUpdateException>(
+            "UX_provider_model_prices_OneActivePerModel forbids two active rows per model");
+    }
+
+    [Test]
+    public async Task RegisterProvider_Inserts_And_Emits_Registered_Event()
+    {
+        var publisher = new RecordingPlatformEventPublisher();
+        await using (var db = NewContext())
+        {
+            var result = await AdminProviderPricingEndpoints.RegisterProvider(
+                new RegisterProviderRequest("xai", "xAI", "api-key"),
+                db, publisher, Actor(), TimeProvider.System, default);
+            AssertStatus(result, StatusCodes.Status201Created);
+        }
+
+        await using var verify = NewContext();
+        (await verify.Providers.AnyAsync(p => p.Key == "xai")).Should().BeTrue();
+        publisher.Events.Should().Contain(e => e.Type == ProviderPricingEventTypes.Registered);
+    }
+
+    [Test]
+    public async Task UpdateProvider_Sets_Status_And_Emits_StatusChanged()
+    {
+        var publisher = new RecordingPlatformEventPublisher();
+        await using (var db = NewContext())
+        {
+            await AdminProviderPricingEndpoints.UpdateProvider(
+                "openai",
+                new UpdateProviderRequest(Status: "retired"),
+                db, publisher, Actor(), TimeProvider.System, default);
+        }
+
+        await using var verify = NewContext();
+        (await verify.Providers.SingleAsync(p => p.Key == "openai")).Status.Should().Be("retired");
+        publisher.Events.Should().Contain(e => e.Type == ProviderPricingEventTypes.StatusChanged);
+    }
+
+    [Test]
+    public async Task ListPrices_Returns_Active_And_Superseded()
+    {
+        await using (var db = NewContext())
+        {
+            await AdminProviderPricingEndpoints.VersionPrice(
+                "anthropic",
+                new VersionPriceRequest("claude-sonnet-4-20250514", 6.00m, 18.00m),
+                db, NewResolver(), new RecordingPlatformEventPublisher(),
+                Actor(), TimeProvider.System, default);
+        }
+
+        await using var db2 = NewContext();
+        var result = await AdminProviderPricingEndpoints.ListPrices("anthropic", db2, default);
+        AssertStatus(result, StatusCodes.Status200OK);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/AdminProviderPricingEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/AdminProviderPricingEndpointsTests.cs
@@ -77,6 +77,12 @@ public class AdminProviderPricingEndpointsTests
             _sp.GetRequiredService<IServiceScopeFactory>(), TimeProvider.System,
             NullLogger<ProviderCostResolver>.Instance, TimeSpan.Zero);
 
+    // The admin write paths take IEnumerable<IProviderCostCacheInvalidator> (C1):
+    // every snapshot holder is flushed on a mutation. A fresh resolver is a valid
+    // (no-op-here) invalidator for the endpoint-level tests.
+    private IProviderCostCacheInvalidator[] NewCaches() =>
+        new IProviderCostCacheInvalidator[] { NewResolver() };
+
     private static ClaimsPrincipal Actor(string userId = "user-34-11", string email = "owner@tamma.dev") =>
         new(new ClaimsIdentity(new[]
         {
@@ -103,7 +109,7 @@ public class AdminProviderPricingEndpointsTests
             var result = await AdminProviderPricingEndpoints.VersionPrice(
                 "anthropic",
                 new VersionPriceRequest("claude-sonnet-4-20250514", 6.00m, 18.00m),
-                db, NewResolver(), publisher, Actor(), TimeProvider.System, default);
+                db, NewCaches(), publisher, Actor(), TimeProvider.System, default);
 
             AssertStatus(result, StatusCodes.Status200OK);
         }
@@ -136,7 +142,7 @@ public class AdminProviderPricingEndpointsTests
             await AdminProviderPricingEndpoints.VersionPrice(
                 "anthropic",
                 new VersionPriceRequest("claude-sonnet-4-20250514", 6.00m, 18.00m),
-                db, NewResolver(), publisher, Actor(), TimeProvider.System, default);
+                db, NewCaches(), publisher, Actor(), TimeProvider.System, default);
         }
 
         var evt = publisher.Events.Should().ContainSingle(e =>
@@ -161,7 +167,7 @@ public class AdminProviderPricingEndpointsTests
             await AdminProviderPricingEndpoints.VersionPrice(
                 "claude",
                 new VersionPriceRequest("claude-3-haiku-20240307", 0.30m, 1.50m),
-                db, NewResolver(), publisher, Actor(), TimeProvider.System, default);
+                db, NewCaches(), publisher, Actor(), TimeProvider.System, default);
         }
 
         await using var verify = NewContext();
@@ -184,7 +190,7 @@ public class AdminProviderPricingEndpointsTests
         await AdminProviderPricingEndpoints.VersionPrice(
             "anthropic",
             new VersionPriceRequest("claude-sonnet-4-20250514", 6.00m, 18.00m),
-            db, NewResolver(), new RecordingPlatformEventPublisher(),
+            db, NewCaches(), new RecordingPlatformEventPublisher(),
             Actor(), TimeProvider.System, default);
 
         var superseded = await db.ProviderModelPrices.AsNoTracking()
@@ -228,7 +234,7 @@ public class AdminProviderPricingEndpointsTests
         {
             var result = await AdminProviderPricingEndpoints.RegisterProvider(
                 new RegisterProviderRequest("xai", "xAI", "api-key"),
-                db, publisher, Actor(), TimeProvider.System, default);
+                db, NewCaches(), publisher, Actor(), TimeProvider.System, default);
             AssertStatus(result, StatusCodes.Status201Created);
         }
 
@@ -246,12 +252,127 @@ public class AdminProviderPricingEndpointsTests
             await AdminProviderPricingEndpoints.UpdateProvider(
                 "openai",
                 new UpdateProviderRequest(Status: "retired"),
-                db, publisher, Actor(), TimeProvider.System, default);
+                db, NewCaches(), publisher, Actor(), TimeProvider.System, default);
         }
 
         await using var verify = NewContext();
         (await verify.Providers.SingleAsync(p => p.Key == "openai")).Status.Should().Be("retired");
         publisher.Events.Should().Contain(e => e.Type == ProviderPricingEventTypes.StatusChanged);
+    }
+
+    // I2 — a negative rate must be rejected with 400 (a typo'd admin write must
+    // not poison the cost basis with a negative cost).
+    [Test]
+    public async Task VersionPrice_NegativeInputRate_Returns400()
+    {
+        await using var db = NewContext();
+        var result = await AdminProviderPricingEndpoints.VersionPrice(
+            "anthropic",
+            new VersionPriceRequest("claude-sonnet-4-20250514", -1.00m, 18.00m),
+            db, NewCaches(), new RecordingPlatformEventPublisher(),
+            Actor(), TimeProvider.System, default);
+
+        AssertStatus(result, StatusCodes.Status400BadRequest);
+
+        // Nothing was versioned — the seed row is still the sole active row.
+        await using var verify = NewContext();
+        (await verify.ProviderModelPrices.CountAsync(p =>
+            p.ProviderKey == "anthropic" && p.Model == "claude-sonnet-4-20250514"))
+            .Should().Be(1, "a rejected write must not insert a row");
+    }
+
+    [Test]
+    public async Task VersionPrice_NegativeCacheRate_Returns400()
+    {
+        await using var db = NewContext();
+        var result = await AdminProviderPricingEndpoints.VersionPrice(
+            "anthropic",
+            new VersionPriceRequest(
+                "claude-sonnet-4-20250514", 3.00m, 15.00m, CacheWriteUsdPer1M: -0.50m),
+            db, NewCaches(), new RecordingPlatformEventPublisher(),
+            Actor(), TimeProvider.System, default);
+
+        AssertStatus(result, StatusCodes.Status400BadRequest);
+    }
+
+    // I2 — versioning a price on a RETIRED provider must be rejected (409): its
+    // cost identity is no longer live.
+    [Test]
+    public async Task VersionPrice_OnRetiredProvider_Returns409()
+    {
+        // Retire openai first.
+        await using (var db = NewContext())
+        {
+            await AdminProviderPricingEndpoints.UpdateProvider(
+                "openai", new UpdateProviderRequest(Status: "retired"),
+                db, NewCaches(), new RecordingPlatformEventPublisher(),
+                Actor(), TimeProvider.System, default);
+        }
+
+        await using var ctx = NewContext();
+        var result = await AdminProviderPricingEndpoints.VersionPrice(
+            "openai",
+            new VersionPriceRequest("gpt-4o", 1.00m, 2.00m),
+            ctx, NewCaches(), new RecordingPlatformEventPublisher(),
+            Actor(), TimeProvider.System, default);
+
+        AssertStatus(result, StatusCodes.Status409Conflict);
+    }
+
+    // I1 — the AUTHORITATIVE immutability guard lives at the DbContext SaveChanges
+    // interceptor (mirrors the Plan EnforcePlanImmutability sibling), NOT only at
+    // the pre-flight EnsureMutableOrThrow helper. A raw EF UPDATE of a superseded
+    // ProviderModelPrice row (bypassing the admin endpoint entirely) must STILL
+    // fail loud with PROVIDER.PRICE.IMMUTABLE.
+    [Test]
+    public async Task DirectMutation_Of_Superseded_Price_Throws_Immutable()
+    {
+        // Version once so a superseded row exists.
+        await using (var db = NewContext())
+        {
+            await AdminProviderPricingEndpoints.VersionPrice(
+                "anthropic",
+                new VersionPriceRequest("claude-sonnet-4-20250514", 6.00m, 18.00m),
+                db, NewCaches(), new RecordingPlatformEventPublisher(),
+                Actor(), TimeProvider.System, default);
+        }
+
+        await using var ctx = NewContext();
+        var superseded = await ctx.ProviderModelPrices.FirstAsync(p =>
+            p.ProviderKey == "anthropic"
+            && p.Model == "claude-sonnet-4-20250514"
+            && p.Status == "superseded");
+
+        // Tamper with the content of an already-superseded (immutable) row.
+        superseded.InputUsdPer1M = 0.01m;
+
+        var act = async () => await ctx.SaveChangesAsync();
+        (await act.Should().ThrowAsync<TammaError>(
+            "a content mutation of a superseded cost row must be rejected at the interceptor"))
+            .Which.Code.Should().Be("PROVIDER.PRICE.IMMUTABLE");
+    }
+
+    // I1 — the legitimate supersede flip (active→superseded) the VersionPrice path
+    // performs must STILL be allowed through the interceptor (otherwise versioning
+    // would be impossible).
+    [Test]
+    public async Task LegitimateSupersedeFlip_Is_Allowed_Through_Interceptor()
+    {
+        await using var db = NewContext();
+        var act = async () => await AdminProviderPricingEndpoints.VersionPrice(
+            "anthropic",
+            new VersionPriceRequest("claude-sonnet-4-20250514", 6.00m, 18.00m),
+            db, NewCaches(), new RecordingPlatformEventPublisher(),
+            Actor(), TimeProvider.System, default);
+
+        await act.Should().NotThrowAsync(
+            "the controlled active→superseded flip + new active insert must clear the interceptor");
+
+        await using var verify = NewContext();
+        (await verify.ProviderModelPrices.CountAsync(p =>
+            p.ProviderKey == "anthropic"
+            && p.Model == "claude-sonnet-4-20250514"
+            && p.Status == "active")).Should().Be(1, "exactly one active after the flip");
     }
 
     [Test]
@@ -262,12 +383,25 @@ public class AdminProviderPricingEndpointsTests
             await AdminProviderPricingEndpoints.VersionPrice(
                 "anthropic",
                 new VersionPriceRequest("claude-sonnet-4-20250514", 6.00m, 18.00m),
-                db, NewResolver(), new RecordingPlatformEventPublisher(),
+                db, NewCaches(), new RecordingPlatformEventPublisher(),
                 Actor(), TimeProvider.System, default);
         }
 
         await using var db2 = NewContext();
         var result = await AdminProviderPricingEndpoints.ListPrices("anthropic", db2, default);
         AssertStatus(result, StatusCodes.Status200OK);
+
+        // M3 — assert the response BODY actually carries BOTH the active (admin)
+        // and the superseded (seed) rows for the versioned model, not just 200.
+        var value = ((IValueHttpResult)result).Value!;
+        var pricesProp = value.GetType().GetProperty("prices")!;
+        var prices = (System.Collections.IEnumerable)pricesProp.GetValue(value)!;
+        var versioned = prices.Cast<ProviderModelPrice>()
+            .Where(p => p.Model == "claude-sonnet-4-20250514")
+            .ToList();
+
+        versioned.Should().HaveCount(2, "the body must contain both the seed + admin rows");
+        versioned.Should().Contain(p => p.Status == "active" && p.Source == "admin");
+        versioned.Should().Contain(p => p.Status == "superseded" && p.Source == "seed");
     }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
@@ -119,6 +119,12 @@ public class ControlPlaneDbContextModelTests
             // CP-resident high-water marks).
             "audit_records",
             "audit_projector_cursor",
+            // Story 34-11 — provider COST price-book. Platform-global (no
+            // TenantId): cost is the provider's published rate, identical for
+            // every tenant. Promotes the frozen ProviderPricingService rate
+            // sheet behind the unchanged IProviderPricingService seam.
+            "providers",
+            "provider_model_prices",
         }, because: "Story 28-1 PR D (Decision #4) — enumerate every "
             + "CP-resident table; the 11 + 4 mentorship tenant-resident "
             + "entities have moved to TenantDbContext. Story 31-2 adds "
@@ -128,7 +134,104 @@ public class ControlPlaneDbContextModelTests
             + "Story 32-2 adds agent_role_selections. "
             + "Story 34-1 adds plan_features + plan_entitlements + plan_prices. "
             + "Story 35-1 adds billing_customers + billing_plan_prices. "
-            + "Story 37-1 adds audit_records + audit_projector_cursor.");
+            + "Story 37-1 adds audit_records + audit_projector_cursor. "
+            + "Story 34-11 adds providers + provider_model_prices.");
+    }
+
+    // ── Story 34-11 — provider cost price-book model shape ──
+
+    [Test]
+    public void Provider_And_ProviderModelPrice_Have_No_TenantOrUser_Column()
+    {
+        using var ctx = CreateContext();
+
+        // AC3 — cost is the provider's published rate, GLOBAL in both modes.
+        // Neither cost entity may carry a tenant/user scope column.
+        var forbidden = new[] { "TenantId", "UserId", "OwnerTenantId", "OwnerUserId" };
+
+        var providerProps = ctx.Model.FindEntityType(typeof(Provider))!
+            .GetProperties().Select(p => p.Name).ToHashSet();
+        var priceProps = ctx.Model.FindEntityType(typeof(ProviderModelPrice))!
+            .GetProperties().Select(p => p.Name).ToHashSet();
+
+        providerProps.Should().NotIntersectWith(forbidden,
+            "Story 34-11 AC3 — the cost identity is platform-global, never tenant-scoped");
+        priceProps.Should().NotIntersectWith(forbidden,
+            "Story 34-11 AC3 — the cost rate is platform-global, never tenant-scoped");
+    }
+
+    [Test]
+    public void Provider_Key_Is_Unique()
+    {
+        using var ctx = CreateContext();
+
+        var provider = ctx.Model.FindEntityType(typeof(Provider))!;
+        var keyIndex = provider.GetIndexes()
+            .FirstOrDefault(i => i.Properties.Count == 1 && i.Properties[0].Name == "Key");
+
+        keyIndex.Should().NotBeNull("the canonical provider key is the natural key");
+        keyIndex!.IsUnique.Should().BeTrue();
+    }
+
+    [Test]
+    public void Provider_Has_AuthModel_And_Status_CheckConstraints()
+    {
+        using var ctx = CreateContext();
+
+        var designModel = Microsoft.EntityFrameworkCore.Infrastructure.AccessorExtensions
+            .GetService<Microsoft.EntityFrameworkCore.Metadata.IDesignTimeModel>(ctx).Model;
+        var provider = designModel.FindEntityType(typeof(Provider))!;
+        var checks = provider.GetCheckConstraints().Select(c => c.Name).ToHashSet();
+
+        checks.Should().Contain("ck_providers_auth_model");
+        checks.Should().Contain("ck_providers_status");
+    }
+
+    [Test]
+    public void ProviderModelPrice_Has_OneActivePerModel_PartialUniqueIndex()
+    {
+        using var ctx = CreateContext();
+
+        var price = ctx.Model.FindEntityType(typeof(ProviderModelPrice))!;
+        var oneActive = price.GetIndexes()
+            .Single(i => i.GetDatabaseName() == "UX_provider_model_prices_OneActivePerModel");
+
+        oneActive.IsUnique.Should().BeTrue("AC4 — exactly one active price per (ProviderKey, Model)");
+        oneActive.GetFilter().Should().Be("\"Status\" = 'active'");
+        oneActive.Properties.Select(p => p.Name).Should().Equal("ProviderKey", "Model");
+    }
+
+    [Test]
+    public void ProviderModelPrice_Has_Window_Index_And_RestrictFk()
+    {
+        using var ctx = CreateContext();
+
+        var price = ctx.Model.FindEntityType(typeof(ProviderModelPrice))!;
+
+        var window = price.GetIndexes()
+            .Single(i => i.GetDatabaseName() == "IX_provider_model_prices_Window");
+        window.Properties.Select(p => p.Name)
+            .Should().Equal(new[] { "ProviderKey", "Model", "EffectiveFrom" },
+                because: "AC5 — EffectiveFrom-windowed resolution lookup");
+
+        var fk = price.GetForeignKeys()
+            .Single(k => k.PrincipalEntityType.ClrType == typeof(Provider));
+        fk.DeleteBehavior.Should().Be(DeleteBehavior.Restrict,
+            "a referenced cost identity must never be hard-deleted out from under its prices");
+    }
+
+    [Test]
+    public void ProviderModelPrice_Has_Status_And_Source_CheckConstraints()
+    {
+        using var ctx = CreateContext();
+
+        var designModel = Microsoft.EntityFrameworkCore.Infrastructure.AccessorExtensions
+            .GetService<Microsoft.EntityFrameworkCore.Metadata.IDesignTimeModel>(ctx).Model;
+        var price = designModel.FindEntityType(typeof(ProviderModelPrice))!;
+        var checks = price.GetCheckConstraints().Select(c => c.Name).ToHashSet();
+
+        checks.Should().Contain("ck_provider_model_prices_status");
+        checks.Should().Contain("ck_provider_model_prices_source");
     }
 
     // ── Story 32-1 — agent entity model shape ──

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Providers/DbProviderPricingServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Providers/DbProviderPricingServiceTests.cs
@@ -1,9 +1,12 @@
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
+using Tamma.Api.Endpoints.Admin;
 using Tamma.Api.Services.Providers;
+using Tamma.Api.Tests.TestDoubles;
 using Tamma.Data;
 using Tamma.Data.Seeders;
 using Testcontainers.PostgreSql;
@@ -190,4 +193,54 @@ public class DbProviderPricingServiceTests
             new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc));
         cost.Should().Be(0m);
     }
+
+    // C1 (regression) — with a NON-ZERO snapshot TTL, an admin re-price through
+    // VersionPrice must invalidate the live IProviderPricingService snapshot so
+    // the very next Compute reflects the NEW rate (NOT the cached old one). The
+    // pre-fix bug: VersionPrice only invalidated the resolver's separate
+    // _activeSnapshot, leaving DbProviderPricingService._snapshot stale for the
+    // whole TTL window.
+    [Test]
+    public async Task VersionPrice_Invalidates_LiveCompute_Snapshot_Immediately()
+    {
+        var scopeFactory = _sp.GetRequiredService<IServiceScopeFactory>();
+        // Long TTL so the snapshot will NOT auto-refresh during the test — only
+        // an explicit Invalidate() can clear it.
+        var ttl = TimeSpan.FromMinutes(30);
+        var resolver = new ProviderCostResolver(
+            scopeFactory, TimeProvider.System,
+            NullLogger<ProviderCostResolver>.Instance, ttl);
+        var svc = new DbProviderPricingService(
+            scopeFactory, resolver, TimeProvider.System,
+            NullLogger<DbProviderPricingService>.Instance,
+            new ProviderPricingService(), ttl);
+
+        // Warm the snapshot at the seed rate ($3/1M in, $15/1M out → $3.00 for 1M in).
+        svc.Compute("anthropic", "claude-sonnet-4-20250514", 1_000_000, 0)
+            .Should().Be(3.00m, "seed rate before the re-price");
+
+        // Admin re-prices to $9/1M in via the real endpoint. The endpoint must
+        // invalidate every cost cache (resolver AND the live pricing service).
+        var invalidators = new IProviderCostCacheInvalidator[] { resolver, svc };
+        await using (var db = NewContext())
+        {
+            var result = await AdminProviderPricingEndpoints.VersionPrice(
+                "anthropic",
+                new VersionPriceRequest("claude-sonnet-4-20250514", 9.00m, 18.00m),
+                db, invalidators, new RecordingPlatformEventPublisher(),
+                Actor(), TimeProvider.System, default);
+            ((IStatusCodeHttpResult)result).StatusCode.Should().Be(StatusCodes.Status200OK);
+        }
+
+        // The very next Compute must reflect the NEW rate, not the stale snapshot.
+        svc.Compute("anthropic", "claude-sonnet-4-20250514", 1_000_000, 0)
+            .Should().Be(9.00m, "VersionPrice must invalidate the live Compute snapshot");
+    }
+
+    private static System.Security.Claims.ClaimsPrincipal Actor() =>
+        new(new System.Security.Claims.ClaimsIdentity(new[]
+        {
+            new System.Security.Claims.Claim(
+                System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub, "user-c1"),
+        }, "test"));
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Providers/DbProviderPricingServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Providers/DbProviderPricingServiceTests.cs
@@ -1,0 +1,193 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Services.Providers;
+using Tamma.Data;
+using Tamma.Data.Seeders;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Providers;
+
+/// <summary>
+/// Story 34-11 (AC5, AC6, AC7) — <see cref="DbProviderPricingService"/> over a
+/// real Postgres testcontainer. Covers the preserved frozen-table quirks (alias
+/// map, loose prefix, null/"default"→first, unknown→0m/IsKnown=false no-throw)
+/// sourced from rows, and the EffectiveFrom-windowed <c>ComputeAtAsync</c>.
+/// </summary>
+[TestFixture]
+public class DbProviderPricingServiceTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+    private ServiceProvider _sp = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("db_pricing_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        var services = new ServiceCollection();
+        services.AddDbContext<ControlPlaneDbContext>(o => o.UseNpgsql(_cs));
+        _sp = services.BuildServiceProvider();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_sp is not null) await _sp.DisposeAsync();
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE provider_model_prices, providers CASCADE;");
+        await ProviderPricingSeeder.SeedAsync(ctx);
+    }
+
+    private ControlPlaneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    private DbProviderPricingService NewService()
+    {
+        var scopeFactory = _sp.GetRequiredService<IServiceScopeFactory>();
+        var resolver = new ProviderCostResolver(
+            scopeFactory, TimeProvider.System,
+            NullLogger<ProviderCostResolver>.Instance, TimeSpan.Zero);
+        return new DbProviderPricingService(
+            scopeFactory, resolver, TimeProvider.System,
+            NullLogger<DbProviderPricingService>.Instance,
+            new ProviderPricingService(), TimeSpan.Zero);
+    }
+
+    [Test]
+    public void Compute_KnownExactPair_ReturnsRowRate()
+    {
+        var svc = NewService();
+        // claude-sonnet-4 @ $3/1M in, $15/1M out: 1000 in + 500 out = $0.0105.
+        svc.Compute("anthropic", "claude-sonnet-4-20250514", 1000, 500)
+            .Should().Be(0.0105m);
+        svc.IsKnown("anthropic", "claude-sonnet-4-20250514").Should().BeTrue();
+    }
+
+    [Test]
+    public void Compute_ResolvesAllFiveAliases_ToCanonicalRate()
+    {
+        var svc = NewService();
+
+        // anthropic-claude / claude → anthropic
+        svc.Compute("anthropic-claude", "claude-sonnet-4-20250514", 1000, 500).Should().Be(0.0105m);
+        svc.Compute("claude", "claude-sonnet-4-20250514", 1000, 500).Should().Be(0.0105m);
+        // gemini → google
+        svc.IsKnown("gemini", "gemini-1.5-flash").Should().BeTrue();
+        // github-copilot → openai
+        svc.IsKnown("github-copilot", "gpt-4o").Should().BeTrue();
+        // ollama / lmstudio → local
+        svc.IsKnown("ollama", "local").Should().BeTrue();
+        svc.IsKnown("lmstudio", "local").Should().BeTrue();
+    }
+
+    [Test]
+    public void Compute_LoosePrefixMatch()
+    {
+        var svc = NewService();
+        // "claude-sonnet-4" matches stored "claude-sonnet-4-20250514".
+        svc.Compute("anthropic", "claude-sonnet-4", 1000, 500).Should().Be(0.0105m);
+        svc.IsKnown("anthropic", "claude-sonnet-4").Should().BeTrue();
+    }
+
+    [Test]
+    public void Compute_NullOrDefault_ResolvesToFirstModel()
+    {
+        var svc = NewService();
+        svc.IsKnown("anthropic", null).Should().BeTrue();
+        svc.IsKnown("anthropic", "default").Should().BeTrue();
+        // First anthropic model is claude-sonnet-4 — same $0.0105 for 1000/500.
+        svc.Compute("anthropic", null, 1000, 500).Should().Be(0.0105m);
+    }
+
+    [Test]
+    public void Compute_UnknownPair_Returns0_And_IsKnownFalse_NoThrow()
+    {
+        var svc = NewService();
+        svc.Compute("zenith-9000", "model-x", 1000, 500).Should().Be(0m);
+        svc.IsKnown("zenith-9000", "model-x").Should().BeFalse();
+        svc.Compute("openai", "gpt-99-nope", 1000, 500).Should().Be(0m);
+        svc.IsKnown("openai", "gpt-99-nope").Should().BeFalse();
+    }
+
+    [Test]
+    public void Compute_ClampsNegativeTokens_ToZero()
+    {
+        var svc = NewService();
+        svc.Compute("anthropic", "claude-sonnet-4-20250514", -100, -200).Should().Be(0m);
+    }
+
+    [Test]
+    public async Task ComputeAtAsync_PricesUnder_RateActive_AtTimestamp_NotLatest()
+    {
+        var svc = NewService();
+        var t1 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        // Version a v2 of anthropic/claude-sonnet-4 effective at t1 ($6/1M in).
+        await using (var ctx = NewContext())
+        {
+            var prior = await ctx.ProviderModelPrices.SingleAsync(p =>
+                p.ProviderKey == "anthropic"
+                && p.Model == "claude-sonnet-4-20250514"
+                && p.Status == "active");
+            prior.Status = "superseded";
+            await ctx.SaveChangesAsync();
+            ctx.ProviderModelPrices.Add(new Tamma.Data.Entities.ProviderModelPrice
+            {
+                Id = Guid.NewGuid(),
+                ProviderKey = "anthropic",
+                Model = "claude-sonnet-4-20250514",
+                InputUsdPer1M = 6.00m,
+                OutputUsdPer1M = 15.00m,
+                EffectiveFrom = t1,
+                Status = "active",
+                Source = "admin",
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        // Before t1 → v1 rate ($3/1M in): 1_000_000 in = $3.00.
+        var before = await svc.ComputeAtAsync(
+            "anthropic", "claude-sonnet-4-20250514", 1_000_000, 0,
+            new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc));
+        before.Should().Be(3.00m, "an event before the re-price uses the v1 rate");
+
+        // At/after t1 → v2 rate ($6/1M in): 1_000_000 in = $6.00.
+        var after = await svc.ComputeAtAsync(
+            "anthropic", "claude-sonnet-4-20250514", 1_000_000, 0, t1);
+        after.Should().Be(6.00m, "an event at the re-price uses the v2 rate");
+    }
+
+    [Test]
+    public async Task ComputeAtAsync_BeforeAnyRow_Returns0()
+    {
+        var svc = NewService();
+        // Seed epoch is 2025-01-01; anything earlier has no effective row.
+        var cost = await svc.ComputeAtAsync(
+            "anthropic", "claude-sonnet-4-20250514", 1000, 500,
+            new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        cost.Should().Be(0m);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Providers/ProviderPricingParityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Providers/ProviderPricingParityTests.cs
@@ -1,0 +1,122 @@
+using System.Collections.Frozen;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Services.Providers;
+using Tamma.Data;
+using Tamma.Data.Seeders;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Providers;
+
+/// <summary>
+/// Story 34-11 (AC12 — THE load-bearing test) — for every seeded
+/// <c>(provider, model)</c> pair, the DB-backed <see cref="DbProviderPricingService"/>
+/// produces byte-identical <c>Compute</c> output to the frozen
+/// <see cref="ProviderPricingService"/>. Proves the promotion behind the
+/// <see cref="IProviderPricingService"/> seam is behaviour-preserving — incl.
+/// sub-cent rates and the integer-token math.
+/// </summary>
+[TestFixture]
+public class ProviderPricingParityTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+    private ServiceProvider _sp = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("parity_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        var services = new ServiceCollection();
+        services.AddDbContext<ControlPlaneDbContext>(o => o.UseNpgsql(_cs));
+        _sp = services.BuildServiceProvider();
+
+        await using var ctx = new ControlPlaneDbContext(
+            new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+        await ctx.Database.MigrateAsync();
+        await ProviderPricingSeeder.SeedAsync(ctx);
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_sp is not null) await _sp.DisposeAsync();
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    private DbProviderPricingService NewDbService()
+    {
+        var scopeFactory = _sp.GetRequiredService<IServiceScopeFactory>();
+        var resolver = new ProviderCostResolver(
+            scopeFactory, TimeProvider.System,
+            NullLogger<ProviderCostResolver>.Instance, TimeSpan.Zero);
+        return new DbProviderPricingService(
+            scopeFactory, resolver, TimeProvider.System,
+            NullLogger<DbProviderPricingService>.Instance,
+            new ProviderPricingService(), TimeSpan.Zero);
+    }
+
+    /// <summary>
+    /// Every (provider, model) in the frozen table — with a few token tuples
+    /// covering small, large, and asymmetric usage so rounding diverges if the
+    /// per-1M ↔ per-token round-trip is lossy.
+    /// </summary>
+    private static IEnumerable<TestCaseData> SeededPairs()
+    {
+        var frozen = ProviderPricingService.Pricing;
+        var tuples = new (int In, int Out)[] { (1000, 500), (1_000_000, 1_000_000), (12345, 0), (0, 9999) };
+
+        foreach (var (provider, models) in frozen)
+        {
+            foreach (var (model, _) in models)
+            {
+                foreach (var (inTok, outTok) in tuples)
+                {
+                    yield return new TestCaseData(provider, model, inTok, outTok)
+                        .SetName($"Parity_{provider}_{model.Replace('/', '_').Replace('.', '_')}_{inTok}_{outTok}");
+                }
+            }
+        }
+    }
+
+    [TestCaseSource(nameof(SeededPairs))]
+    public void DbCompute_Matches_FrozenCompute_ByteForByte(
+        string provider, string model, int inTok, int outTok)
+    {
+        var frozen = new ProviderPricingService();
+        var db = NewDbService();
+
+        var frozenCost = frozen.Compute(provider, model, inTok, outTok);
+        var dbCost = db.Compute(provider, model, inTok, outTok);
+
+        dbCost.Should().Be(frozenCost,
+            $"DB and frozen Compute must agree for {provider}/{model} ({inTok} in, {outTok} out)");
+    }
+
+    [Test]
+    public void IsKnown_Matches_Frozen_ForEverySeededPair()
+    {
+        var frozen = new ProviderPricingService();
+        var db = NewDbService();
+
+        foreach (var (provider, models) in ProviderPricingService.Pricing)
+        {
+            foreach (var (model, _) in models)
+            {
+                db.IsKnown(provider, model).Should().Be(frozen.IsKnown(provider, model),
+                    $"IsKnown must agree for {provider}/{model}");
+            }
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Providers/ProviderPricingSeederTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Providers/ProviderPricingSeederTests.cs
@@ -1,0 +1,145 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using Tamma.Data;
+using Tamma.Data.Seeders;
+
+namespace Tamma.Api.Tests.Providers;
+
+/// <summary>
+/// Story 34-11 (AC8, AC12) — <see cref="ProviderPricingSeeder"/> ports the
+/// frozen rate sheet into providers + provider_model_prices as v1 seed rows,
+/// insert-missing-only, with deterministic UUIDv7-shaped ids. Uses the EF
+/// in-memory provider (the seed is per-row existence checks — the cheap provider
+/// catches idempotency + no-revert; the DB-level CHECK / partial-unique
+/// invariants + the parity/window behaviours are covered by the Postgres suite).
+/// </summary>
+[TestFixture]
+public class ProviderPricingSeederTests
+{
+    private static ControlPlaneDbContext CreateContext(string dbName) =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseInMemoryDatabase(dbName)
+            .Options);
+
+    [Test]
+    public async Task SeedAsync_Inserts_All_Frozen_Providers_With_Correct_AuthModel()
+    {
+        var ctx = CreateContext(nameof(SeedAsync_Inserts_All_Frozen_Providers_With_Correct_AuthModel));
+
+        var inserted = await ProviderPricingSeeder.SeedAsync(ctx);
+        inserted.Should().BeGreaterThan(0);
+
+        var providers = await ctx.Providers.AsNoTracking().ToListAsync();
+        providers.Select(p => p.Key).Should().BeEquivalentTo(
+            new[] { "anthropic", "openai", "google", "openrouter", "claude-code", "local" });
+
+        // AuthModel mapping: claude-code → cli-token; everything else → api-key.
+        providers.Single(p => p.Key == "claude-code").AuthModel.Should().Be("cli-token");
+        providers.Where(p => p.Key != "claude-code")
+            .Should().OnlyContain(p => p.AuthModel == "api-key");
+
+        // Every seeded price is a v1 active seed row anchored at (or a few ticks
+        // past) the seed epoch — a deterministic per-model micro-offset keeps the
+        // frozen declaration order so null/"default"→first-model is reproducible.
+        var prices = await ctx.ProviderModelPrices.AsNoTracking().ToListAsync();
+        prices.Should().OnlyContain(p =>
+            p.Status == "active" && p.Source == "seed"
+            && p.EffectiveFrom >= ProviderPricingSeeder.SeedEpoch
+            && p.EffectiveFrom < ProviderPricingSeeder.SeedEpoch.AddSeconds(1));
+    }
+
+    [Test]
+    public async Task SeedAsync_StoresUsdPer1M_NotPerToken()
+    {
+        var ctx = CreateContext(nameof(SeedAsync_StoresUsdPer1M_NotPerToken));
+        await ProviderPricingSeeder.SeedAsync(ctx);
+
+        // claude-sonnet-4 is $3/1M input, $15/1M output.
+        var sonnet = await ctx.ProviderModelPrices.AsNoTracking()
+            .SingleAsync(p => p.ProviderKey == "anthropic" && p.Model == "claude-sonnet-4-20250514");
+        sonnet.InputUsdPer1M.Should().Be(3.00m);
+        sonnet.OutputUsdPer1M.Should().Be(15.00m);
+
+        // Sub-cent rate survives the per-1M storage (gemini-1.5-flash @ $0.075/1M).
+        var flash = await ctx.ProviderModelPrices.AsNoTracking()
+            .SingleAsync(p => p.ProviderKey == "google" && p.Model == "gemini-1.5-flash");
+        flash.InputUsdPer1M.Should().Be(0.075m);
+    }
+
+    [Test]
+    public async Task SeedAsync_Is_Idempotent_SecondRun_Is_NoOp()
+    {
+        var ctx = CreateContext(nameof(SeedAsync_Is_Idempotent_SecondRun_Is_NoOp));
+
+        var first = await ProviderPricingSeeder.SeedAsync(ctx);
+        var providerCount = await ctx.Providers.CountAsync();
+        var priceCount = await ctx.ProviderModelPrices.CountAsync();
+
+        var second = await ProviderPricingSeeder.SeedAsync(ctx);
+
+        second.Should().Be(0, "a re-run inserts nothing");
+        (await ctx.Providers.CountAsync()).Should().Be(providerCount);
+        (await ctx.ProviderModelPrices.CountAsync()).Should().Be(priceCount);
+        first.Should().BeGreaterThan(0);
+    }
+
+    [Test]
+    public async Task SeedAsync_DeterministicIds_AreStable_AcrossRuns()
+    {
+        var a = CreateContext(nameof(SeedAsync_DeterministicIds_AreStable_AcrossRuns) + "_a");
+        var b = CreateContext(nameof(SeedAsync_DeterministicIds_AreStable_AcrossRuns) + "_b");
+        await ProviderPricingSeeder.SeedAsync(a);
+        await ProviderPricingSeeder.SeedAsync(b);
+
+        var idsA = (await a.ProviderModelPrices.AsNoTracking().ToListAsync())
+            .ToDictionary(p => (p.ProviderKey, p.Model), p => p.Id);
+        var idsB = (await b.ProviderModelPrices.AsNoTracking().ToListAsync())
+            .ToDictionary(p => (p.ProviderKey, p.Model), p => p.Id);
+
+        idsA.Should().BeEquivalentTo(idsB, "deterministic ids are stable across environments");
+
+        // The version nibble is 7 (UUIDv7-shaped).
+        foreach (var id in idsA.Values)
+        {
+            id.ToString("N")[12].Should().Be('7');
+        }
+    }
+
+    [Test]
+    public async Task SeedAsync_DoesNotRevert_AdminEditedRow()
+    {
+        var ctx = CreateContext(nameof(SeedAsync_DoesNotRevert_AdminEditedRow));
+        await ProviderPricingSeeder.SeedAsync(ctx);
+
+        // Simulate an admin re-price: supersede the seed row and add a new
+        // active admin row with a different rate, exactly like the PUT path.
+        var seedRow = await ctx.ProviderModelPrices
+            .SingleAsync(p => p.ProviderKey == "anthropic" && p.Model == "claude-sonnet-4-20250514");
+        seedRow.Status = "superseded";
+        ctx.ProviderModelPrices.Add(new Tamma.Data.Entities.ProviderModelPrice
+        {
+            Id = Guid.NewGuid(),
+            ProviderKey = "anthropic",
+            Model = "claude-sonnet-4-20250514",
+            InputUsdPer1M = 99m,
+            OutputUsdPer1M = 199m,
+            EffectiveFrom = DateTime.UtcNow,
+            Status = "active",
+            Source = "admin",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        await ctx.SaveChangesAsync();
+
+        // Re-seed must NOT re-insert the seed row (its deterministic id already
+        // exists, now superseded) and must NOT touch the admin row.
+        var reInserted = await ProviderPricingSeeder.SeedAsync(ctx);
+        reInserted.Should().Be(0);
+
+        var admin = await ctx.ProviderModelPrices.AsNoTracking()
+            .SingleAsync(p => p.Source == "admin" && p.Model == "claude-sonnet-4-20250514");
+        admin.InputUsdPer1M.Should().Be(99m, "the admin re-price survives a re-seed");
+        admin.Status.Should().Be("active");
+    }
+}


### PR DESCRIPTION
## What

Sequence step **A** of the Epic-32/34 architecture pivot. Promotes the hard-coded `FrozenDictionary` cost rate-sheet to a DB-backed, immutable-versioned **control-plane** entity model (`Provider` + `ProviderModelPrice`) **behind the unchanged `IProviderPricingService` seam** — so cost basis is a single auditable, time-windowed source of truth that 34-5 (markup), 32-9 (metering), 32-5 (managed run), and 36-x (analytics) read without re-deriving rates.

- Two CP entities (platform-global, **no tenant scope**); immutable-versioning (partial-unique one-active-per-model + `EffectiveFrom` window → reproducible historical cost); the verbatim alias/loose-prefix/default/unknown-no-throw behaviour preserved via a **shared lookup** consumed by both the frozen and DB impls (parity-tested byte-for-byte).
- `DbProviderPricingService` swapped in for the frozen impl (one-line DI; interface unchanged; frozen retained as seed/fallback). Insert-missing-only seeder. Admin CRUD `/api/admin/providers*` under **`PlatformOwnerAccess`** with `PROVIDER.*` events. EF migration `20260621180309_ProviderCostPriceBook` (+ DROP-list + strict CP-model-test wiring).

## Process / quality

Implemented TDD → **spec-review (spec-compliant, all 12 ACs)** → **code-quality review** which caught 3 real issues, all fixed in commit `953ac270`:
- **Cache staleness (critical):** the live `Compute` snapshot wasn't invalidated on an admin price change (stale rate up to the TTL). Added an `IProviderCostCacheInvalidator` seam invalidated on every pricing mutation, with a non-zero-TTL test that catches it.
- **Immutability:** enforced superseded-row immutability in the `ControlPlaneDbContext.SaveChanges` interceptor (mirrors the Plan sibling), not just a pre-flight — raw EF mutation of a superseded cost row now throws `PROVIDER.PRICE.IMMUTABLE`.
- **Write validation:** 400 on negative rates, 409 on versioning a retired provider.

## Verification (run independently by me, not the implementer's word)
- `dotnet build Tamma.sln` → **0 errors**.
- `dotnet ef migrations has-pending-model-changes` (ControlPlane) → **none**.
- `Tamma.Api.Tests` → **3406 passed, 0 failed, 6 skipped** (incl. the parity test, the supersede/immutability/window tests, the new fix tests, and the Plan immutability tests — no regression from the shared interceptor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)