### PR TITLE
feat(32-18): agent registry enablement gate + Epic-27 prompt source

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/AgentDtos.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/AgentDtos.cs
@@ -60,6 +60,14 @@ public sealed record PublishVersionRequest(
     string? Notes);
 
 /// <summary>List/summary projection of an <c>Agent</c>.</summary>
+/// <remarks>
+/// Story 32-18 — <see cref="Enabled"/> is the per-tenant enablement flag for a
+/// public persona (own-private agents are implicitly enabled). It is
+/// <c>null</c> on the default member listing (which already filters to
+/// <c>enabled(public) ∪ own-private</c>, so a flag is redundant) and is set only
+/// on the admin <c>?includeDisabled=true</c> view, where the full catalog is
+/// returned and the flag tells the admin what they could enable.
+/// </remarks>
 public sealed record AgentSummary(
     Guid Id,
     string Name,
@@ -68,7 +76,8 @@ public sealed record AgentSummary(
     string Status,
     Guid? OwnerTenantId,
     Guid? OwnerUserId,
-    Guid? CurrentVersionId);
+    Guid? CurrentVersionId,
+    bool? Enabled = null);
 
 /// <summary>Full agent detail (summary + version list).</summary>
 public sealed record AgentDetail(

--- a/apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/AgentDtos.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/AgentDtos.cs
@@ -65,8 +65,10 @@ public sealed record PublishVersionRequest(
 /// public persona (own-private agents are implicitly enabled). It is
 /// <c>null</c> on the default member listing (which already filters to
 /// <c>enabled(public) ∪ own-private</c>, so a flag is redundant) and is set only
-/// on the admin <c>?includeDisabled=true</c> view, where the full catalog is
-/// returned and the flag tells the admin what they could enable.
+/// on the admin <c>?includeDisabled=true</c> view, which ADDITIONALLY surfaces
+/// DISABLED public personas (still subject to any <c>visibility</c>/<c>status</c>
+/// query filters — not a literally-unfiltered catalog) so the flag tells the
+/// admin what they could enable.
 /// </remarks>
 public sealed record AgentSummary(
     Guid Id,

--- a/apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/AgentRegistryDtos.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/AgentRegistryDtos.cs
@@ -12,10 +12,17 @@ namespace Tamma.Api.Dtos.Agents;
 /// <c>active</c>/<c>archived</c>); role is a canonical
 /// <c>RolePhaseMap.ValidRoles</c> wire string.
 /// </summary>
+/// <remarks>
+/// Story 32-18 — <see cref="IncludeDisabled"/> (owner/admin only) returns the
+/// FULL public catalog (not just the enabled set) with an <c>enabled</c> flag per
+/// row, so an admin can see what they could enable. Members never see disabled
+/// public personas; the flag is ignored for non-admin callers.
+/// </remarks>
 public sealed record AgentListFilter(
     string? Role = null,
     string? Visibility = null,
-    string? Status = null);
+    string? Status = null,
+    bool IncludeDisabled = false);
 
 /// <summary>
 /// Body for <c>PUT /api/agents/role-selections/{role}</c> — which agent (public

--- a/apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/AgentRegistryDtos.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Dtos/Agents/AgentRegistryDtos.cs
@@ -13,10 +13,14 @@ namespace Tamma.Api.Dtos.Agents;
 /// <c>RolePhaseMap.ValidRoles</c> wire string.
 /// </summary>
 /// <remarks>
-/// Story 32-18 — <see cref="IncludeDisabled"/> (owner/admin only) returns the
-/// FULL public catalog (not just the enabled set) with an <c>enabled</c> flag per
-/// row, so an admin can see what they could enable. Members never see disabled
-/// public personas; the flag is ignored for non-admin callers.
+/// Story 32-18 — <see cref="IncludeDisabled"/> (owner/admin only) ADDITIONALLY
+/// surfaces DISABLED public personas (which the member view hides) with an
+/// <c>enabled</c> flag per row, so an admin can see what they could enable. The
+/// result is still subject to any <see cref="Visibility"/>/<see cref="Status"/>
+/// query filters — it is NOT a literally-unfiltered catalog (e.g.
+/// <c>?includeDisabled=true&amp;status=active</c> returns only active rows).
+/// Members never see disabled public personas; the flag is ignored for non-admin
+/// callers.
 /// </remarks>
 public sealed record AgentListFilter(
     string? Role = null,

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs
@@ -507,9 +507,11 @@ public static class AgentEndpoints
                 ? enabledPublicIds.Contains(a.Id)
                 : true; // own-private ⇒ implicitly enabled (visibility scoping already ran)
 
-        // ?includeDisabled=true is owner/admin-only and returns the FULL catalog
-        // with an `enabled` flag per row. Members never see disabled public
-        // personas, so the flag is ignored for them.
+        // ?includeDisabled=true is owner/admin-only and ADDITIONALLY surfaces
+        // disabled public personas (which the member view hides) with an `enabled`
+        // flag per row — still subject to the visibility/status filters applied
+        // above (it is NOT a literally-unfiltered catalog). Members never see
+        // disabled public personas, so the flag is ignored for them.
         if (filter.IncludeDisabled && IsTenantAdminOrOwner(principal))
         {
             var full = filtered.Select(a => ToSummary(a) with { Enabled = IsEnabled(a) }).ToList();

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/AgentEndpoints.cs
@@ -420,12 +420,14 @@ public static class AgentEndpoints
     /// </summary>
     public static async Task<IResult> ListAgents(
         IAgentRepository agents,
+        ITenantAgentEnablementReader enablement,
         ClaimsPrincipal principal,
         ITenantContext tenantContext,
         ITammaModeProvider modeProvider,
         string? role = null,
         string? visibility = null,
-        string? status = null)
+        string? status = null,
+        bool includeDisabled = false)
     {
         // Bind the wire params into the documented filter DTO + validate. Absent
         // / empty dimensions stay null (no filter). Validation mirrors the write
@@ -433,7 +435,8 @@ public static class AgentEndpoints
         var filter = new AgentListFilter(
             Role: string.IsNullOrWhiteSpace(role) ? null : role,
             Visibility: string.IsNullOrWhiteSpace(visibility) ? null : visibility,
-            Status: string.IsNullOrWhiteSpace(status) ? null : status);
+            Status: string.IsNullOrWhiteSpace(status) ? null : status,
+            IncludeDisabled: includeDisabled);
 
         string? roleFilter = null;
         if (filter.Role is not null)
@@ -488,9 +491,35 @@ public static class AgentEndpoints
         var filtered = visible.Where(a =>
             (roleFilter is null || string.Equals(a.Role, roleFilter, StringComparison.Ordinal)) &&
             (visibilityFilter is null || a.Visibility == visibilityFilter) &&
-            (statusFilter is null || a.Status == statusFilter));
+            (statusFilter is null || a.Status == statusFilter))
+            .ToList();
 
-        var summaries = filtered.Select(ToSummary).ToList();
+        // Story 32-18 — ENABLEMENT-AWARE listing. The default member view is
+        // enabled(public) ∪ own-private; disabled public personas are hidden. A
+        // single batch read (32-16 ListEnabledPublicAgentIdsAsync) gives the
+        // enabled set; own-private agents are implicitly enabled (no row).
+        var principalRecord = new Principal(tenantId, userId);
+        var enabledPublicIds =
+            (await enablement.ListEnabledPublicAgentIdsAsync(principalRecord)).ToHashSet();
+
+        bool IsEnabled(Agent a) =>
+            a.Visibility == AgentVisibility.Public
+                ? enabledPublicIds.Contains(a.Id)
+                : true; // own-private ⇒ implicitly enabled (visibility scoping already ran)
+
+        // ?includeDisabled=true is owner/admin-only and returns the FULL catalog
+        // with an `enabled` flag per row. Members never see disabled public
+        // personas, so the flag is ignored for them.
+        if (filter.IncludeDisabled && IsTenantAdminOrOwner(principal))
+        {
+            var full = filtered.Select(a => ToSummary(a) with { Enabled = IsEnabled(a) }).ToList();
+            return Results.Ok(full);
+        }
+
+        var summaries = filtered
+            .Where(IsEnabled)
+            .Select(ToSummary)
+            .ToList();
         return Results.Ok(summaries);
     }
 
@@ -581,7 +610,8 @@ public static class AgentEndpoints
     public static async Task<IResult> Resolve(
         string? role,
         string? phase,
-        IAgentResolverService resolver)
+        IAgentResolverService resolver,
+        string? action = null)
     {
         if (string.IsNullOrWhiteSpace(role))
         {
@@ -590,14 +620,25 @@ public static class AgentEndpoints
 
         try
         {
+            // Story 32-18 — a phase (which doubles as the Epic-27 action) takes the
+            // phase-eligibility path; otherwise the role-based path threads the
+            // optional ?action= key to the persona prompt source.
             var resolved = string.IsNullOrWhiteSpace(phase)
-                ? await resolver.ResolveForRoleAsync(role)
+                ? await resolver.ResolveForRoleAsync(role, string.IsNullOrWhiteSpace(action) ? null : action)
                 : await resolver.ResolveForRoleAndPhaseAsync(phase, role);
             return Results.Ok(resolved);
         }
         catch (ArgumentException ex)
         {
             return Results.BadRequest(new { error = "invalid_role", detail = ex.Message });
+        }
+        catch (TammaError ex) when (ex.Code == AgentEventTypes.NoEnabledDefault)
+        {
+            // Story 32-18 — the principal has enabled no usable persona. No blank
+            // config — fail loud. 404: no enabled agent resolvable for the role.
+            return Results.Json(
+                new { error = "agent_no_enabled_default", detail = ex.Message },
+                statusCode: StatusCodes.Status404NotFound);
         }
         catch (TammaError ex) when (ex.Code == "AGENT.RESOLVE.NO_DEFAULT")
         {
@@ -646,6 +687,13 @@ public static class AgentEndpoints
         {
             // 404 (not 403) — never leak the existence of another tenant's agent.
             return Results.NotFound(new { error = "agent_not_found", detail = ex.Message });
+        }
+        catch (TammaError ex) when (ex.Code == AgentEventTypes.SelectNotEnabled)
+        {
+            // Story 32-18 — 409: the persona exists (it is in the catalog) but is
+            // not enabled for the principal — a state conflict, not a missing
+            // resource.
+            return Results.Conflict(new { error = "agent_not_enabled", detail = ex.Message });
         }
         catch (TammaError ex)
         {
@@ -825,6 +873,29 @@ public static class AgentEndpoints
     private static bool IsPlatformAdmin(ClaimsPrincipal principal)
         => string.Equals(
             principal.FindFirst("platformRole")?.Value, "platform_admin", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Story 32-18 — true if the caller is a tenant owner/admin (or platform
+    /// admin / service key), i.e. holds the <c>agents:manage</c> permission. Used
+    /// to gate the <c>?includeDisabled=true</c> full-catalog list view (members
+    /// never see disabled public personas). Mirrors <see cref="PermissionHandler"/>:
+    /// the per-tenant <c>role</c> claim against the <see cref="Permissions"/>
+    /// matrix, an API-key <c>permission</c> claim, or the platform-admin claim.
+    /// </summary>
+    private static bool IsTenantAdminOrOwner(ClaimsPrincipal principal)
+    {
+        var role = principal.FindFirst(ClaimTypes.Role)?.Value;
+        if (Permissions.HasPermission(role, "agents:manage"))
+        {
+            return true;
+        }
+        var perms = principal.FindAll("permission").Select(c => c.Value).ToList();
+        if (perms.Contains("agents:manage") || perms.Contains("*"))
+        {
+            return true;
+        }
+        return IsPlatformAdmin(principal);
+    }
 
     /// <summary>
     /// Resolve the caller's private-agent principal scope from the process

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/AgentResolverServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/AgentResolverServiceCollectionExtensions.cs
@@ -1,7 +1,11 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Tamma.Api.Services.Agents;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Data;
 using Tamma.Data.Repositories;
 
 namespace Tamma.Api.Extensions;
@@ -32,17 +36,32 @@ public static class AgentResolverServiceCollectionExtensions
             .Configure<IConfiguration>((opts, cfg) =>
                 cfg.GetSection(DefaultPersonaOptions.SectionPath).Bind(opts));
 
-        services.AddScoped<IAgentRegistryService, AgentRegistryService>();
-
         // Story 32-16 — per-tenant agent/persona enablement (catalog membership).
         // ONE implementation backs BOTH the write/admin service AND the read-only
         // reader seam 32-18 injects; register the reader against the same scoped
-        // instance so the gate and the API share one source of truth.
+        // instance so the gate and the API share one source of truth. Registered
+        // BEFORE the registry so the registry's enablement-gate constructor
+        // dependency resolves.
         services.AddScoped<TenantAgentEnablementService>();
         services.AddScoped<ITenantAgentEnablementService>(
             sp => sp.GetRequiredService<TenantAgentEnablementService>());
         services.AddScoped<ITenantAgentEnablementReader>(
             sp => sp.GetRequiredService<TenantAgentEnablementService>());
+
+        // Story 32-2 + 32-18 — the registry layers the per-tenant enablement gate
+        // (32-16 read seam) over selection/resolution. Use an explicit factory so
+        // the optional enablement reader is wired (the convenience constructor's
+        // optional params would otherwise leave it null and bypass the gate).
+        services.AddScoped<IAgentRegistryService>(sp => new AgentRegistryService(
+            sp.GetRequiredService<IAgentRepository>(),
+            sp.GetRequiredService<IAgentSelectionRepository>(),
+            sp.GetRequiredService<IEventRepository>(),
+            sp.GetRequiredService<ITammaModeProvider>(),
+            sp.GetRequiredService<ITenantContext>(),
+            sp.GetRequiredService<IHttpContextAccessor>(),
+            sp.GetService<IOptions<DefaultPersonaOptions>>(),
+            sp.GetRequiredService<ITenantAgentEnablementReader>(),
+            sp.GetService<ILogger<AgentRegistryService>>()));
 
         // Story 32-15 — the persona/public prompt seam over the Epic 27 store.
         services.AddScoped<IPersonaPromptResolver, PersonaPromptResolver>();

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentEventTypes.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentEventTypes.cs
@@ -17,4 +17,29 @@ public static class AgentEventTypes
     /// <summary>No agent resolvable for a taxonomy-valid role — the fail-loud
     /// branch (AC 9). Fires even when the missing-config recorder is absent.</summary>
     public const string ResolveFailed = "AGENT.RESOLVE.FAILED";
+
+    /// <summary>
+    /// Story 32-18 — a selection of a public persona was BLOCKED because the
+    /// persona is not enabled for the principal's catalog (per-tenant enablement
+    /// gate, 32-16). Maps to 409 <c>agent_not_enabled</c> at the endpoint. Tags
+    /// <c>{ agentId, personaName, role, mode, tenantId|userId }</c>.
+    /// </summary>
+    public const string SelectNotEnabled = "AGENT.SELECT.NOT_ENABLED";
+
+    /// <summary>
+    /// Story 32-18 — a stored selection pointed at a persona the principal has
+    /// since DISABLED; resolution degraded to the enabled default rather than
+    /// resolving the disabled persona. WARN-level audit event. Tags
+    /// <c>{ role, staleAgentId, fallbackSource, mode }</c>.
+    /// </summary>
+    public const string ResolveDegraded = "AGENT.RESOLVE.DEGRADED";
+
+    /// <summary>
+    /// Story 32-18 — the principal has enabled NO persona (and has no own-private
+    /// agent for the role), so there is no enabled default to resolve. The
+    /// fail-loud code carried by the <see cref="Tamma.Core.TammaError"/> the
+    /// resolver throws on this branch (alongside the mandatory
+    /// <see cref="ResolveFailed"/> audit event).
+    /// </summary>
+    public const string NoEnabledDefault = "AGENT.RESOLVE.NO_ENABLED_DEFAULT";
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRegistryService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRegistryService.cs
@@ -30,6 +30,16 @@ public sealed class AgentRegistryService : IAgentRegistryService
     private readonly ITenantContext _tenantContext;
     private readonly IHttpContextAccessor _httpContext;
     private readonly DefaultPersonaOptions _defaultPersona;
+
+    // Story 32-18 — the per-tenant enablement READ seam (32-16). The usability
+    // gate (CanUseAsync / SelectForRoleAsync / GetSystemDefaultPublicAsync)
+    // consumes it so a public persona is usable ONLY when enabled for the
+    // principal. Optional so the legacy 32-2/32-15 test harnesses (which predate
+    // this gate) keep constructing; production ALWAYS wires it (DI). When null,
+    // the gate degrades to the pre-32-18 "any public is usable" behaviour — used
+    // only by tests that don't exercise enablement.
+    private readonly ITenantAgentEnablementReader? _enablement;
+
     private readonly ILogger<AgentRegistryService>? _logger;
 
     public AgentRegistryService(
@@ -40,6 +50,7 @@ public sealed class AgentRegistryService : IAgentRegistryService
         ITenantContext tenantContext,
         IHttpContextAccessor httpContext,
         IOptions<DefaultPersonaOptions>? defaultPersona = null,
+        ITenantAgentEnablementReader? enablement = null,
         ILogger<AgentRegistryService>? logger = null)
     {
         _agents = agents;
@@ -49,6 +60,7 @@ public sealed class AgentRegistryService : IAgentRegistryService
         _tenantContext = tenantContext;
         _httpContext = httpContext;
         _defaultPersona = defaultPersona?.Value ?? new DefaultPersonaOptions();
+        _enablement = enablement;
         _logger = logger;
     }
 
@@ -66,55 +78,152 @@ public sealed class AgentRegistryService : IAgentRegistryService
         {
             return null;
         }
-        return CanUse(agent) ? agent : null;
+        return await CanUseAsync(agent, ct) ? agent : null;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> CanUseAsync(Agent agent, CancellationToken ct = default)
+    {
+        // Story 32-18 — PUBLIC personas are usable ONLY when enabled for the
+        // principal (32-16 read seam); PRIVATE/custom agents are usable iff owned
+        // by the principal's scope (implicit enablement by authorship). No code
+        // path treats a public persona as usable solely because it is public.
+        if (agent.Visibility == AgentVisibility.Public)
+        {
+            if (_enablement is null)
+            {
+                // Pre-32-18 fallback for legacy test harnesses that don't wire the
+                // enablement seam. Production ALWAYS wires it (DI), so the gate is
+                // never bypassed in a real deployment.
+                return true;
+            }
+            return await _enablement.IsEnabledForPrincipalAsync(agent.Id, CurrentPrincipal(), ct);
+        }
+
+        return IsOwnedByPrincipal(agent);
     }
 
     /// <inheritdoc />
     public async Task<Agent?> GetSystemDefaultPublicAsync(string role, CancellationToken ct = default)
     {
         // Story 32-15 — public agents are named cross-role PERSONAS, so the
-        // system default is the platform-configured DEFAULT PERSONA, resolved by
-        // handle among public agents REGARDLESS of role (the old "public agent
-        // whose Role==role" lookup + the >1-per-role ambiguity warning are gone).
+        // default is the platform-configured DEFAULT PERSONA (by handle, role-
+        // independent; the old "public agent whose Role==role" lookup + the
+        // >1-per-role ambiguity warning are gone).
+        //
+        // Story 32-18 — the default must also be ENABLED for the principal. The
+        // precedence is:
+        //   1. the configured DefaultPersonaName persona, IF the principal enabled it;
+        //   2. else the principal's enabled default per 32-16
+        //      (GetEnabledDefaultPersonaIdAsync — the configured default if enabled,
+        //      else the single enabled persona if unambiguous, else null);
+        //   3. else null ⇒ the resolver fails loud (AGENT.RESOLVE.NO_ENABLED_DEFAULT).
+        // There is NO empty/plain fallback (feedback_resolution_no_empty_fallback).
         var name = _defaultPersona.DefaultPersonaName;
-        var persona = await _agents.GetPublicByNameAsync(name, ct);
+        var configured = await _agents.GetPublicByNameAsync(name, ct);
 
-        if (persona is null || persona.Status != AgentStatus.Active)
+        // When the enablement seam is unwired (legacy test harnesses only), keep
+        // the pre-32-18 behaviour: the configured default persona MUST be seeded
+        // and active, else fail loud.
+        if (_enablement is null)
         {
-            // FAIL LOUD — no empty/plain fallback (feedback_resolution_no_empty_fallback).
-            _logger?.LogWarning(
-                "agent.default_persona.missing personaName={PersonaName} role={Role} — "
-                + "configured default persona is not seeded/active; failing loud",
-                name, role);
-            throw new TammaError(
-                "AGENT_DEFAULT_PERSONA_MISSING",
-                $"Configured default persona '{name}' is not seeded (or not active); "
-                + $"cannot resolve a default for role '{role}'. There is no empty/plain fallback.",
-                new Dictionary<string, object?> { ["personaName"] = name, ["role"] = role },
-                retryable: false,
-                severity: TammaErrorSeverity.High);
+            if (configured is null || configured.Status != AgentStatus.Active)
+            {
+                _logger?.LogWarning(
+                    "agent.default_persona.missing personaName={PersonaName} role={Role} — "
+                    + "configured default persona is not seeded/active; failing loud",
+                    name, role);
+                throw new TammaError(
+                    "AGENT_DEFAULT_PERSONA_MISSING",
+                    $"Configured default persona '{name}' is not seeded (or not active); "
+                    + $"cannot resolve a default for role '{role}'. There is no empty/plain fallback.",
+                    new Dictionary<string, object?> { ["personaName"] = name, ["role"] = role },
+                    retryable: false,
+                    severity: TammaErrorSeverity.High);
+            }
+
+            _logger?.LogInformation(
+                "agent.default_persona.resolved personaName={PersonaName} agentId={AgentId} role={Role}",
+                configured.Name, configured.Id, role);
+            return configured;
         }
 
-        _logger?.LogInformation(
-            "agent.default_persona.resolved personaName={PersonaName} agentId={AgentId} role={Role}",
-            persona.Name, persona.Id, role);
+        var principal = CurrentPrincipal();
 
-        return persona;
+        // 1. configured default persona IF enabled for the principal.
+        if (configured is not null
+            && configured.Status == AgentStatus.Active
+            && await _enablement.IsEnabledForPrincipalAsync(configured.Id, principal, ct))
+        {
+            _logger?.LogInformation(
+                "agent.default_persona.resolved branch=configured personaName={PersonaName} agentId={AgentId} role={Role}",
+                configured.Name, configured.Id, role);
+            return configured;
+        }
+
+        // 2. the principal's enabled default per 32-16.
+        var enabledDefaultId = await _enablement.GetEnabledDefaultPersonaIdAsync(principal, ct);
+        if (enabledDefaultId is Guid id)
+        {
+            var enabledDefault = await _agents.GetByIdAsync(id, ct);
+            if (enabledDefault is { Status: AgentStatus.Active })
+            {
+                _logger?.LogInformation(
+                    "agent.default_persona.resolved branch=enabled-default personaName={PersonaName} agentId={AgentId} role={Role}",
+                    enabledDefault.Name, enabledDefault.Id, role);
+                return enabledDefault;
+            }
+        }
+
+        // 3. nothing enabled ⇒ no default. The resolver fails loud
+        //    (AGENT.RESOLVE.NO_ENABLED_DEFAULT) — NO empty/plain fallback.
+        _logger?.LogWarning(
+            "agent.default_persona.none role={Role} configured={PersonaName} — "
+            + "principal has enabled no usable persona; resolver will fail loud",
+            role, name);
+        return null;
     }
 
     /// <inheritdoc />
     public async Task<AgentRoleSelection> SelectForRoleAsync(
         string role, Guid agentId, Guid? actingUserId, CancellationToken ct = default)
     {
-        // Target must be in (public ∪ own private). A cross-scope private target
-        // (or a non-existent id) is "not found" — never selectable, never leaked.
-        var agent = await ResolveUsableAgentAsync(agentId, ct);
-        if (agent is null)
+        // Target must be VISIBLE to the principal: a public persona (any) or the
+        // principal's own private agent. A cross-scope private target (or a
+        // non-existent id) is "not found" — never selectable, never leaked (404).
+        var agent = await _agents.GetByIdAsync(agentId, ct);
+        if (agent is null || !IsVisibleToPrincipal(agent))
         {
             throw new TammaError(
                 "AGENT.SELECT.NOT_FOUND",
                 $"Agent '{agentId}' is not selectable for role '{role}' (not public and not owned by the caller).",
                 new Dictionary<string, object?> { ["agentId"] = agentId, ["role"] = role },
+                retryable: false,
+                severity: TammaErrorSeverity.Medium);
+        }
+
+        // Story 32-18 — ENABLEMENT GATE. A visible PUBLIC persona that the
+        // principal has NOT enabled is a state CONFLICT (it is in the catalog but
+        // not exposed), not a missing resource: emit AGENT.SELECT.NOT_ENABLED and
+        // throw a 409-mapping TammaError. An own private/custom agent is implicitly
+        // enabled by authorship and skips the gate.
+        if (agent.Visibility == AgentVisibility.Public && !await CanUseAsync(agent, ct))
+        {
+            await AppendSelectNotEnabledEventAsync(agent, role, ct);
+            _logger?.LogWarning(
+                "agent.select.not_enabled agentId={AgentId} personaName={PersonaName} role={Role} — "
+                + "public persona is not enabled for the principal; blocking selection",
+                agent.Id, agent.Name, role);
+            throw new TammaError(
+                "AGENT.SELECT.NOT_ENABLED",
+                $"Persona '{agent.Name}' is not enabled for this {ModeLabel()}; "
+                + $"enable it before selecting it for role '{role}'. There is no empty/plain fallback.",
+                new Dictionary<string, object?>
+                {
+                    ["agentId"] = agentId,
+                    ["personaName"] = agent.Name,
+                    ["role"] = role,
+                },
                 retryable: false,
                 severity: TammaErrorSeverity.Medium);
         }
@@ -189,20 +298,36 @@ public sealed class AgentRegistryService : IAgentRegistryService
     private Guid? CurrentUserId()
         => _httpContext.HttpContext?.User?.GetUserId();
 
-    /// <summary>
-    /// True if the calling principal may USE the agent: any public agent, or a
-    /// private agent owned by the caller's scope.
-    /// </summary>
-    private bool CanUse(Agent agent)
+    /// <summary>The calling principal as the 32-15/32-16 <see cref="Principal"/>
+    /// record (exactly one of TenantId / UserId set per the mode).</summary>
+    private Principal CurrentPrincipal()
     {
-        if (agent.Visibility == AgentVisibility.Public)
-        {
-            return true;
-        }
+        var (tenantId, userId) = ResolvePrincipal();
+        return new Principal(tenantId, userId);
+    }
+
+    private string ModeLabel() => _mode.Mode == TammaMode.SaaS ? "tenant" : "user";
+
+    /// <summary>
+    /// True if the agent is OWNED by the calling principal's scope (an own
+    /// private/custom agent — implicitly enabled by authorship).
+    /// </summary>
+    private bool IsOwnedByPrincipal(Agent agent)
+    {
         var (tenantId, userId) = ResolvePrincipal();
         return (tenantId is not null && agent.OwnerTenantId == tenantId) ||
                (userId is not null && agent.OwnerUserId == userId);
     }
+
+    /// <summary>
+    /// True if the agent is VISIBLE to the calling principal: any public persona,
+    /// or a private agent owned by the principal's scope. Visibility is a weaker
+    /// check than usability (<see cref="CanUseAsync"/>) — a disabled public
+    /// persona is still visible (it is in the catalog), so selecting it is a 409
+    /// conflict, not a 404.
+    /// </summary>
+    private bool IsVisibleToPrincipal(Agent agent)
+        => agent.Visibility == AgentVisibility.Public || IsOwnedByPrincipal(agent);
 
     /// <summary>
     /// Provenance hint stored on a role selection. Must match the source the
@@ -247,6 +372,48 @@ public sealed class AgentRegistryService : IAgentRegistryService
             {
                 ["role"] = sel.Role,
                 ["agentId"] = sel.AgentId.ToString(),
+            }),
+            CreatedAt = DateTime.UtcNow,
+        });
+    }
+
+    /// <summary>
+    /// Story 32-18 — emit <c>AGENT.SELECT.NOT_ENABLED</c> when a selection of a
+    /// public persona is blocked by the enablement gate. Tags
+    /// <c>{ agentId, personaName, role, mode, tenantId|userId }</c>.
+    /// </summary>
+    private async Task AppendSelectNotEnabledEventAsync(Agent agent, string role, CancellationToken ct)
+    {
+        _ = ct;
+        var (tenantId, userId) = ResolvePrincipal();
+        var tags = new Dictionary<string, object?>
+        {
+            ["agentId"] = agent.Id.ToString(),
+            ["personaName"] = agent.Name,
+            ["role"] = role,
+            ["mode"] = _mode.Mode == TammaMode.SaaS ? "saas" : "single-user",
+        };
+        if (tenantId is Guid tid) tags["tenantId"] = tid.ToString();
+        if (userId is Guid uid) tags["userId"] = uid.ToString();
+
+        await _events.AppendAsync(new DomainEvent
+        {
+            Id = Guid.NewGuid(),
+            Type = AgentEventTypes.SelectNotEnabled,
+            // SaaS events land in the tenant store (ambient TenantId); single-user
+            // is a platform-feed row (TenantId null).
+            TenantId = tenantId,
+            Tags = JsonSerializer.Serialize(tags),
+            Metadata = JsonSerializer.Serialize(new
+            {
+                workflowVersion = WorkflowVersion,
+                eventSource = "system",
+            }),
+            Data = JsonSerializer.Serialize(new Dictionary<string, object?>
+            {
+                ["role"] = role,
+                ["agentId"] = agent.Id.ToString(),
+                ["personaName"] = agent.Name,
             }),
             CreatedAt = DateTime.UtcNow,
         });

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRegistryService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRegistryService.cs
@@ -71,6 +71,9 @@ public sealed class AgentRegistryService : IAgentRegistryService
             : ((Guid?)null, CurrentUserId());
 
     /// <inheritdoc />
+    public bool IsEnablementGateActive => _enablement is not null;
+
+    /// <inheritdoc />
     public async Task<Agent?> ResolveUsableAgentAsync(Guid agentId, CancellationToken ct = default)
     {
         var agent = await _agents.GetByIdAsync(agentId, ct);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentResolverService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentResolverService.cs
@@ -379,11 +379,14 @@ public sealed class AgentResolverService : IAgentResolverService
         }
 
         // Branch 4: NO empty/plain fallback — fail loud. Story 32-18 — when the
-        // enablement-aware lookup returned NULL (the principal has enabled nothing
-        // AND has no own-private agent for the role), distinguish the failure as
-        // AGENT.RESOLVE.NO_ENABLED_DEFAULT; the legacy seam-less "configured persona
-        // not seeded" path keeps the canonical AGENT.RESOLVE.NO_DEFAULT code.
-        var noEnabledDefault = systemDefault is null && !configuredPersonaMissing;
+        // ENABLEMENT GATE is active, the principal DID have an enabled default
+        // (whether the lookup returned NULL because nothing is enabled, OR returned
+        // a non-null enabled default that could not MATERIALISE because it has no
+        // active version): in every such case surface AGENT.RESOLVE.NO_ENABLED_DEFAULT.
+        // The canonical AGENT.RESOLVE.NO_DEFAULT is reserved for the legacy seam-less
+        // path (gate unwired) and the configured-persona-unseeded case
+        // (configuredPersonaMissing) — neither changes behaviour here.
+        var noEnabledDefault = !configuredPersonaMissing && _registry.IsEnablementGateActive;
         await FailLoudAsync(role, action, noEnabledDefault, ct);
         // Unreachable — FailLoudAsync always throws.
         throw new InvalidOperationException("unreachable");

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentResolverService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentResolverService.cs
@@ -250,8 +250,8 @@ public sealed class AgentResolverService : IAgentResolverService
 
     /// <inheritdoc />
     public async Task<ResolvedAgentConfig> ResolveForRoleAsync(
-        string role, CancellationToken ct = default)
-        => await ResolveEntityAsync(role, phase: null, ct);
+        string role, string? action = null, CancellationToken ct = default)
+        => await ResolveEntityAsync(role, action, ct);
 
     /// <inheritdoc />
     public async Task<ResolvedAgentConfig> ResolveForRoleAndPhaseAsync(
@@ -270,6 +270,7 @@ public sealed class AgentResolverService : IAgentResolverService
                 nameof(role));
         }
 
+        // The phase doubles as the Epic-27 action key for the prompt source.
         return await ResolveEntityAsync(role, phase, ct);
     }
 
@@ -277,9 +278,17 @@ public sealed class AgentResolverService : IAgentResolverService
     /// The 4-branch precedence chain (AC 3). NEVER returns an empty/plain
     /// config: the 4th branch emits <c>AGENT.RESOLVE.FAILED</c>, best-effort
     /// records a <c>MISSING_CONFIG</c> gap, then throws.
+    ///
+    /// <para>Story 32-18 — the precedence is now ENABLEMENT-AWARE: a stored
+    /// selection that points at a persona the principal has since DISABLED
+    /// degrades to the enabled default (emitting <c>AGENT.RESOLVE.DEGRADED</c>),
+    /// it is never resolved; the system-default branch returns the tenant's
+    /// ENABLED default persona (or null ⇒ fail loud
+    /// <c>AGENT.RESOLVE.NO_ENABLED_DEFAULT</c>). The <paramref name="action"/> is
+    /// the Epic-27 action key threaded into the prompt source.</para>
     /// </summary>
     private async Task<ResolvedAgentConfig> ResolveEntityAsync(
-        string role, string? phase, CancellationToken ct)
+        string role, string? action, CancellationToken ct)
     {
         role = RolePhaseMap.NormalizeRole(role);
         RolePhaseMap.AssertValidRole(role);
@@ -296,22 +305,36 @@ public sealed class AgentResolverService : IAgentResolverService
         var selections = await _registry.GetRoleSelectionsAsync(ct);
         if (selections.TryGetValue(role, out var sel))
         {
-            // Recompute provenance at resolve time — a stale/archived/cross-scope
-            // target degrades to the system default rather than resolving stale.
-            var selected = await _registry.ResolveUsableAgentAsync(sel.AgentId, ct);
-            if (selected is { Status: AgentStatus.Active })
+            // Fetch the raw target so we can distinguish:
+            //   - usable (enabled public OR own-private)  ⇒ resolve it;
+            //   - active+visible but NOT usable (a persona the tenant DISABLED
+            //     after selecting it) ⇒ DEGRADE (AGENT.RESOLVE.DEGRADED), never
+            //     resolve the disabled persona;
+            //   - archived / missing / cross-scope ⇒ stale-selection WARN, degrade.
+            var target = await _agents.GetByIdAsync(sel.AgentId, ct);
+            if (target is { Status: AgentStatus.Active } && await _registry.CanUseAsync(target, ct))
             {
-                var source = selected.Visibility == AgentVisibility.Public
+                var source = target.Visibility == AgentVisibility.Public
                     ? "tenant-public"   // principal SELECTED a public agent
                     : "tenant-private"; // principal's own private agent
-                var materialised = await MaterialiseAsync(selected, role, phase, source, ct);
+                var materialised = await MaterialiseAsync(target, role, action, source, ct);
                 if (materialised is not null)
                 {
                     _logger.LogDebug(
                         "agent.resolve.selection role={Role} agentId={AgentId} source={Source}",
-                        role, selected.Id, source);
+                        role, target.Id, source);
                     return materialised;
                 }
+            }
+            else if (target is { Status: AgentStatus.Active, Visibility: AgentVisibility.Public })
+            {
+                // Story 32-18 — a now-DISABLED public persona. Degrade to the
+                // enabled default with an auditable WARN, never resolve it.
+                _logger.LogWarning(
+                    "agent.resolve.degraded role={Role} staleAgentId={StaleAgentId} — "
+                    + "selected persona no longer enabled; degrading to enabled default",
+                    role, sel.AgentId);
+                await AppendDegradedEventAsync(role, sel.AgentId, ct);
             }
             else
             {
@@ -321,19 +344,23 @@ public sealed class AgentResolverService : IAgentResolverService
             }
         }
 
