### PR TITLE
feat(workflows): build out DeploymentPipelineWorkflow — fail-closed gate, prod approval, DCB events, rollback

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/DeployEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/DeployEvents.cs
@@ -1,0 +1,89 @@
+namespace Tamma.Activities.ADL;
+
+/// <summary>
+/// Central catalogue of the <c>DEPLOY.*</c> DCB event types emitted by the
+/// built-out <c>deployment-pipeline</c> workflow (step 15 of the autonomous loop
+/// — post-merge QA → UAT → Production promotion) via
+/// <see cref="EmitDeploymentEventActivity"/>.
+///
+/// <para>The deploy stage is issue-scoped, so deploy events land in the tenant
+/// <c>domain_events</c> store (first-class <c>IssueNumber</c> column). Events are
+/// emitted via <c>TammaEventEmitter.Emit</c> into the workflow's
+/// <c>tamma:events</c> transient list and persisted <i>durably</i> by the engine
+/// event drain (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) — the same
+/// pattern <see cref="EmitMergeEventActivity"/> / <see cref="EmitMergeApprovalEventActivity"/>
+/// use. No activity holds a DB / repository dependency of its own (none is
+/// registered in the Elsa engine — a directly-injected <c>IEventRepository</c>
+/// would be inert and silently drop the event).</para>
+///
+/// <para>Closes the audit gap (completeness audit item 2): the prior pipeline
+/// emitted <b>zero</b> events, breaking the SOC2 / time-travel requirement and
+/// the auditor journey (filter by deployment events, reconstruct deploy-time
+/// state). Every meaningful edge now emits a typed event.</para>
+///
+/// <para>Type pattern follows the platform's <c>AGGREGATE.ACTION.STATUS</c>
+/// convention.</para>
+/// </summary>
+public static class DeployEvents
+{
+    /// <summary>A deploy stage (qa/uat/production) began dispatching.</summary>
+    public const string StageStarted = "DEPLOY.STAGE.STARTED";
+
+    /// <summary>A deploy stage reported success and was promoted.</summary>
+    public const string StageSuccess = "DEPLOY.STAGE.SUCCESS";
+
+    /// <summary>
+    /// A deploy stage failed — missing / unparseable / empty result, a dispatch
+    /// error, or an explicit <c>status:"failed"</c>. Loud (error-status) so the
+    /// loop never reports a silent false success (completeness audit item 1).
+    /// </summary>
+    public const string StageFailed = "DEPLOY.STAGE.FAILED";
+
+    /// <summary>The whole pipeline reached the success terminal (all stages OK).</summary>
+    public const string PipelineSuccess = "DEPLOY.PIPELINE.SUCCESS";
+
+    /// <summary>The pipeline terminated on a failed stage. Loud (error-status).</summary>
+    public const string PipelineFailed = "DEPLOY.PIPELINE.FAILED";
+
+    /// <summary>A human production-approval gate suspended on its bookmark.</summary>
+    public const string ProductionApprovalRequested = "DEPLOY.PRODUCTION.APPROVAL_REQUESTED";
+
+    /// <summary>A human approved the production deploy at the gate.</summary>
+    public const string ProductionApproved = "DEPLOY.PRODUCTION.APPROVED";
+
+    /// <summary>
+    /// A human rejected the production deploy (or the gate received an invalid
+    /// decision). Loud (error-status) — never a silent promote.
+    /// </summary>
+    public const string ProductionRejected = "DEPLOY.PRODUCTION.REJECTED";
+
+    /// <summary>A production rollback began (revert to the previous release).</summary>
+    public const string RollbackStarted = "DEPLOY.ROLLBACK.STARTED";
+
+    /// <summary>A production rollback completed.</summary>
+    public const string RollbackSuccess = "DEPLOY.ROLLBACK.SUCCESS";
+
+    /// <summary>
+    /// A production rollback itself failed — a critical operator-attention event.
+    /// Loud (error-status).
+    /// </summary>
+    public const string RollbackFailed = "DEPLOY.ROLLBACK.FAILED";
+
+    /// <summary>
+    /// A <c>*.FAILED</c> / <c>*.REJECTED</c> deploy event carries an
+    /// <c>error</c> status; everything else (<c>*.SUCCESS</c> /
+    /// <c>*.STARTED</c> / <c>*.APPROVED</c> / <c>*.APPROVAL_REQUESTED</c>) is
+    /// <c>success</c>. A failed/rejected deploy is a loud audit row, NOT a false
+    /// success (no-silent-failure rule).
+    /// </summary>
+    public static bool IsFailureType(string type)
+        => type is StageFailed or PipelineFailed or ProductionRejected or RollbackFailed;
+
+    /// <summary>
+    /// Parse a tenant id from the loose string form threaded through the workflow
+    /// inputs. Returns <c>null</c> for empty / single-user / unparseable values
+    /// (deploy events in single-user mode are platform-scope, TenantId null).
+    /// </summary>
+    public static Guid? ParseTenantId(string? tenantId)
+        => Guid.TryParse(tenantId, out var g) ? g : null;
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/DispatchCycleActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/DispatchCycleActivity.cs
@@ -6,14 +6,33 @@ using Elsa.Workflows.Models;
 using Elsa.Workflows.Runtime;
 using Elsa.Workflows.Runtime.Contracts;
 using Elsa.Workflows.Runtime.Requests;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Tamma.Activities.Core;
+using Tamma.Core.Deployment;
 
 namespace Tamma.Activities.ADL;
 
 /// <summary>
 /// Dispatches a SingleIssueCycle workflow (fire & forget) with event emission.
 /// Wraps Elsa's DispatchWorkflow to add audit trail.
+///
+/// <para><b>Deployment-mode threading (IMPORTANT fix, 2026-06-22).</b> The
+/// downstream <c>deployment-pipeline</c> gates its production deploy on a human
+/// approval bookmark when <c>mode == "business"</c> (or an explicit
+/// <c>requireProdApproval</c>). Nothing upstream used to set <c>mode</c>, so prod
+/// auto-deployed with no gate (violating "zero deployments without approval in
+/// Business Mode"). This activity now derives the real operating mode from
+/// configuration — mirroring <c>Tamma.Api.Services.PromptStore.TammaModeProvider</c>'s
+/// detection (the engine layer cannot reference <c>Tamma.Api</c> without a
+/// dependency cycle, so the shared, pure <see cref="DeploymentMode.Resolve"/> in
+/// Tamma.Core re-derives the SAME decision from the SAME config signals) — and
+/// forwards <c>mode</c> + <c>tenantId</c> + <c>requireProdApproval</c> to
+/// <c>single-issue-cycle</c>, which threads them into the pipeline.</para>
+///
+/// <para><b>Fail-safe:</b> an absent/unknown mode resolves to <c>business</c>
+/// (REQUIRE approval), never a silent prod auto-deploy. An operator can force the
+/// gate even in single-user mode via <c>Deployment:RequireProdApproval=true</c>.</para>
 /// </summary>
 [Activity(
     "Tamma.ADL",
@@ -26,6 +45,7 @@ public class DispatchCycleActivity : TammaAsyncActivity
     public override string? EventType => "ADL.CYCLE.DISPATCH";
 
     private readonly IWorkflowDispatcher? _dispatcher;
+    private readonly IConfiguration? _configuration;
 
     [Input(Description = "Repository (owner/repo)")]
     public Input<string> Repository { get; set; } = default!;
@@ -45,6 +65,16 @@ public class DispatchCycleActivity : TammaAsyncActivity
     [Input(Description = "Tenant ID for tenant-scoped prompt resolution (empty = system defaults)")]
     public Input<string> TenantId { get; set; } = new("");
 
+    /// <summary>
+    /// Deployment mode (<c>business</c> | <c>dev</c>) forwarded to the cycle and,
+    /// from there, into the deployment pipeline's production-approval gate. Left
+    /// empty here means "derive from configuration in <see cref="RunAsync"/>" — the
+    /// orchestrator wires this from the real operating mode; an explicit override is
+    /// honoured if a caller sets it.
+    /// </summary>
+    [Input(Description = "Deployment mode (business|dev). Empty = derive from configuration.")]
+    public Input<string> Mode { get; set; } = new("");
+
     [Output(Description = "Dispatched workflow instance ID")]
     public Output<string?> InstanceId { get; set; } = default!;
 
@@ -53,10 +83,12 @@ public class DispatchCycleActivity : TammaAsyncActivity
 
     public DispatchCycleActivity(
         ILogger<DispatchCycleActivity> logger,
-        IWorkflowDispatcher dispatcher)
+        IWorkflowDispatcher dispatcher,
+        IConfiguration configuration)
     {
         Logger = logger;
         _dispatcher = dispatcher;
+        _configuration = configuration;
     }
 
     protected override async Task RunAsync(ActivityExecutionContext context)
@@ -68,6 +100,18 @@ public class DispatchCycleActivity : TammaAsyncActivity
             return;
         }
 
+        // Resolve the deployment mode end-to-end so the pipeline's production
+        // approval gate engages for business/SaaS deployments. An explicit Mode
+        // input wins; otherwise derive it from configuration (mirrors
+        // TammaModeProvider's single-vs-SaaS detection). Fail-safe: an
+        // absent/unknown mode resolves to "business" (REQUIRE approval).
+        var mode = ResolveMode(context);
+
+        // requireProdApproval lets an operator force the gate even in single-user
+        // mode (Deployment:RequireProdApproval=true). Defaults false.
+        var requireProdApproval =
+            _configuration?.GetValue<bool>("Deployment:RequireProdApproval") ?? false;
+
         var input = new Dictionary<string, object>
         {
             ["repository"] = Repository.Get(context),
@@ -76,6 +120,8 @@ public class DispatchCycleActivity : TammaAsyncActivity
             ["botAssignee"] = BotAssignee.Get(context),
             ["baseBranch"] = BaseBranch.Get(context),
             ["tenantId"] = TenantId.Get(context),
+            ["mode"] = mode,
+            ["requireProdApproval"] = requireProdApproval,
         };
 
         var instanceId = Guid.NewGuid().ToString();
@@ -90,14 +136,47 @@ public class DispatchCycleActivity : TammaAsyncActivity
         InstanceId.Set(context, instanceId);
 
         Logger?.LogInformation(
-            "Dispatched single-issue-cycle for issue #{IssueNumber}, instance {InstanceId}",
-            IssueNumber.Get(context), instanceId);
+            "Dispatched single-issue-cycle for issue #{IssueNumber}, instance {InstanceId} " +
+            "(mode={Mode}, requireProdApproval={RequireProdApproval})",
+            IssueNumber.Get(context), instanceId, mode, requireProdApproval);
+    }
+
+    private string ResolveMode(ActivityExecutionContext context)
+        => ResolveMode(Mode.Get(context), _configuration);
+
+    /// <summary>
+    /// Resolve the deployment <c>mode</c> threaded to the cycle/pipeline. An
+    /// explicit <paramref name="explicitInput"/> (the orchestrator's <c>Mode</c>
+    /// input) wins; otherwise derive it from the same config signals
+    /// <c>TammaModeProvider</c> reads, via the shared, pure
+    /// <see cref="DeploymentMode.Resolve"/>. Fail-safe to <c>business</c> (gate ON)
+    /// when nothing can be determined — never a silent prod auto-deploy.
+    ///
+    /// <para>Pure + static (config in, token out) so the threading decision is
+    /// unit-testable without an Elsa <c>ActivityExecutionContext</c>.</para>
+    /// </summary>
+    public static string ResolveMode(string? explicitInput, IConfiguration? configuration)
+    {
+        if (!string.IsNullOrWhiteSpace(explicitInput))
+        {
+            // Honour an explicit override but normalise it through the same
+            // resolver so "saas"/"single-user" aliases map to the wire tokens.
+            return DeploymentMode.Resolve(explicitInput, false, false);
+        }
+
+        var tammaMode = configuration?["Tamma:Mode"];
+        var hasSharedSecret = !string.IsNullOrWhiteSpace(configuration?["Tamma:TenantSharedSecret"]);
+        var hasControlPlane =
+            !string.IsNullOrWhiteSpace(configuration?.GetConnectionString("ControlPlane"));
+
+        return DeploymentMode.Resolve(tammaMode, hasSharedSecret, hasControlPlane);
     }
 
     public override Dictionary<string, object?> BuildStartData(ActivityExecutionContext context) => new()
     {
         ["issueNumber"] = IssueNumber.Get(context),
         ["repository"] = Repository.Get(context),
+        ["mode"] = ResolveMode(context),
     };
 
     public override Dictionary<string, object?> BuildEndData(ActivityExecutionContext context) => new()

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitDeploymentEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitDeploymentEventActivity.cs
@@ -1,0 +1,154 @@
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+
+namespace Tamma.Activities.ADL;
+
+/// <summary>
+/// Emits a <c>DEPLOY.*</c> DCB event (completeness audit item 2) for the
+/// built-out <c>deployment-pipeline</c> workflow by appending a
+/// <see cref="TammaEvent"/> to the workflow's <c>tamma:events</c> transient list
+/// via <see cref="TammaEventEmitter.Emit"/>. The engine event drain
+/// (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) flushes that list
+/// <i>durably</i> to the tenant <c>domain_events</c> store after this activity
+/// runs — the drain resolves the tenant from the workflow scope (the pipeline
+/// stamps a <c>TenantId</c> variable). The event therefore persists without this
+/// activity holding any DB / repository dependency of its own (none is registered
+/// in the Elsa engine — a directly-injected <c>IEventRepository</c> would be inert
+/// and silently drop the event, the same trap the PR / merge / branch exemplars
+/// avoid).
+///
+/// <para>This is the per-edge deploy emitter: the workflow fires it before each
+/// stage dispatch (<c>DEPLOY.STAGE.STARTED</c>), after each stage extract
+/// (<c>DEPLOY.STAGE.SUCCESS</c> / <c>DEPLOY.STAGE.FAILED</c>), around the prod
+/// approval gate (<c>DEPLOY.PRODUCTION.APPROVAL_REQUESTED/APPROVED/REJECTED</c>),
+/// in the rollback branch (<c>DEPLOY.ROLLBACK.*</c>), and at the terminals
+/// (<c>DEPLOY.PIPELINE.SUCCESS/FAILED</c>) — so every meaningful edge lands a
+/// queryable audit row for time-travel debugging + SOC2 compliance.</para>
+/// </summary>
+[Activity(
+    "Tamma.ADL",
+    "Emit Deployment Event",
+    "Emit a DEPLOY.* DCB event for the deployment-pipeline audit trail",
+    Kind = ActivityKind.Task
+)]
+public class EmitDeploymentEventActivity : Activity
+{
+    private readonly ILogger<EmitDeploymentEventActivity>? _logger;
+
+    [Input(Description = "Event type — e.g. DEPLOY.STAGE.STARTED / DEPLOY.PRODUCTION.APPROVED")]
+    public Input<string> EventType { get; set; } = default!;
+
+    [Input(Description = "Issue number this deployment resolves")]
+    public Input<int> IssueNumber { get; set; } = new(0);
+
+    [Input(Description = "Repository in owner/repo format")]
+    public Input<string?> Repository { get; set; } = new((string?)null);
+
+    [Input(Description = "Merged commit SHA being deployed")]
+    public Input<string?> MergeSha { get; set; } = new((string?)null);
+
+    [Input(Description = "Deploy stage — qa | uat | production (empty for pipeline-level events)")]
+    public Input<string?> Stage { get; set; } = new((string?)null);
+
+    [Input(Description = "Deployment mode (dev | business) driving the prod approval gate")]
+    public Input<string?> Mode { get; set; } = new((string?)null);
+
+    [Input(Description = "Tenant id (empty / single-user → platform-scope event)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [Input(Description = "Event data payload as JSON (status, reason, completedStages, rollbackStatus, durationMs, approver)")]
+    public Input<string?> DataJson { get; set; } = new((string?)null);
+
+    [JsonConstructor]
+    public EmitDeploymentEventActivity() { }
+
+    public EmitDeploymentEventActivity(ILogger<EmitDeploymentEventActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var type = EventType.Get(context) ?? DeployEvents.PipelineFailed;
+        var issueNumber = IssueNumber.Get(context);
+        var repository = Repository.Get(context) ?? "";
+        var mergeSha = MergeSha.Get(context) ?? "";
+        var stage = Stage.Get(context) ?? "";
+        var mode = Mode.Get(context) ?? "";
+        var tenantId = DeployEvents.ParseTenantId(TenantId.Get(context));
+        var data = ParseData(DataJson.Get(context));
+
+        var evt = BuildTammaEvent(type, issueNumber, repository, mergeSha, stage, mode, tenantId, data);
+        TammaEventEmitter.Emit(context, this, _logger, evt);
+
+        _logger?.LogInformation(
+            "Emitted {Type} for issue #{Issue} stage {Stage} in {Repo}",
+            type, issueNumber, string.IsNullOrEmpty(stage) ? "<pipeline>" : stage, repository);
+
+        return default;
+    }
+
+    /// <summary>
+    /// Map the deploy event inputs onto a <see cref="TammaEvent"/> expressed as the
+    /// engine's transient-list event so the merged drain persists it. Tags carry
+    /// the queryable DCB index keys (<c>issueId</c>/<c>issueNumber</c>/
+    /// <c>repository</c>/<c>mergeSha</c>/<c>stage</c>/<c>mode</c>/<c>tenantId</c>);
+    /// <c>Data</c> carries the operation payload (status / reason / completedStages
+    /// / rollbackStatus). Pure (no Elsa context) — exposed for unit testing.
+    /// </summary>
+    public static TammaEvent BuildTammaEvent(
+        string type,
+        int issueNumber,
+        string repository,
+        string mergeSha,
+        string stage,
+        string mode,
+        Guid? tenantId,
+        IReadOnlyDictionary<string, object?>? data)
+    {
+        var tags = new Dictionary<string, object?>
+        {
+            ["issueId"] = issueNumber.ToString(),
+            ["issueNumber"] = issueNumber.ToString(),
+        };
+        if (!string.IsNullOrWhiteSpace(repository)) tags["repository"] = repository;
+        if (!string.IsNullOrWhiteSpace(mergeSha)) tags["mergeSha"] = mergeSha;
+        if (!string.IsNullOrWhiteSpace(stage)) tags["stage"] = stage;
+        if (!string.IsNullOrWhiteSpace(mode)) tags["mode"] = mode;
+        if (tenantId is not null) tags["tenantId"] = tenantId.Value.ToString("D");
+
+        return new TammaEvent
+        {
+            EventType = type,
+            Status = DeployEvents.IsFailureType(type) ? "error" : "success",
+            Tags = tags,
+            Data = data is null
+                ? new Dictionary<string, object?>()
+                : new Dictionary<string, object?>(data),
+        };
+    }
+
+    /// <summary>
+    /// Deserialize the JSON data payload into a dictionary for the event builder.
+    /// Returns null on empty/malformed input (the event still emits with "{}").
+    /// Exposed for unit testing the parse path.
+    /// </summary>
+    public static IReadOnlyDictionary<string, object?>? ParseData(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+        try
+        {
+            return System.Text.Json.JsonSerializer
+                .Deserialize<Dictionary<string, object?>>(json);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForDeploymentApprovalActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForDeploymentApprovalActivity.cs
@@ -1,0 +1,196 @@
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities.Flowchart.Attributes;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+
+namespace Tamma.Activities.ADL;
+
+/// <summary>
+/// Bookmark-based human <b>PRODUCTION DEPLOY APPROVAL GATE</b> (PRD FR-32 +
+/// "Smart Friction" strategic checkpoint before production; Business Mode requires
+/// approval — "zero deployments without approval in Business Mode"). Suspends the
+/// <c>deployment-pipeline</c> before the production stage until a human decides
+/// whether to <i>approve</i> or <i>reject</i> the prod deploy, then surfaces that
+/// decision (+ approver + feedback) as a typed outcome the parent flowchart
+/// branches on.
+///
+/// <para>Modelled on <see cref="WaitForMergeApprovalActivity"/>. Resume via the
+/// tenant+repo-scoped bookmark
+/// <c>adl-deploy-prod-approval-{tenant}-{repo}-{issue}-{mergeSha}</c> (SECURITY —
+/// see <see cref="BookmarkName"/>) with the workflow input keys
+/// <c>{ decision, feedback, approver }</c>.</para>
+///
+/// <para>Outcomes (the parent routes each to a distinct edge — no fall-through):
+/// <list type="bullet">
+///   <item><description><c>Approve</c> — approved to deploy to production.</description></item>
+///   <item><description><c>Reject</c> — production deploy rejected.</description></item>
+///   <item><description><c>Invalid</c> — unknown / empty decision. Emitted
+///     instead of silently defaulting to "approve" (no-silent-failure /
+///     fail-closed rule); the parent routes it to the prod-failure terminal, NOT
+///     to a deploy.</description></item>
+/// </list></para>
+///
+/// <para>Events: this is a <see cref="TammaOutcomeActivity"/> with
+/// <c>EventType = DEPLOY.PRODUCTION.APPROVAL_REQUESTED</c>, so the engine
+/// auto-emits <c>DEPLOY.PRODUCTION.APPROVAL_REQUESTED.STARTED</c> at suspend and
+/// <c>…FAILED</c> on exception. The decision itself is emitted as a
+/// <c>DEPLOY.PRODUCTION.APPROVED</c> / <c>DEPLOY.PRODUCTION.REJECTED</c> DCB event
+/// on the resuming edge (see <see cref="EmitDeploymentEventActivity"/> in the
+/// workflow graph) so the approver / feedback context is captured durably.</para>
+/// </summary>
+[Activity(
+    "Tamma.ADL",
+    "Wait For Deployment Approval",
+    "Suspend the deployment pipeline and wait for a production approve/reject decision",
+    Kind = ActivityKind.Task
+)]
+[FlowNode("Approve", "Reject", "Invalid")]
+public class WaitForDeploymentApprovalActivity : TammaOutcomeActivity
+{
+    /// <summary>Recognised decisions (case-insensitive). Anything else → <c>Invalid</c>.</summary>
+    public const string DecisionApprove = "approve";
+    public const string DecisionReject = "reject";
+
+    public override string? EventType => DeployEvents.ProductionApprovalRequested;
+
+    [Input(Description = "Issue number for bookmark identification")]
+    public Input<int> IssueNumber { get; set; } = default!;
+
+    /// <summary>
+    /// Merged commit SHA being deployed — folded into the bookmark name so a
+    /// re-deploy of a different SHA on the same issue can't resume a stale gate.
+    /// </summary>
+    [Input(Description = "Merged commit SHA (bookmark scoping — distinguishes re-deploys)")]
+    public Input<string?> MergeSha { get; set; } = new((string?)null);
+
+    /// <summary>
+    /// Tenant id (the workflow's <c>TenantId</c> variable, a GUID string or empty
+    /// for single-user). Folded into the bookmark name so two tenants on the same
+    /// issue/SHA can never share — and so collide on — a bookmark. The resume
+    /// caller (scoped to ITS tenant) can only target a bookmark whose name carries
+    /// its own tenant id.
+    /// </summary>
+    [Input(Description = "Tenant id (bookmark scoping — prevents cross-tenant collision)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    /// <summary>
+    /// Repository slug (<c>owner/repo</c>). Folded into the bookmark name alongside
+    /// the tenant id so the same issue/SHA across different repos can't collide.
+    /// </summary>
+    [Input(Description = "Repository slug (bookmark scoping — prevents cross-repo collision)")]
+    public Input<string?> Repository { get; set; } = new((string?)null);
+
+    [Output(Description = "Approval decision (approve|reject|invalid)")]
+    public Output<string?> Decision { get; set; } = default!;
+
+    [Output(Description = "Feedback from approver")]
+    public Output<string?> Feedback { get; set; } = default!;
+
+    [Output(Description = "Approver identity captured from the resume payload")]
+    public Output<string?> Approver { get; set; } = default!;
+
+    [JsonConstructor]
+    public WaitForDeploymentApprovalActivity() { }
+
+    public WaitForDeploymentApprovalActivity(ILogger<WaitForDeploymentApprovalActivity> logger)
+    {
+        Logger = logger;
+    }
+
+    /// <summary>
+    /// Canonical, globally-unique bookmark name for a production-deploy approval
+    /// gate. Includes <paramref name="tenantId"/> + <paramref name="repository"/>
+    /// + <paramref name="mergeSha"/> (in addition to issue) so two tenants — or two
+    /// repos, or two distinct merged commits — on the same issue get DISTINCT
+    /// bookmarks and can never resume each other's gate. Both the activity (suspend
+    /// side) and the engine endpoint (resume side) MUST call this single method so
+    /// the names match byte-for-byte. Mirrors
+    /// <see cref="WaitForMergeApprovalActivity.BookmarkName"/>.
+    /// </summary>
+    public static string BookmarkName(string? tenantId, string? repository, int issueNumber, string? mergeSha)
+    {
+        var tenant = WaitForMergeApprovalActivity.NormalizeSegment(tenantId);
+        var repo = WaitForMergeApprovalActivity.NormalizeSegment(repository);
+        var sha = WaitForMergeApprovalActivity.NormalizeSegment(mergeSha);
+        return $"adl-deploy-prod-approval-{tenant}-{repo}-{issueNumber}-{sha}";
+    }
+
+    protected override Task RunAsync(ActivityExecutionContext context)
+    {
+        var issueNumber = IssueNumber.Get(context);
+        var mergeSha = MergeSha.Get(context);
+        var tenantId = TenantId.Get(context);
+        var repository = Repository.Get(context);
+        var bookmarkName = BookmarkName(tenantId, repository, issueNumber, mergeSha);
+
+        Logger?.LogInformation(
+            "Creating production-deploy approval bookmark {BookmarkName} for issue #{IssueNumber}",
+            bookmarkName, issueNumber);
+
+        context.CreateBookmark(
+            new CreateBookmarkArgs
+            {
+                BookmarkName = bookmarkName,
+                Callback = OnDeployDecisionAsync,
+                AutoBurn = true,
+                IncludeActivityInstanceId = false,
+            });
+
+        return Task.CompletedTask;
+    }
+
+    private async ValueTask OnDeployDecisionAsync(ActivityExecutionContext context)
+    {
+        var input = context.WorkflowInput;
+
+        var decisionStr = input.TryGetValue("decision", out var d) ? d?.ToString() : null;
+        var feedback = input.TryGetValue("feedback", out var f) ? f?.ToString() : null;
+        var approver = input.TryGetValue("approver", out var a) ? a?.ToString() : null;
+
+        var (outcome, normalized) = Normalize(decisionStr);
+
+        // Surface the NORMALIZED decision (so downstream edges + the emitted DCB
+        // event agree on a canonical token), plus the captured approver/feedback.
+        Decision.Set(context, normalized);
+        Feedback.Set(context, feedback);
+        Approver.Set(context, approver);
+
+        Logger?.LogInformation(
+            "Production-deploy decision received for issue #{IssueNumber}: {Decision} (outcome={Outcome}, approver={Approver})",
+            IssueNumber.Get(context), decisionStr ?? "<null>", outcome, approver ?? "<none>");
+
+        await context.CompleteActivityWithOutcomesAsync(outcome);
+    }
+
+    /// <summary>
+    /// Map a raw decision string to a typed outcome + canonical token. Unknown /
+    /// empty → <c>(Invalid, "invalid")</c> — NEVER a silent "approve" (fail-closed:
+    /// an ambiguous decision must NOT promote to production). Pure — exposed for
+    /// unit testing.
+    /// </summary>
+    public static (string Outcome, string Normalized) Normalize(string? decision)
+        => decision?.Trim().ToLowerInvariant() switch
+        {
+            DecisionApprove => ("Approve", DecisionApprove),
+            DecisionReject => ("Reject", DecisionReject),
+            _ => ("Invalid", "invalid"),
+        };
+
+    public override Dictionary<string, object?> BuildStartData(ActivityExecutionContext context) => new()
+    {
+        ["issueNumber"] = IssueNumber.Get(context),
+        ["mergeSha"] = MergeSha.Get(context) ?? "",
+        ["stage"] = "production",
+    };
+
+    public override Dictionary<string, object?> BuildEndData(ActivityExecutionContext context) => new()
+    {
+        ["issueNumber"] = IssueNumber.Get(context),
+        ["decision"] = this.GetOutput<string?>(context, nameof(Decision)) ?? "",
+        ["approver"] = this.GetOutput<string?>(context, nameof(Approver)) ?? "",
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/AdlEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/AdlEndpoints.cs
@@ -131,6 +131,94 @@ public static class AdlEndpoints
         }
     }
 
+    /// <summary>Decisions the production-deploy gate accepts (case-insensitive).
+    /// Anything else is rejected with 400 up front so the caller never forwards an
+    /// arbitrary string that would silently route to the prod-failure terminal.</summary>
+    private static readonly HashSet<string> AllowedDeployDecisions =
+        new(StringComparer.OrdinalIgnoreCase) { "approve", "reject" };
+
+    /// <summary>
+    /// Resume request for the production-deploy approval gate. <c>Approver</c> is
+    /// intentionally absent — derived from the authenticated caller (I2), never
+    /// trusted from the client.
+    /// </summary>
+    public sealed record DeployApprovalDecisionRequest(
+        int IssueNumber,
+        string Repository,
+        string MergeSha,
+        string Decision,
+        string? Feedback);
+
+    /// <summary>
+    /// Resume the production-deploy approval gate for an issue with a human
+    /// decision (completeness audit P0 item 3).
+    /// Route: <c>POST /api/adl/deploy-approval/resume</c>.
+    /// </summary>
+    public static async Task<IResult> ResumeDeploymentApproval(
+        [FromBody] DeployApprovalDecisionRequest req,
+        [FromServices] IElsaWorkflowService elsa,
+        [FromServices] ITenantContext tenantContext,
+        ClaimsPrincipal principal,
+        [FromServices] ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger("Tamma.Api.AdlEndpoints");
+
+        if (string.IsNullOrWhiteSpace(req.Decision))
+            return Results.BadRequest(new { error = "decision is required (approve|reject)" });
+        if (!AllowedDeployDecisions.Contains(req.Decision.Trim()))
+            return Results.BadRequest(new { error = "decision must be one of: approve, reject" });
+        if (req.IssueNumber <= 0)
+            return Results.BadRequest(new { error = "issueNumber is required (> 0)" });
+        if (string.IsNullOrWhiteSpace(req.Repository))
+            return Results.BadRequest(new { error = "repository is required (owner/repo)" });
+        if (string.IsNullOrWhiteSpace(req.MergeSha))
+            return Results.BadRequest(new { error = "mergeSha is required" });
+
+        // Scope the resume to the caller's ambient tenant — the engine folds it
+        // into the bookmark name so a caller can only resolve a gate in its OWN
+        // tenant. (Ambient null = self-hosted single-user scope.)
+        var tenantId = tenantContext.TenantId?.ToString();
+
+        // I2 — the approver is the authenticated caller, derived server-side. A
+        // client-supplied approver is never honoured so the audit can't be forged.
+        var approver = ResolveApprover(principal);
+
+        try
+        {
+            var result = await elsa.ResumeDeploymentApprovalAsync(
+                req.IssueNumber, tenantId, req.Repository, req.MergeSha,
+                req.Decision, req.Feedback, approver);
+
+            if (result.GateNotFound)
+            {
+                return Results.NotFound(new
+                {
+                    error = "gate_not_waiting",
+                    detail = "No production-deploy approval gate is currently suspended for this issue/SHA.",
+                });
+            }
+
+            logger.LogInformation(
+                "Drove deploy-approval gate for issue #{Issue} with decision {Decision} (approver {Approver})",
+                req.IssueNumber, LogSanitizer.Clean(req.Decision), LogSanitizer.Clean(approver));
+
+            return Results.Ok(new
+            {
+                resumed = result.Resumed,
+                workflowInstanceId = result.WorkflowInstanceId,
+                decision = req.Decision,
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Failed to resume deploy-approval gate for issue #{Issue}", req.IssueNumber);
+            return Results.Problem(
+                detail: "Failed to resume the production-deploy approval gate.",
+                statusCode: StatusCodes.Status502BadGateway);
+        }
+    }
+
     /// <summary>
     /// Derive the approver identity from the authenticated principal (I2):
     /// email → display name → subject id. Falls back to <c>"unknown"</c> only if

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -2167,6 +2167,10 @@ workflows.MapGet("/instances/{id}/events", WorkflowEndpoints.GetInstanceEvents);
 // so a caller can only resume a gate in its OWN tenant (cross-tenant → 404).
 var adl = app.MapGroup("/api/adl").RequireAuthorization("WorkflowsManage");
 adl.MapPost("/merge-approval/resume", AdlEndpoints.ResumeMergeApproval);
+// Production-deploy approval gate (completeness audit P0 item 3). Resumes the
+// tenant+repo+SHA-scoped adl-deploy-prod-approval-{tenant}-{repo}-{issue}-{sha}
+// bookmark; approver derived server-side (I2); tenant-scoped (cross-tenant → 404).
+adl.MapPost("/deploy-approval/resume", AdlEndpoints.ResumeDeploymentApproval);
 
 // ── GitHub App (no auth, webhook signature verification) ──
 // Audit finding 017 — webhook gets the GitHubWebhook policy (300/min). The

--- a/apps/tamma-elsa/src/Tamma.Api/Services/ElsaWorkflowService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/ElsaWorkflowService.cs
@@ -307,6 +307,56 @@ public partial class ElsaWorkflowService : IElsaWorkflowService
             WorkflowInstanceId: result?.WorkflowInstanceId);
     }
 
+    /// <summary>
+    /// Completeness audit P0 item 3 — forward a deployment-pipeline
+    /// production-approval gate resume to the engine's in-process resume endpoint,
+    /// which looks up the tenant+repo+SHA-scoped
+    /// <c>adl-deploy-prod-approval-{tenant}-{repo}-{issue}-{mergeSha}</c> bookmark
+    /// and runs the owning instance with <c>{decision, feedback, approver}</c>
+    /// injected as input. A 404 (no gate waiting) is surfaced as
+    /// <see cref="MergeApprovalResumeResult.GateNotFound"/> rather than thrown.
+    /// </summary>
+    public async Task<MergeApprovalResumeResult> ResumeDeploymentApprovalAsync(
+        int issueNumber, string? tenantId, string? repository, string? mergeSha,
+        string decision, string? feedback, string? approver)
+    {
+        _logger.LogInformation(
+            "Resuming deploy-approval gate for issue #{Issue} (decision={Decision})",
+            issueNumber, SanitizeForLog(decision));
+
+        await EnsureHealthyAsync();
+
+        var payload = new
+        {
+            issueNumber,
+            // Tenant + repo + sha scope the engine's bookmark lookup.
+            tenantId,
+            repository,
+            mergeSha,
+            decision,
+            feedback,
+            approver,
+        };
+
+        var response = await _httpClient.PostAsJsonAsync(
+            "/elsa/api/adl/deploy-approval/resume", payload, JsonOptions);
+
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            _logger.LogWarning(
+                "No deploy-approval gate waiting for issue #{Issue}", issueNumber);
+            return new MergeApprovalResumeResult(Resumed: false, GateNotFound: true, WorkflowInstanceId: null);
+        }
+
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<EngineResumeResponse>(JsonOptions);
+        return new MergeApprovalResumeResult(
+            Resumed: result?.Resumed ?? true,
+            GateNotFound: false,
+            WorkflowInstanceId: result?.WorkflowInstanceId);
+    }
+
     private sealed class EngineResumeResponse
     {
         public bool Resumed { get; set; }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/IElsaWorkflowService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/IElsaWorkflowService.cs
@@ -41,9 +41,26 @@ public interface IElsaWorkflowService
     Task<MergeApprovalResumeResult> ResumeMergeApprovalAsync(
         int issueNumber, int prNumber, string? tenantId, string? repository,
         string decision, string? feedback, string? approver);
+
+    /// <summary>
+    /// Completeness audit P0 item 3 — resume the <c>deployment-pipeline</c>
+    /// production-approval human gate suspended on the tenant+repo+SHA-scoped
+    /// bookmark <c>adl-deploy-prod-approval-{tenant}-{repo}-{issue}-{mergeSha}</c>,
+    /// injecting the <c>{decision, feedback, approver}</c> payload as workflow
+    /// input. Forwards to the engine's in-process resume endpoint. Returns the
+    /// resolved workflow instance id on success.
+    ///
+    /// <para>Tenant scoping — <paramref name="tenantId"/> /
+    /// <paramref name="repository"/> / <paramref name="mergeSha"/> scope the
+    /// bookmark lookup, so the engine can only resolve a gate in the caller's own
+    /// tenant; a cross-tenant attempt resolves no bookmark (GateNotFound).</para>
+    /// </summary>
+    Task<MergeApprovalResumeResult> ResumeDeploymentApprovalAsync(
+        int issueNumber, string? tenantId, string? repository, string? mergeSha,
+        string decision, string? feedback, string? approver);
 }
 
-/// <summary>Outcome of a merge-approval gate resume.</summary>
+/// <summary>Outcome of a merge-approval (or deploy-approval) gate resume.</summary>
 public sealed record MergeApprovalResumeResult(
     bool Resumed,
     bool GateNotFound,

--- a/apps/tamma-elsa/src/Tamma.Core/Deployment/DeploymentMode.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Deployment/DeploymentMode.cs
@@ -1,0 +1,83 @@
+namespace Tamma.Core.Deployment;
+
+/// <summary>
+/// The deployment <c>mode</c> wire token threaded from the autonomous loop
+/// (<c>AdlOrchestratorWorkflow → DispatchCycleActivity → single-issue-cycle →
+/// deployment-pipeline</c>) into the deployment pipeline's production-approval
+/// gate.
+///
+/// <para><b>Why this lives in Tamma.Core (not Tamma.Api).</b> The real
+/// process-wide operating-mode source of truth is
+/// <c>Tamma.Api.Services.PromptStore.ITammaModeProvider</c>, but the Elsa
+/// engine layer (<c>Tamma.Activities</c> / <c>Tamma.ElsaServer</c>) cannot
+/// reference <c>Tamma.Api</c> without re-introducing the dependency cycle that
+/// Story 27-19 broke. So this resolver re-derives the SAME single-vs-SaaS
+/// decision from the SAME configuration signals that <c>TammaModeProvider</c>
+/// reads (<c>Tamma:Mode</c> explicit override, else the presence of the SaaS-only
+/// <c>Tamma:TenantSharedSecret</c> / <c>ConnectionStrings:ControlPlane</c>). The
+/// engine reads those values from its injected <c>IConfiguration</c> and calls
+/// the pure helper here — keeping the detection logic identical and unit-testable
+/// without taking a dependency on the Configuration package in Tamma.Core.</para>
+/// </summary>
+public static class DeploymentMode
+{
+    /// <summary>
+    /// SaaS / Business-Mode token. The deployment pipeline's
+    /// <c>ProdApprovalNeeded</c> gate engages the human approval bookmark on
+    /// <c>mode == "business"</c> — so SaaS deployments are gated by default.
+    /// </summary>
+    public const string Business = "business";
+
+    /// <summary>
+    /// Single-user / self-hosted token. Dev mode deploys to production without
+    /// a human gate (unless an operator forces it via
+    /// <c>Deployment:RequireProdApproval</c>).
+    /// </summary>
+    public const string Dev = "dev";
+
+    /// <summary>
+    /// Resolve the deployment <c>mode</c> wire token from the three configuration
+    /// signals (read by the caller from <c>IConfiguration</c>):
+    /// <list type="number">
+    ///   <item>an explicit <c>Tamma:Mode</c> override (<c>saas</c> → business,
+    ///     <c>single-user</c> → dev) wins;</item>
+    ///   <item>otherwise, the presence of EITHER SaaS-only signal
+    ///     (<c>Tamma:TenantSharedSecret</c> or <c>ConnectionStrings:ControlPlane</c>)
+    ///     → business;</item>
+    ///   <item>otherwise → dev (self-hosted single-user default).</item>
+    /// </list>
+    ///
+    /// <para><b>Fail-safe:</b> an explicit-mode value that is present but
+    /// unrecognised resolves to <see cref="Business"/> (REQUIRE approval) rather
+    /// than silently bypassing the gate — a mis-typed mode must never auto-deploy
+    /// to prod. Mirrors <c>TammaModeProvider.Resolve</c>'s detection but is
+    /// fail-safe instead of throwing (the engine has no good place to surface a
+    /// startup throw, and the safe default is to GATE).</para>
+    /// </summary>
+    /// <param name="explicitMode">Value of <c>Tamma:Mode</c> (nullable).</param>
+    /// <param name="hasTenantSharedSecret">True when <c>Tamma:TenantSharedSecret</c> is set.</param>
+    /// <param name="hasControlPlaneConnection">True when <c>ConnectionStrings:ControlPlane</c> is set.</param>
+    public static string Resolve(
+        string? explicitMode,
+        bool hasTenantSharedSecret,
+        bool hasControlPlaneConnection)
+    {
+        if (!string.IsNullOrWhiteSpace(explicitMode))
+        {
+            return explicitMode.Trim().ToLowerInvariant() switch
+            {
+                "saas" or "business" => Business,
+                "single-user" or "singleuser" or "single_user" or "dev" => Dev,
+                // Fail-safe: an unrecognised explicit mode REQUIRES approval — never
+                // a silent prod auto-deploy.
+                _ => Business,
+            };
+        }
+
+        // Inferred from SaaS-only config presence — same signals TammaModeProvider
+        // uses. Either present → SaaS → Business Mode (gated).
+        return (hasTenantSharedSecret || hasControlPlaneConnection)
+            ? Business
+            : Dev;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Endpoints/DeploymentApprovalResumeEndpoint.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Endpoints/DeploymentApprovalResumeEndpoint.cs
@@ -1,0 +1,140 @@
+using Elsa.Workflows.Runtime;
+using Elsa.Workflows.Runtime.Filters;
+using Elsa.Workflows.Runtime.Messages;
+using Microsoft.AspNetCore.Mvc;
+using Tamma.Activities.ADL;
+
+namespace Tamma.ElsaServer.Endpoints;
+
+/// <summary>
+/// In-process resume seam for the <c>deployment-pipeline</c> production-approval
+/// human gate (completeness audit P0 item 3). Mirrors
+/// <see cref="MergeApprovalResumeEndpoint"/>.
+///
+/// <para>The gate (<c>WaitForDeploymentApprovalActivity</c>) suspends on the named
+/// bookmark <c>adl-deploy-prod-approval-{tenant}-{repo}-{issue}-{mergeSha}</c>
+/// (tenant + repo + SHA folded in) and, on resume, reads
+/// <c>{decision, feedback, approver}</c> from the workflow input. This endpoint
+/// looks the bookmark up by name, then runs the owning instance from that bookmark
+/// with the decision payload INJECTED as workflow input
+/// (<c>IWorkflowClient.RunInstanceAsync</c> with <c>RunWorkflowInstanceRequest.Input</c>,
+/// which lands in <c>ActivityExecutionContext.WorkflowInput</c> the gate reads).</para>
+///
+/// <para>This lives in the engine process because <c>IBookmarkStore</c> /
+/// <c>IWorkflowRuntime</c> are in-process here. <c>Tamma.Api</c> exposes the
+/// RBAC-gated public surface and forwards to this engine endpoint.</para>
+///
+/// <para><b>SECURITY:</b>
+/// <list type="bullet">
+///   <item><description><b>Tenant scoping</b> — the bookmark name carries the
+///   tenant id + repository that the (tenant-scoped) <c>Tamma.Api</c> caller
+///   supplies. A caller scoped to tenant A computes a name with tenant A, so it
+///   can NEVER resolve tenant B's gate: a cross-tenant attempt simply 404s.</description></item>
+///   <item><description><b>Collision refusal</b> — if more than one bookmark
+///   matches the (globally-unique) name, we REFUSE with 409 rather than resume an
+///   arbitrary one.</description></item>
+///   <item><description><b>Engine-service-only</b> — the route is mapped with
+///   <c>.RequireAuthorization()</c> in <c>Program.cs</c> so only the
+///   Tamma.Api→engine hop (presenting the Elsa admin API key) reaches it;
+///   anonymous public callers get 401.</description></item>
+/// </list></para>
+/// </summary>
+public static class DeploymentApprovalResumeEndpoint
+{
+    public sealed record ResumeRequest(
+        int IssueNumber,
+        string Decision,
+        string? Feedback,
+        string? Approver,
+        // Tenant + repository + mergeSha scope the bookmark lookup. Supplied by the
+        // tenant-scoped Tamma.Api caller; folded into the bookmark name so the
+        // lookup can only ever match a gate in the caller's own tenant/repo/SHA.
+        string? TenantId,
+        string? Repository,
+        string? MergeSha);
+
+    /// <summary>Bookmark name the gate registers — delegates to the SINGLE
+    /// canonical builder shared with <see cref="WaitForDeploymentApprovalActivity"/>
+    /// so suspend-side and resume-side names match byte-for-byte.</summary>
+    public static string BookmarkName(string? tenantId, string? repository, int issueNumber, string? mergeSha)
+        => WaitForDeploymentApprovalActivity.BookmarkName(tenantId, repository, issueNumber, mergeSha);
+
+    public static async Task<IResult> Resume(
+        [FromBody] ResumeRequest request,
+        [FromServices] IBookmarkStore bookmarkStore,
+        [FromServices] IWorkflowRuntime workflowRuntime,
+        [FromServices] ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var logger = loggerFactory.CreateLogger("Tamma.ElsaServer.DeploymentApprovalResume");
+
+        if (string.IsNullOrWhiteSpace(request.Decision))
+            return Results.BadRequest(new { error = "decision is required" });
+
+        var name = BookmarkName(request.TenantId, request.Repository, request.IssueNumber, request.MergeSha);
+
+        var bookmarks = (await bookmarkStore
+            .FindManyAsync(new BookmarkFilter { Name = name }, ct)
+            .ConfigureAwait(false)).ToList();
+
+        if (bookmarks.Count == 0)
+        {
+            logger.LogWarning(
+                "No suspended deploy-approval bookmark {Bookmark} — gate not waiting (already decided, wrong issue/sha, or not this tenant/repo)",
+                name);
+            return Results.NotFound(new
+            {
+                error = "bookmark_not_found",
+                bookmark = name,
+                detail = "No production-deploy approval gate is currently waiting for this issue/SHA.",
+            });
+        }
+
+        if (bookmarks.Count > 1)
+        {
+            logger.LogError(
+                "Ambiguous deploy-approval bookmark {Bookmark}: {Count} live instances — refusing to resume an arbitrary one",
+                name, bookmarks.Count);
+            return Results.Conflict(new
+            {
+                error = "ambiguous_bookmark",
+                bookmark = name,
+                count = bookmarks.Count,
+                detail = "Multiple workflow instances are waiting on this gate; refusing to resume an arbitrary one.",
+            });
+        }
+
+        var bookmark = bookmarks[0];
+
+        var input = new Dictionary<string, object>
+        {
+            ["decision"] = request.Decision,
+        };
+        if (request.Feedback is not null) input["feedback"] = request.Feedback;
+        if (request.Approver is not null) input["approver"] = request.Approver;
+
+        var client = await workflowRuntime
+            .CreateClientAsync(bookmark.WorkflowInstanceId, ct)
+            .ConfigureAwait(false);
+
+        await client.RunInstanceAsync(
+            new RunWorkflowInstanceRequest
+            {
+                BookmarkId = bookmark.Id,
+                Input = input,
+            },
+            ct).ConfigureAwait(false);
+
+        logger.LogInformation(
+            "Resumed deploy-approval gate {Bookmark} (instance {InstanceId}) with decision {Decision}",
+            name, bookmark.WorkflowInstanceId, request.Decision);
+
+        return Results.Ok(new
+        {
+            resumed = true,
+            bookmark = name,
+            workflowInstanceId = bookmark.WorkflowInstanceId,
+            decision = request.Decision,
+        });
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
@@ -391,6 +391,16 @@ app.MapPost("/elsa/api/adl/merge-approval/resume",
     Tamma.ElsaServer.Endpoints.MergeApprovalResumeEndpoint.Resume)
     .RequireAuthorization();
 
+// Completeness audit P0 item 3 — in-process resume seam for the deployment
+// pipeline's production-approval human gate. Tamma.Api's tenant-scoped,
+// RBAC-gated POST /api/adl/deploy-approval/resume forwards here; this endpoint
+// looks up the gate's tenant+repo+SHA-scoped named bookmark and runs the owning
+// instance with the {decision,feedback,approver} payload injected. Same
+// engine-control-surface / RequireAuthorization rationale as the merge gate.
+app.MapPost("/elsa/api/adl/deploy-approval/resume",
+    Tamma.ElsaServer.Endpoints.DeploymentApprovalResumeEndpoint.Resume)
+    .RequireAuthorization();
+
 app.UseSerilogRequestLogging();
 
 Log.Information("Tamma ELSA Server starting up...");

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AdlOrchestratorWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AdlOrchestratorWorkflow.cs
@@ -47,6 +47,17 @@ public class AdlOrchestratorWorkflow : WorkflowBase
         var cooldownSeconds = builder.WithVariable<int>("CooldownSeconds", 10);
         var maxConcurrent = builder.WithVariable<int>("MaxConcurrent", 1);
 
+        // Deployment mode + tenant threaded to each dispatched cycle (and from
+        // there into the deployment pipeline's production-approval gate). These
+        // are PASS-THROUGH from the orchestrator's own input: at the engine/
+        // orchestrator layer the process-wide operating mode is a CONFIG concern,
+        // not a per-instance input, so the current self-restart loop carries them
+        // empty and DispatchCycleActivity derives the real mode from configuration
+        // (mirrors TammaModeProvider). A SaaS dispatcher / operator may still set
+        // `mode`/`tenantId` on the orchestrator input to override per-instance.
+        var mode = builder.WithVariable<string>("Mode", "");
+        var tenantId = builder.WithVariable<string>("TenantId", "");
+
         // Selected work item data
         var selectedItemJson = builder.WithVariable<string?>("SelectedItemJson", null);
         var selectedIssueNumber = builder.WithVariable<int>("SelectedIssueNumber", 0);
@@ -122,6 +133,14 @@ public class AdlOrchestratorWorkflow : WorkflowBase
             IssueNumber = new Input<int>(ctx => selectedIssueNumber.Get(ctx)),
             BotAssignee = new Input<string>(ctx => botAssignee.Get(ctx)),
             BaseBranch = new Input<string>(ctx => baseBranch.Get(ctx)),
+            // Thread the operating mode + tenant end-to-end so the deployment
+            // pipeline's production-approval gate engages for business/SaaS.
+            // Pass-through from the orchestrator input (empty in the self-restart
+            // loop); DispatchCycleActivity derives the real mode from config when
+            // empty, fail-safe to "business" (gate ON) — never a silent prod
+            // auto-deploy.
+            Mode = new Input<string>(ctx => ctx.GetInput<string>("mode") ?? mode.Get(ctx)),
+            TenantId = new Input<string>(ctx => ctx.GetInput<string>("tenantId") ?? tenantId.Get(ctx)),
         };
         dispatchCycle.SetDisplayText("Dispatch Issue Cycle");
 

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DeploymentPipelineWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DeploymentPipelineWorkflow.cs
@@ -3,6 +3,7 @@ using Elsa.Extensions;
 using Elsa.Workflows;
 using Elsa.Workflows.Activities;
 using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.IncidentStrategies;
 using Elsa.Workflows.Management.Activities.SetOutput;
 using Elsa.Workflows.Memory;
 using Elsa.Workflows.Models;
@@ -10,38 +11,106 @@ using Elsa.Workflows.Runtime.Activities;
 using FlowEndpoint = Elsa.Workflows.Activities.Flowchart.Models.Endpoint;
 using FlowConnection = Elsa.Workflows.Activities.Flowchart.Models.Connection;
 
+using Tamma.Activities.ADL;
 using Tamma.Api.Services.Agents;
 using static Tamma.ElsaServer.Workflows.ActivityDisplayTextExtensions;
 
 namespace Tamma.ElsaServer.Workflows;
 
 /// <summary>
-/// Deployment Pipeline — Post-merge deployment through QA, UAT, and Production stages.
-/// Each stage dispatches a notification (llm-call for deployment instructions) and then
-/// waits for an external signal (bookmark) confirming stage completion.
+/// Deployment Pipeline — post-merge promotion through QA → UAT → Production
+/// (step 15 of the autonomous loop, invoked by <c>SingleIssueCycleWorkflow</c>).
 ///
-/// If any stage fails, the pipeline stops and reports failure.
+/// <para><b>Build-out (completeness audit 2026-06-22):</b></para>
+/// <list type="bullet">
+///   <item><description><b>P0 item 1 — fail-closed stage result.</b>
+///     <see cref="ExtractStageResult"/> defaults the stage status to
+///     <c>failed</c> and only promotes on an explicitly-parsed
+///     <c>status:"success"</c>. A missing / empty / unparseable / dispatch-error
+///     result takes the failure edge (never a silent false success). The failure
+///     reason is captured into a <c>StageError</c> variable for the audit
+///     event.</description></item>
+///   <item><description><b>P0 item 2 — full DCB audit trail.</b> Every edge emits
+///     a typed <c>DEPLOY.*</c> event via <see cref="EmitDeploymentEventActivity"/>
+///     through the durable engine event drain: <c>STAGE.STARTED</c> before each
+///     dispatch, <c>STAGE.SUCCESS</c>/<c>STAGE.FAILED</c> after each extract,
+///     <c>PRODUCTION.APPROVAL_REQUESTED/APPROVED/REJECTED</c> around the prod
+///     gate, <c>ROLLBACK.*</c> in the rollback branch, and
+///     <c>PIPELINE.SUCCESS</c>/<c>PIPELINE.FAILED</c> at the terminals.</description></item>
+///   <item><description><b>P0 item 3 — production approval gate.</b> Before the
+///     production deploy a <c>FlowDecision(mode == business || requireProdApproval)</c>
+///     routes to <see cref="WaitForDeploymentApprovalActivity"/> (bookmark-based
+///     human gate). Business Mode requires approval; dev mode deploys straight
+///     through. Approve → ProdDeploy; Reject / Invalid → prod-failure terminal
+///     (NEVER a silent prod deploy).</description></item>
+///   <item><description><b>P0 item 4 — rollback on prod failure.</b> A failed
+///     production deploy routes through <c>RollbackProduction</c> (dispatches
+///     <c>llm-call</c> with the <c>rollback</c> action to revert prod to the
+///     previous release), emitting <c>ROLLBACK.STARTED</c> →
+///     <c>ROLLBACK.SUCCESS</c>/<c>ROLLBACK.FAILED</c>, then the prod-failure
+///     terminal.</description></item>
+///   <item><description><b>P1 item 6 — bounded gate retry + escalation.</b> Each
+///     stage retries up to <c>MaxStageRetries</c> (3, per FR-16) before routing to
+///     its failure terminal — no silent bypass.</description></item>
+///   <item><description><b>P1 item 7 — doc-comment matches the code</b> (this
+///     header; the synchronous <c>WaitForCompletion</c> dispatch model is
+///     documented honestly — the async-bookmark deploy-confirmation model is the
+///     follow-up).</description></item>
+/// </list>
+///
+/// <para><b>Honoured rules:</b> all LLM/agent work routes through
+/// <c>DispatchWorkflow(llm-call)</c> — no step calls a provider directly;
+/// fail-closed everywhere (never an empty/plain fallback); a fault uses
+/// continue-with-incidents and the pre-seeded <c>deploymentStatus = "failed"</c>
+/// so an internal fault never reports a silent success.</para>
+///
+/// <para><b>Deferred (P1 item 5 — release/tag):</b> no GitHub-release / git-tag
+/// activity exists anywhere in <c>apps/tamma-elsa/src</c> (a real seam is a
+/// follow-up — a <c>CreateReleaseActivity</c> wrapping the platform's GitHub
+/// client). Rather than FAKE a release, the successful-prod terminal surfaces
+/// <c>releaseStatus = "deferred"</c> + a computed <c>releaseTag</c> output and
+/// records it in the pipeline-success event, so the gap is explicit and queryable
+/// instead of silently claimed-done. P2/P3 items (post-deploy health probe, typed
+/// mediation contract, per-stage timeout, notifications) remain follow-ups.</para>
 ///
 /// Flow:
-///   Init → QA Deploy (llm-call) → Wait QA Signal → QA OK?
-///     ├─ Yes → UAT Deploy (llm-call) → Wait UAT Signal → UAT OK?
-///     │   ├─ Yes → Prod Deploy (llm-call) → Wait Prod Signal → Prod OK?
-///     │   │   ├─ Yes → Output (success) → Finish
-///     │   │   └─ No → Output (failed, stage=production) → Finish
-///     │   └─ No → Output (failed, stage=uat) → Finish
-///     └─ No → Output (failed, stage=qa) → Finish
+///   Init (status=failed default) → QA STARTED → QA Deploy (llm-call) → Extract → QA OK?
+///     ├─ Yes → QA SUCCESS → UAT STARTED → UAT Deploy → Extract → UAT OK?
+///     │   ├─ Yes → UAT SUCCESS → ProdApprovalNeeded?
+///     │   │   ├─ Yes(business) → APPROVAL_REQUESTED gate
+///     │   │   │     ├─ Approve → APPROVED → Prod STARTED → Prod Deploy → Extract → Prod OK?
+///     │   │   │     ├─ Reject  → REJECTED → SetProdFailed
+///     │   │   │     └─ Invalid → REJECTED → SetProdFailed
+///     │   │   └─ No(dev) → Prod STARTED → Prod Deploy → Extract → Prod OK?
+///     │   │         ├─ Yes → Prod SUCCESS → PIPELINE.SUCCESS (releaseStatus=deferred) → Output
+///     │   │         └─ No  → Prod FAILED → Rollback (ROLLBACK.*) → SetProdFailed
+///     │   └─ No → UAT FAILED → SetUATFailed
+///     └─ No → QA FAILED → SetQAFailed
+///   (each SetXxxFailed → PIPELINE.FAILED → Output → Finish)
 ///
-/// Inputs: repository, mergeSha, issueNumber, branchName
-/// Outputs: deploymentStatus (success/failed), completedStages (JSON array)
+/// Inputs: repository, mergeSha, issueNumber, branchName, mode, tenantId, requireProdApproval
+/// Outputs: deploymentStatus (success/failed:&lt;stage&gt;), completedStages (JSON array),
+///          releaseTag, releaseStatus (deferred), rollbackStatus
 /// </summary>
 public class DeploymentPipelineWorkflow : WorkflowBase
 {
+    /// <summary>Max re-dispatch attempts per stage before routing to the failure
+    /// terminal (FR-16: 3-retry limit, mandatory escalation, no bypass).</summary>
+    private const int MaxStageRetries = 3;
+
     protected override void Build(IWorkflowBuilder builder)
     {
         builder.Name = "Deployment Pipeline";
         builder.DefinitionId = "deployment-pipeline";
         builder.Version = WorkflowVersions.ComputedVersion;
-        builder.Description = "Deploy through QA -> UAT -> Prod with gates, releases, and tags";
+        builder.Description = "Deploy through QA -> UAT -> Prod with a fail-closed gate per stage, a Business-Mode production approval gate, rollback on prod failure, and a full DCB audit trail. Release/tag deferred (no seam).";
+
+        // Fail-closed on internal fault — a faulted activity must not halt the
+        // instance with no output. Continue-with-incidents keeps the flow alive;
+        // `deploymentStatus` is seeded to "failed" at Init so a fault that stops
+        // the flow before a terminal still yields a fail-closed status the parent
+        // cycle reads (never a silent success). Mirrors MergeApprovalWorkflow I1.
+        builder.WorkflowOptions.IncidentStrategyType = typeof(ContinueWithIncidentsStrategy);
 
         // ================================================================
         // Variables
@@ -50,11 +119,27 @@ public class DeploymentPipelineWorkflow : WorkflowBase
         var mergeSha = builder.WithVariable<string>("MergeSha", "");
         var issueNumber = builder.WithVariable<int>("IssueNumber", 0);
         var branchName = builder.WithVariable<string>("BranchName", "");
+        var mode = builder.WithVariable<string>("Mode", "");
+        var tenantId = builder.WithVariable<string>("TenantId", "");
+        var requireProdApproval = builder.WithVariable<bool>("RequireProdApproval", false);
 
-        var deploymentStatus = builder.WithVariable<string>("DeploymentStatus", "pending");
+        // Fail-closed default — overwritten only by an explicit terminal.
+        var deploymentStatus = builder.WithVariable<string>("DeploymentStatus", "failed");
         var completedStages = builder.WithVariable<string>("CompletedStages", "[]");
         var currentStage = builder.WithVariable<string>("CurrentStage", "");
         var stageResult = builder.WithVariable<string>("StageResult", "");
+        var stageError = builder.WithVariable<string>("StageError", "");
+        var rollbackStatus = builder.WithVariable<string>("RollbackStatus", "");
+        var releaseTag = builder.WithVariable<string>("ReleaseTag", "");
+
+        var decisionVar = builder.WithVariable<string>("Decision", "");
+        var feedbackVar = builder.WithVariable<string>("Feedback", "");
+        var approverVar = builder.WithVariable<string>("Approver", "");
+
+        // Per-stage retry counters (FR-16 — bounded retry + escalation).
+        var qaRetries = builder.WithVariable<int>("QaRetries", 0);
+        var uatRetries = builder.WithVariable<int>("UatRetries", 0);
+        var prodRetries = builder.WithVariable<int>("ProdRetries", 0);
 
         var llmResult = builder.WithVariable<IDictionary<string, object>?>();
 
@@ -71,7 +156,12 @@ public class DeploymentPipelineWorkflow : WorkflowBase
                 mergeSha.Set(ctx, ctx.GetInput<string>("mergeSha") ?? "");
                 issueNumber.Set(ctx, ctx.GetInput<int>("issueNumber"));
                 branchName.Set(ctx, ctx.GetInput<string>("branchName") ?? "");
+                mode.Set(ctx, ctx.GetInput<string>("mode") ?? "");
+                tenantId.Set(ctx, ctx.GetInput<string>("tenantId") ?? "");
+                requireProdApproval.Set(ctx, ctx.GetInput<bool>("requireProdApproval"));
                 completedStages.Set(ctx, "[]");
+                // Fail-closed: status stays "failed" until a terminal explicitly sets it.
+                deploymentStatus.Set(ctx, "failed");
                 return (object)repo;
             })
         };
@@ -80,45 +170,167 @@ public class DeploymentPipelineWorkflow : WorkflowBase
         // ================================================================
         // 2. QA Stage
         // ================================================================
-        var qaDeployCall = StageDeployDispatch("QADeploy", "QA Deploy", "qa",
-            repository, mergeSha, issueNumber, branchName, completedStages, llmResult);
+        var emitQaStarted = EmitDeployEvent("EmitQaStarted", "Emit QA STARTED",
+            DeployEvents.StageStarted, "qa",
+            repository, mergeSha, issueNumber, mode, tenantId, stageResult, stageError, completedStages, rollbackStatus);
+
+        var qaDeployCall = StageDeployDispatch("QADeploy", "QA Deploy", "qa", deploy: true,
+            repository, mergeSha, issueNumber, branchName, tenantId, completedStages, llmResult);
 
         var extractQaResult = ExtractStageResult("ExtractQA", "Extract QA Result",
-            stageResult, currentStage, "qa", llmResult, completedStages);
+            stageResult, currentStage, stageError, "qa", llmResult, completedStages);
 
-        var qaOk = new FlowDecision(ctx => stageResult.Get(ctx) != "failed")
+        var qaOk = new FlowDecision(ctx => stageResult.Get(ctx) == "success")
         { Id = "QAOk", Name = "QA OK?" };
         qaOk.SetDisplayText("QA OK?");
+
+        var emitQaSuccess = EmitDeployEvent("EmitQaSuccess", "Emit QA SUCCESS",
+            DeployEvents.StageSuccess, "qa",
+            repository, mergeSha, issueNumber, mode, tenantId, stageResult, stageError, completedStages, rollbackStatus);
+
+        // FR-16 — bounded QA retry. Under the cap → re-dispatch; at the cap → fail.
+        var qaRetryCheck = RetryCheck("QaRetryCheck", "QA Under Retry Cap?", qaRetries);
+        var qaIncrement = IncrementRetry("QaIncrement", "QA Retry++", qaRetries);
+        var emitQaFailed = EmitDeployEvent("EmitQaFailed", "Emit QA FAILED",
+            DeployEvents.StageFailed, "qa",
+            repository, mergeSha, issueNumber, mode, tenantId, stageResult, stageError, completedStages, rollbackStatus);
 
         // ================================================================
         // 3. UAT Stage
         // ================================================================
-        var uatDeployCall = StageDeployDispatch("UATDeploy", "UAT Deploy", "uat",
-            repository, mergeSha, issueNumber, branchName, completedStages, llmResult);
+        var emitUatStarted = EmitDeployEvent("EmitUatStarted", "Emit UAT STARTED",
+            DeployEvents.StageStarted, "uat",
+            repository, mergeSha, issueNumber, mode, tenantId, stageResult, stageError, completedStages, rollbackStatus);
+
+        var uatDeployCall = StageDeployDispatch("UATDeploy", "UAT Deploy", "uat", deploy: true,
+            repository, mergeSha, issueNumber, branchName, tenantId, completedStages, llmResult);
 
         var extractUatResult = ExtractStageResult("ExtractUAT", "Extract UAT Result",
-            stageResult, currentStage, "uat", llmResult, completedStages);
+            stageResult, currentStage, stageError, "uat", llmResult, completedStages);
 
-        var uatOk = new FlowDecision(ctx => stageResult.Get(ctx) != "failed")
+        var uatOk = new FlowDecision(ctx => stageResult.Get(ctx) == "success")
         { Id = "UATOk", Name = "UAT OK?" };
         uatOk.SetDisplayText("UAT OK?");
 
+        var emitUatSuccess = EmitDeployEvent("EmitUatSuccess", "Emit UAT SUCCESS",
+            DeployEvents.StageSuccess, "uat",
+            repository, mergeSha, issueNumber, mode, tenantId, stageResult, stageError, completedStages, rollbackStatus);
+
+        var uatRetryCheck = RetryCheck("UatRetryCheck", "UAT Under Retry Cap?", uatRetries);
+        var uatIncrement = IncrementRetry("UatIncrement", "UAT Retry++", uatRetries);
+        var emitUatFailed = EmitDeployEvent("EmitUatFailed", "Emit UAT FAILED",
+            DeployEvents.StageFailed, "uat",
+            repository, mergeSha, issueNumber, mode, tenantId, stageResult, stageError, completedStages, rollbackStatus);
+
         // ================================================================
-        // 4. Production Stage
+        // 4. Production approval gate (P0 item 3) — Business Mode (or an explicit
+        //    requireProdApproval flag) requires a human checkpoint before prod.
         // ================================================================
-        var prodDeployCall = StageDeployDispatch("ProdDeploy", "Prod Deploy", "production",
-            repository, mergeSha, issueNumber, branchName, completedStages, llmResult);
+        var prodApprovalNeeded = new FlowDecision(ctx =>
+            string.Equals(mode.Get(ctx)?.Trim(), "business", StringComparison.OrdinalIgnoreCase)
+            || requireProdApproval.Get(ctx))
+        { Id = "ProdApprovalNeeded", Name = "Prod Approval Needed?" };
+        prodApprovalNeeded.SetDisplayText("Prod Approval Needed?");
+
+        var waitProdApproval = new WaitForDeploymentApprovalActivity
+        {
+            Id = "WaitProdApproval", Name = "Wait Prod Approval",
+            IssueNumber = new Input<int>(ctx => issueNumber.Get(ctx)),
+            MergeSha = new Input<string?>(ctx => mergeSha.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
+            Repository = new Input<string?>(ctx => repository.Get(ctx)),
+            Decision = new Output<string?>(decisionVar),
+            Feedback = new Output<string?>(feedbackVar),
+            Approver = new Output<string?>(approverVar),
+        };
+        waitProdApproval.SetDisplayText("Wait Prod Approval");
+
+        var emitProdApproved = EmitDeployEvent("EmitProdApproved", "Emit PRODUCTION.APPROVED",
+            DeployEvents.ProductionApproved, "production",
+            repository, mergeSha, issueNumber, mode, tenantId, stageResult, stageError, completedStages, rollbackStatus,
+            approver: approverVar, feedback: feedbackVar);
+
+        var emitProdRejected = EmitDeployEvent("EmitProdRejected", "Emit PRODUCTION.REJECTED",
+            DeployEvents.ProductionRejected, "production",
+            repository, mergeSha, issueNumber, mode, tenantId, stageResult, stageError, completedStages, rollbackStatus,
+            approver: approverVar, feedback: feedbackVar);
+
+        // ================================================================
+        // 5. Production Stage
+        // ================================================================
+        var emitProdStarted = EmitDeployEvent("EmitProdStarted", "Emit PROD STARTED",
+            DeployEvents.StageStarted, "production",
+            repository, mergeSha, issueNumber, mode, tenantId, stageResult, stageError, completedStages, rollbackStatus);
+
+        var prodDeployCall = StageDeployDispatch("ProdDeploy", "Prod Deploy", "production", deploy: true,
+            repository, mergeSha, issueNumber, branchName, tenantId, completedStages, llmResult);
 
         var extractProdResult = ExtractStageResult("ExtractProd", "Extract Prod Result",
-            stageResult, currentStage, "production", llmResult, completedStages);
+            stageResult, currentStage, stageError, "production", llmResult, completedStages);
 
-        var prodOk = new FlowDecision(ctx => stageResult.Get(ctx) != "failed")
+        var prodOk = new FlowDecision(ctx => stageResult.Get(ctx) == "success")
         { Id = "ProdOk", Name = "Prod OK?" };
         prodOk.SetDisplayText("Prod OK?");
 
+        var emitProdSuccess = EmitDeployEvent("EmitProdSuccess", "Emit PROD SUCCESS",
+            DeployEvents.StageSuccess, "production",
+            repository, mergeSha, issueNumber, mode, tenantId, stageResult, stageError, completedStages, rollbackStatus);
+
+        var prodRetryCheck = RetryCheck("ProdRetryCheck", "Prod Under Retry Cap?", prodRetries);
+        var prodIncrement = IncrementRetry("ProdIncrement", "Prod Retry++", prodRetries);
+        var emitProdFailed = EmitDeployEvent("EmitProdFailed", "Emit PROD FAILED",
+            DeployEvents.StageFailed, "production",
+            repository, mergeSha, issueNumber, mode, tenantId, stageResult, stageError, completedStages, rollbackStatus);
+
         // ================================================================
-        // 5. Success Output
+        // 6. Rollback on production failure (P0 item 4)
         // ================================================================
+        var emitRollbackStarted = EmitDeployEvent("EmitRollbackStarted", "Emit ROLLBACK.STARTED",
+            DeployEvents.RollbackStarted, "production",
+            repository, mergeSha, issueNumber, mode, tenantId, stageResult, stageError, completedStages, rollbackStatus);
+
+        // Rollback dispatches the mediated llm-call with the `rollback` action —
+        // it does NOT call a provider directly (mediation rule). Reverts prod to
+        // the previous release.
+        var rollbackCall = StageDeployDispatch("RollbackProd", "Rollback Prod", "production", deploy: false,
+            repository, mergeSha, issueNumber, branchName, tenantId, completedStages, llmResult);
+
+        var extractRollbackResult = ExtractRollbackResult("ExtractRollback", "Extract Rollback Result",
+            rollbackStatus, llmResult);
+
+        var rollbackOk = new FlowDecision(ctx => rollbackStatus.Get(ctx) == "success")
+        { Id = "RollbackOk", Name = "Rollback OK?" };
+        rollbackOk.SetDisplayText("Rollback OK?");
+
+        var emitRollbackSuccess = EmitDeployEvent("EmitRollbackSuccess", "Emit ROLLBACK.SUCCESS",
+            DeployEvents.RollbackSuccess, "production",
+            repository, mergeSha, issueNumber, mode, tenantId, stageResult, stageError, completedStages, rollbackStatus);
+
+        var emitRollbackFailed = EmitDeployEvent("EmitRollbackFailed", "Emit ROLLBACK.FAILED",
+            DeployEvents.RollbackFailed, "production",
+            repository, mergeSha, issueNumber, mode, tenantId, stageResult, stageError, completedStages, rollbackStatus);
+
+        // ================================================================
+        // 7. Success terminal — compute the (deferred) release tag, emit
+        //    PIPELINE.SUCCESS, set status=success.
+        // ================================================================
+        var setReleaseTag = new SetVariable
+        {
+            Id = "SetReleaseTag", Name = "Compute Release Tag",
+            Variable = releaseTag,
+            // P1 item 5 (deferred): no release/tag activity exists; we compute a
+            // candidate tag from the merged SHA so the audit row and output carry
+            // it, but DO NOT cut a real release (releaseStatus=deferred). Never a
+            // fake "release created".
+            Value = new Input<object?>(ctx =>
+            {
+                var sha = mergeSha.Get(ctx) ?? "";
+                var shortSha = sha.Length >= 7 ? sha[..7] : sha;
+                return (object)(string.IsNullOrEmpty(shortSha) ? "" : $"deploy-{shortSha}");
+            })
+        };
+        setReleaseTag.SetDisplayText("Compute Release Tag");
+
         var setSuccess = new SetVariable
         {
             Id = "SetSuccess", Name = "Set Success",
@@ -127,15 +339,24 @@ public class DeploymentPipelineWorkflow : WorkflowBase
         };
         setSuccess.SetDisplayText("Set Success");
 
+        var emitPipelineSuccess = EmitDeployEvent("EmitPipelineSuccess", "Emit PIPELINE.SUCCESS",
+            DeployEvents.PipelineSuccess, /*stage*/ "",
+            repository, mergeSha, issueNumber, mode, tenantId, stageResult, stageError, completedStages, rollbackStatus,
+            releaseTag: releaseTag);
+
         // ================================================================
-        // 6. Failure Outputs (one per stage)
+        // 8. Failure terminals (one per stage) → PIPELINE.FAILED → outputs
         // ================================================================
         var setQaFailed = CreateFailureNode("SetQAFailed", "QA Failed", deploymentStatus, "qa");
         var setUatFailed = CreateFailureNode("SetUATFailed", "UAT Failed", deploymentStatus, "uat");
         var setProdFailed = CreateFailureNode("SetProdFailed", "Prod Failed", deploymentStatus, "production");
 
+        var emitPipelineFailed = EmitDeployEvent("EmitPipelineFailed", "Emit PIPELINE.FAILED",
+            DeployEvents.PipelineFailed, /*stage*/ "",
+            repository, mergeSha, issueNumber, mode, tenantId, stageResult, stageError, completedStages, rollbackStatus);
+
         // ================================================================
-        // 7. Set Outputs
+        // 9. Set Outputs
         // ================================================================
         var setOutputs = new Sequence
         {
@@ -146,6 +367,13 @@ public class DeploymentPipelineWorkflow : WorkflowBase
                     { Id = "OutStatus", OutputName = new("deploymentStatus"), OutputValue = new(ctx => (object)deploymentStatus.Get(ctx)) },
                 new SetOutput
                     { Id = "OutStages", OutputName = new("completedStages"), OutputValue = new(ctx => (object)completedStages.Get(ctx)) },
+                new SetOutput
+                    { Id = "OutReleaseTag", OutputName = new("releaseTag"), OutputValue = new(ctx => (object)releaseTag.Get(ctx)) },
+                // P1 item 5 deferral surfaced explicitly so the gap is queryable.
+                new SetOutput
+                    { Id = "OutReleaseStatus", OutputName = new("releaseStatus"), OutputValue = new(_ => (object)"deferred") },
+                new SetOutput
+                    { Id = "OutRollbackStatus", OutputName = new("rollbackStatus"), OutputValue = new(ctx => (object)rollbackStatus.Get(ctx)) },
             }
         };
         setOutputs.SetDisplayText("Set Outputs");
@@ -163,46 +391,99 @@ public class DeploymentPipelineWorkflow : WorkflowBase
             Activities =
             {
                 init,
-                qaDeployCall, extractQaResult, qaOk,
-                uatDeployCall, extractUatResult, uatOk,
-                prodDeployCall, extractProdResult, prodOk,
-                setSuccess,
-                setQaFailed, setUatFailed, setProdFailed,
+                // QA
+                emitQaStarted, qaDeployCall, extractQaResult, qaOk, emitQaSuccess,
+                qaRetryCheck, qaIncrement, emitQaFailed,
+                // UAT
+                emitUatStarted, uatDeployCall, extractUatResult, uatOk, emitUatSuccess,
+                uatRetryCheck, uatIncrement, emitUatFailed,
+                // Prod approval gate
+                prodApprovalNeeded, waitProdApproval, emitProdApproved, emitProdRejected,
+                // Prod
+                emitProdStarted, prodDeployCall, extractProdResult, prodOk, emitProdSuccess,
+                prodRetryCheck, prodIncrement, emitProdFailed,
+                // Rollback
+                emitRollbackStarted, rollbackCall, extractRollbackResult, rollbackOk,
+                emitRollbackSuccess, emitRollbackFailed,
+                // Success terminal
+                setReleaseTag, setSuccess, emitPipelineSuccess,
+                // Failure terminals
+                setQaFailed, setUatFailed, setProdFailed, emitPipelineFailed,
                 setOutputs, finish,
             },
             Connections =
             {
-                // Init → QA
-                Connect(init, qaDeployCall),
+                // ── Init → QA ──
+                Connect(init, emitQaStarted),
+                Connect(emitQaStarted, qaDeployCall),
                 Connect(qaDeployCall, extractQaResult),
                 Connect(extractQaResult, qaOk),
+                // QA OK → emit success → UAT
+                ConnectOutcome(qaOk, "True", emitQaSuccess),
+                Connect(emitQaSuccess, emitUatStarted),
+                // QA not-OK → bounded retry: under cap → increment → re-dispatch;
+                //            at cap → loud FAILED → terminal
+                ConnectOutcome(qaOk, "False", qaRetryCheck),
+                ConnectOutcome(qaRetryCheck, "True", qaIncrement),
+                Connect(qaIncrement, emitQaStarted),         // re-run QA
+                ConnectOutcome(qaRetryCheck, "False", emitQaFailed),
+                Connect(emitQaFailed, setQaFailed),
+                Connect(setQaFailed, emitPipelineFailed),
 
-                // QA OK → UAT
-                ConnectOutcome(qaOk, "True", uatDeployCall),
-                // QA Failed → output failure
-                ConnectOutcome(qaOk, "False", setQaFailed),
-                Connect(setQaFailed, setOutputs),
-
-                // UAT
+                // ── UAT ──
+                Connect(emitUatStarted, uatDeployCall),
                 Connect(uatDeployCall, extractUatResult),
                 Connect(extractUatResult, uatOk),
+                ConnectOutcome(uatOk, "True", emitUatSuccess),
+                Connect(emitUatSuccess, prodApprovalNeeded),
+                ConnectOutcome(uatOk, "False", uatRetryCheck),
+                ConnectOutcome(uatRetryCheck, "True", uatIncrement),
+                Connect(uatIncrement, emitUatStarted),       // re-run UAT
+                ConnectOutcome(uatRetryCheck, "False", emitUatFailed),
+                Connect(emitUatFailed, setUatFailed),
+                Connect(setUatFailed, emitPipelineFailed),
 
-                // UAT OK → Prod
-                ConnectOutcome(uatOk, "True", prodDeployCall),
-                // UAT Failed → output failure
-                ConnectOutcome(uatOk, "False", setUatFailed),
-                Connect(setUatFailed, setOutputs),
+                // ── Production approval gate (P0 item 3) ──
+                // Business mode (or requireProdApproval) → human gate; dev → straight to prod.
+                ConnectOutcome(prodApprovalNeeded, "True", waitProdApproval),
+                ConnectOutcome(prodApprovalNeeded, "False", emitProdStarted),
+                // Gate outcomes — Approve → prod; Reject/Invalid → loud reject → prod-failure
+                ConnectOutcome(waitProdApproval, "Approve", emitProdApproved),
+                Connect(emitProdApproved, emitProdStarted),
+                ConnectOutcome(waitProdApproval, "Reject", emitProdRejected),
+                ConnectOutcome(waitProdApproval, "Invalid", emitProdRejected),
+                Connect(emitProdRejected, setProdFailed),
 
-                // Prod
+                // ── Production deploy ──
+                Connect(emitProdStarted, prodDeployCall),
                 Connect(prodDeployCall, extractProdResult),
                 Connect(extractProdResult, prodOk),
+                ConnectOutcome(prodOk, "True", emitProdSuccess),
+                Connect(emitProdSuccess, setReleaseTag),
+                // Prod not-OK → bounded retry; at cap → FAILED → rollback → terminal
+                ConnectOutcome(prodOk, "False", prodRetryCheck),
+                ConnectOutcome(prodRetryCheck, "True", prodIncrement),
+                Connect(prodIncrement, emitProdStarted),     // re-run prod
+                ConnectOutcome(prodRetryCheck, "False", emitProdFailed),
 
-                // Prod OK → success
-                ConnectOutcome(prodOk, "True", setSuccess),
-                Connect(setSuccess, setOutputs),
-                // Prod Failed → output failure
-                ConnectOutcome(prodOk, "False", setProdFailed),
-                Connect(setProdFailed, setOutputs),
+                // ── Rollback on prod failure (P0 item 4) ──
+                Connect(emitProdFailed, emitRollbackStarted),
+                Connect(emitRollbackStarted, rollbackCall),
+                Connect(rollbackCall, extractRollbackResult),
+                Connect(extractRollbackResult, rollbackOk),
+                ConnectOutcome(rollbackOk, "True", emitRollbackSuccess),
+                Connect(emitRollbackSuccess, setProdFailed),
+                ConnectOutcome(rollbackOk, "False", emitRollbackFailed),
+                Connect(emitRollbackFailed, setProdFailed),
+
+                // ── Success terminal ──
+                Connect(setReleaseTag, setSuccess),
+                Connect(setSuccess, emitPipelineSuccess),
+                Connect(emitPipelineSuccess, setOutputs),
+
+                // ── Failure terminals → PIPELINE.FAILED → outputs ──
+                Connect(setProdFailed, emitPipelineFailed),
+                Connect(emitPipelineFailed, setOutputs),
 
                 // Outputs → finish
                 Connect(setOutputs, finish),
@@ -214,11 +495,17 @@ public class DeploymentPipelineWorkflow : WorkflowBase
     // Helpers
     // ================================================================
 
+    /// <summary>
+    /// A stage deploy/rollback dispatch through the mediated <c>llm-call</c>
+    /// endpoint (NEVER a direct provider call). <paramref name="deploy"/> selects
+    /// the <c>deploy</c> action; <c>false</c> selects the <c>rollback</c> action
+    /// for the prod-failure rollback branch.
+    /// </summary>
     private static DispatchWorkflow StageDeployDispatch(
-        string id, string displayName, string stage,
+        string id, string displayName, string stage, bool deploy,
         Variable<string> repository, Variable<string> mergeSha,
         Variable<int> issueNumber, Variable<string> branchName,
-        Variable<string> completedStages,
+        Variable<string> tenantId, Variable<string> completedStages,
         Variable<IDictionary<string, object>?> result)
     {
         var dispatch = new DispatchWorkflow
@@ -228,10 +515,12 @@ public class DeploymentPipelineWorkflow : WorkflowBase
             Input = new(ctx => new Dictionary<string, object>
             {
                 ["role"] = AgentRole.Devops.ToWire(),
-                ["action"] = AgentAction.Deploy.ToWire(),
+                ["action"] = (deploy ? AgentAction.Deploy : AgentAction.Rollback).ToWire(),
+                ["tenantId"] = tenantId.Get(ctx),
                 ["variables"] = new Dictionary<string, object>
                 {
                     ["stage"] = stage,
+                    ["operation"] = deploy ? "deploy" : "rollback",
                     ["repository"] = repository.Get(ctx),
                     ["mergeSha"] = mergeSha.Get(ctx),
                     ["issueNumber"] = issueNumber.Get(ctx),
@@ -247,9 +536,18 @@ public class DeploymentPipelineWorkflow : WorkflowBase
         return dispatch;
     }
 
+    /// <summary>
+    /// Parse the mediated deploy result into a stage status — <b>fail-closed</b>
+    /// (P0 item 1). Defaults to <c>failed</c> and only sets <c>success</c> when the
+    /// result is present AND carries an explicit <c>status:"success"</c>. A null /
+    /// missing / empty / non-JSON / parse-error result stays <c>failed</c> and the
+    /// reason is captured into <paramref name="stageError"/>. Only an explicit
+    /// success appends the stage to <c>completedStages</c>.
+    /// </summary>
     private static SetVariable ExtractStageResult(
         string id, string displayName,
-        Variable<string> stageResult, Variable<string> currentStage, string stageName,
+        Variable<string> stageResult, Variable<string> currentStage, Variable<string> stageError,
+        string stageName,
         Variable<IDictionary<string, object>?> llmResult,
         Variable<string> completedStages)
     {
@@ -260,37 +558,14 @@ public class DeploymentPipelineWorkflow : WorkflowBase
             Value = new Input<object?>(ctx =>
             {
                 currentStage.Set(ctx, stageName);
-                var result = llmResult.Get(ctx);
-                var status = "success"; // optimistic
+                var (status, error) = ParseStageStatus(llmResult.Get(ctx));
+                stageError.Set(ctx, error);
 
-                if (result != null && result.TryGetValue("llmResponse", out var r))
+                // Only an EXPLICIT success promotes / appends the stage.
+                if (status == "success")
                 {
-                    var output = r?.ToString() ?? "";
-                    try
-                    {
-                        var jsonStart = output.IndexOf('{');
-                        var jsonEnd = output.LastIndexOf('}');
-                        if (jsonStart >= 0 && jsonEnd > jsonStart)
-                        {
-                            var doc = JsonDocument.Parse(output[jsonStart..(jsonEnd + 1)]);
-                            if (doc.RootElement.TryGetProperty("status", out var s))
-                                status = s.GetString() ?? "success";
-                        }
-                    }
-                    catch { /* use optimistic default */ }
-                }
-
-                // Append to completed stages
-                if (status != "failed")
-                {
-                    var stages = new List<string>();
-                    try
-                    {
-                        var existing = JsonSerializer.Deserialize<List<string>>(completedStages.Get(ctx));
-                        if (existing != null) stages = existing;
-                    }
-                    catch { /* start fresh */ }
-                    stages.Add(stageName);
+                    var stages = ParseCompletedStages(completedStages.Get(ctx));
+                    if (!stages.Contains(stageName)) stages.Add(stageName);
                     completedStages.Set(ctx, JsonSerializer.Serialize(stages));
                 }
 
@@ -298,6 +573,107 @@ public class DeploymentPipelineWorkflow : WorkflowBase
             })
         };
         sv.SetDisplayText(displayName);
+        return sv;
+    }
+
+    /// <summary>
+    /// Fail-closed parse of the mediated deploy/rollback result. Returns
+    /// (<c>"success"</c>, "") only on an explicit <c>status:"success"</c>;
+    /// otherwise (<c>"failed"</c>, reason). Pure — exposed for unit testing the
+    /// silent-false-success regression (item 1 / test 13).
+    /// </summary>
+    public static (string Status, string Error) ParseStageStatus(IDictionary<string, object>? result)
+    {
+        if (result == null)
+            return ("failed", "no result from deploy dispatch (null)");
+        if (!result.TryGetValue("llmResponse", out var r))
+            return ("failed", "deploy result missing llmResponse field");
+
+        var output = r?.ToString() ?? "";
+        if (string.IsNullOrWhiteSpace(output))
+            return ("failed", "empty deploy response");
+
+        try
+        {
+            var jsonStart = output.IndexOf('{');
+            var jsonEnd = output.LastIndexOf('}');
+            if (jsonStart < 0 || jsonEnd <= jsonStart)
+                return ("failed", "deploy response is not parseable JSON");
+
+            using var doc = JsonDocument.Parse(output[jsonStart..(jsonEnd + 1)]);
+            if (!doc.RootElement.TryGetProperty("status", out var s))
+                return ("failed", "deploy response has no status field");
+
+            var statusValue = s.GetString();
+            // Fail-closed: ONLY an explicit "success" promotes. "failed" /
+            // anything-else / null is a failure.
+            return string.Equals(statusValue, "success", StringComparison.OrdinalIgnoreCase)
+                ? ("success", "")
+                : ("failed", $"deploy reported status='{statusValue ?? "<null>"}'");
+        }
+        catch (JsonException ex)
+        {
+            return ("failed", $"deploy response JSON parse error: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Fail-closed parse of the rollback dispatch result into a rollback status.
+    /// Same contract as <see cref="ParseStageStatus"/> — only an explicit
+    /// <c>status:"success"</c> is a successful rollback.
+    /// </summary>
+    private static SetVariable ExtractRollbackResult(
+        string id, string displayName,
+        Variable<string> rollbackStatus,
+        Variable<IDictionary<string, object>?> llmResult)
+    {
+        var sv = new SetVariable
+        {
+            Id = id, Name = displayName,
+            Variable = rollbackStatus,
+            Value = new Input<object?>(ctx =>
+            {
+                var (status, _) = ParseStageStatus(llmResult.Get(ctx));
+                return (object)status;
+            })
+        };
+        sv.SetDisplayText(displayName);
+        return sv;
+    }
+
+    /// <summary>Deserialize the completed-stages JSON array; empty list on error.</summary>
+    private static List<string> ParseCompletedStages(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return new List<string>();
+        try
+        {
+            return JsonSerializer.Deserialize<List<string>>(json) ?? new List<string>();
+        }
+        catch
+        {
+            return new List<string>();
+        }
+    }
+
+    /// <summary>A <c>FlowDecision</c> True when the stage is still under the retry
+    /// cap (FR-16 — bounded retry, then escalate).</summary>
+    private static FlowDecision RetryCheck(string id, string name, Variable<int> retries)
+    {
+        var fd = new FlowDecision(ctx => retries.Get(ctx) < MaxStageRetries) { Id = id, Name = name };
+        fd.SetDisplayText(name);
+        return fd;
+    }
+
+    /// <summary>Increment a stage retry counter before re-dispatching.</summary>
+    private static SetVariable IncrementRetry(string id, string name, Variable<int> retries)
+    {
+        var sv = new SetVariable
+        {
+            Id = id, Name = name,
+            Variable = retries,
+            Value = new Input<object?>(ctx => (object)(retries.Get(ctx) + 1)),
+        };
+        sv.SetDisplayText(name);
         return sv;
     }
 
@@ -313,6 +689,56 @@ public class DeploymentPipelineWorkflow : WorkflowBase
         };
         sv.SetDisplayText(displayName);
         return sv;
+    }
+
+    /// <summary>
+    /// A <c>DEPLOY.*</c> event-emit node. Threads the issue/repo/sha/stage/mode +
+    /// tenant tags and serialises the audit data (status, reason, completedStages,
+    /// rollbackStatus, optional approver/feedback/releaseTag) into the
+    /// <c>DataJson</c> input so the durable drain persists it.
+    /// </summary>
+    private static EmitDeploymentEventActivity EmitDeployEvent(
+        string id, string label, string eventType, string stage,
+        Variable<string> repository, Variable<string> mergeSha, Variable<int> issueNumber,
+        Variable<string> mode, Variable<string> tenantId,
+        Variable<string> stageResult, Variable<string> stageError,
+        Variable<string> completedStages, Variable<string> rollbackStatus,
+        Variable<string>? approver = null, Variable<string>? feedback = null,
+        Variable<string>? releaseTag = null)
+    {
+        var emit = new EmitDeploymentEventActivity
+        {
+            Id = id, Name = label,
+            EventType = new Input<string>(_ => eventType),
+            IssueNumber = new Input<int>(ctx => issueNumber.Get(ctx)),
+            Repository = new Input<string?>(ctx => repository.Get(ctx)),
+            MergeSha = new Input<string?>(ctx => mergeSha.Get(ctx)),
+            Stage = new Input<string?>(_ => stage),
+            Mode = new Input<string?>(ctx => mode.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
+            DataJson = new Input<string?>(ctx =>
+            {
+                var data = new Dictionary<string, object?>
+                {
+                    ["status"] = stageResult.Get(ctx),
+                    ["completedStages"] = completedStages.Get(ctx),
+                };
+                var err = stageError.Get(ctx);
+                if (!string.IsNullOrEmpty(err)) data["reason"] = err;
+                var rb = rollbackStatus.Get(ctx);
+                if (!string.IsNullOrEmpty(rb)) data["rollbackStatus"] = rb;
+                if (approver != null) data["approver"] = approver.Get(ctx);
+                if (feedback != null) data["feedback"] = feedback.Get(ctx);
+                if (releaseTag != null)
+                {
+                    data["releaseTag"] = releaseTag.Get(ctx);
+                    data["releaseStatus"] = "deferred"; // P1 item 5 — no real release seam yet.
+                }
+                return JsonSerializer.Serialize(data);
+            }),
+        };
+        emit.SetDisplayText(label);
+        return emit;
     }
 
     private static FlowConnection Connect(IActivity source, IActivity target)

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DeploymentPipelineWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DeploymentPipelineWorkflow.cs
@@ -285,9 +285,12 @@ public class DeploymentPipelineWorkflow : WorkflowBase
         // ================================================================
         // 6. Rollback on production failure (P0 item 4)
         // ================================================================
+        // Rollback emits source their `status` from rollbackStatus (NOT stageResult,
+        // which in this branch is still the stale prod "failed"). isRollback=true.
         var emitRollbackStarted = EmitDeployEvent("EmitRollbackStarted", "Emit ROLLBACK.STARTED",
             DeployEvents.RollbackStarted, "production",
-            repository, mergeSha, issueNumber, mode, tenantId, stageResult, stageError, completedStages, rollbackStatus);
+            repository, mergeSha, issueNumber, mode, tenantId, stageResult, stageError, completedStages, rollbackStatus,
+            isRollback: true);
 
         // Rollback dispatches the mediated llm-call with the `rollback` action —
         // it does NOT call a provider directly (mediation rule). Reverts prod to
@@ -304,11 +307,13 @@ public class DeploymentPipelineWorkflow : WorkflowBase
 
         var emitRollbackSuccess = EmitDeployEvent("EmitRollbackSuccess", "Emit ROLLBACK.SUCCESS",
             DeployEvents.RollbackSuccess, "production",
-            repository, mergeSha, issueNumber, mode, tenantId, stageResult, stageError, completedStages, rollbackStatus);
+            repository, mergeSha, issueNumber, mode, tenantId, stageResult, stageError, completedStages, rollbackStatus,
+            isRollback: true);
 
         var emitRollbackFailed = EmitDeployEvent("EmitRollbackFailed", "Emit ROLLBACK.FAILED",
             DeployEvents.RollbackFailed, "production",
-            repository, mergeSha, issueNumber, mode, tenantId, stageResult, stageError, completedStages, rollbackStatus);
+            repository, mergeSha, issueNumber, mode, tenantId, stageResult, stageError, completedStages, rollbackStatus,
+            isRollback: true);
 
         // ================================================================
         // 7. Success terminal — compute the (deferred) release tag, emit
@@ -618,6 +623,25 @@ public class DeploymentPipelineWorkflow : WorkflowBase
     }
 
     /// <summary>
+    /// Pick the <c>status</c> value an emit node writes into its audit payload.
+    /// For a rollback emit, source it from <paramref name="rollbackStatus"/> (the
+    /// rollback's own outcome) — an empty value means the rollback hasn't run yet
+    /// (the ROLLBACK.STARTED row) so it reads <c>"started"</c>. For a stage emit,
+    /// source it from <paramref name="stageResult"/>.
+    ///
+    /// <para>Fixes the MINOR audit-data bug (2026-06-22): the rollback branch ran
+    /// with <c>stageResult == "failed"</c> (the stale prod failure), so
+    /// <c>DEPLOY.ROLLBACK.SUCCESS</c> was carrying <c>status:"failed"</c>. Pure +
+    /// exposed for unit testing.</para>
+    /// </summary>
+    public static string SelectEmitStatus(bool isRollback, string? stageResult, string? rollbackStatus)
+    {
+        if (!isRollback)
+            return stageResult ?? "";
+        return string.IsNullOrEmpty(rollbackStatus) ? "started" : rollbackStatus;
+    }
+
+    /// <summary>
     /// Fail-closed parse of the rollback dispatch result into a rollback status.
     /// Same contract as <see cref="ParseStageStatus"/> — only an explicit
     /// <c>status:"success"</c> is a successful rollback.
@@ -696,6 +720,12 @@ public class DeploymentPipelineWorkflow : WorkflowBase
     /// tenant tags and serialises the audit data (status, reason, completedStages,
     /// rollbackStatus, optional approver/feedback/releaseTag) into the
     /// <c>DataJson</c> input so the durable drain persists it.
+    ///
+    /// <para><paramref name="isRollback"/> sources the payload <c>status</c> from
+    /// <c>rollbackStatus</c> (the rollback's own outcome) instead of
+    /// <c>stageResult</c> — which in the rollback branch is still the STALE prod
+    /// "failed". Without this, <c>DEPLOY.ROLLBACK.SUCCESS</c> would carry
+    /// <c>status:"failed"</c> (MINOR audit-data bug, 2026-06-22).</para>
     /// </summary>
     private static EmitDeploymentEventActivity EmitDeployEvent(
         string id, string label, string eventType, string stage,
@@ -704,7 +734,7 @@ public class DeploymentPipelineWorkflow : WorkflowBase
         Variable<string> stageResult, Variable<string> stageError,
         Variable<string> completedStages, Variable<string> rollbackStatus,
         Variable<string>? approver = null, Variable<string>? feedback = null,
-        Variable<string>? releaseTag = null)
+        Variable<string>? releaseTag = null, bool isRollback = false)
     {
         var emit = new EmitDeploymentEventActivity
         {
@@ -718,9 +748,12 @@ public class DeploymentPipelineWorkflow : WorkflowBase
             TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
             DataJson = new Input<string?>(ctx =>
             {
+                // Rollback emits report the rollback's own status (started rows have
+                // no rollbackStatus yet → "started"); stage emits report stageResult.
+                var status = SelectEmitStatus(isRollback, stageResult.Get(ctx), rollbackStatus.Get(ctx));
                 var data = new Dictionary<string, object?>
                 {
-                    ["status"] = stageResult.Get(ctx),
+                    ["status"] = status,
                     ["completedStages"] = completedStages.Get(ctx),
                 };
                 var err = stageError.Get(ctx);

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs
@@ -55,6 +55,10 @@ public class SingleIssueCycleWorkflow : WorkflowBase
         // production approval gate (Business Mode requires human approval before
         // prod). Read from input; defaults to dev when absent.
         var mode = builder.WithVariable<string>("Mode", "");
+        // Operator force-flag for the prod approval gate (Deployment:RequireProdApproval).
+        // Threaded from DispatchCycleActivity so an operator can force the gate even
+        // in single-user/dev mode. Read from input; defaults false.
+        var requireProdApproval = builder.WithVariable<bool>("RequireProdApproval", false);
 
         // Conventions (loaded from repo config)
         var conventions = builder.WithVariable<string>("Conventions", "");
@@ -102,6 +106,7 @@ public class SingleIssueCycleWorkflow : WorkflowBase
                 issueNumber.Set(ctx, ctx.GetInput<int>("issueNumber"));
                 tenantId.Set(ctx, ctx.GetInput<string>("tenantId") ?? "");
                 mode.Set(ctx, ctx.GetInput<string>("mode") ?? "");
+                requireProdApproval.Set(ctx, ctx.GetInput<bool>("requireProdApproval"));
                 return (object)repo;
             }),
         };
@@ -699,9 +704,11 @@ public class SingleIssueCycleWorkflow : WorkflowBase
                 ["branchName"] = branchName.Get(ctx),
                 // Thread mode + tenant so the pipeline's production approval gate
                 // is mode-aware (Business Mode → human approval) and its DCB
-                // events / bookmarks are tenant-scoped.
+                // events / bookmarks are tenant-scoped. requireProdApproval lets an
+                // operator force the gate even in dev mode.
                 ["mode"] = mode.Get(ctx),
                 ["tenantId"] = tenantId.Get(ctx),
+                ["requireProdApproval"] = requireProdApproval.Get(ctx),
             }),
             WaitForCompletion = new(true), // wait — need deployment result before reporting
             Result = new(subResult),

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs
@@ -51,6 +51,10 @@ public class SingleIssueCycleWorkflow : WorkflowBase
         var botAssignee = builder.WithVariable<string>("BotAssignee", "tamma-bot");
         var baseBranch = builder.WithVariable<string>("BaseBranch", "main");
         var tenantId = builder.WithVariable<string>("TenantId", "");
+        // Deployment mode (dev | business) — drives the deployment pipeline's
+        // production approval gate (Business Mode requires human approval before
+        // prod). Read from input; defaults to dev when absent.
+        var mode = builder.WithVariable<string>("Mode", "");
 
         // Conventions (loaded from repo config)
         var conventions = builder.WithVariable<string>("Conventions", "");
@@ -97,6 +101,7 @@ public class SingleIssueCycleWorkflow : WorkflowBase
                 baseBranch.Set(ctx, ctx.GetInput<string>("baseBranch") ?? "main");
                 issueNumber.Set(ctx, ctx.GetInput<int>("issueNumber"));
                 tenantId.Set(ctx, ctx.GetInput<string>("tenantId") ?? "");
+                mode.Set(ctx, ctx.GetInput<string>("mode") ?? "");
                 return (object)repo;
             }),
         };
@@ -692,6 +697,11 @@ public class SingleIssueCycleWorkflow : WorkflowBase
                 ["mergeSha"] = mergeSha.Get(ctx),
                 ["issueNumber"] = issueNumber.Get(ctx),
                 ["branchName"] = branchName.Get(ctx),
+                // Thread mode + tenant so the pipeline's production approval gate
+                // is mode-aware (Business Mode → human approval) and its DCB
+                // events / bookmarks are tenant-scoped.
+                ["mode"] = mode.Get(ctx),
+                ["tenantId"] = tenantId.Get(ctx),
             }),
             WaitForCompletion = new(true), // wait — need deployment result before reporting
             Result = new(subResult),

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/DeploymentActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/DeploymentActivityTests.cs
@@ -1,0 +1,195 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+
+namespace Tamma.Activities.Tests.ADL;
+
+/// <summary>
+/// Unit coverage for the deployment-pipeline gate/event pure logic (completeness
+/// audit 2026-06-22):
+///   - <c>WaitForDeploymentApprovalActivity.Normalize</c>: approve/reject map to
+///     typed outcomes; unknown/empty → <c>Invalid</c> (NEVER a silent "approve" —
+///     fail-closed before a production deploy);
+///   - the prod-approval bookmark name folds tenant + repo + SHA so it can't
+///     collide cross-tenant/cross-repo/cross-SHA;
+///   - <c>EmitDeploymentEventActivity.BuildTammaEvent</c> maps onto the durable
+///     drain event shape with the right tags, status and payload;
+///   - <c>DeployEvents.IsFailureType</c>: failed/rejected/rollback-failed are loud
+///     (error-status) rows, not false success.
+/// </summary>
+[TestFixture]
+public class DeploymentActivityTests
+{
+    // ================================================================
+    // WaitForDeploymentApprovalActivity.Normalize — fail-closed, no silent approve
+    // ================================================================
+
+    [TestCase("approve", "Approve", "approve")]
+    [TestCase("APPROVE", "Approve", "approve")]
+    [TestCase("  Approve  ", "Approve", "approve")]
+    [TestCase("reject", "Reject", "reject")]
+    [TestCase("REJECT", "Reject", "reject")]
+    public void Normalize_KnownDecisions_MapToTypedOutcomes(string input, string outcome, string token)
+    {
+        var (o, n) = WaitForDeploymentApprovalActivity.Normalize(input);
+        o.Should().Be(outcome);
+        n.Should().Be(token);
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("yes")]
+    [TestCase("ok")]
+    [TestCase("deploy")]
+    [TestCase("approv")]   // typo
+    public void Normalize_UnknownOrEmpty_IsInvalid_NotSilentApprove(string? input)
+    {
+        var (o, n) = WaitForDeploymentApprovalActivity.Normalize(input);
+        o.Should().Be("Invalid",
+            "an unknown/empty production-deploy decision must be an explicit Invalid outcome — never a silent approve");
+        n.Should().Be("invalid");
+        o.Should().NotBe("Approve");
+    }
+
+    // ================================================================
+    // Bookmark name — tenant + repo + SHA scoping (no cross-tenant collision)
+    // ================================================================
+
+    [Test]
+    public void BookmarkName_FoldsTenantRepoAndSha()
+    {
+        var name = WaitForDeploymentApprovalActivity.BookmarkName(
+            "11111111-1111-1111-1111-111111111111", "acme/app", 42, "abcdef1234");
+        name.Should().StartWith("adl-deploy-prod-approval-");
+        name.Should().Contain("42");
+        name.Should().Contain("abcdef1234");
+    }
+
+    [Test]
+    public void BookmarkName_DifferentTenant_ProducesDistinctName()
+    {
+        var a = WaitForDeploymentApprovalActivity.BookmarkName("tenant-a", "acme/app", 42, "sha1");
+        var b = WaitForDeploymentApprovalActivity.BookmarkName("tenant-b", "acme/app", 42, "sha1");
+        a.Should().NotBe(b, "two tenants on the same issue/SHA must get distinct bookmarks (no cross-tenant resume)");
+    }
+
+    [Test]
+    public void BookmarkName_DifferentSha_ProducesDistinctName()
+    {
+        var a = WaitForDeploymentApprovalActivity.BookmarkName("t", "acme/app", 42, "sha1");
+        var b = WaitForDeploymentApprovalActivity.BookmarkName("t", "acme/app", 42, "sha2");
+        a.Should().NotBe(b, "a re-deploy of a different SHA must not resume a stale gate");
+    }
+
+    [Test]
+    public void BookmarkName_MatchesEngineEndpointBuilder()
+    {
+        // Suspend-side and resume-side must compute the SAME name byte-for-byte.
+        var activitySide = WaitForDeploymentApprovalActivity.BookmarkName("t", "acme/app", 7, "deadbeef");
+        var endpointSide = Tamma.ElsaServer.Endpoints.DeploymentApprovalResumeEndpoint.BookmarkName(
+            "t", "acme/app", 7, "deadbeef");
+        endpointSide.Should().Be(activitySide);
+    }
+
+    // ================================================================
+    // DeployEvents.IsFailureType — loud audit rows
+    // ================================================================
+
+    [TestCase("DEPLOY.STAGE.FAILED", true)]
+    [TestCase("DEPLOY.PIPELINE.FAILED", true)]
+    [TestCase("DEPLOY.PRODUCTION.REJECTED", true)]
+    [TestCase("DEPLOY.ROLLBACK.FAILED", true)]
+    [TestCase("DEPLOY.STAGE.STARTED", false)]
+    [TestCase("DEPLOY.STAGE.SUCCESS", false)]
+    [TestCase("DEPLOY.PIPELINE.SUCCESS", false)]
+    [TestCase("DEPLOY.PRODUCTION.APPROVED", false)]
+    [TestCase("DEPLOY.PRODUCTION.APPROVAL_REQUESTED", false)]
+    [TestCase("DEPLOY.ROLLBACK.STARTED", false)]
+    [TestCase("DEPLOY.ROLLBACK.SUCCESS", false)]
+    public void IsFailureType_FlagsFailedAndRejectedRowsLoud(string type, bool isFailure)
+    {
+        DeployEvents.IsFailureType(type).Should().Be(isFailure);
+    }
+
+    // ================================================================
+    // EmitDeploymentEventActivity.BuildTammaEvent — DCB mapping
+    // ================================================================
+
+    [Test]
+    public void BuildTammaEvent_StageStarted_SetsSuccessStatusTagsAndData()
+    {
+        var data = new Dictionary<string, object?> { ["status"] = "started" };
+        var evt = EmitDeploymentEventActivity.BuildTammaEvent(
+            DeployEvents.StageStarted, issueNumber: 12, repository: "acme/app",
+            mergeSha: "abc1234", stage: "qa", mode: "business", tenantId: null, data: data);
+
+        evt.EventType.Should().Be("DEPLOY.STAGE.STARTED");
+        evt.Status.Should().Be("success");
+        evt.Tags.Should().NotBeNull();
+        evt.Tags!["issueId"].Should().Be("12");
+        evt.Tags["issueNumber"].Should().Be("12");
+        evt.Tags["repository"].Should().Be("acme/app");
+        evt.Tags["mergeSha"].Should().Be("abc1234");
+        evt.Tags["stage"].Should().Be("qa");
+        evt.Tags["mode"].Should().Be("business");
+        evt.Tags.Should().NotContainKey("tenantId");
+        evt.Data["status"].Should().Be("started");
+    }
+
+    [Test]
+    public void BuildTammaEvent_StageFailed_SetsErrorStatus()
+    {
+        var evt = EmitDeploymentEventActivity.BuildTammaEvent(
+            DeployEvents.StageFailed, issueNumber: 7, repository: "acme/app",
+            mergeSha: "", stage: "production", mode: "", tenantId: null, data: null);
+
+        evt.EventType.Should().Be("DEPLOY.STAGE.FAILED");
+        evt.Status.Should().Be("error", "a failed deploy stage is a loud audit row, not a false success");
+        // Empty repo/sha/mode segments are not stamped as tags.
+        evt.Tags!.Should().NotContainKey("mergeSha");
+        evt.Tags.Should().NotContainKey("mode");
+    }
+
+    [Test]
+    public void BuildTammaEvent_ProductionRejected_SetsErrorStatus()
+    {
+        var evt = EmitDeploymentEventActivity.BuildTammaEvent(
+            DeployEvents.ProductionRejected, issueNumber: 9, repository: "acme/app",
+            mergeSha: "sha", stage: "production", mode: "business", tenantId: null, data: null);
+        evt.Status.Should().Be("error", "a rejected production deploy is a loud row, never a silent promote");
+    }
+
+    [Test]
+    public void BuildTammaEvent_WithTenant_StampsTenantTag()
+    {
+        var tenant = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var evt = EmitDeploymentEventActivity.BuildTammaEvent(
+            DeployEvents.PipelineSuccess, issueNumber: 1, repository: "acme/app",
+            mergeSha: "sha", stage: "", mode: "", tenantId: tenant, data: null);
+        evt.Tags!["tenantId"].Should().Be(tenant.ToString("D"));
+        // pipeline-level events carry no stage tag.
+        evt.Tags.Should().NotContainKey("stage");
+    }
+
+    [Test]
+    public void ParseData_RoundTripsJson_AndIsNullOnGarbage()
+    {
+        var parsed = EmitDeploymentEventActivity.ParseData("{\"status\":\"success\",\"reason\":\"\"}");
+        parsed.Should().NotBeNull();
+        parsed!["status"]!.ToString().Should().Be("success");
+
+        EmitDeploymentEventActivity.ParseData(null).Should().BeNull();
+        EmitDeploymentEventActivity.ParseData("   ").Should().BeNull();
+        EmitDeploymentEventActivity.ParseData("not json").Should().BeNull();
+    }
+
+    [Test]
+    public void ParseTenantId_ParsesGuid_NullOtherwise()
+    {
+        DeployEvents.ParseTenantId("33333333-3333-3333-3333-333333333333").Should().NotBeNull();
+        DeployEvents.ParseTenantId("").Should().BeNull();
+        DeployEvents.ParseTenantId("not-a-guid").Should().BeNull();
+        DeployEvents.ParseTenantId(null).Should().BeNull();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/DeploymentModeTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/DeploymentModeTests.cs
@@ -1,0 +1,94 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core.Deployment;
+
+namespace Tamma.Activities.Tests.ADL;
+
+/// <summary>
+/// Unit coverage for <see cref="DeploymentMode.Resolve"/> — the shared, pure
+/// single-vs-SaaS resolver the engine layer uses to thread a real <c>mode</c> into
+/// the deployment pipeline's production-approval gate (IMPORTANT fix, 2026-06-22).
+///
+/// <para>The load-bearing guarantee: SaaS/business resolves to <c>"business"</c>
+/// (gate ON) and an absent/unknown mode FAILS SAFE to <c>"business"</c> — never a
+/// silent <c>"dev"</c> that would skip the human gate and auto-deploy to prod.</para>
+/// </summary>
+[TestFixture]
+public class DeploymentModeTests
+{
+    // ── Explicit Tamma:Mode override wins ──────────────────────────────────
+
+    [TestCase("saas")]
+    [TestCase("SaaS")]
+    [TestCase("  saas  ")]
+    [TestCase("business")]
+    public void Resolve_ExplicitSaaSOrBusiness_IsBusiness(string explicitMode)
+    {
+        DeploymentMode.Resolve(explicitMode, false, false).Should().Be(DeploymentMode.Business);
+    }
+
+    [TestCase("single-user")]
+    [TestCase("singleuser")]
+    [TestCase("single_user")]
+    [TestCase("dev")]
+    [TestCase("DEV")]
+    public void Resolve_ExplicitSingleUser_IsDev(string explicitMode)
+    {
+        DeploymentMode.Resolve(explicitMode, false, false).Should().Be(DeploymentMode.Dev);
+    }
+
+    [Test]
+    public void Resolve_ExplicitModeWins_OverConfigSignals()
+    {
+        // An explicit single-user override beats SaaS-signal presence — explicit wins.
+        DeploymentMode.Resolve("single-user", hasTenantSharedSecret: true, hasControlPlaneConnection: true)
+            .Should().Be(DeploymentMode.Dev);
+    }
+
+    // ── Fail-safe: unknown explicit mode REQUIRES approval ─────────────────
+
+    [TestCase("prod")]
+    [TestCase("enterprise")]
+    [TestCase("xyz")]
+    public void Resolve_UnknownExplicitMode_FailsSafeToBusiness_NotDev(string bad)
+    {
+        DeploymentMode.Resolve(bad, false, false).Should().Be(DeploymentMode.Business,
+            "an unrecognised explicit mode must REQUIRE approval (fail-safe) — never a silent prod auto-deploy");
+    }
+
+    // ── Inferred from SaaS-only config signals ─────────────────────────────
+
+    [Test]
+    public void Resolve_TenantSharedSecretPresent_IsBusiness()
+    {
+        DeploymentMode.Resolve(null, hasTenantSharedSecret: true, hasControlPlaneConnection: false)
+            .Should().Be(DeploymentMode.Business, "Tamma:TenantSharedSecret is a SaaS-only signal");
+    }
+
+    [Test]
+    public void Resolve_ControlPlaneConnectionPresent_IsBusiness()
+    {
+        DeploymentMode.Resolve(null, hasTenantSharedSecret: false, hasControlPlaneConnection: true)
+            .Should().Be(DeploymentMode.Business, "ConnectionStrings:ControlPlane is a SaaS-only signal");
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    public void Resolve_NoExplicitModeNoSignals_DefaultsToDev_SingleUser(string? explicitMode)
+    {
+        DeploymentMode.Resolve(explicitMode, hasTenantSharedSecret: false, hasControlPlaneConnection: false)
+            .Should().Be(DeploymentMode.Dev, "a self-hosted deployment with no SaaS signals is single-user/dev");
+    }
+
+    // ── Gate semantics: business → the pipeline gate engages ───────────────
+
+    [Test]
+    public void BusinessToken_MatchesPipelineGateCondition()
+    {
+        // The pipeline's ProdApprovalNeeded gate fires on mode == "business"
+        // (case-insensitive). The resolver's Business token must equal that literal.
+        DeploymentMode.Business.Should().Be("business",
+            "the resolved SaaS token must equal the pipeline gate's 'business' literal so the gate engages");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Endpoints/DeploymentApprovalResumeEndpointTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Endpoints/DeploymentApprovalResumeEndpointTests.cs
@@ -1,0 +1,139 @@
+using Elsa.Workflows.Runtime;
+using Elsa.Workflows.Runtime.Entities;
+using Elsa.Workflows.Runtime.Filters;
+using Elsa.Workflows.Runtime.Messages;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+using Tamma.ElsaServer.Endpoints;
+
+namespace Tamma.Activities.Tests.Endpoints;
+
+/// <summary>
+/// The engine-side production-deploy approval resume seam
+/// (<c>POST /elsa/api/adl/deploy-approval/resume</c>, completeness audit P0
+/// item 3). Mirrors <see cref="MergeApprovalResumeEndpointTests"/>: it
+///   - computes the SAME tenant+repo+SHA-scoped bookmark name as the gate activity;
+///   - resolves only the matching (single) instance and resumes it;
+///   - REFUSES with 409 on a multi-match (globally-unique name) rather than
+///     resuming an arbitrary one;
+///   - 404s when no bookmark matches (a cross-tenant/cross-SHA resume hits this).
+/// </summary>
+[TestFixture]
+public class DeploymentApprovalResumeEndpointTests
+{
+    private Mock<IBookmarkStore> _bookmarks = null!;
+    private Mock<IWorkflowRuntime> _runtime = null!;
+    private Mock<IWorkflowClient> _client = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _bookmarks = new Mock<IBookmarkStore>();
+        _runtime = new Mock<IWorkflowRuntime>();
+        _client = new Mock<IWorkflowClient>();
+        _runtime
+            .Setup(r => r.CreateClientAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_client.Object);
+        _client
+            .Setup(c => c.RunInstanceAsync(It.IsAny<RunWorkflowInstanceRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunWorkflowInstanceResponse());
+    }
+
+    private static DeploymentApprovalResumeEndpoint.ResumeRequest Req(
+        int issue, string decision, string? tenantId, string? repo, string? sha)
+        => new(issue, decision, Feedback: null, Approver: null, TenantId: tenantId, Repository: repo, MergeSha: sha);
+
+    private static StoredBookmark Bookmark(string name, string instanceId)
+        => new() { Name = name, WorkflowInstanceId = instanceId, Id = Guid.NewGuid().ToString() };
+
+    private void SetupFind(string expectedName, params StoredBookmark[] matches) =>
+        _bookmarks
+            .Setup(b => b.FindManyAsync(
+                It.Is<BookmarkFilter>(f => f.Name == expectedName), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(matches.AsEnumerable());
+
+    [Test]
+    public async Task Resume_UsesTenantRepoShaScopedBookmarkName_AndResumesMatch()
+    {
+        var tenant = Guid.NewGuid().ToString();
+        var expected = WaitForDeploymentApprovalActivity.BookmarkName(tenant, "octo/repo", 42, "deadbeef");
+        SetupFind(expected, Bookmark(expected, "wf-instance-1"));
+
+        var result = await DeploymentApprovalResumeEndpoint.Resume(
+            Req(42, "approve", tenant, "octo/repo", "deadbeef"),
+            _bookmarks.Object, _runtime.Object, NullLoggerFactory.Instance, CancellationToken.None);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status200OK);
+        _client.Verify(c => c.RunInstanceAsync(
+            It.Is<RunWorkflowInstanceRequest>(r => (string)r.Input!["decision"] == "approve"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task Resume_CrossTenant_NoMatchingBookmark_Returns404_NeverResumes()
+    {
+        var callerTenant = Guid.NewGuid().ToString();
+        var callerName = WaitForDeploymentApprovalActivity.BookmarkName(callerTenant, "victim/repo", 5, "sha");
+        SetupFind(callerName /* zero matches */);
+
+        var result = await DeploymentApprovalResumeEndpoint.Resume(
+            Req(5, "approve", callerTenant, "victim/repo", "sha"),
+            _bookmarks.Object, _runtime.Object, NullLoggerFactory.Instance, CancellationToken.None);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status404NotFound);
+        _client.Verify(c => c.RunInstanceAsync(
+            It.IsAny<RunWorkflowInstanceRequest>(), It.IsAny<CancellationToken>()), Times.Never,
+            "a cross-tenant miss must never resume any instance");
+    }
+
+    [Test]
+    public async Task Resume_MoreThanOneMatch_Refuses409_DoesNotResumeArbitrary()
+    {
+        var tenant = Guid.NewGuid().ToString();
+        var name = WaitForDeploymentApprovalActivity.BookmarkName(tenant, "octo/repo", 1, "sha");
+        SetupFind(name, Bookmark(name, "wf-a"), Bookmark(name, "wf-b"));
+
+        var result = await DeploymentApprovalResumeEndpoint.Resume(
+            Req(1, "approve", tenant, "octo/repo", "sha"),
+            _bookmarks.Object, _runtime.Object, NullLoggerFactory.Instance, CancellationToken.None);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status409Conflict);
+        _client.Verify(c => c.RunInstanceAsync(
+            It.IsAny<RunWorkflowInstanceRequest>(), It.IsAny<CancellationToken>()), Times.Never,
+            "an ambiguous bookmark must refuse, not resume an arbitrary instance");
+    }
+
+    [Test]
+    public async Task Resume_EmptyDecision_Returns400()
+    {
+        var result = await DeploymentApprovalResumeEndpoint.Resume(
+            Req(1, "  ", Guid.NewGuid().ToString(), "octo/repo", "sha"),
+            _bookmarks.Object, _runtime.Object, NullLoggerFactory.Instance, CancellationToken.None);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public async Task Resume_RejectDecision_ResumesWithRejectPayload()
+    {
+        var tenant = Guid.NewGuid().ToString();
+        var expected = WaitForDeploymentApprovalActivity.BookmarkName(tenant, "octo/repo", 9, "sha");
+        SetupFind(expected, Bookmark(expected, "wf-reject"));
+
+        var result = await DeploymentApprovalResumeEndpoint.Resume(
+            Req(9, "reject", tenant, "octo/repo", "sha"),
+            _bookmarks.Object, _runtime.Object, NullLoggerFactory.Instance, CancellationToken.None);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status200OK);
+        _client.Verify(c => c.RunInstanceAsync(
+            It.Is<RunWorkflowInstanceRequest>(r => (string)r.Input!["decision"] == "reject"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static int? StatusCodeOf(IResult result)
+        => (result as IStatusCodeHttpResult)?.StatusCode;
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/AdlModeThreadingTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/AdlModeThreadingTests.cs
@@ -1,0 +1,180 @@
+using Elsa.Workflows;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+using Tamma.Core.Deployment;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// IMPORTANT fix (2026-06-22) — the production approval gate never engaged from
+/// the real autonomous loop because <c>mode</c> was never threaded
+/// <c>AdlOrchestratorWorkflow → DispatchCycleActivity → single-issue-cycle →
+/// deployment-pipeline</c>. These tests lock the threading end-to-end (structural,
+/// per the codebase convention — workflows/activities are not runnable in a unit
+/// test without the Elsa runtime; the runtime mode-DECISION is covered by
+/// <c>DeploymentModeTests</c>):
+///
+/// <list type="bullet">
+///   <item>the orchestrator's DispatchIssueCycle node SETS a <c>Mode</c> and a
+///     <c>TenantId</c> input (previously neither was set);</item>
+///   <item><see cref="DispatchCycleActivity"/> exposes a <c>Mode</c> input and
+///     injects <c>IConfiguration</c> (so it can derive the real operating mode);</item>
+///   <item>the cycle threads <c>mode</c> into the deployment-pipeline dispatch.</item>
+/// </list>
+/// </summary>
+[TestFixture]
+public class AdlModeThreadingTests
+{
+    // ── Orchestrator → DispatchCycle: Mode + TenantId are now set ──────────
+
+    [Test]
+    public void Orchestrator_DispatchIssueCycle_SetsModeAndTenantInputs()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new AdlOrchestratorWorkflow());
+        var flowchart = WorkflowTestHelper.GetFlowchart(builder);
+
+        var dispatch = flowchart.Activities
+            .OfType<DispatchCycleActivity>()
+            .FirstOrDefault(a => a.Id == "DispatchIssueCycle");
+
+        dispatch.Should().NotBeNull("the orchestrator must dispatch the single-issue cycle");
+
+        // Mode + TenantId must be configured (non-null Input with an expression) so
+        // a real value flows downstream into the deployment pipeline's gate. Before
+        // the fix neither was set → mode was always "" → prod auto-deployed ungated.
+        dispatch!.Mode.Should().NotBeNull("the cycle dispatch must thread a Mode input");
+        dispatch.Mode.Expression.Should().NotBeNull(
+            "Mode must be wired to an expression (pass-through input, derived from config when empty)");
+        dispatch.TenantId.Should().NotBeNull("the cycle dispatch must thread a TenantId input");
+        dispatch.TenantId.Expression.Should().NotBeNull("TenantId must be wired to an expression");
+    }
+
+    // ── DispatchCycleActivity exposes Mode + injects IConfiguration ────────
+
+    [Test]
+    public void DispatchCycleActivity_ExposesModeInput()
+    {
+        // Regression guard — the Mode input is the seam the orchestrator sets and
+        // the activity reads (falling back to config-derived mode when empty).
+        typeof(DispatchCycleActivity).GetProperty("Mode").Should().NotBeNull(
+            "DispatchCycleActivity must expose a Mode input so the orchestrator can thread it");
+    }
+
+    [Test]
+    public void DispatchCycleActivity_InjectsConfiguration_ToDeriveTheRealMode()
+    {
+        // The activity derives the real single-vs-SaaS mode from IConfiguration
+        // (mirrors TammaModeProvider) when the Mode input is empty. The DI ctor must
+        // therefore take IConfiguration.
+        var ctor = typeof(DispatchCycleActivity).GetConstructors()
+            .FirstOrDefault(c => c.GetParameters()
+                .Any(p => p.ParameterType == typeof(Microsoft.Extensions.Configuration.IConfiguration)));
+        ctor.Should().NotBeNull(
+            "DispatchCycleActivity must inject IConfiguration to derive the operating mode for the prod gate");
+    }
+
+    // ── Cycle → deployment-pipeline: mode is threaded ─────────────────────
+
+    [Test]
+    public void Cycle_DeploymentPipelineDispatch_Exists_AndCycleReadsModeFromInput()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new SingleIssueCycleWorkflow());
+        var flowchart = WorkflowTestHelper.GetFlowchart(builder);
+
+        // The deployment pipeline dispatch must exist (the leg that threads mode).
+        var pipeline = flowchart.Activities
+            .OfType<Elsa.Workflows.Runtime.Activities.DispatchWorkflow>()
+            .FirstOrDefault(d => d.Id == "DeploymentPipeline");
+        pipeline.Should().NotBeNull("the cycle must dispatch the deployment-pipeline");
+        ReadDefinitionId(pipeline!).Should().Be("deployment-pipeline");
+
+        // The cycle declares a Mode variable it reads from its own `mode` input and
+        // forwards to the pipeline (so a real value — not always "" — reaches the gate).
+        builder.Object.Variables.Any(v => v.Name == "Mode").Should().BeTrue(
+            "the cycle must carry a Mode variable threaded into the pipeline gate");
+
+        // It also threads the operator force-flag so Deployment:RequireProdApproval
+        // can force the gate even in dev mode.
+        builder.Object.Variables.Any(v => v.Name == "RequireProdApproval").Should().BeTrue(
+            "the cycle must carry RequireProdApproval threaded into the pipeline gate");
+    }
+
+    // ── DispatchCycleActivity.ResolveMode: the value that reaches the gate ──
+
+    [Test]
+    public void ResolveMode_SaaSConfig_ProducesBusiness_GateEngages()
+    {
+        // A SaaS deployment (TenantSharedSecret present) must produce "business" so
+        // the deployment pipeline's ProdApprovalNeeded gate (mode == "business")
+        // engages — the whole point of the fix.
+        var cfg = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Tamma:TenantSharedSecret"] = "hmac-secret",
+            }).Build();
+
+        DispatchCycleActivity.ResolveMode(explicitInput: "", cfg)
+            .Should().Be(DeploymentMode.Business,
+                "a SaaS deployment must thread mode=business so the prod approval gate engages");
+    }
+
+    [Test]
+    public void ResolveMode_ControlPlaneConfig_ProducesBusiness()
+    {
+        var cfg = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:ControlPlane"] = "Host=cp;Database=tamma",
+            }).Build();
+
+        DispatchCycleActivity.ResolveMode(null, cfg).Should().Be(DeploymentMode.Business);
+    }
+
+    [Test]
+    public void ResolveMode_SingleUserConfig_ProducesDev()
+    {
+        // No SaaS signals → single-user → dev (deploys without a human gate unless
+        // an operator forces it via Deployment:RequireProdApproval).
+        var cfg = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>()).Build();
+
+        DispatchCycleActivity.ResolveMode(null, cfg).Should().Be(DeploymentMode.Dev);
+    }
+
+    [Test]
+    public void ResolveMode_NoConfigAtAll_FailsSafeToDev_ButExplicitSaaSWins()
+    {
+        // A null config with no explicit mode is a self-hosted single-user run → dev.
+        DispatchCycleActivity.ResolveMode(null, configuration: null).Should().Be(DeploymentMode.Dev);
+
+        // An explicit "saas" input overrides regardless of config.
+        DispatchCycleActivity.ResolveMode("saas", configuration: null)
+            .Should().Be(DeploymentMode.Business, "an explicit saas mode must engage the gate even without config");
+    }
+
+    [Test]
+    public void ResolveMode_ExplicitTammaModeSaaS_ProducesBusiness()
+    {
+        var cfg = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Tamma:Mode"] = "saas",
+            }).Build();
+
+        DispatchCycleActivity.ResolveMode(null, cfg).Should().Be(DeploymentMode.Business);
+    }
+
+    private static string? ReadDefinitionId(Elsa.Workflows.Runtime.Activities.DispatchWorkflow dispatch)
+    {
+        var prop = typeof(Elsa.Workflows.Runtime.Activities.DispatchWorkflow)
+            .GetProperty("WorkflowDefinitionId");
+        var value = prop?.GetValue(dispatch);
+        var expression = value?.GetType().GetProperty("Expression")?.GetValue(value)
+            as Elsa.Expressions.Models.Expression;
+        return expression?.Value?.ToString();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/DeploymentPipelineWorkflowTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/DeploymentPipelineWorkflowTests.cs
@@ -1,0 +1,422 @@
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Management.Activities.SetOutput;
+using Elsa.Workflows.Runtime.Activities;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Build-out structure coverage for the <c>deployment-pipeline</c> workflow
+/// (completeness audit 2026-06-22). Asserts the load-bearing guarantees of the
+/// P0/P1 build-out by inspecting the BUILT Flowchart (the codebase convention —
+/// see MergeApprovalWorkflowTests) rather than running the full Elsa runtime:
+///   - P0.1 fail-closed: a failed stage routes through retry → loud FAILED →
+///     terminal, never silently to the next stage or to success;
+///   - P0.2 every edge emits a DEPLOY.* DCB event;
+///   - P0.3 a Business-Mode production approval gate gates the prod deploy
+///     (Approve → prod; Reject/Invalid → prod-failure, never a silent prod deploy);
+///   - P0.4 a failed prod deploy routes through a rollback branch;
+///   - P1.6 each stage retries (bounded) before failing.
+/// </summary>
+[TestFixture]
+public class DeploymentPipelineWorkflowTests
+{
+    private Flowchart _flowchart = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new DeploymentPipelineWorkflow());
+        _flowchart = WorkflowTestHelper.GetFlowchart(builder);
+    }
+
+    // ================================================================
+    // Identity
+    // ================================================================
+
+    [Test]
+    public void Workflow_BuildsWithExpectedDefinitionId()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new DeploymentPipelineWorkflow());
+        builder.Object.DefinitionId.Should().Be("deployment-pipeline");
+    }
+
+    [Test]
+    public void Workflow_UsesContinueWithIncidentsStrategy_SoAFaultDoesNotHaltSilently()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new DeploymentPipelineWorkflow());
+        builder.Object.WorkflowOptions.IncidentStrategyType
+            .Should().Be(typeof(Elsa.Workflows.IncidentStrategies.ContinueWithIncidentsStrategy),
+                "a faulted deploy stage must not halt the pipeline with an incident and report no status");
+    }
+
+    [Test]
+    public void DeploymentStatus_DefaultsToFailed_FailClosed()
+    {
+        // P0.1 — the status variable must default to "failed" so a fault before a
+        // terminal never yields a silent success. The variables are tracked on the
+        // builder (the mock collects every WithVariable call).
+        var builder = WorkflowTestHelper.BuildWorkflow(new DeploymentPipelineWorkflow());
+        var statusVar = builder.Object.Variables.FirstOrDefault(v => v.Name == "DeploymentStatus");
+        statusVar.Should().NotBeNull();
+        statusVar!.Value.Should().Be("failed",
+            "the deployment status must be fail-closed by default (never an optimistic success)");
+    }
+
+    // ================================================================
+    // P0.1 — fail-closed stage gating: each stage decides on `== "success"`,
+    // a non-success routes to retry/failure, NEVER straight to the next stage.
+    // ================================================================
+
+    [Test]
+    public void EachStageDecision_PromotesOnlyOnExplicitSuccess()
+    {
+        // The FlowDecision conditions are opaque lambdas, but their wiring is not:
+        // the True edge of each *Ok decision goes to the stage SUCCESS emit, the
+        // False edge goes to that stage's retry check (then failure). A non-success
+        // can therefore never reach the next stage's deploy directly.
+        HasEdge("QAOk", "True", "EmitQaSuccess").Should().BeTrue();
+        HasEdge("QAOk", "False", "QaRetryCheck").Should().BeTrue();
+        HasEdge("UATOk", "True", "EmitUatSuccess").Should().BeTrue();
+        HasEdge("UATOk", "False", "UatRetryCheck").Should().BeTrue();
+        HasEdge("ProdOk", "True", "EmitProdSuccess").Should().BeTrue();
+        HasEdge("ProdOk", "False", "ProdRetryCheck").Should().BeTrue();
+    }
+
+    [Test]
+    public void QaFailure_NeverReachesUatOrSuccess()
+    {
+        // A QA failure (retry exhausted) must reach the QA failure terminal +
+        // PIPELINE.FAILED, and must NOT reach UAT deploy, prod deploy, or success.
+        var reach = ReachableFromPort("QaRetryCheck", "False");
+        reach.Should().Contain("SetQAFailed");
+        reach.Should().Contain("EmitPipelineFailed");
+        reach.Should().NotContain("UATDeploy", "a failed QA must never deploy UAT");
+        reach.Should().NotContain("ProdDeploy", "a failed QA must never deploy prod");
+        reach.Should().NotContain("SetSuccess", "a failed QA must never reach success");
+        reach.Should().NotContain("EmitPipelineSuccess");
+    }
+
+    [Test]
+    public void UatFailure_NeverReachesProdOrSuccess()
+    {
+        var reach = ReachableFromPort("UatRetryCheck", "False");
+        reach.Should().Contain("SetUATFailed");
+        reach.Should().Contain("EmitPipelineFailed");
+        reach.Should().NotContain("ProdDeploy", "a failed UAT must never deploy prod");
+        reach.Should().NotContain("SetSuccess");
+    }
+
+    [Test]
+    public void ParseStageStatus_IsFailClosed_OnMissingEmptyOrGarbledResult()
+    {
+        // P0.1 regression (audit item 1 / spec test 13): the OLD code defaulted to
+        // "success" and swallowed parse failures. These must ALL be "failed" now.
+        DeploymentPipelineWorkflow.ParseStageStatus(null).Status.Should().Be("failed",
+            "a null result must NOT promote (silent false success)");
+
+        DeploymentPipelineWorkflow.ParseStageStatus(
+            new Dictionary<string, object>()).Status.Should().Be("failed",
+            "a result missing llmResponse must NOT promote");
+
+        DeploymentPipelineWorkflow.ParseStageStatus(
+            new Dictionary<string, object> { ["llmResponse"] = "" }).Status.Should().Be("failed",
+            "an empty llmResponse must NOT promote");
+
+        DeploymentPipelineWorkflow.ParseStageStatus(
+            new Dictionary<string, object> { ["llmResponse"] = "this is not json at all" })
+            .Status.Should().Be("failed", "a non-JSON response must NOT promote");
+
+        DeploymentPipelineWorkflow.ParseStageStatus(
+            new Dictionary<string, object> { ["llmResponse"] = "{\"foo\":\"bar\"}" })
+            .Status.Should().Be("failed", "a JSON response with no status field must NOT promote");
+
+        DeploymentPipelineWorkflow.ParseStageStatus(
+            new Dictionary<string, object> { ["llmResponse"] = "{\"status\":\"failed\"}" })
+            .Status.Should().Be("failed");
+    }
+
+    [Test]
+    public void ParseStageStatus_PromotesOnlyOnExplicitSuccess()
+    {
+        DeploymentPipelineWorkflow.ParseStageStatus(
+            new Dictionary<string, object> { ["llmResponse"] = "Deploying...\n{\"status\":\"success\"}\nDone." })
+            .Status.Should().Be("success", "an explicit status:success embedded in agent text must promote");
+
+        DeploymentPipelineWorkflow.ParseStageStatus(
+            new Dictionary<string, object> { ["llmResponse"] = "{\"status\":\"SUCCESS\"}" })
+            .Status.Should().Be("success", "status matching is case-insensitive");
+    }
+
+    // ================================================================
+    // P0.2 — DCB audit events on every meaningful edge.
+    // ================================================================
+
+    [Test]
+    public void EveryStage_EmitsStartedSuccessAndFailedEvents()
+    {
+        var emitIds = _flowchart.Activities
+            .OfType<EmitDeploymentEventActivity>()
+            .Select(a => a.Id)
+            .ToList();
+
+        foreach (var prefix in new[] { "Qa", "Uat", "Prod" })
+        {
+            emitIds.Should().Contain($"Emit{prefix}Started");
+            emitIds.Should().Contain($"Emit{prefix}Success");
+            emitIds.Should().Contain($"Emit{prefix}Failed");
+        }
+    }
+
+    [Test]
+    public void PipelineTerminals_EmitSuccessAndFailedEvents()
+    {
+        var emitIds = _flowchart.Activities
+            .OfType<EmitDeploymentEventActivity>()
+            .Select(a => a.Id)
+            .ToList();
+
+        emitIds.Should().Contain("EmitPipelineSuccess");
+        emitIds.Should().Contain("EmitPipelineFailed");
+    }
+
+    [Test]
+    public void StartEdge_EmitsStageStarted_BeforeDispatch()
+    {
+        HasEdge("Init", null, "EmitQaStarted").Should().BeTrue("the pipeline must emit STAGE.STARTED before the first dispatch");
+        HasEdge("EmitQaStarted", null, "QADeploy").Should().BeTrue();
+    }
+
+    // ================================================================
+    // P0.3 — production approval gate (Business Mode).
+    // ================================================================
+
+    [Test]
+    public void ProdApprovalGate_ExistsAsBookmarkActivity_WithThreeOutcomes()
+    {
+        var gate = _flowchart.Activities
+            .OfType<WaitForDeploymentApprovalActivity>()
+            .FirstOrDefault(a => a.Id == "WaitProdApproval");
+        gate.Should().NotBeNull("a bookmark-based production approval gate must exist before prod");
+
+        var ports = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "WaitProdApproval")
+            .Select(c => c.Source.Port)
+            .ToList();
+        ports.Should().Contain("Approve");
+        ports.Should().Contain("Reject");
+        ports.Should().Contain("Invalid");
+    }
+
+    [Test]
+    public void ApprovalNeeded_GatesProd_DevModeBypassesToProd()
+    {
+        // After UAT success the pipeline decides whether prod needs approval.
+        HasEdge("EmitUatSuccess", null, "ProdApprovalNeeded").Should().BeTrue();
+        // Business mode (True) → the human gate; dev mode (False) → straight to prod start.
+        HasEdge("ProdApprovalNeeded", "True", "WaitProdApproval").Should().BeTrue(
+            "Business Mode must route to the human approval gate before prod");
+        HasEdge("ProdApprovalNeeded", "False", "EmitProdStarted").Should().BeTrue(
+            "dev mode deploys to prod without a human gate");
+    }
+
+    [Test]
+    public void ApprovalApprove_ProceedsToProd_RejectAndInvalidDoNot()
+    {
+        HasEdge("WaitProdApproval", "Approve", "EmitProdApproved").Should().BeTrue();
+        HasEdge("EmitProdApproved", null, "EmitProdStarted").Should().BeTrue(
+            "an approved prod deploy proceeds to the prod stage");
+
+        // Reject and Invalid must BOTH emit a loud PRODUCTION.REJECTED and route to
+        // the prod-failure terminal — NEVER to a prod deploy.
+        HasEdge("WaitProdApproval", "Reject", "EmitProdRejected").Should().BeTrue();
+        HasEdge("WaitProdApproval", "Invalid", "EmitProdRejected").Should().BeTrue();
+        HasEdge("EmitProdRejected", null, "SetProdFailed").Should().BeTrue();
+
+        var rejectReach = Reachable("EmitProdRejected");
+        rejectReach.Should().NotContain("ProdDeploy",
+            "a rejected/invalid prod approval must never reach the prod deploy");
+        rejectReach.Should().NotContain("SetSuccess");
+    }
+
+    [Test]
+    public void ApprovalGate_NormalizeIsFailClosed_UnknownIsInvalidNotApprove()
+    {
+        WaitForDeploymentApprovalActivity.Normalize("approve").Outcome.Should().Be("Approve");
+        WaitForDeploymentApprovalActivity.Normalize("reject").Outcome.Should().Be("Reject");
+        foreach (var bad in new[] { null, "", "  ", "yes", "ok", "deploy" })
+        {
+            WaitForDeploymentApprovalActivity.Normalize(bad).Outcome.Should().Be("Invalid",
+                "an unknown/empty decision must be Invalid — never a silent approve");
+        }
+    }
+
+    // ================================================================
+    // P0.4 — rollback on production failure.
+    // ================================================================
+
+    [Test]
+    public void ProdFailure_RoutesThroughRollbackBranch_BeforeFailing()
+    {
+        // Exhausted prod retries → loud PROD FAILED → rollback started → rollback
+        // dispatch → extract → rollback OK? → (success or failed) → SetProdFailed.
+        HasEdge("ProdRetryCheck", "False", "EmitProdFailed").Should().BeTrue();
+        HasEdge("EmitProdFailed", null, "EmitRollbackStarted").Should().BeTrue(
+            "a failed prod deploy must trigger a rollback, not just stop");
+        HasEdge("EmitRollbackStarted", null, "RollbackProd").Should().BeTrue();
+        HasEdge("RollbackProd", null, "ExtractRollback").Should().BeTrue();
+        HasEdge("ExtractRollback", null, "RollbackOk").Should().BeTrue();
+        HasEdge("RollbackOk", "True", "EmitRollbackSuccess").Should().BeTrue();
+        HasEdge("RollbackOk", "False", "EmitRollbackFailed").Should().BeTrue();
+        HasEdge("EmitRollbackSuccess", null, "SetProdFailed").Should().BeTrue();
+        HasEdge("EmitRollbackFailed", null, "SetProdFailed").Should().BeTrue();
+    }
+
+    [Test]
+    public void RollbackDispatch_UsesLlmCallMediation_NotADirectProvider()
+    {
+        // Mediation rule — the rollback step must dispatch llm-call, never a provider.
+        var rollback = _flowchart.Activities
+            .OfType<DispatchWorkflow>()
+            .FirstOrDefault(d => d.Id == "RollbackProd");
+        rollback.Should().NotBeNull();
+        ReadDefinitionId(rollback!).Should().Be("llm-call",
+            "rollback must route through the llm-call mediation endpoint");
+    }
+
+    [Test]
+    public void RollbackEvents_AreEmitted()
+    {
+        var emitIds = _flowchart.Activities
+            .OfType<EmitDeploymentEventActivity>()
+            .Select(a => a.Id)
+            .ToList();
+        emitIds.Should().Contain("EmitRollbackStarted");
+        emitIds.Should().Contain("EmitRollbackSuccess");
+        emitIds.Should().Contain("EmitRollbackFailed");
+    }
+
+    // ================================================================
+    // P1.6 — bounded per-stage retry then escalation (no silent bypass).
+    // ================================================================
+
+    [Test]
+    public void EachStage_RetriesUnderCap_ThenFails()
+    {
+        // Under the cap → increment → re-dispatch the SAME stage's STARTED emit.
+        HasEdge("QaRetryCheck", "True", "QaIncrement").Should().BeTrue();
+        HasEdge("QaIncrement", null, "EmitQaStarted").Should().BeTrue("under the cap QA re-runs");
+        HasEdge("UatRetryCheck", "True", "UatIncrement").Should().BeTrue();
+        HasEdge("UatIncrement", null, "EmitUatStarted").Should().BeTrue();
+        HasEdge("ProdRetryCheck", "True", "ProdIncrement").Should().BeTrue();
+        HasEdge("ProdIncrement", null, "EmitProdStarted").Should().BeTrue();
+    }
+
+    // ================================================================
+    // Mediation — deploy dispatches go through llm-call (no direct provider).
+    // ================================================================
+
+    [Test]
+    public void AllStageDeploys_DispatchLlmCall_NoDirectProvider()
+    {
+        foreach (var id in new[] { "QADeploy", "UATDeploy", "ProdDeploy" })
+        {
+            var dispatch = _flowchart.Activities.OfType<DispatchWorkflow>().FirstOrDefault(d => d.Id == id);
+            dispatch.Should().NotBeNull($"{id} must exist as a DispatchWorkflow");
+            ReadDefinitionId(dispatch!).Should().Be("llm-call",
+                $"{id} must route through the llm-call mediation endpoint, never a provider");
+        }
+    }
+
+    // ================================================================
+    // Output contract — preserved + additive.
+    // ================================================================
+
+    [Test]
+    public void Outputs_PreserveContract_AndAddNewOnesAdditively()
+    {
+        var outputSeq = _flowchart.Activities.OfType<Sequence>().FirstOrDefault(s => s.Id == "SetOutputs");
+        outputSeq.Should().NotBeNull();
+        var outputIds = outputSeq!.Activities.OfType<SetOutput>().Select(o => o.Id ?? "").ToList();
+
+        // Preserved contract.
+        outputIds.Should().Contain("OutStatus");
+        outputIds.Should().Contain("OutStages");
+        // Additive only.
+        outputIds.Should().Contain("OutReleaseTag");
+        outputIds.Should().Contain("OutReleaseStatus");
+        outputIds.Should().Contain("OutRollbackStatus");
+    }
+
+    [Test]
+    public void HappyPath_ReachesSuccess_ThroughPipelineSuccessEvent()
+    {
+        // QA success → UAT success → (dev) prod start → prod success → release tag
+        // → set success → PIPELINE.SUCCESS → outputs → finish.
+        HasEdge("EmitProdSuccess", null, "SetReleaseTag").Should().BeTrue();
+        HasEdge("SetReleaseTag", null, "SetSuccess").Should().BeTrue();
+        HasEdge("SetSuccess", null, "EmitPipelineSuccess").Should().BeTrue();
+        HasEdge("EmitPipelineSuccess", null, "SetOutputs").Should().BeTrue();
+        HasEdge("SetOutputs", null, "Finish").Should().BeTrue();
+    }
+
+    // ================================================================
+    // Helpers (mirrors MergeApprovalWorkflowTests)
+    // ================================================================
+
+    private bool HasEdge(string sourceId, string? port, string targetId)
+        => _flowchart.Connections.Any(c =>
+            c.Source.Activity.Id == sourceId &&
+            (port == null || c.Source.Port == port) &&
+            c.Target.Activity.Id == targetId);
+
+    private HashSet<string> Reachable(string startId)
+    {
+        var seen = new HashSet<string>();
+        var queue = new Queue<string>();
+        queue.Enqueue(startId);
+        while (queue.Count > 0)
+        {
+            var id = queue.Dequeue();
+            foreach (var c in _flowchart.Connections.Where(c => c.Source.Activity.Id == id))
+            {
+                var t = c.Target.Activity.Id;
+                if (t != null && seen.Add(t)) queue.Enqueue(t);
+            }
+        }
+        return seen;
+    }
+
+    private HashSet<string> ReachableFromPort(string sourceId, string port)
+    {
+        var seen = new HashSet<string>();
+        var queue = new Queue<string>();
+        foreach (var c in _flowchart.Connections.Where(c =>
+            c.Source.Activity.Id == sourceId && c.Source.Port == port))
+        {
+            if (c.Target.Activity.Id is { } t && seen.Add(t)) queue.Enqueue(t);
+        }
+        while (queue.Count > 0)
+        {
+            var id = queue.Dequeue();
+            foreach (var c in _flowchart.Connections.Where(c => c.Source.Activity.Id == id))
+            {
+                if (c.Target.Activity.Id is { } t && seen.Add(t)) queue.Enqueue(t);
+            }
+        }
+        return seen;
+    }
+
+    private static string? ReadDefinitionId(DispatchWorkflow dispatch)
+    {
+        var prop = typeof(DispatchWorkflow).GetProperty("WorkflowDefinitionId");
+        var value = prop?.GetValue(dispatch);
+        var expression = value?.GetType().GetProperty("Expression")?.GetValue(value)
+            as Elsa.Expressions.Models.Expression;
+        return expression?.Value?.ToString();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/DeploymentPipelineWorkflowTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/DeploymentPipelineWorkflowTests.cs
@@ -300,6 +300,45 @@ public class DeploymentPipelineWorkflowTests
         emitIds.Should().Contain("EmitRollbackFailed");
     }
 
