### PR TITLE
feat(workflow-viewer): clicking a link opens a transition panel

### DIFF
--- a/packages/workflow-viewer/src/LinkDetailPopup.tsx
+++ b/packages/workflow-viewer/src/LinkDetailPopup.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useState } from 'react';
+
+export interface LinkDetailPopupProps {
+  /** Source step of the transition. */
+  source: { id: string; name: string };
+  /** Target step of the transition. */
+  target: { id: string; name: string };
+  /** The trigger / branch condition, when the edge is conditional. */
+  trigger?: string | undefined;
+  /** Rail colour, for the header dot (matches the line on the map). */
+  color: string;
+  /** Dismiss the panel (X, backdrop, or Esc). */
+  onClose: () => void;
+  /** Open a step's own detail panel (replaces this link panel). */
+  onGoToStep: (stepId: string) => void;
+}
+
+/**
+ * Floating detail panel for a TRANSITION (a rail/link between two steps) — the
+ * edge counterpart to {@link StationDetailPopup}. It names the source step and
+ * the target step (each tappable to open that step's own details) and the
+ * trigger condition. Clicking a rail opens THIS panel; it does not jump
+ * straight to the target step.
+ *
+ * Mirrors the station popup chrome (responsive full-screen / modal, Esc +
+ * backdrop dismiss, body-scroll lock) so the two feel like one system.
+ */
+export function LinkDetailPopup({
+  source,
+  target,
+  trigger,
+  color,
+  onClose,
+  onGoToStep,
+}: LinkDetailPopupProps) {
+  const [variant, setVariant] = useState<'fullscreen' | 'modal'>('modal');
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mq = window.matchMedia('(max-width: 640px)');
+    const apply = () => setVariant(mq.matches ? 'fullscreen' : 'modal');
+    apply();
+    mq.addEventListener('change', apply);
+    return () => mq.removeEventListener('change', apply);
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.body.style.overflow = prev;
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      className="twv-popup-backdrop"
+      data-variant={variant}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        className="twv-popup"
+        data-variant={variant}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Transition from ${source.name} to ${target.name}`}
+      >
+        <div className="twv-popup-header">
+          <div className="twv-popup-title">
+            <span
+              className="twv-panel-kind-dot"
+              style={{ background: color }}
+              aria-hidden="true"
+            />
+            <div className="twv-popup-title-text">
+              <div className="twv-panel-name">Transition</div>
+              <code className="twv-panel-class">
+                {trigger ? `when: ${trigger}` : 'unconditional'}
+              </code>
+            </div>
+          </div>
+          <button
+            type="button"
+            className="twv-popup-close"
+            onClick={onClose}
+            aria-label="Close transition details"
+          >
+            <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 6l12 12M18 6L6 18" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="twv-popup-body">
+          {/* source → target, each step tappable to open its own panel */}
+          <div className="twv-link-flow">
+            <button
+              type="button"
+              className="twv-link-step"
+              onClick={() => onGoToStep(source.id)}
+              title={`Open ${source.name}`}
+            >
+              <span className="twv-link-step-role">From</span>
+              <span className="twv-link-step-name">{source.name}</span>
+            </button>
+            <span className="twv-link-flow-arrow" aria-hidden="true">→</span>
+            <button
+              type="button"
+              className="twv-link-step"
+              onClick={() => onGoToStep(target.id)}
+              title={`Open ${target.name}`}
+            >
+              <span className="twv-link-step-role">To</span>
+              <span className="twv-link-step-name">{target.name}</span>
+            </button>
+          </div>
+
+          <section className="twv-section">
+            <h4 className="twv-section-title">Trigger</h4>
+            <p className="twv-panel-desc">
+              {trigger
+                ? trigger
+                : 'Unconditional — this transition is always taken once the source step completes.'}
+            </p>
+          </section>
+
+          <p className="twv-panel-hint">Tap a step above to open its details.</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default LinkDetailPopup;

--- a/packages/workflow-viewer/src/WorkflowMap.tsx
+++ b/packages/workflow-viewer/src/WorkflowMap.tsx
@@ -4,6 +4,7 @@ import './styles.css';
 import type { WorkflowDataset, WorkflowMetadata, WorkflowNode } from './types';
 import { buildMapLayout, type MapLayout } from './mapLayout';
 import { StationDetailPopup } from './StationDetailPopup';
+import { LinkDetailPopup } from './LinkDetailPopup';
 import { kindOf, KIND_ORDER, KIND_DESCRIPTORS } from './kinds';
 
 export interface WorkflowMapProps {
@@ -89,11 +90,36 @@ export function WorkflowMap({
     return workflow.nodes.find((n) => n.id === stepId);
   }, [stepId, workflow]);
 
+  // A clicked rail/link opens its own transition panel (NOT the target step).
+  const [selectedRailId, setSelectedRailId] = useState<string | null>(null);
+  // A selected step and a selected link are mutually exclusive.
+  useEffect(() => {
+    if (stepId) setSelectedRailId(null);
+  }, [stepId]);
+
   const handleStationClick = useCallback(
-    (id: string) => onStepChange?.(id === stepId ? null : id),
+    (id: string) => {
+      setSelectedRailId(null);
+      onStepChange?.(id === stepId ? null : id);
+    },
     [onStepChange, stepId],
   );
   const handleClose = useCallback(() => onStepChange?.(null), [onStepChange]);
+  const handleRailClick = useCallback(
+    (railId: string) => {
+      onStepChange?.(null); // close any open step panel
+      setSelectedRailId((cur) => (cur === railId ? null : railId));
+    },
+    [onStepChange],
+  );
+  const handleLinkClose = useCallback(() => setSelectedRailId(null), []);
+  const handleGoToStep = useCallback(
+    (id: string) => {
+      setSelectedRailId(null);
+      onStepChange?.(id);
+    },
+    [onStepChange],
+  );
   const handleOpenSub = useCallback(
     (targetId: string) => onNavigate?.(targetId),
     [onNavigate],
@@ -114,6 +140,9 @@ export function WorkflowMap({
 
   const geom = computeGeometry(layout, width);
   const kindsPresent = new Set(workflow.nodes.map((n) => n.kind));
+  const selectedRail = selectedRailId
+    ? geom.railPaths.find((rp) => rp.id === selectedRailId)
+    : undefined;
 
   return (
     <div className="twv-map-root">
@@ -161,12 +190,13 @@ export function WorkflowMap({
                   opacity={rp.isBackEdge ? 0.85 : 0.95}
                   markerEnd="url(#twv-rail-arrow)"
                 />
-                {/* wide invisible hit area — click a line to open the step it leads to */}
+                {/* wide invisible hit area — click a line to open its transition panel */}
                 <path
                   className="twv-rail-hit"
                   d={rp.d}
                   fill="none"
-                  onClick={() => onStepChange?.(rp.to)}
+                  data-selected={rp.id === selectedRailId ? 'true' : 'false'}
+                  onClick={() => handleRailClick(rp.id)}
                 >
                   <title>{rp.title}</title>
                 </path>
@@ -247,6 +277,17 @@ export function WorkflowMap({
           subWorkflowHref={subWorkflowHref}
         />
       )}
+
+      {selectedRail && !selectedNode && (
+        <LinkDetailPopup
+          source={{ id: selectedRail.from, name: selectedRail.fromName }}
+          target={{ id: selectedRail.to, name: selectedRail.toName }}
+          trigger={selectedRail.trigger}
+          color={selectedRail.color}
+          onClose={handleLinkClose}
+          onGoToStep={handleGoToStep}
+        />
+      )}
     </div>
   );
 }
@@ -272,9 +313,17 @@ interface RailPath {
   d: string;
   color: string;
   isBackEdge: boolean;
-  /** Destination node id — clicking the rail opens this step. */
+  /** Source node id of the transition. */
+  from: string;
+  /** Destination node id of the transition. */
   to: string;
-  /** Tooltip, e.g. "Valid → Gather Context". */
+  /** Source step display name. */
+  fromName: string;
+  /** Target step display name. */
+  toName: string;
+  /** Trigger / branch condition, when the edge is conditional. */
+  trigger?: string;
+  /** Hover tooltip, e.g. "Validate → Gather Context  ·  when: Valid". */
   title: string;
 }
 interface RailLabel {
@@ -358,7 +407,11 @@ function computeGeometry(layout: MapLayout, width: number): Geometry {
       d,
       color,
       isBackEdge: rail.isBackEdge,
+      from: rail.from,
       to: rail.to,
+      fromName: a.node.name,
+      toName: b.node.name,
+      ...(trigger ? { trigger } : {}),
       title: trigger
         ? `${a.node.name} → ${b.node.name}  ·  when: ${trigger}`
         : `${a.node.name} → ${b.node.name}`,

--- a/packages/workflow-viewer/src/styles.css
+++ b/packages/workflow-viewer/src/styles.css
@@ -301,6 +301,54 @@
   cursor: pointer;
 }
 .twv-rail:hover .twv-rail-line { opacity: 1; stroke-width: 4.5; }
+/* Selected rail: keep it lit while its transition panel is open. */
+.twv-rail-hit[data-selected='true'] + .twv-rail-line,
+.twv-rail:has(.twv-rail-hit[data-selected='true']) .twv-rail-line {
+  opacity: 1;
+  stroke-width: 5;
+}
+
+/* Transition (link) panel — source → target flow + trigger. */
+.twv-link-flow {
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 4px 0 18px;
+}
+.twv-link-step {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1 1 0;
+  min-width: 120px;
+  text-align: left;
+  padding: 10px 12px;
+  border: 1px solid #2a2a31;
+  border-radius: 10px;
+  background-color: #16161b;
+  color: #e4e4e7;
+  cursor: pointer;
+  transition: border-color 0.12s ease, background-color 0.12s ease;
+}
+.twv-link-step:hover {
+  border-color: #3f3f46;
+  background-color: #1d1d23;
+}
+.twv-link-step-role {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #71717a;
+}
+.twv-link-step-name { font-size: 14px; font-weight: 600; line-height: 1.3; }
+.twv-link-flow-arrow {
+  align-self: center;
+  font-size: 18px;
+  color: #71717a;
+}
+.twv-panel-hint { font-size: 12px; color: #71717a; margin: 14px 0 0; }
 
 .twv-map-rail-label {
   position: absolute;


### PR DESCRIPTION
## What

Clicking a rail/link between two steps now opens a **dedicated Transition panel** instead of jumping to the target step's panel (which was indistinguishable from clicking the target station).

The Transition panel shows:
- **From** — the source step (tap to open its own details)
- **To** — the target step (tap to open its own details)
- **Trigger** — the branch condition / event (`when: <trigger>`), or "Unconditional — always taken" for an unconditional edge

Step selection and link selection are mutually exclusive (opening one closes the other). The hover tooltip and the on-map trigger label are unchanged.

## Verification

Verified in-browser on `ci-with-debug-retry/map`:
- Click the `Tests Passed? → Finish Pass · when: True` rail → Transition panel: From "Tests Passed?", To "Finish Pass", Trigger "True".
- Click "To: Finish Pass" inside the panel → navigates to `?step=CiRetryFinishPass`, the station panel replaces the transition panel.

New `LinkDetailPopup` mirrors the `StationDetailPopup` chrome (responsive modal/full-screen, Esc + backdrop dismiss). Source-only change to `@tamma/workflow-viewer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)