### PR TITLE
feat(epic-32): 32-16 Per-Tenant Agent/Persona Enablement (TenantAgentEnablement)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/SeedTenantDefaultsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/SeedTenantDefaultsActivity.cs
@@ -2,38 +2,53 @@ using Elsa.Extensions;
 using Elsa.Workflows;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Tamma.Data;
 using Tamma.Data.Abstractions;
+using Tamma.Data.Seeders;
 
 namespace Tamma.Activities.TenantLifecycle;
 
 /// <summary>
-/// Step 5 of <c>CreateTenantWorkflow</c>. Seeds the new tenant database
-/// with any default rows the application needs at first boot. The current
-/// build has nothing tenant-resident that requires seeding (default
-/// system prompts live in the CP <c>prompt_overrides</c> resolution
-/// chain, default sanitization rules ship as code, etc.) so the activity
-/// is a structural placeholder that:
+/// Step 7 of <c>CreateTenantWorkflow</c>. Seeds the new tenant with any default
+/// rows the application needs at first boot:
 ///
 /// <list type="bullet">
 ///   <item><description>Round-trips a no-op SELECT against the tenant
 ///     connection so we have a live-fire smoke test that the migration
 ///     left a usable database behind.</description></item>
-///   <item><description>Logs the round-trip latency for the dashboard.</description></item>
+///   <item><description><b>Story 32-16 (AC10).</b> Seeds the CP-resident
+///     per-tenant agent enablement: the platform <c>DefaultPersonaName</c>
+///     persona is enabled for the freshly provisioned tenant so its catalog is
+///     usable out of the box (enablement is otherwise default-deny for public
+///     personas). This closes the SaaS half of AC10 — the single-user half is
+///     wired in <c>EnsurePersonalTenantMiddleware</c>. Insert-missing-only +
+///     best-effort/non-fatal: a seed failure must NOT abort tenant
+///     creation.</description></item>
 /// </list>
 ///
