### PR TITLE
feat(workflows): build out BlockerDiagnosisWorkflow — fix always-Escalated, durable timeouts, DCB events

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/BlockerEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/BlockerEvents.cs
@@ -48,6 +48,14 @@ namespace Tamma.Activities.Blocker;
 public static class BlockerEvents
 {
     public const string DiagnosedSuccess = "BLOCKER.DIAGNOSED.SUCCESS";
+
+    // FOLLOW-UP: BLOCKER.DIAGNOSED.FAILED is not emitted on any graph edge today — the graph
+    // only ever emits DiagnosedSuccess after ClassifyBlockerActivity (which never throws: it
+    // always falls back to a rule-based classification). It is retained as the LOUD,
+    // fail-closed default for EmitBlockerEventActivity when an emit is reached with no
+    // EventType (so a mis-wired emit surfaces as an error row, not a false success), and is
+    // the slot a real diagnosis-failure path would emit once classification is allowed to hard
+    // fail. Kept deliberately rather than removed; no fabricated failure path is added here.
     public const string DiagnosedFailed = "BLOCKER.DIAGNOSED.FAILED";
     public const string ResolutionAttempted = "BLOCKER.RESOLUTION_ATTEMPTED";
     public const string ProgressDetected = "BLOCKER.PROGRESS_DETECTED";

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/BlockerEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/BlockerEvents.cs
@@ -1,0 +1,84 @@
+namespace Tamma.Activities.Blocker;
+
+/// <summary>
+/// Completeness audit 2026-06-22 (<c>BlockerDiagnosis.md</c> §Missing #3, 7-1G AC9) —
+/// central catalogue of the <c>BLOCKER.*</c> DCB event types emitted by the
+/// <c>blocker-diagnosis</c> sub-workflow via <see cref="EmitBlockerEventActivity"/>.
+/// Type pattern follows the platform's <c>AGGREGATE.ACTION.STATUS</c> convention
+/// (<c>CLAUDE.md</c>) and mirrors the sibling event catalogues
+/// (<see cref="Tamma.Activities.ADL.BranchEvents"/>,
+/// <see cref="Tamma.Activities.ADL.TddDebugEvents"/>).
+///
+/// <para>The blocker-diagnosis workflow is a progressive-escalation human-in-the-loop
+/// ladder (Hint → Guidance → Assistance → Escalation). Each rung is an auditable
+/// intervention so time-travel debugging and the Epic-32 benchmarking/learning loop can
+/// reconstruct <i>why</i> a junior was stuck, which level resolved it (if any), and
+/// whether a wait expired without progress. Without these events the ladder's decisions
+/// are invisible to the audit trail (the headline AC9 gap).</para>
+///
+/// <para>Events are emitted via <c>TammaEventEmitter.Emit</c> into the workflow's
+/// <c>tamma:events</c> transient list and persisted <i>durably</i> by the engine event
+/// drain (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) — the same pattern
+/// <see cref="Tamma.Activities.ADL.EmitBranchEventActivity"/> and
+/// <see cref="Tamma.Activities.ADL.EmitPrEventActivity"/> use. No activity holds a DB /
+/// repository dependency of its own (none is registered in the Elsa engine — a directly
+/// injected <c>IEventRepository</c> would be inert and silently drop every event). The
+/// drain resolves the tenant from the workflow scope, and each event carries a
+/// <c>tenantId</c> tag (SaaS) so per-tenant perf/action data stays tenant-scoped
+/// (Epic 32).</para>
+///
+/// <list type="bullet">
+///   <item><description><c>BLOCKER.DIAGNOSED.SUCCESS</c> / <c>.FAILED</c> — the
+///     classifier produced (or failed to produce) a blocker type + severity.</description></item>
+///   <item><description><c>BLOCKER.RESOLUTION_ATTEMPTED</c> — a resolution level
+///     (Hint/Guidance/Assistance) was applied (carries level + attempt#).</description></item>
+///   <item><description><c>BLOCKER.PROGRESS_DETECTED</c> — the junior made progress
+///     after an intervention (carries progress type/details).</description></item>
+///   <item><description><c>BLOCKER.PROGRESS_TIMED_OUT</c> — a level's wait expired with
+///     no progress; the ladder advanced to the next rung.</description></item>
+///   <item><description><c>BLOCKER.ESCALATED</c> — the ladder exhausted automated
+///     resolution and notified a senior (carries channel + severity).</description></item>
+///   <item><description><c>BLOCKER.RESOLVED</c> — terminal: the blocker was resolved
+///     (progress detected at some level, or a senior resolved an escalation).</description></item>
+///   <item><description><c>BLOCKER.TIMED_OUT</c> — terminal: the escalation SLA expired
+///     with no senior response. LOUD (error-status) — a never-answered escalation is a
+///     distinct, auditable terminal, NEVER a silent "Escalated" false success.</description></item>
+/// </list>
+/// </summary>
+public static class BlockerEvents
+{
+    public const string DiagnosedSuccess = "BLOCKER.DIAGNOSED.SUCCESS";
+    public const string DiagnosedFailed = "BLOCKER.DIAGNOSED.FAILED";
+    public const string ResolutionAttempted = "BLOCKER.RESOLUTION_ATTEMPTED";
+    public const string ProgressDetected = "BLOCKER.PROGRESS_DETECTED";
+    public const string ProgressTimedOut = "BLOCKER.PROGRESS_TIMED_OUT";
+    public const string Escalated = "BLOCKER.ESCALATED";
+    public const string Resolved = "BLOCKER.RESOLVED";
+    public const string TimedOut = "BLOCKER.TIMED_OUT";
+
+    /// <summary>
+    /// Parse a tenant id from the loose string form threaded through the workflow
+    /// inputs. Returns <c>null</c> for empty / single-user / unparseable values
+    /// (blocker events in single-user mode are platform-scope, TenantId null).
+    /// Mirrors <see cref="Tamma.Activities.ADL.BranchEvents.ParseTenantId"/>.
+    /// </summary>
+    public static Guid? ParseTenantId(string? tenantId)
+        => Guid.TryParse(tenantId, out var g) ? g : null;
+
+    /// <summary>
+    /// Status convention: an escalation SLA expiry (<see cref="TimedOut"/>) and a failed
+    /// diagnosis (<see cref="DiagnosedFailed"/>) are LOUD (error-status) audit rows;
+    /// every other transition (diagnosed, resolution attempted, progress detected, a
+    /// per-level progress timeout that simply advances the ladder, escalated, resolved)
+    /// is a normal (success-status) row. A per-level <see cref="ProgressTimedOut"/> is
+    /// success-status because it is an expected ladder transition (the next rung runs) —
+    /// only the FINAL escalation timeout is error-status. Keeps a degraded/expired
+    /// terminal from ever being recorded as a false success.
+    /// </summary>
+    public static string StatusForEvent(string type) => type switch
+    {
+        TimedOut => "error",
+        DiagnosedFailed => "error",
+        _ => "success",
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/BlockerMetrics.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/BlockerMetrics.cs
@@ -1,0 +1,116 @@
+using System.Diagnostics.Metrics;
+
+namespace Tamma.Activities.Blocker;
+
+/// <summary>
+/// Completeness audit 2026-06-22 (<c>BlockerDiagnosis.md</c> §Missing #13, 7-1G AC9) —
+/// OpenTelemetry metric surface for the <c>blocker-diagnosis</c> sub-workflow. The meter
+/// is self-registering (constructing a <see cref="Meter"/> with <see cref="MeterName"/>
+/// makes the instruments discoverable by any <c>MeterProvider</c> wired to that name —
+/// the codebase keeps no explicit <c>AddMeter</c> allow-list, see
+/// <see cref="Tamma.Data.Pooling.TenantConnectionPoolMetrics"/> /
+/// <see cref="Tamma.Activities.ADL.EmitPrEventActivity"/>).
+///
+/// <para>The instruments below realise the AC9-named metrics. Counters are split by
+/// terminal so the rate metrics the spec names — <c>blocker.resolved_rate</c> /
+/// <c>blocker.escalation_rate</c> — are derived in the dashboard as
+/// <c>blocker.resolved / blocker.total</c> etc. (we expose the raw numerators +
+/// denominator rather than precomputed ratios, which is the correct OTel idiom);
+/// <c>blocker.avg_resolution_time</c> is the mean of the
+/// <c>blocker.resolution_time</c> histogram. Per-level resolution-rate is the
+/// <c>blocker.resolved</c> counter sliced by its <c>level</c> tag; blocker-type
+/// distribution is any counter sliced by its <c>blocker_type</c> tag. Everything is
+/// tagged with <c>tenant</c> so per-tenant perf data stays tenant-scoped (Epic 32).</para>
+/// </summary>
+public static class BlockerMetrics
+{
+    /// <summary>Public meter name — pinned so dashboards stay stable.</summary>
+    public const string MeterName = "Tamma.Blocker";
+
+    private static readonly Meter Meter = new(MeterName, "1.0.0");
+
+    /// <summary>Total blockers diagnosed (denominator for the rate metrics).</summary>
+    private static readonly Counter<long> Total = Meter.CreateCounter<long>(
+        "blocker.total",
+        unit: "{blocker}",
+        description: "Total blockers diagnosed, tagged by blocker_type and tenant.");
+
+    /// <summary>Blockers that reached a Resolved terminal (numerator for resolved_rate).</summary>
+    private static readonly Counter<long> Resolved = Meter.CreateCounter<long>(
+        "blocker.resolved",
+        unit: "{blocker}",
+        description: "Blockers resolved, tagged by the resolving level, blocker_type and tenant.");
+
+    /// <summary>Blockers that reached an Escalated terminal (numerator for escalation_rate).</summary>
+    private static readonly Counter<long> Escalated = Meter.CreateCounter<long>(
+        "blocker.escalated",
+        unit: "{blocker}",
+        description: "Blockers escalated to a senior, tagged by blocker_type and tenant.");
+
+    /// <summary>Blockers whose escalation SLA expired with no senior response.</summary>
+    private static readonly Counter<long> TimedOut = Meter.CreateCounter<long>(
+        "blocker.timed_out",
+        unit: "{blocker}",
+        description: "Blockers whose escalation SLA expired with no senior response, tagged by blocker_type and tenant.");
+
+    /// <summary>Wall-clock resolution time (seconds) — the basis for avg_resolution_time.</summary>
+    private static readonly Histogram<double> ResolutionTime = Meter.CreateHistogram<double>(
+        "blocker.resolution_time",
+        unit: "s",
+        description: "Wall-clock time from blocker capture to terminal, tagged by terminal status, blocker_type and tenant.");
+
+    // In-process running totals since process start (lets unit tests assert increments
+    // without standing up a MeterListener — mirrors EmitPrEventActivity.PrsCreatedTotal).
+    private static long _total;
+    private static long _resolved;
+    private static long _escalated;
+    private static long _timedOut;
+
+    public static long TotalCount => Interlocked.Read(ref _total);
+    public static long ResolvedCount => Interlocked.Read(ref _resolved);
+    public static long EscalatedCount => Interlocked.Read(ref _escalated);
+    public static long TimedOutCount => Interlocked.Read(ref _timedOut);
+
+    private static KeyValuePair<string, object?>[] Tags(string? blockerType, string? tenant, string? level = null)
+    {
+        var tags = new List<KeyValuePair<string, object?>>(3)
+        {
+            new("blocker_type", blockerType ?? "Unknown"),
+            new("tenant", string.IsNullOrWhiteSpace(tenant) ? "platform" : tenant),
+        };
+        if (!string.IsNullOrWhiteSpace(level))
+            tags.Add(new("level", level));
+        return tags.ToArray();
+    }
+
+    /// <summary>Record a newly-diagnosed blocker (denominator).</summary>
+    public static void RecordDiagnosed(string? blockerType, string? tenant)
+    {
+        Interlocked.Increment(ref _total);
+        Total.Add(1, Tags(blockerType, tenant));
+    }
+
+    /// <summary>Record a Resolved terminal at <paramref name="level"/>.</summary>
+    public static void RecordResolved(string? blockerType, string? tenant, string? level, TimeSpan resolutionTime)
+    {
+        Interlocked.Increment(ref _resolved);
+        Resolved.Add(1, Tags(blockerType, tenant, level));
+        ResolutionTime.Record(resolutionTime.TotalSeconds, Tags(blockerType, tenant, level: "Resolved"));
+    }
+
+    /// <summary>Record an Escalated terminal (senior notified, awaiting response).</summary>
+    public static void RecordEscalated(string? blockerType, string? tenant, TimeSpan resolutionTime)
+    {
+        Interlocked.Increment(ref _escalated);
+        Escalated.Add(1, Tags(blockerType, tenant));
+        ResolutionTime.Record(resolutionTime.TotalSeconds, Tags(blockerType, tenant, level: "Escalated"));
+    }
+
+    /// <summary>Record a Timeout terminal (escalation SLA expired with no senior response).</summary>
+    public static void RecordTimedOut(string? blockerType, string? tenant, TimeSpan resolutionTime)
+    {
+        Interlocked.Increment(ref _timedOut);
+        TimedOut.Add(1, Tags(blockerType, tenant));
+        ResolutionTime.Record(resolutionTime.TotalSeconds, Tags(blockerType, tenant, level: "Timeout"));
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/BlockerSignalTimeout.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/BlockerSignalTimeout.cs
@@ -42,7 +42,19 @@ public static class BlockerSignalTimeout
         var workTask = work();
         var completed = await Task.WhenAny(workTask, Task.Delay(timeout));
         if (completed != workTask)
+        {
+            // The deadline won: we ABANDON (don't cancel — the integration methods take no
+            // CancellationToken) the slow work task. It keeps running and will eventually
+            // mutate its own collector signal in the background, but that is harmless: the
+            // aggregator reads ONLY each signal's CollectionSucceeded flag, which stays false
+            // on a timed-out collector (the caller never sets it on this path). Any exception
+            // the abandoned task later throws is observed by the discarded continuation below
+            // (so it is not an unobserved-task crash), not propagated to the caller.
+            _ = workTask.ContinueWith(
+                static t => _ = t.Exception,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
             return false;
+        }
 
         // Surface any exception from the (now-completed) work task to the caller's catch.
         await workTask;

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/BlockerSignalTimeout.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/BlockerSignalTimeout.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Tamma.Activities.Blocker;
+
+/// <summary>
+/// Completeness build-out 2026-06-22 (<c>BlockerDiagnosis.md</c> §Missing #12, 7-1G AC3) —
+/// shared per-collector wait cap for the parallel signal-collection fan-out. A hung
+/// integration call (slow / rate-limited GitHub) must NOT block the whole diagnosis: each
+/// collector races its work against a configurable deadline
+/// (<c>BlockerDiagnosis:SignalCollectionTimeoutSeconds</c>, default 15s = the AC3 cap). On
+/// expiry the collector lands as <c>CollectionSucceeded=false</c> (fail-soft partial signal)
+/// rather than hanging the join — the diagnosis proceeds on whatever signals resolved.
+///
+/// <para>The integration methods do not accept a <see cref="System.Threading.CancellationToken"/>,
+/// so this races the work against <see cref="Task.Delay(TimeSpan)"/> and abandons the slow
+/// task (its result is discarded) rather than cooperatively cancelling — a contained,
+/// fail-soft cap, not a hard kill.</para>
+/// </summary>
+public static class BlockerSignalTimeout
+{
+    /// <summary>The AC3 default: a 15-second per-collector deadline.</summary>
+    public const int DefaultTimeoutSeconds = 15;
+
+    /// <summary>
+    /// Resolve the per-collector timeout (seconds) from config, clamped to ≥ 1s, falling
+    /// back to <see cref="DefaultTimeoutSeconds"/>.
+    /// </summary>
+    public static int ResolveTimeoutSeconds(IConfiguration? configuration)
+    {
+        var configured = configuration?.GetValue<int?>("BlockerDiagnosis:SignalCollectionTimeoutSeconds");
+        return configured is > 0 ? configured.Value : DefaultTimeoutSeconds;
+    }
+
+    /// <summary>
+    /// Run <paramref name="work"/> under the resolved deadline. Returns <c>true</c> when the
+    /// work completed in time (the caller's signal is fully populated), <c>false</c> when the
+    /// deadline won (the caller leaves the signal as <c>CollectionSucceeded=false</c>).
+    /// </summary>
+    public static async Task<bool> RunAsync(IConfiguration? configuration, Func<Task> work)
+    {
+        var timeout = TimeSpan.FromSeconds(ResolveTimeoutSeconds(configuration));
+        var workTask = work();
+        var completed = await Task.WhenAny(workTask, Task.Delay(timeout));
+        if (completed != workTask)
+            return false;
+
+        // Surface any exception from the (now-completed) work task to the caller's catch.
+        await workTask;
+        return true;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/CollectCIStatusActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/CollectCIStatusActivity.cs
@@ -2,6 +2,7 @@ using Elsa.Extensions;
 using Elsa.Workflows;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
 using Tamma.Activities.Blocker.Models;
@@ -24,6 +25,7 @@ public class CollectCIStatusActivity : CodeActivity<CIStatusSignal>
 {
     private readonly ILogger<CollectCIStatusActivity>? _logger;
     private readonly IIntegrationService? _integrationService;
+    private readonly IConfiguration? _configuration;
 
     /// <summary>Repository URL or owner/repo</summary>
     [Input(Description = "Repository URL or owner/repo")]
@@ -38,10 +40,12 @@ public class CollectCIStatusActivity : CodeActivity<CIStatusSignal>
 
     public CollectCIStatusActivity(
         ILogger<CollectCIStatusActivity> logger,
-        IIntegrationService integrationService)
+        IIntegrationService integrationService,
+        IConfiguration configuration)
     {
         _logger = logger;
         _integrationService = integrationService;
+        _configuration = configuration;
     }
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
@@ -57,23 +61,37 @@ public class CollectCIStatusActivity : CodeActivity<CIStatusSignal>
 
         try
         {
-            var buildStatus = await _integrationService!.GetBuildStatusAsync(repository, branchName);
-            signal.BuildStatus = buildStatus.Status;
-            signal.BuildError = buildStatus.Error;
+            // AC3: cap the collector at the configured deadline (default 15s) so a slow
+            // CI / test trigger cannot block the parallel signal join.
+            var completedInTime = await BlockerSignalTimeout.RunAsync(_configuration, async () =>
+            {
+                var buildStatus = await _integrationService!.GetBuildStatusAsync(repository, branchName);
+                signal.BuildStatus = buildStatus.Status;
+                signal.BuildError = buildStatus.Error;
 
-            var testResults = await _integrationService.TriggerTestsAsync(repository, branchName);
-            signal.TotalTests = testResults.TotalTests;
-            signal.PassedTests = testResults.PassedTests;
-            signal.FailedTests = testResults.FailedTests;
-            signal.FailingTestNames = testResults.FailedTestDetails
-                .Select(t => t.TestName)
-                .ToList();
-            signal.CoveragePercentage = testResults.CoveragePercentage;
-            signal.CollectionSucceeded = true;
+                var testResults = await _integrationService.TriggerTestsAsync(repository, branchName);
+                signal.TotalTests = testResults.TotalTests;
+                signal.PassedTests = testResults.PassedTests;
+                signal.FailedTests = testResults.FailedTests;
+                signal.FailingTestNames = testResults.FailedTestDetails
+                    .Select(t => t.TestName)
+                    .ToList();
+                signal.CoveragePercentage = testResults.CoveragePercentage;
+            });
 
-            _logger?.LogInformation(
-                "CI status collected: Build={BuildStatus}, Tests={Passed}/{Total}",
-                signal.BuildStatus, signal.PassedTests, signal.TotalTests);
+            if (completedInTime)
+            {
+                signal.CollectionSucceeded = true;
+                _logger?.LogInformation(
+                    "CI status collected: Build={BuildStatus}, Tests={Passed}/{Total}",
+                    signal.BuildStatus, signal.PassedTests, signal.TotalTests);
+            }
+            else
+            {
+                signal.CollectionSucceeded = false;
+                signal.Error = "CI status collection timed out";
+                _logger?.LogWarning("CI status collection timed out — continuing with partial data");
+            }
         }
         catch (Exception ex)
         {

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/CollectGitActivityActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/CollectGitActivityActivity.cs
@@ -2,6 +2,7 @@ using Elsa.Extensions;
 using Elsa.Workflows;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
 using Tamma.Activities.Blocker.Models;
@@ -24,6 +25,7 @@ public class CollectGitActivityActivity : CodeActivity<GitActivitySignal>
 {
     private readonly ILogger<CollectGitActivityActivity>? _logger;
     private readonly IIntegrationService? _integrationService;
+    private readonly IConfiguration? _configuration;
 
     /// <summary>Repository URL or owner/repo</summary>
     [Input(Description = "Repository URL or owner/repo")]
@@ -42,10 +44,12 @@ public class CollectGitActivityActivity : CodeActivity<GitActivitySignal>
 
     public CollectGitActivityActivity(
         ILogger<CollectGitActivityActivity> logger,
-        IIntegrationService integrationService)
+        IIntegrationService integrationService,
+        IConfiguration configuration)
     {
         _logger = logger;
         _integrationService = integrationService;
+        _configuration = configuration;
     }
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
@@ -62,25 +66,39 @@ public class CollectGitActivityActivity : CodeActivity<GitActivitySignal>
 
         try
         {
-            var since = DateTime.UtcNow.AddHours(-lookbackHours);
-            var commits = await _integrationService!.GetGitHubCommitsAsync(repository, branchName, since);
+            // AC3: cap the collector at the configured deadline (default 15s) so a slow
+            // GitHub call cannot block the parallel signal join.
+            var completedInTime = await BlockerSignalTimeout.RunAsync(_configuration, async () =>
+            {
+                var since = DateTime.UtcNow.AddHours(-lookbackHours);
+                var commits = await _integrationService!.GetGitHubCommitsAsync(repository, branchName, since);
 
-            signal.RecentCommitCount = commits.Count;
-            signal.LastCommitTime = commits.Any() ? commits.Max(c => c.Timestamp) : null;
-            signal.TimeSinceLastCommit = signal.LastCommitTime.HasValue
-                ? DateTime.UtcNow - signal.LastCommitTime.Value
-                : TimeSpan.FromHours(lookbackHours);
+                signal.RecentCommitCount = commits.Count;
+                signal.LastCommitTime = commits.Any() ? commits.Max(c => c.Timestamp) : null;
+                signal.TimeSinceLastCommit = signal.LastCommitTime.HasValue
+                    ? DateTime.UtcNow - signal.LastCommitTime.Value
+                    : TimeSpan.FromHours(lookbackHours);
 
-            var fileChanges = await _integrationService.GetGitHubFileChangesAsync(repository, branchName);
-            signal.FilesChanged = fileChanges.Count;
-            signal.TotalAdditions = fileChanges.Sum(f => f.Additions);
-            signal.TotalDeletions = fileChanges.Sum(f => f.Deletions);
-            signal.ChangedFiles = fileChanges.Select(f => f.FilePath).ToList();
-            signal.CollectionSucceeded = true;
+                var fileChanges = await _integrationService.GetGitHubFileChangesAsync(repository, branchName);
+                signal.FilesChanged = fileChanges.Count;
+                signal.TotalAdditions = fileChanges.Sum(f => f.Additions);
+                signal.TotalDeletions = fileChanges.Sum(f => f.Deletions);
+                signal.ChangedFiles = fileChanges.Select(f => f.FilePath).ToList();
+            });
 
-            _logger?.LogInformation(
-                "Git activity collected: {CommitCount} commits, {FilesChanged} files changed",
-                signal.RecentCommitCount, signal.FilesChanged);
+            if (completedInTime)
+            {
+                signal.CollectionSucceeded = true;
+                _logger?.LogInformation(
+                    "Git activity collected: {CommitCount} commits, {FilesChanged} files changed",
+                    signal.RecentCommitCount, signal.FilesChanged);
+            }
+            else
+            {
+                signal.CollectionSucceeded = false;
+                signal.Error = "Git activity collection timed out";
+                _logger?.LogWarning("Git activity collection timed out — continuing with partial data");
+            }
         }
         catch (Exception ex)
         {

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/CollectInactivityActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/CollectInactivityActivity.cs
@@ -2,6 +2,7 @@ using Elsa.Extensions;
 using Elsa.Workflows;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
 using Tamma.Activities.Blocker.Models;
@@ -24,6 +25,7 @@ public class CollectInactivityActivity : CodeActivity<InactivitySignal>
 {
     private readonly ILogger<CollectInactivityActivity>? _logger;
     private readonly IIntegrationService? _integrationService;
+    private readonly IConfiguration? _configuration;
 
     /// <summary>Repository URL or owner/repo</summary>
     [Input(Description = "Repository URL or owner/repo")]
@@ -42,10 +44,12 @@ public class CollectInactivityActivity : CodeActivity<InactivitySignal>
 
     public CollectInactivityActivity(
         ILogger<CollectInactivityActivity> logger,
-        IIntegrationService integrationService)
+        IIntegrationService integrationService,
+        IConfiguration configuration)
     {
         _logger = logger;
         _integrationService = integrationService;
+        _configuration = configuration;
     }
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
@@ -62,29 +66,43 @@ public class CollectInactivityActivity : CodeActivity<InactivitySignal>
 
         try
         {
-            // Use recent commits as a proxy for activity
-            var since = DateTime.UtcNow.AddHours(-24);
-            var commits = await _integrationService!.GetGitHubCommitsAsync(repository, branchName, since);
-
-            if (commits.Any())
+            // AC3: cap the collector at the configured deadline (default 15s) so a slow
+            // commits call cannot block the parallel signal join.
+            var completedInTime = await BlockerSignalTimeout.RunAsync(_configuration, async () =>
             {
-                var lastCommitTime = commits.Max(c => c.Timestamp);
-                signal.LastActivityTime = lastCommitTime;
-                signal.LastActivityType = "commit";
-                signal.TimeSinceLastActivity = DateTime.UtcNow - lastCommitTime;
+                // Use recent commits as a proxy for activity
+                var since = DateTime.UtcNow.AddHours(-24);
+                var commits = await _integrationService!.GetGitHubCommitsAsync(repository, branchName, since);
+
+                if (commits.Any())
+                {
+                    var lastCommitTime = commits.Max(c => c.Timestamp);
+                    signal.LastActivityTime = lastCommitTime;
+                    signal.LastActivityType = "commit";
+                    signal.TimeSinceLastActivity = DateTime.UtcNow - lastCommitTime;
+                }
+                else
+                {
+                    signal.TimeSinceLastActivity = TimeSpan.FromHours(24);
+                    signal.LastActivityType = "none";
+                }
+
+                signal.IsInactive = signal.TimeSinceLastActivity.TotalMinutes > thresholdMinutes;
+            });
+
+            if (completedInTime)
+            {
+                signal.CollectionSucceeded = true;
+                _logger?.LogInformation(
+                    "Inactivity collected: TimeSince={TimeSince}min, IsInactive={IsInactive}",
+                    signal.TimeSinceLastActivity.TotalMinutes, signal.IsInactive);
             }
             else
             {
-                signal.TimeSinceLastActivity = TimeSpan.FromHours(24);
-                signal.LastActivityType = "none";
+                signal.CollectionSucceeded = false;
+                signal.Error = "Inactivity collection timed out";
+                _logger?.LogWarning("Inactivity collection timed out — continuing with partial data");
             }
-
-            signal.IsInactive = signal.TimeSinceLastActivity.TotalMinutes > thresholdMinutes;
-            signal.CollectionSucceeded = true;
-
-            _logger?.LogInformation(
-                "Inactivity collected: TimeSince={TimeSince}min, IsInactive={IsInactive}",
-                signal.TimeSinceLastActivity.TotalMinutes, signal.IsInactive);
         }
         catch (Exception ex)
         {

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/DetectProgressActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/DetectProgressActivity.cs
@@ -1,7 +1,9 @@
 using Elsa.Extensions;
+using Elsa.Scheduling;
 using Elsa.Workflows;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
 using Tamma.Activities.Blocker.Models;
@@ -17,17 +19,29 @@ namespace Tamma.Activities.Blocker;
 ///   - File changes in relevant files
 ///
 /// The workflow suspends at this point and is resumed externally when progress
-/// is detected or the wait time expires.
+/// is detected.
+///
+/// <para><b>Durable wait-timeout (completeness audit 2026-06-22, 7-1G AC6 / §Missing #1+#2).</b>
+/// Alongside the progress bookmark this activity schedules a delayed resume of the SAME
+/// bookmark at <c>now + WaitTimeMinutes</c> via <see cref="IWorkflowScheduler"/> (the durable
+/// scheduling seam <c>UseScheduling()</c> wires). If no external progress signal arrives first,
+/// the scheduled resume fires with <c>Timeout=true</c> → <see cref="TimedOut"/> output and
+/// <see cref="ProgressDetected"/>=false, and the activity completes. This closes the
+/// hang-forever hole: a never-resumed bookmark now always terminates as a real per-level
+/// timeout rather than suspending indefinitely. The wait time is sourced from config
+/// (<c>BlockerDiagnosis:WaitTimeMinutes:{level}</c>, optionally <c>:Extended</c> for skill ≥
+/// the configured extended-skill floor) with the historical constants as the fallback.</para>
 /// </summary>
 [Activity(
     "Tamma.Blocker",
     "Detect Progress",
-    "Wait for and detect junior's progress after resolution attempt",
+    "Wait for and detect junior's progress after resolution attempt (durable per-level timeout)",
     Kind = ActivityKind.Task
 )]
 public class DetectProgressActivity : Activity
 {
     private readonly ILogger<DetectProgressActivity>? _logger;
+    private readonly IConfiguration? _configuration;
 
     /// <summary>Mentorship session ID</summary>
     [Input(Description = "Mentorship session ID")]
@@ -45,13 +59,17 @@ public class DetectProgressActivity : Activity
     [Input(Description = "Current resolution level")]
     public Input<string> CurrentLevel { get; set; } = default!;
 
-    /// <summary>Wait time in minutes before escalating</summary>
-    [Input(Description = "Wait time in minutes before escalating", DefaultValue = 15)]
-    public Input<int> WaitTimeMinutes { get; set; } = new(15);
+    /// <summary>Wait time in minutes before timing out (0 → resolve from config/defaults).</summary>
+    [Input(Description = "Wait time in minutes before timing out (0 = use BlockerDiagnosis config)", DefaultValue = 0)]
+    public Input<int> WaitTimeMinutes { get; set; } = new(0);
 
     /// <summary>Whether progress was detected</summary>
     [Output(Description = "Whether progress was detected")]
     public Output<bool> ProgressDetected { get; set; } = default!;
+
+    /// <summary>Whether the per-level wait expired with no progress (durable timeout).</summary>
+    [Output(Description = "Whether the per-level wait expired with no progress")]
+    public Output<bool> TimedOut { get; set; } = default!;
 
     /// <summary>Details of the progress detection result</summary>
     [Output(Description = "Progress detection result details")]
@@ -60,55 +78,89 @@ public class DetectProgressActivity : Activity
     [JsonConstructor]
     public DetectProgressActivity() { }
 
-    public DetectProgressActivity(ILogger<DetectProgressActivity> logger)
+    public DetectProgressActivity(ILogger<DetectProgressActivity> logger, IConfiguration configuration)
     {
         _logger = logger;
+        _configuration = configuration;
     }
 
     protected override void Execute(ActivityExecutionContext context)
     {
         var sessionId = SessionId.Get(context);
-        var storyId = StoryId.Get(context);
-        var juniorId = JuniorId.Get(context);
         var currentLevel = CurrentLevel.Get(context);
-        var waitTimeMinutes = WaitTimeMinutes.Get(context);
+        var waitTimeMinutes = ResolveWaitMinutes(context, currentLevel);
 
         _logger?.LogInformation(
             "Waiting for progress detection: Session={SessionId}, Level={Level}, Timeout={Timeout}min",
             sessionId, currentLevel, waitTimeMinutes);
 
-        var payload = new ProgressDetectionPayload
-        {
-            SessionId = sessionId,
-            StoryId = storyId,
-            JuniorId = juniorId,
-            CurrentLevel = Enum.TryParse<ResolutionLevel>(currentLevel, out var level)
-                ? level
-                : ResolutionLevel.Hint,
-            WaitTimeMinutes = waitTimeMinutes
-        };
-
-        // Create bookmark — workflow suspends here until external resume
+        // Create the progress bookmark with a deterministic id so the scheduled timeout can
+        // resume THIS bookmark. The workflow suspends here until external resume OR the
+        // scheduled timeout below fires.
+        var bookmarkId = Guid.NewGuid().ToString("N");
         context.CreateBookmark(new CreateBookmarkArgs
         {
+            BookmarkId = bookmarkId,
             BookmarkName = $"blocker-progress-{sessionId}-{currentLevel}",
             Callback = OnResumeAsync,
             AutoBurn = true
         });
+
+        ScheduleTimeout(context, bookmarkId, waitTimeMinutes);
+    }
+
+    /// <summary>
+    /// Schedule a durable resume of the progress bookmark at <c>now + waitMinutes</c> carrying
+    /// <c>Timeout=true</c>. Best-effort: if the scheduling seam is unavailable the bookmark
+    /// still exists (so an external progress signal can resume it) — we log loudly rather
+    /// than fail the run, but the no-hang guarantee only holds when scheduling is wired
+    /// (<c>UseScheduling()</c>, which the engine host enables).
+    /// </summary>
+    private void ScheduleTimeout(ActivityExecutionContext context, string bookmarkId, int waitMinutes)
+    {
+        var scheduler = context.GetService<IWorkflowScheduler>();
+        if (scheduler is null)
+        {
+            _logger?.LogWarning(
+                "IWorkflowScheduler unavailable — progress bookmark {BookmarkId} has no durable timeout "
+                + "(relies on an external resume).", bookmarkId);
+            return;
+        }
+
+        var instanceId = context.WorkflowExecutionContext.Id;
+        var resumeAt = DateTimeOffset.UtcNow.AddMinutes(Math.Max(1, waitMinutes));
+        var taskName = $"blocker-progress-timeout-{instanceId}-{bookmarkId}";
+
+        var request = new ScheduleExistingWorkflowInstanceRequest
+        {
+            WorkflowInstanceId = instanceId,
+            BookmarkId = bookmarkId,
+            Input = new Dictionary<string, object> { ["Timeout"] = true }
+        };
+
+        // Fire-and-forget the async schedule call from this sync Execute; ScheduleAtAsync only
+        // enqueues a scheduler job (no workflow execution happens inline).
+        scheduler.ScheduleAtAsync(taskName, request, resumeAt).AsTask().GetAwaiter().GetResult();
+
+        _logger?.LogInformation(
+            "Scheduled progress-timeout for bookmark {BookmarkId} at {ResumeAt:o} ({WaitMinutes}min)",
+            bookmarkId, resumeAt, waitMinutes);
     }
 
     private async ValueTask OnResumeAsync(ActivityExecutionContext context)
     {
         var input = context.WorkflowInput;
 
-        var progressDetected = input.TryGetValue("ProgressDetected", out var pd)
+        var isTimeout = input.TryGetValue("Timeout", out var to) && to is true;
+        var progressDetected = !isTimeout
+            && input.TryGetValue("ProgressDetected", out var pd)
             && pd is true;
-        var progressType = input.TryGetValue("ProgressType", out var pt)
-            ? pt?.ToString()
-            : null;
-        var details = input.TryGetValue("Details", out var d)
-            ? d?.ToString()
-            : null;
+        var progressType = isTimeout
+            ? "Timeout"
+            : input.TryGetValue("ProgressType", out var pt) ? pt?.ToString() : null;
+        var details = isTimeout
+            ? "Per-level wait expired with no progress"
+            : input.TryGetValue("Details", out var d) ? d?.ToString() : null;
 
         var result = new ProgressDetectionResult
         {
@@ -118,12 +170,50 @@ public class DetectProgressActivity : Activity
         };
 
         _logger?.LogInformation(
-            "Progress detection resumed: Detected={Detected}, Type={Type}",
-            progressDetected, progressType);
+            "Progress detection resumed: Detected={Detected}, TimedOut={TimedOut}, Type={Type}",
+            progressDetected, isTimeout, progressType);
 
         context.Set(ProgressDetected, progressDetected);
+        context.Set(TimedOut, isTimeout);
         context.Set(Result, result);
 
         await context.CompleteActivityAsync();
+    }
+
+    /// <summary>
+    /// Resolve the per-level wait minutes. Precedence: an explicit positive
+    /// <see cref="WaitTimeMinutes"/> input wins; otherwise read
+    /// <c>BlockerDiagnosis:WaitTimeMinutes:{level}</c> from config; otherwise the historical
+    /// per-level defaults (Hint 15 / Guidance 30 / Assistance 45). For the Hint level a
+    /// skill ≥ <c>BlockerDiagnosis:ExtendedHintSkillFloor</c> (default 4) uses
+    /// <c>BlockerDiagnosis:WaitTimeMinutes:Hint:Extended</c> (default 30).
+    /// </summary>
+    internal int ResolveWaitMinutes(ActivityExecutionContext context, string level)
+    {
+        var explicitValue = WaitTimeMinutes.Get(context);
+        var fromConfig = _configuration?.GetValue<int?>($"BlockerDiagnosis:WaitTimeMinutes:{level}");
+        return ResolveWaitMinutes(explicitValue, fromConfig, level);
+    }
+
+    /// <summary>
+    /// Pure wait-minutes resolution (exposed for unit testing). Precedence:
+    /// a positive <paramref name="explicitValue"/> input wins; else a positive
+    /// <paramref name="configValue"/> (<c>BlockerDiagnosis:WaitTimeMinutes:{level}</c>);
+    /// else the historical per-level default (Hint 15 / Guidance 30 / Assistance 45).
+    /// </summary>
+    internal static int ResolveWaitMinutes(int explicitValue, int? configValue, string level)
+    {
+        if (explicitValue > 0)
+            return explicitValue;
+        if (configValue is > 0)
+            return configValue.Value;
+
+        return level switch
+        {
+            "Hint" => 15,
+            "Guidance" => 30,
+            "Assistance" => 45,
+            _ => 15
+        };
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/DetectProgressActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/DetectProgressActivity.cs
@@ -1,5 +1,4 @@
 using Elsa.Extensions;
-using Elsa.Scheduling;
 using Elsa.Workflows;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
@@ -21,16 +20,27 @@ namespace Tamma.Activities.Blocker;
 /// The workflow suspends at this point and is resumed externally when progress
 /// is detected.
 ///
-/// <para><b>Durable wait-timeout (completeness audit 2026-06-22, 7-1G AC6 / §Missing #1+#2).</b>
-/// Alongside the progress bookmark this activity schedules a delayed resume of the SAME
-/// bookmark at <c>now + WaitTimeMinutes</c> via <see cref="IWorkflowScheduler"/> (the durable
-/// scheduling seam <c>UseScheduling()</c> wires). If no external progress signal arrives first,
-/// the scheduled resume fires with <c>Timeout=true</c> → <see cref="TimedOut"/> output and
-/// <see cref="ProgressDetected"/>=false, and the activity completes. This closes the
-/// hang-forever hole: a never-resumed bookmark now always terminates as a real per-level
-/// timeout rather than suspending indefinitely. The wait time is sourced from config
-/// (<c>BlockerDiagnosis:WaitTimeMinutes:{level}</c>, optionally <c>:Extended</c> for skill ≥
-/// the configured extended-skill floor) with the historical constants as the fallback.</para>
+/// <para><b>Durable wait-timeout (completeness audit 2026-06-22, 7-1G AC6 / §Missing #1+#2;
+/// hardened 2026-06-25 to the durable Delay primitive).</b>
+/// Two resume paths are armed when the activity suspends:</para>
+/// <list type="number">
+///   <item><description>a custom progress bookmark (<c>blocker-progress-{session}-{level}</c>)
+///     resumed by the external progress signal → <see cref="ProgressDetected"/>; and</description></item>
+///   <item><description>a DURABLE delay bookmark via
+///     <see cref="Elsa.Extensions.DelayActivityExecutionContextExtensions.DelayFor(ActivityExecutionContext, System.TimeSpan, ExecuteActivityDelegate)"/>
+///     — the same EF-persisted Delay primitive the framework's <c>Delay</c> activity uses,
+///     which <c>Elsa.Scheduling</c>'s startup background task RE-ARMS after a host restart →
+///     <see cref="TimedOut"/>.</description></item>
+/// </list>
+/// <para>The earlier build used <c>IWorkflowScheduler.ScheduleAtAsync</c>, whose default
+/// (in-memory <c>LocalScheduler</c> / <c>System.Timers.Timer</c>) backing is LOST on a host
+/// restart → the bookmark would hang forever (the exact P0 this was meant to close). The
+/// Delay bookmark is persisted and re-armed on rehydration, so a host restart mid-wait no
+/// longer drops the timeout. Whichever path resumes first completes the activity; Elsa burns
+/// the activity's remaining bookmark on completion, so there is no orphaned timer / stale
+/// double-resume. The wait time is sourced from config
+/// (<c>BlockerDiagnosis:WaitTimeMinutes:{level}</c>) with the historical constants as the
+/// fallback.</para>
 /// </summary>
 [Activity(
     "Tamma.Blocker",
@@ -94,73 +104,35 @@ public class DetectProgressActivity : Activity
             "Waiting for progress detection: Session={SessionId}, Level={Level}, Timeout={Timeout}min",
             sessionId, currentLevel, waitTimeMinutes);
 
-        // Create the progress bookmark with a deterministic id so the scheduled timeout can
-        // resume THIS bookmark. The workflow suspends here until external resume OR the
-        // scheduled timeout below fires.
-        var bookmarkId = Guid.NewGuid().ToString("N");
+        // 1) Progress bookmark — resumed by the external progress signal (commit/CI/junior
+        //    "resolved"). The workflow suspends here until this resumes OR the durable delay
+        //    below fires, whichever happens first.
         context.CreateBookmark(new CreateBookmarkArgs
         {
-            BookmarkId = bookmarkId,
             BookmarkName = $"blocker-progress-{sessionId}-{currentLevel}",
             Callback = OnResumeAsync,
             AutoBurn = true
         });
 
-        ScheduleTimeout(context, bookmarkId, waitTimeMinutes);
+        // 2) Durable timeout — a DelayFor (Delay) bookmark that Elsa.Scheduling's startup
+        //    background task RE-ARMS after a host restart (EF-persisted, not an in-memory
+        //    timer). Closes the hang-forever hole: a never-resumed progress bookmark now
+        //    always terminates as a real per-level timeout even across a VPS restart.
+        context.DelayFor(TimeSpan.FromMinutes(Math.Max(1, waitTimeMinutes)), OnTimeoutAsync);
     }
 
     /// <summary>
-    /// Schedule a durable resume of the progress bookmark at <c>now + waitMinutes</c> carrying
-    /// <c>Timeout=true</c>. Best-effort: if the scheduling seam is unavailable the bookmark
-    /// still exists (so an external progress signal can resume it) — we log loudly rather
-    /// than fail the run, but the no-hang guarantee only holds when scheduling is wired
-    /// (<c>UseScheduling()</c>, which the engine host enables).
+    /// External resume path: the junior made progress. Reads the progress fields from the
+    /// resume input, flags <see cref="ProgressDetected"/>, and completes — Elsa burns the
+    /// still-armed Delay bookmark on completion (no orphaned timer).
     /// </summary>
-    private void ScheduleTimeout(ActivityExecutionContext context, string bookmarkId, int waitMinutes)
-    {
-        var scheduler = context.GetService<IWorkflowScheduler>();
-        if (scheduler is null)
-        {
-            _logger?.LogWarning(
-                "IWorkflowScheduler unavailable — progress bookmark {BookmarkId} has no durable timeout "
-                + "(relies on an external resume).", bookmarkId);
-            return;
-        }
-
-        var instanceId = context.WorkflowExecutionContext.Id;
-        var resumeAt = DateTimeOffset.UtcNow.AddMinutes(Math.Max(1, waitMinutes));
-        var taskName = $"blocker-progress-timeout-{instanceId}-{bookmarkId}";
-
-        var request = new ScheduleExistingWorkflowInstanceRequest
-        {
-            WorkflowInstanceId = instanceId,
-            BookmarkId = bookmarkId,
-            Input = new Dictionary<string, object> { ["Timeout"] = true }
-        };
-
-        // Fire-and-forget the async schedule call from this sync Execute; ScheduleAtAsync only
-        // enqueues a scheduler job (no workflow execution happens inline).
-        scheduler.ScheduleAtAsync(taskName, request, resumeAt).AsTask().GetAwaiter().GetResult();
-
-        _logger?.LogInformation(
-            "Scheduled progress-timeout for bookmark {BookmarkId} at {ResumeAt:o} ({WaitMinutes}min)",
-            bookmarkId, resumeAt, waitMinutes);
-    }
-
     private async ValueTask OnResumeAsync(ActivityExecutionContext context)
     {
         var input = context.WorkflowInput;
 
-        var isTimeout = input.TryGetValue("Timeout", out var to) && to is true;
-        var progressDetected = !isTimeout
-            && input.TryGetValue("ProgressDetected", out var pd)
-            && pd is true;
-        var progressType = isTimeout
-            ? "Timeout"
-            : input.TryGetValue("ProgressType", out var pt) ? pt?.ToString() : null;
-        var details = isTimeout
-            ? "Per-level wait expired with no progress"
-            : input.TryGetValue("Details", out var d) ? d?.ToString() : null;
+        var progressDetected = input.TryGetValue("ProgressDetected", out var pd) && pd is true;
+        var progressType = input.TryGetValue("ProgressType", out var pt) ? pt?.ToString() : null;
+        var details = input.TryGetValue("Details", out var d) ? d?.ToString() : null;
 
         var result = new ProgressDetectionResult
         {
@@ -170,11 +142,41 @@ public class DetectProgressActivity : Activity
         };
 
         _logger?.LogInformation(
-            "Progress detection resumed: Detected={Detected}, TimedOut={TimedOut}, Type={Type}",
-            progressDetected, isTimeout, progressType);
+            "Progress detection resumed (external): Detected={Detected}, Type={Type}",
+            progressDetected, progressType);
 
         context.Set(ProgressDetected, progressDetected);
-        context.Set(TimedOut, isTimeout);
+        context.Set(TimedOut, false);
+        context.Set(Result, result);
+
+        await context.CompleteActivityAsync();
+    }
+
+    /// <summary>
+    /// Durable timeout path: the per-level wait elapsed with no external progress signal. The
+    /// Delay bookmark scheduler resumes the activity here (and re-arms across a host restart).
+    /// Flags <see cref="TimedOut"/> (and <see cref="ProgressDetected"/>=false) so the ladder
+    /// advances instead of suspending forever; the still-armed progress bookmark is burned on
+    /// completion.
+    /// </summary>
+    private async ValueTask OnTimeoutAsync(ActivityExecutionContext context)
+    {
+        var sessionId = SessionId.Get(context);
+        var currentLevel = CurrentLevel.Get(context);
+
+        _logger?.LogInformation(
+            "Progress detection timed out (durable): Session={SessionId}, Level={Level} — advancing ladder",
+            sessionId, currentLevel);
+
+        var result = new ProgressDetectionResult
+        {
+            ProgressDetected = false,
+            ProgressType = "Timeout",
+            Details = "Per-level wait expired with no progress"
+        };
+
+        context.Set(ProgressDetected, false);
+        context.Set(TimedOut, true);
         context.Set(Result, result);
 
         await context.CompleteActivityAsync();

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/EmitBlockerEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/EmitBlockerEventActivity.cs
@@ -1,0 +1,184 @@
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+
+namespace Tamma.Activities.Blocker;
+
+/// <summary>
+/// Emits a <c>BLOCKER.*</c> DCB event (completeness audit 2026-06-22,
+/// <c>BlockerDiagnosis.md</c> §Missing #3, 7-1G AC9) for the <c>blocker-diagnosis</c>
+/// sub-workflow by appending a <see cref="TammaEvent"/> to the workflow's
+/// <c>tamma:events</c> transient list via <see cref="TammaEventEmitter.Emit"/>. The
+/// merged engine event drain (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>)
+/// flushes that list <i>durably</i> to the tenant <c>domain_events</c> store after this
+/// activity runs — the same pattern <see cref="Tamma.Activities.ADL.EmitBranchEventActivity"/>
+/// and <see cref="Tamma.Activities.ADL.EmitPrEventActivity"/> use. No activity holds a DB /
+/// repository dependency of its own (none is registered in the Elsa engine — a directly
+/// injected <c>IEventRepository</c> would be inert and silently drop every event).
+///
+/// <para>On the terminal transitions it also records the AC9 OTel metrics via
+/// <see cref="BlockerMetrics"/> (<c>blocker.total</c> on diagnosed, and
+/// <c>blocker.resolved</c> / <c>blocker.escalated</c> / <c>blocker.timed_out</c> +
+/// the <c>blocker.resolution_time</c> histogram on the matching terminal).</para>
+/// </summary>
+[Activity(
+    "Tamma.Blocker",
+    "Emit Blocker Event",
+    "Emit a BLOCKER.* DCB event for the blocker-diagnosis audit trail",
+    Kind = ActivityKind.Task
+)]
+public class EmitBlockerEventActivity : Activity
+{
+    private readonly ILogger<EmitBlockerEventActivity>? _logger;
+
+    [Input(Description = "Event type — BLOCKER.DIAGNOSED.SUCCESS / .RESOLUTION_ATTEMPTED / .PROGRESS_DETECTED / .PROGRESS_TIMED_OUT / .ESCALATED / .RESOLVED / .TIMED_OUT")]
+    public Input<string> EventType { get; set; } = default!;
+
+    [Input(Description = "Mentorship session id")]
+    public Input<string?> SessionId { get; set; } = new((string?)null);
+
+    [Input(Description = "Story id the junior is blocked on")]
+    public Input<string?> StoryId { get; set; } = new((string?)null);
+
+    [Input(Description = "Junior developer id")]
+    public Input<string?> JuniorId { get; set; } = new((string?)null);
+
+    [Input(Description = "Tenant id (empty / single-user → platform-scope event)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [Input(Description = "Classified blocker type (8 categories)")]
+    public Input<string?> BlockerType { get; set; } = new((string?)null);
+
+    [Input(Description = "Blocker severity")]
+    public Input<string?> Severity { get; set; } = new((string?)null);
+
+    [Input(Description = "Resolution level for this attempt (Hint/Guidance/Assistance/Escalation)")]
+    public Input<string?> Level { get; set; } = new((string?)null);
+
+    [Input(Description = "Attempt number (1-based) for a RESOLUTION_ATTEMPTED event")]
+    public Input<int> Attempt { get; set; } = new(0);
+
+    [Input(Description = "Diagnosis confidence 0..1 (DIAGNOSED events)")]
+    public Input<double> Confidence { get; set; } = new(0d);
+
+    [Input(Description = "Progress type detail (PROGRESS_DETECTED events)")]
+    public Input<string?> ProgressType { get; set; } = new((string?)null);
+
+    [Input(Description = "Total resolution time in seconds (terminal events)")]
+    public Input<double> ResolutionTimeSeconds { get; set; } = new(0d);
+
+    [JsonConstructor]
+    public EmitBlockerEventActivity() { }
+
+    public EmitBlockerEventActivity(ILogger<EmitBlockerEventActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var type = EventType.Get(context) ?? BlockerEvents.DiagnosedFailed;
+        var sessionId = SessionId.Get(context);
+        var storyId = StoryId.Get(context);
+        var juniorId = JuniorId.Get(context);
+        var tenantRaw = TenantId.Get(context);
+        var tenantId = BlockerEvents.ParseTenantId(tenantRaw);
+        var blockerType = BlockerType.Get(context);
+        var severity = Severity.Get(context);
+        var level = Level.Get(context);
+        var attempt = Attempt.Get(context);
+        var confidence = Confidence.Get(context);
+        var progressType = ProgressType.Get(context);
+        var resolutionSeconds = ResolutionTimeSeconds.Get(context);
+
+        // Metrics first — they must fire on the matching transition regardless of the
+        // (best-effort) durable event append. Tenant tag uses the parsed canonical form
+        // (null → "platform") so per-tenant perf data stays tenant-scoped (Epic 32).
+        var tenantTag = tenantId?.ToString("D");
+        RecordMetric(type, blockerType, tenantTag, level, resolutionSeconds);
+
+        var evt = BuildTammaEvent(
+            type, sessionId, storyId, juniorId, tenantId, blockerType, severity,
+            level, attempt, confidence, progressType, resolutionSeconds);
+        TammaEventEmitter.Emit(context, this, _logger, evt);
+
+        _logger?.LogInformation(
+            "Emitted {Type} for session {Session} story {Story} (level={Level}, attempt={Attempt})",
+            type, sessionId, storyId, level, attempt);
+
+        return default;
+    }
+
+    private static void RecordMetric(
+        string type, string? blockerType, string? tenantTag, string? level, double resolutionSeconds)
+    {
+        var rt = TimeSpan.FromSeconds(resolutionSeconds);
+        switch (type)
+        {
+            case BlockerEvents.DiagnosedSuccess:
+                BlockerMetrics.RecordDiagnosed(blockerType, tenantTag);
+                break;
+            case BlockerEvents.Resolved:
+                BlockerMetrics.RecordResolved(blockerType, tenantTag, level, rt);
+                break;
+            case BlockerEvents.Escalated:
+                BlockerMetrics.RecordEscalated(blockerType, tenantTag, rt);
+                break;
+            case BlockerEvents.TimedOut:
+                BlockerMetrics.RecordTimedOut(blockerType, tenantTag, rt);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Map the blocker event inputs onto a <see cref="TammaEvent"/> expressed as the
+    /// engine's transient-list event so the merged drain persists it. Tags carry the
+    /// queryable DCB index keys (<c>sessionId</c>/<c>storyId</c>/<c>juniorId</c>/
+    /// <c>level</c>/<c>blockerType</c>/<c>severity</c>/<c>tenantId</c>); <c>Data</c>
+    /// carries the per-attempt / terminal payload. Status is driven off the event type
+    /// (<see cref="BlockerEvents.StatusForEvent"/>) so a never-answered escalation
+    /// (<c>BLOCKER.TIMED_OUT</c>) is a LOUD error row, never a false success. Pure (no
+    /// Elsa context); exposed for unit testing the mapping.
+    /// </summary>
+    public static TammaEvent BuildTammaEvent(
+        string type,
+        string? sessionId,
+        string? storyId,
+        string? juniorId,
+        Guid? tenantId,
+        string? blockerType,
+        string? severity,
+        string? level,
+        int attempt,
+        double confidence,
+        string? progressType,
+        double resolutionTimeSeconds)
+    {
+        var tags = new Dictionary<string, object?>();
+        if (!string.IsNullOrWhiteSpace(sessionId)) tags["sessionId"] = sessionId;
+        if (!string.IsNullOrWhiteSpace(storyId)) tags["storyId"] = storyId;
+        if (!string.IsNullOrWhiteSpace(juniorId)) tags["juniorId"] = juniorId;
+        if (!string.IsNullOrWhiteSpace(level)) tags["level"] = level;
+        if (!string.IsNullOrWhiteSpace(blockerType)) tags["blockerType"] = blockerType;
+        if (!string.IsNullOrWhiteSpace(severity)) tags["severity"] = severity;
+        if (tenantId is not null) tags["tenantId"] = tenantId.Value.ToString("D");
+
+        var data = new Dictionary<string, object?>();
+        if (attempt > 0) data["attempt"] = attempt;
+        if (confidence > 0d) data["confidence"] = confidence;
+        if (!string.IsNullOrWhiteSpace(progressType)) data["progressType"] = progressType;
+        if (resolutionTimeSeconds > 0d) data["resolutionTimeSeconds"] = resolutionTimeSeconds;
+
+        return new TammaEvent
+        {
+            EventType = type,
+            Status = BlockerEvents.StatusForEvent(type),
+            Tags = tags,
+            Data = data,
+        };
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/EscalateToSeniorActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/EscalateToSeniorActivity.cs
@@ -1,4 +1,5 @@
 using Elsa.Extensions;
+using Elsa.Scheduling;
 using Elsa.Workflows;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
@@ -62,6 +63,10 @@ public class EscalateToSeniorActivity : Activity
     [Output(Description = "Whether the senior resolved the blocker")]
     public Output<bool> Resolved { get; set; } = default!;
 
+    /// <summary>Whether the senior-response SLA expired with no response (durable timeout).</summary>
+    [Output(Description = "Whether the senior-response SLA expired with no response")]
+    public Output<bool> TimedOut { get; set; } = default!;
+
     /// <summary>Senior's response</summary>
     [Output(Description = "Senior's response")]
     public Output<string?> SeniorResponse { get; set; } = default!;
@@ -115,20 +120,56 @@ public class EscalateToSeniorActivity : Activity
         // Notify senior via configured channel
         await NotifySenior(escalationContext);
 
-        var payload = new EscalationPayload
-        {
-            SessionId = sessionId,
-            StoryId = storyId,
-            JuniorId = juniorId
-        };
-
-        // Create bookmark — workflow suspends and waits for senior response
+        // Create bookmark — workflow suspends and waits for senior response. A deterministic
+        // id lets the scheduled SLA timeout resume THIS bookmark.
+        var bookmarkId = Guid.NewGuid().ToString("N");
         context.CreateBookmark(new CreateBookmarkArgs
         {
+            BookmarkId = bookmarkId,
             BookmarkName = $"blocker-escalation-{sessionId}",
             Callback = OnResumeAsync,
             AutoBurn = true
         });
+
+        ScheduleTimeout(context, bookmarkId);
+    }
+
+    /// <summary>
+    /// Schedule a durable resume of the escalation bookmark at the senior-response SLA
+    /// (<c>BlockerDiagnosis:EscalationTimeoutMinutes</c>, default 1440 = 24h) carrying
+    /// <c>Timeout=true</c> via <see cref="IWorkflowScheduler"/>. Closes the hang-forever hole
+    /// (completeness audit 2026-06-22, 7-1G §Missing #1+#2): a never-answered escalation now
+    /// terminates as a real <c>Timeout</c> rather than suspending indefinitely. Best-effort —
+    /// if scheduling is unavailable the bookmark still exists for an external resume.
+    /// </summary>
+    private void ScheduleTimeout(ActivityExecutionContext context, string bookmarkId)
+    {
+        var scheduler = context.GetService<IWorkflowScheduler>();
+        if (scheduler is null)
+        {
+            _logger?.LogWarning(
+                "IWorkflowScheduler unavailable — escalation bookmark {BookmarkId} has no durable SLA "
+                + "timeout (relies on an external resume).", bookmarkId);
+            return;
+        }
+
+        var slaMinutes = _configuration?.GetValue<int?>("BlockerDiagnosis:EscalationTimeoutMinutes") ?? 1440;
+        var instanceId = context.WorkflowExecutionContext.Id;
+        var resumeAt = DateTimeOffset.UtcNow.AddMinutes(Math.Max(1, slaMinutes));
+        var taskName = $"blocker-escalation-timeout-{instanceId}-{bookmarkId}";
+
+        var request = new ScheduleExistingWorkflowInstanceRequest
+        {
+            WorkflowInstanceId = instanceId,
+            BookmarkId = bookmarkId,
+            Input = new Dictionary<string, object> { ["Timeout"] = true }
+        };
+
+        scheduler.ScheduleAtAsync(taskName, request, resumeAt).AsTask().GetAwaiter().GetResult();
+
+        _logger?.LogInformation(
+            "Scheduled escalation SLA timeout for bookmark {BookmarkId} at {ResumeAt:o} ({SlaMinutes}min)",
+            bookmarkId, resumeAt, slaMinutes);
     }
 
     private async Task NotifySenior(EscalationContext escalation)
@@ -173,16 +214,18 @@ Please respond to this escalation via the Tamma API or reply in this thread.";
     {
         var input = context.WorkflowInput;
 
-        var resolved = input.TryGetValue("Resolved", out var r) && r is true;
-        var seniorResponse = input.TryGetValue("SeniorResponse", out var sr)
-            ? sr?.ToString()
-            : null;
+        var isTimeout = input.TryGetValue("Timeout", out var to) && to is true;
+        var resolved = !isTimeout && input.TryGetValue("Resolved", out var r) && r is true;
+        var seniorResponse = isTimeout
+            ? null
+            : input.TryGetValue("SeniorResponse", out var sr) ? sr?.ToString() : null;
 
         _logger?.LogInformation(
-            "Senior escalation resumed: Resolved={Resolved}",
-            resolved);
+            "Senior escalation resumed: Resolved={Resolved}, TimedOut={TimedOut}",
+            resolved, isTimeout);
 
         context.Set(Resolved, resolved);
+        context.Set(TimedOut, isTimeout);
         context.Set(SeniorResponse, seniorResponse);
 
         await context.CompleteActivityAsync();

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/EscalateToSeniorActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/EscalateToSeniorActivity.cs
@@ -1,5 +1,4 @@
 using Elsa.Extensions;
-using Elsa.Scheduling;
 using Elsa.Workflows;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
@@ -14,6 +13,21 @@ namespace Tamma.Activities.Blocker;
 /// <summary>
 /// Bookmark-based activity that compiles a full context dump and escalates to a senior developer.
 /// The workflow suspends and waits for the senior to respond via API or Slack.
+///
+/// <para><b>Durable senior-response SLA timeout (completeness audit 2026-06-22, 7-1G AC2 /
+/// §Missing #1+#2; hardened 2026-06-25 to the durable Delay primitive).</b> Two resume paths
+/// are armed when the activity suspends: a custom escalation bookmark
+/// (<c>blocker-escalation-{session}</c>) resumed by the senior → <see cref="Resolved"/>; and a
+/// DURABLE delay bookmark via
+/// <see cref="Elsa.Extensions.DelayActivityExecutionContextExtensions.DelayFor(ActivityExecutionContext, System.TimeSpan, ExecuteActivityDelegate)"/>
+/// at the SLA (<c>BlockerDiagnosis:EscalationTimeoutMinutes</c>, default 1440 = 24h) →
+/// <see cref="TimedOut"/>. The earlier build scheduled the SLA via
+/// <c>IWorkflowScheduler.ScheduleAtAsync</c>, whose default in-memory backing is LOST on a
+/// host restart — fatal here because the SLA defaults to 24h and a VPS restart inside that
+/// window is routine. The Delay bookmark is EF-persisted and re-armed by
+/// <c>Elsa.Scheduling</c>'s startup task on rehydration, so a restart mid-wait no longer
+/// drops the SLA. Whichever path resumes first completes the activity; Elsa burns the
+/// remaining bookmark, so there is no orphaned timer / stale double-resume.</para>
 /// </summary>
 [Activity(
     "Tamma.Blocker",
@@ -120,56 +134,25 @@ public class EscalateToSeniorActivity : Activity
         // Notify senior via configured channel
         await NotifySenior(escalationContext);
 
-        // Create bookmark — workflow suspends and waits for senior response. A deterministic
-        // id lets the scheduled SLA timeout resume THIS bookmark.
-        var bookmarkId = Guid.NewGuid().ToString("N");
+        // 1) Escalation bookmark — resumed by the senior's response (API/Slack). The workflow
+        //    suspends here until this resumes OR the durable SLA delay below fires.
         context.CreateBookmark(new CreateBookmarkArgs
         {
-            BookmarkId = bookmarkId,
             BookmarkName = $"blocker-escalation-{sessionId}",
             Callback = OnResumeAsync,
             AutoBurn = true
         });
 
-        ScheduleTimeout(context, bookmarkId);
-    }
-
-    /// <summary>
-    /// Schedule a durable resume of the escalation bookmark at the senior-response SLA
-    /// (<c>BlockerDiagnosis:EscalationTimeoutMinutes</c>, default 1440 = 24h) carrying
-    /// <c>Timeout=true</c> via <see cref="IWorkflowScheduler"/>. Closes the hang-forever hole
-    /// (completeness audit 2026-06-22, 7-1G §Missing #1+#2): a never-answered escalation now
-    /// terminates as a real <c>Timeout</c> rather than suspending indefinitely. Best-effort —
-    /// if scheduling is unavailable the bookmark still exists for an external resume.
-    /// </summary>
-    private void ScheduleTimeout(ActivityExecutionContext context, string bookmarkId)
-    {
-        var scheduler = context.GetService<IWorkflowScheduler>();
-        if (scheduler is null)
-        {
-            _logger?.LogWarning(
-                "IWorkflowScheduler unavailable — escalation bookmark {BookmarkId} has no durable SLA "
-                + "timeout (relies on an external resume).", bookmarkId);
-            return;
-        }
-
+        // 2) Durable senior-response SLA — a DelayFor (Delay) bookmark that Elsa.Scheduling's
+        //    startup background task RE-ARMS after a host restart (EF-persisted, not an
+        //    in-memory timer). A never-answered escalation now terminates as a real Timeout
+        //    even across a VPS restart inside the (default 24h) SLA window.
         var slaMinutes = _configuration?.GetValue<int?>("BlockerDiagnosis:EscalationTimeoutMinutes") ?? 1440;
-        var instanceId = context.WorkflowExecutionContext.Id;
-        var resumeAt = DateTimeOffset.UtcNow.AddMinutes(Math.Max(1, slaMinutes));
-        var taskName = $"blocker-escalation-timeout-{instanceId}-{bookmarkId}";
-
-        var request = new ScheduleExistingWorkflowInstanceRequest
-        {
-            WorkflowInstanceId = instanceId,
-            BookmarkId = bookmarkId,
-            Input = new Dictionary<string, object> { ["Timeout"] = true }
-        };
-
-        scheduler.ScheduleAtAsync(taskName, request, resumeAt).AsTask().GetAwaiter().GetResult();
+        context.DelayFor(TimeSpan.FromMinutes(Math.Max(1, slaMinutes)), OnTimeoutAsync);
 
         _logger?.LogInformation(
-            "Scheduled escalation SLA timeout for bookmark {BookmarkId} at {ResumeAt:o} ({SlaMinutes}min)",
-            bookmarkId, resumeAt, slaMinutes);
+            "Escalation awaiting senior; durable SLA timeout armed at +{SlaMinutes}min for session {SessionId}",
+            slaMinutes, sessionId);
     }
 
     private async Task NotifySenior(EscalationContext escalation)
@@ -210,23 +193,45 @@ Please respond to this escalation via the Tamma API or reply in this thread.";
         }
     }
 
+    /// <summary>
+    /// External resume path: the senior responded. Reads the senior's outcome from the resume
+    /// input and completes — Elsa burns the still-armed SLA Delay bookmark on completion (no
+    /// orphaned timer).
+    /// </summary>
     private async ValueTask OnResumeAsync(ActivityExecutionContext context)
     {
         var input = context.WorkflowInput;
 
-        var isTimeout = input.TryGetValue("Timeout", out var to) && to is true;
-        var resolved = !isTimeout && input.TryGetValue("Resolved", out var r) && r is true;
-        var seniorResponse = isTimeout
-            ? null
-            : input.TryGetValue("SeniorResponse", out var sr) ? sr?.ToString() : null;
+        var resolved = input.TryGetValue("Resolved", out var r) && r is true;
+        var seniorResponse = input.TryGetValue("SeniorResponse", out var sr) ? sr?.ToString() : null;
 
-        _logger?.LogInformation(
-            "Senior escalation resumed: Resolved={Resolved}, TimedOut={TimedOut}",
-            resolved, isTimeout);
+        _logger?.LogInformation("Senior escalation resumed (external): Resolved={Resolved}", resolved);
 
         context.Set(Resolved, resolved);
-        context.Set(TimedOut, isTimeout);
+        context.Set(TimedOut, false);
         context.Set(SeniorResponse, seniorResponse);
+
+        await context.CompleteActivityAsync();
+    }
+
+    /// <summary>
+    /// Durable timeout path: the senior-response SLA elapsed with no response. The Delay
+    /// bookmark scheduler resumes the activity here (and re-arms across a host restart). Flags
+    /// <see cref="TimedOut"/> (not <see cref="Resolved"/>) so the workflow reports the real
+    /// Timeout terminal instead of suspending forever; the still-armed escalation bookmark is
+    /// burned on completion.
+    /// </summary>
+    private async ValueTask OnTimeoutAsync(ActivityExecutionContext context)
+    {
+        var sessionId = SessionId.Get(context);
+
+        _logger?.LogWarning(
+            "Senior-response SLA expired (durable timeout) for session {SessionId} — taking the Timeout terminal",
+            sessionId);
+
+        context.Set(Resolved, false);
+        context.Set(TimedOut, true);
+        context.Set(SeniorResponse, null);
 
         await context.CompleteActivityAsync();
     }

--- a/apps/tamma-elsa/src/Tamma.Activities/Tamma.Activities.csproj
+++ b/apps/tamma-elsa/src/Tamma.Activities/Tamma.Activities.csproj
@@ -22,10 +22,12 @@
     <PackageReference Include="Elsa.Http" Version="3.5.3" />
     <!-- WaitForCIResultsActivity (TestingWorkflow) and BlockerDiagnosis
          DetectProgress/EscalateToSenior use DelayActivityExecutionContextExtensions.DelayFor
-         (Elsa.Scheduling) to arm a durable, scheduler-resumed timeout bookmark alongside the
-         work bookmark, so a never-resumed wait times out deterministically instead of hanging
-         forever. Elsa.Scheduling is already wired in the host (Program.cs elsa.UseScheduling());
-         this reference only exposes the extension at compile time. -->
+         (Elsa.Scheduling) to arm a timeout bookmark alongside the work bookmark. The Delay
+         bookmark is EF-persisted and re-armed by Elsa.Scheduling's startup background task
+         after a host restart, so a never-resumed wait times out deterministically instead of
+         hanging forever (survives a VPS restart mid-wait, unlike an in-memory IWorkflowScheduler
+         timer). UseScheduling() is wired in Tamma.ElsaServer; this reference only exposes the
+         DelayFor extension at compile time. -->
     <PackageReference Include="Elsa.Scheduling" Version="3.5.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
   </ItemGroup>

--- a/apps/tamma-elsa/src/Tamma.Activities/Tamma.Activities.csproj
+++ b/apps/tamma-elsa/src/Tamma.Activities/Tamma.Activities.csproj
@@ -20,11 +20,12 @@
     <PackageReference Include="Elsa.Agents.Core" Version="3.5.3" />
     <PackageReference Include="Elsa.Agents.Persistence" Version="3.5.3" />
     <PackageReference Include="Elsa.Http" Version="3.5.3" />
-    <!-- WaitForCIResultsActivity uses DelayActivityExecutionContextExtensions.DelayFor
-         (Elsa.Scheduling) to arm a durable, scheduler-resumed timeout bookmark alongside
-         the CI-result bookmark so the CI wait can time out deterministically instead of
-         hanging forever. Elsa.Scheduling is already wired in the host (Program.cs
-         elsa.UseScheduling()); this reference only exposes the extension at compile time. -->
+    <!-- WaitForCIResultsActivity (TestingWorkflow) and BlockerDiagnosis
+         DetectProgress/EscalateToSenior use DelayActivityExecutionContextExtensions.DelayFor
+         (Elsa.Scheduling) to arm a durable, scheduler-resumed timeout bookmark alongside the
+         work bookmark, so a never-resumed wait times out deterministically instead of hanging
+         forever. Elsa.Scheduling is already wired in the host (Program.cs elsa.UseScheduling());
+         this reference only exposes the extension at compile time. -->
     <PackageReference Include="Elsa.Scheduling" Version="3.5.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
   </ItemGroup>

--- a/apps/tamma-elsa/src/Tamma.Api/Services/ElsaWorkflowService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/ElsaWorkflowService.cs
@@ -145,6 +145,17 @@ public partial class ElsaWorkflowService : IElsaWorkflowService
     /// <summary>
     /// Resume a paused workflow.
     /// </summary>
+    /// <remarks>
+    /// FOLLOW-UP (blocker-diagnosis Resolved terminal): this hits Elsa's GENERIC
+    /// <c>/resume</c> with no bookmark id and no input, so it cannot supply the
+    /// <c>ProgressDetected</c> / <c>Resolved</c> / <c>SeniorResponse</c> keys the
+    /// blocker-diagnosis progress / escalation bookmarks read. As a result a blocker run can
+    /// only reach the Escalated or (durable) Timeout terminal in production, never Resolved.
+    /// Reaching Resolved requires a blocker-specific resume endpoint that targets the bookmark
+    /// and passes that input, mirroring the secure MergeApprovalResumeEndpoint — a tracked
+    /// follow-up (deliberately NOT added here: it touches Program.cs and would collide with a
+    /// sibling endpoint-wiring PR).
+    /// </remarks>
     public async Task ResumeWorkflowAsync(string instanceId)
     {
         _logger.LogInformation("Resuming workflow instance {InstanceId}", instanceId);

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/BlockerDiagnosisWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/BlockerDiagnosisWorkflow.cs
@@ -41,8 +41,9 @@ namespace Tamma.ElsaServer.Workflows;
 ///   - Progress detected at any level short-circuits the ladder (the shared !isResolved
 ///     guard) and emits a terminal RESOLVED event immediately.
 ///   - Per-level waits and the escalation SLA are now durable timeouts (no hang-forever),
-///     enforced inside DetectProgressActivity / EscalateToSeniorActivity via the
-///     scheduler. Wait times moved to BlockerDiagnosis:* config.
+///     enforced inside DetectProgressActivity / EscalateToSeniorActivity via the DelayFor
+///     (Delay) bookmark — EF-persisted and re-armed by Elsa.Scheduling after a host restart
+///     (survives a VPS restart mid-wait). Wait times moved to BlockerDiagnosis:* config.
 ///   - Every rung emits a BLOCKER.* DCB audit event (diagnosed / resolution attempted /
 ///     progress detected / progress timed-out / escalated / resolved / timed-out) tagged
 ///     with sessionId/storyId/juniorId/tenantId/level/blockerType, plus the AC9 OTel
@@ -51,6 +52,20 @@ namespace Tamma.ElsaServer.Workflows;
 /// 7-11 (full prompt-enrichment: story title/description/expected-files/conventions/
 /// resolution-history threading) remains a noted follow-up — out of scope for this
 /// correctness pass.</para>
+///
+/// <para><b>Honest reachability of the <c>Resolved</c> terminal (FOLLOW-UP).</b> The
+/// in-graph wiring for <c>Resolved</c> is correct: a <c>ProgressDetected</c> /
+/// <c>Resolved</c> / <c>SeniorResponse</c> resume at any level flips <c>isResolved</c> and
+/// short-circuits the ladder. However, the ONLY external resumer in the codebase today
+/// (<c>MentorshipController.ResumeSession</c> → <c>ElsaWorkflowService.ResumeWorkflowAsync</c>)
+/// hits Elsa's generic <c>/resume</c> with NO bookmark id and NO input, so it never supplies
+/// those keys. Until a blocker-specific resume endpoint exists — one that passes
+/// <c>ProgressDetected</c> / <c>Resolved</c> / <c>SeniorResponse</c> input and targets the
+/// progress / escalation bookmark, mirroring the secure <c>MergeApprovalResumeEndpoint</c> —
+/// a production run can only reach the <c>Escalated</c> or (durable) <c>Timeout</c> terminal,
+/// never <c>Resolved</c>. That endpoint is a tracked FOLLOW-UP (it touches Program.cs and is
+/// intentionally NOT added here to avoid colliding with a sibling endpoint-wiring PR); the
+/// graph fix stands as-is.</para>
 /// </summary>
 public class BlockerDiagnosisWorkflow : WorkflowBase
 {

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/BlockerDiagnosisWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/BlockerDiagnosisWorkflow.cs
@@ -26,16 +26,31 @@ namespace Tamma.ElsaServer.Workflows;
 ///   Level 1: Hint (Socratic) -- 15min wait (30min for skill 4-5; skipped for skill 1-2)
 ///   Level 2: Guidance -- 30min wait
 ///   Level 3: Assistance -- 45min wait
-///   Level 4: Escalation -- wait for senior
+///   Level 4: Escalation -- wait for senior (durable SLA timeout)
 ///
 /// Can be invoked standalone via ELSA REST API or as a child workflow via DispatchWorkflow.
 ///
 /// Design: Flowchart with visible nodes for each phase in ELSA Studio.
 ///
-/// Flow:
-///   CaptureInputs → ParallelSignals → AggregateSignals → AIDiagnosis
-///     → ClassifyBlocker → DetermineStartLevel → HintLevel → GuidanceLevel
-///     → AssistanceLevel → EscalationLevel → SetOutput
+/// <para><b>Completeness build-out 2026-06-22 (BlockerDiagnosis.md, 7-1G AC2/AC6/AC9).</b>
+/// This pass fixes the P0/P1 correctness + observability gaps:
+///   - The terminal status now reflects the ACTUAL ladder outcome: Resolved (progress
+///     detected, or a senior resolved the escalation) → else Timeout (escalation SLA
+///     expired with no senior response) → else Escalated (senior notified, awaiting).
+///     The old graph always reported "Escalated" and never produced the Timeout terminal.
+///   - Progress detected at any level short-circuits the ladder (the shared !isResolved
+///     guard) and emits a terminal RESOLVED event immediately.
+///   - Per-level waits and the escalation SLA are now durable timeouts (no hang-forever),
+///     enforced inside DetectProgressActivity / EscalateToSeniorActivity via the
+///     scheduler. Wait times moved to BlockerDiagnosis:* config.
+///   - Every rung emits a BLOCKER.* DCB audit event (diagnosed / resolution attempted /
+///     progress detected / progress timed-out / escalated / resolved / timed-out) tagged
+///     with sessionId/storyId/juniorId/tenantId/level/blockerType, plus the AC9 OTel
+///     metrics (blocker.total / resolved / escalated / timed_out / resolution_time).
+///   - tenantId is threaded into every llm-call and escalation (Epic 32 tenant-scoping).
+/// 7-11 (full prompt-enrichment: story title/description/expected-files/conventions/
+/// resolution-history threading) remains a noted follow-up — out of scope for this
+/// correctness pass.</para>
 /// </summary>
 public class BlockerDiagnosisWorkflow : WorkflowBase
 {
@@ -52,6 +67,7 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
         var sessionId = builder.WithVariable<Guid>();
         var storyId = builder.WithVariable<string>();
         var juniorId = builder.WithVariable<string>();
+        var tenantId = builder.WithVariable<string>();
         var skillLevel = builder.WithVariable<int>();
         var blockerContext = builder.WithVariable<string?>();
         var repository = builder.WithVariable<string>();
@@ -75,6 +91,10 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
         var startTime = builder.WithVariable<DateTime>();
         var isResolved = builder.WithVariable<bool>(false);
         var progressDetected = builder.WithVariable<bool>(false);
+        var progressTimedOut = builder.WithVariable<bool>(false);
+        var progressResult = builder.WithVariable<ProgressDetectionResult>();
+        // Escalation SLA expired with no senior response → terminal Timeout (7-1G AC2).
+        var timedOut = builder.WithVariable<bool>(false);
 
         // ============================================
         // Activities
@@ -91,6 +111,7 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
                 var sid = context.GetInput<Guid>("sessionId");
                 storyId.Set(context, context.GetInput<string>("storyId") ?? "");
                 juniorId.Set(context, context.GetInput<string>("juniorId") ?? "");
+                tenantId.Set(context, context.GetInput<string>("tenantId") ?? "");
                 skillLevel.Set(context, Math.Max(1, context.GetInput<int>("skillLevel")));
                 blockerContext.Set(context, context.GetInput<string?>("blockerContext"));
                 repository.Set(context, context.GetInput<string>("repository") ?? "");
@@ -193,6 +214,7 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
                     skillLevel.Get(context),
                     blockerContext.Get(context)),
                 ["sessionId"] = sessionId.Get(context),
+                ["tenantId"] = tenantId.Get(context) ?? "",
                 ["skillLevel"] = skillLevel.Get(context)
             }),
             WaitForCompletion = new(true),
@@ -218,6 +240,22 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
         };
         classifyBlocker.SetDisplayText("Classify Blocker");
 
+        // 5b. Emit BLOCKER.DIAGNOSED.SUCCESS (audit + blocker.total metric)
+        var emitDiagnosed = new EmitBlockerEventActivity
+        {
+            Id = "EmitDiagnosed",
+            Name = "Emit: Diagnosed",
+            EventType = new(BlockerEvents.DiagnosedSuccess),
+            SessionId = new(context => sessionId.Get(context).ToString()),
+            StoryId = new(context => storyId.Get(context) ?? ""),
+            JuniorId = new(context => juniorId.Get(context) ?? ""),
+            TenantId = new(context => tenantId.Get(context) ?? ""),
+            BlockerType = new(context => diagnosisResult.Get(context)?.BlockerType.ToString() ?? ""),
+            Severity = new(context => diagnosisResult.Get(context)?.Severity.ToString() ?? ""),
+            Confidence = new(context => diagnosisResult.Get(context)?.Confidence ?? 0d)
+        };
+        emitDiagnosed.SetDisplayText("Emit: Diagnosed");
+
         // 6. Determine Starting Level (Skill Adaptation)
         var determineStartLevel = new SetVariable
         {
@@ -233,59 +271,81 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
         };
         determineStartLevel.SetDisplayText("Determine Start Level");
 
-        // 7a. Progressive Resolution — Level 1: Hint (wrapped in named Sequence)
+        // 7a. Level 1: Hint
         var hintLevel = new Sequence
         {
             Id = "HintLevel",
             Name = "Level 1: Hint",
             Activities =
             {
-                BuildHintLevel(sessionId, storyId, juniorId, skillLevel, diagnosisResult,
-                    currentLevel, attempts, feedbackProvided, isResolved, progressDetected)
+                BuildHintLevel(sessionId, storyId, juniorId, tenantId, skillLevel, diagnosisResult,
+                    currentLevel, attempts, feedbackProvided, isResolved, progressDetected,
+                    progressTimedOut, progressResult)
             }
         };
         hintLevel.SetDisplayText("Level 1: Hint");
 
-        // 7b. Progressive Resolution — Level 2: Guidance
+        // 7b. Level 2: Guidance
         var guidanceLevel = new Sequence
         {
             Id = "GuidanceLevel",
             Name = "Level 2: Guidance",
             Activities =
             {
-                BuildGuidanceLevel(sessionId, storyId, juniorId, skillLevel, diagnosisResult,
-                    currentLevel, attempts, feedbackProvided, isResolved, progressDetected)
+                BuildGuidanceLevel(sessionId, storyId, juniorId, tenantId, skillLevel, diagnosisResult,
+                    currentLevel, attempts, feedbackProvided, isResolved, progressDetected,
+                    progressTimedOut, progressResult)
             }
         };
         guidanceLevel.SetDisplayText("Level 2: Guidance");
 
-        // 7c. Progressive Resolution — Level 3: Assistance
+        // 7c. Level 3: Assistance
         var assistanceLevel = new Sequence
         {
             Id = "AssistanceLevel",
             Name = "Level 3: Assistance",
             Activities =
             {
-                BuildAssistanceLevel(sessionId, storyId, juniorId, skillLevel, diagnosisResult,
-                    currentLevel, attempts, feedbackProvided, isResolved, progressDetected)
+                BuildAssistanceLevel(sessionId, storyId, juniorId, tenantId, skillLevel, diagnosisResult,
+                    currentLevel, attempts, feedbackProvided, isResolved, progressDetected,
+                    progressTimedOut, progressResult)
             }
         };
         assistanceLevel.SetDisplayText("Level 3: Assistance");
 
-        // 7d. Progressive Resolution — Level 4: Escalation
+        // 7d. Level 4: Escalation
         var escalationLevel = new Sequence
         {
             Id = "EscalationLevel",
             Name = "Level 4: Escalation",
             Activities =
             {
-                BuildEscalationLevel(sessionId, storyId, juniorId, diagnosisResult,
-                    aggregatedSignals, currentLevel, attempts, feedbackProvided, isResolved)
+                BuildEscalationLevel(sessionId, storyId, juniorId, tenantId, diagnosisResult,
+                    aggregatedSignals, currentLevel, attempts, feedbackProvided, isResolved, timedOut)
             }
         };
         escalationLevel.SetDisplayText("Level 4: Escalation");
 
-        // 8. Set Output
+        // 8. Emit terminal BLOCKER event (RESOLVED / TIMED_OUT / ESCALATED) + terminal metric.
+        var emitTerminal = new EmitBlockerEventActivity
+        {
+            Id = "EmitTerminal",
+            Name = "Emit: Terminal",
+            EventType = new(context => TerminalEventType(isResolved.Get(context), timedOut.Get(context))),
+            SessionId = new(context => sessionId.Get(context).ToString()),
+            StoryId = new(context => storyId.Get(context) ?? ""),
+            JuniorId = new(context => juniorId.Get(context) ?? ""),
+            TenantId = new(context => tenantId.Get(context) ?? ""),
+            BlockerType = new(context => diagnosisResult.Get(context)?.BlockerType.ToString() ?? ""),
+            Severity = new(context => diagnosisResult.Get(context)?.Severity.ToString() ?? ""),
+            Level = new(context => currentLevel.Get(context) ?? ""),
+            Attempt = new(context => attempts.Get(context)),
+            ResolutionTimeSeconds = new(context =>
+                (DateTime.UtcNow - startTime.Get(context)).TotalSeconds)
+        };
+        emitTerminal.SetDisplayText("Emit: Terminal");
+
+        // 9. Set Output
         var setOutput = new SetOutput
         {
             Id = "SetBlockerOutput",
@@ -296,13 +356,12 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
                 var diagnosis = diagnosisResult.Get(context);
                 var start = startTime.Get(context);
                 var resolutionTime = DateTime.UtcNow - start;
-                var wasResolved = isResolved.Get(context);
 
                 return new BlockerResolution
                 {
-                    Status = wasResolved
-                        ? BlockerResolutionStatus.Resolved
-                        : BlockerResolutionStatus.Escalated,
+                    // Resolved → else Timeout (escalation SLA expired) → else Escalated.
+                    // Fixes the always-"Escalated" bug and produces the real Timeout terminal.
+                    Status = ResolveStatus(isResolved.Get(context), timedOut.Get(context)),
                     BlockerType = diagnosis?.BlockerType ?? BlockerCategory.TechnicalKnowledgeGap,
                     BlockerSeverity = diagnosis?.Severity ?? BlockerDiagnosisSeverity.Medium,
                     Attempts = attempts.Get(context),
@@ -327,44 +386,51 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
             Activities =
             {
                 captureInputs, parallelSignals, aggregateSignals, aiDiagnosis,
-                classifyBlocker, determineStartLevel,
+                classifyBlocker, emitDiagnosed, determineStartLevel,
                 hintLevel, guidanceLevel, assistanceLevel, escalationLevel,
-                setOutput
+                emitTerminal, setOutput
             },
             Connections =
             {
-                // CaptureInputs → Collect Signals
                 Connect(captureInputs, parallelSignals),
-
-                // Collect Signals → Aggregate Signals
                 Connect(parallelSignals, aggregateSignals),
-
-                // Aggregate Signals → AI Diagnosis
                 Connect(aggregateSignals, aiDiagnosis),
-
-                // AI Diagnosis → Classify Blocker
                 Connect(aiDiagnosis, classifyBlocker),
-
-                // Classify Blocker → Determine Start Level
-                Connect(classifyBlocker, determineStartLevel),
-
-                // Determine Start Level → Hint Level
+                Connect(classifyBlocker, emitDiagnosed),
+                Connect(emitDiagnosed, determineStartLevel),
                 Connect(determineStartLevel, hintLevel),
-
-                // Hint Level → Guidance Level
                 Connect(hintLevel, guidanceLevel),
-
-                // Guidance Level → Assistance Level
                 Connect(guidanceLevel, assistanceLevel),
-
-                // Assistance Level → Escalation Level
                 Connect(assistanceLevel, escalationLevel),
-
-                // Escalation Level → Set Output
-                Connect(escalationLevel, setOutput)
+                Connect(escalationLevel, emitTerminal),
+                Connect(emitTerminal, setOutput)
             }
         };
     }
+
+    // ================================================================
+    // Terminal status / event helpers (pure — exposed for unit testing)
+    // ================================================================
+
+    /// <summary>
+    /// Terminal status precedence (7-1G AC2/AC6): a resolved blocker → Resolved; otherwise an
+    /// escalation whose SLA expired with no senior response → Timeout; otherwise Escalated
+    /// (senior notified, awaiting). NEVER reports Resolved/Escalated inaccurately.
+    /// </summary>
+    internal static BlockerResolutionStatus ResolveStatus(bool isResolved, bool timedOut)
+        => isResolved
+            ? BlockerResolutionStatus.Resolved
+            : timedOut
+                ? BlockerResolutionStatus.Timeout
+                : BlockerResolutionStatus.Escalated;
+
+    /// <summary>Map the terminal status onto its BLOCKER.* event type.</summary>
+    internal static string TerminalEventType(bool isResolved, bool timedOut)
+        => isResolved
+            ? BlockerEvents.Resolved
+            : timedOut
+                ? BlockerEvents.TimedOut
+                : BlockerEvents.Escalated;
 
     // ================================================================
     // Flowchart helpers
@@ -377,20 +443,83 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
         => new(new FlowEndpoint(source, outcome), new FlowEndpoint(target));
 
     /// <summary>
+    /// Builds the per-level "record this attempt's feedback" SetVariable plus the
+    /// BLOCKER.RESOLUTION_ATTEMPTED emit. Kept as a small helper so each level shares the
+    /// identical attempt-counter + audit semantics.
+    /// </summary>
+    private static EmitBlockerEventActivity BuildResolutionAttemptedEmit(
+        string idPrefix,
+        string level,
+        Variable<Guid> sessionId,
+        Variable<string> storyId,
+        Variable<string> juniorId,
+        Variable<string> tenantId,
+        Variable<BlockerDiagnosisResult> diagnosisResult,
+        Variable<int> attempts)
+        => new()
+        {
+            Id = $"{idPrefix}EmitAttempt",
+            Name = $"Emit: {level} Attempt",
+            EventType = new(BlockerEvents.ResolutionAttempted),
+            SessionId = new(context => sessionId.Get(context).ToString()),
+            StoryId = new(context => storyId.Get(context) ?? ""),
+            JuniorId = new(context => juniorId.Get(context) ?? ""),
+            TenantId = new(context => tenantId.Get(context) ?? ""),
+            BlockerType = new(context => diagnosisResult.Get(context)?.BlockerType.ToString() ?? ""),
+            Severity = new(context => diagnosisResult.Get(context)?.Severity.ToString() ?? ""),
+            Level = new(level),
+            Attempt = new(context => attempts.Get(context))
+        };
+
+    /// <summary>
+    /// Builds the per-level "progress detected / timed-out" emit. Emits
+    /// BLOCKER.PROGRESS_DETECTED when the junior made progress, else
+    /// BLOCKER.PROGRESS_TIMED_OUT (the wait expired and the ladder advanced).
+    /// </summary>
+    private static EmitBlockerEventActivity BuildProgressEmit(
+        string idPrefix,
+        string level,
+        Variable<Guid> sessionId,
+        Variable<string> storyId,
+        Variable<string> juniorId,
+        Variable<string> tenantId,
+        Variable<BlockerDiagnosisResult> diagnosisResult,
+        Variable<bool> progressDetected,
+        Variable<ProgressDetectionResult> progressResult)
+        => new()
+        {
+            Id = $"{idPrefix}EmitProgress",
+            Name = $"Emit: {level} Progress",
+            EventType = new(context => progressDetected.Get(context)
+                ? BlockerEvents.ProgressDetected
+                : BlockerEvents.ProgressTimedOut),
+            SessionId = new(context => sessionId.Get(context).ToString()),
+            StoryId = new(context => storyId.Get(context) ?? ""),
+            JuniorId = new(context => juniorId.Get(context) ?? ""),
+            TenantId = new(context => tenantId.Get(context) ?? ""),
+            BlockerType = new(context => diagnosisResult.Get(context)?.BlockerType.ToString() ?? ""),
+            Level = new(level),
+            ProgressType = new(context => progressResult.Get(context)?.ProgressType ?? "")
+        };
+
+    /// <summary>
     /// Level 1: Hint (Socratic Method).
-    /// Skipped for skill level 1-2. Extended timeout (30min) for skill 4-5.
+    /// Skipped for skill level 1-2. Extended timeout (config) for skill 4-5.
     /// </summary>
     private static If BuildHintLevel(
         Variable<Guid> sessionId,
         Variable<string> storyId,
         Variable<string> juniorId,
+        Variable<string> tenantId,
         Variable<int> skillLevel,
         Variable<BlockerDiagnosisResult> diagnosisResult,
         Variable<string> currentLevel,
         Variable<int> attempts,
         Variable<List<string>> feedbackProvided,
         Variable<bool> isResolved,
-        Variable<bool> progressDetected)
+        Variable<bool> progressDetected,
+        Variable<bool> progressTimedOut,
+        Variable<ProgressDetectionResult> progressResult)
     {
         var hintBody = WithLabel(new Sequence
         {
@@ -398,7 +527,6 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
             Name = "Hint Body",
             Activities =
             {
-                    // Dispatch LLM for Socratic hints
                     WithLabel(new DispatchWorkflow
                     {
                         Id = "HintLlmCall",
@@ -413,12 +541,12 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
                                           $"Blocker type: {diagnosisResult.Get(context)?.BlockerType}. " +
                                           "Use guiding questions, not direct answers. Employ the Socratic method.",
                             ["sessionId"] = sessionId.Get(context),
+                            ["tenantId"] = tenantId.Get(context) ?? "",
                             ["skillLevel"] = skillLevel.Get(context)
                         }),
                         WaitForCompletion = new(true)
                     }, "Hint LLM Call"),
 
-                    // Record feedback
                     WithLabel(new SetVariable
                     {
                         Id = "HintRecordFeedback",
@@ -433,7 +561,10 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
                         })
                     }, "Record Hint Feedback"),
 
-                    // Wait for progress (bookmark) — output wired to progressDetected variable
+                    WithLabel(BuildResolutionAttemptedEmit("Hint", "Hint", sessionId, storyId, juniorId, tenantId, diagnosisResult, attempts),
+                        "Emit: Hint Attempt"),
+
+                    // Durable wait: bookmark + scheduled timeout (WaitTimeMinutes=0 → config/defaults).
                     WithLabel(new DetectProgressActivity
                     {
                         Id = "HintDetectProgress",
@@ -442,11 +573,12 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
                         StoryId = new(context => storyId.Get(context) ?? ""),
                         JuniorId = new(context => juniorId.Get(context) ?? ""),
                         CurrentLevel = new("Hint"),
-                        WaitTimeMinutes = new(context => skillLevel.Get(context) >= 4 ? 30 : 15),
-                        ProgressDetected = new(progressDetected)
+                        WaitTimeMinutes = new(0),
+                        ProgressDetected = new(progressDetected),
+                        TimedOut = new(progressTimedOut),
+                        Result = new(progressResult)
                     }, "Hint: Detect Progress"),
 
-                    // Check if progress was detected via the progressDetected variable
                     WithLabel(new SetVariable
                     {
                         Id = "HintCheckProgress",
@@ -459,7 +591,10 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
                                 currentLevel.Set(context, "Guidance");
                             return detected;
                         })
-                    }, "Hint: Check Progress")
+                    }, "Hint: Check Progress"),
+
+                    WithLabel(BuildProgressEmit("Hint", "Hint", sessionId, storyId, juniorId, tenantId, diagnosisResult, progressDetected, progressResult),
+                        "Emit: Hint Progress")
                 }
             }, "Hint Body");
 
@@ -476,19 +611,22 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
     }
 
     /// <summary>
-    /// Level 2: Direct Guidance. 30-minute wait.
+    /// Level 2: Direct Guidance.
     /// </summary>
     private static If BuildGuidanceLevel(
         Variable<Guid> sessionId,
         Variable<string> storyId,
         Variable<string> juniorId,
+        Variable<string> tenantId,
         Variable<int> skillLevel,
         Variable<BlockerDiagnosisResult> diagnosisResult,
         Variable<string> currentLevel,
         Variable<int> attempts,
         Variable<List<string>> feedbackProvided,
         Variable<bool> isResolved,
-        Variable<bool> progressDetected)
+        Variable<bool> progressDetected,
+        Variable<bool> progressTimedOut,
+        Variable<ProgressDetectionResult> progressResult)
     {
         var guidanceBody = WithLabel(new Sequence
         {
@@ -496,7 +634,6 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
             Name = "Guidance Body",
                 Activities =
                 {
-                    // Update current level
                     WithLabel(new SetVariable
                     {
                         Id = "SetLevelGuidance",
@@ -505,7 +642,6 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
                         Value = new(context => "Guidance")
                     }, "Set Level: Guidance"),
 
-                    // Dispatch LLM for direct guidance
                     WithLabel(new DispatchWorkflow
                     {
                         Id = "GuidanceLlmCall",
@@ -520,12 +656,12 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
                                           $"Blocker type: {diagnosisResult.Get(context)?.BlockerType}. " +
                                           "Give clear, step-by-step instructions. Be specific and actionable.",
                             ["sessionId"] = sessionId.Get(context),
+                            ["tenantId"] = tenantId.Get(context) ?? "",
                             ["skillLevel"] = skillLevel.Get(context)
                         }),
                         WaitForCompletion = new(true)
                     }, "Guidance LLM Call"),
 
-                    // Record feedback
                     WithLabel(new SetVariable
                     {
                         Id = "GuidanceRecordFeedback",
@@ -540,7 +676,9 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
                         })
                     }, "Record Guidance Feedback"),
 
-                    // Wait for progress (bookmark) — output wired to progressDetected variable
+                    WithLabel(BuildResolutionAttemptedEmit("Guidance", "Guidance", sessionId, storyId, juniorId, tenantId, diagnosisResult, attempts),
+                        "Emit: Guidance Attempt"),
+
                     WithLabel(new DetectProgressActivity
                     {
                         Id = "GuidanceDetectProgress",
@@ -549,11 +687,12 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
                         StoryId = new(context => storyId.Get(context) ?? ""),
                         JuniorId = new(context => juniorId.Get(context) ?? ""),
                         CurrentLevel = new("Guidance"),
-                        WaitTimeMinutes = new(30),
-                        ProgressDetected = new(progressDetected)
+                        WaitTimeMinutes = new(0),
+                        ProgressDetected = new(progressDetected),
+                        TimedOut = new(progressTimedOut),
+                        Result = new(progressResult)
                     }, "Guidance: Detect Progress"),
 
-                    // Check if progress was detected via the progressDetected variable
                     WithLabel(new SetVariable
                     {
                         Id = "GuidanceCheckProgress",
@@ -566,7 +705,10 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
                                 currentLevel.Set(context, "Assistance");
                             return detected;
                         })
-                    }, "Guidance: Check Progress")
+                    }, "Guidance: Check Progress"),
+
+                    WithLabel(BuildProgressEmit("Guidance", "Guidance", sessionId, storyId, juniorId, tenantId, diagnosisResult, progressDetected, progressResult),
+                        "Emit: Guidance Progress")
                 }
             }, "Guidance Body");
 
