### PR TITLE
feat(workflows): build out + wire MergeApproval (complete, no-deadlock, secure gate)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitMergeApprovalEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitMergeApprovalEventActivity.cs
@@ -132,12 +132,13 @@ public class EmitMergeApprovalEventActivity : Activity
     }
 
     /// <summary>
-    /// Rejected / invalid / escalated transitions are loud (error-status) audit
-    /// rows — they are NOT a false success. Merge / test / merge-requested are
-    /// normal progress.
+    /// Rejected / invalid / escalated / failed-merge transitions are loud
+    /// (error-status) audit rows — they are NOT a false success. Merge / test /
+    /// merge-requested are normal progress.
     /// </summary>
     public static bool IsFailureEvent(string type)
         => type is MergeApprovalEvents.DecisionRejected
                 or MergeApprovalEvents.DecisionInvalid
-                or MergeApprovalEvents.Escalated;
+                or MergeApprovalEvents.Escalated
+                or MergeApprovalEvents.MergeFailed;
 }

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitMergeApprovalEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitMergeApprovalEventActivity.cs
@@ -1,0 +1,143 @@
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+
+namespace Tamma.Activities.ADL;
+
+/// <summary>
+/// Emits a <c>MERGE_APPROVAL.*</c> / <c>MERGE.*</c> DCB event (FR-19 / FR-34 /
+/// Story 4-6) for the audit trail by appending a <see cref="TammaEvent"/> to the
+/// workflow's <c>tamma:events</c> transient list via
+/// <see cref="TammaEventEmitter.Emit"/>. The engine event drain
+/// (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) flushes that list
+/// <i>durably</i> to the tenant <c>domain_events</c> store after this activity
+/// runs — the drain resolves the tenant from the workflow scope (the
+/// merge-approval workflow stamps a <c>TenantId</c> variable). The event
+/// therefore persists without this activity holding any DB / repository
+/// dependency of its own (none is registered in the Elsa engine — the same
+/// reason <see cref="EmitPrEventActivity"/> uses the emitter rather than a direct
+/// <c>IEventRepository</c>).
+///
+/// <para>This is the explicit-decision-edge emitter: the bookmark activity
+/// (<see cref="WaitForMergeApprovalActivity"/>, a <c>TammaOutcomeActivity</c>)
+/// already auto-emits <c>APPROVAL.GATE.STARTED/.FAILED</c>, but the human
+/// decision (merge / test / reject / invalid / escalate) lands on a distinct
+/// graph edge and carries approver / feedback / breakingChange context — so each
+/// edge emits its own DCB event through this activity.</para>
+/// </summary>
+[Activity(
+    "Tamma.ADL",
+    "Emit Merge Approval Event",
+    "Emit a MERGE_APPROVAL.* / MERGE.* DCB event for the approval-gate audit trail",
+    Kind = ActivityKind.Task
+)]
+public class EmitMergeApprovalEventActivity : Activity
+{
+    private readonly ILogger<EmitMergeApprovalEventActivity>? _logger;
+
+    [Input(Description = "Event type — e.g. MERGE_APPROVAL.DECISION.MERGED / MERGE.REQUESTED")]
+    public Input<string> EventType { get; set; } = default!;
+
+    [Input(Description = "Issue number this PR closes")]
+    public Input<int> IssueNumber { get; set; } = default!;
+
+    [Input(Description = "Pull request number")]
+    public Input<int> PrNumber { get; set; } = new(0);
+
+    [Input(Description = "Tenant id (empty / single-user → platform-scope event)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [Input(Description = "Approval decision string (merge|test|reject|<invalid>)")]
+    public Input<string?> Decision { get; set; } = new((string?)null);
+
+    [Input(Description = "Approver identity captured from the resume payload")]
+    public Input<string?> Approver { get; set; } = new((string?)null);
+
+    [Input(Description = "Free-text reviewer feedback")]
+    public Input<string?> Feedback { get; set; } = new((string?)null);
+
+    [JsonConstructor]
+    public EmitMergeApprovalEventActivity() { }
+
+    public EmitMergeApprovalEventActivity(ILogger<EmitMergeApprovalEventActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var type = EventType.Get(context) ?? MergeApprovalEvents.Escalated;
+        var issueNumber = IssueNumber.Get(context);
+        var prNumber = PrNumber.Get(context);
+        var tenantId = MergeApprovalEvents.ParseTenantId(TenantId.Get(context));
+        var decision = Decision.Get(context);
+        var approver = Approver.Get(context);
+        var feedback = Feedback.Get(context);
+
+        var evt = BuildTammaEvent(type, issueNumber, prNumber, tenantId, decision, approver, feedback);
+        TammaEventEmitter.Emit(context, this, _logger, evt);
+
+        _logger?.LogInformation(
+            "Emitted {Type} for issue #{Issue} pr #{Pr} (decision={Decision}, approver={Approver})",
+            type, issueNumber, prNumber, decision ?? "", approver ?? "");
+
+        return default;
+    }
+
+    /// <summary>
+    /// Map the gate inputs onto a <see cref="TammaEvent"/> expressed as the
+    /// engine's transient-list event so the merged drain persists it. Tags carry
+    /// the queryable DCB index keys (<c>issueId</c>/<c>issueNumber</c>/
+    /// <c>prNumber</c>/<c>tenantId</c>/<c>decision</c>/<c>approver</c>); Data
+    /// carries the decision payload. Pure (no Elsa context) — exposed for unit
+    /// testing the mapping.
+    /// </summary>
+    public static TammaEvent BuildTammaEvent(
+        string type,
+        int issueNumber,
+        int prNumber,
+        Guid? tenantId,
+        string? decision,
+        string? approver,
+        string? feedback)
+    {
+        var tags = new Dictionary<string, object?>
+        {
+            ["issueId"] = issueNumber.ToString(),
+            ["issueNumber"] = issueNumber.ToString(),
+        };
+        if (prNumber > 0) tags["prNumber"] = prNumber.ToString();
+        if (tenantId is not null) tags["tenantId"] = tenantId.Value.ToString("D");
+        if (!string.IsNullOrWhiteSpace(decision)) tags["decision"] = decision;
+        if (!string.IsNullOrWhiteSpace(approver)) tags["approver"] = approver;
+
+        var data = new Dictionary<string, object?>
+        {
+            ["decision"] = decision ?? "",
+            ["approver"] = approver ?? "",
+            ["feedback"] = feedback ?? "",
+        };
+
+        return new TammaEvent
+        {
+            EventType = type,
+            Status = IsFailureEvent(type) ? "error" : "success",
+            Tags = tags,
+            Data = data,
+        };
+    }
+
+    /// <summary>
+    /// Rejected / invalid / escalated transitions are loud (error-status) audit
+    /// rows — they are NOT a false success. Merge / test / merge-requested are
+    /// normal progress.
+    /// </summary>
+    public static bool IsFailureEvent(string type)
+        => type is MergeApprovalEvents.DecisionRejected
+                or MergeApprovalEvents.DecisionInvalid
+                or MergeApprovalEvents.Escalated;
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/MergeApprovalEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/MergeApprovalEvents.cs
@@ -1,0 +1,68 @@
+namespace Tamma.Activities.ADL;
+
+/// <summary>
+/// FR-19 / FR-34 / Story 4-6 — central catalogue of the <c>MERGE_APPROVAL.*</c>
+/// and <c>MERGE.*</c> DCB event types emitted by the <c>merge-approval</c>
+/// workflow gate.
+///
+/// <para>The gate is the human <b>APPROVAL_GATE</b> step of the 14-step loop
+/// (<c>docs/architecture.md</c> line 840): a completed PR suspends on a bookmark
+/// until a human chooses <i>merge / test / reject</i>. Every transition of that
+/// gate is an auditable approval/escalation event (the architecture lists
+/// "approvals/escalations" as a first-class captured event family —
+/// <c>docs/stories/epic-4/4-6-event-capture-approvals-escalations.md</c>).</para>
+///
+/// <para>Events are emitted via <c>TammaEventEmitter.Emit</c> into the workflow's
+/// <c>tamma:events</c> transient list and persisted <i>durably</i> by the engine
+/// event drain (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) — the same
+/// pattern <see cref="EmitPrEventActivity"/> uses. No activity holds a DB /
+/// repository dependency of its own (none is registered in the Elsa engine — a
+/// directly-injected <c>IEventRepository</c> would be inert and silently drop
+/// every gate event).</para>
+///
+/// <para>Type pattern follows the platform's <c>AGGREGATE.ACTION.STATUS</c>
+/// convention.</para>
+///
+/// <list type="bullet">
+///   <item><description><c>MERGE_APPROVAL.DECISION.MERGED</c> — a human approved
+///     the PR to merge.</description></item>
+///   <item><description><c>MERGE_APPROVAL.DECISION.TEST</c> — a human requested
+///     more testing before a merge decision.</description></item>
+///   <item><description><c>MERGE_APPROVAL.DECISION.REJECTED</c> — a human
+///     rejected the PR.</description></item>
+///   <item><description><c>MERGE_APPROVAL.DECISION.INVALID</c> — the resume
+///     payload carried an unknown / empty decision. Emitted instead of silently
+///     defaulting to "reject" (no-silent-failure rule). Routes back to the gate
+///     for a valid re-decision.</description></item>
+///   <item><description><c>MERGE_APPROVAL.ESCALATED</c> — the gate escalated to
+///     owners (e.g. an invalid decision needing human attention, or a
+///     breaking-change merge attempted without an authorised approver).</description></item>
+///   <item><description><c>MERGE.REQUESTED</c> — on approval the gate dispatched
+///     the <c>merge</c> workflow.</description></item>
+///   <item><description><c>MERGE_APPROVAL.TEST_REQUESTED</c> — on the test
+///     decision the gate dispatched the testing sub-workflow before re-deciding.</description></item>
+/// </list>
+/// </summary>
+public static class MergeApprovalEvents
+{
+    /// <summary>Activity-level <c>EventType</c> prefix for the bookmark gate
+    /// (drives the auto <c>.STARTED</c> / <c>.FAILED</c> events on
+    /// <see cref="WaitForMergeApprovalActivity"/>, a <c>TammaOutcomeActivity</c>).</summary>
+    public const string GatePrefix = "APPROVAL.GATE";
+
+    public const string DecisionMerged = "MERGE_APPROVAL.DECISION.MERGED";
+    public const string DecisionTest = "MERGE_APPROVAL.DECISION.TEST";
+    public const string DecisionRejected = "MERGE_APPROVAL.DECISION.REJECTED";
+    public const string DecisionInvalid = "MERGE_APPROVAL.DECISION.INVALID";
+    public const string Escalated = "MERGE_APPROVAL.ESCALATED";
+    public const string MergeRequested = "MERGE.REQUESTED";
+    public const string TestRequested = "MERGE_APPROVAL.TEST_REQUESTED";
+
+    /// <summary>
+    /// Parse a tenant id from the loose string form threaded through the workflow
+    /// inputs. Returns <c>null</c> for empty / single-user / unparseable values
+    /// (gate events in single-user mode are platform-scope, TenantId null).
+    /// </summary>
+    public static Guid? ParseTenantId(string? tenantId)
+        => Guid.TryParse(tenantId, out var g) ? g : null;
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/MergeApprovalEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/MergeApprovalEvents.cs
@@ -32,13 +32,19 @@ namespace Tamma.Activities.ADL;
 ///     rejected the PR.</description></item>
 ///   <item><description><c>MERGE_APPROVAL.DECISION.INVALID</c> — the resume
 ///     payload carried an unknown / empty decision. Emitted instead of silently
-///     defaulting to "reject" (no-silent-failure rule). Routes back to the gate
-///     for a valid re-decision.</description></item>
+///     defaulting to "reject" (no-silent-failure rule). The gate ESCALATES on
+///     this (the parent routes the <c>Invalid</c> outcome to the escalate
+///     terminal) — it does NOT loop back to the gate.</description></item>
 ///   <item><description><c>MERGE_APPROVAL.ESCALATED</c> — the gate escalated to
-///     owners (e.g. an invalid decision needing human attention, or a
-///     breaking-change merge attempted without an authorised approver).</description></item>
+///     owners (e.g. an invalid decision needing human attention, a failed merge
+///     sub-workflow, or a breaking-change merge attempted without an authorised
+///     approver).</description></item>
 ///   <item><description><c>MERGE.REQUESTED</c> — on approval the gate dispatched
 ///     the <c>merge</c> workflow.</description></item>
+///   <item><description><c>MERGE.FAILED</c> — the dispatched <c>merge</c>
+///     workflow reported <c>success=false</c>. Loud (error-status) — the gate
+///     escalates instead of routing to the merge/success terminal (which would
+///     hang the cycle on a merge webhook that never fires).</description></item>
 ///   <item><description><c>MERGE_APPROVAL.TEST_REQUESTED</c> — on the test
 ///     decision the gate dispatched the testing sub-workflow before re-deciding.</description></item>
 /// </list>
@@ -56,6 +62,7 @@ public static class MergeApprovalEvents
     public const string DecisionInvalid = "MERGE_APPROVAL.DECISION.INVALID";
     public const string Escalated = "MERGE_APPROVAL.ESCALATED";
     public const string MergeRequested = "MERGE.REQUESTED";
+    public const string MergeFailed = "MERGE.FAILED";
     public const string TestRequested = "MERGE_APPROVAL.TEST_REQUESTED";
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForMergeApprovalActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForMergeApprovalActivity.cs
@@ -5,21 +5,37 @@ using Elsa.Workflows.Activities.Flowchart.Attributes;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
-using Tamma.Activities.ADL.Models;
+using Tamma.Activities.Core;
 
 namespace Tamma.Activities.ADL;
 
 /// <summary>
-/// Bookmark-based activity that suspends the workflow until a human
-/// decides whether to merge, run more tests, or reject the PR.
+/// Bookmark-based human <b>APPROVAL_GATE</b> (FR-19 / FR-34): suspend the loop
+/// until a human decides whether to <i>merge</i>, run more <i>tests</i>, or
+/// <i>reject</i> the PR, then surface that decision (+ approver + feedback) as a
+/// typed outcome the parent flowchart branches on.
 ///
-/// Resume via API: POST /api/adl/{instanceId}/merge-approval
-///   body: { "decision": "merge|test|reject", "feedback": "..." }
+/// <para>Resume via the bookmark <c>adl-merge-approval-{issue}-{pr}</c> with the
+/// workflow input keys <c>{ decision, feedback, approver }</c> (the documented
+/// resume contract; the API surface that injects them is a follow-on — see the
+/// build-out report).</para>
 ///
-/// Outcomes:
-///   - Merge: approved to merge
-///   - Test: run additional tests before merging
-///   - Reject: PR rejected
+/// <para>Outcomes (the parent routes each to a distinct edge — no fall-through):
+/// <list type="bullet">
+///   <item><description><c>Merge</c> — approved to merge.</description></item>
+///   <item><description><c>Test</c> — run additional tests before merging.</description></item>
+///   <item><description><c>Reject</c> — PR rejected.</description></item>
+///   <item><description><c>Invalid</c> — unknown / empty decision. Emitted
+///     instead of silently defaulting to "reject" (no-silent-failure rule); the
+///     parent routes it to escalation / re-prompt.</description></item>
+/// </list></para>
+///
+/// <para>Events: this is a <see cref="TammaOutcomeActivity"/> with
+/// <c>EventType = APPROVAL.GATE</c>, so the engine auto-emits
+/// <c>APPROVAL.GATE.STARTED</c> at suspend and <c>APPROVAL.GATE.FAILED</c> on
+/// exception. The decision itself is emitted as a <c>MERGE_APPROVAL.DECISION.*</c>
+/// DCB event on the resuming edge (see <c>EmitMergeApprovalEventActivity</c> in
+/// the workflow graph) so the approver / feedback context is captured durably.</para>
 /// </summary>
 [Activity(
     "Tamma.ADL",
@@ -27,10 +43,15 @@ namespace Tamma.Activities.ADL;
     "Suspend workflow and wait for merge/test/reject decision",
     Kind = ActivityKind.Task
 )]
-[FlowNode("Merge", "Test", "Reject")]
-public class WaitForMergeApprovalActivity : Activity
+[FlowNode("Merge", "Test", "Reject", "Invalid")]
+public class WaitForMergeApprovalActivity : TammaOutcomeActivity
 {
-    private readonly ILogger<WaitForMergeApprovalActivity>? _logger;
+    /// <summary>Recognised decisions (case-insensitive). Anything else → <c>Invalid</c>.</summary>
+    public const string DecisionMerge = "merge";
+    public const string DecisionTest = "test";
+    public const string DecisionReject = "reject";
+
+    public override string? EventType => MergeApprovalEvents.GatePrefix;
 
     [Input(Description = "Issue number for bookmark identification")]
     public Input<int> IssueNumber { get; set; } = default!;
@@ -41,27 +62,30 @@ public class WaitForMergeApprovalActivity : Activity
     [Input(Description = "PR URL")]
     public Input<string?> PrUrl { get; set; } = default!;
 
-    [Output(Description = "Approval decision")]
+    [Output(Description = "Approval decision (merge|test|reject|invalid)")]
     public Output<string?> Decision { get; set; } = default!;
 
     [Output(Description = "Feedback from reviewer")]
     public Output<string?> Feedback { get; set; } = default!;
+
+    [Output(Description = "Approver identity captured from the resume payload")]
+    public Output<string?> Approver { get; set; } = default!;
 
     [JsonConstructor]
     public WaitForMergeApprovalActivity() { }
 
     public WaitForMergeApprovalActivity(ILogger<WaitForMergeApprovalActivity> logger)
     {
-        _logger = logger;
+        Logger = logger;
     }
 
-    protected override void Execute(ActivityExecutionContext context)
+    protected override Task RunAsync(ActivityExecutionContext context)
     {
         var issueNumber = IssueNumber.Get(context);
         var prNumber = PrNumber.Get(context);
         var bookmarkName = $"adl-merge-approval-{issueNumber}-{prNumber}";
 
-        _logger?.LogInformation(
+        Logger?.LogInformation(
             "Creating merge approval bookmark {BookmarkName} for PR #{PrNumber}",
             bookmarkName, prNumber);
 
@@ -70,8 +94,11 @@ public class WaitForMergeApprovalActivity : Activity
             {
                 BookmarkName = bookmarkName,
                 Callback = OnMergeDecisionAsync,
-                AutoBurn = true
+                AutoBurn = true,
+                IncludeActivityInstanceId = false,
             });
+
+        return Task.CompletedTask;
     }
 
     private async ValueTask OnMergeDecisionAsync(ActivityExecutionContext context)
@@ -80,22 +107,50 @@ public class WaitForMergeApprovalActivity : Activity
 
         var decisionStr = input.TryGetValue("decision", out var d) ? d?.ToString() : null;
         var feedback = input.TryGetValue("feedback", out var f) ? f?.ToString() : null;
+        var approver = input.TryGetValue("approver", out var a) ? a?.ToString() : null;
 
-        Decision.Set(context, decisionStr);
+        var (outcome, normalized) = Normalize(decisionStr);
+
+        // Surface the NORMALIZED decision (so downstream edges + the emitted DCB
+        // event agree on a canonical token), plus the captured approver/feedback.
+        Decision.Set(context, normalized);
         Feedback.Set(context, feedback);
+        Approver.Set(context, approver);
 
-        _logger?.LogInformation(
-            "Merge decision received for PR #{PrNumber}: {Decision}",
-            PrNumber.Get(context), decisionStr);
-
-        var outcome = decisionStr?.ToLowerInvariant() switch
-        {
-            "merge" => "Merge",
-            "test" => "Test",
-            "reject" => "Reject",
-            _ => "Reject"
-        };
+        Logger?.LogInformation(
+            "Merge decision received for PR #{PrNumber}: {Decision} (outcome={Outcome}, approver={Approver})",
+            PrNumber.Get(context), decisionStr ?? "<null>", outcome, approver ?? "<none>");
 
         await context.CompleteActivityWithOutcomesAsync(outcome);
     }
+
+    /// <summary>
+    /// Map a raw decision string to a typed outcome + canonical token. Unknown /
+    /// empty → <c>(Invalid, "invalid")</c> — NEVER a silent "reject" (the prior
+    /// skeleton's bug, violating the no-silent-failure / no-false-result rule).
+    /// Pure — exposed for unit testing.
+    /// </summary>
+    public static (string Outcome, string Normalized) Normalize(string? decision)
+        => decision?.Trim().ToLowerInvariant() switch
+        {
+            DecisionMerge => ("Merge", DecisionMerge),
+            DecisionTest => ("Test", DecisionTest),
+            DecisionReject => ("Reject", DecisionReject),
+            _ => ("Invalid", "invalid"),
+        };
+
+    public override Dictionary<string, object?> BuildStartData(ActivityExecutionContext context) => new()
+    {
+        ["issueNumber"] = IssueNumber.Get(context),
+        ["prNumber"] = PrNumber.Get(context),
+        ["prUrl"] = PrUrl.Get(context) ?? "",
+    };
+
+    public override Dictionary<string, object?> BuildEndData(ActivityExecutionContext context) => new()
+    {
+        ["issueNumber"] = IssueNumber.Get(context),
+        ["prNumber"] = PrNumber.Get(context),
+        ["decision"] = this.GetOutput<string?>(context, nameof(Decision)) ?? "",
+        ["approver"] = this.GetOutput<string?>(context, nameof(Approver)) ?? "",
+    };
 }

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForMergeApprovalActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForMergeApprovalActivity.cs
@@ -62,6 +62,16 @@ public class WaitForMergeApprovalActivity : TammaOutcomeActivity
     [Input(Description = "PR URL")]
     public Input<string?> PrUrl { get; set; } = default!;
 
+    /// <summary>
+    /// Whether the PR carries a breaking change. Threaded into the gate's audit
+    /// <c>start</c> data for forward-compatible audit (IMPORTANT-1 / FR-34). The
+    /// ENFORCEMENT arm (mandatory-approver policy on breaking changes, FR-34) is
+    /// deferred — this only records the signal so it is queryable now and the
+    /// enforcement can light up later without an audit-schema change.
+    /// </summary>
+    [Input(Description = "Whether the PR carries a breaking change (audit signal; enforcement deferred)")]
+    public Input<bool> BreakingChange { get; set; } = new(false);
+
     [Output(Description = "Approval decision (merge|test|reject|invalid)")]
     public Output<string?> Decision { get; set; } = default!;
 
@@ -144,6 +154,8 @@ public class WaitForMergeApprovalActivity : TammaOutcomeActivity
         ["issueNumber"] = IssueNumber.Get(context),
         ["prNumber"] = PrNumber.Get(context),
         ["prUrl"] = PrUrl.Get(context) ?? "",
+        // IMPORTANT-1 — forward-compatible audit signal; enforcement (FR-34) deferred.
+        ["breakingChange"] = BreakingChange.Get(context),
     };
 
     public override Dictionary<string, object?> BuildEndData(ActivityExecutionContext context) => new()

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForMergeApprovalActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForMergeApprovalActivity.cs
@@ -15,10 +15,10 @@ namespace Tamma.Activities.ADL;
 /// <i>reject</i> the PR, then surface that decision (+ approver + feedback) as a
 /// typed outcome the parent flowchart branches on.
 ///
-/// <para>Resume via the bookmark <c>adl-merge-approval-{issue}-{pr}</c> with the
-/// workflow input keys <c>{ decision, feedback, approver }</c> (the documented
-/// resume contract; the API surface that injects them is a follow-on — see the
-/// build-out report).</para>
+/// <para>Resume via the tenant+repo-scoped bookmark
+/// <c>adl-merge-approval-{tenant}-{repo}-{issue}-{pr}</c> (SECURITY C2 — see
+/// <see cref="BookmarkName"/>) with the workflow input keys
+/// <c>{ decision, feedback, approver }</c> (the documented resume contract).</para>
 ///
 /// <para>Outcomes (the parent routes each to a distinct edge — no fall-through):
 /// <list type="bullet">
@@ -59,6 +59,24 @@ public class WaitForMergeApprovalActivity : TammaOutcomeActivity
     [Input(Description = "PR number")]
     public Input<int> PrNumber { get; set; } = default!;
 
+    /// <summary>
+    /// SECURITY C2 — tenant id (the workflow's <c>TenantId</c> variable, a GUID
+    /// string or empty for single-user). Folded into the bookmark name so two
+    /// tenants on the same issue/PR can never share — and so collide on — a
+    /// bookmark. The resume caller (scoped to ITS tenant) can only target a
+    /// bookmark whose name carries its own tenant id.
+    /// </summary>
+    [Input(Description = "Tenant id (bookmark scoping — prevents cross-tenant collision)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    /// <summary>
+    /// SECURITY C2 — repository slug (<c>owner/repo</c>). Folded into the bookmark
+    /// name alongside the tenant id so the same issue/PR number across different
+    /// repos can't collide either.
+    /// </summary>
+    [Input(Description = "Repository slug (bookmark scoping — prevents cross-repo collision)")]
+    public Input<string?> Repository { get; set; } = new((string?)null);
+
     [Input(Description = "PR URL")]
     public Input<string?> PrUrl { get; set; } = default!;
 
@@ -89,11 +107,48 @@ public class WaitForMergeApprovalActivity : TammaOutcomeActivity
         Logger = logger;
     }
 
+    /// <summary>
+    /// SECURITY C2 — canonical, globally-unique bookmark name for a merge-approval
+    /// gate. Includes <paramref name="tenantId"/> + <paramref name="repository"/>
+    /// (in addition to issue/PR) so two tenants — or two repos — on the same
+    /// issue/PR number get DISTINCT bookmarks and can never resume each other's
+    /// gate. The engine resume endpoint computes the SAME name from the
+    /// (tenant-scoped) resume request, so a caller can only ever target a gate in
+    /// its own tenant.
+    ///
+    /// <para>Both the activity (suspend side) and the engine endpoint (resume
+    /// side) MUST call this single method so the names match byte-for-byte.</para>
+    /// </summary>
+    public static string BookmarkName(string? tenantId, string? repository, int issueNumber, int prNumber)
+    {
+        var tenant = NormalizeSegment(tenantId);
+        var repo = NormalizeSegment(repository);
+        return $"adl-merge-approval-{tenant}-{repo}-{issueNumber}-{prNumber}";
+    }
+
+    /// <summary>
+    /// Normalise a tenant/repo segment so it can't break the bookmark-name
+    /// delimiter scheme (which is '-' separated) or smuggle in a collision. We
+    /// lower-case, replace any non <c>[a-z0-9._]</c> char (including '-' and '/')
+    /// with '_', and substitute empty/whitespace with a stable placeholder. The
+    /// SAME transform runs on both sides so the names always agree.
+    /// </summary>
+    public static string NormalizeSegment(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return "none";
+        var lowered = value.Trim().ToLowerInvariant();
+        var chars = lowered.Select(c =>
+            (c is >= 'a' and <= 'z' or >= '0' and <= '9' or '.' or '_') ? c : '_');
+        return new string(chars.ToArray());
+    }
+
     protected override Task RunAsync(ActivityExecutionContext context)
     {
         var issueNumber = IssueNumber.Get(context);
         var prNumber = PrNumber.Get(context);
-        var bookmarkName = $"adl-merge-approval-{issueNumber}-{prNumber}";
+        var tenantId = TenantId.Get(context);
+        var repository = Repository.Get(context);
+        var bookmarkName = BookmarkName(tenantId, repository, issueNumber, prNumber);
 
         Logger?.LogInformation(
             "Creating merge approval bookmark {BookmarkName} for PR #{PrNumber}",

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForPRApprovalActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForPRApprovalActivity.cs
@@ -17,8 +17,9 @@ namespace Tamma.Activities.ADL;
 /// binary approve/merge gate this activity drove was replaced by the richer
 /// merge/test/reject <c>merge-approval</c> gate (<see cref="WaitForMergeApprovalActivity"/>).
 /// It is kept for the <c>pull_request_review</c> webhook-resume seam: the merge gate
-/// resumes on the <c>adl-merge-approval-{issue}-{pr}</c> bookmark via the
-/// <c>POST /api/adl/{instanceId}/merge-approval</c> resume endpoint, and a future
+/// resumes on the tenant+repo-scoped
+/// <c>adl-merge-approval-{tenant}-{repo}-{issue}-{pr}</c> bookmark via the
+/// <c>POST /api/adl/merge-approval/resume</c> resume endpoint, and a future
 /// webhook → <c>{decision}</c> mapping can reuse this activity's binary
 /// <c>pr-approval-{pr}</c> bookmark shape if the platform ever drives the gate
 /// straight from a review event. Do not delete without retiring that seam.</para>

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForPRApprovalActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForPRApprovalActivity.cs
@@ -12,6 +12,16 @@ namespace Tamma.Activities.ADL;
 /// Bookmark-based activity that blocks until a PR is approved.
 /// Resumed by a GitHub webhook (pull_request_review.submitted with state=approved)
 /// or by polling the PR status.
+///
+/// <para><b>Retained — not currently wired into <c>single-issue-cycle</c>.</b> The
+/// binary approve/merge gate this activity drove was replaced by the richer
+/// merge/test/reject <c>merge-approval</c> gate (<see cref="WaitForMergeApprovalActivity"/>).
+/// It is kept for the <c>pull_request_review</c> webhook-resume seam: the merge gate
+/// resumes on the <c>adl-merge-approval-{issue}-{pr}</c> bookmark via the
+/// <c>POST /api/adl/{instanceId}/merge-approval</c> resume endpoint, and a future
+/// webhook → <c>{decision}</c> mapping can reuse this activity's binary
+/// <c>pr-approval-{pr}</c> bookmark shape if the platform ever drives the gate
+/// straight from a review event. Do not delete without retiring that seam.</para>
 /// </summary>
 [Activity(
     "Tamma.ADL",

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/AdlEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/AdlEndpoints.cs
@@ -1,6 +1,9 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
 using Tamma.Api.Services;
 using Tamma.Core.Logging;
+using Tamma.Data;
 
 namespace Tamma.Api.Endpoints;
 
@@ -10,7 +13,7 @@ namespace Tamma.Api.Endpoints;
 ///
 /// <para>The gate (<c>WaitForMergeApprovalActivity</c>) suspends the
 /// <c>single-issue-cycle</c> on the named bookmark
-/// <c>adl-merge-approval-{issue}-{pr}</c> and reads
+/// <c>adl-merge-approval-{tenant}-{repo}-{issue}-{pr}</c> and reads
 /// <c>{decision, feedback, approver}</c> from the workflow input on resume.
 /// Without a producer, wiring the gate into the cycle would suspend the merge
 /// step forever. This endpoint is that producer: it forwards to the engine's
@@ -22,18 +25,39 @@ namespace Tamma.Api.Endpoints;
 /// <c>workflows:manage</c> → tenant owner/admin). Member-role SaaS callers hit
 /// 403 at the policy — driving a merge decision is a workflow-management
 /// action, mirroring the engine command/issue-mutation routes.</para>
+///
+/// <para><b>SECURITY C1 (cross-tenant IDOR)</b>: <c>WorkflowsManage</c> alone is
+/// any tenant owner/admin, so the prior handler — which took no
+/// <see cref="ITenantContext"/> and did no ownership check — let a tenant
+/// owner/admin approve/merge/reject ANOTHER tenant's gate by supplying
+/// issue+PR. The resume is now tenant-scoped end to end: the caller's ambient
+/// tenant id (and the repository) are threaded to the engine, which folds them
+/// into the bookmark name. A caller in tenant A can therefore only ever resolve
+/// tenant A's gate; a cross-tenant attempt simply 404s (gate not found), it
+/// never acts (mirrors <c>WorkflowEndpoints.GetInstanceEvents</c>, finding 016).</para>
+///
+/// <para><b>SECURITY I2 (non-repudiation)</b>: <c>approver</c> is derived from
+/// the authenticated principal server-side; any client-supplied approver is
+/// ignored. The DCB audit trail records WHO actually approved.</para>
 /// </summary>
 public static class AdlEndpoints
 {
-    /// <summary>Accepted decisions (case-insensitive). Anything else routes to
-    /// the gate's <c>Invalid</c> outcome — but we reject obviously empty input
-    /// up front so the caller gets a 400 instead of silently escalating.</summary>
+    /// <summary>Decisions the gate accepts (case-insensitive). Anything else is
+    /// rejected with 400 up front so the caller never forwards an arbitrary
+    /// string into the gate (MINOR).</summary>
+    private static readonly HashSet<string> AllowedDecisions =
+        new(StringComparer.OrdinalIgnoreCase) { "merge", "test", "reject" };
+
+    /// <summary>
+    /// Resume request. <c>Approver</c> is intentionally absent — the approver is
+    /// derived from the authenticated caller (I2), never trusted from the client.
+    /// </summary>
     public sealed record MergeApprovalDecisionRequest(
         int IssueNumber,
         int PrNumber,
+        string Repository,
         string Decision,
-        string? Feedback,
-        string? Approver);
+        string? Feedback);
 
     /// <summary>
     /// Resume the merge-approval gate for an issue/PR with a human decision.
@@ -42,19 +66,39 @@ public static class AdlEndpoints
     public static async Task<IResult> ResumeMergeApproval(
         [FromBody] MergeApprovalDecisionRequest req,
         [FromServices] IElsaWorkflowService elsa,
+        [FromServices] ITenantContext tenantContext,
+        ClaimsPrincipal principal,
         [FromServices] ILoggerFactory loggerFactory)
     {
         var logger = loggerFactory.CreateLogger("Tamma.Api.AdlEndpoints");
 
         if (string.IsNullOrWhiteSpace(req.Decision))
             return Results.BadRequest(new { error = "decision is required (merge|test|reject)" });
+        // MINOR — validate the decision against the accepted set; don't forward an
+        // arbitrary string that would silently escalate at the gate.
+        if (!AllowedDecisions.Contains(req.Decision.Trim()))
+            return Results.BadRequest(new { error = "decision must be one of: merge, test, reject" });
         if (req.IssueNumber <= 0 || req.PrNumber <= 0)
             return Results.BadRequest(new { error = "issueNumber and prNumber are required (> 0)" });
+        if (string.IsNullOrWhiteSpace(req.Repository))
+            return Results.BadRequest(new { error = "repository is required (owner/repo)" });
+
+        // SECURITY C1 — scope the resume to the caller's ambient tenant. The
+        // engine folds this tenant id into the bookmark name, so a caller can
+        // only ever resolve a gate in its OWN tenant. (Ambient null = self-hosted
+        // single-user scope, where there is no cross-tenant surface.)
+        var tenantId = tenantContext.TenantId?.ToString();
+
+        // SECURITY I2 — the approver is the authenticated caller, derived
+        // server-side. A client-supplied approver is never honoured so the audit
+        // trail can't be forged.
+        var approver = ResolveApprover(principal);
 
         try
         {
             var result = await elsa.ResumeMergeApprovalAsync(
-                req.IssueNumber, req.PrNumber, req.Decision, req.Feedback, req.Approver);
+                req.IssueNumber, req.PrNumber, tenantId, req.Repository,
+                req.Decision, req.Feedback, approver);
 
             if (result.GateNotFound)
             {
@@ -66,8 +110,8 @@ public static class AdlEndpoints
             }
 
             logger.LogInformation(
-                "Drove merge-approval gate for issue #{Issue} PR #{Pr} with decision {Decision}",
-                req.IssueNumber, req.PrNumber, LogSanitizer.Clean(req.Decision));
+                "Drove merge-approval gate for issue #{Issue} PR #{Pr} with decision {Decision} (approver {Approver})",
+                req.IssueNumber, req.PrNumber, LogSanitizer.Clean(req.Decision), LogSanitizer.Clean(approver));
 
             return Results.Ok(new
             {
@@ -86,4 +130,17 @@ public static class AdlEndpoints
                 statusCode: StatusCodes.Status502BadGateway);
         }
     }
+
+    /// <summary>
+    /// Derive the approver identity from the authenticated principal (I2):
+    /// email → display name → subject id. Falls back to <c>"unknown"</c> only if
+    /// the principal carries none of these (it should never, behind auth).
+    /// </summary>
+    internal static string ResolveApprover(ClaimsPrincipal principal)
+        => principal.FindFirst(JwtRegisteredClaimNames.Email)?.Value
+           ?? principal.FindFirst(ClaimTypes.Email)?.Value
+           ?? principal.FindFirst("name")?.Value
+           ?? principal.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
+           ?? principal.FindFirst(ClaimTypes.NameIdentifier)?.Value
+           ?? "unknown";
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/AdlEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/AdlEndpoints.cs
@@ -1,0 +1,89 @@
+using Microsoft.AspNetCore.Mvc;
+using Tamma.Api.Services;
+using Tamma.Core.Logging;
+
+namespace Tamma.Api.Endpoints;
+
+/// <summary>
+/// IMPORTANT-2 — RBAC-gated public surface that lets a human DRIVE the
+/// <c>merge-approval</c> gate of the autonomous loop.
+///
+/// <para>The gate (<c>WaitForMergeApprovalActivity</c>) suspends the
+/// <c>single-issue-cycle</c> on the named bookmark
+/// <c>adl-merge-approval-{issue}-{pr}</c> and reads
+/// <c>{decision, feedback, approver}</c> from the workflow input on resume.
+/// Without a producer, wiring the gate into the cycle would suspend the merge
+/// step forever. This endpoint is that producer: it forwards to the engine's
+/// in-process resume seam (<c>POST /elsa/api/adl/merge-approval/resume</c>),
+/// which looks the bookmark up and runs the owning instance with the decision
+/// payload injected.</para>
+///
+/// <para><b>Authorization</b>: <c>WorkflowsManage</c> (permission
+/// <c>workflows:manage</c> → tenant owner/admin). Member-role SaaS callers hit
+/// 403 at the policy — driving a merge decision is a workflow-management
+/// action, mirroring the engine command/issue-mutation routes.</para>
+/// </summary>
+public static class AdlEndpoints
+{
+    /// <summary>Accepted decisions (case-insensitive). Anything else routes to
+    /// the gate's <c>Invalid</c> outcome — but we reject obviously empty input
+    /// up front so the caller gets a 400 instead of silently escalating.</summary>
+    public sealed record MergeApprovalDecisionRequest(
+        int IssueNumber,
+        int PrNumber,
+        string Decision,
+        string? Feedback,
+        string? Approver);
+
+    /// <summary>
+    /// Resume the merge-approval gate for an issue/PR with a human decision.
+    /// Route: <c>POST /api/adl/merge-approval/resume</c>.
+    /// </summary>
+    public static async Task<IResult> ResumeMergeApproval(
+        [FromBody] MergeApprovalDecisionRequest req,
+        [FromServices] IElsaWorkflowService elsa,
+        [FromServices] ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger("Tamma.Api.AdlEndpoints");
+
+        if (string.IsNullOrWhiteSpace(req.Decision))
+            return Results.BadRequest(new { error = "decision is required (merge|test|reject)" });
+        if (req.IssueNumber <= 0 || req.PrNumber <= 0)
+            return Results.BadRequest(new { error = "issueNumber and prNumber are required (> 0)" });
+
+        try
+        {
+            var result = await elsa.ResumeMergeApprovalAsync(
+                req.IssueNumber, req.PrNumber, req.Decision, req.Feedback, req.Approver);
+
+            if (result.GateNotFound)
+            {
+                return Results.NotFound(new
+                {
+                    error = "gate_not_waiting",
+                    detail = "No merge-approval gate is currently suspended for this issue/PR.",
+                });
+            }
+
+            logger.LogInformation(
+                "Drove merge-approval gate for issue #{Issue} PR #{Pr} with decision {Decision}",
+                req.IssueNumber, req.PrNumber, LogSanitizer.Clean(req.Decision));
+
+            return Results.Ok(new
+            {
+                resumed = result.Resumed,
+                workflowInstanceId = result.WorkflowInstanceId,
+                decision = req.Decision,
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Failed to resume merge-approval gate for issue #{Issue} PR #{Pr}",
+                req.IssueNumber, req.PrNumber);
+            return Results.Problem(
+                detail: "Failed to resume the merge-approval gate.",
+                statusCode: StatusCodes.Status502BadGateway);
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -2078,6 +2078,14 @@ workflows.MapPost("/instances/{id}/cancel", WorkflowEndpoints.CancelInstance).Re
 workflows.MapDelete("/instances/{id}", WorkflowEndpoints.DeleteInstance).RequireAuthorization("WorkflowsDelete");
 workflows.MapGet("/instances/{id}/events", WorkflowEndpoints.GetInstanceEvents);
 
+// ── ADL human gates (IMPORTANT-2) ──
+// Lets a human DRIVE the merge-approval gate of the autonomous loop. Resumes
+// the adl-merge-approval-{issue}-{pr} bookmark via the engine, injecting the
+// {decision,feedback,approver} payload. WorkflowsManage = tenant owner/admin
+// (members 403) — driving a merge decision is a workflow-management action.
+var adl = app.MapGroup("/api/adl").RequireAuthorization("WorkflowsManage");
+adl.MapPost("/merge-approval/resume", AdlEndpoints.ResumeMergeApproval);
+
 // ── GitHub App (no auth, webhook signature verification) ──
 // Audit finding 017 — webhook gets the GitHubWebhook policy (300/min). The
 // install callback shares OAuthStart's 60/min cap; legitimate installs are

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -2079,10 +2079,12 @@ workflows.MapDelete("/instances/{id}", WorkflowEndpoints.DeleteInstance).Require
 workflows.MapGet("/instances/{id}/events", WorkflowEndpoints.GetInstanceEvents);
 
 // ── ADL human gates (IMPORTANT-2) ──
-// Lets a human DRIVE the merge-approval gate of the autonomous loop. Resumes
-// the adl-merge-approval-{issue}-{pr} bookmark via the engine, injecting the
-// {decision,feedback,approver} payload. WorkflowsManage = tenant owner/admin
-// (members 403) — driving a merge decision is a workflow-management action.
+// Lets a human DRIVE the merge-approval gate of the autonomous loop. Resumes the
+// tenant+repo-scoped adl-merge-approval-{tenant}-{repo}-{issue}-{pr} bookmark via
+// the engine, injecting the {decision,feedback,approver} payload (approver is
+// derived server-side from the caller — I2). WorkflowsManage = tenant owner/admin
+// (members 403). SECURITY C1 — the handler threads the caller's ambient tenant id
+// so a caller can only resume a gate in its OWN tenant (cross-tenant → 404).
 var adl = app.MapGroup("/api/adl").RequireAuthorization("WorkflowsManage");
 adl.MapPost("/merge-approval/resume", AdlEndpoints.ResumeMergeApproval);
 

--- a/apps/tamma-elsa/src/Tamma.Api/Services/ElsaWorkflowService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/ElsaWorkflowService.cs
@@ -259,15 +259,16 @@ public partial class ElsaWorkflowService : IElsaWorkflowService
 
     /// <summary>
     /// IMPORTANT-2 — forward a merge-approval gate resume to the engine's
-    /// in-process resume endpoint, which looks up the
-    /// <c>adl-merge-approval-{issue}-{pr}</c> bookmark and runs the owning
-    /// instance with <c>{decision, feedback, approver}</c> injected as input.
+    /// in-process resume endpoint, which looks up the tenant+repo-scoped
+    /// <c>adl-merge-approval-{tenant}-{repo}-{issue}-{pr}</c> bookmark and runs the
+    /// owning instance with <c>{decision, feedback, approver}</c> injected as input.
     /// A 404 from the engine (no gate waiting) is surfaced as
     /// <see cref="MergeApprovalResumeResult.GateNotFound"/> rather than thrown,
     /// so the controller can map it to a 404 for the caller.
     /// </summary>
     public async Task<MergeApprovalResumeResult> ResumeMergeApprovalAsync(
-        int issueNumber, int prNumber, string decision, string? feedback, string? approver)
+        int issueNumber, int prNumber, string? tenantId, string? repository,
+        string decision, string? feedback, string? approver)
     {
         _logger.LogInformation(
             "Resuming merge-approval gate for issue #{Issue} PR #{Pr} (decision={Decision})",
@@ -279,6 +280,9 @@ public partial class ElsaWorkflowService : IElsaWorkflowService
         {
             issueNumber,
             prNumber,
+            // SECURITY C1/C2 — tenant + repo scope the engine's bookmark lookup.
+            tenantId,
+            repository,
             decision,
             feedback,
             approver,

--- a/apps/tamma-elsa/src/Tamma.Api/Services/ElsaWorkflowService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/ElsaWorkflowService.cs
@@ -257,6 +257,58 @@ public partial class ElsaWorkflowService : IElsaWorkflowService
         }
     }
 
+    /// <summary>
+    /// IMPORTANT-2 — forward a merge-approval gate resume to the engine's
+    /// in-process resume endpoint, which looks up the
+    /// <c>adl-merge-approval-{issue}-{pr}</c> bookmark and runs the owning
+    /// instance with <c>{decision, feedback, approver}</c> injected as input.
+    /// A 404 from the engine (no gate waiting) is surfaced as
+    /// <see cref="MergeApprovalResumeResult.GateNotFound"/> rather than thrown,
+    /// so the controller can map it to a 404 for the caller.
+    /// </summary>
+    public async Task<MergeApprovalResumeResult> ResumeMergeApprovalAsync(
+        int issueNumber, int prNumber, string decision, string? feedback, string? approver)
+    {
+        _logger.LogInformation(
+            "Resuming merge-approval gate for issue #{Issue} PR #{Pr} (decision={Decision})",
+            issueNumber, prNumber, SanitizeForLog(decision));
+
+        await EnsureHealthyAsync();
+
+        var payload = new
+        {
+            issueNumber,
+            prNumber,
+            decision,
+            feedback,
+            approver,
+        };
+
+        var response = await _httpClient.PostAsJsonAsync(
+            "/elsa/api/adl/merge-approval/resume", payload, JsonOptions);
+
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            _logger.LogWarning(
+                "No merge-approval gate waiting for issue #{Issue} PR #{Pr}", issueNumber, prNumber);
+            return new MergeApprovalResumeResult(Resumed: false, GateNotFound: true, WorkflowInstanceId: null);
+        }
+
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<EngineResumeResponse>(JsonOptions);
+        return new MergeApprovalResumeResult(
+            Resumed: result?.Resumed ?? true,
+            GateNotFound: false,
+            WorkflowInstanceId: result?.WorkflowInstanceId);
+    }
+
+    private sealed class EngineResumeResponse
+    {
+        public bool Resumed { get; set; }
+        public string? WorkflowInstanceId { get; set; }
+    }
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,

--- a/apps/tamma-elsa/src/Tamma.Api/Services/IElsaWorkflowService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/IElsaWorkflowService.cs
@@ -25,14 +25,22 @@ public interface IElsaWorkflowService
 
     /// <summary>
     /// IMPORTANT-2 — resume the <c>merge-approval</c> human gate suspended on the
-    /// <c>adl-merge-approval-{issue}-{pr}</c> bookmark, injecting the
+    /// tenant+repo-scoped bookmark
+    /// <c>adl-merge-approval-{tenant}-{repo}-{issue}-{pr}</c>, injecting the
     /// <c>{decision, feedback, approver}</c> payload as workflow input. Forwards
     /// to the engine's in-process resume endpoint (which owns
     /// <c>IBookmarkStore</c>/<c>IWorkflowRuntime</c>). Returns the resolved
     /// workflow instance id on success.
+    ///
+    /// <para>SECURITY C1/C2 — <paramref name="tenantId"/> and
+    /// <paramref name="repository"/> scope the bookmark lookup. The caller
+    /// (<c>AdlEndpoints</c>) supplies the AMBIENT tenant id, so the engine can
+    /// only ever resolve a gate in that tenant; a cross-tenant attempt resolves
+    /// no bookmark (GateNotFound).</para>
     /// </summary>
     Task<MergeApprovalResumeResult> ResumeMergeApprovalAsync(
-        int issueNumber, int prNumber, string decision, string? feedback, string? approver);
+        int issueNumber, int prNumber, string? tenantId, string? repository,
+        string decision, string? feedback, string? approver);
 }
 
 /// <summary>Outcome of a merge-approval gate resume.</summary>

--- a/apps/tamma-elsa/src/Tamma.Api/Services/IElsaWorkflowService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/IElsaWorkflowService.cs
@@ -22,7 +22,24 @@ public interface IElsaWorkflowService
 
     /// <summary>Send a signal to a workflow</summary>
     Task SendSignalAsync(string instanceId, string signalName, object? payload = null);
+
+    /// <summary>
+    /// IMPORTANT-2 — resume the <c>merge-approval</c> human gate suspended on the
+    /// <c>adl-merge-approval-{issue}-{pr}</c> bookmark, injecting the
+    /// <c>{decision, feedback, approver}</c> payload as workflow input. Forwards
+    /// to the engine's in-process resume endpoint (which owns
+    /// <c>IBookmarkStore</c>/<c>IWorkflowRuntime</c>). Returns the resolved
+    /// workflow instance id on success.
+    /// </summary>
+    Task<MergeApprovalResumeResult> ResumeMergeApprovalAsync(
+        int issueNumber, int prNumber, string decision, string? feedback, string? approver);
 }
+
+/// <summary>Outcome of a merge-approval gate resume.</summary>
+public sealed record MergeApprovalResumeResult(
+    bool Resumed,
+    bool GateNotFound,
+    string? WorkflowInstanceId);
 
 /// <summary>
 /// Workflow status information

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Endpoints/MergeApprovalResumeEndpoint.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Endpoints/MergeApprovalResumeEndpoint.cs
@@ -2,6 +2,7 @@ using Elsa.Workflows.Runtime;
 using Elsa.Workflows.Runtime.Filters;
 using Elsa.Workflows.Runtime.Messages;
 using Microsoft.AspNetCore.Mvc;
+using Tamma.Activities.ADL;
 
 namespace Tamma.ElsaServer.Endpoints;
 
@@ -9,11 +10,10 @@ namespace Tamma.ElsaServer.Endpoints;
 /// IMPORTANT-2 — in-process resume seam for the <c>merge-approval</c> human gate.
 ///
 /// <para>The gate (<c>WaitForMergeApprovalActivity</c>) suspends on the named
-/// bookmark <c>adl-merge-approval-{issue}-{pr}</c> and, on resume, reads
-/// <c>{decision, feedback, approver}</c> from the workflow input. Nothing drove
-/// that bookmark before — wiring the gate into <c>single-issue-cycle</c> without a
-/// producer left the merge step suspended forever. This endpoint closes the seam:
-/// it looks the bookmark up by name, then runs the owning instance from that
+/// bookmark <c>adl-merge-approval-{tenant}-{repo}-{issue}-{pr}</c> (SECURITY C2 —
+/// tenant + repo folded in) and, on resume, reads
+/// <c>{decision, feedback, approver}</c> from the workflow input. This endpoint
+/// looks the bookmark up by name, then runs the owning instance from that
 /// bookmark with the decision payload INJECTED as workflow input (the mechanism
 /// Elsa 3.5 documents — <c>IWorkflowClient.RunInstanceAsync</c> with
 /// <c>RunWorkflowInstanceRequest.Input</c>, which lands in
@@ -21,9 +21,25 @@ namespace Tamma.ElsaServer.Endpoints;
 ///
 /// <para>This lives in the engine process because <c>IBookmarkStore</c> /
 /// <c>IWorkflowRuntime</c> are in-process here. <c>Tamma.Api</c> exposes the
-/// RBAC-gated public surface (<c>POST /api/adl/{instanceId}/merge-approval</c>)
-/// and forwards to this engine endpoint — the same API→engine hop every other
-/// engine call uses.</para>
+/// RBAC-gated public surface and forwards to this engine endpoint.</para>
+///
+/// <para><b>SECURITY:</b>
+/// <list type="bullet">
+///   <item><description><b>C1/C2 (tenant scoping)</b> — the bookmark name carries
+///   the tenant id + repository that the (tenant-scoped) <c>Tamma.Api</c> caller
+///   supplies. A caller scoped to tenant A computes a name with tenant A, so it
+///   can NEVER resolve tenant B's gate: a cross-tenant attempt simply 404s
+///   (bookmark not found), it never acts.</description></item>
+///   <item><description><b>C2 (collision refusal)</b> — if more than one
+///   bookmark matches the (now globally-unique) name, we REFUSE with 409 rather
+///   than resume an arbitrary <c>bookmarks[0]</c>.</description></item>
+///   <item><description><b>C3 (engine-service-only)</b> — the route is mapped
+///   with <c>.RequireAuthorization()</c> in <c>Program.cs</c> so only an
+///   authenticated caller (the Tamma.Api→engine hop presenting the Elsa admin
+///   API key) reaches it; anonymous public-internet callers get 401. It is also
+///   excluded from the public nginx <c>/elsa/api/</c> route (internal-hop-only).
+///   </description></item>
+/// </list></para>
 /// </summary>
 public static class MergeApprovalResumeEndpoint
 {
@@ -32,12 +48,18 @@ public static class MergeApprovalResumeEndpoint
         int PrNumber,
         string Decision,
         string? Feedback,
-        string? Approver);
+        string? Approver,
+        // SECURITY C1/C2 — tenant + repository scope the bookmark lookup. Supplied
+        // by the tenant-scoped Tamma.Api caller; folded into the bookmark name so
+        // the lookup can only ever match a gate in the caller's own tenant/repo.
+        string? TenantId,
+        string? Repository);
 
-    /// <summary>Bookmark name the gate registers — must match
-    /// <c>WaitForMergeApprovalActivity.RunAsync</c>.</summary>
-    public static string BookmarkName(int issueNumber, int prNumber)
-        => $"adl-merge-approval-{issueNumber}-{prNumber}";
+    /// <summary>Bookmark name the gate registers — delegates to the SINGLE
+    /// canonical builder shared with <see cref="WaitForMergeApprovalActivity"/> so
+    /// suspend-side and resume-side names match byte-for-byte (SECURITY C2).</summary>
+    public static string BookmarkName(string? tenantId, string? repository, int issueNumber, int prNumber)
+        => WaitForMergeApprovalActivity.BookmarkName(tenantId, repository, issueNumber, prNumber);
 
     public static async Task<IResult> Resume(
         [FromBody] ResumeRequest request,
@@ -51,10 +73,11 @@ public static class MergeApprovalResumeEndpoint
         if (string.IsNullOrWhiteSpace(request.Decision))
             return Results.BadRequest(new { error = "decision is required" });
 
-        var name = BookmarkName(request.IssueNumber, request.PrNumber);
+        // SECURITY C1/C2 — the name carries the caller's tenant + repo. A caller
+        // in tenant A produces a name keyed by tenant A and therefore can only
+        // ever resolve tenant A's gate.
+        var name = BookmarkName(request.TenantId, request.Repository, request.IssueNumber, request.PrNumber);
 
-        // Find the suspended gate bookmark by name. There is at most one live
-        // gate per (issue, pr); if a stale duplicate exists we resume the first.
         var bookmarks = (await bookmarkStore
             .FindManyAsync(new BookmarkFilter { Name = name }, ct)
             .ConfigureAwait(false)).ToList();
@@ -62,13 +85,30 @@ public static class MergeApprovalResumeEndpoint
         if (bookmarks.Count == 0)
         {
             logger.LogWarning(
-                "No suspended merge-approval bookmark {Bookmark} — gate not waiting (already decided, or wrong issue/pr)",
+                "No suspended merge-approval bookmark {Bookmark} — gate not waiting (already decided, wrong issue/pr, or not this tenant/repo)",
                 name);
             return Results.NotFound(new
             {
                 error = "bookmark_not_found",
                 bookmark = name,
                 detail = "No merge-approval gate is currently waiting for this issue/PR.",
+            });
+        }
+
+        // SECURITY C2 — the name is globally unique (tenant + repo + issue + pr),
+        // so >1 match is an integrity violation, not a "pick the first" situation.
+        // REFUSE rather than resume an arbitrary instance.
+        if (bookmarks.Count > 1)
+        {
+            logger.LogError(
+                "Ambiguous merge-approval bookmark {Bookmark}: {Count} live instances — refusing to resume an arbitrary one",
+                name, bookmarks.Count);
+            return Results.Conflict(new
+            {
+                error = "ambiguous_bookmark",
+                bookmark = name,
+                count = bookmarks.Count,
+                detail = "Multiple workflow instances are waiting on this gate; refusing to resume an arbitrary one.",
             });
         }
 

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Endpoints/MergeApprovalResumeEndpoint.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Endpoints/MergeApprovalResumeEndpoint.cs
@@ -1,0 +1,110 @@
+using Elsa.Workflows.Runtime;
+using Elsa.Workflows.Runtime.Filters;
+using Elsa.Workflows.Runtime.Messages;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Tamma.ElsaServer.Endpoints;
+
+/// <summary>
+/// IMPORTANT-2 — in-process resume seam for the <c>merge-approval</c> human gate.
+///
+/// <para>The gate (<c>WaitForMergeApprovalActivity</c>) suspends on the named
+/// bookmark <c>adl-merge-approval-{issue}-{pr}</c> and, on resume, reads
+/// <c>{decision, feedback, approver}</c> from the workflow input. Nothing drove
+/// that bookmark before — wiring the gate into <c>single-issue-cycle</c> without a
+/// producer left the merge step suspended forever. This endpoint closes the seam:
+/// it looks the bookmark up by name, then runs the owning instance from that
+/// bookmark with the decision payload INJECTED as workflow input (the mechanism
+/// Elsa 3.5 documents — <c>IWorkflowClient.RunInstanceAsync</c> with
+/// <c>RunWorkflowInstanceRequest.Input</c>, which lands in
+/// <c>ActivityExecutionContext.WorkflowInput</c> that the gate reads).</para>
+///
+/// <para>This lives in the engine process because <c>IBookmarkStore</c> /
+/// <c>IWorkflowRuntime</c> are in-process here. <c>Tamma.Api</c> exposes the
+/// RBAC-gated public surface (<c>POST /api/adl/{instanceId}/merge-approval</c>)
+/// and forwards to this engine endpoint — the same API→engine hop every other
+/// engine call uses.</para>
+/// </summary>
+public static class MergeApprovalResumeEndpoint
+{
+    public sealed record ResumeRequest(
+        int IssueNumber,
+        int PrNumber,
+        string Decision,
+        string? Feedback,
+        string? Approver);
+
+    /// <summary>Bookmark name the gate registers — must match
+    /// <c>WaitForMergeApprovalActivity.RunAsync</c>.</summary>
+    public static string BookmarkName(int issueNumber, int prNumber)
+        => $"adl-merge-approval-{issueNumber}-{prNumber}";
+
+    public static async Task<IResult> Resume(
+        [FromBody] ResumeRequest request,
+        [FromServices] IBookmarkStore bookmarkStore,
+        [FromServices] IWorkflowRuntime workflowRuntime,
+        [FromServices] ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var logger = loggerFactory.CreateLogger("Tamma.ElsaServer.MergeApprovalResume");
+
+        if (string.IsNullOrWhiteSpace(request.Decision))
+            return Results.BadRequest(new { error = "decision is required" });
+
+        var name = BookmarkName(request.IssueNumber, request.PrNumber);
+
+        // Find the suspended gate bookmark by name. There is at most one live
+        // gate per (issue, pr); if a stale duplicate exists we resume the first.
+        var bookmarks = (await bookmarkStore
+            .FindManyAsync(new BookmarkFilter { Name = name }, ct)
+            .ConfigureAwait(false)).ToList();
+
+        if (bookmarks.Count == 0)
+        {
+            logger.LogWarning(
+                "No suspended merge-approval bookmark {Bookmark} — gate not waiting (already decided, or wrong issue/pr)",
+                name);
+            return Results.NotFound(new
+            {
+                error = "bookmark_not_found",
+                bookmark = name,
+                detail = "No merge-approval gate is currently waiting for this issue/PR.",
+            });
+        }
+
+        var bookmark = bookmarks[0];
+
+        // Inject the decision payload as workflow input — the gate's resume
+        // callback reads context.WorkflowInput["decision"|"feedback"|"approver"].
+        var input = new Dictionary<string, object>
+        {
+            ["decision"] = request.Decision,
+        };
+        if (request.Feedback is not null) input["feedback"] = request.Feedback;
+        if (request.Approver is not null) input["approver"] = request.Approver;
+
+        var client = await workflowRuntime
+            .CreateClientAsync(bookmark.WorkflowInstanceId, ct)
+            .ConfigureAwait(false);
+
+        await client.RunInstanceAsync(
+            new RunWorkflowInstanceRequest
+            {
+                BookmarkId = bookmark.Id,
+                Input = input,
+            },
+            ct).ConfigureAwait(false);
+
+        logger.LogInformation(
+            "Resumed merge-approval gate {Bookmark} (instance {InstanceId}) with decision {Decision}",
+            name, bookmark.WorkflowInstanceId, request.Decision);
+
+        return Results.Ok(new
+        {
+            resumed = true,
+            bookmark = name,
+            workflowInstanceId = bookmark.WorkflowInstanceId,
+            decision = request.Decision,
+        });
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
@@ -365,6 +365,13 @@ app.UseWorkflows();
 app.UseStaticFiles();
 app.MapHealthChecks("/health");
 
+// IMPORTANT-2 — in-process resume seam for the merge-approval human gate.
+// Tamma.Api's RBAC-gated POST /api/adl/{instanceId}/merge-approval forwards
+// here; this endpoint looks up the gate's named bookmark and runs the owning
+// instance with the {decision,feedback,approver} payload injected as input.
+app.MapPost("/elsa/api/adl/merge-approval/resume",
+    Tamma.ElsaServer.Endpoints.MergeApprovalResumeEndpoint.Resume);
+
 app.UseSerilogRequestLogging();
 
 Log.Information("Tamma ELSA Server starting up...");

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
@@ -366,11 +366,23 @@ app.UseStaticFiles();
 app.MapHealthChecks("/health");
 
 // IMPORTANT-2 — in-process resume seam for the merge-approval human gate.
-// Tamma.Api's RBAC-gated POST /api/adl/{instanceId}/merge-approval forwards
-// here; this endpoint looks up the gate's named bookmark and runs the owning
-// instance with the {decision,feedback,approver} payload injected as input.
+// Tamma.Api's tenant-scoped, RBAC-gated POST /api/adl/merge-approval/resume
+// forwards here; this endpoint looks up the gate's tenant+repo-scoped named
+// bookmark and runs the owning instance with the {decision,feedback,approver}
+// payload injected as input.
+//
+// SECURITY C3 — this is an engine control surface (it can drive a real merge).
+// It MUST NOT be drivable unauthenticated from the public internet. We require
+// an authenticated caller: the only legitimate caller is the Tamma.Api→engine
+// hop, which presents the Elsa admin API key (Authorization: ApiKey ...) that
+// UseAdminApiKey() validates into an authenticated principal. Anonymous public
+// callers fail .RequireAuthorization() with 401. The route is ALSO excluded
+// from the public nginx /elsa/api/ block (internal hop only) — defense in depth.
+// The C1/C2 tenant/repo constraints are enforced inside the handler via the
+// bookmark name.
 app.MapPost("/elsa/api/adl/merge-approval/resume",
-    Tamma.ElsaServer.Endpoints.MergeApprovalResumeEndpoint.Resume);
+    Tamma.ElsaServer.Endpoints.MergeApprovalResumeEndpoint.Resume)
+    .RequireAuthorization();
 
 app.UseSerilogRequestLogging();
 

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/MergeApprovalWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/MergeApprovalWorkflow.cs
@@ -5,12 +5,45 @@ using Elsa.Workflows.Activities.Flowchart.Activities;
 using Elsa.Workflows.Management.Activities.SetOutput;
 using Elsa.Workflows.Memory;
 using Elsa.Workflows.Models;
+using Elsa.Workflows.Runtime.Activities;
 using Tamma.Activities.ADL;
 using FlowEndpoint = Elsa.Workflows.Activities.Flowchart.Models.Endpoint;
 using FlowConnection = Elsa.Workflows.Activities.Flowchart.Models.Connection;
+using static Tamma.ElsaServer.Workflows.ActivityDisplayTextExtensions;
 
 namespace Tamma.ElsaServer.Workflows;
 
+/// <summary>
+/// Merge Approval — the human <b>APPROVAL_GATE</b> of the 14-step loop
+/// (<c>docs/architecture.md</c> line 840, between CI_CHECK and MERGE). A
+/// completed PR suspends on a bookmark until a human decides
+/// <i>merge / test / reject</i>; the gate then <b>acts</b> on that decision
+/// (dispatching the real <c>merge</c> / <c>testing</c> workflows or rejecting),
+/// rather than emitting a bare decision string.
+///
+/// <para>Build-out (FR-19 / FR-34 / Story 4-6): the activity's 3-way (now 4-way)
+/// outcome is branched with typed <see cref="FlowEndpoint"/> edges — every
+/// outcome routes to a distinct, explicit path and no edge falls through to
+/// success. An unknown / empty decision is an explicit <c>Invalid</c> outcome
+/// (NOT a silent "reject") that escalates. Each decision edge emits a
+/// <c>MERGE_APPROVAL.*</c> / <c>MERGE.*</c> DCB event via
+/// <see cref="EmitMergeApprovalEventActivity"/> through the durable engine event
+/// drain (the gate activity itself, a <c>TammaOutcomeActivity</c>, also auto-emits
+/// <c>APPROVAL.GATE.STARTED/.FAILED</c>).</para>
+///
+/// Flow:
+///   ReadInputs → WaitMergeApproval (bookmark)
+///     ├─ Merge   → EmitMergeRequested → DispatchMerge → MergeOutputs → Finish
+///     ├─ Test    → EmitTestRequested  → DispatchTesting (ci-with-debug-retry) → (loop back to WaitMergeApproval)
+///     ├─ Reject  → EmitRejected → NotifyRejected → RejectOutputs → Finish
+///     └─ Invalid → EmitEscalated → NotifyEscalated → EscalateOutputs → Finish
+///
+/// <para>Deferred (reported for confirmation): breaking-change detection +
+/// mandatory-approval enforcement (FR-34), mode-aware approver policy (FR-32),
+/// a finite timeout/reminder arm, and the resume HTTP endpoint
+/// (<c>POST /api/adl/{instanceId}/merge-approval</c>) with RBAC. The bookmark
+/// resume contract (<c>{decision, feedback, approver}</c>) is honoured.</para>
+/// </summary>
 public class MergeApprovalWorkflow : WorkflowBase
 {
     protected override void Build(IWorkflowBuilder builder)
@@ -18,41 +51,280 @@ public class MergeApprovalWorkflow : WorkflowBase
         builder.Name = "Merge Approval";
         builder.DefinitionId = "merge-approval";
         builder.Version = WorkflowVersions.ComputedVersion;
-        builder.Description = "Wait for human merge/test/reject decision";
+        builder.Description = "Human merge/test/reject gate — branches on the decision, acts on it, and audits every edge";
+
+        // ================================================================
+        // Variables
+        // ================================================================
+        var repository = builder.WithVariable<string>("Repository", "");
+        var branchName = builder.WithVariable<string>("BranchName", "");
+        var issueNumberVar = builder.WithVariable<int>("IssueNumber", 0);
+        var prNumberVar = builder.WithVariable<int>("PrNumber", 0);
+        var prUrlVar = builder.WithVariable<string>("PrUrl", "");
+        var tenantIdVar = builder.WithVariable<string>("TenantId", "");
 
         var decisionVar = builder.WithVariable<string>("Decision", "");
         var feedbackVar = builder.WithVariable<string>("Feedback", "");
+        var approverVar = builder.WithVariable<string>("Approver", "");
 
+        // ================================================================
+        // 1. Read inputs
+        // ================================================================
+        var readInputs = new SetVariable
+        {
+            Id = "ReadInputs", Name = "Read Inputs",
+            Variable = repository,
+            Value = new Input<object?>(ctx =>
+            {
+                var repo = ctx.GetInput<string>("repository") ?? "";
+                branchName.Set(ctx, ctx.GetInput<string>("branchName") ?? "");
+                issueNumberVar.Set(ctx, ctx.GetInput<int>("issueNumber"));
+                prNumberVar.Set(ctx, ctx.GetInput<int>("prNumber"));
+                prUrlVar.Set(ctx, ctx.GetInput<string>("prUrl") ?? "");
+                tenantIdVar.Set(ctx, ctx.GetInput<string>("tenantId") ?? "");
+                return (object)repo;
+            })
+        };
+        readInputs.SetDisplayText("Read Inputs");
+
+        // ================================================================
+        // 2. Wait for the human decision (bookmark; 4 typed outcomes)
+        // ================================================================
         var waitMerge = new WaitForMergeApprovalActivity
         {
             Id = "WaitMergeApproval", Name = "Wait Merge Approval",
-            IssueNumber = new Input<int>(ctx => ctx.GetInput<int>("issueNumber")),
-            PrNumber = new Input<int>(ctx => ctx.GetInput<int>("prNumber")),
-            PrUrl = new Input<string?>(ctx => ctx.GetInput<string>("prUrl")),
+            IssueNumber = new Input<int>(ctx => issueNumberVar.Get(ctx)),
+            PrNumber = new Input<int>(ctx => prNumberVar.Get(ctx)),
+            PrUrl = new Input<string?>(ctx => prUrlVar.Get(ctx)),
             Decision = new Output<string?>(decisionVar),
-            Feedback = new Output<string?>(feedbackVar)
+            Feedback = new Output<string?>(feedbackVar),
+            Approver = new Output<string?>(approverVar),
         };
         waitMerge.SetDisplayText("Wait Merge Approval");
 
-        var outputDecision = new SetOutput { Id = "OutputDecision", Name = "Output Decision", OutputName = new("decision"), OutputValue = new(ctx => (object)(decisionVar.Get(ctx) ?? "reject")) };
-        outputDecision.SetDisplayText("Output Decision");
-        var outputFeedback = new SetOutput { Id = "OutputFeedback", Name = "Output Feedback", OutputName = new("feedback"), OutputValue = new(ctx => (object)(feedbackVar.Get(ctx) ?? "")) };
-        outputFeedback.SetDisplayText("Output Feedback");
+        // ================================================================
+        // 3a. Merge path — emit MERGE.REQUESTED → dispatch the real merge workflow
+        // ================================================================
+        var emitMergeRequested = EmitGateEvent(
+            "EmitMergeRequested", "Emit MERGE.REQUESTED",
+            MergeApprovalEvents.MergeRequested,
+            issueNumberVar, prNumberVar, tenantIdVar, decisionVar, approverVar, feedbackVar);
 
+        var dispatchMerge = new DispatchWorkflow
+        {
+            Id = "DispatchMerge", Name = "Dispatch Merge",
+            WorkflowDefinitionId = new("merge"),
+            Input = new(ctx => new Dictionary<string, object>
+            {
+                ["repository"] = repository.Get(ctx),
+                ["prNumber"] = prNumberVar.Get(ctx),
+                ["branchName"] = branchName.Get(ctx),
+                ["issueNumber"] = issueNumberVar.Get(ctx),
+            }),
+            WaitForCompletion = new(true),
+        };
+        dispatchMerge.SetDisplayText("Dispatch Merge");
+
+        var mergeOutputs = OutputsSequence(
+            "MergeOutputs", "Merge Outputs", "merge", decisionVar, feedbackVar, approverVar);
+
+        // ================================================================
+        // 3b. Test path — emit TEST_REQUESTED → dispatch testing → loop back to the gate
+        // ================================================================
+        var emitTestRequested = EmitGateEvent(
+            "EmitTestRequested", "Emit MERGE_APPROVAL.TEST_REQUESTED",
+            MergeApprovalEvents.TestRequested,
+            issueNumberVar, prNumberVar, tenantIdVar, decisionVar, approverVar, feedbackVar);
+
+        // The platform has no standalone "testing" definition; the loop's
+        // test/CI sub-workflow is "ci-with-debug-retry" (the build-out spec lists
+        // it as the alternative). Re-run it, then loop back to the gate.
+        var dispatchTesting = new DispatchWorkflow
+        {
+            Id = "DispatchTesting", Name = "Dispatch Testing",
+            WorkflowDefinitionId = new("ci-with-debug-retry"),
+            Input = new(ctx => new Dictionary<string, object>
+            {
+                ["repository"] = repository.Get(ctx),
+                ["branchName"] = branchName.Get(ctx),
+                ["prNumber"] = prNumberVar.Get(ctx),
+                ["issueNumber"] = issueNumberVar.Get(ctx),
+                ["tenantId"] = tenantIdVar.Get(ctx),
+            }),
+            WaitForCompletion = new(true), // need the test result before re-deciding
+        };
+        dispatchTesting.SetDisplayText("Dispatch Testing");
+
+        // ================================================================
+        // 3c. Reject path — emit REJECTED → label/comment the PR → terminal
+        // ================================================================
+        var emitRejected = EmitGateEvent(
+            "EmitRejected", "Emit MERGE_APPROVAL.DECISION.REJECTED",
+            MergeApprovalEvents.DecisionRejected,
+            issueNumberVar, prNumberVar, tenantIdVar, decisionVar, approverVar, feedbackVar);
+
+        var notifyRejected = NotifyIssue(
+            "NotifyRejected", repository, issueNumberVar,
+            "🚫 PR rejected at the merge-approval gate.",
+            addLabels: new[] { "tamma-rejected" },
+            removeLabels: new[] { "tamma-processing" });
+
+        var rejectOutputs = OutputsSequence(
+            "RejectOutputs", "Reject Outputs", "reject", decisionVar, feedbackVar, approverVar);
+
+        // ================================================================
+        // 3d. Invalid path — emit ESCALATED → notify owners → terminal (loud)
+        //     Unknown / empty decision NEVER silently rejects a good PR.
+        // ================================================================
+        var emitEscalated = EmitGateEvent(
+            "EmitEscalated", "Emit MERGE_APPROVAL.ESCALATED",
+            MergeApprovalEvents.Escalated,
+            issueNumberVar, prNumberVar, tenantIdVar, decisionVar, approverVar, feedbackVar);
+
+        var notifyEscalated = NotifyIssue(
+            "NotifyEscalated", repository, issueNumberVar,
+            "⚠️ Merge-approval gate received an invalid decision — needs human attention.",
+            addLabels: new[] { "tamma-needs-human" });
+
+        var escalateOutputs = OutputsSequence(
+            "EscalateOutputs", "Escalate Outputs", "escalated", decisionVar, feedbackVar, approverVar);
+
+        var finish = new Finish { Id = "Finish", Name = "Complete" };
+        finish.SetDisplayText("Complete");
+
+        // ================================================================
+        // Flowchart — typed-outcome branching, no dangling edge, no fall-through
+        // ================================================================
         builder.Root = new Flowchart
         {
             Id = "MergeApprovalFlowchart",
             Name = "Merge Approval Flowchart",
-            Start = waitMerge,
-            Activities = { waitMerge, outputDecision, outputFeedback },
+            Start = readInputs,
+            Activities =
+            {
+                readInputs, waitMerge,
+                emitMergeRequested, dispatchMerge, mergeOutputs,
+                emitTestRequested, dispatchTesting,
+                emitRejected, notifyRejected, rejectOutputs,
+                emitEscalated, notifyEscalated, escalateOutputs,
+                finish,
+            },
             Connections =
             {
-                Connect(waitMerge, outputDecision),
-                Connect(outputDecision, outputFeedback)
+                Connect(readInputs, waitMerge),
+
+                // Merge → emit → dispatch merge → success outputs → finish
+                ConnectOutcome(waitMerge, "Merge", emitMergeRequested),
+                Connect(emitMergeRequested, dispatchMerge),
+                Connect(dispatchMerge, mergeOutputs),
+                Connect(mergeOutputs, finish),
+
+                // Test → emit → dispatch testing → LOOP BACK to the gate for a re-decision
+                ConnectOutcome(waitMerge, "Test", emitTestRequested),
+                Connect(emitTestRequested, dispatchTesting),
+                Connect(dispatchTesting, waitMerge),
+
+                // Reject → emit → label/comment → reject outputs → finish (NOT success)
+                ConnectOutcome(waitMerge, "Reject", emitRejected),
+                Connect(emitRejected, notifyRejected),
+                Connect(notifyRejected, rejectOutputs),
+                Connect(rejectOutputs, finish),
+
+                // Invalid → emit ESCALATED → notify owners → escalate outputs → finish
+                // (explicit failure terminal — no silent reject, no fall-through to success)
+                ConnectOutcome(waitMerge, "Invalid", emitEscalated),
+                Connect(emitEscalated, notifyEscalated),
+                Connect(notifyEscalated, escalateOutputs),
+                Connect(escalateOutputs, finish),
             }
         };
     }
 
+    /// <summary>
+    /// A gate event-emit node carrying the issue/pr/tenant + decision context.
+    /// </summary>
+    private static EmitMergeApprovalEventActivity EmitGateEvent(
+        string id, string label, string eventType,
+        Variable<int> issueNumber, Variable<int> prNumber, Variable<string> tenantId,
+        Variable<string> decision, Variable<string> approver, Variable<string> feedback)
+    {
+        var emit = new EmitMergeApprovalEventActivity
+        {
+            Id = id, Name = label,
+            EventType = new Input<string>(_ => eventType),
+            IssueNumber = new Input<int>(ctx => issueNumber.Get(ctx)),
+            PrNumber = new Input<int>(ctx => prNumber.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
+            Decision = new Input<string?>(ctx => decision.Get(ctx)),
+            Approver = new Input<string?>(ctx => approver.Get(ctx)),
+            Feedback = new Input<string?>(ctx => feedback.Get(ctx)),
+        };
+        emit.SetDisplayText(label);
+        return emit;
+    }
+
+    /// <summary>
+    /// Terminal output sequence: surfaces <c>decision</c> / <c>feedback</c> /
+    /// <c>approver</c> plus an explicit <c>outcome</c> token so the parent (and
+    /// the cycle) can read the gate result without re-deriving it.
+    /// </summary>
+    private static Sequence OutputsSequence(
+        string id, string label, string outcome,
+        Variable<string> decision, Variable<string> feedback, Variable<string> approver)
+    {
+        var seq = new Sequence
+        {
+            Id = id, Name = label,
+            Activities =
+            {
+                WithLabel(new SetOutput { Id = $"{id}_Outcome", OutputName = new("outcome"), OutputValue = new(_ => (object)outcome) }, "Output outcome"),
+                WithLabel(new SetOutput { Id = $"{id}_Decision", OutputName = new("decision"), OutputValue = new(ctx => (object)(decision.Get(ctx) ?? "")) }, "Output decision"),
+                WithLabel(new SetOutput { Id = $"{id}_Feedback", OutputName = new("feedback"), OutputValue = new(ctx => (object)(feedback.Get(ctx) ?? "")) }, "Output feedback"),
+                WithLabel(new SetOutput { Id = $"{id}_Approver", OutputName = new("approver"), OutputValue = new(ctx => (object)(approver.Get(ctx) ?? "")) }, "Output approver"),
+            }
+        };
+        seq.SetDisplayText(label);
+        return seq;
+    }
+
+    /// <summary>
+    /// Fire-and-forget dispatch to the update-issue-status sub-workflow — same
+    /// helper shape the cycle uses to label / comment an issue.
+    /// </summary>
+    private static DispatchWorkflow NotifyIssue(
+        string id,
+        Variable<string> repository,
+        Variable<int> issueNumber,
+        string message,
+        string[]? addLabels = null,
+        string[]? removeLabels = null)
+    {
+        var dispatch = new DispatchWorkflow
+        {
+            Id = id,
+            Name = $"Notify: {message[..Math.Min(message.Length, 30)]}",
+            WorkflowDefinitionId = new("update-issue-status"),
+            Input = new(ctx =>
+            {
+                var input = new Dictionary<string, object>
+                {
+                    ["repository"] = repository.Get(ctx),
+                    ["issueNumber"] = issueNumber.Get(ctx),
+                    ["message"] = message,
+                };
+                if (addLabels != null) input["addLabels"] = addLabels;
+                if (removeLabels != null) input["removeLabels"] = removeLabels;
+                return input;
+            }),
+            WaitForCompletion = new(false), // fire and forget
+        };
+        dispatch.SetDisplayText($"Notify: {message[..Math.Min(message.Length, 30)]}");
+        return dispatch;
+    }
+
     private static FlowConnection Connect(IActivity source, IActivity target)
         => new(new FlowEndpoint(source), new FlowEndpoint(target));
+
+    private static FlowConnection ConnectOutcome(IActivity source, string outcome, IActivity target)
+        => new(new FlowEndpoint(source, outcome), new FlowEndpoint(target));
 }

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/MergeApprovalWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/MergeApprovalWorkflow.cs
@@ -33,10 +33,17 @@ namespace Tamma.ElsaServer.Workflows;
 ///
 /// Flow:
 ///   ReadInputs → WaitMergeApproval (bookmark)
-///     ├─ Merge   → EmitMergeRequested → DispatchMerge → MergeOutputs → Finish
-///     ├─ Test    → EmitTestRequested  → DispatchTesting (ci-with-debug-retry) → (loop back to WaitMergeApproval)
-///     ├─ Reject  → EmitRejected → NotifyRejected → RejectOutputs → Finish
-///     └─ Invalid → EmitEscalated → NotifyEscalated → EscalateOutputs → Finish
+///     ├─ Merge   → EmitMergeRequested → DispatchMerge → (read `success`)
+///     │             ├─ success → EmitMerged → MergeOutputs (outcome="merge") → Finish
+///     │             └─ failure → EmitMergeFailed → [escalate terminal] (outcome="escalated")
+///     ├─ Test    → EmitTestDecision → increment → cap check (>=3)
+///     │             ├─ under cap → EmitTestRequested → DispatchTesting (ci-with-debug-retry) → loop back to gate
+///     │             └─ over cap  → [escalate terminal] (outcome="escalated")
+///     ├─ Reject  → EmitRejected → NotifyRejected → RejectOutputs (outcome="reject") → Finish
+///     └─ Invalid → EmitInvalid → [escalate terminal] (outcome="escalated")
+///
+///   [escalate terminal] = EmitEscalated → NotifyEscalated → EscalateOutputs → Finish
+///   (shared by Invalid, a failed merge, and an exceeded test-loop cap)
 ///
 /// <para>Deferred (reported for confirmation): breaking-change detection +
 /// mandatory-approval enforcement (FR-34), mode-aware approver policy (FR-32),
@@ -62,10 +69,23 @@ public class MergeApprovalWorkflow : WorkflowBase
         var prNumberVar = builder.WithVariable<int>("PrNumber", 0);
         var prUrlVar = builder.WithVariable<string>("PrUrl", "");
         var tenantIdVar = builder.WithVariable<string>("TenantId", "");
+        var breakingChangeVar = builder.WithVariable<bool>("BreakingChange", false);
 
         var decisionVar = builder.WithVariable<string>("Decision", "");
         var feedbackVar = builder.WithVariable<string>("Feedback", "");
         var approverVar = builder.WithVariable<string>("Approver", "");
+
+        // Result of the dispatched merge sub-workflow (CRITICAL-2) + the test loop
+        // iteration counter (CRITICAL-3). subResult captures any DispatchWorkflow
+        // outputs; mergeSuccessVar is the `success` flag the merge workflow emits.
+        var subResult = builder.WithVariable<IDictionary<string, object>?>();
+        var mergeSuccessVar = builder.WithVariable<bool>("MergeSuccess", false);
+        var testIterationCountVar = builder.WithVariable<int>("TestIterationCount", 0);
+
+        // Max test re-runs before escalating — mirrors PlanMaxRevisions /
+        // TaskMaxRevisions (>=3) in SingleIssueCycleWorkflow so an unbounded
+        // test → gate → test loop can never spin forever.
+        const int MaxTestIterations = 3;
 
         // ================================================================
         // 1. Read inputs
@@ -82,6 +102,7 @@ public class MergeApprovalWorkflow : WorkflowBase
                 prNumberVar.Set(ctx, ctx.GetInput<int>("prNumber"));
                 prUrlVar.Set(ctx, ctx.GetInput<string>("prUrl") ?? "");
                 tenantIdVar.Set(ctx, ctx.GetInput<string>("tenantId") ?? "");
+                breakingChangeVar.Set(ctx, ctx.GetInput<bool>("breakingChange"));
                 return (object)repo;
             })
         };
@@ -96,6 +117,7 @@ public class MergeApprovalWorkflow : WorkflowBase
             IssueNumber = new Input<int>(ctx => issueNumberVar.Get(ctx)),
             PrNumber = new Input<int>(ctx => prNumberVar.Get(ctx)),
             PrUrl = new Input<string?>(ctx => prUrlVar.Get(ctx)),
+            BreakingChange = new Input<bool>(ctx => breakingChangeVar.Get(ctx)),
             Decision = new Output<string?>(decisionVar),
             Feedback = new Output<string?>(feedbackVar),
             Approver = new Output<string?>(approverVar),
@@ -122,19 +144,90 @@ public class MergeApprovalWorkflow : WorkflowBase
                 ["issueNumber"] = issueNumberVar.Get(ctx),
             }),
             WaitForCompletion = new(true),
+            Result = new(subResult), // CRITICAL-2 — read the merge `success` output
         };
         dispatchMerge.SetDisplayText("Dispatch Merge");
+
+        // CRITICAL-2 — a swallowed merge failure used to route to the merge/success
+        // terminal anyway (the cycle then hung on a `pr-merged` webhook that never
+        // fires). Read the dispatched merge workflow's `success` output and branch:
+        // success → MergeOutputs (outcome="merge"); failure → the escalate terminal
+        // (loud, error-status MERGE.FAILED + ESCALATED events) with outcome="escalated".
+        var extractMergeSuccess = Assign(mergeSuccessVar, ctx =>
+        {
+            var result = subResult.Get(ctx);
+            if (result != null && result.TryGetValue("success", out var s))
+            {
+                return (object)(s switch
+                {
+                    bool b => b,
+                    string str => bool.TryParse(str, out var r) && r,
+                    _ => false,
+                });
+            }
+            // No readable success flag → treat as a failed merge (never a silent
+            // success). The cycle's CRITICAL-1 switch routes escalated → reportError.
+            return (object)false;
+        }, "ExtractMergeSuccess", "Extract Merge Success");
+
+        var mergeSucceededCheck = new FlowDecision(ctx => mergeSuccessVar.Get(ctx))
+        {
+            Id = "MergeSucceeded",
+            Name = "Merge Succeeded?",
+        };
+        mergeSucceededCheck.SetDisplayText("Merge Succeeded?");
+
+        var emitMergeFailed = EmitGateEvent(
+            "EmitMergeFailed", "Emit MERGE.FAILED",
+            MergeApprovalEvents.MergeFailed,
+            issueNumberVar, prNumberVar, tenantIdVar, decisionVar, approverVar, feedbackVar);
+
+        // MINOR-1 — emit the DECISION.MERGED audit event on the successful-merge
+        // edge (the constant existed but was never emitted).
+        var emitMerged = EmitGateEvent(
+            "EmitMerged", "Emit MERGE_APPROVAL.DECISION.MERGED",
+            MergeApprovalEvents.DecisionMerged,
+            issueNumberVar, prNumberVar, tenantIdVar, decisionVar, approverVar, feedbackVar);
 
         var mergeOutputs = OutputsSequence(
             "MergeOutputs", "Merge Outputs", "merge", decisionVar, feedbackVar, approverVar);
 
         // ================================================================
-        // 3b. Test path — emit TEST_REQUESTED → dispatch testing → loop back to the gate
+        // 3b. Test path — emit DECISION.TEST → cap check → TEST_REQUESTED →
+        //     dispatch testing → loop back to the gate (bounded, CRITICAL-3)
         // ================================================================
+        // MINOR-1 — emit the DECISION.TEST audit event on the test edge (the
+        // constant existed but was never emitted). TEST_REQUESTED stays the
+        // dispatch-time event below.
+        var emitTestDecision = EmitGateEvent(
+            "EmitTestDecision", "Emit MERGE_APPROVAL.DECISION.TEST",
+            MergeApprovalEvents.DecisionTest,
+            issueNumberVar, prNumberVar, tenantIdVar, decisionVar, approverVar, feedbackVar);
+
         var emitTestRequested = EmitGateEvent(
             "EmitTestRequested", "Emit MERGE_APPROVAL.TEST_REQUESTED",
             MergeApprovalEvents.TestRequested,
             issueNumberVar, prNumberVar, tenantIdVar, decisionVar, approverVar, feedbackVar);
+
+        // CRITICAL-3 — bound the test → gate → test loop. Increment a counter on
+        // every Test decision and cap it (mirrors PlanMaxRevisions / TaskMaxRevisions
+        // >=3 in SingleIssueCycleWorkflow). Over the cap → escalate (loud) instead of
+        // re-running CI forever.
+        var incrementTestIteration = new SetVariable
+        {
+            Id = "IncrementTestIteration", Name = "Increment Test Iteration",
+            Variable = testIterationCountVar,
+            Value = new Input<object?>(ctx => (object)(testIterationCountVar.Get(ctx) + 1)),
+        };
+        incrementTestIteration.SetDisplayText("Increment Test Iteration");
+
+        var testMaxIterationsCheck = new FlowDecision(
+            ctx => testIterationCountVar.Get(ctx) >= MaxTestIterations)
+        {
+            Id = "TestMaxIterations",
+            Name = "Test Max Iterations?",
+        };
+        testMaxIterationsCheck.SetDisplayText("Test Max Iterations?");
 
         // The platform has no standalone "testing" definition; the loop's
         // test/CI sub-workflow is "ci-with-debug-retry" (the build-out spec lists
@@ -173,9 +266,17 @@ public class MergeApprovalWorkflow : WorkflowBase
             "RejectOutputs", "Reject Outputs", "reject", decisionVar, feedbackVar, approverVar);
 
         // ================================================================
