### PR TITLE
fix(workflow-viewer): sub-workflow links → own page, rail arrows, cleaner loop routing

### DIFF
--- a/apps/wiki-site/src/components/WorkflowMapPage.tsx
+++ b/apps/wiki-site/src/components/WorkflowMapPage.tsx
@@ -25,11 +25,6 @@ function loadDataset(): Promise<WorkflowDataset> {
   return datasetCache;
 }
 
-function wikiSlugFor(w: WorkflowMetadata): string {
-  if (w.wikiPage) return w.wikiPage.replace(/^Workflow-/, '').toLowerCase();
-  return w.inventoryId ?? w.id;
-}
-
 function resolveWorkflow(
   dataset: WorkflowDataset,
   slug: string,
@@ -98,7 +93,11 @@ export default function WorkflowMapPage() {
         (w) => w.id === targetWorkflowId || w.inventoryId === targetWorkflowId,
       );
       if (!target) return;
-      const targetSlug = wikiSlugFor(target);
+      // Navigate by the target's UNIQUE id, not a wikiPage-derived slug: many
+      // sub-workflows share one wikiPage (e.g. several dispatch targets are all
+      // documented on "Workflow-Single-Issue-Cycle"), so a wikiPage slug would
+      // collapse them all back to the parent. The map route resolves by id first.
+      const targetSlug = target.id;
       const search = targetStep ? `?step=${encodeURIComponent(targetStep)}` : '';
       navigate(`/workflows/${targetSlug}/map${search}`);
     },
@@ -114,7 +113,9 @@ export default function WorkflowMapPage() {
         (w) => w.id === targetWorkflowId || w.inventoryId === targetWorkflowId,
       );
       if (!target) return undefined;
-      return `/workflows/${wikiSlugFor(target)}/map`;
+      // Use the unique id (see handleNavigate): a wikiPage slug would collapse
+      // sub-workflows sharing one wiki page back onto the parent.
+      return `/workflows/${target.id}/map`;
     },
     [dataset],
   );