@@ -582,20 +724,23 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
     }
 
     /// <summary>
-    /// Level 3: Code Assistance. 45-minute wait. Uses the developer role
-    /// (implement-fix) to produce working solution code.
+    /// Level 3: Code Assistance. Uses the developer role (implement-fix) to produce
+    /// working solution code.
     /// </summary>
     private static If BuildAssistanceLevel(
         Variable<Guid> sessionId,
         Variable<string> storyId,
         Variable<string> juniorId,
+        Variable<string> tenantId,
         Variable<int> skillLevel,
         Variable<BlockerDiagnosisResult> diagnosisResult,
         Variable<string> currentLevel,
         Variable<int> attempts,
         Variable<List<string>> feedbackProvided,
         Variable<bool> isResolved,
-        Variable<bool> progressDetected)
+        Variable<bool> progressDetected,
+        Variable<bool> progressTimedOut,
+        Variable<ProgressDetectionResult> progressResult)
     {
         var assistanceBody = WithLabel(new Sequence
         {
@@ -603,7 +748,6 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
             Name = "Assistance Body",
                 Activities =
                 {
-                    // Update current level
                     WithLabel(new SetVariable
                     {
                         Id = "SetLevelAssistance",
@@ -612,7 +756,6 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
                         Value = new(context => "Assistance")
                     }, "Set Level: Assistance"),
 
-                    // Dispatch LLM for code assistance (developer implements a fix example)
                     WithLabel(new DispatchWorkflow
                     {
                         Id = "AssistanceLlmCall",
@@ -628,12 +771,12 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
                                           "Include a working code example with detailed explanation. " +
                                           "Show the solution step by step.",
                             ["sessionId"] = sessionId.Get(context),
+                            ["tenantId"] = tenantId.Get(context) ?? "",
                             ["skillLevel"] = skillLevel.Get(context)
                         }),
                         WaitForCompletion = new(true)
                     }, "Assistance LLM Call"),
 
-                    // Record feedback
                     WithLabel(new SetVariable
                     {
                         Id = "AssistanceRecordFeedback",
@@ -648,7 +791,9 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
                         })
                     }, "Record Assistance Feedback"),
 
