### PR TITLE
feat(workflows): build out TriagePanelReview — fail-closed aggregation + durable events

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitTriageEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitTriageEventActivity.cs
@@ -1,0 +1,155 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+
+namespace Tamma.Activities.ADL;
+
+/// <summary>
+/// Emits a <c>TRIAGE.PANEL.*</c> DCB event (Story 26-1 AC9 intent / triage-cluster
+/// audit P1) for the audit trail by appending a <see cref="TammaEvent"/> to the
+/// workflow's <c>tamma:events</c> transient list via
+/// <see cref="TammaEventEmitter.Emit"/>. The engine event drain
+/// (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) flushes that list
+/// <i>durably</i> to the tenant <c>domain_events</c> store after this activity
+/// runs — the drain resolves the tenant from the workflow scope (the triage panel
+/// stamps a <c>TenantId</c> variable). The event therefore persists without this
+/// activity holding any DB / repository dependency of its own (none is registered
+/// in the Elsa engine — the same reason <see cref="EmitPrEventActivity"/> and
+/// <see cref="EmitMergeApprovalEventActivity"/> use the emitter rather than a
+/// direct <c>IEventRepository</c>).
+///
+/// <para>The panel emits <c>STARTED</c> right after init and exactly one terminal
+/// event (<c>COMPLETED</c> / <c>PARTIAL</c> / <c>FAILED</c>) carrying the role
+/// roster health (<c>roleCount</c> / <c>succeededCount</c> / <c>failedRoles</c>) —
+/// so a degraded or failed panel is a loud audit row, never a silent false
+/// success.</para>
+/// </summary>
+[Activity(
+    "Tamma.ADL",
+    "Emit Triage Panel Event",
+    "Emit a TRIAGE.PANEL.* DCB event for the triage-panel audit trail",
+    Kind = ActivityKind.Task
+)]
+public class EmitTriageEventActivity : Activity
+{
+    private readonly ILogger<EmitTriageEventActivity>? _logger;
+
+    [Input(Description = "Event type — TRIAGE.PANEL.STARTED / .COMPLETED / .PARTIAL / .FAILED")]
+    public Input<string> EventType { get; set; } = default!;
+
+    [Input(Description = "Repository in owner/repo format")]
+    public Input<string> Repository { get; set; } = default!;
+
+    [Input(Description = "Triage item number (0 when unknown)")]
+    public Input<int> ItemNumber { get; set; } = new(0);
+
+    [Input(Description = "Tenant id (empty / single-user → platform-scope event)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [Input(Description = "Total number of panel roles")]
+    public Input<int> RoleCount { get; set; } = new(0);
+
+    [Input(Description = "Number of roles that produced a usable assessment")]
+    public Input<int> SucceededCount { get; set; } = new(0);
+
+    [Input(Description = "JSON array of role names that failed to produce a usable assessment")]
+    public Input<string?> FailedRolesJson { get; set; } = new((string?)null);
+
+    [JsonConstructor]
+    public EmitTriageEventActivity() { }
+
+    public EmitTriageEventActivity(ILogger<EmitTriageEventActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var type = EventType.Get(context) ?? TriageEvents.PanelFailed;
+        var repository = Repository.Get(context) ?? "";
+        var itemNumber = ItemNumber.Get(context);
+        var tenantId = TriageEvents.ParseTenantId(TenantId.Get(context));
+        var roleCount = RoleCount.Get(context);
+        var succeededCount = SucceededCount.Get(context);
+        var failedRolesJson = FailedRolesJson.Get(context);
+
+        var evt = BuildTammaEvent(type, repository, itemNumber, tenantId, roleCount, succeededCount, failedRolesJson);
+        TammaEventEmitter.Emit(context, this, _logger, evt);
+
+        _logger?.LogInformation(
+            "Emitted {Type} for item #{Item} in {Repo} (roles={Roles}, succeeded={Succeeded})",
+            type, itemNumber, repository, roleCount, succeededCount);
+
+        return default;
+    }
+
+    /// <summary>
+    /// Map the panel inputs onto a <see cref="TammaEvent"/> expressed as the
+    /// engine's transient-list event so the merged drain persists it. Tags carry
+    /// the queryable DCB index keys (<c>repository</c>/<c>itemId</c>/
+    /// <c>itemNumber</c>/<c>tenantId</c>); Data carries the panel-health payload
+    /// (<c>roleCount</c>/<c>succeededCount</c>/<c>failedRoles</c>). Status is
+    /// driven off the event type (failed → error, partial → warning) so a
+    /// degraded/failed panel is never recorded as a false success. Pure (no Elsa
+    /// context) — exposed for unit testing the mapping.
+    /// </summary>
+    public static TammaEvent BuildTammaEvent(
+        string type,
+        string repository,
+        int itemNumber,
+        Guid? tenantId,
+        int roleCount,
+        int succeededCount,
+        string? failedRolesJson)
+    {
+        var tags = new Dictionary<string, object?>
+        {
+            ["repository"] = repository,
+        };
+        if (itemNumber > 0)
+        {
+            tags["itemId"] = itemNumber.ToString();
+            tags["itemNumber"] = itemNumber.ToString();
+        }
+        if (tenantId is not null) tags["tenantId"] = tenantId.Value.ToString("D");
+
+        var data = new Dictionary<string, object?>
+        {
+            ["roleCount"] = roleCount,
+            ["succeededCount"] = succeededCount,
+            ["failedRoles"] = ParseFailedRoles(failedRolesJson),
+        };
+
+        return new TammaEvent
+        {
+            EventType = type,
+            Status = TriageEvents.StatusForEvent(type),
+            Tags = tags,
+            Data = data,
+        };
+    }
+
+    /// <summary>
+    /// Deserialize the failed-roles JSON array into a list of role names for the
+    /// event data. Returns an empty list on null / malformed input (the event
+    /// still emits — an absent roster reads as "no recorded failures", never an
+    /// exception). Exposed for unit testing the parse path.
+    /// </summary>
+    public static List<string> ParseFailedRoles(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return new List<string>();
+        try
+        {
+            return JsonSerializer.Deserialize<List<string>>(json) ?? new List<string>();
+        }
+        catch
+        {
+            return new List<string>();
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/TriageEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/TriageEvents.cs
@@ -1,0 +1,70 @@
+namespace Tamma.Activities.ADL;
+
+/// <summary>
+/// Story 26-1 (AC9 intent) / triage-cluster audit P1 — central catalogue of the
+/// <c>TRIAGE.PANEL.*</c> DCB event types emitted by the <c>triage-panel-review</c>
+/// workflow. Type pattern follows the platform's <c>AGGREGATE.ACTION.STATUS</c>
+/// convention (<c>CLAUDE.md</c>).
+///
+/// <para>The triage panel is a 4-role LLM panel (security / developer / devops /
+/// tester) over one triage item. Each lifecycle transition of the panel is an
+/// auditable event so the audit trail (and the downstream PO decision) can see a
+/// degraded or failed panel rather than a silent false success.</para>
+///
+/// <para>Events are emitted via <c>TammaEventEmitter.Emit</c> into the workflow's
+/// <c>tamma:events</c> transient list and persisted <i>durably</i> by the engine
+/// event drain (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) — the same
+/// pattern <see cref="EmitPrEventActivity"/> and
+/// <see cref="EmitMergeApprovalEventActivity"/> use. No activity holds a DB /
+/// repository dependency of its own (none is registered in the Elsa engine — a
+/// directly-injected <c>IEventRepository</c> would be inert and silently drop
+/// every panel event).</para>
+///
+/// <list type="bullet">
+///   <item><description><c>TRIAGE.PANEL.STARTED</c> — the panel began reviewing an
+///     item (tags carry repository + item number).</description></item>
+///   <item><description><c>TRIAGE.PANEL.COMPLETED</c> — every panellist produced a
+///     usable assessment (full, healthy panel).</description></item>
+///   <item><description><c>TRIAGE.PANEL.PARTIAL</c> — at least one panellist failed
+///     but the panel still met quorum. A degraded — not failed — result; loud
+///     (warning-status) so the PO can down-weight it.</description></item>
+///   <item><description><c>TRIAGE.PANEL.FAILED</c> — too few panellists produced a
+///     usable assessment (below quorum). Loud (error-status). The panel reports
+///     <c>panelStatus="failed"</c> so the parent cycle routes to a non-applying
+///     terminal instead of labelling the item off a wholly-failed panel. This is
+///     the no-false-success / no-empty-fallback rule made explicit: a failed panel
+///     is NEVER coalesced to four <c>{}</c> reviews reported as a success.</description></item>
+/// </list>
+/// </summary>
+public static class TriageEvents
+{
+    public const string PanelStarted = "TRIAGE.PANEL.STARTED";
+    public const string PanelCompleted = "TRIAGE.PANEL.COMPLETED";
+    public const string PanelPartial = "TRIAGE.PANEL.PARTIAL";
+    public const string PanelFailed = "TRIAGE.PANEL.FAILED";
+
+    /// <summary>Default quorum: at least this many panellists must produce a
+    /// usable assessment for the panel to be considered usable (not failed).</summary>
+    public const int DefaultQuorum = 2;
+
+    /// <summary>
+    /// Parse a tenant id from the loose string form threaded through the workflow
+    /// inputs. Returns <c>null</c> for empty / single-user / unparseable values
+    /// (panel events in single-user mode are platform-scope, TenantId null).
+    /// </summary>
+    public static Guid? ParseTenantId(string? tenantId)
+        => Guid.TryParse(tenantId, out var g) ? g : null;
+
+    /// <summary>
+    /// Failure-status check: a failed panel is a loud (error-status) audit row, a
+    /// partial panel is a warning-status row, a completed panel is success.
+    /// Mirrors <see cref="EmitMergeApprovalEventActivity.IsFailureEvent"/>'s intent
+    /// of never recording a degraded/failed outcome as a false success.
+    /// </summary>
+    public static string StatusForEvent(string type) => type switch
+    {
+        PanelFailed => "error",
+        PanelPartial => "warning",
+        _ => "success",
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/Helpers/TriagePanelAggregationHelper.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/Helpers/TriagePanelAggregationHelper.cs
@@ -1,0 +1,242 @@
+using System.Text.Json;
+
+namespace Tamma.ElsaServer.Workflows.Helpers;
+
+/// <summary>
+/// Pure, fail-closed aggregation for the 4-role triage panel (no Elsa runtime
+/// dependency). This is the lever that fixes the headline build-out bug: a
+/// failed/empty per-role review is NEVER silently coalesced to a <c>{}</c>
+/// participant. Each role carries a <c>status ∈ {"ok","failed"}</c>; the panel
+/// exposes <c>succeededCount</c> / <c>failedRoles</c> / <c>panelStatus</c> so a
+/// degraded or wholly-failed panel is a loud signal the PO and audit trail can
+/// see — never a false "successful review".
+///
+/// <para>Mirrors <see cref="ReviewAggregationHelper"/> (the <c>plan-review</c>
+/// sibling that demonstrates the intended bar): deterministic parse independent
+/// of LLM prose, structured fields surfaced for the decider.</para>
+/// </summary>
+public static class TriagePanelAggregationHelper
+{
+    /// <summary>Panel reached quorum and every role succeeded.</summary>
+    public const string StatusOk = "ok";
+
+    /// <summary>Panel reached quorum but at least one role failed (degraded).</summary>
+    public const string StatusPartial = "partial";
+
+    /// <summary>Panel did not reach quorum (too few usable reviews) — fail-closed.</summary>
+    public const string StatusFailed = "failed";
+
+    /// <summary>
+    /// A single panellist's outcome: whether it produced a usable assessment,
+    /// plus the parsed structured fields (verdict / severity / suggestedLabels /
+    /// notes) and the raw assessment kept alongside for audit.
+    /// </summary>
+    public sealed record RoleReview(
+        string Role,
+        bool Ok,
+        string Verdict,
+        string Severity,
+        IReadOnlyList<string> SuggestedLabels,
+        string Notes,
+        string RawAssessment);
+
+    /// <summary>
+    /// The aggregated panel outcome: the per-role reviews, roster-health counts,
+    /// the ordered list of roles that failed, and the overall panel status.
+    /// </summary>
+    public sealed record PanelResult(
+        IReadOnlyList<RoleReview> Reviews,
+        int ReviewCount,
+        int SucceededCount,
+        IReadOnlyList<string> FailedRoles,
+        string PanelStatus);
+
+    /// <summary>
+    /// Classify a single role's extracted review. A role is <b>failed</b> when its
+    /// review variable is null/blank, the literal <c>"{}"</c>, or unparseable —
+    /// i.e. the <c>llm-call</c> yielded no usable assessment. A role is <b>ok</b>
+    /// when it parsed to a non-empty JSON object. Structured fields are best-effort
+    /// (verdict / severity / suggestedLabels / notes); their absence does NOT make
+    /// a role failed (a usable free-form assessment still counts).
+    /// </summary>
+    public static RoleReview ClassifyRole(string role, string? reviewJson)
+    {
+        var raw = reviewJson ?? "";
+
+        if (string.IsNullOrWhiteSpace(raw) || raw.Trim() == "{}")
+        {
+            return new RoleReview(role, false, "", "", Array.Empty<string>(), "", raw);
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(raw);
+            var root = doc.RootElement;
+
+            // An empty object {} (no properties) is not a usable assessment.
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                return new RoleReview(role, false, "", "", Array.Empty<string>(), "", raw);
+            }
+
+            var hasAny = false;
+            foreach (var _ in root.EnumerateObject()) { hasAny = true; break; }
+            if (!hasAny)
+            {
+                return new RoleReview(role, false, "", "", Array.Empty<string>(), "", raw);
+            }
+
+            var verdict = TryGetString(root, "verdict");
+            var severity = TryGetString(root, "severity");
+            var notes = TryGetString(root, "notes");
+            var suggestedLabels = TryGetStringList(root, "suggestedLabels");
+
+            return new RoleReview(role, true, verdict, severity, suggestedLabels, notes, raw);
+        }
+        catch
+        {
+            // Unparseable → not a usable assessment (fail-closed, never a {} pass).
+            return new RoleReview(role, false, "", "", Array.Empty<string>(), "", raw);
+        }
+    }
+
+    /// <summary>
+    /// Aggregate a per-role roster into a panel result. The <paramref name="reviews"/>
+    /// dictionary maps role → that role's raw extracted review JSON, in roster
+    /// order given by <paramref name="roles"/>. The panel status is:
+    /// <list type="bullet">
+    ///   <item><description><c>ok</c> — every role produced a usable assessment;</description></item>
+    ///   <item><description><c>partial</c> — <c>succeededCount &gt;= quorum</c> but
+    ///     at least one role failed (degraded, still usable);</description></item>
+    ///   <item><description><c>failed</c> — <c>succeededCount &lt; quorum</c>
+    ///     (fail-closed — the parent cycle must NOT apply labels off this).</description></item>
+    /// </list>
+    /// </summary>
+    public static PanelResult Aggregate(
+        IReadOnlyList<string> roles,
+        IReadOnlyDictionary<string, string?> reviews,
+        int quorum)
+    {
+        var classified = new List<RoleReview>(roles.Count);
+        var failedRoles = new List<string>();
+        var succeeded = 0;
+
+        foreach (var role in roles)
+        {
+            reviews.TryGetValue(role, out var reviewJson);
+            var rr = ClassifyRole(role, reviewJson);
+            classified.Add(rr);
+            if (rr.Ok) succeeded++;
+            else failedRoles.Add(role);
+        }
+
+        var effectiveQuorum = quorum < 1 ? 1 : quorum;
+        string status;
+        if (succeeded < effectiveQuorum)
+            status = StatusFailed;
+        else if (failedRoles.Count == 0)
+            status = StatusOk;
+        else
+            status = StatusPartial;
+
+        return new PanelResult(classified, classified.Count, succeeded, failedRoles, status);
+    }
+
+    /// <summary>
+    /// Serialize a <see cref="PanelResult"/> into the <c>panelResultJson</c> output
+    /// contract the PO decision consumes:
+    /// <c>{ reviews:[{role,status,verdict,severity,suggestedLabels,notes,assessment}],
+    /// reviewCount, succeededCount, failedRoles:[...], panelStatus }</c>.
+    /// Failed roles are present in the roster with <c>status="failed"</c> and an
+    /// empty assessment — they are NOT dropped (the PO sees the full roster) and
+    /// NOT recorded as a <c>{}</c> success.
+    /// </summary>
+    public static string Serialize(PanelResult result)
+    {
+        var reviews = new List<object>(result.Reviews.Count);
+        foreach (var r in result.Reviews)
+        {
+            reviews.Add(new Dictionary<string, object?>
+            {
+                ["role"] = r.Role,
+                ["status"] = r.Ok ? "ok" : "failed",
+                ["verdict"] = r.Verdict,
+                ["severity"] = r.Severity,
+                ["suggestedLabels"] = r.SuggestedLabels,
+                ["notes"] = r.Notes,
+                ["assessment"] = r.Ok ? r.RawAssessment : "",
+            });
+        }
+
+        return JsonSerializer.Serialize(new Dictionary<string, object?>
+        {
+            ["reviews"] = reviews,
+            ["reviewCount"] = result.ReviewCount,
+            ["succeededCount"] = result.SucceededCount,
+            ["failedRoles"] = result.FailedRoles,
+            ["panelStatus"] = result.PanelStatus,
+        });
+    }
+
+    /// <summary>
+    /// Map a panel status onto its terminal DCB event type. Kept here so the
+    /// status→event mapping lives next to the status definitions.
+    /// </summary>
+    public static string EventTypeForStatus(string panelStatus) => panelStatus switch
+    {
+        StatusOk => Tamma.Activities.ADL.TriageEvents.PanelCompleted,
+        StatusPartial => Tamma.Activities.ADL.TriageEvents.PanelPartial,
+        _ => Tamma.Activities.ADL.TriageEvents.PanelFailed,
+    };
+
+    /// <summary>
+    /// Best-effort parse of the triage item number out of <c>itemJson</c> (the
+    /// <c>number</c> field). Returns 0 when absent / unparseable — the store key
+    /// and event tags then read as "unknown item" rather than throwing.
+    /// </summary>
+    public static int ParseItemNumber(string? itemJson)
+    {
+        if (string.IsNullOrWhiteSpace(itemJson)) return 0;
+        try
+        {
+            using var doc = JsonDocument.Parse(itemJson);
+            if (doc.RootElement.ValueKind == JsonValueKind.Object &&
+                doc.RootElement.TryGetProperty("number", out var n) &&
+                n.ValueKind == JsonValueKind.Number &&
+                n.TryGetInt32(out var v))
+            {
+                return v;
+            }
+        }
+        catch { /* unknown item */ }
+        return 0;
+    }
+
+    private static string TryGetString(JsonElement root, string prop)
+    {
+        if (root.TryGetProperty(prop, out var v))
+        {
+            return v.ValueKind == JsonValueKind.String
+                ? v.GetString() ?? ""
+                : v.GetRawText();
+        }
+        return "";
+    }
+
+    private static IReadOnlyList<string> TryGetStringList(JsonElement root, string prop)
+    {
+        if (root.TryGetProperty(prop, out var v) && v.ValueKind == JsonValueKind.Array)
+        {
+            var list = new List<string>();
+            foreach (var item in v.EnumerateArray())
+            {
+                if (item.ValueKind == JsonValueKind.String)
+                    list.Add(item.GetString() ?? "");
+                else
+                    list.Add(item.GetRawText());
+            }
+            return list;
+        }
+        return Array.Empty<string>();
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TriageItemCycleWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TriageItemCycleWorkflow.cs
@@ -2,10 +2,12 @@ using Elsa.Extensions;
 using Elsa.Workflows;
 using Elsa.Workflows.Activities;
 using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Management.Activities.SetOutput;
 using Elsa.Workflows.Memory;
 using Elsa.Workflows.Models;
 using Elsa.Workflows.Runtime.Activities;
 using Tamma.Activities.ADL;
+using Tamma.ElsaServer.Workflows.Helpers;
 using FlowEndpoint = Elsa.Workflows.Activities.Flowchart.Models.Endpoint;
 using FlowConnection = Elsa.Workflows.Activities.Flowchart.Models.Connection;
 
@@ -21,11 +23,22 @@ namespace Tamma.ElsaServer.Workflows;
 /// IssueTriageWorkflow dispatches one per item (fire & forget);
 /// Elsa queues subsequent dispatches until the current one finishes.
 ///
+/// <para>Build-out (completeness audit 2026-06-22): the panel sub-workflow is now
+/// fail-closed and reports a <c>panelStatus</c> (<c>ok</c>/<c>partial</c>/
+/// <c>failed</c>). This cycle <b>honours</b> that signal: a <c>failed</c> panel
+/// (too few panellists produced a usable assessment) routes to a loud
+/// non-applying terminal — the PO decision is skipped and NO labels are applied
+/// off a wholly-failed panel. Previously the cycle marched straight from the
+/// panel to PO + label application regardless of panel health, so a fully-failed
+/// panel still labelled the item (silent false success downstream).</para>
+///
 /// Flow:
 ///   Init → Gather Context (llm-call) → Panel Review (llm-call x4)
-///   → PO Decision (llm-call) → Apply Labels & Comment → Finish
+///   → Extract Panel Result + Status → Panel Usable?
+///       ├─ True (ok/partial)  → PO Decision (llm-call) → Apply Labels → Finish
+///       └─ False (failed)     → Mark Skipped (no labels)              → Finish
 ///
-/// Inputs: repository, itemJson
+/// Inputs: repository, itemJson, tenantId
 /// </summary>
 public class TriageItemCycleWorkflow : WorkflowBase
 {
@@ -41,8 +54,13 @@ public class TriageItemCycleWorkflow : WorkflowBase
         // ================================================================
         var repository = builder.WithVariable<string>("Repository", "");
         var itemJson = builder.WithVariable<string>("ItemJson", "");
+        var tenantId = builder.WithVariable<string>("TenantId", "");
         var contextJson = builder.WithVariable<string>("ContextJson", "");
         var panelResultJson = builder.WithVariable<string>("PanelResultJson", "");
+        // Panel health signal from the (fail-closed) panel sub-workflow:
+        // "ok" / "partial" => usable; "failed" => below quorum, do NOT apply labels.
+        var panelStatus = builder.WithVariable<string>(
+            "PanelStatus", TriagePanelAggregationHelper.StatusFailed);
         var poDecisionJson = builder.WithVariable<string>("PODecisionJson", "");
         var subResult = builder.WithVariable<IDictionary<string, object>?>();
 
@@ -57,6 +75,7 @@ public class TriageItemCycleWorkflow : WorkflowBase
             {
                 var repo = ctx.GetInput<string>("repository") ?? "";
                 itemJson.Set(ctx, ctx.GetInput<string>("itemJson") ?? "");
+                tenantId.Set(ctx, ctx.GetInput<string>("tenantId") ?? "");
                 return (object)repo;
             })
         };
@@ -108,6 +127,7 @@ public class TriageItemCycleWorkflow : WorkflowBase
                 ["repository"] = repository.Get(ctx),
                 ["itemJson"] = itemJson.Get(ctx),
                 ["contextJson"] = contextJson.Get(ctx),
+                ["tenantId"] = tenantId.Get(ctx),
             }),
             WaitForCompletion = new(true),
             Result = new(subResult),
@@ -122,12 +142,56 @@ public class TriageItemCycleWorkflow : WorkflowBase
             Value = new Input<object?>(ctx =>
             {
                 var result = subResult.Get(ctx);
+
+                // Read the panel-health signal first. Absence is treated as a
+                // FAILED panel (fail-closed): if the sub-workflow did not report
+                // a status we must NOT assume success and apply labels.
+                var status = TriagePanelAggregationHelper.StatusFailed;
+                if (result != null && result.TryGetValue("panelStatus", out var st))
+                {
+                    var s = st?.ToString();
+                    if (!string.IsNullOrWhiteSpace(s)) status = s!;
+                }
+                panelStatus.Set(ctx, status);
+
                 if (result != null && result.TryGetValue("panelResultJson", out var p))
                     return (object)(p?.ToString() ?? "");
                 return (object)"";
             })
         };
         extractPanelResult.SetDisplayText("Extract Panel Result");
+
+        // ================================================================
+        // 3a. Panel Usable? — honour the panel's fail-closed signal. A "failed"
+        //     panel (below quorum) routes to a non-applying terminal; "ok" /
+        //     "partial" proceed to the PO decision + label application.
+        // ================================================================
+        var panelUsable = new FlowDecision(ctx =>
+            panelStatus.Get(ctx) != TriagePanelAggregationHelper.StatusFailed)
+        { Id = "PanelUsable", Name = "Panel Usable?" };
+        panelUsable.SetDisplayText("Panel Usable?");
+
+        // Failed-panel terminal — record the skip on the workflow outputs so the
+        // caller/audit sees a LOUD non-applying outcome (no labels applied off a
+        // wholly-failed panel). The panel sub-workflow already emitted
+        // TRIAGE.PANEL.FAILED to the durable drain.
+        var markSkipped = new SetOutput
+        {
+            Id = "MarkSkipped",
+            Name = "Mark Triage Skipped",
+            OutputName = new("triageSkipped"),
+            OutputValue = new(_ => (object)true),
+        };
+        markSkipped.SetDisplayText("Mark Triage Skipped");
+
+        var outSkipReason = new SetOutput
+        {
+            Id = "OutSkipReason",
+            Name = "Output Skip Reason",
+            OutputName = new("skipReason"),
+            OutputValue = new(_ => (object)"panel-failed"),
+        };
+        outSkipReason.SetDisplayText("Output Skip Reason");
 
         // ================================================================
         // 4. PO Decision (priority, labels, automation level)
@@ -194,8 +258,11 @@ public class TriageItemCycleWorkflow : WorkflowBase
                 init,
                 gatherContext, extractContext,
                 panelReview, extractPanelResult,
+                panelUsable,
                 poDecision, extractDecision,
-                applyLabels, finish,
+                applyLabels,
+                markSkipped, outSkipReason,
+                finish,
             },
             Connections =
             {
@@ -203,14 +270,26 @@ public class TriageItemCycleWorkflow : WorkflowBase
                 Connect(gatherContext, extractContext),
                 Connect(extractContext, panelReview),
                 Connect(panelReview, extractPanelResult),
-                Connect(extractPanelResult, poDecision),
+                Connect(extractPanelResult, panelUsable),
+
+                // Usable (ok/partial) → PO decision → apply labels → finish.
+                ConnectOutcome(panelUsable, "True", poDecision),
                 Connect(poDecision, extractDecision),
                 Connect(extractDecision, applyLabels),
                 Connect(applyLabels, finish),
+
+                // Failed (below quorum) → mark skipped (NO labels) → finish.
+                // The False edge never falls through to the apply-labels path.
+                ConnectOutcome(panelUsable, "False", markSkipped),
+                Connect(markSkipped, outSkipReason),
+                Connect(outSkipReason, finish),
             }
         };
     }
 
     private static FlowConnection Connect(IActivity source, IActivity target)
         => new(new FlowEndpoint(source), new FlowEndpoint(target));
+
+    private static FlowConnection ConnectOutcome(IActivity source, string outcome, IActivity target)
+        => new(new FlowEndpoint(source, outcome), new FlowEndpoint(target));
 }

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TriagePanelReviewWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TriagePanelReviewWorkflow.cs
@@ -7,6 +7,9 @@ using Elsa.Workflows.Management.Activities.SetOutput;
 using Elsa.Workflows.Memory;
 using Elsa.Workflows.Models;
 using Elsa.Workflows.Runtime.Activities;