+    [Test]
+    public void RollbackEmit_SourcesStatusFromRollbackStatus_NotStaleProdFailed()
+    {
+        // MINOR fix (2026-06-22): in the rollback branch stageResult is still the
+        // stale prod "failed", so DEPLOY.ROLLBACK.SUCCESS used to carry
+        // status:"failed". A rollback emit must source status from rollbackStatus.
+
+        // ROLLBACK.SUCCESS — rollback succeeded → status:"success" (NOT the stale "failed").
+        DeploymentPipelineWorkflow.SelectEmitStatus(isRollback: true, stageResult: "failed", rollbackStatus: "success")
+            .Should().Be("success",
+                "DEPLOY.ROLLBACK.SUCCESS must carry status:success, not the stale prod 'failed'");
+
+        // ROLLBACK.FAILED — rollback itself failed.
+        DeploymentPipelineWorkflow.SelectEmitStatus(true, "failed", "failed").Should().Be("failed");
+
+        // ROLLBACK.STARTED — runs before the rollback dispatch → rollbackStatus empty → "started".
+        DeploymentPipelineWorkflow.SelectEmitStatus(true, "failed", "").Should().Be("started");
+        DeploymentPipelineWorkflow.SelectEmitStatus(true, "failed", null).Should().Be("started");
+
+        // A non-rollback (stage) emit still reports stageResult unchanged.
+        DeploymentPipelineWorkflow.SelectEmitStatus(isRollback: false, stageResult: "success", rollbackStatus: "")
+            .Should().Be("success");
+        DeploymentPipelineWorkflow.SelectEmitStatus(false, "failed", "success").Should().Be("failed",
+            "a stage emit must report the stage result, not a rollback status");
+    }
+
+    [Test]
+    public void RollbackEmitNodes_AreNotStageResultSourced()
+    {
+        // Regression guard: the three rollback emit nodes must be the rollback-sourced
+        // variant (isRollback=true). We assert the wiring exists; the value mapping is
+        // covered by RollbackEmit_SourcesStatusFromRollbackStatus_NotStaleProdFailed.
+        foreach (var id in new[] { "EmitRollbackStarted", "EmitRollbackSuccess", "EmitRollbackFailed" })
+        {
+            _flowchart.Activities.OfType<EmitDeploymentEventActivity>()
+                .Any(a => a.Id == id).Should().BeTrue($"{id} must exist as a rollback emit node");
+        }
+    }
+
     // ================================================================
     // P1.6 — bounded per-stage retry then escalation (no silent bypass).
     // ================================================================

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/AdlEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/AdlEndpointsTests.cs
@@ -214,6 +214,104 @@ public class AdlEndpointsTests
             .Should().Be("unknown");
     }
 
