### PR TITLE
feat(epic-32): 32-15 Persona Reframe + Seeding (role-nullable cross-role personas)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/AgentDtos.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/AgentDtos.cs
@@ -63,7 +63,7 @@ public sealed record PublishVersionRequest(
 public sealed record AgentSummary(
     Guid Id,
     string Name,
-    string Role,
+    string? Role,
     string Visibility,
     string Status,
     Guid? OwnerTenantId,
@@ -74,7 +74,7 @@ public sealed record AgentSummary(
 public sealed record AgentDetail(
     Guid Id,
     string Name,
-    string Role,
+    string? Role,
     string Visibility,
     string Status,
     Guid? OwnerTenantId,
@@ -104,7 +104,7 @@ public sealed record AgentVersionDetail(
 public sealed record CreateAgentResponse(
     Guid Id,
     string Name,
-    string Role,
+    string? Role,
     string Visibility,
     string Status,
     int CurrentVersion);

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/AgentResolverServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/AgentResolverServiceCollectionExtensions.cs
@@ -26,11 +26,21 @@ public static class AgentResolverServiceCollectionExtensions
     /// </summary>
     public static IServiceCollection AddAgentResolverServices(this IServiceCollection services)
     {
+        // Story 32-15 — bind Tamma:Agents:DefaultPersonaName (default "claude")
+        // for the configured-default-persona resolution.
+        services.AddOptions<DefaultPersonaOptions>()
+            .Configure<IConfiguration>((opts, cfg) =>
+                cfg.GetSection(DefaultPersonaOptions.SectionPath).Bind(opts));
+
         services.AddScoped<IAgentRegistryService, AgentRegistryService>();
+
+        // Story 32-15 — the persona/public prompt seam over the Epic 27 store.
+        services.AddScoped<IPersonaPromptResolver, PersonaPromptResolver>();
 
         // Use the Story 32-2 full constructor so the entity-aware resolve
         // methods have their collaborators. The missing-config recorder is
         // optional (the epic may not be merged) — resolved as null if unregistered.
+        // Story 32-15 wires the persona prompt seam for the public branch.
         services.AddScoped<IAgentResolverService>(sp => new AgentResolverService(
             sp.GetRequiredService<IAgentConfigRepository>(),
             sp.GetService<IConfiguration>(),
@@ -38,7 +48,8 @@ public static class AgentResolverServiceCollectionExtensions
             sp.GetRequiredService<IAgentRegistryService>(),
             sp.GetRequiredService<IAgentRepository>(),
             sp.GetRequiredService<IEventRepository>(),
-            sp.GetService<IMissingConfigRecorder>()));
+            sp.GetService<IMissingConfigRecorder>(),
+            sp.GetRequiredService<IPersonaPromptResolver>()));
         return services;
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -2182,16 +2182,27 @@ using (var scope = app.Services.CreateScope())
         // apply" — this is that call site.
         await Tamma.Data.Seeders.PlansSeeder.SeedAsync(dbContext);
 
-        // Story 32-1 — public/system agent definitions (one per role with the
-        // tamma-<role> handle + Version=1). Insert-missing-only; no-op on
-        // re-run. CP-resident; coexists with the Elsa-store AgentSeeder.
-        await Tamma.Data.Seeders.AgentEntitySeeder.SeedAsync(dbContext);
-
         // Story 34-11 — provider COST price-book. Ports the frozen
         // ProviderPricingService rate sheet into providers + provider_model_prices
         // as v1 seed rows (Source='seed', Status='active'). Insert-missing-only;
         // no-op on re-run and never reverts a Source='admin' (re-priced) row.
+        //
+        // MUST run before the persona seeder below: Story 32-15's persona
+        // seeder validates each persona's (provider, model) against the active
+        // price rows this seeder writes (the in-data IsKnown guard).
         await Tamma.Data.Seeders.ProviderPricingSeeder.SeedAsync(dbContext);
+
+        // Story 32-15 — public/system PERSONAS (named cross-role agents:
+        // claude/gemini/codegpt, Role=NULL, explicit provider+model, no prompts).
+        // Insert-missing-only (keyed by Name); no-op on re-run and never reverts
+        // an admin edit. Archives any legacy tamma-<role> public rows (AC11).
+        // Emits AGENT.CREATED.SUCCESS / AGENT.ARCHIVED.SUCCESS on real writes.
+        await Tamma.Data.Seeders.AgentEntitySeeder.SeedAsync(
+            dbContext,
+            scope.ServiceProvider.GetRequiredService<Tamma.Data.Repositories.IPlatformEventRepository>(),
+            scope.ServiceProvider.GetRequiredService<
+                Microsoft.Extensions.Logging.ILoggerFactory>()
+                .CreateLogger("Tamma.Data.Seeders.AgentEntitySeeder"));
 
         // tenant_databases: register the central DB as pool member #1
         // (unified-tenancy Phase 2) so single-user/dev and SaaS share one

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRegistryService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRegistryService.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Tamma.Api.Auth;
 using Tamma.Api.Services.PromptStore;
 using Tamma.Core;
@@ -28,6 +29,7 @@ public sealed class AgentRegistryService : IAgentRegistryService
     private readonly ITammaModeProvider _mode;
     private readonly ITenantContext _tenantContext;
     private readonly IHttpContextAccessor _httpContext;
+    private readonly DefaultPersonaOptions _defaultPersona;
     private readonly ILogger<AgentRegistryService>? _logger;
 
     public AgentRegistryService(
@@ -37,6 +39,7 @@ public sealed class AgentRegistryService : IAgentRegistryService
         ITammaModeProvider mode,
         ITenantContext tenantContext,
         IHttpContextAccessor httpContext,
+        IOptions<DefaultPersonaOptions>? defaultPersona = null,
         ILogger<AgentRegistryService>? logger = null)
     {
         _agents = agents;
@@ -45,6 +48,7 @@ public sealed class AgentRegistryService : IAgentRegistryService
         _mode = mode;
         _tenantContext = tenantContext;
         _httpContext = httpContext;
+        _defaultPersona = defaultPersona?.Value ?? new DefaultPersonaOptions();
         _logger = logger;
     }
 
@@ -68,38 +72,34 @@ public sealed class AgentRegistryService : IAgentRegistryService
     /// <inheritdoc />
     public async Task<Agent?> GetSystemDefaultPublicAsync(string role, CancellationToken ct = default)
     {
-        // The system default for a role is the shipped public agent whose Role
-        // matches (one per role from AgentEntitySeeder, handle "tamma-<role>").
-        // Public agents are visible to every principal; pass null scope.
-        var visible = await _agents.ListVisibleAsync(tenantId: null, userId: null, ct);
-        var candidates = visible
-            .Where(a =>
-                a.Visibility == AgentVisibility.Public &&
-                a.Status == AgentStatus.Active &&
-                string.Equals(a.Role, role, StringComparison.Ordinal))
-            .OrderBy(a => a.Name, StringComparer.Ordinal)
-            .ToList();
+        // Story 32-15 — public agents are named cross-role PERSONAS, so the
+        // system default is the platform-configured DEFAULT PERSONA, resolved by
+        // handle among public agents REGARDLESS of role (the old "public agent
+        // whose Role==role" lookup + the >1-per-role ambiguity warning are gone).
+        var name = _defaultPersona.DefaultPersonaName;
+        var persona = await _agents.GetPublicByNameAsync(name, ct);
 
-        var chosen = candidates.FirstOrDefault();
-        if (candidates.Count > 1)
+        if (persona is null || persona.Status != AgentStatus.Active)
         {
-            // The seeder ships exactly one tamma-<role> public agent, so this is
-            // unambiguous today. A platform owner adding a second public agent
-            // for the same role would silently shift the default — make the
-            // ambiguity observable rather than picking blind.
+            // FAIL LOUD — no empty/plain fallback (feedback_resolution_no_empty_fallback).
             _logger?.LogWarning(
-                "agent.system_default.ambiguous role={Role} count={Count} chosenAgentId={ChosenAgentId} — "
-                + "more than one active public agent matches this role; picked the first by name (ordinal)",
-                role, candidates.Count, chosen?.Id);
-        }
-        else if (chosen is not null)
-        {
-            _logger?.LogDebug(
-                "agent.system_default.chosen role={Role} chosenAgentId={ChosenAgentId}",
-                role, chosen.Id);
+                "agent.default_persona.missing personaName={PersonaName} role={Role} — "
+                + "configured default persona is not seeded/active; failing loud",
+                name, role);
+            throw new TammaError(
+                "AGENT_DEFAULT_PERSONA_MISSING",
+                $"Configured default persona '{name}' is not seeded (or not active); "
+                + $"cannot resolve a default for role '{role}'. There is no empty/plain fallback.",
+                new Dictionary<string, object?> { ["personaName"] = name, ["role"] = role },
+                retryable: false,
+                severity: TammaErrorSeverity.High);
         }
 
-        return chosen;
+        _logger?.LogInformation(
+            "agent.default_persona.resolved personaName={PersonaName} agentId={AgentId} role={Role}",
+            persona.Name, persona.Id, role);
+
+        return persona;
     }
 
     /// <inheritdoc />

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentResolverService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentResolverService.cs
@@ -36,6 +36,12 @@ public sealed class AgentResolverService : IAgentResolverService
     private readonly IEventRepository? _events;
     private readonly IMissingConfigRecorder? _missingConfig;
 
+    // Story 32-15 — the persona/public prompt seam (reads Epic 27, fail-loud).
+    // The PUBLIC branch of MaterialiseAsync calls this (not an inline prompt
+    // store resolve). Null only on the legacy constructors that never reach the
+    // public branch.
+    private readonly IPersonaPromptResolver? _personaPrompts;
+
     public AgentResolverService(
         IAgentConfigRepository repo,
         ILogger<AgentResolverService> logger)
@@ -54,6 +60,9 @@ public sealed class AgentResolverService : IAgentResolverService
     /// <summary>
     /// Story 32-2 — full constructor wiring the entity-aware resolution chain.
     /// The missing-config recorder is optional (the epic may not be merged).
+    /// Story 32-15 adds the <see cref="IPersonaPromptResolver"/> persona/public
+    /// prompt seam (optional so the 32-2 chain tests can omit it; the public
+    /// branch fails loud if it is reached without the seam wired).
     /// </summary>
     public AgentResolverService(
         IAgentConfigRepository repo,
@@ -62,13 +71,15 @@ public sealed class AgentResolverService : IAgentResolverService
         IAgentRegistryService registry,
         IAgentRepository agents,
         IEventRepository events,
-        IMissingConfigRecorder? missingConfig = null)
+        IMissingConfigRecorder? missingConfig = null,
+        IPersonaPromptResolver? personaPrompts = null)
         : this(repo, configuration, logger)
     {
         _registry = registry;
         _agents = agents;
         _events = events;
         _missingConfig = missingConfig;
+        _personaPrompts = personaPrompts;
     }
 
     // -----------------------------------------------------------------------
@@ -300,8 +311,24 @@ public sealed class AgentResolverService : IAgentResolverService
             }
         }
 
-        // Branch 3: system-default public agent for the role.
-        var systemDefault = await _registry.GetSystemDefaultPublicAsync(role, ct);
+        // Branch 3: system-default public PERSONA (Story 32-15 — the configured
+        // default persona, role-independent). GetSystemDefaultPublicAsync itself
+        // fails loud (AGENT_DEFAULT_PERSONA_MISSING) when the configured persona
+        // is not seeded; we treat that as "no system default" so the resolver
+        // still emits the mandatory AGENT.RESOLVE.FAILED audit event and throws
+        // its canonical no-default error (32-2 AC9 contract preserved).
+        Agent? systemDefault = null;
+        try
+        {
+            systemDefault = await _registry.GetSystemDefaultPublicAsync(role, ct);
+        }
+        catch (TammaError ex) when (ex.Code == "AGENT_DEFAULT_PERSONA_MISSING")
+        {
+            _logger.LogWarning(
+                "agent.resolve.default_persona_missing role={Role} — no configured default persona seeded",
+                role);
+        }
+
         if (systemDefault is not null)
         {
             var materialised = await MaterialiseAsync(systemDefault, role, phase, "system-public", ct);
@@ -354,6 +381,14 @@ public sealed class AgentResolverService : IAgentResolverService
             // which fails loud on the (now-default) required fields if needed.
         }
 