-        // 3d. Invalid path — emit ESCALATED → notify owners → terminal (loud)
-        //     Unknown / empty decision NEVER silently rejects a good PR.
+        // 3d. Invalid path — emit DECISION.INVALID → ESCALATED → notify owners →
+        //     terminal (loud). Unknown / empty decision NEVER silently rejects a
+        //     good PR — and it ESCALATES (it does NOT loop back to the gate).
         // ================================================================
+        // MINOR-1 — emit the DECISION.INVALID audit event on the invalid edge
+        // (the constant existed but was never emitted) before escalating.
+        var emitInvalid = EmitGateEvent(
+            "EmitInvalid", "Emit MERGE_APPROVAL.DECISION.INVALID",
+            MergeApprovalEvents.DecisionInvalid,
+            issueNumberVar, prNumberVar, tenantIdVar, decisionVar, approverVar, feedbackVar);
+
         var emitEscalated = EmitGateEvent(
             "EmitEscalated", "Emit MERGE_APPROVAL.ESCALATED",
             MergeApprovalEvents.Escalated,
@@ -203,36 +304,58 @@ public class MergeApprovalWorkflow : WorkflowBase
             Activities =
             {
                 readInputs, waitMerge,
-                emitMergeRequested, dispatchMerge, mergeOutputs,
+                emitMergeRequested, dispatchMerge,
+                extractMergeSuccess, mergeSucceededCheck,
+                emitMerged, mergeOutputs, emitMergeFailed,
+                emitTestDecision, incrementTestIteration, testMaxIterationsCheck,
                 emitTestRequested, dispatchTesting,
                 emitRejected, notifyRejected, rejectOutputs,
-                emitEscalated, notifyEscalated, escalateOutputs,
+                emitInvalid, emitEscalated, notifyEscalated, escalateOutputs,
                 finish,
             },
             Connections =
             {
                 Connect(readInputs, waitMerge),
 
-                // Merge → emit → dispatch merge → success outputs → finish
+                // ── Merge → emit MERGE.REQUESTED → dispatch merge → READ success ──
+                // CRITICAL-2: branch on the merge sub-workflow's `success` output.
+                //   success → DECISION.MERGED → merge outputs → finish
+                //   failure → MERGE.FAILED → escalate terminal (loud), never success
                 ConnectOutcome(waitMerge, "Merge", emitMergeRequested),
                 Connect(emitMergeRequested, dispatchMerge),
-                Connect(dispatchMerge, mergeOutputs),
+                Connect(dispatchMerge, extractMergeSuccess),
+                Connect(extractMergeSuccess, mergeSucceededCheck),
+                ConnectOutcome(mergeSucceededCheck, "True", emitMerged),
+                Connect(emitMerged, mergeOutputs),
                 Connect(mergeOutputs, finish),
+                ConnectOutcome(mergeSucceededCheck, "False", emitMergeFailed),
+                Connect(emitMergeFailed, emitEscalated), // funnel into the loud escalate terminal
 
-                // Test → emit → dispatch testing → LOOP BACK to the gate for a re-decision
-                ConnectOutcome(waitMerge, "Test", emitTestRequested),
+                // ── Test → emit DECISION.TEST → increment → CAP CHECK ──
+                // CRITICAL-3: bounded loop. Under the cap → TEST_REQUESTED → re-run
+                // CI → loop back to the gate. At/over the cap → escalate (loud).
+                ConnectOutcome(waitMerge, "Test", emitTestDecision),
+                Connect(emitTestDecision, incrementTestIteration),
+                Connect(incrementTestIteration, testMaxIterationsCheck),
+                ConnectOutcome(testMaxIterationsCheck, "False", emitTestRequested),
                 Connect(emitTestRequested, dispatchTesting),
-                Connect(dispatchTesting, waitMerge),
+                Connect(dispatchTesting, waitMerge), // loop back to the gate for a re-decision
+                ConnectOutcome(testMaxIterationsCheck, "True", emitEscalated), // cap → escalate
 
-                // Reject → emit → label/comment → reject outputs → finish (NOT success)
+                // ── Reject → emit → label/comment → reject outputs → finish (NOT success) ──
                 ConnectOutcome(waitMerge, "Reject", emitRejected),
                 Connect(emitRejected, notifyRejected),
                 Connect(notifyRejected, rejectOutputs),
                 Connect(rejectOutputs, finish),
 
-                // Invalid → emit ESCALATED → notify owners → escalate outputs → finish
-                // (explicit failure terminal — no silent reject, no fall-through to success)
-                ConnectOutcome(waitMerge, "Invalid", emitEscalated),
+                // ── Invalid → emit DECISION.INVALID → ESCALATED → notify → outputs → finish ──
+                // (explicit failure terminal — no silent reject, no fall-through to success,
+                //  no loop back to the gate)
+                ConnectOutcome(waitMerge, "Invalid", emitInvalid),
+                Connect(emitInvalid, emitEscalated),
+
+                // Shared loud escalate terminal (invalid decision / failed merge /
+                // test-loop cap exceeded) → notify owners → escalate outputs → finish
                 Connect(emitEscalated, notifyEscalated),
                 Connect(notifyEscalated, escalateOutputs),
                 Connect(escalateOutputs, finish),
@@ -261,6 +384,20 @@ public class MergeApprovalWorkflow : WorkflowBase
         };
         emit.SetDisplayText(label);
         return emit;
+    }
+
+    /// <summary>
+    /// A <see cref="SetVariable"/> node that assigns <paramref name="valueFunc"/>
+    /// to <paramref name="variable"/> — mirrors the cycle's Assign helper.
+    /// </summary>
+    private static SetVariable Assign(
+        Variable variable,
+        Func<Elsa.Expressions.Models.ExpressionExecutionContext, object?> valueFunc,
+        string id, string name)
+    {
+        var sv = new SetVariable { Id = id, Name = name, Variable = variable, Value = new Input<object?>(valueFunc) };
+        sv.SetDisplayText(name);
+        return sv;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/MergeApprovalWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/MergeApprovalWorkflow.cs
@@ -2,6 +2,7 @@ using Elsa.Extensions;
 using Elsa.Workflows;
 using Elsa.Workflows.Activities;
 using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.IncidentStrategies;
 using Elsa.Workflows.Management.Activities.SetOutput;
 using Elsa.Workflows.Memory;
 using Elsa.Workflows.Models;
@@ -60,6 +61,21 @@ public class MergeApprovalWorkflow : WorkflowBase
         builder.Version = WorkflowVersions.ComputedVersion;
         builder.Description = "Human merge/test/reject gate — branches on the decision, acts on it, and audits every edge";
 
+        // SECURITY I1 (fail-closed on internal fault) — the cycle reads this
+        // workflow's `outcome` output and ONLY routes "merge" forward to the
+        // pr-merged webhook bookmark; "escalated" (and anything unparseable) goes
+        // to a loud reportError terminal. If an activity in here THROWS, Elsa's
+        // default FaultStrategy would HALT the instance with an incident and
+        // produce NO `outcome`, leaving the cycle stuck on `tamma-processing`
+        // with no loud terminal (the last no-deadlock hole). Mirror the
+        // CleanUpFailedTenantWorkflow precedent: continue-with-incidents so a
+        // faulted activity doesn't halt the workflow, AND seed the `outcome`
+        // output to "escalated" up front (below at ReadInputs) so a fault that
+        // stops the flow before a terminal still yields a parseable, fail-closed
+        // outcome the cycle routes to reportError. The happy-path terminals
+        // overwrite it with the real outcome.
+        builder.WorkflowOptions.IncidentStrategyType = typeof(ContinueWithIncidentsStrategy);
+
         // ================================================================
         // Variables
         // ================================================================
@@ -86,6 +102,23 @@ public class MergeApprovalWorkflow : WorkflowBase
         // TaskMaxRevisions (>=3) in SingleIssueCycleWorkflow so an unbounded
         // test → gate → test loop can never spin forever.
         const int MaxTestIterations = 3;
+
+        // ================================================================
+        // 0. SECURITY I1 — seed the fail-closed default outcome
+        // ================================================================
+        // Set `outcome = "escalated"` BEFORE anything that can fault. If a later
+        // activity throws (and continue-with-incidents stops the flow before a
+        // terminal OutputsSequence runs), the workflow output still carries
+        // "escalated", which the cycle routes to its loud reportError terminal —
+        // never a silent "merge", never a stuck instance. The happy-path
+        // terminals below overwrite this with the real outcome.
+        var defaultOutcome = new SetOutput
+        {
+            Id = "DefaultOutcome",
+            OutputName = new("outcome"),
+            OutputValue = new(_ => (object)"escalated"),
+        };
+        defaultOutcome.SetDisplayText("Default Outcome = escalated");
 
         // ================================================================
         // 1. Read inputs
@@ -117,6 +150,10 @@ public class MergeApprovalWorkflow : WorkflowBase
             IssueNumber = new Input<int>(ctx => issueNumberVar.Get(ctx)),
             PrNumber = new Input<int>(ctx => prNumberVar.Get(ctx)),
             PrUrl = new Input<string?>(ctx => prUrlVar.Get(ctx)),
+            // SECURITY C2 — tenant + repo fold into the bookmark name so the gate
+            // is globally unique and a cross-tenant/cross-repo resume can't target it.
+            TenantId = new Input<string?>(ctx => tenantIdVar.Get(ctx)),
+            Repository = new Input<string?>(ctx => repository.Get(ctx)),
             BreakingChange = new Input<bool>(ctx => breakingChangeVar.Get(ctx)),
             Decision = new Output<string?>(decisionVar),
             Feedback = new Output<string?>(feedbackVar),
@@ -300,10 +337,10 @@ public class MergeApprovalWorkflow : WorkflowBase
         {
             Id = "MergeApprovalFlowchart",
             Name = "Merge Approval Flowchart",
-            Start = readInputs,
+            Start = defaultOutcome,
             Activities =
             {
-                readInputs, waitMerge,
+                defaultOutcome, readInputs, waitMerge,
                 emitMergeRequested, dispatchMerge,
                 extractMergeSuccess, mergeSucceededCheck,
                 emitMerged, mergeOutputs, emitMergeFailed,
@@ -315,6 +352,7 @@ public class MergeApprovalWorkflow : WorkflowBase
             },
             Connections =
             {
+                Connect(defaultOutcome, readInputs),
                 Connect(readInputs, waitMerge),
 
                 // ── Merge → emit MERGE.REQUESTED → dispatch merge → READ success ──

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/MergeWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/MergeWorkflow.cs
@@ -34,8 +34,19 @@ public class MergeWorkflow : WorkflowBase
         };
         mergePr.SetDisplayText("Merge PR");
 
+        // CRITICAL-2 — the merge activity's typed `Error` outcome used to be
+        // SWALLOWED: a single portless Connect(mergePr, setSuccess) only matches
+        // the activity's first/default outcome, so on Error the flow stalled and
+        // `success` was never emitted. The merge-approval gate reads `success` and
+        // routes a failed merge to its loud escalate terminal (instead of the
+        // success terminal, which would hang the cycle on a merge webhook that
+        // never fires). So set `success` EXPLICITLY on BOTH outcomes:
+        //   Merged → success = (mergeSha non-empty)
+        //   Error  → success = false  (and mergeSha stays empty)
         var setSuccess = new SetVariable { Id = "SetMergeSuccess", Name = "Set Success", Variable = successVar, Value = new Input<object?>(ctx => (object)!string.IsNullOrEmpty(mergeShaVar.Get(ctx))) };
         setSuccess.SetDisplayText("Set Success");
+        var setFailure = new SetVariable { Id = "SetMergeFailure", Name = "Set Failure", Variable = successVar, Value = new Input<object?>(_ => (object)false) };
+        setFailure.SetDisplayText("Set Failure");
         var outputSuccess = new SetOutput { Id = "OutputSuccess", Name = "Output Success", OutputName = new("success"), OutputValue = new(ctx => (object)successVar.Get(ctx)) };
         outputSuccess.SetDisplayText("Output Success");
         var outputMergeSha = new SetOutput { Id = "OutputMergeSha", Name = "Output Merge SHA", OutputName = new("mergeSha"), OutputValue = new(ctx => (object)(mergeShaVar.Get(ctx) ?? "")) };
@@ -46,11 +57,16 @@ public class MergeWorkflow : WorkflowBase
             Id = "MergeFlowchart",
             Name = "Merge Flowchart",
             Start = mergePr,
-            Activities = { mergePr, setSuccess, outputSuccess, outputMergeSha },
+            Activities = { mergePr, setSuccess, setFailure, outputSuccess, outputMergeSha },
             Connections =
             {
-                Connect(mergePr, setSuccess),
+                // Merged → success flag → emit outputs
+                ConnectOutcome(mergePr, "Merged", setSuccess),
                 Connect(setSuccess, outputSuccess),
+                // Error → explicit success=false → emit the SAME outputs (so the
+                // gate reads success=false rather than a never-set output).
+                ConnectOutcome(mergePr, "Error", setFailure),
+                Connect(setFailure, outputSuccess),
                 Connect(outputSuccess, outputMergeSha)
             }
         };
@@ -58,4 +74,7 @@ public class MergeWorkflow : WorkflowBase
 
     private static FlowConnection Connect(IActivity source, IActivity target)
         => new(new FlowEndpoint(source), new FlowEndpoint(target));
+
+    private static FlowConnection ConnectOutcome(IActivity source, string outcome, IActivity target)
+        => new(new FlowEndpoint(source, outcome), new FlowEndpoint(target));
 }

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs
@@ -539,35 +539,33 @@ public class SingleIssueCycleWorkflow : WorkflowBase
         dispatchCodeReview.SetDisplayText("Dispatch Code Review");
 
         // ================================================================
