### PR TITLE
Epic 30 Phase B follow-ups: deprovision pool-row reclaim (M-1) + shared-plan early gate (M-2)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/CranlProvisioningWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/CranlProvisioningWorkflow.cs
@@ -77,6 +77,23 @@ public sealed class CranlProvisioningWorkflow
         var entry = _db.Entry(tenant);
         try
         {
+            // ── M-2 (Epic 30 Phase B follow-up): Cranl mints a DEDICATED,
+            //    single-tenant database, so it is only valid for a plan whose
+            //    PlacementPolicy is 'dedicated'. Validate up front — BEFORE any
+            //    Cranl resource is minted — so a shared-plan tenant fails fast
+            //    with a legible detail instead of late-and-cryptically inside
+            //    RegisterCranlDatabaseAndMoveAsync, where the schema move rejects
+            //    a dedicated pool row for a shared-policy plan and surfaces a
+            //    generic tenant_schema_move_failed:... after a Cranl project +
+            //    database were already provisioned. Reuses the same plan lookup
+            //    placement/move use (pin Status=='active' so a multi-version slug
+            //    resolves the LIVE PlacementPolicy). ────────────────────────────
+            if (!await IsDedicatedPlacementPlanAsync(tenant, ct))
+            {
+                // Detail already stamped Failed by the guard; nothing minted.
+                return;
+            }
+
             // B3: the Cranl walk/resume working-state lives in the
             // tenants.provider_resource_ids JSONB (via CranlResourceIds), not
             // the retired cranl_* columns. Each step reads back the id it may
@@ -290,6 +307,23 @@ public sealed class CranlProvisioningWorkflow
         var entry = _db.Entry(tenant);
         try
         {
+            // ── M-1 (Epic 30 Phase B follow-up): before tearing down the Cranl
+            //    hosting DB, reclaim the tenant off the dedicated
+            //    `cranl-<tenantId>` pool row B2 minted. Deprovision leaves the
+            //    TENANT alive (state Deprovisioned, re-provisionable) — so the
+            //    tenant's schema (which lives ON the Cranl DB we're about to
+            //    delete) must be moved back onto a surviving shared/central pool
+            //    row, and the orphaned dedicated pool row (holding an encrypted
+            //    admin credential to the deleted DB) retired. Runs BEFORE any
+            //    Cranl delete so the move can still dump the schema off the live
+            //    DB, and fails CLOSED — a failure throws here, before the DB is
+            //    deleted, so the tenant never loses its only DB route. ──────────
+            await ReclaimCranlPoolPlacementAsync(tenant, ct);
+            // ReclaimCranlPoolPlacementAsync may reload the tracked tenant after
+            // an inline move — re-read the entry so the resource-ids below come
+            // from the refreshed instance.
+            entry = _db.Entry(tenant);
+
             var appId = CranlResourceIds.Get(entry, CranlResourceIds.AppId);
             var databaseId = CranlResourceIds.Get(entry, CranlResourceIds.DatabaseId);
             var projectId = CranlResourceIds.Get(entry, CranlResourceIds.ProjectId);
@@ -551,6 +585,148 @@ public sealed class CranlProvisioningWorkflow
             "Moving tenant {TenantId} schema onto Cranl pool row {DatabaseId} (label={Label})",
             tenant.Id, poolRow.Id, label);
         await _moveService.MoveAsync(tenant.Id, poolRow.Id, ct);
+    }
+
+    /// <summary>
+    /// M-2 guard: is the tenant's plan a <c>dedicated</c>-placement plan (the
+    /// only kind Cranl — a single-tenant DB — is valid for)? Returns
+    /// <see langword="false"/> AND stamps the row <see cref="ProvisioningState.Failed"/>
+    /// with a legible short code when the plan is missing or shared-placement,
+    /// so the caller can bail before minting any Cranl resource.
+    /// </summary>
+    private async Task<bool> IsDedicatedPlacementPlanAsync(Tenant tenant, CancellationToken ct)
+    {
+        // Same lookup placement/move use: pin Status=='active' so a multi-
+        // version slug (Story 34-1) resolves the live PlacementPolicy, not a
+        // deprecated row picked in undefined order.
+        var plan = await _db.Plans
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Slug == tenant.Plan && p.Status == "active", ct);
+        if (plan is null)
+        {
+            await TransitionAsync(tenant,
+                ProvisioningState.Failed,
+                $"cranl_plan_not_found:{tenant.Plan}", ct);
+            return false;
+        }
+        if (!string.Equals(plan.PlacementPolicy, "dedicated", StringComparison.OrdinalIgnoreCase))
+        {
+            await TransitionAsync(tenant,
+                ProvisioningState.Failed,
+                $"cranl_requires_dedicated_plan:{plan.Slug}", ct);
+            return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// M-1: reclaim the tenant off the dedicated <c>cranl-&lt;tenantId&gt;</c>
+    /// pool row before the Cranl DB is torn down. If the tenant still routes to
+    /// that row, move its schema back onto a surviving shared/central pool row
+    /// (the schema lives on the Cranl DB, so the move MUST run before the DB is
+    /// deleted). Then retire the orphaned pool row — it holds an encrypted admin
+    /// credential to a database that is about to vanish. Idempotent: a resumed
+    /// deprovision whose move already committed just removes the (now
+    /// unreferenced) row; a deprovision where B2 never minted a pool row (a
+    /// provision that failed before <see cref="ProvisioningState.DatabaseReady"/>)
+    /// is a no-op. Fail-closed: if no eligible move-back target exists this
+    /// THROWS before any Cranl resource is deleted, so the tenant is never
+    /// stranded pointing at a deleted database.
+    /// </summary>
+    private async Task ReclaimCranlPoolPlacementAsync(Tenant tenant, CancellationToken ct)
+    {
+        var label = CranlPoolRowLabel(tenant);
+        var poolRow = await _db.TenantDatabases
+            .FirstOrDefaultAsync(d => d.Label == label, ct);
+        if (poolRow is null)
+        {
+            // B2 never minted the row (provision failed before DatabaseReady) or
+            // a prior deprovision pass already retired it — nothing to reclaim.
+            return;
+        }
+
+        var entry = _db.Entry(tenant);
+        var currentDatabaseId = entry.Property<Guid?>("DatabaseId").CurrentValue;
+
+        if (currentDatabaseId == poolRow.Id)
+        {
+            // Tenant still routes to the Cranl DB — move its schema back onto a
+            // surviving shared/central pool row FIRST (while the Cranl DB is
+            // still alive to be dumped).
+            var target = await FindMoveBackTargetAsync(tenant, poolRow.Id, ct);
+            if (target is null)
+            {
+                // Fail-closed: refuse to delete the Cranl DB while the tenant
+                // still routes to it (that would strand the tenant + lose its
+                // data). The operator downgrades the plan to a shared tier — or
+                // registers an eligible pool row — and re-runs deprovision.
+                throw new InvalidOperationException(
+                    $"Cranl deprovision cannot re-point tenant '{tenant.Id}' off its "
+                    + $"dedicated pool row '{poolRow.Id}': no eligible tenant_databases "
+                    + $"row for plan '{tenant.Plan}'. Downgrade the plan to a shared tier "
+                    + "(or add an eligible pool row) and retry — the Cranl database was NOT "
+                    + "deleted (deleting it would strand the tenant and lose its data).");
+            }
+
+            _logger.LogInformation(
+                "Cranl deprovision: moving tenant {TenantId} schema off Cranl pool row "
+                + "{SourceDatabaseId} onto {TargetDatabaseId} before teardown",
+                tenant.Id, poolRow.Id, target.Id);
+            await _moveService.MoveAsync(tenant.Id, target.Id, ct);
+
+            // The inline move committed its re-point via its OWN DbContext, so
+            // the tracked tenant here is stale — reload to observe the new
+            // DatabaseId before the FK-guarded retire below.
+            await entry.ReloadAsync(ct);
+            currentDatabaseId = entry.Property<Guid?>("DatabaseId").CurrentValue;
+        }
+
+        // Never retire the row while the tenant still references it (the
+        // tenants.DatabaseId FK is Restrict — a delete would 23503 anyway).
+        if (currentDatabaseId == poolRow.Id)
+        {
+            throw new InvalidOperationException(
+                $"Cranl deprovision: tenant '{tenant.Id}' still points at pool row "
+                + $"'{poolRow.Id}' after the move-back attempt — refusing to retire it "
+                + "(the Cranl database was NOT deleted).");
+        }
+
+        // Retire the orphaned pool row. DELETE (not Status='retired') so the
+        // encrypted admin credential to the now-doomed Cranl DB does not linger
+        // in tenant_databases (that ciphertext is exactly the orphaned-credential
+        // the review flagged).
+        _db.TenantDatabases.Remove(poolRow);
+        await _db.SaveChangesAsync(ct);
+        _logger.LogInformation(
+            "Cranl deprovision: removed dedicated pool row {DatabaseId} (label={Label})",
+            poolRow.Id, label);
+    }
+
+    /// <summary>
+    /// Pick the least-loaded pool row a deprovisioned tenant's schema can be
+    /// moved back onto, reusing the ONE eligibility rule placement + move share
+    /// (<see cref="TenantPlacementService.EligibleFor"/>) so a move-back target
+    /// can never disagree with what a fresh placement would choose. Excludes the
+    /// Cranl row being torn down. Returns <see langword="null"/> when the plan is
+    /// missing or no eligible row exists (the caller fails closed).
+    /// </summary>
+    private async Task<TenantDatabase?> FindMoveBackTargetAsync(
+        Tenant tenant, Guid excludeDatabaseId, CancellationToken ct)
+    {
+        var plan = await _db.Plans
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Slug == tenant.Plan && p.Status == "active", ct);
+        if (plan is null)
+        {
+            return null;
+        }
+
+        return await _db.TenantDatabases
+            .Where(TenantPlacementService.EligibleFor(plan.Slug, plan.PlacementPolicy))
+            .Where(d => d.Id != excludeDatabaseId)
+            .OrderBy(d => d.TenantCount)
+            .ThenBy(d => d.CreatedAt)
+            .FirstOrDefaultAsync(ct);
     }
 
     /// <summary>

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/CranlPlatformTaskHandlerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/CranlPlatformTaskHandlerTests.cs
@@ -94,13 +94,17 @@ public sealed class CranlPlatformTaskHandlerTests
     private CranlDeprovisionPlatformTaskHandler BuildDeprovisionHandler() =>
         new(_workflow, NullLogger<CranlDeprovisionPlatformTaskHandler>.Instance);
 
