### PR TITLE
feat(workflows): build out DeleteTenantWorkflow — dispatch bridge, cancellation-safe teardown, single terminal

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/DeleteTenantStepActivities.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/DeleteTenantStepActivities.cs
@@ -33,25 +33,44 @@ namespace Tamma.Activities.TenantLifecycle;
 // ═══════════════════════════════════════════════════════════════════════
 
 /// <summary>
-/// Step A of the rebuilt <c>DeleteTenantWorkflow</c> — continue-on-error
-/// variant of <see cref="MarkTenantDeletingActivity"/>. Flips
-/// <c>tenants.Status='deleting'</c> (idempotent) and emits the
-/// <c>TENANT.DELETE.REQUESTED</c> marker.
+/// Step A of the rebuilt <c>DeleteTenantWorkflow</c>. CONFIRMS the tenant is
+/// still <c>deleting</c> before the destructive span begins, then emits a
+/// <c>TENANT.DELETE.STARTED</c> marker.
 ///
-/// <para>Unlike the throwing <see cref="MarkTenantDeletingActivity"/>, a
-/// failure here records into the per-step accumulator and lets the
-/// Sequence continue so the run still reaches the single terminal event.
-/// The endpoint already flipped the row to <c>deleting</c> before the
-/// trigger dispatched, so this is normally a fast no-op.</para>
+/// <para><b>CRITICAL — cancellation race + self re-dispatch fixes.</b></para>
+/// <list type="bullet">
+///   <item><description><b>Does NOT resurrect an <c>active</c> tenant.</b>
+///     The endpoint already flipped the row to <c>deleting</c> before the
+///     trigger dispatched; this step does NOT flip <c>active→deleting</c>.
+///     If the row is no longer <c>deleting</c> (an operator cancelled during
+///     the cooling-off window, racing the dispatch), this step ABORTS the run
+///     via <see cref="CleanupWorkflowState.MarkAborted(ActivityExecutionContext,string)"/>
+///     — every subsequent destructive step then SKIPS and the terminal emits
+///     <c>TENANT.DELETE.ABORTED</c>. The cancelled tenant is NEVER torn down.</description></item>
+///   <item><description><b>Does NOT re-emit <c>TENANT.DELETE.REQUESTED</c>.</b>
+///     That is the exact event <see cref="Tamma.Activities"/>' delete trigger
+///     polls; re-emitting it is a self re-dispatch loop. The workflow signals
+///     "started" with the distinct <see cref="TenantLifecycleEvents.DeleteStarted"/>
+///     marker instead.</description></item>
+/// </list>
+///
+/// <para>Continue-on-error like its siblings — a transient CP read failure
+/// records into the accumulator and the run still reaches the terminal. It
+/// overrides <see cref="SkipWhenAborted"/> to <c>false</c> because it is the
+/// step that DETECTS cancellation; the destructive steps after it skip.</para>
 /// </summary>
 [Activity(
     "Tamma.TenantLifecycle",
     "Mark Tenant Deleting (Delete)",
-    "Continue-on-error variant — set Status='deleting' + emit TENANT.DELETE.REQUESTED; never throws.",
+    "Confirm Status='deleting' (abort if cancelled) + emit TENANT.DELETE.STARTED; never throws.",
     Kind = ActivityKind.Task)]
 public sealed class MarkTenantDeletingForDeleteActivity : CleanupStepActivity
 {
     public override string StepName => CleanupSteps.MarkDeleting;
+
+    // This step DETECTS cancellation and sets the abort flag, so it must run
+    // even though the destructive steps after it skip on abort.
+    protected override bool SkipWhenAborted => false;
 
     protected override async Task DoStepAsync(
         ActivityExecutionContext context,
@@ -61,37 +80,192 @@ public sealed class MarkTenantDeletingForDeleteActivity : CleanupStepActivity
         await using var db = await factory.CreateDbContextAsync(context.CancellationToken)
             .ConfigureAwait(false);
 
-        var tenant = await db.Tenants
-            .IgnoreQueryFilters()
-            .FirstOrDefaultAsync(t => t.Id == tenantId, context.CancellationToken)
-            .ConfigureAwait(false)
-            ?? throw new InvalidOperationException(
-                $"MarkDeleting: tenant {tenantId} not found in CP.");
+        var store = new ActivityContextStateStore(context);
+        var stillDeleting = await EvaluateAsync(
+            db, store, tenantId, Logger, context.CancellationToken).ConfigureAwait(false);
+        if (!stillDeleting)
+            return; // aborted — EvaluateAsync already set the abort flag.
 
-        var current = (string?)db.Entry(tenant).Property("Status").CurrentValue;
-        if (!string.Equals(current, "deleting", StringComparison.OrdinalIgnoreCase))
-        {
-            db.Entry(tenant).Property("Status").CurrentValue = "deleting";
-            if (db.Entry(tenant).Property("DeleteRequestedAt").CurrentValue is null)
-                db.Entry(tenant).Property("DeleteRequestedAt").CurrentValue = DateTime.UtcNow;
-            tenant.UpdatedAt = DateTime.UtcNow;
-            await db.SaveChangesAsync(context.CancellationToken).ConfigureAwait(false);
-        }
-
+        // Already 'deleting' (the endpoint set it). Emit the STARTED marker —
+        // NOT TENANT.DELETE.REQUESTED (the trigger's own poll target — re-emitting
+        // it would self re-dispatch). Idempotent: the step-dedup index swallows
+        // a replay on the same attempt.
         var publisher = context.GetRequiredService<IPlatformEventPublisher>();
         await publisher.AppendAndPublishAsync(
             TenantLifecycleEvents.BuildEvent(
-                TenantLifecycleEvents.DeleteRequested,
+                TenantLifecycleEvents.DeleteStarted,
                 tenantId,
                 data: new Dictionary<string, object?>
                 {
-                    ["requestedAt"] = DateTime.UtcNow,
+                    ["startedAt"] = DateTime.UtcNow,
                     ["source"] = "delete-workflow",
                 }),
             context.CancellationToken).ConfigureAwait(false);
 
         Logger?.LogInformation(
-            "tenant.delete.mark_deleting completed tenantId={TenantId}", tenantId);
+            "tenant.delete.mark_deleting confirmed_deleting tenantId={TenantId}", tenantId);
+    }
+
+    /// <summary>
+    /// Pure-DI cancellation check — testable against an EF InMemory
+    /// <see cref="ControlPlaneDbContext"/> + an in-memory
+    /// <see cref="ICleanupStateStore"/>, with NO Elsa runtime. Reads the live
+    /// <c>Status</c> and:
+    /// <list type="bullet">
+    ///   <item>returns <c>true</c> when the tenant is still <c>deleting</c> (the
+    ///     destructive span may proceed);</item>
+    ///   <item>returns <c>false</c> and calls
+    ///     <see cref="CleanupWorkflowState.MarkAborted(ICleanupStateStore,string)"/>
+    ///     when the tenant is NOT <c>deleting</c> — it does NOT flip the row, so
+    ///     a cancelled (<c>active</c>) tenant is NEVER resurrected to
+    ///     <c>deleting</c>.</item>
+    /// </list>
+    /// Throws only when the tenant row is missing (a genuinely broken input the
+    /// continue-on-error base records as a step failure).
+    /// </summary>
+    public static async Task<bool> EvaluateAsync(
+        ControlPlaneDbContext db,
+        ICleanupStateStore store,
+        Guid tenantId,
+        ILogger? logger,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(store);
+
+        var current = await db.Tenants
+            .AsNoTracking()
+            .IgnoreQueryFilters()
+            .Where(t => t.Id == tenantId)
+            .Select(t => new { Status = EF.Property<string?>(t, "Status"), Found = true })
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (current is null)
+            throw new InvalidOperationException(
+                $"MarkDeleting: tenant {tenantId} not found in CP.");
+
+        if (!string.Equals(current.Status, "deleting", StringComparison.OrdinalIgnoreCase))
+        {
+            // Cancellation race — the operator flipped the tenant out of
+            // 'deleting' (typically back to 'active' via cancel-delete) after
+            // the trigger dispatched. Do NOT re-flip to 'deleting' and do NOT
+            // proceed: abort so the destructive steps skip and the terminal
+            // emits ABORTED. The tenant stays exactly as the operator left it.
+            var reason = $"tenant no longer 'deleting' (status={current.Status ?? "null"}) — delete cancelled before destructive span";
+            CleanupWorkflowState.MarkAborted(store, reason);
+            logger?.LogWarning(
+                "tenant.delete.mark_deleting aborted_cancelled tenantId={TenantId} status={Status}",
+                tenantId, current.Status);
+            return false;
+        }
+
+        return true;
+    }
+}
+
+/// <summary>
+/// Cancellation guard — runs IMMEDIATELY before the destructive
+/// <c>DropTenantSchema</c> step. Re-reads <c>tenants.Status</c> a final time;
+/// if the tenant is no longer <c>deleting</c> (an operator cancelled during
+/// the brief window after <see cref="MarkTenantDeletingForDeleteActivity"/>
+/// confirmed but before the drop), it ABORTS the run so the drop + role-drop +
+/// relationship-cleanup steps all skip and the terminal emits
+/// <c>TENANT.DELETE.ABORTED</c>.
+///
+/// <para>This is the second (and last) cancellation checkpoint: the first is
+/// the mark step at the top of the run; this one closes the window between
+/// confirmation and the irreversible <c>DROP SCHEMA … CASCADE</c>. Together
+/// they make a cancelled tenant un-droppable regardless of dispatch timing.
+/// (The trigger's pre-dispatch re-read is the third, earliest, line of
+/// defence.)</para>
+///
+/// <para>Like the mark step it overrides <see cref="SkipWhenAborted"/> to
+/// <c>false</c> — it is itself a cancellation detector. A transient CP read
+/// failure FAILS CLOSED: it aborts the run (does NOT proceed to the drop) so a
+/// momentarily-unreadable status can never be assumed to be <c>deleting</c>.</para>
+/// </summary>
+[Activity(
+    "Tamma.TenantLifecycle",
+    "Guard Tenant Deleting (Delete)",
+    "Re-read Status before the destructive drop; abort the run if no longer 'deleting'. Fail-closed; never throws.",
+    Kind = ActivityKind.Task)]
+public sealed class GuardTenantDeletingActivity : CleanupStepActivity
+{
+    public override string StepName => CleanupSteps.GuardDeleting;
+
+    // Itself a cancellation detector — must run on the non-aborted path.
+    protected override bool SkipWhenAborted => false;
+
+    protected override async Task DoStepAsync(
+        ActivityExecutionContext context,
+        Guid tenantId)
+    {
+        var factory = context.GetRequiredService<IDbContextFactory<ControlPlaneDbContext>>();
+        var store = new ActivityContextStateStore(context);
+        await EvaluateAsync(factory, store, tenantId, Logger, context.CancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Pure-DI cancellation guard — testable against an EF InMemory
+    /// <see cref="ControlPlaneDbContext"/> factory + an in-memory
+    /// <see cref="ICleanupStateStore"/>. Re-reads the live <c>Status</c>; if it
+    /// is not <c>deleting</c> it ABORTS the run (so the drop is skipped). A read
+    /// failure FAILS CLOSED — it also aborts, so a momentarily-unreadable status
+    /// can never be mistaken for "still deleting" right before the irreversible
+    /// drop. Returns <c>true</c> only when the tenant is confirmed still
+    /// <c>deleting</c>.
+    /// </summary>
+    public static async Task<bool> EvaluateAsync(
+        IDbContextFactory<ControlPlaneDbContext> factory,
+        ICleanupStateStore store,
+        Guid tenantId,
+        ILogger? logger,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        ArgumentNullException.ThrowIfNull(store);
+
+        string? current;
+        try
+        {
+            await using var db = await factory.CreateDbContextAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            current = await db.Tenants
+                .AsNoTracking()
+                .IgnoreQueryFilters()
+                .Where(t => t.Id == tenantId)
+                .Select(t => EF.Property<string?>(t, "Status"))
+                .FirstOrDefaultAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Fail-closed: a read failure right before DROP SCHEMA must NOT be
+            // treated as "still deleting". Abort so the destructive span skips;
+            // the trigger re-dispatches on the next tick once CP is readable.
+            CleanupWorkflowState.MarkAborted(
+                store, "cancellation guard could not re-read status before drop (fail-closed)");
+            logger?.LogWarning(
+                ex, "tenant.delete.guard read_failed_abort tenantId={TenantId}", tenantId);
+            return false;
+        }
+
+        if (!string.Equals(current, "deleting", StringComparison.OrdinalIgnoreCase))
+        {
+            var reason = $"tenant no longer 'deleting' (status={current ?? "null"}) — delete cancelled before DROP SCHEMA";
+            CleanupWorkflowState.MarkAborted(store, reason);
+            logger?.LogWarning(
+                "tenant.delete.guard aborted_cancelled tenantId={TenantId} status={Status}",
+                tenantId, current);
+            return false;
+        }
+
+        logger?.LogInformation(
+            "tenant.delete.guard still_deleting tenantId={TenantId}", tenantId);
+        return true;
     }
 }
 
@@ -158,26 +332,45 @@ public sealed class BackupTenantDatabaseForDeleteActivity : CleanupStepActivity
 /// step. Removes the control-plane rows that key off the deleted tenant so
 /// no foreign-key dangle survives the soft-delete tombstone.
 ///
-/// <para><b>Disposition policy (decided per table):</b></para>
+/// <para><b>Disposition policy (decided per table; every live CP table with
+/// a tenant key has an explicit verdict — no silent FK dangle).</b></para>
 /// <list type="bullet">
 ///   <item><description><b>Delete</b> — operational CP rows with no audit
 ///     value once the tenant is gone: <c>tenant_memberships</c>,
 ///     <c>user_invites</c>, pending <c>platform_queued_tasks</c>,
 ///     <c>tenant_agent_enablements</c>, <c>alert_channels</c>,
 ///     <c>api_keys</c> (revoked — the credentials must stop working
-///     immediately).</description></item>
+///     immediately), <c>platform_api_key_index</c> (the auth routing rows
+///     for those keys; its model was DESIGNED with a <c>TenantId</c> index
+///     "for bulk-revoke on tenant delete (cascade)" — leaving them dangles
+///     an index pointing at deleted <c>api_keys</c>),
+///     <c>tenant_platform_installations</c> (NON-nullable <c>TenantId</c> FK
+///     — a git-platform binding for the gone tenant; its credentials live in
+///     the tenant-scoped secret store and are dropped with the schema, so
+///     the row has no standalone value and would dangle if kept),
+///     <c>agent_role_selections</c> (tenant-keyed selections) and the
+///     tenant's PRIVATE <c>agents</c> (+ their <c>agent_versions</c>) —
+///     tenant-owned data, deleted with the tenant. Public/system agents
+///     (<c>OwnerTenantId IS NULL</c>) are platform-global and untouched.</description></item>
 ///   <item><description><b>Null the FK</b> — <c>github_installations</c>:
 ///     a GitHub App installation is owned by the GitHub org, not the
 ///     tenant; nulling <c>TenantId</c> releases it for re-binding without
 ///     destroying the installation record.</description></item>
 ///   <item><description><b>Keep for audit</b> — <c>billing_customers</c>
 ///     (financial record / Stripe linkage), <c>audit_records</c>,
-///     <c>platform_events</c>: retained intentionally; the soft-deleted
-///     tenant row + these immutable trails are what compliance reads back.
-///     NOT touched here.</description></item>
+///     <c>platform_events</c>, <c>alerts</c> (operational + compliance
+///     history; <c>TenantId</c> is NULLABLE so no FK dangle, and the alert
+///     feed is read back for incident review), <c>platform_analytics_hourly</c>
+///     (immutable cross-tenant analytics fact table; <c>TenantId</c> NULLABLE,
+///     the platform-wide rollup rows carry <c>TenantId=null</c> — purging a
+///     gone tenant's hourly rows would corrupt historical platform totals).
+///     All retained intentionally; NOT touched here.</description></item>
 ///   <item><description><b>Out of scope (tenant-schema, not CP)</b> —
-///     <c>prompt_overrides</c> and other per-tenant rows live inside the
-///     tenant's own <c>t_&lt;hex&gt;</c> schema (excluded from the
+///     <c>prompt_overrides</c>, <c>secrets</c> (tenant KEK-encrypted),
+///     <c>analytics_usage_daily</c>/<c>analytics_usage_hourly</c>, and the
+///     SaaS tenant-keyed <c>agent_role_selections</c> rows all live inside the
+///     tenant's own <c>t_&lt;hex&gt;</c> schema (configured on
+///     <see cref="TenantDbContext"/>, NOT the
 ///     <see cref="ControlPlaneDbContext"/> model) and are destroyed by the
 ///     upstream <c>DROP SCHEMA … CASCADE</c> — this CP step must not, and
 ///     cannot, reach them.</description></item>
@@ -213,11 +406,15 @@ public sealed class CleanupTenantRelationshipsActivity : CleanupStepActivity
             "tenant.delete.cleanup_relationships completed tenantId={TenantId} "
             + "memberships={Memberships} invites={Invites} installationsReleased={Installations} "
             + "queuedTasks={QueuedTasks} enablements={Enablements} "
-            + "alertChannels={AlertChannels} apiKeys={ApiKeys}",
+            + "alertChannels={AlertChannels} apiKeys={ApiKeys} apiKeyIndex={ApiKeyIndex} "
+            + "platformInstallations={PlatformInstallations} agentSelections={AgentSelections} "
+            + "privateAgents={PrivateAgents} agentVersions={AgentVersions}",
             tenantId,
             removed.Memberships, removed.Invites, removed.InstallationsReleased,
             removed.QueuedTasks, removed.Enablements,
-            removed.AlertChannels, removed.ApiKeys);
+            removed.AlertChannels, removed.ApiKeys, removed.ApiKeyIndexRows,
+            removed.PlatformInstallations, removed.AgentRoleSelections,
+            removed.PrivateAgents, removed.AgentVersions);
     }
 
     /// <summary>
@@ -277,6 +474,49 @@ public sealed class CleanupTenantRelationshipsActivity : CleanupStepActivity
             .ToListAsync(cancellationToken).ConfigureAwait(false);
         db.ApiKeys.RemoveRange(apiKeys);
 
+        // platform_api_key_index — the auth routing rows for those keys. The
+        // entity was DESIGNED with a TenantId index "for bulk-revoke on tenant
+        // delete (cascade)"; with api_keys hard-deleted above, leaving these
+        // dangles an index pointing at gone api_keys rows. Purge them.
+        var apiKeyIndex = await db.PlatformApiKeyIndex
+            .Where(i => i.TenantId == tenantId)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        db.PlatformApiKeyIndex.RemoveRange(apiKeyIndex);
+
+        // tenant_platform_installations — git-platform bindings keyed by a
+        // NON-nullable TenantId FK. The binding credentials live in the
+        // tenant-scoped secret store (dropped with the schema), so the row has
+        // no standalone value and would FK-dangle if kept. Delete.
+        var platformInstallations = await db.TenantPlatformInstallations
+            .IgnoreQueryFilters()
+            .Where(p => p.TenantId == tenantId)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        db.TenantPlatformInstallations.RemoveRange(platformInstallations);
+
+        // agent_role_selections — CP-resident tenant-keyed selections (SaaS
+        // tenant-keyed rows that ALSO live in the tenant schema are dropped by
+        // CASCADE; this purges any CP-side rows carrying this TenantId).
+        var agentSelections = await db.AgentRoleSelections
+            .IgnoreQueryFilters()
+            .Where(s => s.TenantId == tenantId)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        db.AgentRoleSelections.RemoveRange(agentSelections);
+
+        // Private (tenant-owned) agents + their immutable version snapshots.
+        // Public/system agents (OwnerTenantId IS NULL) are platform-global and
+        // untouched. agent_versions has OnDelete(Restrict), so the versions
+        // must be removed BEFORE the parent agents in the same unit of work.
+        var privateAgents = await db.Agents
+            .IgnoreQueryFilters()
+            .Where(a => a.OwnerTenantId == tenantId)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        var privateAgentIds = privateAgents.Select(a => a.Id).ToList();
+        var agentVersions = await db.AgentVersions
+            .Where(v => privateAgentIds.Contains(v.AgentId))
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        db.AgentVersions.RemoveRange(agentVersions);
+        db.Agents.RemoveRange(privateAgents);
+
         // ── Null the FK: github_installations is org-owned, not
         //    tenant-owned. Release it for re-binding; keep the record. ──
         var installations = await db.GitHubInstallations
@@ -295,7 +535,12 @@ public sealed class CleanupTenantRelationshipsActivity : CleanupStepActivity
             Enablements: enablements.Count,
             AlertChannels: alertChannels.Count,
             ApiKeys: apiKeys.Count,