-        // 11b. Wait for PR Approval (bookmark — blocks until approved)
+        // 11b-12. Merge-Approval Gate (sub-workflow — the human APPROVAL_GATE)
+        //
+        // Replaces the prior bare WaitForPRApprovalActivity (binary approve) +
+        // fire-and-forget "merge" dispatch with the 3-way merge/test/reject gate
+        // (merge-approval), delivering the PRD test/merge decision point and the
+        // FR-19/FR-34 audit trail. On the Merge decision the gate dispatches the
+        // SAME "merge" workflow (WaitForCompletion=true) the loop used before; on
+        // Test it re-runs CI then re-decides; on Reject/Invalid it labels/escalates.
+        // We wait for the gate so the cycle does not race ahead of the human.
         // ================================================================
-        var waitForApproval = new WaitForPRApprovalActivity
+        var mergeApprovalGate = new DispatchWorkflow
         {
-            Id = "WaitForPRApproval",
-            Name = "Wait for PR Approval",
-            Repository = new Input<string>(ctx => repository.Get(ctx)),
-            PRNumber = new Input<int>(ctx => prNumber.Get(ctx)),
-        };
-        waitForApproval.SetDisplayText("Wait for PR Approval");
-
-        // ================================================================
-        // 12. Dispatch Merge (fire & forget — handles merge, CI on main, conflicts)
-        // ================================================================
-        var dispatchMerge = new DispatchWorkflow
-        {
-            Id = "DispatchMerge",
-            Name = "Dispatch Merge",
-            WorkflowDefinitionId = new("merge"),
+            Id = "MergeApprovalGate",
+            Name = "Merge Approval Gate",
+            WorkflowDefinitionId = new("merge-approval"),
             Input = new(ctx => new Dictionary<string, object>
             {
                 ["repository"] = repository.Get(ctx),
                 ["prNumber"] = prNumber.Get(ctx),
                 ["branchName"] = branchName.Get(ctx),
                 ["issueNumber"] = issueNumber.Get(ctx),
+                ["prUrl"] = prUrl.Get(ctx),
+                ["tenantId"] = tenantId.Get(ctx),
             }),
-            WaitForCompletion = new(false), // fire & forget
+            WaitForCompletion = new(true), // block until the human decides + the gate acts
         };