-        // Branch 3: system-default public PERSONA (Story 32-15 — the configured
-        // default persona, role-independent). GetSystemDefaultPublicAsync itself
-        // fails loud (AGENT_DEFAULT_PERSONA_MISSING) when the configured persona
-        // is not seeded; we treat that as "no system default" so the resolver
-        // still emits the mandatory AGENT.RESOLVE.FAILED audit event and throws
-        // its canonical no-default error (32-2 AC9 contract preserved).
+        // Branch 3: the tenant's ENABLED default persona (Story 32-18 over 32-15).
+        // GetSystemDefaultPublicAsync returns the configured default persona IF
+        // enabled, else the principal's enabled default (32-16), else NULL when the
+        // tenant has enabled nothing. A null here is the fail-loud signal — there
+        // is NO empty/plain fallback. (The legacy seam-less path may still throw
+        // AGENT_DEFAULT_PERSONA_MISSING when a configured persona is unseeded;
+        // treat that as "no default" so the canonical fail-loud event still fires.)
         Agent? systemDefault = null;
+        var configuredPersonaMissing = false;
         try
         {
             systemDefault = await _registry.GetSystemDefaultPublicAsync(role, ct);
         }
         catch (TammaError ex) when (ex.Code == "AGENT_DEFAULT_PERSONA_MISSING")
         {
+            // Legacy (seam-less) path only: a configured persona was not seeded.
+            configuredPersonaMissing = true;
             _logger.LogWarning(
                 "agent.resolve.default_persona_missing role={Role} — no configured default persona seeded",
                 role);
@@ -341,7 +368,7 @@ public sealed class AgentResolverService : IAgentResolverService
 
         if (systemDefault is not null)
         {
-            var materialised = await MaterialiseAsync(systemDefault, role, phase, "system-public", ct);
+            var materialised = await MaterialiseAsync(systemDefault, role, action, "system-public", ct);
             if (materialised is not null)
             {
                 _logger.LogDebug(
@@ -351,8 +378,13 @@ public sealed class AgentResolverService : IAgentResolverService
             }
         }
 
-        // Branch 4: NO empty/plain fallback — fail loud.
-        await FailLoudAsync(role, phase, ct);
+        // Branch 4: NO empty/plain fallback — fail loud. Story 32-18 — when the
+        // enablement-aware lookup returned NULL (the principal has enabled nothing
+        // AND has no own-private agent for the role), distinguish the failure as
+        // AGENT.RESOLVE.NO_ENABLED_DEFAULT; the legacy seam-less "configured persona
+        // not seeded" path keeps the canonical AGENT.RESOLVE.NO_DEFAULT code.
+        var noEnabledDefault = systemDefault is null && !configuredPersonaMissing;
+        await FailLoudAsync(role, action, noEnabledDefault, ct);
         // Unreachable — FailLoudAsync always throws.
         throw new InvalidOperationException("unreachable");
     }
@@ -367,7 +399,7 @@ public sealed class AgentResolverService : IAgentResolverService
     /// the caller can degrade to the next branch).
     /// </summary>
     private async Task<ResolvedAgentConfig?> MaterialiseAsync(
-        Agent agent, string role, string? phase, string source, CancellationToken ct)
+        Agent agent, string role, string? action, string source, CancellationToken ct)
     {
         var version = await _agents!.GetActiveVersionAsync(agent.Id, ct);
         if (version is null)
@@ -399,7 +431,7 @@ public sealed class AgentResolverService : IAgentResolverService
         // via the 32-15 IPersonaPromptResolver seam. Both fail loud (no
         // empty/plain fallback).
         var (systemPrompt, promptSource) =
-            await ResolvePromptSourceAsync(agent, version, role, phase, ct);
+            await ResolvePromptSourceAsync(agent, version, role, action, ct);
 
         // The agent's stable handle wins over the merged handle (identity).
         var enriched = new ResolvedAgentConfig
@@ -414,7 +446,7 @@ public sealed class AgentResolverService : IAgentResolverService
             Tools = resolved.Tools,
             SystemPrompt = systemPrompt,
             Source = source,
-            Phase = phase,
+            Phase = action,
             MaxBudgetUsd = resolved.MaxBudgetUsd,
             PermissionMode = resolved.PermissionMode,
             AllowedTools = resolved.AllowedTools,
@@ -494,10 +526,12 @@ public sealed class AgentResolverService : IAgentResolverService
         }
         var (tenantId, userId) = _registry!.ResolvePrincipal();
         var principal = new Principal(tenantId, userId);
