### PR TITLE
Thread tenantId through 5 sub-workflows' llm-call dispatches (Bucket B)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ContextGatheringWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ContextGatheringWorkflow.cs
@@ -40,6 +40,7 @@ public class ContextGatheringWorkflow : WorkflowBase
         // ================================================================
         // Variables
         // ================================================================
+        var tenantId = builder.WithVariable<string>("TenantId", "");
         var repository = builder.WithVariable<string>("Repository", "");
         var issueNumber = builder.WithVariable<int>("IssueNumber", 0);
         var workItemJson = builder.WithVariable<string>("WorkItemJson", "");
@@ -71,6 +72,7 @@ public class ContextGatheringWorkflow : WorkflowBase
                 var repo = ctx.GetInput<string>("repository") ?? "";
                 issueNumber.Set(ctx, ctx.GetInput<int>("issueNumber"));
                 workItemJson.Set(ctx, ctx.GetInput<string>("workItemJson") ?? "");
+                tenantId.Set(ctx, ctx.GetInput<string>("tenantId") ?? "");
                 var itemJson = ctx.GetInput<string>("workItemJson") ?? "";
                 var type = "feature";
                 if (itemJson.Contains("\"type\":\"bug\"", System.StringComparison.OrdinalIgnoreCase)) type = "bug";
@@ -90,7 +92,7 @@ public class ContextGatheringWorkflow : WorkflowBase
         // Dev Scan
         var devScan = RoleScan("DevScan", "Dev Scan", AgentRole.Developer,
             repository, workItemJson, workItemType, "{}",
-            llmResult);
+            tenantId, llmResult);
         var extractDev = Extract(devFindings, llmResult, "ExtractDev", "Extract Dev Findings");
         var storeDev = StoreRole("StoreDev", "Store Dev", AgentRole.Developer.ToWire(),
             repository, issueNumber, devFindings, contextIds);
@@ -99,7 +101,7 @@ public class ContextGatheringWorkflow : WorkflowBase
         var qaScan = RoleScan("QAScan", "QA Scan", AgentRole.Tester,
             repository, workItemJson, workItemType,
             ctx => devFindings.Get(ctx),
-            llmResult);
+            tenantId, llmResult);
         var extractQA = Extract(qaFindings, llmResult, "ExtractQA", "Extract QA Findings");
         var storeQA = StoreRole("StoreQA", "Store QA", AgentRole.Tester.ToWire(),
             repository, issueNumber, qaFindings, contextIds);
@@ -112,7 +114,7 @@ public class ContextGatheringWorkflow : WorkflowBase
                 ["dev"] = devFindings.Get(ctx),
                 ["qa"] = qaFindings.Get(ctx),
             }),
-            llmResult);
+            tenantId, llmResult);
         var extractSec = Extract(securityFindings, llmResult, "ExtractSec", "Extract Security Findings");
         var storeSec = StoreRole("StoreSec", "Store Security", AgentRole.Security.ToWire(),
             repository, issueNumber, securityFindings, contextIds);
@@ -126,7 +128,7 @@ public class ContextGatheringWorkflow : WorkflowBase
                 ["qa"] = qaFindings.Get(ctx),
                 ["security"] = securityFindings.Get(ctx),
             }),
-            llmResult);
+            tenantId, llmResult);
         var extractDevOps = Extract(devopsFindings, llmResult, "ExtractDevOps", "Extract DevOps Findings");
         var storeDevOps = StoreRole("StoreDevOps", "Store DevOps", AgentRole.Devops.ToWire(),
             repository, issueNumber, devopsFindings, contextIds);
@@ -141,7 +143,7 @@ public class ContextGatheringWorkflow : WorkflowBase
                 ["security"] = securityFindings.Get(ctx),
                 ["devops"] = devopsFindings.Get(ctx),
             }),
-            llmResult);
+            tenantId, llmResult);
         var extractArch = Extract(architectFindings, llmResult, "ExtractArch", "Extract Architect Findings");
         var storeArch = StoreRole("StoreArch", "Store Architect", AgentRole.Architect.ToWire(),
             repository, issueNumber, architectFindings, contextIds);
