### PR TITLE
feat(workflows): build out CodeReviewWorkflow — bind inputs, mediated guidance, durable timeouts

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/Review/BindCodeReviewConfigActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/BindCodeReviewConfigActivity.cs
@@ -1,0 +1,139 @@
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Review.Models;
+
+namespace Tamma.Activities.Review;
+
+/// <summary>
+/// Resolves the <c>CodeReview:*</c> configuration block (Story 7-1D Config, completeness
+/// audit 2026-06-22 <c>CodeReview.md</c> §Missing #9) into typed outputs the workflow stores
+/// into variables. Config is read via the injected <see cref="IConfiguration"/> here rather
+/// than in the input-binding delegate (a <c>SetVariable</c> expression has no DI access).
+/// The per-input value (when present) takes precedence over config; config takes precedence
+/// over the hardcoded defaults.
+///
+/// <para>Fixes the spec drift where <c>WaitForFixes</c> defaulted to 24h — the resolved
+/// <c>FixTimeoutMinutes</c> (default 60) is surfaced as <see cref="FixTimeoutHours"/>
+/// (minutes/60, min 1h floor for the durable hour-granular wait) so the fix wait no longer
+/// inherits the review timeout.</para>
+/// </summary>
+[Activity(
+    "Tamma.Review",
+    "Bind Code Review Config",
+    "Resolve CodeReview:* configuration into workflow variables",
+    Kind = ActivityKind.Task
+)]
+public class BindCodeReviewConfigActivity : CodeActivity
+{
+    private readonly ILogger<BindCodeReviewConfigActivity>? _logger;
+    private readonly IConfiguration? _configuration;
+
+    /// <summary>Max review iterations from input (0 = use config / default)</summary>
+    [Input(Description = "Max review iterations override from input (0 = unset)", DefaultValue = 0)]
+    public Input<int> MaxIterationsInput { get; set; } = new(0);
+
+    /// <summary>Merge strategy from input (defaults to config / Squash)</summary>
+    [Input(Description = "Merge strategy override from input")]
+    public Input<string?> MergeStrategyInput { get; set; } = new((string?)null);
+
+    [Output(Description = "Resolved max review iterations")]
+    public Output<int> MaxIterations { get; set; } = default!;
+
+    [Output(Description = "Resolved merge strategy")]
+    public Output<MergeStrategy> MergeStrategy { get; set; } = default!;
+
+    [Output(Description = "Resolved review timeout in hours")]
+    public Output<int> ReviewTimeoutHours { get; set; } = default!;
+
+    [Output(Description = "Resolved fix timeout in hours (FixTimeoutMinutes / 60, min 1)")]
+    public Output<int> FixTimeoutHours { get; set; } = default!;
+
+    [Output(Description = "Resolved verify-CI-before-merge flag")]
+    public Output<bool> VerifyCIBeforeMerge { get; set; } = default!;
+
+    [Output(Description = "Resolved delete-branch-after-merge flag")]
+    public Output<bool> DeleteBranchAfterMerge { get; set; } = default!;
+
+    [JsonConstructor]
+    public BindCodeReviewConfigActivity() { }
+
+    public BindCodeReviewConfigActivity(
+        ILogger<BindCodeReviewConfigActivity> logger,
+        IConfiguration configuration)
+    {
+        _logger = logger;
+        _configuration = configuration;
+    }
+
+    protected override void Execute(ActivityExecutionContext context)
+    {
+        var resolved = Resolve(
+            _configuration,
+            MaxIterationsInput.Get(context),
+            MergeStrategyInput.Get(context));
+
+        MaxIterations.Set(context, resolved.MaxIterations);
+        MergeStrategy.Set(context, resolved.MergeStrategy);
+        ReviewTimeoutHours.Set(context, resolved.ReviewTimeoutHours);
+        FixTimeoutHours.Set(context, resolved.FixTimeoutHours);
+        VerifyCIBeforeMerge.Set(context, resolved.VerifyCIBeforeMerge);
+        DeleteBranchAfterMerge.Set(context, resolved.DeleteBranchAfterMerge);
+
+        _logger?.LogInformation(
+            "Resolved CodeReview config: maxIter={MaxIter}, strategy={Strategy}, " +
+            "reviewTimeoutH={ReviewH}, fixTimeoutH={FixH}, verifyCi={VerifyCi}, deleteBranch={DeleteBranch}",
+            resolved.MaxIterations, resolved.MergeStrategy, resolved.ReviewTimeoutHours,
+            resolved.FixTimeoutHours, resolved.VerifyCIBeforeMerge, resolved.DeleteBranchAfterMerge);
+    }
+
+    /// <summary>
+    /// Pure resolution of the <c>CodeReview:*</c> config (input &gt; config &gt; default).
+    /// Exposed for unit testing without an Elsa context.
+    /// </summary>
+    public static ResolvedConfig Resolve(
+        IConfiguration? configuration, int maxIterationsInput, string? mergeStrategyInput)
+    {
+        // MaxReviewIterations: input wins, then config, then 5.
+        var maxIterations = maxIterationsInput > 0
+            ? maxIterationsInput
+            : configuration?.GetValue<int?>("CodeReview:MaxReviewIterations") ?? 5;
+        if (maxIterations <= 0) maxIterations = 5;
+
+        // MergeStrategy: input wins, then config, then Squash.
+        var strategyRaw = !string.IsNullOrWhiteSpace(mergeStrategyInput)
+            ? mergeStrategyInput
+            : configuration?["CodeReview:MergeStrategy"];
+        var strategy = Enum.TryParse<MergeStrategy>(strategyRaw, true, out var parsed)
+            ? parsed
+            : Models.MergeStrategy.Squash;
+
+        var reviewTimeoutHours = configuration?.GetValue<int?>("CodeReview:ReviewTimeoutHours") ?? 24;
+        if (reviewTimeoutHours <= 0) reviewTimeoutHours = 24;
+
+        // FixTimeoutMinutes (default 60) → hours for the hour-granular durable wait (min 1h).
+        // Fixes the spec drift where the fix wait inherited the 24h review timeout.
+        var fixTimeoutMinutes = configuration?.GetValue<int?>("CodeReview:FixTimeoutMinutes") ?? 60;
+        if (fixTimeoutMinutes <= 0) fixTimeoutMinutes = 60;
+        var fixTimeoutHours = Math.Max(1, fixTimeoutMinutes / 60);
+
+        var verifyCi = configuration?.GetValue<bool?>("CodeReview:VerifyCIBeforeMerge") ?? true;
+        var deleteBranch = configuration?.GetValue<bool?>("CodeReview:DeleteBranchAfterMerge") ?? true;
+
+        return new ResolvedConfig(
+            maxIterations, strategy, reviewTimeoutHours, fixTimeoutHours, verifyCi, deleteBranch);
+    }
+
+    /// <summary>Immutable resolved-config bundle (for testability).</summary>
+    public readonly record struct ResolvedConfig(
+        int MaxIterations,
+        MergeStrategy MergeStrategy,
+        int ReviewTimeoutHours,
+        int FixTimeoutHours,
+        bool VerifyCIBeforeMerge,
+        bool DeleteBranchAfterMerge);
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/BuildCodeReviewResultActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/BuildCodeReviewResultActivity.cs
@@ -1,0 +1,92 @@
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Review.Models;
+
+namespace Tamma.Activities.Review;
+
+/// <summary>
+/// Builds the structured <see cref="CodeReviewWorkflowResult"/> for a terminal path
+/// (Story 7-1D AC2, completeness audit 2026-06-22 <c>CodeReview.md</c> §Missing #6) and
+/// exposes it both as the typed <see cref="Result"/> output and as the workflow output
+/// <c>result</c>. Replaces the three loose <c>SetOutput</c>s. Every terminal path
+/// (merged / rejected / escalation-resolved / escalation-rejected / timeout /
+/// validation-failed) maps to a <see cref="PRReviewStatus"/> via <see cref="FinalStatus"/>,
+/// so a degraded outcome is never reported as a success.
+/// </summary>
+[Activity(
+    "Tamma.Review",
+    "Build Code Review Result",
+    "Build the structured CodeReviewWorkflowResult and emit it as workflow output 'result'",
+    Kind = ActivityKind.Task
+)]
+public class BuildCodeReviewResultActivity : CodeActivity<CodeReviewWorkflowResult>
+{
+    private readonly ILogger<BuildCodeReviewResultActivity>? _logger;
+
+    [Input(Description = "Final review status")]
+    public Input<PRReviewStatus> FinalStatus { get; set; } = new(PRReviewStatus.Pending);
+
+    [Input(Description = "Whether the review ended in a merge (success)")]
+    public Input<bool> Success { get; set; } = new(false);
+
+    [Input(Description = "Pull request number (0 = none)")]
+    public Input<int> PRNumber { get; set; } = new(0);
+
+    [Input(Description = "Pull request URL")]
+    public Input<string?> PRUrl { get; set; } = new((string?)null);
+
+    [Input(Description = "Merge commit sha")]
+    public Input<string?> MergeSha { get; set; } = new((string?)null);
+
+    [Input(Description = "Total fix iterations")]
+    public Input<int> TotalIterations { get; set; } = new(0);
+
+    [Input(Description = "Whether the review was escalated to a senior")]
+    public Input<bool> WasEscalated { get; set; } = new(false);
+
+    [Input(Description = "Escalation resolution (e.g. resolved/rejected) when escalated")]
+    public Input<string?> EscalationResolution { get; set; } = new((string?)null);
+
+    [Input(Description = "Human-readable terminal message")]
+    public Input<string?> Message { get; set; } = new((string?)null);
+
+    [JsonConstructor]
+    public BuildCodeReviewResultActivity() { }
+
+    public BuildCodeReviewResultActivity(ILogger<BuildCodeReviewResultActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override void Execute(ActivityExecutionContext context)
+    {
+        var prNumber = PRNumber.Get(context);
+        var totalIterations = TotalIterations.Get(context);
+
+        var result = new CodeReviewWorkflowResult
+        {
+            Success = Success.Get(context),
+            FinalStatus = FinalStatus.Get(context),
+            PRNumber = prNumber > 0 ? prNumber : null,
+            PRUrl = PRUrl.Get(context),
+            MergeSha = MergeSha.Get(context),
+            TotalIterations = totalIterations,
+            ReviewRounds = totalIterations + 1,
+            WasEscalated = WasEscalated.Get(context),
+            EscalationResolution = EscalationResolution.Get(context),
+            Message = Message.Get(context),
+            CompletedAt = DateTime.UtcNow
+        };
+
+        context.SetResult(result);
+        context.WorkflowExecutionContext.Output["result"] = result;
+
+        _logger?.LogInformation(
+            "Built code-review result: status={Status}, success={Success}, pr=#{Pr}, iterations={Iter}, escalated={Escalated}",
+            result.FinalStatus, result.Success, prNumber, totalIterations, result.WasEscalated);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/CodeReviewEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/CodeReviewEvents.cs
@@ -1,0 +1,85 @@
+namespace Tamma.Activities.Review;
+
+/// <summary>
+/// Completeness audit 2026-06-22 (<c>CodeReview.md</c> §Missing #8, Story 7-1D AC10) —
+/// central catalogue of the <c>CODE_REVIEW.*</c> DCB event types emitted by the
+/// <c>code-review</c> sub-workflow via <see cref="EmitCodeReviewEventActivity"/>.
+/// Type pattern follows the platform's <c>AGGREGATE.ACTION.STATUS</c> convention
+/// (<c>CLAUDE.md</c>) and mirrors the sibling event catalogues
+/// (<see cref="Tamma.Activities.Blocker.BlockerEvents"/>,
+/// <see cref="Tamma.Activities.ADL.BranchEvents"/>).
+///
+/// <para>The code-review workflow drives the full PR lifecycle (create → request review →
+/// monitor → guide fixes → re-review → merge / escalate). Each milestone is an auditable
+/// transition so time-travel debugging and the Epic-32 benchmarking/learning loop can
+/// reconstruct <i>how</i> a PR moved from creation to merge (or escalation), how many fix
+/// iterations it took, and whether a wait expired. The pre-existing
+/// <c>MentorshipEvent</c> rows are RETAINED in addition — they feed the mentorship state
+/// machine; these DCB events feed the platform audit/time-travel stream.</para>
+///
+/// <para>Events are emitted via <c>TammaEventEmitter.Emit</c> into the workflow's
+/// <c>tamma:events</c> transient list and persisted <i>durably</i> by the engine event
+/// drain (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) — the same pattern
+/// <see cref="Tamma.Activities.ADL.EmitBranchEventActivity"/> and
+/// <see cref="Tamma.Activities.Blocker.EmitBlockerEventActivity"/> use. No activity holds
+/// a DB / repository dependency of its own (none is registered in the Elsa engine — a
+/// directly injected <c>IEventRepository</c> would be inert and silently drop every
+/// event). The drain resolves the tenant from the workflow scope, and each event carries a
+/// <c>tenantId</c> tag (SaaS) so per-tenant perf/action data stays tenant-scoped
+/// (Epic 32).</para>
+///
+/// <list type="bullet">
+///   <item><description><c>CODE_REVIEW.PR_CREATED.SUCCESS</c> / <c>.FAILED</c> — the PR was
+///     created (or creation failed and the run terminates).</description></item>
+///   <item><description><c>CODE_REVIEW.GUIDANCE_DELIVERED.SUCCESS</c> / <c>.FAILED</c> — fix
+///     guidance was generated (via mediated LLM) and delivered to the junior (or guidance
+///     generation failed and the run escalates).</description></item>
+///   <item><description><c>CODE_REVIEW.ITERATION.STARTED</c> — a new fix iteration began
+///     (carries the iteration number).</description></item>
+///   <item><description><c>CODE_REVIEW.MERGED.SUCCESS</c> / <c>.FAILED</c> — the PR was
+///     merged (carries the merge sha + strategy) or merge failed irrecoverably.</description></item>
+///   <item><description><c>CODE_REVIEW.ESCALATED</c> — the review was escalated to a senior
+///     (carries the reason).</description></item>
+///   <item><description><c>CODE_REVIEW.FAILED</c> — terminal: the review ended without a
+///     merge (validation failure, senior rejection). LOUD (error-status) — never a silent
+///     false success.</description></item>
+/// </list>
+/// </summary>
+public static class CodeReviewEvents
+{
+    public const string PrCreatedSuccess = "CODE_REVIEW.PR_CREATED.SUCCESS";
+    public const string PrCreatedFailed = "CODE_REVIEW.PR_CREATED.FAILED";
+    public const string GuidanceDeliveredSuccess = "CODE_REVIEW.GUIDANCE_DELIVERED.SUCCESS";
+    public const string GuidanceDeliveredFailed = "CODE_REVIEW.GUIDANCE_DELIVERED.FAILED";
+    public const string IterationStarted = "CODE_REVIEW.ITERATION.STARTED";
+    public const string MergedSuccess = "CODE_REVIEW.MERGED.SUCCESS";
+    public const string MergedFailed = "CODE_REVIEW.MERGED.FAILED";
+    public const string Escalated = "CODE_REVIEW.ESCALATED";
+    public const string Failed = "CODE_REVIEW.FAILED";
+
+    /// <summary>
+    /// Parse a tenant id from the loose string form threaded through the workflow inputs.
+    /// Returns <c>null</c> for empty / single-user / unparseable values (code-review events
+    /// in single-user mode are platform-scope, TenantId null). Mirrors
+    /// <see cref="Tamma.Activities.Blocker.BlockerEvents.ParseTenantId"/>.
+    /// </summary>
+    public static Guid? ParseTenantId(string? tenantId)
+        => Guid.TryParse(tenantId, out var g) ? g : null;
+
+    /// <summary>
+    /// Status convention: a creation/merge/guidance failure and the <see cref="Failed"/>
+    /// terminal are LOUD (error-status) audit rows so a degraded/rejected outcome is never
+    /// recorded as a false success; every other transition (PR created, guidance delivered,
+    /// iteration started, merged, escalated) is a normal (success-status) row. An escalation
+    /// is success-status because it is an expected, auditable hand-off to a senior — the
+    /// rejection that may follow is recorded as <see cref="Failed"/>.
+    /// </summary>
+    public static string StatusForEvent(string type) => type switch
+    {
+        PrCreatedFailed => "error",
+        GuidanceDeliveredFailed => "error",
+        MergedFailed => "error",
+        Failed => "error",
+        _ => "success",
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/DeliverGuidanceActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/DeliverGuidanceActivity.cs
@@ -1,9 +1,9 @@
 using System.Text.Json.Serialization;
 using Elsa.Extensions;
 using Elsa.Workflows;
+using Elsa.Workflows.Activities.Flowchart.Attributes;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Tamma.Activities.Review.Models;
 using Tamma.Core.Entities;
@@ -13,22 +13,34 @@ using Tamma.Data.Repositories;
 namespace Tamma.Activities.Review;
 
 /// <summary>
-/// Analyses review comments and delivers actionable fix guidance to the junior developer.
-/// Uses Claude (or engine callback / mock) to generate contextual guidance for each comment,
-/// then sends the guidance via Slack.
+/// Delivers actionable, skill-level-aware fix guidance to the junior developer.
+///
+/// Story 7-1D AC7 (completeness audit 2026-06-22, <c>CodeReview.md</c> §Missing #4):
+/// the guidance text is now produced by the MEDIATED LLM upstream — the workflow runs
+/// <c>AnalyzeChanges</c> (<c>llm-call</c> role=senior_developer / action=code-review) then
+/// <c>GenerateGuidance</c> (<c>llm-call</c> role=senior_developer / action=mentor-feedback,
+/// "explain to a Level {skillLevel} developer …") via <c>DispatchWorkflow("llm-call")</c>,
+/// and passes the LLM output into <see cref="GuidanceText"/>. This activity ONLY formats +
+/// delivers that text (the prior in-process keyword heuristics are removed — there is no
+/// in-engine provider call here).
+///
+/// <para><b>Fail-closed:</b> if the upstream LLM produced no usable guidance text, this
+/// activity routes to the <c>Failed</c> outcome (the workflow escalates) rather than
+/// silently delivering empty/placeholder guidance. Outcomes: <c>Delivered</c> /
+/// <c>Failed</c>.</para>
 /// </summary>
 [Activity(
     "Tamma.Review",
     "Deliver Guidance",
-    "Analyze review comments and deliver fix guidance to the junior developer",
+    "Deliver mediated-LLM fix guidance to the junior developer",
     Kind = ActivityKind.Task
 )]
-public class DeliverGuidanceActivity : CodeActivity<FixGuidance>
+[FlowNode("Delivered", "Failed")]
+public class DeliverGuidanceActivity : Activity
 {
     private readonly ILogger<DeliverGuidanceActivity>? _logger;
     private readonly IMentorshipSessionRepository? _repository;
     private readonly IIntegrationService? _integrationService;
-    private readonly IConfiguration? _configuration;
 
     /// <summary>Mentorship session ID</summary>
     [Input(Description = "Mentorship session ID")]
@@ -50,19 +62,29 @@ public class DeliverGuidanceActivity : CodeActivity<FixGuidance>
     [Input(Description = "Review comments to address")]
     public Input<string> ReviewCommentsJson { get; set; } = default!;
 
+    /// <summary>
+    /// The skill-level-aware fix guidance produced by the mediated LLM
+    /// (<c>GenerateGuidance</c> llm-call). This is the content delivered to the junior —
+    /// the activity no longer generates guidance itself.
+    /// </summary>
+    [Input(Description = "Mediated-LLM guidance text to deliver")]
+    public Input<string?> GuidanceText { get; set; } = new((string?)null);
+
+    /// <summary>The guidance delivered to the junior</summary>
+    [Output(Description = "Guidance delivered")]
+    public Output<FixGuidance?> Result { get; set; } = default!;
+
     [JsonConstructor]
     public DeliverGuidanceActivity() { }
 
     public DeliverGuidanceActivity(
         ILogger<DeliverGuidanceActivity> logger,
         IMentorshipSessionRepository repository,
-        IIntegrationService integrationService,
-        IConfiguration configuration)
+        IIntegrationService integrationService)
     {
         _logger = logger;
         _repository = repository;
         _integrationService = integrationService;
-        _configuration = configuration;
     }
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
@@ -72,32 +94,42 @@ public class DeliverGuidanceActivity : CodeActivity<FixGuidance>
         var prNumber = PRNumber.Get(context);
         var iteration = Iteration.Get(context);
         var commentsJson = ReviewCommentsJson.Get(context);
+        var guidanceText = GuidanceText.Get(context);
 
         _logger?.LogInformation(
             "Delivering fix guidance for PR #{PRNumber}, iteration {Iteration}, session {SessionId}",
             prNumber, iteration, sessionId);
+
+        // Fail-closed: never ship empty guidance. If the mediated LLM produced nothing
+        // usable, route to escalation instead of silently delivering a placeholder.
+        if (string.IsNullOrWhiteSpace(guidanceText))
+        {
+            _logger?.LogWarning(
+                "No LLM guidance text for PR #{PRNumber}, iteration {Iteration}; routing to escalation",
+                prNumber, iteration);
+            Result.Set(context, null);
+            await context.CompleteActivityWithOutcomesAsync("Failed");
+            return;
+        }
 
         try
         {
             var junior = await _repository!.GetJuniorByIdAsync(juniorId);
             var comments = DeserializeComments(commentsJson);
 
-            // Generate guidance for each comment
-            var guidanceItems = comments.Select(c => new CommentFixGuidance
-            {
-                OriginalComment = c.Body,
-                FilePath = c.FilePath,
-                LineNumber = c.LineNumber,
-                Severity = c.Severity,
-                Guidance = GenerateGuidanceForComment(c, junior?.SkillLevel ?? 3),
-                CodeExample = GenerateCodeExample(c)
-            }).ToList();
-
             var guidance = new FixGuidance
             {
                 Iteration = iteration,
-                Items = guidanceItems,
-                OverallMessage = BuildOverallMessage(iteration, guidanceItems.Count, junior?.Name ?? "Developer")
+                Items = comments.Select(c => new CommentFixGuidance
+                {
+                    OriginalComment = c.Body,
+                    FilePath = c.FilePath,
+                    LineNumber = c.LineNumber,
+                    Severity = c.Severity,
+                    Guidance = string.Empty, // per-comment detail is folded into OverallMessage (the LLM output)
+                    CodeExample = c.SuggestedFix
+                }).ToList(),
+                OverallMessage = guidanceText.Trim()
             };
 
             // Send guidance to the junior via Slack
@@ -107,7 +139,7 @@ public class DeliverGuidanceActivity : CodeActivity<FixGuidance>
                 await _integrationService!.SendSlackDirectMessageAsync(junior.SlackId, message);
             }
 
-            // Log the event
+            // Log the mentorship event (retained alongside the DCB event the workflow emits)
             await _repository.LogEventAsync(new MentorshipEvent
             {
                 SessionId = sessionId,
@@ -118,23 +150,23 @@ public class DeliverGuidanceActivity : CodeActivity<FixGuidance>
 
             _logger?.LogInformation(
                 "Delivered guidance for {CommentCount} comments, iteration {Iteration}",
-                guidanceItems.Count, iteration);
+                guidance.Items.Count, iteration);
 
-            context.SetResult(guidance);
+            Result.Set(context, guidance);
+            await context.CompleteActivityWithOutcomesAsync("Delivered");
         }
         catch (Exception ex)
         {
             _logger?.LogError(ex, "Error delivering guidance for session {SessionId}", sessionId);
-            context.SetResult(new FixGuidance
-            {
-                Iteration = iteration,
-                OverallMessage = $"Failed to generate guidance: {ex.Message}"
-            });
+            Result.Set(context, null);
+            await context.CompleteActivityWithOutcomesAsync("Failed");
         }
     }
 
-    private static List<ReviewCommentDetail> DeserializeComments(string json)
+    private static List<ReviewCommentDetail> DeserializeComments(string? json)
     {
+        if (string.IsNullOrWhiteSpace(json))
+            return new List<ReviewCommentDetail>();
         try
         {
             return System.Text.Json.JsonSerializer.Deserialize<List<ReviewCommentDetail>>(json)
@@ -144,58 +176,6 @@ public class DeliverGuidanceActivity : CodeActivity<FixGuidance>
         {
             return new List<ReviewCommentDetail>();
         }
-    }
-
-    private static string GenerateGuidanceForComment(ReviewCommentDetail comment, int skillLevel)
-    {
-        var bodyLower = comment.Body.ToLower();
-
-        // Provide skill-level-appropriate guidance
-        var detail = skillLevel <= 2 ? " Here is a step-by-step explanation:" : "";
-
-        if (bodyLower.Contains("null check") || bodyLower.Contains("null reference"))
-            return $"Add null validation before using this value.{detail} Use `if (variable == null)` or the null-conditional operator `?.` to guard against null references.";
-
-        if (bodyLower.Contains("test") || bodyLower.Contains("coverage"))
-            return $"Add unit tests covering this code path.{detail} Follow the existing test patterns in the project and ensure edge cases are covered.";
-
-        if (bodyLower.Contains("naming") || bodyLower.Contains("rename") || bodyLower.Contains("descriptive"))
-            return $"Improve the variable/method name to be more descriptive.{detail} Names should describe *what* the value represents, not its type.";
-
-        if (bodyLower.Contains("error handling") || bodyLower.Contains("exception") || bodyLower.Contains("try"))
-            return $"Improve error handling in this section.{detail} Wrap the operation in a try-catch block and log meaningful error context.";
-
-        if (bodyLower.Contains("performance") || bodyLower.Contains("optimize"))
-            return $"Consider optimizing this code path.{detail} Look for unnecessary allocations, repeated computations, or N+1 query patterns.";
-
-        if (bodyLower.Contains("security") || bodyLower.Contains("injection") || bodyLower.Contains("sanitize"))
-            return $"Address the security concern.{detail} Validate and sanitize all inputs. Never trust user-provided data directly.";
-
-        if (bodyLower.Contains("extract") || bodyLower.Contains("refactor"))
-            return $"Refactor this code into a smaller, focused method.{detail} Each method should do one thing well.";
-
-        if (bodyLower.Contains("documentation") || bodyLower.Contains("comment") || bodyLower.Contains("xml doc"))
-            return $"Add documentation for this public API.{detail} Use `/// <summary>` XML docs describing what the method does and its parameters.";
-
-        return $"Review the feedback and apply the suggested change.{detail} If anything is unclear, ask your reviewer for clarification.";
-    }
-
-    private static string? GenerateCodeExample(ReviewCommentDetail comment)
-    {
-        if (!string.IsNullOrEmpty(comment.SuggestedFix))
-            return comment.SuggestedFix;
-
-        return null;
-    }
-
-    private static string BuildOverallMessage(int iteration, int commentCount, string devName)
-    {
-        if (iteration == 1)
-            return $"Hi {devName}! The reviewer has left {commentCount} comment(s) on your PR. " +
-                   "Below is guidance for each one. Take your time and push your fixes when ready.";
-
-        return $"Hi {devName}, this is iteration {iteration} of fixes. " +
-               $"There are {commentCount} remaining comment(s) to address. You are making progress!";
     }
 
     private static string FormatGuidanceMessage(FixGuidance guidance, int prNumber)
@@ -208,26 +188,28 @@ public class DeliverGuidanceActivity : CodeActivity<FixGuidance>
             ""
         };
 
-        for (var i = 0; i < guidance.Items.Count; i++)
+        if (guidance.Items.Count > 0)
         {
-            var item = guidance.Items[i];
-            var severityTag = item.Severity switch
+            lines.Add("**Review comments addressed:**");
+            for (var i = 0; i < guidance.Items.Count; i++)
             {
-                ReviewCommentSeverity.Critical => "[CRITICAL]",
-                ReviewCommentSeverity.Major => "[MAJOR]",
-                ReviewCommentSeverity.Minor => "[minor]",
-                ReviewCommentSeverity.Suggestion => "[suggestion]",
-                _ => ""
-            };
+                var item = guidance.Items[i];
+                var severityTag = item.Severity switch
+                {
+                    ReviewCommentSeverity.Critical => "[CRITICAL]",
+                    ReviewCommentSeverity.Major => "[MAJOR]",
+                    ReviewCommentSeverity.Minor => "[minor]",
+                    ReviewCommentSeverity.Suggestion => "[suggestion]",
+                    _ => ""
+                };
 
-            lines.Add($"**{i + 1}. {severityTag} {item.FilePath}**" +
-                       (item.LineNumber.HasValue ? $" (line {item.LineNumber})" : ""));
-            lines.Add($"  Comment: _{item.OriginalComment}_");
-            lines.Add($"  Guidance: {item.Guidance}");
+                lines.Add($"**{i + 1}. {severityTag} {item.FilePath}**" +
+                           (item.LineNumber.HasValue ? $" (line {item.LineNumber})" : ""));
+                lines.Add($"  _{item.OriginalComment}_");
 
-            if (!string.IsNullOrEmpty(item.CodeExample))
-                lines.Add($"  Example: ```{item.CodeExample}```");
-
+                if (!string.IsNullOrEmpty(item.CodeExample))
+                    lines.Add($"  Suggested fix: ```{item.CodeExample}```");
+            }
             lines.Add("");
         }
 

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/EmitCodeReviewEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/EmitCodeReviewEventActivity.cs
@@ -1,0 +1,150 @@
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+
+namespace Tamma.Activities.Review;
+
+/// <summary>
+/// Emits a <c>CODE_REVIEW.*</c> DCB event (completeness audit 2026-06-22,
+/// <c>CodeReview.md</c> §Missing #8, Story 7-1D AC10) for the <c>code-review</c>
+/// sub-workflow by appending a <see cref="TammaEvent"/> to the workflow's
+/// <c>tamma:events</c> transient list via <see cref="TammaEventEmitter.Emit"/>. The merged
+/// engine event drain (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) flushes that
+/// list <i>durably</i> to the tenant <c>domain_events</c> store after this activity runs —
+/// the same pattern <see cref="Tamma.Activities.Blocker.EmitBlockerEventActivity"/> and
+/// <see cref="Tamma.Activities.ADL.EmitBranchEventActivity"/> use. No activity holds a
+/// DB / repository dependency of its own (none is registered in the Elsa engine — a
+/// directly injected <c>IEventRepository</c> would be inert and silently drop every event).
+/// The existing <c>MentorshipEvent</c> rows are kept in addition (they feed the mentorship
+/// state machine); these events feed the platform audit/time-travel stream.
+/// </summary>
+[Activity(
+    "Tamma.Review",
+    "Emit Code Review Event",
+    "Emit a CODE_REVIEW.* DCB event for the code-review audit trail",
+    Kind = ActivityKind.Task
+)]
+public class EmitCodeReviewEventActivity : Activity
+{
+    private readonly ILogger<EmitCodeReviewEventActivity>? _logger;
+
+    [Input(Description = "Event type — CODE_REVIEW.PR_CREATED.SUCCESS / .FAILED / .GUIDANCE_DELIVERED.SUCCESS / .FAILED / .ITERATION.STARTED / .MERGED.SUCCESS / .FAILED / .ESCALATED / .FAILED")]
+    public Input<string> EventType { get; set; } = default!;
+
+    [Input(Description = "Mentorship session id")]
+    public Input<string?> SessionId { get; set; } = new((string?)null);
+
+    [Input(Description = "Story id under review")]
+    public Input<string?> StoryId { get; set; } = new((string?)null);
+
+    [Input(Description = "Junior developer id")]
+    public Input<string?> JuniorId { get; set; } = new((string?)null);
+
+    [Input(Description = "Tenant id (empty / single-user → platform-scope event)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [Input(Description = "Pull request number (0 = not yet created)")]
+    public Input<int> PrNumber { get; set; } = new(0);
+
+    [Input(Description = "Pull request URL")]
+    public Input<string?> PrUrl { get; set; } = new((string?)null);
+
+    [Input(Description = "Fix iteration number (ITERATION.STARTED / GUIDANCE events)")]
+    public Input<int> Iteration { get; set; } = new(0);
+
+    [Input(Description = "Merge commit sha (MERGED.SUCCESS events)")]
+    public Input<string?> MergeSha { get; set; } = new((string?)null);
+
+    [Input(Description = "Escalation reason (ESCALATED events)")]
+    public Input<string?> Reason { get; set; } = new((string?)null);
+
+    [Input(Description = "Error / failure detail (FAILED events)")]
+    public Input<string?> Detail { get; set; } = new((string?)null);
+
+    [JsonConstructor]
+    public EmitCodeReviewEventActivity() { }
+
+    public EmitCodeReviewEventActivity(ILogger<EmitCodeReviewEventActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var type = EventType.Get(context) ?? CodeReviewEvents.Failed;
+        var sessionId = SessionId.Get(context);
+        var storyId = StoryId.Get(context);
+        var juniorId = JuniorId.Get(context);
+        var tenantId = CodeReviewEvents.ParseTenantId(TenantId.Get(context));
+        var prNumber = PrNumber.Get(context);
+        var prUrl = PrUrl.Get(context);
+        var iteration = Iteration.Get(context);
+        var mergeSha = MergeSha.Get(context);
+        var reason = Reason.Get(context);
+        var detail = Detail.Get(context);
+
+        var evt = BuildTammaEvent(
+            type, sessionId, storyId, juniorId, tenantId,
+            prNumber, prUrl, iteration, mergeSha, reason, detail);
+        TammaEventEmitter.Emit(context, this, _logger, evt);
+
+        _logger?.LogInformation(
+            "Emitted {Type} for session {Session} story {Story} (pr=#{Pr}, iteration={Iteration})",
+            type, sessionId, storyId, prNumber, iteration);
+
+        return default;
+    }
+
+    /// <summary>
+    /// Map the code-review event inputs onto a <see cref="TammaEvent"/> expressed as the
+    /// engine's transient-list event so the merged drain persists it. Tags carry the
+    /// queryable DCB index keys (<c>sessionId</c>/<c>storyId</c>/<c>juniorId</c>/<c>prId</c>/
+    /// <c>iteration</c>/<c>tenantId</c>); <c>Data</c> carries the per-milestone payload.
+    /// Status is driven off the event type (<see cref="CodeReviewEvents.StatusForEvent"/>)
+    /// so a creation/merge/guidance failure or rejection is a LOUD error row, never a false
+    /// success. Pure (no Elsa context); exposed for unit testing the mapping.
+    /// </summary>
+    public static TammaEvent BuildTammaEvent(
+        string type,
+        string? sessionId,
+        string? storyId,
+        string? juniorId,
+        Guid? tenantId,
+        int prNumber,
+        string? prUrl,
+        int iteration,
+        string? mergeSha,
+        string? reason,
+        string? detail)
+    {
+        var tags = new Dictionary<string, object?>();
+        if (!string.IsNullOrWhiteSpace(sessionId)) tags["sessionId"] = sessionId;
+        if (!string.IsNullOrWhiteSpace(storyId)) tags["storyId"] = storyId;
+        if (!string.IsNullOrWhiteSpace(juniorId)) tags["juniorId"] = juniorId;
+        if (prNumber > 0) tags["prId"] = prNumber.ToString();
+        if (iteration > 0) tags["iteration"] = iteration.ToString();
+        if (tenantId is not null) tags["tenantId"] = tenantId.Value.ToString("D");
+
+        var data = new Dictionary<string, object?>();
+        if (prNumber > 0) data["prNumber"] = prNumber;
+        if (!string.IsNullOrWhiteSpace(prUrl)) data["prUrl"] = prUrl;
+        if (iteration > 0) data["iteration"] = iteration;
+        if (!string.IsNullOrWhiteSpace(mergeSha)) data["mergeSha"] = mergeSha;
+        if (!string.IsNullOrWhiteSpace(reason)) data["reason"] = reason;
+        if (!string.IsNullOrWhiteSpace(detail)) data["detail"] = detail;
+
+        var status = CodeReviewEvents.StatusForEvent(type);
+        return new TammaEvent
+        {
+            EventType = type,
+            Status = status,
+            Error = status == "error" ? detail : null,
+            Tags = tags,
+            Data = data,
+        };
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/EscalateReviewActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/EscalateReviewActivity.cs
@@ -6,6 +6,7 @@ using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
 using Tamma.Activities.Review.Models;
+using Microsoft.Extensions.Configuration;
 using Tamma.Core.Entities;
 using Tamma.Core.Interfaces;
 using Tamma.Data.Repositories;
@@ -20,6 +21,20 @@ namespace Tamma.Activities.Review;
 /// Outcomes:
 ///   - Resolved: the senior resolved the escalation (approved or fixed)
 ///   - Rejected: the senior rejected the PR entirely
+///   - TimedOut: the senior-response SLA expired with no response (durable timeout)
+///
+/// <para><b>Durable senior-response SLA timeout (review fix 2026-06-25, code-review P0).</b> Two
+/// resume paths are armed when the activity suspends: the escalation bookmark
+/// (<c>escalate-{session}-{pr}</c>) resumed by the senior → <see cref="Resolved"/> /
+/// <see cref="Rejected"/>; and a DURABLE delay bookmark via
+/// <see cref="Elsa.Extensions.DelayActivityExecutionContextExtensions.DelayFor(ActivityExecutionContext, System.TimeSpan, ExecuteActivityDelegate)"/>
+/// at the SLA (<c>CodeReview:EscalationTimeoutMinutes</c>, default 1440 = 24h) →
+/// <see cref="TimedOut"/>. The build-out armed ONLY the escalation bookmark, so a never-answered
+/// escalation suspended forever — there was no path to a terminal at all. The Delay bookmark is
+/// EF-persisted and re-armed by <c>Elsa.Scheduling</c>'s startup task on rehydration, so the SLA
+/// survives a host restart inside the (default 24h) window. Whichever path resumes first
+/// completes the activity; Elsa burns the remaining bookmark (no orphaned timer / double-resume).
+/// Mirrors <see cref="Tamma.Activities.Blocker.EscalateToSeniorActivity"/>.</para>
 /// </summary>
 [Activity(
     "Tamma.Review",
@@ -27,12 +42,13 @@ namespace Tamma.Activities.Review;
     "Escalate the review to a senior developer and wait for response (bookmark-based)",
     Kind = ActivityKind.Task
 )]
-[FlowNode("Resolved", "Rejected")]
+[FlowNode("Resolved", "Rejected", "TimedOut")]
 public class EscalateReviewActivity : Activity
 {
     private readonly ILogger<EscalateReviewActivity>? _logger;
     private readonly IMentorshipSessionRepository? _repository;
     private readonly IIntegrationService? _integrationService;
+    private readonly IConfiguration? _configuration;
 
     /// <summary>Mentorship session ID</summary>
     [Input(Description = "Mentorship session ID")]
@@ -68,11 +84,13 @@ public class EscalateReviewActivity : Activity
     public EscalateReviewActivity(
         ILogger<EscalateReviewActivity> logger,
         IMentorshipSessionRepository repository,
-        IIntegrationService integrationService)
+        IIntegrationService integrationService,
+        IConfiguration configuration)
     {
         _logger = logger;
         _repository = repository;
         _integrationService = integrationService;
+        _configuration = configuration;
     }
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
@@ -147,7 +165,8 @@ public class EscalateReviewActivity : Activity
         _logger?.LogInformation(
             "Creating escalation bookmark {BookmarkName}", bookmarkName);
 
-        // Create the bookmark — workflow suspends here waiting for senior response
+        // 1) Escalation bookmark — resumed by the senior's response (API/Slack). The workflow
+        //    suspends here until this resumes OR the durable SLA delay below fires.
         context.CreateBookmark(
             new CreateBookmarkArgs
             {
@@ -155,6 +174,37 @@ public class EscalateReviewActivity : Activity
                 Callback = OnEscalationResponseAsync,
                 AutoBurn = true
             });
+
+        // 2) Durable senior-response SLA — a DelayFor (Delay) bookmark that Elsa.Scheduling's
+        //    startup task RE-ARMS after a host restart (EF-persisted, not an in-memory timer).
+        //    A never-answered escalation now terminates as a real TimedOut even across a VPS
+        //    restart inside the (default 24h) SLA window — it no longer suspends forever.
+        var slaMinutes = _configuration?.GetValue<int?>("CodeReview:EscalationTimeoutMinutes") ?? 1440;
+        context.DelayFor(TimeSpan.FromMinutes(Math.Max(1, slaMinutes)), OnTimeoutAsync);
+
+        _logger?.LogInformation(
+            "Escalation awaiting senior; durable SLA timeout armed at +{SlaMinutes}min for PR #{PRNumber}",
+            slaMinutes, prNumber);
+    }
+
+    /// <summary>
+    /// Durable timeout path: the senior-response SLA elapsed with no response. The Delay
+    /// bookmark scheduler resumes the activity here (and re-arms across a host restart). Takes
+    /// the <c>TimedOut</c> outcome instead of suspending forever; the still-armed escalation
+    /// bookmark is burned on completion. <see cref="EscalationResponse"/> is left null — there
+    /// was no senior response.
+    /// </summary>
+    private async ValueTask OnTimeoutAsync(ActivityExecutionContext context)
+    {
+        var sessionId = SessionId.Get(context);
+        var prNumber = PRNumber.Get(context);
+
+        _logger?.LogWarning(
+            "Senior-response SLA expired (durable timeout) for PR #{PRNumber}, session {SessionId} — taking the TimedOut outcome",
+            prNumber, sessionId);
+
+        EscalationResponse.Set(context, null);
+        await context.CompleteActivityWithOutcomesAsync("TimedOut");
     }
 
     private async ValueTask OnEscalationResponseAsync(ActivityExecutionContext context)

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/MergeAndCompleteReviewActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/MergeAndCompleteReviewActivity.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using Elsa.Extensions;
 using Elsa.Workflows;
+using Elsa.Workflows.Activities.Flowchart.Attributes;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
@@ -13,17 +14,34 @@ using Tamma.Data.Repositories;
 namespace Tamma.Activities.Review;
 
 /// <summary>
-/// Merges the approved pull request and completes the review sub-workflow.
-/// Supports configurable merge strategies (squash, merge, rebase) with
-/// squash as the default. Notifies the junior developer upon merge.
+/// Merges the approved pull request and completes the review sub-workflow (Story 7-1D AC8).
+///
+/// Hardening (completeness audit 2026-06-22, <c>CodeReview.md</c> §Missing #5):
+///   - <b>Verify CI green before merge</b> (config-gated, default true): polls the PR's
+///     head-branch build status; a non-success status routes to the <c>Failed</c> outcome
+///     (the workflow escalates) instead of merging on red.
+///   - <b>Honour the merge strategy</b>: the configured <see cref="MergeStrategy"/> is mapped
+///     to GitHub's <c>merge_method</c> via the strategy-aware
+///     <see cref="IIntegrationService.MergeGitHubPullRequestAsync(string,int,string)"/>
+///     overload (the prior single-arg call let the service pick squash unconditionally).
+///   - <b>Retry merge once then escalate</b>: a transient merge failure (e.g. a momentary
+///     conflict/CI flake) is retried exactly once; a second failure routes to <c>Failed</c>
+///     so the workflow escalates to a senior — never a silent false success.
+///   - <b>Delete source branch after merge</b> (config-gated, default true): on a successful
+///     merge the head branch is deleted (best-effort — a delete failure does NOT fail the
+///     merge, it is logged and the merge still reports success).
+///
+/// Outcomes: <c>Merged</c> (success — proceed to the structured success terminal) /
+/// <c>Failed</c> (CI red, or merge failed twice — the workflow escalates).
 /// </summary>
 [Activity(
     "Tamma.Review",
     "Merge And Complete Review",
-    "Merge the approved PR and complete the code review sub-workflow",
+    "Merge the approved PR (CI-gated, strategy-aware, retry-once) and complete the code review sub-workflow",
     Kind = ActivityKind.Task
 )]
-public class MergeAndCompleteReviewActivity : CodeActivity<ReviewMergeResult>
+[FlowNode("Merged", "Failed")]
+public class MergeAndCompleteReviewActivity : Activity
 {
     private readonly ILogger<MergeAndCompleteReviewActivity>? _logger;
     private readonly IMentorshipSessionRepository? _repository;
@@ -46,6 +64,10 @@ public class MergeAndCompleteReviewActivity : CodeActivity<ReviewMergeResult>
     [Input(Description = "Pull request number")]
     public Input<int> PRNumber { get; set; } = default!;
 
+    /// <summary>Head branch to delete after merge (default: feature/{storyId})</summary>
+    [Input(Description = "Head branch to delete after merge")]
+    public Input<string?> HeadBranch { get; set; } = new((string?)null);
+
     /// <summary>Merge strategy (default: Squash)</summary>
     [Input(Description = "Merge strategy: Squash, Merge, Rebase", DefaultValue = MergeStrategy.Squash)]
     public Input<MergeStrategy> Strategy { get; set; } = new(MergeStrategy.Squash);
@@ -53,6 +75,18 @@ public class MergeAndCompleteReviewActivity : CodeActivity<ReviewMergeResult>
     /// <summary>Total fix iterations that occurred during review</summary>
     [Input(Description = "Total fix iterations during review", DefaultValue = 0)]
     public Input<int> TotalIterations { get; set; } = new(0);
+
+    /// <summary>Verify CI is green before merging (default: true)</summary>
+    [Input(Description = "Verify CI green before merge", DefaultValue = true)]
+    public Input<bool> VerifyCIBeforeMerge { get; set; } = new(true);
+
+    /// <summary>Delete the source branch after a successful merge (default: true)</summary>
+    [Input(Description = "Delete source branch after merge", DefaultValue = true)]
+    public Input<bool> DeleteBranchAfterMerge { get; set; } = new(true);
+
+    /// <summary>The merge result</summary>
+    [Output(Description = "Merge result")]
+    public Output<ReviewMergeResult?> Result { get; set; } = default!;
 
     [JsonConstructor]
     public MergeAndCompleteReviewActivity() { }
@@ -77,10 +111,12 @@ public class MergeAndCompleteReviewActivity : CodeActivity<ReviewMergeResult>
         var prNumber = PRNumber.Get(context);
         var strategy = Strategy.Get(context);
         var totalIterations = TotalIterations.Get(context);
+        var verifyCi = VerifyCIBeforeMerge.Get(context);
+        var deleteBranch = DeleteBranchAfterMerge.Get(context);
 
         _logger?.LogInformation(
-            "Merging PR #{PRNumber} with strategy {Strategy} for session {SessionId}",
-            prNumber, strategy, sessionId);
+            "Merging PR #{PRNumber} with strategy {Strategy} for session {SessionId} (verifyCi={VerifyCi})",
+            prNumber, strategy, sessionId, verifyCi);
 
         try
         {
@@ -89,31 +125,70 @@ public class MergeAndCompleteReviewActivity : CodeActivity<ReviewMergeResult>
 
             if (story == null || string.IsNullOrEmpty(story.RepositoryUrl))
             {
-                context.SetResult(new ReviewMergeResult
-                {
-                    Success = false,
-                    StrategyUsed = strategy,
-                    Error = "Story or repository URL not found"
-                });
+                await FailAsync(context, strategy, "Story or repository URL not found");
                 return;
             }
 
-            // Merge the PR (the integration service handles the strategy internally)
+            var headBranch = HeadBranch.Get(context);
+            if (string.IsNullOrWhiteSpace(headBranch))
+                headBranch = $"feature/{storyId}";
+
+            // 1) CI gate — verify the head branch's build is green before merging.
+            if (verifyCi)
+            {
+                var ciOk = await IsCiGreenAsync(story.RepositoryUrl, headBranch);
+                if (!ciOk)
+                {
+                    _logger?.LogWarning(
+                        "CI is not green for PR #{PRNumber} (branch {Branch}); routing to escalation",
+                        prNumber, headBranch);
+                    await FailAsync(context, strategy,
+                        $"CI is not green for branch '{headBranch}'; merge blocked pending senior review.");
+                    return;
+                }
+            }
+
+            // 2) Strategy-aware merge with a single retry on failure.
+            var mergeStrategyWire = strategy.ToString().ToLowerInvariant(); // squash | merge | rebase
             var mergeResult = await _integrationService!.MergeGitHubPullRequestAsync(
-                story.RepositoryUrl, prNumber);
+                story.RepositoryUrl, prNumber, mergeStrategyWire);
 
             if (!mergeResult.Success)
             {
                 _logger?.LogWarning(
-                    "Merge failed for PR #{PRNumber}: {Error}", prNumber, mergeResult.Error);
+                    "Merge failed for PR #{PRNumber}: {Error}. Retrying once.",
+                    prNumber, mergeResult.Error);
 
-                context.SetResult(new ReviewMergeResult
+                mergeResult = await _integrationService.MergeGitHubPullRequestAsync(
+                    story.RepositoryUrl, prNumber, mergeStrategyWire);
+
+                if (!mergeResult.Success)
                 {
-                    Success = false,
-                    StrategyUsed = strategy,
-                    Error = $"Merge failed: {mergeResult.Error}"
-                });
-                return;
+                    _logger?.LogWarning(
+                        "Merge retry failed for PR #{PRNumber}: {Error}; routing to escalation",
+                        prNumber, mergeResult.Error);
+                    await FailAsync(context, strategy,
+                        $"Merge failed after retry: {mergeResult.Error}");
+                    return;
+                }
+            }
+
+            // 3) Delete the source branch (best-effort — never fails the merge).
+            if (deleteBranch)
+            {
+                try
+                {
+                    await _integrationService.DeleteGitHubBranchAsync(story.RepositoryUrl, headBranch);
+                    _logger?.LogInformation(
+                        "Deleted source branch {Branch} after merging PR #{PRNumber}",
+                        headBranch, prNumber);
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogWarning(ex,
+                        "Failed to delete source branch {Branch} after merge (merge still succeeded)",
+                        headBranch);
+                }
             }
 
             // Log the event
@@ -146,22 +221,51 @@ public class MergeAndCompleteReviewActivity : CodeActivity<ReviewMergeResult>
                 "PR #{PRNumber} merged successfully for session {SessionId}, sha {MergeSha}",
                 prNumber, sessionId, mergeResult.MergeSha);
 
-            context.SetResult(new ReviewMergeResult
+            Result.Set(context, new ReviewMergeResult
             {
                 Success = true,
                 MergeSha = mergeResult.MergeSha,
                 StrategyUsed = strategy
             });
+            await context.CompleteActivityWithOutcomesAsync("Merged");
         }
         catch (Exception ex)
         {
             _logger?.LogError(ex, "Error merging PR #{PRNumber} for session {SessionId}", prNumber, sessionId);
-            context.SetResult(new ReviewMergeResult
-            {
-                Success = false,
-                StrategyUsed = strategy,
-                Error = $"Merge failed: {ex.Message}"
-            });
+            await FailAsync(context, strategy, $"Merge failed: {ex.Message}");
+        }
+    }
+
+    private async ValueTask FailAsync(
+        ActivityExecutionContext context, MergeStrategy strategy, string error)
+    {
+        Result.Set(context, new ReviewMergeResult
+        {
+            Success = false,
+            StrategyUsed = strategy,
+            Error = error
+        });
+        await context.CompleteActivityWithOutcomesAsync("Failed");
+    }
+
+    /// <summary>
+    /// Returns true only when CI reports an unambiguously green build for the branch.
+    /// Anything else (failure, pending, error, or an exception talking to CI) is treated
+    /// as NOT-green — fail-closed: a PR never merges on an unknown CI state.
+    /// </summary>
+    private async Task<bool> IsCiGreenAsync(string repository, string branch)
+    {
+        try
+        {
+            var status = await _integrationService!.GetBuildStatusAsync(repository, branch);
+            var s = status?.Status?.Trim().ToLowerInvariant();
+            return s is "success" or "passed" or "passing" or "completed" or "green";
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex,
+                "Failed to read CI status for branch {Branch}; treating as not-green", branch);
+            return false;
         }
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/MonitorReviewActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/MonitorReviewActivity.cs
@@ -18,6 +18,21 @@ namespace Tamma.Activities.Review;
 ///   - Approved: reviewer approved the PR
 ///   - ChangesRequested: reviewer requested changes
 ///   - TimedOut: no review within the timeout window
+///
+/// <para><b>Durable review-response timeout (review fix 2026-06-25, code-review P0).</b> Two
+/// resume paths are armed when the activity suspends: the review bookmark
+/// (<c>review-{session}-{pr}</c>) resumed by the reviewer webhook → <see cref="Approved"/> /
+/// <see cref="ChangesRequested"/>; and a DURABLE delay bookmark via
+/// <see cref="Elsa.Extensions.DelayActivityExecutionContextExtensions.DelayFor(ActivityExecutionContext, System.TimeSpan, ExecuteActivityDelegate)"/>
+/// at the timeout → <see cref="TimedOut"/>. The build-out only stored an in-memory deadline
+/// and checked it INSIDE the resume callback — but if the reviewer never responds the callback
+/// never fires, so the <c>TimedOut</c> outcome was runtime-unreachable and the instance
+/// suspended forever. The Delay bookmark is EF-persisted and re-armed by
+/// <c>Elsa.Scheduling</c>'s startup task on rehydration, so a never-answered review now
+/// terminates as a real <c>TimedOut</c> even across a host restart. Whichever path resumes
+/// first completes the activity; Elsa burns the remaining bookmark (no orphaned timer /
+/// double-resume). The in-memory deadline is retained as a belt-and-braces guard inside the
+/// real-resume path.</para>
 /// </summary>
 [Activity(
     "Tamma.Review",
@@ -66,10 +81,11 @@ public class MonitorReviewActivity : Activity
             "Creating review bookmark {BookmarkName}, timeout {TimeoutHours}h",
             bookmarkName, timeoutHours);
 
-        // Store the deadline so we can check on resume
+        // Store the deadline so we can guard on resume (belt-and-braces).
         context.SetVariable("ReviewDeadline", DateTime.UtcNow.AddHours(timeoutHours));
 
-        // Create the bookmark — workflow suspends here
+        // 1) Review bookmark — resumed by the reviewer webhook. The workflow suspends here
+        //    until this resumes OR the durable timeout delay below fires.
         context.CreateBookmark(
             new CreateBookmarkArgs
             {
@@ -77,6 +93,39 @@ public class MonitorReviewActivity : Activity
                 Callback = OnReviewReceivedAsync,
                 AutoBurn = true
             });
+
+        // 2) Durable review timeout — a DelayFor (Delay) bookmark that Elsa.Scheduling's
+        //    startup task RE-ARMS after a host restart (EF-persisted, not an in-memory timer).
+        //    A never-answered review terminates as a real TimedOut even across a restart.
+        //    A non-positive timeout disables the deadline (wait indefinitely).
+        if (timeoutHours > 0)
+        {
+            context.DelayFor(TimeSpan.FromHours(timeoutHours), OnTimeoutAsync);
+        }
+    }
+
+    /// <summary>
+    /// Durable timeout path: the review window elapsed with no webhook. The Delay bookmark
+    /// scheduler resumes the activity here (and re-arms across a host restart). Takes the
+    /// <c>TimedOut</c> outcome instead of suspending forever; the still-armed review bookmark
+    /// is burned on completion.
+    /// </summary>
+    private async ValueTask OnTimeoutAsync(ActivityExecutionContext context)
+    {
+        var sessionId = SessionId.Get(context);
+        var prNumber = PRNumber.Get(context);
+
+        _logger?.LogWarning(
+            "Review window expired (durable timeout) for PR #{PRNumber}, session {SessionId} — taking the TimedOut outcome",
+            prNumber, sessionId);
+
+        ReviewResult.Set(context, new Models.ReviewResult
+        {
+            Status = PRReviewStatus.TimedOut,
+            SubmittedAt = DateTime.UtcNow
+        });
+
+        await context.CompleteActivityWithOutcomesAsync("TimedOut");
     }
 
     private async ValueTask OnReviewReceivedAsync(ActivityExecutionContext context)

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/ValidateCodeReviewInputsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/ValidateCodeReviewInputsActivity.cs
@@ -1,0 +1,185 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities.Flowchart.Attributes;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Tamma.Activities.Review;
+
+/// <summary>
+/// Validates the code-review workflow inputs (Story 7-1D AC2/AC4, completeness audit
+/// 2026-06-22 <c>CodeReview.md</c> §Missing #3) BEFORE any PR is created. Requires a
+/// non-empty story id, repository url, and junior id, AND at least one resolvable reviewer
+/// (from the explicit <c>reviewerIds</c> input or the configured
+/// <c>CodeReview:ReviewerPool</c>). On any failure it routes to the <c>Invalid</c> outcome
+/// with a SPECIFIC <see cref="ErrorMessage"/> — no generic "Code review failed", no silent
+/// false-path. Follows tenant→system→error: it never falls back to an empty reviewer set.
+///
+/// <para><b>Dual-caller guard (deferred #2):</b> the mentorship contract keys on
+/// <c>sessionId</c>; an autonomous-loop <c>SingleIssueCycle</c>-shaped payload
+/// (<c>{repository, prNumber, branchName, tenantId}</c> with no <c>storyId</c>/<c>juniorId</c>)
+/// is NOT silently dropped — it fails validation here with a clear reason directing it to the
+/// (future) LLM-review variant, rather than proceeding to create a PR for an empty story.</para>
+///
+/// Outcomes: <c>Valid</c> / <c>Invalid</c>.
+/// </summary>
+[Activity(
+    "Tamma.Review",
+    "Validate Code Review Inputs",
+    "Validate story/repo/junior/reviewer inputs before creating a PR",
+    Kind = ActivityKind.Task
+)]
+[FlowNode("Valid", "Invalid")]
+public class ValidateCodeReviewInputsActivity : CodeActivity
+{
+    private readonly ILogger<ValidateCodeReviewInputsActivity>? _logger;
+    private readonly IConfiguration? _configuration;
+
+    [Input(Description = "Story id")]
+    public Input<string?> StoryId { get; set; } = new((string?)null);
+
+    [Input(Description = "Repository url")]
+    public Input<string?> RepositoryUrl { get; set; } = new((string?)null);
+
+    [Input(Description = "Junior developer id")]
+    public Input<string?> JuniorId { get; set; } = new((string?)null);
+
+    [Input(Description = "Explicit reviewer ids (JSON array of strings)")]
+    public Input<string?> ReviewerIdsJson { get; set; } = new((string?)null);
+
+    [Output(Description = "Specific validation error message (empty when valid)")]
+    public Output<string> ErrorMessage { get; set; } = default!;
+
+    [Output(Description = "Resolved reviewers (comma-separated; from input or pool)")]
+    public Output<string> ResolvedReviewers { get; set; } = default!;
+
+    [JsonConstructor]
+    public ValidateCodeReviewInputsActivity() { }
+
+    public ValidateCodeReviewInputsActivity(
+        ILogger<ValidateCodeReviewInputsActivity> logger,
+        IConfiguration configuration)
+    {
+        _logger = logger;
+        _configuration = configuration;
+    }
+
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var result = Validate(
+            StoryId.Get(context),
+            RepositoryUrl.Get(context),
+            JuniorId.Get(context),
+            ReviewerIdsJson.Get(context),
+            LoadReviewerPool());
+
+        if (!result.IsValid)
+        {
+            _logger?.LogWarning("Code review input validation failed: {Message}", result.ErrorMessage);
+            ErrorMessage.Set(context, result.ErrorMessage);
+            ResolvedReviewers.Set(context, string.Empty);
+            await context.CompleteActivityWithOutcomesAsync("Invalid");
+            return;
+        }
+
+        ResolvedReviewers.Set(context, string.Join(",", result.Reviewers));
+        ErrorMessage.Set(context, string.Empty);
+
+        _logger?.LogInformation(
+            "Code review inputs valid; {Count} reviewer(s) resolved", result.Reviewers.Count);
+
+        await context.CompleteActivityWithOutcomesAsync("Valid");
+    }
+
+    /// <summary>
+    /// Pure validation (Story 7-1D AC2/AC4). Requires non-empty story/repo/junior and ≥1
+    /// resolvable reviewer (explicit ids, else the supplied <paramref name="reviewerPool"/>).
+    /// Returns a SPECIFIC error message on failure — never empty. Exposed for unit testing.
+    /// </summary>
+    public static ValidationResult Validate(
+        string? storyId, string? repositoryUrl, string? juniorId,
+        string? reviewerIdsJson, IReadOnlyList<string> reviewerPool)
+    {
+        var missing = new List<string>();
+        if (string.IsNullOrWhiteSpace(storyId)) missing.Add("storyId");
+        if (string.IsNullOrWhiteSpace(repositoryUrl)) missing.Add("repositoryUrl");
+        if (string.IsNullOrWhiteSpace(juniorId)) missing.Add("juniorId");
+
+        if (missing.Count > 0)
+        {
+            return ValidationResult.Invalid(
+                $"Code review cannot start: missing required input(s) [{string.Join(", ", missing)}]. " +
+                "The 'code-review' workflow is the mentorship PR-lifecycle workflow and requires " +
+                "sessionId/storyId/juniorId/repositoryUrl. (An autonomous-loop LLM-review payload " +
+                "of {repository, prNumber, branchName, tenantId} is not handled by this workflow.)");
+        }
+
+        // Resolve reviewers: explicit input first, else the configured pool. ≥1 required.
+        var reviewers = ParseReviewerIds(reviewerIdsJson);
+        if (reviewers.Count == 0)
+            reviewers = reviewerPool
+                .Where(s => !string.IsNullOrWhiteSpace(s)).Select(s => s.Trim()).ToList();
+
+        if (reviewers.Count == 0)
+        {
+            return ValidationResult.Invalid(
+                $"Code review cannot start for story '{storyId!.Trim()}': no reviewer resolvable. " +
+                "Provide 'reviewerIds' or configure a non-empty 'CodeReview:ReviewerPool'.");
+        }
+
+        return ValidationResult.Valid(reviewers);
+    }
+
+    /// <summary>Pure validation outcome.</summary>
+    public sealed class ValidationResult
+    {
+        public bool IsValid { get; private init; }
+        public string ErrorMessage { get; private init; } = string.Empty;
+        public IReadOnlyList<string> Reviewers { get; private init; } = Array.Empty<string>();
+
+        public static ValidationResult Valid(IReadOnlyList<string> reviewers)
+            => new() { IsValid = true, Reviewers = reviewers };
+
+        public static ValidationResult Invalid(string message)
+            => new() { IsValid = false, ErrorMessage = message };
+    }
+
+    private static List<string> ParseReviewerIds(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return new List<string>();
+        try
+        {
+            var arr = JsonSerializer.Deserialize<List<string>>(json);
+            return arr?
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .Select(s => s.Trim())
+                .ToList() ?? new List<string>();
+        }
+        catch
+        {
+            // Tolerate a comma-separated string too.
+            return json.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToList();
+        }
+    }
+
+    private List<string> LoadReviewerPool()
+    {
+        var pool = _configuration?.GetSection("CodeReview:ReviewerPool").Get<string[]>();
+        if (pool is { Length: > 0 })
+            return pool.Where(s => !string.IsNullOrWhiteSpace(s)).Select(s => s.Trim()).ToList();
+
+        // Also accept a comma-separated scalar form.
+        var scalar = _configuration?["CodeReview:ReviewerPool"];
+        if (!string.IsNullOrWhiteSpace(scalar))
+            return scalar.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToList();
+
+        return new List<string>();
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/WaitForFixesActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/WaitForFixesActivity.cs
@@ -17,6 +17,20 @@ namespace Tamma.Activities.Review;
 /// Outcomes:
 ///   - FixesReceived: junior pushed fixes
 ///   - TimedOut: no fixes within the timeout window
+///
+/// <para><b>Durable hour-granular fix-submission wait (review fix 2026-06-25, code-review P0).</b>
+/// Two resume paths are armed when the activity suspends: the fixes bookmark
+/// (<c>fixes-{session}-{pr}-{iteration}</c>) resumed by the junior's push →
+/// <see cref="FixesReceived"/>; and a DURABLE delay bookmark via
+/// <see cref="Elsa.Extensions.DelayActivityExecutionContextExtensions.DelayFor(ActivityExecutionContext, System.TimeSpan, ExecuteActivityDelegate)"/>
+/// at the timeout → <see cref="TimedOut"/>. The build-out only stored an in-memory deadline and
+/// checked it INSIDE the resume callback — but if the junior never pushes, the callback never
+/// fires, so the <c>TimedOut</c> outcome was runtime-unreachable and the instance suspended
+/// forever. The Delay bookmark is EF-persisted and re-armed by <c>Elsa.Scheduling</c>'s startup
+/// task on rehydration, so an unanswered fix request now terminates as a real <c>TimedOut</c>
+/// even across a host restart. Whichever path resumes first completes the activity; Elsa burns
+/// the remaining bookmark. The wait is hour-granular: <see cref="TimeoutHours"/> is supplied by
+/// the workflow's resolved <c>CodeReview:FixTimeoutMinutes</c> config, floored at 1h.</para>
 /// </summary>
 [Activity(
     "Tamma.Review",
@@ -70,10 +84,11 @@ public class WaitForFixesActivity : Activity
             "Creating fixes bookmark {BookmarkName}, timeout {TimeoutHours}h",
             bookmarkName, timeoutHours);
 
-        // Store deadline for timeout check on resume
+        // Store deadline for the belt-and-braces guard on resume.
         context.SetVariable("FixDeadline", DateTime.UtcNow.AddHours(timeoutHours));
 
-        // Create the bookmark — workflow suspends here
+        // 1) Fixes bookmark — resumed by the junior's push. The workflow suspends here until
+        //    this resumes OR the durable timeout delay below fires.
         context.CreateBookmark(
             new CreateBookmarkArgs
             {
@@ -81,6 +96,34 @@ public class WaitForFixesActivity : Activity
                 Callback = OnFixesReceivedAsync,
                 AutoBurn = true
             });
+
+        // 2) Durable fix-submission timeout — a DelayFor (Delay) bookmark that Elsa.Scheduling's
+        //    startup task RE-ARMS after a host restart (EF-persisted, not an in-memory timer).
+        //    A never-answered fix request terminates as a real TimedOut even across a restart.
+        //    A non-positive timeout disables the deadline (wait indefinitely).
+        if (timeoutHours > 0)
+        {
+            context.DelayFor(TimeSpan.FromHours(timeoutHours), OnTimeoutAsync);
+        }
+    }
+
+    /// <summary>
+    /// Durable timeout path: the fix-submission window elapsed with no push. The Delay bookmark
+    /// scheduler resumes the activity here (and re-arms across a host restart). Takes the
+    /// <c>TimedOut</c> outcome instead of suspending forever; the still-armed fixes bookmark is
+    /// burned on completion.
+    /// </summary>
+    private async ValueTask OnTimeoutAsync(ActivityExecutionContext context)
+    {
+        var prNumber = PRNumber.Get(context);
+        var iteration = Iteration.Get(context);
+
+        _logger?.LogWarning(
+            "Fix-submission window expired (durable timeout) for PR #{PRNumber}, iteration {Iteration} — taking the TimedOut outcome",
+            prNumber, iteration);
+
+        FixesPayload.Set(context, null);
+        await context.CompleteActivityWithOutcomesAsync("TimedOut");
     }
 
     private async ValueTask OnFixesReceivedAsync(ActivityExecutionContext context)

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/CodeReviewWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/CodeReviewWorkflow.cs
@@ -3,10 +3,12 @@ using Elsa.Extensions;
 using Elsa.Workflows;
 using Elsa.Workflows.Activities;
 using Elsa.Workflows.Activities.Flowchart.Activities;
-using Elsa.Workflows.Management.Activities.SetOutput;
+using Elsa.Workflows.Memory;
 using Elsa.Workflows.Models;
+using Elsa.Workflows.Runtime.Activities;
 using Tamma.Activities.Review;
 using Tamma.Activities.Review.Models;
+using Tamma.Api.Services.Agents;
 using FlowEndpoint = Elsa.Workflows.Activities.Flowchart.Models.Endpoint;
 
 using static Tamma.ElsaServer.Workflows.ActivityDisplayTextExtensions;
@@ -14,20 +16,25 @@ using static Tamma.ElsaServer.Workflows.ActivityDisplayTextExtensions;
 namespace Tamma.ElsaServer.Workflows;
 
 /// <summary>
-/// Code Review sub-workflow.
+/// Code Review sub-workflow (Story 7-1D). Manages the full PR lifecycle for the mentorship
+/// engine:
+///   1. Bind inputs + resolve CodeReview:* config (defect #1 / #9)
+///   2. Validate inputs (story/repo/junior present, ≥1 reviewer) → specific failure (#3)
+///   3. Create PR → emit CODE_REVIEW.PR_CREATED.* (#8)
+///   4. Request review → monitor (bookmark)
+///   5. Approved → CI-gated, strategy-aware, retry-once merge (#5) → structured result (#6)
+///   6. ChangesRequested → AnalyzeChanges + GenerateGuidance via mediated llm-call (#4)
+///      → deliver → wait for fixes (bookmark) → re-request → loop (≤ max)
+///   7. Max iterations / timeout / guidance-failure → escalate (bookmark) → resolve→merge,
+///      reject→fail
 ///
-/// Manages the full PR lifecycle:
-///   1. Create PR
-///   2. Request review
-///   3. Monitor review (bookmark: waits for webhook)
-///   4. If approved  -> merge and complete
-///   5. If changes requested -> deliver guidance -> wait for fixes (bookmark)
-///      -> re-request review -> loop back to monitor (max 5 iterations)
-///   6. If max iterations or timeout -> escalate (bookmark: waits for senior)
-///      -> resolved -> merge, rejected -> fail
+/// Every terminal path produces a structured <see cref="CodeReviewWorkflowResult"/> via
+/// BuildResult and emits the matching CODE_REVIEW.* DCB event. The pre-existing
+/// MentorshipEvent rows are retained (written inside the activities).
 ///
-/// This is a code-first IWorkflow using the Flowchart composite activity
-/// with bookmark-based waiting for external events.
+/// LLM is reached ONLY through DispatchWorkflow("llm-call") — no in-engine provider call.
+/// The fix-guidance roles are canonical (reviewer normalises to senior_developer): the
+/// call-LLM endpoint 422s on unknown roles.
 /// </summary>
 public class CodeReviewWorkflow : WorkflowBase
 {
@@ -41,7 +48,7 @@ public class CodeReviewWorkflow : WorkflowBase
         builder.DefinitionId = "code-review";
         builder.Version = WorkflowVersions.ComputedVersion;
         builder.Description = "Manages the full PR lifecycle from creation through review, " +
-                              "fix guidance, and merge with bookmark-based waiting.";
+                              "mediated-LLM fix guidance, and CI-gated merge with bookmark-based waiting.";
 
         // ============================================
         // Workflow variables
@@ -50,29 +57,116 @@ public class CodeReviewWorkflow : WorkflowBase
         var sessionIdGuid = builder.WithVariable<Guid>("SessionIdGuid", Guid.Empty);
         var storyId = builder.WithVariable<string>("StoryId", "");
         var juniorId = builder.WithVariable<string>("JuniorId", "");
+        var tenantId = builder.WithVariable<string>("TenantId", "");
+        var repositoryUrl = builder.WithVariable<string>("RepositoryUrl", "");
+        var branchName = builder.WithVariable<string>("BranchName", "");
+        var baseBranch = builder.WithVariable<string>("BaseBranch", "main");
+        var reviewerIdsJson = builder.WithVariable<string>("ReviewerIdsJson", "");
+        var resolvedReviewers = builder.WithVariable<string>("ResolvedReviewers", "");
+        var skillLevel = builder.WithVariable<int>("SkillLevel", 3);
         var prNumber = builder.WithVariable<int>("PRNumber", 0);
         var prUrl = builder.WithVariable<string>("PRUrl", "");
         var iteration = builder.WithVariable<int>("Iteration", 0);
         var maxIterations = builder.WithVariable<int>("MaxIterations", 5);
+        var maxIterationsInput = builder.WithVariable<int>("MaxIterationsInput", 0);
+        var mergeStrategyInput = builder.WithVariable<string>("MergeStrategyInput", "");
         var reviewCommentsJson = builder.WithVariable<string>("ReviewCommentsJson", "[]");
+        var analysisText = builder.WithVariable<string>("AnalysisText", "");
+        var guidanceText = builder.WithVariable<string>("GuidanceText", "");
+        var validationError = builder.WithVariable<string>("ValidationError", "");
+        var escalationResolution = builder.WithVariable<string>("EscalationResolution", "");
+        var mergeShaVar = builder.WithVariable<string>("MergeSha", "");
+
+        // Config-resolved variables (filled by BindConfig)
         var mergeStrategy = builder.WithVariable<MergeStrategy>("MergeStrategy", MergeStrategy.Squash);
+        var reviewTimeoutHours = builder.WithVariable<int>("ReviewTimeoutHours", 24);
+        var fixTimeoutHours = builder.WithVariable<int>("FixTimeoutHours", 1);
+        var verifyCi = builder.WithVariable<bool>("VerifyCIBeforeMerge", true);
+        var deleteBranch = builder.WithVariable<bool>("DeleteBranchAfterMerge", true);
+
+        // LLM dispatch result holders
+        var analyzeResult = builder.WithVariable<IDictionary<string, object>?>();
+        var guidanceResult = builder.WithVariable<IDictionary<string, object>?>();
 
         // ============================================
-        // Activities
+        // 0. Bind inputs (defect #1) — mirror AssessmentWorkflow input binding
         // ============================================
+        var bindInputs = new SetVariable
+        {
+            Id = "BindInputs",
+            Name = "Bind Inputs",
+            Variable = sessionId,
+            Value = new(ctx =>
+            {
+                var sid = ctx.GetInput<string>("SessionId") ?? ctx.GetInput<string>("sessionId") ?? "";
+                sessionIdGuid.Set(ctx, Guid.TryParse(sid, out var g) ? g : Guid.Empty);
+                storyId.Set(ctx, ctx.GetInput<string>("StoryId") ?? ctx.GetInput<string>("storyId") ?? "");
+                juniorId.Set(ctx, ctx.GetInput<string>("JuniorId") ?? ctx.GetInput<string>("juniorId") ?? "");
+                tenantId.Set(ctx, ctx.GetInput<string>("TenantId") ?? ctx.GetInput<string>("tenantId") ?? "");
+                repositoryUrl.Set(ctx, ctx.GetInput<string>("RepositoryUrl") ?? ctx.GetInput<string>("repositoryUrl") ?? "");
+                var story = ctx.GetInput<string>("StoryId") ?? ctx.GetInput<string>("storyId") ?? "";
+                baseBranch.Set(ctx, ctx.GetInput<string>("BaseBranch") ?? ctx.GetInput<string>("baseBranch") ?? "main");
+                branchName.Set(ctx,
+                    ctx.GetInput<string>("BranchName") ?? ctx.GetInput<string>("branchName")
+                    ?? (string.IsNullOrEmpty(story) ? "" : $"feature/{story}"));
+                reviewerIdsJson.Set(ctx, ctx.GetInput<string>("ReviewerIds") ?? ctx.GetInput<string>("reviewerIds") ?? "");
+                skillLevel.Set(ctx, Math.Max(1, ctx.GetInput<int>("SkillLevel")));
+                maxIterationsInput.Set(ctx, ctx.GetInput<int>("MaxIterations"));
+                mergeStrategyInput.Set(ctx, ctx.GetInput<string>("MergeStrategy") ?? ctx.GetInput<string>("mergeStrategy") ?? "");
+                return sid;
+            })
+        };
+        bindInputs.SetDisplayText("Bind Inputs");
 
-        // 1. Create the pull request
+        // ============================================
+        // 0b. Resolve CodeReview:* config (#9)
+        // ============================================
+        var bindConfig = new BindCodeReviewConfigActivity
+        {
+            Id = "BindConfig",
+            Name = "Bind Code Review Config",
+            MaxIterationsInput = Expr<int>(ctx => maxIterationsInput.Get(ctx)),
+            MergeStrategyInput = Expr<string?>(ctx => mergeStrategyInput.Get(ctx)),
+            MaxIterations = new(maxIterations),
+            MergeStrategy = new(mergeStrategy),
+            ReviewTimeoutHours = new(reviewTimeoutHours),
+            FixTimeoutHours = new(fixTimeoutHours),
+            VerifyCIBeforeMerge = new(verifyCi),
+            DeleteBranchAfterMerge = new(deleteBranch)
+        };
+        bindConfig.SetDisplayText("Bind Code Review Config");
+
+        // ============================================
+        // 1. Validate inputs (#3)
+        // ============================================
+        var validateInputs = new ValidateCodeReviewInputsActivity
+        {
+            Id = "ValidateInputs",
+            Name = "Validate Inputs",
+            StoryId = Expr<string?>(ctx => storyId.Get(ctx)),
+            RepositoryUrl = Expr<string?>(ctx => repositoryUrl.Get(ctx)),
+            JuniorId = Expr<string?>(ctx => juniorId.Get(ctx)),
+            ReviewerIdsJson = Expr<string?>(ctx => reviewerIdsJson.Get(ctx)),
+            ErrorMessage = new(validationError),
+            ResolvedReviewers = new(resolvedReviewers)
+        };
+        validateInputs.SetDisplayText("Validate Inputs");
+
+        // ============================================
+        // 2. Create PR
+        // ============================================
         var createPR = new CreatePRActivity
         {
             Id = "CreatePR",
             SessionId = Expr<Guid>(ctx => sessionIdGuid.Get(ctx)),
             StoryId = Expr<string>(ctx => storyId.Get(ctx)),
             JuniorId = Expr<string>(ctx => juniorId.Get(ctx)),
+            BaseBranch = Expr<string>(ctx => baseBranch.Get(ctx)),
+            HeadBranch = Expr<string?>(ctx => branchName.Get(ctx)),
             Name = "Create Pull Request"
         };
         createPR.SetDisplayText("Create Pull Request");
 
-        // 2. Check if PR creation succeeded — use workflow variable to track
         var storePRResult = new SetVariable
         {
             Id = "StorePRResult",
@@ -95,7 +189,18 @@ public class CodeReviewWorkflow : WorkflowBase
         { Id = "PRCreatedCheck", Name = "PR Created?" };
         prCreatedCheck.SetDisplayText("PR Created?");
 
+        // DCB event: PR created success / failed
+        var emitPrCreated = EmitEvent("EmitPrCreated", "Emit PR Created",
+            CodeReviewEvents.PrCreatedSuccess, sessionId, storyId, juniorId, tenantId,
+            prNumber, prUrl, iteration, mergeShaVar, new((string?)null));
+        var emitPrFailed = EmitEvent("EmitPrFailed", "Emit PR Failed",
+            CodeReviewEvents.PrCreatedFailed, sessionId, storyId, juniorId, tenantId,
+            prNumber, prUrl, iteration, mergeShaVar,
+            new("PR creation failed (story/repository not resolvable)"));
+
+        // ============================================
         // 3. Request review
+        // ============================================
         var requestReview = new RequestReviewActivity
         {
             Id = "RequestReview",
@@ -103,22 +208,25 @@ public class CodeReviewWorkflow : WorkflowBase
             PRNumber = Expr<int>(ctx => prNumber.Get(ctx)),
             StoryId = Expr<string>(ctx => storyId.Get(ctx)),
             JuniorId = Expr<string>(ctx => juniorId.Get(ctx)),
+            Reviewers = Expr<string?>(ctx => resolvedReviewers.Get(ctx)),
             Name = "Request Code Review"
         };
         requestReview.SetDisplayText("Request Code Review");
 
+        // ============================================
         // 4. Monitor review (bookmark-based)
+        // ============================================
         var monitorReview = new MonitorReviewActivity
         {
             Id = "MonitorReview",
             SessionId = Expr<string>(ctx => sessionId.Get(ctx)),
             PRNumber = Expr<int>(ctx => prNumber.Get(ctx)),
-            TimeoutHours = new(24),
+            TimeoutHours = Expr<int>(ctx => reviewTimeoutHours.Get(ctx)),
             Name = "Monitor Review Status"
         };
         monitorReview.SetDisplayText("Monitor Review Status");
 
-        // 5. Store review comments when changes are requested
+        // 5. Store review comments when changes requested
         var storeReviewComments = new SetVariable
         {
             Id = "StoreReviewComments",
@@ -128,9 +236,7 @@ public class CodeReviewWorkflow : WorkflowBase
             {
                 var review = monitorReview.GetOutput<ReviewResult?>(ctx, "ReviewResult");
                 if (review?.Comments != null && review.Comments.Count > 0)
-                {
                     return System.Text.Json.JsonSerializer.Serialize(review.Comments);
-                }
                 return "[]";
             })
         };
@@ -146,7 +252,82 @@ public class CodeReviewWorkflow : WorkflowBase
         };
         incrementIteration.SetDisplayText("Increment Review Iteration");
 
-        // 7. Deliver fix guidance
+        // DCB event: iteration started
+        var emitIteration = EmitEvent("EmitIteration", "Emit Iteration Started",
+            CodeReviewEvents.IterationStarted, sessionId, storyId, juniorId, tenantId,
+            prNumber, prUrl, iteration, mergeShaVar, new((string?)null));
+
+        // ============================================
+        // 7. AC7 mediated LLM (#4): AnalyzeChanges (role=senior_developer / code-review)
+        // ============================================
+        var analyzeChanges = new DispatchWorkflow
+        {
+            Id = "AnalyzeChanges",
+            Name = "Analyze Changes (LLM)",
+            WorkflowDefinitionId = new("llm-call"),
+            Input = new(ctx => new Dictionary<string, object>
+            {
+                ["role"] = Tamma.Api.Services.Agents.AgentRole.SeniorDeveloper.ToWire(),
+                ["action"] = Tamma.Api.Services.Agents.AgentAction.CodeReview.ToWire(),
+                ["tenantId"] = tenantId.Get(ctx) ?? "",
+                ["variables"] = new Dictionary<string, object>
+                {
+                    ["reviewCommentsJson"] = reviewCommentsJson.Get(ctx) ?? "[]",
+                    ["prompt"] = "Identify what needs fixing based on these code review comments. " +
+                                 "Be specific and concrete about each required change.",
+                },
+                ["enableTools"] = false,
+            }),
+            WaitForCompletion = new(true),
+            Result = new(analyzeResult)
+        };
+        analyzeChanges.SetDisplayText("Analyze Changes (LLM)");
+
+        var storeAnalysis = new SetVariable
+        {
+            Id = "StoreAnalysis",
+            Name = "Store Analysis",
+            Variable = analysisText,
+            Value = Expr<object?>(ctx => (object)(ExtractLlmResponse(analyzeResult.Get(ctx)) ?? ""))
+        };
+        storeAnalysis.SetDisplayText("Store Analysis");
+
+        // GenerateGuidance (role=senior_developer / mentor-feedback, skill-level aware)
+        var generateGuidance = new DispatchWorkflow
+        {
+            Id = "GenerateGuidance",
+            Name = "Generate Guidance (LLM)",
+            WorkflowDefinitionId = new("llm-call"),
+            Input = new(ctx => new Dictionary<string, object>
+            {
+                ["role"] = Tamma.Api.Services.Agents.AgentRole.SeniorDeveloper.ToWire(),
+                ["action"] = Tamma.Api.Services.Agents.AgentAction.MentorFeedback.ToWire(),
+                ["tenantId"] = tenantId.Get(ctx) ?? "",
+                ["variables"] = new Dictionary<string, object>
+                {
+                    ["analysis"] = analysisText.Get(ctx) ?? "",
+                    ["skillLevel"] = skillLevel.Get(ctx),
+                    ["prompt"] = $"Explain to a Level {skillLevel.Get(ctx)} developer how to address the " +
+                                 "following review analysis. Be encouraging, concrete, and teach the " +
+                                 "underlying concept: {analysis}",
+                },
+                ["enableTools"] = false,
+            }),
+            WaitForCompletion = new(true),
+            Result = new(guidanceResult)
+        };
+        generateGuidance.SetDisplayText("Generate Guidance (LLM)");
+
+        var storeGuidance = new SetVariable
+        {
+            Id = "StoreGuidance",
+            Name = "Store Guidance",
+            Variable = guidanceText,
+            Value = Expr<object?>(ctx => (object)(ExtractLlmResponse(guidanceResult.Get(ctx)) ?? ""))
+        };
+        storeGuidance.SetDisplayText("Store Guidance");
+
+        // 8. Deliver guidance (formats + delivers the mediated-LLM output)
         var deliverGuidance = new DeliverGuidanceActivity
         {
             Id = "DeliverGuidance",
@@ -155,23 +336,33 @@ public class CodeReviewWorkflow : WorkflowBase
             PRNumber = Expr<int>(ctx => prNumber.Get(ctx)),
             Iteration = Expr<int>(ctx => iteration.Get(ctx)),
             ReviewCommentsJson = Expr<string>(ctx => reviewCommentsJson.Get(ctx)),
+            GuidanceText = Expr<string?>(ctx => guidanceText.Get(ctx)),
             Name = "Deliver Fix Guidance"
         };
         deliverGuidance.SetDisplayText("Deliver Fix Guidance");
 
-        // 8. Wait for fixes (bookmark-based)
+        var emitGuidanceDelivered = EmitEvent("EmitGuidanceDelivered", "Emit Guidance Delivered",
+            CodeReviewEvents.GuidanceDeliveredSuccess, sessionId, storyId, juniorId, tenantId,
+            prNumber, prUrl, iteration, mergeShaVar, new((string?)null));
+
+        var emitGuidanceFailed = EmitEvent("EmitGuidanceFailed", "Emit Guidance Failed",
+            CodeReviewEvents.GuidanceDeliveredFailed, sessionId, storyId, juniorId, tenantId,
+            prNumber, prUrl, iteration, mergeShaVar,
+            new("Mediated-LLM guidance could not be generated/delivered; escalating."));
+
+        // 9. Wait for fixes (bookmark-based) — fix timeout (#9 drift fix)
         var waitForFixes = new WaitForFixesActivity
         {
             Id = "WaitForFixes",
             SessionId = Expr<string>(ctx => sessionId.Get(ctx)),
             PRNumber = Expr<int>(ctx => prNumber.Get(ctx)),
             Iteration = Expr<int>(ctx => iteration.Get(ctx)),
-            TimeoutHours = new(24),
+            TimeoutHours = Expr<int>(ctx => fixTimeoutHours.Get(ctx)),
             Name = "Wait for Fix Submission"
         };
         waitForFixes.SetDisplayText("Wait for Fix Submission");
 
-        // 9. Re-request review
+        // 10. Re-request review
         var reRequestReview = new ReRequestReviewActivity
         {
             Id = "ReRequestReview",
@@ -185,12 +376,12 @@ public class CodeReviewWorkflow : WorkflowBase
         };
         reRequestReview.SetDisplayText("Re-Request Code Review");
 
-        // 10. Check if max iterations reached
+        // 11. Max iterations check (authoritative guard — #11 dedup)
         var maxIterationsCheck = new FlowDecision(ctx => iteration.Get(ctx) >= maxIterations.Get(ctx))
         { Id = "MaxIterationsCheck", Name = "Max Iterations Reached?" };
         maxIterationsCheck.SetDisplayText("Max Iterations Reached?");
 
-        // 11. Merge and complete
+        // 12. Merge and complete (CI-gated, strategy-aware, retry-once, branch-delete — #5)
         var mergeAndComplete = new MergeAndCompleteReviewActivity
         {
             Id = "MergeAndComplete",
@@ -198,13 +389,33 @@ public class CodeReviewWorkflow : WorkflowBase
             StoryId = Expr<string>(ctx => storyId.Get(ctx)),
             JuniorId = Expr<string>(ctx => juniorId.Get(ctx)),
             PRNumber = Expr<int>(ctx => prNumber.Get(ctx)),
+            HeadBranch = Expr<string?>(ctx => branchName.Get(ctx)),
             Strategy = Expr<MergeStrategy>(ctx => mergeStrategy.Get(ctx)),
             TotalIterations = Expr<int>(ctx => iteration.Get(ctx)),
+            VerifyCIBeforeMerge = Expr<bool>(ctx => verifyCi.Get(ctx)),
+            DeleteBranchAfterMerge = Expr<bool>(ctx => deleteBranch.Get(ctx)),
             Name = "Merge and Complete Review"
         };
         mergeAndComplete.SetDisplayText("Merge and Complete Review");
 
-        // 12. Escalate review (max iterations)
+        var storeMergeSha = new SetVariable
+        {
+            Id = "StoreMergeSha",
+            Name = "Store Merge Sha",
+            Variable = mergeShaVar,
+            Value = Expr<object?>(ctx =>
+            {
+                var r = mergeAndComplete.GetOutput<ReviewMergeResult?>(ctx, "Result");
+                return (object)(r?.MergeSha ?? "");
+            })
+        };
+        storeMergeSha.SetDisplayText("Store Merge Sha");
+
+        var emitMerged = EmitEvent("EmitMerged", "Emit Merged",
+            CodeReviewEvents.MergedSuccess, sessionId, storyId, juniorId, tenantId,
+            prNumber, prUrl, iteration, mergeShaVar, new((string?)null));
+
+        // 13. Escalate review (max iterations)
         var escalateReview = new EscalateReviewActivity
         {
             Id = "EscalateReview",
@@ -218,7 +429,7 @@ public class CodeReviewWorkflow : WorkflowBase
         };
         escalateReview.SetDisplayText("Escalate: Max Iterations");
 
-        // 13. Escalate due to timeout
+        // 14. Escalate due to timeout
         var escalateTimeout = new EscalateReviewActivity
         {
             Id = "EscalateTimeout",
@@ -232,31 +443,96 @@ public class CodeReviewWorkflow : WorkflowBase
         };
         escalateTimeout.SetDisplayText("Escalate: Review Timeout");
 
-        // 14. Terminal nodes (SetOutput sequences)
-        var failedEnd = new Sequence
+        // 15. Escalate due to guidance-generation / merge failure
+        var escalateGuidance = new EscalateReviewActivity
         {
-            Id = "FailedEnd",
-            Name = "Emit Failure Outputs",
-            Activities =
-            {
-                WithLabel(new SetOutput { Id = "OutputFailedSuccess", Name = "Output Failed Success", OutputName = new("success"), OutputValue = new(ctx => (object)false) }, "Output Failed Success"),
-                WithLabel(new SetOutput { Id = "OutputErrorMessage", Name = "Output Error Message", OutputName = new("errorMessage"), OutputValue = new(ctx => (object)"Code review failed") }, "Output Error Message")
-            }
+            Id = "EscalateGuidance",
+            SessionId = Expr<Guid>(ctx => sessionIdGuid.Get(ctx)),
+            PRNumber = Expr<int>(ctx => prNumber.Get(ctx)),
+            JuniorId = Expr<string>(ctx => juniorId.Get(ctx)),
+            Reason = new(EscalationReason.Other),
+            IterationsAttempted = Expr<int>(ctx => iteration.Get(ctx)),
+            EscalationMessage = new("Automated fix guidance could not be generated."),
+            Name = "Escalate: Guidance Failure"
         };
-        failedEnd.SetDisplayText("Emit Failure Outputs");
+        escalateGuidance.SetDisplayText("Escalate: Guidance Failure");
 
-        var successEnd = new Sequence
+        var escalateMerge = new EscalateReviewActivity
         {
-            Id = "SuccessEnd",
-            Name = "Emit Success Outputs",
-            Activities =
-            {
-                WithLabel(new SetOutput { Id = "OutputSuccessFlag", Name = "Output Success Flag", OutputName = new("success"), OutputValue = new(ctx => (object)true) }, "Output Success Flag"),
-                WithLabel(new SetOutput { Id = "OutputPrUrl", Name = "Output PR URL", OutputName = new("prUrl"), OutputValue = new(ctx => (object)(prUrl.Get(ctx) ?? "")) }, "Output PR URL"),
-                WithLabel(new SetOutput { Id = "OutputIterations", Name = "Output Iterations", OutputName = new("iterations"), OutputValue = new(ctx => (object)iteration.Get(ctx)) }, "Output Iterations")
-            }
+            Id = "EscalateMerge",
+            SessionId = Expr<Guid>(ctx => sessionIdGuid.Get(ctx)),
+            PRNumber = Expr<int>(ctx => prNumber.Get(ctx)),
+            JuniorId = Expr<string>(ctx => juniorId.Get(ctx)),
+            Reason = new(EscalationReason.MergeConflict),
+            IterationsAttempted = Expr<int>(ctx => iteration.Get(ctx)),
+            EscalationMessage = new("CI not green or merge failed after retry; senior review required."),
+            Name = "Escalate: Merge Failure"
         };
-        successEnd.SetDisplayText("Emit Success Outputs");
+        escalateMerge.SetDisplayText("Escalate: Merge Failure");
+
+        // Record escalation resolution for the structured result (all escalate nodes)
+        var captureEscalated = new SetVariable
+        {
+            Id = "CaptureEscalated",
+            Name = "Capture Escalation Resolution",
+            Variable = escalationResolution,
+            Value = Expr<object?>(ctx => (object)"resolved")
+        };
+        captureEscalated.SetDisplayText("Capture Escalation Resolution");
+
+        var emitEscalated = EmitEvent("EmitEscalated", "Emit Escalated",
+            CodeReviewEvents.Escalated, sessionId, storyId, juniorId, tenantId,
+            prNumber, prUrl, iteration, mergeShaVar, new("Escalated to senior developer."));
+
+        // ============================================
+        // Terminal: structured results (#6) + DCB FAILED event (#8)
+        // ============================================
+        // Merge-success terminal — shared by the direct-approval and escalation-resolved
+        // merge paths. wasEscalated/escalationResolution are read from the escalationResolution
+        // variable so an escalated-then-merged run is reported as escalated (not a false
+        // "direct approval").
+        var buildSuccessResult = new BuildCodeReviewResultActivity
+        {
+            Id = "BuildSuccessResult",
+            Name = "Build Success Result",
+            FinalStatus = new(PRReviewStatus.Approved),
+            Success = new(true),
+            PRNumber = Expr<int>(ctx => prNumber.Get(ctx)),
+            PRUrl = Expr<string?>(ctx => prUrl.Get(ctx)),
+            MergeSha = Expr<string?>(ctx => mergeShaVar.Get(ctx)),
+            TotalIterations = Expr<int>(ctx => iteration.Get(ctx)),
+            WasEscalated = Expr<bool>(ctx => !string.IsNullOrEmpty(escalationResolution.Get(ctx))),
+            EscalationResolution = Expr<string?>(ctx =>
+            {
+                var r = escalationResolution.Get(ctx);
+                return string.IsNullOrEmpty(r) ? null : r;
+            }),
+            Message = Expr<string?>(ctx => string.IsNullOrEmpty(escalationResolution.Get(ctx))
+                ? "PR approved and merged."
+                : "Escalation resolved by senior; PR merged.")
+        };
+        buildSuccessResult.SetDisplayText("Build Success Result");
+
+        var buildValidationFailedResult = BuildResult("BuildValidationFailedResult", "Build Validation-Failed Result",
+            PRReviewStatus.Error, false, prNumber, prUrl, mergeShaVar, iteration,
+            wasEscalated: false, escalationResolution: new("", null),
+            message: new(ctx => validationError.Get(ctx)));
+
+        var buildRejectedResult = BuildResult("BuildRejectedResult", "Build Rejected Result",
+            PRReviewStatus.ChangesRequested, false, prNumber, prUrl, mergeShaVar, iteration,
+            wasEscalated: true, escalationResolution: new("rejected", "rejected"),
+            message: new("Senior rejected the PR."));
+
+        var emitValidationFailed = EmitEvent("EmitValidationFailed", "Emit Validation Failed",
+            CodeReviewEvents.Failed, sessionId, storyId, juniorId, tenantId,
+            prNumber, prUrl, iteration, mergeShaVar, new(ctx => validationError.Get(ctx)));
+
+        var emitRejected = EmitEvent("EmitRejected", "Emit Review Failed",
+            CodeReviewEvents.Failed, sessionId, storyId, juniorId, tenantId,
+            prNumber, prUrl, iteration, mergeShaVar, new("Senior rejected the PR."));
+
+        var finish = new Finish { Id = "Finish", Name = "Finish" };
+        finish.SetDisplayText("Finish");
 
         // ============================================
         // Flowchart with connections
@@ -267,76 +543,166 @@ public class CodeReviewWorkflow : WorkflowBase
             Name = "Code Review Flowchart",
             Activities =
             {
-                createPR,
-                storePRResult,
-                prCreatedCheck,
-                requestReview,
-                monitorReview,
-                storeReviewComments,
-                incrementIteration,
-                deliverGuidance,
-                waitForFixes,
-                reRequestReview,
-                maxIterationsCheck,
-                mergeAndComplete,
-                escalateReview,
-                escalateTimeout,
-                failedEnd,
-                successEnd
+                bindInputs, bindConfig, validateInputs,
+                createPR, storePRResult, prCreatedCheck, emitPrCreated, emitPrFailed,
+                requestReview, monitorReview,
+                storeReviewComments, incrementIteration, emitIteration,
+                analyzeChanges, storeAnalysis, generateGuidance, storeGuidance,
+                deliverGuidance, emitGuidanceDelivered, emitGuidanceFailed,
+                waitForFixes, reRequestReview, maxIterationsCheck,
+                mergeAndComplete, storeMergeSha, emitMerged,
+                escalateReview, escalateTimeout, escalateGuidance, escalateMerge,
+                captureEscalated, emitEscalated,
+                buildSuccessResult, buildValidationFailedResult, buildRejectedResult,
+                emitValidationFailed, emitRejected, finish
             },
             Connections =
             {
-                // Start: create PR -> store result -> check success
+                // Head: bind inputs -> bind config -> validate
+                new(bindInputs, bindConfig),
+                new(bindConfig, validateInputs),
+
+                // Validation: Valid -> create PR ; Invalid -> validation-failed terminal
+                new(new FlowEndpoint(validateInputs, "Valid"), new FlowEndpoint(createPR)),
+                new(new FlowEndpoint(validateInputs, "Invalid"), new FlowEndpoint(emitValidationFailed)),
+                new(emitValidationFailed, buildValidationFailedResult),
+                new(buildValidationFailedResult, finish),
+
+                // Create PR -> store -> check
                 new(createPR, storePRResult),
                 new(storePRResult, prCreatedCheck),
+                new(new FlowEndpoint(prCreatedCheck, "True"), new FlowEndpoint(emitPrCreated)),
+                new(new FlowEndpoint(prCreatedCheck, "False"), new FlowEndpoint(emitPrFailed)),
+                new(emitPrCreated, requestReview),
+                new(emitPrFailed, buildValidationFailedResult),
 
-                // PR created? true -> request review, false -> fail
-                new(new FlowEndpoint(prCreatedCheck, "True"), new FlowEndpoint(requestReview)),
-                new(new FlowEndpoint(prCreatedCheck, "False"), new FlowEndpoint(failedEnd)),
-
-                // Request review -> monitor review (bookmark)
+                // Request review -> monitor (bookmark)
                 new(requestReview, monitorReview),
 
-                // Monitor review outcomes:
-                //   Approved -> merge
-                //   ChangesRequested -> store comments -> increment -> deliver guidance
-                //   TimedOut -> escalate timeout
+                // Monitor outcomes
                 new(new FlowEndpoint(monitorReview, "Approved"), new FlowEndpoint(mergeAndComplete)),
                 new(new FlowEndpoint(monitorReview, "ChangesRequested"), new FlowEndpoint(storeReviewComments)),
-                new(new FlowEndpoint(monitorReview, "Commented"), new FlowEndpoint(monitorReview)),
                 new(new FlowEndpoint(monitorReview, "TimedOut"), new FlowEndpoint(escalateTimeout)),
 
-                // Store comments -> increment iteration -> deliver guidance
+                // Changes requested -> store -> increment -> iteration event -> analyze (LLM)
                 new(storeReviewComments, incrementIteration),
-                new(incrementIteration, deliverGuidance),
+                new(incrementIteration, emitIteration),
+                new(emitIteration, analyzeChanges),
+                new(analyzeChanges, storeAnalysis),
+                new(storeAnalysis, generateGuidance),
+                new(generateGuidance, storeGuidance),
+                new(storeGuidance, deliverGuidance),
 
-                // Deliver guidance -> wait for fixes (bookmark)
-                new(deliverGuidance, waitForFixes),
+                // Deliver guidance outcomes
+                new(new FlowEndpoint(deliverGuidance, "Delivered"), new FlowEndpoint(emitGuidanceDelivered)),
+                new(new FlowEndpoint(deliverGuidance, "Failed"), new FlowEndpoint(emitGuidanceFailed)),
+                new(emitGuidanceDelivered, waitForFixes),
+                new(emitGuidanceFailed, escalateGuidance),
 
-                // Wait for fixes outcomes:
-                //   FixesReceived -> re-request review
-                //   TimedOut -> escalate timeout
+                // Wait for fixes outcomes
                 new(new FlowEndpoint(waitForFixes, "FixesReceived"), new FlowEndpoint(reRequestReview)),
                 new(new FlowEndpoint(waitForFixes, "TimedOut"), new FlowEndpoint(escalateTimeout)),
 
-                // Re-request review -> check max iterations
+                // Re-request -> max-iterations guard
                 new(reRequestReview, maxIterationsCheck),
-
-                // Max iterations? true -> escalate, false -> back to monitor
                 new(new FlowEndpoint(maxIterationsCheck, "True"), new FlowEndpoint(escalateReview)),
                 new(new FlowEndpoint(maxIterationsCheck, "False"), new FlowEndpoint(monitorReview)),
 
-                // Merge -> success end
-                new(mergeAndComplete, successEnd),
+                // Merge outcomes (CI-gated, retry-once)
+                new(new FlowEndpoint(mergeAndComplete, "Merged"), new FlowEndpoint(storeMergeSha)),
+                new(new FlowEndpoint(mergeAndComplete, "Failed"), new FlowEndpoint(escalateMerge)),
+                new(storeMergeSha, emitMerged),
+                new(emitMerged, buildSuccessResult),
+                new(buildSuccessResult, finish),
 
-                // Escalation outcomes (both escalate activities):
-                //   Resolved -> merge
-                //   Rejected -> fail
-                new(new FlowEndpoint(escalateReview, "Resolved"), new FlowEndpoint(mergeAndComplete)),
-                new(new FlowEndpoint(escalateReview, "Rejected"), new FlowEndpoint(failedEnd)),
-                new(new FlowEndpoint(escalateTimeout, "Resolved"), new FlowEndpoint(mergeAndComplete)),
-                new(new FlowEndpoint(escalateTimeout, "Rejected"), new FlowEndpoint(failedEnd))
+                // Escalations (bookmark) outcomes — Resolved -> capture+merge ; Rejected -> fail
+                new(new FlowEndpoint(escalateReview, "Resolved"), new FlowEndpoint(captureEscalated)),
+                new(new FlowEndpoint(escalateReview, "Rejected"), new FlowEndpoint(emitRejected)),
+                new(new FlowEndpoint(escalateTimeout, "Resolved"), new FlowEndpoint(captureEscalated)),
+                new(new FlowEndpoint(escalateTimeout, "Rejected"), new FlowEndpoint(emitRejected)),
+                new(new FlowEndpoint(escalateGuidance, "Resolved"), new FlowEndpoint(captureEscalated)),
+                new(new FlowEndpoint(escalateGuidance, "Rejected"), new FlowEndpoint(emitRejected)),
+                new(new FlowEndpoint(escalateMerge, "Resolved"), new FlowEndpoint(captureEscalated)),
+                new(new FlowEndpoint(escalateMerge, "Rejected"), new FlowEndpoint(emitRejected)),
+
+                // Escalation resolved -> emit escalated -> merge -> success(escalated) result
+                new(captureEscalated, emitEscalated),
+                new(emitEscalated, mergeAndComplete),
+
+                // Escalation rejected -> rejected result
+                new(emitRejected, buildRejectedResult),
+                new(buildRejectedResult, finish),
+
+                // Merge success after escalation reuses buildSuccessResult path via storeMergeSha→emitMerged→buildSuccessResult.
             }
         };
+    }
+
+    // ================================================================
+    // Helper: EmitCodeReviewEventActivity factory
+    // ================================================================
+    private static EmitCodeReviewEventActivity EmitEvent(
+        string id, string displayName, string eventType,
+        Variable<string> sessionId, Variable<string> storyId, Variable<string> juniorId,
+        Variable<string> tenantId, Variable<int> prNumber, Variable<string> prUrl,
+        Variable<int> iteration, Variable<string> mergeSha, Input<string?> detail)
+    {
+        var emit = new EmitCodeReviewEventActivity
+        {
+            Id = id,
+            Name = displayName,
+            EventType = new(eventType),
+            SessionId = Expr<string?>(ctx => sessionId.Get(ctx)),
+            StoryId = Expr<string?>(ctx => storyId.Get(ctx)),
+            JuniorId = Expr<string?>(ctx => juniorId.Get(ctx)),
+            TenantId = Expr<string?>(ctx => tenantId.Get(ctx)),
+            PrNumber = Expr<int>(ctx => prNumber.Get(ctx)),
+            PrUrl = Expr<string?>(ctx => prUrl.Get(ctx)),
+            Iteration = Expr<int>(ctx => iteration.Get(ctx)),
+            MergeSha = Expr<string?>(ctx => mergeSha.Get(ctx)),
+            Detail = detail
+        };
+        emit.SetDisplayText(displayName);
+        return emit;
+    }
+
+    // ================================================================
+    // Helper: BuildCodeReviewResultActivity factory
+    // ================================================================
+    private static BuildCodeReviewResultActivity BuildResult(
+        string id, string displayName, PRReviewStatus status, bool success,
+        Variable<int> prNumber, Variable<string> prUrl, Variable<string> mergeSha,
+        Variable<int> iteration, bool wasEscalated, Input<string?> escalationResolution,
+        Input<string?> message)
+    {
+        var build = new BuildCodeReviewResultActivity
+        {
+            Id = id,
+            Name = displayName,
+            FinalStatus = new(status),
+            Success = new(success),
+            PRNumber = Expr<int>(ctx => prNumber.Get(ctx)),
+            PRUrl = Expr<string?>(ctx => prUrl.Get(ctx)),
+            MergeSha = Expr<string?>(ctx => mergeSha.Get(ctx)),
+            TotalIterations = Expr<int>(ctx => iteration.Get(ctx)),
+            WasEscalated = new(wasEscalated),
+            EscalationResolution = escalationResolution,
+            Message = message
+        };
+        build.SetDisplayText(displayName);
+        return build;
+    }
+
+    // ================================================================
+    // Helper: extract llmResponse from a DispatchWorkflow("llm-call") result dict
+    // ================================================================
+    private static string? ExtractLlmResponse(IDictionary<string, object>? result)
+    {
+        if (result == null) return null;
+        if (result.TryGetValue("llmResponse", out var r))
+            return r?.ToString();
+        if (result.TryGetValue("response", out var r2))
+            return r2?.ToString();
+        return null;
     }
 }

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/CodeReviewWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/CodeReviewWorkflow.cs
@@ -38,6 +38,14 @@ namespace Tamma.ElsaServer.Workflows;
 /// </summary>
 public class CodeReviewWorkflow : WorkflowBase
 {
+    /// <summary>
+    /// Cap on how many times a resolved merge-failure escalation may route back to the merge
+    /// step before the run terminates as rejected. Each loop is human-gated (a senior responds),
+    /// so this is not a CPU spin — but without a cap the escalate→merge→escalate cycle has no
+    /// terminal guarantee. Two re-merges (then a rejected terminal) is the bound.
+    /// </summary>
+    private const int MaxMergeEscalations = 2;
+
     // Helper to disambiguate the Input constructor overloads.
     private static Input<T> Expr<T>(Func<ExpressionExecutionContext, T> func)
         => new(func);
@@ -76,6 +84,11 @@ public class CodeReviewWorkflow : WorkflowBase
         var validationError = builder.WithVariable<string>("ValidationError", "");
         var escalationResolution = builder.WithVariable<string>("EscalationResolution", "");
         var mergeShaVar = builder.WithVariable<string>("MergeSha", "");
+        // Bound (#IMPORTANT) on the escalate→merge re-merge loop. Each time the merge-failure
+        // escalation resolves and routes back to MergeAndComplete we increment this; once it
+        // reaches the cap the run terminates as rejected (with a distinct, auditable event)
+        // instead of cycling between merge and escalation forever.
+        var mergeRetryCount = builder.WithVariable<int>("MergeRetryCount", 0);
 
         // Config-resolved variables (filled by BindConfig)
         var mergeStrategy = builder.WithVariable<MergeStrategy>("MergeStrategy", MergeStrategy.Squash);
@@ -270,11 +283,13 @@ public class CodeReviewWorkflow : WorkflowBase
                 ["role"] = Tamma.Api.Services.Agents.AgentRole.SeniorDeveloper.ToWire(),
                 ["action"] = Tamma.Api.Services.Agents.AgentAction.CodeReview.ToWire(),
                 ["tenantId"] = tenantId.Get(ctx) ?? "",
+                // Only data placeholders — the seeded (senior_developer, code-review) template
+                // is the prompt (mediated prompt-store design). A hand-written variables["prompt"]
+                // would be INERT: LlmCallWorkflow reads the top-level prompt/taskPrompt, not
+                // variables. The template renders {{reviewCommentsJson}}.
                 ["variables"] = new Dictionary<string, object>
                 {
                     ["reviewCommentsJson"] = reviewCommentsJson.Get(ctx) ?? "[]",
-                    ["prompt"] = "Identify what needs fixing based on these code review comments. " +
-                                 "Be specific and concrete about each required change.",
                 },
                 ["enableTools"] = false,
             }),