--- a/packages/workflow-viewer/src/WorkflowMap.tsx
+++ b/packages/workflow-viewer/src/WorkflowMap.tsx
@@ -131,6 +131,21 @@ export function WorkflowMap({
             preserveAspectRatio="none"
             aria-hidden="true"
           >
+            <defs>
+              {/* Direction arrowhead — inherits each rail's stroke colour. */}
+              <marker
+                id="twv-rail-arrow"
+                viewBox="0 0 10 10"
+                refX="8.5"
+                refY="5"
+                markerWidth="7"
+                markerHeight="7"
+                markerUnits="userSpaceOnUse"
+                orient="auto"
+              >
+                <path d="M0.5 0.5 L9 5 L0.5 9.5 z" fill="context-stroke" />
+              </marker>
+            </defs>
             {geom.railPaths.map((rp) => (
               <g key={rp.id}>
                 <path
@@ -140,8 +155,9 @@ export function WorkflowMap({
                   strokeWidth={rp.isBackEdge ? 2 : 3}
                   strokeLinecap="round"
                   strokeLinejoin="round"
-                  strokeDasharray={rp.isBackEdge ? '5 5' : undefined}
-                  opacity={rp.isBackEdge ? 0.7 : 0.9}
+                  strokeDasharray={rp.isBackEdge ? '6 5' : undefined}
+                  opacity={rp.isBackEdge ? 0.85 : 0.95}
+                  markerEnd="url(#twv-rail-arrow)"
                 />
               </g>
             ))}
@@ -316,7 +332,7 @@ function computeGeometry(layout: MapLayout, width: number): Geometry {
     const b = byId.get(rail.to);
     if (!a || !b) continue;
     const color = LINE_COLORS[rail.line % LINE_COLORS.length]!;
-    const { d, labelX, labelY } = orthogonalPath(a, b, rail.isBackEdge);
+    const { d, labelX, labelY } = orthogonalPath(a, b, rail.isBackEdge, w);
     railPaths.push({ id: rail.id, d, color, isBackEdge: rail.isBackEdge });
     if (rail.label) {
       railLabels.push({ id: rail.id, label: rail.label, x: labelX, y: labelY });
@@ -339,28 +355,32 @@ function orthogonalPath(
   a: StationGeom,
   b: StationGeom,
   isBackEdge: boolean,
+  maxX: number,
 ): { d: string; labelX: number; labelY: number } {
   const startY = a.cy + STATION_H / 2;
   const endY = b.cy - STATION_H / 2;
 
   if (isBackEdge) {
-    // Loop-back: exit the right side of `a`, run up the gutter, re-enter `b`'s
-    // right side. Bow out beyond both stations so the line reads as a return.
-    const ax = a.cx;
-    const bx = b.cx;
-    const gutter = Math.max(ax, bx) + 46;
+    // Loop-back (retry/return): exit the RIGHT EDGE of `a`, run vertically in a
+    // side gutter, and re-enter the RIGHT EDGE of `b`. Dashed styling + the
+    // arrowhead show the return direction. The gutter sits just outside the
+    // wider of the two cards and is clamped to the canvas so it never overflows.
+    const aRight = a.cx + a.width / 2;
+    const bRight = b.cx + b.width / 2;
+    const gutter = Math.min(maxX - 6, Math.max(aRight, bRight) + 22);
     const ay = a.cy;
     const by = b.cy;
-    const r = CORNER;
+    const r = Math.min(CORNER, Math.abs(ay - by) / 2);
+    const up = ay > by ? -1 : 1; // vertical direction a → b
     const d = [
-      `M ${ax} ${ay}`,
+      `M ${aRight} ${ay}`,
       `H ${gutter - r}`,
-      `Q ${gutter} ${ay} ${gutter} ${ay - Math.sign(ay - by) * r}`,
-      `V ${by + Math.sign(ay - by) * r}`,
+      `Q ${gutter} ${ay} ${gutter} ${ay + up * r}`,
+      `V ${by - up * r}`,
       `Q ${gutter} ${by} ${gutter - r} ${by}`,
-      `H ${bx}`,
+      `H ${bRight}`,
     ].join(' ');
-    return { d, labelX: gutter + 6, labelY: (ay + by) / 2 };
+    return { d, labelX: Math.min(gutter + 4, maxX - 44), labelY: (ay + by) / 2 };
   }
 
   if (Math.abs(a.cx - b.cx) < 1) {

--- a/wiki/Workflows.md
+++ b/wiki/Workflows.md
@@ -12,32 +12,32 @@ This page is the index for all 30 workflows in the system.
 | 2 | **Single Issue Cycle** | `single-issue-cycle` | 15-step autonomous development cycle for one issue (receives pre-selected work item from ADL) | [Details](Workflow-Single-Issue-Cycle) |
 | 3 | **Issue Triage** | `issue-triage` | Fetch untriaged items, panel review, PO decision, apply labels | [Details](Workflow-Triage) |
 | 4 | **Context Gathering** | `context-gathering` | Sequential role-based codebase scanning via LLM Call sub-workflow | [Details](Workflow-Context-Gathering) |
-| 5 | **Plan Generation** | `plan-generation` | AI plan generation with human approval loop | [Details](Workflow-Single-Issue-Cycle#plan-generation) |
-| 6 | **Plan Review** | `plan-review` | 7-role LLM panel review (architect, dev, QA, security, devops, PO, orchestrator) with iterative discussion rounds | [Details](Workflow-Single-Issue-Cycle#plan-review) |
-| 7 | **Task Creation** | `task-creation` | Senior dev LLM breaks plan into deep implementation plans per task | [Details](Workflow-Single-Issue-Cycle#task-creation) |
-| 8 | **Task Review** | `task-review` | 4-role LLM panel review (architect, senior dev, dev, QA) of implementation tasks | [Details](Workflow-Single-Issue-Cycle#task-review) |
-| 9 | **Branch Creation** | `branch-creation` | Create a feature branch for the issue | [Details](Workflow-Single-Issue-Cycle#branch-creation) |
+| 5 | **Plan Generation** | `plan-generation` | AI plan generation with human approval loop | [Details](Workflow-Plan-Generation) |
+| 6 | **Plan Review** | `plan-review` | 7-role LLM panel review (architect, dev, QA, security, devops, PO, orchestrator) with iterative discussion rounds | [Details](Workflow-Plan-Review) |
+| 7 | **Task Creation** | `task-creation` | Senior dev LLM breaks plan into deep implementation plans per task | [Details](Workflow-Task-Creation) |
+| 8 | **Task Review** | `task-review` | 4-role LLM panel review (architect, senior dev, dev, QA) of implementation tasks | [Details](Workflow-Task-Review) |
+| 9 | **Branch Creation** | `branch-creation` | Create a feature branch for the issue | [Details](Workflow-Branch-Creation) |
 | 10 | **TDD Cycle** | `tdd-cycle` | Red-green-refactor TDD cycle for a single task | [Details](Workflow-TDD-Cycle) |
-| 11 | **TDD with Debug Retry** | `tdd-with-debug-retry` | TDD cycle with up to 3 debug retry iterations | [Details](Workflow-TDD-Cycle#tdd-with-debug-retry) |
-| 12 | **Test Case Creation** | `test-case-creation` | Generate test cases from task plans for TDD red phase | [Details](Workflow-Single-Issue-Cycle#test-case-creation) |
-| 13 | **Pull Request** | `pull-request` | Create a draft PR with implementation plan `.md` files | [Details](Workflow-Single-Issue-Cycle#pull-request) |
+| 11 | **TDD with Debug Retry** | `tdd-with-debug-retry` | TDD cycle with up to 3 debug retry iterations | [Details](Workflow-TDD-With-Debug-Retry) |
+| 12 | **Test Case Creation** | `test-case-creation` | Generate test cases from task plans for TDD red phase | [Details](Workflow-Test-Case-Creation) |
+| 13 | **Pull Request** | `pull-request` | Create a draft PR with implementation plan `.md` files | [Details](Workflow-Pull-Request) |
 | 14 | **Testing Pipeline** | `testing-pipeline` | CI trigger, wait, evaluate, auto-fix loop | [Details](Workflow-Testing) |
-| 15 | **CI with Debug Retry** | `ci-with-debug-retry` | Testing pipeline with up to 3 debug retry iterations | [Details](Workflow-Testing#ci-with-debug-retry) |
+| 15 | **CI with Debug Retry** | `ci-with-debug-retry` | Testing pipeline with up to 3 debug retry iterations | [Details](Workflow-CI-With-Debug-Retry) |
 | 16 | **Code Review** | `code-review` | Full PR lifecycle: create, review, fix, merge | [Details](Workflow-Code-Review) |
-| 17 | **Review Fix** | `review-fix` | Analyze PR review comments and apply AI fixes | [Details](Workflow-Code-Review#review-fix) |
-| 18 | **Merge Approval** | `merge-approval` | Bookmark-based human merge/test/reject decision | [Details](Workflow-Single-Issue-Cycle#merge-approval) |
-| 19 | **Merge Complete** | `merge-complete` | Squash-merge PR, close issue, delete branch | [Details](Workflow-Single-Issue-Cycle#merge) |
-| 20 | **Deployment Pipeline** | `deployment-pipeline` | Post-merge deployment: QA -> UAT -> Production | [Details](Workflow-Single-Issue-Cycle#deployment-pipeline) |
-| 21 | **Update Issue Status** | `update-issue-status` | Fire-and-forget issue updates with tech-writer LLM summaries | [Details](Workflow-Single-Issue-Cycle#update-issue-status) |
+| 17 | **Review Fix** | `review-fix` | Analyze PR review comments and apply AI fixes | [Details](Workflow-Review-Fix) |
+| 18 | **Merge Approval** | `merge-approval` | Bookmark-based human merge/test/reject decision | [Details](Workflow-Merge-Approval) |
+| 19 | **Merge Complete** | `merge-complete` | Squash-merge PR, close issue, delete branch | [Details](Workflow-Merge) |
+| 20 | **Deployment Pipeline** | `deployment-pipeline` | Post-merge deployment: QA -> UAT -> Production | [Details](Workflow-Deployment-Pipeline) |
+| 21 | **Update Issue Status** | `update-issue-status` | Fire-and-forget issue updates with tech-writer LLM summaries | [Details](Workflow-Update-Issue-Status) |
 | 22 | **LLM Call** | `llm-call` | Universal LLM call with provider chain and circuit breaker | [Details](Workflow-LLM-Call) |
 | 23 | **Mentorship** | `mentorship` | 28-state mentorship session orchestration | [Details](Workflow-Mentorship) |
-| 24 | **Assessment** | `assessment` | Junior developer skill assessment with AI | [Details](Workflow-Mentorship#assessment) |
+| 24 | **Assessment** | `assessment` | Junior developer skill assessment with AI | [Details](Workflow-Assessment) |
 | 25 | **Blocker Diagnosis** | `blocker-diagnosis` | 4-level progressive blocker resolution | [Details](Workflow-Blocker-Diagnosis) |
 | 26 | **Debugging** | `debugging` | Systematic AI-driven debugging with 3 entry modes | [Details](Workflow-Debugging) |
 | 27 | **Triage Item Cycle** | `triage-item-cycle` | Singleton: context → panel → PO → labels for one item | [Details](Workflow-Triage-Item-Cycle) |
-| 28 | **Triage Context Gathering** | `triage-context-gathering` | Gather context for triage: code usage, deps, CVE, changelog | [Details](Workflow-Triage#triage-context-gathering) |
-| 29 | **Triage Panel Review** | `triage-panel-review` | 4-role panel reviews item for triage (security/dev/devops/qa) | [Details](Workflow-Triage#triage-panel-review) |
-| 30 | **Triage PO Decision** | `triage-po-decision` | PO makes final triage decision based on panel review | [Details](Workflow-Triage#triage-po-decision) |
+| 28 | **Triage Context Gathering** | `triage-context-gathering` | Gather context for triage: code usage, deps, CVE, changelog | [Details](Workflow-Triage-Context-Gathering) |
+| 29 | **Triage Panel Review** | `triage-panel-review` | 4-role panel reviews item for triage (security/dev/devops/qa) | [Details](Workflow-Triage-Panel-Review) |
+| 30 | **Triage PO Decision** | `triage-po-decision` | PO makes final triage decision based on panel review | [Details](Workflow-Triage-PO-Decision) |
 
 ## Dependency Diagram
 


### PR DESCRIPTION
Three fixes from live-wiki feedback:

1. **Sub-workflow links pointed to the parent** (Notify, Create Draft PR → `single-issue-cycle`). Root cause: `wiki/Workflows.md` catalogued ~18 sub-workflows as **anchored sections of one page** (`Workflow-Single-Issue-Cycle#pull-request`, …); the generator strips the `#anchor`, collapsing every `wikiPage` to the parent. → (a) navigate by each workflow's **unique `id`**, not the wikiPage slug; (b) rewrote the 18 catalogue `[Details]` links to each workflow's **own already-existing dedicated page** (`Workflow-Pull-Request`, `Workflow-Update-Issue-Status`, …). They're first-class workflows; the links were just wrong.
2. **Direction arrows** on every rail (SVG marker, colour-matched) so flow direction is clear.
3. **Cleaner loop routing** — loop-backs exit/re-enter at the card edge in a clamped side gutter (no overflow), dashed + arrowed, instead of bowing from card centres.

Verified in-browser: Notify → `/workflows/update-issue-status/map`; arrows show direction; the CI-retry loop routes in a clean right gutter; no horizontal overflow at mobile 430. Auto-deploys to wiki.tamma.dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)