### PR TITLE
feat(workflows): build out ReviewFix — fail-closed paths + events (loop scaffolding for Epic 38)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitReviewFixEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitReviewFixEventActivity.cs
@@ -1,0 +1,139 @@
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+
+namespace Tamma.Activities.ADL;
+
+/// <summary>
+/// Emits a <c>REVIEW_FIX.*</c> DCB event (Story 2-18 Phases 4 &amp; 5 / Story 2-9)
+/// for the audit trail by appending a <see cref="TammaEvent"/> to the workflow's
+/// <c>tamma:events</c> transient list via <see cref="TammaEventEmitter.Emit"/>.
+/// The engine event drain (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>)
+/// flushes that list <i>durably</i> to the tenant <c>domain_events</c> store after
+/// this activity runs — the drain resolves the tenant from the workflow scope (the
+/// review-fix workflow stamps a <c>TenantId</c> variable). The event therefore
+/// persists without this activity holding any DB / repository dependency of its
+/// own (none is registered in the Elsa engine — the same reason
+/// <see cref="EmitPrEventActivity"/> / <see cref="EmitMergeApprovalEventActivity"/>
+/// use the emitter rather than a direct <c>IEventRepository</c>).
+/// </summary>
+[Activity(
+    "Tamma.ADL",
+    "Emit Review Fix Event",
+    "Emit a REVIEW_FIX.* DCB event for the review-fix audit trail",
+    Kind = ActivityKind.Task
+)]
+public class EmitReviewFixEventActivity : Activity
+{
+    private readonly ILogger<EmitReviewFixEventActivity>? _logger;
+
+    [Input(Description = "Event type — e.g. REVIEW_FIX.ANALYZED.SUCCESS / REVIEW_FIX.APPLIED.FAILED")]
+    public Input<string> EventType { get; set; } = default!;
+
+    [Input(Description = "Repository in owner/repo format")]
+    public Input<string?> Repository { get; set; } = new((string?)null);
+
+    [Input(Description = "Pull request number")]
+    public Input<int> PrNumber { get; set; } = new(0);
+
+    [Input(Description = "Issue number this PR closes (0 when unknown)")]
+    public Input<int> IssueNumber { get; set; } = new(0);
+
+    [Input(Description = "Tenant id (empty / single-user → platform-scope event)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [Input(Description = "Event data payload as JSON (counts, filesFixed, errorReason, ...)")]
+    public Input<string?> DataJson { get; set; } = new((string?)null);
+
+    [JsonConstructor]
+    public EmitReviewFixEventActivity() { }
+
+    public EmitReviewFixEventActivity(ILogger<EmitReviewFixEventActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var type = EventType.Get(context) ?? ReviewFixEvents.AppliedFailed;
+        var repository = Repository.Get(context) ?? "";
+        var prNumber = PrNumber.Get(context);
+        var issueNumber = IssueNumber.Get(context);
+        var tenantId = ReviewFixEvents.ParseTenantId(TenantId.Get(context));
+        var data = ParseData(DataJson.Get(context));
+
+        var evt = BuildTammaEvent(type, repository, prNumber, issueNumber, tenantId, data);
+        TammaEventEmitter.Emit(context, this, _logger, evt);
+
+        _logger?.LogInformation(
+            "Emitted {Type} for pr #{Pr} in {Repo} (issue #{Issue})",
+            type, prNumber, repository, issueNumber);
+
+        return default;
+    }
+
+    /// <summary>
+    /// Map the review-fix inputs onto a <see cref="TammaEvent"/> expressed as the
+    /// engine's transient-list event so the merged drain persists it. Tags carry
+    /// the queryable DCB index keys (<c>repository</c>/<c>prNumber</c>/<c>prId</c>/
+    /// <c>issueId</c>/<c>tenantId</c>); Data carries the metrics / reason payload.
+    /// Pure (no Elsa context) — exposed for unit testing the mapping.
+    /// </summary>
+    public static TammaEvent BuildTammaEvent(
+        string type,
+        string repository,
+        int prNumber,
+        int issueNumber,
+        Guid? tenantId,
+        IReadOnlyDictionary<string, object?>? data)
+    {
+        var tags = new Dictionary<string, object?>
+        {
+            ["repository"] = repository,
+        };
+        if (prNumber > 0)
+        {
+            tags["prNumber"] = prNumber.ToString();
+            tags["prId"] = prNumber.ToString();
+        }
+        if (issueNumber > 0)
+        {
+            tags["issueNumber"] = issueNumber.ToString();
+            tags["issueId"] = issueNumber.ToString();
+        }
+        if (tenantId is not null) tags["tenantId"] = tenantId.Value.ToString("D");
+
+        return new TammaEvent
+        {
+            EventType = type,
+            Status = ReviewFixEvents.IsFailureEvent(type) ? "error" : "success",
+            Tags = tags,
+            Data = data is null
+                ? new Dictionary<string, object?>()
+                : new Dictionary<string, object?>(data),
+        };
+    }
+
+    /// <summary>
+    /// Deserialize the JSON data payload into a dictionary for the event builder.
+    /// Returns null on empty/malformed input (the event still emits with "{}").
+    /// Exposed for unit testing the parse path.
+    /// </summary>
+    public static IReadOnlyDictionary<string, object?>? ParseData(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+        try
+        {
+            return System.Text.Json.JsonSerializer
+                .Deserialize<Dictionary<string, object?>>(json);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/ReviewFixEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/ReviewFixEvents.cs
@@ -1,0 +1,75 @@
+namespace Tamma.Activities.ADL;
+
+/// <summary>
+/// Story 2-18 (Phases 4 &amp; 5) / Story 2-9 — central catalogue of the
+/// <c>REVIEW_FIX.*</c> DCB event types emitted by the <c>review-fix</c> workflow.
+///
+/// <para>The review-fix phase closes the autonomous loop's review cycle: it
+/// fetches a PR's review comments, decides which are actionable, generates code
+/// fixes via the mediated <c>llm-call</c> path, applies them, and (follow-on)
+/// pushes them back so CI/review can re-run. Every meaningful transition of that
+/// phase is an auditable event for the 100%-audit-trail invariant
+/// (<c>CLAUDE.md</c> "Event Sourcing (DCB Pattern)").</para>
+///
+/// <para>Events are emitted via <c>TammaEventEmitter.Emit</c> into the workflow's
+/// <c>tamma:events</c> transient list and persisted <i>durably</i> by the engine
+/// event drain (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) — the same
+/// pattern <see cref="EmitPrEventActivity"/> /
+/// <see cref="EmitMergeApprovalEventActivity"/> use. No activity holds a DB /
+/// repository dependency of its own (none is registered in the Elsa engine — a
+/// directly-injected <c>IEventRepository</c> would be inert and silently drop
+/// every event).</para>
+///
+/// <para>Type pattern follows the platform's <c>AGGREGATE.ACTION.STATUS</c>
+/// convention.</para>
+///
+/// <list type="bullet">
+///   <item><description><c>REVIEW_FIX.ANALYZED.SUCCESS</c> — review comments were
+///     fetched and analyzed (carries actionable / total counts).</description></item>
+///   <item><description><c>REVIEW_FIX.ANALYZED.FAILED</c> — fetching / analyzing
+///     review comments failed (GitHub error). Loud (error-status) — the workflow
+///     routes to its failure terminal, never a silent success.</description></item>
+///   <item><description><c>REVIEW_FIX.GENERATED.SUCCESS</c> — the dispatched
+///     <c>llm-call</c> returned a fix-generation response
+///     (<c>success=true</c>).</description></item>
+///   <item><description><c>REVIEW_FIX.GENERATED.FAILED</c> — the dispatched
+///     <c>llm-call</c> reported <c>success=false</c>. Loud — the workflow routes
+///     to its failure terminal instead of flowing the empty response into "apply"
+///     as a false success.</description></item>
+///   <item><description><c>REVIEW_FIX.APPLIED.SUCCESS</c> — the generated fix was
+///     applied (carries the count of files fixed).</description></item>
+///   <item><description><c>REVIEW_FIX.APPLIED.FAILED</c> — applying the fix
+///     failed (or the apply activity faulted). Loud — the workflow routes to its
+///     failure terminal, never reports <c>fixesApplied=true</c> when nothing was
+///     applied.</description></item>
+///   <item><description><c>REVIEW_FIX.ESCALATED</c> — the fix loop hit its
+///     graph-enforced iteration cap without converging and escalated to a human
+///     instead of spinning forever (mirrors the merge-approval test-loop cap).</description></item>
+/// </list>
+/// </summary>
+public static class ReviewFixEvents
+{
+    public const string AnalyzedSuccess = "REVIEW_FIX.ANALYZED.SUCCESS";
+    public const string AnalyzedFailed = "REVIEW_FIX.ANALYZED.FAILED";
+    public const string GeneratedSuccess = "REVIEW_FIX.GENERATED.SUCCESS";
+    public const string GeneratedFailed = "REVIEW_FIX.GENERATED.FAILED";
+    public const string AppliedSuccess = "REVIEW_FIX.APPLIED.SUCCESS";
+    public const string AppliedFailed = "REVIEW_FIX.APPLIED.FAILED";
+    public const string Escalated = "REVIEW_FIX.ESCALATED";
+
+    /// <summary>
+    /// Parse a tenant id from the loose string form threaded through the workflow
+    /// inputs. Returns <c>null</c> for empty / single-user / unparseable values
+    /// (review-fix events in single-user mode are platform-scope, TenantId null).
+    /// </summary>
+    public static Guid? ParseTenantId(string? tenantId)
+        => Guid.TryParse(tenantId, out var g) ? g : null;
+
+    /// <summary>
+    /// The <c>.FAILED</c> / <c>.ESCALATED</c> transitions are loud (error-status)
+    /// audit rows — they are NOT a false success. The <c>.SUCCESS</c> transitions
+    /// are normal progress.
+    /// </summary>
+    public static bool IsFailureEvent(string type)
+        => type is AnalyzedFailed or GeneratedFailed or AppliedFailed or Escalated;
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ReviewFixWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ReviewFixWorkflow.cs
@@ -3,6 +3,7 @@ using Elsa.Extensions;
 using Elsa.Workflows;
 using Elsa.Workflows.Activities;
 using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.IncidentStrategies;
 using Elsa.Workflows.Management.Activities.SetOutput;
 using Elsa.Workflows.Memory;
 using Elsa.Workflows.Models;
@@ -14,38 +15,206 @@ using Tamma.Activities.Security;
 using Tamma.Api.Services.Agents;
 using FlowEndpoint = Elsa.Workflows.Activities.Flowchart.Models.Endpoint;
 using FlowConnection = Elsa.Workflows.Activities.Flowchart.Models.Connection;
+using static Tamma.ElsaServer.Workflows.ActivityDisplayTextExtensions;
 
 namespace Tamma.ElsaServer.Workflows;
 
+/// <summary>
+/// Review Fix — the autonomous loop's review-closing phase (Story 2-18 Phases 4 &amp;
+/// 5 / Story 2-9): fetch a PR's review comments, decide which are actionable,
+/// generate code fixes via the mediated <c>llm-call</c> path, apply them, and index
+/// the changed files so CI/review can re-run.
+///
+/// <para>Build-out: the prior version was a happy-path skeleton (analyze → decide →
+/// generate → "apply" → index → constant <c>success=true</c>) with no failure
+/// edges, an activity-internal-only loop bound, and zero audit events. This build-out
+/// makes the load-bearing guarantees graph-enforced:</para>
+///
+/// <list type="bullet">
+///   <item><description><b>Graph-enforced iteration bound</b> — a
+///     <see cref="FlowDecision"/> caps the fix loop (<c>&gt;=MaxIterations</c> →
+///     escalate terminal), mirroring the merge-approval test-loop cap and
+///     <c>PlanMaxRevisions</c>/<c>TaskMaxRevisions</c>. Over the cap the workflow
+///     ESCALATES (loud, <c>REVIEW_FIX.ESCALATED</c>, <c>success=false</c>) instead of
+///     spinning forever or reporting a silent success.</description></item>
+///   <item><description><b>Explicit error / exhaustion path</b> —
+///     <c>AnalyzeReview</c>'s <c>Error</c> outcome and a failed <c>llm-call</c>
+///     (<c>success=false</c>, read from the dispatch result) each route to a loud
+///     <c>OutputFailure</c> terminal. A failed generation NEVER flows into "apply"
+///     as a false success.</description></item>
+///   <item><description><b>Fail-closed apply</b> — <c>ApplyFixes.Error</c> AND a
+///     <c>Fixed</c> outcome that did not actually apply files
+///     (<c>fixesApplied=false</c>) route to the failure terminal. <c>success</c>
+///     reflects reality — it is never a constant <c>true</c>.</description></item>
+///   <item><description><b>DCB audit events</b> — <c>REVIEW_FIX.*</c> events on every
+///     meaningful edge (analyze / generate / apply / escalate), via
+///     <see cref="EmitReviewFixEventActivity"/> through the durable engine event
+///     drain. The workflow carries <c>tenantId</c> so events are tenant-scoped.</description></item>
+/// </list>
+///
+/// <para>Deferred (reported for confirmation):</para>
+/// <list type="bullet">
+///   <item><description>removing the direct-LLM fallback in
+///     <c>ApplyReviewFixesActivity</c> (the <c>CallLlm</c> → Anthropic
+///     <c>/v1/messages</c> path) and forcing the mediated response — that is
+///     <b>32-5 T6</b>'s job; the LLM here already routes via <c>llm-call</c>;</description></item>
+///   <item><description>mediating <c>AnalyzeReview</c>'s GitHub read and any git
+///     writes (real apply / commit / push) through the internal API — that is
+///     <b>Epic 38</b> (non-LLM / git mediation);</description></item>
+///   <item><description>AI comment classification, verify-and-loop on lint/type
+///     errors, commit &amp; push, re-request review, CI re-trigger, and wiring into
+///     <c>SingleIssueCycleWorkflow</c> — gated on Epic 38 / 32-5 / Story 2-18
+///     Phases 6-7 (spec §5 items #2,#8-#13).</description></item>
+/// </list>
+///
+/// Flow:
+///   DefaultOutcome (seed success=false) → ReadInputs → AnalyzeReview
+///     ├─ Done  → EmitAnalyzeSuccess → HasActionable?
+///     │            ├─ False → OutputSuccess (genuine: nothing to fix)
+///     │            └─ True  → IncrementIteration → MaxIterations?
+///     │                         ├─ &gt;=Max → EmitEscalated → OutputFailure (loud)
+///     │                         └─ &lt;Max  → DispatchFixGeneration (llm-call) →
+///     │                                      ExtractGenerateSuccess → GenerateSucceeded?
+///     │                                        ├─ False → EmitGenerateFailed → OutputFailure
+///     │                                        └─ True  → EmitGenerateSuccess → ApplyFixes
+///     │                                                     ├─ Error → EmitApplyFailed → OutputFailure
+///     │                                                     └─ Fixed → FixesApplied?
+///     │                                                                  ├─ False → EmitApplyFailed → OutputFailure
+///     │                                                                  └─ True  → EmitApplySuccess →
+///     │                                                                             UpdateCodeIndex → OutputSuccess
+///     └─ Error → EmitAnalyzeFailed → OutputFailure
+/// </summary>
 public class ReviewFixWorkflow : WorkflowBase
 {
+    /// <summary>
+    /// Max fix-generation attempts before escalating — mirrors PlanMaxRevisions /
+    /// TaskMaxRevisions (&gt;=3) in SingleIssueCycleWorkflow and the merge-approval
+    /// test-loop cap, so the fix loop can never spin forever.
+    /// </summary>
+    private const int MaxIterations = 3;
+
     protected override void Build(IWorkflowBuilder builder)
     {
         builder.Name = "Review Fix";
         builder.DefinitionId = "review-fix";
         builder.Version = WorkflowVersions.ComputedVersion;
-        builder.Description = "Analyze PR review comments and apply AI-generated fixes";
+        builder.Description = "Analyze PR review comments and apply AI-generated fixes — graph-enforced loop bound, explicit error path, REVIEW_FIX.* audit events";
+
+        // Fail-closed on internal fault (mirror MergeApprovalWorkflow SECURITY I1):
+        // a faulted activity must not halt the instance with an incident and produce
+        // NO outputs (which would let a caller read a stale/absent success). Continue
+        // with incidents + seed success=false up front so a fault that stops the flow
+        // before a terminal still yields a parseable, fail-closed result.
+        builder.WorkflowOptions.IncidentStrategyType = typeof(ContinueWithIncidentsStrategy);
+
+        // ================================================================
+        // Variables
+        // ================================================================
+        var repositoryVar = builder.WithVariable<string>("Repository", "");
+        var branchNameVar = builder.WithVariable<string>("BranchName", "");
+        var prNumberVar = builder.WithVariable<int>("PrNumber", 0);
+        var issueNumberVar = builder.WithVariable<int>("IssueNumber", 0);
+        var tenantIdVar = builder.WithVariable<string>("TenantId", "");
 
         var hasActionableVar = builder.WithVariable<bool>("HasActionable", false);
         var analysisJsonVar = builder.WithVariable<string>("AnalysisJson", "");
         var fixesAppliedVar = builder.WithVariable<bool>("FixesApplied", false);
+        var generateSucceededVar = builder.WithVariable<bool>("GenerateSucceeded", false);
+        var iterationVar = builder.WithVariable<int>("Iteration", 0);
         var fixResultVar = builder.WithVariable<ReviewFixResult?>();
         var llmResultVar = builder.WithVariable<IDictionary<string, object>?>();
 
+        // ================================================================
+        // 0. Seed the fail-closed default outcome (success=false)
+        // ================================================================
+        var defaultOutcome = new SetOutput
+        {
+            Id = "DefaultOutcome",
+            OutputName = new("success"),
+            OutputValue = new(_ => (object)false),
+        };
+        defaultOutcome.SetDisplayText("Default Outcome = success:false");
+
+        // ================================================================
+        // 1. Read inputs into variables
+        // ================================================================
+        var readInputs = new SetVariable
+        {
+            Id = "ReadInputs", Name = "Read Inputs",
+            Variable = repositoryVar,
+            Value = new Input<object?>(ctx =>
+            {
+                var repo = ctx.GetInput<string>("repository") ?? "";
+                branchNameVar.Set(ctx, ctx.GetInput<string>("branchName") ?? "");
+                prNumberVar.Set(ctx, ctx.GetInput<int>("prNumber"));
+                issueNumberVar.Set(ctx, ctx.GetInput<int>("issueNumber"));
+                tenantIdVar.Set(ctx, ctx.GetInput<string>("tenantId") ?? "");
+                return (object)repo;
+            })
+        };
+        readInputs.SetDisplayText("Read Inputs");
+
+        // ================================================================
+        // 2. Analyze review comments
+        // ================================================================
         var analyze = new AnalyzeReviewActivity
         {
             Id = "AnalyzeReview", Name = "Analyze Review",
-            Repository = new Input<string>(ctx => ctx.GetInput<string>("repository") ?? ""),
-            PrNumber = new Input<int>(ctx => ctx.GetInput<int>("prNumber")),
+            Repository = new Input<string>(ctx => repositoryVar.Get(ctx)),
+            PrNumber = new Input<int>(ctx => prNumberVar.Get(ctx)),
             HasActionableComments = new Output<bool>(hasActionableVar),
             AnalysisJson = new Output<string?>(analysisJsonVar)
         };
         analyze.SetDisplayText("Analyze Review");
 
+        var emitAnalyzeSuccess = EmitEvent(
+            "EmitAnalyzeSuccess", "Emit REVIEW_FIX.ANALYZED.SUCCESS",
+            ReviewFixEvents.AnalyzedSuccess, repositoryVar, prNumberVar, issueNumberVar, tenantIdVar,
+            ctx => JsonSerializer.Serialize(new Dictionary<string, object?>
+            {
+                ["hasActionable"] = hasActionableVar.Get(ctx),
+            }));
+
+        var emitAnalyzeFailed = EmitEvent(
+            "EmitAnalyzeFailed", "Emit REVIEW_FIX.ANALYZED.FAILED",
+            ReviewFixEvents.AnalyzedFailed, repositoryVar, prNumberVar, issueNumberVar, tenantIdVar,
+            _ => JsonSerializer.Serialize(new Dictionary<string, object?> { ["errorReason"] = "analysis_failed" }));
+
         var hasActionable = new FlowDecision(ctx => hasActionableVar.Get(ctx))
         { Id = "HasActionable", Name = "Has Actionable?" };
         hasActionable.SetDisplayText("Has Actionable?");
 
+        // ================================================================
+        // 3. Graph-enforced iteration bound — increment then cap-check BEFORE
+        //    generating fixes. Over the cap → escalate (loud), never loop forever.
+        // ================================================================
+        var incrementIteration = new SetVariable
+        {
+            Id = "IncrementIteration", Name = "Increment Iteration",
+            Variable = iterationVar,
+            Value = new Input<object?>(ctx => (object)(iterationVar.Get(ctx) + 1)),
+        };
+        incrementIteration.SetDisplayText("Increment Iteration");
+
+        var maxIterations = new FlowDecision(ctx => iterationVar.Get(ctx) >= MaxIterations)
+        { Id = "MaxIterations", Name = "Max Iterations?" };
+        maxIterations.SetDisplayText("Max Iterations?");
+
+        var emitEscalated = EmitEvent(
+            "EmitEscalated", "Emit REVIEW_FIX.ESCALATED",
+            ReviewFixEvents.Escalated, repositoryVar, prNumberVar, issueNumberVar, tenantIdVar,
+            ctx => JsonSerializer.Serialize(new Dictionary<string, object?>
+            {
+                ["errorReason"] = "iteration_cap_exceeded",
+                ["iterations"] = iterationVar.Get(ctx),
+                ["maxIterations"] = MaxIterations,
+            }));
+
+        // ================================================================
+        // 4. Generate fixes via the mediated llm-call workflow
+        //    (DispatchFixGeneration id + developer/address-review-comments are
+        //    asserted by the taxonomy-drift guard — keep them stable.)
+        // ================================================================
         var generateFixes = new DispatchWorkflow
         {
             Id = "DispatchFixGeneration", Name = "Generate Fixes",
@@ -55,19 +224,64 @@ public class ReviewFixWorkflow : WorkflowBase
                 ["agentRole"] = AgentRole.Developer.ToWire(),
                 ["action"] = AgentAction.AddressReviewComments.ToWire(),
                 ["taskPrompt"] = $"Apply fixes for the following review comments:\n{SecurityHelpers.SanitizeForPrompt(analysisJsonVar.Get(ctx))}",
-                ["sessionId"] = $"adl-review-fix-{ctx.GetInput<int>("prNumber")}"
+                ["sessionId"] = $"adl-review-fix-{ctx.GetInput<int>("prNumber")}",
+                ["tenantId"] = tenantIdVar.Get(ctx),
             }),
             WaitForCompletion = new(true),
             Result = new(llmResultVar)
         };
         generateFixes.SetDisplayText("Generate Fixes");
 
+        // Read the dispatched llm-call's `success` output (CRITICAL — a failed
+        // generation must NOT flow into apply as a false success).
+        var extractGenerateSuccess = new SetVariable
+        {
+            Id = "ExtractGenerateSuccess", Name = "Extract Generate Success",
+            Variable = generateSucceededVar,
+            Value = new Input<object?>(ctx =>
+            {
+                var result = llmResultVar.Get(ctx);
+                if (result != null && result.TryGetValue("success", out var s))
+                {
+                    return (object)(s switch
+                    {
+                        bool b => b,
+                        string str => bool.TryParse(str, out var r) && r,
+                        _ => false,
+                    });
+                }
+                // No readable success flag → treat as a failed generation (never a
+                // silent success).
+                return (object)false;
+            }),
+        };
+        extractGenerateSuccess.SetDisplayText("Extract Generate Success");
+
+        var generateSucceeded = new FlowDecision(ctx => generateSucceededVar.Get(ctx))
+        { Id = "GenerateSucceeded", Name = "Generate Succeeded?" };
+        generateSucceeded.SetDisplayText("Generate Succeeded?");
+
+        var emitGenerateSuccess = EmitEvent(
+            "EmitGenerateSuccess", "Emit REVIEW_FIX.GENERATED.SUCCESS",
+            ReviewFixEvents.GeneratedSuccess, repositoryVar, prNumberVar, issueNumberVar, tenantIdVar,
+            ctx => JsonSerializer.Serialize(BuildLlmUsageData(llmResultVar.Get(ctx))));
+
+        var emitGenerateFailed = EmitEvent(
+            "EmitGenerateFailed", "Emit REVIEW_FIX.GENERATED.FAILED",
+            ReviewFixEvents.GeneratedFailed, repositoryVar, prNumberVar, issueNumberVar, tenantIdVar,
+            _ => JsonSerializer.Serialize(new Dictionary<string, object?> { ["errorReason"] = "fix_generation_failed" }));
+
+        // ================================================================
+        // 5. Apply the generated fix (LLM response provided by the dispatch above —
+        //    no direct-LLM fallback is exercised here; removing that fallback from
+        //    the activity is 32-5 T6's job).
+        // ================================================================
         var applyFixes = new ApplyReviewFixesActivity
         {
             Id = "ApplyFixes", Name = "Apply Fixes",
             AnalysisJson = new Input<string>(ctx => analysisJsonVar.Get(ctx)),
-            Repository = new Input<string>(ctx => ctx.GetInput<string>("repository") ?? ""),
-            BranchName = new Input<string>(ctx => ctx.GetInput<string>("branchName") ?? ""),
+            Repository = new Input<string>(ctx => repositoryVar.Get(ctx)),
+            BranchName = new Input<string>(ctx => branchNameVar.Get(ctx)),
             LlmFixResponse = new Input<string?>(ctx =>
             {
                 var result = llmResultVar.Get(ctx);
@@ -80,12 +294,43 @@ public class ReviewFixWorkflow : WorkflowBase
         };
         applyFixes.SetDisplayText("Apply Fixes");
 
-        // Pass fixed file paths from the fix result to the code indexer;
-        // falls back to git-diff detection if no files are available.
+        // A "Fixed" outcome is gated on whether files were actually applied — a
+        // Fixed-but-fixesApplied=false response is NOT a silent success.
+        var fixesAppliedCheck = new FlowDecision(ctx => fixesAppliedVar.Get(ctx))
+        { Id = "FixesApplied", Name = "Fixes Applied?" };
+        fixesAppliedCheck.SetDisplayText("Fixes Applied?");
+
+        var emitApplySuccess = EmitEvent(
+            "EmitApplySuccess", "Emit REVIEW_FIX.APPLIED.SUCCESS",
+            ReviewFixEvents.AppliedSuccess, repositoryVar, prNumberVar, issueNumberVar, tenantIdVar,
+            ctx =>
+            {
+                var fixResult = fixResultVar.Get(ctx);
+                return JsonSerializer.Serialize(new Dictionary<string, object?>
+                {
+                    ["filesFixed"] = fixResult?.FilesFixed?.Count ?? 0,
+                });
+            });
+
+        var emitApplyFailed = EmitEvent(
+            "EmitApplyFailed", "Emit REVIEW_FIX.APPLIED.FAILED",
+            ReviewFixEvents.AppliedFailed, repositoryVar, prNumberVar, issueNumberVar, tenantIdVar,
+            ctx =>
+            {
+                var fixResult = fixResultVar.Get(ctx);
+                return JsonSerializer.Serialize(new Dictionary<string, object?>
+                {
+                    ["errorReason"] = "fix_apply_failed",
+                    ["error"] = fixResult?.ErrorMessage ?? "",
+                });
+            });
+
+        // ================================================================
+        // 6. Update the code index for the changed files (best-effort indexer POST)
+        // ================================================================
         var updateCodeIndex = new UpdateCodeIndexActivity
         {
-            Id = "UpdateCodeIndex",
-            Name = "Update Code Index",
+            Id = "UpdateCodeIndex", Name = "Update Code Index",
             ChangedFilesJson = new Input<string?>(ctx =>
             {
                 var fixResult = fixResultVar.Get(ctx);
@@ -93,35 +338,144 @@ public class ReviewFixWorkflow : WorkflowBase
                     return JsonSerializer.Serialize(fixResult.FilesFixed);
                 return null;
             }),
-            RepositoryPath = new Input<string?>(ctx => ctx.GetInput<string>("repository"))
+            RepositoryPath = new Input<string?>(ctx => repositoryVar.Get(ctx))
         };
         updateCodeIndex.SetDisplayText("Update Code Index");
 
-        var outputSuccess = new SetOutput { Id = "OutputSuccess", Name = "Output Success", OutputName = new("success"), OutputValue = new(ctx => (object)true) };
+        // ================================================================
+        // 7. Terminals — distinct success / failure output sequences. `success`
+        //    reflects reality (never a constant true), and the failure terminal
+        //    surfaces an errorReason.
+        // ================================================================
+        var outputSuccess = new Sequence
+        {
+            Id = "OutputSuccess", Name = "Output Success",
+            Activities =
+            {
+                WithLabel(new SetOutput { Id = "OutputSuccess_Success", OutputName = new("success"), OutputValue = new(_ => (object)true) }, "Output success=true"),
+                WithLabel(new SetOutput { Id = "OutputSuccess_HasComments", OutputName = new("hasComments"), OutputValue = new(ctx => (object)hasActionableVar.Get(ctx)) }, "Output hasComments"),
+                WithLabel(new SetOutput { Id = "OutputSuccess_FixesApplied", OutputName = new("fixesApplied"), OutputValue = new(ctx => (object)fixesAppliedVar.Get(ctx)) }, "Output fixesApplied"),
+                WithLabel(new SetOutput { Id = "OutputSuccess_FilesFixed", OutputName = new("filesFixedCount"), OutputValue = new(ctx => (object)(fixResultVar.Get(ctx)?.FilesFixed?.Count ?? 0)) }, "Output filesFixedCount"),
+            }
+        };
         outputSuccess.SetDisplayText("Output Success");
-        var outputHasComments = new SetOutput { Id = "OutputHasComments", Name = "Output Has Comments", OutputName = new("hasComments"), OutputValue = new(ctx => (object)hasActionableVar.Get(ctx)) };
-        outputHasComments.SetDisplayText("Output Has Comments");
-        var outputFixesApplied = new SetOutput { Id = "OutputFixesApplied", Name = "Output Fixes Applied", OutputName = new("fixesApplied"), OutputValue = new(ctx => (object)fixesAppliedVar.Get(ctx)) };
-        outputFixesApplied.SetDisplayText("Output Fixes Applied");
 
+        var outputFailure = new Sequence
+        {
+            Id = "OutputFailure", Name = "Output Failure",
+            Activities =
+            {
+                WithLabel(new SetOutput { Id = "OutputFailure_Success", OutputName = new("success"), OutputValue = new(_ => (object)false) }, "Output success=false"),
+                WithLabel(new SetOutput { Id = "OutputFailure_HasComments", OutputName = new("hasComments"), OutputValue = new(ctx => (object)hasActionableVar.Get(ctx)) }, "Output hasComments"),
+                WithLabel(new SetOutput { Id = "OutputFailure_FixesApplied", OutputName = new("fixesApplied"), OutputValue = new(ctx => (object)fixesAppliedVar.Get(ctx)) }, "Output fixesApplied"),
+                WithLabel(new SetOutput { Id = "OutputFailure_ErrorReason", OutputName = new("errorReason"), OutputValue = new(_ => (object)"review_fix_failed") }, "Output errorReason"),
+            }
+        };
+        outputFailure.SetDisplayText("Output Failure");
+
+        var finish = new Finish { Id = "Finish", Name = "Complete" };
+        finish.SetDisplayText("Complete");
+
+        // ================================================================
+        // Flowchart — every outcome routed to a terminal, no dangling edge / deadlock
+        // ================================================================
         builder.Root = new Flowchart
         {
             Id = "ReviewFixFlowchart",
             Name = "Review Fix Flowchart",
-            Start = analyze,
-            Activities = { analyze, hasActionable, generateFixes, applyFixes, updateCodeIndex, outputSuccess, outputHasComments, outputFixesApplied },
+            Start = defaultOutcome,
+            Activities =
+            {
+                defaultOutcome, readInputs, analyze,
+                emitAnalyzeSuccess, emitAnalyzeFailed, hasActionable,
+                incrementIteration, maxIterations, emitEscalated,
+                generateFixes, extractGenerateSuccess, generateSucceeded,
+                emitGenerateSuccess, emitGenerateFailed,
+                applyFixes, fixesAppliedCheck, emitApplySuccess, emitApplyFailed,
+                updateCodeIndex,
+                outputSuccess, outputFailure, finish,
+            },
             Connections =
             {
-                Connect(analyze, hasActionable),
-                ConnectOutcome(hasActionable, "True", generateFixes),
-                Connect(generateFixes, applyFixes),
-                Connect(applyFixes, updateCodeIndex),
-                Connect(updateCodeIndex, outputSuccess),
+                Connect(defaultOutcome, readInputs),
+                Connect(readInputs, analyze),
+
+                // ── Analyze ──
+                ConnectOutcome(analyze, "Done", emitAnalyzeSuccess),
+                Connect(emitAnalyzeSuccess, hasActionable),
+                ConnectOutcome(analyze, "Error", emitAnalyzeFailed),
+                Connect(emitAnalyzeFailed, outputFailure),
+
+                // ── No actionable comments → genuine success (nothing to fix) ──
                 ConnectOutcome(hasActionable, "False", outputSuccess),
-                Connect(outputSuccess, outputHasComments),
-                Connect(outputHasComments, outputFixesApplied)
+
+                // ── Actionable → graph-enforced loop bound ──
+                ConnectOutcome(hasActionable, "True", incrementIteration),
+                Connect(incrementIteration, maxIterations),
+                ConnectOutcome(maxIterations, "True", emitEscalated),   // over cap → loud escalate
+                Connect(emitEscalated, outputFailure),
+                ConnectOutcome(maxIterations, "False", generateFixes),  // under cap → generate
+
+                // ── Generate fixes → read success → branch ──
+                Connect(generateFixes, extractGenerateSuccess),
+                Connect(extractGenerateSuccess, generateSucceeded),
+                ConnectOutcome(generateSucceeded, "False", emitGenerateFailed),
+                Connect(emitGenerateFailed, outputFailure),
+                ConnectOutcome(generateSucceeded, "True", emitGenerateSuccess),
+                Connect(emitGenerateSuccess, applyFixes),
+
+                // ── Apply fixes → fail-closed branch ──
+                ConnectOutcome(applyFixes, "Error", emitApplyFailed),
+                ConnectOutcome(applyFixes, "Fixed", fixesAppliedCheck),
+                ConnectOutcome(fixesAppliedCheck, "False", emitApplyFailed),
+                Connect(emitApplyFailed, outputFailure),
+                ConnectOutcome(fixesAppliedCheck, "True", emitApplySuccess),
+                Connect(emitApplySuccess, updateCodeIndex),
+                Connect(updateCodeIndex, outputSuccess),
+
+                // ── Terminals → finish ──
+                Connect(outputSuccess, finish),
+                Connect(outputFailure, finish),
             }
         };
+    }
+
+    /// <summary>
+    /// A <c>REVIEW_FIX.*</c> event-emit node carrying the repo / pr / issue / tenant
+    /// context plus a per-edge JSON data payload.
+    /// </summary>
+    private static EmitReviewFixEventActivity EmitEvent(
+        string id, string label, string eventType,
+        Variable<string> repository, Variable<int> prNumber, Variable<int> issueNumber,
+        Variable<string> tenantId,
+        Func<Elsa.Expressions.Models.ExpressionExecutionContext, string?> dataJson)
+    {
+        var emit = new EmitReviewFixEventActivity
+        {
+            Id = id, Name = label,
+            EventType = new Input<string>(_ => eventType),
+            Repository = new Input<string?>(ctx => repository.Get(ctx)),
+            PrNumber = new Input<int>(ctx => prNumber.Get(ctx)),
+            IssueNumber = new Input<int>(ctx => issueNumber.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
+            DataJson = new Input<string?>(dataJson),
+        };
+        emit.SetDisplayText(label);
+        return emit;
+    }
+
+    /// <summary>
+    /// Extract the provider / cost / token usage the dispatched <c>llm-call</c>
+    /// surfaces on its result dictionary, for the GENERATED.SUCCESS event payload.
+    /// </summary>
+    private static Dictionary<string, object?> BuildLlmUsageData(IDictionary<string, object>? llmResult)
+    {
+        var data = new Dictionary<string, object?>();
+        if (llmResult == null) return data;
+        if (llmResult.TryGetValue("providerUsed", out var p)) data["provider"] = p?.ToString();
+        if (llmResult.TryGetValue("costUsd", out var c)) data["costUsd"] = c;
+        if (llmResult.TryGetValue("tokensUsed", out var t)) data["tokensUsed"] = t;
+        return data;
     }
 
     private static FlowConnection Connect(IActivity source, IActivity target)

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ReviewFixWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ReviewFixWorkflow.cs
@@ -31,12 +31,19 @@ namespace Tamma.ElsaServer.Workflows;
 /// makes the load-bearing guarantees graph-enforced:</para>
 ///
 /// <list type="bullet">
-///   <item><description><b>Graph-enforced iteration bound</b> — a
-///     <see cref="FlowDecision"/> caps the fix loop (<c>&gt;=MaxIterations</c> →
-///     escalate terminal), mirroring the merge-approval test-loop cap and
-///     <c>PlanMaxRevisions</c>/<c>TaskMaxRevisions</c>. Over the cap the workflow
-///     ESCALATES (loud, <c>REVIEW_FIX.ESCALATED</c>, <c>success=false</c>) instead of
-///     spinning forever or reporting a silent success.</description></item>
+///   <item><description><b>Forward-installed iteration-bound scaffolding</b> — an
+///     <c>Iteration</c> counter, a <c>MaxIterations</c> cap <see cref="FlowDecision"/>
+///     (<c>&gt;=MaxIterations</c> → <c>REVIEW_FIX.ESCALATED</c> failure terminal), and
+///     the escalate edge are wired AHEAD of the verify→regenerate retry loop they are
+///     meant to bound. There is NO back-edge today — the connections are strictly
+///     forward, so each invocation runs the analyze→generate→apply path at most once
+///     and the counter only ever reaches 1; the <c>&gt;=MaxIterations</c> cap therefore
+///     does NOT fire at runtime yet (it is structure, not yet a live loop guard). The
+///     escalate path becomes load-bearing only once the verify loop-back lands (the
+///     real file-write / verify / CI-retrigger step, deferred to Epic 38) and feeds a
+///     failed verification back to <c>IncrementIteration</c>. The cap mirrors the
+///     <c>PlanMaxRevisions</c>/<c>TaskMaxRevisions</c> / merge-approval test-loop bound
+///     so the eventual loop bounds out the same way.</description></item>
 ///   <item><description><b>Explicit error / exhaustion path</b> —
 ///     <c>AnalyzeReview</c>'s <c>Error</c> outcome and a failed <c>llm-call</c>
 ///     (<c>success=false</c>, read from the dispatch result) each route to a loud
@@ -87,10 +94,15 @@ namespace Tamma.ElsaServer.Workflows;
 public class ReviewFixWorkflow : WorkflowBase
 {
     /// <summary>
-    /// Max fix-generation attempts before escalating — mirrors PlanMaxRevisions /
+    /// Forward-installed cap on fix-generation attempts, mirroring PlanMaxRevisions /
     /// TaskMaxRevisions (&gt;=3) in SingleIssueCycleWorkflow and the merge-approval
-    /// test-loop cap, so the fix loop can never spin forever.
+    /// test-loop cap. NOTE: this cap is scaffolding — the verify→regenerate back-edge
+    /// it would bound does not exist yet (deferred to Epic 38), so today the counter
+    /// only reaches 1 and the <c>&gt;=MaxIterations</c> check never trips at runtime.
+    /// It becomes the live loop bound once the verify loop-back is wired.
     /// </summary>
+    // TODO(Epic 38): wire the verify→regenerate back-edge (failed verification →
+    // IncrementIteration) that this cap is meant to bound; until then there is no loop.
     private const int MaxIterations = 3;
 
     protected override void Build(IWorkflowBuilder builder)
@@ -185,8 +197,11 @@ public class ReviewFixWorkflow : WorkflowBase
         hasActionable.SetDisplayText("Has Actionable?");
 
         // ================================================================
-        // 3. Graph-enforced iteration bound — increment then cap-check BEFORE
-        //    generating fixes. Over the cap → escalate (loud), never loop forever.
+        // 3. Iteration-bound scaffolding — increment then cap-check BEFORE generating
+        //    fixes. This is forward-installed for the verify→regenerate retry loop
+        //    (deferred to Epic 38); with no back-edge today the counter only reaches 1,
+        //    so the >=MaxIterations cap is structure, not a live runtime guard yet. The
+        //    escalate path goes load-bearing once the verify loop-back lands.
         // ================================================================
         var incrementIteration = new SetVariable
         {
@@ -224,7 +239,7 @@ public class ReviewFixWorkflow : WorkflowBase
                 ["agentRole"] = AgentRole.Developer.ToWire(),
                 ["action"] = AgentAction.AddressReviewComments.ToWire(),
                 ["taskPrompt"] = $"Apply fixes for the following review comments:\n{SecurityHelpers.SanitizeForPrompt(analysisJsonVar.Get(ctx))}",
-                ["sessionId"] = $"adl-review-fix-{ctx.GetInput<int>("prNumber")}",
+                ["sessionId"] = $"adl-review-fix-{prNumberVar.Get(ctx)}",
                 ["tenantId"] = tenantIdVar.Get(ctx),
             }),
             WaitForCompletion = new(true),
@@ -409,12 +424,12 @@ public class ReviewFixWorkflow : WorkflowBase
                 // ── No actionable comments → genuine success (nothing to fix) ──
                 ConnectOutcome(hasActionable, "False", outputSuccess),
 
-                // ── Actionable → graph-enforced loop bound ──
+                // ── Actionable → iteration-bound scaffolding (forward-only today) ──
                 ConnectOutcome(hasActionable, "True", incrementIteration),
                 Connect(incrementIteration, maxIterations),
-                ConnectOutcome(maxIterations, "True", emitEscalated),   // over cap → loud escalate
+                ConnectOutcome(maxIterations, "True", emitEscalated),   // over cap → loud escalate (only reachable once the Epic-38 verify back-edge exists)
                 Connect(emitEscalated, outputFailure),
-                ConnectOutcome(maxIterations, "False", generateFixes),  // under cap → generate
+                ConnectOutcome(maxIterations, "False", generateFixes),  // under cap → generate (always taken today: counter==1)
 
                 // ── Generate fixes → read success → branch ──
                 Connect(generateFixes, extractGenerateSuccess),

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/ReviewFixWorkflowTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/ReviewFixWorkflowTests.cs
@@ -1,0 +1,373 @@
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Management.Activities.SetOutput;
+using Elsa.Workflows.Runtime.Activities;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Build-out structure coverage for the <c>review-fix</c> workflow (Story 2-18
+/// Phases 4 &amp; 5 / Story 2-9). Asserts the load-bearing guarantees of the
+/// build-out:
+/// <list type="bullet">
+///   <item><description>a <b>graph-enforced</b> iteration bound on the fix loop —
+///     over the cap routes to a loud escalate terminal (not an activity-internal
+///     bound, not an infinite loop, not a silent success);</description></item>
+///   <item><description>an explicit failure / exhaustion path — <c>AnalyzeReview</c>'s
+///     <c>Error</c> outcome and a failed <c>llm-call</c> route to a loud
+///     <c>OutputFailure</c> terminal (never fall through to success);</description></item>
+///   <item><description>fail-closed apply — a failed fix-apply
+///     (<c>fixesApplied=false</c> or the activity's <c>Error</c> outcome) routes
+///     to <c>OutputFailure</c>, never reports <c>success=true</c>;</description></item>
+///   <item><description><c>REVIEW_FIX.*</c> DCB events emitted on every meaningful
+///     edge;</description></item>
+///   <item><description>every outcome is routed (no dangling edge / no
+///     deadlock).</description></item>
+/// </list>
+///
+/// <para>Inspects the BUILT Flowchart via <see cref="WorkflowTestHelper"/> (the
+/// codebase convention — see MergeApprovalWorkflowTests / PullRequestWorkflowTests)
+/// rather than running the full Elsa runtime.</para>
+/// </summary>
+[TestFixture]
+public class ReviewFixWorkflowTests
+{
+    private Flowchart _flowchart = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new ReviewFixWorkflow());
+        _flowchart = WorkflowTestHelper.GetFlowchart(builder);
+    }
+
+    // ================================================================
+    // Identity
+    // ================================================================
+
+    [Test]
+    public void Workflow_BuildsWithExpectedDefinitionId()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new ReviewFixWorkflow());
+        builder.Object.DefinitionId.Should().Be("review-fix");
+    }
+
+    [Test]
+    public void Workflow_HasTenantIdVariable()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new ReviewFixWorkflow());
+        builder.Object.Variables.Any(v => v.Name == "TenantId").Should().BeTrue(
+            "review-fix must carry a TenantId so REVIEW_FIX.* events are metered to the right tenant");
+    }
+
+    [Test]
+    public void AllActivities_HaveDisplayText()
+    {
+        foreach (var activity in WorkflowTestHelper.GetAllActivities(_flowchart))
+        {
+            activity.GetDisplayText().Should().NotBeNullOrEmpty(
+                $"Activity '{activity.GetType().Name}' (Id: {activity.Id}) should have DisplayText set");
+        }
+    }
+
+    // ================================================================
+    // The dispatched llm-call fix-generation is preserved (taxonomy drift guard
+    // depends on DispatchFixGeneration emitting developer/address-review-comments)
+    // ================================================================
+
+    [Test]
+    public void FixGeneration_DispatchesLlmCall_NotADirectProviderCall()
+    {
+        var dispatch = _flowchart.Activities
+            .OfType<DispatchWorkflow>()
+            .FirstOrDefault(d => d.Id == "DispatchFixGeneration");
+        dispatch.Should().NotBeNull("fix generation must route through the mediated llm-call workflow");
+        ReadDefinitionId(dispatch!).Should().Be("llm-call",
+            "the LLM must stay mediated via llm-call — no direct provider call in a step");
+    }
+
+    // ================================================================
+    // Graph-enforced iteration bound — over the cap escalates (loud), not infinite
+    // ================================================================
+
+    [Test]
+    public void FixLoop_IsGraphEnforced_IncrementsThenChecksCap()
+    {
+        // The cap must be a FlowDecision IN THE GRAPH (not an activity-internal
+        // bound) reached BEFORE the fix is generated.
+        HasEdge("HasActionable", "True", "IncrementIteration").Should().BeTrue(
+            "an actionable analysis must increment the iteration counter before generating fixes");
+        HasEdge("IncrementIteration", null, "MaxIterations").Should().BeTrue(
+            "after incrementing, the loop must check the iteration cap in the graph");
+
+        _flowchart.Activities.OfType<FlowDecision>()
+            .Any(fd => fd.Id == "MaxIterations")
+            .Should().BeTrue("the iteration bound must be a graph FlowDecision, not buried in an activity");
+    }
+
+    [Test]
+    public void FixLoop_UnderCap_GeneratesFixes()
+    {
+        HasEdge("MaxIterations", "False", "DispatchFixGeneration").Should().BeTrue(
+            "under the cap the loop generates fixes via llm-call");
+    }
+
+    [Test]
+    public void FixLoop_OverCap_EscalatesToLoudTerminal_NotSilentSuccess()
+    {
+        HasEdge("MaxIterations", "True", "EmitEscalated").Should().BeTrue(
+            "over the iteration cap the fix loop must escalate (loud), not loop forever or succeed silently");
+
+        var overCapReach = ReachableFromPort("MaxIterations", "True");
+        // The escalation must reach the FAILURE terminal, never the success terminal.
+        overCapReach.Should().Contain("OutputFailure",
+            "an exhausted fix loop must reach the loud failure terminal");
+        overCapReach.Should().NotContain("OutputSuccess",
+            "an exhausted fix loop must NEVER reach the success terminal");
+        overCapReach.Should().NotContain("DispatchFixGeneration",
+            "the over-cap path must not re-generate fixes");
+    }
+
+    [Test]
+    public void Escalated_IsAFailureEvent_ErrorStatus()
+    {
+        ReviewFixEvents.IsFailureEvent(ReviewFixEvents.Escalated)
+            .Should().BeTrue("REVIEW_FIX.ESCALATED must be an error-status audit event");
+    }
+
+    // ================================================================
+    // Explicit error path — AnalyzeReview.Error and a failed llm-call route loud
+    // ================================================================
+
+    [Test]
+    public void AnalyzeError_RoutesToLoudFailureTerminal_NotDeadEnd()
+    {
+        HasEdge("AnalyzeReview", "Error", "EmitAnalyzeFailed").Should().BeTrue(
+            "AnalyzeReview's Error outcome must emit REVIEW_FIX.ANALYZED.FAILED — not be a dead end");
+
+        var errReach = Reachable("EmitAnalyzeFailed");
+        errReach.Should().Contain("OutputFailure",
+            "an analysis error must reach the loud failure terminal");
+        errReach.Should().NotContain("OutputSuccess",
+            "an analysis error must never reach the success terminal");
+    }
+
+    [Test]
+    public void FixGenerationFailure_RoutesToLoudFailureTerminal_NotApply()
+    {
+        // The llm-call `success` output is read and branched — a failed generation
+        // must NOT flow into "apply" as a false success.
+        HasEdge("DispatchFixGeneration", null, "ExtractGenerateSuccess").Should().BeTrue(
+            "the workflow must read the llm-call success output");
+        HasEdge("ExtractGenerateSuccess", null, "GenerateSucceeded").Should().BeTrue();
+        HasEdge("GenerateSucceeded", "False", "EmitGenerateFailed").Should().BeTrue(
+            "a failed llm-call must emit REVIEW_FIX.GENERATED.FAILED");
+
+        var genFailReach = Reachable("EmitGenerateFailed");
+        genFailReach.Should().Contain("OutputFailure");
+        genFailReach.Should().NotContain("ApplyFixes",
+            "a failed llm-call must never flow into apply as a false success");
+        genFailReach.Should().NotContain("OutputSuccess");
+    }
+
+    [Test]
+    public void FixGenerationSuccess_EmitsEvent_ThenApplies()
+    {
+        HasEdge("GenerateSucceeded", "True", "EmitGenerateSuccess").Should().BeTrue();
+        HasEdge("EmitGenerateSuccess", null, "ApplyFixes").Should().BeTrue(
+            "a successful generation flows into the apply step");
+    }
+
+    // ================================================================
+    // Fail-closed apply — a failed apply is NOT a silent success
+    // ================================================================
+
+    [Test]
+    public void ApplyFixesFailure_RoutesToLoudFailureTerminal_NotSuccess()
+    {
+        // The apply activity's own Error outcome is loud.
+        HasEdge("ApplyFixes", "Error", "EmitApplyFailed").Should().BeTrue(
+            "ApplyFixes.Error must emit REVIEW_FIX.APPLIED.FAILED");
+
+        // And a "Fixed" outcome that nonetheless did not apply files
+        // (fixesApplied=false) is branched and treated as a failure — not a silent
+        // success.
+        HasEdge("ApplyFixes", "Fixed", "FixesApplied").Should().BeTrue(
+            "a Fixed outcome must be gated on whether files were actually applied");
+        HasEdge("FixesApplied", "False", "EmitApplyFailed").Should().BeTrue(
+            "fixesApplied=false must route to the loud failure terminal — never a silent success");
+
+        var applyFailReach = Reachable("EmitApplyFailed");
+        applyFailReach.Should().Contain("OutputFailure");
+        applyFailReach.Should().NotContain("OutputSuccess",
+            "a failed apply must never reach the success terminal");
+    }
+
+    [Test]
+    public void ApplyFixesSuccess_EmitsEvent_IndexesThenSucceeds()
+    {
+        HasEdge("FixesApplied", "True", "EmitApplySuccess").Should().BeTrue();
+        HasEdge("EmitApplySuccess", null, "UpdateCodeIndex").Should().BeTrue();
+
+        var applyOkReach = Reachable("EmitApplySuccess");
+        applyOkReach.Should().Contain("OutputSuccess",
+            "a successful apply must reach the success terminal");
+    }
+
+    // ================================================================
+    // No-actionable-comments — a genuine success terminal (nothing to fix)
+    // ================================================================
+
+    [Test]
+    public void NoActionableComments_RoutesToSuccessTerminal()
+    {
+        // No actionable comments is a genuine success (nothing to fix) — and it
+        // must NOT enter the fix loop.
+        var noActionableReach = ReachableFromPort("HasActionable", "False");
+        noActionableReach.Should().Contain("OutputSuccess");
+        noActionableReach.Should().NotContain("DispatchFixGeneration",
+            "no-actionable-comments must not generate fixes");
+    }
+
+    // ================================================================
+    // DCB events on every meaningful edge
+    // ================================================================
+
+    [Test]
+    public void EveryMeaningfulEdge_EmitsAReviewFixEvent()
+    {
+        var emitIds = _flowchart.Activities
+            .OfType<EmitReviewFixEventActivity>()
+            .Select(a => a.Id)
+            .ToList();
+
+        emitIds.Should().Contain("EmitAnalyzeSuccess");
+        emitIds.Should().Contain("EmitAnalyzeFailed");
+        emitIds.Should().Contain("EmitGenerateSuccess");
+        emitIds.Should().Contain("EmitGenerateFailed");
+        emitIds.Should().Contain("EmitApplySuccess");
+        emitIds.Should().Contain("EmitApplyFailed");
+        emitIds.Should().Contain("EmitEscalated");
+    }
+
+    // ================================================================
+    // Terminal hygiene — success is not a constant true; failure terminal exists
+    // ================================================================
+
+    [Test]
+    public void FailureTerminal_SetsSuccessFalse_AndAnErrorReason()
+    {
+        var outputFailure = _flowchart.Activities.OfType<Sequence>()
+            .FirstOrDefault(s => s.Id == "OutputFailure");
+        outputFailure.Should().NotBeNull("a loud failure terminal must exist (no silent success)");
+
+        var outputIds = outputFailure!.Activities.OfType<SetOutput>().Select(o => o.Id ?? "").ToList();
+        outputIds.Should().Contain("OutputFailure_Success",
+            "the failure terminal must set success=false");
+        outputIds.Should().Contain("OutputFailure_ErrorReason",
+            "the failure terminal must surface an errorReason");
+    }
+
+    [Test]
+    public void SuccessTerminal_Exists_AndIsDistinctFromFailure()
+    {
+        var success = _flowchart.Activities.OfType<Sequence>()
+            .FirstOrDefault(s => s.Id == "OutputSuccess");
+        success.Should().NotBeNull("a success terminal sequence must exist");
+
+        var failure = _flowchart.Activities.OfType<Sequence>()
+            .FirstOrDefault(s => s.Id == "OutputFailure");
+        failure.Should().NotBeNull();
+
+        success.Should().NotBeSameAs(failure, "success and failure must be distinct terminals");
+    }
+
+    [Test]
+    public void EveryActivity_IsReachableFromStart_NoDanglingNode()
+    {
+        // No node may be orphaned — every activity (besides the start) must be
+        // forward-reachable from the start, and every non-terminal must have an
+        // outgoing edge (no deadlock).
+        var start = (IActivity)_flowchart.Start!;
+        var reachable = Reachable(start.Id!);
+        reachable.Add(start.Id!);
+
+        var terminalTypes = new[] { typeof(Finish) };
+        foreach (var activity in _flowchart.Activities)
+        {
+            var id = activity.Id!;
+            reachable.Should().Contain(id, $"activity '{id}' must be reachable from the start (no orphan node)");
+
+            // Sequences are terminal output blocks (they end the flow); Finish is
+            // terminal. Everything else must have an outgoing edge.
+            var isTerminal = activity is Sequence || terminalTypes.Contains(activity.GetType());
+            if (!isTerminal)
+            {
+                _flowchart.Connections.Any(c => c.Source.Activity.Id == id)
+                    .Should().BeTrue($"non-terminal activity '{id}' must have an outgoing edge (no deadlock)");
+            }
+        }
+    }
+
+    // ================================================================
+    // Helpers
+    // ================================================================
+
+    private bool HasEdge(string sourceId, string? port, string targetId)
+        => _flowchart.Connections.Any(c =>
+            c.Source.Activity.Id == sourceId &&
+            (port == null || c.Source.Port == port) &&
+            c.Target.Activity.Id == targetId);
+
+    private HashSet<string> Reachable(string startId)
+    {
+        var seen = new HashSet<string>();
+        var queue = new Queue<string>();
+        queue.Enqueue(startId);
+        while (queue.Count > 0)
+        {
+            var id = queue.Dequeue();
+            foreach (var c in _flowchart.Connections.Where(c => c.Source.Activity.Id == id))
+            {
+                var t = c.Target.Activity.Id;
+                if (t != null && seen.Add(t)) queue.Enqueue(t);
+            }
+        }
+        return seen;
+    }
+
+    private HashSet<string> ReachableFromPort(string sourceId, string port)
+    {
+        var seen = new HashSet<string>();
+        var queue = new Queue<string>();
+        foreach (var c in _flowchart.Connections.Where(c =>
+            c.Source.Activity.Id == sourceId && c.Source.Port == port))
+        {
+            if (c.Target.Activity.Id is { } t && seen.Add(t)) queue.Enqueue(t);
+        }
+        while (queue.Count > 0)
+        {
+            var id = queue.Dequeue();
+            foreach (var c in _flowchart.Connections.Where(c => c.Source.Activity.Id == id))
+            {
+                if (c.Target.Activity.Id is { } t && seen.Add(t)) queue.Enqueue(t);
+            }
+        }
+        return seen;
+    }
+
+    private static string? ReadDefinitionId(DispatchWorkflow dispatch)
+    {
+        var prop = typeof(DispatchWorkflow).GetProperty("WorkflowDefinitionId");
+        var value = prop?.GetValue(dispatch);
+        var expression = value?.GetType().GetProperty("Expression")?.GetValue(value)
+            as Elsa.Expressions.Models.Expression;
+        return expression?.Value?.ToString();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TaxonomyDriftBuildTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TaxonomyDriftBuildTests.cs
@@ -143,15 +143,12 @@ public class TaxonomyDriftBuildTests
     private static readonly IReadOnlyDictionary<(string Workflow, string DispatchId), (string Role, string Action)>
         NonMaterializableSupplement = new Dictionary<(string, string), (string, string)>
         {
-            // ReviewFixWorkflow: ["sessionId"] = $"…{ctx.GetInput<int>("prNumber")}".
-            // Emits agentRole=developer, action=address-review-comments as constants.
-            // MANUAL-SYNC: this (role, action) pair must be kept in lockstep with the
-            // dispatch constants in ReviewFixWorkflow.cs (currently
-            // AgentRole.Developer.ToWire() / AgentAction.AddressReviewComments.ToWire()).
-            // The sync guard (NonMaterializableSupplement_StaysInSyncWithReality) only
-            // verifies the (workflow, dispatchId) KEY exists — it does NOT re-read the
-            // pair from source — so if those constants change, update this pair by hand.
-            [("ReviewFixWorkflow", "DispatchFixGeneration")] = ("developer", "address-review-comments"),
+            // (empty) — every dispatched (role, action) pair is now reflectable from the
+            // workflow source. ReviewFixWorkflow.DispatchFixGeneration was previously listed
+            // here (its sessionId/dispatch constants weren't reflectable), but the ReviewFix
+            // build-out made it materialise normally, so the manual supplement is no longer
+            // needed. The NonMaterializableSupplement_StaysInSyncWithReality guard enforces
+            // that this stays empty until a genuinely non-reflectable dispatch reappears.
         };
 
     private sealed record DispatchPair(string Workflow, string DispatchId, string Role, string Action);


### PR DESCRIPTION
`ReviewFixWorkflow` — thin → complete (leaf). Explicit error paths (analyze/generate/apply all fail-closed → loud `REVIEW_FIX.*.FAILED`, no silent success; `success` seeded false), `REVIEW_FIX.*` DCB events via the durable drain, `tenantId`. The iteration cap + `ESCALATED` terminal are **forward-scaffolding** for the verify→regenerate loop (the back-edge is deferred to Epic 38's real-apply/verify step — accurately documented, not oversold). `ApplyReviewFixes` direct-LLM repoint deferred to 32-5 T6. Reviewed: APPROVED (after the doc-honesty fix). Build 0 err; ReviewFix 24/0; full Activities 1579/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)