+        // Story 32-15 — the system/role prompt source depends on visibility.
+        // PUBLIC (persona): the persona is prompt-free; its prompt comes from the
+        // Epic 27 store via the IPersonaPromptResolver seam, keyed
+        // (principal, role, action). PRIVATE (custom agent): its own embedded
+        // prompts — the parallel ICustomAgentPromptResolver seam owned by 32-17.
+        // Both fail loud (no empty/plain fallback).
+        var systemPrompt = await ResolvePromptSourceAsync(agent, role, phase, resolved, ct);
+
         // The agent's stable handle wins over the merged handle (identity).
         var enriched = new ResolvedAgentConfig
         {
@@ -365,7 +400,7 @@ public sealed class AgentResolverService : IAgentResolverService
             MaxTokens = resolved.MaxTokens,
             TokenBudget = resolved.TokenBudget,
             Tools = resolved.Tools,
-            SystemPrompt = resolved.SystemPrompt,
+            SystemPrompt = systemPrompt,
             Source = source,
             Phase = phase,
             MaxBudgetUsd = resolved.MaxBudgetUsd,
@@ -377,6 +412,48 @@ public sealed class AgentResolverService : IAgentResolverService
 
         ValidateResolved(enriched);
         return enriched;
+    }
+
+    /// <summary>
+    /// Story 32-15 — resolve the system/role prompt for the materialised config
+    /// by VISIBILITY. PUBLIC personas → the <see cref="IPersonaPromptResolver"/>
+    /// seam (Epic 27, fail-loud); PRIVATE/custom agents → their own embedded
+    /// prompts (the <c>ICustomAgentPromptResolver</c> seam owned by Story 32-17,
+    /// not implemented here). The merged config's prompt is NOT used for a
+    /// persona — personas are prompt-free.
+    /// </summary>
+    private async Task<string> ResolvePromptSourceAsync(
+        Agent agent, string role, string? action, ResolvedAgentConfig merged, CancellationToken ct)
+    {
+        _logger.LogDebug(
+            "agent.materialise.prompt_source visibility={Visibility} role={Role} action={Action}",
+            agent.Visibility, role, action ?? "(role-system)");
+
+        if (agent.Visibility == AgentVisibility.Public)
+        {
+            // PERSONA → IPersonaPromptResolver → Epic 27 store. Fail loud if the
+            // seam is not wired (a persona MUST source its prompt from Epic 27,
+            // never from its prompt-free config).
+            if (_personaPrompts is null)
+            {
+                throw new InvalidOperationException(
+                    "A public persona's prompt must be resolved via IPersonaPromptResolver "
+                    + "(Story 32-15), but no resolver is wired. Use the full "
+                    + "AgentResolverService constructor with the persona prompt seam.");
+            }
+            var (tenantId, userId) = _registry!.ResolvePrincipal();
+            var principal = new Principal(tenantId, userId);
+            // The entity-aware resolve path is role-based (no Epic 27 action), so
+            // we resolve the role-system (identity preamble) prompt; the seam is
+            // fail-loud internally (PROMPT_UNRESOLVED) — no empty/plain fallback.
+            return await _personaPrompts.ResolveAsync(principal, role, action: null, ct);
+        }
+
+        // PRIVATE/custom agent → SEAM for Story 32-17 (ICustomAgentPromptResolver).
+        // 32-17 wires merged.SystemPrompt from the custom agent's ConfigJson.prompts
+        // here. Until then the merged config's prompt is used (unchanged behaviour
+        // for the 32-2 private path); 32-17 replaces this branch with its seam.
+        return merged.SystemPrompt;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/DefaultPersonaOptions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/DefaultPersonaOptions.cs
@@ -1,0 +1,20 @@
+namespace Tamma.Api.Services.Agents;
+
+/// <summary>
+/// Story 32-15 — bound from <c>Tamma:Agents:DefaultPersonaName</c>. Names the
+/// public persona <see cref="AgentRegistryService.GetSystemDefaultPublicAsync"/>
+/// returns as the platform default for ANY role (personas are cross-role, so the
+/// default is role-INDEPENDENT). Defaults to <c>"claude"</c> — the persona the
+/// seeder ships first. A configured persona that is not seeded is a fail-loud
+/// error (<c>AGENT_DEFAULT_PERSONA_MISSING</c>), never an empty fallback.
+/// </summary>
+public sealed class DefaultPersonaOptions
+{
+    /// <summary>Configuration section path.</summary>
+    public const string SectionPath = "Tamma:Agents";
+
+    /// <summary>
+    /// The handle of the platform-default public persona. Default <c>"claude"</c>.
+    /// </summary>
+    public string DefaultPersonaName { get; set; } = "claude";
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/IPersonaPromptResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/IPersonaPromptResolver.cs
@@ -1,0 +1,48 @@
+namespace Tamma.Api.Services.Agents;
+
+/// <summary>
+/// Story 32-15 — the calling principal the persona prompt resolves against:
+/// exactly one of <see cref="TenantId"/> (SaaS) XOR <see cref="UserId"/>
+/// (single-user) is set, mirroring the <c>prompt_overrides</c> /
+/// <c>AgentRoleSelection</c> principal model. Derived from
+/// <c>ITammaModeProvider</c> + <c>ITenantContext</c> /
+/// <see cref="IAgentRegistryService.ResolvePrincipal"/>.
+/// </summary>
+public readonly record struct Principal(Guid? TenantId, Guid? UserId)
+{
+    /// <summary>Build a single-user principal (user-keyed Epic 27 lookup).</summary>
+    public static Principal ForUser(Guid? userId) => new(null, userId);
+
+    /// <summary>Build a SaaS principal (tenant-keyed Epic 27 lookup).</summary>
+    public static Principal ForTenant(Guid? tenantId) => new(tenantId, null);
+}
+
+/// <summary>
+/// Story 32-15 — the PUBLIC/persona prompt leg. Personas are prompt-free by
+/// contract, so a persona's system/role prompt comes from the Epic 27 prompt
+/// store keyed <c>(principal, role, action)</c> — NOT from the persona config.
+///
+/// <para>This is an explicit injectable SEAM (rather than an inline
+/// <c>PromptStoreService.Resolve…</c> call inside
+/// <c>AgentResolverService.MaterialiseAsync</c>): the public branch of
+/// <c>MaterialiseAsync</c> calls this. The parallel private/custom-agent leg is
+/// <c>ICustomAgentPromptResolver</c>, owned by Story 32-17.</para>
+///
+/// <para><b>Fail-loud, never empty/plain.</b> Resolution is tenant → system →
+/// ERROR (single-user: user → system → ERROR). A persona run whose
+/// <c>(role, action)</c> has no Epic 27 prompt is a hard error
+/// (<c>PROMPT_UNRESOLVED</c>), never a silent empty/plain prompt
+/// (<c>feedback_resolution_no_empty_fallback</c>).</para>
+/// </summary>
+public interface IPersonaPromptResolver
+{
+    /// <summary>
+    /// Resolve a persona's system/role prompt from the Epic 27 store keyed
+    /// <c>(principal, role, action)</c>. When <paramref name="action"/> is null,
+    /// the role-system (identity preamble) prompt is resolved; otherwise the
+    /// role+action prompt. Tenant → system → ERROR; fail-loud, NEVER empty/plain.
+    /// </summary>
+    /// <returns>The resolved prompt text (non-empty).</returns>
+    Task<string> ResolveAsync(
+        Principal principal, string role, string? action, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/PersonaPromptResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/PersonaPromptResolver.cs
@@ -1,0 +1,93 @@
+using Microsoft.Extensions.Logging;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Core;
+
+namespace Tamma.Api.Services.Agents;
+
+/// <summary>
+/// Story 32-15 — default <see cref="IPersonaPromptResolver"/> over the Epic 27
+/// <see cref="PromptStoreService"/>. Reads the persona's system/role prompt from
+/// the prompt store keyed <c>(principal, role, action)</c> and fails loud on a
+/// miss (<c>PROMPT_UNRESOLVED</c>) — personas carry no prompts, so a missing
+/// Epic 27 prompt is a hard error, never an empty/plain fallback
+/// (<c>feedback_resolution_no_empty_fallback</c>).
+///
+/// <para>Principal routing mirrors the prompt store's two-surface model: a
+/// non-null <see cref="Principal.TenantId"/> takes the SaaS (tenant-keyed) path;
+/// otherwise the single-user (user-keyed) path. The prompt store's own
+/// resolution is already tenant/user → system → <see cref="TammaError"/>; this
+/// resolver maps the role-system <c>null</c> (no override AND no shipped system
+/// default) to the same fail-loud contract.</para>
+/// </summary>
+public sealed class PersonaPromptResolver : IPersonaPromptResolver
+{
+    private readonly PromptStoreService _promptStore;
+    private readonly ILogger<PersonaPromptResolver>? _logger;
+
+    public PersonaPromptResolver(
+        PromptStoreService promptStore,
+        ILogger<PersonaPromptResolver>? logger = null)
+    {
+        _promptStore = promptStore;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<string> ResolveAsync(
+        Principal principal, string role, string? action, CancellationToken ct = default)
+    {
+        _ = ct;
+        var isSaaS = principal.TenantId is not null;
+
+        _logger?.LogDebug(
+            "agent.persona_prompt.resolve role={Role} action={Action} mode={Mode}",
+            role, action ?? "(role-system)", isSaaS ? "saas" : "single-user");
+
+        // action present → role+action prompt (the store is already fail-loud).
+        // We take its SystemPrompt half (the persona's system/role identity).
+        if (!string.IsNullOrEmpty(action))
+        {
+            ResolvedPrompt resolved = isSaaS
+                ? await _promptStore.ResolveRoleActionForTenantAsync(
+                    principal.TenantId!.Value, role, action)
+                : await _promptStore.ResolveRoleActionAsync(principal.UserId, role, action);
+
+            var text = resolved.SystemPrompt;
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                // A role+action resolved but its system half is empty — still a
+                // miss for a PERSONA (which needs a system/role prompt). Fail loud.
+                throw NotResolved(role, action, principal);
+            }
+            return text;
+        }
+
+        // action null → role-system (identity preamble) prompt. The store
+        // returns null when there is neither an override NOR a shipped default.
+        var roleSystem = isSaaS
+            ? await _promptStore.ResolveRoleSystemForTenantAsync(principal.TenantId!.Value, role)
+            : await _promptStore.ResolveRoleSystemAsync(principal.UserId, role);
+
+        if (string.IsNullOrWhiteSpace(roleSystem))
+        {
+            throw NotResolved(role, action, principal);
+        }
+        return roleSystem;
+    }
+
+    private static TammaError NotResolved(string role, string? action, Principal principal)
+        => new(
+            "PROMPT_UNRESOLVED",
+            $"No Epic 27 prompt for (role='{role}', action='{action ?? "(role-system)"}'); "
+            + "personas carry no prompts and there is no empty/plain fallback "
+            + "(tenant/user → system → error).",
+            new Dictionary<string, object?>
+            {
+                ["role"] = role,
+                ["action"] = action,
+                ["tenantId"] = principal.TenantId,
+                ["userId"] = principal.UserId,
+            },
+            retryable: false,
+            severity: TammaErrorSeverity.High);
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/Agent.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/Agent.cs
@@ -39,8 +39,14 @@ public class Agent
     /// <c>RolePhaseMap.NormalizeRole</c> / <c>AgentRoleExtensions.Parse</c> on
     /// create). A benchmarking attribute, NOT a primary key — the Agent, not
     /// the role, is the tracked entity.
+    ///
+    /// <para>Story 32-15 — NULLABLE. Public agents are now named cross-role
+    /// PERSONAS (<c>claude</c>/<c>gemini</c>/<c>codegpt</c>) usable for ANY role,
+    /// so a public persona carries <c>Role = NULL</c> (role is a selection-time
+    /// concern, not a baked-in identity column). Private/custom agents MAY still
+    /// carry a non-null role-binding (their behaviour is unchanged).</para>
     /// </summary>
-    public string Role { get; set; } = null!;
+    public string? Role { get; set; }
 
     /// <summary>Public (system) vs private (tenant/user-owned). See <see cref="AgentVisibility"/>.</summary>
     public AgentVisibility Visibility { get; set; }

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260621205119_PersonaReframeRoleNullable.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260621205119_PersonaReframeRoleNullable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.ControlPlane
 {
     [DbContext(typeof(ControlPlaneDbContext))]
-    partial class ControlPlaneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260621205119_PersonaReframeRoleNullable")]
+    partial class PersonaReframeRoleNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260621205119_PersonaReframeRoleNullable.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260621205119_PersonaReframeRoleNullable.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.ControlPlane
+{
+    /// <inheritdoc />
+    public partial class PersonaReframeRoleNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_agents_public_name_role",
+                table: "agents");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Role",
+                table: "agents",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_agents_public_name",
+                table: "agents",
+                column: "Name",
+                unique: true,
+                filter: "\"Visibility\" = 0");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_agents_public_name",
+                table: "agents");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Role",
+                table: "agents",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_agents_public_name_role",
+                table: "agents",
+                columns: new[] { "Name", "Role" },
+                unique: true,
+                filter: "\"Visibility\" = 0");
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/AgentRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/AgentRepository.cs
@@ -282,6 +282,10 @@ public sealed class AgentRepository : IAgentRepository
         return result;
     }
 
+    public Task<Agent?> GetPublicByNameAsync(string name, CancellationToken ct = default)
+        => _db.Agents.FirstOrDefaultAsync(
+            a => a.Visibility == AgentVisibility.Public && a.Name == name, ct);
+
     // ── helpers ──
 
     private async Task<int> NextVersionAsync(Guid agentId, CancellationToken ct)

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/IAgentRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/IAgentRepository.cs
@@ -84,4 +84,14 @@ public interface IAgentRepository
     /// </summary>
     Task<IReadOnlyList<Agent>> ListVisibleAsync(
         Guid? tenantId, Guid? userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Story 32-15 — fetch the single PUBLIC agent (persona) with the given
+    /// <paramref name="name"/> (case-sensitive handle match), regardless of
+    /// role. Public persona handles are globally unique (IX_agents_public_name),
+    /// so this returns at most one row. Returns <c>null</c> when no public
+    /// persona by that name exists. Backs the configured-default-persona lookup
+    /// (<c>GetSystemDefaultPublicAsync</c>).
+    /// </summary>
+    Task<Agent?> GetPublicByNameAsync(string name, CancellationToken ct = default);
 }

--- a/apps/tamma-elsa/src/Tamma.Data/Seeders/AgentEntitySeeder.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Seeders/AgentEntitySeeder.cs
@@ -1,99 +1,164 @@
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
 
 namespace Tamma.Data.Seeders;
 
 /// <summary>
-/// Story 32-1 — idempotently seeds the CP-resident <c>agents</c> /
-/// <c>agent_versions</c> tables with one <b>public</b> agent per canonical
-/// <c>AgentRole</c>, using the <c>tamma-&lt;role&gt;</c> handle and the shipped
-/// config values (provider chain / temperature / maxTokens / maxBudgetUsd)
-/// currently produced by <c>Tamma.ElsaServer/AgentSeeder.cs</c>. This is the
-/// source of truth for Epic 32; it coexists with the Elsa-store seeder (which
-/// populates Elsa's own <c>IAgentManager</c> store) until that is retired in a
-/// later story.
+/// Story 32-15 — idempotently seeds the CP-resident <c>agents</c> /
+/// <c>agent_versions</c> tables with the named, cross-role public PERSONAS
+/// (<c>claude</c>/<c>gemini</c>/<c>codegpt</c>). Each persona is
+/// <c>Visibility='public'</c>, <c>Role=NULL</c> (cross-role — usable for ANY
+/// role), owners NULL, with a <c>Version=1</c> <see cref="AgentVersion"/> whose
+/// <c>ConfigJson</c> pins an explicit <c>provider</c> AND <c>model</c> and
+/// carries NO prompts (personas are prompt-free — the role/system prompt is the
+/// Epic 27 prompt store's job, keyed <c>(principal, role, action)</c>).
 ///
-/// <para>Insert-missing-only (mirrors <see cref="PlansSeeder"/> /
-/// ConventionStoreSeeder): each agent is skipped if a public agent with the
-/// same <c>(Name, Role)</c> already exists, so re-running on every startup is a
-/// no-op. Owner columns are NULL (public). The seeder does NOT emit DCB events
-/// — seeding system defaults is not a user-driven state transition (consistent
-/// with PlansSeeder); the AGENT.CREATED.SUCCESS event family is reserved for
-/// real create/publish operations via the repository/API.</para>
+/// <para><b>Amends the shipped 32-1 seeder.</b> 32-1 seeded one
+/// <c>tamma-&lt;role&gt;</c> public agent per role on a single Anthropic provider
+/// chain with <c>Role</c> as identity. This rewrite stops producing those rows
+/// and produces the named personas instead; any pre-existing
+/// <c>tamma-&lt;role&gt;</c> public rows are ARCHIVED (never destructive-deleted —
+/// versions are immutable history) so default-persona resolution + enablement
+/// (32-16) operate over the named personas only (AC11).</para>
+///
+/// <para><b>Insert-missing-only, keyed by Name</b> (mirrors
+/// <see cref="ProviderPricingSeeder"/> / <see cref="PlansSeeder"/>): a persona is
+/// skipped if a public agent with the same <c>Name</c> already exists, so a
+/// re-run is a no-op and NEVER reverts an admin edit to an existing persona's
+/// config/version (AC4). Deterministic UUIDv7-shaped ids keep FK targets stable
+/// across environments.</para>
+///
+/// <para><b>Cost-basis guard (AC3/AC14).</b> Each persona's <c>(provider,
+/// model)</c> must be priceable — backed by Story 34-11's
+/// <c>provider_model_prices</c>. The seeder checks for an <c>active</c> price row
+/// before writing; an unpriceable persona is WARN-logged and skipped (no
+/// half-seeded row). This seeder lives in <c>Tamma.Data</c> and cannot reference
+/// the <c>Tamma.Api</c> <c>IProviderPricingService</c>, so it queries the price
+/// table directly — the in-data equivalent of <c>IsKnown(provider, model)</c>.
+/// It therefore MUST run AFTER <see cref="ProviderPricingSeeder"/> at startup.</para>
+///
+/// <para><b>DCB events on real writes only (AC12).</b> When an
+/// <see cref="IPlatformEventRepository"/> is supplied, the seeder emits
+/// <c>AGENT.CREATED.SUCCESS</c> (which doubles as the version-published signal
+/// for the inline Version=1) per newly-created persona and
+/// <c>AGENT.ARCHIVED.SUCCESS</c> per legacy row archived — never a "lie" event
+/// for a skipped (already-existing) persona. Persona definitions are
+/// platform-global, so events land in the control-plane <c>platform_events</c>
+/// store with <c>TenantId = NULL</c> (platform feed) — written via the platform
+/// event repository directly, NOT the tenant-routing <see cref="IEventRepository"/>
+/// (which at startup-seed time would try to resolve a non-existent tenant DB).
+/// Never logs raw <c>ConfigJson</c> — configs carry <c>provider</c>+<c>model</c>,
+/// never a key.</para>
 /// </summary>
 public static class AgentEntitySeeder
 {
-    /// <summary>
-    /// The shipped public-agent catalogue. Keyed by canonical
-    /// <c>AgentRole</c> wire string; values mirror the legacy
-    /// <c>AgentSeeder.GetDefaultAgents()</c> config. All share the default
-    /// provider chain + budget; temperature varies per role.
-    /// </summary>
-    private static readonly IReadOnlyList<SeedAgent> s_seedAgents = new[]
-    {
-        new SeedAgent("developer", 0.4,
-            "Expert software developer for code generation and fixes."),
-        new SeedAgent("tester", 0.3,
-            "QA engineer for test strategy and generation."),
-        new SeedAgent("security", 0.2,
-            "Security reviewer for vulnerabilities, secrets, and compliance."),
-        new SeedAgent("devops", 0.3,
-            "DevOps engineer for infrastructure, CI/CD, and deployment."),
-        new SeedAgent("architect", 0.3,
-            "Software architect for system design decisions."),
-        new SeedAgent("product_owner", 0.4,
-            "Product owner for intake, requirements, and prioritisation."),
-        new SeedAgent("senior_developer", 0.2,
-            "Tech lead for decomposition, code review, and mentorship."),
-        new SeedAgent("tech_writer", 0.4,
-            "Technical writer for documentation."),
-    };
+    /// <summary>DNS-style namespace for deterministic seed ids. NEVER change.</summary>
+    private const string IdNamespace = "tamma.persona.v1";
 
-    private static readonly string[] s_providerChainNames = ["anthropic", "openai", "openrouter"];
+    private const string WorkflowVersion = "1.0.0";
     private const int DefaultMaxTokens = 4096;
     private const double DefaultMaxBudgetUsd = 10.0;
 
     /// <summary>
-    /// Insert any missing public agents + their <c>Version=1</c> snapshots.
-    /// Safe to call on every startup — skip-by-existing-handle makes re-runs a
-    /// no-op. Returns the number of agents inserted.
+    /// The named, cross-role public personas. Each pins an explicit
+    /// <c>provider</c>+<c>model</c> whose pair MUST be priceable under Story
+    /// 34-11 (the seeded price book). The chosen models are present in the
+    /// shipped price book:
+    /// <list type="bullet">
+    ///   <item><c>claude</c> → anthropic / claude-sonnet-4-20250514</item>
+    ///   <item><c>gemini</c> → google / gemini-1.5-pro (the priced Gemini pro
+    ///     SKU — gemini-2.5-pro is NOT in the 34-11 book)</item>
+    ///   <item><c>codegpt</c> → openai / gpt-4o</item>
+    /// </list>
     /// </summary>
+    private static readonly IReadOnlyList<PersonaSeed> s_personas = new[]
+    {
+        new PersonaSeed("claude", "anthropic", "claude-sonnet-4-20250514", 0.3,
+            "Anthropic Claude persona — strong general-purpose coding agent."),
+        new PersonaSeed("gemini", "google", "gemini-1.5-pro", 0.3,
+            "Google Gemini persona — large-context multimodal coding agent."),
+        new PersonaSeed("codegpt", "openai", "gpt-4o", 0.3,
+            "OpenAI GPT persona — fast general-purpose coding agent."),
+    };
+
+    /// <summary>
+    /// Insert any missing named cross-role personas + their <c>Version=1</c>
+    /// snapshots, and archive any legacy <c>tamma-&lt;role&gt;</c> public rows.
+    /// Safe to call on every startup — skip-by-existing-name makes re-runs a
+    /// no-op. Returns the number of personas inserted.
+    /// </summary>
+    /// <param name="context">The control-plane context.</param>
+    /// <param name="events">
+    /// Optional platform DCB event sink. When supplied,
+    /// <c>AGENT.CREATED.SUCCESS</c> / <c>AGENT.ARCHIVED.SUCCESS</c> are emitted to
+    /// the platform feed on real state transitions (AC12). Tests may pass null
+    /// when they don't assert on events.
+    /// </param>
+    /// <param name="logger">Optional structured logger (AC14).</param>
     public static async Task<int> SeedAsync(
-        ControlPlaneDbContext context, CancellationToken cancellationToken = default)
+        ControlPlaneDbContext context,
+        IPlatformEventRepository? events = null,
+        ILogger? logger = null,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        // Existing public (Name, Role) pairs for this seed set — skip those. The
-        // key must match the partial unique index on (Name, Role) so the
-        // idempotency check and the DB constraint can't diverge.
-        var existing = await context.Agents
-            .Where(a => a.Visibility == AgentVisibility.Public)
-            .Select(a => new { a.Name, a.Role })
-            .ToListAsync(cancellationToken);
-        var existingSet = existing
-            .Select(a => (a.Name, a.Role))
-            .ToHashSet();
-
         var now = DateTime.UtcNow;
-        var inserted = 0;
 
-        foreach (var seed in s_seedAgents)
+        // Existing public persona handles — skip those (insert-missing-only
+        // keyed by Name alone, matching the IX_agents_public_name index). Never
+        // reverts an admin-edited persona (AC4).
+        var existingPublicNames = await context.Agents
+            .Where(a => a.Visibility == AgentVisibility.Public)
+            .Select(a => a.Name)
+            .ToListAsync(cancellationToken);
+        var existingSet = existingPublicNames.ToHashSet(StringComparer.Ordinal);
+
+        // Active priced (provider, model) pairs (Story 34-11). Case-insensitive
+        // on both keys — the in-data equivalent of IProviderPricingService.IsKnown.
+        var pricedPairs = await context.ProviderModelPrices
+            .Where(p => p.Status == "active")
+            .Select(p => new { p.ProviderKey, p.Model })
+            .ToListAsync(cancellationToken);
+        var pricedSet = pricedPairs
+            .Select(p => (p.ProviderKey, p.Model))
+            .ToHashSet(ProviderModelComparer.Instance);
+
+        var created = new List<(Agent Agent, int Version)>();
+
+        foreach (var persona in s_personas)
         {
-            var handle = $"tamma-{seed.Role}";
-            if (existingSet.Contains((handle, seed.Role)))
+            if (existingSet.Contains(persona.Name))
             {
+                continue; // skip-by-existing-name — no event (AC4/AC12)
+            }
+
+            // Cost-basis guard (AC3/AC14) — refuse to seed an unpriceable
+            // persona; a half-seeded row that can't meter is worse than a gap.
+            if (!pricedSet.Contains((persona.Provider, persona.Model)))
+            {
+                logger?.LogWarning(
+                    "agent.persona.unpriceable personaName={PersonaName} provider={Provider} model={Model} — "
+                    + "no active price row (Story 34-11); skipping write (run ProviderPricingSeeder first)",
+                    persona.Name, persona.Provider, persona.Model);
                 continue;
             }
 
-            var agentId = Guid.NewGuid();
-            var versionId = Guid.NewGuid();
+            var agentId = DeterministicId($"persona:{persona.Name}");
+            var versionId = DeterministicId($"persona-version:{persona.Name}:1");
 
-            context.Agents.Add(new Agent
+            var configJson = BuildConfigJson(persona);
+
+            var agent = new Agent
             {
                 Id = agentId,
-                Name = handle,
-                Role = seed.Role,
+                Name = persona.Name,
+                Role = null,                          // cross-role persona (AC1/AC3)
                 Visibility = AgentVisibility.Public,
                 OwnerTenantId = null,
                 OwnerUserId = null,
@@ -101,48 +166,189 @@ public static class AgentEntitySeeder
                 CurrentVersionId = versionId,
                 CreatedAt = now,
                 UpdatedAt = now,
-            });
+            };
+            context.Agents.Add(agent);
             context.AgentVersions.Add(new AgentVersion
             {
                 Id = versionId,
                 AgentId = agentId,
                 Version = 1,
-                ConfigJson = BuildConfigJson(seed),
-                Notes = "Shipped default (Story 32-1 seed).",
+                ConfigJson = configJson,
+                Notes = "Shipped persona (Story 32-15 seed).",
                 CreatedAt = now,
             });
-            inserted++;
+
+            logger?.LogInformation(
+                "agent.persona.created personaName={PersonaName} agentId={AgentId} provider={Provider} model={Model}",
+                persona.Name, agentId, persona.Provider, persona.Model);
+
+            created.Add((agent, 1));
         }
 
-        if (inserted > 0)
+        // Legacy disposition (AC11) — archive any pre-existing tamma-<role>
+        // public rows so default resolution operates over the named personas.
+        // Never destructive-delete (immutable history); idempotent (skip rows
+        // already Archived → no second event).
+        var legacy = await context.Agents
+            .Where(a => a.Visibility == AgentVisibility.Public
+                        && a.Status == AgentStatus.Active
+                        && a.Name.StartsWith("tamma-"))
+            .ToListAsync(cancellationToken);
+        var archived = new List<Agent>();
+        foreach (var row in legacy)
+        {
+            row.Status = AgentStatus.Archived;
+            row.UpdatedAt = now;
+            archived.Add(row);
+        }
+
+        if (created.Count > 0 || archived.Count > 0)
         {
             await context.SaveChangesAsync(cancellationToken);
         }
 
-        return inserted;
+        // Emit DCB events only after a real, committed state transition (AC12).
+        if (events is not null)
+        {
+            foreach (var (agent, version) in created)
+            {
+                var persona = s_personas.First(p => p.Name == agent.Name);
+                await AppendCreatedEventAsync(events, agent, version, persona);
+            }
+            foreach (var row in archived)
+            {
+                await AppendArchivedEventAsync(events, row);
+            }
+        }
+
+        if (archived.Count > 0)
+        {
+            logger?.LogInformation(
+                "agent.persona.legacy_archived disposition=archived count={Count}",
+                archived.Count);
+        }
+
+        logger?.LogInformation(
+            "agent.persona.seed_summary created={Created} skipped={Skipped} personas={Personas}",
+            created.Count,
+            s_personas.Count - created.Count,
+            string.Join(",", s_personas.Select(p => p.Name)));
+
+        return created.Count;
     }
 
     /// <summary>
-    /// Build a saved-config snapshot that validates against
-    /// <c>AgentConfigValidator</c> and mirrors the shipped values: primary
-    /// <c>provider</c>, full <c>providerChain</c>, <c>temperature</c>,
-    /// <c>maxTokens</c>, <c>maxBudgetUsd</c>.
+    /// Build a persona saved-config snapshot: explicit <c>provider</c> + explicit
+    /// <c>model</c>, params — and NO <c>prompts</c> block (personas are
+    /// prompt-free; the role/system prompt comes from Epic 27). Validates against
+    /// <c>AgentConfigValidator</c> (provider regex, ranges, ReDoS guard).
     /// </summary>
-    private static string BuildConfigJson(SeedAgent seed)
+    private static string BuildConfigJson(PersonaSeed persona)
     {
         var config = new
         {
-            provider = s_providerChainNames[0],
-            temperature = seed.Temperature,
+            provider = persona.Provider,
+            model = persona.Model,
+            temperature = persona.Temperature,
             maxTokens = DefaultMaxTokens,
             maxBudgetUsd = DefaultMaxBudgetUsd,
-            providerChain = s_providerChainNames
-                .Select(p => new { provider = p })
-                .ToArray(),
-            description = seed.Description,
+            description = persona.Description,
         };
         return JsonSerializer.Serialize(config);
     }
 
-    private readonly record struct SeedAgent(string Role, double Temperature, string Description);
+    private static async Task AppendCreatedEventAsync(
+        IPlatformEventRepository events, Agent agent, int version, PersonaSeed persona)
+    {
+        var tags = new Dictionary<string, object?>
+        {
+            ["agentId"] = agent.Id.ToString(),
+            ["version"] = version,
+            ["visibility"] = "public",
+            ["role"] = null,                      // cross-role persona (AC12)
+            ["personaName"] = agent.Name,
+            ["provider"] = persona.Provider,
+            ["model"] = persona.Model,
+            ["mode"] = "platform",
+        };
+
+        await events.AppendAsync(new PlatformEvent
+        {
+            Id = Guid.NewGuid(),
+            Type = "AGENT.CREATED.SUCCESS",
+            TenantId = null,                      // platform feed (AC12)
+            Tags = JsonSerializer.Serialize(tags),
+            Metadata = JsonSerializer.Serialize(new
+            {
+                workflowVersion = WorkflowVersion,
+                eventSource = "system",
+            }),
+            Data = JsonSerializer.Serialize(new Dictionary<string, object?>
+            {
+                ["version"] = version,
+            }),
+            CreatedAt = DateTime.UtcNow,
+        });
+    }
+
+    private static async Task AppendArchivedEventAsync(IPlatformEventRepository events, Agent agent)
+    {
+        var tags = new Dictionary<string, object?>
+        {
+            ["agentId"] = agent.Id.ToString(),
+            ["visibility"] = "public",
+            ["role"] = agent.Role,
+            ["personaName"] = agent.Name,
+            ["mode"] = "platform",
+        };
+
+        await events.AppendAsync(new PlatformEvent
+        {
+            Id = Guid.NewGuid(),
+            Type = "AGENT.ARCHIVED.SUCCESS",
+            TenantId = null,
+            Tags = JsonSerializer.Serialize(tags),
+            Metadata = JsonSerializer.Serialize(new
+            {
+                workflowVersion = WorkflowVersion,
+                eventSource = "system",
+            }),
+            Data = JsonSerializer.Serialize(new Dictionary<string, object?>()),
+            CreatedAt = DateTime.UtcNow,
+        });
+    }
+
+    /// <summary>
+    /// Derive a stable, deterministic UUIDv7-shaped GUID from a name. SHA-256 of
+    /// <c>"{namespace}:{name}"</c>, version nibble forced to 7, RFC-4122 variant.
+    /// Mirrors <see cref="ProviderPricingSeeder.DeterministicId"/>.
+    /// </summary>
+    public static Guid DeterministicId(string name)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes($"{IdNamespace}:{name}"));
+        Span<byte> guid = stackalloc byte[16];
+        bytes.AsSpan(0, 16).CopyTo(guid);
+        guid[6] = (byte)((guid[6] & 0x0F) | 0x70);
+        guid[8] = (byte)((guid[8] & 0x3F) | 0x80);
+        return new Guid(guid, bigEndian: true);
+    }
+
+    private readonly record struct PersonaSeed(
+        string Name, string Provider, string Model, double Temperature, string Description);
+
+    /// <summary>Case-insensitive (provider, model) tuple comparer — the in-data
+    /// equivalent of the price service's case-insensitive IsKnown lookup.</summary>
+    private sealed class ProviderModelComparer : IEqualityComparer<(string Provider, string Model)>
+    {
+        public static readonly ProviderModelComparer Instance = new();
+
+        public bool Equals((string Provider, string Model) x, (string Provider, string Model) y)
+            => string.Equals(x.Provider, y.Provider, StringComparison.OrdinalIgnoreCase)
+               && string.Equals(x.Model, y.Model, StringComparison.OrdinalIgnoreCase);
+
+        public int GetHashCode((string Provider, string Model) obj)
+            => HashCode.Combine(
+                obj.Provider.ToLowerInvariant(),
+                obj.Model.ToLowerInvariant());
+    }
 }