@@ -303,13 +318,14 @@ public class CodeReviewWorkflow : WorkflowBase
                 ["role"] = Tamma.Api.Services.Agents.AgentRole.SeniorDeveloper.ToWire(),
                 ["action"] = Tamma.Api.Services.Agents.AgentAction.MentorFeedback.ToWire(),
                 ["tenantId"] = tenantId.Get(ctx) ?? "",
+                // Only data placeholders — the seeded (senior_developer, mentor-feedback)
+                // template is the prompt (skill-level-aware). A hand-written variables["prompt"]
+                // would be INERT here (LlmCallWorkflow reads top-level prompt/taskPrompt). The
+                // template renders {{analysis}} / {{skillLevel}}.
                 ["variables"] = new Dictionary<string, object>
                 {
                     ["analysis"] = analysisText.Get(ctx) ?? "",
                     ["skillLevel"] = skillLevel.Get(ctx),
-                    ["prompt"] = $"Explain to a Level {skillLevel.Get(ctx)} developer how to address the " +
-                                 "following review analysis. Be encouraging, concrete, and teach the " +
-                                 "underlying concept: {analysis}",
                 },
                 ["enableTools"] = false,
             }),
@@ -415,6 +431,14 @@ public class CodeReviewWorkflow : WorkflowBase
             CodeReviewEvents.MergedSuccess, sessionId, storyId, juniorId, tenantId,
             prNumber, prUrl, iteration, mergeShaVar, new((string?)null));
 
