### PR TITLE
feat(workflows): build out TddWithDebugRetry — bounded loop + debugger short-circuit + events

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitTddDebugEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitTddDebugEventActivity.cs
@@ -1,0 +1,148 @@
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+
+namespace Tamma.Activities.ADL;
+
+/// <summary>
+/// Emits a <c>TDD_DEBUG.*</c> DCB event (completeness audit 2026-06-22,
+/// <c>TddWithDebugRetry.md</c> §Missing #3) for the built-out
+/// <c>tdd-with-debug-retry</c> orchestrator by appending a <see cref="TammaEvent"/>
+/// to the workflow's <c>tamma:events</c> transient list via
+/// <see cref="TammaEventEmitter.Emit"/>. The merged engine event drain
+/// (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) flushes that list
+/// <i>durably</i> to the tenant <c>domain_events</c> store after this activity runs
+/// — the drain resolves the tenant from the workflow scope (the orchestrator stamps
+/// a <c>TenantId</c> variable). The event therefore persists without this activity
+/// holding any DB / repository dependency of its own (none is registered in the Elsa
+/// engine — the same reason <see cref="EmitBranchEventActivity"/>,
+/// <see cref="EmitPrEventActivity"/> and <see cref="EmitTriageContextEventActivity"/>
+/// use the emitter rather than a direct <c>IEventRepository</c>).
+///
+/// <para>The orchestrator emits a <c>STARTED</c> before each cycle dispatch and a
+/// loud terminal (<c>RETRY.EXHAUSTED</c> / <c>DEBUGGER.ESCALATED</c> are error-status)
+/// so an exhausted retry loop or a debugger escalation is a LOUD audit row, never a
+/// silent false success.</para>
+/// </summary>
+[Activity(
+    "Tamma.ADL",
+    "Emit TDD Debug Event",
+    "Emit a TDD_DEBUG.* DCB event for the TDD-with-debug-retry audit trail",
+    Kind = ActivityKind.Task
+)]
+public class EmitTddDebugEventActivity : Activity
+{
+    private readonly ILogger<EmitTddDebugEventActivity>? _logger;
+
+    [Input(Description = "Event type — TDD_DEBUG.CYCLE.STARTED / .PASSED / .FAILED / .DEBUG.ATTEMPTED / .DEBUGGER.ESCALATED / .RETRY.EXHAUSTED / .COMPLETED.SUCCESS")]
+    public Input<string> EventType { get; set; } = default!;
+
+    [Input(Description = "Story id this TDD cycle implements")]
+    public Input<string?> StoryId { get; set; } = new((string?)null);
+
+    [Input(Description = "Issue number driving the cycle (0 when unknown)")]
+    public Input<int> IssueNumber { get; set; } = new(0);
+
+    [Input(Description = "Repository in owner/repo format")]
+    public Input<string?> Repository { get; set; } = new((string?)null);
+
+    [Input(Description = "Tenant id (empty / single-user → platform-scope event)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [Input(Description = "Current debug-retry attempt number (0 before the first retry)")]
+    public Input<int> Attempt { get; set; } = new(0);
+
+    [Input(Description = "Max debug-retry budget for the loop")]
+    public Input<int> MaxRetries { get; set; } = new(0);
+
+    [Input(Description = "Terminal failure reason (tdd-not-converged / debugger-escalated; empty on non-terminal events)")]
+    public Input<string?> FinishReason { get; set; } = new((string?)null);
+
+    [Input(Description = "Underlying TDD failure detail surfaced on a terminal failure (empty otherwise; never the raw planJson)")]
+    public Input<string?> ErrorDetail { get; set; } = new((string?)null);
+
+    [JsonConstructor]
+    public EmitTddDebugEventActivity() { }
+
+    public EmitTddDebugEventActivity(ILogger<EmitTddDebugEventActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var type = EventType.Get(context) ?? TddDebugEvents.RetryExhausted;
+        var storyId = StoryId.Get(context);
+        var issueNumber = IssueNumber.Get(context);
+        var repository = Repository.Get(context);
+        var tenantId = TddDebugEvents.ParseTenantId(TenantId.Get(context));
+        var attempt = Attempt.Get(context);
+        var maxRetries = MaxRetries.Get(context);
+        var finishReason = FinishReason.Get(context);
+        var errorDetail = ErrorDetail.Get(context);
+
+        var evt = BuildTammaEvent(type, storyId, issueNumber, repository, tenantId, attempt, maxRetries, finishReason, errorDetail);
+        TammaEventEmitter.Emit(context, this, _logger, evt);
+
+        _logger?.LogInformation(
+            "Emitted {Type} for story {Story} issue #{Issue} (attempt={Attempt}/{Max}, reason={Reason})",
+            type, storyId, issueNumber, attempt, maxRetries, finishReason);
+
+        return default;
+    }
+
+    /// <summary>
+    /// Map the TDD-debug inputs onto a <see cref="TammaEvent"/> expressed as the
+    /// engine's transient-list event so the merged drain persists it. Tags carry the
+    /// queryable DCB index keys (<c>storyId</c>/<c>issueId</c>/<c>issueNumber</c>/
+    /// <c>repository</c>/<c>attempt</c>/<c>tenantId</c>); <c>Data</c> carries the loop
+    /// payload (<c>attempt</c>/<c>maxRetries</c>/<c>finishReason</c>/<c>errorDetail</c>).
+    /// Status is driven off the event type (retry-exhausted / debugger-escalated →
+    /// error) so a degraded/failed terminal is never recorded as a false success.
+    /// Pure (no Elsa context); exposed for unit testing the mapping.
+    /// </summary>
+    public static TammaEvent BuildTammaEvent(
+        string type,
+        string? storyId,
+        int issueNumber,
+        string? repository,
+        Guid? tenantId,
+        int attempt,
+        int maxRetries,
+        string? finishReason,
+        string? errorDetail)
+    {
+        var tags = new Dictionary<string, object?>
+        {
+            ["attempt"] = attempt.ToString(),
+        };
+        if (!string.IsNullOrWhiteSpace(storyId)) tags["storyId"] = storyId;
+        if (issueNumber > 0)
+        {
+            tags["issueId"] = issueNumber.ToString();
+            tags["issueNumber"] = issueNumber.ToString();
+        }
+        if (!string.IsNullOrWhiteSpace(repository)) tags["repository"] = repository;
+        if (tenantId is not null) tags["tenantId"] = tenantId.Value.ToString("D");
+
+        var data = new Dictionary<string, object?>
+        {
+            ["attempt"] = attempt,
+            ["maxRetries"] = maxRetries,
+        };
+        if (!string.IsNullOrWhiteSpace(finishReason)) data["finishReason"] = finishReason;
+        if (!string.IsNullOrWhiteSpace(errorDetail)) data["errorDetail"] = errorDetail;
+
+        return new TammaEvent
+        {
+            EventType = type,
+            Status = TddDebugEvents.StatusForEvent(type),
+            Tags = tags,
+            Data = data,
+        };
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/TddDebugEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/TddDebugEvents.cs
@@ -1,0 +1,96 @@
+namespace Tamma.Activities.ADL;
+
+/// <summary>
+/// Completeness audit 2026-06-22 (<c>TddWithDebugRetry.md</c> §Missing #3) — central
+/// catalogue of the <c>TDD_DEBUG.*</c> DCB event types emitted by the built-out
+/// <c>tdd-with-debug-retry</c> workflow via <see cref="EmitTddDebugEventActivity"/>.
+/// Type pattern follows the platform's <c>AGGREGATE.ACTION.STATUS</c> convention
+/// (<c>CLAUDE.md</c>) and mirrors the sibling event catalogues
+/// (<see cref="BranchEvents"/>, <see cref="PrEvents"/>, <see cref="TriageContextEvents"/>).
+///
+/// <para>The <c>tdd-with-debug-retry</c> workflow is a pivot-clean <i>orchestrator</i>:
+/// it dispatches the <c>tdd-cycle</c> red-green-refactor sub-workflow inside a
+/// graph-enforced debug-retry loop (bounded by <c>maxRetries</c>), and on a TDD
+/// failure dispatches the <c>debugging</c> sub-workflow before re-running the cycle.
+/// Each loop boundary is an auditable event so time-travel debugging can reconstruct
+/// <i>why</i> an issue cycle stalled in TDD — whether the cycle converged, how many
+/// debug attempts were burned, whether the debugger escalated, and whether the loop
+/// exhausted its retry budget. Without these the orchestrator's retry decisions are
+/// invisible to the audit trail.</para>
+///
+/// <para>Events are emitted via <c>TammaEventEmitter.Emit</c> into the workflow's
+/// <c>tamma:events</c> transient list and persisted <i>durably</i> by the engine
+/// event drain (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) — the same
+/// pattern <see cref="EmitBranchEventActivity"/> and <see cref="EmitPrEventActivity"/>
+/// use. No activity holds a DB / repository dependency of its own (none is registered
+/// in the Elsa engine — a directly-injected <c>IEventRepository</c> would be inert and
+/// silently drop every event). The drain resolves the tenant from the workflow's
+/// <c>TenantId</c> variable, so a SaaS caller's TDD events carry the tenant tag.</para>
+///
+/// <list type="bullet">
+///   <item><description><c>TDD_DEBUG.CYCLE.STARTED</c> — a <c>tdd-cycle</c> dispatch
+///     is about to run (carries the current attempt number).</description></item>
+///   <item><description><c>TDD_DEBUG.CYCLE.PASSED</c> — the dispatched cycle reported
+///     <c>success=true</c> (the orchestrator finishes success).</description></item>
+///   <item><description><c>TDD_DEBUG.CYCLE.FAILED</c> — the dispatched cycle reported
+///     <c>success=false</c> (the orchestrator consults the retry guard).</description></item>
+///   <item><description><c>TDD_DEBUG.DEBUG.ATTEMPTED</c> — within the retry budget,
+///     the orchestrator dispatched the <c>debugging</c> sub-workflow.</description></item>
+///   <item><description><c>TDD_DEBUG.DEBUGGER.ESCALATED</c> — the dispatched
+///     <c>debugging</c> sub-workflow itself returned <c>success=false</c> (it could not
+///     fix the failure and escalated). The orchestrator short-circuits to a LOUD
+///     failure terminal instead of looping back and burning a retry on a
+///     known-unfixable failure. Loud (error-status).</description></item>
+///   <item><description><c>TDD_DEBUG.RETRY.EXHAUSTED</c> — the retry guard fired
+///     <c>False</c> (the loop ran out of its <c>maxRetries</c> budget without the
+///     cycle converging). Loud (error-status) — this is the explicit exhaustion
+///     terminal, NEVER a silent success.</description></item>
+///   <item><description><c>TDD_DEBUG.COMPLETED.SUCCESS</c> — the orchestrator finished
+///     success (the cycle converged within the retry budget).</description></item>
+/// </list>
+/// </summary>
+public static class TddDebugEvents
+{
+    public const string CycleStarted = "TDD_DEBUG.CYCLE.STARTED";
+    public const string CyclePassed = "TDD_DEBUG.CYCLE.PASSED";
+    public const string CycleFailed = "TDD_DEBUG.CYCLE.FAILED";
+    public const string DebugAttempted = "TDD_DEBUG.DEBUG.ATTEMPTED";
+    public const string DebuggerEscalated = "TDD_DEBUG.DEBUGGER.ESCALATED";
+    public const string RetryExhausted = "TDD_DEBUG.RETRY.EXHAUSTED";
+    public const string CompletedSuccess = "TDD_DEBUG.COMPLETED.SUCCESS";
+
+    /// <summary>
+    /// The <c>finishReason</c> values the orchestrator stamps on its failure output so
+    /// the caller / audit trail can distinguish a genuine TDD non-convergence (the loop
+    /// exhausted its retries) from a debugger crash/escalation. Mirrors
+    /// <c>TddWorkflow</c>'s <c>finishReason</c> pattern. Never an empty string —
+    /// failure always carries a reason (no false success, no silent failure).
+    /// </summary>
+    public const string ReasonNotConverged = "tdd-not-converged";
+    public const string ReasonDebuggerEscalated = "debugger-escalated";
+
+    /// <summary>
+    /// Parse a tenant id from the loose string form threaded through the workflow
+    /// inputs. Returns <c>null</c> for empty / single-user / unparseable values
+    /// (TDD events in single-user mode are platform-scope, TenantId null).
+    /// Mirrors <see cref="BranchEvents.ParseTenantId"/>.
+    /// </summary>
+    public static Guid? ParseTenantId(string? tenantId)
+        => Guid.TryParse(tenantId, out var g) ? g : null;
+
+    /// <summary>
+    /// Status convention: a retry-exhausted loop and a debugger escalation are LOUD
+    /// (error-status) audit rows; every other transition (cycle started/passed/failed,
+    /// debug attempted, completed-success) is a normal (success-status) row.
+    /// A FAILED cycle is success-status because it is an expected, recoverable loop
+    /// transition (the orchestrator retries it) — only the terminal exhaustion /
+    /// escalation rows are error-status. Keeps a degraded/failed terminal from ever
+    /// being recorded as a false success.
+    /// </summary>
+    public static string StatusForEvent(string type) => type switch
+    {
+        RetryExhausted => "error",
+        DebuggerEscalated => "error",
+        _ => "success",
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TddWithDebugRetryWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TddWithDebugRetryWorkflow.cs
@@ -7,6 +7,7 @@ using Elsa.Workflows.Management.Activities.SetOutput;
 using Elsa.Workflows.Memory;
 using Elsa.Workflows.Models;
 using Elsa.Workflows.Runtime.Activities;
+using Tamma.Activities.ADL;
 using FlowEndpoint = Elsa.Workflows.Activities.Flowchart.Models.Endpoint;
 using FlowConnection = Elsa.Workflows.Activities.Flowchart.Models.Connection;
 
@@ -15,18 +16,41 @@ using static Tamma.ElsaServer.Workflows.ActivityDisplayTextExtensions;
 namespace Tamma.ElsaServer.Workflows;
 
 /// <summary>
-/// TDD with Debug Retry sub-workflow — encapsulates the TDD cycle dispatch
-/// with up to 3 debug retry iterations on failure.
+/// TDD with Debug Retry sub-workflow — a pivot-clean orchestrator that wraps the
+/// <c>tdd-cycle</c> red-green-refactor workflow in a graph-enforced, bounded
+/// debug-retry loop. On a TDD failure it dispatches the <c>debugging</c> workflow and
+/// re-runs the cycle, up to <c>maxRetries</c> (default 3), then emits a
+/// <c>success</c>/<c>errorMessage</c> contract. Holds no provider key — all LLM work
+/// is inside the dispatched sub-workflows (mediated through <c>llm-call</c>).
+///
+/// <para>Build-out (completeness audit 2026-06-22, <c>TddWithDebugRetry.md</c>): the
+/// thin extraction grew an explicit <b>exhaustion terminal</b> (a loud
+/// <c>TDD_DEBUG.RETRY.EXHAUSTED</c> event + <c>success=false</c> with the REAL
+/// underlying failure surfaced, never a silent success or a generic "limit reached"
+/// string), run-level <c>TDD_DEBUG.*</c> DCB events via the durable engine drain, a
+/// reset-on-entry attempt counter exposed as output (sibling parity with
+/// <c>CiWithDebugRetryWorkflow</c>), a stable per-issue session id so retries correlate
+/// into one TDD session, and — critically for an orchestrator — routing of EVERY
+/// dispatched sub-workflow outcome to a terminal: the <c>debugging</c> result is now
+/// inspected, so a debugger escalation short-circuits to a loud failure instead of
+/// looping back and burning a retry on a known-unfixable failure. No dangling /
+/// silent-failure edge; the bound is enforced by the <c>TddDebugGuard</c> FlowDecision.</para>
 ///
 /// Flow:
-///   tddCycle -> tddSuccess?
-///     YES -> finish(success=true)
-///     NO  -> tddDebugGuard (< max, default 3)?
-///       NO  -> finish(success=false, errorMessage)
-///       YES -> incrementTddDebug -> dispatchTddDebugging -> (loop to tddCycle)
+///   init (reset attempt, derive sessionId)
+///     → EmitCycleStarted → DispatchTddCycle → TddSuccess?
+///       True  → EmitCyclePassed → EmitCompletedSuccess → FinishSuccess → Finish
+///       False → EmitCycleFailed → TddDebugGuard?
+///         False (exhausted) → EmitRetryExhausted → FinishFailure → Finish
+///         True  (budget left) → IncrTddDebug → EmitDebugAttempted → DispatchTddDebugging
+///                               → DebuggerEscalated?
+///                                 True  (debugger escalated) → EmitDebuggerEscalated → FinishFailure → Finish
+///                                 False (debugger fixed)     → EmitCycleStarted (loop)
 ///
-/// Inputs:  storyId, planJson, repositoryUrl, branchName, skillLevel
-/// Outputs: success (bool), errorMessage (string)
+/// Inputs:  storyId, planJson, repositoryUrl, branchName, skillLevel, issueNumber,
+///          tenantId, maxRetries (optional)
+/// Outputs: success (bool), errorMessage (string), finishReason (string),
+///          tddDebugAttempt (int)
 /// </summary>
 public class TddWithDebugRetryWorkflow : WorkflowBase
 {
@@ -35,7 +59,7 @@ public class TddWithDebugRetryWorkflow : WorkflowBase
         builder.Name = "TDD with Debug Retry";
         builder.DefinitionId = "tdd-with-debug-retry";
         builder.Version = WorkflowVersions.ComputedVersion;
-        builder.Description = "Dispatches TDD cycle with up to 3 debug retry iterations on failure";
+        builder.Description = "Dispatches TDD cycle with a graph-enforced, bounded debug-retry loop and an explicit exhaustion terminal";
 
         // ================================================================
         // Variables
@@ -47,15 +71,28 @@ public class TddWithDebugRetryWorkflow : WorkflowBase
         var skillLevel = builder.WithVariable<int>("SkillLevel", 5);
         var issueNumber = builder.WithVariable<int>("IssueNumber", 0);
         var tenantId = builder.WithVariable<string>("TenantId", "");
+        // tddDebugAttempt is ALWAYS reset to 0 on entry (see initInputs) so each
+        // invocation — including a re-dispatch from a parent re-run — gets the full
+        // retry budget regardless of any stale counter (sibling parity with
+        // CiWithDebugRetryWorkflow's ciRetryCount reset).
         var tddDebugAttempt = builder.WithVariable<int>("TddDebugAttempt", 0);
         var maxRetries = builder.WithVariable<int>("MaxRetries", 3);
+        // Stable per-issue/story TDD session id, derived once in init and shared by the
+        // tdd-cycle and debugging dispatches so retries correlate into ONE TDD session
+        // (instead of a fresh Guid per dispatch). Lets resumed runs dedupe.
+        var sessionId = builder.WithVariable<string>("SessionId", "");
+        // Real underlying failure detail captured from the failing tdd-cycle result so
+        // the failure terminal can surface the actual cause (not a generic string).
+        var lastTddError = builder.WithVariable<string>("LastTddError", "TDD cycle failed");
+        // The terminal failure reason: tdd-not-converged (exhausted) vs debugger-escalated.
+        var finishReason = builder.WithVariable<string>("FinishReason", TddDebugEvents.ReasonNotConverged);
 
         // DispatchWorkflow result capture
         var tddResult = builder.WithVariable<IDictionary<string, object>?>();
         var debugResult = builder.WithVariable<IDictionary<string, object>?>();
 
         // ================================================================
-        // INIT: Capture inputs
+        // INIT: Capture inputs, reset counter, derive a stable session id
         // ================================================================
         var initInputs = new SetVariable
         {
@@ -78,10 +115,42 @@ public class TddWithDebugRetryWorkflow : WorkflowBase
                 if (!string.IsNullOrEmpty(acctId)) tenantId.Set(ctx, acctId);
                 var inputMaxRetries = ctx.GetInput<int?>("maxRetries");
                 if (inputMaxRetries.HasValue) maxRetries.Set(ctx, inputMaxRetries.Value);
-                return (object)(ctx.GetInput<string>("storyId") ?? "");
+
+                var resolvedStory = ctx.GetInput<string>("storyId") ?? "";
+
+                // Reset the retry counter on every entry (full budget per invocation).
+                tddDebugAttempt.Set(ctx, 0);
+
+                // Derive a stable TDD session id shared across the cycle + debug
+                // dispatches so retries correlate into one session. Falls back to a
+                // fresh Guid only when neither issueNumber nor storyId is known.
+                var derivedIssue = issue > 0 ? issue : ctx.GetInput<int>("issueNumber");
+                var sid = derivedIssue > 0 || !string.IsNullOrEmpty(resolvedStory)
+                    ? $"tdd-{(derivedIssue > 0 ? derivedIssue.ToString() : "0")}-{resolvedStory}"
+                    : $"tdd-{Guid.NewGuid():N}";
+                sessionId.Set(ctx, sid);
+
+                return (object)resolvedStory;
             })
         };
         initInputs.SetDisplayText("Init Inputs");
+
+        // ================================================================
+        // DCB: TDD_DEBUG.CYCLE.STARTED — emitted before EACH cycle dispatch
+        //      (also the loop re-entry point, so every dispatch is audited).
+        // ================================================================
+        var emitCycleStarted = new EmitTddDebugEventActivity
+        {
+            Id = "EmitCycleStarted", Name = "Emit TDD_DEBUG.CYCLE.STARTED",
+            EventType = new Input<string>(_ => TddDebugEvents.CycleStarted),
+            StoryId = new Input<string?>(ctx => storyId.Get(ctx)),
+            IssueNumber = new Input<int>(ctx => issueNumber.Get(ctx)),
+            Repository = new Input<string?>(ctx => repositoryUrl.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
+            Attempt = new Input<int>(ctx => tddDebugAttempt.Get(ctx)),
+            MaxRetries = new Input<int>(ctx => maxRetries.Get(ctx)),
+        };
+        emitCycleStarted.SetDisplayText("Emit TDD_DEBUG.CYCLE.STARTED");
 
         // ================================================================
         // TDD Cycle (dispatch to existing tdd-cycle workflow)
@@ -93,7 +162,7 @@ public class TddWithDebugRetryWorkflow : WorkflowBase
             WorkflowDefinitionId = new("tdd-cycle"),
             Input = new(ctx => new Dictionary<string, object>
             {
-                ["sessionId"] = Guid.NewGuid(),
+                ["sessionId"] = sessionId.Get(ctx),
                 ["storyId"] = storyId.Get(ctx),
                 ["taskDescription"] = planJson.Get(ctx),
                 ["taskFiles"] = new List<string>(),
@@ -108,7 +177,7 @@ public class TddWithDebugRetryWorkflow : WorkflowBase
         tddCycle.SetDisplayText("TDD Cycle");
 
         // ================================================================
-        // TDD Success check
+        // TDD Success check (gate on the dispatched cycle's success — no false success)
         // ================================================================
         var tddSuccess = new FlowDecision(ctx =>
         {
@@ -121,7 +190,62 @@ public class TddWithDebugRetryWorkflow : WorkflowBase
         tddSuccess.SetDisplayText("TDD Passed?");
 
         // ================================================================
-        // TDD Debug retry guard (< 3 attempts)
+        // DCB: TDD_DEBUG.CYCLE.PASSED (success path)
+        // ================================================================
+        var emitCyclePassed = new EmitTddDebugEventActivity
+        {
+            Id = "EmitCyclePassed", Name = "Emit TDD_DEBUG.CYCLE.PASSED",
+            EventType = new Input<string>(_ => TddDebugEvents.CyclePassed),
+            StoryId = new Input<string?>(ctx => storyId.Get(ctx)),
+            IssueNumber = new Input<int>(ctx => issueNumber.Get(ctx)),
+            Repository = new Input<string?>(ctx => repositoryUrl.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
+            Attempt = new Input<int>(ctx => tddDebugAttempt.Get(ctx)),
+            MaxRetries = new Input<int>(ctx => maxRetries.Get(ctx)),
+        };
+        emitCyclePassed.SetDisplayText("Emit TDD_DEBUG.CYCLE.PASSED");
+
+        var emitCompletedSuccess = new EmitTddDebugEventActivity
+        {
+            Id = "EmitCompletedSuccess", Name = "Emit TDD_DEBUG.COMPLETED.SUCCESS",
+            EventType = new Input<string>(_ => TddDebugEvents.CompletedSuccess),
+            StoryId = new Input<string?>(ctx => storyId.Get(ctx)),
+            IssueNumber = new Input<int>(ctx => issueNumber.Get(ctx)),
+            Repository = new Input<string?>(ctx => repositoryUrl.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
+            Attempt = new Input<int>(ctx => tddDebugAttempt.Get(ctx)),
+            MaxRetries = new Input<int>(ctx => maxRetries.Get(ctx)),
+        };
+        emitCompletedSuccess.SetDisplayText("Emit TDD_DEBUG.COMPLETED.SUCCESS");
+
+        // ================================================================
+        // DCB: TDD_DEBUG.CYCLE.FAILED (failure path) — also captures the REAL error
+        //      detail so the eventual failure terminal can surface the cause.
+        // ================================================================
+        var captureTddError = new SetVariable
+        {
+            Id = "CaptureTddError", Name = "Capture TDD Error",
+            Variable = lastTddError,
+            Value = new Input<object?>(ctx => (object)GetTddErrorOutput(tddResult.Get(ctx)))
+        };
+        captureTddError.SetDisplayText("Capture TDD Error");
+
+        var emitCycleFailed = new EmitTddDebugEventActivity
+        {
+            Id = "EmitCycleFailed", Name = "Emit TDD_DEBUG.CYCLE.FAILED",
+            EventType = new Input<string>(_ => TddDebugEvents.CycleFailed),
+            StoryId = new Input<string?>(ctx => storyId.Get(ctx)),
+            IssueNumber = new Input<int>(ctx => issueNumber.Get(ctx)),
+            Repository = new Input<string?>(ctx => repositoryUrl.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
+            Attempt = new Input<int>(ctx => tddDebugAttempt.Get(ctx)),
+            MaxRetries = new Input<int>(ctx => maxRetries.Get(ctx)),
+            ErrorDetail = new Input<string?>(ctx => lastTddError.Get(ctx)),
+        };
+        emitCycleFailed.SetDisplayText("Emit TDD_DEBUG.CYCLE.FAILED");
+
+        // ================================================================
+        // TDD Debug retry guard (graph-enforced bound: < maxRetries)
         // ================================================================
         var tddDebugGuard = new FlowDecision(ctx => tddDebugAttempt.Get(ctx) < maxRetries.Get(ctx))
         { Id = "TddDebugGuard", Name = "TDD Debug < Max?" };
@@ -140,7 +264,24 @@ public class TddWithDebugRetryWorkflow : WorkflowBase
         incrementTddDebug.SetDisplayText("Increment TDD Debug");
 
         // ================================================================
-        // Dispatch debugging for TDD failure
+        // DCB: TDD_DEBUG.DEBUG.ATTEMPTED
+        // ================================================================
+        var emitDebugAttempted = new EmitTddDebugEventActivity
+        {
+            Id = "EmitDebugAttempted", Name = "Emit TDD_DEBUG.DEBUG.ATTEMPTED",
+            EventType = new Input<string>(_ => TddDebugEvents.DebugAttempted),
+            StoryId = new Input<string?>(ctx => storyId.Get(ctx)),
+            IssueNumber = new Input<int>(ctx => issueNumber.Get(ctx)),
+            Repository = new Input<string?>(ctx => repositoryUrl.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
+            Attempt = new Input<int>(ctx => tddDebugAttempt.Get(ctx)),
+            MaxRetries = new Input<int>(ctx => maxRetries.Get(ctx)),
+            ErrorDetail = new Input<string?>(ctx => lastTddError.Get(ctx)),
+        };
+        emitDebugAttempted.SetDisplayText("Emit TDD_DEBUG.DEBUG.ATTEMPTED");
+
+        // ================================================================
+        // Dispatch debugging for TDD failure (shares the stable session id)
         // ================================================================
         var dispatchTddDebugging = new DispatchWorkflow
         {
@@ -149,10 +290,10 @@ public class TddWithDebugRetryWorkflow : WorkflowBase
             WorkflowDefinitionId = new("debugging"),
             Input = new(ctx => new Dictionary<string, object>
             {
-                ["sessionId"] = Guid.NewGuid(),
+                ["sessionId"] = sessionId.Get(ctx),
                 ["storyId"] = storyId.Get(ctx),
                 ["debugContextMode"] = "TddFailure",
-                ["errorOutput"] = GetTddErrorOutput(tddResult.Get(ctx)),
+                ["errorOutput"] = lastTddError.Get(ctx),
                 ["repositoryUrl"] = repositoryUrl.Get(ctx),
                 ["branchName"] = branchName.Get(ctx),
                 ["skillLevel"] = skillLevel.Get(ctx),
@@ -164,7 +305,74 @@ public class TddWithDebugRetryWorkflow : WorkflowBase
         dispatchTddDebugging.SetDisplayText("Debug TDD Failure");
 
         // ================================================================
-        // Finish: Success outputs
+        // Debugger escalation gate — INSPECT the dispatched debugging result.
+        // The debugging workflow returns success=false when it ESCALATED (could not
+        // fix). True here => escalated => short-circuit to a loud failure instead of
+        // looping back and burning a retry on a known-unfixable failure (cap. 9).
+        // ================================================================
+        var debuggerEscalated = new FlowDecision(ctx =>
+        {
+            var result = debugResult.Get(ctx);
+            // Escalated when the debugger explicitly reported success=false.
+            if (result != null && result.TryGetValue("success", out var s))
+                return !(s is true || s?.ToString() == "True");
+            // No usable result => treat as escalated (don't loop on an unknown).
+            return result == null;
+        })
+        { Id = "DebuggerEscalated", Name = "Debugger Escalated?" };
+        debuggerEscalated.SetDisplayText("Debugger Escalated?");
+
+        var setReasonEscalated = new SetVariable
+        {
+            Id = "SetReasonEscalated", Name = "Set Reason Escalated",
+            Variable = finishReason,
+            Value = new Input<object?>(_ => (object)TddDebugEvents.ReasonDebuggerEscalated)
+        };
+        setReasonEscalated.SetDisplayText("Set Reason Escalated");
+
+        var emitDebuggerEscalated = new EmitTddDebugEventActivity
+        {
+            Id = "EmitDebuggerEscalated", Name = "Emit TDD_DEBUG.DEBUGGER.ESCALATED",
+            EventType = new Input<string>(_ => TddDebugEvents.DebuggerEscalated),
+            StoryId = new Input<string?>(ctx => storyId.Get(ctx)),
+            IssueNumber = new Input<int>(ctx => issueNumber.Get(ctx)),
+            Repository = new Input<string?>(ctx => repositoryUrl.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
+            Attempt = new Input<int>(ctx => tddDebugAttempt.Get(ctx)),
+            MaxRetries = new Input<int>(ctx => maxRetries.Get(ctx)),
+            FinishReason = new Input<string?>(_ => TddDebugEvents.ReasonDebuggerEscalated),
+            ErrorDetail = new Input<string?>(ctx => lastTddError.Get(ctx)),
+        };
+        emitDebuggerEscalated.SetDisplayText("Emit TDD_DEBUG.DEBUGGER.ESCALATED");
+
+        // ================================================================
+        // Retry exhaustion terminal — LOUD, never a silent success.
+        // ================================================================
+        var setReasonNotConverged = new SetVariable
+        {
+            Id = "SetReasonNotConverged", Name = "Set Reason Not Converged",
+            Variable = finishReason,
+            Value = new Input<object?>(_ => (object)TddDebugEvents.ReasonNotConverged)
+        };
+        setReasonNotConverged.SetDisplayText("Set Reason Not Converged");
+
+        var emitRetryExhausted = new EmitTddDebugEventActivity
+        {
+            Id = "EmitRetryExhausted", Name = "Emit TDD_DEBUG.RETRY.EXHAUSTED",
+            EventType = new Input<string>(_ => TddDebugEvents.RetryExhausted),
+            StoryId = new Input<string?>(ctx => storyId.Get(ctx)),
+            IssueNumber = new Input<int>(ctx => issueNumber.Get(ctx)),
+            Repository = new Input<string?>(ctx => repositoryUrl.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
+            Attempt = new Input<int>(ctx => tddDebugAttempt.Get(ctx)),
+            MaxRetries = new Input<int>(ctx => maxRetries.Get(ctx)),
+            FinishReason = new Input<string?>(_ => TddDebugEvents.ReasonNotConverged),
+            ErrorDetail = new Input<string?>(ctx => lastTddError.Get(ctx)),
+        };
+        emitRetryExhausted.SetDisplayText("Emit TDD_DEBUG.RETRY.EXHAUSTED");
+
+        // ================================================================
+        // Finish: Success outputs (exposes the attempts counter — sibling parity)
         // ================================================================
         var finishSuccessOutputs = new Sequence
         {
@@ -173,13 +381,16 @@ public class TddWithDebugRetryWorkflow : WorkflowBase
             Activities =
             {
                 WithLabel(new SetOutput { Id = "SetTddRetrySuccess", Name = "Set Success", OutputName = new("success"), OutputValue = new(_ => (object)true) }, "Set Success"),
-                WithLabel(new SetOutput { Id = "SetTddRetryErrorEmpty", Name = "Set Error Empty", OutputName = new("errorMessage"), OutputValue = new(_ => (object)"") }, "Set Error Empty")
+                WithLabel(new SetOutput { Id = "SetTddRetryErrorEmpty", Name = "Set Error Empty", OutputName = new("errorMessage"), OutputValue = new(_ => (object)"") }, "Set Error Empty"),
+                WithLabel(new SetOutput { Id = "SetTddRetryReasonEmpty", Name = "Set Reason Empty", OutputName = new("finishReason"), OutputValue = new(_ => (object)"") }, "Set Reason Empty"),
+                WithLabel(new SetOutput { Id = "SetTddRetryAttemptsPass", Name = "Set Attempts", OutputName = new("tddDebugAttempt"), OutputValue = new(ctx => (object)tddDebugAttempt.Get(ctx)) }, "Set Attempts")
             }
         };
         finishSuccessOutputs.SetDisplayText("Finish Success");
 
         // ================================================================
-        // Finish: Failure outputs
+        // Finish: Failure outputs — surfaces the REAL failure detail + finishReason +
+        // attempts. No generic "limit reached" string; no false success.
         // ================================================================
         var finishFailureOutputs = new Sequence
         {
@@ -188,7 +399,9 @@ public class TddWithDebugRetryWorkflow : WorkflowBase
             Activities =
             {
                 WithLabel(new SetOutput { Id = "SetTddRetryFailed", Name = "Set Failed", OutputName = new("success"), OutputValue = new(_ => (object)false) }, "Set Failed"),
-                WithLabel(new SetOutput { Id = "SetTddRetryErrorMsg", Name = "Set Error Message", OutputName = new("errorMessage"), OutputValue = new(ctx => (object)$"TDD debug retry limit reached ({maxRetries.Get(ctx)} attempts)") }, "Set Error Message")
+                WithLabel(new SetOutput { Id = "SetTddRetryErrorMsg", Name = "Set Error Message", OutputName = new("errorMessage"), OutputValue = new(ctx => (object)BuildFailureMessage(finishReason.Get(ctx), tddDebugAttempt.Get(ctx), maxRetries.Get(ctx), lastTddError.Get(ctx))) }, "Set Error Message"),
+                WithLabel(new SetOutput { Id = "SetTddRetryReason", Name = "Set Finish Reason", OutputName = new("finishReason"), OutputValue = new(ctx => (object)finishReason.Get(ctx)) }, "Set Finish Reason"),
+                WithLabel(new SetOutput { Id = "SetTddRetryAttemptsFail", Name = "Set Attempts", OutputName = new("tddDebugAttempt"), OutputValue = new(ctx => (object)tddDebugAttempt.Get(ctx)) }, "Set Attempts")
             }
         };
         finishFailureOutputs.SetDisplayText("Finish Failure");
@@ -207,34 +420,56 @@ public class TddWithDebugRetryWorkflow : WorkflowBase
             Activities =
             {
                 initInputs,
-                tddCycle, tddSuccess, tddDebugGuard,
-                incrementTddDebug, dispatchTddDebugging,
+                emitCycleStarted, tddCycle, tddSuccess,
+                emitCyclePassed, emitCompletedSuccess,
+                captureTddError, emitCycleFailed, tddDebugGuard,
+                setReasonNotConverged, emitRetryExhausted,
+                incrementTddDebug, emitDebugAttempted, dispatchTddDebugging,
+                debuggerEscalated, setReasonEscalated, emitDebuggerEscalated,
                 finishSuccessOutputs, finishFailureOutputs, finish
             },
             Connections =
             {
-                // Init -> TDD Cycle
-                Connect(initInputs, tddCycle),
+                // Init -> STARTED -> TDD Cycle
+                Connect(initInputs, emitCycleStarted),
+                Connect(emitCycleStarted, tddCycle),
 
-                // TDD Cycle -> Success check
+                // TDD Cycle -> Success gate
                 Connect(tddCycle, tddSuccess),
 
-                // TDD passed -> finish success
-                ConnectOutcome(tddSuccess, "True", finishSuccessOutputs),
-
-                // TDD failed -> debug guard
-                ConnectOutcome(tddSuccess, "False", tddDebugGuard),
-
-                // Debug retries remaining -> increment + debug
-                ConnectOutcome(tddDebugGuard, "True", incrementTddDebug),
-                ConnectOutcome(tddDebugGuard, "False", finishFailureOutputs),
-
-                // Increment -> dispatch debugging -> loop back to TDD
-                Connect(incrementTddDebug, dispatchTddDebugging),
-                Connect(dispatchTddDebugging, tddCycle),
-
-                // Both finish outputs -> terminal
+                // TDD passed -> PASSED -> COMPLETED.SUCCESS -> success terminal
+                ConnectOutcome(tddSuccess, "True", emitCyclePassed),
+                Connect(emitCyclePassed, emitCompletedSuccess),
+                Connect(emitCompletedSuccess, finishSuccessOutputs),
                 Connect(finishSuccessOutputs, finish),
+
+                // TDD failed -> capture cause -> FAILED -> retry guard (the bound)
+                ConnectOutcome(tddSuccess, "False", captureTddError),
+                Connect(captureTddError, emitCycleFailed),
+                Connect(emitCycleFailed, tddDebugGuard),
+
+                // Guard False (exhausted) -> reason -> EXHAUSTED -> failure terminal (LOUD)
+                ConnectOutcome(tddDebugGuard, "False", setReasonNotConverged),
+                Connect(setReasonNotConverged, emitRetryExhausted),
+                Connect(emitRetryExhausted, finishFailureOutputs),
+
+                // Guard True (budget left) -> increment -> ATTEMPTED -> dispatch debugging
+                ConnectOutcome(tddDebugGuard, "True", incrementTddDebug),
+                Connect(incrementTddDebug, emitDebugAttempted),
+                Connect(emitDebugAttempted, dispatchTddDebugging),
+
+                // Debugging result -> escalation gate (every sub-workflow outcome routed)
+                Connect(dispatchTddDebugging, debuggerEscalated),
+
+                // Debugger escalated -> reason -> ESCALATED -> failure terminal (LOUD)
+                ConnectOutcome(debuggerEscalated, "True", setReasonEscalated),
+                Connect(setReasonEscalated, emitDebuggerEscalated),
+                Connect(emitDebuggerEscalated, finishFailureOutputs),
+
+                // Debugger fixed (soft) -> loop back to re-test (via STARTED, audited)
+                ConnectOutcome(debuggerEscalated, "False", emitCycleStarted),
+
+                // Failure terminal -> finish
                 Connect(finishFailureOutputs, finish)
             }
         };
@@ -250,10 +485,33 @@ public class TddWithDebugRetryWorkflow : WorkflowBase
     private static FlowConnection ConnectOutcome(IActivity source, string outcome, IActivity target)
         => new(new FlowEndpoint(source, outcome), new FlowEndpoint(target));
 
+    /// <summary>
+    /// Extract the real underlying TDD failure detail from the dispatched
+    /// <c>tdd-cycle</c> result (its <c>errorMessage</c> / <c>finishReason</c> output),
+    /// so the orchestrator can surface the cause instead of a generic string. Never
+    /// returns empty (no silent failure).
+    /// </summary>
     private static string GetTddErrorOutput(IDictionary<string, object>? result)
     {
-        if (result != null && result.TryGetValue("errorMessage", out var err))
-            return err?.ToString() ?? "TDD cycle failed";
+        if (result == null) return "TDD cycle failed with no result (sub-workflow did not complete)";
+        if (result.TryGetValue("errorMessage", out var err) && !string.IsNullOrWhiteSpace(err?.ToString()))
+            return err!.ToString()!;
+        if (result.TryGetValue("finishReason", out var reason) && !string.IsNullOrWhiteSpace(reason?.ToString()))
+            return $"TDD cycle failed ({reason})";
         return "TDD cycle failed with unknown error";
+    }
+
+    /// <summary>
+    /// Build the failure <c>errorMessage</c> from the real cause + the finish reason +
+    /// the retry budget — distinguishing a genuine non-convergence (exhausted) from a
+    /// debugger escalation, and ALWAYS surfacing the underlying detail. Exposed for
+    /// unit testing.
+    /// </summary>
+    public static string BuildFailureMessage(string finishReason, int attempts, int maxRetries, string lastError)
+    {
+        var detail = string.IsNullOrWhiteSpace(lastError) ? "TDD cycle failed" : lastError;
+        return finishReason == TddDebugEvents.ReasonDebuggerEscalated
+            ? $"TDD debugging escalated after {attempts}/{maxRetries} attempt(s): {detail}"
+            : $"TDD did not converge after {attempts}/{maxRetries} debug attempt(s): {detail}";
     }
 }

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/TddDebugEventTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/TddDebugEventTests.cs
@@ -1,0 +1,166 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+
+namespace Tamma.Activities.Tests.ADL;
+
+/// <summary>
+/// Completeness audit 2026-06-22 (<c>TddWithDebugRetry.md</c>) — coverage for the
+/// <c>TDD_DEBUG.*</c> DCB event mapping
+/// (<see cref="EmitTddDebugEventActivity.BuildTammaEvent"/>) and the
+/// <see cref="TddDebugEvents"/> status / finish-reason convention.
+///
+/// <para>The core completeness gap was a thin orchestrator with no audit events and a
+/// generic "retry limit reached" failure string that dropped the real cause. These
+/// tests pin the now-explicit contract: a retry-exhausted loop and a debugger
+/// escalation are LOUD (error-status) audit rows carrying a <c>finishReason</c> and
+/// the underlying <c>errorDetail</c> — never a silent false success.</para>
+/// </summary>
+[TestFixture]
+public class TddDebugEventTests
+{
+    // ================================================================
+    // TddDebugEvents — type catalogue + status convention (no false success)
+    // ================================================================
+
+    [Test]
+    public void EventTypes_FollowAggregateActionStatusConvention()
+    {
+        TddDebugEvents.CycleStarted.Should().Be("TDD_DEBUG.CYCLE.STARTED");
+        TddDebugEvents.CyclePassed.Should().Be("TDD_DEBUG.CYCLE.PASSED");
+        TddDebugEvents.CycleFailed.Should().Be("TDD_DEBUG.CYCLE.FAILED");
+        TddDebugEvents.DebugAttempted.Should().Be("TDD_DEBUG.DEBUG.ATTEMPTED");
+        TddDebugEvents.DebuggerEscalated.Should().Be("TDD_DEBUG.DEBUGGER.ESCALATED");
+        TddDebugEvents.RetryExhausted.Should().Be("TDD_DEBUG.RETRY.EXHAUSTED");
+        TddDebugEvents.CompletedSuccess.Should().Be("TDD_DEBUG.COMPLETED.SUCCESS");
+    }
+
+    [Test]
+    public void StatusForEvent_ExhaustionAndEscalationAreError_RestAreSuccess()
+    {
+        TddDebugEvents.StatusForEvent(TddDebugEvents.RetryExhausted).Should().Be("error");
+        TddDebugEvents.StatusForEvent(TddDebugEvents.DebuggerEscalated).Should().Be("error");
+
+        TddDebugEvents.StatusForEvent(TddDebugEvents.CycleStarted).Should().Be("success");
+        TddDebugEvents.StatusForEvent(TddDebugEvents.CyclePassed).Should().Be("success");
+        // A FAILED cycle is an expected, recoverable loop transition (it gets retried),
+        // so it is NOT an error-status row — only the terminal exhaustion is.
+        TddDebugEvents.StatusForEvent(TddDebugEvents.CycleFailed).Should().Be("success");
+        TddDebugEvents.StatusForEvent(TddDebugEvents.DebugAttempted).Should().Be("success");
+        TddDebugEvents.StatusForEvent(TddDebugEvents.CompletedSuccess).Should().Be("success");
+    }
+
+    [Test]
+    public void FinishReasons_DistinguishNonConvergenceFromDebuggerCrash()
+    {
+        TddDebugEvents.ReasonNotConverged.Should().Be("tdd-not-converged");
+        TddDebugEvents.ReasonDebuggerEscalated.Should().Be("debugger-escalated");
+        TddDebugEvents.ReasonNotConverged.Should().NotBe(TddDebugEvents.ReasonDebuggerEscalated);
+    }
+
+    [Test]
+    public void ParseTenantId_ValidGuid_Parses_InvalidOrEmpty_IsNull()
+    {
+        var g = Guid.NewGuid();
+        TddDebugEvents.ParseTenantId(g.ToString()).Should().Be(g);
+        TddDebugEvents.ParseTenantId("").Should().BeNull();
+        TddDebugEvents.ParseTenantId(null).Should().BeNull();
+        TddDebugEvents.ParseTenantId("not-a-guid").Should().BeNull();
+    }
+
+    // ================================================================
+    // BuildTammaEvent — tags + data + status mapping
+    // ================================================================
+
+    [Test]
+    public void BuildTammaEvent_CompletedSuccess_HasSuccessStatus_AndLoopPayload()
+    {
+        var evt = EmitTddDebugEventActivity.BuildTammaEvent(
+            TddDebugEvents.CompletedSuccess,
+            storyId: "story-7",
+            issueNumber: 7,
+            repository: "owner/repo",
+            tenantId: null,
+            attempt: 2,
+            maxRetries: 3,
+            finishReason: null,
+            errorDetail: null);
+
+        evt.EventType.Should().Be("TDD_DEBUG.COMPLETED.SUCCESS");
+        evt.Status.Should().Be("success");
+
+        evt.Tags!["storyId"].Should().Be("story-7");
+        evt.Tags!["issueId"].Should().Be("7");
+        evt.Tags!["issueNumber"].Should().Be("7");
+        evt.Tags!["repository"].Should().Be("owner/repo");
+        evt.Tags!["attempt"].Should().Be("2");
+        evt.Tags.Should().NotContainKey("tenantId", "single-user / platform-scope event");
+
+        evt.Data["attempt"].Should().Be(2);
+        evt.Data["maxRetries"].Should().Be(3);
+        evt.Data.Should().NotContainKey("finishReason");
+        evt.Data.Should().NotContainKey("errorDetail");
+    }
+
+    [Test]
+    public void BuildTammaEvent_RetryExhausted_HasErrorStatus_AndSurfacesRealCause()
+    {
+        // The core no-false-success guarantee: an exhausted loop is a LOUD (error)
+        // audit row that carries the REAL underlying failure, not a generic string.
+        var evt = EmitTddDebugEventActivity.BuildTammaEvent(
+            TddDebugEvents.RetryExhausted,
+            storyId: "story-9",
+            issueNumber: 9,
+            repository: "owner/repo",
+            tenantId: null,
+            attempt: 3,
+            maxRetries: 3,
+            finishReason: TddDebugEvents.ReasonNotConverged,
+            errorDetail: "GREEN phase failed: 2 tests still red in auth.spec.ts");
+
+        evt.EventType.Should().Be("TDD_DEBUG.RETRY.EXHAUSTED");
+        evt.Status.Should().Be("error");
+        evt.Data["finishReason"].Should().Be("tdd-not-converged");
+        evt.Data["errorDetail"].Should().Be("GREEN phase failed: 2 tests still red in auth.spec.ts");
+    }
+
+    [Test]
+    public void BuildTammaEvent_DebuggerEscalated_HasErrorStatus_AndReason()
+    {
+        var evt = EmitTddDebugEventActivity.BuildTammaEvent(
+            TddDebugEvents.DebuggerEscalated,
+            storyId: "story-9",
+            issueNumber: 9,
+            repository: "owner/repo",
+            tenantId: null,
+            attempt: 1,
+            maxRetries: 3,
+            finishReason: TddDebugEvents.ReasonDebuggerEscalated,
+            errorDetail: "debugger could not produce a fix");
+
+        evt.Status.Should().Be("error");
+        evt.Data["finishReason"].Should().Be("debugger-escalated");
+    }
+
+    [Test]
+    public void BuildTammaEvent_WithTenant_StampsTenantTag()
+    {
+        var tenant = Guid.NewGuid();
+        var evt = EmitTddDebugEventActivity.BuildTammaEvent(
+            TddDebugEvents.CycleStarted, "story-1", 1, "owner/repo", tenant, 0, 3, null, null);
+
+        evt.Tags!["tenantId"].Should().Be(tenant.ToString("D"));
+    }
+
+    [Test]
+    public void BuildTammaEvent_ZeroIssueNumber_OmitsIssueTags_KeepsAttempt()
+    {
+        var evt = EmitTddDebugEventActivity.BuildTammaEvent(
+            TddDebugEvents.CycleStarted, "story-1", 0, "owner/repo", null, 1, 3, null, null);
+
+        evt.Tags!.Should().NotContainKey("issueId");
+        evt.Tags!.Should().NotContainKey("issueNumber");
+        evt.Tags!["attempt"].Should().Be("1");
+        evt.Tags!["storyId"].Should().Be("story-1");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TddWithDebugRetryWorkflowTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TddWithDebugRetryWorkflowTests.cs
@@ -1,0 +1,330 @@
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Management.Activities.SetOutput;
+using Elsa.Workflows.Runtime.Activities;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Completeness audit 2026-06-22 (<c>TddWithDebugRetry.md</c>) — workflow-structure
+/// coverage for the built-out <c>tdd-with-debug-retry</c> orchestrator. Asserts the
+/// load-bearing guarantees the audit flagged as missing:
+/// <list type="bullet">
+///   <item><description>a <b>graph-enforced</b> retry bound (the debug guard FlowDecision
+///     with True/False ports — no unconditional fall-through back to the cycle);</description></item>
+///   <item><description>an explicit <b>exhaustion terminal</b> — the guard's False edge
+///     reaches a LOUD <c>TDD_DEBUG.RETRY.EXHAUSTED</c> emit + a <c>success=false</c>
+///     failure terminal, NEVER the success path (no silent success);</description></item>
+///   <item><description><b>every dispatched sub-workflow's outcome is routed</b> — the
+///     <c>tdd-cycle</c> result feeds a success gate, and the <c>debugging</c> result
+///     feeds an escalation gate that short-circuits to failure instead of dangling;</description></item>
+///   <item><description>run-level <c>TDD_DEBUG.*</c> DCB events at graph boundaries;</description></item>
+///   <item><description>every activity routes to a terminal (no dangling edge / no hang).</description></item>
+/// </list>
+///
+/// <para>Follows the codebase convention of inspecting the BUILT Flowchart via
+/// <see cref="WorkflowTestHelper"/> (see <see cref="TriageContextGatheringWorkflowTests"/>).</para>
+/// </summary>
+[TestFixture]
+public class TddWithDebugRetryWorkflowTests
+{
+    private Flowchart _flowchart = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new TddWithDebugRetryWorkflow());
+        _flowchart = WorkflowTestHelper.GetFlowchart(builder);
+    }
+
+    // ================================================================
+    // Identity
+    // ================================================================
+
+    [Test]
+    public void Workflow_BuildsWithExpectedDefinitionId()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new TddWithDebugRetryWorkflow());
+        builder.Object.DefinitionId.Should().Be("tdd-with-debug-retry");
+    }
+
+    // ================================================================
+    // Sub-workflow mediation — TDD + debugging dispatched (no raw provider call)
+    // ================================================================
+
+    [Test]
+    public void TddCycle_IsDispatchedToTddCycleWorkflow()
+    {
+        var dispatch = _flowchart.Activities.OfType<DispatchWorkflow>()
+            .FirstOrDefault(d => d.Id == "DispatchTddCycle");
+        dispatch.Should().NotBeNull();
+        ReadDefinitionId(dispatch!).Should().Be("tdd-cycle");
+    }
+
+    [Test]
+    public void DebugFailure_IsDispatchedToDebuggingWorkflow()
+    {
+        var dispatch = _flowchart.Activities.OfType<DispatchWorkflow>()
+            .FirstOrDefault(d => d.Id == "DispatchTddDebugging");
+        dispatch.Should().NotBeNull();
+        ReadDefinitionId(dispatch!).Should().Be("debugging");
+    }
+
+    // ================================================================
+    // Graph-enforced loop bound — the retry guard exists with True/False ports
+    // and has NO unconditional fall-through.
+    // ================================================================
+
+    [Test]
+    public void RetryGuard_IsAGraphEnforcedFlowDecision_WithOnlyTrueFalsePorts()
+    {
+        _flowchart.Activities.OfType<FlowDecision>()
+            .Any(d => d.Id == "TddDebugGuard")
+            .Should().BeTrue("the bounded loop must be enforced by a FlowDecision guard, not code-only");
+
+        var fromGuard = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "TddDebugGuard")
+            .ToList();
+
+        fromGuard.Should().NotBeEmpty();
+        fromGuard.Should().OnlyContain(c => c.Source.Port == "True" || c.Source.Port == "False",
+            "the guard must route only via True/False — no unconditional fall-through past the bound");
+    }
+
+    [Test]
+    public void RetryGuard_TrueRoutesIntoTheDebugLeg_FalseRoutesToExhaustionTerminal()
+    {
+        // True (budget remaining) → increment + debug; False (exhausted) → loud terminal.
+        HasEdge("TddDebugGuard", "True", "IncrTddDebug").Should().BeTrue();
+
+        // False MUST reach the exhaustion emit, and MUST NOT reach the success path.
+        var falseTargets = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "TddDebugGuard" && c.Source.Port == "False")
+            .Select(c => c.Target.Activity.Id)
+            .ToList();
+
+        falseTargets.Should().NotContain("TddRetryFinishSuccess");
+        falseTargets.Should().NotContain("EmitCompletedSuccess");
+    }
+
+    // ================================================================
+    // Explicit exhaustion terminal — NOT a silent success.
+    // ================================================================
+
+    [Test]
+    public void RetryExhaustion_RoutesToLoudFailureTerminal_NotSuccess()
+    {
+        // The exhaustion path: guard False → emit RETRY.EXHAUSTED → failure outputs.
+        _flowchart.Activities.OfType<EmitTddDebugEventActivity>()
+            .Any(a => a.Id == "EmitRetryExhausted")
+            .Should().BeTrue("the loop must emit a loud TDD_DEBUG.RETRY.EXHAUSTED on exhaustion");
+
+        // Guard False -> set reason -> emit EXHAUSTED -> failure terminal -> finish.
+        HasEdge("TddDebugGuard", "False", "SetReasonNotConverged").Should().BeTrue();
+        HasEdge("SetReasonNotConverged", null, "EmitRetryExhausted").Should().BeTrue();
+        HasEdge("EmitRetryExhausted", null, "TddRetryFinishFailure").Should().BeTrue();
+        HasEdge("TddRetryFinishFailure", null, "TddRetryFinish").Should().BeTrue();
+    }
+
+    [Test]
+    public void FailureTerminal_SetsSuccessFalse_AndSurfacesRealFailureDetail()
+    {
+        var seq = _flowchart.Activities.OfType<Sequence>()
+            .First(s => s.Id == "TddRetryFinishFailure");
+        var outputs = seq.Activities.OfType<SetOutput>().ToList();
+
+        // success=false is set.
+        outputs.Any(o => o.OutputName?.Expression?.Value?.ToString() == "success")
+            .Should().BeTrue();
+
+        // The failure carries an errorMessage AND a finishReason (no generic-only string).
+        var names = outputs
+            .Select(o => o.OutputName?.Expression?.Value?.ToString())
+            .ToList();
+        names.Should().Contain("errorMessage");
+        names.Should().Contain("finishReason");
+        // Sibling parity: callers see how many retries were burned.
+        names.Should().Contain("tddDebugAttempt");
+    }
+
+    // ================================================================
+    // Sub-workflow outcome routing — TDD success gate + debugger escalation gate.
+    // ================================================================
+
+    [Test]
+    public void TddCycleResult_FeedsASuccessGate_RoutedBothWays()
+    {
+        _flowchart.Activities.OfType<FlowDecision>()
+            .Any(d => d.Id == "TddSuccess").Should().BeTrue();
+
+        // Passed → completed-success emit + success terminal.
+        HasEdge("TddSuccess", "True", "EmitCyclePassed").Should().BeTrue();
+        // Failed → capture the real cause → cycle-failed emit → retry guard (the bound).
+        HasEdge("TddSuccess", "False", "CaptureTddError").Should().BeTrue();
+        HasEdge("CaptureTddError", null, "EmitCycleFailed").Should().BeTrue();
+        HasEdge("EmitCycleFailed", null, "TddDebugGuard").Should().BeTrue();
+    }
+
+    [Test]
+    public void DebuggerResult_FeedsAnEscalationGate_ThatShortCircuitsToFailure()
+    {
+        // cap.9 — the debugging result is INSPECTED, not blindly looped back.
+        _flowchart.Activities.OfType<FlowDecision>()
+            .Any(d => d.Id == "DebuggerEscalated")
+            .Should().BeTrue("the dispatched debugging outcome must be routed, not dangling");
+
+        HasEdge("DispatchTddDebugging", null, "DebuggerEscalated").Should().BeTrue();
+
+        // Escalated (debugger success=false) → set reason → loud escalation terminal
+        // (NOT loop back).
+        HasEdge("DebuggerEscalated", "True", "SetReasonEscalated").Should().BeTrue();
+        HasEdge("SetReasonEscalated", null, "EmitDebuggerEscalated").Should().BeTrue();
+        HasEdge("EmitDebuggerEscalated", null, "TddRetryFinishFailure").Should().BeTrue();
+
+        // Not escalated (debugger fixed / soft-fail) → loop back to re-test (via the
+        // STARTED emit, so each cycle dispatch is audited).
+        HasEdge("DebuggerEscalated", "False", "EmitCycleStarted").Should().BeTrue();
+
+        // The escalation gate has only True/False — no dangling.
+        var fromGate = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "DebuggerEscalated")
+            .ToList();
+        fromGate.Should().OnlyContain(c => c.Source.Port == "True" || c.Source.Port == "False");
+    }
+
+    // ================================================================
+    // Run-level DCB events at graph boundaries.
+    // ================================================================
+
+    [Test]
+    public void CycleStarted_IsEmittedBeforeEachDispatch()
+    {
+        _flowchart.Activities.OfType<EmitTddDebugEventActivity>()
+            .Any(a => a.Id == "EmitCycleStarted").Should().BeTrue();
+
+        // STARTED runs right before the cycle dispatch (and the loop re-enters via it).
+        HasEdge("EmitCycleStarted", null, "DispatchTddCycle").Should().BeTrue();
+    }
+
+    [Test]
+    public void SuccessPath_EmitsCompletedSuccessEvent_BeforeSuccessTerminal()
+    {
+        _flowchart.Activities.OfType<EmitTddDebugEventActivity>()
+            .Any(a => a.Id == "EmitCyclePassed").Should().BeTrue();
+        _flowchart.Activities.OfType<EmitTddDebugEventActivity>()
+            .Any(a => a.Id == "EmitCompletedSuccess").Should().BeTrue();
+
+        HasEdge("EmitCyclePassed", null, "EmitCompletedSuccess").Should().BeTrue();
+        HasEdge("EmitCompletedSuccess", null, "TddRetryFinishSuccess").Should().BeTrue();
+        HasEdge("TddRetryFinishSuccess", null, "TddRetryFinish").Should().BeTrue();
+    }
+
+    [Test]
+    public void DebugAttempt_EmitsAttemptedEvent()
+    {
+        _flowchart.Activities.OfType<EmitTddDebugEventActivity>()
+            .Any(a => a.Id == "EmitDebugAttempted").Should().BeTrue();
+
+        // increment → emit attempted → dispatch debugging.
+        HasEdge("IncrTddDebug", null, "EmitDebugAttempted").Should().BeTrue();
+        HasEdge("EmitDebugAttempted", null, "DispatchTddDebugging").Should().BeTrue();
+    }
+
+    // ================================================================
+    // Outputs — success terminal exposes the attempts counter too (sibling parity).
+    // ================================================================
+
+    [Test]
+    public void SuccessTerminal_ExposesAttemptsCounter()
+    {
+        var seq = _flowchart.Activities.OfType<Sequence>()
+            .First(s => s.Id == "TddRetryFinishSuccess");
+        var names = seq.Activities.OfType<SetOutput>()
+            .Select(o => o.OutputName?.Expression?.Value?.ToString())
+            .ToList();
+
+        names.Should().Contain("success");
+        names.Should().Contain("tddDebugAttempt");
+    }
+
+    // ================================================================
+    // Real failure propagation — the failure message carries the actual cause
+    // and distinguishes non-convergence from a debugger escalation (no generic
+    // "retry limit reached" string; no silent failure).
+    // ================================================================
+
+    [Test]
+    public void BuildFailureMessage_NotConverged_SurfacesRealCause_AndAttempts()
+    {
+        var msg = TddWithDebugRetryWorkflow.BuildFailureMessage(
+            TddDebugEvents.ReasonNotConverged, attempts: 3, maxRetries: 3,
+            lastError: "GREEN phase failed: 2 tests still red in auth.spec.ts");
+
+        msg.Should().Contain("did not converge");
+        msg.Should().Contain("3/3");
+        msg.Should().Contain("auth.spec.ts", "the REAL underlying cause must be surfaced");
+        msg.Should().NotBe("TDD debug retry limit reached (3 attempts)",
+            "the generic string that dropped the cause must be gone");
+    }
+
+    [Test]
+    public void BuildFailureMessage_DebuggerEscalated_IsDistinctFromNonConvergence()
+    {
+        var escalated = TddWithDebugRetryWorkflow.BuildFailureMessage(
+            TddDebugEvents.ReasonDebuggerEscalated, 1, 3, "could not fix");
+        var notConverged = TddWithDebugRetryWorkflow.BuildFailureMessage(
+            TddDebugEvents.ReasonNotConverged, 3, 3, "still red");
+
+        escalated.Should().Contain("escalated");
+        notConverged.Should().NotContain("escalated");
+        escalated.Should().NotBe(notConverged);
+    }
+
+    [Test]
+    public void BuildFailureMessage_EmptyError_StillNonEmpty_NoSilentFailure()
+    {
+        var msg = TddWithDebugRetryWorkflow.BuildFailureMessage(
+            TddDebugEvents.ReasonNotConverged, 3, 3, "");
+        msg.Should().NotBeNullOrWhiteSpace();
+        msg.Should().Contain("TDD cycle failed");
+    }
+
+    // ================================================================
+    // No dangling edges — every non-terminal activity has an outgoing edge.
+    // ================================================================
+
+    [Test]
+    public void EveryActivity_RoutesToATerminal_NoDanglingEdge()
+    {
+        var allIds = _flowchart.Activities.Select(a => a.Id!).ToHashSet();
+        var sources = _flowchart.Connections.Select(c => c.Source.Activity.Id!).ToHashSet();
+
+        foreach (var id in allIds.Where(i => i != "TddRetryFinish"))
+        {
+            sources.Should().Contain(id, $"activity '{id}' must route somewhere (no dangling edge)");
+        }
+    }
+
+    // ================================================================
+    // Helpers
+    // ================================================================
+
+    private bool HasEdge(string sourceId, string? port, string targetId)
+        => _flowchart.Connections.Any(c =>
+            c.Source.Activity.Id == sourceId &&
+            (port == null || c.Source.Port == port) &&
+            c.Target.Activity.Id == targetId);
+
+    private static string? ReadDefinitionId(DispatchWorkflow dispatch)
+    {
+        var prop = typeof(DispatchWorkflow).GetProperty("WorkflowDefinitionId");
+        var value = prop?.GetValue(dispatch);
+        var expression = value?.GetType().GetProperty("Expression")?.GetValue(value)
+            as Elsa.Expressions.Models.Expression;
+        return expression?.Value?.ToString();
+    }
+}


### PR DESCRIPTION
`TddWithDebugRetryWorkflow` — thin → complete (dispatch orchestrator). Real graph-enforced bounded retry loop (the debug→cycle back-edge bounded by `TddDebugGuard`); a `DebuggerEscalated` gate short-circuits a debugger escalation to a loud failure instead of burning a retry on a known-unfixable failure; exhaustion terminal carries the **real** failure cause (not a hardcoded "limit reached"); run-level `TDD_DEBUG.*` DCB events via the durable drain; `sessionId` correlation + `tenantId`. No false success; every sub-workflow outcome routed. Reviewed: APPROVED. Build 0 err; TddDebug 34/0; full Activities 1587/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)