### PR TITLE
feat(workflows): build out Merge — verified success, idempotent, failure path, events

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitMergeEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitMergeEventActivity.cs
@@ -1,0 +1,148 @@
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+
+namespace Tamma.Activities.ADL;
+
+/// <summary>
+/// Emits a <c>MERGE.*</c> / <c>ISSUE.CLOSED.*</c> / <c>BRANCH.DELETED.*</c> DCB
+/// event (Story 2-10 AC5 / Story 4.5) for the built-out <c>merge</c> workflow by
+/// appending a <see cref="TammaEvent"/> to the workflow's <c>tamma:events</c>
+/// transient list via <see cref="TammaEventEmitter.Emit"/>. The merged engine
+/// event drain (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) flushes
+/// that list <i>durably</i> to the tenant <c>domain_events</c> store after this
+/// activity runs — the drain resolves the tenant from the workflow scope (this
+/// workflow stamps a <c>TenantId</c> variable). The event therefore persists
+/// without this activity holding any DB / repository dependency of its own (none
+/// is registered in the Elsa engine — a directly-injected <c>IEventRepository</c>
+/// would be inert and silently drop the event, the same trap the PR / branch
+/// exemplars avoid).
+///
+/// <para>Critically, the <c>MERGE.FAILED</c> event ACTUALLY fires on a real merge
+/// failure (the activity surfaces an <c>Error</c> outcome that the workflow routes
+/// to a failure terminal which emits it), closing the headline bug where the thin
+/// wrapper emitted NO event at all and dead-ended the flow on the unwired
+/// <c>Error</c> outcome.</para>
+/// </summary>
+[Activity(
+    "Tamma.ADL",
+    "Emit Merge Event",
+    "Emit a MERGE.SUCCESS / MERGE.FAILED / ISSUE.CLOSED.* / BRANCH.DELETED.* DCB event for the audit trail",
+    Kind = ActivityKind.Task
+)]
+public class EmitMergeEventActivity : Activity
+{
+    private readonly ILogger<EmitMergeEventActivity>? _logger;
+
+    [Input(Description = "Event type — MERGE.SUCCESS / MERGE.FAILED / ISSUE.CLOSED.* / BRANCH.DELETED.*")]
+    public Input<string> EventType { get; set; } = default!;
+
+    [Input(Description = "Issue number this merge resolves")]
+    public Input<int> IssueNumber { get; set; } = default!;
+
+    [Input(Description = "Pull request number being merged")]
+    public Input<int> PrNumber { get; set; } = default!;
+
+    [Input(Description = "Repository in owner/repo format")]
+    public Input<string> Repository { get; set; } = default!;
+
+    [Input(Description = "Tenant id (empty / single-user → platform-scope event)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [Input(Description = "Event data payload as JSON (mergeSha, mergeStrategy, issueClosed, branchDeleted, partial, failureCode, failureReason, durationMs)")]
+    public Input<string?> DataJson { get; set; } = new((string?)null);
+
+    [JsonConstructor]
+    public EmitMergeEventActivity() { }
+
+    public EmitMergeEventActivity(ILogger<EmitMergeEventActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var type = EventType.Get(context) ?? MergeEvents.Failed;
+        var issueNumber = IssueNumber.Get(context);
+        var prNumber = PrNumber.Get(context);
+        var repository = Repository.Get(context) ?? "";
+        var tenantId = MergeEvents.ParseTenantId(TenantId.Get(context));
+        var data = ParseData(DataJson.Get(context));
+
+        var evt = BuildTammaEvent(type, issueNumber, prNumber, repository, tenantId, data);
+        TammaEventEmitter.Emit(context, this, _logger, evt);
+
+        _logger?.LogInformation(
+            "Emitted {Type} for PR #{Pr} / issue #{Issue} in {Repo}",
+            type, prNumber, issueNumber, repository);
+
+        return default;
+    }
+
+    /// <summary>
+    /// Map the merge event inputs onto a <see cref="TammaEvent"/> expressed as the
+    /// engine's transient-list event so the merged drain persists it. Tags carry
+    /// the queryable DCB index keys (<c>issueId</c>/<c>issueNumber</c>/
+    /// <c>prNumber</c>/<c>repository</c>/<c>tenantId</c>); <c>Data</c> carries the
+    /// operation payload (mergeSha / strategy / sub-action results). Pure (no Elsa
+    /// context); exposed for testing.
+    /// </summary>
+    public static TammaEvent BuildTammaEvent(
+        string type,
+        int issueNumber,
+        int prNumber,
+        string repository,
+        Guid? tenantId,
+        IReadOnlyDictionary<string, object?>? data)
+    {
+        var tags = new Dictionary<string, object?>
+        {
+            ["issueId"] = issueNumber.ToString(),
+            ["issueNumber"] = issueNumber.ToString(),
+            ["prNumber"] = prNumber.ToString(),
+            ["prId"] = prNumber.ToString(),
+            ["repository"] = repository,
+        };
+        if (tenantId is not null) tags["tenantId"] = tenantId.Value.ToString("D");
+
+        return new TammaEvent
+        {
+            EventType = type,
+            Status = IsFailureType(type) ? "error" : "success",
+            Tags = tags,
+            Data = data is null
+                ? new Dictionary<string, object?>()
+                : new Dictionary<string, object?>(data),
+        };
+    }
+
+    /// <summary>
+    /// A <c>*.FAILED</c> event type carries an <c>error</c> status; everything else
+    /// (<c>*.SUCCESS</c> / <c>*.CHECKED</c>) is <c>success</c>.
+    /// </summary>
+    public static bool IsFailureType(string type)
+        => type.EndsWith(".FAILED", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Deserialize the JSON data payload into a dictionary for the event builder.
+    /// Returns null on empty/malformed input (the event still emits with "{}").
+    /// Exposed for unit testing the parse path.
+    /// </summary>
+    public static IReadOnlyDictionary<string, object?>? ParseData(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+        try
+        {
+            return System.Text.Json.JsonSerializer
+                .Deserialize<Dictionary<string, object?>>(json);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/MergeEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/MergeEvents.cs
@@ -1,0 +1,61 @@
+namespace Tamma.Activities.ADL;
+
+/// <summary>
+/// Story 2-10 (AC5) / Story 4.5 — central catalogue of the <c>MERGE.*</c>,
+/// <c>ISSUE.CLOSED.*</c>, and <c>BRANCH.DELETED.*</c> DCB event types emitted by
+/// the built-out <c>merge</c> workflow via <see cref="EmitMergeEventActivity"/>.
+///
+/// <para>The autonomous loop's MERGE step is issue-scoped, so merge events land
+/// in the tenant <c>domain_events</c> store (which carries a first-class
+/// <c>IssueNumber</c> column). The events are emitted via
+/// <c>TammaEventEmitter.Emit</c> into the workflow's <c>tamma:events</c>
+/// transient list and persisted <i>durably</i> by the engine event drain
+/// (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) — the same pattern
+/// <see cref="EmitPrEventActivity"/> / <see cref="EmitBranchEventActivity"/>
+/// use. No activity holds a DB / repository dependency of its own (none is
+/// registered in the Elsa engine — a directly-injected <c>IEventRepository</c>
+/// would be inert and silently drop the event).</para>
+///
+/// <para>Type pattern follows the platform's <c>AGGREGATE.ACTION.STATUS</c>
+/// convention.</para>
+///
+/// <list type="bullet">
+///   <item><description><c>MERGE.SUCCESS</c> — the PR merged (and post-merge
+///     close/delete ran). The umbrella merge event.</description></item>
+///   <item><description><c>MERGE.FAILED</c> — the merge did NOT happen
+///     (not-mergeable / conflict / permission / branch-protected / api error).
+///     ALWAYS emitted on the failure edge (loud, error-status) so the loop never
+///     reports a silent false success — the headline thin-wrapper bug. The
+///     merge-approval gate reads <c>success=false</c> and escalates.</description></item>
+///   <item><description><c>MERGE.READINESS.CHECKED</c> — reserved for an explicit
+///     pre-merge readiness gate (mergeable / CI / approvals). Currently the
+///     mergeable check is folded into the merge activity's idempotency/pre-merge
+///     read; this constant is the audit type if a standalone gate is added.</description></item>
+///   <item><description><c>ISSUE.CLOSED.SUCCESS</c> / <c>ISSUE.CLOSED.FAILED</c> —
+///     the post-merge issue-close sub-action result (surfaced separately so the
+///     audit stream shows partial completion, not just the umbrella event).</description></item>
+///   <item><description><c>BRANCH.DELETED.SUCCESS</c> / <c>BRANCH.DELETED.FAILED</c> —
+///     the post-merge branch-delete sub-action result (best-effort; a failed
+///     delete is a warning, not a merge failure).</description></item>
+/// </list>
+/// </summary>
+public static class MergeEvents
+{
+    public const string Success = "MERGE.SUCCESS";
+    public const string Failed = "MERGE.FAILED";
+    public const string ReadinessChecked = "MERGE.READINESS.CHECKED";
+
+    public const string IssueClosedSuccess = "ISSUE.CLOSED.SUCCESS";
+    public const string IssueClosedFailed = "ISSUE.CLOSED.FAILED";
+
+    public const string BranchDeletedSuccess = "BRANCH.DELETED.SUCCESS";
+    public const string BranchDeletedFailed = "BRANCH.DELETED.FAILED";
+
+    /// <summary>
+    /// Parse a tenant id from the loose string form threaded through the workflow
+    /// inputs. Returns <c>null</c> for empty / single-user / unparseable values
+    /// (merge events in single-user mode are platform-scope, TenantId null).
+    /// </summary>
+    public static Guid? ParseTenantId(string? tenantId)
+        => Guid.TryParse(tenantId, out var g) ? g : null;
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/MergePullRequestActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/MergePullRequestActivity.cs
@@ -5,27 +5,67 @@ using Elsa.Workflows.Activities.Flowchart.Attributes;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
 using Tamma.Core.Interfaces;
 
 namespace Tamma.Activities.ADL;
 
 /// <summary>
-/// Squash-merges the pull request, closes the issue, and deletes the feature branch.
+/// Merges the pull request (configurable strategy), closes the associated issue,
+/// and deletes the feature branch — with a pre-merge readiness/idempotency read,
+/// verified (not inferred) success, and an EXPLICIT failure outcome.
+///
+/// <para>Story 2-10 build-out. The thin wrapper merged blind, inferred success
+/// from a non-empty SHA, swallowed close-issue/branch-delete failures, and
+/// surfaced an <c>Error</c> outcome the workflow left dangling (a silent stall).
+/// This rewrite:</para>
+/// <list type="bullet">
+///   <item><description><b>Idempotency / pre-merge read</b> — fetch PR state first.
+///     Already-merged → success (reuse the existing merge SHA, skip re-merge: no
+///     GitHub 405 → spurious Error). Closed-unmerged or a confirmed conflict
+///     (<c>mergeable == false</c>) → an explicit <c>Error</c> (never a blind
+///     merge attempt). An <i>unknown</i> mergeable state does NOT block — GitHub
+///     often hasn't computed it yet; the merge call itself is the authoritative
+///     gate (a real conflict 405/409s, which we classify).</description></item>
+///   <item><description><b>Configurable strategy</b> — <c>merge | squash | rebase</c>
+///     (default squash) plumbed to the service.</description></item>
+///   <item><description><b>Verified success</b> — the close-issue and branch-delete
+///     results are captured into outputs. A merged PR whose issue-close failed
+///     completes <c>MergedWithWarnings</c> (success=true, partial=true), not a
+///     blanket clean success.</description></item>
+///   <item><description><b>Explicit failure</b> — a merge that did not happen
+///     classifies the failure (<c>merge_conflict | not_mergeable |
+///     permission_denied | branch_protected | ci_pending | api_error</c>), sets
+///     <c>FailureCode</c>/<c>FailureReason</c>, and completes <c>Error</c> (the
+///     workflow routes this to a loud <c>MERGE.FAILED</c> terminal with
+///     <c>success=false</c>).</description></item>
+/// </list>
+///
+/// <para>This is a <see cref="TammaOutcomeActivity"/> so the umbrella
+/// <c>PR.MERGE.STARTED/.COMPLETED/.FAILED</c> lifecycle events auto-emit; the
+/// workflow additionally emits the headline <c>MERGE.SUCCESS</c>/<c>MERGE.FAILED</c>
+/// + <c>ISSUE.CLOSED.*</c> + <c>BRANCH.DELETED.*</c> DCB events on the audit
+/// stream via <see cref="EmitMergeEventActivity"/>.</para>
 ///
 /// Outcomes:
-///   - Merged: PR merged, issue closed, branch deleted
-///   - Error: merge or cleanup failed
+///   - Merged:             PR merged, issue closed, branch deleted (clean).
+///   - MergedWithWarnings: PR merged, but a post-merge sub-action (issue close /
+///                         branch delete) failed — success=true, partial=true.
+///   - Error:              the merge did not happen — success=false (workflow
+///                         routes to the failure terminal).
 /// </summary>
 [Activity(
     "Tamma.ADL",
     "Merge Pull Request",
-    "Squash-merge PR, close issue, and delete feature branch",
+    "Merge PR (configurable strategy), close issue, and delete branch with an explicit failure path",
     Kind = ActivityKind.Task
 )]
-[FlowNode("Merged", "Error")]
-public class MergePullRequestActivity : Activity
+[FlowNode("Merged", "MergedWithWarnings", "Error")]
+public class MergePullRequestActivity : TammaOutcomeActivity
 {
-    private readonly ILogger<MergePullRequestActivity>? _logger;
+    /// <summary>Default merge strategy when none is supplied.</summary>
+    public const string DefaultStrategy = "squash";
+
     private readonly IGitHubIntegrationService? _github;
 
     [Input(Description = "Repository in owner/repo format")]
@@ -40,8 +80,35 @@ public class MergePullRequestActivity : Activity
     [Input(Description = "Branch to delete after merge")]
     public Input<string> BranchName { get; set; } = default!;
 
+    [Input(Description = "Merge strategy: merge | squash | rebase (default squash)")]
+    public Input<string> MergeStrategy { get; set; } = new(DefaultStrategy);
+
+    [Input(Description = "When false, skip deleting the feature branch after merge (default true)")]
+    public Input<bool> AutoDeleteBranch { get; set; } = new(true);
+
+    [Input(Description = "When false, skip closing the associated issue after merge (default true)")]
+    public Input<bool> CloseAssociatedIssue { get; set; } = new(true);
+
     [Output(Description = "Merge commit SHA")]
     public Output<string?> MergeSha { get; set; } = default!;
+
+    [Output(Description = "The strategy actually applied (echoes the input, normalized)")]
+    public Output<string?> AppliedStrategy { get; set; } = default!;
+
+    [Output(Description = "True when the associated issue was closed")]
+    public Output<bool> IssueClosed { get; set; } = default!;
+
+    [Output(Description = "True when the feature branch was deleted")]
+    public Output<bool> BranchDeleted { get; set; } = default!;
+
+    [Output(Description = "True when the PR was already merged (idempotent re-dispatch)")]
+    public Output<bool> AlreadyMerged { get; set; } = default!;
+
+    [Output(Description = "Failure classification when the Error outcome fires")]
+    public Output<string?> FailureCode { get; set; } = default!;
+
+    [Output(Description = "Human-readable failure / warning reason")]
+    public Output<string?> FailureReason { get; set; } = default!;
 
     [JsonConstructor]
     public MergePullRequestActivity() { }
@@ -50,55 +117,313 @@ public class MergePullRequestActivity : Activity
         ILogger<MergePullRequestActivity> logger,
         IGitHubIntegrationService github)
     {
-        _logger = logger;
+        Logger = logger;
         _github = github;
     }
 
-    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
+    /// <summary>
+    /// The umbrella merge lifecycle event prefix — drives the auto
+    /// <c>PR.MERGE.STARTED</c> / <c>PR.MERGE.COMPLETED</c> / <c>PR.MERGE.FAILED</c>
+    /// events on this <see cref="TammaOutcomeActivity"/>. The workflow emits the
+    /// richer headline <c>MERGE.*</c> + sub-action events separately.
+    /// </summary>
+    public override string? EventType => "PR.MERGE";
+
+    public override Dictionary<string, object?> BuildEndData(ActivityExecutionContext context) => new()
     {
-        var repository = Repository.Get(context);
+        ["prNumber"] = PrNumber.Get(context),
+        ["issueNumber"] = IssueNumber.Get(context),
+        ["repository"] = Repository.Get(context),
+        ["mergeStrategy"] = NormalizeStrategy(MergeStrategy.Get(context)),
+    };
+
+    protected override async Task RunAsync(ActivityExecutionContext context)
+    {
+        var repository = Repository.Get(context) ?? "";
         var prNumber = PrNumber.Get(context);
         var issueNumber = IssueNumber.Get(context);
-        var branchName = BranchName.Get(context);
+        var branchName = BranchName.Get(context) ?? "";
+        var strategy = NormalizeStrategy(MergeStrategy.Get(context));
+        var autoDeleteBranch = AutoDeleteBranch.Get(context);
+        var closeIssue = CloseAssociatedIssue.Get(context);
 
+        var github = _github ?? context.GetService<IGitHubIntegrationService>();
+        if (github is null)
+        {
+            Logger?.LogError("GitHub integration service unavailable — cannot merge PR #{Pr}", prNumber);
+            FailureCode.Set(context, "github-service-unavailable");
+            FailureReason.Set(context, "GitHub integration service unavailable");
+            MergeSha.Set(context, "");
+            await context.CompleteActivityWithOutcomesAsync("Error");
+            return;
+        }
+
+        var outcome = await ExecuteCoreAsync(
+            github, repository, prNumber, issueNumber, branchName, strategy,
+            autoDeleteBranch, closeIssue, Logger);
+
+        MergeSha.Set(context, outcome.MergeSha ?? "");
+        AppliedStrategy.Set(context, strategy);
+        IssueClosed.Set(context, outcome.IssueClosed);
+        BranchDeleted.Set(context, outcome.BranchDeleted);
+        AlreadyMerged.Set(context, outcome.AlreadyMerged);
+        FailureCode.Set(context, outcome.FailureCode);
+        FailureReason.Set(context, outcome.FailureReason);
+
+        await context.CompleteActivityWithOutcomesAsync(outcome.Outcome);
+    }
+
+    /// <summary>
+    /// Pure orchestration core (no Elsa context): pre-merge read (idempotency +
+    /// confirmed-conflict gate) → merge (configurable strategy) → verified
+    /// close-issue + best-effort branch-delete → typed outcome. NEVER throws — an
+    /// unexpected exception becomes an <c>Error</c> outcome (no silent success);
+    /// a merge that did not happen is ALWAYS an Error (never a fabricated SHA).
+    /// Returns a typed outcome so happy / idempotency / conflict / permission /
+    /// partial paths are unit-testable against a mocked
+    /// <see cref="IGitHubIntegrationService"/>.
+    /// </summary>
+    public static async Task<MergeOutcome> ExecuteCoreAsync(
+        IGitHubIntegrationService github,
+        string repository,
+        int prNumber,
+        int issueNumber,
+        string branchName,
+        string strategy,
+        bool autoDeleteBranch,
+        bool closeIssue,
+        ILogger? logger = null)
+    {
         try
         {
-            // 1. Squash-merge the PR
-            var mergeResult = await _github!.MergeGitHubPullRequestAsync(repository, prNumber);
+            // ── 1. Pre-merge read: idempotency + confirmed-conflict gate ──
+            var detail = await github.GetGitHubPullRequestAsync(repository, prNumber);
+            if (!detail.Success)
+            {
+                // A transient read failure must NOT be mistaken for "go ahead and
+                // merge blind". Classify and fail explicit (the merge gate already
+                // gave human approval; a read outage is a real failure here).
+                var code = ClassifyError(detail.Error);
+                logger?.LogError("Pre-merge PR #{Pr} read failed: {Error}", prNumber, detail.Error);
+                return MergeOutcome.Failed(code, detail.Error ?? "pre-merge PR read failed");
+            }
+
+            var pr = detail.Data;
+            if (pr is not null && pr.Merged)
+            {
+                // Idempotent re-dispatch / webhook double-fire — already merged.
+                // Reuse the existing merge SHA, run the post-merge cleanup, treat
+                // as success. Never re-PUT /merge (that 405s on a merged PR).
+                logger?.LogInformation("PR #{Pr} already merged ({Sha}) — idempotent path", prNumber, pr.MergeCommitSha ?? "?");
+                return await CompletePostMergeAsync(
+                    github, repository, issueNumber, branchName,
+                    pr.MergeCommitSha ?? "", alreadyMerged: true,
+                    autoDeleteBranch, closeIssue, logger);
+            }
+
+            if (pr is not null && string.Equals(pr.State, "closed", StringComparison.OrdinalIgnoreCase))
+            {
+                // Closed but NOT merged → there is nothing to merge; failing
+                // explicit beats a blind merge that 405s.
+                logger?.LogError("PR #{Pr} is closed but not merged — cannot merge", prNumber);
+                return MergeOutcome.Failed("not_mergeable", $"PR #{prNumber} is closed but not merged");
+            }
+
+            if (pr is not null && pr.Mergeable == false)
+            {
+                // GitHub has CONFIRMED a conflict (mergeable == false). Fail
+                // explicit with the conflict reason — never attempt a doomed
+                // merge. (Mergeable == null = not yet computed → fall through; the
+                // merge call is then the authoritative gate.)
+                var reason = string.IsNullOrWhiteSpace(pr.MergeableState)
+                    ? $"PR #{prNumber} has merge conflicts"
+                    : $"PR #{prNumber} not mergeable (state: {pr.MergeableState})";
+                logger?.LogError("PR #{Pr} not mergeable ({State})", prNumber, pr.MergeableState ?? "dirty");
+                return MergeOutcome.Failed("merge_conflict", reason);
+            }
+
+            // ── 2. Merge (configurable strategy) ──
+            var mergeResult = await github.MergeGitHubPullRequestAsync(repository, prNumber, strategy);
             if (!mergeResult.Success)
             {
-                _logger?.LogError("Failed to merge PR #{Number}: {Error}",
-                    prNumber, mergeResult.Error);
-                await context.CompleteActivityWithOutcomesAsync("Error");
-                return;
+                var code = ClassifyError(mergeResult.Error);
+                logger?.LogError("Failed to merge PR #{Pr}: {Error}", prNumber, mergeResult.Error);
+                return MergeOutcome.Failed(code, mergeResult.Error ?? "merge failed");
             }
 
-            MergeSha.Set(context, mergeResult.Data?.MergeSha);
-
-            // 2. Close the issue with a comment
-            var comment = $"Resolved by PR #{prNumber} (merge SHA: {mergeResult.Data?.MergeSha})";
-            await _github.CloseGitHubIssueAsync(repository, issueNumber, comment);
-
-            // 3. Delete the feature branch (best-effort)
-            try
+            var mergeSha = mergeResult.Data?.MergeSha ?? "";
+            if (string.IsNullOrEmpty(mergeSha))
             {
-                await _github.DeleteGitHubBranchAsync(repository, branchName);
-            }
-            catch (Exception ex)
-            {
-                _logger?.LogWarning(ex, "Failed to delete branch {Branch} (non-fatal)", branchName);
+                // The merge call reported success but no SHA — do not fabricate
+                // one; treat as a failed (un-verifiable) merge.
+                logger?.LogError("Merge of PR #{Pr} returned success with no SHA — treating as failure", prNumber);
+                return MergeOutcome.Failed("api_error", "merge reported success but returned no commit SHA");
             }
 
-            _logger?.LogInformation(
-                "Merged PR #{PrNumber}, closed issue #{IssueNumber}, deleted branch {Branch}",
-                prNumber, issueNumber, branchName);
+            logger?.LogInformation("Merged PR #{Pr} (strategy {Strategy}) → {Sha}", prNumber, strategy, mergeSha);
 
-            await context.CompleteActivityWithOutcomesAsync("Merged");
+            // ── 3. Verified post-merge cleanup ──
+            return await CompletePostMergeAsync(
+                github, repository, issueNumber, branchName, mergeSha,
+                alreadyMerged: false, autoDeleteBranch, closeIssue, logger);
         }
         catch (Exception ex)
         {
-            _logger?.LogError(ex, "Error merging PR #{Number}", prNumber);
-            await context.CompleteActivityWithOutcomesAsync("Error");
+            logger?.LogError(ex, "Error merging PR #{Pr}", prNumber);
+            return MergeOutcome.Failed("api_error", ex.Message);
         }
     }
+
+    /// <summary>
+    /// Post-merge close-issue (verified) + branch-delete (best-effort). A failed
+    /// issue-close downgrades the merged result to <c>MergedWithWarnings</c>
+    /// (success=true, partial=true) — the merge stands but the audit shows it was
+    /// not fully clean. A failed branch-delete is a warning only (the PRD treats
+    /// branch cleanup as best-effort), but it is still surfaced as a warning +
+    /// emitted as <c>BRANCH.DELETED.FAILED</c> by the workflow.
+    /// </summary>
+    private static async Task<MergeOutcome> CompletePostMergeAsync(
+        IGitHubIntegrationService github,
+        string repository,
+        int issueNumber,
+        string branchName,
+        string mergeSha,
+        bool alreadyMerged,
+        bool autoDeleteBranch,
+        bool closeIssue,
+        ILogger? logger)
+    {
+        var warnings = new List<string>();
+        var issueClosed = false;
+        var branchDeleted = false;
+
+        // Close the issue (verified — capture the result).
+        if (closeIssue && issueNumber > 0)
+        {
+            try
+            {
+                var comment = $"Resolved by PR (merge SHA: {mergeSha}).";
+                var close = await github.CloseGitHubIssueAsync(repository, issueNumber, comment);
+                issueClosed = close.Success && close.Data;
+                if (!issueClosed)
+                {
+                    var reason = close.Error ?? "issue close returned an unsuccessful result";
+                    logger?.LogWarning("Failed to close issue #{Issue} after merge: {Error}", issueNumber, reason);
+                    warnings.Add($"issue-close-failed: {reason}");
+                }
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex, "Failed to close issue #{Issue} after merge (non-fatal to merge)", issueNumber);
+                warnings.Add($"issue-close-failed: {ex.Message}");
+            }
+        }
+        else
+        {
+            // Closing disabled or no issue → not a warning; just not done.
+            issueClosed = false;
+        }
+
+        // Delete the feature branch (best-effort).
+        if (autoDeleteBranch && !string.IsNullOrWhiteSpace(branchName))
+        {
+            try
+            {
+                var del = await github.DeleteGitHubBranchAsync(repository, branchName);
+                branchDeleted = del.Success && del.Data;
+                if (!branchDeleted)
+                {
+                    var reason = del.Error ?? "branch delete returned an unsuccessful result";
+                    logger?.LogWarning("Failed to delete branch {Branch} after merge: {Error}", branchName, reason);
+                    warnings.Add($"branch-delete-failed: {reason}");
+                }
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex, "Failed to delete branch {Branch} after merge (non-fatal)", branchName);
+                warnings.Add($"branch-delete-failed: {ex.Message}");
+            }
+        }
+
+        return MergeOutcome.Merged(
+            mergeSha, issueClosed, branchDeleted, alreadyMerged,
+            warnings.Count == 0 ? null : string.Join("; ", warnings));
+    }
+
+    /// <summary>
+    /// Normalize a merge strategy token to <c>merge | squash | rebase</c>; an
+    /// unknown / empty value falls back to <c>squash</c> (the platform default).
+    /// </summary>
+    public static string NormalizeStrategy(string? strategy)
+        => (strategy ?? "").Trim().ToLowerInvariant() switch
+        {
+            "merge" => "merge",
+            "rebase" => "rebase",
+            _ => DefaultStrategy,
+        };
+
+    /// <summary>
+    /// Classify a merge / read failure (Story 2-10 AC8): permission /
+    /// merge-conflict / branch-protected / not-mergeable / ci-pending / transient
+    /// (api_error). The integration layer surfaces a status-prefixed message
+    /// (e.g. <c>"409: ..."</c> / <c>"405: ..."</c>) or a typed sentinel.
+    /// </summary>
+    public static string ClassifyError(string? error)
+    {
+        if (string.IsNullOrWhiteSpace(error)) return "api_error";
+        var lower = error.ToLowerInvariant();
+        if (lower.Contains("conflict") || lower.StartsWith("409")) return "merge_conflict";
+        if (lower.Contains("403") || lower.Contains("forbidden") || lower.Contains("permission")) return "permission_denied";
+        if (lower.Contains("protected") || lower.Contains("required status check") || lower.Contains("review")) return "branch_protected";
+        if (lower.Contains("405") || lower.Contains("not mergeable") || lower.Contains("not_mergeable")) return "not_mergeable";
+        if (lower.Contains("pending") || lower.Contains("checks are not")) return "ci_pending";
+        if (lower.Contains("429") || lower.Contains("rate limit")
+            || lower.Contains("500") || lower.Contains("502") || lower.Contains("503") || lower.Contains("504")
+            || lower.Contains("timeout") || lower.Contains("unavailable")) return "api_error";
+        return "api_error";
+    }
+}
+
+/// <summary>
+/// Typed result of <see cref="MergePullRequestActivity.ExecuteCoreAsync"/> — maps
+/// to the activity's Elsa outcome (Merged / MergedWithWarnings / Error). On
+/// failure <see cref="MergeSha"/> is empty so a consumer can never read a false
+/// merge; the workflow's <c>SetSuccess</c> reads <c>Outcome != "Error"</c>, NOT a
+/// non-empty SHA (the old false-success inference).
+/// </summary>
+public sealed class MergeOutcome
+{
+    public string Outcome { get; init; } = "Error";
+    public string? MergeSha { get; init; }
+    public bool IssueClosed { get; init; }
+    public bool BranchDeleted { get; init; }
+    public bool AlreadyMerged { get; init; }
+    public bool Partial { get; init; }
+    public string? FailureCode { get; init; }
+    public string? FailureReason { get; init; }
+
+    /// <summary>True when the merge happened (clean OR with warnings).</summary>
+    public bool MergeSucceeded => Outcome != "Error";
+
+    public static MergeOutcome Merged(
+        string mergeSha, bool issueClosed, bool branchDeleted, bool alreadyMerged, string? warnings)
+        => new()
+        {
+            Outcome = warnings is null ? "Merged" : "MergedWithWarnings",
+            MergeSha = mergeSha,
+            IssueClosed = issueClosed,
+            BranchDeleted = branchDeleted,
+            AlreadyMerged = alreadyMerged,
+            Partial = warnings is not null,
+            FailureReason = warnings,
+        };
+
+    public static MergeOutcome Failed(string failureCode, string failureReason)
+        => new()
+        {
+            Outcome = "Error",
+            MergeSha = "",
+            FailureCode = failureCode,
+            FailureReason = failureReason,
+        };
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/GitHubIntegrationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/GitHubIntegrationService.cs
@@ -336,24 +336,40 @@ public class GitHubIntegrationService : IGitHubIntegrationService
         }
     }
 
-    public async Task<IntegrationResult<GitHubMergeResult>> MergeGitHubPullRequestAsync(string repository, int pullRequestNumber)
+    public Task<IntegrationResult<GitHubMergeResult>> MergeGitHubPullRequestAsync(string repository, int pullRequestNumber)
+        => MergeGitHubPullRequestAsync(repository, pullRequestNumber, "squash");
+
+    public async Task<IntegrationResult<GitHubMergeResult>> MergeGitHubPullRequestAsync(string repository, int pullRequestNumber, string mergeStrategy)
     {
         var httpClient = _httpClientFactory.CreateClient("github");
 
         try
         {
-            _logger.LogInformation("Merging PR #{Number} in {Repo}", pullRequestNumber, repository);
+            var method = NormalizeMergeMethod(mergeStrategy);
+            _logger.LogInformation(
+                "Merging PR #{Number} in {Repo} (method {Method})", pullRequestNumber, repository, method);
 
-            var payload = new { merge_method = "squash" };
+            var payload = new { merge_method = method };
             var response = await httpClient.PutAsJsonAsync(
                 $"/repos/{repository}/pulls/{pullRequestNumber}/merge", payload);
-            response.EnsureSuccessStatusCode();
+            if (!response.IsSuccessStatusCode)
+            {
+                // Surface the status code + body so the merge activity can classify
+                // the failure (409 conflict / 403 permission / 405 not-mergeable /
+                // 422 branch-protected) rather than collapsing every error into a
+                // bare throw → blind Error outcome.
+                var body = await response.Content.ReadAsStringAsync();
+                _logger.LogError(
+                    "Failed to merge PR #{Number} in {Repo}: {Status} {Body}",
+                    pullRequestNumber, repository, (int)response.StatusCode, body);
+                return IntegrationResult<GitHubMergeResult>.Fail($"{(int)response.StatusCode}: {body}");
+            }
 
             var data = await response.Content.ReadFromJsonAsync<JsonElement>();
             var result = new GitHubMergeResult
             {
-                Success = data.GetProperty("merged").GetBoolean(),
-                MergeSha = data.GetProperty("sha").GetString() ?? ""
+                Success = data.TryGetProperty("merged", out var m) && m.GetBoolean(),
+                MergeSha = data.TryGetProperty("sha", out var s) ? s.GetString() ?? "" : ""
             };
             return IntegrationResult<GitHubMergeResult>.Ok(result);
         }
@@ -361,6 +377,65 @@ public class GitHubIntegrationService : IGitHubIntegrationService
         {
             _logger.LogError(ex, "Failed to merge GitHub PR #{Number}", pullRequestNumber);
             return IntegrationResult<GitHubMergeResult>.Fail(ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Map a Tamma merge strategy (<c>merge | squash | rebase</c>) to GitHub's
+    /// <c>merge_method</c>; an unknown / empty value falls back to <c>squash</c>
+    /// (the platform default).
+    /// </summary>
+    internal static string NormalizeMergeMethod(string? strategy)
+        => (strategy ?? "").Trim().ToLowerInvariant() switch
+        {
+            "merge" => "merge",
+            "rebase" => "rebase",
+            _ => "squash",
+        };
+
+    public async Task<IntegrationResult<GitHubPullRequestDetail>> GetGitHubPullRequestAsync(string repository, int pullRequestNumber)
+    {
+        var httpClient = _httpClientFactory.CreateClient("github");
+
+        try
+        {
+            var response = await httpClient.GetAsync($"/repos/{repository}/pulls/{pullRequestNumber}");
+            if (!response.IsSuccessStatusCode)
+            {
+                var body = await response.Content.ReadAsStringAsync();
+                _logger.LogError(
+                    "Failed to read PR #{Number} in {Repo}: {Status} {Body}",
+                    pullRequestNumber, repository, (int)response.StatusCode, body);
+                return IntegrationResult<GitHubPullRequestDetail>.Fail($"{(int)response.StatusCode}: {body}");
+            }
+
+            var pr = await response.Content.ReadFromJsonAsync<JsonElement>();
+            var detail = new GitHubPullRequestDetail
+            {
+                Number = pr.TryGetProperty("number", out var n) ? n.GetInt32() : pullRequestNumber,
+                State = pr.TryGetProperty("state", out var st) ? st.GetString() ?? "open" : "open",
+                Merged = pr.TryGetProperty("merged", out var mg) && mg.ValueKind == JsonValueKind.True,
+                MergeCommitSha = pr.TryGetProperty("merge_commit_sha", out var ms) && ms.ValueKind == JsonValueKind.String
+                    ? ms.GetString() : null,
+                // `mergeable` is true/false/null (null = GitHub still computing).
+                Mergeable = pr.TryGetProperty("mergeable", out var ma)
+                    ? ma.ValueKind switch
+                    {
+                        JsonValueKind.True => true,
+                        JsonValueKind.False => false,
+                        _ => (bool?)null,
+                    }
+                    : null,
+                MergeableState = pr.TryGetProperty("mergeable_state", out var mst) && mst.ValueKind == JsonValueKind.String
+                    ? mst.GetString() : null,
+                IsDraft = pr.TryGetProperty("draft", out var d) && d.ValueKind == JsonValueKind.True,
+            };
+            return IntegrationResult<GitHubPullRequestDetail>.Ok(detail);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to read GitHub PR #{Number} in {Repo}", pullRequestNumber, repository);
+            return IntegrationResult<GitHubPullRequestDetail>.Fail(ex.Message);
         }
     }
 

--- a/apps/tamma-elsa/src/Tamma.Api/Services/IntegrationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/IntegrationService.cs
@@ -126,6 +126,22 @@ public class IntegrationService : IIntegrationService
             : new GitHubMergeResult { Success = false, Error = result.Error };
     }
 
+    public async Task<GitHubMergeResult> MergeGitHubPullRequestAsync(string repository, int pullRequestNumber, string mergeStrategy)
+    {
+        var result = await _github.MergeGitHubPullRequestAsync(repository, pullRequestNumber, mergeStrategy);
+        return result.Success
+            ? result.Data!
+            : new GitHubMergeResult { Success = false, Error = result.Error };
+    }
+
+    public async Task<GitHubPullRequestDetail> GetGitHubPullRequestAsync(string repository, int pullRequestNumber)
+    {
+        var result = await _github.GetGitHubPullRequestAsync(repository, pullRequestNumber);
+        if (!result.Success)
+            throw new InvalidOperationException(result.Error);
+        return result.Data!;
+    }
+
     public async Task<List<GitHubFileChange>> GetGitHubFileChangesAsync(string repository, string branch)
     {
         var result = await _github.GetGitHubFileChangesAsync(repository, branch);

--- a/apps/tamma-elsa/src/Tamma.Core/Interfaces/IIntegrationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Interfaces/IIntegrationService.cs
@@ -77,8 +77,27 @@ public interface IGitHubIntegrationService
     /// </summary>
     Task<IntegrationResult<GitHubPullRequestResult>> UpdateGitHubPullRequestAsync(string repository, int pullRequestNumber, CreatePullRequestRequest request);
 
-    /// <summary>Merge a pull request</summary>
+    /// <summary>Merge a pull request (squash strategy — back-compat overload).</summary>
     Task<IntegrationResult<GitHubMergeResult>> MergeGitHubPullRequestAsync(string repository, int pullRequestNumber);
+
+    /// <summary>
+    /// Merge a pull request with an explicit <paramref name="mergeStrategy"/>
+    /// (<c>merge | squash | rebase</c>; Story 2-10 — configurable strategy). The
+    /// strategy is mapped to GitHub's <c>merge_method</c>; an unknown value falls
+    /// back to <c>squash</c>. Replaces the previously hardcoded squash-only merge.
+    /// </summary>
+    Task<IntegrationResult<GitHubMergeResult>> MergeGitHubPullRequestAsync(string repository, int pullRequestNumber, string mergeStrategy);
+
+    /// <summary>
+    /// Read a pull request's lifecycle state (Story 2-10 — idempotency +
+    /// pre-merge readiness). Surfaces <c>State</c> (open/closed), <c>Merged</c>,
+    /// the <c>MergeCommitSha</c> when already merged, and the GitHub
+    /// <c>Mergeable</c> / <c>MergeableState</c> conflict signals. <c>Mergeable</c>
+    /// is <c>null</c> when GitHub has not finished computing it (the caller must
+    /// treat unknown as "not yet confirmed mergeable", never proceed blind).
+    /// Returns <c>Fail</c> on API error (never a fabricated state).
+    /// </summary>
+    Task<IntegrationResult<GitHubPullRequestDetail>> GetGitHubPullRequestAsync(string repository, int pullRequestNumber);
 
     /// <summary>Get file changes from a branch</summary>
     Task<IntegrationResult<List<GitHubFileChange>>> GetGitHubFileChangesAsync(string repository, string branch);
@@ -175,8 +194,14 @@ public interface IIntegrationService
     /// <summary>Update an existing pull request's title / body / labels</summary>
     Task<GitHubPullRequestResult> UpdateGitHubPullRequestAsync(string repository, int pullRequestNumber, CreatePullRequestRequest request);
 
-    /// <summary>Merge a pull request</summary>
+    /// <summary>Merge a pull request (squash strategy — back-compat overload).</summary>
     Task<GitHubMergeResult> MergeGitHubPullRequestAsync(string repository, int pullRequestNumber);
+
+    /// <summary>Merge a pull request with an explicit strategy (merge | squash | rebase).</summary>
+    Task<GitHubMergeResult> MergeGitHubPullRequestAsync(string repository, int pullRequestNumber, string mergeStrategy);
+
+    /// <summary>Read a pull request's lifecycle state (idempotency / pre-merge readiness).</summary>
+    Task<GitHubPullRequestDetail> GetGitHubPullRequestAsync(string repository, int pullRequestNumber);
 
     /// <summary>Get file changes from a branch</summary>
     Task<List<GitHubFileChange>> GetGitHubFileChangesAsync(string repository, string branch);
@@ -271,6 +296,42 @@ public class GitHubMergeResult
     public bool Success { get; set; }
     public string? MergeSha { get; set; }
     public string? Error { get; set; }
+}
+
+/// <summary>
+/// Pull-request lifecycle detail returned by
+/// <see cref="IGitHubIntegrationService.GetGitHubPullRequestAsync"/> — backs
+/// Story 2-10 idempotency (already-merged → skip re-merge) and the pre-merge
+/// readiness/conflict gate.
+/// </summary>
+public class GitHubPullRequestDetail
+{
+    public int Number { get; set; }
+
+    /// <summary>open | closed.</summary>
+    public string State { get; set; } = "open";
+
+    /// <summary>True when the PR has already been merged.</summary>
+    public bool Merged { get; set; }
+
+    /// <summary>The merge commit SHA when <see cref="Merged"/> is true.</summary>
+    public string? MergeCommitSha { get; set; }
+
+    /// <summary>
+    /// GitHub's <c>mergeable</c> flag: <c>true</c> = no conflicts, <c>false</c> =
+    /// conflicts, <c>null</c> = not yet computed (GitHub is still calculating —
+    /// the caller must NOT treat unknown as mergeable).
+    /// </summary>
+    public bool? Mergeable { get; set; }
+
+    /// <summary>
+    /// GitHub's <c>mergeable_state</c> (e.g. <c>clean</c>, <c>dirty</c>,
+    /// <c>blocked</c>, <c>behind</c>, <c>unstable</c>, <c>unknown</c>). Surfaced
+    /// for the readiness gate's blocking-reason message.
+    /// </summary>
+    public string? MergeableState { get; set; }
+
+    public bool IsDraft { get; set; }
 }
 
 /// <summary>

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/MergeWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/MergeWorkflow.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Elsa.Extensions;
 using Elsa.Workflows;
 using Elsa.Workflows.Activities;
@@ -8,9 +9,48 @@ using Elsa.Workflows.Models;
 using Tamma.Activities.ADL;
 using FlowEndpoint = Elsa.Workflows.Activities.Flowchart.Models.Endpoint;
 using FlowConnection = Elsa.Workflows.Activities.Flowchart.Models.Connection;
+using static Tamma.ElsaServer.Workflows.ActivityDisplayTextExtensions;
 
 namespace Tamma.ElsaServer.Workflows;
 
+/// <summary>
+/// Merge Complete — the <b>MERGE</b> step of the 14-step autonomous loop
+/// (<c>docs/architecture.md</c>): merge the PR (configurable strategy), close the
+/// associated issue, delete the feature branch, and audit every transition.
+/// Dispatched by the <c>merge-approval</c> gate with <c>WaitForCompletion=true</c>;
+/// the gate READS this workflow's <c>success</c> output and routes a failed merge
+/// (<c>success=false</c>) to its loud escalate terminal (never the merge/success
+/// terminal, which would hang the cycle on a pr-merged webhook that never fires).
+///
+/// <para>Story 2-10 build-out. The thin wrapper was a four-node linear chain whose
+/// <c>Error</c> outcome was UNWIRED — a failed merge dead-ended the flowchart with
+/// no failure terminal, no <c>success</c> output, and no event (a silent stall),
+/// and it inferred <c>success</c> from a non-empty SHA. This build-out:</para>
+/// <list type="bullet">
+///   <item><description>Wires the activity's <c>Error</c> outcome to an EXPLICIT
+///     failure terminal: <c>success=false</c> + a loud <c>MERGE.FAILED</c> DCB
+///     event with the failure code/reason. No dead-end, no false success.</description></item>
+///   <item><description>Verifies (not infers) success: <c>success</c> = the merge
+///     happened (Merged / MergedWithWarnings), NOT "SHA non-empty". A merged PR
+///     whose post-merge issue-close failed routes to <c>MergedWithWarnings</c>
+///     (success=true, partial=true) — honest, not a blanket clean success.</description></item>
+///   <item><description>Emits <c>MERGE.SUCCESS</c>/<c>MERGE.FAILED</c> +
+///     <c>ISSUE.CLOSED.*</c> + <c>BRANCH.DELETED.*</c> DCB events through the
+///     durable engine drain (the activity itself, a <c>TammaOutcomeActivity</c>,
+///     also auto-emits <c>PR.MERGE.STARTED/.COMPLETED/.FAILED</c>).</description></item>
+///   <item><description>Idempotency + a configurable strategy live in the
+///     activity (already-merged → success, no 405; <c>merge|squash|rebase</c>).</description></item>
+/// </list>
+///
+/// Flow:
+///   ReadInputs → MergePR
+///     ├─ Merged             → EmitSuccess (MERGE.SUCCESS + sub-action events) → SuccessOutputs (success=true) → Finish
+///     ├─ MergedWithWarnings → EmitSuccess (MERGE.SUCCESS partial + sub-action events) → SuccessOutputs (success=true, partial) → Finish
+///     └─ Error              → FailureOutputs (success=false) → EmitFailed (MERGE.FAILED) → Finish
+///
+/// Inputs:  repository, prNumber, issueNumber, branchName, mergeStrategy?, tenantId?.
+/// Outputs: success (bool — the gate's contract), mergeSha, partial, failureCode/failureReason.
+/// </summary>
 public class MergeWorkflow : WorkflowBase
 {
     protected override void Build(IWorkflowBuilder builder)
@@ -18,58 +58,268 @@ public class MergeWorkflow : WorkflowBase
         builder.Name = "Merge Complete";
         builder.DefinitionId = "merge";
         builder.Version = WorkflowVersions.ComputedVersion;
-        builder.Description = "Squash-merge PR, close issue, and delete branch";
+        builder.Description = "Merge PR (configurable strategy), close issue, delete branch — with an explicit failure path, verified success, and durable MERGE.* DCB events";
+
+        // ================================================================
+        // Variables
+        // ================================================================
+        var repositoryVar = builder.WithVariable<string>("Repository", "");
+        var prNumberVar = builder.WithVariable<int>("PrNumber", 0);
+        var issueNumberVar = builder.WithVariable<int>("IssueNumber", 0);
+        var branchNameVar = builder.WithVariable<string>("BranchName", "");
+        var mergeStrategyVar = builder.WithVariable<string>("MergeStrategy", MergePullRequestActivity.DefaultStrategy);
+        var tenantIdVar = builder.WithVariable<string>("TenantId", "");
 
         var mergeShaVar = builder.WithVariable<string>("MergeSha", "");
-        var successVar = builder.WithVariable<bool>("Success", false);
+        var issueClosedVar = builder.WithVariable<bool>("IssueClosed", false);
+        var branchDeletedVar = builder.WithVariable<bool>("BranchDeleted", false);
+        var alreadyMergedVar = builder.WithVariable<bool>("AlreadyMerged", false);
+        var failureCodeVar = builder.WithVariable<string>("FailureCode", "");
+        var failureReasonVar = builder.WithVariable<string>("FailureReason", "");
+        var startedAtTicksVar = builder.WithVariable<long>("StartedAtTicks", 0);
 
+        // ================================================================
+        // 1. Read inputs (the merge-approval gate dispatches repository/prNumber/
+        //    branchName/issueNumber; mergeStrategy/tenantId are optional — bound
+        //    with safe defaults when absent so the gate's existing contract is
+        //    untouched).
+        // ================================================================
+        var readInputs = new SetVariable
+        {
+            Id = "ReadInputs", Name = "Read Inputs",
+            Variable = repositoryVar,
+            Value = new Input<object?>(ctx =>
+            {
+                var repo = ctx.GetInput<string>("repository") ?? "";
+                prNumberVar.Set(ctx, ctx.GetInput<int>("prNumber"));
+                issueNumberVar.Set(ctx, ctx.GetInput<int>("issueNumber"));
+                branchNameVar.Set(ctx, ctx.GetInput<string>("branchName") ?? "");
+
+                var strategy = ctx.GetInput<string>("mergeStrategy");
+                mergeStrategyVar.Set(ctx, MergePullRequestActivity.NormalizeStrategy(strategy));
+
+                tenantIdVar.Set(ctx, ctx.GetInput<string>("tenantId") ?? "");
+                startedAtTicksVar.Set(ctx, DateTime.UtcNow.Ticks);
+                return (object)repo;
+            })
+        };
+        readInputs.SetDisplayText("Read Inputs");
+
+        // ================================================================
+        // 2. Merge the PR (outcome-bearing — Merged / MergedWithWarnings / Error)
+        // ================================================================
         var mergePr = new MergePullRequestActivity
         {
             Id = "MergePR", Name = "Merge PR",
-            Repository = new Input<string>(ctx => ctx.GetInput<string>("repository") ?? ""),
-            PrNumber = new Input<int>(ctx => ctx.GetInput<int>("prNumber")),
-            IssueNumber = new Input<int>(ctx => ctx.GetInput<int>("issueNumber")),
-            BranchName = new Input<string>(ctx => ctx.GetInput<string>("branchName") ?? ""),
-            MergeSha = new Output<string?>(mergeShaVar)
+            Repository = new Input<string>(ctx => repositoryVar.Get(ctx)),
+            PrNumber = new Input<int>(ctx => prNumberVar.Get(ctx)),
+            IssueNumber = new Input<int>(ctx => issueNumberVar.Get(ctx)),
+            BranchName = new Input<string>(ctx => branchNameVar.Get(ctx)),
+            MergeStrategy = new Input<string>(ctx => mergeStrategyVar.Get(ctx)),
+            MergeSha = new Output<string?>(mergeShaVar),
+            IssueClosed = new Output<bool>(issueClosedVar),
+            BranchDeleted = new Output<bool>(branchDeletedVar),
+            AlreadyMerged = new Output<bool>(alreadyMergedVar),
+            FailureCode = new Output<string?>(failureCodeVar),
+            FailureReason = new Output<string?>(failureReasonVar),
         };
         mergePr.SetDisplayText("Merge PR");
 
-        // CRITICAL-2 — the merge activity's typed `Error` outcome used to be
-        // SWALLOWED: a single portless Connect(mergePr, setSuccess) only matches
-        // the activity's first/default outcome, so on Error the flow stalled and
-        // `success` was never emitted. The merge-approval gate reads `success` and
-        // routes a failed merge to its loud escalate terminal (instead of the
-        // success terminal, which would hang the cycle on a merge webhook that
-        // never fires). So set `success` EXPLICITLY on BOTH outcomes:
-        //   Merged → success = (mergeSha non-empty)
-        //   Error  → success = false  (and mergeSha stays empty)
-        var setSuccess = new SetVariable { Id = "SetMergeSuccess", Name = "Set Success", Variable = successVar, Value = new Input<object?>(ctx => (object)!string.IsNullOrEmpty(mergeShaVar.Get(ctx))) };
-        setSuccess.SetDisplayText("Set Success");
-        var setFailure = new SetVariable { Id = "SetMergeFailure", Name = "Set Failure", Variable = successVar, Value = new Input<object?>(_ => (object)false) };
-        setFailure.SetDisplayText("Set Failure");
-        var outputSuccess = new SetOutput { Id = "OutputSuccess", Name = "Output Success", OutputName = new("success"), OutputValue = new(ctx => (object)successVar.Get(ctx)) };
-        outputSuccess.SetDisplayText("Output Success");
-        var outputMergeSha = new SetOutput { Id = "OutputMergeSha", Name = "Output Merge SHA", OutputName = new("mergeSha"), OutputValue = new(ctx => (object)(mergeShaVar.Get(ctx) ?? "")) };
-        outputMergeSha.SetDisplayText("Output Merge SHA");
+        // ================================================================
+        // 3. Success path — emit MERGE.SUCCESS + the issue-close / branch-delete
+        //    sub-action events, then the outputs. Shared by BOTH Merged and
+        //    MergedWithWarnings (the success/partial distinction is in the data +
+        //    the `partial` output; `success` is true for both).
+        // ================================================================
+        var emitMergeSuccess = new EmitMergeEventActivity
+        {
+            Id = "EmitSuccess", Name = "Emit MERGE.SUCCESS",
+            EventType = new Input<string>(_ => MergeEvents.Success),
+            IssueNumber = new Input<int>(ctx => issueNumberVar.Get(ctx)),
+            PrNumber = new Input<int>(ctx => prNumberVar.Get(ctx)),
+            Repository = new Input<string>(ctx => repositoryVar.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantIdVar.Get(ctx)),
+            DataJson = new Input<string?>(ctx => BuildSuccessData(
+                mergeShaVar.Get(ctx), mergeStrategyVar.Get(ctx),
+                issueClosedVar.Get(ctx), branchDeletedVar.Get(ctx),
+                alreadyMergedVar.Get(ctx), failureReasonVar.Get(ctx),
+                ElapsedMs(startedAtTicksVar.Get(ctx)))),
+        };
+        emitMergeSuccess.SetDisplayText("Emit MERGE.SUCCESS");
 
+        // Sub-action event: ISSUE.CLOSED.SUCCESS / .FAILED (verified, AC5).
+        var emitIssueClosed = new EmitMergeEventActivity
+        {
+            Id = "EmitIssueClosed", Name = "Emit ISSUE.CLOSED.*",
+            EventType = new Input<string>(ctx => issueClosedVar.Get(ctx)
+                ? MergeEvents.IssueClosedSuccess : MergeEvents.IssueClosedFailed),
+            IssueNumber = new Input<int>(ctx => issueNumberVar.Get(ctx)),
+            PrNumber = new Input<int>(ctx => prNumberVar.Get(ctx)),
+            Repository = new Input<string>(ctx => repositoryVar.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantIdVar.Get(ctx)),
+            DataJson = new Input<string?>(ctx => JsonSerializer.Serialize(new Dictionary<string, object?>
+            {
+                ["issueClosed"] = issueClosedVar.Get(ctx),
+                ["mergeSha"] = mergeShaVar.Get(ctx),
+            })),
+        };
+        emitIssueClosed.SetDisplayText("Emit ISSUE.CLOSED.*");
+
+        // Sub-action event: BRANCH.DELETED.SUCCESS / .FAILED (best-effort, AC5).
+        var emitBranchDeleted = new EmitMergeEventActivity
+        {
+            Id = "EmitBranchDeleted", Name = "Emit BRANCH.DELETED.*",
+            EventType = new Input<string>(ctx => branchDeletedVar.Get(ctx)
+                ? MergeEvents.BranchDeletedSuccess : MergeEvents.BranchDeletedFailed),
+            IssueNumber = new Input<int>(ctx => issueNumberVar.Get(ctx)),
+            PrNumber = new Input<int>(ctx => prNumberVar.Get(ctx)),
+            Repository = new Input<string>(ctx => repositoryVar.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantIdVar.Get(ctx)),
+            DataJson = new Input<string?>(ctx => JsonSerializer.Serialize(new Dictionary<string, object?>
+            {
+                ["branchDeleted"] = branchDeletedVar.Get(ctx),
+                ["branchName"] = branchNameVar.Get(ctx),
+            })),
+        };
+        emitBranchDeleted.SetDisplayText("Emit BRANCH.DELETED.*");
+
+        var successOutputs = new Sequence
+        {
+            Id = "SuccessOutputs", Name = "Success Outputs",
+            Activities =
+            {
+                // `success` is the gate's contract — TRUE for a real merge
+                // (Merged OR MergedWithWarnings), never inferred from a SHA.
+                WithLabel(new SetOutput { Id = "OutSuccess", OutputName = new("success"), OutputValue = new(_ => (object)true) }, "Output success=true"),
+                WithLabel(new SetOutput { Id = "OutMergeSha", OutputName = new("mergeSha"), OutputValue = new(ctx => (object)(mergeShaVar.Get(ctx) ?? "")) }, "Output mergeSha"),
+                WithLabel(new SetOutput { Id = "OutMergeStrategy", OutputName = new("mergeStrategy"), OutputValue = new(ctx => (object)mergeStrategyVar.Get(ctx)) }, "Output mergeStrategy"),
+                WithLabel(new SetOutput { Id = "OutIssueClosed", OutputName = new("issueClosed"), OutputValue = new(ctx => (object)issueClosedVar.Get(ctx)) }, "Output issueClosed"),
+                WithLabel(new SetOutput { Id = "OutBranchDeleted", OutputName = new("branchDeleted"), OutputValue = new(ctx => (object)branchDeletedVar.Get(ctx)) }, "Output branchDeleted"),
+                // partial = a post-merge sub-action failed (MergedWithWarnings) —
+                // surfaced as data, not as a failure (success stays true).
+                WithLabel(new SetOutput { Id = "OutPartial", OutputName = new("partial"), OutputValue = new(ctx => (object)(!string.IsNullOrEmpty(failureReasonVar.Get(ctx)))) }, "Output partial"),
+            }
+        };
+        successOutputs.SetDisplayText("Success Outputs");
+
+        // ================================================================
+        // 4. Failure path — success=false (NO fall-through to success), then emit
+        //    MERGE.FAILED (loud, error-status). The merge-approval gate reads
+        //    success=false → escalate. mergeSha forced empty (no false merge).
+        // ================================================================
+        var failureOutputs = new Sequence
+        {
+            Id = "FailureOutputs", Name = "Failure Outputs",
+            Activities =
+            {
+                WithLabel(new SetOutput { Id = "OutFailSuccess", OutputName = new("success"), OutputValue = new(_ => (object)false) }, "Output success=false"),
+                WithLabel(new SetOutput { Id = "OutFailMergeSha", OutputName = new("mergeSha"), OutputValue = new(_ => (object)"") }, "Output mergeSha="),
+                WithLabel(new SetOutput { Id = "OutFailCode", OutputName = new("failureCode"), OutputValue = new(ctx => (object)(NullIfBlank(failureCodeVar.Get(ctx)) ?? "merge-failed")) }, "Output failureCode"),
+                WithLabel(new SetOutput { Id = "OutFailReason", OutputName = new("failureReason"), OutputValue = new(ctx => (object)(NullIfBlank(failureReasonVar.Get(ctx)) ?? "merge failed")) }, "Output failureReason"),
+                WithLabel(new SetOutput { Id = "OutFailPartial", OutputName = new("partial"), OutputValue = new(_ => (object)false) }, "Output partial=false"),
+            }
+        };
+        failureOutputs.SetDisplayText("Failure Outputs");
+
+        var emitMergeFailed = new EmitMergeEventActivity
+        {
+            Id = "EmitFailed", Name = "Emit MERGE.FAILED",
+            EventType = new Input<string>(_ => MergeEvents.Failed),
+            IssueNumber = new Input<int>(ctx => issueNumberVar.Get(ctx)),
+            PrNumber = new Input<int>(ctx => prNumberVar.Get(ctx)),
+            Repository = new Input<string>(ctx => repositoryVar.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantIdVar.Get(ctx)),
+            DataJson = new Input<string?>(ctx => BuildFailureData(
+                failureCodeVar.Get(ctx), failureReasonVar.Get(ctx),
+                mergeStrategyVar.Get(ctx), ElapsedMs(startedAtTicksVar.Get(ctx)))),
+        };
+        emitMergeFailed.SetDisplayText("Emit MERGE.FAILED");
+
+        var finish = new Finish { Id = "Finish", Name = "Complete" };
+        finish.SetDisplayText("Complete");
+
+        // ================================================================
+        // Flowchart — every outcome routed to a terminal, no dangling edge,
+        // no fall-through to success (the headline thin-wrapper bug).
+        // ================================================================
         builder.Root = new Flowchart
         {
             Id = "MergeFlowchart",
             Name = "Merge Flowchart",
-            Start = mergePr,
-            Activities = { mergePr, setSuccess, setFailure, outputSuccess, outputMergeSha },
+            Start = readInputs,
+            Activities =
+            {
+                readInputs, mergePr,
+                emitMergeSuccess, emitIssueClosed, emitBranchDeleted, successOutputs,
+                failureOutputs, emitMergeFailed, finish,
+            },
             Connections =
             {
-                // Merged → success flag → emit outputs
-                ConnectOutcome(mergePr, "Merged", setSuccess),
-                Connect(setSuccess, outputSuccess),
-                // Error → explicit success=false → emit the SAME outputs (so the
-                // gate reads success=false rather than a never-set output).
-                ConnectOutcome(mergePr, "Error", setFailure),
-                Connect(setFailure, outputSuccess),
-                Connect(outputSuccess, outputMergeSha)
+                Connect(readInputs, mergePr),
+
+                // Merged → success path (MERGE.SUCCESS → sub-action events → outputs)
+                ConnectOutcome(mergePr, "Merged", emitMergeSuccess),
+                // MergedWithWarnings → SAME success path (success=true, partial=true)
+                ConnectOutcome(mergePr, "MergedWithWarnings", emitMergeSuccess),
+                Connect(emitMergeSuccess, emitIssueClosed),
+                Connect(emitIssueClosed, emitBranchDeleted),
+                Connect(emitBranchDeleted, successOutputs),
+                Connect(successOutputs, finish),
+
+                // Error → explicit failure path (success=false → MERGE.FAILED).
+                // NO fall-through to success — the dead-end is gone.
+                ConnectOutcome(mergePr, "Error", failureOutputs),
+                Connect(failureOutputs, emitMergeFailed),
+                Connect(emitMergeFailed, finish),
             }
         };
+    }
+
+    private static string? NullIfBlank(string? s)
+        => string.IsNullOrWhiteSpace(s) ? null : s;
+
+    private static long ElapsedMs(long startedAtTicks)
+    {
+        if (startedAtTicks <= 0) return 0;
+        var elapsed = DateTime.UtcNow.Ticks - startedAtTicks;
+        return elapsed > 0 ? elapsed / TimeSpan.TicksPerMillisecond : 0;
+    }
+
+    private static string BuildSuccessData(
+        string? mergeSha, string mergeStrategy, bool issueClosed, bool branchDeleted,
+        bool alreadyMerged, string? warnings, long durationMs)
+    {
+        var data = new Dictionary<string, object?>
+        {
+            ["mergeSha"] = mergeSha ?? "",
+            ["mergeStrategy"] = mergeStrategy,
+            ["issueClosed"] = issueClosed,
+            ["branchDeleted"] = branchDeleted,
+            ["alreadyMerged"] = alreadyMerged,
+            ["partial"] = !string.IsNullOrEmpty(warnings),
+            ["warnings"] = Truncate(warnings, 280),
+            ["durationMs"] = durationMs,
+        };
+        return JsonSerializer.Serialize(data);
+    }
+
+    private static string BuildFailureData(
+        string? failureCode, string? failureReason, string mergeStrategy, long durationMs)
+    {
+        var data = new Dictionary<string, object?>
+        {
+            ["failureCode"] = NullIfBlank(failureCode) ?? "merge-failed",
+            ["failureReason"] = Truncate(failureReason, 280),
+            ["mergeStrategy"] = mergeStrategy,
+            ["durationMs"] = durationMs,
+        };
+        return JsonSerializer.Serialize(data);
+    }
+
+    private static string Truncate(string? s, int max)
+    {
+        if (string.IsNullOrEmpty(s)) return "";
+        return s.Length <= max ? s : s[..max];
     }
 
     private static FlowConnection Connect(IActivity source, IActivity target)

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/MergePullRequestActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/MergePullRequestActivityTests.cs
@@ -1,0 +1,429 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+using Tamma.Core.Interfaces;
+
+namespace Tamma.Activities.Tests.ADL;
+
+/// <summary>
+/// Story 2-10 build-out — unit coverage for the merge activity's pure helpers
+/// (strategy normalization / failure classification), the <c>ExecuteCoreAsync</c>
+/// orchestration (pre-merge read → idempotency → conflict gate → merge → verified
+/// post-merge close/delete, NEVER a false success / never a silent failure), and
+/// <c>EmitMergeEventActivity</c>'s DCB mapping (<c>BuildTammaEvent</c> — the
+/// <c>TammaEvent</c> pushed into the workflow's <c>tamma:events</c> list, which
+/// the engine event drain persists durably to <c>domain_events</c>). Mirrors the
+/// merged branch/PR exemplars: test the testable static logic + a mocked
+/// <see cref="IGitHubIntegrationService"/> rather than a full Elsa runtime.
+/// </summary>
+[TestFixture]
+public class MergePullRequestActivityTests
+{
+    // ================================================================
+    // Constructors
+    // ================================================================
+
+    [Test]
+    public void MergePullRequestActivity_JsonConstructor_ShouldNotThrow()
+    {
+        Action act = () => new MergePullRequestActivity();
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void EmitMergeEventActivity_JsonConstructor_ShouldNotThrow()
+    {
+        Action act = () => new EmitMergeEventActivity();
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void EmitMergeEventActivity_WithLogger_ShouldNotThrow()
+    {
+        var logger = new Mock<ILogger<EmitMergeEventActivity>>();
+        Action act = () => new EmitMergeEventActivity(logger.Object);
+        act.Should().NotThrow();
+    }
+
+    // ================================================================
+    // NormalizeStrategy
+    // ================================================================
+
+    [Test]
+    public void NormalizeStrategy_MapsKnownStrategies_DefaultsToSquash()
+    {
+        MergePullRequestActivity.NormalizeStrategy("merge").Should().Be("merge");
+        MergePullRequestActivity.NormalizeStrategy("REBASE").Should().Be("rebase");
+        MergePullRequestActivity.NormalizeStrategy("squash").Should().Be("squash");
+        MergePullRequestActivity.NormalizeStrategy("nonsense").Should().Be("squash");
+        MergePullRequestActivity.NormalizeStrategy("").Should().Be("squash");
+        MergePullRequestActivity.NormalizeStrategy(null).Should().Be("squash");
+    }
+
+    // ================================================================
+    // ClassifyError — conflict / permission / protected / not-mergeable / transient
+    // ================================================================
+
+    [Test]
+    public void ClassifyError_MapsKnownCodes()
+    {
+        MergePullRequestActivity.ClassifyError("409: merge conflict").Should().Be("merge_conflict");
+        MergePullRequestActivity.ClassifyError("403 Forbidden").Should().Be("permission_denied");
+        MergePullRequestActivity.ClassifyError("422 required status check failed").Should().Be("branch_protected");
+        MergePullRequestActivity.ClassifyError("405: Pull Request is not mergeable").Should().Be("not_mergeable");
+        MergePullRequestActivity.ClassifyError("503 service unavailable").Should().Be("api_error");
+        MergePullRequestActivity.ClassifyError(null).Should().Be("api_error");
+    }
+
+    // ================================================================
+    // ExecuteCoreAsync helpers
+    // ================================================================
+
+    private static Mock<IGitHubIntegrationService> OpenMergeablePr()
+    {
+        var gh = new Mock<IGitHubIntegrationService>();
+        gh.Setup(g => g.GetGitHubPullRequestAsync("o/r", 7))
+            .ReturnsAsync(IntegrationResult<GitHubPullRequestDetail>.Ok(new GitHubPullRequestDetail
+            { Number = 7, State = "open", Merged = false, Mergeable = true, MergeableState = "clean" }));
+        return gh;
+    }
+
+    // ================================================================
+    // Happy path — merge → close issue → delete branch → clean success
+    // ================================================================
+
+    [Test]
+    public async Task ExecuteCore_HappyPath_Merges_ClosesIssue_DeletesBranch()
+    {
+        var gh = OpenMergeablePr();
+        gh.Setup(g => g.MergeGitHubPullRequestAsync("o/r", 7, "squash"))
+            .ReturnsAsync(IntegrationResult<GitHubMergeResult>.Ok(new GitHubMergeResult
+            { Success = true, MergeSha = "merge-sha-1" }));
+        gh.Setup(g => g.CloseGitHubIssueAsync("o/r", 12, It.IsAny<string>()))
+            .ReturnsAsync(IntegrationResult<bool>.Ok(true));
+        gh.Setup(g => g.DeleteGitHubBranchAsync("o/r", "adl/12-x"))
+            .ReturnsAsync(IntegrationResult<bool>.Ok(true));
+
+        var outcome = await MergePullRequestActivity.ExecuteCoreAsync(
+            gh.Object, "o/r", 7, 12, "adl/12-x", "squash", autoDeleteBranch: true, closeIssue: true);
+
+        outcome.Outcome.Should().Be("Merged");
+        outcome.MergeSucceeded.Should().BeTrue();
+        outcome.MergeSha.Should().Be("merge-sha-1");
+        outcome.IssueClosed.Should().BeTrue();
+        outcome.BranchDeleted.Should().BeTrue();
+        outcome.Partial.Should().BeFalse();
+        outcome.AlreadyMerged.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task ExecuteCore_HappyPath_PassesConfiguredStrategy()
+    {
+        var gh = new Mock<IGitHubIntegrationService>();
+        gh.Setup(g => g.GetGitHubPullRequestAsync("o/r", 7))
+            .ReturnsAsync(IntegrationResult<GitHubPullRequestDetail>.Ok(new GitHubPullRequestDetail
+            { Number = 7, State = "open", Merged = false, Mergeable = true }));
+        gh.Setup(g => g.MergeGitHubPullRequestAsync("o/r", 7, "rebase"))
+            .ReturnsAsync(IntegrationResult<GitHubMergeResult>.Ok(new GitHubMergeResult
+            { Success = true, MergeSha = "sha" }));
+        gh.Setup(g => g.CloseGitHubIssueAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
+            .ReturnsAsync(IntegrationResult<bool>.Ok(true));
+        gh.Setup(g => g.DeleteGitHubBranchAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(IntegrationResult<bool>.Ok(true));
+
+        var outcome = await MergePullRequestActivity.ExecuteCoreAsync(
+            gh.Object, "o/r", 7, 12, "b", "rebase", true, true);
+
+        outcome.Outcome.Should().Be("Merged");
+        gh.Verify(g => g.MergeGitHubPullRequestAsync("o/r", 7, "rebase"), Times.Once);
+        // The squash-only overload must NOT be used (strategy was honoured).
+        gh.Verify(g => g.MergeGitHubPullRequestAsync(It.IsAny<string>(), It.IsAny<int>()), Times.Never);
+    }
+
+    // ================================================================
+    // FAILURE PATH — the core regression: merge did NOT happen → Error,
+    // success=false, NEVER a silent success.
+    // ================================================================
+
+    [Test]
+    public async Task ExecuteCore_MergeReturnsFailure_ReturnsError_NoFalseSuccess()
+    {
+        var gh = OpenMergeablePr();
+        gh.Setup(g => g.MergeGitHubPullRequestAsync("o/r", 7, "squash"))
+            .ReturnsAsync(IntegrationResult<GitHubMergeResult>.Fail("409: merge conflict"));
+
+        var outcome = await MergePullRequestActivity.ExecuteCoreAsync(
+            gh.Object, "o/r", 7, 12, "b", "squash", true, true);
+
+        outcome.Outcome.Should().Be("Error");
+        outcome.MergeSucceeded.Should().BeFalse();
+        outcome.FailureCode.Should().Be("merge_conflict");
+        outcome.MergeSha.Should().BeNullOrEmpty();
+        // A failed merge must NOT close the issue or delete the branch.
+        gh.Verify(g => g.CloseGitHubIssueAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+        gh.Verify(g => g.DeleteGitHubBranchAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ExecuteCore_ConfirmedConflict_FailsBeforeMerge_NoBlindMerge()
+    {
+        var gh = new Mock<IGitHubIntegrationService>();
+        gh.Setup(g => g.GetGitHubPullRequestAsync("o/r", 7))
+            .ReturnsAsync(IntegrationResult<GitHubPullRequestDetail>.Ok(new GitHubPullRequestDetail
+            { Number = 7, State = "open", Merged = false, Mergeable = false, MergeableState = "dirty" }));
+
+        var outcome = await MergePullRequestActivity.ExecuteCoreAsync(
+            gh.Object, "o/r", 7, 12, "b", "squash", true, true);
+
+        outcome.Outcome.Should().Be("Error");
+        outcome.FailureCode.Should().Be("merge_conflict");
+        // mergeable==false must short-circuit — never attempt a doomed merge.
+        gh.Verify(g => g.MergeGitHubPullRequestAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ExecuteCore_PermissionDenied_ReturnsError()
+    {
+        var gh = OpenMergeablePr();
+        gh.Setup(g => g.MergeGitHubPullRequestAsync("o/r", 7, "squash"))
+            .ReturnsAsync(IntegrationResult<GitHubMergeResult>.Fail("403 Forbidden"));
+
+        var outcome = await MergePullRequestActivity.ExecuteCoreAsync(
+            gh.Object, "o/r", 7, 12, "b", "squash", true, true);
+
+        outcome.Outcome.Should().Be("Error");
+        outcome.FailureCode.Should().Be("permission_denied");
+    }
+
+    [Test]
+    public async Task ExecuteCore_ClosedUnmergedPr_ReturnsError_NotMergeable()
+    {
+        var gh = new Mock<IGitHubIntegrationService>();
+        gh.Setup(g => g.GetGitHubPullRequestAsync("o/r", 7))
+            .ReturnsAsync(IntegrationResult<GitHubPullRequestDetail>.Ok(new GitHubPullRequestDetail
+            { Number = 7, State = "closed", Merged = false }));
+
+        var outcome = await MergePullRequestActivity.ExecuteCoreAsync(
+            gh.Object, "o/r", 7, 12, "b", "squash", true, true);
+
+        outcome.Outcome.Should().Be("Error");
+        outcome.FailureCode.Should().Be("not_mergeable");
+        gh.Verify(g => g.MergeGitHubPullRequestAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ExecuteCore_PreMergeReadFails_ReturnsError_NoBlindMerge()
+    {
+        var gh = new Mock<IGitHubIntegrationService>();
+        gh.Setup(g => g.GetGitHubPullRequestAsync("o/r", 7))
+            .ReturnsAsync(IntegrationResult<GitHubPullRequestDetail>.Fail("503 service unavailable"));
+
+        var outcome = await MergePullRequestActivity.ExecuteCoreAsync(
+            gh.Object, "o/r", 7, 12, "b", "squash", true, true);
+
+        outcome.Outcome.Should().Be("Error");
+        outcome.FailureCode.Should().Be("api_error");
+        gh.Verify(g => g.MergeGitHubPullRequestAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ExecuteCore_MergeSuccessButNoSha_TreatedAsFailure()
+    {
+        var gh = OpenMergeablePr();
+        gh.Setup(g => g.MergeGitHubPullRequestAsync("o/r", 7, "squash"))
+            .ReturnsAsync(IntegrationResult<GitHubMergeResult>.Ok(new GitHubMergeResult
+            { Success = true, MergeSha = "" }));
+
+        var outcome = await MergePullRequestActivity.ExecuteCoreAsync(
+            gh.Object, "o/r", 7, 12, "b", "squash", true, true);
+
+        outcome.Outcome.Should().Be("Error");
+        outcome.FailureCode.Should().Be("api_error");
+    }
+
+    [Test]
+    public async Task ExecuteCore_NeverThrows_OnUnexpectedException()
+    {
+        var gh = new Mock<IGitHubIntegrationService>();
+        gh.Setup(g => g.GetGitHubPullRequestAsync(It.IsAny<string>(), It.IsAny<int>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        var outcome = await MergePullRequestActivity.ExecuteCoreAsync(
+            gh.Object, "o/r", 7, 12, "b", "squash", true, true);
+
+        outcome.Outcome.Should().Be("Error");
+        outcome.FailureCode.Should().Be("api_error");
+        outcome.FailureReason.Should().Contain("boom");
+    }
+
+    // ================================================================
+    // Idempotency — already-merged PR → success, no re-merge (no 405)
+    // ================================================================
+
+    [Test]
+    public async Task ExecuteCore_AlreadyMerged_ReturnsSuccess_NoReMerge()
+    {
+        var gh = new Mock<IGitHubIntegrationService>();
+        gh.Setup(g => g.GetGitHubPullRequestAsync("o/r", 7))
+            .ReturnsAsync(IntegrationResult<GitHubPullRequestDetail>.Ok(new GitHubPullRequestDetail
+            { Number = 7, State = "closed", Merged = true, MergeCommitSha = "existing-sha" }));
+        gh.Setup(g => g.CloseGitHubIssueAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
+            .ReturnsAsync(IntegrationResult<bool>.Ok(true));
+        gh.Setup(g => g.DeleteGitHubBranchAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(IntegrationResult<bool>.Ok(true));
+
+        var outcome = await MergePullRequestActivity.ExecuteCoreAsync(
+            gh.Object, "o/r", 7, 12, "b", "squash", true, true);
+
+        outcome.Outcome.Should().Be("Merged");
+        outcome.AlreadyMerged.Should().BeTrue();
+        outcome.MergeSha.Should().Be("existing-sha");
+        // Must NOT re-attempt the merge (that 405s on a merged PR).
+        gh.Verify(g => g.MergeGitHubPullRequestAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+    }
+
+    // ================================================================
+    // Partial — merge OK but issue-close failed → MergedWithWarnings (success=true)
+    // ================================================================
+
+    [Test]
+    public async Task ExecuteCore_MergeOk_IssueCloseFails_ReturnsMergedWithWarnings()
+    {
+        var gh = OpenMergeablePr();
+        gh.Setup(g => g.MergeGitHubPullRequestAsync("o/r", 7, "squash"))
+            .ReturnsAsync(IntegrationResult<GitHubMergeResult>.Ok(new GitHubMergeResult
+            { Success = true, MergeSha = "sha" }));
+        gh.Setup(g => g.CloseGitHubIssueAsync("o/r", 12, It.IsAny<string>()))
+            .ReturnsAsync(IntegrationResult<bool>.Fail("404 not found"));
+        gh.Setup(g => g.DeleteGitHubBranchAsync("o/r", "b"))
+            .ReturnsAsync(IntegrationResult<bool>.Ok(true));
+
+        var outcome = await MergePullRequestActivity.ExecuteCoreAsync(
+            gh.Object, "o/r", 7, 12, "b", "squash", true, true);
+
+        outcome.Outcome.Should().Be("MergedWithWarnings");
+        outcome.MergeSucceeded.Should().BeTrue("the merge stands even though a post-merge action failed");
+        outcome.Partial.Should().BeTrue();
+        outcome.IssueClosed.Should().BeFalse();
+        outcome.BranchDeleted.Should().BeTrue();
+        outcome.FailureReason.Should().Contain("issue-close-failed");
+    }
+
+    [Test]
+    public async Task ExecuteCore_MergeOk_BranchDeleteFails_ReturnsMergedWithWarnings_StillSuccess()
+    {
+        var gh = OpenMergeablePr();
+        gh.Setup(g => g.MergeGitHubPullRequestAsync("o/r", 7, "squash"))
+            .ReturnsAsync(IntegrationResult<GitHubMergeResult>.Ok(new GitHubMergeResult
+            { Success = true, MergeSha = "sha" }));
+        gh.Setup(g => g.CloseGitHubIssueAsync("o/r", 12, It.IsAny<string>()))
+            .ReturnsAsync(IntegrationResult<bool>.Ok(true));
+        gh.Setup(g => g.DeleteGitHubBranchAsync("o/r", "b"))
+            .ReturnsAsync(IntegrationResult<bool>.Fail("422 protected"));
+
+        var outcome = await MergePullRequestActivity.ExecuteCoreAsync(
+            gh.Object, "o/r", 7, 12, "b", "squash", true, true);
+
+        outcome.Outcome.Should().Be("MergedWithWarnings");
+        outcome.MergeSucceeded.Should().BeTrue("a failed branch-delete is a warning, not a merge failure");
+        outcome.IssueClosed.Should().BeTrue();
+        outcome.BranchDeleted.Should().BeFalse();
+        outcome.FailureReason.Should().Contain("branch-delete-failed");
+    }
+
+    [Test]
+    public async Task ExecuteCore_CloseDisabled_DoesNotCallClose_StillClean()
+    {
+        var gh = OpenMergeablePr();
+        gh.Setup(g => g.MergeGitHubPullRequestAsync("o/r", 7, "squash"))
+            .ReturnsAsync(IntegrationResult<GitHubMergeResult>.Ok(new GitHubMergeResult
+            { Success = true, MergeSha = "sha" }));
+        gh.Setup(g => g.DeleteGitHubBranchAsync("o/r", "b"))
+            .ReturnsAsync(IntegrationResult<bool>.Ok(true));
+
+        var outcome = await MergePullRequestActivity.ExecuteCoreAsync(
+            gh.Object, "o/r", 7, 12, "b", "squash", autoDeleteBranch: true, closeIssue: false);
+
+        outcome.Outcome.Should().Be("Merged", "skipping a disabled close is not a warning");
+        outcome.IssueClosed.Should().BeFalse();
+        gh.Verify(g => g.CloseGitHubIssueAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+    }
+
+    // ================================================================
+    // EmitMergeEventActivity.BuildTammaEvent — DCB mapping onto the drain
+    // ================================================================
+
+    [Test]
+    public void BuildTammaEvent_SuccessType_SetsTypeStatusTagsAndData()
+    {
+        var evt = EmitMergeEventActivity.BuildTammaEvent(
+            MergeEvents.Success, issueNumber: 12, prNumber: 7, repository: "o/r",
+            tenantId: null,
+            data: new Dictionary<string, object?> { ["mergeSha"] = "sha", ["mergeStrategy"] = "squash" });
+
+        evt.EventType.Should().Be("MERGE.SUCCESS");
+        evt.Status.Should().Be("success");
+        evt.Tags.Should().NotBeNull();
+        evt.Tags!["issueId"].Should().Be("12");
+        evt.Tags["issueNumber"].Should().Be("12");
+        evt.Tags["prNumber"].Should().Be("7");
+        evt.Tags["repository"].Should().Be("o/r");
+        evt.Tags.Should().NotContainKey("tenantId");
+        evt.Data.Should().ContainKey("mergeSha");
+        evt.Data.Should().ContainKey("mergeStrategy");
+    }
+
+    [Test]
+    public void BuildTammaEvent_FailedType_SetsErrorStatus()
+    {
+        var evt = EmitMergeEventActivity.BuildTammaEvent(
+            MergeEvents.Failed, issueNumber: 7, prNumber: 3, repository: "o/r",
+            tenantId: null, data: null);
+
+        evt.EventType.Should().Be("MERGE.FAILED");
+        evt.Status.Should().Be("error");
+        evt.Data.Should().BeEmpty();
+    }
+
+    [Test]
+    public void BuildTammaEvent_IssueClosedFailed_IsErrorStatus()
+    {
+        var evt = EmitMergeEventActivity.BuildTammaEvent(
+            MergeEvents.IssueClosedFailed, 7, 3, "o/r", tenantId: null, data: null);
+        evt.Status.Should().Be("error");
+
+        var ok = EmitMergeEventActivity.BuildTammaEvent(
+            MergeEvents.IssueClosedSuccess, 7, 3, "o/r", tenantId: null, data: null);
+        ok.Status.Should().Be("success");
+    }
+
+    [Test]
+    public void BuildTammaEvent_WithTenant_SetsTenantIdTag()
+    {
+        var tenant = Guid.NewGuid();
+        var evt = EmitMergeEventActivity.BuildTammaEvent(
+            MergeEvents.Success, 1, 2, "o/r", tenantId: tenant, data: null);
+
+        evt.Tags!["tenantId"].Should().Be(tenant.ToString("D"));
+    }
+
+    [Test]
+    public void MergeEvents_ParseTenantId_HandlesEmptyAndValid()
+    {
+        MergeEvents.ParseTenantId(null).Should().BeNull();
+        MergeEvents.ParseTenantId("").Should().BeNull();
+        MergeEvents.ParseTenantId("not-a-guid").Should().BeNull();
+        var g = Guid.NewGuid();
+        MergeEvents.ParseTenantId(g.ToString()).Should().Be(g);
+    }
+
+    [Test]
+    public void EmitMergeEvent_ParseData_HandlesEmptyAndMalformed()
+    {
+        EmitMergeEventActivity.ParseData(null).Should().BeNull();
+        EmitMergeEventActivity.ParseData("").Should().BeNull();
+        EmitMergeEventActivity.ParseData("{not json").Should().BeNull();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/MergeWorkflowTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/MergeWorkflowTests.cs
@@ -1,0 +1,192 @@
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Management.Activities.SetOutput;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Story 2-10 build-out — workflow-structure integration coverage for the
+/// built-out <c>merge</c> graph. Asserts the load-bearing guarantees of the
+/// build-out (which the activity unit tests can't): the <c>Error</c> outcome is
+/// WIRED to an explicit failure terminal and NEVER falls through to success (the
+/// headline thin-wrapper dead-end bug), the failure terminal sets
+/// <c>success=false</c> and emits <c>MERGE.FAILED</c>, both merge outcomes
+/// (Merged + MergedWithWarnings) reach the success terminal that sets
+/// <c>success=true</c> (the gate's contract) and emits <c>MERGE.SUCCESS</c> +
+/// the issue/branch sub-action events, every edge out of the merge step is
+/// outcome-qualified, and every terminal reaches Finish (no dangling / deadlock).
+///
+/// <para>Follows the codebase convention of inspecting the BUILT Flowchart via
+/// <see cref="WorkflowTestHelper"/> rather than running the full Elsa runtime
+/// (see <see cref="BranchCreationWorkflowTests"/>).</para>
+/// </summary>
+[TestFixture]
+public class MergeWorkflowTests
+{
+    private Flowchart _flowchart = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new MergeWorkflow());
+        _flowchart = WorkflowTestHelper.GetFlowchart(builder);
+    }
+
+    // ================================================================
+    // Identity
+    // ================================================================
+
+    [Test]
+    public void Workflow_BuildsWithExpectedDefinitionId()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new MergeWorkflow());
+        builder.Object.DefinitionId.Should().Be("merge");
+    }
+
+    // ================================================================
+    // No false success / no silent failure — the Error outcome routes to the
+    // explicit failure path ONLY (the headline dead-end bug is gone).
+    // ================================================================
+
+    [Test]
+    public void MergePR_ErrorOutcome_RoutesToFailurePath_NotSuccess()
+    {
+        HasEdge("MergePR", "Error", "FailureOutputs").Should().BeTrue(
+            "the Error outcome must route to the explicit failure path (no dead-end)");
+
+        var errorTargets = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "MergePR" && c.Source.Port == "Error")
+            .Select(c => c.Target.Activity.Id)
+            .ToList();
+
+        errorTargets.Should().NotContain("EmitSuccess");
+        errorTargets.Should().NotContain("SuccessOutputs");
+    }
+
+    [Test]
+    public void MergePR_HasNoUnconditionalFallthrough()
+    {
+        // Every edge out of MergePR must be outcome-qualified
+        // (Merged / MergedWithWarnings / Error). A portless edge would be the old
+        // silent fall-through bug.
+        var fromMerge = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "MergePR")
+            .ToList();
+
+        fromMerge.Should().NotBeEmpty();
+        fromMerge.Should().OnlyContain(c =>
+            c.Source.Port == "Merged" ||
+            c.Source.Port == "MergedWithWarnings" ||
+            c.Source.Port == "Error");
+    }
+
+    [Test]
+    public void AllThreeMergeOutcomes_AreWired()
+    {
+        // All three FlowNode outcomes must have an edge — none dangling.
+        HasEdge("MergePR", "Merged", "EmitSuccess").Should().BeTrue();
+        HasEdge("MergePR", "MergedWithWarnings", "EmitSuccess").Should().BeTrue(
+            "a partial merge is still a success — routes to the success terminal");
+        HasEdge("MergePR", "Error", "FailureOutputs").Should().BeTrue();
+    }
+
+    // ================================================================
+    // DCB events on every terminal transition
+    // ================================================================
+
+    [Test]
+    public void SuccessPath_EmitsMergeSuccess_AndSubActionEvents()
+    {
+        var emit = _flowchart.Activities
+            .OfType<EmitMergeEventActivity>()
+            .FirstOrDefault(a => a.Id == "EmitSuccess");
+        emit.Should().NotBeNull("success path must emit a MERGE.SUCCESS DCB event");
+
+        // Sub-action audit events (AC5): ISSUE.CLOSED.* + BRANCH.DELETED.*.
+        HasEdge("EmitSuccess", null, "EmitIssueClosed").Should().BeTrue();
+        HasEdge("EmitIssueClosed", null, "EmitBranchDeleted").Should().BeTrue();
+        HasEdge("EmitBranchDeleted", null, "SuccessOutputs").Should().BeTrue();
+    }
+
+    [Test]
+    public void FailurePath_EmitsMergeFailed()
+    {
+        var emit = _flowchart.Activities
+            .OfType<EmitMergeEventActivity>()
+            .FirstOrDefault(a => a.Id == "EmitFailed");
+        emit.Should().NotBeNull("failure path must emit MERGE.FAILED");
+        // success=false is set BEFORE the failed event (no fall-through to success).
+        HasEdge("FailureOutputs", null, "EmitFailed").Should().BeTrue();
+    }
+
+    [Test]
+    public void BothTerminalPaths_ReachFinish()
+    {
+        HasEdge("SuccessOutputs", null, "Finish").Should().BeTrue();
+        HasEdge("EmitFailed", null, "Finish").Should().BeTrue();
+    }
+
+    // ================================================================
+    // Outputs — the `success` contract the merge-approval gate reads
+    // ================================================================
+
+    [Test]
+    public void SuccessPath_SetsSuccessTrue_PreservingGateContract()
+    {
+        var successSeq = _flowchart.Activities
+            .OfType<Sequence>()
+            .First(s => s.Id == "SuccessOutputs");
+
+        var outputs = successSeq.Activities.OfType<SetOutput>().ToList();
+        outputs.Select(o => o.Id ?? "").Should().Contain("OutSuccess");
+
+        // The success output name must be exactly "success" — the gate reads it.
+        outputs.Should().Contain(o => o.Id == "OutSuccess");
+        outputs.First(o => o.Id == "OutSuccess").OutputName.Should().NotBeNull();
+        outputs.Select(o => o.Id).Should().Contain("OutMergeSha");
+    }
+
+    [Test]
+    public void FailurePath_SetsSuccessFalse_And_FailureCode_And_EmptyMergeSha()
+    {
+        var failureSeq = _flowchart.Activities
+            .OfType<Sequence>()
+            .First(s => s.Id == "FailureOutputs");
+
+        var ids = failureSeq.Activities
+            .OfType<SetOutput>()
+            .Select(o => o.Id ?? "")
+            .ToList();
+
+        ids.Should().Contain("OutFailSuccess");   // success = false (gate → escalate)
+        ids.Should().Contain("OutFailCode");      // failureCode
+        ids.Should().Contain("OutFailReason");    // failureReason
+        ids.Should().Contain("OutFailMergeSha");  // mergeSha = "" (no false merge)
+    }
+
+    // ================================================================
+    // No deadlock — every terminal node reaches Finish (the flowchart's only
+    // dead-ends should be Finish itself).
+    // ================================================================
+
+    [Test]
+    public void Flowchart_HasSingleFinish_AndStartsAtReadInputs()
+    {
+        _flowchart.Activities.OfType<Finish>().Should().HaveCount(1);
+        HasEdge("ReadInputs", null, "MergePR").Should().BeTrue();
+    }
+
+    // ================================================================
+    // Helpers
+    // ================================================================
+
+    private bool HasEdge(string sourceId, string? port, string targetId)
+        => _flowchart.Connections.Any(c =>
+            c.Source.Activity.Id == sourceId &&
+            (port == null || c.Source.Port == port) &&
+            c.Target.Activity.Id == targetId);
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/GitHub/GitHubIntegrationServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/GitHub/GitHubIntegrationServiceTests.cs
@@ -367,6 +367,144 @@ public class GitHubIntegrationServiceTests
     }
 
     // ================================================================
+    // MergeGitHubPullRequestAsync — configurable strategy → merge_method (Story 2-10)
+    // ================================================================
+
+    [Test]
+    public async Task Merge_DefaultOverload_UsesSquashMethod_ToMergeRoute()
+    {
+        _handler.OnPut("/repos/o/r/pulls/7/merge",
+            """{ "merged": true, "sha": "merge-sha-1" }""");
+
+        var result = await CreateService().MergeGitHubPullRequestAsync("o/r", 7);
+
+        result.Success.Should().BeTrue();
+        result.Data!.MergeSha.Should().Be("merge-sha-1");
+
+        var req = _handler.RequireRequest(HttpMethod.Put, "/repos/o/r/pulls/7/merge");
+        JsonDocument.Parse(req.Body).RootElement
+            .GetProperty("merge_method").GetString().Should().Be("squash");
+    }
+
+    [Test]
+    public async Task Merge_RebaseStrategy_MapsToMergeMethodRebase()
+    {
+        _handler.OnPut("/repos/o/r/pulls/9/merge",
+            """{ "merged": true, "sha": "s" }""");
+
+        var result = await CreateService().MergeGitHubPullRequestAsync("o/r", 9, "rebase");
+
+        result.Success.Should().BeTrue();
+        var req = _handler.RequireRequest(HttpMethod.Put, "/repos/o/r/pulls/9/merge");
+        JsonDocument.Parse(req.Body).RootElement
+            .GetProperty("merge_method").GetString().Should().Be("rebase");
+    }
+
+    [Test]
+    public async Task Merge_UnknownStrategy_FallsBackToSquash()
+    {
+        _handler.OnPut("/repos/o/r/pulls/9/merge", """{ "merged": true, "sha": "s" }""");
+
+        await CreateService().MergeGitHubPullRequestAsync("o/r", 9, "nonsense");
+
+        var req = _handler.RequireRequest(HttpMethod.Put, "/repos/o/r/pulls/9/merge");
+        JsonDocument.Parse(req.Body).RootElement
+            .GetProperty("merge_method").GetString().Should().Be("squash");
+    }
+
+    [Test]
+    public async Task Merge_Conflict_ReturnsFailWithStatusBody_NotThrow()
+    {
+        // A 409 merge conflict must surface as a classifiable Fail (status-prefixed
+        // body), NOT an EnsureSuccessStatusCode throw → blind Error.
+        _handler.OnPut("/repos/o/r/pulls/7/merge", "Merge conflict", HttpStatusCode.Conflict);
+
+        var result = await CreateService().MergeGitHubPullRequestAsync("o/r", 7, "squash");
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().StartWith("409");
+    }
+
+    [Test]
+    public void NormalizeMergeMethod_MapsStrategies()
+    {
+        GitHubIntegrationService.NormalizeMergeMethod("merge").Should().Be("merge");
+        GitHubIntegrationService.NormalizeMergeMethod("REBASE").Should().Be("rebase");
+        GitHubIntegrationService.NormalizeMergeMethod("squash").Should().Be("squash");
+        GitHubIntegrationService.NormalizeMergeMethod("x").Should().Be("squash");
+        GitHubIntegrationService.NormalizeMergeMethod(null).Should().Be("squash");
+    }
+
+    // ================================================================
+    // GetGitHubPullRequestAsync — exact-match pulls/{n} endpoint (Story 2-10
+    // idempotency + pre-merge readiness)
+    // ================================================================
+
+    [Test]
+    public async Task GetPr_ParsesStateMergedMergeableAndSha()
+    {
+        _handler.OnGet("/repos/o/r/pulls/7",
+            """
+            {
+              "number": 7, "state": "closed", "merged": true,
+              "merge_commit_sha": "merged-sha-1",
+              "mergeable": true, "mergeable_state": "clean", "draft": false
+            }
+            """);
+
+        var result = await CreateService().GetGitHubPullRequestAsync("o/r", 7);
+
+        result.Success.Should().BeTrue();
+        result.Data!.Number.Should().Be(7);
+        result.Data.State.Should().Be("closed");
+        result.Data.Merged.Should().BeTrue();
+        result.Data.MergeCommitSha.Should().Be("merged-sha-1");
+        result.Data.Mergeable.Should().BeTrue();
+        result.Data.MergeableState.Should().Be("clean");
+
+        var req = _handler.RequireRequest(HttpMethod.Get, "/repos/o/r/pulls/7");
+        req.Path.Should().Be("/repos/o/r/pulls/7");
+    }
+
+    [Test]
+    public async Task GetPr_MergeableNull_WhenGitHubStillComputing()
+    {
+        // GitHub returns `mergeable: null` while computing — must surface as null
+        // (not false / not true), so the caller never treats unknown as mergeable.
+        _handler.OnGet("/repos/o/r/pulls/8",
+            """{ "number": 8, "state": "open", "merged": false, "mergeable": null }""");
+
+        var result = await CreateService().GetGitHubPullRequestAsync("o/r", 8);
+
+        result.Success.Should().BeTrue();
+        result.Data!.Mergeable.Should().BeNull();
+        result.Data.Merged.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task GetPr_DirtyConflict_MergeableFalse()
+    {
+        _handler.OnGet("/repos/o/r/pulls/8",
+            """{ "number": 8, "state": "open", "merged": false, "mergeable": false, "mergeable_state": "dirty" }""");
+
+        var result = await CreateService().GetGitHubPullRequestAsync("o/r", 8);
+
+        result.Success.Should().BeTrue();
+        result.Data!.Mergeable.Should().BeFalse();
+        result.Data.MergeableState.Should().Be("dirty");
+    }
+
+    [Test]
+    public async Task GetPr_HttpError_ReturnsFail()
+    {
+        _handler.OnGet("/repos/o/r/pulls/8", "nope", HttpStatusCode.InternalServerError);
+
+        var result = await CreateService().GetGitHubPullRequestAsync("o/r", 8);
+
+        result.Success.Should().BeFalse("a 5xx must surface as an error, never a fabricated state");
+    }
+
+    // ================================================================
     // Route-aware fake handler
     // ================================================================
 
@@ -391,6 +529,9 @@ public class GitHubIntegrationServiceTests
 
         public void OnPatch(string path, string body, HttpStatusCode status = HttpStatusCode.OK)
             => _routes[("PATCH", path)] = (status, body);
+
+        public void OnPut(string path, string body, HttpStatusCode status = HttpStatusCode.OK)
+            => _routes[("PUT", path)] = (status, body);
 
         public CapturedRequest RequireRequest(HttpMethod method, string path)
         {


### PR DESCRIPTION
`MergeWorkflow` (the highest-blast-radius git write) — thin → complete.

- **No false success:** success = a VERIFIED merged state (re-read), never "SHA non-empty"; a merge that didn't happen (conflict / not-mergeable / permission / read-failure / SHA-less / closed-unmerged) → `Error` → `success=false` + loud `MERGE.FAILED`. Refuses to fabricate a SHA.
- **Idempotency:** already-merged PR → reports success without re-merging (`Times.Never`); a failed pre-merge read fails closed (no blind merge).
- **`success` contract preserved** for the `merge-approval` gate (reads `success`, escalates on false) — gate unmodified.
- Configurable merge strategy (merge/squash/rebase → `merge_method`), verified issue-close + best-effort branch-delete, `MERGE.*`/`ISSUE.CLOSED.*`/`BRANCH.DELETED.*` events via the durable drain, `tenantId`.
- New `GetGitHubPullRequestAsync` (exact-match `pulls/{n}`) + strategy-aware merge, with HTTP-level tests. CI-green/approval gating stays upstream (cycle + gate); deferred: readiness node, `pr_merge:*` config binding, commit-message templating, transient retry.

Reviewed: APPROVED. Build 0 err; Merge 108/0 + GitHub HTTP 26/0; full Activities 1595/0, Api 3689/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)