### PR TITLE
feat(workflows): build out TriageItemCycleWorkflow — fail-closed apply, decision gate, cycle events

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/ApplyTriageResultActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/ApplyTriageResultActivity.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Elsa.Extensions;
 using Elsa.Workflows;
+using Elsa.Workflows.Activities.Flowchart.Attributes;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Configuration;
@@ -16,31 +17,59 @@ namespace Tamma.Activities.ADL;
 /// posts a triage summary comment.
 ///
 /// <para>Build-out (completeness audit 2026-06-22, <c>TriageItemCycle.md</c> #8): the
-/// activity is now <b>fail-loud</b>. Previously its <c>RunAsync</c> wrapped every
+/// activity is <b>fail-loud</b>. Previously its <c>RunAsync</c> wrapped every
 /// engine-callback POST in a <c>try/catch</c> that logged and returned, and NEVER
 /// checked <c>response.IsSuccessStatusCode</c> — a 4xx/5xx from <c>issue-labels</c> /
 /// <c>issue-comment</c> / <c>create-issue</c> still surfaced as
 /// <c>TRIAGE.APPLY.RESULT.COMPLETED</c> (a false success). It now checks the status of
-/// each POST and <c>throw</c>s on the first non-success, so the base
-/// (<see cref="TammaAsyncActivity"/>) emits <c>TRIAGE.APPLY.RESULT.FAILED</c> and the
-/// faulted activity propagates to the cycle's fail-the-item edge — never a silently
-/// swallowed apply.</para>
+/// each POST (<see cref="ApplyCoreAsync"/> + <see cref="EnsureSuccess"/> throw on the
+/// first non-success).</para>
+///
+/// <para>Review fix (CRITICAL — "stuck, no terminal" hang): the activity is now a
+/// <see cref="TammaOutcomeActivity"/> exposing an explicit <c>Success</c> /
+/// <c>Failure</c> <see cref="FlowNode"/>. An apply failure (a non-success POST or a
+/// network throw from <see cref="ApplyCoreAsync"/>) is caught here, emits a loud
+/// <c>TRIAGE.APPLY.RESULT.FAILED</c> leaf event (secret-free, status-code only), sets
+/// <see cref="FailureReason"/>, and completes the <c>Failure</c> outcome — it does NOT
+/// rethrow. That edge is the precedent (<c>MergePullRequestActivity</c>'s <c>Error</c>
+/// outcome → loud terminal): a Flowchart never schedules outbound edges of a
+/// <i>faulted</i> node (Elsa 3.5 <c>Flowchart.ProcessChildCompletedAsync</c> only routes
+/// a <c>Completed</c> child), so a bare throw under the default <c>FaultStrategy</c>
+/// would HALT the cycle with no <c>TRIAGE.ISSUE.*</c> terminal and no <c>itemResult</c>.
+/// Routing the failure as an outcome lets the cycle emit EXACTLY ONE loud
+/// <c>TRIAGE.ISSUE.FAILED</c> terminal on apply failure. <see cref="EventType"/> is
+/// <c>null</c> so the base does NOT auto-emit a false <c>.COMPLETED</c> on the caught
+/// failure; the leaf <c>STARTED</c>/<c>COMPLETED</c>/<c>FAILED</c> events are emitted
+/// explicitly here.</para>
 ///
 /// <para>Build-out #7: the caller (the cycle) may supply a deterministically-rendered
 /// comment (<see cref="CommentOverride"/>) and a vocabulary-validated label set
 /// (<see cref="LabelsOverride"/>) so the applied labels/comment are the canonical,
 /// validated grid rather than arbitrary LLM prose/labels. When unset, the activity
 /// falls back to the decision JSON's own <c>labels</c>/<c>comment</c> (back-compat).</para>
+///
+/// Outcomes:
+///   - Success: labels/comment applied (or the mock no-op short-circuit).
+///   - Failure: an engine-callback POST failed (4xx/5xx) or threw — the cycle routes
+///     this to a loud <c>TRIAGE.ISSUE.FAILED</c> terminal (no false success).
 /// </summary>
 [Activity(
     "Tamma.ADL",
     "Apply Triage Result",
-    "Apply labels and post triage comment on the issue",
+    "Apply labels and post triage comment on the issue, with an explicit Failure outcome",
     Kind = ActivityKind.Task
 )]
-public class ApplyTriageResultActivity : TammaAsyncActivity
+[FlowNode("Success", "Failure")]
+public class ApplyTriageResultActivity : TammaOutcomeActivity
 {
-    public override string? EventType => "TRIAGE.APPLY.RESULT";
+    /// <summary>The leaf apply event prefix used for the explicit STARTED/COMPLETED/FAILED
+    /// leaf events. <see cref="EventType"/> stays <c>null</c> so the base does not also
+    /// auto-emit (which would surface a false <c>.COMPLETED</c> on a caught failure).</summary>
+    public const string ApplyEventType = "TRIAGE.APPLY.RESULT";
+
+    // Suppress the base auto-emit — a caught Failure outcome returns normally from
+    // RunAsync, which would otherwise make the base emit a false .COMPLETED.
+    public override string? EventType => null;
 
     private readonly IHttpClientFactory? _httpClientFactory;
     private readonly IConfiguration? _configuration;
@@ -60,6 +89,9 @@ public class ApplyTriageResultActivity : TammaAsyncActivity
     [Input(Description = "Deterministically-rendered comment to post (overrides the decision JSON comment when non-empty)")]
     public Input<string?> CommentOverride { get; set; } = new((string?)null);
 
+    [Output(Description = "Secret-free apply-failure reason when the Failure outcome fires")]
+    public Output<string?> FailureReason { get; set; } = default!;
+
     [JsonConstructor]
     public ApplyTriageResultActivity() { }
 
@@ -73,6 +105,11 @@ public class ApplyTriageResultActivity : TammaAsyncActivity
         _configuration = configuration;
     }
 
+    public override Dictionary<string, object?> BuildEndData(ActivityExecutionContext context) => new()
+    {
+        ["repository"] = Repository.Get(context),
+    };
+
     protected override async Task RunAsync(ActivityExecutionContext context)
     {
         var repo = Repository.Get(context);
@@ -81,19 +118,72 @@ public class ApplyTriageResultActivity : TammaAsyncActivity
         var labelsOverride = LabelsOverride.GetOrDefault(context);
         var commentOverride = CommentOverride.GetOrDefault(context);
 
-        var callbackUrl = _configuration?["Engine:CallbackUrl"];
-        if (string.IsNullOrEmpty(callbackUrl) || _httpClientFactory == null)
+        // Explicit leaf STARTED (the base no longer auto-emits — EventType is null).
+        var startedAt = DateTime.UtcNow;
+        EmitLeaf(context, $"{ApplyEventType}.STARTED", "started", null, null);
+
+        // Resolve the apply client. A directly-injected ITriageApplyClient (test seam, or
+        // a future DI registration) wins; otherwise build the HTTP client from config +
+        // the http-client factory (resolved from the activity scope when the ctor did not
+        // inject them — mirrors MergePullRequestActivity's `_github ?? context.GetService`).
+        var injectedClient = context.GetService<ITriageApplyClient>();
+        var configuration = _configuration ?? context.GetService<IConfiguration>();
+        var httpClientFactory = _httpClientFactory ?? context.GetService<IHttpClientFactory>();
+        var callbackUrl = configuration?["Engine:CallbackUrl"];
+
+        ITriageApplyClient client;
+        if (injectedClient != null)
+        {
+            client = injectedClient;
+        }
+        else if (!string.IsNullOrEmpty(callbackUrl) && httpClientFactory != null)
+        {
+            client = new HttpTriageApplyClient(httpClientFactory.CreateClient(), callbackUrl.TrimEnd('/'));
+        }
+        else
         {
             Logger?.LogInformation("[Mock] Would apply triage result");
+            EmitLeaf(context, $"{ApplyEventType}.COMPLETED", "success", DateTime.UtcNow - startedAt, null);
+            await context.CompleteActivityWithOutcomesAsync("Success");
             return;
         }
 
-        var client = new HttpTriageApplyClient(
-            _httpClientFactory.CreateClient(), callbackUrl.TrimEnd('/'));
+        try
+        {
+            await ApplyCoreAsync(
+                client, repo, itemJson, decisionJson,
+                labelsOverride?.ToArray(), commentOverride, Logger, context.CancellationToken);
+        }
+        catch (Exception ex)
+        {
+            // Fail loud — but as a ROUTABLE outcome, not a fault. A faulted node's
+            // outbound edges never fire (Elsa 3.5 Flowchart), so a rethrow here would
+            // halt the cycle with no TRIAGE.ISSUE.* terminal. Emit the loud leaf FAILED
+            // (secret-free message — ApplyCoreAsync/EnsureSuccess throw status-code-only)
+            // and complete the Failure outcome so the cycle routes a single loud
+            // TRIAGE.ISSUE.FAILED terminal.
+            Logger?.LogError(ex, "Triage apply failed for {Repo}", repo);
+            FailureReason.Set(context, ex.Message);
+            EmitLeaf(context, $"{ApplyEventType}.FAILED", "error", DateTime.UtcNow - startedAt, ex.Message);
+            await context.CompleteActivityWithOutcomesAsync("Failure");
+            return;
+        }
 
-        await ApplyCoreAsync(
-            client, repo, itemJson, decisionJson,
-            labelsOverride?.ToArray(), commentOverride, Logger, context.CancellationToken);
+        EmitLeaf(context, $"{ApplyEventType}.COMPLETED", "success", DateTime.UtcNow - startedAt, null);
+        await context.CompleteActivityWithOutcomesAsync("Success");
+    }
+
+    private void EmitLeaf(
+        ActivityExecutionContext context, string type, string status, TimeSpan? duration, string? error)
+    {
+        TammaEventEmitter.Emit(context, this, Logger, new TammaEvent
+        {
+            EventType = type,
+            Status = status,
+            Duration = duration,
+            Error = error,
+            Data = BuildEndData(context),
+        });
     }
 
     /// <summary>
@@ -101,9 +191,11 @@ public class ApplyTriageResultActivity : TammaAsyncActivity
     /// the item + decision, picks the validated labels / rendered comment (#7), then
     /// POSTs the labels/comment (or creates an issue for an alert) through the injectable
     /// <paramref name="client"/>. Every POST is checked: a non-success response or a
-    /// throw propagates so the activity base emits <c>TRIAGE.APPLY.RESULT.FAILED</c> and
-    /// the cycle's fail-the-item edge fires. A null item/decision is an honest input bug
-    /// — it throws, never a false success. Follows the
+    /// throw propagates. <see cref="RunAsync"/> catches that throw, emits the loud
+    /// <c>TRIAGE.APPLY.RESULT.FAILED</c> leaf event, and completes the <c>Failure</c>
+    /// outcome so the cycle's fail-the-item edge fires (a routable outcome, not a fault —
+    /// see the class summary for why a rethrow would halt the cycle). A null item/decision
+    /// is an honest input bug — it throws, never a false success. Follows the
     /// <c>UpdateIssueStatusActivity.ExecuteCoreAsync</c> seam pattern.
     /// </summary>
     public static async Task ApplyCoreAsync(
@@ -156,11 +248,11 @@ public class ApplyTriageResultActivity : TammaAsyncActivity
     }
 
     /// <summary>
-    /// #8 — fail loud. A non-success engine-callback response must <c>throw</c> so the
-    /// base emits <c>TRIAGE.APPLY.RESULT.FAILED</c> and the cycle's fail-the-item edge
-    /// fires — never a swallowed 4xx/5xx reported as <c>.COMPLETED</c>. The thrown
-    /// message is status-code only (no response body) to keep secrets out of the
-    /// event/log. Exposed for unit testing.
+    /// #8 — fail loud. A non-success engine-callback response must <c>throw</c> so
+    /// <see cref="RunAsync"/> emits <c>TRIAGE.APPLY.RESULT.FAILED</c> and completes the
+    /// <c>Failure</c> outcome (the cycle's fail-the-item edge) — never a swallowed 4xx/5xx
+    /// reported as <c>.COMPLETED</c>. The thrown message is status-code only (no response
+    /// body) to keep secrets out of the event/log. Exposed for unit testing.
     /// </summary>
     public static void EnsureSuccess(TriageApplyResult result, string endpoint, int issueNumber)
     {
@@ -168,11 +260,6 @@ public class ApplyTriageResultActivity : TammaAsyncActivity
         throw new HttpRequestException(
             $"Triage apply failed: {endpoint} returned {result.StatusCode} for issue #{issueNumber}.");
     }
-
-    public override Dictionary<string, object?> BuildEndData(ActivityExecutionContext context) => new()
-    {
-        ["repository"] = Repository.Get(context),
-    };
 }
 
 /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/ApplyTriageResultActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/ApplyTriageResultActivity.cs
@@ -14,6 +14,23 @@ namespace Tamma.Activities.ADL;
 /// <summary>
 /// Applies triage results: sets labels on the issue/creates issue for alerts,
 /// posts a triage summary comment.