-        dispatchMerge.SetDisplayText("Dispatch Merge");
+        mergeApprovalGate.SetDisplayText("Merge Approval Gate");
 
         // ================================================================
         // 13. Wait for PR Merged (bookmark — blocks until merged)
@@ -731,8 +729,8 @@ public class SingleIssueCycleWorkflow : WorkflowBase
                 createPR, extractPR,
                 createTestCases,
                 initTaskLoop, hasMoreTasks, extractCurrentTask, tddForTask, incrementTask,
-                dispatchCodeReview, waitForApproval,
-                dispatchMerge, waitForMerged, closeIssue, deploymentPipeline,
+                dispatchCodeReview, mergeApprovalGate,
+                waitForMerged, closeIssue, deploymentPipeline,
                 // Notifications (fire-and-forget)
                 notifyProcessing, notifyInvalid, notifyContextDone,
                 notifyPlanDone, notifyPlanApproved,
@@ -848,14 +846,16 @@ public class SingleIssueCycleWorkflow : WorkflowBase
                 ConnectOutcome(tddForTask, "Failed", incrementTask),
                 Connect(incrementTask, hasMoreTasks), // loop back
 
-                // TDD Loop done → notify + dispatch code review + wait for approval (parallel)
+                // TDD Loop done → notify + dispatch code review + merge-approval gate (parallel)
                 ConnectOutcome(hasMoreTasks, "False", notifyTddDone),
                 ConnectOutcome(hasMoreTasks, "False", dispatchCodeReview),
