### PR TITLE
Assessment P0: replace fake heuristic AI with real llm-call (stops fabricating mentorship confidence)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/Assessment/AnalyzeResponseActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Assessment/AnalyzeResponseActivity.cs
@@ -12,10 +12,20 @@ using Tamma.Data.Repositories;
 namespace Tamma.Activities.Assessment;
 
 /// <summary>
-/// Analyzes the junior's assessment response using AI (LLM Call sub-workflow 7-1B).
-/// Sends questions, response, story context, and skill level to the LLM for structured analysis.
-/// The analysis prompt instructs the LLM to be encouraging but honest.
+/// SUPERSEDED (P0 fix 2026-06-30): <c>AssessmentWorkflow</c> now dispatches
+/// <c>llm-call</c> (role=product_owner / action=analyze-assessment-response)
+/// instead of invoking this activity. This class used keyword counting and
+/// response-length heuristics to fabricate a confidence score
+/// (<see cref="PerformAnalysis"/>), making the mentorship machine route on a
+/// value that was never produced by an LLM. Kept as a reference / explicit
+/// mock-mode fallback (audit 7-2 AC7); not called by any workflow in production.
 /// </summary>
+[Obsolete(
+    "Superseded by DispatchWorkflow(\"llm-call\", role=product_owner, " +
+    "action=analyze-assessment-response) in AssessmentWorkflow (P0 fix 2026-06-30). " +
+    "This activity fabricated confidence from keyword counting and response length " +
+    "instead of calling the LLM. " +
+    "Kept as a documented mock-mode fallback; not wired into any workflow.")]
 [Activity(
     "Tamma.Assessment",
     "Analyze Response",

--- a/apps/tamma-elsa/src/Tamma.Activities/Assessment/GenerateQuestionsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Assessment/GenerateQuestionsActivity.cs
@@ -11,10 +11,18 @@ using Tamma.Activities.Assessment.Models;
 namespace Tamma.Activities.Assessment;
 
 /// <summary>
-/// Generates assessment questions adapted to the junior's skill level.
-/// Uses story context and optional previous attempt data to produce targeted questions.
-/// In production, delegates to the LLM Call sub-workflow (7-1B) via RunWorkflow.
+/// SUPERSEDED (P0 fix 2026-06-30): <c>AssessmentWorkflow</c> now dispatches
+/// <c>llm-call</c> (role=product_owner / action=generate-assessment-questions)
+/// instead of invoking this activity. This class used a hardcoded question bank
+/// (<see cref="GetSkillLevelQuestions"/>) that bypassed the LLM entirely, which
+/// made the whole mentorship assessment non-AI. Kept as a reference / explicit
+/// mock-mode fallback (audit 7-2 AC7); not called by any workflow in production.
 /// </summary>
+[Obsolete(
+    "Superseded by DispatchWorkflow(\"llm-call\", role=product_owner, " +
+    "action=generate-assessment-questions) in AssessmentWorkflow (P0 fix 2026-06-30). " +
+    "This activity used a hardcoded question bank instead of the LLM. " +
+    "Kept as a documented mock-mode fallback; not wired into any workflow.")]
 [Activity(
     "Tamma.Assessment",
     "Generate Questions",

--- a/apps/tamma-elsa/src/Tamma.Api/Auth/SystemPrompts.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Auth/SystemPrompts.cs
@@ -235,6 +235,10 @@ public static class SystemPrompts
         AgentAction.MonitorHealth => Triage,
         AgentAction.AssessCapacity => Triage,
 
+        // ── assessment (assessment P0 — real per-cell bodies, not a transitional family) ──
+        AgentAction.GenerateAssessmentQuestions => GenerateAssessmentQuestionsBody,
+        AgentAction.AnalyzeAssessmentResponse => AnalyzeAssessmentResponseBody,
+
         // ── summarize / documentation / write-ups → Summarize ──
         AgentAction.SummarizeStakeholder => Summarize,
         AgentAction.SummarizeTechnical => Summarize,
@@ -634,6 +638,80 @@ public static class SystemPrompts
         Variables: ["role", "errorContext", "stackTrace", "relevantCode", "conventions", "recentChanges"],
         EnableTools: true,
         MaxTokens: 8192);
+
+    // -----------------------------------------------------------------------
+    // Assessment-specific body builders (assessment P0)
+    //
+    // These are purpose-written for the AssessmentWorkflow llm-call dispatch
+    // (docs/superpowers/plans/2026-06-30-assessment-p0-llm-call.md). Unlike the
+    // transitional bodies above, these are authoritative per-cell prompts that use
+    // the exact Shared-contract variable names Task 2 passes in the dispatch.
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Prompt for <c>(product_owner, generate-assessment-questions)</c>: produce a
+    /// JSON array of skill-appropriate questions about the story so the
+    /// <c>AssessmentWorkflow</c> can present them to the junior developer.
+    /// Shared-contract variables: <c>storyContext</c>, <c>skillLevel</c>,
+    /// <c>questionCount</c>, <c>previousGaps</c>.
+    /// </summary>
+    private static PromptTemplate GenerateAssessmentQuestionsBody(string role, string action) => new(
+        Role: role,
+        Action: action,
+        Template:
+            "You are assessing a junior developer's understanding of a story they are about to implement.\n\n" +
+            "## Story Context\n{{storyContext}}\n\n" +
+            "## Developer Skill Level\n{{skillLevel}}\n\n" +
+            "## Previously Identified Gaps (do not re-ask about these)\n{{previousGaps}}\n\n" +
+            "## Instructions\n\n" +
+            "Generate exactly {{questionCount}} assessment questions that:\n" +
+            "- Are appropriate for a {{skillLevel}} developer (calibrate depth and terminology accordingly)\n" +
+            "- Test understanding of the story's requirements, technical approach, and edge cases\n" +
+            "- Cover different aspects: functional requirements, technical design, testing considerations, risks\n" +
+            "- Avoid topics already covered in the previousGaps list above\n" +
+            "- Are open-ended enough to reveal genuine understanding (not yes/no)\n" +
+            "- Are specific to THIS story, not generic software engineering questions\n\n" +
+            "Return ONLY a JSON array of question strings with no wrapper object:\n" +
+            "```json\n[\"Question 1 text?\", \"Question 2 text?\", ...]\n```\n\n" +
+            "Do not include numbering, explanations, or any text outside the JSON array.",
+        SystemPrompt: SystemFor(role),
+        Variables: ["storyContext", "skillLevel", "questionCount", "previousGaps"],
+        EnableTools: false,
+        MaxTokens: 2048);
+
+    /// <summary>
+    /// Prompt for <c>(product_owner, analyze-assessment-response)</c>: evaluate a
+    /// junior developer's answers against the questions and story context, returning
+    /// a structured JSON result that <c>AssessmentWorkflow</c> feeds into
+    /// <c>ClassifyResultActivity</c> (confidence) and <c>SetOutputResult</c>
+    /// (rationale).
+    /// Shared-contract variables: <c>storyContext</c>, <c>questions</c>,
+    /// <c>response</c>, <c>skillLevel</c>.
+    /// </summary>
+    private static PromptTemplate AnalyzeAssessmentResponseBody(string role, string action) => new(
+        Role: role,
+        Action: action,
+        Template:
+            "You are evaluating a junior developer's assessment response to determine their readiness to implement a story.\n\n" +
+            "## Story Context\n{{storyContext}}\n\n" +
+            "## Assessment Questions\n{{questions}}\n\n" +
+            "## Developer's Response\n{{response}}\n\n" +
+            "## Developer Skill Level\n{{skillLevel}}\n\n" +
+            "## Instructions\n\n" +
+            "Analyze the developer's response against the questions and story context. Assess:\n" +
+            "- **Correctness**: Are the answers factually correct and complete?\n" +
+            "- **Depth**: Does the developer show genuine understanding or superficial familiarity?\n" +
+            "- **Gaps**: What knowledge gaps are revealed that could cause problems during implementation?\n" +
+            "- **Strengths**: What does the developer clearly understand well?\n" +
+            "- **Readiness**: Given their {{skillLevel}} level, are they ready to implement this story?\n\n" +
+            "Calibrate your confidence score to the developer's {{skillLevel}} level — a junior developer " +
+            "is not expected to have senior-level depth; assess relative to appropriate expectations.\n\n" +
+            "Return ONLY a JSON object (no markdown fences, no wrapper):\n" +
+            "{\"status\":\"ready|needs_guidance|not_ready\",\"confidence\":0.0,\"gaps\":[\"...\"],\"strengths\":[\"...\"],\"rationale\":\"...\"}",
+        SystemPrompt: SystemFor(role),
+        Variables: ["storyContext", "questions", "response", "skillLevel"],
+        EnableTools: false,
+        MaxTokens: 2048);
 
     // -----------------------------------------------------------------------
     // Role-specific review lenses (inlined in plan-review / code-review bodies)

--- a/apps/tamma-elsa/src/Tamma.Api/Auth/SystemPrompts.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Auth/SystemPrompts.cs
@@ -707,7 +707,11 @@ public static class SystemPrompts
             "Calibrate your confidence score to the developer's {{skillLevel}} level — a junior developer " +
             "is not expected to have senior-level depth; assess relative to appropriate expectations.\n\n" +
             "Return ONLY a JSON object (no markdown fences, no wrapper):\n" +
-            "{\"status\":\"ready|needs_guidance|not_ready\",\"confidence\":0.0,\"gaps\":[\"...\"],\"strengths\":[\"...\"],\"rationale\":\"...\"}",
+            "{\"status\":\"Correct|Partial|Incorrect\",\"confidence\":0.0,\"gaps\":[\"...\"],\"strengths\":[\"...\"],\"rationale\":\"...\"}\n\n" +
+            "Where `confidence` is a decimal between 0.0 and 1.0, and `status` follows the classification:\n" +
+            "- `Correct` = developer is ready, confidence ≥ 0.7\n" +
+            "- `Partial` = developer has gaps but shows some understanding, 0.4 ≤ confidence < 0.7\n" +
+            "- `Incorrect` = developer is not ready, confidence < 0.4",
         SystemPrompt: SystemFor(role),
         Variables: ["storyContext", "questions", "response", "skillLevel"],
         EnableTools: false,

--- a/apps/tamma-elsa/src/Tamma.Core/Agents/AgentAction.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Agents/AgentAction.cs
@@ -28,6 +28,8 @@ public enum AgentAction
     [Wire("summarize-stakeholder")] SummarizeStakeholder,
     [Wire("review-acceptance")] ReviewAcceptance,
     [Wire("review-scope")] ReviewScope,
+    [Wire("generate-assessment-questions")] GenerateAssessmentQuestions,
+    [Wire("analyze-assessment-response")] AnalyzeAssessmentResponse,
 
     // architect
     [Wire("triage-technical")] TriageTechnical,

--- a/apps/tamma-elsa/src/Tamma.Core/Agents/RolePhaseMap.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Agents/RolePhaseMap.cs
@@ -43,7 +43,7 @@ public static class RolePhaseMap
     private static readonly FrozenDictionary<AgentRole, FrozenSet<AgentAction>> s_eligibleActions =
         new Dictionary<AgentRole, FrozenSet<AgentAction>>
         {
-            // product_owner — intake, requirements, prioritisation, acceptance
+            // product_owner — intake, requirements, prioritisation, acceptance, assessment
             [AgentRole.ProductOwner] = FreezeSet(
                 AgentAction.ContextScan,
                 AgentAction.TriageIntake,
@@ -54,7 +54,9 @@ public static class RolePhaseMap
                 AgentAction.PlanRoadmap,
                 AgentAction.SummarizeStakeholder,
                 AgentAction.ReviewAcceptance,
-                AgentAction.ReviewScope),
+                AgentAction.ReviewScope,
+                AgentAction.GenerateAssessmentQuestions,
+                AgentAction.AnalyzeAssessmentResponse),
 
             // architect — system design, technical strategy
             [AgentRole.Architect] = FreezeSet(

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AssessmentWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AssessmentWorkflow.cs
@@ -8,6 +8,7 @@ using Elsa.Workflows.Runtime.Activities;
 using System.Text.Json;
 using Tamma.Activities.Assessment;
 using Tamma.Activities.Assessment.Models;
+using Tamma.Api.Services.Agents;
 using Tamma.Core.Enums;
 using FlowEndpoint = Elsa.Workflows.Activities.Flowchart.Models.Endpoint;
 
@@ -22,14 +23,23 @@ namespace Tamma.ElsaServer.Workflows;
 ///
 /// Flow:
 ///   1. Gather context (via Context Gathering 7-1F)
-///   2. Generate targeted questions (via LLM Call 7-1B)
+///   2. Generate targeted questions via DispatchWorkflow("llm-call")
+///      role=product_owner / action=generate-assessment-questions
 ///   3. Deliver questions to junior
 ///   4. Wait for response (bookmark-based with timeout)
-///   5a. On response: analyze with AI, classify result, update profile
+///   5a. On response: analyse via DispatchWorkflow("llm-call")
+///       role=product_owner / action=analyze-assessment-response,
+///       classify result, update profile
 ///   5b. On timeout: set timeout result, update profile
 ///   6. Set workflow outputs
 ///
-/// Can be invoked standalone via ELSA REST API or as a child workflow via RunWorkflow.
+/// Fail-closed: if either llm-call returns success=false, or the JSON
+/// response cannot be parsed into the expected shape, the workflow routes
+/// to the LlmCallError terminal — it never proceeds with fabricated
+/// questions or a fabricated confidence score.
+///
+/// Can be invoked standalone via the Elsa REST API or as a child workflow
+/// via RunWorkflow.
 /// </summary>
 public class AssessmentWorkflow : WorkflowBase
 {
@@ -41,38 +51,48 @@ public class AssessmentWorkflow : WorkflowBase
         builder.Description = "Evaluate junior developer's understanding of story requirements";
 
         // ── Workflow variables ──────────────────────────────────────────
-        var sessionId = builder.WithVariable<Guid>();
-        var storyId = builder.WithVariable<string>();
-        var juniorId = builder.WithVariable<string>();
-        var skillLevel = builder.WithVariable<int>();
+        var sessionId        = builder.WithVariable<Guid>();
+        var storyId          = builder.WithVariable<string>();
+        var juniorId         = builder.WithVariable<string>();
+        var skillLevel       = builder.WithVariable<int>();
         var previousAttemptJson = builder.WithVariable<string>();
-        var storyContext = builder.WithVariable<string>();
-        var questionsJson = builder.WithVariable<string>();
-        var juniorResponse = builder.WithVariable<string>();
+        var tenantId         = builder.WithVariable<string>("TenantId", "");
+        var storyContext     = builder.WithVariable<string>();
+        var questionsJson    = builder.WithVariable<string>();
+        var juniorResponse   = builder.WithVariable<string>();
         var analysisResultJson = builder.WithVariable<string>();
         var responseReceived = builder.WithVariable<bool>();
         var assessmentStatus = builder.WithVariable<AssessmentOutcomeStatus>();
-        var confidence = builder.WithVariable<decimal>();
-        var nextState = builder.WithVariable<MentorshipState>();
-        var gapsJson = builder.WithVariable<string>();
-        var strengthsJson = builder.WithVariable<string>();
-        var attemptNumber = builder.WithVariable<int>();
+        var confidence       = builder.WithVariable<decimal>();
+        var nextState        = builder.WithVariable<MentorshipState>();
+        var gapsJson         = builder.WithVariable<string>();
+        var strengthsJson    = builder.WithVariable<string>();
+        var attemptNumber    = builder.WithVariable<int>();
+
+        // llm-call result containers
+        var contextGatherResult = builder.WithVariable<IDictionary<string, object>?>();
+        var questionLlm         = builder.WithVariable<IDictionary<string, object>?>();
+        var analysisLlm         = builder.WithVariable<IDictionary<string, object>?>();
+
+        // Success flags (fail-closed guards)
+        var questionsLlmOk  = builder.WithVariable<bool>();
+        var analysisLlmOk   = builder.WithVariable<bool>();
 
         // Variables to capture activity outputs via binding
         var generatedQuestionSet = builder.WithVariable<QuestionSet>();
-        var deliveryResult = builder.WithVariable<DeliveryResult>();
-        var waitJuniorResponse = builder.WithVariable<string>();
+        var deliveryResult       = builder.WithVariable<DeliveryResult>();
+        var waitJuniorResponse   = builder.WithVariable<string>();
         var waitResponseReceived = builder.WithVariable<bool>();
-        var analysisOutput = builder.WithVariable<AnalysisResult>();
-        var classifiedStatus = builder.WithVariable<AssessmentOutcomeStatus>();
+        var analysisOutput       = builder.WithVariable<AnalysisResult>();
+        var classifiedStatus     = builder.WithVariable<AssessmentOutcomeStatus>();
         var classifiedConfidence = builder.WithVariable<decimal>();
-        var classifiedNextState = builder.WithVariable<MentorshipState>();
+        var classifiedNextState  = builder.WithVariable<MentorshipState>();
 
         // Output variables (readable by parent workflow)
-        var outputResultJson = builder.WithVariable<string>();
-        var outputNextState = builder.WithVariable<string>();
-        var outputStatus = builder.WithVariable<string>();
-        var outputSkillLevel = builder.WithVariable<int>();
+        var outputResultJson  = builder.WithVariable<string>();
+        var outputNextState   = builder.WithVariable<string>();
+        var outputStatus      = builder.WithVariable<string>();
+        var outputSkillLevel  = builder.WithVariable<int>();
 
         // ── Step 1: Read inputs into variables ─────────────────────────
         var readInputs = new SetVariable
@@ -87,6 +107,7 @@ public class AssessmentWorkflow : WorkflowBase
                 juniorId.Set(context, context.GetInput<string>("juniorId") ?? string.Empty);
                 skillLevel.Set(context, context.GetInput<int>("skillLevel"));
                 previousAttemptJson.Set(context, context.GetInput<string>("previousAttemptJson") ?? string.Empty);
+                tenantId.Set(context, context.GetInput<string>("tenantId") ?? string.Empty);
 
                 var prevJson = context.GetInput<string>("previousAttemptJson") ?? string.Empty;
                 if (!string.IsNullOrEmpty(prevJson))
@@ -123,7 +144,8 @@ public class AssessmentWorkflow : WorkflowBase
                 ["Purpose"] = "Assessment",
                 ["MaxContextSize"] = 50000
             }),
-            WaitForCompletion = new(true)
+            WaitForCompletion = new(true),
+            Result = new(contextGatherResult)
         };
         gatherContext.SetDisplayText("Gather Context");
 
@@ -132,26 +154,100 @@ public class AssessmentWorkflow : WorkflowBase
             Id = "StoreContextResult",
             Name = "Store Context Result",
             Variable = storyContext,
-            Value = new(ctx => {
-                // Context is available from the dispatched workflow output
+            Value = new(ctx =>
+            {
+                var result = contextGatherResult.Get(ctx);
+                if (result != null && result.TryGetValue("summary", out var s) && s != null)
+                    return s.ToString() ?? $"Assessment context for story {storyId.Get(ctx)}";
                 return $"Assessment context for story {storyId.Get(ctx)} gathered via ContextGathering workflow";
             })
         };
         storeContextResult.SetDisplayText("Store Context Result");
 
-        // ── Step 3: Generate questions ─────────────────────────────────
-        var generateQuestions = new GenerateQuestionsActivity
+        // ── Step 3: Generate questions via llm-call ────────────────────
+        var generateQuestionsLlm = new DispatchWorkflow
         {
-            Id = "GenerateQuestions",
-            Name = "Generate Questions",
-            SessionId = new(context => sessionId.Get(context)),
-            StoryId = new(context => storyId.Get(context)),
-            SkillLevel = new(context => skillLevel.Get(context)),
-            StoryContext = new(context => storyContext.Get(context)),
-            PreviousAttemptJson = new(context => previousAttemptJson.Get(context)),
-            Result = new(generatedQuestionSet)
+            Id = "GenerateQuestionsLlm",
+            Name = "Generate Questions (LLM)",
+            WorkflowDefinitionId = new("llm-call"),
+            Input = new(ctx => new Dictionary<string, object>
+            {
+                ["role"]      = AgentRole.ProductOwner.ToWire(),
+                ["action"]    = AgentAction.GenerateAssessmentQuestions.ToWire(),
+                ["tenantId"]  = tenantId.Get(ctx),
+                ["variables"] = new Dictionary<string, object>
+                {
+                    ["storyContext"]  = storyContext.Get(ctx) ?? "",
+                    ["skillLevel"]   = skillLevel.Get(ctx),
+                    ["questionCount"] = ComputeQuestionCount(skillLevel.Get(ctx)),
+                    ["previousGaps"] = ExtractPreviousGaps(previousAttemptJson.Get(ctx)),
+                },
+                ["enableTools"] = false,
+            }),
+            WaitForCompletion = new(true),
+            Result = new(questionLlm),
         };
-        generateQuestions.SetDisplayText("Generate Questions");
+        generateQuestionsLlm.SetDisplayText("Generate Questions (LLM)");
+
+        // Parse llm-call response into QuestionSet; set questionsLlmOk flag
+        var parseQuestionsResult = new SetVariable
+        {
+            Id = "ParseQuestionsResult",
+            Name = "Parse Questions Result",
+            Variable = generatedQuestionSet,
+            Value = new(ctx =>
+            {
+                var result = questionLlm.Get(ctx);
+
+                // Fail-closed: no result or success=false → error
+                var succeeded = ReadSuccessFlag(result);
+                if (!succeeded)
+                {
+                    questionsLlmOk.Set(ctx, false);
+                    return null;
+                }
+
+                var text = result!.TryGetValue("llmResponse", out var r) ? r?.ToString() ?? "" : "";
+                try
+                {
+                    // Try JSON array of strings: ["Q1","Q2",...]
+                    var arrStart = text.IndexOf('[');
+                    var arrEnd   = text.LastIndexOf(']');
+                    if (arrStart >= 0 && arrEnd > arrStart)
+                    {
+                        var qs = JsonSerializer.Deserialize<List<string>>(text[arrStart..(arrEnd + 1)]);
+                        if (qs?.Count > 0)
+                        {
+                            questionsLlmOk.Set(ctx, true);
+                            return (object)new QuestionSet { Questions = qs, TargetSkillLevel = skillLevel.Get(ctx) };
+                        }
+                    }
+
+                    // Try JSON object: {"questions":["Q1","Q2",...]}
+                    var objStart = text.IndexOf('{');
+                    var objEnd   = text.LastIndexOf('}');
+                    if (objStart >= 0 && objEnd > objStart)
+                    {
+                        var qs = JsonSerializer.Deserialize<QuestionSet>(text[objStart..(objEnd + 1)]);
+                        if (qs?.Questions?.Count > 0)
+                        {
+                            questionsLlmOk.Set(ctx, true);
+                            return (object)qs;
+                        }
+                    }
+                }
+                catch { /* parse failure → fail closed below */ }
+
+                questionsLlmOk.Set(ctx, false);
+                return null;
+            })
+        };
+        parseQuestionsResult.SetDisplayText("Parse Questions Result");
+
+        // Fail-closed gate: route to error terminal if questions LLM call failed
+        var questionsSuccessCheck = new FlowDecision(ctx => questionsLlmOk.Get(ctx))
+        { Id = "QuestionsLlmOk", Name = "Questions LLM OK?" };
+        questionsSuccessCheck.SetDisplayText("Questions LLM OK?");
 
         // Store generated questions as JSON string
         var storeQuestions = new SetVariable
@@ -207,19 +303,100 @@ public class AssessmentWorkflow : WorkflowBase
         };
         storeResponse.SetDisplayText("Store Response");
 
-        // ── Step 6a: Analyze response ──────────────────────────────────
-        var analyzeResponse = new AnalyzeResponseActivity
+        // ── Step 6a: Analyse response via llm-call ─────────────────────
+        var analyzeResponseLlm = new DispatchWorkflow
         {
-            Id = "AnalyzeResponse",
-            Name = "Analyze Response",
-            SessionId = new(context => sessionId.Get(context)),
-            SkillLevel = new(context => skillLevel.Get(context)),
-            QuestionsJson = new(context => questionsJson.Get(context)),
-            JuniorResponse = new(context => juniorResponse.Get(context)),
-            StoryContext = new(context => storyContext.Get(context)),
-            Result = new(analysisOutput)
+            Id = "AnalyzeResponseLlm",
+            Name = "Analyze Response (LLM)",
+            WorkflowDefinitionId = new("llm-call"),
+            Input = new(ctx => new Dictionary<string, object>
+            {
+                ["role"]      = AgentRole.ProductOwner.ToWire(),
+                ["action"]    = AgentAction.AnalyzeAssessmentResponse.ToWire(),
+                ["tenantId"]  = tenantId.Get(ctx),
+                ["variables"] = new Dictionary<string, object>
+                {
+                    ["storyContext"] = storyContext.Get(ctx) ?? "",
+                    ["questions"]   = questionsJson.Get(ctx) ?? "",
+                    ["response"]    = juniorResponse.Get(ctx) ?? "",
+                    ["skillLevel"]  = skillLevel.Get(ctx),
+                },
+                ["enableTools"] = false,
+            }),
+            WaitForCompletion = new(true),
+            Result = new(analysisLlm),
         };
-        analyzeResponse.SetDisplayText("Analyze Response");
+        analyzeResponseLlm.SetDisplayText("Analyze Response (LLM)");
+
+        // Parse llm-call response into AnalysisResult; set analysisLlmOk flag.
+        //
+        // Uses JsonElement extraction rather than direct AnalysisResult deserialisation
+        // to avoid an enum mismatch: the LLM prompt suggests "ready|needs_guidance|
+        // not_ready" as status values, which do not map to AssessmentOutcomeStatus
+        // (Correct|Partial|Incorrect|Timeout). ClassifyResultActivity recomputes Status
+        // from the Confidence threshold anyway, so we only need to extract Confidence,
+        // Rationale, Gaps, and Strengths robustly.
+        var parseAnalysisResult = new SetVariable
+        {
+            Id = "ParseAnalysisResult",
+            Name = "Parse Analysis Result",
+            Variable = analysisOutput,
+            Value = new(ctx =>
+            {
+                var result = analysisLlm.Get(ctx);
+
+                // Fail-closed: no result or success=false → error
+                var succeeded = ReadSuccessFlag(result);
+                if (!succeeded)
+                {
+                    analysisLlmOk.Set(ctx, false);
+                    return null;
+                }
+
+                var text = result!.TryGetValue("llmResponse", out var r) ? r?.ToString() ?? "" : "";
+                try
+                {
+                    // Slice JSON object: {"confidence":0.8,"gaps":[...],...}
+                    var jsonStart = text.IndexOf('{');
+                    var jsonEnd   = text.LastIndexOf('}');
+                    if (jsonStart >= 0 && jsonEnd > jsonStart)
+                    {
+                        var element = JsonSerializer.Deserialize<JsonElement>(text[jsonStart..(jsonEnd + 1)]);
+
+                        // Extract numeric confidence (fail if missing/unparseable)
+                        if (!element.TryGetProperty("confidence", out var cv) ||
+                            cv.ValueKind != JsonValueKind.Number)
+                        {
+                            analysisLlmOk.Set(ctx, false);
+                            return null;
+                        }
+
+                        var parsed = new AnalysisResult
+                        {
+                            Confidence = (decimal)cv.GetDouble(),
+                            Rationale  = element.TryGetProperty("rationale", out var rv) ? rv.GetString() ?? "" : "",
+                            Gaps       = ExtractStringList(element, "gaps"),
+                            Strengths  = ExtractStringList(element, "strengths"),
+                            // Status is recomputed by ClassifyResultActivity from Confidence
+                            Status = AssessmentOutcomeStatus.Incorrect,
+                        };
+
+                        analysisLlmOk.Set(ctx, true);
+                        return (object)parsed;
+                    }
+                }
+                catch { /* parse failure → fail closed below */ }
+
+                analysisLlmOk.Set(ctx, false);
+                return null;
+            })
+        };
+        parseAnalysisResult.SetDisplayText("Parse Analysis Result");
+
+        // Fail-closed gate: route to error terminal if analysis LLM call failed
+        var analysisSuccessCheck = new FlowDecision(ctx => analysisLlmOk.Get(ctx))
+        { Id = "AnalysisLlmOk", Name = "Analysis LLM OK?" };
+        analysisSuccessCheck.SetDisplayText("Analysis LLM OK?");
 
         // Store analysis result as JSON + extract gaps/strengths
         var storeAnalysis = new SetVariable
@@ -327,7 +504,8 @@ public class AssessmentWorkflow : WorkflowBase
         updateSkillProfileTimeout.SetDisplayText("Update Skill Profile (Timeout)");
 
         // ── Step 9: Set workflow output (response path) ────────────────
-        // Store the final result into output variables for parent workflow retrieval
+        // Use the real LLM rationale from analysisOutput (P0 fix: was hardcoded
+        // "Assessment completed" — now the actual reasoning from the LLM).
         var setOutput = new SetVariable
         {
             Id = "SetOutputResult",
@@ -335,6 +513,7 @@ public class AssessmentWorkflow : WorkflowBase
             Variable = outputResultJson,
             Value = new(context =>
             {
+                var parsed = analysisOutput.Get(context);
                 var result = new AssessmentResult
                 {
                     Status = assessmentStatus.Get(context),
@@ -344,7 +523,7 @@ public class AssessmentWorkflow : WorkflowBase
                     JuniorResponse = juniorResponse.Get(context) ?? string.Empty,
                     Gaps = DeserializeList(gapsJson.Get(context)),
                     Strengths = DeserializeList(strengthsJson.Get(context)),
-                    AnalysisRationale = "Assessment completed"
+                    AnalysisRationale = parsed?.Rationale ?? "Assessment completed"
                 };
                 outputNextState.Set(context, nextState.Get(context).ToString());
                 outputStatus.Set(context, assessmentStatus.Get(context).ToString());
@@ -398,6 +577,7 @@ public class AssessmentWorkflow : WorkflowBase
             }
         };
         exposeOutputResponse.SetDisplayText("Expose Output Response");
+
         var exposeOutputTimeout = new Sequence
         {
             Id = "ExposeOutputTimeout",
@@ -412,6 +592,17 @@ public class AssessmentWorkflow : WorkflowBase
         };
         exposeOutputTimeout.SetDisplayText("Expose Output Timeout");
 
+        // ── Fail-closed error terminal ─────────────────────────────────
+        // Reached when either llm-call returns success=false or the JSON
+        // cannot be parsed. The workflow terminates here rather than
+        // proceeding with fabricated questions or a fabricated confidence.
+        var llmCallError = new Finish
+        {
+            Id = "LlmCallError",
+            Name = "LLM Call Error"
+        };
+        llmCallError.SetDisplayText("LLM Call Error");
+
         // ── Build the flowchart ────────────────────────────────────────
         builder.Root = new Flowchart
         {
@@ -422,44 +613,71 @@ public class AssessmentWorkflow : WorkflowBase
                 readInputs,
                 gatherContext,
                 storeContextResult,
-                generateQuestions,
+
+                // Question generation (llm-call dispatch + parse + gate)
+                generateQuestionsLlm,
+                parseQuestionsResult,
+                questionsSuccessCheck,
+
                 storeQuestions,
                 deliverQuestions,
                 waitForResponse,
                 storeResponse,
-                analyzeResponse,
+
+                // Response analysis (llm-call dispatch + parse + gate)
+                analyzeResponseLlm,
+                parseAnalysisResult,
+                analysisSuccessCheck,
+
                 storeAnalysis,
                 classifyResult,
                 storeClassification,
                 updateSkillProfile,
                 setOutput,
                 exposeOutputResponse,
+
+                // Timeout path
                 setTimeoutResult,
                 updateSkillProfileTimeout,
                 setOutputTimeout,
-                exposeOutputTimeout
+                exposeOutputTimeout,
+
+                // Fail-closed error terminal (both llm-call failures route here)
+                llmCallError
             },
             Connections =
             {
-                // Main flow: inputs -> context -> store context -> questions -> deliver -> wait
+                // Main flow: inputs → context → store context → generate questions
                 new(readInputs, gatherContext),
                 new(gatherContext, storeContextResult),
-                new(storeContextResult, generateQuestions),
-                new(generateQuestions, storeQuestions),
+                new(storeContextResult, generateQuestionsLlm),
+
+                // Question generation: dispatch → parse → gate
+                new(generateQuestionsLlm, parseQuestionsResult),
+                new(parseQuestionsResult, questionsSuccessCheck),
+                new(new FlowEndpoint(questionsSuccessCheck, "True"),  new FlowEndpoint(storeQuestions)),
+                new(new FlowEndpoint(questionsSuccessCheck, "False"), new FlowEndpoint(llmCallError)),
+
+                // Deliver and wait
                 new(storeQuestions, deliverQuestions),
                 new(deliverQuestions, waitForResponse),
 
-                // Response path: wait[Responded] -> store -> analyze -> classify -> profile -> output
+                // Response path: wait[Responded] → store → analyse → parse → gate
                 new(new FlowEndpoint(waitForResponse, "Responded"), new FlowEndpoint(storeResponse)),
-                new(storeResponse, analyzeResponse),
-                new(analyzeResponse, storeAnalysis),
+                new(storeResponse, analyzeResponseLlm),
+                new(analyzeResponseLlm, parseAnalysisResult),
+                new(parseAnalysisResult, analysisSuccessCheck),
+                new(new FlowEndpoint(analysisSuccessCheck, "True"),  new FlowEndpoint(storeAnalysis)),
+                new(new FlowEndpoint(analysisSuccessCheck, "False"), new FlowEndpoint(llmCallError)),
+
+                // Classify → profile → output
                 new(storeAnalysis, classifyResult),
                 new(classifyResult, storeClassification),
                 new(storeClassification, updateSkillProfile),
                 new(updateSkillProfile, setOutput),
                 new(setOutput, exposeOutputResponse),
 
-                // Timeout path: wait[Timeout] -> timeout result -> profile -> output
+                // Timeout path: wait[Timeout] → timeout result → profile → output
                 new(new FlowEndpoint(waitForResponse, "Timeout"), new FlowEndpoint(setTimeoutResult)),
                 new(setTimeoutResult, updateSkillProfileTimeout),
                 new(updateSkillProfileTimeout, setOutputTimeout),
@@ -469,7 +687,74 @@ public class AssessmentWorkflow : WorkflowBase
     }
 
     /// <summary>
-    /// Deserialize a JSON string to a list, returning empty list on failure
+    /// Read the <c>success</c> flag from a dispatched workflow's Result dictionary.
+    /// Returns <c>false</c> if the dictionary is null, the key is absent, or the
+    /// value is falsy — fail-closed by design.
+    /// </summary>
+    private static bool ReadSuccessFlag(IDictionary<string, object>? result)
+    {
+        if (result == null) return false;
+        if (!result.TryGetValue("success", out var s)) return false;
+        return s switch
+        {
+            bool b    => b,
+            string str => bool.TryParse(str, out var r) && r,
+            _         => false,
+        };
+    }
+
+    /// <summary>
+    /// Compute the target question count for a given skill level.
+    /// Mirrors the logic previously in GenerateQuestionsActivity.
+    /// </summary>
+    private static int ComputeQuestionCount(int skillLevel) => skillLevel switch
+    {
+        1 => 2,
+        2 => 3,
+        3 => 4,
+        4 => 4,
+        5 => 5,
+        _ => 3
+    };
+
+    /// <summary>
+    /// Extract the gap list from a previous-attempt JSON blob as a comma-separated
+    /// string for use in the generate-assessment-questions prompt template.
+    /// Returns an empty string when there is no previous attempt or no gaps.
+    /// </summary>
+    private static string ExtractPreviousGaps(string? previousAttemptJson)
+    {
+        if (string.IsNullOrEmpty(previousAttemptJson)) return "";
+        try
+        {
+            var prev = JsonSerializer.Deserialize<PreviousAttempt>(previousAttemptJson);
+            return prev?.Gaps?.Count > 0 ? string.Join(", ", prev.Gaps) : "";
+        }
+        catch
+        {
+            return "";
+        }
+    }
+
+    /// <summary>
+    /// Extract a JSON array of strings from a <see cref="JsonElement"/> property.
+    /// Returns an empty list when the property is absent, not an array, or empty.
+    /// </summary>
+    private static List<string> ExtractStringList(JsonElement element, string key)
+    {
+        if (!element.TryGetProperty(key, out var arr) || arr.ValueKind != JsonValueKind.Array)
+            return new List<string>();
+
+        return arr.EnumerateArray()
+            .Where(e => e.ValueKind == JsonValueKind.String)
+            .Select(e => e.GetString() ?? "")
+            .Where(s => !string.IsNullOrEmpty(s))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Deserialize a JSON string to a list of strings, returning an empty list on failure.
+    /// Handles both plain JSON arrays and QuestionSet-wrapped arrays.
     /// </summary>
     private static List<string> DeserializeList(string? json)
     {

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/AssessmentWorkflowStructureTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/AssessmentWorkflowStructureTests.cs
@@ -1,0 +1,193 @@
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Runtime.Activities;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Structural verification tests for AssessmentWorkflow (P0 fix 2026-06-30).
+///
+/// These tests assert that the workflow:
+/// 1. Dispatches <c>llm-call</c> for question generation (role=product_owner,
+///    action=generate-assessment-questions) instead of the fake heuristic
+///    <c>GenerateQuestionsActivity</c>.
+/// 2. Dispatches <c>llm-call</c> for response analysis (role=product_owner,
+///    action=analyze-assessment-response) instead of the fake heuristic
+///    <c>AnalyzeResponseActivity</c>.
+/// 3. Threads <c>TenantId</c> so the prompt registry resolves tenant-scoped prompts.
+/// 4. Is fail-closed: an <c>LlmCallError</c> terminal node exists, and
+///    <c>FlowDecision</c> gates check LLM-call success before proceeding — a
+///    <c>success=false</c> result routes to the error terminal rather than
+///    fabricating questions or a confidence score.
+/// </summary>
+[TestFixture]
+public class AssessmentWorkflowStructureTests
+{
+    // ================================================================
+    // Build sanity
+    // ================================================================
+
+    [Test]
+    public void AssessmentWorkflow_BuildsWithoutError()
+    {
+        var workflow = new AssessmentWorkflow();
+        var act = () => WorkflowTestHelper.BuildWorkflow(workflow);
+        act.Should().NotThrow("AssessmentWorkflow.Build() must complete without exceptions");
+    }
+
+    [Test]
+    public void AssessmentWorkflow_HasCorrectDefinitionId()
+    {
+        var workflow = new AssessmentWorkflow();
+        var builder = WorkflowTestHelper.BuildWorkflow(workflow);
+        builder.Object.DefinitionId.Should().Be("assessment");
+    }
+
+    // ================================================================
+    // TenantId threading
+    // ================================================================
+
+    [Test]
+    public void AssessmentWorkflow_HasTenantIdVariable()
+    {
+        var workflow = new AssessmentWorkflow();
+        var builder = WorkflowTestHelper.BuildWorkflow(workflow);
+        builder.Object.Variables
+            .Any(v => v.Name == "TenantId")
+            .Should().BeTrue(
+                "AssessmentWorkflow must thread TenantId so llm-call can resolve " +
+                "tenant-scoped prompts for generate-assessment-questions and " +
+                "analyze-assessment-response");
+    }
+
+    // ================================================================
+    // P0 fix: llm-call dispatches for both AI steps
+    // ================================================================
+
+    [Test]
+    public void AssessmentWorkflow_DispatchesLlmCallForQuestionGeneration()
+    {
+        var workflow = new AssessmentWorkflow();
+        var builder = WorkflowTestHelper.BuildWorkflow(workflow);
+        var flowchart = WorkflowTestHelper.GetFlowchart(builder);
+
+        flowchart.Activities
+            .OfType<DispatchWorkflow>()
+            .Should().Contain(d => d.Id == "GenerateQuestionsLlm",
+                "AssessmentWorkflow must dispatch llm-call (Id='GenerateQuestionsLlm') " +
+                "for AI question generation; GenerateQuestionsActivity used a hardcoded " +
+                "question bank that bypassed the LLM entirely");
+    }
+
+    [Test]
+    public void AssessmentWorkflow_DispatchesLlmCallForResponseAnalysis()
+    {
+        var workflow = new AssessmentWorkflow();
+        var builder = WorkflowTestHelper.BuildWorkflow(workflow);
+        var flowchart = WorkflowTestHelper.GetFlowchart(builder);
+
+        flowchart.Activities
+            .OfType<DispatchWorkflow>()
+            .Should().Contain(d => d.Id == "AnalyzeResponseLlm",
+                "AssessmentWorkflow must dispatch llm-call (Id='AnalyzeResponseLlm') " +
+                "for AI response analysis; AnalyzeResponseActivity used keyword counting " +
+                "that fabricated the confidence score the mentorship machine routes on");
+    }
+
+    // ================================================================
+    // Fail-closed: success-check gates + error terminal
+    // ================================================================
+
+    [Test]
+    public void AssessmentWorkflow_HasFailClosedErrorTerminal()
+    {
+        var workflow = new AssessmentWorkflow();
+        var builder = WorkflowTestHelper.BuildWorkflow(workflow);
+        var flowchart = WorkflowTestHelper.GetFlowchart(builder);
+
+        flowchart.Activities
+            .OfType<Finish>()
+            .Should().Contain(f => f.Id == "LlmCallError",
+                "AssessmentWorkflow must have a fail-closed LlmCallError terminal " +
+                "(Id='LlmCallError') that LLM-call failures route to — never proceed " +
+                "with fabricated questions or a fabricated confidence score");
+    }
+
+    [Test]
+    public void AssessmentWorkflow_HasSuccessCheckDecisionForQuestions()
+    {
+        var workflow = new AssessmentWorkflow();
+        var builder = WorkflowTestHelper.BuildWorkflow(workflow);
+        var flowchart = WorkflowTestHelper.GetFlowchart(builder);
+
+        flowchart.Activities
+            .OfType<FlowDecision>()
+            .Should().Contain(d => d.Id == "QuestionsLlmOk",
+                "AssessmentWorkflow must gate question delivery behind a QuestionsLlmOk " +
+                "FlowDecision — if the llm-call for questions fails, the workflow must " +
+                "route to the error terminal, not proceed with an empty/fabricated set");
+    }
+
+    [Test]
+    public void AssessmentWorkflow_HasSuccessCheckDecisionForAnalysis()
+    {
+        var workflow = new AssessmentWorkflow();
+        var builder = WorkflowTestHelper.BuildWorkflow(workflow);
+        var flowchart = WorkflowTestHelper.GetFlowchart(builder);
+
+        flowchart.Activities
+            .OfType<FlowDecision>()
+            .Should().Contain(d => d.Id == "AnalysisLlmOk",
+                "AssessmentWorkflow must gate the classify/profile steps behind an " +
+                "AnalysisLlmOk FlowDecision — if the llm-call for analysis fails, the " +
+                "workflow must route to the error terminal, not fabricate a confidence score");
+    }
+
+    // ================================================================
+    // Negative: heuristic activities must not appear in the flowchart
+    // ================================================================
+
+    [Test]
+    public void AssessmentWorkflow_DoesNotUseHeuristicActivities()
+    {
+        var workflow = new AssessmentWorkflow();
+        var builder = WorkflowTestHelper.BuildWorkflow(workflow);
+        var flowchart = WorkflowTestHelper.GetFlowchart(builder);
+
+        var typeNames = flowchart.Activities
+            .Select(a => a.GetType().Name)
+            .ToList();
+
+        typeNames.Should().NotContain("GenerateQuestionsActivity",
+            "GenerateQuestionsActivity has a hardcoded question bank — it is a fake " +
+            "AI step that must be replaced by DispatchWorkflow(\"llm-call\")");
+        typeNames.Should().NotContain("AnalyzeResponseActivity",
+            "AnalyzeResponseActivity uses keyword counting / response-length heuristics " +
+            "to fabricate confidence — it is a fake AI step that must be replaced by " +
+            "DispatchWorkflow(\"llm-call\")");
+    }
+
+    // ================================================================
+    // Parse activities exist in the flowchart
+    // ================================================================
+
+    [Test]
+    public void AssessmentWorkflow_HasParseActivitiesForLlmResults()
+    {
+        var workflow = new AssessmentWorkflow();
+        var builder = WorkflowTestHelper.BuildWorkflow(workflow);
+        var flowchart = WorkflowTestHelper.GetFlowchart(builder);
+
+        var ids = flowchart.Activities.Select(a => a.Id).ToList();
+
+        ids.Should().Contain("ParseQuestionsResult",
+            "AssessmentWorkflow must have a ParseQuestionsResult step to extract the " +
+            "JSON question array from the llm-call llmResponse");
+        ids.Should().Contain("ParseAnalysisResult",
+            "AssessmentWorkflow must have a ParseAnalysisResult step to extract the " +
+            "JSON {status,confidence,gaps,strengths,rationale} from the llm-call llmResponse");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TaxonomyDriftBuildTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TaxonomyDriftBuildTests.cs
@@ -102,6 +102,7 @@ public class TaxonomyDriftBuildTests
     /// </summary>
     private static readonly IReadOnlySet<string> ExpectedContributingWorkflows = new HashSet<string>
     {
+        "AssessmentWorkflow",           // P0 fix 2026-06-30: dispatches generate-assessment-questions + analyze-assessment-response
         "BlockerDiagnosisWorkflow",
         "ContextGatheringWorkflow",
         "DebuggingWorkflow",

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentActionTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentActionTests.cs
@@ -24,7 +24,9 @@ public class AgentActionTests
     [Test]
     public void Has_the_expected_token_count()
     {
-        Enum.GetValues<AgentAction>().Length.Should().Be(72);
+        // 72 original + 2 assessment actions (generate-assessment-questions,
+        // analyze-assessment-response) added in assessment P0.
+        Enum.GetValues<AgentAction>().Length.Should().Be(74);
     }
 
     [TestCase("context-scan", AgentAction.ContextScan)]

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/RolePhaseMapTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/RolePhaseMapTests.cs
@@ -11,7 +11,9 @@ namespace Tamma.Api.Tests.Agents;
 /// The 8 roles: developer, tester, security, devops, architect, product_owner,
 /// senior_developer, tech_writer.
 ///
-/// The 72 actions are the union of the per-role action sets in SPEC §4.
+/// The 74 actions are the union of the per-role action sets in SPEC §4
+/// (72 original + 2 assessment actions: generate-assessment-questions,
+/// analyze-assessment-response under product_owner — added in assessment P0).
 /// Which (role, action) pairs are valid is the per-role eligibility matrix.
 /// </summary>
 [TestFixture]
@@ -39,9 +41,11 @@ public class RolePhaseMapTests
     }
 
     [Test]
-    public void ValidActions_Should_Contain_Seventy_Two_Actions()
+    public void ValidActions_Should_Contain_Seventy_Four_Actions()
     {
-        RolePhaseMap.ValidActions.Should().HaveCount(72);
+        // 72 original actions + 2 assessment actions added in assessment P0
+        // (generate-assessment-questions, analyze-assessment-response under product_owner).
+        RolePhaseMap.ValidActions.Should().HaveCount(74);
     }
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/PromptStore/SystemPromptsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/PromptStore/SystemPromptsTests.cs
@@ -163,6 +163,45 @@ public class SystemPromptsTests
     }
 
     // ------------------------------------------------------------------
+    // Assessment P0 — the 2 assessment cells under product_owner
+    // (task-1 of docs/superpowers/plans/2026-06-30-assessment-p0-llm-call.md)
+    // TDD RED: these assertions fail BEFORE the enum/taxonomy/template additions.
+    // ------------------------------------------------------------------
+
+    [Test]
+    public void AssessmentActions_ExistInTaxonomy_ProductOwner()
+    {
+        // Both cells must be present in the taxonomy (added to product_owner's §4
+        // action set and AgentAction enum) and resolve to a non-empty template.
+        var generate = SystemPrompts.GetRoleAction("product_owner", "generate-assessment-questions");
+        var analyze = SystemPrompts.GetRoleAction("product_owner", "analyze-assessment-response");
+
+        generate.Should().NotBeNull(
+            "generate-assessment-questions must be in product_owner's RolePhaseMap action set " +
+            "with a non-empty SystemPrompts template (assessment P0 taxonomy)");
+        analyze.Should().NotBeNull(
+            "analyze-assessment-response must be in product_owner's RolePhaseMap action set " +
+            "with a non-empty SystemPrompts template (assessment P0 taxonomy)");
+
+        generate!.Variables.Should().Contain("storyContext")
+            .And.Contain("skillLevel")
+            .And.Contain("questionCount")
+            .And.Contain("previousGaps",
+                "generate-assessment-questions must declare the Shared-contract variables from the plan");
+
+        analyze!.Variables.Should().Contain("storyContext")
+            .And.Contain("questions")
+            .And.Contain("response")
+            .And.Contain("skillLevel",
+                "analyze-assessment-response must declare the Shared-contract variables from the plan");
+
+        generate.Template.Should().NotBeNullOrWhiteSpace(
+            "generate-assessment-questions template must not be empty (resolution is tenant→system→error)");
+        analyze.Template.Should().NotBeNullOrWhiteSpace(
+            "analyze-assessment-response template must not be empty (resolution is tenant→system→error)");
+    }
+
+    // ------------------------------------------------------------------
     // Audit prompts/001 — role-tailored review-lens shape is retained on the
     // review-family cells. The PlanReview body is used by the per-role
     // plan-review lens actions; CodeReview by the code-review lens actions.

--- a/docs/superpowers/plans/2026-06-30-assessment-p0-llm-call.md
+++ b/docs/superpowers/plans/2026-06-30-assessment-p0-llm-call.md
@@ -1,0 +1,148 @@
+# Assessment P0 — Replace fake-AI steps with real `llm-call` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Replace `AssessmentWorkflow`'s two fake heuristic "AI" steps (`GenerateQuestionsActivity` hardcoded question bank; `AnalyzeResponseActivity` keyword-counting that *fabricates the confidence the mentorship machine routes on*) with real `DispatchWorkflow("llm-call")` calls (per the Epic-32 rule: a workflow step never calls a provider directly), feeding the existing `context-gathering` output as context and threading `tenantId`. Add the two assessment prompt `(role, action)` cells the registry needs.
+
+**Architecture:** `llm-call` resolves prompts by `(role, action)` from the jagged `RolePhaseMap` taxonomy (SPEC §4); resolution is tenant→system→**error** (no empty fallback). So the new assessment actions must be added consistently across `AgentAction` (enum) + `RolePhaseMap` (the role's action set) + `SystemPrompts.RoleActionTemplates` (a non-empty body per cell) — the taxonomy-drift tests enforce this. Then the workflow dispatches `llm-call` with `role`+`action`+`variables` and parses the structured result (mirroring `ContextGatheringWorkflow`'s JSON-slice pattern). **Epic-6 RAG is deferred** — `IIntelligenceHttpClient` lives in `Tamma.Api` with zero references from `Tamma.Activities`/`Tamma.ElsaServer`; the achievable context is the existing `context-gathering` output (currently dropped into a placeholder).
+
+**Tech Stack:** .NET 9 / EF Core 9 / Elsa 3.5.3 workflows / NUnit + Moq / tests via `sg docker -c "dotnet test ..."`.
+
+## Global Constraints
+
+- **Build gate:** `dotnet build apps/tamma-elsa/Tamma.sln -clp:ErrorsOnly` → 0 errors. **Test runner:** `sg docker -c "dotnet test ..."`. Run the FULL `Tamma.Api.Tests` (taxonomy/prompt tests) + `Tamma.Activities.Tests` (workflow) before committing.
+- **Taxonomy drift is enforced:** every `RolePhaseMap` `(role, action)` cell MUST have a non-empty `SystemPrompts.RoleActionTemplates` body (and matching convention cell if conventions use the same taxonomy). Adding an action to `RolePhaseMap` without a template (or vice versa) fails a drift test. Add ALL sides atomically in Task 1; run the drift tests.
+- **No empty fallback:** prompt resolution is tenant→system→error. The new templates must be real, non-empty bodies.
+- **Canonical role:** use `product_owner` (the audit's `analyst` aliases to `product_owner` via `RolePhaseMap.cs:229`). The `llm-call` wire `role` may be `"analyst"` (normalizes) or `"product_owner"` — use the canonical `AgentRole.ProductOwner.ToWire()` to avoid the alias indirection. Confirm `product_owner` is the right home vs `senior_developer` by checking what role `MentorshipWorkflow` (Assessment's parent) uses; prefer consistency.
+- **No schema change** (no migration, no `TammaModelConfiguration`). The prompt templates are code (`SystemPrompts.cs`), not DB rows.
+- **Branch:** `feat/assessment-p0-llm-call` off `origin/main` (`f118e58d`) in worktree `/home/meywd/tamma-wt/assessment-p0`.
+
+---
+
+## Verified current-state appendix (origin/main `f118e58d`, 2026-06-30 — do not re-derive)
+
+### The 2 fake-AI activities (convert) + the 1 to keep
+- `apps/tamma-elsa/src/Tamma.Activities/Assessment/GenerateQuestionsActivity.cs` — `CodeActivity<QuestionSet>`; hardcoded question bank (`GetSkillLevelQuestions` L168-197); comment L135 "in production, this would delegate to the LLM Call workflow." **FAKE → replace with llm-call.**
+- `apps/tamma-elsa/src/Tamma.Activities/Assessment/AnalyzeResponseActivity.cs` — heuristic `PerformAnalysis` (L120): confidence from response-length/question-count (L152-171) + technical-term counting (L174-183) + substring presence (L186-193); comments L80-82/L117-118 admit it should be llm-call. **FAKE → replace with llm-call.** (Injects `IMentorshipSessionRepository` only to log an event.)
+- `apps/tamma-elsa/src/Tamma.Activities/Assessment/ClassifyResultActivity.cs` — deterministic threshold router (L112-129). **KEEP** — just feed it the real LLM confidence.
+- Models: `apps/tamma-elsa/src/Tamma.Activities/Assessment/Models/AssessmentModels.cs` (`QuestionSet`, `AnalysisResult`, `PreviousAttempt`, `AssessmentResult`).
+
+### The `llm-call` dispatch + result pattern (copy)
+- Compliant ref `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/PlanGenerationWorkflow.cs`: `var llmResult = builder.WithVariable<IDictionary<string,object>?>();` (L59); dispatch L88-113 `new DispatchWorkflow { WorkflowDefinitionId = new("llm-call"), Input = new(ctx => new Dictionary<string,object>{ ["role"]=..., ["action"]=..., ["tenantId"]=tenantId.Get(ctx), ["variables"]=new Dictionary<string,object>{...}, ["enableTools"]=true }), WaitForCompletion = new(true), Result = new(llmResult) };` then read L118-135 `result.TryGetValue("llmResponse", out var r)`.
+- Structured-JSON parse ref `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ContextGatheringWorkflow.cs:177-204` (slice `output[jsonStart..jsonEnd]` + deserialize). AnalyzeResponse must mirror this to recover `{status, confidence, gaps[], strengths[], rationale}`.
+- `llm-call` contract — `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/LlmCallWorkflow.cs` (`DefinitionId="llm-call"`, L55). Inputs read in `InitInputs` (L109-198): `role`/`agentRole`, `action`, `tenantId`, `variables` (nested dict the prompt template renders), `enableTools`, optional `context`/`systemPromptOverride`/`taskPrompt`. Outputs (readable from `Result` dict): `success`, `llmResponse` (text), `workflowOutput` (full JSON), `costUsd`, `tokensUsed`. Defaults role to `"developer"` if none resolves (L196).
+- Roles `apps/tamma-elsa/src/Tamma.Core/Agents/AgentRole.cs:11-18` (`developer/tester/security/devops/architect/product_owner/senior_developer/tech_writer`). Aliases `RolePhaseMap.cs:221-233` (`analyst`→`product_owner` L229). `AgentAction` enum `apps/tamma-elsa/src/Tamma.Core/Agents/AgentAction.cs:16` + `ToWire()` L112. **No assessment action exists yet.**
+
+### The prompt taxonomy (where Task 1 adds cells)
+- `apps/tamma-elsa/src/Tamma.Api/Auth/SystemPrompts.cs`: `RoleActionTemplates = BuildRoleActionTemplates()` (L101) — the jagged `(role, action)` template list (~72 cells, "one non-empty body per cell in each role's `RolePhaseMap` action set"). `RoleSystemPrompts` (L76, per-role identity). Resolution is tenant→system→error (header L34-56). `PromptStoreService` (`Tamma.Api/Services/PromptStore/PromptStoreService.cs`) resolves; `ResolvePromptFromRegistryActivity` (in the llm-call path) calls it by `(role, action)`.
+- `apps/tamma-elsa/src/Tamma.Core/Agents/RolePhaseMap.cs` — each role's action set (the taxonomy the templates must match). Conventions key off the same taxonomy (`Tamma.Api/Services/Conventions/ConventionSeedSpecs.cs` — check whether a convention cell is also required per role+action, to keep the convention drift test green).
+
+### AssessmentWorkflow shape — `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AssessmentWorkflow.cs`
+`ReadInputs` (L80; **add `tenantId` read here**) → `GatherContext` DispatchWorkflow("context-gathering") (L114-116; result currently NOT captured) → `StoreContextResult` (L132; **writes a placeholder — wire the real output**) → `GenerateQuestions` activity (L143-145; **→ llm-call**) → `StoreQuestions` (L159) → `DeliverQuestions` (L171) → `WaitForResponse` (L184) → [Responded] `StoreResponse` (L199) → `AnalyzeResponse` activity (L211-213; **→ llm-call**) → `StoreAnalysis` (L227) → `ClassifyResult` (L272; keep) → `UpdateSkillProfile` (L300) → `SetOutputResult` (L333; **hardcodes `AnalysisRationale="Assessment completed"` — use the real rationale**); [Timeout] branch L246/315/363. Flowchart root L416, connections L442.
+
+### Out of scope (deferred / recorded)
+- **Epic-6 RAG context** — no Activities-layer seam (`IIntelligenceHttpClient` is `Tamma.Api`-only). Use `context-gathering` output instead; file a follow-up to expose RAG to the Activities layer.
+- The structurally-dead timeout branch (no timer/resume — audit #3/#4); benchmark/leaderboard wiring for the new actions (Epic-32 later).
+
+---
+
+## File Structure
+
+**Task 1 (prompt taxonomy):** modify `Tamma.Core/Agents/AgentAction.cs` (+2 enum entries), `Tamma.Core/Agents/RolePhaseMap.cs` (add the 2 actions to `product_owner`'s set), `Tamma.Api/Auth/SystemPrompts.cs` (2 `RoleActionTemplates` bodies), and (if the convention drift test requires) `Tamma.Api/Services/Conventions/ConventionSeedSpecs.cs`.
+
+**Task 2 (workflow):** modify `Tamma.ElsaServer/Workflows/AssessmentWorkflow.cs` (replace 2 activity nodes with llm-call dispatch+parse; wire context + tenantId + real rationale); a small `AssessmentLlmParsing` helper if the JSON parsing is non-trivial; the fake activities `GenerateQuestionsActivity`/`AnalyzeResponseActivity` either kept as a documented `mockMode` fallback OR deleted (decide by their references — if only AssessmentWorkflow used them, prefer keeping as an explicit-mock fallback per audit 7-2 AC7, gated off by default).
+
+---
+
+## Shared contract (both tasks must agree on these variable names)
+
+**`generate-assessment-questions`** — template variables (rendered by the prompt; passed in `variables`):
+`{{storyContext}}` (context-gathering output), `{{skillLevel}}`, `{{questionCount}}`, `{{previousGaps}}` (empty on first attempt). Expected LLM output: a JSON array of question strings (or `{questions:[...]}`) the workflow parses into `QuestionSet`.
+
+**`analyze-assessment-response`** — template variables: `{{storyContext}}`, `{{questions}}`, `{{response}}`, `{{skillLevel}}`. Expected LLM output: JSON `{"status":"...","confidence":0.0-1.0,"gaps":[...],"strengths":[...],"rationale":"..."}` the workflow parses into `AnalysisResult` and feeds `confidence` to `ClassifyResultActivity`.
+
+---
+
+## Task 1: Add the 2 assessment `(role, action)` cells to the prompt taxonomy
+
+**Files:** `AgentAction.cs`, `RolePhaseMap.cs`, `SystemPrompts.cs`, (maybe) `ConventionSeedSpecs.cs`. **Test:** the existing taxonomy-drift test project (find it — likely `Tamma.Api.Tests`).
+
+**Interfaces:**
+- Produces: `AgentAction.GenerateAssessmentQuestions` (wire `"generate-assessment-questions"`) + `AgentAction.AnalyzeAssessmentResponse` (wire `"analyze-assessment-response"`), both in `product_owner`'s `RolePhaseMap` action set, each with a non-empty `SystemPrompts` template using the Shared-contract variables.
+
+- [ ] **Step 1: Find the drift test + the taxonomy wiring.** Locate the test that asserts "every `RolePhaseMap` (role,action) cell has a `SystemPrompts.RoleActionTemplates` body" (grep `RoleActionTemplates`/`drift`/`taxonomy` in `tests/`). Read `RolePhaseMap.cs` to see how a role's action set + the `AgentAction`→wire mapping + the alias map are structured. Read `SystemPrompts.BuildRoleActionTemplates()` to see the `PromptTemplate` shape (role, action, body, variables?). Read `ConventionSeedSpecs.cs` to determine if conventions ALSO require a cell per (role,action) (if so, add there too).
+
+- [ ] **Step 2: Write the failing taxonomy test** — add an assertion (or rely on the existing drift test) that `PromptStoreService` (or the resolver) resolves `(product_owner, generate-assessment-questions)` and `(product_owner, analyze-assessment-response)` to a non-empty template. Run it → FAIL (action/template absent). Capture RED.
+
+- [ ] **Step 3: Add the AgentAction entries** in `AgentAction.cs` (2 enum members; confirm `ToWire()` via `EnumWire` produces `"generate-assessment-questions"`/`"analyze-assessment-response"` — match the project's enum-wire kebab convention; if `EnumWire` needs an attribute/registration, add it).
+
+- [ ] **Step 4: Add the actions to `product_owner`'s `RolePhaseMap` action set** (so the (role,action) cell is part of the taxonomy). Follow the exact structure the other actions use.
+
+- [ ] **Step 5: Add the 2 non-empty templates** in `SystemPrompts.BuildRoleActionTemplates()` for `(product_owner, generate-assessment-questions)` and `(product_owner, analyze-assessment-response)`. Write real, useful prompt bodies using the Shared-contract variables — e.g. the generate body instructs the model to produce N skill-appropriate questions about the story as a JSON array; the analyze body instructs it to assess the junior's response and return the JSON `{status,confidence,gaps,strengths,rationale}` shape. (If `ConventionSeedSpecs` requires a matching cell, add minimal convention bodies too.)
+
+- [ ] **Step 6: Run the taxonomy/drift tests → GREEN.** Run the full `Tamma.Api.Tests` project → no drift failures, prompt resolution passes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/tamma-elsa/src/Tamma.Core/Agents/AgentAction.cs \
+        apps/tamma-elsa/src/Tamma.Core/Agents/RolePhaseMap.cs \
+        apps/tamma-elsa/src/Tamma.Api/Auth/SystemPrompts.cs \
+        apps/tamma-elsa/src/Tamma.Api/Services/Conventions/ConventionSeedSpecs.cs \
+        apps/tamma-elsa/tests
+git commit -m "feat(assessment): add generate/analyze assessment (role,action) prompt cells"
+```
+
+---
+
+## Task 2: Restructure `AssessmentWorkflow` to dispatch `llm-call`
+
+**Files:** `AssessmentWorkflow.cs` (+ a parsing helper if needed). **Test:** the workflow test project (`Tamma.Activities.Tests` / `WorkflowStructureTests`).
+
+**Interfaces:**
+- Consumes: the Task-1 actions (`AgentAction.GenerateAssessmentQuestions`/`AnalyzeAssessmentResponse`), `AgentRole.ProductOwner`, the `llm-call` Input/Result contract.
+
+- [ ] **Step 1: Thread `tenantId`** — add `var tenantId = builder.WithVariable<string>("TenantId","")` + set it from `ctx.GetInput<string>("tenantId") ?? ""` in `ReadInputs` (mirror PlanGeneration). (MentorshipWorkflow, Assessment's parent, should pass it; the `?? ""` default is safe.)
+
+- [ ] **Step 2: Capture the context-gathering output** — bind the `GatherContext` DispatchWorkflow's `Result` to a variable and replace `StoreContextResult`'s placeholder with the real gathered context (the `storyContext` fed into the question/analysis variables).
+
+- [ ] **Step 3: Replace `GenerateQuestions`** — write the failing workflow test first (assert the workflow has a `DispatchWorkflow("llm-call")` node for question generation carrying `role=product_owner`/`action=generate-assessment-questions`/`tenantId`; mirror the Bucket-B structural test seam if that's the ceiling). Then replace the `GenerateQuestionsActivity` node with a `DispatchWorkflow{ WorkflowDefinitionId=new("llm-call"), Input=...(role, action=GenerateAssessmentQuestions, tenantId, variables={storyContext,skillLevel,questionCount,previousGaps}, enableTools=false), WaitForCompletion=true, Result=questionLlm }` + a parse step that turns `questionLlm["llmResponse"]` JSON into `QuestionSet` (reuse the ContextGathering JSON-slice helper). On `success=false` route to the existing Error/timeout path (do not proceed with empty questions).
+
+- [ ] **Step 4: Replace `AnalyzeResponse`** — same pattern: `DispatchWorkflow("llm-call")` with `action=AnalyzeAssessmentResponse`, variables `{storyContext,questions,response,skillLevel}`; parse the `{status,confidence,gaps,strengths,rationale}` JSON into `AnalysisResult`; on `success=false`, fail closed (route to Error, do NOT fabricate confidence). Feed the parsed `confidence` to `ClassifyResultActivity` and the parsed `rationale` to `SetOutputResult` (replacing the hardcoded `"Assessment completed"`).
+
+- [ ] **Step 5: Rewire the flowchart `Connections`** (L442) for the new dispatch+parse nodes (each dispatch → parse → next), preserving the Responded/Timeout branches. Add an Error terminal for `success=false` on either llm-call (fail-closed, no fabricated result).
+
+- [ ] **Step 6: Handle the now-unused fake activities** — if `GenerateQuestionsActivity`/`AnalyzeResponseActivity` are referenced ONLY by AssessmentWorkflow, either delete them or keep them behind an explicit `mockMode` (audit 7-2 AC7) defaulted off. Decide by `grep` for their references; record the choice. Don't leave them silently dead.
+
+- [ ] **Step 7: Run the workflow tests + build → green.** Full `Tamma.Activities.Tests` + build 0 errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AssessmentWorkflow.cs apps/tamma-elsa/tests
+git commit -m "feat(assessment): dispatch llm-call for questions+analysis, wire context+tenantId, real rationale"
+```
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Taxonomy drift test fails (action added to one side only) | Task 1 adds AgentAction + RolePhaseMap + SystemPrompts (+ conventions) atomically; Step 6 runs the drift tests. |
+| Prompt resolution 422/errors on the new role+action | The action lives in `product_owner`'s RolePhaseMap set with a non-empty template; Task 1 Step 2 tests resolution. Role passed as canonical `product_owner`. |
+| LLM returns unparseable JSON → fabricated/empty result | Parse defensively (slice like ContextGathering); on parse-fail or `success=false`, route to the Error/fail-closed path — never proceed with empty questions or fabricated confidence (the whole point — the heuristic's fabrication was the P0). |
+| Wrong role home (product_owner vs senior_developer) | Confirm against MentorshipWorkflow's role usage in Task 1 Step 1; product_owner is the audit's analyst-alias target. |
+| Deleting the fake activities breaks other callers | Task 2 Step 6 greps references first. |
+
+## Acceptance criteria
+
+1. `AssessmentWorkflow` generates questions and analyzes responses via `DispatchWorkflow("llm-call")` (role `product_owner`, the 2 new actions), not the heuristic activities; `ClassifyResult` is fed the real LLM confidence; `SetOutputResult` uses the real rationale; `context-gathering` output + `tenantId` are wired through.
+2. The 2 new `(product_owner, action)` cells exist in `AgentAction` + `RolePhaseMap` + `SystemPrompts` (+ conventions if required); taxonomy-drift tests green; prompt resolution returns non-empty.
+3. Fail-closed: `success=false` or unparseable LLM output routes to Error (no fabricated confidence / empty questions).
+4. Build 0 errors; full `Tamma.Api.Tests` + `Tamma.Activities.Tests` green; **no schema change**. RAG explicitly deferred with a follow-up note.
+
+## Self-review
+- Spec coverage: audit P0 #1 (GenerateQuestions→llm-call) = Task 2 Step 3; #2 (AnalyzeResponse→llm-call) = Task 2 Step 4; #7 (StoreContextResult placeholder + hardcoded rationale) = Task 2 Steps 2/4. The prompt prerequisite = Task 1. RAG deferred (no seam).
+- Coupling: the Shared-contract variable names bind Task 1's templates to Task 2's dispatch `variables` — keep them identical.
+- Highest blast radius: Task 1 (the canonical AgentAction enum + the drift-guarded taxonomy) — gated behind the drift tests; Task 2's fail-closed parsing (the P0 fabrication fix).


### PR DESCRIPTION
## Assessment P0 — replace fake heuristic AI with real `llm-call`

`AssessmentWorkflow`'s two "AI" steps were fakes: `GenerateQuestionsActivity` returned a hardcoded question bank, and `AnalyzeResponseActivity` computed confidence by **counting keywords and response length** — *fabricating the confidence the entire mentorship skill-routing machine then acts on*. This replaces both with real `DispatchWorkflow("llm-call")` calls and makes the flow **fail-closed** (it now refuses to proceed on a failed/garbled LLM call rather than inventing a result). Per the Epic-32 rule, the workflow never calls a provider directly — it routes through `llm-call`.

Plan: `docs/superpowers/plans/2026-06-30-assessment-p0-llm-call.md` (subagent-driven: per-task TDD + two-stage review; the workflow restructure was reviewed on the most capable model for fail-closed correctness).

### What changed (2 tasks)

1. **Prompt taxonomy** — added `generate-assessment-questions` + `analyze-assessment-response` under the `product_owner` role across all sides of the drift-guarded `(role, action)` taxonomy: `AgentAction` (enum + wire), `RolePhaseMap` (the role's action set), and `SystemPrompts.RoleActionTemplates` (two real, non-empty bodies). The 3-way keyset drift test (prompts == conventions == taxonomy) stays green; conventions auto-iterate the taxonomy so no manual cell was needed.
2. **Workflow restructure** — `GenerateQuestions`/`AnalyzeResponse` activity nodes replaced with `llm-call` dispatch + JSON parse (role `product_owner`, the two new actions). The parsed LLM **confidence** is fed to the existing deterministic `ClassifyResultActivity` (kept); the real **rationale** replaces the hardcoded `"Assessment completed"`; the `context-gathering` output (previously dropped into a placeholder) is wired in as `storyContext`; `tenantId` is threaded. The fake activities are `[Obsolete]`-gated and de-wired (kept as explicit mocks per the audit).

**Fail-closed (the P0 fix):** every JSON parse runs inside a `try/catch` that converts *any* failure (null result, `success=false`, missing/unparseable response, empty questions, non-numeric confidence) into a flag — **no exception escapes** — and a `FlowDecision` routes the failure to an `LlmCallError` terminal. `ClassifyResult` is reachable *only* with a real parsed numeric confidence, so a failed analysis can never produce a fabricated score. (This avoids the Elsa "throwing activity with a success-only edge halts with no terminal" trap — the fail-closed edge is genuinely reachable.)

### Verification
- Build **0 errors**; `Tamma.Api.Tests` **3780/3780**; `Tamma.Activities.Tests` **2099/2099**; `TaxonomyDriftBuildTests` green; `AssessmentWorkflowStructureTests` 10/10 (RED→GREEN).
- **No schema change** (prompts are code, not DB rows).

### Deferred / follow-ups (documented)
- **Epic-6 RAG context** — not reachable: `IIntelligenceHttpClient.QueryRagAsync` lives in `Tamma.Api` with zero references from `Tamma.Activities`/`Tamma.ElsaServer`. The achievable context (the `context-gathering` summary) is now wired; embedding retrieval needs a separate story to expose the RAG client to the Activities layer.
- **Parent `tenantId` pass-through** — `AssessmentWorkflow` threads `tenantId`, but its parent `MentorshipWorkflow` doesn't yet *supply* it (so it resolves to `""` → system-default prompts, tenant overrides bypassed in SaaS). The 1-line fix belongs in `MentorshipWorkflow`, which only gains its own `tenantId` variable in **#397** — so this is a post-#397 follow-up (adding it here would conflict).
- Structural tests assert node-presence (the harness ceiling); the fail-closed edge wiring was verified by review, not pinned by a test.

Merging does not deploy (the `qa-*` tag gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
