### PR TITLE
feat(workflows): build out TestingWorkflow — fail-closed CI gate, durable CI-wait timeout, DCB events

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/Tamma.Activities.csproj
+++ b/apps/tamma-elsa/src/Tamma.Activities/Tamma.Activities.csproj
@@ -20,6 +20,12 @@
     <PackageReference Include="Elsa.Agents.Core" Version="3.5.3" />
     <PackageReference Include="Elsa.Agents.Persistence" Version="3.5.3" />
     <PackageReference Include="Elsa.Http" Version="3.5.3" />
+    <!-- WaitForCIResultsActivity uses DelayActivityExecutionContextExtensions.DelayFor
+         (Elsa.Scheduling) to arm a durable, scheduler-resumed timeout bookmark alongside
+         the CI-result bookmark so the CI wait can time out deterministically instead of
+         hanging forever. Elsa.Scheduling is already wired in the host (Program.cs
+         elsa.UseScheduling()); this reference only exposes the extension at compile time. -->
+    <PackageReference Include="Elsa.Scheduling" Version="3.5.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
   </ItemGroup>
 

--- a/apps/tamma-elsa/src/Tamma.Activities/Testing/EmitTestingEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Testing/EmitTestingEventActivity.cs
@@ -1,0 +1,174 @@
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+
+namespace Tamma.Activities.Testing;
+
+/// <summary>
+/// Emits a <c>TEST.*</c> / <c>GATE.*</c> DCB event (completeness audit 2026-06-22,
+/// <c>Testing.md</c> §Missing #3) for the built-out <c>testing-pipeline</c> workflow by
+/// appending a <see cref="TammaEvent"/> to the workflow's <c>tamma:events</c> transient
+/// list via <see cref="TammaEventEmitter.Emit"/>. The merged engine event drain
+/// (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) flushes that list <i>durably</i>
+/// to the tenant <c>domain_events</c> store after this activity runs — no DB / repository
+/// dependency is held by this activity (none is registered in the Elsa engine, the same
+/// reason <see cref="EmitTddDebugEventActivity"/> uses the emitter rather than a direct
+/// <c>IEventRepository</c>).
+///
+/// <para>The pipeline emits these at: CI trigger (success/failed), results received, each
+/// gate evaluation, each fix commit (committed / no-op), and every terminal
+/// (pass / fail / escalated). The failure / timeout / no-op / escalation events are
+/// error-status (see <see cref="TestingEvents.StatusForEvent"/>) so a degraded terminal is
+/// a LOUD audit row, never a silent false success.</para>
+/// </summary>
+[Activity(
+    "Tamma.Testing",
+    "Emit Testing Event",
+    "Emit a TEST.* / GATE.* DCB event for the testing-pipeline audit trail",
+    Kind = ActivityKind.Task
+)]
+public class EmitTestingEventActivity : Activity
+{
+    private readonly ILogger<EmitTestingEventActivity>? _logger;
+
+    [Input(Description = "Event type — TEST.CI_TRIGGERED.* / TEST.RESULTS_RECEIVED / TEST.CI_TIMED_OUT / GATE.EVALUATED / GATE.AUTOFIX_* / GATE.PASSED / GATE.FAILED / GATE.ESCALATED")]
+    public Input<string> EventType { get; set; } = default!;
+
+    [Input(Description = "Mentorship / testing session id (empty when unknown)")]
+    public Input<string?> SessionId { get; set; } = new((string?)null);
+
+    [Input(Description = "Repository URL or owner/repo")]
+    public Input<string?> Repository { get; set; } = new((string?)null);
+
+    [Input(Description = "Branch under test")]
+    public Input<string?> Branch { get; set; } = new((string?)null);
+
+    [Input(Description = "CI run id (empty before/without a run)")]
+    public Input<string?> RunId { get; set; } = new((string?)null);
+
+    [Input(Description = "Tenant id (empty / single-user → platform-scope event)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [Input(Description = "Current auto-fix attempt number (0 before the first fix)")]
+    public Input<int> Attempt { get; set; } = new(0);
+
+    [Input(Description = "Max auto-fix attempts for the loop")]
+    public Input<int> MaxAttempts { get; set; } = new(0);
+
+    [Input(Description = "Quality-gate outcome (AllPass / MinorIssues / MajorIssues / Critical; empty when N/A)")]
+    public Input<string?> Outcome { get; set; } = new((string?)null);
+
+    [Input(Description = "Overall quality score 0-100 (negative → omitted)")]
+    public Input<double> Score { get; set; } = new(-1d);
+
+    [Input(Description = "Junior skill level 1-5 (0 → omitted)")]
+    public Input<int> SkillLevel { get; set; } = new(0);
+
+    [Input(Description = "Files changed by an auto-fix commit (negative → omitted)")]
+    public Input<int> FilesChanged { get; set; } = new(-1);
+
+    [Input(Description = "Terminal escalation reason (critical-quality-failure / retry-budget-exhausted / ci-timeout / ci-trigger-failed / autofix-no-op; empty on non-terminal events)")]
+    public Input<string?> EscalationReason { get; set; } = new((string?)null);
+
+    [Input(Description = "Underlying failure detail surfaced on a loud terminal (empty otherwise; never raw secrets)")]
+    public Input<string?> ErrorDetail { get; set; } = new((string?)null);
+
+    [JsonConstructor]
+    public EmitTestingEventActivity() { }
+
+    public EmitTestingEventActivity(ILogger<EmitTestingEventActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var type = EventType.Get(context) ?? TestingEvents.GateFailed;
+
+        var evt = BuildTammaEvent(
+            type,
+            sessionId: SessionId.Get(context),
+            repository: Repository.Get(context),
+            branch: Branch.Get(context),
+            runId: RunId.Get(context),
+            tenantId: TestingEvents.ParseTenantId(TenantId.Get(context)),
+            attempt: Attempt.Get(context),
+            maxAttempts: MaxAttempts.Get(context),
+            outcome: Outcome.Get(context),
+            score: Score.Get(context),
+            skillLevel: SkillLevel.Get(context),
+            filesChanged: FilesChanged.Get(context),
+            escalationReason: EscalationReason.Get(context),
+            errorDetail: ErrorDetail.Get(context));
+
+        TammaEventEmitter.Emit(context, this, _logger, evt);
+
+        _logger?.LogInformation(
+            "Emitted {Type} for session {Session} repo {Repo} (run={Run}, attempt={Attempt}/{Max}, outcome={Outcome})",
+            type, SessionId.Get(context), Repository.Get(context), RunId.Get(context),
+            Attempt.Get(context), MaxAttempts.Get(context), Outcome.Get(context));
+
+        return default;
+    }
+
+    /// <summary>
+    /// Map the testing-pipeline inputs onto a <see cref="TammaEvent"/> expressed as the
+    /// engine's transient-list event so the merged drain persists it. Tags carry the
+    /// queryable DCB index keys (<c>sessionId</c> / <c>repository</c> / <c>branch</c> /
+    /// <c>runId</c> / <c>attempt</c> / <c>tenantId</c>); <c>Data</c> carries the gate
+    /// payload (<c>outcome</c> / <c>score</c> / <c>skillLevel</c> / <c>filesChanged</c> /
+    /// <c>escalationReason</c> / <c>errorDetail</c>). Status is driven off the event type
+    /// (failed / timeout / no-op / escalated → error) so a degraded terminal is never
+    /// recorded as a false success. Pure (no Elsa context); exposed for unit testing.
+    /// </summary>
+    public static TammaEvent BuildTammaEvent(
+        string type,
+        string? sessionId,
+        string? repository,
+        string? branch,
+        string? runId,
+        Guid? tenantId,
+        int attempt,
+        int maxAttempts,
+        string? outcome,
+        double score,
+        int skillLevel,
+        int filesChanged,
+        string? escalationReason,
+        string? errorDetail)
+    {
+        var tags = new Dictionary<string, object?>
+        {
+            ["attempt"] = attempt.ToString(),
+        };
+        if (!string.IsNullOrWhiteSpace(sessionId)) tags["sessionId"] = sessionId;
+        if (!string.IsNullOrWhiteSpace(repository)) tags["repository"] = repository;
+        if (!string.IsNullOrWhiteSpace(branch)) tags["branch"] = branch;
+        if (!string.IsNullOrWhiteSpace(runId)) tags["runId"] = runId;
+        if (tenantId is not null) tags["tenantId"] = tenantId.Value.ToString("D");
+
+        var data = new Dictionary<string, object?>
+        {
+            ["attempt"] = attempt,
+            ["maxAttempts"] = maxAttempts,
+        };
+        if (!string.IsNullOrWhiteSpace(outcome)) data["outcome"] = outcome;
+        if (score >= 0) data["score"] = score;
+        if (skillLevel > 0) data["skillLevel"] = skillLevel;
+        if (filesChanged >= 0) data["filesChanged"] = filesChanged;
+        if (!string.IsNullOrWhiteSpace(escalationReason)) data["escalationReason"] = escalationReason;
+        if (!string.IsNullOrWhiteSpace(errorDetail)) data["errorDetail"] = errorDetail;
+
+        return new TammaEvent
+        {
+            EventType = type,
+            Status = TestingEvents.StatusForEvent(type),
+            Tags = tags,
+            Data = data,
+        };
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Testing/TestingEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Testing/TestingEvents.cs
@@ -1,0 +1,103 @@
+namespace Tamma.Activities.Testing;
+
+/// <summary>
+/// Completeness audit 2026-06-22 (<c>Testing.md</c> §Missing #3, Build-out Phase 1 step 4)
+/// — central catalogue of the <c>TEST.*</c> / <c>GATE.*</c> DCB event types emitted by
+/// the built-out <c>testing-pipeline</c> workflow via <see cref="EmitTestingEventActivity"/>.
+/// Type pattern follows the platform's <c>AGGREGATE.ACTION.STATUS</c> convention
+/// (<c>CLAUDE.md</c>) and mirrors the sibling event catalogue
+/// (<see cref="Tamma.Activities.ADL.TddDebugEvents"/>).
+///
+/// <para>The core completeness gap was a real multi-branch pipeline with a bookmark CI
+/// wait, an auto-fix loop and skill-level thresholds — but ZERO audit events anywhere,
+/// violating <c>CLAUDE.md</c> ("every operation must emit events"), Story 2-5 AC7
+/// ("logged to event trail") and Story 7-7 AC6 (improvement tracking). Without these the
+/// pipeline's quality-gate decisions, fix commits and terminal pass/fail/escalation are
+/// invisible to the audit trail and time-travel debugging.</para>
+///
+/// <para>Events are emitted via <c>TammaEventEmitter.Emit</c> into the workflow's
+/// <c>tamma:events</c> transient list and persisted <i>durably</i> by the engine event
+/// drain (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) — the same pattern
+/// <see cref="Tamma.Activities.ADL.EmitTddDebugEventActivity"/> uses. No activity holds a
+/// DB / repository dependency of its own (none is registered in the Elsa engine — a
+/// directly-injected <c>IEventRepository</c> would be inert and silently drop every
+/// event). The drain resolves the tenant from the workflow scope, so a SaaS caller's
+/// testing events carry the tenant tag.</para>
+///
+/// <list type="bullet">
+///   <item><description><c>TEST.CI_TRIGGERED.SUCCESS</c> / <c>.FAILED</c> — a CI run was
+///     requested; FAILED is a LOUD (error) row taken when the trigger itself failed (no
+///     run id → guaranteed hang downstream), routed to escalation, never a silent
+///     proceed-into-a-dead-wait.</description></item>
+///   <item><description><c>TEST.RESULTS_RECEIVED</c> — CI results arrived via the
+///     bookmark resume (carries runId / build-passed / failed-test count).</description></item>
+///   <item><description><c>TEST.CI_TIMED_OUT</c> — the bookmark wait hit its
+///     <c>TimeoutMinutes</c> deadline before CI reported. LOUD (error) — the workflow
+///     takes a deterministic failure edge instead of suspending forever.</description></item>
+///   <item><description><c>GATE.EVALUATED</c> — a quality-gate evaluation completed
+///     (carries outcome / score / skillLevel).</description></item>
+///   <item><description><c>GATE.AUTOFIX_COMMITTED</c> — an auto-fix commit landed real
+///     changes (carries attempt / filesChanged).</description></item>
+///   <item><description><c>GATE.AUTOFIX_NOOP</c> — the fix generation produced NO file
+///     changes; treated as a non-fix and routed to escalation rather than re-triggering CI
+///     and pretending progress. LOUD (error) — closes the false-success hole.</description></item>
+///   <item><description><c>GATE.PASSED</c> — a terminal pass (all gates green on a real
+///     CI result).</description></item>
+///   <item><description><c>GATE.FAILED</c> — a terminal fail. LOUD (error).</description></item>
+///   <item><description><c>GATE.ESCALATED</c> — a terminal escalation to human review
+///     (critical / retry-exhausted / ci-timeout / ci-trigger-failed / autofix-noop). LOUD
+///     (error) — the mandatory escalation after the bounded retry budget, never a silent
+///     give-up.</description></item>
+/// </list>
+/// </summary>
+public static class TestingEvents
+{
+    public const string CiTriggeredSuccess = "TEST.CI_TRIGGERED.SUCCESS";
+    public const string CiTriggeredFailed = "TEST.CI_TRIGGERED.FAILED";
+    public const string ResultsReceived = "TEST.RESULTS_RECEIVED.SUCCESS";
+    public const string CiTimedOut = "TEST.CI_TIMED_OUT.FAILED";
+    public const string GateEvaluated = "GATE.EVALUATED.SUCCESS";
+    public const string AutofixCommitted = "GATE.AUTOFIX_COMMITTED.SUCCESS";
+    public const string AutofixNoop = "GATE.AUTOFIX_NOOP.FAILED";
+    public const string GatePassed = "GATE.PASSED.SUCCESS";
+    public const string GateFailed = "GATE.FAILED.FAILED";
+    public const string GateEscalated = "GATE.ESCALATED.FAILED";
+
+    /// <summary>
+    /// The terminal <c>escalationReason</c> values the workflow stamps on its escalation
+    /// output so the caller / audit trail can distinguish WHY the pipeline escalated to a
+    /// human gate. Never an empty string — an escalation always carries a reason (no false
+    /// success, no silent failure). Mirrors <c>TddDebugEvents</c>'s finish-reason pattern.
+    /// </summary>
+    public const string ReasonCritical = "critical-quality-failure";
+    public const string ReasonRetryExhausted = "retry-budget-exhausted";
+    public const string ReasonCiTimeout = "ci-timeout";
+    public const string ReasonCiTriggerFailed = "ci-trigger-failed";
+    public const string ReasonAutofixNoop = "autofix-no-op";
+
+    /// <summary>
+    /// Parse a tenant id from the loose string form threaded through the workflow inputs.
+    /// Returns <c>null</c> for empty / single-user / unparseable values (testing events in
+    /// single-user mode are platform-scope, TenantId null). Mirrors
+    /// <see cref="Tamma.Activities.ADL.TddDebugEvents.ParseTenantId"/>.
+    /// </summary>
+    public static Guid? ParseTenantId(string? tenantId)
+        => Guid.TryParse(tenantId, out var g) ? g : null;
+
+    /// <summary>
+    /// Status convention: a CI trigger failure, a CI timeout, an auto-fix no-op, a terminal
+    /// fail and a terminal escalation are LOUD (error-status) audit rows; every other
+    /// transition (CI triggered, results received, gate evaluated, auto-fix committed,
+    /// terminal pass) is a normal (success-status) row. Keeps a degraded / failed terminal
+    /// from ever being recorded as a false success.
+    /// </summary>
+    public static string StatusForEvent(string type) => type switch
+    {
+        CiTriggeredFailed => "error",
+        CiTimedOut => "error",
+        AutofixNoop => "error",
+        GateFailed => "error",
+        GateEscalated => "error",
+        _ => "success",
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Testing/WaitForCIResultsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Testing/WaitForCIResultsActivity.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Elsa.Extensions;
 using Elsa.Workflows;
+using Elsa.Workflows.Activities.Flowchart.Attributes;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
@@ -10,16 +11,35 @@ using Tamma.Activities.Testing.Models;
 namespace Tamma.Activities.Testing;
 
 /// <summary>
-/// Bookmark-based ELSA activity that suspends the workflow until CI results arrive.
-/// Creates a bookmark with the pattern: ci-result-{sessionId}-{runId}
-/// An external webhook or API call resumes the workflow by matching this bookmark payload.
+/// Bookmark-based ELSA activity that suspends the workflow until CI results arrive — OR
+/// the configured <see cref="TimeoutMinutes"/> deadline elapses, whichever happens first.
+///
+/// <para>Build-out (completeness audit 2026-06-22, <c>Testing.md</c> §Missing #2): the
+/// previously-dead <see cref="TimeoutMinutes"/> input is now ENFORCED. Two resume paths
+/// are armed when the activity suspends:</para>
+/// <list type="number">
+///   <item><description>a CI-result bookmark (<c>ci-result-{sessionId}-{runId}</c>)
+///     resumed by the external CI webhook → <c>Received</c> outcome; and</description></item>
+///   <item><description>a durable scheduled delay bookmark (via
+///     <c>DelayActivityExecutionContextExtensions.DelayFor</c>, the same primitive the
+///     framework's <c>Delay</c> activity uses) that the bookmark scheduler auto-resumes at
+///     the deadline → <c>Timeout</c> outcome.</description></item>
+/// </list>
+/// <para>Whichever resumes first completes the activity; Elsa burns the activity's
+/// remaining bookmark on completion, so the loser is discarded. On timeout the activity
+/// emits a sentinel <see cref="CIResultsPayload"/> (<c>Status="TimedOut"</c>,
+/// <c>BuildPassed=false</c>) and takes the deterministic <c>Timeout</c> edge — the workflow
+/// can never suspend forever (no permanent-hang / silent false success). The delay is
+/// durable (scheduler-driven), not a blocking <c>Task.Delay</c>, so no thread is held for
+/// the (default 30-minute) wait.</para>
 /// </summary>
 [Activity(
     "Tamma.Testing",
     "Wait For CI Results",
-    "Suspend workflow execution until CI pipeline results are received via bookmark",
+    "Suspend workflow execution until CI pipeline results are received via bookmark, or time out",
     Kind = ActivityKind.Task
 )]
+[FlowNode("Received", "Timeout")]
 public class WaitForCIResultsActivity : Activity
 {
     private readonly ILogger<WaitForCIResultsActivity>? _logger;
@@ -36,7 +56,7 @@ public class WaitForCIResultsActivity : Activity
     [Input(Description = "Timeout in minutes", DefaultValue = 30)]
     public Input<int> TimeoutMinutes { get; set; } = new(30);
 
-    /// <summary>The CI results received when resumed</summary>
+    /// <summary>The CI results received when resumed (or a TimedOut sentinel on timeout)</summary>
     [Output(Description = "CI pipeline results")]
     public Output<CIResultsPayload> Results { get; set; } = default!;
 
@@ -55,15 +75,24 @@ public class WaitForCIResultsActivity : Activity
     {
         var sessionId = SessionId.Get(context);
         var runId = RunId.Get(context);
+        var timeoutMinutes = TimeoutMinutes.Get(context);
 
         var bookmarkPayload = new CIResultBookmarkPayload(sessionId, runId);
 
         _logger?.LogInformation(
-            "Creating bookmark for CI results: {BookmarkId} (session={SessionId}, run={RunId})",
-            bookmarkPayload.BookmarkId, sessionId, runId);
+            "Creating bookmark for CI results: {BookmarkId} (session={SessionId}, run={RunId}, timeout={TimeoutMinutes}m)",
+            bookmarkPayload.BookmarkId, sessionId, runId, timeoutMinutes);
 
-        // Create bookmark — the workflow suspends here until resumed externally
+        // 1) CI-result bookmark — resumed by the external CI webhook.
         context.CreateBookmark(bookmarkPayload, OnResumeAsync);
+
+        // 2) Durable timeout bookmark — the bookmark scheduler resumes it at the deadline.
+        //    A non-positive timeout disables the deadline (wait indefinitely) — the caller
+        //    is responsible for supplying a positive timeout (the workflow always does).
+        if (timeoutMinutes > 0)
+        {
+            context.DelayFor(TimeSpan.FromMinutes(timeoutMinutes), OnTimeoutAsync);
+        }
     }
 
     private async ValueTask OnResumeAsync(ActivityExecutionContext context)
@@ -114,12 +143,41 @@ public class WaitForCIResultsActivity : Activity
         }
         catch (Exception ex)
         {
-            _logger?.LogWarning(ex, "Failed to parse CI results, using defaults");
+            // Fail closed: a CI result we cannot parse is NOT a pass. Surface a build-failed
+            // sentinel (CreateDefaultResults => BuildPassed=false, Status="Unknown") so the
+            // gate cannot read a green result out of an unparseable payload.
+            _logger?.LogWarning(ex, "Failed to parse CI results — failing closed with a build-failed sentinel");
             results = CreateDefaultResults(runId);
         }
 
         Results.Set(context, results);
-        await context.CompleteActivityAsync();
+        await context.CompleteActivityWithOutcomesAsync("Received");
+    }
+
+    /// <summary>
+    /// Resumed by the bookmark scheduler when the timeout deadline elapses before CI
+    /// reports. Emits a sentinel build-failed payload and takes the deterministic
+    /// <c>Timeout</c> edge so the workflow escalates instead of hanging forever.
+    /// </summary>
+    private async ValueTask OnTimeoutAsync(ActivityExecutionContext context)
+    {
+        var runId = RunId.Get(context);
+        var timeoutMinutes = TimeoutMinutes.Get(context);
+
+        _logger?.LogWarning(
+            "CI wait timed out after {TimeoutMinutes}m for run {RunId} — taking the Timeout edge",
+            timeoutMinutes, runId);
+
+        var sentinel = new CIResultsPayload
+        {
+            RunId = runId,
+            Status = "TimedOut",
+            BuildPassed = false,
+            CompletedAt = DateTime.UtcNow
+        };
+
+        Results.Set(context, sentinel);
+        await context.CompleteActivityWithOutcomesAsync("Timeout");
     }
 
     private static CIResultsPayload CreateDefaultResults(string runId)

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TestingWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TestingWorkflow.cs
@@ -1,31 +1,69 @@
 using System.Text.Json;
+using Elsa.Expressions.Models;
 using Elsa.Extensions;
 using Elsa.Workflows;
 using Elsa.Workflows.Activities;
 using Elsa.Workflows.Activities.Flowchart.Activities;
 using Elsa.Workflows.Activities.Flowchart.Models;
 using Elsa.Workflows.Management.Activities.SetOutput;
+using Elsa.Workflows.Memory;
 using Elsa.Workflows.Models;
+using Elsa.Workflows.Runtime.Activities;
 using Tamma.Activities.CodeIndex;
 using Tamma.Activities.Testing;
 using Tamma.Activities.Testing.Models;
+using Tamma.Api.Services.Agents;
 
 namespace Tamma.ElsaServer.Workflows;
 
 /// <summary>
-/// Testing sub-workflow: runs the full testing/quality pipeline with skill-level-aware thresholds,
-/// bookmark-based CI wait, auto-fix loops (using LLM Call sub-workflow), and teaching feedback.
+/// Testing sub-workflow: runs the full testing/quality pipeline with skill-level-aware
+/// thresholds, a timeout-enforced bookmark-based CI wait, an LLM-mediated auto-fix loop,
+/// teaching feedback, a complete DCB audit trail, and a mandatory escalation terminal.
 ///
-/// Flow:
-///   1. TriggerCI -> WaitForCIResults (bookmark) -> EvaluateResults
-///   2. EvaluateResults routes to:
-///      - AllPass:       CheckCoverage -> CheckLinting -> CheckSecurity -> GenerateQualityReport -> Finish(pass)
-///      - MinorIssues:   Same check pipeline (report determines final status)
-///      - MajorIssues:   Auto-fix loop (CommitFix -> re-trigger CI, max 3 attempts)
-///      - Critical:      Checks -> GenerateQualityReport -> Finish(fail)
+/// <para>Build-out (completeness audit 2026-06-22, <c>Testing.md</c> Phase 1 P0 + Phase 2
+/// P1):</para>
+/// <list type="bullet">
+///   <item><description><b>#1/#6 — auto-fix that actually fixes.</b> The MajorIssues path
+///     now dispatches <c>llm-call</c> (role=developer, action=implement-fix,
+///     enableTools=true) to GENERATE the fix BEFORE <c>CommitFix</c>. A zero-files-changed
+///     commit is treated as a NON-fix: it emits <c>GATE.AUTOFIX_NOOP</c> and routes to
+///     escalation instead of re-triggering CI and pretending progress. No step ever calls
+///     a provider directly — fix generation is mediated through <c>llm-call</c>.</description></item>
+///   <item><description><b>#2 — CI-wait timeout.</b> <c>WaitForCIResultsActivity</c> now
+///     arms a durable scheduled timeout bookmark alongside the result bookmark and exposes
+///     a <c>Timeout</c> outcome → the workflow takes a deterministic escalation edge if CI
+///     never reports (no permanent hang).</description></item>
+///   <item><description><b>#3 — DCB audit trail.</b> <c>EmitTestingEventActivity</c> emits
+///     <c>TEST.CI_TRIGGERED.*</c>, <c>TEST.RESULTS_RECEIVED</c>, <c>TEST.CI_TIMED_OUT</c>,
+///     <c>GATE.EVALUATED</c>, <c>GATE.AUTOFIX_COMMITTED</c>/<c>NOOP</c>, <c>GATE.PASSED</c>,
+///     <c>GATE.FAILED</c> and <c>GATE.ESCALATED</c> via the durable engine drain.</description></item>
+///   <item><description><b>#4 — fail fast on trigger failure.</b> A <c>FlowDecision</c> on
+///     <c>CITriggerResult.Success</c> after each trigger routes a failed trigger to
+///     escalation instead of proceeding into a dead CI wait with <c>RunId="unknown"</c>.</description></item>
+///   <item><description><b>#5 — mandatory escalation terminal.</b> Critical, retry-exhausted,
+///     ci-timeout, ci-trigger-failed and autofix-noop all converge on a single escalation
+///     terminal that emits <c>GATE.ESCALATED</c> with a structured reason and sets
+///     <c>escalated=true</c> + <c>escalationReason</c> outputs so the parent loop can route
+///     to a human gate. No infinite waits; no silent give-up.</description></item>
+/// </list>
 ///
-/// Inputs:  SessionId (Guid), Repository (string), Branch (string), SkillLevel (int), ConsecutivePassCount (int)
-/// Outputs: QualityReport
+/// <para>Output contract (preserved, extended additively): <c>qualityReport</c> (JSON),
+/// <c>passed</c> (bool), <c>teachingFeedback</c> (string) on every terminal path, plus the
+/// new <c>escalated</c> (bool) + <c>escalationReason</c> (string) on the escalation path.
+/// <c>passed</c> is only ever true on a real green gate result — never on a timeout, a
+/// trigger failure, a no-op fix or a parse failure.</para>
+///
+/// <para><b>Deferred (P1 #6 — MinorIssues vs AllPass):</b> the MinorIssues outcome
+/// INTENTIONALLY shares the AllPass check→report→pass path. Minor issues are
+/// warning-severity and <c>passed</c> is reported truthfully (the report reflects the
+/// warnings); a dedicated minor-auto-fix branch (generate→commit→re-evaluate for
+/// <c>Severity==Warning</c> issues) is a follow-up, not faked here. The destructive cases
+/// (MajorIssues / Critical) are the ones that gained real fix-generation + escalation.</para>
+///
+/// Inputs:  SessionId (Guid), Repository (string), Branch (string), SkillLevel (int),
+///          ConsecutivePassCount (int), tenantId (string, optional), maxRetries (int, optional)
+/// Outputs: qualityReport, passed, teachingFeedback, escalated, escalationReason
 /// </summary>
 public class TestingWorkflow : WorkflowBase
 {
@@ -45,6 +83,12 @@ public class TestingWorkflow : WorkflowBase
         var consecutivePassCountVar = builder.WithVariable<int>("ConsecutivePassCount", 0);
         var attemptNumberVar = builder.WithVariable<int>("AttemptNumber", 1);
         var maxAttemptsVar = builder.WithVariable<int>("MaxAttempts", 3);
+        // Best-effort tenant tag for the DCB events (empty/single-user → platform-scope).
+        var tenantIdVar = builder.WithVariable<string>("TenantIdTag", "");
+        // The terminal escalation reason (set just before routing into the escalation leg).
+        var escalationReasonVar = builder.WithVariable<string>("EscalationReason", "");
+        // The real underlying failure detail surfaced on an escalation (never empty).
+        var escalationDetailVar = builder.WithVariable<string>("EscalationDetail", "");
 
         // Result variables — activities write directly to these via Output<T>(variable)
         var ciTriggerResultVar = builder.WithVariable<CITriggerResult>("CITriggerResult", default!);
@@ -56,9 +100,10 @@ public class TestingWorkflow : WorkflowBase
         var qualityReportVar = builder.WithVariable<QualityReport>("QualityReport", default!);
         var commitFixResultVar = builder.WithVariable<CommitFixResult>("CommitFixResult", default!);
         var ciResultsFromWaitVar = builder.WithVariable<CIResultsPayload>("CIResultsFromWait", default!);
+        var fixDispatchResultVar = builder.WithVariable<IDictionary<string, object>?>();
 
         // ============================================
-        // Step 0: Initialize — read optional maxRetries input
+        // Step 0: Initialize — read optional maxRetries + tenantId input
         // ============================================
         var initInputs = new SetVariable
         {
@@ -67,6 +112,10 @@ public class TestingWorkflow : WorkflowBase
             Variable = maxAttemptsVar,
             Value = new Input<object?>(ctx =>
             {
+                // Best-effort tenant tag (callers may not supply it; single-user → empty).
+                var tenant = ctx.GetInput<string>("tenantId");
+                if (!string.IsNullOrWhiteSpace(tenant)) tenantIdVar.Set(ctx, tenant);
+
                 var inputMaxRetries = ctx.GetInput<int?>("maxRetries");
                 return (object)(inputMaxRetries ?? maxAttemptsVar.Get(ctx));
             })
@@ -87,8 +136,19 @@ public class TestingWorkflow : WorkflowBase
         };
         triggerCI.SetDisplayText("Trigger CI Pipeline");
 
+        var emitCiTriggered = EmitEvent("EmitCiTriggered", TestingEvents.CiTriggeredSuccess,
+            sessionIdVar, repositoryVar, branchVar, tenantIdVar,
+            runId: ctx => ciTriggerResultVar.Get(ctx)?.RunId ?? "",
+            attempt: ctx => attemptNumberVar.Get(ctx),
+            maxAttempts: ctx => maxAttemptsVar.Get(ctx));
+
+        // #4 — fail fast on trigger failure: gate on CITriggerResult.Success.
+        var triggerSucceeded = new FlowDecision(ctx => ciTriggerResultVar.Get(ctx)?.Success == true)
+        { Id = "TriggerSucceeded", Name = "CI Trigger Succeeded?" };
+        triggerSucceeded.SetDisplayText("CI Trigger Succeeded?");
+
         // ============================================
-        // Step 2: Wait for CI results (bookmark-based)
+        // Step 2: Wait for CI results (bookmark + durable timeout)
         // ============================================
         var waitForCI = new WaitForCIResultsActivity
         {
@@ -111,6 +171,20 @@ public class TestingWorkflow : WorkflowBase
         };
         storeCIResults.SetDisplayText("Store CI Results");
 
+        var emitResultsReceived = EmitEvent("EmitResultsReceived", TestingEvents.ResultsReceived,
+            sessionIdVar, repositoryVar, branchVar, tenantIdVar,
+            runId: ctx => ciResultsVar.Get(ctx)?.RunId ?? "",
+            attempt: ctx => attemptNumberVar.Get(ctx),
+            maxAttempts: ctx => maxAttemptsVar.Get(ctx),
+            configure: (a, _) =>
+            {
+                a.ErrorDetail = new Input<string?>(ctx =>
+                {
+                    var r = ciResultsVar.Get(ctx);
+                    return r == null ? null : $"build={r.BuildPassed}, failedTests={r.FailedTests}/{r.TotalTests}";
+                });
+            });
+
         // ============================================
         // Step 3: Evaluate results with outcome-based routing
         // ============================================
@@ -125,105 +199,95 @@ public class TestingWorkflow : WorkflowBase
         };
         evaluateResults.SetDisplayText("Evaluate CI Results");
 
+        var emitGateEvaluated = EmitGateEvaluated("EmitGateEvaluated",
+            sessionIdVar, repositoryVar, branchVar, tenantIdVar, ciResultsVar,
+            evaluationResultVar, attemptNumberVar, maxAttemptsVar, skillLevelVar);
+        // Separate GATE.EVALUATED emit for the MajorIssues branch so it can fan out to the
+        // auto-fix guard WITHOUT the pass-path emit also routing into both legs (each
+        // flowchart activity owns exactly one outbound edge set).
+        var emitGateEvaluatedMajor = EmitGateEvaluated("EmitGateEvaluatedMajor",
+            sessionIdVar, repositoryVar, branchVar, tenantIdVar, ciResultsVar,
+            evaluationResultVar, attemptNumberVar, maxAttemptsVar, skillLevelVar);
+
         // ============================================
         // AllPass/MinorIssues path: detailed checks
         // ============================================
-        var checkCoverage = new CheckCoverageActivity
-        {
-            Id = "CheckCoverage",
-            Name = "Check Code Coverage",
-            CIResults = new(ctx => ciResultsVar.Get(ctx)!),
-            SkillLevel = new(ctx => skillLevelVar.Get(ctx)),
-            Result = new(coverageResultVar)
-        };
-        checkCoverage.SetDisplayText("Check Code Coverage");
+        var checkCoverage = MakeCoverage("CheckCoverage", "Check Code Coverage", ciResultsVar, skillLevelVar, coverageResultVar);
+        var checkLinting = MakeLint("CheckLinting", "Check Linting Rules", ciResultsVar, skillLevelVar, lintResultVar);
+        var checkSecurity = MakeSecurity("CheckSecurity", "Check Security Issues", ciResultsVar, skillLevelVar, securityResultVar);
+        var generateReport = MakeReport("GenerateQualityReport", "Generate Quality Report",
+            sessionIdVar, ciResultsVar, coverageResultVar, lintResultVar, securityResultVar, skillLevelVar, consecutivePassCountVar, qualityReportVar);
 
-        var checkLinting = new CheckLintingActivity
-        {
-            Id = "CheckLinting",
-            Name = "Check Linting Rules",
-            CIResults = new(ctx => ciResultsVar.Get(ctx)!),
-            SkillLevel = new(ctx => skillLevelVar.Get(ctx)),
-            Result = new(lintResultVar)
-        };
-        checkLinting.SetDisplayText("Check Linting Rules");
-
-        var checkSecurity = new CheckSecurityActivity
-        {
-            Id = "CheckSecurity",
-            Name = "Check Security Issues",
-            CIResults = new(ctx => ciResultsVar.Get(ctx)!),
-            SkillLevel = new(ctx => skillLevelVar.Get(ctx)),
-            Result = new(securityResultVar)
-        };
-        checkSecurity.SetDisplayText("Check Security Issues");
-
-        var generateReport = new GenerateQualityReportActivity
-        {
-            Id = "GenerateQualityReport",
-            Name = "Generate Quality Report",
-            SessionId = new(ctx => sessionIdVar.Get(ctx)),
-            CIResults = new(ctx => ciResultsVar.Get(ctx)!),
-            CoverageResult = new(ctx => coverageResultVar.Get(ctx)!),
-            LintResult = new(ctx => lintResultVar.Get(ctx)!),
-            SecurityResult = new(ctx => securityResultVar.Get(ctx)!),
-            SkillLevel = new(ctx => skillLevelVar.Get(ctx)),
-            ConsecutivePassCount = new(ctx => consecutivePassCountVar.Get(ctx)),
-            Result = new(qualityReportVar)
-        };
-        generateReport.SetDisplayText("Generate Quality Report");
+        var emitGatePassed = EmitEvent("EmitGatePassed", TestingEvents.GatePassed,
+            sessionIdVar, repositoryVar, branchVar, tenantIdVar,
+            runId: ctx => ciResultsVar.Get(ctx)?.RunId ?? "",
+            attempt: ctx => attemptNumberVar.Get(ctx),
+            maxAttempts: ctx => maxAttemptsVar.Get(ctx),
+            configure: (a, _) =>
+            {
+                a.Score = new Input<double>(ctx => qualityReportVar.Get(ctx)?.OverallScore ?? 0);
+                a.SkillLevel = new Input<int>(ctx => skillLevelVar.Get(ctx));
+            });
 
         // ============================================
-        // Critical path: same checks, different finish
+        // Critical path: same checks, then escalate (no false pass)
         // ============================================
-        var checkCoverageCritical = new CheckCoverageActivity
-        {
-            Id = "CheckCoverageCritical",
-            Name = "Check Coverage (Critical)",
-            CIResults = new(ctx => ciResultsVar.Get(ctx)!),
-            SkillLevel = new(ctx => skillLevelVar.Get(ctx)),
-            Result = new(coverageResultVar)
-        };
-        checkCoverageCritical.SetDisplayText("Check Coverage (Critical)");
+        var checkCoverageCritical = MakeCoverage("CheckCoverageCritical", "Check Coverage (Critical)", ciResultsVar, skillLevelVar, coverageResultVar);
+        var checkLintCritical = MakeLint("CheckLintCritical", "Check Lint (Critical)", ciResultsVar, skillLevelVar, lintResultVar);
+        var checkSecurityCritical = MakeSecurity("CheckSecurityCritical", "Check Security (Critical)", ciResultsVar, skillLevelVar, securityResultVar);
+        var generateReportCritical = MakeReport("GenerateQualityReportCritical", "Generate Report (Critical)",
+            sessionIdVar, ciResultsVar, coverageResultVar, lintResultVar, securityResultVar, skillLevelVar, consecutivePassCountVar, qualityReportVar);
 
-        var checkLintCritical = new CheckLintingActivity
+        var setReasonCritical = new SetVariable
         {
-            Id = "CheckLintCritical",
-            Name = "Check Lint (Critical)",
-            CIResults = new(ctx => ciResultsVar.Get(ctx)!),
-            SkillLevel = new(ctx => skillLevelVar.Get(ctx)),
-            Result = new(lintResultVar)
+            Id = "SetReasonCritical", Name = "Set Reason: Critical",
+            Variable = escalationReasonVar,
+            Value = new Input<object?>(_ => (object)TestingEvents.ReasonCritical)
         };
-        checkLintCritical.SetDisplayText("Check Lint (Critical)");
-
-        var checkSecurityCritical = new CheckSecurityActivity
+        setReasonCritical.SetDisplayText("Set Reason: Critical");
+        var setDetailCritical = new SetVariable
         {
-            Id = "CheckSecurityCritical",
-            Name = "Check Security (Critical)",
-            CIResults = new(ctx => ciResultsVar.Get(ctx)!),
-            SkillLevel = new(ctx => skillLevelVar.Get(ctx)),
-            Result = new(securityResultVar)
+            Id = "SetDetailCritical", Name = "Set Detail: Critical",
+            Variable = escalationDetailVar,
+            Value = new Input<object?>(ctx => (object)(evaluationResultVar.Get(ctx)?.Summary ?? "Critical quality-gate failure"))
         };
-        checkSecurityCritical.SetDisplayText("Check Security (Critical)");
-
-        var generateReportCritical = new GenerateQualityReportActivity
-        {
-            Id = "GenerateQualityReportCritical",
-            Name = "Generate Report (Critical)",
-            SessionId = new(ctx => sessionIdVar.Get(ctx)),
-            CIResults = new(ctx => ciResultsVar.Get(ctx)!),
-            CoverageResult = new(ctx => coverageResultVar.Get(ctx)!),
-            LintResult = new(ctx => lintResultVar.Get(ctx)!),
-            SecurityResult = new(ctx => securityResultVar.Get(ctx)!),
-            SkillLevel = new(ctx => skillLevelVar.Get(ctx)),
-            ConsecutivePassCount = new(ctx => consecutivePassCountVar.Get(ctx)),
-            Result = new(qualityReportVar)
-        };
-        generateReportCritical.SetDisplayText("Generate Report (Critical)");
+        setDetailCritical.SetDisplayText("Set Detail: Critical");
 
         // ============================================
-        // MajorIssues path: auto-fix loop
+        // MajorIssues path: LLM-mediated GENERATE FIX -> commit -> verify changes
         // ============================================
+        var maxAttemptGuard = new FlowDecision(ctx =>
+            attemptNumberVar.Get(ctx) < maxAttemptsVar.Get(ctx))
+        { Id = "MaxAttemptGuard", Name = "Fix Attempts Remaining?" };
+        maxAttemptGuard.SetDisplayText("Fix Attempts Remaining?");
+
+        // #1 — GENERATE the fix via the mediated llm-call sub-workflow BEFORE committing.
+        // A step NEVER calls a provider directly; fix generation is routed through llm-call.
+        var generateFix = new DispatchWorkflow
+        {
+            Id = "GenerateFix",
+            Name = "Generate Fix (llm-call)",
+            WorkflowDefinitionId = new("llm-call"),
+            Input = new(ctx => new Dictionary<string, object>
+            {
+                ["role"] = AgentRole.Developer.ToWire(),
+                ["action"] = AgentAction.ImplementFix.ToWire(),
+                ["tenantId"] = tenantIdVar.Get(ctx),
+                ["variables"] = new Dictionary<string, object>
+                {
+                    ["repository"] = repositoryVar.Get(ctx),
+                    ["branch"] = branchVar.Get(ctx),
+                    ["attemptNumber"] = attemptNumberVar.Get(ctx),
+                    ["issuesJson"] = SerializeAutoFixableIssues(evaluationResultVar, ctx),
+                    ["evaluationSummary"] = evaluationResultVar.Get(ctx)?.Summary ?? "",
+                },
+                ["enableTools"] = true,
+            }),
+            WaitForCompletion = new(true),
+            Result = new(fixDispatchResultVar)
+        };
+        generateFix.SetDisplayText("Generate Fix (llm-call)");
+
         var commitFix = new CommitFixActivity
         {
             Id = "CommitFix",
@@ -235,13 +299,58 @@ public class TestingWorkflow : WorkflowBase
                 .Where(i => i.AutoFixable).ToList() ?? new List<QualityIssue>()),
             AttemptNumber = new(ctx => attemptNumberVar.Get(ctx)),
             MaxAttempts = new(ctx => maxAttemptsVar.Get(ctx)),
-            FixDescription = new("Auto-fix quality issues via LLM"),
+            FixDescription = new(ctx => GetFixSummary(fixDispatchResultVar.Get(ctx))),
             Result = new(commitFixResultVar)
         };
         commitFix.SetDisplayText("Commit Auto-Fix");
 
-        // CommitFixResult only has FilesChanged (int count), no file paths —
-        // pass null so the indexer falls back to git-diff detection.
+        // #1/#6 — treat a zero-files-changed commit as a NON-fix: do not loop pretending
+        // progress. Only a commit that actually changed files continues the loop.
+        var commitMadeChanges = new FlowDecision(ctx =>
+        {
+            var r = commitFixResultVar.Get(ctx);
+            return r is { Success: true, FilesChanged: > 0 };
+        })
+        { Id = "CommitMadeChanges", Name = "Fix Changed Files?" };
+        commitMadeChanges.SetDisplayText("Fix Changed Files?");
+
+        var emitAutofixCommitted = EmitEvent("EmitAutofixCommitted", TestingEvents.AutofixCommitted,
+            sessionIdVar, repositoryVar, branchVar, tenantIdVar,
+            runId: ctx => ciResultsVar.Get(ctx)?.RunId ?? "",
+            attempt: ctx => attemptNumberVar.Get(ctx),
+            maxAttempts: ctx => maxAttemptsVar.Get(ctx),
+            configure: (a, _) =>
+            {
+                a.FilesChanged = new Input<int>(ctx => commitFixResultVar.Get(ctx)?.FilesChanged ?? 0);
+            });
+
+        var emitAutofixNoop = EmitEvent("EmitAutofixNoop", TestingEvents.AutofixNoop,
+            sessionIdVar, repositoryVar, branchVar, tenantIdVar,
+            runId: ctx => ciResultsVar.Get(ctx)?.RunId ?? "",
+            attempt: ctx => attemptNumberVar.Get(ctx),
+            maxAttempts: ctx => maxAttemptsVar.Get(ctx),
+            configure: (a, _) =>
+            {
+                a.FilesChanged = new Input<int>(ctx => commitFixResultVar.Get(ctx)?.FilesChanged ?? 0);
+                a.EscalationReason = new Input<string?>(_ => TestingEvents.ReasonAutofixNoop);
+                a.ErrorDetail = new Input<string?>(_ => "Auto-fix commit changed no files — the generated fix made no real change");
+            });
+
+        var setReasonNoop = new SetVariable
+        {
+            Id = "SetReasonNoop", Name = "Set Reason: Autofix No-op",
+            Variable = escalationReasonVar,
+            Value = new Input<object?>(_ => (object)TestingEvents.ReasonAutofixNoop)
+        };
+        setReasonNoop.SetDisplayText("Set Reason: Autofix No-op");
+        var setDetailNoop = new SetVariable
+        {
+            Id = "SetDetailNoop", Name = "Set Detail: Autofix No-op",
+            Variable = escalationDetailVar,
+            Value = new Input<object?>(_ => (object)"Auto-fix produced no file changes; cannot make progress")
+        };
+        setDetailNoop.SetDisplayText("Set Detail: Autofix No-op");
+
         var updateCodeIndex = new UpdateCodeIndexActivity
         {
             Id = "UpdateCodeIndex",
@@ -259,7 +368,6 @@ public class TestingWorkflow : WorkflowBase
         };
         incrementAttempt.SetDisplayText("Increment Fix Attempt");
 
-        // Re-trigger CI after fix
         var reTriggerCI = new TriggerCIActivity
         {
             Id = "ReTriggerCI",
@@ -270,6 +378,16 @@ public class TestingWorkflow : WorkflowBase
             Result = new(ciTriggerResultVar)
         };
         reTriggerCI.SetDisplayText("Re-Trigger CI After Fix");
+
+        var emitReCiTriggered = EmitEvent("EmitReCiTriggered", TestingEvents.CiTriggeredSuccess,
+            sessionIdVar, repositoryVar, branchVar, tenantIdVar,
+            runId: ctx => ciTriggerResultVar.Get(ctx)?.RunId ?? "",
+            attempt: ctx => attemptNumberVar.Get(ctx),
+            maxAttempts: ctx => maxAttemptsVar.Get(ctx));
+
+        var reTriggerSucceeded = new FlowDecision(ctx => ciTriggerResultVar.Get(ctx)?.Success == true)
+        { Id = "ReTriggerSucceeded", Name = "Re-Trigger Succeeded?" };
+        reTriggerSucceeded.SetDisplayText("Re-Trigger Succeeded?");
 
         var waitForCIRetry = new WaitForCIResultsActivity
         {
@@ -291,7 +409,12 @@ public class TestingWorkflow : WorkflowBase
         };
         storeRetryResults.SetDisplayText("Store Retry CI Results");
 
-        // Re-evaluate after retry
+        var emitRetryResultsReceived = EmitEvent("EmitRetryResultsReceived", TestingEvents.ResultsReceived,
+            sessionIdVar, repositoryVar, branchVar, tenantIdVar,
+            runId: ctx => ciResultsVar.Get(ctx)?.RunId ?? "",
+            attempt: ctx => attemptNumberVar.Get(ctx),
+            maxAttempts: ctx => maxAttemptsVar.Get(ctx));
+
         var evaluateRetryResults = new EvaluateResultsActivity
         {
             Id = "EvaluateRetryResults",
@@ -303,149 +426,175 @@ public class TestingWorkflow : WorkflowBase
         };
         evaluateRetryResults.SetDisplayText("Evaluate Retry Results");
 
+        var emitRetryGateEvaluated = EmitGateEvaluated("EmitRetryGateEvaluated",
+            sessionIdVar, repositoryVar, branchVar, tenantIdVar, ciResultsVar,
+            evaluationResultVar, attemptNumberVar, maxAttemptsVar, skillLevelVar);
+        var emitRetryGateEvaluatedMajor = EmitGateEvaluated("EmitRetryGateEvaluatedMajor",
+            sessionIdVar, repositoryVar, branchVar, tenantIdVar, ciResultsVar,
+            evaluationResultVar, attemptNumberVar, maxAttemptsVar, skillLevelVar);
+
         // Retry pass path: detailed checks
-        var checkCoverageRetry = new CheckCoverageActivity
-        {
-            Id = "CheckCoverageRetry",
-            Name = "Check Coverage (Retry)",
-            CIResults = new(ctx => ciResultsVar.Get(ctx)!),
-            SkillLevel = new(ctx => skillLevelVar.Get(ctx)),
-            Result = new(coverageResultVar)
-        };
-        checkCoverageRetry.SetDisplayText("Check Coverage (Retry)");
+        var checkCoverageRetry = MakeCoverage("CheckCoverageRetry", "Check Coverage (Retry)", ciResultsVar, skillLevelVar, coverageResultVar);
+        var checkLintRetry = MakeLint("CheckLintRetry", "Check Lint (Retry)", ciResultsVar, skillLevelVar, lintResultVar);
+        var checkSecurityRetry = MakeSecurity("CheckSecurityRetry", "Check Security (Retry)", ciResultsVar, skillLevelVar, securityResultVar);
+        var generateRetryReport = MakeReport("GenerateQualityReportRetry", "Generate Report (Retry)",
+            sessionIdVar, ciResultsVar, coverageResultVar, lintResultVar, securityResultVar, skillLevelVar, consecutivePassCountVar, qualityReportVar);
 
-        var checkLintRetry = new CheckLintingActivity
-        {
-            Id = "CheckLintRetry",
-            Name = "Check Lint (Retry)",
-            CIResults = new(ctx => ciResultsVar.Get(ctx)!),
-            SkillLevel = new(ctx => skillLevelVar.Get(ctx)),
-            Result = new(lintResultVar)
-        };
-        checkLintRetry.SetDisplayText("Check Lint (Retry)");
+        var emitRetryGatePassed = EmitEvent("EmitRetryGatePassed", TestingEvents.GatePassed,
+            sessionIdVar, repositoryVar, branchVar, tenantIdVar,
+            runId: ctx => ciResultsVar.Get(ctx)?.RunId ?? "",
+            attempt: ctx => attemptNumberVar.Get(ctx),
+            maxAttempts: ctx => maxAttemptsVar.Get(ctx),
+            configure: (a, _) =>
+            {
+                a.Score = new Input<double>(ctx => qualityReportVar.Get(ctx)?.OverallScore ?? 0);
+                a.SkillLevel = new Input<int>(ctx => skillLevelVar.Get(ctx));
+            });
 
-        var checkSecurityRetry = new CheckSecurityActivity
+        // Retry Critical / exhaustion escalation reason setters
+        var setReasonRetryCritical = new SetVariable
         {
-            Id = "CheckSecurityRetry",
-            Name = "Check Security (Retry)",
-            CIResults = new(ctx => ciResultsVar.Get(ctx)!),
-            SkillLevel = new(ctx => skillLevelVar.Get(ctx)),
-            Result = new(securityResultVar)
+            Id = "SetReasonRetryCritical", Name = "Set Reason: Retry Critical",
+            Variable = escalationReasonVar,
+            Value = new Input<object?>(_ => (object)TestingEvents.ReasonCritical)
         };
-        checkSecurityRetry.SetDisplayText("Check Security (Retry)");
+        setReasonRetryCritical.SetDisplayText("Set Reason: Retry Critical");
+        var setDetailRetryCritical = new SetVariable
+        {
+            Id = "SetDetailRetryCritical", Name = "Set Detail: Retry Critical",
+            Variable = escalationDetailVar,
+            Value = new Input<object?>(ctx => (object)(evaluationResultVar.Get(ctx)?.Summary ?? "Critical quality-gate failure on retry"))
+        };
+        setDetailRetryCritical.SetDisplayText("Set Detail: Retry Critical");
 
-        var generateRetryReport = new GenerateQualityReportActivity
+        var setReasonExhausted = new SetVariable
         {
-            Id = "GenerateQualityReportRetry",
-            Name = "Generate Report (Retry)",
-            SessionId = new(ctx => sessionIdVar.Get(ctx)),
-            CIResults = new(ctx => ciResultsVar.Get(ctx)!),
-            CoverageResult = new(ctx => coverageResultVar.Get(ctx)!),
-            LintResult = new(ctx => lintResultVar.Get(ctx)!),
-            SecurityResult = new(ctx => securityResultVar.Get(ctx)!),
-            SkillLevel = new(ctx => skillLevelVar.Get(ctx)),
-            ConsecutivePassCount = new(ctx => consecutivePassCountVar.Get(ctx)),
-            Result = new(qualityReportVar)
+            Id = "SetReasonExhausted", Name = "Set Reason: Retry Exhausted",
+            Variable = escalationReasonVar,
+            Value = new Input<object?>(_ => (object)TestingEvents.ReasonRetryExhausted)
         };
-        generateRetryReport.SetDisplayText("Generate Report (Retry)");
+        setReasonExhausted.SetDisplayText("Set Reason: Retry Exhausted");
+        var setDetailExhausted = new SetVariable
+        {
+            Id = "SetDetailExhausted", Name = "Set Detail: Retry Exhausted",
+            Variable = escalationDetailVar,
+            Value = new Input<object?>(ctx => (object)$"Auto-fix did not converge after {attemptNumberVar.Get(ctx)}/{maxAttemptsVar.Get(ctx)} attempt(s): {evaluationResultVar.Get(ctx)?.Summary ?? "major issues remain"}")
+        };
+        setDetailExhausted.SetDisplayText("Set Detail: Retry Exhausted");
+
+        // ci-timeout / ci-trigger-failed reason setters
+        var setReasonTimeout = new SetVariable
+        {
+            Id = "SetReasonTimeout", Name = "Set Reason: CI Timeout",
+            Variable = escalationReasonVar,
+            Value = new Input<object?>(_ => (object)TestingEvents.ReasonCiTimeout)
+        };
+        setReasonTimeout.SetDisplayText("Set Reason: CI Timeout");
+        var setDetailTimeout = new SetVariable
+        {
+            Id = "SetDetailTimeout", Name = "Set Detail: CI Timeout",
+            Variable = escalationDetailVar,
+            Value = new Input<object?>(_ => (object)"CI did not report results before the timeout deadline")
+        };
+        setDetailTimeout.SetDisplayText("Set Detail: CI Timeout");
+
+        var emitCiTimedOut = EmitEvent("EmitCiTimedOut", TestingEvents.CiTimedOut,
+            sessionIdVar, repositoryVar, branchVar, tenantIdVar,
+            runId: ctx => ciTriggerResultVar.Get(ctx)?.RunId ?? "",
+            attempt: ctx => attemptNumberVar.Get(ctx),
+            maxAttempts: ctx => maxAttemptsVar.Get(ctx),
+            configure: (a, _) =>
+            {
+                a.ErrorDetail = new Input<string?>(_ => "CI wait timed out");
+            });
+
+        var setReasonTriggerFailed = new SetVariable
+        {
+            Id = "SetReasonTriggerFailed", Name = "Set Reason: Trigger Failed",
+            Variable = escalationReasonVar,
+            Value = new Input<object?>(_ => (object)TestingEvents.ReasonCiTriggerFailed)
+        };
+        setReasonTriggerFailed.SetDisplayText("Set Reason: Trigger Failed");
+        var setDetailTriggerFailed = new SetVariable
+        {
+            Id = "SetDetailTriggerFailed", Name = "Set Detail: Trigger Failed",
+            Variable = escalationDetailVar,
+            Value = new Input<object?>(ctx => (object)(ciTriggerResultVar.Get(ctx)?.Error ?? "CI trigger failed"))
+        };
+        setDetailTriggerFailed.SetDisplayText("Set Detail: Trigger Failed");
+
+        var emitCiTriggerFailed = EmitEvent("EmitCiTriggerFailed", TestingEvents.CiTriggeredFailed,
+            sessionIdVar, repositoryVar, branchVar, tenantIdVar,
+            runId: ctx => ciTriggerResultVar.Get(ctx)?.RunId ?? "",
+            attempt: ctx => attemptNumberVar.Get(ctx),
+            maxAttempts: ctx => maxAttemptsVar.Get(ctx),
+            configure: (a, _) =>
+            {
+                a.EscalationReason = new Input<string?>(_ => TestingEvents.ReasonCiTriggerFailed);
+                a.ErrorDetail = new Input<string?>(ctx => ciTriggerResultVar.Get(ctx)?.Error ?? "CI trigger failed");
+            });
 
         // ============================================
-        // Max-attempt guard for MajorIssues retry loop
+        // ESCALATION TERMINAL — mandatory after the bounded retry budget / on any hard
+        // failure. Emits GATE.ESCALATED + sets escalated/escalationReason outputs so the
+        // parent loop can route to a human gate. LOUD, never a silent give-up.
         // ============================================
-        var maxAttemptGuard = new FlowDecision(ctx =>
-            attemptNumberVar.Get(ctx) < maxAttemptsVar.Get(ctx))
-        { Id = "MaxAttemptGuard", Name = "Fix Attempts Remaining?" };
-        maxAttemptGuard.SetDisplayText("Fix Attempts Remaining?");
+        var emitGateEscalated = new EmitTestingEventActivity
+        {
+            Id = "EmitGateEscalated", Name = "Emit GATE.ESCALATED",
+            EventType = new Input<string>(_ => TestingEvents.GateEscalated),
+            SessionId = new Input<string?>(ctx => sessionIdVar.Get(ctx).ToString()),
+            Repository = new Input<string?>(ctx => repositoryVar.Get(ctx)),
+            Branch = new Input<string?>(ctx => branchVar.Get(ctx)),
+            RunId = new Input<string?>(ctx => ciResultsVar.Get(ctx)?.RunId ?? ""),
+            TenantId = new Input<string?>(ctx => tenantIdVar.Get(ctx)),
+            Attempt = new Input<int>(ctx => attemptNumberVar.Get(ctx)),
+            MaxAttempts = new Input<int>(ctx => maxAttemptsVar.Get(ctx)),
+            Outcome = new Input<string?>(ctx => evaluationResultVar.Get(ctx)?.Outcome.ToString()),
+            EscalationReason = new Input<string?>(ctx => escalationReasonVar.Get(ctx)),
+            ErrorDetail = new Input<string?>(ctx => escalationDetailVar.Get(ctx)),
+        };
+        emitGateEscalated.SetDisplayText("Emit GATE.ESCALATED");
 
         // ============================================
         // SetOutput activities (expose workflow outputs before each Finish)
         // ============================================
+        var setOutputPassReport = MakeOutput("SetOutputPassReport", "qualityReport",
+            ctx => (object)JsonSerializer.Serialize(qualityReportVar.Get(ctx)));
+        var setOutputPassPassed = MakeOutput("SetOutputPassPassed", "passed",
+            ctx => (object)(qualityReportVar.Get(ctx)?.Passed ?? true));
+        var setOutputPassFeedback = MakeOutput("SetOutputPassFeedback", "teachingFeedback",
+            ctx => (object)(qualityReportVar.Get(ctx)?.TeachingFeedback ?? ""));
+        var setOutputPassEscalated = MakeOutput("SetOutputPassEscalated", "escalated", _ => (object)false);
+        var setOutputPassReason = MakeOutput("SetOutputPassReason", "escalationReason", _ => (object)"");
 
-        // Pass path outputs
-        var setOutputPassReport = new SetOutput
-        {
-            Id = "SetOutputPassReport",
-            Name = "Output: Quality Report (Pass)",
-            OutputName = new("qualityReport"),
-            OutputValue = new(ctx => (object)JsonSerializer.Serialize(qualityReportVar.Get(ctx)))
-        };
-        setOutputPassReport.SetDisplayText("Output: Quality Report (Pass)");
-        var setOutputPassPassed = new SetOutput
-        {
-            Id = "SetOutputPassPassed",
-            Name = "Output: Passed Flag (Pass)",
-            OutputName = new("passed"),
-            OutputValue = new(ctx => (object)(qualityReportVar.Get(ctx)?.Passed ?? true))
-        };
-        setOutputPassPassed.SetDisplayText("Output: Passed Flag (Pass)");
-        var setOutputPassFeedback = new SetOutput
-        {
-            Id = "SetOutputPassFeedback",
-            Name = "Output: Teaching Feedback (Pass)",
-            OutputName = new("teachingFeedback"),
-            OutputValue = new(ctx => (object)(qualityReportVar.Get(ctx)?.TeachingFeedback ?? ""))
-        };
-        setOutputPassFeedback.SetDisplayText("Output: Teaching Feedback (Pass)");
+        var setOutputRetryPassReport = MakeOutput("SetOutputRetryPassReport", "qualityReport",
+            ctx => (object)JsonSerializer.Serialize(qualityReportVar.Get(ctx)));
+        var setOutputRetryPassPassed = MakeOutput("SetOutputRetryPassPassed", "passed",
+            ctx => (object)(qualityReportVar.Get(ctx)?.Passed ?? true));
+        var setOutputRetryPassFeedback = MakeOutput("SetOutputRetryPassFeedback", "teachingFeedback",
+            ctx => (object)(qualityReportVar.Get(ctx)?.TeachingFeedback ?? ""));
+        var setOutputRetryPassEscalated = MakeOutput("SetOutputRetryPassEscalated", "escalated", _ => (object)false);
+        var setOutputRetryPassReason = MakeOutput("SetOutputRetryPassReason", "escalationReason", _ => (object)"");
 
-        // Fail path outputs
-        var setOutputFailReport = new SetOutput
-        {
-            Id = "SetOutputFailReport",
-            Name = "Output: Quality Report (Fail)",
-            OutputName = new("qualityReport"),
-            OutputValue = new(ctx => (object)JsonSerializer.Serialize(qualityReportVar.Get(ctx)))
-        };
-        setOutputFailReport.SetDisplayText("Output: Quality Report (Fail)");
-        var setOutputFailPassed = new SetOutput
-        {
-            Id = "SetOutputFailPassed",
-            Name = "Output: Passed Flag (Fail)",
-            OutputName = new("passed"),
-            OutputValue = new(ctx => (object)(qualityReportVar.Get(ctx)?.Passed ?? false))
-        };
-        setOutputFailPassed.SetDisplayText("Output: Passed Flag (Fail)");
-        var setOutputFailFeedback = new SetOutput
-        {
-            Id = "SetOutputFailFeedback",
-            Name = "Output: Teaching Feedback (Fail)",
-            OutputName = new("teachingFeedback"),
-            OutputValue = new(ctx => (object)(qualityReportVar.Get(ctx)?.TeachingFeedback ?? ""))
-        };
-        setOutputFailFeedback.SetDisplayText("Output: Teaching Feedback (Fail)");
-
-        // Retry pass path outputs
-        var setOutputRetryPassReport = new SetOutput
-        {
-            Id = "SetOutputRetryPassReport",
-            Name = "Output: Quality Report (Retry Pass)",
-            OutputName = new("qualityReport"),
-            OutputValue = new(ctx => (object)JsonSerializer.Serialize(qualityReportVar.Get(ctx)))
-        };
-        setOutputRetryPassReport.SetDisplayText("Output: Quality Report (Retry Pass)");
-        var setOutputRetryPassPassed = new SetOutput
-        {
-            Id = "SetOutputRetryPassPassed",
-            Name = "Output: Passed Flag (Retry Pass)",
-            OutputName = new("passed"),
-            OutputValue = new(ctx => (object)(qualityReportVar.Get(ctx)?.Passed ?? true))
-        };
-        setOutputRetryPassPassed.SetDisplayText("Output: Passed Flag (Retry Pass)");
-        var setOutputRetryPassFeedback = new SetOutput
-        {
-            Id = "SetOutputRetryPassFeedback",
-            Name = "Output: Teaching Feedback (Retry Pass)",
-            OutputName = new("teachingFeedback"),
-            OutputValue = new(ctx => (object)(qualityReportVar.Get(ctx)?.TeachingFeedback ?? ""))
-        };
-        setOutputRetryPassFeedback.SetDisplayText("Output: Teaching Feedback (Retry Pass)");
+        // Escalation/fail outputs — passed is ALWAYS false here (no false success).
+        var setOutputFailReport = MakeOutput("SetOutputFailReport", "qualityReport",
+            ctx => (object)JsonSerializer.Serialize(qualityReportVar.Get(ctx)));
+        var setOutputFailPassed = MakeOutput("SetOutputFailPassed", "passed", _ => (object)false);
+        var setOutputFailFeedback = MakeOutput("SetOutputFailFeedback", "teachingFeedback",
+            ctx => (object)(qualityReportVar.Get(ctx)?.TeachingFeedback
+                ?? $"Quality gate escalated to human review: {escalationDetailVar.Get(ctx)}"));
+        var setOutputFailEscalated = MakeOutput("SetOutputFailEscalated", "escalated", _ => (object)true);
+        var setOutputFailReason = MakeOutput("SetOutputFailReason", "escalationReason",
+            ctx => (object)escalationReasonVar.Get(ctx));
 
         // ============================================
         // Finish activities
         // ============================================
         var finishPass = new Finish { Id = "FinishPass", Name = "Complete: Tests Passed" };
         finishPass.SetDisplayText("Complete: Tests Passed");
-        var finishFail = new Finish { Id = "FinishFail", Name = "Complete: Tests Failed" };
-        finishFail.SetDisplayText("Complete: Tests Failed");
+        var finishFail = new Finish { Id = "FinishFail", Name = "Complete: Escalated" };
+        finishFail.SetDisplayText("Complete: Escalated");
         var finishRetryPass = new Finish { Id = "FinishRetryPass", Name = "Complete: Tests Passed After Retry" };
         finishRetryPass.SetDisplayText("Complete: Tests Passed After Retry");
 
@@ -455,112 +604,321 @@ public class TestingWorkflow : WorkflowBase
         var flowchart = new Flowchart { Id = "TestingPipelineFlowchart", Name = "Testing Pipeline Flowchart" };
         flowchart.SetDisplayText("Testing Pipeline Flowchart");
 
-        // Add all activities to the flowchart
         var allActivities = new IActivity[]
         {
-            // Init
             initInputs,
-            // Main pipeline
-            triggerCI, waitForCI, storeCIResults, evaluateResults,
-            // AllPass/MinorIssues path
-            checkCoverage, checkLinting, checkSecurity, generateReport,
-            setOutputPassReport, setOutputPassPassed, setOutputPassFeedback, finishPass,
+            triggerCI, emitCiTriggered, triggerSucceeded,
+            waitForCI, storeCIResults, emitResultsReceived, evaluateResults, emitGateEvaluated, emitGateEvaluatedMajor,
+            // AllPass/MinorIssues pass path
+            checkCoverage, checkLinting, checkSecurity, generateReport, emitGatePassed,
+            setOutputPassReport, setOutputPassPassed, setOutputPassFeedback, setOutputPassEscalated, setOutputPassReason, finishPass,
             // Critical path
-            checkCoverageCritical, checkLintCritical, checkSecurityCritical,
-            generateReportCritical,
-            setOutputFailReport, setOutputFailPassed, setOutputFailFeedback, finishFail,
-            // MajorIssues (auto-fix loop) path with max-attempt guard
-            maxAttemptGuard, commitFix, updateCodeIndex, incrementAttempt, reTriggerCI, waitForCIRetry,
-            storeRetryResults, evaluateRetryResults,
+            checkCoverageCritical, checkLintCritical, checkSecurityCritical, generateReportCritical,
+            setReasonCritical, setDetailCritical,
+            // MajorIssues auto-fix loop
+            maxAttemptGuard, generateFix, commitFix, commitMadeChanges, emitAutofixCommitted, emitAutofixNoop,
+            setReasonNoop, setDetailNoop,
+            updateCodeIndex, incrementAttempt, reTriggerCI, emitReCiTriggered, reTriggerSucceeded,
+            waitForCIRetry, storeRetryResults, emitRetryResultsReceived, evaluateRetryResults, emitRetryGateEvaluated, emitRetryGateEvaluatedMajor,
             // Retry pass path
-            checkCoverageRetry, checkLintRetry, checkSecurityRetry,
-            generateRetryReport,
-            setOutputRetryPassReport, setOutputRetryPassPassed, setOutputRetryPassFeedback,
-            finishRetryPass
+            checkCoverageRetry, checkLintRetry, checkSecurityRetry, generateRetryReport, emitRetryGatePassed,
+            setOutputRetryPassReport, setOutputRetryPassPassed, setOutputRetryPassFeedback, setOutputRetryPassEscalated, setOutputRetryPassReason, finishRetryPass,
+            // Escalation reason setters + terminal
+            setReasonRetryCritical, setDetailRetryCritical, setReasonExhausted, setDetailExhausted,
+            setReasonTimeout, setDetailTimeout, emitCiTimedOut,
+            setReasonTriggerFailed, setDetailTriggerFailed, emitCiTriggerFailed,
+            emitGateEscalated,
+            setOutputFailReport, setOutputFailPassed, setOutputFailFeedback, setOutputFailEscalated, setOutputFailReason, finishFail,
         };
 
         foreach (var activity in allActivities)
-        {
             flowchart.Activities.Add(activity);
-        }
 
         // ============================================
         // Wire connections
         // ============================================
 
-        // Init -> Main pipeline: Trigger -> Wait -> Store -> Evaluate
+        // Init -> Trigger -> emit -> trigger gate
         Connect(flowchart, initInputs, triggerCI);
-        Connect(flowchart, triggerCI, waitForCI);
-        Connect(flowchart, waitForCI, storeCIResults);
-        Connect(flowchart, storeCIResults, evaluateResults);
+        Connect(flowchart, triggerCI, emitCiTriggered);
+        Connect(flowchart, emitCiTriggered, triggerSucceeded);
+        // Trigger failed -> escalate (ci-trigger-failed)
+        Connect(flowchart, triggerSucceeded, setReasonTriggerFailed, "False");
+        Connect(flowchart, setReasonTriggerFailed, setDetailTriggerFailed);
+        Connect(flowchart, setDetailTriggerFailed, emitCiTriggerFailed);
+        Connect(flowchart, emitCiTriggerFailed, emitGateEscalated);
+        // Trigger ok -> wait
+        Connect(flowchart, triggerSucceeded, waitForCI, "True");
 
-        // AllPass outcome: detailed checks -> report -> SetOutputs -> finish
-        Connect(flowchart, evaluateResults, checkCoverage, "AllPass");
+        // Wait Received -> store -> emit -> evaluate -> emit gate
+        Connect(flowchart, waitForCI, storeCIResults, "Received");
+        Connect(flowchart, storeCIResults, emitResultsReceived);
+        Connect(flowchart, emitResultsReceived, evaluateResults);
+        Connect(flowchart, evaluateResults, emitGateEvaluated, "AllPass");
+        Connect(flowchart, evaluateResults, emitGateEvaluated, "MinorIssues");
+        // Wait Timeout -> escalate (ci-timeout)
+        Connect(flowchart, waitForCI, setReasonTimeout, "Timeout");
+        Connect(flowchart, setReasonTimeout, setDetailTimeout);
+        Connect(flowchart, setDetailTimeout, emitCiTimedOut);
+        Connect(flowchart, emitCiTimedOut, emitGateEscalated);
+
+        // AllPass/MinorIssues -> checks -> report -> emit PASSED -> outputs -> finish
+        Connect(flowchart, emitGateEvaluated, checkCoverage);
         Connect(flowchart, checkCoverage, checkLinting);
         Connect(flowchart, checkLinting, checkSecurity);
         Connect(flowchart, checkSecurity, generateReport);
-        Connect(flowchart, generateReport, setOutputPassReport);
+        Connect(flowchart, generateReport, emitGatePassed);
+        Connect(flowchart, emitGatePassed, setOutputPassReport);
         Connect(flowchart, setOutputPassReport, setOutputPassPassed);
         Connect(flowchart, setOutputPassPassed, setOutputPassFeedback);
-        Connect(flowchart, setOutputPassFeedback, finishPass);
+        Connect(flowchart, setOutputPassFeedback, setOutputPassEscalated);
+        Connect(flowchart, setOutputPassEscalated, setOutputPassReason);
+        Connect(flowchart, setOutputPassReason, finishPass);
 
-        // MinorIssues outcome: same check pipeline (report captures the status)
-        Connect(flowchart, evaluateResults, checkCoverage, "MinorIssues");
-
-        // Critical outcome: checks -> report -> SetOutputs -> fail
-        Connect(flowchart, evaluateResults, checkCoverageCritical, "Critical");
+        // Critical -> emit gate -> checks -> report -> reason -> escalate
+        var emitGateEvaluatedCritical = EmitGateEvaluated("EmitGateEvaluatedCritical",
+            sessionIdVar, repositoryVar, branchVar, tenantIdVar, ciResultsVar,
+            evaluationResultVar, attemptNumberVar, maxAttemptsVar, skillLevelVar);
+        flowchart.Activities.Add(emitGateEvaluatedCritical);
+        Connect(flowchart, evaluateResults, emitGateEvaluatedCritical, "Critical");
+        Connect(flowchart, emitGateEvaluatedCritical, checkCoverageCritical);
         Connect(flowchart, checkCoverageCritical, checkLintCritical);
         Connect(flowchart, checkLintCritical, checkSecurityCritical);
         Connect(flowchart, checkSecurityCritical, generateReportCritical);
-        Connect(flowchart, generateReportCritical, setOutputFailReport);
-        Connect(flowchart, setOutputFailReport, setOutputFailPassed);
-        Connect(flowchart, setOutputFailPassed, setOutputFailFeedback);
-        Connect(flowchart, setOutputFailFeedback, finishFail);
+        Connect(flowchart, generateReportCritical, setReasonCritical);
+        Connect(flowchart, setReasonCritical, setDetailCritical);
+        Connect(flowchart, setDetailCritical, emitGateEscalated);
 
-        // MajorIssues outcome: guard -> auto-fix loop
-        Connect(flowchart, evaluateResults, maxAttemptGuard, "MajorIssues");
-        // Guard True (attempts < max): proceed with fix
-        Connect(flowchart, maxAttemptGuard, commitFix, "True");
-        // Guard False (attempts >= max): fail out via SetOutputs -> finishFail
-        Connect(flowchart, maxAttemptGuard, setOutputFailReport, "False");
-        Connect(flowchart, commitFix, updateCodeIndex);
+        // MajorIssues -> emit gate (major) -> guard
+        Connect(flowchart, evaluateResults, emitGateEvaluatedMajor, "MajorIssues");
+        Connect(flowchart, emitGateEvaluatedMajor, maxAttemptGuard);
+
+        // Guard True (budget left) -> GENERATE FIX (mediated) -> commit -> verify changes
+        Connect(flowchart, maxAttemptGuard, generateFix, "True");
+        Connect(flowchart, generateFix, commitFix);
+        Connect(flowchart, commitFix, commitMadeChanges);
+        // Commit made real changes -> emit committed -> index -> increment -> re-trigger
+        Connect(flowchart, commitMadeChanges, emitAutofixCommitted, "True");
+        Connect(flowchart, emitAutofixCommitted, updateCodeIndex);
         Connect(flowchart, updateCodeIndex, incrementAttempt);
         Connect(flowchart, incrementAttempt, reTriggerCI);
-        Connect(flowchart, reTriggerCI, waitForCIRetry);
-        Connect(flowchart, waitForCIRetry, storeRetryResults);
-        Connect(flowchart, storeRetryResults, evaluateRetryResults);
+        Connect(flowchart, reTriggerCI, emitReCiTriggered);
+        Connect(flowchart, emitReCiTriggered, reTriggerSucceeded);
+        // Re-trigger failed -> escalate (ci-trigger-failed)
+        Connect(flowchart, reTriggerSucceeded, setReasonTriggerFailed, "False");
+        Connect(flowchart, reTriggerSucceeded, waitForCIRetry, "True");
+        // Commit was a no-op -> emit no-op -> reason -> escalate
+        Connect(flowchart, commitMadeChanges, emitAutofixNoop, "False");
+        Connect(flowchart, emitAutofixNoop, setReasonNoop);
+        Connect(flowchart, setReasonNoop, setDetailNoop);
+        Connect(flowchart, setDetailNoop, emitGateEscalated);
+        // Guard False (exhausted) -> reason -> escalate
+        Connect(flowchart, maxAttemptGuard, setReasonExhausted, "False");
+        Connect(flowchart, setReasonExhausted, setDetailExhausted);
+        Connect(flowchart, setDetailExhausted, emitGateEscalated);
 
-        // Retry evaluation routes
-        Connect(flowchart, evaluateRetryResults, checkCoverageRetry, "AllPass");
-        Connect(flowchart, evaluateRetryResults, checkCoverageRetry, "MinorIssues");
+        // Retry wait Received -> store -> emit -> evaluate -> emit gate
+        Connect(flowchart, waitForCIRetry, storeRetryResults, "Received");
+        Connect(flowchart, storeRetryResults, emitRetryResultsReceived);
+        Connect(flowchart, emitRetryResultsReceived, evaluateRetryResults);
+        Connect(flowchart, evaluateRetryResults, emitRetryGateEvaluated, "AllPass");
+        Connect(flowchart, evaluateRetryResults, emitRetryGateEvaluated, "MinorIssues");
+        // Retry wait Timeout -> escalate (ci-timeout)
+        Connect(flowchart, waitForCIRetry, setReasonTimeout, "Timeout");
+
+        // Retry pass path
+        Connect(flowchart, emitRetryGateEvaluated, checkCoverageRetry);
         Connect(flowchart, checkCoverageRetry, checkLintRetry);
         Connect(flowchart, checkLintRetry, checkSecurityRetry);
         Connect(flowchart, checkSecurityRetry, generateRetryReport);
-        Connect(flowchart, generateRetryReport, setOutputRetryPassReport);
+        Connect(flowchart, generateRetryReport, emitRetryGatePassed);
+        Connect(flowchart, emitRetryGatePassed, setOutputRetryPassReport);
         Connect(flowchart, setOutputRetryPassReport, setOutputRetryPassPassed);
         Connect(flowchart, setOutputRetryPassPassed, setOutputRetryPassFeedback);
-        Connect(flowchart, setOutputRetryPassFeedback, finishRetryPass);
+        Connect(flowchart, setOutputRetryPassFeedback, setOutputRetryPassEscalated);
+        Connect(flowchart, setOutputRetryPassEscalated, setOutputRetryPassReason);
+        Connect(flowchart, setOutputRetryPassReason, finishRetryPass);
 
-        // Retry MajorIssues: go through max-attempt guard before looping
-        Connect(flowchart, evaluateRetryResults, maxAttemptGuard, "MajorIssues");
+        // Retry MajorIssues -> emit gate (major) -> guard (loop)
+        Connect(flowchart, evaluateRetryResults, emitRetryGateEvaluatedMajor, "MajorIssues");
+        Connect(flowchart, emitRetryGateEvaluatedMajor, maxAttemptGuard);
+        // Retry Critical -> reason -> escalate
+        Connect(flowchart, evaluateRetryResults, setReasonRetryCritical, "Critical");
+        Connect(flowchart, setReasonRetryCritical, setDetailRetryCritical);
+        Connect(flowchart, setDetailRetryCritical, emitGateEscalated);
 
-        // Retry Critical: fail out via SetOutputs
-        Connect(flowchart, evaluateRetryResults, setOutputFailReport, "Critical");
+        // Escalation terminal -> fail outputs -> finish
+        Connect(flowchart, emitGateEscalated, setOutputFailReport);
+        Connect(flowchart, setOutputFailReport, setOutputFailPassed);
+        Connect(flowchart, setOutputFailPassed, setOutputFailFeedback);
+        Connect(flowchart, setOutputFailFeedback, setOutputFailEscalated);
+        Connect(flowchart, setOutputFailEscalated, setOutputFailReason);
+        Connect(flowchart, setOutputFailReason, finishFail);
 
         builder.Root = flowchart;
     }
 
+    // ================================================================
+    // Activity factory helpers (keep the Build method readable)
+    // ================================================================
+
+    private static CheckCoverageActivity MakeCoverage(string id, string name,
+        Variable<CIResultsPayload> ci, Variable<int> skill, Variable<CoverageCheckResult> result)
+    {
+        var a = new CheckCoverageActivity
+        {
+            Id = id, Name = name,
+            CIResults = new(ctx => ci.Get(ctx)!),
+            SkillLevel = new(ctx => skill.Get(ctx)),
+            Result = new(result)
+        };
+        a.SetDisplayText(name);
+        return a;
+    }
+
+    private static CheckLintingActivity MakeLint(string id, string name,
+        Variable<CIResultsPayload> ci, Variable<int> skill, Variable<LintCheckResult> result)
+    {
+        var a = new CheckLintingActivity
+        {
+            Id = id, Name = name,
+            CIResults = new(ctx => ci.Get(ctx)!),
+            SkillLevel = new(ctx => skill.Get(ctx)),
+            Result = new(result)
+        };
+        a.SetDisplayText(name);
+        return a;
+    }
+
+    private static CheckSecurityActivity MakeSecurity(string id, string name,
+        Variable<CIResultsPayload> ci, Variable<int> skill, Variable<SecurityCheckResult> result)
+    {
+        var a = new CheckSecurityActivity
+        {
+            Id = id, Name = name,
+            CIResults = new(ctx => ci.Get(ctx)!),
+            SkillLevel = new(ctx => skill.Get(ctx)),
+            Result = new(result)
+        };
+        a.SetDisplayText(name);
+        return a;
+    }
+
+    private static GenerateQualityReportActivity MakeReport(string id, string name,
+        Variable<Guid> session, Variable<CIResultsPayload> ci,
+        Variable<CoverageCheckResult> cov, Variable<LintCheckResult> lint, Variable<SecurityCheckResult> sec,
+        Variable<int> skill, Variable<int> consecutive, Variable<QualityReport> result)
+    {
+        var a = new GenerateQualityReportActivity
+        {
+            Id = id, Name = name,
+            SessionId = new(ctx => session.Get(ctx)),
+            CIResults = new(ctx => ci.Get(ctx)!),
+            CoverageResult = new(ctx => cov.Get(ctx)!),
+            LintResult = new(ctx => lint.Get(ctx)!),
+            SecurityResult = new(ctx => sec.Get(ctx)!),
+            SkillLevel = new(ctx => skill.Get(ctx)),
+            ConsecutivePassCount = new(ctx => consecutive.Get(ctx)),
+            Result = new(result)
+        };
+        a.SetDisplayText(name);
+        return a;
+    }
+
+    private static SetOutput MakeOutput(string id, string outputName, Func<ActivityExecutionContext, object> value)
+    {
+        var a = new SetOutput
+        {
+            Id = id,
+            Name = $"Output: {outputName}",
+            OutputName = new(outputName),
+            OutputValue = new(value)
+        };
+        a.SetDisplayText($"Output: {outputName}");
+        return a;
+    }
+
+    private static EmitTestingEventActivity EmitEvent(
+        string id, string eventType,
+        Variable<Guid> session, Variable<string> repo, Variable<string> branch, Variable<string> tenant,
+        Func<ExpressionExecutionContext, string> runId,
+        Func<ExpressionExecutionContext, int> attempt,
+        Func<ExpressionExecutionContext, int> maxAttempts,
+        Action<EmitTestingEventActivity, ActivityExecutionContext>? configure = null)
+    {
+        var a = new EmitTestingEventActivity
+        {
+            Id = id,
+            Name = $"Emit {eventType}",
+            EventType = new Input<string>(_ => eventType),
+            SessionId = new Input<string?>(ctx => session.Get(ctx).ToString()),
+            Repository = new Input<string?>(ctx => repo.Get(ctx)),
+            Branch = new Input<string?>(ctx => branch.Get(ctx)),
+            RunId = new Input<string?>(ctx => runId(ctx)),
+            TenantId = new Input<string?>(ctx => tenant.Get(ctx)),
+            Attempt = new Input<int>(ctx => attempt(ctx)),
+            MaxAttempts = new Input<int>(ctx => maxAttempts(ctx)),
+        };
+        configure?.Invoke(a, default!);
+        a.SetDisplayText($"Emit {eventType}");
+        return a;
+    }
+
+    private static EmitTestingEventActivity EmitGateEvaluated(
+        string id,
+        Variable<Guid> session, Variable<string> repo, Variable<string> branch, Variable<string> tenant,
+        Variable<CIResultsPayload> ci, Variable<QualityGateResult> eval,
+        Variable<int> attempt, Variable<int> maxAttempts, Variable<int> skill)
+    {
+        var a = new EmitTestingEventActivity
+        {
+            Id = id,
+            Name = "Emit GATE.EVALUATED",
+            EventType = new Input<string>(_ => TestingEvents.GateEvaluated),
+            SessionId = new Input<string?>(ctx => session.Get(ctx).ToString()),
+            Repository = new Input<string?>(ctx => repo.Get(ctx)),
+            Branch = new Input<string?>(ctx => branch.Get(ctx)),
+            RunId = new Input<string?>(ctx => ci.Get(ctx)?.RunId ?? ""),
+            TenantId = new Input<string?>(ctx => tenant.Get(ctx)),
+            Attempt = new Input<int>(ctx => attempt.Get(ctx)),
+            MaxAttempts = new Input<int>(ctx => maxAttempts.Get(ctx)),
+            Outcome = new Input<string?>(ctx => eval.Get(ctx)?.Outcome.ToString()),
+            Score = new Input<double>(ctx => eval.Get(ctx)?.OverallScore ?? -1),
+            SkillLevel = new Input<int>(ctx => skill.Get(ctx)),
+        };
+        a.SetDisplayText("Emit GATE.EVALUATED");
+        return a;
+    }
+
+    /// <summary>Serialize the auto-fixable issues to JSON for the llm-call fix prompt.</summary>
+    private static string SerializeAutoFixableIssues(Variable<QualityGateResult> eval, ExpressionExecutionContext ctx)
+    {
+        var issues = eval.Get(ctx)?.Issues.Where(i => i.AutoFixable).ToList() ?? new List<QualityIssue>();
+        return JsonSerializer.Serialize(issues);
+    }
+
     /// <summary>
-    /// Helper to add a connection with default (unnamed) port.
+    /// Best-effort summary of the generated fix from the llm-call dispatch result, used as
+    /// the commit description. Never returns null (falls back to a stable default).
     /// </summary>
+    private static string? GetFixSummary(IDictionary<string, object>? fixResult)
+    {
+        if (fixResult == null) return "Auto-fix quality issues (LLM-mediated)";
+        if (fixResult.TryGetValue("llmResponse", out var r) && !string.IsNullOrWhiteSpace(r?.ToString()))
+        {
+            var s = r!.ToString()!;
+            return s.Length > 120 ? s[..120] : s;
+        }
+        return "Auto-fix quality issues (LLM-mediated)";
+    }
+
+    /// <summary>Helper to add a connection with default (unnamed) port.</summary>
     private static void Connect(Flowchart flowchart, IActivity source, IActivity target)
     {
         flowchart.Connections.Add(new Connection(source, target));
     }
 
-    /// <summary>
-    /// Helper to add a connection with a named source port (for FlowNode outcomes).
-    /// </summary>
+    /// <summary>Helper to add a connection with a named source port (for FlowNode outcomes).</summary>
     private static void Connect(Flowchart flowchart, IActivity source, IActivity target, string sourcePort)
     {
         flowchart.Connections.Add(new Connection(

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Testing/TestingEventTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Testing/TestingEventTests.cs
@@ -1,0 +1,203 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Testing;
+
+namespace Tamma.Activities.Tests.Testing;
+
+/// <summary>
+/// Completeness audit 2026-06-22 (<c>Testing.md</c> §Missing #3) — coverage for the
+/// <c>TEST.*</c> / <c>GATE.*</c> DCB event mapping
+/// (<see cref="EmitTestingEventActivity.BuildTammaEvent"/>) and the
+/// <see cref="TestingEvents"/> status / escalation-reason convention.
+///
+/// <para>The core completeness gap was a real pipeline with NO audit events. These tests
+/// pin the now-explicit contract: CI-trigger-failure, CI-timeout, auto-fix no-op, terminal
+/// fail and terminal escalation are LOUD (error-status) audit rows carrying an
+/// <c>escalationReason</c> and the underlying <c>errorDetail</c> — never a silent false
+/// success.</para>
+/// </summary>
+[TestFixture]
+public class TestingEventTests
+{
+    [Test]
+    public void EventTypes_FollowAggregateActionStatusConvention()
+    {
+        TestingEvents.CiTriggeredSuccess.Should().Be("TEST.CI_TRIGGERED.SUCCESS");
+        TestingEvents.CiTriggeredFailed.Should().Be("TEST.CI_TRIGGERED.FAILED");
+        TestingEvents.ResultsReceived.Should().Be("TEST.RESULTS_RECEIVED.SUCCESS");
+        TestingEvents.CiTimedOut.Should().Be("TEST.CI_TIMED_OUT.FAILED");
+        TestingEvents.GateEvaluated.Should().Be("GATE.EVALUATED.SUCCESS");
+        TestingEvents.AutofixCommitted.Should().Be("GATE.AUTOFIX_COMMITTED.SUCCESS");
+        TestingEvents.AutofixNoop.Should().Be("GATE.AUTOFIX_NOOP.FAILED");
+        TestingEvents.GatePassed.Should().Be("GATE.PASSED.SUCCESS");
+        TestingEvents.GateFailed.Should().Be("GATE.FAILED.FAILED");
+        TestingEvents.GateEscalated.Should().Be("GATE.ESCALATED.FAILED");
+    }
+
+    [Test]
+    public void StatusForEvent_DegradedTerminalsAreError_RestAreSuccess()
+    {
+        // LOUD failures — never a silent false success.
+        TestingEvents.StatusForEvent(TestingEvents.CiTriggeredFailed).Should().Be("error");
+        TestingEvents.StatusForEvent(TestingEvents.CiTimedOut).Should().Be("error");
+        TestingEvents.StatusForEvent(TestingEvents.AutofixNoop).Should().Be("error");
+        TestingEvents.StatusForEvent(TestingEvents.GateFailed).Should().Be("error");
+        TestingEvents.StatusForEvent(TestingEvents.GateEscalated).Should().Be("error");
+
+        // Normal transitions.
+        TestingEvents.StatusForEvent(TestingEvents.CiTriggeredSuccess).Should().Be("success");
+        TestingEvents.StatusForEvent(TestingEvents.ResultsReceived).Should().Be("success");
+        TestingEvents.StatusForEvent(TestingEvents.GateEvaluated).Should().Be("success");
+        TestingEvents.StatusForEvent(TestingEvents.AutofixCommitted).Should().Be("success");
+        TestingEvents.StatusForEvent(TestingEvents.GatePassed).Should().Be("success");
+    }
+
+    [Test]
+    public void EscalationReasons_AreDistinctAndNonEmpty()
+    {
+        var reasons = new[]
+        {
+            TestingEvents.ReasonCritical,
+            TestingEvents.ReasonRetryExhausted,
+            TestingEvents.ReasonCiTimeout,
+            TestingEvents.ReasonCiTriggerFailed,
+            TestingEvents.ReasonAutofixNoop,
+        };
+        reasons.Should().OnlyContain(r => !string.IsNullOrWhiteSpace(r));
+        reasons.Should().OnlyHaveUniqueItems();
+    }
+
+    [Test]
+    public void ParseTenantId_ValidGuid_Parses_InvalidOrEmpty_IsNull()
+    {
+        var g = Guid.NewGuid();
+        TestingEvents.ParseTenantId(g.ToString()).Should().Be(g);
+        TestingEvents.ParseTenantId("").Should().BeNull();
+        TestingEvents.ParseTenantId(null).Should().BeNull();
+        TestingEvents.ParseTenantId("not-a-guid").Should().BeNull();
+    }
+
+    [Test]
+    public void BuildTammaEvent_GateEvaluated_HasSuccessStatus_AndGatePayload()
+    {
+        var evt = EmitTestingEventActivity.BuildTammaEvent(
+            TestingEvents.GateEvaluated,
+            sessionId: "tdd-7",
+            repository: "owner/repo",
+            branch: "feat/x",
+            runId: "run-123",
+            tenantId: null,
+            attempt: 1,
+            maxAttempts: 3,
+            outcome: "MajorIssues",
+            score: 72.5,
+            skillLevel: 3,
+            filesChanged: -1,
+            escalationReason: null,
+            errorDetail: null);
+
+        evt.EventType.Should().Be("GATE.EVALUATED.SUCCESS");
+        evt.Status.Should().Be("success");
+
+        evt.Tags!["sessionId"].Should().Be("tdd-7");
+        evt.Tags!["repository"].Should().Be("owner/repo");
+        evt.Tags!["branch"].Should().Be("feat/x");
+        evt.Tags!["runId"].Should().Be("run-123");
+        evt.Tags!["attempt"].Should().Be("1");
+        evt.Tags.Should().NotContainKey("tenantId", "single-user / platform-scope event");
+
+        evt.Data["outcome"].Should().Be("MajorIssues");
+        evt.Data["score"].Should().Be(72.5);
+        evt.Data["skillLevel"].Should().Be(3);
+        evt.Data.Should().NotContainKey("filesChanged", "negative sentinel is omitted");
+        evt.Data.Should().NotContainKey("escalationReason");
+    }
+
+    [Test]
+    public void BuildTammaEvent_Escalated_HasErrorStatus_AndSurfacesReasonAndCause()
+    {
+        // The core no-false-success guarantee: an escalation is a LOUD (error) audit row
+        // that carries the reason AND the real underlying cause, not a generic string.
+        var evt = EmitTestingEventActivity.BuildTammaEvent(
+            TestingEvents.GateEscalated,
+            sessionId: "tdd-9",
+            repository: "owner/repo",
+            branch: "feat/y",
+            runId: "run-9",
+            tenantId: null,
+            attempt: 3,
+            maxAttempts: 3,
+            outcome: "MajorIssues",
+            score: 40,
+            skillLevel: 4,
+            filesChanged: -1,
+            escalationReason: TestingEvents.ReasonRetryExhausted,
+            errorDetail: "2 lint error(s) still present after 3 fix attempt(s)");
+
+        evt.EventType.Should().Be("GATE.ESCALATED.FAILED");
+        evt.Status.Should().Be("error");
+        evt.Data["escalationReason"].Should().Be("retry-budget-exhausted");
+        evt.Data["errorDetail"].Should().Be("2 lint error(s) still present after 3 fix attempt(s)");
+    }
+
+    [Test]
+    public void BuildTammaEvent_AutofixCommitted_RecordsFilesChanged()
+    {
+        var evt = EmitTestingEventActivity.BuildTammaEvent(
+            TestingEvents.AutofixCommitted,
+            sessionId: "tdd-1", repository: "owner/repo", branch: "b", runId: "run-1",
+            tenantId: null, attempt: 1, maxAttempts: 3,
+            outcome: null, score: -1, skillLevel: 0, filesChanged: 4,
+            escalationReason: null, errorDetail: null);
+
+        evt.Status.Should().Be("success");
+        evt.Data["filesChanged"].Should().Be(4);
+        evt.Data.Should().NotContainKey("score", "negative sentinel is omitted");
+        evt.Data.Should().NotContainKey("skillLevel", "zero sentinel is omitted");
+    }
+
+    [Test]
+    public void BuildTammaEvent_AutofixNoop_HasErrorStatus()
+    {
+        var evt = EmitTestingEventActivity.BuildTammaEvent(
+            TestingEvents.AutofixNoop,
+            sessionId: "tdd-1", repository: "owner/repo", branch: "b", runId: "run-1",
+            tenantId: null, attempt: 2, maxAttempts: 3,
+            outcome: "MajorIssues", score: 50, skillLevel: 3, filesChanged: 0,
+            escalationReason: TestingEvents.ReasonAutofixNoop,
+            errorDetail: "LLM fix produced no file changes");
+
+        evt.Status.Should().Be("error");
+        evt.Data["filesChanged"].Should().Be(0, "a zero-files-changed commit is recorded, not omitted");
+        evt.Data["escalationReason"].Should().Be("autofix-no-op");
+    }
+
+    [Test]
+    public void BuildTammaEvent_WithTenant_StampsTenantTag()
+    {
+        var tenant = Guid.NewGuid();
+        var evt = EmitTestingEventActivity.BuildTammaEvent(
+            TestingEvents.CiTriggeredSuccess,
+            sessionId: "s", repository: "owner/repo", branch: "b", runId: "run-1",
+            tenantId: tenant, attempt: 0, maxAttempts: 3,
+            outcome: null, score: -1, skillLevel: 0, filesChanged: -1,
+            escalationReason: null, errorDetail: null);
+
+        evt.Tags!["tenantId"].Should().Be(tenant.ToString("D"));
+    }
+
+    [Test]
+    public void BuildTammaEvent_AlwaysCarriesAttemptTag_EvenAtZero()
+    {
+        var evt = EmitTestingEventActivity.BuildTammaEvent(
+            TestingEvents.CiTriggeredSuccess,
+            sessionId: null, repository: null, branch: null, runId: null,
+            tenantId: null, attempt: 0, maxAttempts: 3,
+            outcome: null, score: -1, skillLevel: 0, filesChanged: -1,
+            escalationReason: null, errorDetail: null);
+
+        evt.Tags!["attempt"].Should().Be("0");
+        evt.Tags!.Should().NotContainKey("sessionId");
+        evt.Tags!.Should().NotContainKey("repository");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TestingWorkflowTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TestingWorkflowTests.cs
@@ -1,0 +1,307 @@
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Runtime.Activities;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Testing;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Completeness audit 2026-06-22 (<c>Testing.md</c>) — workflow-structure coverage for the
+/// built-out <c>testing-pipeline</c>. Asserts the P0/P1 guarantees the audit flagged as
+/// missing, by inspecting the BUILT Flowchart via <see cref="WorkflowTestHelper"/>:
+/// <list type="bullet">
+///   <item><description>#1/#6 — the MajorIssues path GENERATES a fix (mediated
+///     <c>llm-call</c>) BEFORE <c>CommitFix</c>, and a zero-files-changed commit is gated
+///     to escalation (no false-success loop);</description></item>
+///   <item><description>#2 — the CI wait exposes a <c>Timeout</c> edge that escalates (no
+///     permanent hang);</description></item>
+///   <item><description>#3 — DCB events at trigger / results / each gate / fix-commit /
+///     pass / escalation;</description></item>
+///   <item><description>#4 — a trigger-success gate routes a failed trigger to escalation
+///     instead of into a dead wait;</description></item>
+///   <item><description>#5 — a mandatory escalation terminal that sets
+///     <c>escalated=true</c> + <c>passed=false</c> + a structured reason;</description></item>
+///   <item><description>every activity routes to a terminal (no dangling edge / no hang).</description></item>
+/// </list>
+/// </summary>
+[TestFixture]
+public class TestingWorkflowTests
+{
+    private Flowchart _flowchart = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new TestingWorkflow());
+        _flowchart = WorkflowTestHelper.GetFlowchart(builder);
+    }
+
+    [Test]
+    public void Workflow_BuildsWithExpectedDefinitionId()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new TestingWorkflow());
+        builder.Object.DefinitionId.Should().Be("testing-pipeline");
+    }
+
+    // ================================================================
+    // #1/#6 — auto-fix that actually GENERATES a fix (mediated) before committing.
+    // ================================================================
+
+    [Test]
+    public void AutoFix_GeneratesFixViaLlmCall_BeforeCommitting()
+    {
+        var generateFix = _flowchart.Activities.OfType<DispatchWorkflow>()
+            .FirstOrDefault(d => d.Id == "GenerateFix");
+        generateFix.Should().NotBeNull("the MajorIssues path must GENERATE a fix before committing");
+        ReadDefinitionId(generateFix!).Should().Be("llm-call",
+            "fix generation MUST be mediated through llm-call — a step never calls a provider directly");
+
+        // guard True -> GenerateFix -> CommitFix (generation precedes the commit)
+        HasEdge("MaxAttemptGuard", "True", "GenerateFix").Should().BeTrue();
+        HasEdge("GenerateFix", null, "CommitFix").Should().BeTrue();
+    }
+
+    [Test]
+    public void OnlyMediatedDispatch_NoRawProviderCall()
+    {
+        // The single dispatch in this workflow is the mediated llm-call fix generation.
+        _flowchart.Activities.OfType<DispatchWorkflow>()
+            .Select(ReadDefinitionId)
+            .Should().OnlyContain(id => id == "llm-call");
+    }
+
+    [Test]
+    public void ZeroFilesChangedCommit_IsTreatedAsNonFix_AndEscalates()
+    {
+        // CommitFix -> a FlowDecision on whether files actually changed.
+        _flowchart.Activities.OfType<FlowDecision>()
+            .Any(d => d.Id == "CommitMadeChanges")
+            .Should().BeTrue("a no-op commit must be gated, not blindly re-CI'd");
+
+        HasEdge("CommitFix", null, "CommitMadeChanges").Should().BeTrue();
+
+        // True (real change) -> emit committed -> index -> increment -> re-trigger.
+        HasEdge("CommitMadeChanges", "True", "EmitAutofixCommitted").Should().BeTrue();
+        HasEdge("EmitAutofixCommitted", null, "UpdateCodeIndex").Should().BeTrue();
+
+        // False (no change) -> emit NOOP -> reason -> escalation terminal (NOT a re-trigger).
+        HasEdge("CommitMadeChanges", "False", "EmitAutofixNoop").Should().BeTrue();
+        var noopTargets = ReachableFrom("EmitAutofixNoop");
+        noopTargets.Should().Contain("EmitGateEscalated",
+            "a no-op fix must escalate, never loop pretending progress");
+        noopTargets.Should().NotContain("ReTriggerCI",
+            "a no-op fix must NOT re-trigger CI (no false-success loop)");
+    }
+
+    // ================================================================
+    // #4 — fail fast on trigger failure (no dead wait with RunId=unknown).
+    // ================================================================
+
+    [Test]
+    public void TriggerFailure_RoutesToEscalation_NotIntoTheWait()
+    {
+        _flowchart.Activities.OfType<FlowDecision>()
+            .Any(d => d.Id == "TriggerSucceeded")
+            .Should().BeTrue("a failed CI trigger must be gated before the wait");
+
+        // True -> wait; False -> escalate (ci-trigger-failed), never the wait.
+        HasEdge("TriggerSucceeded", "True", "WaitForCIResults").Should().BeTrue();
+        var failTargets = ReachableFrom("SetReasonTriggerFailed");
+        failTargets.Should().Contain("EmitGateEscalated");
+
+        var falseTargets = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "TriggerSucceeded" && c.Source.Port == "False")
+            .Select(c => c.Target.Activity.Id)
+            .ToList();
+        falseTargets.Should().NotContain("WaitForCIResults");
+    }
+
+    // ================================================================
+    // #2 — CI-wait timeout takes a deterministic escalation edge (no permanent hang).
+    // ================================================================
+
+    [Test]
+    public void CiWait_HasReceivedAndTimeoutOutcomes()
+    {
+        var fromWait = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "WaitForCIResults")
+            .Select(c => c.Source.Port)
+            .ToList();
+        fromWait.Should().Contain("Received");
+        fromWait.Should().Contain("Timeout", "the dead-CI-wait hang risk is closed by a Timeout edge");
+    }
+
+    [Test]
+    public void CiTimeout_RoutesToEscalation()
+    {
+        HasEdge("WaitForCIResults", "Timeout", "SetReasonTimeout").Should().BeTrue();
+        ReachableFrom("SetReasonTimeout").Should().Contain("EmitGateEscalated");
+        // The timeout edge emits a loud TEST.CI_TIMED_OUT before escalating.
+        _flowchart.Activities.OfType<EmitTestingEventActivity>()
+            .Any(a => a.Id == "EmitCiTimedOut").Should().BeTrue();
+    }
+
+    // ================================================================
+    // #3 — DCB audit trail at every boundary.
+    // ================================================================
+
+    [Test]
+    public void EmitsDcbEvents_AtEveryBoundary()
+    {
+        var emitIds = _flowchart.Activities.OfType<EmitTestingEventActivity>()
+            .Select(a => a.Id!)
+            .ToList();
+
+        emitIds.Should().Contain("EmitCiTriggered");        // TEST.CI_TRIGGERED
+        emitIds.Should().Contain("EmitResultsReceived");    // TEST.RESULTS_RECEIVED
+        emitIds.Should().Contain("EmitGateEvaluated");      // GATE.EVALUATED
+        emitIds.Should().Contain("EmitAutofixCommitted");   // GATE.AUTOFIX_COMMITTED
+        emitIds.Should().Contain("EmitAutofixNoop");        // GATE.AUTOFIX_NOOP
+        emitIds.Should().Contain("EmitGatePassed");         // GATE.PASSED
+        emitIds.Should().Contain("EmitGateEscalated");      // GATE.ESCALATED
+        emitIds.Should().Contain("EmitCiTimedOut");         // TEST.CI_TIMED_OUT
+        emitIds.Should().Contain("EmitCiTriggerFailed");    // TEST.CI_TRIGGERED.FAILED
+    }
+
+    // ================================================================
+    // #5 — mandatory escalation terminal (no false success, no infinite wait).
+    // ================================================================
+
+    [Test]
+    public void RetryExhaustion_EscalatesViaSingleTerminal()
+    {
+        _flowchart.Activities.OfType<FlowDecision>()
+            .Any(d => d.Id == "MaxAttemptGuard").Should().BeTrue();
+
+        // Guard False (budget exhausted) -> reason -> escalation terminal (NOT a pass).
+        HasEdge("MaxAttemptGuard", "False", "SetReasonExhausted").Should().BeTrue();
+        ReachableFrom("SetReasonExhausted").Should().Contain("EmitGateEscalated");
+
+        var falseTargets = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "MaxAttemptGuard" && c.Source.Port == "False")
+            .Select(c => c.Target.Activity.Id)
+            .ToList();
+        falseTargets.Should().NotContain("FinishPass");
+        falseTargets.Should().NotContain("FinishRetryPass");
+    }
+
+    [Test]
+    public void CriticalOutcome_Escalates_NeverPasses()
+    {
+        // Critical -> evaluated emit -> checks -> reason -> escalation (no FinishPass).
+        HasEdge("EvaluateResults", "Critical", "EmitGateEvaluatedCritical").Should().BeTrue();
+        ReachableFrom("EmitGateEvaluatedCritical").Should().Contain("EmitGateEscalated");
+        ReachableFrom("EmitGateEvaluatedCritical").Should().NotContain("FinishPass");
+    }
+
+    [Test]
+    public void EscalationTerminal_SetsPassedFalse_AndEscalatedTrue_WithReason()
+    {
+        // The escalation terminal sets passed=false, escalated=true and an escalationReason.
+        var outputNames = _flowchart.Activities.OfType<Elsa.Workflows.Management.Activities.SetOutput.SetOutput>()
+            .Where(o => o.Id != null && o.Id.StartsWith("SetOutputFail"))
+            .Select(o => o.OutputName?.Expression?.Value?.ToString())
+            .ToList();
+
+        outputNames.Should().Contain("passed");
+        outputNames.Should().Contain("escalated");
+        outputNames.Should().Contain("escalationReason");
+        outputNames.Should().Contain("qualityReport");
+        outputNames.Should().Contain("teachingFeedback");
+
+        // The escalation emit feeds the fail outputs which feed FinishFail.
+        HasEdge("EmitGateEscalated", null, "SetOutputFailReport").Should().BeTrue();
+        ReachableFrom("EmitGateEscalated").Should().Contain("FinishFail");
+    }
+
+    // ================================================================
+    // Output contract preserved on every terminal path (additively extended).
+    // ================================================================
+
+    [Test]
+    public void PassTerminal_EmitsFullOutputContract()
+    {
+        var passOutputs = _flowchart.Activities.OfType<Elsa.Workflows.Management.Activities.SetOutput.SetOutput>()
+            .Where(o => o.Id != null && o.Id.StartsWith("SetOutputPass"))
+            .Select(o => o.OutputName?.Expression?.Value?.ToString())
+            .ToList();
+
+        passOutputs.Should().Contain("qualityReport");
+        passOutputs.Should().Contain("passed");
+        passOutputs.Should().Contain("teachingFeedback");
+
+        // Pass path: report -> emit PASSED -> outputs -> finish.
+        HasEdge("GenerateQualityReport", null, "EmitGatePassed").Should().BeTrue();
+        ReachableFrom("EmitGatePassed").Should().Contain("FinishPass");
+    }
+
+    [Test]
+    public void RetryPassTerminal_EmitsFullOutputContract()
+    {
+        var retryOutputs = _flowchart.Activities.OfType<Elsa.Workflows.Management.Activities.SetOutput.SetOutput>()
+            .Where(o => o.Id != null && o.Id.StartsWith("SetOutputRetryPass"))
+            .Select(o => o.OutputName?.Expression?.Value?.ToString())
+            .ToList();
+
+        retryOutputs.Should().Contain("qualityReport");
+        retryOutputs.Should().Contain("passed");
+        retryOutputs.Should().Contain("teachingFeedback");
+    }
+
+    // ================================================================
+    // No dangling edges — every non-terminal activity routes somewhere.
+    // ================================================================
+
+    [Test]
+    public void EveryActivity_RoutesToATerminal_NoDanglingEdge()
+    {
+        var terminals = new[] { "FinishPass", "FinishFail", "FinishRetryPass" };
+        var allIds = _flowchart.Activities.Select(a => a.Id!).ToHashSet();
+        var sources = _flowchart.Connections.Select(c => c.Source.Activity.Id!).ToHashSet();
+
+        foreach (var id in allIds.Where(i => !terminals.Contains(i)))
+        {
+            sources.Should().Contain(id, $"activity '{id}' must route somewhere (no dangling edge / no hang)");
+        }
+    }
+
+    // ================================================================
+    // Helpers
+    // ================================================================
+
+    private bool HasEdge(string sourceId, string? port, string targetId)
+        => _flowchart.Connections.Any(c =>
+            c.Source.Activity.Id == sourceId &&
+            (port == null || c.Source.Port == port) &&
+            c.Target.Activity.Id == targetId);
+
+    /// <summary>BFS over the connection graph to collect every activity id reachable from a source.</summary>
+    private HashSet<string> ReachableFrom(string startId)
+    {
+        var visited = new HashSet<string>();
+        var queue = new Queue<string>();
+        queue.Enqueue(startId);
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+            foreach (var edge in _flowchart.Connections.Where(c => c.Source.Activity.Id == current))
+            {
+                var target = edge.Target.Activity.Id!;
+                if (visited.Add(target)) queue.Enqueue(target);
+            }
+        }
+        return visited;
+    }
+
+    private static string? ReadDefinitionId(DispatchWorkflow dispatch)
+    {
+        var prop = typeof(DispatchWorkflow).GetProperty("WorkflowDefinitionId");
+        var value = prop?.GetValue(dispatch);
+        var expression = value?.GetType().GetProperty("Expression")?.GetValue(value)
+            as Elsa.Expressions.Models.Expression;
+        return expression?.Value?.ToString();
+    }
+}


