### PR TITLE
fix(workflow-viewer): sub-workflow name pill is a real clickable link (new-tab on wheel/ctrl-click)

### DIFF
--- a/apps/wiki-site/src/components/WorkflowMapPage.tsx
+++ b/apps/wiki-site/src/components/WorkflowMapPage.tsx
@@ -105,6 +105,20 @@ export default function WorkflowMapPage() {
     [dataset, navigate],
   );
 
+  // Real href for a sub-workflow's map page, so the popup's name pill is a true
+  // <a> link (middle/ctrl-click → new tab). Same resolution as handleNavigate.
+  const subWorkflowHref = useCallback(
+    (targetWorkflowId: string): string | undefined => {
+      if (!dataset) return undefined;
+      const target = dataset.workflows.find(
+        (w) => w.id === targetWorkflowId || w.inventoryId === targetWorkflowId,
+      );
+      if (!target) return undefined;
+      return `/workflows/${wikiSlugFor(target)}/map`;
+    },
+    [dataset],
+  );
+
   return (
     <div className="fixed inset-0 flex flex-col bg-[#0c0c0e] text-zinc-200">
       {/* Minimal fixed top bar */}
@@ -157,6 +171,7 @@ export default function WorkflowMapPage() {
             stepId={stepId}
             onStepChange={handleStepChange}
             onNavigate={handleNavigate}
+            subWorkflowHref={subWorkflowHref}
           />
         )}
       </div>

--- a/packages/workflow-viewer/src/StationDetailPopup.tsx
+++ b/packages/workflow-viewer/src/StationDetailPopup.tsx
@@ -6,8 +6,14 @@ export interface StationDetailPopupProps {
   node: WorkflowNode;
   /** Called when the popup is dismissed (X, backdrop, or Esc). */
   onClose: () => void;
-  /** Follow a sub-workflow link. Host decides how to navigate. */
+  /** Follow a sub-workflow link (plain left-click → in-app navigate). */
   onOpenSubWorkflow?: (workflowId: string) => void;
+  /**
+   * Real href for a sub-workflow's page, so the name pill is a true `<a>` link:
+   * plain click navigates in-app, middle/ctrl/cmd-click opens a new tab natively.
+   * Returns undefined when the target isn't in the dataset.
+   */
+  subWorkflowHref?: ((workflowId: string) => string | undefined) | undefined;
 }
 
 type Tab = 'overview' | 'api' | 'code';