--- a/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
@@ -788,17 +788,21 @@ internal static class TammaModelConfiguration
             entity.HasKey(e => e.Id);
             entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
             entity.Property(e => e.Name).IsRequired().HasMaxLength(128);
-            entity.Property(e => e.Role).IsRequired().HasMaxLength(64);
+            // Story 32-15 — Role is NULLABLE (no .IsRequired()). Public personas
+            // are cross-role (Role = NULL); private agents may still bind a role.
+            entity.Property(e => e.Role).HasMaxLength(64);
             entity.Property(e => e.Visibility).HasConversion<int>();
             entity.Property(e => e.Status).HasConversion<int>().HasDefaultValue(AgentStatus.Active);
             entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
             entity.Property(e => e.UpdatedAt).HasDefaultValueSql("now()");
 
-            // Public handles unique on (Name, Role).
-            entity.HasIndex(e => new { e.Name, e.Role })
+            // Story 32-15 — public handles are globally unique on (Name) alone:
+            // a persona is cross-role, so (Name, Role) is no longer the public
+            // identity. Replaces the old IX_agents_public_name_role.
+            entity.HasIndex(e => e.Name)
                 .IsUnique()
                 .HasFilter("\"Visibility\" = 0")
-                .HasDatabaseName("IX_agents_public_name_role");
+                .HasDatabaseName("IX_agents_public_name");
 
             // Private handles unique per owner — two tenants may each own a
             // private agent named "atlas" without colliding.

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentEntitySeederTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentEntitySeederTests.cs
@@ -1,23 +1,27 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using NUnit.Framework;
 using Tamma.Api.Services.Agents;
 using Tamma.Data;
 using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
 using Tamma.Data.Seeders;
 
 namespace Tamma.Api.Tests.Agents;
 
 /// <summary>
