### PR TITLE
refactor(epic-38): relocate InlineToolLoopRunner into Tamma.Api

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities.Guardrails/Allowlist.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities.Guardrails/Allowlist.cs
@@ -50,19 +50,10 @@ internal static class Allowlist
         "Tamma.Activities.AgentDispatch.IGitHubActionsClient",
         "Tamma.Core.Interfaces.IGitHubIntegrationService",
         "Tamma.Core.Interfaces.ISlackIntegrationService",
-        // The engine must not resolve provider credentials post-32-5. (The one legitimate
-        // holder, InlineToolLoopRunner, is the Tamma.Api-executed LLM core — exempted below.)
+        // The engine must not resolve provider credentials post-32-5. (The LLM core that
+        // legitimately holds it — InlineToolLoopRunner — now lives in the Tamma.Api assembly,
+        // outside the analyzed engine surface, so no engine exemption is needed.)
         "Tamma.Activities.LlmCall.Credentials.IProviderCredentialResolver",
-        // FIX M1 — the inline tool-loop runner is the Tamma.Api-executed LLM core: it holds
-        // the direct anthropic/openai calls + IProviderCredentialResolver. It is DI-registered
-        // ONLY in Tamma.Api (Program.cs). INJECTING it into any engine activity would drive a
-        // credentialed LLM call from a workflow STEP — a rule-1 violation — so its injection is
-        // denied here. NB no conflict with the whole-type EXEMPTION below: the exemption keys on
-        // the ANALYZED (owner) type, so it only suppresses the runner's OWN members (its
-        // IProviderCredentialResolver ctor injection); a DIFFERENT engine type injecting the
-        // runner has a non-exempt owner and is correctly flagged.
-        "Tamma.Activities.LlmCall.IInlineToolLoopRunner",
-        "Tamma.Activities.LlmCall.InlineToolLoopRunner",
         // Forward-compatible (Epic 35 billing / future vendor SDKs) — harmless string data
         // until such a type is actually referenced by the engine:
         "SlackNet.ISlackApiClient",
@@ -140,15 +131,5 @@ internal static class Allowlist
         "Tamma.Activities.LlmCall.Tools.ShellExecuteTool",
         "Tamma.Activities.LlmCall.Tools.GitOperationsTool",
         // Inbound webhook-signal store (inbound; no outbound call):
-        "Tamma.Activities.AgentDispatch.WebhookSignalRegistry",
-        // TRACKED FOLLOW-UP — the API-plane LLM execution core. It is DI-registered and
-        // executed ONLY in Tamma.Api (ManagedAgent); it lives in the Tamma.Activities
-        // ASSEMBLY purely for code-organisation (32-5 extracted it verbatim from
-        // CallLlmInlineActivity). It ctor-injects IProviderCredentialResolver and holds the
-        // direct anthropic/openai calls = the sanctioned Tamma.Api LLM core, NOT an
-        // engine-executed path. Exempt so it does not false-positive the engine guardrail.
-        // Follow-up: physically relocate InlineToolLoopRunner (+ IInlineToolLoopRunner) into
-        // Tamma.Api, then delete this line (its IProviderCredentialResolver injection is
-        // then correctly outside the engine surface).
-        "Tamma.Activities.LlmCall.InlineToolLoopRunner");
+        "Tamma.Activities.AgentDispatch.WebhookSignalRegistry");
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -530,9 +530,11 @@ builder.Services.AddProviderCredentialResolution();
 // NullUsageEmitter = no-op, the AGENT.RUN.* DCB events remain the durable
 // signal) ship the SAFE default until those stories replace them behind the
 // same interfaces. IBudgetGuard is the per-call fail-closed gate (32-9 backs
-// running-spend later). InlineToolLoopRunner is the extracted T2 runner shared
-// from Tamma.Activities; its provider-side collaborators (sanitizer/registry/
-// validator/compactor) are all optional and are fully wired in the API in T4.
+// running-spend later). InlineToolLoopRunner is the extracted T2 runner, now
+// hosted in Tamma.Api.Services.Agents (the workflow-engine assembly no longer
+// hosts the agentic tool loop); its provider-side collaborators (sanitizer/
+// registry/validator/compactor) are all optional and are fully wired in the API
+// in T4.
 builder.Services.TryAddSingleton<Tamma.Api.Services.Agents.IProviderMarkupEngine,
     Tamma.Api.Services.Agents.PassthroughProviderMarkupEngine>();
 builder.Services.TryAddSingleton<Tamma.Api.Services.Agents.IUsageEmitter,