-                ConnectOutcome(hasMoreTasks, "False", waitForApproval),
+                ConnectOutcome(hasMoreTasks, "False", mergeApprovalGate),
 
-                // 11. PR Approved → Dispatch Merge + Wait for Merged (parallel)
-                Connect(waitForApproval, dispatchMerge),
-                Connect(waitForApproval, waitForMerged),
+                // 11b-12. Merge-Approval Gate (human merge/test/reject + acts on it)
+                //         → Wait for Merged. The gate dispatches the real "merge"
+                //         workflow on approval; the loop still blocks on the merge
+                //         webhook via waitForMerged before closing the issue.
+                Connect(mergeApprovalGate, waitForMerged),
 
                 // 13. Merged → Close Issue + Deployment Pipeline (parallel)
                 Connect(waitForMerged, closeIssue),

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs
@@ -548,6 +548,14 @@ public class SingleIssueCycleWorkflow : WorkflowBase
         // SAME "merge" workflow (WaitForCompletion=true) the loop used before; on
         // Test it re-runs CI then re-decides; on Reject/Invalid it labels/escalates.
         // We wait for the gate so the cycle does not race ahead of the human.
+        //
+        // CRITICAL: the cycle MUST branch on the gate's `outcome` output. Only the
+        // "merge" outcome may reach WaitForPRMerged (which blocks on a
+        // `pr-merged-{pr}` webhook that fires ONLY on a real merge). reject /
+        // escalated finish at a loud human-handoff / error terminal — wiring those
+        // into WaitForPRMerged would hang the cycle forever (no webhook will ever
+        // fire), leaving the issue stuck `tamma-processing` with no terminal
+        // reported to the orchestrator.
         // ================================================================
         var mergeApprovalGate = new DispatchWorkflow
         {
@@ -564,8 +572,48 @@ public class SingleIssueCycleWorkflow : WorkflowBase
                 ["tenantId"] = tenantId.Get(ctx),
             }),
             WaitForCompletion = new(true), // block until the human decides + the gate acts
+            Result = new(subResult),       // capture the gate's outputs (incl. `outcome`)
         };
         mergeApprovalGate.SetDisplayText("Merge Approval Gate");
+
+        // Gate outcome: "merge" | "reject" | "escalated" (MergeApprovalWorkflow's
+        // `outcome` output). Defaults to "escalated" when the gate returns nothing
+        // parseable so an unreadable result is treated as a loud non-merge (never a
+        // silent merge), keeping the cycle on a terminal path.
+        var gateOutcome = builder.WithVariable<string>("GateOutcome", "escalated");
+        var extractGateOutcome = Assign(gateOutcome, ctx =>
+        {
+            var result = subResult.Get(ctx);
+            if (result != null && result.TryGetValue("outcome", out var o))
+            {
+                var token = o?.ToString();
+                if (!string.IsNullOrWhiteSpace(token)) return (object)token;
+            }
+            return (object)"escalated";
+        }, "ExtractGateOutcome", "Extract Gate Outcome");
+
+        // Branch the cycle on the gate outcome. ONLY "merge" continues to
+        // WaitForPRMerged; everything else reaches a loud terminal.
+        var gateOutcomeSwitch = new FlowSwitch
+        {
+            Id = "GateOutcomeSwitch",
+            Name = "Gate Outcome",
+            Cases =
+            {
+                new FlowSwitchCase("Merge", ctx => gateOutcome.Get(ctx) == "merge"),
+                new FlowSwitchCase("Reject", ctx => gateOutcome.Get(ctx) == "reject"),
+                new FlowSwitchCase("Escalated", ctx => true), // escalated + any unknown
+            },
+        };
+        gateOutcomeSwitch.SetDisplayText("Gate Outcome");
+
+        // Non-merge terminals: reject = human handoff; escalated = error report.
+        var notifyMergeRejected = NotifyIssue("NotifyMergeRejected", repository, issueNumber,
+            "🚫 PR rejected at the merge-approval gate. Needs human follow-up.",
+            new[] { "tamma-rejected", "needs-human" }, new[] { "tamma-processing" });
+        var notifyMergeEscalated = NotifyIssue("NotifyMergeEscalated", repository, issueNumber,
+            "⚠️ Merge-approval gate escalated (failed merge / invalid decision). Needs human attention.",
+            new[] { "tamma-error", "needs-human" }, new[] { "tamma-processing" });
 
         // ================================================================
         // 13. Wait for PR Merged (bookmark — blocks until merged)
@@ -730,6 +778,8 @@ public class SingleIssueCycleWorkflow : WorkflowBase
                 createTestCases,
                 initTaskLoop, hasMoreTasks, extractCurrentTask, tddForTask, incrementTask,
                 dispatchCodeReview, mergeApprovalGate,
+                extractGateOutcome, gateOutcomeSwitch,
+                notifyMergeRejected, notifyMergeEscalated,
                 waitForMerged, closeIssue, deploymentPipeline,
                 // Notifications (fire-and-forget)
                 notifyProcessing, notifyInvalid, notifyContextDone,
@@ -852,10 +902,26 @@ public class SingleIssueCycleWorkflow : WorkflowBase
                 ConnectOutcome(hasMoreTasks, "False", mergeApprovalGate),
 
                 // 11b-12. Merge-Approval Gate (human merge/test/reject + acts on it)
-                //         → Wait for Merged. The gate dispatches the real "merge"
-                //         workflow on approval; the loop still blocks on the merge
-                //         webhook via waitForMerged before closing the issue.
-                Connect(mergeApprovalGate, waitForMerged),
+                //         → branch on the gate `outcome`. ONLY merge → WaitForPRMerged.
+                //         The gate dispatches the real "merge" workflow on approval;
+                //         the loop then blocks on the merge webhook via waitForMerged
+                //         before closing the issue. reject / escalated must NEVER reach
+                //         waitForMerged (no webhook would ever fire → permanent hang) —
+                //         they finish at a loud human-handoff / error terminal instead.
+                Connect(mergeApprovalGate, extractGateOutcome),
+                Connect(extractGateOutcome, gateOutcomeSwitch),
+
+                // merge → wait for the real merge webhook (the only path to success)
+                ConnectOutcome(gateOutcomeSwitch, "Merge", waitForMerged),
+
+                // reject → human-handoff terminal (loud), never waitForMerged
+                ConnectOutcome(gateOutcomeSwitch, "Reject", notifyMergeRejected),
+                ConnectOutcome(gateOutcomeSwitch, "Reject", reportNeedsHuman),
+
+                // escalated (incl. a failed merge sub-workflow, CRITICAL-2) → error
+                // terminal (loud), never waitForMerged
+                ConnectOutcome(gateOutcomeSwitch, "Escalated", notifyMergeEscalated),
+                ConnectOutcome(gateOutcomeSwitch, "Escalated", reportError),
 
                 // 13. Merged → Close Issue + Deployment Pipeline (parallel)
                 Connect(waitForMerged, closeIssue),

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/MergeApprovalActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/MergeApprovalActivityTests.cs
@@ -139,4 +139,55 @@ public class MergeApprovalActivityTests
         var g = Guid.NewGuid();
         MergeApprovalEvents.ParseTenantId(g.ToString()).Should().Be(g);
     }