-/// Story 32-1 (Task 4) — idempotency + correctness tests for
-/// <see cref="AgentEntitySeeder"/>. The seeder creates one public agent per
-/// canonical role with the <c>tamma-&lt;role&gt;</c> handle + a <c>Version=1</c>
-/// snapshot, reusing the shipped config values. Re-running inserts nothing
-/// (skip-by-existing-handle).
+/// Story 32-15 — idempotency + correctness tests for the rewritten
+/// <see cref="AgentEntitySeeder"/>. The seeder creates the named cross-role
+/// public PERSONAS (claude/gemini/codegpt), each <c>Visibility='public'</c>,
+/// <c>Role=NULL</c>, explicit <c>provider</c>+<c>model</c>, NO prompts, and a
+/// <c>Version=1</c> snapshot. Re-running inserts nothing (skip-by-existing-name)
+/// and never reverts an admin edit; an unpriceable persona is skipped.
 ///
 /// <para>Runs against a Postgres testcontainer applying the real CP migration,
-/// so the partial unique index on public <c>(Name, Role)</c> is enforced — the
-/// idempotency contract is proven structurally, not just by the EXISTS check.</para>
+/// so the partial unique index on public <c>(Name)</c> is enforced and the price
+/// book (Story 34-11) is real — the cost-basis guard is proven structurally.</para>
 /// </summary>
 [TestFixture]
 public class AgentEntitySeederTests