-        // The entity-aware resolve path is role-based (no Epic 27 action), so we
-        // resolve the role-system (identity preamble) prompt; the seam is
-        // fail-loud internally (PROMPT_UNRESOLVED) — no empty/plain fallback.
-        var personaPrompt = await _personaPrompts.ResolveAsync(principal, role, action: null, ct);
+        // Story 32-18 — thread the Epic-27 ACTION key (AC7): the persona prompt
+        // resolves at (principal, role, action). When action is null the seam
+        // resolves the role-system (identity preamble) / action-default branch.
+        // The seam is fail-loud internally (PROMPT_UNRESOLVED) — no empty/plain
+        // fallback.
+        var personaPrompt = await _personaPrompts.ResolveAsync(principal, role, action, ct);
         return (personaPrompt, AgentPromptSource.Epic27Store);
     }
 
@@ -506,8 +540,14 @@ public sealed class AgentResolverService : IAgentResolverService
     /// (mandatory), best-effort records a <c>MISSING_CONFIG</c> gap (optional),
     /// then throws <see cref="TammaError"/>. Mirrors
     /// <c>PromptStoreService.NoPromptError</c> / <c>ConventionStore</c>.
+    ///
+    /// <para>Story 32-18 — when <paramref name="noEnabledDefault"/> is true the
+    /// failure is "the principal enabled no usable persona", thrown as
+    /// <c>AGENT.RESOLVE.NO_ENABLED_DEFAULT</c>; otherwise the canonical 32-2
+    /// <c>AGENT.RESOLVE.NO_DEFAULT</c>.</para>
     /// </summary>
