### PR TITLE
Engine → platform_events callback: durable control-plane audit for tenant-lifecycle + analytics

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Models/TammaApiModels.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Models/TammaApiModels.cs
@@ -239,6 +239,33 @@ public record AppendEventsRequest(
 );
 
 /// <summary>
+/// POST body for <c>/api/engine/platform-events</c> — a BATCH of platform
+/// events the Elsa engine forwards to the Tamma API for durable audit storage.
+/// </summary>
+public record AppendPlatformEventsRequest(
+    [property: JsonPropertyName("events")] IReadOnlyList<PlatformEventRecord> Events
+);
+
+/// <summary>
+/// Wire projection of one platform event (see
+/// <c>Tamma.Api.Dtos.Engine.PlatformEventRecord</c>). camelCase to match the
+/// API DTO serialization (JsonNamingPolicy.CamelCase in Program.cs).
+/// TenantId/UserId travel per-event in the body; no <c>X-Tenant-Id</c> header
+/// is needed because <c>EngineServiceOnly</c> auth is satisfied by the service
+/// Bearer token.
+/// </summary>
+public record PlatformEventRecord(
+    [property: JsonPropertyName("id")] Guid Id,
+    [property: JsonPropertyName("type")] string Type,
+    [property: JsonPropertyName("tenantId")] Guid? TenantId,
+    [property: JsonPropertyName("userId")] Guid? UserId,
+    [property: JsonPropertyName("tags")] IReadOnlyDictionary<string, string?>? Tags,
+    [property: JsonPropertyName("metadata")] JsonElement? Metadata,
+    [property: JsonPropertyName("data")] JsonElement? Data,
+    [property: JsonPropertyName("createdAt")] DateTime? CreatedAt
+);
+
+/// <summary>
 /// Wire projection of one engine <c>TammaEvent</c> (see
 /// <c>Tamma.Activities.Core.TammaEvent</c>). camelCase to match the API DTO
 /// (<c>Tamma.Api.Dtos.Engine.EngineEventRecord</c>).

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/TammaApiClient.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/TammaApiClient.cs
@@ -273,6 +273,56 @@ public class TammaApiClient
         }
     }
 
+    // ----- Platform event append ----------------------------------------
+
+    /// <summary>
+    /// Persist a BATCH of platform events to durable storage via
+    /// <c>POST /api/engine/platform-events</c>. Used by Task 3's publisher
+    /// to forward cross-tenant lifecycle events (e.g. TENANT.DELETED.SUCCESS)
+    /// that the engine witnesses but the Tamma API owns durably.
+    ///
+    /// <para>Returns <c>true</c> only on a fully-successful append (2xx).
+    /// Any non-2xx or transport failure returns <c>false</c> so the caller
+    /// can retry. No <c>X-Tenant-Id</c> header is sent — <c>TenantId</c>
+    /// travels per-event in the body, and <c>EngineServiceOnly</c> auth is
+    /// satisfied by the service Bearer token the client already attaches.</para>
+    /// </summary>
+    public async Task<bool> AppendPlatformEventsAsync(
+        IReadOnlyList<Models.PlatformEventRecord> events,
+        CancellationToken ct = default)
+    {
+        if (events is null || events.Count == 0)
+            return true; // nothing to flush — a successful no-op.
+
+        var url = $"{_baseUrl}/api/engine/platform-events";
+        var body = new Models.AppendPlatformEventsRequest(events);
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = JsonContent.Create(body, options: JsonOpts),
+            };
+            using var response = await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
+            await RecordHealthAsync(
+                response.IsSuccessStatusCode, (int)response.StatusCode, null, ct)
+                .ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Tamma API POST /api/engine/platform-events returned {Status} for {Count} events",
+                    (int)response.StatusCode, events.Count);
+                return false;
+            }
+            return true;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            _logger.LogWarning(ex, "Tamma API POST /api/engine/platform-events failed");
+            await RecordHealthAsync(false, null, ex.GetType().Name, ct).ConfigureAwait(false);
+            return false;
+        }
+    }
+
     // ----- Helpers ------------------------------------------------------
 
     private async Task<T?> GetAsync<T>(

--- a/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/EngineApiPlatformEventPublisher.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/EngineApiPlatformEventPublisher.cs
@@ -47,29 +47,40 @@ public sealed class EngineApiPlatformEventPublisher : IPlatformEventPublisher
     {
         if (evt is null) return null;
 
-        using var scope = _scopeFactory.CreateScope();
-        var api = scope.ServiceProvider.GetRequiredService<TammaApiClient>();
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var api = scope.ServiceProvider.GetRequiredService<TammaApiClient>();
 
-        var record = new PlatformEventRecord(
-            evt.Id,
-            evt.Type,
-            evt.TenantId,
-            evt.UserId,
-            ParseTags(evt.Tags),
-            ToJsonElement(evt.Metadata),
-            ToJsonElement(evt.Data),
-            evt.CreatedAt == default ? null : evt.CreatedAt);
+            var record = new PlatformEventRecord(
+                evt.Id,
+                evt.Type,
+                evt.TenantId,
+                evt.UserId,
+                ParseTags(evt.Tags),
+                ToJsonElement(evt.Metadata),
+                ToJsonElement(evt.Data),
+                evt.CreatedAt == default ? null : evt.CreatedAt);
 
-        var ok = await api.AppendPlatformEventsAsync(new[] { record }, ct).ConfigureAwait(false);
-        if (!ok)
+            var ok = await api.AppendPlatformEventsAsync(new[] { record }, ct).ConfigureAwait(false);
+            if (!ok)
+            {
+                _logger.LogWarning(
+                    "platform_event.post_failed type={Type} tenantId={TenantId}",
+                    evt.Type, evt.TenantId);
+                return null;
+            }
+
+            return evt;
+        }
+        catch (Exception ex)
         {
             _logger.LogWarning(
-                "platform_event.post_failed type={Type} tenantId={TenantId}",
+                ex,
+                "platform_event.publish_error type={Type} tenantId={TenantId}",
                 evt.Type, evt.TenantId);
             return null;
         }
-
-        return evt;
     }
 
     // -----------------------------------------------------------------------
@@ -100,6 +111,7 @@ public sealed class EngineApiPlatformEventPublisher : IPlatformEventPublisher
         if (string.IsNullOrWhiteSpace(json) || json == "{}")
             return null;
 
-        return JsonDocument.Parse(json).RootElement.Clone();
+        using var doc = System.Text.Json.JsonDocument.Parse(json);
+        return doc.RootElement.Clone();
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/EngineApiPlatformEventPublisher.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/EngineApiPlatformEventPublisher.cs
@@ -1,0 +1,105 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+
+namespace Tamma.Activities.TenantLifecycle;
+
+/// <summary>
+/// Engine-side <see cref="IPlatformEventPublisher"/>: the engine has no
+/// control-plane DB access, so it POSTs platform events to
+/// <c>POST /api/engine/platform-events</c> (mirroring the domain_events
+/// drain that flows through <c>POST /api/engine/events</c>).
+///
+/// <para>Persistence and idempotency happen server-side. On POST failure
+/// the publisher logs a WARN and returns <c>null</c> (degraded, not
+/// throwing) — same philosophy as the prior
+/// <see cref="NullPlatformEventPublisher"/>, but events now land durably
+/// when the API is reachable.</para>
+///
+/// <para><b>Captive-dependency guard.</b> <see cref="TammaApiClient"/>
+/// is registered as a typed <see cref="Microsoft.Extensions.Http"/>
+/// transient — capturing it in a singleton field is unsafe. Instead this
+/// publisher resolves the client per-call via
+/// <see cref="IServiceScopeFactory"/>, mirroring the pattern used by
+/// <c>Tamma.Api.Services.PlatformEvents.PlatformEventPublisher</c>.</para>
+/// </summary>
+public sealed class EngineApiPlatformEventPublisher : IPlatformEventPublisher
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<EngineApiPlatformEventPublisher> _logger;
+
+    public EngineApiPlatformEventPublisher(
+        IServiceScopeFactory scopeFactory,
+        ILogger<EngineApiPlatformEventPublisher> logger)
+    {
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc/>
+    public async Task<PlatformEvent?> AppendAndPublishAsync(
+        PlatformEvent evt,
+        CancellationToken ct = default)
+    {
+        if (evt is null) return null;
+
+        using var scope = _scopeFactory.CreateScope();
+        var api = scope.ServiceProvider.GetRequiredService<TammaApiClient>();
+
+        var record = new PlatformEventRecord(
+            evt.Id,
+            evt.Type,
+            evt.TenantId,
+            evt.UserId,
+            ParseTags(evt.Tags),
+            ToJsonElement(evt.Metadata),
+            ToJsonElement(evt.Data),
+            evt.CreatedAt == default ? null : evt.CreatedAt);
+
+        var ok = await api.AppendPlatformEventsAsync(new[] { record }, ct).ConfigureAwait(false);
+        if (!ok)
+        {
+            _logger.LogWarning(
+                "platform_event.post_failed type={Type} tenantId={TenantId}",
+                evt.Type, evt.TenantId);
+            return null;
+        }
+
+        return evt;
+    }
+
+    // -----------------------------------------------------------------------
+    // Mapping helpers
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Parses the JSONB-as-string <c>Tags</c> column into the dictionary
+    /// shape the wire record expects. Returns <c>null</c> for empty/null JSON
+    /// (the server treats missing/null tags the same as an empty object).
+    /// </summary>
+    private static IReadOnlyDictionary<string, string?>? ParseTags(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json) || json == "{}")
+            return null;
+
+        return JsonSerializer.Deserialize<Dictionary<string, string?>>(json);
+    }
+
+    /// <summary>
+    /// Parses the JSONB-as-string <c>Metadata</c> / <c>Data</c> columns into
+    /// a <see cref="JsonElement?"/>. Returns <c>null</c> for empty/null JSON.
+    /// Uses <see cref="JsonElement.Clone"/> so the element is independent of
+    /// the parent <see cref="JsonDocument"/> lifetime.
+    /// </summary>
+    private static JsonElement? ToJsonElement(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json) || json == "{}")
+            return null;
+
+        return JsonDocument.Parse(json).RootElement.Clone();
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Dtos/Engine/EngineDtos.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Dtos/Engine/EngineDtos.cs
@@ -129,3 +129,22 @@ public record EngineEventRecord(
     int? IssueNumber,
     JsonElement? Data,
     Dictionary<string, string?>? Tags);