+
+    // ================================================================
+    // SECURITY C2 — BookmarkName uniqueness / determinism
+    // ================================================================
+
+    [Test]
+    public void BookmarkName_IncludesTenantAndRepo_NoCrossTenantCollision()
+    {
+        var tA = Guid.NewGuid().ToString();
+        var tB = Guid.NewGuid().ToString();
+
+        // Same issue/PR, different tenant → DISTINCT names (the C2 collision the
+        // old `adl-merge-approval-{issue}-{pr}` name had).
+        WaitForMergeApprovalActivity.BookmarkName(tA, "octo/repo", 5, 5)
+            .Should().NotBe(WaitForMergeApprovalActivity.BookmarkName(tB, "octo/repo", 5, 5));
+
+        // Same issue/PR + tenant, different repo → DISTINCT names too.
+        WaitForMergeApprovalActivity.BookmarkName(tA, "octo/repo", 5, 5)
+            .Should().NotBe(WaitForMergeApprovalActivity.BookmarkName(tA, "octo/other", 5, 5));
+    }
+
+    [Test]
+    public void BookmarkName_IsDeterministic_SameInputsSameName()
+    {
+        var t = Guid.NewGuid().ToString();
+        WaitForMergeApprovalActivity.BookmarkName(t, "Octo/Repo", 5, 7)
+            .Should().Be(WaitForMergeApprovalActivity.BookmarkName(t, "Octo/Repo", 5, 7),
+                "suspend-side and resume-side must compute identical names");
+    }
+
+    [Test]
+    public void BookmarkName_NormalizesSeparators_SoSegmentsCannotForgeAName()
+    {
+        // A repo whose chars include the '-' delimiter must not be able to alias a
+        // different (tenant, repo, issue, pr) tuple. Normalisation maps '-' and '/'
+        // to '_', so a crafted segment can't smuggle in extra delimiters.
+        var t = Guid.NewGuid().ToString();
+        var crafted = WaitForMergeApprovalActivity.BookmarkName(t, "a-b-9-9", 5, 5);
+        crafted.Should().Contain("a_b_9_9");
+        crafted.Should().EndWith("-5-5");
+    }
+
+    [TestCase(null, "none")]
+    [TestCase("", "none")]
+    [TestCase("   ", "none")]
+    [TestCase("Octo/Repo", "octo_repo")]
+    [TestCase("a-b", "a_b")]
+    public void NormalizeSegment_LowersAndReplacesDelimiters(string? input, string expected)
+    {
+        WaitForMergeApprovalActivity.NormalizeSegment(input).Should().Be(expected);
+    }
 }

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/MergeApprovalActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/MergeApprovalActivityTests.cs
@@ -1,0 +1,142 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+
+namespace Tamma.Activities.Tests.ADL;
+
+/// <summary>
+/// Unit coverage for the merge-approval gate's pure decision logic and DCB event
+/// mapping (FR-19 / FR-34 / Story 4-6):
+///   - decision normalisation: merge/test/reject map to typed outcomes;
+///     unknown/empty → <c>Invalid</c> (NEVER a silent "reject");
+///   - <c>EmitMergeApprovalEventActivity.BuildTammaEvent</c> maps onto the durable
+///     drain event shape with the right tags, status and decision payload;
+///   - reject/invalid/escalated are loud (error-status) audit rows, not false success.
+/// </summary>
+[TestFixture]
+public class MergeApprovalActivityTests
+{
+    // ================================================================
+    // WaitForMergeApprovalActivity.Normalize — no silent reject
+    // ================================================================
+
+    [TestCase("merge", "Merge", "merge")]
+    [TestCase("MERGE", "Merge", "merge")]
+    [TestCase("  Merge  ", "Merge", "merge")]
+    [TestCase("test", "Test", "test")]
+    [TestCase("Test", "Test", "test")]
+    [TestCase("reject", "Reject", "reject")]
+    [TestCase("REJECT", "Reject", "reject")]
+    public void Normalize_KnownDecisions_MapToTypedOutcomes(string input, string outcome, string token)
+    {
+        var (o, n) = WaitForMergeApprovalActivity.Normalize(input);
+        o.Should().Be(outcome);
+        n.Should().Be(token);
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("approve")]      // close-but-wrong word
+    [TestCase("merg")]         // typo
+    [TestCase("yes")]
+    public void Normalize_UnknownOrEmpty_IsInvalid_NotSilentReject(string? input)
+    {
+        var (o, n) = WaitForMergeApprovalActivity.Normalize(input);
+        o.Should().Be("Invalid",
+            "an unknown/empty decision must be an explicit Invalid outcome — never a silent reject");
+        n.Should().Be("invalid");
+        o.Should().NotBe("Reject");
+    }
+
+    // ================================================================
+    // EmitMergeApprovalEventActivity.BuildTammaEvent — DCB mapping
+    // ================================================================
+
+    [Test]
+    public void BuildTammaEvent_MergeRequested_SetsSuccessStatusTagsAndData()
+    {
+        var evt = EmitMergeApprovalEventActivity.BuildTammaEvent(
+            MergeApprovalEvents.MergeRequested, issueNumber: 12, prNumber: 34,
+            tenantId: null, decision: "merge", approver: "alice", feedback: "lgtm");
+
+        evt.EventType.Should().Be("MERGE.REQUESTED");
+        evt.Status.Should().Be("success");
+        evt.Tags.Should().NotBeNull();
+        evt.Tags!["issueId"].Should().Be("12");
+        evt.Tags["issueNumber"].Should().Be("12");
+        evt.Tags["prNumber"].Should().Be("34");
+        evt.Tags["decision"].Should().Be("merge");
+        evt.Tags["approver"].Should().Be("alice");
+        evt.Tags.Should().NotContainKey("tenantId");
+        evt.Data["decision"].Should().Be("merge");
+        evt.Data["approver"].Should().Be("alice");
+        evt.Data["feedback"].Should().Be("lgtm");
+    }
+
+    [Test]
+    public void BuildTammaEvent_Rejected_SetsErrorStatus()
+    {
+        var evt = EmitMergeApprovalEventActivity.BuildTammaEvent(
+            MergeApprovalEvents.DecisionRejected, issueNumber: 7, prNumber: 8,
+            tenantId: null, decision: "reject", approver: "bob", feedback: "needs work");
+
+        evt.EventType.Should().Be("MERGE_APPROVAL.DECISION.REJECTED");
+        evt.Status.Should().Be("error",
+            "a rejection is a loud audit row, not a false success");
+    }
+
+    [Test]
+    public void BuildTammaEvent_Escalated_SetsErrorStatus()
+    {
+        var evt = EmitMergeApprovalEventActivity.BuildTammaEvent(
+            MergeApprovalEvents.Escalated, 1, 2, null, "invalid", null, null);
+
+        evt.Status.Should().Be("error");
+    }
+
+    [Test]
+    public void BuildTammaEvent_OmitsZeroPrNumber_And_EmptyOptionalTags()
+    {
+        var evt = EmitMergeApprovalEventActivity.BuildTammaEvent(
+            MergeApprovalEvents.DecisionInvalid, issueNumber: 5, prNumber: 0,
+            tenantId: null, decision: null, approver: null, feedback: null);
+
+        evt.Tags!.Should().NotContainKey("prNumber");
+        evt.Tags.Should().NotContainKey("decision");
+        evt.Tags.Should().NotContainKey("approver");
+    }
+
+    [Test]
+    public void BuildTammaEvent_WithTenant_SetsTenantIdTag()
+    {
+        var tenant = Guid.NewGuid();
+        var evt = EmitMergeApprovalEventActivity.BuildTammaEvent(
+            MergeApprovalEvents.MergeRequested, 1, 2, tenant, "merge", "a", "");
+
+        evt.Tags!["tenantId"].Should().Be(tenant.ToString("D"));
+    }
+
+    [Test]
+    public void IsFailureEvent_RejectInvalidEscalated_AreFailures_MergeTestAreNot()
+    {
+        EmitMergeApprovalEventActivity.IsFailureEvent(MergeApprovalEvents.DecisionRejected).Should().BeTrue();
+        EmitMergeApprovalEventActivity.IsFailureEvent(MergeApprovalEvents.DecisionInvalid).Should().BeTrue();
+        EmitMergeApprovalEventActivity.IsFailureEvent(MergeApprovalEvents.Escalated).Should().BeTrue();
+
+        EmitMergeApprovalEventActivity.IsFailureEvent(MergeApprovalEvents.MergeRequested).Should().BeFalse();
+        EmitMergeApprovalEventActivity.IsFailureEvent(MergeApprovalEvents.TestRequested).Should().BeFalse();
+        EmitMergeApprovalEventActivity.IsFailureEvent(MergeApprovalEvents.DecisionMerged).Should().BeFalse();
+        EmitMergeApprovalEventActivity.IsFailureEvent(MergeApprovalEvents.DecisionTest).Should().BeFalse();
+    }
+
+    [Test]
+    public void ParseTenantId_HandlesEmptyAndValid()
+    {
+        MergeApprovalEvents.ParseTenantId(null).Should().BeNull();
+        MergeApprovalEvents.ParseTenantId("").Should().BeNull();
+        MergeApprovalEvents.ParseTenantId("not-a-guid").Should().BeNull();
+        var g = Guid.NewGuid();
+        MergeApprovalEvents.ParseTenantId(g.ToString()).Should().Be(g);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Endpoints/MergeApprovalResumeEndpointTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Endpoints/MergeApprovalResumeEndpointTests.cs
@@ -1,0 +1,149 @@
+using Elsa.Workflows.Runtime;
+using Elsa.Workflows.Runtime.Entities;
+using Elsa.Workflows.Runtime.Filters;
+using Elsa.Workflows.Runtime.Messages;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+using Tamma.ElsaServer.Endpoints;
+
+namespace Tamma.Activities.Tests.Endpoints;
+
+/// <summary>
+/// SECURITY C1/C2 — the engine-side merge-approval resume seam
+/// (<c>POST /elsa/api/adl/merge-approval/resume</c>). Verifies it:
+///   - computes the SAME tenant+repo-scoped bookmark name as the gate activity;
+///   - resolves only the matching (single) instance and resumes it;
+///   - REFUSES with 409 when more than one instance matches a (globally-unique)
+///     name rather than resuming an arbitrary <c>bookmarks[0]</c> (C2);
+///   - 404s when no bookmark matches (a cross-tenant/cross-repo resume hits this
+///     because the name carries the caller's tenant+repo, C1).
+/// </summary>
+[TestFixture]
+public class MergeApprovalResumeEndpointTests
+{
+    private Mock<IBookmarkStore> _bookmarks = null!;
+    private Mock<IWorkflowRuntime> _runtime = null!;
+    private Mock<IWorkflowClient> _client = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _bookmarks = new Mock<IBookmarkStore>();
+        _runtime = new Mock<IWorkflowRuntime>();
+        _client = new Mock<IWorkflowClient>();
+        _runtime
+            .Setup(r => r.CreateClientAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_client.Object);
+        _client
+            .Setup(c => c.RunInstanceAsync(It.IsAny<RunWorkflowInstanceRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunWorkflowInstanceResponse());
+    }
+
+    private static MergeApprovalResumeEndpoint.ResumeRequest Req(
+        int issue, int pr, string decision, string? tenantId, string? repo)
+        => new(issue, pr, decision, Feedback: null, Approver: null, TenantId: tenantId, Repository: repo);
+
+    private static StoredBookmark Bookmark(string name, string instanceId)
+        => new() { Name = name, WorkflowInstanceId = instanceId, Id = Guid.NewGuid().ToString() };
+
+    private void SetupFind(string expectedName, params StoredBookmark[] matches) =>
+        _bookmarks
+            .Setup(b => b.FindManyAsync(
+                It.Is<BookmarkFilter>(f => f.Name == expectedName), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(matches.AsEnumerable());
+
+    [Test]
+    public async Task Resume_UsesTenantRepoScopedBookmarkName_AndResumesMatch()
+    {
+        var tenant = Guid.NewGuid().ToString();
+        var expected = WaitForMergeApprovalActivity.BookmarkName(tenant, "octo/repo", 42, 7);
+        SetupFind(expected, Bookmark(expected, "wf-instance-1"));
+
+        var result = await MergeApprovalResumeEndpoint.Resume(
+            Req(42, 7, "merge", tenant, "octo/repo"),
+            _bookmarks.Object, _runtime.Object, NullLoggerFactory.Instance, CancellationToken.None);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status200OK);
+        _client.Verify(c => c.RunInstanceAsync(
+            It.Is<RunWorkflowInstanceRequest>(r => (string)r.Input!["decision"] == "merge"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task Resume_CrossTenant_NoMatchingBookmark_Returns404_NeverResumes()
+    {
+        // C1 — tenant B's gate is stored under tenant B's name. A caller scoped to
+        // tenant A computes tenant A's name → no match → 404, and crucially never
+        // calls RunInstanceAsync against the victim instance.
+        var callerTenant = Guid.NewGuid().ToString();
+        var callerName = WaitForMergeApprovalActivity.BookmarkName(callerTenant, "victim/repo", 5, 5);
+        SetupFind(callerName /* zero matches */);
+
+        var result = await MergeApprovalResumeEndpoint.Resume(
+            Req(5, 5, "merge", callerTenant, "victim/repo"),
+            _bookmarks.Object, _runtime.Object, NullLoggerFactory.Instance, CancellationToken.None);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status404NotFound);
+        _client.Verify(c => c.RunInstanceAsync(
+            It.IsAny<RunWorkflowInstanceRequest>(), It.IsAny<CancellationToken>()), Times.Never,
+            "a cross-tenant miss must never resume any instance");
+    }
+
+    [Test]
+    public async Task Resume_MoreThanOneMatch_Refuses409_DoesNotResumeArbitrary()
+    {
+        // C2 — the name is globally unique; >1 match is an integrity violation.
+        // The old code resumed bookmarks[0] (arbitrary). Now we refuse.
+        var tenant = Guid.NewGuid().ToString();
+        var name = WaitForMergeApprovalActivity.BookmarkName(tenant, "octo/repo", 1, 1);
+        SetupFind(name, Bookmark(name, "wf-a"), Bookmark(name, "wf-b"));
+
+        var result = await MergeApprovalResumeEndpoint.Resume(
+            Req(1, 1, "merge", tenant, "octo/repo"),
+            _bookmarks.Object, _runtime.Object, NullLoggerFactory.Instance, CancellationToken.None);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status409Conflict);
+        _client.Verify(c => c.RunInstanceAsync(
+            It.IsAny<RunWorkflowInstanceRequest>(), It.IsAny<CancellationToken>()), Times.Never,
+            "an ambiguous bookmark must refuse, not resume an arbitrary instance");
+    }
+
+    [Test]
+    public async Task Resume_EmptyDecision_Returns400()
+    {
+        var result = await MergeApprovalResumeEndpoint.Resume(
+            Req(1, 1, "  ", Guid.NewGuid().ToString(), "octo/repo"),
+            _bookmarks.Object, _runtime.Object, NullLoggerFactory.Instance, CancellationToken.None);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public async Task Resume_TwoTenantsSameIssuePr_TargetOnlyTheirOwnGate()
+    {
+        // C2 end-to-end: two tenants each waiting on issue #5 / PR #5 have DISTINCT
+        // bookmark names, so a resume for tenant A resolves ONLY tenant A's
+        // instance even though tenant B has the same issue/PR.
+        var tenantA = Guid.NewGuid().ToString();
+        var tenantB = Guid.NewGuid().ToString();
+        var nameA = WaitForMergeApprovalActivity.BookmarkName(tenantA, "octo/repo", 5, 5);
+        var nameB = WaitForMergeApprovalActivity.BookmarkName(tenantB, "octo/repo", 5, 5);
+        nameA.Should().NotBe(nameB, "two tenants on the same issue/PR must not collide");
+
+        SetupFind(nameA, Bookmark(nameA, "wf-tenant-a"));
+
+        var result = await MergeApprovalResumeEndpoint.Resume(
+            Req(5, 5, "merge", tenantA, "octo/repo"),
+            _bookmarks.Object, _runtime.Object, NullLoggerFactory.Instance, CancellationToken.None);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status200OK);
+        _runtime.Verify(r => r.CreateClientAsync("wf-tenant-a", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static int? StatusCodeOf(IResult result)
+        => (result as IStatusCodeHttpResult)?.StatusCode;
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/MergeApprovalWorkflowTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/MergeApprovalWorkflowTests.cs
@@ -115,8 +115,91 @@ public class MergeApprovalWorkflowTests
         ReadDefinitionId(dispatch!).Should().Be("merge",
             "the gate must dispatch the existing merge workflow on approval");
 
-        HasEdge("DispatchMerge", null, "MergeOutputs").Should().BeTrue();
+        // CRITICAL-2: the merge dispatch must read its `success` output and branch
+        // — a successful merge reaches the merge/success terminal, a failed one
+        // does NOT.
+        HasEdge("DispatchMerge", null, "ExtractMergeSuccess").Should().BeTrue(
+            "the gate must read the merge sub-workflow's success output");
+        HasEdge("ExtractMergeSuccess", null, "MergeSucceeded").Should().BeTrue();
+        HasEdge("MergeSucceeded", "True", "EmitMerged").Should().BeTrue();
+        HasEdge("EmitMerged", null, "MergeOutputs").Should().BeTrue();
         HasEdge("MergeOutputs", null, "Finish").Should().BeTrue();
+    }
+
+    // ================================================================
+    // CRITICAL-2 — a failed merge sub-workflow surfaces loudly (MERGE.FAILED +
+    // ESCALATED) and routes to the escalate terminal (outcome="escalated"), NEVER
+    // the merge/success terminal (which would hang the cycle on a merge webhook).
+    // ================================================================
+
+    [Test]
+    public void MergeFailure_RoutesToEscalateTerminal_NotMergeSuccess()
+    {
+        HasEdge("MergeSucceeded", "False", "EmitMergeFailed").Should().BeTrue(
+            "a failed merge (success=false) must emit a loud MERGE.FAILED event");
+        HasEdge("EmitMergeFailed", null, "EmitEscalated").Should().BeTrue(
+            "a failed merge must funnel into the escalate terminal");
+
+        var failureReach = Reachable("EmitMergeFailed");
+        // A failed merge must NOT reach the merge/success outputs (outcome="merge").
+        failureReach.Should().NotContain("MergeOutputs",
+            "a failed merge must never reach the merge/success terminal");
+        failureReach.Should().NotContain("EmitMerged");
+        // It MUST reach the escalate outputs (outcome="escalated") so the cycle's
+        // GateOutcomeSwitch routes it to reportError (and never to WaitForPRMerged).
+        failureReach.Should().Contain("EscalateOutputs",
+            "a failed merge must reach the escalate terminal (outcome=escalated)");
+    }
+
+    [Test]
+    public void MergeFailed_IsAFailureEvent_ErrorStatus()
+    {
+        // The MERGE.FAILED audit row must be loud (error status), not a false success.
+        EmitMergeApprovalEventActivity.IsFailureEvent(MergeApprovalEvents.MergeFailed)
+            .Should().BeTrue("MERGE.FAILED must be an error-status audit event");
+    }
+
+    // ================================================================
+    // CRITICAL-3 — the Test → gate → test loop is iteration-capped; over the cap
+    // it escalates instead of spinning forever.
+    // ================================================================
+
+    [Test]
+    public void TestLoop_IsBounded_IncrementsThenChecksCap()
+    {
+        HasEdge("WaitMergeApproval", "Test", "EmitTestDecision").Should().BeTrue();
+        HasEdge("EmitTestDecision", null, "IncrementTestIteration").Should().BeTrue(
+            "each Test decision must increment the iteration counter");
+        HasEdge("IncrementTestIteration", null, "TestMaxIterations").Should().BeTrue(
+            "after incrementing, the loop must check the iteration cap");
+    }
+
+    [Test]
+    public void TestLoop_UnderCap_RunsCiThenLoopsBackToGate()
+    {
+        HasEdge("TestMaxIterations", "False", "EmitTestRequested").Should().BeTrue(
+            "under the cap the gate re-runs CI");
+        var dispatch = _flowchart.Activities
+            .OfType<DispatchWorkflow>()
+            .FirstOrDefault(d => d.Id == "DispatchTesting");
+        dispatch.Should().NotBeNull();
+        ReadDefinitionId(dispatch!).Should().Be("ci-with-debug-retry");
+        HasEdge("DispatchTesting", null, "WaitMergeApproval").Should().BeTrue(
+            "under the cap the loop returns to the gate for a re-decision");
+    }
+
+    [Test]
+    public void TestLoop_OverCap_EscalatesNotLoops()
+    {
+        HasEdge("TestMaxIterations", "True", "EmitEscalated").Should().BeTrue(
+            "over the iteration cap the test loop must escalate (loud), not loop forever");
+
+        // Over the cap must reach the escalate terminal and must NOT re-run CI /
+        // loop back to the gate.
+        var overCapReach = ReachableFromPort("TestMaxIterations", "True");
+        overCapReach.Should().Contain("EscalateOutputs");
+        overCapReach.Should().NotContain("DispatchTesting",
+            "the cap path must not re-run CI");
     }
 
     // ================================================================
@@ -126,7 +209,10 @@ public class MergeApprovalWorkflowTests
     [Test]
     public void TestOutcome_EmitsTestRequested_RunsCi_ThenLoopsBackToGate()
     {
-        HasEdge("WaitMergeApproval", "Test", "EmitTestRequested").Should().BeTrue();
+        // The Test edge now goes through the bounded loop (DECISION.TEST →
+        // increment → cap check → TEST_REQUESTED → CI → back to gate).
+        HasEdge("WaitMergeApproval", "Test", "EmitTestDecision").Should().BeTrue();
+        HasEdge("TestMaxIterations", "False", "EmitTestRequested").Should().BeTrue();
         HasEdge("EmitTestRequested", null, "DispatchTesting").Should().BeTrue();
 
         var dispatch = _flowchart.Activities
@@ -168,17 +254,21 @@ public class MergeApprovalWorkflowTests
     [Test]
     public void InvalidOutcome_Escalates_NotSilentRejectOrMerge()
     {
-        HasEdge("WaitMergeApproval", "Invalid", "EmitEscalated").Should().BeTrue(
-            "an unknown/empty decision must emit MERGE_APPROVAL.ESCALATED — never silently reject");
+        // Invalid now emits DECISION.INVALID first, then funnels into the shared
+        // escalate terminal — it ESCALATES, it does NOT loop back to the gate.
+        HasEdge("WaitMergeApproval", "Invalid", "EmitInvalid").Should().BeTrue(
+            "an unknown/empty decision must emit MERGE_APPROVAL.DECISION.INVALID — never silently reject");
+        HasEdge("EmitInvalid", null, "EmitEscalated").Should().BeTrue();
         HasEdge("EmitEscalated", null, "NotifyEscalated").Should().BeTrue();
         HasEdge("NotifyEscalated", null, "EscalateOutputs").Should().BeTrue();
         HasEdge("EscalateOutputs", null, "Finish").Should().BeTrue();
 
-        var invalidReach = Reachable("EmitEscalated");
+        var invalidReach = Reachable("EmitInvalid");
         invalidReach.Should().NotContain("DispatchMerge");
         invalidReach.Should().NotContain("MergeOutputs");
-        // Invalid must NOT be folded into the Reject path either — it is a loud,
-        // distinct escalation.
+        // Invalid must NOT loop back to the gate (would let a malformed payload
+        // re-arm the suspend forever) and must NOT be folded into the Reject path.
+        invalidReach.Should().NotContain("WaitMergeApproval");
         invalidReach.Should().NotContain("NotifyRejected");
     }
 
@@ -198,6 +288,25 @@ public class MergeApprovalWorkflowTests
         emitIds.Should().Contain("EmitTestRequested");
         emitIds.Should().Contain("EmitRejected");
         emitIds.Should().Contain("EmitEscalated");
+    }
+
+    // ================================================================
+    // MINOR-1 — the DECISION.MERGED / DECISION.TEST / DECISION.INVALID constants
+    // are now actually emitted on their matching edges (no dead constants).
+    // ================================================================
+
+    [Test]
+    public void DecisionConstants_AreEmittedOnTheirEdges()
+    {
+        var emitIds = _flowchart.Activities
+            .OfType<EmitMergeApprovalEventActivity>()
+            .Select(a => a.Id)
+            .ToList();
+
+        emitIds.Should().Contain("EmitMerged", "DECISION.MERGED must be emitted on the successful-merge edge");
+        emitIds.Should().Contain("EmitTestDecision", "DECISION.TEST must be emitted on the test edge");
+        emitIds.Should().Contain("EmitInvalid", "DECISION.INVALID must be emitted on the invalid edge");
+        emitIds.Should().Contain("EmitMergeFailed", "MERGE.FAILED must be emitted on a failed merge");
     }
 
     // ================================================================
@@ -250,6 +359,28 @@ public class MergeApprovalWorkflowTests
             {
                 var t = c.Target.Activity.Id;
                 if (t != null && seen.Add(t)) queue.Enqueue(t);
+            }
+        }
+        return seen;
+    }
+
+    /// <summary>Forward-reachable activity ids starting from a specific outcome
+    /// port of a source node.</summary>
+    private HashSet<string> ReachableFromPort(string sourceId, string port)
+    {
+        var seen = new HashSet<string>();
+        var queue = new Queue<string>();
+        foreach (var c in _flowchart.Connections.Where(c =>
+            c.Source.Activity.Id == sourceId && c.Source.Port == port))
+        {
+            if (c.Target.Activity.Id is { } t && seen.Add(t)) queue.Enqueue(t);
+        }
+        while (queue.Count > 0)
+        {
+            var id = queue.Dequeue();
+            foreach (var c in _flowchart.Connections.Where(c => c.Source.Activity.Id == id))
+            {
+                if (c.Target.Activity.Id is { } t && seen.Add(t)) queue.Enqueue(t);
             }
         }
         return seen;

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/MergeApprovalWorkflowTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/MergeApprovalWorkflowTests.cs
@@ -1,0 +1,266 @@
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Management.Activities.SetOutput;
+using Elsa.Workflows.Runtime.Activities;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Build-out structure coverage for the <c>merge-approval</c> gate (FR-19 /
+/// FR-34 / Story 4-6). Asserts the load-bearing guarantees of the build-out:
+/// every outcome of the human decision activity is routed to a distinct edge (no
+/// dangling outcome, no fall-through), the reject / invalid paths reach an
+/// explicit terminal (never the merge/success path), each decision edge emits a
+/// <c>MERGE_APPROVAL.*</c> / <c>MERGE.*</c> DCB event, the Merge decision
+/// dispatches the real <c>merge</c> workflow, and the Test decision loops back to
+/// the gate for a re-decision.
+///
+/// <para>Inspects the BUILT Flowchart via <see cref="WorkflowTestHelper"/> (the
+/// codebase convention — see PullRequestWorkflowTests / SingleIssueCycleRoutingTests)
+/// rather than running the full Elsa runtime.</para>
+/// </summary>
+[TestFixture]
+public class MergeApprovalWorkflowTests
+{
+    private Flowchart _flowchart = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new MergeApprovalWorkflow());
+        _flowchart = WorkflowTestHelper.GetFlowchart(builder);
+    }
+
+    // ================================================================
+    // Identity
+    // ================================================================
+
+    [Test]
+    public void Workflow_BuildsWithExpectedDefinitionId()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new MergeApprovalWorkflow());
+        builder.Object.DefinitionId.Should().Be("merge-approval");
+    }
+
+    [Test]
+    public void Gate_IsWaitForMergeApprovalActivity_WithFourTypedOutcomes()
+    {
+        var gate = _flowchart.Activities
+            .OfType<WaitForMergeApprovalActivity>()
+            .FirstOrDefault(a => a.Id == "WaitMergeApproval");
+
+        gate.Should().NotBeNull("the merge-approval workflow must suspend on the human gate activity");
+
+        // The four decision edges must all leave the gate, each outcome-qualified.
+        var ports = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "WaitMergeApproval")
+            .Select(c => c.Source.Port)
+            .ToList();
+
+        ports.Should().Contain("Merge");
+        ports.Should().Contain("Test");
+        ports.Should().Contain("Reject");
+        ports.Should().Contain("Invalid");
+    }
+
+    // ================================================================
+    // No dangling outcome / no fall-through
+    // ================================================================
+
+    [Test]
+    public void Gate_HasNoUnconditionalFallthrough_EveryEdgeIsOutcomeQualified()
+    {
+        // A portless edge out of the gate would be the old silent fan-out bug
+        // (the skeleton wired waitMerge → SetOutput with a plain Connect()).
+        var fromGate = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "WaitMergeApproval")
+            .ToList();
+
+        fromGate.Should().NotBeEmpty();
+        fromGate.Should().OnlyContain(c =>
+            c.Source.Port == "Merge" || c.Source.Port == "Test" ||
+            c.Source.Port == "Reject" || c.Source.Port == "Invalid");
+    }
+
+    [Test]
+    public void EveryGateOutcome_IsRouted()
+    {
+        foreach (var outcome in new[] { "Merge", "Test", "Reject", "Invalid" })
+        {
+            _flowchart.Connections.Any(c =>
+                c.Source.Activity.Id == "WaitMergeApproval" && c.Source.Port == outcome)
+                .Should().BeTrue($"the '{outcome}' outcome must route to a distinct edge");
+        }
+    }
+
+    // ================================================================
+    // Merge path — emit MERGE.REQUESTED → dispatch the real merge workflow
+    // ================================================================
+
+    [Test]
+    public void MergeOutcome_EmitsMergeRequested_ThenDispatchesMergeWorkflow()
+    {
+        HasEdge("WaitMergeApproval", "Merge", "EmitMergeRequested").Should().BeTrue(
+            "the Merge decision must first emit a MERGE.REQUESTED DCB event");
+        HasEdge("EmitMergeRequested", null, "DispatchMerge").Should().BeTrue();
+
+        var dispatch = _flowchart.Activities
+            .OfType<DispatchWorkflow>()
+            .FirstOrDefault(d => d.Id == "DispatchMerge");
+        dispatch.Should().NotBeNull("approval must actually trigger the merge — not emit a bare string");
+        ReadDefinitionId(dispatch!).Should().Be("merge",
+            "the gate must dispatch the existing merge workflow on approval");
+
+        HasEdge("DispatchMerge", null, "MergeOutputs").Should().BeTrue();
+        HasEdge("MergeOutputs", null, "Finish").Should().BeTrue();
+    }
+
+    // ================================================================
+    // Test path — emit TEST_REQUESTED → re-run CI → loop back to the gate
+    // ================================================================
+
+    [Test]
+    public void TestOutcome_EmitsTestRequested_RunsCi_ThenLoopsBackToGate()
+    {
+        HasEdge("WaitMergeApproval", "Test", "EmitTestRequested").Should().BeTrue();
+        HasEdge("EmitTestRequested", null, "DispatchTesting").Should().BeTrue();
+
+        var dispatch = _flowchart.Activities
+            .OfType<DispatchWorkflow>()
+            .FirstOrDefault(d => d.Id == "DispatchTesting");
+        dispatch.Should().NotBeNull();
+        ReadDefinitionId(dispatch!).Should().Be("ci-with-debug-retry");
+
+        // Re-test then re-enter the gate for a fresh decision (the PRD "run more
+        // tests before merging" loop).
+        HasEdge("DispatchTesting", null, "WaitMergeApproval").Should().BeTrue(
+            "the Test decision must loop back to the gate for a re-decision");
+    }
+
+    // ================================================================
+    // Reject path — explicit terminal, NEVER the merge/success path
+    // ================================================================
+
+    [Test]
+    public void RejectOutcome_RoutesToExplicitRejectTerminal_NotMerge()
+    {
+        HasEdge("WaitMergeApproval", "Reject", "EmitRejected").Should().BeTrue(
+            "the Reject decision must emit a MERGE_APPROVAL.DECISION.REJECTED event");
+        HasEdge("EmitRejected", null, "NotifyRejected").Should().BeTrue();
+        HasEdge("NotifyRejected", null, "RejectOutputs").Should().BeTrue();
+        HasEdge("RejectOutputs", null, "Finish").Should().BeTrue();
+
+        // Reject must NOT reach the merge dispatch or the merge success outputs.
+        var rejectReach = Reachable("EmitRejected");
+        rejectReach.Should().NotContain("DispatchMerge");
+        rejectReach.Should().NotContain("MergeOutputs");
+    }
+
+    // ================================================================
+    // Invalid path — unknown/empty decision escalates (no silent reject, no
+    // fall-through to success)
+    // ================================================================
+
+    [Test]
+    public void InvalidOutcome_Escalates_NotSilentRejectOrMerge()
+    {
+        HasEdge("WaitMergeApproval", "Invalid", "EmitEscalated").Should().BeTrue(
+            "an unknown/empty decision must emit MERGE_APPROVAL.ESCALATED — never silently reject");
+        HasEdge("EmitEscalated", null, "NotifyEscalated").Should().BeTrue();
+        HasEdge("NotifyEscalated", null, "EscalateOutputs").Should().BeTrue();
+        HasEdge("EscalateOutputs", null, "Finish").Should().BeTrue();
+
+        var invalidReach = Reachable("EmitEscalated");
+        invalidReach.Should().NotContain("DispatchMerge");
+        invalidReach.Should().NotContain("MergeOutputs");
+        // Invalid must NOT be folded into the Reject path either — it is a loud,
+        // distinct escalation.
+        invalidReach.Should().NotContain("NotifyRejected");
+    }
+
+    // ================================================================
+    // DCB events on every decision edge
+    // ================================================================
+
+    [Test]
+    public void EveryDecisionEdge_EmitsAGateEvent()
+    {
+        var emitIds = _flowchart.Activities
+            .OfType<EmitMergeApprovalEventActivity>()
+            .Select(a => a.Id)
+            .ToList();
+
+        emitIds.Should().Contain("EmitMergeRequested");
+        emitIds.Should().Contain("EmitTestRequested");
+        emitIds.Should().Contain("EmitRejected");
+        emitIds.Should().Contain("EmitEscalated");
+    }
+
+    // ================================================================
+    // Outputs — reject/escalate carry a non-success outcome token
+    // ================================================================
+
+    [Test]
+    public void EachTerminal_EmitsItsOutcomeAndDecisionOutputs()
+    {
+        // Each terminal sequence surfaces an explicit `outcome` token plus the
+        // decision/feedback/approver — the gate stops emitting a bare string and
+        // instead reports a structured, distinct result per path.
+        foreach (var id in new[] { "MergeOutputs", "RejectOutputs", "EscalateOutputs" })
+        {
+            var seq = _flowchart.Activities.OfType<Sequence>().FirstOrDefault(s => s.Id == id);
+            seq.Should().NotBeNull($"{id} terminal sequence must exist");
+
+            var outputNames = seq!.Activities.OfType<SetOutput>().Select(o => o.Id ?? "").ToList();
+            outputNames.Should().Contain($"{id}_Outcome");
+            outputNames.Should().Contain($"{id}_Decision");
+            outputNames.Should().Contain($"{id}_Approver");
+        }
+
+        // Reject/escalate are distinct terminals from the merge terminal — they
+        // must not be the same sequence node.
+        var terminals = new[] { "MergeOutputs", "RejectOutputs", "EscalateOutputs" };
+        terminals.Distinct().Should().HaveCount(3);
+    }
+
+    // ================================================================
+    // Helpers
+    // ================================================================
+
+    private bool HasEdge(string sourceId, string? port, string targetId)
+        => _flowchart.Connections.Any(c =>
+            c.Source.Activity.Id == sourceId &&
+            (port == null || c.Source.Port == port) &&
+            c.Target.Activity.Id == targetId);
+
+    /// <summary>Forward-reachable activity ids from a starting node.</summary>
+    private HashSet<string> Reachable(string startId)
+    {
+        var seen = new HashSet<string>();
+        var queue = new Queue<string>();
+        queue.Enqueue(startId);
+        while (queue.Count > 0)
+        {
+            var id = queue.Dequeue();
+            foreach (var c in _flowchart.Connections.Where(c => c.Source.Activity.Id == id))
+            {
+                var t = c.Target.Activity.Id;
+                if (t != null && seen.Add(t)) queue.Enqueue(t);
+            }
+        }
+        return seen;
+    }
+
+    private static string? ReadDefinitionId(DispatchWorkflow dispatch)
+    {
+        var prop = typeof(DispatchWorkflow).GetProperty("WorkflowDefinitionId");
+        var value = prop?.GetValue(dispatch);
+        var expression = value?.GetType().GetProperty("Expression")?.GetValue(value)
+            as Elsa.Expressions.Models.Expression;
+        return expression?.Value?.ToString();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/MergeApprovalWorkflowTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/MergeApprovalWorkflowTests.cs
@@ -337,6 +337,39 @@ public class MergeApprovalWorkflowTests
     }
 
     // ================================================================
+    // SECURITY I1 — fail-closed on internal fault (no-deadlock last hole)
+    // ================================================================
+
+    [Test]
+    public void Workflow_SeedsEscalatedOutcomeBeforeAnythingThatCanFault()
+    {
+        // The flowchart must START by setting outcome="escalated" so a later
+        // fault (with continue-with-incidents) that stops the flow before a
+        // terminal still yields a parseable, fail-closed outcome the cycle routes
+        // to reportError — never a silent merge, never a stuck instance.
+        _flowchart.Start.Should().NotBeNull();
+        ((Elsa.Workflows.IActivity)_flowchart.Start!).Id.Should().Be("DefaultOutcome",
+            "the fail-closed default outcome must be set before any faultable activity");
+
+        var defaultOutcome = _flowchart.Activities
+            .OfType<SetOutput>()
+            .FirstOrDefault(a => a.Id == "DefaultOutcome");
+        defaultOutcome.Should().NotBeNull("a DefaultOutcome SetOutput node must seed the outcome");
+
+        HasEdge("DefaultOutcome", null, "ReadInputs").Should().BeTrue(
+            "the default-outcome node must flow into ReadInputs");
+    }
+
+    [Test]
+    public void Workflow_UsesContinueWithIncidentsStrategy_SoAFaultDoesNotHaltSilently()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new MergeApprovalWorkflow());
+        builder.Object.WorkflowOptions.IncidentStrategyType
+            .Should().Be(typeof(Elsa.Workflows.IncidentStrategies.ContinueWithIncidentsStrategy),
+                "a faulted gate must not halt the workflow with an incident and produce no outcome");
+    }
+
+    // ================================================================
     // Helpers
     // ================================================================
 

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/SingleIssueCycleRoutingTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/SingleIssueCycleRoutingTests.cs
@@ -369,7 +369,7 @@ public class SingleIssueCycleRoutingTests
     }
 
     [Test]
