### PR TITLE
fix(workflow-viewer): rail link info shows source → target + trigger

### DIFF
--- a/packages/workflow-viewer/src/WorkflowMap.tsx
+++ b/packages/workflow-viewer/src/WorkflowMap.tsx
@@ -348,16 +348,23 @@ function computeGeometry(layout: MapLayout, width: number): Geometry {
     if (!a || !b) continue;
     const color = LINE_COLORS[rail.line % LINE_COLORS.length]!;
     const { d, labelX, labelY } = orthogonalPath(a, b, rail.isBackEdge, w);
+    // Link info: always name the source AND target step; surface the trigger
+    // (branch condition / event) only when it adds information — a trigger that
+    // just repeats the target step name is noise, so drop it.
+    const trigger =
+      rail.label && rail.label !== b.node.name ? rail.label : undefined;
     railPaths.push({
       id: rail.id,
       d,
       color,
       isBackEdge: rail.isBackEdge,
       to: rail.to,
-      title: rail.label ? `${rail.label} → ${b.node.name}` : `→ ${b.node.name}`,
+      title: trigger
+        ? `${a.node.name} → ${b.node.name}  ·  when: ${trigger}`
+        : `${a.node.name} → ${b.node.name}`,
     });
-    if (rail.label) {
-      railLabels.push({ id: rail.id, label: rail.label, x: labelX, y: labelY });
+    if (trigger) {
+      railLabels.push({ id: rail.id, label: trigger, x: labelX, y: labelY });
     }
   }
 


### PR DESCRIPTION
## What

The link info (hover tooltip) on a rail/line between steps now shows the **source step → target step**, plus the **trigger** (branch condition / event) called out separately — and no longer just repeats the target.

Before: `<trigger> → <target>` (e.g. `→ Testing Pipeline`) — no source, and the trigger read as part of the target.
After:
- plain transitions → `<source> → <target>` (e.g. `Init Inputs → Testing Pipeline`)
- conditional transitions → `<source> → <target>  ·  when: <trigger>` (e.g. `Tests Passed? → Finish Pass · when: True`)

A trigger that merely duplicates the target step name is dropped — from both the tooltip and the on-map rail label.

## Verification

Verified in-browser on `ci-with-debug-retry/map`:
- `Init Inputs → Testing Pipeline`, `Debug CI Failure → Testing Pipeline` (source + target)
- `Tests Passed? → Finish Pass · when: True`, `CI Retries < Max? → Finish Fail · when: False` (source + target + trigger)

Source-only change to `@tamma/workflow-viewer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)