### PR TITLE
feat(workflows): build out UpdateIssueStatus — explicit failure path + durable events

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitIssueStatusEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitIssueStatusEventActivity.cs
@@ -1,0 +1,130 @@
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+
+namespace Tamma.Activities.ADL;
+
+/// <summary>
+/// Emits an <c>ISSUE_STATUS.*</c> DCB event (Epic 4 audit trail) for the
+/// built-out <c>update-issue-status</c> workflow by appending a
+/// <see cref="TammaEvent"/> to the workflow's <c>tamma:events</c> transient list
+/// via <see cref="TammaEventEmitter.Emit"/>. The merged engine event drain
+/// (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) flushes that list
+/// <i>durably</i> to the tenant <c>domain_events</c> store after this activity
+/// runs — the drain resolves the tenant from the workflow scope (this workflow
+/// stamps a <c>TenantId</c> variable). The event therefore persists without this
+/// activity holding any DB / repository dependency of its own (none is registered
+/// in the Elsa engine — a directly-injected <c>IEventRepository</c> would be
+/// inert and silently drop the event, the same trap the PR exemplar avoids).
+///
+/// <para>Critically, the FAILED event ACTUALLY fires on a real callback failure
+/// (the activity surfaces a <c>Failed</c> outcome that the workflow routes here),
+/// closing the headline swallow-failure bug where a failed update was recorded as
+/// <c>.COMPLETED</c>.</para>
+/// </summary>
+[Activity(
+    "Tamma.ADL",
+    "Emit Issue Status Event",
+    "Emit an ISSUE_STATUS.UPDATED.SUCCESS / .FAILED DCB event for the audit trail",
+    Kind = ActivityKind.Task
+)]
+public class EmitIssueStatusEventActivity : Activity
+{
+    private readonly ILogger<EmitIssueStatusEventActivity>? _logger;
+
+    [Input(Description = "Event type — ISSUE_STATUS.UPDATED.SUCCESS or .FAILED")]
+    public Input<string> EventType { get; set; } = default!;
+
+    [Input(Description = "Issue number")]
+    public Input<int> IssueNumber { get; set; } = default!;
+
+    [Input(Description = "Repository in owner/repo format")]
+    public Input<string> Repository { get; set; } = default!;
+
+    [Input(Description = "Tenant id (empty / single-user → platform-scope event)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [Input(Description = "Event data payload as JSON (message, addLabels, removeLabels, degraded, error, errorCode, durationMs)")]
+    public Input<string?> DataJson { get; set; } = new((string?)null);
+
+    [JsonConstructor]
+    public EmitIssueStatusEventActivity() { }
+
+    public EmitIssueStatusEventActivity(ILogger<EmitIssueStatusEventActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var type = EventType.Get(context) ?? IssueStatusEvents.UpdatedFailed;
+        var issueNumber = IssueNumber.Get(context);
+        var repository = Repository.Get(context) ?? "";
+        var tenantId = IssueStatusEvents.ParseTenantId(TenantId.Get(context));
+        var data = ParseData(DataJson.Get(context));
+
+        var evt = BuildTammaEvent(type, issueNumber, repository, tenantId, data);
+        TammaEventEmitter.Emit(context, this, _logger, evt);
+
+        _logger?.LogInformation(
+            "Emitted {Type} for issue #{Issue} in {Repo}", type, issueNumber, repository);
+
+        return default;
+    }
+
+    /// <summary>
+    /// Map the issue-status event inputs onto a <see cref="TammaEvent"/> expressed
+    /// as the engine's transient-list event so the merged drain persists it. Tags
+    /// carry the queryable DCB index keys (<c>issueId</c>/<c>issueNumber</c>/
+    /// <c>repository</c>/<c>tenantId</c>); <c>Data</c> carries the operation
+    /// payload (key-free — no token). Pure (no Elsa context); exposed for testing.
+    /// </summary>
+    public static TammaEvent BuildTammaEvent(
+        string type,
+        int issueNumber,
+        string repository,
+        Guid? tenantId,
+        IReadOnlyDictionary<string, object?>? data)
+    {
+        var tags = new Dictionary<string, object?>
+        {
+            ["issueId"] = issueNumber.ToString(),
+            ["issueNumber"] = issueNumber.ToString(),
+            ["repository"] = repository,
+        };
+        if (tenantId is not null) tags["tenantId"] = tenantId.Value.ToString("D");
+
+        return new TammaEvent
+        {
+            EventType = type,
+            Status = type == IssueStatusEvents.UpdatedFailed ? "error" : "success",
+            Tags = tags,
+            Data = data is null
+                ? new Dictionary<string, object?>()
+                : new Dictionary<string, object?>(data),
+        };
+    }
+
+    /// <summary>
+    /// Deserialize the JSON data payload into a dictionary for the event builder.
+    /// Returns null on empty/malformed input (the event still emits with "{}").
+    /// Exposed for unit testing the parse path.
+    /// </summary>
+    public static IReadOnlyDictionary<string, object?>? ParseData(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+        try
+        {
+            return System.Text.Json.JsonSerializer
+                .Deserialize<Dictionary<string, object?>>(json);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitIssueStatusEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitIssueStatusEventActivity.cs
@@ -98,6 +98,12 @@ public class EmitIssueStatusEventActivity : Activity
         };
         if (tenantId is not null) tags["tenantId"] = tenantId.Value.ToString("D");
 
+        // A degraded (callback-unavailable) no-op still emits a SUCCESS event. Lift
+        // the degraded flag from Data into a QUERYABLE tag so a consumer filtering
+        // on event TYPE can exclude these no-ops — otherwise a degrade reads as a
+        // genuine success (the Data-only flag is non-indexed). Kept in Data too.
+        if (IsDegraded(data)) tags["degraded"] = "true";
+
         return new TammaEvent
         {
             EventType = type,
@@ -106,6 +112,26 @@ public class EmitIssueStatusEventActivity : Activity
             Data = data is null
                 ? new Dictionary<string, object?>()
                 : new Dictionary<string, object?>(data),
+        };
+    }
+
+    /// <summary>
+    /// True when the event payload flags a degraded no-op. Tolerates both a direct
+    /// <see cref="bool"/> (in-process dictionary) and a <see cref="JsonElement"/>
+    /// (the payload arrives via <see cref="ParseData"/> in the running workflow).
+    /// </summary>
+    private static bool IsDegraded(IReadOnlyDictionary<string, object?>? data)
+    {
+        if (data is null || !data.TryGetValue("degraded", out var raw) || raw is null)
+            return false;
+        return raw switch
+        {
+            bool b => b,
+            System.Text.Json.JsonElement je => je.ValueKind == System.Text.Json.JsonValueKind.True
+                || (je.ValueKind == System.Text.Json.JsonValueKind.String
+                    && bool.TryParse(je.GetString(), out var pb) && pb),
+            string s => bool.TryParse(s, out var sb) && sb,
+            _ => false,
         };
     }
 

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/IssueCallbackClient.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/IssueCallbackClient.cs
@@ -1,0 +1,83 @@
+using System.Net.Http.Json;
+
+namespace Tamma.Activities.ADL;
+
+/// <summary>
+/// Thin seam over the engine issue callbacks (<c>POST /api/engine/issue-comment</c>,
+/// <c>POST /api/engine/issue-labels</c>, <c>DELETE /api/engine/issue-labels/...</c>)
+/// used by <see cref="UpdateIssueStatusActivity"/>. Extracting the I/O behind an
+/// interface lets the activity's <c>ExecuteCoreAsync</c> orchestration (retry,
+/// outcome mapping, no-false-success) be unit-tested against a mock without a
+/// live HTTP endpoint or Octokit. The default implementation
+/// (<see cref="HttpIssueCallbackClient"/>) preserves the existing engine-callback
+/// integration path — steps still never call a vendor API directly.
+///
+/// <para>Each method returns the typed callback result so a failure surfaces as a
+/// loud <c>!Success</c> rather than a swallowed exception. The single label-add
+/// call is atomic; each label-remove is independent so a partial label failure
+/// does not force the comment to be re-posted (duplicate-comment hazard).</para>
+/// </summary>
+public interface IIssueCallbackClient
+{
+    Task<IssueCallbackResult> PostCommentAsync(string repository, int issueNumber, string body, CancellationToken ct = default);
+    Task<IssueCallbackResult> AddLabelsAsync(string repository, int issueNumber, string[] labels, CancellationToken ct = default);
+    Task<IssueCallbackResult> RemoveLabelAsync(string repository, int issueNumber, string label, CancellationToken ct = default);
+}
+
+/// <summary>Typed result of a single engine issue callback. Never throws — a
+/// transport / non-2xx failure becomes <c>Success=false</c> with a reason.</summary>
+public sealed record IssueCallbackResult(bool Success, string? Error = null)
+{
+    public static IssueCallbackResult Ok() => new(true);
+    public static IssueCallbackResult Fail(string error) => new(false, error);
+}
+
+/// <summary>
+/// Default <see cref="IIssueCallbackClient"/> — calls the existing
+/// <c>/api/engine/*</c> callback endpoints via <see cref="IHttpClientFactory"/>,
+/// using the configured <c>Engine:CallbackUrl</c>. This is the transitional
+/// integration path the build-out keeps (no new direct vendor calls); Story 38-1
+/// later re-points this at the <c>PATCH /api/v1/git/{repo}/issues/{n}</c>
+/// git-mediation endpoint.
+/// </summary>
+public sealed class HttpIssueCallbackClient : IIssueCallbackClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _baseUrl;
+
+    public HttpIssueCallbackClient(HttpClient httpClient, string callbackUrl)
+    {
+        _httpClient = httpClient;
+        _baseUrl = callbackUrl.TrimEnd('/');
+    }
+
+    public async Task<IssueCallbackResult> PostCommentAsync(string repository, int issueNumber, string body, CancellationToken ct = default)
+    {
+        var response = await _httpClient.PostAsJsonAsync(
+            $"{_baseUrl}/api/engine/issue-comment",
+            new { repository, issueNumber, body }, ct).ConfigureAwait(false);
+        return response.IsSuccessStatusCode
+            ? IssueCallbackResult.Ok()
+            : IssueCallbackResult.Fail($"issue-comment {(int)response.StatusCode}");
+    }
+
+    public async Task<IssueCallbackResult> AddLabelsAsync(string repository, int issueNumber, string[] labels, CancellationToken ct = default)
+    {
+        var response = await _httpClient.PostAsJsonAsync(
+            $"{_baseUrl}/api/engine/issue-labels",
+            new { repository, issueNumber, labels }, ct).ConfigureAwait(false);
+        return response.IsSuccessStatusCode
+            ? IssueCallbackResult.Ok()
+            : IssueCallbackResult.Fail($"issue-labels {(int)response.StatusCode}");
+    }
+
+    public async Task<IssueCallbackResult> RemoveLabelAsync(string repository, int issueNumber, string label, CancellationToken ct = default)
+    {
+        var response = await _httpClient.DeleteAsync(
+            $"{_baseUrl}/api/engine/issue-labels/{Uri.EscapeDataString(repository)}/{issueNumber}/{Uri.EscapeDataString(label)}",
+            ct).ConfigureAwait(false);
+        return response.IsSuccessStatusCode
+            ? IssueCallbackResult.Ok()
+            : IssueCallbackResult.Fail($"issue-labels-delete {(int)response.StatusCode}");
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/IssueStatusEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/IssueStatusEvents.cs
@@ -1,0 +1,41 @@
+namespace Tamma.Activities.ADL;
+
+/// <summary>
+/// Central catalogue of <c>ISSUE_STATUS.*</c> DCB event types emitted by the
+/// built-out <c>update-issue-status</c> workflow via
+/// <see cref="EmitIssueStatusEventActivity"/>.
+///
+/// <para>The status-update step is issue-scoped, so the events land in the
+/// tenant <c>domain_events</c> store (which carries a first-class
+/// <c>IssueNumber</c> column). They are emitted via
+/// <c>TammaEventEmitter.Emit</c> into the workflow's <c>tamma:events</c>
+/// transient list and persisted durably by the engine event drain
+/// (<c>EventPersistenceMiddleware</c>) — see
+/// <see cref="EmitIssueStatusEventActivity.BuildTammaEvent"/> for the DCB
+/// mapping (tags carry <c>issueId</c>/<c>issueNumber</c>/<c>repository</c>/
+/// <c>tenantId</c>; data carries the operation payload).</para>
+///
+/// <list type="bullet">
+///   <item><description><c>ISSUE_STATUS.UPDATED.SUCCESS</c> — the status
+///     comment / label update (and, when supplied, the close transition) was
+///     applied.</description></item>
+///   <item><description><c>ISSUE_STATUS.UPDATED.FAILED</c> — the update failed
+///     after retries (callback error / API failure). ALWAYS emitted on the
+///     failure edge so the loop never reports a silent false success — closes
+///     the headline swallow-failure bug.</description></item>
+/// </list>
+/// </summary>
+public static class IssueStatusEvents
+{
+    public const string UpdatedSuccess = "ISSUE_STATUS.UPDATED.SUCCESS";
+    public const string UpdatedFailed = "ISSUE_STATUS.UPDATED.FAILED";
+
+    /// <summary>
+    /// Parse a tenant id from the loose string form threaded through the
+    /// workflow inputs. Returns <c>null</c> for empty / single-user /
+    /// unparseable values (status events in single-user mode are
+    /// platform-scope, TenantId null).
+    /// </summary>
+    public static Guid? ParseTenantId(string? tenantId)
+        => Guid.TryParse(tenantId, out var g) ? g : null;
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/UpdateIssueStatusActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/UpdateIssueStatusActivity.cs
@@ -1,30 +1,46 @@
-using System.Net.Http.Json;
+using System.Text;
 using System.Text.Json.Serialization;
 using Elsa.Extensions;
 using Elsa.Workflows;
+using Elsa.Workflows.Activities.Flowchart.Attributes;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Tamma.Activities.Core;
 
 namespace Tamma.Activities.ADL;
 
 /// <summary>
-/// Posts a status update comment on the GitHub issue.
-/// Used after every step in SingleIssueCycle to keep the issue
-/// as a living log of what Tamma is doing.
+/// Updates a GitHub issue during the autonomous cycle: posts a status comment,
+/// adds / removes labels and (when supplied) composes a PR-linked close comment,
+/// keeping the issue a "living log" of what Tamma is doing.
+///
+/// <para>Story 2.10 build-out: this activity used to <b>swallow</b> a failed
+/// status update — after 3 failed attempts it logged a WARN and returned
+/// normally, so the workflow always reported success even when nothing was
+/// posted (a false-success / silent-failure violation). It is now an
+/// <b>outcome-bearing</b> activity: a genuine callback failure surfaces a loud
+/// <c>Failed</c> outcome (the workflow routes it to a failure edge that emits
+/// <c>ISSUE_STATUS.UPDATED.FAILED</c>); a successful (or degraded local-no-op)
+/// update surfaces <c>Updated</c>. It never reports success on a real failure.</para>
+///
+/// Outcomes:
+///   - Updated: the update was applied (or degraded to a local no-op when no
+///     engine callback is configured — flagged <c>degraded</c>, nothing failed).
+///   - Failed:  the configured callback failed after retries (loud failure).
 /// </summary>
 [Activity(
     "Tamma.ADL",
     "Update Issue Status",
-    "Post a status comment on the GitHub issue",
+    "Update a GitHub issue: status comment, labels, and PR-linked close",
     Kind = ActivityKind.Task
 )]
-public class UpdateIssueStatusActivity : TammaAsyncActivity
+[FlowNode("Updated", "Failed")]
+public class UpdateIssueStatusActivity : Activity
 {
-    public override string? EventType => "CYCLE.ISSUE.UPDATE";
+    private const int MaxAttempts = 3;
 
+    private readonly ILogger<UpdateIssueStatusActivity>? _logger;
     private readonly IHttpClientFactory? _httpClientFactory;
     private readonly IConfiguration? _configuration;
 
@@ -38,10 +54,31 @@ public class UpdateIssueStatusActivity : TammaAsyncActivity
     public Input<string> Message { get; set; } = default!;
 
     [Input(Description = "Optional labels to add")]
-    public Input<string[]?> AddLabels { get; set; } = default!;
+    public Input<string[]?> AddLabels { get; set; } = new((string[]?)null);
 
     [Input(Description = "Optional labels to remove")]
-    public Input<string[]?> RemoveLabels { get; set; } = default!;
+    public Input<string[]?> RemoveLabels { get; set; } = new((string[]?)null);
+
+    [Input(Description = "Tenant id (empty / single-user → platform-scope event)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [Input(Description = "Merged-PR number to link in the close comment (0 → no link)")]
+    public Input<int> PrNumber { get; set; } = new(0);
+
+    [Input(Description = "Merged-PR URL to link in the close comment (empty → no link)")]
+    public Input<string?> PrUrl { get; set; } = new((string?)null);
+
+    [Output(Description = "True when the update was applied / degraded (no real failure)")]
+    public Output<bool> Updated { get; set; } = default!;
+
+    [Output(Description = "True when the update degraded to a local no-op (no callback configured)")]
+    public Output<bool> Degraded { get; set; } = default!;
+
+    [Output(Description = "Failure classification when the Failed outcome fires")]
+    public Output<string?> ErrorCode { get; set; } = default!;
+
+    [Output(Description = "Human-readable error reason when the Failed outcome fires")]
+    public Output<string?> Error { get; set; } = default!;
 
     [JsonConstructor]
     public UpdateIssueStatusActivity() { }
@@ -51,84 +88,196 @@ public class UpdateIssueStatusActivity : TammaAsyncActivity
         IHttpClientFactory httpClientFactory,
         IConfiguration configuration)
     {
-        Logger = logger;
+        _logger = logger;
         _httpClientFactory = httpClientFactory;
         _configuration = configuration;
     }
 
-    protected override async Task RunAsync(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
         var repo = Repository.Get(context);
         var issueNum = IssueNumber.Get(context);
-        var message = Message.Get(context);
+        var message = Message.Get(context) ?? "";
         var addLabels = AddLabels.Get(context);
         var removeLabels = RemoveLabels.Get(context);
+        var prNumber = PrNumber.Get(context);
+        var prUrl = PrUrl.Get(context);
+
+        var body = ComposeBody(message, prNumber, prUrl);
 
         var callbackUrl = _configuration?["Engine:CallbackUrl"];
-        if (string.IsNullOrEmpty(callbackUrl) || _httpClientFactory == null)
+        if (string.IsNullOrEmpty(callbackUrl) || _httpClientFactory is null)
         {
-            Logger?.LogInformation("[Issue #{IssueNumber}] {Message}", issueNum, message);
+            // Degraded local/dev no-op: log and report a flagged success.
+            // Nothing was attempted against a platform, so this is NOT a failure —
+            // it is an auditable degrade (Degraded=true), never a false success.
+            _logger?.LogInformation("[Issue #{IssueNumber}] {Message}", issueNum, body);
+            SetSuccess(context, degraded: true);
+            await context.CompleteActivityWithOutcomesAsync("Updated");
             return;
         }
 
-        var httpClient = _httpClientFactory.CreateClient();
-        var baseUrl = callbackUrl.TrimEnd('/');
+        var client = new HttpIssueCallbackClient(_httpClientFactory.CreateClient(), callbackUrl);
+        var outcome = await ExecuteCoreAsync(client, repo, issueNum, body, addLabels, removeLabels, _logger, context.CancellationToken);
 
-        // Retry with backoff: 1s, 2s, 4s
-        for (var attempt = 0; attempt < 3; attempt++)
+        if (outcome.Success)
         {
-            try
-            {
-                // Post comment
-                var commentPayload = new
-                {
-                    repository = repo,
-                    issueNumber = issueNum,
-                    body = message,
-                };
-                var response = await httpClient.PostAsJsonAsync(
-                    $"{baseUrl}/api/engine/issue-comment", commentPayload);
-                response.EnsureSuccessStatusCode();
-
-                // Add labels if specified
-                if (addLabels is { Length: > 0 })
-                {
-                    var labelPayload = new { repository = repo, issueNumber = issueNum, labels = addLabels };
-                    await httpClient.PostAsJsonAsync($"{baseUrl}/api/engine/issue-labels", labelPayload);
-                }
-
-                // Remove labels if specified
-                if (removeLabels is { Length: > 0 })
-                {
-                    foreach (var label in removeLabels)
-                    {
-                        await httpClient.DeleteAsync(
-                            $"{baseUrl}/api/engine/issue-labels/{Uri.EscapeDataString(repo)}/{issueNum}/{Uri.EscapeDataString(label)}");
-                    }
-                }
-
-                return; // success — exit retry loop
-            }
-            catch (Exception ex)
-            {
-                if (attempt < 2)
-                {
-                    var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt)); // 1s, 2s, 4s
-                    Logger?.LogWarning(ex, "Issue update attempt {Attempt} failed, retrying in {Delay}s", attempt + 1, delay.TotalSeconds);
-                    await Task.Delay(delay);
-                }
-                else
-                {
-                    // Final attempt failed — log and continue (don't block workflow)
-                    Logger?.LogWarning(ex, "Failed to update issue #{IssueNumber} after 3 attempts", issueNum);
-                }
-            }
+            SetSuccess(context, degraded: false);
+            await context.CompleteActivityWithOutcomesAsync("Updated");
+        }
+        else
+        {
+            // No false success — surface the failure loudly. The workflow's
+            // Failed edge emits ISSUE_STATUS.UPDATED.FAILED.
+            Updated.Set(context, false);
+            Degraded.Set(context, false);
+            ErrorCode.Set(context, outcome.ErrorCode ?? "issue-update-failed");
+            Error.Set(context, outcome.Error);
+            await context.CompleteActivityWithOutcomesAsync("Failed");
         }
     }
 
-    public override Dictionary<string, object?> BuildEndData(ActivityExecutionContext context) => new()
+    private void SetSuccess(ActivityExecutionContext context, bool degraded)
     {
-        ["issueNumber"] = IssueNumber.Get(context),
-        ["message"] = Message.Get(context),
-    };
+        Updated.Set(context, true);
+        Degraded.Set(context, degraded);
+        ErrorCode.Set(context, null);
+        Error.Set(context, null);
+    }
+
+    /// <summary>
+    /// Pure-ish orchestration core (no Elsa context): post the comment, then add
+    /// labels (single atomic call) and remove labels (each independent) with a
+    /// 3-attempt backoff. Returns a typed outcome so the happy / partial-failure
+    /// / total-failure paths are unit-testable against a mocked
+    /// <see cref="IIssueCallbackClient"/>.
+    ///
+    /// <para>NEVER swallows a real failure: a non-retryable result after the last
+    /// attempt becomes a <c>Failed</c> outcome (closes the headline bug). The
+    /// comment is posted first and, once it succeeds, is NOT re-posted on a
+    /// subsequent label-only retry (duplicate-comment de-dup).</para>
+    /// </summary>
+    public static async Task<IssueUpdateOutcome> ExecuteCoreAsync(
+        IIssueCallbackClient client,
+        string repository,
+        int issueNumber,
+        string body,
+        string[]? addLabels,
+        string[]? removeLabels,
+        ILogger? logger = null,
+        CancellationToken ct = default)
+    {
+        var commentPosted = string.IsNullOrEmpty(body);
+        var labelsAdded = addLabels is not { Length: > 0 };
+        var pendingRemovals = new List<string>(removeLabels ?? Array.Empty<string>());
+
+        IssueCallbackResult last = IssueCallbackResult.Ok();
+
+        for (var attempt = 0; attempt < MaxAttempts; attempt++)
+        {
+            try
+            {
+                if (!commentPosted)
+                {
+                    last = await client.PostCommentAsync(repository, issueNumber, body, ct).ConfigureAwait(false);
+                    if (!last.Success) { await BackoffAsync(attempt, last, logger, ct); continue; }
+                    commentPosted = true; // de-dup: never re-post on a later retry
+                }
+
+                if (!labelsAdded)
+                {
+                    last = await client.AddLabelsAsync(repository, issueNumber, addLabels!, ct).ConfigureAwait(false);
+                    if (!last.Success) { await BackoffAsync(attempt, last, logger, ct); continue; }
+                    labelsAdded = true;
+                }
+
+                while (pendingRemovals.Count > 0)
+                {
+                    last = await client.RemoveLabelAsync(repository, issueNumber, pendingRemovals[0], ct).ConfigureAwait(false);
+                    if (!last.Success) break;
+                    pendingRemovals.RemoveAt(0); // de-dup: completed removals are not retried
+                }
+                if (pendingRemovals.Count > 0) { await BackoffAsync(attempt, last, logger, ct); continue; }
+
+                return IssueUpdateOutcome.Updated(); // every block applied
+            }
+            catch (Exception ex)
+            {
+                last = IssueCallbackResult.Fail(ex.Message);
+                if (attempt < MaxAttempts - 1)
+                {
+                    await BackoffAsync(attempt, last, logger, ct);
+                }
+                else
+                {
+                    logger?.LogWarning(ex, "Failed to update issue #{IssueNumber} after {Attempts} attempts", issueNumber, MaxAttempts);
+                    return IssueUpdateOutcome.Failed(ClassifyError(ex.Message), ex.Message);
+                }
+            }
+        }
+
+        // Final attempt failed without throwing — surface the loud failure.
+        logger?.LogWarning("Failed to update issue #{IssueNumber} after {Attempts} attempts: {Error}", issueNumber, MaxAttempts, last.Error);
+        return IssueUpdateOutcome.Failed(ClassifyError(last.Error), last.Error);
+    }
+
+    private static async Task BackoffAsync(int attempt, IssueCallbackResult last, ILogger? logger, CancellationToken ct)
+    {
+        if (attempt >= MaxAttempts - 1) return;
+        var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt)); // 1s, 2s, 4s
+        logger?.LogWarning("Issue update attempt {Attempt} failed ({Error}), retrying in {Delay}s",
+            attempt + 1, last.Error, delay.TotalSeconds);
+        await Task.Delay(delay, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Compose the comment body. When a merged-PR number / URL is supplied, link
+    /// it (Story 2.10 AC5 — "comment linking to merged PR") rather than posting a
+    /// static string. Never returns null. Pure — exposed for unit testing.
+    /// </summary>
+    public static string ComposeBody(string? message, int prNumber, string? prUrl)
+    {
+        var sb = new StringBuilder(message?.Trim() ?? "");
+        var hasNumber = prNumber > 0;
+        var hasUrl = !string.IsNullOrWhiteSpace(prUrl);
+        if (hasNumber || hasUrl)
+        {
+            if (sb.Length > 0) sb.Append("\n\n");
+            if (hasNumber && hasUrl) sb.Append($"Resolved by #{prNumber} ({prUrl!.Trim()})");
+            else if (hasNumber) sb.Append($"Resolved by #{prNumber}");
+            else sb.Append($"Resolved by {prUrl!.Trim()}");
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Classify a callback failure for the failure edge (not-found / permission /
+    /// rate-limit / generic) — drives the <c>errorCode</c> output / event tag.
+    /// </summary>
+    public static string ClassifyError(string? error)
+    {
+        if (string.IsNullOrWhiteSpace(error)) return "issue-update-failed";
+        var lower = error.ToLowerInvariant();
+        if (lower.Contains("404") || lower.Contains("not found")) return "issue-not-found";
+        if (lower.Contains("403") || lower.Contains("forbidden") || lower.Contains("permission")) return "permission-denied";
+        if (lower.Contains("401") || lower.Contains("unauthorized")) return "unauthorized";
+        if (lower.Contains("429") || lower.Contains("rate limit") || lower.Contains("rate_limited")) return "rate-limited";
+        if (lower.Contains("503") || lower.Contains("not_configured")) return "callback-unavailable";
+        return "issue-update-failed";
+    }
+}
+
+/// <summary>
+/// Typed result of <see cref="UpdateIssueStatusActivity.ExecuteCoreAsync"/> —
+/// maps directly to the activity's Elsa outcome (Updated / Failed).
+/// </summary>
+public sealed class IssueUpdateOutcome
+{
+    public bool Success { get; init; }
+    public string? ErrorCode { get; init; }
+    public string? Error { get; init; }
+
+    public static IssueUpdateOutcome Updated() => new() { Success = true };
+    public static IssueUpdateOutcome Failed(string errorCode, string? error)
+        => new() { Success = false, ErrorCode = errorCode, Error = error };
 }

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/UpdateIssueStatusWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/UpdateIssueStatusWorkflow.cs
@@ -144,7 +144,10 @@ public class UpdateIssueStatusWorkflow : WorkflowBase
             {
                 WithLabel(new SetOutput { Id = "OutFailSuccess", OutputName = new("success"), OutputValue = new(_ => (object)false) }, "Output success=false"),
                 WithLabel(new SetOutput { Id = "OutFailErrorCode", OutputName = new("errorCode"), OutputValue = new(ctx => (object)(errorCodeVar.Get(ctx) ?? "issue-update-failed")) }, "Output errorCode"),
-                WithLabel(new SetOutput { Id = "OutFailReason", OutputName = new("exitReason"), OutputValue = new(_ => (object)"issue-update-failed") }, "Output exitReason"),
+                // Surface the activity's rich human Error reason (not a duplicate of
+                // errorCode) so callers/observability see WHY it failed; fall back to
+                // the stable constant only when no reason was captured.
+                WithLabel(new SetOutput { Id = "OutFailReason", OutputName = new("exitReason"), OutputValue = new(ctx => (object)(NullIfBlank(errorVar.Get(ctx)) ?? "issue-update-failed")) }, "Output exitReason"),
             }
         };
         failureOutputs.SetDisplayText("Failure Outputs");
@@ -198,6 +201,9 @@ public class UpdateIssueStatusWorkflow : WorkflowBase
 
     private static string[]? NullIfEmpty(string[]? labels)
         => labels is { Length: > 0 } ? labels : null;
+
+    private static string? NullIfBlank(string? s)
+        => string.IsNullOrWhiteSpace(s) ? null : s;
 
     private static long ElapsedMs(long startedAtTicks)
     {

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/UpdateIssueStatusWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/UpdateIssueStatusWorkflow.cs
@@ -1,25 +1,38 @@
+using System.Text.Json;
 using Elsa.Extensions;
 using Elsa.Workflows;
 using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Management.Activities.SetOutput;
 using Elsa.Workflows.Memory;
 using Elsa.Workflows.Models;
 using Tamma.Activities.ADL;
-
+using FlowEndpoint = Elsa.Workflows.Activities.Flowchart.Models.Endpoint;
+using FlowConnection = Elsa.Workflows.Activities.Flowchart.Models.Connection;
 using static Tamma.ElsaServer.Workflows.ActivityDisplayTextExtensions;
 
 namespace Tamma.ElsaServer.Workflows;
 
 /// <summary>
-/// Tiny sub-workflow that posts a status comment on a GitHub issue.
-/// Called via DispatchWorkflow with WaitForCompletion=false (fire and forget).
-/// Has built-in retries in the activity.
+/// Update Issue Status — post a status comment on a GitHub issue, manage labels,
+/// and (when a merged PR is supplied) compose a PR-linked close comment, keeping
+/// the issue a "living log" of the autonomous cycle.
 ///
-/// Inputs:
-///   - repository: owner/repo
-///   - issueNumber: int
-///   - message: string (the comment body)
-///   - addLabels: string[] (optional)
-///   - removeLabels: string[] (optional)
+/// <para>Story 2.10 build-out: the activity no longer <b>swallows</b> a failed
+/// status update into a silent success. The workflow is now a real flowchart with
+/// an EXPLICIT failure edge: on a genuine callback failure the activity surfaces a
+/// <c>Failed</c> outcome that emits <c>ISSUE_STATUS.UPDATED.FAILED</c> (durable
+/// DCB drain) and sets <c>success=false</c>; success emits
+/// <c>ISSUE_STATUS.UPDATED.SUCCESS</c>. No <c>Failed</c> edge ever falls through
+/// to the success outputs — no false success.</para>
+///
+/// Flow:
+///   ReadInputs → UpdateIssue
+///     ├─ Updated → EmitSuccess → Success Outputs → Finish
+///     └─ Failed  → Failure Outputs (success=false) → EmitFailed → Finish
+///
+/// Inputs: repository, issueNumber, message, addLabels?, removeLabels?,
+///         tenantId?, prNumber?, prUrl?.
 /// </summary>
 public class UpdateIssueStatusWorkflow : WorkflowBase
 {
@@ -28,20 +41,209 @@ public class UpdateIssueStatusWorkflow : WorkflowBase
         builder.Name = "Update Issue Status";
         builder.DefinitionId = "update-issue-status";
         builder.Version = WorkflowVersions.ComputedVersion;
-        builder.Description = "Post a status comment on a GitHub issue (fire-and-forget with retries)";
+        builder.Description = "Update a GitHub issue (status comment, labels, PR-linked close) with an explicit failure path and durable DCB events";
 
+        // ================================================================
+        // Variables
+        // ================================================================
+        var repositoryVar = builder.WithVariable<string>("Repository", "");
+        var issueNumberVar = builder.WithVariable<int>("IssueNumber", 0);
+        var messageVar = builder.WithVariable<string>("Message", "");
+        var tenantIdVar = builder.WithVariable<string>("TenantId", "");
+        var prNumberVar = builder.WithVariable<int>("PrNumber", 0);
+        var prUrlVar = builder.WithVariable<string>("PrUrl", "");
+        var addLabelsVar = builder.WithVariable<string[]>("AddLabels", Array.Empty<string>());
+        var removeLabelsVar = builder.WithVariable<string[]>("RemoveLabels", Array.Empty<string>());
+
+        var updatedVar = builder.WithVariable<bool>("Updated", false);
+        var degradedVar = builder.WithVariable<bool>("Degraded", false);
+        var errorCodeVar = builder.WithVariable<string>("ErrorCode", "");
+        var errorVar = builder.WithVariable<string>("Error", "");
+        var startedAtTicksVar = builder.WithVariable<long>("StartedAtTicks", 0);
+
+        // ================================================================
+        // 1. Read inputs
+        // ================================================================
+        var readInputs = new SetVariable
+        {
+            Id = "ReadInputs", Name = "Read Inputs",
+            Variable = repositoryVar,
+            Value = new Input<object?>(ctx =>
+            {
+                var repo = ctx.GetInput<string>("repository") ?? "";
+                issueNumberVar.Set(ctx, ctx.GetInput<int>("issueNumber"));
+                messageVar.Set(ctx, ctx.GetInput<string>("message") ?? "");
+                tenantIdVar.Set(ctx, ctx.GetInput<string>("tenantId") ?? "");
+                prNumberVar.Set(ctx, ctx.GetInput<int?>("prNumber") ?? 0);
+                prUrlVar.Set(ctx, ctx.GetInput<string>("prUrl") ?? "");
+                addLabelsVar.Set(ctx, ctx.GetInput<string[]>("addLabels") ?? Array.Empty<string>());
+                removeLabelsVar.Set(ctx, ctx.GetInput<string[]>("removeLabels") ?? Array.Empty<string>());
+                startedAtTicksVar.Set(ctx, DateTime.UtcNow.Ticks);
+                return (object)repo;
+            })
+        };
+        readInputs.SetDisplayText("Read Inputs");
+
+        // ================================================================
+        // 2. Update the issue (outcome-bearing — Updated / Failed)
+        // ================================================================
         var updateIssue = new UpdateIssueStatusActivity
         {
-            Id = "UpdateIssue",
-            Name = "Update Issue",
-            Repository = new Input<string>(ctx => ctx.GetInput<string>("repository") ?? ""),
-            IssueNumber = new Input<int>(ctx => ctx.GetInput<int>("issueNumber")),
-            Message = new Input<string>(ctx => ctx.GetInput<string>("message") ?? ""),
-            AddLabels = new Input<string[]?>(ctx => ctx.GetInput<string[]>("addLabels")),
-            RemoveLabels = new Input<string[]?>(ctx => ctx.GetInput<string[]>("removeLabels")),
+            Id = "UpdateIssue", Name = "Update Issue",
+            Repository = new Input<string>(ctx => repositoryVar.Get(ctx)),
+            IssueNumber = new Input<int>(ctx => issueNumberVar.Get(ctx)),
+            Message = new Input<string>(ctx => messageVar.Get(ctx)),
+            AddLabels = new Input<string[]?>(ctx => NullIfEmpty(addLabelsVar.Get(ctx))),
+            RemoveLabels = new Input<string[]?>(ctx => NullIfEmpty(removeLabelsVar.Get(ctx))),
+            TenantId = new Input<string?>(ctx => tenantIdVar.Get(ctx)),
+            PrNumber = new Input<int>(ctx => prNumberVar.Get(ctx)),
+            PrUrl = new Input<string?>(ctx => prUrlVar.Get(ctx)),
+            Updated = new Output<bool>(updatedVar),
+            Degraded = new Output<bool>(degradedVar),
+            ErrorCode = new Output<string?>(errorCodeVar),
+            Error = new Output<string?>(errorVar),
         };
         updateIssue.SetDisplayText("Update Issue");
 
-        builder.Root = updateIssue;
+        // ================================================================
+        // 3. Success path — emit ISSUE_STATUS.UPDATED.SUCCESS + outputs
+        // ================================================================
+        var emitSuccess = new EmitIssueStatusEventActivity
+        {
+            Id = "EmitSuccess", Name = "Emit ISSUE_STATUS.UPDATED.SUCCESS",
+            EventType = new Input<string>(_ => IssueStatusEvents.UpdatedSuccess),
+            IssueNumber = new Input<int>(ctx => issueNumberVar.Get(ctx)),
+            Repository = new Input<string>(ctx => repositoryVar.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantIdVar.Get(ctx)),
+            DataJson = new Input<string?>(ctx => BuildSuccessData(
+                messageVar.Get(ctx), addLabelsVar.Get(ctx), removeLabelsVar.Get(ctx),
+                prNumberVar.Get(ctx), degradedVar.Get(ctx),
+                ElapsedMs(startedAtTicksVar.Get(ctx)))),
+        };
+        emitSuccess.SetDisplayText("Emit ISSUE_STATUS.UPDATED.SUCCESS");
+
+        var successOutputs = new Sequence
+        {
+            Id = "SuccessOutputs", Name = "Success Outputs",
+            Activities =
+            {
+                WithLabel(new SetOutput { Id = "OutSuccess", OutputName = new("success"), OutputValue = new(_ => (object)true) }, "Output success"),
+                WithLabel(new SetOutput { Id = "OutDegraded", OutputName = new("degraded"), OutputValue = new(ctx => (object)degradedVar.Get(ctx)) }, "Output degraded"),
+                WithLabel(new SetOutput { Id = "OutIssueNumber", OutputName = new("issueNumber"), OutputValue = new(ctx => (object)issueNumberVar.Get(ctx)) }, "Output issueNumber"),
+            }
+        };
+        successOutputs.SetDisplayText("Success Outputs");
+
+        // ================================================================
+        // 4. Failure path — success=false, emit ISSUE_STATUS.UPDATED.FAILED
+        // ================================================================
+        var failureOutputs = new Sequence
+        {
+            Id = "FailureOutputs", Name = "Failure Outputs",
+            Activities =
+            {
+                WithLabel(new SetOutput { Id = "OutFailSuccess", OutputName = new("success"), OutputValue = new(_ => (object)false) }, "Output success=false"),
+                WithLabel(new SetOutput { Id = "OutFailErrorCode", OutputName = new("errorCode"), OutputValue = new(ctx => (object)(errorCodeVar.Get(ctx) ?? "issue-update-failed")) }, "Output errorCode"),
+                WithLabel(new SetOutput { Id = "OutFailReason", OutputName = new("exitReason"), OutputValue = new(_ => (object)"issue-update-failed") }, "Output exitReason"),
+            }
+        };
+        failureOutputs.SetDisplayText("Failure Outputs");
+
+        var emitFailed = new EmitIssueStatusEventActivity
+        {
+            Id = "EmitFailed", Name = "Emit ISSUE_STATUS.UPDATED.FAILED",
+            EventType = new Input<string>(_ => IssueStatusEvents.UpdatedFailed),
+            IssueNumber = new Input<int>(ctx => issueNumberVar.Get(ctx)),
+            Repository = new Input<string>(ctx => repositoryVar.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantIdVar.Get(ctx)),
+            DataJson = new Input<string?>(ctx => BuildFailureData(
+                errorCodeVar.Get(ctx), errorVar.Get(ctx), issueNumberVar.Get(ctx),
+                ElapsedMs(startedAtTicksVar.Get(ctx)))),
+        };
+        emitFailed.SetDisplayText("Emit ISSUE_STATUS.UPDATED.FAILED");
+
+        var finish = new Finish { Id = "Finish", Name = "Complete" };
+        finish.SetDisplayText("Complete");
+
+        // ================================================================
+        // Flowchart
+        // ================================================================
+        builder.Root = new Flowchart
+        {
+            Id = "UpdateIssueStatusFlowchart",
+            Name = "Update Issue Status Flowchart",
+            Start = readInputs,
+            Activities =
+            {
+                readInputs, updateIssue,
+                emitSuccess, successOutputs,
+                failureOutputs, emitFailed, finish,
+            },
+            Connections =
+            {
+                Connect(readInputs, updateIssue),
+
+                // Updated → success path
+                ConnectOutcome(updateIssue, "Updated", emitSuccess),
+                Connect(emitSuccess, successOutputs),
+                Connect(successOutputs, finish),
+
+                // Failed → explicit failure path (NO fall-through to success)
+                ConnectOutcome(updateIssue, "Failed", failureOutputs),
+                Connect(failureOutputs, emitFailed),
+                Connect(emitFailed, finish),
+            }
+        };
     }
+
+    private static string[]? NullIfEmpty(string[]? labels)
+        => labels is { Length: > 0 } ? labels : null;
+
+    private static long ElapsedMs(long startedAtTicks)
+    {
+        if (startedAtTicks <= 0) return 0;
+        var elapsed = DateTime.UtcNow.Ticks - startedAtTicks;
+        return elapsed > 0 ? elapsed / TimeSpan.TicksPerMillisecond : 0;
+    }
+
+    private static string BuildSuccessData(
+        string message, string[]? addLabels, string[]? removeLabels,
+        int prNumber, bool degraded, long durationMs)
+    {
+        var data = new Dictionary<string, object?>
+        {
+            ["message"] = Truncate(message, 280),
+            ["addLabels"] = addLabels ?? Array.Empty<string>(),
+            ["removeLabels"] = removeLabels ?? Array.Empty<string>(),
+            ["prNumber"] = prNumber,
+            ["degraded"] = degraded,
+            ["durationMs"] = durationMs,
+        };
+        return JsonSerializer.Serialize(data);
+    }
+
+    private static string BuildFailureData(
+        string? errorCode, string? error, int issueNumber, long durationMs)
+    {
+        var data = new Dictionary<string, object?>
+        {
+            ["issueNumber"] = issueNumber,
+            ["errorCode"] = errorCode ?? "issue-update-failed",
+            ["error"] = Truncate(error, 280),
+            ["durationMs"] = durationMs,
+        };
+        return JsonSerializer.Serialize(data);
+    }
+
+    private static string Truncate(string? s, int max)
+    {
+        if (string.IsNullOrEmpty(s)) return "";
+        return s.Length <= max ? s : s[..max];
+    }
+
+    private static FlowConnection Connect(IActivity source, IActivity target)
+        => new(new FlowEndpoint(source), new FlowEndpoint(target));
+
+    private static FlowConnection ConnectOutcome(IActivity source, string outcome, IActivity target)
+        => new(new FlowEndpoint(source, outcome), new FlowEndpoint(target));
 }

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/UpdateIssueStatusActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/UpdateIssueStatusActivityTests.cs
@@ -1,0 +1,337 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+
+namespace Tamma.Activities.Tests.ADL;
+
+/// <summary>
+/// Story 2.10 build-out — unit coverage for the update-issue-status activity.
+///
+/// <para>The headline regression: a failed status update must surface a loud
+/// <c>Failed</c> outcome (which the workflow routes to an
+/// <c>ISSUE_STATUS.UPDATED.FAILED</c> emit), NOT be swallowed into a silent
+/// success. Tests cover <see cref="UpdateIssueStatusActivity.ExecuteCoreAsync"/>
+/// (happy / total-failure / partial-retry de-dup / exception), the PR-link body
+/// composition, error classification, and <see cref="EmitIssueStatusEventActivity"/>'s
+/// DCB mapping onto the durable drain. Follows the codebase pattern of testing the
+/// testable static logic (no full Elsa ActivityExecutionContext).</para>
+/// </summary>
+[TestFixture]
+public class UpdateIssueStatusActivityTests
+{
+    // ================================================================
+    // Constructors
+    // ================================================================
+
+    [Test]
+    public void UpdateIssueStatusActivity_JsonConstructor_ShouldNotThrow()
+    {
+        Action act = () => new UpdateIssueStatusActivity();
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void EmitIssueStatusEventActivity_JsonConstructor_ShouldNotThrow()
+    {
+        Action act = () => new EmitIssueStatusEventActivity();
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void EmitIssueStatusEventActivity_WithLogger_ShouldNotThrow()
+    {
+        var logger = new Mock<ILogger<EmitIssueStatusEventActivity>>();
+        Action act = () => new EmitIssueStatusEventActivity(logger.Object);
+        act.Should().NotThrow();
+    }
+
+    // ================================================================
+    // ExecuteCoreAsync — happy path
+    // ================================================================
+
+    private static Mock<IIssueCallbackClient> AllOk()
+    {
+        var c = new Mock<IIssueCallbackClient>();
+        c.Setup(x => x.PostCommentAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(IssueCallbackResult.Ok());
+        c.Setup(x => x.AddLabelsAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(IssueCallbackResult.Ok());
+        c.Setup(x => x.RemoveLabelAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(IssueCallbackResult.Ok());
+        return c;
+    }
+
+    [Test]
+    public async Task ExecuteCore_HappyPath_PostsCommentAddsAndRemovesLabels_ReturnsUpdated()
+    {
+        var c = AllOk();
+
+        var outcome = await UpdateIssueStatusActivity.ExecuteCoreAsync(
+            c.Object, "o/r", 5, "Working on it",
+            addLabels: new[] { "tamma-processing" },
+            removeLabels: new[] { "tamma-queued" });
+
+        outcome.Success.Should().BeTrue();
+        outcome.ErrorCode.Should().BeNull();
+        c.Verify(x => x.PostCommentAsync("o/r", 5, "Working on it", It.IsAny<CancellationToken>()), Times.Once);
+        c.Verify(x => x.AddLabelsAsync("o/r", 5, It.Is<string[]>(l => l.Contains("tamma-processing")), It.IsAny<CancellationToken>()), Times.Once);
+        c.Verify(x => x.RemoveLabelAsync("o/r", 5, "tamma-queued", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task ExecuteCore_NoLabels_OnlyPostsComment()
+    {
+        var c = AllOk();
+
+        var outcome = await UpdateIssueStatusActivity.ExecuteCoreAsync(
+            c.Object, "o/r", 9, "Status only", addLabels: null, removeLabels: null);
+
+        outcome.Success.Should().BeTrue();
+        c.Verify(x => x.PostCommentAsync("o/r", 9, "Status only", It.IsAny<CancellationToken>()), Times.Once);
+        c.Verify(x => x.AddLabelsAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Never);
+        c.Verify(x => x.RemoveLabelAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ================================================================
+    // ExecuteCoreAsync — the headline bug: no silent failure / no false success
+    // ================================================================
+
+    [Test]
+    public async Task ExecuteCore_CommentFailsEveryAttempt_ReturnsFailed_NotSilentSuccess()
+    {
+        // The core regression test: a status update that fails on every attempt
+        // must NOT be swallowed into a success — it must surface a Failed outcome.
+        var c = new Mock<IIssueCallbackClient>();
+        c.Setup(x => x.PostCommentAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(IssueCallbackResult.Fail("issue-comment 403"));
+
+        var outcome = await UpdateIssueStatusActivity.ExecuteCoreAsync(
+            c.Object, "o/r", 5, "Closing", addLabels: null, removeLabels: null);
+
+        outcome.Success.Should().BeFalse("a failed status update must NOT report success (no false success)");
+        outcome.ErrorCode.Should().Be("permission-denied");
+        outcome.Error.Should().Contain("403");
+    }
+
+    [Test]
+    public async Task ExecuteCore_CallbackThrowsEveryAttempt_ReturnsFailed_NeverThrows()
+    {
+        var c = new Mock<IIssueCallbackClient>();
+        c.Setup(x => x.PostCommentAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("network down"));
+
+        var outcome = await UpdateIssueStatusActivity.ExecuteCoreAsync(
+            c.Object, "o/r", 5, "msg", addLabels: null, removeLabels: null);
+
+        outcome.Success.Should().BeFalse("an exception must become a Failed outcome, never a throw or false success");
+        outcome.ErrorCode.Should().Be("issue-update-failed");
+    }
+
+    [Test]
+    public async Task ExecuteCore_AddLabelsFailEveryAttempt_ReturnsFailed()
+    {
+        var c = AllOk();
+        c.Setup(x => x.AddLabelsAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(IssueCallbackResult.Fail("issue-labels 503"));
+
+        var outcome = await UpdateIssueStatusActivity.ExecuteCoreAsync(
+            c.Object, "o/r", 5, "msg", addLabels: new[] { "x" }, removeLabels: null);
+
+        outcome.Success.Should().BeFalse();
+        outcome.ErrorCode.Should().Be("callback-unavailable");
+    }
+
+    // ================================================================
+    // ExecuteCoreAsync — idempotency / de-dup (no duplicate comment on retry)
+    // ================================================================
+
+    [Test]
+    public async Task ExecuteCore_CommentSucceedsThenLabelFailsOnce_DoesNotRepostComment()
+    {
+        // Comment succeeds attempt 1; add-labels fails attempt 1 then succeeds
+        // attempt 2. The comment must be posted exactly ONCE (no duplicate-comment
+        // hazard on the label-only retry).
+        var c = new Mock<IIssueCallbackClient>();
+        c.Setup(x => x.PostCommentAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(IssueCallbackResult.Ok());
+
+        var addCalls = 0;
+        c.Setup(x => x.AddLabelsAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => ++addCalls == 1 ? IssueCallbackResult.Fail("issue-labels 500") : IssueCallbackResult.Ok());
+
+        var outcome = await UpdateIssueStatusActivity.ExecuteCoreAsync(
+            c.Object, "o/r", 5, "msg", addLabels: new[] { "x" }, removeLabels: null);
+
+        outcome.Success.Should().BeTrue();
+        c.Verify(x => x.PostCommentAsync("o/r", 5, "msg", It.IsAny<CancellationToken>()), Times.Once,
+            "the comment must not be re-posted on a label-only retry (de-dup)");
+        addCalls.Should().Be(2);
+    }
+
+    [Test]
+    public async Task ExecuteCore_PartialRemovals_DoesNotRepeatCompletedRemovals()
+    {
+        // Two removals: first succeeds, second fails on attempt 1 then succeeds on
+        // attempt 2. The first (completed) removal must not be repeated.
+        var c = new Mock<IIssueCallbackClient>();
+        c.Setup(x => x.PostCommentAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(IssueCallbackResult.Ok());
+
+        var bCalls = 0;
+        c.Setup(x => x.RemoveLabelAsync("o/r", 5, "a", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(IssueCallbackResult.Ok());
+        c.Setup(x => x.RemoveLabelAsync("o/r", 5, "b", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => ++bCalls == 1 ? IssueCallbackResult.Fail("issue-labels-delete 500") : IssueCallbackResult.Ok());
+
+        var outcome = await UpdateIssueStatusActivity.ExecuteCoreAsync(
+            c.Object, "o/r", 5, "msg", addLabels: null, removeLabels: new[] { "a", "b" });
+
+        outcome.Success.Should().BeTrue();
+        c.Verify(x => x.RemoveLabelAsync("o/r", 5, "a", It.IsAny<CancellationToken>()), Times.Once,
+            "a completed removal must not be repeated on retry");
+        bCalls.Should().Be(2);
+    }
+
+    // ================================================================
+    // ComposeBody — PR-link composition (Story 2.10 AC5)
+    // ================================================================
+
+    [Test]
+    public void ComposeBody_NoPr_ReturnsMessageOnly()
+    {
+        UpdateIssueStatusActivity.ComposeBody("Done!", prNumber: 0, prUrl: null)
+            .Should().Be("Done!");
+    }
+
+    [Test]
+    public void ComposeBody_WithPrNumberAndUrl_LinksMergedPr()
+    {
+        var body = UpdateIssueStatusActivity.ComposeBody(
+            "🎉 PR merged! Issue resolved.", prNumber: 42, prUrl: "https://x/pull/42");
+
+        body.Should().Contain("🎉 PR merged! Issue resolved.");
+        body.Should().Contain("Resolved by #42");
+        body.Should().Contain("https://x/pull/42");
+    }
+
+    [Test]
+    public void ComposeBody_WithPrNumberOnly_LinksNumber()
+    {
+        UpdateIssueStatusActivity.ComposeBody("Closed", prNumber: 7, prUrl: null)
+            .Should().Contain("Resolved by #7");
+    }
+
+    [Test]
+    public void ComposeBody_EmptyMessageWithPr_StillLinks_NeverEmpty()
+    {
+        var body = UpdateIssueStatusActivity.ComposeBody("", prNumber: 3, prUrl: "u");
+        body.Should().NotBeNullOrWhiteSpace();
+        body.Should().Contain("Resolved by #3");
+    }
+
+    // ================================================================
+    // ClassifyError — drives the failure-edge errorCode
+    // ================================================================
+
+    [Test]
+    public void ClassifyError_MapsKnownCodes()
+    {
+        UpdateIssueStatusActivity.ClassifyError("issue-comment 404").Should().Be("issue-not-found");
+        UpdateIssueStatusActivity.ClassifyError("403 Forbidden").Should().Be("permission-denied");
+        UpdateIssueStatusActivity.ClassifyError("401 Unauthorized").Should().Be("unauthorized");
+        UpdateIssueStatusActivity.ClassifyError("429 rate limit").Should().Be("rate-limited");
+        UpdateIssueStatusActivity.ClassifyError("503 not_configured").Should().Be("callback-unavailable");
+    }
+
+    [Test]
+    public void ClassifyError_GenericFallback()
+    {
+        UpdateIssueStatusActivity.ClassifyError(null).Should().Be("issue-update-failed");
+        UpdateIssueStatusActivity.ClassifyError("boom").Should().Be("issue-update-failed");
+    }
+
+    // ================================================================
+    // EmitIssueStatusEventActivity.BuildTammaEvent — DCB mapping onto the drain
+    // ================================================================
+
+    [Test]
+    public void BuildTammaEvent_SuccessType_SetsTypeStatusTagsAndData()
+    {
+        var evt = EmitIssueStatusEventActivity.BuildTammaEvent(
+            IssueStatusEvents.UpdatedSuccess, issueNumber: 12, repository: "o/r",
+            tenantId: null,
+            data: new Dictionary<string, object?> { ["message"] = "ok", ["degraded"] = false });
+
+        evt.EventType.Should().Be("ISSUE_STATUS.UPDATED.SUCCESS");
+        evt.Status.Should().Be("success");
+        evt.Tags.Should().NotBeNull();
+        evt.Tags!["issueId"].Should().Be("12");
+        evt.Tags["issueNumber"].Should().Be("12");
+        evt.Tags["repository"].Should().Be("o/r");
+        evt.Tags.Should().NotContainKey("tenantId");
+        evt.Data.Should().ContainKey("message");
+    }
+
+    [Test]
+    public void BuildTammaEvent_FailedType_SetsErrorStatus()
+    {
+        var evt = EmitIssueStatusEventActivity.BuildTammaEvent(
+            IssueStatusEvents.UpdatedFailed, issueNumber: 7, repository: "o/r",
+            tenantId: null,
+            data: new Dictionary<string, object?> { ["errorCode"] = "permission-denied" });
+
+        evt.EventType.Should().Be("ISSUE_STATUS.UPDATED.FAILED");
+        evt.Status.Should().Be("error", "a failed update must emit a loud error-status event");
+        evt.Data.Should().ContainKey("errorCode");
+    }
+
+    [Test]
+    public void BuildTammaEvent_WithTenant_SetsTenantIdTag()
+    {
+        var tenant = Guid.NewGuid();
+        var evt = EmitIssueStatusEventActivity.BuildTammaEvent(
+            IssueStatusEvents.UpdatedSuccess, 1, "o/r", tenantId: tenant, data: null);
+
+        evt.Tags!["tenantId"].Should().Be(tenant.ToString("D"));
+        evt.Data.Should().BeEmpty();
+    }
+
+    [Test]
+    public void IssueStatusEvents_ParseTenantId_HandlesEmptyAndValid()
+    {
+        IssueStatusEvents.ParseTenantId(null).Should().BeNull();
+        IssueStatusEvents.ParseTenantId("").Should().BeNull();
+        IssueStatusEvents.ParseTenantId("not-a-guid").Should().BeNull();
+        var g = Guid.NewGuid();
+        IssueStatusEvents.ParseTenantId(g.ToString()).Should().Be(g);
+    }
+
+    [Test]
+    public void EmitIssueStatusEvent_ParseData_HandlesEmptyMalformedAndValid()
+    {
+        EmitIssueStatusEventActivity.ParseData(null).Should().BeNull();
+        EmitIssueStatusEventActivity.ParseData("").Should().BeNull();
+        EmitIssueStatusEventActivity.ParseData("{not json").Should().BeNull();
+
+        var data = EmitIssueStatusEventActivity.ParseData("{\"errorCode\":\"x\",\"durationMs\":3}");
+        data.Should().NotBeNull();
+        data!.Should().ContainKey("errorCode");
+        data.Should().ContainKey("durationMs");
+    }
+
+    // ================================================================
+    // IssueCallbackResult
+    // ================================================================
+
+    [Test]
+    public void IssueCallbackResult_OkAndFail_AreDistinct()
+    {
+        IssueCallbackResult.Ok().Success.Should().BeTrue();
+        var fail = IssueCallbackResult.Fail("boom");
+        fail.Success.Should().BeFalse();
+        fail.Error.Should().Be("boom");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/UpdateIssueStatusActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/UpdateIssueStatusActivityTests.cs
@@ -300,6 +300,36 @@ public class UpdateIssueStatusActivityTests
     }
 
     [Test]
+    public void BuildTammaEvent_DegradedSuccess_AddsDegradedTag_NotJustData()
+    {
+        // A degraded (callback-unavailable) no-op still emits a SUCCESS event. A
+        // consumer filtering on event TYPE would miscount it as a real success
+        // unless the degraded flag is a QUERYABLE tag — not buried in Data only.
+        var evt = EmitIssueStatusEventActivity.BuildTammaEvent(
+            IssueStatusEvents.UpdatedSuccess, issueNumber: 8, repository: "o/r",
+            tenantId: null,
+            data: new Dictionary<string, object?> { ["message"] = "noop", ["degraded"] = true });
+
+        evt.Tags.Should().NotBeNull();
+        evt.Tags!.Should().ContainKey("degraded");
+        evt.Tags["degraded"].Should().Be("true", "the degraded flag must be indexed/queryable as a tag");
+        // still present in Data (non-indexed payload retained).
+        evt.Data.Should().ContainKey("degraded");
+    }
+
+    [Test]
+    public void BuildTammaEvent_NonDegradedSuccess_DoesNotAddDegradedTag()
+    {
+        var evt = EmitIssueStatusEventActivity.BuildTammaEvent(
+            IssueStatusEvents.UpdatedSuccess, issueNumber: 8, repository: "o/r",
+            tenantId: null,
+            data: new Dictionary<string, object?> { ["message"] = "ok", ["degraded"] = false });
+
+        evt.Tags!.Should().NotContainKey("degraded",
+            "a genuine (non-degraded) success must NOT carry the degraded tag");
+    }
+
+    [Test]
     public void IssueStatusEvents_ParseTenantId_HandlesEmptyAndValid()
     {
         IssueStatusEvents.ParseTenantId(null).Should().BeNull();

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/UpdateIssueStatusWorkflowTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/UpdateIssueStatusWorkflowTests.cs
@@ -1,6 +1,10 @@
+using System.Reflection;
+using Elsa.Expressions.Models;
+using Elsa.Workflows;
 using Elsa.Workflows.Activities;
 using Elsa.Workflows.Activities.Flowchart.Activities;
 using Elsa.Workflows.Management.Activities.SetOutput;
+using Elsa.Workflows.Memory;
 using FluentAssertions;
 using NUnit.Framework;
 using Tamma.Activities.ADL;
@@ -186,6 +190,36 @@ public class UpdateIssueStatusWorkflowTests
     }
 
     // ================================================================
+    // exitReason carries the REAL error reason (not a hard-coded constant)
+    // ================================================================
+
+    [Test]
+    public void FailurePath_ExitReason_CarriesRealErrorReason_NotConstant()
+    {
+        // The activity exposes a rich human Error reason; the failure exitReason
+        // output must surface THAT (so observability/callers see why it failed),
+        // not a hard-coded "issue-update-failed" duplicate of errorCode.
+        var outReason = FailureOutput("OutFailReason");
+
+        const string realReason = "issue-comment 403 Forbidden: token lacks issues:write";
+        EvaluateOutputValue(outReason, realReason)
+            .Should().Be(realReason,
+                "exitReason must bind to the workflow error variable, surfacing the real reason");
+    }
+
+    [Test]
+    public void FailurePath_ExitReason_FallsBackToConstant_WhenNoReason()
+    {
+        // When no error reason was captured (null/empty), exitReason must still
+        // produce the stable fallback rather than null.
+        var outReason = FailureOutput("OutFailReason");
+
+        EvaluateOutputValue(outReason, null)
+            .Should().Be("issue-update-failed",
+                "exitReason must fall back to the stable constant when no reason is present");
+    }
+
+    // ================================================================
     // Helpers
     // ================================================================
 
@@ -194,4 +228,111 @@ public class UpdateIssueStatusWorkflowTests
             c.Source.Activity.Id == sourceId &&
             (port == null || c.Source.Port == port) &&
             c.Target.Activity.Id == targetId);
+
+    private SetOutput FailureOutput(string id)
+        => _flowchart.Activities
+            .OfType<Sequence>()
+            .First(s => s.Id == "FailureOutputs")
+            .Activities
+            .OfType<SetOutput>()
+            .First(o => o.Id == id);
+
+    /// <summary>
+    /// Evaluate a <see cref="SetOutput"/>'s <c>OutputValue</c> delegate against a
+    /// minimal expression context in which the workflow error variable (the only
+    /// <see cref="MemoryBlockReference"/> the delegate captures) is declared and
+    /// pre-set to <paramref name="errorReason"/>. Returns the materialised output
+    /// so a test can assert the value the delegate actually computes — i.e. whether
+    /// <c>exitReason</c> reads the variable or just returns a constant.
+    /// </summary>
+    private static object? EvaluateOutputValue(SetOutput setOutput, string? errorReason)
+    {
+        var input = typeof(SetOutput).GetProperty("OutputValue")!.GetValue(setOutput);
+        var expression = input!.GetType()
+            .GetProperty("Expression", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            ?.GetValue(input) as Expression;
+
+        if (expression?.Value is not Delegate del)
+            throw new InvalidOperationException("OutputValue is not a delegate-backed input");
+
+        var memory = new MemoryRegister(new Dictionary<string, MemoryBlock>());
+        var ctx = new ExpressionExecutionContext(
+            NullServiceProvider.Instance, memory, null, null, null, default);
+
+        // Declare every variable the delegate closes over, then set the captured
+        // error variable to the chosen reason so .Get(ctx) returns it.
+        var counter = 0;
+        foreach (var reference in CapturedReferences(del))
+        {
+            EnsureUniqueId(reference, ref counter);
+            try { memory.Declare(reference); } catch { /* default resolves below */ }
+            if (reference is Variable<string> sv)
+                sv.Set(ctx, errorReason);
+        }
+
+        var raw = del.DynamicInvoke(ctx);
+        return Unwrap(raw);
+    }
+
+    private static IEnumerable<MemoryBlockReference> CapturedReferences(Delegate del)
+    {
+        var seen = new HashSet<object>(ReferenceEqualityComparer.Instance);
+        var stack = new Stack<object>();
+        if (del.Target != null) stack.Push(del.Target);
+
+        while (stack.Count > 0)
+        {
+            var obj = stack.Pop();
+            if (obj == null || !seen.Add(obj)) continue;
+            if (obj is string || obj.GetType().IsPrimitive) continue;
+
+            if (obj is MemoryBlockReference reference)
+            {
+                yield return reference;
+                continue;
+            }
+
+            foreach (var field in obj.GetType()
+                         .GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+            {
+                object? value;
+                try { value = field.GetValue(obj); }
+                catch { continue; }
+                if (value == null || value is string || value.GetType().IsPrimitive) continue;
+                if (value is MemoryBlockReference r) yield return r;
+                else if (value.GetType().IsClass) stack.Push(value);
+            }
+        }
+    }
+
+    private static void EnsureUniqueId(MemoryBlockReference reference, ref int counter)
+    {
+        try { if (!string.IsNullOrEmpty(reference.Id)) return; }
+        catch { return; }
+        var idProp = typeof(MemoryBlockReference).GetProperty("Id",
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        if (idProp?.CanWrite == true)
+        {
+            try { idProp.SetValue(reference, $"__uis_{counter++}"); }
+            catch { /* leave as-is */ }
+        }
+    }
+
+    private static object? Unwrap(object? raw)
+    {
+        if (raw == null) return null;
+        var type = raw.GetType();
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ValueTask<>))
+        {
+            var asTask = type.GetMethod("AsTask")!.Invoke(raw, null);
+            return asTask!.GetType().GetProperty("Result")!.GetValue(asTask);
+        }
+        return raw;
+    }
+
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public static readonly NullServiceProvider Instance = new();
+        public object? GetService(Type serviceType) => null;
+    }
 }

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/UpdateIssueStatusWorkflowTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/UpdateIssueStatusWorkflowTests.cs
@@ -1,0 +1,197 @@
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Management.Activities.SetOutput;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Story 2.10 build-out — workflow-structure coverage for the built-out
+/// <c>update-issue-status</c> graph. Asserts the load-bearing guarantees the
+/// activity unit tests can't: the <b>failure edge exists</b> and the activity's
+/// <c>Failed</c> outcome NEVER falls through to success (the headline
+/// swallow-failure fix), both terminal transitions emit an <c>ISSUE_STATUS.*</c>
+/// DCB event via the durable drain, every outcome is routed (no dangling edge),
+/// and both paths reach Finish.
+///
+/// <para>Follows the codebase convention of inspecting the BUILT Flowchart via
+/// <see cref="WorkflowTestHelper"/> rather than running the full Elsa runtime.</para>
+/// </summary>
+[TestFixture]
+public class UpdateIssueStatusWorkflowTests
+{
+    private Flowchart _flowchart = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new UpdateIssueStatusWorkflow());
+        _flowchart = WorkflowTestHelper.GetFlowchart(builder);
+    }
+
+    // ================================================================
+    // Identity
+    // ================================================================
+
+    [Test]
+    public void Workflow_BuildsWithExpectedDefinitionId()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new UpdateIssueStatusWorkflow());
+        builder.Object.DefinitionId.Should().Be("update-issue-status");
+    }
+
+    [Test]
+    public void Workflow_RootIsFlowchart_NotBareActivity()
+    {
+        // The old thin form set builder.Root = updateIssue (a bare activity). The
+        // build-out must be a real flowchart with branches.
+        _flowchart.Should().NotBeNull();
+        _flowchart.Activities.OfType<UpdateIssueStatusActivity>()
+            .Should().ContainSingle("the update activity must be a node in the flowchart");
+    }
+
+    // ================================================================
+    // Flow shape
+    // ================================================================
+
+    [Test]
+    public void Flow_ReadInputs_Then_UpdateIssue()
+    {
+        HasEdge("ReadInputs", null, "UpdateIssue").Should().BeTrue();
+    }
+
+    // ================================================================
+    // No false success — the Failed outcome routes to the failure path ONLY
+    // ================================================================
+
+    [Test]
+    public void UpdateIssue_FailedOutcome_RoutesToFailurePath_NotSuccess()
+    {
+        HasEdge("UpdateIssue", "Failed", "FailureOutputs").Should().BeTrue(
+            "the Failed outcome must route to the explicit failure path");
+
+        var failedTargets = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "UpdateIssue" && c.Source.Port == "Failed")
+            .Select(c => c.Target.Activity.Id)
+            .ToList();
+
+        failedTargets.Should().NotContain("EmitSuccess");
+        failedTargets.Should().NotContain("SuccessOutputs");
+    }
+
+    [Test]
+    public void UpdateIssue_HasNoUnconditionalFallthrough()
+    {
+        // Every edge out of UpdateIssue must be outcome-qualified (Updated/Failed).
+        // A portless edge would be the old silent fall-through bug.
+        var fromUpdate = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "UpdateIssue")
+            .ToList();
+
+        fromUpdate.Should().NotBeEmpty();
+        fromUpdate.Should().OnlyContain(c => c.Source.Port == "Updated" || c.Source.Port == "Failed");
+    }
+
+    [Test]
+    public void UpdateIssue_UpdatedOutcome_RoutesToSuccess()
+    {
+        HasEdge("UpdateIssue", "Updated", "EmitSuccess").Should().BeTrue();
+    }
+
+    // ================================================================
+    // DCB events on every terminal transition (durable drain)
+    // ================================================================
+
+    [Test]
+    public void SuccessPath_EmitsIssueStatusUpdatedSuccess()
+    {
+        var emit = _flowchart.Activities
+            .OfType<EmitIssueStatusEventActivity>()
+            .FirstOrDefault(a => a.Id == "EmitSuccess");
+        emit.Should().NotBeNull("success path must emit an ISSUE_STATUS DCB event");
+        HasEdge("EmitSuccess", null, "SuccessOutputs").Should().BeTrue();
+    }
+
+    [Test]
+    public void FailurePath_EmitsIssueStatusUpdatedFailed()
+    {
+        var emit = _flowchart.Activities
+            .OfType<EmitIssueStatusEventActivity>()
+            .FirstOrDefault(a => a.Id == "EmitFailed");
+        emit.Should().NotBeNull("failure path must emit ISSUE_STATUS.UPDATED.FAILED");
+        // success=false outputs must run before / into the failed-event emit.
+        HasEdge("FailureOutputs", null, "EmitFailed").Should().BeTrue();
+    }
+
+    [Test]
+    public void BothTerminalPaths_ReachFinish()
+    {
+        HasEdge("SuccessOutputs", null, "Finish").Should().BeTrue();
+        HasEdge("EmitFailed", null, "Finish").Should().BeTrue();
+    }
+
+    // ================================================================
+    // No dangling edge — every outcome / node routed to a terminal
+    // ================================================================
+
+    [Test]
+    public void EveryConnection_PointsAtAKnownActivity()
+    {
+        var ids = _flowchart.Activities.Select(a => a.Id).ToHashSet();
+        foreach (var c in _flowchart.Connections)
+        {
+            ids.Should().Contain(c.Source.Activity.Id);
+            ids.Should().Contain(c.Target.Activity.Id);
+        }
+    }
+
+    // ================================================================
+    // Outputs — success=false on the failure path; success=true on success
+    // ================================================================
+
+    [Test]
+    public void FailurePath_SetsSuccessFalse_And_ErrorCode()
+    {
+        var failureSeq = _flowchart.Activities
+            .OfType<Sequence>()
+            .First(s => s.Id == "FailureOutputs");
+
+        var ids = failureSeq.Activities
+            .OfType<SetOutput>()
+            .Select(o => o.Id ?? "")
+            .ToList();
+
+        ids.Should().Contain("OutFailSuccess");   // success = false
+        ids.Should().Contain("OutFailErrorCode"); // errorCode
+        ids.Should().Contain("OutFailReason");    // exitReason
+    }
+
+    [Test]
+    public void SuccessPath_SetsSuccessTrue()
+    {
+        var successSeq = _flowchart.Activities
+            .OfType<Sequence>()
+            .First(s => s.Id == "SuccessOutputs");
+
+        var ids = successSeq.Activities
+            .OfType<SetOutput>()
+            .Select(o => o.Id ?? "")
+            .ToList();
+
+        ids.Should().Contain("OutSuccess");   // success = true
+        ids.Should().Contain("OutDegraded");  // degraded flag (auditable local no-op)
+    }
+
+    // ================================================================
+    // Helpers
+    // ================================================================
+
+    private bool HasEdge(string sourceId, string? port, string targetId)
+        => _flowchart.Connections.Any(c =>
+            c.Source.Activity.Id == sourceId &&
+            (port == null || c.Source.Port == port) &&
+            c.Target.Activity.Id == targetId);
+}


### PR DESCRIPTION
## What
`UpdateIssueStatusWorkflow`: thin wrapper that **swallowed a failed status update into success** → complete. Now an outcome-bearing activity (`Updated`/`Failed`), the `Failed` edge never reaches the success outputs, a loud `ISSUE_STATUS.UPDATED.FAILED` DCB event fires via the durable drain, `tenantId` threaded, PR-link close comment, idempotent retry (in-execution de-dup), and a degraded (no callback URL) no-op carries a queryable `degraded` tag (not counted as a plain success). Leaf workflow (fire-and-forget) — no cycle wiring changed, no deadlock.

Reviewed: APPROVED; two MINORs fixed (degraded tag + real error reason at `exitReason`).

The real open→closed **state transition** is correctly deferred to Story 38-1's `PATCH /api/v1/git/.../issues/{n}` mediation endpoint (not landed); everything achievable on today's engine-callback seam is delivered.

## Verification
Build 0 errors; `has-pending-model-changes` clean; `~UpdateIssueStatus` 38/0; full `Tamma.Activities.Tests` 1428/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)