### PR TITLE
Epic 30 Phase B: reconcile V2 Cranl provisioning with the unified model (pool rows + drop Cranl columns)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/Cranl/CranlModels.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/Cranl/CranlModels.cs
@@ -115,6 +115,14 @@ public sealed class CranlDatabase
     /// <see cref="ConnectionString"/> if Cranl provided one; otherwise stitches
     /// <c>postgresql://user:pass@host:port/db</c>. Returns null when any required
     /// part is missing.
+    ///
+    /// <para>The username and password are percent-encoded
+    /// (<see cref="Uri.EscapeDataString(string)"/>) so a random Cranl-minted
+    /// credential containing URI-reserved chars (<c>@ : / # ? % + </c> or
+    /// space) produces a VALID libpq URI — both for the pool-row admin string
+    /// parse and for the <c>DATABASE_URL</c> the Cranl engine reads. The
+    /// keyword-form parser percent-decodes on the way back, so the credential
+    /// round-trips exactly.</para>
     /// </summary>
     public string? BuildConnectionString()
     {
@@ -124,7 +132,9 @@ public sealed class CranlDatabase
             || string.IsNullOrWhiteSpace(Password) || string.IsNullOrWhiteSpace(Database))
             return null;
         var port = Port ?? 5432;
-        return $"postgresql://{Username}:{Password}@{Host}:{port}/{Database}";
+        var user = Uri.EscapeDataString(Username);
+        var pass = Uri.EscapeDataString(Password);
+        return $"postgresql://{user}:{pass}@{Host}:{port}/{Database}";
     }
 }
 

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/CranlProvisioningWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/CranlProvisioningWorkflow.cs
@@ -1,7 +1,10 @@
+using System.Globalization;
 using Microsoft.EntityFrameworkCore;
+using Npgsql;
 using Tamma.Api.Services.Provisioning.Cranl;
 using Tamma.Api.Services.Secrets.Stopgap;
 using Tamma.Data;
+using Tamma.Data.Abstractions;
 using Tamma.Data.Entities;
 
 namespace Tamma.Api.Services.Provisioning;
@@ -33,41 +36,68 @@ public sealed class CranlProvisioningWorkflow
     private readonly ControlPlaneDbContext _db;
     private readonly ICranlApiClient _cranl;
     private readonly CranlOptions _options;
-    private readonly TenantSecretProtector _protector;
     private readonly IConfiguration _configuration;
     private readonly IRuntimeSecretResolver? _secretResolver;
     private readonly ILogger<CranlProvisioningWorkflow> _logger;
+
+    // Epic 30 Phase B — the pool-row admin envelope + KEK slot use the
+    // AES-GCM connection-string protector the tenant_databases CRUD/seeder
+    // use; the schema move re-points the tenant onto the newly-registered
+    // Cranl pool row. (Task B3 dropped the standalone TenantSecretProtector
+    // dependency: the encrypted DB URL is no longer persisted on the tenant
+    // row — it lives only on the pool row's AdminConnectionStringEncrypted,
+    // and the plaintext libpq URI is re-derived transiently by polling.)
+    private readonly ITenantConnectionStringProtector _connProtector;
+    private readonly ITenantMoveService _moveService;
 
     public CranlProvisioningWorkflow(
         ControlPlaneDbContext db,
         ICranlApiClient cranl,
         CranlOptions options,
-        TenantSecretProtector protector,
         IConfiguration configuration,
         ILogger<CranlProvisioningWorkflow> logger,
+        ITenantConnectionStringProtector connProtector,
+        ITenantMoveService moveService,
         IRuntimeSecretResolver? secretResolver = null)
     {
         _db = db;
         _cranl = cranl;
         _options = options;
-        _protector = protector;
         _configuration = configuration;
         _secretResolver = secretResolver;
         _logger = logger;
+        _connProtector = connProtector;
+        _moveService = moveService;
     }
 
     /// <summary>Run the full provisioning flow for the tenant.</summary>
     public async Task ProvisionAsync(Guid tenantId, ProvisioningOptions options, CancellationToken ct)
     {
         var tenant = await LoadTenantAsync(tenantId, ct);
+        var entry = _db.Entry(tenant);
         try
         {
+            // B3: the Cranl walk/resume working-state lives in the
+            // tenants.provider_resource_ids JSONB (via CranlResourceIds), not
+            // the retired cranl_* columns. Each step reads back the id it may
+            // have already minted so a re-reserved task resumes rather than
+            // restarting. Stamp the region up front so the resource-ids map is
+            // self-consistent regardless of which caller seeded it (the v2
+            // provider stamps it at enqueue; the standalone walk relies on the
+            // resolved ProvisioningOptions.Region).
+            if (!string.IsNullOrEmpty(options.Region))
+            {
+                CranlResourceIds.Set(entry, CranlResourceIds.Region, options.Region);
+            }
+
             // Step 1: project
-            if (string.IsNullOrEmpty(tenant.CranlProjectId))
+            var projectId = CranlResourceIds.Get(entry, CranlResourceIds.ProjectId);
+            if (string.IsNullOrEmpty(projectId))
             {
                 var name = options.CustomName ?? BuildProjectName(tenantId);
                 var project = await _cranl.CreateProjectAsync(name, _options.OrganizationId, ct);
-                tenant.CranlProjectId = project.Id;
+                projectId = project.Id;
+                CranlResourceIds.Set(entry, CranlResourceIds.ProjectId, projectId);
                 await TransitionAsync(tenant,
                     ProvisioningState.DatabaseProvisioning,
                     "cranl_project_created", ct);
@@ -80,55 +110,88 @@ public sealed class CranlProvisioningWorkflow
             }
 
             // Step 2: create db
-            if (string.IsNullOrEmpty(tenant.CranlDatabaseId))
+            var databaseId = CranlResourceIds.Get(entry, CranlResourceIds.DatabaseId);
+            if (string.IsNullOrEmpty(databaseId))
             {
                 var dbName = "tamma-" + ShortenForName(tenantId);
                 var dbReq = new CreateDatabaseRequest
                 {
                     Name = dbName,
-                    ProjectId = tenant.CranlProjectId!,
+                    ProjectId = projectId!,
                     Type = "postgresql",
                     ServerId = options.Region
                 };
                 var created = await _cranl.CreateDatabaseAsync(dbReq, ct);
-                tenant.CranlDatabaseId = created.Id;
+                databaseId = created.Id;
+                CranlResourceIds.Set(entry, CranlResourceIds.DatabaseId, databaseId);
                 await TransitionAsync(tenant,
                     ProvisioningState.DatabaseProvisioning,
                     "cranl_database_create_pending", ct);
             }
 
-            // Step 3: poll db until running, capture connection string
-            if (tenant.CranlDatabaseUrlEncrypted is null
-                || tenant.CranlDatabaseUrlEncrypted.Length == 0)
+            // Step 3: poll db until running, capture the connection string
+            // transiently. B3: the encrypted DB URL is no longer persisted on
+            // the tenant row — the durable copy lives on the tenant_databases
+            // pool row (admin envelope) minted just below, and the plaintext
+            // libpq URI is re-derived here on every pass (polling a running
+            // DB returns immediately, so a resumed walk still gets it).
+            var databaseUrl = await PollDatabaseUntilRunningAsync(databaseId!, ct);
+            if (databaseUrl is null)
             {
-                var connectionString = await PollDatabaseUntilRunningAsync(tenant.CranlDatabaseId!, ct);
-                if (connectionString is null)
-                {
-                    await TransitionAsync(tenant,
-                        ProvisioningState.Failed,
-                        "database_did_not_report_connection_string", ct);
-                    return;
-                }
-                tenant.CranlDatabaseUrlEncrypted = _protector.Encrypt(connectionString);
                 await TransitionAsync(tenant,
-                    ProvisioningState.DatabaseReady,
-                    "cranl_database_running", ct);
+                    ProvisioningState.Failed,
+                    "database_did_not_report_connection_string", ct);
+                return;
             }
-            else
+            await TransitionAsync(tenant,
+                ProvisioningState.DatabaseReady,
+                "cranl_database_running", ct);
+
+            // ── B2 (Epic 30 Phase B): register the ready Cranl hosting DB as
+            //    a tenant_databases pool row and move the tenant's schema onto
+            //    it — so a Cranl-backed tenant routes through its unified
+            //    per-tenant EncryptedConnectionString envelope (the only DB
+            //    route after Phase B Task B1). Runs on every DatabaseReady
+            //    pass (fresh or resumed) and is idempotent. Fail-closed: a
+            //    pool-row/move failure flips the row to Failed rather than
+            //    deploying an app against a not-yet-moved tenant. The freshly
+            //    polled libpq URI is passed in — B2 no longer decrypts a
+            //    tenant column.
+            try
             {
+                await RegisterCranlDatabaseAndMoveAsync(tenant, databaseUrl, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                // Shutdown/cancellation — resume from DatabaseReady on the
+                // next reservation (mirrors the outer cancellation policy).
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // The full exception (with message + stack) goes to the trusted
+                // log sink for diagnostics. The PERSISTED provisioning detail
+                // gets a STRUCTURED short code (the exception type name) only —
+                // a raw ex.Message from a conn-string/DB failure can echo the
+                // admin connection string (CLAUDE.md: never persist/log secrets).
+                _logger.LogError(ex,
+                    "Cranl pool-row registration / schema move failed for tenant {TenantId}",
+                    tenantId);
                 await TransitionAsync(tenant,
-                    ProvisioningState.DatabaseReady,
-                    "resuming_with_existing_connection_string", ct);
+                    ProvisioningState.Failed,
+                    $"tenant_schema_move_failed:{ex.GetType().Name}", ct);
+                return;
             }
 
             // Step 4: create application
-            if (string.IsNullOrEmpty(tenant.CranlAppId))
+            var appId = CranlResourceIds.Get(entry, CranlResourceIds.AppId);
+            if (string.IsNullOrEmpty(appId))
             {
                 var appName = "tamma-engine-" + ShortenForName(tenantId);
                 var appReq = new CreateApplicationRequest
                 {
                     Name = appName,
-                    ProjectId = tenant.CranlProjectId!,
+                    ProjectId = projectId!,
                     RepositoryId = _options.RepositoryId,
                     Branch = _options.DefaultBranch,
                     BuildType = _options.DefaultBuildType,
@@ -136,7 +199,8 @@ public sealed class CranlProvisioningWorkflow
                     BuildPath = _options.AppBuildPath
                 };
                 var app = await _cranl.CreateApplicationAsync(appReq, ct);
-                tenant.CranlAppId = app.Id;
+                appId = app.Id;
+                CranlResourceIds.Set(entry, CranlResourceIds.AppId, appId);
                 await TransitionAsync(tenant,
                     ProvisioningState.AppProvisioning,
                     "cranl_application_created", ct);
@@ -148,24 +212,21 @@ public sealed class CranlProvisioningWorkflow
                     "resuming_existing_application", ct);
             }
 
-            // Step 5: push environment
-            var envText = await BuildEnvironmentTextAsync(
-                tenantId,
-                _protector.Decrypt(tenant.CranlDatabaseUrlEncrypted!),
-                ct);
-            await _cranl.PutEnvironmentAsync(tenant.CranlAppId!, envText, ct);
+            // Step 5: push environment (uses the freshly-polled libpq URI)
+            var envText = await BuildEnvironmentTextAsync(tenantId, databaseUrl, ct);
+            await _cranl.PutEnvironmentAsync(appId!, envText, ct);
             await TransitionAsync(tenant,
                 ProvisioningState.AppProvisioning,
                 "environment_pushed", ct);
 
             // Step 6: deploy
-            await _cranl.DeployApplicationAsync(tenant.CranlAppId!, ct);
+            await _cranl.DeployApplicationAsync(appId!, ct);
             await TransitionAsync(tenant,
                 ProvisioningState.AppDeploying,
                 "deploy_triggered", ct);
 
             // Step 7: poll app until running
-            var appReady = await PollApplicationUntilRunningAsync(tenant.CranlAppId!, ct);
+            var appReady = await PollApplicationUntilRunningAsync(appId!, ct);
             if (!appReady)
             {
                 await TransitionAsync(tenant,
@@ -174,16 +235,18 @@ public sealed class CranlProvisioningWorkflow
                 return;
             }
 
-            // Step 8: fetch domains
-            var domains = await _cranl.GetApplicationDomainsAsync(tenant.CranlAppId!, ct);
-            tenant.CranlAppUrl = domains.DefaultDomain
+            // Step 8: fetch domains → persist the engine host into the JSONB
+            // resource map (its last piece, known only once the app is up).
+            var domains = await _cranl.GetApplicationDomainsAsync(appId!, ct);
+            var appUrl = domains.DefaultDomain
                 ?? domains.Domains.FirstOrDefault()?.Host;
+            CranlResourceIds.Set(entry, CranlResourceIds.AppUrl, appUrl);
 
             // Step 9: ready
             await TransitionAsync(tenant, ProvisioningState.Ready, "provisioning_complete", ct);
             _logger.LogInformation(
                 "Cranl provisioning complete for tenant {TenantId} (app={AppUrl})",
-                tenantId, tenant.CranlAppUrl);
+                tenantId, appUrl);
         }
         catch (CranlApiException ex)
         {
@@ -217,38 +280,49 @@ public sealed class CranlProvisioningWorkflow
     /// <summary>
     /// Tear down the tenant's Cranl resources in the safe order:
     /// app → db → project (Cranl rejects project deletes that still own
-    /// resources). Clears the tenant's <c>cranl_*</c> columns on success.
+    /// resources). Clears the Cranl walk-state from the tenant's
+    /// <c>provider_resource_ids</c> JSONB on success, keeping only the region
+    /// hint for a possible re-provision.
     /// </summary>
     public async Task DeprovisionAsync(Guid tenantId, CancellationToken ct)
     {
         var tenant = await LoadTenantAsync(tenantId, ct);
+        var entry = _db.Entry(tenant);
         try
         {
-            if (!string.IsNullOrEmpty(tenant.CranlAppId))
+            var appId = CranlResourceIds.Get(entry, CranlResourceIds.AppId);
+            var databaseId = CranlResourceIds.Get(entry, CranlResourceIds.DatabaseId);
+            var projectId = CranlResourceIds.Get(entry, CranlResourceIds.ProjectId);
+
+            if (!string.IsNullOrEmpty(appId))
             {
                 await SafeDeleteAsync(
-                    () => _cranl.DeleteApplicationAsync(tenant.CranlAppId!, ct),
-                    $"application {tenant.CranlAppId}");
+                    () => _cranl.DeleteApplicationAsync(appId!, ct),
+                    $"application {appId}");
             }
-            if (!string.IsNullOrEmpty(tenant.CranlDatabaseId))
+            if (!string.IsNullOrEmpty(databaseId))
             {
                 await SafeDeleteAsync(
-                    () => _cranl.DeleteDatabaseAsync(tenant.CranlDatabaseId!, ct),
-                    $"database {tenant.CranlDatabaseId}");
+                    () => _cranl.DeleteDatabaseAsync(databaseId!, ct),
+                    $"database {databaseId}");
             }
-            if (!string.IsNullOrEmpty(tenant.CranlProjectId))
+            if (!string.IsNullOrEmpty(projectId))
             {
                 await SafeDeleteAsync(
-                    () => _cranl.DeleteProjectAsync(tenant.CranlProjectId!, ct),
-                    $"project {tenant.CranlProjectId}");
+                    () => _cranl.DeleteProjectAsync(projectId!, ct),
+                    $"project {projectId}");
             }
 