+        // DCB event: merge failed (CI red / merge failed after retry) — emitted on the
+        // MergeAndComplete "Failed" edge BEFORE escalating, so the repeated failure is
+        // auditable (the CODE_REVIEW.MERGED.FAILED type was defined but never emitted).
+        var emitMergeFailed = EmitEvent("EmitMergeFailed", "Emit Merge Failed",
+            CodeReviewEvents.MergedFailed, sessionId, storyId, juniorId, tenantId,
+            prNumber, prUrl, iteration, mergeShaVar,
+            new("CI not green or merge failed after retry; escalating to senior."));
+
         // 13. Escalate review (max iterations)
         var escalateReview = new EscalateReviewActivity
         {
@@ -484,6 +508,46 @@ public class CodeReviewWorkflow : WorkflowBase
             CodeReviewEvents.Escalated, sessionId, storyId, juniorId, tenantId,
             prNumber, prUrl, iteration, mergeShaVar, new("Escalated to senior developer."));
 
+        // ---- Merge re-escalation loop bound (#IMPORTANT) -------------------------------
+        // The merge-failure escalation resolving routes back to MergeAndComplete; count the
+        // re-merges and terminate as rejected once the cap is hit instead of looping forever.
+        var incrementMergeRetry = new SetVariable
+        {
+            Id = "IncrementMergeRetry",
+            Name = "Increment Merge Retry",
+            Variable = mergeRetryCount,
+            Value = Expr<object?>(ctx => (object)(mergeRetryCount.Get(ctx) + 1))
+        };
+        incrementMergeRetry.SetDisplayText("Increment Merge Retry");
+
+        var mergeRetryCapCheck = new FlowDecision(ctx => mergeRetryCount.Get(ctx) >= MaxMergeEscalations)
+        { Id = "MergeRetryCapCheck", Name = "Merge Retry Cap Reached?" };
+        mergeRetryCapCheck.SetDisplayText("Merge Retry Cap Reached?");
+
+        // Distinct, auditable terminal event for the capped merge loop (LOUD error-status).
+        var emitMergeLoopExhausted = EmitEvent("EmitMergeLoopExhausted", "Emit Merge Loop Exhausted",
+            CodeReviewEvents.MergedFailed, sessionId, storyId, juniorId, tenantId,
+            prNumber, prUrl, iteration, mergeShaVar,
+            new($"Merge could not be completed after {MaxMergeEscalations} senior re-merge attempts; terminating as rejected."));
+
+        var buildMergeExhaustedResult = BuildResult("BuildMergeExhaustedResult", "Build Merge-Exhausted Result",
+            PRReviewStatus.Error, false, prNumber, prUrl, mergeShaVar, iteration,
+            wasEscalated: true, escalationResolution: new("merge-loop-exhausted", "merge-loop-exhausted"),
+            message: new($"Merge could not be completed after {MaxMergeEscalations} senior re-merge attempts."));
+
+        // ---- Escalation senior-SLA timeout terminal (durable timeout P0) ----------------
+        // A never-answered escalation now resumes via the durable Delay bookmark on the
+        // TimedOut outcome — terminate LOUD (never a silent suspend-forever / false success).
+        var emitEscalationTimedOut = EmitEvent("EmitEscalationTimedOut", "Emit Escalation Timed Out",
+            CodeReviewEvents.Failed, sessionId, storyId, juniorId, tenantId,
+            prNumber, prUrl, iteration, mergeShaVar,
+            new("Senior-response SLA expired with no response; escalation timed out."));
+
+        var buildEscalationTimedOutResult = BuildResult("BuildEscalationTimedOutResult", "Build Escalation-TimedOut Result",
+            PRReviewStatus.TimedOut, false, prNumber, prUrl, mergeShaVar, iteration,
+            wasEscalated: true, escalationResolution: new("timed-out", "timed-out"),
+            message: new("Senior-response SLA expired with no response; escalation timed out."));
+
         // ============================================
         // Terminal: structured results (#6) + DCB FAILED event (#8)
         // ============================================
