### PR TITLE
Epic 38 Story 38-4: TAMMA001 build-time guardrail (locks rule-1 permanently)

### DIFF
--- a/apps/tamma-elsa/Tamma.sln
+++ b/apps/tamma-elsa/Tamma.sln
@@ -49,6 +49,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tamma.Platforms.GitHub", "s
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tamma.Platforms.GitHub.Tests", "tests\Tamma.Platforms.GitHub.Tests\Tamma.Platforms.GitHub.Tests.csproj", "{18F794B6-B5D0-4CB5-AFCE-E4BE8F6A1836}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tamma.Activities.Guardrails", "src\Tamma.Activities.Guardrails\Tamma.Activities.Guardrails.csproj", "{9C4357A4-1C6E-46A5-A0B2-7202D1FC1BBE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tamma.Activities.Guardrails.Tests", "tests\Tamma.Activities.Guardrails.Tests\Tamma.Activities.Guardrails.Tests.csproj", "{02E50D67-DD52-489F-B40E-A061F9840C46}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -311,6 +315,30 @@ Global
 		{18F794B6-B5D0-4CB5-AFCE-E4BE8F6A1836}.Release|x64.Build.0 = Release|Any CPU
 		{18F794B6-B5D0-4CB5-AFCE-E4BE8F6A1836}.Release|x86.ActiveCfg = Release|Any CPU
 		{18F794B6-B5D0-4CB5-AFCE-E4BE8F6A1836}.Release|x86.Build.0 = Release|Any CPU
+		{9C4357A4-1C6E-46A5-A0B2-7202D1FC1BBE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C4357A4-1C6E-46A5-A0B2-7202D1FC1BBE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C4357A4-1C6E-46A5-A0B2-7202D1FC1BBE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9C4357A4-1C6E-46A5-A0B2-7202D1FC1BBE}.Debug|x64.Build.0 = Debug|Any CPU
+		{9C4357A4-1C6E-46A5-A0B2-7202D1FC1BBE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9C4357A4-1C6E-46A5-A0B2-7202D1FC1BBE}.Debug|x86.Build.0 = Debug|Any CPU
+		{9C4357A4-1C6E-46A5-A0B2-7202D1FC1BBE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C4357A4-1C6E-46A5-A0B2-7202D1FC1BBE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C4357A4-1C6E-46A5-A0B2-7202D1FC1BBE}.Release|x64.ActiveCfg = Release|Any CPU
+		{9C4357A4-1C6E-46A5-A0B2-7202D1FC1BBE}.Release|x64.Build.0 = Release|Any CPU
+		{9C4357A4-1C6E-46A5-A0B2-7202D1FC1BBE}.Release|x86.ActiveCfg = Release|Any CPU
+		{9C4357A4-1C6E-46A5-A0B2-7202D1FC1BBE}.Release|x86.Build.0 = Release|Any CPU
+		{02E50D67-DD52-489F-B40E-A061F9840C46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{02E50D67-DD52-489F-B40E-A061F9840C46}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{02E50D67-DD52-489F-B40E-A061F9840C46}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{02E50D67-DD52-489F-B40E-A061F9840C46}.Debug|x64.Build.0 = Debug|Any CPU
+		{02E50D67-DD52-489F-B40E-A061F9840C46}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{02E50D67-DD52-489F-B40E-A061F9840C46}.Debug|x86.Build.0 = Debug|Any CPU
+		{02E50D67-DD52-489F-B40E-A061F9840C46}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{02E50D67-DD52-489F-B40E-A061F9840C46}.Release|Any CPU.Build.0 = Release|Any CPU
+		{02E50D67-DD52-489F-B40E-A061F9840C46}.Release|x64.ActiveCfg = Release|Any CPU
+		{02E50D67-DD52-489F-B40E-A061F9840C46}.Release|x64.Build.0 = Release|Any CPU
+		{02E50D67-DD52-489F-B40E-A061F9840C46}.Release|x86.ActiveCfg = Release|Any CPU
+		{02E50D67-DD52-489F-B40E-A061F9840C46}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -329,5 +357,7 @@ Global
 		{B8ABC317-316F-4394-8BBA-2B1A959C8953} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{4AD38CEC-F4A9-466A-9D4D-E52794DFE44A} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{18F794B6-B5D0-4CB5-AFCE-E4BE8F6A1836} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{9C4357A4-1C6E-46A5-A0B2-7202D1FC1BBE} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{02E50D67-DD52-489F-B40E-A061F9840C46} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/apps/tamma-elsa/src/Tamma.Activities.Guardrails/Allowlist.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities.Guardrails/Allowlist.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Immutable;
+
+namespace Tamma.Activities.Guardrails;
+
+/// <summary>
+/// Story 38-4 — the sanctioned-seam allowlist, the vendor-credential injection denylist,
+/// the denied Slack-send invocations, and the design-§5.3 exemptions, expressed as DATA
+/// so the guardrail is forward-compatible (Epic 35 adds Stripe → add its client type here;
+/// no analyzer rewrite).
+/// </summary>
+internal static class Allowlist
+{
+    /// <summary>The engine surface the analyzer targets. <c>Tamma.Api</c> is deliberately
+    /// EXCLUDED — the API is supposed to hold credentials and call vendors.</summary>
+    public static bool IsEngineSurface(string? assemblyName) =>
+        assemblyName is "Tamma.Activities" or "Tamma.ElsaServer";
+
+    /// <summary>The sanctioned engine→API seam (documentation only). The analyzer never
+    /// flags HTTP whose host is not a statically-resolvable EXTERNAL host, so
+    /// <c>TammaApiClient</c>'s config-driven base URL and the <c>Engine:CallbackUrl</c>
+    /// interpolated hosts are never flagged.</summary>
+    public const string ApiClientType = "Tamma.Activities.LlmCall.TammaApiClient";
+
+    /// <summary>The internal-endpoint host key (<c>TriggerCIActivity</c>'s pattern).</summary>
+    public const string CallbackHostConfigKey = "Engine:CallbackUrl";
+
+    // ------------------------------------------------------------------------------------
+    // Vendor-credential INJECTION denylist — ctor parameters / fields / properties whose
+    // type is one of these re-introduces an in-process external credential (rule-1
+    // violation, design §1.2 audit table). Post-32-5/38-1/38-2/38-3 there are ZERO engine
+    // INJECTIONS of these: the ADL git service and the GitHub-Actions client are METHOD
+    // PARAMETERS of the reused static cores (called by Tamma.Api's mediation services), not
+    // ctor/field injections; Slack/GitHub effects route through TammaApiClient.
+    //
+    // DELIBERATELY EXCLUDED — the COMPOSITE `Tamma.Core.Interfaces.IIntegrationService`:
+    //   it is STILL legitimately injected in 5 engine activities (MergeCompleteActivity,
+    //   DiagnoseBlockerActivity, CodeReviewActivity, MergeAndCompleteReviewActivity,
+    //   DeliverQuestionsActivity) for NON-Slack ops (GitHub merge/CI, JIRA, email) that
+    //   Epic 38 did NOT mediate. Denying its INJECTION would fail the build on clean main.
+    //   Those un-migrated GitHub/CI/JIRA/email uses are a TRACKED FOLLOW-UP; once they move
+    //   to Tamma.Api endpoints, add IIntegrationService here. The Slack hole this exclusion
+    //   would otherwise open is closed by DeniedInvocationNames below (Correction 2) — the
+    //   composite's Slack SEND methods are denied at the call site.
+    // ------------------------------------------------------------------------------------
+    public static readonly ImmutableHashSet<string> InjectionDenylist = ImmutableHashSet.Create(
+        StringComparer.Ordinal,
+        "Octokit.IGitHubClient",
+        "Octokit.GitHubClient",
+        "Tamma.Activities.AgentDispatch.IGitHubActionsClient",
+        "Tamma.Core.Interfaces.IGitHubIntegrationService",
+        "Tamma.Core.Interfaces.ISlackIntegrationService",
+        // The engine must not resolve provider credentials post-32-5. (The one legitimate
+        // holder, InlineToolLoopRunner, is the Tamma.Api-executed LLM core — exempted below.)
+        "Tamma.Activities.LlmCall.Credentials.IProviderCredentialResolver",
+        // FIX M1 — the inline tool-loop runner is the Tamma.Api-executed LLM core: it holds
+        // the direct anthropic/openai calls + IProviderCredentialResolver. It is DI-registered
+        // ONLY in Tamma.Api (Program.cs). INJECTING it into any engine activity would drive a
+        // credentialed LLM call from a workflow STEP — a rule-1 violation — so its injection is
+        // denied here. NB no conflict with the whole-type EXEMPTION below: the exemption keys on
+        // the ANALYZED (owner) type, so it only suppresses the runner's OWN members (its
+        // IProviderCredentialResolver ctor injection); a DIFFERENT engine type injecting the
+        // runner has a non-exempt owner and is correctly flagged.
+        "Tamma.Activities.LlmCall.IInlineToolLoopRunner",
+        "Tamma.Activities.LlmCall.InlineToolLoopRunner",
+        // Forward-compatible (Epic 35 billing / future vendor SDKs) — harmless string data
+        // until such a type is actually referenced by the engine:
+        "SlackNet.ISlackApiClient",
+        "Stripe.StripeClient",
+        "Stripe.IStripeClient");
+
+    // ------------------------------------------------------------------------------------
+    // FIX I1 — service-locator method names. Resolving a denylisted vendor-credential type
+    // via the DI container (Microsoft.Extensions.DependencyInjection's
+    // GetService/GetRequiredService/GetKeyedService/GetRequiredKeyedService, or Elsa's
+    // ActivityExecutionContext.GetService<T>()) inside a method BODY is not a ctor param /
+    // field / property, so passes (2) miss it — yet it is the most natural way a future dev
+    // re-introduces a credentialed vendor effect. A call to one of these whose type argument
+    // (generic <T> OR the typeof(T)/Type-arg overload) is on InjectionDenylist is flagged.
+    // Keyed on the DENYLISTED type argument, so a legitimate context.GetService<TammaApiClient>()
+    // / GetService<IConfiguration>() never trips — only a denylisted vendor type does.
+    // ------------------------------------------------------------------------------------
+    public static readonly ImmutableHashSet<string> ServiceLocatorMethodNames = ImmutableHashSet.Create(
+        StringComparer.Ordinal,
+        "GetService",
+        "GetRequiredService",
+        "GetKeyedService",
+        "GetRequiredKeyedService");
+
+    // ------------------------------------------------------------------------------------
+    // Correction 2 — denied Slack SEND invocations on ANY receiver. Because the composite
+    // IIntegrationService INJECTION is allowed (for GitHub/CI/JIRA/email), also deny its
+    // Slack send METHODS at the call site so a re-introduced engine-side Slack post via the
+    // composite is still caught. Its GitHub/CI methods stay allowed (the tracked follow-up).
+    // ------------------------------------------------------------------------------------
+    public static readonly ImmutableHashSet<string> DeniedInvocationNames = ImmutableHashSet.Create(
+        StringComparer.Ordinal,
+        "SendSlackMessageAsync",
+        "SendSlackDirectMessageAsync");
+
+    /// <summary>HttpClient send-method names (instance + <c>System.Net.Http.Json</c>
+    /// extensions) whose statically-resolvable external target host is a violation.</summary>
+    public static readonly ImmutableHashSet<string> HttpSendMethodNames = ImmutableHashSet.Create(
+        StringComparer.Ordinal,
+        "PostAsync", "PostAsJsonAsync",
+        "PutAsync", "PutAsJsonAsync",
+        "PatchAsync", "PatchAsJsonAsync",
+        "GetAsync", "GetStringAsync", "GetByteArrayAsync", "GetStreamAsync", "GetFromJsonAsync",
+        "DeleteAsync", "DeleteFromJsonAsync",
+        "SendAsync",
+        // FIX M3 — net5+ synchronous HttpClient.Send(HttpRequestMessage). Gated on the
+        // containing type being HttpClient/HttpMessageInvoker (IsHttpSendMethod), so an
+        // unrelated `.Send()` on a bus/actor is not matched; still only a resolvable external
+        // host (including one dug out of an inline `new HttpRequestMessage(m, "https://...")`)
+        // is flagged.
+        "Send");
+
+    /// <summary>The types that own the HTTP send methods (so a same-named method on an
+    /// unrelated type — a bus <c>SendAsync</c>, a cache <c>GetAsync</c> — is not flagged).</summary>
+    public static readonly ImmutableHashSet<string> HttpClientTypeNames = ImmutableHashSet.Create(
+        StringComparer.Ordinal,
+        "System.Net.Http.HttpClient",
+        "System.Net.Http.HttpMessageInvoker",
+        "System.Net.Http.Json.HttpClientJsonExtensions",
+        "System.Net.Http.HttpClientJsonExtensions");
+
+    // ------------------------------------------------------------------------------------
+    // EXEMPT types (design §5.3) — a local process / local filesystem / inbound signal is
+    // NOT an external API call. Matched by the analyzed type's own FQN, or any base type /
+    // implemented interface FQN.
+    // ------------------------------------------------------------------------------------
+    public static readonly ImmutableHashSet<string> ExemptTypeNames = ImmutableHashSet.Create(
+        StringComparer.Ordinal,
+        // Local single-user CLI agents (design §5.3). No C# implementation exists today
+        // (CLI providers are the TS harness) — kept as forward-compatible data that matches
+        // an implementor's interface list if one is ever added to the engine surface.
+        "Tamma.Providers.ICLIAgentProvider",
+        // In-engine LOCAL tools — local filesystem / local process, not external HTTP:
+        "Tamma.Activities.LlmCall.Tools.FileReadTool",
+        "Tamma.Activities.LlmCall.Tools.ShellExecuteTool",
+        "Tamma.Activities.LlmCall.Tools.GitOperationsTool",
+        // Inbound webhook-signal store (inbound; no outbound call):
+        "Tamma.Activities.AgentDispatch.WebhookSignalRegistry",
+        // TRACKED FOLLOW-UP — the API-plane LLM execution core. It is DI-registered and
+        // executed ONLY in Tamma.Api (ManagedAgent); it lives in the Tamma.Activities
+        // ASSEMBLY purely for code-organisation (32-5 extracted it verbatim from
+        // CallLlmInlineActivity). It ctor-injects IProviderCredentialResolver and holds the
+        // direct anthropic/openai calls = the sanctioned Tamma.Api LLM core, NOT an
+        // engine-executed path. Exempt so it does not false-positive the engine guardrail.
+        // Follow-up: physically relocate InlineToolLoopRunner (+ IInlineToolLoopRunner) into
+        // Tamma.Api, then delete this line (its IProviderCredentialResolver injection is
+        // then correctly outside the engine surface).
+        "Tamma.Activities.LlmCall.InlineToolLoopRunner");
+}

--- a/apps/tamma-elsa/src/Tamma.Activities.Guardrails/AnalyzerReleases.Shipped.md
+++ b/apps/tamma-elsa/src/Tamma.Activities.Guardrails/AnalyzerReleases.Shipped.md
@@ -1,0 +1,2 @@
+; Shipped analyzer releases
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md

--- a/apps/tamma-elsa/src/Tamma.Activities.Guardrails/AnalyzerReleases.Unshipped.md
+++ b/apps/tamma-elsa/src/Tamma.Activities.Guardrails/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,8 @@
+; Unshipped analyzer release
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+TAMMA001 | Tamma.Architecture | Error | Engine step makes a direct external call or injects a vendor credential (rule 1; Story 38-4).

--- a/apps/tamma-elsa/src/Tamma.Activities.Guardrails/EngineExternalCallAnalyzer.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities.Guardrails/EngineExternalCallAnalyzer.cs
@@ -1,0 +1,367 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Tamma.Activities.Guardrails;
+
+/// <summary>
+/// Story 38-4 — the rule-1 guardrail. Reports <c>TAMMA001</c> (Error) when an
+/// ENGINE-SURFACE type (<c>Tamma.Activities</c> / <c>Tamma.ElsaServer</c> only — never
+/// <c>Tamma.Api</c>) does any of three things:
+///
+/// <list type="number">
+///   <item><b>Direct external HTTP</b> — an <c>HttpClient</c> send whose statically
+///     resolvable target host is an EXTERNAL host (i.e. not a loopback host and not an
+///     un-resolvable, config-driven <c>TammaApiClient</c> / <c>Engine:CallbackUrl</c>
+///     host). A non-literal-host raw <c>HttpClient</c> call is NOT re-scanned for a host;
+///     it is instead caught by the injection / service-locator / construction passes below —
+///     the credential to reach a real vendor has to ARRIVE somehow (an injected client, a
+///     container resolve, or a constructed vendor SDK). The one residual gap (documented) is
+///     a fully-untyped credential reaching a non-literal URL — no static seam exists to key
+///     on, so that narrow case is not caught by this analyzer.</item>
+///   <item><b>Vendor-credential injection</b> — a constructor parameter, field, or
+///     property whose type is on <see cref="Allowlist.InjectionDenylist"/>. METHOD
+///     parameters are NOT injection (the reused static cores keep the git service as a
+///     method param), so only ctor params + fields/properties are inspected.</item>
+///   <item><b>Service-locator resolve</b> (FIX I1) — a call to
+///     <c>GetService</c>/<c>GetRequiredService</c>/<c>GetKeyedService</c>/<c>GetRequiredKeyedService</c>
+///     (MS.DI or Elsa's <c>context.GetService&lt;T&gt;()</c>) whose type argument (generic
+///     <c>&lt;T&gt;</c> or the <c>typeof(T)</c>/<c>Type</c> overload) is on
+///     <see cref="Allowlist.InjectionDenylist"/> — the dominant DI idiom here, evading the
+///     ctor/field/property pass.</item>
+///   <item><b>Vendor construction</b> (FIX M2) — <c>new T()</c> where <c>T</c> is a concrete
+///     denylisted type (<c>Octokit.GitHubClient</c>, <c>Stripe.StripeClient</c>, ...), which
+///     evades pass (2) unless stored in a denylisted-typed field.</item>
+///   <item><b>Denied Slack send</b> — an invocation of
+///     <c>SendSlackMessageAsync</c>/<c>SendSlackDirectMessageAsync</c> on any receiver
+///     (Correction 2: closes the hole left by allowing the composite
+///     <c>IIntegrationService</c> injection).</item>
+/// </list>
+///
+/// The design-§5.3 exempt categories (<see cref="Allowlist.ExemptTypeNames"/>) are never
+/// flagged. Uses the semantic model (not strings), so an alias / <c>using</c> rename can't
+/// evade it.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class EngineExternalCallAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly SymbolDisplayFormat FullyQualified = new(
+        globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Omitted,
+        typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
+        genericsOptions: SymbolDisplayGenericsOptions.None);
+
+    private const string HttpMessageInvoker = "System.Net.Http.HttpMessageInvoker";
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(GuardrailDiagnostics.EngineDirectExternalCall);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(start =>
+        {
+            // Engine surface ONLY — Tamma.Api is supposed to hold credentials + call vendors.
+            if (!Allowlist.IsEngineSurface(start.Compilation.AssemblyName))
+                return;
+
+            start.RegisterOperationAction(InspectInvocation, OperationKind.Invocation);
+            start.RegisterOperationAction(InspectObjectCreation, OperationKind.ObjectCreation);
+            start.RegisterSymbolAction(InspectConstructor, SymbolKind.Method);
+            start.RegisterSymbolAction(InspectFieldOrProperty, SymbolKind.Field, SymbolKind.Property);
+        });
+    }
+
+    // ----- (2) vendor-credential injection: constructor parameters -----------------------
+    private static void InspectConstructor(SymbolAnalysisContext context)
+    {
+        var method = (IMethodSymbol)context.Symbol;
+        if (method.MethodKind != MethodKind.Constructor)
+            return;
+
+        var owner = method.ContainingType;
+        if (owner is null || IsExempt(owner))
+            return;
+
+        foreach (var parameter in method.Parameters)
+        {
+            var typeName = FullName(parameter.Type);
+            if (Allowlist.InjectionDenylist.Contains(typeName))
+            {
+                var location = parameter.Locations.FirstOrDefault()
+                               ?? method.Locations.FirstOrDefault()
+                               ?? Location.None;
+                context.ReportDiagnostic(Diagnostic.Create(
+                    GuardrailDiagnostics.EngineDirectExternalCall, location, owner.Name, typeName));
+            }
+        }
+    }
+
+    // ----- (2) vendor-credential injection: fields + properties --------------------------
+    private static void InspectFieldOrProperty(SymbolAnalysisContext context)
+    {
+        ITypeSymbol memberType;
+        INamedTypeSymbol? owner;
+        Location location;
+
+        switch (context.Symbol)
+        {
+            case IFieldSymbol field:
+                // Skip compiler-synthesized fields (e.g. auto-property backing fields); the
+                // property itself is inspected separately.
+                if (field.IsImplicitlyDeclared || field.AssociatedSymbol is IPropertySymbol)
+                    return;
+                memberType = field.Type;
+                owner = field.ContainingType;
+                location = field.Locations.FirstOrDefault() ?? Location.None;
+                break;
+
+            case IPropertySymbol property:
+                memberType = property.Type;
+                owner = property.ContainingType;
+                location = property.Locations.FirstOrDefault() ?? Location.None;
+                break;
+
+            default:
+                return;
+        }
+
+        if (owner is null || IsExempt(owner))
+            return;
+
+        var typeName = FullName(memberType);
+        if (Allowlist.InjectionDenylist.Contains(typeName))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                GuardrailDiagnostics.EngineDirectExternalCall, location, owner.Name, typeName));
+        }
+    }
+
+    // ----- (1) direct external HTTP + (3) denied Slack send ------------------------------
+    private static void InspectInvocation(OperationAnalysisContext context)
+    {
+        var invocation = (IInvocationOperation)context.Operation;
+
+        var enclosing = context.ContainingSymbol as INamedTypeSymbol
+                        ?? context.ContainingSymbol?.ContainingType;
+        if (enclosing is not null && IsExempt(enclosing))
+            return;
+
+        var target = invocation.TargetMethod;
+        var enclosingName = enclosing?.Name ?? "<engine>";
+
+        // (3) Denied Slack send on ANY receiver.
+        if (Allowlist.DeniedInvocationNames.Contains(target.Name))
+        {
+            var receiver = target.ContainingType is { } ct ? $"{ct.Name}.{target.Name}" : target.Name;
+            context.ReportDiagnostic(Diagnostic.Create(
+                GuardrailDiagnostics.EngineDirectExternalCall,
+                invocation.Syntax.GetLocation(), enclosingName, receiver));
+            return;
+        }
+
+        // (I1) Service-locator resolve of a denylisted vendor-credential type.
+        if (Allowlist.ServiceLocatorMethodNames.Contains(target.Name))
+        {
+            var resolved = ResolvedServiceType(invocation);
+            if (resolved is not null && Allowlist.InjectionDenylist.Contains(FullName(resolved)))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    GuardrailDiagnostics.EngineDirectExternalCall,
+                    invocation.Syntax.GetLocation(), enclosingName,
+                    $"service-locator resolve of '{FullName(resolved)}'"));
+                return;
+            }
+        }
+
+        // (1) Direct external HTTP.
+        if (!IsHttpSendMethod(target))
+            return;
+
+        foreach (var argument in invocation.Arguments)
+        {
+            var host = TryResolveExternalHost(argument.Value);
+            if (host is not null)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    GuardrailDiagnostics.EngineDirectExternalCall,
+                    invocation.Syntax.GetLocation(), enclosingName, $"external host '{host}'"));
+                return;
+            }
+        }
+    }
+
+    // ----- (M2) vendor construction: `new <denylisted-type>()` ---------------------------
+    private static void InspectObjectCreation(OperationAnalysisContext context)
+    {
+        var creation = (IObjectCreationOperation)context.Operation;
+
+        var enclosing = context.ContainingSymbol as INamedTypeSymbol
+                        ?? context.ContainingSymbol?.ContainingType;
+        if (enclosing is not null && IsExempt(enclosing))
+            return;
+
+        var typeName = FullName(creation.Type);
+        if (Allowlist.InjectionDenylist.Contains(typeName))
+        {
+            var enclosingName = enclosing?.Name ?? "<engine>";
+            context.ReportDiagnostic(Diagnostic.Create(
+                GuardrailDiagnostics.EngineDirectExternalCall,
+                creation.Syntax.GetLocation(), enclosingName, $"construction of '{typeName}'"));
+        }
+    }
+
+    // ----- helpers -----------------------------------------------------------------------
+
+    /// <summary>The service type a <c>GetService</c>/<c>GetRequiredService</c>/... call
+    /// resolves: the generic <c>&lt;T&gt;</c> type argument, else the <c>typeof(T)</c> operand
+    /// of the <c>Type</c>-arg overload. Null when neither is statically known.</summary>
+    private static ITypeSymbol? ResolvedServiceType(IInvocationOperation invocation)
+    {
+        var typeArgs = invocation.TargetMethod.TypeArguments;
+        if (typeArgs.Length == 1)
+            return typeArgs[0];
+
+        foreach (var argument in invocation.Arguments)
+        {
+            if (Unwrap(argument.Value) is ITypeOfOperation typeOf)
+                return typeOf.TypeOperand;
+        }
+
+        return null;
+    }
+
+    private static bool IsHttpSendMethod(IMethodSymbol method)
+    {
+        if (!Allowlist.HttpSendMethodNames.Contains(method.Name))
+            return false;
+
+        var containing = method.ContainingType;
+        if (containing is null)
+            return false;
+
+        if (Allowlist.HttpClientTypeNames.Contains(FullName(containing)))
+            return true;
+
+        // Instance sends (e.g. SendAsync) declared on HttpMessageInvoker / a subtype.
+        for (var baseType = containing.BaseType; baseType is not null; baseType = baseType.BaseType)
+        {
+            if (FullName(baseType) == HttpMessageInvoker)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>Returns the EXTERNAL host of a URL argument when it is statically
+    /// resolvable (a string constant; an interpolated string whose LEADING part is a literal
+    /// absolute URL; or an inline <c>new HttpRequestMessage(method, "https://...")</c> /
+    /// <c>new Uri("https://...")</c> whose literal URL is dug out). Returns null for loopback
+    /// hosts and for any argument whose host cannot be resolved (a variable / config value /
+    /// a leading interpolation). A non-literal host is NOT treated as a violation here — the
+    /// credential to reach a real vendor has to arrive via an injected client, a
+    /// service-locator resolve, or a constructed vendor SDK, all caught by the other passes;
+    /// only a fully-untyped credential reaching a non-literal URL is a documented residual
+    /// gap.</summary>
+    private static string? TryResolveExternalHost(IOperation? value)
+    {
+        value = Unwrap(value);
+        if (value is null)
+            return null;
+
+        // Dig a literal URL out of an inline `new HttpRequestMessage(method, "https://...")`
+        // / `new Uri("https://...")` (the shape a sync/async Send takes) — the request/URI is
+        // constructed at the call site, so its literal host is statically resolvable.
+        if (value is IObjectCreationOperation creation)
+        {
+            foreach (var argument in creation.Arguments)
+            {
+                var nested = TryResolveExternalHost(argument.Value);
+                if (nested is not null)
+                    return nested;
+            }
+            return null;
+        }
+
+        string? text = null;
+
+        if (value.ConstantValue.HasValue && value.ConstantValue.Value is string constant)
+        {
+            text = constant;
+        }
+        else if (value is IInterpolatedStringOperation interpolated)
+        {
+            var firstPart = interpolated.Parts.FirstOrDefault();
+            if (firstPart is IInterpolatedStringTextOperation textPart &&
+                textPart.Text.ConstantValue.HasValue &&
+                textPart.Text.ConstantValue.Value is string leading)
+            {
+                text = leading;
+            }
+            else
+            {
+                // Leading interpolation (e.g. $"{callbackUrl}/...") — host not resolvable.
+                return null;
+            }
+        }
+
+        if (string.IsNullOrEmpty(text))
+            return null;
+
+        if (!Uri.TryCreate(text, UriKind.Absolute, out var uri))
+            return null;
+        if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
+            return null;
+
+        var host = uri.Host;
+        if (string.IsNullOrEmpty(host) || IsLoopback(host))
+            return null;
+
+        return host;
+    }
+
+    private static bool IsLoopback(string host) =>
+        host.Equals("localhost", StringComparison.OrdinalIgnoreCase)
+        || host == "127.0.0.1"
+        || host == "0.0.0.0"
+        || host == "::1"
+        || host == "[::1]"
+        || host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase);
+
+    private static IOperation? Unwrap(IOperation? operation)
+    {
+        while (operation is IConversionOperation conversion)
+            operation = conversion.Operand;
+        return operation;
+    }
+
+    private static bool IsExempt(INamedTypeSymbol? type)
+    {
+        if (type is null)
+            return false;
+
+        if (Allowlist.ExemptTypeNames.Contains(FullName(type)))
+            return true;
+
+        foreach (var iface in type.AllInterfaces)
+        {
+            if (Allowlist.ExemptTypeNames.Contains(FullName(iface)))
+                return true;
+        }
+
+        for (var baseType = type.BaseType; baseType is not null; baseType = baseType.BaseType)
+        {
+            if (Allowlist.ExemptTypeNames.Contains(FullName(baseType)))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static string FullName(ITypeSymbol? type) =>
+        type is null ? string.Empty : type.OriginalDefinition.ToDisplayString(FullyQualified);
+}

--- a/apps/tamma-elsa/src/Tamma.Activities.Guardrails/GuardrailDiagnostics.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities.Guardrails/GuardrailDiagnostics.cs
@@ -1,0 +1,45 @@
+using Microsoft.CodeAnalysis;
+
+namespace Tamma.Activities.Guardrails;
+
+/// <summary>
+/// Story 38-4 — the single build diagnostic emitted by
+/// <see cref="EngineExternalCallAnalyzer"/>.
+///
+/// <para><b>TAMMA001</b> — an engine-surface type (<c>Tamma.Activities</c> /
+/// <c>Tamma.ElsaServer</c>) either makes a direct external HTTP call, injects a
+/// credential-holding vendor service, or invokes a denied Slack send. It is declared at
+/// <see cref="DiagnosticSeverity.Error"/> so it FAILS THE BUILD — the repo sets
+/// <c>TreatWarningsAsErrors=false</c> (see <c>Directory.Build.props</c>), so a Warning
+/// would not gate. This is the permanent backstop for rule 1 ("a workflow STEP must never
+/// call an external API/provider directly"): the credential-holding code, the external
+/// HTTP call, and the metering/audit all live in <c>Tamma.Api</c>; the engine delegates
+/// over HTTP via <c>TammaApiClient</c> and holds NO external credential.</para>
+/// </summary>
+public static class GuardrailDiagnostics
+{
+    /// <summary>The diagnostic id — documented under <c>## TAMMA001</c> so a developer who
+    /// hits it can self-serve the mediation fix.</summary>
+    public const string Id = "TAMMA001";
+
+    /// <summary>The analyzer category (used by rule-config / suppression tooling).</summary>
+    public const string Category = "Tamma.Architecture";
+
+    public static readonly DiagnosticDescriptor EngineDirectExternalCall = new(
+        id: Id,
+        title: "Engine step makes a direct external call or injects a vendor credential",
+        messageFormat:
+            "'{0}' performs a direct external call / injects credential-holding '{1}'. " +
+            "Engine steps must delegate to Tamma.Api via TammaApiClient (rule 1; design §1). " +
+            "See the /api/v1/llm/call (32-5) / /api/v1/git/* (38-1) / /api/v1/notifications/slack (38-3) pattern.",
+        category: Category,
+        // Error so it fails the build (TreatWarningsAsErrors is false repo-wide).
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description:
+            "A workflow step must never call an external API/provider directly or hold an external credential. " +
+            "Route the effect through Tamma.Api via TammaApiClient; the API is the sole holder of external " +
+            "credentials and the sole caller of external endpoints.",
+        helpLinkUri:
+            "https://github.com/meywd/tamma/blob/main/docs/superpowers/specs/2026-06-20-epic-32-revised-agent-architecture.md");
+}

--- a/apps/tamma-elsa/src/Tamma.Activities.Guardrails/Tamma.Activities.Guardrails.csproj
+++ b/apps/tamma-elsa/src/Tamma.Activities.Guardrails/Tamma.Activities.Guardrails.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Story 38-4 — build-time rule-1 guardrail analyzer.
+
+    A netstandard2.0 Roslyn DiagnosticAnalyzer (TAMMA001) referenced by the engine
+    projects (Tamma.Activities / Tamma.ElsaServer) via an
+    <ProjectReference OutputItemType="Analyzer" ReferenceOutputAssembly="false" />,
+    so the existing `dotnet build Tamma.sln` is the gate (no new CI job). Declared at
+    DiagnosticSeverity.Error because Directory.Build.props sets TreatWarningsAsErrors=false
+    repo-wide — a Warning would not fail the build.
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>Tamma.Activities.Guardrails</RootNamespace>
+    <AssemblyName>Tamma.Activities.Guardrails</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <!-- This project is consumed as an analyzer, never as a runtime library. -->
+    <IncludeSymbols>false</IncludeSymbols>
+    <Version>1.0.0</Version>
+    <Authors>Tamma Team</Authors>
+    <Description>Story 38-4 — build-time rule-1 guardrail analyzer (TAMMA001) for the Tamma engine surface.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Compiler-provided at analysis time; PrivateAssets=all keeps it from flowing to
+         consumers (the host compiler supplies Microsoft.CodeAnalysis.* at its own version). -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
+  </ItemGroup>
+
+  <!-- Analyzer release tracking (RS2008) — declares TAMMA001 for the release-tracking rule. -->
+  <ItemGroup>
+    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+  </ItemGroup>
+
+</Project>

--- a/apps/tamma-elsa/src/Tamma.Activities/Tamma.Activities.csproj
+++ b/apps/tamma-elsa/src/Tamma.Activities/Tamma.Activities.csproj
@@ -37,4 +37,13 @@
     <ProjectReference Include="..\Tamma.Data\Tamma.Data.csproj" />
   </ItemGroup>
 
+  <!-- Story 38-4 — rule-1 build-time guardrail (TAMMA001). Referenced as an ANALYZER so
+       `dotnet build Tamma.sln` fails if any engine-surface type re-introduces a direct
+       external call or a vendor-credential injection. Do NOT suppress TAMMA001. -->
+  <ItemGroup>
+    <ProjectReference Include="..\Tamma.Activities.Guardrails\Tamma.Activities.Guardrails.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
 </Project>

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Tamma.ElsaServer.csproj
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Tamma.ElsaServer.csproj
@@ -50,4 +50,13 @@
     <ProjectReference Include="..\Tamma.Activities\Tamma.Activities.csproj" />
   </ItemGroup>
 
+  <!-- Story 38-4 — rule-1 build-time guardrail (TAMMA001). Referenced as an ANALYZER so
+       `dotnet build Tamma.sln` fails if any engine-surface type re-introduces a direct
+       external call or a vendor-credential injection. Do NOT suppress TAMMA001. -->
+  <ItemGroup>
+    <ProjectReference Include="..\Tamma.Activities.Guardrails\Tamma.Activities.Guardrails.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
 </Project>

--- a/apps/tamma-elsa/tests/Tamma.Activities.Guardrails.Tests/EngineExternalCallAnalyzerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Guardrails.Tests/EngineExternalCallAnalyzerTests.cs
@@ -1,0 +1,380 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using NUnit.Framework;
+
+namespace Tamma.Activities.Guardrails.Tests;
+
+/// <summary>
+/// Story 38-4 (AC11) — analyzer unit tests: positive controls (direct vendor HTTP + vendor
+/// injection + denied Slack send), negative controls (TammaApiClient / Engine:CallbackUrl /
+/// variable-host / loopback), design-§5.3 exemptions, the non-engine-surface skip, and the
+/// descriptor severity/id/category.
+/// </summary>
+[TestFixture]
+public class EngineExternalCallAnalyzerTests
+{
+    // Minimal stubs for the vendor types the fixtures reference (declared with the exact
+    // FQNs the analyzer matches, so the fixtures compile with no external references and the
+    // analyzer's semantic-model FQN match is what is exercised).
+    private const string Vendors = @"
+namespace Octokit { public interface IGitHubClient { } public class GitHubClient { } }
+namespace Tamma.Activities.AgentDispatch { public interface IGitHubActionsClient { } }
+namespace Tamma.Activities.LlmCall.Credentials { public interface IProviderCredentialResolver { } }
+namespace Tamma.Activities.LlmCall { public interface IInlineToolLoopRunner { } }
+namespace SlackNet { public interface ISlackApiClient { } }
+namespace Microsoft.Extensions.Configuration { public interface IConfiguration { } }
+namespace Tamma.Core.Interfaces {
+  public interface IIntegrationService {
+    System.Threading.Tasks.Task SendSlackMessageAsync(string channel, string message);
+    System.Threading.Tasks.Task SendSlackDirectMessageAsync(string userId, string message);
+    System.Threading.Tasks.Task<bool> MergePullRequestAsync(string repo, int pr);
+  }
+}
+// Minimal service-locator surface (DI container / Elsa's ActivityExecutionContext) — the
+// generic <T> + typeof(T) resolve overloads the FIX I1 pass keys on.
+public class ServiceCtx {
+  public T GetService<T>() => throw new System.NotImplementedException();
+  public T GetRequiredService<T>() => throw new System.NotImplementedException();
+  public T GetKeyedService<T>(object key) => throw new System.NotImplementedException();
+  public T GetRequiredKeyedService<T>(object key) => throw new System.NotImplementedException();
+  public object GetService(System.Type serviceType) => throw new System.NotImplementedException();
+}
+";
+
+    // ---------- (1) direct external HTTP → TAMMA001 --------------------------------------
+
+    [Test]
+    public Task DirectVendorHttp_PostAsJsonAsync_ToGitHub_Flags() => Verify.Engine(@"
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+public class BadHttpActivity {
+    private readonly HttpClient _http = new HttpClient();
+    public async Task Run() {
+        await {|TAMMA001:_http.PostAsJsonAsync(""https://api.github.com/repos/o/r/merges"", new { })|};
+    }
+}" + Vendors);
+
+    [Test]
+    public Task DirectVendorHttp_GetAsync_ToOpenAi_Flags() => Verify.Engine(@"
+using System.Net.Http;
+using System.Threading.Tasks;
+public class BadHttpActivity {
+    private readonly HttpClient _http = new HttpClient();
+    public async Task Run() {
+        await {|TAMMA001:_http.GetAsync(""https://api.openai.com/v1/models"")|};
+    }
+}" + Vendors);
+
+    [Test]
+    public Task DirectVendorHttp_InterpolatedLiteralHost_Flags() => Verify.Engine(@"
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+public class BadHttpActivity {
+    private readonly HttpClient _http = new HttpClient();
+    public async Task Run(string owner) {
+        await {|TAMMA001:_http.PostAsJsonAsync($""https://api.github.com/repos/{owner}/x/merges"", new { })|};
+    }
+}" + Vendors);
+
+    [Test]
+    public Task DirectVendorHttp_OnElsaServerSurface_Flags() => Verify.ElsaServer(@"
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+public class BadSeeder {
+    private readonly HttpClient _http = new HttpClient();
+    public async Task Run() {
+        await {|TAMMA001:_http.PostAsJsonAsync(""https://slack.com/api/chat.postMessage"", new { })|};
+    }
+}" + Vendors);
+
+    // ---------- (2) vendor-credential injection → TAMMA001 ------------------------------
+
+    [Test]
+    public Task OctokitClient_CtorInjection_Flags() => Verify.Engine(@"
+public class BadActivity {
+    public BadActivity(Octokit.IGitHubClient {|TAMMA001:client|}) { }
+}" + Vendors);
+
+    [Test]
+    public Task GitHubActionsClient_CtorInjection_Flags() => Verify.Engine(@"
+public class BadActivity {
+    public BadActivity(Tamma.Activities.AgentDispatch.IGitHubActionsClient {|TAMMA001:actions|}) { }
+}" + Vendors);
+
+    [Test]
+    public Task ProviderCredentialResolver_FieldInjection_Flags() => Verify.Engine(@"
+public class BadActivity {
+    private Tamma.Activities.LlmCall.Credentials.IProviderCredentialResolver? {|TAMMA001:_resolver|};
+}" + Vendors);
+
+    [Test]
+    public Task ProviderCredentialResolver_PropertyInjection_Flags() => Verify.Engine(@"
+public class BadActivity {
+    public Tamma.Activities.LlmCall.Credentials.IProviderCredentialResolver? {|TAMMA001:Resolver|} { get; set; }
+}" + Vendors);
+
+    [Test]
+    public Task SlackClient_CtorInjection_Flags() => Verify.Engine(@"
+public class BadActivity {
+    public BadActivity(SlackNet.ISlackApiClient {|TAMMA001:slack|}) { }
+}" + Vendors);
+
+    // ---------- (3) denied Slack SEND invocation → TAMMA001 -----------------------------
+    // Injecting the COMPOSITE IIntegrationService is allowed (no injection diagnostic); only
+    // its Slack send methods are denied at the call site (Correction 2).
+
+    [Test]
+    public Task SendSlackMessageAsync_Invocation_Flags() => Verify.Engine(@"
+using System.Threading.Tasks;
+using Tamma.Core.Interfaces;
+public class Notifier {
+    private readonly IIntegrationService _svc;
+    public Notifier(IIntegrationService svc) { _svc = svc; }
+    public async Task Ping() {
+        await {|TAMMA001:_svc.SendSlackMessageAsync(""chan"", ""hi"")|};
+    }
+}" + Vendors);
+
+    [Test]
+    public Task SendSlackDirectMessageAsync_Invocation_Flags() => Verify.Engine(@"
+using System.Threading.Tasks;
+using Tamma.Core.Interfaces;
+public class Notifier {
+    private readonly IIntegrationService _svc;
+    public Notifier(IIntegrationService svc) { _svc = svc; }
+    public async Task Ping() {
+        await {|TAMMA001:_svc.SendSlackDirectMessageAsync(""U1"", ""hi"")|};
+    }
+}" + Vendors);
+
+    [Test]
+    public Task CompositeIntegrationService_NonSlackMethod_DoesNotFlag() => Verify.Engine(@"
+using System.Threading.Tasks;
+using Tamma.Core.Interfaces;
+public class Merger {
+    private readonly IIntegrationService _svc;
+    public Merger(IIntegrationService svc) { _svc = svc; }
+    public async Task Do() {
+        await _svc.MergePullRequestAsync(""o/r"", 5);
+    }
+}" + Vendors);
+
+    // ---------- (M1) injecting the Tamma.Api LLM core into an engine step → TAMMA001 -----
+    // The whole-type EXEMPTION suppresses ONLY the runner's own members; INJECTING it into a
+    // different engine activity would drive a credentialed LLM call from a workflow STEP.
+
+    [Test]
+    public Task InlineToolLoopRunner_CtorInjection_Flags() => Verify.Engine(@"
+public class BadActivity {
+    public BadActivity(Tamma.Activities.LlmCall.IInlineToolLoopRunner {|TAMMA001:runner|}) { }
+}" + Vendors);
+
+    // ---------- (I1) service-locator resolve of a denylisted vendor type → TAMMA001 ------
+
+    [Test]
+    public Task ServiceLocator_GetRequiredService_Octokit_Flags() => Verify.Engine(@"
+public class BadActivity {
+    private readonly ServiceCtx _ctx;
+    public BadActivity(ServiceCtx ctx) { _ctx = ctx; }
+    public void Run() {
+        {|TAMMA001:_ctx.GetRequiredService<Octokit.IGitHubClient>()|};
+    }
+}" + Vendors);
+
+    [Test]
+    public Task ServiceLocator_GetService_CredentialResolver_Flags() => Verify.Engine(@"
+public class BadActivity {
+    private readonly ServiceCtx _ctx;
+    public BadActivity(ServiceCtx ctx) { _ctx = ctx; }
+    public void Run() {
+        {|TAMMA001:_ctx.GetService<Tamma.Activities.LlmCall.Credentials.IProviderCredentialResolver>()|};
+    }
+}" + Vendors);
+
+    [Test]
+    public Task ServiceLocator_TypeofOverload_Octokit_Flags() => Verify.Engine(@"
+public class BadActivity {
+    private readonly ServiceCtx _ctx;
+    public BadActivity(ServiceCtx ctx) { _ctx = ctx; }
+    public void Run() {
+        {|TAMMA001:_ctx.GetService(typeof(Octokit.IGitHubClient))|};
+    }
+}" + Vendors);
+
+    [Test]
+    public Task ServiceLocator_NonDenylistedTypes_DoesNotFlag() => Verify.Engine(@"
+namespace Tamma.Activities.LlmCall { public class TammaApiClient { } }
+public class GoodActivity {
+    private readonly ServiceCtx _ctx;
+    public GoodActivity(ServiceCtx ctx) { _ctx = ctx; }
+    public void Run() {
+        _ctx.GetService<Tamma.Activities.LlmCall.TammaApiClient>();
+        _ctx.GetRequiredService<Microsoft.Extensions.Configuration.IConfiguration>();
+        _ctx.GetService(typeof(Microsoft.Extensions.Configuration.IConfiguration));
+    }
+}" + Vendors);
+
+    // ---------- (M2) `new <denylisted-vendor>()` construction → TAMMA001 -----------------
+    // Stored in an `object` field so the field pass (2) does NOT fire — only the
+    // ObjectCreation pass does, proving construction is inspected on its own.
+
+    [Test]
+    public Task VendorConstruction_NewOctokitClient_Flags() => Verify.Engine(@"
+public class BadActivity {
+    private readonly object _client = {|TAMMA001:new Octokit.GitHubClient()|};
+}" + Vendors);
+
+    [Test]
+    public Task VendorConstruction_NonVendor_DoesNotFlag() => Verify.Engine(@"
+public class GoodActivity {
+    private readonly object _x = new object();
+    private readonly System.Net.Http.HttpClient _http = new System.Net.Http.HttpClient();
+}" + Vendors);
+
+    // ---------- (M3) synchronous HttpClient.Send to a literal external host → TAMMA001 ---
+
+    [Test]
+    public Task DirectVendorHttp_SyncSend_LiteralHost_Flags() => Verify.Engine(@"
+using System.Net.Http;
+public class BadHttpActivity {
+    private readonly HttpClient _http = new HttpClient();
+    public void Run() {
+        var resp = {|TAMMA001:_http.Send(new HttpRequestMessage(HttpMethod.Get, ""https://api.github.com/x""))|};
+    }
+}" + Vendors);
+
+    // ---------- negative controls: sanctioned seams (AC4) → no diagnostic --------------
+
+    [Test]
+    public Task ThinClient_TammaApiClientCall_DoesNotFlag() => Verify.Engine(@"
+using System.Threading.Tasks;
+namespace Tamma.Activities.LlmCall {
+  public class TammaApiClient {
+    public Task<bool> QueueSlackNotificationAsync(object request) => Task.FromResult(true);
+  }
+}
+public class ThinActivity {
+    private readonly Tamma.Activities.LlmCall.TammaApiClient _api;
+    public ThinActivity(Tamma.Activities.LlmCall.TammaApiClient api) { _api = api; }
+    public async Task Run() { await _api.QueueSlackNotificationAsync(new { }); }
+}" + Vendors);
+
+    [Test]
+    public Task EngineCallbackHost_InterpolatedPost_DoesNotFlag() => Verify.Engine(@"
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+public class CiActivity {
+    private readonly HttpClient _http = new HttpClient();
+    private readonly string _callbackUrl = ""http://elsa-callback/root"";
+    public async Task Run() {
+        await _http.PostAsJsonAsync($""{_callbackUrl}/api/engine/trigger-ci"", new { });
+    }
+}" + Vendors);
+
+    [Test]
+    public Task VariableHostHttp_DoesNotFlag() => Verify.Engine(@"
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+public class DynActivity {
+    private readonly HttpClient _http = new HttpClient();
+    public async Task Run(string url) { await _http.PostAsJsonAsync(url, new { }); }
+}" + Vendors);
+
+    [Test]
+    public Task LoopbackHost_DoesNotFlag() => Verify.Engine(@"
+using System.Net.Http;
+using System.Threading.Tasks;
+public class LocalActivity {
+    private readonly HttpClient _http = new HttpClient();
+    public async Task Run() { await _http.GetAsync(""http://localhost:3000/api/v1/agents/x/resolve""); }
+}" + Vendors);
+
+    [Test]
+    public Task InjectingTammaApiClient_DoesNotFlag() => Verify.Engine(@"
+namespace Tamma.Activities.LlmCall { public class TammaApiClient { } }
+public class ThinActivity {
+    private readonly Tamma.Activities.LlmCall.TammaApiClient _api;
+    public ThinActivity(Tamma.Activities.LlmCall.TammaApiClient api) { _api = api; }
+}" + Vendors);
+
+    // ---------- exemptions (design §5.3) → no diagnostic --------------------------------
+
+    [Test]
+    public Task LocalTool_FileReadTool_DoesNotFlag() => Verify.Engine(@"
+namespace Tamma.Activities.LlmCall.Tools {
+  using System.Net.Http; using System.Net.Http.Json; using System.Threading.Tasks;
+  public class FileReadTool {
+    private readonly HttpClient _http = new HttpClient();
+    public async Task Run() { await _http.PostAsJsonAsync(""https://api.github.com/x"", new { }); }
+  }
+}" + Vendors);
+
+    [Test]
+    public Task InboundWebhookRegistry_WithVendorCtor_DoesNotFlag() => Verify.Engine(@"
+namespace Tamma.Activities.AgentDispatch {
+  public class WebhookSignalRegistry {
+    public WebhookSignalRegistry(Octokit.IGitHubClient gh) { }
+  }
+}" + Vendors);
+
+    [Test]
+    public Task InlineToolLoopRunner_ApiCoreCoLocated_DoesNotFlag() => Verify.Engine(@"
+namespace Tamma.Activities.LlmCall {
+  using System.Net.Http; using System.Net.Http.Json; using System.Threading.Tasks;
+  public class InlineToolLoopRunner {
+    private readonly HttpClient _http = new HttpClient();
+    public InlineToolLoopRunner(Tamma.Activities.LlmCall.Credentials.IProviderCredentialResolver r) { }
+    public async Task Run() { await _http.PostAsJsonAsync(""https://api.anthropic.com/v1/messages"", new { }); }
+  }
+}" + Vendors);
+
+    [Test]
+    public Task CliAgentProviderImpl_DoesNotFlag() => Verify.Engine(@"
+using System.Net.Http;
+using System.Threading.Tasks;
+namespace Tamma.Providers { public interface ICLIAgentProvider { } }
+public class LocalCliAgent : Tamma.Providers.ICLIAgentProvider {
+    private readonly HttpClient _http = new HttpClient();
+    public async Task Run() { await _http.GetAsync(""https://api.example.com/x""); }
+}" + Vendors);
+
+    // ---------- non-engine surface (AC / testing #6) → no diagnostic --------------------
+
+    [Test]
+    public Task SameDirectVendorCall_InTammaApi_DoesNotFlag() => Verify.Api(@"
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+public class ApiCaller {
+    private readonly HttpClient _http = new HttpClient();
+    public async Task Run() { await _http.PostAsJsonAsync(""https://api.github.com/x"", new { }); }
+}" + Vendors);
+
+    [Test]
+    public Task VendorInjection_InTammaApi_DoesNotFlag() => Verify.Api(@"
+public class ApiService {
+    public ApiService(Octokit.IGitHubClient client) { }
+}" + Vendors);
+
+    // ---------- descriptor severity / id / category (AC6, testing #7 & #10) -------------
+
+    [Test]
+    public void Descriptor_Is_Error_Tamma001_Architecture()
+    {
+        var d = GuardrailDiagnostics.EngineDirectExternalCall;
+        Assert.That(d.Id, Is.EqualTo("TAMMA001"));
+        Assert.That(d.DefaultSeverity, Is.EqualTo(DiagnosticSeverity.Error));
+        Assert.That(d.Category, Is.EqualTo("Tamma.Architecture"));
+        Assert.That(d.IsEnabledByDefault, Is.True);
+        Assert.That(d.HelpLinkUri, Is.Not.Empty);
+
+        var supported = new EngineExternalCallAnalyzer().SupportedDiagnostics;
+        Assert.That(supported.Any(x => x.Id == "TAMMA001"), Is.True);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Guardrails.Tests/Tamma.Activities.Guardrails.Tests.csproj
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Guardrails.Tests/Tamma.Activities.Guardrails.Tests.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Story 38-4 — unit tests for the EngineExternalCallAnalyzer (TAMMA001), using the Roslyn
+    analyzer-testing harness (Microsoft.CodeAnalysis.CSharp.Analyzer.Testing) with NUnit
+    (matching the repo's test stack). The analyzer is referenced as a NORMAL library here
+    (we instantiate its type + descriptor); it is NOT applied as an analyzer to this project.
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <!-- Roslyn analyzer-testing harness (CSharpAnalyzerTest + DefaultVerifier) + a pinned
+         Roslyn (Workspaces) matching the analyzer's Microsoft.CodeAnalysis.CSharp 4.8.0. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Plain reference (NOT OutputItemType=Analyzer): load the analyzer type + descriptor. -->
+    <ProjectReference Include="..\..\src\Tamma.Activities.Guardrails\Tamma.Activities.Guardrails.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/apps/tamma-elsa/tests/Tamma.Activities.Guardrails.Tests/Verify.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Guardrails.Tests/Verify.cs
@@ -1,0 +1,39 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Tamma.Activities.Guardrails.Tests;
+
+/// <summary>
+/// Story 38-4 — thin wrapper over the Roslyn analyzer-testing harness
+/// (<see cref="CSharpAnalyzerTest{TAnalyzer, TVerifier}"/> + <see cref="DefaultVerifier"/>).
+/// The engine-surface guard keys off <c>Compilation.AssemblyName</c>, so each run renames
+/// the test project's assembly to a real engine name (or <c>Tamma.Api</c> for the
+/// non-engine negative control) via a solution transform. Expected diagnostics are declared
+/// inline with <c>{|TAMMA001:...|}</c> markup; a source with no markup asserts zero.
+/// </summary>
+internal static class Verify
+{
+    /// <summary>Analyze <paramref name="source"/> as the <c>Tamma.Activities</c> engine assembly.</summary>
+    public static Task Engine(string source) => Run(source, "Tamma.Activities");
+
+    /// <summary>Analyze <paramref name="source"/> as the <c>Tamma.ElsaServer</c> engine assembly.</summary>
+    public static Task ElsaServer(string source) => Run(source, "Tamma.ElsaServer");
+
+    /// <summary>Analyze <paramref name="source"/> as <c>Tamma.Api</c> (NOT the engine surface).</summary>
+    public static Task Api(string source) => Run(source, "Tamma.Api");
+
+    private static async Task Run(string source, string assemblyName)
+    {
+        var test = new CSharpAnalyzerTest<EngineExternalCallAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+        test.TestState.OutputKind = OutputKind.DynamicallyLinkedLibrary;
+        test.SolutionTransforms.Add((solution, projectId) =>
+            solution.WithProjectAssemblyName(projectId, assemblyName));
+        await test.RunAsync();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Guardrails/ActivitiesGuardrailTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Guardrails/ActivitiesGuardrailTests.cs
@@ -1,0 +1,322 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace Tamma.Activities.Tests.Guardrails;
+
+/// <summary>
+/// Story 38-4 (AC7 + AC8) — the reflection-backed backstop for the TAMMA001 Roslyn
+/// analyzer. It:
+/// <list type="bullet">
+///   <item>loads the REAL built <c>Tamma.Activities</c> / <c>Tamma.ElsaServer</c> assemblies
+///     and asserts no type's constructor parameter / field / property is a denylisted
+///     vendor-credential type (proving the post-cutover engine surface is clean) — except
+///     the documented exemptions (design §5.3 + the co-located Tamma.Api LLM core);</item>
+///   <item>asserts the analyzer is WIRED into both engine projects as an
+///     <c>OutputItemType="Analyzer"</c> reference (so the gate is actually active); and</item>
+///   <item>asserts NO <c>TAMMA001</c> suppression exists anywhere under the engine surface
+///     (AC8 — the gate can't be quietly turned off).</item>
+/// </list>
+/// This is an INDEPENDENT check: the denylist below is hardcoded (not imported from the
+/// analyzer's internal Allowlist), so weakening the analyzer would not weaken this backstop.
+/// </summary>
+[TestFixture]
+public class ActivitiesGuardrailTests
+{
+    // Independent mirror of the vendor-credential INJECTION denylist (the composite
+    // IIntegrationService is deliberately NOT here — see Allowlist.cs / the story report).
+    private static readonly HashSet<string> Denylist = new(StringComparer.Ordinal)
+    {
+        "Octokit.IGitHubClient",
+        "Octokit.GitHubClient",
+        "Tamma.Activities.AgentDispatch.IGitHubActionsClient",
+        "Tamma.Core.Interfaces.IGitHubIntegrationService",
+        "Tamma.Core.Interfaces.ISlackIntegrationService",
+        "Tamma.Activities.LlmCall.Credentials.IProviderCredentialResolver",
+        // FIX M1 — the Tamma.Api-executed LLM core; injecting it into an engine step is a
+        // rule-1 violation. Its OWN ctor injection of IProviderCredentialResolver is covered
+        // by the Exempt set below (the runner type is skipped entirely).
+        "Tamma.Activities.LlmCall.IInlineToolLoopRunner",
+        "Tamma.Activities.LlmCall.InlineToolLoopRunner",
+        "SlackNet.ISlackApiClient",
+        "Stripe.StripeClient",
+        "Stripe.IStripeClient",
+    };
+
+    // Design-§5.3 exemptions + the co-located Tamma.Api LLM core (tracked follow-up).
+    private static readonly HashSet<string> Exempt = new(StringComparer.Ordinal)
+    {
+        "Tamma.Providers.ICLIAgentProvider",
+        "Tamma.Activities.LlmCall.Tools.FileReadTool",
+        "Tamma.Activities.LlmCall.Tools.ShellExecuteTool",
+        "Tamma.Activities.LlmCall.Tools.GitOperationsTool",
+        "Tamma.Activities.AgentDispatch.WebhookSignalRegistry",
+        "Tamma.Activities.LlmCall.InlineToolLoopRunner",
+    };
+
+    private const BindingFlags AllMembers =
+        BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance |
+        BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+    [Test]
+    public void TammaActivitiesAssembly_HasNoDenylistedVendorInjection()
+        => AssertAssemblyClean(typeof(Tamma.Activities.LlmCall.TammaApiClient).Assembly);
+
+    [Test]
+    public void TammaElsaServerAssembly_HasNoDenylistedVendorInjection()
+        => AssertAssemblyClean(Assembly.Load("Tamma.ElsaServer"));
+
+    private static void AssertAssemblyClean(Assembly assembly)
+    {
+        foreach (var type in SafeGetTypes(assembly))
+        {
+            if (type is null || IsExempt(type) || IsCompilerGenerated(type))
+                continue;
+
+            foreach (var ctor in type.GetConstructors(AllMembers))
+                foreach (var p in ctor.GetParameters())
+                    Assert.That(Denylisted(p.ParameterType), Is.False,
+                        $"{type.FullName}: constructor injects denylisted vendor type " +
+                        $"'{p.ParameterType.FullName}' (rule-1 violation). Route the effect " +
+                        "through Tamma.Api via TammaApiClient.");
+
+            foreach (var f in type.GetFields(AllMembers))
+                Assert.That(Denylisted(f.FieldType), Is.False,
+                    $"{type.FullName}: field '{f.Name}' holds denylisted vendor type " +
+                    $"'{f.FieldType.FullName}' (rule-1 violation).");
+
+            foreach (var pr in type.GetProperties(AllMembers))
+                Assert.That(Denylisted(pr.PropertyType), Is.False,
+                    $"{type.FullName}: property '{pr.Name}' holds denylisted vendor type " +
+                    $"'{pr.PropertyType.FullName}' (rule-1 violation).");
+        }
+    }
+
+    [Test]
+    public void Analyzer_IsWiredInto_BothEngineProjects()
+    {
+        foreach (var rel in new[]
+        {
+            Path.Combine("src", "Tamma.Activities", "Tamma.Activities.csproj"),
+            Path.Combine("src", "Tamma.ElsaServer", "Tamma.ElsaServer.csproj"),
+        })
+        {
+            var path = Path.Combine(RepoRoot(), rel);
+            Assert.That(File.Exists(path), Is.True, $"missing {rel}");
+            var text = File.ReadAllText(path);
+            Assert.That(text.Contains("Tamma.Activities.Guardrails"), Is.True,
+                $"{rel} does not reference the guardrail analyzer project.");
+            Assert.That(text.Contains("OutputItemType=\"Analyzer\""), Is.True,
+                $"{rel} does not reference the guardrail as an Analyzer (gate inactive).");
+        }
+    }
+
+    [Test]
+    public void NoTamma001Suppression_UnderEngineSurface()
+    {
+        var offenders = ScanForTamma001Suppression(RepoRoot());
+
+        Assert.That(offenders, Is.Empty,
+            "TAMMA001 must never be suppressed under the engine surface:\n" +
+            string.Join("\n", offenders));
+    }
+
+    // AC8 counter-proof — plant every silent-off vector and assert the scan DETECTS each, so
+    // NoTamma001Suppression_UnderEngineSurface can actually fail (empirically the .editorconfig
+    // severity=none and the <NoWarn>TAMMA001 both disable the gate while an inline-only scan
+    // stays green).
+    [Test]
+    public void SuppressionScan_DetectsPlantedEditorconfigNoWarnAndPragma()
+    {
+        var temp = Path.Combine(
+            Path.GetTempPath(), "tamma-guardrail-suppress-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(temp, "src", "Tamma.Activities"));
+
+            // (1) .editorconfig severity override at the apps/tamma-elsa root.
+            File.WriteAllText(Path.Combine(temp, ".editorconfig"),
+                "root = true\n\n[*.cs]\ndotnet_diagnostic.TAMMA001.severity = none\n");
+            // (2) <NoWarn> in the root Directory.Build.props (the file that already carries NU1605).
+            File.WriteAllText(Path.Combine(temp, "Directory.Build.props"),
+                "<Project><PropertyGroup><NoWarn>$(NoWarn);NU1605;TAMMA001</NoWarn></PropertyGroup></Project>\n");
+            // (3) #pragma under the engine src surface.
+            File.WriteAllText(Path.Combine(temp, "src", "Tamma.Activities", "Evil.cs"),
+                "#pragma warning disable TAMMA001\npublic class Evil { }\n");
+
+            var offenders = ScanForTamma001Suppression(temp);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(offenders.Any(o => o.Contains(".editorconfig")), Is.True,
+                    "planted .editorconfig 'dotnet_diagnostic.TAMMA001.severity = none' was NOT detected");
+                Assert.That(offenders.Any(o => o.Contains("Directory.Build.props")), Is.True,
+                    "planted '<NoWarn>...TAMMA001</NoWarn>' was NOT detected");
+                Assert.That(offenders.Any(o => o.Contains("Evil.cs")), Is.True,
+                    "planted '#pragma warning disable TAMMA001' was NOT detected");
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(temp))
+                Directory.Delete(temp, recursive: true);
+        }
+    }
+
+    // ----- helpers -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Scans an <c>apps/tamma-elsa</c> root for ANY way TAMMA001 could be silently turned off:
+    /// <list type="bullet">
+    ///   <item>an <c>.editorconfig</c>/<c>.globalconfig</c> (anywhere from the root down)
+    ///     setting <c>dotnet_diagnostic.TAMMA001.severity</c> to <c>none</c>/<c>silent</c>/<c>suppress</c>;</item>
+    ///   <item>a <c>Directory.Build.props</c>/<c>Directory.Build.targets</c>/<c>.csproj</c>
+    ///     (anywhere from the root down, so a root <c>Directory.Build.props</c> is in scope)
+    ///     whose <c>NoWarn</c> contains TAMMA001;</item>
+    ///   <item>a <c>#pragma warning disable TAMMA001</c> / <c>SuppressMessage</c> in a
+    ///     <c>.cs</c> file under the engine src surface.</item>
+    /// </list>
+    /// Independent of the analyzer's internal Allowlist — pure string inspection.
+    /// </summary>
+    private static List<string> ScanForTamma001Suppression(string elsaRoot)
+    {
+        var offenders = new List<string>();
+
+        // (a) build-config files anywhere from the root down.
+        foreach (var file in EnumerateFilesSkippingBuildDirs(elsaRoot))
+        {
+            var name = Path.GetFileName(file);
+
+            if (name.Equals(".editorconfig", StringComparison.OrdinalIgnoreCase) ||
+                name.Equals(".globalconfig", StringComparison.OrdinalIgnoreCase))
+            {
+                foreach (var line in File.ReadAllLines(file))
+                    if (IsEditorConfigTamma001Suppression(line))
+                        offenders.Add($"{file}: {line.Trim()}");
+            }
+            else if (name.Equals("Directory.Build.props", StringComparison.OrdinalIgnoreCase) ||
+                     name.Equals("Directory.Build.targets", StringComparison.OrdinalIgnoreCase) ||
+                     name.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+            {
+                foreach (var line in File.ReadAllLines(file))
+                    if (ContainsNoWarnTamma001(line))
+                        offenders.Add($"{file}: {line.Trim()}");
+            }
+        }
+
+        // (b) #pragma / SuppressMessage in .cs under the engine src surface only.
+        foreach (var engineDir in new[]
+        {
+            Path.Combine(elsaRoot, "src", "Tamma.Activities"),
+            Path.Combine(elsaRoot, "src", "Tamma.ElsaServer"),
+        })
+        {
+            foreach (var file in EnumerateFilesSkippingBuildDirs(engineDir))
+            {
+                if (!file.EndsWith(".cs", StringComparison.Ordinal))
+                    continue;
+                foreach (var line in File.ReadAllLines(file))
+                {
+                    if (!line.Contains("TAMMA001"))
+                        continue;
+                    var isSuppression =
+                        (line.Contains("#pragma") && line.Contains("warning") && line.Contains("disable")) ||
+                        line.Contains("SuppressMessage");
+                    if (isSuppression)
+                        offenders.Add($"{file}: {line.Trim()}");
+                }
+            }
+        }
+
+        return offenders;
+    }
+
+    /// <summary>True for an ACTIVE (non-comment) editorconfig/globalconfig line that sets
+    /// <c>dotnet_diagnostic.TAMMA001.severity</c> to none/silent/suppress.</summary>
+    private static bool IsEditorConfigTamma001Suppression(string rawLine)
+    {
+        var trimmed = rawLine.Trim();
+        if (trimmed.Length == 0 || trimmed[0] == '#' || trimmed[0] == ';')
+            return false; // blank / comment
+
+        var normalized = new string(trimmed.Where(c => !char.IsWhiteSpace(c)).ToArray())
+            .ToLowerInvariant();
+        const string prefix = "dotnet_diagnostic.tamma001.severity=";
+        if (!normalized.StartsWith(prefix, StringComparison.Ordinal))
+            return false;
+
+        var value = normalized.Substring(prefix.Length);
+        var comment = value.IndexOfAny(new[] { '#', ';' });
+        if (comment >= 0)
+            value = value.Substring(0, comment);
+        return value is "none" or "silent" or "suppress";
+    }
+
+    /// <summary>True for a line that carries both a <c>NoWarn</c> token and TAMMA001 (the
+    /// single-line <c>&lt;NoWarn&gt;$(NoWarn);TAMMA001&lt;/NoWarn&gt;</c> / MSBuild-property form).</summary>
+    private static bool ContainsNoWarnTamma001(string line) =>
+        line.IndexOf("NoWarn", StringComparison.OrdinalIgnoreCase) >= 0 &&
+        line.IndexOf("TAMMA001", StringComparison.Ordinal) >= 0;
+
+    private static IEnumerable<string> EnumerateFilesSkippingBuildDirs(string dir)
+    {
+        if (!Directory.Exists(dir))
+            yield break;
+        foreach (var file in Directory.EnumerateFiles(dir, "*", SearchOption.AllDirectories))
+        {
+            if (file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}") ||
+                file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}"))
+                continue;
+            yield return file;
+        }
+    }
+
+    private static bool Denylisted(Type t) =>
+        t.FullName is { } name && Denylist.Contains(StripNullable(name));
+
+    private static string StripNullable(string fullName)
+    {
+        // Nullable<T> value types surface as System.Nullable`1[[...]]; the denylist has no
+        // value types, so only the plain FQN prefix matters here.
+        var tick = fullName.IndexOf('`');
+        return tick >= 0 ? fullName.Substring(0, tick) : fullName;
+    }
+
+    private static bool IsExempt(Type type)
+    {
+        if (type.FullName is { } fqn && Exempt.Contains(fqn))
+            return true;
+        if (type.GetInterfaces().Any(i => i.FullName is { } n && Exempt.Contains(n)))
+            return true;
+        for (var b = type.BaseType; b is not null; b = b.BaseType)
+            if (b.FullName is { } bn && Exempt.Contains(bn))
+                return true;
+        return false;
+    }
+
+    private static bool IsCompilerGenerated(Type type) =>
+        type.Name.Contains('<') ||
+        type.GetCustomAttribute<System.Runtime.CompilerServices.CompilerGeneratedAttribute>() is not null;
+
+    private static IEnumerable<Type?> SafeGetTypes(Assembly assembly)
+    {
+        try { return assembly.GetTypes(); }
+        catch (ReflectionTypeLoadException ex) { return ex.Types; }
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "Tamma.sln")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+        throw new DirectoryNotFoundException(
+            "Could not locate apps/tamma-elsa (Tamma.sln) from " + AppContext.BaseDirectory);
+    }
+}


### PR DESCRIPTION
## Epic 38 Story 38-4 — Build-time guardrail analyzer (`TAMMA001`) — locks rule-1 permanently

The final Epic 38 story, and the **permanent backstop** for the whole "engine steps never call external APIs / hold vendor credentials" rule across Epics 32 + 38. The cutover stories (32-5 LLM, 38-1 git, 38-2 agent-dispatch, 38-3/3b Slack) removed the violations *once*; this makes a re-introduction **fail to compile**.

A Roslyn `DiagnosticAnalyzer` (`TAMMA001`, `Tamma.Architecture`, **`DiagnosticSeverity.Error`**) + a reflection backstop, wired via `OutputItemType="Analyzer"` `ProjectReference` into both engine csprojs so the existing `dotnet build Tamma.sln` is the gate (no new CI job). Pure build tooling — no CP table (AC10).

### Detection (semantic model, alias-proof) — 5 passes
1. Direct external HTTP to a statically-resolvable non-`TammaApiClient` / non-`Engine:CallbackUrl` host
2. Vendor-credential **injection** (ctor param / field / property) on a denylist
3. `SendSlack*Async` invocation on any receiver
4. Service-locator `GetService<denylisted>` (the dominant DI idiom — added in review)
5. `new <denylisted-vendor>()` construction (added in review)

Denylist: Octokit, `IGitHubActionsClient`, `IGitHubIntegrationService`, `ISlackIntegrationService`, `IProviderCredentialResolver`, `IInlineToolLoopRunner`, Slack/Stripe SDK. Allowlist: `TammaApiClient` + `Engine:CallbackUrl` + `IHttpClientFactory` feeding them. Exempt (design §5.3): local tools, `ICLIAgentProvider`, `WebhookSignalRegistry` (inbound). Engine surface only — `Tamma.Api` is *supposed* to call vendors.

### Two documented scope calls (tracked follow-ups)
- Composite `IIntegrationService` **excluded** from the injection denylist (still legitimately injected in 5 activities for non-Slack GitHub/CI/JIRA/email Epic 38 didn't mediate); pass 3 closes the Slack hole. Follow-up: migrate those, then add it.
- `InlineToolLoopRunner` (the 32-5 LLM core) lives in the engine assembly but is DI-registered + executed **only** in `Tamma.Api` (verified) — exempted by name; follow-up to physically relocate it.

### Review + fixes (adversarial reviewer empirically reproduced every evasion against the built analyzer)
- **CRITICAL** — the gate could be **silently killed** via `.editorconfig` `severity = none` or `<NoWarn>TAMMA001` in `Directory.Build.props`, and the AC8 suppression test missed both. The scan now walks the `apps/tamma-elsa` root (incl. `Directory.Build.props`/`.targets` + `.editorconfig`/`.globalconfig`) with a planted-detection counter-test.
- **IMPORTANT** — service-locator `GetService<denylisted>` evaded all passes → new pass 4.
- Plus: `new <vendor>()` (pass 5), `IInlineToolLoopRunner` injection, sync `HttpClient.Send`, and a doc correction (the reflection backstop covers injection, not HTTP).

Core gate confirmed solid: fails a real `dotnet build` (exit 1) on a violation, semantic-model FQN matching (alias-proof), constant-folds `const + "/path"` hosts, correct engine-surface gating, concurrency-safe.

### Verify (the load-bearing check)
`dotnet build Tamma.sln` → **0 errors / 0 TAMMA001 on the real cut-over engine surface** (no false positives). Analyzer unit tests **32/32** (every reproduced evasion now trips), reflection backstop **5/5** (incl. planted-suppression detection), full `Tamma.Activities.Tests` 2172/0, `Tamma.Api.Tests` 3949/0/5skip.

**Epic 38 COMPLETE.** The engine holds no LLM / git / agent-dispatch / Slack credential, and `TAMMA001` makes it permanent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
