### PR TITLE
feat(32-4): SaaS provider gate stage for the call-LLM endpoint

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -855,6 +855,34 @@ builder.Services.AddScoped<
 // boot fallback.
 builder.Services.AddDbProviderPricing();
 
+// Story 32-4 — SaaS provider gate (composition step 1 of the 32-5 call-LLM
+// endpoint). In SaaS it denies cli-token (harness) + unknown providers
+// fail-closed (typed → HTTP 400) and un-entitled tenants (typed → 403); in
+// single-user it is a hard no-op. The gate is a pure service over existing
+// seams (mode + provider-auth lookup + entitlement + events + metrics) — NO EF
+// migration, NO new table, NO credential/secret dependency.
+//
+//   * IProviderAuthLookup → EntityProviderAuthLookup reads the 34-11
+//     Provider.AuthModel column (canonical source, now landed). To revert to
+//     the interim static allowlist, swap this ONE line for:
+//         builder.Services.AddSingleton<IProviderAuthLookup, StaticProviderAuthLookup>();
+//     The ProviderGateDecision / ISaaSProviderGate contract is identical for
+//     both (contract-neutral; pinned by the 34-11 swap matrix test).
+//   * ITenantProviderEntitlement → permissive default (every tenant entitled to
+//     every api-key provider). Replace with Epic 34's entitlement engine (DI
+//     swap) to activate the 403 TenantNotEntitled path; this story owns only
+//     the typed surfacing of the result, not the entitlement rules.
+builder.Services.AddScoped<
+    Tamma.Api.Services.Security.IProviderAuthLookup,
+    Tamma.Api.Services.Security.EntityProviderAuthLookup>();
+builder.Services.AddSingleton<
+    Tamma.Api.Services.Security.ITenantProviderEntitlement,
+    Tamma.Api.Services.Security.PermissiveTenantProviderEntitlement>();
+builder.Services.AddSingleton<Tamma.Api.Services.Security.ProviderGatingMetrics>();
+builder.Services.AddScoped<
+    Tamma.Api.Services.Security.ISaaSProviderGate,
+    Tamma.Api.Services.Security.SaaSProviderGate>();
+
 // Story 28-8 AC3 — short-TTL tenant status cache (per-pod, in-memory).
 // Cuts CP round-trips in TenantContextMiddleware on hot tenant requests.
 // Cluster-wide invalidation (RabbitMQ pub/sub) is a future enhancement —

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Security/EntityProviderAuthLookup.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Security/EntityProviderAuthLookup.cs
@@ -1,0 +1,79 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Tamma.Data;
+
+namespace Tamma.Api.Services.Security;
+
+/// <summary>
+/// Story 32-4 / 34-11 — the entity-backed <see cref="IProviderAuthLookup"/>.
+/// Reads <c>Provider.AuthModel</c> (<c>api-key</c> | <c>cli-token</c>) from the
+/// control-plane <c>providers</c> table (the canonical source once 34-11 has
+/// landed) for the requested provider key. Returns <c>null</c> for an unknown
+/// key — which drives the SaaS fail-closed DENY (never a permissive allow, per
+/// <c>feedback_resolution_no_empty_fallback</c>).
+///
+/// <para>This is the production default for <see cref="IProviderAuthLookup"/>:
+/// swapping it for / from <see cref="StaticProviderAuthLookup"/> is a single DI
+/// registration line, and the <see cref="ISaaSProviderGate"/> contract is
+/// identical for both (the 34-11 swap test pins contract-neutrality).</para>
+///
+/// <para>Reads through a short-lived scope (mirrors
+/// <c>DbProviderPricingService</c>) so it is safe behind any service lifetime.
+/// Matching is case-insensitive and trimmed.</para>
+/// </summary>
+public sealed class EntityProviderAuthLookup : IProviderAuthLookup
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<EntityProviderAuthLookup> _logger;
+
+    public EntityProviderAuthLookup(
+        IServiceScopeFactory scopeFactory,
+        ILogger<EntityProviderAuthLookup> logger)
+    {
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<ProviderAuthModel?> AuthModelAsync(
+        string? providerName, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(providerName))
+            return null;
+
+        var name = providerName.Trim();
+
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ControlPlaneDbContext>();
+
+        // Read only the AuthModel string for the provider key (case-insensitive).
+        // No tenant scope — provider cost/auth identity is platform-global (34-11).
+        var authModel = await db.Providers
+            .AsNoTracking()
+            .Where(p => EF.Functions.ILike(p.Key, name))
+            .Select(p => p.AuthModel)
+            .FirstOrDefaultAsync(ct);
+
+        if (string.IsNullOrWhiteSpace(authModel))
+            return null; // unknown provider ⇒ fail-closed deny in SaaS
+
+        return authModel.Trim().ToLowerInvariant() switch
+        {
+            "api-key" => ProviderAuthModel.ApiKey,
+            "cli-token" => ProviderAuthModel.CliToken,
+            _ => UnknownAuthModel(name, authModel),
+        };
+    }
+
+    private ProviderAuthModel? UnknownAuthModel(string providerName, string authModel)
+    {
+        // An unrecognised AuthModel string is a data defect — fail-closed (deny)
+        // rather than guess. The 34-11 CHECK pins the enum, so this should never
+        // fire in practice; we never silently allow.
+        _logger.LogWarning(
+            "Provider '{Provider}' has an unrecognised AuthModel '{AuthModel}'; "
+            + "treating as unknown (fail-closed deny in SaaS).",
+            providerName, authModel);
+        return null;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Security/EntityProviderAuthLookup.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Security/EntityProviderAuthLookup.cs
@@ -48,9 +48,12 @@ public sealed class EntityProviderAuthLookup : IProviderAuthLookup
 
         // Read only the AuthModel string for the provider key (case-insensitive).
         // No tenant scope — provider cost/auth identity is platform-global (34-11).
+        // Only ACTIVE providers are SaaS-eligible: a `retired` provider must
+        // resolve to null (unknown → fail-closed deny), mirroring 34-11's
+        // DbProviderPricingService which filters `Status == "active"`.
         var authModel = await db.Providers
             .AsNoTracking()
-            .Where(p => EF.Functions.ILike(p.Key, name))
+            .Where(p => p.Status == "active" && EF.Functions.ILike(p.Key, name))
             .Select(p => p.AuthModel)
             .FirstOrDefaultAsync(ct);
 

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Security/IProviderAuthLookup.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Security/IProviderAuthLookup.cs
@@ -1,0 +1,52 @@
+namespace Tamma.Api.Services.Security;
+
+/// <summary>
+/// Story 32-4 — the auth model a provider authenticates with. Drives SaaS
+/// eligibility (only <see cref="ApiKey"/> providers are reachable in SaaS).
+/// Mirrors the <c>Provider.AuthModel</c> string field (<c>api-key</c> |
+/// <c>cli-token</c>) introduced by sibling story 34-11 (design §4.2).
+/// </summary>
+public enum ProviderAuthModel
+{
+    /// <summary>
+    /// Cloud / local LLM API authenticated by an API key
+    /// (<c>ILLMProvider</c> / <c>IAIProvider</c>, <c>type:'llm-api'</c>).
+    /// SaaS-eligible — the key resolves from the principal's secret source
+    /// (Story 32-3) and the call runs server-side inside the call-LLM
+    /// endpoint.
+    /// </summary>
+    ApiKey,
+
+    /// <summary>
+    /// Headless CLI / token-based harness agent (<c>ICLIAgentProvider</c>,
+    /// <c>type:'cli-agent'</c> — e.g. <c>claude-code</c>, <c>opencode</c>,
+    /// <c>zen-mcp</c>). Spawns a local process and needs a host shell + local
+    /// credential — NOT reachable in SaaS; single-user / self-hosted only
+    /// (managed-LLM-execution deep-dive §1).
+    /// </summary>
+    CliToken,
+}
+
+/// <summary>
+/// Story 32-4 — the single eligibility read seam the SaaS provider gate
+/// consults. Returns the <see cref="ProviderAuthModel"/> for a provider key,
+/// or <c>null</c> when the provider is unknown (which drives the fail-closed
+/// DENY in SaaS — never a permissive allow, per
+/// <c>feedback_resolution_no_empty_fallback</c>).
+///
+/// <para>The interim implementation (<see cref="StaticProviderAuthLookup"/>)
+/// is keyed off <c>ProviderAllowlist.DefaultProviders</c>. Once 34-11's
+/// <c>Provider</c> entity is the canonical source, an
+/// <c>EntityProviderAuthLookup</c> backs this seam — swapping is a single DI
+/// registration line; the <see cref="ISaaSProviderGate"/> contract is
+/// unchanged.</para>
+/// </summary>
+public interface IProviderAuthLookup
+{
+    /// <summary>
+    /// Resolve the <see cref="ProviderAuthModel"/> for a provider name.
+    /// Case-insensitive and trimmed. Returns <c>null</c> for an unknown /
+    /// blank provider (drives the SaaS fail-closed deny).
+    /// </summary>
+    Task<ProviderAuthModel?> AuthModelAsync(string? providerName, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Security/ISaaSProviderGate.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Security/ISaaSProviderGate.cs
@@ -1,0 +1,92 @@
+namespace Tamma.Api.Services.Security;
+
+/// <summary>
+/// Story 32-4 — the reason a gate decision resolves the way it does. Maps 1:1
+/// to the design §2.4 call-LLM error envelope (consumed by 32-5's
+/// <c>ManagedAgent.RunAsync</c>).
+/// </summary>
+public enum ProviderGateOutcome
+{
+    /// <summary>Pass to composition step 2 (resolve agent). HTTP 200.</summary>
+    Allowed,
+
+    /// <summary>
+    /// A <c>cli-token</c> provider in SaaS, or an unknown provider
+    /// (fail-closed). The endpoint maps this to HTTP 400
+    /// <c>SAAS_PROVIDER_NOT_ALLOWED</c>.
+    /// </summary>
+    SaasProviderNotAllowed,
+
+    /// <summary>
+    /// A SaaS auth / entitlement rejection of the tenant for the managed-LLM
+    /// path. The endpoint maps this to HTTP 403 <c>TENANT_NOT_ENTITLED</c>.
+    /// </summary>
+    TenantNotEntitled,
+}
+
+/// <summary>
+/// Story 32-4 — the input to <see cref="ISaaSProviderGate.InspectAsync"/>. The
+/// gate is a pure function of <c>(mode, providerName, tenantEntitlement)</c>:
+/// it touches the provider NAME and the mode only — never a key, token, or
+/// secret.
+/// </summary>
+/// <param name="ProviderName">The resolved provider key for the request.</param>
+/// <param name="Role">Optional role context (audit only).</param>
+/// <param name="Action">Optional action context (audit only).</param>
+/// <param name="TenantId">The tenant the decision is scoped to (SaaS).</param>
+public sealed record ProviderGateContext(
+    string ProviderName,
+    string? Role = null,
+    string? Action = null,
+    Guid? TenantId = null);
+
+/// <summary>
+/// Story 32-4 — the typed gate decision the call-LLM endpoint maps to the
+/// design §2.4 envelope. The gate NEVER throws to signal a denial — a denial
+/// is a clean typed decision so a gated request can never leak a 500.
+/// </summary>
+/// <param name="Allowed"><c>true</c> ⇒ proceed to step 2; <c>false</c> ⇒ map the <see cref="Outcome"/> to the envelope.</param>
+/// <param name="Outcome">The §2.4 outcome category.</param>
+/// <param name="Reason">Human-readable, key-free reason; <c>null</c> when allowed.</param>
+/// <param name="AuthModel">The resolved auth model; <c>null</c> when the provider is unknown.</param>
+/// <param name="HttpStatusHint">200 allow / 400 not-allowed / 403 not-entitled.</param>
+public sealed record ProviderGateDecision(
+    bool Allowed,
+    ProviderGateOutcome Outcome,
+    string? Reason,
+    ProviderAuthModel? AuthModel,
+    int HttpStatusHint)
+{
+    /// <summary>An allow decision (single-user no-op, or SaaS api-key + entitled).</summary>
+    public static ProviderGateDecision Allow(ProviderAuthModel? model) =>
+        new(true, ProviderGateOutcome.Allowed, null, model, 200);
+}
+
+/// <summary>
+/// Story 32-4 — composition step 1 of the call-LLM endpoint
+/// (<c>POST /api/v1/llm/call</c>), invoked by 32-5's
+/// <c>ManagedAgent.RunAsync</c> BEFORE agent resolution (step 2), credential
+/// resolution (step 3), and the provider call (step 5).
+///
+/// <para>In single-user / self-hosted mode the gate is a hard no-op — every
+/// provider (including <c>cli-token</c> harness providers) ⇒ <c>Allowed</c>,
+/// with zero events and zero metric increments (harness providers are a
+/// legitimate local affordance). In SaaS mode it is load-bearing:
+/// <c>cli-token</c> and unknown providers ⇒ <see cref="ProviderGateOutcome.SaasProviderNotAllowed"/>
+/// (400, fail-closed); un-entitled tenants ⇒
+/// <see cref="ProviderGateOutcome.TenantNotEntitled"/> (403); only entitled
+/// <c>api-key</c> providers pass.</para>
+/// </summary>
+public interface ISaaSProviderGate
+{
+    /// <summary>
+    /// Inspect the resolved provider's auth model and the tenant's
+    /// entitlement, returning a typed <see cref="ProviderGateDecision"/>. On a
+    /// SaaS denial emits exactly one <c>AGENT.PROVIDER.GATED</c> event + one
+    /// <c>tamma.provider.gated</c> metric increment as a swallowed side effect
+    /// (an event-append failure never converts the decision into a 500). NEVER
+    /// throws to signal a denial; only a contract violation (a null
+    /// <paramref name="ctx"/>) may throw.
+    /// </summary>
+    Task<ProviderGateDecision> InspectAsync(ProviderGateContext ctx, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Security/ITenantProviderEntitlement.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Security/ITenantProviderEntitlement.cs
@@ -1,0 +1,40 @@
+namespace Tamma.Api.Services.Security;
+
+/// <summary>
+/// Story 32-4 — the minimal read seam for the SaaS auth / entitlement check
+/// (the 403 <see cref="ProviderGateOutcome.TenantNotEntitled"/> path). The gate
+/// owns ONLY the typed surfacing of the entitlement result, never the
+/// entitlement RULES — those are owned by Epic 34's SaaS auth/entitlement
+/// engine. When that engine exposes a richer surface, this seam is backed by it
+/// (a DI swap); the gate contract is unchanged.
+///
+/// <para>The shipped default (<see cref="PermissiveTenantProviderEntitlement"/>)
+/// returns <c>true</c> for every tenant × provider — so an <c>api-key</c>
+/// provider in SaaS is allowed by default. The 403 path only fires once a real
+/// entitlement engine is wired in place of the permissive default.</para>
+/// </summary>
+public interface ITenantProviderEntitlement
+{
+    /// <summary>
+    /// Is the tenant entitled to use the managed-LLM path for
+    /// <paramref name="providerName"/>? Evaluated only for <c>api-key</c>
+    /// providers in SaaS (after the auth-model classification, before allow).
+    /// A <c>false</c> result surfaces as a 403
+    /// <see cref="ProviderGateOutcome.TenantNotEntitled"/>.
+    /// </summary>
+    Task<bool> IsTenantEntitledAsync(Guid? tenantId, string providerName, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Story 32-4 — the shipped default entitlement seam: permissive (every tenant
+/// is entitled to every api-key provider). This keeps "api-key + entitled" the
+/// default SaaS behaviour while the typed 403 outcome surface is in place,
+/// ready for Epic 34's entitlement engine to replace it (DI swap, no contract
+/// change). It performs no I/O and reads no secret.
+/// </summary>
+public sealed class PermissiveTenantProviderEntitlement : ITenantProviderEntitlement
+{
+    public Task<bool> IsTenantEntitledAsync(
+        Guid? tenantId, string providerName, CancellationToken ct = default) =>
+        Task.FromResult(true);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Security/ProviderGatingMetrics.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Security/ProviderGatingMetrics.cs
@@ -1,0 +1,62 @@
+using System.Diagnostics.Metrics;
+
+namespace Tamma.Api.Services.Security;
+
+/// <summary>
+/// Story 32-4 — OpenTelemetry surface for the SaaS provider gate
+/// (<see cref="SaaSProviderGate"/>).
+///
+/// <list type="bullet">
+///   <item><description><c>tamma.provider.gated</c> — monotonic counter of SaaS
+///     gate denials, tagged with <c>provider</c>, <c>auth_model</c>
+///     (<c>cli-token</c> | <c>unknown</c> | <c>api-key</c>) and <c>reason</c>
+///     (<c>CLI_TOKEN_PROVIDER</c> | <c>PROVIDER_UNKNOWN</c> |
+///     <c>TENANT_NOT_ENTITLED</c>). Incremented exactly once per SaaS denial;
+///     never in single-user, never on an allow.</description></item>
+/// </list>
+///
+/// <para>Self-registering meter (see <c>KekRotationMetrics</c> /
+/// <c>AuditProjectionMetrics</c>): constructing a <see cref="Meter"/> with
+/// <see cref="MeterName"/> makes the counter discoverable; registering this
+/// class as a singleton in DI is sufficient. The plain <see cref="long"/>
+/// tally (<see cref="GatedTotal"/>) lets unit tests assert "exactly one
+/// increment" without subscribing a <see cref="MeterListener"/>.</para>
+/// </summary>
+public sealed class ProviderGatingMetrics : IDisposable
+{
+    /// <summary>Public meter name — pin so dashboards stay stable.</summary>
+    public const string MeterName = "Tamma.ProviderGating";
+
+    private readonly Meter _meter;
+    private readonly Counter<long> _gated;
+    private long _gatedTotal;
+
+    public ProviderGatingMetrics()
+    {
+        _meter = new Meter(MeterName, "1.0.0");
+
+        _gated = _meter.CreateCounter<long>(
+            "tamma.provider.gated",
+            unit: "{denial}",
+            description: "SaaS call-LLM provider-gate denials, tagged by provider, "
+                + "auth_model and reason (cli-token / unknown / not-entitled).");
+    }
+
+    /// <summary>In-process running total of gate denials since process start.</summary>
+    public long GatedTotal => Interlocked.Read(ref _gatedTotal);
+
+    /// <summary>
+    /// Record exactly one SaaS gate denial. <paramref name="authModel"/> is the
+    /// OTel-tag form (<c>cli-token</c> | <c>unknown</c> | <c>api-key</c>).
+    /// </summary>
+    public void RecordGated(string provider, string authModel, string reason)
+    {
+        Interlocked.Increment(ref _gatedTotal);
+        _gated.Add(1,
+            new KeyValuePair<string, object?>("provider", provider),
+            new KeyValuePair<string, object?>("auth_model", authModel),
+            new KeyValuePair<string, object?>("reason", reason));
+    }
+
+    public void Dispose() => _meter.Dispose();
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Security/SaaSProviderGate.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Security/SaaSProviderGate.cs
@@ -1,0 +1,184 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Security;
+
+/// <summary>
+/// Story 32-4 — the SaaS provider gate: composition step 1 of the call-LLM
+/// endpoint (<c>POST /api/v1/llm/call</c>). See <see cref="ISaaSProviderGate"/>.
+///
+/// <para>Single-user mode ⇒ hard no-op (Allow, no lookup, no event, no metric).
+/// SaaS mode ⇒ classify via <see cref="IProviderAuthLookup"/> (fail-closed on
+/// unknown), deny <c>cli-token</c> / unknown (400), check entitlement for
+/// <c>api-key</c> (403 if not entitled), else allow. The gate touches provider
+/// NAMES and the mode only — it has NO credential / secret dependency.</para>
+/// </summary>
+public sealed class SaaSProviderGate : ISaaSProviderGate
+{
+    private readonly ITammaModeProvider _mode;
+    private readonly IProviderAuthLookup _authLookup;
+    private readonly ITenantProviderEntitlement _entitlement;
+    private readonly IEventRepository _events;
+    private readonly ProviderGatingMetrics _metrics;
+    private readonly ILogger<SaaSProviderGate> _logger;
+
+    public SaaSProviderGate(
+        ITammaModeProvider mode,
+        IProviderAuthLookup authLookup,
+        ITenantProviderEntitlement entitlement,
+        IEventRepository events,
+        ProviderGatingMetrics metrics,
+        ILogger<SaaSProviderGate> logger)
+    {
+        _mode = mode ?? throw new ArgumentNullException(nameof(mode));
+        _authLookup = authLookup ?? throw new ArgumentNullException(nameof(authLookup));
+        _entitlement = entitlement ?? throw new ArgumentNullException(nameof(entitlement));
+        _events = events ?? throw new ArgumentNullException(nameof(events));
+        _metrics = metrics ?? throw new ArgumentNullException(nameof(metrics));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<ProviderGateDecision> InspectAsync(
+        ProviderGateContext ctx, CancellationToken ct = default)
+    {
+        // Contract violation — the ONLY case the gate may throw.
+        ArgumentNullException.ThrowIfNull(ctx);
+
+        // 1. single-user / self-hosted: hard no-op. Harness providers are a
+        //    legitimate local affordance — no lookup, no event, no metric.
+        if (_mode.Mode != TammaMode.SaaS)
+        {
+            _logger.LogDebug(
+                "SaaS provider gate no-op (single-user mode): provider={Provider}",
+                ctx.ProviderName);
+            return ProviderGateDecision.Allow(model: null);
+        }
+
+        // 2. SaaS: classify the provider (fail-closed on unknown).
+        var authModel = await _authLookup.AuthModelAsync(ctx.ProviderName, ct);
+        if (authModel is null || authModel == ProviderAuthModel.CliToken)
+        {
+            var reason = authModel is null ? "PROVIDER_UNKNOWN" : "CLI_TOKEN_PROVIDER";
+
+            if (authModel is null)
+            {
+                _logger.LogWarning(
+                    "SaaS provider gate denied unknown provider (fail-closed): "
+                    + "provider={Provider}, role={Role}, action={Action}, tenantId={TenantId}",
+                    ctx.ProviderName, ctx.Role, ctx.Action, ctx.TenantId);
+            }
+            else
+            {
+                _logger.LogInformation(
+                    "SaaS provider gated: provider={Provider}, authModel=cli-token, "
+                    + "outcome=SaasProviderNotAllowed, reason={Reason}, role={Role}, "
+                    + "action={Action}, tenantId={TenantId}",
+                    ctx.ProviderName, reason, ctx.Role, ctx.Action, ctx.TenantId);
+            }
+
+            await EmitGatedAsync(ctx, authModel, reason, ct);
+            return new ProviderGateDecision(
+                false,
+                ProviderGateOutcome.SaasProviderNotAllowed,
+                Reason: $"Provider '{ctx.ProviderName}' is not available in SaaS mode "
+                    + "(api-key providers only).",
+                AuthModel: authModel,
+                HttpStatusHint: 400);
+        }
+
+        // 3. SaaS auth / entitlement (Epic 34 seam). Provider is api-key — is the
+        //    tenant entitled to the managed-LLM path for it?
+        if (!await _entitlement.IsTenantEntitledAsync(ctx.TenantId, ctx.ProviderName, ct))
+        {
+            _logger.LogInformation(
+                "SaaS provider gated: provider={Provider}, authModel=api-key, "
+                + "outcome=TenantNotEntitled, reason=TENANT_NOT_ENTITLED, role={Role}, "
+                + "action={Action}, tenantId={TenantId}",
+                ctx.ProviderName, ctx.Role, ctx.Action, ctx.TenantId);
+
+            await EmitGatedAsync(ctx, authModel, "TENANT_NOT_ENTITLED", ct);
+            return new ProviderGateDecision(
+                false,
+                ProviderGateOutcome.TenantNotEntitled,
+                Reason: "Tenant is not entitled to the managed LLM path for this provider.",
+                AuthModel: authModel,
+                HttpStatusHint: 403);
+        }
+
+        // api-key + entitled ⇒ allow (no event, no metric).
+        _logger.LogDebug(
+            "SaaS provider gate allowed: provider={Provider}, authModel=api-key",
+            ctx.ProviderName);
+        return ProviderGateDecision.Allow(authModel);
+    }
+
+    /// <summary>
+    /// Emit exactly one <c>AGENT.PROVIDER.GATED</c> DCB event via the tenant
+    /// <see cref="IEventRepository"/> and increment the
+    /// <c>tamma.provider.gated</c> counter once. The event append is best-effort:
+    /// a failure is logged at ERROR and SWALLOWED so a clean typed decision never
+    /// becomes a 500. The metric is incremented regardless of append success.
+    /// </summary>
+    private async Task EmitGatedAsync(
+        ProviderGateContext ctx, ProviderAuthModel? authModel, string reason, CancellationToken ct)
+    {
+        var authModelTag = AuthModelTag(authModel);
+
+        // Metric first — a denial is always counted even if the event store is down.
+        _metrics.RecordGated(ctx.ProviderName, authModelTag, reason);
+
+        try
+        {
+            await _events.AppendAsync(new DomainEvent
+            {
+                Id = Guid.NewGuid(),
+                Type = "AGENT.PROVIDER.GATED",
+                TenantId = ctx.TenantId,
+                Tags = JsonSerializer.Serialize(new
+                {
+                    tenantId = ctx.TenantId?.ToString(),
+                    provider = ctx.ProviderName,
+                    authModel = authModelTag,
+                    mode = "saas",
+                    role = ctx.Role,
+                    action = ctx.Action,
+                }),
+                Metadata = JsonSerializer.Serialize(new
+                {
+                    workflowVersion = "1.0.0",
+                    eventSource = "system",
+                }),
+                Data = JsonSerializer.Serialize(new
+                {
+                    provider = ctx.ProviderName,
+                    authModel = authModelTag,
+                    mode = "saas",
+                    reason,
+                    role = ctx.Role,
+                    action = ctx.Action,
+                }),
+                CreatedAt = DateTime.UtcNow,
+            });
+        }
+        catch (Exception ex)
+        {
+            // Swallow — the deny/allow decision is never masked by an event-store
+            // failure. The metric was already incremented above.
+            _logger.LogError(ex,
+                "AGENT.PROVIDER.GATED event append failed; the typed gate decision "
+                + "still returns. provider={Provider}, reason={Reason}, tenantId={TenantId}",
+                ctx.ProviderName, reason, ctx.TenantId);
+        }
+    }
+
+    private static string AuthModelTag(ProviderAuthModel? authModel) => authModel switch
+    {
+        ProviderAuthModel.CliToken => "cli-token",
+        ProviderAuthModel.ApiKey => "api-key",
+        _ => "unknown",
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Security/SaaSProviderGate.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Security/SaaSProviderGate.cs
@@ -59,7 +59,36 @@ public sealed class SaaSProviderGate : ISaaSProviderGate
         }
 
         // 2. SaaS: classify the provider (fail-closed on unknown).
-        var authModel = await _authLookup.AuthModelAsync(ctx.ProviderName, ct);
+        //    AC4: eligibility that CANNOT be determined (the entity read throws —
+        //    a transient Npgsql/DbException, the future Epic-34 lookup, etc.) ⇒
+        //    DENY, never a leaked 500 and never a silent allow. Cancellation is
+        //    NOT a denial — it must propagate.
+        ProviderAuthModel? authModel;
+        try
+        {
+            authModel = await _authLookup.AuthModelAsync(ctx.ProviderName, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw; // a cancellation is not a gate denial — let it propagate.
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "SaaS provider gate could not determine eligibility (lookup failed); "
+                + "failing closed (deny). provider={Provider}, role={Role}, action={Action}, "
+                + "tenantId={TenantId}",
+                ctx.ProviderName, ctx.Role, ctx.Action, ctx.TenantId);
+
+            await EmitGatedAsync(ctx, authModel: null, "ELIGIBILITY_UNAVAILABLE", ct);
+            return new ProviderGateDecision(
+                false,
+                ProviderGateOutcome.SaasProviderNotAllowed,
+                Reason: "Provider eligibility could not be determined; denied.",
+                AuthModel: null,
+                HttpStatusHint: 400);
+        }
+
         if (authModel is null || authModel == ProviderAuthModel.CliToken)
         {
             var reason = authModel is null ? "PROVIDER_UNKNOWN" : "CLI_TOKEN_PROVIDER";
@@ -92,7 +121,40 @@ public sealed class SaaSProviderGate : ISaaSProviderGate
 
         // 3. SaaS auth / entitlement (Epic 34 seam). Provider is api-key — is the
         //    tenant entitled to the managed-LLM path for it?
-        if (!await _entitlement.IsTenantEntitledAsync(ctx.TenantId, ctx.ProviderName, ct))
+        //    AC4: an entitlement check that THROWS means we cannot determine the
+        //    tenant is entitled ⇒ fail-closed DENY (never a silent allow, never a
+        //    leaked 500). We map this to SaasProviderNotAllowed/400 (reason
+        //    ENTITLEMENT_UNAVAILABLE) rather than TenantNotEntitled/403: 403 is a
+        //    DETERMINED "not entitled" verdict, whereas a thrown exception is an
+        //    UNDETERMINED eligibility — the same §2.4 "could not determine ⇒ 400"
+        //    category as a lookup failure above. Cancellation still propagates.
+        bool entitled;
+        try
+        {
+            entitled = await _entitlement.IsTenantEntitledAsync(ctx.TenantId, ctx.ProviderName, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw; // a cancellation is not a gate denial — let it propagate.
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "SaaS provider gate could not determine entitlement (check failed); "
+                + "failing closed (deny). provider={Provider}, role={Role}, action={Action}, "
+                + "tenantId={TenantId}",
+                ctx.ProviderName, ctx.Role, ctx.Action, ctx.TenantId);
+
+            await EmitGatedAsync(ctx, authModel, "ENTITLEMENT_UNAVAILABLE", ct);
+            return new ProviderGateDecision(
+                false,
+                ProviderGateOutcome.SaasProviderNotAllowed,
+                Reason: "Tenant entitlement could not be determined; denied.",
+                AuthModel: authModel,
+                HttpStatusHint: 400);
+        }
+
+        if (!entitled)
         {
             _logger.LogInformation(
                 "SaaS provider gated: provider={Provider}, authModel=api-key, "

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Security/StaticProviderAuthLookup.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Security/StaticProviderAuthLookup.cs
@@ -1,0 +1,58 @@
+using Tamma.Activities.Security;
+
+namespace Tamma.Api.Services.Security;
+
+/// <summary>
+/// Story 32-4 — the interim (pre-34-11) <see cref="IProviderAuthLookup"/>,
+/// keyed off the existing <c>ProviderAllowlist.DefaultProviders</c> set (the
+/// single source of known providers — this class does NOT re-list providers).
+///
+/// <para>Classification: the harness providers (<c>ICLIAgentProvider</c>:
+/// <c>claude-code</c>, <c>opencode</c>, <c>zen-mcp</c>) ⇒
+/// <see cref="ProviderAuthModel.CliToken"/>; the complement within
+/// <c>DefaultProviders</c> ⇒ <see cref="ProviderAuthModel.ApiKey"/>; an unknown
+/// name ⇒ <c>null</c> (fail-closed in SaaS). Matching is case-insensitive and
+/// trimmed.</para>
+///
+/// <para>Once 34-11 is the canonical source, an <c>EntityProviderAuthLookup</c>
+/// reading <c>Provider.AuthModel</c> replaces this via a single DI registration
+/// line — the <see cref="IProviderAuthLookup"/> / gate contracts are unchanged.</para>
+/// </summary>
+public sealed class StaticProviderAuthLookup : IProviderAuthLookup
+{
+    /// <summary>
+    /// The harness (<c>ICLIAgentProvider</c>) providers. Verified against the
+    /// TS <c>BUILTIN_PROVIDER_NAMES</c> / <c>agent-provider-factory.ts</c>
+    /// CLI-agent registrations and the <c>ProviderPricingService.AuthModels</c>
+    /// map (which classifies only <c>claude-code</c> as <c>cli-token</c>). The
+    /// <c>ProviderAllowlist</c> additionally carries <c>opencode</c> and
+    /// <c>zen-mcp</c>, which are also CLI-agent harnesses. Everything else in
+    /// <c>DefaultProviders</c> is an api-key LLM API.
+    /// </summary>
+    private static readonly HashSet<string> CliTokenProviders =
+        new(StringComparer.OrdinalIgnoreCase) { "claude-code", "opencode", "zen-mcp" };
+
+    public Task<ProviderAuthModel?> AuthModelAsync(
+        string? providerName, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(providerName))
+            return Task.FromResult<ProviderAuthModel?>(null);
+
+        var name = providerName.Trim();
+
+        // A known CLI harness provider classifies as cli-token. We check this
+        // set FIRST because ProviderAllowlist.DefaultProviders omits the
+        // flagship `claude-code` harness (it carries `opencode`/`zen-mcp` only),
+        // so relying on the allowlist alone would mis-classify `claude-code` as
+        // unknown — exactly the silent-mis-classification this seam must avoid.
+        if (CliTokenProviders.Contains(name))
+            return Task.FromResult<ProviderAuthModel?>(ProviderAuthModel.CliToken);
+
+        // Otherwise it's api-key only if it's a known allowlisted provider;
+        // anything else is unknown ⇒ null ⇒ fail-closed deny in SaaS.
+        if (!ProviderAllowlist.IsAllowedDefault(name))
+            return Task.FromResult<ProviderAuthModel?>(null);
+
+        return Task.FromResult<ProviderAuthModel?>(ProviderAuthModel.ApiKey);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Security/EntityProviderAuthLookupTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Security/EntityProviderAuthLookupTests.cs
@@ -70,6 +70,12 @@ public class EntityProviderAuthLookupTests
             {
                 Id = Guid.NewGuid(), Key = "claude-code", DisplayName = "Claude Code",
                 AuthModel = "cli-token", Status = "active", CreatedAt = now, UpdatedAt = now,
+            },
+            new Provider
+            {
+                // A retired api-key provider — must NOT classify as ApiKey (fail-closed).
+                Id = Guid.NewGuid(), Key = "retired-openai", DisplayName = "Retired OpenAI",
+                AuthModel = "api-key", Status = "retired", CreatedAt = now, UpdatedAt = now,
             });
         await ctx.SaveChangesAsync();
     }
@@ -99,6 +105,16 @@ public class EntityProviderAuthLookupTests
     public async Task Unknown_key_resolves_to_null_failclosed()
     {
         var model = await NewLookup().AuthModelAsync("not-a-provider");
+        model.Should().BeNull();
+    }
+
+    [Test]
+    public async Task Retired_provider_resolves_to_null_failclosed()
+    {
+        // A retired api-key provider must resolve to null (unknown → SaaS deny),
+        // never classify as ApiKey — the active-status filter (matching 34-11's
+        // DbProviderPricingService Status == "active") is load-bearing here.
+        var model = await NewLookup().AuthModelAsync("retired-openai");
         model.Should().BeNull();
     }
 

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Security/EntityProviderAuthLookupTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Security/EntityProviderAuthLookupTests.cs
@@ -1,0 +1,122 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Services.Security;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Security;
+
+/// <summary>
+/// Story 32-4 / 34-11 — <see cref="EntityProviderAuthLookup"/> over a real
+/// Postgres testcontainer. Proves the entity-backed read of
+/// <c>Provider.AuthModel</c> resolves <c>api-key</c> / <c>cli-token</c> rows,
+/// returns <c>null</c> for an unknown key (SaaS fail-closed), and matches
+/// case-insensitively / trimmed — the production default behind
+/// <see cref="IProviderAuthLookup"/>.
+/// </summary>
+[TestFixture]
+public class EntityProviderAuthLookupTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+    private ServiceProvider _sp = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("db_authlookup_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        var services = new ServiceCollection();
+        services.AddDbContext<ControlPlaneDbContext>(o => o.UseNpgsql(_cs));
+        _sp = services.BuildServiceProvider();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_sp is not null) await _sp.DisposeAsync();
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE provider_model_prices, providers CASCADE;");
+
+        var now = DateTime.UtcNow;
+        ctx.Providers.AddRange(
+            new Provider
+            {
+                Id = Guid.NewGuid(), Key = "anthropic", DisplayName = "Anthropic",
+                AuthModel = "api-key", Status = "active", CreatedAt = now, UpdatedAt = now,
+            },
+            new Provider
+            {
+                Id = Guid.NewGuid(), Key = "claude-code", DisplayName = "Claude Code",
+                AuthModel = "cli-token", Status = "active", CreatedAt = now, UpdatedAt = now,
+            });
+        await ctx.SaveChangesAsync();
+    }
+
+    private ControlPlaneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    private EntityProviderAuthLookup NewLookup() =>
+        new(_sp.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<EntityProviderAuthLookup>.Instance);
+
+    [Test]
+    public async Task Reads_api_key_provider_as_ApiKey()
+    {
+        var model = await NewLookup().AuthModelAsync("anthropic");
+        model.Should().Be(ProviderAuthModel.ApiKey);
+    }
+
+    [Test]
+    public async Task Reads_cli_token_provider_as_CliToken()
+    {
+        var model = await NewLookup().AuthModelAsync("claude-code");
+        model.Should().Be(ProviderAuthModel.CliToken);
+    }
+
+    [Test]
+    public async Task Unknown_key_resolves_to_null_failclosed()
+    {
+        var model = await NewLookup().AuthModelAsync("not-a-provider");
+        model.Should().BeNull();
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    public async Task Blank_key_resolves_to_null(string? key)
+    {
+        var model = await NewLookup().AuthModelAsync(key);
+        model.Should().BeNull();
+    }
+
+    [TestCase("ANTHROPIC", ProviderAuthModel.ApiKey)]
+    [TestCase("  claude-code ", ProviderAuthModel.CliToken)]
+    [TestCase("Claude-Code", ProviderAuthModel.CliToken)]
+    public async Task Matching_is_case_insensitive_and_trimmed(string key, ProviderAuthModel expected)
+    {
+        var model = await NewLookup().AuthModelAsync(key);
+        model.Should().Be(expected);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Security/GateTestDoubles.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Security/GateTestDoubles.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Services.Security;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Security;
+
+/// <summary>
+/// Story 32-4 — shared test doubles for the SaaS provider gate suites.
+/// Deliberately minimal: the gate touches mode + auth-lookup + entitlement +
+/// events + metrics only — there is NO credential/secret seam anywhere in the
+/// fixture (the credential-safety guard).
+/// </summary>
+internal static class GateTestHelpers
+{
+    /// <summary>Build a gate wired with the supplied doubles (logger is a no-op).</summary>
+    public static SaaSProviderGate Build(
+        ITammaModeProvider mode,
+        IProviderAuthLookup lookup,
+        ITenantProviderEntitlement entitlement,
+        IEventRepository events,
+        ProviderGatingMetrics metrics) =>
+        new(mode, lookup, entitlement, events, metrics,
+            NullLogger<SaaSProviderGate>.Instance);
+}
+
+/// <summary>A process-stable mode stub.</summary>
+internal sealed class StubMode(TammaMode mode) : ITammaModeProvider
+{
+    public TammaMode Mode { get; } = mode;
+}
+
+/// <summary>
+/// An <see cref="IProviderAuthLookup"/> double driven by an explicit map. Records
+/// every call so single-user tests can assert the lookup is NEVER consulted.
+/// </summary>
+internal sealed class FakeAuthLookup : IProviderAuthLookup
+{
+    private readonly IReadOnlyDictionary<string, ProviderAuthModel?> _map;
+    public List<string?> Calls { get; } = new();
+
+    public FakeAuthLookup(IReadOnlyDictionary<string, ProviderAuthModel?> map) => _map = map;
+
+    /// <summary>Convenience: anthropic=api-key, claude-code=cli-token, everything else unknown.</summary>
+    public static FakeAuthLookup Default() => new(new Dictionary<string, ProviderAuthModel?>(
+        StringComparer.OrdinalIgnoreCase)
+    {
+        ["anthropic"] = ProviderAuthModel.ApiKey,
+        ["openai"] = ProviderAuthModel.ApiKey,
+        ["openrouter"] = ProviderAuthModel.ApiKey,
+        ["gemini"] = ProviderAuthModel.ApiKey,
+        ["claude-code"] = ProviderAuthModel.CliToken,
+        ["opencode"] = ProviderAuthModel.CliToken,
+        ["zen-mcp"] = ProviderAuthModel.CliToken,
+    });
+
+    public Task<ProviderAuthModel?> AuthModelAsync(string? providerName, CancellationToken ct = default)
+    {
+        Calls.Add(providerName);
+        if (providerName is not null && _map.TryGetValue(providerName.Trim(), out var model))
+            return Task.FromResult(model);
+        return Task.FromResult<ProviderAuthModel?>(null);
+    }
+}
+
+/// <summary>An entitlement double returning a fixed verdict; records calls.</summary>
+internal sealed class FakeEntitlement(bool entitled) : ITenantProviderEntitlement
+{
+    public List<(Guid? TenantId, string Provider)> Calls { get; } = new();
+
+    public Task<bool> IsTenantEntitledAsync(Guid? tenantId, string providerName, CancellationToken ct = default)
+    {
+        Calls.Add((tenantId, providerName));
+        return Task.FromResult(entitled);
+    }
+}
+
+/// <summary>A recording <see cref="IEventRepository"/>; optionally throws on append.</summary>
+internal sealed class RecordingGateEventRepository : IEventRepository
+{
+    private readonly bool _throwOnAppend;
+    public List<DomainEvent> Appended { get; } = new();
+
+    public RecordingGateEventRepository(bool throwOnAppend = false) => _throwOnAppend = throwOnAppend;
+
+    public Task<DomainEvent> AppendAsync(DomainEvent evt)
+    {
+        if (_throwOnAppend)
+            throw new InvalidOperationException("simulated event-store failure");
+        Appended.Add(evt);
+        return Task.FromResult(evt);
+    }
+
+    public Task<DomainEvent?> GetByIdAsync(Guid id) => Task.FromResult<DomainEvent?>(null);
+    public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit) =>
+        Task.FromResult(new List<DomainEvent>());
+    public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type) =>
+        Task.FromResult<DomainEvent?>(null);
+    public Task ClearAsync(Guid tenantId) => Task.CompletedTask;
+    public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(
+        Guid? tenantId, string? type, int? issueNumber, int limit, int offset) =>
+        Task.FromResult(((IReadOnlyList<DomainEvent>)new List<DomainEvent>(), 0));
+    public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(
+        Guid tenantId, string? typePrefix, int limit, int offset) =>
+        Task.FromResult(((IReadOnlyList<DomainEvent>)new List<DomainEvent>(), 0));
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Security/GateTestDoubles.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Security/GateTestDoubles.cs
@@ -38,9 +38,16 @@ internal sealed class StubMode(TammaMode mode) : ITammaModeProvider
 internal sealed class FakeAuthLookup : IProviderAuthLookup
 {
     private readonly IReadOnlyDictionary<string, ProviderAuthModel?> _map;
+    private readonly Func<Exception>? _throwFactory;
     public List<string?> Calls { get; } = new();
 
-    public FakeAuthLookup(IReadOnlyDictionary<string, ProviderAuthModel?> map) => _map = map;
+    public FakeAuthLookup(
+        IReadOnlyDictionary<string, ProviderAuthModel?> map,
+        Func<Exception>? throwFactory = null)
+    {
+        _map = map;
+        _throwFactory = throwFactory;
+    }
 
     /// <summary>Convenience: anthropic=api-key, claude-code=cli-token, everything else unknown.</summary>
     public static FakeAuthLookup Default() => new(new Dictionary<string, ProviderAuthModel?>(
@@ -55,24 +62,43 @@ internal sealed class FakeAuthLookup : IProviderAuthLookup
         ["zen-mcp"] = ProviderAuthModel.CliToken,
     });
 
+    /// <summary>A lookup that throws the supplied exception on every call (simulates a transient DB/seam failure).</summary>
+    public static FakeAuthLookup Throwing(Func<Exception> throwFactory) =>
+        new(new Dictionary<string, ProviderAuthModel?>(StringComparer.OrdinalIgnoreCase), throwFactory);
+
     public Task<ProviderAuthModel?> AuthModelAsync(string? providerName, CancellationToken ct = default)
     {
         Calls.Add(providerName);
+        if (_throwFactory is not null)
+            throw _throwFactory();
         if (providerName is not null && _map.TryGetValue(providerName.Trim(), out var model))
             return Task.FromResult(model);
         return Task.FromResult<ProviderAuthModel?>(null);
     }
 }
 
-/// <summary>An entitlement double returning a fixed verdict; records calls.</summary>
-internal sealed class FakeEntitlement(bool entitled) : ITenantProviderEntitlement
+/// <summary>An entitlement double returning a fixed verdict; records calls. Can be configured to throw.</summary>
+internal sealed class FakeEntitlement : ITenantProviderEntitlement
 {
+    private readonly bool _entitled;
+    private readonly Func<Exception>? _throwFactory;
     public List<(Guid? TenantId, string Provider)> Calls { get; } = new();
+
+    public FakeEntitlement(bool entitled, Func<Exception>? throwFactory = null)
+    {
+        _entitled = entitled;
+        _throwFactory = throwFactory;
+    }
+
+    /// <summary>An entitlement check that throws the supplied exception (simulates an Epic-34 engine failure).</summary>
+    public static FakeEntitlement Throwing(Func<Exception> throwFactory) => new(entitled: true, throwFactory);
 
     public Task<bool> IsTenantEntitledAsync(Guid? tenantId, string providerName, CancellationToken ct = default)
     {
         Calls.Add((tenantId, providerName));
-        return Task.FromResult(entitled);
+        if (_throwFactory is not null)
+            throw _throwFactory();
+        return Task.FromResult(_entitled);
     }
 }
 

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Security/ProviderGateDiTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Security/ProviderGateDiTests.cs
@@ -1,0 +1,87 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Services.Security;
+using Tamma.Data;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Security;
+
+/// <summary>
+/// Story 32-4 — DI-wiring smoke test. Replicates the exact Program.cs gate
+/// registration block (EntityProviderAuthLookup default, permissive entitlement,
+/// metrics singleton, scoped gate) against a minimal service collection and
+/// asserts every gate dependency resolves. Cheaper than a full
+/// WebApplicationFactory boot; the registration shapes match Program.cs.
+/// </summary>
+[TestFixture]
+public class ProviderGateDiTests
+{
+    private static ServiceProvider BuildProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // Ambient deps the gate consumes (faked / minimal, as Program.cs supplies
+        // the real ones elsewhere). The DbContext backs EntityProviderAuthLookup.
+        services.AddDbContext<ControlPlaneDbContext>(o =>
+            o.UseInMemoryDatabase("provider-gate-di-smoke"));
+        services.AddSingleton<ITammaModeProvider>(new StubMode(TammaMode.SaaS));
+        services.AddScoped<IEventRepository, RecordingGateEventRepository>();
+
+        // ── The Program.cs gate registration block (mirrored verbatim) ──
+        services.AddScoped<IProviderAuthLookup, EntityProviderAuthLookup>();
+        services.AddSingleton<ITenantProviderEntitlement, PermissiveTenantProviderEntitlement>();
+        services.AddSingleton<ProviderGatingMetrics>();
+        services.AddScoped<ISaaSProviderGate, SaaSProviderGate>();
+
+        return services.BuildServiceProvider();
+    }
+
+    [Test]
+    public void Gate_lookup_metrics_and_entitlement_all_resolve()
+    {
+        using var sp = BuildProvider();
+        using var scope = sp.CreateScope();
+        var p = scope.ServiceProvider;
+
+        p.GetService<ISaaSProviderGate>().Should().NotBeNull().And.BeOfType<SaaSProviderGate>();
+        p.GetService<IProviderAuthLookup>().Should().NotBeNull().And.BeOfType<EntityProviderAuthLookup>(
+            "EntityProviderAuthLookup is the production default (34-11 has landed)");
+        p.GetService<ITenantProviderEntitlement>().Should().NotBeNull()
+            .And.BeOfType<PermissiveTenantProviderEntitlement>();
+        p.GetService<ProviderGatingMetrics>().Should().NotBeNull();
+    }
+
+    [Test]
+    public void Metrics_is_a_singleton()
+    {
+        using var sp = BuildProvider();
+        var a = sp.GetRequiredService<ProviderGatingMetrics>();
+        var b = sp.GetRequiredService<ProviderGatingMetrics>();
+        a.Should().BeSameAs(b);
+    }
+
+    [Test]
+    public void Static_lookup_swap_also_resolves_contract_neutral()
+    {
+        // Proves the documented one-line swap to StaticProviderAuthLookup resolves.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<ITammaModeProvider>(new StubMode(TammaMode.SaaS));
+        services.AddScoped<IEventRepository, RecordingGateEventRepository>();
+        services.AddSingleton<IProviderAuthLookup, StaticProviderAuthLookup>();
+        services.AddSingleton<ITenantProviderEntitlement, PermissiveTenantProviderEntitlement>();
+        services.AddSingleton<ProviderGatingMetrics>();
+        services.AddScoped<ISaaSProviderGate, SaaSProviderGate>();
+
+        using var sp = services.BuildServiceProvider();
+        using var scope = sp.CreateScope();
+        scope.ServiceProvider.GetService<ISaaSProviderGate>().Should().NotBeNull();
+        scope.ServiceProvider.GetService<IProviderAuthLookup>().Should()
+            .BeOfType<StaticProviderAuthLookup>();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Security/SaaSProviderGateMatrixTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Security/SaaSProviderGateMatrixTests.cs
@@ -1,0 +1,195 @@
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Services.Security;
+
+namespace Tamma.Api.Tests.Security;
+
+/// <summary>
+/// Story 32-4 — the canonical regression guards: the full
+/// mode × auth-model × known/unknown × entitlement matrix; the typed-decision →
+/// §2.4 status mapping; the 34-11 entity-swap contract-neutrality; and the
+/// credential-safety assertion (the gate has NO secret/credential dependency).
+/// </summary>
+[TestFixture]
+public class SaaSProviderGateMatrixTests
+{
+    /// <summary>One matrix cell: inputs → expected decision shape.</summary>
+    public sealed record Cell(
+        TammaMode Mode,
+        string Provider,
+        bool Entitled,
+        bool ExpectAllowed,
+        ProviderGateOutcome ExpectOutcome,
+        int ExpectStatus,
+        int ExpectEvents,
+        int ExpectMetric);
+
+    private static IEnumerable<TestCaseData> MatrixCells()
+    {
+        // Single-user: every provider allowed, zero side effects (entitlement
+        // and provider type are irrelevant — mode short-circuits first).
+        foreach (var provider in new[] { "anthropic", "claude-code", "unknown-x" })
+        foreach (var entitled in new[] { true, false })
+        {
+            yield return new TestCaseData(new Cell(
+                TammaMode.SingleUser, provider, entitled,
+                ExpectAllowed: true, ProviderGateOutcome.Allowed, 200,
+                ExpectEvents: 0, ExpectMetric: 0))
+                .SetName($"SingleUser_{provider}_entitled={entitled}_allows");
+        }
+
+        // SaaS api-key (anthropic): allowed iff entitled, else 403.
+        yield return new TestCaseData(new Cell(
+            TammaMode.SaaS, "anthropic", true,
+            ExpectAllowed: true, ProviderGateOutcome.Allowed, 200, 0, 0))
+            .SetName("SaaS_anthropic_entitled_allows");
+        yield return new TestCaseData(new Cell(
+            TammaMode.SaaS, "anthropic", false,
+            ExpectAllowed: false, ProviderGateOutcome.TenantNotEntitled, 403, 1, 1))
+            .SetName("SaaS_anthropic_notEntitled_denies403");
+
+        // SaaS cli-token (claude-code): denied 400 regardless of entitlement.
+        yield return new TestCaseData(new Cell(
+            TammaMode.SaaS, "claude-code", true,
+            ExpectAllowed: false, ProviderGateOutcome.SaasProviderNotAllowed, 400, 1, 1))
+            .SetName("SaaS_claudeCode_entitled_denies400");
+        yield return new TestCaseData(new Cell(
+            TammaMode.SaaS, "claude-code", false,
+            ExpectAllowed: false, ProviderGateOutcome.SaasProviderNotAllowed, 400, 1, 1))
+            .SetName("SaaS_claudeCode_notEntitled_denies400");
+
+        // SaaS unknown: denied 400 fail-closed regardless of entitlement.
+        yield return new TestCaseData(new Cell(
+            TammaMode.SaaS, "unknown-x", true,
+            ExpectAllowed: false, ProviderGateOutcome.SaasProviderNotAllowed, 400, 1, 1))
+            .SetName("SaaS_unknown_entitled_denies400_failclosed");
+        yield return new TestCaseData(new Cell(
+            TammaMode.SaaS, "unknown-x", false,
+            ExpectAllowed: false, ProviderGateOutcome.SaasProviderNotAllowed, 400, 1, 1))
+            .SetName("SaaS_unknown_notEntitled_denies400_failclosed");
+    }
+
+    [TestCaseSource(nameof(MatrixCells))]
+    public async Task Matrix_with_static_lookup(Cell cell) =>
+        await RunCell(cell, FakeAuthLookup.Default());
+
+    /// <summary>
+    /// 34-11 swap: the SAME matrix with an entity-shaped lookup (anthropic=api-key,
+    /// claude-code=cli-token, everything else unknown) — proving the DI swap from
+    /// StaticProviderAuthLookup to EntityProviderAuthLookup is contract-neutral.
+    /// </summary>
+    [TestCaseSource(nameof(MatrixCells))]
+    public async Task Matrix_with_entity_shaped_lookup(Cell cell)
+    {
+        var entityLikeLookup = new FakeAuthLookup(new Dictionary<string, ProviderAuthModel?>(
+            StringComparer.OrdinalIgnoreCase)
+        {
+            ["anthropic"] = ProviderAuthModel.ApiKey,
+            ["claude-code"] = ProviderAuthModel.CliToken,
+        });
+        await RunCell(cell, entityLikeLookup);
+    }
+
+    private static async Task RunCell(Cell cell, IProviderAuthLookup lookup)
+    {
+        var events = new RecordingGateEventRepository();
+        using var metrics = new ProviderGatingMetrics();
+        var gate = GateTestHelpers.Build(
+            new StubMode(cell.Mode), lookup, new FakeEntitlement(cell.Entitled), events, metrics);
+
+        var decision = await gate.InspectAsync(
+            new ProviderGateContext(cell.Provider, "developer", "implement", Guid.NewGuid()));
+
+        decision.Allowed.Should().Be(cell.ExpectAllowed);
+        decision.Outcome.Should().Be(cell.ExpectOutcome);
+        decision.HttpStatusHint.Should().Be(cell.ExpectStatus);
+        events.Appended.Should().HaveCount(cell.ExpectEvents);
+        metrics.GatedTotal.Should().Be(cell.ExpectMetric);
+    }
+
+    // ── Endpoint-mapping contract: typed decision drives the §2.4 status ────
+
+    [Test]
+    public void SaasProviderNotAllowed_maps_to_400_and_TenantNotEntitled_to_403()
+    {
+        var notAllowed = new ProviderGateDecision(
+            false, ProviderGateOutcome.SaasProviderNotAllowed, "x", null, 400);
+        var notEntitled = new ProviderGateDecision(
+            false, ProviderGateOutcome.TenantNotEntitled, "y", ProviderAuthModel.ApiKey, 403);
+        var allow = ProviderGateDecision.Allow(ProviderAuthModel.ApiKey);
+
+        notAllowed.HttpStatusHint.Should().Be(400);
+        notEntitled.HttpStatusHint.Should().Be(403);
+        allow.HttpStatusHint.Should().Be(200);
+        allow.Allowed.Should().BeTrue();
+        allow.Reason.Should().BeNull();
+    }
+
+    // ── Credential-safety: the gate has NO credential/secret dependency ─────
+
+    [Test]
+    public void Gate_constructor_has_no_credential_or_secret_dependency()
+    {
+        var ctor = typeof(SaaSProviderGate).GetConstructors().Single();
+
+        // Collect the SHORT type name of each ctor parameter plus, for generics,
+        // the short names of the generic arguments (so ILogger<SaaSProviderGate>
+        // contributes "ILogger`1" + "SaaSProviderGate"). We deliberately avoid the
+        // assembly-qualified FullName because it carries "...PublicKeyToken=null".
+        var names = new List<string>();
+        foreach (var p in ctor.GetParameters())
+        {
+            names.Add(p.ParameterType.Name);
+            if (p.ParameterType.IsGenericType)
+                names.AddRange(p.ParameterType.GetGenericArguments().Select(a => a.Name));
+        }
+
+        // No dependency type name may hint at a secret / credential / cabinet /
+        // key / token / cipher — the gate operates on provider names + mode only.
+        string[] forbidden =
+            { "Credential", "Secret", "Cabinet", "ApiKey", "Cipher", "Vault", "Kek" };
+
+        foreach (var name in names)
+        foreach (var bad in forbidden)
+        {
+            name.Should().NotContainEquivalentOf(bad,
+                $"the gate must have no '{bad}'-shaped dependency (credential safety, AC9)");
+        }
+
+        // Sanity: the gate's dependency set is exactly the mode + auth lookup +
+        // entitlement + events + metrics + logger — nothing secret-bearing.
+        ctor.GetParameters().Select(p => p.ParameterType).Should().BeEquivalentTo(new[]
+        {
+            typeof(ITammaModeProvider),
+            typeof(IProviderAuthLookup),
+            typeof(ITenantProviderEntitlement),
+            typeof(Tamma.Data.Repositories.IEventRepository),
+            typeof(ProviderGatingMetrics),
+            typeof(Microsoft.Extensions.Logging.ILogger<SaaSProviderGate>),
+        });
+    }
+
+    [Test]
+    public async Task Gate_decision_carries_no_secret_material_in_reason()
+    {
+        var events = new RecordingGateEventRepository();
+        using var metrics = new ProviderGatingMetrics();
+        var gate = GateTestHelpers.Build(
+            new StubMode(TammaMode.SaaS), FakeAuthLookup.Default(),
+            new FakeEntitlement(true), events, metrics);
+
+        var decision = await gate.InspectAsync(
+            new ProviderGateContext("claude-code", "developer", "implement", Guid.NewGuid()));
+
+        // The reason + event payload reference only provider name / mode / reason
+        // codes — never key material.
+        decision.Reason.Should().NotBeNullOrWhiteSpace();
+        decision.Reason!.ToLowerInvariant().Should().NotContain("sk-");
+        events.Appended.Should().ContainSingle();
+        events.Appended[0].Data.ToLowerInvariant().Should().NotContain("sk-");
+        events.Appended[0].Tags.ToLowerInvariant().Should().NotContain("sk-");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Security/SaaSProviderGateTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Security/SaaSProviderGateTests.cs
@@ -1,0 +1,241 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Services.Security;
+
+namespace Tamma.Api.Tests.Security;
+
+/// <summary>
+/// Story 32-4 — branch + side-effect tests for <see cref="SaaSProviderGate"/>.
+/// Covers: single-user hard no-op (zero side effects, lookup never consulted);
+/// the four SaaS outcomes (api-key+entitled allow, cli-token deny, unknown deny
+/// fail-closed, not-entitled deny); the AGENT.PROVIDER.GATED event + metric
+/// shape; event-append-failure swallow; and the "never throws on denial"
+/// invariant.
+/// </summary>
+[TestFixture]
+public class SaaSProviderGateTests
+{
+    private FakeAuthLookup _lookup = null!;
+    private RecordingGateEventRepository _events = null!;
+    private ProviderGatingMetrics _metrics = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _lookup = FakeAuthLookup.Default();
+        _events = new RecordingGateEventRepository();
+        _metrics = new ProviderGatingMetrics();
+    }
+
+    [TearDown]
+    public void TearDown() => _metrics.Dispose();
+
+    private SaaSProviderGate BuildGate(TammaMode mode, bool entitled = true) =>
+        GateTestHelpers.Build(
+            new StubMode(mode), _lookup, new FakeEntitlement(entitled), _events, _metrics);
+
+    private static ProviderGateContext Ctx(string provider) =>
+        new(provider, Role: "developer", Action: "implement", TenantId: Guid.NewGuid());
+
+    // ── Single-user: hard no-op ─────────────────────────────────────────
+
+    [TestCase("anthropic")]
+    [TestCase("claude-code")]
+    [TestCase("opencode")]
+    [TestCase("definitely-unknown")]
+    public async Task SingleUser_allows_every_provider_with_zero_side_effects(string provider)
+    {
+        var gate = BuildGate(TammaMode.SingleUser);
+
+        var decision = await gate.InspectAsync(Ctx(provider));
+
+        decision.Allowed.Should().BeTrue();
+        decision.Outcome.Should().Be(ProviderGateOutcome.Allowed);
+        decision.HttpStatusHint.Should().Be(200);
+        decision.Reason.Should().BeNull();
+
+        _lookup.Calls.Should().BeEmpty("single-user short-circuits before any lookup");
+        _events.Appended.Should().BeEmpty("single-user emits no events");
+        _metrics.GatedTotal.Should().Be(0, "single-user increments no metric");
+    }
+
+    // ── SaaS: api-key + entitled ⇒ allow ────────────────────────────────
+
+    [TestCase("anthropic")]
+    [TestCase("openai")]
+    [TestCase("openrouter")]
+    [TestCase("gemini")]
+    public async Task SaaS_apiKey_entitled_allows_with_no_event_or_metric(string provider)
+    {
+        var gate = BuildGate(TammaMode.SaaS, entitled: true);
+
+        var decision = await gate.InspectAsync(Ctx(provider));
+
+        decision.Allowed.Should().BeTrue();
+        decision.Outcome.Should().Be(ProviderGateOutcome.Allowed);
+        decision.AuthModel.Should().Be(ProviderAuthModel.ApiKey);
+        decision.HttpStatusHint.Should().Be(200);
+
+        _events.Appended.Should().BeEmpty();
+        _metrics.GatedTotal.Should().Be(0);
+    }
+
+    // ── SaaS: cli-token ⇒ deny 400 ──────────────────────────────────────
+
+    [TestCase("claude-code")]
+    [TestCase("opencode")]
+    [TestCase("zen-mcp")]
+    public async Task SaaS_cliToken_denies_400_with_one_event_and_one_metric(string provider)
+    {
+        var ctx = Ctx(provider);
+        var gate = BuildGate(TammaMode.SaaS);
+
+        var decision = await gate.InspectAsync(ctx);
+
+        decision.Allowed.Should().BeFalse();
+        decision.Outcome.Should().Be(ProviderGateOutcome.SaasProviderNotAllowed);
+        decision.HttpStatusHint.Should().Be(400);
+        decision.AuthModel.Should().Be(ProviderAuthModel.CliToken);
+        decision.Reason.Should().NotBeNullOrWhiteSpace();
+        // Key-free: references the provider name + the "api-key providers only"
+        // policy text, but never secret key material (no `sk-` token etc.).
+        decision.Reason!.ToLowerInvariant().Should().NotContain("sk-");
+        decision.Reason.Should().Contain(provider);
+
+        _events.Appended.Should().ContainSingle();
+        var evt = _events.Appended[0];
+        evt.Type.Should().Be("AGENT.PROVIDER.GATED");
+        evt.TenantId.Should().Be(ctx.TenantId);
+
+        using var data = JsonDocument.Parse(evt.Data);
+        data.RootElement.GetProperty("provider").GetString().Should().Be(provider);
+        data.RootElement.GetProperty("authModel").GetString().Should().Be("cli-token");
+        data.RootElement.GetProperty("mode").GetString().Should().Be("saas");
+        data.RootElement.GetProperty("reason").GetString().Should().Be("CLI_TOKEN_PROVIDER");
+        data.RootElement.GetProperty("role").GetString().Should().Be("developer");
+        data.RootElement.GetProperty("action").GetString().Should().Be("implement");
+
+        using var tags = JsonDocument.Parse(evt.Tags);
+        tags.RootElement.GetProperty("tenantId").GetString().Should().Be(ctx.TenantId!.Value.ToString());
+        tags.RootElement.GetProperty("provider").GetString().Should().Be(provider);
+        tags.RootElement.GetProperty("authModel").GetString().Should().Be("cli-token");
+
+        _metrics.GatedTotal.Should().Be(1);
+    }
+
+    // ── SaaS: unknown ⇒ deny 400 fail-closed ────────────────────────────
+
+    [Test]
+    public async Task SaaS_unknown_denies_400_failclosed_with_one_event_and_metric()
+    {
+        var ctx = Ctx("totally-unknown-provider");
+        var gate = BuildGate(TammaMode.SaaS);
+
+        var decision = await gate.InspectAsync(ctx);
+
+        decision.Allowed.Should().BeFalse();
+        decision.Outcome.Should().Be(ProviderGateOutcome.SaasProviderNotAllowed);
+        decision.HttpStatusHint.Should().Be(400);
+        decision.AuthModel.Should().BeNull("an unknown provider has no resolved auth model");
+
+        _events.Appended.Should().ContainSingle();
+        using var data = JsonDocument.Parse(_events.Appended[0].Data);
+        data.RootElement.GetProperty("reason").GetString().Should().Be("PROVIDER_UNKNOWN");
+        data.RootElement.GetProperty("authModel").GetString().Should().Be("unknown");
+
+        _metrics.GatedTotal.Should().Be(1);
+    }
+
+    // ── SaaS: api-key + NOT entitled ⇒ deny 403 ─────────────────────────
+
+    [Test]
+    public async Task SaaS_apiKey_notEntitled_denies_403_with_one_event_and_metric()
+    {
+        var ctx = Ctx("anthropic");
+        var gate = BuildGate(TammaMode.SaaS, entitled: false);
+
+        var decision = await gate.InspectAsync(ctx);
+
+        decision.Allowed.Should().BeFalse();
+        decision.Outcome.Should().Be(ProviderGateOutcome.TenantNotEntitled);
+        decision.HttpStatusHint.Should().Be(403);
+        decision.AuthModel.Should().Be(ProviderAuthModel.ApiKey);
+
+        _events.Appended.Should().ContainSingle();
+        using var data = JsonDocument.Parse(_events.Appended[0].Data);
+        data.RootElement.GetProperty("reason").GetString().Should().Be("TENANT_NOT_ENTITLED");
+        data.RootElement.GetProperty("authModel").GetString().Should().Be("api-key");
+
+        _metrics.GatedTotal.Should().Be(1);
+    }
+
+    [Test]
+    public async Task SaaS_cliToken_does_not_consult_entitlement()
+    {
+        var entitlement = new FakeEntitlement(entitled: true);
+        var gate = GateTestHelpers.Build(
+            new StubMode(TammaMode.SaaS), _lookup, entitlement, _events, _metrics);
+
+        await gate.InspectAsync(Ctx("claude-code"));
+
+        entitlement.Calls.Should().BeEmpty(
+            "cli-token is denied at the auth-model branch, before the entitlement check");
+    }
+
+    // ── Event-append failure is swallowed ───────────────────────────────
+
+    [Test]
+    public async Task SaaS_denial_swallows_event_append_failure_and_still_returns_decision()
+    {
+        var throwingEvents = new RecordingGateEventRepository(throwOnAppend: true);
+        var gate = GateTestHelpers.Build(
+            new StubMode(TammaMode.SaaS), _lookup, new FakeEntitlement(true), throwingEvents, _metrics);
+
+        // Should NOT throw — the typed decision is still returned.
+        var decision = await gate.InspectAsync(Ctx("claude-code"));
+
+        decision.Allowed.Should().BeFalse();
+        decision.Outcome.Should().Be(ProviderGateOutcome.SaasProviderNotAllowed);
+        // Metric is incremented even though the event append failed.
+        _metrics.GatedTotal.Should().Be(1);
+    }
+
+    // ── Never throws to signal a denial ─────────────────────────────────
+
+    [TestCase(TammaMode.SaaS, "claude-code")]
+    [TestCase(TammaMode.SaaS, "unknown-x")]
+    [TestCase(TammaMode.SaaS, "anthropic")]
+    [TestCase(TammaMode.SingleUser, "claude-code")]
+    public async Task InspectAsync_never_throws_for_a_valid_context(TammaMode mode, string provider)
+    {
+        var gate = BuildGate(mode, entitled: true);
+        var act = async () => await gate.InspectAsync(Ctx(provider));
+        await act.Should().NotThrowAsync();
+    }
+
+    // ── Null context is the only throw (contract violation) ─────────────
+
+    [Test]
+    public async Task Null_context_throws_ArgumentNullException()
+    {
+        var gate = BuildGate(TammaMode.SaaS);
+        var act = async () => await gate.InspectAsync(null!);
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    // ── Case-insensitive / trimmed provider matching ────────────────────
+
+    [Test]
+    public async Task SaaS_classification_is_case_insensitive_and_trimmed()
+    {
+        var gate = BuildGate(TammaMode.SaaS);
+
+        var decision = await gate.InspectAsync(Ctx("Claude-Code "));
+
+        decision.Allowed.Should().BeFalse();
+        decision.AuthModel.Should().Be(ProviderAuthModel.CliToken);
+        decision.Outcome.Should().Be(ProviderGateOutcome.SaasProviderNotAllowed);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Security/SaaSProviderGateTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Security/SaaSProviderGateTests.cs
@@ -202,6 +202,89 @@ public class SaaSProviderGateTests
         _metrics.GatedTotal.Should().Be(1);
     }
 
+    // ── Fail-closed on a lookup/entitlement exception (AC4) ─────────────
+
+    [Test]
+    public async Task SaaS_lookup_exception_fails_closed_400_with_one_event_and_metric()
+    {
+        var ctx = Ctx("anthropic");
+        var throwingLookup = FakeAuthLookup.Throwing(
+            () => new InvalidOperationException("simulated transient DB failure"));
+        var gate = GateTestHelpers.Build(
+            new StubMode(TammaMode.SaaS), throwingLookup, new FakeEntitlement(true), _events, _metrics);
+
+        // Must NOT throw — a lookup failure is a typed fail-closed DENY, never a 500.
+        var decision = await gate.InspectAsync(ctx);
+
+        decision.Allowed.Should().BeFalse();
+        decision.Outcome.Should().Be(ProviderGateOutcome.SaasProviderNotAllowed);
+        decision.HttpStatusHint.Should().Be(400);
+        decision.AuthModel.Should().BeNull("eligibility could not be determined");
+
+        _events.Appended.Should().ContainSingle();
+        using var data = JsonDocument.Parse(_events.Appended[0].Data);
+        data.RootElement.GetProperty("reason").GetString().Should().Be("ELIGIBILITY_UNAVAILABLE");
+        data.RootElement.GetProperty("authModel").GetString().Should().Be("unknown");
+
+        _metrics.GatedTotal.Should().Be(1);
+    }
+
+    [Test]
+    public async Task SaaS_entitlement_exception_fails_closed_400_with_one_event_and_metric()
+    {
+        var ctx = Ctx("anthropic"); // api-key provider — reaches the entitlement check
+        var throwingEntitlement = FakeEntitlement.Throwing(
+            () => new InvalidOperationException("simulated entitlement-engine failure"));
+        var gate = GateTestHelpers.Build(
+            new StubMode(TammaMode.SaaS), _lookup, throwingEntitlement, _events, _metrics);
+
+        // Must NOT throw — an entitlement failure means we cannot determine the
+        // tenant is entitled ⇒ fail-closed DENY (400), never a 500.
+        var decision = await gate.InspectAsync(ctx);
+
+        decision.Allowed.Should().BeFalse();
+        decision.Outcome.Should().Be(ProviderGateOutcome.SaasProviderNotAllowed);
+        decision.HttpStatusHint.Should().Be(400);
+        // The provider classified as api-key before the entitlement check threw.
+        decision.AuthModel.Should().Be(ProviderAuthModel.ApiKey);
+
+        _events.Appended.Should().ContainSingle();
+        using var data = JsonDocument.Parse(_events.Appended[0].Data);
+        data.RootElement.GetProperty("reason").GetString().Should().Be("ENTITLEMENT_UNAVAILABLE");
+        data.RootElement.GetProperty("authModel").GetString().Should().Be("api-key");
+
+        _metrics.GatedTotal.Should().Be(1);
+    }
+
+    [Test]
+    public async Task SaaS_lookup_cancellation_propagates_and_is_not_a_denial()
+    {
+        var cancelledLookup = FakeAuthLookup.Throwing(() => new OperationCanceledException());
+        var gate = GateTestHelpers.Build(
+            new StubMode(TammaMode.SaaS), cancelledLookup, new FakeEntitlement(true), _events, _metrics);
+
+        // A cancellation is NOT a gate denial — it must propagate, not become a DENY.
+        var act = async () => await gate.InspectAsync(Ctx("anthropic"));
+        await act.Should().ThrowAsync<OperationCanceledException>();
+
+        _events.Appended.Should().BeEmpty("a cancellation emits no gated event");
+        _metrics.GatedTotal.Should().Be(0, "a cancellation increments no gated metric");
+    }
+
+    [Test]
+    public async Task SaaS_entitlement_cancellation_propagates_and_is_not_a_denial()
+    {
+        var cancelledEntitlement = FakeEntitlement.Throwing(() => new TaskCanceledException());
+        var gate = GateTestHelpers.Build(
+            new StubMode(TammaMode.SaaS), _lookup, cancelledEntitlement, _events, _metrics);
+
+        var act = async () => await gate.InspectAsync(Ctx("anthropic"));
+        await act.Should().ThrowAsync<OperationCanceledException>();
+
+        _events.Appended.Should().BeEmpty("a cancellation emits no gated event");
+        _metrics.GatedTotal.Should().Be(0, "a cancellation increments no gated metric");
+    }
+
     // ── Never throws to signal a denial ─────────────────────────────────
 
     [TestCase(TammaMode.SaaS, "claude-code")]

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Security/StaticProviderAuthLookupTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Security/StaticProviderAuthLookupTests.cs
@@ -1,0 +1,103 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Security;
+using Tamma.Api.Services.Security;
+
+namespace Tamma.Api.Tests.Security;
+
+/// <summary>
+/// Story 32-4 — unit tests for <see cref="StaticProviderAuthLookup"/> (the
+/// interim pre-34-11 eligibility seam). The canonical guard is "every
+/// <c>ProviderAllowlist.DefaultProviders</c> entry resolves to a deterministic
+/// non-null <see cref="ProviderAuthModel"/>" — so a newly added provider can
+/// never be silently mis-classified (left <c>null</c>) and slip an unknown
+/// past the SaaS fail-closed deny.
+/// </summary>
+[TestFixture]
+public class StaticProviderAuthLookupTests
+{
+    private readonly StaticProviderAuthLookup _sut = new();
+
+    private static readonly string[] CliTokenProviders = { "claude-code", "opencode", "zen-mcp" };
+
+    // The allowlist entries as published by ProviderAllowlist.DefaultProviders.
+    private static readonly string[] AllowlistProviders =
+    {
+        "anthropic", "openai", "openrouter", "google", "github-copilot",
+        "local-llm", "opencode", "z-ai", "zen-mcp", "azure-openai",
+        "gemini", "ollama", "lmstudio", "together", "groq",
+    };
+
+    // Every name the lookup MUST classify deterministically (non-null): the
+    // allowlist + the flagship `claude-code` harness (which the allowlist
+    // omits but is the canonical CLI-token provider).
+    private static readonly string[] KnownProviders =
+        AllowlistProviders.Concat(new[] { "claude-code" }).Distinct().ToArray();
+
+    [TestCaseSource(nameof(KnownProviders))]
+    public async Task Known_provider_resolves_to_a_deterministic_non_null_auth_model(string provider)
+    {
+        // Guards against a new provider being silently mis-classified as unknown
+        // (null) and slipping past the SaaS fail-closed deny.
+        var model = await _sut.AuthModelAsync(provider);
+        model.Should().NotBeNull(
+            "every known provider must classify deterministically — null is unknown (fail-closed)");
+    }
+
+    [TestCaseSource(nameof(CliTokenProviders))]
+    public async Task Harness_providers_classify_as_cli_token(string provider)
+    {
+        var model = await _sut.AuthModelAsync(provider);
+        model.Should().Be(ProviderAuthModel.CliToken);
+    }
+
+    [TestCase("anthropic")]
+    [TestCase("openai")]
+    [TestCase("openrouter")]
+    [TestCase("gemini")]
+    [TestCase("google")]
+    [TestCase("groq")]
+    public async Task Api_key_providers_classify_as_api_key(string provider)
+    {
+        var model = await _sut.AuthModelAsync(provider);
+        model.Should().Be(ProviderAuthModel.ApiKey);
+    }
+
+    [Test]
+    public async Task Unknown_provider_resolves_to_null()
+    {
+        var model = await _sut.AuthModelAsync("definitely-not-a-provider");
+        model.Should().BeNull("an unknown provider must be null to drive the SaaS fail-closed deny");
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    public async Task Blank_or_null_provider_resolves_to_null(string? provider)
+    {
+        var model = await _sut.AuthModelAsync(provider);
+        model.Should().BeNull();
+    }
+
+    [TestCase("Claude-Code ", ProviderAuthModel.CliToken)]
+    [TestCase("  ANTHROPIC", ProviderAuthModel.ApiKey)]
+    [TestCase("OpenCode", ProviderAuthModel.CliToken)]
+    [TestCase(" OpenAI ", ProviderAuthModel.ApiKey)]
+    public async Task Matching_is_case_insensitive_and_trimmed(string provider, ProviderAuthModel expected)
+    {
+        var model = await _sut.AuthModelAsync(provider);
+        model.Should().Be(expected);
+    }
+
+    [Test]
+    public void Every_allowlist_provider_is_covered_by_the_test_list()
+    {
+        // Belt-and-braces: if ProviderAllowlist gains a provider, this surfaces
+        // that the AllowlistProviders list above (and the lookup) must be updated.
+        foreach (var provider in AllowlistProviders)
+        {
+            ProviderAllowlist.IsAllowedDefault(provider).Should().BeTrue(
+                $"'{provider}' should be a known default provider");
+        }
+    }
+}


### PR DESCRIPTION
## Story 32-4 — SaaS Provider Gate (call-LLM endpoint stage)

The fail-closed **gate stage** (composition step 1) of the upcoming `POST /api/v1/llm/call` endpoint. Returns a typed `ProviderGateDecision` the endpoint maps to the §2.4 envelope; **never throws to signal a denial**. No new table / no migration — a pure service over existing seams (sequence F, consumed by 32-5).

### Behavior
- **single-user mode**: hard no-op — every provider allowed, zero events, zero metrics (harness/CLI providers are a legitimate local affordance).
- **SaaS mode**: `cli-token` providers (`claude-code`/`opencode`/`zen-mcp`) → deny 400 `SAAS_PROVIDER_NOT_ALLOWED`; unknown provider → deny fail-closed 400; un-entitled tenant → deny 403 `TENANT_NOT_ENTITLED`; entitled `api-key` provider → allow. Exactly one `AGENT.PROVIDER.GATED` DCB event + one `tamma.provider.gated` metric per denial (event-append failure swallowed).
- **fail-closed (AC4)**: an unknown provider OR any inability to evaluate eligibility (lookup/entitlement throws) → typed DENY, never a permissive allow or a leaked 500.

### Notes
- `IProviderAuthLookup` is wired to the **entity-backed `EntityProviderAuthLookup`** (reads 34-11's merged `Provider.AuthModel`, filtered to `Status == "active"`), with `StaticProviderAuthLookup` retained as the documented interim/test fallback — the spec's "DI swap when 34-11 lands", contract-neutral (pinned by the matrix test).
- Defined a minimal `ITenantProviderEntitlement` seam (permissive default) since no Epic-34 provider-entitlement seam existed; 32-4 owns only the typed surfacing of its result.
- Caught a latent spec-sample bug: `claude-code` is not in `ProviderAllowlist.DefaultProviders` — classified via the `CliTokenProviders` set first so it correctly resolves `cli-token`.

### Reviews & verification
- **Spec review**: `SPEC_COMPLIANT` — all 10 ACs met; the 3 Files-table deviations (entity lookup, entitlement seam, extra tests) judged faithful to spec intent.
- **Quality review**: found an **IMPORTANT** fail-closed gap (entity lookup can throw → would leak a 500) — **fixed** in `ea9705d4` (try/catch → typed 400 DENY, cancellation propagates) + retired-provider filter + throwing/cancellation/retired coverage.
- **Gate verified locally**: `dotnet build` 0 errors; `has-pending-model-changes` (ControlPlane) reports no pending changes; full `Tamma.Api.Tests` **3637 passed / 0 failed** (pre-fix HEAD), Security suite **111 passed** (post-fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)