-    private async Task FailLoudAsync(string role, string? phase, CancellationToken ct)
+    private async Task FailLoudAsync(
+        string role, string? phase, bool noEnabledDefault, CancellationToken ct)
     {
         var (tenantId, _) = _registry!.ResolvePrincipal();
         var tags = new Dictionary<string, object?>
@@ -559,7 +599,21 @@ public sealed class AgentResolverService : IAgentResolverService
         }
 
         _logger.LogError(
-            "AGENT.RESOLVE.FAILED role={Role} phase={Phase} — no agent resolvable", role, phase);
+            "AGENT.RESOLVE.FAILED role={Role} phase={Phase} noEnabledDefault={NoEnabledDefault} — no agent resolvable",
+            role, phase, noEnabledDefault);
+
+        if (noEnabledDefault)
+        {
+            throw new TammaError(
+                AgentEventTypes.NoEnabledDefault,
+                $"No enabled agent resolvable for role '{role}': the principal has enabled no "
+                + "usable persona and has no own-private agent for the role. Resolution is "
+                + "private-selection → enabled-public-selection → enabled-default-persona → error; "
+                + "there is no empty/plain fallback.",
+                new Dictionary<string, object?> { ["role"] = role, ["phase"] = phase },
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+        }
 
         throw new TammaError(
             "AGENT.RESOLVE.NO_DEFAULT",
@@ -569,6 +623,44 @@ public sealed class AgentResolverService : IAgentResolverService
             new Dictionary<string, object?> { ["role"] = role, ["phase"] = phase },
             retryable: false,
             severity: TammaErrorSeverity.High);
+    }
+
+    /// <summary>
+    /// Story 32-18 — emit <c>AGENT.RESOLVE.DEGRADED</c> (WARN-level) when a stored
+    /// selection pointed at a persona the principal has since DISABLED, so the
+    /// disablement-driven degrade is auditable. Tags
+    /// <c>{ role, staleAgentId, fallbackSource, mode }</c>.
+    /// </summary>
+    private async Task AppendDegradedEventAsync(string role, Guid staleAgentId, CancellationToken ct)
+    {
+        _ = ct;
+        var (tenantId, _) = _registry!.ResolvePrincipal();
+        var tags = new Dictionary<string, object?>
+        {
+            ["role"] = role,
+            ["staleAgentId"] = staleAgentId.ToString(),
+            ["fallbackSource"] = "system-public",
+            ["mode"] = tenantId is not null ? "saas" : "single-user",
+        };
+
+        await _events!.AppendAsync(new DomainEvent
+        {
+            Id = Guid.NewGuid(),
+            Type = AgentEventTypes.ResolveDegraded,
+            TenantId = tenantId,
+            Tags = JsonSerializer.Serialize(tags),
+            Metadata = JsonSerializer.Serialize(new
+            {
+                workflowVersion = "1.0.0",
+                eventSource = "system",
+            }),
+            Data = JsonSerializer.Serialize(new Dictionary<string, object?>
+            {
+                ["role"] = role,
+                ["staleAgentId"] = staleAgentId.ToString(),
+            }),
+            CreatedAt = DateTime.UtcNow,
+        });
     }
 
     // -----------------------------------------------------------------------

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/IAgentRegistryService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/IAgentRegistryService.cs
@@ -27,6 +27,16 @@ public interface IAgentRegistryService
     (Guid? TenantId, Guid? UserId) ResolvePrincipal();
 
     /// <summary>
+    /// Story 32-18 — true when the per-tenant ENABLEMENT GATE (32-16 read seam) is
+    /// wired (production ALWAYS wires it via DI). The resolver consumes this to pick
+    /// the accurate fail-loud code: when the gate is active, a fail-loud after a
+    /// non-null-but-unmaterialisable enabled default is <c>AGENT.RESOLVE.NO_ENABLED_DEFAULT</c>
+    /// (the principal HAD an enabled default); when the gate is unwired (legacy
+    /// seam-less test harnesses), the canonical <c>AGENT.RESOLVE.NO_DEFAULT</c> stays.
+    /// </summary>
+    bool IsEnablementGateActive { get; }
+
+    /// <summary>
     /// Resolve an agent the caller may USE: an ENABLED public persona (32-18 gate
     /// over 32-16), or a private agent owned by the caller's scope (implicitly
     /// enabled). Returns <c>null</c> for a non-existent id, a cross-scope private

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/IAgentRegistryService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/IAgentRegistryService.cs
@@ -27,27 +27,51 @@ public interface IAgentRegistryService
     (Guid? TenantId, Guid? UserId) ResolvePrincipal();
 
     /// <summary>
-    /// Resolve an agent the caller may USE: a public agent (any), or a private
-    /// agent owned by the caller's scope. Returns <c>null</c> for a
-    /// non-existent id OR a cross-scope private id (caller can't see it) — the
-    /// endpoint maps null → 404 to avoid an existence leak.
+    /// Resolve an agent the caller may USE: an ENABLED public persona (32-18 gate
+    /// over 32-16), or a private agent owned by the caller's scope (implicitly
+    /// enabled). Returns <c>null</c> for a non-existent id, a cross-scope private
+    /// id (caller can't see it), OR a public persona NOT enabled for the
+    /// principal — the endpoint maps null → 404 to avoid an existence leak.
     /// </summary>
     Task<Agent?> ResolveUsableAgentAsync(Guid agentId, CancellationToken ct = default);
 
     /// <summary>
-    /// The system-default public agent for a role: the active, public agent
-    /// whose <see cref="Agent.Role"/> matches (the <c>tamma-&lt;role&gt;</c>
-    /// shipped seed). Returns <c>null</c> when none is seeded — the resolver's
-    /// fail-loud branch (AC 9) then fires.
+    /// Story 32-18 — the usability predicate, enablement-aware: a PUBLIC persona
+    /// is usable iff it is ENABLED for the principal (32-16 read seam); a private
+    /// agent is usable iff owned by the principal's scope (implicit enablement by
+    /// authorship). No code path treats a public persona as usable solely because
+    /// it is public. The resolve precedence calls this to decide whether a stored
+    /// selection still resolves or must degrade to the enabled default.
+    /// </summary>
+    Task<bool> CanUseAsync(Agent agent, CancellationToken ct = default);
+
+    /// <summary>
+    /// The tenant's ENABLED default persona (Story 32-18 over 32-15/32-16).
+    /// Personas are cross-role (<see cref="Agent.Role"/> is NULL), so this no
+    /// longer matches <c>Role == role</c>: it returns the configured
+    /// <c>DefaultPersonaName</c> persona IF the principal has enabled it, else the
+    /// principal's enabled default per 32-16
+    /// (<c>GetEnabledDefaultPersonaIdAsync</c>), else <c>null</c>. A <c>null</c>
+    /// result is the resolver's fail-loud signal
+    /// (<c>AGENT.RESOLVE.NO_ENABLED_DEFAULT</c>) — never an empty/plain fallback.
     /// </summary>
     Task<Agent?> GetSystemDefaultPublicAsync(string role, CancellationToken ct = default);
 
     /// <summary>
     /// Persist which agent serves <paramref name="role"/> for the calling
-    /// principal. Validates the target is in (public ∪ own private); a
-    /// cross-scope/non-existent target throws
-    /// <see cref="Tamma.Core.TammaError"/> <c>AGENT.SELECT.NOT_FOUND</c> (mapped
-    /// to 404). Emits <c>AGENT.SELECTED_FOR_ROLE.SUCCESS</c> on a real upsert.
+    /// principal. Validates the target is selectable:
+    /// <list type="bullet">
+    ///   <item>a cross-scope/non-existent target throws
+    ///     <see cref="Tamma.Core.TammaError"/> <c>AGENT.SELECT.NOT_FOUND</c>
+    ///     (mapped to 404 — existence-leak-safe);</item>
+    ///   <item>Story 32-18 — a PUBLIC persona NOT enabled for the principal throws
+    ///     <c>AGENT.SELECT.NOT_ENABLED</c> (mapped to 409
+    ///     <c>agent_not_enabled</c>) and emits the
+    ///     <see cref="AgentEventTypes.SelectNotEnabled"/> audit event — selecting a
+    ///     disabled persona is a state conflict, not a missing resource;</item>
+    ///   <item>an own private/custom agent is implicitly enabled and is accepted.</item>
+    /// </list>
+    /// Emits <c>AGENT.SELECTED_FOR_ROLE.SUCCESS</c> on a real upsert.
     /// </summary>
     Task<AgentRoleSelection> SelectForRoleAsync(
         string role, Guid agentId, Guid? actingUserId, CancellationToken ct = default);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/IAgentResolverService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/IAgentResolverService.cs
@@ -70,11 +70,22 @@ public interface IAgentResolverService
     /// gap, then throws <see cref="Tamma.Core.TammaError"/>
     /// <c>AGENT.RESOLVE.NO_DEFAULT</c> (severity High) — mirroring the
     /// prompt/convention fail-loud rule.</para>
+    ///
+    /// <para>Story 32-18 — the optional <paramref name="action"/> is the Epic-27
+    /// action key threaded through to the persona prompt source
+    /// (<c>IPersonaPromptResolver</c>) and the custom-agent prompt source
+    /// (<c>ICustomAgentPromptResolver</c>), so the persona prompt resolves at
+    /// <c>(principal, role, action)</c> — matching the <c>LlmCallRequest.action</c>
+    /// the call-LLM endpoint (32-5) passes. When <c>null</c>, the role-system
+    /// (identity preamble) / action-default branch is used (still tenant→system→
+    /// error, never empty).</para>
     /// </summary>
     /// <exception cref="ArgumentException">Unknown role.</exception>
     /// <exception cref="Tamma.Core.TammaError">No agent resolvable