@@ -51,15 +55,22 @@ public class AgentEntitySeederTests
     public async Task SetUp()
     {
         await using var ctx = NewContext();
-        await ctx.Database.ExecuteSqlRawAsync("TRUNCATE agent_versions, agents CASCADE;");
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE agent_versions, agents, provider_model_prices, providers CASCADE;");
+        // The persona seeder's cost-basis guard (Story 34-11) needs the price
+        // book populated — seed it before each test (mirrors the production
+        // ordering: pricing seeder runs before the persona seeder).
+        await ProviderPricingSeeder.SeedAsync(ctx);
     }
 
     private ControlPlaneDbContext NewContext()
         => new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
             .UseNpgsql(_connectionString).Options);
 
+    private static readonly string[] s_expectedPersonas = ["claude", "gemini", "codegpt"];
+
     [Test]
-    public async Task FirstRun_Creates_OnePublicAgentPerRole_WithTammaHandles_AndVersion1()
+    public async Task FirstRun_Creates_NamedCrossRolePersonas_RoleNull_ExplicitModel_NoPrompts()
     {
         await using (var ctx = NewContext())
         {
@@ -69,20 +80,17 @@ public class AgentEntitySeederTests
         await using var verify = NewContext();
         var agents = await verify.Agents.ToListAsync();
 
-        // One per canonical role (8 roles in the AgentRole taxonomy).
-        agents.Should().HaveCount(RolePhaseMap.ValidRoles.Count);
+        agents.Should().HaveCount(s_expectedPersonas.Length);
         agents.Should().OnlyContain(a => a.Visibility == AgentVisibility.Public);
         agents.Should().OnlyContain(a => a.OwnerTenantId == null && a.OwnerUserId == null);
+        // Cross-role personas — Role is NULL.
+        agents.Should().OnlyContain(a => a.Role == null);
 
-        // Handles are tamma-<role>, one per valid role.
         var names = agents.Select(a => a.Name).ToHashSet();
-        foreach (var role in RolePhaseMap.ValidRoles)
-        {
-            names.Should().Contain($"tamma-{role}");
-        }
+        names.Should().BeEquivalentTo(s_expectedPersonas);
+        // No legacy tamma-<role> rows produced.
+        names.Should().NotContain(n => n.StartsWith("tamma-"));
 
-        // Each agent has exactly one Version=1 snapshot, and CurrentVersionId
-        // points at it.
         foreach (var a in agents)
         {
             var versions = await verify.AgentVersions
@@ -90,37 +98,135 @@ public class AgentEntitySeederTests
             versions.Should().ContainSingle();
             versions[0].Version.Should().Be(1);
             a.CurrentVersionId.Should().Be(versions[0].Id);
+
+            using var doc = JsonDocument.Parse(versions[0].ConfigJson);
+            var root = doc.RootElement;
+            // Explicit provider + model (no longer leaning on DefaultAgentConfig).
+            root.GetProperty("provider").GetString().Should().NotBeNullOrEmpty();
+            root.GetProperty("model").GetString().Should().NotBeNullOrEmpty();
+            // Personas are prompt-free.
+            root.TryGetProperty("prompts", out _).Should().BeFalse();
+            root.TryGetProperty("systemPrompt", out _).Should().BeFalse();
         }
+
+        // Each persona's explicit (provider, model).
+        var claude = agents.Single(a => a.Name == "claude");
+        var claudeCfg = JsonDocument.Parse(
+            (await verify.AgentVersions.FirstAsync(v => v.AgentId == claude.Id)).ConfigJson);
+        claudeCfg.RootElement.GetProperty("provider").GetString().Should().Be("anthropic");
+        claudeCfg.RootElement.GetProperty("model").GetString().Should().Be("claude-sonnet-4-20250514");
+
+        var gemini = agents.Single(a => a.Name == "gemini");
+        var geminiCfg = JsonDocument.Parse(
+            (await verify.AgentVersions.FirstAsync(v => v.AgentId == gemini.Id)).ConfigJson);
+        geminiCfg.RootElement.GetProperty("provider").GetString().Should().Be("google");
+        geminiCfg.RootElement.GetProperty("model").GetString().Should().Be("gemini-1.5-pro");
+
+        var codegpt = agents.Single(a => a.Name == "codegpt");
+        var codegptCfg = JsonDocument.Parse(
+            (await verify.AgentVersions.FirstAsync(v => v.AgentId == codegpt.Id)).ConfigJson);
+        codegptCfg.RootElement.GetProperty("provider").GetString().Should().Be("openai");
+        codegptCfg.RootElement.GetProperty("model").GetString().Should().Be("gpt-4o");
     }
 
     [Test]
-    public async Task SecondRun_IsNoop_CountUnchanged()
+    public async Task SecondRun_IsNoop_CountUnchanged_NoCreatedEvent()
+    {
+        var events = new CapturingEvents();
+        await using (var ctx = NewContext())
+        {
+            await AgentEntitySeeder.SeedAsync(ctx, events);
+        }
+
+        int firstCount;
+        await using (var verify1 = NewContext())
+        {
+            firstCount = await verify1.Agents.CountAsync();
+        }
+        events.Captured.Count(e => e.Type == "AGENT.CREATED.SUCCESS")
+            .Should().Be(firstCount, "one created event per newly-seeded persona");
+
+        // Second run — fresh event sink to prove no event fires on a skip.
+        var events2 = new CapturingEvents();
+        await using (var ctx2 = NewContext())
+        {
+            var inserted = await AgentEntitySeeder.SeedAsync(ctx2, events2);
+            inserted.Should().Be(0, "re-run inserts nothing (skip-by-existing-name)");
+        }
+
+        await using var verify2 = NewContext();
+        (await verify2.Agents.CountAsync()).Should().Be(firstCount);
+        (await verify2.AgentVersions.CountAsync()).Should().Be(firstCount,
+            "no duplicate Version=1 rows on re-run");
+        events2.Captured.Should().NotContain(e => e.Type == "AGENT.CREATED.SUCCESS",
+            "no AGENT.CREATED.SUCCESS is emitted for a skipped (already-existing) persona");
+    }
+
+    [Test]
+    public async Task SecondRun_NeverReverts_AdminEditedPersona()
     {
         await using (var ctx = NewContext())
         {
             await AgentEntitySeeder.SeedAsync(ctx);
         }
 
-        int agentCountAfterFirst;
-        await using (var verify1 = NewContext())
+        // Admin publishes Version=2 for claude.
+        Guid claudeId;
+        await using (var edit = NewContext())
         {
-            agentCountAfterFirst = await verify1.Agents.CountAsync();
+            var claude = await edit.Agents.FirstAsync(a => a.Name == "claude");
+            claudeId = claude.Id;
+            var v2 = new AgentVersion
+            {
+                Id = Guid.NewGuid(),
+                AgentId = claude.Id,
+                Version = 2,
+                ConfigJson = """{ "provider": "anthropic", "model": "claude-opus-4-20250514" }""",
+                Notes = "admin edit",
+                CreatedAt = DateTime.UtcNow,
+            };
+            edit.AgentVersions.Add(v2);
+            claude.CurrentVersionId = v2.Id;
+            await edit.SaveChangesAsync();
         }
 
-        // Second run.
+        // Re-run the seeder — must leave the admin edit intact.
         await using (var ctx2 = NewContext())
         {
-            await AgentEntitySeeder.SeedAsync(ctx2);
+            (await AgentEntitySeeder.SeedAsync(ctx2)).Should().Be(0);
         }
 
-        await using var verify2 = NewContext();
-        var agentCountAfterSecond = await verify2.Agents.CountAsync();
-        var versionCount = await verify2.AgentVersions.CountAsync();
+        await using var verify = NewContext();
+        var claudeAfter = await verify.Agents.FirstAsync(a => a.Id == claudeId);
+        var active = await verify.AgentVersions.FirstAsync(v => v.Id == claudeAfter.CurrentVersionId);
+        active.Version.Should().Be(2, "the seeder must not revert an admin-published version");
+        active.ConfigJson.Should().Contain("claude-opus-4-20250514");
+    }
 
-        agentCountAfterSecond.Should().Be(agentCountAfterFirst,
-            "re-running the seeder inserts nothing (skip-by-existing-handle)");
-        versionCount.Should().Be(agentCountAfterFirst,
-            "no duplicate Version=1 rows on re-run");
+    [Test]
+    public async Task UnpriceablePersona_IsSkipped_NoHalfSeededRow()
+    {
+        // Remove the google price rows so the gemini persona's (provider, model)
+        // is not IsKnown — it must be WARN-skipped (no half-seeded row), while
+        // the priced personas still seed.
+        await using (var prep = NewContext())
+        {
+            await prep.Database.ExecuteSqlRawAsync(
+                "DELETE FROM provider_model_prices WHERE \"ProviderKey\" = 'google';");
+        }
+
+        await using (var ctx = NewContext())
+        {
+            await AgentEntitySeeder.SeedAsync(ctx);
+        }
+
+        await using var verify = NewContext();
+        var names = (await verify.Agents.Select(a => a.Name).ToListAsync()).ToHashSet();
+        names.Should().Contain("claude").And.Contain("codegpt");
+        names.Should().NotContain("gemini", "an unpriceable persona is skipped");
+        // No orphaned version row for the skipped persona.
+        (await verify.AgentVersions.CountAsync())
+            .Should().Be(names.Count, "no half-seeded version row for the skipped persona");
     }
 
     [Test]
@@ -139,29 +245,180 @@ public class AgentEntitySeederTests
         {
             var (valid, errors) = AgentConfigValidator.Validate(v.ConfigJson);
             valid.Should().BeTrue(
-                "every seeded public-agent config must pass the saved-config validator; "
+                "every seeded persona config must pass the saved-config validator; "
                 + "errors: {0}", string.Join("; ", errors));
         }
     }
 
     [Test]
