### PR TITLE
Epic 38 Story 38-3b: cut over the 12 direct Slack callers (engine holds no Slack token)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/Assessment/DeliverQuestionsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Assessment/DeliverQuestionsActivity.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using System.Text;
 using System.Text.Json.Serialization;
 using Tamma.Activities.Assessment.Models;
+using Tamma.Activities.LlmCall;
 using Tamma.Core.Interfaces;
 using Tamma.Data.Repositories;
 
@@ -83,7 +84,10 @@ public class DeliverQuestionsActivity : CodeActivity<DeliveryResult>
                 case "slack":
                     if (junior?.SlackId != null)
                     {
-                        await _integrationService!.SendSlackDirectMessageAsync(junior.SlackId, message);
+                        // Story 38-3b — enqueue the DM intent via the API seam (engine
+                        // holds no Slack credential); fire-and-forget, fail-soft.
+                        await MediatedSlack.QueueDirectMessageAsync(
+                            context, junior.SlackId, message, "Info", "SendAssessment", context.CancellationToken);
                     }
                     else
                     {

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/EscalateToSeniorActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/EscalateToSeniorActivity.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
 using Tamma.Activities.Blocker.Models;
-using Tamma.Core.Interfaces;
+using Tamma.Activities.LlmCall;
 
 namespace Tamma.Activities.Blocker;
 
@@ -38,7 +38,6 @@ namespace Tamma.Activities.Blocker;
 public class EscalateToSeniorActivity : Activity
 {
     private readonly ILogger<EscalateToSeniorActivity>? _logger;
-    private readonly IIntegrationService? _integrationService;
     private readonly IConfiguration? _configuration;
 
     /// <summary>Mentorship session ID</summary>
@@ -90,11 +89,9 @@ public class EscalateToSeniorActivity : Activity
 
     public EscalateToSeniorActivity(
         ILogger<EscalateToSeniorActivity> logger,
-        IIntegrationService integrationService,
         IConfiguration configuration)
     {
         _logger = logger;
-        _integrationService = integrationService;
         _configuration = configuration;
     }
 
@@ -132,7 +129,7 @@ public class EscalateToSeniorActivity : Activity
         };
 
         // Notify senior via configured channel
-        await NotifySenior(escalationContext);
+        await NotifySenior(context, escalationContext);
 
         // 1) Escalation bookmark — resumed by the senior's response (API/Slack). The workflow
         //    suspends here until this resumes OR the durable SLA delay below fires.
@@ -155,7 +152,7 @@ public class EscalateToSeniorActivity : Activity
             slaMinutes, sessionId);
     }
 