@@ -30,6 +36,7 @@ export function StationDetailPopup({
   node,
   onClose,
   onOpenSubWorkflow,
+  subWorkflowHref,
 }: StationDetailPopupProps) {
   const k = kindOf(node.kind);
   const isApi = node.kind === 'api-call' || Boolean(node.api);
@@ -115,7 +122,7 @@ export function StationDetailPopup({
         </div>
 
         <div className="twv-popup-body">
-          {tab === 'overview' && <OverviewTab node={node} onOpenSubWorkflow={onOpenSubWorkflow} k={k} />}
+          {tab === 'overview' && <OverviewTab node={node} onOpenSubWorkflow={onOpenSubWorkflow} subWorkflowHref={subWorkflowHref} k={k} />}
           {tab === 'api' && <ApiTab node={node} />}
           {tab === 'code' && <CodeTab node={node} hasCode={hasCode} />}
         </div>
@@ -155,10 +162,12 @@ function TabButton({
 function OverviewTab({
   node,
   onOpenSubWorkflow,
+  subWorkflowHref,
   k,
 }: {
   node: WorkflowNode;
   onOpenSubWorkflow?: ((workflowId: string) => void) | undefined;
+  subWorkflowHref?: ((workflowId: string) => string | undefined) | undefined;
   k: ReturnType<typeof kindOf>;
 }) {
   const empty =
@@ -181,18 +190,11 @@ function OverviewTab({
       {node.subWorkflowId && (
         <Section title="Sub-workflow">
           <div className="twv-subwf">
-            <code>{node.subWorkflowId}</code>
-            {node.subWorkflowResolves && onOpenSubWorkflow ? (
-              <button
-                type="button"
-                className="twv-subwf-link"
-                onClick={() => onOpenSubWorkflow(node.subWorkflowId!)}
-              >
-                Open map →
-              </button>
-            ) : (
-              <span className="twv-subwf-unresolved">(not in dataset)</span>
-            )}
+            <SubWorkflowPill
+              workflowId={node.subWorkflowId}
+              href={node.subWorkflowResolves ? subWorkflowHref?.(node.subWorkflowId) : undefined}
+              onOpen={onOpenSubWorkflow}
+            />
           </div>
         </Section>
       )}
@@ -299,6 +301,47 @@ function CodeTab({ node, hasCode }: { node: WorkflowNode; hasCode: boolean }) {
         </Section>
       )}
     </>
+  );
+}
+
+/**
+ * The sub-workflow NAME pill — a real link when the target resolves.
+ * Plain left-click navigates in-app (via `onOpen`); middle-click and
+ * ctrl/cmd/shift-click open a new tab natively (the `<a href>` default).
+ * Unresolvable targets render as a plain, non-clickable pill.
+ */
+function SubWorkflowPill({
+  workflowId,
+  href,
+  onOpen,
+}: {
+  workflowId: string;
+  href?: string | undefined;
+  onOpen?: ((workflowId: string) => void) | undefined;
+}) {
+  if (href) {
+    return (
+      <a
+        className="twv-subwf-pill"
+        href={href}
+        title={`Open ${workflowId}`}
+        onClick={(e) => {
+          // Let the browser handle modified / non-left clicks → new tab/window.
+          if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+          e.preventDefault();
+          onOpen?.(workflowId);
+        }}
+      >
+        <code>{workflowId}</code>
+        <span className="twv-subwf-arrow" aria-hidden="true">→</span>
+      </a>
+    );
+  }
+  return (
+    <span className="twv-subwf-pill twv-subwf-pill-disabled" title="Not in this dataset">
+      <code>{workflowId}</code>
+      <span className="twv-subwf-unresolved">(not in dataset)</span>
+    </span>
   );
 }
 

--- a/packages/workflow-viewer/src/WorkflowMap.tsx
+++ b/packages/workflow-viewer/src/WorkflowMap.tsx
@@ -17,6 +17,13 @@ export interface WorkflowMapProps {
   onStepChange?: (stepId: string | null) => void;
   /** Called when the user opens a sub-workflow (its map). */
   onNavigate?: (workflowId: string, stepId?: string) => void;
+  /**
+   * Real href for a sub-workflow's page, so the popup's name pill is a true
+   * `<a>` link (middle/ctrl-click opens a new tab). Returns undefined when the
+   * target isn't in the dataset. If omitted, the pill falls back to in-app
+   * navigation only.
+   */
+  subWorkflowHref?: (workflowId: string) => string | undefined;
 }
 
 function normalizeDataset(
@@ -43,6 +50,7 @@ export function WorkflowMap({
   stepId,
   onStepChange,
   onNavigate,
+  subWorkflowHref,
 }: WorkflowMapProps) {
   const workflows = useMemo(() => normalizeDataset(metadata), [metadata]);
 
@@ -209,6 +217,7 @@ export function WorkflowMap({
           node={selectedNode}
           onClose={handleClose}
           onOpenSubWorkflow={handleOpenSub}
+          subWorkflowHref={subWorkflowHref}
         />
       )}
     </div>

--- a/packages/workflow-viewer/src/styles.css
+++ b/packages/workflow-viewer/src/styles.css
@@ -212,25 +212,37 @@
 .twv-mono { font-family: ui-monospace, SFMono-Regular, monospace; font-size: 11px; }
 
 .twv-subwf { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
-.twv-subwf code {
-  font-size: 12px;
-  color: #93c5fd;
-  background: rgba(59, 130, 246, 0.1);
-  border: 1px solid rgba(96, 165, 250, 0.25);
-  padding: 2px 7px;
-  border-radius: 5px;
-  font-family: ui-monospace, SFMono-Regular, monospace;
-}
-.twv-subwf-link {
+/* The sub-workflow NAME pill is itself the link (an <a>): click navigates,
+   middle/ctrl-click opens a new tab. */
+.twv-subwf-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  text-decoration: none;
   background: rgba(59, 130, 246, 0.12);
   border: 1px solid rgba(96, 165, 250, 0.35);
-  color: #bfdbfe;
-  font-size: 12px;
-  padding: 3px 9px;
   border-radius: 6px;
+  padding: 4px 9px;
   cursor: pointer;
+  transition: background 0.12s ease, border-color 0.12s ease;
 }
-.twv-subwf-link:hover { background: rgba(59, 130, 246, 0.22); }
+.twv-subwf-pill code {
+  font-size: 12px;
+  color: #bfdbfe;
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+}
+.twv-subwf-arrow { color: #93c5fd; font-size: 13px; line-height: 1; }
+.twv-subwf-pill:hover { background: rgba(59, 130, 246, 0.24); border-color: rgba(96, 165, 250, 0.6); }
+.twv-subwf-pill:focus-visible { outline: 2px solid #60a5fa; outline-offset: 2px; }
+.twv-subwf-pill-disabled {
+  background: rgba(82, 82, 91, 0.12);
+  border-color: rgba(82, 82, 91, 0.3);
+  cursor: default;
+}
+.twv-subwf-pill-disabled code { color: #a1a1aa; }
 .twv-subwf-unresolved { font-size: 11px; color: #71717a; }
 
 /* Stack panel below the canvas on narrow screens. */


### PR DESCRIPTION
In the map popup, the sub-workflow reference was a plain pill + a separate "Open map →" button. Now the **name pill itself is a real `<a href>` link** to the sub-workflow's map:
- **plain click** → navigates in-app (SPA)
- **middle-click / ctrl·cmd·shift-click** → opens in a new tab (native anchor behavior)
- dropped the separate button; unresolvable targets render as a plain non-clickable pill

Threaded via a new `subWorkflowHref` prop (WorkflowMapPage → WorkflowMap → StationDetailPopup). Verified in-browser: the `context-gathering` pill is `<a href="/workflows/context-gathering/map">`, plain click navigated, href present for new-tab. Typecheck clean. Auto-deploys to wiki.tamma.dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)