### PR TITLE
fix(workflow-viewer): make rails between steps clickable

### DIFF
--- a/packages/workflow-viewer/src/WorkflowMap.tsx
+++ b/packages/workflow-viewer/src/WorkflowMap.tsx
@@ -147,8 +147,10 @@ export function WorkflowMap({
               </marker>
             </defs>
             {geom.railPaths.map((rp) => (
-              <g key={rp.id}>
+              <g key={rp.id} className="twv-rail">
+                {/* visible rail — decorative; clicks are handled by the hit path */}
                 <path
+                  className="twv-rail-line"
                   d={rp.d}
                   fill="none"
                   stroke={rp.color}
@@ -159,6 +161,15 @@ export function WorkflowMap({
                   opacity={rp.isBackEdge ? 0.85 : 0.95}
                   markerEnd="url(#twv-rail-arrow)"
                 />
+                {/* wide invisible hit area — click a line to open the step it leads to */}
+                <path
+                  className="twv-rail-hit"
+                  d={rp.d}
+                  fill="none"
+                  onClick={() => onStepChange?.(rp.to)}
+                >
+                  <title>{rp.title}</title>
+                </path>
               </g>
             ))}
           </svg>
@@ -261,6 +272,10 @@ interface RailPath {
   d: string;
   color: string;
   isBackEdge: boolean;
+  /** Destination node id — clicking the rail opens this step. */
+  to: string;
+  /** Tooltip, e.g. "Valid → Gather Context". */
+  title: string;
 }
 interface RailLabel {
   id: string;
@@ -333,7 +348,14 @@ function computeGeometry(layout: MapLayout, width: number): Geometry {
     if (!a || !b) continue;
     const color = LINE_COLORS[rail.line % LINE_COLORS.length]!;
     const { d, labelX, labelY } = orthogonalPath(a, b, rail.isBackEdge, w);
-    railPaths.push({ id: rail.id, d, color, isBackEdge: rail.isBackEdge });
+    railPaths.push({
+      id: rail.id,
+      d,
+      color,
+      isBackEdge: rail.isBackEdge,
+      to: rail.to,
+      title: rail.label ? `${rail.label} → ${b.node.name}` : `→ ${b.node.name}`,
+    });
     if (rail.label) {
       railLabels.push({ id: rail.id, label: rail.label, x: labelX, y: labelY });
     }

--- a/packages/workflow-viewer/src/styles.css
+++ b/packages/workflow-viewer/src/styles.css
@@ -289,9 +289,18 @@
   position: absolute;
   inset: 0;
   width: 100%;
-  pointer-events: none;
   z-index: 1;
 }
+/* The visible rail is decorative; a wide transparent hit-path takes the clicks.
+   Stations sit above (z-index 3), so a rail is only clickable in the gaps. */
+.twv-rail-line { pointer-events: none; }
+.twv-rail-hit {
+  stroke: transparent;
+  stroke-width: 16;
+  pointer-events: stroke;
+  cursor: pointer;
+}
+.twv-rail:hover .twv-rail-line { opacity: 1; stroke-width: 4.5; }
 
 .twv-map-rail-label {
   position: absolute;


### PR DESCRIPTION
## What

The lines/rails between steps on the workflow map are now clickable. Clicking a line opens the step it leads into.

## How

- Each rail renders two SVG paths inside a `<g class="twv-rail">`:
  - `.twv-rail-line` — the visible decorative rail (with the direction arrow), `pointer-events: none`.
  - `.twv-rail-hit` — a wide (16px) transparent stroke with `pointer-events: stroke` and `cursor: pointer` that captures the click and calls `onStepChange(rail.to)`.
- Stations stack above the rail SVG (`z-index: 3` vs `1`), so a rail is only clickable in the gaps between cards — station clicks continue to open their own step, unchanged.
- Added a `<title>` tooltip (`"<label> → <destination>"`) and a hover affordance that brightens/thickens the line.

## Verification

Verified in-browser (Playwright) on `ci-with-debug-retry/map`:
- Clicking the first rail → URL became `?step=DispatchTestingPipeline` and the "Testing Pipeline" step popup opened (the line's destination).
- Clicking a station (`CI Retries < Max?`) → `?step=CiRetryGuard` — stations still independently clickable over the new hit-layer.

Source-only change to `@tamma/workflow-viewer`; deploy regenerates `public/content/**` via `sync-content` at build time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)