@@ -604,8 +606,8 @@ builder.Services.TryAddSingleton<Tamma.Activities.ToolExecution.ParallelToolExec
 // dep is the cabinet-backed DefaultProviderCredentialResolver (registered above
 // via AddProviderCredentialResolution) — but the loop never re-resolves: the key
 // is set on the provider config ManagedAgent hands it.
-builder.Services.AddScoped<Tamma.Activities.LlmCall.IInlineToolLoopRunner,
-    Tamma.Activities.LlmCall.InlineToolLoopRunner>();
+builder.Services.AddScoped<Tamma.Api.Services.Agents.IInlineToolLoopRunner,
+    Tamma.Api.Services.Agents.InlineToolLoopRunner>();
 builder.Services.AddScoped<Tamma.Api.Services.Agents.IManagedAgent,
     Tamma.Api.Services.Agents.ManagedAgent>();
 

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/IInlineToolLoopRunner.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/IInlineToolLoopRunner.cs
@@ -1,6 +1,6 @@
 using Tamma.Activities.LlmCall.Models;
 
-namespace Tamma.Activities.LlmCall;
+namespace Tamma.Api.Services.Agents;
 
 /// <summary>
 /// Story 32-5 (AC4) — the extracted, reusable agentic tool-loop seam.

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/InlineToolLoopRunner.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/InlineToolLoopRunner.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Tamma.Activities.LlmCall;
 using Tamma.Activities.LlmCall.Credentials;
 using Tamma.Activities.LlmCall.Models;
 using Tamma.Activities.LlmCall.Tools;
@@ -10,7 +11,7 @@ using Tamma.Activities.Security;
 using Tamma.Activities.ToolExecution;
 using Tamma.Core;
 
-namespace Tamma.Activities.LlmCall;
+namespace Tamma.Api.Services.Agents;
 
 /// <summary>
 /// Story 32-5 (AC4) — the agentic tool loop, extracted VERBATIM from

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/ManagedAgent.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/ManagedAgent.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
-using Tamma.Activities.LlmCall;
 using Tamma.Activities.LlmCall.Credentials;
 using Tamma.Activities.LlmCall.Models;
 using Tamma.Api.Services.Providers;

--- a/apps/tamma-elsa/tests/Tamma.Activities.Guardrails.Tests/EngineExternalCallAnalyzerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Guardrails.Tests/EngineExternalCallAnalyzerTests.cs
@@ -21,7 +21,6 @@ public class EngineExternalCallAnalyzerTests
 namespace Octokit { public interface IGitHubClient { } public class GitHubClient { } }
 namespace Tamma.Activities.AgentDispatch { public interface IGitHubActionsClient { } }
 namespace Tamma.Activities.LlmCall.Credentials { public interface IProviderCredentialResolver { } }