-    private async Task<Tenant> SeedTenantAsync(string state = "pending")
+    // M-2 (Epic 30 Phase B follow-up): CranlProvisioningWorkflow.ProvisionAsync
+    // now fails closed for a shared-policy plan, so the provision walk needs a
+    // DEDICATED-placement plan (enterprise) to reach Ready.
+    private async Task<Tenant> SeedTenantAsync(string state = "pending", string plan = "enterprise")
     {
         var tenant = new Tenant
         {
             Id = Guid.NewGuid(),
             Name = "Acme",
             Slug = "acme-" + Guid.NewGuid().ToString("N").Substring(0, 6),
+            Plan = plan,
             ProvisioningState = state,
             CreatedAt = DateTime.UtcNow,
             UpdatedAt = DateTime.UtcNow

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/CranlProvisioningWorkflowTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/CranlProvisioningWorkflowTests.cs
@@ -88,13 +88,19 @@ public class CranlProvisioningWorkflowTests
     private Dictionary<string, string> ResourceIds(Tenant tenant) =>
         CranlResourceIds.Read(_db.Entry(tenant));
 
-    private async Task<Tenant> SeedTenantAsync()
+    // M-2 (Epic 30 Phase B follow-up): Cranl provisions a dedicated,
+    // single-tenant DB, so ProvisionAsync now fails closed for a shared-policy
+    // plan. Default the seed to a DEDICATED-placement plan (enterprise) so the
+    // provisioning walk proceeds; tests that exercise the shared-plan gate (or
+    // the M-1 move-back onto a shared central row) pass an explicit slug.
+    private async Task<Tenant> SeedTenantAsync(string plan = "enterprise")
     {
         var tenant = new Tenant
         {
             Id = Guid.NewGuid(),
             Name = "Acme",
             Slug = "acme-" + Guid.NewGuid().ToString("N").Substring(0, 6),
+            Plan = plan,
             ProvisioningState = "pending",
             CreatedAt = DateTime.UtcNow,
             UpdatedAt = DateTime.UtcNow
@@ -194,6 +200,57 @@ public class CranlProvisioningWorkflowTests
                 && s.Contains("TAMMA_SHARED_SECRET=shared-secret-for-tests")),
             It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    // ─── M-2: Cranl requires a dedicated-placement plan ──────────────────────
+
+    [Test]
+    public async Task ProvisionAsync_SharedPlan_FailsClosedBeforeMintingAnyResource()
+    {
+        // A shared-placement plan (team) can't land on a dedicated single-tenant
+        // Cranl DB. The guard must fail closed at the TOP of the walk — before a
+        // Cranl project/database is created and before a tenant_databases row is
+        // minted — with a legible detail (not a late tenant_schema_move_failed).
+        var tenant = await SeedTenantAsync(plan: "team");
+
+        // Strict Cranl mock with NO setups: any Cranl call would throw.
+        await _workflow.ProvisionAsync(
+            tenant.Id, new ProvisioningOptions("germany-1"), CancellationToken.None);
+
+        var refreshed = await ReloadAsync(tenant.Id);
+        refreshed.ProvisioningState.Should().Be("failed");
+        refreshed.ProvisioningDetail.Should().Be("cranl_requires_dedicated_plan:team");
+
+        _cranl.Verify(c => c.CreateProjectAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _cranl.Verify(c => c.CreateDatabaseAsync(
+            It.IsAny<CreateDatabaseRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+        // No dedicated pool row was minted for this tenant.
+        var label = "cranl-" + CranlProvisioningWorkflow.ShortenForName(tenant.Id);
+        (await _db.TenantDatabases.AnyAsync(d => d.Label == label)).Should().BeFalse();
+    }
+
+    // (No unit test for the cranl_plan_not_found guard: the ck_tenants_plan
+    // CHECK constraint restricts tenants.Plan to free|team|enterprise — all
+    // seeded — so a tenant row can never hold a slug with no active plans row.
+    // The guard stays as defence-in-depth against a wiped/misconfigured plans
+    // table, but its precondition can't be seeded through the tenants table.)
+
+    [Test]
+    public async Task ProvisionAsync_DedicatedPlan_PassesGate_AndReachesReady()
+    {
+        // The dedicated-plan happy path still provisions end-to-end (guards the
+        // gate against being over-eager and blocking a legitimate Cranl tenant).
+        var tenant = await SeedTenantAsync(plan: "enterprise");
+        CranlResourceIds.Set(_db.Entry(tenant), CranlResourceIds.Region, "germany-1");
+        await _db.SaveChangesAsync();
+        SetupFullCranlWalk();
+
+        await _workflow.ProvisionAsync(
+            tenant.Id, new ProvisioningOptions("germany-1"), CancellationToken.None);
+
+        var refreshed = await ReloadAsync(tenant.Id);
+        refreshed.ProvisioningState.Should().Be("ready");
     }
 
     // ─── Epic 30 Phase B (B2): pool-row registration + resource ids + move ───
@@ -847,6 +904,176 @@ public class CranlProvisioningWorkflowTests
 
         var refreshed = await ReloadAsync(tenant.Id);
         refreshed.ProvisioningState.Should().Be("deprovisioned");
+    }
+
+    // ─── M-1: reclaim the tenant off the dedicated Cranl pool row on teardown ─
+
+    [Test]
+    public async Task DeprovisionAsync_TenantOnCranlPoolRow_MovesSchemaBackToSharedRow_ThenRetiresCranlRow()
+    {
+        // The realistic deprovision-with-persist path: a dedicated Cranl tenant
+        // downgraded to a shared plan still routes to the cranl-<id> pool row B2
+        // minted. Deprovision must move its schema back onto the shared central
+        // row, retire the cranl row, and leave NO orphaned encrypted-credential
+        // row behind.
+        var tenant = await SeedTenantAsync(plan: "team");   // shared placement
+        var entry = _db.Entry(tenant);
+        CranlResourceIds.Set(entry, CranlResourceIds.ProjectId, "proj-1");
+        CranlResourceIds.Set(entry, CranlResourceIds.DatabaseId, "db-1");
+        CranlResourceIds.Set(entry, CranlResourceIds.AppId, "app-1");
+        CranlResourceIds.Set(entry, CranlResourceIds.Region, "germany-1");
+
+        var cranlRow = await AddCranlPoolRowAsync(tenant);
+        // Place the tenant on the cranl row, as a completed B2 move would.
+        entry.Property<Guid?>("DatabaseId").CurrentValue = cranlRow.Id;
+        await _db.SaveChangesAsync();
+
+        var central = await _db.TenantDatabases.AsNoTracking()
+            .SingleAsync(d => d.Label == "central");
+
+        // Mock the inline move exactly like the real engine's committed
+        // re-point: flip tenants.DatabaseId to the target pool row.
+        Guid? movedTo = null;
+        _moveService
+            .Setup(m => m.MoveAsync(tenant.Id, It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Returns(async (Guid _, Guid targetDbId, CancellationToken _) =>
+            {
+                movedTo = targetDbId;
+                _db.Entry(tenant).Property<Guid?>("DatabaseId").CurrentValue = targetDbId;
+                await _db.SaveChangesAsync();
+            });
+
+        _cranl.Setup(c => c.DeleteApplicationAsync("app-1", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _cranl.Setup(c => c.DeleteDatabaseAsync("db-1", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _cranl.Setup(c => c.DeleteProjectAsync("proj-1", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await _workflow.DeprovisionAsync(tenant.Id, CancellationToken.None);
+
+        // Schema moved back onto the shared central row exactly once.
+        _moveService.Verify(m => m.MoveAsync(
+            tenant.Id, central.Id, It.IsAny<CancellationToken>()), Times.Once);
+        movedTo.Should().Be(central.Id);
+
+        // The orphaned cranl pool row (an encrypted admin credential to the
+        // now-deleted Cranl DB) is GONE — not merely marked retired.
+        var label = "cranl-" + CranlProvisioningWorkflow.ShortenForName(tenant.Id);
+        (await _db.TenantDatabases.AnyAsync(d => d.Label == label)).Should().BeFalse();
+
+        var refreshed = await ReloadAsync(tenant.Id);
+        refreshed.ProvisioningState.Should().Be("deprovisioned");
+        // Tenant re-pointed onto the surviving shared row — resolves a real DB.
+        _db.Entry(refreshed).Property<Guid?>("DatabaseId").CurrentValue
+            .Should().Be(central.Id);
+    }
+
+    [Test]
+    public async Task DeprovisionAsync_ResumeAfterMove_RetiresCranlRow_WithoutReMoving()
+    {
+        // Resume: a prior deprovision pass already moved the schema back (the
+        // tenant now points at central) but died before retiring the cranl pool
+        // row. The second pass must NOT re-move, but must still clean up the
+        // orphaned pool row.
+        var tenant = await SeedTenantAsync(plan: "team");
+        var entry = _db.Entry(tenant);
+        CranlResourceIds.Set(entry, CranlResourceIds.ProjectId, "proj-1");
+        CranlResourceIds.Set(entry, CranlResourceIds.DatabaseId, "db-1");
+        CranlResourceIds.Set(entry, CranlResourceIds.AppId, "app-1");
+        await _db.SaveChangesAsync();
+
+        var cranlRow = await AddCranlPoolRowAsync(tenant);
+        var central = await _db.TenantDatabases.AsNoTracking()
+            .SingleAsync(d => d.Label == "central");
+        // Tenant already re-pointed onto central by the earlier (crashed) pass.
+        entry.Property<Guid?>("DatabaseId").CurrentValue = central.Id;
+        await _db.SaveChangesAsync();
+
+        _cranl.Setup(c => c.DeleteApplicationAsync("app-1", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _cranl.Setup(c => c.DeleteDatabaseAsync("db-1", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _cranl.Setup(c => c.DeleteProjectAsync("proj-1", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await _workflow.DeprovisionAsync(tenant.Id, CancellationToken.None);
+
+        _moveService.Verify(m => m.MoveAsync(
+            It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+        var label = "cranl-" + CranlProvisioningWorkflow.ShortenForName(tenant.Id);
+        (await _db.TenantDatabases.AnyAsync(d => d.Label == label)).Should().BeFalse();
+
+        var refreshed = await ReloadAsync(tenant.Id);
+        refreshed.ProvisioningState.Should().Be("deprovisioned");
+    }
+
+    [Test]
+    public async Task DeprovisionAsync_NoEligibleMoveBackTarget_FailsClosed_KeepsCranlDbAndPoolRow()
+    {
+        // A still-DEDICATED tenant (never downgraded) has no shared/central row
+        // it can move onto and no free dedicated row — deprovision must fail
+        // closed WITHOUT deleting the Cranl DB or orphaning the pool row.
+        var tenant = await SeedTenantAsync(plan: "enterprise");   // dedicated
+        var entry = _db.Entry(tenant);
+        CranlResourceIds.Set(entry, CranlResourceIds.ProjectId, "proj-1");
+        CranlResourceIds.Set(entry, CranlResourceIds.DatabaseId, "db-1");
+        CranlResourceIds.Set(entry, CranlResourceIds.AppId, "app-1");
+        await _db.SaveChangesAsync();
+
+        var cranlRow = await AddCranlPoolRowAsync(tenant);
+        entry.Property<Guid?>("DatabaseId").CurrentValue = cranlRow.Id;
+        await _db.SaveChangesAsync();
+
+        // No delete mocks + strict mock: a Cranl delete before the fail-closed
+        // throw would blow up the strict mock; MoveAsync is never reached.
+        var act = async () => await _workflow.DeprovisionAsync(tenant.Id, CancellationToken.None);
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        _moveService.Verify(m => m.MoveAsync(
+            It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+        _cranl.Verify(c => c.DeleteDatabaseAsync(
+            It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        var refreshed = await ReloadAsync(tenant.Id);
+        refreshed.ProvisioningState.Should().Be("failed");
+        refreshed.ProvisioningDetail.Should().Contain("deprovision_error");
+        // The cranl pool row survives (still referenced by the tenant) — no
+        // encrypted credential dropped, no data lost.
+        var label = "cranl-" + CranlProvisioningWorkflow.ShortenForName(tenant.Id);
+        (await _db.TenantDatabases.AnyAsync(d => d.Label == label)).Should().BeTrue();
+        _db.Entry(refreshed).Property<Guid?>("DatabaseId").CurrentValue
+            .Should().Be(cranlRow.Id);
+    }
+
+    /// <summary>
+    /// Seed a dedicated <c>cranl-&lt;tenantId&gt;</c> pool row (mirrors what B2
+    /// mints) and place a completed-move TenantCount of 1 on it. Central (the
+    /// shared move-back target) is already seeded by the fixture.
+    /// </summary>
+    private async Task<TenantDatabase> AddCranlPoolRowAsync(Tenant tenant)
+    {
+        var label = "cranl-" + CranlProvisioningWorkflow.ShortenForName(tenant.Id);
+        var row = new TenantDatabase
+        {
+            Id = Guid.NewGuid(),
+            Label = label,
+            Host = "db1.cranl.internal",
+            Port = 5432,
+            AdminConnectionStringEncrypted = _protector.Encrypt(
+                "Host=db1.cranl.internal;Port=5432;Username=admin;Password=s3cret;Database=tamma-x"),
+            PlacementClass = "dedicated",
+            TierEligibility = new[] { tenant.Plan },
+            TenantCapacity = 1,
+            TenantCount = 1,
+            Status = "active",
+            KekVersion = 1,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        _db.TenantDatabases.Add(row);
+        await _db.SaveChangesAsync();
+        return row;
     }
 
     // ─── Naming ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Epic 30 Phase B follow-ups (M-1, M-2)

Two correctness fixes flagged by the #399 two-lens review. Behavioral only, no schema change. The V2 Cranl path is dormant (RunOnStartup=false, Cranl opt-in).

**M-1 — deprovision no longer orphans the pool row.** `DeprovisionAsync` now reclaims the tenant off its dedicated `cranl-<tenantId>` pool row **before** deleting the Cranl DB: moves the schema back to an eligible shared/central pool row, then removes the `cranl-` row so its encrypted admin credential doesn't linger. Deprovision ≠ deletion (the tenant persists and needs a working DB), so it's re-pointed, not orphaned. Fail-closed — throws before any Cranl delete if no move-back target exists (no data loss); idempotent on resume.

**M-2 — clearer shared-plan failure.** `ProvisionAsync` fails closed early with `cranl_requires_dedicated_plan:<slug>` when the tenant's plan isn't dedicated, before minting any resource — instead of the late/cryptic `tenant_schema_move_failed` from the move validator.

### Verify
- Build 0 errors; `has-pending-model-changes` clean (no model change)
- Full `Tamma.Api.Tests` — 3832 passed, 5 skipped, 0 failed
- New tests: move-back + row-retire + no-orphan, idempotent resume, fail-closed-no-target (delete never called); shared-plan early-fail (no row minted) + dedicated-plan passes

Remaining tracked follow-up: **I1** (ProvisionTenantV2Workflow block-poll restructure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