+///
+/// <para>Build-out (completeness audit 2026-06-22, <c>TriageItemCycle.md</c> #8): the
+/// activity is now <b>fail-loud</b>. Previously its <c>RunAsync</c> wrapped every
+/// engine-callback POST in a <c>try/catch</c> that logged and returned, and NEVER
+/// checked <c>response.IsSuccessStatusCode</c> — a 4xx/5xx from <c>issue-labels</c> /
+/// <c>issue-comment</c> / <c>create-issue</c> still surfaced as
+/// <c>TRIAGE.APPLY.RESULT.COMPLETED</c> (a false success). It now checks the status of
+/// each POST and <c>throw</c>s on the first non-success, so the base
+/// (<see cref="TammaAsyncActivity"/>) emits <c>TRIAGE.APPLY.RESULT.FAILED</c> and the
+/// faulted activity propagates to the cycle's fail-the-item edge — never a silently
+/// swallowed apply.</para>
+///
+/// <para>Build-out #7: the caller (the cycle) may supply a deterministically-rendered
+/// comment (<see cref="CommentOverride"/>) and a vocabulary-validated label set
+/// (<see cref="LabelsOverride"/>) so the applied labels/comment are the canonical,
+/// validated grid rather than arbitrary LLM prose/labels. When unset, the activity
+/// falls back to the decision JSON's own <c>labels</c>/<c>comment</c> (back-compat).</para>
 /// </summary>
 [Activity(
     "Tamma.ADL",
@@ -37,6 +54,12 @@ public class ApplyTriageResultActivity : TammaAsyncActivity
     [Input(Description = "PO decision JSON with labels, priority, comment")]
     public Input<string> DecisionJson { get; set; } = default!;
 
+    [Input(Description = "Validated label set to apply (overrides the decision JSON labels when set; empty list → fall back)")]
+    public Input<ICollection<string>?> LabelsOverride { get; set; } = new((ICollection<string>?)null);
+
+    [Input(Description = "Deterministically-rendered comment to post (overrides the decision JSON comment when non-empty)")]
+    public Input<string?> CommentOverride { get; set; } = new((string?)null);
+
     [JsonConstructor]
     public ApplyTriageResultActivity() { }
 
@@ -55,6 +78,8 @@ public class ApplyTriageResultActivity : TammaAsyncActivity
         var repo = Repository.Get(context);
         var itemJson = ItemJson.Get(context);
         var decisionJson = DecisionJson.Get(context);
+        var labelsOverride = LabelsOverride.GetOrDefault(context);
+        var commentOverride = CommentOverride.GetOrDefault(context);
 
         var callbackUrl = _configuration?["Engine:CallbackUrl"];
         if (string.IsNullOrEmpty(callbackUrl) || _httpClientFactory == null)
@@ -63,62 +88,151 @@ public class ApplyTriageResultActivity : TammaAsyncActivity
             return;
         }
 
-        try
+        var client = new HttpTriageApplyClient(
+            _httpClientFactory.CreateClient(), callbackUrl.TrimEnd('/'));
+
+        await ApplyCoreAsync(
+            client, repo, itemJson, decisionJson,
+            labelsOverride?.ToArray(), commentOverride, Logger, context.CancellationToken);
+    }
+
+    /// <summary>
+    /// Testable core (no Elsa context) — the load-bearing fail-loud logic (#8). Parses
+    /// the item + decision, picks the validated labels / rendered comment (#7), then
+    /// POSTs the labels/comment (or creates an issue for an alert) through the injectable
+    /// <paramref name="client"/>. Every POST is checked: a non-success response or a
+    /// throw propagates so the activity base emits <c>TRIAGE.APPLY.RESULT.FAILED</c> and
+    /// the cycle's fail-the-item edge fires. A null item/decision is an honest input bug
+    /// — it throws, never a false success. Follows the
+    /// <c>UpdateIssueStatusActivity.ExecuteCoreAsync</c> seam pattern.
+    /// </summary>
+    public static async Task ApplyCoreAsync(
+        ITriageApplyClient client,
+        string? repository,
+        string? itemJson,
+        string? decisionJson,
+        IReadOnlyList<string>? labelsOverride,
+        string? commentOverride,
+        ILogger? logger = null,
+        CancellationToken ct = default)
+    {
+        var item = JsonSerializer.Deserialize<TriageItem>(itemJson ?? "",
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        var decision = JsonSerializer.Deserialize<TriageDecision>(decisionJson ?? "",
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        if (item == null || decision == null)
+            throw new InvalidOperationException(
+                "Cannot apply triage result: item or decision JSON did not deserialize.");
+
+        // #7 — prefer the caller's validated label set / rendered comment; fall back to
+        // the decision JSON's own values for back-compat when the override is unset.
+        var labels = labelsOverride is { Count: > 0 }
+            ? new List<string>(labelsOverride)
+            : decision.Labels;
+        var comment = !string.IsNullOrWhiteSpace(commentOverride)
+            ? commentOverride!
+            : decision.Comment;
+
+        if (item.Type == "issue" && item.Number > 0)
         {
-            var item = JsonSerializer.Deserialize<TriageItem>(itemJson,
-                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-            var decision = JsonSerializer.Deserialize<TriageDecision>(decisionJson,
-                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            if (labels is { Count: > 0 })
+                EnsureSuccess(await client.SetLabelsAsync(repository ?? "", item.Number, labels, ct),
+                    "issue-labels", item.Number);
 
-            if (item == null || decision == null) return;
-
-            var httpClient = _httpClientFactory.CreateClient();
-            var baseUrl = callbackUrl.TrimEnd('/');
-
-            if (item.Type == "issue" && item.Number > 0)
-            {
-                // Apply labels to existing issue
-                if (decision.Labels is { Count: > 0 })
-                {
-                    await httpClient.PostAsJsonAsync(
-                        $"{baseUrl}/api/engine/issue-labels",
-                        new { repository = repo, issueNumber = item.Number, labels = decision.Labels });
-                }
-
-                // Post triage comment
-                if (!string.IsNullOrEmpty(decision.Comment))
-                {
-                    await httpClient.PostAsJsonAsync(
-                        $"{baseUrl}/api/engine/issue-comment",
-                        new { repository = repo, issueNumber = item.Number, body = decision.Comment });
-                }
-            }
-            else
-            {
-                // Create issue for security alert
-                var createResult = await httpClient.PostAsJsonAsync(
-                    $"{baseUrl}/api/engine/create-issue",
-                    new
-                    {
-                        repository = repo,
-                        title = item.Title,
-                        body = $"{item.Body}\n\n---\n{decision.Comment}",
-                        labels = decision.Labels,
-                    });
-
-                Logger?.LogInformation("Created issue for {Type}: {Title}", item.Type, item.Title);
-            }
+            if (!string.IsNullOrEmpty(comment))
+                EnsureSuccess(await client.PostCommentAsync(repository ?? "", item.Number, comment, ct),
+                    "issue-comment", item.Number);
         }
-        catch (Exception ex)
+        else
         {
-            Logger?.LogError(ex, "Failed to apply triage result");
+            EnsureSuccess(
+                await client.CreateIssueAsync(
+                    repository ?? "", item.Title, $"{item.Body}\n\n---\n{comment}", labels, ct),
+                "create-issue", item.Number);
+
+            logger?.LogInformation("Created issue for {Type}: {Title}", item.Type, item.Title);
         }
+    }
+
+    /// <summary>
+    /// #8 — fail loud. A non-success engine-callback response must <c>throw</c> so the
+    /// base emits <c>TRIAGE.APPLY.RESULT.FAILED</c> and the cycle's fail-the-item edge
+    /// fires — never a swallowed 4xx/5xx reported as <c>.COMPLETED</c>. The thrown
+    /// message is status-code only (no response body) to keep secrets out of the
+    /// event/log. Exposed for unit testing.
+    /// </summary>
+    public static void EnsureSuccess(TriageApplyResult result, string endpoint, int issueNumber)
+    {
+        if (result.Success) return;
+        throw new HttpRequestException(
+            $"Triage apply failed: {endpoint} returned {result.StatusCode} for issue #{issueNumber}.");
     }
 
     public override Dictionary<string, object?> BuildEndData(ActivityExecutionContext context) => new()
     {
         ["repository"] = Repository.Get(context),
     };
+}
+
+/// <summary>
+/// Result of one triage-apply engine-callback POST. <see cref="Success"/> mirrors
+/// <c>HttpResponseMessage.IsSuccessStatusCode</c>; <see cref="StatusCode"/> is the
+/// numeric code for the (secret-free) error message.
+/// </summary>
+public readonly record struct TriageApplyResult(bool Success, int StatusCode)
+{
+    public static TriageApplyResult Ok() => new(true, 200);
+    public static TriageApplyResult Fail(int statusCode) => new(false, statusCode);
+}
+
+/// <summary>
+/// Injectable seam for the triage-apply engine callbacks (issue-labels / issue-comment /
+/// create-issue), so <see cref="ApplyTriageResultActivity.ApplyCoreAsync"/> is unit
+/// testable without a live HTTP server. Mirrors <c>IIssueCallbackClient</c>.
+/// </summary>
+public interface ITriageApplyClient
+{
+    Task<TriageApplyResult> SetLabelsAsync(string repository, int issueNumber, IReadOnlyList<string> labels, CancellationToken ct);
+    Task<TriageApplyResult> PostCommentAsync(string repository, int issueNumber, string body, CancellationToken ct);
+    Task<TriageApplyResult> CreateIssueAsync(string repository, string title, string body, IReadOnlyList<string> labels, CancellationToken ct);
+}
+
+/// <summary>Default <see cref="ITriageApplyClient"/> over the engine-callback HTTP API.</summary>
+internal sealed class HttpTriageApplyClient : ITriageApplyClient
+{
+    private readonly HttpClient _http;
+    private readonly string _baseUrl;
+
+    public HttpTriageApplyClient(HttpClient http, string baseUrl)
+    {
+        _http = http;
+        _baseUrl = baseUrl;
+    }
+
+    public async Task<TriageApplyResult> SetLabelsAsync(string repository, int issueNumber, IReadOnlyList<string> labels, CancellationToken ct)
+    {
+        var r = await _http.PostAsJsonAsync($"{_baseUrl}/api/engine/issue-labels",
+            new { repository, issueNumber, labels }, ct);
+        return ToResult(r);
+    }
+
+    public async Task<TriageApplyResult> PostCommentAsync(string repository, int issueNumber, string body, CancellationToken ct)
+    {
+        var r = await _http.PostAsJsonAsync($"{_baseUrl}/api/engine/issue-comment",
+            new { repository, issueNumber, body }, ct);
+        return ToResult(r);
+    }
+
+    public async Task<TriageApplyResult> CreateIssueAsync(string repository, string title, string body, IReadOnlyList<string> labels, CancellationToken ct)
+    {
+        var r = await _http.PostAsJsonAsync($"{_baseUrl}/api/engine/create-issue",
+            new { repository, title, body, labels }, ct);
+        return ToResult(r);
+    }
+
+    private static TriageApplyResult ToResult(HttpResponseMessage r)
+        => new(r.IsSuccessStatusCode, (int)r.StatusCode);
 }
 
 public class TriageDecision

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitTriageCycleEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitTriageCycleEventActivity.cs
@@ -1,0 +1,171 @@
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+
+namespace Tamma.Activities.ADL;
+
+/// <summary>
+/// Emits a <b>cycle-scoped</b> <c>TRIAGE.ISSUE.*</c> DCB event (completeness audit
+/// 2026-06-22, <c>TriageItemCycle.md</c> #3 / Story 26-1 AC9) for the audit trail by
+/// appending a <see cref="TammaEvent"/> to the workflow's <c>tamma:events</c> transient
+/// list via <see cref="TammaEventEmitter.Emit"/>. The engine event drain
+/// (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) flushes that list
+/// <i>durably</i> to the tenant <c>domain_events</c> store after this activity runs —
+/// the drain resolves the tenant from the workflow scope (the <c>triage-item-cycle</c>
+/// workflow stamps a <c>TenantId</c> variable). The event therefore persists without
+/// this activity holding any DB / repository dependency of its own (none is registered
+/// in the Elsa engine — the same reason <see cref="EmitTriageContextEventActivity"/>,
+/// <see cref="EmitTriageEventActivity"/> and <see cref="EmitTriagePoDecisionEventActivity"/>
+/// use the emitter rather than a direct <c>IEventRepository</c>).
+///
+/// <para>The cycle emits <c>STARTED</c> right at init and exactly one terminal event:
+/// <c>COMPLETED</c> (labels/comment applied), <c>SKIPPED</c> (a stage reported a
+/// non-applying-but-not-faulted signal — context unavailable / panel below quorum), or
+/// <c>FAILED</c> (a sub-workflow faulted, the PO produced no usable decision, or the
+/// apply failed). A skipped or failed cycle is a loud audit row, never a silent false
+/// success.</para>
+/// </summary>
+[Activity(
+    "Tamma.ADL",
+    "Emit Triage Cycle Event",
+    "Emit a cycle-scoped TRIAGE.ISSUE.* DCB event for the per-item triage audit trail",
+    Kind = ActivityKind.Task
+)]
+public class EmitTriageCycleEventActivity : Activity
+{
+    private readonly ILogger<EmitTriageCycleEventActivity>? _logger;
+
+    [Input(Description = "Event type — TRIAGE.ISSUE.STARTED / .COMPLETED / .SKIPPED / .FAILED")]
+    public Input<string> EventType { get; set; } = default!;
+
+    [Input(Description = "Repository in owner/repo format")]
+    public Input<string> Repository { get; set; } = default!;
+
+    [Input(Description = "Deterministic item key — repo#number for an issue, repo:source for an alert")]
+    public Input<string?> ItemKey { get; set; } = new((string?)null);
+
+    [Input(Description = "Triage item number (0 when unknown / an alert)")]
+    public Input<int> ItemNumber { get; set; } = new(0);
+
+    [Input(Description = "Tenant id (empty / single-user → platform-scope event)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [Input(Description = "Item source — issue / dependabot / codeql / ... (from the item JSON)")]
+    public Input<string?> ItemSource { get; set; } = new((string?)null);
+
+    [Input(Description = "Decided type (empty unless COMPLETED)")]
+    public Input<string?> Type { get; set; } = new((string?)null);
+
+    [Input(Description = "Decided priority (empty unless COMPLETED)")]
+    public Input<string?> Priority { get; set; } = new((string?)null);
+
+    [Input(Description = "Decided automation level (empty unless COMPLETED)")]
+    public Input<string?> Automation { get; set; } = new((string?)null);
+
+    [Input(Description = "Decision status carried from the PO step (ok / unparsed / llm-failed / skipped)")]
+    public Input<string?> DecisionStatus { get; set; } = new((string?)null);
+
+    [Input(Description = "Short, secret-free reason/error (empty unless SKIPPED / FAILED)")]
+    public Input<string?> Reason { get; set; } = new((string?)null);
+
+    [JsonConstructor]
+    public EmitTriageCycleEventActivity() { }
+
+    public EmitTriageCycleEventActivity(ILogger<EmitTriageCycleEventActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var type = EventType.Get(context) ?? TriageCycleEvents.Failed;
+        var repository = Repository.Get(context) ?? "";
+        var itemKey = ItemKey.Get(context);
+        var itemNumber = ItemNumber.Get(context);
+        var tenantId = TriageCycleEvents.ParseTenantId(TenantId.Get(context));
+        var itemSource = ItemSource.Get(context);
+        var type2 = Type.Get(context);
+        var priority = Priority.Get(context);
+        var automation = Automation.Get(context);
+        var decisionStatus = DecisionStatus.Get(context);
+        var reason = Reason.Get(context);
+
+        var evt = BuildTammaEvent(
+            type, repository, itemKey, itemNumber, tenantId, itemSource,
+            type2, priority, automation, decisionStatus, reason);
+
+        TammaEventEmitter.Emit(context, this, _logger, evt);
+
+        _logger?.LogInformation(
+            "Emitted {Type} for {ItemKey} in {Repo} (source={Source}, status={Status})",
+            type, itemKey, repository, itemSource, decisionStatus);
+
+        return default;
+    }
+
+    /// <summary>
+    /// Map the cycle inputs onto a <see cref="TammaEvent"/> expressed as the engine's
+    /// transient-list event so the merged drain persists it. Tags carry the queryable
+    /// DCB index keys requested by the build-out spec
+    /// (<c>repository</c>/<c>itemKey</c>/<c>issueId</c>/<c>itemNumber</c>/
+    /// <c>itemSource</c>/<c>type</c>/<c>priority</c>/<c>automation</c>/<c>tenantId</c>);
+    /// Data carries the cycle payload (<c>itemSource</c>/<c>type</c>/<c>priority</c>/
+    /// <c>automation</c>/<c>decisionStatus</c>). Status is driven off the event type
+    /// (failed → error, skipped → warning) so a skipped/failed cycle is never recorded
+    /// as a false success. Pure (no Elsa context) — exposed for unit testing the mapping.
+    /// </summary>
+    public static TammaEvent BuildTammaEvent(
+        string type,
+        string repository,
+        string? itemKey,
+        int itemNumber,
+        Guid? tenantId,
+        string? itemSource,
+        string? itemType,
+        string? priority,
+        string? automation,
+        string? decisionStatus,
+        string? reason)
+    {
+        var tags = new Dictionary<string, object?>
+        {
+            ["repository"] = repository,
+        };
+        if (!string.IsNullOrWhiteSpace(itemKey)) tags["itemKey"] = itemKey;
+        if (itemNumber > 0)
+        {
+            tags["itemId"] = itemNumber.ToString();
+            tags["itemNumber"] = itemNumber.ToString();
+            tags["issueId"] = itemNumber.ToString();
+        }
+        if (!string.IsNullOrWhiteSpace(itemSource)) tags["itemSource"] = itemSource;
+        if (!string.IsNullOrWhiteSpace(itemType)) tags["type"] = itemType;
+        if (!string.IsNullOrWhiteSpace(priority)) tags["priority"] = priority;
+        if (!string.IsNullOrWhiteSpace(automation)) tags["automation"] = automation;
+        if (tenantId is not null) tags["tenantId"] = tenantId.Value.ToString("D");
+
+        var data = new Dictionary<string, object?>
+        {
+            ["itemSource"] = itemSource ?? "",
+            ["type"] = itemType ?? "",
+            ["priority"] = priority ?? "",
+            ["automation"] = automation ?? "",
+            ["decisionStatus"] = decisionStatus ?? "",
+        };
+
+        return new TammaEvent
+        {
+            EventType = type,
+            Status = TriageCycleEvents.StatusForEvent(type),
+            Error = type == TriageCycleEvents.Failed && !string.IsNullOrWhiteSpace(reason)
+                ? reason
+                : null,
+            Tags = tags,
+            Data = data,
+        };
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/TriageCycleEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/TriageCycleEvents.cs
@@ -1,0 +1,82 @@
+namespace Tamma.Activities.ADL;
+
+/// <summary>
+/// Completeness audit 2026-06-22 (<c>TriageItemCycle.md</c> #3) / Story 26-1 AC9 —
+/// central catalogue of the <b>cycle-scoped</b> <c>TRIAGE.ISSUE.*</c> DCB event types
+/// emitted by the <c>triage-item-cycle</c> workflow. Type pattern follows the
+/// platform's <c>AGGREGATE.ACTION.STATUS</c> convention (<c>CLAUDE.md</c>) and mirrors
+/// the sibling per-stage catalogues (<see cref="TriageContextEvents"/>,
+/// <see cref="TriageEvents"/>, <see cref="TriagePoDecisionEvents"/>).
+///
+/// <para>The per-item cycle is the <b>unit of audit</b>: "we triaged item X →
+/// outcome Y". Before this build-out the cycle emitted only the leaf
+/// <c>TRIAGE.APPLY.RESULT.*</c> events — the stage sub-workflows each emit their own
+/// <c>TRIAGE.{CONTEXT,PANEL,PO_DECISION}.*</c> events, but there was NO event for the
+/// cycle as a whole, so the audit trail could not answer "was item X triaged, skipped,
+/// or did it fail?" without reconstructing it from the leaf events. These cycle events
+/// make the outcome a single loud audit row.</para>
+///
+/// <para>Events are emitted via <c>TammaEventEmitter.Emit</c> into the workflow's
+/// <c>tamma:events</c> transient list and persisted <i>durably</i> by the engine event
+/// drain (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) — the same pattern the
+/// per-stage emitters use. No activity holds a DB / repository dependency of its own
+/// (none is registered in the Elsa engine — a directly-injected <c>IEventRepository</c>
+/// would be inert and silently drop every event). The drain resolves the tenant from
+/// the workflow's <c>TenantId</c> variable, so a SaaS caller's cycle events carry the
+/// tenant tag.</para>
+///
+/// <list type="bullet">
+///   <item><description><c>TRIAGE.ISSUE.STARTED</c> — the cycle began processing an
+///     item (tags carry repository + item key + item source/type).</description></item>
+///   <item><description><c>TRIAGE.ISSUE.COMPLETED</c> — the item was fully triaged and
+///     labels/comment were applied (data carries type/priority/automation +
+///     decisionStatus). Success.</description></item>
+///   <item><description><c>TRIAGE.ISSUE.SKIPPED</c> — the cycle stopped before applying
+///     because a stage reported a non-applying-but-not-faulted signal (context could not
+///     be gathered, or the panel fell below quorum). A degraded — not faulted — outcome;
+///     loud (warning-status) so the audit trail records "we deliberately did not label
+///     this", never a silent no-op.</description></item>
+///   <item><description><c>TRIAGE.ISSUE.FAILED</c> — a sub-workflow faulted, or the PO
+///     produced no usable decision, or the apply step failed. Loud (error-status). NO
+///     labels are applied off a fabricated/empty decision — the no-false-success /
+///     no-empty-fallback rule made explicit at the cycle level.</description></item>
+/// </list>
+/// </summary>
+public static class TriageCycleEvents
+{
+    public const string Started = "TRIAGE.ISSUE.STARTED";
+    public const string Completed = "TRIAGE.ISSUE.COMPLETED";
+    public const string Skipped = "TRIAGE.ISSUE.SKIPPED";
+    public const string Failed = "TRIAGE.ISSUE.FAILED";
+
+    /// <summary>
+    /// The per-item <c>outcome</c> values surfaced on the cycle's <c>itemResult</c>
+    /// output (<see cref="TriageItemCycle.md"/> #5) so the fire-and-forget parent can
+    /// report <c>{ triaged, failed, skipped }</c> instead of a blanket success.
+    /// </summary>
+    public const string OutcomeTriaged = "triaged";
+    public const string OutcomeSkipped = "skipped";
+    public const string OutcomeFailed = "failed";
+
+    /// <summary>
+    /// Parse a tenant id from the loose string form threaded through the workflow
+    /// inputs. Returns <c>null</c> for empty / single-user / unparseable values (cycle
+    /// events in single-user mode are platform-scope, TenantId null). Mirrors
+    /// <see cref="TriageEvents.ParseTenantId"/>.
+    /// </summary>
+    public static Guid? ParseTenantId(string? tenantId)
+        => Guid.TryParse(tenantId, out var g) ? g : null;
+
+    /// <summary>
+    /// Status convention: a failed cycle is a loud (error-status) audit row, a skipped
+    /// cycle is a warning-status row, a started/completed cycle is success. Mirrors the
+    /// per-stage catalogues — a degraded/failed outcome is never recorded as a false
+    /// success.
+    /// </summary>
+    public static string StatusForEvent(string type) => type switch
+    {
+        Failed => "error",
+        Skipped => "warning",
+        _ => "success",
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/TriageCycleEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/TriageCycleEvents.cs
@@ -50,6 +50,15 @@ public static class TriageCycleEvents
     public const string Failed = "TRIAGE.ISSUE.FAILED";
 
     /// <summary>
+    /// Emitted (warning-status) when <see cref="Tamma.ElsaServer.Workflows.Helpers"/>'s
+    /// label validation dropped one or more out-of-vocabulary labels the PO returned
+    /// before apply (#7). NOT a terminal — the cycle still applies the validated subset
+    /// and proceeds to <c>COMPLETED</c>; this records what was dropped so the audit trail
+    /// shows the LLM proposed an invalid label rather than silently discarding it.
+    /// </summary>
+    public const string LabelsInvalid = "TRIAGE.LABELS.INVALID";
+
+    /// <summary>
     /// The per-item <c>outcome</c> values surfaced on the cycle's <c>itemResult</c>
     /// output (<see cref="TriageItemCycle.md"/> #5) so the fire-and-forget parent can
     /// report <c>{ triaged, failed, skipped }</c> instead of a blanket success.
@@ -77,6 +86,7 @@ public static class TriageCycleEvents
     {
         Failed => "error",
         Skipped => "warning",
+        LabelsInvalid => "warning",
         _ => "success",
     };
 }

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/Helpers/TriageItemCycleHelper.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/Helpers/TriageItemCycleHelper.cs
@@ -1,0 +1,286 @@
+using System.Text;
+using System.Text.Json;
+using Tamma.Activities.ADL;
+
+namespace Tamma.ElsaServer.Workflows.Helpers;
+
+/// <summary>
+/// Pure, fail-closed helpers for the <c>triage-item-cycle</c> workflow (no Elsa runtime
+/// dependency). These are the levers behind the cycle build-out (completeness audit
+/// 2026-06-22, <c>TriageItemCycle.md</c>):
+///
+/// <list type="bullet">
+///   <item><description>#1 — <see cref="IsDecisionApplicable"/> is the decision-OK gate.
+///     A missing / empty / <c>unparsed</c> / <c>llm-failed</c> / <c>skipped</c> PO
+///     decision is NOT applicable: the cycle must skip label application and fail the
+///     item, never label off a fabricated/empty decision (no-empty-fallback rule).</description></item>
+///   <item><description>#5 — <see cref="BuildItemResult"/> renders the per-item outcome
+///     the fire-and-forget parent needs (<c>{ itemKey, outcome, decisionStatus, error? }</c>)
+///     so it reports <c>{ triaged, failed, skipped }</c> rather than a blanket success.</description></item>
+///   <item><description>#7 — <see cref="DeriveItemKey"/> gives a deterministic key for
+///     events/dedupe; <see cref="ValidateLabels"/> drops labels outside the canonical
+///     vocabulary; <see cref="RenderComment"/> builds the AC5 markdown-table comment
+///     <i>deterministically from the parsed decision</i>, not from raw LLM prose.</description></item>
+/// </list>
+/// </summary>
+public static class TriageItemCycleHelper
+{
+    /// <summary>
+    /// The canonical triage label vocabulary (the type/priority/complexity/automation
+    /// grid) — superset mirror of <c>FetchUntriagedItemsActivity.TriageLabels</c>. A
+    /// label the PO returned that is NOT in this set is dropped before applying (#7), so
+    /// arbitrary LLM-invented labels never reach the issue.
+    /// </summary>
+    public static readonly IReadOnlySet<string> CanonicalLabels = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        // type
+        "bug", "feature", "chore", "question", "security", "docs",
+        // priority
+        "priority-critical", "priority-high", "priority-medium", "priority-low",
+        // automation
+        "tamma-auto", "tamma-assist", "needs-human",
+        // complexity
+        "complexity-trivial", "complexity-simple", "complexity-medium",
+        "complexity-complex", "complexity-epic",
+        // lifecycle / triage outcome markers
+        "tamma-processing", "tamma-completed", "tamma-error",
+        "needs-human-review", "triage-failed", "triage-skipped",
+    };
+
+    /// <summary>The parsed PO decision the cycle reasons over.</summary>
+    public sealed record CycleDecision(
+        string Status,
+        string Priority,
+        string Type,
+        string Complexity,
+        string Automation,
+        IReadOnlyList<string> Labels,
+        string Comment);
+
+    /// <summary>
+    /// Derive a deterministic, replay-stable key for the item from its JSON. An issue →
+    /// <c>repo#number</c>; an alert (no usable number) → <c>repo:source:title</c> (or
+    /// <c>repo:source</c> when no title). Used for event tags and a future dedupe gate.
+    /// Returns <c>repo:unknown</c> on wholly-unparseable input rather than throwing.
+    /// </summary>
+    public static string DeriveItemKey(string? repository, string? itemJson)
+    {
+        var repo = string.IsNullOrWhiteSpace(repository) ? "unknown-repo" : repository!.Trim();
+        if (string.IsNullOrWhiteSpace(itemJson))
+            return $"{repo}:unknown";
+
+        try
+        {
+            using var doc = JsonDocument.Parse(itemJson);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+                return $"{repo}:unknown";
+
+            var number = 0;
+            if (root.TryGetProperty("number", out var n) && n.ValueKind == JsonValueKind.Number)
+                n.TryGetInt32(out number);
+
+            if (number > 0)
+                return $"{repo}#{number}";
+
+            var source = ReadString(root, "source");
+            var title = ReadString(root, "title");
+            if (!string.IsNullOrWhiteSpace(source) && !string.IsNullOrWhiteSpace(title))
+                return $"{repo}:{source}:{title}";
+            if (!string.IsNullOrWhiteSpace(source))
+                return $"{repo}:{source}";
+            if (!string.IsNullOrWhiteSpace(title))
+                return $"{repo}:{title}";
+
+            return $"{repo}:unknown";
+        }
+        catch
+        {
+            return $"{repo}:unknown";
+        }
+    }
+
+    /// <summary>Read the item <c>source</c> field (issue / dependabot / codeql / ...)
+    /// for the event tags; empty when absent / unparseable.</summary>
+    public static string ReadItemSource(string? itemJson)
+    {
+        if (string.IsNullOrWhiteSpace(itemJson)) return "";
+        try
+        {
+            using var doc = JsonDocument.Parse(itemJson);
+            if (doc.RootElement.ValueKind == JsonValueKind.Object)
+            {
+                var src = ReadString(doc.RootElement, "source");
+                if (!string.IsNullOrWhiteSpace(src)) return src;
+                // Fall back to the type field (issue / security / dependency).
+                return ReadString(doc.RootElement, "type");
+            }
+        }
+        catch { /* unknown */ }
+        return "";
+    }
+
+    /// <summary>
+    /// Parse the PO <c>decisionJson</c> into the cycle's decision view. Unparseable /
+    /// blank input yields a decision whose <see cref="CycleDecision.Status"/> is empty
+    /// — which <see cref="IsDecisionApplicable"/> treats as NOT applicable (fail-closed).
+    /// </summary>
+    public static CycleDecision ParseDecision(string? decisionJson)
+    {
+        if (string.IsNullOrWhiteSpace(decisionJson))
+            return Empty("");
+
+        try
+        {
+            using var doc = JsonDocument.Parse(decisionJson);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+                return Empty("");
+
+            var status = ReadString(root, "status");
+            var priority = ReadString(root, "priority");
+            var type = ReadString(root, "type");
+            var complexity = ReadString(root, "complexity");
+            var automation = ReadString(root, "automation");
+            var comment = ReadString(root, "comment");
+            var labels = new List<string>();
+            if (root.TryGetProperty("labels", out var l) && l.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in l.EnumerateArray())
+                {
+                    if (item.ValueKind == JsonValueKind.String)
+                    {
+                        var s = item.GetString();
+                        if (!string.IsNullOrWhiteSpace(s)) labels.Add(s!);
+                    }
+                }
+            }
+
+            return new CycleDecision(status, priority, type, complexity, automation, labels, comment);
+        }
+        catch
+        {
+            return Empty("");
+        }
+    }
+
+    private static CycleDecision Empty(string status)
+        => new(status, "", "", "", "", Array.Empty<string>(), "");
+
+    /// <summary>
+    /// #1 — the decision-OK gate. A decision is applicable ONLY when the PO step
+    /// reported the LLM call succeeded (<paramref name="callSucceeded"/>) AND the parsed
+    /// decision status is <c>ok</c>. A faulted PO sub-workflow (no <c>callSucceeded</c>
+    /// output), an <c>llm-failed</c> / <c>unparsed</c> / <c>skipped</c> status, or a
+    /// missing/empty decision → NOT applicable: the cycle must fail the item and NOT
+    /// apply labels off it. This is where the "never label from a fabricated/empty
+    /// decision" rule is enforced at the cycle level.
+    /// </summary>
+    public static bool IsDecisionApplicable(bool callSucceeded, CycleDecision decision)
+        => callSucceeded
+           && string.Equals(decision.Status, TriagePoDecisionHelper.StatusOk, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Convenience overload reading the status straight off the decision JSON, for the
+    /// workflow FlowDecision delegate. <paramref name="callSucceeded"/> is the PO step's
+    /// <c>callSucceeded</c> output (false / absent → not applicable, fail-closed).
+    /// </summary>
+    public static bool IsDecisionApplicable(bool callSucceeded, string? decisionJson)
+        => IsDecisionApplicable(callSucceeded, ParseDecision(decisionJson));
+
+    /// <summary>
+    /// #7 — validate the PO's labels against the canonical vocabulary, returning only
+    /// the in-vocab ones. Out-of-vocab labels are dropped (never written to the issue);
+    /// <paramref name="dropped"/> receives them so the caller can emit a
+    /// <c>TRIAGE.LABELS.INVALID</c> warning. Order is preserved; duplicates collapsed.
+    /// </summary>
+    public static IReadOnlyList<string> ValidateLabels(IEnumerable<string>? labels, out IReadOnlyList<string> dropped)
+    {
+        var kept = new List<string>();
+        var droppedList = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (labels != null)
+        {
+            foreach (var raw in labels)
+            {
+                if (string.IsNullOrWhiteSpace(raw)) continue;
+                var label = raw.Trim();
+                if (!CanonicalLabels.Contains(label))
+                {
+                    droppedList.Add(label);
+                    continue;
+                }
+                if (seen.Add(label)) kept.Add(label);
+            }
+        }
+
+        dropped = droppedList;
+        return kept;
+    }
+
+    /// <summary>
+    /// #7 — render the AC5 triage comment <b>deterministically from the parsed decision
+    /// fields</b>, NOT from raw LLM prose. The PO's free-form <c>comment</c> is preserved
+    /// below the table as the rationale (it is human-facing, not a classification), but
+    /// the applied classification is the canonical, validated grid — so the comment can
+    /// never disagree with the labels. Returns a stable markdown table a human can read.
+    /// </summary>
+    public static string RenderComment(CycleDecision decision)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("## Triage Decision");
+        sb.AppendLine();
+        sb.AppendLine("| Field | Value |");
+        sb.AppendLine("| --- | --- |");
+        sb.AppendLine($"| Type | {Display(decision.Type, TriagePoDecisionHelper.DefaultType)} |");
+        sb.AppendLine($"| Priority | {Display(decision.Priority, TriagePoDecisionHelper.DefaultPriority)} |");
+        sb.AppendLine($"| Complexity | {Display(decision.Complexity, TriagePoDecisionHelper.DefaultComplexity)} |");
+        sb.AppendLine($"| Automation | {Display(decision.Automation, TriagePoDecisionHelper.DefaultAutomation)} |");
+
+        var rationale = decision.Comment?.Trim();
+        if (!string.IsNullOrWhiteSpace(rationale))
+        {
+            sb.AppendLine();
+            sb.AppendLine("### Notes");
+            sb.AppendLine();
+            sb.AppendLine(rationale);
+        }
+
+        sb.AppendLine();
+        sb.Append("_Triaged automatically by Tamma._");
+        return sb.ToString();
+    }
+
+    private static string Display(string? value, string fallback)
+        => string.IsNullOrWhiteSpace(value) ? fallback : value!.Trim();
+
+    /// <summary>
+    /// #5 — serialize the per-item outcome surfaced on the cycle's <c>itemResult</c>
+    /// output: <c>{ itemKey, outcome, decisionStatus, error? }</c>. <paramref name="outcome"/>
+    /// is one of <see cref="TriageCycleEvents.OutcomeTriaged"/> /
+    /// <c>OutcomeSkipped</c> / <c>OutcomeFailed</c>.
+    /// </summary>
+    public static string BuildItemResult(string itemKey, string outcome, string? decisionStatus, string? error)
+    {
+        var dict = new Dictionary<string, object?>
+        {
+            ["itemKey"] = itemKey,
+            ["outcome"] = outcome,
+            ["decisionStatus"] = decisionStatus ?? "",
+        };
+        if (!string.IsNullOrWhiteSpace(error)) dict["error"] = error;
+        return JsonSerializer.Serialize(dict);
+    }
+
+    private static string ReadString(JsonElement root, string prop)
+    {
+        if (!root.TryGetProperty(prop, out var v)) return "";
+        return v.ValueKind switch
+        {
+            JsonValueKind.String => v.GetString() ?? "",
+            JsonValueKind.Null => "",
+            _ => v.GetRawText(),
+        };
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/IssueTriageWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/IssueTriageWorkflow.cs
@@ -14,12 +14,15 @@ using static Tamma.ElsaServer.Workflows.ActivityDisplayTextExtensions;
 namespace Tamma.ElsaServer.Workflows;
 
 /// <summary>
-/// Issue Triage — fetches untriaged items and dispatches a singleton
+/// Issue Triage — fetches untriaged items and dispatches a
 /// triage-item-cycle for each one (fire & forget).
 ///
-/// The per-item processing (context → panel → PO → labels) is handled
-/// by TriageItemCycleWorkflow which runs as a singleton — Elsa queues
-/// dispatches so items are triaged sequentially without overloading.
+/// The per-item processing (context → panel → PO → labels) is handled by
+/// TriageItemCycleWorkflow. Each dispatch is independent (NOT a singleton — a
+/// SingletonStrategy would REJECT, not queue, concurrent dispatches and silently drop
+/// items from this per-item fan-out; see the cycle's header). tenantId is threaded from
+/// this workflow's input into each dispatch so the cycle's TRIAGE.ISSUE.* events are
+/// tenant-scoped.
 ///
 /// Flow:
 ///   Fetch Untriaged Items → Has Items? → Loop:
@@ -44,6 +47,11 @@ public class IssueTriageWorkflow : WorkflowBase
         // Variables
         // ================================================================
         var repository = builder.WithVariable<string>("Repository", "");
+        // Tenant id threaded from this workflow's input through to each cycle dispatch so
+        // a SaaS caller's per-item TRIAGE.ISSUE.* events carry the tenant tag (the cycle
+        // forwards it onward to its context/panel/PO sub-workflows). Empty in single-user
+        // mode → platform-scope events (honest default — no fabricated tenant).
+        var tenantId = builder.WithVariable<string>("TenantId", "");
         var itemsJson = builder.WithVariable<string>("ItemsJson", "[]");
         var currentItemIndex = builder.WithVariable<int>("CurrentItemIndex", 0);
         var totalItems = builder.WithVariable<int>("TotalItems", 0);
@@ -60,6 +68,9 @@ public class IssueTriageWorkflow : WorkflowBase
             {
                 var repo = ctx.GetInput<string>("repository") ?? "";
                 repository.Set(ctx, repo);
+                // Capture tenantId from this workflow's input so each cycle dispatch can
+                // forward it (tenant-scoped TRIAGE.ISSUE.* events).
+                tenantId.Set(ctx, ctx.GetInput<string>("tenantId") ?? "");
                 return repo;
             }),
             ItemsJson = new Output<string>(itemsJson),
@@ -99,7 +110,7 @@ public class IssueTriageWorkflow : WorkflowBase
         extractItem.SetDisplayText("Extract Current Item");
 
         // ================================================================
-        // 4. Dispatch Triage Item Cycle (fire & forget, singleton)
+        // 4. Dispatch Triage Item Cycle (fire & forget)
         // ================================================================
         var dispatchCycle = new DispatchWorkflow
         {
@@ -110,8 +121,13 @@ public class IssueTriageWorkflow : WorkflowBase
             {
                 ["repository"] = repository.Get(ctx),
                 ["itemJson"] = currentItemJson.Get(ctx),
+                // Thread tenantId so the cycle's TRIAGE.ISSUE.* events (and its
+                // context/panel/PO sub-workflows) are tenant-scoped.
+                ["tenantId"] = tenantId.Get(ctx),
             }),
-            WaitForCompletion = new(false), // fire & forget — singleton queues
+            // Fire & forget: each cycle runs independently (NOT a singleton — the child's
+            // header explains why a SingletonStrategy would silently DROP fan-out items).
+            WaitForCompletion = new(false),
         };
         dispatchCycle.SetDisplayText("Dispatch Triage Cycle");
 

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TriageItemCycleWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TriageItemCycleWorkflow.cs
@@ -19,37 +19,61 @@ namespace Tamma.ElsaServer.Workflows;
 /// Triage Item Cycle — processes a single untriaged item through
 /// context gathering, 4-role panel review, PO decision, and label application.
 ///
-/// Runs as a singleton workflow: only one instance at a time.
-/// IssueTriageWorkflow dispatches one per item (fire & forget);
-/// Elsa queues subsequent dispatches until the current one finishes.
+/// <para>Build-out (completeness audit 2026-06-22, <c>TriageItemCycle.md</c>): the
+/// orchestrator layer is now <b>fail-closed and audited</b> — it is no longer a
+/// happy-path spine over robust sub-workflows. Specifically:</para>
 ///
-/// <para>Build-out (completeness audit 2026-06-22): the panel sub-workflow is now
-/// fail-closed and reports a <c>panelStatus</c> (<c>ok</c>/<c>partial</c>/
-/// <c>failed</c>). This cycle <b>honours</b> that signal: a <c>failed</c> panel
-/// (too few panellists produced a usable assessment) routes to a loud
-/// non-applying terminal — the PO decision is skipped and NO labels are applied
-/// off a wholly-failed panel. Previously the cycle marched straight from the
-/// panel to PO + label application regardless of panel health, so a fully-failed
-/// panel still labelled the item (silent false success downstream).</para>
+/// <list type="bullet">
+///   <item><description>#3 — cycle-scoped DCB events. <c>TRIAGE.ISSUE.STARTED</c> at
+///     Init and exactly one terminal (<c>COMPLETED</c> / <c>SKIPPED</c> /
+///     <c>FAILED</c>) at each exit, tagged itemKey/issueId/repository/itemSource/type/
+///     priority/automation (via <see cref="EmitTriageCycleEventActivity"/>). The unit
+///     of audit ("we triaged item X → outcome Y") is now a single loud row.</description></item>
+///   <item><description>#1/#2 — a decision-OK gate before apply. The PO sub-workflow now
+///     outputs <c>callSucceeded</c> + a <c>status</c> (#391). A faulted PO dispatch (no
+///     <c>callSucceeded</c> output → fail-closed false), an <c>llm-failed</c> /
+///     <c>unparsed</c> / <c>skipped</c> decision, or a missing/empty decision SKIPS
+///     apply and FAILS the item — never labels off a fabricated/empty decision.</description></item>
+///   <item><description>#2 — failure edges on the three <c>DispatchWorkflow</c> nodes.
+///     <c>DispatchWorkflow</c> has NO <c>Faulted</c> outcome port; a faulted child
+///     reaches <c>Finished</c> (so the parent bookmark resumes — never a hang) but its
+///     output dict lacks the success-signal keys. The cycle therefore fail-closes on the
+///     ABSENCE of those keys: context → <c>contextStatus</c> gate, panel →
+///     <c>panelStatus</c> gate, PO → <c>callSucceeded</c>/<c>status</c> gate. A faulted
+///     stage routes to a loud non-applying terminal, never proceeds with empty JSON.</description></item>
+///   <item><description>#5 — a per-item <c>itemResult</c> output
+///     (<c>{ itemKey, outcome, decisionStatus, error? }</c>) so the fire-and-forget
+///     parent can report <c>{ triaged, failed, skipped }</c> rather than a blanket
+///     success.</description></item>
+///   <item><description>#7 — labels are validated against the canonical vocabulary and
+///     the comment is rendered deterministically from the parsed decision (an AC5
+///     markdown table) before apply — never arbitrary LLM prose/labels.</description></item>
+///   <item><description>#8 — <see cref="ApplyTriageResultActivity"/> now throws on a
+///     non-success engine-callback POST, so a 4xx/5xx faults the cycle
+///     (<c>TRIAGE.APPLY.RESULT.FAILED</c>) instead of a swallowed false
+///     <c>.COMPLETED</c>.</description></item>
+/// </list>
 ///
-/// <para>Build-out (completeness audit 2026-06-22, <c>TriageContextGathering.md</c>):
-/// the context-gathering sub-workflow is likewise fail-closed and now reports a
-/// <c>contextStatus</c> (<c>ok</c>/<c>empty</c>/<c>failed</c>) and accepts a
-/// <c>tenantId</c>. This cycle forwards <c>tenantId</c> into it and <b>honours</b>
-/// the <c>failed</c> signal: when NO context could be gathered (the LLM scan
-/// failed), the panel is NOT run over phantom context — the cycle routes to the
-/// same loud non-applying terminal. (<c>empty</c>/<c>ok</c> still run the panel;
-/// an empty-but-successful scan is a degraded, not failed, result.)</para>
+/// <para>#9 — singleton: the previous header claimed "singleton — Elsa queues
+/// subsequent dispatches until the current one finishes". That is FALSE for Elsa's
+/// <c>SingletonStrategy</c>, which <i>rejects</i> (does not queue) a new dispatch while
+/// one is running — enforcing it would silently DROP items from the parent's per-item
+/// fan-out. The claim is therefore dropped; correctness does not rely on serialization.
+/// A real dedupe/triage-state gate (#4) is deferred to a follow-on 26-1 sub-story.</para>
 ///
 /// Flow:
-///   Init → Gather Context (llm-call) → Extract Context + Status → Context Gathered?
-///       ├─ True (ok/empty)    → Panel Review (llm-call x4)
-///       │     → Extract Panel Result + Status → Panel Usable?
-///       │         ├─ True (ok/partial)  → PO Decision → Apply Labels → Finish
-///       │         └─ False (failed)     → Mark Skipped (no labels)    → Finish
-///       └─ False (failed)     → Mark Skipped (no labels)              → Finish
+///   Init → Emit STARTED → Gather Context (llm-call) → Extract Context + Status → Context Gathered?
+///       ├─ True (ok/empty)    → Panel Review (llm-call x4) → Extract Panel + Status → Panel Usable?
+///       │     ├─ True (ok/partial)  → PO Decision → Capture (callSucceeded/status/fields)
+///       │     │       → Decision OK?
+///       │     │           ├─ True (callSucceeded && status=ok) → Build Apply Inputs (validated
+///       │     │           │     labels + rendered comment) → Apply → Emit COMPLETED → Finish
+///       │     │           └─ False → Fail Item (reason=decisionUnusable) → Emit FAILED → Finish
+///       │     └─ False (failed)     → Mark Skipped (panel-failed)  → Emit SKIPPED → Finish
+///       └─ False (failed)     → Mark Skipped (context-failed)      → Emit SKIPPED → Finish
 ///
 /// Inputs: repository, itemJson, tenantId
+/// Outputs: itemResult ({ itemKey, outcome, decisionStatus, error? }); triageSkipped/skipReason (back-compat)
 /// </summary>
 public class TriageItemCycleWorkflow : WorkflowBase
 {
@@ -58,7 +82,7 @@ public class TriageItemCycleWorkflow : WorkflowBase
         builder.Name = "Triage Item Cycle";
         builder.DefinitionId = "triage-item-cycle";
         builder.Version = WorkflowVersions.ComputedVersion;
-        builder.Description = "Process one untriaged item: context → panel → PO → labels (singleton)";
+        builder.Description = "Process one untriaged item: context → panel → PO → labels (fail-closed, audited)";
 
         // ================================================================
         // Variables
@@ -66,6 +90,11 @@ public class TriageItemCycleWorkflow : WorkflowBase
         var repository = builder.WithVariable<string>("Repository", "");
         var itemJson = builder.WithVariable<string>("ItemJson", "");
         var tenantId = builder.WithVariable<string>("TenantId", "");
+        // Deterministic key + tags for events / outcome (#3/#5).
+        var itemKey = builder.WithVariable<string>("ItemKey", "");
+        var itemNumber = builder.WithVariable<int>("ItemNumber", 0);
+        var itemSource = builder.WithVariable<string>("ItemSource", "");
+
         var contextJson = builder.WithVariable<string>("ContextJson", "");
         // Context health signal from the (fail-closed) context sub-workflow:
         // "ok" / "empty" => usable; "failed" => no context gathered, skip the panel.
@@ -77,14 +106,24 @@ public class TriageItemCycleWorkflow : WorkflowBase
         var panelStatus = builder.WithVariable<string>(
             "PanelStatus", TriagePanelAggregationHelper.StatusFailed);
         var poDecisionJson = builder.WithVariable<string>("PODecisionJson", "");
-        // Why the cycle skipped label application — "context-failed" (no context
-        // gathered) or "panel-failed" (panel below quorum). Set by whichever gate
-        // tripped, surfaced on the workflow output for the caller / audit.
+        // PO call health (#1/#2): the PO sub-workflow's `callSucceeded` output. Default
+        // false — a faulted PO dispatch never sets it, so the cycle fail-closes.
+        var poCallSucceeded = builder.WithVariable<bool>("PoCallSucceeded", false);
+        // Decision fields surfaced for the COMPLETED event + apply (#3/#7).
+        var decisionStatus = builder.WithVariable<string>("DecisionStatus", "");
+        var decisionType = builder.WithVariable<string>("DecisionType", "");
+        var decisionPriority = builder.WithVariable<string>("DecisionPriority", "");
+        var decisionAutomation = builder.WithVariable<string>("DecisionAutomation", "");
+        // Validated labels + rendered comment for apply (#7).
+        var appliedLabels = builder.WithVariable<string[]>("AppliedLabels", System.Array.Empty<string>());
+        var appliedComment = builder.WithVariable<string>("AppliedComment", "");
+
+        // Why the cycle skipped/failed apply — surfaced on the outputs + events.
         var skipReason = builder.WithVariable<string>("SkipReason", "");
         var subResult = builder.WithVariable<IDictionary<string, object>?>();
 
         // ================================================================
-        // 1. Init — read inputs
+        // 1. Init — read inputs; derive itemKey/itemNumber/itemSource.
         // ================================================================
         var init = new SetVariable
         {
@@ -93,12 +132,25 @@ public class TriageItemCycleWorkflow : WorkflowBase
             Value = new Input<object?>(ctx =>
             {
                 var repo = ctx.GetInput<string>("repository") ?? "";
-                itemJson.Set(ctx, ctx.GetInput<string>("itemJson") ?? "");
+                var item = ctx.GetInput<string>("itemJson") ?? "";
+                itemJson.Set(ctx, item);
                 tenantId.Set(ctx, ctx.GetInput<string>("tenantId") ?? "");
+                itemKey.Set(ctx, TriageItemCycleHelper.DeriveItemKey(repo, item));
+                itemNumber.Set(ctx, TriagePanelAggregationHelper.ParseItemNumber(item));
+                itemSource.Set(ctx, TriageItemCycleHelper.ReadItemSource(item));
                 return (object)repo;
             })
         };
         init.SetDisplayText("Initialize");
+
+        // ================================================================
+        // 1a. Emit TRIAGE.ISSUE.STARTED (#3).
+        // ================================================================
+        var emitStarted = CycleEvent(
+            "EmitCycleStarted", "Emit TRIAGE.ISSUE.STARTED",
+            _ => TriageCycleEvents.Started,
+            repository, itemKey, itemNumber, tenantId, itemSource,
+            _ => "", _ => "", _ => "", _ => "", _ => "");
 
         // ================================================================
         // 2. Gather Context (code usage, deps, CVE details)
@@ -129,8 +181,9 @@ public class TriageItemCycleWorkflow : WorkflowBase
                 var result = subResult.Get(ctx);
 
                 // Read the context-health signal first. Absence is treated as a
-                // FAILED scan (fail-closed): if the sub-workflow did not report a
-                // status we must NOT assume context was gathered and run the panel.
+                // FAILED scan (fail-closed): a faulted context dispatch (#2) reaches
+                // Finished with no output, so the status key is absent — we must NOT
+                // assume context was gathered and run the panel.
                 var status = TriageContextEvents.StatusFailed;
                 if (result != null && result.TryGetValue("contextStatus", out var st))
                 {
@@ -148,8 +201,6 @@ public class TriageItemCycleWorkflow : WorkflowBase
 
         // ================================================================
         // 2a. Context Gathered? — honour the context stage's fail-closed signal.
-        //     A "failed" scan (no context gathered) routes to the same non-applying
-        //     terminal as a failed panel; "ok"/"empty" proceed to the panel review.
         // ================================================================
         var contextGathered = new FlowDecision(ctx =>
             contextStatus.Get(ctx) != TriageContextEvents.StatusFailed)
@@ -185,9 +236,9 @@ public class TriageItemCycleWorkflow : WorkflowBase
             {
                 var result = subResult.Get(ctx);
 
-                // Read the panel-health signal first. Absence is treated as a
-                // FAILED panel (fail-closed): if the sub-workflow did not report
-                // a status we must NOT assume success and apply labels.
+                // Read the panel-health signal first. Absence is treated as a FAILED
+                // panel (fail-closed): a faulted panel dispatch (#2) yields no status
+                // key — we must NOT assume success and apply labels.
                 var status = TriagePanelAggregationHelper.StatusFailed;
                 if (result != null && result.TryGetValue("panelStatus", out var st))
                 {
@@ -204,58 +255,12 @@ public class TriageItemCycleWorkflow : WorkflowBase
         extractPanelResult.SetDisplayText("Extract Panel Result");
 
         // ================================================================
-        // 3a. Panel Usable? — honour the panel's fail-closed signal. A "failed"
-        //     panel (below quorum) routes to a non-applying terminal; "ok" /
-        //     "partial" proceed to the PO decision + label application.
+        // 3a. Panel Usable? — honour the panel's fail-closed signal.
         // ================================================================
         var panelUsable = new FlowDecision(ctx =>
             panelStatus.Get(ctx) != TriagePanelAggregationHelper.StatusFailed)
         { Id = "PanelUsable", Name = "Panel Usable?" };
         panelUsable.SetDisplayText("Panel Usable?");
-
-        // Shared non-applying terminal — record the skip on the workflow outputs so
-        // the caller/audit sees a LOUD non-applying outcome (no labels applied off a
-        // failed context scan or a wholly-failed panel). The relevant sub-workflow
-        // already emitted TRIAGE.CONTEXT.FAILED / TRIAGE.PANEL.FAILED to the durable
-        // drain; the skipReason variable says which stage tripped.
-        var markSkipped = new SetOutput
-        {
-            Id = "MarkSkipped",
-            Name = "Mark Triage Skipped",
-            OutputName = new("triageSkipped"),
-            OutputValue = new(_ => (object)true),
-        };
-        markSkipped.SetDisplayText("Mark Triage Skipped");
-
-        var outSkipReason = new SetOutput
-        {
-            Id = "OutSkipReason",
-            Name = "Output Skip Reason",
-            OutputName = new("skipReason"),
-            OutputValue = new(ctx => (object)skipReason.Get(ctx)),
-        };
-        outSkipReason.SetDisplayText("Output Skip Reason");
-
-        // Set the skip reason on the context-failed branch (before the shared
-        // terminal). A dedicated SetVariable keeps the reason explicit + testable.
-        var setContextFailedReason = new SetVariable
-        {
-            Id = "SetContextFailedReason",
-            Name = "Set Context-Failed Reason",
-            Variable = skipReason,
-            Value = new Input<object?>(_ => (object)"context-failed"),
-        };
-        setContextFailedReason.SetDisplayText("Set Context-Failed Reason");
-
-        // Set the skip reason on the panel-failed branch.
-        var setPanelFailedReason = new SetVariable
-        {
-            Id = "SetPanelFailedReason",
-            Name = "Set Panel-Failed Reason",
-            Variable = skipReason,
-            Value = new Input<object?>(_ => (object)"panel-failed"),
-        };
-        setPanelFailedReason.SetDisplayText("Set Panel-Failed Reason");
 
         // ================================================================
         // 4. PO Decision (priority, labels, automation level)
@@ -270,12 +275,16 @@ public class TriageItemCycleWorkflow : WorkflowBase
                 ["repository"] = repository.Get(ctx),
                 ["itemJson"] = itemJson.Get(ctx),
                 ["panelResultJson"] = panelResultJson.Get(ctx),
+                ["tenantId"] = tenantId.Get(ctx),
             }),
             WaitForCompletion = new(true),
             Result = new(subResult),
         };
         poDecision.SetDisplayText("PO Decision");
 
+        // 4a. Capture decision — #1/#2. Read callSucceeded + decisionJson, parse the
+        //     status + classification fields. Fail-closed: a faulted PO dispatch
+        //     leaves callSucceeded absent (=> false) and decisionJson empty.
         var extractDecision = new SetVariable
         {
             Id = "ExtractDecision",
@@ -284,15 +293,56 @@ public class TriageItemCycleWorkflow : WorkflowBase
             Value = new Input<object?>(ctx =>
             {
                 var result = subResult.Get(ctx);
+
+                var succeeded = result != null
+                    && result.TryGetValue("callSucceeded", out var cs) && cs is true;
+                poCallSucceeded.Set(ctx, succeeded);
+
+                var json = "";
                 if (result != null && result.TryGetValue("decisionJson", out var d))
-                    return (object)(d?.ToString() ?? "");
-                return (object)"";
+                    json = d?.ToString() ?? "";
+
+                var parsed = TriageItemCycleHelper.ParseDecision(json);
+                decisionStatus.Set(ctx, parsed.Status);
+                decisionType.Set(ctx, parsed.Type);
+                decisionPriority.Set(ctx, parsed.Priority);
+                decisionAutomation.Set(ctx, parsed.Automation);
+
+                return (object)json;
             })
         };
         extractDecision.SetDisplayText("Extract Decision");
 
+        // 4b. Decision OK? — #1 the apply gate. Applicable ONLY when the PO call
+        //     succeeded AND the decision status is "ok". A faulted PO, an llm-failed /
+        //     unparsed / skipped decision, or empty JSON → False → fail the item.
+        var decisionOk = new FlowDecision(ctx =>
+            TriageItemCycleHelper.IsDecisionApplicable(
+                poCallSucceeded.Get(ctx),
+                TriageItemCycleHelper.ParseDecision(poDecisionJson.Get(ctx))))
+        { Id = "DecisionOK", Name = "Decision OK?" };
+        decisionOk.SetDisplayText("Decision OK?");
+
+        // 4c. Build apply inputs — #7 validate labels against the canonical vocab and
+        //     render the AC5 markdown-table comment deterministically from the decision.
+        var buildApplyInputs = new SetVariable
+        {
+            Id = "BuildApplyInputs",
+            Name = "Build Apply Inputs",
+            Variable = appliedLabels,
+            Value = new Input<object?>(ctx =>
+            {
+                var decision = TriageItemCycleHelper.ParseDecision(poDecisionJson.Get(ctx));
+                var validated = TriageItemCycleHelper.ValidateLabels(decision.Labels, out _);
+                appliedComment.Set(ctx, TriageItemCycleHelper.RenderComment(decision));
+                return (object)validated.ToArray();
+            })
+        };
+        buildApplyInputs.SetDisplayText("Build Apply Inputs");
+
         // ================================================================
-        // 5. Apply Labels + Post Comment
+        // 5. Apply Labels + Post Comment (#7/#8 — validated labels, rendered
+        //    comment, fail-loud on a non-success engine POST).
         // ================================================================
         var applyLabels = new ApplyTriageResultActivity
         {
@@ -301,8 +351,116 @@ public class TriageItemCycleWorkflow : WorkflowBase
             Repository = new Input<string>(ctx => repository.Get(ctx)),
             ItemJson = new Input<string>(ctx => itemJson.Get(ctx)),
             DecisionJson = new Input<string>(ctx => poDecisionJson.Get(ctx)),
+            LabelsOverride = new Input<ICollection<string>?>(ctx => appliedLabels.Get(ctx)),
+            CommentOverride = new Input<string?>(ctx => appliedComment.Get(ctx)),
         };
         applyLabels.SetDisplayText("Apply Labels & Comment");
+
+        // 5a. Emit TRIAGE.ISSUE.COMPLETED (#3) — apply succeeded (it throws on failure,
+        //     which faults the cycle before this node, so COMPLETED is never false).
+        var emitCompleted = CycleEvent(
+            "EmitCycleCompleted", "Emit TRIAGE.ISSUE.COMPLETED",
+            _ => TriageCycleEvents.Completed,
+            repository, itemKey, itemNumber, tenantId, itemSource,
+            ctx => decisionType.Get(ctx), ctx => decisionPriority.Get(ctx),
+            ctx => decisionAutomation.Get(ctx), ctx => decisionStatus.Get(ctx), _ => "");
+
+        var outCompletedResult = new SetOutput
+        {
+            Id = "OutCompletedResult",
+            Name = "Output Item Result (triaged)",
+            OutputName = new("itemResult"),
+            OutputValue = new(ctx => (object)TriageItemCycleHelper.BuildItemResult(
+                itemKey.Get(ctx), TriageCycleEvents.OutcomeTriaged, decisionStatus.Get(ctx), null)),
+        };
+        outCompletedResult.SetDisplayText("Output Item Result (triaged)");
+
+        // ================================================================
+        // Skip / fail terminals
+        // ================================================================
+        // Skip reason setters (per branch) — explicit + testable.
+        var setContextFailedReason = new SetVariable
+        {
+            Id = "SetContextFailedReason", Name = "Set Context-Failed Reason",
+            Variable = skipReason,
+            Value = new Input<object?>(_ => (object)"context-failed"),
+        };
+        setContextFailedReason.SetDisplayText("Set Context-Failed Reason");
+
+        var setPanelFailedReason = new SetVariable
+        {
+            Id = "SetPanelFailedReason", Name = "Set Panel-Failed Reason",
+            Variable = skipReason,
+            Value = new Input<object?>(_ => (object)"panel-failed"),
+        };
+        setPanelFailedReason.SetDisplayText("Set Panel-Failed Reason");
+
+        // Shared SKIPPED terminal — a stage reported a non-applying-but-not-faulted
+        // signal (context unavailable / panel below quorum). Loud (warning) audit row.
+        var markSkipped = new SetOutput
+        {
+            Id = "MarkSkipped", Name = "Mark Triage Skipped",
+            OutputName = new("triageSkipped"),
+            OutputValue = new(_ => (object)true),
+        };
+        markSkipped.SetDisplayText("Mark Triage Skipped");
+
+        var outSkipReason = new SetOutput
+        {
+            Id = "OutSkipReason", Name = "Output Skip Reason",
+            OutputName = new("skipReason"),
+            OutputValue = new(ctx => (object)skipReason.Get(ctx)),
+        };
+        outSkipReason.SetDisplayText("Output Skip Reason");
+
+        var emitSkipped = CycleEvent(
+            "EmitCycleSkipped", "Emit TRIAGE.ISSUE.SKIPPED",
+            _ => TriageCycleEvents.Skipped,
+            repository, itemKey, itemNumber, tenantId, itemSource,
+            _ => "", _ => "", _ => "", ctx => decisionStatus.Get(ctx),
+            ctx => skipReason.Get(ctx));
+
+        var outSkippedResult = new SetOutput
+        {
+            Id = "OutSkippedResult", Name = "Output Item Result (skipped)",
+            OutputName = new("itemResult"),
+            OutputValue = new(ctx => (object)TriageItemCycleHelper.BuildItemResult(
+                itemKey.Get(ctx), TriageCycleEvents.OutcomeSkipped, decisionStatus.Get(ctx),
+                skipReason.Get(ctx))),
+        };
+        outSkippedResult.SetDisplayText("Output Item Result (skipped)");
+
+        // FAILED terminal — the PO produced no usable decision (#1/#2). Loud (error).
+        var setDecisionFailedReason = new SetVariable
+        {
+            Id = "SetDecisionFailedReason", Name = "Set Decision-Failed Reason",
+            Variable = skipReason,
+            Value = new Input<object?>(ctx =>
+            {
+                var status = decisionStatus.Get(ctx);
+                return (object)(string.IsNullOrWhiteSpace(status)
+                    ? "decisionUnusable"
+                    : $"decisionUnusable:{status}");
+            }),
+        };
+        setDecisionFailedReason.SetDisplayText("Set Decision-Failed Reason");
+
+        var emitFailed = CycleEvent(
+            "EmitCycleFailed", "Emit TRIAGE.ISSUE.FAILED",
+            _ => TriageCycleEvents.Failed,
+            repository, itemKey, itemNumber, tenantId, itemSource,
+            _ => "", _ => "", _ => "", ctx => decisionStatus.Get(ctx),
+            ctx => skipReason.Get(ctx));
+
+        var outFailedResult = new SetOutput
+        {
+            Id = "OutFailedResult", Name = "Output Item Result (failed)",
+            OutputName = new("itemResult"),
+            OutputValue = new(ctx => (object)TriageItemCycleHelper.BuildItemResult(
+                itemKey.Get(ctx), TriageCycleEvents.OutcomeFailed, decisionStatus.Get(ctx),
+                skipReason.Get(ctx))),
+        };
+        outFailedResult.SetDisplayText("Output Item Result (failed)");
 
         // ================================================================
         // 6. Finish
@@ -319,20 +477,20 @@ public class TriageItemCycleWorkflow : WorkflowBase
             Start = init,
             Activities =
             {
-                init,
-                gatherContext, extractContext,
-                contextGathered,
-                panelReview, extractPanelResult,
-                panelUsable,
-                poDecision, extractDecision,
-                applyLabels,
+                init, emitStarted,
+                gatherContext, extractContext, contextGathered,
+                panelReview, extractPanelResult, panelUsable,
+                poDecision, extractDecision, decisionOk, buildApplyInputs,
+                applyLabels, emitCompleted, outCompletedResult,
                 setContextFailedReason, setPanelFailedReason,
-                markSkipped, outSkipReason,
+                markSkipped, outSkipReason, emitSkipped, outSkippedResult,
+                setDecisionFailedReason, emitFailed, outFailedResult,
                 finish,
             },
             Connections =
             {
-                Connect(init, gatherContext),
+                Connect(init, emitStarted),
+                Connect(emitStarted, gatherContext),
                 Connect(gatherContext, extractContext),
                 Connect(extractContext, contextGathered),
 
@@ -341,25 +499,73 @@ public class TriageItemCycleWorkflow : WorkflowBase
                 Connect(panelReview, extractPanelResult),
                 Connect(extractPanelResult, panelUsable),
 
-                // Context failed (no context gathered) → skip the panel + labels.
-                // The False edge never falls through to the panel-review path.
+                // Context failed → SKIPPED (no panel over phantom context).
                 ConnectOutcome(contextGathered, "False", setContextFailedReason),
                 Connect(setContextFailedReason, markSkipped),
 
-                // Usable (ok/partial) → PO decision → apply labels → finish.
+                // Panel usable (ok/partial) → PO decision → capture → decision gate.
                 ConnectOutcome(panelUsable, "True", poDecision),
                 Connect(poDecision, extractDecision),
-                Connect(extractDecision, applyLabels),
-                Connect(applyLabels, finish),
+                Connect(extractDecision, decisionOk),
 
-                // Failed (below quorum) → mark skipped (NO labels) → finish.
-                // The False edge never falls through to the apply-labels path.
+                // Panel failed → SKIPPED (no labels off a wholly-failed panel).
                 ConnectOutcome(panelUsable, "False", setPanelFailedReason),
                 Connect(setPanelFailedReason, markSkipped),
+
+                // Decision OK → validate labels + render comment → apply → COMPLETED.
+                ConnectOutcome(decisionOk, "True", buildApplyInputs),
+                Connect(buildApplyInputs, applyLabels),
+                Connect(applyLabels, emitCompleted),
+                Connect(emitCompleted, outCompletedResult),
+                Connect(outCompletedResult, finish),
+
+                // Decision NOT OK (faulted PO / llm-failed / unparsed / empty) → FAILED.
+                // The False edge NEVER reaches buildApplyInputs / applyLabels.
+                ConnectOutcome(decisionOk, "False", setDecisionFailedReason),
+                Connect(setDecisionFailedReason, emitFailed),
+                Connect(emitFailed, outFailedResult),
+                Connect(outFailedResult, finish),
+
+                // Shared SKIPPED terminal.
                 Connect(markSkipped, outSkipReason),
-                Connect(outSkipReason, finish),
+                Connect(outSkipReason, emitSkipped),
+                Connect(emitSkipped, outSkippedResult),
+                Connect(outSkippedResult, finish),
             }
         };
+    }
+
+    // ================================================================
+    // Helper: Emit a cycle-scoped TRIAGE.ISSUE.* DCB event via the durable drain.
+    // ================================================================
+    private static EmitTriageCycleEventActivity CycleEvent(
+        string id, string label,
+        System.Func<Elsa.Expressions.Models.ExpressionExecutionContext, string> eventType,
+        Variable<string> repository, Variable<string> itemKey, Variable<int> itemNumber,
+        Variable<string> tenantId, Variable<string> itemSource,
+        System.Func<Elsa.Expressions.Models.ExpressionExecutionContext, string> type,
+        System.Func<Elsa.Expressions.Models.ExpressionExecutionContext, string> priority,
+        System.Func<Elsa.Expressions.Models.ExpressionExecutionContext, string> automation,
+        System.Func<Elsa.Expressions.Models.ExpressionExecutionContext, string> decisionStatus,
+        System.Func<Elsa.Expressions.Models.ExpressionExecutionContext, string> reason)
+    {
+        var emit = new EmitTriageCycleEventActivity
+        {
+            Id = id, Name = label,
+            EventType = new Input<string>(eventType),
+            Repository = new Input<string>(ctx => repository.Get(ctx)),
+            ItemKey = new Input<string?>(ctx => itemKey.Get(ctx)),
+            ItemNumber = new Input<int>(ctx => itemNumber.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
+            ItemSource = new Input<string?>(ctx => itemSource.Get(ctx)),
+            Type = new Input<string?>(ctx => type(ctx)),
+            Priority = new Input<string?>(ctx => priority(ctx)),
+            Automation = new Input<string?>(ctx => automation(ctx)),
+            DecisionStatus = new Input<string?>(ctx => decisionStatus(ctx)),
+            Reason = new Input<string?>(ctx => reason(ctx)),
+        };
+        emit.SetDisplayText(label);
+        return emit;
     }
 
     private static FlowConnection Connect(IActivity source, IActivity target)

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TriageItemCycleWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TriageItemCycleWorkflow.cs
@@ -2,6 +2,7 @@ using Elsa.Extensions;
 using Elsa.Workflows;
 using Elsa.Workflows.Activities;
 using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.IncidentStrategies;
 using Elsa.Workflows.Management.Activities.SetOutput;
 using Elsa.Workflows.Memory;
 using Elsa.Workflows.Models;
@@ -48,11 +49,29 @@ namespace Tamma.ElsaServer.Workflows;
 ///   <item><description>#7 — labels are validated against the canonical vocabulary and
 ///     the comment is rendered deterministically from the parsed decision (an AC5
 ///     markdown table) before apply — never arbitrary LLM prose/labels.</description></item>
-///   <item><description>#8 — <see cref="ApplyTriageResultActivity"/> now throws on a
-///     non-success engine-callback POST, so a 4xx/5xx faults the cycle
-///     (<c>TRIAGE.APPLY.RESULT.FAILED</c>) instead of a swallowed false
-///     <c>.COMPLETED</c>.</description></item>
+///   <item><description>#8 — <see cref="ApplyTriageResultActivity"/> is fail-loud on a
+///     non-success engine-callback POST. It emits a loud <c>TRIAGE.APPLY.RESULT.FAILED</c>
+///     leaf event instead of a swallowed false <c>.COMPLETED</c>, and exposes a
+///     <c>Success</c> / <c>Failure</c> outcome so the cycle routes an apply failure to a
+///     LOUD <c>TRIAGE.ISSUE.FAILED</c> terminal (review fix below) rather than halting
+///     with no terminal.</description></item>
 /// </list>
+///
+/// <para>Review fix (CRITICAL — "stuck, no terminal" hang). Previously the apply node
+/// <i>threw</i> on a 4xx/5xx and had only a success-only edge
+/// (<c>applyLabels → emitCompleted</c>) with the DEFAULT incident strategy. A Flowchart
+/// never schedules a <i>faulted</i> node's outbound edges (Elsa 3.5
+/// <c>Flowchart.ProcessChildCompletedAsync</c> only routes a <c>Completed</c> child), and
+/// the default <c>FaultStrategy</c> transitions the whole instance to <c>Faulted</c> — so
+/// an apply HTTP failure halted the instance with NO <c>TRIAGE.ISSUE.*</c> terminal and
+/// no <c>itemResult</c>. Mirroring the merge-approval / deployment-pipeline precedent:
+/// (a) <c>WorkflowOptions.IncidentStrategyType = ContinueWithIncidentsStrategy</c> so an
+/// unexpected fault does not hard-halt; (b) the <c>itemResult</c> output + fail-reason are
+/// SEEDED to a fail-closed <c>failed</c> default BEFORE apply, so even a halt yields a
+/// parseable failed outcome; and (c) the apply node's <c>Failure</c> outcome routes to a
+/// loud <c>TRIAGE.ISSUE.FAILED</c> terminal that overwrites the <c>itemResult</c>. The
+/// <c>Success</c> outcome routes to <c>COMPLETED</c>. Exactly ONE cycle terminal event
+/// fires per run — including the apply-fault path.</para>
 ///
 /// <para>#9 — singleton: the previous header claimed "singleton — Elsa queues
 /// subsequent dispatches until the current one finishes". That is FALSE for Elsa's
@@ -66,8 +85,11 @@ namespace Tamma.ElsaServer.Workflows;
 ///       ├─ True (ok/empty)    → Panel Review (llm-call x4) → Extract Panel + Status → Panel Usable?
 ///       │     ├─ True (ok/partial)  → PO Decision → Capture (callSucceeded/status/fields)
 ///       │     │       → Decision OK?
-///       │     │           ├─ True (callSucceeded && status=ok) → Build Apply Inputs (validated
-///       │     │           │     labels + rendered comment) → Apply → Emit COMPLETED → Finish
+///       │     │           ├─ True (callSucceeded && status=ok) → Seed failed itemResult →
+///       │     │           │     Build Apply Inputs (validated labels + rendered comment;
+///       │     │           │     emit LABELS.INVALID for any dropped) → Apply
+///       │     │           │         ├─ Success → Emit COMPLETED → Finish
+///       │     │           │         └─ Failure → Fail Item (reason=applyFailed) → Emit FAILED → Finish
 ///       │     │           └─ False → Fail Item (reason=decisionUnusable) → Emit FAILED → Finish
 ///       │     └─ False (failed)     → Mark Skipped (panel-failed)  → Emit SKIPPED → Finish
 ///       └─ False (failed)     → Mark Skipped (context-failed)      → Emit SKIPPED → Finish
@@ -83,6 +105,14 @@ public class TriageItemCycleWorkflow : WorkflowBase
         builder.DefinitionId = "triage-item-cycle";
         builder.Version = WorkflowVersions.ComputedVersion;
         builder.Description = "Process one untriaged item: context → panel → PO → labels (fail-closed, audited)";
+
+        // Review fix (CRITICAL — "stuck, no terminal" hang). Continue-with-incidents so
+        // an unexpected fault (e.g. in an Extract/Build node) does NOT halt the instance
+        // with no output. The apply step routes its failure as an explicit Failure
+        // OUTCOME (not a throw), so the loud TRIAGE.ISSUE.FAILED terminal is always
+        // reachable; the seeded fail-closed itemResult (below, before apply) covers any
+        // other halt. Mirrors MergeApprovalWorkflow I1 / DeploymentPipelineWorkflow.
+        builder.WorkflowOptions.IncidentStrategyType = typeof(ContinueWithIncidentsStrategy);
 
         // ================================================================
         // Variables
@@ -117,6 +147,10 @@ public class TriageItemCycleWorkflow : WorkflowBase
         // Validated labels + rendered comment for apply (#7).
         var appliedLabels = builder.WithVariable<string[]>("AppliedLabels", System.Array.Empty<string>());
         var appliedComment = builder.WithVariable<string>("AppliedComment", "");
+        // Out-of-vocab labels the PO returned that were dropped by ValidateLabels (#7) —
+        // captured (no longer discarded) so the cycle emits a TRIAGE.LABELS.INVALID
+        // warning recording what was dropped, rather than silently swallowing it.
+        var droppedLabels = builder.WithVariable<string[]>("DroppedLabels", System.Array.Empty<string>());
 
         // Why the cycle skipped/failed apply — surfaced on the outputs + events.
         var skipReason = builder.WithVariable<string>("SkipReason", "");
@@ -325,6 +359,8 @@ public class TriageItemCycleWorkflow : WorkflowBase
 
         // 4c. Build apply inputs — #7 validate labels against the canonical vocab and
         //     render the AC5 markdown-table comment deterministically from the decision.
+        //     Capture the dropped (out-of-vocab) labels so the cycle can emit a
+        //     TRIAGE.LABELS.INVALID warning rather than silently discarding them.
         var buildApplyInputs = new SetVariable
         {
             Id = "BuildApplyInputs",
@@ -333,16 +369,55 @@ public class TriageItemCycleWorkflow : WorkflowBase
             Value = new Input<object?>(ctx =>
             {
                 var decision = TriageItemCycleHelper.ParseDecision(poDecisionJson.Get(ctx));
-                var validated = TriageItemCycleHelper.ValidateLabels(decision.Labels, out _);
+                var validated = TriageItemCycleHelper.ValidateLabels(decision.Labels, out var dropped);
+                droppedLabels.Set(ctx, dropped.ToArray());
                 appliedComment.Set(ctx, TriageItemCycleHelper.RenderComment(decision));
                 return (object)validated.ToArray();
             })
         };
         buildApplyInputs.SetDisplayText("Build Apply Inputs");
 
+        // 4d. MINOR (#7) — record dropped out-of-vocab labels as a loud (warning) audit
+        //     row. Non-terminal: the cycle still applies the validated subset and
+        //     proceeds to COMPLETED. Reason carries the dropped set (comma-joined,
+        //     secret-free — they are label strings). Emitted unconditionally; the
+        //     downstream durable drain persists it, and an empty dropped set carries an
+        //     empty reason (the cheap path — no extra branch in the flowchart).
+        var emitLabelsInvalid = CycleEvent(
+            "EmitLabelsInvalid", "Emit TRIAGE.LABELS.INVALID",
+            _ => TriageCycleEvents.LabelsInvalid,
+            repository, itemKey, itemNumber, tenantId, itemSource,
+            _ => "", _ => "", _ => "", ctx => decisionStatus.Get(ctx),
+            ctx => string.Join(",", droppedLabels.Get(ctx) ?? System.Array.Empty<string>()));
+
+        // 4e. Seed a fail-closed itemResult + reason BEFORE apply (review fix). If apply
+        //     (or anything after this) faults and continue-with-incidents stops the flow
+        //     before a terminal, the workflow output still carries a parseable
+        //     itemResult{outcome:"failed"} — never a stuck instance with no output. The
+        //     Success / Failure terminals below overwrite this with the real outcome.
+        var seedFailedReason = new SetVariable
+        {
+            Id = "SeedFailedReason", Name = "Seed Fail-Closed Reason",
+            Variable = skipReason,
+            Value = new Input<object?>(_ => (object)"applyIncomplete"),
+        };
+        seedFailedReason.SetDisplayText("Seed Fail-Closed Reason");
+
+        var seedFailedResult = new SetOutput
+        {
+            Id = "SeedFailedResult", Name = "Seed Item Result (failed)",
+            OutputName = new("itemResult"),
+            OutputValue = new(ctx => (object)TriageItemCycleHelper.BuildItemResult(
+                itemKey.Get(ctx), TriageCycleEvents.OutcomeFailed, decisionStatus.Get(ctx),
+                "applyIncomplete")),
+        };
+        seedFailedResult.SetDisplayText("Seed Item Result (failed)");
+
         // ================================================================
         // 5. Apply Labels + Post Comment (#7/#8 — validated labels, rendered
-        //    comment, fail-loud on a non-success engine POST).
+        //    comment, fail-loud on a non-success engine POST). The activity exposes a
+        //    Success / Failure outcome so an apply HTTP failure routes to a loud
+        //    TRIAGE.ISSUE.FAILED terminal (review fix) instead of faulting the cycle.
         // ================================================================
         var applyLabels = new ApplyTriageResultActivity
         {
@@ -356,8 +431,9 @@ public class TriageItemCycleWorkflow : WorkflowBase
         };
         applyLabels.SetDisplayText("Apply Labels & Comment");
 
-        // 5a. Emit TRIAGE.ISSUE.COMPLETED (#3) — apply succeeded (it throws on failure,
-        //     which faults the cycle before this node, so COMPLETED is never false).
+        // 5a. Emit TRIAGE.ISSUE.COMPLETED (#3) — reached ONLY via the apply Success
+        //     outcome, so COMPLETED is never a false success (a failed apply takes the
+        //     Failure edge to the FAILED terminal below).
         var emitCompleted = CycleEvent(
             "EmitCycleCompleted", "Emit TRIAGE.ISSUE.COMPLETED",
             _ => TriageCycleEvents.Completed,
@@ -374,6 +450,34 @@ public class TriageItemCycleWorkflow : WorkflowBase
                 itemKey.Get(ctx), TriageCycleEvents.OutcomeTriaged, decisionStatus.Get(ctx), null)),
         };
         outCompletedResult.SetDisplayText("Output Item Result (triaged)");
+
+        // 5b. Apply Failure terminal (review fix) — the engine-callback POST failed
+        //     (4xx/5xx or a network throw). Loud TRIAGE.ISSUE.FAILED, fail-closed
+        //     itemResult{outcome:"failed"}. Exactly one cycle terminal on this path.
+        var setApplyFailedReason = new SetVariable
+        {
+            Id = "SetApplyFailedReason", Name = "Set Apply-Failed Reason",
+            Variable = skipReason,
+            Value = new Input<object?>(_ => (object)"applyFailed"),
+        };
+        setApplyFailedReason.SetDisplayText("Set Apply-Failed Reason");
+
+        var emitApplyFailed = CycleEvent(
+            "EmitCycleApplyFailed", "Emit TRIAGE.ISSUE.FAILED (apply)",
+            _ => TriageCycleEvents.Failed,
+            repository, itemKey, itemNumber, tenantId, itemSource,
+            _ => "", _ => "", _ => "", ctx => decisionStatus.Get(ctx),
+            ctx => skipReason.Get(ctx));
+
+        var outApplyFailedResult = new SetOutput
+        {
+            Id = "OutApplyFailedResult", Name = "Output Item Result (apply failed)",
+            OutputName = new("itemResult"),
+            OutputValue = new(ctx => (object)TriageItemCycleHelper.BuildItemResult(
+                itemKey.Get(ctx), TriageCycleEvents.OutcomeFailed, decisionStatus.Get(ctx),
+                skipReason.Get(ctx))),
+        };
+        outApplyFailedResult.SetDisplayText("Output Item Result (apply failed)");
 
         // ================================================================
         // Skip / fail terminals
@@ -481,7 +585,9 @@ public class TriageItemCycleWorkflow : WorkflowBase
                 gatherContext, extractContext, contextGathered,
                 panelReview, extractPanelResult, panelUsable,
                 poDecision, extractDecision, decisionOk, buildApplyInputs,
+                emitLabelsInvalid, seedFailedReason, seedFailedResult,
                 applyLabels, emitCompleted, outCompletedResult,
+                setApplyFailedReason, emitApplyFailed, outApplyFailedResult,
                 setContextFailedReason, setPanelFailedReason,
                 markSkipped, outSkipReason, emitSkipped, outSkippedResult,
                 setDecisionFailedReason, emitFailed, outFailedResult,
@@ -512,12 +618,26 @@ public class TriageItemCycleWorkflow : WorkflowBase
                 ConnectOutcome(panelUsable, "False", setPanelFailedReason),
                 Connect(setPanelFailedReason, markSkipped),
 
-                // Decision OK → validate labels + render comment → apply → COMPLETED.
+                // Decision OK → validate labels + render comment → record any dropped
+                // labels (LABELS.INVALID warning) → seed a fail-closed itemResult →
+                // apply. The apply Success outcome → COMPLETED; Failure → loud FAILED.
                 ConnectOutcome(decisionOk, "True", buildApplyInputs),
-                Connect(buildApplyInputs, applyLabels),
-                Connect(applyLabels, emitCompleted),
+                Connect(buildApplyInputs, emitLabelsInvalid),
+                Connect(emitLabelsInvalid, seedFailedReason),
+                Connect(seedFailedReason, seedFailedResult),
+                Connect(seedFailedResult, applyLabels),
+
+                // Apply succeeded → COMPLETED (overwrites the seeded itemResult).
+                ConnectOutcome(applyLabels, "Success", emitCompleted),
                 Connect(emitCompleted, outCompletedResult),
                 Connect(outCompletedResult, finish),
+
+                // Apply failed (4xx/5xx / network) → loud TRIAGE.ISSUE.FAILED terminal —
+                // exactly one cycle terminal on the apply-fault path (the review fix).
+                ConnectOutcome(applyLabels, "Failure", setApplyFailedReason),
+                Connect(setApplyFailedReason, emitApplyFailed),
+                Connect(emitApplyFailed, outApplyFailedResult),
+                Connect(outApplyFailedResult, finish),
 
                 // Decision NOT OK (faulted PO / llm-failed / unparsed / empty) → FAILED.
                 // The False edge NEVER reaches buildApplyInputs / applyLabels.

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/ApplyTriageResultActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/ApplyTriageResultActivityTests.cs
@@ -1,0 +1,201 @@
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+
+namespace Tamma.Activities.Tests.ADL;
+
+/// <summary>
+/// Completeness audit 2026-06-22 (<c>TriageItemCycle.md</c> #8) — the headline
+/// regression: <see cref="ApplyTriageResultActivity"/> must <b>fail loud</b>. Its old
+/// <c>RunAsync</c> swallowed every engine-callback failure (try/catch + return) and
+/// never checked <c>response.IsSuccessStatusCode</c>, so a 4xx/5xx still emitted
+/// <c>TRIAGE.APPLY.RESULT.COMPLETED</c> (a false success). The build-out checks the
+/// status of each POST and THROWS on the first non-success (or a null item/decision),
+/// so the activity base emits <c>TRIAGE.APPLY.RESULT.FAILED</c> and the cycle's
+/// fail-the-item edge fires.
+///
+/// <para>Also covers #7 — the validated-label / rendered-comment overrides take
+/// precedence over the decision JSON's own values.</para>
+///
+/// Tests the testable core (<see cref="ApplyTriageResultActivity.ApplyCoreAsync"/>) via
+/// the <see cref="ITriageApplyClient"/> seam — the codebase pattern (no live HTTP).
+/// </summary>
+[TestFixture]
+public class ApplyTriageResultActivityTests
+{
+    private const string IssueItem = """{"type":"issue","number":5,"title":"t","body":"b"}""";
+    private const string AlertItem = """{"type":"security","number":0,"title":"CVE","body":"b"}""";
+    private const string OkDecision = """{"status":"ok","labels":["bug"],"comment":"c"}""";
+
+    private static Mock<ITriageApplyClient> AllOk()
+    {
+        var c = new Mock<ITriageApplyClient>();
+        c.Setup(x => x.SetLabelsAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TriageApplyResult.Ok());
+        c.Setup(x => x.PostCommentAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TriageApplyResult.Ok());
+        c.Setup(x => x.CreateIssueAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TriageApplyResult.Ok());
+        return c;
+    }
+
+    [Test]
+    public void JsonConstructor_DoesNotThrow()
+    {
+        FluentActions.Invoking(() => new ApplyTriageResultActivity()).Should().NotThrow();
+    }
+
+    // ================================================================
+    // Happy path
+    // ================================================================
+
+    [Test]
+    public async Task ApplyCore_Issue_AppliesLabelsThenComment()
+    {
+        var c = AllOk();
+
+        await ApplyTriageResultActivity.ApplyCoreAsync(
+            c.Object, "o/r", IssueItem, OkDecision, labelsOverride: null, commentOverride: null);
+
+        c.Verify(x => x.SetLabelsAsync("o/r", 5, It.Is<IReadOnlyList<string>>(l => l.Contains("bug")), It.IsAny<CancellationToken>()), Times.Once);
+        c.Verify(x => x.PostCommentAsync("o/r", 5, "c", It.IsAny<CancellationToken>()), Times.Once);
+        c.Verify(x => x.CreateIssueAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ApplyCore_Alert_CreatesIssue()
+    {
+        var c = AllOk();
+
+        await ApplyTriageResultActivity.ApplyCoreAsync(
+            c.Object, "o/r", AlertItem, OkDecision, labelsOverride: null, commentOverride: null);
+
+        c.Verify(x => x.CreateIssueAsync("o/r", "CVE", It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ================================================================
+    // #8 — fail loud (no silent swallow, no false success)
+    // ================================================================
+
+    [Test]
+    public async Task ApplyCore_LabelsReturn403_Throws_NotSilentSuccess()
+    {
+        var c = AllOk();
+        c.Setup(x => x.SetLabelsAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TriageApplyResult.Fail(403));
+
+        var act = async () => await ApplyTriageResultActivity.ApplyCoreAsync(
+            c.Object, "o/r", IssueItem, OkDecision, null, null);
+
+        (await act.Should().ThrowAsync<HttpRequestException>())
+            .Which.Message.Should().Contain("issue-labels").And.Contain("403");
+        // The comment must NOT be posted after a label failure (we threw first).
+        c.Verify(x => x.PostCommentAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ApplyCore_CommentReturns500_Throws()
+    {
+        var c = AllOk();
+        c.Setup(x => x.PostCommentAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TriageApplyResult.Fail(500));
+
+        var act = async () => await ApplyTriageResultActivity.ApplyCoreAsync(
+            c.Object, "o/r", IssueItem, OkDecision, null, null);
+
+        (await act.Should().ThrowAsync<HttpRequestException>())
+            .Which.Message.Should().Contain("issue-comment").And.Contain("500");
+    }
+
+    [Test]
+    public async Task ApplyCore_CreateIssueReturns422_Throws()
+    {
+        var c = AllOk();
+        c.Setup(x => x.CreateIssueAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TriageApplyResult.Fail(422));
+
+        var act = async () => await ApplyTriageResultActivity.ApplyCoreAsync(
+            c.Object, "o/r", AlertItem, OkDecision, null, null);
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+    }
+
+    [Test]
+    public async Task ApplyCore_ClientThrows_Propagates_NotSwallowed()
+    {
+        var c = AllOk();
+        c.Setup(x => x.SetLabelsAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("network down"));
+
+        var act = async () => await ApplyTriageResultActivity.ApplyCoreAsync(
+            c.Object, "o/r", IssueItem, OkDecision, null, null);
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+    }
+
+    [Test]
+    public async Task ApplyCore_NullDecisionJson_Throws_NeverFalseSuccess()
+    {
+        var c = AllOk();
+        var act = async () => await ApplyTriageResultActivity.ApplyCoreAsync(
+            c.Object, "o/r", IssueItem, decisionJson: "not json", labelsOverride: null, commentOverride: null);
+
+        await act.Should().ThrowAsync<Exception>(
+            "a non-deserializable decision must not silently succeed");
+    }
+
+    // ================================================================
+    // #7 — overrides take precedence
+    // ================================================================
+
+    [Test]
+    public async Task ApplyCore_LabelsAndCommentOverride_TakePrecedenceOverDecisionJson()
+    {
+        var c = AllOk();
+
+        await ApplyTriageResultActivity.ApplyCoreAsync(
+            c.Object, "o/r", IssueItem, OkDecision,
+            labelsOverride: new[] { "priority-high", "feature" },
+            commentOverride: "## Triage Decision (rendered)");
+
+        c.Verify(x => x.SetLabelsAsync("o/r", 5,
+            It.Is<IReadOnlyList<string>>(l => l.Contains("priority-high") && l.Contains("feature") && !l.Contains("bug")),
+            It.IsAny<CancellationToken>()), Times.Once);
+        c.Verify(x => x.PostCommentAsync("o/r", 5, "## Triage Decision (rendered)", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task ApplyCore_EmptyLabelOverride_FallsBackToDecisionLabels()
+    {
+        var c = AllOk();
+
+        await ApplyTriageResultActivity.ApplyCoreAsync(
+            c.Object, "o/r", IssueItem, OkDecision,
+            labelsOverride: Array.Empty<string>(), commentOverride: null);
+
+        c.Verify(x => x.SetLabelsAsync("o/r", 5,
+            It.Is<IReadOnlyList<string>>(l => l.Contains("bug")), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ================================================================
+    // EnsureSuccess — direct
+    // ================================================================
+
+    [Test]
+    public void EnsureSuccess_OkResult_DoesNotThrow()
+    {
+        FluentActions.Invoking(() =>
+            ApplyTriageResultActivity.EnsureSuccess(TriageApplyResult.Ok(), "issue-labels", 1))
+            .Should().NotThrow();
+    }
+
+    [Test]
+    public void EnsureSuccess_FailResult_ThrowsWithStatusAndEndpoint()
+    {
+        FluentActions.Invoking(() =>
+            ApplyTriageResultActivity.EnsureSuccess(TriageApplyResult.Fail(404), "create-issue", 9))
+            .Should().Throw<HttpRequestException>()
+            .Which.Message.Should().Contain("create-issue").And.Contain("404");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/TriageCycleEventTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/TriageCycleEventTests.cs
@@ -1,0 +1,147 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+
+namespace Tamma.Activities.Tests.ADL;
+
+/// <summary>
+/// Completeness audit 2026-06-22 (<c>TriageItemCycle.md</c> #3) — coverage for the
+/// cycle-scoped TRIAGE.ISSUE.* DCB event mapping
+/// (<see cref="EmitTriageCycleEventActivity.BuildTammaEvent"/>) and the
+/// <see cref="TriageCycleEvents"/> status convention. A skipped/failed cycle must map
+/// to a loud (warning/error) status carrying the item key + classification tags, never
+/// a false "success" audit row.
+/// </summary>
+[TestFixture]
+public class TriageCycleEventTests
+{
+    [Test]
+    public void EventTypes_FollowAggregateActionStatusConvention()
+    {
+        TriageCycleEvents.Started.Should().Be("TRIAGE.ISSUE.STARTED");
+        TriageCycleEvents.Completed.Should().Be("TRIAGE.ISSUE.COMPLETED");
+        TriageCycleEvents.Skipped.Should().Be("TRIAGE.ISSUE.SKIPPED");
+        TriageCycleEvents.Failed.Should().Be("TRIAGE.ISSUE.FAILED");
+    }
+
+    [Test]
+    public void StatusForEvent_FailedIsError_SkippedIsWarning_OthersSuccess()
+    {
+        TriageCycleEvents.StatusForEvent(TriageCycleEvents.Failed).Should().Be("error");
+        TriageCycleEvents.StatusForEvent(TriageCycleEvents.Skipped).Should().Be("warning");
+        TriageCycleEvents.StatusForEvent(TriageCycleEvents.Completed).Should().Be("success");
+        TriageCycleEvents.StatusForEvent(TriageCycleEvents.Started).Should().Be("success");
+    }
+
+    [Test]
+    public void ParseTenantId_ValidGuid_Parses_InvalidOrEmpty_IsNull()
+    {
+        var g = Guid.NewGuid();
+        TriageCycleEvents.ParseTenantId(g.ToString()).Should().Be(g);
+        TriageCycleEvents.ParseTenantId("").Should().BeNull();
+        TriageCycleEvents.ParseTenantId(null).Should().BeNull();
+        TriageCycleEvents.ParseTenantId("nope").Should().BeNull();
+    }
+
+    [Test]
+    public void JsonConstructor_AndLoggerConstructor_DoNotThrow()
+    {
+        FluentActions.Invoking(() => new EmitTriageCycleEventActivity()).Should().NotThrow();
+    }
+
+    // ================================================================
+    // BuildTammaEvent — tags + data + status mapping
+    // ================================================================
+
+    [Test]
+    public void BuildTammaEvent_Completed_HasSuccessStatus_ClassificationTags_AndIssueTag()
+    {
+        var evt = EmitTriageCycleEventActivity.BuildTammaEvent(
+            TriageCycleEvents.Completed,
+            repository: "owner/repo",
+            itemKey: "owner/repo#7",
+            itemNumber: 7,
+            tenantId: null,
+            itemSource: "issue",
+            itemType: "bug",
+            priority: "high",
+            automation: "tamma-auto",
+            decisionStatus: "ok",
+            reason: null);
+
+        evt.EventType.Should().Be("TRIAGE.ISSUE.COMPLETED");
+        evt.Status.Should().Be("success");
+        evt.Error.Should().BeNull();
+
+        evt.Tags!["repository"].Should().Be("owner/repo");
+        evt.Tags!["itemKey"].Should().Be("owner/repo#7");
+        evt.Tags!["issueId"].Should().Be("7");
+        evt.Tags!["itemSource"].Should().Be("issue");
+        evt.Tags!["type"].Should().Be("bug");
+        evt.Tags!["priority"].Should().Be("high");
+        evt.Tags!["automation"].Should().Be("tamma-auto");
+        evt.Tags.Should().NotContainKey("tenantId");
+
+        evt.Data["type"].Should().Be("bug");
+        evt.Data["priority"].Should().Be("high");
+        evt.Data["decisionStatus"].Should().Be("ok");
+    }
+
+    [Test]
+    public void BuildTammaEvent_Failed_HasErrorStatus_AndCarriesReasonAsError()
+    {
+        var evt = EmitTriageCycleEventActivity.BuildTammaEvent(
+            TriageCycleEvents.Failed,
+            repository: "owner/repo",
+            itemKey: "owner/repo#9",
+            itemNumber: 9,
+            tenantId: null,
+            itemSource: "issue",
+            itemType: null, priority: null, automation: null,
+            decisionStatus: "llm-failed",
+            reason: "decisionUnusable:llm-failed");
+
+        evt.Status.Should().Be("error");
+        evt.Error.Should().Be("decisionUnusable:llm-failed");
+        // No classification tags on a failed cycle (none decided).
+        evt.Tags.Should().NotContainKey("type");
+        evt.Data["decisionStatus"].Should().Be("llm-failed");
+    }
+
+    [Test]
+    public void BuildTammaEvent_Skipped_HasWarningStatus_NoErrorField()
+    {
+        var evt = EmitTriageCycleEventActivity.BuildTammaEvent(
+            TriageCycleEvents.Skipped,
+            "owner/repo", "owner/repo#3", 3, null, "issue",
+            null, null, null, "", "panel-failed");
+
+        evt.Status.Should().Be("warning");
+        // reason is carried as the error field ONLY on FAILED (loud), never on SKIPPED.
+        evt.Error.Should().BeNull();
+    }
+
+    [Test]
+    public void BuildTammaEvent_WithTenant_StampsTenantTag()
+    {
+        var tenant = Guid.NewGuid();
+        var evt = EmitTriageCycleEventActivity.BuildTammaEvent(
+            TriageCycleEvents.Started, "owner/repo", "owner/repo#1", 1, tenant, "issue",
+            null, null, null, null, null);
+
+        evt.Tags!["tenantId"].Should().Be(tenant.ToString("D"));
+    }
+
+    [Test]
+    public void BuildTammaEvent_AlertNoNumber_HasItemKeyButNoIssueTag()
+    {
+        var evt = EmitTriageCycleEventActivity.BuildTammaEvent(
+            TriageCycleEvents.Started, "owner/repo", "owner/repo:dependabot:CVE-1", 0, null, "dependabot",
+            null, null, null, null, null);
+
+        evt.Tags!["itemKey"].Should().Be("owner/repo:dependabot:CVE-1");
+        evt.Tags!["itemSource"].Should().Be("dependabot");
+        evt.Tags.Should().NotContainKey("issueId");
+        evt.Tags.Should().NotContainKey("itemId");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/TriageCycleEventTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/TriageCycleEventTests.cs
@@ -34,6 +34,15 @@ public class TriageCycleEventTests
     }
 
     [Test]
+    public void LabelsInvalid_FollowsConvention_AndIsWarning()
+    {
+        // MINOR (#7) — dropped out-of-vocab labels are recorded as a loud (warning) audit
+        // row rather than silently discarded; non-terminal (apply still proceeds).
+        TriageCycleEvents.LabelsInvalid.Should().Be("TRIAGE.LABELS.INVALID");
+        TriageCycleEvents.StatusForEvent(TriageCycleEvents.LabelsInvalid).Should().Be("warning");
+    }
+
+    [Test]
     public void ParseTenantId_ValidGuid_Parses_InvalidOrEmpty_IsNull()
     {
         var g = Guid.NewGuid();

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/IssueTriageWorkflowTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/IssueTriageWorkflowTests.cs
@@ -1,0 +1,70 @@
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Runtime.Activities;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Review fix (IMPORTANT) — the parent <c>issue-triage</c> workflow must thread a
+/// <c>tenantId</c> into each <c>triage-item-cycle</c> dispatch so the cycle's
+/// <c>TRIAGE.ISSUE.*</c> events are tenant-scoped (the cycle reads
+/// <c>GetInput&lt;string&gt;("tenantId")</c> and forwards it onward). Previously the
+/// dispatch passed only repository + itemJson, leaving every cycle event platform-scope.
+/// </summary>
+[TestFixture]
+public class IssueTriageWorkflowTests
+{
+    private Flowchart _flowchart = null!;
+    private Moq.Mock<Elsa.Workflows.IWorkflowBuilder> _builder = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _builder = WorkflowTestHelper.BuildWorkflow(new IssueTriageWorkflow());
+        _flowchart = WorkflowTestHelper.GetFlowchart(_builder);
+    }
+
+    [Test]
+    public void Workflow_BuildsWithExpectedDefinitionId()
+    {
+        _builder.Object.DefinitionId.Should().Be("issue-triage");
+    }
+
+    [Test]
+    public void Workflow_DeclaresATenantIdVariable_ReadFromInput()
+    {
+        // The TenantId variable is the carrier: FetchItems reads it from this workflow's
+        // own `tenantId` input, and the cycle dispatch forwards it. Without the variable
+        // there is nothing to thread (the old platform-scope bug).
+        _builder.Object.Variables.Any(v => v.Name == "TenantId").Should().BeTrue(
+            "issue-triage must carry a TenantId variable threaded into each cycle dispatch");
+    }
+
+    [Test]
+    public void CycleDispatch_TargetsTriageItemCycle_AndThreadsTenantId()
+    {
+        var dispatch = _flowchart.Activities
+            .OfType<DispatchWorkflow>()
+            .FirstOrDefault(d => d.Id == "DispatchTriageCycle");
+        dispatch.Should().NotBeNull("the parent must dispatch the per-item cycle");
+        ReadDefinitionId(dispatch!).Should().Be("triage-item-cycle");
+
+        // The dispatch Input is a runtime delegate; assert it is wired (the input
+        // expression exists) so the {repository,itemJson,tenantId} dictionary is built.
+        dispatch!.Input.Should().NotBeNull("the cycle dispatch must build an input dictionary");
+        dispatch.Input!.Expression.Should().NotBeNull(
+            "the cycle dispatch input (carrying tenantId) must be wired to an expression");
+    }
+
+    private static string? ReadDefinitionId(DispatchWorkflow dispatch)
+    {
+        var prop = typeof(DispatchWorkflow).GetProperty("WorkflowDefinitionId");
+        var value = prop?.GetValue(dispatch);
+        var expression = value?.GetType().GetProperty("Expression")?.GetValue(value)
+            as Elsa.Expressions.Models.Expression;
+        return expression?.Value?.ToString();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TriageItemCycleApplyFaultExecutionTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TriageItemCycleApplyFaultExecutionTests.cs
@@ -1,0 +1,313 @@
+using System.Net;
+using System.Text.Json;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Management.Activities.SetOutput;
+using Elsa.Workflows.Memory;
+using Elsa.Workflows.Models;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+using Tamma.Activities.Core;
+using FlowEndpoint = Elsa.Workflows.Activities.Flowchart.Models.Endpoint;
+using FlowConnection = Elsa.Workflows.Activities.Flowchart.Models.Connection;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// EXECUTION coverage for the review fix (CRITICAL — "stuck, no terminal" hang). This
+/// runs the cycle's apply branch through the REAL Elsa runtime (the same harness pattern
+/// as <c>EventPersistencePipelineTests</c>: a real <see cref="IWorkflowRunner"/> with the
+/// DCB-event drain installed and a capturing API client), with a FAULTING
+/// <see cref="ITriageApplyClient"/>, and asserts the load-bearing guarantee the topology
+/// tests cannot prove:
+///
+/// <list type="number">
+///   <item>an apply HTTP failure produces EXACTLY ONE <c>TRIAGE.ISSUE.FAILED</c> cycle
+///         terminal (never a stuck instance with no terminal), and</item>
+///   <item>NO false <c>TRIAGE.ISSUE.COMPLETED</c> is emitted on the fault path, and</item>
+///   <item>the loud leaf <c>TRIAGE.APPLY.RESULT.FAILED</c> still fires.</item>
+/// </list>
+///
+/// <para>The flowchart under test is the EXACT apply-branch wiring of
+/// <c>TriageItemCycleWorkflow</c> (real <see cref="ApplyTriageResultActivity"/> with its
+/// <c>Success</c>/<c>Failure</c> outcomes → the real <see cref="EmitTriageCycleEventActivity"/>
+/// COMPLETED / FAILED terminals). Running the whole cycle end-to-end would require an
+/// async <c>IWorkflowDispatcher</c> + three registered, bookmark-resuming sub-workflows
+/// (context / panel / PO) — far heavier than the load-bearing seam, which is precisely
+/// the apply outcome → cycle terminal routing this proves. The happy path
+/// (Success → COMPLETED) is exercised symmetrically by
+/// <see cref="ApplySuccess_EmitsExactlyOneCompletedTerminal_AndNoFailed"/>.</para>
+///
+/// <para>Mirrors <c>MergeApprovalWorkflowTests.Workflow_UsesContinueWithIncidentsStrategy_…</c>
+/// in intent (a fault must not halt silently) but proves it by EXECUTION, not topology.</para>
+/// </summary>
+[TestFixture]
+public class TriageItemCycleApplyFaultExecutionTests
+{
+    private const string Repo = "owner/repo";
+    private const string ItemJson = """{"type":"issue","number":7,"title":"t","body":"b","source":"issue"}""";
+    private const string OkDecision = """{"status":"ok","priority":"high","type":"bug","automation":"tamma-auto","labels":["bug"],"comment":"c"}""";
+
+    [Test]
+    public async Task ApplyHttpFailure_EmitsExactlyOneFailedTerminal_NeverFalseCompleted()
+    {
+        var capture = new CapturingHandler();
+        await using var provider = BuildProvider(capture, new FaultingApplyClient(statusCode: 500));
+
+        await RunApplyBranchAsync(provider);
+
+        var cycleTypes = CapturedEventTypes(capture).Where(t => t!.StartsWith("TRIAGE.ISSUE.")).ToList();
+
+        cycleTypes.Should().ContainSingle(
+            "an apply HTTP failure must yield EXACTLY ONE cycle terminal (no stuck/no-terminal hang)");
+        cycleTypes.Single().Should().Be(TriageCycleEvents.Failed,
+            "the single cycle terminal on an apply HTTP failure must be the loud TRIAGE.ISSUE.FAILED");
+        cycleTypes.Should().NotContain(TriageCycleEvents.Completed,
+            "a failed apply must NEVER surface as TRIAGE.ISSUE.COMPLETED (no false success)");
+    }
+
+    [Test]
+    public async Task ApplyHttpFailure_EmitsTheLoudLeafApplyFailedEvent()
+    {
+        var capture = new CapturingHandler();
+        await using var provider = BuildProvider(capture, new FaultingApplyClient(statusCode: 403));
+
+        await RunApplyBranchAsync(provider);
+
+        var allTypes = CapturedEventTypes(capture).ToList();
+        allTypes.Should().Contain("TRIAGE.APPLY.RESULT.FAILED",
+            "the apply step must still emit its loud leaf FAILED event (#8) on a non-success POST");
+        allTypes.Should().NotContain("TRIAGE.APPLY.RESULT.COMPLETED",
+            "a failed apply must not emit a false leaf .COMPLETED");
+    }
+
+    [Test]
+    public async Task ApplyFailedTerminal_OutputsFailedItemResult()
+    {
+        var capture = new CapturingHandler();
+        await using var provider = BuildProvider(capture, new FaultingApplyClient(statusCode: 500));
+
+        var output = await RunApplyBranchAsync(provider);
+
+        output.Should().ContainKey("itemResult");
+        using var doc = JsonDocument.Parse(output["itemResult"]!.ToString()!);
+        doc.RootElement.GetProperty("outcome").GetString().Should().Be(TriageCycleEvents.OutcomeFailed,
+            "the per-item result on the apply-fault path must report a failed outcome for the parent");
+    }
+
+    [Test]
+    public async Task ApplySuccess_EmitsExactlyOneCompletedTerminal_AndNoFailed()
+    {
+        var capture = new CapturingHandler();
+        await using var provider = BuildProvider(capture, new AllOkApplyClient());
+
+        await RunApplyBranchAsync(provider);
+
+        var cycleTypes = CapturedEventTypes(capture).Where(t => t!.StartsWith("TRIAGE.ISSUE.")).ToList();
+
+        cycleTypes.Should().ContainSingle("a successful apply must yield exactly one cycle terminal");
+        cycleTypes.Single().Should().Be(TriageCycleEvents.Completed);
+        cycleTypes.Should().NotContain(TriageCycleEvents.Failed);
+    }
+
+    // ── Harness ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Runs the apply-branch flowchart (real apply activity + real cycle-event terminals,
+    /// wired exactly as <c>TriageItemCycleWorkflow</c>) and returns the workflow output.
+    /// </summary>
+    private static async Task<IDictionary<string, object>> RunApplyBranchAsync(IServiceProvider rootProvider)
+    {
+        using var scope = rootProvider.CreateScope();
+        var runner = scope.ServiceProvider.GetRequiredService<IWorkflowRunner>();
+        var result = await runner.RunAsync(BuildApplyBranch());
+        return result.WorkflowState.Output ?? new Dictionary<string, object>();
+    }
+
+    /// <summary>
+    /// The apply branch of <c>TriageItemCycleWorkflow</c>, isolated: Init (seed item key +
+    /// decision fields) → Seed fail-closed itemResult → Apply → { Success → COMPLETED,
+    /// Failure → FAILED }. Uses the SAME node types and the SAME Success/Failure outcome
+    /// routing as the production workflow.
+    /// </summary>
+    private static Flowchart BuildApplyBranch()
+    {
+        var itemKey = new Variable<string>("ItemKey", "owner/repo#7");
+        var skipReason = new Variable<string>("SkipReason", "");
+
+        var apply = new ApplyTriageResultActivity
+        {
+            Id = "ApplyLabels",
+            Name = "Apply Labels & Comment",
+            Repository = new Input<string>(_ => Repo),
+            ItemJson = new Input<string>(_ => ItemJson),
+            DecisionJson = new Input<string>(_ => OkDecision),
+        };
+
+        var seedFailedResult = new SetOutput
+        {
+            Id = "SeedFailedResult",
+            OutputName = new("itemResult"),
+            OutputValue = new(ctx => (object)Tamma.ElsaServer.Workflows.Helpers.TriageItemCycleHelper.BuildItemResult(
+                itemKey.Get(ctx), TriageCycleEvents.OutcomeFailed, "ok", "applyIncomplete")),
+        };
+
+        var emitCompleted = CycleEvent("EmitCycleCompleted", TriageCycleEvents.Completed, itemKey, _ => "");
+        var outCompleted = new SetOutput
+        {
+            Id = "OutCompletedResult",
+            OutputName = new("itemResult"),
+            OutputValue = new(ctx => (object)Tamma.ElsaServer.Workflows.Helpers.TriageItemCycleHelper.BuildItemResult(
+                itemKey.Get(ctx), TriageCycleEvents.OutcomeTriaged, "ok", null)),
+        };
+
+        var setApplyFailedReason = new SetVariable
+        {
+            Id = "SetApplyFailedReason", Variable = skipReason,
+            Value = new Input<object?>(_ => (object)"applyFailed"),
+        };
+        var emitApplyFailed = CycleEvent("EmitCycleApplyFailed", TriageCycleEvents.Failed,
+            itemKey, ctx => skipReason.Get(ctx));
+        var outApplyFailed = new SetOutput
+        {
+            Id = "OutApplyFailedResult",
+            OutputName = new("itemResult"),
+            OutputValue = new(ctx => (object)Tamma.ElsaServer.Workflows.Helpers.TriageItemCycleHelper.BuildItemResult(
+                itemKey.Get(ctx), TriageCycleEvents.OutcomeFailed, "ok", skipReason.Get(ctx))),
+        };
+
+        var finish = new Finish { Id = "Finish" };
+
+        return new Flowchart
+        {
+            Id = "ApplyBranchFlowchart",
+            Variables = { itemKey, skipReason },
+            Start = seedFailedResult,
+            Activities =
+            {
+                seedFailedResult, apply,
+                emitCompleted, outCompleted,
+                setApplyFailedReason, emitApplyFailed, outApplyFailed,
+                finish,
+            },
+            Connections =
+            {
+                Connect(seedFailedResult, apply),
+                // Exactly the cycle's apply-outcome routing.
+                ConnectOutcome(apply, "Success", emitCompleted),
+                Connect(emitCompleted, outCompleted),
+                Connect(outCompleted, finish),
+                ConnectOutcome(apply, "Failure", setApplyFailedReason),
+                Connect(setApplyFailedReason, emitApplyFailed),
+                Connect(emitApplyFailed, outApplyFailed),
+                Connect(outApplyFailed, finish),
+            },
+        };
+    }
+
+    private static EmitTriageCycleEventActivity CycleEvent(
+        string id, string eventType, Variable<string> itemKey,
+        Func<Elsa.Expressions.Models.ExpressionExecutionContext, string> reason) => new()
+    {
+        Id = id,
+        EventType = new Input<string>(_ => eventType),
+        Repository = new Input<string>(_ => Repo),
+        ItemKey = new Input<string?>(ctx => itemKey.Get(ctx)),
+        ItemNumber = new Input<int>(_ => 7),
+        TenantId = new Input<string?>(_ => ""),
+        ItemSource = new Input<string?>(_ => "issue"),
+        Type = new Input<string?>(_ => ""),
+        Priority = new Input<string?>(_ => ""),
+        Automation = new Input<string?>(_ => ""),
+        DecisionStatus = new Input<string?>(_ => "ok"),
+        Reason = new Input<string?>(ctx => reason(ctx)),
+    };
+
+    private static List<string?> CapturedEventTypes(CapturingHandler capture) =>
+        capture.Bodies
+            .SelectMany(b => JsonDocument.Parse(b).RootElement.GetProperty("events").EnumerateArray())
+            .Select(e => e.GetProperty("eventType").GetString())
+            .ToList();
+
+    private static ServiceProvider BuildProvider(CapturingHandler capture, ITriageApplyClient applyClient)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddElsa(elsa =>
+        {
+            elsa.AddActivity<ApplyTriageResultActivity>();
+            elsa.AddActivity<EmitTriageCycleEventActivity>();
+            elsa.UseWorkflows(w => w.UseTammaEventPersistence());
+        });
+
+        // Engine:CallbackUrl present so the apply activity takes the real-client path; the
+        // injected ITriageApplyClient (the test seam) decides success/failure.
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Tamma:ApiUrl"] = "http://tamma.test",
+                ["Engine:CallbackUrl"] = "http://engine.test",
+            })
+            .Build();
+        services.AddSingleton<IConfiguration>(config);
+        services.AddSingleton(applyClient);
+
+        services.AddSingleton(_ => new Tamma.Activities.LlmCall.TammaApiClient(
+            new HttpClient(capture) { BaseAddress = null },
+            NullLogger<Tamma.Activities.LlmCall.TammaApiClient>.Instance,
+            config));
+
+        return services.BuildServiceProvider();
+    }
+
+    private static FlowConnection Connect(IActivity source, IActivity target)
+        => new(new FlowEndpoint(source), new FlowEndpoint(target));
+
+    private static FlowConnection ConnectOutcome(IActivity source, string outcome, IActivity target)
+        => new(new FlowEndpoint(source, outcome), new FlowEndpoint(target));
+
+    // ── Test apply clients ──────────────────────────────────────────────────
+
+    private sealed class FaultingApplyClient(int statusCode) : ITriageApplyClient
+    {
+        public Task<TriageApplyResult> SetLabelsAsync(string repository, int issueNumber, IReadOnlyList<string> labels, CancellationToken ct)
+            => Task.FromResult(TriageApplyResult.Fail(statusCode));
+        public Task<TriageApplyResult> PostCommentAsync(string repository, int issueNumber, string body, CancellationToken ct)
+            => Task.FromResult(TriageApplyResult.Fail(statusCode));
+        public Task<TriageApplyResult> CreateIssueAsync(string repository, string title, string body, IReadOnlyList<string> labels, CancellationToken ct)
+            => Task.FromResult(TriageApplyResult.Fail(statusCode));
+    }
+
+    private sealed class AllOkApplyClient : ITriageApplyClient
+    {
+        public Task<TriageApplyResult> SetLabelsAsync(string repository, int issueNumber, IReadOnlyList<string> labels, CancellationToken ct)
+            => Task.FromResult(TriageApplyResult.Ok());
+        public Task<TriageApplyResult> PostCommentAsync(string repository, int issueNumber, string body, CancellationToken ct)
+            => Task.FromResult(TriageApplyResult.Ok());
+        public Task<TriageApplyResult> CreateIssueAsync(string repository, string title, string body, IReadOnlyList<string> labels, CancellationToken ct)
+            => Task.FromResult(TriageApplyResult.Ok());
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public List<string> Bodies { get; } = new();
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Content is not null)
+                Bodies.Add(await request.Content.ReadAsStringAsync(cancellationToken));
+            return new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent("{\"ok\":true,\"persisted\":1}"),
+            };
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TriageItemCycleHelperTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TriageItemCycleHelperTests.cs
@@ -1,0 +1,203 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+using Tamma.ElsaServer.Workflows.Helpers;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Completeness audit 2026-06-22 (<c>TriageItemCycle.md</c>) — pure-function coverage
+/// for the cycle build-out helpers. These are the levers behind the cycle's fail-closed
+/// guarantees:
+/// <list type="bullet">
+///   <item><description>#1 — <see cref="TriageItemCycleHelper.IsDecisionApplicable"/> is
+///     the apply gate. A failed PO call / <c>llm-failed</c> / <c>unparsed</c> /
+///     <c>skipped</c> / empty decision is NOT applicable (no labelling off garbage).</description></item>
+///   <item><description>#7 — labels validated against the canonical vocab; comment
+///     rendered deterministically from the parsed decision (AC5 markdown table).</description></item>
+///   <item><description>#5 — per-item outcome serialization.</description></item>
+/// </list>
+/// </summary>
+[TestFixture]
+public class TriageItemCycleHelperTests
+{
+    // ================================================================
+    // #1 — decision-OK gate (the headline fail-closed guard)
+    // ================================================================
+
+    [Test]
+    public void IsDecisionApplicable_OkStatusAndCallSucceeded_IsApplicable()
+    {
+        var ok = TriageItemCycleHelper.ParseDecision(
+            """{"status":"ok","priority":"high","type":"bug","labels":["bug"],"comment":"x"}""");
+        TriageItemCycleHelper.IsDecisionApplicable(true, ok).Should().BeTrue();
+    }
+
+    [Test]
+    public void IsDecisionApplicable_CallFailed_IsNotApplicable_EvenIfStatusOk()
+    {
+        // A faulted PO dispatch leaves callSucceeded == false. Even if some stale/empty
+        // decision JSON parses to "ok", the absence of a successful call must block apply.
+        var ok = TriageItemCycleHelper.ParseDecision("""{"status":"ok","type":"bug"}""");
+        TriageItemCycleHelper.IsDecisionApplicable(false, ok).Should().BeFalse(
+            "a faulted PO sub-workflow (no callSucceeded) must NOT lead to labelling");
+    }
+
+    [TestCase("llm-failed")]
+    [TestCase("unparsed")]
+    [TestCase("skipped")]
+    [TestCase("")]
+    [TestCase("anything-else")]
+    public void IsDecisionApplicable_NonOkStatus_IsNotApplicable(string status)
+    {
+        var d = TriageItemCycleHelper.ParseDecision($$"""{"status":"{{status}}","type":"bug"}""");
+        TriageItemCycleHelper.IsDecisionApplicable(true, d).Should().BeFalse(
+            $"status '{status}' is not a usable PO decision — apply must be skipped");
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("not json")]
+    [TestCase("[1,2,3]")]
+    public void IsDecisionApplicable_MissingOrUnparseableJson_IsNotApplicable(string? json)
+    {
+        TriageItemCycleHelper.IsDecisionApplicable(true, json).Should().BeFalse(
+            "a missing/unparseable decision must never be applied");
+    }
+
+    [Test]
+    public void IsDecisionApplicable_StringOverload_ReadsStatusFromJson()
+    {
+        TriageItemCycleHelper.IsDecisionApplicable(true, """{"status":"ok","type":"bug"}""")
+            .Should().BeTrue();
+        TriageItemCycleHelper.IsDecisionApplicable(true, """{"status":"llm-failed"}""")
+            .Should().BeFalse();
+    }
+
+    // ================================================================
+    // #7 — label validation against the canonical vocab
+    // ================================================================
+
+    [Test]
+    public void ValidateLabels_KeepsCanonical_DropsUnknown()
+    {
+        var kept = TriageItemCycleHelper.ValidateLabels(
+            new[] { "bug", "priority-high", "made-up-label", "tamma-auto", "rm -rf" },
+            out var dropped);
+
+        kept.Should().BeEquivalentTo(new[] { "bug", "priority-high", "tamma-auto" });
+        dropped.Should().BeEquivalentTo(new[] { "made-up-label", "rm -rf" });
+    }
+
+    [Test]
+    public void ValidateLabels_NullOrEmpty_ReturnsEmpty_NoThrow()
+    {
+        TriageItemCycleHelper.ValidateLabels(null, out var dropped).Should().BeEmpty();
+        dropped.Should().BeEmpty();
+    }
+
+    [Test]
+    public void ValidateLabels_DeduplicatesCaseInsensitively_PreservesOrder()
+    {
+        var kept = TriageItemCycleHelper.ValidateLabels(
+            new[] { "bug", "BUG", "feature", "bug" }, out _);
+        kept.Should().ContainInOrder("bug", "feature");
+        kept.Should().HaveCount(2);
+    }
+
+    // ================================================================
+    // #7 — deterministic AC5 comment render from the parsed decision
+    // ================================================================
+
+    [Test]
+    public void RenderComment_RendersMarkdownTable_FromParsedFields_NotRawProse()
+    {
+        var d = TriageItemCycleHelper.ParseDecision(
+            """{"status":"ok","priority":"high","type":"bug","complexity":"simple","automation":"tamma-auto","comment":"NPE at startup"}""");
+
+        var md = TriageItemCycleHelper.RenderComment(d);
+
+        md.Should().Contain("| Field | Value |");
+        md.Should().Contain("| Type | bug |");
+        md.Should().Contain("| Priority | high |");
+        md.Should().Contain("| Complexity | simple |");
+        md.Should().Contain("| Automation | tamma-auto |");
+        // the PO rationale is preserved as notes, below the canonical table
+        md.Should().Contain("NPE at startup");
+    }
+
+    [Test]
+    public void RenderComment_MissingFields_UsesSafeDefaults_NeverBlankCells()
+    {
+        var d = TriageItemCycleHelper.ParseDecision("""{"status":"ok"}""");
+        var md = TriageItemCycleHelper.RenderComment(d);
+
+        md.Should().Contain($"| Type | {TriagePoDecisionHelper.DefaultType} |");
+        md.Should().Contain($"| Priority | {TriagePoDecisionHelper.DefaultPriority} |");
+        md.Should().Contain($"| Automation | {TriagePoDecisionHelper.DefaultAutomation} |");
+    }
+
+    // ================================================================
+    // itemKey derivation
+    // ================================================================
+
+    [Test]
+    public void DeriveItemKey_Issue_UsesRepoAndNumber()
+    {
+        TriageItemCycleHelper.DeriveItemKey("owner/repo", """{"number":42,"title":"x"}""")
+            .Should().Be("owner/repo#42");
+    }
+
+    [Test]
+    public void DeriveItemKey_AlertNoNumber_UsesSourceAndTitle()
+    {
+        TriageItemCycleHelper.DeriveItemKey("owner/repo", """{"source":"dependabot","title":"CVE-2025-1"}""")
+            .Should().Be("owner/repo:dependabot:CVE-2025-1");
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("not json")]
+    public void DeriveItemKey_MissingOrUnparseable_IsStable_NoThrow(string? json)
+    {
+        TriageItemCycleHelper.DeriveItemKey("owner/repo", json).Should().Be("owner/repo:unknown");
+    }
+
+    [Test]
+    public void ReadItemSource_ReadsSource_ThenType_ElseEmpty()
+    {
+        TriageItemCycleHelper.ReadItemSource("""{"source":"codeql"}""").Should().Be("codeql");
+        TriageItemCycleHelper.ReadItemSource("""{"type":"issue"}""").Should().Be("issue");
+        TriageItemCycleHelper.ReadItemSource("{}").Should().Be("");
+        TriageItemCycleHelper.ReadItemSource(null).Should().Be("");
+    }
+
+    // ================================================================
+    // #5 — per-item outcome serialization
+    // ================================================================
+
+    [Test]
+    public void BuildItemResult_Triaged_HasNoError()
+    {
+        var json = TriageItemCycleHelper.BuildItemResult("owner/repo#1", TriageCycleEvents.OutcomeTriaged, "ok", null);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        root.GetProperty("itemKey").GetString().Should().Be("owner/repo#1");
+        root.GetProperty("outcome").GetString().Should().Be("triaged");
+        root.GetProperty("decisionStatus").GetString().Should().Be("ok");
+        root.TryGetProperty("error", out _).Should().BeFalse("a triaged item carries no error");
+    }
+
+    [Test]
+    public void BuildItemResult_Failed_CarriesError()
+    {
+        var json = TriageItemCycleHelper.BuildItemResult(
+            "owner/repo#2", TriageCycleEvents.OutcomeFailed, "llm-failed", "decisionUnusable:llm-failed");
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        root.GetProperty("outcome").GetString().Should().Be("failed");
+        root.GetProperty("error").GetString().Should().Contain("decisionUnusable");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TriageItemCycleRoutingTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TriageItemCycleRoutingTests.cs
@@ -1,8 +1,10 @@
 using Elsa.Workflows.Activities;
 using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Management.Activities.SetOutput;
 using Elsa.Workflows.Runtime.Activities;
 using FluentAssertions;
 using NUnit.Framework;
+using Tamma.Activities.ADL;
 using Tamma.ElsaServer.Workflows;
 
 namespace Tamma.Activities.Tests.Workflows;
@@ -107,12 +109,16 @@ public class TriageItemCycleRoutingTests
     }
 
     [Test]
-    public void UsablePanel_ProceedsToPoDecisionAndLabels()
+    public void UsablePanel_ProceedsToPoDecisionAndDecisionGate()
     {
+        // Build-out: ExtractDecision now feeds the Decision-OK gate (not apply directly),
+        // and apply is reached only via the gate's True edge → BuildApplyInputs.
         HasEdge("PanelUsable", "True", "PODecision").Should().BeTrue();
         HasEdge("PODecision", null, "ExtractDecision").Should().BeTrue();
-        HasEdge("ExtractDecision", null, "ApplyLabels").Should().BeTrue();
-        HasEdge("ApplyLabels", null, "Finish").Should().BeTrue();
+        HasEdge("ExtractDecision", null, "DecisionOK").Should().BeTrue();
+        HasEdge("DecisionOK", "True", "BuildApplyInputs").Should().BeTrue();
+        HasEdge("BuildApplyInputs", null, "ApplyLabels").Should().BeTrue();
+        HasEdge("ApplyLabels", null, "EmitCycleCompleted").Should().BeTrue();
     }
 
     [Test]
@@ -124,7 +130,11 @@ public class TriageItemCycleRoutingTests
         HasEdge("PanelUsable", "False", "SetPanelFailedReason").Should().BeTrue();
         HasEdge("SetPanelFailedReason", null, "MarkSkipped").Should().BeTrue();
         HasEdge("MarkSkipped", null, "OutSkipReason").Should().BeTrue();
-        HasEdge("OutSkipReason", null, "Finish").Should().BeTrue();
+        // Build-out: the SKIPPED terminal now emits TRIAGE.ISSUE.SKIPPED + a per-item
+        // result before Finish (no longer OutSkipReason → Finish directly).
+        HasEdge("OutSkipReason", null, "EmitCycleSkipped").Should().BeTrue();
+        HasEdge("EmitCycleSkipped", null, "OutSkippedResult").Should().BeTrue();
+        HasEdge("OutSkippedResult", null, "Finish").Should().BeTrue();
 
         var falseTargets = _flowchart.Connections
             .Where(c => c.Source.Activity.Id == "PanelUsable" && c.Source.Port == "False")
@@ -149,9 +159,13 @@ public class TriageItemCycleRoutingTests
     [Test]
     public void BothGateOutcomes_ReachFinish_NoDeadlock()
     {
-        // Usable path: ApplyLabels → Finish. Failed path: OutSkipReason → Finish.
-        HasEdge("ApplyLabels", null, "Finish").Should().BeTrue();
-        HasEdge("OutSkipReason", null, "Finish").Should().BeTrue();
+        // Build-out: every terminal routes to Finish (no deadlock/hang).
+        //   triaged:  ApplyLabels → EmitCycleCompleted → OutCompletedResult → Finish
+        //   skipped:  OutSkipReason → EmitCycleSkipped → OutSkippedResult → Finish
+        //   failed:   SetDecisionFailedReason → EmitCycleFailed → OutFailedResult → Finish
+        HasEdge("OutCompletedResult", null, "Finish").Should().BeTrue();
+        HasEdge("OutSkippedResult", null, "Finish").Should().BeTrue();
+        HasEdge("OutFailedResult", null, "Finish").Should().BeTrue();
     }
 
     [Test]
@@ -164,6 +178,141 @@ public class TriageItemCycleRoutingTests
             .FirstOrDefault(d => d.Id == "PanelReview");
         dispatch.Should().NotBeNull();
         ReadDefinitionId(dispatch!).Should().Be("triage-panel-review");
+    }
+
+    // ================================================================
+    // #1/#2 — decision-OK gate before apply (no labelling off a bad decision)
+    // ================================================================
+
+    [Test]
+    public void DecisionOkGate_Exists_AfterExtractingDecision()
+    {
+        _flowchart.Activities.OfType<FlowDecision>()
+            .Any(d => d.Id == "DecisionOK")
+            .Should().BeTrue("the cycle must gate apply on a usable PO decision");
+
+        HasEdge("ExtractDecision", null, "DecisionOK").Should().BeTrue();
+    }
+
+    [Test]
+    public void GoodDecision_RoutesToBuildApplyInputsThenApply()
+    {
+        HasEdge("DecisionOK", "True", "BuildApplyInputs").Should().BeTrue();
+        HasEdge("BuildApplyInputs", null, "ApplyLabels").Should().BeTrue();
+    }
+
+    [Test]
+    public void BadDecision_RoutesToFailedTerminal_NeverToApply()
+    {
+        // False (faulted PO / llm-failed / unparsed / empty) → set reason → FAILED →
+        // result → finish. It must NEVER reach BuildApplyInputs / ApplyLabels.
+        HasEdge("DecisionOK", "False", "SetDecisionFailedReason").Should().BeTrue();
+        HasEdge("SetDecisionFailedReason", null, "EmitCycleFailed").Should().BeTrue();
+        HasEdge("EmitCycleFailed", null, "OutFailedResult").Should().BeTrue();
+        HasEdge("OutFailedResult", null, "Finish").Should().BeTrue();
+
+        var falseTargets = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "DecisionOK" && c.Source.Port == "False")
+            .Select(c => c.Target.Activity.Id)
+            .ToList();
+
+        falseTargets.Should().NotContain("BuildApplyInputs");
+        falseTargets.Should().NotContain("ApplyLabels");
+    }
+
+    [Test]
+    public void AllGates_HaveNoUnconditionalFallthrough()
+    {
+        foreach (var gateId in new[] { "ContextGathered", "PanelUsable", "DecisionOK" })
+        {
+            var fromGate = _flowchart.Connections
+                .Where(c => c.Source.Activity.Id == gateId)
+                .ToList();
+            fromGate.Should().NotBeEmpty();
+            fromGate.Should().OnlyContain(c => c.Source.Port == "True" || c.Source.Port == "False",
+                $"gate '{gateId}' must branch only on True/False, never fall through");
+        }
+    }
+
+    // ================================================================
+    // #3 — cycle-scoped TRIAGE.ISSUE.* events on each path
+    // ================================================================
+
+    [Test]
+    public void StartedEvent_EmittedAtInit_BeforeContextGathering()
+    {
+        CycleEventNode("EmitCycleStarted").Should().NotBeNull();
+        HasEdge("Init", null, "EmitCycleStarted").Should().BeTrue();
+        HasEdge("EmitCycleStarted", null, "GatherTriageContext").Should().BeTrue();
+    }
+
+    [Test]
+    public void EachTerminalPath_EmitsExactlyOneCycleEvent()
+    {
+        // COMPLETED on the apply-success path.
+        CycleEventNode("EmitCycleCompleted").Should().NotBeNull();
+        HasEdge("ApplyLabels", null, "EmitCycleCompleted").Should().BeTrue();
+
+        // SKIPPED on the shared context/panel non-applying terminal.
+        CycleEventNode("EmitCycleSkipped").Should().NotBeNull();
+        HasEdge("OutSkipReason", null, "EmitCycleSkipped").Should().BeTrue();
+
+        // FAILED on the bad-decision terminal.
+        CycleEventNode("EmitCycleFailed").Should().NotBeNull();
+        HasEdge("SetDecisionFailedReason", null, "EmitCycleFailed").Should().BeTrue();
+    }
+
+    // ================================================================
+    // #5 — per-item outcome output on every terminal
+    // ================================================================
+
+    [Test]
+    public void EveryTerminal_EmitsAnItemResultOutput()
+    {
+        var itemResultNodes = _flowchart.Activities.OfType<SetOutput>()
+            .Where(o => ReadOutputName(o) == "itemResult")
+            .Select(o => o.Id)
+            .ToList();
+
+        itemResultNodes.Should().Contain(new[] { "OutCompletedResult", "OutSkippedResult", "OutFailedResult" },
+            "the fire-and-forget parent needs a per-item outcome on every exit");
+    }
+
+    [Test]
+    public void PoDispatch_ThreadsTenantId_AndIsMediated()
+    {
+        var dispatch = _flowchart.Activities.OfType<DispatchWorkflow>()
+            .FirstOrDefault(d => d.Id == "PODecision");
+        dispatch.Should().NotBeNull();
+        ReadDefinitionId(dispatch!).Should().Be("triage-po-decision");
+    }
+
+    // ================================================================
+    // No dangling edge — every non-terminal activity routes somewhere.
+    // ================================================================
+
+    [Test]
+    public void EveryActivity_RoutesToATerminal_NoDanglingEdge()
+    {
+        var allIds = _flowchart.Activities.Select(a => a.Id!).ToHashSet();
+        var sources = _flowchart.Connections.Select(c => c.Source.Activity.Id!).ToHashSet();
+
+        foreach (var id in allIds.Where(i => i != "Finish"))
+        {
+            sources.Should().Contain(id, $"activity '{id}' must route somewhere (no dangling edge / hang)");
+        }
+    }
+
+    private EmitTriageCycleEventActivity? CycleEventNode(string id)
+        => _flowchart.Activities.OfType<EmitTriageCycleEventActivity>()
+            .FirstOrDefault(a => a.Id == id);
+
+    private static string? ReadOutputName(SetOutput output)
+    {
+        var value = output.OutputName;
+        var expression = value?.GetType().GetProperty("Expression")?.GetValue(value)
+            as Elsa.Expressions.Models.Expression;
+        return expression?.Value?.ToString();
     }
 
     private bool HasEdge(string sourceId, string? port, string targetId)

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TriageItemCycleRoutingTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TriageItemCycleRoutingTests.cs
@@ -117,8 +117,11 @@ public class TriageItemCycleRoutingTests
         HasEdge("PODecision", null, "ExtractDecision").Should().BeTrue();
         HasEdge("ExtractDecision", null, "DecisionOK").Should().BeTrue();
         HasEdge("DecisionOK", "True", "BuildApplyInputs").Should().BeTrue();
-        HasEdge("BuildApplyInputs", null, "ApplyLabels").Should().BeTrue();
-        HasEdge("ApplyLabels", null, "EmitCycleCompleted").Should().BeTrue();
+        // Review fix: BuildApplyInputs → record dropped labels → seed fail-closed result
+        // → apply; the apply Success outcome → COMPLETED (a failed apply takes Failure).
+        HasEdge("BuildApplyInputs", null, "EmitLabelsInvalid").Should().BeTrue();
+        HasEdge("SeedFailedResult", null, "ApplyLabels").Should().BeTrue();
+        HasEdge("ApplyLabels", "Success", "EmitCycleCompleted").Should().BeTrue();
     }
 
     [Test]
@@ -197,8 +200,14 @@ public class TriageItemCycleRoutingTests
     [Test]
     public void GoodDecision_RoutesToBuildApplyInputsThenApply()
     {
+        // Review fix: BuildApplyInputs → record dropped labels (LABELS.INVALID) → seed a
+        // fail-closed itemResult → apply. The seed guarantees a parseable failed output
+        // even if the flow halts at a faulting apply.
         HasEdge("DecisionOK", "True", "BuildApplyInputs").Should().BeTrue();
-        HasEdge("BuildApplyInputs", null, "ApplyLabels").Should().BeTrue();
+        HasEdge("BuildApplyInputs", null, "EmitLabelsInvalid").Should().BeTrue();
+        HasEdge("EmitLabelsInvalid", null, "SeedFailedReason").Should().BeTrue();
+        HasEdge("SeedFailedReason", null, "SeedFailedResult").Should().BeTrue();
+        HasEdge("SeedFailedResult", null, "ApplyLabels").Should().BeTrue();
     }
 
     [Test]
@@ -249,9 +258,9 @@ public class TriageItemCycleRoutingTests
     [Test]
     public void EachTerminalPath_EmitsExactlyOneCycleEvent()
     {
-        // COMPLETED on the apply-success path.
+        // COMPLETED on the apply-SUCCESS outcome only.
         CycleEventNode("EmitCycleCompleted").Should().NotBeNull();
-        HasEdge("ApplyLabels", null, "EmitCycleCompleted").Should().BeTrue();
+        HasEdge("ApplyLabels", "Success", "EmitCycleCompleted").Should().BeTrue();
 
         // SKIPPED on the shared context/panel non-applying terminal.
         CycleEventNode("EmitCycleSkipped").Should().NotBeNull();
@@ -260,6 +269,90 @@ public class TriageItemCycleRoutingTests
         // FAILED on the bad-decision terminal.
         CycleEventNode("EmitCycleFailed").Should().NotBeNull();
         HasEdge("SetDecisionFailedReason", null, "EmitCycleFailed").Should().BeTrue();
+
+        // FAILED on the apply-FAILURE outcome (review fix — the "stuck, no terminal" hole).
+        CycleEventNode("EmitCycleApplyFailed").Should().NotBeNull();
+        HasEdge("SetApplyFailedReason", null, "EmitCycleApplyFailed").Should().BeTrue();
+    }
+
+    // ================================================================
+    // Review fix (CRITICAL) — the apply step exposes Success / Failure outcomes; an
+    // apply failure routes to a LOUD TRIAGE.ISSUE.FAILED terminal (not a silent halt),
+    // and the workflow seeds a fail-closed itemResult before apply + uses
+    // continue-with-incidents so a fault can never leave the cycle with no terminal.
+    // ================================================================
+
+    [Test]
+    public void ApplySuccessOutcome_RoutesToCompletedTerminal()
+    {
+        HasEdge("ApplyLabels", "Success", "EmitCycleCompleted").Should().BeTrue(
+            "a successful apply routes to the COMPLETED terminal");
+        HasEdge("EmitCycleCompleted", null, "OutCompletedResult").Should().BeTrue();
+        HasEdge("OutCompletedResult", null, "Finish").Should().BeTrue();
+    }
+
+    [Test]
+    public void ApplyFailureOutcome_RoutesToLoudFailedTerminal_NotCompleted()
+    {
+        // The apply Failure outcome must reach the loud TRIAGE.ISSUE.FAILED terminal —
+        // exactly one cycle terminal on the apply-fault path — and must NOT reach the
+        // COMPLETED terminal (no false success / no stuck instance with no terminal).
+        HasEdge("ApplyLabels", "Failure", "SetApplyFailedReason").Should().BeTrue();
+        HasEdge("SetApplyFailedReason", null, "EmitCycleApplyFailed").Should().BeTrue();
+        HasEdge("EmitCycleApplyFailed", null, "OutApplyFailedResult").Should().BeTrue();
+        HasEdge("OutApplyFailedResult", null, "Finish").Should().BeTrue();
+
+        var failureReach = Reachable("SetApplyFailedReason");
+        failureReach.Should().NotContain("EmitCycleCompleted",
+            "an apply failure must never reach the COMPLETED terminal");
+        failureReach.Should().NotContain("OutCompletedResult");
+    }
+
+    [Test]
+    public void ApplyNode_HasBothOutcomePorts_NoUnconditionalFallthrough()
+    {
+        var fromApply = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "ApplyLabels")
+            .ToList();
+
+        fromApply.Should().NotBeEmpty();
+        fromApply.Should().OnlyContain(c => c.Source.Port == "Success" || c.Source.Port == "Failure",
+            "apply must branch only on its Success/Failure outcomes, never fall through");
+        fromApply.Select(c => c.Source.Port).Should().Contain(new[] { "Success", "Failure" });
+    }
+
+    [Test]
+    public void Workflow_SeedsFailClosedItemResultBeforeApply()
+    {
+        // A SeedFailedResult SetOutput runs BEFORE ApplyLabels so even a halt (a fault
+        // that stops the flow before a terminal) yields a parseable failed itemResult.
+        var seed = _flowchart.Activities.OfType<SetOutput>().FirstOrDefault(o => o.Id == "SeedFailedResult");
+        seed.Should().NotBeNull("a fail-closed itemResult must be seeded before apply");
+        ReadOutputName(seed!).Should().Be("itemResult");
+        HasEdge("SeedFailedResult", null, "ApplyLabels").Should().BeTrue(
+            "the seeded fail-closed result must immediately precede apply");
+    }
+
+    [Test]
+    public void Workflow_UsesContinueWithIncidentsStrategy_SoAFaultDoesNotHaltSilently()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new TriageItemCycleWorkflow());
+        builder.Object.WorkflowOptions.IncidentStrategyType
+            .Should().Be(typeof(Elsa.Workflows.IncidentStrategies.ContinueWithIncidentsStrategy),
+                "a faulted node must not halt the cycle with no TRIAGE.ISSUE.* terminal");
+    }
+
+    [Test]
+    public void DroppedLabels_AreRecordedAsALabelsInvalidEvent_BeforeApply()
+    {
+        // #7 (MINOR) — dropped out-of-vocab labels are recorded as a loud (warning)
+        // TRIAGE.LABELS.INVALID audit row rather than silently discarded. Non-terminal:
+        // the cycle still applies the validated subset and proceeds toward apply.
+        var node = CycleEventNode("EmitLabelsInvalid");
+        node.Should().NotBeNull("dropped labels must be recorded, not silently discarded");
+        HasEdge("BuildApplyInputs", null, "EmitLabelsInvalid").Should().BeTrue();
+        // It is on the path to apply (non-terminal), not a separate exit.
+        Reachable("EmitLabelsInvalid").Should().Contain("ApplyLabels");
     }
 
     // ================================================================
@@ -320,6 +413,24 @@ public class TriageItemCycleRoutingTests
             c.Source.Activity.Id == sourceId &&
             (port == null || c.Source.Port == port) &&
             c.Target.Activity.Id == targetId);
+
+    /// <summary>Forward-reachable activity ids from a starting node.</summary>
+    private HashSet<string> Reachable(string startId)
+    {
+        var seen = new HashSet<string>();
+        var queue = new Queue<string>();
+        queue.Enqueue(startId);
+        while (queue.Count > 0)
+        {
+            var id = queue.Dequeue();
+            foreach (var c in _flowchart.Connections.Where(c => c.Source.Activity.Id == id))
+            {
+                var t = c.Target.Activity.Id;
+                if (t != null && seen.Add(t)) queue.Enqueue(t);
+            }
+        }
+        return seen;
+    }
 
     private static string? ReadDefinitionId(DispatchWorkflow dispatch)
     {


### PR DESCRIPTION
## TriageItemCycleWorkflow build-out — Bucket D (P0)

Per `docs/superpowers/audits/2026-06-22/completeness/TriageItemCycle.md`. The per-item orchestrator was a strictly-linear happy path (no gates, no error edges, no events).
- **Decision-OK gate** before apply (consumes `TriagePODecision`'s `callSucceeded`/`unparsed` from #391) → a bad/empty/unparsed/failed PO decision SKIPS apply (never labels off garbage).
- **Fail-closed dispatch handling** on context/panel/PO (gate on success-signal absence — `DispatchWorkflow` has no `Faulted` port; a faulted child Finishes with an empty dict).
- **`ApplyTriageResultActivity` fail-loud** — checks engine-callback HTTP status (was swallow-and-false-success).
- **Cycle-scoped DCB events** `TRIAGE.ISSUE.STARTED/COMPLETED/FAILED/SKIPPED`; per-item `itemResult`; deterministic comment + label validation.

**Review + fix:** review caught a **CRITICAL "stuck, no terminal" hang** — the now-throwing apply node had no cycle fault handling, so an apply HTTP failure halted the instance with no `TRIAGE.ISSUE.*` terminal. Fixed (mirroring the in-repo `MergeApprovalWorkflow` precedent): `ApplyTriageResultActivity` → a `[FlowNode("Success","Failure")]` outcome activity that catches + completes the `Failure` outcome **without rethrowing** + `IncidentStrategyType=ContinueWithIncidentsStrategy` + a seeded fail-closed `itemResult` + `Failure → TRIAGE.ISSUE.FAILED` terminal. A **real-runtime execution test** proves the single FAILED terminal on apply failure. Also threaded `tenantId` from the parent `IssueTriageWorkflow` (cycle events were platform-scoped); emit `TRIAGE.LABELS.INVALID` on dropped labels.

**Gate:** build 0; full `Tamma.Activities.Tests` **2049/0**. Touches `IssueTriageWorkflow.cs` (tenantId threading). No EF migration/Program.cs/csproj. Deferred (honest): #4 full triage-state dedupe store, #6 milestone, #10 project-board, #11 richer context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)