### PR DESCRIPTION
## TestingWorkflow (`testing-pipeline`) build-out — Bucket D (fix-now, pivot-independent)

Per the completeness audit `docs/superpowers/audits/2026-06-22/completeness/Testing.md`. Closes the P0/P1 correctness & safety gaps:

- **P0 — false-success auto-fix hole:** the MajorIssues path now dispatches `llm-call` (role=developer, action=implement-fix) to **generate** the fix before `CommitFix`, with a zero-files-changed guard → a no-op commit escalates instead of re-triggering CI pretending progress. `WaitForCIResultsActivity` **fails closed** on a result parse error (never reads green from an unparseable payload).
- **P0 — dead CI-wait timeout:** `WaitForCIResultsActivity` arms a durable `DelayFor` timeout bookmark alongside the CI-result bookmark → a never-reported CI run takes a deterministic Timeout edge → escalation (not an infinite hang; not a blocking `Task.Delay`). Applied to initial + retry waits.
- **P0 — DCB audit trail:** new `TestingEvents` + `EmitTestingEventActivity` (via `TammaEventEmitter` → durable engine drain, not a direct `IEventRepository`) — events at trigger / results / each gate / each fix-commit / timeout / every terminal. Degraded/timeout events are LOUD (error status).
- **P0 — trigger-failure routing:** a failed CI trigger routes to escalation instead of a dead wait with `RunId="unknown"`.
- **P1 — single mandatory escalation terminal:** Critical / retry-exhausted / ci-timeout / trigger-failed / autofix-noop converge with a structured `escalationReason`; `passed=true` is reported only on real gate success.

Output contract (`qualityReport` / `passed` / `teachingFeedback`) preserved on every terminal; `escalated`/`escalationReason` added additively. Mock paths (`Testing:UseMock`) intact. No direct provider call; no EF migration. Adds `Elsa.Scheduling` 3.5.3 PackageReference (matches the host's `UseScheduling()`).

**Review:** adversarial spec+quality review **APPROVED** — verified the durable timeout against Elsa 3.5.3 internals (EF-persisted bookmark, re-armed on host restart), the fail-closed auto-fix guard, and the event seam; no CRITICAL/IMPORTANT findings.

**Gate:** build 0 errors; `Tamma.Activities.Tests` full suite **1695/0** (incl. the build-every-workflow drift test); targeted 32/0.

Deferred (P2/P3, noted not faked): consecutive-pass persistence, `/api/v1` mediation formalization, artifact capture, infra-vs-test failure distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)