-    /// (<c>AGENT.RESOLVE.NO_DEFAULT</c>).</exception>
-    Task<ResolvedAgentConfig> ResolveForRoleAsync(string role, CancellationToken ct = default);
+    /// (<c>AGENT.RESOLVE.NO_DEFAULT</c> or, when the tenant has enabled nothing,
+    /// <c>AGENT.RESOLVE.NO_ENABLED_DEFAULT</c>).</exception>
+    Task<ResolvedAgentConfig> ResolveForRoleAsync(
+        string role, string? action = null, CancellationToken ct = default);
 
     /// <summary>
     /// Story 32-2 — same precedence chain as <see cref="ResolveForRoleAsync"/>

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentEnablementGateEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentEnablementGateEndpointsTests.cs
@@ -1,0 +1,349 @@
+using System.Collections.Concurrent;
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Auth;
+using Tamma.Api.Dtos.Agents;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Services.Agents;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Core;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Agents;
+
+/// <summary>
+/// Story 32-18 — endpoint-level mapping for the enablement gate. Drives the
+/// <see cref="AgentEndpoints"/> handlers directly against a real Postgres
+/// testcontainer with the real registry/resolver + a FAKED
+/// <see cref="ITenantAgentEnablementReader"/>. Covers: PUT role-selection at a
+/// disabled persona → 409 agent_not_enabled; Resolve with nothing enabled → 404
+/// agent_no_enabled_default; GET /api/agents member view = enabled∪own-private;
+/// ?includeDisabled=true admin view = full catalog + enabled flags; member
+/// ?includeDisabled ignored.
+/// </summary>
+[TestFixture]
+public class AgentEnablementGateEndpointsTests
+{
+    private static readonly Guid TenantA = Guid.Parse("aaaaaaaa-3218-e9d0-3218-aaaaaaaaaaaa");
+
+    private PostgreSqlContainer _postgres = null!;
+    private string _connectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("agent_enablement_gate_ep_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _connectionString = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE agent_role_selections, agent_versions, agents CASCADE;");
+    }
+
+    private ControlPlaneDbContext NewContext()
+        => new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseNpgsql(_connectionString).Options);
+
+    private const string Cfg = """{ "provider": "anthropic", "model": "claude-sonnet-4" }""";
+
+    private Stack BuildStack(
+        Guid? tenantId, bool admin, FakeEnablement enablement, string defaultPersonaName = "claude")
+    {
+        var cpCtx = NewContext();
+        var events = new CapturingEvents();
+        var agentRepo = new AgentRepository(cpCtx, events);
+
+        var tenantContext = new TenantContext();
+        if (tenantId is Guid tid) tenantContext.SetTenantId(tid);
+
+        var factory = new SameDbTenantFactory(_connectionString);
+        var selectionRepo = new AgentSelectionRepository(cpCtx, factory, tenantContext);
+        var modeProvider = new StubMode(TammaMode.SaaS);
+        var principal = Principal(admin);
+        var httpAccessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext { User = principal },
+        };
+
+        var personaOptions = Microsoft.Extensions.Options.Options.Create(
+            new DefaultPersonaOptions { DefaultPersonaName = defaultPersonaName });
+
+        var registry = new AgentRegistryService(
+            agentRepo, selectionRepo, events, modeProvider, tenantContext, httpAccessor,
+            personaOptions, enablement, NullLogger<AgentRegistryService>.Instance);
+        var resolver = new AgentResolverService(
+            new AgentConfigRepository(factory), null, NullLogger<AgentResolverService>.Instance,
+            registry, agentRepo, events, null, new StubPersonaPrompts());
+
+        return new Stack(agentRepo, registry, resolver, principal, enablement, tenantContext, cpCtx);
+    }
+
+    private sealed record Stack(
+        AgentRepository Agents,
+        AgentRegistryService Registry,
+        AgentResolverService Resolver,
+        ClaimsPrincipal Principal,
+        FakeEnablement Enablement,
+        TenantContext TenantContext,
+        ControlPlaneDbContext Ctx);
+
+    private static ClaimsPrincipal Principal(bool admin)
+    {
+        var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()) };
+        // The role claim drives Permissions.HasPermission("agents:manage").
+        claims.Add(new Claim(ClaimTypes.Role, admin ? "admin" : "member"));
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
+    }
+
+    private static async Task<(int Status, JsonElement Body)> ExecuteAsync(IResult result)
+    {
+        var services = new ServiceCollection().AddLogging().AddOptions().BuildServiceProvider();
+        var ctx = new DefaultHttpContext
+        {
+            RequestServices = services,
+            Response = { Body = new MemoryStream() },
+        };
+        await result.ExecuteAsync(ctx);
+        ctx.Response.Body.Seek(0, SeekOrigin.Begin);
+        if (ctx.Response.Body.Length == 0)
+        {
+            return (ctx.Response.StatusCode, default);
+        }
+        using var doc = await JsonDocument.ParseAsync(ctx.Response.Body);
+        return (ctx.Response.StatusCode, doc.RootElement.Clone());
+    }
+
+    private async Task<Agent> SeedPersonaAsync(AgentRepository repo, string name)
+        => await repo.CreateAsync(
+            new Agent { Name = name, Role = null, Visibility = AgentVisibility.Public }, Cfg, null, null);
+
+    private async Task<Agent> SeedTenantPrivateAsync(AgentRepository repo, Guid tenantId, string role, string name)
+        => await repo.CreateAsync(
+            new Agent { Name = name, Role = role, Visibility = AgentVisibility.Private, OwnerTenantId = tenantId },
+            Cfg, null, null);
+
+    // ── PUT role-selection at a disabled persona → 409 agent_not_enabled ──
+
+    [Test]
+    public async Task SelectForRole_DisabledPersona_Returns409_AgentNotEnabled()
+    {
+        var enablement = new FakeEnablement();
+        var s = BuildStack(TenantA, admin: true, enablement);
+        await using (s.Ctx)
+        {
+            var persona = await SeedPersonaAsync(s.Agents, "claude"); // NOT enabled
+
+            var result = await AgentEndpoints.SelectForRole(
+                "developer", new SelectRoleRequest(persona.Id), s.Registry, s.Principal);
+            var (status, body) = await ExecuteAsync(result);
+
+            status.Should().Be(StatusCodes.Status409Conflict);
+            body.GetProperty("error").GetString().Should().Be("agent_not_enabled");
+        }
+    }
+
+    [Test]
+    public async Task SelectForRole_EnabledPersona_Returns200()
+    {
+        var enablement = new FakeEnablement();
+        var s = BuildStack(TenantA, admin: true, enablement);
+        await using (s.Ctx)
+        {
+            var persona = await SeedPersonaAsync(s.Agents, "claude");
+            enablement.Enable(persona.Id);
+
+            var result = await AgentEndpoints.SelectForRole(
+                "developer", new SelectRoleRequest(persona.Id), s.Registry, s.Principal);
+            var (status, _) = await ExecuteAsync(result);
+
+            status.Should().Be(StatusCodes.Status200OK);
+        }
+    }
+
+    // ── Resolve with nothing enabled → 404 agent_no_enabled_default ──
+
+    [Test]
+    public async Task Resolve_NothingEnabled_Returns404_NoEnabledDefault()
+    {
+        var enablement = new FakeEnablement();
+        var s = BuildStack(TenantA, admin: true, enablement);
+        await using (s.Ctx)
+        {
+            await SeedPersonaAsync(s.Agents, "claude"); // seeded, NOT enabled
+
+            var (status, body) = await ExecuteAsync(
+                await AgentEndpoints.Resolve("developer", null, s.Resolver));
+
+            status.Should().Be(StatusCodes.Status404NotFound);
+            body.GetProperty("error").GetString().Should().Be("agent_no_enabled_default");
+        }
+    }
+
+    // ── GET /api/agents — member view = enabled(public) ∪ own-private ──
+
+    [Test]
+    public async Task ListAgents_Member_ReturnsOnlyEnabledPublic_PlusOwnPrivate()
+    {
+        var enablement = new FakeEnablement();
+        var s = BuildStack(TenantA, admin: false, enablement);
+        await using (s.Ctx)
+        {
+            var enabled = await SeedPersonaAsync(s.Agents, "claude");
+            var disabled = await SeedPersonaAsync(s.Agents, "gemini");
+            var ownPriv = await SeedTenantPrivateAsync(s.Agents, TenantA, "developer", "atlas");
+            enablement.Enable(enabled.Id);
+
+            var (status, body) = await ExecuteAsync(await AgentEndpoints.ListAgents(
+                s.Agents, enablement, s.Principal, s.TenantContext, new StubMode(TammaMode.SaaS)));
+
+            status.Should().Be(StatusCodes.Status200OK);
+            var ids = body.EnumerateArray().Select(e => e.GetProperty("id").GetGuid()).ToList();
+            ids.Should().Contain(enabled.Id);
+            ids.Should().Contain(ownPriv.Id);
+            ids.Should().NotContain(disabled.Id, "members never see disabled public personas");
+        }
+    }
+
+    // ── ?includeDisabled=true admin view = full catalog + enabled flags ──
+
+    [Test]
+    public async Task ListAgents_AdminIncludeDisabled_ReturnsFullCatalog_WithEnabledFlags()
+    {
+        var enablement = new FakeEnablement();
+        var s = BuildStack(TenantA, admin: true, enablement);
+        await using (s.Ctx)
+        {
+            var enabled = await SeedPersonaAsync(s.Agents, "claude");
+            var disabled = await SeedPersonaAsync(s.Agents, "gemini");
+            enablement.Enable(enabled.Id);
+
+            var (status, body) = await ExecuteAsync(await AgentEndpoints.ListAgents(
+                s.Agents, enablement, s.Principal, s.TenantContext, new StubMode(TammaMode.SaaS),
+                includeDisabled: true));
+
+            status.Should().Be(StatusCodes.Status200OK);
+            var rows = body.EnumerateArray().ToList();
+            var ids = rows.Select(e => e.GetProperty("id").GetGuid()).ToList();
+            ids.Should().Contain(enabled.Id);
+            ids.Should().Contain(disabled.Id, "admins see the full catalog incl. disabled");
+
+            bool EnabledFlag(Guid id) => rows
+                .Single(e => e.GetProperty("id").GetGuid() == id)
+                .GetProperty("enabled").GetBoolean();
+            EnabledFlag(enabled.Id).Should().BeTrue();
+            EnabledFlag(disabled.Id).Should().BeFalse();
+        }
+    }
+
+    [Test]
+    public async Task ListAgents_MemberIncludeDisabled_Ignored_StillHidesDisabled()
+    {
+        var enablement = new FakeEnablement();
+        var s = BuildStack(TenantA, admin: false, enablement);
+        await using (s.Ctx)
+        {
+            var enabled = await SeedPersonaAsync(s.Agents, "claude");
+            var disabled = await SeedPersonaAsync(s.Agents, "gemini");
+            enablement.Enable(enabled.Id);
+
+            var (status, body) = await ExecuteAsync(await AgentEndpoints.ListAgents(
+                s.Agents, enablement, s.Principal, s.TenantContext, new StubMode(TammaMode.SaaS),
+                includeDisabled: true));
+
+            status.Should().Be(StatusCodes.Status200OK);
+            var ids = body.EnumerateArray().Select(e => e.GetProperty("id").GetGuid()).ToList();
+            ids.Should().Contain(enabled.Id);
+            ids.Should().NotContain(disabled.Id, "?includeDisabled is admin-only; member view stays gated");
+        }
+    }
+
+    // ── test doubles ──
+
+    private sealed class FakeEnablement : ITenantAgentEnablementReader
+    {
+        private readonly HashSet<Guid> _enabled = new();
+        public void Enable(Guid id) => _enabled.Add(id);
+
+        public Task<bool> IsEnabledForPrincipalAsync(Guid agentId, Principal principal, CancellationToken ct = default)
+            => Task.FromResult(_enabled.Contains(agentId));
+        public Task<IReadOnlyList<Guid>> ListEnabledPublicAgentIdsAsync(Principal principal, CancellationToken ct = default)
+            => Task.FromResult((IReadOnlyList<Guid>)_enabled.ToList());
+        public Task<Guid?> GetEnabledDefaultPersonaIdAsync(Principal principal, CancellationToken ct = default)
+            => Task.FromResult(_enabled.Count == 1 ? _enabled.Single() : (Guid?)null);
+    }
+
+    private sealed class StubPersonaPrompts : IPersonaPromptResolver
+    {
+        public Task<string> ResolveAsync(
+            Principal principal, string role, string? action, CancellationToken ct = default)
+            => Task.FromResult($"[persona system prompt for role={role}]");
+    }
+
+    private sealed class StubMode(TammaMode mode) : ITammaModeProvider
+    {
+        public TammaMode Mode { get; } = mode;
+    }
+
+    private sealed class SameDbTenantFactory(string conn) : ITenantDbContextFactory
+    {
+        public ValueTask<TenantDbContext> CreateAsync(
+            Guid tenantId, CancellationToken cancellationToken = default)
+        {
+            var ctx = new TenantDbContext(
+                new DbContextOptionsBuilder<TenantDbContext>().UseNpgsql(conn).Options,
+                tenantId);
+            return ValueTask.FromResult(ctx);
+        }
+    }
+
+    private sealed class CapturingEvents : IEventRepository
+    {
+        public ConcurrentQueue<DomainEvent> Captured { get; } = new();
+        public Task<DomainEvent> AppendAsync(DomainEvent evt)
+        {
+            Captured.Enqueue(evt);
+            return Task.FromResult(evt);
+        }
+        public Task<DomainEvent?> GetByIdAsync(Guid id) => Task.FromResult<DomainEvent?>(null);
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit) =>
+            Task.FromResult(Captured.ToList());
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type) =>
+            Task.FromResult<DomainEvent?>(null);
+        public Task ClearAsync(Guid tenantId) => Task.CompletedTask;
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(
+            Guid? tenantId, string? type, int? issueNumber, int limit, int offset) =>
+            Task.FromResult(((IReadOnlyList<DomainEvent>)Captured.ToList(), Captured.Count));
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(
+            Guid tenantId, string? typePrefix, int limit, int offset) =>
+            Task.FromResult(((IReadOnlyList<DomainEvent>)Captured.ToList(), Captured.Count));
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentEnablementGateTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentEnablementGateTests.cs
@@ -1,0 +1,667 @@
+using System.Collections.Concurrent;
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Auth;
+using Tamma.Api.Services.Agents;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Core;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Agents;
+
+/// <summary>
+/// Story 32-18 — the per-tenant ENABLEMENT GATE over the shipped 32-2/32-15
+/// registry/resolver. Drives <see cref="AgentRegistryService"/> +
+/// <see cref="AgentResolverService"/> against a real Postgres testcontainer with
+/// a FAKED <see cref="ITenantAgentEnablementReader"/> (32-16) and a FAKED
+/// <see cref="IPersonaPromptResolver"/> (32-15) — this story consumes those seams
+/// and never re-implements them. Covers: the selection gate (enabled accepted /
+/// disabled → 409 + AGENT.SELECT.NOT_ENABLED / own-private accepted / cross-tenant
+/// 404), CanUseAsync truth table, resolution degrading past a disabled selection
+/// (AGENT.RESOLVE.DEGRADED), the enabled-default lookup incl. fail-loud
+/// (AGENT.RESOLVE.NO_ENABLED_DEFAULT), action plumbing, the mode matrix, and the
+/// no-credential assertion.
+/// </summary>
+[TestFixture]
+public class AgentEnablementGateTests
+{
+    private static readonly Guid TenantA = Guid.Parse("aaaaaaaa-3218-3218-3218-aaaaaaaaaaaa");
+    private static readonly Guid TenantB = Guid.Parse("bbbbbbbb-3218-3218-3218-bbbbbbbbbbbb");
+    private static readonly Guid UserA = Guid.Parse("cccccccc-3218-3218-3218-cccccccccccc");
+
+    private PostgreSqlContainer _postgres = null!;
+    private string _connectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("agent_enablement_gate_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _connectionString = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE agent_role_selections, agent_versions, agents CASCADE;");
+    }
+
+    private ControlPlaneDbContext NewContext()
+        => new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseNpgsql(_connectionString).Options);
+
+    private const string Cfg = """{ "provider": "anthropic", "model": "claude-sonnet-4" }""";
+
+    // ── harness ──
+
+    private Harness BuildHarness(
+        TammaMode mode, Guid? tenantId, Guid? userId,
+        FakeEnablement enablement,
+        string defaultPersonaName = "claude",
+        IPersonaPromptResolver? personaPrompts = null,
+        ICustomAgentPromptResolver? customPrompts = null)
+    {
+        var cpCtx = NewContext();
+        var events = new CapturingEvents();
+        var agentRepo = new AgentRepository(cpCtx, events);
+
+        var tenantContext = new TenantContext();
+        if (tenantId is Guid tid) tenantContext.SetTenantId(tid);
+
+        var factory = new SameDbTenantFactory(_connectionString);
+        var selectionRepo = new AgentSelectionRepository(cpCtx, factory, tenantContext);
+
+        var modeProvider = new StubMode(mode);
+        var httpAccessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext { User = Principal(userId) },
+        };
+
+        var personaOptions = Microsoft.Extensions.Options.Options.Create(
+            new DefaultPersonaOptions { DefaultPersonaName = defaultPersonaName });
+
+        var registry = new AgentRegistryService(
+            agentRepo, selectionRepo, events, modeProvider, tenantContext, httpAccessor,
+            personaOptions, enablement, NullLogger<AgentRegistryService>.Instance);
+
+        var legacyRepo = new AgentConfigRepository(factory);
+        var resolver = new AgentResolverService(
+            legacyRepo, null, NullLogger<AgentResolverService>.Instance,
+            registry, agentRepo, events, null,
+            personaPrompts ?? new CapturingPersonaPrompts("[PERSONA PROMPT]"),
+            customPrompts ?? new CustomAgentPromptResolver(
+                NullLogger<CustomAgentPromptResolver>.Instance));
+
+        return new Harness(resolver, registry, agentRepo, events, cpCtx);
+    }
+
+    private sealed record Harness(
+        AgentResolverService Resolver,
+        AgentRegistryService Registry,
+        AgentRepository Agents,
+        CapturingEvents Events,
+        ControlPlaneDbContext Ctx);
+
+    private static ClaimsPrincipal Principal(Guid? userId)
+    {
+        var claims = new List<Claim>();
+        if (userId is Guid uid) claims.Add(new Claim(ClaimTypes.NameIdentifier, uid.ToString()));
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
+    }
+
+    private async Task<Agent> SeedPersonaAsync(AgentRepository repo, string name)
+        => await repo.CreateAsync(
+            new Agent { Name = name, Role = null, Visibility = AgentVisibility.Public }, Cfg, "seed", null);
+
+    private async Task<Agent> SeedTenantPrivateAsync(AgentRepository repo, Guid tenantId, string role, string name)
+        => await repo.CreateAsync(
+            new Agent { Name = name, Role = role, Visibility = AgentVisibility.Private, OwnerTenantId = tenantId },
+            Cfg, "seed", null);
+
+    private async Task<Agent> SeedUserPrivateAsync(AgentRepository repo, Guid userId, string role, string name)
+        => await repo.CreateAsync(
+            new Agent { Name = name, Role = role, Visibility = AgentVisibility.Private, OwnerUserId = userId },
+            Cfg, "seed", null);
+
+    // ── (1) Enablement gate on selection ──
+
+    [Test]
+    public async Task Select_EnabledPublicPersona_Succeeds()
+    {
+        var enablement = new FakeEnablement();
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null, enablement);
+        await using (h.Ctx)
+        {
+            var persona = await SeedPersonaAsync(h.Agents, "claude");
+            enablement.Enable(persona.Id);
+            h.Events.Captured.Clear();
+
+            var sel = await h.Registry.SelectForRoleAsync("developer", persona.Id, null);
+
+            sel.AgentId.Should().Be(persona.Id);
+            h.Events.Captured.Should().ContainSingle(e => e.Type == "AGENT.SELECTED_FOR_ROLE.SUCCESS");
+            h.Events.Captured.Should().NotContain(e => e.Type == "AGENT.SELECT.NOT_ENABLED");
+        }
+    }
+
+    [Test]
+    public async Task Select_DisabledPublicPersona_Throws_NotEnabled_EmitsEvent()
+    {
+        var enablement = new FakeEnablement();
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null, enablement);
+        await using (h.Ctx)
+        {
+            var persona = await SeedPersonaAsync(h.Agents, "claude");
+            // NOT enabled.
+            h.Events.Captured.Clear();
+
+            Func<Task> act = async () => await h.Registry.SelectForRoleAsync("developer", persona.Id, null);
+
+            (await act.Should().ThrowAsync<TammaError>())
+                .Which.Code.Should().Be("AGENT.SELECT.NOT_ENABLED");
+
+            h.Events.Captured.Where(e => e.Type == "AGENT.SELECT.NOT_ENABLED").Should().HaveCount(1);
+            // No selection row was upserted.
+            var selections = await h.Registry.GetRoleSelectionsAsync();
+            selections.Should().NotContainKey("developer");
+        }
+    }
+
+    [Test]
+    public async Task Select_DisabledPersona_Event_CarriesPersonaNameAndRole()
+    {
+        var enablement = new FakeEnablement();
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null, enablement);
+        await using (h.Ctx)
+        {
+            var persona = await SeedPersonaAsync(h.Agents, "claude");
+            h.Events.Captured.Clear();
+
+            try { await h.Registry.SelectForRoleAsync("security", persona.Id, null); }
+            catch (TammaError) { /* expected */ }
+
+            var evt = h.Events.Captured.Single(e => e.Type == "AGENT.SELECT.NOT_ENABLED");
+            using var tags = JsonDocument.Parse(evt.Tags!);
+            tags.RootElement.GetProperty("agentId").GetString().Should().Be(persona.Id.ToString());
+            tags.RootElement.GetProperty("personaName").GetString().Should().Be("claude");
+            tags.RootElement.GetProperty("role").GetString().Should().Be("security");
+            tags.RootElement.GetProperty("mode").GetString().Should().Be("saas");
+        }
+    }
+
+    [Test]
+    public async Task Select_OwnPrivateAgent_Succeeds_GateSkipped()
+    {
+        var enablement = new FakeEnablement();
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null, enablement);
+        await using (h.Ctx)
+        {
+            var priv = await SeedTenantPrivateAsync(h.Agents, TenantA, "developer", "atlas");
+
+            var sel = await h.Registry.SelectForRoleAsync("developer", priv.Id, null);
+
+            sel.AgentId.Should().Be(priv.Id);
+            // own-private is implicitly enabled — the enablement reader is never
+            // even consulted for the gate decision.
+            enablement.IsEnabledCalls.Should().NotContain(priv.Id);
+        }
+    }
+
+    [Test]
+    public async Task Select_CrossTenantPrivateTarget_Returns_NotFound_Not409()
+    {
+        var enablement = new FakeEnablement();
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null, enablement);
+        await using (h.Ctx)
+        {
+            var foreign = await SeedTenantPrivateAsync(h.Agents, TenantB, "developer", "their-atlas");
+
+            Func<Task> act = async () => await h.Registry.SelectForRoleAsync("developer", foreign.Id, null);
+
+            (await act.Should().ThrowAsync<TammaError>())
+                .Which.Code.Should().Be("AGENT.SELECT.NOT_FOUND");
+        }
+    }
+
+    // ── (2) CanUseAsync truth table ──
+
+    [Test]
+    public async Task CanUseAsync_PublicEnabled_True_PublicDisabled_False()
+    {
+        var enablement = new FakeEnablement();
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null, enablement);
+        await using (h.Ctx)
+        {
+            var enabled = await SeedPersonaAsync(h.Agents, "claude");
+            var disabled = await SeedPersonaAsync(h.Agents, "gemini");
+            enablement.Enable(enabled.Id);
+
+            (await h.Registry.CanUseAsync(enabled)).Should().BeTrue();
+            (await h.Registry.CanUseAsync(disabled)).Should().BeFalse(
+                "a public persona is NOT usable solely because it is public");
+        }
+    }
+
+    [Test]
+    public async Task CanUseAsync_OwnPrivate_True_OtherTenantPrivate_False()
+    {
+        var enablement = new FakeEnablement();
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null, enablement);
+        await using (h.Ctx)
+        {
+            var own = await SeedTenantPrivateAsync(h.Agents, TenantA, "developer", "atlas");
+            var other = await SeedTenantPrivateAsync(h.Agents, TenantB, "developer", "their-atlas");
+
+            (await h.Registry.CanUseAsync(own)).Should().BeTrue();
+            (await h.Registry.CanUseAsync(other)).Should().BeFalse();
+        }
+    }
+
+    // ── (3) Resolution degrades past a disabled selection ──
+
+    [Test]
+    public async Task Resolve_SelectionDisabledAfterSelect_DegradesToEnabledDefault_EmitsDegraded()
+    {
+        var enablement = new FakeEnablement();
+        var persona = new CapturingPersonaPrompts("[SEAM PROMPT]");
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null, enablement,
+            defaultPersonaName: "claude", personaPrompts: persona);
+        await using (h.Ctx)
+        {
+            var def = await SeedPersonaAsync(h.Agents, "claude");
+            var picked = await SeedPersonaAsync(h.Agents, "gemini");
+            // Both enabled when selecting "gemini".
+            enablement.Enable(def.Id);
+            enablement.Enable(picked.Id);
+            await h.Registry.SelectForRoleAsync("developer", picked.Id, null);
+
+            // Now disable the selected persona — the stored selection is stale.
+            enablement.Disable(picked.Id);
+            h.Events.Captured.Clear();
+
+            var resolved = await h.Resolver.ResolveForRoleAsync("developer");
+
+            resolved.AgentId.Should().Be(def.Id, "degrades to the enabled default, not the disabled selection");
+            resolved.Source.Should().Be("system-public");
+            h.Events.Captured.Should().ContainSingle(e => e.Type == "AGENT.RESOLVE.DEGRADED");
+            var evt = h.Events.Captured.Single(e => e.Type == "AGENT.RESOLVE.DEGRADED");
+            using var tags = JsonDocument.Parse(evt.Tags!);
+            tags.RootElement.GetProperty("staleAgentId").GetString().Should().Be(picked.Id.ToString());
+            tags.RootElement.GetProperty("role").GetString().Should().Be("developer");
+        }
+    }
+
+    [Test]
+    public async Task Resolve_DisabledSelection_NeverMaterialisesDisabledPersona()
+    {
+        var enablement = new FakeEnablement();
+        // A persona-prompt resolver that records which roles it was asked for —
+        // proving the disabled persona is never materialised.
+        var persona = new CapturingPersonaPrompts("[SEAM PROMPT]");
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null, enablement,
+            defaultPersonaName: "claude", personaPrompts: persona);
+        await using (h.Ctx)
+        {
+            var def = await SeedPersonaAsync(h.Agents, "claude");
+            var picked = await SeedPersonaAsync(h.Agents, "gemini");
+            enablement.Enable(def.Id);
+            enablement.Enable(picked.Id);
+            await h.Registry.SelectForRoleAsync("developer", picked.Id, null);
+            enablement.Disable(picked.Id);
+
+            var resolved = await h.Resolver.ResolveForRoleAsync("developer");
+
+            // The resolved handle is the enabled default, never the disabled pick.
+            resolved.Handle.Should().Be("claude");
+            resolved.AgentId.Should().NotBe(picked.Id);
+        }
+    }
+
+    // ── (4) Enabled-default lookup ──
+
+    [Test]
+    public async Task GetSystemDefault_ConfiguredDefaultEnabled_Returned()
+    {
+        var enablement = new FakeEnablement();
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null, enablement, defaultPersonaName: "claude");
+        await using (h.Ctx)
+        {
+            var claude = await SeedPersonaAsync(h.Agents, "claude");
+            enablement.Enable(claude.Id);
+
+            var result = await h.Registry.GetSystemDefaultPublicAsync("developer");
+
+            result.Should().NotBeNull();
+            result!.Id.Should().Be(claude.Id);
+        }
+    }
+
+    [Test]
+    public async Task GetSystemDefault_ConfiguredDisabled_FallsToEnabledDefault()
+    {
+        var enablement = new FakeEnablement();
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null, enablement, defaultPersonaName: "claude");
+        await using (h.Ctx)
+        {
+            await SeedPersonaAsync(h.Agents, "claude");     // configured but NOT enabled
+            var gemini = await SeedPersonaAsync(h.Agents, "gemini");
+            enablement.Enable(gemini.Id);
+            enablement.EnabledDefault = gemini.Id;          // 32-16 says gemini is the enabled default
+
+            var result = await h.Registry.GetSystemDefaultPublicAsync("developer");
+
+            result.Should().NotBeNull();
+            result!.Id.Should().Be(gemini.Id);
+        }
+    }
+
+    [Test]
+    public async Task GetSystemDefault_NothingEnabled_ReturnsNull()
+    {
+        var enablement = new FakeEnablement();
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null, enablement, defaultPersonaName: "claude");
+        await using (h.Ctx)
+        {
+            await SeedPersonaAsync(h.Agents, "claude"); // seeded but NOT enabled
+
+            var result = await h.Registry.GetSystemDefaultPublicAsync("developer");
+
+            result.Should().BeNull("nothing enabled ⇒ no default; the resolver fails loud");
+        }
+    }
+
+    [Test]
+    public async Task Resolve_NothingEnabled_FailsLoud_NoEnabledDefault()
+    {
+        var enablement = new FakeEnablement();
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null, enablement, defaultPersonaName: "claude");
+        await using (h.Ctx)
+        {
+            await SeedPersonaAsync(h.Agents, "claude"); // seeded, NOT enabled, no own-private
+
+            Func<Task> act = async () => await h.Resolver.ResolveForRoleAsync("developer");
+
+            (await act.Should().ThrowAsync<TammaError>())
+                .Which.Code.Should().Be("AGENT.RESOLVE.NO_ENABLED_DEFAULT");
+
+            h.Events.Captured.Should().ContainSingle(e => e.Type == "AGENT.RESOLVE.FAILED");
+        }
+    }
+
+    // ── (5/7) Persona prompt dispatched to IPersonaPromptResolver (boundary) ──
+
+    [Test]
+    public async Task Resolve_EnabledPersona_PromptDispatchedToPersonaSeam_NotPromptStore()
+    {
+        var enablement = new FakeEnablement();
+        var persona = new CapturingPersonaPrompts("[SEAM PROMPT]");
+        var custom = new CountingCustomPrompts("[SHOULD NOT BE USED]");
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null, enablement,
+            defaultPersonaName: "claude", personaPrompts: persona, customPrompts: custom);
+        await using (h.Ctx)
+        {
+            var claude = await SeedPersonaAsync(h.Agents, "claude");
+            enablement.Enable(claude.Id);
+
+            var resolved = await h.Resolver.ResolveForRoleAsync("architect");
+
+            resolved.SystemPrompt.Should().Be("[SEAM PROMPT]");
+            resolved.PromptSource.Should().Be(AgentPromptSource.Epic27Store);
+            persona.CallCount.Should().Be(1, "the public persona dispatches to IPersonaPromptResolver");
+            custom.CallCount.Should().Be(0, "a persona NEVER takes the custom-agent seam");
+        }
+    }
+
+    [Test]
+    public async Task Resolve_EnabledPersona_SeamFailsLoud_Propagates_NoEmptyFallback()
+    {
+        var enablement = new FakeEnablement();
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null, enablement,
+            defaultPersonaName: "claude", personaPrompts: new ThrowingPersonaPrompts());
+        await using (h.Ctx)
+        {
+            var claude = await SeedPersonaAsync(h.Agents, "claude");
+            enablement.Enable(claude.Id);
+
+            Func<Task> act = async () => await h.Resolver.ResolveForRoleAsync("architect");
+            (await act.Should().ThrowAsync<TammaError>())
+                .Which.Code.Should().Be("PROMPT_UNRESOLVED");
+        }
+    }
+
+    // ── (6) Action key plumbing ──
+
+    [Test]
+    public async Task Resolve_WithAction_ThreadsActionToPersonaSeam()
+    {
+        var enablement = new FakeEnablement();
+        var persona = new CapturingPersonaPrompts("[SEAM PROMPT]");
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null, enablement,
+            defaultPersonaName: "claude", personaPrompts: persona);
+        await using (h.Ctx)
+        {
+            var claude = await SeedPersonaAsync(h.Agents, "claude");
+            enablement.Enable(claude.Id);
+
+            await h.Resolver.ResolveForRoleAsync("developer", action: "implement-feature");
+
+            persona.LastRole.Should().Be("developer");
+            persona.LastAction.Should().Be("implement-feature",
+                "the action key is threaded to the persona prompt source (AC7)");
+        }
+    }
+
+    [Test]
+    public async Task Resolve_WithoutAction_PassesNullActionToPersonaSeam()
+    {
+        var enablement = new FakeEnablement();
+        var persona = new CapturingPersonaPrompts("[SEAM PROMPT]");
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null, enablement,
+            defaultPersonaName: "claude", personaPrompts: persona);
+        await using (h.Ctx)
+        {
+            var claude = await SeedPersonaAsync(h.Agents, "claude");
+            enablement.Enable(claude.Id);
+
+            await h.Resolver.ResolveForRoleAsync("developer");
+
+            persona.LastAction.Should().BeNull("absent action ⇒ role-system / action-default branch");
+        }
+    }
+
+    // ── (8) Mode-parameterized principal ──
+
+    [Test]
+    [TestCase(TammaMode.SaaS)]
+    [TestCase(TammaMode.SingleUser)]
+    public async Task Resolve_Gate_EvaluatedAgainstModePrincipal(TammaMode mode)
+    {
+        var enablement = new FakeEnablement();
+        var tenantId = mode == TammaMode.SaaS ? (Guid?)TenantA : null;
+        var userId = mode == TammaMode.SingleUser ? (Guid?)UserA : null;
+        var h = BuildHarness(mode, tenantId, userId, enablement, defaultPersonaName: "claude");
+        await using (h.Ctx)
+        {
+            var claude = await SeedPersonaAsync(h.Agents, "claude");
+            enablement.Enable(claude.Id);
+
+            var resolved = await h.Resolver.ResolveForRoleAsync("developer");
+
+            resolved.Handle.Should().Be("claude");
+            // The gate consulted the principal matching the mode.
+            var lastPrincipal = enablement.LastPrincipal;
+            if (mode == TammaMode.SaaS)
+            {
+                lastPrincipal.TenantId.Should().Be(TenantA);
+                lastPrincipal.UserId.Should().BeNull();
+            }
+            else
+            {
+                lastPrincipal.UserId.Should().Be(UserA);
+                lastPrincipal.TenantId.Should().BeNull();
+            }
+        }
+    }
+
+    // ── (9) No credential in the resolve path ──
+
+    [Test]
+    public async Task Resolve_NeverCarriesACredential_ProviderAndModelOnly()
+    {
+        var enablement = new FakeEnablement();
+        var h = BuildHarness(TammaMode.SaaS, TenantA, null, enablement, defaultPersonaName: "claude");
+        await using (h.Ctx)
+        {
+            var claude = await h.Agents.CreateAsync(
+                new Agent { Name = "claude", Role = null, Visibility = AgentVisibility.Public },
+                """{ "provider": "anthropic", "model": "claude-sonnet-4-20250514" }""", "seed", null);
+            enablement.Enable(claude.Id);
+
+            var resolved = await h.Resolver.ResolveForRoleAsync("developer");
+
+            resolved.Provider.Should().Be("anthropic");
+            resolved.Model.Should().Be("claude-sonnet-4-20250514");
+            // ResolvedAgentConfig has NO ApiKey/credential field — assert by
+            // reflection that nothing key-shaped exists on the resolved config.
+            var props = typeof(ResolvedAgentConfig).GetProperties().Select(p => p.Name).ToList();
+            props.Should().NotContain(p => p.Contains("ApiKey", StringComparison.OrdinalIgnoreCase));
+            props.Should().NotContain(p => p.Contains("Credential", StringComparison.OrdinalIgnoreCase));
+            props.Should().NotContain(p => p.Contains("Secret", StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    // ── test doubles ──
+
+    /// <summary>Story 32-16 read-seam fake. Records calls so tests can assert the
+    /// gate was evaluated against the right principal and never for own-private.</summary>
+    private sealed class FakeEnablement : ITenantAgentEnablementReader
+    {
+        private readonly HashSet<Guid> _enabled = new();
+        public List<Guid> IsEnabledCalls { get; } = new();
+        public Principal LastPrincipal { get; private set; }
+        public Guid? EnabledDefault { get; set; }
+
+        public void Enable(Guid id) => _enabled.Add(id);
+        public void Disable(Guid id) => _enabled.Remove(id);
+
+        public Task<bool> IsEnabledForPrincipalAsync(Guid agentId, Principal principal, CancellationToken ct = default)
+        {
+            IsEnabledCalls.Add(agentId);
+            LastPrincipal = principal;
+            return Task.FromResult(_enabled.Contains(agentId));
+        }
+
+        public Task<IReadOnlyList<Guid>> ListEnabledPublicAgentIdsAsync(Principal principal, CancellationToken ct = default)
+        {
+            LastPrincipal = principal;
+            return Task.FromResult((IReadOnlyList<Guid>)_enabled.ToList());
+        }
+
+        public Task<Guid?> GetEnabledDefaultPersonaIdAsync(Principal principal, CancellationToken ct = default)
+        {
+            LastPrincipal = principal;
+            // If a test set an explicit enabled default, honour it; else the single
+            // enabled persona if unambiguous, else null (mirrors the real service).
+            if (EnabledDefault is { } d && _enabled.Contains(d)) return Task.FromResult<Guid?>(d);
+            return Task.FromResult(_enabled.Count == 1 ? _enabled.Single() : (Guid?)null);
+        }
+    }
+
+    private sealed class CapturingPersonaPrompts(string prompt) : IPersonaPromptResolver
+    {
+        public int CallCount { get; private set; }
+        public string? LastRole { get; private set; }
+        public string? LastAction { get; private set; }
+        public Task<string> ResolveAsync(
+            Principal principal, string role, string? action, CancellationToken ct = default)
+        {
+            CallCount++;
+            LastRole = role;
+            LastAction = action;
+            return Task.FromResult(prompt);
+        }
+    }
+
+    private sealed class ThrowingPersonaPrompts : IPersonaPromptResolver
+    {
+        public Task<string> ResolveAsync(
+            Principal principal, string role, string? action, CancellationToken ct = default)
+            => throw new TammaError("PROMPT_UNRESOLVED", "no prompt", retryable: false,
+                severity: TammaErrorSeverity.High);
+    }
+
+    private sealed class CountingCustomPrompts(string prompt) : ICustomAgentPromptResolver
+    {
+        public int CallCount { get; private set; }
+        public Task<string> ResolveAsync(
+            Guid agentId, AgentPromptSet prompts, string role, string? action, CancellationToken ct = default)
+        {
+            CallCount++;
+            return Task.FromResult(prompt);
+        }
+    }
+
+    private sealed class StubMode(TammaMode mode) : ITammaModeProvider
+    {
+        public TammaMode Mode { get; } = mode;
+    }
+
+    private sealed class SameDbTenantFactory(string conn) : ITenantDbContextFactory
+    {
+        public ValueTask<TenantDbContext> CreateAsync(
+            Guid tenantId, CancellationToken cancellationToken = default)
+        {
+            var ctx = new TenantDbContext(
+                new DbContextOptionsBuilder<TenantDbContext>().UseNpgsql(conn).Options,
+                tenantId);
+            return ValueTask.FromResult(ctx);
+        }
+    }
+
+    private sealed class CapturingEvents : IEventRepository
+    {
+        public ConcurrentQueue<DomainEvent> Captured { get; } = new();
+        public Task<DomainEvent> AppendAsync(DomainEvent evt)
+        {
+            Captured.Enqueue(evt);
+            return Task.FromResult(evt);
+        }
+        public Task<DomainEvent?> GetByIdAsync(Guid id) => Task.FromResult<DomainEvent?>(null);
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit) =>
+            Task.FromResult(Captured.ToList());
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type) =>
+            Task.FromResult<DomainEvent?>(null);
+        public Task ClearAsync(Guid tenantId) => Task.CompletedTask;
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(
+            Guid? tenantId, string? type, int? issueNumber, int limit, int offset) =>
+            Task.FromResult(((IReadOnlyList<DomainEvent>)Captured.ToList(), Captured.Count));
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(
+            Guid tenantId, string? typePrefix, int limit, int offset) =>
+            Task.FromResult(((IReadOnlyList<DomainEvent>)Captured.ToList(), Captured.Count));
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentEndpointsTests.cs
@@ -101,6 +101,42 @@ public class AgentEndpointsTests
     private static JsonElement Config(string json)
         => JsonDocument.Parse(json).RootElement.Clone();
 
+    /// <summary>
+    /// Story 32-18 — these Story 32-1/32-2 list tests assert the role/visibility/
+    /// status FILTERS and cross-tenant isolation, NOT the per-tenant enablement
+    /// gate (that is pinned by AgentEnablementGate(Endpoints)Tests). They feed an
+    /// "all public enabled" reader (every live public persona enabled) so the
+    /// visibility/filter behaviour they target is unaffected by the new gate.
+    /// </summary>
+    private static Tamma.Api.Services.Agents.ITenantAgentEnablementReader AllEnabled(
+        IAgentRepository repo)
+        => new AllPublicEnabledReader(repo);
+
+    private sealed class AllPublicEnabledReader(IAgentRepository repo)
+        : Tamma.Api.Services.Agents.ITenantAgentEnablementReader
+    {
+        public Task<bool> IsEnabledForPrincipalAsync(
+            Guid agentId, Tamma.Api.Services.Agents.Principal principal, CancellationToken ct = default)
+            => Task.FromResult(true);
+
+        public async Task<IReadOnlyList<Guid>> ListEnabledPublicAgentIdsAsync(
+            Tamma.Api.Services.Agents.Principal principal, CancellationToken ct = default)
+        {
+            // Every live (active, public) persona is "enabled" for this fake — the
+            // endpoint intersects this with the visibility-scoped rows, preserving
+            // the pre-gate list behaviour these filter tests assert.
+            var all = await repo.ListVisibleAsync(principal.TenantId, principal.UserId, ct);
+            return all
+                .Where(a => a.Visibility == AgentVisibility.Public && a.Status == AgentStatus.Active)
+                .Select(a => a.Id)
+                .ToList();
+        }
+
+        public Task<Guid?> GetEnabledDefaultPersonaIdAsync(
+            Tamma.Api.Services.Agents.Principal principal, CancellationToken ct = default)
+            => Task.FromResult((Guid?)null);
+    }
+
     private static readonly JsonElement ValidConfig =
         Config("""{ "provider": "anthropic", "model": "claude-sonnet-4" }""");
 
@@ -395,7 +431,7 @@ public class AgentEndpointsTests
                 repo, Principal(Guid.NewGuid()), TenantCtx(TenantB), Mode(TammaMode.SaaS)));
 
             var list = await AgentEndpoints.ListAgents(
-                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS));
+                repo, AllEnabled(repo), adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS));
             var (status, body) = await ExecuteAsync(list);
             status.Should().Be(StatusCodes.Status200OK);
 