@@ -157,6 +159,7 @@ public class ContextGatheringWorkflow : WorkflowBase
             {
                 ["role"] = AgentRole.ProductOwner.ToWire(),
                 ["action"] = AgentAction.SummarizeStakeholder.ToWire(),
+                ["tenantId"] = tenantId.Get(ctx),
                 ["variables"] = new Dictionary<string, object>
                 {
                     ["workItemJson"] = workItemJson.Get(ctx),
@@ -281,6 +284,7 @@ public class ContextGatheringWorkflow : WorkflowBase
         string id, string name, AgentRole role,
         Variable<string> repository, Variable<string> workItemJson,
         Variable<string> workItemType, string previousFindings,
+        Variable<string> tenantId,
         Variable<IDictionary<string, object>?> result)
     {
         var dispatch = new DispatchWorkflow
@@ -291,6 +295,7 @@ public class ContextGatheringWorkflow : WorkflowBase
             {
                 ["role"] = role.ToWire(),
                 ["action"] = AgentAction.ContextScan.ToWire(),
+                ["tenantId"] = tenantId.Get(ctx),
                 ["variables"] = new Dictionary<string, object>
                 {
                     ["workItemJson"] = workItemJson.Get(ctx),
@@ -312,6 +317,7 @@ public class ContextGatheringWorkflow : WorkflowBase
         Variable<string> repository, Variable<string> workItemJson,
         Variable<string> workItemType,
         Func<Elsa.Expressions.Models.ExpressionExecutionContext, string> previousFindingsBuilder,
+        Variable<string> tenantId,
         Variable<IDictionary<string, object>?> result)
     {
         var dispatch = new DispatchWorkflow
@@ -322,6 +328,7 @@ public class ContextGatheringWorkflow : WorkflowBase
             {
                 ["role"] = role.ToWire(),
                 ["action"] = AgentAction.ContextScan.ToWire(),
+                ["tenantId"] = tenantId.Get(ctx),
                 ["variables"] = new Dictionary<string, object>
                 {
                     ["workItemJson"] = workItemJson.Get(ctx),

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/MentorshipWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/MentorshipWorkflow.cs
@@ -52,6 +52,7 @@ public class MentorshipWorkflow : WorkflowBase
         // =====================================================================
         // Workflow Variables
         // =====================================================================
+        var tenantId = builder.WithVariable<string>("TenantId", "");
         var sessionId = builder.WithVariable<Guid>("SessionId", default(Guid));
         var storyId = builder.WithVariable<string>("StoryId", "");
         var juniorId = builder.WithVariable<string>("JuniorId", "");
@@ -79,6 +80,7 @@ public class MentorshipWorkflow : WorkflowBase
             Variable = maxBasicRetries,
             Value = new Input<object?>(ctx =>
             {
+                tenantId.Set(ctx, ctx.GetInput<string>("tenantId") ?? "");
                 var inputBasic = ctx.GetInput<int?>("maxBasicRetries");
                 if (inputBasic.HasValue) maxBasicRetries.Set(ctx, inputBasic.Value);
                 var inputDebug = ctx.GetInput<int?>("maxDebugRetries");
@@ -352,7 +354,8 @@ public class MentorshipWorkflow : WorkflowBase
                 ["agentRole"] = AgentRole.SeniorDeveloper.ToWire(),
                 ["action"] = AgentAction.MentorFeedback.ToWire(),
                 ["taskPrompt"] = "Generate plan decomposition",
-                ["sessionId"] = sessionId.Get(context).ToString()
+                ["sessionId"] = sessionId.Get(context).ToString(),
+                ["tenantId"] = tenantId.Get(context),
             }),
             WaitForCompletion = new(true)
         };
@@ -369,7 +372,8 @@ public class MentorshipWorkflow : WorkflowBase
                 ["SessionId"] = sessionId.Get(context),
                 ["StoryId"] = storyId.Get(context) ?? "",
                 ["Purpose"] = "Assessment",
-                ["MaxContextSize"] = 50000
+                ["MaxContextSize"] = 50000,
+                ["tenantId"] = tenantId.Get(context),
             }),
             WaitForCompletion = new(true)
         };

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/PlanReviewWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/PlanReviewWorkflow.cs
@@ -58,6 +58,7 @@ public class PlanReviewWorkflow : WorkflowBase
         // ================================================================
         // Variables
         // ================================================================
+        var tenantId = builder.WithVariable<string>("TenantId", "");
         var repository = builder.WithVariable<string>("Repository", "");
         var issueNumber = builder.WithVariable<int>("IssueNumber", 0);
         var planJson = builder.WithVariable<string>("PlanJson", "");
@@ -145,6 +146,7 @@ public class PlanReviewWorkflow : WorkflowBase
                 planJson.Set(ctx, ctx.GetInput<string>("planJson") ?? "");
                 contextIds.Set(ctx, ctx.GetInput<string>("contextIds") ?? "[]");
                 workItemJson.Set(ctx, ctx.GetInput<string>("workItemJson") ?? "");
+                tenantId.Set(ctx, ctx.GetInput<string>("tenantId") ?? "");
                 roundCount.Set(ctx, 1);
                 var inputMaxRounds = ctx.GetInput<int?>("maxRetries");
                 if (inputMaxRounds.HasValue) maxRounds.Set(ctx, inputMaxRounds.Value);
@@ -163,7 +165,7 @@ public class PlanReviewWorkflow : WorkflowBase
 
         // Architect review
         var phase1ArchCall = RoleReviewDispatch("Phase1ArchReview", "Phase 1: Architect Review", AgentRole.Architect,
-            repository, planJson, contextIds, workItemJson, allReviewsJson, llmResult);
+            repository, planJson, contextIds, workItemJson, allReviewsJson, tenantId, llmResult);
         var extractPhase1Arch = ExtractReview(architectReview, llmResult, "architect",
             "ExtractPhase1Arch", "Extract Phase 1 Architect Review");
         var storePhase1Arch = StoreReviewRole("StorePhase1Arch", "Store Phase 1 Architect Review", "architect",
@@ -171,7 +173,7 @@ public class PlanReviewWorkflow : WorkflowBase
 
         // Developer review
         var phase1DevCall = RoleReviewDispatch("Phase1DevReview", "Phase 1: Developer Review", AgentRole.Developer,
-            repository, planJson, contextIds, workItemJson, allReviewsJson, llmResult);
+            repository, planJson, contextIds, workItemJson, allReviewsJson, tenantId, llmResult);
         var extractPhase1Dev = ExtractReview(developerReview, llmResult, "developer",
             "ExtractPhase1Dev", "Extract Phase 1 Developer Review");
         var storePhase1Dev = StoreReviewRole("StorePhase1Dev", "Store Phase 1 Developer Review", "developer",
@@ -179,7 +181,7 @@ public class PlanReviewWorkflow : WorkflowBase
 
         // Tester review
         var phase1TesterCall = RoleReviewDispatch("Phase1TesterReview", "Phase 1: Tester Review", AgentRole.Tester,
-            repository, planJson, contextIds, workItemJson, allReviewsJson, llmResult);
+            repository, planJson, contextIds, workItemJson, allReviewsJson, tenantId, llmResult);
         var extractPhase1Tester = ExtractReview(testerReview, llmResult, "tester",
             "ExtractPhase1Tester", "Extract Phase 1 Tester Review");
         var storePhase1Tester = StoreReviewRole("StorePhase1Tester", "Store Phase 1 Tester Review", "tester",
@@ -187,7 +189,7 @@ public class PlanReviewWorkflow : WorkflowBase
 
         // Security review
         var phase1SecCall = RoleReviewDispatch("Phase1SecReview", "Phase 1: Security Review", AgentRole.Security,
-            repository, planJson, contextIds, workItemJson, allReviewsJson, llmResult);
+            repository, planJson, contextIds, workItemJson, allReviewsJson, tenantId, llmResult);
         var extractPhase1Sec = ExtractReview(securityReview, llmResult, "security",
             "ExtractPhase1Sec", "Extract Phase 1 Security Review");
         var storePhase1Sec = StoreReviewRole("StorePhase1Sec", "Store Phase 1 Security Review", "security",
@@ -195,7 +197,7 @@ public class PlanReviewWorkflow : WorkflowBase
 
         // DevOps review
         var phase1DevOpsCall = RoleReviewDispatch("Phase1DevOpsReview", "Phase 1: DevOps Review", AgentRole.Devops,
-            repository, planJson, contextIds, workItemJson, allReviewsJson, llmResult);
+            repository, planJson, contextIds, workItemJson, allReviewsJson, tenantId, llmResult);
         var extractPhase1DevOps = ExtractReview(devopsReview, llmResult, "devops",
             "ExtractPhase1DevOps", "Extract Phase 1 DevOps Review");
         var storePhase1DevOps = StoreReviewRole("StorePhase1DevOps", "Store Phase 1 DevOps Review", "devops",
@@ -203,7 +205,7 @@ public class PlanReviewWorkflow : WorkflowBase
 
         // Product Owner review
         var phase1POCall = RoleReviewDispatch("Phase1POReview", "Phase 1: PO Review", AgentRole.ProductOwner,
-            repository, planJson, contextIds, workItemJson, allReviewsJson, llmResult);
+            repository, planJson, contextIds, workItemJson, allReviewsJson, tenantId, llmResult);
         var extractPhase1PO = ExtractReview(productOwnerReview, llmResult, "product_owner",
             "ExtractPhase1PO", "Extract Phase 1 PO Review");
         var storePhase1PO = StoreReviewRole("StorePhase1PO", "Store Phase 1 PO Review", "product_owner",
@@ -211,7 +213,7 @@ public class PlanReviewWorkflow : WorkflowBase
 
         // Senior Developer review
         var phase1SrDevCall = RoleReviewDispatch("Phase1SrDevReview", "Phase 1: Senior Dev Review", AgentRole.SeniorDeveloper,
-            repository, planJson, contextIds, workItemJson, allReviewsJson, llmResult);
+            repository, planJson, contextIds, workItemJson, allReviewsJson, tenantId, llmResult);
         var extractPhase1SrDev = ExtractReview(seniorDeveloperReview, llmResult, "senior_developer",
             "ExtractPhase1SrDev", "Extract Phase 1 Senior Dev Review");
         var storePhase1SrDev = StoreReviewRole("StorePhase1SrDev", "Store Phase 1 Senior Dev Review", "senior_developer",
@@ -323,7 +325,7 @@ public class PlanReviewWorkflow : WorkflowBase
 
         // Architect rebuttal
         var phase2ArchCall = RebuttalDispatch("Phase2ArchRebuttal", "Phase 2: Architect Rebuttal", AgentRole.Architect,
-            repository, planJson, contextIds, anonymizedReviewsJson, architectReview, roundCount, llmResult);
+            repository, planJson, contextIds, anonymizedReviewsJson, architectReview, roundCount, tenantId, llmResult);
         var extractPhase2Arch = ExtractRebuttal(architectRebuttal, llmResult,
             "ExtractPhase2Arch", "Extract Phase 2 Architect Rebuttal");
         var storePhase2Arch = StoreReviewRole("StorePhase2Arch", "Store Phase 2 Architect Rebuttal", "architect-rebuttal",
@@ -331,7 +333,7 @@ public class PlanReviewWorkflow : WorkflowBase
 
         // Developer rebuttal
         var phase2DevCall = RebuttalDispatch("Phase2DevRebuttal", "Phase 2: Developer Rebuttal", AgentRole.Developer,
-            repository, planJson, contextIds, anonymizedReviewsJson, developerReview, roundCount, llmResult);
+            repository, planJson, contextIds, anonymizedReviewsJson, developerReview, roundCount, tenantId, llmResult);
         var extractPhase2Dev = ExtractRebuttal(developerRebuttal, llmResult,
             "ExtractPhase2Dev", "Extract Phase 2 Developer Rebuttal");
         var storePhase2Dev = StoreReviewRole("StorePhase2Dev", "Store Phase 2 Developer Rebuttal", "developer-rebuttal",
@@ -339,7 +341,7 @@ public class PlanReviewWorkflow : WorkflowBase
 
         // Tester rebuttal
         var phase2TesterCall = RebuttalDispatch("Phase2TesterRebuttal", "Phase 2: Tester Rebuttal", AgentRole.Tester,
-            repository, planJson, contextIds, anonymizedReviewsJson, testerReview, roundCount, llmResult);
+            repository, planJson, contextIds, anonymizedReviewsJson, testerReview, roundCount, tenantId, llmResult);
         var extractPhase2Tester = ExtractRebuttal(testerRebuttal, llmResult,
             "ExtractPhase2Tester", "Extract Phase 2 Tester Rebuttal");
         var storePhase2Tester = StoreReviewRole("StorePhase2Tester", "Store Phase 2 Tester Rebuttal", "tester-rebuttal",
@@ -347,7 +349,7 @@ public class PlanReviewWorkflow : WorkflowBase
 
         // Security rebuttal
         var phase2SecCall = RebuttalDispatch("Phase2SecRebuttal", "Phase 2: Security Rebuttal", AgentRole.Security,
-            repository, planJson, contextIds, anonymizedReviewsJson, securityReview, roundCount, llmResult);
+            repository, planJson, contextIds, anonymizedReviewsJson, securityReview, roundCount, tenantId, llmResult);
         var extractPhase2Sec = ExtractRebuttal(securityRebuttal, llmResult,
             "ExtractPhase2Sec", "Extract Phase 2 Security Rebuttal");
         var storePhase2Sec = StoreReviewRole("StorePhase2Sec", "Store Phase 2 Security Rebuttal", "security-rebuttal",
@@ -355,7 +357,7 @@ public class PlanReviewWorkflow : WorkflowBase
 
         // DevOps rebuttal
         var phase2DevOpsCall = RebuttalDispatch("Phase2DevOpsRebuttal", "Phase 2: DevOps Rebuttal", AgentRole.Devops,
-            repository, planJson, contextIds, anonymizedReviewsJson, devopsReview, roundCount, llmResult);
+            repository, planJson, contextIds, anonymizedReviewsJson, devopsReview, roundCount, tenantId, llmResult);
         var extractPhase2DevOps = ExtractRebuttal(devopsRebuttal, llmResult,
             "ExtractPhase2DevOps", "Extract Phase 2 DevOps Rebuttal");
         var storePhase2DevOps = StoreReviewRole("StorePhase2DevOps", "Store Phase 2 DevOps Rebuttal", "devops-rebuttal",
@@ -363,7 +365,7 @@ public class PlanReviewWorkflow : WorkflowBase
 
         // Product Owner rebuttal
         var phase2POCall = RebuttalDispatch("Phase2PORebuttal", "Phase 2: PO Rebuttal", AgentRole.ProductOwner,
-            repository, planJson, contextIds, anonymizedReviewsJson, productOwnerReview, roundCount, llmResult);
+            repository, planJson, contextIds, anonymizedReviewsJson, productOwnerReview, roundCount, tenantId, llmResult);
         var extractPhase2PO = ExtractRebuttal(productOwnerRebuttal, llmResult,
             "ExtractPhase2PO", "Extract Phase 2 PO Rebuttal");
         var storePhase2PO = StoreReviewRole("StorePhase2PO", "Store Phase 2 PO Rebuttal", "product_owner-rebuttal",
@@ -371,7 +373,7 @@ public class PlanReviewWorkflow : WorkflowBase
 
         // Senior Developer rebuttal
         var phase2SrDevCall = RebuttalDispatch("Phase2SrDevRebuttal", "Phase 2: Senior Dev Rebuttal", AgentRole.SeniorDeveloper,
-            repository, planJson, contextIds, anonymizedReviewsJson, seniorDeveloperReview, roundCount, llmResult);
+            repository, planJson, contextIds, anonymizedReviewsJson, seniorDeveloperReview, roundCount, tenantId, llmResult);
         var extractPhase2SrDev = ExtractRebuttal(seniorDeveloperRebuttal, llmResult,
             "ExtractPhase2SrDev", "Extract Phase 2 Senior Dev Rebuttal");
         var storePhase2SrDev = StoreReviewRole("StorePhase2SrDev", "Store Phase 2 Senior Dev Rebuttal", "senior_developer-rebuttal",
@@ -491,6 +493,7 @@ public class PlanReviewWorkflow : WorkflowBase
             {
                 ["role"] = AgentRole.ProductOwner.ToWire(),
                 ["action"] = AgentAction.ReviewScope.ToWire(),
+                ["tenantId"] = tenantId.Get(ctx),
                 ["variables"] = new Dictionary<string, object>
                 {
                     ["planJson"] = planJson.Get(ctx),
@@ -847,7 +850,7 @@ public class PlanReviewWorkflow : WorkflowBase
         string id, string displayName, AgentRole role,
         Variable<string> repository, Variable<string> planJson,
         Variable<string> contextIds, Variable<string> workItemJson,
-        Variable<string> allReviewsJson,
+        Variable<string> allReviewsJson, Variable<string> tenantId,
         Variable<IDictionary<string, object>?> result)
     {
         var dispatch = new DispatchWorkflow
@@ -858,6 +861,7 @@ public class PlanReviewWorkflow : WorkflowBase
             {
                 ["role"] = role.ToWire(),
                 ["action"] = RolePhaseMap.GetReviewActionForRole(role).ToWire(),
+                ["tenantId"] = tenantId.Get(ctx),
                 ["variables"] = new Dictionary<string, object>
                 {
                     ["planJson"] = planJson.Get(ctx),
@@ -882,6 +886,7 @@ public class PlanReviewWorkflow : WorkflowBase
         Variable<string> repository, Variable<string> planJson,
         Variable<string> contextIds, Variable<string> anonymizedReviewsJson,
         Variable<string> previousReview, Variable<int> roundCount,
+        Variable<string> tenantId,
         Variable<IDictionary<string, object>?> result)
     {
         var dispatch = new DispatchWorkflow
@@ -892,6 +897,7 @@ public class PlanReviewWorkflow : WorkflowBase
             {
                 ["role"] = role.ToWire(),
                 ["action"] = RolePhaseMap.GetReviewActionForRole(role).ToWire(),
+                ["tenantId"] = tenantId.Get(ctx),
                 ["variables"] = new Dictionary<string, object>
                 {
                     ["planJson"] = planJson.Get(ctx),

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TaskCreationWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TaskCreationWorkflow.cs
@@ -48,6 +48,8 @@ public class TaskCreationWorkflow : WorkflowBase
         var contextIds = builder.WithVariable<string>("ContextIds", "[]");
         var workItemJson = builder.WithVariable<string>("WorkItemJson", "");
 
+        var tenantId = builder.WithVariable<string>("TenantId", "");
+
         var tasksJson = builder.WithVariable<string>("TasksJson", "[]");
         var tasksValid = builder.WithVariable<bool>("TasksValid", false);
         var validationErrors = builder.WithVariable<string>("ValidationErrors", "");
@@ -70,6 +72,7 @@ public class TaskCreationWorkflow : WorkflowBase
                 planJson.Set(ctx, ctx.GetInput<string>("planJson") ?? "");
                 contextIds.Set(ctx, ctx.GetInput<string>("contextIds") ?? "[]");
                 workItemJson.Set(ctx, ctx.GetInput<string>("workItemJson") ?? "");
+                tenantId.Set(ctx, ctx.GetInput<string>("tenantId") ?? "");
                 var inputMaxRetries = ctx.GetInput<int?>("maxRetries");
                 if (inputMaxRetries.HasValue) maxRetries.Set(ctx, inputMaxRetries.Value);
                 return (object)repo;
@@ -88,6 +91,7 @@ public class TaskCreationWorkflow : WorkflowBase
             {
                 ["role"] = AgentRole.SeniorDeveloper.ToWire(),
                 ["action"] = AgentAction.CreateTasks.ToWire(),
+                ["tenantId"] = tenantId.Get(ctx),
                 ["variables"] = new Dictionary<string, object>
                 {
                     ["planJson"] = planJson.Get(ctx),

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TaskReviewWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TaskReviewWorkflow.cs
@@ -64,6 +64,8 @@ public class TaskReviewWorkflow : WorkflowBase
         var allReviewsJson = builder.WithVariable<string>("AllReviewsJson", "[]");
         var allApproved = builder.WithVariable<bool>("AllApproved", false);
 
+        var tenantId = builder.WithVariable<string>("TenantId", "");
+
         // Final outputs
         var decision = builder.WithVariable<string>("Decision", "needsHuman");
         var reviewNotes = builder.WithVariable<string>("ReviewNotes", "");
@@ -93,6 +95,7 @@ public class TaskReviewWorkflow : WorkflowBase
                 issueNumber.Set(ctx, ctx.GetInput<int>("issueNumber"));
                 tasksJson.Set(ctx, ctx.GetInput<string>("tasksJson") ?? "[]");
                 planJson.Set(ctx, ctx.GetInput<string>("planJson") ?? "");
+                tenantId.Set(ctx, ctx.GetInput<string>("tenantId") ?? "");
                 return (object)repo;
             })
         };
@@ -104,25 +107,25 @@ public class TaskReviewWorkflow : WorkflowBase
 
         // Architect review
         var archReviewCall = RoleReviewDispatch("ArchReview", "Architect Review", AgentRole.Architect,
-            repository, tasksJson, planJson, allReviewsJson, llmResult);
+            repository, tasksJson, planJson, allReviewsJson, tenantId, llmResult);
         var extractArch = ExtractReview(architectReview, llmResult,
             "ExtractArchReview", "Extract Architect Review");
 
         // Senior Developer review
         var srDevReviewCall = RoleReviewDispatch("SrDevReview", "Sr Dev Review", AgentRole.SeniorDeveloper,
-            repository, tasksJson, planJson, allReviewsJson, llmResult);
+            repository, tasksJson, planJson, allReviewsJson, tenantId, llmResult);
         var extractSrDev = ExtractReview(seniorDevReview, llmResult,
             "ExtractSrDevReview", "Extract Sr Dev Review");
 
         // Developer review
         var devReviewCall = RoleReviewDispatch("DevReview", "Developer Review", AgentRole.Developer,
-            repository, tasksJson, planJson, allReviewsJson, llmResult);
+            repository, tasksJson, planJson, allReviewsJson, tenantId, llmResult);
         var extractDev = ExtractReview(developerReview, llmResult,
             "ExtractDevReview", "Extract Developer Review");
 
         // Tester review
         var testerReviewCall = RoleReviewDispatch("TesterReview", "Tester Review", AgentRole.Tester,
-            repository, tasksJson, planJson, allReviewsJson, llmResult);
+            repository, tasksJson, planJson, allReviewsJson, tenantId, llmResult);
         var extractTester = ExtractReview(testerReview, llmResult,
             "ExtractTesterReview", "Extract Tester Review");
 
@@ -308,6 +311,7 @@ public class TaskReviewWorkflow : WorkflowBase
         string id, string displayName, AgentRole role,
         Variable<string> repository, Variable<string> tasksJson,
         Variable<string> planJson, Variable<string> allReviewsJson,
+        Variable<string> tenantId,
         Variable<IDictionary<string, object>?> result)
     {
         var dispatch = new DispatchWorkflow
@@ -318,6 +322,7 @@ public class TaskReviewWorkflow : WorkflowBase
             {
                 ["role"] = role.ToWire(),
                 ["action"] = RolePhaseMap.GetReviewActionForRole(role).ToWire(),
+                ["tenantId"] = tenantId.Get(ctx),
                 ["variables"] = new Dictionary<string, object>
                 {
                     ["tasksJson"] = tasksJson.Get(ctx),

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/WorkflowStructureTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/WorkflowStructureTests.cs
@@ -684,6 +684,60 @@ public class WorkflowStructureTests
     }
 
     // ================================================================
+    // Bucket-B TenantId propagation tests (5 sub-workflows)
+    // ================================================================
+
+    [Test]
+    public void PlanReviewWorkflow_ShouldHaveTenantIdVariable()
+    {
+        var workflow = new PlanReviewWorkflow();
+        var builder = BuildWorkflow(workflow);
+        var variables = builder.Object.Variables;
+        variables.Any(v => v.Name == "TenantId").Should().BeTrue(
+            "PlanReviewWorkflow must accept TenantId and thread it to llm-call dispatches");
+    }
+
+    [Test]
+    public void ContextGatheringWorkflow_ShouldHaveTenantIdVariable()
+    {
+        var workflow = new ContextGatheringWorkflow();
+        var builder = BuildWorkflow(workflow);
+        var variables = builder.Object.Variables;
+        variables.Any(v => v.Name == "TenantId").Should().BeTrue(
+            "ContextGatheringWorkflow must accept TenantId and thread it to llm-call dispatches");
+    }
+
+    [Test]
+    public void MentorshipWorkflow_ShouldHaveTenantIdVariable()
+    {
+        var workflow = new MentorshipWorkflow();
+        var builder = BuildWorkflow(workflow);
+        var variables = builder.Object.Variables;
+        variables.Any(v => v.Name == "TenantId").Should().BeTrue(
+            "MentorshipWorkflow must accept TenantId and thread it to llm-call and context-gathering dispatches");
+    }
+
+    [Test]
+    public void TaskReviewWorkflow_ShouldHaveTenantIdVariable()
+    {
+        var workflow = new TaskReviewWorkflow();
+        var builder = BuildWorkflow(workflow);
+        var variables = builder.Object.Variables;
+        variables.Any(v => v.Name == "TenantId").Should().BeTrue(
+            "TaskReviewWorkflow must accept TenantId and thread it to llm-call dispatches");
+    }
+
+    [Test]
+    public void TaskCreationWorkflow_ShouldHaveTenantIdVariable()
+    {
+        var workflow = new TaskCreationWorkflow();
+        var builder = BuildWorkflow(workflow);
+        var variables = builder.Object.Variables;
+        variables.Any(v => v.Name == "TenantId").Should().BeTrue(
+            "TaskCreationWorkflow must accept TenantId and thread it to llm-call dispatches");
+    }
+
+    // ================================================================
     // Cross-cutting structure tests
     // ================================================================
 


### PR DESCRIPTION
## Thread `tenantId` through 5 sub-workflows' `llm-call` dispatches (Bucket B)

Five Elsa sub-workflows (`PlanReview`, `ContextGathering`, `Mentorship`, `TaskReview`, `TaskCreation`) **received** `tenantId` from their parent (`SingleIssueCycleWorkflow` already passes it) but **dropped it** — their internal `llm-call` dispatches ran without tenant attribution. This forwards it through, mirroring the compliant `PlanGenerationWorkflow` / `SingleIssueCycleWorkflow`.

### What changed
Each workflow now: declares `var tenantId = builder.WithVariable<string>("TenantId","")`, sets it from `ctx.GetInput<string>("tenantId") ?? ""` at init, and adds `["tenantId"] = tenantId.Get(ctx)` to **all 9 `llm-call` dispatch sites** (several reached via parameterized helpers — the helpers gained a `tenantId` param that every caller passes). Mentorship's `context-gathering` child dispatch also forwards `tenantId`.

- ContextGathering's "vector store" is `StoreRoleFindingActivity` (a custom activity with no tenant-scope parameter) — correctly left alone (no dispatch to thread).

### Verification
- Build **0 errors**; `Tamma.Activities.Tests` **2094/2094**.
- 5 structural `*_ShouldHaveTenantIdVariable` tests added (mirroring the `PlanGeneration` reference test). The actual dispatch-Input forwarding is verified by review (the builder-mock harness can't execute the dispatch lambda — the established ceiling for these structural tests).
- **No schema change**, no `Program.cs` change, no new dispatch nodes — only the `tenantId` Input key added to existing dispatches.

Merging does not deploy (the `qa-*` tag gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
