### PR TITLE
fix(guardrails): pin LangVersion on the netstandard2.0 analyzer (fixes CS8630 / broken image build)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities.Guardrails/Tamma.Activities.Guardrails.csproj
+++ b/apps/tamma-elsa/src/Tamma.Activities.Guardrails/Tamma.Activities.Guardrails.csproj
@@ -13,6 +13,10 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <!-- netstandard2.0 defaults to C# 7.3 on some SDKs (notably the Docker build image),
+         which rejects <Nullable>enable</Nullable> with CS8630. Pin the language version so
+         nullable + modern C# compile regardless of the SDK's TFM default. -->
+    <LangVersion>latest</LangVersion>
     <RootNamespace>Tamma.Activities.Guardrails</RootNamespace>
     <AssemblyName>Tamma.Activities.Guardrails</AssemblyName>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
The 38-4 analyzer project (netstandard2.0 + `<Nullable>enable</Nullable>`, no `<LangVersion>`) defaulted to C# 7.3 on the Docker build SDK → CS8630 → `Build tamma-api` failed → deploy skipped. Local `dotnet build Tamma.sln` passed (higher SDK default), so the per-PR gate missed it. Pinned `<LangVersion>latest</LangVersion>`. Verified: `-p:LangVersion=7.3` reproduces the exact CS8630; the pin builds clean + guardrail tests pass. Unblocks all deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)