@@ -518,6 +582,14 @@ public class CodeReviewWorkflow : WorkflowBase
             wasEscalated: false, escalationResolution: new("", null),
             message: new(ctx => validationError.Get(ctx)));
 
+        // PR-creation failure has its own terminal + message — it must NOT reuse the
+        // validation-failed result (whose message reads ValidationError, which is empty on
+        // this path → an empty terminal Message). Never-empty.
+        var buildPrFailedResult = BuildResult("BuildPrFailedResult", "Build PR-Failed Result",
+            PRReviewStatus.Error, false, prNumber, prUrl, mergeShaVar, iteration,
+            wasEscalated: false, escalationResolution: new("", null),
+            message: new("PR creation failed (story/repository not resolvable); review cannot proceed."));
+
         var buildRejectedResult = BuildResult("BuildRejectedResult", "Build Rejected Result",
             PRReviewStatus.ChangesRequested, false, prNumber, prUrl, mergeShaVar, iteration,
             wasEscalated: true, escalationResolution: new("rejected", "rejected"),
@@ -550,10 +622,12 @@ public class CodeReviewWorkflow : WorkflowBase
                 analyzeChanges, storeAnalysis, generateGuidance, storeGuidance,
                 deliverGuidance, emitGuidanceDelivered, emitGuidanceFailed,
                 waitForFixes, reRequestReview, maxIterationsCheck,
-                mergeAndComplete, storeMergeSha, emitMerged,
+                mergeAndComplete, storeMergeSha, emitMerged, emitMergeFailed,
                 escalateReview, escalateTimeout, escalateGuidance, escalateMerge,
                 captureEscalated, emitEscalated,
-                buildSuccessResult, buildValidationFailedResult, buildRejectedResult,
+                incrementMergeRetry, mergeRetryCapCheck, emitMergeLoopExhausted, buildMergeExhaustedResult,
+                emitEscalationTimedOut, buildEscalationTimedOutResult,
+                buildSuccessResult, buildValidationFailedResult, buildRejectedResult, buildPrFailedResult,
                 emitValidationFailed, emitRejected, finish
             },
             Connections =