+using Tamma.Activities.ADL;
+using Tamma.Activities.Context;
+using Tamma.ElsaServer.Workflows.Helpers;
 using FlowEndpoint = Elsa.Workflows.Activities.Flowchart.Models.Endpoint;
 using FlowConnection = Elsa.Workflows.Activities.Flowchart.Models.Connection;
 
@@ -21,29 +24,42 @@ namespace Tamma.ElsaServer.Workflows;
 ///
 /// Each role dispatches llm-call with a role-specific triage action
 /// (security=assess-vulnerability, developer/tester=triage-defect,
-/// devops=diagnose-incident).
-/// Results are aggregated into a panel result JSON.
+/// devops=diagnose-incident) — LLM mediation via the central <c>llm-call</c>
+/// seam (the 32-5 boundary); no provider key ever enters the engine.
 ///
-/// For security alerts: CVE impact, attack surface, breaking changes,
-/// dependency chain, compatibility.
-///
-/// For issues: type classification, complexity estimate, scope.
+/// <para>Build-out (completeness audit 2026-06-22): the panel is now
+/// <b>fail-closed</b>. A role whose <c>llm-call</c> yields no/garbage response is
+/// recorded with <c>status="failed"</c> — NOT coalesced to a <c>{}</c>
+/// participant — and each role's finding is persisted immediately so a later-role
+/// failure does not lose earlier work. The aggregate exposes
+/// <c>succeededCount</c> / <c>failedRoles</c> / <c>panelStatus</c>; a
+/// <c>Panel Usable?</c> quorum gate routes a below-quorum panel to a
+/// <c>FAILED</c> terminal (<c>panelStatus="failed"</c>) so the parent cycle can
+/// skip label application — a failed panel is a LOUD failure, never a false
+/// "successful review". Every lifecycle transition emits a <c>TRIAGE.PANEL.*</c>
+/// DCB event via the durable drain (<see cref="EmitTriageEventActivity"/>).</para>
 ///
 /// Flow:
-///   Init → Security Review → Dev Review → DevOps Review → Tester Review
-///   → Aggregate Results → Output → Finish
+///   Init → Emit STARTED → (per role: Review(llm-call) → Extract → Store)x4
+///     → Aggregate → Panel Usable?
+///         ├─ True  → Outputs(ok/partial) → Emit COMPLETED/PARTIAL → Finish
+///         └─ False → Outputs(failed)      → Emit FAILED            → Finish
 ///
-/// Inputs: repository, itemJson, contextJson
-/// Outputs: panelResultJson
+/// Inputs: repository, itemJson, contextJson, tenantId, quorum
+/// Outputs: panelResultJson, panelStatus, succeededCount, failedRolesJson
 /// </summary>
 public class TriagePanelReviewWorkflow : WorkflowBase
 {
-    private static readonly string[] ReviewRoles =
+    /// <summary>
+    /// The single source of truth for the panel roster (DRY — the dispatch list
+    /// and the aggregation iterate this one list, so they cannot drift).
+    /// </summary>
+    private static readonly AgentRole[] PanelRoles =
     [
-        "security",
-        "developer",
-        "devops",
-        "tester",
+        AgentRole.Security,
+        AgentRole.Developer,
+        AgentRole.Devops,
+        AgentRole.Tester,
     ];
 
     protected override void Build(IWorkflowBuilder builder)
@@ -51,7 +67,7 @@ public class TriagePanelReviewWorkflow : WorkflowBase
         builder.Name = "Triage Panel Review";
         builder.DefinitionId = "triage-panel-review";
         builder.Version = WorkflowVersions.ComputedVersion;
-        builder.Description = "4-role panel reviews item for triage (security/dev/devops/qa)";
+        builder.Description = "4-role panel reviews item for triage (security/dev/devops/qa), fail-closed";
 
         // ================================================================
         // Variables
@@ -59,21 +75,26 @@ public class TriagePanelReviewWorkflow : WorkflowBase
         var repository = builder.WithVariable<string>("Repository", "");
         var itemJson = builder.WithVariable<string>("ItemJson", "");
         var contextJson = builder.WithVariable<string>("ContextJson", "{}");
+        var tenantId = builder.WithVariable<string>("TenantId", "");
+        var quorum = builder.WithVariable<int>("Quorum", TriageEvents.DefaultQuorum);
+        var itemNumber = builder.WithVariable<int>("ItemNumber", 0);
 
-        // Per-role review results
-        var securityReview = builder.WithVariable<string>("SecurityReview", "{}");
-        var developerReview = builder.WithVariable<string>("DeveloperReview", "{}");
-        var devopsReview = builder.WithVariable<string>("DevOpsReview", "{}");
-        var testerReview = builder.WithVariable<string>("TesterReview", "{}");
+        // Per-role review results (JSON strings). Default "{}" = no usable review.
+        var roleReviewVars = PanelRoles.ToDictionary(
+            r => r,
+            r => builder.WithVariable<string>($"{r}Review", "{}"));
 
-        // Aggregated result
+        // Aggregated result + panel-health contract.
         var panelResultJson = builder.WithVariable<string>("PanelResultJson", "{}");
+        var panelStatus = builder.WithVariable<string>("PanelStatus", TriagePanelAggregationHelper.StatusFailed);
+        var succeededCount = builder.WithVariable<int>("SucceededCount", 0);
+        var failedRolesJson = builder.WithVariable<string>("FailedRolesJson", "[]");
 
-        // Shared LLM result
+        // Shared LLM result.
         var llmResult = builder.WithVariable<IDictionary<string, object>?>();
 
         // ================================================================
-        // 1. Init
+        // 1. Init — copy inputs; parse the item number for store key + event tags.
         // ================================================================
         var init = new SetVariable
         {
@@ -82,43 +103,50 @@ public class TriagePanelReviewWorkflow : WorkflowBase
             Value = new Input<object?>(ctx =>
             {
                 var repo = ctx.GetInput<string>("repository") ?? "";
-                itemJson.Set(ctx, ctx.GetInput<string>("itemJson") ?? "");
+                var item = ctx.GetInput<string>("itemJson") ?? "";
+                itemJson.Set(ctx, item);
                 contextJson.Set(ctx, ctx.GetInput<string>("contextJson") ?? "{}");
+                tenantId.Set(ctx, ctx.GetInput<string>("tenantId") ?? "");
+                var inputQuorum = ctx.GetInput<int?>("quorum");
+                if (inputQuorum.HasValue && inputQuorum.Value >= 1)
+                    quorum.Set(ctx, inputQuorum.Value);
+                itemNumber.Set(ctx, TriagePanelAggregationHelper.ParseItemNumber(item));
                 return (object)repo;
             })
         };
         init.SetDisplayText("Initialize");
 
         // ================================================================
-        // 2. Role Reviews — 4 sequential llm-call dispatches
+        // 2. Emit TRIAGE.PANEL.STARTED
         // ================================================================
-
-        // Security review
-        var secReviewCall = RoleTriageDispatch("SecReview", "Security Review", AgentRole.Security,
-            repository, itemJson, contextJson, llmResult);
-        var extractSec = ExtractTriageReview(securityReview, llmResult,
-            "ExtractSecReview", "Extract Security Review");
-
-        // Developer review
-        var devReviewCall = RoleTriageDispatch("DevReview", "Developer Review", AgentRole.Developer,
-            repository, itemJson, contextJson, llmResult);
-        var extractDev = ExtractTriageReview(developerReview, llmResult,
-            "ExtractDevReview", "Extract Developer Review");
-
-        // DevOps review
-        var devopsReviewCall = RoleTriageDispatch("DevOpsReview", "DevOps Review", AgentRole.Devops,
-            repository, itemJson, contextJson, llmResult);
-        var extractDevOps = ExtractTriageReview(devopsReview, llmResult,
-            "ExtractDevOpsReview", "Extract DevOps Review");
-
-        // Tester review
-        var testerReviewCall = RoleTriageDispatch("TesterReview", "Tester Review", AgentRole.Tester,
-            repository, itemJson, contextJson, llmResult);
-        var extractTester = ExtractTriageReview(testerReview, llmResult,
-            "ExtractTesterReview", "Extract Tester Review");
+        var emitStarted = EmitPanelEvent("EmitStarted", "Emit TRIAGE.PANEL.STARTED",
+            _ => TriageEvents.PanelStarted,
+            repository, itemNumber, tenantId,
+            _ => PanelRoles.Length, _ => 0, _ => "[]");
 
         // ================================================================
-        // 3. Aggregate Results
+        // 3. Role Reviews — 4 sequential llm-call dispatches, each followed by
+        //    extraction and immediate persistence (so partial work survives).
+        // ================================================================
+        var roleNodes = new List<(DispatchWorkflow call, SetVariable extract, StoreRoleFindingActivity store)>();
+        foreach (var role in PanelRoles)
+        {
+            var reviewVar = roleReviewVars[role];
+            var idBase = role.ToString(); // Security / Developer / Devops / Tester
+
+            var call = RoleTriageDispatch($"{idBase}Review", $"{idBase} Review", role,
+                repository, itemJson, contextJson, llmResult);
+            var extract = ExtractTriageReview(reviewVar, llmResult,
+                $"Extract{idBase}Review", $"Extract {idBase} Review");
+            var store = StoreReviewRole($"Store{idBase}Review", $"Store {idBase} Review",
+                $"triage-{role.ToWire()}", repository, itemNumber, reviewVar);
+
+            roleNodes.Add((call, extract, store));
+        }
+
+        // ================================================================
+        // 4. Aggregate Results — fail-closed. Failed/empty role reviews are
+        //    recorded as status="failed", NOT as {} participants.
         // ================================================================
         var aggregate = new SetVariable
         {
@@ -126,65 +154,52 @@ public class TriagePanelReviewWorkflow : WorkflowBase
             Variable = panelResultJson,
             Value = new Input<object?>(ctx =>
             {
-                var roleVars = new Dictionary<string, Variable<string>>
-                {
-                    ["security"] = securityReview,
-                    ["developer"] = developerReview,
-                    ["devops"] = devopsReview,
-                    ["tester"] = testerReview,
-                };
+                var reviews = PanelRoles.ToDictionary(
+                    r => r.ToWire(),
+                    r => (string?)roleReviewVars[r].Get(ctx));
 
-                var reviews = new List<object>();
-                foreach (var role in ReviewRoles)
-                {
-                    var reviewJson = roleVars[role].Get(ctx);
-                    try
-                    {
-                        if (!string.IsNullOrWhiteSpace(reviewJson) && reviewJson != "{}")
-                        {
-                            var parsed = JsonSerializer.Deserialize<JsonElement>(reviewJson);
-                            reviews.Add(new Dictionary<string, object>
-                            {
-                                ["role"] = role,
-                                ["assessment"] = parsed.GetRawText(),
-                            });
-                        }
-                        else
-                        {
-                            reviews.Add(new Dictionary<string, object>
-                            {
-                                ["role"] = role,
-                                ["assessment"] = "{}",
-                            });
-                        }
-                    }
-                    catch
-                    {
-                        reviews.Add(new Dictionary<string, object>
-                        {
-                            ["role"] = role,
-                            ["assessment"] = JsonSerializer.Serialize(new { raw = reviewJson }),
-                        });
-                    }
-                }
+                var roster = PanelRoles.Select(r => r.ToWire()).ToList();
+                var result = TriagePanelAggregationHelper.Aggregate(roster, reviews, quorum.Get(ctx));
 
-                var result = JsonSerializer.Serialize(new Dictionary<string, object>
-                {
-                    ["reviews"] = reviews,
-                    ["reviewCount"] = reviews.Count,
-                });
+                // Surface the panel-health signal as separate workflow variables so
+                // the gate + the emit nodes + the outputs all read the same source.
+                panelStatus.Set(ctx, result.PanelStatus);
+                succeededCount.Set(ctx, result.SucceededCount);
+                failedRolesJson.Set(ctx, JsonSerializer.Serialize(result.FailedRoles));
 
-                return (object)result;
+                return (object)TriagePanelAggregationHelper.Serialize(result);
             })
         };
         aggregate.SetDisplayText("Aggregate Results");
 
         // ================================================================
-        // 4. Set Outputs
+        // 5. Panel Usable? — quorum gate. Below quorum (panelStatus="failed")
+        //    routes to the FAILED terminal; ok/partial route to the usable
+        //    terminal. NO false success: a failed panel never reaches COMPLETED.
         // ================================================================
-        var setOutputs = new SetOutput
-        { Id = "OutPanelResult", OutputName = new("panelResultJson"), OutputValue = new(ctx => (object)panelResultJson.Get(ctx)) };
-        setOutputs.SetDisplayText("Output Panel Result");
+        var panelUsable = new FlowDecision(ctx =>
+            panelStatus.Get(ctx) != TriagePanelAggregationHelper.StatusFailed)
+        { Id = "PanelUsable", Name = "Panel Usable?" };
+        panelUsable.SetDisplayText("Panel Usable?");
+
+        // ----- Usable path (ok / partial) -----
+        var usableOutputs = BuildOutputs("UsableOutputs", "Usable Outputs",
+            panelResultJson, panelStatus, succeededCount, failedRolesJson);
+
+        // Emit COMPLETED (status=ok) or PARTIAL (some failed) — driven by panelStatus.
+        var emitUsable = EmitPanelEvent("EmitUsable", "Emit TRIAGE.PANEL.COMPLETED/PARTIAL",
+            ctx => TriagePanelAggregationHelper.EventTypeForStatus(panelStatus.Get(ctx)),
+            repository, itemNumber, tenantId,
+            _ => PanelRoles.Length, ctx => succeededCount.Get(ctx), ctx => failedRolesJson.Get(ctx));
+
+        // ----- Failed path (below quorum) -----
+        var failedOutputs = BuildOutputs("FailedOutputs", "Failed Outputs",
+            panelResultJson, panelStatus, succeededCount, failedRolesJson);
+
+        var emitFailed = EmitPanelEvent("EmitFailed", "Emit TRIAGE.PANEL.FAILED",
+            _ => TriageEvents.PanelFailed,
+            repository, itemNumber, tenantId,
+            _ => PanelRoles.Length, ctx => succeededCount.Get(ctx), ctx => failedRolesJson.Get(ctx));
 
         var finish = new Finish { Id = "Finish", Name = "Complete" };
         finish.SetDisplayText("Complete");
@@ -192,42 +207,118 @@ public class TriagePanelReviewWorkflow : WorkflowBase
         // ================================================================
         // Flowchart
         // ================================================================
+        var activities = new List<IActivity> { init, emitStarted };
+        foreach (var (call, extract, store) in roleNodes)
+        {
+            activities.Add(call);
+            activities.Add(extract);
+            activities.Add(store);
+        }
+        activities.Add(aggregate);
+        activities.Add(panelUsable);
+        activities.Add(usableOutputs);
+        activities.Add(emitUsable);
+        activities.Add(failedOutputs);
+        activities.Add(emitFailed);
+        activities.Add(finish);
+
+        var connections = new List<FlowConnection>
+        {
+            Connect(init, emitStarted),
+            Connect(emitStarted, roleNodes[0].call),
+        };
+
+        // Per-role chain: call → extract → store → next role's call.
+        for (var i = 0; i < roleNodes.Count; i++)
+        {
+            var (call, extract, store) = roleNodes[i];
+            connections.Add(Connect(call, extract));
+            connections.Add(Connect(extract, store));
+            if (i + 1 < roleNodes.Count)
+                connections.Add(Connect(store, roleNodes[i + 1].call));
+            else
+                connections.Add(Connect(store, aggregate));
+        }
+
+        // Aggregate → quorum gate → (usable | failed) terminals.
+        connections.Add(Connect(aggregate, panelUsable));
+
+        // Usable: outputs → emit COMPLETED/PARTIAL → finish.
+        connections.Add(ConnectOutcome(panelUsable, "True", usableOutputs));
+        connections.Add(Connect(usableOutputs, emitUsable));
+        connections.Add(Connect(emitUsable, finish));
+
+        // Failed: outputs (panelStatus=failed) → emit FAILED → finish.
+        // The Error/False edge NEVER falls through to the usable/COMPLETED path.
+        connections.Add(ConnectOutcome(panelUsable, "False", failedOutputs));
+        connections.Add(Connect(failedOutputs, emitFailed));
+        connections.Add(Connect(emitFailed, finish));
+
         builder.Root = new Flowchart
         {
             Id = "TriagePanelReviewFlowchart",
             Start = init,
-            Activities =
-            {
-                init,
-                secReviewCall, extractSec,
-                devReviewCall, extractDev,
-                devopsReviewCall, extractDevOps,
-                testerReviewCall, extractTester,
-                aggregate,
-                setOutputs, finish,
-            },
-            Connections =
-            {
-                // Init → sequential role reviews
-                Connect(init, secReviewCall),
-                Connect(secReviewCall, extractSec),
-                Connect(extractSec, devReviewCall),
-                Connect(devReviewCall, extractDev),
-                Connect(extractDev, devopsReviewCall),
-                Connect(devopsReviewCall, extractDevOps),
-                Connect(extractDevOps, testerReviewCall),
-                Connect(testerReviewCall, extractTester),
-
-                // → Aggregate → Output → Finish
-                Connect(extractTester, aggregate),
-                Connect(aggregate, setOutputs),
-                Connect(setOutputs, finish),
-            }
+            Activities = activities,
+            Connections = connections,
         };
     }
 
     // ================================================================