-    private async Task NotifySenior(EscalationContext escalation)
+    private async Task NotifySenior(ActivityExecutionContext context, EscalationContext escalation)
     {
         var escalationChannel = _configuration?["BlockerDiagnosis:EscalationChannel"] ?? "slack";
         var seniorChannel = _configuration?["BlockerDiagnosis:SeniorNotificationChannel"] ?? "#mentorship-escalations";
@@ -180,9 +177,13 @@ Please respond to this escalation via the Tamma API or reply in this thread.";
 
         try
         {
-            if (escalationChannel == "slack" && _integrationService != null)
+            if (escalationChannel == "slack")
             {
-                await _integrationService.SendSlackMessageAsync(seniorChannel, message);
+                // Story 38-3b — enqueue the senior-channel post via the API seam
+                // (engine holds no Slack credential); fire-and-forget, fail-soft so
+                // the escalation bookmark is still created if the notification fails.
+                await MediatedSlack.QueueChannelMessageAsync(
+                    context, seniorChannel, message, "Warning", "SendNotification", context.CancellationToken);
             }
 
             _logger?.LogInformation("Senior notification sent for session {SessionId}", escalation.SessionId);

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/MediatedSlack.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/MediatedSlack.cs
@@ -1,0 +1,119 @@
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Tamma.Activities.LlmCall.Models;
+
+namespace Tamma.Activities.LlmCall;
+
+/// <summary>
+/// Story 38-3b (Epic 38, Class D) — the shared engine→API Slack seam the cut-over
+/// domain activities (Mentorship / Review / Blocker / Assessment) use INSTEAD of a
+/// direct <c>IIntegrationService.SendSlack*Async</c> call (a rule-1 violation: the
+/// engine holds no Slack credential).
+///
+/// <para>It enqueues a Slack notification INTENT via
+/// <see cref="TammaApiClient.QueueSlackNotificationAsync"/> →
+/// <c>POST /api/v1/notifications/slack</c>, where the API writes a
+/// <c>slack_outbox</c> row and the out-of-band <c>OutboxSlackSender</c> (the sole
+/// webhook-credential holder) performs the transport. The engine holds NO Slack
+/// token; this seam mirrors <see cref="MediatedLlmText"/> for the LLM path.</para>
+///
+/// <para><b>Fire-and-forget + fail-soft (a deliberate, correct semantics change).</b>
+/// No legacy caller branched on the Slack return value, but the old composite
+/// <c>IntegrationService.SendSlack*Async</c> actually THREW on failure (unset
+/// <c>Slack:WebhookUrl</c> or a transport error), so a notification failure sitting
+/// inside an activity's success <c>try</c> could flip that activity to its Failure
+/// outcome. This seam INTENTIONALLY makes Slack non-fatal: a false enqueue (API down /
+/// non-2xx) or an unwired client is returned to the caller but NEVER throws and NEVER
+/// changes the activity's outcome — a missing Slack post must not break a
+/// mentorship/review run (and this also fixes the latent "PR merged but reported
+/// Failed because the notify threw" bug). The message body is passed through UNCHANGED
+/// (each activity formats its own body engine-side exactly as before the cutover; this
+/// seam adds no re-formatting — Slack-token hardening is a separate 38-3 follow-up).</para>
+/// </summary>
+internal static class MediatedSlack
+{
+    /// <summary>
+    /// Enqueue a Slack DIRECT MESSAGE intent for <paramref name="slackUserId"/> from
+    /// inside an activity. Resolves the <see cref="TammaApiClient"/> and the ambient
+    /// tenant scope from <paramref name="context"/>; fire-and-forget, never throws.
+    /// </summary>
+    public static Task<bool> QueueDirectMessageAsync(
+        ActivityExecutionContext context, string slackUserId, string message,
+        string messageType, string action, CancellationToken ct)
+        => EnqueueAsync(
+            context.GetService<TammaApiClient>(),
+            ResolveTenantId(context),
+            BuildDirectMessage(slackUserId, message, messageType, action),
+            ct);
+
+    /// <summary>
+    /// Enqueue a Slack CHANNEL POST intent for <paramref name="channel"/> from inside
+    /// an activity. Same seam + fail-soft contract as
+    /// <see cref="QueueDirectMessageAsync"/>.
+    /// </summary>
+    public static Task<bool> QueueChannelMessageAsync(
+        ActivityExecutionContext context, string channel, string message,
+        string messageType, string action, CancellationToken ct)
+        => EnqueueAsync(
+            context.GetService<TammaApiClient>(),
+            ResolveTenantId(context),
+            BuildChannelMessage(channel, message, messageType, action),
+            ct);
+
+    /// <summary>Pure builder: a single-target DM request (channel = null).</summary>
+    public static SlackNotificationRequest BuildDirectMessage(
+        string slackUserId, string message, string messageType, string action)
+        => new()
+        {
+            Action = action,
+            Channel = null,
+            UserId = slackUserId,
+            Message = message,
+            MessageType = string.IsNullOrWhiteSpace(messageType) ? "Info" : messageType,
+        };
+
+    /// <summary>Pure builder: a single-target channel-post request (userId = null).</summary>
+    public static SlackNotificationRequest BuildChannelMessage(
+        string channel, string message, string messageType, string action)
+        => new()
+        {
+            Action = action,
+            Channel = channel,
+            UserId = null,
+            Message = message,
+            MessageType = string.IsNullOrWhiteSpace(messageType) ? "Info" : messageType,
+        };
+
+    /// <summary>
+    /// Context-free enqueue (unit-tested with a fake <see cref="TammaApiClient"/>).
+    /// A null client (engine unwired) or a false enqueue returns <c>false</c> — never
+    /// throws — so the caller stays fire-and-forget and its outcome is unchanged.
+    /// </summary>
+    public static async Task<bool> EnqueueAsync(
+        TammaApiClient? api, string? tenantId, SlackNotificationRequest request, CancellationToken ct)
+    {
+        if (api is null)
+            return false;
+        return await api.QueueSlackNotificationAsync(request, tenantId, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Resolve the tenant scope (X-Tenant-Id) from the workflow's ambient tenant
+    /// variable — identical convention to <see cref="MediatedLlmText"/> /
+    /// <c>EventPersistenceMiddleware</c>: read <c>TenantId</c> (legacy fallback
+    /// <c>AccountId</c>) as an <c>object</c> (it may be a <see cref="Guid"/> or a
+    /// string) and coerce to a canonical Guid string. An empty / unset / non-Guid
+    /// value ⇒ single-user / platform scope (null); the endpoint handles null.
+    /// </summary>
+    internal static string? ResolveTenantId(ActivityExecutionContext context)
+    {
+        var raw = context.GetVariable<object?>("TenantId")
+                  ?? context.GetVariable<object?>("AccountId");
+        return raw switch
+        {
+            Guid g when g != Guid.Empty => g.ToString(),
+            string s when Guid.TryParse(s, out var p) && p != Guid.Empty => p.ToString(),
+            _ => null,
+        };
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Mentorship/AssessJuniorCapabilityActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Mentorship/AssessJuniorCapabilityActivity.cs
@@ -4,8 +4,8 @@ using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
+using Tamma.Activities.LlmCall;
 using Tamma.Core.Enums;
-using Tamma.Core.Interfaces;
 using Tamma.Data.Repositories;
 
 namespace Tamma.Activities.Mentorship;
@@ -25,7 +25,6 @@ public class AssessJuniorCapabilityActivity : CodeActivity<AssessmentOutput>
 {
     private readonly ILogger<AssessJuniorCapabilityActivity>? _logger;
     private readonly IMentorshipSessionRepository? _repository;
-    private readonly IIntegrationService? _integrationService;
 
     /// <summary>ID of the story to assess</summary>
     [Input(Description = "ID of the story to assess")]
@@ -48,12 +47,10 @@ public class AssessJuniorCapabilityActivity : CodeActivity<AssessmentOutput>
 
     public AssessJuniorCapabilityActivity(
         ILogger<AssessJuniorCapabilityActivity> logger,
-        IMentorshipSessionRepository repository,
-        IIntegrationService integrationService)
+        IMentorshipSessionRepository repository)
     {
         _logger = logger;
         _repository = repository;
-        _integrationService = integrationService;
     }
 
     /// <summary>
@@ -106,11 +103,14 @@ public class AssessJuniorCapabilityActivity : CodeActivity<AssessmentOutput>
             // Build assessment questions based on story complexity
             var questions = BuildAssessmentQuestions(story.Complexity);
 
-            // Send assessment via Slack (if configured)
+            // Send assessment via Slack (if configured) — Story 38-3b: enqueue the
+            // DM intent via the API seam (engine holds no Slack credential);
+            // fire-and-forget, fail-soft.
             if (!string.IsNullOrEmpty(junior.SlackId))
             {
                 var message = FormatAssessmentMessage(story.Title, story.Description ?? "", questions);
-                await _integrationService!.SendSlackDirectMessageAsync(junior.SlackId, message);
+                await MediatedSlack.QueueDirectMessageAsync(
+                    context, junior.SlackId, message, "Info", "SendAssessment", context.CancellationToken);
             }
 
             // Log the assessment event

--- a/apps/tamma-elsa/src/Tamma.Activities/Mentorship/CodeReviewActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Mentorship/CodeReviewActivity.cs
@@ -4,6 +4,7 @@ using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
+using Tamma.Activities.LlmCall;
 using Tamma.Core.Enums;
 using Tamma.Core.Interfaces;
 using Tamma.Data.Repositories;
@@ -96,9 +97,9 @@ public class CodeReviewActivity : CodeActivity<CodeReviewOutput>
 
             CodeReviewOutput result = action switch
             {
-                CodeReviewAction.Prepare => await PrepareCodeReview(sessionId, story, junior),
-                CodeReviewAction.Monitor => await MonitorCodeReview(sessionId, story, junior, prNumber),
-                CodeReviewAction.RequestChanges => await HandleReviewChanges(sessionId, story, junior, prNumber),
+                CodeReviewAction.Prepare => await PrepareCodeReview(context, sessionId, story, junior),
+                CodeReviewAction.Monitor => await MonitorCodeReview(context, sessionId, story, junior, prNumber),
+                CodeReviewAction.RequestChanges => await HandleReviewChanges(context, sessionId, story, junior, prNumber),
                 _ => new CodeReviewOutput
                 {
                     Success = false,
@@ -139,6 +140,7 @@ public class CodeReviewActivity : CodeActivity<CodeReviewOutput>
     }
 
     private async Task<CodeReviewOutput> PrepareCodeReview(
+        ActivityExecutionContext context,
         Guid sessionId,
         Tamma.Core.Entities.Story story,
         Tamma.Core.Entities.JuniorDeveloper junior)
@@ -196,7 +198,7 @@ public class CodeReviewActivity : CodeActivity<CodeReviewOutput>
         // Notify junior about PR creation
         if (!string.IsNullOrEmpty(junior.SlackId))
         {
-            await NotifyPullRequestCreated(junior.SlackId, prResult, story.Title);
+            await NotifyPullRequestCreated(context, junior.SlackId, prResult, story.Title);
         }
 
         // Record analytics
@@ -226,6 +228,7 @@ public class CodeReviewActivity : CodeActivity<CodeReviewOutput>
     }
 
     private async Task<CodeReviewOutput> MonitorCodeReview(
+        ActivityExecutionContext context,
         Guid sessionId,
         Tamma.Core.Entities.Story story,
         Tamma.Core.Entities.JuniorDeveloper junior,
@@ -250,12 +253,15 @@ public class CodeReviewActivity : CodeActivity<CodeReviewOutput>
         switch (reviewStatus.Status)
         {
             case ReviewStatus.Approved:
-                // Notify junior about approval
+                // Notify junior about approval — Story 38-3b: enqueue via the API
+                // seam (engine holds no Slack credential); fire-and-forget, fail-soft.
                 if (!string.IsNullOrEmpty(junior.SlackId))
                 {
-                    await _integrationService!.SendSlackDirectMessageAsync(
+                    await MediatedSlack.QueueDirectMessageAsync(
+                        context,
                         junior.SlackId,
-                        $"Great news! Your PR #{prNumber} has been approved! Proceeding to merge.");
+                        $"Great news! Your PR #{prNumber} has been approved! Proceeding to merge.",
+                        "Success", "SendDirect", context.CancellationToken);
                 }
 
                 await _analyticsService!.RecordMetricAsync(sessionId, "pr_approved", 1);
@@ -273,7 +279,7 @@ public class CodeReviewActivity : CodeActivity<CodeReviewOutput>
                 // Notify junior about requested changes
                 if (!string.IsNullOrEmpty(junior.SlackId))
                 {
-                    await NotifyChangesRequested(junior.SlackId, prNumber.Value, reviewStatus.Comments);
+                    await NotifyChangesRequested(context, junior.SlackId, prNumber.Value, reviewStatus.Comments);
                 }
 
                 return new CodeReviewOutput
@@ -308,6 +314,7 @@ public class CodeReviewActivity : CodeActivity<CodeReviewOutput>
     }
 
     private async Task<CodeReviewOutput> HandleReviewChanges(
+        ActivityExecutionContext context,
         Guid sessionId,
         Tamma.Core.Entities.Story story,
         Tamma.Core.Entities.JuniorDeveloper junior,
@@ -343,7 +350,10 @@ Here's help addressing the review feedback on PR #{prNumber}:
 
 After making changes, the PR will be re-reviewed automatically.";
 
-            await _integrationService!.SendSlackDirectMessageAsync(junior.SlackId, message);
+            // Story 38-3b — enqueue via the API seam (engine holds no Slack
+            // credential); fire-and-forget, fail-soft.
+            await MediatedSlack.QueueDirectMessageAsync(
+                context, junior.SlackId, message, "Info", "SendGuidance", context.CancellationToken);
         }
 
         await _analyticsService!.RecordMetricAsync(sessionId, "review_changes_guided", commentGuidance.Count);
@@ -508,7 +518,8 @@ Implementation of story **{story.Id}**: {story.Title}
         return "Review the comment and apply the suggested change. Ask if you need clarification.";
     }
 
-    private async Task NotifyPullRequestCreated(string slackId, GitHubPullRequestResult pr, string storyTitle)
+    private static async Task NotifyPullRequestCreated(
+        ActivityExecutionContext context, string slackId, GitHubPullRequestResult pr, string storyTitle)
     {
         var message = $@"**Tamma: Pull Request Created**
 
@@ -520,10 +531,14 @@ Your code is ready for review!
 
 A reviewer will look at your code soon. You'll be notified when there's feedback.";
 
-        await _integrationService!.SendSlackDirectMessageAsync(slackId, message);
+        // Story 38-3b — enqueue via the API seam (engine holds no Slack credential);
+        // fire-and-forget, fail-soft.
+        await MediatedSlack.QueueDirectMessageAsync(
+            context, slackId, message, "Info", "SendDirect", context.CancellationToken);
     }
 
-    private async Task NotifyChangesRequested(string slackId, int prNumber, List<ReviewComment> comments)
+    private static async Task NotifyChangesRequested(
+        ActivityExecutionContext context, string slackId, int prNumber, List<ReviewComment> comments)
     {
         var message = $@"**Tamma: Review Feedback Received**
 
@@ -533,7 +548,10 @@ Your PR #{prNumber} has received feedback. {comments.Count} change(s) requested:
 
 I'll send you guidance on how to address each item shortly.";
 
-        await _integrationService!.SendSlackDirectMessageAsync(slackId, message);
+        // Story 38-3b — enqueue via the API seam (engine holds no Slack credential);
+        // fire-and-forget, fail-soft.
+        await MediatedSlack.QueueDirectMessageAsync(
+            context, slackId, message, "Warning", "SendDirect", context.CancellationToken);
     }
 }
 

--- a/apps/tamma-elsa/src/Tamma.Activities/Mentorship/DiagnoseBlockerActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Mentorship/DiagnoseBlockerActivity.cs
@@ -4,6 +4,7 @@ using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
+using Tamma.Activities.LlmCall;
 using Tamma.Core.Enums;
 using Tamma.Core.Interfaces;
 using Tamma.Data.Repositories;
@@ -127,7 +128,7 @@ public class DiagnoseBlockerActivity : CodeActivity<BlockerDiagnosisOutput>
             // Notify junior about diagnosis
             if (!string.IsNullOrEmpty(junior.SlackId))
             {
-                await NotifyJunior(junior.SlackId, diagnosis);
+                await NotifyJunior(context, junior.SlackId, diagnosis);
             }
 
             context.SetResult(diagnosis);
@@ -341,7 +342,8 @@ public class DiagnoseBlockerActivity : CodeActivity<BlockerDiagnosisOutput>
         };
     }
 
-    private async Task NotifyJunior(string slackId, BlockerDiagnosisOutput diagnosis)
+    private static async Task NotifyJunior(
+        ActivityExecutionContext context, string slackId, BlockerDiagnosisOutput diagnosis)
     {
         var message = $@"**Tamma: Blocker Detected**
 
@@ -354,7 +356,10 @@ I've noticed you might be stuck. Here's what I've identified:
 
 Don't worry - this is a normal part of learning! Reply if you need more help.";
 
-        await _integrationService!.SendSlackDirectMessageAsync(slackId, message);
+        // Story 38-3b — enqueue the diagnosis DM via the API seam (engine holds no
+        // Slack credential); fire-and-forget, fail-soft.
+        await MediatedSlack.QueueDirectMessageAsync(
+            context, slackId, message, "Warning", "SendDirect", context.CancellationToken);
     }
 }
 

--- a/apps/tamma-elsa/src/Tamma.Activities/Mentorship/MergeCompleteActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Mentorship/MergeCompleteActivity.cs
@@ -4,6 +4,7 @@ using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
+using Tamma.Activities.LlmCall;
 using Tamma.Core.Enums;
 using Tamma.Core.Interfaces;
 using Tamma.Data.Repositories;
@@ -160,7 +161,7 @@ public class MergeCompleteActivity : CodeActivity<MergeCompleteOutput>
             // Step 9: Notify junior about completion
             if (!string.IsNullOrEmpty(junior.SlackId))
             {
-                await NotifyCompletion(junior.SlackId, story, report, skillUpdate);
+                await NotifyCompletion(context, junior.SlackId, story, report, skillUpdate);
             }
 
             _logger?.LogInformation(
@@ -338,7 +339,8 @@ public class MergeCompleteActivity : CodeActivity<MergeCompleteOutput>
             "count");
     }
 
-    private async Task NotifyCompletion(
+    private static async Task NotifyCompletion(
+        ActivityExecutionContext context,
         string slackId,
         Tamma.Core.Entities.Story story,
         SessionReport report,
@@ -399,7 +401,10 @@ Your skill level has been updated from {skillUpdate.OldSkillLevel} to {skillUpda
 
 Great work! Ready for your next challenge?";
 
-        await _integrationService!.SendSlackDirectMessageAsync(slackId, message);
+        // Story 38-3b — enqueue the completion DM via the API seam (engine holds no
+        // Slack credential); fire-and-forget, fail-soft.
+        await MediatedSlack.QueueDirectMessageAsync(
+            context, slackId, message, "Celebration", "SendDirect", context.CancellationToken);
     }
 }
 

--- a/apps/tamma-elsa/src/Tamma.Activities/Mentorship/ProvideGuidanceActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Mentorship/ProvideGuidanceActivity.cs
@@ -4,6 +4,7 @@ using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
+using Tamma.Activities.LlmCall;
 using Tamma.Core.Enums;
 using Tamma.Core.Interfaces;
 using Tamma.Data.Repositories;
@@ -24,7 +25,6 @@ public class ProvideGuidanceActivity : CodeActivity<GuidanceOutput>
 {
     private readonly ILogger<ProvideGuidanceActivity>? _logger;
     private readonly IMentorshipSessionRepository? _repository;
-    private readonly IIntegrationService? _integrationService;
     private readonly IAnalyticsService? _analyticsService;
 
     /// <summary>Mentorship session ID</summary>
@@ -57,12 +57,10 @@ public class ProvideGuidanceActivity : CodeActivity<GuidanceOutput>
     public ProvideGuidanceActivity(
         ILogger<ProvideGuidanceActivity> logger,
         IMentorshipSessionRepository repository,
-        IIntegrationService integrationService,
         IAnalyticsService analyticsService)
     {
         _logger = logger;
         _repository = repository;
-        _integrationService = integrationService;
         _analyticsService = analyticsService;
     }
 
@@ -134,7 +132,7 @@ public class ProvideGuidanceActivity : CodeActivity<GuidanceOutput>
             // Deliver guidance via appropriate channel
             if (!string.IsNullOrEmpty(junior.SlackId))
             {
-                await DeliverGuidanceViaSlack(junior.SlackId, guidance, resources, guidanceLevel);
+                await DeliverGuidanceViaSlack(context, junior.SlackId, guidance, resources, guidanceLevel);
             }
 
             _logger?.LogInformation(
@@ -519,7 +517,8 @@ public class ProvideGuidanceActivity : CodeActivity<GuidanceOutput>
         return resources;
     }
 
-    private async Task DeliverGuidanceViaSlack(
+    private static async Task DeliverGuidanceViaSlack(
+        ActivityExecutionContext context,
         string slackId,
         GuidanceContent guidance,
         List<Resource> resources,
@@ -554,7 +553,11 @@ public class ProvideGuidanceActivity : CodeActivity<GuidanceOutput>
 
         message += "\n\nReply if you need more help!";
 
-        await _integrationService!.SendSlackDirectMessageAsync(slackId, message);
+        // Story 38-3b — enqueue the DM intent via the API seam (engine holds no
+        // Slack credential); fire-and-forget, fail-soft (a missed post never breaks
+        // the mentorship session).
+        await MediatedSlack.QueueDirectMessageAsync(
+            context, slackId, message, "Info", "SendGuidance", context.CancellationToken);
     }
 }
 

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/DeliverGuidanceActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/DeliverGuidanceActivity.cs
@@ -5,9 +5,9 @@ using Elsa.Workflows.Activities.Flowchart.Attributes;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
+using Tamma.Activities.LlmCall;
 using Tamma.Activities.Review.Models;
 using Tamma.Core.Entities;
-using Tamma.Core.Interfaces;
 using Tamma.Data.Repositories;
 
 namespace Tamma.Activities.Review;
@@ -40,7 +40,6 @@ public class DeliverGuidanceActivity : Activity
 {
     private readonly ILogger<DeliverGuidanceActivity>? _logger;
     private readonly IMentorshipSessionRepository? _repository;
-    private readonly IIntegrationService? _integrationService;
 
     /// <summary>Mentorship session ID</summary>
     [Input(Description = "Mentorship session ID")]
@@ -79,12 +78,10 @@ public class DeliverGuidanceActivity : Activity
 
     public DeliverGuidanceActivity(
         ILogger<DeliverGuidanceActivity> logger,
-        IMentorshipSessionRepository repository,
-        IIntegrationService integrationService)
+        IMentorshipSessionRepository repository)
     {
         _logger = logger;
         _repository = repository;
-        _integrationService = integrationService;
     }
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
@@ -132,11 +129,14 @@ public class DeliverGuidanceActivity : Activity
                 OverallMessage = guidanceText.Trim()
             };
 
-            // Send guidance to the junior via Slack
+            // Send guidance to the junior via Slack — Story 38-3b: enqueue the DM
+            // intent via the API seam (engine holds no Slack credential);
+            // fire-and-forget, fail-soft.
             if (junior != null && !string.IsNullOrEmpty(junior.SlackId))
             {
                 var message = FormatGuidanceMessage(guidance, prNumber);
-                await _integrationService!.SendSlackDirectMessageAsync(junior.SlackId, message);
+                await MediatedSlack.QueueDirectMessageAsync(
+                    context, junior.SlackId, message, "Info", "SendGuidance", context.CancellationToken);
             }
 
             // Log the mentorship event (retained alongside the DCB event the workflow emits)

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/EscalateReviewActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/EscalateReviewActivity.cs
@@ -5,10 +5,10 @@ using Elsa.Workflows.Activities.Flowchart.Attributes;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
+using Tamma.Activities.LlmCall;
 using Tamma.Activities.Review.Models;
 using Microsoft.Extensions.Configuration;
 using Tamma.Core.Entities;
-using Tamma.Core.Interfaces;
 using Tamma.Data.Repositories;
 
 namespace Tamma.Activities.Review;
@@ -47,7 +47,6 @@ public class EscalateReviewActivity : Activity
 {
     private readonly ILogger<EscalateReviewActivity>? _logger;
     private readonly IMentorshipSessionRepository? _repository;
-    private readonly IIntegrationService? _integrationService;
     private readonly IConfiguration? _configuration;
 
     /// <summary>Mentorship session ID</summary>
@@ -84,12 +83,10 @@ public class EscalateReviewActivity : Activity
     public EscalateReviewActivity(
         ILogger<EscalateReviewActivity> logger,
         IMentorshipSessionRepository repository,
-        IIntegrationService integrationService,
         IConfiguration configuration)
     {
         _logger = logger;
         _repository = repository;
-        _integrationService = integrationService;
         _configuration = configuration;
     }
 
@@ -134,24 +131,31 @@ public class EscalateReviewActivity : Activity
                     _ => "The review requires senior developer input."
                 };
 
-                await _integrationService!.SendSlackDirectMessageAsync(
+                // Story 38-3b — enqueue the junior DM intent via the API seam (engine
+                // holds no Slack credential); fire-and-forget, fail-soft.
+                await MediatedSlack.QueueDirectMessageAsync(
+                    context,
                     junior.SlackId,
                     $"**Tamma: Review Escalated**\n\n" +
                     $"PR #{prNumber} has been escalated to a senior developer.\n" +
                     $"Reason: {reasonText}\n\n" +
                     "A senior developer will review and respond. This is a normal part of " +
-                    "the development process and a great learning opportunity!");
+                    "the development process and a great learning opportunity!",
+                    "Warning", "SendNotification", context.CancellationToken);
             }
 
-            // Send escalation notification to a senior channel
-            await _integrationService!.SendSlackMessageAsync(
+            // Send escalation notification to the senior channel — Story 38-3b: a
+            // second, independent enqueue (channel post) via the same API seam.
+            await MediatedSlack.QueueChannelMessageAsync(
+                context,
                 "senior-review",
                 $"**Tamma: Escalation Required**\n\n" +
                 $"PR #{prNumber} needs senior review.\n" +
                 $"Developer: {junior?.Name ?? juniorId}\n" +
                 $"Reason: {reason}\n" +
                 $"Iterations attempted: {iterations}\n" +
-                $"{(message != null ? $"Details: {message}" : "")}");
+                $"{(message != null ? $"Details: {message}" : "")}",
+                "Warning", "SendChannel", context.CancellationToken);
         }
         catch (Exception ex)
         {

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/MergeAndCompleteReviewActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/MergeAndCompleteReviewActivity.cs
@@ -5,6 +5,7 @@ using Elsa.Workflows.Activities.Flowchart.Attributes;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
+using Tamma.Activities.LlmCall;
 using Tamma.Activities.Review.Models;
 using Tamma.Core.Entities;
 using Tamma.Core.Enums;
@@ -204,17 +205,20 @@ public class MergeAndCompleteReviewActivity : Activity
             await _analyticsService!.RecordMetricAsync(sessionId, "pr_merged", 1);
             await _analyticsService.RecordMetricAsync(sessionId, "review_iterations", totalIterations);
 
-            // Notify junior
+            // Notify junior — Story 38-3b: enqueue via the API seam (engine holds no
+            // Slack credential); fire-and-forget, fail-soft.
             if (junior != null && !string.IsNullOrEmpty(junior.SlackId))
             {
                 var iterationNote = totalIterations > 0
                     ? $" after {totalIterations} fix iteration(s)"
                     : "";
 
-                await _integrationService.SendSlackDirectMessageAsync(
+                await MediatedSlack.QueueDirectMessageAsync(
+                    context,
                     junior.SlackId,
                     $"Your PR #{prNumber} has been approved and merged{iterationNote}! " +
-                    "Great work on completing the code review process.");
+                    "Great work on completing the code review process.",
+                    "Success", "SendDirect", context.CancellationToken);
             }
 
             _logger?.LogInformation(

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/ReRequestReviewActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/ReRequestReviewActivity.cs
@@ -4,9 +4,9 @@ using Elsa.Workflows;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
+using Tamma.Activities.LlmCall;
 using Tamma.Activities.Review.Models;
 using Tamma.Core.Entities;
-using Tamma.Core.Interfaces;
 using Tamma.Data.Repositories;
 
 namespace Tamma.Activities.Review;
@@ -27,7 +27,6 @@ public class ReRequestReviewActivity : CodeActivity<ReRequestReviewOutput>
 {
     private readonly ILogger<ReRequestReviewActivity>? _logger;
     private readonly IMentorshipSessionRepository? _repository;
-    private readonly IIntegrationService? _integrationService;
 
     /// <summary>Mentorship session ID</summary>
     [Input(Description = "Mentorship session ID")]
@@ -58,12 +57,10 @@ public class ReRequestReviewActivity : CodeActivity<ReRequestReviewOutput>
 
     public ReRequestReviewActivity(
         ILogger<ReRequestReviewActivity> logger,
-        IMentorshipSessionRepository repository,
-        IIntegrationService integrationService)
+        IMentorshipSessionRepository repository)
     {
         _logger = logger;
         _repository = repository;
-        _integrationService = integrationService;
     }
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
@@ -101,13 +98,17 @@ public class ReRequestReviewActivity : CodeActivity<ReRequestReviewOutput>
 
             var junior = await _repository!.GetJuniorByIdAsync(juniorId);
 
-            // Notify the junior that re-review is in progress
+            // Notify the junior that re-review is in progress — Story 38-3b: enqueue
+            // the DM intent via the API seam (engine holds no Slack credential);
+            // fire-and-forget, fail-soft.
             if (junior != null && !string.IsNullOrEmpty(junior.SlackId))
             {
-                await _integrationService!.SendSlackDirectMessageAsync(
+                await MediatedSlack.QueueDirectMessageAsync(
+                    context,
                     junior.SlackId,
                     $"Your fixes for PR #{prNumber} have been submitted (iteration {iteration}). " +
-                    "The PR is being re-reviewed. Hang tight!");
+                    "The PR is being re-reviewed. Hang tight!",
+                    "Info", "SendDirect", context.CancellationToken);
             }
 
             // Log the event

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/RequestReviewActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/RequestReviewActivity.cs
@@ -4,9 +4,9 @@ using Elsa.Workflows;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
+using Tamma.Activities.LlmCall;
 using Tamma.Activities.Review.Models;
 using Tamma.Core.Entities;
-using Tamma.Core.Interfaces;
 using Tamma.Data.Repositories;
 
 namespace Tamma.Activities.Review;
@@ -26,7 +26,6 @@ public class RequestReviewActivity : CodeActivity<RequestReviewOutput>
 {
     private readonly ILogger<RequestReviewActivity>? _logger;
     private readonly IMentorshipSessionRepository? _repository;
-    private readonly IIntegrationService? _integrationService;
 
     /// <summary>Mentorship session ID</summary>
     [Input(Description = "Mentorship session ID")]
@@ -53,12 +52,10 @@ public class RequestReviewActivity : CodeActivity<RequestReviewOutput>
 
     public RequestReviewActivity(
         ILogger<RequestReviewActivity> logger,
-        IMentorshipSessionRepository repository,
-        IIntegrationService integrationService)
+        IMentorshipSessionRepository repository)
     {
         _logger = logger;
         _repository = repository;
-        _integrationService = integrationService;
     }
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
@@ -77,13 +74,17 @@ public class RequestReviewActivity : CodeActivity<RequestReviewOutput>
         {
             var junior = await _repository!.GetJuniorByIdAsync(juniorId);
 
-            // Notify the junior that the PR is awaiting review
+            // Notify the junior that the PR is awaiting review — Story 38-3b: enqueue
+            // the DM intent via the API seam (engine holds no Slack credential);
+            // fire-and-forget, fail-soft.
             if (junior != null && !string.IsNullOrEmpty(junior.SlackId))
             {
-                await _integrationService!.SendSlackDirectMessageAsync(
+                await MediatedSlack.QueueDirectMessageAsync(
+                    context,
                     junior.SlackId,
                     $"Your PR #{prNumber} is now awaiting code review. " +
-                    "You will be notified when a reviewer submits feedback.");
+                    "You will be notified when a reviewer submits feedback.",
+                    "Info", "SendDirect", context.CancellationToken);
             }
 
             // Log the event

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/AssessJuniorCapabilityActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/AssessJuniorCapabilityActivityTests.cs
@@ -15,24 +15,22 @@ public class AssessJuniorCapabilityActivityTests
 {
     private Mock<ILogger<AssessJuniorCapabilityActivity>> _mockLogger = null!;
     private Mock<IMentorshipSessionRepository> _mockRepository = null!;
-    private Mock<IIntegrationService> _mockIntegrationService = null!;
 
     [SetUp]
     public void SetUp()
     {
         _mockLogger = new Mock<ILogger<AssessJuniorCapabilityActivity>>();
         _mockRepository = new Mock<IMentorshipSessionRepository>();
-        _mockIntegrationService = new Mock<IIntegrationService>();
     }
 
     [Test]
     public void Constructor_WithValidDependencies_ShouldNotThrow()
     {
-        // Act
+        // Act — Story 38-3b: the activity no longer injects IIntegrationService
+        // (Slack now routes through the mediated API seam), so the ctor is 2-arg.
         Action act = () => new AssessJuniorCapabilityActivity(
             _mockLogger.Object,
-            _mockRepository.Object,
-            _mockIntegrationService.Object);
+            _mockRepository.Object);
 
         // Assert
         act.Should().NotThrow();

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Integration/SlackCallerCutoverTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Integration/SlackCallerCutoverTests.cs
@@ -1,0 +1,234 @@
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
+using Tamma.Core.Interfaces;
+
+namespace Tamma.Activities.Tests.Integration;
+
+/// <summary>
+/// Story 38-3b (Epic 38, Class D) — the 12 domain activities that used to send Slack
+/// directly via the co-hosted <see cref="IIntegrationService"/> (a rule-1 violation:
+/// the engine holds no Slack credential) now route through the
+/// <see cref="MediatedSlack"/> seam → <see cref="TammaApiClient.QueueSlackNotificationAsync"/>
+/// → <c>POST /api/v1/notifications/slack</c> (fire-and-forget outbox).
+///
+/// <para>These tests cover: (1) the seam's request mapping (target/message/messageType/
+/// action) + tenant passthrough + fail-soft (a false enqueue or an unwired client never
+/// throws and returns false); (2) the per-activity cutover proof — the seven activities
+/// whose ONLY external use was Slack no longer inject any credential-holding integration
+/// service, while the five that also use <see cref="IIntegrationService"/> for non-Slack
+/// (GitHub / CI / JIRA / email) legitimately retain it; and (3) the drift guard — ZERO
+/// direct Slack calls remain anywhere under <c>Tamma.Activities</c> (mirrors the 38-1/38-3
+/// grep gates), which the 38-4 guardrail depends on.</para>
+/// </summary>
+[TestFixture]
+public class SlackCallerCutoverTests
+{
+    // A concrete TammaApiClient subclass capturing the enqueued intent. The seam made
+    // QueueSlackNotificationAsync virtual (38-3), so no real HTTP leaves. The base ctor
+    // gets a throwaway HttpClient + NullLogger.
+    private sealed class CapturingSlackApiClient : TammaApiClient
+    {
+        public CapturingSlackApiClient()
+            : base(new HttpClient(), NullLogger<TammaApiClient>.Instance, null, null) { }
+
+        public SlackNotificationRequest? Captured { get; private set; }
+        public string? CapturedTenant { get; private set; }
+        public int Calls { get; private set; }
+        public bool Result { get; set; } = true;
+
+        public override Task<bool> QueueSlackNotificationAsync(
+            SlackNotificationRequest request, string? tenantId = null, CancellationToken ct = default)
+        {
+            Calls++;
+            Captured = request;
+            CapturedTenant = tenantId;
+            return Task.FromResult(Result);
+        }
+    }
+
+    // ── Request mapping (AC5) ─────────────────────────────────────────────────
+
+    [Test]
+    public void BuildDirectMessage_RoutesToTargetUser_NoChannel()
+    {
+        var req = MediatedSlack.BuildDirectMessage("U9", "hi there", "Success", "SendDirect");
+
+        req.UserId.Should().Be("U9");
+        req.Channel.Should().BeNull("a DM has no channel target");
+        req.Message.Should().Be("hi there", "the body is passed through unchanged (no re-formatting)");
+        req.MessageType.Should().Be("Success");
+        req.Action.Should().Be("SendDirect");
+    }
+
+    [Test]
+    public void BuildChannelMessage_RoutesToChannel_NoUser()
+    {
+        var req = MediatedSlack.BuildChannelMessage("senior-review", "needs review", "Warning", "SendChannel");
+
+        req.Channel.Should().Be("senior-review");
+        req.UserId.Should().BeNull("a channel post has no DM target");
+        req.Message.Should().Be("needs review");
+        req.MessageType.Should().Be("Warning");
+        req.Action.Should().Be("SendChannel");
+    }
+
+    [Test]
+    public void Build_BlankMessageType_DefaultsToInfo()
+    {
+        MediatedSlack.BuildDirectMessage("U1", "m", "", "SendDirect").MessageType.Should().Be("Info");
+        MediatedSlack.BuildChannelMessage("c", "m", "   ", "SendChannel").MessageType.Should().Be("Info");
+    }
+
+    // ── Enqueue + tenant passthrough (AC5) ────────────────────────────────────
+
+    [Test]
+    public async Task Enqueue_CallsQueueSlackNotification_WithRequestAndTenant()
+    {
+        var api = new CapturingSlackApiClient();
+        var request = MediatedSlack.BuildDirectMessage("U9", "hi", "Info", "SendDirect");
+
+        var ok = await MediatedSlack.EnqueueAsync(api, "tenant-42", request, CancellationToken.None);
+
+        ok.Should().BeTrue();
+        api.Calls.Should().Be(1);
+        api.Captured.Should().BeSameAs(request);
+        api.Captured!.UserId.Should().Be("U9");
+        api.CapturedTenant.Should().Be("tenant-42", "the ambient tenant is forwarded as X-Tenant-Id scope");
+    }
+
+    // ── Fail-soft (AC10) ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Enqueue_FalseResult_IsReturned_NotThrown()
+    {
+        var api = new CapturingSlackApiClient { Result = false };
+
+        var ok = await MediatedSlack.EnqueueAsync(
+            api, null, MediatedSlack.BuildChannelMessage("c", "m", "Info", "SendChannel"), CancellationToken.None);
+
+        ok.Should().BeFalse("a failed enqueue is fail-soft — the caller stays fire-and-forget, never throws");
+        api.Calls.Should().Be(1);
+    }
+
+    [Test]
+    public async Task Enqueue_NullClient_ReturnsFalse_NeverThrows()
+    {
+        var ok = await MediatedSlack.EnqueueAsync(
+            null, "t", MediatedSlack.BuildDirectMessage("U", "m", "Info", "SendDirect"), CancellationToken.None);
+
+        ok.Should().BeFalse("an unwired engine client must not break a mentorship/review run");
+    }
+
+    // ── Per-activity cutover proof (AC6) ──────────────────────────────────────
+
+    // The seven activities whose ONLY external call was Slack — they must inject NO
+    // credential-holding integration service after the cutover.
+    private static readonly Type[] SlackOnlyActivities =
+    {
+        typeof(Tamma.Activities.Mentorship.ProvideGuidanceActivity),
+        typeof(Tamma.Activities.Mentorship.AssessJuniorCapabilityActivity),
+        typeof(Tamma.Activities.Review.DeliverGuidanceActivity),
+        typeof(Tamma.Activities.Review.ReRequestReviewActivity),
+        typeof(Tamma.Activities.Review.RequestReviewActivity),
+        typeof(Tamma.Activities.Review.EscalateReviewActivity),
+        typeof(Tamma.Activities.Blocker.EscalateToSeniorActivity),
+    };
+
+    // The five activities that ALSO use IIntegrationService for non-Slack work
+    // (GitHub merge/PR, CI status, JIRA, email) — they legitimately retain it; the
+    // cutover removed only their Slack calls (proved by the drift guard below).
+    private static readonly Type[] NonSlackRetainers =
+    {
+        typeof(Tamma.Activities.Mentorship.MergeCompleteActivity),
+        typeof(Tamma.Activities.Mentorship.DiagnoseBlockerActivity),
+        typeof(Tamma.Activities.Mentorship.CodeReviewActivity),
+        typeof(Tamma.Activities.Review.MergeAndCompleteReviewActivity),
+        typeof(Tamma.Activities.Assessment.DeliverQuestionsActivity),
+    };
+
+    [Test]
+    [TestCaseSource(nameof(SlackOnlyActivities))]
+    public void SlackOnlyActivity_InjectsNoIntegrationService(Type activityType)
+    {
+        foreach (var ctor in activityType.GetConstructors())
+        {
+            ctor.GetParameters()
+                .Any(p => IsIntegrationServiceType(p.ParameterType))
+                .Should().BeFalse(
+                    $"{activityType.Name} must not inject a Slack-credential integration service (ctor)");
+        }
+
+        activityType
+            .GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+            .Any(f => IsIntegrationServiceType(f.FieldType))
+            .Should().BeFalse(
+                $"{activityType.Name} must hold no Slack-credential integration-service field");
+    }
+
+    [Test]
+    [TestCaseSource(nameof(NonSlackRetainers))]
+    public void NonSlackRetainer_KeepsIntegrationService_ForNonSlackUse(Type activityType)
+    {
+        var hasField = activityType
+            .GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+            .Any(f => IsIntegrationServiceType(f.FieldType));
+
+        hasField.Should().BeTrue(
+            $"{activityType.Name} still uses IIntegrationService for non-Slack work (GitHub / CI / JIRA / "
+            + "email); the cutover removed only its Slack calls");
+    }
+
+    private static bool IsIntegrationServiceType(Type t) =>
+        typeof(IIntegrationService).IsAssignableFrom(t)
+        || typeof(ISlackIntegrationService).IsAssignableFrom(t);
+
+    // ── Drift guard: ZERO direct Slack calls remain under Tamma.Activities ─────
+
+    [Test]
+    public void TammaActivities_MakeNoDirectSlackCall()
+    {
+        var root = FindActivitiesRoot();
+        root.Should().NotBeNull("the drift gate needs the Tamma.Activities source tree");
+
+        var offenders = new List<string>();
+        foreach (var file in Directory.EnumerateFiles(root!, "*.cs", SearchOption.AllDirectories))
+        {
+            var rel = Path.GetRelativePath(root!, file).Replace('\\', '/');
+            if (rel.StartsWith("obj/") || rel.StartsWith("bin/"))
+                continue;
+
+            var text = File.ReadAllText(file);
+            if (text.Contains("SendSlackDirectMessageAsync", StringComparison.Ordinal)
+                || text.Contains("SendSlackMessageAsync", StringComparison.Ordinal)
+                || text.Contains("ISlackIntegrationService", StringComparison.Ordinal))
+            {
+                offenders.Add(rel);
+            }
+        }
+
+        offenders.Should().BeEmpty(
+            "no in-engine activity may send Slack directly — every Slack post routes through "
+            + "MediatedSlack → TammaApiClient.QueueSlackNotificationAsync → POST /api/v1/notifications/slack. "
+            + "Offending files: " + string.Join(", ", offenders));
+    }
+
+    private static string? FindActivitiesRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "src", "Tamma.Activities");
+            if (Directory.Exists(candidate)) return candidate;
+
+            var nested = Path.Combine(dir.FullName, "apps", "tamma-elsa", "src", "Tamma.Activities");
+            if (Directory.Exists(nested)) return nested;
+
+            dir = dir.Parent;
+        }
+        return null;
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/ProvideGuidanceActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/ProvideGuidanceActivityTests.cs
@@ -15,7 +15,6 @@ public class ProvideGuidanceActivityTests
 {
     private Mock<ILogger<ProvideGuidanceActivity>> _mockLogger = null!;
     private Mock<IMentorshipSessionRepository> _mockRepository = null!;
-    private Mock<IIntegrationService> _mockIntegrationService = null!;
     private Mock<IAnalyticsService> _mockAnalyticsService = null!;
 
     [SetUp]
@@ -23,18 +22,17 @@ public class ProvideGuidanceActivityTests
     {
         _mockLogger = new Mock<ILogger<ProvideGuidanceActivity>>();
         _mockRepository = new Mock<IMentorshipSessionRepository>();
-        _mockIntegrationService = new Mock<IIntegrationService>();
         _mockAnalyticsService = new Mock<IAnalyticsService>();
     }
 
     [Test]
     public void Constructor_WithValidDependencies_ShouldNotThrow()
     {
-        // Act
+        // Act — Story 38-3b: the activity no longer injects IIntegrationService
+        // (Slack now routes through the mediated API seam), so the ctor is 3-arg.
         Action act = () => new ProvideGuidanceActivity(
             _mockLogger.Object,
             _mockRepository.Object,
-            _mockIntegrationService.Object,
             _mockAnalyticsService.Object);
 
         // Assert


### PR DESCRIPTION
## Epic 38 Story 38-3b — cut over the 12 direct Slack callers

Completes what 38-3 started: the mediation seam is now used by the activities that carry the **real** Slack traffic. 38-3 built the outbox + endpoint + `SlackActivity` cutover; this PR cuts over the 12 domain activities (Mentorship/Review/Blocker/Assessment) that still sent Slack directly via the co-hosted `IIntegrationService`.

**Result:** the engine holds **no Slack credential** and **zero** direct Slack calls remain in `Tamma.Activities`/`Tamma.ElsaServer` — the precondition for the 38-4 build-time guardrail.

New `MediatedSlack` seam (mirrors `MediatedLlmText`) → `TammaApiClient.QueueSlackNotificationAsync` → `/api/v1/notifications/slack`. Fire-and-forget + fail-soft. 7 activities dropped the `IIntegrationService` injection (Slack-only); 5 kept it for legitimate non-Slack ops (GitHub merge/CI/JIRA/email — `DeliverQuestions`' email branch untouched). `EscalateReview`'s DM + `senior-review` channel → two independent enqueues inside the try/catch (bookmark still created on failure). Tenant sourced from ambient `TenantId`/`AccountId`.

### Review: SHIP
The adversarial review caught a subtle real change: the old composite `IntegrationService` **threw** on Slack failure, so a failed notify could flip an activity to its Failure outcome. The new fail-soft seam **intentionally** makes Slack non-fatal — correct for the engine-holds-no-credential architecture, and it fixes a latent "PR merged but reported Failed because the notify threw" bug. All guards, outcomes, and non-Slack behavior preserved; the `MediatedSlack` docstring was corrected to state this accurately.

Tracked follow-up: Slack mention/broadcast-token escaping on untrusted bodies (belongs in the 38-3 endpoint/sender, matches old raw-interpolation behavior — not a regression).

### Verify
Build 0; full `Tamma.Activities.Tests` 2167/0; full `Tamma.Api.Tests` 3949/0/5skip; grep-zero direct Slack calls in the engine. No schema change.

Next: **38-4** — the build-time guardrail that makes rule #1 structural (bans DI-injection of vendor services + direct external calls in the engine), locking the whole epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