@@ -460,7 +496,7 @@ public class AgentEndpointsTests
         {
             var adminA = await SeedFilterFixtureAsync(repo);
             var list = await AgentEndpoints.ListAgents(
-                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS));
+                repo, AllEnabled(repo), adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS));
             var (status, body) = await ExecuteAsync(list);
 
             status.Should().Be(StatusCodes.Status200OK);
@@ -479,7 +515,7 @@ public class AgentEndpointsTests
         {
             var adminA = await SeedFilterFixtureAsync(repo);
             var list = await AgentEndpoints.ListAgents(
-                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), role: "developer");
+                repo, AllEnabled(repo), adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), role: "developer");
             var (status, body) = await ExecuteAsync(list);
 
             status.Should().Be(StatusCodes.Status200OK);
@@ -497,7 +533,7 @@ public class AgentEndpointsTests
             // architect role matches a-architect (own private), pub-architect
             // (public), AND b-architect (tenant B private) — but B must be scoped out.
             var list = await AgentEndpoints.ListAgents(
-                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), role: "architect");
+                repo, AllEnabled(repo), adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), role: "architect");
             var (status, body) = await ExecuteAsync(list);
 
             status.Should().Be(StatusCodes.Status200OK);
@@ -516,7 +552,7 @@ public class AgentEndpointsTests
         {
             var adminA = await SeedFilterFixtureAsync(repo);
             var list = await AgentEndpoints.ListAgents(
-                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), visibility: "private");
+                repo, AllEnabled(repo), adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), visibility: "private");
             var (status, body) = await ExecuteAsync(list);
 
             status.Should().Be(StatusCodes.Status200OK);