-            InstallationsReleased: installations.Count);
+            InstallationsReleased: installations.Count,
+            ApiKeyIndexRows: apiKeyIndex.Count,
+            PlatformInstallations: platformInstallations.Count,
+            AgentRoleSelections: agentSelections.Count,
+            PrivateAgents: privateAgents.Count,
+            AgentVersions: agentVersions.Count);
     }
 
     /// <summary>Per-table disposition counts returned by
@@ -308,5 +553,10 @@ public sealed class CleanupTenantRelationshipsActivity : CleanupStepActivity
         int Enablements,
         int AlertChannels,
         int ApiKeys,
-        int InstallationsReleased);
+        int InstallationsReleased,
+        int ApiKeyIndexRows = 0,
+        int PlatformInstallations = 0,
+        int AgentRoleSelections = 0,
+        int PrivateAgents = 0,
+        int AgentVersions = 0);
 }

--- a/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/DeleteTenantStepActivities.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/DeleteTenantStepActivities.cs
@@ -1,0 +1,312 @@
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Tamma.Activities.AgentDispatch;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Pooling;
+
+namespace Tamma.Activities.TenantLifecycle;
+
+// ═══════════════════════════════════════════════════════════════════════
+// Story 28-5 item #3 — DeleteTenantWorkflow continue-on-error decomposition
+//
+// The destructive teardown used to be a flat Sequence of throwing
+// TenantLifecycleActivity steps: a mid-sequence throw aborted the run and
+// left the tenant stuck in 'deleting' with NO terminal event (violating
+// "no silent-failure" + "exactly one terminal event"). This file mirrors
+// the sibling cleanup decomposition (CleanupStepActivity + the
+// *ForCleanupActivity variants) so the delete workflow runs every step
+// regardless of upstream failures and concludes with exactly one terminal
+// event (EmitDeleteTerminalEventActivity).
+//
+// These delete-specific steps inherit CleanupStepActivity for the
+// continue-on-error contract (catch → record into CleanupWorkflowState →
+// emit TENANT.DELETE.STEP_* → return). The reusable destructive steps
+// (evict pool, drop schema, drop role) already have continue-on-error
+// variants in the cleanup file; the delete workflow reuses those directly.
+// ═══════════════════════════════════════════════════════════════════════
+
+/// <summary>
+/// Step A of the rebuilt <c>DeleteTenantWorkflow</c> — continue-on-error
+/// variant of <see cref="MarkTenantDeletingActivity"/>. Flips
+/// <c>tenants.Status='deleting'</c> (idempotent) and emits the
+/// <c>TENANT.DELETE.REQUESTED</c> marker.
+///
+/// <para>Unlike the throwing <see cref="MarkTenantDeletingActivity"/>, a
+/// failure here records into the per-step accumulator and lets the
+/// Sequence continue so the run still reaches the single terminal event.
+/// The endpoint already flipped the row to <c>deleting</c> before the
+/// trigger dispatched, so this is normally a fast no-op.</para>
+/// </summary>
+[Activity(
+    "Tamma.TenantLifecycle",
+    "Mark Tenant Deleting (Delete)",
+    "Continue-on-error variant — set Status='deleting' + emit TENANT.DELETE.REQUESTED; never throws.",
+    Kind = ActivityKind.Task)]
+public sealed class MarkTenantDeletingForDeleteActivity : CleanupStepActivity
+{
+    public override string StepName => CleanupSteps.MarkDeleting;
+
+    protected override async Task DoStepAsync(
+        ActivityExecutionContext context,
+        Guid tenantId)
+    {
+        var factory = context.GetRequiredService<IDbContextFactory<ControlPlaneDbContext>>();
+        await using var db = await factory.CreateDbContextAsync(context.CancellationToken)
+            .ConfigureAwait(false);
+
+        var tenant = await db.Tenants
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(t => t.Id == tenantId, context.CancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new InvalidOperationException(
+                $"MarkDeleting: tenant {tenantId} not found in CP.");
+
+        var current = (string?)db.Entry(tenant).Property("Status").CurrentValue;
+        if (!string.Equals(current, "deleting", StringComparison.OrdinalIgnoreCase))
+        {
+            db.Entry(tenant).Property("Status").CurrentValue = "deleting";
+            if (db.Entry(tenant).Property("DeleteRequestedAt").CurrentValue is null)
+                db.Entry(tenant).Property("DeleteRequestedAt").CurrentValue = DateTime.UtcNow;
+            tenant.UpdatedAt = DateTime.UtcNow;
+            await db.SaveChangesAsync(context.CancellationToken).ConfigureAwait(false);
+        }
+
+        var publisher = context.GetRequiredService<IPlatformEventPublisher>();
+        await publisher.AppendAndPublishAsync(
+            TenantLifecycleEvents.BuildEvent(
+                TenantLifecycleEvents.DeleteRequested,
+                tenantId,
+                data: new Dictionary<string, object?>
+                {
+                    ["requestedAt"] = DateTime.UtcNow,
+                    ["source"] = "delete-workflow",
+                }),
+            context.CancellationToken).ConfigureAwait(false);
+
+        Logger?.LogInformation(
+            "tenant.delete.mark_deleting completed tenantId={TenantId}", tenantId);
+    }
+}
+
+/// <summary>
+/// Step B2 of the rebuilt <c>DeleteTenantWorkflow</c> — continue-on-error
+/// variant of <see cref="BackupTenantDatabaseActivity"/>. Optional
+/// <c>pg_dump</c> taken before the schema drop, gated by
+/// <c>Backup:DeletionBackup</c> (a pure no-op when off). Reuses the
+/// pure-DI static entry points so the dump logic stays single-sourced.
+///
+/// <para>A backup failure records into the accumulator and continues —
+/// but because the backup is taken BEFORE the destructive drop, the
+/// terminal will report <c>TENANT.DELETE.FAILED</c> and quarantine the
+/// tenant so an operator decides whether to proceed without a snapshot.</para>
+/// </summary>
+[Activity(
+    "Tamma.TenantLifecycle",
+    "Backup Tenant Database (Delete)",
+    "Continue-on-error variant — pg_dump before drop (gated by Backup:DeletionBackup); never throws.",
+    Kind = ActivityKind.Task)]
+public sealed class BackupTenantDatabaseForDeleteActivity : CleanupStepActivity
+{
+    public override string StepName => CleanupSteps.BackupDatabase;
+
+    protected override async Task DoStepAsync(
+        ActivityExecutionContext context,
+        Guid tenantId)
+    {
+        var options = context.GetService<IOptions<TenantBackupOptions>>()?.Value
+                      ?? new TenantBackupOptions();
+
+        if (!options.DeletionBackup)
+        {
+            Logger?.LogInformation(
+                "tenant.delete.backup_database disabled_skip tenantId={TenantId}", tenantId);
+            return;
+        }
+
+        var runner = context.GetRequiredService<IProcessRunner>();
+        var factory = context.GetRequiredService<IDbContextFactory<ControlPlaneDbContext>>();
+        var placement = await TenantPlacementShadow.LoadAsync(
+            factory, tenantId, context.CancellationToken).ConfigureAwait(false);
+
+        if (placement.DatabaseId is not null && placement.SchemaName is not null)
+        {
+            var pool = context.GetRequiredService<ITenantDatabasePool>();
+            await BackupTenantDatabaseActivity.BackupSchemaAsync(
+                options, pool, runner, tenantId,
+                placement.DatabaseId.Value, placement.SchemaName,
+                DateTime.UtcNow, Logger, context.CancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        var admin = context.GetRequiredService<ITenantAdminConnection>();
+        await BackupTenantDatabaseActivity.BackupAsync(
+            options, admin, runner, tenantId, DateTime.UtcNow, Logger,
+            context.CancellationToken).ConfigureAwait(false);
+    }
+}
+
+/// <summary>
+/// Story 28-5 item #4 / AC4 Step I — CP-side relationship cleanup. Runs
+/// between <see cref="DropTenantRoleForCleanupActivity"/> and the terminal
+/// step. Removes the control-plane rows that key off the deleted tenant so
+/// no foreign-key dangle survives the soft-delete tombstone.
+///
+/// <para><b>Disposition policy (decided per table):</b></para>
+/// <list type="bullet">
+///   <item><description><b>Delete</b> — operational CP rows with no audit
+///     value once the tenant is gone: <c>tenant_memberships</c>,
+///     <c>user_invites</c>, pending <c>platform_queued_tasks</c>,
+///     <c>tenant_agent_enablements</c>, <c>alert_channels</c>,
+///     <c>api_keys</c> (revoked — the credentials must stop working
+///     immediately).</description></item>
+///   <item><description><b>Null the FK</b> — <c>github_installations</c>:
+///     a GitHub App installation is owned by the GitHub org, not the
+///     tenant; nulling <c>TenantId</c> releases it for re-binding without
+///     destroying the installation record.</description></item>
+///   <item><description><b>Keep for audit</b> — <c>billing_customers</c>
+///     (financial record / Stripe linkage), <c>audit_records</c>,
+///     <c>platform_events</c>: retained intentionally; the soft-deleted
+///     tenant row + these immutable trails are what compliance reads back.
+///     NOT touched here.</description></item>
+///   <item><description><b>Out of scope (tenant-schema, not CP)</b> —
+///     <c>prompt_overrides</c> and other per-tenant rows live inside the
+///     tenant's own <c>t_&lt;hex&gt;</c> schema (excluded from the
+///     <see cref="ControlPlaneDbContext"/> model) and are destroyed by the
+///     upstream <c>DROP SCHEMA … CASCADE</c> — this CP step must not, and
+///     cannot, reach them.</description></item>
+/// </list>
+///
+/// <para>Idempotent + single <c>SaveChanges</c>: the whole disposition is
+/// one unit of work, so a replay after a partial commit re-runs cleanly
+/// (already-deleted rows match nothing; already-nulled FKs are no-ops). A
+/// failure records into the per-step accumulator → the terminal emits
+/// <c>TENANT.DELETE.FAILED</c> + quarantine.</para>
+/// </summary>
+[Activity(
+    "Tamma.TenantLifecycle",
+    "Cleanup Tenant Relationships",
+    "Delete/null CP rows keyed off the tenant (memberships, invites, installations, queued tasks, ...). Continue-on-error.",
+    Kind = ActivityKind.Task)]
+public sealed class CleanupTenantRelationshipsActivity : CleanupStepActivity
+{
+    public override string StepName => CleanupSteps.CleanupRelationships;
+
+    protected override async Task DoStepAsync(
+        ActivityExecutionContext context,
+        Guid tenantId)
+    {
+        var factory = context.GetRequiredService<IDbContextFactory<ControlPlaneDbContext>>();
+        await using var db = await factory.CreateDbContextAsync(context.CancellationToken)
+            .ConfigureAwait(false);
+
+        var removed = await CleanupRelationshipsAsync(db, tenantId, context.CancellationToken)
+            .ConfigureAwait(false);
+
+        Logger?.LogInformation(
+            "tenant.delete.cleanup_relationships completed tenantId={TenantId} "
+            + "memberships={Memberships} invites={Invites} installationsReleased={Installations} "
+            + "queuedTasks={QueuedTasks} enablements={Enablements} "
+            + "alertChannels={AlertChannels} apiKeys={ApiKeys}",
+            tenantId,
+            removed.Memberships, removed.Invites, removed.InstallationsReleased,
+            removed.QueuedTasks, removed.Enablements,
+            removed.AlertChannels, removed.ApiKeys);
+    }
+
+    /// <summary>
+    /// Pure-DI entry point — testable against an EF InMemory
+    /// <see cref="ControlPlaneDbContext"/> without a live Elsa runtime.
+    /// Deletes/nulls every tenant-keyed CP row per the disposition policy
+    /// in a single <c>SaveChanges</c>. Audit-retained tables
+    /// (billing_customers, audit_records, platform_events) are left
+    /// untouched. Returns per-table counts for the structured log.
+    /// </summary>
+    public static async Task<RelationshipCleanupResult> CleanupRelationshipsAsync(
+        ControlPlaneDbContext db,
+        Guid tenantId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+
+        // ── Delete: operational rows with no post-deletion audit value ──
+        var memberships = await db.TenantMemberships
+            .IgnoreQueryFilters()
+            .Where(m => m.TenantId == tenantId)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        db.TenantMemberships.RemoveRange(memberships);
+
+        var invites = await db.UserInvites
+            .IgnoreQueryFilters()
+            .Where(i => i.TenantId == tenantId)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        db.UserInvites.RemoveRange(invites);
+
+        // Pending platform_queued_tasks only — completed/dead_letter rows
+        // stay as their own audit trail; a pending row pointed at a gone
+        // tenant would dead-letter forever otherwise.
+        var queuedTasks = await db.PlatformQueuedTasks
+            .Where(q => q.TenantId == tenantId && q.Status == "pending")
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        db.PlatformQueuedTasks.RemoveRange(queuedTasks);
+
+        var enablements = await db.TenantAgentEnablements
+            .IgnoreQueryFilters()
+            .Where(e => e.TenantId == tenantId)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        db.TenantAgentEnablements.RemoveRange(enablements);
+
+        var alertChannels = await db.AlertChannels
+            .IgnoreQueryFilters()
+            .Where(a => a.TenantId == tenantId)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        db.AlertChannels.RemoveRange(alertChannels);
+
+        // api_keys revoked outright — the credentials must stop working the
+        // instant the tenant is deleted, and a dangling key against a
+        // soft-deleted tenant is a standing security liability.
+        var apiKeys = await db.ApiKeys
+            .IgnoreQueryFilters()
+            .Where(k => k.TenantId == tenantId)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        db.ApiKeys.RemoveRange(apiKeys);
+
+        // ── Null the FK: github_installations is org-owned, not
+        //    tenant-owned. Release it for re-binding; keep the record. ──
+        var installations = await db.GitHubInstallations
+            .IgnoreQueryFilters()
+            .Where(g => g.TenantId == tenantId)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        foreach (var installation in installations)
+            installation.TenantId = null;
+
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return new RelationshipCleanupResult(
+            Memberships: memberships.Count,
+            Invites: invites.Count,
+            QueuedTasks: queuedTasks.Count,
+            Enablements: enablements.Count,
+            AlertChannels: alertChannels.Count,
+            ApiKeys: apiKeys.Count,
+            InstallationsReleased: installations.Count);
+    }
+
+    /// <summary>Per-table disposition counts returned by
+    /// <see cref="CleanupRelationshipsAsync"/> for the structured log +
+    /// test assertions.</summary>
+    public readonly record struct RelationshipCleanupResult(
+        int Memberships,
+        int Invites,
+        int QueuedTasks,
+        int Enablements,
+        int AlertChannels,
+        int ApiKeys,
+        int InstallationsReleased);
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/EmitCleanupTerminalEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/EmitCleanupTerminalEventActivity.cs
@@ -72,9 +72,15 @@ public static class CleanupSteps
     public const string CleanupRelationships = "cleanup-cp-relationships";
 
     // ── Story 28-5 item #3 — delete-workflow pre-destructive steps ──
-    /// <summary>Flip tenants.Status='deleting' before the destructive
-    /// span (continue-on-error variant for the delete workflow).</summary>
+    /// <summary>Confirm tenants.Status='deleting' before the destructive
+    /// span (continue-on-error variant for the delete workflow). Aborts the
+    /// run — does NOT resurrect — if the tenant was cancelled.</summary>
     public const string MarkDeleting = "mark-deleting";
+
+    /// <summary>Cancellation guard re-read of tenants.Status IMMEDIATELY
+    /// before DROP SCHEMA — aborts the run if the tenant left 'deleting'
+    /// (fail-closed). Closes the dispatch→cancel→drop race.</summary>
+    public const string GuardDeleting = "guard-deleting";
 
     /// <summary>Optional pg_dump backup taken before the schema drop
     /// (continue-on-error variant for the delete workflow).</summary>
@@ -97,6 +103,21 @@ internal static class CleanupWorkflowVariables
 
     /// <summary>JSON list of succeeded step names (string[]).</summary>
     public const string SucceededStepsJson = "Tenant.CleanupStep.SucceededSteps";
+
+    /// <summary>JSON list of skipped step names (string[]) — steps that did
+    /// not run because the run aborted upstream.</summary>
+    public const string SkippedStepsJson = "Tenant.CleanupStep.SkippedSteps";
+
+    /// <summary>Bool flag — the run was aborted (cancelled out of
+    /// <c>deleting</c>) before the destructive span. Set by the mark /
+    /// cancellation-guard steps; read by every subsequent step (to skip its
+    /// destructive work) and by the terminal (to emit
+    /// <c>TENANT.DELETE.ABORTED</c> instead of dropping the schema).</summary>
+    public const string AbortedFlag = "Tenant.CleanupStep.Aborted";
+
+    /// <summary>String — human-readable abort reason for the terminal event
+    /// + log (e.g. "tenant no longer 'deleting' (status=active)").</summary>
+    public const string AbortReason = "Tenant.CleanupStep.AbortReason";
 
     /// <summary>Per-step Success flag — for fast lookup. Variable name
     /// pattern: <c>Tenant.CleanupStep.{stepName}.Success</c> (bool).</summary>
@@ -122,6 +143,7 @@ public interface ICleanupStateStore
     string? GetString(string variable);
     void SetString(string variable, string? value);
     void SetBool(string variable, bool value);
+    bool? GetBool(string variable);
 }
 
 /// <summary>
@@ -145,6 +167,9 @@ internal sealed class ActivityContextStateStore : ICleanupStateStore
 
     public void SetBool(string variable, bool value) =>
         _context.SetVariable(variable, value);
+
+    public bool? GetBool(string variable) =>
+        _context.GetVariable<bool?>(variable);
 }
 
 /// <summary>
@@ -209,6 +234,21 @@ public static class CleanupWorkflowState
         ActivityExecutionContext context) =>
         GetStepDetails(new ActivityContextStateStore(context));
 
+    public static void RecordSkipped(ActivityExecutionContext context, string step) =>
+        RecordSkipped(new ActivityContextStateStore(context), step);
+
+    public static IReadOnlyList<string> GetSkippedSteps(ActivityExecutionContext context) =>
+        GetSkippedSteps(new ActivityContextStateStore(context));
+
+    public static void MarkAborted(ActivityExecutionContext context, string reason) =>
+        MarkAborted(new ActivityContextStateStore(context), reason);
+
+    public static bool IsAborted(ActivityExecutionContext context) =>
+        IsAborted(new ActivityContextStateStore(context));
+
+    public static string? GetAbortReason(ActivityExecutionContext context) =>
+        GetAbortReason(new ActivityContextStateStore(context));
+
     // ── Pure store-bound implementations (testable) ──────────────────
 
     /// <summary>Mark a step as succeeded — appends to the in-flight
@@ -252,6 +292,39 @@ public static class CleanupWorkflowState
 
     public static IReadOnlyDictionary<string, string> GetStepDetails(ICleanupStateStore store) =>
         ReadStepDetails(store);
+
+    /// <summary>Mark a step as skipped — it did not run because the run was
+    /// aborted (cancelled) upstream. Tracked separately from succeeded /
+    /// failed so the terminal abort summary is honest about what ran.</summary>
+    public static void RecordSkipped(ICleanupStateStore store, string step)
+    {
+        var skipped = ReadStepList(store, CleanupWorkflowVariables.SkippedStepsJson);
+        if (!skipped.Contains(step))
+            skipped.Add(step);
+        WriteStepList(store, CleanupWorkflowVariables.SkippedStepsJson, skipped);
+    }
+
+    public static IReadOnlyList<string> GetSkippedSteps(ICleanupStateStore store) =>
+        ReadStepList(store, CleanupWorkflowVariables.SkippedStepsJson);
+
+    /// <summary>
+    /// Set the run-aborted flag (idempotent — keeps the FIRST reason). Once
+    /// set, every subsequent <see cref="CleanupStepActivity"/> skips its
+    /// destructive work and the terminal emits <c>TENANT.DELETE.ABORTED</c>
+    /// without dropping the schema or soft-deleting the row.
+    /// </summary>
+    public static void MarkAborted(ICleanupStateStore store, string reason)
+    {
+        store.SetBool(CleanupWorkflowVariables.AbortedFlag, true);
+        if (string.IsNullOrEmpty(store.GetString(CleanupWorkflowVariables.AbortReason)))
+            store.SetString(CleanupWorkflowVariables.AbortReason, reason);
+    }
+
+    public static bool IsAborted(ICleanupStateStore store) =>
+        store.GetBool(CleanupWorkflowVariables.AbortedFlag) == true;
+
+    public static string? GetAbortReason(ICleanupStateStore store) =>
+        store.GetString(CleanupWorkflowVariables.AbortReason);
 
     private static List<string> ReadStepList(ICleanupStateStore store, string variable)
     {
@@ -341,6 +414,17 @@ public abstract class CleanupStepActivity : TammaAsyncActivity
     /// flags.</summary>
     public abstract string StepName { get; }
 
+    /// <summary>
+    /// Whether this step is SKIPPED (its <see cref="DoStepAsync"/> is not
+    /// invoked) once the run has been aborted via
+    /// <see cref="CleanupWorkflowState.MarkAborted(ActivityExecutionContext,string)"/>.
+    /// Defaults to <c>true</c> — every DESTRUCTIVE step must skip on abort so
+    /// a cancelled tenant is never torn down. The mark-deleting + cancellation
+    /// guard steps (which DETECT cancellation and set the abort flag
+    /// themselves) override this to <c>false</c> so they always run.
+    /// </summary>
+    protected virtual bool SkipWhenAborted => true;
+
     public override string? EventType => $"TENANT.CLEANUP.{StepName.ToUpperInvariant().Replace('-', '_')}";
 
     protected sealed override async Task RunAsync(ActivityExecutionContext context)
@@ -350,6 +434,24 @@ public abstract class CleanupStepActivity : TammaAsyncActivity
         var tenantId = ResolveTenantId(context);
         var attempt = ResolveAttempt(context);
         var publisher = context.GetRequiredService<IPlatformEventPublisher>();
+
+        // CRITICAL (cancellation race) — if the run was aborted upstream (the
+        // tenant was cancelled out of 'deleting' before the destructive span),
+        // every destructive step must SKIP its work. Without this, a cancel
+        // that lands after dispatch would still be steamrolled by the in-flight
+        // workflow dropping the schema. The terminal emits TENANT.DELETE.ABORTED.
+        if (SkipWhenAborted && CleanupWorkflowState.IsAborted(context))
+        {
+            CleanupWorkflowState.RecordSkipped(context, StepName);
+            Logger?.LogInformation(
+                "tenant.delete.step_skipped_aborted step={Step} tenantId={TenantId} reason={Reason}",
+                StepName, tenantId, CleanupWorkflowState.GetAbortReason(context));
+            await SafePublish(publisher, BuildStepEvent(
+                TenantLifecycleEvents.DeleteStepSkipped, tenantId, attempt,
+                errorType: "aborted",
+                redactedMessage: CleanupWorkflowState.GetAbortReason(context) ?? "run aborted"));
+            return;
+        }
 
         if (tenantId == Guid.Empty)
         {

--- a/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/EmitCleanupTerminalEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/EmitCleanupTerminalEventActivity.cs
@@ -63,6 +63,22 @@ public static class CleanupSteps
 
     public const string DropRole = "drop-tenant-role";
     public const string SoftDeleteRow = "soft-delete-cp-row";
+
+    // ── Story 28-5 item #4 — delete-workflow CP relationship cleanup ──
+    /// <summary>CP-side relationship cleanup (memberships, invites,
+    /// installations, queued tasks, tenant-keyed rows). Distinct from the
+    /// destructive DDL steps so a relationship-row failure is attributed
+    /// to its own step in the terminal failure summary.</summary>
+    public const string CleanupRelationships = "cleanup-cp-relationships";
+
+    // ── Story 28-5 item #3 — delete-workflow pre-destructive steps ──
+    /// <summary>Flip tenants.Status='deleting' before the destructive
+    /// span (continue-on-error variant for the delete workflow).</summary>
+    public const string MarkDeleting = "mark-deleting";
+
+    /// <summary>Optional pg_dump backup taken before the schema drop
+    /// (continue-on-error variant for the delete workflow).</summary>
+    public const string BackupDatabase = "backup-database";
 }
 
 /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/EmitDeleteTerminalEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/EmitDeleteTerminalEventActivity.cs
@@ -1,0 +1,285 @@
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+
+namespace Tamma.Activities.TenantLifecycle;
+
+/// <summary>
+/// Story 28-5 item #3 — terminal step of the rebuilt
+/// <c>DeleteTenantWorkflow</c>. The delete analogue of
+/// <see cref="EmitCleanupTerminalEventActivity"/>: it reads the accumulated
+/// per-step state and emits EXACTLY ONE terminal event.
+///
+/// <list type="bullet">
+///   <item><description><b>All destructive steps succeeded</b> →
+///     soft-delete the CP row (<c>DeletedAt</c>, <c>Status='deleted'</c>,
+///     null the encrypted connection string), release the unified-tenancy
+///     placement (pool <c>TenantCount</c> decrement + <c>DatabaseId</c>/
+///     <c>SchemaName</c> nulled) in the same <c>SaveChanges</c>, and emit
+///     <c>TENANT.DELETED.SUCCESS</c>. This folds in what
+///     <see cref="EmitDeletedSuccessActivity"/> used to do as a separate
+///     mid-sequence step.</description></item>
+///   <item><description><b>Any step failed</b> → emit
+///     <c>TENANT.DELETE.FAILED</c> with a <c>failedSteps</c> array + the
+///     redacted per-step detail, and set
+///     <c>tenants.ProvisioningState='requires_manual_cleanup'</c> so an
+///     operator sees the row needs intervention. The row is left
+///     recoverable via <c>POST /cleanup</c>; it is NOT soft-deleted.</description></item>
+/// </list>
+///
+/// <para><b>Why fold the soft-delete in here</b>: the previous shape
+/// soft-deleted in a mid-sequence <see cref="EmitDeletedSuccessActivity"/>
+/// and a later throw would leave a soft-deleted row with a still-failed
+/// teardown. Folding the soft-delete into the terminal means the row is
+/// only marked deleted when every destructive step actually succeeded —
+/// fail-closed.</para>
+///
+/// <para><b>Single terminal event invariant</b>: only this activity emits
+/// a terminal event; the per-step activities emit
+/// <c>TENANT.DELETE.STEP_*</c> markers (step-scoped, not terminal).</para>
+/// </summary>
+[Activity(
+    "Tamma.TenantLifecycle",
+    "Emit Delete Terminal Event",
+    "Read accumulated step state; on full success soft-delete row + release placement + emit TENANT.DELETED.SUCCESS, else emit TENANT.DELETE.FAILED + quarantine.",
+    Kind = ActivityKind.Task)]
+public sealed class EmitDeleteTerminalEventActivity : TammaAsyncActivity
+{
+    private const int MaxSummaryChars = 1900;
+
+    [Input(Description = "Tenant id whose delete is concluding. If unbound, reads the workflow variable 'TenantId'.")]
+    public Input<Guid> TenantId { get; set; } = new(Guid.Empty);
+
+    public override string? EventType => "TENANT.DELETE.TERMINAL";
+
+    protected override async Task RunAsync(ActivityExecutionContext context)
+    {
+        Logger ??= context.GetService<ILogger<EmitDeleteTerminalEventActivity>>();
+
+        var tenantId = ResolveTenantId(context);
+
+        var failedSteps = CleanupWorkflowState.GetFailedSteps(context);
+        var succeededSteps = CleanupWorkflowState.GetSucceededSteps(context);
+        var stepDetails = CleanupWorkflowState.GetStepDetails(context);
+
+        if (tenantId == Guid.Empty)
+        {
+            Logger?.LogError(
+                "tenant.delete.terminal_event_skipped reason=empty_tenant_id failedSteps={FailedSteps}",
+                string.Join(",", failedSteps));
+            return;
+        }
+
+        var publisher = context.GetRequiredService<IPlatformEventPublisher>();
+
+        if (failedSteps.Count == 0)
+        {
+            // Full success — soft-delete + release placement in ONE save,
+            // then fire the terminal success event. Fail-closed: if the
+            // soft-delete itself throws, we fall through to the FAILED
+            // path rather than reporting a success the row doesn't reflect.
+            var softDeleted = await TrySoftDeleteAndReleaseAsync(context, tenantId)
+                .ConfigureAwait(false);
+
+            if (softDeleted)
+            {
+                await publisher.AppendAndPublishAsync(
+                    TenantLifecycleEvents.BuildEvent(
+                        TenantLifecycleEvents.DeletedSuccess,
+                        tenantId,
+                        data: new Dictionary<string, object?>
+                        {
+                            ["source"] = "delete-workflow",
+                            ["deletedAt"] = DateTime.UtcNow,
+                            ["succeededSteps"] = succeededSteps,
+                        }),
+                    context.CancellationToken).ConfigureAwait(false);
+
+                Logger?.LogInformation(
+                    "tenant.delete.success tenantId={TenantId} succeededSteps={SucceededSteps}",
+                    tenantId, string.Join(",", succeededSteps));
+                return;
+            }
+
+            // Soft-delete failed even though every prior step succeeded —
+            // attribute it as a failed terminal step and quarantine.
+            var detail = $"{CleanupSteps.SoftDeleteRow}: soft-delete + placement release failed";
+            var syntheticFailed = new List<string> { CleanupSteps.SoftDeleteRow };
+            var syntheticDetails = new Dictionary<string, string>
+            {
+                [CleanupSteps.SoftDeleteRow] = detail,
+            };
+            await EmitFailedAsync(
+                context, publisher, tenantId, syntheticFailed, succeededSteps, syntheticDetails)
+                .ConfigureAwait(false);
+            return;
+        }
+
+        await EmitFailedAsync(
+            context, publisher, tenantId, failedSteps, succeededSteps, stepDetails)
+            .ConfigureAwait(false);
+    }
+
+    private async Task EmitFailedAsync(
+        ActivityExecutionContext context,
+        IPlatformEventPublisher publisher,
+        Guid tenantId,
+        IReadOnlyList<string> failedSteps,
+        IReadOnlyList<string> succeededSteps,
+        IReadOnlyDictionary<string, string> stepDetails)
+    {
+        await QuarantineRowAsync(context, tenantId, failedSteps, stepDetails)
+            .ConfigureAwait(false);
+
+        await publisher.AppendAndPublishAsync(
+            TenantLifecycleEvents.BuildEvent(
+                TenantLifecycleEvents.DeleteFailed,
+                tenantId,
+                data: new Dictionary<string, object?>
+                {
+                    ["source"] = "delete-workflow",
+                    ["failedSteps"] = failedSteps,
+                    ["succeededSteps"] = succeededSteps,
+                    ["stepDetails"] = stepDetails,
+                    ["requiresManualCleanup"] = true,
+                }),
+            context.CancellationToken).ConfigureAwait(false);
+
+        Logger?.LogWarning(
+            "tenant.delete.partial tenantId={TenantId} failedSteps={FailedSteps} succeededSteps={SucceededSteps}",
+            tenantId,
+            string.Join(",", failedSteps),
+            string.Join(",", succeededSteps));
+    }
+
+    /// <summary>
+    /// Soft-delete the CP row + release the placement in a single
+    /// <c>SaveChanges</c>. Returns false (without throwing) on any
+    /// failure so the caller can route to the FAILED terminal — the
+    /// terminal event must always fire.
+    /// </summary>
+    private async Task<bool> TrySoftDeleteAndReleaseAsync(
+        ActivityExecutionContext context,
+        Guid tenantId)
+    {
+        try
+        {
+            var factory = context.GetRequiredService<IDbContextFactory<ControlPlaneDbContext>>();
+            await using var db = await factory
+                .CreateDbContextAsync(context.CancellationToken)
+                .ConfigureAwait(false);
+
+            var tenant = await db.Tenants
+                .IgnoreQueryFilters()
+                .FirstOrDefaultAsync(t => t.Id == tenantId, context.CancellationToken)
+                .ConfigureAwait(false);
+            if (tenant is null)
+            {
+                Logger?.LogWarning(
+                    "tenant.delete.terminal_row_not_found tenantId={TenantId}", tenantId);
+                return false;
+            }
+
+            if (tenant.DeletedAt is null)
+                tenant.DeletedAt = DateTime.UtcNow;
+            tenant.UpdatedAt = DateTime.UtcNow;
+            db.Entry(tenant).Property("Status").CurrentValue = "deleted";
+            db.Entry(tenant).Property("EncryptedConnectionString").CurrentValue = (byte[]?)null;
+            // KekVersion is smallint NOT NULL DEFAULT 1 — clearing is a no-op.
+
+            tenant.ProvisioningState = "none";
+            tenant.ProvisioningUpdatedAt = DateTime.UtcNow;
+
+            await TenantPlacementShadow.ReleaseAsync(
+                db, tenant, Logger, context.CancellationToken).ConfigureAwait(false);
+
+            await db.SaveChangesAsync(context.CancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Logger?.LogError(
+                ex, "tenant.delete.soft_delete_failed tenantId={TenantId}", tenantId);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Flag the row for manual cleanup on partial failure — best-effort,
+    /// like the cleanup sibling. Even if the row stamp fails the terminal
+    /// FAILED event still fires so the dashboard sees the run completed.
+    /// </summary>
+    private async Task QuarantineRowAsync(
+        ActivityExecutionContext context,
+        Guid tenantId,
+        IReadOnlyList<string> failedSteps,
+        IReadOnlyDictionary<string, string> stepDetails)
+    {
+        try
+        {
+            var factory = context.GetRequiredService<IDbContextFactory<ControlPlaneDbContext>>();
+            await using var db = await factory
+                .CreateDbContextAsync(context.CancellationToken)
+                .ConfigureAwait(false);
+
+            var tenant = await db.Tenants
+                .IgnoreQueryFilters()
+                .FirstOrDefaultAsync(t => t.Id == tenantId, context.CancellationToken)
+                .ConfigureAwait(false);
+            if (tenant is null)
+            {
+                Logger?.LogWarning(
+                    "tenant.delete.terminal_row_not_found tenantId={TenantId}", tenantId);
+                return;
+            }
+
+            tenant.UpdatedAt = DateTime.UtcNow;
+            tenant.ProvisioningState = "requires_manual_cleanup";
+            tenant.ProvisioningDetail = BuildFailureSummary(failedSteps, stepDetails);
+            tenant.ProvisioningUpdatedAt = DateTime.UtcNow;
+            await db.SaveChangesAsync(context.CancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Logger?.LogError(
+                ex, "tenant.delete.terminal_row_update_failed tenantId={TenantId}", tenantId);
+        }
+    }
+
+    private Guid ResolveTenantId(ActivityExecutionContext context)
+    {
+        var bound = TenantId.Get(context);
+        if (bound != Guid.Empty) return bound;
+        var raw = context.GetVariable<object?>("TenantId");
+        return raw switch
+        {
+            Guid g => g,
+            string s when Guid.TryParse(s, out var p) => p,
+            _ => Guid.Empty,
+        };
+    }
+
+    private static string BuildFailureSummary(
+        IReadOnlyList<string> failedSteps,
+        IReadOnlyDictionary<string, string> details)
+    {
+        var summary = $"Delete partial — {failedSteps.Count} step(s) failed: " +
+            string.Join("; ",
+                failedSteps.Select(s => $"{s}: {(details.TryGetValue(s, out var d) ? d : "(no detail)")}"));
+        return summary.Length > MaxSummaryChars ? summary[..MaxSummaryChars] : summary;
+    }
+
+    /// <summary>Exposed for test callers — same truncation contract used by
+    /// the activity at runtime.</summary>
+    public static string BuildFailureSummaryForTesting(
+        IReadOnlyList<string> failedSteps,
+        IReadOnlyDictionary<string, string> details) =>
+        BuildFailureSummary(failedSteps, details);
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/EmitDeleteTerminalEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/EmitDeleteTerminalEventActivity.cs
@@ -43,7 +43,23 @@ namespace Tamma.Activities.TenantLifecycle;
 ///
 /// <para><b>Single terminal event invariant</b>: only this activity emits
 /// a terminal event; the per-step activities emit
-/// <c>TENANT.DELETE.STEP_*</c> markers (step-scoped, not terminal).</para>
+/// <c>TENANT.DELETE.STEP_*</c> markers (step-scoped, not terminal). A
+/// workflow-variable replay guard (<see cref="TerminalEmittedFlag"/>) keeps
+/// the terminal to ONE emission even under an Elsa replay.</para>
+///
+/// <para><b>Where the authoritative outcome lives.</b> The reliable signal of
+/// teardown completion is the <c>tenants</c> COLUMNS this activity writes
+/// DIRECTLY via <see cref="IDbContextFactory{ControlPlaneDbContext}"/>
+/// (<c>Status='deleted'</c> + <c>DeletedAt</c> + nulled connection envelope +
+/// released placement on success; <c>ProvisioningState='requires_manual_cleanup'</c>
+/// on partial failure) — those persist regardless of the event sink. The
+/// terminal <c>platform_events</c> rows are the DCB AUDIT signal, and in the
+/// engine process they currently route to <see cref="NullPlatformEventPublisher"/>
+/// (no-op) — DCB terminal-event DURABILITY therefore depends on the
+/// engine→<c>platform_events</c> callback FOLLOW-UP (the systemic gap tracked
+/// for all tenant-lifecycle workflows; NOT wired in this change). Until that
+/// callback lands, do not treat "exactly one terminal event reached the audit
+/// stream" as guaranteed — the column state is what is authoritative.</para>
 /// </summary>
 [Activity(
     "Tamma.TenantLifecycle",
@@ -58,6 +74,11 @@ public sealed class EmitDeleteTerminalEventActivity : TammaAsyncActivity
     public Input<Guid> TenantId { get; set; } = new(Guid.Empty);
 
     public override string? EventType => "TENANT.DELETE.TERMINAL";
+
+    /// <summary>Workflow variable guarding against a duplicate terminal emit
+    /// under an Elsa replay (the terminal is not a CleanupStepActivity, so it
+    /// doesn't ride the per-step dedup index — this is its replay guard).</summary>
+    internal const string TerminalEmittedFlag = "Tenant.Delete.TerminalEmitted";
 
     protected override async Task RunAsync(ActivityExecutionContext context)
     {
@@ -77,7 +98,50 @@ public sealed class EmitDeleteTerminalEventActivity : TammaAsyncActivity
             return;
         }
 
+        // Replay guard — exactly ONE terminal per run. If an Elsa replay re-runs
+        // the terminal after it already emitted, short-circuit so we don't fire
+        // a second terminal event (or re-soft-delete / re-release placement).
+        // The flag lives in the workflow variable bag, so it survives the same
+        // suspend/replay checkpoints the per-step accumulator does.
+        if (context.GetVariable<bool?>(TerminalEmittedFlag) == true)
+        {
+            Logger?.LogInformation(
+                "tenant.delete.terminal_replay_skipped tenantId={TenantId}", tenantId);
+            return;
+        }
+        context.SetVariable(TerminalEmittedFlag, true);
+
         var publisher = context.GetRequiredService<IPlatformEventPublisher>();
+
+        // CRITICAL (cancellation race) — the run was aborted before the
+        // destructive span (an operator cancelled the delete during the
+        // cooling-off window and a cancellation guard caught it). This is the
+        // NON-destructive terminal: the schema was NOT dropped and the row is
+        // NOT soft-deleted. Emit TENANT.DELETE.ABORTED and leave the tenant in
+        // whatever state the operator restored it to. This is what protects a
+        // cancelled tenant from being irreversibly dropped.
+        if (CleanupWorkflowState.IsAborted(context))
+        {
+            var skippedSteps = CleanupWorkflowState.GetSkippedSteps(context);
+            var reason = CleanupWorkflowState.GetAbortReason(context) ?? "delete cancelled";
+            await publisher.AppendAndPublishAsync(
+                TenantLifecycleEvents.BuildEvent(
+                    TenantLifecycleEvents.DeleteAborted,
+                    tenantId,
+                    data: new Dictionary<string, object?>
+                    {
+                        ["source"] = "delete-workflow",
+                        ["reason"] = reason,
+                        ["skippedSteps"] = skippedSteps,
+                        ["abortedAt"] = DateTime.UtcNow,
+                    }),
+                context.CancellationToken).ConfigureAwait(false);
+
+            Logger?.LogWarning(
+                "tenant.delete.aborted tenantId={TenantId} reason={Reason} skippedSteps={SkippedSteps}",
+                tenantId, reason, string.Join(",", skippedSteps));
+            return;
+        }
 
         if (failedSteps.Count == 0)
         {

--- a/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/TenantLifecycleActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/TenantLifecycleActivity.cs
@@ -57,6 +57,19 @@ public abstract class TenantLifecycleActivity : TammaAsyncActivity
     /// override this to <c>false</c>.</summary>
     protected virtual bool EmitStepEvents => true;
 
+    /// <summary>
+    /// Story 28-5 item #6 — which <c>STEP_*</c> event family this activity
+    /// emits. Create-path steps use the default
+    /// <see cref="TenantStepEventFamily.Provision"/> family
+    /// (<c>TENANT.PROVISION.STEP_*</c>); delete-path steps override this to
+    /// <see cref="TenantStepEventFamily.Delete"/> so they emit
+    /// <c>TENANT.DELETE.STEP_*</c> instead of polluting the provision
+    /// timeline + the 28-11 dashboards. The constants already exist on
+    /// <see cref="TenantLifecycleEvents"/>.
+    /// </summary>
+    protected virtual TenantStepEventFamily StepEventFamily =>
+        TenantStepEventFamily.Provision;
+
     public override string? EventType => $"TENANT.LIFECYCLE.{StepName.ToUpperInvariant().Replace('-', '_')}";
 
     protected sealed override async Task RunAsync(ActivityExecutionContext context)
@@ -66,11 +79,13 @@ public abstract class TenantLifecycleActivity : TammaAsyncActivity
         var publisher = context.GetRequiredService<IPlatformEventPublisher>();
         Logger ??= context.GetService<ILogger<TenantLifecycleActivity>>();
 
+        var (started, completed, failed) = StepEventNames(StepEventFamily);
+
         if (EmitStepEvents)
         {
             await publisher.AppendAndPublishAsync(
                 TenantLifecycleEvents.BuildEvent(
-                    TenantLifecycleEvents.ProvisionStepStarted,
+                    started,
                     tenantId,
                     step: StepName,
                     attempt: attempt),
@@ -89,7 +104,7 @@ public abstract class TenantLifecycleActivity : TammaAsyncActivity
                 {
                     await publisher.AppendAndPublishAsync(
                         TenantLifecycleEvents.BuildEvent(
-                            TenantLifecycleEvents.ProvisionStepFailed,
+                            failed,
                             tenantId,
                             step: StepName,
                             attempt: attempt,
@@ -119,13 +134,36 @@ public abstract class TenantLifecycleActivity : TammaAsyncActivity
         {
             await publisher.AppendAndPublishAsync(
                 TenantLifecycleEvents.BuildEvent(
-                    TenantLifecycleEvents.ProvisionStepCompleted,
+                    completed,
                     tenantId,
                     step: StepName,
                     attempt: attempt),
                 context.CancellationToken).ConfigureAwait(false);
         }
     }
+
+    /// <summary>
+    /// Resolves the started/completed/failed event-type triple for a step
+    /// event family. Exposed via <see cref="StepEventNamesFor"/> for tests.
+    /// </summary>
+    private static (string Started, string Completed, string Failed) StepEventNames(
+        TenantStepEventFamily family) =>
+        family switch
+        {
+            TenantStepEventFamily.Delete => (
+                TenantLifecycleEvents.DeleteStepStarted,
+                TenantLifecycleEvents.DeleteStepCompleted,
+                TenantLifecycleEvents.DeleteStepFailed),
+            _ => (
+                TenantLifecycleEvents.ProvisionStepStarted,
+                TenantLifecycleEvents.ProvisionStepCompleted,
+                TenantLifecycleEvents.ProvisionStepFailed),
+        };
+
+    /// <summary>Test seam — the same started/completed/failed triple the
+    /// base uses at runtime for a given family.</summary>
+    public static (string Started, string Completed, string Failed) StepEventNamesFor(
+        TenantStepEventFamily family) => StepEventNames(family);
 
     /// <summary>
     /// Concrete activities implement this. <paramref name="tenantId"/> +
@@ -145,4 +183,21 @@ public abstract class TenantLifecycleActivity : TammaAsyncActivity
         var raw = Attempt.Get(context);
         return raw <= 0 ? 1 : raw;
     }
+}
+
+/// <summary>
+/// Story 28-5 item #6 — which <c>TENANT.*.STEP_*</c> event family a
+/// <see cref="TenantLifecycleActivity"/> step emits. Create-path steps use
+/// <see cref="Provision"/> (<c>TENANT.PROVISION.STEP_*</c>); delete-path
+/// steps use <see cref="Delete"/> (<c>TENANT.DELETE.STEP_*</c>) so the
+/// teardown timeline + the 28-11 dashboards are not polluted with provision
+/// markers.
+/// </summary>
+public enum TenantStepEventFamily
+{
+    /// <summary>Emit <c>TENANT.PROVISION.STEP_*</c> (create path, default).</summary>
+    Provision,
+
+    /// <summary>Emit <c>TENANT.DELETE.STEP_*</c> (delete path).</summary>
+    Delete,
 }

--- a/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/TenantLifecycleEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/TenantLifecycleEvents.cs
@@ -52,6 +52,14 @@ public static class TenantLifecycleEvents
     public const string DeleteStepCompleted = "TENANT.DELETE.STEP_COMPLETED";
     public const string DeleteStepFailed = "TENANT.DELETE.STEP_FAILED";
     public const string DeletedSuccess = "TENANT.DELETED.SUCCESS";
+
+    /// <summary>Terminal delete failure — emitted by the single terminal
+    /// step when any destructive step failed; carries a <c>failedSteps</c>
+    /// array and pairs with <c>ProvisioningState='requires_manual_cleanup'</c>.
+    /// The cleanup sibling already emits this literal string; the constant
+    /// centralises it so delete + cleanup agree.</summary>
+    public const string DeleteFailed = "TENANT.DELETE.FAILED";
+
     public const string DeleteCancelled = "TENANT.DELETE_CANCELLED";
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/TenantLifecycleEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/TenantLifecycleEvents.cs
@@ -48,10 +48,42 @@ public static class TenantLifecycleEvents
     public const string ProvisionFailed = "TENANT.PROVISION.FAILED";
 
     public const string DeleteRequested = "TENANT.DELETE.REQUESTED";
+
+    /// <summary>
+    /// Marker the delete WORKFLOW emits once it confirms a tenant is still
+    /// <c>deleting</c> and begins the destructive teardown. DISTINCT from
+    /// <see cref="DeleteRequested"/> — the workflow must NOT re-emit the
+    /// trigger's own event type (that is the
+    /// <c>TenantDeleteRequestedTrigger</c> poll target and re-emitting it is
+    /// a self re-dispatch loop). The admin endpoint already emitted
+    /// <see cref="DeleteRequested"/> to start the flow; the workflow signals
+    /// "I have picked this up and started" with this separate marker.
+    /// </summary>
+    public const string DeleteStarted = "TENANT.DELETE.STARTED";
+
     public const string DeleteStepStarted = "TENANT.DELETE.STEP_STARTED";
     public const string DeleteStepCompleted = "TENANT.DELETE.STEP_COMPLETED";
     public const string DeleteStepFailed = "TENANT.DELETE.STEP_FAILED";
+
+    /// <summary>Step-scoped marker emitted when a continue-on-error step is
+    /// SKIPPED because the run aborted upstream (the tenant was cancelled
+    /// out of <c>deleting</c> before the destructive span). Step-scoped,
+    /// not terminal.</summary>
+    public const string DeleteStepSkipped = "TENANT.DELETE.STEP_SKIPPED";
+
     public const string DeletedSuccess = "TENANT.DELETED.SUCCESS";
+
+    /// <summary>
+    /// Terminal delete ABORT — emitted by the single terminal step when the
+    /// run was cancelled before the destructive drop (an operator flipped the
+    /// tenant out of <c>deleting</c> during the cooling-off window, and the
+    /// in-flight workflow's cancellation guard caught it). NON-destructive:
+    /// the tenant is left in whatever state the operator restored it to
+    /// (typically <c>active</c>); the schema is NOT dropped and the row is
+    /// NOT soft-deleted. This is what protects a cancelled tenant from the
+    /// dispatch→cancel→re-flip→drop race.
+    /// </summary>
+    public const string DeleteAborted = "TENANT.DELETE.ABORTED";
 
     /// <summary>Terminal delete failure — emitted by the single terminal
     /// step when any destructive step failed; carries a <c>failedSteps</c>

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminTenantsEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminTenantsEndpoints.cs
@@ -406,15 +406,22 @@ public static class AdminTenantsEndpoints
 
     /// <summary>
     /// Story 28-5 AC4 — cancels a pending tenant deletion during the
-    /// cooling-off window. A tenant in <c>deleting</c> has its
-    /// <c>TenantDeleteRequestedTrigger</c> dispatch suppressed once it flips
-    /// back to <c>active</c> (the trigger re-reads <c>Status</c> immediately
-    /// before dispatch and skips anything that isn't <c>deleting</c>). Flips
-    /// <c>Status</c> → <c>active</c>, clears <c>DeleteRequestedAt</c>,
-    /// invalidates the status cache (+ resolver pool + cluster NOTIFY), and
-    /// emits <c>TENANT.DELETE_CANCELLED</c>. 409 if the tenant is not
-    /// currently <c>deleting</c> (the destructive drop may already have run,
-    /// or never started).
+    /// cooling-off window. Flips <c>Status</c> → <c>active</c>, clears
+    /// <c>DeleteRequestedAt</c>, invalidates the status cache (+ resolver pool
+    /// + cluster NOTIFY), and emits <c>TENANT.DELETE_CANCELLED</c>. 409 if the
+    /// tenant is not currently <c>deleting</c> (the destructive drop may
+    /// already have run, or never started).
+    ///
+    /// <para><b>Cancellation is honoured even AFTER the trigger dispatches.</b>
+    /// The flip back to <c>active</c> is caught at THREE checkpoints: (1) the
+    /// trigger's pre-dispatch re-read (before the workflow even starts); (2)
+    /// the workflow's mark step (top of run); (3) the workflow's cancellation
+    /// guard immediately before <c>DROP SCHEMA</c>. Any of the three aborts the
+    /// teardown (terminal emits <c>TENANT.DELETE.ABORTED</c>), so a cancel that
+    /// races a just-dispatched workflow does NOT result in a dropped schema.
+    /// The only un-cancellable point is after the irreversible drop has
+    /// physically run — at which point the status is no longer <c>deleting</c>
+    /// and this endpoint returns 409.</para>
     /// </summary>
     public static async Task<IResult> CancelDeleteTenant(
         Guid tenantId,

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminTenantsEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminTenantsEndpoints.cs
@@ -402,6 +402,68 @@ public static class AdminTenantsEndpoints
             "Delete queued — cooling-off period begins now; destructive drop runs after the configured delay."));
     }
 
+    // ── POST /api/admin/tenants/{id}/actions/cancel-delete ──
+
+    /// <summary>
+    /// Story 28-5 AC4 — cancels a pending tenant deletion during the
+    /// cooling-off window. A tenant in <c>deleting</c> has its
+    /// <c>TenantDeleteRequestedTrigger</c> dispatch suppressed once it flips
+    /// back to <c>active</c> (the trigger re-reads <c>Status</c> immediately
+    /// before dispatch and skips anything that isn't <c>deleting</c>). Flips
+    /// <c>Status</c> → <c>active</c>, clears <c>DeleteRequestedAt</c>,
+    /// invalidates the status cache (+ resolver pool + cluster NOTIFY), and
+    /// emits <c>TENANT.DELETE_CANCELLED</c>. 409 if the tenant is not
+    /// currently <c>deleting</c> (the destructive drop may already have run,
+    /// or never started).
+    /// </summary>
+    public static async Task<IResult> CancelDeleteTenant(
+        Guid tenantId,
+        ControlPlaneDbContext db,
+        IPlatformEventPublisher publisher,
+        ITenantStatusCache statusCache,
+        ITenantConnectionResolver connectionResolver,
+        ITenantStatusInvalidationBus invalidationBus,
+        [FromServices] TimeProvider timeProvider,
+        ClaimsPrincipal principal,
+        CancellationToken ct = default)
+    {
+        var tenant = await db.Tenants
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(t => t.Id == tenantId && t.DeletedAt == null, ct);
+        if (tenant is null)
+            return Results.NotFound(new { error = "tenant_not_found" });
+
+        var current = (string?)db.Entry(tenant).Property("Status").CurrentValue;
+        if (!IsCancelDeletable(current))
+            return IllegalTransition(current, "cancel-delete");
+
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+        db.Entry(tenant).Property("Status").CurrentValue = StatusActive;
+        db.Entry(tenant).Property("DeleteRequestedAt").CurrentValue = (DateTime?)null;
+        tenant.UpdatedAt = now;
+        await db.SaveChangesAsync(ct);
+        statusCache.Invalidate(tenantId);  // Story 28-8
+        await connectionResolver.EvictAsync(tenantId, ct);  // H12 #2
+        await invalidationBus.PublishAsync(tenantId, ct);  // R2 follow-up — cluster fan-out
+
+        await publisher.AppendAndPublishAsync(
+            BuildAdminEvent(
+                "TENANT.DELETE_CANCELLED",
+                tenantId,
+                principal,
+                new Dictionary<string, object?>
+                {
+                    ["cancelledAt"] = now,
+                    ["source"] = "admin-cancel-delete",
+                }),
+            ct);
+
+        return Results.Ok(new AdminTenantActionResponse(
+            tenantId,
+            StatusActive,
+            "Delete cancelled — tenant restored to active before the destructive drop ran."));
+    }
+
     // ── POST /api/admin/tenants/{id}/actions/force-delete ──
 
     /// <summary>
@@ -870,6 +932,15 @@ public static class AdminTenantsEndpoints
         return string.Equals(status, StatusFailed, StringComparison.OrdinalIgnoreCase)
             || string.Equals(status, StatusDeleting, StringComparison.OrdinalIgnoreCase);
     }
+
+    /// <summary>
+    /// Story 28-5 AC4 — cancel-delete is legal only while the tenant is
+    /// still <c>deleting</c> (i.e. inside the cooling-off window before the
+    /// trigger dispatches the destructive workflow). Once the workflow runs
+    /// the status leaves <c>deleting</c> and the cancel is rejected with 409.
+    /// </summary>
+    private static bool IsCancelDeletable(string? status) =>
+        string.Equals(status, StatusDeleting, StringComparison.OrdinalIgnoreCase);
 
     private static bool IsPlanChangeAllowed(string? status)
     {

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -1577,6 +1577,11 @@ admin.MapPost("/tenants/{tenantId:guid}/actions/delete",
 admin.MapPost("/tenants/{tenantId:guid}/actions/force-delete",
         Tamma.Api.Endpoints.Admin.AdminTenantsEndpoints.ForceDeleteTenant)
     .RequireAuthorization("PlatformOwnerAccess");
+// Story 28-5 AC4 — cancel a pending delete during the cooling-off window.
+// PlatformOwnerAccess (cross-tenant infra state, like delete/force-delete).
+admin.MapPost("/tenants/{tenantId:guid}/actions/cancel-delete",
+        Tamma.Api.Endpoints.Admin.AdminTenantsEndpoints.CancelDeleteTenant)
+    .RequireAuthorization("PlatformOwnerAccess");
 // Story 28-5 AC7 — operator-triggered cleanup of damaged tenants.
 // Story 28-R2 / C1: PlatformOwnerAccess (destructive DDL across DBs).
 admin.MapPost("/tenants/{tenantId:guid}/cleanup",

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
@@ -174,6 +174,16 @@ if (!string.IsNullOrWhiteSpace(cpConnection))
                 .GetSection(Tamma.ElsaServer.Workflows.TenantCleanupRequestedTriggerOptions.SectionName)
                 .Bind(opts));
     builder.Services.AddHostedService<Tamma.ElsaServer.Workflows.TenantCleanupRequestedTrigger>();
+
+    // Story 28-5 item #1 — bridge that dispatches DeleteTenantWorkflow from
+    // TENANT.DELETE.REQUESTED rows (with the cooling-off + operator-cancel
+    // checks). Mirrors the cleanup trigger above.
+    builder.Services.AddOptions<Tamma.ElsaServer.Workflows.TenantDeleteRequestedTriggerOptions>()
+        .Configure(opts =>
+            builder.Configuration
+                .GetSection(Tamma.ElsaServer.Workflows.TenantDeleteRequestedTriggerOptions.SectionName)
+                .Bind(opts));
+    builder.Services.AddHostedService<Tamma.ElsaServer.Workflows.TenantDeleteRequestedTrigger>();
 }
 
 // CORS for Tamma API and Dashboard

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DeleteTenantWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DeleteTenantWorkflow.cs
@@ -30,11 +30,24 @@ namespace Tamma.ElsaServer.Workflows;
 /// 'requires_manual_cleanup'</c>).</para>
 ///
 /// <para>Order: trigger → init → mark-deleting → evict pool → backup
-/// (gated) → drop schema → drop role → CP relationship cleanup → terminal.
-/// Pool eviction precedes <c>DROP SCHEMA … CASCADE</c> so the resolver
-/// releases its cached <c>NpgsqlDataSource</c> first; the backup precedes
-/// the drop; the relationship cleanup precedes the terminal so a
-/// dangling-FK failure is attributed before the soft-delete decision.</para>
+/// (gated) → cancellation guard → drop schema → drop role → CP relationship
+/// cleanup → terminal. Pool eviction precedes <c>DROP SCHEMA … CASCADE</c> so
+/// the resolver releases its cached <c>NpgsqlDataSource</c> first; the backup
+/// precedes the drop; the cancellation guard re-reads <c>Status</c> as the
+/// LAST act before the irreversible drop (closing the
+/// dispatch→cancel→drop race); the relationship cleanup precedes the terminal
+/// so a dangling-FK failure is attributed before the soft-delete decision.</para>
+///
+/// <para><b>Cancellation safety.</b> The mark step (top of run) and the
+/// cancellation guard (immediately before the drop) both re-read
+/// <c>tenants.Status</c> and ABORT the run (via the workflow accumulator's
+/// abort flag) if the tenant is no longer <c>deleting</c> — an operator
+/// cancelled during the cooling-off window. On abort every destructive step
+/// SKIPS and the terminal emits <c>TENANT.DELETE.ABORTED</c> (non-destructive:
+/// no schema drop, no soft-delete). The mark step does NOT re-flip an
+/// <c>active</c> tenant back to <c>deleting</c>, and does NOT re-emit
+/// <c>TENANT.DELETE.REQUESTED</c> (the trigger's own poll target — which would
+/// self re-dispatch).</para>
 ///
 /// <para>Idempotency: every step probes its target (or uses <c>IF EXISTS</c>)
 /// before destructive work, so an Elsa restart between any two steps is
@@ -122,6 +135,19 @@ public class DeleteTenantWorkflow : WorkflowBase
             Attempt = new Input<int>(ctx => attempt.Get(ctx)),
         };
 
+        // ── Step B3: cancellation guard — LAST check before the
+        //    irreversible DROP SCHEMA. Re-reads Status; aborts the run
+        //    (so the drop + role-drop + relationship cleanup all skip and
+        //    the terminal emits TENANT.DELETE.ABORTED) if the operator
+        //    cancelled. Closes the dispatch→cancel→drop race. ────────────
+        var guardDeleting = new GuardTenantDeletingActivity
+        {
+            Id = "GuardTenantDeleting",
+            Name = "Guard Tenant Deleting",
+            TenantId = new Input<Guid>(ctx => tenantId.Get(ctx)),
+            Attempt = new Input<int>(ctx => attempt.Get(ctx)),
+        };
+
         // ── Step C: DROP SCHEMA IF EXISTS t_<hex> CASCADE ───────────────
         var dropSchema = new DropTenantSchemaForCleanupActivity
         {
@@ -166,6 +192,7 @@ public class DeleteTenantWorkflow : WorkflowBase
                 markDeleting,
                 evictPool,
                 backupDatabase,
+                guardDeleting,
                 dropSchema,
                 dropRole,
                 cleanupRelationships,

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DeleteTenantWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DeleteTenantWorkflow.cs
@@ -3,44 +3,73 @@ using Elsa.Workflows;
 using Elsa.Workflows.Activities;
 using Elsa.Workflows.Memory;
 using Elsa.Workflows.Models;
+using Elsa.Workflows.Runtime.Activities;
 using Tamma.Activities.TenantLifecycle;
 
 namespace Tamma.ElsaServer.Workflows;
 
 /// <summary>
-/// Story 28-5 — global Elsa workflow that tears down a tenant. Triggered
-/// by <c>TENANT.DELETE_REQUESTED</c> emitted by the admin endpoint
-/// <c>DELETE /api/admin/tenants/{id}</c>. The workflow flips the tenant
-/// to <c>deleting</c>, optionally honours a cooling-off delay (held by
-/// the trigger / queue, not by this definition), evicts the LRU pool
-/// entry, drops the tenant's schema (unified-tenancy Phase 2 —
-/// schema-per-tenant on the assigned pool database), drops the role, and
-/// emits the terminal <c>TENANT.DELETED.SUCCESS</c> event, releasing the
-/// placement slot in the same save.
+/// Story 28-5 — global Elsa workflow that tears down a tenant. Triggered by
+/// <c>TENANT.DELETE.REQUESTED</c> emitted by the admin endpoint
+/// <c>POST /api/admin/tenants/{id}/actions/delete</c> and bridged to Elsa by
+/// <see cref="TenantDeleteRequestedTrigger"/> (which also enforces the
+/// cooling-off window + the operator-cancel check before dispatch).
 ///
-/// <para>Wall-clock O(1) on tenant data volume — the cost is
-/// <c>DROP SCHEMA … CASCADE</c>, not a row-by-row purge — matching
-/// epic-28 success metric #3 (a tenant with 10 events and a tenant with
-/// 10M events both finish in &lt; 30s).</para>
+/// <para><b>Item #3 rebuild — continue-on-error + single terminal event.</b>
+/// The previous shape was a flat <see cref="Sequence"/> of throwing
+/// <see cref="TenantLifecycleActivity"/> steps: a mid-sequence throw aborted
+/// the run and left the tenant stuck in <c>deleting</c> with NO terminal
+/// event. This rebuild mirrors the sibling
+/// <see cref="CleanUpFailedTenantWorkflow"/>: every destructive step is a
+/// continue-on-error <see cref="CleanupStepActivity"/> (catch → record into
+/// the workflow accumulator → emit <c>TENANT.DELETE.STEP_*</c> → return),
+/// and a single terminal step (<see cref="EmitDeleteTerminalEventActivity"/>)
+/// reads the accumulated state and emits exactly one of
+/// <c>TENANT.DELETED.SUCCESS</c> (soft-delete + placement release folded in)
+/// or <c>TENANT.DELETE.FAILED</c> (+ <c>ProvisioningState=
+/// 'requires_manual_cleanup'</c>).</para>
 ///
-/// <para>Idempotency: every activity probes its target (or uses
-/// <c>IF EXISTS</c>) before performing the destructive work. A workflow
-/// restart between Step C and Step D (schema dropped, role still
-/// present) re-runs both steps; the schema drop is a silent no-op and
-/// the role drop short-circuits if the role is already gone.</para>
+/// <para>Order: trigger → init → mark-deleting → evict pool → backup
+/// (gated) → drop schema → drop role → CP relationship cleanup → terminal.
+/// Pool eviction precedes <c>DROP SCHEMA … CASCADE</c> so the resolver
+/// releases its cached <c>NpgsqlDataSource</c> first; the backup precedes
+/// the drop; the relationship cleanup precedes the terminal so a
+/// dangling-FK failure is attributed before the soft-delete decision.</para>
+///
+/// <para>Idempotency: every step probes its target (or uses <c>IF EXISTS</c>)
+/// before destructive work, so an Elsa restart between any two steps is
+/// safe.</para>
 /// </summary>
 public class DeleteTenantWorkflow : WorkflowBase
 {
+    /// <summary>
+    /// Elsa event name the workflow listens for.
+    /// <see cref="TenantDeleteRequestedTrigger"/> publishes this name through
+    /// <see cref="Elsa.Workflows.Runtime.IEventPublisher"/> when the platform
+    /// event log shows a <c>TENANT.DELETE.REQUESTED</c> row whose cooling-off
+    /// window has elapsed and whose tenant is still <c>deleting</c>.
+    /// </summary>
+    public const string DeleteRequestedEventName = "tenant-delete-requested";
+
     protected override void Build(IWorkflowBuilder builder)
     {
         builder.Name = "Delete Tenant";
         builder.DefinitionId = "delete-tenant";
         builder.Version = WorkflowVersions.ComputedVersion;
         builder.Description =
-            "Tear down a tenant: mark deleting, evict pool, drop schema + role, emit terminal event.";
+            "Tear down a tenant: mark deleting, evict pool, backup, drop schema + role, "
+            + "clean up CP relationships. Each step runs continue-on-error; a single "
+            + "terminal event reports the overall outcome.";
 
         var tenantId = builder.WithVariable<Guid>("TenantId", Guid.Empty);
         var attempt = builder.WithVariable<int>("Attempt", 1);
+
+        // ── Starter trigger — bridged from TENANT.DELETE.REQUESTED ──────
+        var trigger = new Event(DeleteRequestedEventName)
+        {
+            Id = "OnDeleteRequested",
+            Name = "On Delete Requested",
+        };
 
         var initInputs = new SetVariable
         {
@@ -67,7 +96,7 @@ public class DeleteTenantWorkflow : WorkflowBase
         };
 
         // ── Step A: mark tenant deleting + emit TENANT.DELETE.REQUESTED ──
-        var markDeleting = new MarkTenantDeletingActivity
+        var markDeleting = new MarkTenantDeletingForDeleteActivity
         {
             Id = "MarkTenantDeleting",
             Name = "Mark Tenant Deleting",
@@ -75,8 +104,8 @@ public class DeleteTenantWorkflow : WorkflowBase
             Attempt = new Input<int>(ctx => attempt.Get(ctx)),
         };
 
-        // ── Step B: evict pool ──────────────────────────────────────────
-        var evictPool = new EvictTenantPoolActivity
+        // ── Step B: evict pool (before DROP SCHEMA … CASCADE) ───────────
+        var evictPool = new EvictTenantPoolForCleanupActivity
         {
             Id = "EvictTenantPool",
             Name = "Evict Tenant Pool",
@@ -84,10 +113,8 @@ public class DeleteTenantWorkflow : WorkflowBase
             Attempt = new Input<int>(ctx => attempt.Get(ctx)),
         };
 
-        // ── Step B2: optional pg_dump backup (gated by Backup:DeletionBackup;
-        //    no-op when off). Must run AFTER evictPool (pool released) and
-        //    BEFORE dropSchema (snapshot the data before it's gone). ────
-        var backupDatabase = new BackupTenantDatabaseActivity
+        // ── Step B2: optional pg_dump backup (gated; before the drop) ───
+        var backupDatabase = new BackupTenantDatabaseForDeleteActivity
         {
             Id = "BackupTenantDatabase",
             Name = "Backup Tenant Database",
@@ -95,9 +122,8 @@ public class DeleteTenantWorkflow : WorkflowBase
             Attempt = new Input<int>(ctx => attempt.Get(ctx)),
         };
 
-        // ── Step C: DROP SCHEMA IF EXISTS t_<hex> CASCADE on the
-        //    assigned pool database (unified-tenancy Phase 2) ────────────
-        var dropSchema = new DropTenantSchemaActivity
+        // ── Step C: DROP SCHEMA IF EXISTS t_<hex> CASCADE ───────────────
+        var dropSchema = new DropTenantSchemaForCleanupActivity
         {
             Id = "DropTenantSchema",
             Name = "Drop Tenant Schema",
@@ -105,8 +131,8 @@ public class DeleteTenantWorkflow : WorkflowBase
             Attempt = new Input<int>(ctx => attempt.Get(ctx)),
         };
 
-        // ── Step D: DROP OWNED BY + DROP ROLE ──────────────────────────
-        var dropRole = new DropTenantRoleActivity
+        // ── Step D: DROP OWNED BY + DROP ROLE ───────────────────────────
+        var dropRole = new DropTenantRoleForCleanupActivity
         {
             Id = "DropTenantRole",
             Name = "Drop Tenant Role",
@@ -114,26 +140,36 @@ public class DeleteTenantWorkflow : WorkflowBase
             Attempt = new Input<int>(ctx => attempt.Get(ctx)),
         };
 
-        // ── Step E: soft-delete the CP row + emit terminal event ───────
-        var emitDeleted = new EmitDeletedSuccessActivity
+        // ── Step I: CP-side relationship cleanup (item #4) ──────────────
+        var cleanupRelationships = new CleanupTenantRelationshipsActivity
         {
-            Id = "EmitDeletedSuccess",
-            Name = "Emit Deleted Success",
+            Id = "CleanupTenantRelationships",
+            Name = "Cleanup Tenant Relationships",
             TenantId = new Input<Guid>(ctx => tenantId.Get(ctx)),
             Attempt = new Input<int>(ctx => attempt.Get(ctx)),
+        };
+
+        // ── Terminal: single terminal event (soft-delete folded in) ─────
+        var terminal = new EmitDeleteTerminalEventActivity
+        {
+            Id = "EmitDeleteTerminalEvent",
+            Name = "Emit Delete Terminal Event",
+            TenantId = new Input<Guid>(ctx => tenantId.Get(ctx)),
         };
 
         builder.Root = new Sequence
         {
             Activities =
             {
+                trigger,
                 initInputs,
                 markDeleting,
                 evictPool,
                 backupDatabase,
                 dropSchema,
                 dropRole,
-                emitDeleted,
+                cleanupRelationships,
+                terminal,
             },
         };
     }

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TenantDeleteRequestedTrigger.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TenantDeleteRequestedTrigger.cs
@@ -1,0 +1,286 @@
+using Elsa.Workflows.Runtime;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Tamma.Data;
+
+namespace Tamma.ElsaServer.Workflows;
+
+/// <summary>
+/// Options for <see cref="TenantDeleteRequestedTrigger"/>. Bound to the
+/// <c>TenantDeleteTrigger</c> configuration section.
+/// </summary>
+public sealed class TenantDeleteRequestedTriggerOptions
+{
+    public const string SectionName = "TenantDeleteTrigger";
+
+    /// <summary>
+    /// When <c>false</c> the bridge does not start. Defaults to <c>true</c>
+    /// so production picks up the delete workflow trigger automatically;
+    /// tests + non-Elsa hosts flip this off.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// How often the bridge polls <c>platform_events</c> for new
+    /// <c>TENANT.DELETE.REQUESTED</c> rows. 2 seconds matches the admin SSE
+    /// cadence; the cooling-off window (below) is what actually paces the
+    /// destructive drop.
+    /// </summary>
+    public TimeSpan PollInterval { get; set; } = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// Story 28-5 AC4 — grace window between the admin DELETE flip and the
+    /// destructive drop. The bridge will NOT dispatch the workflow until
+    /// <c>now - tenants.DeleteRequestedAt &gt;= CoolingOff</c>, giving an
+    /// operator time to cancel via
+    /// <c>POST /api/admin/tenants/{id}/actions/cancel-delete</c>. Defaults
+    /// to 5 minutes (Doc 04 §6.5 + Doc 01 §10.1).
+    /// </summary>
+    public TimeSpan CoolingOff { get; set; } = TimeSpan.FromMinutes(5);
+}
+
+/// <summary>
+/// Story 28-5 items #1, #2, #5 — bridge that closes the integration cliff
+/// between the admin <c>POST /api/admin/tenants/{id}/actions/delete</c>
+/// endpoint and <see cref="DeleteTenantWorkflow"/>.
+///
+/// <para>The endpoint emits a <c>TENANT.DELETE.REQUESTED</c> row into
+/// <c>platform_events</c> + flips the tenant to <c>deleting</c>. Tamma.Api
+/// and Tamma.ElsaServer run in separate processes, so this background
+/// service polls the durable event log for new <c>TENANT.DELETE.REQUESTED</c>
+/// rows and re-publishes the matching Elsa-side event via
+/// <see cref="IEventPublisher.PublishAsync"/>, which fires the workflow's
+/// <c>Event</c> starter trigger.</para>
+///
+/// <para><b>Cooling-off (item #2):</b> a row is NOT dispatched until
+/// <c>now - tenants.DeleteRequestedAt &gt;= CoolingOff</c>. A row still
+/// inside its window is left for a later tick (the cursor is NOT advanced
+/// past it) so the destructive drop fires only after the grace period.</para>
+///
+/// <para><b>Cancellation (item #5):</b> immediately before dispatch the
+/// bridge re-reads the tenant. If <c>Status != 'deleting'</c> (an operator
+/// cancelled during the window, flipping back to <c>active</c>) the row is
+/// skipped — the cursor advances past it so it is never reconsidered, and
+/// no workflow runs.</para>
+///
+/// <para><b>Idempotency</b>: the bridge tracks the last-seen
+/// <c>SequenceNumber</c> in process memory and starts at the max sequence
+/// at boot (not zero) so a redeploy doesn't replay historical requests.
+/// The delete workflow itself is idempotent (probe-before-drop on every
+/// step) so a duplicate dispatch is safe.</para>
+///
+/// <para><b>Failure isolation</b>: a tick failure (CP DB unreachable,
+/// dispatch failure) is logged at WARN and the cursor is NOT advanced, so
+/// the row is retried on the next tick.</para>
+/// </summary>
+public sealed class TenantDeleteRequestedTrigger : BackgroundService
+{
+    private const string EventType = "TENANT.DELETE.REQUESTED";
+
+    private readonly IServiceProvider _services;
+    private readonly IOptions<TenantDeleteRequestedTriggerOptions> _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<TenantDeleteRequestedTrigger> _logger;
+
+    private long _lastSequence;
+
+    public TenantDeleteRequestedTrigger(
+        IServiceProvider services,
+        IOptions<TenantDeleteRequestedTriggerOptions> options,
+        TimeProvider timeProvider,
+        ILogger<TenantDeleteRequestedTrigger> logger)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentNullException.ThrowIfNull(logger);
+        _services = services;
+        _options = options;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var opts = _options.Value;
+        if (!opts.Enabled)
+        {
+            _logger.LogInformation(
+                "TenantDeleteRequestedTrigger disabled — set " +
+                "TenantDeleteTrigger:Enabled=true to opt in.");
+            return;
+        }
+
+        try
+        {
+            _lastSequence = await ReadInitialCursorAsync(stoppingToken)
+                .ConfigureAwait(false);
+            _logger.LogInformation(
+                "TenantDeleteRequestedTrigger starting cursor={Cursor} pollInterval={Poll}s coolingOff={Cooling}m",
+                _lastSequence,
+                opts.PollInterval.TotalSeconds,
+                opts.CoolingOff.TotalMinutes);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "TenantDeleteRequestedTrigger initial cursor read failed; starting at 0.");
+            _lastSequence = 0;
+        }
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await TickAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "TenantDeleteRequestedTrigger tick threw; continuing.");
+            }
+
+            try
+            {
+                await Task.Delay(opts.PollInterval, _timeProvider, stoppingToken)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { break; }
+        }
+
+        _logger.LogInformation("TenantDeleteRequestedTrigger shut down.");
+    }
+
+    private async Task<long> ReadInitialCursorAsync(CancellationToken ct)
+    {
+        await using var scope = _services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ControlPlaneDbContext>();
+        var max = await db.PlatformEvents
+            .AsNoTracking()
+            .Where(e => e.Type == EventType)
+            .Select(e => (long?)e.SequenceNumber)
+            .MaxAsync(ct).ConfigureAwait(false);
+        return max ?? 0L;
+    }
+
+    private async Task TickAsync(CancellationToken ct)
+    {
+        await using var scope = _services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ControlPlaneDbContext>();
+        var publisher = scope.ServiceProvider.GetRequiredService<IEventPublisher>();
+
+        var rows = await db.PlatformEvents
+            .AsNoTracking()
+            .Where(e => e.Type == EventType
+                        && e.SequenceNumber > _lastSequence)
+            .OrderBy(e => e.SequenceNumber)
+            .Take(25)
+            .Select(e => new { e.Id, e.SequenceNumber, e.TenantId })
+            .ToListAsync(ct).ConfigureAwait(false);
+
+        if (rows.Count == 0) return;
+
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+
+        foreach (var row in rows)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            if (row.TenantId is null)
+            {
+                // Malformed row with no tenant binding — nothing to do; skip
+                // it (advance cursor) so it doesn't wedge the bridge.
+                _lastSequence = row.SequenceNumber;
+                continue;
+            }
+
+            var tenantId = row.TenantId.Value;
+
+            // Re-read the tenant's live state: cooling-off window + the
+            // operator-cancel check. Both read the authoritative shadow
+            // columns, not the (possibly stale) event payload.
+            var state = await db.Tenants
+                .AsNoTracking()
+                .IgnoreQueryFilters()
+                .Where(t => t.Id == tenantId)
+                .Select(t => new
+                {
+                    Status = EF.Property<string?>(t, "Status"),
+                    DeleteRequestedAt = EF.Property<DateTime?>(t, "DeleteRequestedAt"),
+                    t.DeletedAt,
+                })
+                .FirstOrDefaultAsync(ct).ConfigureAwait(false);
+
+            // Item #5 — cancellation: tenant no longer in 'deleting' (an
+            // operator cancelled, or it was already torn down). Skip and
+            // advance the cursor — there is nothing to dispatch.
+            if (state is null
+                || state.DeletedAt is not null
+                || !string.Equals(state.Status, "deleting", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogInformation(
+                    "tenant.delete.dispatch_skipped reason=not_deleting tenantId={TenantId} status={Status} sequence={Sequence}",
+                    tenantId, state?.Status, row.SequenceNumber);
+                _lastSequence = row.SequenceNumber;
+                continue;
+            }
+
+            // Item #2 — cooling-off: hold the row until the grace window
+            // elapses. Do NOT advance the cursor; a later tick reconsiders
+            // it (and re-checks the cancel condition). A null
+            // DeleteRequestedAt is treated as "just requested" → hold.
+            var requestedAt = state.DeleteRequestedAt ?? now;
+            if (now - requestedAt < _options.Value.CoolingOff)
+            {
+                _logger.LogDebug(
+                    "tenant.delete.cooling_off tenantId={TenantId} requestedAt={RequestedAt} remaining={Remaining}s",
+                    tenantId, requestedAt,
+                    (_options.Value.CoolingOff - (now - requestedAt)).TotalSeconds);
+                // Stop scanning here — rows are ordered by sequence and this
+                // one isn't ready, so we leave it (and everything after it on
+                // this tick) for a later poll. Cursor unchanged.
+                return;
+            }
+
+            try
+            {
+                var correlationId = tenantId.ToString("D");
+                var payload = new Dictionary<string, object?>
+                {
+                    ["tenantId"] = tenantId.ToString("D"),
+                    ["attempt"] = 1,
+                };
+                await publisher.PublishAsync(
+                    DeleteTenantWorkflow.DeleteRequestedEventName,
+                    correlationId,
+                    null,
+                    null,
+                    payload,
+                    false,
+                    ct).ConfigureAwait(false);
+
+                _logger.LogInformation(
+                    "tenant.delete.dispatched eventId={EventId} tenantId={TenantId} sequence={Sequence}",
+                    row.Id, tenantId, row.SequenceNumber);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "tenant.delete.dispatch_failed eventId={EventId} tenantId={TenantId} — " +
+                    "will retry on next tick (cursor not advanced).",
+                    row.Id, tenantId);
+                // Cursor not advanced — the next tick re-reads this row.
+                return;
+            }
+
+            _lastSequence = row.SequenceNumber;
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TenantDeleteRequestedTrigger.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TenantDeleteRequestedTrigger.cs
@@ -57,14 +57,28 @@ public sealed class TenantDeleteRequestedTriggerOptions
 ///
 /// <para><b>Cooling-off (item #2):</b> a row is NOT dispatched until
 /// <c>now - tenants.DeleteRequestedAt &gt;= CoolingOff</c>. A row still
-/// inside its window is left for a later tick (the cursor is NOT advanced
-/// past it) so the destructive drop fires only after the grace period.</para>
+/// inside its window is DEFERRED for a later tick (the cursor is not advanced
+/// past it) — but the bridge keeps scanning the rest of the batch so a ready
+/// higher-sequence row is not starved behind it (head-of-line fix).
+/// FORCE-DELETE waives the window entirely: a row whose payload carries
+/// <c>data.source == "admin-force-delete"</c> dispatches immediately,
+/// matching the force-delete contract.</para>
 ///
 /// <para><b>Cancellation (item #5):</b> immediately before dispatch the
 /// bridge re-reads the tenant. If <c>Status != 'deleting'</c> (an operator
 /// cancelled during the window, flipping back to <c>active</c>) the row is
-/// skipped — the cursor advances past it so it is never reconsidered, and
-/// no workflow runs.</para>
+/// skipped and never dispatched. This is the EARLIEST of three cancellation
+/// checkpoints; the in-flight delete workflow has two more (the mark step and
+/// the cancellation guard immediately before <c>DROP SCHEMA</c>) so a cancel
+/// that lands AFTER dispatch is still caught and the schema is never dropped.</para>
+///
+/// <para><b>Self re-dispatch / dedup</b>: once a tenant's teardown is
+/// dispatched it is held in an in-process set until the bridge observes the
+/// tenant is no longer <c>deleting</c>. A second <c>TENANT.DELETE.REQUESTED</c>
+/// row for the same tenant (force-delete after delete, or a cooling-off
+/// re-scan) does NOT re-dispatch. The workflow also no longer re-emits
+/// <c>TENANT.DELETE.REQUESTED</c> (it emits <c>TENANT.DELETE.STARTED</c>), so
+/// the bridge can never be fed its own output.</para>
 ///
 /// <para><b>Idempotency</b>: the bridge tracks the last-seen
 /// <c>SequenceNumber</c> in process memory and starts at the max sequence
@@ -73,8 +87,8 @@ public sealed class TenantDeleteRequestedTriggerOptions
 /// step) so a duplicate dispatch is safe.</para>
 ///
 /// <para><b>Failure isolation</b>: a tick failure (CP DB unreachable,
-/// dispatch failure) is logged at WARN and the cursor is NOT advanced, so
-/// the row is retried on the next tick.</para>
+/// dispatch failure) is logged at WARN and the cursor is NOT advanced past
+/// the offending row, so it is retried on the next tick.</para>
 /// </summary>
 public sealed class TenantDeleteRequestedTrigger : BackgroundService
 {
@@ -86,6 +100,18 @@ public sealed class TenantDeleteRequestedTrigger : BackgroundService
     private readonly ILogger<TenantDeleteRequestedTrigger> _logger;
 
     private long _lastSequence;
+
+    /// <summary>
+    /// Per-tenant dispatch dedup (self re-dispatch guard). Once a tenant's
+    /// delete workflow has been dispatched it is held here until we observe
+    /// the tenant is no longer <c>deleting</c> (cancelled, or torn down). This
+    /// prevents BOTH a second <c>TENANT.DELETE.REQUESTED</c> row for the same
+    /// tenant (force-delete after delete, or a future workflow re-emit) AND a
+    /// cooling-off head-of-line re-scan from re-dispatching an already-running
+    /// teardown. The delete workflow itself is idempotent, so a missed dedup
+    /// is safe — this just avoids redundant runs.
+    /// </summary>
+    private readonly HashSet<Guid> _dispatched = new();
 
     public TenantDeleteRequestedTrigger(
         IServiceProvider services,
@@ -182,22 +208,37 @@ public sealed class TenantDeleteRequestedTrigger : BackgroundService
                         && e.SequenceNumber > _lastSequence)
             .OrderBy(e => e.SequenceNumber)
             .Take(25)
-            .Select(e => new { e.Id, e.SequenceNumber, e.TenantId })
+            .Select(e => new { e.Id, e.SequenceNumber, e.TenantId, e.Data })
             .ToListAsync(ct).ConfigureAwait(false);
 
         if (rows.Count == 0) return;
 
         var now = _timeProvider.GetUtcNow().UtcDateTime;
 
+        // Head-of-line fix — when a not-yet-due (cooling-off) row is hit we
+        // must NOT advance the cursor PAST it (a later tick has to reconsider
+        // it once its window elapses), but we MUST keep scanning the rest of
+        // this batch so a ready higher-sequence row isn't starved behind it.
+        // We therefore advance _lastSequence only across the leading run of
+        // fully-handled rows; the moment we defer one, the cursor freezes at
+        // the row just before it and every later row is processed in-place
+        // (the per-tenant dedup below makes re-scanning those rows a no-op).
+        var cursorAdvancing = true;
+
         foreach (var row in rows)
         {
             ct.ThrowIfCancellationRequested();
 
+            void AdvanceIfLeading()
+            {
+                if (cursorAdvancing) _lastSequence = row.SequenceNumber;
+            }
+
             if (row.TenantId is null)
             {
                 // Malformed row with no tenant binding — nothing to do; skip
-                // it (advance cursor) so it doesn't wedge the bridge.
-                _lastSequence = row.SequenceNumber;
+                // it. Counts as fully-handled so the cursor can move past it.
+                AdvanceIfLeading();
                 continue;
             }
 
@@ -219,34 +260,53 @@ public sealed class TenantDeleteRequestedTrigger : BackgroundService
                 .FirstOrDefaultAsync(ct).ConfigureAwait(false);
 
             // Item #5 — cancellation: tenant no longer in 'deleting' (an
-            // operator cancelled, or it was already torn down). Skip and
-            // advance the cursor — there is nothing to dispatch.
+            // operator cancelled, or it was already torn down). Skip; this row
+            // is fully-handled (nothing to dispatch). Clear any in-flight dedup
+            // so a fresh future delete of the same tenant can dispatch again.
             if (state is null
                 || state.DeletedAt is not null
                 || !string.Equals(state.Status, "deleting", StringComparison.OrdinalIgnoreCase))
             {
+                _dispatched.Remove(tenantId);
                 _logger.LogInformation(
                     "tenant.delete.dispatch_skipped reason=not_deleting tenantId={TenantId} status={Status} sequence={Sequence}",
                     tenantId, state?.Status, row.SequenceNumber);
-                _lastSequence = row.SequenceNumber;
+                AdvanceIfLeading();
+                continue;
+            }
+
+            // Self re-dispatch / duplicate-request dedup — the tenant is still
+            // 'deleting' and we already dispatched its teardown. Don't dispatch
+            // again (force-delete after delete; a cooling-off head-of-line
+            // re-scan; a hypothetical workflow re-emit). Fully-handled row.
+            if (_dispatched.Contains(tenantId))
+            {
+                _logger.LogDebug(
+                    "tenant.delete.dispatch_skipped reason=already_in_flight tenantId={TenantId} sequence={Sequence}",
+                    tenantId, row.SequenceNumber);
+                AdvanceIfLeading();
                 continue;
             }
 
             // Item #2 — cooling-off: hold the row until the grace window
-            // elapses. Do NOT advance the cursor; a later tick reconsiders
-            // it (and re-checks the cancel condition). A null
-            // DeleteRequestedAt is treated as "just requested" → hold.
+            // elapses, UNLESS this is a force-delete (cooling-off waived per
+            // the force-delete contract). A null DeleteRequestedAt is treated
+            // as "just requested" → hold. Force-delete is detected from the
+            // emitting endpoint's source marker in the event payload.
+            var forced = IsForceDelete(row.Data);
             var requestedAt = state.DeleteRequestedAt ?? now;
-            if (now - requestedAt < _options.Value.CoolingOff)
+            if (!forced && now - requestedAt < _options.Value.CoolingOff)
             {
                 _logger.LogDebug(
                     "tenant.delete.cooling_off tenantId={TenantId} requestedAt={RequestedAt} remaining={Remaining}s",
                     tenantId, requestedAt,
                     (_options.Value.CoolingOff - (now - requestedAt)).TotalSeconds);
-                // Stop scanning here — rows are ordered by sequence and this
-                // one isn't ready, so we leave it (and everything after it on
-                // this tick) for a later poll. Cursor unchanged.
-                return;
+                // Head-of-line fix — DEFER this row (do not advance the cursor
+                // past it) but keep scanning the rest of the batch. Freeze the
+                // cursor here so a later tick reconsiders this row once its
+                // window elapses.
+                cursorAdvancing = false;
+                continue;
             }
 
             try
@@ -266,21 +326,47 @@ public sealed class TenantDeleteRequestedTrigger : BackgroundService
                     false,
                     ct).ConfigureAwait(false);
 
+                _dispatched.Add(tenantId);
                 _logger.LogInformation(
-                    "tenant.delete.dispatched eventId={EventId} tenantId={TenantId} sequence={Sequence}",
-                    row.Id, tenantId, row.SequenceNumber);
+                    "tenant.delete.dispatched eventId={EventId} tenantId={TenantId} sequence={Sequence} forced={Forced}",
+                    row.Id, tenantId, row.SequenceNumber, forced);
             }
             catch (Exception ex)
             {
                 _logger.LogWarning(ex,
                     "tenant.delete.dispatch_failed eventId={EventId} tenantId={TenantId} — " +
-                    "will retry on next tick (cursor not advanced).",
+                    "will retry on next tick (cursor not advanced past this row).",
                     row.Id, tenantId);
-                // Cursor not advanced — the next tick re-reads this row.
-                return;
+                // Defer this row (do not advance past it) so the next tick
+                // re-reads it; keep scanning the rest of the batch.
+                cursorAdvancing = false;
+                continue;
             }
 
-            _lastSequence = row.SequenceNumber;
+            AdvanceIfLeading();
+        }
+    }
+
+    /// <summary>
+    /// Detects a force-delete request from the <c>TENANT.DELETE.REQUESTED</c>
+    /// event payload (<c>data.source == "admin-force-delete"</c>). Force-delete
+    /// waives the cooling-off window. Tolerant of malformed JSON — an
+    /// unparseable payload is simply treated as a normal (cooling-off) delete.
+    /// </summary>
+    internal static bool IsForceDelete(string? data)
+    {
+        if (string.IsNullOrWhiteSpace(data)) return false;
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(data);
+            return doc.RootElement.ValueKind == System.Text.Json.JsonValueKind.Object
+                && doc.RootElement.TryGetProperty("source", out var src)
+                && src.ValueKind == System.Text.Json.JsonValueKind.String
+                && string.Equals(src.GetString(), "admin-force-delete", StringComparison.Ordinal);
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return false;
         }
     }
 }

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Tamma.Activities.Tests.csproj
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Tamma.Activities.Tests.csproj
@@ -18,6 +18,7 @@
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/TenantLifecycle/CleanupTenantRelationshipsActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/TenantLifecycle/CleanupTenantRelationshipsActivityTests.cs
@@ -1,0 +1,242 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NUnit.Framework;
+using Tamma.Activities.TenantLifecycle;
+using Tamma.Data;
+using Tamma.Data.Entities;
+
+namespace Tamma.Activities.Tests.TenantLifecycle;
+
+/// <summary>
+/// Story 28-5 item #4 / AC4 Step I — tests for
+/// <see cref="CleanupTenantRelationshipsActivity"/>. Exercises the pure-DI
+/// static <see cref="CleanupTenantRelationshipsActivity.CleanupRelationshipsAsync"/>
+/// against an EF InMemory <see cref="ControlPlaneDbContext"/> so the
+/// disposition policy (delete vs. null vs. keep-for-audit) is covered
+/// without standing up the Elsa runtime.
+/// </summary>
+[TestFixture]
+public class CleanupTenantRelationshipsActivityTests
+{
+    private ControlPlaneDbContext _db = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var options = new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+        _db = new ControlPlaneDbContext(options);
+    }
+
+    [TearDown]
+    public void TearDown() => _db.Dispose();
+
+    [Test]
+    public void Activity_HasCorrectStepName_AndIsContinueOnError()
+    {
+        var activity = new CleanupTenantRelationshipsActivity();
+        activity.StepName.Should().Be(CleanupSteps.CleanupRelationships);
+        activity.StepName.Should().Be("cleanup-cp-relationships");
+        activity.Should().BeAssignableTo<CleanupStepActivity>(
+            "a row-delete failure must record into the accumulator, not abort the run");
+    }
+
+    [Test]
+    public void Activity_EmitsDeleteStepEvents()
+    {
+        // CleanupStepActivity emits the DELETE.* family — confirms item #6
+        // alignment for this delete-only step.
+        new CleanupTenantRelationshipsActivity().EventType
+            .Should().Be("TENANT.CLEANUP.CLEANUP_CP_RELATIONSHIPS");
+    }
+
+    [Test]
+    public async Task CleanupRelationships_DeletesMembershipsInvitesAndTenantKeyedRows()
+    {
+        var tenantId = Guid.NewGuid();
+        SeedDeletableRows(tenantId);
+        await _db.SaveChangesAsync();
+
+        var result = await CleanupTenantRelationshipsActivity.CleanupRelationshipsAsync(
+            _db, tenantId, CancellationToken.None);
+
+        result.Memberships.Should().Be(1);
+        result.Invites.Should().Be(1);
+        result.QueuedTasks.Should().Be(1);
+        result.Enablements.Should().Be(1);
+        result.AlertChannels.Should().Be(1);
+        result.ApiKeys.Should().Be(1);
+
+        (await _db.TenantMemberships.IgnoreQueryFilters()
+            .CountAsync(m => m.TenantId == tenantId)).Should().Be(0);
+        (await _db.UserInvites.IgnoreQueryFilters()
+            .CountAsync(i => i.TenantId == tenantId)).Should().Be(0);
+        (await _db.TenantAgentEnablements.IgnoreQueryFilters()
+            .CountAsync(e => e.TenantId == tenantId)).Should().Be(0);
+        (await _db.AlertChannels.IgnoreQueryFilters()
+            .CountAsync(a => a.TenantId == tenantId)).Should().Be(0);
+        (await _db.ApiKeys.IgnoreQueryFilters()
+            .CountAsync(k => k.TenantId == tenantId)).Should().Be(0);
+    }
+
+    [Test]
+    public async Task CleanupRelationships_NullsGithubInstallationTenantId_WithoutDeletingRow()
+    {
+        var tenantId = Guid.NewGuid();
+        var installation = new GitHubInstallation
+        {
+            Id = Guid.NewGuid(),
+            InstallationId = 42,
+            AccountLogin = "acme",
+            AccountType = "Organization",
+            AppId = 1,
+            TenantId = tenantId,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        _db.GitHubInstallations.Add(installation);
+        await _db.SaveChangesAsync();
+
+        var result = await CleanupTenantRelationshipsActivity.CleanupRelationshipsAsync(
+            _db, tenantId, CancellationToken.None);
+
+        result.InstallationsReleased.Should().Be(1);
+        var reloaded = await _db.GitHubInstallations.IgnoreQueryFilters()
+            .FirstAsync(g => g.Id == installation.Id);
+        reloaded.TenantId.Should().BeNull("the org-owned installation is released, not destroyed");
+    }
+
+    [Test]
+    public async Task CleanupRelationships_KeepsCompletedQueuedTasks_AndAuditTables()
+    {
+        var tenantId = Guid.NewGuid();
+        // Completed task — kept as its own audit trail (only pending rows go).
+        _db.PlatformQueuedTasks.Add(new PlatformQueuedTask
+        {
+            Id = Guid.NewGuid(),
+            Type = "tenant.move",
+            TenantId = tenantId,
+            Status = "completed",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        // Billing customer — financial record, keep-for-audit.
+        _db.BillingCustomers.Add(new BillingCustomer
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        await _db.SaveChangesAsync();
+
+        var result = await CleanupTenantRelationshipsActivity.CleanupRelationshipsAsync(
+            _db, tenantId, CancellationToken.None);
+
+        result.QueuedTasks.Should().Be(0, "only pending queued tasks are deleted");
+        (await _db.PlatformQueuedTasks.CountAsync(q => q.TenantId == tenantId))
+            .Should().Be(1, "completed queued tasks are retained for audit");
+        (await _db.BillingCustomers.IgnoreQueryFilters()
+            .CountAsync(b => b.TenantId == tenantId))
+            .Should().Be(1, "billing customers are financial records — keep for audit");
+    }
+
+    [Test]
+    public async Task CleanupRelationships_OnlyTouchesTargetTenant()
+    {
+        var tenantId = Guid.NewGuid();
+        var otherTenantId = Guid.NewGuid();
+        SeedDeletableRows(tenantId);
+        SeedDeletableRows(otherTenantId);
+        await _db.SaveChangesAsync();
+
+        await CleanupTenantRelationshipsActivity.CleanupRelationshipsAsync(
+            _db, tenantId, CancellationToken.None);
+
+        (await _db.TenantMemberships.IgnoreQueryFilters()
+            .CountAsync(m => m.TenantId == otherTenantId)).Should().Be(1);
+        (await _db.ApiKeys.IgnoreQueryFilters()
+            .CountAsync(k => k.TenantId == otherTenantId)).Should().Be(1);
+        (await _db.AlertChannels.IgnoreQueryFilters()
+            .CountAsync(a => a.TenantId == otherTenantId)).Should().Be(1,
+            "the neighbour tenant's relationship rows must survive");
+    }
+
+    [Test]
+    public async Task CleanupRelationships_IsIdempotent()
+    {
+        var tenantId = Guid.NewGuid();
+        SeedDeletableRows(tenantId);
+        await _db.SaveChangesAsync();
+
+        await CleanupTenantRelationshipsActivity.CleanupRelationshipsAsync(
+            _db, tenantId, CancellationToken.None);
+        // Second run (replay after a crash) — nothing left to delete.
+        var second = await CleanupTenantRelationshipsActivity.CleanupRelationshipsAsync(
+            _db, tenantId, CancellationToken.None);
+
+        second.Memberships.Should().Be(0);
+        second.ApiKeys.Should().Be(0);
+        second.InstallationsReleased.Should().Be(0);
+    }
+
+    private void SeedDeletableRows(Guid tenantId)
+    {
+        _db.TenantMemberships.Add(new TenantMembership
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            UserId = Guid.NewGuid(),
+            Role = "member",
+            JoinedAt = DateTime.UtcNow,
+        });
+        _db.UserInvites.Add(new UserInvite
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            Email = "x@example.com",
+            InviteTokenHash = "hash",
+            InvitedBy = Guid.NewGuid(),
+            ExpiresAt = DateTime.UtcNow.AddDays(1),
+            CreatedAt = DateTime.UtcNow,
+        });
+        _db.PlatformQueuedTasks.Add(new PlatformQueuedTask
+        {
+            Id = Guid.NewGuid(),
+            Type = "tenant.move",
+            TenantId = tenantId,
+            Status = "pending",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        _db.TenantAgentEnablements.Add(new TenantAgentEnablement
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            AgentId = Guid.NewGuid(),
+            Enabled = true,
+            CreatedAt = DateTime.UtcNow,
+        });
+        _db.AlertChannels.Add(new AlertChannel
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            Name = "ops",
+            ChannelType = "email",
+        });
+        _db.ApiKeys.Add(new ApiKey
+        {
+            Id = Guid.NewGuid(),
+            Scope = "tenant",
+            OwnerId = Guid.NewGuid().ToString(),
+            KeyHash = "h",
+            KeyPrefix = "tk_",
+            Label = "k",
+            TenantId = tenantId,
+            CreatedAt = DateTime.UtcNow,
+        });
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/TenantLifecycle/CleanupTenantRelationshipsActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/TenantLifecycle/CleanupTenantRelationshipsActivityTests.cs
@@ -83,6 +83,159 @@ public class CleanupTenantRelationshipsActivityTests
     }
 
     [Test]
+    public async Task CleanupRelationships_PurgesPlatformApiKeyIndex()
+    {
+        // The platform_api_key_index entity was DESIGNED with a TenantId index
+        // "for bulk-revoke on tenant delete (cascade)". With api_keys
+        // hard-deleted, its routing rows MUST be purged too — leaving them
+        // dangles an index pointing at deleted api_keys.
+        var tenantId = Guid.NewGuid();
+        _db.PlatformApiKeyIndex.Add(new PlatformApiKeyIndex
+        {
+            KeyPrefix = "tk_aaaaaa",
+            HashedSuffix = "h",
+            Scope = "tenant",
+            ApiKeyId = Guid.NewGuid(),
+            TenantId = tenantId,
+            CreatedAt = DateTime.UtcNow,
+        });
+        await _db.SaveChangesAsync();
+
+        var result = await CleanupTenantRelationshipsActivity.CleanupRelationshipsAsync(
+            _db, tenantId, CancellationToken.None);
+
+        result.ApiKeyIndexRows.Should().Be(1);
+        (await _db.PlatformApiKeyIndex.CountAsync(i => i.TenantId == tenantId))
+            .Should().Be(0, "the auth routing index for the tenant's keys must be purged");
+    }
+
+    [Test]
+    public async Task CleanupRelationships_DeletesTenantPlatformInstallations()
+    {
+        // Non-nullable TenantId FK — would dangle if kept.
+        var tenantId = Guid.NewGuid();
+        _db.TenantPlatformInstallations.Add(new TenantPlatformInstallation
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            PlatformKind = "github",
+            BaseUrl = "https://api.github.com",
+            CredentialSecretScope = "tenant",
+            CredentialSecretName = "github/token",
+            Status = "connected",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        await _db.SaveChangesAsync();
+
+        var result = await CleanupTenantRelationshipsActivity.CleanupRelationshipsAsync(
+            _db, tenantId, CancellationToken.None);
+
+        result.PlatformInstallations.Should().Be(1);
+        (await _db.TenantPlatformInstallations.IgnoreQueryFilters()
+            .CountAsync(p => p.TenantId == tenantId)).Should().Be(0);
+    }
+
+    [Test]
+    public async Task CleanupRelationships_DeletesPrivateAgents_AndVersions_KeepsPublicAgents()
+    {
+        var tenantId = Guid.NewGuid();
+
+        var privateAgent = new Agent
+        {
+            Id = Guid.NewGuid(),
+            Name = "atlas",
+            Visibility = AgentVisibility.Private,
+            OwnerTenantId = tenantId,
+            Status = AgentStatus.Active,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        _db.Agents.Add(privateAgent);
+        _db.AgentVersions.Add(new AgentVersion
+        {
+            Id = Guid.NewGuid(),
+            AgentId = privateAgent.Id,
+            Version = 1,
+            ConfigJson = "{}",
+            CreatedAt = DateTime.UtcNow,
+        });
+
+        // Public/system agent — platform-global, must survive.
+        var publicAgent = new Agent
+        {
+            Id = Guid.NewGuid(),
+            Name = "system-reviewer",
+            Visibility = AgentVisibility.Public,
+            OwnerTenantId = null,
+            OwnerUserId = null,
+            Status = AgentStatus.Active,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        _db.Agents.Add(publicAgent);
+
+        // Tenant-keyed role selection — CP-side, purge.
+        _db.AgentRoleSelections.Add(new AgentRoleSelection
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            UserId = null,
+            Role = "developer",
+            AgentId = privateAgent.Id,
+            Visibility = "private",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        await _db.SaveChangesAsync();
+
+        var result = await CleanupTenantRelationshipsActivity.CleanupRelationshipsAsync(
+            _db, tenantId, CancellationToken.None);
+
+        result.PrivateAgents.Should().Be(1);
+        result.AgentVersions.Should().Be(1);
+        result.AgentRoleSelections.Should().Be(1);
+
+        (await _db.Agents.IgnoreQueryFilters().CountAsync(a => a.OwnerTenantId == tenantId))
+            .Should().Be(0, "tenant-owned private agents are deleted with the tenant");
+        (await _db.Agents.IgnoreQueryFilters().CountAsync(a => a.Id == publicAgent.Id))
+            .Should().Be(1, "public/system agents are platform-global and untouched");
+        (await _db.AgentVersions.CountAsync(v => v.AgentId == privateAgent.Id))
+            .Should().Be(0);
+    }
+
+    [Test]
+    public async Task CleanupRelationships_KeepsAlerts_AndPlatformAnalyticsHourly_ForAudit()
+    {
+        var tenantId = Guid.NewGuid();
+        _db.Alerts.Add(new Alert
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            Severity = "warning",
+            Title = "x",
+            Description = "y",
+            Status = "open",
+            CreatedAt = DateTime.UtcNow,
+        });
+        _db.PlatformAnalyticsHourly.Add(new PlatformAnalyticsHourly
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            Hour = DateTime.UtcNow,
+        });
+        await _db.SaveChangesAsync();
+
+        await CleanupTenantRelationshipsActivity.CleanupRelationshipsAsync(
+            _db, tenantId, CancellationToken.None);
+
+        (await _db.Alerts.IgnoreQueryFilters().CountAsync(a => a.TenantId == tenantId))
+            .Should().Be(1, "alerts are kept for incident/compliance history (TenantId nullable, no dangle)");
+        (await _db.PlatformAnalyticsHourly.CountAsync(p => p.TenantId == tenantId))
+            .Should().Be(1, "platform_analytics_hourly is an immutable analytics fact table — kept");
+    }
+
+    [Test]
     public async Task CleanupRelationships_NullsGithubInstallationTenantId_WithoutDeletingRow()
     {
         var tenantId = Guid.NewGuid();

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/TenantLifecycle/DeleteStepActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/TenantLifecycle/DeleteStepActivityTests.cs
@@ -16,19 +16,22 @@ public class DeleteStepActivityTests
     public void DeleteSteps_AreContinueOnError_WithDistinctStepNames()
     {
         var mark = new MarkTenantDeletingForDeleteActivity();
+        var guard = new GuardTenantDeletingActivity();
         var backup = new BackupTenantDatabaseForDeleteActivity();
         var relationships = new CleanupTenantRelationshipsActivity();
 
         mark.Should().BeAssignableTo<CleanupStepActivity>();
+        guard.Should().BeAssignableTo<CleanupStepActivity>();
         backup.Should().BeAssignableTo<CleanupStepActivity>();
         relationships.Should().BeAssignableTo<CleanupStepActivity>();
 
         mark.StepName.Should().Be(CleanupSteps.MarkDeleting);
+        guard.StepName.Should().Be(CleanupSteps.GuardDeleting);
         backup.StepName.Should().Be(CleanupSteps.BackupDatabase);
         relationships.StepName.Should().Be(CleanupSteps.CleanupRelationships);
 
-        new[] { mark.StepName, backup.StepName, relationships.StepName }
-            .Distinct().Should().HaveCount(3);
+        new[] { mark.StepName, guard.StepName, backup.StepName, relationships.StepName }
+            .Distinct().Should().HaveCount(4);
     }
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/TenantLifecycle/DeleteStepActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/TenantLifecycle/DeleteStepActivityTests.cs
@@ -1,0 +1,64 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.TenantLifecycle;
+
+namespace Tamma.Activities.Tests.TenantLifecycle;
+
+/// <summary>
+/// Story 28-5 items #3 + #6 — wiring assertions for the delete-workflow
+/// continue-on-error step activities and the <c>StepEventFamily</c> hook
+/// that switches delete steps to the <c>TENANT.DELETE.STEP_*</c> prefix.
+/// </summary>
+[TestFixture]
+public class DeleteStepActivityTests
+{
+    [Test]
+    public void DeleteSteps_AreContinueOnError_WithDistinctStepNames()
+    {
+        var mark = new MarkTenantDeletingForDeleteActivity();
+        var backup = new BackupTenantDatabaseForDeleteActivity();
+        var relationships = new CleanupTenantRelationshipsActivity();
+
+        mark.Should().BeAssignableTo<CleanupStepActivity>();
+        backup.Should().BeAssignableTo<CleanupStepActivity>();
+        relationships.Should().BeAssignableTo<CleanupStepActivity>();
+
+        mark.StepName.Should().Be(CleanupSteps.MarkDeleting);
+        backup.StepName.Should().Be(CleanupSteps.BackupDatabase);
+        relationships.StepName.Should().Be(CleanupSteps.CleanupRelationships);
+
+        new[] { mark.StepName, backup.StepName, relationships.StepName }
+            .Distinct().Should().HaveCount(3);
+    }
+
+    [Test]
+    public void StepEventFamily_Delete_ResolvesToDeletePrefix()
+    {
+        // Item #6 — delete steps emit TENANT.DELETE.STEP_*, not PROVISION.*.
+        var (started, completed, failed) =
+            TenantLifecycleActivity.StepEventNamesFor(TenantStepEventFamily.Delete);
+
+        started.Should().Be("TENANT.DELETE.STEP_STARTED");
+        completed.Should().Be("TENANT.DELETE.STEP_COMPLETED");
+        failed.Should().Be("TENANT.DELETE.STEP_FAILED");
+    }
+
+    [Test]
+    public void StepEventFamily_Provision_ResolvesToProvisionPrefix()
+    {
+        var (started, completed, failed) =
+            TenantLifecycleActivity.StepEventNamesFor(TenantStepEventFamily.Provision);
+
+        started.Should().Be("TENANT.PROVISION.STEP_STARTED");
+        completed.Should().Be("TENANT.PROVISION.STEP_COMPLETED");
+        failed.Should().Be("TENANT.PROVISION.STEP_FAILED");
+    }
+
+    [Test]
+    public void DeleteFailedEventConstant_MatchesLiteral()
+    {
+        // The cleanup terminal emits this literal; centralising the constant
+        // keeps delete + cleanup in lockstep.
+        TenantLifecycleEvents.DeleteFailed.Should().Be("TENANT.DELETE.FAILED");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/TenantLifecycle/DeleteTenantCancellationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/TenantLifecycle/DeleteTenantCancellationTests.cs
@@ -1,0 +1,253 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NUnit.Framework;
+using Tamma.Activities.TenantLifecycle;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.TenantLifecycle;
+
+/// <summary>
+/// Review-finding coverage for the DESTRUCTIVE delete workflow:
+///
+/// <list type="bullet">
+///   <item>[CRITICAL] Cancellation race — a cancel that lands AFTER the trigger
+///     dispatches must NOT result in a dropped schema. The mark step + the
+///     cancellation guard each re-read Status; if it is no longer 'deleting'
+///     they ABORT the run (set the abort flag) WITHOUT resurrecting the row,
+///     and the terminal emits ABORTED instead of dropping.</item>
+///   <item>[CRITICAL] Self re-dispatch — the workflow no longer re-emits
+///     TENANT.DELETE.REQUESTED (the trigger's own poll target); the mark step
+///     emits the distinct TENANT.DELETE.STARTED marker.</item>
+///   <item>Abort short-circuit — once aborted, every destructive step skips.</item>
+/// </list>
+///
+/// All exercised through the pure-DI seams (EF InMemory + in-memory
+/// <see cref="ICleanupStateStore"/>) so the race is testable without an Elsa
+/// runtime.
+/// </summary>
+[TestFixture]
+public class DeleteTenantCancellationTests
+{
+    private ControlPlaneDbContext _db = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var options = new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+        _db = new ControlPlaneDbContext(options);
+    }
+
+    [TearDown]
+    public void TearDown() => _db.Dispose();
+
+    private async Task<Guid> SeedTenantAsync(string status)
+    {
+        var id = Guid.NewGuid();
+        var tenant = new Tenant
+        {
+            Id = id,
+            Name = "Acme",
+            Slug = "acme-" + id.ToString("N")[..6],
+            Type = "team",
+            Plan = "free",
+            CreatedAt = DateTime.UtcNow.AddMinutes(-10),
+            UpdatedAt = DateTime.UtcNow,
+        };
+        _db.Tenants.Add(tenant);
+        _db.Entry(tenant).Property("Status").CurrentValue = status;
+        await _db.SaveChangesAsync();
+        return id;
+    }
+
+    // ───────────────────────── MARK STEP — the race ─────────────────────────
+
+    [Test]
+    public async Task MarkStep_CancelledTenant_AbortsWithoutResurrecting()
+    {
+        // The race: trigger dispatched → operator cancelled (deleting→active) →
+        // workflow's mark step runs. It must NOT flip active→deleting and MUST
+        // abort the run so the schema is never dropped.
+        var tenantId = await SeedTenantAsync("active");
+        var store = new InMemoryCleanupStateStore();
+
+        var stillDeleting = await MarkTenantDeletingForDeleteActivity.EvaluateAsync(
+            _db, store, tenantId, logger: null, CancellationToken.None);
+
+        stillDeleting.Should().BeFalse("a cancelled tenant must not proceed to the destructive span");
+        CleanupWorkflowState.IsAborted(store).Should().BeTrue();
+        CleanupWorkflowState.GetAbortReason(store).Should().Contain("active");
+
+        // CRITICAL — the row was NOT resurrected to 'deleting'.
+        var reloaded = await _db.Tenants.IgnoreQueryFilters().FirstAsync(t => t.Id == tenantId);
+        ((string?)_db.Entry(reloaded).Property("Status").CurrentValue)
+            .Should().Be("active", "the mark step must never flip a cancelled tenant back to deleting");
+    }
+
+    [Test]
+    public async Task MarkStep_StillDeleting_ProceedsWithoutAbort()
+    {
+        var tenantId = await SeedTenantAsync("deleting");
+        var store = new InMemoryCleanupStateStore();
+
+        var stillDeleting = await MarkTenantDeletingForDeleteActivity.EvaluateAsync(
+            _db, store, tenantId, logger: null, CancellationToken.None);
+
+        stillDeleting.Should().BeTrue();
+        CleanupWorkflowState.IsAborted(store).Should().BeFalse();
+    }
+
+    [Test]
+    public async Task MarkStep_MissingTenant_Throws()
+    {
+        var store = new InMemoryCleanupStateStore();
+        var act = async () => await MarkTenantDeletingForDeleteActivity.EvaluateAsync(
+            _db, store, Guid.NewGuid(), logger: null, CancellationToken.None);
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    // ──────────────────── GUARD STEP — last line before drop ────────────────
+
+    [Test]
+    public async Task GuardStep_CancelledTenant_AbortsBeforeDrop()
+    {
+        var tenantId = await SeedTenantAsync("active");
+        var store = new InMemoryCleanupStateStore();
+        var factory = new SingleContextFactory(_db);
+
+        var stillDeleting = await GuardTenantDeletingActivity.EvaluateAsync(
+            factory, store, tenantId, logger: null, CancellationToken.None);
+
+        stillDeleting.Should().BeFalse();
+        CleanupWorkflowState.IsAborted(store).Should().BeTrue();
+        CleanupWorkflowState.GetAbortReason(store).Should().Contain("DROP SCHEMA");
+    }
+
+    [Test]
+    public async Task GuardStep_StillDeleting_Proceeds()
+    {
+        var tenantId = await SeedTenantAsync("deleting");
+        var store = new InMemoryCleanupStateStore();
+        var factory = new SingleContextFactory(_db);
+
+        var stillDeleting = await GuardTenantDeletingActivity.EvaluateAsync(
+            factory, store, tenantId, logger: null, CancellationToken.None);
+
+        stillDeleting.Should().BeTrue();
+        CleanupWorkflowState.IsAborted(store).Should().BeFalse();
+    }
+
+    [Test]
+    public async Task GuardStep_ReadFailure_FailsClosed_Aborts()
+    {
+        // A read failure right before DROP SCHEMA must FAIL CLOSED — abort, not
+        // assume "still deleting". Simulated by a factory that throws.
+        var store = new InMemoryCleanupStateStore();
+        var factory = new ThrowingContextFactory();
+
+        var stillDeleting = await GuardTenantDeletingActivity.EvaluateAsync(
+            factory, store, Guid.NewGuid(), logger: null, CancellationToken.None);
+
+        stillDeleting.Should().BeFalse("a CP read failure must abort, never proceed to the drop");
+        CleanupWorkflowState.IsAborted(store).Should().BeTrue();
+        CleanupWorkflowState.GetAbortReason(store).Should().Contain("fail-closed");
+    }
+
+    // ──────────────────── Abort state machine + terminal ────────────────────
+
+    [Test]
+    public void Abort_IsIdempotent_KeepsFirstReason()
+    {
+        var store = new InMemoryCleanupStateStore();
+        CleanupWorkflowState.MarkAborted(store, "first");
+        CleanupWorkflowState.MarkAborted(store, "second");
+
+        CleanupWorkflowState.IsAborted(store).Should().BeTrue();
+        CleanupWorkflowState.GetAbortReason(store).Should().Be("first");
+    }
+
+    [Test]
+    public void Abort_SkippedStepsTracked_NotInSucceededOrFailed()
+    {
+        var store = new InMemoryCleanupStateStore();
+        CleanupWorkflowState.MarkAborted(store, "cancelled");
+        CleanupWorkflowState.RecordSkipped(store, CleanupSteps.DropSchema);
+        CleanupWorkflowState.RecordSkipped(store, CleanupSteps.DropRole);
+
+        CleanupWorkflowState.GetSkippedSteps(store).Should()
+            .BeEquivalentTo(new[] { CleanupSteps.DropSchema, CleanupSteps.DropRole });
+        CleanupWorkflowState.GetSucceededSteps(store).Should().BeEmpty();
+        CleanupWorkflowState.GetFailedSteps(store).Should().BeEmpty(
+            "a skipped (aborted) step is neither a success nor a failure");
+    }
+
+    [Test]
+    public void NotAborted_ByDefault()
+    {
+        var store = new InMemoryCleanupStateStore();
+        CleanupWorkflowState.IsAborted(store).Should().BeFalse();
+        CleanupWorkflowState.GetAbortReason(store).Should().BeNull();
+    }
+
+    // ──────────────────── Self re-dispatch guard (event name) ───────────────
+
+    [Test]
+    public void Workflow_DoesNotReEmit_DeleteRequested_UsesDistinctStartedMarker()
+    {
+        // The self re-dispatch fix: the workflow must NEVER emit the exact event
+        // the trigger polls (TENANT.DELETE.REQUESTED). It uses a distinct
+        // STARTED marker. Lock the constant so a future edit can't reintroduce
+        // the loop without breaking this test.
+        TenantLifecycleEvents.DeleteStarted.Should().Be("TENANT.DELETE.STARTED");
+        TenantLifecycleEvents.DeleteStarted.Should().NotBe(TenantLifecycleEvents.DeleteRequested);
+        TenantLifecycleEvents.DeleteAborted.Should().Be("TENANT.DELETE.ABORTED");
+    }
+
+    // ──────────────── Force-delete cooling-off bypass (trigger) ─────────────
+
+    [Test]
+    public void Trigger_IsForceDelete_DetectsForceDeleteSource()
+    {
+        // The force-delete contract: a force-delete request waives the
+        // cooling-off window. The trigger detects it from the event payload's
+        // source marker (set by ForceDeleteTenant → "admin-force-delete").
+        TenantDeleteRequestedTrigger.IsForceDelete(
+            """{"source":"admin-force-delete","requestedAt":"x"}""").Should().BeTrue();
+
+        // A normal delete (or any other source) is NOT force — subject to the
+        // cooling-off window.
+        TenantDeleteRequestedTrigger.IsForceDelete(
+            """{"source":"admin-delete"}""").Should().BeFalse();
+        TenantDeleteRequestedTrigger.IsForceDelete("{}").Should().BeFalse();
+        TenantDeleteRequestedTrigger.IsForceDelete(null).Should().BeFalse();
+        // Tolerant of malformed payloads — treated as a normal delete.
+        TenantDeleteRequestedTrigger.IsForceDelete("not json").Should().BeFalse();
+    }
+
+    // ── Test factories ──
+
+    private sealed class SingleContextFactory : IDbContextFactory<ControlPlaneDbContext>
+    {
+        private readonly ControlPlaneDbContext _ctx;
+        public SingleContextFactory(ControlPlaneDbContext ctx) => _ctx = ctx;
+        // Return the SAME context — the InMemory store is shared by name, and
+        // the guard only reads (AsNoTracking), so re-using the instance is safe
+        // and avoids a disposed-context surprise.
+        public ControlPlaneDbContext CreateDbContext() => _ctx;
+        public Task<ControlPlaneDbContext> CreateDbContextAsync(CancellationToken ct = default) =>
+            Task.FromResult(_ctx);
+    }
+
+    private sealed class ThrowingContextFactory : IDbContextFactory<ControlPlaneDbContext>
+    {
+        public ControlPlaneDbContext CreateDbContext() =>
+            throw new InvalidOperationException("simulated CP read failure");
+        public Task<ControlPlaneDbContext> CreateDbContextAsync(CancellationToken ct = default) =>
+            throw new InvalidOperationException("simulated CP read failure");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/TenantLifecycle/DeleteTenantWorkflowStructureTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/TenantLifecycle/DeleteTenantWorkflowStructureTests.cs
@@ -38,6 +38,7 @@ public class DeleteTenantWorkflowStructureTests
         typeof(MarkTenantDeletingForDeleteActivity),
         typeof(EvictTenantPoolForCleanupActivity),
         typeof(BackupTenantDatabaseForDeleteActivity),  // AC4 — pre-drop backup (gated)
+        typeof(GuardTenantDeletingActivity),            // cancellation guard — last check before drop
         typeof(DropTenantSchemaForCleanupActivity),
         typeof(DropTenantRoleForCleanupActivity),
         typeof(CleanupTenantRelationshipsActivity),     // item #4 — CP relationship cleanup
@@ -118,6 +119,34 @@ public class DeleteTenantWorkflowStructureTests
     }
 
     [Test]
+    public void Build_CancellationGuardImmediatelyPrecedesDropSchema()
+    {
+        // CRITICAL (cancellation race) — the guard re-reads Status as the LAST
+        // act before the irreversible DROP SCHEMA, so a cancel that lands after
+        // dispatch aborts the run before anything is dropped.
+        var sequence = SequenceOf();
+        var guardIdx = sequence.FindIndex(a => a is GuardTenantDeletingActivity);
+        var dropDbIdx = sequence.FindIndex(a => a is DropTenantSchemaForCleanupActivity);
+
+        guardIdx.Should().BeGreaterThan(0);
+        dropDbIdx.Should().Be(guardIdx + 1,
+            "the cancellation guard must run immediately before DROP SCHEMA … CASCADE");
+    }
+
+    [Test]
+    public void Build_BackupPrecedesCancellationGuard()
+    {
+        // The guard is the LAST step before the drop; the (gated) backup runs
+        // before it so a backup is still taken on the non-aborted path.
+        var sequence = SequenceOf();
+        var backupIdx = sequence.FindIndex(a => a is BackupTenantDatabaseForDeleteActivity);
+        var guardIdx = sequence.FindIndex(a => a is GuardTenantDeletingActivity);
+
+        backupIdx.Should().BeGreaterThan(0);
+        guardIdx.Should().BeGreaterThan(backupIdx);
+    }
+
+    [Test]
     public void Build_DropSchemaPrecedesDropRole()
     {
         var sequence = SequenceOf();
@@ -163,7 +192,7 @@ public class DeleteTenantWorkflowStructureTests
             .Where(a => a is not SetVariable and not EmitDeleteTerminalEventActivity and not Event)
             .ToList();
 
-        stepActivities.Should().HaveCount(6);
+        stepActivities.Should().HaveCount(7);
         foreach (var step in stepActivities)
         {
             step.Should().BeAssignableTo<CleanupStepActivity>(

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/TenantLifecycle/DeleteTenantWorkflowStructureTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/TenantLifecycle/DeleteTenantWorkflowStructureTests.cs
@@ -1,5 +1,6 @@
 using Elsa.Workflows;
 using Elsa.Workflows.Activities;
+using Elsa.Workflows.Runtime.Activities;
 using FluentAssertions;
 using NUnit.Framework;
 using Tamma.Activities.Tests.Workflows;
@@ -9,18 +10,22 @@ using Tamma.ElsaServer.Workflows;
 namespace Tamma.Activities.Tests.TenantLifecycle;
 
 /// <summary>
-/// Story 28-5 — structural assertions on
+/// Story 28-5 item #1 + #3 — structural assertions on the rebuilt
 /// <see cref="DeleteTenantWorkflow"/>:
 ///
 /// <list type="bullet">
-///   <item><description>Build()'s metadata is set.</description></item>
-///   <item><description>Root is a Sequence — the delete flow is linear and
-///     idempotent.</description></item>
-///   <item><description>Steps run in the right order: mark → evict pool →
-///     drop schema → drop role → emit success. The pool eviction must precede
-///     <c>DROP SCHEMA … CASCADE</c> so the resolver releases its cached
-///     <c>NpgsqlDataSource</c> first (unified-tenancy Phase 2 — the
-///     delete path is schema-scoped).</description></item>
+///   <item><description>Root is a <see cref="Sequence"/> that starts with
+///     the delete-event trigger (item #1 — the bridge from
+///     <c>TENANT.DELETE.REQUESTED</c> fires this).</description></item>
+///   <item><description>The destructive steps are continue-on-error
+///     (<see cref="CleanupStepActivity"/>) so a mid-sequence failure no
+///     longer aborts the run (item #3).</description></item>
+///   <item><description>A single terminal activity
+///     (<see cref="EmitDeleteTerminalEventActivity"/>) is last — exactly one
+///     terminal event per run.</description></item>
+///   <item><description>Ordering: evict precedes drop-schema; backup
+///     precedes drop-schema; drop-schema precedes drop-role; CP relationship
+///     cleanup precedes the terminal.</description></item>
 /// </list>
 /// </summary>
 [TestFixture]
@@ -28,13 +33,15 @@ public class DeleteTenantWorkflowStructureTests
 {
     private static readonly Type[] ExpectedActivitiesInOrder = new[]
     {
-        typeof(SetVariable),                       // initInputs
-        typeof(MarkTenantDeletingActivity),
-        typeof(EvictTenantPoolActivity),
-        typeof(BackupTenantDatabaseActivity),      // AC4 — pre-drop backup (gated)
-        typeof(DropTenantSchemaActivity),
-        typeof(DropTenantRoleActivity),
-        typeof(EmitDeletedSuccessActivity),
+        typeof(Event),                                  // item #1 — starter trigger
+        typeof(SetVariable),                            // initInputs
+        typeof(MarkTenantDeletingForDeleteActivity),
+        typeof(EvictTenantPoolForCleanupActivity),
+        typeof(BackupTenantDatabaseForDeleteActivity),  // AC4 — pre-drop backup (gated)
+        typeof(DropTenantSchemaForCleanupActivity),
+        typeof(DropTenantRoleForCleanupActivity),
+        typeof(CleanupTenantRelationshipsActivity),     // item #4 — CP relationship cleanup
+        typeof(EmitDeleteTerminalEventActivity),        // item #3 — single terminal
     };
 
     [Test]
@@ -70,43 +77,39 @@ public class DeleteTenantWorkflowStructureTests
     }
 
     [Test]
-    public void Build_EvictPoolPrecedesDropSchema()
+    public void Build_StarterTrigger_BindsToDeleteRequestedEventName()
     {
         var workflow = new DeleteTenantWorkflow();
         var builder = WorkflowTestHelper.BuildWorkflow(workflow);
-        var sequence = (Sequence)builder.Object.Root;
-        var activities = sequence.Activities.ToList();
 
-        var evictIdx = -1;
-        var dropDbIdx = -1;
-        for (var i = 0; i < activities.Count; i++)
-        {
-            if (activities[i] is EvictTenantPoolActivity) evictIdx = i;
-            if (activities[i] is DropTenantSchemaActivity) dropDbIdx = i;
-        }
+        var sequence = (Sequence)builder.Object.Root;
+        var trigger = sequence.Activities.OfType<Event>().FirstOrDefault();
+
+        trigger.Should().NotBeNull("the workflow must start with an Event trigger (item #1)");
+        trigger!.Id.Should().Be("OnDeleteRequested");
+        var raw = trigger.EventName.Expression?.Value?.ToString();
+        raw.Should().Be(DeleteTenantWorkflow.DeleteRequestedEventName);
+    }
+
+    [Test]
+    public void Build_EvictPoolPrecedesDropSchema()
+    {
+        var sequence = SequenceOf();
+        var evictIdx = sequence.FindIndex(a => a is EvictTenantPoolForCleanupActivity);
+        var dropDbIdx = sequence.FindIndex(a => a is DropTenantSchemaForCleanupActivity);
 
         evictIdx.Should().BeGreaterThan(0);
         dropDbIdx.Should().BeGreaterThan(0);
         evictIdx.Should().BeLessThan(dropDbIdx,
-            "the resolver pool must be evicted before DROP SCHEMA … CASCADE "
-            + "so the cached NpgsqlDataSource is released first");
+            "the resolver pool must be evicted before DROP SCHEMA … CASCADE");
     }
 
     [Test]
     public void Build_BackupPrecedesDropSchema()
     {
-        var workflow = new DeleteTenantWorkflow();
-        var builder = WorkflowTestHelper.BuildWorkflow(workflow);
-        var sequence = (Sequence)builder.Object.Root;
-        var activities = sequence.Activities.ToList();
-
-        var backupIdx = -1;
-        var dropDbIdx = -1;
-        for (var i = 0; i < activities.Count; i++)
-        {
-            if (activities[i] is BackupTenantDatabaseActivity) backupIdx = i;
-            if (activities[i] is DropTenantSchemaActivity) dropDbIdx = i;
-        }
+        var sequence = SequenceOf();
+        var backupIdx = sequence.FindIndex(a => a is BackupTenantDatabaseForDeleteActivity);
+        var dropDbIdx = sequence.FindIndex(a => a is DropTenantSchemaForCleanupActivity);
 
         backupIdx.Should().BeGreaterThan(0);
         dropDbIdx.Should().BeGreaterThan(0);
@@ -117,22 +120,70 @@ public class DeleteTenantWorkflowStructureTests
     [Test]
     public void Build_DropSchemaPrecedesDropRole()
     {
-        var workflow = new DeleteTenantWorkflow();
-        var builder = WorkflowTestHelper.BuildWorkflow(workflow);
-        var sequence = (Sequence)builder.Object.Root;
-        var activities = sequence.Activities.ToList();
-
-        var dropDbIdx = -1;
-        var dropRoleIdx = -1;
-        for (var i = 0; i < activities.Count; i++)
-        {
-            if (activities[i] is DropTenantSchemaActivity) dropDbIdx = i;
-            if (activities[i] is DropTenantRoleActivity) dropRoleIdx = i;
-        }
+        var sequence = SequenceOf();
+        var dropDbIdx = sequence.FindIndex(a => a is DropTenantSchemaForCleanupActivity);
+        var dropRoleIdx = sequence.FindIndex(a => a is DropTenantRoleForCleanupActivity);
 
         dropDbIdx.Should().BeGreaterThan(0);
         dropRoleIdx.Should().BeGreaterThan(0);
         dropDbIdx.Should().BeLessThan(dropRoleIdx,
-            "DROP ROLE in DropTenantRoleActivity fails if the role still owns the schema");
+            "DROP ROLE fails if the role still owns the schema");
+    }
+
+    [Test]
+    public void Build_RelationshipCleanupPrecedesTerminal()
+    {
+        var sequence = SequenceOf();
+        var relIdx = sequence.FindIndex(a => a is CleanupTenantRelationshipsActivity);
+        var terminalIdx = sequence.FindIndex(a => a is EmitDeleteTerminalEventActivity);
+
+        relIdx.Should().BeGreaterThan(0);
+        terminalIdx.Should().Be(relIdx + 1,
+            "the CP relationship cleanup must run immediately before the terminal so a "
+            + "dangling-FK failure is attributed before the soft-delete decision");
+    }
+
+    [Test]
+    public void Build_TerminalActivityIsLastInSequence()
+    {
+        var sequence = SequenceOf();
+        sequence.Last().Should().BeOfType<EmitDeleteTerminalEventActivity>(
+            "the single terminal event must fire after every per-step activity has run");
+    }
+
+    [Test]
+    public void Build_AllDestructiveStepsAreContinueOnError()
+    {
+        // Item #3 — every per-step activity inherits CleanupStepActivity
+        // (catch-record-continue). None inherits the throwing
+        // TenantLifecycleActivity base — that's what guarantees the run
+        // always reaches the terminal step.
+        var sequence = SequenceOf();
+        var stepActivities = sequence
+            .Where(a => a is not SetVariable and not EmitDeleteTerminalEventActivity and not Event)
+            .ToList();
+
+        stepActivities.Should().HaveCount(6);
+        foreach (var step in stepActivities)
+        {
+            step.Should().BeAssignableTo<CleanupStepActivity>(
+                $"{step.GetType().Name} must inherit CleanupStepActivity for continue-on-error semantics");
+        }
+    }
+
+    [Test]
+    public void Build_TerminalActivity_DoesNotInheritStepBase()
+    {
+        // The terminal emits the SINGLE terminal event, not the per-step
+        // tuple — locking the inheritance guards the single-terminal-event
+        // invariant.
+        new EmitDeleteTerminalEventActivity().Should()
+            .NotBeAssignableTo<CleanupStepActivity>();
+    }
+
+    private static List<IActivity> SequenceOf()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new DeleteTenantWorkflow());
+        return ((Sequence)builder.Object.Root).Activities.ToList();
     }
 }

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/TenantLifecycle/EmitDeleteTerminalEventActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/TenantLifecycle/EmitDeleteTerminalEventActivityTests.cs
@@ -1,0 +1,106 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.TenantLifecycle;
+
+namespace Tamma.Activities.Tests.TenantLifecycle;
+
+/// <summary>
+/// Story 28-5 item #3 — tests for the delete-workflow terminal activity
+/// <see cref="EmitDeleteTerminalEventActivity"/>. Mirrors the cleanup
+/// sibling's coverage: the failure-summary truncation rules + the
+/// outcome-decision shape (full success → DELETED.SUCCESS, any failure →
+/// DELETE.FAILED). The row-update + event-emit paths require the Elsa
+/// runtime, so this fixture targets the pure-helper logic and the outcome
+/// derived from a populated <see cref="ICleanupStateStore"/>.
+/// </summary>
+[TestFixture]
+public class EmitDeleteTerminalEventActivityTests
+{
+    [Test]
+    public void Activity_IsNotAStep_AndEmitsTerminalEventType()
+    {
+        var activity = new EmitDeleteTerminalEventActivity();
+        activity.Should().NotBeAssignableTo<CleanupStepActivity>(
+            "the terminal emits the single terminal event, not the per-step tuple");
+        activity.EventType.Should().Be("TENANT.DELETE.TERMINAL");
+    }
+
+    [Test]
+    public void BuildFailureSummary_ContainsAllFailedSteps()
+    {
+        var failedSteps = new[]
+        {
+            CleanupSteps.DropSchema,
+            CleanupSteps.DropRole,
+        };
+        var details = new Dictionary<string, string>
+        {
+            [CleanupSteps.DropSchema] = "drop_schema_failed: db in use",
+            [CleanupSteps.DropRole] = "drop_role_failed: still owns objects",
+        };
+
+        var summary = EmitDeleteTerminalEventActivity.BuildFailureSummaryForTesting(
+            failedSteps, details);
+
+        summary.Should().Contain(CleanupSteps.DropSchema);
+        summary.Should().Contain(CleanupSteps.DropRole);
+        summary.Should().Contain("db in use");
+        summary.Should().StartWith("Delete partial — 2 step(s) failed:");
+    }
+
+    [Test]
+    public void BuildFailureSummary_TruncatesAt1900Chars()
+    {
+        var failedSteps = Enumerable.Range(0, 100).Select(i => $"step-{i}").ToArray();
+        var details = failedSteps.ToDictionary(s => s, s => $"X: {new string('x', 200)}");
+
+        var summary = EmitDeleteTerminalEventActivity.BuildFailureSummaryForTesting(
+            failedSteps, details);
+
+        summary.Length.Should().BeLessThanOrEqualTo(1900,
+            "summary must fit within tenants.ProvisioningDetail");
+    }
+
+    [Test]
+    public void BuildFailureSummary_HandlesMissingDetails()
+    {
+        var failedSteps = new[] { CleanupSteps.DropSchema };
+        var details = new Dictionary<string, string>();
+
+        var summary = EmitDeleteTerminalEventActivity.BuildFailureSummaryForTesting(
+            failedSteps, details);
+
+        summary.Should().Contain(CleanupSteps.DropSchema);
+        summary.Should().Contain("(no detail)");
+    }
+
+    [Test]
+    public void TerminalOutcome_AllStepsSucceeded_IsSuccess()
+    {
+        // Drives the same predicate the activity uses: failedSteps.Count == 0.
+        var store = new InMemoryCleanupStateStore();
+        CleanupWorkflowState.RecordSuccess(store, CleanupSteps.MarkDeleting);
+        CleanupWorkflowState.RecordSuccess(store, CleanupSteps.EvictPool);
+        CleanupWorkflowState.RecordSuccess(store, CleanupSteps.BackupDatabase);
+        CleanupWorkflowState.RecordSuccess(store, CleanupSteps.DropSchema);
+        CleanupWorkflowState.RecordSuccess(store, CleanupSteps.DropRole);
+        CleanupWorkflowState.RecordSuccess(store, CleanupSteps.CleanupRelationships);
+
+        CleanupWorkflowState.GetFailedSteps(store).Should().BeEmpty();
+        CleanupWorkflowState.GetSucceededSteps(store).Should().HaveCount(6);
+    }
+
+    [Test]
+    public void TerminalOutcome_AnyStepFailed_IsFailure()
+    {
+        var store = new InMemoryCleanupStateStore();
+        CleanupWorkflowState.RecordSuccess(store, CleanupSteps.MarkDeleting);
+        CleanupWorkflowState.RecordSuccess(store, CleanupSteps.EvictPool);
+        CleanupWorkflowState.RecordFailure(
+            store, CleanupSteps.DropSchema, "drop_schema_failed", "db in use");
+        CleanupWorkflowState.RecordSuccess(store, CleanupSteps.DropRole);
+
+        var failed = CleanupWorkflowState.GetFailedSteps(store);
+        failed.Should().ContainSingle().Which.Should().Be(CleanupSteps.DropSchema);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Admin/AdminTenantsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Admin/AdminTenantsTests.cs
@@ -647,6 +647,59 @@ public class AdminTenantsTests
         StatusCodeOf(result).Should().Be(StatusCodes.Status409Conflict);
     }
 
+    // ── Cancel-delete action (Story 28-5 AC4) ──
+
+    [Test]
+    public async Task CancelDeleteTenant_InDeletingState_FlipsToActive_ClearsDeleteRequestedAt_AndEmitsCancelled()
+    {
+        var tenantId = await SeedTenantAsync(
+            status: "deleting", deleteRequestedAt: DateTime.UtcNow.AddMinutes(-1));
+
+        var result = await AdminTenantsEndpoints.CancelDeleteTenant(
+            tenantId, _db, _publisher, _statusCache, _connectionResolver,
+            _invalidationBus, _timeProvider, AdminPrincipal());
+
+        var ok = result.Should().BeOfType<Ok<AdminTenantActionResponse>>().Subject;
+        ok.Value!.Status.Should().Be("active");
+
+        var reloaded = await _db.Tenants.IgnoreQueryFilters()
+            .FirstAsync(t => t.Id == tenantId);
+        ((string?)_db.Entry(reloaded).Property("Status").CurrentValue)
+            .Should().Be("active");
+        ((DateTime?)_db.Entry(reloaded).Property("DeleteRequestedAt").CurrentValue)
+            .Should().BeNull("cancel clears the delete-requested stamp");
+
+        _publisher.Events.Should().ContainSingle(
+            e => e.Type == "TENANT.DELETE_CANCELLED" && e.TenantId == tenantId);
+
+        _statusCache.Invalidations.Should().Contain(tenantId);
+        _connectionResolver.Evictions.Should().Contain(tenantId);
+        _invalidationBus.Publishes.Should().Contain(tenantId);
+    }
+
+    [Test]
+    public async Task CancelDeleteTenant_InActiveState_Returns409()
+    {
+        var tenantId = await SeedTenantAsync(status: "active");
+
+        var result = await AdminTenantsEndpoints.CancelDeleteTenant(
+            tenantId, _db, _publisher, _statusCache, _connectionResolver,
+            _invalidationBus, _timeProvider, AdminPrincipal());
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status409Conflict);
+        _publisher.Events.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task CancelDeleteTenant_Returns404_WhenTenantMissing()
+    {
+        var result = await AdminTenantsEndpoints.CancelDeleteTenant(
+            Guid.NewGuid(), _db, _publisher, _statusCache, _connectionResolver,
+            _invalidationBus, _timeProvider, AdminPrincipal());
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status404NotFound);
+    }
+
     // ── Force-delete action ──
 
     [Test]


### PR DESCRIPTION
## DeleteTenantWorkflow build-out — Bucket D (P0: destructive teardown was undispatchable)

Per `docs/superpowers/audits/2026-06-22/completeness/DeleteTenant.md`, mirroring the more-complete `CleanUpFailedTenantWorkflow`:
- **#1 (P0):** `TenantDeleteRequestedTrigger` BackgroundService bridges admin DELETE → the workflow (it was dead code — admin DELETE flipped the row but never ran the teardown).
- **#2+#5:** 5-min cooling-off + `POST /api/admin/tenants/{id}/actions/cancel-delete` (`PlatformOwnerAccess`).
- **#3 (P0):** continue-on-error body + a single `EmitDeleteTerminalEventActivity` (success→soft-delete+`TENANT.DELETED.SUCCESS`; any failure→`TENANT.DELETE.FAILED`+`requires_manual_cleanup`) — was: a mid-step throw left tenants stuck in `deleting` with no terminal.
- **#4 (P0):** `CleanupTenantRelationshipsActivity` purges CP `TenantId`-keyed rows (memberships/invites/queued-tasks/enablements/alert-channels/`platform_api_key_index`/platform-installations/private-agents; api-keys revoked; github-installation nulled; billing/audit kept) — no silent FK dangles.
- **#6:** `TENANT.DELETE.STEP_*` prefix.

**Review + fix (3 CRITICALs):** (1) **cancellation race** — a cancel landing after dispatch was steamrolled (the mark step re-flipped active→deleting) → fixed: mark step no longer resurrects, aborts if not `deleting`; new `GuardTenantDeletingActivity` re-reads (fail-closed) immediately before `DROP SCHEMA`; abort → non-destructive `TENANT.DELETE.ABORTED`. (2) **self re-dispatch loop** — emitted the trigger's own `DELETE.REQUESTED` → fixed to a distinct `DELETE.STARTED` + per-tenant dedup. (3) force-delete cooling-off bypass (the "runs immediately" contract was false).

**Known dependency (NOT a regression):** the engine's `IPlatformEventPublisher` is the `NullPlatformEventPublisher` (systemic — all tenant-lifecycle workflows), so DCB terminal *events* aren't durably persisted yet; the **authoritative teardown signal is the `tenants` status/`ProvisioningState` columns** (written directly, persisted regardless). Durable platform-event emission is the tracked engine→`platform_events` callback follow-up.

**Gate:** build 0; Activities `~Tenant*` 159/0; Api `~Tenant` 939/0; full `Tamma.Activities.Tests` **1859/0**. No new migration. Touches ElsaServer/Program.cs (hosted service) + Api/Program.cs (route). Deferred (honest): #7 retry, #8 backup-live, #9 soft-timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)