-    public async Task SeededConfig_PreservesShippedValues()
+    public async Task LegacyTammaRoleRows_AreArchived_Idempotently_WithSingleEvent()
     {
+        // Pre-seed a legacy tamma-<role> public row (as 32-1 would have on main).
+        Guid legacyId = Guid.NewGuid();
+        await using (var prep = NewContext())
+        {
+            prep.Agents.Add(new Agent
+            {
+                Id = legacyId,
+                Name = "tamma-architect",
+                Role = "architect",
+                Visibility = AgentVisibility.Public,
+                Status = AgentStatus.Active,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+            });
+            await prep.SaveChangesAsync();
+        }
+
+        var events = new CapturingEvents();
         await using (var ctx = NewContext())
         {
-            await AgentEntitySeeder.SeedAsync(ctx);
+            await AgentEntitySeeder.SeedAsync(ctx, events);
+        }
+
+        await using (var verify = NewContext())
+        {
+            var legacy = await verify.Agents.FirstAsync(a => a.Id == legacyId);
+            legacy.Status.Should().Be(AgentStatus.Archived,
+                "legacy tamma-<role> rows are archived (never destructive-deleted)");
+        }
+        events.Captured.Count(e => e.Type == "AGENT.ARCHIVED.SUCCESS")
+            .Should().Be(1, "archiving emits exactly one event per legacy row");
+
+        // Second run — idempotent: no second archive event.
+        var events2 = new CapturingEvents();
+        await using (var ctx2 = NewContext())
+        {
+            await AgentEntitySeeder.SeedAsync(ctx2, events2);
+        }
+        events2.Captured.Should().NotContain(e => e.Type == "AGENT.ARCHIVED.SUCCESS",
+            "an already-archived legacy row is not re-archived");
+    }
+
+    [Test]
+    public async Task CreatedEvent_CarriesPersonaShape_RoleNull_PlatformTenant()
+    {
+        var events = new CapturingEvents();
+        await using (var ctx = NewContext())
+        {
+            await AgentEntitySeeder.SeedAsync(ctx, events);
+        }
+
+        var created = events.Captured.Where(e => e.Type == "AGENT.CREATED.SUCCESS").ToList();
+        created.Should().HaveCount(s_expectedPersonas.Length);
+        created.Should().OnlyContain(e => e.TenantId == null, "persona events are platform-feed");
+
+        var claudeEvt = created.Single(e =>
+        {
+            using var t = JsonDocument.Parse(e.Tags);
+            return t.RootElement.GetProperty("personaName").GetString() == "claude";
+        });
+        using var tags = JsonDocument.Parse(claudeEvt.Tags);
+        tags.RootElement.GetProperty("visibility").GetString().Should().Be("public");
+        tags.RootElement.GetProperty("role").ValueKind.Should().Be(JsonValueKind.Null);
+        tags.RootElement.GetProperty("provider").GetString().Should().Be("anthropic");
+        tags.RootElement.GetProperty("model").GetString().Should().Be("claude-sonnet-4-20250514");
+        tags.RootElement.GetProperty("version").GetInt32().Should().Be(1);
+    }
+
+    [Test]
+    public async Task NullableRole_PublicPersona_RoundTrips_CheckPasses()
+    {
+        // AC1/AC13 — a Visibility=public, Role=NULL persona inserts (the
+        // visibility-ownership CHECK still passes: public + no owners) and reads
+        // back with Role null.
+        var id = Guid.NewGuid();
+        await using (var ctx = NewContext())
+        {
+            ctx.Agents.Add(new Agent
+            {
+                Id = id,
+                Name = "claude",
+                Role = null,
+                Visibility = AgentVisibility.Public,
+                Status = AgentStatus.Active,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+            });
+            await ctx.SaveChangesAsync();
         }
 
         await using var verify = NewContext();
-        var architect = await verify.Agents.FirstAsync(a => a.Name == "tamma-architect");
-        var version = await verify.AgentVersions.FirstAsync(v => v.AgentId == architect.Id);
+        var read = await verify.Agents.FirstAsync(a => a.Id == id);
+        read.Role.Should().BeNull();
+        read.Visibility.Should().Be(AgentVisibility.Public);
+    }
 
-        using var doc = System.Text.Json.JsonDocument.Parse(version.ConfigJson);
-        var root = doc.RootElement;
-        // Shipped architect values from the legacy AgentSeeder: temperature 0.3,
-        // maxTokens 4096, provider chain anthropic→openai→openrouter.
-        root.GetProperty("temperature").GetDouble().Should().BeApproximately(0.3, 0.001);
-        root.GetProperty("maxTokens").GetInt32().Should().Be(4096);
-        root.GetProperty("providerChain").GetArrayLength().Should().BeGreaterThan(0);
+    [Test]
+    public async Task PublicNameIndex_RejectsDuplicateName_AcrossAnyRole()
+    {
+        // AC2/AC13 — two PUBLIC agents may not share a Name (even with different
+        // or null roles) → IX_agents_public_name (the swapped index).
+        await using (var ctx = NewContext())
+        {
+            ctx.Agents.Add(new Agent
+            {
+                Id = Guid.NewGuid(), Name = "claude", Role = null,
+                Visibility = AgentVisibility.Public, Status = AgentStatus.Active,
+                CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow,
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        await using var ctx2 = NewContext();
+        ctx2.Agents.Add(new Agent
+        {
+            Id = Guid.NewGuid(), Name = "claude", Role = "developer",
+            Visibility = AgentVisibility.Public, Status = AgentStatus.Active,
+            CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow,
+        });
+        Func<Task> act = async () => await ctx2.SaveChangesAsync();
+        await act.Should().ThrowAsync<DbUpdateException>(
+            "a second public agent with the same Name violates IX_agents_public_name");
+    }
+
+    [Test]
+    public async Task PublicAndPrivate_SameName_Coexist()
+    {
+        // AC2/AC13 — a public 'claude' persona and a private 'claude' agent
+        // coexist (private partial indexes are unchanged, scoped by owner).
+        var tenantId = Guid.NewGuid();
+        await using var ctx = NewContext();
+        ctx.Agents.Add(new Agent
+        {
+            Id = Guid.NewGuid(), Name = "claude", Role = null,
+            Visibility = AgentVisibility.Public, Status = AgentStatus.Active,
+            CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow,
+        });
+        ctx.Agents.Add(new Agent
+        {
+            Id = Guid.NewGuid(), Name = "claude", Role = "developer",
+            Visibility = AgentVisibility.Private, OwnerTenantId = tenantId,
+            Status = AgentStatus.Active,
+            CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow,
+        });
+        Func<Task> act = async () => await ctx.SaveChangesAsync();
+        await act.Should().NotThrowAsync(
+            "public and private name spaces are disjoint (separate partial indexes)");
+    }
+
+    private sealed class CapturingEvents : IPlatformEventRepository
+    {
+        public ConcurrentQueue<PlatformEvent> Captured { get; } = new();
+
+        public Task<PlatformEvent?> AppendAsync(PlatformEvent evt, CancellationToken ct = default)
+        {
+            Captured.Enqueue(evt);
+            return Task.FromResult<PlatformEvent?>(evt);
+        }
+
+        public Task<PlatformEvent?> GetByIdAsync(Guid id, CancellationToken ct = default)
+            => Task.FromResult<PlatformEvent?>(null);
+
+        public Task<IReadOnlyList<PlatformEvent>> QueryAsync(
+            Guid? tenantId = null, Guid? userId = null, string? typePrefix = null,
+            DateTime? since = null, bool includePlatformWide = false, int limit = 100,
+            CancellationToken ct = default)
+            => Task.FromResult((IReadOnlyList<PlatformEvent>)Captured.ToList());
     }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentRegistryEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentRegistryEndpointsTests.cs
@@ -74,7 +74,9 @@ public class AgentRegistryEndpointsTests
 
     private const string Cfg = """{ "provider": "anthropic", "model": "claude-sonnet-4" }""";
 
-    private Stack BuildStack(TammaMode mode, Guid? tenantId, Guid? userId, bool platformAdmin = false)
+    private Stack BuildStack(
+        TammaMode mode, Guid? tenantId, Guid? userId, bool platformAdmin = false,
+        string defaultPersonaName = "tamma-developer")
     {
         var cpCtx = NewContext();
         var events = new CapturingEvents();
@@ -92,12 +94,17 @@ public class AgentRegistryEndpointsTests
             HttpContext = new DefaultHttpContext { User = principal },
         };
 
+        // Story 32-15 — the system default is the configured default PERSONA (by
+        // name, role-independent). Point it at the handle the test seeds.
+        var personaOptions = Microsoft.Extensions.Options.Options.Create(
+            new DefaultPersonaOptions { DefaultPersonaName = defaultPersonaName });
+
         var registry = new AgentRegistryService(
             agentRepo, selectionRepo, events, modeProvider, tenantContext, httpAccessor,
-            NullLogger<AgentRegistryService>.Instance);
+            personaOptions, NullLogger<AgentRegistryService>.Instance);
         var resolver = new AgentResolverService(
             new AgentConfigRepository(factory), null, NullLogger<AgentResolverService>.Instance,
-            registry, agentRepo, events);
+            registry, agentRepo, events, null, new StubPersonaPrompts());
 
         return new Stack(
             agentRepo, registry, resolver, principal, tenantContext, modeProvider, cpCtx);
@@ -141,6 +148,11 @@ public class AgentRegistryEndpointsTests
     private async Task<Agent> SeedPublicAsync(AgentRepository repo, string role, string handle)
         => await repo.CreateAsync(
             new Agent { Name = handle, Role = role, Visibility = AgentVisibility.Public }, Cfg, null, null);
+
+    /// <summary>Story 32-15 — seed a named cross-role PUBLIC persona (Role=NULL).</summary>
+    private async Task<Agent> SeedPersonaAsync(AgentRepository repo, string name)
+        => await repo.CreateAsync(
+            new Agent { Name = name, Role = null, Visibility = AgentVisibility.Public }, Cfg, null, null);
 
     private async Task<Agent> SeedTenantPrivateAsync(AgentRepository repo, Guid tenantId, string role, string name)
         => await repo.CreateAsync(
@@ -399,11 +411,12 @@ public class AgentRegistryEndpointsTests
     }
 
     [Test]
-    public async Task GetSystemDefaultPublic_MultipleActivePublicForRole_PicksFirstByName_WarnsOnAmbiguity()
+    public async Task GetSystemDefaultPublic_ReturnsConfiguredPersona_RoleIndependent_NoAmbiguityWarning()
     {
-        // Review follow-up (32-2 #3): adding a second active public agent for the
-        // same role must NOT silently shift the default — keep the deterministic
-        // first-by-name pick, but log a WARN so the ambiguity is observable.
+        // Story 32-15 — public agents are cross-role PERSONAS, so the system
+        // default is the configured default persona (by name), resolved REGARDLESS
+        // of role. The old per-role ">1 public agent for this role" ambiguity
+        // warning is DELETED — seeding several public personas must NOT log it.
         var logProvider = new Infrastructure.CapturingLoggerProvider();
         using var loggerFactory = LoggerFactory.Create(b => b.AddProvider(logProvider));
 
@@ -414,28 +427,58 @@ public class AgentRegistryEndpointsTests
         tenantContext.SetTenantId(TenantA);
         var factory = new SameDbTenantFactory(_connectionString);
         var selectionRepo = new AgentSelectionRepository(cpCtx, factory, tenantContext);
+        var personaOptions = Microsoft.Extensions.Options.Options.Create(
+            new DefaultPersonaOptions { DefaultPersonaName = "claude" });
         var registry = new AgentRegistryService(
             agentRepo, selectionRepo, events, new StubMode(TammaMode.SaaS),
             tenantContext, new HttpContextAccessor { HttpContext = new DefaultHttpContext() },
-            loggerFactory.CreateLogger<AgentRegistryService>());
+            personaOptions, loggerFactory.CreateLogger<AgentRegistryService>());
 
         await using (cpCtx)
         {
-            // Two active public agents for the same role; "alpha" < "tamma" ordinal.
-            await SeedPublicAsync(agentRepo, "developer", "tamma-developer");
-            var alpha = await SeedPublicAsync(agentRepo, "developer", "alpha-developer");
+            // Several public personas (Role=NULL, cross-role).
+            var claude = await SeedPersonaAsync(agentRepo, "claude");
+            await SeedPersonaAsync(agentRepo, "gemini");
+            await SeedPersonaAsync(agentRepo, "codegpt");
 
-            var chosen = await registry.GetSystemDefaultPublicAsync("developer");
+            // Resolves the configured persona for ANY role — never role-matches.
+            foreach (var role in new[] { "developer", "architect", "tester" })
+            {
+                var chosen = await registry.GetSystemDefaultPublicAsync(role);
+                chosen.Should().NotBeNull();
+                chosen!.Id.Should().Be(claude.Id,
+                    "the configured default persona is returned regardless of role");
+            }
 
-            chosen.Should().NotBeNull("ambiguity must not throw — keep a deterministic pick");
-            chosen!.Id.Should().Be(alpha.Id, "first-by-name (ordinal) is the deterministic winner");
+            logProvider.Entries.Should().NotContain(e =>
+                e.Message.Contains("agent.system_default.ambiguous"),
+                "the per-role ambiguity warning is deleted in Story 32-15");
+        }
+    }
 