@@ -574,7 +648,8 @@ public class CodeReviewWorkflow : WorkflowBase
                 new(new FlowEndpoint(prCreatedCheck, "True"), new FlowEndpoint(emitPrCreated)),
                 new(new FlowEndpoint(prCreatedCheck, "False"), new FlowEndpoint(emitPrFailed)),
                 new(emitPrCreated, requestReview),
-                new(emitPrFailed, buildValidationFailedResult),
+                new(emitPrFailed, buildPrFailedResult),
+                new(buildPrFailedResult, finish),
 
                 // Request review -> monitor (bookmark)
                 new(requestReview, monitorReview),
@@ -610,20 +685,37 @@ public class CodeReviewWorkflow : WorkflowBase
 
                 // Merge outcomes (CI-gated, retry-once)
                 new(new FlowEndpoint(mergeAndComplete, "Merged"), new FlowEndpoint(storeMergeSha)),
-                new(new FlowEndpoint(mergeAndComplete, "Failed"), new FlowEndpoint(escalateMerge)),
+                // Failed -> emit CODE_REVIEW.MERGED.FAILED (auditable) -> escalate
+                new(new FlowEndpoint(mergeAndComplete, "Failed"), new FlowEndpoint(emitMergeFailed)),
+                new(emitMergeFailed, escalateMerge),
                 new(storeMergeSha, emitMerged),
                 new(emitMerged, buildSuccessResult),
                 new(buildSuccessResult, finish),
 