-                    // Wait for progress (bookmark) — output wired to progressDetected variable
+                    WithLabel(BuildResolutionAttemptedEmit("Assistance", "Assistance", sessionId, storyId, juniorId, tenantId, diagnosisResult, attempts),
+                        "Emit: Assistance Attempt"),
+
                     WithLabel(new DetectProgressActivity
                     {
                         Id = "AssistanceDetectProgress",
@@ -657,11 +802,12 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
                         StoryId = new(context => storyId.Get(context) ?? ""),
                         JuniorId = new(context => juniorId.Get(context) ?? ""),
                         CurrentLevel = new("Assistance"),
-                        WaitTimeMinutes = new(45),
-                        ProgressDetected = new(progressDetected)
+                        WaitTimeMinutes = new(0),
+                        ProgressDetected = new(progressDetected),
+                        TimedOut = new(progressTimedOut),
+                        Result = new(progressResult)
                     }, "Assistance: Detect Progress"),
 
-                    // Check if progress was detected via the progressDetected variable
                     WithLabel(new SetVariable
                     {
                         Id = "AssistanceCheckProgress",
@@ -674,7 +820,10 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
                                 currentLevel.Set(context, "Escalation");
                             return detected;
                         })
-                    }, "Assistance: Check Progress")
+                    }, "Assistance: Check Progress"),
+
+                    WithLabel(BuildProgressEmit("Assistance", "Assistance", sessionId, storyId, juniorId, tenantId, diagnosisResult, progressDetected, progressResult),
+                        "Emit: Assistance Progress")
                 }
             }, "Assistance Body");
 