-            tenant.CranlProjectId = null;
-            tenant.CranlDatabaseId = null;
-            tenant.CranlAppId = null;
-            tenant.CranlDatabaseUrlEncrypted = null;
-            tenant.CranlAppUrl = null;
-            // Keep CranlRegion as a hint for re-provisioning.
+            // Clear the Cranl walk-state, keeping only the region hint for a
+            // possible re-provision (mirrors the old "null everything but
+            // CranlRegion" behaviour).
+            var region = CranlResourceIds.Get(entry, CranlResourceIds.Region);
+            var kept = new Dictionary<string, string>(StringComparer.Ordinal);
+            if (!string.IsNullOrEmpty(region))
+            {
+                kept[CranlResourceIds.Region] = region!;
+            }
+            CranlResourceIds.Write(entry, kept);
 
             await TransitionAsync(tenant, ProvisioningState.Deprovisioned, "teardown_complete", ct);
             _logger.LogInformation("Cranl deprovisioning complete for tenant {TenantId}", tenantId);
@@ -379,6 +453,260 @@ public sealed class CranlProvisioningWorkflow
         }
         return string.Join("\n", lines);
     }
+
+    /// <summary>
+    /// Epic 30 Phase B (Task B2): register the freshly-ready Cranl hosting
+    /// database as a <c>tenant_databases</c> pool row and move the tenant's
+    /// schema onto it — so a Cranl-backed tenant ends up routed through the
+    /// unified per-tenant <c>EncryptedConnectionString</c> envelope (the only
+    /// DB route after Phase B Task B1). Idempotent: the pool row is keyed by a
+    /// stable label (reused on a crash-resumed run rather than duplicated) and
+    /// the move is skipped once the tenant already points at the row.
+    ///
+    /// <para>Task B3: the admin credential is passed in as the freshly-polled
+    /// plaintext libpq URI (<paramref name="databaseUrl"/>) rather than
+    /// decrypted from a tenant column — that column no longer exists. The pool
+    /// row's <c>AdminConnectionStringEncrypted</c> becomes the sole durable
+    /// home of the encrypted credential.</para>
+    /// </summary>
+    private async Task RegisterCranlDatabaseAndMoveAsync(
+        Tenant tenant, string databaseUrl, CancellationToken ct)
+    {
+        // The Cranl DATABASE_URL is an owner/admin credential (design of
+        // record: it CAN CREATE ROLE + CREATE SCHEMA). Cranl returns a libpq
+        // URI; the pool + move engine parse admin strings with
+        // NpgsqlConnectionStringBuilder (keyword form only), so normalise
+        // before storing it as the pool row's admin connection string.
+        var adminConn = ToNpgsqlKeywordConnectionString(databaseUrl);
+        var parsed = new NpgsqlConnectionStringBuilder(adminConn);
+
+        var label = CranlPoolRowLabel(tenant);
+
+        // Idempotency: reuse an existing pool row for this Cranl DB. A
+        // duplicate would be an aliasing hazard — two rows pointing at one
+        // physical database let a move drop the live schema (TenantMoveService).
+        var poolRow = await _db.TenantDatabases
+            .FirstOrDefaultAsync(d => d.Label == label, ct);
+        if (poolRow is null)
+        {
+            var now = DateTime.UtcNow;
+            poolRow = new TenantDatabase
+            {
+                Id = Guid.NewGuid(),
+                Label = label,
+                Host = string.IsNullOrWhiteSpace(parsed.Host) ? "localhost" : parsed.Host,
+                Port = parsed.Port,
+                AdminConnectionStringEncrypted = _connProtector.Encrypt(adminConn),
+                // A Cranl hosting DB is single-tenant by construction.
+                PlacementClass = "dedicated",
+                // TenantMoveService.EligibleFor requires the tenant's plan
+                // slug to be present in TierEligibility for a dedicated row.
+                TierEligibility = string.IsNullOrWhiteSpace(tenant.Plan)
+                    ? Array.Empty<string>()
+                    : new[] { tenant.Plan },
+                TenantCapacity = 1,
+                TenantCount = 0,
+                Status = "active",
+                KekVersion = (short)_connProtector.CurrentKekVersion,
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+            _db.TenantDatabases.Add(poolRow);
+        }
+
+        // The provider resource-ids map (project/db/region ids) is already
+        // buffered on the tenant's JSONB shadow column by the walk's
+        // CranlResourceIds.Set calls; this SaveChanges flushes both the new
+        // pool row and that map together.
+        await _db.SaveChangesAsync(ct);
+
+        // Idempotency: skip the move ONLY when a prior move PROVABLY completed
+        // — the tenant points at this pool row AND its lifecycle Status is back
+        // to 'active' (TenantMoveService's final step 10). A tenant that points
+        // at the row but is still 'draining' committed the step-7 re-point and
+        // then died before verify/DROP-source/activate (steps 8-10). Skipping
+        // there would strand the tenant 'draining' forever (every write 503s,
+        // unrecoverable without operator action). Fall through instead and
+        // re-invoke MoveAsync — its IsResume tail sweeps stale schemas,
+        // re-verifies the round-trip, and re-activates.
+        var tenantEntry = _db.Entry(tenant);
+        var currentDatabaseId = tenantEntry.Property<Guid?>("DatabaseId").CurrentValue;
+        var lifecycleStatus = tenantEntry.Property<string?>("Status").CurrentValue;
+        if (currentDatabaseId == poolRow.Id
+            && string.Equals(lifecycleStatus, "active", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogInformation(
+                "Tenant {TenantId} already placed on Cranl pool row {DatabaseId} "
+                + "(status=active) — skipping schema move", tenant.Id, poolRow.Id);
+            return;
+        }
+
+        // Move INLINE (synchronously). CranlProvisioningWorkflow itself runs
+        // inside the single-slot provisioning.tenant platform task, so
+        // enqueueing a tenant.move task here would deadlock (the move task
+        // could never be reserved while this task holds the only slot).
+        // MoveAsync issues its DDL/pg_dump/pg_restore directly via
+        // IProcessRunner/ITenantDatabasePool — it enqueues no same-queue task.
+        _logger.LogInformation(
+            "Moving tenant {TenantId} schema onto Cranl pool row {DatabaseId} (label={Label})",
+            tenant.Id, poolRow.Id, label);
+        await _moveService.MoveAsync(tenant.Id, poolRow.Id, ct);
+    }
+
+    /// <summary>
+    /// Stable, unique pool-row label for a tenant's Cranl DB. Keyed on the
+    /// IMMUTABLE tenant id (not the admin-mutable Slug): a slug change between
+    /// provisioning passes must not make the idempotency lookup miss the
+    /// existing row and mint a SECOND pool row aliasing the same physical
+    /// database (which the move engine's aliasing guard would then reject,
+    /// wedging the tenant in Failed). Mirrors every other Cranl resource name,
+    /// which all use <see cref="ShortenForName"/>.
+    /// </summary>
+    private static string CranlPoolRowLabel(Tenant tenant) =>
+        "cranl-" + ShortenForName(tenant.Id);
+
+    /// <summary>
+    /// Convert a libpq URI (<c>postgres://</c> / <c>postgresql://</c>) to an
+    /// Npgsql keyword connection string. A string already in keyword form is
+    /// returned unchanged. Npgsql's builder/connection do NOT parse URIs, so
+    /// the pool + move engine need keyword form.
+    ///
+    /// <para>The URI is parsed MANUALLY rather than via <see cref="Uri"/>:
+    /// Cranl mints random passwords that are NOT percent-encoded, so a userinfo
+    /// containing a URI-reserved char (<c>@ : / # ? % + </c> or space) makes
+    /// <c>new Uri(...)</c> throw <see cref="UriFormatException"/> ("hostname
+    /// could not be parsed" / "Invalid port specified") — which previously
+    /// bricked pool-row registration and stranded the tenant in
+    /// <see cref="ProvisioningState.Failed"/> on every retry. This parser is
+    /// tolerant of raw OR percent-encoded userinfo, defaults a missing port to
+    /// 5432, tolerates an absent database, preserves query params (e.g.
+    /// <c>sslmode</c>), and strips IPv6 brackets. The final keyword string is
+    /// produced by <see cref="NpgsqlConnectionStringBuilder"/>, which escapes
+    /// values correctly.</para>
+    /// </summary>
+    internal static string ToNpgsqlKeywordConnectionString(string connectionString)
+    {
+        const string schemeMarker = "://";
+        var schemeIdx = connectionString.IndexOf(schemeMarker, StringComparison.Ordinal);
+        if (schemeIdx < 0
+            || !(connectionString.StartsWith("postgres://", StringComparison.OrdinalIgnoreCase)
+              || connectionString.StartsWith("postgresql://", StringComparison.OrdinalIgnoreCase)))
+        {
+            return connectionString;
+        }
+
+        // rest = user[:password]@host[:port][/database][?query]
+        var rest = connectionString[(schemeIdx + schemeMarker.Length)..];
+
+        // 1) userinfo — split at the LAST '@' (the password may itself contain
+        //    '@'; host/port/path never do). Everything after is the authority.
+        string userInfo = string.Empty;
+        var authorityAndQuery = rest;
+        var lastAt = rest.LastIndexOf('@');
+        if (lastAt >= 0)
+        {
+            userInfo = rest[..lastAt];
+            authorityAndQuery = rest[(lastAt + 1)..];
+        }
+
+        // 2) query string — split at the FIRST '?' in the authority portion
+        //    (host/port/db never contain '?').
+        string query = string.Empty;
+        var authority = authorityAndQuery;
+        var qIdx = authorityAndQuery.IndexOf('?');
+        if (qIdx >= 0)
+        {
+            query = authorityAndQuery[(qIdx + 1)..];
+            authority = authorityAndQuery[..qIdx];
+        }
+
+        // 3) database — split host[:port] from the db name at the FIRST '/'.
+        string database = string.Empty;
+        var hostPort = authority;
+        var slashIdx = authority.IndexOf('/');
+        if (slashIdx >= 0)
+        {
+            hostPort = authority[..slashIdx];
+            database = authority[(slashIdx + 1)..];
+        }
+
+        // 4) host[:port], honouring IPv6 literals ([::1]:5432 → Host=::1).
+        string host;
+        int? port = null;
+        if (hostPort.StartsWith('['))
+        {
+            var close = hostPort.IndexOf(']');
+            host = close > 0 ? hostPort[1..close] : hostPort.TrimStart('[');
+            var afterBracket = close >= 0 ? hostPort[(close + 1)..] : string.Empty;
+            if (afterBracket.StartsWith(':') && afterBracket.Length > 1)
+                port = ParsePort(afterBracket[1..]);
+        }
+        else
+        {
+            var colon = hostPort.LastIndexOf(':');
+            if (colon >= 0)
+            {
+                host = hostPort[..colon];
+                var portText = hostPort[(colon + 1)..];
+                if (portText.Length > 0)
+                    port = ParsePort(portText);
+            }
+            else
+            {
+                host = hostPort;
+            }
+        }
+
+        var builder = new NpgsqlConnectionStringBuilder
+        {
+            Port = port ?? 5432,
+        };
+        if (!string.IsNullOrEmpty(host))
+            builder.Host = host;
+
+        if (userInfo.Length > 0)
+        {
+            var sep = userInfo.IndexOf(':');
+            if (sep < 0)
+            {
+                builder.Username = Uri.UnescapeDataString(userInfo);
+            }
+            else
+            {
+                builder.Username = Uri.UnescapeDataString(userInfo[..sep]);
+                builder.Password = Uri.UnescapeDataString(userInfo[(sep + 1)..]);
+            }
+        }
+
+        if (database.Length > 0)
+            builder.Database = Uri.UnescapeDataString(database);
+
+        // Carry over query params (e.g. sslmode) best-effort — an unknown
+        // keyword must not abort the whole conversion.
+        if (query.Length > 0)
+        {
+            foreach (var raw in query.Split('&', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var kv = raw.Split('=', 2);
+                if (kv.Length != 2) continue;
+                try
+                {
+                    builder[Uri.UnescapeDataString(kv[0])] = Uri.UnescapeDataString(kv[1]);
+                }
+                catch (ArgumentException)
+                {
+                    // Unknown/unsupported keyword — skip rather than fail.
+                }
+            }
+        }
+
+        return builder.ConnectionString;
+    }
+
+    private static int? ParsePort(string text) =>
+        int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var p)
+            ? p
+            : null;
 
     private async Task SafeDeleteAsync(Func<Task> action, string description)
     {

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/CranlResourceIds.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/CranlResourceIds.cs
@@ -1,0 +1,109 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Provisioning;
+
+/// <summary>
+/// Epic 30 Phase B (Task B3) — typed read/write helper for the Cranl
+/// walk / resume working-state that used to live in the dedicated
+/// <c>tenants.cranl_*</c> columns (<c>CranlProjectId</c>,
+/// <c>CranlDatabaseId</c>, <c>CranlAppId</c>, <c>CranlAppUrl</c>,
+/// <c>CranlRegion</c>). Those columns were dropped in B3; the state now
+/// lives in the <c>tenants.provider_resource_ids</c> JSONB shadow column
+/// (a flat string→string map).
+///
+/// <para><b>Why a shared helper.</b> Two collaborators read/write the same
+/// map and must not drift: <see cref="CranlProvisioningWorkflow"/>
+/// accumulates the ids as the multi-step Cranl REST walk progresses (a
+/// <c>provisioning.tenant</c> platform task can be re-reserved mid-walk and
+/// must resume by reading the ids it already minted), and
+/// <see cref="V2.Cranl.CranlTenantProviderV2"/> reads them back for the
+/// idempotency guard, the <c>ProviderResourceIds</c> result contract, and
+/// endpoint building. Keeping the key names + (de)serialisation in one place
+/// prevents a writer/reader mismatch.</para>
+///
+/// <para><b>Encrypted DB URL is deliberately NOT in this map.</b> The Cranl
+/// admin <c>DATABASE_URL</c> is a secret; it lives encrypted-at-rest on the
+/// <c>tenant_databases</c> pool row's <c>AdminConnectionStringEncrypted</c>
+/// (minted by B2) and is re-derived transiently by polling the Cranl DB on
+/// each <c>DatabaseReady</c> pass. It is never persisted on the tenant row.</para>
+///
+/// <para><b>Storage semantics.</b> The map is stored via the EF change
+/// tracker's shadow property so we can persist it without adding it to the
+/// <see cref="Tenant"/> POCO; a subsequent <c>SaveChangesAsync</c> flushes
+/// it. An empty map is stored as <c>null</c> (so the column reads back as
+/// SQL NULL rather than <c>"{}"</c>), matching how a fresh tenant looks.</para>
+/// </summary>
+internal static class CranlResourceIds
+{
+    public const string ProjectId = "cranl_project_id";
+    public const string DatabaseId = "cranl_database_id";
+    public const string AppId = "cranl_app_id";
+    public const string AppUrl = "cranl_app_url";
+    public const string Region = "cranl_region";
+
+    /// <summary>Shadow-property name of the <c>tenants.provider_resource_ids</c>
+    /// JSONB column (CLR type <c>string?</c>).</summary>
+    private const string ShadowProperty = "ProviderResourceIds";
+
+    /// <summary>
+    /// Read the resource-id map from the JSONB shadow column. Returns a
+    /// fresh empty (ordinal) map when the column is null/empty. Throws
+    /// (fail-loud) if the column holds malformed JSON — a corrupt row must
+    /// not be silently treated as "no ids" (that would restart the walk and
+    /// leak a duplicate project/db/app).
+    /// </summary>
+    public static Dictionary<string, string> Read(EntityEntry<Tenant> entry)
+    {
+        var json = entry.Property<string?>(ShadowProperty).CurrentValue;
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return new Dictionary<string, string>(StringComparer.Ordinal);
+        }
+
+        var map = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
+        return map is null
+            ? new Dictionary<string, string>(StringComparer.Ordinal)
+            : new Dictionary<string, string>(map, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Read a single id, or <c>null</c> when absent/empty. The empty-string
+    /// coalescing keeps the call sites' <c>string.IsNullOrEmpty(...)</c>
+    /// resume guards behaving exactly as the old column reads did.
+    /// </summary>
+    public static string? Get(EntityEntry<Tenant> entry, string key)
+        => Read(entry).TryGetValue(key, out var value) && !string.IsNullOrEmpty(value)
+            ? value
+            : null;
+
+    /// <summary>
+    /// Upsert a single id and write the map back to the shadow column. A
+    /// null/empty <paramref name="value"/> removes the key (mirrors clearing
+    /// a column to NULL). The write is buffered on the change tracker; the
+    /// caller's next <c>SaveChangesAsync</c> persists it.
+    /// </summary>
+    public static void Set(EntityEntry<Tenant> entry, string key, string? value)
+    {
+        var map = Read(entry);
+        if (string.IsNullOrEmpty(value))
+        {
+            map.Remove(key);
+        }
+        else
+        {
+            map[key] = value;
+        }
+
+        Write(entry, map);
+    }
+
+    /// <summary>Replace the whole map (used by deprovision teardown, which
+    /// keeps only the region hint).</summary>
+    public static void Write(EntityEntry<Tenant> entry, IReadOnlyDictionary<string, string> map)
+    {
+        entry.Property<string?>(ShadowProperty).CurrentValue =
+            map.Count == 0 ? null : JsonSerializer.Serialize(map);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/V2/Cranl/CranlTenantProviderV2.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/V2/Cranl/CranlTenantProviderV2.cs
@@ -81,20 +81,17 @@ public sealed class CranlTenantProviderV2 : ITenantInfrastructureProvider
 
     private readonly ControlPlaneDbContext _db;
     private readonly IPlatformQueuedTaskRepository _platformTasks;
-    private readonly TenantSecretProtector _protector;
     private readonly CranlOptions _options;
     private readonly ILogger<CranlTenantProviderV2> _logger;
 
     public CranlTenantProviderV2(
         ControlPlaneDbContext db,
         IPlatformQueuedTaskRepository platformTasks,
-        TenantSecretProtector protector,
         CranlOptions options,
         ILogger<CranlTenantProviderV2> logger)
     {
         _db = db;
         _platformTasks = platformTasks;
-        _protector = protector;
         _options = options;
         _logger = logger;
     }
@@ -133,8 +130,13 @@ public sealed class CranlTenantProviderV2 : ITenantInfrastructureProvider
 
         // Idempotency: if Cranl resources already exist (or the row is mid-flow)
         // return the current snapshot rather than enqueueing a second task.
+        // B3: the "already has a project" signal reads from the
+        // provider_resource_ids JSONB (via CranlResourceIds), not the retired
+        // cranl_project_id column.
         var current = ProvisioningStateExtensions.ParseState(tenant.ProvisioningState);
-        if (!string.IsNullOrEmpty(tenant.CranlProjectId)
+        var hasCranlProject =
+            !string.IsNullOrEmpty(CranlResourceIds.Get(_db.Entry(tenant), CranlResourceIds.ProjectId));
+        if (hasCranlProject
             || current is ProvisioningState.Pending
                        or ProvisioningState.DatabaseProvisioning
                        or ProvisioningState.DatabaseReady
@@ -142,7 +144,7 @@ public sealed class CranlTenantProviderV2 : ITenantInfrastructureProvider
                        or ProvisioningState.AppDeploying
                        or ProvisioningState.Ready)
         {
-            return BuildResult(tenant, decryptEndpoint: current is ProvisioningState.Ready or ProvisioningState.DatabaseReady or ProvisioningState.AppProvisioning or ProvisioningState.AppDeploying);
+            return BuildResult(tenant, includeEndpoints: current is ProvisioningState.Ready or ProvisioningState.DatabaseReady or ProvisioningState.AppProvisioning or ProvisioningState.AppDeploying);
         }
 
         var now = DateTime.UtcNow;
@@ -153,7 +155,6 @@ public sealed class CranlTenantProviderV2 : ITenantInfrastructureProvider
         tenant.ProvisioningState = ProvisioningState.Pending.ToStorageString();
         tenant.ProvisioningDetail = "queued_for_cranl_provisioning";
         tenant.ProvisioningUpdatedAt = now;
-        tenant.CranlRegion = region;
         tenant.UpdatedAt = now;
 
         // Story 30-3 — write the new v2 fields. Shadow columns are accessed via
@@ -164,6 +165,10 @@ public sealed class CranlTenantProviderV2 : ITenantInfrastructureProvider
         entry.Property<string?>("ProviderKey").CurrentValue = CranlCapabilities.ProviderKey;
         // Clear any stale failure short-code from a prior failed run.
         entry.Property<string?>("FailureReason").CurrentValue = null;
+        // B3: seed the region into the provider_resource_ids JSONB (the
+        // retired cranl_region column) so the walk + BuildResourceIds read a
+        // consistent value.
+        CranlResourceIds.Set(entry, CranlResourceIds.Region, region);
 
         await _db.SaveChangesAsync(ct);
 
@@ -184,7 +189,7 @@ public sealed class CranlTenantProviderV2 : ITenantInfrastructureProvider
             "Cranl V2 provider: enqueued provisioning task for tenant {TenantId} (region={Region}, topology={Topology})",
             tenantId, region, request.Topology);
 
-        return BuildResult(tenant, decryptEndpoint: false);
+        return BuildResult(tenant, includeEndpoints: false);
     }
 
     /// <inheritdoc />
@@ -223,7 +228,7 @@ public sealed class CranlTenantProviderV2 : ITenantInfrastructureProvider
         var payload = JsonSerializer.Serialize(new ProvisioningTaskPayload
         {
             TenantId = tenantId,
-            Region = tenant.CranlRegion ?? string.Empty,
+            Region = CranlResourceIds.Get(_db.Entry(tenant), CranlResourceIds.Region) ?? string.Empty,
             CustomName = null
         });
         await _platformTasks.EnqueueAsync(new PlatformQueuedTask
@@ -249,9 +254,9 @@ public sealed class CranlTenantProviderV2 : ITenantInfrastructureProvider
         if (endpoints is null)
         {
             throw new InvalidOperationException(
-                $"Tenant {tenantId} is in state '{state}' (no endpoint available). " +
-                "ResolveEndpointsAsync requires DatabaseReady / AppProvisioning / " +
-                "AppDeploying / Ready — call GetStatusAsync first to check progress.");
+                $"Tenant {tenantId} is in state '{state}' (no engine endpoint available). " +
+                "ResolveEndpointsAsync requires the engine host (cranl_app_url) to be " +
+                "published — that lands at Ready. Call GetStatusAsync first to check progress.");
         }
         return endpoints;
     }
@@ -264,10 +269,10 @@ public sealed class CranlTenantProviderV2 : ITenantInfrastructureProvider
             ?? throw new InvalidOperationException($"Tenant {tenantId} not found");
     }
 
-    private ProvisioningResult BuildResult(Tenant tenant, bool decryptEndpoint)
+    private ProvisioningResult BuildResult(Tenant tenant, bool includeEndpoints)
     {
         var snapshot = BuildSnapshot(tenant);
-        var endpoints = decryptEndpoint ? TryBuildEndpoints(tenant) : null;
+        var endpoints = includeEndpoints ? TryBuildEndpoints(tenant) : null;
         return new ProvisioningResult(
             snapshot,
             ProviderResourceIds: BuildResourceIds(tenant),
@@ -308,52 +313,38 @@ public sealed class CranlTenantProviderV2 : ITenantInfrastructureProvider
             UpdatedAt: updated);
     }
 
-    private static IReadOnlyDictionary<string, string> BuildResourceIds(Tenant tenant)
+    private IReadOnlyDictionary<string, string> BuildResourceIds(Tenant tenant)
     {
-        // Build the resource-id map from whatever columns are populated. The
-        // dispatch workflow persists this onto tenants.provider_resource_ids
-        // when the v2 result lands — the in-memory shape is the contract.
-        var map = new Dictionary<string, string>(StringComparer.Ordinal);
-        if (!string.IsNullOrEmpty(tenant.CranlProjectId))
-            map["cranl_project_id"] = tenant.CranlProjectId!;
-        if (!string.IsNullOrEmpty(tenant.CranlDatabaseId))
-            map["cranl_database_id"] = tenant.CranlDatabaseId!;
-        if (!string.IsNullOrEmpty(tenant.CranlAppId))
-            map["cranl_app_id"] = tenant.CranlAppId!;
-        if (!string.IsNullOrEmpty(tenant.CranlRegion))
-            map["cranl_region"] = tenant.CranlRegion!;
+        // B3: the resource-id map is read straight from the
+        // tenants.provider_resource_ids JSONB (the CranlProvisioningWorkflow
+        // accumulates it as the walk progresses). The in-memory shape is the
+        // dispatch-workflow contract; keys: cranl_project_id, cranl_database_id,
+        // cranl_app_id, cranl_app_url, cranl_region (whichever are populated).
+        var map = CranlResourceIds.Read(_db.Entry(tenant));
         return map.Count == 0 ? EmptyResourceIds : map;
     }
 
     private TenantEndpoints? TryBuildEndpoints(Tenant tenant)
     {
-        if (tenant.CranlDatabaseUrlEncrypted is null
-            || tenant.CranlDatabaseUrlEncrypted.Length == 0)
+        // B3 (with B1): DB routing no longer uses a provider-supplied
+        // DatabaseUrl — every tenant routes through the unified per-tenant
+        // EncryptedConnectionString pool envelope. The Cranl admin DATABASE_URL
+        // is therefore no longer persisted on the tenant row and is not
+        // resolvable here. The only endpoint still meaningful is the engine
+        // host (cranl_app_url), kept for a future dedicated-compute engine
+        // dispatch. When it isn't populated yet there is no endpoint to hand
+        // back — return null so ResolveEndpointsAsync fails loud.
+        var appUrl = CranlResourceIds.Get(_db.Entry(tenant), CranlResourceIds.AppUrl);
+        if (string.IsNullOrWhiteSpace(appUrl))
         {
             return null;
         }
 
-        string databaseUrl;
-        try
-        {
-            databaseUrl = _protector.Decrypt(tenant.CranlDatabaseUrlEncrypted);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex,
-                "Cranl V2 provider: failed to decrypt DATABASE_URL for tenant {TenantId} — the encryption key may be misconfigured",
-                tenant.Id);
-            throw;
-        }
-
-        var engineUrl = !string.IsNullOrWhiteSpace(tenant.CranlAppUrl)
-            ? $"https://{tenant.CranlAppUrl}"
-            : null;
-
         return new TenantEndpoints(
-            DatabaseUrl: databaseUrl,
-            EngineHost: tenant.CranlAppUrl,
-            EngineUrl: engineUrl,
+            // DB routing is owned by the unified pool envelope, not this field.
+            DatabaseUrl: string.Empty,
+            EngineHost: appUrl,
+            EngineUrl: $"https://{appUrl}",
             CustomDomain: null);
     }
 

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/V2/V2TenantEndpointDirectory.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/V2/V2TenantEndpointDirectory.cs
@@ -5,40 +5,36 @@ using Tamma.Data.Abstractions;
 namespace Tamma.Api.Services.Provisioning.V2;
 
 /// <summary>
-/// Story 30-8 — production
+/// Story 30-8 / Epic 30 Phase B (B1) — production
 /// <see cref="ITenantEndpointDirectory"/> that bridges
 /// <see cref="LruPooledTenantConnectionResolver"/> (in
 /// <c>Tamma.Data.Pooling</c>) to the V2 provider surface
 /// (<see cref="ITenantInfrastructureProvider"/> +
 /// <see cref="TenantProviderRegistry"/>).
 ///
-/// <para>Resolution flow per <c>TryResolveAsync(tenantId)</c>:
-/// <list type="number">
-///   <item><description>Look up <c>tenants.provider_key</c> via
-///     <see cref="ITenantProviderKeyLookup"/>. If <c>null</c> →
-///     <see cref="TenantEndpointResolution.NotApplicable"/>; the LRU
-///     resolver falls back to the legacy
-///     <c>EncryptedConnectionString</c> path.</description></item>
-///   <item><description>Look up the registered provider via
-///     <see cref="TenantProviderRegistry.TryGetProvider"/>. If the
-///     provider key is unknown to the registry → log a WARN +
-///     <see cref="TenantEndpointResolution.NotApplicable"/>. This
-///     handles deployments where a tenant has been migrated to a
-///     provider the local process doesn't have wired (e.g. Cloudflare
-///     provider on a deployment without the Cloudflare client). The
-///     legacy fallback gives the operator a chance to recover.</description></item>
-///   <item><description>Call
-///     <see cref="ITenantInfrastructureProvider.ResolveEndpointsAsync"/>.
-///     Provider-thrown
-///     <see cref="InvalidOperationException"/> ("not in a state where
-///     endpoints are available") translates to
-///     <see cref="TenantNotProvisionedException"/> so the resolver's
-///     negative cache + status middleware behave consistently across
-///     the V2 path and the legacy path.</description></item>
-///   <item><description>Build a
-///     <see cref="TenantEndpointResolution"/> from the provider's
-///     <see cref="TenantEndpoints"/> and return it.</description></item>
-/// </list></para>
+/// <para><b>B1 — the DB-routing bypass is removed.</b> The unified
+/// per-tenant <c>EncryptedConnectionString</c> envelope (via the
+/// <c>tenant_databases</c> pool) is the SINGLE DB route. This directory
+/// no longer turns a provider-supplied <c>DatabaseUrl</c> into a routed
+/// connection string. <c>TryResolveAsync(tenantId)</c> therefore always
+/// returns <see cref="TenantEndpointResolution.NotApplicable"/> for the
+/// resolver's DB-routing purpose, so the resolver falls through to the
+/// unified <c>EncryptedConnectionString</c> path for EVERY tenant —
+/// including provider-backed (Cranl / dedicated-compute) tenants. That
+/// path is fail-closed: a provider-keyed tenant whose unified envelope is
+/// missing surfaces <c>TenantConnectionStringMissingException</c> rather
+/// than silently routing to the central connection.</para>
+///
+/// <para>The provider <c>provider_key</c> is still read (via
+/// <see cref="ITenantProviderKeyLookup"/>) purely for observability — a
+/// provider-backed tenant is logged at Debug, and a tenant claiming a
+/// key that isn't wired in this deployment (unknown to
+/// <see cref="TenantProviderRegistry.TryGetProvider"/>) is logged at
+/// Warn — but neither changes the DB route. Engine-URL resolution for a
+/// future dedicated-compute engine dispatch stays available on
+/// <see cref="ITenantInfrastructureProvider.ResolveEndpointsAsync"/> for
+/// a distinct future consumer; it is intentionally NOT called on the
+/// DB-routing hot path.</para>
 ///
 /// <para><b>Concurrency</b>: this type is a thread-safe singleton.
 /// Multiple LRU cold-misses for the same tenant call
@@ -72,94 +68,65 @@ public sealed class V2TenantEndpointDirectory : ITenantEndpointDirectory
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        // 1. Read provider_key from CP. NullTenantFoundException bubbles.
-        string? providerKey;
-        try
-        {
-            providerKey = await _providerKeyLookup
-                .GetProviderKeyAsync(tenantId, cancellationToken)
-                .ConfigureAwait(false);
-        }
-        catch (TenantNotFoundException)
-        {
-            // Bubble verbatim — the resolver expects this to surface as
-            // a definitive 404 / "no such tenant".
-            throw;
-        }
+        // Epic 30 Phase B (B1) — the unified per-tenant
+        // EncryptedConnectionString envelope (via the tenant_databases
+        // pool) is the SINGLE DB route. This directory no longer turns a
+        // provider-supplied DatabaseUrl into a routed connection string;
+        // that bypass is removed. EVERY tenant — including provider-backed
+        // (Cranl / dedicated-compute) tenants — resolves its DB connection
+        // through the unified envelope, so this method always returns
+        // NotApplicable for the resolver's DB-routing purpose. The resolver
+        // then falls through to its EncryptedConnectionString path, which is
+        // fail-closed: a provider-keyed tenant whose unified envelope is
+        // missing surfaces TenantConnectionStringMissingException rather than
+        // silently routing to the central connection.
+        //
+        // Engine-URL resolution for a future dedicated-compute engine
+        // dispatch stays available on
+        // ITenantInfrastructureProvider.ResolveEndpointsAsync (reachable via
+        // the registry) for a distinct future consumer. It is intentionally
+        // NOT called here — DB routing must never depend on a provider
+        // round-trip, and must never be short-circuited by the provider's
+        // provisioning state (which would preempt the unified envelope's
+        // own fail-closed handling).
+
+        // 1. Read provider_key from CP — purely for observability now.
+        //    TenantNotFoundException bubbles verbatim (definitive 404),
+        //    matching the resolver's own not-found surface.
+        var providerKey = await _providerKeyLookup
+            .GetProviderKeyAsync(tenantId, cancellationToken)
+            .ConfigureAwait(false);
 
         if (string.IsNullOrWhiteSpace(providerKey))
         {
-            // Legacy tenant — no V2 routing applies. Resolver falls
-            // back to the EncryptedConnectionString path.
+            // Legacy / unified-only tenant — nothing provider-specific to
+            // note. Resolver uses the EncryptedConnectionString path.
             return TenantEndpointResolution.NotApplicable;
         }
 
-        // 2. Find the provider. Unknown key → NotApplicable so the
-        //    resolver can still recover via the legacy path. We log a
-        //    warning so operators see that a tenant claims to be on a
-        //    provider that isn't wired in this deployment.
-        if (!_registry.TryGetProvider(providerKey, out var provider) || provider is null)
+        // 2. Provider-backed tenant. Emit an observability signal, then still
+        //    route via the unified envelope. A tenant claiming a provider key
+        //    that isn't wired in this deployment is worth a WARN — but it no
+        //    longer changes the DB route (the pool envelope is authoritative).
+        if (_registry.TryGetProvider(providerKey, out _))
+        {
+            _logger.LogDebug(
+                "tenant.routing.provider_backed_via_unified_envelope tenantId={TenantId} providerKey={ProviderKey}",
+                tenantId,
+                providerKey);
+        }
+        else
         {
             _logger.LogWarning(
                 "tenant.routing.provider_key_unregistered tenantId={TenantId} providerKey={ProviderKey} " +
-                "registeredKeys={RegisteredKeys} fallback=legacy",
+                "registeredKeys={RegisteredKeys} route=unified_envelope",
                 tenantId,
                 providerKey,
                 string.Join(",", _registry.RegisteredKeys));
-            return TenantEndpointResolution.NotApplicable;
         }
 
-        // 3. Resolve endpoints. Translate provider exceptions into the
-        //    abstraction-layer exceptions Tamma.Data understands.
-        TenantEndpoints endpoints;
-        try
-        {
-            endpoints = await provider
-                .ResolveEndpointsAsync(tenantId, cancellationToken)
-                .ConfigureAwait(false);
-        }
-        catch (InvalidOperationException ex)
-        {
-            // The V2 contract uses InvalidOperationException to mean
-            // "tenant is not in a state where endpoints are available"
-            // (e.g. ProvisioningState.Pending). The LRU resolver's
-            // negative cache + Story 28-8 middleware both speak
-            // TenantNotProvisionedException, so translate.
-            _logger.LogInformation(
-                "tenant.routing.endpoints_unavailable tenantId={TenantId} providerKey={ProviderKey} reason={Reason}",
-                tenantId,
-                providerKey,
-                ex.Message);
-            throw new TenantNotProvisionedException(tenantId, providerKey);
-        }
-        catch (NotSupportedException)
-        {
-            // Null provider seam was selected (or another provider
-            // explicitly opted out). NotApplicable so the resolver
-            // falls back to the legacy path — distinct from the
-            // not-provisioned semantic above.
-            _logger.LogWarning(
-                "tenant.routing.provider_not_supported tenantId={TenantId} providerKey={ProviderKey} fallback=legacy",
-                tenantId,
-                providerKey);
-            return TenantEndpointResolution.NotApplicable;
-        }
-
-        if (string.IsNullOrWhiteSpace(endpoints.DatabaseUrl))
-        {
-            // Provider returned without a database URL — treat as
-            // "endpoints unavailable" so the resolver doesn't try to
-            // build a NpgsqlDataSource on an empty string.
-            _logger.LogWarning(
-                "tenant.routing.endpoints_missing_db_url tenantId={TenantId} providerKey={ProviderKey}",
-                tenantId,
-                providerKey);
-            throw new TenantNotProvisionedException(tenantId, providerKey);
-        }
-
-        return TenantEndpointResolution.Resolved(
-            endpoints.DatabaseUrl,
-            endpoints.EngineUrl,
-            providerKey);
+        // B1: never return a provider DatabaseUrl. Unified envelope is the
+        // one and only DB route.
+        return TenantEndpointResolution.NotApplicable;
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Stopgap/StopgapSecretMap.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Stopgap/StopgapSecretMap.cs
@@ -12,9 +12,10 @@ namespace Tamma.Api.Services.Secrets.Stopgap;
 /// runtime reads through <see cref="IRuntimeSecretResolver"/>.</para>
 ///
 /// <para>All entries are <b>platform-scoped</b> in the current port —
-/// per-tenant Cranl DATABASE_URL entries are handled out-of-band by
-/// the provisioning flow (one row per tenant, imported dynamically
-/// based on the <c>tenants.CranlDatabaseUrlEncrypted</c> column).</para>
+/// per-tenant Cranl DATABASE_URL secrets are handled out-of-band by the
+/// provisioning flow. Since Epic 30 Phase B (Task B3) the encrypted admin
+/// credential lives on the tenant's <c>tenant_databases</c> pool row
+/// (<c>AdminConnectionStringEncrypted</c>), not a dedicated tenant column.</para>
 /// </summary>
 public static class StopgapSecretMap
 {

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/Tenant.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/Tenant.cs
@@ -14,34 +14,16 @@ public class Tenant
     public DateTime UpdatedAt { get; set; }
     public DateTime? DeletedAt { get; set; }
 
-    // ── Cranl per-tenant provisioning (audit cranl/001 — Doc 02 §3) ──
+    // ── Cranl per-tenant provisioning ──
     //
-    // Populated when a platform owner provisions the tenant onto Cranl
-    // (via POST /api/admin/tenants/{id}/provision). NULL when Cranl has
-    // not minted hosting infrastructure for the tenant — the default;
-    // placement is owned by the unified schema-per-tenant model
-    // (SchemaName + DatabaseId against the tenant_databases pool).
-    public string? CranlProjectId { get; set; }
-    public string? CranlDatabaseId { get; set; }
-    public string? CranlAppId { get; set; }
-    public string? CranlRegion { get; set; }
-
-    /// <summary>
-    /// Encrypted DATABASE_URL handed back by Cranl after the database
-    /// reaches <c>running</c>. Encrypted at rest with AES-GCM keyed
-    /// from <c>Cranl:EncryptionKey</c> (or the HKDF fallback noted
-    /// in TenantSecretProtector). NULL when Cranl never minted a
-    /// database for the tenant — routing then uses the tenant's
-    /// unified-model connection string (EncryptedConnectionString).
-    /// </summary>
-    public byte[]? CranlDatabaseUrlEncrypted { get; set; }
-
-    /// <summary>
-    /// Default <c>*.cranl.net</c> hostname for the tenant's Elsa app
-    /// (e.g. <c>tamma-engine-abc123.cranl.net</c>). Populated by the
-    /// final step of the provisioning flow.
-    /// </summary>
-    public string? CranlAppUrl { get; set; }
+    // Epic 30 Phase B (Task B3): the six dedicated Cranl columns
+    // (CranlProjectId/DatabaseId/AppId/Region/AppUrl + the encrypted
+    // CranlDatabaseUrlEncrypted) were dropped. The walk/resume working-state
+    // (project/db/app ids, region, engine host) now lives in the
+    // `tenants.provider_resource_ids` JSONB (accessed via CranlResourceIds),
+    // and the encrypted admin DATABASE_URL lives only on the tenant's
+    // `tenant_databases` pool row (AdminConnectionStringEncrypted). The
+    // provisioning state machine below is unchanged.
 
     /// <summary>
     /// Provisioning state machine — string-encoded

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260701023202_DropCranlTenantColumns.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260701023202_DropCranlTenantColumns.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.ControlPlane
 {
     [DbContext(typeof(ControlPlaneDbContext))]
-    partial class ControlPlaneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260701023202_DropCranlTenantColumns")]
+    partial class DropCranlTenantColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260701023202_DropCranlTenantColumns.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260701023202_DropCranlTenantColumns.cs
@@ -1,0 +1,83 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.ControlPlane
+{
+    /// <inheritdoc />
+    public partial class DropCranlTenantColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CranlAppId",
+                table: "tenants");
+
+            migrationBuilder.DropColumn(
+                name: "CranlAppUrl",
+                table: "tenants");
+
+            migrationBuilder.DropColumn(
+                name: "CranlDatabaseId",
+                table: "tenants");
+
+            migrationBuilder.DropColumn(
+                name: "CranlDatabaseUrlEncrypted",
+                table: "tenants");
+
+            migrationBuilder.DropColumn(
+                name: "CranlProjectId",
+                table: "tenants");
+
+            migrationBuilder.DropColumn(
+                name: "CranlRegion",
+                table: "tenants");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "CranlAppId",
+                table: "tenants",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CranlAppUrl",
+                table: "tenants",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CranlDatabaseId",
+                table: "tenants",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "CranlDatabaseUrlEncrypted",
+                table: "tenants",
+                type: "bytea",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CranlProjectId",
+                table: "tenants",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CranlRegion",
+                table: "tenants",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
@@ -190,15 +190,13 @@ internal static class TammaModelConfiguration
             entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
             entity.Property(e => e.UpdatedAt).HasDefaultValueSql("now()");
 
-            // Cranl per-tenant provisioning columns (audit cranl/001).
+            // Cranl per-tenant provisioning state machine. Epic 30 Phase B
+            // (Task B3) dropped the six dedicated Cranl columns
+            // (project/db/app ids, region, app url, encrypted DB URL) — that
+            // walk/resume state now lives in provider_resource_ids JSONB and
+            // the tenant_databases pool row. ProvisioningState stays here.
             entity.Property(e => e.ProvisioningState)
                 .IsRequired().HasMaxLength(40).HasDefaultValue("none");
-            entity.Property(e => e.CranlProjectId).HasMaxLength(255);
-            entity.Property(e => e.CranlDatabaseId).HasMaxLength(255);
-            entity.Property(e => e.CranlAppId).HasMaxLength(255);
-            entity.Property(e => e.CranlRegion).HasMaxLength(100);
-            entity.Property(e => e.CranlAppUrl).HasMaxLength(255);
-            entity.Property(e => e.CranlDatabaseUrlEncrypted).HasColumnType("bytea");
 
             if (includeTenantShadowColumns)
             {

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
@@ -508,30 +508,39 @@ public class ControlPlaneDbContextModelTests
         slugIndex!.IsUnique.Should().BeTrue();
     }
 
+    // Epic 30 Phase B (Task B3) — SHIPPED. The six dedicated Cranl columns
+    // were dropped (migration DropCranlTenantColumns); their walk/resume state
+    // moved into the tenants.provider_resource_ids JSONB (CranlResourceIds) and
+    // the encrypted admin DB URL onto the tenant_databases pool row. B1 already
+    // removed the LruPooledTenantConnectionResolver's dependency on
+    // CranlDatabaseUrlEncrypted (every tenant now routes through the unified
+    // EncryptedConnectionString envelope), so the stale rationale that kept this
+    // test [Ignore]d no longer holds — it is re-enabled here.
+    //
+    // Deviation from the original Story 28-1 test: the three Provisioning*
+    // assertions were DELETED. B3 KEEPS ProvisioningState/ProvisioningDetail/
+    // ProvisioningUpdatedAt (the saga state machine) — only the six Cranl
+    // columns were dropped, so asserting the Provisioning* columns are absent
+    // would be wrong.
     [Test]
-    [Ignore("Story 28-1 PR D — Decision #3: keep this test ignored until "
-        + "Epic 30 ships pluggable infra backends and an alternative "
-        + "routing column. Today the Cranl columns are load-bearing "
-        + "(Story 29-10 stopgap) — LruPooledTenantConnectionResolver "
-        + "reads tenants.CranlDatabaseUrlEncrypted to route per-request "
-        + "DB connections in production. Re-enable when Epic 30 lands "
-        + "the alternative routing column.")]
-    public void Tenants_Cranl_Columns_Are_Ignored_On_NewContext()
+    public void Tenants_Cranl_Columns_Are_Dropped_From_Model()
     {
         using var ctx = CreateContext();
 
         var tenant = ctx.Model.FindEntityType(typeof(Tenant))!;
         var propertyNames = tenant.GetProperties().Select(p => p.Name).ToHashSet();
 
-        // Cranl columns belong to the legacy single-DB topology.
+        // Dropped in Epic 30 Phase B (Task B3).
         propertyNames.Should().NotContain("CranlProjectId");
         propertyNames.Should().NotContain("CranlDatabaseId");
         propertyNames.Should().NotContain("CranlAppId");
         propertyNames.Should().NotContain("CranlAppUrl");
         propertyNames.Should().NotContain("CranlDatabaseUrlEncrypted");
         propertyNames.Should().NotContain("CranlRegion");
-        propertyNames.Should().NotContain("ProvisioningState");
-        propertyNames.Should().NotContain("ProvisioningDetail");
-        propertyNames.Should().NotContain("ProvisioningUpdatedAt");
+
+        // KEPT by B3 — the saga state machine stays on the tenants row.
+        propertyNames.Should().Contain("ProvisioningState");
+        propertyNames.Should().Contain("ProvisioningDetail");
+        propertyNames.Should().Contain("ProvisioningUpdatedAt");
     }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/CrossTenantIsolationPostgresTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/CrossTenantIsolationPostgresTests.cs
@@ -474,12 +474,8 @@ internal sealed class MinimalCpDbContext : ControlPlaneDbContext
             b.Ignore(t => t.Settings);
             b.Ignore(t => t.CreatedAt);
             b.Ignore(t => t.UpdatedAt);
-            b.Ignore(t => t.CranlProjectId);
-            b.Ignore(t => t.CranlDatabaseId);
-            b.Ignore(t => t.CranlAppId);
-            b.Ignore(t => t.CranlRegion);
-            b.Ignore(t => t.CranlDatabaseUrlEncrypted);
-            b.Ignore(t => t.CranlAppUrl);
+            // Epic 30 Phase B (Task B3): the six dedicated Cranl columns were
+            // dropped from the Tenant entity, so there is nothing to Ignore.
             b.Ignore(t => t.ProvisioningState);
             b.Ignore(t => t.ProvisioningDetail);
             b.Ignore(t => t.ProvisioningUpdatedAt);

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic30/LruResolverV2RoutingTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic30/LruResolverV2RoutingTests.cs
@@ -6,6 +6,8 @@ using Microsoft.Extensions.Options;
 using NUnit.Framework;
 using System.Collections.Concurrent;
 using System.Text;
+using Tamma.Api.Services.Provisioning.V2;
+using Tamma.Api.Tests.Provisioning.V2;
 using Tamma.Data;
 using Tamma.Data.Abstractions;
 using Tamma.Data.Entities;
@@ -117,6 +119,49 @@ public class LruResolverV2RoutingTests
         _decryptor.Calls.Should().Be(0,
             "V2 directory provided the connection string; the encrypted-column decryptor must be skipped");
         directory.ResolveCalls.Should().Be(1);
+    }
+
+    // ─── 1b. Epic 30 Phase B (B1) — the REAL directory never bypasses ─
+    //
+    // The tests above exercise the resolver's generic seam via a
+    // test-double directory (FakeEndpointDirectory) that CAN return
+    // Applicable — that seam is intentionally retained. This test proves
+    // that the PRODUCTION V2TenantEndpointDirectory never uses it for DB
+    // routing: a provider-keyed (provider_key set) tenant resolves its DB
+    // connection through the unified EncryptedConnectionString envelope,
+    // NOT the provider's DatabaseUrl.
+
+    [Test]
+    public async Task Resolver_WithRealV2Directory_RoutesProviderKeyedTenant_ViaUnifiedEnvelope()
+    {
+        var tenantId = await SeedTenantAsync(
+            legacyConnectionString:
+                "Host=stub.invalid;Port=5432;Database=unified;Username=u;Password=p");
+
+        var provider = new FakeTenantInfrastructureProvider("cranl")
+        {
+            // The provider WOULD hand back a routable DatabaseUrl, but B1
+            // means DB routing never consults it. If the directory calls
+            // this, the test fails loudly.
+            OnResolveEndpoints = (_, _) => throw new InvalidOperationException(
+                "provider ResolveEndpointsAsync must not be consulted for DB routing (B1)"),
+        };
+        var registry = new TenantProviderRegistry(
+            new ITenantInfrastructureProvider[] { provider });
+        var directory = new V2TenantEndpointDirectory(
+            registry,
+            new StubProviderKeyLookup("cranl"),
+            NullLogger<V2TenantEndpointDirectory>.Instance);
+
+        await using var resolver = CreateResolver(directory);
+
+        var ds = await resolver.GetDataSourceAsync(tenantId);
+
+        ds.ConnectionString.Should().Contain("Database=unified",
+            "the provider-keyed tenant must be routed via the unified envelope");
+        _decryptor.Calls.Should().Be(1,
+            "the unified EncryptedConnectionString decrypt path must be taken — " +
+            "the provider DatabaseUrl bypass is removed in B1");
     }
 
     // ─── 2. Fall back to legacy path when provider_key is null ────────
@@ -366,6 +411,21 @@ public class LruResolverV2RoutingTests
             public string? ProviderKey { get; init; }
             public string? Status { get; init; }
         }
+    }
+
+    /// <summary>
+    /// Minimal <see cref="ITenantProviderKeyLookup"/> that returns a fixed
+    /// provider key for every tenant — used to drive the REAL
+    /// <see cref="V2TenantEndpointDirectory"/> in the B1 end-to-end test.
+    /// </summary>
+    private sealed class StubProviderKeyLookup : ITenantProviderKeyLookup
+    {
+        private readonly string? _providerKey;
+
+        public StubProviderKeyLookup(string? providerKey) => _providerKey = providerKey;
+
+        public Task<string?> GetProviderKeyAsync(Guid tenantId, CancellationToken ct)
+            => Task.FromResult(_providerKey);
     }
 
     private sealed class RecordingDecryptor : IConnectionStringDecryptor

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic30/V2TenantEndpointDirectoryTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic30/V2TenantEndpointDirectoryTests.cs
@@ -1,0 +1,143 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Services.Provisioning.V2;
+using Tamma.Api.Tests.Provisioning.V2;
+using Tamma.Data.Abstractions;
+
+namespace Tamma.Api.Tests.Epic30;
+
+/// <summary>
+/// Epic 30 Phase B (B1) — <see cref="V2TenantEndpointDirectory"/> is
+/// narrowed so it NEVER supplies a routed DB connection string. The
+/// unified per-tenant <c>EncryptedConnectionString</c> envelope (via the
+/// <c>tenant_databases</c> pool) is the ONLY DB route. The old bypass —
+/// turning a provider-supplied <c>DatabaseUrl</c> into a
+/// <see cref="TenantEndpointResolution.Resolved"/> result the LRU resolver
+/// routes on — is removed.
+///
+/// <para>These tests pin the new contract directly at the directory
+/// level: every path returns
+/// <see cref="TenantEndpointResolution.NotApplicable"/> for DB-routing
+/// purposes, and the provider's
+/// <see cref="ITenantInfrastructureProvider.ResolveEndpointsAsync"/> is
+/// NOT consulted on the DB-routing hot path.</para>
+/// </summary>
+[TestFixture]
+public class V2TenantEndpointDirectoryTests
+{
+    private static V2TenantEndpointDirectory CreateDirectory(
+        ITenantProviderKeyLookup keyLookup,
+        params ITenantInfrastructureProvider[] providers)
+    {
+        var registry = new TenantProviderRegistry(providers);
+        return new V2TenantEndpointDirectory(
+            registry, keyLookup, NullLogger<V2TenantEndpointDirectory>.Instance);
+    }
+
+    // ─── Core B1 assertion — the DatabaseUrl bypass is gone ───────────
+
+    [Test]
+    public async Task TryResolveAsync_NeverRoutesOnProviderDatabaseUrl_ForProviderKeyedTenant()
+    {
+        var tenantId = Guid.NewGuid();
+        var resolveCalls = 0;
+        // A fully-provisioned provider that WOULD hand back a routable
+        // DatabaseUrl. Pre-B1 this made the directory return Resolved(...)
+        // and the resolver route on the provider URL. Post-B1 the directory
+        // must ignore it entirely (and not even ask the provider).
+        var provider = new FakeTenantInfrastructureProvider("cranl")
+        {
+            OnResolveEndpoints = (id, _) =>
+            {
+                Interlocked.Increment(ref resolveCalls);
+                return Task.FromResult(new TenantEndpoints(
+                    DatabaseUrl: $"Host=provider;Port=5432;Database=provider_bypass_{id:N};Username=u;Password=p",
+                    EngineHost: null,
+                    EngineUrl: "https://engine.example"));
+            },
+        };
+        var directory = CreateDirectory(FakeProviderKeyLookup.Returning("cranl"), provider);
+
+        var result = await directory.TryResolveAsync(tenantId);
+
+        result.IsApplicable.Should().BeFalse(
+            "B1: the unified EncryptedConnectionString envelope is the only DB route; " +
+            "the directory must never supply a routed provider DatabaseUrl");
+        result.DatabaseUrl.Should().BeNull(
+            "no DatabaseUrl may be carried back to the resolver for DB routing");
+        resolveCalls.Should().Be(0,
+            "DB routing must not consult the provider's ResolveEndpointsAsync — " +
+            "engine-URL resolution stays available for a future dedicated-compute dispatch consumer, " +
+            "but it is not on the DB-routing hot path");
+    }
+
+    // ─── Provider-key not set → NotApplicable (unchanged) ─────────────
+
+    [Test]
+    public async Task TryResolveAsync_ReturnsNotApplicable_WhenProviderKeyNull()
+    {
+        var tenantId = Guid.NewGuid();
+        var directory = CreateDirectory(FakeProviderKeyLookup.Returning(null));
+
+        var result = await directory.TryResolveAsync(tenantId);
+
+        result.IsApplicable.Should().BeFalse();
+        result.DatabaseUrl.Should().BeNull();
+    }
+
+    // ─── Provider key set but not registered in this deployment ───────
+
+    [Test]
+    public async Task TryResolveAsync_ReturnsNotApplicable_WhenProviderKeyUnregistered()
+    {
+        var tenantId = Guid.NewGuid();
+        // Registry only knows "cranl"; the tenant claims "hetzner".
+        var directory = CreateDirectory(
+            FakeProviderKeyLookup.Returning("hetzner"),
+            new FakeTenantInfrastructureProvider("cranl"));
+
+        var result = await directory.TryResolveAsync(tenantId);
+
+        result.IsApplicable.Should().BeFalse();
+        result.DatabaseUrl.Should().BeNull();
+    }
+
+    // ─── Unknown tenant bubbles as a definitive control-plane 404 ─────
+
+    [Test]
+    public async Task TryResolveAsync_BubblesTenantNotFound()
+    {
+        var tenantId = Guid.NewGuid();
+        var directory = CreateDirectory(FakeProviderKeyLookup.NotFound());
+
+        var act = async () => await directory.TryResolveAsync(tenantId);
+
+        await act.Should().ThrowAsync<TenantNotFoundException>();
+    }
+
+    // ─── Test double ──────────────────────────────────────────────────
+
+    private sealed class FakeProviderKeyLookup : ITenantProviderKeyLookup
+    {
+        private readonly string? _providerKey;
+        private readonly bool _throwNotFound;
+
+        private FakeProviderKeyLookup(string? providerKey, bool throwNotFound)
+        {
+            _providerKey = providerKey;
+            _throwNotFound = throwNotFound;
+        }
+
+        public static FakeProviderKeyLookup Returning(string? providerKey) => new(providerKey, false);
+
+        public static FakeProviderKeyLookup NotFound() => new(null, true);
+
+        public Task<string?> GetProviderKeyAsync(Guid tenantId, CancellationToken ct)
+        {
+            if (_throwNotFound)
+                throw new TenantNotFoundException(tenantId);
+            return Task.FromResult(_providerKey);
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/CranlPlatformTaskHandlerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/CranlPlatformTaskHandlerTests.cs
@@ -45,6 +45,8 @@ public sealed class CranlPlatformTaskHandlerTests
     private Mock<ICranlApiClient> _cranl = null!;
     private CranlOptions _options = null!;
     private TenantSecretProtector _protector = null!;
+    private ITenantConnectionStringProtector _connProtector = null!;
+    private Mock<ITenantMoveService> _moveService = null!;
     private IConfiguration _configuration = null!;
     private CranlProvisioningWorkflow _workflow = null!;
 
@@ -67,6 +69,8 @@ public sealed class CranlPlatformTaskHandlerTests
             DefaultBranch = "main"
         };
         _protector = new TenantSecretProtector(new byte[32]);
+        _connProtector = new TenantSecretProtectorAdapter(_protector);
+        _moveService = new Mock<ITenantMoveService>();
         _configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
@@ -76,8 +80,9 @@ public sealed class CranlPlatformTaskHandlerTests
             .Build();
 
         _workflow = new CranlProvisioningWorkflow(
-            _db, _cranl.Object, _options, _protector, _configuration,
-            NullLogger<CranlProvisioningWorkflow>.Instance);
+            _db, _cranl.Object, _options, _configuration,
+            NullLogger<CranlProvisioningWorkflow>.Instance,
+            _connProtector, _moveService.Object);
     }
 
     [TearDown]
@@ -154,8 +159,10 @@ public sealed class CranlPlatformTaskHandlerTests
 
         var refreshed = await ReloadAsync(tenant.Id);
         refreshed.ProvisioningState.Should().Be("ready");
-        refreshed.CranlProjectId.Should().Be("proj-1");
-        refreshed.CranlAppId.Should().Be("app-1");
+        // B3: walk ids land in the provider_resource_ids JSONB.
+        var ids = CranlResourceIds.Read(_db.Entry(refreshed));
+        ids.Should().Contain(CranlResourceIds.ProjectId, "proj-1");
+        ids.Should().Contain(CranlResourceIds.AppId, "app-1");
         // The handler genuinely walked the Cranl REST flow via the engine.
         _cranl.Verify(c => c.CreateProjectAsync(
             It.IsAny<string>(), "org-1", It.IsAny<CancellationToken>()), Times.Once);
@@ -251,11 +258,11 @@ public sealed class CranlPlatformTaskHandlerTests
     public async Task DeprovisionHandler_HappyPath_DrivesWorkflowToDeprovisioned()
     {
         var tenant = await SeedTenantAsync(state: "ready");
-        tenant.CranlProjectId = "proj-1";
-        tenant.CranlDatabaseId = "db-1";
-        tenant.CranlAppId = "app-1";
-        tenant.CranlAppUrl = "x.cranl.net";
-        tenant.CranlDatabaseUrlEncrypted = _protector.Encrypt("postgresql://h");
+        var entry = _db.Entry(tenant);
+        CranlResourceIds.Set(entry, CranlResourceIds.ProjectId, "proj-1");
+        CranlResourceIds.Set(entry, CranlResourceIds.DatabaseId, "db-1");
+        CranlResourceIds.Set(entry, CranlResourceIds.AppId, "app-1");
+        CranlResourceIds.Set(entry, CranlResourceIds.AppUrl, "x.cranl.net");
         await _db.SaveChangesAsync();
 
         _cranl.Setup(c => c.DeleteApplicationAsync("app-1", It.IsAny<CancellationToken>()))
@@ -281,8 +288,10 @@ public sealed class CranlPlatformTaskHandlerTests
 
         var refreshed = await ReloadAsync(tenant.Id);
         refreshed.ProvisioningState.Should().Be("deprovisioned");
-        refreshed.CranlProjectId.Should().BeNull();
-        refreshed.CranlAppId.Should().BeNull();
+        // B3: teardown clears the Cranl ids from the JSONB.
+        var ids = CranlResourceIds.Read(_db.Entry(refreshed));
+        ids.Should().NotContainKey(CranlResourceIds.ProjectId);
+        ids.Should().NotContainKey(CranlResourceIds.AppId);
     }
 
     [Test]
@@ -344,6 +353,12 @@ public sealed class CranlPlatformTaskHandlerTests
         // registered handler, so the whole graph must be satisfiable.
         services.AddSingleton(TimeProvider.System);
         services.AddSingleton(Mock.Of<IPlatformEventPublisher>());
+        // Epic 30 Phase B — CranlProvisioningWorkflow now takes the pool-row
+        // protector + the schema-move engine (both provided by
+        // AddPlatformEventBus in production, not wired in this bare graph).
+        services.AddSingleton(Mock.Of<ITenantMoveService>());
+        services.AddSingleton<ITenantConnectionStringProtector>(sp =>
+            new TenantSecretProtectorAdapter(sp.GetRequiredService<TenantSecretProtector>()));
         services.AddTenantProvisioning(configuration);
 
         using var sp = services.BuildServiceProvider();

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/CranlProvisioningWorkflowTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/CranlProvisioningWorkflowTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text.Json;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -9,6 +10,7 @@ using NUnit.Framework;
 using Tamma.Api.Services.Provisioning;
 using Tamma.Api.Services.Provisioning.Cranl;
 using Tamma.Data;
+using Tamma.Data.Abstractions;
 using Tamma.Data.Entities;
 
 namespace Tamma.Api.Tests.Provisioning;
@@ -32,6 +34,8 @@ public class CranlProvisioningWorkflowTests
     private Mock<ICranlApiClient> _cranl = null!;
     private CranlOptions _options = null!;
     private TenantSecretProtector _protector = null!;
+    private ITenantConnectionStringProtector _connProtector = null!;
+    private Mock<ITenantMoveService> _moveService = null!;
     private IConfiguration _configuration = null!;
     private CranlProvisioningWorkflow _workflow = null!;
 
@@ -54,6 +58,11 @@ public class CranlProvisioningWorkflowTests
             DefaultBranch = "main"
         };
         _protector = new TenantSecretProtector(new byte[32]);