-                // Escalations (bookmark) outcomes — Resolved -> capture+merge ; Rejected -> fail
+                // Escalations (bookmark) outcomes — Resolved -> capture+merge ; Rejected -> fail ;
+                // TimedOut -> senior-SLA-expired terminal (durable timeout; never a silent suspend).
                 new(new FlowEndpoint(escalateReview, "Resolved"), new FlowEndpoint(captureEscalated)),
                 new(new FlowEndpoint(escalateReview, "Rejected"), new FlowEndpoint(emitRejected)),
+                new(new FlowEndpoint(escalateReview, "TimedOut"), new FlowEndpoint(emitEscalationTimedOut)),
                 new(new FlowEndpoint(escalateTimeout, "Resolved"), new FlowEndpoint(captureEscalated)),
                 new(new FlowEndpoint(escalateTimeout, "Rejected"), new FlowEndpoint(emitRejected)),
+                new(new FlowEndpoint(escalateTimeout, "TimedOut"), new FlowEndpoint(emitEscalationTimedOut)),
                 new(new FlowEndpoint(escalateGuidance, "Resolved"), new FlowEndpoint(captureEscalated)),
                 new(new FlowEndpoint(escalateGuidance, "Rejected"), new FlowEndpoint(emitRejected)),
-                new(new FlowEndpoint(escalateMerge, "Resolved"), new FlowEndpoint(captureEscalated)),
+                new(new FlowEndpoint(escalateGuidance, "TimedOut"), new FlowEndpoint(emitEscalationTimedOut)),
+                // EscalateMerge.Resolved goes through the re-merge loop bound, not straight to merge.
+                new(new FlowEndpoint(escalateMerge, "Resolved"), new FlowEndpoint(incrementMergeRetry)),
                 new(new FlowEndpoint(escalateMerge, "Rejected"), new FlowEndpoint(emitRejected)),
