### PR TITLE
Epic 38 Story 38-1: git-platform step mediation (engine holds no git token)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/AnalyzeReviewActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/AnalyzeReviewActivity.cs
@@ -7,6 +7,8 @@ using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
 using Tamma.Activities.ADL.Models;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
 using Tamma.Core.Interfaces;
 
 namespace Tamma.Activities.ADL;
@@ -30,13 +32,16 @@ namespace Tamma.Activities.ADL;
 public class AnalyzeReviewActivity : Activity
 {
     private readonly ILogger<AnalyzeReviewActivity>? _logger;
-    private readonly IGitHubIntegrationService? _github;
+    private readonly TammaApiClient? _apiClient;
 
     [Input(Description = "Repository in owner/repo format")]
     public Input<string> Repository { get; set; } = default!;
 
     [Input(Description = "Pull request number")]
     public Input<int> PrNumber { get; set; } = default!;
+
+    [Input(Description = "Tenant id (GUID string) for BYOK token resolution; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
 
     [Output(Description = "Whether there are actionable review comments")]
     public Output<bool> HasActionableComments { get; set; } = default!;
@@ -47,30 +52,43 @@ public class AnalyzeReviewActivity : Activity
     [JsonConstructor]
     public AnalyzeReviewActivity() { }
 
+    /// <summary>
+    /// Story 38-1 — thin-client DI constructor. No <c>IGitHubIntegrationService</c>
+    /// and no git token: the review comments are fetched through
+    /// <c>GET /api/v1/git/{owner}/{repo}/pull-requests/{n}/comments</c> via
+    /// <see cref="TammaApiClient"/>; the (token-free) categorization runs engine-side.
+    /// </summary>
     public AnalyzeReviewActivity(
-        ILogger<AnalyzeReviewActivity> logger,
-        IGitHubIntegrationService github)
+        ILogger<AnalyzeReviewActivity>? logger,
+        TammaApiClient? apiClient)
     {
         _logger = logger;
-        _github = github;
+        _apiClient = apiClient;
     }
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
         var repository = Repository.Get(context);
         var prNumber = PrNumber.Get(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
 
         try
         {
-            var result = await _github!.GetPullRequestReviewCommentsAsync(repository, prNumber);
-            if (!result.Success)
+            var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+            var response = await apiClient
+                .GetPullRequestCommentsAsync(repository, prNumber, context.WorkflowExecutionContext.Id, tenantId, context.CancellationToken)
+                .ConfigureAwait(false);
+
+            if (response is null || !response.Success)
             {
-                _logger?.LogError("Failed to fetch review comments: {Error}", result.Error);
+                _logger?.LogError(
+                    "Failed to fetch review comments for PR #{Number}: {Failure}",
+                    prNumber, response?.FailureReason ?? "git mediation endpoint unavailable");
                 await context.CompleteActivityWithOutcomesAsync("Error");
                 return;
             }
 
-            var comments = result.Data ?? new List<GitHubReviewComment>();
+            var comments = response.Comments ?? new List<GitCommentDto>();
 
             var fixItems = comments.Select(c =>
             {

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/ApplyTriageResultActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/ApplyTriageResultActivity.cs
@@ -125,7 +125,7 @@ public class ApplyTriageResultActivity : TammaOutcomeActivity
         // Resolve the apply client. A directly-injected ITriageApplyClient (test seam, or
         // a future DI registration) wins; otherwise build the HTTP client from config +
         // the http-client factory (resolved from the activity scope when the ctor did not
-        // inject them — mirrors MergePullRequestActivity's `_github ?? context.GetService`).
+        // inject them — the same ctor-or-context.GetService fallback the thin activities use).
         var injectedClient = context.GetService<ITriageApplyClient>();
         var configuration = _configuration ?? context.GetService<IConfiguration>();
         var httpClientFactory = _httpClientFactory ?? context.GetService<IHttpClientFactory>();

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/CreateBranchActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/CreateBranchActivity.cs
@@ -7,6 +7,8 @@ using Elsa.Workflows.Activities.Flowchart.Attributes;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
 using Tamma.Core.Interfaces;
 
 namespace Tamma.Activities.ADL;
@@ -49,7 +51,7 @@ public class CreateBranchActivity : Activity
     public const int MaxConflictSuffix = 100;
 
     private readonly ILogger<CreateBranchActivity>? _logger;
-    private readonly IGitHubIntegrationService? _github;
+    private readonly TammaApiClient? _apiClient;
 
     [Input(Description = "Repository in owner/repo format")]
     public Input<string> Repository { get; set; } = default!;
@@ -65,6 +67,9 @@ public class CreateBranchActivity : Activity
 
     [Input(Description = "Conflict strategy: suffix | timestamp | abort (default suffix)")]
     public Input<string> ConflictStrategy { get; set; } = new(DefaultConflictStrategy);
+
+    [Input(Description = "Tenant id (GUID string) for BYOK token resolution; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
 
     [Output(Description = "Created (or reused) branch name")]
     public Output<string?> BranchName { get; set; } = default!;
@@ -84,12 +89,18 @@ public class CreateBranchActivity : Activity
     [JsonConstructor]
     public CreateBranchActivity() { }
 
+    /// <summary>
+    /// Story 38-1 — thin-client DI constructor. The activity holds NO
+    /// <c>IGitHubIntegrationService</c> and no git token: it delegates the branch
+    /// create to <c>POST /api/v1/git/{owner}/{repo}/branches</c> via
+    /// <see cref="TammaApiClient"/>, where the per-tenant token lives.
+    /// </summary>
     public CreateBranchActivity(
-        ILogger<CreateBranchActivity> logger,
-        IGitHubIntegrationService github)
+        ILogger<CreateBranchActivity>? logger,
+        TammaApiClient? apiClient)
     {
         _logger = logger;
-        _github = github;
+        _apiClient = apiClient;
     }
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
@@ -99,20 +110,25 @@ public class CreateBranchActivity : Activity
         var issueTitle = IssueTitle.Get(context) ?? "";
         var baseBranch = string.IsNullOrWhiteSpace(BaseBranch.Get(context)) ? DefaultBaseBranch : BaseBranch.Get(context)!;
         var strategy = string.IsNullOrWhiteSpace(ConflictStrategy.Get(context)) ? DefaultConflictStrategy : ConflictStrategy.Get(context)!;
+        var tenantId = NormalizeTenant(TenantId.Get(context));
 
-        var github = _github ?? context.GetService<IGitHubIntegrationService>();
-        if (github is null)
-        {
-            _logger?.LogError("GitHub integration service unavailable — cannot create branch for issue #{Issue}", issueNumber);
-            ErrorCode.Set(context, "github-service-unavailable");
-            Error.Set(context, "GitHub integration service unavailable");
-            await context.CompleteActivityWithOutcomesAsync("Error");
-            return;
-        }
-
+        // The candidate branch name is generated engine-side (pure, token-free);
+        // the API performs the idempotent conflict-resolution + create + validate.
         var candidate = GenerateBranchName(issueNumber, issueTitle);
-        var outcome = await ExecuteCoreAsync(github, repository, issueNumber, candidate, baseBranch, strategy, _logger);
+        var request = new GitCreateBranchRequest
+        {
+            BranchName = candidate,
+            BaseRef = baseBranch,
+            ConflictStrategy = strategy,
+            IssueNumber = issueNumber,
+            CorrelationId = context.WorkflowExecutionContext.Id,
+        };
 
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+        var response = await apiClient.CreateBranchAsync(repository, request, tenantId, context.CancellationToken)
+            .ConfigureAwait(false);
+
+        var outcome = MapResponse(response);
         if (outcome.Outcome == "Created")
         {
             BranchName.Set(context, outcome.BranchName);
@@ -127,6 +143,31 @@ public class CreateBranchActivity : Activity
             await context.CompleteActivityWithOutcomesAsync("Error");
         }
     }
+
+    /// <summary>
+    /// Story 38-1 (AC5) — project the git-mediation wire response into the SAME
+    /// <see cref="BranchCreationOutcome"/> the local path produced, so the outputs
+    /// (BranchName / BaseSha / ConflictResolved / ErrorCode / Error) and the
+    /// Created/Error outcome are byte-compatible. A null response (guard 403 /
+    /// token 503 / auth 401 / transport) fails closed to Error.
+    /// </summary>
+    public static BranchCreationOutcome MapResponse(GitCallResponse? response)
+    {
+        if (response is null)
+            return BranchCreationOutcome.Failed("git-mediation-unavailable", "git mediation endpoint unavailable");
+
+        if (response.Success && response.Outcome == "Created")
+            return BranchCreationOutcome.Created(response.BranchRef ?? "", response.BaseSha, response.ConflictResolved ?? false);
+
+        return BranchCreationOutcome.Failed(
+            response.FailureCode ?? "unknown",
+            response.FailureReason ?? "branch creation failed");
+    }
+
+    /// <summary>Normalize a tenant-id input to a non-empty trimmed string or null
+    /// (empty / whitespace ⇒ single-user / platform scope).</summary>
+    internal static string? NormalizeTenant(string? raw)
+        => string.IsNullOrWhiteSpace(raw) ? null : raw.Trim();
 
     /// <summary>
     /// Pure-ish orchestration core (no Elsa context): ref-name validation →

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/CreatePullRequestActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/CreatePullRequestActivity.cs
@@ -8,6 +8,8 @@ using Elsa.Workflows.Activities.Flowchart.Attributes;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
 using Tamma.Core.Interfaces;
 
 namespace Tamma.Activities.ADL;
@@ -33,7 +35,7 @@ namespace Tamma.Activities.ADL;
 public class CreatePullRequestActivity : Activity
 {
     private readonly ILogger<CreatePullRequestActivity>? _logger;
-    private readonly IGitHubIntegrationService? _github;
+    private readonly TammaApiClient? _apiClient;
 
     [Input(Description = "Repository in owner/repo format")]
     public Input<string> Repository { get; set; } = default!;
@@ -71,6 +73,9 @@ public class CreatePullRequestActivity : Activity
     [Input(Description = "Reviewers JSON array (usernames to request)")]
     public Input<string?> ReviewersJson { get; set; } = new((string?)null);
 
+    [Input(Description = "Tenant id (GUID string) for BYOK token resolution; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
     [Output(Description = "Created/updated PR number")]
     public Output<int> PrNumber { get; set; } = default!;
 
@@ -92,12 +97,19 @@ public class CreatePullRequestActivity : Activity
     [JsonConstructor]
     public CreatePullRequestActivity() { }
 
+    /// <summary>
+    /// Story 38-1 — thin-client DI constructor. No <c>IGitHubIntegrationService</c>
+    /// and no git token: the PR create/update routes through
+    /// <c>POST /api/v1/git/{owner}/{repo}/pull-requests</c> via
+    /// <see cref="TammaApiClient"/>. Title / body / labels are still composed
+    /// engine-side (pure, token-free).
+    /// </summary>
     public CreatePullRequestActivity(
-        ILogger<CreatePullRequestActivity> logger,
-        IGitHubIntegrationService github)
+        ILogger<CreatePullRequestActivity>? logger,
+        TammaApiClient? apiClient)
     {
         _logger = logger;
-        _github = github;
+        _apiClient = apiClient;
     }
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
@@ -114,33 +126,29 @@ public class CreatePullRequestActivity : Activity
         var testSummary = TestSummary.Parse(TestSummaryJson.Get(context));
         var issueLabels = ParseStringList(IssueLabelsJson.Get(context));
         var reviewers = ParseStringList(ReviewersJson.Get(context));
-
-        var github = _github ?? context.GetService<IGitHubIntegrationService>();
-        if (github is null)
-        {
-            _logger?.LogError("GitHub integration service unavailable — cannot create PR for issue #{Issue}", issueNumber);
-            ErrorCode.Set(context, "github-service-unavailable");
-            await context.CompleteActivityWithOutcomesAsync("Error");
-            return;
-        }
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
 
         var title = BuildTitle(issueNumber, issueTitle);
         var body = BuildBody(issueNumber, aiBody, planJson, changeSummary, testSummary);
         var labels = DetermineLabels(issueLabels, changeSummary);
 
-        var request = new CreatePullRequestRequest
+        var request = new GitCreatePrRequest
         {
             Title = title,
             Body = body,
-            Head = branchName,
-            Base = baseBranch,
+            HeadRef = branchName,
+            BaseRef = baseBranch,
             Labels = labels,
             Reviewers = reviewers,
-            IsDraft = draft
+            IsDraft = draft,
+            CorrelationId = context.WorkflowExecutionContext.Id,
         };
 
-        var outcome = await ExecuteCoreAsync(github, repository, branchName, baseBranch, draft, request, _logger);
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+        var response = await apiClient.CreatePullRequestAsync(repository, request, tenantId, context.CancellationToken)
+            .ConfigureAwait(false);
 
+        var outcome = MapResponse(response);
         switch (outcome.Outcome)
         {
             case "Created":
@@ -154,6 +162,25 @@ public class CreatePullRequestActivity : Activity
                 await context.CompleteActivityWithOutcomesAsync("Error");
                 break;
         }
+    }
+
+    /// <summary>
+    /// Story 38-1 (AC5) — project the git-mediation wire response into the SAME
+    /// <see cref="PrCreationOutcome"/> the local path produced (Created / Updated /
+    /// Error + PrNumber / PrUrl / IsDraft / Reused / ErrorCode). A null response
+    /// (guard 403 / token 503 / auth 401 / transport) fails closed to Error.
+    /// </summary>
+    public static PrCreationOutcome MapResponse(GitCallResponse? response)
+    {
+        if (response is null)
+            return PrCreationOutcome.Failed("git-mediation-unavailable");
+
+        return response switch
+        {
+            { Success: true, Outcome: "Created" } => PrCreationOutcome.Create(response.PrNumber ?? 0, response.PrUrl, response.IsDraft ?? false),
+            { Success: true, Outcome: "Updated" } => PrCreationOutcome.Reuse(response.PrNumber ?? 0, response.PrUrl, response.IsDraft ?? false),
+            _ => PrCreationOutcome.Failed(response.FailureCode ?? "pr-creation-failed"),
+        };
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/MergePullRequestActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/MergePullRequestActivity.cs
@@ -6,6 +6,8 @@ using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
 using Tamma.Activities.Core;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
 using Tamma.Core.Interfaces;
 
 namespace Tamma.Activities.ADL;
@@ -66,7 +68,7 @@ public class MergePullRequestActivity : TammaOutcomeActivity
     /// <summary>Default merge strategy when none is supplied.</summary>
     public const string DefaultStrategy = "squash";
 
-    private readonly IGitHubIntegrationService? _github;
+    private readonly TammaApiClient? _apiClient;
 
     [Input(Description = "Repository in owner/repo format")]
     public Input<string> Repository { get; set; } = default!;
@@ -88,6 +90,9 @@ public class MergePullRequestActivity : TammaOutcomeActivity
 
     [Input(Description = "When false, skip closing the associated issue after merge (default true)")]
     public Input<bool> CloseAssociatedIssue { get; set; } = new(true);
+
+    [Input(Description = "Tenant id (GUID string) for BYOK token resolution; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
 
     [Output(Description = "Merge commit SHA")]
     public Output<string?> MergeSha { get; set; } = default!;
@@ -113,12 +118,20 @@ public class MergePullRequestActivity : TammaOutcomeActivity
     [JsonConstructor]
     public MergePullRequestActivity() { }
 
+    /// <summary>
+    /// Story 38-1 — thin-client DI constructor. No <c>IGitHubIntegrationService</c>
+    /// and no git token: the pre-merge read + merge + verified post-merge
+    /// close-issue/branch-delete run server-side behind
+    /// <c>PUT /api/v1/git/{owner}/{repo}/pull-requests/{n}/merge</c>. This stays a
+    /// <see cref="TammaOutcomeActivity"/> so the <c>PR.MERGE.STARTED/COMPLETED/FAILED</c>
+    /// lifecycle events still auto-emit.
+    /// </summary>
     public MergePullRequestActivity(
-        ILogger<MergePullRequestActivity> logger,
-        IGitHubIntegrationService github)
+        ILogger<MergePullRequestActivity>? logger,
+        TammaApiClient? apiClient)
     {
         Logger = logger;
-        _github = github;
+        _apiClient = apiClient;
     }
 
     /// <summary>
@@ -146,21 +159,23 @@ public class MergePullRequestActivity : TammaOutcomeActivity
         var strategy = NormalizeStrategy(MergeStrategy.Get(context));
         var autoDeleteBranch = AutoDeleteBranch.Get(context);
         var closeIssue = CloseAssociatedIssue.Get(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
 
-        var github = _github ?? context.GetService<IGitHubIntegrationService>();
-        if (github is null)
+        var request = new GitMergePrRequest
         {
-            Logger?.LogError("GitHub integration service unavailable — cannot merge PR #{Pr}", prNumber);
-            FailureCode.Set(context, "github-service-unavailable");
-            FailureReason.Set(context, "GitHub integration service unavailable");
-            MergeSha.Set(context, "");
-            await context.CompleteActivityWithOutcomesAsync("Error");
-            return;
-        }
+            MergeStrategy = strategy,
+            IssueNumber = issueNumber,
+            BranchName = branchName,
+            AutoDeleteBranch = autoDeleteBranch,
+            CloseAssociatedIssue = closeIssue,
+            CorrelationId = context.WorkflowExecutionContext.Id,
+        };
 
-        var outcome = await ExecuteCoreAsync(
-            github, repository, prNumber, issueNumber, branchName, strategy,
-            autoDeleteBranch, closeIssue, Logger);
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+        var response = await apiClient.MergePullRequestAsync(repository, prNumber, request, tenantId, context.CancellationToken)
+            .ConfigureAwait(false);
+
+        var outcome = MapResponse(response);
 
         MergeSha.Set(context, outcome.MergeSha ?? "");
         AppliedStrategy.Set(context, strategy);
@@ -171,6 +186,37 @@ public class MergePullRequestActivity : TammaOutcomeActivity
         FailureReason.Set(context, outcome.FailureReason);
 
         await context.CompleteActivityWithOutcomesAsync(outcome.Outcome);
+    }
+
+    /// <summary>
+    /// Story 38-1 (AC5) — project the git-mediation wire response into the SAME
+    /// <see cref="MergeOutcome"/> the local path produced, so the outputs
+    /// (MergeSha / IssueClosed / BranchDeleted / AlreadyMerged / FailureCode /
+    /// FailureReason) and the Merged / MergedWithWarnings / Error outcome are
+    /// byte-compatible. A null response (guard 403 / token 503 / auth 401 /
+    /// transport) fails closed to Error.
+    /// </summary>
+    public static MergeOutcome MapResponse(GitCallResponse? response)
+    {
+        if (response is null)
+            return MergeOutcome.Failed("api_error", "git mediation endpoint unavailable");
+
+        if (response.Success)
+        {
+            var warnings = response.Outcome == "MergedWithWarnings"
+                ? (response.FailureReason ?? "post-merge warning")
+                : null;
+            return MergeOutcome.Merged(
+                response.MergeSha ?? "",
+                response.IssueClosed ?? false,
+                response.BranchDeleted ?? false,
+                response.AlreadyMerged ?? false,
+                warnings);
+        }
+
+        return MergeOutcome.Failed(
+            response.FailureCode ?? "api_error",
+            response.FailureReason ?? "merge failed");
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/UpdateIssueStatusActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/UpdateIssueStatusActivity.cs
@@ -5,8 +5,9 @@ using Elsa.Workflows;
 using Elsa.Workflows.Activities.Flowchart.Attributes;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
 
 namespace Tamma.Activities.ADL;
 
@@ -15,19 +16,25 @@ namespace Tamma.Activities.ADL;
 /// adds / removes labels and (when supplied) composes a PR-linked close comment,
 /// keeping the issue a "living log" of what Tamma is doing.
 ///
-/// <para>Story 2.10 build-out: this activity used to <b>swallow</b> a failed
-/// status update — after 3 failed attempts it logged a WARN and returned
-/// normally, so the workflow always reported success even when nothing was
-/// posted (a false-success / silent-failure violation). It is now an
-/// <b>outcome-bearing</b> activity: a genuine callback failure surfaces a loud
-/// <c>Failed</c> outcome (the workflow routes it to a failure edge that emits
-/// <c>ISSUE_STATUS.UPDATED.FAILED</c>); a successful (or degraded local-no-op)
-/// update surfaces <c>Updated</c>. It never reports success on a real failure.</para>
+/// <para>Story 2.10 build-out + Story 38-1 pivot: this activity used to
+/// <b>swallow</b> a failed status update into a silent success. It is now a thin
+/// <see cref="TammaApiClient"/> client over
+/// <c>PATCH /api/v1/git/{owner}/{repo}/issues/{n}</c> (the API holds the
+/// per-tenant token) and is strictly <b>outcome-bearing</b>: the mediation
+/// response maps to <c>Updated</c> on success and to a loud <c>Failed</c> on any
+/// failure (guard 403, token 503, auth 401, transport, or a null response),
+/// which the workflow routes to a failure edge that emits
+/// <c>ISSUE_STATUS.UPDATED.FAILED</c>. It never reports success on a real
+/// failure.</para>
+///
+/// <para>The pivot guarantees <c>Tamma:ApiUrl</c>, so there is NO "degraded
+/// local no-op" branch any more: a missing / failed callback is a loud failure,
+/// not a silent success. The former degraded path — and its dead
+/// <c>Degraded</c> output — were removed with the cutover.</para>
 ///
 /// Outcomes:
-///   - Updated: the update was applied (or degraded to a local no-op when no
-///     engine callback is configured — flagged <c>degraded</c>, nothing failed).
-///   - Failed:  the configured callback failed after retries (loud failure).
+///   - Updated: the mediation call applied the update.
+///   - Failed:  the mediation call failed (loud failure — never a false success).
 /// </summary>
 [Activity(
     "Tamma.ADL",
@@ -41,8 +48,7 @@ public class UpdateIssueStatusActivity : Activity
     private const int MaxAttempts = 3;
 
     private readonly ILogger<UpdateIssueStatusActivity>? _logger;
-    private readonly IHttpClientFactory? _httpClientFactory;
-    private readonly IConfiguration? _configuration;
+    private readonly TammaApiClient? _apiClient;
 
     [Input(Description = "Repository (owner/repo)")]
     public Input<string> Repository { get; set; } = default!;
@@ -68,11 +74,8 @@ public class UpdateIssueStatusActivity : Activity
     [Input(Description = "Merged-PR URL to link in the close comment (empty → no link)")]
     public Input<string?> PrUrl { get; set; } = new((string?)null);
 
-    [Output(Description = "True when the update was applied / degraded (no real failure)")]
+    [Output(Description = "True when the update was applied")]
     public Output<bool> Updated { get; set; } = default!;
-
-    [Output(Description = "True when the update degraded to a local no-op (no callback configured)")]
-    public Output<bool> Degraded { get; set; } = default!;
 
     [Output(Description = "Failure classification when the Failed outcome fires")]
     public Output<string?> ErrorCode { get; set; } = default!;
@@ -83,14 +86,20 @@ public class UpdateIssueStatusActivity : Activity
     [JsonConstructor]
     public UpdateIssueStatusActivity() { }
 
+    /// <summary>
+    /// Story 38-1 — thin-client DI constructor. This activity previously posted to
+    /// <c>Engine:CallbackUrl</c> (<c>/api/engine/issue-*</c>) via
+    /// <see cref="IIssueCallbackClient"/>; it now re-points to the git-mediation
+    /// endpoint <c>PATCH /api/v1/git/{owner}/{repo}/issues/{n}</c> via
+    /// <see cref="TammaApiClient"/> (base URL <c>Tamma:ApiUrl</c>), where the API
+    /// holds the per-tenant token. No token, no engine-callback path here.
+    /// </summary>
     public UpdateIssueStatusActivity(
-        ILogger<UpdateIssueStatusActivity> logger,
-        IHttpClientFactory httpClientFactory,
-        IConfiguration configuration)
+        ILogger<UpdateIssueStatusActivity>? logger,
+        TammaApiClient? apiClient)
     {
         _logger = logger;
-        _httpClientFactory = httpClientFactory;
-        _configuration = configuration;
+        _apiClient = apiClient;
     }
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
@@ -102,27 +111,26 @@ public class UpdateIssueStatusActivity : Activity
         var removeLabels = RemoveLabels.Get(context);
         var prNumber = PrNumber.Get(context);
         var prUrl = PrUrl.Get(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
 
         var body = ComposeBody(message, prNumber, prUrl);
 
-        var callbackUrl = _configuration?["Engine:CallbackUrl"];
-        if (string.IsNullOrEmpty(callbackUrl) || _httpClientFactory is null)
+        var request = new GitUpdateIssueRequest
         {
-            // Degraded local/dev no-op: log and report a flagged success.
-            // Nothing was attempted against a platform, so this is NOT a failure —
-            // it is an auditable degrade (Degraded=true), never a false success.
-            _logger?.LogInformation("[Issue #{IssueNumber}] {Message}", issueNum, body);
-            SetSuccess(context, degraded: true);
-            await context.CompleteActivityWithOutcomesAsync("Updated");
-            return;
-        }
+            Body = body,
+            AddLabels = addLabels,
+            RemoveLabels = removeLabels,
+            CorrelationId = context.WorkflowExecutionContext.Id,
+        };
 
-        var client = new HttpIssueCallbackClient(_httpClientFactory.CreateClient(), callbackUrl);
-        var outcome = await ExecuteCoreAsync(client, repo, issueNum, body, addLabels, removeLabels, _logger, context.CancellationToken);
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+        var response = await apiClient.UpdateIssueStatusAsync(repo, issueNum, request, tenantId, context.CancellationToken)
+            .ConfigureAwait(false);
 
+        var outcome = MapResponse(response);
         if (outcome.Success)
         {
-            SetSuccess(context, degraded: false);
+            SetSuccess(context);
             await context.CompleteActivityWithOutcomesAsync("Updated");
         }
         else
@@ -130,17 +138,31 @@ public class UpdateIssueStatusActivity : Activity
             // No false success — surface the failure loudly. The workflow's
             // Failed edge emits ISSUE_STATUS.UPDATED.FAILED.
             Updated.Set(context, false);
-            Degraded.Set(context, false);
             ErrorCode.Set(context, outcome.ErrorCode ?? "issue-update-failed");
             Error.Set(context, outcome.Error);
             await context.CompleteActivityWithOutcomesAsync("Failed");
         }
     }
 
-    private void SetSuccess(ActivityExecutionContext context, bool degraded)
+    /// <summary>
+    /// Story 38-1 (AC5) — project the git-mediation wire response into the SAME
+    /// <see cref="IssueUpdateOutcome"/> the local path produced (Updated / Failed +
+    /// ErrorCode / Error). A null response (guard 403 / token 503 / auth 401 /
+    /// transport) fails closed to Failed.
+    /// </summary>
+    public static IssueUpdateOutcome MapResponse(GitCallResponse? response)
+    {
+        if (response is null)
+            return IssueUpdateOutcome.Failed("callback-unavailable", "git mediation endpoint unavailable");
+
+        return response.Success
+            ? IssueUpdateOutcome.Updated()
+            : IssueUpdateOutcome.Failed(response.FailureCode ?? "issue-update-failed", response.FailureReason);
+    }
+
+    private void SetSuccess(ActivityExecutionContext context)
     {
         Updated.Set(context, true);
-        Degraded.Set(context, degraded);
         ErrorCode.Set(context, null);
         Error.Set(context, null);
     }

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Models/TammaApiModels.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Models/TammaApiModels.cs
@@ -265,6 +265,106 @@ public record PlatformEventRecord(
     [property: JsonPropertyName("createdAt")] DateTime? CreatedAt
 );
 
+// ============================================================
+// Story 38-1 (Epic 38): git-mediation wire models
+//
+// These mirror the JSON shapes of Tamma.Api's Services/Git request records +
+// GitMediationResult for the engine→API git-mediation endpoints
+// POST/PUT/GET/PATCH /api/v1/git/{owner}/{repo}/... . They live in
+// Tamma.Activities (the reference graph runs Tamma.Api → Tamma.Activities, so the
+// engine client cannot see Tamma.Api's types) and carry [JsonPropertyName]
+// camelCase to match the API's CamelCase serialization. NONE carry a token — the
+// API resolves the per-tenant credential server-side; only credentialSource (the
+// LABEL) ever comes back.
+// ============================================================
+
+public sealed record GitCreateBranchRequest
+{
+    [JsonPropertyName("branchName")] public string BranchName { get; init; } = string.Empty;
+    [JsonPropertyName("baseRef")] public string BaseRef { get; init; } = "main";
+    [JsonPropertyName("conflictStrategy")] public string? ConflictStrategy { get; init; }
+    [JsonPropertyName("issueNumber")] public int IssueNumber { get; init; }
+    [JsonPropertyName("correlationId")] public string CorrelationId { get; init; } = string.Empty;
+}
+
+public sealed record GitCreatePrRequest
+{
+    [JsonPropertyName("title")] public string Title { get; init; } = string.Empty;
+    [JsonPropertyName("body")] public string? Body { get; init; }
+    [JsonPropertyName("headRef")] public string HeadRef { get; init; } = string.Empty;
+    [JsonPropertyName("baseRef")] public string BaseRef { get; init; } = "main";
+    [JsonPropertyName("labels")] public IReadOnlyList<string>? Labels { get; init; }
+    [JsonPropertyName("reviewers")] public IReadOnlyList<string>? Reviewers { get; init; }
+    [JsonPropertyName("isDraft")] public bool IsDraft { get; init; }
+    [JsonPropertyName("correlationId")] public string CorrelationId { get; init; } = string.Empty;
+}
+
+public sealed record GitMergePrRequest
+{
+    [JsonPropertyName("mergeStrategy")] public string? MergeStrategy { get; init; }
+    [JsonPropertyName("issueNumber")] public int IssueNumber { get; init; }
+    [JsonPropertyName("branchName")] public string? BranchName { get; init; }
+    [JsonPropertyName("autoDeleteBranch")] public bool AutoDeleteBranch { get; init; } = true;
+    [JsonPropertyName("closeAssociatedIssue")] public bool CloseAssociatedIssue { get; init; } = true;
+    [JsonPropertyName("correlationId")] public string CorrelationId { get; init; } = string.Empty;
+}
+
+public sealed record GitUpdateIssueRequest
+{
+    [JsonPropertyName("body")] public string? Body { get; init; }
+    [JsonPropertyName("addLabels")] public IReadOnlyList<string>? AddLabels { get; init; }
+    [JsonPropertyName("removeLabels")] public IReadOnlyList<string>? RemoveLabels { get; init; }
+    [JsonPropertyName("status")] public string? Status { get; init; }
+    [JsonPropertyName("correlationId")] public string CorrelationId { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// Engine→API wire response for the git-mediation endpoints. Mirrors
+/// <c>Tamma.Api.Services.Git.GitMediationResult</c>. KEY-FREE: only the
+/// <see cref="CredentialSource"/> LABEL is ever present — never the token.
+/// </summary>
+public sealed record GitCallResponse
+{
+    [JsonPropertyName("success")] public bool Success { get; init; }
+    [JsonPropertyName("credentialSource")] public string? CredentialSource { get; init; }
+    [JsonPropertyName("outcome")] public string? Outcome { get; init; }
+
+    [JsonPropertyName("branchRef")] public string? BranchRef { get; init; }
+    [JsonPropertyName("baseSha")] public string? BaseSha { get; init; }
+    [JsonPropertyName("conflictResolved")] public bool? ConflictResolved { get; init; }
+
+    [JsonPropertyName("prNumber")] public int? PrNumber { get; init; }
+    [JsonPropertyName("prUrl")] public string? PrUrl { get; init; }
+    [JsonPropertyName("reused")] public bool? Reused { get; init; }
+    [JsonPropertyName("isDraft")] public bool? IsDraft { get; init; }
+
+    [JsonPropertyName("merged")] public bool? Merged { get; init; }
+    [JsonPropertyName("mergeSha")] public string? MergeSha { get; init; }
+    [JsonPropertyName("issueClosed")] public bool? IssueClosed { get; init; }
+    [JsonPropertyName("branchDeleted")] public bool? BranchDeleted { get; init; }
+    [JsonPropertyName("alreadyMerged")] public bool? AlreadyMerged { get; init; }
+
+    [JsonPropertyName("issueStatus")] public string? IssueStatus { get; init; }
+
+    [JsonPropertyName("comments")] public IReadOnlyList<GitCommentDto>? Comments { get; init; }
+
+    [JsonPropertyName("failureCode")] public string? FailureCode { get; init; }
+    [JsonPropertyName("failureReason")] public string? FailureReason { get; init; }
+    [JsonPropertyName("platformStatusCode")] public int? PlatformStatusCode { get; init; }
+    [JsonPropertyName("correlationId")] public string? CorrelationId { get; init; }
+}
+
+/// <summary>A key-free PR review comment. Mirrors <c>Tamma.Api.Services.Git.PrCommentDto</c>.</summary>
+public sealed record GitCommentDto
+{
+    [JsonPropertyName("id")] public long Id { get; init; }
+    [JsonPropertyName("body")] public string Body { get; init; } = string.Empty;
+    [JsonPropertyName("path")] public string? Path { get; init; }
+    [JsonPropertyName("line")] public int? Line { get; init; }
+    [JsonPropertyName("author")] public string Author { get; init; } = string.Empty;
+    [JsonPropertyName("createdAt")] public DateTime CreatedAt { get; init; }
+}
+
 /// <summary>
 /// Wire projection of one engine <c>TammaEvent</c> (see
 /// <c>Tamma.Activities.Core.TammaEvent</c>). camelCase to match the API DTO

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/TammaApiClient.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/TammaApiClient.cs
@@ -115,6 +115,70 @@ public class TammaApiClient
         return PostAsync<LlmCallApiResponse>(url, request, tenantId, ct);
     }
 
+    // ----- Git mediation (Story 38-1 — the git step-mediation endpoints) --
+
+    /// <summary>
+    /// Story 38-1 (AC5) — POST the engine→API <see cref="GitCreateBranchRequest"/>
+    /// to <c>POST /api/v1/git/{owner}/{repo}/branches</c>. <paramref name="repo"/>
+    /// is <c>owner/name</c>; it is split into two path segments (a full name
+    /// carries a slash). Returns null on any non-2xx (guard 403 / token 503 / auth
+    /// 401 / transport), which the thin activity maps to its Error outcome
+    /// (fail-closed). The token is resolved + used server-side; it never travels here.
+    /// </summary>
+    public Task<GitCallResponse?> CreateBranchAsync(
+        string repo, GitCreateBranchRequest request, string? tenantId = null, CancellationToken ct = default)
+    {
+        var url = $"{_baseUrl}/api/v1/git/{RepoPath(repo)}/branches";
+        return PostAsync<GitCallResponse>(url, request, tenantId, ct);
+    }
+
+    /// <summary>Story 38-1 (AC5) — <c>POST /api/v1/git/{owner}/{repo}/pull-requests</c>.</summary>
+    public Task<GitCallResponse?> CreatePullRequestAsync(
+        string repo, GitCreatePrRequest request, string? tenantId = null, CancellationToken ct = default)
+    {
+        var url = $"{_baseUrl}/api/v1/git/{RepoPath(repo)}/pull-requests";
+        return PostAsync<GitCallResponse>(url, request, tenantId, ct);
+    }
+
+    /// <summary>Story 38-1 (AC5) — <c>PUT /api/v1/git/{owner}/{repo}/pull-requests/{n}/merge</c>.</summary>
+    public Task<GitCallResponse?> MergePullRequestAsync(
+        string repo, int prNumber, GitMergePrRequest request, string? tenantId = null, CancellationToken ct = default)
+    {
+        var url = $"{_baseUrl}/api/v1/git/{RepoPath(repo)}/pull-requests/{prNumber}/merge";
+        return SendJsonAsync<GitCallResponse>(HttpMethod.Put, url, request, tenantId, ct);
+    }
+
+    /// <summary>Story 38-1 (AC5) — <c>PATCH /api/v1/git/{owner}/{repo}/issues/{n}</c>.</summary>
+    public Task<GitCallResponse?> UpdateIssueStatusAsync(
+        string repo, int issueNumber, GitUpdateIssueRequest request, string? tenantId = null, CancellationToken ct = default)
+    {
+        var url = $"{_baseUrl}/api/v1/git/{RepoPath(repo)}/issues/{issueNumber}";
+        return PatchAsync<GitCallResponse>(url, request, tenantId, ct);
+    }
+
+    /// <summary>Story 38-1 (AC5) — <c>GET /api/v1/git/{owner}/{repo}/pull-requests/{n}/comments</c>.</summary>
+    public Task<GitCallResponse?> GetPullRequestCommentsAsync(
+        string repo, int prNumber, string? correlationId = null, string? tenantId = null, CancellationToken ct = default)
+    {
+        var url = $"{_baseUrl}/api/v1/git/{RepoPath(repo)}/pull-requests/{prNumber}/comments";
+        if (!string.IsNullOrWhiteSpace(correlationId))
+            url += $"?correlationId={Uri.EscapeDataString(correlationId)}";
+        return GetAsync<GitCallResponse>(url, tenantId, ct);
+    }
+
+    /// <summary>Build the two-segment <c>{owner}/{repo}</c> path from an
+    /// <c>owner/name</c> repo string, URL-escaping each segment. A repo string
+    /// without a slash is escaped as a single segment (the endpoint's owner param).</summary>
+    private static string RepoPath(string repo)
+    {
+        var slash = (repo ?? string.Empty).IndexOf('/');
+        if (slash <= 0 || slash >= repo!.Length - 1)
+            return Uri.EscapeDataString(repo ?? string.Empty);
+        var owner = repo[..slash];
+        var name = repo[(slash + 1)..];
+        return $"{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(name)}";
+    }
+
     // ----- Provider Health ---------------------------------------------
 
     public Task<ProviderHealthStatus?> GetProviderHealthAsync(
@@ -395,6 +459,56 @@ public class TammaApiClient
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException)
         {
             _logger.LogWarning(ex, "Tamma API POST failed");
+            await RecordHealthAsync(false, null, ex.GetType().Name, ct).ConfigureAwait(false);
+            return null;
+        }
+    }
+
+    private Task<T?> PatchAsync<T>(
+        string url,
+        object body,
+        string? tenantId,
+        CancellationToken ct) where T : class
+        => SendJsonAsync<T>(HttpMethod.Patch, url, body, tenantId, ct);
+
+    /// <summary>
+    /// Shared PUT/PATCH JSON send with the same contract as
+    /// <see cref="PostAsync{T}"/> — engine bearer + <c>X-Tenant-Id</c> + per-call
+    /// health recording, returning null on any non-2xx / transport failure so the
+    /// caller falls back (fail-closed for the git-mediation shim).
+    /// </summary>
+    private async Task<T?> SendJsonAsync<T>(
+        HttpMethod method,
+        string url,
+        object body,
+        string? tenantId,
+        CancellationToken ct) where T : class
+    {
+        try
+        {
+            using var request = new HttpRequestMessage(method, url)
+            {
+                Content = JsonContent.Create(body, options: JsonOpts),
+            };
+            AddTenantHeader(request, tenantId);
+            using var response = await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
+            await RecordHealthAsync(
+                response.IsSuccessStatusCode, (int)response.StatusCode, null, ct)
+                .ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Tamma API {Method} returned {Status}",
+                    method.Method, (int)response.StatusCode);
+                return null;
+            }
+            return await response.Content
+                .ReadFromJsonAsync<T>(JsonOpts, ct)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException)
+        {
+            _logger.LogWarning(ex, "Tamma API {Method} failed", method.Method);
             await RecordHealthAsync(false, null, ex.GetType().Name, ct).ConfigureAwait(false);
             return null;
         }

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/GitEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/GitEndpoints.cs
@@ -1,0 +1,74 @@
+using Microsoft.AspNetCore.Http;
+using Tamma.Api.Services.Git;
+using Tamma.Data;
+
+namespace Tamma.Api.Endpoints;
+
+/// <summary>
+/// Story 38-1 (AC1) — the internal, engine-only git-mediation endpoints
+/// (<c>/api/v1/git/{owner}/{repo}/...</c>). They mirror the Story 32-5
+/// <c>/api/v1/llm/call</c> plane exactly:
+/// <list type="bullet">
+///   <item><b>Auth</b> — the <c>EngineServiceOnly</c> policy (the engine posts the
+///     service-scope <c>Tamma:ApiToken</c> Bearer via <c>TammaEngineAuthHandler</c>).
+///     A missing/invalid bearer ⇒ 401; a user JWT ⇒ 403 — both BEFORE the handler.</item>
+///   <item><b>Tenant scope</b> — the acting tenant is the auth-derived
+///     <see cref="ITenantContext"/> (X-Tenant-Id), NEVER the request body.</item>
+///   <item><b>Composition</b> — delegates to <see cref="IGitMediationService"/>
+///     (cross-tenant guard → per-tenant token → platform call with the resolved
+///     token → one DCB audit event), then projects the typed key-free
+///     <see cref="GitMediationResult"/> via <c>ToHttpResult()</c> (200 / 200
+///     success:false + preserved platformStatusCode / 403 REPO_NOT_AUTHORIZED /
+///     503 GIT_TOKEN_UNAVAILABLE — never a raw 5xx).</item>
+/// </list>
+///
+/// <para><c>{owner}/{repo}</c> is bound as two route segments (an
+/// <c>owner/name</c> full name carries a slash, which a single path segment
+/// cannot capture); the endpoints reconstruct the <c>owner/name</c> repo string
+/// the guard/token/platform layer expects.</para>
+/// </summary>
+public static class GitEndpoints
+{
+    public static async Task<IResult> CreateBranch(
+        string owner, string repo, CreateBranchRequest body,
+        ITenantContext tenantContext, IGitMediationService git, CancellationToken ct)
+    {
+        var result = await git.CreateBranchAsync(tenantContext.TenantId, Repo(owner, repo), body, ct).ConfigureAwait(false);
+        return result.ToHttpResult();
+    }
+
+    public static async Task<IResult> CreatePullRequest(
+        string owner, string repo, CreatePrRequest body,
+        ITenantContext tenantContext, IGitMediationService git, CancellationToken ct)
+    {
+        var result = await git.CreatePullRequestAsync(tenantContext.TenantId, Repo(owner, repo), body, ct).ConfigureAwait(false);
+        return result.ToHttpResult();
+    }
+
+    public static async Task<IResult> MergePullRequest(
+        string owner, string repo, int n, MergePrRequest body,
+        ITenantContext tenantContext, IGitMediationService git, CancellationToken ct)
+    {
+        var result = await git.MergePullRequestAsync(tenantContext.TenantId, Repo(owner, repo), n, body, ct).ConfigureAwait(false);
+        return result.ToHttpResult();
+    }
+
+    public static async Task<IResult> GetPullRequestComments(
+        string owner, string repo, int n, string? correlationId,
+        ITenantContext tenantContext, IGitMediationService git, CancellationToken ct)
+    {
+        var result = await git.GetPullRequestCommentsAsync(
+            tenantContext.TenantId, Repo(owner, repo), n, correlationId ?? string.Empty, ct).ConfigureAwait(false);
+        return result.ToHttpResult();
+    }
+
+    public static async Task<IResult> UpdateIssue(
+        string owner, string repo, int n, UpdateIssueRequest body,
+        ITenantContext tenantContext, IGitMediationService git, CancellationToken ct)
+    {
+        var result = await git.UpdateIssueAsync(tenantContext.TenantId, Repo(owner, repo), n, body, ct).ConfigureAwait(false);
+        return result.ToHttpResult();
+    }
+
+    private static string Repo(string owner, string repo) => $"{owner}/{repo}";
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -539,6 +539,23 @@ builder.Services.TryAddSingleton<Tamma.Api.Services.Agents.IBudgetGuard,
 builder.Services.TryAddSingleton<Tamma.Api.Services.Agents.ILlmCallResponseMapper,
     Tamma.Api.Services.Agents.LlmCallResponseMapper>();
 
+// Story 38-1 (Epic 38) — git-platform step mediation (Class A). The engine's
+// thin ADL git activities (CreateBranch / CreatePullRequest / MergePullRequest /
+// UpdateIssueStatus / AnalyzeReview) POST to /api/v1/git/{owner}/{repo}/... here
+// instead of resolving the co-hosted IGitHubIntegrationService. The API holds the
+// per-tenant token: it authorizes tenant↔repo FIRST (the cross-tenant guard),
+// resolves the token BYOK→platform, performs the platform call with THAT token,
+// and emits one terminal GIT.* DCB event. IGitHubIntegrationService stays
+// API-only; the GitHubClientFactory mints a token-bound instance per request.
+builder.Services.AddScoped<Tamma.Api.Services.Git.IGitRepoAuthorizer,
+    Tamma.Api.Services.Git.GitRepoAuthorizer>();
+builder.Services.AddScoped<Tamma.Api.Services.Git.IGitTokenResolver,
+    Tamma.Api.Services.Git.GitTokenResolver>();
+builder.Services.AddSingleton<Tamma.Api.Services.Git.IGitHubClientFactory,
+    Tamma.Api.Services.Git.GitHubClientFactory>();
+builder.Services.AddScoped<Tamma.Api.Services.Git.IGitMediationService,
+    Tamma.Api.Services.Git.GitMediationService>();
+
 // Story 32-5 (T4) — provider-side DI for the server-side tool loop, FORMALIZED
 // in the API process (replacing T3's best-effort GetService factory). The loop
 // (extracted verbatim into InlineToolLoopRunner) now executes HERE, where the
@@ -2299,6 +2316,28 @@ app.MapPost("/api/v1/llm/chat", SaaSEndpoints.LlmChat).RequireAuthorization();
 app.MapPost("/api/v1/llm/call", LlmCallEndpoints.CallLlm)
     .RequireAuthorization("EngineServiceOnly")
     .WithName("CallLlm");
+
+// ── Story 38-1 (Epic 38) — git-platform step mediation (Class A) ──
+// Same engine-only plane as /api/v1/llm/call: the engine's thin ADL git
+// activities post here as the service-scope Tamma:ApiToken; the API holds the
+// per-tenant token, authorizes tenant↔repo (cross-tenant guard), performs the
+// platform call with the resolved token, and audits it. {owner}/{repo} is bound
+// as two segments (an owner/name full name carries a slash).
+app.MapPost("/api/v1/git/{owner}/{repo}/branches", GitEndpoints.CreateBranch)
+    .RequireAuthorization("EngineServiceOnly")
+    .WithName("GitCreateBranch");
+app.MapPost("/api/v1/git/{owner}/{repo}/pull-requests", GitEndpoints.CreatePullRequest)
+    .RequireAuthorization("EngineServiceOnly")
+    .WithName("GitCreatePullRequest");
+app.MapPut("/api/v1/git/{owner}/{repo}/pull-requests/{n:int}/merge", GitEndpoints.MergePullRequest)
+    .RequireAuthorization("EngineServiceOnly")
+    .WithName("GitMergePullRequest");
+app.MapGet("/api/v1/git/{owner}/{repo}/pull-requests/{n:int}/comments", GitEndpoints.GetPullRequestComments)
+    .RequireAuthorization("EngineServiceOnly")
+    .WithName("GitGetPullRequestComments");
+app.MapPatch("/api/v1/git/{owner}/{repo}/issues/{n:int}", GitEndpoints.UpdateIssue)
+    .RequireAuthorization("EngineServiceOnly")
+    .WithName("GitUpdateIssue");
 app.MapPost("/api/v1/workflows/{id}/status", SaaSEndpoints.UpdateWorkflowStatus).RequireAuthorization();
 app.MapPost("/api/v1/workflows/{id}/result", SaaSEndpoints.PostWorkflowResult).RequireAuthorization();
 app.MapPost("/api/v1/installations/{id}/rotate-key", SaaSEndpoints.RotateInstallationKey).RequireAuthorization();

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitEventTypes.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitEventTypes.cs
@@ -1,0 +1,67 @@
+namespace Tamma.Api.Services.Git;
+
+/// <summary>
+/// Story 38-1 (AC7) — the terminal DCB event families the git-mediation
+/// endpoints emit (exactly one per call). Naming mirrors the Story 32-5
+/// <c>AGENT.RUN.*</c> convention (<c>AGGREGATE.ACTION.STATUS</c>). Payloads +
+/// tags are KEY-FREE — they reference the repo + PR/issue numbers, never the
+/// resolved git token or any Authorization header.
+/// </summary>
+public static class GitEventTypes
+{
+    // Operation labels (the `operation` tag + the {OPERATION} slug).
+    public const string BranchCreateOperation = "branch_create";
+    public const string PrOpenOperation = "pr_open";
+    public const string PrMergeOperation = "pr_merge";
+    public const string IssueUpdateOperation = "issue_update";
+    public const string PrCommentsReadOperation = "pr_comments_read";
+
+    public const string BranchCreatedSuccess = "GIT.BRANCH_CREATED.SUCCESS";
+    public const string BranchCreatedFailed = "GIT.BRANCH_CREATED.FAILED";
+
+    public const string PrOpenedSuccess = "GIT.PR_OPENED.SUCCESS";
+    public const string PrOpenedFailed = "GIT.PR_OPENED.FAILED";
+
+    public const string PrMergedSuccess = "GIT.PR_MERGED.SUCCESS";
+    public const string PrMergeFailed = "GIT.PR_MERGE.FAILED";
+
+    public const string IssueUpdatedSuccess = "GIT.ISSUE_UPDATED.SUCCESS";
+    public const string IssueUpdatedFailed = "GIT.ISSUE_UPDATED.FAILED";
+
+    public const string PrCommentsReadSuccess = "GIT.PR_COMMENTS_READ.SUCCESS";
+    public const string PrCommentsReadFailed = "GIT.PR_COMMENTS_READ.FAILED";
+}
+
+/// <summary>
+/// Story 38-1 (AC6) — the coarse, key-free failure taxonomy surfaced on the
+/// wire so the ADL workflow can branch on the outcome exactly the way it does
+/// today. Never a raw provider 5xx.
+/// </summary>
+public static class GitFailureCodes
+{
+    /// <summary>The tenant↔repo cross-tenant guard denied (AC2). Platform never called.</summary>
+    public const string RepoNotAuthorized = "REPO_NOT_AUTHORIZED";
+
+    /// <summary>An expected platform conflict (branch already exists, PR conflict).</summary>
+    public const string GitConflict = "GIT_CONFLICT";
+
+    /// <summary>The PR is not in a mergeable state.</summary>
+    public const string NotMergeable = "NOT_MERGEABLE";
+
+    /// <summary>The referenced branch / PR / issue was not found.</summary>
+    public const string NotFound = "NOT_FOUND";
+
+    /// <summary>Any other expected platform failure (permission, rate-limit, transient).</summary>
+    public const string PlatformError = "PLATFORM_ERROR";
+
+    /// <summary>The per-tenant git token could not be resolved (fail-closed, AC3/AC6).</summary>
+    public const string TokenUnavailable = "GIT_TOKEN_UNAVAILABLE";
+}
+
+/// <summary>The credential-source LABEL surfaced on the audit event + response —
+/// never the token itself (AC3).</summary>
+public static class GitCredentialSources
+{
+    public const string Byok = "byok";
+    public const string Platform = "platform";
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitMediationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitMediationService.cs
@@ -1,0 +1,579 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.ADL;
+using Tamma.Core.Interfaces;
+using Tamma.Core.Logging;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Git;
+
+/// <summary>
+/// Story 38-1 — composes the git-mediation sequence entirely inside
+/// <c>Tamma.Api</c>: cross-tenant guard → per-tenant token (BYOK→platform) →
+/// platform call with the RESOLVED token → exactly-one terminal DCB event.
+///
+/// <para>The platform call reuses the existing, well-tested ADL orchestration
+/// cores (<c>CreateBranchActivity.ExecuteCoreAsync</c> etc.) but against a
+/// TOKEN-BOUND <see cref="IGitHubIntegrationService"/> minted by
+/// <see cref="IGitHubClientFactory"/> — so "the token used == the token
+/// resolved". The resolved token lives only on that request-scoped service
+/// instance; it is NEVER logged, returned, or written to the audit event
+/// (only the <c>credentialSource</c> LABEL is surfaced).</para>
+/// </summary>
+public sealed class GitMediationService : IGitMediationService
+{
+    private readonly IGitRepoAuthorizer _authorizer;
+    private readonly IGitTokenResolver _tokenResolver;
+    private readonly IGitHubClientFactory _githubFactory;
+    private readonly IEventRepository _events;
+    private readonly ILogger<GitMediationService> _logger;
+
+    public GitMediationService(
+        IGitRepoAuthorizer authorizer,
+        IGitTokenResolver tokenResolver,
+        IGitHubClientFactory githubFactory,
+        IEventRepository events,
+        ILogger<GitMediationService> logger)
+    {
+        _authorizer = authorizer ?? throw new ArgumentNullException(nameof(authorizer));
+        _tokenResolver = tokenResolver ?? throw new ArgumentNullException(nameof(tokenResolver));
+        _githubFactory = githubFactory ?? throw new ArgumentNullException(nameof(githubFactory));
+        _events = events ?? throw new ArgumentNullException(nameof(events));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    // ===================================================================
+    // Public API — each op is wrapped so an unexpected exception between the
+    // guard and the platform call becomes a typed PLATFORM_ERROR (never a raw
+    // 5xx) with exactly one terminal GIT.* FAILED event (F3 / AC6 / AC7).
+    // ===================================================================
+
+    public Task<GitMediationResult> CreateBranchAsync(Guid? tenantId, string repo, CreateBranchRequest body, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        return ExecuteGuardedAsync(tenantId, repo, GitEventTypes.BranchCreateOperation, GitEventTypes.BranchCreatedFailed, body.CorrelationId, ct,
+            () => CreateBranchCoreAsync(tenantId, repo, body, ct));
+    }
+
+    public Task<GitMediationResult> CreatePullRequestAsync(Guid? tenantId, string repo, CreatePrRequest body, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        return ExecuteGuardedAsync(tenantId, repo, GitEventTypes.PrOpenOperation, GitEventTypes.PrOpenedFailed, body.CorrelationId, ct,
+            () => CreatePullRequestCoreAsync(tenantId, repo, body, ct));
+    }
+
+    public Task<GitMediationResult> MergePullRequestAsync(Guid? tenantId, string repo, int prNumber, MergePrRequest body, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        return ExecuteGuardedAsync(tenantId, repo, GitEventTypes.PrMergeOperation, GitEventTypes.PrMergeFailed, body.CorrelationId, ct,
+            () => MergePullRequestCoreAsync(tenantId, repo, prNumber, body, ct));
+    }
+
+    public Task<GitMediationResult> UpdateIssueAsync(Guid? tenantId, string repo, int issueNumber, UpdateIssueRequest body, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        return ExecuteGuardedAsync(tenantId, repo, GitEventTypes.IssueUpdateOperation, GitEventTypes.IssueUpdatedFailed, body.CorrelationId, ct,
+            () => UpdateIssueCoreAsync(tenantId, repo, issueNumber, body, ct));
+    }
+
+    public Task<GitMediationResult> GetPullRequestCommentsAsync(Guid? tenantId, string repo, int prNumber, string correlationId, CancellationToken ct = default)
+        => ExecuteGuardedAsync(tenantId, repo, GitEventTypes.PrCommentsReadOperation, GitEventTypes.PrCommentsReadFailed, correlationId, ct,
+            () => GetPullRequestCommentsCoreAsync(tenantId, repo, prNumber, correlationId, ct));
+
+    /// <summary>
+    /// F3 — run one mediation op body; convert any unexpected exception (DB read,
+    /// secret decrypt, client mint, transport) into a typed key-free
+    /// PLATFORM_ERROR result plus exactly one terminal GIT.* FAILED event. A
+    /// cancellation is not a platform failure and propagates.
+    /// </summary>
+    private async Task<GitMediationResult> ExecuteGuardedAsync(
+        Guid? tenantId, string repo, string operation, string failedEventType, string correlationId,
+        CancellationToken ct, Func<Task<GitMediationResult>> body)
+    {
+        try
+        {
+            return await body().ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "git-mediation op {Operation} threw; returning typed PLATFORM_ERROR (never a raw 5xx) with one FAILED event. correlationId={CorrelationId}, repo={Repo}, tenantId={TenantId}",
+                operation, LogSanitizer.Clean(correlationId), LogSanitizer.Clean(repo), tenantId);
+
+            await EmitAsync(failedEventType, operation, tenantId, repo, correlationId, credentialSource: null,
+                GitFailureCodes.PlatformError, new { }, ct).ConfigureAwait(false);
+
+            return new GitMediationResult
+            {
+                Success = false,
+                Outcome = "Error",
+                FailureCode = GitFailureCodes.PlatformError,
+                FailureReason = "an unexpected error occurred processing the git operation",
+                CorrelationId = correlationId,
+            };
+        }
+    }
+
+    // ===================================================================
+    // Create branch
+    // ===================================================================
+
+    private async Task<GitMediationResult> CreateBranchCoreAsync(Guid? tenantId, string repo, CreateBranchRequest body, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        var op = GitEventTypes.BranchCreateOperation;
+
+        var gate = await GuardOrDenyAsync(tenantId, repo, op, GitEventTypes.BranchCreatedFailed, body.CorrelationId, ct).ConfigureAwait(false);
+        if (gate is not null) return gate;
+
+        var cred = await _tokenResolver.ResolveAsync(tenantId, repo, ct).ConfigureAwait(false);
+        if (cred is null)
+            return await TokenUnavailableAsync(tenantId, repo, op, GitEventTypes.BranchCreatedFailed, body.CorrelationId, ct).ConfigureAwait(false);
+
+        var github = _githubFactory.Create(cred.Token);
+        var strategy = string.IsNullOrWhiteSpace(body.ConflictStrategy)
+            ? CreateBranchActivity.DefaultConflictStrategy
+            : body.ConflictStrategy!;
+
+        var outcome = await CreateBranchActivity.ExecuteCoreAsync(
+            github, repo, body.IssueNumber, body.BranchName, body.BaseRef, strategy, _logger).ConfigureAwait(false);
+
+        if (outcome.Outcome == "Created")
+        {
+            var ok = new GitMediationResult
+            {
+                Success = true,
+                CredentialSource = cred.Source,
+                Outcome = "Created",
+                BranchRef = outcome.BranchName,
+                BaseSha = outcome.BaseSha,
+                ConflictResolved = outcome.ConflictResolved,
+                CorrelationId = body.CorrelationId,
+            };
+            await EmitAsync(GitEventTypes.BranchCreatedSuccess, op, tenantId, repo, body.CorrelationId, cred.Source, null,
+                new { branchRef = outcome.BranchName, conflictResolved = outcome.ConflictResolved }, ct).ConfigureAwait(false);
+            return ok;
+        }
+
+        var failCode = MapBranchFailure(outcome.ErrorCode);
+        var fail = new GitMediationResult
+        {
+            Success = false,
+            CredentialSource = cred.Source,
+            Outcome = "Error",
+            FailureCode = failCode,
+            FailureReason = outcome.Error,
+            PlatformStatusCode = ParsePlatformStatus(outcome.Error),
+            CorrelationId = body.CorrelationId,
+        };
+        await EmitAsync(GitEventTypes.BranchCreatedFailed, op, tenantId, repo, body.CorrelationId, cred.Source, failCode,
+            new { branchName = body.BranchName }, ct).ConfigureAwait(false);
+        return fail;
+    }
+
+    // ===================================================================
+    // Create / update pull request
+    // ===================================================================
+
+    private async Task<GitMediationResult> CreatePullRequestCoreAsync(Guid? tenantId, string repo, CreatePrRequest body, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        var op = GitEventTypes.PrOpenOperation;
+
+        var gate = await GuardOrDenyAsync(tenantId, repo, op, GitEventTypes.PrOpenedFailed, body.CorrelationId, ct).ConfigureAwait(false);
+        if (gate is not null) return gate;
+
+        var cred = await _tokenResolver.ResolveAsync(tenantId, repo, ct).ConfigureAwait(false);
+        if (cred is null)
+            return await TokenUnavailableAsync(tenantId, repo, op, GitEventTypes.PrOpenedFailed, body.CorrelationId, ct).ConfigureAwait(false);
+
+        var github = _githubFactory.Create(cred.Token);
+        var coreRequest = new CreatePullRequestRequest
+        {
+            Title = body.Title,
+            Body = body.Body ?? string.Empty,
+            Head = body.HeadRef,
+            Base = body.BaseRef,
+            Labels = body.Labels?.ToList() ?? new List<string>(),
+            Reviewers = body.Reviewers?.ToList() ?? new List<string>(),
+            IsDraft = body.IsDraft,
+        };
+
+        var outcome = await CreatePullRequestActivity.ExecuteCoreAsync(
+            github, repo, body.HeadRef, body.BaseRef, body.IsDraft, coreRequest, _logger).ConfigureAwait(false);
+
+        if (outcome.Outcome is "Created" or "Updated")
+        {
+            var ok = new GitMediationResult
+            {
+                Success = true,
+                CredentialSource = cred.Source,
+                Outcome = outcome.Outcome,
+                PrNumber = outcome.PrNumber,
+                PrUrl = outcome.PrUrl,
+                Reused = outcome.Reused,
+                IsDraft = outcome.IsDraft,
+                CorrelationId = body.CorrelationId,
+            };
+            await EmitAsync(GitEventTypes.PrOpenedSuccess, op, tenantId, repo, body.CorrelationId, cred.Source, null,
+                new { prNumber = outcome.PrNumber, reused = outcome.Reused, outcome = outcome.Outcome }, ct).ConfigureAwait(false);
+            return ok;
+        }
+
+        var failCode = MapPrFailure(outcome.ErrorCode);
+        var fail = new GitMediationResult
+        {
+            Success = false,
+            CredentialSource = cred.Source,
+            Outcome = "Error",
+            FailureCode = failCode,
+            FailureReason = outcome.ErrorCode,
+            CorrelationId = body.CorrelationId,
+        };
+        await EmitAsync(GitEventTypes.PrOpenedFailed, op, tenantId, repo, body.CorrelationId, cred.Source, failCode,
+            new { head = body.HeadRef, @base = body.BaseRef }, ct).ConfigureAwait(false);
+        return fail;
+    }
+
+    // ===================================================================
+    // Merge pull request (highest-risk write)
+    // ===================================================================
+
+    private async Task<GitMediationResult> MergePullRequestCoreAsync(Guid? tenantId, string repo, int prNumber, MergePrRequest body, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        var op = GitEventTypes.PrMergeOperation;
+
+        var gate = await GuardOrDenyAsync(tenantId, repo, op, GitEventTypes.PrMergeFailed, body.CorrelationId, ct).ConfigureAwait(false);
+        if (gate is not null) return gate;
+
+        var cred = await _tokenResolver.ResolveAsync(tenantId, repo, ct).ConfigureAwait(false);
+        if (cred is null)
+            return await TokenUnavailableAsync(tenantId, repo, op, GitEventTypes.PrMergeFailed, body.CorrelationId, ct).ConfigureAwait(false);
+
+        var github = _githubFactory.Create(cred.Token);
+        var strategy = MergePullRequestActivity.NormalizeStrategy(body.MergeStrategy);
+
+        var outcome = await MergePullRequestActivity.ExecuteCoreAsync(
+            github, repo, prNumber, body.IssueNumber, body.BranchName ?? string.Empty, strategy,
+            body.AutoDeleteBranch, body.CloseAssociatedIssue, _logger).ConfigureAwait(false);
+
+        if (outcome.MergeSucceeded)
+        {
+            var ok = new GitMediationResult
+            {
+                Success = true,
+                CredentialSource = cred.Source,
+                Outcome = outcome.Outcome, // "Merged" | "MergedWithWarnings"
+                Merged = true,
+                MergeSha = outcome.MergeSha,
+                IssueClosed = outcome.IssueClosed,
+                BranchDeleted = outcome.BranchDeleted,
+                AlreadyMerged = outcome.AlreadyMerged,
+                FailureReason = outcome.FailureReason, // warnings (partial), key-free
+                CorrelationId = body.CorrelationId,
+            };
+            await EmitAsync(GitEventTypes.PrMergedSuccess, op, tenantId, repo, body.CorrelationId, cred.Source, null,
+                new { prNumber, issueNumber = body.IssueNumber, alreadyMerged = outcome.AlreadyMerged, outcome = outcome.Outcome }, ct).ConfigureAwait(false);
+            return ok;
+        }
+
+        var failCode = MapMergeFailure(outcome.FailureCode);
+        var fail = new GitMediationResult
+        {
+            Success = false,
+            CredentialSource = cred.Source,
+            Outcome = "Error",
+            Merged = false,
+            FailureCode = failCode,
+            FailureReason = outcome.FailureReason,
+            PlatformStatusCode = ParsePlatformStatus(outcome.FailureReason),
+            CorrelationId = body.CorrelationId,
+        };
+        await EmitAsync(GitEventTypes.PrMergeFailed, op, tenantId, repo, body.CorrelationId, cred.Source, failCode,
+            new { prNumber, issueNumber = body.IssueNumber }, ct).ConfigureAwait(false);
+        return fail;
+    }
+
+    // ===================================================================
+    // Update issue (status comment + labels)
+    // ===================================================================
+
+    private async Task<GitMediationResult> UpdateIssueCoreAsync(Guid? tenantId, string repo, int issueNumber, UpdateIssueRequest body, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        var op = GitEventTypes.IssueUpdateOperation;
+
+        var gate = await GuardOrDenyAsync(tenantId, repo, op, GitEventTypes.IssueUpdatedFailed, body.CorrelationId, ct).ConfigureAwait(false);
+        if (gate is not null) return gate;
+
+        var cred = await _tokenResolver.ResolveAsync(tenantId, repo, ct).ConfigureAwait(false);
+        if (cred is null)
+            return await TokenUnavailableAsync(tenantId, repo, op, GitEventTypes.IssueUpdatedFailed, body.CorrelationId, ct).ConfigureAwait(false);
+
+        var github = _githubFactory.Create(cred.Token);
+
+        // Post the status comment, then add / remove labels. The first failure
+        // surfaces a loud typed failure (no partial false success).
+        if (!string.IsNullOrWhiteSpace(body.Body))
+        {
+            var comment = await github.PostIssueCommentAsync(repo, issueNumber, body.Body!).ConfigureAwait(false);
+            if (!comment.Success)
+                return await IssueFailAsync(tenantId, repo, issueNumber, body.CorrelationId, cred.Source, comment.Error, ct).ConfigureAwait(false);
+        }
+
+        if (body.AddLabels is { Count: > 0 })
+        {
+            var added = await github.AddIssueLabelsAsync(repo, issueNumber, body.AddLabels.ToArray()).ConfigureAwait(false);
+            if (!added.Success)
+                return await IssueFailAsync(tenantId, repo, issueNumber, body.CorrelationId, cred.Source, added.Error, ct).ConfigureAwait(false);
+        }
+
+        if (body.RemoveLabels is { Count: > 0 })
+        {
+            foreach (var label in body.RemoveLabels)
+            {
+                var removed = await github.RemoveIssueLabelAsync(repo, issueNumber, label).ConfigureAwait(false);
+                if (!removed.Success)
+                    return await IssueFailAsync(tenantId, repo, issueNumber, body.CorrelationId, cred.Source, removed.Error, ct).ConfigureAwait(false);
+            }
+        }
+
+        // Optional state transition (today the ADL activity never closes here, but
+        // the wire supports it for completeness).
+        if (string.Equals(body.Status, "closed", StringComparison.OrdinalIgnoreCase))
+        {
+            var closed = await github.CloseGitHubIssueAsync(repo, issueNumber).ConfigureAwait(false);
+            if (!closed.Success || !closed.Data)
+                return await IssueFailAsync(tenantId, repo, issueNumber, body.CorrelationId, cred.Source, closed.Error, ct).ConfigureAwait(false);
+        }
+
+        var ok = new GitMediationResult
+        {
+            Success = true,
+            CredentialSource = cred.Source,
+            Outcome = "Updated",
+            IssueStatus = string.IsNullOrWhiteSpace(body.Status) ? "updated" : body.Status,
+            CorrelationId = body.CorrelationId,
+        };
+        await EmitAsync(GitEventTypes.IssueUpdatedSuccess, op, tenantId, repo, body.CorrelationId, cred.Source, null,
+            new { issueNumber, status = ok.IssueStatus }, ct).ConfigureAwait(false);
+        return ok;
+    }
+
+    private async Task<GitMediationResult> IssueFailAsync(
+        Guid? tenantId, string repo, int issueNumber, string correlationId, string credentialSource, string? reason, CancellationToken ct)
+    {
+        var failCode = MapIssueFailure(reason);
+        var fail = new GitMediationResult
+        {
+            Success = false,
+            CredentialSource = credentialSource,
+            Outcome = "Failed",
+            FailureCode = failCode,
+            FailureReason = reason,
+            PlatformStatusCode = ParsePlatformStatus(reason),
+            CorrelationId = correlationId,
+        };
+        await EmitAsync(GitEventTypes.IssueUpdatedFailed, GitEventTypes.IssueUpdateOperation, tenantId, repo, correlationId, credentialSource, failCode,
+            new { issueNumber }, ct).ConfigureAwait(false);
+        return fail;
+    }
+
+    // ===================================================================
+    // Read PR review comments
+    // ===================================================================
+
+    private async Task<GitMediationResult> GetPullRequestCommentsCoreAsync(Guid? tenantId, string repo, int prNumber, string correlationId, CancellationToken ct = default)
+    {
+        var op = GitEventTypes.PrCommentsReadOperation;
+
+        var gate = await GuardOrDenyAsync(tenantId, repo, op, GitEventTypes.PrCommentsReadFailed, correlationId, ct).ConfigureAwait(false);
+        if (gate is not null) return gate;
+
+        var cred = await _tokenResolver.ResolveAsync(tenantId, repo, ct).ConfigureAwait(false);
+        if (cred is null)
+            return await TokenUnavailableAsync(tenantId, repo, op, GitEventTypes.PrCommentsReadFailed, correlationId, ct).ConfigureAwait(false);
+
+        var github = _githubFactory.Create(cred.Token);
+        var res = await github.GetPullRequestReviewCommentsAsync(repo, prNumber).ConfigureAwait(false);
+
+        if (!res.Success)
+        {
+            var failCode = MapReadFailure(res.Error);
+            var fail = new GitMediationResult
+            {
+                Success = false,
+                CredentialSource = cred.Source,
+                Outcome = "Error",
+                FailureCode = failCode,
+                FailureReason = res.Error,
+                PlatformStatusCode = ParsePlatformStatus(res.Error),
+                CorrelationId = correlationId,
+            };
+            await EmitAsync(GitEventTypes.PrCommentsReadFailed, op, tenantId, repo, correlationId, cred.Source, failCode,
+                new { prNumber }, ct).ConfigureAwait(false);
+            return fail;
+        }
+
+        var comments = (res.Data ?? new List<GitHubReviewComment>())
+            .Select(c => new PrCommentDto
+            {
+                Id = c.Id,
+                Body = c.Body,
+                Path = c.Path,
+                Line = c.Line,
+                Author = c.Author,
+                CreatedAt = c.CreatedAt,
+            })
+            .ToList();
+
+        var ok = new GitMediationResult
+        {
+            Success = true,
+            CredentialSource = cred.Source,
+            Outcome = "Done",
+            Comments = comments,
+            CorrelationId = correlationId,
+        };
+        await EmitAsync(GitEventTypes.PrCommentsReadSuccess, op, tenantId, repo, correlationId, cred.Source, null,
+            new { prNumber, commentCount = comments.Count }, ct).ConfigureAwait(false);
+        return ok;
+    }
+
+    // ===================================================================
+    // Guard / token-unavailable shared paths
+    // ===================================================================
+
+    /// <summary>Run the cross-tenant guard. On deny, emit the terminal FAILED
+    /// event and return the 403 result; the platform is NEVER called and no token
+    /// is resolved. On allow, returns null so the caller proceeds.</summary>
+    private async Task<GitMediationResult?> GuardOrDenyAsync(
+        Guid? tenantId, string repo, string operation, string failedEventType, string correlationId, CancellationToken ct)
+    {
+        var authz = await _authorizer.AuthorizeAsync(tenantId, repo, ct).ConfigureAwait(false);
+        if (authz.Allowed) return null;
+
+        var result = new GitMediationResult
+        {
+            Success = false,
+            Outcome = "Error",
+            FailureCode = GitFailureCodes.RepoNotAuthorized,
+            FailureReason = authz.Reason,
+            CorrelationId = correlationId,
+        };
+        // credentialSource is null — no token was resolved (fail-closed).
+        await EmitAsync(failedEventType, operation, tenantId, repo, correlationId, credentialSource: null,
+            GitFailureCodes.RepoNotAuthorized, new { }, ct).ConfigureAwait(false);
+        return result;
+    }
+
+    private async Task<GitMediationResult> TokenUnavailableAsync(
+        Guid? tenantId, string repo, string operation, string failedEventType, string correlationId, CancellationToken ct)
+    {
+        var result = new GitMediationResult
+        {
+            Success = false,
+            Outcome = "Error",
+            FailureCode = GitFailureCodes.TokenUnavailable,
+            FailureReason = "the per-tenant git token could not be resolved",
+            CorrelationId = correlationId,
+        };
+        await EmitAsync(failedEventType, operation, tenantId, repo, correlationId, credentialSource: null,
+            GitFailureCodes.TokenUnavailable, new { }, ct).ConfigureAwait(false);
+        return result;
+    }
+
+    // ===================================================================
+    // DCB audit (exactly one terminal GIT.* event per call)
+    // ===================================================================
+
+    private async Task EmitAsync(
+        string eventType, string operation, Guid? tenantId, string repo, string correlationId,
+        string? credentialSource, string? failureCode, object data, CancellationToken ct)
+    {
+        try
+        {
+            object tagsObj = failureCode is null
+                ? new { tenantId = tenantId?.ToString(), repo, operation, credentialSource, correlationId }
+                : new { tenantId = tenantId?.ToString(), repo, operation, credentialSource, correlationId, failureCode };
+
+            await _events.AppendAsync(new DomainEvent
+            {
+                Id = Guid.NewGuid(),
+                Type = eventType,
+                TenantId = tenantId,
+                Tags = JsonSerializer.Serialize(tagsObj),
+                Metadata = JsonSerializer.Serialize(new { workflowVersion = "1.0.0", eventSource = "system" }),
+                Data = JsonSerializer.Serialize(data),
+                CreatedAt = DateTime.UtcNow,
+            }).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // AC7 / logging-requirements: an append failure is logged at ERROR, NOT
+            // swallowed into a lost result — the mediation result still returns.
+            _logger.LogError(ex,
+                "GIT.* event append failed (type={Type}); the mediation result still returns. correlationId={CorrelationId}, repo={Repo}, tenantId={TenantId}",
+                eventType, LogSanitizer.Clean(correlationId), LogSanitizer.Clean(repo), tenantId);
+        }
+    }
+
+    // ===================================================================
+    // Failure-code mapping (activity classification → coarse, key-free wire code)
+    // ===================================================================
+
+    private static string MapBranchFailure(string? code) => (code ?? string.Empty).ToLowerInvariant() switch
+    {
+        "branch_exists" or "conflict_exhausted" => GitFailureCodes.GitConflict,
+        "base_branch_not_found" => GitFailureCodes.NotFound,
+        _ => GitFailureCodes.PlatformError,
+    };
+
+    private static string MapPrFailure(string? code) => (code ?? string.Empty).ToLowerInvariant() switch
+    {
+        "merge-conflict" or "pr-already-exists" => GitFailureCodes.GitConflict,
+        "not-found" => GitFailureCodes.NotFound,
+        _ => GitFailureCodes.PlatformError,
+    };
+
+    private static string MapMergeFailure(string? code) => (code ?? string.Empty).ToLowerInvariant() switch
+    {
+        "merge_conflict" => GitFailureCodes.GitConflict,
+        "not_mergeable" => GitFailureCodes.NotMergeable,
+        _ => GitFailureCodes.PlatformError,
+    };
+
+    private static string MapIssueFailure(string? reason)
+    {
+        var code = UpdateIssueStatusActivity.ClassifyError(reason);
+        return code switch
+        {
+            "issue-not-found" => GitFailureCodes.NotFound,
+            _ => GitFailureCodes.PlatformError,
+        };
+    }
+
+    private static string MapReadFailure(string? reason)
+    {
+        var status = ParsePlatformStatus(reason);
+        return status == 404 ? GitFailureCodes.NotFound : GitFailureCodes.PlatformError;
+    }
+
+    /// <summary>Best-effort extraction of a leading numeric HTTP status from the
+    /// integration layer's status-prefixed error (e.g. <c>"403: ..."</c>). Null
+    /// when the message carries no numeric prefix (the coarse failureCode still
+    /// classifies it).</summary>
+    private static int? ParsePlatformStatus(string? reason)
+    {
+        if (string.IsNullOrWhiteSpace(reason)) return null;
+        var colon = reason.IndexOf(':');
+        var head = colon > 0 ? reason[..colon] : reason;
+        return int.TryParse(head.Trim(), out var status) && status is >= 100 and < 600 ? status : null;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitRepoAuthorizer.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitRepoAuthorizer.cs
@@ -1,0 +1,87 @@
+using Microsoft.Extensions.Logging;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Core.Logging;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Git;
+
+/// <summary>
+/// Story 38-1 (AC2) — resolves the GitHub installation that grants access to
+/// <c>{repo}</c> (via the Epic 18/28 tenant↔repo registry,
+/// <see cref="IInstallationRepository.GetByRepoFullNameAsync"/>) and asserts the
+/// installation's tenant equals the acting tenant. Fail-closed:
+/// <list type="bullet">
+///   <item>no installation for the repo ⇒ denied;</item>
+///   <item>the installation belongs to a DIFFERENT tenant ⇒ denied (the
+///     cross-tenant write/merge this story exists to prevent).</item>
+/// </list>
+/// A denial NEVER resolves a token or reaches the platform.
+///
+/// <para><b>Null-tenant handling is mode-gated (F1).</b> Nullable equality alone
+/// fails OPEN in SaaS: a null acting tenant (<c>EngineServiceOnly</c> needs no
+/// <c>X-Tenant-Id</c>) against a null-<c>TenantId</c> orphan install
+/// (<c>InstallationRouterService</c> persists <c>TenantId=null</c> for unlinked
+/// installs) is <c>null == null</c> ⇒ Allow, then the platform static
+/// <c>GitHub:Token</c> writes cross-tenant. So:
+/// <list type="bullet">
+///   <item><b>single-user</b> — the sole user owns everything; a matched
+///     null/null is the legit sole-user case ⇒ Allow when
+///     <c>installation.TenantId == tenantId</c>.</item>
+///   <item><b>SaaS</b> — BOTH the acting tenant AND the installation's tenant
+///     must be present and equal. A null acting tenant OR a null-<c>TenantId</c>
+///     (orphan) install ⇒ Deny.</item>
+/// </list></para>
+/// </summary>
+public sealed class GitRepoAuthorizer : IGitRepoAuthorizer
+{
+    private readonly IInstallationRepository _installations;
+    private readonly ITammaModeProvider _mode;
+    private readonly ILogger<GitRepoAuthorizer> _logger;
+
+    public GitRepoAuthorizer(
+        IInstallationRepository installations,
+        ITammaModeProvider mode,
+        ILogger<GitRepoAuthorizer> logger)
+    {
+        _installations = installations ?? throw new ArgumentNullException(nameof(installations));
+        _mode = mode ?? throw new ArgumentNullException(nameof(mode));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<GitRepoAuthorization> AuthorizeAsync(Guid? tenantId, string repo, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(repo))
+        {
+            return GitRepoAuthorization.Deny("repo is required");
+        }
+
+        var installation = await _installations.GetByRepoFullNameAsync(repo).ConfigureAwait(false);
+        if (installation is null)
+        {
+            _logger.LogWarning(
+                "git-mediation guard DENIED: no installation grants access to repo {Repo} (tenant {TenantId})",
+                LogSanitizer.Clean(repo), tenantId);
+            return GitRepoAuthorization.Deny("no installation grants access to this repository");
+        }
+
+        // The acting tenant (X-Tenant-Id) MUST own the installation for {repo}.
+        // The null/null allowance is legit ONLY in single-user mode; in SaaS a
+        // null acting tenant or a null-TenantId (orphan) install fails OPEN under
+        // plain nullable equality, so SaaS requires BOTH ids present and equal.
+        var authorized = _mode.Mode == TammaMode.SaaS
+            ? tenantId is { } actingTenant
+                && installation.TenantId is { } installTenant
+                && installTenant == actingTenant
+            : installation.TenantId == tenantId;
+
+        if (!authorized)
+        {
+            _logger.LogWarning(
+                "git-mediation guard DENIED (cross-tenant): repo {Repo} is not owned by the acting tenant {TenantId} (mode {Mode})",
+                LogSanitizer.Clean(repo), tenantId, _mode.Mode);
+            return GitRepoAuthorization.Deny("the acting tenant is not authorized for this repository");
+        }
+
+        return GitRepoAuthorization.Allow();
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitRequests.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitRequests.cs
@@ -1,0 +1,73 @@
+namespace Tamma.Api.Services.Git;
+
+// ============================================================
+// Story 38-1 — server-side binding records for the git-mediation endpoints.
+// Bound from the engine client's camelCase JSON (Program.cs
+// ConfigureHttpJsonOptions → JsonNamingPolicy.CamelCase applies to reads too),
+// so the PascalCase property names below map from camelCase on the wire. The
+// mirroring client-side records live in
+// Tamma.Activities/LlmCall/Models/TammaApiModels.cs.
+//
+// NONE of these records carry a token — the API resolves the per-tenant
+// credential server-side (BYOK→platform); the engine holds no git token.
+// ============================================================
+
+/// <summary>
+/// <c>POST /api/v1/git/{owner}/{repo}/branches</c>. The candidate branch name is
+/// generated engine-side (a pure, token-free helper); the API performs the
+/// idempotent conflict-resolution + create + validate with the resolved token.
+/// </summary>
+public sealed record CreateBranchRequest
+{
+    public string BranchName { get; init; } = string.Empty;
+    public string BaseRef { get; init; } = "main";
+    public string? ConflictStrategy { get; init; }
+    public int IssueNumber { get; init; }
+    public string CorrelationId { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// <c>POST /api/v1/git/{owner}/{repo}/pull-requests</c>. Title / body / labels
+/// are composed engine-side (pure, token-free); the API opens or idempotently
+/// updates the PR with the resolved token.
+/// </summary>
+public sealed record CreatePrRequest
+{
+    public string Title { get; init; } = string.Empty;
+    public string? Body { get; init; }
+    public string HeadRef { get; init; } = string.Empty;
+    public string BaseRef { get; init; } = "main";
+    public IReadOnlyList<string>? Labels { get; init; }
+    public IReadOnlyList<string>? Reviewers { get; init; }
+    public bool IsDraft { get; init; }
+    public string CorrelationId { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// <c>PUT /api/v1/git/{owner}/{repo}/pull-requests/{n}/merge</c> — the
+/// highest-risk write. The API performs the pre-merge readiness read, the merge,
+/// and the verified post-merge close-issue + branch-delete with the resolved token.
+/// </summary>
+public sealed record MergePrRequest
+{
+    public string? MergeStrategy { get; init; } // merge | squash | rebase
+    public int IssueNumber { get; init; }
+    public string? BranchName { get; init; }
+    public bool AutoDeleteBranch { get; init; } = true;
+    public bool CloseAssociatedIssue { get; init; } = true;
+    public string CorrelationId { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// <c>PATCH /api/v1/git/{owner}/{repo}/issues/{n}</c>. The status comment body is
+/// composed engine-side; the API posts the comment + adds/removes labels with the
+/// resolved token.
+/// </summary>
+public sealed record UpdateIssueRequest
+{
+    public string? Body { get; init; }
+    public IReadOnlyList<string>? AddLabels { get; init; }
+    public IReadOnlyList<string>? RemoveLabels { get; init; }
+    public string? Status { get; init; } // open | closed (optional; today: no state change)
+    public string CorrelationId { get; init; } = string.Empty;
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitResponses.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitResponses.cs
@@ -1,0 +1,101 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Tamma.Api.Services.Git;
+
+/// <summary>
+/// Story 38-1 (AC4/AC6) — the single normalized, KEY-FREE result the git
+/// endpoints return. Only <see cref="CredentialSource"/> (the label
+/// <c>byok</c>/<c>platform</c>) is ever present; the resolved token NEVER appears
+/// here (nor in any log or DCB event). The mirroring engine-side wire type is
+/// <c>Tamma.Activities.LlmCall.Models.GitCallResponse</c>.
+/// </summary>
+public sealed record GitMediationResult
+{
+    public bool Success { get; init; }
+
+    /// <summary>"byok" | "platform" — the credential label, NEVER the token.</summary>
+    public string? CredentialSource { get; init; }
+
+    /// <summary>
+    /// Operation-specific Elsa outcome the thin activity routes on
+    /// (e.g. "Created" / "Updated" / "Merged" / "MergedWithWarnings" / "Done" /
+    /// "Error"). Lets the activity reproduce its exact edge without re-deriving it.
+    /// </summary>
+    public string? Outcome { get; init; }
+
+    // ── branch ──
+    public string? BranchRef { get; init; }
+    public string? BaseSha { get; init; }
+    public bool? ConflictResolved { get; init; }
+
+    // ── pull request ──
+    public int? PrNumber { get; init; }
+    public string? PrUrl { get; init; }
+    public bool? Reused { get; init; }
+    public bool? IsDraft { get; init; }
+
+    // ── merge ──
+    public bool? Merged { get; init; }
+    public string? MergeSha { get; init; }
+    public bool? IssueClosed { get; init; }
+    public bool? BranchDeleted { get; init; }
+    public bool? AlreadyMerged { get; init; }
+
+    // ── issue ──
+    public string? IssueStatus { get; init; }
+
+    // ── comments ──
+    public IReadOnlyList<PrCommentDto>? Comments { get; init; }
+
+    // ── failure-only (key-free) ──
+    public string? FailureCode { get; init; }   // REPO_NOT_AUTHORIZED | GIT_CONFLICT | NOT_MERGEABLE | NOT_FOUND | PLATFORM_ERROR | GIT_TOKEN_UNAVAILABLE
+    public string? FailureReason { get; init; }  // key-free
+    public int? PlatformStatusCode { get; init; }
+
+    public string? CorrelationId { get; init; }
+}
+
+/// <summary>A key-free PR review comment projection.</summary>
+public sealed record PrCommentDto
+{
+    public long Id { get; init; }
+    public string Body { get; init; } = string.Empty;
+    public string? Path { get; init; }
+    public int? Line { get; init; }
+    public string Author { get; init; } = string.Empty;
+    public DateTime CreatedAt { get; init; }
+}
+
+/// <summary>
+/// Story 38-1 (AC6) — the HTTP-status decision. Mirrors the Story 32-5 mapper's
+/// discipline but with the git story's explicit real-status semantics:
+/// <list type="bullet">
+///   <item>success ⇒ 200</item>
+///   <item>expected platform failure (200 <c>success:false</c> + preserved
+///     <c>platformStatusCode</c>) ⇒ 200 so the workflow branches on the outcome</item>
+///   <item><c>REPO_NOT_AUTHORIZED</c> ⇒ 403 (the cross-tenant guard, fail-closed)</item>
+///   <item><c>GIT_TOKEN_UNAVAILABLE</c> ⇒ 503 (credential unresolvable, fail-closed)</item>
+/// </list>
+/// A raw 5xx is NEVER produced.
+/// </summary>
+public static class GitMediationResultExtensions
+{
+    public static IResult ToHttpResult(this GitMediationResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        if (result.Success)
+        {
+            return Results.Ok(result);
+        }
+
+        return result.FailureCode switch
+        {
+            GitFailureCodes.RepoNotAuthorized => Results.Json(result, statusCode: StatusCodes.Status403Forbidden),
+            GitFailureCodes.TokenUnavailable => Results.Json(result, statusCode: StatusCodes.Status503ServiceUnavailable),
+            // Expected platform failures ride inside 200 success:false so the ADL
+            // workflow can branch on the outcome (preserved platformStatusCode).
+            _ => Results.Ok(result),
+        };
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitTokenResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitTokenResolver.cs
@@ -1,0 +1,93 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Tamma.Data.Repositories;
+using Tamma.Platforms.Abstractions;
+
+namespace Tamma.Api.Services.Git;
+
+/// <summary>
+/// Story 38-1 (AC3) — BYOK→platform git-token resolution, keyed per-tenant
+/// (Epic 28) through the Epic 29 secret cabinet, tenant→system→error.
+///
+/// <para><b>BYOK</b> — the tenant's git installation credential: the Story 31-2
+/// <c>tenant_platform_installations</c> row (platform kind <c>github</c>) carries
+/// a <c>SecretRef</c> (scope + name); the active plaintext is read through Epic
+/// 29's <see cref="IPlatformCredentialReader"/> (no bypass). A non-empty read ⇒
+/// <c>byok</c>.</para>
+///
+/// <para><b>Platform</b> — the platform-provided default token
+/// (<c>GitHub:Token</c>), used where BYOK is not (yet) wired for this tenant ⇒
+/// <c>platform</c>. This is the legitimate "system" tier of tenant→system→error,
+/// and the resolved token IS what the platform call uses.</para>
+///
+/// <para><b>Error</b> — neither resolvable ⇒ null ⇒ the mediation returns 503
+/// <c>GIT_TOKEN_UNAVAILABLE</c> (fail-closed). NEVER an empty/default token.</para>
+/// </summary>
+public sealed class GitTokenResolver : IGitTokenResolver
+{
+    private const string GitHubPlatformKind = "github";
+
+    private readonly ITenantPlatformInstallationRepository _installations;
+    private readonly IPlatformCredentialReader _credentialReader;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<GitTokenResolver> _logger;
+
+    public GitTokenResolver(
+        ITenantPlatformInstallationRepository installations,
+        IPlatformCredentialReader credentialReader,
+        IConfiguration configuration,
+        ILogger<GitTokenResolver> logger)
+    {
+        _installations = installations ?? throw new ArgumentNullException(nameof(installations));
+        _credentialReader = credentialReader ?? throw new ArgumentNullException(nameof(credentialReader));
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<GitTokenResolution?> ResolveAsync(Guid? tenantId, string repo, CancellationToken ct = default)
+    {
+        // ── tenant tier (BYOK) ──
+        if (tenantId is { } tid)
+        {
+            var byok = await TryResolveByokAsync(tid, ct).ConfigureAwait(false);
+            if (byok is not null)
+            {
+                return new GitTokenResolution(byok, GitCredentialSources.Byok);
+            }
+        }
+
+        // ── system tier (platform default) ──
+        var platformToken = _configuration["GitHub:Token"];
+        if (!string.IsNullOrWhiteSpace(platformToken))
+        {
+            return new GitTokenResolution(platformToken, GitCredentialSources.Platform);
+        }
+
+        // ── error tier (fail-closed) ──
+        _logger.LogWarning(
+            "git token unresolvable (BYOK absent + no platform GitHub:Token) for tenant {TenantId} — failing closed (GIT_TOKEN_UNAVAILABLE)",
+            tenantId);
+        return null;
+    }
+
+    private async Task<string?> TryResolveByokAsync(Guid tenantId, CancellationToken ct)
+    {
+        var installation = await _installations
+            .GetByTenantKindAsync(tenantId, GitHubPlatformKind, ct)
+            .ConfigureAwait(false);
+        if (installation is null || string.IsNullOrWhiteSpace(installation.CredentialSecretName))
+        {
+            return null;
+        }
+
+        var token = await _credentialReader
+            .ReadActivePlaintextAsync(
+                installation.CredentialSecretScope,
+                tenantId,
+                installation.CredentialSecretName,
+                ct)
+            .ConfigureAwait(false);
+
+        return string.IsNullOrWhiteSpace(token) ? null : token;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Git/IGitHubClientFactory.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Git/IGitHubClientFactory.cs
@@ -1,0 +1,46 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Tamma.Core.Interfaces;
+
+namespace Tamma.Api.Services.Git;
+
+/// <summary>
+/// Story 38-1 (AC3/AC4) — mints an <see cref="IGitHubIntegrationService"/> bound
+/// to a SPECIFIC resolved token so the platform call uses the token that was
+/// resolved (the invariant: "the token used == the token resolved"). The bound
+/// service overrides the named "github" client's static <c>GitHub:Token</c>
+/// bearer with the request-scoped token for that one call and drops it after.
+/// The token NEVER leaves the service instance — no logging, no return, no event.
+/// </summary>
+public interface IGitHubClientFactory
+{
+    IGitHubIntegrationService Create(string token);
+}
+
+/// <inheritdoc />
+public sealed class GitHubClientFactory : IGitHubClientFactory
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<GitHubIntegrationService> _logger;
+
+    public GitHubClientFactory(
+        IHttpClientFactory httpClientFactory,
+        IConfiguration configuration,
+        ILogger<GitHubIntegrationService> logger)
+    {
+        _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public IGitHubIntegrationService Create(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            throw new ArgumentException("A non-empty git token is required.", nameof(token));
+        }
+
+        return new Tamma.Api.Services.GitHubIntegrationService(_httpClientFactory, _configuration, _logger, token);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Git/IGitMediationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Git/IGitMediationService.cs
@@ -1,0 +1,18 @@
+namespace Tamma.Api.Services.Git;
+
+/// <summary>
+/// Story 38-1 — the managed git execution layer behind the
+/// <c>/api/v1/git/{repo}/...</c> endpoints. Composes the rule-1 sequence ENTIRELY
+/// inside <c>Tamma.Api</c> (the only place the git token lives): cross-tenant
+/// guard → per-tenant token resolution (BYOK→platform) → platform call with the
+/// RESOLVED token → exactly-one terminal DCB audit event. ALWAYS returns a typed,
+/// key-free <see cref="GitMediationResult"/> — a failure never throws a raw 5xx.
+/// </summary>
+public interface IGitMediationService
+{
+    Task<GitMediationResult> CreateBranchAsync(Guid? tenantId, string repo, CreateBranchRequest body, CancellationToken ct = default);
+    Task<GitMediationResult> CreatePullRequestAsync(Guid? tenantId, string repo, CreatePrRequest body, CancellationToken ct = default);
+    Task<GitMediationResult> MergePullRequestAsync(Guid? tenantId, string repo, int prNumber, MergePrRequest body, CancellationToken ct = default);
+    Task<GitMediationResult> UpdateIssueAsync(Guid? tenantId, string repo, int issueNumber, UpdateIssueRequest body, CancellationToken ct = default);
+    Task<GitMediationResult> GetPullRequestCommentsAsync(Guid? tenantId, string repo, int prNumber, string correlationId, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Git/IGitRepoAuthorizer.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Git/IGitRepoAuthorizer.cs
@@ -1,0 +1,22 @@
+namespace Tamma.Api.Services.Git;
+
+/// <summary>
+/// Story 38-1 (AC2) — the cross-tenant guard. THE load-bearing control
+/// (design §1.3: "a mis-scoped platform token = cross-tenant write/merge").
+/// Authorizes that the acting tenant (from <c>ITenantContext</c> / X-Tenant-Id,
+/// NEVER the request body) may act on <c>{repo}</c> BEFORE any token resolution
+/// or platform call. Fail-closed: no installation / a tenant mismatch ⇒ denied.
+/// </summary>
+public interface IGitRepoAuthorizer
+{
+    Task<GitRepoAuthorization> AuthorizeAsync(Guid? tenantId, string repo, CancellationToken ct = default);
+}
+
+/// <summary>The authorization decision. <see cref="Allowed"/> false ⇒ the caller
+/// returns 403 <c>REPO_NOT_AUTHORIZED</c> and NEVER resolves a token or calls the
+/// platform.</summary>
+public sealed record GitRepoAuthorization(bool Allowed, string? Reason)
+{
+    public static GitRepoAuthorization Allow() => new(true, null);
+    public static GitRepoAuthorization Deny(string reason) => new(false, reason);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Git/IGitTokenResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Git/IGitTokenResolver.cs
@@ -1,0 +1,22 @@
+namespace Tamma.Api.Services.Git;
+
+/// <summary>
+/// Story 38-1 (AC3) — resolves the per-tenant git token BYOK→platform,
+/// tenant→system→error (never empty/default, <c>feedback_resolution_no_empty_fallback</c>).
+/// The resolved token is request-scoped and used for exactly one platform call;
+/// it NEVER appears in a response, log line, or DCB event. Only the
+/// <see cref="GitTokenResolution.Source"/> LABEL is safe to surface.
+/// </summary>
+public interface IGitTokenResolver
+{
+    /// <summary>
+    /// Resolve the git token for the acting tenant + repo. Returns null when the
+    /// credential genuinely cannot be resolved (⇒ the caller returns 503
+    /// <c>GIT_TOKEN_UNAVAILABLE</c>, fail-closed — NEVER a call with an empty token).
+    /// </summary>
+    Task<GitTokenResolution?> ResolveAsync(Guid? tenantId, string repo, CancellationToken ct = default);
+}
+
+/// <summary>The resolved token + its source label. The token is load-bearing
+/// sensitive and must never be logged / returned / persisted.</summary>
+public sealed record GitTokenResolution(string Token, string Source);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/GitHubIntegrationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/GitHubIntegrationService.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Tamma.Core.Interfaces;
@@ -14,14 +15,57 @@ public class GitHubIntegrationService : IGitHubIntegrationService
     private readonly IConfiguration _configuration;
     private readonly IHttpClientFactory _httpClientFactory;
 
+    /// <summary>
+    /// Story 38-1 — when set, this request-scoped token overrides the named
+    /// "github" client's static <c>GitHub:Token</c> bearer for EVERY call made
+    /// through this instance, so the platform call uses the per-tenant token the
+    /// mediation layer resolved (the "token used == token resolved" invariant).
+    /// Minted per-request by <see cref="Git.GitHubClientFactory"/>; the token is
+    /// never logged, returned, or persisted. Null ⇒ legacy static-token behaviour.
+    /// </summary>
+    private readonly string? _tokenOverride;
+
     public GitHubIntegrationService(
         IHttpClientFactory httpClientFactory,
         IConfiguration configuration,
         ILogger<GitHubIntegrationService> logger)
+        : this(httpClientFactory, configuration, logger, tokenOverride: null)
+    {
+    }
+
+    /// <summary>
+    /// Story 38-1 — construct bound to a request-scoped <paramref name="tokenOverride"/>.
+    /// Used by <see cref="Git.GitHubClientFactory"/> so the git-mediation endpoints
+    /// perform the platform call with the resolved per-tenant token.
+    /// </summary>
+    public GitHubIntegrationService(
+        IHttpClientFactory httpClientFactory,
+        IConfiguration configuration,
+        ILogger<GitHubIntegrationService> logger,
+        string? tokenOverride)
     {
         _httpClientFactory = httpClientFactory;
         _configuration = configuration;
         _logger = logger;
+        _tokenOverride = tokenOverride;
+    }
+
+    /// <summary>
+    /// Create the named "github" <see cref="HttpClient"/>, applying the
+    /// request-scoped <see cref="_tokenOverride"/> when present. The factory
+    /// returns a fresh client instance per call, so mutating its default
+    /// Authorization header is scoped to this instance only.
+    /// </summary>
+    private HttpClient CreateGitHubClient()
+    {
+        var client = _httpClientFactory.CreateClient("github");
+        if (!string.IsNullOrWhiteSpace(_tokenOverride))
+        {
+            client.DefaultRequestHeaders.Remove("Authorization");
+            client.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", _tokenOverride);
+        }
+        return client;
     }
 
     public Task<IntegrationResult<GitHubBranchResult>> CreateGitHubBranchAsync(string repository, string branchName)
@@ -29,8 +73,10 @@ public class GitHubIntegrationService : IGitHubIntegrationService
 
     public async Task<IntegrationResult<GitHubBranchResult>> CreateGitHubBranchAsync(string repository, string branchName, string? baseBranch)
     {
-        var httpClient = _httpClientFactory.CreateClient("github");
-        var token = _configuration["GitHub:Token"];
+        var httpClient = CreateGitHubClient();
+        // A request-scoped override (BYOK, resolved by the mediation layer) IS the
+        // token; only require the static GitHub:Token when no override is bound.
+        var token = _tokenOverride ?? _configuration["GitHub:Token"];
         if (string.IsNullOrEmpty(token))
         {
             _logger.LogWarning("GitHub token not configured");
@@ -118,7 +164,7 @@ public class GitHubIntegrationService : IGitHubIntegrationService
 
     public async Task<IntegrationResult<bool>> BranchExistsAsync(string repository, string branchName)
     {
-        var httpClient = _httpClientFactory.CreateClient("github");
+        var httpClient = CreateGitHubClient();
 
         try
         {
@@ -147,7 +193,7 @@ public class GitHubIntegrationService : IGitHubIntegrationService
 
     public async Task<IntegrationResult<List<GitHubCommit>>> GetGitHubCommitsAsync(string repository, string branch, DateTime? since = null)
     {
-        var httpClient = _httpClientFactory.CreateClient("github");
+        var httpClient = CreateGitHubClient();
 
         try
         {
@@ -187,7 +233,7 @@ public class GitHubIntegrationService : IGitHubIntegrationService
 
     public async Task<IntegrationResult<GitHubPullRequestResult>> CreateGitHubPullRequestAsync(string repository, CreatePullRequestRequest request)
     {
-        var httpClient = _httpClientFactory.CreateClient("github");
+        var httpClient = CreateGitHubClient();
 
         try
         {
@@ -230,7 +276,7 @@ public class GitHubIntegrationService : IGitHubIntegrationService
 
     public async Task<IntegrationResult<GitHubPullRequestRef?>> GetGitHubOpenPullRequestForBranchAsync(string repository, string headBranch, string baseBranch)
     {
-        var httpClient = _httpClientFactory.CreateClient("github");
+        var httpClient = CreateGitHubClient();
 
         try
         {
@@ -267,7 +313,7 @@ public class GitHubIntegrationService : IGitHubIntegrationService
 
     public async Task<IntegrationResult<GitHubPullRequestResult>> UpdateGitHubPullRequestAsync(string repository, int pullRequestNumber, CreatePullRequestRequest request)
     {
-        var httpClient = _httpClientFactory.CreateClient("github");
+        var httpClient = CreateGitHubClient();
 
         try
         {
@@ -341,7 +387,7 @@ public class GitHubIntegrationService : IGitHubIntegrationService
 
     public async Task<IntegrationResult<GitHubMergeResult>> MergeGitHubPullRequestAsync(string repository, int pullRequestNumber, string mergeStrategy)
     {
-        var httpClient = _httpClientFactory.CreateClient("github");
+        var httpClient = CreateGitHubClient();
 
         try
         {
@@ -395,7 +441,7 @@ public class GitHubIntegrationService : IGitHubIntegrationService
 
     public async Task<IntegrationResult<GitHubPullRequestDetail>> GetGitHubPullRequestAsync(string repository, int pullRequestNumber)
     {
-        var httpClient = _httpClientFactory.CreateClient("github");
+        var httpClient = CreateGitHubClient();
 
         try
         {
@@ -441,7 +487,7 @@ public class GitHubIntegrationService : IGitHubIntegrationService
 
     public async Task<IntegrationResult<List<GitHubFileChange>>> GetGitHubFileChangesAsync(string repository, string branch)
     {
-        var httpClient = _httpClientFactory.CreateClient("github");
+        var httpClient = CreateGitHubClient();
 
         try
         {
@@ -481,7 +527,7 @@ public class GitHubIntegrationService : IGitHubIntegrationService
 
     public async Task<IntegrationResult<List<GitHubIssue>>> ListGitHubIssuesAsync(string repository, string[]? labels = null, string state = "open")
     {
-        var httpClient = _httpClientFactory.CreateClient("github");
+        var httpClient = CreateGitHubClient();
 
         try
         {
@@ -536,7 +582,7 @@ public class GitHubIntegrationService : IGitHubIntegrationService
 
     public async Task<IntegrationResult<bool>> AssignGitHubIssueAsync(string repository, int issueNumber, string assignee)
     {
-        var httpClient = _httpClientFactory.CreateClient("github");
+        var httpClient = CreateGitHubClient();
 
         try
         {
@@ -555,7 +601,7 @@ public class GitHubIntegrationService : IGitHubIntegrationService
 
     public async Task<IntegrationResult<bool>> CloseGitHubIssueAsync(string repository, int issueNumber, string? comment = null)
     {
-        var httpClient = _httpClientFactory.CreateClient("github");
+        var httpClient = CreateGitHubClient();
 
         try
         {
@@ -581,7 +627,7 @@ public class GitHubIntegrationService : IGitHubIntegrationService
 
     public async Task<IntegrationResult<bool>> DeleteGitHubBranchAsync(string repository, string branchName)
     {
-        var httpClient = _httpClientFactory.CreateClient("github");
+        var httpClient = CreateGitHubClient();
 
         try
         {
@@ -599,7 +645,7 @@ public class GitHubIntegrationService : IGitHubIntegrationService
 
     public async Task<IntegrationResult<List<GitHubReviewComment>>> GetPullRequestReviewCommentsAsync(string repository, int pullRequestNumber)
     {
-        var httpClient = _httpClientFactory.CreateClient("github");
+        var httpClient = CreateGitHubClient();
 
         try
         {
@@ -629,6 +675,87 @@ public class GitHubIntegrationService : IGitHubIntegrationService
         {
             _logger.LogError(ex, "Failed to get review comments for PR #{Number} in {Repo}", pullRequestNumber, repository);
             return IntegrationResult<List<GitHubReviewComment>>.Fail(ex.Message);
+        }
+    }
+
+    public async Task<IntegrationResult<bool>> PostIssueCommentAsync(string repository, int issueNumber, string body)
+    {
+        var httpClient = CreateGitHubClient();
+
+        try
+        {
+            var response = await httpClient.PostAsJsonAsync(
+                $"/repos/{repository}/issues/{issueNumber}/comments", new { body });
+            if (!response.IsSuccessStatusCode)
+            {
+                var respBody = await response.Content.ReadAsStringAsync();
+                _logger.LogError(
+                    "Failed to post comment on issue #{Number} in {Repo}: {Status} {Body}",
+                    issueNumber, repository, (int)response.StatusCode, respBody);
+                return IntegrationResult<bool>.Fail($"{(int)response.StatusCode}: {respBody}");
+            }
+            return IntegrationResult<bool>.Ok(true);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to post comment on issue #{Number} in {Repo}", issueNumber, repository);
+            return IntegrationResult<bool>.Fail(ex.Message);
+        }
+    }
+
+    public async Task<IntegrationResult<bool>> AddIssueLabelsAsync(string repository, int issueNumber, string[] labels)
+    {
+        if (labels is not { Length: > 0 })
+            return IntegrationResult<bool>.Ok(true);
+
+        var httpClient = CreateGitHubClient();
+
+        try
+        {
+            var response = await httpClient.PostAsJsonAsync(
+                $"/repos/{repository}/issues/{issueNumber}/labels", new { labels });
+            if (!response.IsSuccessStatusCode)
+            {
+                var respBody = await response.Content.ReadAsStringAsync();
+                _logger.LogError(
+                    "Failed to add labels to issue #{Number} in {Repo}: {Status} {Body}",
+                    issueNumber, repository, (int)response.StatusCode, respBody);
+                return IntegrationResult<bool>.Fail($"{(int)response.StatusCode}: {respBody}");
+            }
+            return IntegrationResult<bool>.Ok(true);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to add labels to issue #{Number} in {Repo}", issueNumber, repository);
+            return IntegrationResult<bool>.Fail(ex.Message);
+        }
+    }
+
+    public async Task<IntegrationResult<bool>> RemoveIssueLabelAsync(string repository, int issueNumber, string label)
+    {
+        var httpClient = CreateGitHubClient();
+
+        try
+        {
+            var response = await httpClient.DeleteAsync(
+                $"/repos/{repository}/issues/{issueNumber}/labels/{Uri.EscapeDataString(label)}");
+            // A 404 means the label was not present — idempotently treat as removed.
+            if (response.StatusCode == HttpStatusCode.NotFound)
+                return IntegrationResult<bool>.Ok(true);
+            if (!response.IsSuccessStatusCode)
+            {
+                var respBody = await response.Content.ReadAsStringAsync();
+                _logger.LogError(
+                    "Failed to remove label '{Label}' from issue #{Number} in {Repo}: {Status} {Body}",
+                    label, issueNumber, repository, (int)response.StatusCode, respBody);
+                return IntegrationResult<bool>.Fail($"{(int)response.StatusCode}: {respBody}");
+            }
+            return IntegrationResult<bool>.Ok(true);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to remove label '{Label}' from issue #{Number} in {Repo}", label, issueNumber, repository);
+            return IntegrationResult<bool>.Fail(ex.Message);
         }
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Core/Interfaces/IIntegrationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Interfaces/IIntegrationService.cs
@@ -116,6 +116,19 @@ public interface IGitHubIntegrationService
 
     /// <summary>Get pull request review comments</summary>
     Task<IntegrationResult<List<GitHubReviewComment>>> GetPullRequestReviewCommentsAsync(string repository, int pullRequestNumber);
+
+    /// <summary>
+    /// Story 38-1 — post a comment on an issue (the git-mediation issue-update
+    /// path). Backs <c>PATCH /api/v1/git/{repo}/issues/{n}</c>.
+    /// </summary>
+    Task<IntegrationResult<bool>> PostIssueCommentAsync(string repository, int issueNumber, string body);
+
+    /// <summary>Story 38-1 — add labels to an issue (git-mediation issue-update path).</summary>
+    Task<IntegrationResult<bool>> AddIssueLabelsAsync(string repository, int issueNumber, string[] labels);
+
+    /// <summary>Story 38-1 — remove a single label from an issue (idempotent: a 404
+    /// "label not present" is treated as removed).</summary>
+    Task<IntegrationResult<bool>> RemoveIssueLabelAsync(string repository, int issueNumber, string label);
 }
 
 /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/InstallationRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/InstallationRepository.cs
@@ -211,9 +211,16 @@ public class InstallationRepository(ControlPlaneDbContext db) : IInstallationRep
     {
         // Join via the active-only repo view so that a repo removed from the
         // installation no longer resolves back to the installation row.
+        //
+        // GitHub repo full names are case-INsensitive ("Acme/Widget" ==
+        // "acme/widget"); a case-sensitive match would 404 a legitimate tenant
+        // and hard-fail the ADL cycle. Lowercase both sides — works across EF
+        // providers (Postgres LOWER() + InMemory), unlike EF.Functions.ILike
+        // which is Postgres-only.
+        var needle = repoFullName?.ToLowerInvariant();
         var repo = await db.GitHubInstallationRepos
             .AsNoTracking()
-            .FirstOrDefaultAsync(r => r.IsActive && r.RepoFullName == repoFullName);
+            .FirstOrDefaultAsync(r => r.IsActive && r.RepoFullName.ToLower() == needle);
         if (repo is null) return null;
         return await db.GitHubInstallations
             .FirstOrDefaultAsync(i => i.Id == repo.InstallationEntityId);

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
@@ -202,31 +202,15 @@ builder.Services.AddCors(options =>
 // HttpClientFactory — used by activities that call external APIs (e.g. UpdateCodeIndexActivity, CallLlmInlineActivity)
 builder.Services.AddHttpClient();
 
-// GitHub integration service — required by the ADL PR / branch / review
-// activities (CreatePullRequestActivity, CreateBranchActivity, …) so the
-// pull-request workflow can actually open / reuse a PR inside the engine.
-//
-// The engine does NOT reference Tamma.Api (where the production
-// GitHubIntegrationService lives — see the Octokit / credential notes
-// below), so it can't register that concrete type here. The PR activities
-// are DI-tolerant: they resolve IGitHubIntegrationService via
-// context.GetService<T>() and, when absent, surface an explicit `Error`
-// outcome (no silent false success) rather than throwing. In the production
-// composition the GitHub work routes through the Tamma.Api process (consistent
-// with the agent-architecture pivot: engine steps delegate external API calls
-// to tamma-api). The named "github" HttpClient is still registered so any
-// in-process IGitHubIntegrationService picked up via DI gets a configured
-// client.
-builder.Services.AddHttpClient("github", client =>
-{
-    client.BaseAddress = new Uri(builder.Configuration["GitHub:ApiBaseUrl"] ?? "https://api.github.com");
-    var token = builder.Configuration["GitHub:Token"];
-    if (!string.IsNullOrWhiteSpace(token))
-        client.DefaultRequestHeaders.Authorization =
-            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
-    client.DefaultRequestHeaders.UserAgent.ParseAdd("Tamma-Engine");
-    client.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
-});
+// Story 38-1 (Epic 38) — the ADL git activities (CreateBranch /
+// CreatePullRequest / MergePullRequest / UpdateIssueStatus / AnalyzeReview) NO
+// LONGER resolve IGitHubIntegrationService or hold a GitHub token in the engine.
+// A workflow step never calls GitHub over the wire: each thin activity POSTs to
+// the internal /api/v1/git/{owner}/{repo}/... endpoints in Tamma.Api (via
+// TammaApiClient), where the per-tenant token lives, the tenant↔repo guard runs,
+// and the platform call + audit happen. So there is deliberately NO
+// IGitHubIntegrationService registration and NO "github" HttpClient / GitHub:Token
+// in the engine process (the highest-blast-radius rule-1 violation is closed).
 
 // Story 9-11: Tamma API client — used by simplified activities to delegate
 // agent config, health, diagnostics, and provider execution to the central

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/UpdateIssueStatusWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/UpdateIssueStatusWorkflow.cs
@@ -56,7 +56,6 @@ public class UpdateIssueStatusWorkflow : WorkflowBase
         var removeLabelsVar = builder.WithVariable<string[]>("RemoveLabels", Array.Empty<string>());
 
         var updatedVar = builder.WithVariable<bool>("Updated", false);
-        var degradedVar = builder.WithVariable<bool>("Degraded", false);
         var errorCodeVar = builder.WithVariable<string>("ErrorCode", "");
         var errorVar = builder.WithVariable<string>("Error", "");
         var startedAtTicksVar = builder.WithVariable<long>("StartedAtTicks", 0);
@@ -99,7 +98,6 @@ public class UpdateIssueStatusWorkflow : WorkflowBase
             PrNumber = new Input<int>(ctx => prNumberVar.Get(ctx)),
             PrUrl = new Input<string?>(ctx => prUrlVar.Get(ctx)),
             Updated = new Output<bool>(updatedVar),
-            Degraded = new Output<bool>(degradedVar),
             ErrorCode = new Output<string?>(errorCodeVar),
             Error = new Output<string?>(errorVar),
         };
@@ -117,7 +115,7 @@ public class UpdateIssueStatusWorkflow : WorkflowBase
             TenantId = new Input<string?>(ctx => tenantIdVar.Get(ctx)),
             DataJson = new Input<string?>(ctx => BuildSuccessData(
                 messageVar.Get(ctx), addLabelsVar.Get(ctx), removeLabelsVar.Get(ctx),
-                prNumberVar.Get(ctx), degradedVar.Get(ctx),
+                prNumberVar.Get(ctx),
                 ElapsedMs(startedAtTicksVar.Get(ctx)))),
         };
         emitSuccess.SetDisplayText("Emit ISSUE_STATUS.UPDATED.SUCCESS");
@@ -128,7 +126,6 @@ public class UpdateIssueStatusWorkflow : WorkflowBase
             Activities =
             {
                 WithLabel(new SetOutput { Id = "OutSuccess", OutputName = new("success"), OutputValue = new(_ => (object)true) }, "Output success"),
-                WithLabel(new SetOutput { Id = "OutDegraded", OutputName = new("degraded"), OutputValue = new(ctx => (object)degradedVar.Get(ctx)) }, "Output degraded"),
                 WithLabel(new SetOutput { Id = "OutIssueNumber", OutputName = new("issueNumber"), OutputValue = new(ctx => (object)issueNumberVar.Get(ctx)) }, "Output issueNumber"),
             }
         };
@@ -214,7 +211,7 @@ public class UpdateIssueStatusWorkflow : WorkflowBase
 
     private static string BuildSuccessData(
         string message, string[]? addLabels, string[]? removeLabels,
-        int prNumber, bool degraded, long durationMs)
+        int prNumber, long durationMs)
     {
         var data = new Dictionary<string, object?>
         {
@@ -222,7 +219,6 @@ public class UpdateIssueStatusWorkflow : WorkflowBase
             ["addLabels"] = addLabels ?? Array.Empty<string>(),
             ["removeLabels"] = removeLabels ?? Array.Empty<string>(),
             ["prNumber"] = prNumber,
-            ["degraded"] = degraded,
             ["durationMs"] = durationMs,
         };
         return JsonSerializer.Serialize(data);

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/AdlActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/AdlActivityTests.cs
@@ -49,9 +49,8 @@ public class AdlActivityTests
     public void CreateBranchActivity_WithDependencies_ShouldNotThrow()
     {
         var logger = new Mock<ILogger<CreateBranchActivity>>();
-        var github = new Mock<IGitHubIntegrationService>();
 
-        Action act = () => new CreateBranchActivity(logger.Object, github.Object);
+        Action act = () => new CreateBranchActivity(logger.Object, (Tamma.Activities.LlmCall.TammaApiClient?)null);
         act.Should().NotThrow();
     }
 
@@ -70,9 +69,8 @@ public class AdlActivityTests
     public void CreatePullRequestActivity_WithDependencies_ShouldNotThrow()
     {
         var logger = new Mock<ILogger<CreatePullRequestActivity>>();
-        var github = new Mock<IGitHubIntegrationService>();
 
-        Action act = () => new CreatePullRequestActivity(logger.Object, github.Object);
+        Action act = () => new CreatePullRequestActivity(logger.Object, (Tamma.Activities.LlmCall.TammaApiClient?)null);
         act.Should().NotThrow();
     }
 
@@ -91,9 +89,8 @@ public class AdlActivityTests
     public void AnalyzeReviewActivity_WithDependencies_ShouldNotThrow()
     {
         var logger = new Mock<ILogger<AnalyzeReviewActivity>>();
-        var github = new Mock<IGitHubIntegrationService>();
 
-        Action act = () => new AnalyzeReviewActivity(logger.Object, github.Object);
+        Action act = () => new AnalyzeReviewActivity(logger.Object, (Tamma.Activities.LlmCall.TammaApiClient?)null);
         act.Should().NotThrow();
     }
 
@@ -163,9 +160,8 @@ public class AdlActivityTests
     public void MergePullRequestActivity_WithDependencies_ShouldNotThrow()
     {
         var logger = new Mock<ILogger<MergePullRequestActivity>>();
-        var github = new Mock<IGitHubIntegrationService>();
 
-        Action act = () => new MergePullRequestActivity(logger.Object, github.Object);
+        Action act = () => new MergePullRequestActivity(logger.Object, (Tamma.Activities.LlmCall.TammaApiClient?)null);
         act.Should().NotThrow();
     }
 

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/BranchCreationActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/BranchCreationActivityTests.cs
@@ -37,8 +37,7 @@ public class BranchCreationActivityTests
     public void CreateBranchActivity_WithDependencies_ShouldNotThrow()
     {
         var logger = new Mock<ILogger<CreateBranchActivity>>();
-        var github = new Mock<IGitHubIntegrationService>();
-        Action act = () => new CreateBranchActivity(logger.Object, github.Object);
+        Action act = () => new CreateBranchActivity(logger.Object, (Tamma.Activities.LlmCall.TammaApiClient?)null);
         act.Should().NotThrow();
     }
 

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/GitActivityThinClientTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/GitActivityThinClientTests.cs
@@ -1,0 +1,243 @@
+using System.Reflection;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+using Tamma.Activities.LlmCall.Models;
+using Tamma.Core.Interfaces;
+
+namespace Tamma.Activities.Tests.ADL;
+
+/// <summary>
+/// Story 38-1 (AC5/AC9) — the five ADL git activities are now THIN
+/// <c>TammaApiClient</c> clients. These tests cover the wire-response →
+/// workflow-variable mapping (so the surrounding ADL workflows are unchanged),
+/// the fail-closed null-response path, and the cutover proof: ZERO
+/// <see cref="IGitHubIntegrationService"/> injections remain in
+/// <c>Tamma.Activities</c> (no constructor param, no field, no
+/// <c>GetService&lt;IGitHubIntegrationService&gt;</c>) — the engine can no longer
+/// resolve the credential-holding vendor service.
+/// </summary>
+[TestFixture]
+public class GitActivityThinClientTests
+{
+    // ===================================================================
+    // CreateBranch mapping (AC5)
+    // ===================================================================
+
+    [Test]
+    public void CreateBranch_Map_Created_ProjectsBranchOutputs()
+    {
+        var outcome = CreateBranchActivity.MapResponse(new GitCallResponse
+        {
+            Success = true, Outcome = "Created", BranchRef = "adl/7-thing", BaseSha = "sha1", ConflictResolved = true,
+        });
+
+        outcome.Outcome.Should().Be("Created");
+        outcome.BranchName.Should().Be("adl/7-thing");
+        outcome.BaseSha.Should().Be("sha1");
+        outcome.ConflictResolved.Should().BeTrue();
+    }
+
+    [Test]
+    public void CreateBranch_Map_Failure_ProjectsErrorCode()
+    {
+        var outcome = CreateBranchActivity.MapResponse(new GitCallResponse
+        {
+            Success = false, Outcome = "Error", FailureCode = "GIT_CONFLICT", FailureReason = "branch exists",
+        });
+
+        outcome.Outcome.Should().Be("Error");
+        outcome.ErrorCode.Should().Be("GIT_CONFLICT");
+        outcome.Error.Should().Be("branch exists");
+    }
+
+    [Test]
+    public void CreateBranch_Map_NullResponse_FailsClosed()
+    {
+        var outcome = CreateBranchActivity.MapResponse(null);
+        outcome.Outcome.Should().Be("Error");
+        outcome.ErrorCode.Should().Be("git-mediation-unavailable");
+    }
+
+    // ===================================================================
+    // CreatePullRequest mapping (AC5)
+    // ===================================================================
+
+    [Test]
+    public void CreatePr_Map_Created_And_Updated()
+    {
+        var created = CreatePullRequestActivity.MapResponse(new GitCallResponse
+        { Success = true, Outcome = "Created", PrNumber = 42, PrUrl = "u", IsDraft = false });
+        created.Outcome.Should().Be("Created");
+        created.PrNumber.Should().Be(42);
+        created.Reused.Should().BeFalse();
+
+        var updated = CreatePullRequestActivity.MapResponse(new GitCallResponse
+        { Success = true, Outcome = "Updated", PrNumber = 42, PrUrl = "u", IsDraft = true });
+        updated.Outcome.Should().Be("Updated");
+        updated.Reused.Should().BeTrue();
+        updated.IsDraft.Should().BeTrue();
+    }
+
+    [Test]
+    public void CreatePr_Map_NullResponse_FailsClosed()
+    {
+        var outcome = CreatePullRequestActivity.MapResponse(null);
+        outcome.Outcome.Should().Be("Error");
+        outcome.ErrorCode.Should().Be("git-mediation-unavailable");
+    }
+
+    // ===================================================================
+    // Merge mapping (AC5) — preserves the Merged / MergedWithWarnings / Error edge
+    // ===================================================================
+
+    [Test]
+    public void Merge_Map_Merged_Clean()
+    {
+        var outcome = MergePullRequestActivity.MapResponse(new GitCallResponse
+        {
+            Success = true, Outcome = "Merged", Merged = true, MergeSha = "sha", IssueClosed = true, BranchDeleted = true, AlreadyMerged = false,
+        });
+
+        outcome.Outcome.Should().Be("Merged");
+        outcome.MergeSha.Should().Be("sha");
+        outcome.IssueClosed.Should().BeTrue();
+        outcome.BranchDeleted.Should().BeTrue();
+        outcome.MergeSucceeded.Should().BeTrue();
+    }
+
+    [Test]
+    public void Merge_Map_MergedWithWarnings_CarriesWarnings()
+    {
+        var outcome = MergePullRequestActivity.MapResponse(new GitCallResponse
+        {
+            Success = true, Outcome = "MergedWithWarnings", Merged = true, MergeSha = "sha",
+            IssueClosed = false, BranchDeleted = true, FailureReason = "issue-close-failed: 500",
+        });
+
+        outcome.Outcome.Should().Be("MergedWithWarnings");
+        outcome.Partial.Should().BeTrue();
+        outcome.FailureReason.Should().Contain("issue-close-failed");
+    }
+
+    [Test]
+    public void Merge_Map_Error_ProjectsFailureCode()
+    {
+        var outcome = MergePullRequestActivity.MapResponse(new GitCallResponse
+        { Success = false, Outcome = "Error", FailureCode = "NOT_MERGEABLE", FailureReason = "closed" });
+
+        outcome.Outcome.Should().Be("Error");
+        outcome.FailureCode.Should().Be("NOT_MERGEABLE");
+        outcome.MergeSucceeded.Should().BeFalse();
+    }
+
+    [Test]
+    public void Merge_Map_NullResponse_FailsClosed()
+    {
+        var outcome = MergePullRequestActivity.MapResponse(null);
+        outcome.Outcome.Should().Be("Error");
+        outcome.MergeSucceeded.Should().BeFalse();
+    }
+
+    // ===================================================================
+    // UpdateIssue mapping (AC5)
+    // ===================================================================
+
+    [Test]
+    public void UpdateIssue_Map_Success_And_Failure_And_Null()
+    {
+        UpdateIssueStatusActivity.MapResponse(new GitCallResponse { Success = true }).Success.Should().BeTrue();
+
+        var fail = UpdateIssueStatusActivity.MapResponse(new GitCallResponse
+        { Success = false, FailureCode = "PLATFORM_ERROR", FailureReason = "403" });
+        fail.Success.Should().BeFalse();
+        fail.ErrorCode.Should().Be("PLATFORM_ERROR");
+
+        UpdateIssueStatusActivity.MapResponse(null).Success.Should().BeFalse();
+    }
+
+    // ===================================================================
+    // Cutover proof (AC9) — zero IGitHubIntegrationService injections
+    // ===================================================================
+
+    private static readonly Type[] GitActivityTypes =
+    {
+        typeof(CreateBranchActivity),
+        typeof(CreatePullRequestActivity),
+        typeof(MergePullRequestActivity),
+        typeof(UpdateIssueStatusActivity),
+        typeof(AnalyzeReviewActivity),
+    };
+
+    [Test]
+    public void NoGitActivity_HasIGitHubIntegrationServiceConstructorParameter()
+    {
+        foreach (var type in GitActivityTypes)
+        {
+            foreach (var ctor in type.GetConstructors())
+            {
+                ctor.GetParameters()
+                    .Any(p => typeof(IGitHubIntegrationService).IsAssignableFrom(p.ParameterType))
+                    .Should().BeFalse($"{type.Name} must not inject IGitHubIntegrationService via its constructor");
+            }
+        }
+    }
+
+    [Test]
+    public void NoGitActivity_HasIGitHubIntegrationServiceField()
+    {
+        foreach (var type in GitActivityTypes)
+        {
+            type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+                .Any(f => typeof(IGitHubIntegrationService).IsAssignableFrom(f.FieldType))
+                .Should().BeFalse($"{type.Name} must hold no IGitHubIntegrationService field");
+        }
+    }
+
+    [Test]
+    public void NoActivitySource_ResolvesIGitHubIntegrationServiceFromDi()
+    {
+        // Belt-and-suspenders over the reflection checks: a source scan catches the
+        // context.GetService<IGitHubIntegrationService>() service-locator pattern (a
+        // method call, invisible to reflection). Zero occurrences across the WHOLE
+        // Tamma.Activities tree — no activity may resolve the credential-holding
+        // vendor service from DI after the pivot.
+        var activitiesDir = FindActivitiesRoot();
+        activitiesDir.Should().NotBeNull("the Tamma.Activities source root should be locatable from the test run");
+
+        var serviceLocatorOffenders = Directory.EnumerateFiles(activitiesDir!, "*.cs", SearchOption.AllDirectories)
+            .Where(f =>
+            {
+                var text = File.ReadAllText(f);
+                return text.Contains("GetService<IGitHubIntegrationService>")
+                    || text.Contains("GetRequiredService<IGitHubIntegrationService>");
+            })
+            .Select(Path.GetFileName)
+            .ToList();
+        serviceLocatorOffenders.Should().BeEmpty("no activity may resolve IGitHubIntegrationService from DI after the 38-1 cutover");
+
+        // The five cutover activities additionally hold no `_github` field.
+        var adlDir = Path.Combine(activitiesDir!, "ADL");
+        foreach (var name in new[]
+        {
+            "CreateBranchActivity.cs", "CreatePullRequestActivity.cs", "MergePullRequestActivity.cs",
+            "UpdateIssueStatusActivity.cs", "AnalyzeReviewActivity.cs",
+        })
+        {
+            var text = File.ReadAllText(Path.Combine(adlDir, name));
+            text.Should().NotContain("_github", $"{name} must hold no IGitHubIntegrationService field after the cutover");
+        }
+    }
+
+    private static string? FindActivitiesRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "src", "Tamma.Activities");
+            if (Directory.Exists(candidate)) return candidate;
+            dir = dir.Parent;
+        }
+        return null;
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/PullRequestActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/PullRequestActivityTests.cs
@@ -36,8 +36,7 @@ public class PullRequestActivityTests
     public void CreatePullRequestActivity_WithDependencies_ShouldNotThrow()
     {
         var logger = new Mock<ILogger<CreatePullRequestActivity>>();
-        var github = new Mock<IGitHubIntegrationService>();
-        Action act = () => new CreatePullRequestActivity(logger.Object, github.Object);
+        Action act = () => new CreatePullRequestActivity(logger.Object, (Tamma.Activities.LlmCall.TammaApiClient?)null);
         act.Should().NotThrow();
     }
 

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/UpdateIssueStatusWorkflowTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/UpdateIssueStatusWorkflowTests.cs
@@ -186,7 +186,7 @@ public class UpdateIssueStatusWorkflowTests
             .ToList();
 
         ids.Should().Contain("OutSuccess");   // success = true
-        ids.Should().Contain("OutDegraded");  // degraded flag (auditable local no-op)
+        ids.Should().Contain("OutIssueNumber");
     }
 
     // ================================================================

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Git/GitEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Git/GitEndpointsTests.cs
@@ -1,0 +1,326 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using Tamma.Api.Auth;
+using Tamma.Api.Services.Git;
+using Tamma.Api.Tests.Infrastructure;
+using Tamma.Data;
+
+namespace Tamma.Api.Tests.Git;
+
+/// <summary>
+/// Story 38-1 (AC1/AC6) — HTTP tests for the git-mediation endpoints via
+/// <see cref="WebApplicationFactory{TEntryPoint}"/>. Same engine-only plane as
+/// <c>/api/v1/llm/call</c>: a missing/invalid bearer ⇒ 401, a non-engine (user)
+/// principal ⇒ 403 — both BEFORE the handler. The composition
+/// (<see cref="IGitMediationService"/>) is a capturing fake so these tests
+/// exercise ONLY the endpoint: auth, the auth-derived tenant scope (the body /
+/// route never override it), {owner}/{repo} reconstruction, and the
+/// <c>ToHttpResult</c> status mapping (200 / 200 success:false / 403 / 503).
+/// </summary>
+[TestFixture]
+public class GitEndpointsTests
+{
+    private const string TestBearer = "engine-callback-token";
+    private const string UserBearer = "tenant-user-token";
+    private const string BranchesRoute = "/api/v1/git/acme/widgets/branches";
+
+    private WebApplicationFactory<Program> _factory = null!;
+    private CapturingGitMediationService _git = null!;
+    private StubTenantContext _tenantContext = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _git = new CapturingGitMediationService();
+        _tenantContext = new StubTenantContext();
+
+        _factory = ApiTestFixture.Factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Development");
+            builder.DisableAlertHostedServices();
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<IGitMediationService>();
+                services.AddSingleton<IGitMediationService>(_git);
+
+                services.RemoveAll<ITenantContext>();
+                services.AddScoped<ITenantContext>(_ => _tenantContext);
+
+                services.AddAuthentication(TestEngineAuthHandler.SchemeName)
+                    .AddScheme<AuthenticationSchemeOptions, TestEngineAuthHandler>(
+                        TestEngineAuthHandler.SchemeName, _ => { });
+
+                services.AddHttpContextAccessor();
+                services.AddSingleton<IAuthorizationHandler, ServicePrincipalHandler>();
+
+                services.AddAuthorization(options =>
+                {
+                    options.DefaultPolicy = new AuthorizationPolicyBuilder()
+                        .AddAuthenticationSchemes(TestEngineAuthHandler.SchemeName)
+                        .RequireAuthenticatedUser()
+                        .Build();
+                    options.AddPolicy("EngineServiceOnly", p =>
+                    {
+                        p.AddAuthenticationSchemes(TestEngineAuthHandler.SchemeName);
+                        p.RequireAuthenticatedUser();
+                        p.AddRequirements(new ServicePrincipalRequirement());
+                    });
+                });
+            });
+        });
+    }
+
+    [TearDown]
+    public void TearDown() => _factory?.Dispose();
+
+    private HttpClient AuthedClient()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", TestBearer);
+        return client;
+    }
+
+    private static object BranchBody() => new
+    {
+        branchName = "adl/7-thing",
+        baseRef = "main",
+        conflictStrategy = "suffix",
+        issueNumber = 7,
+        correlationId = "wf-1",
+    };
+
+    // -----------------------------------------------------------------------
+    // AC1 — auth
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task Post_NoBearer_Returns401_HandlerNotReached()
+    {
+        using var client = _factory.CreateClient();
+        var resp = await client.PostAsJsonAsync(BranchesRoute, BranchBody());
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        _git.LastRepo.Should().BeNull("the handler must not run when the bearer is missing");
+    }
+
+    [Test]
+    public async Task Post_InvalidBearer_Returns401_HandlerNotReached()
+    {
+        using var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "nope");
+        var resp = await client.PostAsJsonAsync(BranchesRoute, BranchBody());
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        _git.LastRepo.Should().BeNull();
+    }
+
+    [Test]
+    public async Task Post_NonEnginePrincipal_Returns403_HandlerNotReached()
+    {
+        using var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", UserBearer);
+        var resp = await client.PostAsJsonAsync(BranchesRoute, BranchBody());
+        resp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        _git.LastRepo.Should().BeNull();
+    }
+
+    [Test]
+    public async Task Post_ValidBearer_ReconstructsRepo_And_DerivesTenantFromContext()
+    {
+        var tenant = Guid.NewGuid();
+        _tenantContext.SetTenantId(tenant);
+        _git.NextBranch = new GitMediationResult { Success = true, Outcome = "Created", BranchRef = "adl/7-thing", CredentialSource = "byok" };
+
+        using var client = AuthedClient();
+        client.DefaultRequestHeaders.Add("X-Tenant-Id", tenant.ToString());
+
+        var resp = await client.PostAsJsonAsync(BranchesRoute, BranchBody());
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        _git.LastRepo.Should().Be("acme/widgets", "{owner}/{repo} is reconstructed from the two route segments");
+        _git.LastTenantId.Should().Be(tenant, "the acting tenant comes from ITenantContext (X-Tenant-Id), not the body");
+    }
+
+    // -----------------------------------------------------------------------
+    // AC6 — status mapping
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task Post_Success_Returns200()
+    {
+        _git.NextBranch = new GitMediationResult { Success = true, Outcome = "Created", BranchRef = "adl/7-thing", CredentialSource = "platform" };
+        using var client = AuthedClient();
+        var resp = await client.PostAsJsonAsync(BranchesRoute, BranchBody());
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("success").GetBoolean().Should().BeTrue();
+        body.GetProperty("branchRef").GetString().Should().Be("adl/7-thing");
+        body.GetProperty("credentialSource").GetString().Should().Be("platform");
+    }
+
+    [Test]
+    public async Task Post_ExpectedPlatformFailure_Returns200SuccessFalse_WithPreservedStatus()
+    {
+        _git.NextBranch = new GitMediationResult
+        {
+            Success = false, Outcome = "Error",
+            FailureCode = GitFailureCodes.GitConflict, FailureReason = "branch exists", PlatformStatusCode = 422,
+            CredentialSource = "byok",
+        };
+        using var client = AuthedClient();
+        var resp = await client.PostAsJsonAsync(BranchesRoute, BranchBody());
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK, "an expected platform failure rides inside 200 success:false");
+        ((int)resp.StatusCode).Should().BeLessThan(500, "a raw 5xx must NEVER leak");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("success").GetBoolean().Should().BeFalse();
+        body.GetProperty("failureCode").GetString().Should().Be(GitFailureCodes.GitConflict);
+        body.GetProperty("platformStatusCode").GetInt32().Should().Be(422);
+    }
+
+    [Test]
+    public async Task Post_RepoNotAuthorized_Returns403()
+    {
+        _git.NextBranch = new GitMediationResult { Success = false, Outcome = "Error", FailureCode = GitFailureCodes.RepoNotAuthorized };
+        using var client = AuthedClient();
+        var resp = await client.PostAsJsonAsync(BranchesRoute, BranchBody());
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("failureCode").GetString().Should().Be(GitFailureCodes.RepoNotAuthorized);
+    }
+
+    [Test]
+    public async Task Post_TokenUnavailable_Returns503()
+    {
+        _git.NextBranch = new GitMediationResult { Success = false, Outcome = "Error", FailureCode = GitFailureCodes.TokenUnavailable };
+        using var client = AuthedClient();
+        var resp = await client.PostAsJsonAsync(BranchesRoute, BranchBody());
+
+        resp.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+    }
+
+    [Test]
+    public async Task Get_Comments_Success_Returns200()
+    {
+        _git.NextComments = new GitMediationResult
+        {
+            Success = true, Outcome = "Done",
+            Comments = new List<PrCommentDto> { new() { Id = 1, Body = "nit", Author = "a" } },
+        };
+        using var client = AuthedClient();
+        var resp = await client.GetAsync("/api/v1/git/acme/widgets/pull-requests/9/comments?correlationId=wf-2");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        _git.LastRepo.Should().Be("acme/widgets");
+    }
+
+    // -----------------------------------------------------------------------
+    // Test doubles
+    // -----------------------------------------------------------------------
+
+    private sealed class CapturingGitMediationService : IGitMediationService
+    {
+        public Guid? LastTenantId { get; private set; }
+        public string? LastRepo { get; private set; }
+        public GitMediationResult? NextBranch { get; set; }
+        public GitMediationResult? NextComments { get; set; }
+
+        public Task<GitMediationResult> CreateBranchAsync(Guid? tenantId, string repo, CreateBranchRequest body, CancellationToken ct = default)
+        {
+            LastTenantId = tenantId; LastRepo = repo;
+            return Task.FromResult(NextBranch ?? new GitMediationResult { Success = true, Outcome = "Created", BranchRef = body.BranchName });
+        }
+
+        public Task<GitMediationResult> CreatePullRequestAsync(Guid? tenantId, string repo, CreatePrRequest body, CancellationToken ct = default)
+        {
+            LastTenantId = tenantId; LastRepo = repo;
+            return Task.FromResult(new GitMediationResult { Success = true, Outcome = "Created", PrNumber = 1 });
+        }
+
+        public Task<GitMediationResult> MergePullRequestAsync(Guid? tenantId, string repo, int prNumber, MergePrRequest body, CancellationToken ct = default)
+        {
+            LastTenantId = tenantId; LastRepo = repo;
+            return Task.FromResult(new GitMediationResult { Success = true, Outcome = "Merged", Merged = true });
+        }
+
+        public Task<GitMediationResult> UpdateIssueAsync(Guid? tenantId, string repo, int issueNumber, UpdateIssueRequest body, CancellationToken ct = default)
+        {
+            LastTenantId = tenantId; LastRepo = repo;
+            return Task.FromResult(new GitMediationResult { Success = true, Outcome = "Updated", IssueStatus = "updated" });
+        }
+
+        public Task<GitMediationResult> GetPullRequestCommentsAsync(Guid? tenantId, string repo, int prNumber, string correlationId, CancellationToken ct = default)
+        {
+            LastTenantId = tenantId; LastRepo = repo;
+            return Task.FromResult(NextComments ?? new GitMediationResult { Success = true, Outcome = "Done", Comments = new List<PrCommentDto>() });
+        }
+    }
+
+    private sealed class StubTenantContext : ITenantContext
+    {
+        private Guid? _tenantId;
+        public Guid? TenantId => _tenantId;
+        public void SetTenantId(Guid tenantId) => _tenantId = tenantId;
+        public void ClearTenantId() => _tenantId = null;
+    }
+
+    private sealed class TestEngineAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    {
+        public const string SchemeName = "TestEngine";
+
+        public TestEngineAuthHandler(
+            IOptionsMonitor<AuthenticationSchemeOptions> options,
+            Microsoft.Extensions.Logging.ILoggerFactory logger,
+            UrlEncoder encoder)
+            : base(options, logger, encoder) { }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (!Request.Headers.TryGetValue("Authorization", out var header))
+                return Task.FromResult(AuthenticateResult.NoResult());
+
+            var value = header.ToString();
+            if (!value.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+                return Task.FromResult(AuthenticateResult.NoResult());
+
+            var token = value["Bearer ".Length..].Trim();
+
+            if (string.Equals(token, TestBearer, StringComparison.Ordinal))
+            {
+                Context.SetAuthPrincipal(new ServiceAuthPrincipal(
+                    KeyId: Guid.NewGuid(), ServiceName: "tamma-engine",
+                    Permissions: Array.Empty<string>(), TenantId: null));
+                var identity = new ClaimsIdentity(
+                    new[] { new Claim(ClaimTypes.NameIdentifier, "tamma-engine"), new Claim("scope", "service") },
+                    SchemeName);
+                return Task.FromResult(AuthenticateResult.Success(
+                    new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName)));
+            }
+
+            if (string.Equals(token, UserBearer, StringComparison.Ordinal))
+            {
+                var identity = new ClaimsIdentity(
+                    new[] { new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()), new Claim("role", "owner") },
+                    SchemeName);
+                return Task.FromResult(AuthenticateResult.Success(
+                    new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName)));
+            }
+
+            return Task.FromResult(AuthenticateResult.Fail("Invalid token"));
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Git/GitMediationServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Git/GitMediationServiceTests.cs
@@ -1,0 +1,473 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.Git;
+using Tamma.Core.Interfaces;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Git;
+
+/// <summary>
+/// Story 38-1 — <see cref="GitMediationService"/> composition (guard → token →
+/// platform-with-resolved-token → one DCB event). Every collaborator is faked;
+/// assertions cover the fail-closed order (guard FIRST — deny ⇒ no token
+/// resolved, platform never invoked), BYOK vs platform <c>credentialSource</c>,
+/// the typed key-free failure taxonomy with a preserved <c>platformStatusCode</c>,
+/// the 503 token-unavailable path, the exactly-one-terminal-event invariant + its
+/// tags, and credential safety (the resolved token appears in no result / event).
+/// </summary>
+[TestFixture]
+public class GitMediationServiceTests
+{
+    private const string SecretToken = "ghp-SUPER-SECRET-DO-NOT-LEAK-1234567890";
+    private const string Repo = "acme/widgets";
+
+    private Mock<IGitRepoAuthorizer> _authorizer = null!;
+    private Mock<IGitTokenResolver> _tokenResolver = null!;
+    private Mock<IGitHubClientFactory> _factory = null!;
+    private Mock<IGitHubIntegrationService> _github = null!;
+    private RecordingEventRepository _events = null!;
+    private GitMediationService _sut = null!;
+    private readonly Guid _tenant = Guid.NewGuid();
+
+    [SetUp]
+    public void SetUp()
+    {
+        _authorizer = new Mock<IGitRepoAuthorizer>(MockBehavior.Strict);
+        _tokenResolver = new Mock<IGitTokenResolver>(MockBehavior.Strict);
+        _factory = new Mock<IGitHubClientFactory>(MockBehavior.Strict);
+        _github = new Mock<IGitHubIntegrationService>(MockBehavior.Loose);
+        _events = new RecordingEventRepository();
+
+        _factory.Setup(f => f.Create(It.IsAny<string>())).Returns(_github.Object);
+
+        _sut = new GitMediationService(
+            _authorizer.Object, _tokenResolver.Object, _factory.Object, _events,
+            NullLogger<GitMediationService>.Instance);
+    }
+
+    private void Allow() => _authorizer
+        .Setup(a => a.AuthorizeAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(GitRepoAuthorization.Allow());
+
+    private void Deny() => _authorizer
+        .Setup(a => a.AuthorizeAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(GitRepoAuthorization.Deny("not authorized"));
+
+    private void ResolveToken(string source) => _tokenResolver
+        .Setup(t => t.ResolveAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new GitTokenResolution(SecretToken, source));
+
+    private void NoToken() => _tokenResolver
+        .Setup(t => t.ResolveAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync((GitTokenResolution?)null);
+
+    private static CreatePrRequest PrBody() => new()
+    {
+        Title = "[ADL] #7: thing", Body = "body", HeadRef = "feature", BaseRef = "main", CorrelationId = "corr-pr",
+    };
+
+    private static MergePrRequest MergeBody() => new()
+    {
+        MergeStrategy = "squash", IssueNumber = 7, BranchName = "feature", CorrelationId = "corr-merge",
+    };
+
+    // ===================================================================
+    // Cross-tenant guard (AC2) — FIRST, fail-closed
+    // ===================================================================
+
+    [Test]
+    public async Task CreatePr_GuardDenied_403_NoTokenResolved_PlatformNeverCalled()
+    {
+        Deny();
+
+        var result = await _sut.CreatePullRequestAsync(_tenant, Repo, PrBody());
+
+        result.Success.Should().BeFalse();
+        result.FailureCode.Should().Be(GitFailureCodes.RepoNotAuthorized);
+        result.CredentialSource.Should().BeNull("no token is resolved on a guard denial");
+
+        _tokenResolver.Verify(
+            t => t.ResolveAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never, "the guard runs BEFORE token resolution");
+        _factory.Verify(f => f.Create(It.IsAny<string>()), Times.Never,
+            "no token-bound client is minted → the platform is never called");
+        _github.VerifyNoOtherCalls();
+
+        _events.Appended.Should().HaveCount(1);
+        var evt = _events.Appended.Single();
+        evt.Type.Should().Be(GitEventTypes.PrOpenedFailed);
+        evt.Tags.Should().Contain(GitFailureCodes.RepoNotAuthorized);
+    }
+
+    [Test]
+    public void GuardDenied_ToHttpResult_Is403()
+    {
+        var denied = new GitMediationResult { Success = false, FailureCode = GitFailureCodes.RepoNotAuthorized };
+        var http = denied.ToHttpResult();
+        StatusOf(http).Should().Be(403);
+    }
+
+    // ===================================================================
+    // Token resolution (AC3) — BYOK / platform / fail-closed
+    // ===================================================================
+
+    [Test]
+    public async Task CreatePr_Success_Byok_UsesResolvedToken_EmitsOneSuccessEvent()
+    {
+        Allow();
+        ResolveToken(GitCredentialSources.Byok);
+        _github.Setup(g => g.GetGitHubOpenPullRequestForBranchAsync(Repo, "feature", "main"))
+            .ReturnsAsync(IntegrationResult<GitHubPullRequestRef?>.Ok(null));
+        _github.Setup(g => g.CreateGitHubPullRequestAsync(Repo, It.IsAny<CreatePullRequestRequest>()))
+            .ReturnsAsync(IntegrationResult<GitHubPullRequestResult>.Ok(
+                new GitHubPullRequestResult { Success = true, Number = 42, Url = "https://gh/pr/42" }));
+
+        var result = await _sut.CreatePullRequestAsync(_tenant, Repo, PrBody());
+
+        result.Success.Should().BeTrue();
+        result.Outcome.Should().Be("Created");
+        result.PrNumber.Should().Be(42);
+        result.PrUrl.Should().Be("https://gh/pr/42");
+        result.CredentialSource.Should().Be(GitCredentialSources.Byok);
+
+        // The invariant: the token USED (minted into the client) == the token RESOLVED.
+        _factory.Verify(f => f.Create(SecretToken), Times.Once);
+
+        _events.Appended.Should().HaveCount(1);
+        var evt = _events.Appended.Single();
+        evt.Type.Should().Be(GitEventTypes.PrOpenedSuccess);
+        evt.TenantId.Should().Be(_tenant);
+        AssertTags(evt, operation: GitEventTypes.PrOpenOperation, credentialSource: GitCredentialSources.Byok, correlationId: "corr-pr");
+    }
+
+    [Test]
+    public async Task CreatePr_Success_Platform_StampsPlatformCredentialSource()
+    {
+        Allow();
+        ResolveToken(GitCredentialSources.Platform);
+        _github.Setup(g => g.GetGitHubOpenPullRequestForBranchAsync(Repo, "feature", "main"))
+            .ReturnsAsync(IntegrationResult<GitHubPullRequestRef?>.Ok(null));
+        _github.Setup(g => g.CreateGitHubPullRequestAsync(Repo, It.IsAny<CreatePullRequestRequest>()))
+            .ReturnsAsync(IntegrationResult<GitHubPullRequestResult>.Ok(
+                new GitHubPullRequestResult { Success = true, Number = 9, Url = "u" }));
+
+        var result = await _sut.CreatePullRequestAsync(_tenant, Repo, PrBody());
+
+        result.CredentialSource.Should().Be(GitCredentialSources.Platform);
+        _factory.Verify(f => f.Create(SecretToken), Times.Once);
+    }
+
+    [Test]
+    public async Task CreatePr_TokenUnavailable_503_FailClosed_PlatformNeverCalled()
+    {
+        Allow();
+        NoToken();
+
+        var result = await _sut.CreatePullRequestAsync(_tenant, Repo, PrBody());
+
+        result.Success.Should().BeFalse();
+        result.FailureCode.Should().Be(GitFailureCodes.TokenUnavailable);
+        _factory.Verify(f => f.Create(It.IsAny<string>()), Times.Never);
+
+        result.ToHttpResult().Let(StatusOf).Should().Be(503);
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(GitEventTypes.PrOpenedFailed);
+    }
+
+    // ===================================================================
+    // Typed platform failures (AC6) — key-free + preserved platformStatusCode
+    // ===================================================================
+
+    [Test]
+    public async Task CreatePr_PlatformConflict_200SuccessFalse_GitConflict()
+    {
+        Allow();
+        ResolveToken(GitCredentialSources.Platform);
+        _github.Setup(g => g.GetGitHubOpenPullRequestForBranchAsync(Repo, "feature", "main"))
+            .ReturnsAsync(IntegrationResult<GitHubPullRequestRef?>.Ok(null));
+        _github.Setup(g => g.CreateGitHubPullRequestAsync(Repo, It.IsAny<CreatePullRequestRequest>()))
+            .ReturnsAsync(IntegrationResult<GitHubPullRequestResult>.Fail("409: a merge conflict"));
+
+        var result = await _sut.CreatePullRequestAsync(_tenant, Repo, PrBody());
+
+        result.Success.Should().BeFalse();
+        result.FailureCode.Should().Be(GitFailureCodes.GitConflict);
+        result.ToHttpResult().Let(StatusOf).Should().Be(200, "expected platform failures ride inside 200 success:false");
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(GitEventTypes.PrOpenedFailed);
+    }
+
+    [Test]
+    public async Task Merge_ClosedUnmerged_NotMergeable()
+    {
+        Allow();
+        ResolveToken(GitCredentialSources.Byok);
+        _github.Setup(g => g.GetGitHubPullRequestAsync(Repo, 15))
+            .ReturnsAsync(IntegrationResult<GitHubPullRequestDetail>.Ok(
+                new GitHubPullRequestDetail { Number = 15, State = "closed", Merged = false }));
+
+        var result = await _sut.MergePullRequestAsync(_tenant, Repo, 15, MergeBody());
+
+        result.Success.Should().BeFalse();
+        result.Merged.Should().Be(false);
+        result.FailureCode.Should().Be(GitFailureCodes.NotMergeable);
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(GitEventTypes.PrMergeFailed);
+    }
+
+    [Test]
+    public async Task Merge_ConflictOnMerge_GitConflict_PreservesPlatformStatusCode()
+    {
+        Allow();
+        ResolveToken(GitCredentialSources.Byok);
+        _github.Setup(g => g.GetGitHubPullRequestAsync(Repo, 15))
+            .ReturnsAsync(IntegrationResult<GitHubPullRequestDetail>.Ok(
+                new GitHubPullRequestDetail { Number = 15, State = "open", Merged = false, Mergeable = null }));
+        _github.Setup(g => g.MergeGitHubPullRequestAsync(Repo, 15, "squash"))
+            .ReturnsAsync(IntegrationResult<GitHubMergeResult>.Fail("409: merge conflict"));
+
+        var result = await _sut.MergePullRequestAsync(_tenant, Repo, 15, MergeBody());
+
+        result.Success.Should().BeFalse();
+        result.FailureCode.Should().Be(GitFailureCodes.GitConflict);
+        result.PlatformStatusCode.Should().Be(409, "the upstream status is preserved for the workflow to branch on");
+    }
+
+    // ===================================================================
+    // Merge happy path + verified post-merge cleanup
+    // ===================================================================
+
+    [Test]
+    public async Task Merge_Success_MergedWithIssueClosedAndBranchDeleted()
+    {
+        Allow();
+        ResolveToken(GitCredentialSources.Byok);
+        _github.Setup(g => g.GetGitHubPullRequestAsync(Repo, 15))
+            .ReturnsAsync(IntegrationResult<GitHubPullRequestDetail>.Ok(
+                new GitHubPullRequestDetail { Number = 15, State = "open", Merged = false, Mergeable = true }));
+        _github.Setup(g => g.MergeGitHubPullRequestAsync(Repo, 15, "squash"))
+            .ReturnsAsync(IntegrationResult<GitHubMergeResult>.Ok(new GitHubMergeResult { Success = true, MergeSha = "sha-123" }));
+        _github.Setup(g => g.CloseGitHubIssueAsync(Repo, 7, It.IsAny<string>()))
+            .ReturnsAsync(IntegrationResult<bool>.Ok(true));
+        _github.Setup(g => g.DeleteGitHubBranchAsync(Repo, "feature"))
+            .ReturnsAsync(IntegrationResult<bool>.Ok(true));
+
+        var result = await _sut.MergePullRequestAsync(_tenant, Repo, 15, MergeBody());
+
+        result.Success.Should().BeTrue();
+        result.Merged.Should().Be(true);
+        result.MergeSha.Should().Be("sha-123");
+        result.IssueClosed.Should().Be(true);
+        result.BranchDeleted.Should().Be(true);
+        result.Outcome.Should().Be("Merged");
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(GitEventTypes.PrMergedSuccess);
+    }
+
+    // ===================================================================
+    // Comments read + issue update
+    // ===================================================================
+
+    [Test]
+    public async Task GetComments_Success_ReturnsMappedComments_OneEvent()
+    {
+        Allow();
+        ResolveToken(GitCredentialSources.Platform);
+        _github.Setup(g => g.GetPullRequestReviewCommentsAsync(Repo, 3))
+            .ReturnsAsync(IntegrationResult<List<GitHubReviewComment>>.Ok(new List<GitHubReviewComment>
+            {
+                new() { Id = 1, Body = "this is a bug", Path = "a.cs", Line = 5, Author = "bob" },
+                new() { Id = 2, Body = "lgtm", Author = "sue" },
+            }));
+
+        var result = await _sut.GetPullRequestCommentsAsync(_tenant, Repo, 3, "corr-c");
+
+        result.Success.Should().BeTrue();
+        result.Outcome.Should().Be("Done");
+        result.Comments.Should().HaveCount(2);
+        result.Comments![0].Body.Should().Be("this is a bug");
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(GitEventTypes.PrCommentsReadSuccess);
+    }
+
+    [Test]
+    public async Task GetComments_GuardDenied_403_PlatformNeverCalled()
+    {
+        Deny();
+
+        var result = await _sut.GetPullRequestCommentsAsync(_tenant, Repo, 3, "corr-c");
+
+        result.FailureCode.Should().Be(GitFailureCodes.RepoNotAuthorized);
+        _factory.Verify(f => f.Create(It.IsAny<string>()), Times.Never);
+        _github.VerifyNoOtherCalls();
+    }
+
+    [Test]
+    public async Task UpdateIssue_Success_PostsCommentAndLabels_OneEvent()
+    {
+        Allow();
+        ResolveToken(GitCredentialSources.Byok);
+        _github.Setup(g => g.PostIssueCommentAsync(Repo, 8, "status")).ReturnsAsync(IntegrationResult<bool>.Ok(true));
+        _github.Setup(g => g.AddIssueLabelsAsync(Repo, 8, It.IsAny<string[]>())).ReturnsAsync(IntegrationResult<bool>.Ok(true));
+
+        var body = new UpdateIssueRequest { Body = "status", AddLabels = new[] { "in-progress" }, CorrelationId = "corr-i" };
+        var result = await _sut.UpdateIssueAsync(_tenant, Repo, 8, body);
+
+        result.Success.Should().BeTrue();
+        result.Outcome.Should().Be("Updated");
+        result.IssueStatus.Should().Be("updated");
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(GitEventTypes.IssueUpdatedSuccess);
+    }
+
+    [Test]
+    public async Task UpdateIssue_CommentFails_LoudFailure_PreservesStatus()
+    {
+        Allow();
+        ResolveToken(GitCredentialSources.Byok);
+        _github.Setup(g => g.PostIssueCommentAsync(Repo, 8, "status"))
+            .ReturnsAsync(IntegrationResult<bool>.Fail("403: forbidden"));
+
+        var body = new UpdateIssueRequest { Body = "status", CorrelationId = "corr-i" };
+        var result = await _sut.UpdateIssueAsync(_tenant, Repo, 8, body);
+
+        result.Success.Should().BeFalse();
+        result.Outcome.Should().Be("Failed");
+        result.PlatformStatusCode.Should().Be(403);
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(GitEventTypes.IssueUpdatedFailed);
+    }
+
+    // ===================================================================
+    // F3 — an unexpected exception (DB/decrypt/mint/transport) between the
+    // guard and the platform call becomes a typed PLATFORM_ERROR (never a raw
+    // 5xx) with exactly ONE terminal FAILED event.
+    // ===================================================================
+
+    [Test]
+    public async Task GuardThrows_TypedPlatformError_OneFailedEvent_No5xx()
+    {
+        _authorizer
+            .Setup(a => a.AuthorizeAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("installation lookup DB down"));
+
+        Func<Task> act = async () => await _sut.CreatePullRequestAsync(_tenant, Repo, PrBody());
+        await act.Should().NotThrowAsync("a guard exception must never surface as a raw 5xx");
+
+        var result = await _sut.CreatePullRequestAsync(_tenant, Repo, PrBody());
+        result.Success.Should().BeFalse();
+        result.FailureCode.Should().Be(GitFailureCodes.PlatformError);
+        result.Outcome.Should().Be("Error");
+        result.ToHttpResult().Let(StatusOf).Should().Be(200);
+
+        // Two calls above, each fires exactly one FAILED event.
+        _events.Appended.Should().OnlyContain(e => e.Type == GitEventTypes.PrOpenedFailed);
+        _events.Appended.Should().HaveCount(2);
+    }
+
+    [Test]
+    public async Task TokenResolverThrows_TypedPlatformError_OneFailedEvent()
+    {
+        Allow();
+        _tokenResolver
+            .Setup(t => t.ResolveAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("secret decrypt failed"));
+
+        var result = await _sut.CreatePullRequestAsync(_tenant, Repo, PrBody());
+
+        result.Success.Should().BeFalse();
+        result.FailureCode.Should().Be(GitFailureCodes.PlatformError);
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(GitEventTypes.PrOpenedFailed);
+    }
+
+    [Test]
+    public async Task ClientFactoryThrows_TypedPlatformError_OneFailedEvent()
+    {
+        Allow();
+        ResolveToken(GitCredentialSources.Byok);
+        _factory.Setup(f => f.Create(It.IsAny<string>())).Throws(new InvalidOperationException("client mint failed"));
+
+        var result = await _sut.MergePullRequestAsync(_tenant, Repo, 15, MergeBody());
+
+        result.Success.Should().BeFalse();
+        result.FailureCode.Should().Be(GitFailureCodes.PlatformError);
+        result.ToHttpResult().Let(StatusOf).Should().Be(200);
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(GitEventTypes.PrMergeFailed);
+    }
+
+    // ===================================================================
+    // Credential safety (AC3/AC7) — the token appears in no result / event
+    // ===================================================================
+
+    [Test]
+    public async Task CredentialSafety_ResolvedToken_NeverAppearsInResultOrEvent()
+    {
+        Allow();
+        ResolveToken(GitCredentialSources.Byok);
+        _github.Setup(g => g.GetGitHubOpenPullRequestForBranchAsync(Repo, "feature", "main"))
+            .ReturnsAsync(IntegrationResult<GitHubPullRequestRef?>.Ok(null));
+        _github.Setup(g => g.CreateGitHubPullRequestAsync(Repo, It.IsAny<CreatePullRequestRequest>()))
+            .ReturnsAsync(IntegrationResult<GitHubPullRequestResult>.Ok(
+                new GitHubPullRequestResult { Success = true, Number = 1, Url = "u" }));
+
+        var result = await _sut.CreatePullRequestAsync(_tenant, Repo, PrBody());
+
+        JsonSerializer.Serialize(result).Should().NotContain(SecretToken);
+        foreach (var evt in _events.Appended)
+        {
+            (evt.Tags + evt.Data + evt.Metadata).Should().NotContain(SecretToken);
+        }
+        result.CredentialSource.Should().Be(GitCredentialSources.Byok, "only the LABEL is surfaced");
+    }
+
+    // ===================================================================
+    // Helpers
+    // ===================================================================
+
+    private static void AssertTags(DomainEvent evt, string operation, string credentialSource, string correlationId)
+    {
+        using var doc = JsonDocument.Parse(evt.Tags);
+        var root = doc.RootElement;
+        root.GetProperty("repo").GetString().Should().Be(Repo);
+        root.GetProperty("operation").GetString().Should().Be(operation);
+        root.GetProperty("credentialSource").GetString().Should().Be(credentialSource);
+        root.GetProperty("correlationId").GetString().Should().Be(correlationId);
+        root.TryGetProperty("tenantId", out _).Should().BeTrue();
+    }
+
+    private static int StatusOf(Microsoft.AspNetCore.Http.IResult result)
+    {
+        // Results.Ok(...) → Ok<T> (200); Results.Json(..., statusCode) → JsonHttpResult<T>.
+        var prop = result.GetType().GetProperty("StatusCode");
+        var value = prop?.GetValue(result);
+        return value is int code ? code : 200;
+    }
+
+    private sealed class RecordingEventRepository : IEventRepository
+    {
+        public ConcurrentBag<DomainEvent> Appended { get; } = new();
+
+        public Task<DomainEvent> AppendAsync(DomainEvent evt)
+        {
+            Appended.Add(evt);
+            return Task.FromResult(evt);
+        }
+
+        public Task<DomainEvent?> GetByIdAsync(Guid id) => Task.FromResult<DomainEvent?>(null);
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit)
+            => Task.FromResult(new List<DomainEvent>());
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type) => Task.FromResult<DomainEvent?>(null);
+        public Task ClearAsync(Guid tenantId) => Task.CompletedTask;
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(
+            Guid? tenantId, string? type, int? issueNumber, int limit, int offset)
+            => Task.FromResult(((IReadOnlyList<DomainEvent>)new List<DomainEvent>(), 0));
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(
+            Guid tenantId, string? typePrefix, int limit, int offset)
+            => Task.FromResult(((IReadOnlyList<DomainEvent>)new List<DomainEvent>(), 0));
+    }
+}
+
+/// <summary>Tiny functional helper so a fluent one-liner can pipe an
+/// <c>IResult</c> through <c>StatusOf</c> in the assertions above.</summary>
+internal static class GitTestPipe
+{
+    public static TOut Let<TIn, TOut>(this TIn value, Func<TIn, TOut> f) => f(value);
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Git/GitRepoAuthorizerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Git/GitRepoAuthorizerTests.cs
@@ -1,0 +1,179 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.Git;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Git;
+
+/// <summary>
+/// Story 38-1 (AC2) + F1 — direct coverage of the load-bearing cross-tenant
+/// guard. The guard is the single control that stops a mis-scoped platform token
+/// from writing to another tenant's repo, so its null-handling is mode-gated:
+/// <list type="bullet">
+///   <item><b>single-user</b> — a matched null/null is the sole-user case ⇒ Allow.</item>
+///   <item><b>SaaS</b> — a null acting tenant OR a null-<c>TenantId</c> (orphan)
+///     install must NOT fail open ⇒ Deny; only both-present-and-equal ⇒ Allow.</item>
+/// </list>
+/// </summary>
+[TestFixture]
+public class GitRepoAuthorizerTests
+{
+    private const string Repo = "acme/widgets";
+
+    private Mock<IInstallationRepository> _installations = null!;
+    private static readonly Guid TenantA = Guid.NewGuid();
+    private static readonly Guid TenantB = Guid.NewGuid();
+
+    [SetUp]
+    public void SetUp()
+    {
+        _installations = new Mock<IInstallationRepository>(MockBehavior.Strict);
+    }
+
+    private GitRepoAuthorizer Build(TammaMode mode)
+    {
+        var modeProvider = new Mock<ITammaModeProvider>();
+        modeProvider.SetupGet(m => m.Mode).Returns(mode);
+        return new GitRepoAuthorizer(
+            _installations.Object, modeProvider.Object, NullLogger<GitRepoAuthorizer>.Instance);
+    }
+
+    private void InstallationForRepo(Guid? tenantId)
+        => _installations
+            .Setup(r => r.GetByRepoFullNameAsync(Repo))
+            .ReturnsAsync(new GitHubInstallation
+            {
+                Id = Guid.NewGuid(),
+                InstallationId = 1234,
+                AccountLogin = "acme",
+                AccountType = "Organization",
+                AppId = 1,
+                TenantId = tenantId,
+            });
+
+    private void NoInstallationForRepo()
+        => _installations
+            .Setup(r => r.GetByRepoFullNameAsync(Repo))
+            .ReturnsAsync((GitHubInstallation?)null);
+
+    // ── single-user ────────────────────────────────────────────────────
+
+    [Test]
+    public async Task SingleUser_NullActing_NullInstallTenant_Allows()
+    {
+        // The legit sole-user case: both sides null (no tenancy) ⇒ Allow.
+        InstallationForRepo(tenantId: null);
+
+        var result = await Build(TammaMode.SingleUser).AuthorizeAsync(null, Repo);
+
+        result.Allowed.Should().BeTrue("single-user both-null is the sole-user case");
+    }
+
+    [Test]
+    public async Task SingleUser_MatchingTenant_Allows()
+    {
+        InstallationForRepo(tenantId: TenantA);
+
+        var result = await Build(TammaMode.SingleUser).AuthorizeAsync(TenantA, Repo);
+
+        result.Allowed.Should().BeTrue();
+    }
+
+    // ── SaaS: the F1 fail-open cases ────────────────────────────────────
+
+    [Test]
+    public async Task Saas_NullActingTenant_Denies()
+    {
+        // A null-X-Tenant-Id engine request must NOT pass in SaaS, even against a
+        // tenant-owned install — plain nullable equality would fail open here.
+        InstallationForRepo(tenantId: TenantA);
+
+        var result = await Build(TammaMode.SaaS).AuthorizeAsync(null, Repo);
+
+        result.Allowed.Should().BeFalse("a null acting tenant must be denied in SaaS");
+    }
+
+    [Test]
+    public async Task Saas_OrphanInstall_NullInstallTenant_Denies()
+    {
+        // Orphan install (TenantId=null) against a real acting tenant: the exact
+        // null == null fail-open the F1 fix closes.
+        InstallationForRepo(tenantId: null);
+
+        var result = await Build(TammaMode.SaaS).AuthorizeAsync(TenantA, Repo);
+
+        result.Allowed.Should().BeFalse("an orphan (null-TenantId) install must be denied in SaaS");
+    }
+
+    [Test]
+    public async Task Saas_NullActing_And_OrphanInstall_BothNull_Denies()
+    {
+        // The precise reported hole: null acting tenant + orphan install = null==null.
+        InstallationForRepo(tenantId: null);
+
+        var result = await Build(TammaMode.SaaS).AuthorizeAsync(null, Repo);
+
+        result.Allowed.Should().BeFalse("both-null must NOT fail open in SaaS");
+    }
+
+    [Test]
+    public async Task Saas_CrossTenant_ActingA_InstallB_Denies()
+    {
+        InstallationForRepo(tenantId: TenantB);
+
+        var result = await Build(TammaMode.SaaS).AuthorizeAsync(TenantA, Repo);
+
+        result.Allowed.Should().BeFalse("a cross-tenant attempt is the write this guard exists to prevent");
+    }
+
+    [Test]
+    public async Task Saas_MatchingTenant_Allows()
+    {
+        InstallationForRepo(tenantId: TenantA);
+
+        var result = await Build(TammaMode.SaaS).AuthorizeAsync(TenantA, Repo);
+
+        result.Allowed.Should().BeTrue("both present and equal ⇒ allow");
+    }
+
+    // ── mode-agnostic fail-closed ───────────────────────────────────────
+
+    [Test]
+    public async Task NoInstallation_Denies()
+    {
+        NoInstallationForRepo();
+
+        var result = await Build(TammaMode.SaaS).AuthorizeAsync(TenantA, Repo);
+
+        result.Allowed.Should().BeFalse("no installation grants access ⇒ fail-closed deny");
+    }
+
+    [Test]
+    public async Task BlankRepo_Denies_WithoutLookup()
+    {
+        var result = await Build(TammaMode.SaaS).AuthorizeAsync(TenantA, "  ");
+
+        result.Allowed.Should().BeFalse();
+        _installations.Verify(r => r.GetByRepoFullNameAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    // ── duplicate-installation (see F2): repo resolves to whichever install the
+    //    registry returns; the guard still asserts that install's tenant matches ──
+
+    [Test]
+    public async Task Saas_DuplicateRepoRegistration_ResolvesToForeignTenant_Denies()
+    {
+        // If the same repo full-name is registered under an install owned by
+        // tenant B, an acting tenant A must still be denied (the guard trusts the
+        // registry's resolved install, then re-checks tenancy).
+        InstallationForRepo(tenantId: TenantB);
+
+        var result = await Build(TammaMode.SaaS).AuthorizeAsync(TenantA, Repo);
+
+        result.Allowed.Should().BeFalse();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Git/GitTokenResolverTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Git/GitTokenResolverTests.cs
@@ -1,0 +1,139 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.Git;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+using Tamma.Platforms.Abstractions;
+
+namespace Tamma.Api.Tests.Git;
+
+/// <summary>
+/// Story 38-1 (AC3) + F1 — direct coverage of the per-tenant git-token resolver
+/// (tenant BYOK → platform default → fail-closed null). The token itself is
+/// load-bearing sensitive; these tests assert only the SOURCE label and the
+/// fail-closed contract (never an empty/default token).
+/// </summary>
+[TestFixture]
+public class GitTokenResolverTests
+{
+    private const string Repo = "acme/widgets";
+    private const string ByokToken = "ghp-byok-SECRET-aaaa";
+    private const string PlatformToken = "ghp-platform-SECRET-bbbb";
+
+    private Mock<ITenantPlatformInstallationRepository> _installations = null!;
+    private Mock<IPlatformCredentialReader> _credentialReader = null!;
+    private static readonly Guid Tenant = Guid.NewGuid();
+
+    [SetUp]
+    public void SetUp()
+    {
+        _installations = new Mock<ITenantPlatformInstallationRepository>();
+        _credentialReader = new Mock<IPlatformCredentialReader>();
+    }
+
+    private GitTokenResolver Build(params (string Key, string Value)[] config)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(config.Select(c =>
+                new KeyValuePair<string, string?>(c.Key, c.Value)))
+            .Build();
+
+        return new GitTokenResolver(
+            _installations.Object, _credentialReader.Object, configuration,
+            NullLogger<GitTokenResolver>.Instance);
+    }
+
+    private void ByokInstallation()
+        => _installations
+            .Setup(r => r.GetByTenantKindAsync(Tenant, "github", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TenantPlatformInstallation
+            {
+                TenantId = Tenant,
+                PlatformKind = "github",
+                CredentialSecretScope = "tenant",
+                CredentialSecretName = "github-installation",
+            });
+
+    // ── BYOK (tenant tier) ──────────────────────────────────────────────
+
+    [Test]
+    public async Task Byok_Present_ReturnsByokSource()
+    {
+        ByokInstallation();
+        _credentialReader
+            .Setup(c => c.ReadActivePlaintextAsync("tenant", Tenant, "github-installation", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ByokToken);
+
+        var result = await Build(("GitHub:Token", PlatformToken)).ResolveAsync(Tenant, Repo);
+
+        result.Should().NotBeNull();
+        result!.Source.Should().Be(GitCredentialSources.Byok);
+        result.Token.Should().Be(ByokToken, "BYOK wins over the platform default when present");
+    }
+
+    // ── platform (system tier) ──────────────────────────────────────────
+
+    [Test]
+    public async Task ByokAbsent_PlatformTokenSet_ReturnsPlatformSource()
+    {
+        // No BYOK installation for the tenant → falls to the platform default.
+        _installations
+            .Setup(r => r.GetByTenantKindAsync(Tenant, "github", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TenantPlatformInstallation?)null);
+
+        var result = await Build(("GitHub:Token", PlatformToken)).ResolveAsync(Tenant, Repo);
+
+        result.Should().NotBeNull();
+        result!.Source.Should().Be(GitCredentialSources.Platform);
+        result.Token.Should().Be(PlatformToken);
+    }
+
+    [Test]
+    public async Task NullTenant_PlatformTokenSet_ReturnsPlatformSource()
+    {
+        // A null acting tenant skips the BYOK tier entirely and uses the platform
+        // default (system tier).
+        var result = await Build(("GitHub:Token", PlatformToken)).ResolveAsync(null, Repo);
+
+        result.Should().NotBeNull();
+        result!.Source.Should().Be(GitCredentialSources.Platform);
+        _installations.Verify(
+            r => r.GetByTenantKindAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never, "a null tenant has no BYOK tier to consult");
+    }
+
+    // ── error tier (fail-closed) ────────────────────────────────────────
+
+    [Test]
+    public async Task Neither_ReturnsNull_FailClosed()
+    {
+        // No BYOK, no platform GitHub:Token → null ⇒ the caller returns 503
+        // GIT_TOKEN_UNAVAILABLE, never an empty/default token.
+        _installations
+            .Setup(r => r.GetByTenantKindAsync(Tenant, "github", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TenantPlatformInstallation?)null);
+
+        var result = await Build(/* no GitHub:Token */).ResolveAsync(Tenant, Repo);
+
+        result.Should().BeNull("neither tier resolvable ⇒ fail-closed null");
+    }
+
+    [Test]
+    public async Task Byok_InstallationPresent_ButBlankSecret_FallsBackToPlatform()
+    {
+        // An installation row whose credential read yields blank is NOT a valid
+        // BYOK token → fall through to the platform tier (never a blank token).
+        ByokInstallation();
+        _credentialReader
+            .Setup(c => c.ReadActivePlaintextAsync("tenant", Tenant, "github-installation", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("   ");
+
+        var result = await Build(("GitHub:Token", PlatformToken)).ResolveAsync(Tenant, Repo);
+
+        result.Should().NotBeNull();
+        result!.Source.Should().Be(GitCredentialSources.Platform);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/GitHub/InstallationRepositoryCaseInsensitiveTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/GitHub/InstallationRepositoryCaseInsensitiveTests.cs
@@ -1,0 +1,112 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.GitHub;
+
+/// <summary>
+/// Story 38-1 (F2) — <see cref="InstallationRepository.GetByRepoFullNameAsync"/>
+/// must match repo full names case-INsensitively. GitHub repo full names are
+/// case-insensitive ("Acme/Widget" == "acme/widget"); a case-sensitive DB
+/// compare would 404 a legitimate tenant and hard-fail the ADL git-mediation
+/// guard with a spurious <c>REPO_NOT_AUTHORIZED</c>.
+/// </summary>
+[TestFixture]
+public class InstallationRepositoryCaseInsensitiveTests
+{
+    private DbContextOptions<ControlPlaneDbContext> _options = null!;
+    private ControlPlaneDbContext _db = null!;
+    private InstallationRepository _repo = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _options = new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(
+                Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+        _db = new ControlPlaneDbContext(_options);
+        _repo = new InstallationRepository(_db);
+    }
+
+    [TearDown]
+    public void TearDown() => _db.Dispose();
+
+    private async Task<Guid> SeedInstallationWithRepoAsync(string repoFullName, Guid? tenantId = null)
+    {
+        var installationEntityId = Guid.NewGuid();
+        _db.GitHubInstallations.Add(new GitHubInstallation
+        {
+            Id = installationEntityId,
+            InstallationId = 4242,
+            AccountLogin = "acme",
+            AccountType = "Organization",
+            AppId = 1,
+            TenantId = tenantId,
+        });
+        await _db.SaveChangesAsync();
+
+        // AddRepoAsync also derives Owner/Name from the full name.
+        await _repo.AddRepoAsync(installationEntityId, repoId: 777, repoFullName: repoFullName);
+        return installationEntityId;
+    }
+
+    [Test]
+    public async Task GetByRepoFullName_LowercaseQuery_MatchesMixedCaseRegistration()
+    {
+        var installEntityId = await SeedInstallationWithRepoAsync("Acme/Widget");
+
+        var result = await _repo.GetByRepoFullNameAsync("acme/widget");
+
+        result.Should().NotBeNull("GitHub repo names are case-insensitive");
+        result!.Id.Should().Be(installEntityId);
+    }
+
+    [Test]
+    public async Task GetByRepoFullName_MixedCaseQuery_MatchesLowercaseRegistration()
+    {
+        var installEntityId = await SeedInstallationWithRepoAsync("acme/widget");
+
+        var result = await _repo.GetByRepoFullNameAsync("Acme/Widget");
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(installEntityId);
+    }
+
+    [Test]
+    public async Task GetByRepoFullName_ExactMatch_StillWorks()
+    {
+        var installEntityId = await SeedInstallationWithRepoAsync("acme/widget");
+
+        var result = await _repo.GetByRepoFullNameAsync("acme/widget");
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(installEntityId);
+    }
+
+    [Test]
+    public async Task GetByRepoFullName_UnknownRepo_ReturnsNull()
+    {
+        await SeedInstallationWithRepoAsync("acme/widget");
+
+        var result = await _repo.GetByRepoFullNameAsync("other/repo");
+
+        result.Should().BeNull();
+    }
+
+    [Test]
+    public async Task GetByRepoFullName_InactiveRepo_ReturnsNull_EvenCaseInsensitive()
+    {
+        var installEntityId = await SeedInstallationWithRepoAsync("Acme/Widget");
+        // Deactivate the repo link (repo removed from the installation).
+        await _repo.RemoveRepoAsync(installEntityId, repoId: 777);
+
+        var result = await _repo.GetByRepoFullNameAsync("acme/widget");
+
+        result.Should().BeNull("an inactive repo link must not resolve, regardless of case");
+    }
+}


### PR DESCRIPTION
## Epic 38 Story 38-1 — Git-platform step mediation (Class A)

First story of Epic 38 (pull non-LLM external effects out of the engine). Mirrors the 32-5 `/llm/call` template.

**Problem:** 5 ADL git activities reached GitHub via a co-hosted credential-holding service (`IGitHubIntegrationService`) — a rule-1 violation that becomes live the moment the engine runs as per-tenant dedicated compute (a mis-scoped token = cross-tenant write/merge).

**Fix:** each activity becomes a thin `TammaApiClient` client calling a new `/api/v1/git/{owner}/{repo}/...` endpoint in `Tamma.Api`:
1. **Authorize tenant↔repo FIRST** (`IGitRepoAuthorizer`, fail-closed) — the load-bearing control.
2. **Resolve a per-tenant token** BYOK→platform (`IGitTokenResolver`; 503 `GIT_TOKEN_UNAVAILABLE` fail-closed; `credentialSource` surfaced, token never).
3. **Call GitHub with that token** (token-bound service via `IGitHubClientFactory` — token used == token resolved).
4. **Emit exactly one `GIT.*` DCB audit event** (key-free, token-free).

Endpoints: `POST branches`, `POST pull-requests`, `PUT pull-requests/{n}/merge`, `GET pull-requests/{n}/comments`, `PATCH issues/{n}` — all `EngineServiceOnly`, tenant from `ITenantContext`. Engine no longer registers `IGitHubIntegrationService` / the `github` HttpClient / `GitHub:Token`. No control-plane table (AC8).

### Review + fixes (two independent reviewers, both converged on F1)
- **F1 (HIGH)** — guard fail-open: a null acting tenant + null-`TenantId` orphan install passed the guard in SaaS → fell to the platform token. Mode-gated via `ITammaModeProvider` (SaaS denies null acting tenant + orphan match; both-null allowed only single-user). The guard + token resolver, previously untested, now have direct unit tests.
- **F2 (MED)** — case-insensitive repo lookup (GitHub is case-insensitive → no more false `REPO_NOT_AUTHORIZED`).
- **F3 (MED)** — an exception between guard-pass and platform-call now emits `GIT.*.FAILED` + typed 200 `success:false` (never a raw 5xx; exactly one audit event).
- **F4 (MED)** — removed the dead/lying `Degraded` no-op on `UpdateIssueStatus` (cycles dispatch it fire-and-forget; fail-loud is correct post-pivot).

Reviewers confirmed clean: no token leakage, token invariant holds, no phantom-success outcomes, engine has no direct-GitHub path.

### Verify
- Build 0 errors; full `Tamma.Api.Tests` 3878/0/5skip; full `Tamma.Activities.Tests` 2126/0
- Zero `IGitHubIntegrationService` DI injections remain in `Tamma.Activities` (AC9)

Follow-ons: 38-2 (agent-dispatch), 38-3 (Slack), 38-4 (build-time guardrail — must ban DI-injection + direct external calls, not type refs in the reused server-side cores). GitHub-App installation-token minting (vs cabinet-secret BYOK) is a noted follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
