### PR TITLE
feat(workflows): build out TriageContextGathering — fix empty-scan bug + fail-closed + events

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitTriageContextEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitTriageContextEventActivity.cs
@@ -1,0 +1,137 @@
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+
+namespace Tamma.Activities.ADL;
+
+/// <summary>
+/// Emits a <c>TRIAGE.CONTEXT.*</c> DCB event (completeness audit 2026-06-22,
+/// <c>TriageContextGathering.md</c> §5 #4) for the audit trail by appending a
+/// <see cref="TammaEvent"/> to the workflow's <c>tamma:events</c> transient list via
+/// <see cref="TammaEventEmitter.Emit"/>. The engine event drain
+/// (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) flushes that list
+/// <i>durably</i> to the tenant <c>domain_events</c> store after this activity runs
+/// — the drain resolves the tenant from the workflow scope (the context-gathering
+/// workflow stamps a <c>TenantId</c> variable). The event therefore persists without
+/// this activity holding any DB / repository dependency of its own (none is
+/// registered in the Elsa engine — the same reason <see cref="EmitTriageEventActivity"/>,
+/// <see cref="EmitPrEventActivity"/> and <see cref="EmitMergeApprovalEventActivity"/>
+/// use the emitter rather than a direct <c>IEventRepository</c>).
+///
+/// <para>The stage emits <c>STARTED</c> right after init and exactly one terminal
+/// event (<c>COMPLETED</c> / <c>EMPTY</c> / <c>FAILED</c>) carrying the gathered
+/// context health (<c>contextStatus</c> / <c>contextJsonLength</c> / <c>itemType</c>)
+/// — so a degraded (empty) or failed scan is a loud audit row, never a silent false
+/// success.</para>
+/// </summary>
+[Activity(
+    "Tamma.ADL",
+    "Emit Triage Context Event",
+    "Emit a TRIAGE.CONTEXT.* DCB event for the triage-context audit trail",
+    Kind = ActivityKind.Task
+)]
+public class EmitTriageContextEventActivity : Activity
+{
+    private readonly ILogger<EmitTriageContextEventActivity>? _logger;
+
+    [Input(Description = "Event type — TRIAGE.CONTEXT.STARTED / .COMPLETED / .EMPTY / .FAILED")]
+    public Input<string> EventType { get; set; } = default!;
+
+    [Input(Description = "Repository in owner/repo format")]
+    public Input<string> Repository { get; set; } = default!;
+
+    [Input(Description = "Triage item number (0 when unknown)")]
+    public Input<int> ItemNumber { get; set; } = new(0);
+
+    [Input(Description = "Tenant id (empty / single-user → platform-scope event)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [Input(Description = "Detected item type — issue / security / dependency")]
+    public Input<string?> ItemType { get; set; } = new((string?)null);
+
+    [Input(Description = "Terminal context status — ok / empty / failed (empty on STARTED)")]
+    public Input<string?> ContextStatus { get; set; } = new((string?)null);
+
+    [Input(Description = "Length of the gathered context JSON (0 on STARTED / FAILED)")]
+    public Input<int> ContextJsonLength { get; set; } = new(0);
+
+    [JsonConstructor]
+    public EmitTriageContextEventActivity() { }
+
+    public EmitTriageContextEventActivity(ILogger<EmitTriageContextEventActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var type = EventType.Get(context) ?? TriageContextEvents.Failed;
+        var repository = Repository.Get(context) ?? "";
+        var itemNumber = ItemNumber.Get(context);
+        var tenantId = TriageContextEvents.ParseTenantId(TenantId.Get(context));
+        var itemType = ItemType.Get(context);
+        var contextStatus = ContextStatus.Get(context);
+        var contextJsonLength = ContextJsonLength.Get(context);
+
+        var evt = BuildTammaEvent(type, repository, itemNumber, tenantId, itemType, contextStatus, contextJsonLength);
+        TammaEventEmitter.Emit(context, this, _logger, evt);
+
+        _logger?.LogInformation(
+            "Emitted {Type} for item #{Item} in {Repo} (itemType={ItemType}, status={Status}, len={Len})",
+            type, itemNumber, repository, itemType, contextStatus, contextJsonLength);
+
+        return default;
+    }
+
+    /// <summary>
+    /// Map the context inputs onto a <see cref="TammaEvent"/> expressed as the
+    /// engine's transient-list event so the merged drain persists it. Tags carry
+    /// the queryable DCB index keys (<c>repository</c>/<c>itemId</c>/
+    /// <c>itemNumber</c>/<c>itemSource</c>/<c>contextStatus</c>/<c>tenantId</c>);
+    /// Data carries the context-health payload (<c>itemType</c>/<c>contextStatus</c>/
+    /// <c>contextJsonLength</c>). Status is driven off the event type (failed →
+    /// error, empty → warning) so a degraded/failed scan is never recorded as a
+    /// false success. Pure (no Elsa context) — exposed for unit testing the mapping.
+    /// </summary>
+    public static TammaEvent BuildTammaEvent(
+        string type,
+        string repository,
+        int itemNumber,
+        Guid? tenantId,
+        string? itemType,
+        string? contextStatus,
+        int contextJsonLength)
+    {
+        var tags = new Dictionary<string, object?>
+        {
+            ["repository"] = repository,
+        };
+        if (itemNumber > 0)
+        {
+            tags["itemId"] = itemNumber.ToString();
+            tags["itemNumber"] = itemNumber.ToString();
+        }
+        if (!string.IsNullOrWhiteSpace(itemType)) tags["itemSource"] = itemType;
+        if (!string.IsNullOrWhiteSpace(contextStatus)) tags["contextStatus"] = contextStatus;
+        if (tenantId is not null) tags["tenantId"] = tenantId.Value.ToString("D");
+
+        var data = new Dictionary<string, object?>
+        {
+            ["itemType"] = itemType ?? "",
+            ["contextStatus"] = contextStatus ?? "",
+            ["contextJsonLength"] = contextJsonLength,
+        };
+
+        return new TammaEvent
+        {
+            EventType = type,
+            Status = TriageContextEvents.StatusForEvent(type),
+            Tags = tags,
+            Data = data,
+        };
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/TriageContextEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/TriageContextEvents.cs
@@ -1,0 +1,98 @@
+namespace Tamma.Activities.ADL;
+
+/// <summary>
+/// Completeness audit 2026-06-22 (<c>TriageContextGathering.md</c> §5 #4) — central
+/// catalogue of the <c>TRIAGE.CONTEXT.*</c> DCB event types emitted by the
+/// <c>triage-context-gathering</c> workflow. Type pattern follows the platform's
+/// <c>AGGREGATE.ACTION.STATUS</c> convention (<c>CLAUDE.md</c>) and mirrors the
+/// sibling <see cref="TriageEvents"/> catalogue used by the panel.
+///
+/// <para>The context-gathering stage runs one tool-enabled <c>context-scan</c>
+/// (mediated through the central <c>llm-call</c> seam — no provider key ever enters
+/// the engine) to gather triage-time context for a single untriaged item (code
+/// usage of the affected package/module, dependency graph, CVE details, changelog
+/// / migration guides). Each lifecycle transition is an auditable event so
+/// time-travel debugging can reconstruct whether context was genuinely gathered,
+/// degraded to an unstructured blob, or failed entirely — rather than a failed
+/// scan being silently coalesced to <c>{}</c> and presented downstream as a false
+/// success.</para>
+///
+/// <para>Events are emitted via <c>TammaEventEmitter.Emit</c> into the workflow's
+/// <c>tamma:events</c> transient list and persisted <i>durably</i> by the engine
+/// event drain (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) — the same
+/// pattern <see cref="EmitTriageEventActivity"/>, <see cref="EmitPrEventActivity"/>
+/// and <see cref="EmitMergeApprovalEventActivity"/> use. No activity holds a DB /
+/// repository dependency of its own (none is registered in the Elsa engine — a
+/// directly-injected <c>IEventRepository</c> would be inert and silently drop every
+/// context event). The drain resolves the tenant from the workflow's
+/// <c>TenantId</c> variable, so a SaaS caller's context events carry the tenant
+/// tag.</para>
+///
+/// <list type="bullet">
+///   <item><description><c>TRIAGE.CONTEXT.STARTED</c> — the stage began gathering
+///     context for an item (tags carry repository + item number + item type).</description></item>
+///   <item><description><c>TRIAGE.CONTEXT.COMPLETED</c> — the scan produced a usable
+///     structured context bundle (success).</description></item>
+///   <item><description><c>TRIAGE.CONTEXT.EMPTY</c> — the scan succeeded but yielded
+///     no usable structured context (only free-form prose / an empty object). A
+///     degraded — not failed — result; loud (warning-status) so the panel / PO can
+///     down-weight it rather than reasoning over phantom context.</description></item>
+///   <item><description><c>TRIAGE.CONTEXT.FAILED</c> — the mediated <c>llm-call</c>
+///     reported failure (all providers failed) so no context was gathered. Loud
+///     (error-status). The stage reports <c>contextStatus="failed"</c> so the
+///     parent cycle routes to a non-applying terminal instead of running the panel
+///     over empty context. This is the no-false-success / no-empty-fallback rule
+///     made explicit: a failed scan is NEVER coalesced to <c>"{}"</c> reported as a
+///     success.</description></item>
+/// </list>
+/// </summary>
+public static class TriageContextEvents
+{
+    public const string Started = "TRIAGE.CONTEXT.STARTED";
+    public const string Completed = "TRIAGE.CONTEXT.COMPLETED";
+    public const string Empty = "TRIAGE.CONTEXT.EMPTY";
+    public const string Failed = "TRIAGE.CONTEXT.FAILED";
+
+    /// <summary>The <c>contextStatus</c> values the stage reports on its output so
+    /// the parent cycle can branch on context health. <c>ok</c> / <c>empty</c> are
+    /// usable (panel may still run); <c>failed</c> means no context was gathered and
+    /// the cycle must NOT run the panel over phantom context.</summary>
+    public const string StatusOk = "ok";
+    public const string StatusEmpty = "empty";
+    public const string StatusFailed = "failed";
+
+    /// <summary>
+    /// Parse a tenant id from the loose string form threaded through the workflow
+    /// inputs. Returns <c>null</c> for empty / single-user / unparseable values
+    /// (context events in single-user mode are platform-scope, TenantId null).
+    /// Mirrors <see cref="TriageEvents.ParseTenantId"/>.
+    /// </summary>
+    public static Guid? ParseTenantId(string? tenantId)
+        => Guid.TryParse(tenantId, out var g) ? g : null;
+
+    /// <summary>
+    /// Failure-status check: a failed scan is a loud (error-status) audit row, an
+    /// empty (degraded) scan is a warning-status row, a completed scan is success.
+    /// Mirrors <see cref="TriageEvents.StatusForEvent"/>'s intent of never recording
+    /// a degraded/failed outcome as a false success.
+    /// </summary>
+    public static string StatusForEvent(string type) => type switch
+    {
+        Failed => "error",
+        Empty => "warning",
+        _ => "success",
+    };
+
+    /// <summary>
+    /// Map a terminal <c>contextStatus</c> string to the corresponding DCB event
+    /// type. <c>failed</c> → FAILED, <c>empty</c> → EMPTY, anything else (ok) →
+    /// COMPLETED. Keeps the success-path emit node and the status variable reading
+    /// the same single source of truth.
+    /// </summary>
+    public static string EventTypeForStatus(string contextStatus) => contextStatus switch
+    {
+        StatusFailed => Failed,
+        StatusEmpty => Empty,
+        _ => Completed,
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/Helpers/TriageContextHelper.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/Helpers/TriageContextHelper.cs
@@ -1,0 +1,156 @@
+using System.Text.Json;
+using Tamma.Activities.ADL;
+
+namespace Tamma.ElsaServer.Workflows.Helpers;
+
+/// <summary>
+/// Completeness audit 2026-06-22 (<c>TriageContextGathering.md</c>) — pure helpers
+/// for the built-out <c>triage-context-gathering</c> workflow. Kept side-effect-free
+/// and Elsa-context-free so the load-bearing logic (item-type detection that the
+/// prompt actually consumes, and the no-false-success context extraction) is
+/// unit-testable directly.
+/// </summary>
+public static class TriageContextHelper
+{
+    public const string ItemTypeIssue = "issue";
+    public const string ItemTypeSecurity = "security";
+    public const string ItemTypeDependency = "dependency";
+
+    /// <summary>
+    /// Detect the triage item type by PARSING the item JSON (not substring-sniffing
+    /// the raw text — the prior approach broke on whitespaced / pretty-printed JSON,
+    /// audit §5 #5). Reads the <c>type</c> field plus the presence of
+    /// <c>advisory</c>/<c>cve</c>/<c>ghsaId</c> (security) or <c>dependency</c>/
+    /// <c>package</c>/<c>manifestPath</c> (dependency) markers. Defaults to
+    /// <see cref="ItemTypeIssue"/> only when genuinely absent. Never throws — a
+    /// malformed body falls back to a tolerant raw-text sniff and then to
+    /// <c>issue</c>.
+    /// </summary>
+    public static string DetectItemType(string? itemJson)
+    {
+        if (string.IsNullOrWhiteSpace(itemJson)) return ItemTypeIssue;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(itemJson);
+            var root = doc.RootElement;
+            if (root.ValueKind == JsonValueKind.Object)
+            {
+                // Explicit "type" field takes precedence.
+                if (root.TryGetProperty("type", out var t) && t.ValueKind == JsonValueKind.String)
+                {
+                    var type = (t.GetString() ?? "").Trim().ToLowerInvariant();
+                    if (type.StartsWith("security", StringComparison.Ordinal)) return ItemTypeSecurity;
+                    if (type.StartsWith("dependabot", StringComparison.Ordinal)
+                        || type.StartsWith("dependency", StringComparison.Ordinal)) return ItemTypeDependency;
+                    if (type.StartsWith("vuln", StringComparison.Ordinal)) return ItemTypeSecurity;
+                }
+
+                // Structural markers — a security advisory carries advisory/cve/ghsa.
+                if (HasAnyProperty(root, "advisory", "cve", "ghsaId", "ghsa_id", "cvss"))
+                    return ItemTypeSecurity;
+
+                // A dependency/dependabot alert carries a dependency/package descriptor.
+                if (HasAnyProperty(root, "dependency", "manifestPath", "manifest_path"))
+                    return ItemTypeDependency;
+            }
+        }
+        catch
+        {
+            // Malformed JSON — fall through to the tolerant raw-text sniff so a
+            // best-effort type is still derived (never throws).
+        }
+
+        return SniffRawText(itemJson);
+    }
+
+    /// <summary>
+    /// Extract the gathered context JSON from the mediated <c>llm-call</c> result,
+    /// reporting a <c>contextStatus</c> so the workflow never presents a failed /
+    /// empty scan as a false success (audit §5 #1/#2/#9).
+    ///
+    /// <list type="bullet">
+    ///   <item><description><c>failed</c> — the call reported failure / produced no
+    ///     response. ContextJson is the <c>"{}"</c> sentinel; the workflow routes to
+    ///     the FAILED terminal (it does NOT present this as gathered context).</description></item>
+    ///   <item><description><c>empty</c> — the call succeeded but yielded no usable
+    ///     structured context (whitespace, or an empty <c>{}</c> object). Degraded,
+    ///     not failed — emitted loud (warning).</description></item>
+    ///   <item><description><c>ok</c> — a usable JSON object was extracted, OR
+    ///     free-form prose was wrapped as <c>{"rawContext": ...}</c> (the scan still
+    ///     produced content). ContextJson carries it.</description></item>
+    /// </list>
+    /// </summary>
+    public static (string ContextJson, string ContextStatus) ExtractContext(
+        IDictionary<string, object>? llmResult)
+    {
+        // No result at all → the mediated call never completed → failed.
+        if (llmResult == null)
+            return ("{}", TriageContextEvents.StatusFailed);
+
+        // Explicit success=false from llm-call (all providers failed) → failed.
+        // Absence of the flag is treated as success (back-compat with callers that
+        // don't surface it), matching the panel's ExtractTriageReview convention.
+        var success = !llmResult.TryGetValue("success", out var s) || s is true;
+        if (!success)
+            return ("{}", TriageContextEvents.StatusFailed);
+
+        if (!llmResult.TryGetValue("llmResponse", out var r))
+            return ("{}", TriageContextEvents.StatusFailed);
+
+        var output = r?.ToString();
+        if (string.IsNullOrWhiteSpace(output))
+            return ("{}", TriageContextEvents.StatusEmpty);
+
+        var jsonStart = output.IndexOf('{');
+        var jsonEnd = output.LastIndexOf('}');
+        if (jsonStart >= 0 && jsonEnd > jsonStart)
+        {
+            var candidate = output[jsonStart..(jsonEnd + 1)];
+            try
+            {
+                using var doc = JsonDocument.Parse(candidate);
+                if (doc.RootElement.ValueKind == JsonValueKind.Object)
+                {
+                    var hasAny = false;
+                    foreach (var _ in doc.RootElement.EnumerateObject()) { hasAny = true; break; }
+                    // An empty {} object is not usable structured context → degraded.
+                    if (hasAny) return (candidate, TriageContextEvents.StatusOk);
+                    return ("{}", TriageContextEvents.StatusEmpty);
+                }
+            }
+            catch { /* not valid JSON — wrap the prose below */ }
+        }
+
+        // Free-form prose is still gathered content — wrap it (ok, not empty). The
+        // schema is unstructured, but the panel/PO still receive real context.
+        var wrapped = JsonSerializer.Serialize(new Dictionary<string, string>
+        {
+            ["rawContext"] = output,
+        });
+        return (wrapped, TriageContextEvents.StatusOk);
+    }
+
+    private static bool HasAnyProperty(JsonElement root, params string[] names)
+    {
+        foreach (var name in names)
+            if (root.TryGetProperty(name, out _)) return true;
+        return false;
+    }
+
+    /// <summary>
+    /// Tolerant raw-text fallback used only when the body is not parseable JSON.
+    /// Best-effort — never the primary detection path.
+    /// </summary>
+    private static string SniffRawText(string itemJson)
+    {
+        if (itemJson.Contains("\"type\":\"security", StringComparison.OrdinalIgnoreCase)
+            || itemJson.Contains("\"advisory\"", StringComparison.OrdinalIgnoreCase)
+            || itemJson.Contains("\"cve\"", StringComparison.OrdinalIgnoreCase))
+            return ItemTypeSecurity;
+        if (itemJson.Contains("\"type\":\"dependabot", StringComparison.OrdinalIgnoreCase)
+            || itemJson.Contains("\"dependency\"", StringComparison.OrdinalIgnoreCase))
+            return ItemTypeDependency;
+        return ItemTypeIssue;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TriageContextGatheringWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TriageContextGatheringWorkflow.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Elsa.Extensions;
 using Elsa.Workflows;
 using Elsa.Workflows.Activities;
@@ -7,6 +6,8 @@ using Elsa.Workflows.Management.Activities.SetOutput;
 using Elsa.Workflows.Memory;
 using Elsa.Workflows.Models;
 using Elsa.Workflows.Runtime.Activities;
+using Tamma.Activities.ADL;
+using Tamma.ElsaServer.Workflows.Helpers;
 using FlowEndpoint = Elsa.Workflows.Activities.Flowchart.Models.Endpoint;
 using FlowConnection = Elsa.Workflows.Activities.Flowchart.Models.Connection;
 
@@ -17,19 +18,51 @@ using static Tamma.ElsaServer.Workflows.ActivityDisplayTextExtensions;
 namespace Tamma.ElsaServer.Workflows;
 
 /// <summary>
-/// Triage Context Gathering — gathers context for triage, focused on:
-/// - Code usage of affected package/module
-/// - Dependency graph
-/// - CVE details (for security alerts)
-/// - Changelog and migration guides
+/// Triage Context Gathering — gathers triage-time context for a single untriaged
+/// item (code usage of the affected package/module, dependency graph, CVE details
+/// for security alerts, changelog / migration guides) by dispatching one
+/// tool-enabled <c>llm-call</c> (<c>role=developer</c>, <c>action=context-scan</c>)
+/// and returning a <c>contextJson</c> bundle that the panel-review and PO-decision
+/// sub-workflows reason over.
 ///
-/// Dispatches llm-call with role=developer, action=context-scan with triage-specific variables.
+/// <para>Build-out (completeness audit 2026-06-22, <c>TriageContextGathering.md</c>):
+/// the stage is now contract-correct and fail-closed:
+/// <list type="bullet">
+///   <item><description><b>Variable contract fixed (P0 #1).</b> The dispatch passes
+///     the <c>context-scan</c> template's <i>declared</i> variables
+///     (<c>workItemJson</c> / <c>workItemType</c> / <c>previousFindings</c>) — the
+///     prior <c>itemJson</c> / <c>itemType</c> / <c>scanFocus</c> rendered empty, so
+///     the model scanned with no work item. The detected item type now feeds a real
+///     <c>{{workItemType}}</c> so the scan is item-type-aware.</description></item>
+///   <item><description><b>Fail-closed on the <c>llm-call</c> <c>success</c> flag
+///     (P0 #2).</b> An all-providers-failed scan no longer coalesces to <c>"{}"</c>
+///     presented as success — a <c>Context Gathered?</c> gate routes a failed scan
+///     to a LOUD <c>TRIAGE.CONTEXT.FAILED</c> terminal and reports
+///     <c>contextStatus="failed"</c> so the parent cycle can skip the panel.</description></item>
+///   <item><description><b>Robust item-type detection (P1 #5)</b> — parses the item
+///     JSON via <see cref="TriageContextHelper.DetectItemType"/> instead of
+///     substring-sniffing the raw text.</description></item>
+///   <item><description><b>DCB events (P1 #4)</b> — <c>TRIAGE.CONTEXT.STARTED</c>
+///     after init and exactly one terminal (<c>COMPLETED</c> / <c>EMPTY</c> /
+///     <c>FAILED</c>) via <see cref="EmitTriageContextEventActivity"/> on the durable
+///     drain, so audit can see whether context was gathered, degraded, or failed.</description></item>
+///   <item><description><b><c>tenantId</c> threading (P1 #6)</b> — a <c>TenantId</c>
+///     variable is stamped (the drain scopes events to it) and forwarded into the
+///     <c>llm-call</c> dispatch for SaaS prompt + BYOK resolution.</description></item>
+/// </list>
+/// (Deferred per the audit: a dedicated CVE/changelog action + structured advisory
+/// engine-callback (#7), idempotency cache (#8), balanced-brace scanner (#9), and
+/// the shared init→scan→extract helper shared with <c>ContextGatheringWorkflow</c>
+/// (#10).)</para>
 ///
 /// Flow:
-///   Init → Gather Context (llm-call) → Extract Result → Output → Finish
+///   Init → Emit STARTED → Gather Context (llm-call) → Extract + Status
+///     → Context Gathered?
+///         ├─ True  → Output(ok/empty) → Emit COMPLETED/EMPTY → Finish
+///         └─ False → Output(failed)   → Emit FAILED          → Finish
 ///
-/// Inputs: repository, itemJson
-/// Outputs: contextJson
+/// Inputs: repository, itemJson, tenantId
+/// Outputs: contextJson, contextStatus
 /// </summary>
 public class TriageContextGatheringWorkflow : WorkflowBase
 {
@@ -38,20 +71,28 @@ public class TriageContextGatheringWorkflow : WorkflowBase
         builder.Name = "Triage Context Gathering";
         builder.DefinitionId = "triage-context-gathering";
         builder.Version = WorkflowVersions.ComputedVersion;
-        builder.Description = "Gather context for triage: code usage, deps, CVE, changelog";
+        builder.Description = "Gather context for triage: code usage, deps, CVE, changelog (fail-closed)";
 
         // ================================================================
         // Variables
         // ================================================================
         var repository = builder.WithVariable<string>("Repository", "");
         var itemJson = builder.WithVariable<string>("ItemJson", "");
+        var tenantId = builder.WithVariable<string>("TenantId", "");
         var contextJson = builder.WithVariable<string>("ContextJson", "{}");
-        var itemType = builder.WithVariable<string>("ItemType", "issue");
+        // Detected item type — drives {{workItemType}} so the scan is item-aware.
+        var itemType = builder.WithVariable<string>("ItemType", TriageContextHelper.ItemTypeIssue);
+        // Item number for event tags / audit correlation (0 when unknown).
+        var itemNumber = builder.WithVariable<int>("ItemNumber", 0);
+        // Context-health signal from the (fail-closed) extraction:
+        // "ok" / "empty" => usable; "failed" => no context gathered, do NOT run panel.
+        var contextStatus = builder.WithVariable<string>(
+            "ContextStatus", TriageContextEvents.StatusFailed);
 
         var llmResult = builder.WithVariable<IDictionary<string, object>?>();
 
         // ================================================================
-        // 1. Init
+        // 1. Init — read inputs; parse item type + number.
         // ================================================================
         var init = new SetVariable
         {
@@ -62,25 +103,24 @@ public class TriageContextGatheringWorkflow : WorkflowBase
                 var repo = ctx.GetInput<string>("repository") ?? "";
                 var item = ctx.GetInput<string>("itemJson") ?? "";
                 itemJson.Set(ctx, item);
-
-                // Detect item type for context-scan focus
-                var type = "issue";
-                if (item.Contains("\"type\":\"security", StringComparison.OrdinalIgnoreCase)
-                    || item.Contains("\"advisory\"", StringComparison.OrdinalIgnoreCase)
-                    || item.Contains("\"cve\"", StringComparison.OrdinalIgnoreCase))
-                    type = "security";
-                else if (item.Contains("\"type\":\"dependabot", StringComparison.OrdinalIgnoreCase)
-                    || item.Contains("\"dependency\"", StringComparison.OrdinalIgnoreCase))
-                    type = "dependency";
-                itemType.Set(ctx, type);
-
+                tenantId.Set(ctx, ctx.GetInput<string>("tenantId") ?? "");
+                itemType.Set(ctx, TriageContextHelper.DetectItemType(item));
+                itemNumber.Set(ctx, TriagePanelAggregationHelper.ParseItemNumber(item));
                 return (object)repo;
             })
         };
         init.SetDisplayText("Initialize");
 
         // ================================================================
-        // 2. Gather Context (via LlmCallWorkflow)
+        // 2. Emit TRIAGE.CONTEXT.STARTED
+        // ================================================================
+        var emitStarted = EmitContextEvent("EmitStarted", "Emit TRIAGE.CONTEXT.STARTED",
+            _ => TriageContextEvents.Started,
+            repository, itemNumber, tenantId,
+            ctx => itemType.Get(ctx), _ => "", _ => 0);
+
+        // ================================================================
+        // 3. Gather Context (via LlmCallWorkflow) — correct template variables.
         // ================================================================
         var gatherContext = new DispatchWorkflow
         {
@@ -90,12 +130,16 @@ public class TriageContextGatheringWorkflow : WorkflowBase
             {
                 ["role"] = AgentRole.Developer.ToWire(),
                 ["action"] = AgentAction.ContextScan.ToWire(),
+                ["tenantId"] = tenantId.Get(ctx),
                 ["variables"] = new Dictionary<string, object>
                 {
-                    ["itemJson"] = itemJson.Get(ctx),
-                    ["itemType"] = itemType.Get(ctx),
+                    // The context-scan template (SystemPrompts.cs) declares
+                    // workItemJson / workItemType / previousFindings — pass those
+                    // names so the model actually sees the triage item.
+                    ["workItemJson"] = itemJson.Get(ctx),
+                    ["workItemType"] = itemType.Get(ctx),
+                    ["previousFindings"] = "{}",
                     ["repository"] = repository.Get(ctx),
-                    ["scanFocus"] = "triage",
                 },
                 ["enableTools"] = true,
             }),
@@ -105,7 +149,7 @@ public class TriageContextGatheringWorkflow : WorkflowBase
         gatherContext.SetDisplayText("Gather Context");
 
         // ================================================================
-        // 3. Extract Result
+        // 4. Extract Result + Status — fail-closed (no false success).
         // ================================================================
         var extractResult = new SetVariable
         {
@@ -113,42 +157,56 @@ public class TriageContextGatheringWorkflow : WorkflowBase
             Variable = contextJson,
             Value = new Input<object?>(ctx =>
             {
-                var result = llmResult.Get(ctx);
-                if (result != null && result.TryGetValue("llmResponse", out var r))
-                {
-                    var output = r?.ToString() ?? "{}";
-
-                    // Try to extract JSON
-                    var jsonStart = output.IndexOf('{');
-                    var jsonEnd = output.LastIndexOf('}');
-                    if (jsonStart >= 0 && jsonEnd > jsonStart)
-                    {
-                        var candidate = output[jsonStart..(jsonEnd + 1)];
-                        try
-                        {
-                            JsonDocument.Parse(candidate);
-                            return (object)candidate;
-                        }
-                        catch { /* not valid JSON, use raw */ }
-                    }
-
-                    // Wrap raw text as context
-                    return (object)JsonSerializer.Serialize(new Dictionary<string, string>
-                    {
-                        ["rawContext"] = output,
-                    });
-                }
-                return (object)"{}";
+                var (json, status) = TriageContextHelper.ExtractContext(llmResult.Get(ctx));
+                contextStatus.Set(ctx, status);
+                return (object)json;
             })
         };
         extractResult.SetDisplayText("Extract Result");
 
         // ================================================================
-        // 4. Set Outputs
+        // 4a. Context Gathered? — fail-closed gate. "failed" routes to the LOUD
+        //     FAILED terminal; "ok"/"empty" proceed to the usable terminal. NO
+        //     false success: a failed scan never reaches COMPLETED.
         // ================================================================
-        var setOutputs = new SetOutput
-        { Id = "OutContext", OutputName = new("contextJson"), OutputValue = new(ctx => (object)contextJson.Get(ctx)) };
-        setOutputs.SetDisplayText("Output Context");
+        var contextGathered = new FlowDecision(ctx =>
+            contextStatus.Get(ctx) != TriageContextEvents.StatusFailed)
+        { Id = "ContextGathered", Name = "Context Gathered?" };
+        contextGathered.SetDisplayText("Context Gathered?");
+
+        // ----- Usable path (ok / empty) -----
+        var usableOutputs = BuildOutputs("UsableOutputs", "Usable Outputs",
+            contextJson, contextStatus);
+
+        // Emit COMPLETED (ok) or EMPTY (degraded) — driven by contextStatus.
+        var emitUsable = EmitContextEvent("EmitUsable", "Emit TRIAGE.CONTEXT.COMPLETED/EMPTY",
+            ctx => TriageContextEvents.EventTypeForStatus(contextStatus.Get(ctx)),
+            repository, itemNumber, tenantId,
+            ctx => itemType.Get(ctx), ctx => contextStatus.Get(ctx),
+            ctx => contextJson.Get(ctx).Length);
+
+        // ----- Failed path (no context gathered) -----
+        // Force the output to the "{}" sentinel + failed status so a downstream
+        // consumer that ignores contextStatus still gets no phantom context.
+        var failedSetStatus = new SetVariable
+        {
+            Id = "FailedSetStatus", Name = "Mark Context Failed",
+            Variable = contextJson,
+            Value = new Input<object?>(ctx =>
+            {
+                contextStatus.Set(ctx, TriageContextEvents.StatusFailed);
+                return (object)"{}";
+            })
+        };
+        failedSetStatus.SetDisplayText("Mark Context Failed");
+
+        var failedOutputs = BuildOutputs("FailedOutputs", "Failed Outputs",
+            contextJson, contextStatus);
+
+        var emitFailed = EmitContextEvent("EmitFailed", "Emit TRIAGE.CONTEXT.FAILED",
+            _ => TriageContextEvents.Failed,
+            repository, itemNumber, tenantId,
+            ctx => itemType.Get(ctx), _ => TriageContextEvents.StatusFailed, _ => 0);
 
         var finish = new Finish { Id = "Finish", Name = "Complete" };
         finish.SetDisplayText("Complete");
@@ -162,19 +220,85 @@ public class TriageContextGatheringWorkflow : WorkflowBase
             Start = init,
             Activities =
             {
-                init, gatherContext, extractResult,
-                setOutputs, finish,
+                init, emitStarted, gatherContext, extractResult,
+                contextGathered,
+                usableOutputs, emitUsable,
+                failedSetStatus, failedOutputs, emitFailed,
+                finish,
             },
             Connections =
             {
-                Connect(init, gatherContext),
+                Connect(init, emitStarted),
+                Connect(emitStarted, gatherContext),
                 Connect(gatherContext, extractResult),
-                Connect(extractResult, setOutputs),
-                Connect(setOutputs, finish),
+                Connect(extractResult, contextGathered),
+
+                // Usable (ok/empty) → outputs → emit COMPLETED/EMPTY → finish.
+                ConnectOutcome(contextGathered, "True", usableOutputs),
+                Connect(usableOutputs, emitUsable),
+                Connect(emitUsable, finish),
+
+                // Failed → mark "{}"/failed → outputs → emit FAILED → finish.
+                // The False edge NEVER falls through to the usable/COMPLETED path.
+                ConnectOutcome(contextGathered, "False", failedSetStatus),
+                Connect(failedSetStatus, failedOutputs),
+                Connect(failedOutputs, emitFailed),
+                Connect(emitFailed, finish),
             }
         };
     }
 
+    // ================================================================
+    // Helper: Set the two workflow outputs (contextJson + contextStatus).
+    // ================================================================
+    private static Sequence BuildOutputs(
+        string id, string name,
+        Variable<string> contextJson, Variable<string> contextStatus)
+    {
+        var seq = new Sequence
+        {
+            Id = id, Name = name,
+            Activities =
+            {
+                WithLabel(new SetOutput
+                    { Id = $"{id}_Context", OutputName = new("contextJson"), OutputValue = new(ctx => (object)contextJson.Get(ctx)) }, "Output contextJson"),
+                WithLabel(new SetOutput
+                    { Id = $"{id}_Status", OutputName = new("contextStatus"), OutputValue = new(ctx => (object)contextStatus.Get(ctx)) }, "Output contextStatus"),
+            }
+        };
+        seq.SetDisplayText(name);
+        return seq;
+    }
+
+    // ================================================================
+    // Helper: Emit a TRIAGE.CONTEXT.* DCB event through the durable drain.
+    // ================================================================
+    private static EmitTriageContextEventActivity EmitContextEvent(
+        string id, string label,
+        Func<Elsa.Expressions.Models.ExpressionExecutionContext, string> eventType,
+        Variable<string> repository, Variable<int> itemNumber, Variable<string> tenantId,
+        Func<Elsa.Expressions.Models.ExpressionExecutionContext, string> itemType,
+        Func<Elsa.Expressions.Models.ExpressionExecutionContext, string> contextStatus,
+        Func<Elsa.Expressions.Models.ExpressionExecutionContext, int> contextJsonLength)
+    {
+        var emit = new EmitTriageContextEventActivity
+        {
+            Id = id, Name = label,
+            EventType = new Input<string>(eventType),
+            Repository = new Input<string>(ctx => repository.Get(ctx)),
+            ItemNumber = new Input<int>(ctx => itemNumber.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
+            ItemType = new Input<string?>(ctx => itemType(ctx)),
+            ContextStatus = new Input<string?>(ctx => contextStatus(ctx)),
+            ContextJsonLength = new Input<int>(contextJsonLength),
+        };
+        emit.SetDisplayText(label);
+        return emit;
+    }
+
     private static FlowConnection Connect(IActivity source, IActivity target)
         => new(new FlowEndpoint(source), new FlowEndpoint(target));
+
+    private static FlowConnection ConnectOutcome(IActivity source, string outcome, IActivity target)
+        => new(new FlowEndpoint(source, outcome), new FlowEndpoint(target));
 }

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TriageItemCycleWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TriageItemCycleWorkflow.cs
@@ -32,10 +32,21 @@ namespace Tamma.ElsaServer.Workflows;
 /// panel to PO + label application regardless of panel health, so a fully-failed
 /// panel still labelled the item (silent false success downstream).</para>
 ///
+/// <para>Build-out (completeness audit 2026-06-22, <c>TriageContextGathering.md</c>):
+/// the context-gathering sub-workflow is likewise fail-closed and now reports a
+/// <c>contextStatus</c> (<c>ok</c>/<c>empty</c>/<c>failed</c>) and accepts a
+/// <c>tenantId</c>. This cycle forwards <c>tenantId</c> into it and <b>honours</b>
+/// the <c>failed</c> signal: when NO context could be gathered (the LLM scan
+/// failed), the panel is NOT run over phantom context — the cycle routes to the
+/// same loud non-applying terminal. (<c>empty</c>/<c>ok</c> still run the panel;
+/// an empty-but-successful scan is a degraded, not failed, result.)</para>
+///
 /// Flow:
-///   Init → Gather Context (llm-call) → Panel Review (llm-call x4)
-///   → Extract Panel Result + Status → Panel Usable?
-///       ├─ True (ok/partial)  → PO Decision (llm-call) → Apply Labels → Finish
+///   Init → Gather Context (llm-call) → Extract Context + Status → Context Gathered?
+///       ├─ True (ok/empty)    → Panel Review (llm-call x4)
+///       │     → Extract Panel Result + Status → Panel Usable?
+///       │         ├─ True (ok/partial)  → PO Decision → Apply Labels → Finish
+///       │         └─ False (failed)     → Mark Skipped (no labels)    → Finish
 ///       └─ False (failed)     → Mark Skipped (no labels)              → Finish
 ///
 /// Inputs: repository, itemJson, tenantId
@@ -56,12 +67,20 @@ public class TriageItemCycleWorkflow : WorkflowBase
         var itemJson = builder.WithVariable<string>("ItemJson", "");
         var tenantId = builder.WithVariable<string>("TenantId", "");
         var contextJson = builder.WithVariable<string>("ContextJson", "");
+        // Context health signal from the (fail-closed) context sub-workflow:
+        // "ok" / "empty" => usable; "failed" => no context gathered, skip the panel.
+        var contextStatus = builder.WithVariable<string>(
+            "ContextStatus", TriageContextEvents.StatusFailed);
         var panelResultJson = builder.WithVariable<string>("PanelResultJson", "");
         // Panel health signal from the (fail-closed) panel sub-workflow:
         // "ok" / "partial" => usable; "failed" => below quorum, do NOT apply labels.
         var panelStatus = builder.WithVariable<string>(
             "PanelStatus", TriagePanelAggregationHelper.StatusFailed);
         var poDecisionJson = builder.WithVariable<string>("PODecisionJson", "");
+        // Why the cycle skipped label application — "context-failed" (no context
+        // gathered) or "panel-failed" (panel below quorum). Set by whichever gate
+        // tripped, surfaced on the workflow output for the caller / audit.
+        var skipReason = builder.WithVariable<string>("SkipReason", "");
         var subResult = builder.WithVariable<IDictionary<string, object>?>();
 
         // ================================================================
@@ -93,6 +112,7 @@ public class TriageItemCycleWorkflow : WorkflowBase
             {
                 ["repository"] = repository.Get(ctx),
                 ["itemJson"] = itemJson.Get(ctx),
+                ["tenantId"] = tenantId.Get(ctx),
             }),
             WaitForCompletion = new(true),
             Result = new(subResult),
@@ -107,12 +127,34 @@ public class TriageItemCycleWorkflow : WorkflowBase
             Value = new Input<object?>(ctx =>
             {
                 var result = subResult.Get(ctx);
+
+                // Read the context-health signal first. Absence is treated as a
+                // FAILED scan (fail-closed): if the sub-workflow did not report a
+                // status we must NOT assume context was gathered and run the panel.
+                var status = TriageContextEvents.StatusFailed;
+                if (result != null && result.TryGetValue("contextStatus", out var st))
+                {
+                    var s = st?.ToString();
+                    if (!string.IsNullOrWhiteSpace(s)) status = s!;
+                }
+                contextStatus.Set(ctx, status);
+
                 if (result != null && result.TryGetValue("contextJson", out var c))
                     return (object)(c?.ToString() ?? "");
                 return (object)"";
             })
         };
         extractContext.SetDisplayText("Extract Context");
+
+        // ================================================================
+        // 2a. Context Gathered? — honour the context stage's fail-closed signal.
+        //     A "failed" scan (no context gathered) routes to the same non-applying
+        //     terminal as a failed panel; "ok"/"empty" proceed to the panel review.
+        // ================================================================
+        var contextGathered = new FlowDecision(ctx =>
+            contextStatus.Get(ctx) != TriageContextEvents.StatusFailed)
+        { Id = "ContextGathered", Name = "Context Gathered?" };
+        contextGathered.SetDisplayText("Context Gathered?");
 
         // ================================================================
         // 3. Panel Review (security analyst, dev, devops, qa)
@@ -171,10 +213,11 @@ public class TriageItemCycleWorkflow : WorkflowBase
         { Id = "PanelUsable", Name = "Panel Usable?" };
         panelUsable.SetDisplayText("Panel Usable?");
 
-        // Failed-panel terminal — record the skip on the workflow outputs so the
-        // caller/audit sees a LOUD non-applying outcome (no labels applied off a
-        // wholly-failed panel). The panel sub-workflow already emitted
-        // TRIAGE.PANEL.FAILED to the durable drain.
+        // Shared non-applying terminal — record the skip on the workflow outputs so
+        // the caller/audit sees a LOUD non-applying outcome (no labels applied off a
+        // failed context scan or a wholly-failed panel). The relevant sub-workflow
+        // already emitted TRIAGE.CONTEXT.FAILED / TRIAGE.PANEL.FAILED to the durable
+        // drain; the skipReason variable says which stage tripped.
         var markSkipped = new SetOutput
         {
             Id = "MarkSkipped",
@@ -189,9 +232,30 @@ public class TriageItemCycleWorkflow : WorkflowBase
             Id = "OutSkipReason",
             Name = "Output Skip Reason",
             OutputName = new("skipReason"),
-            OutputValue = new(_ => (object)"panel-failed"),
+            OutputValue = new(ctx => (object)skipReason.Get(ctx)),
         };
         outSkipReason.SetDisplayText("Output Skip Reason");
+
+        // Set the skip reason on the context-failed branch (before the shared
+        // terminal). A dedicated SetVariable keeps the reason explicit + testable.
+        var setContextFailedReason = new SetVariable
+        {
+            Id = "SetContextFailedReason",
+            Name = "Set Context-Failed Reason",
+            Variable = skipReason,
+            Value = new Input<object?>(_ => (object)"context-failed"),
+        };
+        setContextFailedReason.SetDisplayText("Set Context-Failed Reason");
+
+        // Set the skip reason on the panel-failed branch.
+        var setPanelFailedReason = new SetVariable
+        {
+            Id = "SetPanelFailedReason",
+            Name = "Set Panel-Failed Reason",
+            Variable = skipReason,
+            Value = new Input<object?>(_ => (object)"panel-failed"),
+        };
+        setPanelFailedReason.SetDisplayText("Set Panel-Failed Reason");
 
         // ================================================================
         // 4. PO Decision (priority, labels, automation level)
@@ -257,10 +321,12 @@ public class TriageItemCycleWorkflow : WorkflowBase
             {
                 init,
                 gatherContext, extractContext,
+                contextGathered,
                 panelReview, extractPanelResult,
                 panelUsable,
                 poDecision, extractDecision,
                 applyLabels,
+                setContextFailedReason, setPanelFailedReason,
                 markSkipped, outSkipReason,
                 finish,
             },
@@ -268,9 +334,17 @@ public class TriageItemCycleWorkflow : WorkflowBase
             {
                 Connect(init, gatherContext),
                 Connect(gatherContext, extractContext),
-                Connect(extractContext, panelReview),
+                Connect(extractContext, contextGathered),
+
+                // Context gathered (ok/empty) → run the panel.
+                ConnectOutcome(contextGathered, "True", panelReview),
                 Connect(panelReview, extractPanelResult),
                 Connect(extractPanelResult, panelUsable),
+
+                // Context failed (no context gathered) → skip the panel + labels.
+                // The False edge never falls through to the panel-review path.
+                ConnectOutcome(contextGathered, "False", setContextFailedReason),
+                Connect(setContextFailedReason, markSkipped),
 
                 // Usable (ok/partial) → PO decision → apply labels → finish.
                 ConnectOutcome(panelUsable, "True", poDecision),
@@ -280,7 +354,8 @@ public class TriageItemCycleWorkflow : WorkflowBase
 
                 // Failed (below quorum) → mark skipped (NO labels) → finish.
                 // The False edge never falls through to the apply-labels path.
-                ConnectOutcome(panelUsable, "False", markSkipped),
+                ConnectOutcome(panelUsable, "False", setPanelFailedReason),
+                Connect(setPanelFailedReason, markSkipped),
                 Connect(markSkipped, outSkipReason),
                 Connect(outSkipReason, finish),
             }

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/TriageContextEventTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/TriageContextEventTests.cs
@@ -1,0 +1,314 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+using Tamma.ElsaServer.Workflows.Helpers;
+
+namespace Tamma.Activities.Tests.ADL;
+
+/// <summary>
+/// Completeness audit 2026-06-22 (<c>TriageContextGathering.md</c>) — coverage for
+/// the TRIAGE.CONTEXT.* DCB event mapping
+/// (<see cref="EmitTriageContextEventActivity.BuildTammaEvent"/>), the
+/// <see cref="TriageContextEvents"/> status convention, and the
+/// <see cref="TriageContextHelper"/> fail-closed extraction + item-type detection.
+///
+/// <para>The core completeness gap was a P0 <b>no-false-success</b> defect: a failed
+/// LLM scan was silently coalesced to <c>"{}"</c> and reported "successful". These
+/// tests pin the now-explicit contract: a failed scan → <c>failed</c> status / error
+/// audit row; an empty scan → <c>empty</c> / warning; only a usable scan → <c>ok</c>
+/// / success. They also pin the variable-contract-driving item-type detection.</para>
+/// </summary>
+[TestFixture]
+public class TriageContextEventTests
+{
+    // ================================================================
+    // TriageContextEvents — status convention (no false success)
+    // ================================================================
+
+    [Test]
+    public void StatusForEvent_FailedIsError_EmptyIsWarning_CompletedIsSuccess()
+    {
+        TriageContextEvents.StatusForEvent(TriageContextEvents.Failed).Should().Be("error");
+        TriageContextEvents.StatusForEvent(TriageContextEvents.Empty).Should().Be("warning");
+        TriageContextEvents.StatusForEvent(TriageContextEvents.Completed).Should().Be("success");
+        TriageContextEvents.StatusForEvent(TriageContextEvents.Started).Should().Be("success");
+    }
+
+    [Test]
+    public void EventTypes_FollowAggregateActionStatusConvention()
+    {
+        TriageContextEvents.Started.Should().Be("TRIAGE.CONTEXT.STARTED");
+        TriageContextEvents.Completed.Should().Be("TRIAGE.CONTEXT.COMPLETED");
+        TriageContextEvents.Empty.Should().Be("TRIAGE.CONTEXT.EMPTY");
+        TriageContextEvents.Failed.Should().Be("TRIAGE.CONTEXT.FAILED");
+    }
+
+    [Test]
+    public void EventTypeForStatus_MapsStatusToTerminalEvent()
+    {
+        TriageContextEvents.EventTypeForStatus(TriageContextEvents.StatusFailed)
+            .Should().Be(TriageContextEvents.Failed);
+        TriageContextEvents.EventTypeForStatus(TriageContextEvents.StatusEmpty)
+            .Should().Be(TriageContextEvents.Empty);
+        TriageContextEvents.EventTypeForStatus(TriageContextEvents.StatusOk)
+            .Should().Be(TriageContextEvents.Completed);
+        // Anything unexpected defaults to COMPLETED (ok) — never silently FAILED.
+        TriageContextEvents.EventTypeForStatus("whatever")
+            .Should().Be(TriageContextEvents.Completed);
+    }
+
+    [Test]
+    public void ParseTenantId_ValidGuid_Parses_InvalidOrEmpty_IsNull()
+    {
+        var g = Guid.NewGuid();
+        TriageContextEvents.ParseTenantId(g.ToString()).Should().Be(g);
+        TriageContextEvents.ParseTenantId("").Should().BeNull();
+        TriageContextEvents.ParseTenantId(null).Should().BeNull();
+        TriageContextEvents.ParseTenantId("not-a-guid").Should().BeNull();
+    }
+
+    // ================================================================
+    // BuildTammaEvent — tags + data + status mapping
+    // ================================================================
+
+    [Test]
+    public void BuildTammaEvent_Completed_HasSuccessStatus_AndHealthPayload()
+    {
+        var evt = EmitTriageContextEventActivity.BuildTammaEvent(
+            TriageContextEvents.Completed,
+            repository: "owner/repo",
+            itemNumber: 7,
+            tenantId: null,
+            itemType: "issue",
+            contextStatus: "ok",
+            contextJsonLength: 128);
+
+        evt.EventType.Should().Be("TRIAGE.CONTEXT.COMPLETED");
+        evt.Status.Should().Be("success");
+
+        evt.Tags!["repository"].Should().Be("owner/repo");
+        evt.Tags!["itemId"].Should().Be("7");
+        evt.Tags!["itemNumber"].Should().Be("7");
+        evt.Tags!["itemSource"].Should().Be("issue");
+        evt.Tags!["contextStatus"].Should().Be("ok");
+        evt.Tags.Should().NotContainKey("tenantId", "single-user / platform-scope event");
+
+        evt.Data["itemType"].Should().Be("issue");
+        evt.Data["contextStatus"].Should().Be("ok");
+        evt.Data["contextJsonLength"].Should().Be(128);
+    }
+
+    [Test]
+    public void BuildTammaEvent_Failed_HasErrorStatus()
+    {
+        // The core guarantee: a failed scan is a LOUD (error) audit row — never a
+        // silent false success.
+        var evt = EmitTriageContextEventActivity.BuildTammaEvent(
+            TriageContextEvents.Failed,
+            repository: "owner/repo",
+            itemNumber: 99,
+            tenantId: null,
+            itemType: "security",
+            contextStatus: "failed",
+            contextJsonLength: 0);
+
+        evt.EventType.Should().Be("TRIAGE.CONTEXT.FAILED");
+        evt.Status.Should().Be("error");
+        evt.Tags!["contextStatus"].Should().Be("failed");
+        evt.Data["contextStatus"].Should().Be("failed");
+        evt.Data["contextJsonLength"].Should().Be(0);
+    }
+
+    [Test]
+    public void BuildTammaEvent_Empty_HasWarningStatus()
+    {
+        var evt = EmitTriageContextEventActivity.BuildTammaEvent(
+            TriageContextEvents.Empty,
+            repository: "owner/repo",
+            itemNumber: 3,
+            tenantId: null,
+            itemType: "issue",
+            contextStatus: "empty",
+            contextJsonLength: 2);
+
+        evt.Status.Should().Be("warning");
+        evt.Tags!["contextStatus"].Should().Be("empty");
+    }
+
+    [Test]
+    public void BuildTammaEvent_WithTenant_StampsTenantTag()
+    {
+        var tenant = Guid.NewGuid();
+        var evt = EmitTriageContextEventActivity.BuildTammaEvent(
+            TriageContextEvents.Started, "owner/repo", 1, tenant, "issue", null, 0);
+
+        evt.Tags!["tenantId"].Should().Be(tenant.ToString("D"));
+    }
+
+    [Test]
+    public void BuildTammaEvent_ZeroItemNumber_OmitsItemTags()
+    {
+        var evt = EmitTriageContextEventActivity.BuildTammaEvent(
+            TriageContextEvents.Started, "owner/repo", 0, null, "issue", null, 0);
+
+        evt.Tags!.Should().NotContainKey("itemId");
+        evt.Tags!.Should().NotContainKey("itemNumber");
+        evt.Tags!["repository"].Should().Be("owner/repo");
+    }
+
+    // ================================================================
+    // TriageContextHelper.DetectItemType — parse-based, whitespace-robust (§5 #5)
+    // ================================================================
+
+    [Test]
+    public void DetectItemType_SecurityAdvisory_DetectedRegardlessOfWhitespace()
+    {
+        // Pretty-printed JSON broke the prior substring sniff ("type":"security").
+        const string pretty = """
+        {
+            "number": 12,
+            "type": "security",
+            "title": "CVE in lodash"
+        }
+        """;
+        TriageContextHelper.DetectItemType(pretty).Should().Be("security");
+    }
+
+    [Test]
+    public void DetectItemType_AdvisoryMarker_WithoutTypeField_IsSecurity()
+    {
+        const string json = """{ "number": 1, "advisory": { "ghsaId": "GHSA-xxxx" } }""";
+        TriageContextHelper.DetectItemType(json).Should().Be("security");
+    }
+
+    [Test]
+    public void DetectItemType_DependabotType_IsDependency()
+    {
+        const string json = """{ "number": 5, "type": "dependabot", "dependency": "lodash" }""";
+        TriageContextHelper.DetectItemType(json).Should().Be("dependency");
+    }
+
+    [Test]
+    public void DetectItemType_PlainIssue_IsIssue()
+    {
+        const string json = """{ "number": 3, "type": "bug", "title": "broken" }""";
+        TriageContextHelper.DetectItemType(json).Should().Be("issue");
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("not json at all")]
+    public void DetectItemType_NullOrEmptyOrMalformed_DefaultsToIssue_NeverThrows(string? json)
+    {
+        TriageContextHelper.DetectItemType(json).Should().Be("issue");
+    }
+
+    [Test]
+    public void DetectItemType_MalformedButSecurityMarkers_TolerantSniff()
+    {
+        // Not parseable JSON, but carries the security marker → tolerant fallback.
+        const string broken = """{ "type":"security" ... truncated""";
+        TriageContextHelper.DetectItemType(broken).Should().Be("security");
+    }
+
+    // ================================================================
+    // TriageContextHelper.ExtractContext — fail-closed (the P0 regression)
+    // ================================================================
+
+    [Test]
+    public void ExtractContext_NullResult_IsFailed_NotEmptyAsSuccess()
+    {
+        var (json, status) = TriageContextHelper.ExtractContext(null);
+        status.Should().Be(TriageContextEvents.StatusFailed);
+        json.Should().Be("{}");
+    }
+
+    [Test]
+    public void ExtractContext_SuccessFalse_IsFailed()
+    {
+        // The all-providers-failed shape: success=false. Must NOT be presented as
+        // gathered context.
+        var result = new Dictionary<string, object>
+        {
+            ["success"] = false,
+            ["llmResponse"] = "partial garbage",
+        };
+        var (json, status) = TriageContextHelper.ExtractContext(result);
+        status.Should().Be(TriageContextEvents.StatusFailed);
+        json.Should().Be("{}");
+    }
+
+    [Test]
+    public void ExtractContext_NoLlmResponse_IsFailed()
+    {
+        var result = new Dictionary<string, object> { ["success"] = true };
+        var (json, status) = TriageContextHelper.ExtractContext(result);
+        status.Should().Be(TriageContextEvents.StatusFailed);
+        json.Should().Be("{}");
+    }
+
+    [Test]
+    public void ExtractContext_BlankResponse_IsEmpty_NotOk()
+    {
+        var result = new Dictionary<string, object>
+        {
+            ["success"] = true,
+            ["llmResponse"] = "   ",
+        };
+        var (json, status) = TriageContextHelper.ExtractContext(result);
+        status.Should().Be(TriageContextEvents.StatusEmpty);
+    }
+
+    [Test]
+    public void ExtractContext_EmptyObject_IsEmpty_NotOk()
+    {
+        var result = new Dictionary<string, object>
+        {
+            ["success"] = true,
+            ["llmResponse"] = "here it is: {}",
+        };
+        var (json, status) = TriageContextHelper.ExtractContext(result);
+        status.Should().Be(TriageContextEvents.StatusEmpty);
+        json.Should().Be("{}");
+    }
+
+    [Test]
+    public void ExtractContext_StructuredObject_IsOk()
+    {
+        var result = new Dictionary<string, object>
+        {
+            ["success"] = true,
+            ["llmResponse"] = """Findings: {"relevantFiles": [{"path": "a.cs"}]} done""",
+        };
+        var (json, status) = TriageContextHelper.ExtractContext(result);
+        status.Should().Be(TriageContextEvents.StatusOk);
+        json.Should().Contain("relevantFiles");
+    }
+
+    [Test]
+    public void ExtractContext_FreeFormProse_IsOk_WrappedAsRawContext()
+    {
+        var result = new Dictionary<string, object>
+        {
+            ["success"] = true,
+            ["llmResponse"] = "The affected module is widely used across the codebase.",
+        };
+        var (json, status) = TriageContextHelper.ExtractContext(result);
+        status.Should().Be(TriageContextEvents.StatusOk);
+        json.Should().Contain("rawContext");
+    }
+
+    [Test]
+    public void ExtractContext_AbsentSuccessFlag_TreatedAsSuccess()
+    {
+        // Back-compat: a caller that doesn't surface "success" but returns a usable
+        // response is treated as success (matching the panel's convention).
+        var result = new Dictionary<string, object>
+        {
+            ["llmResponse"] = """{"dependencies": [{"name": "lodash"}]}""",
+        };
+        var (json, status) = TriageContextHelper.ExtractContext(result);
+        status.Should().Be(TriageContextEvents.StatusOk);
+        json.Should().Contain("dependencies");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TriageContextGatheringWorkflowTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TriageContextGatheringWorkflowTests.cs
@@ -1,0 +1,195 @@
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Management.Activities.SetOutput;
+using Elsa.Workflows.Runtime.Activities;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Completeness audit 2026-06-22 (<c>TriageContextGathering.md</c>) —
+/// workflow-structure coverage for the built-out <c>triage-context-gathering</c>
+/// graph. Asserts the load-bearing guarantees: the scan is LLM-mediated (dispatch →
+/// <c>llm-call</c>, never a raw provider call); the fail-closed gate routes a failed
+/// scan to a LOUD <c>TRIAGE.CONTEXT.FAILED</c> terminal (the FAILED edge never falls
+/// through to the COMPLETED/EMPTY path — no false success); STARTED is emitted after
+/// init and exactly one terminal event per path; both terminals output
+/// <c>contextStatus</c>; every outcome reaches Finish (no dangling edge).
+///
+/// <para>Follows the codebase convention of inspecting the BUILT Flowchart via
+/// <see cref="WorkflowTestHelper"/> (see <see cref="TriagePanelReviewWorkflowTests"/>).</para>
+/// </summary>
+[TestFixture]
+public class TriageContextGatheringWorkflowTests
+{
+    private Flowchart _flowchart = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new TriageContextGatheringWorkflow());
+        _flowchart = WorkflowTestHelper.GetFlowchart(builder);
+    }
+
+    // ================================================================
+    // Identity
+    // ================================================================
+
+    [Test]
+    public void Workflow_BuildsWithExpectedDefinitionId()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new TriageContextGatheringWorkflow());
+        builder.Object.DefinitionId.Should().Be("triage-context-gathering");
+    }
+
+    // ================================================================
+    // LLM mediation — the scan goes through llm-call, never a raw provider call
+    // ================================================================
+
+    [Test]
+    public void GatherContext_IsMediatedThroughLlmCall()
+    {
+        var dispatch = _flowchart.Activities
+            .OfType<DispatchWorkflow>()
+            .FirstOrDefault(d => d.Id == "GatherContext");
+
+        dispatch.Should().NotBeNull("context gathering must be a DispatchWorkflow step");
+        ReadDefinitionId(dispatch!).Should().Be("llm-call",
+            "the scan must be mediated through llm-call, never a raw provider call");
+    }
+
+    // ================================================================
+    // DCB events — STARTED after init; exactly one terminal event per path
+    // ================================================================
+
+    [Test]
+    public void StartedEvent_EmittedRightAfterInit()
+    {
+        var started = _flowchart.Activities
+            .OfType<EmitTriageContextEventActivity>()
+            .FirstOrDefault(a => a.Id == "EmitStarted");
+        started.Should().NotBeNull("the stage must emit TRIAGE.CONTEXT.STARTED");
+
+        HasEdge("Init", null, "EmitStarted").Should().BeTrue();
+        HasEdge("EmitStarted", null, "GatherContext").Should().BeTrue();
+    }
+
+    [Test]
+    public void BothTerminalPaths_EmitAContextEvent_AndReachFinish()
+    {
+        _flowchart.Activities.OfType<EmitTriageContextEventActivity>()
+            .Any(a => a.Id == "EmitUsable").Should().BeTrue();
+        _flowchart.Activities.OfType<EmitTriageContextEventActivity>()
+            .Any(a => a.Id == "EmitFailed").Should().BeTrue();
+
+        HasEdge("EmitUsable", null, "Finish").Should().BeTrue();
+        HasEdge("EmitFailed", null, "Finish").Should().BeTrue();
+    }
+
+    // ================================================================
+    // Fail-closed gate — failed scan reaches a LOUD terminal, no false success
+    // ================================================================
+
+    [Test]
+    public void ContextGatheredGate_ExistsAfterExtraction()
+    {
+        _flowchart.Activities.OfType<FlowDecision>()
+            .Any(d => d.Id == "ContextGathered")
+            .Should().BeTrue("the gate must exist to fail a non-gathered scan");
+
+        HasEdge("ExtractResult", null, "ContextGathered").Should().BeTrue();
+    }
+
+    [Test]
+    public void FailedScan_RoutesToFailedTerminal_NotToCompleted()
+    {
+        // False (no context) → mark failed → failed outputs → TRIAGE.CONTEXT.FAILED.
+        // The False edge must NEVER reach the usable/COMPLETED emit (no false success).
+        HasEdge("ContextGathered", "False", "FailedSetStatus").Should().BeTrue();
+        HasEdge("FailedSetStatus", null, "FailedOutputs").Should().BeTrue();
+        HasEdge("FailedOutputs", null, "EmitFailed").Should().BeTrue();
+
+        var falseTargets = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "ContextGathered" && c.Source.Port == "False")
+            .Select(c => c.Target.Activity.Id)
+            .ToList();
+
+        falseTargets.Should().NotContain("EmitUsable");
+        falseTargets.Should().NotContain("UsableOutputs");
+    }
+
+    [Test]
+    public void UsableScan_RoutesToUsableTerminal()
+    {
+        HasEdge("ContextGathered", "True", "UsableOutputs").Should().BeTrue();
+        HasEdge("UsableOutputs", null, "EmitUsable").Should().BeTrue();
+    }
+
+    [Test]
+    public void ContextGatheredGate_HasNoUnconditionalFallthrough()
+    {
+        var fromGate = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "ContextGathered")
+            .ToList();
+
+        fromGate.Should().NotBeEmpty();
+        fromGate.Should().OnlyContain(c => c.Source.Port == "True" || c.Source.Port == "False");
+    }
+
+    // ================================================================
+    // Outputs — both terminals expose the contextStatus contract
+    // ================================================================
+
+    [Test]
+    public void BothTerminals_OutputContextJsonAndStatus()
+    {
+        foreach (var seqId in new[] { "UsableOutputs", "FailedOutputs" })
+        {
+            var seq = _flowchart.Activities.OfType<Sequence>().First(s => s.Id == seqId);
+            var ids = seq.Activities.OfType<SetOutput>()
+                .Select(o => o.Id ?? "")
+                .ToList();
+
+            ids.Should().Contain($"{seqId}_Context");
+            ids.Should().Contain($"{seqId}_Status");
+        }
+    }
+
+    // ================================================================
+    // No dangling edges — every non-terminal activity has an outgoing edge.
+    // ================================================================
+
+    [Test]
+    public void EveryActivity_RoutesToATerminal_NoDanglingEdge()
+    {
+        var allIds = _flowchart.Activities.Select(a => a.Id!).ToHashSet();
+        var sources = _flowchart.Connections.Select(c => c.Source.Activity.Id!).ToHashSet();
+
+        foreach (var id in allIds.Where(i => i != "Finish"))
+        {
+            sources.Should().Contain(id, $"activity '{id}' must route somewhere (no dangling edge)");
+        }
+    }
+
+    // ================================================================
+    // Helpers
+    // ================================================================
+
+    private bool HasEdge(string sourceId, string? port, string targetId)
+        => _flowchart.Connections.Any(c =>
+            c.Source.Activity.Id == sourceId &&
+            (port == null || c.Source.Port == port) &&
+            c.Target.Activity.Id == targetId);
+
+    private static string? ReadDefinitionId(DispatchWorkflow dispatch)
+    {
+        var prop = typeof(DispatchWorkflow).GetProperty("WorkflowDefinitionId");
+        var value = prop?.GetValue(dispatch);
+        var expression = value?.GetType().GetProperty("Expression")?.GetValue(value)
+            as Elsa.Expressions.Models.Expression;
+        return expression?.Value?.ToString();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TriageItemCycleRoutingTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TriageItemCycleRoutingTests.cs
@@ -43,6 +43,69 @@ public class TriageItemCycleRoutingTests
         HasEdge("ExtractPanelResult", null, "PanelUsable").Should().BeTrue();
     }
 