@@ -536,7 +572,7 @@ public class AgentEndpointsTests
         {
             var adminA = await SeedFilterFixtureAsync(repo);
             var list = await AgentEndpoints.ListAgents(
-                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), visibility: "public");
+                repo, AllEnabled(repo), adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), visibility: "public");
             var (status, body) = await ExecuteAsync(list);
 
             status.Should().Be(StatusCodes.Status200OK);
@@ -552,7 +588,7 @@ public class AgentEndpointsTests
         {
             var adminA = await SeedFilterFixtureAsync(repo);
             var list = await AgentEndpoints.ListAgents(
-                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), status: "archived");
+                repo, AllEnabled(repo), adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), status: "archived");
             var (status, body) = await ExecuteAsync(list);
 
             status.Should().Be(StatusCodes.Status200OK);
@@ -568,7 +604,7 @@ public class AgentEndpointsTests
         {
             var adminA = await SeedFilterFixtureAsync(repo);
             var list = await AgentEndpoints.ListAgents(
-                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), status: "active");
+                repo, AllEnabled(repo), adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), status: "active");
             var (status, body) = await ExecuteAsync(list);
 
             status.Should().Be(StatusCodes.Status200OK);
@@ -587,7 +623,7 @@ public class AgentEndpointsTests
             var adminA = await SeedFilterFixtureAsync(repo);
             // private AND architect AND active → only a-architect.
             var list = await AgentEndpoints.ListAgents(
-                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS),
+                repo, AllEnabled(repo), adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS),
                 role: "architect", visibility: "private", status: "active");
             var (status, body) = await ExecuteAsync(list);
 