+                new(new FlowEndpoint(escalateMerge, "TimedOut"), new FlowEndpoint(emitEscalationTimedOut)),
+
+                // Merge re-escalation loop bound: increment -> cap check.
+                //   cap reached  -> distinct MERGED.FAILED event -> rejected terminal (no loop)
+                //   under the cap -> capture + re-merge
+                new(incrementMergeRetry, mergeRetryCapCheck),
+                new(new FlowEndpoint(mergeRetryCapCheck, "True"), new FlowEndpoint(emitMergeLoopExhausted)),
+                new(new FlowEndpoint(mergeRetryCapCheck, "False"), new FlowEndpoint(captureEscalated)),
+                new(emitMergeLoopExhausted, buildMergeExhaustedResult),
+                new(buildMergeExhaustedResult, finish),
 
                 // Escalation resolved -> emit escalated -> merge -> success(escalated) result
                 new(captureEscalated, emitEscalated),
@@ -632,6 +724,10 @@ public class CodeReviewWorkflow : WorkflowBase
                 // Escalation rejected -> rejected result
                 new(emitRejected, buildRejectedResult),
                 new(buildRejectedResult, finish),
+
+                // Escalation senior-SLA timed out -> escalation-timeout terminal
+                new(emitEscalationTimedOut, buildEscalationTimedOutResult),
+                new(buildEscalationTimedOutResult, finish),
 
                 // Merge success after escalation reuses buildSuccessResult path via storeMergeSha→emitMerged→buildSuccessResult.
             }

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Review/CodeReviewEventTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Review/CodeReviewEventTests.cs
@@ -1,0 +1,286 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+using Tamma.Activities.Review;
+using Tamma.Activities.Review.Models;
+
+namespace Tamma.Activities.Tests.Review;
+
+/// <summary>
+/// Completeness build-out 2026-06-22 (<c>CodeReview.md</c>, Story 7-1D) — coverage for the
+/// code-review correctness + observability fixes:
+///   - the <c>CODE_REVIEW.*</c> DCB event catalogue + status convention (no false success, #8),
+///   - <see cref="EmitCodeReviewEventActivity.BuildTammaEvent"/> tag/data mapping (#8),
+///   - <see cref="BindCodeReviewConfigActivity.Resolve"/> config precedence + the
+///     FixTimeoutMinutes→hours drift fix (#9),
+///   - <see cref="ValidateCodeReviewInputsActivity.Validate"/> specific-failure validation (#3).
+/// </summary>
+[TestFixture]
+public class CodeReviewEventTests
+{
+    // ================================================================
+    // CodeReviewEvents — type catalogue + status convention (#8)
+    // ================================================================
+
+    [Test]
+    public void EventTypes_FollowAggregateActionStatusConvention()
+    {
+        CodeReviewEvents.PrCreatedSuccess.Should().Be("CODE_REVIEW.PR_CREATED.SUCCESS");
+        CodeReviewEvents.PrCreatedFailed.Should().Be("CODE_REVIEW.PR_CREATED.FAILED");
+        CodeReviewEvents.GuidanceDeliveredSuccess.Should().Be("CODE_REVIEW.GUIDANCE_DELIVERED.SUCCESS");
+        CodeReviewEvents.GuidanceDeliveredFailed.Should().Be("CODE_REVIEW.GUIDANCE_DELIVERED.FAILED");
+        CodeReviewEvents.IterationStarted.Should().Be("CODE_REVIEW.ITERATION.STARTED");
+        CodeReviewEvents.MergedSuccess.Should().Be("CODE_REVIEW.MERGED.SUCCESS");
+        CodeReviewEvents.MergedFailed.Should().Be("CODE_REVIEW.MERGED.FAILED");
+        CodeReviewEvents.Escalated.Should().Be("CODE_REVIEW.ESCALATED");
+        CodeReviewEvents.Failed.Should().Be("CODE_REVIEW.FAILED");
+    }
+
+    [Test]
+    public void StatusForEvent_FailuresAreError_RestAreSuccess()
+    {
+        CodeReviewEvents.StatusForEvent(CodeReviewEvents.PrCreatedFailed).Should().Be("error");
+        CodeReviewEvents.StatusForEvent(CodeReviewEvents.GuidanceDeliveredFailed).Should().Be("error");
+        CodeReviewEvents.StatusForEvent(CodeReviewEvents.MergedFailed).Should().Be("error");
+        CodeReviewEvents.StatusForEvent(CodeReviewEvents.Failed).Should().Be("error");
+
+        CodeReviewEvents.StatusForEvent(CodeReviewEvents.PrCreatedSuccess).Should().Be("success");
+        CodeReviewEvents.StatusForEvent(CodeReviewEvents.GuidanceDeliveredSuccess).Should().Be("success");
+        CodeReviewEvents.StatusForEvent(CodeReviewEvents.IterationStarted).Should().Be("success");
+        CodeReviewEvents.StatusForEvent(CodeReviewEvents.MergedSuccess).Should().Be("success");
+        // An escalation is an expected, auditable hand-off — success-status (the rejection
+        // that may follow is recorded as CODE_REVIEW.FAILED).
+        CodeReviewEvents.StatusForEvent(CodeReviewEvents.Escalated).Should().Be("success");
+    }
+
+    [Test]
+    public void ParseTenantId_ValidGuid_Parses_InvalidOrEmpty_IsNull()
+    {
+        var g = Guid.NewGuid();
+        CodeReviewEvents.ParseTenantId(g.ToString()).Should().Be(g);
+        CodeReviewEvents.ParseTenantId("").Should().BeNull();
+        CodeReviewEvents.ParseTenantId(null).Should().BeNull();
+        CodeReviewEvents.ParseTenantId("not-a-guid").Should().BeNull();
+    }
+
+    // ================================================================
+    // EmitCodeReviewEventActivity.BuildTammaEvent — tags + data + status
+    // ================================================================
+
+    [Test]
+    public void BuildTammaEvent_PrCreated_StampsTagsAndPrData_SuccessStatus()
+    {
+        var evt = EmitCodeReviewEventActivity.BuildTammaEvent(
+            CodeReviewEvents.PrCreatedSuccess,
+            sessionId: "sess-1", storyId: "story-7", juniorId: "junior-9", tenantId: null,
+            prNumber: 42, prUrl: "https://github.com/o/r/pull/42", iteration: 0,
+            mergeSha: null, reason: null, detail: null);
+
+        evt.EventType.Should().Be("CODE_REVIEW.PR_CREATED.SUCCESS");
+        evt.Status.Should().Be("success");
+        evt.Tags!["sessionId"].Should().Be("sess-1");
+        evt.Tags!["storyId"].Should().Be("story-7");
+        evt.Tags!["juniorId"].Should().Be("junior-9");
+        evt.Tags!["prId"].Should().Be("42");
+        evt.Tags.Should().NotContainKey("tenantId", "single-user / platform-scope event");
+        evt.Data["prNumber"].Should().Be(42);
+        evt.Data["prUrl"].Should().Be("https://github.com/o/r/pull/42");
+    }
+
+    [Test]
+    public void BuildTammaEvent_WithTenant_StampsTenantTag_AndIteration()
+    {
+        var tenant = Guid.NewGuid();
+        var evt = EmitCodeReviewEventActivity.BuildTammaEvent(
+            CodeReviewEvents.IterationStarted,
+            "sess-1", "story-1", "junior-1", tenant,
+            prNumber: 7, prUrl: null, iteration: 2,
+            mergeSha: null, reason: null, detail: null);
+
+        evt.Tags!["tenantId"].Should().Be(tenant.ToString("D"));
+        evt.Tags!["iteration"].Should().Be("2");
+        evt.Data["iteration"].Should().Be(2);
+    }
+
+    [Test]
+    public void BuildTammaEvent_Merged_CarriesShaAndStrategy()
+    {
+        var evt = EmitCodeReviewEventActivity.BuildTammaEvent(
+            CodeReviewEvents.MergedSuccess,
+            "sess-1", "story-1", "junior-1", null,
+            prNumber: 7, prUrl: null, iteration: 3,
+            mergeSha: "abc123", reason: null, detail: null);
+
+        evt.Status.Should().Be("success");
+        evt.Data["mergeSha"].Should().Be("abc123");
+    }
+
+    [Test]
+    public void BuildTammaEvent_Failed_IsErrorStatus_WithDetailOnError_NotFalseSuccess()
+    {
+        var evt = EmitCodeReviewEventActivity.BuildTammaEvent(
+            CodeReviewEvents.Failed,
+            "sess-1", "story-1", "junior-1", null,
+            prNumber: 0, prUrl: null, iteration: 0,
+            mergeSha: null, reason: null, detail: "missing storyId");
+
+        evt.EventType.Should().Be("CODE_REVIEW.FAILED");
+        evt.Status.Should().Be("error");
+        evt.Error.Should().Be("missing storyId");
+        evt.Data["detail"].Should().Be("missing storyId");
+    }
+
+    [Test]
+    public void BuildTammaEvent_OmitsEmptyTagsAndZeroData()
+    {
+        var evt = EmitCodeReviewEventActivity.BuildTammaEvent(
+            CodeReviewEvents.Escalated,
+            sessionId: "", storyId: "", juniorId: "", tenantId: null,
+            prNumber: 0, prUrl: "", iteration: 0,
+            mergeSha: "", reason: "", detail: "");
+
+        evt.Tags!.Should().NotContainKey("sessionId");
+        evt.Tags!.Should().NotContainKey("prId");
+        evt.Tags!.Should().NotContainKey("iteration");
+        evt.Data.Should().NotContainKey("prNumber");
+        evt.Data.Should().NotContainKey("mergeSha");
+    }
+
+    // ================================================================
+    // BindCodeReviewConfigActivity.Resolve — config precedence + drift fix (#9)
+    // ================================================================
+
+    private static IConfiguration Config(Dictionary<string, string?> values)
+        => new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+
+    [Test]
+    public void Resolve_Defaults_WhenNoInputNoConfig()
+    {
+        var r = BindCodeReviewConfigActivity.Resolve(configuration: null, maxIterationsInput: 0, mergeStrategyInput: null);
+
+        r.MaxIterations.Should().Be(5);
+        r.MergeStrategy.Should().Be(MergeStrategy.Squash);
+        r.ReviewTimeoutHours.Should().Be(24);
+        // FixTimeoutMinutes default 60 → 1h (NOT the 24h review timeout — the drift fix).
+        r.FixTimeoutHours.Should().Be(1);
+        r.VerifyCIBeforeMerge.Should().BeTrue();
+        r.DeleteBranchAfterMerge.Should().BeTrue();
+    }
+
+    [Test]
+    public void Resolve_InputOverridesConfig_ForMaxIterAndStrategy()
+    {
+        var cfg = Config(new()
+        {
+            ["CodeReview:MaxReviewIterations"] = "3",
+            ["CodeReview:MergeStrategy"] = "Merge",
+        });
+
+        var r = BindCodeReviewConfigActivity.Resolve(cfg, maxIterationsInput: 8, mergeStrategyInput: "Rebase");
+
+        r.MaxIterations.Should().Be(8, "explicit input wins over config");
+        r.MergeStrategy.Should().Be(MergeStrategy.Rebase, "explicit input wins over config");
+    }
+
+    [Test]
+    public void Resolve_ConfigUsedWhenNoInput()
+    {
+        var cfg = Config(new()
+        {
+            ["CodeReview:MaxReviewIterations"] = "7",
+            ["CodeReview:MergeStrategy"] = "merge",
+            ["CodeReview:ReviewTimeoutHours"] = "48",
+            ["CodeReview:FixTimeoutMinutes"] = "120",
+            ["CodeReview:VerifyCIBeforeMerge"] = "false",
+            ["CodeReview:DeleteBranchAfterMerge"] = "false",
+        });
+
+        var r = BindCodeReviewConfigActivity.Resolve(cfg, maxIterationsInput: 0, mergeStrategyInput: null);
+
+        r.MaxIterations.Should().Be(7);
+        r.MergeStrategy.Should().Be(MergeStrategy.Merge);
+        r.ReviewTimeoutHours.Should().Be(48);
+        r.FixTimeoutHours.Should().Be(2, "120 minutes / 60 = 2 hours");
+        r.VerifyCIBeforeMerge.Should().BeFalse();
+        r.DeleteBranchAfterMerge.Should().BeFalse();
+    }
+
+    [Test]
+    public void Resolve_FixTimeoutHasOneHourFloor()
+    {
+        var cfg = Config(new() { ["CodeReview:FixTimeoutMinutes"] = "30" });
+        var r = BindCodeReviewConfigActivity.Resolve(cfg, 0, null);
+        r.FixTimeoutHours.Should().Be(1, "sub-hour fix timeouts floor at 1h for the hour-granular durable wait");
+    }
+
+    // ================================================================
+    // ValidateCodeReviewInputsActivity.Validate — specific failures (#3)
+    // ================================================================
+
+    [Test]
+    public void Validate_AllPresentWithExplicitReviewers_IsValid()
+    {
+        var r = ValidateCodeReviewInputsActivity.Validate(
+            storyId: "S-1", repositoryUrl: "https://github.com/o/r", juniorId: "J-1",
+            reviewerIdsJson: "[\"alice\",\"bob\"]", reviewerPool: Array.Empty<string>());
+
+        r.IsValid.Should().BeTrue();
+        r.Reviewers.Should().BeEquivalentTo(new[] { "alice", "bob" });
+        r.ErrorMessage.Should().BeEmpty();
+    }
+
+    [Test]
+    public void Validate_FallsBackToPool_WhenNoExplicitReviewers()
+    {
+        var r = ValidateCodeReviewInputsActivity.Validate(
+            "S-1", "https://github.com/o/r", "J-1",
+            reviewerIdsJson: null, reviewerPool: new[] { "carol" });
+
+        r.IsValid.Should().BeTrue();
+        r.Reviewers.Should().ContainSingle().Which.Should().Be("carol");
+    }
+
+    [TestCase(null, "repo", "j", "storyId")]
+    [TestCase("", "repo", "j", "storyId")]
+    [TestCase("s", null, "j", "repositoryUrl")]
+    [TestCase("s", "repo", null, "juniorId")]
+    public void Validate_MissingRequiredInput_IsInvalid_WithSpecificMessage(
+        string? story, string? repo, string? junior, string expectedToken)
+    {
+        var r = ValidateCodeReviewInputsActivity.Validate(
+            story, repo, junior, "[\"alice\"]", Array.Empty<string>());
+
+        r.IsValid.Should().BeFalse();
+        r.ErrorMessage.Should().NotBeEmpty();
+        r.ErrorMessage.Should().Contain(expectedToken);
+        r.ErrorMessage.Should().NotContain("Code review failed", "no generic message — must be specific (#3)");
+    }
+
+    [Test]
+    public void Validate_NoResolvableReviewer_IsInvalid_WithSpecificMessage()
+    {
+        var r = ValidateCodeReviewInputsActivity.Validate(
+            "S-1", "https://github.com/o/r", "J-1",
+            reviewerIdsJson: "[]", reviewerPool: Array.Empty<string>());
+
+        r.IsValid.Should().BeFalse();
+        r.ErrorMessage.Should().Contain("no reviewer resolvable");
+        r.ErrorMessage.Should().Contain("ReviewerPool");
+    }
+
+    [Test]
+    public void Validate_SingleIssueCyclePayloadShape_IsInvalid_NotSilentlyDropped()
+    {
+        // The autonomous-loop dispatch sends {repository, prNumber, branchName, tenantId} with
+        // no storyId/juniorId. It must FAIL with a clear reason here (deferred #2) — never a
+        // silent no-op that proceeds to create a PR for an empty story.
+        var r = ValidateCodeReviewInputsActivity.Validate(
+            storyId: null, repositoryUrl: "https://github.com/o/r", juniorId: null,
+            reviewerIdsJson: null, reviewerPool: Array.Empty<string>());
+
+        r.IsValid.Should().BeFalse();
+        r.ErrorMessage.Should().Contain("storyId");
+        r.ErrorMessage.Should().Contain("juniorId");
+        r.ErrorMessage.Should().Contain("autonomous-loop", "the message points the misrouted payload at the right workflow");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Review/ReviewDurableTimeoutTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Review/ReviewDurableTimeoutTests.cs
@@ -1,0 +1,114 @@
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Tamma.Activities.Tests.Review;
+
+/// <summary>
+/// Review fix 2026-06-25 (code-review P0) — the durable wait-timeout invariant for the three
+/// code-review bookmark waits.
+///
+/// <para>The build-out left <see cref="Tamma.Activities.Review.MonitorReviewActivity"/>,
+/// <see cref="Tamma.Activities.Review.WaitForFixesActivity"/> and
+/// <see cref="Tamma.Activities.Review.EscalateReviewActivity"/> with ONLY a
+/// <c>CreateBookmark</c> plus an in-memory deadline that was checked exclusively inside the
+/// resume callback. If the reviewer / junior / senior never responds, the callback never
+/// fires, so the <c>TimedOut</c> outcome was runtime-unreachable and the workflow instance
+/// suspended forever — the exact hang this guards against.</para>
+///
+/// <para>The fix arms a DURABLE <c>context.DelayFor(...)</c> (the EF-persisted Delay bookmark
+/// that <c>Elsa.Scheduling</c>'s startup background task RE-ARMS on rehydration) alongside the
+/// work bookmark, resuming into a dedicated <c>OnTimeoutAsync</c> that takes the <c>TimedOut</c>
+/// outcome. These source-scan invariants guard against regression to a callback-only timeout
+/// or the in-memory <c>IWorkflowScheduler</c>. (A live resume/rehydration test needs the full
+/// Elsa runtime + EF store, which these activities have no unit harness for; the behavioural
+/// contract — never-resumed bookmark → <c>TimedOut</c> terminal — is covered structurally by
+/// <see cref="Tamma.Activities.Tests.Workflows.CodeReviewWorkflowStructureTests"/>.) Mirrors
+/// <see cref="Tamma.Activities.Tests.Blocker.BlockerDurableTimeoutTests"/>.</para>
+/// </summary>
+[TestFixture]
+public class ReviewDurableTimeoutTests
+{
+    private static readonly string[] TimeoutBearingActivities =
+    {
+        "MonitorReviewActivity.cs",
+        "WaitForFixesActivity.cs",
+        "EscalateReviewActivity.cs",
+    };
+
+    [Test]
+    [TestCaseSource(nameof(TimeoutBearingActivities))]
+    public void TimeoutActivity_ArmsDurableDelayBookmark_WithATimeoutHandler(string fileName)
+    {
+        var src = ReadReviewActivity(fileName);
+
+        // The durable primitive — DelayFor (the Delay bookmark) — must be armed, and a
+        // dedicated timeout callback must exist to take the TimedOut edge.
+        src.Should().Contain("context.DelayFor(",
+            $"{fileName} must arm the durable DelayFor (Delay) bookmark so the timeout survives a host restart and is reachable when no one responds");
+        src.Should().Contain("OnTimeoutAsync",
+            $"{fileName} must resume into a dedicated durable-timeout handler");
+        src.Should().Contain("CompleteActivityWithOutcomesAsync(\"TimedOut\")",
+            $"{fileName}'s timeout handler must complete with the TimedOut outcome (not suspend forever)");
+    }
+
+    [Test]
+    [TestCaseSource(nameof(TimeoutBearingActivities))]
+    public void TimeoutActivity_StillArmsTheExternalWorkBookmark(string fileName)
+    {
+        var src = ReadReviewActivity(fileName);
+
+        // Dual-arm: the external work bookmark must remain so a real reviewer/junior/senior
+        // signal can resume (only the timeout primitive was added, not the resume path).
+        src.Should().Contain("CreateBookmark(",
+            $"{fileName} must keep its external work bookmark so a real response can resume");
+    }
+
+    [Test]
+    [TestCaseSource(nameof(TimeoutBearingActivities))]
+    public void TimeoutActivity_DoesNotUseTheInMemoryScheduler(string fileName)
+    {
+        var src = ReadReviewActivity(fileName);
+
+        // The in-memory LocalScheduler seam (ScheduleAtAsync / IWorkflowScheduler) is the lost-
+        // on-restart hazard. It must be absent.
+        src.Should().NotContain("ScheduleAtAsync(",
+            $"{fileName} must NOT schedule via IWorkflowScheduler.ScheduleAtAsync (in-memory timer lost on restart)");
+        src.Should().NotContain("GetService<IWorkflowScheduler>",
+            $"{fileName} must not resolve the in-memory IWorkflowScheduler");
+    }
+
+    // ---------------------------------------------------------------------
+    // Source-tree helper (mirrors BlockerDurableTimeoutTests' worktree locator).
+    // ---------------------------------------------------------------------
+
+    private static string ReadReviewActivity(string fileName)
+    {
+        var path = Path.Combine(ReviewActivityDir(), fileName);
+        File.Exists(path).Should().BeTrue($"expected review activity source at {path}");
+        return File.ReadAllText(path);
+    }
+
+    private static string ReviewActivityDir() =>
+        Path.Combine(TammaElsaSrcRoot(), "Tamma.Activities", "Review");
+
+    private static string TammaElsaSrcRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "src", "Tamma.Activities");
+            if (Directory.Exists(candidate))
+                return Path.Combine(dir.FullName, "src");
+
+            var nested = Path.Combine(dir.FullName, "apps", "tamma-elsa", "src", "Tamma.Activities");
+            if (Directory.Exists(nested))
+                return Path.Combine(dir.FullName, "apps", "tamma-elsa", "src");
+
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not locate apps/tamma-elsa/src by walking up from "
+            + AppContext.BaseDirectory + " — the durable-timeout invariant test needs the source tree.");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/CodeReviewWorkflowStructureTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/CodeReviewWorkflowStructureTests.cs
@@ -1,0 +1,178 @@
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Runtime.Activities;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Review;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Completeness build-out 2026-06-22 (<c>CodeReview.md</c>, Story 7-1D) — structural
+/// verification of the corrected <c>code-review</c> graph:
+///   - inputs are bound by a head node (#1) before CreatePR,
+///   - a ValidateInputs decision routes invalid inputs to a specific failure terminal (#3),
+///   - fix guidance is produced by mediated llm-call dispatches (#4) — no in-engine provider,
+///   - merge is CI-gated / strategy-aware / branch-deleting via the outcome activity (#5),
+///   - structured CodeReviewWorkflowResult terminals replace loose SetOutputs (#6),
+///   - CODE_REVIEW.* DCB emits are wired at each milestone (#8),
+///   - config variables (timeouts/strategy/flags) are present (#9),
+///   - the workflow keeps its DefinitionId and uses the computed version,
+///   - every wait (review / fix / escalation) reaches a terminal — no dangling bookmark.
+/// </summary>
+[TestFixture]
+public class CodeReviewWorkflowStructureTests
+{
+    private static Flowchart Build()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new CodeReviewWorkflow());
+        return WorkflowTestHelper.GetFlowchart(builder);
+    }
+
+    [Test]
+    public void BuildsWithoutError_AndKeepsDefinitionId()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new CodeReviewWorkflow());
+        builder.Object.DefinitionId.Should().Be("code-review");
+        builder.Object.Version.Should().Be(WorkflowVersions.ComputedVersion);
+    }
+
+    [Test]
+    public void HasInputBindingHeadNode_BeforeCreatePR_DefectNo1()
+    {
+        var fc = Build();
+        var bind = fc.Activities.FirstOrDefault(a => a.Id == "BindInputs");
+        bind.Should().NotBeNull("a Bind Inputs head node must read workflow inputs (defect #1)");
+
+        var createPr = fc.Activities.First(a => a.Id == "CreatePR");
+        // BindInputs must reach CreatePR; CreatePR must NOT be the entry (it must be downstream of binding/validation).
+        var createPrHasInbound = fc.Connections.Any(c => c.Target.Activity == createPr);
+        createPrHasInbound.Should().BeTrue("CreatePR must be downstream of input binding + validation, not the entry point");
+    }
+
+    [Test]
+    public void HasValidationDecision_RoutingToSpecificFailure_No3()
+    {
+        var fc = Build();
+        var validate = fc.Activities.FirstOrDefault(a => a.Id == "ValidateInputs");
+        validate.Should().BeOfType<ValidateCodeReviewInputsActivity>();
+
+        // Invalid edge must reach the validation-failed terminal (not the generic failed path / silent drop).
+        var emitValidationFailed = fc.Activities.FirstOrDefault(a => a.Id == "EmitValidationFailed");
+        emitValidationFailed.Should().NotBeNull();
+        var hasInvalidEdge = fc.Connections.Any(c =>
+            c.Source.Activity?.Id == "ValidateInputs" && c.Source.Port == "Invalid");
+        hasInvalidEdge.Should().BeTrue("ValidateInputs must have an Invalid outcome edge");
+    }
+
+    [Test]
+    public void FixGuidance_UsesMediatedLlmCall_No4()
+    {
+        var fc = Build();
+        var dispatches = fc.Activities.OfType<DispatchWorkflow>().ToList();
+        var ids = dispatches.Select(d => d.Id).ToList();
+        ids.Should().Contain("AnalyzeChanges", "AC7 AnalyzeChanges must be a mediated llm-call dispatch");
+        ids.Should().Contain("GenerateGuidance", "AC7 GenerateGuidance must be a mediated llm-call dispatch");
+    }
+
+    [Test]
+    public void Merge_IsOutcomeActivity_WithFailureEscalation_No5()
+    {
+        var fc = Build();
+        var merge = fc.Activities.FirstOrDefault(a => a.Id == "MergeAndComplete");
+        merge.Should().BeOfType<MergeAndCompleteReviewActivity>();
+
+        // A merge Failed outcome must escalate (not silently succeed).
+        var failedEdge = fc.Connections.FirstOrDefault(c =>
+            c.Source.Activity?.Id == "MergeAndComplete" && c.Source.Port == "Failed");
+        failedEdge.Should().NotBeNull("a CI-red / merge-failed outcome must route to escalation");
+        failedEdge!.Target.Activity!.Id.Should().Be("EscalateMerge");
+    }
+
+    [Test]
+    public void EmitsStructuredResultTerminals_No6()
+    {
+        var fc = Build();
+        var resultBuilders = fc.Activities.OfType<BuildCodeReviewResultActivity>().ToList();
+        resultBuilders.Should().HaveCountGreaterThanOrEqualTo(3,
+            "every terminal (merged / validation-failed / rejected) must build a structured result");
+    }
+
+    [Test]
+    public void EmitsDcbEvents_AtMilestones_No8()
+    {
+        var fc = Build();
+        var emits = fc.Activities.OfType<EmitCodeReviewEventActivity>().ToList();
+        emits.Should().HaveCountGreaterThanOrEqualTo(6,
+            "DCB CODE_REVIEW.* events must be emitted at PR-created/guidance/iteration/merged/escalated/failed milestones");
+    }
+
+    [Test]
+    public void HasConfigVariables_No9()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new CodeReviewWorkflow());
+        var names = builder.Object.Variables.Select(v => v.Name).ToHashSet();
+        names.Should().Contain("ReviewTimeoutHours");
+        names.Should().Contain("FixTimeoutHours");
+        names.Should().Contain("VerifyCIBeforeMerge");
+        names.Should().Contain("DeleteBranchAfterMerge");
+        names.Should().Contain("TenantId");
+        // NB: the MergeStrategy variable IS declared by the workflow, but the shared mock
+        // builder has no WithVariable<MergeStrategy>(name, default) setup, so its name isn't
+        // captured here. Its resolution is covered by BindCodeReviewConfigActivity.Resolve tests.
+    }
+
+    [Test]
+    public void EveryWaitReachesATerminal_NoDanglingBookmark()
+    {
+        var fc = Build();
+        var finish = fc.Activities.OfType<Finish>().FirstOrDefault();
+        finish.Should().NotBeNull("workflow must have a terminal Finish node");
+
+        // Every bookmark-bearing wait must have at least one outbound edge so it can't hang.
+        foreach (var waitId in new[] { "MonitorReview", "WaitForFixes", "EscalateReview", "EscalateTimeout", "EscalateGuidance", "EscalateMerge" })
+        {
+            var node = fc.Activities.FirstOrDefault(a => a.Id == waitId);
+            node.Should().NotBeNull($"{waitId} should exist");
+            var hasOutbound = fc.Connections.Any(c => c.Source.Activity == node);
+            hasOutbound.Should().BeTrue($"{waitId} must have an outbound edge to a terminal (no dangling bookmark)");
+        }
+    }
+
+    [Test]
+    public void NoOrphanActivities_EveryNonEntryNodeHasInbound_EveryNonTerminalHasOutbound()
+    {
+        var fc = Build();
+        var entry = fc.Activities.First(a => a.Id == "BindInputs");
+
+        foreach (var a in fc.Activities)
+        {
+            if (a == entry) continue;
+            var hasInbound = fc.Connections.Any(c => c.Target.Activity == a);
+            hasInbound.Should().BeTrue($"activity '{a.Id}' must be reachable (have an inbound edge)");
+        }
+
+        // Every node except the terminal Finish must have an outbound edge.
+        var finish = fc.Activities.OfType<Finish>().Single();
+        foreach (var a in fc.Activities)
+        {
+            if (a == finish) continue;
+            var hasOutbound = fc.Connections.Any(c => c.Source.Activity == a);
+            hasOutbound.Should().BeTrue($"activity '{a.Id}' must lead somewhere (have an outbound edge)");
+        }
+    }
+
+    [Test]
+    public void AllActivitiesHaveDisplayText()
+    {
+        var fc = Build();
+        foreach (var activity in WorkflowTestHelper.GetAllActivities(fc))
+        {
+            activity.GetDisplayText().Should().NotBeNullOrEmpty(
+                $"Activity '{activity.GetType().Name}' (Id: {activity.Id}) should have DisplayText");
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/CodeReviewWorkflowStructureTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/CodeReviewWorkflowStructureTests.cs
@@ -85,11 +85,14 @@ public class CodeReviewWorkflowStructureTests
         var merge = fc.Activities.FirstOrDefault(a => a.Id == "MergeAndComplete");
         merge.Should().BeOfType<MergeAndCompleteReviewActivity>();
 
-        // A merge Failed outcome must escalate (not silently succeed).
+        // A merge Failed outcome must escalate (not silently succeed). It first emits the
+        // auditable CODE_REVIEW.MERGED.FAILED event, then routes to EscalateMerge.
         var failedEdge = fc.Connections.FirstOrDefault(c =>
             c.Source.Activity?.Id == "MergeAndComplete" && c.Source.Port == "Failed");
         failedEdge.Should().NotBeNull("a CI-red / merge-failed outcome must route to escalation");
-        failedEdge!.Target.Activity!.Id.Should().Be("EscalateMerge");
+        failedEdge!.Target.Activity!.Id.Should().Be("EmitMergeFailed");
+        var emitToEscalate = fc.Connections.FirstOrDefault(c => c.Source.Activity?.Id == "EmitMergeFailed");
+        emitToEscalate!.Target.Activity!.Id.Should().Be("EscalateMerge");
     }
 
     [Test]
@@ -140,6 +143,128 @@ public class CodeReviewWorkflowStructureTests
             var hasOutbound = fc.Connections.Any(c => c.Source.Activity == node);
             hasOutbound.Should().BeTrue($"{waitId} must have an outbound edge to a terminal (no dangling bookmark)");
         }
