### PR TITLE
Epic 38 Story 38-3: Slack/notifications step mediation (outbox seam)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/Integration/SlackActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Integration/SlackActivity.cs
@@ -4,14 +4,33 @@ using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
-using Tamma.Core.Interfaces;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
+using Tamma.Core.Entities;
 using Tamma.Data.Repositories;
 
 namespace Tamma.Activities.Integration;
 
 /// <summary>
 /// ELSA activity for Slack communication.
-/// Supports sending messages to channels and direct messages to users.
+///
+/// <para>Story 38-3 (Epic 38, Class D) — this activity is a THIN
+/// <see cref="TammaApiClient"/> client. It holds no Slack credential and makes no
+/// Slack HTTP call: it formats the message engine-side (pure, token-free), then
+/// enqueues the notification INTENT via
+/// <c>TammaApiClient.QueueSlackNotificationAsync</c> →
+/// <c>POST /api/v1/notifications/slack</c>, where the API writes a
+/// <c>slack_outbox</c> row and the out-of-band <c>OutboxSlackSender</c> (the sole
+/// webhook-credential holder) performs the transport out of band.</para>
+///
+/// <para><b>Output contract:</b> the <see cref="SlackOperationResult"/> shape is
+/// preserved for the mentorship workflows that read it, but <c>Success</c> now
+/// means "enqueued" (fire-and-forget), NOT "delivered". <c>WaitingForResponse</c>
+/// stays <c>true</c> only for the assessment action (and only when the enqueue
+/// succeeded). The local <c>MentorshipEvent</c> session-log write is kept — it is a
+/// local repository write, not an external call. Fail-soft: an enqueue failure
+/// (API down / non-2xx) returns <c>Success=false</c> and does NOT throw, so a
+/// missing Slack post never breaks a mentorship session.</para>
 /// </summary>
 [Activity(
     "Tamma.Integration",
@@ -22,7 +41,7 @@ namespace Tamma.Activities.Integration;
 public class SlackActivity : CodeActivity<SlackOperationResult>
 {
     private readonly ILogger<SlackActivity>? _logger;
-    private readonly IIntegrationService? _integrationService;
+    private readonly TammaApiClient? _apiClient;
     private readonly IMentorshipSessionRepository? _repository;
 
     /// <summary>Slack action to perform</summary>
@@ -49,21 +68,31 @@ public class SlackActivity : CodeActivity<SlackOperationResult>
     [Input(Description = "Message type: Info, Warning, Success, Error")]
     public Input<MessageType> MessageType { get; set; } = new(Integration.MessageType.Info);
 
+    /// <summary>Tenant id (GUID string) for the X-Tenant-Id scope; empty = single-user/platform.</summary>
+    [Input(Description = "Tenant id (GUID string) for notification scope; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
     [JsonConstructor]
     public SlackActivity() { }
 
+    /// <summary>
+    /// Story 38-3 — thin-client DI constructor. The activity injects no
+    /// Slack-credential-holding integration service and no Slack token: it delegates
+    /// the post to <c>POST /api/v1/notifications/slack</c> via
+    /// <see cref="TammaApiClient"/>.
+    /// </summary>
     public SlackActivity(
         ILogger<SlackActivity> logger,
-        IIntegrationService integrationService,
+        TammaApiClient apiClient,
         IMentorshipSessionRepository repository)
     {
         _logger = logger;
-        _integrationService = integrationService;
+        _apiClient = apiClient;
         _repository = repository;
     }
 
     /// <summary>
-    /// Execute the Slack operation
+    /// Execute the Slack operation — map inputs → intent → enqueue.
     /// </summary>
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
@@ -73,49 +102,159 @@ public class SlackActivity : CodeActivity<SlackOperationResult>
         var message = Message.Get(context);
         var sessionId = SessionId.Get(context);
         var messageType = MessageType.Get(context);
+        var tenantId = NormalizeTenant(TenantId.Get(context));
 
-        _logger?.LogInformation(
-            "Executing Slack action {Action}",
-            action);
+        _logger?.LogInformation("Executing Slack action {Action} (mediated)", action);
 
+        var api = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+        var repository = _repository ?? context.GetService<IMentorshipSessionRepository>();
+
+        var result = await ExecuteCoreAsync(
+            action, channel, userId, message, messageType, sessionId, tenantId,
+            (req, tid, ct) => api.QueueSlackNotificationAsync(req, tid, ct),
+            repository,
+            context.CancellationToken,
+            _logger).ConfigureAwait(false);
+
+        context.SetResult(result);
+    }
+
+    /// <summary>
+    /// Pure-ish, testable execution core (no Elsa context): format the message,
+    /// enqueue the intent via <paramref name="enqueue"/>, write the mentorship
+    /// session event on enqueue-success, and project the <see cref="SlackOperationResult"/>.
+    /// NEVER throws — any failure becomes <c>Success=false</c> (fail-soft, AC10).
+    /// </summary>
+    public static async Task<SlackOperationResult> ExecuteCoreAsync(
+        SlackAction action,
+        string? channel,
+        string? userId,
+        string message,
+        MessageType messageType,
+        Guid? sessionId,
+        string? tenantId,
+        Func<SlackNotificationRequest, string?, CancellationToken, Task<bool>> enqueue,
+        IMentorshipSessionRepository? repository,
+        CancellationToken ct,
+        ILogger? logger = null)
+    {
         try
         {
-            var formattedMessage = FormatMessage(message, messageType);
-
-            SlackOperationResult result = action switch
+            var plan = BuildPlan(action, channel, userId, message, messageType);
+            if (plan is null)
             {
-                SlackAction.SendChannel => await SendToChannel(channel!, formattedMessage),
-                SlackAction.SendDirect => await SendDirectMessage(userId!, formattedMessage),
-                SlackAction.SendAssessment => await SendAssessmentRequest(userId!, message, sessionId),
-                SlackAction.SendGuidance => await SendGuidanceMessage(userId!, message, sessionId),
-                SlackAction.SendNotification => await SendNotification(userId!, channel, formattedMessage),
-                _ => new SlackOperationResult { Success = false, Message = $"Unknown action: {action}" }
-            };
-
-            // Log the event if session is provided
-            if (sessionId.HasValue && result.Success)
-            {
-                await _repository!.LogEventAsync(new Tamma.Core.Entities.MentorshipEvent
-                {
-                    SessionId = sessionId.Value,
-                    EventType = Tamma.Core.Entities.EventTypes.Info
-                });
+                return new SlackOperationResult { Success = false, Message = $"Unknown action: {action}" };
             }
 
-            context.SetResult(result);
+            var request = new SlackNotificationRequest
+            {
+                Action = action.ToString(),
+                Channel = plan.Channel,
+                UserId = plan.TargetUserId,
+                Message = plan.Body,
+                MessageType = messageType.ToString(),
+                SessionId = sessionId,
+            };
+
+            var queued = await enqueue(request, tenantId, ct).ConfigureAwait(false);
+
+            // Local session log — a local repository write, kept from the legacy
+            // activity (not an external call). Only on enqueue-success.
+            if (sessionId.HasValue && queued && repository is not null)
+            {
+                await repository.LogEventAsync(new MentorshipEvent
+                {
+                    SessionId = sessionId.Value,
+                    EventType = EventTypes.Info,
+                }).ConfigureAwait(false);
+            }
+
+            return new SlackOperationResult
+            {
+                Success = queued,
+                Message = queued ? plan.SuccessMessage : "Notification queue failed",
+                Destination = plan.Destination,
+                // Fire-and-forget: nothing to await except the assessment action,
+                // and only when the enqueue actually succeeded.
+                WaitingForResponse = queued && plan.WaitingForResponse,
+            };
         }
         catch (Exception ex)
         {
-            _logger?.LogError(ex, "Slack operation failed");
-            context.SetResult(new SlackOperationResult
+            logger?.LogError(ex, "Slack operation failed");
+            return new SlackOperationResult
             {
                 Success = false,
-                Message = $"Operation failed: {ex.Message}"
-            });
+                Message = $"Operation failed: {ex.Message}",
+            };
         }
     }
 
-    private string FormatMessage(string message, MessageType type)
+    /// <summary>
+    /// Map a <see cref="SlackAction"/> + inputs into a token-free notification plan:
+    /// the formatted body, the channel/target, the destination label, the
+    /// success message, and whether the action awaits a response. Returns
+    /// <c>null</c> for an unknown action.
+    /// </summary>
+    public static SlackNotificationPlan? BuildPlan(
+        SlackAction action, string? channel, string? userId, string message, MessageType messageType)
+    {
+        return action switch
+        {
+            SlackAction.SendChannel => new SlackNotificationPlan
+            {
+                Body = FormatMessage(message, messageType),
+                Channel = channel,
+                TargetUserId = null,
+                Destination = channel,
+                SuccessMessage = $"Message queued for #{channel}",
+                WaitingForResponse = false,
+            },
+            SlackAction.SendDirect => new SlackNotificationPlan
+            {
+                Body = FormatMessage(message, messageType),
+                Channel = null,
+                TargetUserId = userId,
+                Destination = userId,
+                SuccessMessage = $"DM queued for @{userId}",
+                WaitingForResponse = false,
+            },
+            SlackAction.SendAssessment => new SlackNotificationPlan
+            {
+                Body = FormatAssessment(message),
+                Channel = null,
+                TargetUserId = userId,
+                Destination = userId,
+                SuccessMessage = "Assessment request queued",
+                WaitingForResponse = true,
+            },
+            SlackAction.SendGuidance => new SlackNotificationPlan
+            {
+                Body = FormatGuidance(message),
+                Channel = null,
+                TargetUserId = userId,
+                Destination = userId,
+                SuccessMessage = "Guidance queued",
+                WaitingForResponse = false,
+            },
+            SlackAction.SendNotification => new SlackNotificationPlan
+            {
+                Body = FormatMessage(message, messageType),
+                Channel = string.IsNullOrEmpty(channel) ? null : channel,
+                TargetUserId = string.IsNullOrEmpty(userId) ? null : userId,
+                Destination = userId ?? channel ?? "unknown",
+                SuccessMessage = "Notification queued",
+                WaitingForResponse = false,
+            },
+            _ => null,
+        };
+    }
+
+    /// <summary>Normalize a tenant-id input to a non-empty trimmed string or null.</summary>
+    internal static string? NormalizeTenant(string? raw)
+        => string.IsNullOrWhiteSpace(raw) ? null : raw.Trim();
+
+    internal static string FormatMessage(string message, MessageType type)
     {
         var emoji = type switch
         {
@@ -127,90 +266,41 @@ public class SlackActivity : CodeActivity<SlackOperationResult>
             _ => ""
         };
 
-        return $"{emoji} {message}";
+        return $"{emoji} {EscapeSlack(message)}";
     }
 
-    private async Task<SlackOperationResult> SendToChannel(string channel, string message)
-    {
-        await _integrationService!.SendSlackMessageAsync(channel, message);
-        return new SlackOperationResult
-        {
-            Success = true,
-            Message = $"Message sent to #{channel}",
-            Destination = channel
-        };
-    }
+    internal static string FormatAssessment(string assessmentContent)
+        => $@"**Tamma Assessment Request** :clipboard:
 
-    private async Task<SlackOperationResult> SendDirectMessage(string userId, string message)
-    {
-        await _integrationService!.SendSlackDirectMessageAsync(userId, message);
-        return new SlackOperationResult
-        {
-            Success = true,
-            Message = $"DM sent to @{userId}",
-            Destination = userId
-        };
-    }
-
-    private async Task<SlackOperationResult> SendAssessmentRequest(
-        string userId, string assessmentContent, Guid? sessionId)
-    {
-        var formattedMessage = $@"**Tamma Assessment Request** :clipboard:
-
-{assessmentContent}
+{EscapeSlack(assessmentContent)}
 
 Please respond to this message with your answers.
 _This assessment will help me understand your current understanding and provide better guidance._";
 
-        await _integrationService!.SendSlackDirectMessageAsync(userId, formattedMessage);
+    internal static string FormatGuidance(string guidanceContent)
+        => $@"**Tamma Guidance** :bulb:
 
-        return new SlackOperationResult
-        {
-            Success = true,
-            Message = "Assessment request sent",
-            Destination = userId,
-            WaitingForResponse = true
-        };
-    }
-
-    private async Task<SlackOperationResult> SendGuidanceMessage(
-        string userId, string guidanceContent, Guid? sessionId)
-    {
-        var formattedMessage = $@"**Tamma Guidance** :bulb:
-
-{guidanceContent}
+{EscapeSlack(guidanceContent)}
 
 _Reply if you have questions or need more help!_";
 
-        await _integrationService!.SendSlackDirectMessageAsync(userId, formattedMessage);
-
-        return new SlackOperationResult
-        {
-            Success = true,
-            Message = "Guidance sent",
-            Destination = userId
-        };
-    }
-
-    private async Task<SlackOperationResult> SendNotification(
-        string? userId, string? channel, string message)
+    /// <summary>
+    /// Neutralize Slack control characters in an UNTRUSTED message body before it is
+    /// interpolated into a posted body. Slack's documented escaping (<c>&amp;</c> →
+    /// <c>&amp;amp;</c>, <c>&lt;</c> → <c>&amp;lt;</c>, <c>&gt;</c> → <c>&amp;gt;</c>)
+    /// renders broadcast/mention tokens like <c>&lt;!channel&gt;</c>, <c>&lt;!here&gt;</c>,
+    /// <c>&lt;@U…&gt;</c> literally, so issue/task/AI-derived content can't expand into
+    /// pings beyond the intended audience. Applied ONLY to caller-supplied text — never
+    /// to our own emoji/label prefixes. Order matters: escape <c>&amp;</c> first so the
+    /// replacements it introduces are not double-escaped.
+    /// </summary>
+    internal static string EscapeSlack(string? text)
     {
-        if (!string.IsNullOrEmpty(userId))
-        {
-            await _integrationService!.SendSlackDirectMessageAsync(userId, message);
-        }
-
-        if (!string.IsNullOrEmpty(channel))
-        {
-            await _integrationService!.SendSlackMessageAsync(channel, message);
-        }
-
-        return new SlackOperationResult
-        {
-            Success = true,
-            Message = "Notification sent",
-            Destination = userId ?? channel ?? "unknown"
-        };
+        if (string.IsNullOrEmpty(text)) return string.Empty;
+        return text
+            .Replace("&", "&amp;", StringComparison.Ordinal)
+            .Replace("<", "&lt;", StringComparison.Ordinal)
+            .Replace(">", "&gt;", StringComparison.Ordinal);
     }
 }
 
@@ -236,6 +326,22 @@ public enum MessageType
     Success,
     Error,
     Celebration
+}
+
+/// <summary>
+/// Token-free plan for a single Slack notification, produced by
+/// <see cref="SlackActivity.BuildPlan"/> — the formatted body plus the routing +
+/// output metadata the thin client maps into the wire request and the
+/// <see cref="SlackOperationResult"/>.
+/// </summary>
+public sealed class SlackNotificationPlan
+{
+    public string Body { get; init; } = string.Empty;
+    public string? Channel { get; init; }
+    public string? TargetUserId { get; init; }
+    public string? Destination { get; init; }
+    public string SuccessMessage { get; init; } = string.Empty;
+    public bool WaitingForResponse { get; init; }
 }
 
 /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Models/SlackNotificationModels.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Models/SlackNotificationModels.cs
@@ -1,0 +1,42 @@
+using System.Text.Json.Serialization;
+
+namespace Tamma.Activities.LlmCall.Models;
+
+/// <summary>
+/// Story 38-3 (Epic 38, Class D) — the engine→API wire contract for the Slack
+/// notification mediation endpoint <c>POST /api/v1/notifications/slack</c>.
+///
+/// <para>The engine's thin <c>SlackActivity</c> maps its inputs into this record
+/// and posts it via <c>TammaApiClient.QueueSlackNotificationAsync</c>. The
+/// message body is ALREADY formatted engine-side (pure emoji/assessment/guidance
+/// templating — no secret), so the API only writes the outbox row + drains it.
+/// The row carries NO Slack credential; the webhook lives only in
+/// <c>OutboxSlackSender</c>. The acting tenant is the authenticated
+/// <c>X-Tenant-Id</c> the client attaches — this body carries no tenant
+/// authority.</para>
+///
+/// <para>Camel-case <see cref="JsonPropertyName"/> matches the API's default
+/// web JSON serialization; the record lives in <c>Tamma.Activities</c> because
+/// the reference graph runs <c>Tamma.Api → Tamma.Activities</c>, so both the
+/// engine client and the API endpoint bind the SAME type.</para>
+/// </summary>
+public sealed record SlackNotificationRequest
+{
+    /// <summary>SendChannel | SendDirect | SendAssessment | SendGuidance | SendNotification.</summary>
+    [JsonPropertyName("action")] public string Action { get; init; } = string.Empty;
+
+    /// <summary>Target channel for a channel post.</summary>
+    [JsonPropertyName("channel")] public string? Channel { get; init; }
+
+    /// <summary>Target Slack user id for a DM (NOT a Tamma UserId).</summary>
+    [JsonPropertyName("userId")] public string? UserId { get; init; }
+
+    /// <summary>The already-formatted message body (token-free).</summary>
+    [JsonPropertyName("message")] public string Message { get; init; } = string.Empty;
+
+    /// <summary>Info | Warning | Success | Error | Celebration (carried for audit).</summary>
+    [JsonPropertyName("messageType")] public string MessageType { get; init; } = "Info";
+
+    /// <summary>Mentorship session context (logged; never transmitted to Slack).</summary>
+    [JsonPropertyName("sessionId")] public Guid? SessionId { get; init; }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/TammaApiClient.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/TammaApiClient.cs
@@ -248,6 +248,29 @@ public class TammaApiClient
         return $"{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(name)}";
     }
 
+    // ----- Slack / notifications mediation (Story 38-3 — Class D) -------
+
+    /// <summary>
+    /// Story 38-3 (AC5) — enqueue a Slack notification INTENT to the internal,
+    /// engine-only endpoint <c>POST /api/v1/notifications/slack</c>. Fire-and-forget:
+    /// the API writes a <c>slack_outbox</c> row and returns 202; the out-of-band
+    /// <c>OutboxSlackSender</c> (the sole webhook-credential holder) performs the
+    /// transport. Uses the <see cref="PostVoidAsync"/> path so the request gets the
+    /// engine bearer + <c>X-Tenant-Id</c> (<paramref name="tenantId"/>, the acting
+    /// scope) + per-call health recording. Returns <c>false</c> on any non-2xx /
+    /// transport failure — the thin activity treats that as a fail-soft "queue
+    /// failed" (the workflow continues; a missing Slack post must not break a
+    /// mentorship session). The Slack token never travels here.
+    /// </summary>
+    public virtual Task<bool> QueueSlackNotificationAsync(
+        Models.SlackNotificationRequest request,
+        string? tenantId = null,
+        CancellationToken ct = default)
+    {
+        var url = $"{_baseUrl}/api/v1/notifications/slack";
+        return PostVoidAsync(url, request, tenantId, ct);
+    }
+
     // ----- Provider Health ---------------------------------------------
 
     public Task<ProviderHealthStatus?> GetProviderHealthAsync(

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/NotificationEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/NotificationEndpoints.cs
@@ -1,0 +1,133 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.LlmCall.Models;
+using Tamma.Core.Logging;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Endpoints;
+
+/// <summary>
+/// Story 38-3 (Epic 38, Class D) — the internal, engine-only Slack notification
+/// mediation endpoint (<c>POST /api/v1/notifications/slack</c>). Same auth plane
+/// as <c>/api/v1/llm/call</c> / <c>/api/v1/git/...</c> / <c>/api/v1/agent-dispatch/...</c>:
+/// <list type="bullet">
+///   <item><b>Auth</b> — the <c>EngineServiceOnly</c> policy (the engine posts the
+///     service-scope <c>Tamma:ApiToken</c> Bearer via <c>TammaEngineAuthHandler</c>).
+///     A missing/invalid bearer ⇒ 401; a user JWT ⇒ 403 — both BEFORE the handler.</item>
+///   <item><b>Tenant scope</b> — the acting tenant is the auth-derived
+///     <see cref="ITenantContext"/> (X-Tenant-Id), NEVER the request body. There is
+///     no tenant↔repo guard (Slack is not repo-scoped).</item>
+///   <item><b>Outbox, not transport</b> — the handler writes ONE <c>pending</c>
+///     <see cref="SlackOutboxMessage"/> row and returns 202. It NEVER calls Slack
+///     synchronously and NEVER reads the webhook credential; the out-of-band
+///     <c>OutboxSlackSender</c> is the sole token-holder.</item>
+/// </list>
+/// </summary>
+public static class NotificationEndpoints
+{
+    /// <summary>Slack's practical block-text limit; the CP outbox body is capped here.</summary>
+    private const int MaxBodyLength = 4000;
+
+    /// <summary>Suffix appended when an over-cap body is truncated.</summary>
+    private const string TruncationMarker = "… [truncated]";
+
+    /// <summary>
+    /// Handle <c>POST /api/v1/notifications/slack</c>. Binds the engine's
+    /// <see cref="SlackNotificationRequest"/> (already-formatted body), scopes the
+    /// outbox row by the auth-derived tenant (SaaS → <c>TenantId</c>; single-user →
+    /// <c>TenantId</c> null, no per-user identity at the service-principal plane),
+    /// persists intent, and returns 202 + <c>{ outboxId, outboxIds }</c>.
+    ///
+    /// <para>A <c>SendNotification</c> intent can carry BOTH a channel and a target
+    /// user; each is written as an INDEPENDENT single-target row (channel XOR DM) so
+    /// the legs claim, retry, and fail on their own — a channel-leg retry never
+    /// re-sends the DM, and a DM failure never blocks the channel post. A request with
+    /// neither target is rejected 400 (it could only burn every retry on "no channel
+    /// or target user"). The body is length-capped so an unbounded engine payload
+    /// can't bloat a control-plane row.</para>
+    /// </summary>
+    public static async Task<IResult> QueueSlack(
+        SlackNotificationRequest request,
+        ITenantContext tenantContext,
+        ISlackOutboxRepository outbox,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var logger = loggerFactory.CreateLogger("Tamma.Api.Endpoints.NotificationEndpoints");
+
+        if (string.IsNullOrWhiteSpace(request.Message))
+        {
+            return Results.BadRequest(new { error = "message is required" });
+        }
+
+        var channel = string.IsNullOrWhiteSpace(request.Channel) ? null : request.Channel;
+        var targetUser = string.IsNullOrWhiteSpace(request.UserId) ? null : request.UserId;
+
+        // A row with neither a channel nor a target user can never deliver — reject
+        // up-front instead of writing a row that fails all its retries.
+        if (channel is null && targetUser is null)
+        {
+            return Results.BadRequest(new { error = "channel or userId is required" });
+        }
+
+        // Cap the persisted body — Slack's practical block limit is ~4000 chars and an
+        // unbounded engine payload should not grow the control-plane row without bound.
+        var body = request.Message.Length > MaxBodyLength
+            ? string.Concat(request.Message.AsSpan(0, MaxBodyLength - TruncationMarker.Length), TruncationMarker)
+            : request.Message;
+
+        // The AUTHORITATIVE owner scope is the auth-derived ambient tenant
+        // (X-Tenant-Id) — the body carries no tenant authority. null ⇒
+        // single-user / platform scope.
+        var tenantId = tenantContext.TenantId;
+        var messageType = string.IsNullOrWhiteSpace(request.MessageType) ? "Info" : request.MessageType;
+
+        // Split a both-targets intent into independent single-target rows.
+        var rows = new List<SlackOutboxMessage>(2);
+        if (channel is not null)
+        {
+            rows.Add(NewRow(tenantId, channel, targetUser: null, messageType, body));
+        }
+        if (targetUser is not null)
+        {
+            rows.Add(NewRow(tenantId, channel: null, targetUser, messageType, body));
+        }
+
+        var savedIds = new List<Guid>(rows.Count);
+        foreach (var row in rows)
+        {
+            var saved = await outbox.EnqueueAsync(row, ct).ConfigureAwait(false);
+            savedIds.Add(saved.Id);
+
+            logger.LogInformation(
+                "slack-notification queued: outboxId={OutboxId}, action={Action}, channel={Channel}, "
+                + "targetUser={TargetUser}, sessionId={SessionId}, tenantId={TenantId}",
+                saved.Id,
+                LogSanitizer.Clean(request.Action),
+                LogSanitizer.Clean(saved.Channel),
+                LogSanitizer.Clean(saved.TargetUserId),
+                request.SessionId,
+                saved.TenantId);
+        }
+
+        var primaryId = savedIds[0];
+        return Results.Accepted(
+            $"/api/v1/notifications/slack/{primaryId}",
+            new { outboxId = primaryId, outboxIds = savedIds });
+    }
+
+    /// <summary>Build one single-target (channel XOR DM) pending outbox row.</summary>
+    private static SlackOutboxMessage NewRow(
+        Guid? tenantId, string? channel, string? targetUser, string messageType, string body)
+        => new()
+        {
+            TenantId = tenantId,
+            UserId = null, // engine-service principal carries no per-user identity; TenantId is the scope.
+            Channel = channel,
+            TargetUserId = targetUser,
+            MessageType = messageType,
+            Body = body,
+        };
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/NotificationServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/NotificationServiceCollectionExtensions.cs
@@ -1,0 +1,23 @@
+using Tamma.Api.Services.Notifications;
+
+namespace Tamma.Api.Extensions;
+
+/// <summary>
+/// Story 38-3 — wires the Slack notification mediation subsystem into DI: the
+/// out-of-band <see cref="OutboxSlackSender"/> (the sole webhook-credential holder)
+/// and its options. The <c>ISlackOutboxRepository</c> is registered by
+/// <c>Tamma.Data</c>'s <c>AddTammaData</c>; <c>ISlackIntegrationService</c> and
+/// <c>IPlatformEventRepository</c> are already registered by the composition root.
+/// The sender is registered unconditionally — its <c>ExecuteAsync</c> bails out
+/// immediately when <c>Slack:WebhookUrl</c> is unset, so no-webhook deployments pay
+/// zero polling overhead.
+/// </summary>
+public static class NotificationServiceCollectionExtensions
+{
+    public static IServiceCollection AddSlackNotificationServices(this IServiceCollection services)
+    {
+        services.AddSingleton<OutboxSlackSenderOptions>();
+        services.AddHostedService<OutboxSlackSender>();
+        return services;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -395,6 +395,9 @@ builder.Services.AddGitHubInstallationServices(builder.Configuration);
 // Wave 2
 builder.Services.AddConventionServices();
 builder.Services.AddEmailServices();
+// Story 38-3 (Epic 38, Class D) — Slack notification outbox sender (sole webhook
+// credential holder). Gated off automatically when Slack:WebhookUrl is unset.
+builder.Services.AddSlackNotificationServices();
 builder.Services.AddTaskQueue();
 builder.Services.AddProviderSessionServices();
 builder.Services.AddSaaSServices();
@@ -2377,6 +2380,17 @@ app.MapGet("/api/v1/agent-dispatch/{owner}/{repo}/runs/{id:long}/results", Agent
 app.MapGet("/api/v1/agent-dispatch/{owner}/{repo}/installation", AgentDispatchEndpoints.ResolveInstallation)
     .RequireAuthorization("EngineServiceOnly")
     .WithName("ResolveAgentInstallation");
+
+// ── Story 38-3 (Epic 38) — Slack / notifications step mediation (Class D) ──
+// Same engine-only plane as /api/v1/llm/call: the engine's thin SlackActivity
+// posts an (already-formatted) notification intent here as the service-scope
+// Tamma:ApiToken; the API writes a slack_outbox row (tenant from ITenantContext,
+// never the body — no tenant↔repo guard, Slack is not repo-scoped) and returns
+// 202. The out-of-band OutboxSlackSender holds the webhook credential, performs
+// the transport, and audits to platform_events. NO Slack token ever reaches here.
+app.MapPost("/api/v1/notifications/slack", NotificationEndpoints.QueueSlack)
+    .RequireAuthorization("EngineServiceOnly")
+    .WithName("QueueSlackNotification");
 app.MapPost("/api/v1/workflows/{id}/status", SaaSEndpoints.UpdateWorkflowStatus).RequireAuthorization();
 app.MapPost("/api/v1/workflows/{id}/result", SaaSEndpoints.PostWorkflowResult).RequireAuthorization();
 app.MapPost("/api/v1/installations/{id}/rotate-key", SaaSEndpoints.RotateInstallationKey).RequireAuthorization();
@@ -2489,6 +2503,7 @@ using (var scope = app.Services.CreateScope())
                     platform_api_key_index,
                     platform_bootstrap,
                     platform_email_outbox, platform_events, platform_queued_tasks,
+                    slack_outbox,
                     prompt_overrides,
                     provider_diagnostics, provider_health, queued_tasks, refresh_tokens,
                     sanitization_rules, stories,

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Notifications/NotificationSlackEventTypes.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Notifications/NotificationSlackEventTypes.cs
@@ -1,0 +1,17 @@
+namespace Tamma.Api.Services.Notifications;
+
+/// <summary>
+/// Story 38-3 — DCB event type constants for the Slack notification outbox
+/// terminal outcomes. Emitted from <c>Tamma.Api</c> (where the credential + the
+/// tenant store live) to <c>platform_events</c> via <c>IPlatformEventRepository</c>
+/// — the CP-outbox audit plane, NOT the tenant event store (mirrors the
+/// <c>OutboxSmtpSender</c> platform-path audit). Payloads are key-free.
+/// </summary>
+public static class NotificationSlackEventTypes
+{
+    /// <summary>Terminal success — the Slack post was delivered by the sender.</summary>
+    public const string Sent = "NOTIFICATION.SLACK.SENT.SUCCESS";
+
+    /// <summary>A delivery attempt failed (transient-with-backoff or terminal).</summary>
+    public const string Failed = "NOTIFICATION.SLACK.SEND.FAILED";
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Notifications/OutboxSlackSender.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Notifications/OutboxSlackSender.cs
@@ -1,0 +1,320 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Tamma.Core.Interfaces;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Notifications;
+
+/// <summary>
+/// Options bound by <c>NotificationServiceCollectionExtensions.AddSlackNotificationServices</c>.
+/// Mirrors <c>OutboxSmtpSenderOptions</c>.
+/// </summary>
+public sealed class OutboxSlackSenderOptions
+{
+    /// <summary>How often the sender polls for pending rows. Default 5s.</summary>
+    public TimeSpan PollInterval { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>Retry backoff schedule; the nth entry applies after the nth failure.</summary>
+    public IReadOnlyList<TimeSpan> BackoffSchedule { get; set; } = new[]
+    {
+        TimeSpan.FromSeconds(60),
+        TimeSpan.FromMinutes(5),
+        TimeSpan.FromMinutes(30),
+        TimeSpan.FromHours(2),
+        TimeSpan.FromHours(6),
+    };
+
+    /// <summary>
+    /// When <c>true</c> (default) the sender starts its poll loop. Tests that assert
+    /// outbox-row state opt out so the loop doesn't race the assertion (mirrors
+    /// <c>OutboxSmtpSenderOptions.RunOnStartup</c>).
+    /// </summary>
+    public bool RunOnStartup { get; set; } = true;
+}
+
+/// <summary>
+/// Story 38-3 (Epic 38, Class D) — the out-of-band Slack notification sender.
+/// The fire-and-forget analogue of <c>OutboxSmtpSender</c> and the SOLE holder of
+/// the Slack webhook credential in the platform: it drains <c>slack_outbox</c> via
+/// <see cref="ISlackOutboxRepository.ClaimNextPendingAsync"/> and performs the
+/// transport through the existing <see cref="ISlackIntegrationService"/> (which
+/// POSTs to <c>Slack:WebhookUrl</c>). Terminal outcomes are audited to
+/// <c>platform_events</c> via <see cref="IPlatformEventRepository"/>:
+/// <list type="bullet">
+///   <item><description><see cref="NotificationSlackEventTypes.Sent"/> on delivery.</description></item>
+///   <item><description><see cref="NotificationSlackEventTypes.Failed"/> on each
+///     failed attempt (transient-with-backoff or terminal).</description></item>
+/// </list>
+///
+/// <para><b>Credential safety (load-bearing):</b> the webhook URL/secret is read
+/// only by <see cref="ISlackIntegrationService"/> (never by this sender), the
+/// message body is not copied into event payloads, and <see cref="Redact"/> strips
+/// the configured webhook URL from any error string before it is stored / logged /
+/// audited.</para>
+/// </summary>
+public sealed class OutboxSlackSender : BackgroundService
+{
+    private const int MaxErrorLength = 500;
+
+    private readonly IServiceProvider _serviceProvider;
+    private readonly OutboxSlackSenderOptions _options;
+    private readonly IConfiguration _config;
+    private readonly ILogger<OutboxSlackSender> _logger;
+
+    public OutboxSlackSender(
+        IServiceProvider serviceProvider,
+        OutboxSlackSenderOptions options,
+        IConfiguration config,
+        ILogger<OutboxSlackSender> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _options = options;
+        _config = config;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Test gate — tests that assert outbox-row state shouldn't race the loop.
+        if (!_options.RunOnStartup)
+        {
+            _logger.LogDebug("OutboxSlackSender gated off (RunOnStartup=false); skipping poll loop.");
+            return;
+        }
+
+        // The webhook is the transport credential — with none configured there is
+        // nothing to deliver, so the sender stays idle (enqueue still works; rows
+        // pile up until a webhook is configured and the process restarts).
+        if (string.IsNullOrWhiteSpace(_config["Slack:WebhookUrl"]))
+        {
+            _logger.LogInformation("OutboxSlackSender disabled (Slack:WebhookUrl not configured)");
+            return;
+        }
+
+        var seconds = _config.GetValue("Slack:OutboxPollIntervalSeconds", 0);
+        if (seconds > 0)
+        {
+            _options.PollInterval = TimeSpan.FromSeconds(seconds);
+        }
+
+        _logger.LogInformation("OutboxSlackSender started. Poll interval={Interval}", _options.PollInterval);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await ProcessOnceAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "OutboxSlackSender cycle failed");
+            }
+
+            try
+            {
+                await Task.Delay(_options.PollInterval, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+
+        _logger.LogInformation("OutboxSlackSender stopped");
+    }
+
+    /// <summary>
+    /// Claim and deliver a single pending row, returning <c>true</c> when a row was
+    /// processed. Exposed for tests so they don't race the polling timer.
+    /// </summary>
+    public async Task<bool> ProcessOnceAsync(CancellationToken ct)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var outbox = scope.ServiceProvider.GetRequiredService<ISlackOutboxRepository>();
+        var slack = scope.ServiceProvider.GetRequiredService<ISlackIntegrationService>();
+        var events = scope.ServiceProvider.GetService<IPlatformEventRepository>();
+
+        var claimed = await outbox.ClaimNextPendingAsync(DateTime.UtcNow, ct).ConfigureAwait(false);
+        if (claimed is null) return false;
+
+        try
+        {
+            var error = await PostAsync(slack, claimed, ct).ConfigureAwait(false);
+            if (error is null)
+            {
+                await outbox.MarkSentAsync(claimed.Id, ct).ConfigureAwait(false);
+                if (events is not null) await EmitSentAsync(events, claimed, ct).ConfigureAwait(false);
+
+                // Purge the row now the durable audit is in platform_events — the
+                // formatted body must not linger past delivery (unbounded growth +
+                // content retention). Mirrors OutboxSmtpSender's delete-on-success.
+                await outbox.DeleteAsync(claimed.Id, ct).ConfigureAwait(false);
+
+                _logger.LogInformation(
+                    "Slack notification delivered outboxId={OutboxId} messageType={MessageType}",
+                    claimed.Id, claimed.MessageType);
+            }
+            else
+            {
+                await HandleFailureAsync(outbox, events, claimed, error, ct).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            await HandleFailureAsync(outbox, events, claimed, Redact(ex.Message), ct).ConfigureAwait(false);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Perform the actual Slack transport for a claimed row. Each row is a SINGLE
+    /// target — a channel XOR a DM (a both-targets intent is split into two rows at
+    /// enqueue, so one leg's retry never re-sends the other). A channel post routes to
+    /// the channel; a DM opens a direct message. Returns <c>null</c> on success, or a
+    /// key-free error string on failure.
+    /// </summary>
+    private static async Task<string?> PostAsync(
+        ISlackIntegrationService slack, SlackOutboxMessage row, CancellationToken ct)
+    {
+        _ = ct; // ISlackIntegrationService does not take a token today; kept for signature symmetry.
+
+        if (!string.IsNullOrWhiteSpace(row.Channel))
+        {
+            var post = await slack.SendSlackMessageAsync(row.Channel!, row.Body).ConfigureAwait(false);
+            return post.Success ? null : (post.Error ?? "slack channel post failed");
+        }
+
+        if (!string.IsNullOrWhiteSpace(row.TargetUserId))
+        {
+            var dm = await slack.SendSlackDirectMessageAsync(row.TargetUserId!, row.Body).ConfigureAwait(false);
+            return dm.Success ? null : (dm.Error ?? "slack dm failed");
+        }
+
+        return "no channel or target user on the outbox row";
+    }
+
+    private async Task HandleFailureAsync(
+        ISlackOutboxRepository outbox,
+        IPlatformEventRepository? events,
+        SlackOutboxMessage row,
+        string error,
+        CancellationToken ct)
+    {
+        var safeError = Redact(error);
+        var attempt = row.Attempts + 1;
+        var backoff = PickBackoff(attempt);
+        var updated = await outbox.MarkFailedAsync(row.Id, safeError, backoff, ct).ConfigureAwait(false);
+
+        var terminal = updated is not null && updated.Status == "failed";
+        if (terminal)
+        {
+            _logger.LogError(
+                "Slack notification permanently failed outboxId={OutboxId} attempts={Attempts}",
+                row.Id, updated!.Attempts);
+        }
+        else
+        {
+            _logger.LogWarning(
+                "Slack notification transient failure outboxId={OutboxId} attempt={Attempt}",
+                row.Id, attempt);
+        }
+
+        if (events is not null)
+        {
+            await EmitFailedAsync(events, row, safeError, terminal, ct).ConfigureAwait(false);
+        }
+
+        if (terminal)
+        {
+            // Retry buffer exhausted — the audit lives in platform_events
+            // (NotificationSlackEventTypes.Failed, terminal=true). The row's body must
+            // not linger, so delete it. Mirrors OutboxSmtpSender's delete-on-terminal.
+            await outbox.DeleteAsync(row.Id, ct).ConfigureAwait(false);
+        }
+    }
+
+    private TimeSpan PickBackoff(int attempt)
+    {
+        if (_options.BackoffSchedule.Count == 0) return TimeSpan.FromMinutes(1);
+        var idx = Math.Min(attempt - 1, _options.BackoffSchedule.Count - 1);
+        idx = Math.Max(idx, 0);
+        return _options.BackoffSchedule[idx];
+    }
+
+    /// <summary>
+    /// Strip the configured Slack webhook URL from an error string and length-bound
+    /// it — the row / event / log must never carry the webhook secret.
+    /// </summary>
+    private string Redact(string? error)
+    {
+        if (string.IsNullOrEmpty(error)) return string.Empty;
+        var webhook = _config["Slack:WebhookUrl"];
+        var cleaned = error;
+        if (!string.IsNullOrWhiteSpace(webhook))
+        {
+            cleaned = cleaned.Replace(webhook, "[redacted-webhook]", StringComparison.OrdinalIgnoreCase);
+        }
+        return cleaned.Length > MaxErrorLength ? cleaned[..MaxErrorLength] : cleaned;
+    }
+
+    private static Task EmitSentAsync(
+        IPlatformEventRepository events, SlackOutboxMessage row, CancellationToken ct)
+    {
+        var data = new Dictionary<string, object?>
+        {
+            ["provider"] = "slack-webhook",
+            ["attempts"] = row.Attempts + 1,
+            ["bodyLength"] = row.Body?.Length ?? 0,
+        };
+        return AppendAsync(events, NotificationSlackEventTypes.Sent, row, data, ct);
+    }
+
+    private static Task EmitFailedAsync(
+        IPlatformEventRepository events, SlackOutboxMessage row, string safeError, bool terminal, CancellationToken ct)
+    {
+        var data = new Dictionary<string, object?>
+        {
+            ["provider"] = "slack-webhook",
+            ["attempts"] = row.Attempts + 1,
+            ["terminal"] = terminal,
+            ["failureReason"] = safeError,
+        };
+        return AppendAsync(events, NotificationSlackEventTypes.Failed, row, data, ct);
+    }
+
+    private static async Task AppendAsync(
+        IPlatformEventRepository events,
+        string type,
+        SlackOutboxMessage row,
+        Dictionary<string, object?> data,
+        CancellationToken ct)
+    {
+        var tags = new Dictionary<string, string?>
+        {
+            ["outbox_id"] = row.Id.ToString(),
+            ["message_type"] = row.MessageType,
+            ["channel"] = row.Channel,
+            ["target_user"] = row.TargetUserId,
+            ["tenant_id"] = row.TenantId?.ToString(),
+            ["user_id"] = row.UserId?.ToString(),
+            ["scope"] = "platform",
+        };
+
+        await events.AppendAsync(new PlatformEvent
+        {
+            Type = type,
+            TenantId = row.TenantId,
+            UserId = row.UserId,
+            Tags = JsonSerializer.Serialize(tags),
+            Metadata = """{"eventSource":"system"}""",
+            Data = JsonSerializer.Serialize(data),
+        }, ct).ConfigureAwait(false);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
@@ -504,6 +504,15 @@ public class ControlPlaneDbContext : DbContext
     public DbSet<PlatformEmailOutboxMessage> PlatformEmailOutbox => Set<PlatformEmailOutboxMessage>();
 
     /// <summary>
+    /// Story 38-3 — control-plane Slack notification outbox. The fire-and-forget
+    /// analogue of <see cref="PlatformEmailOutbox"/>; the engine writes intent via
+    /// <c>POST /api/v1/notifications/slack</c> and <c>OutboxSlackSender</c> (the
+    /// sole webhook-credential holder) drains it. CP-resident so it delivers
+    /// regardless of tenant-DB routing (same rationale as the email outbox).
+    /// </summary>
+    public DbSet<SlackOutboxMessage> SlackOutbox => Set<SlackOutboxMessage>();
+
+    /// <summary>
     /// Story 28-10 fact table — one row per <c>(Hour, TenantId)</c> tuple,
     /// populated hourly by <c>HourlyAnalyticsRollupWorkflow</c>. Platform-wide
     /// rows carry <c>TenantId = null</c>. See

--- a/apps/tamma-elsa/src/Tamma.Data/DependencyInjection.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/DependencyInjection.cs
@@ -175,6 +175,8 @@ public static class DependencyInjection
         services.TryAddScoped<IPlatformEventRepository, PlatformEventRepository>();
         services.TryAddScoped<IPlatformQueuedTaskRepository, PlatformQueuedTaskRepository>();
         services.TryAddScoped<IPlatformEmailOutboxRepository, PlatformEmailOutboxRepository>();
+        // Story 38-3 — control-plane Slack notification outbox repository.
+        services.TryAddScoped<ISlackOutboxRepository, SlackOutboxRepository>();
 
         return services;
     }

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/SlackOutboxMessage.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/SlackOutboxMessage.cs
@@ -1,0 +1,55 @@
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 38-3 (Epic 38, Class D) — control-plane Slack notification outbox.
+/// The fire-and-forget analogue of <see cref="PlatformEmailOutboxMessage"/>:
+/// the engine's <c>SlackActivity</c> no longer holds the Slack credential;
+/// it posts the (already-formatted) notification intent to
+/// <c>POST /api/v1/notifications/slack</c>, which writes one <c>pending</c>
+/// row here. The out-of-band <c>OutboxSlackSender</c> — the ONLY holder of the
+/// Slack webhook credential — drains this table and performs the transport.
+///
+/// <para>Control-plane / public-schema table (it must deliver regardless of
+/// tenant-DB routing, same rationale as <c>platform_email_outbox</c>). Owner
+/// scope is <c>TenantId</c> XOR <c>UserId</c> (SaaS → <c>TenantId</c> from
+/// <c>X-Tenant-Id</c>; single-user → <c>UserId</c>), exactly like the email
+/// outbox. Terminal outcomes are audited to <c>platform_events</c>; the row,
+/// its <see cref="LastError"/>, and every event payload are token-free by
+/// contract (the webhook URL/secret is never written here).</para>
+/// </summary>
+public sealed class SlackOutboxMessage
+{
+    public Guid Id { get; set; }
+
+    /// <summary>SaaS-mode owner scope. XOR with <see cref="UserId"/>.</summary>
+    public Guid? TenantId { get; set; }
+
+    /// <summary>Single-user-mode owner scope. XOR with <see cref="TenantId"/>.</summary>
+    public Guid? UserId { get; set; }
+
+    /// <summary>Target channel for a channel post (null for a DM-only intent).</summary>
+    public string? Channel { get; set; }
+
+    /// <summary>Target Slack user id for a DM (null for a channel-only intent). NOT a Tamma UserId.</summary>
+    public string? TargetUserId { get; set; }
+
+    /// <summary>Message type carried for audit (Info|Warning|Success|Error|Celebration). Formatting is applied engine-side.</summary>
+    public string MessageType { get; set; } = "Info";
+
+    /// <summary>The already-formatted message body (emoji/assessment/guidance templating done engine-side; token-free).</summary>
+    public string Body { get; set; } = null!;
+
+    /// <summary>pending | sending | sent | failed.</summary>
+    public string Status { get; set; } = "pending";
+
+    public int Attempts { get; set; }
+    public int MaxAttempts { get; set; } = 5;
+    public DateTime NextAttemptAt { get; set; }
+
+    /// <summary>Last transport error — key-free (webhook URL/secret redacted before write).</summary>
+    public string? LastError { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public DateTime? SentAt { get; set; }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260701164208_AddSlackOutbox.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260701164208_AddSlackOutbox.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.ControlPlane
 {
     [DbContext(typeof(ControlPlaneDbContext))]
-    partial class ControlPlaneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260701164208_AddSlackOutbox")]
+    partial class AddSlackOutbox
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260701164208_AddSlackOutbox.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260701164208_AddSlackOutbox.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.ControlPlane
+{
+    /// <inheritdoc />
+    public partial class AddSlackOutbox : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "slack_outbox",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: true),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: true),
+                    Channel = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    TargetUserId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    MessageType = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false, defaultValue: "Info"),
+                    Body = table.Column<string>(type: "text", nullable: false),
+                    Status = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false, defaultValue: "pending"),
+                    Attempts = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    MaxAttempts = table.Column<int>(type: "integer", nullable: false, defaultValue: 5),
+                    NextAttemptAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    LastError = table.Column<string>(type: "text", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    SentAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_slack_outbox", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_slack_outbox_Status_NextAttemptAt",
+                table: "slack_outbox",
+                columns: new[] { "Status", "NextAttemptAt" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "slack_outbox");
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/ISlackOutboxRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/ISlackOutboxRepository.cs
@@ -1,0 +1,47 @@
+using Tamma.Data.Entities;
+
+namespace Tamma.Data.Repositories;
+
+/// <summary>
+/// Story 38-3 — persistence port for the control-plane Slack notification
+/// outbox (<see cref="SlackOutboxMessage"/>). The fire-and-forget analogue of
+/// <see cref="IPlatformEmailOutboxRepository"/>: the mediation endpoint enqueues
+/// intent and <c>OutboxSlackSender</c> claims-then-delivers with the same
+/// reservation contract (<c>FOR UPDATE SKIP LOCKED</c> on Postgres).
+/// </summary>
+public interface ISlackOutboxRepository
+{
+    /// <summary>
+    /// Insert a new message in <c>pending</c> state and return the persisted row.
+    /// The returned <see cref="SlackOutboxMessage.Id"/> is the outbox id the
+    /// endpoint returns and audit events tag.
+    /// </summary>
+    Task<SlackOutboxMessage> EnqueueAsync(SlackOutboxMessage msg, CancellationToken ct = default);
+
+    /// <summary>
+    /// Atomically claim the next <c>pending</c> row whose <c>NextAttemptAt</c> is
+    /// at or before <paramref name="now"/>, flipping it to <c>sending</c>. Returns
+    /// <c>null</c> when nothing is due. Postgres path uses <c>FOR UPDATE SKIP
+    /// LOCKED</c> so concurrent senders are cluster-safe; the in-memory fallback is
+    /// single-writer (test-only).
+    /// </summary>
+    Task<SlackOutboxMessage?> ClaimNextPendingAsync(DateTime now, CancellationToken ct = default);
+
+    /// <summary>Mark a claimed message delivered (<c>Status=sent</c> + <c>SentAt</c>).</summary>
+    Task MarkSentAsync(Guid id, CancellationToken ct = default);
+
+    /// <summary>
+    /// Record a transport failure. Increments <c>Attempts</c>; under the ceiling
+    /// reschedules with <paramref name="backoff"/>; at the ceiling flips to
+    /// <c>failed</c>. Returns the updated row so the caller can react to the
+    /// terminal outcome. <paramref name="error"/> must already be key-free.
+    /// </summary>
+    Task<SlackOutboxMessage?> MarkFailedAsync(
+        Guid id, string error, TimeSpan? backoff, CancellationToken ct = default);
+
+    /// <summary>Read by id, or <c>null</c>.</summary>
+    Task<SlackOutboxMessage?> GetByIdAsync(Guid id, CancellationToken ct = default);
+
+    /// <summary>Permanently remove a row.</summary>
+    Task DeleteAsync(Guid id, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/SlackOutboxRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/SlackOutboxRepository.cs
@@ -1,0 +1,138 @@
+using Microsoft.EntityFrameworkCore;
+using Tamma.Data.Entities;
+
+namespace Tamma.Data.Repositories;
+
+/// <summary>
+/// Story 38-3 — EF-backed <see cref="ISlackOutboxRepository"/> bound to
+/// <see cref="ControlPlaneDbContext"/>. Mirrors
+/// <see cref="PlatformEmailOutboxRepository"/>'s claim-then-deliver shape so
+/// <c>OutboxSlackSender</c> drains the queue exactly like the SMTP sender.
+/// </summary>
+public sealed class SlackOutboxRepository : ISlackOutboxRepository
+{
+    private const string NpgsqlProviderName = "Npgsql.EntityFrameworkCore.PostgreSQL";
+
+    private readonly ControlPlaneDbContext _db;
+
+    public SlackOutboxRepository(ControlPlaneDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<SlackOutboxMessage> EnqueueAsync(
+        SlackOutboxMessage msg, CancellationToken ct = default)
+    {
+        if (msg is null) throw new ArgumentNullException(nameof(msg));
+
+        var now = DateTime.UtcNow;
+        msg.Status = "pending";
+        msg.Attempts = 0;
+        msg.LastError = null;
+        msg.SentAt = null;
+        if (msg.NextAttemptAt == default) msg.NextAttemptAt = now;
+        msg.CreatedAt = now;
+        msg.UpdatedAt = now;
+        if (msg.MaxAttempts <= 0) msg.MaxAttempts = 5;
+        if (string.IsNullOrWhiteSpace(msg.MessageType)) msg.MessageType = "Info";
+
+        _db.SlackOutbox.Add(msg);
+        await _db.SaveChangesAsync(ct);
+        return msg;
+    }
+
+    public async Task<SlackOutboxMessage?> ClaimNextPendingAsync(
+        DateTime now, CancellationToken ct = default)
+    {
+        if (string.Equals(_db.Database.ProviderName, NpgsqlProviderName, StringComparison.Ordinal))
+        {
+            return await ClaimViaPostgresAsync(now, ct);
+        }
+
+        return await ClaimViaNaivePathAsync(now, ct);
+    }
+
+    private async Task<SlackOutboxMessage?> ClaimViaPostgresAsync(DateTime now, CancellationToken ct)
+    {
+        var rows = await _db.SlackOutbox.FromSqlInterpolated($"""
+            UPDATE slack_outbox
+            SET "Status" = 'sending', "UpdatedAt" = {now}
+            WHERE "Id" = (
+                SELECT "Id" FROM slack_outbox
+                WHERE "Status" = 'pending'
+                  AND "NextAttemptAt" <= {now}
+                ORDER BY "NextAttemptAt" ASC, "CreatedAt" ASC
+                FOR UPDATE SKIP LOCKED
+                LIMIT 1
+            )
+            RETURNING *
+            """).AsNoTracking().ToListAsync(ct);
+
+        return rows.FirstOrDefault();
+    }
+
+    private async Task<SlackOutboxMessage?> ClaimViaNaivePathAsync(DateTime now, CancellationToken ct)
+    {
+        var candidate = await _db.SlackOutbox
+            .Where(m => m.Status == "pending" && m.NextAttemptAt <= now)
+            .OrderBy(m => m.NextAttemptAt)
+            .ThenBy(m => m.CreatedAt)
+            .FirstOrDefaultAsync(ct);
+
+        if (candidate is null) return null;
+
+        candidate.Status = "sending";
+        candidate.UpdatedAt = now;
+        await _db.SaveChangesAsync(ct);
+        return candidate;
+    }
+
+    public async Task MarkSentAsync(Guid id, CancellationToken ct = default)
+    {
+        var msg = await _db.SlackOutbox.FindAsync(new object[] { id }, ct);
+        if (msg is null) return;
+
+        var now = DateTime.UtcNow;
+        msg.Status = "sent";
+        msg.LastError = null;
+        msg.SentAt = now;
+        msg.UpdatedAt = now;
+        await _db.SaveChangesAsync(ct);
+    }
+
+    public async Task<SlackOutboxMessage?> MarkFailedAsync(
+        Guid id, string error, TimeSpan? backoff, CancellationToken ct = default)
+    {
+        var msg = await _db.SlackOutbox.FindAsync(new object[] { id }, ct);
+        if (msg is null) return null;
+
+        var now = DateTime.UtcNow;
+        msg.Attempts += 1;
+        msg.LastError = error;
+        msg.UpdatedAt = now;
+
+        if (msg.Attempts < msg.MaxAttempts)
+        {
+            msg.Status = "pending";
+            msg.NextAttemptAt = now + (backoff ?? TimeSpan.FromMinutes(1));
+        }
+        else
+        {
+            msg.Status = "failed";
+        }
+
+        await _db.SaveChangesAsync(ct);
+        return msg;
+    }
+
+    public async Task<SlackOutboxMessage?> GetByIdAsync(Guid id, CancellationToken ct = default)
+        => await _db.SlackOutbox.FindAsync(new object[] { id }, ct);
+
+    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+    {
+        var row = await _db.SlackOutbox.FindAsync(new object[] { id }, ct);
+        if (row is null) return;
+        _db.SlackOutbox.Remove(row);
+        await _db.SaveChangesAsync(ct);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
@@ -680,6 +680,30 @@ internal static class TammaModelConfiguration
                 .HasDatabaseName("UX_platform_email_outbox_tenant_template_active");
         });
 
+        // ── SlackOutboxMessage (Story 38-3) ──
+        // The fire-and-forget Slack analogue of platform_email_outbox. CP-resident
+        // so it delivers regardless of tenant-DB routing; the body is already
+        // formatted engine-side (token-free) and LastError is key-free.
+        modelBuilder.Entity<SlackOutboxMessage>(entity =>
+        {
+            entity.ToTable("slack_outbox");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+            entity.Property(e => e.Channel).HasMaxLength(255);
+            entity.Property(e => e.TargetUserId).HasMaxLength(255);
+            entity.Property(e => e.MessageType).IsRequired().HasMaxLength(32).HasDefaultValue("Info");
+            entity.Property(e => e.Body).IsRequired();
+            entity.Property(e => e.Status).IsRequired().HasMaxLength(20).HasDefaultValue("pending");
+            entity.Property(e => e.Attempts).HasDefaultValue(0);
+            entity.Property(e => e.MaxAttempts).HasDefaultValue(5);
+            entity.Property(e => e.NextAttemptAt).HasDefaultValueSql("now()");
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("now()");
+
+            // Claim scan — the OutboxSlackSender polls pending rows due for delivery.
+            entity.HasIndex(e => new { e.Status, e.NextAttemptAt });
+        });
+
         // ── AdminImpersonation (Story 28-R2 follow-up B) ──
         //
         // SOC2 / ISO 27001 audit row: each platform-admin impersonation
@@ -1184,6 +1208,9 @@ internal static class TammaModelConfiguration
             modelBuilder.Ignore<PlatformEvent>();
             modelBuilder.Ignore<PlatformQueuedTask>();
             modelBuilder.Ignore<PlatformEmailOutboxMessage>();
+            // Story 38-3 — slack_outbox is CP-resident; keep it out of the tenant
+            // model graph (mirrors platform_email_outbox above).
+            modelBuilder.Ignore<SlackOutboxMessage>();
         }
 
         // ── AgentConfig ──

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Integration/SlackActivityThinClientTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Integration/SlackActivityThinClientTests.cs
@@ -1,0 +1,236 @@
+using System.Reflection;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Activities.Integration;
+using Tamma.Activities.LlmCall.Models;
+using Tamma.Core.Entities;
+using Tamma.Core.Interfaces;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Activities.Tests.Integration;
+
+/// <summary>
+/// Story 38-3 (AC5/AC6/AC10) — <c>SlackActivity</c> is now a THIN
+/// <c>TammaApiClient</c> client. These tests cover the engine-side formatting +
+/// plan mapping, the enqueue → <see cref="SlackOperationResult"/> projection
+/// (outputs preserved, <c>Success</c> = enqueued), the kept <c>MentorshipEvent</c>
+/// session-log write, the fail-soft null-enqueue path, and the cutover proof:
+/// the activity injects no Slack-credential-holding integration service.
+/// </summary>
+[TestFixture]
+public class SlackActivityThinClientTests
+{
+    private static SlackNotificationRequest? _captured;
+
+    private static Func<SlackNotificationRequest, string?, CancellationToken, Task<bool>> Enqueue(bool result)
+        => (req, _, _) => { _captured = req; return Task.FromResult(result); };
+
+    [SetUp]
+    public void Reset() => _captured = null;
+
+    // ── BuildPlan formatting + routing (AC5) ──────────────────────────────────
+
+    [Test]
+    public void BuildPlan_SendChannel_EmojiPrefixesBody_RoutesToChannel()
+    {
+        var plan = SlackActivity.BuildPlan(SlackAction.SendChannel, "eng", null, "green", MessageType.Success)!;
+        plan.Body.Should().Be(":white_check_mark: green");
+        plan.Channel.Should().Be("eng");
+        plan.TargetUserId.Should().BeNull();
+        plan.Destination.Should().Be("eng");
+        plan.WaitingForResponse.Should().BeFalse();
+    }
+
+    [Test]
+    public void BuildPlan_SendDirect_RoutesToTargetUser()
+    {
+        var plan = SlackActivity.BuildPlan(SlackAction.SendDirect, null, "U9", "hi", MessageType.Info)!;
+        plan.Body.Should().Be(":information_source: hi");
+        plan.TargetUserId.Should().Be("U9");
+        plan.Channel.Should().BeNull();
+        plan.Destination.Should().Be("U9");
+    }
+
+    [Test]
+    public void BuildPlan_SendAssessment_UsesAssessmentTemplate_And_WaitsForResponse()
+    {
+        var plan = SlackActivity.BuildPlan(SlackAction.SendAssessment, null, "U9", "Q1?", MessageType.Info)!;
+        plan.Body.Should().Contain("**Tamma Assessment Request**").And.Contain("Q1?");
+        plan.TargetUserId.Should().Be("U9");
+        plan.WaitingForResponse.Should().BeTrue("the assessment action awaits the junior's reply");
+    }
+
+    [Test]
+    public void BuildPlan_SendGuidance_UsesGuidanceTemplate()
+    {
+        var plan = SlackActivity.BuildPlan(SlackAction.SendGuidance, null, "U9", "do X", MessageType.Info)!;
+        plan.Body.Should().Contain("**Tamma Guidance**").And.Contain("do X");
+        plan.WaitingForResponse.Should().BeFalse();
+    }
+
+    [Test]
+    public void BuildPlan_SendNotification_CarriesBothTargets()
+    {
+        var plan = SlackActivity.BuildPlan(SlackAction.SendNotification, "eng", "U9", "note", MessageType.Warning)!;
+        plan.Channel.Should().Be("eng");
+        plan.TargetUserId.Should().Be("U9");
+        plan.Destination.Should().Be("U9");
+    }
+
+    // ── Slack control-char escaping (FIX 4 — mention/broadcast injection) ──────
+
+    [Test]
+    public void FormatMessage_EscapesBroadcastAndMentionTokens_LeavesOurPrefix()
+    {
+        var body = SlackActivity.FormatMessage("<!channel> ping <@U123> & <b>", MessageType.Info);
+
+        body.Should().StartWith(":information_source: ", "our own emoji prefix is not escaped");
+        body.Should().NotContain("<!channel>", "the broadcast token must be neutralized");
+        body.Should().NotContain("<@U123>", "the mention token must be neutralized");
+        body.Should().Contain("&lt;!channel&gt;");
+        body.Should().Contain("&lt;@U123&gt;");
+        body.Should().Contain("&amp;");
+    }
+
+    [Test]
+    public void FormatAssessment_EscapesBroadcastToken_KeepsTemplateLabel()
+    {
+        var body = SlackActivity.FormatAssessment("please review <!here> now");
+
+        body.Should().Contain("**Tamma Assessment Request**", "the template label is our own, not escaped");
+        body.Should().NotContain("<!here>");
+        body.Should().Contain("&lt;!here&gt;");
+    }
+
+    [Test]
+    public void FormatGuidance_EscapesMentionToken()
+    {
+        var body = SlackActivity.FormatGuidance("ask <@U777> for help");
+
+        body.Should().Contain("**Tamma Guidance**");
+        body.Should().NotContain("<@U777>");
+        body.Should().Contain("&lt;@U777&gt;");
+    }
+
+    // ── ExecuteCoreAsync enqueue + output projection (AC5) ─────────────────────
+
+    [Test]
+    public async Task ExecuteCore_Enqueues_MapsRequest_And_ProjectsSuccessOutputs()
+    {
+        var result = await SlackActivity.ExecuteCoreAsync(
+            SlackAction.SendChannel, "eng", null, "green", MessageType.Success,
+            sessionId: null, tenantId: "t-1", Enqueue(true), repository: null, CancellationToken.None);
+
+        result.Success.Should().BeTrue("Success now means enqueued");
+        result.Destination.Should().Be("eng");
+        result.WaitingForResponse.Should().BeFalse();
+
+        _captured.Should().NotBeNull();
+        _captured!.Action.Should().Be("SendChannel");
+        _captured.Channel.Should().Be("eng");
+        _captured.Message.Should().Be(":white_check_mark: green");
+        _captured.MessageType.Should().Be("Success");
+    }
+
+    [Test]
+    public async Task ExecuteCore_Assessment_WaitingForResponse_TrueOnQueued()
+    {
+        var result = await SlackActivity.ExecuteCoreAsync(
+            SlackAction.SendAssessment, null, "U9", "Q1?", MessageType.Info,
+            sessionId: null, tenantId: null, Enqueue(true), repository: null, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.WaitingForResponse.Should().BeTrue();
+        _captured!.Message.Should().Contain("Q1?");
+    }
+
+    [Test]
+    public async Task ExecuteCore_WritesMentorshipEvent_OnQueuedSuccess_WithSession()
+    {
+        var sid = Guid.NewGuid();
+        var repo = new Mock<IMentorshipSessionRepository>();
+        repo.Setup(r => r.LogEventAsync(It.IsAny<MentorshipEvent>()))
+            .ReturnsAsync((MentorshipEvent e) => e);
+
+        var result = await SlackActivity.ExecuteCoreAsync(
+            SlackAction.SendDirect, null, "U9", "hi", MessageType.Info,
+            sessionId: sid, tenantId: null, Enqueue(true), repo.Object, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        repo.Verify(r => r.LogEventAsync(
+            It.Is<MentorshipEvent>(e => e.SessionId == sid && e.EventType == EventTypes.Info)),
+            Times.Once, "the local session log is kept and fires on enqueue-success");
+    }
+
+    // ── Fail-soft (AC10) ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task ExecuteCore_FailSoft_WhenEnqueueReturnsFalse()
+    {
+        var sid = Guid.NewGuid();
+        var repo = new Mock<IMentorshipSessionRepository>();
+
+        var result = await SlackActivity.ExecuteCoreAsync(
+            SlackAction.SendAssessment, null, "U9", "Q1?", MessageType.Info,
+            sessionId: sid, tenantId: null, Enqueue(false), repo.Object, CancellationToken.None);
+
+        result.Success.Should().BeFalse("a failed enqueue is fail-soft, not a throw");
+        result.Message.Should().Be("Notification queue failed");
+        result.WaitingForResponse.Should().BeFalse("do not wait when the enqueue failed");
+        result.Destination.Should().Be("U9");
+
+        repo.Verify(r => r.LogEventAsync(It.IsAny<MentorshipEvent>()), Times.Never,
+            "no session log write when the notification wasn't queued");
+    }
+
+    // ── Cutover proof (AC6) ───────────────────────────────────────────────────
+
+    [Test]
+    public void SlackActivity_HasNoIntegrationServiceConstructorParameter()
+    {
+        foreach (var ctor in typeof(SlackActivity).GetConstructors())
+        {
+            ctor.GetParameters()
+                .Any(p => typeof(IIntegrationService).IsAssignableFrom(p.ParameterType)
+                       || typeof(ISlackIntegrationService).IsAssignableFrom(p.ParameterType))
+                .Should().BeFalse("SlackActivity must not inject a Slack-credential integration service");
+        }
+    }
+
+    [Test]
+    public void SlackActivity_HasNoIntegrationServiceField()
+    {
+        typeof(SlackActivity)
+            .GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+            .Any(f => typeof(IIntegrationService).IsAssignableFrom(f.FieldType)
+                   || typeof(ISlackIntegrationService).IsAssignableFrom(f.FieldType))
+            .Should().BeFalse("SlackActivity must hold no Slack-credential integration-service field");
+    }
+
+    [Test]
+    public void SlackActivitySource_MakesNoDirectSlackCall()
+    {
+        var root = FindActivitiesRoot();
+        root.Should().NotBeNull();
+        var text = File.ReadAllText(Path.Combine(root!, "Integration", "SlackActivity.cs"));
+
+        text.Should().NotContain("GetService<IIntegrationService>");
+        text.Should().NotContain("GetRequiredService<IIntegrationService>");
+        text.Should().NotContain("SendSlackMessageAsync");
+        text.Should().NotContain("SendSlackDirectMessageAsync");
+        text.Should().NotContain("_integrationService");
+    }
+
+    private static string? FindActivitiesRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "src", "Tamma.Activities");
+            if (Directory.Exists(candidate)) return candidate;
+            dir = dir.Parent;
+        }
+        return null;
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
@@ -66,6 +66,10 @@ public class ControlPlaneDbContextModelTests
             "platform_events",
             "platform_queued_tasks",
             "platform_email_outbox",
+            // Story 38-3 — control-plane Slack notification outbox (Class D
+            // step-mediation). CP-resident so it delivers regardless of tenant-DB
+            // routing (same rationale as platform_email_outbox).
+            "slack_outbox",
             // Story 28-7 — bearer-token routing index.
             "platform_api_key_index",
             // Story 28-10 — hourly analytics fact table.
@@ -141,7 +145,8 @@ public class ControlPlaneDbContextModelTests
             + "Story 34-1 adds plan_features + plan_entitlements + plan_prices. "
             + "Story 35-1 adds billing_customers + billing_plan_prices. "
             + "Story 37-1 adds audit_records + audit_projector_cursor. "
-            + "Story 34-11 adds providers + provider_model_prices.");
+            + "Story 34-11 adds providers + provider_model_prices. "
+            + "Story 38-3 adds slack_outbox.");
     }
 
     // ── Story 34-11 — provider cost price-book model shape ──

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Infrastructure/AlertHostedServiceTestExtensions.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Infrastructure/AlertHostedServiceTestExtensions.cs
@@ -6,6 +6,7 @@ using Tamma.Api.Services.Alerts.Rules;
 using Tamma.Api.Services.Conventions;
 using Tamma.Api.Services.Email;
 using Tamma.Api.Services.Engine.Lifecycle;
+using Tamma.Api.Services.Notifications;
 using Tamma.Api.Services.PlatformTasks;
 using Tamma.Api.Services.Providers;
 using Tamma.Api.Services.TaskQueue;
@@ -84,6 +85,14 @@ internal static class AlertHostedServiceTestExtensions
             // override per-fixture.
             services.RemoveAll<OutboxSmtpSenderOptions>();
             services.AddSingleton(new OutboxSmtpSenderOptions
+            {
+                RunOnStartup = false,
+            });
+
+            // Story 38-3 — gate the Slack notification outbox sender the same way
+            // so it never races endpoint tests asserting slack_outbox row state.
+            services.RemoveAll<OutboxSlackSenderOptions>();
+            services.AddSingleton(new OutboxSlackSenderOptions
             {
                 RunOnStartup = false,
             });

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Notifications/NotificationEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Notifications/NotificationEndpointsTests.cs
@@ -1,0 +1,362 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Auth;
+using Tamma.Api.Tests.Infrastructure;
+using Tamma.Core.Interfaces;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Notifications;
+
+/// <summary>
+/// Story 38-3 (AC1/AC2) — HTTP tests for <c>POST /api/v1/notifications/slack</c>
+/// via <see cref="WebApplicationFactory{TEntryPoint}"/>. Same engine-only plane
+/// as <c>/api/v1/llm/call</c>: a missing/invalid bearer ⇒ 401, a non-engine (user)
+/// principal ⇒ 403 — both BEFORE the handler. The outbox
+/// (<see cref="ISlackOutboxRepository"/>) is a capturing fake so these tests
+/// exercise ONLY the endpoint: auth, the auth-derived tenant scope (never the
+/// body), the intent-write, the 202 envelope, and that Slack is NEVER called
+/// synchronously in the request path.
+/// </summary>
+[TestFixture]
+public class NotificationEndpointsTests
+{
+    private const string TestBearer = "engine-callback-token";
+    private const string UserBearer = "tenant-user-token";
+    private const string Route = "/api/v1/notifications/slack";
+
+    private WebApplicationFactory<Program> _factory = null!;
+    private CapturingSlackOutboxRepository _outbox = null!;
+    private Mock<ISlackIntegrationService> _slack = null!;
+    private StubTenantContext _tenantContext = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _outbox = new CapturingSlackOutboxRepository();
+        _slack = new Mock<ISlackIntegrationService>(MockBehavior.Strict);
+        _tenantContext = new StubTenantContext();
+
+        _factory = ApiTestFixture.Factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Development");
+            builder.DisableAlertHostedServices();
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<ISlackOutboxRepository>();
+                services.AddScoped<ISlackOutboxRepository>(_ => _outbox);
+
+                // Strict mock — any synchronous Slack call in the request path fails the test.
+                services.RemoveAll<ISlackIntegrationService>();
+                services.AddScoped<ISlackIntegrationService>(_ => _slack.Object);
+
+                services.RemoveAll<ITenantContext>();
+                services.AddScoped<ITenantContext>(_ => _tenantContext);
+
+                services.AddAuthentication(TestEngineAuthHandler.SchemeName)
+                    .AddScheme<AuthenticationSchemeOptions, TestEngineAuthHandler>(
+                        TestEngineAuthHandler.SchemeName, _ => { });
+
+                services.AddHttpContextAccessor();
+                services.AddSingleton<IAuthorizationHandler, ServicePrincipalHandler>();
+
+                services.AddAuthorization(options =>
+                {
+                    options.DefaultPolicy = new AuthorizationPolicyBuilder()
+                        .AddAuthenticationSchemes(TestEngineAuthHandler.SchemeName)
+                        .RequireAuthenticatedUser()
+                        .Build();
+                    options.AddPolicy("EngineServiceOnly", p =>
+                    {
+                        p.AddAuthenticationSchemes(TestEngineAuthHandler.SchemeName);
+                        p.RequireAuthenticatedUser();
+                        p.AddRequirements(new ServicePrincipalRequirement());
+                    });
+                });
+            });
+        });
+    }
+
+    [TearDown]
+    public void TearDown() => _factory?.Dispose();
+
+    private HttpClient AuthedClient()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", TestBearer);
+        return client;
+    }
+
+    private static object ChannelBody() => new
+    {
+        action = "SendChannel",
+        channel = "eng-updates",
+        message = ":information_source: build green",
+        messageType = "Info",
+    };
+
+    // -----------------------------------------------------------------------
+    // AC1 — auth
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task Post_NoBearer_Returns401_HandlerNotReached()
+    {
+        using var client = _factory.CreateClient();
+        var resp = await client.PostAsJsonAsync(Route, ChannelBody());
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        _outbox.Enqueued.Should().BeEmpty("the handler must not run when the bearer is missing");
+    }
+
+    [Test]
+    public async Task Post_InvalidBearer_Returns401_HandlerNotReached()
+    {
+        using var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "nope");
+        var resp = await client.PostAsJsonAsync(Route, ChannelBody());
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        _outbox.Enqueued.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task Post_NonEnginePrincipal_Returns403_HandlerNotReached()
+    {
+        using var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", UserBearer);
+        var resp = await client.PostAsJsonAsync(Route, ChannelBody());
+        resp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        _outbox.Enqueued.Should().BeEmpty();
+    }
+
+    // -----------------------------------------------------------------------
+    // AC2 — writes intent, returns 202, never calls Slack synchronously
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task Post_ValidBearer_WritesPendingRow_Returns202_And_DoesNotCallSlack()
+    {
+        var tenant = Guid.NewGuid();
+        _tenantContext.SetTenantId(tenant);
+
+        using var client = AuthedClient();
+        client.DefaultRequestHeaders.Add("X-Tenant-Id", tenant.ToString());
+
+        var resp = await client.PostAsJsonAsync(Route, new
+        {
+            action = "SendDirect",
+            userId = "U123",
+            message = ":x: something failed",
+            messageType = "Error",
+        });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("outboxId").GetGuid().Should().NotBe(Guid.Empty);
+
+        _outbox.Enqueued.Should().ContainSingle();
+        var row = _outbox.Enqueued[0];
+        row.Status.Should().Be("pending");
+        row.TenantId.Should().Be(tenant, "the acting tenant comes from ITenantContext, not the body");
+        row.UserId.Should().BeNull();
+        row.TargetUserId.Should().Be("U123");
+        row.Channel.Should().BeNull();
+        row.MessageType.Should().Be("Error");
+        row.Body.Should().Be(":x: something failed");
+
+        // AC2 — the endpoint never posts to Slack synchronously (strict mock: any
+        // call would have thrown before we got here).
+        _slack.VerifyNoOtherCalls();
+    }
+
+    [Test]
+    public async Task Post_SingleUser_NoTenantHeader_WritesRowWithNullTenant()
+    {
+        // No X-Tenant-Id → single-user/platform scope; the row carries TenantId null.
+        using var client = AuthedClient();
+
+        var resp = await client.PostAsJsonAsync(Route, ChannelBody());
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        _outbox.Enqueued.Should().ContainSingle();
+        _outbox.Enqueued[0].TenantId.Should().BeNull();
+        _outbox.Enqueued[0].Channel.Should().Be("eng-updates");
+        _slack.VerifyNoOtherCalls();
+    }
+
+    // -----------------------------------------------------------------------
+    // FIX 1 — a both-targets intent splits into two independent single-target rows
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task Post_BothTargets_WritesTwoRows_OneChannelOnly_OneDmOnly()
+    {
+        using var client = AuthedClient();
+
+        var resp = await client.PostAsJsonAsync(Route, new
+        {
+            action = "SendNotification",
+            channel = "eng-updates",
+            userId = "U123",
+            message = ":warning: heads up",
+            messageType = "Warning",
+        });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("outboxIds").GetArrayLength().Should().Be(2);
+
+        _outbox.Enqueued.Should().HaveCount(2);
+        _outbox.Enqueued.Should().ContainSingle(
+            r => r.Channel == "eng-updates" && r.TargetUserId == null,
+            "the channel leg is a channel-only row");
+        _outbox.Enqueued.Should().ContainSingle(
+            r => r.TargetUserId == "U123" && r.Channel == null,
+            "the DM leg is a DM-only row");
+        _slack.VerifyNoOtherCalls();
+    }
+
+    // -----------------------------------------------------------------------
+    // FIX 3 — both targets blank is rejected before any row is written
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task Post_NoChannelAndNoUser_Returns400_NoRowWritten()
+    {
+        using var client = AuthedClient();
+
+        var resp = await client.PostAsJsonAsync(Route, new
+        {
+            action = "SendNotification",
+            message = ":x: orphaned",
+            messageType = "Error",
+        });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        _outbox.Enqueued.Should().BeEmpty("a row with no target could only burn every retry");
+    }
+
+    // -----------------------------------------------------------------------
+    // FIX 5 — an oversized body is truncated at the cap before the row is written
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task Post_OversizedMessage_TruncatesBodyToCap()
+    {
+        using var client = AuthedClient();
+
+        var resp = await client.PostAsJsonAsync(Route, new
+        {
+            action = "SendChannel",
+            channel = "eng-updates",
+            message = new string('x', 10_000),
+            messageType = "Info",
+        });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        _outbox.Enqueued.Should().ContainSingle();
+        var row = _outbox.Enqueued[0];
+        row.Body.Length.Should().BeLessThanOrEqualTo(4000);
+        row.Body.Should().EndWith("[truncated]");
+    }
+
+    // -----------------------------------------------------------------------
+    // Test doubles
+    // -----------------------------------------------------------------------
+
+    private sealed class CapturingSlackOutboxRepository : ISlackOutboxRepository
+    {
+        public List<SlackOutboxMessage> Enqueued { get; } = new();
+
+        public Task<SlackOutboxMessage> EnqueueAsync(SlackOutboxMessage msg, CancellationToken ct = default)
+        {
+            msg.Id = Guid.NewGuid();
+            msg.Status = "pending";
+            Enqueued.Add(msg);
+            return Task.FromResult(msg);
+        }
+
+        // The hosted sender is gated off in tests; return null so a stray poll no-ops.
+        public Task<SlackOutboxMessage?> ClaimNextPendingAsync(DateTime now, CancellationToken ct = default)
+            => Task.FromResult<SlackOutboxMessage?>(null);
+
+        public Task MarkSentAsync(Guid id, CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task<SlackOutboxMessage?> MarkFailedAsync(Guid id, string error, TimeSpan? backoff, CancellationToken ct = default)
+            => Task.FromResult<SlackOutboxMessage?>(null);
+
+        public Task<SlackOutboxMessage?> GetByIdAsync(Guid id, CancellationToken ct = default)
+            => Task.FromResult(Enqueued.FirstOrDefault(m => m.Id == id));
+
+        public Task DeleteAsync(Guid id, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class StubTenantContext : ITenantContext
+    {
+        private Guid? _tenantId;
+        public Guid? TenantId => _tenantId;
+        public void SetTenantId(Guid tenantId) => _tenantId = tenantId;
+        public void ClearTenantId() => _tenantId = null;
+    }
+
+    private sealed class TestEngineAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    {
+        public const string SchemeName = "TestEngine";
+
+        public TestEngineAuthHandler(
+            IOptionsMonitor<AuthenticationSchemeOptions> options,
+            Microsoft.Extensions.Logging.ILoggerFactory logger,
+            UrlEncoder encoder)
+            : base(options, logger, encoder) { }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (!Request.Headers.TryGetValue("Authorization", out var header))
+                return Task.FromResult(AuthenticateResult.NoResult());
+
+            var value = header.ToString();
+            if (!value.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+                return Task.FromResult(AuthenticateResult.NoResult());
+
+            var token = value["Bearer ".Length..].Trim();
+
+            if (string.Equals(token, TestBearer, StringComparison.Ordinal))
+            {
+                Context.SetAuthPrincipal(new ServiceAuthPrincipal(
+                    KeyId: Guid.NewGuid(), ServiceName: "tamma-engine",
+                    Permissions: Array.Empty<string>(), TenantId: null));
+                var identity = new ClaimsIdentity(
+                    new[] { new Claim(ClaimTypes.NameIdentifier, "tamma-engine"), new Claim("scope", "service") },
+                    SchemeName);
+                return Task.FromResult(AuthenticateResult.Success(
+                    new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName)));
+            }
+
+            if (string.Equals(token, UserBearer, StringComparison.Ordinal))
+            {
+                var identity = new ClaimsIdentity(
+                    new[] { new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()), new Claim("role", "owner") },
+                    SchemeName);
+                return Task.FromResult(AuthenticateResult.Success(
+                    new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName)));
+            }
+
+            return Task.FromResult(AuthenticateResult.Fail("Invalid token"));
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Notifications/OutboxSlackSenderTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Notifications/OutboxSlackSenderTests.cs
@@ -1,0 +1,340 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Services.Notifications;
+using Tamma.Api.Tests.Infrastructure;
+using Tamma.Core.Interfaces;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Notifications;
+
+/// <summary>
+/// Story 38-3 (AC4/AC7) — exercises the out-of-band <see cref="OutboxSlackSender"/>:
+/// the sole webhook-credential holder drains <c>slack_outbox</c>, performs the post
+/// via <see cref="ISlackIntegrationService"/>, marks the row, and audits terminal
+/// outcomes to <c>platform_events</c>. Also asserts the credential-safety contract:
+/// the webhook URL never lands in the row / event / (implicitly) the log.
+/// </summary>
+[TestFixture]
+public class OutboxSlackSenderTests
+{
+    private const string Webhook = "https://hooks.slack.com/services/T000/B000/XXXSUPERSECRET";
+
+    private DbContextOptions<ControlPlaneDbContext> _cpOptions = null!;
+    private IConfiguration _config = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _cpOptions = new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseInMemoryDatabase("slack-outbox-" + Guid.NewGuid())
+            .ConfigureWarnings(w => w.Ignore(
+                Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+        _config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Slack:WebhookUrl"] = Webhook,
+            })
+            .Build();
+    }
+
+    private (ServiceProvider sp, OutboxSlackSender sender, FakeSlack slack) BuildSender()
+    {
+        var captured = _cpOptions;
+        var services = new ServiceCollection();
+        services.AddScoped<ControlPlaneDbContext>(_ => new TestControlPlaneDbContext(captured));
+        services.AddScoped<ISlackOutboxRepository, SlackOutboxRepository>();
+        services.AddScoped<IPlatformEventRepository, PlatformEventRepository>();
+        var slack = new FakeSlack();
+        services.AddSingleton<ISlackIntegrationService>(slack);
+
+        var sp = services.BuildServiceProvider();
+        var sender = new OutboxSlackSender(
+            sp,
+            new OutboxSlackSenderOptions
+            {
+                PollInterval = TimeSpan.FromMilliseconds(10),
+                BackoffSchedule = new[] { TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2) },
+            },
+            _config,
+            NullLogger<OutboxSlackSender>.Instance);
+        return (sp, sender, slack);
+    }
+
+    private async Task<SlackOutboxMessage> SeedAsync(SlackOutboxMessage row)
+    {
+        using var cp = new TestControlPlaneDbContext(_cpOptions);
+        var repo = new SlackOutboxRepository(cp);
+        return await repo.EnqueueAsync(row);
+    }
+
+    private static SlackOutboxMessage ChannelRow(int maxAttempts = 5) => new()
+    {
+        Channel = "eng-updates",
+        MessageType = "Info",
+        Body = ":information_source: build green",
+        MaxAttempts = maxAttempts,
+    };
+
+    private static SlackOutboxMessage DmRow() => new()
+    {
+        TargetUserId = "U123",
+        MessageType = "Warning",
+        Body = ":warning: heads up",
+        MaxAttempts = 5,
+    };
+
+    // ── Happy path (AC4/AC7) ──────────────────────────────────────────────────
+
+    [Test]
+    public async Task ProcessOnceAsync_ChannelRow_PostsToChannel_MarksSent_EmitsSentEvent()
+    {
+        var (sp, sender, slack) = BuildSender();
+        try
+        {
+            var enq = await SeedAsync(ChannelRow());
+
+            var processed = await sender.ProcessOnceAsync(CancellationToken.None);
+
+            processed.Should().BeTrue();
+            slack.ChannelCalls.Should().ContainSingle();
+            slack.ChannelCalls[0].channel.Should().Be("eng-updates");
+            slack.ChannelCalls[0].message.Should().Be(":information_source: build green");
+            slack.DmCalls.Should().BeEmpty();
+
+            using var verify = new TestControlPlaneDbContext(_cpOptions);
+            var row = await verify.SlackOutbox.FindAsync(enq.Id);
+            row.Should().BeNull("the delivered row is purged — the durable audit lives in platform_events");
+
+            var events = await verify.PlatformEvents
+                .Where(e => e.Type == NotificationSlackEventTypes.Sent)
+                .ToListAsync();
+            events.Should().ContainSingle();
+            var tags = JsonSerializer.Deserialize<Dictionary<string, string?>>(events[0].Tags)!;
+            tags["outbox_id"].Should().Be(enq.Id.ToString());
+            tags["scope"].Should().Be("platform");
+            tags["channel"].Should().Be("eng-updates");
+        }
+        finally
+        {
+            sender.Dispose();
+            sp.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task ProcessOnceAsync_DmRow_PostsDirectMessage_MarksSent()
+    {
+        var (sp, sender, slack) = BuildSender();
+        try
+        {
+            var enq = await SeedAsync(DmRow());
+
+            await sender.ProcessOnceAsync(CancellationToken.None);
+
+            slack.DmCalls.Should().ContainSingle();
+            slack.DmCalls[0].userId.Should().Be("U123");
+            slack.ChannelCalls.Should().BeEmpty();
+
+            using var verify = new TestControlPlaneDbContext(_cpOptions);
+            (await verify.SlackOutbox.FindAsync(enq.Id))
+                .Should().BeNull("the delivered row is purged");
+        }
+        finally
+        {
+            sender.Dispose();
+            sp.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task ProcessOnceAsync_NoPending_ReturnsFalse()
+    {
+        var (sp, sender, _) = BuildSender();
+        try
+        {
+            (await sender.ProcessOnceAsync(CancellationToken.None)).Should().BeFalse();
+        }
+        finally
+        {
+            sender.Dispose();
+            sp.Dispose();
+        }
+    }
+
+    // ── Failure / backoff (AC4) ───────────────────────────────────────────────
+
+    [Test]
+    public async Task ProcessOnceAsync_TransientFailure_RequeuesWithBackoff_EmitsFailedEvent()
+    {
+        var (sp, sender, slack) = BuildSender();
+        try
+        {
+            slack.ChannelResult = IntegrationResult<bool>.Fail("slack returned 500");
+            var enq = await SeedAsync(ChannelRow(maxAttempts: 5));
+
+            var before = DateTime.UtcNow;
+            await sender.ProcessOnceAsync(CancellationToken.None);
+
+            using var verify = new TestControlPlaneDbContext(_cpOptions);
+            var row = await verify.SlackOutbox.FindAsync(enq.Id);
+            row!.Status.Should().Be("pending", "under the ceiling the row is re-queued");
+            row.Attempts.Should().Be(1);
+            row.NextAttemptAt.Should().BeAfter(before, "the retry is backed off into the future");
+            row.LastError.Should().Contain("500");
+
+            var failed = await verify.PlatformEvents
+                .Where(e => e.Type == NotificationSlackEventTypes.Failed)
+                .ToListAsync();
+            failed.Should().ContainSingle();
+        }
+        finally
+        {
+            sender.Dispose();
+            sp.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task ProcessOnceAsync_TerminalFailure_RemovesRow_EmitsTerminalFailedEvent()
+    {
+        var (sp, sender, slack) = BuildSender();
+        try
+        {
+            slack.ChannelResult = IntegrationResult<bool>.Fail("slack unreachable");
+            var enq = await SeedAsync(ChannelRow(maxAttempts: 1));
+
+            await sender.ProcessOnceAsync(CancellationToken.None);
+
+            using var verify = new TestControlPlaneDbContext(_cpOptions);
+            (await verify.SlackOutbox.FindAsync(enq.Id))
+                .Should().BeNull("the terminally-failed row is purged — the audit lives in platform_events");
+
+            var failed = await verify.PlatformEvents
+                .Where(e => e.Type == NotificationSlackEventTypes.Failed)
+                .ToListAsync();
+            failed.Should().ContainSingle();
+            var data = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(failed[0].Data)!;
+            data["terminal"].GetBoolean().Should().BeTrue();
+        }
+        finally
+        {
+            sender.Dispose();
+            sp.Dispose();
+        }
+    }
+
+    // ── Split-leg independence (FIX 1) ────────────────────────────────────────
+
+    [Test]
+    public async Task ProcessOnceAsync_SplitLegs_ChannelFailRetries_WithoutTouchingDeliveredDmRow()
+    {
+        var (sp, sender, slack) = BuildSender();
+        try
+        {
+            // The channel leg fails; the DM leg succeeds. Each is a SEPARATE row (split
+            // at enqueue), so the channel retry must not re-send — or resurrect — the DM.
+            slack.ChannelResult = IntegrationResult<bool>.Fail("channel 500");
+
+            var chan = await SeedAsync(new SlackOutboxMessage
+            {
+                Channel = "eng-updates",
+                MessageType = "Info",
+                Body = ":information_source: note",
+                MaxAttempts = 5,
+                NextAttemptAt = DateTime.UtcNow.AddSeconds(-10), // claimed first
+            });
+            var dm = await SeedAsync(new SlackOutboxMessage
+            {
+                TargetUserId = "U9",
+                MessageType = "Info",
+                Body = ":information_source: note",
+                MaxAttempts = 5,
+                NextAttemptAt = DateTime.UtcNow,
+            });
+
+            // Poll 1 → channel leg fails and re-queues; Poll 2 → DM leg claimed on its own.
+            (await sender.ProcessOnceAsync(CancellationToken.None)).Should().BeTrue();
+            (await sender.ProcessOnceAsync(CancellationToken.None)).Should().BeTrue();
+
+            slack.ChannelCalls.Should().ContainSingle("only the channel leg is (re)posted");
+            slack.DmCalls.Should().ContainSingle("the DM leg is delivered exactly once");
+            slack.DmCalls[0].userId.Should().Be("U9");
+
+            using var verify = new TestControlPlaneDbContext(_cpOptions);
+            var chanRow = await verify.SlackOutbox.FindAsync(chan.Id);
+            chanRow!.Status.Should().Be("pending", "the channel leg re-queues independently");
+            chanRow.Attempts.Should().Be(1);
+            (await verify.SlackOutbox.FindAsync(dm.Id))
+                .Should().BeNull("the delivered DM leg is purged, untouched by the channel retry");
+        }
+        finally
+        {
+            sender.Dispose();
+            sp.Dispose();
+        }
+    }
+
+    // ── Credential safety (AC7) ───────────────────────────────────────────────
+
+    [Test]
+    public async Task ProcessOnceAsync_Failure_RedactsWebhookFromRowAndEvent()
+    {
+        var (sp, sender, slack) = BuildSender();
+        try
+        {
+            // The transport error leaks the webhook URL — the sender must redact it
+            // before it reaches the row, the event, or the log.
+            slack.ChannelResult = IntegrationResult<bool>.Fail($"POST {Webhook} failed: connection reset");
+            var enq = await SeedAsync(ChannelRow(maxAttempts: 5));
+
+            await sender.ProcessOnceAsync(CancellationToken.None);
+
+            using var verify = new TestControlPlaneDbContext(_cpOptions);
+            var row = await verify.SlackOutbox.FindAsync(enq.Id);
+            row!.LastError.Should().NotContain(Webhook, "the webhook secret must never be stored on the row");
+            row.LastError.Should().Contain("[redacted-webhook]");
+
+            var failed = await verify.PlatformEvents
+                .Where(e => e.Type == NotificationSlackEventTypes.Failed)
+                .ToListAsync();
+            var payload = failed[0].Tags + failed[0].Data + failed[0].Metadata;
+            payload.Should().NotContain(Webhook, "no event payload may carry the webhook secret");
+        }
+        finally
+        {
+            sender.Dispose();
+            sp.Dispose();
+        }
+    }
+
+    // ── Test double ───────────────────────────────────────────────────────────
+
+    private sealed class FakeSlack : ISlackIntegrationService
+    {
+        public List<(string channel, string message)> ChannelCalls { get; } = new();
+        public List<(string userId, string message)> DmCalls { get; } = new();
+        public IntegrationResult<bool> ChannelResult { get; set; } = IntegrationResult<bool>.Ok(true);
+        public IntegrationResult<bool> DmResult { get; set; } = IntegrationResult<bool>.Ok(true);
+
+        public Task<IntegrationResult<bool>> SendSlackMessageAsync(string channel, string message)
+        {
+            ChannelCalls.Add((channel, message));
+            return Task.FromResult(ChannelResult);
+        }
+
+        public Task<IntegrationResult<bool>> SendSlackDirectMessageAsync(string userId, string message)
+        {
+            DmCalls.Add((userId, message));
+            return Task.FromResult(DmResult);
+        }
+    }
+}


### PR DESCRIPTION
## Epic 38 Story 38-3 — Slack/notifications step mediation (Class D, outbox)

Third Epic 38 story. Fire-and-forget, so it uses the **outbox** pattern (not the synchronous request/response of 38-1/38-2).

**Fix:** engine `SlackActivity` → `TammaApiClient.QueueSlackNotificationAsync` → `POST /api/v1/notifications/slack` (`EngineServiceOnly`, tenant from `ITenantContext`) → API writes a new CP table `slack_outbox` row → an API-side `OutboxSlackSender` `BackgroundService` (sole holder of `Slack:WebhookUrl`) drains it, marks sent/failed with backoff (MaxAttempts=5), and audits `NOTIFICATION.SLACK.*` to `platform_events`. Mirrors `platform_email_outbox`/`OutboxSmtpSender`. Kept the webhook model (no bot token — mediation, not new capability). No tenant↔repo guard (Slack isn't repo-scoped). New CP migration `AddSlackOutbox` (+ DROP-list + model contract test).

### Review + fixes (two independent reviewers)
- **IMPORTANT** — multi-leg duplicate: a `SendNotification` row with both channel + DM re-sent the delivered leg on retry (up to 5 dup DMs) and a DM failure blocked the channel post → **split into two independent single-target rows at enqueue**.
- **IMPORTANT** — terminal rows are now **deleted** on delivery / terminal-failure (matches the SMTP sibling; durable record is the `platform_events` audit) → no unbounded table growth / content retention.
- **LOW** — endpoint 400s when both channel + user blank; Slack mention/broadcast injection escaped (`<!channel>`/`<@U..>` render literally); body capped at 4000 chars.

Reviewers confirmed clean: webhook URL never leaks (row/event/log/`LastError` redacted), retry bounded at 5, atomic `FOR UPDATE SKIP LOCKED` claim, migration reversible + snapshot-matched, fail-soft cutover.

### ⚠️ Known follow-up (38-3b) — this PR is the seam, not the whole cutover
Review found `SlackActivity` is referenced by **no workflow**; the live Slack traffic flows through **14 domain activities that still directly inject `ISlackIntegrationService`** (Mentorship/Review/Blocker/CodeReview/Assessment). This PR lands the mediation **seam** + the `SlackActivity` cutover + the outbox infra. **38-3b** cuts those 14 callers over to `QueueSlackNotificationAsync` so the engine is truly Slack-cred-free (required before the 38-4 guardrail). **Until 38-3b lands, the engine still needs `Slack:WebhookUrl`.**

### Verify
Build 0; full `Tamma.Api.Tests` 3949/0/5skip; full `Tamma.Activities.Tests` 2148/0; `has-pending-model-changes` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