@@ -690,26 +839,35 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
     }
 
     /// <summary>
-    /// Level 4: Senior Escalation. Compiles context dump, notifies senior, waits via bookmark.
+    /// Level 4: Senior Escalation. Compiles context dump, notifies senior, waits via
+    /// bookmark with a durable SLA timeout. A senior who RESOLVES the escalation flips
+    /// isResolved (terminal Resolved at Escalation); an expired SLA flips timedOut
+    /// (terminal Timeout). Fixes the always-"Escalated" bug.
     /// </summary>
     private static If BuildEscalationLevel(
         Variable<Guid> sessionId,
         Variable<string> storyId,
         Variable<string> juniorId,
+        Variable<string> tenantId,
         Variable<BlockerDiagnosisResult> diagnosisResult,
         Variable<AggregatedSignals> aggregatedSignals,
         Variable<string> currentLevel,
         Variable<int> attempts,
         Variable<List<string>> feedbackProvided,
-        Variable<bool> isResolved)
+        Variable<bool> isResolved,
+        Variable<bool> timedOut)
     {
+        // Local outputs from the escalation activity, fed back into isResolved / timedOut.
+        var escalationResolved = new Variable<bool>();
+        var escalationTimedOut = new Variable<bool>();
+
         var escalationBody = WithLabel(new Sequence
         {
             Id = "EscalationBody",
             Name = "Escalation Body",
+            Variables = { escalationResolved, escalationTimedOut },
                 Activities =
                 {
-                    // Update current level
                     WithLabel(new SetVariable
                     {
                         Id = "SetLevelEscalation",
@@ -718,7 +876,25 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
                         Value = new(context => "Escalation")
                     }, "Set Level: Escalation"),
 
-                    // Escalate to senior (bookmark-based wait)
+                    WithLabel(BuildResolutionAttemptedEmit("Escalation", "Escalation", sessionId, storyId, juniorId, tenantId, diagnosisResult, attempts),
+                        "Emit: Escalation Attempt"),
+
+                    // Emit BLOCKER.ESCALATED before the (suspending) wait so the audit row
+                    // lands even if the workflow then suspends awaiting the senior.
+                    WithLabel(new EmitBlockerEventActivity
+                    {
+                        Id = "EmitEscalated",
+                        Name = "Emit: Escalated",
+                        EventType = new(BlockerEvents.Escalated),
+                        SessionId = new(context => sessionId.Get(context).ToString()),
+                        StoryId = new(context => storyId.Get(context) ?? ""),
+                        JuniorId = new(context => juniorId.Get(context) ?? ""),
+                        TenantId = new(context => tenantId.Get(context) ?? ""),
+                        BlockerType = new(context => diagnosisResult.Get(context)?.BlockerType.ToString() ?? ""),
+                        Severity = new(context => diagnosisResult.Get(context)?.Severity.ToString() ?? ""),
+                        Level = new("Escalation")
+                    }, "Emit: Escalated"),
+
                     WithLabel(new EscalateToSeniorActivity
                     {
                         Id = "EscalateToSenior",
@@ -730,10 +906,26 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
                         BlockerSeverity = new(context => diagnosisResult.Get(context)?.Severity.ToString() ?? "High"),
                         DiagnosisDetails = new(context => diagnosisResult.Get(context)?.RootCauseHypothesis ?? ""),
                         PreviousAttempts = new(context => feedbackProvided.Get(context) ?? new List<string>()),
-                        Signals = new(context => aggregatedSignals.Get(context))
+                        Signals = new(context => aggregatedSignals.Get(context)),
+                        Resolved = new(escalationResolved),
+                        TimedOut = new(escalationTimedOut)
                     }, "Escalate to Senior"),
 
-                    // Record escalation feedback
+                    // Feed the escalation outcome back into the terminal-status variables.
+                    WithLabel(new SetVariable
+                    {
+                        Id = "EscalationApplyOutcome",
+                        Name = "Escalation: Apply Outcome",
+                        Variable = isResolved,
+                        Value = new(context =>
+                        {
+                            var resolved = escalationResolved.Get(context);
+                            if (!resolved && escalationTimedOut.Get(context))
+                                timedOut.Set(context, true);
+                            return resolved;
+                        })
+                    }, "Escalation: Apply Outcome"),
+
                     WithLabel(new SetVariable
                     {
                         Id = "EscalationRecordFeedback",
@@ -742,7 +934,10 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
                         Value = new(context =>
                         {
                             var existing = feedbackProvided.Get(context) ?? new List<string>();
-                            var newList = new List<string>(existing) { "[Escalation] Escalated to senior developer" };
+                            var outcome = escalationResolved.Get(context)
+                                ? "resolved by senior"
+                                : escalationTimedOut.Get(context) ? "senior-response SLA expired" : "awaiting senior";
+                            var newList = new List<string>(existing) { $"[Escalation] Escalated to senior developer ({outcome})" };
                             attempts.Set(context, attempts.Get(context) + 1);
                             return newList;
                         })

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Blocker/BlockerDurableTimeoutTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Blocker/BlockerDurableTimeoutTests.cs
@@ -1,0 +1,123 @@
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Tamma.Activities.Tests.Blocker;
+
+/// <summary>
+/// Review fix 2026-06-25 (BlockerDiagnosis P0) — the durable wait-timeout invariant.
+///
+/// <para>The original build-out armed each per-level / escalation timeout via
+/// <c>IWorkflowScheduler.ScheduleAtAsync</c>. With the host's default <c>Elsa.Scheduling</c>
+/// setup (no persistent scheduling store) that is the in-memory <c>LocalScheduler</c>
+/// (<c>System.Timers.Timer</c>): on ANY host restart during the wait the timer is lost and
+/// nothing re-arms it on bookmark rehydration → the bookmark hangs forever — the exact P0 the
+/// feature claims to close. The escalation SLA defaults to 24h and a VPS restart inside that
+/// window is routine, so this is not theoretical.</para>
+///
+/// <para>The fix switches both <c>DetectProgressActivity</c> and
+/// <c>EscalateToSeniorActivity</c> to <c>context.DelayFor(...)</c> — the EF-persisted Delay
+/// bookmark that <c>Elsa.Scheduling</c>'s startup background task RE-ARMS after a restart.
+/// These source-scan invariants guard against regression to the in-memory scheduler. (A live
+/// resume/rehydration test would need the full Elsa runtime + EF store, which these activities
+/// have no unit harness for; the behavioural contract — never-resumed bookmark → Timeout
+/// terminal — is covered by the <c>ResolveStatus</c>/<c>TerminalEventType</c> precedence tests
+/// in <see cref="BlockerEventTests"/>.)</para>
+/// </summary>
+[TestFixture]
+public class BlockerDurableTimeoutTests
+{
+    private static readonly string[] TimeoutBearingActivities =
+    {
+        "DetectProgressActivity.cs",
+        "EscalateToSeniorActivity.cs",
+    };
+
+    [Test]
+    [TestCaseSource(nameof(TimeoutBearingActivities))]
+    public void TimeoutActivity_ArmsDurableDelayBookmark_WithATimeoutHandler(string fileName)
+    {
+        var src = ReadBlockerActivity(fileName);
+
+        // The durable primitive — DelayFor (the Delay bookmark) — must be armed, and a
+        // dedicated timeout callback must exist to take the Timeout edge.
+        src.Should().Contain("context.DelayFor(",
+            $"{fileName} must arm the durable DelayFor (Delay) bookmark so the timeout survives a host restart");
+        src.Should().Contain("OnTimeoutAsync",
+            $"{fileName} must resume into a dedicated durable-timeout handler");
+    }
+
+    [Test]
+    [TestCaseSource(nameof(TimeoutBearingActivities))]
+    public void TimeoutActivity_DoesNotUseTheInMemoryScheduler(string fileName)
+    {
+        var src = ReadBlockerActivity(fileName);
+
+        // The in-memory LocalScheduler seam (ScheduleAtAsync / IWorkflowScheduler) is the lost-
+        // on-restart P0. It must be GONE — a string-literal/identifier scan, doc-comment safe
+        // because the doc-comments reference it as <c>IWorkflowScheduler</c> / <c>ScheduleAtAsync</c>
+        // (angle-bracketed, never as a bare call/using).
+        src.Should().NotContain("ScheduleAtAsync(",
+            $"{fileName} must NOT schedule via IWorkflowScheduler.ScheduleAtAsync (in-memory timer lost on restart)");
+        src.Should().NotContain("using Elsa.Scheduling;",
+            $"{fileName} must not import Elsa.Scheduling's scheduler types — DelayFor lives in Elsa.Extensions");
+        src.Should().NotContain("GetService<IWorkflowScheduler>",
+            $"{fileName} must not resolve the in-memory IWorkflowScheduler");
+    }
+
+    [Test]
+    public void DetectProgress_StillArmsTheExternalProgressBookmark()
+    {
+        var src = ReadBlockerActivity("DetectProgressActivity.cs");
+        // Dual-arm: the external progress bookmark must remain so a real progress signal can
+        // resume (only the timeout primitive changed, not the resume path).
+        src.Should().Contain("CreateBookmark(",
+            "the external progress bookmark must remain so a junior's progress signal can resume");
+        src.Should().Contain("OnResumeAsync",
+            "the external progress resume handler must remain");
+    }
+
+    [Test]
+    public void Escalation_StillArmsTheExternalSeniorBookmark()
+    {
+        var src = ReadBlockerActivity("EscalateToSeniorActivity.cs");
+        src.Should().Contain("CreateBookmark(",
+            "the external escalation bookmark must remain so the senior's response can resume");
+        src.Should().Contain("OnResumeAsync",
+            "the external senior-response resume handler must remain");
+    }
+
+    // ---------------------------------------------------------------------
+    // Source-tree helper (mirrors NoDirectLlmCallTests' worktree locator).
+    // ---------------------------------------------------------------------
+
+    private static string ReadBlockerActivity(string fileName)
+    {
+        var path = Path.Combine(BlockerActivityDir(), fileName);
+        File.Exists(path).Should().BeTrue($"expected blocker activity source at {path}");
+        return File.ReadAllText(path);
+    }
+
+    private static string BlockerActivityDir() =>
+        Path.Combine(TammaElsaSrcRoot(), "Tamma.Activities", "Blocker");
+
+    private static string TammaElsaSrcRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "src", "Tamma.Activities");
+            if (Directory.Exists(candidate))
+                return Path.Combine(dir.FullName, "src");
+
+            var nested = Path.Combine(dir.FullName, "apps", "tamma-elsa", "src", "Tamma.Activities");
+            if (Directory.Exists(nested))
+                return Path.Combine(dir.FullName, "apps", "tamma-elsa", "src");
+
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not locate apps/tamma-elsa/src by walking up from "
+            + AppContext.BaseDirectory + " — the durable-timeout invariant test needs the source tree.");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Blocker/BlockerEventTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Blocker/BlockerEventTests.cs
@@ -210,6 +210,40 @@ public class BlockerEventTests
         BlockerDiagnosisWorkflow.TerminalEventType(false, false).Should().Be(BlockerEvents.Escalated);
     }
 
+    [Test]
+    public void NeverResumedEscalationBookmark_DurableTimeout_MapsToTimeoutTerminal_NotFalseSuccess()
+    {
+        // Behavioural contract of the durable-DelayFor fix (review P0): when the escalation
+        // bookmark is NEVER resumed by a senior, the durable Delay timeout fires →
+        // EscalateToSeniorActivity sets Resolved=false / TimedOut=true. The workflow folds that
+        // into isResolved=false / timedOut=true. The terminal MUST be the loud Timeout terminal
+        // (error-status), never a silent Resolved/Escalated false success.
+        const bool isResolved = false; // senior never answered
+        const bool timedOut = true;    // durable SLA Delay fired
+
+        BlockerDiagnosisWorkflow.ResolveStatus(isResolved, timedOut)
+            .Should().Be(BlockerResolutionStatus.Timeout, "a never-answered escalation is a Timeout terminal");
+
+        var terminalEvent = BlockerDiagnosisWorkflow.TerminalEventType(isResolved, timedOut);
+        terminalEvent.Should().Be(BlockerEvents.TimedOut);
+        BlockerEvents.StatusForEvent(terminalEvent).Should().Be("error",
+            "the durable-timeout terminal is a LOUD error row — no silent false success");
+    }
+
+    [Test]
+    public void NeverResumedProgressBookmark_DurableTimeout_AdvancesLadder_NotResolved()
+    {
+        // When a per-level progress bookmark is never resumed, the durable Delay timeout fires →
+        // DetectProgressActivity sets ProgressDetected=false / TimedOut=true. That is NOT a
+        // resolution: the level's Check-Progress step advances the ladder and isResolved stays
+        // false. The emitted per-level event is PROGRESS_TIMED_OUT (expected, success-status:
+        // advancing the ladder is normal), distinct from PROGRESS_DETECTED.
+        BlockerEvents.StatusForEvent(BlockerEvents.ProgressTimedOut).Should().Be("success",
+            "a per-level progress timeout advances the ladder — expected, not an error");
+        BlockerEvents.ProgressTimedOut.Should().NotBe(BlockerEvents.ProgressDetected,
+            "a timed-out level is audited distinctly from a level where progress was detected");
+    }
+
     // ================================================================
     // BlockerMetrics — AC9 instrument increments
     // ================================================================

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Blocker/BlockerEventTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Blocker/BlockerEventTests.cs
@@ -1,0 +1,296 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+using Tamma.Activities.Blocker;
+using Tamma.Activities.Blocker.Models;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Blocker;
+
+/// <summary>
+/// Completeness build-out 2026-06-22 (<c>BlockerDiagnosis.md</c>, 7-1G AC2/AC6/AC9) —
+/// coverage for the blocker-diagnosis correctness + observability fixes:
+///   - the <c>BLOCKER.*</c> DCB event catalogue + status convention (no false success),
+///   - <see cref="EmitBlockerEventActivity.BuildTammaEvent"/> tag/data mapping,
+///   - the AC9 OTel metric increments (<see cref="BlockerMetrics"/>),
+///   - the durable per-level wait-minutes resolution (<see cref="DetectProgressActivity.ResolveWaitMinutes(int, int?, string)"/>),
+///   - the terminal-status precedence that fixes the always-"Escalated" bug and adds the
+///     real <c>Timeout</c> terminal (<see cref="BlockerDiagnosisWorkflow.ResolveStatus"/> /
+///     <see cref="BlockerDiagnosisWorkflow.TerminalEventType"/>).
+/// </summary>
+[TestFixture]
+public class BlockerEventTests
+{
+    // ================================================================
+    // BlockerEvents — type catalogue + status convention
+    // ================================================================
+
+    [Test]
+    public void EventTypes_FollowAggregateActionStatusConvention()
+    {
+        BlockerEvents.DiagnosedSuccess.Should().Be("BLOCKER.DIAGNOSED.SUCCESS");
+        BlockerEvents.DiagnosedFailed.Should().Be("BLOCKER.DIAGNOSED.FAILED");
+        BlockerEvents.ResolutionAttempted.Should().Be("BLOCKER.RESOLUTION_ATTEMPTED");
+        BlockerEvents.ProgressDetected.Should().Be("BLOCKER.PROGRESS_DETECTED");
+        BlockerEvents.ProgressTimedOut.Should().Be("BLOCKER.PROGRESS_TIMED_OUT");
+        BlockerEvents.Escalated.Should().Be("BLOCKER.ESCALATED");
+        BlockerEvents.Resolved.Should().Be("BLOCKER.RESOLVED");
+        BlockerEvents.TimedOut.Should().Be("BLOCKER.TIMED_OUT");
+    }
+
+    [Test]
+    public void StatusForEvent_TimeoutAndFailedDiagnosisAreError_RestAreSuccess()
+    {
+        // A never-answered escalation (TIMED_OUT) and a failed diagnosis are LOUD error rows
+        // — never a silent false success.
+        BlockerEvents.StatusForEvent(BlockerEvents.TimedOut).Should().Be("error");
+        BlockerEvents.StatusForEvent(BlockerEvents.DiagnosedFailed).Should().Be("error");
+
+        BlockerEvents.StatusForEvent(BlockerEvents.DiagnosedSuccess).Should().Be("success");
+        BlockerEvents.StatusForEvent(BlockerEvents.ResolutionAttempted).Should().Be("success");
+        BlockerEvents.StatusForEvent(BlockerEvents.ProgressDetected).Should().Be("success");
+        // A per-level progress timeout simply advances the ladder — expected, NOT error.
+        BlockerEvents.StatusForEvent(BlockerEvents.ProgressTimedOut).Should().Be("success");
+        BlockerEvents.StatusForEvent(BlockerEvents.Escalated).Should().Be("success");
+        BlockerEvents.StatusForEvent(BlockerEvents.Resolved).Should().Be("success");
+    }
+
+    [Test]
+    public void ParseTenantId_ValidGuid_Parses_InvalidOrEmpty_IsNull()
+    {
+        var g = Guid.NewGuid();
+        BlockerEvents.ParseTenantId(g.ToString()).Should().Be(g);
+        BlockerEvents.ParseTenantId("").Should().BeNull();
+        BlockerEvents.ParseTenantId(null).Should().BeNull();
+        BlockerEvents.ParseTenantId("not-a-guid").Should().BeNull();
+    }
+
+    // ================================================================
+    // EmitBlockerEventActivity.BuildTammaEvent — tags + data + status
+    // ================================================================
+
+    [Test]
+    public void BuildTammaEvent_Diagnosed_StampsTagsAndConfidence_SuccessStatus()
+    {
+        var evt = EmitBlockerEventActivity.BuildTammaEvent(
+            BlockerEvents.DiagnosedSuccess,
+            sessionId: "sess-1", storyId: "story-7", juniorId: "junior-9",
+            tenantId: null,
+            blockerType: "TechnicalKnowledgeGap", severity: "High",
+            level: null, attempt: 0, confidence: 0.82,
+            progressType: null, resolutionTimeSeconds: 0);
+
+        evt.EventType.Should().Be("BLOCKER.DIAGNOSED.SUCCESS");
+        evt.Status.Should().Be("success");
+        evt.Tags!["sessionId"].Should().Be("sess-1");
+        evt.Tags!["storyId"].Should().Be("story-7");
+        evt.Tags!["juniorId"].Should().Be("junior-9");
+        evt.Tags!["blockerType"].Should().Be("TechnicalKnowledgeGap");
+        evt.Tags!["severity"].Should().Be("High");
+        evt.Tags.Should().NotContainKey("tenantId", "single-user / platform-scope event");
+        evt.Data["confidence"].Should().Be(0.82);
+    }
+
+    [Test]
+    public void BuildTammaEvent_WithTenant_StampsTenantTag()
+    {
+        var tenant = Guid.NewGuid();
+        var evt = EmitBlockerEventActivity.BuildTammaEvent(
+            BlockerEvents.ResolutionAttempted,
+            "sess-1", "story-1", "junior-1", tenant,
+            "DebuggingStuck", "Medium", "Hint", attempt: 1, confidence: 0,
+            progressType: null, resolutionTimeSeconds: 0);
+
+        evt.Tags!["tenantId"].Should().Be(tenant.ToString("D"));
+        evt.Tags!["level"].Should().Be("Hint");
+        evt.Data["attempt"].Should().Be(1);
+    }
+
+    [Test]
+    public void BuildTammaEvent_TimedOut_IsErrorStatus_NotFalseSuccess()
+    {
+        var evt = EmitBlockerEventActivity.BuildTammaEvent(
+            BlockerEvents.TimedOut,
+            "sess-1", "story-1", "junior-1", null,
+            "ExternalDependency", "Critical", "Escalation", attempt: 4, confidence: 0,
+            progressType: null, resolutionTimeSeconds: 90000);
+
+        evt.EventType.Should().Be("BLOCKER.TIMED_OUT");
+        evt.Status.Should().Be("error");
+        evt.Data["resolutionTimeSeconds"].Should().Be(90000d);
+    }
+
+    [Test]
+    public void BuildTammaEvent_ProgressDetected_CarriesProgressType()
+    {
+        var evt = EmitBlockerEventActivity.BuildTammaEvent(
+            BlockerEvents.ProgressDetected,
+            "sess-1", "story-1", "junior-1", null,
+            "DebuggingStuck", null, "Guidance", attempt: 0, confidence: 0,
+            progressType: "new-commit", resolutionTimeSeconds: 0);
+
+        evt.Data["progressType"].Should().Be("new-commit");
+        evt.Status.Should().Be("success");
+    }
+
+    [Test]
+    public void BuildTammaEvent_OmitsEmptyTagsAndZeroData()
+    {
+        var evt = EmitBlockerEventActivity.BuildTammaEvent(
+            BlockerEvents.Resolved,
+            sessionId: "", storyId: "", juniorId: "", tenantId: null,
+            blockerType: "", severity: "", level: "", attempt: 0, confidence: 0,
+            progressType: "", resolutionTimeSeconds: 0);
+
+        evt.Tags!.Should().NotContainKey("sessionId");
+        evt.Tags!.Should().NotContainKey("blockerType");
+        evt.Data.Should().NotContainKey("attempt");
+        evt.Data.Should().NotContainKey("confidence");
+        evt.Data.Should().NotContainKey("resolutionTimeSeconds");
+    }
+
+    // ================================================================
+    // DetectProgressActivity.ResolveWaitMinutes — durable per-level wait + config
+    // ================================================================
+
+    [Test]
+    public void ResolveWaitMinutes_ExplicitInputWins()
+    {
+        DetectProgressActivity.ResolveWaitMinutes(42, configValue: 99, level: "Hint").Should().Be(42);
+    }
+
+    [Test]
+    public void ResolveWaitMinutes_ConfigUsedWhenNoExplicit()
+    {
+        DetectProgressActivity.ResolveWaitMinutes(0, configValue: 99, level: "Hint").Should().Be(99);
+    }
+
+    [Test]
+    public void ResolveWaitMinutes_FallsBackToPerLevelDefaults()
+    {
+        DetectProgressActivity.ResolveWaitMinutes(0, configValue: null, level: "Hint").Should().Be(15);
+        DetectProgressActivity.ResolveWaitMinutes(0, configValue: null, level: "Guidance").Should().Be(30);
+        DetectProgressActivity.ResolveWaitMinutes(0, configValue: null, level: "Assistance").Should().Be(45);
+        DetectProgressActivity.ResolveWaitMinutes(0, configValue: 0, level: "Unknown").Should().Be(15);
+    }
+
+    // ================================================================
+    // Terminal status precedence — fixes always-"Escalated"; adds Timeout
+    // ================================================================
+
+    [Test]
+    public void ResolveStatus_ResolvedWins()
+    {
+        BlockerDiagnosisWorkflow.ResolveStatus(isResolved: true, timedOut: false)
+            .Should().Be(BlockerResolutionStatus.Resolved);
+        // Resolved takes precedence even if a timeout flag was also set.
+        BlockerDiagnosisWorkflow.ResolveStatus(isResolved: true, timedOut: true)
+            .Should().Be(BlockerResolutionStatus.Resolved);
+    }
+
+    [Test]
+    public void ResolveStatus_TimedOut_ProducesRealTimeoutTerminal()
+    {
+        BlockerDiagnosisWorkflow.ResolveStatus(isResolved: false, timedOut: true)
+            .Should().Be(BlockerResolutionStatus.Timeout);
+    }
+
+    [Test]
+    public void ResolveStatus_DefaultsToEscalated_WhenNotResolvedAndNotTimedOut()
+    {
+        BlockerDiagnosisWorkflow.ResolveStatus(isResolved: false, timedOut: false)
+            .Should().Be(BlockerResolutionStatus.Escalated);
+    }
+
+    [Test]
+    public void TerminalEventType_MatchesStatusPrecedence()
+    {
+        BlockerDiagnosisWorkflow.TerminalEventType(true, false).Should().Be(BlockerEvents.Resolved);
+        BlockerDiagnosisWorkflow.TerminalEventType(false, true).Should().Be(BlockerEvents.TimedOut);
+        BlockerDiagnosisWorkflow.TerminalEventType(false, false).Should().Be(BlockerEvents.Escalated);
+    }
+
+    // ================================================================
+    // BlockerMetrics — AC9 instrument increments
+    // ================================================================
+
+    [Test]
+    public void Metrics_RecordDiagnosed_IncrementsTotal()
+    {
+        var before = BlockerMetrics.TotalCount;
+        BlockerMetrics.RecordDiagnosed("TechnicalKnowledgeGap", tenant: null);
+        BlockerMetrics.TotalCount.Should().Be(before + 1);
+    }
+
+    [Test]
+    public void Metrics_RecordTerminals_IncrementMatchingCounters()
+    {
+        var beforeResolved = BlockerMetrics.ResolvedCount;
+        var beforeEscalated = BlockerMetrics.EscalatedCount;
+        var beforeTimedOut = BlockerMetrics.TimedOutCount;
+
+        BlockerMetrics.RecordResolved("DebuggingStuck", null, "Guidance", TimeSpan.FromMinutes(5));
+        BlockerMetrics.RecordEscalated("ExternalDependency", null, TimeSpan.FromMinutes(60));
+        BlockerMetrics.RecordTimedOut("PersonalBlocker", null, TimeSpan.FromHours(24));
+
+        BlockerMetrics.ResolvedCount.Should().Be(beforeResolved + 1);
+        BlockerMetrics.EscalatedCount.Should().Be(beforeEscalated + 1);
+        BlockerMetrics.TimedOutCount.Should().Be(beforeTimedOut + 1);
+    }
+
+    // ================================================================
+    // BlockerSignalTimeout — 15s per-collector cap (7-1G AC3)
+    // ================================================================
+
+    private static IConfiguration ConfigWithTimeout(int seconds)
+        => new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["BlockerDiagnosis:SignalCollectionTimeoutSeconds"] = seconds.ToString()
+            })
+            .Build();
+
+    [Test]
+    public void SignalTimeout_DefaultIs15Seconds_AndConfigOverrides()
+    {
+        BlockerSignalTimeout.DefaultTimeoutSeconds.Should().Be(15);
+        BlockerSignalTimeout.ResolveTimeoutSeconds(configuration: null).Should().Be(15);
+        BlockerSignalTimeout.ResolveTimeoutSeconds(ConfigWithTimeout(5)).Should().Be(5);
+    }
+
+    [Test]
+    public async Task SignalTimeout_FastWork_CompletesInTime()
+    {
+        var ran = false;
+        var completed = await BlockerSignalTimeout.RunAsync(ConfigWithTimeout(5), async () =>
+        {
+            await Task.Yield();
+            ran = true;
+        });
+
+        completed.Should().BeTrue();
+        ran.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task SignalTimeout_SlowWork_ReportsTimeout_DoesNotHang()
+    {
+        // A collector that out-runs the deadline must return false (CollectionSucceeded=false)
+        // rather than block the join. With a 1s configured deadline, a 60s work task loses the
+        // race and the helper returns promptly (we cap the test at 15s to prove no hang).
+        var completed = await BlockerSignalTimeout
+            .RunAsync(ConfigWithTimeout(1), () => Task.Delay(TimeSpan.FromSeconds(60)))
+            .WaitAsync(TimeSpan.FromSeconds(15));
+
+        completed.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task SignalTimeout_WorkThrows_PropagatesToCaller()
+    {
+        Func<Task> act = async () => await BlockerSignalTimeout.RunAsync(ConfigWithTimeout(5), () =>
+            throw new InvalidOperationException("boom"));
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("boom");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/BlockerDiagnosisWorkflowStructureTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/BlockerDiagnosisWorkflowStructureTests.cs
@@ -1,0 +1,186 @@
+using System.Reflection;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Memory;
+using Elsa.Workflows.Runtime.Activities;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Activities.Blocker;
+using Tamma.Activities.Blocker.Models;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Completeness build-out 2026-06-22 (<c>BlockerDiagnosis.md</c>, 7-1G AC2/AC6/AC9) —
+/// structural verification of the corrected <c>blocker-diagnosis</c> graph:
+///   - a <c>tenantId</c> string variable is captured (Epic 32 tenant-scoping),
+///   - DCB audit emits are wired (a Diagnosed emit + a Terminal emit on the flowchart;
+///     per-level RESOLUTION_ATTEMPTED / PROGRESS emits inside the level Sequences),
+///   - the terminal BLOCKER emit runs immediately BEFORE SetOutput,
+///   - every LLM interaction still routes through the <c>llm-call</c> mediation seam
+///     (no direct provider call — pivot rule #1),
+///   - the per-level DetectProgress + escalation bookmark activities expose the new
+///     <c>TimedOut</c> output wiring.
+///
+/// A self-contained mock <see cref="IWorkflowBuilder"/> is used (the shared
+/// WorkflowStructureTests harness only sets up the Epic-13 variable types).
+/// </summary>
+[TestFixture]
+public class BlockerDiagnosisWorkflowStructureTests
+{
+    private static Flowchart BuildFlowchart()
+    {
+        var mockBuilder = new Mock<IWorkflowBuilder>();
+        IActivity? root = null;
+        var variables = new List<Variable>();
+
+        mockBuilder.SetupSet(b => b.Name = It.IsAny<string>());
+        mockBuilder.SetupSet(b => b.DefinitionId = It.IsAny<string>());
+        mockBuilder.SetupSet(b => b.Description = It.IsAny<string>());
+        mockBuilder.SetupSet(b => b.Version = It.IsAny<int>());
+        mockBuilder.SetupSet(b => b.Root = It.IsAny<IActivity>()).Callback<IActivity>(v => root = v);
+        mockBuilder.SetupGet(b => b.Root).Returns(() => root!);
+        mockBuilder.SetupGet(b => b.Variables).Returns(variables);
+
+        // Generic WithVariable<T>() — return a fresh typed Variable for every type the
+        // workflow declares.
+        SetupVar<Guid>(mockBuilder, variables);
+        SetupVar<string>(mockBuilder, variables);
+        SetupVar<string?>(mockBuilder, variables);
+        SetupVar<int>(mockBuilder, variables);
+        SetupVar<bool>(mockBuilder, variables);
+        SetupVar<GitActivitySignal>(mockBuilder, variables);
+        SetupVar<CIStatusSignal>(mockBuilder, variables);
+        SetupVar<InactivitySignal>(mockBuilder, variables);
+        SetupVar<CommunicationSignal>(mockBuilder, variables);
+        SetupVar<AggregatedSignals>(mockBuilder, variables);
+        SetupVar<BlockerDiagnosisResult>(mockBuilder, variables);
+        SetupVar<ProgressDetectionResult>(mockBuilder, variables);
+        SetupVar<IDictionary<string, object>?>(mockBuilder, variables);
+
+        // WithVariable<T>(name, default) overloads used (string / int / bool).
+        mockBuilder.Setup(b => b.WithVariable<string>(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns((string n, string d) => { var v = new Variable<string>(n, d); variables.Add(v); return v; });
+        mockBuilder.Setup(b => b.WithVariable<int>(It.IsAny<string>(), It.IsAny<int>()))
+            .Returns((string n, int d) => { var v = new Variable<int>(n, d); variables.Add(v); return v; });
+        mockBuilder.Setup(b => b.WithVariable<bool>(It.IsAny<string>(), It.IsAny<bool>()))
+            .Returns((string n, bool d) => { var v = new Variable<bool>(n, d); variables.Add(v); return v; });
+
+        var build = typeof(BlockerDiagnosisWorkflow).GetMethod(
+            "Build", BindingFlags.Instance | BindingFlags.NonPublic, null,
+            new[] { typeof(IWorkflowBuilder) }, null);
+        build!.Invoke(new BlockerDiagnosisWorkflow(), new object[] { mockBuilder.Object });
+
+        root.Should().BeOfType<Flowchart>();
+        return (Flowchart)root!;
+    }
+
+    private static void SetupVar<T>(Mock<IWorkflowBuilder> mockBuilder, List<Variable> variables)
+        => mockBuilder.Setup(b => b.WithVariable<T>())
+            .Returns(() => { var v = new Variable<T>(); variables.Add(v); return v; });
+
+    private static IEnumerable<IActivity> Flatten(IActivity activity)
+    {
+        yield return activity;
+        switch (activity)
+        {
+            case Sequence seq:
+                foreach (var child in seq.Activities)
+                    foreach (var d in Flatten(child)) yield return d;
+                break;
+            case Elsa.Workflows.Activities.Parallel par:
+                foreach (var child in par.Activities)
+                    foreach (var d in Flatten(child)) yield return d;
+                break;
+            case If iff:
+                if (iff.Then is not null)
+                    foreach (var d in Flatten(iff.Then)) yield return d;
+                break;
+            case Flowchart fc:
+                foreach (var child in fc.Activities)
+                    foreach (var d in Flatten(child)) yield return d;
+                break;
+        }
+    }
+
+    [Test]
+    public void Workflow_CapturesInputsAndThreadsTenantIntoEmits()
+    {
+        var fc = BuildFlowchart();
+        var capture = fc.Activities.OfType<SetVariable>().FirstOrDefault(a => a.Id == "CaptureInputs");
+        capture.Should().NotBeNull("CaptureInputs must run");
+
+        // Every BLOCKER emit carries a TenantId input bound to the captured tenant variable
+        // (Epic 32 tenant-scoping). Inspecting the DispatchWorkflow Input dictionary is not
+        // statically possible (it is a runtime delegate), so the emit TenantId wiring is the
+        // observable proxy that tenantId is threaded through.
+        var emits = Flatten(fc).OfType<EmitBlockerEventActivity>().ToList();
+        emits.Should().NotBeEmpty();
+        emits.Should().OnlyContain(e => e.TenantId != null,
+            "every BLOCKER.* event must be tenant-tagged");
+    }
+
+    [Test]
+    public void Workflow_EmitsDiagnosedAndTerminalBlockerEvents()
+    {
+        var fc = BuildFlowchart();
+        var allEmits = Flatten(fc).OfType<EmitBlockerEventActivity>().ToList();
+
+        allEmits.Should().NotBeEmpty("the corrected graph must emit BLOCKER.* DCB events (AC9)");
+        allEmits.Select(e => e.Id).Should().Contain("EmitDiagnosed");
+        allEmits.Select(e => e.Id).Should().Contain("EmitTerminal");
+        allEmits.Select(e => e.Id).Should().Contain("EmitEscalated");
+        // Per-level attempt + progress emits are present inside the level Sequences.
+        allEmits.Select(e => e.Id).Should().Contain("HintEmitAttempt");
+        allEmits.Select(e => e.Id).Should().Contain("HintEmitProgress");
+    }
+
+    [Test]
+    public void Workflow_TerminalEmitRunsImmediatelyBeforeSetOutput()
+    {
+        var fc = BuildFlowchart();
+        // The flowchart has a connection EmitTerminal → SetBlockerOutput.
+        var hasEdge = fc.Connections.Any(c =>
+            c.Source.Activity.Id == "EmitTerminal" && c.Target.Activity.Id == "SetBlockerOutput");
+        hasEdge.Should().BeTrue("the terminal BLOCKER event must be emitted right before SetOutput");
+    }
+
+    [Test]
+    public void Workflow_AllLlmCallsRouteThroughLlmCallMediationSeam()
+    {
+        var fc = BuildFlowchart();
+        var dispatches = Flatten(fc).OfType<DispatchWorkflow>().ToList();
+
+        dispatches.Should().NotBeEmpty();
+        foreach (var d in dispatches)
+        {
+            var defId = d.WorkflowDefinitionId.Expression?.Value?.ToString();
+            defId.Should().Be("llm-call",
+                "every LLM interaction must route through the llm-call mediation seam (pivot rule #1)");
+        }
+    }
+
+    [Test]
+    public void Workflow_DetectProgressActivities_WireTimedOutOutput()
+    {
+        var fc = BuildFlowchart();
+        var detects = Flatten(fc).OfType<DetectProgressActivity>().ToList();
+
+        detects.Should().HaveCountGreaterThanOrEqualTo(3, "Hint/Guidance/Assistance each wait for progress");
+        detects.Should().OnlyContain(d => d.TimedOut != null,
+            "each per-level wait must surface the durable TimedOut output");
+    }
+
+    [Test]
+    public void Workflow_EscalationActivity_WiresResolvedAndTimedOutOutputs()
+    {
+        var fc = BuildFlowchart();
+        var escalate = Flatten(fc).OfType<EscalateToSeniorActivity>().Single();
+
+        escalate.Resolved.Should().NotBeNull("a senior-resolved escalation must flip isResolved");
+        escalate.TimedOut.Should().NotBeNull("an expired SLA must flip the Timeout terminal");
+    }
+}


### PR DESCRIPTION
## BlockerDiagnosisWorkflow build-out — Bucket D (fix-now)

Per `docs/superpowers/audits/2026-06-22/completeness/BlockerDiagnosis.md` (Story 7-1G correctness + observability). Closes the P0/P1 gaps:

- **Always-"Escalated" bug fixed:** terminal status is now `Resolved` → else `Timeout` → else `Escalated`, based on the actual ladder outcome; `EscalateToSeniorActivity` resolved/timed-out outcomes feed back into `isResolved`/`timedOut`.
- **Stop-ladder-on-progress (AC6):** progress at any level short-circuits the remaining levels and emits the terminal immediately.
- **Durable wait-timeouts (no hang):** per-level progress detection + escalation use the **EF-persisted `DelayFor` Delay bookmark** (re-armed by `Elsa.Scheduling` after a host restart) — a never-resumed bookmark times out instead of hanging forever. (Initial impl used the in-memory `IWorkflowScheduler`/`LocalScheduler`, lost on restart — caught in review, switched to `DelayFor`, mirroring `WaitForCIResultsActivity`.)
- **15s signal-collection timeout (AC3):** each parallel collector is capped (`BlockerDiagnosis:SignalCollectionTimeoutSeconds`), fail-soft `CollectionSucceeded=false`.
- **DCB events + metrics (AC9):** `EmitBlockerEventActivity` (via `TammaEventEmitter`) at classify/each level/progress/timeout/escalation/terminal; `BlockerMetrics` meter (`blocker.total/resolved/escalated/timed_out` + resolution-time histogram); `TIMED_OUT`/`DIAGNOSED.FAILED` are LOUD error rows.
- **Config block + tenant scoping:** wait times from `BlockerDiagnosis:*`; `tenantId` threaded into every `llm-call`/escalation.

Every LLM call routes through `DispatchWorkflow("llm-call")` (`SanitizeForPrompt` retained); no direct provider call; no EF migration; `BlockerResolution` contract preserved.

**Honest scope note:** the `Resolved` terminal is correctly wired in-graph, but production runs currently reach only `Escalated`/`Timeout` until a blocker-specific resume endpoint (that passes `ProgressDetected`/`Resolved`/`SeniorResponse` input, mirroring `MergeApprovalResumeEndpoint`) is added — a tracked **follow-up**. Story 7-11 prompt-enrichment also deferred.

**Review + fix:** review flagged the in-memory timer as a hang risk (CRITICAL) → fixed via `DelayFor`; the Resolved-reachability claim → made honest. `BlockerDurableTimeoutTests` guards against reverting to the lost-on-restart timer.

**Gate:** build 0; full `Tamma.Activities.Tests` **1706/0**; Blocker filter 45/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)