-/// <para>When seeders accrete (per-tenant default budget config, per-tenant
+/// <para>When more seeders accrete (per-tenant default budget config, per-tenant
 /// default convention starter, etc.), they go inside this activity rather
 /// than as a chain of mini-activities — the workflow shape stays stable.</para>
 /// </summary>
 [Activity(
     "Tamma.TenantLifecycle",
     "Seed Tenant Defaults",
-    "Connect to the new tenant DB and write any default rows (placeholder today).",
+    "Connect to the new tenant DB, smoke-test it, and seed default rows (incl. default-persona enablement).",
     Kind = ActivityKind.Task)]
 public sealed class SeedTenantDefaultsActivity : TenantLifecycleActivity
 {
+    /// <summary>Config key for the platform default persona handle (Story 32-15).
+    /// Kept as a literal because <c>Tamma.Activities</c> cannot reference
+    /// <c>Tamma.Api</c>'s <c>DefaultPersonaOptions.SectionPath</c>.</summary>
+    private const string DefaultPersonaConfigKey = "Tamma:Agents:DefaultPersonaName";
+
+    /// <summary>Matches <c>DefaultPersonaOptions.DefaultPersonaName</c>'s default.</summary>
+    private const string FallbackDefaultPersonaName = "claude";
+
     public override string StepName => "seed-defaults";
 
     [Input(Description = "Per-tenant connection string (same value used by the migrate step).")]
@@ -53,22 +68,66 @@ public sealed class SeedTenantDefaultsActivity : TenantLifecycleActivity
         // tenant role. If the migration step left the database in an
         // unhealthy state, we surface the error here as part of the
         // create flow rather than at the first end-user request.
-        await using var conn = new Npgsql.NpgsqlConnection(cs);
-        await conn.OpenAsync(context.CancellationToken).ConfigureAwait(false);
-        await using var cmd = conn.CreateCommand();
-        cmd.CommandText = "SELECT 1;";
-        var result = await cmd.ExecuteScalarAsync(context.CancellationToken)
-            .ConfigureAwait(false);
-
-        if (result is not int ok || ok != 1)
+        await using (var conn = new Npgsql.NpgsqlConnection(cs))
         {
-            throw new InvalidOperationException(
-                $"SeedTenantDefaults: smoke-test SELECT 1 returned {result ?? "<null>"} "
-                + "for tenant " + tenantId);
+            await conn.OpenAsync(context.CancellationToken).ConfigureAwait(false);
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT 1;";
+            var result = await cmd.ExecuteScalarAsync(context.CancellationToken)
+                .ConfigureAwait(false);
+
+            if (result is not int ok || ok != 1)
+            {
+                throw new InvalidOperationException(
+                    $"SeedTenantDefaults: smoke-test SELECT 1 returned {result ?? "<null>"} "
+                    + "for tenant " + tenantId);
+            }
         }
 
         Logger?.LogInformation(
             "tenant.lifecycle.seed_defaults smoke_ok tenantId={TenantId}",
             tenantId);
+
+        // Story 32-16 (AC10) — seed the fresh SaaS tenant's default-persona
+        // enablement against the CONTROL PLANE (the enablement table is
+        // CP-resident in both modes), NOT the tenant schema. Best-effort/non-fatal.
+        var factory = context.GetRequiredService<IDbContextFactory<ControlPlaneDbContext>>();
+        var personaName = context.GetService<IConfiguration>()?[DefaultPersonaConfigKey]
+            ?? FallbackDefaultPersonaName;
+
+        await using var cpDb = await factory.CreateDbContextAsync(context.CancellationToken)
+            .ConfigureAwait(false);
+        await SeedTenantDefaultPersonaAsync(cpDb, personaName, tenantId, Logger, context.CancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Story 32-16 (AC10) — enable the platform default persona for a freshly
+    /// provisioned SaaS <paramref name="tenantId"/> (tenant-keyed CP enablement
+    /// row), insert-missing-only. <b>Best-effort/non-fatal</b>: a seed failure is
+    /// WARN-logged and swallowed so it cannot abort tenant creation — mirroring
+    /// how <c>EnsurePersonalTenantMiddleware</c> calls the seeder for the
+    /// single-user (user-keyed) path. Directly callable (no Elsa runtime) so the
+    /// wiring is unit-testable.
+    /// </summary>
+    public static async Task SeedTenantDefaultPersonaAsync(
+        ControlPlaneDbContext cpDb,
+        string defaultPersonaName,
+        Guid tenantId,
+        ILogger? logger = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await TenantEnablementSeeder.SeedDefaultPersonaAsync(
+                cpDb, defaultPersonaName, tenantId: tenantId, userId: null,
+                logger: logger, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex,
+                "tenant.lifecycle.seed_defaults default_persona_enablement_failed "
+                + "tenantId={TenantId} (non-fatal — tenant creation proceeds)", tenantId);
+        }
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/AgentEnablementDtos.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/AgentEnablementDtos.cs
@@ -1,0 +1,31 @@
+using Tamma.Api.Services.Agents;
+
+namespace Tamma.Api.Dtos.Agents;
+
+// Story 32-16 — request/response DTOs for the per-tenant agent/persona
+// enablement surface (/api/agents/.../enablement). Enablement = catalog
+// membership (which PUBLIC personas a tenant exposes). Distinct from the 32-2
+// role-selection DTOs in AgentRegistryDtos.cs.
+
+/// <summary>
+/// Body for <c>PUT /api/agents/{agentId}/enablement</c> — enable
+/// (<c>true</c>) or disable (<c>false</c>) a public persona for the calling
+/// principal's catalog.
+/// </summary>
+public sealed record SetEnablementRequest(bool Enabled);
+
+/// <summary>
+/// One enablement-catalog projection for <c>GET</c>/<c>PUT</c> responses.
+/// <see cref="ImplicitlyEnabled"/> is true for own-private agents (cannot be
+/// toggled here). <see cref="PersonaName"/> is the persona/agent handle.
+/// </summary>
+public sealed record AgentEnablementResponse(
+    Guid AgentId,
+    string? PersonaName,
+    bool Enabled,
+    bool ImplicitlyEnabled)
+{
+    /// <summary>Project an <see cref="AgentEnablementState"/> onto the wire DTO.</summary>
+    public static AgentEnablementResponse From(AgentEnablementState state) => new(
+        state.AgentId, state.PersonaName, state.Enabled, state.ImplicitlyEnabled);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs
@@ -661,6 +661,87 @@ public static class AgentEndpoints
         return Results.Ok(response);
     }
 
+    // -----------------------------------------------------------------------
+    // Story 32-16 — per-tenant agent/persona enablement (catalog membership)
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// GET <c>/api/agents/enablement</c> — the calling principal's enablement
+    /// catalog view: every visible public persona with its <c>enabled</c> flag,
+    /// plus own-private agents marked implicitly enabled. Reads are NOT gated —
+    /// any tenant member may read (the group's <c>MemberAccess</c> gate applies).
+    /// </summary>
+    public static async Task<IResult> ListEnablement(ITenantAgentEnablementService svc)
+    {
+        var states = await svc.ListAsync();
+        var response = states.Select(AgentEnablementResponse.From).ToList();
+        return Results.Ok(response);
+    }
+
+    /// <summary>
+    /// PUT <c>/api/agents/{agentId}/enablement</c> — enable (<c>{enabled:true}</c>)
+    /// or disable (<c>{enabled:false}</c>) a public persona for the calling
+    /// principal's catalog. Member-role callers are 403'd by the
+    /// <c>AgentManage</c> route policy before reaching here. A target the principal
+    /// cannot see → 404 (existence-leak-safe); disabling an own private/custom
+    /// agent → 409.
+    /// </summary>
+    public static async Task<IResult> SetEnablement(
+        Guid agentId,
+        SetEnablementRequest req,
+        ITenantAgentEnablementService svc)
+    {
+        try
+        {
+            var state = req.Enabled
+                ? await svc.EnableAsync(agentId)
+                : await svc.DisableAsync(agentId);
+            return Results.Ok(AgentEnablementResponse.From(state));
+        }
+        catch (TammaError ex) when (ex.Code == "AGENT.ENABLEMENT.NOT_FOUND")
+        {
+            // 404 (not 403) — never leak the existence of another tenant's agent.
+            return Results.NotFound(new { error = "agent_not_found", detail = ex.Message });
+        }
+        catch (TammaError ex) when (ex.Code == "AGENT.ENABLEMENT.PRIVATE_NOT_DISABLEABLE")
+        {
+            return Results.Conflict(new { error = "private_not_disableable", detail = ex.Message });
+        }
+        catch (TammaError ex)
+        {
+            return Results.BadRequest(new { error = ex.Code, detail = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// DELETE <c>/api/agents/{agentId}/enablement</c> — disable a public persona
+    /// for the calling principal's catalog (alias for
+    /// <c>PUT … {enabled:false}</c>). Same 404/409 discipline as
+    /// <see cref="SetEnablement"/>.
+    /// </summary>
+    public static async Task<IResult> DisableEnablement(
+        Guid agentId,
+        ITenantAgentEnablementService svc)
+    {
+        try
+        {
+            var state = await svc.DisableAsync(agentId);
+            return Results.Ok(AgentEnablementResponse.From(state));
+        }
+        catch (TammaError ex) when (ex.Code == "AGENT.ENABLEMENT.NOT_FOUND")
+        {
+            return Results.NotFound(new { error = "agent_not_found", detail = ex.Message });
+        }
+        catch (TammaError ex) when (ex.Code == "AGENT.ENABLEMENT.PRIVATE_NOT_DISABLEABLE")
+        {
+            return Results.Conflict(new { error = "private_not_disableable", detail = ex.Message });
+        }
+        catch (TammaError ex)
+        {
+            return Results.BadRequest(new { error = ex.Code, detail = ex.Message });
+        }
+    }
+
     /// <summary>
     /// POST <c>/api/agents/{id}/rollback</c> — rollback (AC 13): repoint the
     /// agent's active version at an EXISTING prior version (no new snapshot). The

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/AgentResolverServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/AgentResolverServiceCollectionExtensions.cs
@@ -34,6 +34,16 @@ public static class AgentResolverServiceCollectionExtensions
 
         services.AddScoped<IAgentRegistryService, AgentRegistryService>();
 
+        // Story 32-16 — per-tenant agent/persona enablement (catalog membership).
+        // ONE implementation backs BOTH the write/admin service AND the read-only
+        // reader seam 32-18 injects; register the reader against the same scoped
+        // instance so the gate and the API share one source of truth.
+        services.AddScoped<TenantAgentEnablementService>();
+        services.AddScoped<ITenantAgentEnablementService>(
+            sp => sp.GetRequiredService<TenantAgentEnablementService>());
+        services.AddScoped<ITenantAgentEnablementReader>(
+            sp => sp.GetRequiredService<TenantAgentEnablementService>());
+
         // Story 32-15 — the persona/public prompt seam over the Epic 27 store.
         services.AddScoped<IPersonaPromptResolver, PersonaPromptResolver>();
 

--- a/apps/tamma-elsa/src/Tamma.Api/Middleware/EnsurePersonalTenantMiddleware.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Middleware/EnsurePersonalTenantMiddleware.cs
@@ -1,11 +1,14 @@
 using System.Security.Claims;
+using Microsoft.Extensions.Options;
 using Tamma.Api.Auth;
 using System.Text.Json;
+using Tamma.Api.Services.Agents;
 using Tamma.Api.Services.PromptStore;
 using Tamma.Data;
 using Tamma.Data.Abstractions;
 using Tamma.Data.Entities;
 using Tamma.Data.Repositories;
+using Tamma.Data.Seeders;
 
 namespace Tamma.Api.Middleware;
 
@@ -172,6 +175,27 @@ public class EnsurePersonalTenantMiddleware(RequestDelegate next)
         var provisioning = context.RequestServices
             .GetRequiredService<ITenantProvisioningService>();
         await provisioning.ProvisionAsync(tenant.Id, context.RequestAborted);
+
+        // Story 32-16 (AC10) — seed the fresh single-user principal with the
+        // platform default persona enabled (insert-missing-only) so the catalog
+        // is usable out of the box. Single-user enablement is USER-keyed (the sole
+        // user is the principal), so seed by userId — not tenant.Id. Best-effort:
+        // a seed failure must not break first-login (the seeder is idempotent and
+        // a missing default persona is WARN-logged + skipped inside the seeder).
+        try
+        {
+            var cpDb = context.RequestServices.GetRequiredService<ControlPlaneDbContext>();
+            var personaName = context.RequestServices
+                .GetRequiredService<IOptions<DefaultPersonaOptions>>().Value.DefaultPersonaName;
+            await TenantEnablementSeeder.SeedDefaultPersonaAsync(
+                cpDb, personaName, tenantId: null, userId: userId, logger: logger,
+                cancellationToken: context.RequestAborted);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Failed to seed default-persona enablement for user {UserId} (non-fatal)", userId);
+        }
 
         try
         {

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -1835,6 +1835,18 @@ agentsV2.MapPost("/{id:guid}/rollback", AgentEndpoints.RollbackVersion)
 agentsV2.MapPut("/role-selections/{role}", AgentEndpoints.SelectForRole)
     .RequireAuthorization("AgentManage").RequireRateLimiting("ConfigWrite");
 
+// ── Story 32-16 — per-tenant agent/persona enablement (catalog membership) ──
+// GET (catalog view) inherits the group's MemberAccess gate — any member may
+// read. PUT/DELETE (enable/disable a public persona for THIS tenant's catalog)
+// are AgentManage (tenant_owner/tenant_admin → member 403). Public-catalog
+// management (creating/retiring personas) stays PlatformOwnerAccess and is NOT
+// in this group.
+agentsV2.MapGet("/enablement", AgentEndpoints.ListEnablement);
+agentsV2.MapPut("/{agentId:guid}/enablement", AgentEndpoints.SetEnablement)
+    .RequireAuthorization("AgentManage").RequireRateLimiting("ConfigWrite");
+agentsV2.MapDelete("/{agentId:guid}/enablement", AgentEndpoints.DisableEnablement)
+    .RequireAuthorization("AgentManage").RequireRateLimiting("ConfigWrite");
+
 // ── Prompts ──
 // CLAUDE.md "Prompt Store Architecture > API" defines /defaults as the canonical
 // read-only system-default URL. Both /system (legacy TS naming) and /defaults
@@ -2139,6 +2151,7 @@ using (var scope = app.Services.CreateScope())
                 DROP TABLE IF EXISTS
                     admin_impersonations,
                     agents, agent_versions, agent_role_selections,
+                    tenant_agent_enablements,
                     audit_records, audit_projector_cursor,
                     billing_customers, billing_plan_prices,
                     alert_delivery_attempts, alert_channels, alerts,

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentEnablementEventTypes.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentEnablementEventTypes.cs
@@ -1,0 +1,16 @@
+namespace Tamma.Api.Services.Agents;
+
+/// <summary>
+/// Story 32-16 — DCB event-type constants for the per-tenant agent/persona
+/// enablement surface (pattern <c>AGGREGATE.ACTION.STATUS</c>, per CLAUDE.md
+/// "Event Types"). Kept here as the single source so service code never
+/// hand-types a literal that could drift from the audit/projector expectations.
+/// </summary>
+public static class AgentEnablementEventTypes
+{
+    /// <summary>A principal enabled a public persona for its tenant's catalog.</summary>
+    public const string Enabled = "AGENT.ENABLED.SUCCESS";
+
+    /// <summary>A principal disabled a public persona from its tenant's catalog.</summary>
+    public const string Disabled = "AGENT.DISABLED.SUCCESS";
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/ITenantAgentEnablementReader.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/ITenantAgentEnablementReader.cs
@@ -1,0 +1,47 @@
+namespace Tamma.Api.Services.Agents;
+
+/// <summary>
+/// Story 32-16 — the READ-ONLY enablement seam (ISP split). This is the seam the
+/// sibling story <b>32-18</b> injects and consumes to GATE selection/resolution
+/// and to resolve the enabled default — it never touches the write methods on
+/// <see cref="ITenantAgentEnablementService"/>.
+///
+/// <para>Enablement = <i>catalog membership</i> (which PUBLIC personas a principal
+/// exposes). Own private/custom agents are implicitly enabled (no row required).
+/// A public persona is enabled iff an enablement row with <c>Enabled = true</c>
+/// exists — default-deny otherwise (the seeded-default carve-out keeps a fresh
+/// tenant usable; the resolve-time fail-loud lives in 32-18).</para>
+///
+/// <para>All methods are async and take an explicit <see cref="Principal"/> so the
+/// consumer (32-18) passes its already-resolved principal; the write methods on
+/// the extending service derive the principal from the ambient request.</para>
+/// </summary>
+public interface ITenantAgentEnablementReader
+{
+    /// <summary>
+    /// True iff the agent is part of the principal's usable catalog: an own
+    /// private/custom agent ⇒ implicitly <c>true</c> (no row required); a public
+    /// persona ⇒ an enablement row with <c>Enabled = true</c> exists. An absent or
+    /// disabled row for a public persona ⇒ <c>false</c> (default-deny). A target
+    /// that is neither public nor the principal's own private ⇒ <c>false</c>. This
+    /// is the gate 32-18 calls from <c>CanUse</c> / <c>SelectForRoleAsync</c> /
+    /// <c>ResolveUsableAgentAsync</c>.
+    /// </summary>
+    Task<bool> IsEnabledForPrincipalAsync(Guid agentId, Principal principal, CancellationToken ct = default);
+
+    /// <summary>
+    /// The set of PUBLIC agent ids enabled for the principal — for 32-18's
+    /// <c>ListVisibleAsync</c> (<c>enabled(public) ∪ own-private</c>). Excludes
+    /// disabled rows, no-row publics, private ids, and any persona that is no
+    /// longer a live (active, public) agent.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> ListEnabledPublicAgentIdsAsync(Principal principal, CancellationToken ct = default);
+
+    /// <summary>
+    /// The principal's enabled DEFAULT persona id: the configured
+    /// <c>DefaultPersonaName</c> (Story 32-15) if it is enabled, else the single
+    /// enabled persona if unambiguous, else <c>null</c>. 32-18 CONSUMES this for
+    /// <c>GetSystemDefaultPublicAsync</c> — it never redefines it.
+    /// </summary>
+    Task<Guid?> GetEnabledDefaultPersonaIdAsync(Principal principal, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/ITenantAgentEnablementService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/ITenantAgentEnablementService.cs
@@ -1,0 +1,57 @@
+namespace Tamma.Api.Services.Agents;
+
+/// <summary>
+/// Story 32-16 — the WRITE/ADMIN enablement service. Extends the read seam
+/// (<see cref="ITenantAgentEnablementReader"/>) with the enable/disable/list
+/// surface that backs <c>PUT/DELETE/GET /api/agents/.../enablement</c>. ONE
+/// implementation (<see cref="TenantAgentEnablementService"/>) implements both
+/// interfaces; 32-18 depends only on the reader and never sees these methods.
+///
+/// <para>The write methods derive the principal from the ambient request
+/// (<c>ITammaModeProvider</c> + <c>ITenantContext</c>/<c>ClaimsPrincipal</c>):
+/// SaaS ⇒ <c>TenantId</c>; single-user ⇒ <c>UserId</c>. They validate the target
+/// is in (public ∪ own-private) and emit exactly one DCB event per successful
+/// write.</para>
+/// </summary>
+public interface ITenantAgentEnablementService : ITenantAgentEnablementReader
+{
+    /// <summary>
+    /// Enable a public persona for the current principal: idempotent upsert
+    /// setting <c>Enabled = true</c>; emits <c>AGENT.ENABLED.SUCCESS</c>.
+    /// Validates the target ∈ (public ∪ own-private) — a cross-scope/non-existent
+    /// target throws <see cref="Tamma.Core.TammaError"/>
+    /// <c>AGENT.ENABLEMENT.NOT_FOUND</c> (mapped to 404, existence-leak-safe).
+    /// Enabling an own private/custom agent is a no-op confirm (implicitly
+    /// enabled) with no row and no event.
+    /// </summary>
+    Task<AgentEnablementState> EnableAsync(Guid agentId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Disable a public persona for the current principal: sets the row's
+    /// <c>Enabled = false</c> (default-deny removes it from the usable set);
+    /// emits <c>AGENT.DISABLED.SUCCESS</c>. Disabling an OWN private/custom agent
+    /// throws <c>AGENT.ENABLEMENT.PRIVATE_NOT_DISABLEABLE</c> (mapped to 409) — it
+    /// is implicitly enabled by authorship and is removed via archive (32-2), not
+    /// here. A cross-scope/non-existent target ⇒ 404.
+    /// </summary>
+    Task<AgentEnablementState> DisableAsync(Guid agentId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Catalog view: every visible public persona with its enabled flag, plus the
+    /// principal's own-private agents (marked implicitly enabled). Any member may
+    /// read (reads are not gated).
+    /// </summary>
+    Task<IReadOnlyList<AgentEnablementState>> ListAsync(CancellationToken ct = default);
+}
+
+/// <summary>
+/// Story 32-16 — one row of the enablement catalog view. <see cref="PersonaName"/>
+/// is the public persona handle (or the private agent's name);
+/// <see cref="ImplicitlyEnabled"/> is true for own-private agents (which cannot be
+/// toggled via the enablement API).
+/// </summary>
+public sealed record AgentEnablementState(
+    Guid AgentId,
+    string? PersonaName,
+    bool Enabled,
+    bool ImplicitlyEnabled);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/TenantAgentEnablementService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/TenantAgentEnablementService.cs
@@ -283,6 +283,18 @@ public sealed class TenantAgentEnablementService : ITenantAgentEnablementService
     /// <paramref name="enabled"/> flag. Idempotent: re-running with the same flag
     /// touches the same single row (no duplicate). Returns whether a row was
     /// created plus the persisted row.
+    ///
+    /// <para><b>Concurrent-insert race.</b> Two concurrent first-time enable calls
+    /// for the same <c>(principal, agentId)</c> both read <c>null</c>; one INSERT
+    /// wins, the loser hits the unique <c>(TenantId, UserId, AgentId)</c> violation
+    /// as a <see cref="DbUpdateException"/>. We catch the Postgres unique-violation
+    /// (scoped precisely to <see cref="Npgsql.PostgresErrorCodes.UniqueViolation"/>,
+    /// same as <see cref="AgentSelectionRepository"/> /
+    /// <c>AgentRepository.PublishVersionAsync</c>), detach the orphaned insert,
+    /// re-read the now-present row, and UPDATE it. Enablement is idempotent:
+    /// last-writer-wins is the correct outcome — without this the loser would
+    /// throw an unhandled <see cref="DbUpdateException"/> (a 500, since it is not a
+    /// <c>TammaError</c>), contradicting the "idempotent" contract.</para>
     /// </summary>
     private async Task<(bool Created, TenantAgentEnablement Row)> UpsertEnabledAsync(
         Principal principal, Guid agentId, bool enabled, CancellationToken ct)
@@ -313,9 +325,32 @@ public sealed class TenantAgentEnablementService : ITenantAgentEnablementService
             UpdatedBy = actingUser,
         };
         _db.TenantAgentEnablements.Add(row);
-        await _db.SaveChangesAsync(ct);
-        return (true, row);
+
+        try
+        {
+            await _db.SaveChangesAsync(ct);
+            return (true, row);
+        }
+        catch (DbUpdateException ex) when (IsUniqueViolation(ex))
+        {
+            // We lost a first-time-insert race; the winner's row now exists.
+            // Detach our orphaned insert, re-read the winner, and UPDATE it.
+            _db.Entry(row).State = EntityState.Detached;
+            var winner = await FindRowAsync(principal, agentId, ct)
+                ?? throw new InvalidOperationException(
+                    "TenantAgentEnablementService upsert hit a unique-violation but the "
+                    + "conflicting enablement row could not be re-read.");
+            winner.Enabled = enabled;
+            winner.UpdatedAt = DateTime.UtcNow;
+            winner.UpdatedBy = actingUser;
+            await _db.SaveChangesAsync(ct);
+            return (false, winner);
+        }
     }
+
+    private static bool IsUniqueViolation(DbUpdateException ex)
+        => ex.InnerException is Npgsql.PostgresException pg &&
+           pg.SqlState == Npgsql.PostgresErrorCodes.UniqueViolation;
 
     private Task<TenantAgentEnablement?> FindRowAsync(Principal principal, Guid agentId, CancellationToken ct)
         => _db.TenantAgentEnablements.FirstOrDefaultAsync(

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/TenantAgentEnablementService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/TenantAgentEnablementService.cs
@@ -1,0 +1,400 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Tamma.Api.Auth;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Core;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Agents;
+
+/// <summary>
+/// Story 32-16 — default <see cref="ITenantAgentEnablementService"/> (and
+/// therefore <see cref="ITenantAgentEnablementReader"/>). Owns per-tenant
+/// agent/persona ENABLEMENT (catalog membership). Reads/writes the CP-resident
+/// <c>tenant_agent_enablements</c> table directly (CP-resident in BOTH modes),
+/// validates targets against the public <see cref="Agent"/> catalog (∪ the
+/// principal's own-private agents), and emits the DCB enablement events.
+///
+/// <para>The process mode (<see cref="ITammaModeProvider"/>) settles the
+/// principal: SaaS ⇒ ambient tenant id; single-user ⇒ the calling user id —
+/// exactly one of <c>(TenantId, UserId)</c> per the entity XOR.</para>
+///
+/// <para><b>Boundary (32-18).</b> This service ships the reader PRIMITIVES; it
+/// does NOT wire the gate into the registry/resolver. <c>CanUse</c> →
+/// <c>IsEnabledForPrincipal</c> and the enablement-aware
+/// <c>SelectForRoleAsync</c>/<c>ResolveUsableAgentAsync</c>/<c>ListVisibleAsync</c>/
+/// <c>GetSystemDefaultPublicAsync</c> are sibling story 32-18, which injects
+/// <see cref="ITenantAgentEnablementReader"/>.</para>
+/// </summary>
+public sealed class TenantAgentEnablementService : ITenantAgentEnablementService
+{
+    private const string WorkflowVersion = "1.0.0";
+
+    private readonly ControlPlaneDbContext _db;
+    private readonly IAgentRepository _agents;
+    private readonly IEventRepository _events;
+    private readonly ITammaModeProvider _mode;
+    private readonly ITenantContext _tenantContext;
+    private readonly IHttpContextAccessor _httpContext;
+    private readonly DefaultPersonaOptions _defaultPersona;
+    private readonly ILogger<TenantAgentEnablementService>? _logger;
+
+    public TenantAgentEnablementService(
+        ControlPlaneDbContext db,
+        IAgentRepository agents,
+        IEventRepository events,
+        ITammaModeProvider mode,
+        ITenantContext tenantContext,
+        IHttpContextAccessor httpContext,
+        IOptions<DefaultPersonaOptions>? defaultPersona = null,
+        ILogger<TenantAgentEnablementService>? logger = null)
+    {
+        _db = db;
+        _agents = agents;
+        _events = events;
+        _mode = mode;
+        _tenantContext = tenantContext;
+        _httpContext = httpContext;
+        _defaultPersona = defaultPersona?.Value ?? new DefaultPersonaOptions();
+        _logger = logger;
+    }
+
+    // ── write/admin surface ──
+
+    /// <inheritdoc />
+    public async Task<AgentEnablementState> EnableAsync(Guid agentId, CancellationToken ct = default)
+    {
+        var principal = ResolvePrincipal();
+        var agent = await ResolveVisibleAsync(agentId, principal, ct);
+        if (agent is null)
+        {
+            throw NotFound(agentId);
+        }
+
+        // Own private/custom agent ⇒ implicitly enabled by authorship. Enabling is
+        // a no-op confirm — no row, no event.
+        if (agent.Visibility == AgentVisibility.Private)
+        {
+            _logger?.LogInformation(
+                "agent.enablement.enable_private_noop agentId={AgentId} mode={Mode} — "
+                + "own private/custom agents are implicitly enabled",
+                agentId, ModeWire());
+            return new AgentEnablementState(agent.Id, agent.Name, Enabled: true, ImplicitlyEnabled: true);
+        }
+
+        var (created, row) = await UpsertEnabledAsync(principal, agentId, enabled: true, ct);
+
+        _logger?.LogInformation(
+            "agent.enablement.enabled agentId={AgentId} personaName={PersonaName} mode={Mode} created={Created}",
+            agentId, agent.Name, ModeWire(), created);
+
+        await AppendEventAsync(AgentEnablementEventTypes.Enabled, agent, principal, ct);
+        return new AgentEnablementState(agent.Id, agent.Name, Enabled: row.Enabled, ImplicitlyEnabled: false);
+    }
+
+    /// <inheritdoc />
+    public async Task<AgentEnablementState> DisableAsync(Guid agentId, CancellationToken ct = default)
+    {
+        var principal = ResolvePrincipal();
+        var agent = await ResolveVisibleAsync(agentId, principal, ct);
+        if (agent is null)
+        {
+            throw NotFound(agentId);
+        }
+
+        // Disabling an own private/custom agent is rejected (409). Implicitly
+        // enabled by authorship; remove via archive (32-2), not here.
+        if (agent.Visibility == AgentVisibility.Private)
+        {
+            _logger?.LogWarning(
+                "agent.enablement.disable_private_rejected agentId={AgentId} mode={Mode} — "
+                + "own private/custom agents are implicitly enabled (remove via archive, 32-2)",
+                agentId, ModeWire());
+            throw new TammaError(
+                "AGENT.ENABLEMENT.PRIVATE_NOT_DISABLEABLE",
+                $"Agent '{agentId}' is an own private/custom agent — implicitly enabled by "
+                + "authorship and cannot be disabled via the enablement API (archive it instead).",
+                new Dictionary<string, object?> { ["agentId"] = agentId },
+                retryable: false,
+                severity: TammaErrorSeverity.Medium);
+        }
+
+        var (_, row) = await UpsertEnabledAsync(principal, agentId, enabled: false, ct);
+
+        _logger?.LogInformation(
+            "agent.enablement.disabled agentId={AgentId} personaName={PersonaName} mode={Mode}",
+            agentId, agent.Name, ModeWire());
+
+        await AppendEventAsync(AgentEnablementEventTypes.Disabled, agent, principal, ct);
+        return new AgentEnablementState(agent.Id, agent.Name, Enabled: row.Enabled, ImplicitlyEnabled: false);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<AgentEnablementState>> ListAsync(CancellationToken ct = default)
+    {
+        var principal = ResolvePrincipal();
+        var visible = await _agents.ListVisibleAsync(principal.TenantId, principal.UserId, ct);
+        var live = visible.Where(a => a.Status == AgentStatus.Active).ToList();
+
+        var enabledPublicIds = await EnabledPublicRowIdsAsync(principal, ct);
+
+        var states = live
+            .Select(a => a.Visibility == AgentVisibility.Public
+                ? new AgentEnablementState(a.Id, a.Name, enabledPublicIds.Contains(a.Id), ImplicitlyEnabled: false)
+                : new AgentEnablementState(a.Id, a.Name, Enabled: true, ImplicitlyEnabled: true))
+            .OrderBy(s => s.PersonaName, StringComparer.Ordinal)
+            .ToList();
+
+        _logger?.LogInformation(
+            "agent.enablement.list_requested mode={Mode} enabled={Enabled} disabled={Disabled}",
+            ModeWire(),
+            states.Count(s => s.Enabled),
+            states.Count(s => !s.Enabled));
+
+        return states;
+    }
+
+    // ── read seam (consumed by 32-18) ──
+
+    /// <inheritdoc />
+    public async Task<bool> IsEnabledForPrincipalAsync(
+        Guid agentId, Principal principal, CancellationToken ct = default)
+    {
+        var agent = await _agents.GetByIdAsync(agentId, ct);
+        if (agent is null || agent.Status != AgentStatus.Active)
+        {
+            _logger?.LogDebug("agent.enablement.is_enabled branch=absent_or_retired agentId={AgentId}", agentId);
+            return false;
+        }
+
+        // Own private/custom agent ⇒ implicitly enabled (no row required).
+        if (agent.Visibility == AgentVisibility.Private)
+        {
+            var owns = (principal.TenantId is Guid tid && agent.OwnerTenantId == tid)
+                       || (principal.UserId is Guid uid && agent.OwnerUserId == uid);
+            _logger?.LogDebug(
+                "agent.enablement.is_enabled branch=implicit_private agentId={AgentId} owns={Owns}",
+                agentId, owns);
+            return owns;
+        }
+
+        // Public persona ⇒ enabled iff a row with Enabled=true exists.
+        var enabled = await EnabledRowExistsAsync(principal, agentId, ct);
+        _logger?.LogDebug(
+            "agent.enablement.is_enabled branch=public agentId={AgentId} enabled={Enabled}",
+            agentId, enabled);
+        return enabled;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<Guid>> ListEnabledPublicAgentIdsAsync(
+        Principal principal, CancellationToken ct = default)
+    {
+        var ids = await EnabledPublicRowIdsAsync(principal, ct);
+        return ids.ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task<Guid?> GetEnabledDefaultPersonaIdAsync(
+        Principal principal, CancellationToken ct = default)
+    {
+        var enabledIds = await EnabledPublicRowIdsAsync(principal, ct);
+        if (enabledIds.Count == 0)
+        {
+            _logger?.LogDebug("agent.enablement.default_persona outcome=none mode={Mode}", ModeWire());
+            return null;
+        }
+
+        // Configured default persona, if it is one of the enabled set.
+        var configured = await _agents.GetPublicByNameAsync(_defaultPersona.DefaultPersonaName, ct);
+        if (configured is not null
+            && configured.Status == AgentStatus.Active
+            && enabledIds.Contains(configured.Id))
+        {
+            _logger?.LogDebug(
+                "agent.enablement.default_persona outcome=configured personaName={PersonaName} agentId={AgentId}",
+                configured.Name, configured.Id);
+            return configured.Id;
+        }
+
+        // Else the single enabled persona, if unambiguous.
+        if (enabledIds.Count == 1)
+        {
+            var only = enabledIds.Single();
+            _logger?.LogDebug("agent.enablement.default_persona outcome=single agentId={AgentId}", only);
+            return only;
+        }
+
+        _logger?.LogDebug(
+            "agent.enablement.default_persona outcome=ambiguous count={Count} mode={Mode}",
+            enabledIds.Count, ModeWire());
+        return null;
+    }
+
+    // ── helpers ──
+
+    /// <summary>The calling principal derived from the process mode.</summary>
+    private Principal ResolvePrincipal()
+        => _mode.Mode == TammaMode.SaaS
+            ? Principal.ForTenant(_tenantContext.TenantId)
+            : Principal.ForUser(_httpContext.HttpContext?.User?.GetUserId());
+
+    private Guid? CurrentUserId() => _httpContext.HttpContext?.User?.GetUserId();
+
+    private string ModeWire() => _mode.Mode == TammaMode.SaaS ? "saas" : "single-user";
+
+    /// <summary>
+    /// Resolve an agent the principal may SEE for an enablement write: any public
+    /// agent (active), or a private agent owned by the principal's scope. Returns
+    /// null for a non-existent id, an archived id, OR a cross-scope private id
+    /// (no existence leak).
+    /// </summary>
+    private async Task<Agent?> ResolveVisibleAsync(Guid agentId, Principal principal, CancellationToken ct)
+    {
+        var agent = await _agents.GetByIdAsync(agentId, ct);
+        if (agent is null || agent.Status != AgentStatus.Active)
+        {
+            return null;
+        }
+        if (agent.Visibility == AgentVisibility.Public)
+        {
+            return agent;
+        }
+        var owns = (principal.TenantId is Guid tid && agent.OwnerTenantId == tid)
+                   || (principal.UserId is Guid uid && agent.OwnerUserId == uid);
+        return owns ? agent : null;
+    }
+
+    private static TammaError NotFound(Guid agentId)
+        => new(
+            "AGENT.ENABLEMENT.NOT_FOUND",
+            $"Agent '{agentId}' is not enableable (not public and not owned by the caller).",
+            new Dictionary<string, object?> { ["agentId"] = agentId },
+            retryable: false,
+            severity: TammaErrorSeverity.Medium);
+
+    /// <summary>
+    /// Upsert the principal's enablement row for an agent to the given
+    /// <paramref name="enabled"/> flag. Idempotent: re-running with the same flag
+    /// touches the same single row (no duplicate). Returns whether a row was
+    /// created plus the persisted row.
+    /// </summary>
+    private async Task<(bool Created, TenantAgentEnablement Row)> UpsertEnabledAsync(
+        Principal principal, Guid agentId, bool enabled, CancellationToken ct)
+    {
+        var now = DateTime.UtcNow;
+        var actingUser = CurrentUserId();
+
+        var existing = await FindRowAsync(principal, agentId, ct);
+        if (existing is not null)
+        {
+            existing.Enabled = enabled;
+            existing.UpdatedAt = now;
+            existing.UpdatedBy = actingUser;
+            await _db.SaveChangesAsync(ct);
+            return (false, existing);
+        }
+
+        var row = new TenantAgentEnablement
+        {
+            Id = Guid.NewGuid(),
+            TenantId = principal.TenantId,
+            UserId = principal.UserId,
+            AgentId = agentId,
+            Enabled = enabled,
+            CreatedAt = now,
+            CreatedBy = actingUser,
+            UpdatedAt = now,
+            UpdatedBy = actingUser,
+        };
+        _db.TenantAgentEnablements.Add(row);
+        await _db.SaveChangesAsync(ct);
+        return (true, row);
+    }
+
+    private Task<TenantAgentEnablement?> FindRowAsync(Principal principal, Guid agentId, CancellationToken ct)
+        => _db.TenantAgentEnablements.FirstOrDefaultAsync(
+            r => r.TenantId == principal.TenantId
+                 && r.UserId == principal.UserId
+                 && r.AgentId == agentId,
+            ct);
+
+    private async Task<bool> EnabledRowExistsAsync(Principal principal, Guid agentId, CancellationToken ct)
+        => await _db.TenantAgentEnablements.AnyAsync(
+            r => r.TenantId == principal.TenantId
+                 && r.UserId == principal.UserId
+                 && r.AgentId == agentId
+                 && r.Enabled,
+            ct);
+
+    /// <summary>
+    /// The principal's enabled public agent ids, intersected with the LIVE public
+    /// catalog so a row pointing at a retired/deleted persona resolves out.
+    /// </summary>
+    private async Task<HashSet<Guid>> EnabledPublicRowIdsAsync(Principal principal, CancellationToken ct)
+    {
+        var enabledRowIds = await _db.TenantAgentEnablements
+            .Where(r => r.TenantId == principal.TenantId
+                        && r.UserId == principal.UserId
+                        && r.Enabled)
+            .Select(r => r.AgentId)
+            .ToListAsync(ct);
+
+        if (enabledRowIds.Count == 0)
+        {
+            return new HashSet<Guid>();
+        }
+
+        var rowSet = enabledRowIds.ToHashSet();
+
+        // Keep only ids that are still a live (active, public) agent.
+        var livePublic = await _db.Agents
+            .Where(a => a.Visibility == AgentVisibility.Public
+                        && a.Status == AgentStatus.Active
+                        && rowSet.Contains(a.Id))
+            .Select(a => a.Id)
+            .ToListAsync(ct);
+
+        return livePublic.ToHashSet();
+    }
+
+    private async Task AppendEventAsync(
+        string eventType, Agent agent, Principal principal, CancellationToken ct)
+    {
+        _ = ct;
+        var tags = new Dictionary<string, object?>
+        {
+            ["agentId"] = agent.Id.ToString(),
+            ["personaName"] = agent.Name,
+            ["mode"] = ModeWire(),
+        };
+        if (principal.TenantId is Guid tid) tags["tenantId"] = tid.ToString();
+        if (principal.UserId is Guid uid) tags["userId"] = uid.ToString();
+
+        await _events.AppendAsync(new DomainEvent
+        {
+            Id = Guid.NewGuid(),
+            Type = eventType,
+            // SaaS enablement events land in the tenant store (ambient TenantId);
+            // single-user enablement is a platform-feed row (TenantId null).
+            TenantId = principal.TenantId,
+            Tags = JsonSerializer.Serialize(tags),
+            Metadata = JsonSerializer.Serialize(new
+            {
+                workflowVersion = WorkflowVersion,
+                eventSource = "system",
+            }),
+            Data = JsonSerializer.Serialize(new Dictionary<string, object?>
+            {
+                ["agentId"] = agent.Id.ToString(),
+                ["personaName"] = agent.Name,
+            }),
+            CreatedAt = DateTime.UtcNow,
+        });
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
@@ -620,6 +620,16 @@ public class ControlPlaneDbContext : DbContext
     /// </summary>
     public DbSet<AgentRoleSelection> AgentRoleSelections => Set<AgentRoleSelection>();
 
+    /// <summary>
+    /// Story 32-16 — per-tenant agent/persona ENABLEMENT (catalog membership:
+    /// which PUBLIC personas a principal exposes). CP-resident in BOTH modes
+    /// (SaaS rows keyed by <c>TenantId</c>, single-user rows by <c>UserId</c>) —
+    /// it gates the CP-resident public agent catalog and is not a
+    /// <c>t_&lt;hex&gt;</c> tenant-private row. See
+    /// <see cref="Entities.TenantAgentEnablement"/>.
+    /// </summary>
+    public DbSet<TenantAgentEnablement> TenantAgentEnablements => Set<TenantAgentEnablement>();
+
     // ── Story 35-1 — billing foundation (Epic 35) ──
     //
     // The tenant→Stripe customer mapping + the slug→Stripe-ids catalog are
@@ -749,6 +759,12 @@ public class ControlPlaneDbContext : DbContext
         // shape on both, mirroring audit_records). fixedTenantId: null = the CP
         // build.
         TammaModelConfiguration.ConfigureAgentRoleSelections(modelBuilder, fixedTenantId: null);
+
+        // Story 32-16 — per-tenant agent/persona enablement (catalog membership).
+        // CP-resident in BOTH modes (gates the CP public agent catalog; keyed by
+        // tenant id / user id, not per t_<hex>) — configured ONLY here, never on
+        // the tenant context.
+        TammaModelConfiguration.ConfigureTenantAgentEnablements(modelBuilder);
 
         // Story 35-1 — billing customer mapping + Stripe catalog. CP-resident,
         // configured in the shared single source so the model graph + migration

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/TenantAgentEnablement.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/TenantAgentEnablement.cs
@@ -1,0 +1,67 @@
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 32-16 — per-tenant agent/persona ENABLEMENT (Epic 32 locked model rule
+/// 6 / design §3.3). Catalog membership: which PUBLIC personas a tenant exposes
+/// to its members. The tenant's usable set is
+/// <c>enabled(public) ∪ own-private</c>, not every public persona on the platform.
+///
+/// <para><b>Enablement vs selection.</b> This is <i>catalog membership</i> — which
+/// personas are part of this tenant's set. It is distinct from
+/// <see cref="AgentRoleSelection"/> (32-2), which is <i>role binding</i> — which
+/// (already-enabled) agent serves a given role. Enablement gates selection, never
+/// the reverse.</para>
+///
+/// <para><b>CP-resident in BOTH modes.</b> Unlike <see cref="AgentRoleSelection"/>
+/// (tenant-schema in SaaS, CP for single-user), this table is control-plane
+/// resident in <i>both</i> modes because it gates the CP-resident public
+/// <see cref="Agent"/> catalog and is keyed by tenant id (SaaS) / user id
+/// (single-user), not stored per <c>t_&lt;hex&gt;</c>. Hence it joins the
+/// <c>Program.cs</c> startup-reset DROP list and the
+/// <c>ControlPlaneDbContextModelTests</c> strict entity list.</para>
+///
+/// <para><b>Principal XOR + dual-keying</b> (mirrors <see cref="AgentRoleSelection"/>
+/// / <c>prompt_overrides</c>): exactly one of <see cref="TenantId"/> (SaaS) XOR
+/// <see cref="UserId"/> (single-user) is non-null — enforced by the
+/// <c>ck_tenant_agent_enablements_principal_xor</c> CHECK and the
+/// <c>UNIQUE NULLS NOT DISTINCT (TenantId, UserId, AgentId)</c> index. There is NO
+/// per-user enablement layer in SaaS (CLAUDE.md "no per-user override layer").</para>
+///
+/// <para><b>Default-deny for public personas.</b> Absent a row, a public persona
+/// is NOT enabled. Own private/custom agents are implicitly enabled by authorship
+/// (no row required). A fresh tenant is seeded with the platform default persona
+/// enabled (insert-missing-only) so it is usable out of the box.</para>
+/// </summary>
+public class TenantAgentEnablement
+{
+    public Guid Id { get; set; }
+
+    /// <summary>SaaS principal — set iff <see cref="UserId"/> is NULL.</summary>
+    public Guid? TenantId { get; set; }
+
+    /// <summary>single-user principal — set iff <see cref="TenantId"/> is NULL.</summary>
+    public Guid? UserId { get; set; }
+
+    /// <summary>
+    /// A public persona OR an own private/custom agent. Logical reference only —
+    /// public agents live in the CP catalog; no cross-schema DB FK is modelled.
+    /// The service validates the target is in (public ∪ own-private) at write time.
+    /// </summary>
+    public Guid AgentId { get; set; }
+
+    /// <summary>
+    /// True = part of the tenant's usable catalog. A disable sets this false. An
+    /// absent row for a public persona = not enabled (default-deny).
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+
+    /// <summary>User id that created the row (audit).</summary>
+    public Guid? CreatedBy { get; set; }
+
+    public DateTime UpdatedAt { get; set; }
+
+    /// <summary>User id that performed the most recent upsert (audit).</summary>
+    public Guid? UpdatedBy { get; set; }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260621232834_AddTenantAgentEnablements.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260621232834_AddTenantAgentEnablements.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.ControlPlane
 {
     [DbContext(typeof(ControlPlaneDbContext))]
-    partial class ControlPlaneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260621232834_AddTenantAgentEnablements")]
+    partial class AddTenantAgentEnablements
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260621232834_AddTenantAgentEnablements.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260621232834_AddTenantAgentEnablements.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.ControlPlane
+{
+    /// <inheritdoc />
+    public partial class AddTenantAgentEnablements : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "tenant_agent_enablements",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: true),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: true),
+                    AgentId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Enabled = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    UpdatedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_tenant_agent_enablements", x => x.Id);
+                    table.CheckConstraint("ck_tenant_agent_enablements_principal_xor", "(\"UserId\" IS NOT NULL AND \"TenantId\" IS NULL) OR (\"UserId\" IS NULL AND \"TenantId\" IS NOT NULL)");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_tenant_agent_enablements_TenantId_UserId_AgentId",
+                table: "tenant_agent_enablements",
+                columns: new[] { "TenantId", "UserId", "AgentId" },
+                unique: true)
+                .Annotation("Npgsql:NullsDistinct", false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "tenant_agent_enablements");
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Seeders/TenantEnablementSeeder.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Seeders/TenantEnablementSeeder.cs
@@ -1,0 +1,114 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Tamma.Data.Entities;
+
+namespace Tamma.Data.Seeders;
+
+/// <summary>
+/// Story 32-16 (AC10) — seeds a FRESH tenant (SaaS) or user (single-user) with
+/// the platform DEFAULT PERSONA enabled, so a brand-new principal has a usable
+/// catalog out of the box (enablement is otherwise default-deny for public
+/// personas). This is the <i>seeding hook</i>; the resolve-time fail-loud when a
+/// principal explicitly disables everything lives in sibling story 32-18.
+///
+/// <para><b>Insert-missing-only.</b> The seeder writes an enablement row for the
+/// default persona ONLY when the principal has NO existing row for it — it NEVER
+/// reverts an explicit disable (an <c>Enabled = false</c> row is left untouched).
+/// Re-running is a no-op. Mirrors <see cref="AgentEntitySeeder"/> /
+/// <see cref="ConventionStoreSeeder"/> insert-missing-only discipline.</para>
+///
+/// <para><b>CP-resident, both modes.</b> <c>tenant_agent_enablements</c> is
+/// control-plane resident in BOTH modes — SaaS rows keyed by <c>TenantId</c>,
+/// single-user rows by <c>UserId</c> (principal XOR). The seeder writes against
+/// <see cref="ControlPlaneDbContext"/> directly.</para>
+///
+/// <para>This seeder lives in <c>Tamma.Data</c> and cannot reference the
+/// <c>Tamma.Api</c> <c>DefaultPersonaOptions</c>, so the default persona handle
+/// is passed in (the caller binds <c>Tamma:Agents:DefaultPersonaName</c>). The
+/// default persona must already be seeded (Story 32-15) — this seeder MUST run
+/// AFTER <see cref="AgentEntitySeeder"/>; a missing/inactive default persona is
+/// WARN-logged and skipped (no half-seeded row).</para>
+/// </summary>
+public static class TenantEnablementSeeder
+{
+    /// <summary>
+    /// Enable the platform default persona for a fresh principal, insert-missing-only.
+    /// Exactly one of <paramref name="tenantId"/> (SaaS) / <paramref name="userId"/>
+    /// (single-user) must be non-null (principal XOR).
+    /// </summary>
+    /// <param name="context">The control-plane context.</param>
+    /// <param name="defaultPersonaName">The configured default persona handle
+    /// (<c>Tamma:Agents:DefaultPersonaName</c>, e.g. <c>claude</c>).</param>
+    /// <param name="tenantId">SaaS principal — set iff <paramref name="userId"/> is null.</param>
+    /// <param name="userId">single-user principal — set iff <paramref name="tenantId"/> is null.</param>
+    /// <param name="logger">Optional structured logger.</param>
+    /// <returns><c>true</c> when a new enablement row was inserted; <c>false</c>
+    /// when skipped (already present, or the default persona is unavailable).</returns>
+    public static async Task<bool> SeedDefaultPersonaAsync(
+        ControlPlaneDbContext context,
+        string defaultPersonaName,
+        Guid? tenantId,
+        Guid? userId,
+        ILogger? logger = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(defaultPersonaName);
+
+        if ((tenantId is null) == (userId is null))
+        {
+            throw new ArgumentException(
+                "Exactly one of tenantId / userId must be set (principal XOR).");
+        }
+
+        // The default persona must be a live (active, public) agent.
+        var persona = await context.Agents.FirstOrDefaultAsync(
+            a => a.Visibility == AgentVisibility.Public
+                 && a.Status == AgentStatus.Active
+                 && a.Name == defaultPersonaName,
+            cancellationToken);
+
+        if (persona is null)
+        {
+            logger?.LogWarning(
+                "agent.enablement.seed_default_missing personaName={PersonaName} tenantId={TenantId} userId={UserId} — "
+                + "configured default persona is not seeded/active; skipping seed (run AgentEntitySeeder first)",
+                defaultPersonaName, tenantId, userId);
+            return false;
+        }
+
+        // Insert-missing-only: skip if the principal already has ANY row for this
+        // persona (including an explicit disable — NEVER revert it).
+        var existing = await context.TenantAgentEnablements.AnyAsync(
+            r => r.TenantId == tenantId && r.UserId == userId && r.AgentId == persona.Id,
+            cancellationToken);
+
+        if (existing)
+        {
+            logger?.LogDebug(
+                "agent.enablement.seed_default_skip personaName={PersonaName} tenantId={TenantId} userId={UserId} — "
+                + "an enablement row already exists (never reverts an explicit disable)",
+                defaultPersonaName, tenantId, userId);
+            return false;
+        }
+
+        var now = DateTime.UtcNow;
+        context.TenantAgentEnablements.Add(new TenantAgentEnablement
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            UserId = userId,
+            AgentId = persona.Id,
+            Enabled = true,
+            CreatedAt = now,
+            UpdatedAt = now,
+        });
+        await context.SaveChangesAsync(cancellationToken);
+
+        logger?.LogInformation(
+            "agent.enablement.seed_default_applied personaName={PersonaName} agentId={AgentId} tenantId={TenantId} userId={UserId}",
+            defaultPersonaName, persona.Id, tenantId, userId);
+
+        return true;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
@@ -896,6 +896,52 @@ internal static class TammaModelConfiguration
     }
 
     /// <summary>
+    /// Story 32-16 — configure the <c>tenant_agent_enablements</c> table (which
+    /// PUBLIC personas a principal exposes in its usable catalog). CP-resident in
+    /// BOTH modes (it gates the CP-resident public <see cref="Agent"/> catalog and
+    /// is keyed by tenant id / user id, never per <c>t_&lt;hex&gt;</c>), so —
+    /// unlike <see cref="ConfigureAgentRoleSelections"/> — it is configured ONLY on
+    /// the CP context (no tenant-context variant).
+    ///
+    /// <para>The <c>ck_tenant_agent_enablements_principal_xor</c> CHECK ties
+    /// exactly one of (<c>UserId</c>, <c>TenantId</c>) to non-null (mirrors
+    /// <c>ck_agent_role_selections_principal_xor</c>). The unique index on
+    /// <c>(TenantId, UserId, AgentId)</c> uses NULLS NOT DISTINCT so the
+    /// (null, uid, agent) and (tid, null, agent) row spaces are disjoint and both
+    /// halves dedupe on null — one row per <c>(principal, agent)</c>.</para>
+    /// </summary>
+    public static void ConfigureTenantAgentEnablements(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<TenantAgentEnablement>(entity =>
+        {
+            entity.ToTable("tenant_agent_enablements", t =>
+            {
+                // Exactly one of user_id / tenant_id is non-null (mirrors
+                // ck_agent_role_selections_principal_xor).
+                t.HasCheckConstraint(
+                    "ck_tenant_agent_enablements_principal_xor",
+                    "(\"UserId\" IS NOT NULL AND \"TenantId\" IS NULL) " +
+                    "OR (\"UserId\" IS NULL AND \"TenantId\" IS NOT NULL)");
+            });
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+            entity.Property(e => e.AgentId).IsRequired();
+            entity.Property(e => e.Enabled).IsRequired();
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("now()");
+
+            // One row per (principal, agent). NULLS NOT DISTINCT (PG15+;
+            // production runs PG17) so a single (null, uid, agent) or
+            // (tid, null, agent) row is unique across the repeated NULL halves —
+            // same pattern as agent_role_selections / prompt_overrides.
+            entity.HasIndex(e => new { e.TenantId, e.UserId, e.AgentId })
+                .IsUnique()
+                .AreNullsDistinct(false)
+                .HasDatabaseName("IX_tenant_agent_enablements_TenantId_UserId_AgentId");
+        });
+    }
+
+    /// <summary>
     /// Story 35-1 — billing foundation entities. The tenant→Stripe customer
     /// mapping (<c>billing_customers</c>, unique <c>TenantId</c>) and the
     /// slug→Stripe-ids catalog (<c>billing_plan_prices</c>, unique

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentEnablementEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentEnablementEndpointsTests.cs
@@ -1,0 +1,271 @@
+using System.Collections.Concurrent;
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using Tamma.Api.Auth;
+using Tamma.Api.Dtos.Agents;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Services.Agents;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Agents;
+
+/// <summary>
+/// Story 32-16 — endpoint-level tests for the /api/agents enablement surface.
+/// Drives the <see cref="AgentEndpoints"/> handlers directly (the same delegates
+/// Program.cs maps) against a real Postgres testcontainer with the real
+/// enablement service. Covers enable/disable → 200, 404 unseen, 409
+/// disable-own-private, the list catalog view, and the RBAC contract (the
+/// <c>agents:manage</c> permission gate that backs the route's member-403).
+/// </summary>
+[TestFixture]
+public class AgentEnablementEndpointsTests
+{
+    private static readonly Guid TenantA = Guid.Parse("aaaaaaaa-3216-e9d0-3216-aaaaaaaaaaaa");
+    private static readonly Guid TenantB = Guid.Parse("bbbbbbbb-3216-e9d0-3216-bbbbbbbbbbbb");
+
+    private PostgreSqlContainer _postgres = null!;
+    private string _connectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("agent_enablement_ep_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _connectionString = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE tenant_agent_enablements, agent_versions, agents CASCADE;");
+    }
+
+    private ControlPlaneDbContext NewContext()
+        => new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseNpgsql(_connectionString).Options);
+
+    private const string Cfg = """{ "provider": "anthropic", "model": "claude-sonnet-4" }""";
+
+    private sealed record Stack(
+        TenantAgentEnablementService Service, AgentRepository Agents, ControlPlaneDbContext Ctx);
+
+    private Stack BuildStack(Guid tenantId)
+    {
+        var ctx = NewContext();
+        var events = new CapturingEvents();
+        var agents = new AgentRepository(ctx, events);
+        var tenantContext = new TenantContext();
+        tenantContext.SetTenantId(tenantId);
+        var http = new HttpContextAccessor { HttpContext = new DefaultHttpContext() };
+        var personaOptions = Options.Create(new DefaultPersonaOptions { DefaultPersonaName = "claude" });
+        var svc = new TenantAgentEnablementService(
+            ctx, agents, events, new StubMode(TammaMode.SaaS), tenantContext, http,
+            personaOptions, NullLogger<TenantAgentEnablementService>.Instance);
+        return new Stack(svc, agents, ctx);
+    }
+
+    private async Task<Agent> SeedPersonaAsync(AgentRepository repo, string name)
+        => await repo.CreateAsync(
+            new Agent { Name = name, Role = null, Visibility = AgentVisibility.Public }, Cfg, null, null);
+
+    private async Task<Agent> SeedTenantPrivateAsync(AgentRepository repo, Guid tenantId, string name)
+        => await repo.CreateAsync(
+            new Agent { Name = name, Role = "developer", Visibility = AgentVisibility.Private, OwnerTenantId = tenantId },
+            Cfg, null, null);
+
+    private static async Task<(int Status, JsonElement Body)> ExecuteAsync(IResult result)
+    {
+        var services = new ServiceCollection().AddLogging().AddOptions().BuildServiceProvider();
+        var ctx = new DefaultHttpContext
+        {
+            RequestServices = services,
+            Response = { Body = new MemoryStream() },
+        };
+        await result.ExecuteAsync(ctx);
+        ctx.Response.Body.Seek(0, SeekOrigin.Begin);
+        if (ctx.Response.Body.Length == 0)
+        {
+            return (ctx.Response.StatusCode, default);
+        }
+        using var doc = await JsonDocument.ParseAsync(ctx.Response.Body);
+        return (ctx.Response.StatusCode, doc.RootElement.Clone());
+    }
+
+    // ── PUT enable / disable ──
+
+    [Test]
+    public async Task SetEnablement_EnablePublicPersona_Returns200()
+    {
+        var s = BuildStack(TenantA);
+        await using (s.Ctx)
+        {
+            var claude = await SeedPersonaAsync(s.Agents, "claude");
+            var result = await AgentEndpoints.SetEnablement(claude.Id, new SetEnablementRequest(true), s.Service);
+            var (status, body) = await ExecuteAsync(result);
+            status.Should().Be(StatusCodes.Status200OK);
+            body.GetProperty("agentId").GetGuid().Should().Be(claude.Id);
+            body.GetProperty("enabled").GetBoolean().Should().BeTrue();
+            body.GetProperty("personaName").GetString().Should().Be("claude");
+        }
+    }
+
+    [Test]
+    public async Task SetEnablement_DisableViaFalse_Returns200()
+    {
+        var s = BuildStack(TenantA);
+        await using (s.Ctx)
+        {
+            var claude = await SeedPersonaAsync(s.Agents, "claude");
+            await s.Service.EnableAsync(claude.Id);
+            var result = await AgentEndpoints.SetEnablement(claude.Id, new SetEnablementRequest(false), s.Service);
+            var (status, body) = await ExecuteAsync(result);
+            status.Should().Be(StatusCodes.Status200OK);
+            body.GetProperty("enabled").GetBoolean().Should().BeFalse();
+        }
+    }
+
+    [Test]
+    public async Task SetEnablement_UnseenTarget_Returns404()
+    {
+        var s = BuildStack(TenantA);
+        await using (s.Ctx)
+        {
+            var foreign = await SeedTenantPrivateAsync(s.Agents, TenantB, "their-atlas");
+            var result = await AgentEndpoints.SetEnablement(foreign.Id, new SetEnablementRequest(true), s.Service);
+            var (status, body) = await ExecuteAsync(result);
+            status.Should().Be(StatusCodes.Status404NotFound);
+            body.GetProperty("error").GetString().Should().Be("agent_not_found");
+        }
+    }
+
+    [Test]
+    public async Task SetEnablement_DisableOwnPrivate_Returns409()
+    {
+        var s = BuildStack(TenantA);
+        await using (s.Ctx)
+        {
+            var atlas = await SeedTenantPrivateAsync(s.Agents, TenantA, "atlas");
+            var result = await AgentEndpoints.SetEnablement(atlas.Id, new SetEnablementRequest(false), s.Service);
+            var (status, body) = await ExecuteAsync(result);
+            status.Should().Be(StatusCodes.Status409Conflict);
+            body.GetProperty("error").GetString().Should().Be("private_not_disableable");
+        }
+    }
+
+    // ── DELETE disable ──
+
+    [Test]
+    public async Task DisableEnablement_PublicPersona_Returns200()
+    {
+        var s = BuildStack(TenantA);
+        await using (s.Ctx)
+        {
+            var claude = await SeedPersonaAsync(s.Agents, "claude");
+            await s.Service.EnableAsync(claude.Id);
+            var result = await AgentEndpoints.DisableEnablement(claude.Id, s.Service);
+            var (status, body) = await ExecuteAsync(result);
+            status.Should().Be(StatusCodes.Status200OK);
+            body.GetProperty("enabled").GetBoolean().Should().BeFalse();
+        }
+    }
+
+    [Test]
+    public async Task DisableEnablement_OwnPrivate_Returns409()
+    {
+        var s = BuildStack(TenantA);
+        await using (s.Ctx)
+        {
+            var atlas = await SeedTenantPrivateAsync(s.Agents, TenantA, "atlas");
+            var result = await AgentEndpoints.DisableEnablement(atlas.Id, s.Service);
+            var (status, _) = await ExecuteAsync(result);
+            status.Should().Be(StatusCodes.Status409Conflict);
+        }
+    }
+
+    // ── GET list ──
+
+    [Test]
+    public async Task ListEnablement_ReturnsCatalogView()
+    {
+        var s = BuildStack(TenantA);
+        await using (s.Ctx)
+        {
+            var claude = await SeedPersonaAsync(s.Agents, "claude");
+            await SeedPersonaAsync(s.Agents, "gemini");
+            await s.Service.EnableAsync(claude.Id);
+
+            var (status, body) = await ExecuteAsync(await AgentEndpoints.ListEnablement(s.Service));
+            status.Should().Be(StatusCodes.Status200OK);
+            var rows = body.EnumerateArray().ToList();
+            rows.Should().HaveCount(2);
+            rows.Single(r => r.GetProperty("personaName").GetString() == "claude")
+                .GetProperty("enabled").GetBoolean().Should().BeTrue();
+            rows.Single(r => r.GetProperty("personaName").GetString() == "gemini")
+                .GetProperty("enabled").GetBoolean().Should().BeFalse();
+        }
+    }
+
+    // ── RBAC contract (the agents:manage gate backing the route's member-403) ──
+
+    [Test]
+    public void EnablementWrites_GatedBy_AgentsManage_MemberDenied_AdminOwnerAllowed()
+    {
+        // The PUT/DELETE routes are .RequireAuthorization("AgentManage") =
+        // agents:manage. Prove the underlying permission excludes member and
+        // admits admin + owner (the route's member-403 contract, AC6).
+        Permissions.HasPermission("member", "agents:manage").Should().BeFalse(
+            "members cannot enable/disable — reads only");
+        Permissions.HasPermission("admin", "agents:manage").Should().BeTrue();
+        Permissions.HasPermission("owner", "agents:manage").Should().BeTrue();
+    }
+
+    private sealed class StubMode(TammaMode mode) : ITammaModeProvider
+    {
+        public TammaMode Mode { get; } = mode;
+    }
+
+    private sealed class CapturingEvents : IEventRepository
+    {
+        private readonly ConcurrentQueue<DomainEvent> _captured = new();
+        public Task<DomainEvent> AppendAsync(DomainEvent evt) { _captured.Enqueue(evt); return Task.FromResult(evt); }
+        public Task<DomainEvent?> GetByIdAsync(Guid id) => Task.FromResult<DomainEvent?>(null);
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit) =>
+            Task.FromResult(_captured.ToList());
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type) =>
+            Task.FromResult<DomainEvent?>(null);
+        public Task ClearAsync(Guid tenantId) => Task.CompletedTask;
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(
+            Guid? tenantId, string? type, int? issueNumber, int limit, int offset) =>
+            Task.FromResult(((IReadOnlyList<DomainEvent>)_captured.ToList(), _captured.Count));
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(
+            Guid tenantId, string? typePrefix, int limit, int offset) =>
+            Task.FromResult(((IReadOnlyList<DomainEvent>)_captured.ToList(), _captured.Count));
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/SeedTenantDefaultsActivityEnablementTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/SeedTenantDefaultsActivityEnablementTests.cs
@@ -1,0 +1,119 @@
+using System.Collections.Concurrent;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Activities.TenantLifecycle;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Agents;
+
+/// <summary>
+/// Story 32-16 (spec deviation #1 closure) — proves the SaaS fresh-tenant path
+/// (<see cref="SeedTenantDefaultsActivity"/>, Step 7 of <c>CreateTenantWorkflow</c>)
+/// seeds the platform <c>DefaultPersonaName</c> persona enabled for the freshly
+/// provisioned tenant — mirroring the single-user <c>FreshUser_…</c> seed wired
+/// in <c>EnsurePersonalTenantMiddleware</c>.
+///
+/// <para>The activity's <see cref="ActivityExecutionContext"/> requires the Elsa
+/// runtime, so (as with the other lifecycle activities) we exercise the
+/// directly-callable seed helper the activity delegates to —
+/// <see cref="SeedTenantDefaultsActivity.SeedTenantDefaultPersonaAsync"/> — against
+/// a real <see cref="ControlPlaneDbContext"/>.</para>
+/// </summary>
+[TestFixture]
+public class SeedTenantDefaultsActivityEnablementTests
+{
+    private static readonly Guid FreshTenant = Guid.Parse("aaaaaaaa-3216-5ac2-3216-aaaaaaaaaaaa");
+
+    private PostgreSqlContainer _postgres = null!;
+    private string _connectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("seed_tenant_defaults_enablement_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _connectionString = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE tenant_agent_enablements, agent_versions, agents CASCADE;");
+    }
+
+    private ControlPlaneDbContext NewContext()
+        => new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseNpgsql(_connectionString).Options);
+
+    private const string Cfg = """{ "provider": "anthropic", "model": "claude-sonnet-4" }""";
+
+    private async Task<Agent> SeedClaudeAsync(ControlPlaneDbContext ctx)
+        => await new AgentRepository(ctx, new NoopEvents()).CreateAsync(
+            new Agent { Name = "claude", Role = null, Visibility = AgentVisibility.Public }, Cfg, null, null);
+
+    [Test]
+    public async Task FreshSaasTenant_GetsDefaultPersonaEnabled_TenantKeyed()
+    {
+        await using var ctx = NewContext();
+        var claude = await SeedClaudeAsync(ctx);
+
+        await SeedTenantDefaultsActivity.SeedTenantDefaultPersonaAsync(
+            ctx, "claude", FreshTenant, NullLogger.Instance);
+
+        var row = await ctx.TenantAgentEnablements.SingleAsync(r => r.TenantId == FreshTenant);
+        row.AgentId.Should().Be(claude.Id);
+        row.Enabled.Should().BeTrue("a fresh SaaS tenant is usable out of the box");
+        row.UserId.Should().BeNull("XOR — SaaS keys TenantId only (mirrors the single-user FreshUser_ case)");
+    }
+
+    [Test]
+    public async Task FreshSaasTenant_Seed_IsInsertMissingOnly_NonFatal_WhenDefaultPersonaMissing()
+    {
+        await using var ctx = NewContext();
+        // No persona seeded — must NOT throw (a seed failure cannot abort tenant creation).
+        Func<Task> act = async () => await SeedTenantDefaultsActivity.SeedTenantDefaultPersonaAsync(
+            ctx, "claude", FreshTenant, NullLogger.Instance);
+
+        await act.Should().NotThrowAsync("seeding is best-effort/non-fatal");
+        (await ctx.TenantAgentEnablements.CountAsync()).Should().Be(0, "no half-seeded row");
+    }
+
+    private sealed class NoopEvents : IEventRepository
+    {
+        private readonly ConcurrentQueue<DomainEvent> _captured = new();
+        public Task<DomainEvent> AppendAsync(DomainEvent evt) { _captured.Enqueue(evt); return Task.FromResult(evt); }
+        public Task<DomainEvent?> GetByIdAsync(Guid id) => Task.FromResult<DomainEvent?>(null);
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit) =>
+            Task.FromResult(_captured.ToList());
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type) =>
+            Task.FromResult<DomainEvent?>(null);
+        public Task ClearAsync(Guid tenantId) => Task.CompletedTask;
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(
+            Guid? tenantId, string? type, int? issueNumber, int limit, int offset) =>
+            Task.FromResult(((IReadOnlyList<DomainEvent>)_captured.ToList(), _captured.Count));
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(
+            Guid tenantId, string? typePrefix, int limit, int offset) =>
+            Task.FromResult(((IReadOnlyList<DomainEvent>)_captured.ToList(), _captured.Count));
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/TenantAgentEnablementConstraintTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/TenantAgentEnablementConstraintTests.cs
@@ -1,0 +1,147 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Agents;
+
+/// <summary>
+/// Story 32-16 — DB-level constraint tests for <c>tenant_agent_enablements</c>:
+/// the principal-XOR CHECK and the UNIQUE NULLS NOT DISTINCT
+/// <c>(TenantId, UserId, AgentId)</c> index. Runs against a real Postgres
+/// testcontainer (the CHECK + nulls-not-distinct semantics are PG-specific).
+/// Mirrors <see cref="AgentRoleSelectionConstraintTests"/> byte-for-byte.
+/// </summary>
+[TestFixture]
+public class TenantAgentEnablementConstraintTests
+{
+    private static readonly Guid TenantA = Guid.Parse("aaaaaaaa-3216-3216-3216-aaaaaaaaaaaa");
+    private static readonly Guid TenantB = Guid.Parse("bbbbbbbb-3216-3216-3216-bbbbbbbbbbbb");
+    private static readonly Guid UserA = Guid.Parse("cccccccc-3216-3216-3216-cccccccccccc");
+    private static readonly Guid AgentX = Guid.Parse("dddddddd-3216-3216-3216-dddddddddddd");
+
+    private PostgreSqlContainer _postgres = null!;
+    private string _connectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("tenant_enablement_constraint_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _connectionString = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync("TRUNCATE tenant_agent_enablements CASCADE;");
+    }
+
+    private ControlPlaneDbContext NewContext()
+        => new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseNpgsql(_connectionString).Options);
+
+    private static TenantAgentEnablement Row(Guid? tenantId, Guid? userId, Guid? agentId = null)
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            UserId = userId,
+            AgentId = agentId ?? AgentX,
+            Enabled = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+
+    [Test]
+    public async Task PrincipalXor_BothSet_IsRejected()
+    {
+        await using var ctx = NewContext();
+        ctx.TenantAgentEnablements.Add(Row(TenantA, UserA));
+        Func<Task> act = async () => await ctx.SaveChangesAsync();
+        await act.Should().ThrowAsync<DbUpdateException>();
+    }
+
+    [Test]
+    public async Task PrincipalXor_NeitherSet_IsRejected()
+    {
+        await using var ctx = NewContext();
+        ctx.TenantAgentEnablements.Add(Row(null, null));
+        Func<Task> act = async () => await ctx.SaveChangesAsync();
+        await act.Should().ThrowAsync<DbUpdateException>();
+    }
+
+    [Test]
+    public async Task PrincipalXor_TenantOnly_Accepted()
+    {
+        await using var ctx = NewContext();
+        ctx.TenantAgentEnablements.Add(Row(TenantA, null));
+        await ctx.SaveChangesAsync();
+        (await ctx.TenantAgentEnablements.CountAsync()).Should().Be(1);
+    }
+
+    [Test]
+    public async Task PrincipalXor_UserOnly_Accepted()
+    {
+        await using var ctx = NewContext();
+        ctx.TenantAgentEnablements.Add(Row(null, UserA));
+        await ctx.SaveChangesAsync();
+        (await ctx.TenantAgentEnablements.CountAsync()).Should().Be(1);
+    }
+
+    [Test]
+    public async Task Unique_DuplicateTenantAgent_IsRejected()
+    {
+        await using var ctx = NewContext();
+        ctx.TenantAgentEnablements.Add(Row(TenantA, null, AgentX));
+        await ctx.SaveChangesAsync();
+
+        await using var ctx2 = NewContext();
+        ctx2.TenantAgentEnablements.Add(Row(TenantA, null, AgentX));
+        Func<Task> act = async () => await ctx2.SaveChangesAsync();
+        await act.Should().ThrowAsync<DbUpdateException>("one enablement row per (tenant, agent)");
+    }
+
+    [Test]
+    public async Task Unique_NullsNotDistinct_UserHalf_DedupesOnNullTenant()
+    {
+        // Two user-keyed rows (tenant_id NULL both) for the same (user, agent)
+        // must collide — NULLS NOT DISTINCT treats the NULL tenant halves equal.
+        await using var ctx = NewContext();
+        ctx.TenantAgentEnablements.Add(Row(null, UserA, AgentX));
+        await ctx.SaveChangesAsync();
+
+        await using var ctx2 = NewContext();
+        ctx2.TenantAgentEnablements.Add(Row(null, UserA, AgentX));
+        Func<Task> act = async () => await ctx2.SaveChangesAsync();
+        await act.Should().ThrowAsync<DbUpdateException>();
+    }
+
+    [Test]
+    public async Task Unique_DifferentTenants_SameAgent_BothAllowed()
+    {
+        await using var ctx = NewContext();
+        ctx.TenantAgentEnablements.Add(Row(TenantA, null, AgentX));
+        ctx.TenantAgentEnablements.Add(Row(TenantB, null, AgentX));
+        await ctx.SaveChangesAsync();
+        (await ctx.TenantAgentEnablements.CountAsync()).Should().Be(2,
+            "two tenants enable the same persona independently");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/TenantAgentEnablementIsolationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/TenantAgentEnablementIsolationTests.cs
@@ -1,0 +1,164 @@
+using System.Collections.Concurrent;
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using Tamma.Api.Services.Agents;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Core;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Agents;
+
+/// <summary>
+/// Story 32-16 (AC11) — cross-tenant isolation: a tenant cannot enable/disable
+/// for another tenant; A's enablement never appears in or affects B's view.
+/// </summary>
+[TestFixture]
+public class TenantAgentEnablementIsolationTests
+{
+    private static readonly Guid TenantA = Guid.Parse("aaaaaaaa-3216-1501-3216-aaaaaaaaaaaa");
+    private static readonly Guid TenantB = Guid.Parse("bbbbbbbb-3216-1501-3216-bbbbbbbbbbbb");
+
+    private PostgreSqlContainer _postgres = null!;
+    private string _connectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("tenant_enablement_iso_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _connectionString = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE tenant_agent_enablements, agent_versions, agents CASCADE;");
+    }
+
+    private ControlPlaneDbContext NewContext()
+        => new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseNpgsql(_connectionString).Options);
+
+    private const string Cfg = """{ "provider": "anthropic", "model": "claude-sonnet-4" }""";
+
+    private TenantAgentEnablementService ServiceFor(ControlPlaneDbContext ctx, Guid tenantId, IEventRepository events)
+    {
+        var agents = new AgentRepository(ctx, events);
+        var tenantContext = new TenantContext();
+        tenantContext.SetTenantId(tenantId);
+        var http = new HttpContextAccessor { HttpContext = new DefaultHttpContext() };
+        var personaOptions = Options.Create(new DefaultPersonaOptions { DefaultPersonaName = "claude" });
+        return new TenantAgentEnablementService(
+            ctx, agents, events, new StubMode(TammaMode.SaaS), tenantContext, http,
+            personaOptions, NullLogger<TenantAgentEnablementService>.Instance);
+    }
+
+    [Test]
+    public async Task TenantA_Enable_DoesNotAppearIn_TenantB_View()
+    {
+        await using var ctx = NewContext();
+        var events = new CapturingEvents();
+        var agents = new AgentRepository(ctx, events);
+        var claude = await agents.CreateAsync(
+            new Agent { Name = "claude", Role = null, Visibility = AgentVisibility.Public }, Cfg, null, null);
+
+        await ServiceFor(ctx, TenantA, events).EnableAsync(claude.Id);
+
+        var svcB = ServiceFor(ctx, TenantB, events);
+        (await svcB.IsEnabledForPrincipalAsync(claude.Id, Principal.ForTenant(TenantB)))
+            .Should().BeFalse("A's enablement must not leak to B");
+        (await svcB.ListEnabledPublicAgentIdsAsync(Principal.ForTenant(TenantB)))
+            .Should().BeEmpty("B has enabled nothing");
+
+        var viewB = await svcB.ListAsync();
+        viewB.Single(v => v.AgentId == claude.Id).Enabled.Should().BeFalse(
+            "claude is not enabled for B even though it is for A");
+    }
+
+    [Test]
+    public async Task TenantA_CannotEnable_TenantB_PrivateAgent_404()
+    {
+        await using var ctx = NewContext();
+        var events = new CapturingEvents();
+        var agents = new AgentRepository(ctx, events);
+        var foreign = await agents.CreateAsync(
+            new Agent { Name = "their-atlas", Role = "developer", Visibility = AgentVisibility.Private, OwnerTenantId = TenantB },
+            Cfg, null, null);
+
+        var svcA = ServiceFor(ctx, TenantA, events);
+        Func<Task> act = async () => await svcA.EnableAsync(foreign.Id);
+        (await act.Should().ThrowAsync<TammaError>())
+            .Which.Code.Should().Be("AGENT.ENABLEMENT.NOT_FOUND");
+    }
+
+    [Test]
+    public async Task TenantA_Disable_DoesNotAffect_TenantB()
+    {
+        await using var ctx = NewContext();
+        var events = new CapturingEvents();
+        var agents = new AgentRepository(ctx, events);
+        var claude = await agents.CreateAsync(
+            new Agent { Name = "claude", Role = null, Visibility = AgentVisibility.Public }, Cfg, null, null);
+
+        // Both enable it.
+        await ServiceFor(ctx, TenantA, events).EnableAsync(claude.Id);
+        await ServiceFor(ctx, TenantB, events).EnableAsync(claude.Id);
+
+        // A disables — B is untouched.
+        await ServiceFor(ctx, TenantA, events).DisableAsync(claude.Id);
+
+        (await ServiceFor(ctx, TenantA, events)
+            .IsEnabledForPrincipalAsync(claude.Id, Principal.ForTenant(TenantA)))
+            .Should().BeFalse();
+        (await ServiceFor(ctx, TenantB, events)
+            .IsEnabledForPrincipalAsync(claude.Id, Principal.ForTenant(TenantB)))
+            .Should().BeTrue("B's enablement survives A's disable");
+    }
+
+    private sealed class StubMode(TammaMode mode) : ITammaModeProvider
+    {
+        public TammaMode Mode { get; } = mode;
+    }
+
+    private sealed class CapturingEvents : IEventRepository
+    {
+        private readonly ConcurrentQueue<DomainEvent> _captured = new();
+        public Task<DomainEvent> AppendAsync(DomainEvent evt) { _captured.Enqueue(evt); return Task.FromResult(evt); }
+        public Task<DomainEvent?> GetByIdAsync(Guid id) => Task.FromResult<DomainEvent?>(null);
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit) =>
+            Task.FromResult(_captured.ToList());
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type) =>
+            Task.FromResult<DomainEvent?>(null);
+        public Task ClearAsync(Guid tenantId) => Task.CompletedTask;
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(
+            Guid? tenantId, string? type, int? issueNumber, int limit, int offset) =>
+            Task.FromResult(((IReadOnlyList<DomainEvent>)_captured.ToList(), _captured.Count));
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(
+            Guid tenantId, string? typePrefix, int limit, int offset) =>
+            Task.FromResult(((IReadOnlyList<DomainEvent>)_captured.ToList(), _captured.Count));
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/TenantAgentEnablementSecondBootTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/TenantAgentEnablementSecondBootTests.cs
@@ -1,0 +1,105 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using Tamma.Data;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Agents;
+
+/// <summary>
+/// Story 32-16 (AC8) — proves the new CP table <c>tenant_agent_enablements</c> is
+/// part of the destructive startup-reset DROP list so a SECOND host boot does not
+/// fail with <c>relation "tenant_agent_enablements" already exists</c>.
+///
+/// <para>Reproduces the <c>Program.cs</c> "Wiping Tamma-managed public-schema
+/// tables" → <c>Migrate()</c> cycle against a testcontainer: migrate (first boot),
+/// drop the table as the startup wipe would, migrate again (second boot). If the
+/// DROP list omitted the table the second migrate would throw the 42P07
+/// collision; this test fails-fast if a future edit regresses the DROP-list
+/// amendment.</para>
+/// </summary>
+[TestFixture]
+public class TenantAgentEnablementSecondBootTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _connectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("tenant_enablement_secondboot_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _connectionString = _postgres.GetConnectionString();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    private ControlPlaneDbContext NewContext()
+        => new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseNpgsql(_connectionString).Options);
+
+    [Test]
+    public async Task SecondBoot_AfterWipe_DoesNotThrow_RelationAlreadyExists()
+    {
+        // First boot — migrate creates tenant_agent_enablements (among all CP tables).
+        await using (var first = NewContext())
+        {
+            await first.Database.MigrateAsync();
+            var exists = await TableExistsAsync(first, "tenant_agent_enablements");
+            exists.Should().BeTrue("first boot creates the CP table");
+        }
+
+        // Startup wipe — Program.cs DROPs every Tamma-managed public-schema table
+        // (incl. tenant_agent_enablements) + the migrations-history table so a
+        // clean second Migrate() re-applies the whole graph from scratch. Reset the
+        // public schema to faithfully reproduce that clean-slate second boot; if
+        // the DROP list had omitted the table, the prod path would 42P07 instead.
+        await using (var wipe = NewContext())
+        {
+            await wipe.Database.ExecuteSqlRawAsync(
+                "DROP SCHEMA public CASCADE; CREATE SCHEMA public;");
+        }
+
+        // Second boot — must re-apply the full migration graph (incl. the new
+        // AddTenantAgentEnablements migration) without any collision.
+        await using (var second = NewContext())
+        {
+            Func<Task> act = async () => await second.Database.MigrateAsync();
+            await act.Should().NotThrowAsync(
+                "the DROP-list amendment (AC8) lets a second host boot re-create the table");
+            (await TableExistsAsync(second, "tenant_agent_enablements")).Should().BeTrue();
+        }
+    }
+
+    private static async Task<bool> TableExistsAsync(ControlPlaneDbContext ctx, string table)
+    {
+        var conn = ctx.Database.GetDbConnection();
+        await conn.OpenAsync();
+        try
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText =
+                "SELECT EXISTS (SELECT 1 FROM information_schema.tables "
+                + "WHERE table_schema = 'public' AND table_name = @t);";
+            var p = cmd.CreateParameter();
+            p.ParameterName = "t";
+            p.Value = table;
+            cmd.Parameters.Add(p);
+            var result = await cmd.ExecuteScalarAsync();
+            return result is bool b && b;
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/TenantAgentEnablementSecondBootTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/TenantAgentEnablementSecondBootTests.cs
@@ -47,6 +47,16 @@ public class TenantAgentEnablementSecondBootTests
         => new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
             .UseNpgsql(_connectionString).Options);
 
+    // TEST-FIDELITY LIMITATION (Story 32-16 review): this test wipes via
+    // "DROP SCHEMA public CASCADE" — a SUPERSET of the Program.cs startup wipe.
+    // It faithfully proves a clean second Migrate() succeeds, but because it does
+    // not replay the exact Program.cs DROP-list LITERAL, it would NOT catch a
+    // future edit that drops `tenant_agent_enablements` from that literal (the
+    // wipe block lives in Program.cs Main top-level statements as a raw SQL string,
+    // not a reachable constant/collection a test could assert against). If that
+    // DROP list is ever refactored into a named constant/list, add a direct
+    // `.Should().Contain("tenant_agent_enablements")` assertion here. Until then,
+    // the prod regression surfaces as a 42P07 on the second real host boot.
     [Test]
     public async Task SecondBoot_AfterWipe_DoesNotThrow_RelationAlreadyExists()
     {

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/TenantAgentEnablementServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/TenantAgentEnablementServiceTests.cs
@@ -1,0 +1,516 @@
+using System.Collections.Concurrent;
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using Tamma.Api.Services.Agents;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Core;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Agents;
+
+/// <summary>
+/// Story 32-16 — service-level tests for <see cref="TenantAgentEnablementService"/>
+/// against a real Postgres testcontainer with the real
+/// <see cref="AgentRepository"/> catalog. Covers enable/disable upsert + events,
+/// the <c>IsEnabledForPrincipalAsync</c> truth table, <c>ListEnabledPublicAgentIds</c>,
+/// <c>GetEnabledDefaultPersonaId</c>, disable-own-private 409, 404 unseen, and
+/// idempotency — parameterized over single-user / SaaS principal keying.
+/// </summary>
+[TestFixture]
+public class TenantAgentEnablementServiceTests
+{
+    private static readonly Guid TenantA = Guid.Parse("aaaaaaaa-3216-5e21-3216-aaaaaaaaaaaa");
+    private static readonly Guid TenantB = Guid.Parse("bbbbbbbb-3216-5e21-3216-bbbbbbbbbbbb");
+    private static readonly Guid UserA = Guid.Parse("cccccccc-3216-5e21-3216-cccccccccccc");
+
+    private PostgreSqlContainer _postgres = null!;
+    private string _connectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("tenant_enablement_svc_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _connectionString = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE tenant_agent_enablements, agent_role_selections, agent_versions, agents CASCADE;");
+    }
+
+    private ControlPlaneDbContext NewContext()
+        => new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseNpgsql(_connectionString).Options);
+
+    private const string Cfg = """{ "provider": "anthropic", "model": "claude-sonnet-4" }""";
+
+    private sealed record Svc(
+        TenantAgentEnablementService Service,
+        CapturingEvents Events,
+        AgentRepository Agents,
+        ControlPlaneDbContext Ctx,
+        Principal Principal);
+
+    /// <summary>Build the service for a principal, parameterized by mode.</summary>
+    private Svc BuildService(
+        TammaMode mode, Guid? tenantId, Guid? userId, string defaultPersonaName = "claude")
+    {
+        var ctx = NewContext();
+        var events = new CapturingEvents();
+        var agents = new AgentRepository(ctx, events);
+
+        var tenantContext = new TenantContext();
+        if (tenantId is Guid tid) tenantContext.SetTenantId(tid);
+
+        var claims = new List<Claim>();
+        if (userId is Guid uid) claims.Add(new Claim(ClaimTypes.NameIdentifier, uid.ToString()));
+        var http = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(claims, "Test")),
+            },
+        };
+
+        var personaOptions = Options.Create(
+            new DefaultPersonaOptions { DefaultPersonaName = defaultPersonaName });
+
+        var svc = new TenantAgentEnablementService(
+            ctx, agents, events, new StubMode(mode), tenantContext, http,
+            personaOptions, NullLogger<TenantAgentEnablementService>.Instance);
+
+        var principal = mode == TammaMode.SaaS
+            ? Principal.ForTenant(tenantId)
+            : Principal.ForUser(userId);
+
+        return new Svc(svc, events, agents, ctx, principal);
+    }
+
+    private async Task<Agent> SeedPersonaAsync(AgentRepository repo, string name)
+        => await repo.CreateAsync(
+            new Agent { Name = name, Role = null, Visibility = AgentVisibility.Public }, Cfg, null, null);
+
+    private async Task<Agent> SeedTenantPrivateAsync(AgentRepository repo, Guid tenantId, string name)
+        => await repo.CreateAsync(
+            new Agent { Name = name, Role = "developer", Visibility = AgentVisibility.Private, OwnerTenantId = tenantId },
+            Cfg, null, null);
+
+    private async Task<Agent> SeedUserPrivateAsync(AgentRepository repo, Guid userId, string name)
+        => await repo.CreateAsync(
+            new Agent { Name = name, Role = "developer", Visibility = AgentVisibility.Private, OwnerUserId = userId },
+            Cfg, null, null);
+
+    // ── enable/disable + events ──
+
+    [Test]
+    public async Task EnableAsync_PublicPersona_CreatesRow_And_EmitsOneEvent()
+    {
+        var s = BuildService(TammaMode.SaaS, TenantA, null);
+        await using (s.Ctx)
+        {
+            var claude = await SeedPersonaAsync(s.Agents, "claude");
+
+            var state = await s.Service.EnableAsync(claude.Id);
+            state.Enabled.Should().BeTrue();
+            state.ImplicitlyEnabled.Should().BeFalse();
+            state.PersonaName.Should().Be("claude");
+
+            (await s.Ctx.TenantAgentEnablements.CountAsync(
+                r => r.TenantId == TenantA && r.AgentId == claude.Id && r.Enabled)).Should().Be(1);
+
+            var evts = s.Events.OfType(AgentEnablementEventTypes.Enabled);
+            evts.Should().ContainSingle("exactly one AGENT.ENABLED.SUCCESS per enable");
+            var tags = Tags(evts.Single());
+            tags["agentId"].Should().Be(claude.Id.ToString());
+            tags["personaName"].Should().Be("claude");
+            tags["mode"].Should().Be("saas");
+            tags["tenantId"].Should().Be(TenantA.ToString());
+            tags.Should().NotContainKey("userId");
+        }
+    }
+
+    [Test]
+    public async Task EnableAsync_Reenable_IsIdempotent_SingleRow()
+    {
+        var s = BuildService(TammaMode.SaaS, TenantA, null);
+        await using (s.Ctx)
+        {
+            var claude = await SeedPersonaAsync(s.Agents, "claude");
+            await s.Service.EnableAsync(claude.Id);
+            await s.Service.EnableAsync(claude.Id);
+
+            (await s.Ctx.TenantAgentEnablements.CountAsync(r => r.AgentId == claude.Id))
+                .Should().Be(1, "re-enable upserts the same single row");
+        }
+    }
+
+    [Test]
+    public async Task DisableAsync_PublicPersona_SetsFalse_And_EmitsOneEvent()
+    {
+        var s = BuildService(TammaMode.SaaS, TenantA, null);
+        await using (s.Ctx)
+        {
+            var claude = await SeedPersonaAsync(s.Agents, "claude");
+            await s.Service.EnableAsync(claude.Id);
+            s.Events.Reset();
+
+            var state = await s.Service.DisableAsync(claude.Id);
+            state.Enabled.Should().BeFalse();
+
+            var row = await s.Ctx.TenantAgentEnablements
+                .SingleAsync(r => r.TenantId == TenantA && r.AgentId == claude.Id);
+            row.Enabled.Should().BeFalse();
+
+            s.Events.OfType(AgentEnablementEventTypes.Disabled)
+                .Should().ContainSingle("exactly one AGENT.DISABLED.SUCCESS per disable");
+        }
+    }
+
+    [Test]
+    public async Task DisableAsync_OwnPrivateAgent_Throws409Equivalent()
+    {
+        var s = BuildService(TammaMode.SaaS, TenantA, null);
+        await using (s.Ctx)
+        {
+            var atlas = await SeedTenantPrivateAsync(s.Agents, TenantA, "atlas");
+
+            Func<Task> act = async () => await s.Service.DisableAsync(atlas.Id);
+            (await act.Should().ThrowAsync<TammaError>())
+                .Which.Code.Should().Be("AGENT.ENABLEMENT.PRIVATE_NOT_DISABLEABLE");
+
+            (await s.Ctx.TenantAgentEnablements.CountAsync()).Should().Be(0, "no row written");
+            s.Events.OfType(AgentEnablementEventTypes.Disabled).Should().BeEmpty();
+        }
+    }
+
+    [Test]
+    public async Task EnableAsync_OwnPrivateAgent_NoOpConfirm_NoRow_NoEvent()
+    {
+        var s = BuildService(TammaMode.SaaS, TenantA, null);
+        await using (s.Ctx)
+        {
+            var atlas = await SeedTenantPrivateAsync(s.Agents, TenantA, "atlas");
+
+            var state = await s.Service.EnableAsync(atlas.Id);
+            state.Enabled.Should().BeTrue();
+            state.ImplicitlyEnabled.Should().BeTrue();
+
+            (await s.Ctx.TenantAgentEnablements.CountAsync()).Should().Be(0, "private agents need no row");
+            s.Events.OfType(AgentEnablementEventTypes.Enabled).Should().BeEmpty();
+        }
+    }
+
+    [Test]
+    public async Task EnableAsync_UnseenTarget_Throws404Equivalent()
+    {
+        var s = BuildService(TammaMode.SaaS, TenantA, null);
+        await using (s.Ctx)
+        {
+            // Cross-tenant private target — TenantA can't see TenantB's private agent.
+            var foreign = await SeedTenantPrivateAsync(s.Agents, TenantB, "their-atlas");
+
+            Func<Task> act = async () => await s.Service.EnableAsync(foreign.Id);
+            (await act.Should().ThrowAsync<TammaError>())
+                .Which.Code.Should().Be("AGENT.ENABLEMENT.NOT_FOUND");
+
+            // Also a wholly non-existent id.
+            Func<Task> act2 = async () => await s.Service.EnableAsync(Guid.NewGuid());
+            (await act2.Should().ThrowAsync<TammaError>())
+                .Which.Code.Should().Be("AGENT.ENABLEMENT.NOT_FOUND");
+        }
+    }
+
+    // ── IsEnabledForPrincipalAsync truth table ──
+
+    [Test]
+    public async Task IsEnabledForPrincipal_TruthTable()
+    {
+        var s = BuildService(TammaMode.SaaS, TenantA, null);
+        await using (s.Ctx)
+        {
+            var claudeEnabled = await SeedPersonaAsync(s.Agents, "claude");
+            var geminiNoRow = await SeedPersonaAsync(s.Agents, "gemini");
+            var codegptDisabled = await SeedPersonaAsync(s.Agents, "codegpt");
+            var ownPriv = await SeedTenantPrivateAsync(s.Agents, TenantA, "atlas");
+            var foreignPriv = await SeedTenantPrivateAsync(s.Agents, TenantB, "their-atlas");
+
+            await s.Service.EnableAsync(claudeEnabled.Id);
+            await s.Service.EnableAsync(codegptDisabled.Id);
+            await s.Service.DisableAsync(codegptDisabled.Id);
+
+            var p = s.Principal;
+            (await s.Service.IsEnabledForPrincipalAsync(claudeEnabled.Id, p))
+                .Should().BeTrue("enabled public persona ⇒ true");
+            (await s.Service.IsEnabledForPrincipalAsync(geminiNoRow.Id, p))
+                .Should().BeFalse("no-row public persona ⇒ false (default-deny)");
+            (await s.Service.IsEnabledForPrincipalAsync(codegptDisabled.Id, p))
+                .Should().BeFalse("disabled public persona ⇒ false");
+            (await s.Service.IsEnabledForPrincipalAsync(ownPriv.Id, p))
+                .Should().BeTrue("own private/custom agent ⇒ implicitly true with no row");
+            (await s.Service.IsEnabledForPrincipalAsync(foreignPriv.Id, p))
+                .Should().BeFalse("cross-scope private agent ⇒ false");
+            (await s.Service.IsEnabledForPrincipalAsync(Guid.NewGuid(), p))
+                .Should().BeFalse("non-existent agent ⇒ false");
+        }
+    }
+
+    [Test]
+    public async Task IsEnabledForPrincipal_RetiredEnabledPersona_IsFalse()
+    {
+        var s = BuildService(TammaMode.SaaS, TenantA, null);
+        await using (s.Ctx)
+        {
+            var claude = await SeedPersonaAsync(s.Agents, "claude");
+            await s.Service.EnableAsync(claude.Id);
+
+            // Archive the persona platform-wide; the stale enabled row resolves out.
+            await s.Agents.ArchiveAsync(claude.Id, null);
+
+            (await s.Service.IsEnabledForPrincipalAsync(claude.Id, s.Principal))
+                .Should().BeFalse("a retired persona is not enabled even with a stale row");
+        }
+    }
+
+    // ── ListEnabledPublicAgentIdsAsync ──
+
+    [Test]
+    public async Task ListEnabledPublicAgentIds_ReturnsOnlyEnabledPublic()
+    {
+        var s = BuildService(TammaMode.SaaS, TenantA, null);
+        await using (s.Ctx)
+        {
+            var claude = await SeedPersonaAsync(s.Agents, "claude");
+            var gemini = await SeedPersonaAsync(s.Agents, "gemini");
+            var codegpt = await SeedPersonaAsync(s.Agents, "codegpt");
+            await SeedTenantPrivateAsync(s.Agents, TenantA, "atlas"); // private — excluded
+
+            await s.Service.EnableAsync(claude.Id);
+            await s.Service.EnableAsync(gemini.Id);
+            await s.Service.EnableAsync(codegpt.Id);
+            await s.Service.DisableAsync(gemini.Id); // disabled — excluded
+
+            var ids = await s.Service.ListEnabledPublicAgentIdsAsync(s.Principal);
+            ids.Should().BeEquivalentTo(new[] { claude.Id, codegpt.Id });
+        }
+    }
+
+    // ── GetEnabledDefaultPersonaIdAsync ──
+
+    [Test]
+    public async Task GetEnabledDefaultPersona_ConfiguredDefaultEnabled_ReturnsIt()
+    {
+        var s = BuildService(TammaMode.SaaS, TenantA, null, defaultPersonaName: "claude");
+        await using (s.Ctx)
+        {
+            var claude = await SeedPersonaAsync(s.Agents, "claude");
+            var gemini = await SeedPersonaAsync(s.Agents, "gemini");
+            await s.Service.EnableAsync(claude.Id);
+            await s.Service.EnableAsync(gemini.Id);
+
+            (await s.Service.GetEnabledDefaultPersonaIdAsync(s.Principal))
+                .Should().Be(claude.Id, "the configured default persona wins when enabled");
+        }
+    }
+
+    [Test]
+    public async Task GetEnabledDefaultPersona_DefaultNotEnabled_SingleEnabled_ReturnsThatOne()
+    {
+        var s = BuildService(TammaMode.SaaS, TenantA, null, defaultPersonaName: "claude");
+        await using (s.Ctx)
+        {
+            await SeedPersonaAsync(s.Agents, "claude"); // configured default, NOT enabled
+            var gemini = await SeedPersonaAsync(s.Agents, "gemini");
+            await s.Service.EnableAsync(gemini.Id);
+
+            (await s.Service.GetEnabledDefaultPersonaIdAsync(s.Principal))
+                .Should().Be(gemini.Id, "the single enabled persona when the default is not enabled");
+        }
+    }
+
+    [Test]
+    public async Task GetEnabledDefaultPersona_NothingEnabled_ReturnsNull()
+    {
+        var s = BuildService(TammaMode.SaaS, TenantA, null, defaultPersonaName: "claude");
+        await using (s.Ctx)
+        {
+            await SeedPersonaAsync(s.Agents, "claude");
+            await SeedPersonaAsync(s.Agents, "gemini");
+
+            (await s.Service.GetEnabledDefaultPersonaIdAsync(s.Principal))
+                .Should().BeNull("nothing enabled ⇒ null");
+        }
+    }
+
+    [Test]
+    public async Task GetEnabledDefaultPersona_Ambiguous_ReturnsNull()
+    {
+        var s = BuildService(TammaMode.SaaS, TenantA, null, defaultPersonaName: "claude");
+        await using (s.Ctx)
+        {
+            await SeedPersonaAsync(s.Agents, "claude"); // default NOT enabled
+            var gemini = await SeedPersonaAsync(s.Agents, "gemini");
+            var codegpt = await SeedPersonaAsync(s.Agents, "codegpt");
+            await s.Service.EnableAsync(gemini.Id);
+            await s.Service.EnableAsync(codegpt.Id);
+
+            (await s.Service.GetEnabledDefaultPersonaIdAsync(s.Principal))
+                .Should().BeNull("multiple enabled and none is the configured default ⇒ ambiguous ⇒ null");
+        }
+    }
+
+    [Test]
+    public async Task GetEnabledDefaultPersona_IsPureRead_NoWritesOrEvents()
+    {
+        var s = BuildService(TammaMode.SaaS, TenantA, null, defaultPersonaName: "claude");
+        await using (s.Ctx)
+        {
+            var claude = await SeedPersonaAsync(s.Agents, "claude");
+            await s.Service.EnableAsync(claude.Id);
+            s.Events.Reset();
+
+            await s.Service.GetEnabledDefaultPersonaIdAsync(s.Principal);
+
+            s.Events.All().Should().BeEmpty("the default-persona read emits no events");
+            (await s.Ctx.TenantAgentEnablements.CountAsync()).Should().Be(1, "and writes no rows");
+        }
+    }
+
+    // ── ListAsync catalog view ──
+
+    [Test]
+    public async Task ListAsync_ShowsPublicFlags_And_PrivateImplicit()
+    {
+        var s = BuildService(TammaMode.SaaS, TenantA, null);
+        await using (s.Ctx)
+        {
+            var claude = await SeedPersonaAsync(s.Agents, "claude");
+            await SeedPersonaAsync(s.Agents, "gemini");
+            var atlas = await SeedTenantPrivateAsync(s.Agents, TenantA, "atlas");
+            await s.Service.EnableAsync(claude.Id);
+
+            var view = await s.Service.ListAsync();
+
+            view.Single(v => v.AgentId == claude.Id).Enabled.Should().BeTrue();
+            view.Single(v => v.AgentId == claude.Id).ImplicitlyEnabled.Should().BeFalse();
+            view.Single(v => v.PersonaName == "gemini").Enabled.Should().BeFalse();
+            var priv = view.Single(v => v.AgentId == atlas.Id);
+            priv.Enabled.Should().BeTrue();
+            priv.ImplicitlyEnabled.Should().BeTrue();
+        }
+    }
+
+    // ── mode-parameterized principal keying (single-user vs SaaS) ──
+
+    [Test]
+    public async Task EnableAsync_ModeParameterized_KeysCorrectColumn(
+        [Values(TammaMode.SingleUser, TammaMode.SaaS)] TammaMode mode)
+    {
+        var tenantId = mode == TammaMode.SaaS ? TenantA : (Guid?)null;
+        var userId = mode == TammaMode.SingleUser ? UserA : (Guid?)null;
+        var s = BuildService(mode, tenantId, userId);
+        await using (s.Ctx)
+        {
+            var claude = await SeedPersonaAsync(s.Agents, "claude");
+            await s.Service.EnableAsync(claude.Id);
+
+            var row = await s.Ctx.TenantAgentEnablements.SingleAsync(r => r.AgentId == claude.Id);
+            if (mode == TammaMode.SaaS)
+            {
+                row.TenantId.Should().Be(TenantA);
+                row.UserId.Should().BeNull("XOR — only TenantId is set in SaaS");
+            }
+            else
+            {
+                row.UserId.Should().Be(UserA);
+                row.TenantId.Should().BeNull("XOR — only UserId is set in single-user");
+            }
+
+            // Event tags the correct principal.
+            var tags = Tags(s.Events.OfType(AgentEnablementEventTypes.Enabled).Single());
+            tags["mode"].Should().Be(mode == TammaMode.SaaS ? "saas" : "single-user");
+            if (mode == TammaMode.SaaS)
+            {
+                tags["tenantId"].Should().Be(TenantA.ToString());
+                tags.Should().NotContainKey("userId");
+            }
+            else
+            {
+                tags["userId"].Should().Be(UserA.ToString());
+                tags.Should().NotContainKey("tenantId");
+            }
+        }
+    }
+
+    [Test]
+    public async Task IsEnabledForPrincipal_SingleUser_OwnPrivate_Implicit()
+    {
+        var s = BuildService(TammaMode.SingleUser, null, UserA);
+        await using (s.Ctx)
+        {
+            var ownPriv = await SeedUserPrivateAsync(s.Agents, UserA, "atlas");
+            (await s.Service.IsEnabledForPrincipalAsync(ownPriv.Id, s.Principal))
+                .Should().BeTrue("the sole user's own private agent is implicitly enabled");
+        }
+    }
+
+    // ── helpers ──
+
+    private static Dictionary<string, string?> Tags(DomainEvent evt)
+        => JsonSerializer.Deserialize<Dictionary<string, string?>>(evt.Tags)!;
+
+    private sealed class StubMode(TammaMode mode) : ITammaModeProvider
+    {
+        public TammaMode Mode { get; } = mode;
+    }
+
+    private sealed class CapturingEvents : IEventRepository
+    {
+        private readonly ConcurrentQueue<DomainEvent> _captured = new();
+
+        public IReadOnlyList<DomainEvent> All() => _captured.ToList();
+        public IReadOnlyList<DomainEvent> OfType(string type)
+            => _captured.Where(e => e.Type == type).ToList();
+        public void Reset() { while (_captured.TryDequeue(out _)) { } }
+
+        public Task<DomainEvent> AppendAsync(DomainEvent evt) { _captured.Enqueue(evt); return Task.FromResult(evt); }
+        public Task<DomainEvent?> GetByIdAsync(Guid id) => Task.FromResult<DomainEvent?>(null);
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit) =>
+            Task.FromResult(_captured.ToList());
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type) =>
+            Task.FromResult<DomainEvent?>(null);
+        public Task ClearAsync(Guid tenantId) => Task.CompletedTask;
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(
+            Guid? tenantId, string? type, int? issueNumber, int limit, int offset) =>
+            Task.FromResult(((IReadOnlyList<DomainEvent>)_captured.ToList(), _captured.Count));
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(
+            Guid tenantId, string? typePrefix, int limit, int offset) =>
+            Task.FromResult(((IReadOnlyList<DomainEvent>)_captured.ToList(), _captured.Count));
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/TenantAgentEnablementServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/TenantAgentEnablementServiceTests.cs
@@ -157,6 +157,46 @@ public class TenantAgentEnablementServiceTests
     }
 
     [Test]
+    public async Task EnableAsync_ConcurrentFirstTimeInsert_LoserUpdates_NoUnhandledDbUpdateException()
+    {
+        // Pre-stage a public persona via an independent context so BOTH racing
+        // services see it in the catalog.
+        Guid claudeId;
+        await using (var seedCtx = NewContext())
+        {
+            var claude = await SeedPersonaAsync(new AgentRepository(seedCtx, new CapturingEvents()), "claude");
+            claudeId = claude.Id;
+        }
+
+        // Two independent services (independent contexts/connections) for the SAME
+        // principal+agent — the exact shape of two concurrent first-time enable calls.
+        var a = BuildService(TammaMode.SaaS, TenantA, null);
+        var b = BuildService(TammaMode.SaaS, TenantA, null);
+        await using (a.Ctx)
+        await using (b.Ctx)
+        {
+            // Both read null (empty table), both attempt the first-time INSERT; the
+            // unique (TenantId, UserId, AgentId) index makes exactly one win. The
+            // loser MUST recover via the unique-violation catch (detach → re-read →
+            // UPDATE), NOT escape as an unhandled DbUpdateException.
+            Func<Task> race = async () => await Task.WhenAll(
+                a.Service.EnableAsync(claudeId),
+                b.Service.EnableAsync(claudeId));
+
+            await race.Should().NotThrowAsync<DbUpdateException>(
+                "the upsert race loser recovers to an UPDATE (no unhandled DbUpdateException)");
+
+            await using var verify = NewContext();
+            (await verify.TenantAgentEnablements.CountAsync(
+                    r => r.TenantId == TenantA && r.AgentId == claudeId))
+                .Should().Be(1, "exactly one enablement row survives the race");
+            (await verify.TenantAgentEnablements.SingleAsync(
+                    r => r.TenantId == TenantA && r.AgentId == claudeId))
+                .Enabled.Should().BeTrue("both racers intended enabled=true");
+        }
+    }
+
+    [Test]
     public async Task EnableAsync_Reenable_IsIdempotent_SingleRow()
     {
         var s = BuildService(TammaMode.SaaS, TenantA, null);

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/TenantEnablementSeederTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/TenantEnablementSeederTests.cs
@@ -1,0 +1,173 @@
+using System.Collections.Concurrent;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+using Tamma.Data.Seeders;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Agents;
+
+/// <summary>
+/// Story 32-16 (AC10) — <see cref="TenantEnablementSeeder"/>: a fresh principal
+/// gets the platform default persona enabled out of the box; the seeder is
+/// insert-missing-only and NEVER reverts an explicit disable.
+/// </summary>
+[TestFixture]
+public class TenantEnablementSeederTests
+{
+    private static readonly Guid TenantA = Guid.Parse("aaaaaaaa-3216-5eed-3216-aaaaaaaaaaaa");
+    private static readonly Guid UserA = Guid.Parse("cccccccc-3216-5eed-3216-cccccccccccc");
+
+    private PostgreSqlContainer _postgres = null!;
+    private string _connectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("tenant_enablement_seed_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _connectionString = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE tenant_agent_enablements, agent_versions, agents CASCADE;");
+    }
+
+    private ControlPlaneDbContext NewContext()
+        => new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseNpgsql(_connectionString).Options);
+
+    private const string Cfg = """{ "provider": "anthropic", "model": "claude-sonnet-4" }""";
+
+    private async Task<Agent> SeedClaudeAsync(ControlPlaneDbContext ctx)
+        => await new AgentRepository(ctx, new NoopEvents()).CreateAsync(
+            new Agent { Name = "claude", Role = null, Visibility = AgentVisibility.Public }, Cfg, null, null);
+
+    [Test]
+    public async Task FreshTenant_GetsDefaultPersonaEnabled()
+    {
+        await using var ctx = NewContext();
+        var claude = await SeedClaudeAsync(ctx);
+
+        var inserted = await TenantEnablementSeeder.SeedDefaultPersonaAsync(
+            ctx, "claude", tenantId: TenantA, userId: null);
+
+        inserted.Should().BeTrue();
+        var row = await ctx.TenantAgentEnablements.SingleAsync(r => r.TenantId == TenantA);
+        row.AgentId.Should().Be(claude.Id);
+        row.Enabled.Should().BeTrue();
+        row.UserId.Should().BeNull("XOR — SaaS keys TenantId only");
+    }
+
+    [Test]
+    public async Task FreshUser_SingleUser_GetsDefaultPersonaEnabled()
+    {
+        await using var ctx = NewContext();
+        await SeedClaudeAsync(ctx);
+
+        var inserted = await TenantEnablementSeeder.SeedDefaultPersonaAsync(
+            ctx, "claude", tenantId: null, userId: UserA);
+
+        inserted.Should().BeTrue();
+        var row = await ctx.TenantAgentEnablements.SingleAsync(r => r.UserId == UserA);
+        row.Enabled.Should().BeTrue();
+        row.TenantId.Should().BeNull("XOR — single-user keys UserId only");
+    }
+
+    [Test]
+    public async Task Rerun_DoesNotRevertExplicitDisable()
+    {
+        await using var ctx = NewContext();
+        var claude = await SeedClaudeAsync(ctx);
+
+        // First seed enables.
+        await TenantEnablementSeeder.SeedDefaultPersonaAsync(ctx, "claude", TenantA, null);
+
+        // Admin explicitly disables.
+        var row = await ctx.TenantAgentEnablements.SingleAsync(r => r.TenantId == TenantA);
+        row.Enabled = false;
+        await ctx.SaveChangesAsync();
+
+        // Re-run the seeder — must NOT revert the disable.
+        var inserted = await TenantEnablementSeeder.SeedDefaultPersonaAsync(ctx, "claude", TenantA, null);
+
+        inserted.Should().BeFalse("insert-missing-only — a row already exists");
+        var reread = await ctx.TenantAgentEnablements.SingleAsync(r => r.TenantId == TenantA);
+        reread.Enabled.Should().BeFalse("the explicit disable is preserved across re-seed");
+        (await ctx.TenantAgentEnablements.CountAsync(r => r.AgentId == claude.Id)).Should().Be(1);
+    }
+
+    [Test]
+    public async Task Rerun_Idempotent_NoSecondRow()
+    {
+        await using var ctx = NewContext();
+        await SeedClaudeAsync(ctx);
+
+        await TenantEnablementSeeder.SeedDefaultPersonaAsync(ctx, "claude", TenantA, null);
+        var second = await TenantEnablementSeeder.SeedDefaultPersonaAsync(ctx, "claude", TenantA, null);
+
+        second.Should().BeFalse();
+        (await ctx.TenantAgentEnablements.CountAsync(r => r.TenantId == TenantA)).Should().Be(1);
+    }
+
+    [Test]
+    public async Task MissingDefaultPersona_SkipsWithoutThrow()
+    {
+        await using var ctx = NewContext();
+        // No persona seeded.
+        var inserted = await TenantEnablementSeeder.SeedDefaultPersonaAsync(ctx, "claude", TenantA, null);
+
+        inserted.Should().BeFalse("no live default persona ⇒ skip, no half-seeded row");
+        (await ctx.TenantAgentEnablements.CountAsync()).Should().Be(0);
+    }
+
+    [Test]
+    public async Task BothPrincipals_ThrowsXorViolation()
+    {
+        await using var ctx = NewContext();
+        await SeedClaudeAsync(ctx);
+
+        Func<Task> act = async () => await TenantEnablementSeeder.SeedDefaultPersonaAsync(
+            ctx, "claude", tenantId: TenantA, userId: UserA);
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    private sealed class NoopEvents : IEventRepository
+    {
+        private readonly ConcurrentQueue<DomainEvent> _captured = new();
+        public Task<DomainEvent> AppendAsync(DomainEvent evt) { _captured.Enqueue(evt); return Task.FromResult(evt); }
+        public Task<DomainEvent?> GetByIdAsync(Guid id) => Task.FromResult<DomainEvent?>(null);
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit) =>
+            Task.FromResult(_captured.ToList());
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type) =>
+            Task.FromResult<DomainEvent?>(null);
+        public Task ClearAsync(Guid tenantId) => Task.CompletedTask;
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(
+            Guid? tenantId, string? type, int? issueNumber, int limit, int offset) =>
+            Task.FromResult(((IReadOnlyList<DomainEvent>)_captured.ToList(), _captured.Count));
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(
+            Guid tenantId, string? typePrefix, int limit, int offset) =>
+            Task.FromResult(((IReadOnlyList<DomainEvent>)_captured.ToList(), _captured.Count));
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
@@ -106,6 +106,11 @@ public class ControlPlaneDbContextModelTests
             // build holds single-user user-keyed rows; tenant build holds SaaS
             // tenant-keyed rows). Same dual-resident pattern as audit_records.
             "agent_role_selections",
+            // Story 32-16 — per-tenant agent/persona enablement (catalog
+            // membership). CP-resident in BOTH modes (gates the CP public agent
+            // catalog; keyed by tenant id / user id, not per t_<hex>) — so it is
+            // mapped ONLY on the CP context, not the tenant context.
+            "tenant_agent_enablements",
             // Story 35-1 — Epic 35 billing foundation. CP-resident: the
             // tenant→Stripe customer mapping (keyed by tenant) + the
             // slug→Stripe-ids catalog (platform-global). Definition/binding
@@ -132,6 +137,7 @@ public class ControlPlaneDbContextModelTests
             + "platform_webhook_deliveries. Unified-tenancy Phase 0 adds "
             + "tenant_databases. Story 32-1 adds agents + agent_versions. "
             + "Story 32-2 adds agent_role_selections. "
+            + "Story 32-16 adds tenant_agent_enablements. "
             + "Story 34-1 adds plan_features + plan_entitlements + plan_prices. "
             + "Story 35-1 adds billing_customers + billing_plan_prices. "
             + "Story 37-1 adds audit_records + audit_projector_cursor. "


### PR DESCRIPTION
Sequence step **C** of the Epic-32 pivot — the genuinely-missing **per-tenant enablement** layer (rule 6). A tenant's usable agent set tightens from "all public personas" to `enabled(public) ∪ own-private`.

- New CP entity `TenantAgentEnablement` (principal-XOR, `UNIQUE NULLS NOT DISTINCT (TenantId, UserId, AgentId)`, mirroring `AgentRoleSelection`); migration `20260621232834_AddTenantAgentEnablements` + DROP-list + strict CP-model-test wiring.
- ISP-split seams: `ITenantAgentEnablementReader` (`IsEnabledForPrincipalAsync` / `ListEnabledPublicAgentIdsAsync` / `GetEnabledDefaultPersonaIdAsync` — what **32-18** consumes) + `ITenantAgentEnablementService` (enable/disable/list).
- Enable/disable/list API on `/api/agents` (`AgentManage` = admin+owner; member 403 on writes, reads open); `AGENT.ENABLED/DISABLED.SUCCESS` events; default-deny + seeded default persona; own-private implicitly enabled (404 unseen / 409 disable-own-private). Owns the entity+API+primitives **only** — the registry gate is 32-18 (boundary verified: `AgentRegistryService`/`AgentResolverService` untouched).

## Process / quality
TDD → **spec-review (spec-compliant)** + **code-quality review (approve-with-nits)**. Both substantive findings fixed in `71e39bf1`:
- **Upsert race:** `EnableAsync` now catches the unique-violation and re-reads/updates (mirroring `AgentSelectionRepository.UpsertAsync`) instead of throwing an unhandled `DbUpdateException` under concurrent first-enable. + concurrency test.
- **SaaS fresh-tenant seeded-default:** wired `SeedDefaultPersonaAsync` into `SeedTenantDefaultsActivity` (Step 7 of `CreateTenantWorkflow`), tenant-keyed, insert-missing-only, non-fatal — closing the gap before 32-18 needs it. + tests.

## Verification (run independently by me)
- `dotnet build Tamma.sln` → **0 errors**; `has-pending-model-changes` → none.
- **Tamma.Api.Tests 3469 / 0 · Tamma.Activities.Tests 1259 / 0.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)