### PR TITLE
feat(workflows): wire RotateSecret retire-drain + trigger surface — close AC8, fail-closed task queue

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/SecretsRotation/Contracts/IRotationAuditEmitter.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/SecretsRotation/Contracts/IRotationAuditEmitter.cs
@@ -60,6 +60,16 @@ public sealed record RotationAuditEvent(
 /// </summary>
 public static class RotationAuditEvents
 {
+    /// <summary>Emitted by the trigger surface (operator endpoint /
+    /// scheduled auto-rotation) when a rotation is dispatched to the
+    /// <c>rotate-secret</c> workflow — BEFORE the saga's STARTED.</summary>
+    public const string Requested = "SECRET.ROTATION.REQUESTED";
+
+    /// <summary>Emitted by the trigger surface when the per-secret
+    /// concurrency guard refuses a rotation because one is already in
+    /// flight (<c>rotation_in_progress</c>).</summary>
+    public const string Rejected = "SECRET.ROTATION.REJECTED";
+
     public const string Started = "SECRET.ROTATION.STARTED";
     public const string Staged = "SECRET.ROTATION.STAGED";
 

--- a/apps/tamma-elsa/src/Tamma.Activities/SecretsRotation/Contracts/ISecretRotationGateway.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/SecretsRotation/Contracts/ISecretRotationGateway.cs
@@ -96,6 +96,42 @@ public interface ISecretRotationGateway
         Guid secretId,
         int versionNumber,
         CancellationToken ct);
+
+    /// <summary>
+    /// Story 29-6 (audit gap #3) — per-secret concurrency guard. Attempt
+    /// to take an exclusive "rotation in flight" claim on
+    /// <paramref name="secretId"/> before a trigger dispatches the
+    /// rotation workflow. Returns <c>true</c> when the claim was acquired
+    /// (no other rotation is in flight), <c>false</c> when a rotation is
+    /// already in progress — in which case the caller MUST reject with a
+    /// terminal <c>rotation_in_progress</c> rather than minting a second
+    /// pending version (which would race the version-number sequence and
+    /// double-push).
+    ///
+    /// <para>The default implementation is a status check: a secret with
+    /// an existing <c>Pending</c> version row is mid-rotation. The claim
+    /// is released implicitly when that pending version reaches a
+    /// terminal state — activation flips it to <c>Active</c>, compensation
+    /// deletes it — so <see cref="EndRotationAsync"/> is a no-op for the
+    /// status-check backend (kept for advisory-lock backends).</para>
+    /// </summary>
+    Task<bool> TryBeginRotationAsync(
+        Guid secretId,
+        string rotationCorrelationId,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Story 29-6 (audit gap #3) — release a claim taken by
+    /// <see cref="TryBeginRotationAsync"/> when the rotation reaches a
+    /// terminal outcome WITHOUT having minted a pending version (e.g. the
+    /// dispatch failed before the saga's mint step). For the status-check
+    /// backend this is a no-op because the pending version IS the claim;
+    /// advisory-lock backends release the lock here.
+    /// </summary>
+    Task EndRotationAsync(
+        Guid secretId,
+        string rotationCorrelationId,
+        CancellationToken ct);
 }
 
 /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/SecretEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/SecretEndpoints.cs
@@ -475,6 +475,154 @@ public static class SecretEndpoints
         }
     }
 
