### PR TITLE
feat(workflows): build out DebuggingWorkflow — real result, AC7 guard, no-false-success, durable timeout

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/Debug/ContextCollectionTimeoutActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Debug/ContextCollectionTimeoutActivity.cs
@@ -1,0 +1,103 @@
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities.Flowchart.Attributes;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Tamma.Activities.Debug;
+
+/// <summary>
+/// AC4 / completeness audit 2026-06-22 (<c>Debugging.md</c> §Missing #11) — the durable
+/// guard that bounds the debug context-collection Fork/Join so a hung collector
+/// (a never-returning GitHub / test integration call) cannot suspend the workflow
+/// forever. Runs as a parallel fork branch racing the 5 collectors: it arms a DURABLE
+/// <see cref="Elsa.Extensions.DelayActivityExecutionContextExtensions.DelayFor(ActivityExecutionContext, System.TimeSpan, ExecuteActivityDelegate)"/>
+/// bookmark (EF-persisted, re-armed by <c>Elsa.Scheduling</c> across a host restart — NOT
+/// an in-memory <c>IWorkflowScheduler</c> timer) for <c>Debugging:ContextCollectionTimeoutSeconds</c>
+/// (default 15s). On fire it takes the <c>TimedOut</c> outcome so the flowchart proceeds to
+/// serialization with whatever collector outputs completed (partial context) instead of
+/// hanging.
+///
+/// <para>The downstream serialization step is guarded by the workflow's
+/// <c>contextGatherDone</c> bool so the FIRST of (join-completed / this-timeout) to reach
+/// it wins and the second is short-circuited — the collectors and the existing
+/// <c>FlowJoin(WaitAll)</c> are unchanged. A non-positive timeout disables the guard
+/// (wait for the join only).</para>
+/// </summary>
+[Activity(
+    "Tamma.Debug",
+    "Context Collection Timeout",
+    "Durable timeout that bounds the debug context Fork/Join (proceed with partial context on timeout)",
+    Kind = ActivityKind.Task
+)]
+[FlowNode("Armed", "TimedOut")]
+public class ContextCollectionTimeoutActivity : Activity
+{
+    private readonly ILogger<ContextCollectionTimeoutActivity>? _logger;
+    private readonly IConfiguration? _configuration;
+
+    /// <summary>Debug session id (for log correlation)</summary>
+    [Input(Description = "Debug session id")]
+    public Input<string> SessionId { get; set; } = new(string.Empty);
+
+    [JsonConstructor]
+    public ContextCollectionTimeoutActivity() { }
+
+    public ContextCollectionTimeoutActivity(
+        ILogger<ContextCollectionTimeoutActivity> logger,
+        IConfiguration configuration)
+    {
+        _logger = logger;
+        _configuration = configuration;
+    }
+
+    /// <summary>
+    /// Resolve the configured context-collection timeout (<c>Debugging:ContextCollectionTimeoutSeconds</c>),
+    /// defaulting to 15s and flooring a non-positive value to 0 (disabled). Pure; exposed
+    /// for unit testing the config read.
+    /// </summary>
+    public static int ResolveTimeoutSeconds(IConfiguration? configuration)
+    {
+        var raw = configuration?["Debugging:ContextCollectionTimeoutSeconds"];
+        if (int.TryParse(raw, out var parsed))
+            return parsed < 0 ? 0 : parsed;
+        return 15;
+    }
+
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var sessionId = SessionId.Get(context) ?? string.Empty;
+        var timeoutSeconds = ResolveTimeoutSeconds(_configuration);
+
+        if (timeoutSeconds <= 0)
+        {
+            // Guard disabled — this branch completes immediately (the Armed outcome is a
+            // no-op sink) without arming a delay, so the join (WaitAll) is the only path.
+            _logger?.LogInformation(
+                "Context-collection timeout guard disabled (ContextCollectionTimeoutSeconds<=0) for session {SessionId}",
+                sessionId);
+            await context.CompleteActivityWithOutcomesAsync("Armed");
+            return;
+        }
+
+        _logger?.LogInformation(
+            "Arming durable context-collection timeout ({TimeoutSeconds}s) for session {SessionId}",
+            timeoutSeconds, sessionId);
+
+        // Durable timeout bookmark — re-armed by Elsa.Scheduling across a restart.
+        // The activity suspends here; OnTimeoutAsync resumes it with the TimedOut outcome.
+        context.DelayFor(TimeSpan.FromSeconds(timeoutSeconds), OnTimeoutAsync);
+    }
+
+    private async ValueTask OnTimeoutAsync(ActivityExecutionContext context)
+    {
+        var sessionId = SessionId.Get(context) ?? string.Empty;
+        _logger?.LogWarning(
+            "Context-collection window expired (durable timeout) for session {SessionId} — proceeding with partial context",
+            sessionId);
+        await context.CompleteActivityWithOutcomesAsync("TimedOut");
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Debug/DebugEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Debug/DebugEvents.cs
@@ -1,0 +1,77 @@
+namespace Tamma.Activities.Debug;
+
+/// <summary>
+/// Completeness audit 2026-06-22 (<c>Debugging.md</c> §Missing #8) — central catalogue
+/// of the <c>DEBUG.*</c> DCB event types emitted by the built-out <c>debugging</c>
+/// sub-workflow via <see cref="EmitDebugEventActivity"/>. Type pattern follows the
+/// platform's <c>AGGREGATE.ACTION.STATUS</c> convention (<c>CLAUDE.md</c>) and mirrors
+/// the sibling event catalogues (<see cref="Tamma.Activities.Testing.TestingEvents"/>,
+/// <see cref="Tamma.Activities.ADL.TddDebugEvents"/>).
+///
+/// <para>The core completeness gap was a genuine hypothesis-driven diagnose→fix→verify
+/// loop with an iteration cap, a BugInvestigation regression branch and an escalation
+/// report — but ZERO audit events anywhere, violating <c>CLAUDE.md</c> ("every operation
+/// must emit events") and Story 7-1I's audit-trail intent. Without these the workflow's
+/// diagnosis, hypothesis selection, fix attempts and terminal resolved/escalated
+/// decisions are invisible to the audit trail and time-travel debugging.</para>
+///
+/// <para>Events are emitted via <c>TammaEventEmitter.Emit</c> into the workflow's
+/// <c>tamma:events</c> transient list and persisted <i>durably</i> by the engine event
+/// drain (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) — the same pattern
+/// <see cref="Tamma.Activities.Testing.EmitTestingEventActivity"/> uses. No activity
+/// holds a DB / repository dependency of its own (none is registered in the Elsa
+/// engine — a directly-injected <c>IEventRepository</c> would be inert and silently drop
+/// every event). The drain resolves the tenant from the workflow scope, so a SaaS
+/// caller's debug events carry the tenant tag.</para>
+/// </summary>
+public static class DebugEvents
+{
+    public const string SessionStarted = "DEBUG.SESSION.STARTED";
+    public const string DiagnosisSuccess = "DEBUG.DIAGNOSIS.SUCCESS";
+    public const string DiagnosisFailed = "DEBUG.DIAGNOSIS.FAILED";
+    public const string HypothesisSelected = "DEBUG.HYPOTHESIS.SELECTED";
+    public const string FixAttempted = "DEBUG.FIX.ATTEMPTED";
+    public const string TestsPassed = "DEBUG.TESTS.PASSED";
+    public const string TestsFailed = "DEBUG.TESTS.FAILED";
+    public const string RegressionInvalid = "DEBUG.REGRESSION_TEST.INVALID";
+    public const string ResolvedSuccess = "DEBUG.RESOLVED.SUCCESS";
+    public const string Escalated = "DEBUG.ESCALATED.FAILED";
+
+    /// <summary>
+    /// The terminal <c>reason</c> values the workflow stamps on its escalation so the
+    /// caller / audit trail can distinguish WHY the debug loop escalated. Never an empty
+    /// string — an escalation always carries a reason (no false success, no silent
+    /// failure). Mirrors <c>TestingEvents</c>'s escalation-reason pattern.
+    /// </summary>
+    public const string ReasonNoHypothesis = "no-hypothesis-selected";
+    public const string ReasonMaxIterations = "max-iterations-reached";
+    public const string ReasonRegressionInvalid = "regression-test-did-not-reproduce-bug";
+
+    /// <summary>
+    /// Parse a tenant id from the loose string form threaded through the workflow inputs.
+    /// Returns <c>null</c> for empty / single-user / unparseable values (debug events in
+    /// single-user mode are platform-scope, TenantId null). Mirrors
+    /// <see cref="Tamma.Activities.Testing.TestingEvents.ParseTenantId"/>.
+    /// </summary>
+    public static Guid? ParseTenantId(string? tenantId)
+        => Guid.TryParse(tenantId, out var g) ? g : null;
+
+    /// <summary>
+    /// Status convention: a diagnosis failure, a test failure, an invalid regression test
+    /// and a terminal escalation are LOUD (error-status) audit rows; every other
+    /// transition (session started, diagnosis success, hypothesis selected, fix attempted,
+    /// tests passed, terminal resolved) is a normal (success-status) row. Keeps a degraded
+    /// / failed terminal from ever being recorded as a false success. The
+    /// <c>DEBUG.FIX.ATTEMPTED</c> row carries a <c>success</c> flag in its data payload so
+    /// a failed fix is still a non-error transition (the loop legitimately continues), but
+    /// the failure is visible.
+    /// </summary>
+    public static string StatusForEvent(string type) => type switch
+    {
+        DiagnosisFailed => "error",
+        TestsFailed => "error",
+        RegressionInvalid => "error",
+        Escalated => "error",
+        _ => "success",
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Debug/EmitDebugEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Debug/EmitDebugEventActivity.cs
@@ -1,0 +1,153 @@
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+
+namespace Tamma.Activities.Debug;
+
+/// <summary>
+/// Emits a <c>DEBUG.*</c> DCB event (completeness audit 2026-06-22,
+/// <c>Debugging.md</c> §Missing #8) for the built-out <c>debugging</c> sub-workflow by
+/// appending a <see cref="TammaEvent"/> to the workflow's <c>tamma:events</c> transient
+/// list via <see cref="TammaEventEmitter.Emit"/>. The merged engine event drain
+/// (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) flushes that list <i>durably</i>
+/// to the tenant <c>domain_events</c> store after this activity runs — no DB / repository
+/// dependency is held by this activity (none is registered in the Elsa engine, the same
+/// reason <see cref="Tamma.Activities.Testing.EmitTestingEventActivity"/> uses the emitter
+/// rather than a direct <c>IEventRepository</c>).
+///
+/// <para>The workflow emits these at: session start (after classify), each diagnosis
+/// (success / failed), each hypothesis selection, each fix attempt (with a success flag),
+/// each test verdict (passed / failed), an invalid regression test, and every terminal
+/// (resolved / escalated). The diagnosis-failed, tests-failed, regression-invalid and
+/// escalated events are error-status (see <see cref="DebugEvents.StatusForEvent"/>) so a
+/// degraded terminal is a LOUD audit row, never a silent false success.</para>
+/// </summary>
+[Activity(
+    "Tamma.Debug",
+    "Emit Debug Event",
+    "Emit a DEBUG.* DCB event for the debugging sub-workflow audit trail",
+    Kind = ActivityKind.Task
+)]
+public class EmitDebugEventActivity : Activity
+{
+    private readonly ILogger<EmitDebugEventActivity>? _logger;
+
+    [Input(Description = "Event type — DEBUG.SESSION.STARTED / .DIAGNOSIS.SUCCESS|FAILED / .HYPOTHESIS.SELECTED / .FIX.ATTEMPTED / .TESTS.PASSED|FAILED / .REGRESSION_TEST.INVALID / .RESOLVED.SUCCESS / .ESCALATED.FAILED")]
+    public Input<string> EventType { get; set; } = default!;
+
+    [Input(Description = "Debug session id")]
+    public Input<string?> SessionId { get; set; } = new((string?)null);
+
+    [Input(Description = "Story id being debugged")]
+    public Input<string?> StoryId { get; set; } = new((string?)null);
+
+    [Input(Description = "Debug context mode (TddFailure / RuntimeError / BugInvestigation)")]
+    public Input<string?> Mode { get; set; } = new((string?)null);
+
+    [Input(Description = "Tenant id (empty / single-user → platform-scope event)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [Input(Description = "Current debug iteration (0 before the first iteration)")]
+    public Input<int> Iteration { get; set; } = new(0);
+
+    [Input(Description = "Max iterations budget for the loop (0 → omitted)")]
+    public Input<int> MaxIterations { get; set; } = new(0);
+
+    [Input(Description = "Selected/root-cause hypothesis description (empty when N/A)")]
+    public Input<string?> Hypothesis { get; set; } = new((string?)null);
+
+    [Input(Description = "Whether the most recent fix dispatch reported success (only meaningful on DEBUG.FIX.ATTEMPTED)")]
+    public Input<bool> FixSucceeded { get; set; } = new(false);
+
+    [Input(Description = "Terminal escalation reason (no-hypothesis-selected / max-iterations-reached / regression-test-did-not-reproduce-bug; empty on non-terminal events)")]
+    public Input<string?> Reason { get; set; } = new((string?)null);
+
+    [JsonConstructor]
+    public EmitDebugEventActivity() { }
+
+    public EmitDebugEventActivity(ILogger<EmitDebugEventActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var type = EventType.Get(context) ?? DebugEvents.Escalated;
+
+        var evt = BuildTammaEvent(
+            type,
+            sessionId: SessionId.Get(context),
+            storyId: StoryId.Get(context),
+            mode: Mode.Get(context),
+            tenantId: DebugEvents.ParseTenantId(TenantId.Get(context)),
+            iteration: Iteration.Get(context),
+            maxIterations: MaxIterations.Get(context),
+            hypothesis: Hypothesis.Get(context),
+            fixSucceeded: FixSucceeded.Get(context),
+            reason: Reason.Get(context));
+
+        TammaEventEmitter.Emit(context, this, _logger, evt);
+
+        _logger?.LogInformation(
+            "Emitted {Type} for session {Session} story {Story} (mode={Mode}, iteration={Iteration}/{Max}, reason={Reason})",
+            type, SessionId.Get(context), StoryId.Get(context), Mode.Get(context),
+            Iteration.Get(context), MaxIterations.Get(context), Reason.Get(context));
+
+        return default;
+    }
+
+    /// <summary>
+    /// Map the debug inputs onto a <see cref="TammaEvent"/> expressed as the engine's
+    /// transient-list event so the merged drain persists it. Tags carry the queryable DCB
+    /// index keys (<c>sessionId</c> / <c>storyId</c> / <c>mode</c> / <c>tenantId</c> /
+    /// <c>iteration</c>); <c>Data</c> carries the loop payload (<c>iteration</c> /
+    /// <c>maxIterations</c> / <c>hypothesis</c> / <c>fixSucceeded</c> / <c>reason</c>).
+    /// Status is driven off the event type (diagnosis-failed / tests-failed /
+    /// regression-invalid / escalated → error) so a degraded terminal is never recorded as
+    /// a false success. <c>fixSucceeded</c> is only emitted on <c>DEBUG.FIX.ATTEMPTED</c>
+    /// so a failed-but-continuing fix is visible without being a loud error. Pure (no Elsa
+    /// context); exposed for unit testing the mapping.
+    /// </summary>
+    public static TammaEvent BuildTammaEvent(
+        string type,
+        string? sessionId,
+        string? storyId,
+        string? mode,
+        Guid? tenantId,
+        int iteration,
+        int maxIterations,
+        string? hypothesis,
+        bool fixSucceeded,
+        string? reason)
+    {
+        var tags = new Dictionary<string, object?>
+        {
+            ["iteration"] = iteration.ToString(),
+        };
+        if (!string.IsNullOrWhiteSpace(sessionId)) tags["sessionId"] = sessionId;
+        if (!string.IsNullOrWhiteSpace(storyId)) tags["storyId"] = storyId;
+        if (!string.IsNullOrWhiteSpace(mode)) tags["mode"] = mode;
+        if (tenantId is not null) tags["tenantId"] = tenantId.Value.ToString("D");
+
+        var data = new Dictionary<string, object?>
+        {
+            ["iteration"] = iteration,
+        };
+        if (maxIterations > 0) data["maxIterations"] = maxIterations;
+        if (!string.IsNullOrWhiteSpace(hypothesis)) data["hypothesis"] = hypothesis;
+        if (type == DebugEvents.FixAttempted) data["fixSucceeded"] = fixSucceeded;
+        if (!string.IsNullOrWhiteSpace(reason)) data["reason"] = reason;
+
+        return new TammaEvent
+        {
+            EventType = type,
+            Status = DebugEvents.StatusForEvent(type),
+            Tags = tags,
+            Data = data,
+        };
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Debug/RefineHypothesisActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Debug/RefineHypothesisActivity.cs
@@ -2,19 +2,30 @@ using Elsa.Extensions;
 using Elsa.Workflows;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Tamma.Activities.Debug.Models;
+using Tamma.Activities.LlmCall;
 
 namespace Tamma.Activities.Debug;
 
 /// <summary>
-/// Refines hypotheses after a failed fix attempt by calling LLM (role=debugger).
-/// Passes the previous fix attempt results, test output, and updated errors to produce
-/// refined or new hypotheses. This prevents the LLM from repeating failed approaches.
+/// Refines hypotheses after a failed fix attempt by calling the LLM to produce
+/// refined or new hypotheses. Passes the previous fix attempt results, test output,
+/// and updated errors so the LLM does not repeat failed approaches.
+///
+/// <para>Story 32-5 (AC9) / completeness audit 2026-06-22 (Debugging.md §Missing #9):
+/// the LLM call routes through the mediated call-LLM endpoint
+/// (<see cref="MediatedLlmText"/>) — the engine holds NO provider key and makes no
+/// direct <c>/api/engine/execute-task</c> or <c>/v1/messages</c> call. The free-text
+/// "debugger" label is NOT a canonical role (the API's AgentResolverService 422s on
+/// it); refinement is a senior analytical task so it resolves the
+/// <c>senior_developer</c> agent/prompt (Epic-27), matching
+/// <see cref="AIDiagnosisActivity"/>. There is NO simulated fallback (a fabricated
+/// refinement poisons the iterative loop and the audit trail) and a textless mediated
+/// response throws rather than fabricating. The output contract
+/// (<see cref="DiagnosisResult"/>) is unchanged.</para>
 /// </summary>
 [Activity(
     "Tamma.Debug",
@@ -25,8 +36,6 @@ namespace Tamma.Activities.Debug;
 public class RefineHypothesisActivity : CodeActivity<DiagnosisResult>
 {
     private readonly ILogger<RefineHypothesisActivity>? _logger;
-    private readonly IHttpClientFactory? _httpClientFactory;
-    private readonly IConfiguration? _configuration;
 
     /// <summary>Session ID</summary>
     [Input(Description = "Mentorship session ID")]
@@ -51,14 +60,9 @@ public class RefineHypothesisActivity : CodeActivity<DiagnosisResult>
     [JsonConstructor]
     public RefineHypothesisActivity() { }
 
-    public RefineHypothesisActivity(
-        ILogger<RefineHypothesisActivity> logger,
-        IHttpClientFactory httpClientFactory,
-        IConfiguration configuration)
+    public RefineHypothesisActivity(ILogger<RefineHypothesisActivity> logger)
     {
         _logger = logger;
-        _httpClientFactory = httpClientFactory;
-        _configuration = configuration;
     }
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
@@ -76,7 +80,10 @@ public class RefineHypothesisActivity : CodeActivity<DiagnosisResult>
         try
         {
             var prompt = BuildRefinementPrompt(triedJson, testResults, updatedErrors, iterationCtxJson);
-            var response = await CallLlm(prompt);
+            // Mediated call-LLM (no direct provider key in the engine). "senior_developer"
+            // is the canonical analytical role the API can resolve; the free-text
+            // "debugger" label 422s. See AIDiagnosisActivity for the same cut-over.
+            var response = await MediatedLlmText.CompleteAsync(context, "senior_developer", prompt, context.CancellationToken);
             var result = ParseRefinementResponse(response);
 
             _logger?.LogInformation(
@@ -142,30 +149,6 @@ public class RefineHypothesisActivity : CodeActivity<DiagnosisResult>
 }");
 
         return sb.ToString();
-    }
-
-    private async Task<string> CallLlm(string prompt)
-    {
-        // No mock path: simulated refinement responses fed fake "what we learned"
-        // narratives and fabricated hypotheses into the iterative debug loop,
-        // poisoning subsequent attempts and the audit trail. All refinements now
-        // require a real engine callback. See: feat/wave-b cleanup.
-        var callbackUrl = _configuration?["Engine:CallbackUrl"];
-        if (string.IsNullOrEmpty(callbackUrl) || _httpClientFactory == null)
-        {
-            throw new InvalidOperationException(
-                "RefineHypothesisActivity requires Engine:CallbackUrl and IHttpClientFactory; "
-                + "no simulated fallback is permitted.");
-        }
-
-        var client = _httpClientFactory.CreateClient();
-        var response = await client.PostAsJsonAsync(
-            $"{callbackUrl.TrimEnd('/')}/api/engine/execute-task",
-            new { prompt, analysisType = "debugging_refinement", role = "debugger" });
-        response.EnsureSuccessStatusCode();
-
-        var result = await response.Content.ReadFromJsonAsync<JsonElement>();
-        return result.GetProperty("output").GetString() ?? "{}";
     }
 
     private DiagnosisResult ParseRefinementResponse(string response)

--- a/apps/tamma-elsa/src/Tamma.Activities/Debug/WriteRegressionTestActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Debug/WriteRegressionTestActivity.cs
@@ -2,12 +2,11 @@ using Elsa.Extensions;
 using Elsa.Workflows;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Tamma.Activities.Debug.Models;
+using Tamma.Activities.LlmCall;
 
 namespace Tamma.Activities.Debug;
 
@@ -15,7 +14,15 @@ namespace Tamma.Activities.Debug;
 /// Writes a regression test that reproduces the bug (BugInvestigation mode).
 /// The test should FAIL initially — if it passes, the bug may already be fixed
 /// or the test doesn't correctly reproduce the issue.
-/// Calls LLM (role=tester) to generate the test.
+///
+/// <para>Story 32-5 (AC9) / completeness audit 2026-06-22 (Debugging.md §Missing #9):
+/// the LLM call routes through the mediated call-LLM endpoint
+/// (<see cref="MediatedLlmText"/>) with the canonical <c>tester</c> role — the engine
+/// holds NO provider key and makes no direct <c>/api/engine/execute-task</c> or
+/// <c>/v1/messages</c> call. There is NO simulated fallback (a fabricated
+/// <c>expect(true).toBe(true)</c> test that lies about reproducing the bug is a
+/// false-success in the audit trail) and a textless mediated response throws. The
+/// output contract (<see cref="TestGenerationResult"/>) is unchanged.</para>
 /// </summary>
 [Activity(
     "Tamma.Debug",
@@ -26,8 +33,6 @@ namespace Tamma.Activities.Debug;
 public class WriteRegressionTestActivity : CodeActivity<TestGenerationResult>
 {
     private readonly ILogger<WriteRegressionTestActivity>? _logger;
-    private readonly IHttpClientFactory? _httpClientFactory;
-    private readonly IConfiguration? _configuration;
 
     /// <summary>Session ID</summary>
     [Input(Description = "Mentorship session ID")]
@@ -60,14 +65,9 @@ public class WriteRegressionTestActivity : CodeActivity<TestGenerationResult>
     [JsonConstructor]
     public WriteRegressionTestActivity() { }
 
-    public WriteRegressionTestActivity(
-        ILogger<WriteRegressionTestActivity> logger,
-        IHttpClientFactory httpClientFactory,
-        IConfiguration configuration)
+    public WriteRegressionTestActivity(ILogger<WriteRegressionTestActivity> logger)
     {
         _logger = logger;
-        _httpClientFactory = httpClientFactory;
-        _configuration = configuration;
     }
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
@@ -85,7 +85,9 @@ public class WriteRegressionTestActivity : CodeActivity<TestGenerationResult>
         try
         {
             var prompt = BuildTestPrompt(storyId, bugDescription, hypothesisJson, codeContext);
-            var response = await CallLlm(prompt);
+            // Mediated call-LLM (no direct provider key in the engine). "tester" is the
+            // canonical role the API resolves for test authoring. See AIDiagnosisActivity.
+            var response = await MediatedLlmText.CompleteAsync(context, "tester", prompt, context.CancellationToken);
             var result = ParseTestResponse(response);
 
             if (result.Success)
@@ -147,31 +149,6 @@ public class WriteRegressionTestActivity : CodeActivity<TestGenerationResult>
 }");
 
         return sb.ToString();
-    }
-
-    private async Task<string> CallLlm(string prompt)
-    {
-        // No mock path: simulated test responses returned a hard-coded
-        // `expect(true).toBe(true)` test claiming `fails_as_expected = true`,
-        // which (a) doesn't reproduce any bug and (b) lies in the audit trail
-        // about regression coverage. All regression tests now require a real
-        // engine callback. See: feat/wave-b cleanup.
-        var callbackUrl = _configuration?["Engine:CallbackUrl"];
-        if (string.IsNullOrEmpty(callbackUrl) || _httpClientFactory == null)
-        {
-            throw new InvalidOperationException(
-                "WriteRegressionTestActivity requires Engine:CallbackUrl and IHttpClientFactory; "
-                + "no simulated fallback is permitted.");
-        }
-
-        var client = _httpClientFactory.CreateClient();
-        var response = await client.PostAsJsonAsync(
-            $"{callbackUrl.TrimEnd('/')}/api/engine/execute-task",
-            new { prompt, analysisType = "regression_test", role = "tester" });
-        response.EnsureSuccessStatusCode();
-
-        var result = await response.Content.ReadFromJsonAsync<JsonElement>();
-        return result.GetProperty("output").GetString() ?? "{}";
     }
 
     private TestGenerationResult ParseTestResponse(string response)

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DebuggingWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DebuggingWorkflow.cs
@@ -28,20 +28,25 @@ namespace Tamma.ElsaServer.Workflows;
 ///   - BugInvestigation: pre-implementation bug investigation -- TDD for bugs
 ///
 /// Flow:
-///   1. ClassifyDebugContext -> route by mode
-///   2. FlowFork: parallel context gathering (error messages, code, git, tests, repro steps)
-///   3. FlowJoin (WaitAll)
-///   4. Serialize collector outputs to string variables
-///   5. AIDiagnosis -> ranked hypotheses
-///   6. Debug loop (max 5 iterations):
-///      a. Select highest-confidence untried hypothesis
-///      b. Apply fix (mode-specific: TDD/Runtime/Bug)
-///      c. Run tests
-///      d. Pass -> RecordResolution -> done
-///      e. Fail -> RefineHypothesis -> loop
-///   7. Max iterations -> CompileDebugReport -> escalate
+///   1. ReadInputs -> Initialize (start time, iteration, max iterations from config)
+///   2. ClassifyDebugContext -> route by mode; emit DEBUG.SESSION.STARTED
+///   3. FlowFork: parallel context gathering, durably bounded by a 15s timeout
+///      (ContextCollectionTimeoutActivity / Debugging:ContextCollectionTimeoutSeconds)
+///   4. Serialize collector outputs to string variables (partial on timeout)
+///   5. AIDiagnosis (mediated call-LLM) -> ranked hypotheses; DEBUG.DIAGNOSIS.SUCCESS/FAILED
+///   6. Debug loop (max N iterations, graph-enforced bound):
+///      a. Select highest-confidence untried hypothesis; DEBUG.HYPOTHESIS.SELECTED
+///      b. BugInvestigation: write regression test, run it, REQUIRE it to FAIL (AC7)
+///      c. Apply fix via mediated llm-call; capture result, branch on success (no false success)
+///      d. Run tests (testing-pipeline)
+///      e. Pass -> RecordResolution -> serialize DebugResult -> done (DEBUG.RESOLVED.SUCCESS)
+///      f. Fail -> mark hypothesis outcome + FixAttempt -> RefineHypothesis -> loop
+///   7. No hypothesis / max iterations / invalid regression test -> CompileDebugReport ->
+///      serialize DebugResult -> escalate (DEBUG.ESCALATED)
 ///
-/// Invoked as child workflow via RunWorkflow or standalone via ELSA REST API.
+/// Invoked as child workflow via DispatchWorkflow or standalone via ELSA REST API.
+/// Callers (TddWithDebugRetry / CiWithDebugRetry) pass sessionId/storyId/debugContextMode/
+/// errorOutput/repositoryUrl/branchName/skillLevel and (optionally) tenantId.
 /// </summary>
 public class DebuggingWorkflow : WorkflowBase
 {
@@ -61,6 +66,9 @@ public class DebuggingWorkflow : WorkflowBase
         var repositoryUrl = builder.WithVariable<string>();
         var branchName = builder.WithVariable<string>();
         var skillLevel = builder.WithVariable<int>();
+        // Named "TenantId" so MediatedLlmText.ResolveTenantId + the event drain resolve
+        // the tenant scope from this ambient variable (SaaS prompts/conventions/creds).
+        var tenantId = builder.WithVariable<string>("TenantId", "");
 
         // Typed result variables for collector activity outputs (bound via Output<T>)
         var collectErrorsResult = builder.WithVariable<ErrorMessages>();
@@ -90,22 +98,61 @@ public class DebuggingWorkflow : WorkflowBase
         var debugStartTime = builder.WithVariable<string>();
         var debugResultJson = builder.WithVariable<string>();
         var allFilesModified = builder.WithVariable<string>();
+        var attemptsJson = builder.WithVariable<string>();
         var regressionTestWritten = builder.WithVariable<bool>();
+        var contextGatherDone = builder.WithVariable<bool>();
+        var debugStatus = builder.WithVariable<string>();
+        var escalationReason = builder.WithVariable<string>();
         var runTestsOutput = builder.WithVariable<IDictionary<string, object>?>();
+        var applyFixOutput = builder.WithVariable<IDictionary<string, object>?>();
+        var regressionRunOutput = builder.WithVariable<IDictionary<string, object>?>();
+        var regressionTestResultVar = builder.WithVariable<TestGenerationResult>();
+        var compileReportResultVar = builder.WithVariable<DebugReport>();
 
         // ---- Activities ----
 
-        // 1. Initialize variables from workflow inputs
-        var initialize = new SetVariable<string>(debugStartTime,
-            _ => DateTime.UtcNow.ToString("o"))
-        { Id = "initialize", Name = "Initialize Start Time" };
-        initialize.SetDisplayText("Initialize Start Time");
+        // 0. Read workflow inputs into named variables (no auto-binding for anonymous vars).
+        var readInputs = new SetVariable<string>(debugStartTime,
+            ctx =>
+            {
+                var sid = ctx.GetInput<Guid>("sessionId");
+                if (sid != Guid.Empty) sessionId.Set(ctx, sid);
+                var story = ctx.GetInput<string>("storyId");
+                if (!string.IsNullOrEmpty(story)) storyId.Set(ctx, story);
+                var mode = ctx.GetInput<string>("debugContextMode");
+                debugContextMode.Set(ctx, string.IsNullOrEmpty(mode) ? "RuntimeError" : mode);
+                var err = ctx.GetInput<string>("errorOutput");
+                if (!string.IsNullOrEmpty(err)) errorOutput.Set(ctx, err);
+                var files = ctx.GetInput<string>("relevantFiles");
+                if (!string.IsNullOrEmpty(files)) relevantFiles.Set(ctx, files);
+                var issue = ctx.GetInput<string>("issueDescription");
+                if (!string.IsNullOrEmpty(issue)) issueDescription.Set(ctx, issue);
+                var repo = ctx.GetInput<string>("repositoryUrl");
+                if (!string.IsNullOrEmpty(repo)) repositoryUrl.Set(ctx, repo);
+                var branch = ctx.GetInput<string>("branchName");
+                if (!string.IsNullOrEmpty(branch)) branchName.Set(ctx, branch);
+                var skill = ctx.GetInput<int>("skillLevel");
+                if (skill > 0) skillLevel.Set(ctx, skill);
+                var tenant = ctx.GetInput<string>("tenantId");
+                if (!string.IsNullOrEmpty(tenant)) tenantId.Set(ctx, tenant);
+
+                return DateTime.UtcNow.ToString("o");
+            })
+        { Id = "readInputs", Name = "Read Inputs & Init Start Time" };
+        readInputs.SetDisplayText("Read Inputs & Init Start Time");
 
         var initIteration = new SetVariable<int>(currentIteration, _ => 1)
         { Id = "initIteration", Name = "Initialize Iteration" };
         initIteration.SetDisplayText("Initialize Iteration");
 
-        var initMaxIterations = new SetVariable<int>(maxIterations, _ => 5)
+        // #13 (cheap): MaxIterations from Debugging:MaxIterations config (default 5).
+        var initMaxIterations = new SetVariable<int>(maxIterations,
+            ctx =>
+            {
+                var cfg = ctx.GetRequiredService<Microsoft.Extensions.Configuration.IConfiguration>();
+                var raw = cfg["Debugging:MaxIterations"];
+                return int.TryParse(raw, out var n) && n > 0 ? n : 5;
+            })
         { Id = "initMaxIterations", Name = "Initialize Max Iterations" };
         initMaxIterations.SetDisplayText("Initialize Max Iterations");
 
@@ -113,9 +160,17 @@ public class DebuggingWorkflow : WorkflowBase
         { Id = "initFilesModified", Name = "Initialize Files Modified" };
         initFilesModified.SetDisplayText("Initialize Files Modified");
 
+        var initAttempts = new SetVariable<string>(attemptsJson, _ => "[]")
+        { Id = "initAttempts", Name = "Initialize Attempts" };
+        initAttempts.SetDisplayText("Initialize Attempts");
+
         var initRegressionTest = new SetVariable<bool>(regressionTestWritten, _ => false)
         { Id = "initRegressionTest", Name = "Initialize Regression Test Flag" };
         initRegressionTest.SetDisplayText("Initialize Regression Test Flag");
+
+        var initContextDone = new SetVariable<bool>(contextGatherDone, _ => false)
+        { Id = "initContextDone", Name = "Initialize Context Gather Flag" };
+        initContextDone.SetDisplayText("Initialize Context Gather Flag");
 
         var initIterationContext = new SetVariable<string>(iterationContextJson,
             _ => "{\"currentIteration\":0,\"hypotheses\":[],\"previousAttempts\":[]}")
@@ -144,6 +199,20 @@ public class DebuggingWorkflow : WorkflowBase
         var bugEmphasis = new WriteLine("Debug mode: Bug Investigation -- emphasizing issue description and reproduction steps")
         { Id = "bugEmphasis", Name = "Bug Emphasis" };
         bugEmphasis.SetDisplayText("Bug Emphasis");
+
+        // #8: DEBUG.SESSION.STARTED (after classify)
+        var emitSessionStarted = new EmitDebugEventActivity
+        {
+            Id = "emitSessionStarted", Name = "Emit DEBUG.SESSION.STARTED",
+            EventType = new Input<string>(_ => DebugEvents.SessionStarted),
+            SessionId = new Input<string?>(ctx => sessionId.Get(ctx).ToString()),
+            StoryId = new Input<string?>(ctx => storyId.Get(ctx)),
+            Mode = new Input<string?>(ctx => debugContextMode.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
+            Iteration = new Input<int>(ctx => currentIteration.Get(ctx)),
+            MaxIterations = new Input<int>(ctx => maxIterations.Get(ctx)),
+        };
+        emitSessionStarted.SetDisplayText("Emit DEBUG.SESSION.STARTED");
 
         // 4. Parallel context gathering activities -- Result output wired to typed variables
         var collectErrors = new CollectErrorMessagesActivity
@@ -209,7 +278,7 @@ public class DebuggingWorkflow : WorkflowBase
         };
         collectRepro.SetDisplayText("Collect Reproduction Steps");
 
-        // 5. FlowFork for parallel context gathering (branch names used in connections)
+        // 5. FlowFork for parallel context gathering (5 collectors + 1 durable timeout guard)
         var fork = new FlowFork
         {
             Id = "contextFork",
@@ -220,12 +289,22 @@ public class DebuggingWorkflow : WorkflowBase
                 "CollectCode",
                 "CollectGit",
                 "CollectTests",
-                "CollectRepro"
+                "CollectRepro",
+                "Timeout"
             })
         };
         fork.SetDisplayText("Context Fork");
 
-        // 6. FlowJoin -- waits for all parallel branches to complete
+        // #11 AC4: durable 15s context-collection timeout racing the collectors.
+        var contextTimeout = new ContextCollectionTimeoutActivity
+        {
+            Id = "contextTimeout",
+            Name = "Context Collection Timeout",
+            SessionId = new Input<string>(ctx => sessionId.Get(ctx).ToString())
+        };
+        contextTimeout.SetDisplayText("Context Collection Timeout");
+
+        // 6. FlowJoin -- waits for all 5 collectors (the timeout branch resumes separately).
         var join = new FlowJoin
         {
             Id = "contextJoin",
@@ -234,11 +313,28 @@ public class DebuggingWorkflow : WorkflowBase
         };
         join.SetDisplayText("Context Join");
 
-        var joinLog = new WriteLine("All debug context gathered -- proceeding to serialization")
+        // #11: guard so the FIRST of (join-completed / timeout-fired) proceeds to
+        // serialization and the second is short-circuited.
+        var contextGatherGate = new FlowDecision(ctx =>
+        {
+            // True == first to arrive (proceed); set the flag so the loser short-circuits.
+            if (contextGatherDone.Get(ctx)) return false;
+            contextGatherDone.Set(ctx, true);
+            return true;
+        })
+        { Id = "contextGatherGate", Name = "Context Gathered First?" };
+        contextGatherGate.SetDisplayText("Context Gathered First?");
+
+        var contextGateSink = new WriteLine("Context already gathered -- short-circuiting the slower context branch")
+        { Id = "contextGateSink", Name = "Context Gate Sink" };
+        contextGateSink.SetDisplayText("Context Gate Sink");
+
+        var joinLog = new WriteLine("Debug context gathered -- proceeding to serialization")
         { Id = "joinLog", Name = "Join Log" };
         joinLog.SetDisplayText("Join Log");
 
         // 6a. Serialize typed collector outputs to string variables for AIDiagnosis
+        // (a collector that timed out / errored leaves its var null -> serialized as "").
         var serializeErrors = new SetVariable<string>(errorMessages,
             ctx =>
             {
@@ -284,7 +380,7 @@ public class DebuggingWorkflow : WorkflowBase
         { Id = "serializeRepro", Name = "Serialize Reproduction Steps" };
         serializeRepro.SetDisplayText("Serialize Reproduction Steps");
 
-        // 7. AI Diagnosis -- reads from serialized string variables, outputs typed result
+        // 7. AI Diagnosis -- mediated call-LLM; reads serialized context, outputs typed result
         var aiDiagnosis = new AIDiagnosisActivity
         {
             Id = "aiDiagnosis",
@@ -313,6 +409,42 @@ public class DebuggingWorkflow : WorkflowBase
             })
         { Id = "serializeDiagnosis", Name = "Serialize Diagnosis Hypotheses" };
         serializeDiagnosis.SetDisplayText("Serialize Diagnosis Hypotheses");
+
+        // #8: DEBUG.DIAGNOSIS.SUCCESS / .FAILED (failed == zero usable hypotheses)
+        var diagnosisProduced = new FlowDecision(ctx =>
+        {
+            var result = diagnosisResultVar.Get(ctx);
+            return result?.Hypotheses != null && result.Hypotheses.Count > 0;
+        })
+        { Id = "diagnosisProduced", Name = "Diagnosis Produced?" };
+        diagnosisProduced.SetDisplayText("Diagnosis Produced?");
+
+        var emitDiagnosisSuccess = new EmitDebugEventActivity
+        {
+            Id = "emitDiagnosisSuccess", Name = "Emit DEBUG.DIAGNOSIS.SUCCESS",
+            EventType = new Input<string>(_ => DebugEvents.DiagnosisSuccess),
+            SessionId = new Input<string?>(ctx => sessionId.Get(ctx).ToString()),
+            StoryId = new Input<string?>(ctx => storyId.Get(ctx)),
+            Mode = new Input<string?>(ctx => debugContextMode.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
+            Iteration = new Input<int>(ctx => currentIteration.Get(ctx)),
+            MaxIterations = new Input<int>(ctx => maxIterations.Get(ctx)),
+        };
+        emitDiagnosisSuccess.SetDisplayText("Emit DEBUG.DIAGNOSIS.SUCCESS");
+
+        var emitDiagnosisFailed = new EmitDebugEventActivity
+        {
+            Id = "emitDiagnosisFailed", Name = "Emit DEBUG.DIAGNOSIS.FAILED",
+            EventType = new Input<string>(_ => DebugEvents.DiagnosisFailed),
+            SessionId = new Input<string?>(ctx => sessionId.Get(ctx).ToString()),
+            StoryId = new Input<string?>(ctx => storyId.Get(ctx)),
+            Mode = new Input<string?>(ctx => debugContextMode.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
+            Iteration = new Input<int>(ctx => currentIteration.Get(ctx)),
+            MaxIterations = new Input<int>(ctx => maxIterations.Get(ctx)),
+            Reason = new Input<string?>(_ => DebugEvents.ReasonNoHypothesis),
+        };
+        emitDiagnosisFailed.SetDisplayText("Emit DEBUG.DIAGNOSIS.FAILED");
 
         // 8. Select hypothesis -- outputs typed Hypothesis?, wired to selectedHypothesisVar
         var selectHypothesis = new SelectHypothesisActivity
@@ -345,6 +477,21 @@ public class DebuggingWorkflow : WorkflowBase
         { Id = "hasHypothesis", Name = "Has Hypothesis?" };
         hasHypothesis.SetDisplayText("Has Hypothesis?");
 
+        // #8: DEBUG.HYPOTHESIS.SELECTED
+        var emitHypothesisSelected = new EmitDebugEventActivity
+        {
+            Id = "emitHypothesisSelected", Name = "Emit DEBUG.HYPOTHESIS.SELECTED",
+            EventType = new Input<string>(_ => DebugEvents.HypothesisSelected),
+            SessionId = new Input<string?>(ctx => sessionId.Get(ctx).ToString()),
+            StoryId = new Input<string?>(ctx => storyId.Get(ctx)),
+            Mode = new Input<string?>(ctx => debugContextMode.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
+            Iteration = new Input<int>(ctx => currentIteration.Get(ctx)),
+            MaxIterations = new Input<int>(ctx => maxIterations.Get(ctx)),
+            Hypothesis = new Input<string?>(ctx => DescribeHypothesis(selectedHypothesisVar.Get(ctx))),
+        };
+        emitHypothesisSelected.SetDisplayText("Emit DEBUG.HYPOTHESIS.SELECTED");
+
         // 10. BugInvestigation guard: write regression test if needed
         var isBugMode = new FlowDecision(ctx =>
             debugContextMode.Get(ctx) == "BugInvestigation" && !regressionTestWritten.Get(ctx))
@@ -361,15 +508,80 @@ public class DebuggingWorkflow : WorkflowBase
             HypothesisJson = new Input<string>(ctx => selectedHypothesisJson.Get(ctx) ?? "{}"),
             CodeContext = new Input<string>(ctx => relevantCode.Get(ctx) ?? ""),
             RepositoryUrl = new Input<string>(ctx => repositoryUrl.Get(ctx) ?? ""),
-            BranchName = new Input<string>(ctx => branchName.Get(ctx) ?? "")
+            BranchName = new Input<string>(ctx => branchName.Get(ctx) ?? ""),
+            Result = new Output<TestGenerationResult>(regressionTestResultVar)
         };
         writeRegressionTest.SetDisplayText("Write Regression Test");
+
+        // Track the regression test file into allFilesModified.
+        var captureRegressionFile = new SetVariable<string>(allFilesModified,
+            ctx => MergeFiles(allFilesModified.Get(ctx), regressionTestResultVar.Get(ctx)?.TestFilePath))
+        { Id = "captureRegressionFile", Name = "Capture Regression Test File" };
+        captureRegressionFile.SetDisplayText("Capture Regression Test File");
+
+        // #4 AC7: run the regression test and REQUIRE it to FAIL before fixing.
+        var runRegressionTest = new DispatchWorkflow
+        {
+            Id = "runRegressionTest",
+            Name = "Run Regression Test",
+            WorkflowDefinitionId = new("testing-pipeline"),
+            Input = new(ctx => new Dictionary<string, object>
+            {
+                ["SessionId"] = sessionId.Get(ctx),
+                ["Repository"] = repositoryUrl.Get(ctx) ?? "",
+                ["Branch"] = branchName.Get(ctx) ?? "",
+                ["SkillLevel"] = skillLevel.Get(ctx),
+                ["tenantId"] = tenantId.Get(ctx) ?? "",
+            }),
+            WaitForCompletion = new(true),
+            Result = new(regressionRunOutput)
+        };
+        runRegressionTest.SetDisplayText("Run Regression Test");
+
+        // AC7 guard: the regression test must FAIL (reproduce the bug). honor
+        // Debugging:BugInvestigation:RequireRegressionTest (default true).
+        var regressionFailsAsExpected = new FlowDecision(ctx =>
+        {
+            var cfg = ctx.GetRequiredService<Microsoft.Extensions.Configuration.IConfiguration>();
+            var requireRaw = cfg["Debugging:BugInvestigation:RequireRegressionTest"];
+            var require = !bool.TryParse(requireRaw, out var r) || r; // default true
+            if (!require) return true; // guard disabled -> proceed to fix
+
+            // The regression test must reproduce the bug == the pipeline must NOT pass.
+            var output = regressionRunOutput.Get(ctx);
+            var passed = output != null
+                && output.TryGetValue("passed", out var p) && p is bool b && b;
+            // Fails-as-expected when the run did NOT pass.
+            return !passed;
+        })
+        { Id = "regressionFailsAsExpected", Name = "Regression Fails As Expected?" };
+        regressionFailsAsExpected.SetDisplayText("Regression Fails As Expected?");
 
         var markRegressionTestWritten = new SetVariable<bool>(regressionTestWritten, _ => true)
         { Id = "markRegressionTestWritten", Name = "Mark Regression Test Written" };
         markRegressionTestWritten.SetDisplayText("Mark Regression Test Written");
 
-        // 11. Apply fix via LLM call sub-workflow
+        // AC7: regression test PASSED (did not reproduce the bug) -> abort/escalate.
+        var setRegressionInvalidReason = new SetVariable<string>(escalationReason,
+            _ => DebugEvents.ReasonRegressionInvalid)
+        { Id = "setRegressionInvalidReason", Name = "Set Regression Invalid Reason" };
+        setRegressionInvalidReason.SetDisplayText("Set Regression Invalid Reason");
+
+        var emitRegressionInvalid = new EmitDebugEventActivity
+        {
+            Id = "emitRegressionInvalid", Name = "Emit DEBUG.REGRESSION_TEST.INVALID",
+            EventType = new Input<string>(_ => DebugEvents.RegressionInvalid),
+            SessionId = new Input<string?>(ctx => sessionId.Get(ctx).ToString()),
+            StoryId = new Input<string?>(ctx => storyId.Get(ctx)),
+            Mode = new Input<string?>(ctx => debugContextMode.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
+            Iteration = new Input<int>(ctx => currentIteration.Get(ctx)),
+            MaxIterations = new Input<int>(ctx => maxIterations.Get(ctx)),
+            Reason = new Input<string?>(_ => DebugEvents.ReasonRegressionInvalid),
+        };
+        emitRegressionInvalid.SetDisplayText("Emit DEBUG.REGRESSION_TEST.INVALID");
+
+        // 11. Apply fix via LLM call sub-workflow (mediated, tenant-scoped)
         var applyFix = new DispatchWorkflow
         {
             Id = "applyFix",
@@ -380,13 +592,55 @@ public class DebuggingWorkflow : WorkflowBase
                 ["agentRole"] = AgentRole.Developer.ToWire(),
                 ["action"] = AgentAction.Debug.ToWire(),
                 ["taskPrompt"] = $"Apply fix for hypothesis: {SecurityHelpers.SanitizeForPrompt(selectedHypothesisJson.Get(ctx) ?? "unknown")} (mode: {debugContextMode.Get(ctx)}, iteration: {currentIteration.Get(ctx)})",
-                ["sessionId"] = sessionId.Get(ctx).ToString()
+                ["sessionId"] = sessionId.Get(ctx).ToString(),
+                ["tenantId"] = tenantId.Get(ctx) ?? ""
             }),
-            WaitForCompletion = new(true)
+            WaitForCompletion = new(true),
+            Result = new(applyFixOutput)
         };
         applyFix.SetDisplayText("Apply Fix");
 
-        // 12. Run tests via testing-pipeline sub-workflow
+        // #2: accumulate files from the selected hypothesis affected_files (the LLM call's
+        // structured file list is not surfaced by llm-call; hypothesis affected_files is the
+        // authoritative signal of what the fix touched).
+        var captureFixFiles = new SetVariable<string>(allFilesModified,
+            ctx => MergeFiles(allFilesModified.Get(ctx), selectedHypothesisVar.Get(ctx)?.AffectedFiles))
+        { Id = "captureFixFiles", Name = "Capture Fix Files" };
+        captureFixFiles.SetDisplayText("Capture Fix Files");
+
+        // #3 no-false-success: branch on the llm-call success flag.
+        var fixApplied = new FlowDecision(ctx =>
+        {
+            var output = applyFixOutput.Get(ctx);
+            if (output != null && output.TryGetValue("success", out var s))
+                return s is true || s?.ToString() == "True";
+            return false;
+        })
+        { Id = "fixApplied", Name = "Fix Applied?" };
+        fixApplied.SetDisplayText("Fix Applied?");
+
+        // #8: DEBUG.FIX.ATTEMPTED (carries success flag in data)
+        var emitFixAttempted = new EmitDebugEventActivity
+        {
+            Id = "emitFixAttempted", Name = "Emit DEBUG.FIX.ATTEMPTED",
+            EventType = new Input<string>(_ => DebugEvents.FixAttempted),
+            SessionId = new Input<string?>(ctx => sessionId.Get(ctx).ToString()),
+            StoryId = new Input<string?>(ctx => storyId.Get(ctx)),
+            Mode = new Input<string?>(ctx => debugContextMode.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
+            Iteration = new Input<int>(ctx => currentIteration.Get(ctx)),
+            MaxIterations = new Input<int>(ctx => maxIterations.Get(ctx)),
+            Hypothesis = new Input<string?>(ctx => DescribeHypothesis(selectedHypothesisVar.Get(ctx))),
+            FixSucceeded = new Input<bool>(ctx =>
+            {
+                var output = applyFixOutput.Get(ctx);
+                return output != null && output.TryGetValue("success", out var s)
+                    && (s is true || s?.ToString() == "True");
+            }),
+        };
+        emitFixAttempted.SetDisplayText("Emit DEBUG.FIX.ATTEMPTED");
+
+        // 12. Run tests via testing-pipeline sub-workflow (tenant-scoped)
         var runTests = new DispatchWorkflow
         {
             Id = "runTests",
@@ -397,7 +651,8 @@ public class DebuggingWorkflow : WorkflowBase
                 ["SessionId"] = sessionId.Get(ctx),
                 ["Repository"] = repositoryUrl.Get(ctx) ?? "",
                 ["Branch"] = branchName.Get(ctx) ?? "",
-                ["SkillLevel"] = skillLevel.Get(ctx)
+                ["SkillLevel"] = skillLevel.Get(ctx),
+                ["tenantId"] = tenantId.Get(ctx) ?? ""
             }),
             WaitForCompletion = new(true),
             Result = new(runTestsOutput)
@@ -415,6 +670,32 @@ public class DebuggingWorkflow : WorkflowBase
         { Id = "testsPass", Name = "Tests Pass?" };
         testsPass.SetDisplayText("Tests Pass?");
 
+        var emitTestsPassed = new EmitDebugEventActivity
+        {
+            Id = "emitTestsPassed", Name = "Emit DEBUG.TESTS.PASSED",
+            EventType = new Input<string>(_ => DebugEvents.TestsPassed),
+            SessionId = new Input<string?>(ctx => sessionId.Get(ctx).ToString()),
+            StoryId = new Input<string?>(ctx => storyId.Get(ctx)),
+            Mode = new Input<string?>(ctx => debugContextMode.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
+            Iteration = new Input<int>(ctx => currentIteration.Get(ctx)),
+            MaxIterations = new Input<int>(ctx => maxIterations.Get(ctx)),
+        };
+        emitTestsPassed.SetDisplayText("Emit DEBUG.TESTS.PASSED");
+
+        var emitTestsFailed = new EmitDebugEventActivity
+        {
+            Id = "emitTestsFailed", Name = "Emit DEBUG.TESTS.FAILED",
+            EventType = new Input<string>(_ => DebugEvents.TestsFailed),
+            SessionId = new Input<string?>(ctx => sessionId.Get(ctx).ToString()),
+            StoryId = new Input<string?>(ctx => storyId.Get(ctx)),
+            Mode = new Input<string?>(ctx => debugContextMode.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
+            Iteration = new Input<int>(ctx => currentIteration.Get(ctx)),
+            MaxIterations = new Input<int>(ctx => maxIterations.Get(ctx)),
+        };
+        emitTestsFailed.SetDisplayText("Emit DEBUG.TESTS.FAILED");
+
         // 14. Record resolution (tests passed)
         var recordResolution = new RecordResolutionActivity
         {
@@ -423,24 +704,8 @@ public class DebuggingWorkflow : WorkflowBase
             SessionId = new Input<Guid>(ctx => sessionId.Get(ctx)),
             StoryId = new Input<string>(ctx => storyId.Get(ctx) ?? ""),
             DebugContextMode = new Input<string>(ctx => debugContextMode.Get(ctx) ?? ""),
-            RootCause = new Input<string>(ctx =>
-            {
-                try
-                {
-                    var h = JsonSerializer.Deserialize<Hypothesis>(selectedHypothesisJson.Get(ctx) ?? "{}");
-                    return h?.Description ?? "unknown";
-                }
-                catch { return "unknown"; }
-            }),
-            FixApproach = new Input<string>(ctx =>
-            {
-                try
-                {
-                    var h = JsonSerializer.Deserialize<Hypothesis>(selectedHypothesisJson.Get(ctx) ?? "{}");
-                    return h?.SuggestedFix ?? "unknown";
-                }
-                catch { return "unknown"; }
-            }),
+            RootCause = new Input<string>(ctx => DescribeHypothesis(selectedHypothesisVar.Get(ctx)) ?? "unknown"),
+            FixApproach = new Input<string>(ctx => selectedHypothesisVar.Get(ctx)?.SuggestedFix ?? "unknown"),
             FilesChangedJson = new Input<string>(ctx => allFilesModified.Get(ctx) ?? "[]"),
             Attempts = new Input<int>(ctx => currentIteration.Get(ctx)),
             StartTime = new Input<string>(ctx => debugStartTime.Get(ctx) ?? DateTime.UtcNow.ToString("o"))
@@ -456,6 +721,36 @@ public class DebuggingWorkflow : WorkflowBase
         };
         updateCodeIndex.SetDisplayText("Update Code Index");
 
+        // #1 / #16: serialize a real DebugResult (status=Resolved) into debugResultJson.
+        var serializeResolvedResult = new SetVariable<string>(debugResultJson,
+            ctx => BuildResolvedResultJson(
+                selectedHypothesisVar.Get(ctx),
+                selectedHypothesisJson.Get(ctx),
+                hypothesesJson.Get(ctx),
+                allFilesModified.Get(ctx),
+                currentIteration.Get(ctx),
+                regressionTestWritten.Get(ctx)))
+        { Id = "serializeResolvedResult", Name = "Serialize Resolved Result" };
+        serializeResolvedResult.SetDisplayText("Serialize Resolved Result");
+
+        var setResolvedStatus = new SetVariable<string>(debugStatus, _ => DebugStatus.Resolved.ToString())
+        { Id = "setResolvedStatus", Name = "Set Resolved Status" };
+        setResolvedStatus.SetDisplayText("Set Resolved Status");
+
+        var emitResolved = new EmitDebugEventActivity
+        {
+            Id = "emitResolved", Name = "Emit DEBUG.RESOLVED.SUCCESS",
+            EventType = new Input<string>(_ => DebugEvents.ResolvedSuccess),
+            SessionId = new Input<string?>(ctx => sessionId.Get(ctx).ToString()),
+            StoryId = new Input<string?>(ctx => storyId.Get(ctx)),
+            Mode = new Input<string?>(ctx => debugContextMode.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
+            Iteration = new Input<int>(ctx => currentIteration.Get(ctx)),
+            MaxIterations = new Input<int>(ctx => maxIterations.Get(ctx)),
+            Hypothesis = new Input<string?>(ctx => DescribeHypothesis(selectedHypothesisVar.Get(ctx))),
+        };
+        emitResolved.SetDisplayText("Emit DEBUG.RESOLVED.SUCCESS");
+
         var setResolvedOutputs = new Sequence
         {
             Id = "setResolvedOutputs",
@@ -464,13 +759,35 @@ public class DebuggingWorkflow : WorkflowBase
             {
                 WithLabel(new WriteLine("Debug resolved -- fix verified by tests") { Id = "setResolved", Name = "Log Resolved" }, "Log Resolved"),
                 WithLabel(new SetOutput { Id = "outputResolvedSuccess", Name = "Output Resolved Success", OutputName = new("success"), OutputValue = new(ctx => (object)true) }, "Output Resolved Success"),
+                WithLabel(new SetOutput { Id = "outputResolvedStatus", Name = "Output Resolved Status", OutputName = new("status"), OutputValue = new(ctx => (object)(debugStatus.Get(ctx) ?? DebugStatus.Resolved.ToString())) }, "Output Resolved Status"),
                 WithLabel(new SetOutput { Id = "outputResolution", Name = "Output Resolution", OutputName = new("resolution"), OutputValue = new(ctx => (object)(debugResultJson.Get(ctx) ?? "{}")) }, "Output Resolution"),
                 WithLabel(new SetOutput { Id = "outputResolvedIterations", Name = "Output Resolved Iterations", OutputName = new("iterations"), OutputValue = new(ctx => (object)currentIteration.Get(ctx)) }, "Output Resolved Iterations")
             }
         };
         setResolvedOutputs.SetDisplayText("Set Resolved Outputs");
 
-        // 15. Refine hypothesis (tests failed) -- outputs typed DiagnosisResult
+        // 15. Test-fail branch: record outcome + attempt, then refine hypothesis.
+        // #5: mark the tried hypothesis DidNotFix/MadeWorse + append a FixAttempt.
+        var recordFailedAttempt = new SetVariable<string>(attemptsJson,
+            ctx => AppendFailedAttempt(
+                attemptsJson.Get(ctx),
+                selectedHypothesisVar.Get(ctx),
+                currentIteration.Get(ctx),
+                testResults.Get(ctx),
+                allFilesModified.Get(ctx)))
+        { Id = "recordFailedAttempt", Name = "Record Failed Attempt" };
+        recordFailedAttempt.SetDisplayText("Record Failed Attempt");
+
+        // recordFailedAttempt updated hypothesesJson out-of-band; persist it too.
+        var persistOutcomeHypotheses = new SetVariable<string>(hypothesesJson,
+            ctx => MarkHypothesisOutcome(
+                hypothesesJson.Get(ctx),
+                selectedHypothesisVar.Get(ctx),
+                collectTestsResult.Get(ctx),
+                runTestsOutput.Get(ctx)))
+        { Id = "persistOutcomeHypotheses", Name = "Persist Hypothesis Outcomes" };
+        persistOutcomeHypotheses.SetDisplayText("Persist Hypothesis Outcomes");
+
         var refineHypothesis = new RefineHypothesisActivity
         {
             Id = "refineHypothesis",
@@ -503,8 +820,11 @@ public class DebuggingWorkflow : WorkflowBase
                 {
                     CurrentIteration = currentIteration.Get(ctx),
                     Hypotheses = refinedDiagnosisVar.Get(ctx)?.Hypotheses ?? new List<Hypothesis>(),
+                    PreviousAttempts = DeserializeAttempts(attemptsJson.Get(ctx)),
                     LatestTestResults = testResults.Get(ctx) ?? "",
-                    LatestErrors = errorMessages.Get(ctx) ?? ""
+                    LatestErrors = errorMessages.Get(ctx) ?? "",
+                    AllFilesModified = DeserializeFiles(allFilesModified.Get(ctx)),
+                    RegressionTestWritten = regressionTestWritten.Get(ctx)
                 };
                 return JsonSerializer.Serialize(iterCtx);
             })
@@ -517,6 +837,22 @@ public class DebuggingWorkflow : WorkflowBase
         { Id = "incrementIteration", Name = "Increment Iteration" };
         incrementIteration.SetDisplayText("Increment Iteration");
 
+        // #12: graph-enforced loop bound -- explicit FlowDecision on currentIteration>maxIterations.
+        var iterationsExhausted = new FlowDecision(ctx =>
+            currentIteration.Get(ctx) > maxIterations.Get(ctx))
+        { Id = "iterationsExhausted", Name = "Iterations Exhausted?" };
+        iterationsExhausted.SetDisplayText("Iterations Exhausted?");
+
+        var setMaxIterationsReason = new SetVariable<string>(escalationReason,
+            _ => DebugEvents.ReasonMaxIterations)
+        { Id = "setMaxIterationsReason", Name = "Set Max Iterations Reason" };
+        setMaxIterationsReason.SetDisplayText("Set Max Iterations Reason");
+
+        var setNoHypothesisReason = new SetVariable<string>(escalationReason,
+            _ => DebugEvents.ReasonNoHypothesis)
+        { Id = "setNoHypothesisReason", Name = "Set No-Hypothesis Reason" };
+        setNoHypothesisReason.SetDisplayText("Set No-Hypothesis Reason");
+
         // 17. Compile debug report (escalation)
         var compileReport = new CompileDebugReportActivity
         {
@@ -526,12 +862,46 @@ public class DebuggingWorkflow : WorkflowBase
             StoryId = new Input<string>(ctx => storyId.Get(ctx) ?? ""),
             DebugContextMode = new Input<string>(ctx => debugContextMode.Get(ctx) ?? ""),
             HypothesesJson = new Input<string>(ctx => hypothesesJson.Get(ctx) ?? "[]"),
-            AttemptsJson = new Input<string>(ctx => iterationContextJson.Get(ctx) ?? "[]"),
+            AttemptsJson = new Input<string>(ctx => attemptsJson.Get(ctx) ?? "[]"),
             RemainingFailures = new Input<string>(ctx => testResults.Get(ctx) ?? ""),
             FilesInvestigated = new Input<string>(ctx => allFilesModified.Get(ctx) ?? "[]"),
-            StartTime = new Input<string>(ctx => debugStartTime.Get(ctx) ?? DateTime.UtcNow.ToString("o"))
+            StartTime = new Input<string>(ctx => debugStartTime.Get(ctx) ?? DateTime.UtcNow.ToString("o")),
+            Result = new Output<DebugReport>(compileReportResultVar)
         };
         compileReport.SetDisplayText("Compile Debug Report");
+
+        var setEscalatedStatus = new SetVariable<string>(debugStatus, _ => DebugStatus.Escalated.ToString())
+        { Id = "setEscalatedStatus", Name = "Set Escalated Status" };
+        setEscalatedStatus.SetDisplayText("Set Escalated Status");
+
+        // #1 / #16: serialize a real DebugResult (status=Escalated) into debugResultJson.
+        var serializeEscalatedResult = new SetVariable<string>(debugResultJson,
+            ctx => BuildEscalatedResultJson(
+                compileReportResultVar.Get(ctx),
+                hypothesesJson.Get(ctx),
+                allFilesModified.Get(ctx),
+                currentIteration.Get(ctx),
+                regressionTestWritten.Get(ctx)))
+        { Id = "serializeEscalatedResult", Name = "Serialize Escalated Result" };
+        serializeEscalatedResult.SetDisplayText("Serialize Escalated Result");
+
+        var emitEscalated = new EmitDebugEventActivity
+        {
+            Id = "emitEscalated", Name = "Emit DEBUG.ESCALATED",
+            EventType = new Input<string>(_ => DebugEvents.Escalated),
+            SessionId = new Input<string?>(ctx => sessionId.Get(ctx).ToString()),
+            StoryId = new Input<string?>(ctx => storyId.Get(ctx)),
+            Mode = new Input<string?>(ctx => debugContextMode.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
+            Iteration = new Input<int>(ctx => currentIteration.Get(ctx)),
+            MaxIterations = new Input<int>(ctx => maxIterations.Get(ctx)),
+            Reason = new Input<string?>(ctx =>
+            {
+                var r = escalationReason.Get(ctx);
+                return string.IsNullOrEmpty(r) ? DebugEvents.ReasonMaxIterations : r;
+            }),
+        };
+        emitEscalated.SetDisplayText("Emit DEBUG.ESCALATED");
 
         var setEscalatedOutputs = new Sequence
         {
@@ -539,9 +909,11 @@ public class DebuggingWorkflow : WorkflowBase
             Name = "Set Escalated Outputs",
             Activities =
             {
-                WithLabel(new WriteLine("Debug ESCALATED -- max iterations reached, report compiled") { Id = "setEscalated", Name = "Log Escalated" }, "Log Escalated"),
+                WithLabel(new WriteLine("Debug ESCALATED -- could not resolve, report compiled") { Id = "setEscalated", Name = "Log Escalated" }, "Log Escalated"),
                 WithLabel(new SetOutput { Id = "outputEscalatedSuccess", Name = "Output Escalated Success", OutputName = new("success"), OutputValue = new(ctx => (object)false) }, "Output Escalated Success"),
+                WithLabel(new SetOutput { Id = "outputEscalatedStatus", Name = "Output Escalated Status", OutputName = new("status"), OutputValue = new(ctx => (object)(debugStatus.Get(ctx) ?? DebugStatus.Escalated.ToString())) }, "Output Escalated Status"),
                 WithLabel(new SetOutput { Id = "outputDebugReport", Name = "Output Debug Report", OutputName = new("debugReport"), OutputValue = new(ctx => (object)(debugResultJson.Get(ctx) ?? "{}")) }, "Output Debug Report"),
+                WithLabel(new SetOutput { Id = "outputEscalatedReason", Name = "Output Escalated Reason", OutputName = new("escalationReason"), OutputValue = new(ctx => (object)(escalationReason.Get(ctx) ?? DebugEvents.ReasonMaxIterations)) }, "Output Escalated Reason"),
                 WithLabel(new SetOutput { Id = "outputEscalatedIterations", Name = "Output Escalated Iterations", OutputName = new("iterations"), OutputValue = new(ctx => (object)currentIteration.Get(ctx)) }, "Output Escalated Iterations")
             }
         };
@@ -558,32 +930,40 @@ public class DebuggingWorkflow : WorkflowBase
             Name = "Debugging Flowchart",
             Activities =
             {
-                initialize, initIteration, initMaxIterations,
-                initFilesModified, initRegressionTest, initIterationContext,
+                readInputs, initIteration, initMaxIterations,
+                initFilesModified, initAttempts, initRegressionTest, initContextDone, initIterationContext,
                 classify,
                 tddEmphasis, runtimeEmphasis, bugEmphasis,
+                emitSessionStarted,
                 fork,
-                collectErrors, collectCode, collectGit, collectTests, collectRepro,
-                join, joinLog,
+                collectErrors, collectCode, collectGit, collectTests, collectRepro, contextTimeout,
+                join, contextGatherGate, contextGateSink, joinLog,
                 serializeErrors, serializeCode, serializeGit, serializeTests, serializeRepro,
-                aiDiagnosis, serializeDiagnosis,
-                selectHypothesis, serializeSelectedHypothesis, hasHypothesis,
-                isBugMode, writeRegressionTest, markRegressionTestWritten,
-                applyFix, runTests, testsPass,
-                recordResolution, updateCodeIndex, setResolvedOutputs,
+                aiDiagnosis, serializeDiagnosis, diagnosisProduced, emitDiagnosisSuccess, emitDiagnosisFailed,
+                selectHypothesis, serializeSelectedHypothesis, hasHypothesis, emitHypothesisSelected,
+                isBugMode, writeRegressionTest, captureRegressionFile, runRegressionTest,
+                regressionFailsAsExpected, markRegressionTestWritten,
+                setRegressionInvalidReason, emitRegressionInvalid,
+                applyFix, captureFixFiles, fixApplied, emitFixAttempted,
+                runTests, testsPass, emitTestsPassed, emitTestsFailed,
+                recordResolution, updateCodeIndex, serializeResolvedResult, setResolvedStatus, emitResolved, setResolvedOutputs,
+                recordFailedAttempt, persistOutcomeHypotheses,
                 refineHypothesis, serializeRefinedHypotheses, updateIterationContext,
-                incrementIteration,
-                compileReport, setEscalatedOutputs,
+                incrementIteration, iterationsExhausted,
+                setMaxIterationsReason, setNoHypothesisReason,
+                compileReport, setEscalatedStatus, serializeEscalatedResult, emitEscalated, setEscalatedOutputs,
                 finish
             },
             Connections =
             {
                 // Initialization chain
-                new(initialize, initIteration),
+                new(readInputs, initIteration),
                 new(initIteration, initMaxIterations),
                 new(initMaxIterations, initFilesModified),
-                new(initFilesModified, initRegressionTest),
-                new(initRegressionTest, initIterationContext),
+                new(initFilesModified, initAttempts),
+                new(initAttempts, initRegressionTest),
+                new(initRegressionTest, initContextDone),
+                new(initContextDone, initIterationContext),
                 new(initIterationContext, classify),
 
                 // Classification branches (FlowNode outcomes)
@@ -591,27 +971,37 @@ public class DebuggingWorkflow : WorkflowBase
                 new(new Endpoint(classify, "RuntimeError"), new Endpoint(runtimeEmphasis)),
                 new(new Endpoint(classify, "BugInvestigation"), new Endpoint(bugEmphasis)),
 
-                // All emphasis branches converge at fork
-                new(tddEmphasis, fork),
-                new(runtimeEmphasis, fork),
-                new(bugEmphasis, fork),
+                // All emphasis branches converge -> session started -> fork
+                new(tddEmphasis, emitSessionStarted),
+                new(runtimeEmphasis, emitSessionStarted),
+                new(bugEmphasis, emitSessionStarted),
+                new(emitSessionStarted, fork),
 
-                // Fork branches to parallel collection activities
+                // Fork branches to parallel collection activities + the timeout guard
                 new(new Endpoint(fork, "CollectErrors"), new Endpoint(collectErrors)),
                 new(new Endpoint(fork, "CollectCode"), new Endpoint(collectCode)),
                 new(new Endpoint(fork, "CollectGit"), new Endpoint(collectGit)),
                 new(new Endpoint(fork, "CollectTests"), new Endpoint(collectTests)),
                 new(new Endpoint(fork, "CollectRepro"), new Endpoint(collectRepro)),
+                new(new Endpoint(fork, "Timeout"), new Endpoint(contextTimeout)),
 
-                // All collection activities converge at FlowJoin
+                // All 5 collection activities converge at FlowJoin (WaitAll)
                 new(collectErrors, join),
                 new(collectCode, join),
                 new(collectGit, join),
                 new(collectTests, join),
                 new(collectRepro, join),
 
+                // Join (all collected) AND timeout (partial) both funnel through the gate.
+                new(join, contextGatherGate),
+                new(new Endpoint(contextTimeout, "TimedOut"), new Endpoint(contextGatherGate)),
+                new(new Endpoint(contextTimeout, "Armed"), new Endpoint(contextGateSink)),
+
+                // Gate: first to arrive proceeds; the loser short-circuits.
+                new(new Endpoint(contextGatherGate, "True"), new Endpoint(joinLog)),
+                new(new Endpoint(contextGatherGate, "False"), new Endpoint(contextGateSink)),
+
                 // Join -> log -> serialize collector outputs
-                new(join, joinLog),
                 new(joinLog, serializeErrors),
                 new(serializeErrors, serializeCode),
                 new(serializeCode, serializeGit),
@@ -621,53 +1011,275 @@ public class DebuggingWorkflow : WorkflowBase
                 // Serialization -> AI Diagnosis -> serialize diagnosis
                 new(serializeRepro, aiDiagnosis),
                 new(aiDiagnosis, serializeDiagnosis),
+                new(serializeDiagnosis, diagnosisProduced),
 
-                // Serialize diagnosis -> Select Hypothesis -> serialize selected
-                new(serializeDiagnosis, selectHypothesis),
+                // Diagnosis success/failed event, then select hypothesis
+                new(new Endpoint(diagnosisProduced, "True"), new Endpoint(emitDiagnosisSuccess)),
+                new(new Endpoint(diagnosisProduced, "False"), new Endpoint(emitDiagnosisFailed)),
+                new(emitDiagnosisSuccess, selectHypothesis),
+                // Diagnosis produced nothing -> still try select (will exhaust) -> escalate path.
+                new(emitDiagnosisFailed, selectHypothesis),
+
+                // Select Hypothesis -> serialize selected -> check
                 new(selectHypothesis, serializeSelectedHypothesis),
-
-                // Serialize selected -> check if we have a hypothesis
                 new(serializeSelectedHypothesis, hasHypothesis),
 
-                // Has hypothesis? Yes -> check if bug mode needs regression test
-                new(new Endpoint(hasHypothesis, "True"), new Endpoint(isBugMode)),
+                // Has hypothesis? Yes -> emit selected -> bug-mode guard
+                new(new Endpoint(hasHypothesis, "True"), new Endpoint(emitHypothesisSelected)),
+                new(emitHypothesisSelected, isBugMode),
 
-                // Has hypothesis? No -> escalate
-                new(new Endpoint(hasHypothesis, "False"), new Endpoint(compileReport)),
+                // Has hypothesis? No -> set reason -> escalate
+                new(new Endpoint(hasHypothesis, "False"), new Endpoint(setNoHypothesisReason)),
+                new(setNoHypothesisReason, compileReport),
 
-                // Bug mode? Yes -> write regression test
+                // Bug mode? Yes -> write regression test -> capture file -> run it -> guard
                 new(new Endpoint(isBugMode, "True"), new Endpoint(writeRegressionTest)),
-                new(writeRegressionTest, markRegressionTestWritten),
+                new(writeRegressionTest, captureRegressionFile),
+                new(captureRegressionFile, runRegressionTest),
+                new(runRegressionTest, regressionFailsAsExpected),
+
+                // Regression FAILS as expected -> mark written -> apply fix
+                new(new Endpoint(regressionFailsAsExpected, "True"), new Endpoint(markRegressionTestWritten)),
                 new(markRegressionTestWritten, applyFix),
+
+                // Regression PASSES (does not reproduce) -> escalate (AC7)
+                new(new Endpoint(regressionFailsAsExpected, "False"), new Endpoint(setRegressionInvalidReason)),
+                new(setRegressionInvalidReason, emitRegressionInvalid),
+                new(emitRegressionInvalid, compileReport),
 
                 // Bug mode? No -> apply fix directly
                 new(new Endpoint(isBugMode, "False"), new Endpoint(applyFix)),
 
-                // Apply fix -> run tests
-                new(applyFix, runTests),
+                // Apply fix -> capture files -> emit attempted -> check success
+                new(applyFix, captureFixFiles),
+                new(captureFixFiles, emitFixAttempted),
+                new(emitFixAttempted, fixApplied),
+
+                // Fix applied? Yes -> run tests. No -> treat as failed attempt -> refine.
+                new(new Endpoint(fixApplied, "True"), new Endpoint(runTests)),
+                new(new Endpoint(fixApplied, "False"), new Endpoint(recordFailedAttempt)),
 
                 // Run tests -> check results
                 new(runTests, testsPass),
 
-                // Tests pass? Yes -> record resolution
-                new(new Endpoint(testsPass, "True"), new Endpoint(recordResolution)),
+                // Tests pass? Yes -> emit passed -> record resolution
+                new(new Endpoint(testsPass, "True"), new Endpoint(emitTestsPassed)),
+                new(emitTestsPassed, recordResolution),
                 new(recordResolution, updateCodeIndex),
-                new(updateCodeIndex, setResolvedOutputs),
+                new(updateCodeIndex, serializeResolvedResult),
+                new(serializeResolvedResult, setResolvedStatus),
+                new(setResolvedStatus, emitResolved),
+                new(emitResolved, setResolvedOutputs),
                 new(setResolvedOutputs, finish),
 
-                // Tests pass? No -> refine hypothesis -> serialize -> update context -> increment -> loop
-                new(new Endpoint(testsPass, "False"), new Endpoint(refineHypothesis)),
+                // Tests pass? No -> emit failed -> record attempt -> outcomes -> refine
+                new(new Endpoint(testsPass, "False"), new Endpoint(emitTestsFailed)),
+                new(emitTestsFailed, recordFailedAttempt),
+                new(recordFailedAttempt, persistOutcomeHypotheses),
+                new(persistOutcomeHypotheses, refineHypothesis),
                 new(refineHypothesis, serializeRefinedHypotheses),
                 new(serializeRefinedHypotheses, updateIterationContext),
                 new(updateIterationContext, incrementIteration),
 
-                // Loop back: increment -> select next hypothesis
-                new(incrementIteration, selectHypothesis),
+                // #12: graph-enforced loop bound on increment.
+                new(incrementIteration, iterationsExhausted),
+                new(new Endpoint(iterationsExhausted, "True"), new Endpoint(setMaxIterationsReason)),
+                new(setMaxIterationsReason, compileReport),
+                // Within budget -> select next hypothesis (loop back)
+                new(new Endpoint(iterationsExhausted, "False"), new Endpoint(selectHypothesis)),
 
-                // Escalation path
-                new(compileReport, setEscalatedOutputs),
+                // Escalation path -> status -> serialize -> emit -> outputs
+                new(compileReport, setEscalatedStatus),
+                new(setEscalatedStatus, serializeEscalatedResult),
+                new(serializeEscalatedResult, emitEscalated),
+                new(emitEscalated, setEscalatedOutputs),
                 new(setEscalatedOutputs, finish)
             }
         };
+    }
+
+    // ====================================================================
+    // Pure helpers (no Elsa context) — file/attempt/result building.
+    // ====================================================================
+
+    private static string? DescribeHypothesis(Hypothesis? h)
+        => string.IsNullOrEmpty(h?.Description) ? null : h!.Description;
+
+    /// <summary>Merge a single file path into the JSON list var (dedup, drop empties).</summary>
+    private static string MergeFiles(string? existingJson, string? newFile)
+    {
+        var list = DeserializeFiles(existingJson);
+        if (!string.IsNullOrWhiteSpace(newFile) && !list.Contains(newFile))
+            list.Add(newFile);
+        return JsonSerializer.Serialize(list);
+    }
+
+    /// <summary>Merge a set of file paths into the JSON list var (dedup, drop empties).</summary>
+    private static string MergeFiles(string? existingJson, List<string>? newFiles)
+    {
+        var list = DeserializeFiles(existingJson);
+        if (newFiles != null)
+        {
+            foreach (var f in newFiles)
+                if (!string.IsNullOrWhiteSpace(f) && !list.Contains(f))
+                    list.Add(f);
+        }
+        return JsonSerializer.Serialize(list);
+    }
+
+    private static List<string> DeserializeFiles(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return new List<string>();
+        try { return JsonSerializer.Deserialize<List<string>>(json) ?? new List<string>(); }
+        catch { return new List<string>(); }
+    }
+
+    private static List<FixAttempt> DeserializeAttempts(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return new List<FixAttempt>();
+        try { return JsonSerializer.Deserialize<List<FixAttempt>>(json) ?? new List<FixAttempt>(); }
+        catch { return new List<FixAttempt>(); }
+    }
+
+    private static List<Hypothesis> DeserializeHypotheses(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return new List<Hypothesis>();
+        try { return JsonSerializer.Deserialize<List<Hypothesis>>(json) ?? new List<Hypothesis>(); }
+        catch { return new List<Hypothesis>(); }
+    }
+
+    /// <summary>
+    /// #5: classify a failed attempt's outcome. MadeWorse when the failing-test count
+    /// after the fix exceeds the pre-fix baseline (collectTests context); otherwise DidNotFix.
+    /// </summary>
+    private static HypothesisOutcome ClassifyOutcome(
+        TestResultsContext? baseline, IDictionary<string, object>? testOutput)
+    {
+        var baselineFailing = baseline?.FailingTests ?? 0;
+        var afterFailing = ExtractFailingCount(testOutput);
+        if (afterFailing > baselineFailing && baselineFailing >= 0 && afterFailing >= 0)
+            return HypothesisOutcome.MadeWorse;
+        return HypothesisOutcome.DidNotFix;
+    }
+
+    private static int ExtractFailingCount(IDictionary<string, object>? testOutput)
+    {
+        if (testOutput == null) return -1;
+        foreach (var key in new[] { "failingTests", "failedTests", "failures" })
+        {
+            if (testOutput.TryGetValue(key, out var v))
+            {
+                if (v is int i) return i;
+                if (v is long l) return (int)l;
+                if (int.TryParse(v?.ToString(), out var p)) return p;
+            }
+        }
+        return -1;
+    }
+
+    /// <summary>
+    /// #5: re-serialize hypothesesJson with the tried hypothesis's Outcome/FixAttempted set,
+    /// so CompileDebugReport and the iteration context carry real outcomes.
+    /// </summary>
+    private static string MarkHypothesisOutcome(
+        string? hypothesesJson, Hypothesis? tried,
+        TestResultsContext? baseline, IDictionary<string, object>? testOutput)
+    {
+        var list = DeserializeHypotheses(hypothesesJson);
+        if (tried != null)
+        {
+            var outcome = ClassifyOutcome(baseline, testOutput);
+            var match = list.FirstOrDefault(h =>
+                string.Equals(h.Description, tried.Description, StringComparison.Ordinal));
+            if (match != null)
+            {
+                match.Outcome = outcome;
+                match.FixAttempted = tried.SuggestedFix;
+                match.FailureReason = outcome == HypothesisOutcome.MadeWorse
+                    ? "Fix increased the failing-test count"
+                    : "Fix did not make the tests pass";
+            }
+        }
+        return JsonSerializer.Serialize(list);
+    }
+
+    /// <summary>
+    /// #5: append a FixAttempt record (this iteration) to attemptsJson. The
+    /// outcome-marking of the tried hypothesis is persisted separately by
+    /// <see cref="MarkHypothesisOutcome"/> (the workflow's persistOutcomeHypotheses step).
+    /// </summary>
+    private static string AppendFailedAttempt(
+        string? attemptsJson, Hypothesis? tried,
+        int iteration, string? testResults, string? filesJson)
+    {
+        var attempts = DeserializeAttempts(attemptsJson);
+        attempts.Add(new FixAttempt
+        {
+            Iteration = iteration,
+            HypothesisDescription = tried?.Description ?? "unknown",
+            Approach = tried?.SuggestedFix ?? "unknown",
+            TestResult = Truncate(testResults, 2000),
+            Resolved = false,
+            FilesModified = DeserializeFiles(filesJson),
+            StartedAt = DateTime.UtcNow
+        });
+        return JsonSerializer.Serialize(attempts);
+    }
+
+    private static string Truncate(string? s, int max)
+        => string.IsNullOrEmpty(s) ? "" : (s!.Length <= max ? s : s[..max]);
+
+    /// <summary>#1: build the resolved DebugResult JSON.</summary>
+    private static string BuildResolvedResultJson(
+        Hypothesis? selected, string? selectedJson, string? hypothesesJson,
+        string? filesJson, int iteration, bool regressionAdded)
+    {
+        // Mark the winning hypothesis FixedIssue in the surfaced list.
+        var hypotheses = DeserializeHypotheses(hypothesesJson);
+        if (selected != null)
+        {
+            var match = hypotheses.FirstOrDefault(h =>
+                string.Equals(h.Description, selected.Description, StringComparison.Ordinal));
+            if (match != null) match.Outcome = HypothesisOutcome.FixedIssue;
+            else { selected.Outcome = HypothesisOutcome.FixedIssue; hypotheses.Insert(0, selected); }
+        }
+
+        var result = new DebugResult
+        {
+            Status = DebugStatus.Resolved,
+            RootCause = selected?.Description ?? "unknown",
+            FixApplied = selected?.SuggestedFix ?? "",
+            Attempts = iteration,
+            Hypotheses = hypotheses,
+            RegressionTestAdded = regressionAdded,
+            FilesChanged = DeserializeFiles(filesJson),
+            DebugReport = ""
+        };
+        return JsonSerializer.Serialize(result);
+    }
+
+    /// <summary>#1: build the escalated DebugResult JSON from the compiled report.</summary>
+    private static string BuildEscalatedResultJson(
+        DebugReport? report, string? hypothesesJson,
+        string? filesJson, int iteration, bool regressionAdded)
+    {
+        var hypotheses = report?.AllHypotheses != null && report.AllHypotheses.Count > 0
+            ? report.AllHypotheses
+            : DeserializeHypotheses(hypothesesJson);
+
+        var result = new DebugResult
+        {
+            Status = DebugStatus.Escalated,
+            RootCause = "",
+            FixApplied = "",
+            Attempts = iteration,
+            Hypotheses = hypotheses,
+            RegressionTestAdded = regressionAdded,
+            FilesChanged = report?.FilesInvestigated != null && report.FilesInvestigated.Count > 0
+                ? report.FilesInvestigated
+                : DeserializeFiles(filesJson),
+            DebugReport = report?.ReportText ?? ""
+        };
+        return JsonSerializer.Serialize(result);
     }
 }

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Debug/ContextCollectionTimeoutActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Debug/ContextCollectionTimeoutActivityTests.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+using Tamma.Activities.Debug;
+
+namespace Tamma.Activities.Tests.Debug;
+
+/// <summary>
+/// Completeness audit 2026-06-22 (<c>Debugging.md</c> §Missing #11, AC4) — coverage for
+/// the configurable context-collection timeout read
+/// (<see cref="ContextCollectionTimeoutActivity.ResolveTimeoutSeconds"/>). The activity
+/// itself arms a DURABLE <c>DelayFor</c> bookmark (not an in-memory scheduler), which is
+/// runtime behaviour the structural workflow test pins; this unit covers the config seam.
+/// </summary>
+[TestFixture]
+public class ContextCollectionTimeoutActivityTests
+{
+    private static IConfiguration Config(params (string Key, string Value)[] kvps)
+        => new ConfigurationBuilder()
+            .AddInMemoryCollection(kvps.Select(k =>
+                new KeyValuePair<string, string?>(k.Key, k.Value)))
+            .Build();
+
+    [Test]
+    public void ResolveTimeoutSeconds_DefaultsTo15_WhenUnset()
+    {
+        ContextCollectionTimeoutActivity.ResolveTimeoutSeconds(Config()).Should().Be(15);
+        ContextCollectionTimeoutActivity.ResolveTimeoutSeconds(null).Should().Be(15);
+    }
+
+    [Test]
+    public void ResolveTimeoutSeconds_HonorsConfiguredValue()
+    {
+        var cfg = Config(("Debugging:ContextCollectionTimeoutSeconds", "30"));
+        ContextCollectionTimeoutActivity.ResolveTimeoutSeconds(cfg).Should().Be(30);
+    }
+
+    [Test]
+    public void ResolveTimeoutSeconds_NonPositive_DisablesGuard()
+    {
+        var cfg = Config(("Debugging:ContextCollectionTimeoutSeconds", "0"));
+        ContextCollectionTimeoutActivity.ResolveTimeoutSeconds(cfg).Should().Be(0);
+
+        var neg = Config(("Debugging:ContextCollectionTimeoutSeconds", "-5"));
+        ContextCollectionTimeoutActivity.ResolveTimeoutSeconds(neg).Should().Be(0,
+            "a negative value floors to disabled rather than arming a negative delay");
+    }
+
+    [Test]
+    public void ResolveTimeoutSeconds_Garbage_FallsBackToDefault()
+    {
+        var cfg = Config(("Debugging:ContextCollectionTimeoutSeconds", "fifteen"));
+        ContextCollectionTimeoutActivity.ResolveTimeoutSeconds(cfg).Should().Be(15);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Debug/DebugEventTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Debug/DebugEventTests.cs
@@ -1,0 +1,116 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Debug;
+
+namespace Tamma.Activities.Tests.Debug;
+
+/// <summary>
+/// Completeness audit 2026-06-22 (<c>Debugging.md</c> §Missing #8) — coverage for the
+/// <c>DEBUG.*</c> DCB event mapping (<see cref="EmitDebugEventActivity.BuildTammaEvent"/>)
+/// and the <see cref="DebugEvents"/> status / reason convention.
+///
+/// <para>The core completeness gap was a real diagnose→fix→verify loop with ZERO audit
+/// events. These tests pin the now-explicit contract: diagnosis-failed, tests-failed,
+/// invalid-regression and escalated are LOUD (error-status) rows; fix-attempted carries a
+/// <c>success</c> flag so a failed-but-continuing fix is visible without being a loud
+/// error; tags carry the queryable sessionId/storyId/mode/tenantId/iteration keys.</para>
+/// </summary>
+[TestFixture]
+public class DebugEventTests
+{
+    [Test]
+    public void EventTypes_FollowAggregateActionStatusConvention()
+    {
+        DebugEvents.SessionStarted.Should().Be("DEBUG.SESSION.STARTED");
+        DebugEvents.DiagnosisSuccess.Should().Be("DEBUG.DIAGNOSIS.SUCCESS");
+        DebugEvents.DiagnosisFailed.Should().Be("DEBUG.DIAGNOSIS.FAILED");
+        DebugEvents.HypothesisSelected.Should().Be("DEBUG.HYPOTHESIS.SELECTED");
+        DebugEvents.FixAttempted.Should().Be("DEBUG.FIX.ATTEMPTED");
+        DebugEvents.TestsPassed.Should().Be("DEBUG.TESTS.PASSED");
+        DebugEvents.TestsFailed.Should().Be("DEBUG.TESTS.FAILED");
+        DebugEvents.RegressionInvalid.Should().Be("DEBUG.REGRESSION_TEST.INVALID");
+        DebugEvents.ResolvedSuccess.Should().Be("DEBUG.RESOLVED.SUCCESS");
+        DebugEvents.Escalated.Should().Be("DEBUG.ESCALATED.FAILED");
+    }
+
+    [Test]
+    public void StatusForEvent_DegradedTerminalsAreError_RestAreSuccess()
+    {
+        DebugEvents.StatusForEvent(DebugEvents.DiagnosisFailed).Should().Be("error");
+        DebugEvents.StatusForEvent(DebugEvents.TestsFailed).Should().Be("error");
+        DebugEvents.StatusForEvent(DebugEvents.RegressionInvalid).Should().Be("error");
+        DebugEvents.StatusForEvent(DebugEvents.Escalated).Should().Be("error");
+
+        DebugEvents.StatusForEvent(DebugEvents.SessionStarted).Should().Be("success");
+        DebugEvents.StatusForEvent(DebugEvents.DiagnosisSuccess).Should().Be("success");
+        DebugEvents.StatusForEvent(DebugEvents.HypothesisSelected).Should().Be("success");
+        DebugEvents.StatusForEvent(DebugEvents.FixAttempted).Should().Be("success");
+        DebugEvents.StatusForEvent(DebugEvents.TestsPassed).Should().Be("success");
+        DebugEvents.StatusForEvent(DebugEvents.ResolvedSuccess).Should().Be("success");
+    }
+
+    [Test]
+    public void BuildTammaEvent_StampsQueryableTags()
+    {
+        var tenant = Guid.NewGuid();
+        var evt = EmitDebugEventActivity.BuildTammaEvent(
+            DebugEvents.HypothesisSelected,
+            sessionId: "sess-1", storyId: "7-1I", mode: "BugInvestigation",
+            tenantId: tenant, iteration: 2, maxIterations: 5,
+            hypothesis: "off-by-one in loop bound", fixSucceeded: false, reason: null);
+
+        evt.EventType.Should().Be(DebugEvents.HypothesisSelected);
+        evt.Status.Should().Be("success");
+        evt.Tags.Should().NotBeNull();
+        evt.Tags!["sessionId"].Should().Be("sess-1");
+        evt.Tags["storyId"].Should().Be("7-1I");
+        evt.Tags["mode"].Should().Be("BugInvestigation");
+        evt.Tags["tenantId"].Should().Be(tenant.ToString("D"));
+        evt.Tags["iteration"].Should().Be("2");
+        evt.Data["maxIterations"].Should().Be(5);
+        evt.Data["hypothesis"].Should().Be("off-by-one in loop bound");
+        // fixSucceeded is only present on DEBUG.FIX.ATTEMPTED.
+        evt.Data.Should().NotContainKey("fixSucceeded");
+    }
+
+    [Test]
+    public void BuildTammaEvent_FixAttempted_CarriesSuccessFlag()
+    {
+        var evtFail = EmitDebugEventActivity.BuildTammaEvent(
+            DebugEvents.FixAttempted, "s", "story", "TddFailure", null, 1, 5, "h", fixSucceeded: false, reason: null);
+        evtFail.Status.Should().Be("success", "a failed-but-continuing fix is NOT a loud error");
+        evtFail.Data["fixSucceeded"].Should().Be(false);
+
+        var evtOk = EmitDebugEventActivity.BuildTammaEvent(
+            DebugEvents.FixAttempted, "s", "story", "TddFailure", null, 1, 5, "h", fixSucceeded: true, reason: null);
+        evtOk.Data["fixSucceeded"].Should().Be(true);
+    }
+
+    [Test]
+    public void BuildTammaEvent_NullTenant_OmitsTenantTag()
+    {
+        var evt = EmitDebugEventActivity.BuildTammaEvent(
+            DebugEvents.SessionStarted, "s", "story", "RuntimeError", null, 1, 5, null, false, null);
+        evt.Tags!.Should().NotContainKey("tenantId", "single-user / no-tenant events are platform-scope");
+    }
+
+    [Test]
+    public void BuildTammaEvent_Escalated_CarriesReason_AndIsError()
+    {
+        var evt = EmitDebugEventActivity.BuildTammaEvent(
+            DebugEvents.Escalated, "s", "story", "RuntimeError", null, 6, 5,
+            null, false, DebugEvents.ReasonMaxIterations);
+        evt.Status.Should().Be("error");
+        evt.Data["reason"].Should().Be(DebugEvents.ReasonMaxIterations);
+    }
+
+    [Test]
+    public void ParseTenantId_RejectsBlankAndGarbage()
+    {
+        DebugEvents.ParseTenantId(null).Should().BeNull();
+        DebugEvents.ParseTenantId("").Should().BeNull();
+        DebugEvents.ParseTenantId("not-a-guid").Should().BeNull();
+        var g = Guid.NewGuid();
+        DebugEvents.ParseTenantId(g.ToString()).Should().Be(g);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/LlmCall/NoDirectLlmCallTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/LlmCall/NoDirectLlmCallTests.cs
@@ -208,6 +208,10 @@ public class NoDirectLlmCallTests
         typeof(ApplyRefactoringActivity),
         typeof(Tamma.Activities.ADL.ApplyReviewFixesActivity),
         typeof(AIDiagnosisActivity),
+        // Debugging.md §Missing #9 — Refine + regression-test gen were the two debug
+        // activities still on the direct /api/engine/execute-task callback; now mediated.
+        typeof(RefineHypothesisActivity),
+        typeof(WriteRegressionTestActivity),
         typeof(ClaudeAnalysisActivity),
     };
 

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/DebuggingWorkflowTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/DebuggingWorkflowTests.cs
@@ -1,0 +1,228 @@
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Management.Activities.SetOutput;
+using Elsa.Workflows.Runtime.Activities;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Activities.Debug;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Build-out graph tests for the <c>debugging</c> sub-workflow (completeness audit
+/// 2026-06-22, Debugging.md). Structural (the flowchart is not runnable in a unit
+/// test without the Elsa runtime — the codebase convention is to assert the graph
+/// shape via <see cref="WorkflowTestHelper"/>). Covers the P0/P1 build-out items:
+/// #1 debugResultJson populated before BOTH terminals, #3 applyFix failure edge,
+/// #4 regression-must-fail guard, #8 DCB events, #10 tenantId threading, #11 durable
+/// context-collection timeout, #12 graph-enforced loop bound, #16 status output.
+/// </summary>
+[TestFixture]
+public class DebuggingWorkflowTests
+{
+    private Flowchart _flowchart = null!;
+    private Mock<IWorkflowBuilder> _builder = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _builder = WorkflowTestHelper.BuildWorkflow(new DebuggingWorkflow());
+        _flowchart = WorkflowTestHelper.GetFlowchart(_builder);
+    }
+
+    private bool HasConnection(string sourceId, string targetId, string? sourcePort = null) =>
+        _flowchart.Connections.Any(c =>
+            c.Source.Activity.Id == sourceId &&
+            c.Target.Activity.Id == targetId &&
+            (sourcePort == null || c.Source.Port == sourcePort));
+
+    private T? Find<T>(string id) where T : class, IActivity =>
+        WorkflowTestHelper.GetAllActivities(_flowchart).OfType<T>().FirstOrDefault(a => a.Id == id);
+
+    // ── #1 / #16 — debugResultJson is populated before BOTH terminal output sequences ──
+
+    [Test]
+    public void ResolvedTerminal_SerializesDebugResult_BeforeSettingOutputs()
+    {
+        // serializeResolvedResult must run on the resolved path before setResolvedOutputs.
+        Find<SetVariable<string>>("serializeResolvedResult").Should().NotBeNull(
+            "the resolved terminal must serialize a real DebugResult into debugResultJson (#1)");
+        HasConnection("UpdateCodeIndex", "serializeResolvedResult").Should().BeTrue();
+        // setResolvedStatus -> emitResolved -> setResolvedOutputs (status before outputs).
+        HasConnection("serializeResolvedResult", "setResolvedStatus").Should().BeTrue();
+        HasConnection("emitResolved", "setResolvedOutputs").Should().BeTrue();
+    }
+
+    [Test]
+    public void EscalatedTerminal_SerializesDebugResult_BeforeSettingOutputs()
+    {
+        Find<SetVariable<string>>("serializeEscalatedResult").Should().NotBeNull(
+            "the escalation terminal must serialize a real DebugResult into debugResultJson (#1)");
+        HasConnection("compileReport", "setEscalatedStatus").Should().BeTrue();
+        HasConnection("setEscalatedStatus", "serializeEscalatedResult").Should().BeTrue();
+        HasConnection("serializeEscalatedResult", "emitEscalated").Should().BeTrue();
+        HasConnection("emitEscalated", "setEscalatedOutputs").Should().BeTrue();
+    }
+
+    [Test]
+    public void CompileReport_ResultIsCaptured_NotDiscarded()
+    {
+        // #1: CompileDebugReport.Result must be wired (previously discarded → empty report).
+        var compile = Find<CompileDebugReportActivity>("compileReport");
+        compile.Should().NotBeNull();
+        compile!.Result.Should().NotBeNull(
+            "CompileDebugReport.Result must be captured so the escalated DebugResult carries the report text");
+    }
+
+    [Test]
+    public void BothTerminals_EmitStatusOutput()
+    {
+        // #16: a real status enum is emitted on BOTH terminals (not only boolean success).
+        Find<SetOutput>("outputResolvedStatus").Should().NotBeNull("resolved terminal emits status (#16)");
+        Find<SetOutput>("outputEscalatedStatus").Should().NotBeNull("escalated terminal emits status (#16)");
+    }
+
+    // ── #3 — applyFix captures result + branches on success (no false success) ──
+
+    [Test]
+    public void ApplyFix_CapturesResult_AndBranchesOnSuccess()
+    {
+        var applyFix = Find<DispatchWorkflow>("applyFix");
+        applyFix.Should().NotBeNull();
+        applyFix!.Result.Should().NotBeNull("applyFix must capture the llm-call result (#3)");
+
+        Find<FlowDecision>("fixApplied").Should().NotBeNull("a fixApplied? decision must gate the result (#3)");
+    }
+
+    [Test]
+    public void ApplyFix_Failure_RoutesToRefine_NotRunTests()
+    {
+        // #3 no-false-success: a failed fix dispatch must NOT silently proceed to runTests.
+        HasConnection("fixApplied", "runTests", "True").Should().BeTrue(
+            "a successful fix proceeds to run tests");
+        HasConnection("fixApplied", "recordFailedAttempt", "False").Should().BeTrue(
+            "a failed fix is counted as a failed attempt and routed to refine, never a silent success");
+        // The failed-fix edge must NOT go straight to runTests.
+        HasConnection("fixApplied", "runTests", "False").Should().BeFalse();
+    }
+
+    // ── #4 — BugInvestigation regression-test-must-fail guard (AC7) ──
+
+    [Test]
+    public void BugMode_RunsRegressionTest_AndRequiresItToFail_BeforeFixing()
+    {
+        Find<DispatchWorkflow>("runRegressionTest").Should().NotBeNull(
+            "the written regression test must be RUN before fixing (AC7, #4)");
+        Find<FlowDecision>("regressionFailsAsExpected").Should().NotBeNull(
+            "a regression-fails-as-expected? guard must gate the fix (AC7, #4)");
+
+        // Write -> capture file -> run -> guard.
+        HasConnection("writeRegressionTest", "captureRegressionFile").Should().BeTrue();
+        HasConnection("captureRegressionFile", "runRegressionTest").Should().BeTrue();
+        HasConnection("runRegressionTest", "regressionFailsAsExpected").Should().BeTrue();
+
+        // Fails-as-expected -> mark written -> applyFix.
+        HasConnection("regressionFailsAsExpected", "markRegressionTestWritten", "True").Should().BeTrue();
+        HasConnection("markRegressionTestWritten", "applyFix").Should().BeTrue();
+    }
+
+    [Test]
+    public void BugMode_RegressionTestPasses_Escalates_DoesNotFix()
+    {
+        // AC7: a regression test that PASSES (does not reproduce the bug) must abort/escalate,
+        // not silently proceed to apply a fix.
+        HasConnection("regressionFailsAsExpected", "setRegressionInvalidReason", "False").Should().BeTrue();
+        HasConnection("setRegressionInvalidReason", "emitRegressionInvalid").Should().BeTrue();
+        HasConnection("emitRegressionInvalid", "compileReport").Should().BeTrue(
+            "an invalid (passing) regression test escalates with a compiled report, never applies a fix");
+    }
+
+    // ── #11 — durable context-collection timeout bounds the Fork/Join ──
+
+    [Test]
+    public void ContextCollection_HasDurableTimeoutGuard_RacingTheCollectors()
+    {
+        Find<ContextCollectionTimeoutActivity>("contextTimeout").Should().NotBeNull(
+            "a durable DelayFor-based timeout must bound the context Fork/Join (AC4, #11)");
+
+        // The timeout is a fork branch.
+        HasConnection("contextFork", "contextTimeout", "Timeout").Should().BeTrue();
+        // On timeout it funnels through the gate (proceed with partial context).
+        HasConnection("contextTimeout", "contextGatherGate", "TimedOut").Should().BeTrue();
+        // The WaitAll join also funnels through the gate.
+        HasConnection("contextJoin", "contextGatherGate").Should().BeTrue();
+        // The gate proceeds to serialization on the first arrival.
+        HasConnection("contextGatherGate", "joinLog", "True").Should().BeTrue();
+    }
+
+    // ── #12 — graph-enforced loop bound ──
+
+    [Test]
+    public void LoopBound_IsGraphEnforced_OnIterationIncrement()
+    {
+        Find<FlowDecision>("iterationsExhausted").Should().NotBeNull(
+            "the iteration cap must be an explicit graph FlowDecision, not only internal to SelectHypothesis (#12)");
+        HasConnection("incrementIteration", "iterationsExhausted").Should().BeTrue();
+        // Exhausted -> escalate; within budget -> loop back to select.
+        HasConnection("iterationsExhausted", "setMaxIterationsReason", "True").Should().BeTrue();
+        HasConnection("setMaxIterationsReason", "compileReport").Should().BeTrue();
+        HasConnection("iterationsExhausted", "selectHypothesis", "False").Should().BeTrue();
+    }
+
+    // ── #8 — DCB events at graph boundaries ──
+
+    [Test]
+    public void EmitsDcbEvents_AtAllGraphBoundaries()
+    {
+        var emitters = WorkflowTestHelper.GetAllActivities(_flowchart)
+            .OfType<EmitDebugEventActivity>()
+            .ToList();
+        emitters.Should().HaveCountGreaterThanOrEqualTo(8,
+            "DEBUG.* events must be emitted at session-start, diagnosis, hypothesis-selected, "
+            + "fix-attempted, tests-passed/failed, resolved and escalated (#8)");
+
+        new[]
+        {
+            "emitSessionStarted", "emitDiagnosisSuccess", "emitDiagnosisFailed",
+            "emitHypothesisSelected", "emitFixAttempted", "emitTestsPassed",
+            "emitTestsFailed", "emitResolved", "emitEscalated",
+        }.Should().OnlyContain(id => Find<EmitDebugEventActivity>(id) != null);
+    }
+
+    // ── #10 — tenantId is threaded into the llm-call and testing-pipeline dispatches ──
+
+    [Test]
+    public void ApplyFix_ThreadsTenantId()
+    {
+        var applyFix = Find<DispatchWorkflow>("applyFix");
+        applyFix.Should().NotBeNull();
+        applyFix!.Input.Should().NotBeNull("applyFix must forward a tenantId in its llm-call input (#10)");
+    }
+
+    [Test]
+    public void RunTests_ThreadsTenantId()
+    {
+        var runTests = Find<DispatchWorkflow>("runTests");
+        runTests.Should().NotBeNull();
+        runTests!.Input.Should().NotBeNull("runTests must forward a tenantId in its testing-pipeline input (#10)");
+    }
+
+    [Test]
+    public void DeclaresTenantIdVariable_NamedForMediatedResolution()
+    {
+        // MediatedLlmText.ResolveTenantId reads the "TenantId" workflow variable.
+        _builder.Object.Variables.Should().Contain(v => v.Name == "TenantId",
+            "the workflow must declare a TenantId variable so the mediated call-LLM resolves tenant scope (#10)");
+    }
+
+    // ── Sanity: definition id is stable ──
+
+    [Test]
+    public void DefinitionId_IsDebugging()
+    {
+        _builder.Object.DefinitionId.Should().Be("debugging");
+    }
+}


### PR DESCRIPTION
## DebuggingWorkflow build-out — Bucket D (fix-now)

Per `docs/superpowers/audits/2026-06-22/completeness/Debugging.md` (Story 7-1I):
- **#1/#16 (P0):** both terminals now serialize a real `DebugResult` into `debugResultJson` (was always `{}`) + a real `status` enum.
- **#2/#5 (P0/P1):** track modified files + hypothesis outcomes (`DidNotFix`/`MadeWorse`) + `FixAttempt` records.
- **#3 (P0, no-false-success):** `applyFix` branches on the `llm-call` `success` flag — a failed fix → refine, never silently "fix applied".
- **#4 (P0, AC7):** BugInvestigation regression-test-must-FAIL guard — write the test, run it, require FAIL before fixing; a passing test escalates (`DEBUG.REGRESSION_TEST.INVALID`).
- **#8 (P1):** `DEBUG.*` DCB events via `TammaEventEmitter`. **#10 (P1):** thread `tenantId` (the workflow bound *no* inputs before — added `readInputs`). **#11 (P1, AC4):** durable `context.DelayFor` 15s context-collection timeout (no hang). **#12 (P1):** graph-enforced loop bound. **#13 (partial):** `Debugging:MaxIterations` config.
- **#9:** found `RefineHypothesisActivity` + `WriteRegressionTestActivity` still on the direct `/api/engine/execute-task` callback (a path the 32-5 grep-gate didn't cover) → repointed to `MediatedLlmText` (roles `senior_developer`/`tester`) + added to `NoDirectLlmCallTests`.

**Review:** APPROVED — AC7 guard polarity correct, repointed roles canonical (no 422), durable timeout can't hang, debugResultJson real on both terminals. **Follow-ups (MINOR):** a non-executed regression/fix dispatch defaults to "proceed" (low-impact — `runTests` still gates resolution); the timeout-loser join branch is abandoned (no hang) — worth a comment.

**Gate:** build 0; full `Tamma.Activities.Tests` **1933/0** (incl. NoDirectLlmCall + drift). No Program.cs/csproj/migration. Deferred (honest): #6/#7 (Epic 38 Slack/git), #14/#15/#17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)