@@ -604,7 +640,7 @@ public class AgentEndpointsTests
         {
             var adminA = await SeedFilterFixtureAsync(repo);
             var list = await AgentEndpoints.ListAgents(
-                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), role: "wizard");
+                repo, AllEnabled(repo), adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), role: "wizard");
             var (status, body) = await ExecuteAsync(list);
 
             status.Should().Be(StatusCodes.Status400BadRequest);
@@ -620,7 +656,7 @@ public class AgentEndpointsTests
         {
             var adminA = await SeedFilterFixtureAsync(repo);
             var list = await AgentEndpoints.ListAgents(
-                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), visibility: "secret");
+                repo, AllEnabled(repo), adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), visibility: "secret");
             var (status, body) = await ExecuteAsync(list);
 
             status.Should().Be(StatusCodes.Status400BadRequest);
@@ -636,7 +672,7 @@ public class AgentEndpointsTests
         {
             var adminA = await SeedFilterFixtureAsync(repo);
             var list = await AgentEndpoints.ListAgents(
-                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), status: "deleted");
+                repo, AllEnabled(repo), adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), status: "deleted");
             var (status, body) = await ExecuteAsync(list);
 
             status.Should().Be(StatusCodes.Status400BadRequest);
@@ -653,7 +689,7 @@ public class AgentEndpointsTests
             var adminA = await SeedFilterFixtureAsync(repo);
             // Empty/whitespace params must NOT 400 and must NOT narrow.
             var list = await AgentEndpoints.ListAgents(
-                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS),
+                repo, AllEnabled(repo), adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS),
                 role: "", visibility: "  ", status: null);
             var (status, body) = await ExecuteAsync(list);
 
@@ -672,7 +708,7 @@ public class AgentEndpointsTests
             var adminA = await SeedFilterFixtureAsync(repo);
             // 'implementer' is a legacy alias for 'developer' (RolePhaseMap).
             var list = await AgentEndpoints.ListAgents(
-                repo, adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), role: "implementer");
+                repo, AllEnabled(repo), adminA, TenantCtx(TenantA), Mode(TammaMode.SaaS), role: "implementer");
             var (status, body) = await ExecuteAsync(list);
 
             status.Should().Be(StatusCodes.Status200OK);

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentRegistryEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentRegistryEndpointsTests.cs
@@ -101,7 +101,7 @@ public class AgentRegistryEndpointsTests
 
         var registry = new AgentRegistryService(
             agentRepo, selectionRepo, events, modeProvider, tenantContext, httpAccessor,
-            personaOptions, NullLogger<AgentRegistryService>.Instance);
+            personaOptions, enablement: null, NullLogger<AgentRegistryService>.Instance);
         var resolver = new AgentResolverService(
             new AgentConfigRepository(factory), null, NullLogger<AgentResolverService>.Instance,
             registry, agentRepo, events, null, new StubPersonaPrompts());
@@ -432,7 +432,7 @@ public class AgentRegistryEndpointsTests
         var registry = new AgentRegistryService(
             agentRepo, selectionRepo, events, new StubMode(TammaMode.SaaS),
             tenantContext, new HttpContextAccessor { HttpContext = new DefaultHttpContext() },
-            personaOptions, loggerFactory.CreateLogger<AgentRegistryService>());
+            personaOptions, enablement: null, loggerFactory.CreateLogger<AgentRegistryService>());
 
         await using (cpCtx)
         {
@@ -471,7 +471,7 @@ public class AgentRegistryEndpointsTests
         var registry = new AgentRegistryService(
             agentRepo, selectionRepo, events, new StubMode(TammaMode.SaaS),
             tenantContext, new HttpContextAccessor { HttpContext = new DefaultHttpContext() },
-            personaOptions, NullLogger<AgentRegistryService>.Instance);
+            personaOptions, enablement: null, NullLogger<AgentRegistryService>.Instance);
 
         await using (cpCtx)
         {

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentResolverChainTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentResolverChainTests.cs
@@ -108,7 +108,7 @@ public class AgentResolverChainTests
 
         var registry = new AgentRegistryService(
             agentRepo, selectionRepo, events, modeProvider, tenantContext, httpAccessor,
-            personaOptions, NullLogger<AgentRegistryService>.Instance);
+            personaOptions, enablement: null, NullLogger<AgentRegistryService>.Instance);
 
         // The legacy JSONB repo is never exercised by the entity-aware chain; a
         // real instance is wired so the full constructor is satisfied. Story


### PR DESCRIPTION
## Story 32-18 — Agent Registry Enablement Gate + Epic-27 Prompt Source

Adds the per-tenant **enablement gate** to agent selection/resolution and threads the Epic-27 `action` into the persona prompt source. Builds on 32-15 (persona reframe), 32-16 (`ITenantAgentEnablementReader`), 32-17 (`ICustomAgentPromptResolver`). **No new table/migration** — pure service-layer logic.

### What it does
- **Gate** (`AgentRegistryService`): `CanUseAsync` = public ⇒ `IsEnabledForPrincipalAsync`, private ⇒ owner-only. `SelectForRoleAsync` distinguishes visible-but-disabled public (→ `AGENT.SELECT.NOT_ENABLED` / 409) from missing/cross-tenant (→ 404). `GetSystemDefaultPublicAsync` is enablement-aware (configured default if enabled → `GetEnabledDefaultPersonaIdAsync` → null).
- **Resolve degrade** (`AgentResolverService`): a now-disabled public selection emits `AGENT.RESOLVE.DEGRADED` (WARN) and degrades to the enabled default — never resolves the disabled one; a null default fails loud with `AGENT.RESOLVE.NO_ENABLED_DEFAULT` (no empty fallback).
- **AC7**: `action` threaded through `ResolveForRoleAsync(role, action?)` to the persona seam.
- **Listing**: `enabled(public) ∪ own-private`; `?includeDisabled=true` (owner/admin) returns the catalog (subject to `visibility`/`status` filters) with an `enabled` flag.

### Reviews & verification
- **Spec review**: `SPEC_COMPLIANT` — all 12 ACs met with cited evidence; per-mode (single-user/SaaS) semantics, fail-loud/no-empty-fallback, and credential-free registry/resolver all correct.
- **Quality review**: `APPROVED` (no CRITICAL/IMPORTANT); two MINORs fixed in `836c2f13` — accurate `NO_ENABLED_DEFAULT` code when an enabled default exists but can't materialise (new `IsEnablementGateActive` signal), and `?includeDisabled` doc-comment accuracy.
- **Gate verified locally**: `dotnet build` 0 errors; `has-pending-model-changes` (ControlPlane) reports no pending changes; full `Tamma.Api.Tests` suite **3543 passed / 0 failed / 6 skipped** on the post-fix HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)