+
+/// <summary>Batch of platform (control-plane) events from the engine, written to platform_events.</summary>
+public record AppendPlatformEventsRequest(List<PlatformEventRecord> Events);
+
+/// <summary>
+/// One platform event from the engine. <see cref="Id"/> is the stable idempotency key
+/// (Guid.Empty → server assigns). <see cref="TenantId"/> is nullable and carried in the
+/// body because <c>platform_events</c> is cross-tenant (unlike <c>domain_events</c> whose
+/// tenant comes from the <c>X-Tenant-Id</c> service header).
+/// </summary>
+public record PlatformEventRecord(
+    Guid Id,
+    string Type,
+    Guid? TenantId,
+    Guid? UserId,
+    Dictionary<string, string?>? Tags,
+    JsonElement? Metadata,
+    JsonElement? Data,
+    DateTime? CreatedAt);

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/EngineEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/EngineEndpoints.cs
@@ -7,6 +7,7 @@ using Tamma.Api.Dtos.Engine;
 using Tamma.Api.Services.Engine;
 using Tamma.Api.Services.Engine.Lifecycle;
 using Tamma.Data;
+using Tamma.Data.Abstractions;
 using Tamma.Data.Entities;
 using Tamma.Data.Repositories;
 
@@ -797,6 +798,93 @@ public static class EngineEndpoints
         return Results.Created(
             "/api/engine/events",
             new { ok = true, persisted, storedAt = DateTime.UtcNow });
+    }
+
+    // ─── Platform-events (control-plane) append ────────────────────────────────
+
+    /// <summary>
+    /// Engine→<c>platform_events</c> DCB-event callback. Persists a batch of
+    /// cross-tenant lifecycle / analytics events to the control-plane store and
+    /// fans them out to in-process subscribers via
+    /// <see cref="IPlatformEventPublisher"/>.
+    ///
+    /// <para>This mirrors <see cref="AppendEvents"/> (which targets per-tenant
+    /// <c>domain_events</c>). The tenant is nullable and carried in the body
+    /// because platform events are cross-tenant — some fire before/after a
+    /// tenant DB exists (e.g. <c>TENANT.DELETED.*</c>, <c>ORCHESTRATOR.TICK.*</c>).</para>
+    ///
+    /// <para>Partial-batch semantics match <see cref="AppendEvents"/>: per-event
+    /// failures are collected; any failure → 502 so the engine drain cursor stays
+    /// put and the batch is retried. A dedup no-op (<c>AppendAndPublishAsync</c>
+    /// returns null) counts as success — the engine-minted stable id makes retries
+    /// idempotent.</para>
+    /// </summary>
+    public static async Task<IResult> AppendPlatformEvents(
+        AppendPlatformEventsRequest req,
+        IPlatformEventPublisher publisher)
+    {
+        if (req?.Events is null || req.Events.Count == 0)
+            return Results.BadRequest(new { error = "events array is required and must be non-empty" });
+
+        var persisted = 0;
+        var failures = new List<object>();
+
+        for (var i = 0; i < req.Events.Count; i++)
+        {
+            var e = req.Events[i];
+
+            if (string.IsNullOrWhiteSpace(e.Type))
+            {
+                failures.Add(new { index = i, error = "type is required" });
+                continue;
+            }
+
+            try
+            {
+                var evt = new PlatformEvent
+                {
+                    Id = e.Id == Guid.Empty ? Guid.NewGuid() : e.Id,
+                    Type = e.Type,
+                    TenantId = e.TenantId,
+                    UserId = e.UserId,
+                    Tags = e.Tags is null ? "{}" : JsonSerializer.Serialize(e.Tags),
+                    Metadata = e.Metadata is JsonElement md && md.ValueKind != JsonValueKind.Undefined
+                        ? md.GetRawText()
+                        : "{}",
+                    Data = e.Data is JsonElement d && d.ValueKind != JsonValueKind.Undefined
+                        ? d.GetRawText()
+                        : "{}",
+                    CreatedAt = e.CreatedAt ?? DateTime.UtcNow,
+                };
+
+                // null result = idempotent dedup no-op = success (already persisted).
+                await publisher.AppendAndPublishAsync(evt);
+                persisted++;
+            }
+            catch (Exception ex)
+            {
+                // Per-event failure — collect and continue so a single bad row
+                // doesn't lose the rest of the batch. The engine retries the
+                // WHOLE batch on a non-2xx (cursor stays put), which re-sends
+                // the events that DID persist on this call. That re-send is safe
+                // only because AppendAndPublishAsync is idempotent on the stable
+                // per-event Id (ON CONFLICT DO NOTHING).
+                failures.Add(new { index = i, error = ex.GetType().Name });
+            }
+        }
+
+        if (failures.Count > 0)
+        {
+            return Results.Json(new
+            {
+                error = "partial_append_failure",
+                persisted,
+                failed = failures.Count,
+                failures,
+            }, statusCode: StatusCodes.Status502BadGateway);
+        }
+
+        return Results.Created("/api/engine/platform-events", new { ok = true, persisted });
     }
 
     // ─── Agent availability — finding 002 ─────────────────────────────────────

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/EngineEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/EngineEndpoints.cs
@@ -813,11 +813,19 @@ public static class EngineEndpoints
     /// because platform events are cross-tenant — some fire before/after a
     /// tenant DB exists (e.g. <c>TENANT.DELETED.*</c>, <c>ORCHESTRATOR.TICK.*</c>).</para>
     ///
-    /// <para>Partial-batch semantics match <see cref="AppendEvents"/>: per-event
-    /// failures are collected; any failure → 502 so the engine drain cursor stays
-    /// put and the batch is retried. A dedup no-op (<c>AppendAndPublishAsync</c>
-    /// returns null) counts as success — the engine-minted stable id makes retries
-    /// idempotent.</para>
+    /// <para>Partial-batch semantics: per-event failures are collected; any
+    /// per-event failure → 502; full success → 201. A dedup no-op
+    /// (<c>AppendAndPublishAsync</c> returns null) counts as success.
+    /// PK-level dedup applies only when the caller sends a stable non-empty
+    /// <c>Id</c>; in production all 11 lifecycle emitters go through
+    /// <c>TenantLifecycleEvents.BuildEvent</c> (never sets <c>Id</c> →
+    /// <c>Guid.Empty</c> → the server mints a fresh Id per POST), and the 2
+    /// analytics emitters use <c>Guid.NewGuid()</c> per build — so PK-dedup is
+    /// effectively dormant. The real cross-retry guard is the partial unique
+    /// index on <c>(tenant_id, type, tags-&gt;&gt;'step', tags-&gt;&gt;'attempt')
+    /// WHERE type LIKE 'TENANT.PROVISION.STEP_%'</c>, which does survive
+    /// round-trips. <c>DELETE.STEP_*</c>, terminal, and analytics events are
+    /// not index-covered and can duplicate on a lost-success retry.</para>
     /// </summary>
     public static async Task<IResult> AppendPlatformEvents(
         AppendPlatformEventsRequest req,
@@ -864,11 +872,12 @@ public static class EngineEndpoints
             catch (Exception ex)
             {
                 // Per-event failure — collect and continue so a single bad row
-                // doesn't lose the rest of the batch. The engine retries the
-                // WHOLE batch on a non-2xx (cursor stays put), which re-sends
-                // the events that DID persist on this call. That re-send is safe
-                // only because AppendAndPublishAsync is idempotent on the stable
-                // per-event Id (ON CONFLICT DO NOTHING).
+                // doesn't lose the rest of the batch. A full-batch failure returns
+                // 502. PK-dedup (ON CONFLICT DO NOTHING) applies only when the
+                // caller sends a stable non-empty Id; current emitters send
+                // Guid.Empty, so the server mints a fresh Id per call — dedup
+                // is dormant for all but TENANT.PROVISION.STEP_* (which is
+                // covered by the partial unique index on step+attempt tags).
                 failures.Add(new { id = e.Id, type = e.Type, error = ex.Message });
             }
         }

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/EngineEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/EngineEndpoints.cs
@@ -835,7 +835,7 @@ public static class EngineEndpoints
 
             if (string.IsNullOrWhiteSpace(e.Type))
             {
-                failures.Add(new { index = i, error = "type is required" });
+                failures.Add(new { id = e.Id, error = "empty_type" });
                 continue;
             }
 
@@ -869,7 +869,7 @@ public static class EngineEndpoints
                 // the events that DID persist on this call. That re-send is safe
                 // only because AppendAndPublishAsync is idempotent on the stable
                 // per-event Id (ON CONFLICT DO NOTHING).
-                failures.Add(new { index = i, error = ex.GetType().Name });
+                failures.Add(new { id = e.Id, type = e.Type, error = ex.Message });
             }
         }
 

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -2220,6 +2220,11 @@ engine.MapGet("/cycle-results", EngineEndpoints.GetCycleResults);
 // Gated to EngineServiceOnly (service principal) — NOT WorkflowsManage, which
 // every tenant owner/admin holds and would let them forge audit events (I4).
 engine.MapPost("/events", EngineEndpoints.AppendEvents).RequireAuthorization("EngineServiceOnly");
+// Engine→platform_events callback: cross-tenant lifecycle / analytics events that the
+// engine drains from its in-process list and POSTs here for durable control-plane
+// persistence + in-process fan-out. Gated EngineServiceOnly (same rationale as /events).
+engine.MapPost("/platform-events", EngineEndpoints.AppendPlatformEvents)
+    .RequireAuthorization("EngineServiceOnly");
 // Audit finding 002 — `agent-available` is a GET liveness probe (no body),
 // not a POST registration call. The previous wiring as POST silently drifted
 // from the TS contract.

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
@@ -277,19 +277,21 @@ builder.Services.AddSingleton<Tamma.Activities.LlmCall.TammaApiHealthMonitor>(sp
 builder.Services.AddSingleton<Tamma.Activities.AgentDispatch.IGitHubActionsClient,
     Tamma.Activities.AgentDispatch.NullGitHubActionsClient>();
 
-// Engine has no control-plane platform_events sink. The tenant-lifecycle
-// activities (TenantLifecycleActivity / CleanupStepActivity /
+// Real engine→API platform-events publisher. The tenant-lifecycle activities
+// (TenantLifecycleActivity / CleanupStepActivity /
 // EmitCleanupTerminalEventActivity) resolve IPlatformEventPublisher via
-// GetRequiredService — without a registration that THROWS in the engine and
-// aborts CreateTenant/DeleteTenant/CleanUpFailedTenant workflows. The Null
-// seam (mirrors NullGitHubActionsClient above) lets those workflows complete;
-// the per-step platform telemetry is a best-effort no-op (logged at WARN)
-// until a sibling POST /api/engine/platform-events callback lands (FOLLOW-UP).
-// This is DISTINCT from the tenant domain_events drain, which now flows
-// through POST /api/engine/events + the event-persistence middleware below.
+// GetRequiredService. EngineApiPlatformEventPublisher POSTs to
+// POST /api/engine/platform-events (Task 3 of the engine→platform_events
+// callback plan) so the 13 emitters that previously dropped events now
+// land durably. On POST failure it degrades to WARN+null (never throws)
+// so lifecycle workflows complete even when the callback is briefly
+// unavailable. This is DISTINCT from the tenant domain_events drain, which
+// flows through POST /api/engine/events + the event-persistence middleware.
+// NullPlatformEventPublisher is kept below (documents the seam; may be used
+// in tests).
 Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions
     .TryAddSingleton<Tamma.Data.Abstractions.IPlatformEventPublisher,
-        Tamma.Activities.TenantLifecycle.NullPlatformEventPublisher>(builder.Services);
+        Tamma.Activities.TenantLifecycle.EngineApiPlatformEventPublisher>(builder.Services);
 
 // Story 29-6 — engine-side rotation audit emitter. RotateSecretWorkflow runs
 // HERE (the engine), and RotateSecretSagaActivity resolves

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/LlmCall/TammaApiClientTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/LlmCall/TammaApiClientTests.cs
@@ -267,6 +267,75 @@ public class TammaApiClientTests
         handler.LastRequest.Should().BeNull("an empty batch must not hit the network");
     }
 