-            var warn = logProvider.Entries.Should().ContainSingle(e =>
-                e.Level == LogLevel.Warning &&
-                e.Message.Contains("agent.system_default.ambiguous")).Subject;
-            warn.Message.Should().Contain("developer");
-            warn.Message.Should().Contain("count=2");
-            warn.Message.Should().Contain(alpha.Id.ToString());
+    [Test]
+    public async Task GetSystemDefaultPublic_ConfiguredPersonaAbsent_FailsLoud()
+    {
+        var cpCtx = NewContext();
+        var events = new CapturingEvents();
+        var agentRepo = new AgentRepository(cpCtx, events);
+        var tenantContext = new TenantContext();
+        tenantContext.SetTenantId(TenantA);
+        var factory = new SameDbTenantFactory(_connectionString);
+        var selectionRepo = new AgentSelectionRepository(cpCtx, factory, tenantContext);
+        var personaOptions = Microsoft.Extensions.Options.Options.Create(
+            new DefaultPersonaOptions { DefaultPersonaName = "claude" });
+        var registry = new AgentRegistryService(
+            agentRepo, selectionRepo, events, new StubMode(TammaMode.SaaS),
+            tenantContext, new HttpContextAccessor { HttpContext = new DefaultHttpContext() },
+            personaOptions, NullLogger<AgentRegistryService>.Instance);
+
+        await using (cpCtx)
+        {
+            // No persona seeded — fail loud, never an empty/plain fallback.
+            Func<Task> act = async () => await registry.GetSystemDefaultPublicAsync("developer");
+            (await act.Should().ThrowAsync<TammaError>())
+                .Which.Code.Should().Be("AGENT_DEFAULT_PERSONA_MISSING");
         }
     }
 
@@ -517,6 +560,15 @@ public class AgentRegistryEndpointsTests
     private sealed class StubMode(TammaMode mode) : ITammaModeProvider
     {
         public TammaMode Mode { get; } = mode;
+    }
+
+    /// <summary>Story 32-15 — supplies the PUBLIC branch's system prompt so
+    /// persona resolution succeeds without the full Epic 27 store.</summary>
+    private sealed class StubPersonaPrompts : IPersonaPromptResolver
+    {
+        public Task<string> ResolveAsync(
+            Principal principal, string role, string? action, CancellationToken ct = default)
+            => Task.FromResult($"[persona system prompt for role={role}]");
     }
 
     private sealed class SameDbTenantFactory(string conn) : ITenantDbContextFactory

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentResolverChainTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentResolverChainTests.cs
@@ -79,7 +79,9 @@ public class AgentResolverChainTests
     /// here we validate the discriminator-column routing, mirroring how
     /// audit/prompt repos test the shared-DB transitional phase).
     /// </summary>
-    private Harness BuildHarness(TammaMode mode, Guid? tenantId, Guid? userId)
+    private Harness BuildHarness(
+        TammaMode mode, Guid? tenantId, Guid? userId, string defaultPersonaName = "tamma-developer",
+        IPersonaPromptResolver? personaPrompts = null)
     {
         var cpCtx = NewContext();
         var events = new CapturingEvents();
@@ -97,16 +99,24 @@ public class AgentResolverChainTests
             HttpContext = new DefaultHttpContext { User = Principal(userId) },
         };
 
+        // Story 32-15 — the system default is now the configured DEFAULT PERSONA
+        // (by name, role-independent). These chain tests seed tamma-<role> public
+        // rows, so point the default persona at the seeded handle the test uses.
+        var personaOptions = Microsoft.Extensions.Options.Options.Create(
+            new DefaultPersonaOptions { DefaultPersonaName = defaultPersonaName });
+
         var registry = new AgentRegistryService(
             agentRepo, selectionRepo, events, modeProvider, tenantContext, httpAccessor,
-            NullLogger<AgentRegistryService>.Instance);
+            personaOptions, NullLogger<AgentRegistryService>.Instance);
 
         // The legacy JSONB repo is never exercised by the entity-aware chain; a
-        // real instance is wired so the full constructor is satisfied.
+        // real instance is wired so the full constructor is satisfied. Story
+        // 32-15 — a stub persona prompt resolver supplies the PUBLIC branch's
+        // system prompt (persona = prompt-free; prompt comes from the seam).
         var legacyRepo = new AgentConfigRepository(factory);
         var resolver = new AgentResolverService(
             legacyRepo, null, NullLogger<AgentResolverService>.Instance,
-            registry, agentRepo, events);
+            registry, agentRepo, events, null, personaPrompts ?? new StubPersonaPrompts());
 
         return new Harness(resolver, registry, agentRepo, events, cpCtx);
     }
@@ -147,7 +157,9 @@ public class AgentResolverChainTests
     [Test]
     public async Task Resolve_NoSelection_FallsToSystemDefaultPublic()
     {
-        var h = BuildHarness(TammaMode.SaaS, TenantA, null);
+        // Story 32-15 — the default is the configured persona (by name). Point it
+        // at the seeded handle so the role-independent default resolves.
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null, defaultPersonaName: "tamma-architect");
         await using (h.Ctx)
         {
             var pub = await SeedPublicAsync(h.Agents, "architect", "tamma-architect");
@@ -387,11 +399,144 @@ public class AgentResolverChainTests
         }
     }
 