-    public void MergeApprovalGate_WaitsForCompletion_ThenWaitsForMerged()
+    public void MergeApprovalGate_WaitsForCompletion_ThenBranchesOnOutcome()
     {
         var gate = _flowchart.Activities
             .OfType<DispatchWorkflow>()
@@ -380,10 +380,82 @@ public class SingleIssueCycleRoutingTests
         ReadWaitForCompletion(gate).Should().BeTrue(
             "the cycle must wait for the merge-approval gate to complete");
 
+        // CRITICAL-1: the gate must NOT connect unconditionally to WaitForPRMerged.
+        // It must flow into ExtractGateOutcome → GateOutcomeSwitch and branch.
         _flowchart.Connections.Any(c =>
             c.Source.Activity.Id == "MergeApprovalGate" &&
             c.Target.Activity.Id == "WaitForPRMerged")
-            .Should().BeTrue("after the gate, the cycle still blocks on the merge webhook");
+            .Should().BeFalse(
+                "the gate must NOT connect directly to WaitForPRMerged — reject/escalate " +
+                "would then hang the cycle forever on a merge webhook that never fires");
+
+        _flowchart.Connections.Any(c =>
+            c.Source.Activity.Id == "MergeApprovalGate" &&
+            c.Target.Activity.Id == "ExtractGateOutcome")
+            .Should().BeTrue("the gate result must be captured for branching");
+        _flowchart.Connections.Any(c =>
+            c.Source.Activity.Id == "ExtractGateOutcome" &&
+            c.Target.Activity.Id == "GateOutcomeSwitch")
+            .Should().BeTrue("the cycle must branch on the gate outcome");
+    }
+
+    // ================================================================
+    // CRITICAL-1 — the cycle branches on the gate `outcome`. ONLY merge reaches
+    // WaitForPRMerged; reject/escalate reach loud terminals → no deadlock.
+    // ================================================================
+
+    [Test]
+    public void GateOutcomeSwitch_HasThreeCases_MergeRejectEscalated()
+    {
+        var sw = _flowchart.Activities
+            .OfType<FlowSwitch>()
+            .FirstOrDefault(fs => fs.Id == "GateOutcomeSwitch");
+
+        sw.Should().NotBeNull("the cycle must switch on the gate outcome");
+        var caseNames = sw!.Cases.Select(c => c.Label).ToList();
+        caseNames.Should().Contain("Merge");
+        caseNames.Should().Contain("Reject");
+        caseNames.Should().Contain("Escalated");
+    }
+
+    [Test]
+    public void GateOutcome_OnlyMerge_ReachesWaitForPRMerged()
+    {
+        // The merge outcome is the ONLY path to the merge-webhook wait.
+        _flowchart.Connections.Any(c =>
+            c.Source.Activity.Id == "GateOutcomeSwitch" &&
+            c.Source.Port == "Merge" &&
+            c.Target.Activity.Id == "WaitForPRMerged")
+            .Should().BeTrue("merge outcome must wait for the real merge webhook");
+
+        // Exactly one edge into WaitForPRMerged, and it is the merge case (no
+        // unconditional / non-merge edge can reach the hang point).
+        var intoWait = _flowchart.Connections
+            .Where(c => c.Target.Activity.Id == "WaitForPRMerged")
+            .ToList();
+        intoWait.Should().HaveCount(1, "only the merge outcome may reach WaitForPRMerged");
+        intoWait[0].Source.Activity.Id.Should().Be("GateOutcomeSwitch");
+        intoWait[0].Source.Port.Should().Be("Merge");
+    }
+
+    [Test]
+    public void GateOutcome_NonMerge_DoesNotReachWaitForPRMerged_NoDeadlock()
+    {
+        // The load-bearing no-deadlock guarantee: from a reject/escalate outcome
+        // the cycle must NOT be able to reach WaitForPRMerged (which blocks on a
+        // pr-merged webhook that never fires for a non-merge).
+        foreach (var port in new[] { "Reject", "Escalated" })
+        {
+            var reach = ReachableFromPort("GateOutcomeSwitch", port);
+            reach.Should().NotContain("WaitForPRMerged",
+                $"the '{port}' outcome must NEVER reach WaitForPRMerged (would hang forever)");
+        }
+
+        // reject → human-handoff terminal; escalated → error terminal (loud).
+        ReachableFromPort("GateOutcomeSwitch", "Reject").Should().Contain("ReportNeedsHuman",
+            "reject must reach the human-handoff terminal");
+        ReachableFromPort("GateOutcomeSwitch", "Escalated").Should().Contain("ReportError",
+            "escalated (incl. a failed merge) must reach the error terminal");
     }
 
     [Test]
@@ -395,6 +467,28 @@ public class SingleIssueCycleRoutingTests
             .Should().BeFalse("the binary approval gate is replaced by the merge-approval gate");
         _flowchart.Activities.Any(a => a.Id == "DispatchMerge")
             .Should().BeFalse("the fire-and-forget merge dispatch is now inside the merge-approval gate");
+    }
+
+    /// <summary>Forward-reachable activity ids starting from a specific
+    /// outcome port of a source node.</summary>
+    private HashSet<string> ReachableFromPort(string sourceId, string port)
+    {
+        var seen = new HashSet<string>();
+        var queue = new Queue<string>();
+        foreach (var c in _flowchart.Connections.Where(c =>
+            c.Source.Activity.Id == sourceId && c.Source.Port == port))
+        {
+            if (seen.Add(c.Target.Activity.Id)) queue.Enqueue(c.Target.Activity.Id);
+        }
+        while (queue.Count > 0)
+        {
+            var id = queue.Dequeue();
+            foreach (var c in _flowchart.Connections.Where(c => c.Source.Activity.Id == id))
+            {
+                if (c.Target.Activity.Id is { } t && seen.Add(t)) queue.Enqueue(t);
+            }
+        }
+        return seen;
     }
 
     private static string? ReadDefinitionId(DispatchWorkflow dispatch)

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/SingleIssueCycleRoutingTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/SingleIssueCycleRoutingTests.cs
@@ -342,4 +342,80 @@ public class SingleIssueCycleRoutingTests
         tddForTask!.TimeoutMinutes.Should().NotBeNull(
             "TimeoutMinutes input must be configured for the TDD task (30 minutes default)");
     }
+
+    // ================================================================
+    // Merge-Approval Gate wiring — the cycle now routes the merge step through
+    // the 3-way merge/test/reject gate (was an unwired skeleton)
+    // ================================================================
+
+    [Test]
+    public void TddLoopDone_DispatchesMergeApprovalGate()
+    {
+        // The merge step must run through the merge-approval gate sub-workflow,
+        // not the bare binary WaitForPRApprovalActivity it replaced.
+        var gate = _flowchart.Activities
+            .OfType<DispatchWorkflow>()
+            .FirstOrDefault(d => d.Id == "MergeApprovalGate");
+
+        gate.Should().NotBeNull("the cycle must dispatch the merge-approval gate");
+        ReadDefinitionId(gate!).Should().Be("merge-approval",
+            "the merge gate must dispatch the merge-approval workflow (previously orphaned)");
+
+        _flowchart.Connections.Any(c =>
+            c.Source.Activity.Id == "HasMoreTasks" &&
+            c.Source.Port == "False" &&
+            c.Target.Activity.Id == "MergeApprovalGate")
+            .Should().BeTrue("the gate must be entered when the TDD loop is done");
+    }
+
+    [Test]
+    public void MergeApprovalGate_WaitsForCompletion_ThenWaitsForMerged()
+    {
+        var gate = _flowchart.Activities
+            .OfType<DispatchWorkflow>()
+            .First(d => d.Id == "MergeApprovalGate");
+
+        // The cycle must block on the human decision + the gate's action, not race
+        // ahead fire-and-forget.
+        ReadWaitForCompletion(gate).Should().BeTrue(
+            "the cycle must wait for the merge-approval gate to complete");
+
+        _flowchart.Connections.Any(c =>
+            c.Source.Activity.Id == "MergeApprovalGate" &&
+            c.Target.Activity.Id == "WaitForPRMerged")
+            .Should().BeTrue("after the gate, the cycle still blocks on the merge webhook");
+    }
+
+    [Test]
+    public void OldBinaryApprovalGate_IsRetiredFromTheCycle()
+    {
+        // The prior bare WaitForPRApprovalActivity gate and its fire-and-forget
+        // "DispatchMerge" node must no longer be in the cycle — exactly one gate.
+        _flowchart.Activities.Any(a => a.Id == "WaitForPRApproval")
+            .Should().BeFalse("the binary approval gate is replaced by the merge-approval gate");
+        _flowchart.Activities.Any(a => a.Id == "DispatchMerge")
+            .Should().BeFalse("the fire-and-forget merge dispatch is now inside the merge-approval gate");
+    }
+
+    private static string? ReadDefinitionId(DispatchWorkflow dispatch)
+    {
+        var prop = typeof(DispatchWorkflow).GetProperty("WorkflowDefinitionId");
+        var value = prop?.GetValue(dispatch);
+        var expression = value?.GetType().GetProperty("Expression")?.GetValue(value)
+            as Elsa.Expressions.Models.Expression;
+        return expression?.Value?.ToString();
+    }
+
+    private static bool ReadWaitForCompletion(DispatchWorkflow dispatch)
+    {
+        // WaitForCompletion is an Input<bool> whose literal is carried on the
+        // expression value; a configured `new(true)` exposes "True"/"true"/True.
+        var value = dispatch.WaitForCompletion?.Expression?.Value;
+        return value switch
+        {
+            bool b => b,
+            string s => bool.TryParse(s, out var r) && r,
+            _ => false,
+        };
+    }
 }

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/WorkflowTestHelper.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/WorkflowTestHelper.cs
@@ -61,6 +61,13 @@ public static class WorkflowTestHelper
 
         mockBuilder.SetupGet(b => b.Variables).Returns(variables);
 