+    // ================================================================
+    // Production-deploy approval gate (completeness audit P0 item 3) —
+    // POST /api/adl/deploy-approval/resume. Same security model as the merge gate.
+    // ================================================================
+
+    [Test]
+    public async Task ResumeDeploymentApproval_ValidApprove_ForwardsTenantRepoShaAndDerivedApprover_Returns200()
+    {
+        var tenant = Guid.NewGuid();
+        _elsa
+            .Setup(s => s.ResumeDeploymentApprovalAsync(
+                42, tenant.ToString(), "octo/repo", "deadbeef", "approve", "ship it", "alice@example.com"))
+            .ReturnsAsync(new MergeApprovalResumeResult(Resumed: true, GateNotFound: false, WorkflowInstanceId: "wf-1"));
+
+        var req = new AdlEndpoints.DeployApprovalDecisionRequest(42, "octo/repo", "deadbeef", "approve", "ship it");
+
+        var result = await AdlEndpoints.ResumeDeploymentApproval(
+            req, _elsa.Object, TenantContext(tenant), Principal("alice@example.com"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status200OK);
+        _elsa.Verify(s => s.ResumeDeploymentApprovalAsync(
+            42, tenant.ToString(), "octo/repo", "deadbeef", "approve", "ship it", "alice@example.com"), Times.Once);
+    }
+
+    [Test]
+    public async Task ResumeDeploymentApproval_ApproverDerivedFromPrincipal_NotForgeable()
+    {
+        var tenant = Guid.NewGuid();
+        string? capturedApprover = null;
+        _elsa
+            .Setup(s => s.ResumeDeploymentApprovalAsync(
+                It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<int, string?, string?, string?, string, string?, string?>(
+                (_, _, _, _, _, _, approver) => capturedApprover = approver)
+            .ReturnsAsync(new MergeApprovalResumeResult(true, false, "wf-9"));
+
+        var req = new AdlEndpoints.DeployApprovalDecisionRequest(1, "octo/repo", "sha", "reject", null);
+
+        await AdlEndpoints.ResumeDeploymentApproval(
+            req, _elsa.Object, TenantContext(tenant), Principal("bob@corp.test"), _loggerFactory);
+
+        capturedApprover.Should().Be("bob@corp.test",
+            "the prod-deploy approver must be derived from the authenticated principal for non-repudiation");
+    }
+
+    [Test]
+    public async Task ResumeDeploymentApproval_CrossTenantGate_Returns404_NeverActs()
+    {
+        var callerTenant = Guid.NewGuid();
+        _elsa
+            .Setup(s => s.ResumeDeploymentApprovalAsync(
+                5, callerTenant.ToString(), "victim/repo", "sha", "approve", null, It.IsAny<string?>()))
+            .ReturnsAsync(new MergeApprovalResumeResult(Resumed: false, GateNotFound: true, WorkflowInstanceId: null));
+
+        var req = new AdlEndpoints.DeployApprovalDecisionRequest(5, "victim/repo", "sha", "approve", null);
+
+        var result = await AdlEndpoints.ResumeDeploymentApproval(
+            req, _elsa.Object, TenantContext(callerTenant), Principal("attacker@evil.test"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status404NotFound);
+        _elsa.Verify(s => s.ResumeDeploymentApprovalAsync(
+            5, callerTenant.ToString(), "victim/repo", "sha", "approve", null, It.IsAny<string?>()), Times.Once);
+    }
+
+    [TestCase("yes")]
+    [TestCase("merge")]      // wrong gate's vocabulary
+    [TestCase("approve; drop table")]
+    public async Task ResumeDeploymentApproval_UnknownDecision_Returns400_NoForward(string decision)
+    {
+        var req = new AdlEndpoints.DeployApprovalDecisionRequest(1, "octo/repo", "sha", decision, null);
+
+        var result = await AdlEndpoints.ResumeDeploymentApproval(
+            req, _elsa.Object, TenantContext(Guid.NewGuid()), Principal("a@b.test"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest, "only approve|reject are accepted");
+        VerifyDeployNeverForwarded();
+    }
+
+    [Test]
+    public async Task ResumeDeploymentApproval_MissingMergeSha_Returns400()
+    {
+        var req = new AdlEndpoints.DeployApprovalDecisionRequest(1, "octo/repo", "  ", "approve", null);
+
+        var result = await AdlEndpoints.ResumeDeploymentApproval(
+            req, _elsa.Object, TenantContext(Guid.NewGuid()), Principal("a@b.test"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest,
+            "mergeSha is part of the bookmark scope and must be supplied");
+        VerifyDeployNeverForwarded();
+    }
+
+    private void VerifyDeployNeverForwarded() =>
+        _elsa.Verify(s => s.ResumeDeploymentApprovalAsync(
+            It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(),
+            It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()),
+            Times.Never, "invalid input must be rejected up front, not forwarded");
+
     private void VerifyNeverForwarded() =>
         _elsa.Verify(s => s.ResumeMergeApprovalAsync(
             It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<string?>(),


### PR DESCRIPTION
## DeploymentPipelineWorkflow build-out — Bucket D (fix-now)

Per `docs/superpowers/audits/2026-06-22/completeness/DeploymentPipeline.md`. Closes the P0/P1 correctness & safety gaps:

- **P0 — silent false-success fixed:** `ParseStageStatus` defaults `failed`; null / missing-`llmResponse` / empty / non-JSON / no-`status` / parse-exception all take the failure edge. Pipeline seeds `deploymentStatus="failed"` + `ContinueWithIncidentsStrategy` so an internal fault can never report success.
- **P0 — full DCB audit trail:** `DEPLOY.STAGE.STARTED/SUCCESS/FAILED`, `PRODUCTION.APPROVAL_REQUESTED/APPROVED/REJECTED`, `ROLLBACK.STARTED/SUCCESS/FAILED`, `PIPELINE.SUCCESS/FAILED` via `TammaEventEmitter` (durable engine drain).
- **P0 — production approval gate:** bookmark-based `WaitForDeploymentApprovalActivity` (Approve/Reject/Invalid, fail-closed normalize) gated on business/SaaS mode; secure resume endpoints (engine `EngineServiceOnly` + tenant-scoped RBAC API), faithfully copying the merge-approval pattern (cross-tenant→404, ambiguous→409). **`mode` is threaded end-to-end** from `AdlOrchestrator → DispatchCycleActivity → SingleIssueCycle → pipeline`, derived from the same config signals as `TammaModeProvider` via a new pure `Tamma.Core/Deployment/DeploymentMode.Resolve` (engine can't reference `Tamma.Api`); **fail-safe: unknown mode → business (gate ON)**; `Deployment:RequireProdApproval` operator override.
- **P0 — rollback** on prod failure (mediated `llm-call`, `DEPLOY.ROLLBACK.*` events with accurate status).
- **P1 — bounded retry (3) + loud escalation**, no silent bypass.

Output contract (`deploymentStatus`+`completedStages`) preserved; `releaseTag`/`releaseStatus`/`rollbackStatus` additive. No direct provider call; no EF migration. Release/tag cutting honestly **deferred** (`releaseStatus="deferred"`, no faked release) — no release activity exists yet.

**Review + fix:** adversarial review found the prod-approval gate didn't engage from the real loop (`mode` unthreaded) → fixed (threaded end-to-end, fail-safe gate-on, `AdlModeThreadingTests` proves it) + a rollback-status cosmetic. Resume-endpoint security verified (no IDOR; secure merge-approval pattern).

**Gate:** build 0; full `Tamma.Activities.Tests` **1761/0**; filtered (Deployment|SingleIssueCycle|DispatchCycle|AdlModeThreading|DeploymentMode) 136/0.

Follow-ups (P2/P3): real release/tag activity, per-stage approval timeout, health probe, notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)