+    // -------------------------------------------------------------------
+    // AppendPlatformEventsAsync
+    // -------------------------------------------------------------------
+
+    [Test]
+    public async Task AppendPlatformEventsAsync_Posts_To_PlatformEvents_Endpoint_And_Returns_True_On_2xx()
+    {
+        var id = Guid.NewGuid();
+        var tenantId = Guid.NewGuid();
+        var handler = new StubHttpMessageHandler(HttpStatusCode.Created, "{\"ok\":true}");
+        var client = BuildClient(handler);
+        var evt = new PlatformEventRecord(id, "TENANT.DELETED.SUCCESS", tenantId, null, null, null, null, null);
+
+        var ok = await client.AppendPlatformEventsAsync(new[] { evt }, CancellationToken.None);
+
+        ok.Should().BeTrue();
+        handler.LastRequest!.Method.Should().Be(HttpMethod.Post);
+        handler.LastRequest.RequestUri!.AbsolutePath.Should().Be("/api/engine/platform-events");
+
+        // TenantId travels per-event in the body — no X-Tenant-Id header.
+        handler.LastRequest.Headers.TryGetValues("X-Tenant-Id", out _).Should().BeFalse();
+
+        // Verify the body carries the event batch.
+        handler.LastBody.Should().NotBeNull();
+        var body = JsonDocument.Parse(handler.LastBody!).RootElement;
+        body.GetProperty("events").GetArrayLength().Should().Be(1);
+        body.GetProperty("events")[0].GetProperty("id").GetGuid().Should().Be(id);
+        body.GetProperty("events")[0].GetProperty("type").GetString().Should().Be("TENANT.DELETED.SUCCESS");
+        body.GetProperty("events")[0].GetProperty("tenantId").GetGuid().Should().Be(tenantId);
+    }
+
+    [Test]
+    public async Task AppendPlatformEventsAsync_Returns_False_On_Non2xx()
+    {
+        var handler = new StubHttpMessageHandler(HttpStatusCode.InternalServerError, "{}");
+        var client = BuildClient(handler);
+
+        var ok = await client.AppendPlatformEventsAsync(
+            new[] { new PlatformEventRecord(Guid.NewGuid(), "X", null, null, null, null, null, null) },
+            default);
+
+        ok.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task AppendPlatformEventsAsync_Returns_False_On_NetworkError()
+    {
+        var handler = new StubHttpMessageHandler(new HttpRequestException("down"));
+        var client = BuildClient(handler);
+
+        var ok = await client.AppendPlatformEventsAsync(
+            new[] { new PlatformEventRecord(Guid.NewGuid(), "X", null, null, null, null, null, null) },
+            default);
+
+        ok.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task AppendPlatformEventsAsync_EmptyList_IsNoOp_ReturnsTrue_SendsNoRequest()
+    {
+        var handler = new StubHttpMessageHandler(HttpStatusCode.Created, "{}");
+        var client = BuildClient(handler);
+
+        var ok = await client.AppendPlatformEventsAsync(Array.Empty<PlatformEventRecord>(), default);
+
+        ok.Should().BeTrue();
+        handler.LastRequest.Should().BeNull("an empty list must not hit the network");
+    }
+
     [Test]
     public async Task DisposeProviderAsync_SendsDelete_AndReturnsFalseOnFailure()
     {

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/TenantLifecycle/EngineApiPlatformEventPublisherTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/TenantLifecycle/EngineApiPlatformEventPublisherTests.cs
@@ -1,0 +1,145 @@
+using System.Net;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.TenantLifecycle;
+using Tamma.Data.Entities;
+
+namespace Tamma.Activities.Tests.TenantLifecycle;
+
+/// <summary>
+/// Task 3 — unit tests for <see cref="EngineApiPlatformEventPublisher"/>.
+///
+/// <para>The publisher is a singleton that resolves <see cref="TammaApiClient"/>
+/// per-call via <see cref="IServiceScopeFactory"/> to avoid the captive-dependency
+/// trap. Tests use a real <see cref="ServiceCollection"/> registered with the
+/// pre-wired client so <c>GetRequiredService&lt;TammaApiClient&gt;()</c> works
+/// exactly as in production — no Moq seam needed for the scope factory.</para>
+/// </summary>
+[TestFixture]
+public class EngineApiPlatformEventPublisherTests
+{
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static TammaApiClient BuildClient(StubHandler handler)
+    {
+        var http = new HttpClient(handler) { BaseAddress = null };
+        var cfg = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Tamma:ApiUrl"] = "http://tamma.test",
+            })
+            .Build();
+        return new TammaApiClient(http, NullLogger<TammaApiClient>.Instance, cfg);
+    }
+
+    /// <summary>
+    /// Wire a real DI container so <c>GetRequiredService&lt;TammaApiClient&gt;()</c>
+    /// inside the publisher returns the pre-built client (backed by <paramref name="api"/>).
+    /// The publisher is NOT registered here — the test constructs it directly.
+    /// </summary>
+    private static EngineApiPlatformEventPublisher NewPublisher(TammaApiClient api)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(api);
+        var rootProvider = services.BuildServiceProvider();
+        var scopeFactory = rootProvider.GetRequiredService<IServiceScopeFactory>();
+        return new EngineApiPlatformEventPublisher(
+            scopeFactory,
+            NullLogger<EngineApiPlatformEventPublisher>.Instance);
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task AppendAndPublishAsync_Posts_Event_And_Returns_It_On_Success()
+    {
+        HttpRequestMessage? captured = null;
+        var handler = new StubHandler(req =>
+        {
+            captured = req;
+            return new HttpResponseMessage(HttpStatusCode.Created);
+        });
+        var api = BuildClient(handler);
+        var pub = NewPublisher(api);
+        var evt = new PlatformEvent
+        {
+            Id = Guid.NewGuid(),
+            Type = "TENANT.DELETED.SUCCESS",
+            TenantId = Guid.NewGuid(),
+            Tags = "{}",
+            Metadata = "{}",
+            Data = "{}",
+        };
+
+        var result = await pub.AppendAndPublishAsync(evt, CancellationToken.None);
+
+        Assert.That(result, Is.SameAs(evt));
+        Assert.That(captured, Is.Not.Null, "publisher must POST to the API");
+        Assert.That(captured!.RequestUri!.AbsolutePath, Is.EqualTo("/api/engine/platform-events"));
+    }
+
+    [Test]
+    public async Task AppendAndPublishAsync_Returns_Null_And_Does_Not_Throw_On_Post_Failure()
+    {
+        var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError));
+        var api = BuildClient(handler);
+        var pub = NewPublisher(api);
+        var evt = new PlatformEvent
+        {
+            Id = Guid.NewGuid(),
+            Type = "X",
+            Tags = "{}",
+            Metadata = "{}",
+            Data = "{}",
+        };
+
+        // Must NOT throw — degraded path returns null so lifecycle workflows
+        // complete even when the control-plane callback is temporarily unavailable.
+        var result = await pub.AppendAndPublishAsync(evt, CancellationToken.None);
+
+        Assert.That(result, Is.Null, "degraded: logged at WARN, not thrown (mirrors Null seam philosophy)");
+    }
+
+    [Test]
+    public async Task AppendAndPublishAsync_Null_Event_Returns_Null_Without_Posting()
+    {
+        var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.Created));
+        var api = BuildClient(handler);
+        var pub = NewPublisher(api);
+
+        // Act — null guard must short-circuit before network I/O.
+        var result = await pub.AppendAndPublishAsync(null!, CancellationToken.None);
+
+        Assert.That(result, Is.Null);
+        Assert.That(handler.LastRequest, Is.Null, "null event must not trigger a POST");
+    }
+
+    // -----------------------------------------------------------------------
+    // Test double
+    // -----------------------------------------------------------------------
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _respond;
+
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond)
+            => _respond = respond;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(_respond(request));
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/TenantLifecycle/EngineApiPlatformEventPublisherTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/TenantLifecycle/EngineApiPlatformEventPublisherTests.cs
@@ -121,6 +121,63 @@ public class EngineApiPlatformEventPublisherTests
         Assert.That(handler.LastRequest, Is.Null, "null event must not trigger a POST");
     }
 