+    // ── Story 32-15 — persona prompt sourced from the IPersonaPromptResolver seam ──
+
+    [Test]
+    public async Task Resolve_PublicPersona_PromptComesFromSeam_NotFromConfig()
+    {
+        // The persona's ConfigJson carries NO prompt; MaterialiseAsync's public
+        // branch sources the system prompt from the IPersonaPromptResolver seam.
+        var capturing = new CapturingPersonaPrompts("[SEAM PROMPT]");
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null,
+            defaultPersonaName: "claude", personaPrompts: capturing);
+        await using (h.Ctx)
+        {
+            // Persona-style public agent: Role=NULL, prompt-free config.
+            var persona = await h.Agents.CreateAsync(
+                new Agent { Name = "claude", Role = null, Visibility = AgentVisibility.Public },
+                """{ "provider": "anthropic", "model": "claude-sonnet-4-20250514" }""", "seed", null);
+
+            var resolved = await h.Resolver.ResolveForRoleAsync("architect");
+
+            resolved.AgentId.Should().Be(persona.Id);
+            resolved.Source.Should().Be("system-public");
+            resolved.SystemPrompt.Should().Be("[SEAM PROMPT]",
+                "the persona prompt comes from the Epic 27 seam, not the prompt-free config");
+            capturing.LastRole.Should().Be("architect");
+            capturing.CallCount.Should().Be(1, "the public branch invokes the seam exactly once");
+        }
+    }
+
+    [Test]
+    public async Task Resolve_PublicPersona_SeamFailsLoud_Propagates()
+    {
+        // Epic 27 returns nothing for (role, action) → the seam throws
+        // PROMPT_UNRESOLVED; MaterialiseAsync must NOT swallow it into an
+        // empty/plain prompt.
+        var failing = new ThrowingPersonaPrompts();
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null,
+            defaultPersonaName: "claude", personaPrompts: failing);
+        await using (h.Ctx)
+        {
+            await h.Agents.CreateAsync(
+                new Agent { Name = "claude", Role = null, Visibility = AgentVisibility.Public },
+                """{ "provider": "anthropic", "model": "claude-sonnet-4-20250514" }""", "seed", null);
+
+            Func<Task> act = async () => await h.Resolver.ResolveForRoleAsync("architect");
+            (await act.Should().ThrowAsync<TammaError>())
+                .Which.Code.Should().Be("PROMPT_UNRESOLVED");
+        }
+    }
+
+    [Test]
+    public async Task Resolve_StampsAgentIdAndVersion_AndMergesDefault()
+    {
+        // Merge + stamp are preserved (Story 32-2 behaviour kept through 32-15).
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null, defaultPersonaName: "claude");
+        await using (h.Ctx)
+        {
+            var persona = await h.Agents.CreateAsync(
+                new Agent { Name = "claude", Role = null, Visibility = AgentVisibility.Public },
+                """{ "provider": "openai", "model": "gpt-4o" }""", "seed", null);
+
+            var resolved = await h.Resolver.ResolveForRoleAsync("developer");
+
+            resolved.AgentId.Should().Be(persona.Id);
+            resolved.AgentVersion.Should().Be(1);
+            resolved.Provider.Should().Be("openai", "the persona config overrides the role default");
+            resolved.Model.Should().Be("gpt-4o");
+        }
+    }
+
+    [Test]
+    public async Task EndToEnd_SeedPersonas_ResolveConfiguredDefault()
+    {
+        // AC15 — seed the named personas (with the price book), set the default
+        // to "gemini", and resolve any role → the gemini persona with its
+        // explicit provider+model, prompt from the Epic 27 seam.
+        await using (var seedCtx = NewContext())
+        {
+            await seedCtx.Database.ExecuteSqlRawAsync(
+                "TRUNCATE provider_model_prices, providers CASCADE;");
+            await Tamma.Data.Seeders.ProviderPricingSeeder.SeedAsync(seedCtx);
+            await Tamma.Data.Seeders.AgentEntitySeeder.SeedAsync(seedCtx);
+        }
+
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null, defaultPersonaName: "gemini");
+        await using (h.Ctx)
+        {
+            var resolved = await h.Resolver.ResolveForRoleAsync("architect");
+
+            resolved.Source.Should().Be("system-public");
+            resolved.Handle.Should().Be("gemini");
+            resolved.Provider.Should().Be("google");
+            resolved.Model.Should().Be("gemini-1.5-pro");
+            resolved.SystemPrompt.Should().NotBeNullOrWhiteSpace("prompt comes from the Epic 27 seam");
+        }
+
+        // Clean up the price rows we seeded so the shared fixture stays tidy.
+        await using var cleanup = NewContext();
+        await cleanup.Database.ExecuteSqlRawAsync(
+            "TRUNCATE provider_model_prices, providers CASCADE;");
+    }
+
     // ── test doubles ──
 
     private sealed class StubMode(TammaMode mode) : ITammaModeProvider
     {
         public TammaMode Mode { get; } = mode;
+    }
+
+    private sealed class CapturingPersonaPrompts(string prompt) : IPersonaPromptResolver
+    {
+        public int CallCount { get; private set; }
+        public string? LastRole { get; private set; }
+        public Task<string> ResolveAsync(
+            Principal principal, string role, string? action, CancellationToken ct = default)
+        {
+            CallCount++;
+            LastRole = role;
+            return Task.FromResult(prompt);
+        }
+    }
+
+    private sealed class ThrowingPersonaPrompts : IPersonaPromptResolver
+    {
+        public Task<string> ResolveAsync(
+            Principal principal, string role, string? action, CancellationToken ct = default)
+            => throw new TammaError("PROMPT_UNRESOLVED", "no prompt", retryable: false,
+                severity: TammaErrorSeverity.High);
+    }
+
+    /// <summary>Story 32-15 — supplies the PUBLIC branch's system prompt (a
+    /// persona is prompt-free; its prompt comes from this seam). Returns a
+    /// non-empty deterministic prompt so the chain tests' public resolution
+    /// succeeds without standing up the full Epic 27 store.</summary>
+    private sealed class StubPersonaPrompts : IPersonaPromptResolver
+    {
+        public Task<string> ResolveAsync(
+            Principal principal, string role, string? action, CancellationToken ct = default)
+            => Task.FromResult($"[persona system prompt for role={role}]");
     }
 
     /// <summary>Tenant factory that hands back a TenantDbContext bound to the

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/PersonaPromptResolverTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/PersonaPromptResolverTests.cs
@@ -1,0 +1,110 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.Agents;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Core;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Agents;
+
+/// <summary>
+/// Story 32-15 — unit tests for <see cref="PersonaPromptResolver"/>, the
+/// persona/public prompt seam. Reads the Epic 27 <see cref="PromptStoreService"/>
+/// keyed (principal, role, action) and FAILS LOUD (<c>PROMPT_UNRESOLVED</c>) on a
+/// miss — never an empty/plain fallback. Principal routes the single-user
+/// (user-keyed) vs SaaS (tenant-keyed) prompt-store surface.
+/// </summary>
+[TestFixture]
+public class PersonaPromptResolverTests
+{
+    private Mock<IPromptRepository> _repo = null!;
+    private PromptStoreService _store = null!;
+    private PersonaPromptResolver _resolver = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _repo = new Mock<IPromptRepository>(MockBehavior.Loose);
+        _store = new PromptStoreService(_repo.Object);
+        _resolver = new PersonaPromptResolver(_store, NullLogger<PersonaPromptResolver>.Instance);
+    }
+
+    [Test]
+    public async Task SingleUser_RoleSystem_ReturnsUserOverride()
+    {
+        var userId = Guid.NewGuid();
+        _repo.Setup(r => r.GetAsync(userId, "role-system", "developer", null))
+            .ReturnsAsync(new PromptOverride { Template = "USER PERSONA PROMPT" });
+
+        var text = await _resolver.ResolveAsync(
+            Principal.ForUser(userId), "developer", action: null);
+
+        text.Should().Be("USER PERSONA PROMPT");
+    }
+
+    [Test]
+    public async Task SingleUser_RoleSystem_FallsToShippedSystemDefault()
+    {
+        var userId = Guid.NewGuid();
+        _repo.Setup(r => r.GetAsync(userId, "role-system", "developer", null))
+            .ReturnsAsync((PromptOverride?)null);
+
+        // No override → shipped SystemPrompts.RoleSystemPrompts["developer"].
+        var text = await _resolver.ResolveAsync(
+            Principal.ForUser(userId), "developer", action: null);
+
+        text.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public async Task Saas_RoleSystem_RoutesTenantPath()
+    {
+        var tenantId = Guid.NewGuid();
+        _repo.Setup(r => r.GetByTenantAsync(tenantId, "role-system", "architect", null))
+            .ReturnsAsync(new PromptOverride { Template = "TENANT PERSONA PROMPT" });
+
+        var text = await _resolver.ResolveAsync(
+            Principal.ForTenant(tenantId), "architect", action: null);
+
+        text.Should().Be("TENANT PERSONA PROMPT");
+        // The single-user path must NOT be consulted in SaaS mode.
+        _repo.Verify(r => r.GetAsync(It.IsAny<Guid?>(), It.IsAny<string>(),
+            It.IsAny<string>(), It.IsAny<string?>()), Times.Never);
+    }
+
+    [Test]
+    public async Task RoleSystem_Absent_FailsLoud_PromptUnresolved()
+    {
+        var userId = Guid.NewGuid();
+        // An unknown role has neither an override NOR a shipped role-system
+        // default → the seam fails loud (never empty/plain).
+        _repo.Setup(r => r.GetAsync(userId, "role-system", "no-such-role", null))
+            .ReturnsAsync((PromptOverride?)null);
+
+        Func<Task> act = async () => await _resolver.ResolveAsync(
+            Principal.ForUser(userId), "no-such-role", action: null);
+
+        (await act.Should().ThrowAsync<TammaError>())
+            .Which.Code.Should().Be("PROMPT_UNRESOLVED");
+    }
+
+    [Test]
+    public async Task RoleAction_ReturnsSystemHalf_OfResolvedPrompt()
+    {
+        var userId = Guid.NewGuid();
+        _repo.Setup(r => r.GetAsync(userId, "role-action", "developer", "implement_feature"))
+            .ReturnsAsync(new PromptOverride
+            {
+                Template = "user template",
+                SystemPrompt = "SYSTEM HALF",
+            });
+
+        var text = await _resolver.ResolveAsync(
+            Principal.ForUser(userId), "developer", action: "implement_feature");
+
+        text.Should().Be("SYSTEM HALF");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
@@ -265,12 +265,18 @@ public class ControlPlaneDbContextModelTests
         var agent = ctx.Model.FindEntityType(typeof(Agent))!;
         var indexes = agent.GetIndexes().ToList();
 
-        var publicNameRole = indexes.Single(i =>
+        // Story 32-15 — the public unique index drops Role: a persona is
+        // cross-role, so public handles are globally unique on (Name) alone.
+        var publicName = indexes.Single(i =>
+            i.GetDatabaseName() == "IX_agents_public_name");
+        publicName.IsUnique.Should().BeTrue();
+        publicName.GetFilter().Should().Be("\"Visibility\" = 0");
+        publicName.Properties.Select(p => p.Name)
+            .Should().Equal("Name");
+
+        // The old (Name, Role) public index is GONE (Story 32-15).
+        indexes.Should().NotContain(i =>
             i.GetDatabaseName() == "IX_agents_public_name_role");
-        publicNameRole.IsUnique.Should().BeTrue();
-        publicNameRole.GetFilter().Should().Be("\"Visibility\" = 0");
-        publicNameRole.Properties.Select(p => p.Name)
-            .Should().Equal("Name", "Role");
 
         var privateTenant = indexes.Single(i =>
             i.GetDatabaseName() == "IX_agents_private_tenant_name");
@@ -283,6 +289,21 @@ public class ControlPlaneDbContextModelTests
         privateUser.IsUnique.Should().BeTrue();
         privateUser.GetFilter().Should()
             .Be("\"Visibility\" = 1 AND \"OwnerUserId\" IS NOT NULL");
+    }
+
+    [Test]
+    public void Agents_Role_Is_Nullable()
+    {
+        using var ctx = CreateContext();
+
+        // Story 32-15 — Role becomes nullable: public personas are cross-role
+        // (Role = NULL). The strict model contract must reflect the nullable
+        // column so a regression to required is caught.
+        var roleProp = ctx.Model.FindEntityType(typeof(Agent))!
+            .FindProperty(nameof(Agent.Role))!;
+        roleProp.IsNullable.Should().BeTrue(
+            "Story 32-15 makes Agent.Role nullable for cross-role public personas");
+        roleProp.GetMaxLength().Should().Be(64, "the HasMaxLength(64) cap is kept");
     }
 
     [Test]


### PR DESCRIPTION
## What

Sequence step **B** of the Epic-32 pivot. Amends the shipped 32-1/32-2 so **public agents become named cross-role PERSONAS** (`claude`/`gemini`/`codegpt`) presetting a real provider + explicit model, with **prompts coming from the Epic 27 store** (personas are prompt-free).

- `Agent.Role` → nullable; public unique index `(Name,Role)`→`(Name)`; migration `20260621205119_PersonaReframeRoleNullable` (alter + index swap, no new table).
- `AgentEntitySeeder` rewritten → named cross-role personas, `Role=NULL`, explicit `provider`+`model`, no prompts, insert-missing-only, `IsKnown` cost guard, legacy `tamma-<role>` archived idempotently.
- `GetSystemDefaultPublicAsync` returns the configured `DefaultPersonaName` (role-independent), fail-loud if absent; ambiguity warning deleted.
- New `IPersonaPromptResolver` seam → `MaterialiseAsync`'s public branch sources the prompt from Epic 27 `(principal, role, action)`, fail-loud (private branch left as a marked seam for 32-17).

## Deviations (reviewed & verified correct)
- **`gemini-1.5-pro`** instead of the story's `gemini-2.5-pro` — the latter isn't in 34-11's price book, so it would trip the `IsKnown` guard and skip the persona. All 3 persona models price under 34-11.
- Wrapped the real **`PromptStoreService`** (no `IPromptStore` interface exists).
- Persona events via **`IPlatformEventRepository`** (`platform_events`, `TenantId=NULL`) — the tenant-routing repo threw `TenantNotFoundException` at startup-seed; this is the correct platform-feed semantics for AC12.
- Reordered `Program.cs` seeds: `ProviderPricingSeeder` before `AgentEntitySeeder` (cost guard needs the price rows).

## Process / quality
TDD → **spec-review (spec-compliant, all 14 ACs, deviations verified)** → **code-quality review (approve-with-nits, no critical)**. The one IMPORTANT finding fixed in `19b7a00e`: response DTOs (`AgentSummary`/`AgentDetail`/`CreateAgentResponse`) now type `Role` as nullable so cross-role personas don't serialize a contract-lying `Role: null` (removes CS8604).

## Verification (run independently by me)
- `dotnet build Tamma.sln` → **0 errors**; `ef migrations has-pending-model-changes` (ControlPlane) → **none**.
- `Tamma.Api.Tests` → **3423 passed, 0 failed, 6 skipped** (incl. nullable-Role round-trip, index swap, persona seeding, idempotency, default-persona fail-loud, prompt-from-seam, legacy archival, model-contract). Agent-filter re-run after the DTO fix → **310/0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)