-    // Helper: Create a DispatchWorkflow for a triage role review
+    // Helper: Set the four workflow outputs (identical on both terminals; the
+    // panelStatus value differs by which terminal set it).
+    // ================================================================
+    private static Sequence BuildOutputs(
+        string id, string name,
+        Variable<string> panelResultJson, Variable<string> panelStatus,
+        Variable<int> succeededCount, Variable<string> failedRolesJson)
+    {
+        var seq = new Sequence
+        {
+            Id = id, Name = name,
+            Activities =
+            {
+                WithLabel(new SetOutput
+                    { Id = $"{id}_PanelResult", OutputName = new("panelResultJson"), OutputValue = new(ctx => (object)panelResultJson.Get(ctx)) }, "Output panelResultJson"),
+                WithLabel(new SetOutput
+                    { Id = $"{id}_PanelStatus", OutputName = new("panelStatus"), OutputValue = new(ctx => (object)panelStatus.Get(ctx)) }, "Output panelStatus"),
+                WithLabel(new SetOutput
+                    { Id = $"{id}_Succeeded", OutputName = new("succeededCount"), OutputValue = new(ctx => (object)succeededCount.Get(ctx)) }, "Output succeededCount"),
+                WithLabel(new SetOutput
+                    { Id = $"{id}_FailedRoles", OutputName = new("failedRolesJson"), OutputValue = new(ctx => (object)failedRolesJson.Get(ctx)) }, "Output failedRolesJson"),
+            }
+        };
+        seq.SetDisplayText(name);
+        return seq;
+    }
+
+    // ================================================================
+    // Helper: Emit a TRIAGE.PANEL.* DCB event through the durable drain.
+    // ================================================================
+    private static EmitTriageEventActivity EmitPanelEvent(
+        string id, string label,
+        Func<Elsa.Expressions.Models.ExpressionExecutionContext, string> eventType,
+        Variable<string> repository, Variable<int> itemNumber, Variable<string> tenantId,
+        Func<Elsa.Expressions.Models.ExpressionExecutionContext, int> roleCount,
+        Func<Elsa.Expressions.Models.ExpressionExecutionContext, int> succeededCount,
+        Func<Elsa.Expressions.Models.ExpressionExecutionContext, string> failedRolesJson)
+    {
+        var emit = new EmitTriageEventActivity
+        {
+            Id = id, Name = label,
+            EventType = new Input<string>(eventType),
+            Repository = new Input<string>(ctx => repository.Get(ctx)),
+            ItemNumber = new Input<int>(ctx => itemNumber.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
+            RoleCount = new Input<int>(roleCount),
+            SucceededCount = new Input<int>(succeededCount),
+            FailedRolesJson = new Input<string?>(ctx => failedRolesJson(ctx)),
+        };
+        emit.SetDisplayText(label);
+        return emit;
+    }
+
+    // ================================================================
+    // Helper: Create a DispatchWorkflow for a triage role review (llm-call).
     // ================================================================
     private static DispatchWorkflow RoleTriageDispatch(
         string id, string displayName, AgentRole role,
@@ -259,7 +350,13 @@ public class TriagePanelReviewWorkflow : WorkflowBase
     }
 
     // ================================================================
-    // Helper: Extract a role's triage review from llmResult
+    // Helper: Extract a role's triage review from llmResult.
+    //
+    // Fail-closed: when llmResult is null / has no llmResponse / yields no
+    // parseable JSON object, the target is left as the "{}" sentinel — which the
+    // aggregation classifies as a FAILED role (NOT a participant). A real JSON
+    // object is stored verbatim; free-form prose is wrapped as a usable
+    // {"rawAssessment": ...} object (the role still produced an assessment).
     // ================================================================
     private static SetVariable ExtractTriageReview(
         Variable<string> target,
@@ -273,36 +370,68 @@ public class TriagePanelReviewWorkflow : WorkflowBase
             Value = new Input<object?>(ctx =>
             {
                 var result = llmResult.Get(ctx);
-                if (result != null && result.TryGetValue("llmResponse", out var r))
+
+                // No result, or the mediated call reported failure → fail-closed "{}".
+                if (result == null) return (object)"{}";
+                var success = !result.TryGetValue("success", out var s) || s is true;
+                if (!success) return (object)"{}";
+                if (!result.TryGetValue("llmResponse", out var r)) return (object)"{}";
+
+                var output = r?.ToString();
+                if (string.IsNullOrWhiteSpace(output)) return (object)"{}";
+
+                var jsonStart = output.IndexOf('{');
+                var jsonEnd = output.LastIndexOf('}');
+                if (jsonStart >= 0 && jsonEnd > jsonStart)
                 {
-                    var output = r?.ToString() ?? "{}";
-
-                    var jsonStart = output.IndexOf('{');
-                    var jsonEnd = output.LastIndexOf('}');
-                    if (jsonStart >= 0 && jsonEnd > jsonStart)
+                    var jsonCandidate = output[jsonStart..(jsonEnd + 1)];
+                    try
                     {
-                        var jsonCandidate = output[jsonStart..(jsonEnd + 1)];
-                        try
-                        {
-                            JsonDocument.Parse(jsonCandidate);
-                            return (object)jsonCandidate;
-                        }
-                        catch { /* not valid JSON */ }
+                        using var doc = JsonDocument.Parse(jsonCandidate);
+                        // An empty {} object is not a usable assessment → fall through.
+                        var hasAny = false;
+                        if (doc.RootElement.ValueKind == JsonValueKind.Object)
+                            foreach (var _ in doc.RootElement.EnumerateObject()) { hasAny = true; break; }
+                        if (hasAny) return (object)jsonCandidate;
                     }
-
-                    // Wrap raw text
-                    return (object)JsonSerializer.Serialize(new Dictionary<string, string>
-                    {
-                        ["rawAssessment"] = output,
-                    });
+                    catch { /* not valid JSON */ }
                 }
-                return (object)"{}";
+
+                // Free-form prose is still a usable assessment — wrap it.
+                return (object)JsonSerializer.Serialize(new Dictionary<string, string>
+                {
+                    ["rawAssessment"] = output,
+                });
             })
         };
         sv.SetDisplayText(displayName);
         return sv;
     }
 
