### PR TITLE
feat(workflows): build out BranchCreation — idempotent, exact-ref, cycle-gated

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/BranchEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/BranchEvents.cs
@@ -1,0 +1,38 @@
+namespace Tamma.Activities.ADL;
+
+/// <summary>
+/// Story 2.4 (AC8) / Story 4.5 AC3 — central catalogue of <c>BRANCH.*</c> DCB
+/// event types emitted by the built-out <c>branch-creation</c> workflow via
+/// <see cref="EmitBranchEventActivity"/>.
+///
+/// <para>The branch-creation step is issue-scoped, so the events land in the
+/// tenant <c>domain_events</c> store (which carries a first-class
+/// <c>IssueNumber</c> column). They are emitted via <c>TammaEventEmitter.Emit</c>
+/// into the workflow's <c>tamma:events</c> transient list and persisted durably
+/// by the engine event drain (<c>EventPersistenceMiddleware</c>) — see
+/// <see cref="EmitBranchEventActivity.BuildTammaEvent"/> for the DCB mapping
+/// (tags carry <c>issueId</c>/<c>issueNumber</c>/<c>repository</c>/<c>tenantId</c>;
+/// data carries <c>baseBranch</c>/<c>baseSha</c>/<c>finalName</c>/<c>durationMs</c>).</para>
+///
+/// <list type="bullet">
+///   <item><description><c>BRANCH.CREATED.SUCCESS</c> — a branch was created (or
+///     an existing branch was reused under the idempotent conflict strategy).</description></item>
+///   <item><description><c>BRANCH.CREATED.FAILED</c> — branch creation failed
+///     (permission / protected base / missing base / conflict-exhausted / API
+///     error). ALWAYS emitted on the failure edge so the loop never reports a
+///     silent false success — closes the headline thin-wrapper bug.</description></item>
+/// </list>
+/// </summary>
+public static class BranchEvents
+{
+    public const string CreatedSuccess = "BRANCH.CREATED.SUCCESS";
+    public const string CreatedFailed = "BRANCH.CREATED.FAILED";
+
+    /// <summary>
+    /// Parse a tenant id from the loose string form threaded through the workflow
+    /// inputs. Returns <c>null</c> for empty / single-user / unparseable values
+    /// (branch events in single-user mode are platform-scope, TenantId null).
+    /// </summary>
+    public static Guid? ParseTenantId(string? tenantId)
+        => Guid.TryParse(tenantId, out var g) ? g : null;
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/CreateBranchActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/CreateBranchActivity.cs
@@ -104,7 +104,7 @@ public class CreateBranchActivity : Activity
         if (github is null)
         {
             _logger?.LogError("GitHub integration service unavailable — cannot create branch for issue #{Issue}", issueNumber);
-            ErrorCode.Set(context, "github_service_unavailable");
+            ErrorCode.Set(context, "github-service-unavailable");
             Error.Set(context, "GitHub integration service unavailable");
             await context.CompleteActivityWithOutcomesAsync("Error");
             return;

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/CreateBranchActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/CreateBranchActivity.cs
@@ -1,4 +1,6 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using Elsa.Extensions;
 using Elsa.Workflows;
 using Elsa.Workflows.Activities.Flowchart.Attributes;
@@ -10,12 +12,20 @@ using Tamma.Core.Interfaces;
 namespace Tamma.Activities.ADL;
 
 /// <summary>
-/// Creates a feature branch for the selected issue.
-/// Branch name format: adl/{issueNumber}-{sanitized-title}
+/// Creates (or idempotently reuses) a feature branch that isolates an issue's
+/// autonomous-development work. Branch name: <c>adl/{issueNumber}-{sanitized-title}</c>.
+///
+/// <para>Story 2.4 build-out: the activity now performs base-branch validation,
+/// idempotent conflict resolution (branch already exists → suffix / timestamp /
+/// abort per strategy — never a 422 hard-fail), and post-create validation, and
+/// surfaces the base SHA + a typed error classification. The orchestration core
+/// NEVER throws and NEVER reports a false success — every path completes with a
+/// single Elsa outcome that the workflow routes (Created → success edge / Error →
+/// explicit failure edge).</para>
 ///
 /// Outcomes:
-///   - Created: branch created successfully
-///   - Error: branch creation failed
+///   - Created: branch created (or reused under the conflict strategy).
+///   - Error:   branch creation failed (the workflow routes this to the failure edge).
 /// </summary>
 [Activity(
     "Tamma.ADL",
@@ -26,6 +36,18 @@ namespace Tamma.Activities.ADL;
 [FlowNode("Created", "Error")]
 public class CreateBranchActivity : Activity
 {
+    /// <summary>Default conflict strategy when none is supplied.</summary>
+    public const string DefaultConflictStrategy = "suffix";
+
+    /// <summary>Default base branch when none is supplied.</summary>
+    public const string DefaultBaseBranch = "main";
+
+    /// <summary>Max sanitized-title length carried into the branch slug.</summary>
+    public const int MaxTitleLength = 40;
+
+    /// <summary>Cap on the suffix search so a pathological repo can't loop forever.</summary>
+    public const int MaxConflictSuffix = 100;
+
     private readonly ILogger<CreateBranchActivity>? _logger;
     private readonly IGitHubIntegrationService? _github;
 
@@ -38,8 +60,26 @@ public class CreateBranchActivity : Activity
     [Input(Description = "Issue title for branch naming")]
     public Input<string> IssueTitle { get; set; } = default!;
 
-    [Output(Description = "Created branch name")]
+    [Input(Description = "Base branch to cut from (default main)")]
+    public Input<string> BaseBranch { get; set; } = new(DefaultBaseBranch);
+
+    [Input(Description = "Conflict strategy: suffix | timestamp | abort (default suffix)")]
+    public Input<string> ConflictStrategy { get; set; } = new(DefaultConflictStrategy);
+
+    [Output(Description = "Created (or reused) branch name")]
     public Output<string?> BranchName { get; set; } = default!;
+
+    [Output(Description = "SHA of the base ref the branch was cut from")]
+    public Output<string?> BaseSha { get; set; } = default!;
+
+    [Output(Description = "True when an existing-branch conflict was resolved (suffix/timestamp)")]
+    public Output<bool> ConflictResolved { get; set; } = default!;
+
+    [Output(Description = "Failure classification when the Error outcome fires")]
+    public Output<string?> ErrorCode { get; set; } = default!;
+
+    [Output(Description = "Human-readable failure reason when the Error outcome fires")]
+    public Output<string?> Error { get; set; } = default!;
 
     [JsonConstructor]
     public CreateBranchActivity() { }
@@ -54,50 +94,275 @@ public class CreateBranchActivity : Activity
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var repository = Repository.Get(context);
+        var repository = Repository.Get(context) ?? "";
         var issueNumber = IssueNumber.Get(context);
         var issueTitle = IssueTitle.Get(context) ?? "";
+        var baseBranch = string.IsNullOrWhiteSpace(BaseBranch.Get(context)) ? DefaultBaseBranch : BaseBranch.Get(context)!;
+        var strategy = string.IsNullOrWhiteSpace(ConflictStrategy.Get(context)) ? DefaultConflictStrategy : ConflictStrategy.Get(context)!;
 
-        var sanitized = SanitizeBranchName(issueTitle);
-        var branchName = $"adl/{issueNumber}-{sanitized}";
-
-        try
+        var github = _github ?? context.GetService<IGitHubIntegrationService>();
+        if (github is null)
         {
-            var result = await _github!.CreateGitHubBranchAsync(repository, branchName);
-            if (!result.Success)
-            {
-                _logger?.LogError("Failed to create branch {Branch}: {Error}",
-                    branchName, result.Error);
-                await context.CompleteActivityWithOutcomesAsync("Error");
-                return;
-            }
+            _logger?.LogError("GitHub integration service unavailable — cannot create branch for issue #{Issue}", issueNumber);
+            ErrorCode.Set(context, "github_service_unavailable");
+            Error.Set(context, "GitHub integration service unavailable");
+            await context.CompleteActivityWithOutcomesAsync("Error");
+            return;
+        }
 
-            BranchName.Set(context, branchName);
+        var candidate = GenerateBranchName(issueNumber, issueTitle);
+        var outcome = await ExecuteCoreAsync(github, repository, issueNumber, candidate, baseBranch, strategy, _logger);
 
-            _logger?.LogInformation("Created branch {Branch} for issue #{Number}",
-                branchName, issueNumber);
+        if (outcome.Outcome == "Created")
+        {
+            BranchName.Set(context, outcome.BranchName);
+            BaseSha.Set(context, outcome.BaseSha);
+            ConflictResolved.Set(context, outcome.ConflictResolved);
             await context.CompleteActivityWithOutcomesAsync("Created");
         }
-        catch (Exception ex)
+        else
         {
-            _logger?.LogError(ex, "Error creating branch {Branch}", branchName);
+            ErrorCode.Set(context, outcome.ErrorCode ?? "unknown");
+            Error.Set(context, outcome.Error ?? "branch creation failed");
             await context.CompleteActivityWithOutcomesAsync("Error");
         }
     }
 
+    /// <summary>
+    /// Pure-ish orchestration core (no Elsa context): ref-name validation →
+    /// idempotent conflict resolution → base-branch-aware create → post-create
+    /// validation, with typed error classification. Returns a typed outcome so the
+    /// happy / idempotency / failure / validation paths are unit-testable against a
+    /// mocked <see cref="IGitHubIntegrationService"/>. NEVER throws — exceptions
+    /// become an <c>Error</c> outcome (no silent success); a transient existence
+    /// lookup failure is an Error too (never mistaken for "absent → free to create").
+    /// </summary>
+    public static async Task<BranchCreationOutcome> ExecuteCoreAsync(
+        IGitHubIntegrationService github,
+        string repository,
+        int issueNumber,
+        string candidateName,
+        string baseBranch,
+        string conflictStrategy,
+        ILogger? logger = null)
+    {
+        try
+        {
+            // ── Ref-name injection hardening (cap #11) ──
+            if (!IsValidRefName(candidateName))
+            {
+                logger?.LogError("Invalid branch ref name {Branch} for issue #{Issue}", candidateName, issueNumber);
+                return BranchCreationOutcome.Failed("invalid_ref", $"invalid branch ref name: {candidateName}");
+            }
+
+            // ── Idempotent conflict resolution (AC3) ──
+            var resolved = await ResolveConflictAsync(github, repository, candidateName, conflictStrategy, logger);
+            if (!resolved.Success)
+                return BranchCreationOutcome.Failed(resolved.ErrorCode!, resolved.Error!);
+
+            var finalName = resolved.FinalName!;
+            var conflictResolved = resolved.ConflictResolved;
+
+            // ── Base-branch-aware create (AC2 / AC4) ──
+            var create = await github.CreateGitHubBranchAsync(repository, finalName, baseBranch);
+            if (!create.Success)
+            {
+                var code = ClassifyError(create.Error);
+                logger?.LogError("Failed to create branch {Branch} from {Base}: {Error}", finalName, baseBranch, create.Error);
+                return BranchCreationOutcome.Failed(code, create.Error ?? "branch creation failed");
+            }
+
+            var baseSha = create.Data?.BaseSha;
+
+            // ── Post-create validation (AC5) — confirm the ref actually exists. ──
+            var verify = await github.BranchExistsAsync(repository, finalName);
+            if (!verify.Success)
+            {
+                logger?.LogError("Post-create validation lookup failed for {Branch}: {Error}", finalName, verify.Error);
+                return BranchCreationOutcome.Failed(ClassifyError(verify.Error), verify.Error ?? "validation lookup failed");
+            }
+            if (!verify.Data)
+            {
+                logger?.LogError("Branch {Branch} not found after create — validation failed", finalName);
+                return BranchCreationOutcome.Failed("validation_failed", $"branch {finalName} not found after create");
+            }
+
+            logger?.LogInformation(
+                "Created branch {Branch} for issue #{Number} from {Base}@{Sha}",
+                finalName, issueNumber, baseBranch, baseSha ?? "?");
+            return BranchCreationOutcome.Created(finalName, baseSha, conflictResolved);
+        }
+        catch (Exception ex)
+        {
+            logger?.LogError(ex, "Error creating branch for issue #{Issue}", issueNumber);
+            return BranchCreationOutcome.Failed("unknown", ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Resolve a branch-name conflict per the strategy. Returns the name to create
+    /// (the original when free, a suffixed/timestamped name when occupied) or a
+    /// failure. A transient existence-lookup failure surfaces as an Error rather
+    /// than being treated as "absent → create" (no false success).
+    /// </summary>
+    private static async Task<ConflictResolution> ResolveConflictAsync(
+        IGitHubIntegrationService github,
+        string repository,
+        string candidate,
+        string strategy,
+        ILogger? logger)
+    {
+        var exists = await github.BranchExistsAsync(repository, candidate);
+        if (!exists.Success)
+            return ConflictResolution.Fail(ClassifyError(exists.Error), exists.Error ?? "existence lookup failed");
+        if (!exists.Data)
+            return ConflictResolution.Ok(candidate, conflictResolved: false);
+
+        switch (strategy.ToLowerInvariant())
+        {
+            case "abort":
+                logger?.LogWarning("Branch {Branch} already exists; abort strategy → failing", candidate);
+                return ConflictResolution.Fail("branch_exists", $"branch {candidate} already exists");
+
+            case "timestamp":
+            {
+                var stamped = $"{candidate}-{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
+                var stampedExists = await github.BranchExistsAsync(repository, stamped);
+                if (!stampedExists.Success)
+                    return ConflictResolution.Fail(ClassifyError(stampedExists.Error), stampedExists.Error ?? "existence lookup failed");
+                if (stampedExists.Data)
+                    return ConflictResolution.Fail("conflict_exhausted", $"timestamped branch {stamped} already exists");
+                logger?.LogWarning("Branch {Base} exists; timestamp strategy → {Final}", candidate, stamped);
+                return ConflictResolution.Ok(stamped, conflictResolved: true);
+            }
+
+            default: // "suffix"
+            {
+                for (var i = 2; i <= MaxConflictSuffix; i++)
+                {
+                    var suffixed = $"{candidate}-{i}";
+                    var suffixedExists = await github.BranchExistsAsync(repository, suffixed);
+                    if (!suffixedExists.Success)
+                        return ConflictResolution.Fail(ClassifyError(suffixedExists.Error), suffixedExists.Error ?? "existence lookup failed");
+                    if (!suffixedExists.Data)
+                    {
+                        logger?.LogWarning("Branch {Base} exists; suffix strategy → {Final}", candidate, suffixed);
+                        return ConflictResolution.Ok(suffixed, conflictResolved: true);
+                    }
+                }
+                logger?.LogError("Suffix strategy exhausted for {Branch} (>{Max})", candidate, MaxConflictSuffix);
+                return ConflictResolution.Fail("conflict_exhausted", $"no free suffix for {candidate} within {MaxConflictSuffix}");
+            }
+        }
+    }
+
+    // ================================================================
+    // Pure, testable helpers
+    // ================================================================
+
+    /// <summary>
+    /// Generate the branch name <c>adl/{issueNumber}-{sanitized-title}</c>. When the
+    /// title sanitizes to empty the slug is just <c>adl/{issueNumber}</c>.
+    /// </summary>
+    public static string GenerateBranchName(int issueNumber, string? issueTitle)
+    {
+        var sanitized = SanitizeBranchName(issueTitle ?? "");
+        return string.IsNullOrEmpty(sanitized)
+            ? $"adl/{issueNumber}"
+            : $"adl/{issueNumber}-{sanitized}";
+    }
+
     private static string SanitizeBranchName(string title)
     {
-        var sanitized = title.ToLowerInvariant()
+        var lowered = title.ToLowerInvariant()
             .Replace(' ', '-')
             .Replace('/', '-')
             .Replace('\\', '-');
 
-        // Keep only alphanumeric and hyphens, limit length
-        var chars = sanitized
+        var chars = lowered
             .Where(c => char.IsLetterOrDigit(c) || c == '-')
-            .Take(40)
+            .Take(MaxTitleLength)
             .ToArray();
 
         return new string(chars).Trim('-');
     }
+
+    /// <summary>
+    /// Validate a branch ref name against the load-bearing git ref rules (cap #11):
+    /// non-empty, no <c>..</c>, no leading <c>-</c>, no whitespace / control chars,
+    /// no <c>~^:?*[</c>, no trailing slash, no double slash. Defensive — the
+    /// generator already produces safe names, but a config-driven pattern or an
+    /// odd title must never reach the API as an injection.
+    /// </summary>
+    public static bool IsValidRefName(string? name)
+    {
+        if (string.IsNullOrEmpty(name)) return false;
+        if (name.StartsWith('-')) return false;
+        if (name.EndsWith('/')) return false;
+        if (name.Contains("..")) return false;
+        if (name.Contains("//")) return false;
+        if (name.EndsWith(".lock")) return false;
+        foreach (var c in name)
+        {
+            if (char.IsWhiteSpace(c) || char.IsControl(c)) return false;
+            if (c is '~' or '^' or ':' or '?' or '*' or '[' or '\\') return false;
+        }
+        return Regex.IsMatch(name, @"^[A-Za-z0-9._/-]+$");
+    }
+
+    /// <summary>
+    /// Classify a create / lookup failure for the failure edge: permission /
+    /// missing-base / protected-base / transient / unknown. The integration layer
+    /// surfaces a status-prefixed message (e.g. <c>"403: ..."</c>) or a typed
+    /// <c>base_branch_not_found: ...</c> sentinel.
+    /// </summary>
+    public static string ClassifyError(string? error)
+    {
+        if (string.IsNullOrWhiteSpace(error)) return "unknown";
+        var lower = error.ToLowerInvariant();
+        if (lower.Contains("base_branch_not_found") || lower.StartsWith("404")) return "base_branch_not_found";
+        if (lower.Contains("protected")) return "base_branch_protected";
+        if (lower.Contains("403") || lower.Contains("forbidden") || lower.Contains("permission")) return "permission_denied";
+        if (lower.Contains("422")) return "base_branch_protected";
+        if (lower.Contains("429") || lower.Contains("rate limit")
+            || lower.Contains("500") || lower.Contains("502") || lower.Contains("503") || lower.Contains("504")
+            || lower.Contains("timeout") || lower.Contains("unavailable")) return "transient";
+        return "unknown";
+    }
+
+    private sealed class ConflictResolution
+    {
+        public bool Success { get; private init; }
+        public string? FinalName { get; private init; }
+        public bool ConflictResolved { get; private init; }
+        public string? ErrorCode { get; private init; }
+        public string? Error { get; private init; }
+
+        public static ConflictResolution Ok(string finalName, bool conflictResolved)
+            => new() { Success = true, FinalName = finalName, ConflictResolved = conflictResolved };
+
+        public static ConflictResolution Fail(string errorCode, string error)
+            => new() { Success = false, ErrorCode = errorCode, Error = error };
+    }
+}
+
+/// <summary>
+/// Typed result of <see cref="CreateBranchActivity.ExecuteCoreAsync"/> — maps
+/// directly to the activity's Elsa outcome (Created / Error). On failure
+/// <see cref="BranchName"/> is empty so a consumer can never read a false branch.
+/// </summary>
+public sealed class BranchCreationOutcome
+{
+    public string Outcome { get; init; } = "Error";
+    public string? BranchName { get; init; }
+    public string? BaseSha { get; init; }
+    public bool ConflictResolved { get; init; }
+    public string? ErrorCode { get; init; }
+    public string? Error { get; init; }
+
+    public static BranchCreationOutcome Created(string branchName, string? baseSha, bool conflictResolved)
+        => new() { Outcome = "Created", BranchName = branchName, BaseSha = baseSha, ConflictResolved = conflictResolved };
+
+    public static BranchCreationOutcome Failed(string errorCode, string error)
+        => new() { Outcome = "Error", BranchName = "", ErrorCode = errorCode, Error = error };
 }

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitBranchEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitBranchEventActivity.cs
@@ -1,0 +1,130 @@
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+
+namespace Tamma.Activities.ADL;
+
+/// <summary>
+/// Emits a <c>BRANCH.*</c> DCB event (Story 2.4 AC8 / Story 4.5 AC3) for the
+/// built-out <c>branch-creation</c> workflow by appending a <see cref="TammaEvent"/>
+/// to the workflow's <c>tamma:events</c> transient list via
+/// <see cref="TammaEventEmitter.Emit"/>. The merged engine event drain
+/// (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) flushes that list
+/// <i>durably</i> to the tenant <c>domain_events</c> store after this activity
+/// runs — the drain resolves the tenant from the workflow scope (this workflow
+/// stamps a <c>TenantId</c> variable). The event therefore persists without this
+/// activity holding any DB / repository dependency of its own (none is registered
+/// in the Elsa engine — a directly-injected <c>IEventRepository</c> would be inert
+/// and silently drop the event, the same trap the PR / issue-status exemplars avoid).
+///
+/// <para>Critically, the FAILED event ACTUALLY fires on a real create failure (the
+/// activity surfaces an <c>Error</c> outcome that the workflow routes here),
+/// closing the headline bug where the thin wrapper emitted NO event at all and
+/// reported a swallowed <c>success=false</c> with a dangling Error edge.</para>
+/// </summary>
+[Activity(
+    "Tamma.ADL",
+    "Emit Branch Event",
+    "Emit a BRANCH.CREATED.SUCCESS / BRANCH.CREATED.FAILED DCB event for the audit trail",
+    Kind = ActivityKind.Task
+)]
+public class EmitBranchEventActivity : Activity
+{
+    private readonly ILogger<EmitBranchEventActivity>? _logger;
+
+    [Input(Description = "Event type — BRANCH.CREATED.SUCCESS or BRANCH.CREATED.FAILED")]
+    public Input<string> EventType { get; set; } = default!;
+
+    [Input(Description = "Issue number this branch isolates")]
+    public Input<int> IssueNumber { get; set; } = default!;
+
+    [Input(Description = "Repository in owner/repo format")]
+    public Input<string> Repository { get; set; } = default!;
+
+    [Input(Description = "Tenant id (empty / single-user → platform-scope event)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [Input(Description = "Event data payload as JSON (baseBranch, baseSha, finalName, conflictResolved, error, errorCode, durationMs)")]
+    public Input<string?> DataJson { get; set; } = new((string?)null);
+
+    [JsonConstructor]
+    public EmitBranchEventActivity() { }
+
+    public EmitBranchEventActivity(ILogger<EmitBranchEventActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var type = EventType.Get(context) ?? BranchEvents.CreatedFailed;
+        var issueNumber = IssueNumber.Get(context);
+        var repository = Repository.Get(context) ?? "";
+        var tenantId = BranchEvents.ParseTenantId(TenantId.Get(context));
+        var data = ParseData(DataJson.Get(context));
+
+        var evt = BuildTammaEvent(type, issueNumber, repository, tenantId, data);
+        TammaEventEmitter.Emit(context, this, _logger, evt);
+
+        _logger?.LogInformation(
+            "Emitted {Type} for issue #{Issue} in {Repo}", type, issueNumber, repository);
+
+        return default;
+    }
+
+    /// <summary>
+    /// Map the branch event inputs onto a <see cref="TammaEvent"/> expressed as the
+    /// engine's transient-list event so the merged drain persists it. Tags carry the
+    /// queryable DCB index keys (<c>issueId</c>/<c>issueNumber</c>/<c>repository</c>/
+    /// <c>tenantId</c>); <c>Data</c> carries the operation payload (key-free — no
+    /// token). Pure (no Elsa context); exposed for testing.
+    /// </summary>
+    public static TammaEvent BuildTammaEvent(
+        string type,
+        int issueNumber,
+        string repository,
+        Guid? tenantId,
+        IReadOnlyDictionary<string, object?>? data)
+    {
+        var tags = new Dictionary<string, object?>
+        {
+            ["issueId"] = issueNumber.ToString(),
+            ["issueNumber"] = issueNumber.ToString(),
+            ["repository"] = repository,
+        };
+        if (tenantId is not null) tags["tenantId"] = tenantId.Value.ToString("D");
+
+        return new TammaEvent
+        {
+            EventType = type,
+            Status = type == BranchEvents.CreatedFailed ? "error" : "success",
+            Tags = tags,
+            Data = data is null
+                ? new Dictionary<string, object?>()
+                : new Dictionary<string, object?>(data),
+        };
+    }
+
+    /// <summary>
+    /// Deserialize the JSON data payload into a dictionary for the event builder.
+    /// Returns null on empty/malformed input (the event still emits with "{}").
+    /// Exposed for unit testing the parse path.
+    /// </summary>
+    public static IReadOnlyDictionary<string, object?>? ParseData(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+        try
+        {
+            return System.Text.Json.JsonSerializer
+                .Deserialize<Dictionary<string, object?>>(json);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/GitHubIntegrationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/GitHubIntegrationService.cs
@@ -46,10 +46,16 @@ public class GitHubIntegrationService : IGitHubIntegrationService
             // Resolve the base SHA. With an explicit base, resolve THAT ref and do
             // NOT silently fall back to an unrelated branch (no false success).
             // Without one, use the default-branch behaviour (main → master).
+            // Use the EXACT-MATCH singular `git/ref/heads/{ref}` endpoint — it
+            // returns a single ref object on an exact hit and a real 404 on a
+            // miss. The plural `git/refs/heads/{ref}` is the prefix-matching
+            // list form: it 200s with a JSON ARRAY for any ref a sibling STARTS
+            // WITH (e.g. `develop` when `develop-2` exists), which both breaks
+            // the single-object parse below and masks a true miss.
             string sha;
             if (!string.IsNullOrWhiteSpace(baseBranch))
             {
-                var baseResponse = await httpClient.GetAsync($"/repos/{repository}/git/refs/heads/{Uri.EscapeDataString(baseBranch)}");
+                var baseResponse = await httpClient.GetAsync($"/repos/{repository}/git/ref/heads/{Uri.EscapeDataString(baseBranch)}");
                 if (baseResponse.StatusCode == HttpStatusCode.NotFound)
                 {
                     _logger.LogError("Base branch {Base} not found in {Repo}", baseBranch, repository);
@@ -64,9 +70,9 @@ public class GitHubIntegrationService : IGitHubIntegrationService
             }
             else
             {
-                var refsResponse = await httpClient.GetAsync($"/repos/{repository}/git/refs/heads/main");
+                var refsResponse = await httpClient.GetAsync($"/repos/{repository}/git/ref/heads/main");
                 if (!refsResponse.IsSuccessStatusCode)
-                    refsResponse = await httpClient.GetAsync($"/repos/{repository}/git/refs/heads/master");
+                    refsResponse = await httpClient.GetAsync($"/repos/{repository}/git/ref/heads/master");
                 if (refsResponse.StatusCode == HttpStatusCode.NotFound)
                     return IntegrationResult<GitHubBranchResult>.Fail("base_branch_not_found: main/master");
                 refsResponse.EnsureSuccessStatusCode();
@@ -116,7 +122,12 @@ public class GitHubIntegrationService : IGitHubIntegrationService
 
         try
         {
-            var response = await httpClient.GetAsync($"/repos/{repository}/git/refs/heads/{Uri.EscapeDataString(branchName)}");
+            // Exact-match singular `git/ref/heads/{branch}` — single object on an
+            // exact hit, 404 on a true miss. The plural prefix-matching form would
+            // 200 on a sibling ref (e.g. `adl/42-auth` when only `adl/42-auth-2`
+            // exists) → a false conflict / bogus suffix. This 200/404 contract is
+            // exactly what the branches below are coded against.
+            var response = await httpClient.GetAsync($"/repos/{repository}/git/ref/heads/{Uri.EscapeDataString(branchName)}");
             if (response.StatusCode == HttpStatusCode.NotFound)
                 return IntegrationResult<bool>.Ok(false);
             if (response.IsSuccessStatusCode)

--- a/apps/tamma-elsa/src/Tamma.Api/Services/GitHubIntegrationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/GitHubIntegrationService.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Tamma.Core.Interfaces;
@@ -23,7 +24,10 @@ public class GitHubIntegrationService : IGitHubIntegrationService
         _logger = logger;
     }
 
-    public async Task<IntegrationResult<GitHubBranchResult>> CreateGitHubBranchAsync(string repository, string branchName)
+    public Task<IntegrationResult<GitHubBranchResult>> CreateGitHubBranchAsync(string repository, string branchName)
+        => CreateGitHubBranchAsync(repository, branchName, baseBranch: null);
+
+    public async Task<IntegrationResult<GitHubBranchResult>> CreateGitHubBranchAsync(string repository, string branchName, string? baseBranch)
     {
         var httpClient = _httpClientFactory.CreateClient("github");
         var token = _configuration["GitHub:Token"];
@@ -35,18 +39,41 @@ public class GitHubIntegrationService : IGitHubIntegrationService
 
         try
         {
-            _logger.LogInformation("Creating branch {Branch} in {Repo}", branchName, repository);
+            _logger.LogInformation(
+                "Creating branch {Branch} in {Repo} from base {Base}",
+                branchName, repository, string.IsNullOrWhiteSpace(baseBranch) ? "<default>" : baseBranch);
 
-            // Get default branch SHA
-            var refsResponse = await httpClient.GetAsync($"/repos/{repository}/git/refs/heads/main");
-            if (!refsResponse.IsSuccessStatusCode)
+            // Resolve the base SHA. With an explicit base, resolve THAT ref and do
+            // NOT silently fall back to an unrelated branch (no false success).
+            // Without one, use the default-branch behaviour (main → master).
+            string sha;
+            if (!string.IsNullOrWhiteSpace(baseBranch))
             {
-                refsResponse = await httpClient.GetAsync($"/repos/{repository}/git/refs/heads/master");
-            }
-            refsResponse.EnsureSuccessStatusCode();
+                var baseResponse = await httpClient.GetAsync($"/repos/{repository}/git/refs/heads/{Uri.EscapeDataString(baseBranch)}");
+                if (baseResponse.StatusCode == HttpStatusCode.NotFound)
+                {
+                    _logger.LogError("Base branch {Base} not found in {Repo}", baseBranch, repository);
+                    return IntegrationResult<GitHubBranchResult>.Fail($"base_branch_not_found: {baseBranch}");
+                }
+                if (!baseResponse.IsSuccessStatusCode)
+                    return IntegrationResult<GitHubBranchResult>.Fail(
+                        $"{(int)baseResponse.StatusCode}: failed to resolve base {baseBranch}");
 
-            var refData = await refsResponse.Content.ReadFromJsonAsync<JsonElement>();
-            var sha = refData.GetProperty("object").GetProperty("sha").GetString()!;
+                var baseData = await baseResponse.Content.ReadFromJsonAsync<JsonElement>();
+                sha = baseData.GetProperty("object").GetProperty("sha").GetString()!;
+            }
+            else
+            {
+                var refsResponse = await httpClient.GetAsync($"/repos/{repository}/git/refs/heads/main");
+                if (!refsResponse.IsSuccessStatusCode)
+                    refsResponse = await httpClient.GetAsync($"/repos/{repository}/git/refs/heads/master");
+                if (refsResponse.StatusCode == HttpStatusCode.NotFound)
+                    return IntegrationResult<GitHubBranchResult>.Fail("base_branch_not_found: main/master");
+                refsResponse.EnsureSuccessStatusCode();
+
+                var refData = await refsResponse.Content.ReadFromJsonAsync<JsonElement>();
+                sha = refData.GetProperty("object").GetProperty("sha").GetString()!;
+            }
 
             // Create the branch
             var createPayload = new
@@ -55,13 +82,24 @@ public class GitHubIntegrationService : IGitHubIntegrationService
                 sha
             };
             var createResponse = await httpClient.PostAsJsonAsync($"/repos/{repository}/git/refs", createPayload);
-            createResponse.EnsureSuccessStatusCode();
+            if (!createResponse.IsSuccessStatusCode)
+            {
+                // Surface the status code + body so the activity can classify the
+                // failure (permission / already-exists / protected-base) rather
+                // than collapsing every error into a bare throw.
+                var body = await createResponse.Content.ReadAsStringAsync();
+                _logger.LogError(
+                    "Failed to create branch {Branch} in {Repo}: {Status} {Body}",
+                    branchName, repository, (int)createResponse.StatusCode, body);
+                return IntegrationResult<GitHubBranchResult>.Fail($"{(int)createResponse.StatusCode}: {body}");
+            }
 
             var result = new GitHubBranchResult
             {
                 Success = true,
                 BranchName = branchName,
-                BranchUrl = $"https://github.com/{repository}/tree/{branchName}"
+                BranchUrl = $"https://github.com/{repository}/tree/{branchName}",
+                BaseSha = sha
             };
             return IntegrationResult<GitHubBranchResult>.Ok(result);
         }
@@ -69,6 +107,30 @@ public class GitHubIntegrationService : IGitHubIntegrationService
         {
             _logger.LogError(ex, "Failed to create GitHub branch {Branch}", branchName);
             return IntegrationResult<GitHubBranchResult>.Fail(ex.Message);
+        }
+    }
+
+    public async Task<IntegrationResult<bool>> BranchExistsAsync(string repository, string branchName)
+    {
+        var httpClient = _httpClientFactory.CreateClient("github");
+
+        try
+        {
+            var response = await httpClient.GetAsync($"/repos/{repository}/git/refs/heads/{Uri.EscapeDataString(branchName)}");
+            if (response.StatusCode == HttpStatusCode.NotFound)
+                return IntegrationResult<bool>.Ok(false);
+            if (response.IsSuccessStatusCode)
+                return IntegrationResult<bool>.Ok(true);
+
+            // Any other status (403/5xx/...) is an error — NOT "absent", so we
+            // never mistake a transient failure for a free-to-create branch.
+            var body = await response.Content.ReadAsStringAsync();
+            return IntegrationResult<bool>.Fail($"{(int)response.StatusCode}: {body}");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to check branch existence {Branch} in {Repo}", branchName, repository);
+            return IntegrationResult<bool>.Fail(ex.Message);
         }
     }
 

--- a/apps/tamma-elsa/src/Tamma.Api/Services/IntegrationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/IntegrationService.cs
@@ -70,6 +70,22 @@ public class IntegrationService : IIntegrationService
             : new GitHubBranchResult { Success = false, Error = result.Error };
     }
 
+    public async Task<GitHubBranchResult> CreateGitHubBranchAsync(string repository, string branchName, string? baseBranch)
+    {
+        var result = await _github.CreateGitHubBranchAsync(repository, branchName, baseBranch);
+        return result.Success
+            ? result.Data!
+            : new GitHubBranchResult { Success = false, Error = result.Error };
+    }
+
+    public async Task<bool> BranchExistsAsync(string repository, string branchName)
+    {
+        var result = await _github.BranchExistsAsync(repository, branchName);
+        if (!result.Success)
+            throw new InvalidOperationException(result.Error);
+        return result.Data;
+    }
+
     public async Task<List<GitHubCommit>> GetGitHubCommitsAsync(string repository, string branch, DateTime? since = null)
     {
         var result = await _github.GetGitHubCommitsAsync(repository, branch, since);

--- a/apps/tamma-elsa/src/Tamma.Core/Interfaces/IIntegrationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Interfaces/IIntegrationService.cs
@@ -35,8 +35,27 @@ public interface ISlackIntegrationService
 /// </summary>
 public interface IGitHubIntegrationService
 {
-    /// <summary>Create a GitHub branch</summary>
+    /// <summary>Create a GitHub branch from the repo default branch (main → master).</summary>
     Task<IntegrationResult<GitHubBranchResult>> CreateGitHubBranchAsync(string repository, string branchName);
+
+    /// <summary>
+    /// Create a GitHub branch cut from an explicit <paramref name="baseBranch"/>
+    /// (Story 2.4 AC2). The base SHA is resolved from the given base ref; if the
+    /// base is explicitly supplied and missing this FAILS (<c>base_branch_not_found</c>)
+    /// rather than silently cutting from an unrelated branch (no false success).
+    /// The resolved base SHA is surfaced on <see cref="GitHubBranchResult.BaseSha"/>
+    /// for the audit event. When <paramref name="baseBranch"/> is null/empty the
+    /// default-branch behaviour (main → master) is used.
+    /// </summary>
+    Task<IntegrationResult<GitHubBranchResult>> CreateGitHubBranchAsync(string repository, string branchName, string? baseBranch);
+
+    /// <summary>
+    /// Returns whether a branch (ref <c>heads/{branchName}</c>) already exists
+    /// (Story 2.4 — idempotency / conflict handling + post-create validation):
+    /// <c>Ok(true)</c> exists, <c>Ok(false)</c> absent, <c>Fail</c> on API error
+    /// (so a transient lookup failure is NOT mistaken for "absent").
+    /// </summary>
+    Task<IntegrationResult<bool>> BranchExistsAsync(string repository, string branchName);
 
     /// <summary>Get recent commits from a branch</summary>
     Task<IntegrationResult<List<GitHubCommit>>> GetGitHubCommitsAsync(string repository, string branch, DateTime? since = null);
@@ -138,6 +157,12 @@ public interface IIntegrationService
     /// <summary>Create a GitHub branch</summary>
     Task<GitHubBranchResult> CreateGitHubBranchAsync(string repository, string branchName);
 
+    /// <summary>Create a GitHub branch cut from an explicit base branch</summary>
+    Task<GitHubBranchResult> CreateGitHubBranchAsync(string repository, string branchName, string? baseBranch);
+
+    /// <summary>Returns whether a branch already exists</summary>
+    Task<bool> BranchExistsAsync(string repository, string branchName);
+
     /// <summary>Get recent commits from a branch</summary>
     Task<List<GitHubCommit>> GetGitHubCommitsAsync(string repository, string branch, DateTime? since = null);
 
@@ -193,6 +218,14 @@ public class GitHubBranchResult
     public bool Success { get; set; }
     public string? BranchName { get; set; }
     public string? BranchUrl { get; set; }
+
+    /// <summary>
+    /// The SHA of the base ref the branch was cut from (Story 2.4 AC4 — surfaced
+    /// in the <c>BRANCH.CREATED.SUCCESS</c> event/log). Null when not resolved
+    /// (e.g. a failed create) or on the legacy default-branch path.
+    /// </summary>
+    public string? BaseSha { get; set; }
+
     public string? Error { get; set; }
 }
 

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/BranchCreationWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/BranchCreationWorkflow.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Elsa.Extensions;
 using Elsa.Workflows;
 using Elsa.Workflows.Activities;
@@ -8,16 +9,32 @@ using Elsa.Workflows.Models;
 using Tamma.Activities.ADL;
 using FlowEndpoint = Elsa.Workflows.Activities.Flowchart.Models.Endpoint;
 using FlowConnection = Elsa.Workflows.Activities.Flowchart.Models.Connection;
+using static Tamma.ElsaServer.Workflows.ActivityDisplayTextExtensions;
 
 namespace Tamma.ElsaServer.Workflows;
 
 /// <summary>
-/// Branch Creation sub-workflow: creates a feature branch for the issue.
+/// Branch Creation — create (or idempotently reuse) the feature branch that
+/// isolates an issue's autonomous-development work, cut from a configurable base
+/// branch, with conflict resolution and post-create validation.
 ///
-/// Flow: CreateBranch → SetSuccess → OutputSuccess → OutputBranchName
+/// <para>Story 2.4 build-out: the workflow is a real flowchart with an EXPLICIT
+/// failure edge. The thin wrapper's dangling <c>Error</c> outcome (which left the
+/// activity's failure with nowhere to go and reported a swallowed
+/// <c>success=false</c>) is replaced: on a genuine create failure the activity
+/// surfaces an <c>Error</c> outcome that emits <c>BRANCH.CREATED.FAILED</c>
+/// (durable DCB drain) and sets <c>success=false</c>; success emits
+/// <c>BRANCH.CREATED.SUCCESS</c> with the base SHA. No <c>Error</c> edge ever
+/// falls through to the success outputs — no false success.</para>
 ///
-/// Inputs: repository, issueNumber, issueTitle
-/// Outputs: success, branchName
+/// Flow:
+///   ReadInputs → CreateBranch
+///     ├─ Created → EmitSuccess → Success Outputs → Finish
+///     └─ Error   → Failure Outputs (success=false) → EmitFailed → Finish
+///
+/// Inputs:  repository, issueNumber, issueTitle? (else derived from workItemJson),
+///          baseBranch?, conflictStrategy?, tenantId?, workItemJson?.
+/// Outputs: success, branchName, baseSha (success path) / errorCode, error (failure path).
 /// </summary>
 public class BranchCreationWorkflow : WorkflowBase
 {
@@ -26,64 +43,243 @@ public class BranchCreationWorkflow : WorkflowBase
         builder.Name = "Branch Creation";
         builder.DefinitionId = "branch-creation";
         builder.Version = WorkflowVersions.ComputedVersion;
-        builder.Description = "Create a feature branch for autonomous development";
+        builder.Description = "Create a feature branch (configurable base, idempotent conflict resolution) with an explicit failure path and durable DCB events";
+
+        // ================================================================
+        // Variables
+        // ================================================================
+        var repositoryVar = builder.WithVariable<string>("Repository", "");
+        var issueNumberVar = builder.WithVariable<int>("IssueNumber", 0);
+        var issueTitleVar = builder.WithVariable<string>("IssueTitle", "");
+        var baseBranchVar = builder.WithVariable<string>("BaseBranch", "main");
+        var conflictStrategyVar = builder.WithVariable<string>("ConflictStrategy", "suffix");
+        var tenantIdVar = builder.WithVariable<string>("TenantId", "");
 
         var branchNameVar = builder.WithVariable<string>("BranchName", "");
-        var successVar = builder.WithVariable<bool>("Success", false);
+        var baseShaVar = builder.WithVariable<string>("BaseSha", "");
+        var conflictResolvedVar = builder.WithVariable<bool>("ConflictResolved", false);
+        var errorCodeVar = builder.WithVariable<string>("ErrorCode", "");
+        var errorVar = builder.WithVariable<string>("Error", "");
+        var startedAtTicksVar = builder.WithVariable<long>("StartedAtTicks", 0);
 
+        // ================================================================
+        // 1. Read inputs (derive issueTitle from workItemJson when not supplied —
+        //    the real cycle path passes workItemJson, not issueTitle: gap #9).
+        // ================================================================
+        var readInputs = new SetVariable
+        {
+            Id = "ReadInputs", Name = "Read Inputs",
+            Variable = repositoryVar,
+            Value = new Input<object?>(ctx =>
+            {
+                var repo = ctx.GetInput<string>("repository") ?? "";
+                issueNumberVar.Set(ctx, ctx.GetInput<int>("issueNumber"));
+
+                var title = ctx.GetInput<string>("issueTitle");
+                if (string.IsNullOrWhiteSpace(title))
+                    title = ExtractWorkItemTitle(ctx.GetInput<string>("workItemJson"));
+                issueTitleVar.Set(ctx, title ?? "");
+
+                var baseBranch = ctx.GetInput<string>("baseBranch");
+                baseBranchVar.Set(ctx, string.IsNullOrWhiteSpace(baseBranch) ? "main" : baseBranch!);
+
+                var strategy = ctx.GetInput<string>("conflictStrategy");
+                conflictStrategyVar.Set(ctx, string.IsNullOrWhiteSpace(strategy) ? "suffix" : strategy!);
+
+                tenantIdVar.Set(ctx, ctx.GetInput<string>("tenantId") ?? "");
+                startedAtTicksVar.Set(ctx, DateTime.UtcNow.Ticks);
+                return (object)repo;
+            })
+        };
+        readInputs.SetDisplayText("Read Inputs");
+
+        // ================================================================
+        // 2. Create the branch (outcome-bearing — Created / Error)
+        // ================================================================
         var createBranch = new CreateBranchActivity
         {
-            Id = "CreateBranch",
-            Name = "Create Branch",
-            Repository = new Input<string>(ctx => ctx.GetInput<string>("repository") ?? ""),
-            IssueNumber = new Input<int>(ctx => ctx.GetInput<int>("issueNumber")),
-            IssueTitle = new Input<string>(ctx => ctx.GetInput<string>("issueTitle") ?? ""),
-            BranchName = new Output<string?>(branchNameVar)
+            Id = "CreateBranch", Name = "Create Branch",
+            Repository = new Input<string>(ctx => repositoryVar.Get(ctx)),
+            IssueNumber = new Input<int>(ctx => issueNumberVar.Get(ctx)),
+            IssueTitle = new Input<string>(ctx => issueTitleVar.Get(ctx)),
+            BaseBranch = new Input<string>(ctx => baseBranchVar.Get(ctx)),
+            ConflictStrategy = new Input<string>(ctx => conflictStrategyVar.Get(ctx)),
+            BranchName = new Output<string?>(branchNameVar),
+            BaseSha = new Output<string?>(baseShaVar),
+            ConflictResolved = new Output<bool>(conflictResolvedVar),
+            ErrorCode = new Output<string?>(errorCodeVar),
+            Error = new Output<string?>(errorVar),
         };
         createBranch.SetDisplayText("Create Branch");
 
-        var setSuccess = new SetVariable
+        // ================================================================
+        // 3. Success path — emit BRANCH.CREATED.SUCCESS + outputs
+        // ================================================================
+        var emitSuccess = new EmitBranchEventActivity
         {
-            Id = "SetBranchSuccess",
-            Name = "Set Success",
-            Variable = successVar,
-            Value = new Input<object?>(ctx => (object)!string.IsNullOrEmpty(branchNameVar.Get(ctx)))
+            Id = "EmitSuccess", Name = "Emit BRANCH.CREATED.SUCCESS",
+            EventType = new Input<string>(_ => BranchEvents.CreatedSuccess),
+            IssueNumber = new Input<int>(ctx => issueNumberVar.Get(ctx)),
+            Repository = new Input<string>(ctx => repositoryVar.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantIdVar.Get(ctx)),
+            DataJson = new Input<string?>(ctx => BuildSuccessData(
+                branchNameVar.Get(ctx), baseBranchVar.Get(ctx), baseShaVar.Get(ctx),
+                conflictResolvedVar.Get(ctx), ElapsedMs(startedAtTicksVar.Get(ctx)))),
         };
-        setSuccess.SetDisplayText("Set Success");
+        emitSuccess.SetDisplayText("Emit BRANCH.CREATED.SUCCESS");
 
-        var outputSuccess = new SetOutput
+        var successOutputs = new Sequence
         {
-            Id = "OutputSuccess",
-            Name = "Output Success",
-            OutputName = new("success"),
-            OutputValue = new(ctx => (object)successVar.Get(ctx))
+            Id = "SuccessOutputs", Name = "Success Outputs",
+            Activities =
+            {
+                WithLabel(new SetOutput { Id = "OutSuccess", OutputName = new("success"), OutputValue = new(_ => (object)true) }, "Output success"),
+                WithLabel(new SetOutput { Id = "OutBranchName", OutputName = new("branchName"), OutputValue = new(ctx => (object)(branchNameVar.Get(ctx) ?? "")) }, "Output branchName"),
+                WithLabel(new SetOutput { Id = "OutBaseSha", OutputName = new("baseSha"), OutputValue = new(ctx => (object)(baseShaVar.Get(ctx) ?? "")) }, "Output baseSha"),
+                WithLabel(new SetOutput { Id = "OutBaseBranch", OutputName = new("baseBranch"), OutputValue = new(ctx => (object)baseBranchVar.Get(ctx)) }, "Output baseBranch"),
+                WithLabel(new SetOutput { Id = "OutConflictResolved", OutputName = new("conflictResolved"), OutputValue = new(ctx => (object)conflictResolvedVar.Get(ctx)) }, "Output conflictResolved"),
+            }
         };
-        outputSuccess.SetDisplayText("Output Success");
+        successOutputs.SetDisplayText("Success Outputs");
 
-        var outputBranchName = new SetOutput
+        // ================================================================
+        // 4. Failure path — success=false, emit BRANCH.CREATED.FAILED
+        //    (NO fall-through to success; branchName forced empty — no false branch)
+        // ================================================================
+        var failureOutputs = new Sequence
         {
-            Id = "OutputBranchName",
-            Name = "Output Branch Name",
-            OutputName = new("branchName"),
-            OutputValue = new(ctx => (object)(branchNameVar.Get(ctx) ?? ""))
+            Id = "FailureOutputs", Name = "Failure Outputs",
+            Activities =
+            {
+                WithLabel(new SetOutput { Id = "OutFailSuccess", OutputName = new("success"), OutputValue = new(_ => (object)false) }, "Output success=false"),
+                WithLabel(new SetOutput { Id = "OutFailBranchName", OutputName = new("branchName"), OutputValue = new(_ => (object)"") }, "Output branchName="),
+                WithLabel(new SetOutput { Id = "OutFailErrorCode", OutputName = new("errorCode"), OutputValue = new(ctx => (object)(NullIfBlank(errorCodeVar.Get(ctx)) ?? "branch-creation-failed")) }, "Output errorCode"),
+                // Surface the activity's rich human Error reason (not a duplicate of
+                // errorCode) so callers/observability see WHY it failed; fall back to
+                // the stable constant only when no reason was captured.
+                WithLabel(new SetOutput { Id = "OutFailReason", OutputName = new("exitReason"), OutputValue = new(ctx => (object)(NullIfBlank(errorVar.Get(ctx)) ?? "branch-creation-failed")) }, "Output exitReason"),
+            }
         };
-        outputBranchName.SetDisplayText("Output Branch Name");
+        failureOutputs.SetDisplayText("Failure Outputs");
 
+        var emitFailed = new EmitBranchEventActivity
+        {
+            Id = "EmitFailed", Name = "Emit BRANCH.CREATED.FAILED",
+            EventType = new Input<string>(_ => BranchEvents.CreatedFailed),
+            IssueNumber = new Input<int>(ctx => issueNumberVar.Get(ctx)),
+            Repository = new Input<string>(ctx => repositoryVar.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantIdVar.Get(ctx)),
+            DataJson = new Input<string?>(ctx => BuildFailureData(
+                errorCodeVar.Get(ctx), errorVar.Get(ctx), baseBranchVar.Get(ctx),
+                ElapsedMs(startedAtTicksVar.Get(ctx)))),
+        };
+        emitFailed.SetDisplayText("Emit BRANCH.CREATED.FAILED");
+
+        var finish = new Finish { Id = "Finish", Name = "Complete" };
+        finish.SetDisplayText("Complete");
+
+        // ================================================================
+        // Flowchart
+        // ================================================================
         builder.Root = new Flowchart
         {
             Id = "BranchCreationFlowchart",
             Name = "Branch Creation Flowchart",
-            Start = createBranch,
-            Activities = { createBranch, setSuccess, outputSuccess, outputBranchName },
+            Start = readInputs,
+            Activities =
+            {
+                readInputs, createBranch,
+                emitSuccess, successOutputs,
+                failureOutputs, emitFailed, finish,
+            },
             Connections =
             {
-                Connect(createBranch, setSuccess),
-                Connect(setSuccess, outputSuccess),
-                Connect(outputSuccess, outputBranchName)
+                Connect(readInputs, createBranch),
+
+                // Created → success path
+                ConnectOutcome(createBranch, "Created", emitSuccess),
+                Connect(emitSuccess, successOutputs),
+                Connect(successOutputs, finish),
+
+                // Error → explicit failure path (NO fall-through to success)
+                ConnectOutcome(createBranch, "Error", failureOutputs),
+                Connect(failureOutputs, emitFailed),
+                Connect(emitFailed, finish),
             }
         };
     }
 
+    /// <summary>
+    /// Derive the issue title from the work-item JSON the cycle dispatches (it sends
+    /// <c>workItemJson</c>, not <c>issueTitle</c> — gap #9). Mirrors
+    /// <c>SingleIssueCycleWorkflow.ExtractWorkItemTitle</c>.
+    /// </summary>
+    private static string ExtractWorkItemTitle(string? workItemJson)
+    {
+        if (string.IsNullOrWhiteSpace(workItemJson)) return "";
+        try
+        {
+            using var doc = JsonDocument.Parse(workItemJson);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object) return "";
+            foreach (var name in new[] { "title", "Title", "name", "Name" })
+            {
+                if (doc.RootElement.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String)
+                    return v.GetString() ?? "";
+            }
+            return "";
+        }
+        catch
+        {
+            return "";
+        }
+    }
+
+    private static string? NullIfBlank(string? s)
+        => string.IsNullOrWhiteSpace(s) ? null : s;
+
+    private static long ElapsedMs(long startedAtTicks)
+    {
+        if (startedAtTicks <= 0) return 0;
+        var elapsed = DateTime.UtcNow.Ticks - startedAtTicks;
+        return elapsed > 0 ? elapsed / TimeSpan.TicksPerMillisecond : 0;
+    }
+
+    private static string BuildSuccessData(
+        string? branchName, string baseBranch, string? baseSha, bool conflictResolved, long durationMs)
+    {
+        var data = new Dictionary<string, object?>
+        {
+            ["finalName"] = branchName ?? "",
+            ["baseBranch"] = baseBranch,
+            ["baseSha"] = baseSha ?? "",
+            ["conflictResolved"] = conflictResolved,
+            ["durationMs"] = durationMs,
+        };
+        return JsonSerializer.Serialize(data);
+    }
+
+    private static string BuildFailureData(
+        string? errorCode, string? error, string baseBranch, long durationMs)
+    {
+        var data = new Dictionary<string, object?>
+        {
+            ["errorCode"] = NullIfBlank(errorCode) ?? "branch-creation-failed",
+            ["error"] = Truncate(error, 280),
+            ["baseBranch"] = baseBranch,
+            ["durationMs"] = durationMs,
+        };
+        return JsonSerializer.Serialize(data);
+    }
+
+    private static string Truncate(string? s, int max)
+    {
+        if (string.IsNullOrEmpty(s)) return "";
+        return s.Length <= max ? s : s[..max];
+    }
+
     private static FlowConnection Connect(IActivity source, IActivity target)
         => new(new FlowEndpoint(source), new FlowEndpoint(target));
+
+    private static FlowConnection ConnectOutcome(IActivity source, string outcome, IActivity target)
+        => new(new FlowEndpoint(source, outcome), new FlowEndpoint(target));
 }

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs
@@ -63,6 +63,13 @@ public class SingleIssueCycleWorkflow : WorkflowBase
         var tasksJson = builder.WithVariable<string>("TasksJson", "");
         var taskReviewDecision = builder.WithVariable<string>("TaskReviewDecision", "");
         var branchName = builder.WithVariable<string>("BranchName", "");
+        // Branch-creation gating (IMPORTANT-5): the cycle must NOT proceed to
+        // createPR on a failed branch (empty head → doomed PR + false "branch
+        // created" notify). The branch sub-workflow reports success / errorCode /
+        // exitReason; we capture them to route a loud terminal on failure.
+        var branchSuccess = builder.WithVariable<bool>("BranchSuccess", false);
+        var branchErrorCode = builder.WithVariable<string>("BranchErrorCode", "");
+        var branchErrorReason = builder.WithVariable<string>("BranchErrorReason", "");
         var prNumber = builder.WithVariable<int>("PRNumber", 0);
         var prUrl = builder.WithVariable<string>("PRUrl", "");
         var exitReason = builder.WithVariable<string>("ExitReason", "");
@@ -374,10 +381,42 @@ public class SingleIssueCycleWorkflow : WorkflowBase
         var extractBranch = Assign(branchName, ctx =>
         {
             var result = subResult.Get(ctx);
+
+            // Capture the branch step's success + failure classification so the
+            // gate below can route a loud terminal (never a doomed PR). An
+            // unreadable/absent result is treated as failure (no false success).
+            var success = result != null
+                && result.TryGetValue("success", out var s)
+                && s is true;
+            branchSuccess.Set(ctx, success);
+            branchErrorCode.Set(ctx, result?.GetValueOrDefault("errorCode")?.ToString() ?? "branch-creation-failed");
+            branchErrorReason.Set(ctx, result?.GetValueOrDefault("exitReason")?.ToString() ?? "branch creation failed");
+
             if (result != null && result.TryGetValue("branchName", out var b))
                 return (object)(b?.ToString() ?? "");
             return (object)"";
         }, "ExtractBranch", "Extract Branch");
+
+        // Gate the cycle on the branch step's success (IMPORTANT-5). Only a
+        // created branch proceeds to createPR + the branch-created notify; a
+        // failure routes to a loud terminal (no empty-head PR, no false notify).
+        // Defaults to "Failed" so an unreadable result can never slip into PR
+        // creation.
+        var branchOutcomeSwitch = new FlowSwitch
+        {
+            Id = "BranchOutcomeSwitch",
+            Name = "Branch Outcome",
+            Cases =
+            {
+                new FlowSwitchCase("Created", ctx => branchSuccess.Get(ctx)),
+                new FlowSwitchCase("Failed", ctx => true), // failure + any unreadable result
+            },
+        };
+        branchOutcomeSwitch.SetDisplayText("Branch Outcome");
+
+        var notifyBranchFailed = NotifyIssue("NotifyBranchFailed", repository, issueNumber,
+            "❌ Branch creation failed. Needs human attention.",
+            new[] { "tamma-error", "needs-human" }, new[] { "tamma-processing" });
 
         // ================================================================
         // 8. Create PR (draft, with implementation plan .md files)
@@ -776,7 +815,7 @@ public class SingleIssueCycleWorkflow : WorkflowBase
                 createDeferredIssues, createSplitIssues,
                 createTasks, extractTasks,
                 reviewTasks, extractTaskReview, taskReviewOutcome,
-                createBranch, extractBranch,
+                createBranch, extractBranch, branchOutcomeSwitch, notifyBranchFailed,
                 createPR, extractPR,
                 createTestCases,
                 initTaskLoop, hasMoreTasks, extractCurrentTask, tddForTask, incrementTask,
@@ -876,10 +915,20 @@ public class SingleIssueCycleWorkflow : WorkflowBase
                 ConnectOutcome(taskReviewOutcome, "NeedsHuman", notifyNeedsHuman),
                 ConnectOutcome(taskReviewOutcome, "NeedsHuman", reportNeedsHuman),
 
-                // 7. Create Branch → notify + Create Draft PR (parallel)
+                // 7. Create Branch → capture result → gate on success (IMPORTANT-5).
+                //    The branch step must succeed before the cycle proceeds to PR
+                //    creation; a failure routes to a loud terminal (no empty-head
+                //    PR, no false "branch created" notify). Both outcomes reach Finish.
                 Connect(createBranch, extractBranch),
-                Connect(extractBranch, notifyBranchCreated),
-                Connect(extractBranch, createPR),
+                Connect(extractBranch, branchOutcomeSwitch),
+
+                // Created → notify + Create Draft PR (parallel)
+                ConnectOutcome(branchOutcomeSwitch, "Created", notifyBranchCreated),
+                ConnectOutcome(branchOutcomeSwitch, "Created", createPR),
+
+                // Failed → loud human-handoff/error terminal (never PR creation)
+                ConnectOutcome(branchOutcomeSwitch, "Failed", notifyBranchFailed),
+                ConnectOutcome(branchOutcomeSwitch, "Failed", reportError),
 
                 // 8. Create Draft PR → 9. Create Test Cases
                 Connect(createPR, extractPR),

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs
@@ -362,6 +362,9 @@ public class SingleIssueCycleWorkflow : WorkflowBase
                 ["issueNumber"] = issueNumber.Get(ctx),
                 ["baseBranch"] = baseBranch.Get(ctx),
                 ["workItemJson"] = workItemJson.Get(ctx),
+                // Thread the tenant so BRANCH.CREATED.* events are tenant-scoped
+                // in the durable DCB drain (single-user → empty → platform-scope).
+                ["tenantId"] = tenantId.Get(ctx),
             }),
             WaitForCompletion = new(true),
             Result = new(subResult),

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/BranchCreationActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/BranchCreationActivityTests.cs
@@ -1,0 +1,361 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+using Tamma.Core.Interfaces;
+
+namespace Tamma.Activities.Tests.ADL;
+
+/// <summary>
+/// Story 2.4 build-out — unit coverage for the branch-creation activity's pure
+/// helpers (name generation / sanitize / ref-validation / error classification),
+/// the <c>ExecuteCoreAsync</c> orchestration (base validation → idempotent
+/// conflict resolution → create → post-create validation, NEVER a false success),
+/// and <c>EmitBranchEventActivity</c>'s DCB mapping (<c>BuildTammaEvent</c> — the
+/// <c>TammaEvent</c> pushed into the workflow's <c>tamma:events</c> list, which
+/// the engine event drain persists durably to <c>domain_events</c>). Mirrors the
+/// merged PR exemplar (<see cref="PullRequestActivityTests"/>): test the testable
+/// static logic + a mocked <see cref="IGitHubIntegrationService"/> rather than a
+/// full Elsa runtime.
+/// </summary>
+[TestFixture]
+public class BranchCreationActivityTests
+{
+    // ================================================================
+    // Constructors
+    // ================================================================
+
+    [Test]
+    public void CreateBranchActivity_JsonConstructor_ShouldNotThrow()
+    {
+        Action act = () => new CreateBranchActivity();
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void CreateBranchActivity_WithDependencies_ShouldNotThrow()
+    {
+        var logger = new Mock<ILogger<CreateBranchActivity>>();
+        var github = new Mock<IGitHubIntegrationService>();
+        Action act = () => new CreateBranchActivity(logger.Object, github.Object);
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void EmitBranchEventActivity_JsonConstructor_ShouldNotThrow()
+    {
+        Action act = () => new EmitBranchEventActivity();
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void EmitBranchEventActivity_WithLogger_ShouldNotThrow()
+    {
+        var logger = new Mock<ILogger<EmitBranchEventActivity>>();
+        Action act = () => new EmitBranchEventActivity(logger.Object);
+        act.Should().NotThrow();
+    }
+
+    // ================================================================
+    // GenerateBranchName / sanitize
+    // ================================================================
+
+    [Test]
+    public void GenerateBranchName_BuildsAdlPrefixedSlug()
+    {
+        CreateBranchActivity.GenerateBranchName(42, "Add OAuth login!")
+            .Should().Be("adl/42-add-oauth-login");
+    }
+
+    [Test]
+    public void GenerateBranchName_TruncatesLongTitle()
+    {
+        var name = CreateBranchActivity.GenerateBranchName(7, new string('a', 200));
+        // adl/7- prefix + at most 40 title chars.
+        name.Should().StartWith("adl/7-");
+        name[(name.IndexOf('-') + 1)..].Length.Should().BeLessThanOrEqualTo(40);
+    }
+
+    [Test]
+    public void GenerateBranchName_EmptyTitle_StillValid()
+    {
+        var name = CreateBranchActivity.GenerateBranchName(9, "");
+        name.Should().Be("adl/9");
+        CreateBranchActivity.IsValidRefName(name).Should().BeTrue();
+    }
+
+    [Test]
+    public void GenerateBranchName_StripsSlashesAndDots()
+    {
+        var name = CreateBranchActivity.GenerateBranchName(3, "feature/../etc");
+        name.Should().NotContain("..");
+        CreateBranchActivity.IsValidRefName(name).Should().BeTrue();
+    }
+
+    // ================================================================
+    // IsValidRefName — injection hardening
+    // ================================================================
+
+    [Test]
+    public void IsValidRefName_RejectsDangerousPatterns()
+    {
+        CreateBranchActivity.IsValidRefName("").Should().BeFalse();
+        CreateBranchActivity.IsValidRefName("-leading-hyphen").Should().BeFalse();
+        CreateBranchActivity.IsValidRefName("has..dotdot").Should().BeFalse();
+        CreateBranchActivity.IsValidRefName("has space").Should().BeFalse();
+        CreateBranchActivity.IsValidRefName("has~tilde").Should().BeFalse();
+        CreateBranchActivity.IsValidRefName("trailing/").Should().BeFalse();
+        CreateBranchActivity.IsValidRefName("double//slash").Should().BeFalse();
+    }
+
+    [Test]
+    public void IsValidRefName_AcceptsNormalBranchNames()
+    {
+        CreateBranchActivity.IsValidRefName("adl/42-add-auth").Should().BeTrue();
+        CreateBranchActivity.IsValidRefName("main").Should().BeTrue();
+        CreateBranchActivity.IsValidRefName("feature/x").Should().BeTrue();
+    }
+
+    // ================================================================
+    // ClassifyError — permission / not-found / protected / transient
+    // ================================================================
+
+    [Test]
+    public void ClassifyError_MapsKnownCodes()
+    {
+        CreateBranchActivity.ClassifyError("403 Forbidden").Should().Be("permission_denied");
+        CreateBranchActivity.ClassifyError("base_branch_not_found: develop").Should().Be("base_branch_not_found");
+        CreateBranchActivity.ClassifyError("422 protected branch").Should().Be("base_branch_protected");
+        CreateBranchActivity.ClassifyError("503 service unavailable").Should().Be("transient");
+        CreateBranchActivity.ClassifyError("some weird error").Should().Be("unknown");
+        CreateBranchActivity.ClassifyError(null).Should().Be("unknown");
+    }
+
+    // ================================================================
+    // ExecuteCoreAsync — behavioral (happy / idempotency / failure / validation)
+    // ================================================================
+
+    private static Mock<IGitHubIntegrationService> NoExistingBranch()
+    {
+        var gh = new Mock<IGitHubIntegrationService>();
+        // candidate does not exist
+        gh.Setup(g => g.BranchExistsAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(IntegrationResult<bool>.Ok(false));
+        return gh;
+    }
+
+    [Test]
+    public async Task ExecuteCore_HappyPath_CreatesBranch_AndCapturesBaseSha()
+    {
+        var gh = NoExistingBranch();
+        gh.Setup(g => g.CreateGitHubBranchAsync("o/r", "adl/42-add-auth", "main"))
+            .ReturnsAsync(IntegrationResult<GitHubBranchResult>.Ok(new GitHubBranchResult
+            { Success = true, BranchName = "adl/42-add-auth", BaseSha = "deadbeef" }));
+        // post-create validation: now it exists.
+        gh.SetupSequence(g => g.BranchExistsAsync("o/r", "adl/42-add-auth"))
+            .ReturnsAsync(IntegrationResult<bool>.Ok(false))   // pre-create conflict check
+            .ReturnsAsync(IntegrationResult<bool>.Ok(true));   // post-create validation
+
+        var outcome = await CreateBranchActivity.ExecuteCoreAsync(
+            gh.Object, "o/r", 42, "adl/42-add-auth", "main", "suffix");
+
+        outcome.Outcome.Should().Be("Created");
+        outcome.BranchName.Should().Be("adl/42-add-auth");
+        outcome.BaseSha.Should().Be("deadbeef");
+        outcome.ConflictResolved.Should().BeFalse();
+        outcome.ErrorCode.Should().BeNull();
+    }
+
+    [Test]
+    public async Task ExecuteCore_BranchAlreadyExists_SuffixStrategy_CreatesSuffixed_NoDoubleCreate()
+    {
+        var gh = new Mock<IGitHubIntegrationService>();
+        // base candidate exists, -2 free
+        gh.Setup(g => g.BranchExistsAsync("o/r", "adl/42-add-auth"))
+            .ReturnsAsync(IntegrationResult<bool>.Ok(true));
+        gh.SetupSequence(g => g.BranchExistsAsync("o/r", "adl/42-add-auth-2"))
+            .ReturnsAsync(IntegrationResult<bool>.Ok(false))   // pre-create
+            .ReturnsAsync(IntegrationResult<bool>.Ok(true));   // post-create validation
+        gh.Setup(g => g.CreateGitHubBranchAsync("o/r", "adl/42-add-auth-2", "main"))
+            .ReturnsAsync(IntegrationResult<GitHubBranchResult>.Ok(new GitHubBranchResult
+            { Success = true, BranchName = "adl/42-add-auth-2", BaseSha = "sha2" }));
+
+        var outcome = await CreateBranchActivity.ExecuteCoreAsync(
+            gh.Object, "o/r", 42, "adl/42-add-auth", "main", "suffix");
+
+        outcome.Outcome.Should().Be("Created");
+        outcome.BranchName.Should().Be("adl/42-add-auth-2");
+        outcome.ConflictResolved.Should().BeTrue();
+        // The original (existing) name must NOT have been (re)created.
+        gh.Verify(g => g.CreateGitHubBranchAsync("o/r", "adl/42-add-auth", It.IsAny<string?>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ExecuteCore_BranchAlreadyExists_AbortStrategy_ReturnsExistsError_NoCreate()
+    {
+        var gh = new Mock<IGitHubIntegrationService>();
+        gh.Setup(g => g.BranchExistsAsync("o/r", "adl/42-add-auth"))
+            .ReturnsAsync(IntegrationResult<bool>.Ok(true));
+
+        var outcome = await CreateBranchActivity.ExecuteCoreAsync(
+            gh.Object, "o/r", 42, "adl/42-add-auth", "main", "abort");
+
+        outcome.Outcome.Should().Be("Error");
+        outcome.ErrorCode.Should().Be("branch_exists");
+        gh.Verify(g => g.CreateGitHubBranchAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ExecuteCore_CreateFailure_ReturnsError_NoFalseSuccess()
+    {
+        var gh = NoExistingBranch();
+        gh.Setup(g => g.CreateGitHubBranchAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>()))
+            .ReturnsAsync(IntegrationResult<GitHubBranchResult>.Fail("403 Forbidden"));
+
+        var outcome = await CreateBranchActivity.ExecuteCoreAsync(
+            gh.Object, "o/r", 42, "adl/42-add-auth", "main", "suffix");
+
+        outcome.Outcome.Should().Be("Error");
+        outcome.ErrorCode.Should().Be("permission_denied");
+        outcome.BranchName.Should().BeNullOrEmpty();
+    }
+
+    [Test]
+    public async Task ExecuteCore_BaseBranchMissing_ReturnsError_NoCreate()
+    {
+        var gh = NoExistingBranch();
+        gh.Setup(g => g.CreateGitHubBranchAsync(It.IsAny<string>(), It.IsAny<string>(), "develop"))
+            .ReturnsAsync(IntegrationResult<GitHubBranchResult>.Fail("base_branch_not_found: develop"));
+
+        var outcome = await CreateBranchActivity.ExecuteCoreAsync(
+            gh.Object, "o/r", 42, "adl/42-add-auth", "develop", "suffix");
+
+        outcome.Outcome.Should().Be("Error");
+        outcome.ErrorCode.Should().Be("base_branch_not_found");
+    }
+
+    [Test]
+    public async Task ExecuteCore_PostCreateValidationFails_ReturnsError_NoFalseSuccess()
+    {
+        var gh = new Mock<IGitHubIntegrationService>();
+        gh.SetupSequence(g => g.BranchExistsAsync("o/r", "adl/42-add-auth"))
+            .ReturnsAsync(IntegrationResult<bool>.Ok(false))   // pre-create
+            .ReturnsAsync(IntegrationResult<bool>.Ok(false));  // post-create: STILL absent
+        gh.Setup(g => g.CreateGitHubBranchAsync("o/r", "adl/42-add-auth", "main"))
+            .ReturnsAsync(IntegrationResult<GitHubBranchResult>.Ok(new GitHubBranchResult
+            { Success = true, BranchName = "adl/42-add-auth", BaseSha = "sha" }));
+
+        var outcome = await CreateBranchActivity.ExecuteCoreAsync(
+            gh.Object, "o/r", 42, "adl/42-add-auth", "main", "suffix");
+
+        outcome.Outcome.Should().Be("Error");
+        outcome.ErrorCode.Should().Be("validation_failed");
+    }
+
+    [Test]
+    public async Task ExecuteCore_InvalidRefName_ReturnsError_NoCreate()
+    {
+        var gh = new Mock<IGitHubIntegrationService>();
+
+        var outcome = await CreateBranchActivity.ExecuteCoreAsync(
+            gh.Object, "o/r", 42, "-bad..name", "main", "suffix");
+
+        outcome.Outcome.Should().Be("Error");
+        outcome.ErrorCode.Should().Be("invalid_ref");
+        gh.Verify(g => g.CreateGitHubBranchAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ExecuteCore_ConflictCheckApiError_ReturnsError_NotSilentCreate()
+    {
+        // A transient existence-lookup failure must NOT be treated as "absent → create".
+        var gh = new Mock<IGitHubIntegrationService>();
+        gh.Setup(g => g.BranchExistsAsync("o/r", "adl/42-add-auth"))
+            .ReturnsAsync(IntegrationResult<bool>.Fail("503 service unavailable"));
+
+        var outcome = await CreateBranchActivity.ExecuteCoreAsync(
+            gh.Object, "o/r", 42, "adl/42-add-auth", "main", "suffix");
+
+        outcome.Outcome.Should().Be("Error");
+        outcome.ErrorCode.Should().Be("transient");
+        gh.Verify(g => g.CreateGitHubBranchAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ExecuteCore_NeverThrows_OnUnexpectedException()
+    {
+        var gh = new Mock<IGitHubIntegrationService>();
+        gh.Setup(g => g.BranchExistsAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        var outcome = await CreateBranchActivity.ExecuteCoreAsync(
+            gh.Object, "o/r", 42, "adl/42-add-auth", "main", "suffix");
+
+        outcome.Outcome.Should().Be("Error");
+        outcome.ErrorCode.Should().NotBeNullOrEmpty();
+    }
+
+    // ================================================================
+    // EmitBranchEventActivity.BuildTammaEvent — DCB mapping onto the drain
+    // ================================================================
+
+    [Test]
+    public void BuildTammaEvent_SuccessType_SetsTypeStatusTagsAndData()
+    {
+        var evt = EmitBranchEventActivity.BuildTammaEvent(
+            BranchEvents.CreatedSuccess, issueNumber: 12, repository: "o/r",
+            tenantId: null,
+            data: new Dictionary<string, object?> { ["baseSha"] = "sha", ["finalName"] = "adl/12-x" });
+
+        evt.EventType.Should().Be("BRANCH.CREATED.SUCCESS");
+        evt.Status.Should().Be("success");
+        evt.Tags.Should().NotBeNull();
+        evt.Tags!["issueId"].Should().Be("12");
+        evt.Tags["issueNumber"].Should().Be("12");
+        evt.Tags["repository"].Should().Be("o/r");
+        evt.Tags.Should().NotContainKey("tenantId");
+        evt.Data.Should().ContainKey("baseSha");
+        evt.Data.Should().ContainKey("finalName");
+    }
+
+    [Test]
+    public void BuildTammaEvent_FailedType_SetsErrorStatus()
+    {
+        var evt = EmitBranchEventActivity.BuildTammaEvent(
+            BranchEvents.CreatedFailed, issueNumber: 7, repository: "o/r",
+            tenantId: null, data: null);
+
+        evt.EventType.Should().Be("BRANCH.CREATED.FAILED");
+        evt.Status.Should().Be("error");
+        evt.Data.Should().BeEmpty();
+    }
+
+    [Test]
+    public void BuildTammaEvent_WithTenant_SetsTenantIdTag()
+    {
+        var tenant = Guid.NewGuid();
+        var evt = EmitBranchEventActivity.BuildTammaEvent(
+            BranchEvents.CreatedSuccess, 1, "o/r", tenantId: tenant, data: null);
+
+        evt.Tags!["tenantId"].Should().Be(tenant.ToString("D"));
+    }
+
+    [Test]
+    public void BranchEvents_ParseTenantId_HandlesEmptyAndValid()
+    {
+        BranchEvents.ParseTenantId(null).Should().BeNull();
+        BranchEvents.ParseTenantId("").Should().BeNull();
+        BranchEvents.ParseTenantId("not-a-guid").Should().BeNull();
+        var g = Guid.NewGuid();
+        BranchEvents.ParseTenantId(g.ToString()).Should().Be(g);
+    }
+
+    [Test]
+    public void EmitBranchEvent_ParseData_HandlesEmptyAndMalformed()
+    {
+        EmitBranchEventActivity.ParseData(null).Should().BeNull();
+        EmitBranchEventActivity.ParseData("").Should().BeNull();
+        EmitBranchEventActivity.ParseData("{not json").Should().BeNull();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/BranchCreationWorkflowTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/BranchCreationWorkflowTests.cs
@@ -1,0 +1,164 @@
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Management.Activities.SetOutput;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Story 2.4 build-out — workflow-structure integration coverage for the built-out
+/// <c>branch-creation</c> graph. Asserts the load-bearing guarantees of the
+/// build-out (which the activity unit tests can't): the <c>Error</c> outcome NEVER
+/// falls through to success, both terminal transitions emit a <c>BRANCH.*</c> DCB
+/// event, the failure path sets <c>success=false</c> and surfaces an
+/// <c>errorCode</c>, and every edge out of the create step is outcome-qualified
+/// (no portless silent fall-through — the headline "thin wrapper" bug).
+///
+/// <para>Follows the codebase convention of inspecting the BUILT Flowchart via
+/// <see cref="WorkflowTestHelper"/> rather than running the full Elsa runtime
+/// (see <see cref="PullRequestWorkflowTests"/>).</para>
+/// </summary>
+[TestFixture]
+public class BranchCreationWorkflowTests
+{
+    private Flowchart _flowchart = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new BranchCreationWorkflow());
+        _flowchart = WorkflowTestHelper.GetFlowchart(builder);
+    }
+
+    // ================================================================
+    // Identity
+    // ================================================================
+
+    [Test]
+    public void Workflow_BuildsWithExpectedDefinitionId()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new BranchCreationWorkflow());
+        builder.Object.DefinitionId.Should().Be("branch-creation");
+    }
+
+    // ================================================================
+    // No false success — the Error outcome routes to the failure path ONLY
+    // ================================================================
+
+    [Test]
+    public void CreateBranch_ErrorOutcome_RoutesToFailurePath_NotSuccess()
+    {
+        HasEdge("CreateBranch", "Error", "FailureOutputs").Should().BeTrue(
+            "the Error outcome must route to the explicit failure path");
+
+        var errorTargets = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "CreateBranch" && c.Source.Port == "Error")
+            .Select(c => c.Target.Activity.Id)
+            .ToList();
+
+        errorTargets.Should().NotContain("EmitSuccess");
+        errorTargets.Should().NotContain("SuccessOutputs");
+    }
+
+    [Test]
+    public void CreateBranch_HasNoUnconditionalFallthrough()
+    {
+        // Every edge out of CreateBranch must be outcome-qualified (Created/Error).
+        // A portless edge would be the old silent fall-through bug.
+        var fromCreate = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "CreateBranch")
+            .ToList();
+
+        fromCreate.Should().NotBeEmpty();
+        fromCreate.Should().OnlyContain(c =>
+            c.Source.Port == "Created" || c.Source.Port == "Error");
+    }
+
+    [Test]
+    public void CreatedOutcome_RoutesToSuccess()
+    {
+        HasEdge("CreateBranch", "Created", "EmitSuccess").Should().BeTrue();
+    }
+
+    // ================================================================
+    // DCB events on every terminal transition
+    // ================================================================
+
+    [Test]
+    public void SuccessPath_EmitsBranchCreatedSuccess()
+    {
+        var emit = _flowchart.Activities
+            .OfType<EmitBranchEventActivity>()
+            .FirstOrDefault(a => a.Id == "EmitSuccess");
+        emit.Should().NotBeNull("success path must emit a BRANCH DCB event");
+        HasEdge("EmitSuccess", null, "SuccessOutputs").Should().BeTrue();
+    }
+
+    [Test]
+    public void FailurePath_EmitsBranchCreatedFailed()
+    {
+        var emit = _flowchart.Activities
+            .OfType<EmitBranchEventActivity>()
+            .FirstOrDefault(a => a.Id == "EmitFailed");
+        emit.Should().NotBeNull("failure path must emit BRANCH.CREATED.FAILED");
+        HasEdge("FailureOutputs", null, "EmitFailed").Should().BeTrue();
+    }
+
+    [Test]
+    public void BothTerminalPaths_ReachFinish()
+    {
+        HasEdge("SuccessOutputs", null, "Finish").Should().BeTrue();
+        HasEdge("EmitFailed", null, "Finish").Should().BeTrue();
+    }
+
+    // ================================================================
+    // Outputs — success=false on the failure path; branchName/baseSha on success
+    // ================================================================
+
+    [Test]
+    public void FailurePath_SetsSuccessFalse_And_ErrorCode()
+    {
+        var failureSeq = _flowchart.Activities
+            .OfType<Sequence>()
+            .First(s => s.Id == "FailureOutputs");
+
+        var ids = failureSeq.Activities
+            .OfType<SetOutput>()
+            .Select(o => o.Id ?? "")
+            .ToList();
+
+        ids.Should().Contain("OutFailSuccess");    // success = false
+        ids.Should().Contain("OutFailErrorCode");  // errorCode
+        ids.Should().Contain("OutFailBranchName"); // branchName = "" (no false branch)
+    }
+
+    [Test]
+    public void SuccessPath_ExposesOutputs_BranchNameBaseShaSuccess()
+    {
+        var successSeq = _flowchart.Activities
+            .OfType<Sequence>()
+            .First(s => s.Id == "SuccessOutputs");
+
+        var ids = successSeq.Activities
+            .OfType<SetOutput>()
+            .Select(o => o.Id ?? "")
+            .ToList();
+
+        ids.Should().Contain("OutSuccess");     // success = true
+        ids.Should().Contain("OutBranchName");  // branchName
+        ids.Should().Contain("OutBaseSha");     // baseSha (AC4)
+    }
+
+    // ================================================================
+    // Helpers
+    // ================================================================
+
+    private bool HasEdge(string sourceId, string? port, string targetId)
+        => _flowchart.Connections.Any(c =>
+            c.Source.Activity.Id == sourceId &&
+            (port == null || c.Source.Port == port) &&
+            c.Target.Activity.Id == targetId);
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/SingleIssueCycleRoutingTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/SingleIssueCycleRoutingTests.cs
@@ -458,6 +458,91 @@ public class SingleIssueCycleRoutingTests
             "escalated (incl. a failed merge) must reach the error terminal");
     }
 
+    // ================================================================
+    // IMPORTANT-5 — the cycle gates createPR on the branch step's success.
+    // A failed branch creation routes to a loud terminal (no doomed PR with an
+    // empty head, no false "branch created" notification). Both outcomes reach a
+    // Finish terminal (no dangling edge / deadlock).
+    // ================================================================
+
+    [Test]
+    public void BranchOutcomeSwitch_HasTwoCases_CreatedFailed()
+    {
+        var sw = _flowchart.Activities
+            .OfType<FlowSwitch>()
+            .FirstOrDefault(fs => fs.Id == "BranchOutcomeSwitch");
+
+        sw.Should().NotBeNull("the cycle must switch on the branch-creation success flag");
+        var caseNames = sw!.Cases.Select(c => c.Label).ToList();
+        caseNames.Should().Contain("Created");
+        caseNames.Should().Contain("Failed");
+    }
+
+    [Test]
+    public void ExtractBranch_FeedsTheBranchOutcomeSwitch()
+    {
+        // The branch result must be captured (ExtractBranch) and routed through
+        // the switch — never wired unconditionally to createPR.
+        _flowchart.Connections.Any(c =>
+            c.Source.Activity.Id == "ExtractBranch" &&
+            c.Target.Activity.Id == "BranchOutcomeSwitch")
+            .Should().BeTrue("the branch result must branch on success");
+    }
+
+    [Test]
+    public void BranchSuccess_ReachesCreatePr_AndNotifyBranchCreated()
+    {
+        var created = ReachableFromPort("BranchOutcomeSwitch", "Created");
+        created.Should().Contain("CreatePR", "a successful branch must continue to PR creation");
+        created.Should().Contain("NotifyBranchCreated", "a successful branch fires the branch-created notify");
+    }
+
+    [Test]
+    public void BranchFailure_DoesNotReachCreatePr_NorFalseBranchNotify()
+    {
+        // The load-bearing gate: a failed branch must NEVER reach createPR (a
+        // doomed PR with an empty head) nor fire the false "branch created" notify.
+        var failed = ReachableFromPort("BranchOutcomeSwitch", "Failed");
+        failed.Should().NotContain("CreatePR",
+            "a failed branch must not invoke createPR with an empty head");
+        failed.Should().NotContain("NotifyBranchCreated",
+            "a failed branch must not emit a false 'branch created' notification");
+    }
+
+    [Test]
+    public void BranchFailure_ReachesLoudErrorTerminal()
+    {
+        // The failure path must reach a loud terminal (ReportError) and Finish —
+        // no dangling edge, no deadlock.
+        var failed = ReachableFromPort("BranchOutcomeSwitch", "Failed");
+        failed.Should().Contain("ReportError", "a failed branch must reach the error terminal");
+        failed.Should().Contain("Finish", "the failure path must terminate at Finish (no dangling edge)");
+    }
+
+    [Test]
+    public void CreatePr_HasNoUnconditionalEdgeFromExtractBranch()
+    {
+        // Regression guard for IMPORTANT-5: the old unconditional
+        // ExtractBranch → CreatePR / NotifyBranchCreated edges must be gone.
+        _flowchart.Connections.Any(c =>
+            c.Source.Activity.Id == "ExtractBranch" &&
+            c.Target.Activity.Id == "CreatePR")
+            .Should().BeFalse("createPR must be gated on branch success, not wired unconditionally");
+        _flowchart.Connections.Any(c =>
+            c.Source.Activity.Id == "ExtractBranch" &&
+            c.Target.Activity.Id == "NotifyBranchCreated")
+            .Should().BeFalse("the branch-created notify must be gated on success");
+
+        // Every edge into CreatePR originates at the Created branch outcome.
+        var intoPr = _flowchart.Connections
+            .Where(c => c.Target.Activity.Id == "CreatePR")
+            .ToList();
+        intoPr.Should().NotBeEmpty();
+        intoPr.Should().OnlyContain(c =>
+            c.Source.Activity.Id == "BranchOutcomeSwitch" && c.Source.Port == "Created",
+            "createPR may only be reached via the Created branch outcome");
+    }
+
     [Test]
     public void OldBinaryApprovalGate_IsRetiredFromTheCycle()
     {

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/GitHub/GitHubIntegrationServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/GitHub/GitHubIntegrationServiceTests.cs
@@ -249,6 +249,124 @@ public class GitHubIntegrationServiceTests
     }
 
     // ================================================================
+    // BranchExistsAsync — exact-match SINGULAR git/ref endpoint (review I-1/I-2)
+    //
+    // The prefix-matching PLURAL `git/refs/heads/{ref}` endpoint returns 200 + a
+    // JSON ARRAY for any ref another ref STARTS WITH (e.g. `adl/42-auth` when only
+    // `adl/42-auth-2` exists) — a false conflict + an array that breaks the
+    // single-object parse. The SINGULAR `git/ref/heads/{branch}` endpoint is the
+    // exact-match form: a single object on a hit, a real 404 on a miss — exactly
+    // the 200/404 contract this code is written against.
+    // ================================================================
+
+    // The branch slug carries a '/', which the service URL-escapes to %2F; the
+    // request's AbsolutePath keeps that encoded, so route registration mirrors it.
+    private const string BranchPathSingular = "/repos/o/r/git/ref/heads/adl%2F42-auth";
+
+    [Test]
+    public async Task BranchExists_HitsSingularExactMatchEndpoint_NotPluralPrefixEndpoint()
+    {
+        _handler.OnGet(BranchPathSingular,
+            """{ "ref": "refs/heads/adl/42-auth", "object": { "sha": "abc123" } }""");
+
+        var result = await CreateService().BranchExistsAsync("o/r", "adl/42-auth");
+
+        result.Success.Should().BeTrue();
+        result.Data.Should().BeTrue("a 200 single-object response means the branch exists");
+
+        // The request must go to the SINGULAR `git/ref/...` (exact match), never
+        // the prefix-matching PLURAL `git/refs/...`.
+        var req = _handler.RequireRequest(HttpMethod.Get, BranchPathSingular);
+        req.Path.Should().Contain("/git/ref/heads/");
+        req.Path.Should().NotContain("/git/refs/heads/",
+            "the plural prefix-matching endpoint would 200 on sibling refs (false conflict)");
+    }
+
+    [Test]
+    public async Task BranchExists_404_ReturnsOkFalse()
+    {
+        // Exact-match miss → 404 → Ok(false), free to create.
+        _handler.OnGet(BranchPathSingular, "Not Found", HttpStatusCode.NotFound);
+
+        var result = await CreateService().BranchExistsAsync("o/r", "adl/42-auth");
+
+        result.Success.Should().BeTrue();
+        result.Data.Should().BeFalse("a true 404 from the exact-match endpoint means absent");
+    }
+
+    [Test]
+    public async Task BranchExists_5xx_ReturnsFail_NotAbsent()
+    {
+        // A transient 5xx is an error — NOT "absent → free to create".
+        _handler.OnGet(BranchPathSingular, "boom", HttpStatusCode.ServiceUnavailable);
+
+        var result = await CreateService().BranchExistsAsync("o/r", "adl/42-auth");
+
+        result.Success.Should().BeFalse("a 5xx must surface as an error, never as absent");
+    }
+
+    // ================================================================
+    // Base-ref SHA resolution (CreateGitHubBranchAsync, explicit base) — must use
+    // the SINGULAR exact-match endpoint and parse the single object.
+    // ================================================================
+
+    [Test]
+    public async Task CreateBranch_ExplicitBase_ResolvesShaViaSingularExactEndpoint()
+    {
+        _handler.OnGet("/repos/o/r/git/ref/heads/develop",
+            """{ "ref": "refs/heads/develop", "object": { "sha": "base-sha-777" } }""");
+        _handler.OnPost("/repos/o/r/git/refs",
+            """{ "ref": "refs/heads/adl/9", "object": { "sha": "new-sha" } }""");
+
+        var result = await CreateService().CreateGitHubBranchAsync("o/r", "adl/9", "develop");
+
+        result.Success.Should().BeTrue();
+        result.Data!.BaseSha.Should().Be("base-sha-777", "the single-object base ref must parse cleanly");
+
+        var req = _handler.RequireRequest(HttpMethod.Get, "/repos/o/r/git/ref/heads/develop");
+        req.Path.Should().Contain("/git/ref/heads/");
+        req.Path.Should().NotContain("/git/refs/heads/");
+
+        // The create POST must carry the SHA resolved from the exact base ref.
+        var create = _handler.RequireRequest(HttpMethod.Post, "/repos/o/r/git/refs");
+        var body = JsonDocument.Parse(create.Body).RootElement;
+        body.GetProperty("sha").GetString().Should().Be("base-sha-777");
+        body.GetProperty("ref").GetString().Should().Be("refs/heads/adl/9");
+    }
+
+    [Test]
+    public async Task CreateBranch_ExplicitBase_404_ReturnsBaseBranchNotFound()
+    {
+        _handler.OnGet("/repos/o/r/git/ref/heads/nope", "Not Found", HttpStatusCode.NotFound);
+
+        var result = await CreateService().CreateGitHubBranchAsync("o/r", "adl/9", "nope");
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("base_branch_not_found",
+            "a true 404 on the exact base ref is a missing-base failure (no fall-through)");
+    }
+
+    [Test]
+    public async Task CreateBranch_DefaultBase_ResolvesMainViaSingularExactEndpoint()
+    {
+        // Default-branch path (no explicit base) must also use the singular
+        // exact-match endpoint (main → master fallback).
+        _handler.OnGet("/repos/o/r/git/ref/heads/main",
+            """{ "ref": "refs/heads/main", "object": { "sha": "main-sha-1" } }""");
+        _handler.OnPost("/repos/o/r/git/refs",
+            """{ "ref": "refs/heads/adl/9", "object": { "sha": "new-sha" } }""");
+
+        var result = await CreateService().CreateGitHubBranchAsync("o/r", "adl/9");
+
+        result.Success.Should().BeTrue();
+        result.Data!.BaseSha.Should().Be("main-sha-1");
+
+        var req = _handler.RequireRequest(HttpMethod.Get, "/repos/o/r/git/ref/heads/main");
+        req.Path.Should().Contain("/git/ref/heads/");
+        req.Path.Should().NotContain("/git/refs/heads/");
+    }
+
+    // ================================================================
     // Route-aware fake handler
     // ================================================================
 


### PR DESCRIPTION
## What

`BranchCreationWorkflow`: thin wrapper → complete. Idempotency (branch-exists → suffix strategy, never re-create), base-branch validation (no silent fallback → `base_branch_not_found`), explicit failure path (loud `BRANCH.CREATED.FAILED`, typed error codes), `BRANCH.CREATED.*` events via the durable drain, `tenantId` threaded. New substrate: `BranchExistsAsync`, base-aware `CreateGitHubBranchAsync`, `BaseSha`.

## Reviewed — two real issues fixed

- **GitHub REST-semantics bug:** `BranchExistsAsync` + base-ref resolution were using the prefix-matching plural `git/refs/heads/{ref}` endpoint, which returns 200 for a *sibling* ref (`adl/42-auth` "exists" because `adl/42-auth-2` does) — breaking idempotency + post-create validation. Switched both to the exact-match singular `git/ref/heads/{ref}` (404 on a true miss), with HTTP-level `GitHubIntegrationService` tests (the gap that let it through).
- **Cycle gating:** `SingleIssueCycle` was calling `createPR` with an empty branch name (a doomed PR + a false "branch created" notice) on branch-creation failure. Now a `BranchOutcomeSwitch` gates it — Created → PR; Failed → a loud `reportError` terminal. Both outcomes reach `Finish`; no deadlock (6 routing tests).

## Verification
Build 0 errors; `has-pending-model-changes` clean; GitHub/Integration Api 233/0, BranchCreation/SingleIssueCycle Activities 80/0; full `Tamma.Activities.Tests` 1521/0, `Tamma.Api.Tests` 3680/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)