### PR TITLE
ci(wiki-deploy): trigger on packages/workflow-viewer changes

### DIFF
--- a/.github/workflows/wiki-deploy.yml
+++ b/.github/workflows/wiki-deploy.yml
@@ -6,6 +6,7 @@ on:
       - 'wiki/**'
       - 'docs/stories/**'
       - 'apps/wiki-site/**'
+      - 'packages/workflow-viewer/**'
     branches:
       - main
   workflow_dispatch: {}


### PR DESCRIPTION
The wiki consumes `@tamma/workflow-viewer`, but `wiki-deploy.yml` only watched `apps/wiki-site/**`/`docs/**`. A viewer-package change (like the subway-map layout fix) therefore didn't auto-deploy — it had to be `workflow_dispatch`ed manually. Adds `packages/workflow-viewer/**` to the push path filter so viewer changes ship automatically. One-line workflow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)