-namespace Tamma.Activities.LlmCall { public interface IInlineToolLoopRunner { } }
 namespace SlackNet { public interface ISlackApiClient { } }
 namespace Microsoft.Extensions.Configuration { public interface IConfiguration { } }
 namespace Tamma.Core.Interfaces {
@@ -161,16 +160,6 @@ public class Merger {
     public async Task Do() {
         await _svc.MergePullRequestAsync(""o/r"", 5);
     }
-}" + Vendors);
-
-    // ---------- (M1) injecting the Tamma.Api LLM core into an engine step → TAMMA001 -----
-    // The whole-type EXEMPTION suppresses ONLY the runner's own members; INJECTING it into a
-    // different engine activity would drive a credentialed LLM call from a workflow STEP.
-
-    [Test]
-    public Task InlineToolLoopRunner_CtorInjection_Flags() => Verify.Engine(@"
-public class BadActivity {
-    public BadActivity(Tamma.Activities.LlmCall.IInlineToolLoopRunner {|TAMMA001:runner|}) { }
 }" + Vendors);
 
     // ---------- (I1) service-locator resolve of a denylisted vendor type → TAMMA001 ------
@@ -320,17 +309,6 @@ namespace Tamma.Activities.LlmCall.Tools {
 namespace Tamma.Activities.AgentDispatch {
   public class WebhookSignalRegistry {
     public WebhookSignalRegistry(Octokit.IGitHubClient gh) { }
-  }
-}" + Vendors);
-
-    [Test]
-    public Task InlineToolLoopRunner_ApiCoreCoLocated_DoesNotFlag() => Verify.Engine(@"
-namespace Tamma.Activities.LlmCall {
-  using System.Net.Http; using System.Net.Http.Json; using System.Threading.Tasks;
-  public class InlineToolLoopRunner {
-    private readonly HttpClient _http = new HttpClient();
-    public InlineToolLoopRunner(Tamma.Activities.LlmCall.Credentials.IProviderCredentialResolver r) { }
-    public async Task Run() { await _http.PostAsJsonAsync(""https://api.anthropic.com/v1/messages"", new { }); }
   }
 }" + Vendors);
 

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Guardrails/ActivitiesGuardrailTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Guardrails/ActivitiesGuardrailTests.cs
@@ -14,7 +14,7 @@ namespace Tamma.Activities.Tests.Guardrails;
 ///   <item>loads the REAL built <c>Tamma.Activities</c> / <c>Tamma.ElsaServer</c> assemblies
 ///     and asserts no type's constructor parameter / field / property is a denylisted
 ///     vendor-credential type (proving the post-cutover engine surface is clean) — except
-///     the documented exemptions (design §5.3 + the co-located Tamma.Api LLM core);</item>
+///     the documented design-§5.3 exemptions;</item>
 ///   <item>asserts the analyzer is WIRED into both engine projects as an
 ///     <c>OutputItemType="Analyzer"</c> reference (so the gate is actually active); and</item>
 ///   <item>asserts NO <c>TAMMA001</c> suppression exists anywhere under the engine surface
@@ -36,17 +36,12 @@ public class ActivitiesGuardrailTests
         "Tamma.Core.Interfaces.IGitHubIntegrationService",
         "Tamma.Core.Interfaces.ISlackIntegrationService",
         "Tamma.Activities.LlmCall.Credentials.IProviderCredentialResolver",
-        // FIX M1 — the Tamma.Api-executed LLM core; injecting it into an engine step is a
-        // rule-1 violation. Its OWN ctor injection of IProviderCredentialResolver is covered
-        // by the Exempt set below (the runner type is skipped entirely).
-        "Tamma.Activities.LlmCall.IInlineToolLoopRunner",
-        "Tamma.Activities.LlmCall.InlineToolLoopRunner",
         "SlackNet.ISlackApiClient",
         "Stripe.StripeClient",
         "Stripe.IStripeClient",
     };
 
-    // Design-§5.3 exemptions + the co-located Tamma.Api LLM core (tracked follow-up).
+    // Design-§5.3 exemptions (local process / local filesystem / inbound signal).
     private static readonly HashSet<string> Exempt = new(StringComparer.Ordinal)
     {
         "Tamma.Providers.ICLIAgentProvider",
@@ -54,7 +49,6 @@ public class ActivitiesGuardrailTests
         "Tamma.Activities.LlmCall.Tools.ShellExecuteTool",
         "Tamma.Activities.LlmCall.Tools.GitOperationsTool",
         "Tamma.Activities.AgentDispatch.WebhookSignalRegistry",
-        "Tamma.Activities.LlmCall.InlineToolLoopRunner",
     };
 
     private const BindingFlags AllMembers =

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/LlmCall/NoDirectLlmCallTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/LlmCall/NoDirectLlmCallTests.cs
@@ -22,10 +22,11 @@ namespace Tamma.Activities.Tests.LlmCall;
 /// <list type="bullet">
 ///   <item>ZERO <c>*:ApiKey</c> / <c>*_API_KEY</c> config or env reads;</item>
 ///   <item>ZERO <c>/v1/messages</c> / <c>/v1/chat/completions</c> provider URLs
-///         and ZERO named provider <c>HttpClient</c>s EXCEPT inside the shared
-///         <see cref="InlineToolLoopRunner"/> (which executes in the API process,
-///         where the key is resolved) and the <see cref="TammaApiClient"/> wire
-///         client itself;</item>
+///         and ZERO named provider <c>HttpClient</c>s EXCEPT inside the
+///         <see cref="TammaApiClient"/> wire client itself (which only POSTs to the
+///         call-LLM endpoint, not to a provider). The shared
+///         <c>InlineToolLoopRunner</c> — the one type that DOES make a keyed
+///         provider call — now lives in <c>Tamma.Api</c>, outside this engine scan;</item>
 ///   <item>and the engine's <c>Tamma.ElsaServer</c> must be COMPLETELY clean of
 ///         all of the above AND register no provider credential resolver
 ///         (<c>AddEngineProviderCredentialResolution</c> /
@@ -43,12 +44,12 @@ namespace Tamma.Activities.Tests.LlmCall;
 [TestFixture]
 public class NoDirectLlmCallTests
 {
-    // Files that legitimately retain the provider HTTP call. The runner is the
-    // single extracted tool-loop (AC4) and runs in the API process; the wire
-    // client only POSTs to the call-LLM endpoint, not to a provider.
+    // Files under Tamma.Activities that legitimately retain a provider-shaped HTTP
+    // literal. Only the wire client remains: it POSTs to the call-LLM endpoint, not
+    // to a provider. The InlineToolLoopRunner (the sole keyed provider caller) has
+    // been relocated into Tamma.Api, so it is no longer part of this engine scan.
     private static readonly string[] AllowedProviderCallFiles =
     {
-        Path.Combine("LlmCall", "InlineToolLoopRunner.cs"),
         Path.Combine("LlmCall", "TammaApiClient.cs"),
     };
 
@@ -90,7 +91,7 @@ public class NoDirectLlmCallTests
     // ── Source scans over Tamma.Activities ─────────────────────────────────
 
     [Test]
-    public void TammaActivities_HasNoDirectProviderMessagesCall_OutsideRunnerAndWireClient()
+    public void TammaActivities_HasNoDirectProviderMessagesCall_OutsideWireClient()
     {
         var offenders = ActivitiesSourceFiles()
             .Where(f => !IsAllowedProviderCallFile(f.Relative))
@@ -105,7 +106,7 @@ public class NoDirectLlmCallTests
     }
 
     [Test]
-    public void TammaActivities_HasNoDirectProviderChatCompletionsCall_OutsideRunnerAndWireClient()
+    public void TammaActivities_HasNoDirectProviderChatCompletionsCall_OutsideWireClient()
     {
         var offenders = ActivitiesSourceFiles()
             .Where(f => !IsAllowedProviderCallFile(f.Relative))
@@ -119,7 +120,7 @@ public class NoDirectLlmCallTests
     }
 
     [Test]
-    public void TammaActivities_HasNoDirectProviderCompleteCall_OutsideRunnerAndWireClient()
+    public void TammaActivities_HasNoDirectProviderCompleteCall_OutsideWireClient()
     {
         var offenders = ActivitiesSourceFiles()
             .Where(f => !IsAllowedProviderCallFile(f.Relative))
@@ -133,7 +134,7 @@ public class NoDirectLlmCallTests
     }
 
     [Test]
-    public void TammaActivities_DoesNotCreateNamedProviderHttpClient_OutsideRunnerAndWireClient()
+    public void TammaActivities_DoesNotCreateNamedProviderHttpClient_OutsideWireClient()
     {
         var offenders = ActivitiesSourceFiles()
             .Where(f => !IsAllowedProviderCallFile(f.Relative))

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgenticToolLoopIntegrationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgenticToolLoopIntegrationTests.cs
@@ -10,8 +10,9 @@ using Tamma.Activities.LlmCall;
 using Tamma.Activities.LlmCall.Models;
 using Tamma.Activities.LlmCall.Tools;
 using Tamma.Activities.Security;
+using Tamma.Api.Services.Agents;
 
-namespace Tamma.Activities.Tests.LlmCall;
+namespace Tamma.Api.Tests.Agents;
 
 /// <summary>
 /// Integration tests for the agentic tool loop (Epic 12).

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgenticToolLoopTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgenticToolLoopTests.cs
@@ -8,8 +8,9 @@ using Tamma.Activities.LlmCall;
 using Tamma.Activities.LlmCall.Models;
 using Tamma.Activities.LlmCall.Tools;
 using Tamma.Activities.Security;
+using Tamma.Api.Services.Agents;
 
-namespace Tamma.Activities.Tests.LlmCall;
+namespace Tamma.Api.Tests.Agents;
 
 /// <summary>
 /// Tests for the agentic tool loop in CallLlmInlineActivity (Story 12.2).

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/CallLlmInlineCredentialTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/CallLlmInlineCredentialTests.cs
@@ -8,8 +8,9 @@ using NUnit.Framework;
 using Tamma.Activities.LlmCall;
 using Tamma.Activities.LlmCall.Credentials;
 using Tamma.Activities.LlmCall.Models;
+using Tamma.Api.Services.Agents;
 
-namespace Tamma.Activities.Tests.LlmCall;
+namespace Tamma.Api.Tests.Agents;
 
 /// <summary>
 /// Story 32-3 Phase 3 / Phase 5 — credential resolution in the shared

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/InlineToolLoopRunnerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/InlineToolLoopRunnerTests.cs
@@ -9,8 +9,9 @@ using Tamma.Activities.LlmCall;
 using Tamma.Activities.LlmCall.Models;
 using Tamma.Activities.LlmCall.Tools;
 using Tamma.Activities.Security;
+using Tamma.Api.Services.Agents;
 
-namespace Tamma.Activities.Tests.LlmCall;
+namespace Tamma.Api.Tests.Agents;
 
 /// <summary>
 /// Story 32-5 (AC4) — runner-level coverage of the agentic tool loop, now the

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/LlmCallEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/LlmCallEndpointsTests.cs
@@ -454,7 +454,7 @@ public class LlmCallEndpointsTests
         // scope under ValidateScopes (a pre-existing host wiring, not a T4 gap).
         ApiTestFixture.Factory.Services.Should().NotBeNull();
         AssertRegistered<IManagedAgent>();
-        AssertRegistered<Tamma.Activities.LlmCall.IInlineToolLoopRunner>();
+        AssertRegistered<Tamma.Api.Services.Agents.IInlineToolLoopRunner>();
     }
 
     /// <summary>Assert a service is REGISTERED (a descriptor exists) without


### PR DESCRIPTION
## What

Relocates the agentic tool-loop core (`InlineToolLoopRunner` + `IInlineToolLoopRunner` + result records) out of the `Tamma.Activities` workflow-engine assembly and into `Tamma.Api.Services.Agents`, where it is DI-registered and executed by `ManagedAgent`. Architecture-pivot cleanup: the engine assembly must not host the API-plane LLM core.

## Why it's clean

- `Tamma.Api` already references `Tamma.Activities` (never the reverse), so this is a "pull up" with no circular dependency.
- All of the runner's collaborators stay in `Tamma.Activities.*` (public) and remain reachable.
- The runner uses no `internal` types, so no `InternalsVisibleTo` wall.

## Changes

- `git mv` the two source files → `Tamma.Api/Services/Agents/`, namespace `Tamma.Activities.LlmCall` → `Tamma.Api.Services.Agents`.
- DI registration in `Program.cs` retyped to the new namespace.
- **Guardrail cleanup** (`Allowlist.cs`): removed the two `InlineToolLoopRunner` `TAMMA001` denylist entries **and** the whole-type exemption — both are now dead code since the type left the analyzed engine surface. Updated the `IProviderCredentialResolver` rationale comment accordingly.
- The four runner tests move to `Tamma.Api.Tests/Agents/` (the runner is now a `Tamma.Api` public type). `NoDirectLlmCallTests` drops it from the engine-scan allowlist (no longer an engine file); analyzer tests drop the now-moot inject/exempt fixtures.

## Verification

- `dotnet build`: 0 errors.
- `Tamma.Activities.Tests`: 2086 passed · `Tamma.Api.Tests`: 4035 passed (5 skipped) · `Tamma.Activities.Guardrails.Tests`: 30 passed.

Behavior unchanged — pure relocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)