+    // ================================================================
+    // Helper: Persist a role's finding immediately (partial-result durability).
+    // ================================================================
+    private static StoreRoleFindingActivity StoreReviewRole(
+        string id, string name, string role,
+        Variable<string> repository, Variable<int> itemNumber,
+        Variable<string> reviewVar)
+    {
+        var store = new StoreRoleFindingActivity
+        {
+            Id = id, Name = name,
+            Repository = new Input<string>(ctx => repository.Get(ctx)),
+            IssueNumber = new Input<int>(ctx => itemNumber.Get(ctx)),
+            Role = new Input<string>(role),
+            FindingsJson = new Input<string>(ctx => reviewVar.Get(ctx)),
+            ContextId = new Output<string>(new Variable<string>()),
+        };
+        store.SetDisplayText(name);
+        return store;
+    }
+
     private static FlowConnection Connect(IActivity source, IActivity target)
         => new(new FlowEndpoint(source), new FlowEndpoint(target));
+
+    private static FlowConnection ConnectOutcome(IActivity source, string outcome, IActivity target)
+        => new(new FlowEndpoint(source, outcome), new FlowEndpoint(target));
 }

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/TriagePanelEventTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/TriagePanelEventTests.cs
@@ -1,0 +1,164 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+
+namespace Tamma.Activities.Tests.ADL;
+
+/// <summary>
+/// Completeness audit 2026-06-22 — coverage for the TRIAGE.PANEL.* DCB event
+/// mapping (<see cref="EmitTriageEventActivity.BuildTammaEvent"/>) and the
+/// <see cref="TriageEvents"/> status convention. A degraded/failed panel must map
+/// to a loud (warning/error) status, never a false "success" audit row, and the
+/// roster-health payload (roleCount/succeededCount/failedRoles) must be carried so
+/// the audit trail can see a degraded panel.
+/// </summary>
+[TestFixture]
+public class TriagePanelEventTests
+{
+    // ================================================================
+    // TriageEvents — status convention (no false success)
+    // ================================================================
+
+    [Test]
+    public void StatusForEvent_FailedIsError_PartialIsWarning_CompletedIsSuccess()
+    {
+        TriageEvents.StatusForEvent(TriageEvents.PanelFailed).Should().Be("error");
+        TriageEvents.StatusForEvent(TriageEvents.PanelPartial).Should().Be("warning");
+        TriageEvents.StatusForEvent(TriageEvents.PanelCompleted).Should().Be("success");
+        TriageEvents.StatusForEvent(TriageEvents.PanelStarted).Should().Be("success");
+    }
+
+    [Test]
+    public void EventTypes_FollowAggregateActionStatusConvention()
+    {
+        TriageEvents.PanelStarted.Should().Be("TRIAGE.PANEL.STARTED");
+        TriageEvents.PanelCompleted.Should().Be("TRIAGE.PANEL.COMPLETED");
+        TriageEvents.PanelPartial.Should().Be("TRIAGE.PANEL.PARTIAL");
+        TriageEvents.PanelFailed.Should().Be("TRIAGE.PANEL.FAILED");
+    }
+
+    [Test]
+    public void ParseTenantId_ValidGuid_Parses_InvalidOrEmpty_IsNull()
+    {
+        var g = Guid.NewGuid();
+        TriageEvents.ParseTenantId(g.ToString()).Should().Be(g);
+        TriageEvents.ParseTenantId("").Should().BeNull();
+        TriageEvents.ParseTenantId(null).Should().BeNull();
+        TriageEvents.ParseTenantId("not-a-guid").Should().BeNull();
+    }
+
+    // ================================================================
+    // BuildTammaEvent — tags + data + status mapping
+    // ================================================================
+
+    [Test]
+    public void BuildTammaEvent_Completed_HasSuccessStatus_AndHealthPayload()
+    {
+        var evt = EmitTriageEventActivity.BuildTammaEvent(
+            TriageEvents.PanelCompleted,
+            repository: "owner/repo",
+            itemNumber: 7,
+            tenantId: null,
+            roleCount: 4,
+            succeededCount: 4,
+            failedRolesJson: "[]");
+
+        evt.EventType.Should().Be("TRIAGE.PANEL.COMPLETED");
+        evt.Status.Should().Be("success");
+
+        evt.Tags!["repository"].Should().Be("owner/repo");
+        evt.Tags!["itemId"].Should().Be("7");
+        evt.Tags!["itemNumber"].Should().Be("7");
+        evt.Tags.Should().NotContainKey("tenantId", "single-user / platform-scope event");
+
+        evt.Data["roleCount"].Should().Be(4);
+        evt.Data["succeededCount"].Should().Be(4);
+        evt.Data["failedRoles"].Should().BeOfType<List<string>>()
+            .Which.Should().BeEmpty();
+    }
+
+    [Test]
+    public void BuildTammaEvent_Failed_HasErrorStatus_AndFailedRoster()
+    {
+        // The core guarantee: a failed panel is a LOUD (error) audit row carrying
+        // the failed roster — never a silent false success.
+        var evt = EmitTriageEventActivity.BuildTammaEvent(
+            TriageEvents.PanelFailed,
+            repository: "owner/repo",
+            itemNumber: 99,
+            tenantId: null,
+            roleCount: 4,
+            succeededCount: 0,
+            failedRolesJson: """["security","developer","devops","tester"]""");
+
+        evt.EventType.Should().Be("TRIAGE.PANEL.FAILED");
+        evt.Status.Should().Be("error");
+        evt.Data["succeededCount"].Should().Be(0);
+        evt.Data["failedRoles"].Should().BeOfType<List<string>>()
+            .Which.Should().BeEquivalentTo("security", "developer", "devops", "tester");
+    }
+
+    [Test]
+    public void BuildTammaEvent_Partial_HasWarningStatus()
+    {
+        var evt = EmitTriageEventActivity.BuildTammaEvent(
+            TriageEvents.PanelPartial,
+            repository: "owner/repo",
+            itemNumber: 3,
+            tenantId: null,
+            roleCount: 4,
+            succeededCount: 3,
+            failedRolesJson: """["tester"]""");
+
+        evt.Status.Should().Be("warning");
+        evt.Data["failedRoles"].Should().BeOfType<List<string>>()
+            .Which.Should().ContainSingle().Which.Should().Be("tester");
+    }
+
+    [Test]
+    public void BuildTammaEvent_WithTenant_StampsTenantTag()
+    {
+        var tenant = Guid.NewGuid();
+        var evt = EmitTriageEventActivity.BuildTammaEvent(
+            TriageEvents.PanelStarted,
+            repository: "owner/repo",
+            itemNumber: 1,
+            tenantId: tenant,
+            roleCount: 4,
+            succeededCount: 0,
+            failedRolesJson: "[]");
+
+        evt.Tags!["tenantId"].Should().Be(tenant.ToString("D"));
+    }
+
+    [Test]
+    public void BuildTammaEvent_ZeroItemNumber_OmitsItemTags()
+    {
+        var evt = EmitTriageEventActivity.BuildTammaEvent(
+            TriageEvents.PanelStarted, "owner/repo", 0, null, 4, 0, "[]");
+
+        evt.Tags!.Should().NotContainKey("itemId");
+        evt.Tags!.Should().NotContainKey("itemNumber");
+        evt.Tags!["repository"].Should().Be("owner/repo");
+    }
+
+    // ================================================================
+    // ParseFailedRoles — tolerant of malformed JSON (event still emits)
+    // ================================================================
+
+    [Test]
+    public void ParseFailedRoles_ValidArray_Parses()
+    {
+        EmitTriageEventActivity.ParseFailedRoles("""["a","b"]""")
+            .Should().BeEquivalentTo("a", "b");
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("not json")]
+    [TestCase("{}")]
+    public void ParseFailedRoles_NullOrMalformed_ReturnsEmpty_NeverThrows(string? json)
+    {
+        EmitTriageEventActivity.ParseFailedRoles(json).Should().BeEmpty();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TriageItemCycleRoutingTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TriageItemCycleRoutingTests.cs
@@ -1,0 +1,119 @@
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Runtime.Activities;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Completeness audit 2026-06-22 — the consumer of the (now fail-closed)
+/// triage panel must HONOUR its failure signal. A "failed" panel (below quorum)
+/// must NOT march on to PO decision + label application: it routes to a loud
+/// non-applying terminal (no silent false success downstream). An "ok"/"partial"
+/// panel proceeds as before. Both gate outcomes reach Finish (no deadlock/hang).
+/// </summary>
+[TestFixture]
+public class TriageItemCycleRoutingTests
+{
+    private Flowchart _flowchart = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new TriageItemCycleWorkflow());
+        _flowchart = WorkflowTestHelper.GetFlowchart(builder);
+    }
+
+    [Test]
+    public void Workflow_BuildsWithExpectedDefinitionId()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new TriageItemCycleWorkflow());
+        builder.Object.DefinitionId.Should().Be("triage-item-cycle");
+    }
+
+    [Test]
+    public void PanelUsableGate_Exists_AfterExtractingPanelResult()
+    {
+        _flowchart.Activities.OfType<FlowDecision>()
+            .Any(d => d.Id == "PanelUsable")
+            .Should().BeTrue("the cycle must gate on the panel's fail-closed signal");
+
+        HasEdge("ExtractPanelResult", null, "PanelUsable").Should().BeTrue();
+    }
+
+    [Test]
+    public void UsablePanel_ProceedsToPoDecisionAndLabels()
+    {
+        HasEdge("PanelUsable", "True", "PODecision").Should().BeTrue();
+        HasEdge("PODecision", null, "ExtractDecision").Should().BeTrue();
+        HasEdge("ExtractDecision", null, "ApplyLabels").Should().BeTrue();
+        HasEdge("ApplyLabels", null, "Finish").Should().BeTrue();
+    }
+
+    [Test]
+    public void FailedPanel_SkipsLabelApplication_RoutesToLoudTerminal()
+    {
+        // False (failed panel) → mark skipped → finish. It must NOT reach the PO
+        // decision or the label-application activity (no silent labelling off a
+        // wholly-failed panel).
+        HasEdge("PanelUsable", "False", "MarkSkipped").Should().BeTrue();
+        HasEdge("MarkSkipped", null, "OutSkipReason").Should().BeTrue();
+        HasEdge("OutSkipReason", null, "Finish").Should().BeTrue();
+
+        var falseTargets = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "PanelUsable" && c.Source.Port == "False")
+            .Select(c => c.Target.Activity.Id)
+            .ToList();
+
+        falseTargets.Should().NotContain("PODecision");
+        falseTargets.Should().NotContain("ApplyLabels");
+    }
+
+    [Test]
+    public void PanelUsableGate_HasNoUnconditionalFallthrough()
+    {
+        var fromGate = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "PanelUsable")
+            .ToList();
+
+        fromGate.Should().NotBeEmpty();
+        fromGate.Should().OnlyContain(c => c.Source.Port == "True" || c.Source.Port == "False");
+    }
+
+    [Test]
+    public void BothGateOutcomes_ReachFinish_NoDeadlock()
+    {
+        // Usable path: ApplyLabels → Finish. Failed path: OutSkipReason → Finish.
+        HasEdge("ApplyLabels", null, "Finish").Should().BeTrue();
+        HasEdge("OutSkipReason", null, "Finish").Should().BeTrue();
+    }
+
+    [Test]
+    public void PanelDispatch_ThreadsTenantId()
+    {
+        // The cycle threads tenantId through to the panel sub-workflow input so a
+        // tenant-scoped caller's TRIAGE.PANEL.* events carry the tenant tag.
+        var dispatch = _flowchart.Activities
+            .OfType<DispatchWorkflow>()
+            .FirstOrDefault(d => d.Id == "PanelReview");
+        dispatch.Should().NotBeNull();
+        ReadDefinitionId(dispatch!).Should().Be("triage-panel-review");
+    }
+
+    private bool HasEdge(string sourceId, string? port, string targetId)
+        => _flowchart.Connections.Any(c =>
+            c.Source.Activity.Id == sourceId &&
+            (port == null || c.Source.Port == port) &&
+            c.Target.Activity.Id == targetId);
+
+    private static string? ReadDefinitionId(DispatchWorkflow dispatch)
+    {
+        var prop = typeof(DispatchWorkflow).GetProperty("WorkflowDefinitionId");
+        var value = prop?.GetValue(dispatch);
+        var expression = value?.GetType().GetProperty("Expression")?.GetValue(value)
+            as Elsa.Expressions.Models.Expression;
+        return expression?.Value?.ToString();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TriagePanelAggregationHelperTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TriagePanelAggregationHelperTests.cs
@@ -1,0 +1,291 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.ElsaServer.Workflows.Helpers;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Completeness audit 2026-06-22 — the CORE regression coverage for the
+/// triage-panel build-out: <see cref="TriagePanelAggregationHelper"/> must be
+/// <b>fail-closed</b>. A failed/empty per-role review is NEVER coalesced to a
+/// <c>{}</c> participant reported as a success; it surfaces a per-role failure
+/// signal (<c>status="failed"</c>) and is counted in <c>failedRoles</c>, and a
+/// wholly-failed panel reports <c>panelStatus="failed"</c> (the no-false-success
+/// rule). These are pure-function tests independent of the Elsa runtime.
+/// </summary>
+[TestFixture]
+public class TriagePanelAggregationHelperTests
+{
+    private static readonly IReadOnlyList<string> Roster =
+        new[] { "security", "developer", "devops", "tester" };
+
+    // ================================================================
+    // ClassifyRole — the fail-closed unit (no {}-as-participant)
+    // ================================================================
+
+    [Test]
+    public void ClassifyRole_EmptyObjectSentinel_IsFailed_NotParticipant()
+    {
+        // The "{}" sentinel is the no-usable-review marker — it must classify as
+        // FAILED, never as an ok participant. This is the headline bug.
+        var rr = TriagePanelAggregationHelper.ClassifyRole("security", "{}");
+
+        rr.Ok.Should().BeFalse("an empty {} review is not a usable assessment");
+        rr.Role.Should().Be("security");
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    public void ClassifyRole_NullOrBlank_IsFailed(string? review)
+    {
+        TriagePanelAggregationHelper.ClassifyRole("developer", review)
+            .Ok.Should().BeFalse();
+    }
+
+    [Test]
+    public void ClassifyRole_UnparseableJson_IsFailed_FailClosed()
+    {
+        // Garbage from the LLM must NOT pass as a usable assessment.
+        TriagePanelAggregationHelper.ClassifyRole("devops", "{not valid json")
+            .Ok.Should().BeFalse();
+    }
+
+    [Test]
+    public void ClassifyRole_NonObjectJson_IsFailed()
+    {
+        // A bare JSON array / scalar is not a structured assessment object.
+        TriagePanelAggregationHelper.ClassifyRole("tester", "[1,2,3]")
+            .Ok.Should().BeFalse();
+    }
+
+    [Test]
+    public void ClassifyRole_NonEmptyObject_IsOk_AndParsesStructuredFields()
+    {
+        var json = """
+        {"verdict":"defect","severity":"high","suggestedLabels":["bug","p1"],"notes":"npe on null path"}
+        """;
+
+        var rr = TriagePanelAggregationHelper.ClassifyRole("developer", json);
+
+        rr.Ok.Should().BeTrue();
+        rr.Verdict.Should().Be("defect");
+        rr.Severity.Should().Be("high");
+        rr.SuggestedLabels.Should().BeEquivalentTo("bug", "p1");
+        rr.Notes.Should().Be("npe on null path");
+        rr.RawAssessment.Should().Be(json);
+    }
+
+    [Test]
+    public void ClassifyRole_RawAssessmentWrapper_IsOk_EvenWithoutTypedFields()
+    {
+        // Free-form prose wrapped as {"rawAssessment": "..."} is still a usable
+        // assessment — its absence of verdict/severity does NOT make it failed.
+        var json = """{"rawAssessment":"This looks like a config drift incident."}""";
+
+        var rr = TriagePanelAggregationHelper.ClassifyRole("devops", json);
+
+        rr.Ok.Should().BeTrue();
+        rr.Verdict.Should().BeEmpty();
+    }
+
+    // ================================================================
+    // Aggregate — panel health + status (the contract the PO consumes)
+    // ================================================================
+
+    [Test]
+    public void Aggregate_AllRolesUsable_IsOk_WithFullSucceededCount()
+    {
+        var reviews = AllOk();
+
+        var result = TriagePanelAggregationHelper.Aggregate(Roster, reviews, quorum: 2);
+
+        result.PanelStatus.Should().Be(TriagePanelAggregationHelper.StatusOk);
+        result.SucceededCount.Should().Be(4);
+        result.ReviewCount.Should().Be(4);
+        result.FailedRoles.Should().BeEmpty();
+    }
+
+    [Test]
+    public void Aggregate_OneRoleFailed_AtQuorum_IsPartial_NotOk_NotFailed()
+    {
+        var reviews = AllOk();
+        reviews["tester"] = "{}"; // tester failed
+
+        var result = TriagePanelAggregationHelper.Aggregate(Roster, reviews, quorum: 2);
+
+        result.PanelStatus.Should().Be(TriagePanelAggregationHelper.StatusPartial,
+            "one failure above quorum is degraded, not a clean success and not a failure");
+        result.SucceededCount.Should().Be(3);
+        result.FailedRoles.Should().ContainSingle().Which.Should().Be("tester");
+    }
+
+    [Test]
+    public void Aggregate_AllRolesFailed_IsFailed_NoFalseSuccess()
+    {
+        // THE core regression: a fully-failed panel must report panelStatus="failed"
+        // — never coalesced to four {} reviews reported as a usable/ok panel.
+        var reviews = new Dictionary<string, string?>
+        {
+            ["security"] = "{}",
+            ["developer"] = null,
+            ["devops"] = "garbage",
+            ["tester"] = "",
+        };
+
+        var result = TriagePanelAggregationHelper.Aggregate(Roster, reviews, quorum: 2);
+
+        result.PanelStatus.Should().Be(TriagePanelAggregationHelper.StatusFailed);
+        result.SucceededCount.Should().Be(0);
+        result.FailedRoles.Should().BeEquivalentTo(Roster);
+    }
+
+    [Test]
+    public void Aggregate_BelowQuorum_IsFailed_EvenWithSomeUsableReviews()
+    {
+        // 1 usable review but quorum is 2 → failed (fail-closed: too few to decide).
+        var reviews = new Dictionary<string, string?>
+        {
+            ["security"] = """{"verdict":"vuln","severity":"critical"}""",
+            ["developer"] = "{}",
+            ["devops"] = "{}",
+            ["tester"] = "{}",
+        };
+
+        var result = TriagePanelAggregationHelper.Aggregate(Roster, reviews, quorum: 2);
+
+        result.PanelStatus.Should().Be(TriagePanelAggregationHelper.StatusFailed);
+        result.SucceededCount.Should().Be(1);
+    }
+
+    [Test]
+    public void Aggregate_MissingRoleInDictionary_CountsAsFailed_FailClosed()
+    {
+        // A role entirely absent from the results map must be treated as failed,
+        // not skipped — the roster, and thus the failure roster, stays complete.
+        var reviews = new Dictionary<string, string?>
+        {
+            ["security"] = """{"verdict":"ok"}""",
+            ["developer"] = """{"verdict":"ok"}""",
+            // devops + tester absent
+        };
+
+        var result = TriagePanelAggregationHelper.Aggregate(Roster, reviews, quorum: 2);
+
+        result.ReviewCount.Should().Be(4, "every roster role is represented");
+        result.SucceededCount.Should().Be(2);
+        result.FailedRoles.Should().BeEquivalentTo(new[] { "devops", "tester" });
+    }
+
+    [Test]
+    public void Aggregate_QuorumBelowOne_IsClampedToOne()
+    {
+        var reviews = new Dictionary<string, string?>
+        {
+            ["security"] = "{}",
+            ["developer"] = "{}",
+            ["devops"] = "{}",
+            ["tester"] = "{}",
+        };
+
+        // quorum 0 must not make a zero-success panel "usable".
+        var result = TriagePanelAggregationHelper.Aggregate(Roster, reviews, quorum: 0);
+
+        result.PanelStatus.Should().Be(TriagePanelAggregationHelper.StatusFailed);
+    }
+
+    // ================================================================
+    // Serialize — failed roles present in roster but NOT as {} successes
+    // ================================================================
+
+    [Test]
+    public void Serialize_FailedRole_HasStatusFailed_AndEmptyAssessment_NotBraces()
+    {
+        var reviews = AllOk();
+        reviews["devops"] = "{}"; // failed
+
+        var result = TriagePanelAggregationHelper.Aggregate(Roster, reviews, quorum: 2);
+        var json = TriagePanelAggregationHelper.Serialize(result);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        root.GetProperty("panelStatus").GetString().Should().Be("partial");
+        root.GetProperty("succeededCount").GetInt32().Should().Be(3);
+        root.GetProperty("reviewCount").GetInt32().Should().Be(4);
+
+        var failed = root.GetProperty("reviews").EnumerateArray()
+            .Single(r => r.GetProperty("role").GetString() == "devops");
+
+        failed.GetProperty("status").GetString().Should().Be("failed");
+        // The failed role's assessment must be empty — NOT a "{}" that the PO
+        // could mistake for an empty-but-present assessment.
+        failed.GetProperty("assessment").GetString().Should().BeEmpty();
+
+        var failedRoles = root.GetProperty("failedRoles").EnumerateArray()
+            .Select(e => e.GetString()).ToList();
+        failedRoles.Should().Contain("devops");
+    }
+
+    [Test]
+    public void Serialize_OkRole_CarriesRawAssessment()
+    {
+        var reviews = AllOk();
+        var result = TriagePanelAggregationHelper.Aggregate(Roster, reviews, quorum: 2);
+        var json = TriagePanelAggregationHelper.Serialize(result);
+
+        using var doc = JsonDocument.Parse(json);
+        var sec = doc.RootElement.GetProperty("reviews").EnumerateArray()
+            .Single(r => r.GetProperty("role").GetString() == "security");
+
+        sec.GetProperty("status").GetString().Should().Be("ok");
+        sec.GetProperty("assessment").GetString().Should().NotBeEmpty();
+    }
+
+    // ================================================================
+    // EventTypeForStatus + ParseItemNumber helpers
+    // ================================================================
+
+    [Test]
+    public void EventTypeForStatus_MapsEachStatusToItsTerminalEvent()
+    {
+        TriagePanelAggregationHelper.EventTypeForStatus(TriagePanelAggregationHelper.StatusOk)
+            .Should().Be(Tamma.Activities.ADL.TriageEvents.PanelCompleted);
+        TriagePanelAggregationHelper.EventTypeForStatus(TriagePanelAggregationHelper.StatusPartial)
+            .Should().Be(Tamma.Activities.ADL.TriageEvents.PanelPartial);
+        TriagePanelAggregationHelper.EventTypeForStatus(TriagePanelAggregationHelper.StatusFailed)
+            .Should().Be(Tamma.Activities.ADL.TriageEvents.PanelFailed);
+        // Unknown status is treated as failed (fail-closed default).
+        TriagePanelAggregationHelper.EventTypeForStatus("nonsense")
+            .Should().Be(Tamma.Activities.ADL.TriageEvents.PanelFailed);
+    }
+
+    [Test]
+    public void ParseItemNumber_ReadsNumberField()
+    {
+        TriagePanelAggregationHelper.ParseItemNumber("""{"number":42,"title":"x"}""")
+            .Should().Be(42);
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("not json")]
+    [TestCase("""{"title":"no number"}""")]
+    public void ParseItemNumber_MissingOrMalformed_ReturnsZero(string? itemJson)
+    {
+        TriagePanelAggregationHelper.ParseItemNumber(itemJson).Should().Be(0);
+    }
+
+    // ================================================================
+    // Helpers
+    // ================================================================
+
+    private static Dictionary<string, string?> AllOk() => new()
+    {
+        ["security"] = """{"verdict":"vuln","severity":"high"}""",
+        ["developer"] = """{"verdict":"defect","severity":"medium"}""",
+        ["devops"] = """{"verdict":"incident","severity":"low"}""",
+        ["tester"] = """{"verdict":"defect","severity":"medium"}""",
+    };
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TriagePanelReviewWorkflowTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TriagePanelReviewWorkflowTests.cs
@@ -1,0 +1,226 @@
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Management.Activities.SetOutput;
+using Elsa.Workflows.Runtime.Activities;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Completeness audit 2026-06-22 — workflow-structure coverage for the built-out
+/// <c>triage-panel-review</c> graph. Asserts the load-bearing guarantees the
+/// pure-function tests can't: every panel role is LLM-mediated (dispatch →
+/// <c>llm-call</c>, never a raw provider call); every role's finding is persisted;
+/// the quorum gate routes a failed panel to a LOUD <c>TRIAGE.PANEL.FAILED</c>
+/// terminal (no false success — the FAILED edge never falls through to the
+/// COMPLETED/PARTIAL path); every outcome reaches Finish (no dangling edge).
+///
+/// <para>Follows the codebase convention of inspecting the BUILT Flowchart via
+/// <see cref="WorkflowTestHelper"/> rather than running the full Elsa runtime
+/// (see <see cref="PullRequestWorkflowTests"/>).</para>
+/// </summary>
+[TestFixture]
+public class TriagePanelReviewWorkflowTests
+{
+    private Flowchart _flowchart = null!;
+
+    private static readonly string[] RoleIdBases = { "Security", "Developer", "Devops", "Tester" };
+
+    [SetUp]
+    public void SetUp()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new TriagePanelReviewWorkflow());
+        _flowchart = WorkflowTestHelper.GetFlowchart(builder);
+    }
+
+    // ================================================================
+    // Identity
+    // ================================================================
+
+    [Test]
+    public void Workflow_BuildsWithExpectedDefinitionId()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new TriagePanelReviewWorkflow());
+        builder.Object.DefinitionId.Should().Be("triage-panel-review");
+    }
+
+    // ================================================================
+    // LLM mediation — every role review goes through llm-call
+    // ================================================================
+
+    [Test]
+    public void EveryRoleReview_IsMediatedThroughLlmCall()
+    {
+        foreach (var role in RoleIdBases)
+        {
+            var dispatch = _flowchart.Activities
+                .OfType<DispatchWorkflow>()
+                .FirstOrDefault(d => d.Id == $"{role}Review");
+
+            dispatch.Should().NotBeNull($"{role} review must be a DispatchWorkflow step");
+            ReadDefinitionId(dispatch!).Should().Be("llm-call",
+                $"{role} review must be mediated through llm-call, never a raw provider call");
+        }
+    }
+
+    // ================================================================
+    // Per-role persistence (partial-result durability)
+    // ================================================================
+
+    [Test]
+    public void EveryRole_PersistsItsFinding_BeforeAggregation()
+    {
+        foreach (var role in RoleIdBases)
+        {
+            // call → extract → store chain per role.
+            HasEdge($"{role}Review", null, $"Extract{role}Review").Should().BeTrue();
+            HasEdge($"Extract{role}Review", null, $"Store{role}Review").Should().BeTrue();
+
+            _flowchart.Activities.Any(a => a.Id == $"Store{role}Review")
+                .Should().BeTrue($"{role}'s finding must be persisted (StoreRoleFinding)");
+        }
+
+        // The last role's store chains into aggregation.
+        HasEdge("StoreTesterReview", null, "Aggregate").Should().BeTrue();
+    }
+
+    // ================================================================
+    // Fail-closed quorum gate — failed panel reaches a LOUD terminal
+    // ================================================================
+
+    [Test]
+    public void PanelUsableGate_ExistsAfterAggregation()
+    {
+        _flowchart.Activities.OfType<FlowDecision>()
+            .Any(d => d.Id == "PanelUsable")
+            .Should().BeTrue("the quorum gate must exist to fail a below-quorum panel");
+
+        HasEdge("Aggregate", null, "PanelUsable").Should().BeTrue();
+    }
+
+    [Test]
+    public void FailedPanel_RoutesToFailedTerminal_NotToCompleted()
+    {
+        // False (below quorum) → failed outputs → TRIAGE.PANEL.FAILED. The False
+        // edge must NEVER reach the usable/COMPLETED emit (no false success).
+        HasEdge("PanelUsable", "False", "FailedOutputs").Should().BeTrue();
+        HasEdge("FailedOutputs", null, "EmitFailed").Should().BeTrue();
+
+        var falseTargets = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "PanelUsable" && c.Source.Port == "False")
+            .Select(c => c.Target.Activity.Id)
+            .ToList();
+
+        falseTargets.Should().NotContain("EmitUsable");
+        falseTargets.Should().NotContain("UsableOutputs");
+    }
+
+    [Test]
+    public void UsablePanel_RoutesToUsableTerminal()
+    {
+        HasEdge("PanelUsable", "True", "UsableOutputs").Should().BeTrue();
+        HasEdge("UsableOutputs", null, "EmitUsable").Should().BeTrue();
+    }
+
+    [Test]
+    public void PanelUsableGate_HasNoUnconditionalFallthrough()
+    {
+        // Every edge out of the gate must be outcome-qualified (True/False); a
+        // portless edge would be a silent fall-through.
+        var fromGate = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "PanelUsable")
+            .ToList();
+
+        fromGate.Should().NotBeEmpty();
+        fromGate.Should().OnlyContain(c => c.Source.Port == "True" || c.Source.Port == "False");
+    }
+
+    // ================================================================
+    // DCB events — STARTED after init; exactly one terminal event per path
+    // ================================================================
+
+    [Test]
+    public void StartedEvent_EmittedRightAfterInit()
+    {
+        var started = _flowchart.Activities
+            .OfType<EmitTriageEventActivity>()
+            .FirstOrDefault(a => a.Id == "EmitStarted");
+        started.Should().NotBeNull("the panel must emit TRIAGE.PANEL.STARTED");
+
+        HasEdge("Init", null, "EmitStarted").Should().BeTrue();
+        HasEdge("EmitStarted", null, "SecurityReview").Should().BeTrue();
+    }
+
+    [Test]
+    public void BothTerminalPaths_EmitAPanelEvent_AndReachFinish()
+    {
+        _flowchart.Activities.OfType<EmitTriageEventActivity>()
+            .Any(a => a.Id == "EmitUsable").Should().BeTrue();
+        _flowchart.Activities.OfType<EmitTriageEventActivity>()
+            .Any(a => a.Id == "EmitFailed").Should().BeTrue();
+
+        HasEdge("EmitUsable", null, "Finish").Should().BeTrue();
+        HasEdge("EmitFailed", null, "Finish").Should().BeTrue();
+    }
+
+    // ================================================================
+    // Outputs — both terminals expose the panel-health contract
+    // ================================================================
+
+    [Test]
+    public void BothTerminals_OutputPanelStatusAndHealthSignals()
+    {
+        foreach (var seqId in new[] { "UsableOutputs", "FailedOutputs" })
+        {
+            var seq = _flowchart.Activities.OfType<Sequence>().First(s => s.Id == seqId);
+            var ids = seq.Activities.OfType<SetOutput>()
+                .Select(o => o.Id ?? "")
+                .ToList();
+
+            ids.Should().Contain($"{seqId}_PanelResult");
+            ids.Should().Contain($"{seqId}_PanelStatus");
+            ids.Should().Contain($"{seqId}_Succeeded");
+            ids.Should().Contain($"{seqId}_FailedRoles");
+        }
+    }
+
+    // ================================================================
+    // No dangling edges — every non-terminal activity has an outgoing edge,
+    // and Finish is reachable from each terminal.
+    // ================================================================
+
+    [Test]
+    public void EveryActivity_RoutesToATerminal_NoDanglingEdge()
+    {
+        var allIds = _flowchart.Activities.Select(a => a.Id!).ToHashSet();
+        var sources = _flowchart.Connections.Select(c => c.Source.Activity.Id!).ToHashSet();
+
+        // Every activity except Finish must have at least one outgoing connection.
+        foreach (var id in allIds.Where(i => i != "Finish"))
+        {
+            sources.Should().Contain(id, $"activity '{id}' must route somewhere (no dangling edge)");
+        }
+    }
+
+    // ================================================================
+    // Helpers
+    // ================================================================
+
+    private bool HasEdge(string sourceId, string? port, string targetId)
+        => _flowchart.Connections.Any(c =>
+            c.Source.Activity.Id == sourceId &&
+            (port == null || c.Source.Port == port) &&
+            c.Target.Activity.Id == targetId);
+
+    private static string? ReadDefinitionId(DispatchWorkflow dispatch)
+    {
+        var prop = typeof(DispatchWorkflow).GetProperty("WorkflowDefinitionId");
+        var value = prop?.GetValue(dispatch);
+        var expression = value?.GetType().GetProperty("Expression")?.GetValue(value)
+            as Elsa.Expressions.Models.Expression;
+        return expression?.Value?.ToString();
+    }
+}


### PR DESCRIPTION
## What
`TriagePanelReviewWorkflow`: the 4-role panel **aggregated failed/empty reviews as `{}` with no failure signal** (a fully-failed panel reported a "successful" review) → fail-closed. A pure `TriagePanelAggregationHelper` classifies null/blank/`{}`/empty/unparseable per-role reviews as failures (never a `{}` participant), with a quorum producing `ok`/`partial`/`failed`; `TRIAGE.PANEL.*` events via the durable drain; `tenantId` threaded; LLM stays mediated via `llm-call`.

**Also fixes the consumer:** `TriageItemCycleWorkflow` was ignoring `panelStatus` and applying labels even on a wholly-failed panel — a new `Panel Usable?` gate now routes a failed panel to a loud, non-applying skip terminal (`triageSkipped=true`, `skipReason="panel-failed"`). Both outcomes reach a terminal — reviewed: no failed-panel path reaches label-apply, no dangling edge, no deadlock.

Reviewed: APPROVED.

## Verification
Build 0 errors; `has-pending-model-changes` clean; triage filter 53/0; full `Tamma.Activities.Tests` 1443/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)