+    // ================================================================
+    // Context-gathering fail-closed signal (TriageContextGathering build-out)
+    // ================================================================
+
+    [Test]
+    public void ContextGatheredGate_Exists_AfterExtractingContext()
+    {
+        _flowchart.Activities.OfType<FlowDecision>()
+            .Any(d => d.Id == "ContextGathered")
+            .Should().BeTrue("the cycle must gate on the context stage's fail-closed signal");
+
+        HasEdge("ExtractContext", null, "ContextGathered").Should().BeTrue();
+    }
+
+    [Test]
+    public void GatheredContext_ProceedsToPanelReview()
+    {
+        HasEdge("ContextGathered", "True", "PanelReview").Should().BeTrue();
+    }
+
+    [Test]
+    public void FailedContext_SkipsPanelAndLabels_RoutesToLoudTerminal()
+    {
+        // False (no context gathered) → set reason → mark skipped → finish. It must
+        // NOT reach the panel review, PO decision, or label-application activity
+        // (no panel over phantom context, no silent labelling).
+        HasEdge("ContextGathered", "False", "SetContextFailedReason").Should().BeTrue();
+        HasEdge("SetContextFailedReason", null, "MarkSkipped").Should().BeTrue();
+
+        var falseTargets = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "ContextGathered" && c.Source.Port == "False")
+            .Select(c => c.Target.Activity.Id)
+            .ToList();
+
+        falseTargets.Should().NotContain("PanelReview");
+        falseTargets.Should().NotContain("PODecision");
+        falseTargets.Should().NotContain("ApplyLabels");
+    }
+
+    [Test]
+    public void ContextGatheredGate_HasNoUnconditionalFallthrough()
+    {
+        var fromGate = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "ContextGathered")
+            .ToList();
+
+        fromGate.Should().NotBeEmpty();
+        fromGate.Should().OnlyContain(c => c.Source.Port == "True" || c.Source.Port == "False");
+    }
+
+    [Test]
+    public void ContextDispatch_ThreadsTenantId()
+    {
+        // The cycle forwards tenantId to the context sub-workflow so a tenant-scoped
+        // caller's TRIAGE.CONTEXT.* events carry the tenant tag (durable drain reads
+        // the TenantId variable, which the sub-workflow stamps from this input).
+        var dispatch = _flowchart.Activities
+            .OfType<DispatchWorkflow>()
+            .FirstOrDefault(d => d.Id == "GatherTriageContext");
+        dispatch.Should().NotBeNull();
+        ReadDefinitionId(dispatch!).Should().Be("triage-context-gathering");
+    }
+
     [Test]
     public void UsablePanel_ProceedsToPoDecisionAndLabels()
     {
@@ -55,10 +118,11 @@ public class TriageItemCycleRoutingTests
     [Test]
     public void FailedPanel_SkipsLabelApplication_RoutesToLoudTerminal()
     {
-        // False (failed panel) → mark skipped → finish. It must NOT reach the PO
-        // decision or the label-application activity (no silent labelling off a
-        // wholly-failed panel).
-        HasEdge("PanelUsable", "False", "MarkSkipped").Should().BeTrue();
+        // False (failed panel) → set reason → mark skipped → finish. It must NOT
+        // reach the PO decision or the label-application activity (no silent
+        // labelling off a wholly-failed panel).
+        HasEdge("PanelUsable", "False", "SetPanelFailedReason").Should().BeTrue();
+        HasEdge("SetPanelFailedReason", null, "MarkSkipped").Should().BeTrue();
         HasEdge("MarkSkipped", null, "OutSkipReason").Should().BeTrue();
         HasEdge("OutSkipReason", null, "Finish").Should().BeTrue();
 


### PR DESCRIPTION
## What

`TriageContextGatheringWorkflow` — built out, and a **real functional bug fixed**: it was dispatching `llm-call` with variable names (`itemJson`/`itemType`) the `context-scan` prompt template never reads (`{{workItemJson}}`/`{{workItemType}}`/`{{previousFindings}}`) — so **the model was scanning an empty work item**. Now passes the correct variables (matching the `ContextGathering` sibling), plus:
- Fail-closed `Context Gathered?` gate — a failed/empty scan → loud `TRIAGE.CONTEXT.FAILED`/`EMPTY` terminal, never `{}`-as-success; `contextStatus` reported.
- `TRIAGE.CONTEXT.*` DCB events via the durable drain; `tenantId` threaded; robust JSON item-type detection.
- **Caller wiring:** `TriageItemCycle` now forwards `tenantId` and honors `contextStatus=failed` (skip panel+labels → loud terminal, `skipReason=context-failed`), alongside the existing panel-failed gate. Reviewed: no failed-context path reaches panel/labels; both gates' outcomes reach a terminal; no deadlock.

Reviewed: APPROVED. Deferred (P2/P3): per-type CVE/changelog action, idempotency cache, balanced-brace scanner, shared helper with `ContextGathering`.

## Verification
Build 0 errors; `has-pending-model-changes` clean; triage filter 47/0; full `Tamma.Activities.Tests` 1521/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)