+    [Test]
+    public async Task AppendAndPublishAsync_Malformed_Tags_Returns_Null_And_Does_Not_Throw()
+    {
+        // "[1,2,3]" is valid JSON but cannot be deserialized as Dictionary<string,string?>.
+        // Before FIX 1 this would have thrown JsonException, aborting the lifecycle workflow.
+        var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.Created));
+        var api = BuildClient(handler);
+        var pub = NewPublisher(api);
+        var evt = new PlatformEvent
+        {
+            Id = Guid.NewGuid(),
+            Type = "TENANT.DROPPED.SUCCESS",
+            TenantId = Guid.NewGuid(),
+            Tags = "[1,2,3]",   // not a JSON object — ParseTags will throw without FIX 1
+            Metadata = "{}",
+            Data = "{}",
+        };
+
+        // Must NOT throw — the catch block returns null and logs WARN instead.
+        var result = await pub.AppendAndPublishAsync(evt, CancellationToken.None);
+
+        Assert.That(result, Is.Null, "malformed jsonb must degrade to null, not throw");
+    }
+
+    [Test]
+    public async Task AppendAndPublishAsync_NonEmpty_Tags_Round_Trips_Through_Mapping()
+    {
+        // Verifies that ParseTags / ToJsonElement are actually exercised (not short-circuited
+        // by the null/"{}" early-return) and that the publisher still returns the event on success.
+        string? capturedBody = null;
+        var handler = new StubHandler(req =>
+        {
+            // Read synchronously inside the callback (the handler is invoked on the test thread).
+            capturedBody = req.Content?.ReadAsStringAsync().GetAwaiter().GetResult();
+            return new HttpResponseMessage(HttpStatusCode.Created);
+        });
+        var api = BuildClient(handler);
+        var pub = NewPublisher(api);
+        var evt = new PlatformEvent
+        {
+            Id = Guid.NewGuid(),
+            Type = "TENANT.SCHEMA.DROPPED",
+            TenantId = Guid.NewGuid(),
+            Tags = "{\"step\":\"drop_schema\"}",
+            Metadata = "{\"workflowVersion\":\"1.0.0\"}",
+            Data = "{\"foo\":1}",
+        };
+
+        var result = await pub.AppendAndPublishAsync(evt, CancellationToken.None);
+
+        Assert.That(result, Is.SameAs(evt), "non-empty tags must succeed and return the event");
+        Assert.That(capturedBody, Is.Not.Null, "publisher must POST a request body");
+        // Confirm the mapping ran — the serialized body must contain the tag key/value.
+        Assert.That(capturedBody, Does.Contain("drop_schema"),
+            "captured request body must include the mapped tag value");
+    }
+
     // -----------------------------------------------------------------------
     // Test double
     // -----------------------------------------------------------------------

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Engine/AppendPlatformEventsEndpointTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Engine/AppendPlatformEventsEndpointTests.cs
@@ -1,0 +1,163 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Tamma.Api.Dtos.Engine;
+using Tamma.Api.Endpoints;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+
+namespace Tamma.Api.Tests.Engine;
+
+/// <summary>
+/// Durable engine→platform_events callback — direct-handler coverage for
+/// <see cref="EngineEndpoints.AppendPlatformEvents"/>. Mirrors the handler-direct
+/// pattern from <see cref="EngineAppendEventsEndpointTests"/>: bypass the auth +
+/// tenant-binding middleware, supply <see cref="IPlatformEventPublisher"/> from the
+/// real DI container, and assert against <see cref="ControlPlaneDbContext.PlatformEvents"/>
+/// on the fixture's control-plane Postgres container (real EF write path, not a mock).
+/// </summary>
+[TestFixture]
+public class AppendPlatformEventsEndpointTests
+{
+    private IServiceScope _scope = null!;
+    private IPlatformEventPublisher _publisher = null!;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await ApiTestFixture.ResetDatabaseAsync();
+        _scope = ApiTestFixture.Factory.Services.CreateScope();
+        _publisher = _scope.ServiceProvider.GetRequiredService<IPlatformEventPublisher>();
+    }
+
+    [TearDown]
+    public void TearDown() => _scope?.Dispose();
+
+    [Test]
+    public async Task AppendPlatformEvents_PersistsRowToPlatformEvents_AndIsIdempotent()
+    {
+        var id = Guid.NewGuid();
+        var tenantId = Guid.NewGuid();
+        var req = BuildRequest(new[]
+        {
+            new PlatformEventRecord(
+                id, "TENANT.DELETED.SUCCESS", tenantId, null,
+                new Dictionary<string, string?> { ["source"] = "cleanup-workflow" },
+                null, null, null),
+        });
+
+        var result = await EngineEndpoints.AppendPlatformEvents(req, _publisher);
+        var (status, body) = await ReadAsync(result);
+
+        status.Should().Be(StatusCodes.Status201Created);
+        body.GetProperty("ok").GetBoolean().Should().BeTrue();
+        body.GetProperty("persisted").GetInt32().Should().Be(1);
+
+        // Idempotent re-POST of the same id → dedup no-op, still 201, still one row.
+        var result2 = await EngineEndpoints.AppendPlatformEvents(req, _publisher);
+        (await ReadAsync(result2)).Status.Should().Be(StatusCodes.Status201Created,
+            "a dedup no-op counts as success — engine drain advances cursor");
+
+        await using var assertScope = ApiTestFixture.Factory.Services.CreateAsyncScope();
+        var cp = assertScope.ServiceProvider.GetRequiredService<ControlPlaneDbContext>();
+        var rows = await cp.PlatformEvents.Where(e => e.Id == id).ToListAsync();
+        rows.Should().HaveCount(1, "idempotent append must not duplicate rows");
+        rows[0].Type.Should().Be("TENANT.DELETED.SUCCESS");
+        rows[0].TenantId.Should().Be(tenantId);
+
+        // Tags must be persisted as serialized JSON.
+        var tags = JsonSerializer.Deserialize<Dictionary<string, string?>>(rows[0].Tags)!;
+        tags["source"].Should().Be("cleanup-workflow");
+    }
+
+    [Test]
+    public async Task AppendPlatformEvents_NullableTenantId_PersistedWithNullTenant()
+    {
+        // platform_events is cross-tenant; TenantId=null is valid (e.g. orchestrator ticks).
+        var id = Guid.NewGuid();
+        var req = BuildRequest(new[]
+        {
+            new PlatformEventRecord(id, "ORCHESTRATOR.TICK.COMPLETED", null, null, null, null, null, null),
+        });
+
+        var result = await EngineEndpoints.AppendPlatformEvents(req, _publisher);
+        (await ReadAsync(result)).Status.Should().Be(StatusCodes.Status201Created);
+
+        await using var assertScope = ApiTestFixture.Factory.Services.CreateAsyncScope();
+        var cp = assertScope.ServiceProvider.GetRequiredService<ControlPlaneDbContext>();
+        var row = await cp.PlatformEvents.SingleAsync(e => e.Id == id);
+        row.TenantId.Should().BeNull();
+        row.Type.Should().Be("ORCHESTRATOR.TICK.COMPLETED");
+    }
+
+    [Test]
+    public async Task AppendPlatformEvents_EmptyBatch_ReturnsBadRequest()
+    {
+        var result = await EngineEndpoints.AppendPlatformEvents(
+            new AppendPlatformEventsRequest(new List<PlatformEventRecord>()), _publisher);
+        (await ReadAsync(result)).Status.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public async Task AppendPlatformEvents_PartialFailure_PersistsValid_ReportsInvalid()
+    {
+        var tenantId = Guid.NewGuid();
+        var req = BuildRequest(new[]
+        {
+            new PlatformEventRecord(Guid.NewGuid(), "TENANT.PROVISIONED.SUCCESS", tenantId, null, null, null, null, null),
+            new PlatformEventRecord(Guid.NewGuid(), "", tenantId, null, null, null, null, null), // empty type → per-event reject
+            new PlatformEventRecord(Guid.NewGuid(), "TENANT.DELETED.SUCCESS", tenantId, null, null, null, null, null),
+        });
+
+        var result = await EngineEndpoints.AppendPlatformEvents(req, _publisher);
+        var (status, body) = await ReadAsync(result);
+
+        status.Should().Be(StatusCodes.Status502BadGateway,
+            "a partial batch failure must NOT 2xx so the engine drain retries (cursor stays put)");
+        body.GetProperty("error").GetString().Should().Be("partial_append_failure");
+        body.GetProperty("persisted").GetInt32().Should().Be(2);
+        body.GetProperty("failed").GetInt32().Should().Be(1);
+    }
+
+    [Test]
+    public async Task AppendPlatformEvents_GuidEmptyId_ServerMintsNewId()
+    {
+        var req = BuildRequest(new[]
+        {
+            new PlatformEventRecord(Guid.Empty, "TENANT.CREATED.SUCCESS", Guid.NewGuid(), null, null, null, null, null),
+        });
+
+        var result = await EngineEndpoints.AppendPlatformEvents(req, _publisher);
+        var (status, body) = await ReadAsync(result);
+
+        status.Should().Be(StatusCodes.Status201Created);
+        body.GetProperty("persisted").GetInt32().Should().Be(1);
+
+        // Row should exist with a server-minted id (non-Empty).
+        await using var assertScope = ApiTestFixture.Factory.Services.CreateAsyncScope();
+        var cp = assertScope.ServiceProvider.GetRequiredService<ControlPlaneDbContext>();
+        var rows = await cp.PlatformEvents.Where(e => e.Type == "TENANT.CREATED.SUCCESS").ToListAsync();
+        rows.Should().HaveCount(1);
+        rows[0].Id.Should().NotBe(Guid.Empty);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private static AppendPlatformEventsRequest BuildRequest(IEnumerable<PlatformEventRecord> records) =>
+        new(records.ToList());
+
+    private static async Task<(int Status, JsonElement Body)> ReadAsync(IResult result)
+    {
+        var ctx = new DefaultHttpContext { RequestServices = ApiTestFixture.Factory.Services };
+        ctx.Response.Body = new MemoryStream();
+        await result.ExecuteAsync(ctx);
+        ctx.Response.Body.Seek(0, SeekOrigin.Begin);
+        var body = ctx.Response.Body.Length == 0
+            ? JsonDocument.Parse("null").RootElement
+            : JsonDocument.Parse(ctx.Response.Body).RootElement.Clone();
+        return (ctx.Response.StatusCode, body);
+    }
+}

--- a/docs/superpowers/plans/2026-06-29-engine-platform-events-callback.md
+++ b/docs/superpowers/plans/2026-06-29-engine-platform-events-callback.md
@@ -442,7 +442,7 @@ git commit -m "feat(platform-events): real engine publisher replaces NullPlatfor
 | Endpoint reachable by tenant users (audit forgery / spend) | `EngineServiceOnly` (service-principal only) copied verbatim from the `/events` line; Task 1 includes the auth-rejection assertion (or route-policy assertion). |
 | Singleton publisher captures a transient typed `TammaApiClient` (stale handler) | Resolve `TammaApiClient` per-call via `IServiceScopeFactory` (mirrors `PlatformEventPublisher`). |
 | Lost audit event on a transient API failure | Degrade-to-WARN (`platform_event.post_failed`) — strictly better than today's always-drop; the authoritative lifecycle state is still the `tenants` columns the terminals write directly. At-least-once buffering is a documented follow-up, out of scope. |
-| Duplicate rows on activity retry for non-`PROVISION.STEP` types | Stable `Guid Id` per event gives PK-level dedup (`AppendAsync` returns null on unique-violation); the partial unique index adds step/attempt dedup for `TENANT.PROVISION.STEP_*`. Cross-retry dedup for other types is pre-existing emitter behavior, out of scope. |
+| Duplicate rows on activity retry for non-`PROVISION.STEP` types | PK-level dedup applies only when the caller sends a stable non-empty `Id`; in production all 11 lifecycle emitters go through `TenantLifecycleEvents.BuildEvent` (never sets `Id` → `Guid.Empty` → server mints a fresh Id per POST), and the 2 analytics emitters use `Guid.NewGuid()` per build — so PK-dedup is effectively dormant. The real cross-retry guard is the partial unique index on `(tenant_id, type, tags->>'step', tags->>'attempt') WHERE type LIKE 'TENANT.PROVISION.STEP_%'`, which does survive round-trips. `DELETE.STEP_*`, terminal, and analytics events are not index-covered and can duplicate on a lost-success retry. Tracked as a follow-up (see below). |
 | jsonb column mapping (`Tags`/`Metadata`/`Data` string vs object) | Task 1/3 steps say to confirm the entity's actual types and serialize/parse accordingly. |
 | Engine in-process subscribers don't fire (endpoint publishes in Tamma.Api, not the engine) | Accepted + same as `domain_events`; the endpoint's `AppendAndPublishAsync` fans out to the Tamma.Api in-process subscribers (where they live). Cross-process fan-out is a separate documented concern. |
 
@@ -452,6 +452,10 @@ git commit -m "feat(platform-events): real engine publisher replaces NullPlatfor
 2. `TammaApiClient.AppendPlatformEventsAsync` POSTs to it (true on 2xx, false otherwise); covered by a client test.
 3. `EngineApiPlatformEventPublisher` replaces `NullPlatformEventPublisher` in the engine (`ElsaServer/Program.cs`); resolves `TammaApiClient` per-call; returns the event on success and degrades to WARN+null on failure; covered by a publisher test. All 13 emitters now flow through it (no emitter changes).
 4. Build 0 errors; full `Tamma.Api.Tests` + `Tamma.Activities.Tests` green; **no schema change / no migration**.
+
+## Follow-ups
+
+- **FOLLOW-UP (before any exactly-once consumer of `platform_events`, e.g. aggregation/billing):** give the 13 emitters deterministic/stable event Ids (or add natural-key unique indexes for `DELETE.STEP_*`/terminal/analytics types), and consider at-least-once buffering for the engine publisher. Today's PK-dedup is dormant (emitters send `Guid.Empty`); only `TENANT.PROVISION.STEP_*` is index-protected.
 
 ## Self-review
 

--- a/docs/superpowers/plans/2026-06-29-engine-platform-events-callback.md
+++ b/docs/superpowers/plans/2026-06-29-engine-platform-events-callback.md
@@ -1,0 +1,460 @@
+# Engine → platform_events Callback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Give the Elsa engine a durable control-plane audit path for `platform_events` by adding a `POST /api/engine/platform-events` callback (mirroring #373's `domain_events` drain) and replacing the engine's no-op `NullPlatformEventPublisher` with a real publisher that POSTs to it — so the 13 tenant-lifecycle + analytics emitters that are silently dropped today land durably in `platform_events`.
+
+**Architecture:** The Elsa runtime is hosted only in `Tamma.ElsaServer` (the engine), which has **no control-plane DB access** by design; `PlatformEventRepository` is bound to `ControlPlaneDbContext` which lives only in `Tamma.Api`. So the engine must round-trip an `EngineServiceOnly` API callback (exactly like the existing `domain_events` path). One new endpoint + one new engine client method + one publisher swap covers all 13 emitters (they all call `IPlatformEventPublisher.AppendAndPublishAsync`).
+
+**Tech Stack:** .NET 9 / EF Core 9 / Npgsql / NUnit + Moq / `ApiTestFixture` (WebApplicationFactory) / tests via `sg docker -c "dotnet test ..."`.
+
+## Global Constraints
+
+- **Build gate (every task):** `dotnet build apps/tamma-elsa/Tamma.sln -clp:ErrorsOnly` → 0 errors (build is NOT docker-wrapped).
+- **Test runner:** `sg docker -c "dotnet test ..."` is REQUIRED for `dotnet test` (stale session docker group). Run focused tests while iterating; the full `Tamma.Api.Tests` project before committing.
+- **No schema change:** the `platform_events` table already exists. Do NOT add a migration or edit `TammaModelConfiguration`. If you think you need to, stop — you've left scope.
+- **Auth:** the new endpoint MUST require `EngineServiceOnly` (service-principal only — `ServicePrincipalRequirement`/`ServicePrincipalHandler`; a `ServiceAuthPrincipal` minted from the `Tamma:ApiToken` service key). A tenant-user JWT must be rejected (it never carries the `"*"` permission). Do NOT use `WorkflowsManage`/`WorkflowsView`.
+- **Idempotency / fail-closed:** reuse the #373 contract — each event carries a stable `Guid Id` on the wire (`Id == Guid.Empty ? NewGuid() : Id`); the repo append is idempotent (PK + the partial unique index on `TENANT.PROVISION.STEP_*`); a partial-batch failure returns `502` so the engine does not advance / treats the POST as failed. A dedup no-op (`AppendAsync` returns `null`) counts as SUCCESS, not failure.
+- **Persist + publish:** the endpoint runs in `Tamma.Api` where the real in-process subscribers live, so it calls `IPlatformEventPublisher.AppendAndPublishAsync` (persist via the idempotent repo + fan-out). `InMemoryPlatformEventBus` swallows per-subscriber exceptions, so fan-out can't fail the append.
+- **Branch:** feature branch off `origin/main` (`f118e58d`) in worktree `/home/meywd/tamma-wt/engine-platform-events`. Suggested: `feat/engine-platform-events-callback`.
+
+---
+
+## Verified current-state appendix (origin/main `f118e58d`, 2026-06-29 — do not re-derive)
+
+### The #373 `domain_events` pattern to mirror
+- **Endpoint** `EngineEndpoints.AppendEvents` — `apps/tamma-elsa/src/Tamma.Api/Endpoints/EngineEndpoints.cs:693` `(AppendEventsRequest req, IEventRepository eventRepo, ITenantContext tc)`. Empty-batch → 400; per-event loop projects `EngineEventRecord`→`DomainEvent` (stable Guid at L748); partial failures → `502 partial_append_failure` (L783-795); full success → `201 Created "/api/engine/events"` (L797-799).
+- **Route** — `apps/tamma-elsa/src/Tamma.Api/Program.cs:2222`: `engine.MapPost("/events", EngineEndpoints.AppendEvents).RequireAuthorization("EngineServiceOnly");` (group `var engine = app.MapGroup("/api/engine").RequireAuthorization("WorkflowsView");` at L2195; the `/events` line overrides to `EngineServiceOnly`, comment L2220-2221).
+- **Request DTOs** — `apps/tamma-elsa/src/Tamma.Api/Dtos/Engine/EngineDtos.cs`: `AppendEventsRequest(List<EngineEventRecord> Events)` (L109); `EngineEventRecord(Guid Id, string EventType, string? Status, string? Error, DateTime? Timestamp, double? DurationMs, string? ActivityId, string? ActivityName, string? WorkflowInstanceId, int? IssueNumber, JsonElement? Data, Dictionary<string,string?>? Tags)` (L119-131). **No tenant field** (domain_events derives tenant from context).
+- **Engine client** — `apps/tamma-elsa/src/Tamma.Activities/LlmCall/TammaApiClient.cs:238` `AppendEventsAsync(IReadOnlyList<Models.EngineEventRecord> events, Guid? tenantId = null, CancellationToken ct = default) → Task<bool>`. POSTs to `$"{_baseUrl}/api/engine/events"` (L246); `AddTenantHeader` → `X-Tenant-Id` (L254/399-405); Bearer service token via ctor (L41-64) + `TammaEngineAuthHandler`; returns `true` only on 2xx (L259-273). Engine wire DTOs in `apps/tamma-elsa/src/Tamma.Activities/LlmCall/Models/TammaApiModels.cs` (`AppendEventsRequest` L237, `EngineEventRecord` L246).
+- **Auth policy** `EngineServiceOnly` — `Program.cs:1263-1268` (`Jwt`+`ApiKey` schemes, `RequireAuthenticatedUser`, `ServicePrincipalRequirement`); handler DI `Program.cs:1152`; dev-permissive list `Program.cs:1336-1338`. `ServicePrincipalRequirement`/`ServicePrincipalHandler` in `apps/tamma-elsa/src/Tamma.Api/Auth/PermissionHandler.cs:121`/`:136` (succeeds when principal is `ServiceAuthPrincipal` OR `"permission"` claim contains `"*"`). `ServiceAuthPrincipal(Guid KeyId, string ServiceName, IReadOnlyList<string> Permissions, Guid? TenantId)` — `apps/tamma-elsa/src/Tamma.Api/Auth/AuthPrincipal.cs:35`.
+
+### The `platform_events` target seam
+- **Publisher port** — `apps/tamma-elsa/src/Tamma.Data/Abstractions/IPlatformEventPublisher.cs:35`: `Task<PlatformEvent?> AppendAndPublishAsync(PlatformEvent evt, CancellationToken ct = default)` (L44; returns persisted event, or `null` on dedup no-op). Lives in `Tamma.Data.Abstractions` so `Tamma.Activities` can reference it.
+- **Real impl** (Tamma.Api) — `apps/tamma-elsa/src/Tamma.Api/Services/PlatformEvents/PlatformEventPublisher.cs:20`: ctor `(IPlatformEventBus bus, IServiceScopeFactory scopeFactory)`; `AppendAndPublishAsync` opens a fresh scope, resolves scoped `IPlatformEventRepository`, calls `bus.AppendAndPublishAsync(repo, evt, ct)`. Registered (singleton) by `AddPlatformEventBus()` — `apps/tamma-elsa/src/Tamma.Api/Extensions/PlatformEventsServiceCollectionExtensions.cs:37` (called `Program.cs:812`).
+- **Repository** — `apps/tamma-elsa/src/Tamma.Data/Repositories/IPlatformEventRepository.cs:22` `Task<PlatformEvent?> AppendAsync(PlatformEvent evt, ct)` (L32). Impl `PlatformEventRepository.cs:21` (ctor `ControlPlaneDbContext`); `AppendAsync` stamps `CreatedAt`, `Add`, `SaveChangesAsync`; on `DbUpdateException` detaches + returns `null` (dedup via PK + partial unique index `(tenant_id, type, tags->>'step', tags->>'attempt') WHERE type LIKE 'TENANT.PROVISION.STEP_%'`). DI: `apps/tamma-elsa/src/Tamma.Data/DependencyInjection.cs:175` `TryAddScoped<IPlatformEventRepository, PlatformEventRepository>()` (via `AddTammaData`).
+- **Entity / table** — `apps/tamma-elsa/src/Tamma.Data/Entities/PlatformEvent.cs:20`; EF cfg `TammaModelConfiguration.cs:589-622`. Columns: `Id` (Guid PK, `gen_random_uuid()`), `Type` (varchar 255), `TenantId` (Guid?, nullable), `UserId` (Guid?, nullable), `Tags`/`Metadata`/`Data` (jsonb, default `'{}'`), `CreatedAt` (now()), `SequenceNumber` (BIGSERIAL, unique). Control-plane: `ControlPlaneDbContext.cs:502` `DbSet<PlatformEvent> PlatformEvents`; `modelBuilder.Ignore<PlatformEvent>()` in the tenant branch (`TammaModelConfiguration.cs:1186`).
+- **The Null seam to replace** — class `apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/NullPlatformEventPublisher.cs:35` (`AppendAndPublishAsync` logs `platform_event.dropped` WARN + returns `null`, L42-51). Registration `apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs:290-292`: `TryAddSingleton<IPlatformEventPublisher, NullPlatformEventPublisher>` (comment L280-289 names the planned `POST /api/engine/platform-events` follow-up). `TammaApiClient` is available in the engine (`AddHttpClient<TammaApiClient>()` at `Program.cs:234`).
+
+### The 13 dropped emitters (all run in the engine, all call `AppendAndPublishAsync`)
+Tenant lifecycle (`Tamma.Activities/TenantLifecycle/`): `TenantLifecycleActivity` base (`PROVISION.STEP_*`/`DELETE.STEP_*`), `MarkTenantActiveActivity` (`TENANT.CREATED.SUCCESS`+`PROVISIONED.SUCCESS`), `MarkTenantDeletingActivity` (`DELETE.REQUESTED`), `DeleteTenantStepActivities`/`MarkTenantDeletingForDeleteActivity` (`DELETE.STARTED`), `EmitDeletedSuccessActivity`, `EmitCleanupTerminalEventActivity` + `CleanupStepActivity` base, `EmitDeleteTerminalEventActivity` (terminal `DELETE.ABORTED`/`DELETED.SUCCESS`/`DELETE.FAILED`). Analytics (`HourlyAnalyticsRollupWorkflow`): `ComputeTenantRollupActivity`, `FanOutTenantRollupsActivity`, `ComputePlatformRollupActivity`, `EmitHourCompletedActivity`, `PurgeStaleAnalyticsActivity`. `BuildEvent` sets `Metadata={"workflowVersion":"1.0.0","eventSource":"system"}`. **No emitter changes needed** — the publisher swap covers all.
+
+### Out of scope
+- Changing the 13 emitters; cross-process pub/sub (LISTEN/NOTIFY) for engine→Api subscriber fan-out (the endpoint's in-process publish only reaches Tamma.Api subscribers in that process — accepted, matches `domain_events`); at-least-once buffering/cursor for platform events (direct POST per call; degrade-to-log on failure — proportionate for low-volume lifecycle/analytics events). `RegisterSecrets`, deleting `NullPlatformEventPublisher` (keep it; tests/fallback may reference it).
+
+---
+
+## File Structure
+
+**Modify:**
+- `apps/tamma-elsa/src/Tamma.Api/Dtos/Engine/EngineDtos.cs` — add `AppendPlatformEventsRequest` + `PlatformEventRecord`.
+- `apps/tamma-elsa/src/Tamma.Api/Endpoints/EngineEndpoints.cs` — add `AppendPlatformEvents` handler.
+- `apps/tamma-elsa/src/Tamma.Api/Program.cs` — map `POST /api/engine/platform-events` (`EngineServiceOnly`).
+- `apps/tamma-elsa/src/Tamma.Activities/LlmCall/Models/TammaApiModels.cs` — add engine wire DTOs.
+- `apps/tamma-elsa/src/Tamma.Activities/LlmCall/TammaApiClient.cs` — add `AppendPlatformEventsAsync`.
+- `apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs` — swap the publisher registration (L290-292).
+
+**Create:**
+- `apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/EngineApiPlatformEventPublisher.cs`
+- Tests: `apps/tamma-elsa/tests/Tamma.Api.Tests/Engine/AppendPlatformEventsEndpointTests.cs`, `apps/tamma-elsa/tests/Tamma.Activities.Tests/.../EngineApiPlatformEventPublisherTests.cs` (+ a client test alongside the existing `AppendEventsAsync` tests).
+
+---
+
+## Task 1: `POST /api/engine/platform-events` endpoint + DTOs
+
+**Files:**
+- Modify: `apps/tamma-elsa/src/Tamma.Api/Dtos/Engine/EngineDtos.cs`, `apps/tamma-elsa/src/Tamma.Api/Endpoints/EngineEndpoints.cs`, `apps/tamma-elsa/src/Tamma.Api/Program.cs:2222` (area).
+- Test: `apps/tamma-elsa/tests/Tamma.Api.Tests/Engine/AppendPlatformEventsEndpointTests.cs`.
+
+**Interfaces:**
+- Produces: `POST /api/engine/platform-events` accepting `AppendPlatformEventsRequest(List<PlatformEventRecord> Events)`; `PlatformEventRecord(Guid Id, string Type, Guid? TenantId, Guid? UserId, Dictionary<string,string?>? Tags, JsonElement? Metadata, JsonElement? Data, DateTime? CreatedAt)`. Returns `201` on full success, `502 partial_append_failure` if any event throws, `400` on empty batch. `EngineServiceOnly`.
+
+- [ ] **Step 1: Add the DTOs** to `EngineDtos.cs` (mirror `AppendEventsRequest`/`EngineEventRecord` but platform-shaped — note `Type` not `EventType`, and the nullable `TenantId`/`UserId` carried in the body):
+
+```csharp
+/// <summary>Batch of platform (control-plane) events from the engine, written to platform_events.</summary>
+public record AppendPlatformEventsRequest(List<PlatformEventRecord> Events);
+
+/// <summary>One platform event. Id is the stable idempotency key (Guid.Empty → server assigns).
+/// TenantId is nullable and carried in the body (platform_events is cross-tenant), unlike domain_events.</summary>
+public record PlatformEventRecord(
+    Guid Id,
+    string Type,
+    Guid? TenantId,
+    Guid? UserId,
+    Dictionary<string, string?>? Tags,
+    System.Text.Json.JsonElement? Metadata,
+    System.Text.Json.JsonElement? Data,
+    DateTime? CreatedAt);
+```
+
+- [ ] **Step 2: Write the failing endpoint test** in `AppendPlatformEventsEndpointTests.cs` (mirror the existing `domain_events` endpoint test style — `ApiTestFixture` in Development mode is permissive for auth; for the auth-rejection assertion follow how an `EngineServiceOnly`-gated endpoint is tested elsewhere, e.g. an existing `/api/engine/events` auth test, or assert the route requires the policy):
+
+```csharp
+[Test]
+public async Task AppendPlatformEvents_PersistsRowToPlatformEvents_AndIsIdempotent()
+{
+    var id = Guid.NewGuid();
+    var tenantId = Guid.NewGuid();
+    var body = new
+    {
+        events = new[] { new {
+            id, type = "TENANT.DELETED.SUCCESS", tenantId, userId = (Guid?)null,
+            tags = new Dictionary<string,string?> { ["source"] = "cleanup-workflow" },
+            metadata = (object?)null, data = (object?)null, createdAt = (DateTime?)null } }
+    };
+    var resp = await Client.PostAsJsonAsync("/api/engine/platform-events", body);
+    Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.Created));
+
+    // re-POST the SAME id → dedup no-op, still 201, still exactly one row
+    var resp2 = await Client.PostAsJsonAsync("/api/engine/platform-events", body);
+    Assert.That(resp2.StatusCode, Is.EqualTo(HttpStatusCode.Created));
+
+    await using var db = NewControlPlaneDbContext(); // per the fixture's helper
+    var rows = await db.PlatformEvents.Where(e => e.Id == id).ToListAsync();
+    Assert.That(rows, Has.Count.EqualTo(1));
+    Assert.That(rows[0].Type, Is.EqualTo("TENANT.DELETED.SUCCESS"));
+    Assert.That(rows[0].TenantId, Is.EqualTo(tenantId));
+}
+```
+
+(Use the fixture's actual control-plane DbContext accessor; copy it from a neighboring test that reads `platform_events`/control-plane rows. If `ApiTestFixture` runs auth-permissive, add a second test that the route carries `EngineServiceOnly` exactly as the existing `/api/engine/events` test does — or assert a tenant-user token gets 403 if that harness exists.)
+
+- [ ] **Step 3: Run it to verify it fails**
+
+Run: `sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Api.Tests --filter FullyQualifiedName~AppendPlatformEventsEndpointTests"`
+Expected: FAIL (route 404 / handler missing).
+
+- [ ] **Step 4: Add the handler** to `EngineEndpoints.cs` (mirror `AppendEvents`; resolve `IPlatformEventPublisher` so the append is persisted + fanned out in-process):
+
+```csharp
+public static async Task<IResult> AppendPlatformEvents(
+    AppendPlatformEventsRequest req,
+    Tamma.Data.Abstractions.IPlatformEventPublisher publisher)
+{
+    if (req?.Events is null || req.Events.Count == 0)
+        return Results.BadRequest(new { error = "empty_batch" });
+
+    var failures = new List<object>();
+    var persisted = 0;
+    foreach (var e in req.Events)
+    {
+        if (string.IsNullOrWhiteSpace(e.Type)) { failures.Add(new { id = e.Id, error = "empty_type" }); continue; }
+        try
+        {
+            var evt = new Tamma.Data.Entities.PlatformEvent
+            {
+                Id = e.Id == Guid.Empty ? Guid.NewGuid() : e.Id,
+                Type = e.Type,
+                TenantId = e.TenantId,
+                UserId = e.UserId,
+                Tags = e.Tags is null ? "{}" : System.Text.Json.JsonSerializer.Serialize(e.Tags),
+                Metadata = e.Metadata.HasValue ? e.Metadata.Value.GetRawText() : "{}",
+                Data = e.Data.HasValue ? e.Data.Value.GetRawText() : "{}",
+                CreatedAt = e.CreatedAt ?? DateTime.UtcNow,
+            };
+            // null result = idempotent dedup no-op = success (already persisted).
+            await publisher.AppendAndPublishAsync(evt);
+            persisted++;
+        }
+        catch (Exception ex)
+        {
+            failures.Add(new { id = e.Id, type = e.Type, error = ex.Message });
+        }
+    }
+
+    if (failures.Count > 0)
+        return Results.Json(new { error = "partial_append_failure", persisted, failed = failures.Count, failures },
+            statusCode: StatusCodes.Status502BadGateway);
+
+    return Results.Created("/api/engine/platform-events", new { ok = true, persisted });
+}
+```
+
+> Confirm `PlatformEvent`'s `Tags`/`Metadata`/`Data` are `string` (jsonb-as-string) per the entity — serialize accordingly. Match the exact column types from the appendix.
+
+- [ ] **Step 5: Map the route** in `Program.cs` next to the `/events` line (≈L2222), gated `EngineServiceOnly`:
+
+```csharp
+engine.MapPost("/platform-events", EngineEndpoints.AppendPlatformEvents)
+    .RequireAuthorization("EngineServiceOnly");
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: same filter as Step 3 → PASS. Then run the full `Tamma.Api.Tests` project → green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/tamma-elsa/src/Tamma.Api/Dtos/Engine/EngineDtos.cs \
+        apps/tamma-elsa/src/Tamma.Api/Endpoints/EngineEndpoints.cs \
+        apps/tamma-elsa/src/Tamma.Api/Program.cs \
+        apps/tamma-elsa/tests/Tamma.Api.Tests/Engine/AppendPlatformEventsEndpointTests.cs
+git commit -m "feat(platform-events): POST /api/engine/platform-events callback (EngineServiceOnly)"
+```
+
+---
+
+## Task 2: Engine-side client `TammaApiClient.AppendPlatformEventsAsync`
+
+**Files:**
+- Modify: `apps/tamma-elsa/src/Tamma.Activities/LlmCall/Models/TammaApiModels.cs`, `apps/tamma-elsa/src/Tamma.Activities/LlmCall/TammaApiClient.cs`.
+- Test: alongside the existing `AppendEventsAsync` client tests in `Tamma.Activities.Tests`.
+
+**Interfaces:**
+- Consumes: the Task-1 endpoint contract (`/api/engine/platform-events`, `AppendPlatformEventsRequest`).
+- Produces: `TammaApiClient.AppendPlatformEventsAsync(IReadOnlyList<Models.PlatformEventRecord> events, CancellationToken ct = default) → Task<bool>` (true only on 2xx). Engine wire DTOs `Models.AppendPlatformEventsRequest` / `Models.PlatformEventRecord` (camelCase mirror).
+
+- [ ] **Step 1: Add the engine wire DTOs** to `TammaApiModels.cs` (mirror `Models.EngineEventRecord`'s style):
+
+```csharp
+public sealed record AppendPlatformEventsRequest(IReadOnlyList<PlatformEventRecord> Events);
+
+public sealed record PlatformEventRecord(
+    Guid Id,
+    string Type,
+    Guid? TenantId,
+    Guid? UserId,
+    IReadOnlyDictionary<string, string?>? Tags,
+    System.Text.Json.JsonElement? Metadata,
+    System.Text.Json.JsonElement? Data,
+    DateTime? CreatedAt);
+```
+
+- [ ] **Step 2: Write the failing client test** (mirror the existing `AppendEventsAsync` test — construct `TammaApiClient` over a fake `HttpMessageHandler` that records the request + returns `201`/`500`):
+
+```csharp
+[Test]
+public async Task AppendPlatformEventsAsync_Posts_To_PlatformEvents_Endpoint_And_Returns_True_On_2xx()
+{
+    HttpRequestMessage? captured = null;
+    var handler = new StubHandler((req) => { captured = req; return new HttpResponseMessage(HttpStatusCode.Created); });
+    var client = NewTammaApiClient(handler); // mirror the AppendEventsAsync test's construction
+    var evt = new Models.PlatformEventRecord(Guid.NewGuid(), "TENANT.DELETED.SUCCESS", Guid.NewGuid(), null, null, null, null, null);
+
+    var ok = await client.AppendPlatformEventsAsync(new[] { evt }, CancellationToken.None);
+
+    Assert.That(ok, Is.True);
+    Assert.That(captured!.RequestUri!.AbsolutePath, Is.EqualTo("/api/engine/platform-events"));
+}
+
+[Test]
+public async Task AppendPlatformEventsAsync_Returns_False_On_Non2xx()
+{
+    var client = NewTammaApiClient(new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError)));
+    var ok = await client.AppendPlatformEventsAsync(
+        new[] { new Models.PlatformEventRecord(Guid.NewGuid(), "X", null, null, null, null, null, null) }, default);
+    Assert.That(ok, Is.False);
+}
+```
+
+(Reuse whatever stub-handler + client-construction helper the existing `AppendEventsAsync` tests use; do not invent a new harness.)
+
+- [ ] **Step 3: Run to verify failure** — `sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Activities.Tests --filter FullyQualifiedName~AppendPlatformEventsAsync"` → FAIL (method missing).
+
+- [ ] **Step 4: Implement `AppendPlatformEventsAsync`** in `TammaApiClient.cs` (mirror `AppendEventsAsync` L238-273; no `X-Tenant-Id` header needed — `TenantId` travels per-event in the body, and `EngineServiceOnly` is satisfied by the service Bearer token):
+
+```csharp
+public async Task<bool> AppendPlatformEventsAsync(
+    IReadOnlyList<Models.PlatformEventRecord> events,
+    CancellationToken ct = default)
+{
+    if (events is null || events.Count == 0) return true;
+    try
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"{_baseUrl}/api/engine/platform-events")
+        {
+            Content = JsonContent.Create(new Models.AppendPlatformEventsRequest(events)),
+        };
+        using var resp = await _http.SendAsync(request, ct).ConfigureAwait(false);
+        if (!resp.IsSuccessStatusCode)
+        {
+            _logger?.LogWarning("platform_events.append_failed status={Status} count={Count}",
+                (int)resp.StatusCode, events.Count);
+            return false;
+        }
+        return true;
+    }
+    catch (Exception ex) when (ex is not OperationCanceledException)
+    {
+        _logger?.LogWarning(ex, "platform_events.append_error count={Count}", events.Count);
+        return false;
+    }
+}
+```
+
+> Match the exact field names this class already uses (`_baseUrl`, `_http`/the named client, `_logger`) — read `AppendEventsAsync` and copy its transport + auth approach verbatim.
+
+- [ ] **Step 5: Run the tests → PASS.** Then the full `Tamma.Activities.Tests` project → green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/tamma-elsa/src/Tamma.Activities/LlmCall/Models/TammaApiModels.cs \
+        apps/tamma-elsa/src/Tamma.Activities/LlmCall/TammaApiClient.cs \
+        apps/tamma-elsa/tests/Tamma.Activities.Tests
+git commit -m "feat(platform-events): engine client AppendPlatformEventsAsync"
+```
+
+---
+
+## Task 3: Real engine publisher + replace the Null seam
+
+**Files:**
+- Create: `apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/EngineApiPlatformEventPublisher.cs`.
+- Modify: `apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs:290-292`.
+- Test: `apps/tamma-elsa/tests/Tamma.Activities.Tests/.../EngineApiPlatformEventPublisherTests.cs`.
+
+**Interfaces:**
+- Consumes: `TammaApiClient.AppendPlatformEventsAsync` (Task 2), `IPlatformEventPublisher` (`Tamma.Data.Abstractions`), `PlatformEvent` (`Tamma.Data.Entities`).
+- Produces: `EngineApiPlatformEventPublisher : IPlatformEventPublisher` — `AppendAndPublishAsync(evt, ct)` maps `PlatformEvent`→`Models.PlatformEventRecord`, POSTs via `TammaApiClient`, returns `evt` on success / `null` + WARN on failure. Resolves `TammaApiClient` per-call (avoid the singleton-captures-typed-client trap).
+
+- [ ] **Step 1: Write the failing publisher test** (use a real or mocked `TammaApiClient` over a stub handler returning 201/500; assert the record shape + the degrade path):
+
+```csharp
+[Test]
+public async Task AppendAndPublishAsync_Posts_Event_And_Returns_It_On_Success()
+{
+    HttpRequestMessage? captured = null;
+    var api = NewTammaApiClient(new StubHandler(req => { captured = req; return new HttpResponseMessage(HttpStatusCode.Created); }));
+    var pub = NewPublisher(api); // see ctor note below
+    var evt = new PlatformEvent { Id = Guid.NewGuid(), Type = "TENANT.DELETED.SUCCESS", TenantId = Guid.NewGuid(), Tags = "{}", Metadata = "{}", Data = "{}" };
+
+    var result = await pub.AppendAndPublishAsync(evt, CancellationToken.None);
+
+    Assert.That(result, Is.SameAs(evt));
+    Assert.That(captured!.RequestUri!.AbsolutePath, Is.EqualTo("/api/engine/platform-events"));
+}
+
+[Test]
+public async Task AppendAndPublishAsync_Returns_Null_And_Does_Not_Throw_On_Post_Failure()
+{
+    var api = NewTammaApiClient(new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError)));
+    var pub = NewPublisher(api);
+    var evt = new PlatformEvent { Id = Guid.NewGuid(), Type = "X", Tags = "{}", Metadata = "{}", Data = "{}" };
+    var result = await pub.AppendAndPublishAsync(evt, CancellationToken.None);
+    Assert.That(result, Is.Null); // degraded: logged, not thrown (mirrors Null seam philosophy)
+}
+```
+
+- [ ] **Step 2: Run → FAIL** (`sg docker -c "dotnet test apps/tamma-elsa/tests/Tamma.Activities.Tests --filter FullyQualifiedName~EngineApiPlatformEventPublisher"`).
+
+- [ ] **Step 3: Implement `EngineApiPlatformEventPublisher`** (resolve `TammaApiClient` per-call via `IServiceScopeFactory` — mirror `PlatformEventPublisher`'s scope-resolution to avoid a singleton capturing the transient typed client):
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.LlmCall;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+
+namespace Tamma.Activities.TenantLifecycle;
+
+/// <summary>
+/// Engine-side <see cref="IPlatformEventPublisher"/>: the engine has no control-plane
+/// DB access, so it POSTs platform events to POST /api/engine/platform-events (mirroring
+/// the domain_events drain). Persistence + idempotency happen server-side. On POST failure
+/// it logs and returns null (degraded, not throwing) — same philosophy as the prior
+/// NullPlatformEventPublisher, but events now land durably when the API is reachable.
+/// </summary>
+public sealed class EngineApiPlatformEventPublisher : IPlatformEventPublisher
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<EngineApiPlatformEventPublisher> _logger;
+
+    public EngineApiPlatformEventPublisher(
+        IServiceScopeFactory scopeFactory, ILogger<EngineApiPlatformEventPublisher> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    public async Task<PlatformEvent?> AppendAndPublishAsync(PlatformEvent evt, CancellationToken ct = default)
+    {
+        if (evt is null) return null;
+        using var scope = _scopeFactory.CreateScope();
+        var api = scope.ServiceProvider.GetRequiredService<TammaApiClient>();
+
+        var record = new TammaApiClient.Models.PlatformEventRecord(  // use the actual Models namespace path
+            evt.Id,
+            evt.Type,
+            evt.TenantId,
+            evt.UserId,
+            ParseTags(evt.Tags),
+            ToJsonElement(evt.Metadata),
+            ToJsonElement(evt.Data),
+            evt.CreatedAt == default ? null : evt.CreatedAt);
+
+        var ok = await api.AppendPlatformEventsAsync(new[] { record }, ct).ConfigureAwait(false);
+        if (!ok)
+        {
+            _logger.LogWarning("platform_event.post_failed type={Type} tenantId={TenantId}", evt.Type, evt.TenantId);
+            return null;
+        }
+        return evt;
+    }
+
+    private static IReadOnlyDictionary<string, string?>? ParseTags(string? json) =>
+        string.IsNullOrWhiteSpace(json) || json == "{}" ? null
+            : System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, string?>>(json);
+
+    private static System.Text.Json.JsonElement? ToJsonElement(string? json) =>
+        string.IsNullOrWhiteSpace(json) || json == "{}" ? (System.Text.Json.JsonElement?)null
+            : System.Text.Json.JsonDocument.Parse(json).RootElement.Clone();
+}
+```
+
+> Fix the `Models.PlatformEventRecord` reference to the real namespace (`Tamma.Activities.LlmCall.Models.PlatformEventRecord`). Confirm `PlatformEvent.Tags/Metadata/Data` are `string` (jsonb-as-string); if they're already `JsonElement`/objects, adjust the mapping. The ctor-injection style + `IServiceScopeFactory` mirrors `PlatformEventPublisher`.
+
+- [ ] **Step 4: Swap the registration** in `Tamma.ElsaServer/Program.cs:290-292` — replace the `NullPlatformEventPublisher` `TryAddSingleton` with the real publisher:
+
+```csharp
+// Real engine→API platform-events publisher (replaces the NullPlatformEventPublisher
+// no-op seam): tenant-lifecycle + analytics activities now POST to
+// /api/engine/platform-events instead of dropping. See EngineApiPlatformEventPublisher.
+Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions
+    .TryAddSingleton<Tamma.Data.Abstractions.IPlatformEventPublisher,
+        Tamma.Activities.TenantLifecycle.EngineApiPlatformEventPublisher>(builder.Services);
+```
+
+Keep the `NullPlatformEventPublisher` class (do not delete — it documents the seam and may be referenced by tests). Update the surrounding comment (L280-289) to say the callback now exists.
+
+- [ ] **Step 5: Add a wire-up test** confirming the engine resolves the real publisher (not Null). If the engine has a DI-composition test harness, assert `IPlatformEventPublisher` resolves to `EngineApiPlatformEventPublisher`. If not, this is covered by the unit tests + Step 3 — note that in the report.
+
+- [ ] **Step 6: Run the publisher tests → PASS;** build the solution → 0 errors; run the full `Tamma.Activities.Tests` project → green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/EngineApiPlatformEventPublisher.cs \
+        apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs \
+        apps/tamma-elsa/tests/Tamma.Activities.Tests
+git commit -m "feat(platform-events): real engine publisher replaces NullPlatformEventPublisher"
+```
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Endpoint reachable by tenant users (audit forgery / spend) | `EngineServiceOnly` (service-principal only) copied verbatim from the `/events` line; Task 1 includes the auth-rejection assertion (or route-policy assertion). |
+| Singleton publisher captures a transient typed `TammaApiClient` (stale handler) | Resolve `TammaApiClient` per-call via `IServiceScopeFactory` (mirrors `PlatformEventPublisher`). |
+| Lost audit event on a transient API failure | Degrade-to-WARN (`platform_event.post_failed`) — strictly better than today's always-drop; the authoritative lifecycle state is still the `tenants` columns the terminals write directly. At-least-once buffering is a documented follow-up, out of scope. |
+| Duplicate rows on activity retry for non-`PROVISION.STEP` types | Stable `Guid Id` per event gives PK-level dedup (`AppendAsync` returns null on unique-violation); the partial unique index adds step/attempt dedup for `TENANT.PROVISION.STEP_*`. Cross-retry dedup for other types is pre-existing emitter behavior, out of scope. |
+| jsonb column mapping (`Tags`/`Metadata`/`Data` string vs object) | Task 1/3 steps say to confirm the entity's actual types and serialize/parse accordingly. |
+| Engine in-process subscribers don't fire (endpoint publishes in Tamma.Api, not the engine) | Accepted + same as `domain_events`; the endpoint's `AppendAndPublishAsync` fans out to the Tamma.Api in-process subscribers (where they live). Cross-process fan-out is a separate documented concern. |
+
+## Acceptance criteria
+
+1. `POST /api/engine/platform-events` exists, `EngineServiceOnly`, accepts a batch, persists to `platform_events` via `IPlatformEventPublisher.AppendAndPublishAsync`, idempotent on stable `Id` (re-POST → one row, 201), partial failure → 502, empty batch → 400; covered by an endpoint test.
+2. `TammaApiClient.AppendPlatformEventsAsync` POSTs to it (true on 2xx, false otherwise); covered by a client test.
+3. `EngineApiPlatformEventPublisher` replaces `NullPlatformEventPublisher` in the engine (`ElsaServer/Program.cs`); resolves `TammaApiClient` per-call; returns the event on success and degrades to WARN+null on failure; covered by a publisher test. All 13 emitters now flow through it (no emitter changes).
+4. Build 0 errors; full `Tamma.Api.Tests` + `Tamma.Activities.Tests` green; **no schema change / no migration**.
+
+## Self-review
+
+- Spec coverage: the memory's ask ("mirror #373 → platform_events via `IPlatformEventRepository`, `EngineServiceOnly`, replace `NullPlatformEventPublisher`") maps to Tasks 1/3; the engine client is Task 2. The endpoint uses `IPlatformEventPublisher` (which wraps the repo) rather than the bare repo to also fan out to in-process subscribers — a deliberate, justified deviation noted in Global Constraints.
+- Type consistency: `PlatformEventRecord` field order is identical in the API DTO (Task 1) and the engine wire DTO (Task 2); the publisher (Task 3) maps `PlatformEvent`→that record.
+- Highest blast radius: Task 3's `Program.cs` swap (changes behavior for all 13 emitters) — gated behind the publisher unit tests + the build; the change is additive (dropped → POSTed) and degrades safely.


### PR DESCRIPTION
## Engine → `platform_events` callback — durable control-plane audit

The Elsa engine (`Tamma.ElsaServer`) hosts the workflow runtime but has **no control-plane DB access** by design, so 13 tenant-lifecycle + analytics emitters were silently dropped by a `NullPlatformEventPublisher`. This adds a durable round-trip path (mirroring the deployed #373 `domain_events` callback), giving CreateTenant / DeleteTenant / CleanUpFailedTenant / HourlyAnalyticsRollup real `platform_events` audit rows.

Plan: `docs/superpowers/plans/2026-06-29-engine-platform-events-callback.md` (subagent-driven: per-task TDD + two-stage review + whole-branch review).

### What changed (3 pieces, one swap covers all 13 emitters)

1. **`POST /api/engine/platform-events`** (`EngineEndpoints.AppendPlatformEvents`, **`EngineServiceOnly`**) → `IPlatformEventPublisher.AppendAndPublishAsync` (idempotent persist to `platform_events` + in-process fan-out to the Tamma.Api subscribers, which live in the same process). Each event carries its own nullable `TenantId` in the body — the key difference from `domain_events` (tenant-lifecycle events about tenant X must land in the **central** table, which stays reachable after tenant X is deleted; the per-tenant `domain_events` store does not).
2. **`TammaApiClient.AppendPlatformEventsAsync`** — engine-side client + wire DTOs (field-for-field match with the API DTO; verified round-trip with `TenantId` intact).
3. **`EngineApiPlatformEventPublisher`** replaces `NullPlatformEventPublisher` in `Tamma.ElsaServer/Program.cs`. Resolves `TammaApiClient` per-call via `IServiceScopeFactory` (no singleton-captures-typed-client trap), and is **throw-proof** — the entire body is wrapped so a POST/parse/DI failure logs + returns null instead of throwing. This is load-bearing: the lifecycle activities `await` the emit **un-guarded**, so a throwing publisher would abort the provisioning/deletion step. Degrades to a WARN on failure (never fatal to the workflow).

No emitter changes — all 13 resolve `IPlatformEventPublisher` and call `AppendAndPublishAsync`, so the one swap activates them all. `RotateSecret` (rides the `domain_events` drain) and `MoveTenant` (Api-side) were already covered — untouched.

### Verification

- Build **0 errors**; `Tamma.Api.Tests` **3782/0**; `Tamma.Activities.Tests` **2098/0**.
- Auth is `EngineServiceOnly` (service principal only — a tenant-user JWT is rejected; no audit-event forgery). Body `TenantId` is data on a cross-tenant table, used for no auth/routing decision (no spoofing surface).
- Throw-proofing proven by a malformed-input test (`Tags="[1,2,3]"` → `JsonException` caught → null, no throw) — the per-task green suite missed this until the review forced a test that actually exercises the parse branch.
- **No schema change** (the `platform_events` table already exists; no migration, no `TammaModelConfiguration` edit).

### Known limitation (documented) + follow-up

PK-level dedup ("re-POST same Id → one row") is **dormant in production**: the real emitters send `Guid.Empty`, so the server mints a fresh Id per POST. The only end-to-end cross-retry guard is the partial unique index on `TENANT.PROVISION.STEP_*` `(tenant_id, type, tags->>'step', tags->>'attempt')` (confirmed to survive the round-trip). `DELETE.STEP_*`, terminal, and analytics events can duplicate on a lost-success retry. This is strictly better than today's drop-everything, and the authoritative lifecycle state is the `tenants` columns the terminals write directly. **Follow-up filed in the plan**: give emitters deterministic Ids (or natural-key indexes) + optional at-least-once buffering before any exactly-once consumer (aggregation/billing) reads `platform_events`.

Merging does not deploy (the `qa-*` tag gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