+        // WorkflowOptions — return a real, stable instance so workflows that set
+        // builder.WorkflowOptions.* (e.g. the merge-approval gate's
+        // IncidentStrategyType, SECURITY I1) don't NRE during Build(), and so the
+        // value is inspectable afterwards.
+        var workflowOptions = new WorkflowOptions();
+        mockBuilder.SetupGet(b => b.WorkflowOptions).Returns(workflowOptions);
+
         // WithVariable<T>() — no args
         mockBuilder.Setup(b => b.WithVariable<string>())
             .Returns(() => { var v = new Variable<string>(); variables.Add(v); return v; });

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/AdlEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/AdlEndpointsTests.cs
@@ -1,3 +1,5 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -5,14 +7,20 @@ using Moq;
 using NUnit.Framework;
 using Tamma.Api.Endpoints;
 using Tamma.Api.Services;
+using Tamma.Data;
 
 namespace Tamma.Api.Tests.Endpoints;
 
 /// <summary>
-/// IMPORTANT-2 — the RBAC-gated merge-approval resume surface
-/// (<c>POST /api/adl/merge-approval/resume</c>). Verifies the handler forwards a
-/// well-formed decision to <see cref="IElsaWorkflowService.ResumeMergeApprovalAsync"/>,
-/// validates input, and maps a "no gate waiting" engine response to 404.
+/// IMPORTANT-2 + SECURITY (C1 cross-tenant IDOR, I2 forged approver, MINOR
+/// decision validation) — the RBAC-gated merge-approval resume surface
+/// (<c>POST /api/adl/merge-approval/resume</c>). Verifies the handler:
+///   - forwards a well-formed decision to the engine with the caller's AMBIENT
+///     tenant id + repository so the engine can only resolve THIS tenant's gate;
+///   - derives the approver from the authenticated principal (a client-supplied
+///     approver is impossible — the request type carries none);
+///   - validates the decision against {merge,test,reject} and rejects junk 400;
+///   - maps a "no gate waiting" engine response (incl. a cross-tenant miss) to 404.
 /// </summary>
 [TestFixture]
 public class AdlEndpointsTests
@@ -26,21 +34,94 @@ public class AdlEndpointsTests
         _elsa = new Mock<IElsaWorkflowService>();
     }
 
-    [Test]
-    public async Task ResumeMergeApproval_ValidMerge_ForwardsAndInjectsPayload_Returns200()
+    /// <summary>A tenant context fixed to a given tenant (or ambient-null).</summary>
+    private static ITenantContext TenantContext(Guid? tenantId)
     {
+        var ctx = new Mock<ITenantContext>();
+        ctx.SetupGet(c => c.TenantId).Returns(tenantId);
+        return ctx.Object;
+    }
+
+    /// <summary>An authenticated principal carrying an email claim (the approver).</summary>
+    private static ClaimsPrincipal Principal(string email, string? sub = null)
+    {
+        var claims = new List<Claim> { new(JwtRegisteredClaimNames.Email, email) };
+        if (sub is not null) claims.Add(new Claim(JwtRegisteredClaimNames.Sub, sub));
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "test"));
+    }
+
+    [Test]
+    public async Task ResumeMergeApproval_ValidMerge_ForwardsTenantRepoAndDerivedApprover_Returns200()
+    {
+        var tenant = Guid.NewGuid();
         _elsa
-            .Setup(s => s.ResumeMergeApprovalAsync(42, 7, "merge", "lgtm", "alice"))
+            .Setup(s => s.ResumeMergeApprovalAsync(
+                42, 7, tenant.ToString(), "octo/repo", "merge", "lgtm", "alice@example.com"))
             .ReturnsAsync(new MergeApprovalResumeResult(Resumed: true, GateNotFound: false, WorkflowInstanceId: "wf-1"));
 
-        var req = new AdlEndpoints.MergeApprovalDecisionRequest(42, 7, "merge", "lgtm", "alice");
+        var req = new AdlEndpoints.MergeApprovalDecisionRequest(42, 7, "octo/repo", "merge", "lgtm");
 
-        var result = await AdlEndpoints.ResumeMergeApproval(req, _elsa.Object, _loggerFactory);
+        var result = await AdlEndpoints.ResumeMergeApproval(
+            req, _elsa.Object, TenantContext(tenant), Principal("alice@example.com"), _loggerFactory);
 
         StatusCodeOf(result).Should().Be(StatusCodes.Status200OK);
-        // The decision + approver + feedback must be forwarded verbatim so the gate
-        // can inject them as workflow input on resume.
-        _elsa.Verify(s => s.ResumeMergeApprovalAsync(42, 7, "merge", "lgtm", "alice"), Times.Once);
+        // The ambient tenant id + repository must be forwarded so the engine
+        // scopes the bookmark lookup; the approver must be the principal's email,
+        // NOT anything from the request body.
+        _elsa.Verify(s => s.ResumeMergeApprovalAsync(
+            42, 7, tenant.ToString(), "octo/repo", "merge", "lgtm", "alice@example.com"), Times.Once);
+    }
+
+    [Test]
+    public async Task ResumeMergeApproval_ApproverDerivedFromPrincipal_NotForgeable()
+    {
+        // I2 — even though the principal claims one identity, the engine must
+        // receive THAT identity as approver. The request type carries no approver
+        // field at all, so a client cannot forge it.
+        var tenant = Guid.NewGuid();
+        string? capturedApprover = null;
+        _elsa
+            .Setup(s => s.ResumeMergeApprovalAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<int, int, string?, string?, string, string?, string?>(
+                (_, _, _, _, _, _, approver) => capturedApprover = approver)
+            .ReturnsAsync(new MergeApprovalResumeResult(true, false, "wf-9"));
+
+        var req = new AdlEndpoints.MergeApprovalDecisionRequest(1, 2, "octo/repo", "reject", null);
+
+        await AdlEndpoints.ResumeMergeApproval(
+            req, _elsa.Object, TenantContext(tenant), Principal("bob@corp.test"), _loggerFactory);
+
+        capturedApprover.Should().Be("bob@corp.test",
+            "the approver must be derived from the authenticated principal for non-repudiation");
+    }
+
+    [Test]
+    public async Task ResumeMergeApproval_CrossTenantGate_Returns404_NeverActs()
+    {
+        // C1 — a caller in tenant A resumes with their ambient tenant id. Tenant
+        // B's gate lives under a different bookmark name, so the engine reports
+        // GateNotFound. The handler must surface 404 — it must NOT act on another
+        // tenant's gate. (We assert the handler forwards the CALLER's tenant id,
+        // never the victim's, and maps the miss to 404.)
+        var callerTenant = Guid.NewGuid();
+        _elsa
+            .Setup(s => s.ResumeMergeApprovalAsync(
+                5, 5, callerTenant.ToString(), "victim/repo", "merge", null, It.IsAny<string?>()))
+            .ReturnsAsync(new MergeApprovalResumeResult(Resumed: false, GateNotFound: true, WorkflowInstanceId: null));
+
+        var req = new AdlEndpoints.MergeApprovalDecisionRequest(5, 5, "victim/repo", "merge", null);
+
+        var result = await AdlEndpoints.ResumeMergeApproval(
+            req, _elsa.Object, TenantContext(callerTenant), Principal("attacker@evil.test"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status404NotFound,
+            "a cross-tenant resume must be a not-found, never an action on the victim's gate");
+        _elsa.Verify(s => s.ResumeMergeApprovalAsync(
+            5, 5, callerTenant.ToString(), "victim/repo", "merge", null, It.IsAny<string?>()), Times.Once);
+        // The caller's tenant id was used — there is no path that forwards a
+        // different (victim) tenant id.
     }
 
     [Test]
@@ -48,12 +129,14 @@ public class AdlEndpointsTests
     {
         _elsa
             .Setup(s => s.ResumeMergeApprovalAsync(It.IsAny<int>(), It.IsAny<int>(),
-                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()))
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string>(),
+                It.IsAny<string?>(), It.IsAny<string?>()))
             .ReturnsAsync(new MergeApprovalResumeResult(Resumed: false, GateNotFound: true, WorkflowInstanceId: null));
 
-        var req = new AdlEndpoints.MergeApprovalDecisionRequest(1, 2, "reject", null, null);
+        var req = new AdlEndpoints.MergeApprovalDecisionRequest(1, 2, "octo/repo", "reject", null);
 
-        var result = await AdlEndpoints.ResumeMergeApproval(req, _elsa.Object, _loggerFactory);
+        var result = await AdlEndpoints.ResumeMergeApproval(
+            req, _elsa.Object, TenantContext(Guid.NewGuid()), Principal("a@b.test"), _loggerFactory);
 
         StatusCodeOf(result).Should().Be(StatusCodes.Status404NotFound,
             "a resume for a gate that is not suspended must 404, not 500");
@@ -62,28 +145,80 @@ public class AdlEndpointsTests
     [Test]
     public async Task ResumeMergeApproval_EmptyDecision_Returns400_NoForward()
     {
-        var req = new AdlEndpoints.MergeApprovalDecisionRequest(1, 2, "   ", null, null);
+        var req = new AdlEndpoints.MergeApprovalDecisionRequest(1, 2, "octo/repo", "   ", null);
 
-        var result = await AdlEndpoints.ResumeMergeApproval(req, _elsa.Object, _loggerFactory);
+        var result = await AdlEndpoints.ResumeMergeApproval(
+            req, _elsa.Object, TenantContext(Guid.NewGuid()), Principal("a@b.test"), _loggerFactory);
 
         StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest);
-        _elsa.Verify(s => s.ResumeMergeApprovalAsync(
-            It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()),
-            Times.Never, "an empty decision must be rejected up front, not escalated silently");
+        VerifyNeverForwarded();
+    }
+
+    [TestCase("approve")]
+    [TestCase("yes")]
+    [TestCase("delete")]
+    [TestCase("merge; drop table")]
+    public async Task ResumeMergeApproval_UnknownDecision_Returns400_NoForward(string decision)
+    {
+        // MINOR — an arbitrary decision string must be rejected up front, never
+        // forwarded to silently escalate at the gate.
+        var req = new AdlEndpoints.MergeApprovalDecisionRequest(1, 2, "octo/repo", decision, null);
+
+        var result = await AdlEndpoints.ResumeMergeApproval(
+            req, _elsa.Object, TenantContext(Guid.NewGuid()), Principal("a@b.test"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest,
+            "only merge|test|reject are accepted");
+        VerifyNeverForwarded();
     }
 
     [Test]
     public async Task ResumeMergeApproval_NonPositiveIssueOrPr_Returns400()
     {
-        var req = new AdlEndpoints.MergeApprovalDecisionRequest(0, 0, "merge", null, null);
+        var req = new AdlEndpoints.MergeApprovalDecisionRequest(0, 0, "octo/repo", "merge", null);
 
-        var result = await AdlEndpoints.ResumeMergeApproval(req, _elsa.Object, _loggerFactory);
+        var result = await AdlEndpoints.ResumeMergeApproval(
+            req, _elsa.Object, TenantContext(Guid.NewGuid()), Principal("a@b.test"), _loggerFactory);
 
         StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest);
-        _elsa.Verify(s => s.ResumeMergeApprovalAsync(
-            It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()),
-            Times.Never);
+        VerifyNeverForwarded();
     }
+
+    [Test]
+    public async Task ResumeMergeApproval_MissingRepository_Returns400()
+    {
+        var req = new AdlEndpoints.MergeApprovalDecisionRequest(1, 2, "   ", "merge", null);
+
+        var result = await AdlEndpoints.ResumeMergeApproval(
+            req, _elsa.Object, TenantContext(Guid.NewGuid()), Principal("a@b.test"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest,
+            "repository is part of the bookmark scope and must be supplied");
+        VerifyNeverForwarded();
+    }
+
+    [Test]
+    public void ResolveApprover_PrefersEmail_ThenName_ThenSub()
+    {
+        AdlEndpoints.ResolveApprover(Principal("e@x.test", sub: "sub-1")).Should().Be("e@x.test");
+
+        var nameOnly = new ClaimsPrincipal(new ClaimsIdentity(
+            new[] { new Claim("name", "Carol"), new Claim(JwtRegisteredClaimNames.Sub, "sub-2") }, "test"));
+        AdlEndpoints.ResolveApprover(nameOnly).Should().Be("Carol");
+
+        var subOnly = new ClaimsPrincipal(new ClaimsIdentity(
+            new[] { new Claim(JwtRegisteredClaimNames.Sub, "sub-3") }, "test"));
+        AdlEndpoints.ResolveApprover(subOnly).Should().Be("sub-3");
+
+        AdlEndpoints.ResolveApprover(new ClaimsPrincipal(new ClaimsIdentity()))
+            .Should().Be("unknown");
+    }
+
+    private void VerifyNeverForwarded() =>
+        _elsa.Verify(s => s.ResumeMergeApprovalAsync(
+            It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<string?>(),
+            It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()),
+            Times.Never, "invalid input must be rejected up front, not forwarded");
 
     /// <summary>Read the HTTP status code off any minimal-API result (typed
     /// results implement IStatusCodeHttpResult).</summary>

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/AdlEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/AdlEndpointsTests.cs
@@ -1,0 +1,92 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Services;
+
+namespace Tamma.Api.Tests.Endpoints;
+
+/// <summary>
+/// IMPORTANT-2 — the RBAC-gated merge-approval resume surface
+/// (<c>POST /api/adl/merge-approval/resume</c>). Verifies the handler forwards a
+/// well-formed decision to <see cref="IElsaWorkflowService.ResumeMergeApprovalAsync"/>,
+/// validates input, and maps a "no gate waiting" engine response to 404.
+/// </summary>
+[TestFixture]
+public class AdlEndpointsTests
+{
+    private Mock<IElsaWorkflowService> _elsa = null!;
+    private readonly NullLoggerFactory _loggerFactory = NullLoggerFactory.Instance;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _elsa = new Mock<IElsaWorkflowService>();
+    }
+
+    [Test]
+    public async Task ResumeMergeApproval_ValidMerge_ForwardsAndInjectsPayload_Returns200()
+    {
+        _elsa
+            .Setup(s => s.ResumeMergeApprovalAsync(42, 7, "merge", "lgtm", "alice"))
+            .ReturnsAsync(new MergeApprovalResumeResult(Resumed: true, GateNotFound: false, WorkflowInstanceId: "wf-1"));
+
+        var req = new AdlEndpoints.MergeApprovalDecisionRequest(42, 7, "merge", "lgtm", "alice");
+
+        var result = await AdlEndpoints.ResumeMergeApproval(req, _elsa.Object, _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status200OK);
+        // The decision + approver + feedback must be forwarded verbatim so the gate
+        // can inject them as workflow input on resume.
+        _elsa.Verify(s => s.ResumeMergeApprovalAsync(42, 7, "merge", "lgtm", "alice"), Times.Once);
+    }
+
+    [Test]
+    public async Task ResumeMergeApproval_GateNotWaiting_Returns404()
+    {
+        _elsa
+            .Setup(s => s.ResumeMergeApprovalAsync(It.IsAny<int>(), It.IsAny<int>(),
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(new MergeApprovalResumeResult(Resumed: false, GateNotFound: true, WorkflowInstanceId: null));
+
+        var req = new AdlEndpoints.MergeApprovalDecisionRequest(1, 2, "reject", null, null);
+
+        var result = await AdlEndpoints.ResumeMergeApproval(req, _elsa.Object, _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status404NotFound,
+            "a resume for a gate that is not suspended must 404, not 500");
+    }
+
+    [Test]
+    public async Task ResumeMergeApproval_EmptyDecision_Returns400_NoForward()
+    {
+        var req = new AdlEndpoints.MergeApprovalDecisionRequest(1, 2, "   ", null, null);
+
+        var result = await AdlEndpoints.ResumeMergeApproval(req, _elsa.Object, _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest);
+        _elsa.Verify(s => s.ResumeMergeApprovalAsync(
+            It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()),
+            Times.Never, "an empty decision must be rejected up front, not escalated silently");
+    }
+
+    [Test]
+    public async Task ResumeMergeApproval_NonPositiveIssueOrPr_Returns400()
+    {
+        var req = new AdlEndpoints.MergeApprovalDecisionRequest(0, 0, "merge", null, null);
+
+        var result = await AdlEndpoints.ResumeMergeApproval(req, _elsa.Object, _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest);
+        _elsa.Verify(s => s.ResumeMergeApprovalAsync(
+            It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()),
+            Times.Never);
+    }
+
+    /// <summary>Read the HTTP status code off any minimal-API result (typed
+    /// results implement IStatusCodeHttpResult).</summary>
+    private static int? StatusCodeOf(IResult result)
+        => (result as IStatusCodeHttpResult)?.StatusCode;
+}

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -21,9 +21,14 @@ JWT_SECRET=change-me-to-a-random-string
 # Required when oauth2-proxy is enabled; leave empty to skip oauth2-proxy.
 OAUTH2_PROXY_COOKIE_SECRET=
 
-# ELSA admin API key — injected by nginx into ELSA Server API requests.
-# Must match the API key configured in ELSA Server (Elsa__Identity__ApiKey).
-ELSA_ADMIN_API_KEY=
+# ELSA admin API key — presented as `Authorization: ApiKey <key>` on requests to
+# the ELSA Server API. Used in two places: (1) nginx injects it on proxied
+# /elsa/api/ requests, and (2) Tamma.Api presents it on its direct container-to-
+# container hop to the engine (Elsa__ApiKey), which the engine's merge-approval
+# resume seam now requires (SECURITY C3). The engine runs UseAdminApiKey(), whose
+# AdminApiKeyProvider accepts ONLY the all-zero GUID, so set this to:
+#   00000000-0000-0000-0000-000000000000
+ELSA_ADMIN_API_KEY=00000000-0000-0000-0000-000000000000
 
 # Service-to-service API key for internal calls (Elsa → tamma-api, tamma-api-dotnet → tamma-api).
 # Generate via admin API: POST /api/admin/service-keys { serviceName: "elsa-server" }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -184,6 +184,14 @@ services:
       ConnectionStrings__TammaDb: "Host=postgres;Port=5432;Database=${POSTGRES_DB:-tamma};Username=${POSTGRES_USER:-tamma};Password=${POSTGRES_PASSWORD}"
       ConnectionStrings__TammaAppDb: "Host=postgres;Port=5432;Database=${POSTGRES_DB:-tamma};Username=tamma_app;Password=${TAMMA_APP_DB_PASSWORD:-}"
       ElsaServer__Url: http://elsa-server:5000
+      # Tamma.Api → Elsa engine hop (ElsaWorkflowService reads Elsa:ServerUrl /
+      # Elsa:ApiKey). The hop goes container-to-container, bypassing nginx.
+      Elsa__ServerUrl: http://elsa-server:5000
+      # SECURITY C3 — the engine's merge-approval resume seam now requires an
+      # authenticated caller. The legitimate hop authenticates by presenting the
+      # Elsa admin API key (Authorization: ApiKey ...). Must equal the key the
+      # engine accepts (the same value nginx injects as ELSA_ADMIN_API_KEY).
+      Elsa__ApiKey: ${ELSA_ADMIN_API_KEY:-}
       TAMMA_SERVICE_API_KEY: ${TAMMA_SERVICE_API_KEY:-}
       Jwt__Secret: ${JWT_SECRET:-tamma-internal-jwt-secret-change-in-production}
       GitHub__AppId: ${GITHUB_APP_ID:?GITHUB_APP_ID is required}

--- a/docker/nginx-proxy.conf.template
+++ b/docker/nginx-proxy.conf.template
@@ -282,6 +282,19 @@ server {
         return 302 /oauth2/start?rd=$scheme://$http_host$request_uri;
     }
 
+    # ----- SECURITY C3 — internal-hop-only ADL control surface -----
+    # The merge-approval resume seam (POST /elsa/api/adl/merge-approval/resume)
+    # can drive a real merge. It is reached ONLY container-to-container by the
+    # Tamma.Api→engine hop (http://elsa-server:5000), which presents the Elsa
+    # admin API key directly — it must NEVER be reachable from the public
+    # internet. The general /elsa/api/ block below injects the admin API key for
+    # any dashboard admin/owner (of ANY tenant) who can pass /auth/role-check,
+    # which would let them bypass Tamma.Api's tenant scoping entirely. This more
+    # specific prefix wins nginx's longest-match and hard-blocks the path.
+    location /elsa/api/adl/ {
+        return 404;
+    }
+
     # ----- ELSA Server API: RBAC-gated, API key injected -----
     location /elsa/api/ {
         auth_request /auth/role-check;


### PR DESCRIPTION
## What

Builds out the `MergeApprovalWorkflow` from a thin unwired skeleton to a complete gate **and wires it into the autonomous loop** (`SingleIssueCycleWorkflow`'s merge step), also dispatching `ci-with-debug-retry` on the Test path.

The gate: approve→merge / test→CI→re-decide / reject / escalate, with explicit failure edges (no false success), durable DCB events via the drain, `tenantId` threading, and a resumable bookmark.

## Why this PR is large — two review rounds caught serious bugs (all passed their functional tests)

**Round 1 (deadlocks in the autonomous loop):** the initial wiring would have hung the loop forever — reject/invalid → waits on a merge webhook that never fires; a failed merge swallowed → same hang; unbounded test loop. Fixed: the cycle now branches on the gate outcome (only `merge` → `WaitForPRMerged`; reject/escalate → loud terminal), with **BFS reachability tests** proving non-merge can't reach the merge-wait; merge-failure is surfaced loudly (also hardened `MergeWorkflow` to stop swallowing its `Error`); the test loop is iteration-capped.

**Round 2 (multi-tenant security on the new resume endpoint):** the resume surface was a cross-tenant, internet-facing control hole. Fixed:
- **Cross-tenant IDOR** → the bookmark is tenant+repo scoped (`adl-merge-approval-{tenant}-{repo}-{issue}-{pr}`); a cross-tenant resume 404s, mirroring the existing "audit finding 016" guard.
- **Bookmark collision** → canonical name builder + the engine refuses (409) on ambiguity instead of resuming an arbitrary instance.
- **Unauthenticated public engine endpoint** → `.RequireAuthorization()` (admin API key) + removed from the public nginx route (`location /elsa/api/adl/ { return 404; }`); the API→engine hop authenticates via `Elsa:ApiKey` (wired in docker-compose).
- **Forgeable approver** → derived from the authenticated principal, not caller input.
- A faulted gate now fails closed to `escalate` (→ `reportError`) instead of stranding the issue.

## Verification
- Build 0 errors; `has-pending-model-changes` clean (no new entity).
- Full `Tamma.Activities.Tests` **1385/0**, `Tamma.Api.Tests` **3674/0**; new tests cover the no-deadlock routing, the loop cap, merge-failure → escalate, cross-tenant denial, engine auth, bookmark uniqueness, approver-from-principal, decision validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)