+        _connProtector = new TenantSecretProtectorAdapter(_protector);
+        // Loose mock — MoveAsync returns a completed Task by default (Moq's
+        // async default value), so the happy-path walk is a no-op unless a
+        // test overrides it.
+        _moveService = new Mock<ITenantMoveService>();
         _configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
@@ -63,12 +72,21 @@ public class CranlProvisioningWorkflowTests
             .Build();
 
         _workflow = new CranlProvisioningWorkflow(
-            _db, _cranl.Object, _options, _protector, _configuration,
-            NullLogger<CranlProvisioningWorkflow>.Instance);
+            _db, _cranl.Object, _options, _configuration,
+            NullLogger<CranlProvisioningWorkflow>.Instance,
+            _connProtector, _moveService.Object);
     }
 
     [TearDown]
     public void TearDown() => _scope?.Dispose();
+
+    /// <summary>
+    /// Epic 30 Phase B (Task B3): the Cranl walk/resume ids live in the
+    /// tenants.provider_resource_ids JSONB (via CranlResourceIds), not the
+    /// dropped cranl_* columns. Read them back off a freshly-loaded row.
+    /// </summary>
+    private Dictionary<string, string> ResourceIds(Tenant tenant) =>
+        CranlResourceIds.Read(_db.Entry(tenant));
 
     private async Task<Tenant> SeedTenantAsync()
     {
@@ -157,13 +175,15 @@ public class CranlProvisioningWorkflowTests
 
         var refreshed = await ReloadAsync(tenant.Id);
         refreshed.ProvisioningState.Should().Be("ready");
-        refreshed.CranlProjectId.Should().Be("proj-1");
-        refreshed.CranlDatabaseId.Should().Be("db-1");
-        refreshed.CranlAppId.Should().Be("app-1");
-        refreshed.CranlAppUrl.Should().Be("tamma-engine-x.cranl.net");
-        refreshed.CranlDatabaseUrlEncrypted.Should().NotBeNull();
-        var decrypted = _protector.Decrypt(refreshed.CranlDatabaseUrlEncrypted!);
-        decrypted.Should().Be("postgresql://admin:s3cret@db1.cranl.internal:5432/tamma-x");
+        // B3: the walk ids land in the provider_resource_ids JSONB, not
+        // dedicated columns. The encrypted DB URL is no longer persisted on
+        // the tenant row (it lives only on the pool row); the plaintext is
+        // asserted via the env push below.
+        var ids = ResourceIds(refreshed);
+        ids.Should().Contain(CranlResourceIds.ProjectId, "proj-1");
+        ids.Should().Contain(CranlResourceIds.DatabaseId, "db-1");
+        ids.Should().Contain(CranlResourceIds.AppId, "app-1");
+        ids.Should().Contain(CranlResourceIds.AppUrl, "tamma-engine-x.cranl.net");
 
         _cranl.Verify(c => c.PutEnvironmentAsync(
             "app-1",
@@ -176,13 +196,423 @@ public class CranlProvisioningWorkflowTests
             Times.Once);
     }
 
+    // ─── Epic 30 Phase B (B2): pool-row registration + resource ids + move ───
+
+    [Test]
+    public async Task ProvisionAsync_DatabaseReady_RegistersDedicatedPoolRow_PersistsResourceIds_AndMovesInline()
+    {
+        var tenant = await SeedTenantAsync();
+        // The v2 provider stamps CranlRegion before enqueueing; mirror that.
+        CranlResourceIds.Set(_db.Entry(tenant), CranlResourceIds.Region, "germany-1");
+        await _db.SaveChangesAsync();
+        SetupFullCranlWalk();
+
+        await _workflow.ProvisionAsync(
+            tenant.Id, new ProvisioningOptions("germany-1"), CancellationToken.None);
+
+        // A dedicated pool row was registered for the Cranl hosting DB.
+        var label = "cranl-" + CranlProvisioningWorkflow.ShortenForName(tenant.Id);
+        var poolRow = await _db.TenantDatabases
+            .AsNoTracking().SingleAsync(d => d.Label == label);
+        poolRow.PlacementClass.Should().Be("dedicated");
+        poolRow.Status.Should().Be("active");
+        poolRow.TenantCapacity.Should().Be(1);
+        poolRow.Host.Should().Be("db1.cranl.internal");
+        poolRow.Port.Should().Be(5432);
+        poolRow.TierEligibility.Should().Contain(tenant.Plan);
+        // Admin envelope is encrypted keyword form — NOT the raw libpq URI.
+        var adminConn = _protector.Decrypt(poolRow.AdminConnectionStringEncrypted);
+        adminConn.Should().Contain("Host=db1.cranl.internal");
+        adminConn.Should().Contain("Database=tamma-x");
+        adminConn.Should().Contain("Username=admin");
+        adminConn.Should().NotContain("postgresql://");
+
+        // The tenant's schema was moved onto the new row exactly once, inline.
+        _moveService.Verify(m => m.MoveAsync(
+            tenant.Id, poolRow.Id, It.IsAny<CancellationToken>()), Times.Once);
+
+        // F1 — resource-ids map persisted onto the JSONB shadow column, with
+        // cranl_app_id landing after the app was created.
+        var refreshed = await ReloadAsync(tenant.Id);
+        var json = _db.Entry(refreshed).Property<string?>("ProviderResourceIds").CurrentValue;
+        json.Should().NotBeNullOrEmpty();
+        var map = JsonSerializer.Deserialize<Dictionary<string, string>>(json!)!;
+        map.Should().Contain("cranl_project_id", "proj-1");
+        map.Should().Contain("cranl_database_id", "db-1");
+        map.Should().Contain("cranl_app_id", "app-1");
+        map.Should().Contain("cranl_region", "germany-1");
+
+        refreshed.ProvisioningState.Should().Be("ready");
+    }
+
+    [Test]
+    public async Task ProvisionAsync_SecondPass_DoesNotDuplicatePoolRow()
+    {
+        var tenant = await SeedTenantAsync();
+        CranlResourceIds.Set(_db.Entry(tenant), CranlResourceIds.Region, "germany-1");
+        await _db.SaveChangesAsync();
+        SetupFullCranlWalk();
+
+        await _workflow.ProvisionAsync(
+            tenant.Id, new ProvisioningOptions("germany-1"), CancellationToken.None);
+        // Resume: a re-run must reuse the pool row keyed by its label.
+        await _workflow.ProvisionAsync(
+            tenant.Id, new ProvisioningOptions("germany-1"), CancellationToken.None);
+
+        var label = "cranl-" + CranlProvisioningWorkflow.ShortenForName(tenant.Id);
+        (await _db.TenantDatabases.CountAsync(d => d.Label == label)).Should().Be(1);
+    }
+
+    [Test]
+    public async Task ProvisionAsync_TenantAlreadyPlacedOnPoolRow_SkipsMove()
+    {
+        var tenant = await SeedTenantAsync();
+        CranlResourceIds.Set(_db.Entry(tenant), CranlResourceIds.Region, "germany-1");
+        await _db.SaveChangesAsync();
+
+        // Pre-create the pool row and place the tenant on it (a completed
+        // prior move points DatabaseId at the row).
+        var label = "cranl-" + CranlProvisioningWorkflow.ShortenForName(tenant.Id);
+        var poolRow = new TenantDatabase
+        {
+            Id = Guid.NewGuid(),
+            Label = label,
+            Host = "db1.cranl.internal",
+            Port = 5432,
+            AdminConnectionStringEncrypted =
+                _protector.Encrypt("Host=db1.cranl.internal;Port=5432;Username=admin;Password=s3cret;Database=tamma-x"),
+            PlacementClass = "dedicated",
+            TierEligibility = new[] { tenant.Plan },
+            TenantCapacity = 1,
+            TenantCount = 1,
+            Status = "active",
+            KekVersion = 1,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        _db.TenantDatabases.Add(poolRow);
+        await _db.SaveChangesAsync();
+        // A PROVABLY-complete prior move points DatabaseId at the row AND has
+        // flipped the lifecycle Status back to 'active' (step 10). The
+        // connection-string envelope is required by
+        // ck_tenants_connection_string_present when Status is 'active'.
+        var placedEntry = _db.Entry(tenant);
+        placedEntry.Property<Guid?>("DatabaseId").CurrentValue = poolRow.Id;
+        placedEntry.Property<string?>("Status").CurrentValue = "active";
+        placedEntry.Property<byte[]?>("EncryptedConnectionString").CurrentValue = new byte[] { 1, 2, 3 };
+        await _db.SaveChangesAsync();
+
+        SetupFullCranlWalk();
+
+        await _workflow.ProvisionAsync(
+            tenant.Id, new ProvisioningOptions("germany-1"), CancellationToken.None);
+
+        _moveService.Verify(m => m.MoveAsync(
+            It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+        // Still no duplicate row.
+        (await _db.TenantDatabases.CountAsync(d => d.Label == label)).Should().Be(1);
+    }
+
+    // ─── FIX 2: post-repoint resume gap (move committed but left 'draining') ─
+    [Test]
+    public async Task ProvisionAsync_MoveCommittedButLeftDraining_ResumeReInvokesMove()
+    {
+        var tenant = await SeedTenantAsync();
+        var entry = _db.Entry(tenant);
+        CranlResourceIds.Set(entry, CranlResourceIds.Region, "germany-1");
+        // A tenant that is mid-move carries a connection-string envelope; the
+        // 'draining' status the fake move commits requires it
+        // (ck_tenants_connection_string_present).
+        entry.Property<byte[]?>("EncryptedConnectionString").CurrentValue = new byte[] { 1, 2, 3 };
+        await _db.SaveChangesAsync();
+        SetupFullCranlWalk();
+
+        // Fake move: commit the step-7 re-point (DatabaseId → target) but stay
+        // 'draining' and "die" before step-10 activate — exactly the crash
+        // window that strands a tenant. MoveAsync's own idempotent resume tail
+        // (which sweeps + re-verifies + activates) can only run if it is
+        // re-invoked, so the workflow must NOT skip on a draining tenant that
+        // already points at the pool row.
+        _moveService
+            .Setup(m => m.MoveAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Returns(async (Guid _, Guid targetDbId, CancellationToken _) =>
+            {
+                var e = _db.Entry(tenant);
+                e.Property<Guid?>("DatabaseId").CurrentValue = targetDbId;
+                e.Property<string?>("Status").CurrentValue = "draining";
+                await _db.SaveChangesAsync();
+            });
+
+        // Pass 1 — reaches Ready but the lifecycle Status is stuck 'draining'.
+        await _workflow.ProvisionAsync(
+            tenant.Id, new ProvisioningOptions("germany-1"), CancellationToken.None);
+        // Pass 2 (resume) — must NOT skip: it re-invokes MoveAsync.
+        await _workflow.ProvisionAsync(
+            tenant.Id, new ProvisioningOptions("germany-1"), CancellationToken.None);
+
+        _moveService.Verify(m => m.MoveAsync(
+            tenant.Id, It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    // ─── FIX 3: pool-row label keyed on the immutable tenant id, not slug ─────
+    [Test]
+    public async Task ProvisionAsync_SlugChangesBetweenPasses_ReusesSinglePoolRow()
+    {
+        var tenant = await SeedTenantAsync();
+        CranlResourceIds.Set(_db.Entry(tenant), CranlResourceIds.Region, "germany-1");
+        await _db.SaveChangesAsync();
+        SetupFullCranlWalk();
+
+        await _workflow.ProvisionAsync(
+            tenant.Id, new ProvisioningOptions("germany-1"), CancellationToken.None);
+
+        // Admin renames the tenant between provisioning passes. The pool-row
+        // label must be keyed on the immutable id, so the idempotency lookup
+        // still finds the first row (a slug-keyed label would miss it and mint
+        // a SECOND row aliasing the same physical DB → move aliasing guard).
+        tenant.Slug = "renamed-" + Guid.NewGuid().ToString("N").Substring(0, 6);
+        await _db.SaveChangesAsync();
+
+        await _workflow.ProvisionAsync(
+            tenant.Id, new ProvisioningOptions("germany-1"), CancellationToken.None);
+
+        var label = "cranl-" + CranlProvisioningWorkflow.ShortenForName(tenant.Id);
+        (await _db.TenantDatabases.CountAsync(d => d.Label == label)).Should().Be(1);
+        // And no stray slug-keyed Cranl row was minted on the second pass.
+        (await _db.TenantDatabases.CountAsync(d => d.Label.StartsWith("cranl-"))).Should().Be(1);
+    }
+
+    [Test]
+    public async Task ProvisionAsync_MoveThrows_FlipsToFailed_AndDoesNotDeployApp()
+    {
+        var tenant = await SeedTenantAsync();
+        CranlResourceIds.Set(_db.Entry(tenant), CranlResourceIds.Region, "germany-1");
+        await _db.SaveChangesAsync();
+
+        // Walk only as far as the DB being ready — the app-creation mocks are
+        // intentionally NOT set up, so the strict Cranl mock would throw if
+        // the workflow wrongly continued past the failed move.
+        _cranl.Setup(c => c.CreateProjectAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CranlProject { Id = "proj-1" });
+        _cranl.Setup(c => c.CreateDatabaseAsync(
+                It.IsAny<CreateDatabaseRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CranlDatabase { Id = "db-1", Status = "pending" });
+        _cranl.Setup(c => c.GetDatabaseAsync("db-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CranlDatabase
+            {
+                Id = "db-1", Status = "running",
+                Host = "db1.cranl.internal", Port = 5432,
+                Username = "admin", Password = "s3cret", Database = "tamma-x"
+            });
+
+        _moveService
+            .Setup(m => m.MoveAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("move boom"));
+
+        await _workflow.ProvisionAsync(
+            tenant.Id, new ProvisioningOptions("germany-1"), CancellationToken.None);
+
+        var refreshed = await ReloadAsync(tenant.Id);
+        refreshed.ProvisioningState.Should().Be("failed");
+        // FIX 4: the persisted detail carries a STRUCTURED short code (the
+        // exception type name) — NEVER the raw ex.Message, which can echo a
+        // connection string. The full exception still reaches the log sink.
+        refreshed.ProvisioningDetail.Should().Contain("tenant_schema_move_failed");
+        refreshed.ProvisioningDetail.Should().Contain("InvalidOperationException");
+        refreshed.ProvisioningDetail.Should().NotContain("move boom");
+        // The app step never ran, so no cranl_app_id landed in the JSONB.
+        ResourceIds(refreshed).Should().NotContainKey(CranlResourceIds.AppId);
+        _cranl.Verify(c => c.CreateApplicationAsync(
+            It.IsAny<CreateApplicationRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+        // The pool row is registered (committed before the move was attempted).
+        var label = "cranl-" + CranlProvisioningWorkflow.ShortenForName(tenant.Id);
+        (await _db.TenantDatabases.AnyAsync(d => d.Label == label)).Should().BeTrue();
+    }
+
+    [Test]
+    public void ToNpgsqlKeywordConnectionString_ConvertsLibpqUri()
+    {
+        var kw = CranlProvisioningWorkflow.ToNpgsqlKeywordConnectionString(
+            "postgresql://admin:s3cret@db1.cranl.internal:5432/tamma-x");
+        var b = new Npgsql.NpgsqlConnectionStringBuilder(kw);
+        b.Host.Should().Be("db1.cranl.internal");
+        b.Port.Should().Be(5432);
+        b.Username.Should().Be("admin");
+        b.Password.Should().Be("s3cret");
+        b.Database.Should().Be("tamma-x");
+    }
+
+    [Test]
+    public void ToNpgsqlKeywordConnectionString_PassesThroughKeywordForm()
+    {
+        const string kw = "Host=h;Port=5432;Username=u;Password=p;Database=d";
+        CranlProvisioningWorkflow.ToNpgsqlKeywordConnectionString(kw).Should().Be(kw);
+    }
+
+    // ─── FIX 1: URI-reserved chars in a raw (un-percent-encoded) password ─────
+    // Cranl mints random passwords that regularly contain URI-reserved chars
+    // (@ : / # ? % + space). The old `new Uri(...)` parse threw
+    // UriFormatException on those, permanently bricking the pool-row
+    // registration → tenant stuck 'failed'. The manual libpq-URI parser must
+    // recover the exact raw password from a RAW URI.
+
+    [TestCase("s3cret", "s3cret")]         // clean baseline (regression)
+    [TestCase("p@ssword", "p@ssword")]     // '@' in password (Uri: bad host)
+    [TestCase("pa/ss", "pa/ss")]           // '/' in password
+    [TestCase("pa#ss", "pa#ss")]           // '#' (Uri: fragment)
+    [TestCase("pa%ss", "pa%ss")]           // '%' not a valid escape
+    [TestCase("pa+ss", "pa+ss")]           // '+' must NOT become space
+    [TestCase("p ss", "p ss")]             // space (Uri: invalid)
+    public void ToNpgsqlKeywordConnectionString_RawReservedCharsInPassword_RoundTrip(
+        string rawPassword, string expectedPassword)
+    {
+        var uri = $"postgresql://admin:{rawPassword}@db1.cranl.internal:5432/tamma-x";
+        var kw = CranlProvisioningWorkflow.ToNpgsqlKeywordConnectionString(uri);
+        var b = new Npgsql.NpgsqlConnectionStringBuilder(kw);
+        b.Host.Should().Be("db1.cranl.internal");
+        b.Port.Should().Be(5432);
+        b.Username.Should().Be("admin");
+        b.Password.Should().Be(expectedPassword);
+        b.Database.Should().Be("tamma-x");
+    }
+
+    [Test]
+    public void ToNpgsqlKeywordConnectionString_MissingPort_DefaultsTo5432()
+    {
+        var kw = CranlProvisioningWorkflow.ToNpgsqlKeywordConnectionString(
+            "postgresql://admin:s3cret@db1.cranl.internal/tamma-x");
+        var b = new Npgsql.NpgsqlConnectionStringBuilder(kw);
+        b.Host.Should().Be("db1.cranl.internal");
+        b.Port.Should().Be(5432);
+        b.Database.Should().Be("tamma-x");
+    }
+
+    [Test]
+    public void ToNpgsqlKeywordConnectionString_EmptyDatabase_OmitsDatabase()
+    {
+        var kw = CranlProvisioningWorkflow.ToNpgsqlKeywordConnectionString(
+            "postgresql://admin:s3cret@db1.cranl.internal:5432/");
+        var b = new Npgsql.NpgsqlConnectionStringBuilder(kw);
+        b.Host.Should().Be("db1.cranl.internal");
+        b.Port.Should().Be(5432);
+        b.Database.Should().BeNullOrEmpty();
+    }
+
+    [Test]
+    public void ToNpgsqlKeywordConnectionString_PreservesSslModeQueryParam()
+    {
+        var kw = CranlProvisioningWorkflow.ToNpgsqlKeywordConnectionString(
+            "postgresql://admin:s3cret@db1.cranl.internal:5432/tamma-x?sslmode=require");
+        var b = new Npgsql.NpgsqlConnectionStringBuilder(kw);
+        b.Host.Should().Be("db1.cranl.internal");
+        b.Database.Should().Be("tamma-x");
+        b.SslMode.Should().Be(Npgsql.SslMode.Require);
+    }
+
+    [Test]
+    public void ToNpgsqlKeywordConnectionString_IPv6Host_StripsBrackets()
+    {
+        var kw = CranlProvisioningWorkflow.ToNpgsqlKeywordConnectionString(
+            "postgresql://admin:s3cret@[::1]:5432/tamma-x");
+        var b = new Npgsql.NpgsqlConnectionStringBuilder(kw);
+        b.Host.Should().Be("::1");
+        b.Port.Should().Be(5432);
+        b.Database.Should().Be("tamma-x");
+    }
+
+    [Test]
+    public void BuildConnectionString_EscapesCredentials_RoundTripsThroughParser()
+    {
+        // Belt-and-suspenders: BuildConnectionString percent-escapes the
+        // username/password when it stitches the URI, and the parser
+        // percent-decodes — so even a password full of reserved chars makes a
+        // VALID libpq URI (correct DATABASE_URL for the Cranl engine too) AND
+        // round-trips back to the exact credential.
+        var db = new CranlDatabase
+        {
+            Host = "db1.cranl.internal",
+            Port = 5432,
+            Username = "adm@n",
+            Password = "p@ss/w#rd+1 x%2",
+            Database = "tamma-x",
+        };
+        var uri = db.BuildConnectionString();
+        uri.Should().NotBeNull();
+        // A valid libpq URI: the reserved chars are percent-encoded, so no raw
+        // '@' or ':' survives inside the userinfo to confuse a re-parse.
+        uri!.Should().NotContain("p@ss/w#rd");
+
+        var kw = CranlProvisioningWorkflow.ToNpgsqlKeywordConnectionString(uri);
+        var b = new Npgsql.NpgsqlConnectionStringBuilder(kw);
+        b.Host.Should().Be("db1.cranl.internal");
+        b.Port.Should().Be(5432);
+        b.Username.Should().Be("adm@n");
+        b.Password.Should().Be("p@ss/w#rd+1 x%2");
+        b.Database.Should().Be("tamma-x");
+    }
+
+    private void SetupFullCranlWalk()
+    {
+        _cranl.Setup(c => c.CreateProjectAsync(
+                It.Is<string>(s => s.StartsWith("tamma-tenant-")),
+                "org-1",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CranlProject { Id = "proj-1", Name = "tamma-tenant-x" });
+
+        _cranl.Setup(c => c.CreateDatabaseAsync(
+                It.Is<CreateDatabaseRequest>(r =>
+                    r.ProjectId == "proj-1" && r.ServerId == "germany-1" && r.Type == "postgresql"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CranlDatabase { Id = "db-1", Status = "pending" });
+
+        _cranl.Setup(c => c.GetDatabaseAsync("db-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CranlDatabase
+            {
+                Id = "db-1",
+                Status = "running",
+                Host = "db1.cranl.internal",
+                Port = 5432,
+                Username = "admin",
+                Password = "s3cret",
+                Database = "tamma-x"
+            });
+
+        _cranl.Setup(c => c.CreateApplicationAsync(
+                It.Is<CreateApplicationRequest>(r =>
+                    r.ProjectId == "proj-1" && r.RepositoryId == "repo-1"
+                    && r.BuildType == "dockerfile" && r.BuildPath == "/apps/tamma-elsa"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CranlApplication { Id = "app-1", Status = "pending" });
+
+        _cranl.Setup(c => c.PutEnvironmentAsync("app-1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _cranl.Setup(c => c.DeployApplicationAsync("app-1", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _cranl.Setup(c => c.GetApplicationAsync("app-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CranlApplication { Id = "app-1", Status = "running" });
+
+        _cranl.Setup(c => c.GetApplicationDomainsAsync("app-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CranlAppDomains
+            {
+                DefaultDomain = "tamma-engine-x.cranl.net",
+                Domains = new List<CranlAppDomain>
+                {
+                    new() { DomainId = "d1", Host = "tamma-engine-x.cranl.net", Https = true }
+                }
+            });
+    }
+
     // ─── Resume from existing project / db ───────────────────────────────────
 
     [Test]
     public async Task ProvisionAsync_ResumesWhenProjectAlreadyExists_DoesNotCreateProject()
     {
         var tenant = await SeedTenantAsync();
-        tenant.CranlProjectId = "proj-existing";
+        CranlResourceIds.Set(_db.Entry(tenant), CranlResourceIds.ProjectId, "proj-existing");
         await _db.SaveChangesAsync();
 
         _cranl.Setup(c => c.CreateDatabaseAsync(
@@ -211,6 +641,112 @@ public class CranlProvisioningWorkflowTests
             It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         var refreshed = await ReloadAsync(tenant.Id);
         refreshed.ProvisioningState.Should().Be("ready");
+    }
+
+    // ─── B3: resume mid-walk from JSONB working-state ─────────────────────────
+
+    [Test]
+    public async Task ProvisionAsync_ResumesAfterDatabaseCreated_SkipsProjectAndDbCreate_ContinuesToReady()
+    {
+        // Simulate a worker that died after creating the project + database
+        // (the two ids are already in the provider_resource_ids JSONB). A
+        // re-reserved task must read them back and continue project→db→app,
+        // NOT restart (which would leak a duplicate project/db).
+        var tenant = await SeedTenantAsync();
+        var entry = _db.Entry(tenant);
+        CranlResourceIds.Set(entry, CranlResourceIds.ProjectId, "proj-1");
+        CranlResourceIds.Set(entry, CranlResourceIds.DatabaseId, "db-1");
+        CranlResourceIds.Set(entry, CranlResourceIds.Region, "germany-1");
+        await _db.SaveChangesAsync();
+
+        // Only the steps AFTER db-create are mocked. The strict Cranl mock
+        // would throw if the walk wrongly called CreateProject/CreateDatabase.
+        _cranl.Setup(c => c.GetDatabaseAsync("db-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CranlDatabase
+            {
+                Id = "db-1", Status = "running",
+                Host = "db1.cranl.internal", Port = 5432,
+                Username = "admin", Password = "s3cret", Database = "tamma-x"
+            });
+        _cranl.Setup(c => c.CreateApplicationAsync(
+                It.Is<CreateApplicationRequest>(r => r.ProjectId == "proj-1"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CranlApplication { Id = "app-1", Status = "pending" });
+        _cranl.Setup(c => c.PutEnvironmentAsync("app-1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _cranl.Setup(c => c.DeployApplicationAsync("app-1", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _cranl.Setup(c => c.GetApplicationAsync("app-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CranlApplication { Id = "app-1", Status = "running" });
+        _cranl.Setup(c => c.GetApplicationDomainsAsync("app-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CranlAppDomains { DefaultDomain = "tamma-engine-x.cranl.net" });
+
+        await _workflow.ProvisionAsync(
+            tenant.Id, new ProvisioningOptions("germany-1"), CancellationToken.None);
+
+        _cranl.Verify(c => c.CreateProjectAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _cranl.Verify(c => c.CreateDatabaseAsync(
+            It.IsAny<CreateDatabaseRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+        // Resume moved forward: the app was created and the schema moved once.
+        _cranl.Verify(c => c.CreateApplicationAsync(
+            It.IsAny<CreateApplicationRequest>(), It.IsAny<CancellationToken>()), Times.Once);
+        _moveService.Verify(m => m.MoveAsync(
+            tenant.Id, It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Once);
+
+        var refreshed = await ReloadAsync(tenant.Id);
+        refreshed.ProvisioningState.Should().Be("ready");
+        var ids = ResourceIds(refreshed);
+        ids.Should().Contain(CranlResourceIds.ProjectId, "proj-1");
+        ids.Should().Contain(CranlResourceIds.DatabaseId, "db-1");
+        ids.Should().Contain(CranlResourceIds.AppId, "app-1");
+        ids.Should().Contain(CranlResourceIds.AppUrl, "tamma-engine-x.cranl.net");
+    }
+
+    [Test]
+    public async Task ProvisionAsync_ResumesAfterAppCreated_SkipsAppCreate_PushesEnvAndDeploys()
+    {
+        // Worker died after the application was created (project + db + app ids
+        // all in the JSONB). Resume must NOT re-create the app; it pushes env,
+        // deploys, polls, and completes.
+        var tenant = await SeedTenantAsync();
+        var entry = _db.Entry(tenant);
+        CranlResourceIds.Set(entry, CranlResourceIds.ProjectId, "proj-1");
+        CranlResourceIds.Set(entry, CranlResourceIds.DatabaseId, "db-1");
+        CranlResourceIds.Set(entry, CranlResourceIds.AppId, "app-1");
+        CranlResourceIds.Set(entry, CranlResourceIds.Region, "germany-1");
+        await _db.SaveChangesAsync();
+
+        _cranl.Setup(c => c.GetDatabaseAsync("db-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CranlDatabase
+            {
+                Id = "db-1", Status = "running",
+                Host = "db1.cranl.internal", Port = 5432,
+                Username = "admin", Password = "s3cret", Database = "tamma-x"
+            });
+        _cranl.Setup(c => c.PutEnvironmentAsync("app-1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _cranl.Setup(c => c.DeployApplicationAsync("app-1", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _cranl.Setup(c => c.GetApplicationAsync("app-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CranlApplication { Id = "app-1", Status = "running" });
+        _cranl.Setup(c => c.GetApplicationDomainsAsync("app-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CranlAppDomains { DefaultDomain = "tamma-engine-x.cranl.net" });
+
+        await _workflow.ProvisionAsync(
+            tenant.Id, new ProvisioningOptions("germany-1"), CancellationToken.None);
+
+        // Strict mock proves CreateApplication was NOT called (never set up).
+        _cranl.Verify(c => c.CreateApplicationAsync(
+            It.IsAny<CreateApplicationRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+        _cranl.Verify(c => c.PutEnvironmentAsync(
+            "app-1", It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        _cranl.Verify(c => c.DeployApplicationAsync(
+            "app-1", It.IsAny<CancellationToken>()), Times.Once);
+
+        var refreshed = await ReloadAsync(tenant.Id);
+        refreshed.ProvisioningState.Should().Be("ready");
+        ResourceIds(refreshed).Should().Contain(CranlResourceIds.AppUrl, "tamma-engine-x.cranl.net");
     }
 
     // ─── Failure modes ───────────────────────────────────────────────────────
@@ -258,11 +794,12 @@ public class CranlProvisioningWorkflowTests
     public async Task DeprovisionAsync_DeletesInOrder_AppThenDbThenProject()
     {
         var tenant = await SeedTenantAsync();
-        tenant.CranlProjectId = "proj-1";
-        tenant.CranlDatabaseId = "db-1";
-        tenant.CranlAppId = "app-1";
-        tenant.CranlAppUrl = "x.cranl.net";
-        tenant.CranlDatabaseUrlEncrypted = _protector.Encrypt("postgresql://h");
+        var entry = _db.Entry(tenant);
+        CranlResourceIds.Set(entry, CranlResourceIds.ProjectId, "proj-1");
+        CranlResourceIds.Set(entry, CranlResourceIds.DatabaseId, "db-1");
+        CranlResourceIds.Set(entry, CranlResourceIds.AppId, "app-1");
+        CranlResourceIds.Set(entry, CranlResourceIds.AppUrl, "x.cranl.net");
+        CranlResourceIds.Set(entry, CranlResourceIds.Region, "germany-1");
         await _db.SaveChangesAsync();
 
         var sequence = new List<string>();
@@ -281,20 +818,24 @@ public class CranlProvisioningWorkflowTests
         sequence.Should().Equal("app", "db", "project");
         var refreshed = await ReloadAsync(tenant.Id);
         refreshed.ProvisioningState.Should().Be("deprovisioned");
-        refreshed.CranlProjectId.Should().BeNull();
-        refreshed.CranlDatabaseId.Should().BeNull();
-        refreshed.CranlAppId.Should().BeNull();
-        refreshed.CranlAppUrl.Should().BeNull();
-        refreshed.CranlDatabaseUrlEncrypted.Should().BeNull();
+        // B3: teardown clears the Cranl walk-state from the JSONB, keeping
+        // only the region hint for a possible re-provision.
+        var ids = ResourceIds(refreshed);
+        ids.Should().NotContainKey(CranlResourceIds.ProjectId);
+        ids.Should().NotContainKey(CranlResourceIds.DatabaseId);
+        ids.Should().NotContainKey(CranlResourceIds.AppId);
+        ids.Should().NotContainKey(CranlResourceIds.AppUrl);
+        ids.Should().Contain(CranlResourceIds.Region, "germany-1");
     }
 
     [Test]
     public async Task DeprovisionAsync_404OnApp_TreatedAsAlreadyAbsent()
     {
         var tenant = await SeedTenantAsync();
-        tenant.CranlProjectId = "proj-1";
-        tenant.CranlDatabaseId = "db-1";
-        tenant.CranlAppId = "app-1";
+        var entry = _db.Entry(tenant);
+        CranlResourceIds.Set(entry, CranlResourceIds.ProjectId, "proj-1");
+        CranlResourceIds.Set(entry, CranlResourceIds.DatabaseId, "db-1");
+        CranlResourceIds.Set(entry, CranlResourceIds.AppId, "app-1");
         await _db.SaveChangesAsync();
 
         _cranl.Setup(c => c.DeleteApplicationAsync("app-1", It.IsAny<CancellationToken>()))

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/V2/CranlTenantProviderV2Tests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/V2/CranlTenantProviderV2Tests.cs
@@ -29,28 +29,20 @@ namespace Tamma.Api.Tests.Provisioning.V2;
 ///     reads the structured failure short-code from the
 ///     <c>FailureReason</c> shadow column when state is <c>Failed</c>.</description></item>
 ///   <item><description><see cref="ITenantInfrastructureProvider.ResolveEndpointsAsync"/>
-///     decrypts the stored <c>CranlDatabaseUrlEncrypted</c> via
-///     <see cref="TenantSecretProtector"/> and assembles the
-///     <see cref="TenantEndpoints"/>.</description></item>
+///     assembles the engine <see cref="TenantEndpoints"/> from the
+///     <c>cranl_app_url</c> in the provider_resource_ids JSONB. Epic 30
+///     Phase B (Task B3): the DB URL was dropped from the endpoint — B1 made
+///     DB routing flow through the unified pool envelope, not this field.</description></item>
 /// </list>
 /// </summary>
 [TestFixture]
 public sealed class CranlTenantProviderV2Tests
 {
-    private static readonly byte[] TestKey =
-    {
-        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
-        0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
-        0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
-        0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20,
-    };
-
     private IServiceScope _scope = null!;
 #pragma warning disable NUnit1032
     private ControlPlaneDbContext _db = null!;
 #pragma warning restore NUnit1032
     private Mock<IPlatformQueuedTaskRepository> _platformTasks = null!;
-    private TenantSecretProtector _protector = null!;
     private CranlOptions _options = null!;
     private CranlTenantProviderV2 _provider = null!;
 
@@ -71,7 +63,6 @@ public sealed class CranlTenantProviderV2Tests
                 return t;
             });
 
-        _protector = new TenantSecretProtector(TestKey);
         _options = new CranlOptions
         {
             ApiKey = "cranl_sk_test_dummy",
@@ -80,7 +71,7 @@ public sealed class CranlTenantProviderV2Tests
         };
 
         _provider = new CranlTenantProviderV2(
-            _db, _platformTasks.Object, _protector, _options,
+            _db, _platformTasks.Object, _options,
             NullLogger<CranlTenantProviderV2>.Instance);
     }
 
@@ -94,7 +85,6 @@ public sealed class CranlTenantProviderV2Tests
         string? appId = null,
         string? region = null,
         string? appUrl = null,
-        byte[]? dbUrlEncrypted = null,
         string? failureReason = null)
     {
         var tenant = new Tenant
@@ -103,23 +93,29 @@ public sealed class CranlTenantProviderV2Tests
             Name = "Acme",
             Slug = "acme-" + Guid.NewGuid().ToString("N").Substring(0, 6),
             ProvisioningState = state,
-            CranlProjectId = projectId,
-            CranlDatabaseId = databaseId,
-            CranlAppId = appId,
-            CranlRegion = region,
-            CranlAppUrl = appUrl,
-            CranlDatabaseUrlEncrypted = dbUrlEncrypted,
             CreatedAt = DateTime.UtcNow,
             UpdatedAt = DateTime.UtcNow,
         };
         _db.Tenants.Add(tenant);
         await _db.SaveChangesAsync();
 
+        // B3: the Cranl walk ids live in the provider_resource_ids JSONB
+        // (CranlResourceIds), not dedicated columns.
+        var entry = _db.Entry(tenant);
+        if (!string.IsNullOrEmpty(projectId))
+            CranlResourceIds.Set(entry, CranlResourceIds.ProjectId, projectId);
+        if (!string.IsNullOrEmpty(databaseId))
+            CranlResourceIds.Set(entry, CranlResourceIds.DatabaseId, databaseId);
+        if (!string.IsNullOrEmpty(appId))
+            CranlResourceIds.Set(entry, CranlResourceIds.AppId, appId);
+        if (!string.IsNullOrEmpty(region))
+            CranlResourceIds.Set(entry, CranlResourceIds.Region, region);
+        if (!string.IsNullOrEmpty(appUrl))
+            CranlResourceIds.Set(entry, CranlResourceIds.AppUrl, appUrl);
         if (failureReason is not null)
-        {
-            _db.Entry(tenant).Property<string?>("FailureReason").CurrentValue = failureReason;
-            await _db.SaveChangesAsync();
-        }
+            entry.Property<string?>("FailureReason").CurrentValue = failureReason;
+        await _db.SaveChangesAsync();
+
         return tenant;
     }
 
@@ -238,15 +234,13 @@ public sealed class CranlTenantProviderV2Tests
     [Test]
     public async Task ProvisionAsync_AlreadyReady_DoesNotReProvisionAndExposesEndpoint()
     {
-        var encrypted = _protector.Encrypt("postgresql://u:p@db.cranl.net/x");
         var tenant = await SeedAsync(
             state: "ready",
             projectId: "proj-1",
             databaseId: "db-1",
             appId: "app-1",
             region: "germany-1",
-            appUrl: "tamma-engine-x.cranl.net",
-            dbUrlEncrypted: encrypted);
+            appUrl: "tamma-engine-x.cranl.net");
 
         var result = await _provider.ProvisionAsync(
             tenant.Id,
@@ -255,7 +249,9 @@ public sealed class CranlTenantProviderV2Tests
 
         result.Status.State.Should().Be(ProvisioningState.Ready);
         result.Endpoints.Should().NotBeNull();
-        result.Endpoints!.DatabaseUrl.Should().Be("postgresql://u:p@db.cranl.net/x");
+        // B3: DB routing is owned by the unified pool envelope — the endpoint
+        // no longer carries a DatabaseUrl. The engine host survives.
+        result.Endpoints!.DatabaseUrl.Should().BeEmpty();
         result.Endpoints.EngineHost.Should().Be("tamma-engine-x.cranl.net");
         result.Endpoints.EngineUrl.Should().Be("https://tamma-engine-x.cranl.net");
         result.ProviderResourceIds.Should().ContainKeys(
@@ -356,27 +352,27 @@ public sealed class CranlTenantProviderV2Tests
     // ─── ResolveEndpointsAsync ───────────────────────────────────────────
 
     [Test]
-    public async Task ResolveEndpointsAsync_ReadyTenant_DecryptsAndAssembles()
+    public async Task ResolveEndpointsAsync_ReadyTenant_AssemblesEngineEndpoint()
     {
-        var encrypted = _protector.Encrypt("postgresql://user:secret@cranl.example/db");
         var tenant = await SeedAsync(
             state: "ready",
             projectId: "proj-1",
-            appUrl: "tamma-engine-y.cranl.net",
-            dbUrlEncrypted: encrypted);
+            appUrl: "tamma-engine-y.cranl.net");
 
         var endpoints = await _provider.ResolveEndpointsAsync(
             tenant.Id, CancellationToken.None);
 
-        endpoints.DatabaseUrl.Should().Be("postgresql://user:secret@cranl.example/db");
+        // B3: DB routing moved to the unified pool envelope — no DatabaseUrl.
+        endpoints.DatabaseUrl.Should().BeEmpty();
         endpoints.EngineHost.Should().Be("tamma-engine-y.cranl.net");
         endpoints.EngineUrl.Should().Be("https://tamma-engine-y.cranl.net");
         endpoints.CustomDomain.Should().BeNull();
     }
 
     [Test]
-    public async Task ResolveEndpointsAsync_NoEncryptedUrl_Throws()
+    public async Task ResolveEndpointsAsync_NoEngineHost_Throws()
     {
+        // No cranl_app_url yet (pending) → no engine endpoint → fail loud.
         var tenant = await SeedAsync(state: "pending");
 
         var act = async () => await _provider.ResolveEndpointsAsync(


### PR DESCRIPTION
## Epic 30 Phase B — Reconcile the V2 Cranl provisioning path with the unified schema-per-tenant model

Follows Phase A (#395). Plan: `docs/superpowers/plans/2026-06-11-epic-30-pluggable-provisioning.md` §3 Phase B.

**The whole V2 Cranl path is dormant** (`PlatformTaskWorker.RunOnStartup=false`, Cranl opt-in), so this is forward-investment + tech-debt cleanup — it changes nothing on the default (null-provider) deployment. Designed against **full-admin tenant-DB access** (`CREATE SCHEMA`/`CREATE ROLE` assumed).

### What changed
- **B1 — DB routing is unified-only.** `V2TenantEndpointDirectory.TryResolveAsync` now always returns `NotApplicable` for DB routing, so `LruPooledTenantConnectionResolver` routes solely via the per-tenant `EncryptedConnectionString` envelope. Removes the provider-`DatabaseUrl` bypass. Fail-closed: a provider-keyed tenant with a missing envelope errors (`TenantConnectionStringMissingException`), never silently falls back to central.
- **B2 — providers mint pool rows.** On Cranl `DatabaseReady`, `CranlProvisioningWorkflow` mints a `tenant_databases` pool row (`cranl-<tenantId>`, `dedicated`, `active`, admin conn encrypted via `ITenantConnectionStringProtector`), persists provider resource-ids into `tenants.ProviderResourceIds` JSONB (**the previously-missing writer**), then calls `ITenantMoveService.MoveAsync` **inline** (not a queued `tenant.move` task — avoids same-`PlatformTaskWorker`-queue contention). Idempotent + fail-closed.
- **B3 — drop the Cranl* columns.** Removed the 6 `Cranl*` tenant columns; re-homed the Cranl walk/resume working-state into `ProviderResourceIds` JSONB (new `CranlResourceIds` helper; the **encrypted DB URL never enters JSONB** — it lives only on the pool row and is re-derived transiently on resume). CP migration `20260701023202_DropCranlTenantColumns` (reversible `Down`); `has-pending-model-changes` clean; un-ignored + amended the model-drift test.

### Corrected 4 stale plan assumptions
`ProviderResourceIds` had no writer (added it); the CP chain is 10+ migrations not a single baseline (appended a new one); the directory *did* route on provider `DatabaseUrl` (removed); the ignored test's assertions contradicted the plan (amended — keeps `Provisioning*`, drops the 6 Cranl columns).

### Review + fixes
Two independent adversarial reviewers (correctness + bug-hunt lenses); both converged **SHIP-WITH-FIXES**. Fixed before this PR:
1. **URI-reserved-char password brick** — `new Uri()` on a raw-password libpq URL threw `UriFormatException` for `@ / # % + space`, permanently `Failed`-ing provisioning. Replaced with a robust manual libpq parser + `EscapeDataString` on stitch; data-driven tests over reserved-char passwords, missing port, empty db, `?sslmode`, IPv6.
2. **Post-repoint resume gap** — the skip-guard bypassed `MoveAsync`'s resume tail if the worker died between `RepointAsync` and `activate`, stranding the tenant in permanent `draining` (writes 503). Now skips only when `DatabaseId==poolRow AND Status==active`; regression test drives a fake move that dies mid-tail.
3. **Mutable-slug pool-row label** → keyed on immutable tenant id.
4. **Secret-safety** → structured `ProvisioningDetail` (`ex.GetType().Name`), never raw `ex.Message`.

### Tracked follow-ups (all dormant-path; NOT in this PR)
- **I1** — `ProvisionTenantV2Workflow` block-polls a same-queue inner task → single-worker deadlock. Fix needs a re-entrant saga (persist step state + rebuild the compensation catalog + re-enqueue with `VisibleAt`). Deferred by decision; blocks nothing in production today.
- **M-1** — deprovision should retire the B2-minted pool row + re-point the tenant off it (currently orphans it).
- **M-2** — validate dedicated `PlacementPolicy` before the inline move for a legible failure.

### Verification
- `dotnet build Tamma.sln` — 0 errors
- `dotnet ef migrations has-pending-model-changes` (ControlPlane) — clean
- Full `Tamma.Api.Tests` — **3827 passed, 5 skipped (pre-existing), 0 failed**
- Migration `Down` verified reversible (6 columns, correct types incl. `bytea`); DROP-list unchanged (columns, not tables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