+    /// <summary>
+    /// Story 29-6 (audit gap #2) — trigger the audited
+    /// <c>rotate-secret</c> SAGA workflow for a platform-scoped secret:
+    /// <c>POST /api/v1/secrets/{secretId}/rotate</c>. Gated by
+    /// <c>PlatformOwnerAccess</c> at the mapping site (cross-tenant
+    /// infrastructure — NOT <c>OwnerAccess</c>, which admits every
+    /// personal-tenant owner).
+    ///
+    /// <para>Unlike the legacy reveal-based rotate, this mints a fresh
+    /// rotation correlation id, takes the per-secret concurrency guard,
+    /// and dispatches the mint → push → probe → activate → schedule-retire
+    /// saga. Returns <c>202 Accepted</c> + the correlation id; emits
+    /// <c>SECRET.ROTATION.REQUESTED</c>. A rotation already in flight is
+    /// refused with <c>409</c> + <c>SECRET.ROTATION.REJECTED(rotation_in_progress)</c>.</para>
+    /// </summary>
+    public static async Task<IResult> TriggerRotateWorkflow(
+        Guid secretId,
+        TriggerRotateRequestBody? body,
+        ClaimsPrincipal principal,
+        [FromServices] Services.Secrets.Rotation.IRotationTriggerService triggerService,
+        HttpContext http)
+    {
+        if (secretId == Guid.Empty)
+            return Results.BadRequest(new { error = "secretId must be a non-empty Guid" });
+
+        var validation = ValidateTriggerBody(body);
+        if (validation is not null) return validation;
+
+        var operatorUserId = ResolveUserId(principal);
+
+        try
+        {
+            var result = await triggerService.TriggerRotationAsync(
+                secretId,
+                operatorUserId,
+                newPlaintext: body?.NewPlaintext,
+                generateLength: body?.GenerateLength,
+                graceWindowSeconds: body?.GraceWindowSeconds ?? 0L,
+                ct: http.RequestAborted)
+                .ConfigureAwait(false);
+
+            if (!result.Accepted)
+            {
+                return Results.Json(
+                    new { error = result.Reason, rotationCorrelationId = result.RotationCorrelationId },
+                    statusCode: StatusCodes.Status409Conflict);
+            }
+
+            return Results.Accepted(
+                value: new
+                {
+                    secretId,
+                    rotationCorrelationId = result.RotationCorrelationId,
+                    status = "dispatched",
+                });
+        }
+        catch (ArgumentException ex)
+        {
+            return Results.BadRequest(new { error = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// Story 29-6 (audit gap #2) — tenant-scoped trigger of the saga
+    /// workflow: <c>POST /api/v1/orgs/{tenantId}/secrets/{id}/rotate-workflow</c>.
+    /// Requires tenant admin+ role (membership filter wraps the route).
+    /// Distinct path from the legacy reveal-based tenant rotate so both
+    /// surfaces coexist.
+    /// </summary>
+    public static async Task<IResult> TriggerRotateTenantWorkflow(
+        Guid tenantId,
+        Guid id,
+        TriggerRotateRequestBody? body,
+        ClaimsPrincipal principal,
+        [FromServices] Services.Secrets.Rotation.IRotationTriggerService triggerService,
+        [FromServices] ISecretQueryService queryService,
+        HttpContext http)
+    {
+        if (!RequireTenantAdmin(http, out var forbid)) return forbid!;
+
+        if (tenantId == Guid.Empty)
+            return Results.BadRequest(new { error = "tenantId must be a non-empty Guid" });
+        if (id == Guid.Empty)
+            return Results.BadRequest(new { error = "secretId must be a non-empty Guid" });
+
+        var validation = ValidateTriggerBody(body);
+        if (validation is not null) return validation;
+
+        // Defense-in-depth scope check: the secret must belong to this
+        // tenant before we dispatch a rotation for it.
+        var existing = await queryService.GetAsync(
+            id, SecretScope.Tenant, tenantId, http.RequestAborted)
+            .ConfigureAwait(false);
+        if (existing is null)
+            return Results.NotFound(new { error = "Secret not found" });
+
+        var operatorUserId = ResolveUserId(principal);
+
+        try
+        {
+            var result = await triggerService.TriggerRotationAsync(
+                id,
+                operatorUserId,
+                newPlaintext: body?.NewPlaintext,
+                generateLength: body?.GenerateLength,
+                graceWindowSeconds: body?.GraceWindowSeconds ?? 0L,
+                ct: http.RequestAborted)
+                .ConfigureAwait(false);
+
+            if (!result.Accepted)
+            {
+                return Results.Json(
+                    new { error = result.Reason, rotationCorrelationId = result.RotationCorrelationId },
+                    statusCode: StatusCodes.Status409Conflict);
+            }
+
+            return Results.Accepted(
+                value: new
+                {
+                    secretId = id,
+                    rotationCorrelationId = result.RotationCorrelationId,
+                    status = "dispatched",
+                });
+        }
+        catch (ArgumentException ex)
+        {
+            return Results.BadRequest(new { error = ex.Message });
+        }
+    }
+
+    private static IResult? ValidateTriggerBody(TriggerRotateRequestBody? body)
+    {
+        if (body is null) return null; // all-optional: saga generates a value
+        if (body.NewPlaintext is not null
+            && body.NewPlaintext.Length is < MinPlaintextLength or > MaxPlaintextLength)
+        {
+            return Results.BadRequest(new
+            {
+                error = $"newPlaintext length must be between {MinPlaintextLength} and {MaxPlaintextLength} characters"
+            });
+        }
+        if (body.GenerateLength is not null && body.GenerateLength is < 16 or > 256)
+            return Results.BadRequest(new { error = "generateLength must be between 16 and 256" });
+        if (body.GraceWindowSeconds is < 0)
+            return Results.BadRequest(new { error = "graceWindowSeconds must be >= 0" });
+        return null;
+    }
+
     // ─────────────────────────────────────────────────────────────────
 
     /// <summary>
@@ -630,4 +778,16 @@ public static class SecretEndpoints
 
     /// <summary>Request body for <see cref="RotateSecret"/>.</summary>
     public sealed record RotateSecretRequestBody(string NewPlaintext);
+
+    /// <summary>
+    /// Request body for <see cref="TriggerRotateWorkflow"/> /
+    /// <see cref="TriggerRotateTenantWorkflow"/>. All fields optional:
+    /// omit <c>newPlaintext</c> to have the saga CSPRNG-generate a value
+    /// (optionally sized via <c>generateLength</c>); omit
+    /// <c>graceWindowSeconds</c> to use the saga default (15 min).
+    /// </summary>
+    public sealed record TriggerRotateRequestBody(
+        string? NewPlaintext = null,
+        int? GenerateLength = null,
+        long GraceWindowSeconds = 0L);
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -12,6 +12,7 @@ using Tamma.Api.Auth;
 using Tamma.Api.Endpoints;
 using Tamma.Api.Extensions;
 using Tamma.Api.Infrastructure;
+using Tamma.Api.Services.Secrets.Rotation;
 using Tamma.Api.Middleware;
 using Tamma.Api.Services;
 using Tamma.Api.Services.Provisioning.V2;
@@ -449,6 +450,62 @@ if (!string.IsNullOrWhiteSpace(
         builder.Configuration.GetConnectionString("ControlPlane")))
 {
     builder.Services.AddTammaSecretReveal(builder.Configuration);
+
+    // Story 29-6 — rotation saga ports (gateway / handler registry /
+    // audit emitter / retire executor + scheduler / trigger service) +
+    // the postgres / cranl / generic-http handlers. Wired here (inside
+    // the cabinet-present guard) because the gateway depends on the
+    // IDbContextFactory<SecretsDbContext> AddTammaSecretReveal just
+    // registered. Without this call the rotate-secret workflow's ports
+    // resolve to nothing and a dispatch 500s.
+    builder.Services
+        .AddTammaSecretRotation(); // Tamma.Api.Services.Secrets.Rotation
+
+    // Story 29-6 (review fix) — bind the rotation gateway options
+    // (stale-pending TTL: a pending marker older than this is treated as an
+    // abandoned/crashed saga and reclaimed so a crash can't wedge the secret).
+    builder.Services
+        .AddOptions<Tamma.Api.Services.Secrets.Rotation.SecretRotationGatewayOptions>()
+        .Configure(opts => builder.Configuration
+            .GetSection(Tamma.Api.Services.Secrets.Rotation.SecretRotationGatewayOptions.SectionName)
+            .Bind(opts));
+
+    // Story 29-6 AC8 — the RETIRE_SECRET_VERSION platform-task handler.
+    // This is the AC8-specified PlatformTaskWorker drain route for the
+    // retire tail. Registering it makes the type HANDLED, which is the
+    // fix for the type-blind dead-letter hazard (we deliberately do NOT
+    // flip PlatformTaskWorker:RunOnStartup).
+    builder.Services
+        .AddPlatformTaskHandler<
+            Tamma.Api.Services.Secrets.Rotation.RetireSecretVersionTaskHandler>();
+
+    // Story 29-6 (audit gap #2b) — scheduled auto-rotation. Gated off by
+    // default (SecretAutoRotation:Enabled=false); an operator opts in
+    // once the Elsa engine + rotation handlers are deployed.
+    builder.Services
+        .AddOptions<Tamma.Api.Services.Secrets.Rotation.SecretAutoRotationSchedulerOptions>()
+        .Configure(opts => builder.Configuration
+            .GetSection(Tamma.Api.Services.Secrets.Rotation.SecretAutoRotationSchedulerOptions.SectionName)
+            .Bind(opts));
+    builder.Services
+        .AddHostedService<Tamma.Api.Services.Secrets.Rotation.SecretAutoRotationScheduler>();
+
+    // Story 29-6 (review fix) — the ACTIVE retire-tail drainer. Because
+    // PlatformTaskWorker:RunOnStartup stays false (the generic worker is not
+    // yet safe for every platform-task type), the AC8 per-task handler would
+    // never run — nothing would drain RETIRE_SECRET_VERSION rows. This
+    // dedicated sweeper periodically reserves ONLY due retire rows (the
+    // VisibleAt guard leaves not-due rows untouched) and routes them through
+    // the same IRetireTaskExecutor body, so the old credential reliably
+    // reaches Revoked. Always on once the cabinet is wired — draining a
+    // scheduled retirement is a correctness requirement, not an opt-in.
+    builder.Services
+        .AddOptions<Tamma.Api.Services.Secrets.Rotation.RetireSweepOptions>()
+        .Configure(opts => builder.Configuration
+            .GetSection(Tamma.Api.Services.Secrets.Rotation.RetireSweepOptions.SectionName)
+            .Bind(opts));
+    builder.Services
+        .AddHostedService<Tamma.Api.Services.Secrets.Rotation.RetireSweepHostedService>();
 }
 
 // Story 32-3 — BYOK→platform provider-credential resolver + cache invalidator.
@@ -1783,6 +1840,13 @@ orgs.MapGet("/{tenantId:guid}/secrets/{id:guid}/versions",
 orgs.MapPost("/{tenantId:guid}/secrets/{id:guid}/rotate",
         SecretEndpoints.RotateTenantSecret)
     .AddEndpointFilter<Tamma.Api.Authorization.RequireTenantMembershipFilter>();
+// Story 29-6 (audit gap #2) — tenant-scoped trigger of the AUDITED
+// rotate-secret SAGA workflow (distinct from the legacy reveal-based
+// rotate above). Admin+ enforced inside the handler; membership proof
+// via the filter. Returns 202 + correlation id.
+orgs.MapPost("/{tenantId:guid}/secrets/{id:guid}/rotate-workflow",
+        SecretEndpoints.TriggerRotateTenantWorkflow)
+    .AddEndpointFilter<Tamma.Api.Authorization.RequireTenantMembershipFilter>();
 orgs.MapPost("/{tenantId:guid}/secrets/{id:guid}/retire-version/{versionNumber:int}",
         SecretEndpoints.RetireTenantVersion)
     .AddEndpointFilter<Tamma.Api.Authorization.RequireTenantMembershipFilter>();
@@ -1853,6 +1917,17 @@ app.MapGet("/api/v1/tenants/{tenantId:guid}/status",
 // guessing attempts without needing a login.
 app.MapGet("/api/v1/secrets/reveal/{token}", SecretEndpoints.RevealSecret)
     .RequireRateLimiting("SecretReveal");
+
+// Story 29-6 (audit gap #2) — platform-scope trigger of the AUDITED
+// rotate-secret SAGA workflow. Mints a fresh correlation id, takes the
+// per-secret concurrency guard, dispatches mint → push → probe →
+// activate → schedule-retire, returns 202 + correlation id. This is the
+// trigger that finally STARTS the workflow (it was previously dead
+// unless invoked manually via Elsa Studio). Gated by PlatformOwnerAccess
+// (cross-tenant infrastructure — NOT OwnerAccess, which admits every
+// personal-tenant owner).
+app.MapPost("/api/v1/secrets/{secretId:guid}/rotate", SecretEndpoints.TriggerRotateWorkflow)
+    .RequireAuthorization("PlatformOwnerAccess");
 
 // ── Onboarding wizard (Story 18-4) ──
 // Status is the polling endpoint the dashboard wizard hits every few

--- a/apps/tamma-elsa/src/Tamma.Api/Services/ElsaWorkflowService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/ElsaWorkflowService.cs
@@ -87,11 +87,60 @@ public partial class ElsaWorkflowService : IElsaWorkflowService
     }
 
     /// <summary>
+    /// Keys whose VALUES must never be logged. Matched case-insensitively
+    /// against the substring patterns in <see cref="SensitiveKeyFragments"/>.
+    /// <c>RotationTriggerService</c> puts the operator's <c>newPlaintext</c>
+    /// into the dispatch dict; this is the only caller that places secret
+    /// material in <c>input</c>, but the match is defensive (covers any
+    /// future caller) so a fresh dispatch surface can't reintroduce the leak.
+    /// </summary>
+    private static readonly string[] SensitiveKeyFragments =
+    {
+        "plaintext", "secret", "password", "token", "apikey", "api_key", "credential",
+    };
+
+    private static bool IsSensitiveKey(string key)
+    {
+        foreach (var fragment in SensitiveKeyFragments)
+        {
+            if (key.Contains(fragment, StringComparison.OrdinalIgnoreCase)) return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Render the dispatch input's KEY SET for safe logging — keys only,
+    /// never values, and a sensitive key is rendered as <c>name=[redacted]</c>
+    /// so its presence is auditable without leaking the value. The control
+    /// chars in each key are stripped to prevent log forging.
+    /// </summary>
+    private static string DescribeInputKeys(Dictionary<string, object>? input)
+    {
+        if (input is null || input.Count == 0) return "(none)";
+        var parts = new List<string>(input.Count);
+        foreach (var key in input.Keys)
+        {
+            var safeKey = SanitizeForLog(key);
+            parts.Add(IsSensitiveKey(key) ? $"{safeKey}=[redacted]" : safeKey);
+        }
+        return string.Join(", ", parts);
+    }
+
+    /// <summary>
     /// Start a new workflow instance by definition name.
     /// </summary>
     public async Task<string> StartWorkflowAsync(string workflowName, Dictionary<string, object> input)
     {
-        _logger.LogInformation("Starting workflow {WorkflowName} with input: {@Input}", SanitizeForLog(workflowName), input);
+        // SECURITY — do NOT destructure the dispatch input ({@Input}). The
+        // rotate-secret dispatch carries the operator's new secret plaintext
+        // under the `newPlaintext` key; destructuring logged it in cleartext
+        // at Information level. Log the workflow name + the input KEY SET only
+        // (keys never values; sensitive keys shown as name=[redacted]). This
+        // method is shared (MentorshipController is the other caller) so the
+        // key-only contract is safe for every caller.
+        _logger.LogInformation(
+            "Starting workflow {WorkflowName} with input keys: {InputKeys}",
+            SanitizeForLog(workflowName), DescribeInputKeys(input));
 
         await EnsureHealthyAsync();
 

--- a/apps/tamma-elsa/src/Tamma.Api/Services/PlatformTasks/IPlatformTaskHandler.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/PlatformTasks/IPlatformTaskHandler.cs
@@ -55,3 +55,22 @@ public sealed class PlatformTaskTerminalException : Exception
     public PlatformTaskTerminalException(string message, Exception inner)
         : base(message, inner) { }
 }
+
+/// <summary>
+/// Story 29-6 (review fix) — throw from
+/// <see cref="IPlatformTaskHandler.HandleAsync"/> AFTER the handler has
+/// itself returned the row to <c>pending</c> (e.g. via
+/// <c>IPlatformQueuedTaskRepository.DeferAsync</c>) to tell the worker the
+/// row is already in its desired state: the worker must NOT
+/// <c>CompleteAsync</c> (which would clobber the defer) and must NOT
+/// <c>FailAsync</c> (which would burn the retry budget / dead-letter).
+///
+/// <para>This is a no-op acknowledgement, not a failure. Only the retire
+/// handler's clock-skew not-yet-due path uses it; every other handler is
+/// completely unaffected (they never throw it, so their
+/// complete/fail/dead-letter behaviour is byte-for-byte unchanged).</para>
+/// </summary>
+public sealed class PlatformTaskDeferredException : Exception
+{
+    public PlatformTaskDeferredException(string message) : base(message) { }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/PlatformTasks/PlatformTaskWorker.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/PlatformTasks/PlatformTaskWorker.cs
@@ -49,28 +49,30 @@ public sealed class PlatformTaskWorkerOptions
     /// <para><b>⚠ Do NOT enable in production yet</b> (tenancy-residuals
     /// assessment, 2026-06): handlers being wired is necessary but NOT
     /// sufficient. <c>ReserveNextAsync</c> claims the oldest
-    /// <c>pending</c> row of <b>any</b> type, and
-    /// <c>platform_queued_tasks</c> is shared with producers whose rows
-    /// must stay pending:
+    /// <c>pending</c> row of <b>any</b> type whose <c>VisibleAt</c> has
+    /// elapsed, and <c>platform_queued_tasks</c> is shared with producers
+    /// whose rows still have no handler registered here:
     /// <list type="bullet">
-    ///   <item><description><c>RETIRE_SECRET_VERSION</c> — the 29-6
-    ///     rotation saga parks these with <c>runAfter</c> ONLY in the
-    ///     payload (no run-after column); only the
-    ///     <c>RetireScheduler</c> sweeper may drain them. This worker
-    ///     has no handler for the type, so it would park+retry the row
-    ///     each tick and dead-letter it after
-    ///     <see cref="MaxRetries"/> ticks (~25s) — destroying the
-    ///     scheduled secret retirement before its grace period.</description></item>
     ///   <item><description>Orphan-webhook fallback rows
     ///     (<c>InstallationRouterService</c>) and v1 Cranl
-    ///     <c>provisioning.tenant</c>[.deprovision] rows — same
-    ///     no-handler park→dead-letter fate.</description></item>
+    ///     <c>provisioning.tenant</c>[.deprovision] rows — no handler is
+    ///     registered, so a poll parks them and (after the retry ceiling)
+    ///     dead-letters them.</description></item>
     /// </list>
-    /// Prerequisite for flipping this on: type-aware reservation (the
+    /// <b>Note (29-6 review fix):</b> the <c>RETIRE_SECRET_VERSION</c>
+    /// hazard that previously made this dangerous is RESOLVED — those rows
+    /// now carry a first-class <c>VisibleAt = runAfter</c> reservation
+    /// column (<c>ReserveNextAsync</c> won't claim a not-yet-due row) AND a
+    /// registered <see cref="Tamma.Api.Services.Secrets.Rotation.RetireSecretVersionTaskHandler"/>,
+    /// so a not-due retire is never dead-lettered before its grace window.
+    /// The retire tail is drained by the dedicated, always-on
+    /// <c>RetireSweepHostedService</c> regardless of this flag, so leaving
+    /// the generic worker off does NOT strand retires.
+    /// <para>Prerequisite for flipping THIS on: type-aware reservation (the
     /// worker reserves only types present in its
-    /// <c>IPlatformTaskHandlerRegistry</c>) or handlers for every
+    /// <c>IPlatformTaskHandlerRegistry</c>) or handlers for every remaining
     /// producer type. See
-    /// <c>.dev/findings/platform-task-worker-runonstartup-hazard.md</c>.
+    /// <c>.dev/findings/platform-task-worker-runonstartup-hazard.md</c>.</para>
     /// </summary>
     public bool RunOnStartup { get; set; } = false;
 }
@@ -247,6 +249,19 @@ public sealed class PlatformTaskWorker : BackgroundService
             var deadLetterMsg = Redact(redactor, ex.Message);
             await repo.DeadLetterAsync(task.Id, deadLetterMsg, ct)
                 .ConfigureAwait(false);
+        }
+        catch (PlatformTaskDeferredException ex)
+        {
+            // Story 29-6 (review fix) — the handler already returned the
+            // row to 'pending' (with a future VisibleAt). This is an
+            // acknowledgement, NOT a failure: do NOT CompleteAsync (would
+            // clobber the defer) and do NOT FailAsync (would burn the
+            // retry budget / dead-letter). The retry count is untouched.
+            _logger.LogDebug(
+                "platform_task.deferred taskId={TaskId} type={TaskType} reason={Reason}",
+                task.Id,
+                task.Type,
+                ex.Message);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Postgres/Migrations/20260625150609_AddOnePendingPerSecretIndex.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Postgres/Migrations/20260625150609_AddOnePendingPerSecretIndex.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Api.Services.Secrets.Postgres;
@@ -11,9 +12,11 @@ using Tamma.Api.Services.Secrets.Postgres;
 namespace Tamma.Api.Services.Secrets.Postgres.Migrations
 {
     [DbContext(typeof(SecretsDbContext))]
-    partial class SecretsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260625150609_AddOnePendingPerSecretIndex")]
+    partial class AddOnePendingPerSecretIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Postgres/Migrations/20260625150609_AddOnePendingPerSecretIndex.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Postgres/Migrations/20260625150609_AddOnePendingPerSecretIndex.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Api.Services.Secrets.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOnePendingPerSecretIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "UX_secret_versions_OnePendingPerSecret",
+                table: "secret_versions",
+                column: "SecretId",
+                unique: true,
+                filter: "\"Status\" = 'pending'");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "UX_secret_versions_OnePendingPerSecret",
+                table: "secret_versions");
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Postgres/SecretsDbContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Postgres/SecretsDbContext.cs
@@ -91,6 +91,18 @@ public class SecretsDbContext : DbContext
                 .WithMany()
                 .HasForeignKey(e => e.SecretId)
                 .OnDelete(DeleteBehavior.Cascade);
+
+            // Story 29-6 (review fix) — at most ONE in-flight rotation per
+            // secret, enforced in SQL. A partial unique index on SecretId
+            // WHERE Status = 'pending' closes the TryBeginRotationAsync
+            // TOCTOU: two concurrent triggers that both observe "no pending"
+            // can no longer both mint — the loser's INSERT raises a unique
+            // violation, which the gateway maps to a clean rotation-rejected
+            // result (no silent plaintext collapse / double-push).
+            entity.HasIndex(e => e.SecretId)
+                .HasDatabaseName("UX_secret_versions_OnePendingPerSecret")
+                .HasFilter("\"Status\" = 'pending'")
+                .IsUnique();
         });
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Rotation/IRetireTaskExecutor.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Rotation/IRetireTaskExecutor.cs
@@ -1,0 +1,37 @@
+namespace Tamma.Api.Services.Secrets.Rotation;
+
+/// <summary>
+/// Story 29-6 AC8 — performs the side-effecting part of retiring ONE
+/// secret version: fetch the old plaintext, flip
+/// <c>RetiredGrace → Revoked</c> via the gateway, best-effort invoke the
+/// handler's <c>RevokeOldAsync</c> hook, and emit
+/// <c>SECRET.VERSION.RETIRED</c>. Deliberately does NOT touch the queue
+/// row's state — the two drainers own their own bookkeeping:
+///
+/// <list type="bullet">
+///   <item><description><c>RetireSecretVersionTaskHandler</c> (the AC8
+///     <c>PlatformTaskWorker</c> route) lets the worker mark
+///     completed / failed / dead-letter from the handler's return /
+///     thrown exception.</description></item>
+///   <item><description><see cref="RetireScheduler.SweepDueRetireTasksAsync"/>
+///     (the periodic fallback) reserves + completes / fails the row
+///     itself.</description></item>
+/// </list>
+/// </summary>
+public interface IRetireTaskExecutor
+{
+    /// <summary>
+    /// Retire the version referenced by <paramref name="payload"/>.
+    /// Idempotent — an already-<c>Revoked</c> version is a no-op (the
+    /// gateway short-circuits). A throwing <c>RevokeOldAsync</c> is
+    /// logged and swallowed (best-effort) so the store-side revocation
+    /// is not undone by a downstream cleanup hiccup. Any OTHER failure
+    /// (gateway throw) propagates so the caller can decide retry vs
+    /// dead-letter.
+    /// </summary>
+    /// <param name="payload">Parsed retire payload (secret id, version,
+    /// correlation id).</param>
+    /// <param name="taskId">Queue row id — recorded on the emitted
+    /// <c>SECRET.VERSION.RETIRED</c> event for traceability.</param>
+    Task RetireOneAsync(RetireTaskPayload payload, Guid taskId, CancellationToken ct);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Rotation/IRotationTriggerService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Rotation/IRotationTriggerService.cs
@@ -1,0 +1,54 @@
+namespace Tamma.Api.Services.Secrets.Rotation;
+
+/// <summary>
+/// Story 29-6 (audit gap #2 + #3) — the trigger surface for the
+/// <c>rotate-secret</c> Elsa workflow. Used by the operator endpoint
+/// (<c>POST /api/v1/secrets/{secretId}/rotate</c>) and the scheduled
+/// auto-rotation hosted service. Owns the per-secret concurrency guard,
+/// the correlation-id mint, the workflow dispatch, and the
+/// <c>SECRET.ROTATION.REQUESTED</c> / <c>SECRET.ROTATION.REJECTED</c>
+/// audit events.
+/// </summary>
+public interface IRotationTriggerService
+{
+    /// <summary>
+    /// Mint a fresh <c>rotationCorrelationId</c>, take the per-secret
+    /// concurrency guard, and (when acquired) dispatch the
+    /// <c>rotate-secret</c> workflow with the supplied inputs. Emits
+    /// <c>SECRET.ROTATION.REQUESTED</c> on dispatch or
+    /// <c>SECRET.ROTATION.REJECTED(rotation_in_progress)</c> when a
+    /// rotation is already in flight.
+    /// </summary>
+    /// <param name="secretId">Secret to rotate.</param>
+    /// <param name="operatorUserId"><see cref="Guid.Empty"/> for
+    /// scheduled / auto rotations.</param>
+    /// <param name="newPlaintext">Operator-supplied new value, or null to
+    /// have the saga CSPRNG-generate one of <paramref name="generateLength"/>
+    /// bytes.</param>
+    /// <param name="generateLength">Length (bytes) for generated plaintext
+    /// when <paramref name="newPlaintext"/> is null.</param>
+    /// <param name="graceWindowSeconds">Retire grace window; 0 ⇒ saga
+    /// default (15 min).</param>
+    Task<RotationTriggerResult> TriggerRotationAsync(
+        Guid secretId,
+        Guid operatorUserId,
+        string? newPlaintext,
+        int? generateLength,
+        long graceWindowSeconds,
+        CancellationToken ct);
+}
+
+/// <summary>
+/// Outcome of <see cref="IRotationTriggerService.TriggerRotationAsync"/>.
+/// </summary>
+/// <param name="Accepted"><c>true</c> when the workflow was dispatched;
+/// <c>false</c> when the concurrency guard rejected it.</param>
+/// <param name="RotationCorrelationId">The minted correlation id (always
+/// returned so the caller can surface it / log it).</param>
+/// <param name="Reason">Non-null rejection reason when
+/// <see cref="Accepted"/> is <c>false</c> (e.g.
+/// <c>rotation_in_progress</c>).</param>
+public sealed record RotationTriggerResult(
+    bool Accepted,
+    string RotationCorrelationId,
+    string? Reason);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Rotation/RetireScheduler.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Rotation/RetireScheduler.cs
@@ -18,36 +18,35 @@ namespace Tamma.Api.Services.Secrets.Rotation;
 ///     secret id, version number, <c>run_after</c> ISO-8601 timestamp,
 ///     and the rotation correlation id. <c>PlatformQueuedTask</c> in
 ///     28-10 does not yet model a first-class <c>RunAfter</c> column,
-///     so the sweeper filters on payload content.</description></item>
+///     so the drainer filters on payload content.</description></item>
 ///   <item><description><see cref="SweepDueRetireTasksAsync"/>
 ///     drains all pending <c>RETIRE_SECRET_VERSION</c> rows whose
-///     payload <c>runAfter</c> is in the past, calls the gateway's
-///     <see cref="ISecretRotationGateway.RetireVersionAsync"/>, and
-///     invokes the handler's optional <c>RevokeOldAsync</c> hook.
-///     Idempotent: an already-revoked version is a no-op.</description></item>
+///     payload <c>runAfter</c> is in the past via the shared
+///     <see cref="IRetireTaskExecutor"/>. Idempotent: an
+///     already-revoked version is a no-op.</description></item>
 /// </list>
+///
+/// <para><b>Two drainers, one body</b>: the AC8-specified route is the
+/// per-task <c>RetireSecretVersionTaskHandler</c> driven by
+/// <c>PlatformTaskWorker</c>; this sweeper is a periodic fallback. Both
+/// call <see cref="IRetireTaskExecutor.RetireOneAsync"/> so the
+/// retire-and-revoke behaviour cannot drift between the two paths.</para>
 /// </summary>
 public sealed class RetireScheduler : IRetireScheduler
 {
     public const string TaskType = "RETIRE_SECRET_VERSION";
 
     private readonly IServiceProvider _services;
-    private readonly ISecretRotationGateway _gateway;
-    private readonly IRotationHandlerRegistry _registry;
-    private readonly IRotationAuditEmitter _auditor;
+    private readonly IRetireTaskExecutor _executor;
     private readonly ILogger<RetireScheduler> _logger;
 
     public RetireScheduler(
         IServiceProvider services,
-        ISecretRotationGateway gateway,
-        IRotationHandlerRegistry registry,
-        IRotationAuditEmitter auditor,
+        IRetireTaskExecutor executor,
         ILogger<RetireScheduler> logger)
     {
         _services = services;
-        _gateway = gateway;
-        _registry = registry;
-        _auditor = auditor;
+        _executor = executor;
         _logger = logger;
     }
 
@@ -77,6 +76,15 @@ public sealed class RetireScheduler : IRetireScheduler
             TenantId = tenantId,
             Payload = payload,
             Status = "pending",
+            // Story 29-6 (review fix) — the grace window is enforced by the
+            // QUEUE, not by a per-task throw. Setting VisibleAt = runAfter
+            // means ReserveNextAsync simply won't claim this row until the
+            // window opens, so a not-yet-due retire is NEVER dead-lettered
+            // (the old per-task "ordinary throw" path burned the retry budget
+            // ~every poll and killed the row in ~25s). The payload still
+            // carries RunAfter as the defence-in-depth check inside the
+            // executor / sweeper.
+            VisibleAt = runAfter.UtcDateTime,
             CreatedAt = DateTime.UtcNow,
             UpdatedAt = DateTime.UtcNow,
         };
@@ -111,7 +119,7 @@ public sealed class RetireScheduler : IRetireScheduler
             }
             catch (JsonException) { /* fall through to dead-letter */ }
 
-            if (parsed is null)
+            if (parsed is null || parsed.SecretId == Guid.Empty || parsed.VersionNumber <= 0)
             {
                 await repo.DeadLetterAsync(reserved.Id, "malformed_payload", ct).ConfigureAwait(false);
                 continue;
@@ -119,76 +127,19 @@ public sealed class RetireScheduler : IRetireScheduler
 
             if (parsed.RunAfter > DateTimeOffset.UtcNow)
             {
-                // Not due yet — put back.
-                await repo.FailAsync(reserved.Id, "not_yet_due", maxRetries: int.MaxValue, ct)
+                // Not due yet — DEFER (return to pending with VisibleAt =
+                // runAfter, retry count UNCHANGED) instead of FailAsync. With
+                // the VisibleAt reservation guard the sweeper won't even
+                // reserve a future row, so this is belt-and-suspenders for a
+                // clock-skew edge; deferring keeps it from burning the budget.
+                await repo.DeferAsync(reserved.Id, parsed.RunAfter.UtcDateTime, ct)
                     .ConfigureAwait(false);
                 continue;
             }
 
             try
             {
-                // Fetch the old plaintext BEFORE retiring so the handler's
-                // RevokeOld can use it (e.g. Postgres can ALTER ROLE with
-                // the last-known password).
-                var oldPlaintext = await _gateway.GetVersionPlaintextAsync(
-                        parsed.SecretId, parsed.VersionNumber, ct)
-                    .ConfigureAwait(false);
-
-                await _gateway.RetireVersionAsync(parsed.SecretId, parsed.VersionNumber, ct)
-                    .ConfigureAwait(false);
-
-                var snapshot = await _gateway.GetSnapshotAsync(parsed.SecretId, ct).ConfigureAwait(false);
-                if (snapshot is not null && oldPlaintext is not null)
-                {
-                    var handler = _registry.Resolve(snapshot.ConsumerSystem);
-                    if (handler is not null)
-                    {
-                        try
-                        {
-                            var target = new RotationTarget(
-                                snapshot.SecretId,
-                                snapshot.Name,
-                                snapshot.TenantId,
-                                snapshot.ConsumerSystem,
-                                snapshot.ConsumerIdentifier,
-                                NewVersionNumber: snapshot.ActiveVersionNumber,
-                                PreviousVersionNumber: parsed.VersionNumber);
-                            await handler.RevokeOldAsync(
-                                    target,
-                                    oldPlaintext,
-                                    new RotationContext(
-                                        parsed.RotationCorrelationId,
-                                        Guid.Empty,
-                                        DryRun: false,
-                                        new Dictionary<string, string>()),
-                                    ct)
-                                .ConfigureAwait(false);
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogWarning(ex,
-                                "RevokeOldAsync threw for secret {Secret} v{Version}; " +
-                                "version is still revoked in the store but the handler's " +
-                                "cleanup did not complete.",
-                                parsed.SecretId, parsed.VersionNumber);
-                        }
-                    }
-                }
-
-                await _auditor.EmitAsync(
-                    RotationAuditEvent.Create(
-                        RotationAuditEvents.VersionRetired,
-                        parsed.SecretId,
-                        snapshot?.TenantId,
-                        parsed.RotationCorrelationId,
-                        versionNumber: parsed.VersionNumber,
-                        data: new Dictionary<string, object?>
-                        {
-                            ["taskId"] = reserved.Id,
-                        }),
-                    ct)
-                    .ConfigureAwait(false);
-
+                await _executor.RetireOneAsync(parsed, reserved.Id, ct).ConfigureAwait(false);
                 await repo.CompleteAsync(reserved.Id, ct).ConfigureAwait(false);
                 processed++;
             }
@@ -202,13 +153,5 @@ public sealed class RetireScheduler : IRetireScheduler
         }
 
         return processed;
-    }
-
-    internal sealed class RetireTaskPayload
-    {
-        public Guid SecretId { get; set; }
-        public int VersionNumber { get; set; }
-        public DateTimeOffset RunAfter { get; set; }
-        public string RotationCorrelationId { get; set; } = string.Empty;
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Rotation/RetireSecretVersionTaskHandler.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Rotation/RetireSecretVersionTaskHandler.cs
@@ -1,0 +1,146 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Tamma.Api.Services.PlatformTasks;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Secrets.Rotation;
+
+/// <summary>
+/// Story 29-6 AC8 — the <c>PlatformTaskWorker</c> handler that finally
+/// drains the rotation saga's retire tail. Registered via
+/// <c>services.AddPlatformTaskHandler&lt;RetireSecretVersionTaskHandler&gt;()</c>;
+/// the worker routes <c>RETIRE_SECRET_VERSION</c> rows here.
+///
+/// <para><b>Why this exists</b>: before this handler, no
+/// <see cref="IPlatformTaskHandler"/> was registered for
+/// <c>RETIRE_SECRET_VERSION</c>, so a type-blind worker would observe a
+/// no-handler tick on every reserved retire row and (after the retry
+/// ceiling) dead-letter it — destroying a scheduled secret retirement
+/// before its grace period. Registering this handler makes the type
+/// HANDLED, which is the fix. (We deliberately do NOT flip
+/// <c>PlatformTaskWorker:RunOnStartup</c> as part of this change.)</para>
+///
+/// <para><b>Failure semantics</b> (delegated to
+/// <see cref="PlatformTaskWorker.ProcessOnceAsync"/> via return / throw):</para>
+/// <list type="bullet">
+///   <item><description>malformed / empty payload ⇒
+///     <see cref="PlatformTaskTerminalException"/> (<c>malformed_payload</c>)
+///     so the row goes straight to dead-letter without burning the
+///     retry budget.</description></item>
+///   <item><description><c>RunAfter &gt; now</c> ⇒ the row is DEFERRED
+///     (<see cref="IPlatformQueuedTaskRepository.DeferAsync"/>): returned
+///     to <c>pending</c> with <c>VisibleAt = runAfter</c> and the retry
+///     count LEFT UNCHANGED, so it is never dead-lettered before its grace
+///     window. This path is now belt-and-suspenders — the primary defence
+///     is that <c>ReserveNextAsync</c> won't claim a future-<c>VisibleAt</c>
+///     row at all (the scheduler stamps <c>VisibleAt = runAfter</c> at
+///     enqueue); it only fires on a clock-skew edge. The old code threw an
+///     ordinary exception so <c>FailAsync</c> re-queued WITH a retry-count
+///     bump and NO run-after — which dead-lettered a not-due retire in
+///     ~25s. That was the lost-retire bug this fix closes.</description></item>
+///   <item><description>gateway retire throw ⇒ an ordinary exception
+///     (worker retry budget; dead-letter at the ceiling).</description></item>
+///   <item><description>handler <c>RevokeOldAsync</c> throw ⇒ best-effort
+///     log+continue (the store-side revoke already happened); the row
+///     still completes.</description></item>
+///   <item><description>already-<c>Revoked</c> version ⇒ idempotent
+///     no-op; the row completes.</description></item>
+/// </list>
+/// </summary>
+public sealed class RetireSecretVersionTaskHandler : IPlatformTaskHandler
+{
+    private readonly IRetireTaskExecutor _executor;
+    private readonly IPlatformQueuedTaskRepository _repo;
+    private readonly ILogger<RetireSecretVersionTaskHandler> _logger;
+
+    public RetireSecretVersionTaskHandler(
+        IRetireTaskExecutor executor,
+        IPlatformQueuedTaskRepository repo,
+        ILogger<RetireSecretVersionTaskHandler> logger)
+    {
+        _executor = executor;
+        _repo = repo;
+        _logger = logger;
+    }
+
+    public string TaskType => RetireScheduler.TaskType;
+
+    public async Task HandleAsync(PlatformQueuedTask task, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+
+        RetireTaskPayload? payload;
+        try
+        {
+            payload = string.IsNullOrWhiteSpace(task.Payload)
+                ? null
+                : JsonSerializer.Deserialize<RetireTaskPayload>(task.Payload);
+        }
+        catch (JsonException ex)
+        {
+            // Will never parse — terminal so the worker dead-letters
+            // immediately (no retry budget burned).
+            throw new PlatformTaskTerminalException(
+                $"malformed_payload: retire task {task.Id} has unparseable JSON: {ex.Message}",
+                ex);
+        }
+
+        if (payload is null || payload.SecretId == Guid.Empty || payload.VersionNumber <= 0)
+        {
+            throw new PlatformTaskTerminalException(
+                $"malformed_payload: retire task {task.Id} payload is empty or missing secretId/versionNumber.");
+        }
+
+        if (payload.RunAfter > DateTimeOffset.UtcNow)
+        {
+            // Not due yet — DEFER, do not fail. Return the row to 'pending'
+            // with VisibleAt = runAfter and the retry count UNCHANGED, then
+            // throw PlatformTaskDeferredException so the worker treats it as
+            // a no-op (no CompleteAsync clobber, no FailAsync budget burn).
+            //
+            // Under normal operation this path is unreachable: the scheduler
+            // stamps VisibleAt = runAfter at enqueue, so ReserveNextAsync
+            // won't claim a future row at all. This belt-and-suspenders only
+            // fires on a clock-skew edge (row reserved a hair before its
+            // window). The OLD code threw an ordinary exception → FailAsync
+            // bumped RetryCount with no run-after → the row was re-delivered
+            // every ~5s poll and dead-lettered in ~25s, destroying the
+            // scheduled retirement before its grace. THAT is the bug closed.
+            _logger.LogDebug(
+                "secret.retire.not_yet_due taskId={TaskId} secret={Secret} v{Version} runAfter={RunAfter:o}",
+                task.Id, payload.SecretId, payload.VersionNumber, payload.RunAfter);
+            await _repo.DeferAsync(task.Id, payload.RunAfter.UtcDateTime, ct).ConfigureAwait(false);
+            throw new PlatformTaskDeferredException(
+                $"not_yet_due: retire task {task.Id} deferred until {payload.RunAfter:o}.");
+        }
+
+        try
+        {
+            // Idempotent body (shared with the periodic sweeper). A
+            // throwing RevokeOld is swallowed inside the executor; a
+            // gateway throw propagates here as a retryable failure.
+            await _executor.RetireOneAsync(payload, task.Id, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Worker shutdown — leave the row in 'processing' for the
+            // reaper. RetireVersionAsync is idempotent so the re-run is
+            // safe.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "secret.retire.failed taskId={TaskId} secret={Secret} v{Version}",
+                task.Id, payload.SecretId, payload.VersionNumber);
+            // Ordinary throw — worker FailAsync (retry budget, dead-letter
+            // at the ceiling).
+            throw;
+        }
+
+        _logger.LogInformation(
+            "secret.retire.completed taskId={TaskId} secret={Secret} v{Version}",
+            task.Id, payload.SecretId, payload.VersionNumber);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Rotation/RetireSweepHostedService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Rotation/RetireSweepHostedService.cs
@@ -1,0 +1,129 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Tamma.Activities.SecretsRotation.Contracts;
+using Tamma.Api.Services.Secrets.Postgres;
+
+namespace Tamma.Api.Services.Secrets.Rotation;
+
+/// <summary>
+/// Options for <see cref="RetireSweepHostedService"/>. Bound to the
+/// <c>RetireSweep</c> configuration section.
+/// </summary>
+public sealed class RetireSweepOptions
+{
+    public const string SectionName = "RetireSweep";
+
+    /// <summary>
+    /// How often the sweeper drains due <c>RETIRE_SECRET_VERSION</c> rows.
+    /// Default 1 minute — retires are low-frequency (grace windows are in
+    /// minutes-to-hours) so a coarse cadence keeps the queue scan cheap
+    /// while still draining a due retire promptly after its window opens.
+    /// </summary>
+    public TimeSpan PollInterval { get; set; } = TimeSpan.FromMinutes(1);
+}
+
+/// <summary>
+/// Story 29-6 (review fix) — the ACTIVE retire-tail drainer.
+///
+/// <para><b>Why this exists.</b> The retire tail must drain even though
+/// <c>PlatformTaskWorker:RunOnStartup</c> stays <c>false</c> (the worker is
+/// not yet safe to enable for ALL platform-task types). The AC8-specified
+/// per-task <see cref="RetireSecretVersionTaskHandler"/> only runs WHEN that
+/// worker polls; with the worker gated off, nothing was draining
+/// <c>RETIRE_SECRET_VERSION</c> rows at all. This dedicated hosted service
+/// periodically calls <see cref="RetireScheduler.SweepDueRetireTasksAsync"/>
+/// — which reserves ONLY due rows (the <c>VisibleAt</c> reservation guard
+/// keeps not-yet-due rows untouched and never dead-letters them) and routes
+/// each through the SAME <see cref="IRetireTaskExecutor"/> body the handler
+/// uses, so the two drainers can't drift.</para>
+///
+/// <para><b>Independent of <c>PlatformTaskWorker</c>.</b> The sweeper's
+/// <c>ReserveNextAsync</c> only acts on <c>RETIRE_SECRET_VERSION</c> rows it
+/// can parse; any other reserved type is immediately put back
+/// (<c>FailAsync(maxRetries: int.MaxValue)</c>) so it stays pending for the
+/// (currently gated-off) generic worker. Running this sweeper does NOT
+/// enable the generic worker and does NOT change any other task type's
+/// reservation or dead-letter behaviour.</para>
+///
+/// <para>Mirrors the <see cref="SecretAutoRotationScheduler"/> /
+/// <c>HourlyAnalyticsRollupScheduler</c> shape: a lightweight
+/// poll-the-clock <see cref="BackgroundService"/>. Always on once the
+/// secret cabinet is wired (no opt-in flag) because draining a scheduled
+/// retirement is a correctness requirement, not an optional feature —
+/// without it the old credential never reaches <c>Revoked</c>.</para>
+/// </summary>
+public sealed class RetireSweepHostedService : BackgroundService
+{
+    private readonly IServiceProvider _services;
+    private readonly IOptions<RetireSweepOptions> _options;
+    private readonly ILogger<RetireSweepHostedService> _logger;
+
+    public RetireSweepHostedService(
+        IServiceProvider services,
+        IOptions<RetireSweepOptions> options,
+        ILogger<RetireSweepHostedService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(logger);
+        _services = services;
+        _options = options;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var opts = _options.Value;
+        _logger.LogInformation(
+            "RetireSweepHostedService running poll={PollSeconds}s — active retire-tail drainer "
+            + "(PlatformTaskWorker:RunOnStartup may stay false).",
+            opts.PollInterval.TotalSeconds);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await SweepOnceAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "RetireSweepHostedService tick threw; continuing.");
+            }
+
+            try
+            {
+                await Task.Delay(opts.PollInterval, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { break; }
+        }
+
+        _logger.LogInformation("RetireSweepHostedService shut down.");
+    }
+
+    private async Task SweepOnceAsync(CancellationToken ct)
+    {
+        await using var scope = _services.CreateAsyncScope();
+
+        // No Postgres secret cabinet wired (dev / test without the cabinet)
+        // ⇒ there can be no retire rows to drain. Not an error — skip.
+        var dbFactory = scope.ServiceProvider
+            .GetService<IDbContextFactory<SecretsDbContext>>();
+        if (dbFactory is null) return;
+
+        var scheduler = scope.ServiceProvider.GetRequiredService<IRetireScheduler>();
+        var processed = await scheduler.SweepDueRetireTasksAsync(ct).ConfigureAwait(false);
+        if (processed > 0)
+        {
+            _logger.LogInformation(
+                "secret.retire.sweep drained={Drained}", processed);
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Rotation/RetireTaskExecutor.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Rotation/RetireTaskExecutor.cs
@@ -1,0 +1,111 @@
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.SecretsRotation.Contracts;
+
+namespace Tamma.Api.Services.Secrets.Rotation;
+
+/// <summary>
+/// Story 29-6 AC8 — default <see cref="IRetireTaskExecutor"/>. Holds the
+/// single-version retire body shared by the per-task
+/// <c>RetireSecretVersionTaskHandler</c> and the periodic
+/// <see cref="RetireScheduler.SweepDueRetireTasksAsync"/> fallback.
+/// </summary>
+public sealed class RetireTaskExecutor : IRetireTaskExecutor
+{
+    private readonly ISecretRotationGateway _gateway;
+    private readonly IRotationHandlerRegistry _registry;
+    private readonly IRotationAuditEmitter _auditor;
+    private readonly ILogger<RetireTaskExecutor> _logger;
+
+    public RetireTaskExecutor(
+        ISecretRotationGateway gateway,
+        IRotationHandlerRegistry registry,
+        IRotationAuditEmitter auditor,
+        ILogger<RetireTaskExecutor> logger)
+    {
+        _gateway = gateway;
+        _registry = registry;
+        _auditor = auditor;
+        _logger = logger;
+    }
+
+    public async Task RetireOneAsync(
+        RetireTaskPayload payload, Guid taskId, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+
+        // Fetch the old plaintext BEFORE retiring so the handler's
+        // RevokeOld can use it (e.g. Postgres can ALTER ROLE with the
+        // last-known password). After RetireVersionAsync scrubs the
+        // ciphertext this read would return null.
+        var oldPlaintext = await _gateway
+            .GetVersionPlaintextAsync(payload.SecretId, payload.VersionNumber, ct)
+            .ConfigureAwait(false);
+
+        // Idempotent: an already-revoked version is a no-op inside the
+        // gateway. This is the AC8 "idempotent on already-Revoked" edge.
+        await _gateway
+            .RetireVersionAsync(payload.SecretId, payload.VersionNumber, ct)
+            .ConfigureAwait(false);
+
+        var snapshot = await _gateway
+            .GetSnapshotAsync(payload.SecretId, ct)
+            .ConfigureAwait(false);
+
+        if (snapshot is not null && oldPlaintext is not null)
+        {
+            var handler = _registry.Resolve(snapshot.ConsumerSystem);
+            if (handler is not null)
+            {
+                try
+                {
+                    var target = new RotationTarget(
+                        snapshot.SecretId,
+                        snapshot.Name,
+                        snapshot.TenantId,
+                        snapshot.ConsumerSystem,
+                        snapshot.ConsumerIdentifier,
+                        NewVersionNumber: snapshot.ActiveVersionNumber,
+                        PreviousVersionNumber: payload.VersionNumber);
+                    await handler
+                        .RevokeOldAsync(
+                            target,
+                            oldPlaintext,
+                            new RotationContext(
+                                payload.RotationCorrelationId,
+                                Guid.Empty,
+                                DryRun: false,
+                                new Dictionary<string, string>()),
+                            ct)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    // Best-effort: the version is already Revoked in the
+                    // store; a handler-cleanup hiccup must not undo that
+                    // or fail the queue row.
+                    _logger.LogWarning(ex,
+                        "RevokeOldAsync threw for secret {Secret} v{Version}; " +
+                        "version is still revoked in the store but the handler's " +
+                        "cleanup did not complete.",
+                        payload.SecretId, payload.VersionNumber);
+                }
+            }
+        }
+
+        await _auditor
+            .EmitAsync(
+                RotationAuditEvent.Create(
+                    RotationAuditEvents.VersionRetired,
+                    payload.SecretId,
+                    snapshot?.TenantId,
+                    payload.RotationCorrelationId,
+                    versionNumber: payload.VersionNumber,
+                    data: new Dictionary<string, object?>
+                    {
+                        ["taskId"] = taskId,
+                        ["versionNumber"] = payload.VersionNumber,
+                    }),
+                ct)
+            .ConfigureAwait(false);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Rotation/RetireTaskPayload.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Rotation/RetireTaskPayload.cs
@@ -1,0 +1,32 @@
+namespace Tamma.Api.Services.Secrets.Rotation;
+
+/// <summary>
+/// Story 29-6 AC8 — JSON payload shape for a <c>RETIRE_SECRET_VERSION</c>
+/// <c>platform_queued_tasks</c> row. Enqueued by
+/// <see cref="RetireScheduler.ScheduleRetireAsync"/> at the end of a
+/// successful rotation and drained either by the per-task
+/// <c>RetireSecretVersionTaskHandler</c> (the AC8-specified
+/// <c>PlatformTaskWorker</c> route) or by
+/// <see cref="RetireScheduler.SweepDueRetireTasksAsync"/> (periodic
+/// fallback). <c>PlatformQueuedTask</c> does not model a first-class
+/// <c>RunAfter</c> column, so the grace-window deadline travels in the
+/// payload and the drainer enforces it.
+/// </summary>
+public sealed class RetireTaskPayload
+{
+    /// <summary>Secret whose old version is being retired.</summary>
+    public Guid SecretId { get; set; }
+
+    /// <summary>Monotonic version number to flip <c>RetiredGrace → Revoked</c>.</summary>
+    public int VersionNumber { get; set; }
+
+    /// <summary>
+    /// Absolute UTC deadline — the drainer refuses to retire before
+    /// this instant (re-queues as retryable) so the grace window is
+    /// honoured even though the queue has no run-after column.
+    /// </summary>
+    public DateTimeOffset RunAfter { get; set; }
+
+    /// <summary>Correlation id of the rotation saga that scheduled this.</summary>
+    public string RotationCorrelationId { get; set; } = string.Empty;
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Rotation/RotationTriggerService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Rotation/RotationTriggerService.cs
@@ -1,0 +1,129 @@
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.SecretsRotation.Contracts;
+
+namespace Tamma.Api.Services.Secrets.Rotation;
+
+/// <summary>
+/// Story 29-6 (audit gap #2 + #3) — default
+/// <see cref="IRotationTriggerService"/>. Bridges a rotation trigger
+/// (operator endpoint or scheduled auto-rotation) to the
+/// <c>rotate-secret</c> Elsa workflow over the existing HTTP dispatch
+/// seam (<see cref="IElsaWorkflowService"/>), with the per-secret
+/// concurrency guard in front.
+///
+/// <para><b>No empty/plain fallback</b>: this service does NOT pre-resolve
+/// the handler or skip secrets with no consumer. A secret with no handler
+/// is dispatched anyway and the saga emits
+/// <c>SECRET.ROTATION.FAILED(handler_not_registered)</c> — an honest,
+/// audited failure rather than a silent skip.</para>
+/// </summary>
+public sealed class RotationTriggerService : IRotationTriggerService
+{
+    /// <summary>Workflow definition id of <c>RotateSecretWorkflow</c>.</summary>
+    public const string WorkflowDefinitionId = "rotate-secret";
+
+    private readonly ISecretRotationGateway _gateway;
+    private readonly IRotationAuditEmitter _auditor;
+    private readonly IElsaWorkflowService _workflows;
+    private readonly ILogger<RotationTriggerService> _logger;
+
+    public RotationTriggerService(
+        ISecretRotationGateway gateway,
+        IRotationAuditEmitter auditor,
+        IElsaWorkflowService workflows,
+        ILogger<RotationTriggerService> logger)
+    {
+        _gateway = gateway;
+        _auditor = auditor;
+        _workflows = workflows;
+        _logger = logger;
+    }
+
+    public async Task<RotationTriggerResult> TriggerRotationAsync(
+        Guid secretId,
+        Guid operatorUserId,
+        string? newPlaintext,
+        int? generateLength,
+        long graceWindowSeconds,
+        CancellationToken ct)
+    {
+        if (secretId == Guid.Empty)
+            throw new ArgumentException("secretId must be a non-empty Guid", nameof(secretId));
+
+        var correlationId = $"rot_{Guid.NewGuid():N}";
+
+        // Resolve the secret's tenant scope for audit tagging. A
+        // not-found secret is still dispatched — the saga short-circuits
+        // to SECRET.ROTATION.FAILED(secret_not_found), an honest failure.
+        var snapshot = await _gateway.GetSnapshotAsync(secretId, ct).ConfigureAwait(false);
+        var tenantId = snapshot?.TenantId;
+
+        // #3 — per-secret concurrency guard. Reject (do NOT dispatch) when
+        // a rotation is already in flight.
+        var acquired = await _gateway
+            .TryBeginRotationAsync(secretId, correlationId, ct)
+            .ConfigureAwait(false);
+        if (!acquired)
+        {
+            await _auditor.EmitAsync(
+                RotationAuditEvent.Create(
+                    RotationAuditEvents.Rejected,
+                    secretId,
+                    tenantId,
+                    correlationId,
+                    detail: "rotation_in_progress"),
+                ct).ConfigureAwait(false);
+            _logger.LogWarning(
+                "secret.rotation.rejected secret={Secret} reason=rotation_in_progress", secretId);
+            return new RotationTriggerResult(
+                Accepted: false, correlationId, Reason: "rotation_in_progress");
+        }
+
+        var input = new Dictionary<string, object>
+        {
+            ["secretId"] = secretId.ToString(),
+            ["rotationCorrelationId"] = correlationId,
+            ["operatorUserId"] = operatorUserId.ToString(),
+            ["graceWindowSeconds"] = graceWindowSeconds,
+        };
+        if (!string.IsNullOrEmpty(newPlaintext))
+            input["newPlaintext"] = newPlaintext;
+        else if (generateLength is > 0)
+            input["generateLength"] = generateLength.Value;
+
+        try
+        {
+            await _workflows.StartWorkflowAsync(WorkflowDefinitionId, input).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // Dispatch failed before the saga minted a pending version —
+            // release the claim so a retry isn't blocked by a phantom
+            // in-flight marker. (No-op for the status-check backend, but
+            // correct for advisory-lock backends.)
+            await _gateway.EndRotationAsync(secretId, correlationId, ct).ConfigureAwait(false);
+            throw;
+        }
+
+        await _auditor.EmitAsync(
+            RotationAuditEvent.Create(
+                RotationAuditEvents.Requested,
+                secretId,
+                tenantId,
+                correlationId,
+                data: new Dictionary<string, object?>
+                {
+                    ["operatorUserId"] = operatorUserId,
+                    ["graceWindowSeconds"] = graceWindowSeconds,
+                    // NEVER the plaintext — only whether one was supplied.
+                    ["generated"] = string.IsNullOrEmpty(newPlaintext),
+                }),
+            ct).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "secret.rotation.requested secret={Secret} corr={Corr} operator={Operator}",
+            secretId, correlationId, operatorUserId);
+
+        return new RotationTriggerResult(Accepted: true, correlationId, Reason: null);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Rotation/SecretAutoRotationScheduler.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Rotation/SecretAutoRotationScheduler.cs
@@ -1,0 +1,198 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Tamma.Api.Services.Secrets.Postgres;
+
+namespace Tamma.Api.Services.Secrets.Rotation;
+
+/// <summary>
+/// Options for <see cref="SecretAutoRotationScheduler"/>. Bound to the
+/// <c>SecretAutoRotation</c> configuration section.
+/// </summary>
+public sealed class SecretAutoRotationSchedulerOptions
+{
+    public const string SectionName = "SecretAutoRotation";
+
+    /// <summary>
+    /// When <c>true</c> the scheduler dispatches the <c>rotate-secret</c>
+    /// workflow for each due secret on the poll cadence. <b>Default
+    /// <c>false</c></b> — an operator opts in once the Elsa engine and
+    /// rotation handlers are deployed (the workflow is dispatched over
+    /// HTTP to the engine). Tests + non-rotation composition roots leave
+    /// this off so no background loop spawns.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// How often the scheduler scans for due secrets. Default 5 minutes
+    /// — auto-rotation is a low-frequency cadence (intervals are in
+    /// days), so a coarse poll keeps the DB scan cheap.
+    /// </summary>
+    public TimeSpan PollInterval { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Default retire grace window (seconds) handed to each dispatched
+    /// rotation. 0 ⇒ the saga's own default (15 min).
+    /// </summary>
+    public long GraceWindowSeconds { get; set; }
+}
+
+/// <summary>
+/// Story 29-6 (audit gap #2b) — scheduled auto-rotation. Mirrors the
+/// <c>HourlyAnalyticsRollupScheduler</c> shape: a lightweight
+/// poll-the-clock <see cref="BackgroundService"/> that selects secrets
+/// whose <c>NextRotationDueAt</c> has elapsed and dispatches the
+/// <c>rotate-secret</c> workflow for each with
+/// <c>operatorUserId = Guid.Empty</c> (system actor).
+///
+/// <para><b>No empty/plain fallback</b>: a due secret with no consumer /
+/// handler is still dispatched — the saga emits
+/// <c>SECRET.ROTATION.FAILED(handler_not_registered)</c> (an honest,
+/// audited failure) rather than being silently skipped.</para>
+///
+/// <para><b>Double-dispatch safety</b>: the
+/// <see cref="IRotationTriggerService"/> takes the per-secret concurrency
+/// guard before dispatch, so an in-flight rotation (operator click or a
+/// prior tick still running) is rejected with
+/// <c>SECRET.ROTATION.REJECTED(rotation_in_progress)</c> rather than
+/// double-pushed.</para>
+///
+/// <para>The clock is the only state — <c>NextRotationDueAt</c> moves
+/// forward only after the saga activates (the gateway stamps
+/// <c>LastRotatedAt</c>; the metadata layer recomputes the next-due), so
+/// a crash mid-rotation re-selects the same secret on the next tick and
+/// the guard keeps it from stacking.</para>
+/// </summary>
+public sealed class SecretAutoRotationScheduler : BackgroundService
+{
+    private readonly IServiceProvider _services;
+    private readonly IOptions<SecretAutoRotationSchedulerOptions> _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<SecretAutoRotationScheduler> _logger;
+
+    public SecretAutoRotationScheduler(
+        IServiceProvider services,
+        IOptions<SecretAutoRotationSchedulerOptions> options,
+        TimeProvider timeProvider,
+        ILogger<SecretAutoRotationScheduler> logger)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentNullException.ThrowIfNull(logger);
+        _services = services;
+        _options = options;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var opts = _options.Value;
+        if (!opts.Enabled)
+        {
+            _logger.LogDebug(
+                "SecretAutoRotationScheduler disabled (Enabled=false) — not scanning for due secrets.");
+            return;
+        }
+
+        _logger.LogInformation(
+            "SecretAutoRotationScheduler running poll={PollSeconds}s grace={Grace}s",
+            opts.PollInterval.TotalSeconds, opts.GraceWindowSeconds);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await TickAsync(opts, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "SecretAutoRotationScheduler tick threw; continuing.");
+            }
+
+            try
+            {
+                await Task.Delay(opts.PollInterval, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { break; }
+        }
+
+        _logger.LogInformation("SecretAutoRotationScheduler shut down.");
+    }
+
+    /// <summary>
+    /// Test-only entry point so unit tests can drive a single scan
+    /// without spinning the BackgroundService loop. Returns the number of
+    /// secrets for which a rotation was dispatched (accepted by the
+    /// guard).
+    /// </summary>
+    internal Task<int> ScanOnceForTestsAsync(CancellationToken ct) =>
+        TickAsync(_options.Value, ct);
+
+    private async Task<int> TickAsync(
+        SecretAutoRotationSchedulerOptions opts, CancellationToken ct)
+    {
+        await using var scope = _services.CreateAsyncScope();
+        var dbFactory = scope.ServiceProvider
+            .GetService<IDbContextFactory<SecretsDbContext>>();
+        if (dbFactory is null)
+        {
+            // No Postgres secrets wired (dev / test without the cabinet) —
+            // nothing to scan. Not an error.
+            return 0;
+        }
+        var trigger = scope.ServiceProvider.GetRequiredService<IRotationTriggerService>();
+
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+
+        List<Guid> dueIds;
+        await using (var db = await dbFactory.CreateDbContextAsync(ct).ConfigureAwait(false))
+        {
+            dueIds = await db.Secrets
+                .AsNoTracking()
+                .Where(s => s.NextRotationDueAt != null && s.NextRotationDueAt <= now)
+                .Select(s => s.Id)
+                .ToListAsync(ct)
+                .ConfigureAwait(false);
+        }
+
+        if (dueIds.Count == 0) return 0;
+
+        var dispatched = 0;
+        foreach (var secretId in dueIds)
+        {
+            ct.ThrowIfCancellationRequested();
+            try
+            {
+                var result = await trigger.TriggerRotationAsync(
+                    secretId,
+                    operatorUserId: Guid.Empty,
+                    newPlaintext: null,        // saga CSPRNG-generates
+                    generateLength: null,      // saga default length
+                    graceWindowSeconds: opts.GraceWindowSeconds,
+                    ct: ct).ConfigureAwait(false);
+                if (result.Accepted) dispatched++;
+            }
+            catch (Exception ex)
+            {
+                // One secret's dispatch failure must not abort the scan —
+                // the next tick re-selects it.
+                _logger.LogWarning(ex,
+                    "secret.auto_rotation.dispatch_failed secret={Secret}", secretId);
+            }
+        }
+
+        _logger.LogInformation(
+            "secret.auto_rotation.scan due={Due} dispatched={Dispatched}",
+            dueIds.Count, dispatched);
+        return dispatched;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Rotation/SecretRotationServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Rotation/SecretRotationServiceCollectionExtensions.cs
@@ -14,10 +14,21 @@ public static class SecretRotationServiceCollectionExtensions
 {
     public static IServiceCollection AddTammaSecretRotation(this IServiceCollection services)
     {
+        // Story 29-6 (review fix) — gateway options (stale-pending TTL).
+        // Registered so IOptions<SecretRotationGatewayOptions> resolves;
+        // Program.cs binds the SecretRotationGateway config section on top.
+        services.AddOptions<SecretRotationGatewayOptions>();
         services.AddScoped<ISecretRotationGateway, SecretStoreRotationGateway>();
         services.AddSingleton<IRotationHandlerRegistry, KeyedRotationHandlerRegistry>();
         services.AddScoped<IRotationAuditEmitter, RotationAuditEmitter>();
+        // Story 29-6 AC8 — the single-version retire body shared by the
+        // periodic sweeper and the per-task RetireSecretVersionTaskHandler.
+        services.AddScoped<IRetireTaskExecutor, RetireTaskExecutor>();
         services.AddScoped<IRetireScheduler, RetireScheduler>();
+        // Story 29-6 audit gap #2/#3 — the trigger surface (operator
+        // endpoint + scheduled auto-rotation): concurrency guard, fresh
+        // correlation id, rotate-secret dispatch, REQUESTED/REJECTED audit.
+        services.AddScoped<IRotationTriggerService, RotationTriggerService>();
 
         // Fallback generic-http handler (AC4). Uses a named HttpClient
         // so CI/operator can tune timeouts via the usual HttpClientFactory

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Rotation/SecretStoreRotationGateway.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Rotation/SecretStoreRotationGateway.cs
@@ -1,11 +1,33 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Tamma.Activities.SecretsRotation.Contracts;
 using Tamma.Api.Services.Secrets.Postgres;
 using Tamma.Data.Entities;
 
 namespace Tamma.Api.Services.Secrets.Rotation;
+
+/// <summary>
+/// Options for <see cref="SecretStoreRotationGateway"/>. Bound to the
+/// <c>SecretRotationGateway</c> configuration section.
+/// </summary>
+public sealed class SecretRotationGatewayOptions
+{
+    public const string SectionName = "SecretRotationGateway";
+
+    /// <summary>
+    /// Story 29-6 (review fix) — max age of a <c>pending</c> version row
+    /// before it is treated as ABANDONED (a saga that crashed after mint).
+    /// A stale pending marker older than this is reclaimable: the next
+    /// rotation trigger deletes it (+ scrubs its backend bytes) and
+    /// proceeds, so a crashed run can't wedge the secret forever. Default
+    /// 1 hour — comfortably longer than any healthy rotation saga (mint →
+    /// push → probe → activate completes in seconds-to-minutes), so a live
+    /// rotation is never mistaken for abandoned.
+    /// </summary>
+    public TimeSpan StalePendingTtl { get; set; } = TimeSpan.FromHours(1);
+}
 
 /// <summary>
 /// Story 29-6 — bridges the rotation activities'
@@ -29,24 +51,26 @@ namespace Tamma.Api.Services.Secrets.Rotation;
 /// </summary>
 public sealed class SecretStoreRotationGateway : ISecretRotationGateway
 {
-    private readonly IServiceProvider _services;
+    private readonly IDbContextFactory<SecretsDbContext> _dbFactory;
     private readonly ISecretStoreBackend _backend;
+    private readonly SecretRotationGatewayOptions _options;
     private readonly ILogger<SecretStoreRotationGateway> _logger;
 
     public SecretStoreRotationGateway(
-        IServiceProvider services,
+        IDbContextFactory<SecretsDbContext> dbFactory,
         ISecretStoreBackend backend,
+        IOptions<SecretRotationGatewayOptions> options,
         ILogger<SecretStoreRotationGateway> logger)
     {
-        _services = services;
+        _dbFactory = dbFactory;
         _backend = backend;
+        _options = options?.Value ?? new SecretRotationGatewayOptions();
         _logger = logger;
     }
 
     public async Task<SecretRotationSnapshot?> GetSnapshotAsync(Guid secretId, CancellationToken ct)
     {
-        using var scope = _services.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<SecretsDbContext>();
+        await using var db = await _dbFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
         var row = await db.Secrets
             .AsNoTracking()
             .FirstOrDefaultAsync(s => s.Id == secretId, ct)
@@ -70,8 +94,7 @@ public sealed class SecretStoreRotationGateway : ISecretRotationGateway
         Guid operatorUserId,
         CancellationToken ct)
     {
-        using var scope = _services.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<SecretsDbContext>();
+        await using var db = await _dbFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
 
         // Idempotency — if a pending version already exists (e.g.
         // Elsa replayed the activity), return its number.
@@ -109,7 +132,28 @@ public sealed class SecretStoreRotationGateway : ISecretRotationGateway
             CreatedAt = DateTime.UtcNow,
             CreatedByUserId = operatorUserId,
         });
-        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await db.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
+        catch (DbUpdateException ex) when (IsPendingUniqueViolation(ex))
+        {
+            // Story 29-6 (review fix) — the partial unique index
+            // UX_secret_versions_OnePendingPerSecret rejected this INSERT:
+            // a CONCURRENT rotation won the race and minted its own pending
+            // version between our "no existing pending" read and this write.
+            // This closes the TOCTOU: we must NOT silently reuse the other
+            // rotation's row (that was the silent-collapse + double-push
+            // bug). Fail loud with a retryable concurrency error so the saga
+            // surfaces SECRET.ROTATION.FAILED(rotation_in_progress) instead.
+            _logger.LogWarning(ex,
+                "Mint lost the per-secret pending-uniqueness race for secret {Secret} " +
+                "(corr {Corr}) — another rotation is in flight.",
+                secretId, rotationCorrelationId);
+            throw new InvalidOperationException(
+                $"rotation_in_progress: secret {secretId} already has an in-flight " +
+                "rotation (a concurrent mint won the per-secret pending claim).", ex);
+        }
 
         await _backend.PutVersionAsync(secretId, next, newPlaintext, ct).ConfigureAwait(false);
 
@@ -118,8 +162,7 @@ public sealed class SecretStoreRotationGateway : ISecretRotationGateway
 
     public async Task DeleteVersionAsync(Guid secretId, int versionNumber, CancellationToken ct)
     {
-        using var scope = _services.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<SecretsDbContext>();
+        await using var db = await _dbFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
         var row = await db.SecretVersions
             .FirstOrDefaultAsync(v => v.SecretId == secretId && v.VersionNumber == versionNumber, ct)
             .ConfigureAwait(false);
@@ -140,8 +183,7 @@ public sealed class SecretStoreRotationGateway : ISecretRotationGateway
         int previousVersionNumber,
         CancellationToken ct)
     {
-        using var scope = _services.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<SecretsDbContext>();
+        await using var db = await _dbFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
 
         var newRow = await db.SecretVersions
             .FirstOrDefaultAsync(v => v.SecretId == secretId && v.VersionNumber == newVersionNumber, ct)
@@ -186,8 +228,7 @@ public sealed class SecretStoreRotationGateway : ISecretRotationGateway
         int previousVersionNumber,
         CancellationToken ct)
     {
-        using var scope = _services.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<SecretsDbContext>();
+        await using var db = await _dbFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
 
         var newRow = await db.SecretVersions
             .FirstOrDefaultAsync(v => v.SecretId == secretId && v.VersionNumber == newVersionNumber, ct)
@@ -223,8 +264,7 @@ public sealed class SecretStoreRotationGateway : ISecretRotationGateway
 
     public async Task RetireVersionAsync(Guid secretId, int versionNumber, CancellationToken ct)
     {
-        using var scope = _services.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<SecretsDbContext>();
+        await using var db = await _dbFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
         var row = await db.SecretVersions
             .FirstOrDefaultAsync(v => v.SecretId == secretId && v.VersionNumber == versionNumber, ct)
             .ConfigureAwait(false);
@@ -252,6 +292,87 @@ public sealed class SecretStoreRotationGateway : ISecretRotationGateway
         {
             return Task.FromResult<string?>(null);
         }
+    }
+
+    public async Task<bool> TryBeginRotationAsync(
+        Guid secretId, string rotationCorrelationId, CancellationToken ct)
+    {
+        // Pre-dispatch guard: a secret with an existing Pending version row
+        // is already mid-rotation. The pending row IS the in-flight marker —
+        // it clears when the saga activates (Pending→Active) or compensates
+        // (deletes it). Two overlapping rotations would otherwise both mint a
+        // pending version and race the version-number sequence + double-push.
+        //
+        // This is a best-effort pre-check (the AUTHORITATIVE TOCTOU close is
+        // the partial unique index UX_secret_versions_OnePendingPerSecret +
+        // the unique-violation catch in MintPendingVersionAsync — two callers
+        // that both pass THIS check still can't both mint). Here we ALSO
+        // reclaim a STALE pending marker so a saga that crashed after mint
+        // can't wedge the secret forever.
+        await using var db = await _dbFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+        var pending = await db.SecretVersions
+            .Where(v => v.SecretId == secretId && v.Status == "pending")
+            .OrderByDescending(v => v.VersionNumber)
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+
+        if (pending is null) return true;
+
+        var age = DateTime.UtcNow - pending.CreatedAt;
+        if (age <= _options.StalePendingTtl)
+        {
+            _logger.LogWarning(
+                "Rotation rejected for secret {Secret} (corr {Corr}): a pending version " +
+                "(v{Version}, age {AgeSeconds:0}s) already exists — another rotation is in flight.",
+                secretId, rotationCorrelationId, pending.VersionNumber, age.TotalSeconds);
+            return false;
+        }
+
+        // The pending marker is older than the TTL — treat it as ABANDONED
+        // (a saga that crashed after mint). Reclaim it: hard-delete the row +
+        // scrub its backend bytes so the new rotation can proceed instead of
+        // being wedged forever. Then allow the caller. If a racing reclaim
+        // already removed it (or the row activated under us), the new mint
+        // simply re-checks; the unique index keeps the final state consistent.
+        _logger.LogWarning(
+            "Reclaiming ABANDONED pending version v{Version} for secret {Secret} " +
+            "(corr {Corr}, age {AgeSeconds:0}s > TTL {TtlSeconds:0}s) — a prior rotation " +
+            "saga appears to have crashed after mint; clearing the stale claim.",
+            pending.VersionNumber, secretId, rotationCorrelationId,
+            age.TotalSeconds, _options.StalePendingTtl.TotalSeconds);
+
+        db.SecretVersions.Remove(pending);
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await _backend.DeleteVersionAsync(secretId, pending.VersionNumber, ct)
+                .ConfigureAwait(false);
+        }
+        catch (KeyNotFoundException) { /* already scrubbed */ }
+
+        return true;
+    }
+
+    /// <summary>
+    /// True iff <paramref name="ex"/> is the Postgres unique violation
+    /// raised by the per-secret one-pending partial index
+    /// (<c>UX_secret_versions_OnePendingPerSecret</c>). Constrained to that
+    /// constraint name so an unrelated unique violation (e.g. the
+    /// SecretId+VersionNumber index) is NOT swallowed as a concurrency reject.
+    /// </summary>
+    private static bool IsPendingUniqueViolation(DbUpdateException ex)
+        => ex.InnerException is Npgsql.PostgresException pg
+            && pg.SqlState == Npgsql.PostgresErrorCodes.UniqueViolation
+            && (pg.ConstraintName is null
+                || pg.ConstraintName.Contains("OnePendingPerSecret", StringComparison.OrdinalIgnoreCase));
+
+    public Task EndRotationAsync(
+        Guid secretId, string rotationCorrelationId, CancellationToken ct)
+    {
+        // No-op for the status-check backend: the pending version row is
+        // the claim, and it is cleared by activate / compensation. An
+        // advisory-lock backend would release its lock here.
+        return Task.CompletedTask;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/PlatformQueuedTask.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/PlatformQueuedTask.cs
@@ -42,4 +42,20 @@ public class PlatformQueuedTask
     /// only after <c>RetryCount</c> reaches the configured ceiling.
     /// </summary>
     public DateTime? UnprocessableAt { get; set; }
+
+    /// <summary>
+    /// Story 29-6 (review fix) — reservation visibility timestamp.
+    /// <c>ReserveNextAsync</c> only claims a row when <c>VisibleAt</c> is
+    /// <c>NULL</c> OR has elapsed, so a deferred ("not yet due") task is
+    /// simply not reserved until its window opens instead of being
+    /// re-delivered every poll and dead-lettered before it is due.
+    ///
+    /// <para><b>Backward-compatible</b>: existing producers (MoveTenant,
+    /// ProvisionTenantV2, CreateBillingCustomer, installation routing)
+    /// leave this <c>NULL</c> ⇒ always visible ⇒ their reservation is
+    /// UNCHANGED. Only <c>RETIRE_SECRET_VERSION</c> rows set it (to the
+    /// payload's <c>runAfter</c>) so the grace window is enforced by the
+    /// queue itself, not by a per-task throw that burns the retry budget.</para>
+    /// </summary>
+    public DateTime? VisibleAt { get; set; }
 }

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260625150508_AddPlatformQueuedTaskVisibleAt.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260625150508_AddPlatformQueuedTaskVisibleAt.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.ControlPlane
 {
     [DbContext(typeof(ControlPlaneDbContext))]
-    partial class ControlPlaneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260625150508_AddPlatformQueuedTaskVisibleAt")]
+    partial class AddPlatformQueuedTaskVisibleAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260625150508_AddPlatformQueuedTaskVisibleAt.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260625150508_AddPlatformQueuedTaskVisibleAt.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.ControlPlane
+{
+    /// <inheritdoc />
+    public partial class AddPlatformQueuedTaskVisibleAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "VisibleAt",
+                table: "platform_queued_tasks",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "VisibleAt",
+                table: "platform_queued_tasks");
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/IPlatformQueuedTaskRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/IPlatformQueuedTaskRepository.cs
@@ -76,6 +76,21 @@ public interface IPlatformQueuedTaskRepository
     Task<PlatformQueuedTask?> ParkUnprocessableAsync(
         Guid id, string reason, int maxRetries, CancellationToken ct = default);
 
+    /// <summary>
+    /// Story 29-6 (review fix) — return a reserved task to <c>pending</c>
+    /// and (re)set its <see cref="PlatformQueuedTask.VisibleAt"/> so it is
+    /// not reserved again until <paramref name="visibleAt"/>. This is a
+    /// defer, NOT a failure: <see cref="PlatformQueuedTask.RetryCount"/> is
+    /// LEFT UNCHANGED so deferring never burns the retry budget or
+    /// dead-letters the row.
+    ///
+    /// <para>Used by the retire handler's belt-and-suspenders not-yet-due
+    /// path (the primary defence is that <see cref="ReserveNextAsync"/>
+    /// won't claim a future-<c>VisibleAt</c> row at all; this covers the
+    /// clock-skew edge where a row was reserved a hair before its window).</para>
+    /// </summary>
+    Task DeferAsync(Guid id, DateTime visibleAt, CancellationToken ct = default);
+
     /// <summary>Read a task by id, or <c>null</c>.</summary>
     Task<PlatformQueuedTask?> GetAsync(Guid id, CancellationToken ct = default);
 

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/PlatformQueuedTaskRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/PlatformQueuedTaskRepository.cs
@@ -78,6 +78,15 @@ public sealed class PlatformQueuedTaskRepository : IPlatformQueuedTaskRepository
         // flip to processing, return every column. FOR UPDATE SKIP LOCKED
         // lets concurrent workers in a multi-pod deploy each pick a
         // different row without retrying on lock contention.
+        //
+        // Story 29-6 (review fix) — the VisibleAt guard:
+        //   ("VisibleAt" IS NULL OR "VisibleAt" <= now)
+        // is BACKWARD-COMPATIBLE. Every existing producer (MoveTenant,
+        // ProvisionTenantV2, CreateBillingCustomer, installation routing)
+        // leaves VisibleAt NULL ⇒ the predicate is always true ⇒ their
+        // reservation is byte-for-byte unchanged. Only RETIRE_SECRET_VERSION
+        // sets VisibleAt = runAfter, so a not-yet-due retire is simply not
+        // reserved (never re-delivered, never dead-lettered before its grace).
         var rows = await _db.PlatformQueuedTasks.FromSqlInterpolated($"""
             UPDATE platform_queued_tasks
             SET "Status" = 'processing',
@@ -87,6 +96,7 @@ public sealed class PlatformQueuedTaskRepository : IPlatformQueuedTaskRepository
             WHERE "Id" = (
                 SELECT "Id" FROM platform_queued_tasks
                 WHERE "Status" = 'pending'
+                  AND ("VisibleAt" IS NULL OR "VisibleAt" <= {now})
                 ORDER BY "CreatedAt" ASC
                 FOR UPDATE SKIP LOCKED
                 LIMIT 1
@@ -100,14 +110,18 @@ public sealed class PlatformQueuedTaskRepository : IPlatformQueuedTaskRepository
     private async Task<PlatformQueuedTask?> ReserveViaNaivePathAsync(
         string workerId, CancellationToken ct)
     {
+        // Story 29-6 (review fix) — mirror the Postgres VisibleAt guard so
+        // the InMemory test path enforces the same not-yet-due semantics:
+        // a row with a future VisibleAt is skipped (NULL = always visible).
+        var now = DateTime.UtcNow;
         var task = await _db.PlatformQueuedTasks
-            .Where(t => t.Status == "pending")
+            .Where(t => t.Status == "pending"
+                && (t.VisibleAt == null || t.VisibleAt <= now))
             .OrderBy(t => t.CreatedAt)
             .FirstOrDefaultAsync(ct);
 
         if (task is null) return null;
 
-        var now = DateTime.UtcNow;
         task.Status = "processing";
         task.ClaimedAt = now;
         task.ClaimedBy = workerId;
@@ -185,6 +199,24 @@ public sealed class PlatformQueuedTaskRepository : IPlatformQueuedTaskRepository
 
         await _db.SaveChangesAsync(ct);
         return task;
+    }
+
+    public async Task DeferAsync(Guid id, DateTime visibleAt, CancellationToken ct = default)
+    {
+        var task = await _db.PlatformQueuedTasks.FindAsync(new object[] { id }, ct);
+        if (task is null) return;
+
+        var now = DateTime.UtcNow;
+        // Return to the pending pool WITHOUT touching RetryCount — a defer
+        // is not a failure. The (re)set VisibleAt keeps ReserveNextAsync from
+        // re-claiming the row until the window opens, so the row can't be
+        // re-delivered every poll and can't dead-letter before it is due.
+        task.Status = "pending";
+        task.ClaimedAt = null;
+        task.ClaimedBy = null;
+        task.VisibleAt = visibleAt;
+        task.UpdatedAt = now;
+        await _db.SaveChangesAsync(ct);
     }
 
     public async Task DeadLetterAsync(Guid id, string error, CancellationToken ct = default)

--- a/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
@@ -639,6 +639,10 @@ internal static class TammaModelConfiguration
             // Nullable; non-null only on rows currently parked waiting
             // for a handler to be deployed.
             entity.Property(e => e.UnprocessableAt);
+            // Story 29-6 (review fix) — reservation visibility timestamp.
+            // NULL = always visible (every existing producer); a future
+            // value defers reservation until it elapses (RETIRE_SECRET_VERSION).
+            entity.Property(e => e.VisibleAt);
 
             entity.HasIndex(e => new { e.Status, e.CreatedAt });
             entity.HasIndex(e => e.TenantId).HasFilter("\"TenantId\" IS NOT NULL");

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/SecretsRotation/SagaRunnerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/SecretsRotation/SagaRunnerTests.cs
@@ -343,6 +343,12 @@ internal sealed class StubGateway : ISecretRotationGateway
 
         public Task<string?> GetVersionPlaintextAsync(Guid secretId, int versionNumber, CancellationToken ct) =>
             Task.FromResult(Plaintexts.TryGetValue((secretId, versionNumber), out var p) ? p : null);
+
+        public Task<bool> TryBeginRotationAsync(Guid secretId, string rotationCorrelationId, CancellationToken ct) =>
+            Task.FromResult(true);
+
+        public Task EndRotationAsync(Guid secretId, string rotationCorrelationId, CancellationToken ct) =>
+            Task.CompletedTask;
     }
 
 internal sealed class StubHandler : IRotationHandler

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Secrets/Handlers/CranlEnvVarRotationHandlerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Secrets/Handlers/CranlEnvVarRotationHandlerTests.cs
@@ -263,5 +263,11 @@ public class CranlEnvVarRotationHandlerTests
         public Task RetireVersionAsync(Guid s, int v, CancellationToken ct) => Task.CompletedTask;
         public Task<string?> GetVersionPlaintextAsync(Guid s, int v, CancellationToken ct) =>
             Task.FromResult(Plaintexts.TryGetValue((s, v), out var p) ? p : null);
+
+        public Task<bool> TryBeginRotationAsync(Guid s, string rotationCorrelationId, CancellationToken ct) =>
+            Task.FromResult(true);
+
+        public Task EndRotationAsync(Guid s, string rotationCorrelationId, CancellationToken ct) =>
+            Task.CompletedTask;
     }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Secrets/Handlers/PostgresRoleRotationHandlerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Secrets/Handlers/PostgresRoleRotationHandlerTests.cs
@@ -256,5 +256,11 @@ public class PostgresRoleRotationHandlerTests
 
         public Task<string?> GetVersionPlaintextAsync(Guid secretId, int v, CancellationToken ct) =>
             Task.FromResult(Plaintexts.TryGetValue((secretId, v), out var p) ? p : null);
+
+        public Task<bool> TryBeginRotationAsync(Guid secretId, string rotationCorrelationId, CancellationToken ct) =>
+            Task.FromResult(true);
+
+        public Task EndRotationAsync(Guid secretId, string rotationCorrelationId, CancellationToken ct) =>
+            Task.CompletedTask;
     }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Secrets/Rotation/RetireSecretVersionTaskHandlerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Secrets/Rotation/RetireSecretVersionTaskHandlerTests.cs
@@ -1,0 +1,307 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Activities.SecretsRotation.Contracts;
+using Tamma.Api.Services.PlatformTasks;
+using Tamma.Api.Services.Secrets.Rotation;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Secrets.Rotation;
+
+/// <summary>
+/// Story 29-6 AC8 — tests for the <c>RETIRE_SECRET_VERSION</c> platform
+/// task handler. The handler is the AC8-specified
+/// <see cref="PlatformTaskWorker"/> route that finally drains the retire
+/// tail (closing the type-blind dead-letter hazard). Failure semantics
+/// are delegated to the worker via the handler's return / throw:
+///
+/// <list type="bullet">
+///   <item><description>malformed payload ⇒ <see cref="PlatformTaskTerminalException"/>
+///     (worker dead-letters, no retry budget burned).</description></item>
+///   <item><description><c>runAfter &gt; now</c> ⇒ ordinary throw (worker
+///     <c>FailAsync</c> → re-queue, NOT dead-letter).</description></item>
+///   <item><description>retire throw ⇒ ordinary throw (worker retry budget).</description></item>
+///   <item><description>happy path ⇒ returns, emits <c>SECRET.VERSION.RETIRED</c>,
+///     invokes the handler's <c>RevokeOldAsync</c>, idempotent on
+///     already-revoked.</description></item>
+/// </list>
+/// </summary>
+[TestFixture]
+public sealed class RetireSecretVersionTaskHandlerTests
+{
+    private static readonly Guid SecretA = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    private static RetireSecretVersionTaskHandler BuildHandler(
+        StubGateway gateway, StubRegistry registry, StubAuditor auditor,
+        StubQueueRepo? repo = null)
+    {
+        var executor = new RetireTaskExecutor(
+            gateway, registry, auditor,
+            NullLogger<RetireTaskExecutor>.Instance);
+        return new RetireSecretVersionTaskHandler(
+            executor, repo ?? new StubQueueRepo(),
+            NullLogger<RetireSecretVersionTaskHandler>.Instance);
+    }
+
+    private static PlatformQueuedTask BuildTask(RetireTaskPayload payload) => new()
+    {
+        Id = Guid.NewGuid(),
+        Type = RetireScheduler.TaskType,
+        Payload = JsonSerializer.Serialize(payload),
+    };
+
+    [Test]
+    public void TaskType_IsRetireSecretVersion()
+    {
+        var handler = BuildHandler(new StubGateway(), new StubRegistry(), new StubAuditor());
+        handler.TaskType.Should().Be("RETIRE_SECRET_VERSION");
+        handler.TaskType.Should().Be(RetireScheduler.TaskType);
+    }
+
+    [Test]
+    public async Task DueTask_Retires_RevokesOld_EmitsRetiredEvent()
+    {
+        var gateway = new StubGateway();
+        gateway.Snapshots[SecretA] = new SecretRotationSnapshot(
+            SecretA, "db/app-role", null, "postgres", "role=app", ActiveVersionNumber: 3);
+        gateway.Plaintexts[(SecretA, 2)] = "old-pw";
+        gateway.Versions[(SecretA, 2)] = "retired_grace";
+        var handler = new StubHandler("postgres");
+        var registry = new StubRegistry { ["postgres"] = handler };
+        var auditor = new StubAuditor();
+        var sut = BuildHandler(gateway, registry, auditor);
+
+        await sut.HandleAsync(BuildTask(new RetireTaskPayload
+        {
+            SecretId = SecretA,
+            VersionNumber = 2,
+            RunAfter = DateTimeOffset.UtcNow.AddMinutes(-1),
+            RotationCorrelationId = "rot_x",
+        }), default);
+
+        gateway.Versions[(SecretA, 2)].Should().Be("revoked");
+        handler.RevokedOldPlaintext.Should().Be("old-pw");
+        auditor.Events.Select(e => e.EventType)
+            .Should().Contain(RotationAuditEvents.VersionRetired);
+    }
+
+    [Test]
+    public async Task NotYetDue_Defers_NotDeadLettered_NoRetryBudgetBurn()
+    {
+        var gateway = new StubGateway();
+        gateway.Snapshots[SecretA] = new SecretRotationSnapshot(
+            SecretA, "db/app-role", null, "postgres", "role=app", ActiveVersionNumber: 3);
+        var repo = new StubQueueRepo();
+        var sut = BuildHandler(gateway, new StubRegistry(), new StubAuditor(), repo);
+
+        var runAfter = DateTimeOffset.UtcNow.AddMinutes(30);
+        var task = BuildTask(new RetireTaskPayload
+        {
+            SecretId = SecretA,
+            VersionNumber = 2,
+            RunAfter = runAfter,
+            RotationCorrelationId = "rot_x",
+        });
+
+        var act = async () => await sut.HandleAsync(task, default);
+
+        // Review fix: a not-yet-due retire is DEFERRED, not failed. The
+        // handler throws PlatformTaskDeferredException (worker treats it as a
+        // no-op: no CompleteAsync clobber, no FailAsync retry-budget burn /
+        // dead-letter) AND it is explicitly NOT a terminal exception.
+        var thrown = await Record(act);
+        thrown.Should().BeOfType<PlatformTaskDeferredException>();
+        thrown.Should().NotBeOfType<PlatformTaskTerminalException>();
+        // The row was deferred until runAfter (VisibleAt pushed forward),
+        // with the retry count untouched.
+        repo.Deferred.Should().ContainSingle();
+        repo.Deferred[0].Id.Should().Be(task.Id);
+        repo.Deferred[0].VisibleAt.Should().BeCloseTo(runAfter.UtcDateTime, TimeSpan.FromSeconds(1));
+        // No store mutation, no event.
+        gateway.RetireCalls.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task MalformedPayload_Throws_Terminal_DeadLetters()
+    {
+        var sut = BuildHandler(new StubGateway(), new StubRegistry(), new StubAuditor());
+        var task = new PlatformQueuedTask
+        {
+            Id = Guid.NewGuid(),
+            Type = RetireScheduler.TaskType,
+            Payload = "not json {{{",
+        };
+
+        var act = async () => await sut.HandleAsync(task, default);
+
+        var ex = await act.Should().ThrowAsync<PlatformTaskTerminalException>();
+        ex.Which.Message.Should().Contain("malformed_payload");
+    }
+
+    [Test]
+    public async Task EmptyPayload_Throws_Terminal()
+    {
+        var sut = BuildHandler(new StubGateway(), new StubRegistry(), new StubAuditor());
+        var task = new PlatformQueuedTask
+        {
+            Id = Guid.NewGuid(),
+            Type = RetireScheduler.TaskType,
+            Payload = string.Empty,
+        };
+
+        await FluentActions.Awaiting(() => sut.HandleAsync(task, default))
+            .Should().ThrowAsync<PlatformTaskTerminalException>();
+    }
+
+    [Test]
+    public async Task RetireThrow_Bubbles_AsRetryable()
+    {
+        var gateway = new StubGateway { RetireException = new InvalidOperationException("db down") };
+        gateway.Snapshots[SecretA] = new SecretRotationSnapshot(
+            SecretA, "db/app-role", null, "postgres", "role=app", ActiveVersionNumber: 3);
+        var sut = BuildHandler(gateway, new StubRegistry(), new StubAuditor());
+
+        var act = async () => await sut.HandleAsync(BuildTask(new RetireTaskPayload
+        {
+            SecretId = SecretA,
+            VersionNumber = 2,
+            RunAfter = DateTimeOffset.UtcNow.AddMinutes(-1),
+            RotationCorrelationId = "rot_x",
+        }), default);
+
+        var thrown = await Record(act);
+        thrown.Should().NotBeNull();
+        thrown.Should().NotBeOfType<PlatformTaskTerminalException>();
+    }
+
+    [Test]
+    public async Task AlreadyRevoked_IsNoOp_StillEmitsAndCompletes()
+    {
+        var gateway = new StubGateway();
+        gateway.Snapshots[SecretA] = new SecretRotationSnapshot(
+            SecretA, "db/app-role", null, "postgres", "role=app", ActiveVersionNumber: 3);
+        gateway.Versions[(SecretA, 2)] = "revoked"; // already terminal
+        var sut = BuildHandler(gateway, new StubRegistry(), new StubAuditor());
+
+        // No throw — handler returns so the worker marks completed.
+        await sut.HandleAsync(BuildTask(new RetireTaskPayload
+        {
+            SecretId = SecretA,
+            VersionNumber = 2,
+            RunAfter = DateTimeOffset.UtcNow.AddMinutes(-1),
+            RotationCorrelationId = "rot_x",
+        }), default);
+
+        gateway.Versions[(SecretA, 2)].Should().Be("revoked");
+    }
+
+    private static async Task<Exception?> Record(Func<Task> act)
+    {
+        try { await act(); return null; }
+        catch (Exception ex) { return ex; }
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Stubs
+
+    private sealed class StubGateway : ISecretRotationGateway
+    {
+        public Dictionary<Guid, SecretRotationSnapshot> Snapshots { get; } = new();
+        public Dictionary<(Guid, int), string> Versions { get; } = new();
+        public Dictionary<(Guid, int), string> Plaintexts { get; } = new();
+        public List<(Guid, int)> RetireCalls { get; } = new();
+        public Exception? RetireException { get; set; }
+
+        public Task<SecretRotationSnapshot?> GetSnapshotAsync(Guid secretId, CancellationToken ct) =>
+            Task.FromResult(Snapshots.TryGetValue(secretId, out var s) ? s : null);
+
+        public Task<int> MintPendingVersionAsync(Guid secretId, string newPlaintext, string rotationCorrelationId, Guid operatorUserId, CancellationToken ct) =>
+            Task.FromResult(0);
+
+        public Task DeleteVersionAsync(Guid secretId, int versionNumber, CancellationToken ct) => Task.CompletedTask;
+
+        public Task ActivateVersionAsync(Guid secretId, int newVersionNumber, int previousVersionNumber, CancellationToken ct) => Task.CompletedTask;
+
+        public Task RevertActivationAsync(Guid secretId, int newVersionNumber, int previousVersionNumber, CancellationToken ct) => Task.CompletedTask;
+
+        public Task RetireVersionAsync(Guid secretId, int versionNumber, CancellationToken ct)
+        {
+            if (RetireException is not null) throw RetireException;
+            RetireCalls.Add((secretId, versionNumber));
+            if (Versions.TryGetValue((secretId, versionNumber), out var status) && status == "revoked")
+                return Task.CompletedTask; // idempotent
+            Versions[(secretId, versionNumber)] = "revoked";
+            Plaintexts.Remove((secretId, versionNumber));
+            return Task.CompletedTask;
+        }
+
+        public Task<string?> GetVersionPlaintextAsync(Guid secretId, int versionNumber, CancellationToken ct) =>
+            Task.FromResult(Plaintexts.TryGetValue((secretId, versionNumber), out var p) ? p : null);
+
+        public Task<bool> TryBeginRotationAsync(Guid secretId, string rotationCorrelationId, CancellationToken ct) =>
+            Task.FromResult(true);
+
+        public Task EndRotationAsync(Guid secretId, string rotationCorrelationId, CancellationToken ct) =>
+            Task.CompletedTask;
+    }
+
+    private sealed class StubHandler : IRotationHandler
+    {
+        public StubHandler(string system) => System = system;
+        public string System { get; }
+        public string? RevokedOldPlaintext;
+        public Task PushAsync(RotationTarget t, string p, RotationContext c, CancellationToken ct) => Task.CompletedTask;
+        public Task<ProbeResult> ProbeAsync(RotationTarget t, RotationContext c, CancellationToken ct) => Task.FromResult(ProbeResult.Healthy(1));
+        public Task RollbackAsync(RotationTarget t, string p, RotationContext c, CancellationToken ct) => Task.CompletedTask;
+        public Task RevokeOldAsync(RotationTarget t, string oldPlaintext, RotationContext c, CancellationToken ct)
+        {
+            RevokedOldPlaintext = oldPlaintext;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class StubRegistry : IRotationHandlerRegistry
+    {
+        private readonly Dictionary<string, IRotationHandler> _h = new();
+        public IRotationHandler? Resolve(string system) => _h.TryGetValue(system, out var h) ? h : null;
+        public IRotationHandler this[string key] { get => _h[key]; set => _h[key] = value; }
+    }
+
+    private sealed class StubAuditor : IRotationAuditEmitter
+    {
+        public ConcurrentBag<RotationAuditEvent> Events { get; } = new();
+        public Task EmitAsync(RotationAuditEvent evt, CancellationToken ct) { Events.Add(evt); return Task.CompletedTask; }
+    }
+
+    /// <summary>
+    /// Minimal queue-repo stub: records DeferAsync calls (the only method
+    /// the handler invokes) and no-ops the rest.
+    /// </summary>
+    private sealed class StubQueueRepo : IPlatformQueuedTaskRepository
+    {
+        public List<(Guid Id, DateTime VisibleAt)> Deferred { get; } = new();
+
+        public Task<PlatformQueuedTask> EnqueueAsync(PlatformQueuedTask task, CancellationToken ct = default)
+            => Task.FromResult(task);
+        public Task<PlatformQueuedTask?> ReserveNextAsync(string workerId, CancellationToken ct = default)
+            => Task.FromResult<PlatformQueuedTask?>(null);
+        public Task CompleteAsync(Guid id, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<PlatformQueuedTask?> FailAsync(Guid id, string error, int maxRetries, CancellationToken ct = default)
+            => Task.FromResult<PlatformQueuedTask?>(null);
+        public Task DeadLetterAsync(Guid id, string error, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<PlatformQueuedTask?> ParkUnprocessableAsync(Guid id, string reason, int maxRetries, CancellationToken ct = default)
+            => Task.FromResult<PlatformQueuedTask?>(null);
+        public Task DeferAsync(Guid id, DateTime visibleAt, CancellationToken ct = default)
+        {
+            Deferred.Add((id, visibleAt));
+            return Task.CompletedTask;
+        }
+        public Task<PlatformQueuedTask?> GetAsync(Guid id, CancellationToken ct = default)
+            => Task.FromResult<PlatformQueuedTask?>(null);
+        public Task<int> ReapStaleProcessingAsync(TimeSpan visibilityTimeout, int maxRetries, CancellationToken ct = default)
+            => Task.FromResult(0);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Secrets/Rotation/RetireTailEndToEndTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Secrets/Rotation/RetireTailEndToEndTests.cs
@@ -1,0 +1,322 @@
+using System.Collections.Concurrent;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using Tamma.Activities.SecretsRotation.Contracts;
+using Tamma.Api.Services.PlatformTasks;
+using Tamma.Api.Services.Secrets.Rotation;
+using Tamma.Data;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Secrets.Rotation;
+
+/// <summary>
+/// Story 29-6 AC7/AC8 (audit gap #10) — durable end-to-end test of the
+/// RETIRE TAIL. Proves the "old retired" leg that was previously
+/// untestable end-to-end (the sweeper / handler was unwired):
+///
+/// <list type="number">
+///   <item><description>A rotation has activated, leaving a previous
+///     version in <c>RetiredGrace</c> and a due
+///     <c>RETIRE_SECRET_VERSION</c> task enqueued (via the real
+///     <see cref="RetireScheduler.ScheduleRetireAsync"/>).</description></item>
+///   <item><description>The real <see cref="PlatformTaskWorker"/> reserves
+///     the row and routes it to the real
+///     <see cref="RetireSecretVersionTaskHandler"/>.</description></item>
+///   <item><description>Assert the old version → <c>Revoked</c>,
+///     <c>SECRET.VERSION.RETIRED</c> emitted, the queue row
+///     <c>completed</c>, and the handler's <c>RevokeOldAsync</c> ran.</description></item>
+/// </list>
+///
+/// <para>Also pins the grace-window edge: a NOT-yet-due retire row is
+/// re-queued (retryable, NOT dead-lettered) so the secret keeps its old
+/// credential until the window expires.</para>
+/// </summary>
+[TestFixture]
+public sealed class RetireTailEndToEndTests
+{
+    private static readonly Guid SecretA = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    private string _dbName = null!;
+    private StubGateway _gateway = null!;
+    private StubRegistry _registry = null!;
+    private StubAuditor _auditor = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _dbName = $"retire-e2e-{Guid.NewGuid():N}";
+        _gateway = new StubGateway();
+        _registry = new StubRegistry();
+        _auditor = new StubAuditor();
+    }
+
+    /// <summary>
+    /// Build a self-contained SP wiring the control-plane queue repo, the
+    /// rotation ports (stubbed gateway/registry/auditor + real executor),
+    /// and the real RetireSecretVersionTaskHandler in the platform-task
+    /// registry — so the real PlatformTaskWorker drives the real handler.
+    /// </summary>
+    private ServiceProvider BuildProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContext<ControlPlaneDbContext>(o => o.UseInMemoryDatabase(_dbName));
+        services.AddScoped<IPlatformQueuedTaskRepository, PlatformQueuedTaskRepository>();
+
+        services.AddSingleton<ISecretRotationGateway>(_gateway);
+        services.AddSingleton<IRotationHandlerRegistry>(_registry);
+        services.AddSingleton<IRotationAuditEmitter>(_auditor);
+        services.AddScoped<IRetireTaskExecutor, RetireTaskExecutor>();
+        services.AddScoped<IRetireScheduler, RetireScheduler>();
+
+        // The retire handler in the platform-task registry.
+        services.AddScoped<IPlatformTaskHandler, RetireSecretVersionTaskHandler>();
+        services.AddScoped<IPlatformTaskHandlerRegistry, PlatformTaskHandlerRegistry>();
+
+        return services.BuildServiceProvider();
+    }
+
+    private static PlatformTaskWorker NewWorker(IServiceProvider sp) =>
+        new(sp,
+            Options.Create(new PlatformTaskWorkerOptions { RunOnStartup = false, MaxRetries = 5 }),
+            TimeProvider.System,
+            NullLogger<PlatformTaskWorker>.Instance);
+
+    [Test]
+    public async Task ActivatedThenDrain_OldVersionRevoked_RetiredEventEmitted()
+    {
+        // Arrange: a secret with v3 active, v2 in retired_grace + handler.
+        _gateway.Snapshots[SecretA] = new SecretRotationSnapshot(
+            SecretA, "db/app-role", null, "postgres", "role=app", ActiveVersionNumber: 3);
+        _gateway.Versions[(SecretA, 2)] = "retired_grace";
+        _gateway.Plaintexts[(SecretA, 2)] = "old-pw";
+        var rotationHandler = new StubHandler("postgres");
+        _registry["postgres"] = rotationHandler;
+
+        var sp = BuildProvider();
+
+        // Enqueue a DUE retire task via the real scheduler.
+        Guid taskId;
+        await using (var scope = sp.CreateAsyncScope())
+        {
+            var scheduler = scope.ServiceProvider.GetRequiredService<IRetireScheduler>();
+            taskId = await scheduler.ScheduleRetireAsync(
+                SecretA, versionNumber: 2, tenantId: null,
+                runAfter: DateTimeOffset.UtcNow.AddMinutes(-1),
+                rotationCorrelationId: "rot_e2e", ct: default);
+        }
+
+        // Act: drive the real worker once → routes to the retire handler.
+        var worker = NewWorker(sp);
+        var processed = await worker.ProcessOnceAsync(default);
+
+        // Assert.
+        processed.Should().BeTrue();
+        _gateway.Versions[(SecretA, 2)].Should().Be("revoked");
+        rotationHandler.RevokedOldPlaintext.Should().Be("old-pw");
+        _auditor.Events.Select(e => e.EventType)
+            .Should().Contain(RotationAuditEvents.VersionRetired);
+
+        await using var verifyScope = sp.CreateAsyncScope();
+        var repo = verifyScope.ServiceProvider.GetRequiredService<IPlatformQueuedTaskRepository>();
+        var row = await repo.GetAsync(taskId);
+        row!.Status.Should().Be("completed");
+
+        sp.Dispose();
+    }
+
+    [Test]
+    public async Task NotYetDue_OverManyTicks_NeverReservedNeverDeadLettered()
+    {
+        // Review fix (lost-retire bug): a freshly-scheduled retire (default
+        // grace 900s) must NOT be dead-lettered before it is due. The OLD
+        // code re-delivered the row every ~5s poll and hit MaxRetries (5) in
+        // ~25s → dead_letter → the old credential never reached Revoked. The
+        // single-tick test gave false confidence; drive MANY ticks (more than
+        // MaxRetries=5) and assert the row stays pending the whole time.
+        _gateway.Snapshots[SecretA] = new SecretRotationSnapshot(
+            SecretA, "db/app-role", null, "postgres", "role=app", ActiveVersionNumber: 3);
+        _gateway.Versions[(SecretA, 2)] = "retired_grace";
+        _gateway.Plaintexts[(SecretA, 2)] = "old-pw";
+
+        var sp = BuildProvider();
+
+        Guid taskId;
+        await using (var scope = sp.CreateAsyncScope())
+        {
+            var scheduler = scope.ServiceProvider.GetRequiredService<IRetireScheduler>();
+            taskId = await scheduler.ScheduleRetireAsync(
+                SecretA, 2, null,
+                runAfter: DateTimeOffset.UtcNow.AddHours(1),    // not due
+                rotationCorrelationId: "rot_future", ct: default);
+        }
+
+        var worker = NewWorker(sp);
+
+        // Far more ticks than MaxRetries (5) — the old code dead-lettered by
+        // tick 5. With VisibleAt = runAfter the row is simply NOT reserved,
+        // so every tick observes an empty queue (ProcessOnceAsync == false).
+        for (var tick = 0; tick < 12; tick++)
+        {
+            var processed = await worker.ProcessOnceAsync(default);
+            processed.Should().BeFalse(
+                "a not-yet-due retire row must not be reserved (VisibleAt guard)");
+
+            await using var checkScope = sp.CreateAsyncScope();
+            var checkRepo = checkScope.ServiceProvider.GetRequiredService<IPlatformQueuedTaskRepository>();
+            var current = await checkRepo.GetAsync(taskId);
+            current!.Status.Should().Be("pending", $"tick {tick}: row stays pending until due");
+            current.Status.Should().NotBe("dead_letter");
+            current.RetryCount.Should().Be(0, $"tick {tick}: a deferred row never burns the retry budget");
+        }
+
+        // Old version untouched; row still pending, never dead-lettered.
+        _gateway.Versions[(SecretA, 2)].Should().Be("retired_grace");
+
+        sp.Dispose();
+    }
+
+    [Test]
+    public async Task NotYetDue_BecomesDue_ThenDrains()
+    {
+        // The complement: once VisibleAt elapses, the SAME row is reserved
+        // and drained normally (proves VisibleAt gates, not blocks forever).
+        _gateway.Snapshots[SecretA] = new SecretRotationSnapshot(
+            SecretA, "db/app-role", null, "postgres", "role=app", ActiveVersionNumber: 3);
+        _gateway.Versions[(SecretA, 2)] = "retired_grace";
+        _gateway.Plaintexts[(SecretA, 2)] = "old-pw";
+        _registry["postgres"] = new StubHandler("postgres");
+
+        var sp = BuildProvider();
+
+        Guid taskId;
+        await using (var scope = sp.CreateAsyncScope())
+        {
+            var scheduler = scope.ServiceProvider.GetRequiredService<IRetireScheduler>();
+            // Already-due window so the very first tick reserves + drains it.
+            taskId = await scheduler.ScheduleRetireAsync(
+                SecretA, 2, null,
+                runAfter: DateTimeOffset.UtcNow.AddSeconds(-1),
+                rotationCorrelationId: "rot_due", ct: default);
+        }
+
+        var worker = NewWorker(sp);
+        var processed = await worker.ProcessOnceAsync(default);
+
+        processed.Should().BeTrue();
+        _gateway.Versions[(SecretA, 2)].Should().Be("revoked");
+        await using var verifyScope = sp.CreateAsyncScope();
+        var repo = verifyScope.ServiceProvider.GetRequiredService<IPlatformQueuedTaskRepository>();
+        var row = await repo.GetAsync(taskId);
+        row!.Status.Should().Be("completed");
+
+        sp.Dispose();
+    }
+
+    [Test]
+    public async Task Sweeper_DrainsDue_LeavesNotDuePending()
+    {
+        // The ACTIVE drainer (RetireSweepHostedService calls this) must
+        // drain a DUE row and leave a NOT-DUE row pending — proving retires
+        // drain even with PlatformTaskWorker:RunOnStartup=false.
+        _gateway.Snapshots[SecretA] = new SecretRotationSnapshot(
+            SecretA, "db/app-role", null, "postgres", "role=app", ActiveVersionNumber: 3);
+        _gateway.Versions[(SecretA, 2)] = "retired_grace";
+        _gateway.Plaintexts[(SecretA, 2)] = "old-pw";
+        _gateway.Versions[(SecretA, 1)] = "retired_grace";
+        _gateway.Plaintexts[(SecretA, 1)] = "older-pw";
+        _registry["postgres"] = new StubHandler("postgres");
+
+        var sp = BuildProvider();
+
+        Guid dueId, notDueId;
+        await using (var scope = sp.CreateAsyncScope())
+        {
+            var scheduler = scope.ServiceProvider.GetRequiredService<IRetireScheduler>();
+            dueId = await scheduler.ScheduleRetireAsync(
+                SecretA, 2, null, DateTimeOffset.UtcNow.AddSeconds(-1), "rot_due", default);
+            notDueId = await scheduler.ScheduleRetireAsync(
+                SecretA, 1, null, DateTimeOffset.UtcNow.AddHours(1), "rot_future", default);
+        }
+
+        int drained;
+        await using (var scope = sp.CreateAsyncScope())
+        {
+            var scheduler = scope.ServiceProvider.GetRequiredService<IRetireScheduler>();
+            drained = await scheduler.SweepDueRetireTasksAsync(default);
+        }
+
+        drained.Should().Be(1, "only the due row is reservable (VisibleAt guard)");
+        _gateway.Versions[(SecretA, 2)].Should().Be("revoked");
+        _gateway.Versions[(SecretA, 1)].Should().Be("retired_grace", "not-due row untouched");
+
+        await using var verify = sp.CreateAsyncScope();
+        var repo = verify.ServiceProvider.GetRequiredService<IPlatformQueuedTaskRepository>();
+        (await repo.GetAsync(dueId))!.Status.Should().Be("completed");
+        var notDue = await repo.GetAsync(notDueId);
+        notDue!.Status.Should().Be("pending");
+        notDue.RetryCount.Should().Be(0);
+
+        sp.Dispose();
+    }
+
+    // ── Stubs ────────────────────────────────────────────────────────
+
+    private sealed class StubGateway : ISecretRotationGateway
+    {
+        public Dictionary<Guid, SecretRotationSnapshot> Snapshots { get; } = new();
+        public Dictionary<(Guid, int), string> Versions { get; } = new();
+        public Dictionary<(Guid, int), string> Plaintexts { get; } = new();
+
+        public Task<SecretRotationSnapshot?> GetSnapshotAsync(Guid secretId, CancellationToken ct) =>
+            Task.FromResult(Snapshots.TryGetValue(secretId, out var s) ? s : null);
+        public Task<int> MintPendingVersionAsync(Guid s, string p, string c, Guid o, CancellationToken ct) => Task.FromResult(0);
+        public Task DeleteVersionAsync(Guid s, int v, CancellationToken ct) => Task.CompletedTask;
+        public Task ActivateVersionAsync(Guid s, int n, int p, CancellationToken ct) => Task.CompletedTask;
+        public Task RevertActivationAsync(Guid s, int n, int p, CancellationToken ct) => Task.CompletedTask;
+        public Task RetireVersionAsync(Guid secretId, int versionNumber, CancellationToken ct)
+        {
+            if (Versions.TryGetValue((secretId, versionNumber), out var status) && status == "revoked")
+                return Task.CompletedTask;
+            Versions[(secretId, versionNumber)] = "revoked";
+            Plaintexts.Remove((secretId, versionNumber));
+            return Task.CompletedTask;
+        }
+        public Task<string?> GetVersionPlaintextAsync(Guid secretId, int versionNumber, CancellationToken ct) =>
+            Task.FromResult(Plaintexts.TryGetValue((secretId, versionNumber), out var p) ? p : null);
+        public Task<bool> TryBeginRotationAsync(Guid s, string c, CancellationToken ct) => Task.FromResult(true);
+        public Task EndRotationAsync(Guid s, string c, CancellationToken ct) => Task.CompletedTask;
+    }
+
+    private sealed class StubHandler : IRotationHandler
+    {
+        public StubHandler(string system) => System = system;
+        public string System { get; }
+        public string? RevokedOldPlaintext;
+        public Task PushAsync(RotationTarget t, string p, RotationContext c, CancellationToken ct) => Task.CompletedTask;
+        public Task<ProbeResult> ProbeAsync(RotationTarget t, RotationContext c, CancellationToken ct) => Task.FromResult(ProbeResult.Healthy(1));
+        public Task RollbackAsync(RotationTarget t, string p, RotationContext c, CancellationToken ct) => Task.CompletedTask;
+        public Task RevokeOldAsync(RotationTarget t, string oldPlaintext, RotationContext c, CancellationToken ct)
+        {
+            RevokedOldPlaintext = oldPlaintext;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class StubRegistry : IRotationHandlerRegistry
+    {
+        private readonly Dictionary<string, IRotationHandler> _h = new();
+        public IRotationHandler? Resolve(string system) => _h.TryGetValue(system, out var h) ? h : null;
+        public IRotationHandler this[string key] { get => _h[key]; set => _h[key] = value; }
+    }
+
+    private sealed class StubAuditor : IRotationAuditEmitter
+    {
+        public ConcurrentBag<RotationAuditEvent> Events { get; } = new();
+        public Task EmitAsync(RotationAuditEvent evt, CancellationToken ct) { Events.Add(evt); return Task.CompletedTask; }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Secrets/Rotation/RotationTriggerServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Secrets/Rotation/RotationTriggerServiceTests.cs
@@ -1,0 +1,176 @@
+using System.Collections.Concurrent;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Activities.SecretsRotation.Contracts;
+using Tamma.Api.Services;
+using Tamma.Api.Services.Secrets.Rotation;
+
+namespace Tamma.Api.Tests.Secrets.Rotation;
+
+/// <summary>
+/// Story 29-6 (audit gap #2 + #3) — tests for the
+/// <see cref="RotationTriggerService"/>: mint a correlation id, take the
+/// per-secret concurrency guard, dispatch <c>rotate-secret</c>, and emit
+/// <c>SECRET.ROTATION.REQUESTED</c> / <c>SECRET.ROTATION.REJECTED</c>.
+/// Plaintext is never placed on the audit event.
+/// </summary>
+[TestFixture]
+public sealed class RotationTriggerServiceTests
+{
+    private static readonly Guid SecretA = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid TenantA = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static readonly Guid Operator = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+
+    private static RotationTriggerService Build(
+        StubGateway gateway, StubAuditor auditor, StubWorkflows workflows) =>
+        new(gateway, auditor, workflows, NullLogger<RotationTriggerService>.Instance);
+
+    [Test]
+    public async Task Trigger_WhenNotInFlight_Dispatches_And_EmitsRequested()
+    {
+        var gateway = new StubGateway { CanBegin = true };
+        gateway.Snapshots[SecretA] = new SecretRotationSnapshot(
+            SecretA, "db/app", TenantA, "postgres", "role=app", 1);
+        var auditor = new StubAuditor();
+        var workflows = new StubWorkflows();
+        var sut = Build(gateway, auditor, workflows);
+
+        var result = await sut.TriggerRotationAsync(
+            SecretA, Operator, newPlaintext: "supplied-pw", generateLength: null,
+            graceWindowSeconds: 60, ct: default);
+
+        result.Accepted.Should().BeTrue();
+        result.RotationCorrelationId.Should().StartWith("rot_");
+        workflows.Dispatches.Should().HaveCount(1);
+        workflows.Dispatches[0].WorkflowName.Should().Be("rotate-secret");
+        workflows.Dispatches[0].Input["secretId"].Should().Be(SecretA.ToString());
+        workflows.Dispatches[0].Input["rotationCorrelationId"].Should().Be(result.RotationCorrelationId);
+        workflows.Dispatches[0].Input.Should().ContainKey("newPlaintext");
+
+        var requested = auditor.Events.Single(e => e.EventType == RotationAuditEvents.Requested);
+        requested.SecretId.Should().Be(SecretA);
+        requested.TenantId.Should().Be(TenantA);
+        // NEVER the plaintext on the audit event.
+        requested.Data.Values
+            .Where(v => v is string)
+            .Cast<string>()
+            .Should().NotContain(s => s.Contains("supplied-pw"));
+        requested.Data["generated"].Should().Be(false);
+    }
+
+    [Test]
+    public async Task Trigger_NoPlaintext_PassesGenerateLength()
+    {
+        var gateway = new StubGateway { CanBegin = true };
+        var auditor = new StubAuditor();
+        var workflows = new StubWorkflows();
+        var sut = Build(gateway, auditor, workflows);
+
+        var result = await sut.TriggerRotationAsync(
+            SecretA, Guid.Empty, newPlaintext: null, generateLength: 48,
+            graceWindowSeconds: 0, ct: default);
+
+        result.Accepted.Should().BeTrue();
+        workflows.Dispatches[0].Input.Should().NotContainKey("newPlaintext");
+        workflows.Dispatches[0].Input["generateLength"].Should().Be(48);
+        auditor.Events.Single(e => e.EventType == RotationAuditEvents.Requested)
+            .Data["generated"].Should().Be(true);
+    }
+
+    [Test]
+    public async Task Trigger_WhenInFlight_Rejects_EmitsRejected_NoDispatch()
+    {
+        var gateway = new StubGateway { CanBegin = false };
+        var auditor = new StubAuditor();
+        var workflows = new StubWorkflows();
+        var sut = Build(gateway, auditor, workflows);
+
+        var result = await sut.TriggerRotationAsync(
+            SecretA, Operator, "pw", null, 0, default);
+
+        result.Accepted.Should().BeFalse();
+        result.Reason.Should().Be("rotation_in_progress");
+        workflows.Dispatches.Should().BeEmpty();
+        var rejected = auditor.Events.Single(e => e.EventType == RotationAuditEvents.Rejected);
+        rejected.Detail.Should().Be("rotation_in_progress");
+        auditor.Events.Should().NotContain(e => e.EventType == RotationAuditEvents.Requested);
+    }
+
+    [Test]
+    public async Task Trigger_DispatchThrows_ReleasesGuard_AndPropagates()
+    {
+        var gateway = new StubGateway { CanBegin = true };
+        var auditor = new StubAuditor();
+        var workflows = new StubWorkflows { ThrowOnDispatch = new InvalidOperationException("engine down") };
+        var sut = Build(gateway, auditor, workflows);
+
+        var act = async () => await sut.TriggerRotationAsync(SecretA, Operator, "pw", null, 0, default);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        gateway.EndCalls.Should().Contain(SecretA);
+        auditor.Events.Should().NotContain(e => e.EventType == RotationAuditEvents.Requested);
+    }
+
+    [Test]
+    public async Task Trigger_EmptySecretId_Throws()
+    {
+        var sut = Build(new StubGateway(), new StubAuditor(), new StubWorkflows());
+        await FluentActions
+            .Awaiting(() => sut.TriggerRotationAsync(Guid.Empty, Operator, "pw", null, 0, default))
+            .Should().ThrowAsync<ArgumentException>();
+    }
+
+    // ── Stubs ────────────────────────────────────────────────────────
+
+    private sealed class StubGateway : ISecretRotationGateway
+    {
+        public bool CanBegin { get; set; } = true;
+        public Dictionary<Guid, SecretRotationSnapshot> Snapshots { get; } = new();
+        public List<Guid> EndCalls { get; } = new();
+
+        public Task<SecretRotationSnapshot?> GetSnapshotAsync(Guid secretId, CancellationToken ct) =>
+            Task.FromResult(Snapshots.TryGetValue(secretId, out var s) ? s : null);
+        public Task<int> MintPendingVersionAsync(Guid s, string p, string c, Guid o, CancellationToken ct) => Task.FromResult(0);
+        public Task DeleteVersionAsync(Guid s, int v, CancellationToken ct) => Task.CompletedTask;
+        public Task ActivateVersionAsync(Guid s, int n, int p, CancellationToken ct) => Task.CompletedTask;
+        public Task RevertActivationAsync(Guid s, int n, int p, CancellationToken ct) => Task.CompletedTask;
+        public Task RetireVersionAsync(Guid s, int v, CancellationToken ct) => Task.CompletedTask;
+        public Task<string?> GetVersionPlaintextAsync(Guid s, int v, CancellationToken ct) => Task.FromResult<string?>(null);
+        public Task<bool> TryBeginRotationAsync(Guid secretId, string corr, CancellationToken ct) => Task.FromResult(CanBegin);
+        public Task EndRotationAsync(Guid secretId, string corr, CancellationToken ct)
+        {
+            EndCalls.Add(secretId);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class StubAuditor : IRotationAuditEmitter
+    {
+        public ConcurrentBag<RotationAuditEvent> Events { get; } = new();
+        public Task EmitAsync(RotationAuditEvent evt, CancellationToken ct) { Events.Add(evt); return Task.CompletedTask; }
+    }
+
+    private sealed class StubWorkflows : IElsaWorkflowService
+    {
+        public List<(string WorkflowName, Dictionary<string, object> Input)> Dispatches { get; } = new();
+        public Exception? ThrowOnDispatch { get; set; }
+
+        public Task<string> StartWorkflowAsync(string workflowName, Dictionary<string, object> input)
+        {
+            if (ThrowOnDispatch is not null) throw ThrowOnDispatch;
+            Dispatches.Add((workflowName, input));
+            return Task.FromResult(Guid.NewGuid().ToString());
+        }
+
+        public Task PauseWorkflowAsync(string instanceId) => Task.CompletedTask;
+        public Task ResumeWorkflowAsync(string instanceId) => Task.CompletedTask;
+        public Task CancelWorkflowAsync(string instanceId) => Task.CompletedTask;
+        public Task<WorkflowStatus> GetWorkflowStatusAsync(string instanceId) => Task.FromResult(new WorkflowStatus());
+        public Task SendSignalAsync(string instanceId, string signalName, object? payload = null) => Task.CompletedTask;
+        public Task<MergeApprovalResumeResult> ResumeMergeApprovalAsync(int i, int p, string? t, string? r, string d, string? f, string? a) =>
+            Task.FromResult(new MergeApprovalResumeResult(false, false, null));
+        public Task<MergeApprovalResumeResult> ResumeDeploymentApprovalAsync(int i, string? t, string? r, string? sha, string d, string? f, string? a) =>
+            Task.FromResult(new MergeApprovalResumeResult(false, false, null));
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Services/ElsaWorkflowServiceLoggingTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Services/ElsaWorkflowServiceLoggingTests.cs
@@ -1,0 +1,125 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using Tamma.Api.Services;
+using Tamma.Api.Tests.Infrastructure;
+
+namespace Tamma.Api.Tests.Services;
+
+/// <summary>
+/// Review fix (CRITICAL) — <see cref="ElsaWorkflowService.StartWorkflowAsync"/>
+/// must NEVER log the dispatch input's values. The rotate-secret dispatch puts
+/// the operator's NEW secret plaintext under the <c>newPlaintext</c> key; the
+/// previous code destructured the entire dict (<c>{@Input}</c>) at Information
+/// level, leaking the plaintext in cleartext. The fix logs the workflow name +
+/// the input KEY SET only (sensitive keys shown as <c>name=[redacted]</c>).
+///
+/// <para>The log line runs BEFORE the ELSA health-check / HTTP call, so we can
+/// capture it then let the (no-network) dispatch fail — the assertion is on the
+/// captured log content, not on the dispatch result.</para>
+/// </summary>
+[TestFixture]
+public sealed class ElsaWorkflowServiceLoggingTests
+{
+    private const string Plaintext = "S3cr3t-Rotated-Value-9f3a2b71c0d4";
+
+    private static (ElsaWorkflowService Svc, CapturingLoggerProvider Logs) Build()
+    {
+        var provider = new CapturingLoggerProvider();
+        // Do NOT dispose the factory — that would dispose the provider and we
+        // need it live to capture the synchronous log line below.
+        var loggerFactory = LoggerFactory.Create(b => b.AddProvider(provider));
+        var logger = loggerFactory.CreateLogger<ElsaWorkflowService>();
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                // Point at a black hole so EnsureHealthyAsync fails fast AFTER
+                // the log line we care about has already been emitted.
+                ["Elsa:ServerUrl"] = "http://127.0.0.1:1",
+            })
+            .Build();
+
+        var svc = new ElsaWorkflowService(new SimpleHttpClientFactory(), config, logger);
+        return (svc, provider);
+    }
+
+    [Test]
+    public void StartWorkflow_NeverLogsPlaintext_LogsRedactedKeySet()
+    {
+        var (svc, logs) = Build();
+
+        var input = new Dictionary<string, object>
+        {
+            ["secretId"] = Guid.NewGuid().ToString(),
+            ["rotationCorrelationId"] = "rot_abc",
+            ["operatorUserId"] = Guid.NewGuid().ToString(),
+            ["graceWindowSeconds"] = 900L,
+            ["newPlaintext"] = Plaintext, // <- must never reach a log
+        };
+
+        // The "Starting workflow ... with input keys" log line is the FIRST
+        // statement in StartWorkflowAsync and is emitted synchronously before
+        // any await (the health check / HTTP call). Kick the call off and
+        // observe the log without waiting out the (no-server) health-check
+        // retry loop. The background task's eventual failure is irrelevant —
+        // observe it so it doesn't surface as an unobserved task exception.
+        var pending = svc.StartWorkflowAsync("rotate-secret", input);
+        pending.ContinueWith(static t => _ = t.Exception, TaskScheduler.Default);
+
+        var all = string.Join("\n", logs.Messages);
+
+        // CRITICAL: the plaintext must NOT appear in ANY captured log message.
+        all.Should().NotContain(Plaintext);
+        // The sensitive key's PRESENCE is auditable, redacted.
+        all.Should().Contain("newPlaintext=[redacted]");
+        // Non-sensitive keys are listed by name (no values) so the dispatch is
+        // still observable.
+        all.Should().Contain("secretId");
+        all.Should().Contain("rotationCorrelationId");
+        // The workflow name is logged.
+        all.Should().Contain("rotate-secret");
+    }
+
+    [Test]
+    public void StartWorkflow_RedactsAnySensitiveKeyPattern()
+    {
+        var (svc, logs) = Build();
+
+        var input = new Dictionary<string, object>
+        {
+            ["apiKey"] = "sk-should-not-appear",
+            ["userPassword"] = "pw-should-not-appear",
+            ["authToken"] = "tok-should-not-appear",
+            ["dbSecret"] = "secret-should-not-appear",
+            ["plainField"] = "ok-to-list-name-only",
+        };
+
+        var pending = svc.StartWorkflowAsync("some-workflow", input);
+        pending.ContinueWith(static t => _ = t.Exception, TaskScheduler.Default);
+
+        var all = string.Join("\n", logs.Messages);
+
+        all.Should().NotContain("sk-should-not-appear");
+        all.Should().NotContain("pw-should-not-appear");
+        all.Should().NotContain("tok-should-not-appear");
+        all.Should().NotContain("secret-should-not-appear");
+        // Value of the plain field is also never logged (keys only), but its
+        // name is.
+        all.Should().NotContain("ok-to-list-name-only");
+        all.Should().Contain("plainField");
+        all.Should().Contain("apiKey=[redacted]");
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IHttpClientFactory"/> — returns a plain HttpClient.
+    /// The service's health check targets an unreachable address so it fails
+    /// fast after the (already-emitted) log line.
+    /// </summary>
+    private sealed class SimpleHttpClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) =>
+            new() { Timeout = TimeSpan.FromMilliseconds(200) };
+    }
+}


### PR DESCRIPTION
## RotateSecretWorkflow operational completion — Bucket D (P0: retires never drained)

Per `docs/superpowers/audits/2026-06-22/completeness/RotateSecret.md`. The saga body was production-grade; this closes the operational edges:
- **#1 (P0, AC8):** `RetireSecretVersionTaskHandler` (`RETIRE_SECRET_VERSION`) + `RetireSweepHostedService` as the active drainer + shared `IRetireTaskExecutor` — old secret versions now actually retire past the grace window.
- **#2 (P0):** trigger surface — `POST /api/v1/secrets/{secretId}/rotate` (`PlatformOwnerAccess`) + tenant route + `SecretAutoRotationScheduler` (default OFF).
- **#3:** per-secret concurrency guard. **#10:** real-`PlatformTaskWorker` e2e retire test.

**Review + fix (2 CRITICALs + 1 IMPORTANT):** (1) **plaintext secret was logged at INFO** via `{@Input}` destructuring → fixed: `ElsaWorkflowService` logs the input KEY SET only + redacts sensitive keys (`*plaintext*`/`*secret*`/`*password*`/`*token*`/…); regression test asserts no plaintext in logs. (2) **not-yet-due retire dead-lettered** in ~25s (immediate re-queue, no backoff → exhausts MaxRetries → lost retire) → fixed with a **backward-compatible `VisibleAt` reservation column** (`ReserveNextAsync` filters `VisibleAt IS NULL OR <= now`; existing task types leave it NULL → reservation byte-for-byte unchanged) + `DeferAsync` belt-and-suspenders; `RETIRE` enqueues with `VisibleAt=runAfter` so not-due rows are never reserved. (3) rotation **TOCTOU** + crashed-run stuck-`Pending` wedge → partial unique index (one in-flight rotation/secret) + stale-`Pending` reclaim (1h TTL).

**Safety confirmations:** `PlatformTaskWorker:RunOnStartup` stays **false**; `ReserveNextAsync` unchanged for other types — MoveTenant/ProvisionTenantV2/CreateBillingCustomer/PlatformTask tests **673/0**; no secret/plaintext in any log/event.

**Migrations (2, additive, backward-compatible):** ControlPlane `AddPlatformQueuedTaskVisibleAt`; SecretStore `AddOnePendingPerSecretIndex`. **Gate:** build 0; both has-pending clean; full `Tamma.Api.Tests` **3774/0**. Deferred (honest): #4 dry-run, #5 scope input, #6 spelling, #7–9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)