### PR TITLE
fix(engine): rotation audit persists via the DCB drain (was a crash)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/SecretsRotation/Activities/DrainRotationAuditEmitter.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/SecretsRotation/Activities/DrainRotationAuditEmitter.cs
@@ -1,0 +1,120 @@
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+using Tamma.Activities.SecretsRotation.Contracts;
+
+namespace Tamma.Activities.SecretsRotation.Activities;
+
+/// <summary>
+/// Engine-side implementation of <see cref="IRotationAuditEmitter"/>.
+///
+/// <para><b>Why this exists.</b> <c>RotateSecretWorkflow</c> runs inside
+/// <c>Tamma.ElsaServer</c> (the engine). The concrete
+/// <c>RotationAuditEmitter</c> lives in <c>Tamma.Api</c> (it forwards to
+/// <c>IPlatformEventPublisher</c>), which the engine cannot reference — so
+/// <c>IRotationAuditEmitter</c> was unregistered there and
+/// <c>ctx.GetRequiredService&lt;IRotationAuditEmitter&gt;()</c> threw
+/// <c>No service for type IRotationAuditEmitter</c> at runtime, crashing the
+/// rotation saga and losing the audit trail entirely.</para>
+///
+/// <para><b>What it does.</b> Maps each <see cref="RotationAuditEvent"/> to a
+/// <see cref="TammaEvent"/> and appends it to the workflow's <c>tamma:events</c>
+/// list (reached via the ambient <see cref="RotationAuditDrainScope"/> that
+/// <see cref="RotateSecretSagaActivity"/> opens around the saga run). The
+/// merged <c>EventPersistenceMiddleware</c> then drains those events to
+/// <c>POST /api/engine/events</c> → the tenant's <c>domain_events</c> — the
+/// same durable path every other engine audit event rides. The produced events
+/// carry the SAME <c>EventType</c> + tag keys (<c>secretId</c>,
+/// <c>rotationCorrelationId</c>, <c>tenantId</c>, <c>versionNumber</c>) as the
+/// Api-side emitter so dashboards/alert rules pattern-match identically.</para>
+///
+/// <para>Per the interface contract, <see cref="EmitAsync"/> never throws on a
+/// persistence gap — if there is no ambient drain scope (e.g. resolved outside
+/// a saga run) the emit is a logged no-op rather than a crash.</para>
+/// </summary>
+public sealed class DrainRotationAuditEmitter : IRotationAuditEmitter
+{
+    private readonly ILogger<DrainRotationAuditEmitter>? _logger;
+
+    public DrainRotationAuditEmitter(ILogger<DrainRotationAuditEmitter>? logger = null)
+    {
+        _logger = logger;
+    }
+
+    public Task EmitAsync(RotationAuditEvent evt, CancellationToken ct)
+    {
+        try
+        {
+            var scope = RotationAuditDrainScope.Current;
+            if (scope is null)
+            {
+                // No workflow drain context in scope — nothing to append to.
+                // Must not throw (the saga has already mutated state); log so
+                // a genuine wiring gap is visible.
+                _logger?.LogWarning(
+                    "Rotation audit event {EventType} for secret {SecretId} dropped — "
+                    + "no RotationAuditDrainScope in scope (emitter resolved outside a saga run?)",
+                    evt.EventType, evt.SecretId);
+                return Task.CompletedTask;
+            }
+
+            var tammaEvent = MapToTammaEvent(evt, scope);
+            scope.Events.Add(tammaEvent);
+
+            _logger?.LogDebug(
+                "Rotation audit event {EventType} queued for the DCB drain (secret {SecretId}, correlation {CorrelationId})",
+                evt.EventType, evt.SecretId, evt.RotationCorrelationId);
+        }
+        catch (Exception ex)
+        {
+            // Contract: never throw on a persistence failure.
+            _logger?.LogWarning(ex,
+                "Failed to queue rotation audit event {EventType} for secret {SecretId}",
+                evt.EventType, evt.SecretId);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Pure projection <see cref="RotationAuditEvent"/> → <see cref="TammaEvent"/>.
+    /// Public + static so it's unit-testable without an Elsa runtime and so the
+    /// tag/data shape can be asserted against the Api-side emitter's.
+    /// </summary>
+    public static TammaEvent MapToTammaEvent(RotationAuditEvent evt, RotationAuditDrainScope scope)
+    {
+        // Status mirrors the saga semantics the Api side encodes implicitly:
+        // a *.FAILED event is an error; everything else is a success step.
+        var isFailure =
+            evt.EventType.EndsWith(".FAILED", StringComparison.Ordinal)
+            || evt.EventType == RotationAuditEvents.Failed;
+
+        // Tags = the queryable DCB index keys. Same key set the Api-side
+        // RotationAuditEmitter.BuildTagsAndData writes.
+        var tags = new Dictionary<string, object?>
+        {
+            ["secretId"] = evt.SecretId,
+            ["rotationCorrelationId"] = evt.RotationCorrelationId,
+            ["tenantId"] = evt.TenantId,
+            ["versionNumber"] = evt.VersionNumber,
+        };
+
+        // Data = the structured payload; detail folded in when present (same as
+        // the Api side).
+        var data = new Dictionary<string, object?>(evt.Data);
+        if (!string.IsNullOrEmpty(evt.Detail))
+            data["detail"] = evt.Detail;
+
+        return new TammaEvent
+        {
+            EventType = evt.EventType,
+            Status = isFailure ? "error" : "success",
+            Error = isFailure ? evt.Detail : null,
+            Timestamp = evt.OccurredAt.UtcDateTime,
+            ActivityId = scope.ActivityId,
+            ActivityName = scope.ActivityName,
+            WorkflowInstanceId = scope.WorkflowInstanceId,
+            Tags = tags,
+            Data = data,
+        };
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/SecretsRotation/Activities/RotateSecretSagaActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/SecretsRotation/Activities/RotateSecretSagaActivity.cs
@@ -113,6 +113,21 @@ public class RotateSecretSagaActivity : TammaAsyncActivity
             // In unit-test harnesses the emitter is usually absent and
             // the runner degrades to RotationAuditEmitter-only.
             context.GetService<IAlertEventEmitter>());
+
+        // Open the ambient drain scope so the engine-side
+        // DrainRotationAuditEmitter can reach this workflow's tamma:events list
+        // (it isn't passed the ActivityExecutionContext). The events appended
+        // by the saga's per-step audit emits then ride the durable DCB drain
+        // (EventPersistenceMiddleware) to domain_events. The scope is restored
+        // on dispose so it never leaks across runs. A no-op for non-drain
+        // emitters (the Api-side RotationAuditEmitter ignores the ambient).
+        var drainEvents = GetOrCreateDrainEvents(context);
+        using var drainScope = RotationAuditDrainScope.Begin(
+            drainEvents,
+            activityId: Id,
+            activityName: Name ?? nameof(RotateSecretSagaActivity),
+            workflowInstanceId: context.WorkflowExecutionContext.Id);
+
         var outcome = await runner.ExecuteAsync(
             state,
             suppliedPlaintext: NewPlaintext.Get(context),
@@ -123,6 +138,25 @@ public class RotateSecretSagaActivity : TammaAsyncActivity
         NewVersionNumber?.Set(context, state.NewVersionNumber);
         OldVersionNumber?.Set(context, state.PreviousVersionNumber);
         Error?.Set(context, state.Error ?? string.Empty);
+    }
+
+    /// <summary>
+    /// Resolve (or create) the workflow's <c>tamma:events</c> transient list —
+    /// the exact list <see cref="EventPersistenceMiddleware"/> drains. Using the
+    /// same key (<see cref="EventDrain.EventsKey"/>) and instance means the
+    /// rotation audit events appended via the ambient drain scope are flushed by
+    /// the standard per-activity / workflow-completion drain alongside the
+    /// activity's own lifecycle events.
+    /// </summary>
+    private static List<TammaEvent> GetOrCreateDrainEvents(ActivityExecutionContext context)
+    {
+        var props = context.WorkflowExecutionContext.TransientProperties;
+        if (!props.TryGetValue(EventDrain.EventsKey, out var raw) || raw is not List<TammaEvent> list)
+        {
+            list = new List<TammaEvent>();
+            props[EventDrain.EventsKey] = list;
+        }
+        return list;
     }
 
     internal static string OutcomeLabel(SagaOutcome outcome) => outcome switch

--- a/apps/tamma-elsa/src/Tamma.Activities/SecretsRotation/Activities/RotationAuditDrainScope.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/SecretsRotation/Activities/RotationAuditDrainScope.cs
@@ -1,0 +1,82 @@
+using Tamma.Activities.Core;
+
+namespace Tamma.Activities.SecretsRotation.Activities;
+
+/// <summary>
+/// Ambient bridge from the rotation saga's <c>ActivityExecutionContext</c> to
+/// the engine-side <see cref="Contracts.IRotationAuditEmitter"/>.
+///
+/// <para><b>Why an ambient?</b> The rotation audit-emit calls happen deep
+/// inside <c>SagaRunner</c>, which (by design — it's unit-testable without
+/// Elsa) holds no <c>ActivityExecutionContext</c>. The emitter interface
+/// <c>EmitAsync(RotationAuditEvent, ct)</c> likewise carries no context. But
+/// the durable DCB drain (<c>EventPersistenceMiddleware</c>) reads the
+/// workflow's <c>tamma:events</c> transient list, which is only reachable via
+/// the context. Rather than thread the context through ~20 emit call sites,
+/// <see cref="RotateSecretSagaActivity"/> (which DOES hold the context) opens
+/// a scope around the single saga run; the engine emitter reads the ambient
+/// <c>tamma:events</c> list from it and appends mapped events that then ride
+/// the drain to <c>domain_events</c>.</para>
+///
+/// <para>The scope is opened with a <c>using</c> tightly around the saga body
+/// and restores the previous ambient on dispose, so it never leaks across runs
+/// (and nests safely — an inner scope restores the outer on dispose).</para>
+/// </summary>
+public sealed class RotationAuditDrainScope : IDisposable
+{
+    private static readonly AsyncLocal<RotationAuditDrainScope?> AmbientScope = new();
+
+    private readonly RotationAuditDrainScope? _previous;
+    private bool _disposed;
+
+    private RotationAuditDrainScope(
+        List<TammaEvent> events,
+        string? activityId,
+        string? activityName,
+        string? workflowInstanceId)
+    {
+        Events = events;
+        ActivityId = activityId;
+        ActivityName = activityName;
+        WorkflowInstanceId = workflowInstanceId;
+        _previous = AmbientScope.Value;
+        AmbientScope.Value = this;
+    }
+
+    /// <summary>The workflow's <c>tamma:events</c> list the emitter appends to.</summary>
+    public List<TammaEvent> Events { get; }
+
+    /// <summary>Source activity id stamped onto each emitted event.</summary>
+    public string? ActivityId { get; }
+
+    /// <summary>Source activity name stamped onto each emitted event.</summary>
+    public string? ActivityName { get; }
+
+    /// <summary>Owning workflow-instance id stamped onto each emitted event.</summary>
+    public string? WorkflowInstanceId { get; }
+
+    /// <summary>The ambient scope for the current async flow, or <c>null</c>.</summary>
+    public static RotationAuditDrainScope? Current => AmbientScope.Value;
+
+    /// <summary>
+    /// Open an ambient scope bound to <paramref name="events"/> (the workflow's
+    /// <c>tamma:events</c> list). Dispose to restore the previous ambient.
+    /// </summary>
+    public static RotationAuditDrainScope Begin(
+        List<TammaEvent> events,
+        string? activityId,
+        string? activityName,
+        string? workflowInstanceId) =>
+        new(events ?? throw new ArgumentNullException(nameof(events)),
+            activityId, activityName, workflowInstanceId);
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        // Restore only if we're still the active ambient (defensive against
+        // out-of-order disposal); otherwise leave the current ambient alone.
+        if (ReferenceEquals(AmbientScope.Value, this))
+            AmbientScope.Value = _previous;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
@@ -286,6 +286,21 @@ builder.Services.AddSingleton<Tamma.Activities.AgentDispatch.IGitHubActionsClien
 Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions
     .TryAddSingleton<Tamma.Data.Abstractions.IPlatformEventPublisher,
         Tamma.Activities.TenantLifecycle.NullPlatformEventPublisher>(builder.Services);
+
+// Story 29-6 — engine-side rotation audit emitter. RotateSecretWorkflow runs
+// HERE (the engine), and RotateSecretSagaActivity resolves
+// IRotationAuditEmitter via GetRequiredService. The concrete RotationAuditEmitter
+// lives in Tamma.Api (it forwards to IPlatformEventPublisher) and can't be
+// referenced from the engine — so without this registration the resolve threw
+// "No service for type IRotationAuditEmitter" and crashed the saga, losing the
+// audit trail. DrainRotationAuditEmitter maps each rotation event to a
+// TammaEvent on the workflow's tamma:events list (via the ambient
+// RotationAuditDrainScope the saga opens) so the events ride the durable DCB
+// drain (EventPersistenceMiddleware) → POST /api/engine/events → domain_events,
+// matching the EventType + tag keys the Api-side emitter produces.
+builder.Services.AddSingleton<Tamma.Activities.SecretsRotation.Contracts.IRotationAuditEmitter,
+    Tamma.Activities.SecretsRotation.Activities.DrainRotationAuditEmitter>();
+
 builder.Services.AddScoped<Tamma.Activities.AgentDispatch.IAgentDispatchService,
     Tamma.Activities.AgentDispatch.AgentDispatchService>();
 builder.Services.AddScoped<Tamma.Activities.AgentDispatch.IAgentMonitorService,

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/SecretsRotation/DrainRotationAuditEmitterTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/SecretsRotation/DrainRotationAuditEmitterTests.cs
@@ -1,0 +1,172 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Core;
+using Tamma.Activities.SecretsRotation.Activities;
+using Tamma.Activities.SecretsRotation.Contracts;
+
+namespace Tamma.Activities.Tests.SecretsRotation;
+
+/// <summary>
+/// Engine-side rotation-audit fix — <see cref="DrainRotationAuditEmitter"/>
+/// is the implementation of <see cref="IRotationAuditEmitter"/> registered in
+/// <c>Tamma.ElsaServer</c> (the API's <c>RotationAuditEmitter</c> can't be
+/// referenced there). It maps each <see cref="RotationAuditEvent"/> to a
+/// <see cref="TammaEvent"/> and appends it to the workflow's
+/// <c>tamma:events</c> list so the DCB-event drain
+/// (<see cref="EventPersistenceMiddleware"/>) persists it to
+/// <c>domain_events</c> — instead of throwing
+/// <c>No service for type IRotationAuditEmitter</c> at runtime.
+///
+/// <para>The ambient <c>tamma:events</c> list is set per-saga-run by
+/// <see cref="RotateSecretSagaActivity"/> (which holds the
+/// <c>ActivityExecutionContext</c>). These tests drive the emitter through
+/// the same ambient seam without standing up an Elsa runtime — mirroring the
+/// "Elsa's context can't be cheaply mocked, test the extracted seam" pattern
+/// used by <c>CheckBudgetActivityEmissionTests</c>.</para>
+/// </summary>
+[TestFixture]
+public class DrainRotationAuditEmitterTests
+{
+    private static readonly Guid SecretId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid TenantId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    [Test]
+    public async Task EmitAsync_AppendsMappedTammaEventToAmbientDrainList()
+    {
+        var events = new List<TammaEvent>();
+        var emitter = new DrainRotationAuditEmitter();
+
+        using (RotationAuditDrainScope.Begin(events, activityId: "act-1",
+                   activityName: "Rotate Secret Saga", workflowInstanceId: "wf-99"))
+        {
+            await emitter.EmitAsync(
+                RotationAuditEvent.Create(
+                    RotationAuditEvents.Staged,
+                    SecretId,
+                    TenantId,
+                    rotationCorrelationId: "rot_abc",
+                    versionNumber: 3,
+                    detail: null,
+                    data: new Dictionary<string, object?> { ["previousVersion"] = 2 }),
+                ct: default);
+        }
+
+        events.Should().ContainSingle();
+        var evt = events[0];
+        evt.EventType.Should().Be(RotationAuditEvents.Staged);
+        evt.Status.Should().Be("success");
+        // Activity/workflow identifiers ride through so the persisted row is
+        // joinable to the saga run.
+        evt.ActivityId.Should().Be("act-1");
+        evt.ActivityName.Should().Be("Rotate Secret Saga");
+        evt.WorkflowInstanceId.Should().Be("wf-99");
+
+        // Tags carry the same queryable index keys the Api-side emitter writes.
+        evt.Tags.Should().NotBeNull();
+        evt.Tags!["secretId"].Should().Be(SecretId);
+        evt.Tags["tenantId"].Should().Be(TenantId);
+        evt.Tags["rotationCorrelationId"].Should().Be("rot_abc");
+        evt.Tags["versionNumber"].Should().Be(3);
+
+        // Data carries the structured payload (+ detail when present).
+        evt.Data.Should().ContainKey("previousVersion");
+        evt.Data["previousVersion"].Should().Be(2);
+    }
+
+    [Test]
+    public async Task EmitAsync_FailedEvent_MapsErrorStatusAndDetail()
+    {
+        var events = new List<TammaEvent>();
+        var emitter = new DrainRotationAuditEmitter();
+
+        using (RotationAuditDrainScope.Begin(events, null, null, "wf-1"))
+        {
+            await emitter.EmitAsync(
+                RotationAuditEvent.Create(
+                    RotationAuditEvents.Failed,
+                    SecretId,
+                    tenantId: null,
+                    rotationCorrelationId: "rot_x",
+                    detail: "probe_failed:timeout"),
+                ct: default);
+        }
+
+        var evt = events.Should().ContainSingle().Subject;
+        evt.EventType.Should().Be(RotationAuditEvents.Failed);
+        evt.Status.Should().Be("error");
+        evt.Error.Should().Be("probe_failed:timeout");
+        evt.Data["detail"].Should().Be("probe_failed:timeout");
+        // Null tenant rotations still emit (platform-level secret) — tenantId
+        // tag is present but null, exactly like the Api-side emitter.
+        evt.Tags!["tenantId"].Should().BeNull();
+    }
+
+    [Test]
+    public async Task EmitAsync_WithNoAmbientScope_DoesNotThrowAndDropsSilently()
+    {
+        // The interface contract: EmitAsync must NOT throw on a persistence
+        // gap (the caller has already mutated state). With no ambient drain
+        // list (e.g. resolved outside a saga run) the emit is a logged no-op,
+        // never a crash — the whole point of the fix.
+        var emitter = new DrainRotationAuditEmitter();
+
+        var act = async () => await emitter.EmitAsync(
+            RotationAuditEvent.Create(
+                RotationAuditEvents.Completed, SecretId, TenantId, "rot_y"),
+            ct: default);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Test]
+    public async Task EmitAsync_ResolvedFromActivityScope_StyleSaga_DoesNotThrow()
+    {
+        // Regression for the engine crash: in production the saga resolves the
+        // emitter and emits ~8 events. Emitting a full sequence through the
+        // ambient seam must persist all of them without throwing.
+        var events = new List<TammaEvent>();
+        var emitter = new DrainRotationAuditEmitter();
+
+        using (RotationAuditDrainScope.Begin(events, "act", "saga", "wf"))
+        {
+            foreach (var type in new[]
+                     {
+                         RotationAuditEvents.Started, RotationAuditEvents.Staged,
+                         RotationAuditEvents.PushSuccess, RotationAuditEvents.ProbeSuccess,
+                         RotationAuditEvents.Switched, RotationAuditEvents.Activated,
+                         RotationAuditEvents.RetireScheduled, RotationAuditEvents.Completed,
+                     })
+            {
+                await emitter.EmitAsync(
+                    RotationAuditEvent.Create(type, SecretId, TenantId, "rot_seq"),
+                    ct: default);
+            }
+        }
+
+        events.Should().HaveCount(8);
+        events.Select(e => e.EventType).Should().Contain(RotationAuditEvents.Completed);
+    }
+
+    [Test]
+    public void DrainScope_RestoresPreviousAmbientOnDispose()
+    {
+        var outer = new List<TammaEvent>();
+        var inner = new List<TammaEvent>();
+
+        using (RotationAuditDrainScope.Begin(outer, null, null, "wf-outer"))
+        {
+            RotationAuditDrainScope.Current.Should().NotBeNull();
+            RotationAuditDrainScope.Current!.Events.Should().BeSameAs(outer);
+
+            using (RotationAuditDrainScope.Begin(inner, null, null, "wf-inner"))
+            {
+                RotationAuditDrainScope.Current!.Events.Should().BeSameAs(inner);
+            }
+
+            // Inner scope disposed → outer restored.
+            RotationAuditDrainScope.Current!.Events.Should().BeSameAs(outer);
+        }
+
+        RotationAuditDrainScope.Current.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## What

`RotateSecretWorkflow` runs in `Tamma.ElsaServer`, where `IRotationAuditEmitter` was unregistered (the concrete impl lives in `Tamma.Api`, which the engine can't reference) — so `GetRequiredService<IRotationAuditEmitter>()` **threw**, crashing the saga and emitting zero audit events.

Adds an engine-side `DrainRotationAuditEmitter` that maps each `RotationAuditEvent` → a `TammaEvent` (same event types + tags: `secretId`/`rotationCorrelationId`/`tenantId`/`versionNumber`) and rides the merged DCB drain → tenant `domain_events`. Registered in `ElsaServer`; the `Tamma.Api` registration is untouched. No interface change, no SagaRunner churn (an ambient scope around the saga exposes the drain list).

So rotation audit events now **persist** in the engine instead of crashing.

## Tracked follow-up (flagged, out of scope here)
The saga's other three ports (`ISecretRotationGateway`/`IRotationHandlerRegistry`/`IRetireScheduler`) are *also* engine-unregistered, so `RotateSecretWorkflow` still can't run end-to-end in the engine — a larger pivot-style engine→API seam job. Latent today (nothing dispatches the workflow programmatically; `Tamma.Api` doesn't host Elsa).

## Verification
- Build 0 errors; `has-pending-model-changes` clean.
- Rotation/Secret filters: Activities 37/0, Api 568/0. Full `Tamma.Activities.Tests` **1333/0**, `Tamma.Api.Tests` **3662/0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)