### PR TITLE
fix(workflow-viewer): centre trunk + opaque stations (subway-map visual bugs)

### DIFF
--- a/packages/workflow-viewer/src/mapLayout.ts
+++ b/packages/workflow-viewer/src/mapLayout.ts
@@ -164,10 +164,26 @@ export function buildMapLayout(workflow: WorkflowMetadata): MapLayout {
     }
   }
 
-  // ---- compact lanes to a dense 0..N-1 range, then centre the busiest column.
-  const usedLanes = [...new Set(raw.map((r) => r.rawLane))].sort((a, b) => a - b);
-  const dense = new Map(usedLanes.map((l, i) => [l, i] as const));
-  for (const r of raw) r.lane = dense.get(r.rawLane) ?? 0;
+  // ---- compact lanes, then CENTRE the trunk so branches fan to BOTH sides.
+  // Trunk = the lane carrying the most stations (the spine). The trunk takes the
+  // centre column; the remaining lanes alternate to its right and left
+  // (+1, -1, +2, -2, …). This stops every branch piling up on one side (a
+  // left-anchored, right-only fan) and instead fans the map symmetrically about
+  // a centred trunk — less width, less clutter.
+  const laneCounts = new Map<number, number>();
+  for (const r of raw) laneCounts.set(r.rawLane, (laneCounts.get(r.rawLane) ?? 0) + 1);
+  const usedLanes = [...laneCounts.keys()];
+  const trunk = usedLanes
+    .slice()
+    .sort((a, b) => (laneCounts.get(b)! - laneCounts.get(a)!) || a - b)[0]!;
+  const others = usedLanes.filter((l) => l !== trunk).sort((a, b) => a - b);
+  const signed = new Map<number, number>([[trunk, 0]]);
+  others.forEach((l, i) => {
+    const step = Math.floor(i / 2) + 1;
+    signed.set(l, i % 2 === 0 ? step : -step); // +1, -1, +2, -2, …
+  });
+  const minSigned = Math.min(0, ...signed.values());
+  for (const r of raw) r.lane = (signed.get(r.rawLane) ?? 0) - minSigned;
 
   const laneCount = usedLanes.length;
   const stations: MapStation[] = raw.map((r) => ({ node: r.node, row: r.row, lane: r.lane }));

--- a/packages/workflow-viewer/src/styles.css
+++ b/packages/workflow-viewer/src/styles.css
@@ -310,7 +310,11 @@
   height: 56px;
   padding: 6px 8px;
   border-radius: 12px;
-  background: var(--twv-bg, rgba(82, 82, 91, 0.18));
+  /* OPAQUE card: a solid base under the per-kind tint so the rails (drawn
+     behind, z-index 1) are occluded by the card body and only show BETWEEN
+     stations — not bleeding through a translucent card body. */
+  background-color: #16161b;
+  background-image: linear-gradient(var(--twv-bg, transparent), var(--twv-bg, transparent));
   border: 1.5px solid color-mix(in srgb, var(--twv-accent, #a1a1aa) 55%, transparent);
   box-shadow: 0 3px 10px rgba(0, 0, 0, 0.4);
   color: #e4e4e7;


### PR DESCRIPTION
Fixes two visual bugs in the subway-map viewer reported on the live wiki:

1. **Rails ran continuously top-to-bottom *atop* the stations** instead of stopping between steps. The `.twv-station` background was `rgba(82,82,91,0.18)` (~82% transparent), so the rails (correctly behind, z-index 1 vs 3) **bled through the card bodies**. → Opaque card base (`#16161b`) with the per-kind tint layered on top; the card now occludes the rail behind it, and the line only shows **between** stations.
2. **The trunk was pinned to the left**, every branch fanning right. `mapLayout` promised "centre the busiest column" in a comment but only compacted lanes `0..N-1` — **centering was never implemented**. → Pick the trunk (lane with the most stations) as the centre column and alternate the rest `+1,-1,+2,-2,…` so branches **fan to both sides** around a centred trunk (less width, less clutter).

Verified in-browser (Playwright): **mobile 390** + **desktop 1440** + the dense **`debugging`** workflow (12-lane row) — trunk centred, branches both sides, rails between/behind opaque cards, **no horizontal overflow**. Typecheck clean on both packages. Two-file change (`mapLayout.ts`, `styles.css`). Merging auto-deploys to wiki.tamma.dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)