+    }
+
+    [Test]
+    public void EveryEscalation_HasADurableTimedOutEdge_ToALoudTerminal_ReviewFix()
+    {
+        // Each EscalateReviewActivity now arms a durable senior-SLA Delay → TimedOut outcome.
+        // The TimedOut edge must be wired to the escalation-timeout terminal (never a silent
+        // suspend-forever / false success).
+        var fc = Build();
+        foreach (var escId in new[] { "EscalateReview", "EscalateTimeout", "EscalateGuidance", "EscalateMerge" })
+        {
+            var timedOutEdge = fc.Connections.FirstOrDefault(c =>
+                c.Source.Activity?.Id == escId && c.Source.Port == "TimedOut");
+            timedOutEdge.Should().NotBeNull($"{escId} must have a TimedOut outcome edge (durable senior-SLA timeout)");
+            timedOutEdge!.Target.Activity!.Id.Should().Be("EmitEscalationTimedOut",
+                $"{escId}.TimedOut must route to the escalation-timeout terminal");
+        }
+
+        // The escalation-timeout terminal must build a structured (loud) result reaching Finish.
+        var emit = fc.Activities.FirstOrDefault(a => a.Id == "EmitEscalationTimedOut");
+        emit.Should().NotBeNull();
+        var toResult = fc.Connections.FirstOrDefault(c => c.Source.Activity?.Id == "EmitEscalationTimedOut");
+        toResult!.Target.Activity!.Id.Should().Be("BuildEscalationTimedOutResult");
+    }
+
+    [Test]
+    public void MergeReEscalationLoop_IsBounded_ReviewFix()
+    {
+        // The escalate-merge → resolved → re-merge loop must be bounded: EscalateMerge.Resolved
+        // routes through the retry counter + cap check (NOT straight back to MergeAndComplete),
+        // and the cap-reached branch terminates as rejected instead of looping forever.
+        var fc = Build();
+
+        var resolvedEdge = fc.Connections.FirstOrDefault(c =>
+            c.Source.Activity?.Id == "EscalateMerge" && c.Source.Port == "Resolved");
+        resolvedEdge.Should().NotBeNull();
+        resolvedEdge!.Target.Activity!.Id.Should().Be("IncrementMergeRetry",
+            "a resolved merge escalation must go through the re-merge counter, not straight back to merge");
+
+        var capCheck = fc.Activities.FirstOrDefault(a => a.Id == "MergeRetryCapCheck");
+        capCheck.Should().NotBeNull("there must be a cap-check decision on the re-merge loop");
+
+        // True (cap reached) -> distinct event -> terminal; never loops back to MergeAndComplete.
+        var capReached = fc.Connections.FirstOrDefault(c =>
+            c.Source.Activity?.Id == "MergeRetryCapCheck" && c.Source.Port == "True");
+        capReached.Should().NotBeNull();
+        capReached!.Target.Activity!.Id.Should().Be("EmitMergeLoopExhausted");
+
+        var exhaustedToResult = fc.Connections.FirstOrDefault(c => c.Source.Activity?.Id == "EmitMergeLoopExhausted");
+        exhaustedToResult!.Target.Activity!.Id.Should().Be("BuildMergeExhaustedResult");
+        var toFinish = fc.Connections.FirstOrDefault(c => c.Source.Activity?.Id == "BuildMergeExhaustedResult");
+        toFinish!.Target.Activity.Should().BeOfType<Finish>("the capped merge loop must terminate, not cycle");
+
+        // Under the cap, it re-merges (capture -> emit escalated -> merge).
+        var underCap = fc.Connections.FirstOrDefault(c =>
+            c.Source.Activity?.Id == "MergeRetryCapCheck" && c.Source.Port == "False");
+        underCap!.Target.Activity!.Id.Should().Be("CaptureEscalated");
+    }
+
+    [Test]
+    public void MergeFailedEdge_EmitsMergedFailedEvent_BeforeEscalating_ReviewFix()
+    {
+        // CODE_REVIEW.MERGED.FAILED was defined but never emitted — the MergeAndComplete.Failed
+        // edge must now pass through an emit node before escalating.
+        var fc = Build();
+        var failedEdge = fc.Connections.FirstOrDefault(c =>
+            c.Source.Activity?.Id == "MergeAndComplete" && c.Source.Port == "Failed");
+        failedEdge.Should().NotBeNull();
+        failedEdge!.Target.Activity!.Id.Should().Be("EmitMergeFailed",
+            "the merge-failed edge must emit CODE_REVIEW.MERGED.FAILED before escalating");
+
+        var emitToEscalate = fc.Connections.FirstOrDefault(c => c.Source.Activity?.Id == "EmitMergeFailed");
+        emitToEscalate!.Target.Activity!.Id.Should().Be("EscalateMerge");
+    }
+
+    [Test]
+    public void PrCreationFailure_HasItsOwnTerminal_WithNonEmptyMessage_ReviewFix()
+    {
+        // PR-creation failure must NOT reuse the validation-failed terminal (whose message is
+        // empty on this path). It has a dedicated terminal that reaches Finish.
+        var fc = Build();
+        var prFailedEdge = fc.Connections.FirstOrDefault(c => c.Source.Activity?.Id == "EmitPrFailed");
+        prFailedEdge.Should().NotBeNull();
+        prFailedEdge!.Target.Activity!.Id.Should().Be("BuildPrFailedResult",
+            "PR-creation failure must build its own result with a specific message, not reuse the empty validation message");
+
+        var toFinish = fc.Connections.FirstOrDefault(c => c.Source.Activity?.Id == "BuildPrFailedResult");
+        toFinish!.Target.Activity.Should().BeOfType<Finish>();
+    }
+
+    [Test]
+    public void LlmDispatches_PassOnlyDataPlaceholders_NoInertPromptVariable_ReviewFix()
+    {
+        // The hand-written variables["prompt"] is inert (LlmCallWorkflow reads top-level
+        // prompt/taskPrompt, not variables). It must be dropped — the seeded role+action
+        // template is the prompt; only data placeholders are passed. (Match the ASSIGNMENT
+        // form so the explanatory doc-comments that mention variables["prompt"] don't trip it.)
+        var src = ReadWorkflowSource();
+        src.Should().NotContain("[\"prompt\"] =",
+            "the inert variables[\"prompt\"] = ... assignment must be dropped from the llm-call dispatches");
+    }
+
+    [Test]
+    public void HasMergeRetryCountVariable_ReviewFix()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new CodeReviewWorkflow());
+        var names = builder.Object.Variables.Select(v => v.Name).ToHashSet();
+        names.Should().Contain("MergeRetryCount", "the re-merge loop must track a bounded retry count");
+    }
+
+    private static string ReadWorkflowSource()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var nested = Path.Combine(dir.FullName, "apps", "tamma-elsa", "src", "Tamma.ElsaServer", "Workflows", "CodeReviewWorkflow.cs");
+            if (File.Exists(nested)) return File.ReadAllText(nested);
+            var flat = Path.Combine(dir.FullName, "src", "Tamma.ElsaServer", "Workflows", "CodeReviewWorkflow.cs");
+            if (File.Exists(flat)) return File.ReadAllText(flat);
+            dir = dir.Parent;
+        }
+        throw new DirectoryNotFoundException("Could not locate CodeReviewWorkflow.cs source.");
     }
 
     [Test]


### PR DESCRIPTION
## CodeReviewWorkflow build-out — Bucket D (fix-now)

Per `docs/superpowers/audits/2026-06-22/completeness/CodeReview.md`. Made the workflow functional + correct:
- **#1 (P0, critical defect):** bind workflow inputs (nothing bound them → every run died at CreatePR).
- **#3:** validate inputs → specific failure (no generic/silent false-path); a `SingleIssueCycle`-shaped payload faults clearly.
- **#4:** mediated LLM guidance — `AnalyzeChanges`/`GenerateGuidance` via `DispatchWorkflow("llm-call")` (canonical roles senior_developer + code-review/mentor-feedback), removed keyword heuristics + "Uses Claude" doc lie.
- **#5:** CI-green-before-merge + retry-once-then-escalate + config branch-delete via `IIntegrationService`.
- **#6:** structured `CodeReviewWorkflowResult`. **#8:** DCB events via `TammaEventEmitter`. **#9:** `CodeReview:*` config binding (+ WaitForFixes 24h→1h drift fix).

**Review + fix:** CRITICAL — the 3 bookmark waits' timeout branches were runtime-unreachable (in-memory deadline, no durable timer) → hang forever; fixed by arming `context.DelayFor` (mirrors the merged Blocker pattern; EscalateReview gained a missing `TimedOut` terminal). IMPORTANT — bounded the escalate→merge loop (max 2). Plus MINORs (emit MERGED.FAILED, PR-fail message, dropped inert prompt var). `ReviewDurableTimeoutTests` guards the never-resumed→TimedOut path.

**Gate:** build 0; full `Tamma.Activities.Tests` **1866/0** (incl. drift test). No migration/Program.cs/csproj change. Deferred (honest): #2 full dual-caller, #7/#10–14 (Epic 38 git mediation, metrics, draft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)