### PR TITLE
feat(epic-38): mediate IIntegrationService — engine holds no integration credential

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities.Guardrails/Allowlist.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities.Guardrails/Allowlist.cs
@@ -33,23 +33,26 @@ internal static class Allowlist
     // PARAMETERS of the reused static cores (called by Tamma.Api's mediation services), not
     // ctor/field injections; Slack/GitHub effects route through TammaApiClient.
     //
-    // DELIBERATELY EXCLUDED — the COMPOSITE `Tamma.Core.Interfaces.IIntegrationService`:
-    //   it is STILL legitimately injected in 5 engine activities (MergeCompleteActivity,
-    //   DiagnoseBlockerActivity, CodeReviewActivity, MergeAndCompleteReviewActivity,
-    //   DeliverQuestionsActivity) for NON-Slack ops (GitHub merge/CI, JIRA, email) that
-    //   Epic 38 did NOT mediate. Denying its INJECTION would fail the build on clean main.
-    //   Those un-migrated GitHub/CI/JIRA/email uses are a TRACKED FOLLOW-UP; once they move
-    //   to Tamma.Api endpoints, add IIntegrationService here. The Slack hole this exclusion
-    //   would otherwise open is closed by DeniedInvocationNames below (Correction 2) — the
-    //   composite's Slack SEND methods are denied at the call site.
+    // Epic 38 (Phase 3, cutover COMPLETE) — the engine reaches all four integration domains
+    // (GitHub, CI, JIRA, email) exclusively via Tamma.Api mediation over TammaApiClient, and
+    // holds NO integration credential. The COMPOSITE `Tamma.Core.Interfaces.IIntegrationService`
+    // and every focused variant (GitHub/Slack/CI/JIRA/email) are therefore DENIED as engine
+    // injections — the earlier "still injected in 5 activities" exclusion is retired now that
+    // those activities are thin-client (Phase 2). Reintroducing any as a ctor/field/property
+    // fails the build (TAMMA001). The composite's Slack SEND methods stay additionally denied
+    // at the call site via DeniedInvocationNames below (defence in depth).
     // ------------------------------------------------------------------------------------
     public static readonly ImmutableHashSet<string> InjectionDenylist = ImmutableHashSet.Create(
         StringComparer.Ordinal,
         "Octokit.IGitHubClient",
         "Octokit.GitHubClient",
         "Tamma.Activities.AgentDispatch.IGitHubActionsClient",
+        "Tamma.Core.Interfaces.IIntegrationService",
         "Tamma.Core.Interfaces.IGitHubIntegrationService",
         "Tamma.Core.Interfaces.ISlackIntegrationService",
+        "Tamma.Core.Interfaces.ICIIntegrationService",
+        "Tamma.Core.Interfaces.IJiraIntegrationService",
+        "Tamma.Core.Interfaces.IEmailIntegrationService",
         // The engine must not resolve provider credentials post-32-5. (The LLM core that
         // legitimately holds it — InlineToolLoopRunner — now lives in the Tamma.Api assembly,
         // outside the analyzed engine surface, so no engine exemption is needed.)
@@ -79,10 +82,11 @@ internal static class Allowlist
         "GetRequiredKeyedService");
 
     // ------------------------------------------------------------------------------------
-    // Correction 2 — denied Slack SEND invocations on ANY receiver. Because the composite
-    // IIntegrationService INJECTION is allowed (for GitHub/CI/JIRA/email), also deny its
-    // Slack send METHODS at the call site so a re-introduced engine-side Slack post via the
-    // composite is still caught. Its GitHub/CI methods stay allowed (the tracked follow-up).
+    // Correction 2 — denied Slack SEND invocations on ANY receiver (defence in depth). The
+    // composite IIntegrationService INJECTION is now itself denied (Epic 38 Phase 3), but
+    // these Slack send METHOD names stay denied at the call site so a re-introduced
+    // engine-side Slack post — via the composite or any other receiver that exposes them —
+    // is caught even if the injection pass is somehow bypassed.
     // ------------------------------------------------------------------------------------
     public static readonly ImmutableHashSet<string> DeniedInvocationNames = ImmutableHashSet.Create(
         StringComparer.Ordinal,

--- a/apps/tamma-elsa/src/Tamma.Activities/AI/ContextGatheringActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/AI/ContextGatheringActivity.cs
@@ -8,6 +8,8 @@ using Elsa.Workflows.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
+using Tamma.Activities.ADL;
+using Tamma.Activities.LlmCall;
 using Tamma.Core.Interfaces;
 using Tamma.Data.Repositories;
 
@@ -27,7 +29,7 @@ public class ContextGatheringActivity : CodeActivity<CodeContextOutput>
 {
     private readonly ILogger<ContextGatheringActivity>? _logger;
     private readonly IMentorshipSessionRepository? _repository;
-    private readonly IIntegrationService? _integrationService;
+    private readonly TammaApiClient? _apiClient;
     private readonly IHttpClientFactory? _httpClientFactory;
     private readonly IConfiguration? _configuration;
 
@@ -55,19 +57,28 @@ public class ContextGatheringActivity : CodeActivity<CodeContextOutput>
     [Input(Description = "Include test files", DefaultValue = true)]
     public Input<bool> IncludeTests { get; set; } = new(true);
 
+    [Input(Description = "Tenant id (GUID string) for BYOK token resolution; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
     [JsonConstructor]
     public ContextGatheringActivity() { }
 
+    /// <summary>
+    /// Story 38 (Phase 2) — thin-client DI constructor. No <c>IIntegrationService</c>
+    /// and no git token: recent commits + the CI test summary are read through the
+    /// git/CI mediation endpoints via <see cref="TammaApiClient"/>. The GitHub
+    /// Contents/tree reads keep using the injected <see cref="IHttpClientFactory"/>.
+    /// </summary>
     public ContextGatheringActivity(
         ILogger<ContextGatheringActivity> logger,
         IMentorshipSessionRepository repository,
-        IIntegrationService integrationService,
+        TammaApiClient apiClient,
         IHttpClientFactory httpClientFactory,
         IConfiguration configuration)
     {
         _logger = logger;
         _repository = repository;
-        _integrationService = integrationService;
+        _apiClient = apiClient;
         _httpClientFactory = httpClientFactory;
         _configuration = configuration;
     }
@@ -83,6 +94,10 @@ public class ContextGatheringActivity : CodeActivity<CodeContextOutput>
         var maxContextSize = MaxContextSize.Get(context);
         var includeSimilarPatterns = IncludeSimilarPatterns.Get(context);
         var includeTests = IncludeTests.Get(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var correlationId = context.WorkflowExecutionContext.Id;
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+        var ct = context.CancellationToken;
 
         _logger?.LogInformation(
             "Gathering context for story {StoryId} in session {SessionId}",
@@ -114,7 +129,7 @@ public class ContextGatheringActivity : CodeActivity<CodeContextOutput>
             if (!string.IsNullOrEmpty(story.RepositoryUrl))
             {
                 // 1. Get recent changes
-                var recentChanges = await GatherRecentChanges(story.RepositoryUrl, storyId);
+                var recentChanges = await GatherRecentChanges(apiClient, story.RepositoryUrl, storyId, correlationId, tenantId, ct);
                 codeContext.RecentChanges = recentChanges;
 
                 // 2. Get target file contents
@@ -141,7 +156,7 @@ public class ContextGatheringActivity : CodeActivity<CodeContextOutput>
                 // 4. Get test files if requested
                 if (includeTests)
                 {
-                    var testContext = await GatherTestContext(story.RepositoryUrl, storyId);
+                    var testContext = await GatherTestContext(apiClient, story.RepositoryUrl, storyId, correlationId, tenantId, ct);
                     codeContext.TestContext = testContext;
                 }
 
@@ -187,14 +202,21 @@ public class ContextGatheringActivity : CodeActivity<CodeContextOutput>
 
     private bool UseMock => _configuration?.GetValue<bool>("Anthropic:UseMock") ?? false;
 
-    private async Task<List<FileChange>> GatherRecentChanges(string repositoryUrl, string storyId)
+    private async Task<List<FileChange>> GatherRecentChanges(
+        TammaApiClient apiClient, string repositoryUrl, string storyId,
+        string correlationId, string? tenantId, CancellationToken ct)
     {
         try
         {
-            var commits = await _integrationService!.GetGitHubCommitsAsync(
+            var commitsResponse = await apiClient.GetCommitsAsync(
                 repositoryUrl,
                 $"feature/{storyId}",
-                DateTime.UtcNow.AddDays(-7));
+                DateTime.UtcNow.AddDays(-7),
+                correlationId, tenantId, ct);
+            if (commitsResponse is null || !commitsResponse.Success)
+                throw new InvalidOperationException(
+                    commitsResponse?.FailureReason ?? "git mediation endpoint unavailable");
+            var commits = GitMediationMapping.ToCommits(commitsResponse.Commits);
 
             var changes = new List<FileChange>();
 
@@ -441,13 +463,24 @@ public class ContextGatheringActivity : CodeActivity<CodeContextOutput>
         }
     }
 
-    private async Task<TestContextInfo> GatherTestContext(string repositoryUrl, string storyId)
+    private async Task<TestContextInfo> GatherTestContext(
+        TammaApiClient apiClient, string repositoryUrl, string storyId,
+        string correlationId, string? tenantId, CancellationToken ct)
     {
         try
         {
-            var testResults = await _integrationService!.TriggerTestsAsync(
+            var ciResponse = await apiClient.TriggerTestsAsync(
                 repositoryUrl,
-                $"feature/{storyId}");
+                new LlmCall.Models.CiTriggerTestsRequest
+                {
+                    Branch = $"feature/{storyId}",
+                    CorrelationId = correlationId,
+                },
+                tenantId, ct);
+            if (ciResponse is null || !ciResponse.Success)
+                throw new InvalidOperationException(
+                    ciResponse?.FailureReason ?? "ci mediation endpoint unavailable");
+            var testResults = GitMediationMapping.ToTestRun(ciResponse.TestRun);
 
             return new TestContextInfo
             {
@@ -455,6 +488,8 @@ public class ContextGatheringActivity : CodeActivity<CodeContextOutput>
                 PassingTests = testResults.PassedTests,
                 FailingTests = testResults.FailedTests,
                 CoveragePercentage = testResults.CoveragePercentage ?? 0,
+                // Per-test failure detail is not returned by the CI-mediation endpoint —
+                // FailedTestDetails is empty (aggregate counts only).
                 FailingTestDetails = testResults.FailedTestDetails.Select(t => new FailingTestInfo
                 {
                     TestName = t.TestName,

--- a/apps/tamma-elsa/src/Tamma.Activities/Assessment/DeliverQuestionsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Assessment/DeliverQuestionsActivity.cs
@@ -6,9 +6,10 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System.Text;
 using System.Text.Json.Serialization;
+using Tamma.Activities.ADL;
 using Tamma.Activities.Assessment.Models;
 using Tamma.Activities.LlmCall;
-using Tamma.Core.Interfaces;
+using Tamma.Activities.LlmCall.Models;
 using Tamma.Data.Repositories;
 
 namespace Tamma.Activities.Assessment;
@@ -26,7 +27,7 @@ namespace Tamma.Activities.Assessment;
 public class DeliverQuestionsActivity : CodeActivity<DeliveryResult>
 {
     private readonly ILogger<DeliverQuestionsActivity>? _logger;
-    private readonly IIntegrationService? _integrationService;
+    private readonly TammaApiClient? _apiClient;
     private readonly IMentorshipSessionRepository? _repository;
     private readonly IConfiguration? _configuration;
 
@@ -46,17 +47,26 @@ public class DeliverQuestionsActivity : CodeActivity<DeliveryResult>
     [Input(Description = "Assessment attempt number", DefaultValue = 1)]
     public Input<int> AttemptNumber { get; set; } = new(1);
 
+    [Input(Description = "Tenant id (GUID string) for the acting scope; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
     [JsonConstructor]
     public DeliverQuestionsActivity() { }
 
+    /// <summary>
+    /// Story 38 (Phase 2, Batch C) — thin-client DI constructor. No <c>IIntegrationService</c>
+    /// and no email credential: the email delivery channel routes through the outbox-backed
+    /// email-mediation endpoint via <see cref="TammaApiClient"/> (the API owns the <c>EMAIL.*</c>
+    /// audit event); the Slack channel already goes through the <see cref="MediatedSlack"/> seam.
+    /// </summary>
     public DeliverQuestionsActivity(
         ILogger<DeliverQuestionsActivity> logger,
-        IIntegrationService integrationService,
+        TammaApiClient apiClient,
         IMentorshipSessionRepository repository,
         IConfiguration configuration)
     {
         _logger = logger;
-        _integrationService = integrationService;
+        _apiClient = apiClient;
         _repository = repository;
         _configuration = configuration;
     }
@@ -67,6 +77,10 @@ public class DeliverQuestionsActivity : CodeActivity<DeliveryResult>
         var juniorId = JuniorId.Get(context);
         var questionsJson = QuestionsJson.Get(context);
         var attemptNumber = AttemptNumber.Get(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var correlationId = context.WorkflowExecutionContext.Id;
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+        var ct = context.CancellationToken;
 
         _logger?.LogInformation(
             "Delivering assessment questions for session {SessionId}, attempt {AttemptNumber}",
@@ -100,10 +114,21 @@ public class DeliverQuestionsActivity : CodeActivity<DeliveryResult>
                 case "email":
                     if (junior?.Email != null)
                     {
-                        await _integrationService!.SendEmailAsync(
-                            junior.Email,
-                            $"Tamma Assessment - Session {sessionId}",
-                            message);
+                        // Mediated, outbox-backed send (the API owns the EMAIL.* audit event).
+                        // A null / success:false envelope is an unexpected send failure — throw
+                        // so the outer catch reports delivery failure, exactly as the composite's
+                        // void SendEmailAsync did when it threw.
+                        var emailResponse = await apiClient.SendEmailAsync(new EmailSendRequest
+                        {
+                            To = junior.Email,
+                            Subject = $"Tamma Assessment - Session {sessionId}",
+                            Body = message,
+                            CorrelationId = correlationId,
+                        }, tenantId, ct);
+
+                        if (emailResponse is null || !emailResponse.Success)
+                            throw new InvalidOperationException(
+                                emailResponse?.FailureReason ?? "email mediation endpoint unavailable");
                     }
                     else
                     {

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/CollectCIStatusActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/CollectCIStatusActivity.cs
@@ -5,8 +5,10 @@ using Elsa.Workflows.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
+using Tamma.Activities.ADL;
 using Tamma.Activities.Blocker.Models;
-using Tamma.Core.Interfaces;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
 
 namespace Tamma.Activities.Blocker;
 
@@ -24,7 +26,7 @@ namespace Tamma.Activities.Blocker;
 public class CollectCIStatusActivity : CodeActivity<CIStatusSignal>
 {
     private readonly ILogger<CollectCIStatusActivity>? _logger;
-    private readonly IIntegrationService? _integrationService;
+    private readonly TammaApiClient? _apiClient;
     private readonly IConfiguration? _configuration;
 
     /// <summary>Repository URL or owner/repo</summary>
@@ -35,16 +37,26 @@ public class CollectCIStatusActivity : CodeActivity<CIStatusSignal>
     [Input(Description = "Branch name to check")]
     public Input<string> BranchName { get; set; } = default!;
 
+    [Input(Description = "Tenant id (GUID string) for BYOK token resolution; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
     [JsonConstructor]
     public CollectCIStatusActivity() { }
 
+    /// <summary>
+    /// Story 38 (Phase 2) — thin-client DI constructor. No <c>IIntegrationService</c>
+    /// and no git token: build status + the CI test summary are read through the CI
+    /// mediation endpoints (<c>GET /api/v1/ci/{owner}/{repo}/build-status</c> and
+    /// <c>POST .../test-runs</c>) via <see cref="TammaApiClient"/>, where the per-tenant
+    /// token lives.
+    /// </summary>
     public CollectCIStatusActivity(
         ILogger<CollectCIStatusActivity> logger,
-        IIntegrationService integrationService,
+        TammaApiClient apiClient,
         IConfiguration configuration)
     {
         _logger = logger;
-        _integrationService = integrationService;
+        _apiClient = apiClient;
         _configuration = configuration;
     }
 
@@ -52,6 +64,10 @@ public class CollectCIStatusActivity : CodeActivity<CIStatusSignal>
     {
         var repository = Repository.Get(context);
         var branchName = BranchName.Get(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var correlationId = context.WorkflowExecutionContext.Id;
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+        var ct = context.CancellationToken;
 
         _logger?.LogInformation(
             "Collecting CI status signals for {Repository}/{Branch}",
@@ -65,11 +81,23 @@ public class CollectCIStatusActivity : CodeActivity<CIStatusSignal>
             // CI / test trigger cannot block the parallel signal join.
             var completedInTime = await BlockerSignalTimeout.RunAsync(_configuration, async () =>
             {
-                var buildStatus = await _integrationService!.GetBuildStatusAsync(repository, branchName);
+                var buildStatusResponse = await apiClient.GetBuildStatusAsync(
+                    repository, branchName, correlationId, tenantId, ct);
+                if (buildStatusResponse is null || !buildStatusResponse.Success)
+                    throw new InvalidOperationException(
+                        buildStatusResponse?.FailureReason ?? "ci mediation endpoint unavailable");
+                var buildStatus = GitMediationMapping.ToBuildStatus(buildStatusResponse.BuildStatus);
                 signal.BuildStatus = buildStatus.Status;
                 signal.BuildError = buildStatus.Error;
 
-                var testResults = await _integrationService.TriggerTestsAsync(repository, branchName);
+                var testResponse = await apiClient.TriggerTestsAsync(
+                    repository,
+                    new CiTriggerTestsRequest { Branch = branchName, CorrelationId = correlationId },
+                    tenantId, ct);
+                if (testResponse is null || !testResponse.Success)
+                    throw new InvalidOperationException(
+                        testResponse?.FailureReason ?? "ci mediation endpoint unavailable");
+                var testResults = GitMediationMapping.ToTestRun(testResponse.TestRun);
                 signal.TotalTests = testResults.TotalTests;
                 signal.PassedTests = testResults.PassedTests;
                 signal.FailedTests = testResults.FailedTests;

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/CollectCommunicationActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/CollectCommunicationActivity.cs
@@ -5,7 +5,6 @@ using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
 using Tamma.Activities.Blocker.Models;
-using Tamma.Core.Interfaces;
 
 namespace Tamma.Activities.Blocker;
 
@@ -23,7 +22,6 @@ namespace Tamma.Activities.Blocker;
 public class CollectCommunicationActivity : CodeActivity<CommunicationSignal>
 {
     private readonly ILogger<CollectCommunicationActivity>? _logger;
-    private readonly IIntegrationService? _integrationService;
 
     /// <summary>Junior developer's Slack ID (if available)</summary>
     [Input(Description = "Junior developer's Slack ID")]
@@ -36,12 +34,17 @@ public class CollectCommunicationActivity : CodeActivity<CommunicationSignal>
     [JsonConstructor]
     public CollectCommunicationActivity() { }
 
+    /// <summary>
+    /// Story 38 (Phase 2) — this best-effort signal collector never called the
+    /// credential-holding <c>IIntegrationService</c> (it cannot query Slack history
+    /// without extra API scopes and only reports availability), so that dead injection
+    /// was removed in the Batch B cutover. It sends no Slack message, so no mediation
+    /// client is needed.
+    /// </summary>
     public CollectCommunicationActivity(
-        ILogger<CollectCommunicationActivity> logger,
-        IIntegrationService integrationService)
+        ILogger<CollectCommunicationActivity> logger)
     {
         _logger = logger;
-        _integrationService = integrationService;
     }
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/CollectGitActivityActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/CollectGitActivityActivity.cs
@@ -5,7 +5,10 @@ using Elsa.Workflows.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
+using Tamma.Activities.ADL;
 using Tamma.Activities.Blocker.Models;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
 using Tamma.Core.Interfaces;
 
 namespace Tamma.Activities.Blocker;
@@ -24,7 +27,7 @@ namespace Tamma.Activities.Blocker;
 public class CollectGitActivityActivity : CodeActivity<GitActivitySignal>
 {
     private readonly ILogger<CollectGitActivityActivity>? _logger;
-    private readonly IIntegrationService? _integrationService;
+    private readonly TammaApiClient? _apiClient;
     private readonly IConfiguration? _configuration;
 
     /// <summary>Repository URL or owner/repo</summary>
@@ -39,16 +42,25 @@ public class CollectGitActivityActivity : CodeActivity<GitActivitySignal>
     [Input(Description = "Lookback period in hours", DefaultValue = 24)]
     public Input<int> LookbackHours { get; set; } = new(24);
 
+    [Input(Description = "Tenant id (GUID string) for BYOK token resolution; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
     [JsonConstructor]
     public CollectGitActivityActivity() { }
 
+    /// <summary>
+    /// Story 38 (Phase 2) — thin-client DI constructor. No <c>IIntegrationService</c>
+    /// and no git token: commits + file changes are read through
+    /// <c>GET /api/v1/git/{owner}/{repo}/commits</c> and <c>/file-changes</c> via
+    /// <see cref="TammaApiClient"/>, where the per-tenant token lives.
+    /// </summary>
     public CollectGitActivityActivity(
         ILogger<CollectGitActivityActivity> logger,
-        IIntegrationService integrationService,
+        TammaApiClient apiClient,
         IConfiguration configuration)
     {
         _logger = logger;
-        _integrationService = integrationService;
+        _apiClient = apiClient;
         _configuration = configuration;
     }
 
@@ -57,12 +69,15 @@ public class CollectGitActivityActivity : CodeActivity<GitActivitySignal>
         var repository = Repository.Get(context);
         var branchName = BranchName.Get(context);
         var lookbackHours = LookbackHours.Get(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var correlationId = context.WorkflowExecutionContext.Id;
 
         _logger?.LogInformation(
             "Collecting git activity signals for {Repository}/{Branch}",
             repository, branchName);
 
         var signal = new GitActivitySignal();
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
 
         try
         {
@@ -71,7 +86,12 @@ public class CollectGitActivityActivity : CodeActivity<GitActivitySignal>
             var completedInTime = await BlockerSignalTimeout.RunAsync(_configuration, async () =>
             {
                 var since = DateTime.UtcNow.AddHours(-lookbackHours);
-                var commits = await _integrationService!.GetGitHubCommitsAsync(repository, branchName, since);
+                var commitsResponse = await apiClient.GetCommitsAsync(
+                    repository, branchName, since, correlationId, tenantId, context.CancellationToken);
+                if (commitsResponse is null || !commitsResponse.Success)
+                    throw new InvalidOperationException(
+                        commitsResponse?.FailureReason ?? "git mediation endpoint unavailable");
+                var commits = GitMediationMapping.ToCommits(commitsResponse.Commits);
 
                 signal.RecentCommitCount = commits.Count;
                 signal.LastCommitTime = commits.Any() ? commits.Max(c => c.Timestamp) : null;
@@ -79,7 +99,12 @@ public class CollectGitActivityActivity : CodeActivity<GitActivitySignal>
                     ? DateTime.UtcNow - signal.LastCommitTime.Value
                     : TimeSpan.FromHours(lookbackHours);
 
-                var fileChanges = await _integrationService.GetGitHubFileChangesAsync(repository, branchName);
+                var fileChangesResponse = await apiClient.GetFileChangesAsync(
+                    repository, branchName, correlationId, tenantId, context.CancellationToken);
+                if (fileChangesResponse is null || !fileChangesResponse.Success)
+                    throw new InvalidOperationException(
+                        fileChangesResponse?.FailureReason ?? "git mediation endpoint unavailable");
+                var fileChanges = GitMediationMapping.ToFileChanges(fileChangesResponse.FileChanges);
                 signal.FilesChanged = fileChanges.Count;
                 signal.TotalAdditions = fileChanges.Sum(f => f.Additions);
                 signal.TotalDeletions = fileChanges.Sum(f => f.Deletions);

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/CollectInactivityActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/CollectInactivityActivity.cs
@@ -5,7 +5,9 @@ using Elsa.Workflows.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
+using Tamma.Activities.ADL;
 using Tamma.Activities.Blocker.Models;
+using Tamma.Activities.LlmCall;
 using Tamma.Core.Interfaces;
 
 namespace Tamma.Activities.Blocker;
@@ -24,7 +26,7 @@ namespace Tamma.Activities.Blocker;
 public class CollectInactivityActivity : CodeActivity<InactivitySignal>
 {
     private readonly ILogger<CollectInactivityActivity>? _logger;
-    private readonly IIntegrationService? _integrationService;
+    private readonly TammaApiClient? _apiClient;
     private readonly IConfiguration? _configuration;
 
     /// <summary>Repository URL or owner/repo</summary>
@@ -39,16 +41,24 @@ public class CollectInactivityActivity : CodeActivity<InactivitySignal>
     [Input(Description = "Inactivity threshold in minutes", DefaultValue = 30)]
     public Input<int> InactivityThresholdMinutes { get; set; } = new(30);
 
+    [Input(Description = "Tenant id (GUID string) for BYOK token resolution; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
     [JsonConstructor]
     public CollectInactivityActivity() { }
 
+    /// <summary>
+    /// Story 38 (Phase 2) — thin-client DI constructor. No <c>IIntegrationService</c>
+    /// and no git token: recent commits (an activity proxy) are read through
+    /// <c>GET /api/v1/git/{owner}/{repo}/commits</c> via <see cref="TammaApiClient"/>.
+    /// </summary>
     public CollectInactivityActivity(
         ILogger<CollectInactivityActivity> logger,
-        IIntegrationService integrationService,
+        TammaApiClient apiClient,
         IConfiguration configuration)
     {
         _logger = logger;
-        _integrationService = integrationService;
+        _apiClient = apiClient;
         _configuration = configuration;
     }
 
@@ -57,12 +67,15 @@ public class CollectInactivityActivity : CodeActivity<InactivitySignal>
         var repository = Repository.Get(context);
         var branchName = BranchName.Get(context);
         var thresholdMinutes = InactivityThresholdMinutes.Get(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var correlationId = context.WorkflowExecutionContext.Id;
 
         _logger?.LogInformation(
             "Collecting inactivity signals for {Repository}/{Branch}",
             repository, branchName);
 
         var signal = new InactivitySignal();
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
 
         try
         {
@@ -72,7 +85,12 @@ public class CollectInactivityActivity : CodeActivity<InactivitySignal>
             {
                 // Use recent commits as a proxy for activity
                 var since = DateTime.UtcNow.AddHours(-24);
-                var commits = await _integrationService!.GetGitHubCommitsAsync(repository, branchName, since);
+                var commitsResponse = await apiClient.GetCommitsAsync(
+                    repository, branchName, since, correlationId, tenantId, context.CancellationToken);
+                if (commitsResponse is null || !commitsResponse.Success)
+                    throw new InvalidOperationException(
+                        commitsResponse?.FailureReason ?? "git mediation endpoint unavailable");
+                var commits = GitMediationMapping.ToCommits(commitsResponse.Commits);
 
                 if (commits.Any())
                 {

--- a/apps/tamma-elsa/src/Tamma.Activities/Context/FetchFileContentsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Context/FetchFileContentsActivity.cs
@@ -8,7 +8,9 @@ using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Tamma.Activities.ADL;
 using Tamma.Activities.Context.Models;
+using Tamma.Activities.LlmCall;
 using Tamma.Core.Interfaces;
 
 namespace Tamma.Activities.Context;
@@ -30,7 +32,7 @@ namespace Tamma.Activities.Context;
 public class FetchFileContentsActivity : CodeActivity<FileContentsResult>
 {
     private readonly ILogger<FetchFileContentsActivity>? _logger;
-    private readonly IIntegrationService? _integrationService;
+    private readonly TammaApiClient? _apiClient;
     private readonly IHttpClientFactory? _httpClientFactory;
     private readonly IConfiguration? _configuration;
 
@@ -58,19 +60,28 @@ public class FetchFileContentsActivity : CodeActivity<FileContentsResult>
     [Input(Description = "Maximum files to fetch", DefaultValue = 15)]
     public Input<int> MaxFiles { get; set; } = new(15);
 
+    [Input(Description = "Tenant id (GUID string) for BYOK token resolution; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
     [JsonConstructor]
     public FetchFileContentsActivity()
     {
     }
 
+    /// <summary>
+    /// Story 38 (Phase 2) — thin-client DI constructor. No <c>IIntegrationService</c>
+    /// and no git token: the fallback branch file-change list is read through
+    /// <c>GET /api/v1/git/{owner}/{repo}/file-changes</c> via <see cref="TammaApiClient"/>.
+    /// The GitHub Contents API reads keep using the injected <see cref="IHttpClientFactory"/>.
+    /// </summary>
     public FetchFileContentsActivity(
         ILogger<FetchFileContentsActivity> logger,
-        IIntegrationService integrationService,
+        TammaApiClient apiClient,
         IHttpClientFactory httpClientFactory,
         IConfiguration configuration)
     {
         _logger = logger;
-        _integrationService = integrationService;
+        _apiClient = apiClient;
         _httpClientFactory = httpClientFactory;
         _configuration = configuration;
     }
@@ -83,6 +94,9 @@ public class FetchFileContentsActivity : CodeActivity<FileContentsResult>
         var storyDescription = StoryDescription.Get(context);
         var commitFiles = CommitFiles.Get(context);
         var maxFiles = MaxFiles.Get(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var correlationId = context.WorkflowExecutionContext.Id;
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
 
         _logger?.LogInformation(
             "Fetching file contents for story {StoryId} from {Repo}",
@@ -108,8 +122,12 @@ public class FetchFileContentsActivity : CodeActivity<FileContentsResult>
             if (!filePaths.Any())
             {
                 // Fallback: try to get file changes from the branch
-                var fileChanges = await _integrationService!.GetGitHubFileChangesAsync(
-                    repositoryUrl, $"feature/{storyId}");
+                var fileChangesResponse = await apiClient.GetFileChangesAsync(
+                    repositoryUrl, $"feature/{storyId}", correlationId, tenantId, context.CancellationToken);
+                if (fileChangesResponse is null || !fileChangesResponse.Success)
+                    throw new InvalidOperationException(
+                        fileChangesResponse?.FailureReason ?? "git mediation endpoint unavailable");
+                var fileChanges = GitMediationMapping.ToFileChanges(fileChangesResponse.FileChanges);
                 filePaths = fileChanges.Select(f => f.FilePath).Take(maxFiles).ToList();
             }
 

--- a/apps/tamma-elsa/src/Tamma.Activities/Context/FetchRecentCommitsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Context/FetchRecentCommitsActivity.cs
@@ -4,7 +4,9 @@ using Elsa.Workflows;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
+using Tamma.Activities.ADL;
 using Tamma.Activities.Context.Models;
+using Tamma.Activities.LlmCall;
 using Tamma.Core.Interfaces;
 
 namespace Tamma.Activities.Context;
@@ -22,7 +24,7 @@ namespace Tamma.Activities.Context;
 public class FetchRecentCommitsActivity : CodeActivity<RecentCommitsResult>
 {
     private readonly ILogger<FetchRecentCommitsActivity>? _logger;
-    private readonly IIntegrationService? _integrationService;
+    private readonly TammaApiClient? _apiClient;
 
     /// <summary>Repository URL (e.g., owner/repo)</summary>
     [Input(Description = "Repository URL or identifier")]
@@ -40,17 +42,25 @@ public class FetchRecentCommitsActivity : CodeActivity<RecentCommitsResult>
     [Input(Description = "Maximum commits to return", DefaultValue = 10)]
     public Input<int> MaxCommits { get; set; } = new(10);
 
+    [Input(Description = "Tenant id (GUID string) for BYOK token resolution; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
     [JsonConstructor]
     public FetchRecentCommitsActivity()
     {
     }
 
+    /// <summary>
+    /// Story 38 (Phase 2) — thin-client DI constructor. No <c>IIntegrationService</c>
+    /// and no git token: recent commits are read through
+    /// <c>GET /api/v1/git/{owner}/{repo}/commits</c> via <see cref="TammaApiClient"/>.
+    /// </summary>
     public FetchRecentCommitsActivity(
         ILogger<FetchRecentCommitsActivity> logger,
-        IIntegrationService integrationService)
+        TammaApiClient apiClient)
     {
         _logger = logger;
-        _integrationService = integrationService;
+        _apiClient = apiClient;
     }
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
@@ -59,6 +69,9 @@ public class FetchRecentCommitsActivity : CodeActivity<RecentCommitsResult>
         var storyId = StoryId.Get(context);
         var daysBack = DaysBack.Get(context);
         var maxCommits = MaxCommits.Get(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var correlationId = context.WorkflowExecutionContext.Id;
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
 
         _logger?.LogInformation(
             "Fetching recent commits for story {StoryId} from {Repo}",
@@ -79,8 +92,12 @@ public class FetchRecentCommitsActivity : CodeActivity<RecentCommitsResult>
             var branchName = $"feature/{storyId}";
             var since = DateTime.UtcNow.AddDays(-daysBack);
 
-            var commits = await _integrationService!.GetGitHubCommitsAsync(
-                repositoryUrl, branchName, since);
+            var commitsResponse = await apiClient.GetCommitsAsync(
+                repositoryUrl, branchName, since, correlationId, tenantId, context.CancellationToken);
+            if (commitsResponse is null || !commitsResponse.Success)
+                throw new InvalidOperationException(
+                    commitsResponse?.FailureReason ?? "git mediation endpoint unavailable");
+            var commits = GitMediationMapping.ToCommits(commitsResponse.Commits);
 
             var entries = commits
                 .Take(maxCommits)

--- a/apps/tamma-elsa/src/Tamma.Activities/Context/FetchSimilarPatternsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Context/FetchSimilarPatternsActivity.cs
@@ -8,7 +8,6 @@ using Elsa.Workflows.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Tamma.Activities.Context.Models;
-using Tamma.Core.Interfaces;
 
 namespace Tamma.Activities.Context;
 
@@ -26,7 +25,6 @@ namespace Tamma.Activities.Context;
 public class FetchSimilarPatternsActivity : CodeActivity<SimilarPatternsResult>
 {
     private readonly ILogger<FetchSimilarPatternsActivity>? _logger;
-    private readonly IIntegrationService? _integrationService;
     private readonly IHttpClientFactory? _httpClientFactory;
     private readonly IConfiguration? _configuration;
 
@@ -51,14 +49,18 @@ public class FetchSimilarPatternsActivity : CodeActivity<SimilarPatternsResult>
     {
     }
 
+    /// <summary>
+    /// Story 38 (Phase 2) — this activity discovers patterns purely by scanning the
+    /// GitHub tree via the injected <see cref="IHttpClientFactory"/>; it never called
+    /// the credential-holding <c>IIntegrationService</c>, so that dead injection was
+    /// removed in the Batch B cutover (no mediation client is needed here).
+    /// </summary>
     public FetchSimilarPatternsActivity(
         ILogger<FetchSimilarPatternsActivity> logger,
-        IIntegrationService integrationService,
         IHttpClientFactory httpClientFactory,
         IConfiguration configuration)
     {
         _logger = logger;
-        _integrationService = integrationService;
         _httpClientFactory = httpClientFactory;
         _configuration = configuration;
     }

--- a/apps/tamma-elsa/src/Tamma.Activities/Context/FetchTestResultsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Context/FetchTestResultsActivity.cs
@@ -4,8 +4,10 @@ using Elsa.Workflows;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
+using Tamma.Activities.ADL;
 using Tamma.Activities.Context.Models;
-using Tamma.Core.Interfaces;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
 
 namespace Tamma.Activities.Context;
 
@@ -22,7 +24,7 @@ namespace Tamma.Activities.Context;
 public class FetchTestResultsActivity : CodeActivity<TestResultsData>
 {
     private readonly ILogger<FetchTestResultsActivity>? _logger;
-    private readonly IIntegrationService? _integrationService;
+    private readonly TammaApiClient? _apiClient;
 
     /// <summary>Repository URL (e.g., owner/repo)</summary>
     [Input(Description = "Repository URL or identifier")]
@@ -32,23 +34,35 @@ public class FetchTestResultsActivity : CodeActivity<TestResultsData>
     [Input(Description = "Story ID for branch naming")]
     public Input<string> StoryId { get; set; } = default!;
 
+    [Input(Description = "Tenant id (GUID string) for BYOK token resolution; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
     [JsonConstructor]
     public FetchTestResultsActivity()
     {
     }
 
+    /// <summary>
+    /// Story 38 (Phase 2) — thin-client DI constructor. No <c>IIntegrationService</c>
+    /// and no git token: the CI test summary is read through the CI mediation endpoint
+    /// (<c>POST /api/v1/ci/{owner}/{repo}/test-runs</c>) via <see cref="TammaApiClient"/>.
+    /// </summary>
     public FetchTestResultsActivity(
         ILogger<FetchTestResultsActivity> logger,
-        IIntegrationService integrationService)
+        TammaApiClient apiClient)
     {
         _logger = logger;
-        _integrationService = integrationService;
+        _apiClient = apiClient;
     }
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
         var repositoryUrl = RepositoryUrl.Get(context);
         var storyId = StoryId.Get(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var correlationId = context.WorkflowExecutionContext.Id;
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+        var ct = context.CancellationToken;
 
         _logger?.LogInformation(
             "Fetching test results for story {StoryId} from {Repo}",
@@ -67,8 +81,14 @@ public class FetchTestResultsActivity : CodeActivity<TestResultsData>
             }
 
             var branchName = $"feature/{storyId}";
-            var testResults = await _integrationService!.TriggerTestsAsync(
-                repositoryUrl, branchName);
+            var testResponse = await apiClient.TriggerTestsAsync(
+                repositoryUrl,
+                new CiTriggerTestsRequest { Branch = branchName, CorrelationId = correlationId },
+                tenantId, ct);
+            if (testResponse is null || !testResponse.Success)
+                throw new InvalidOperationException(
+                    testResponse?.FailureReason ?? "ci mediation endpoint unavailable");
+            var testResults = GitMediationMapping.ToTestRun(testResponse.TestRun);
 
             context.SetResult(new TestResultsData
             {

--- a/apps/tamma-elsa/src/Tamma.Activities/Debug/CollectGitHistoryActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Debug/CollectGitHistoryActivity.cs
@@ -4,8 +4,9 @@ using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
+using Tamma.Activities.ADL;
 using Tamma.Activities.Debug.Models;
-using Tamma.Core.Interfaces;
+using Tamma.Activities.LlmCall;
 
 namespace Tamma.Activities.Debug;
 
@@ -22,7 +23,7 @@ namespace Tamma.Activities.Debug;
 public class CollectGitHistoryActivity : CodeActivity<GitHistoryContext>
 {
     private readonly ILogger<CollectGitHistoryActivity>? _logger;
-    private readonly IIntegrationService? _integrationService;
+    private readonly TammaApiClient? _apiClient;
 
     /// <summary>Repository URL</summary>
     [Input(Description = "Repository URL")]
@@ -36,15 +37,23 @@ public class CollectGitHistoryActivity : CodeActivity<GitHistoryContext>
     [Input(Description = "Debug context mode")]
     public Input<string> DebugContextMode { get; set; } = default!;
 
+    [Input(Description = "Tenant id (GUID string) for BYOK token resolution; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
     [JsonConstructor]
     public CollectGitHistoryActivity() { }
 
+    /// <summary>
+    /// Story 38 (Phase 2) — thin-client DI constructor. No <c>IIntegrationService</c>
+    /// and no git token: recent commits are read through the git mediation endpoint
+    /// (<c>GET /api/v1/git/{owner}/{repo}/commits</c>) via <see cref="TammaApiClient"/>.
+    /// </summary>
     public CollectGitHistoryActivity(
         ILogger<CollectGitHistoryActivity> logger,
-        IIntegrationService integrationService)
+        TammaApiClient apiClient)
     {
         _logger = logger;
-        _integrationService = integrationService;
+        _apiClient = apiClient;
     }
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
@@ -52,6 +61,10 @@ public class CollectGitHistoryActivity : CodeActivity<GitHistoryContext>
         var repositoryUrl = RepositoryUrl.Get(context);
         var branchName = BranchName.Get(context);
         var mode = DebugContextMode.Get(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var correlationId = context.WorkflowExecutionContext.Id;
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+        var ct = context.CancellationToken;
 
         _logger?.LogInformation(
             "Collecting git history for {Repository}:{Branch} in mode {Mode}",
@@ -61,15 +74,19 @@ public class CollectGitHistoryActivity : CodeActivity<GitHistoryContext>
         {
             var result = new GitHistoryContext();
 
-            if (_integrationService != null && !string.IsNullOrEmpty(repositoryUrl))
+            if (!string.IsNullOrEmpty(repositoryUrl))
             {
                 // For RuntimeError, look at a wider time range
                 var since = mode == "RuntimeError"
                     ? DateTime.UtcNow.AddDays(-3)
                     : DateTime.UtcNow.AddDays(-1);
 
-                var commits = await _integrationService.GetGitHubCommitsAsync(
-                    repositoryUrl, branchName, since);
+                var commitsResponse = await apiClient.GetCommitsAsync(
+                    repositoryUrl, branchName, since, correlationId, tenantId, ct);
+                if (commitsResponse is null || !commitsResponse.Success)
+                    throw new InvalidOperationException(
+                        commitsResponse?.FailureReason ?? "git mediation endpoint unavailable");
+                var commits = GitMediationMapping.ToCommits(commitsResponse.Commits);
 
                 result.RecentCommits = commits
                     .OrderByDescending(c => c.Timestamp)

--- a/apps/tamma-elsa/src/Tamma.Activities/Debug/CollectRelevantCodeActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Debug/CollectRelevantCodeActivity.cs
@@ -4,8 +4,9 @@ using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
+using Tamma.Activities.ADL;
 using Tamma.Activities.Debug.Models;
-using Tamma.Core.Interfaces;
+using Tamma.Activities.LlmCall;
 
 namespace Tamma.Activities.Debug;
 
@@ -22,7 +23,7 @@ namespace Tamma.Activities.Debug;
 public class CollectRelevantCodeActivity : CodeActivity<RelevantCode>
 {
     private readonly ILogger<CollectRelevantCodeActivity>? _logger;
-    private readonly IIntegrationService? _integrationService;
+    private readonly TammaApiClient? _apiClient;
 
     /// <summary>Files involved in the error</summary>
     [Input(Description = "Files involved in the error (optional)")]
@@ -40,15 +41,23 @@ public class CollectRelevantCodeActivity : CodeActivity<RelevantCode>
     [Input(Description = "Debug context mode")]
     public Input<string> DebugContextMode { get; set; } = default!;
 
+    [Input(Description = "Tenant id (GUID string) for BYOK token resolution; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
     [JsonConstructor]
     public CollectRelevantCodeActivity() { }
 
+    /// <summary>
+    /// Story 38 (Phase 2) — thin-client DI constructor. No <c>IIntegrationService</c>
+    /// and no git token: branch file changes are read through the git mediation endpoint
+    /// (<c>GET /api/v1/git/{owner}/{repo}/file-changes</c>) via <see cref="TammaApiClient"/>.
+    /// </summary>
     public CollectRelevantCodeActivity(
         ILogger<CollectRelevantCodeActivity> logger,
-        IIntegrationService integrationService)
+        TammaApiClient apiClient)
     {
         _logger = logger;
-        _integrationService = integrationService;
+        _apiClient = apiClient;
     }
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
@@ -57,6 +66,10 @@ public class CollectRelevantCodeActivity : CodeActivity<RelevantCode>
         var repositoryUrl = RepositoryUrl.Get(context);
         var branchName = BranchName.Get(context);
         var mode = DebugContextMode.Get(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var correlationId = context.WorkflowExecutionContext.Id;
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+        var ct = context.CancellationToken;
 
         _logger?.LogInformation(
             "Collecting relevant code for {FileCount} files in mode {Mode}",
@@ -70,10 +83,14 @@ public class CollectRelevantCodeActivity : CodeActivity<RelevantCode>
             };
 
             // Get file changes from the branch
-            if (_integrationService != null && !string.IsNullOrEmpty(repositoryUrl))
+            if (!string.IsNullOrEmpty(repositoryUrl))
             {
-                var fileChanges = await _integrationService.GetGitHubFileChangesAsync(
-                    repositoryUrl, branchName);
+                var fileChangesResponse = await apiClient.GetFileChangesAsync(
+                    repositoryUrl, branchName, correlationId, tenantId, ct);
+                if (fileChangesResponse is null || !fileChangesResponse.Success)
+                    throw new InvalidOperationException(
+                        fileChangesResponse?.FailureReason ?? "git mediation endpoint unavailable");
+                var fileChanges = GitMediationMapping.ToFileChanges(fileChangesResponse.FileChanges);
 
                 // Add changed files not already in relevant files
                 foreach (var change in fileChanges)

--- a/apps/tamma-elsa/src/Tamma.Activities/Debug/CollectTestResultsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Debug/CollectTestResultsActivity.cs
@@ -4,8 +4,10 @@ using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
+using Tamma.Activities.ADL;
 using Tamma.Activities.Debug.Models;
-using Tamma.Core.Interfaces;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
 
 namespace Tamma.Activities.Debug;
 
@@ -22,7 +24,7 @@ namespace Tamma.Activities.Debug;
 public class CollectTestResultsActivity : CodeActivity<TestResultsContext>
 {
     private readonly ILogger<CollectTestResultsActivity>? _logger;
-    private readonly IIntegrationService? _integrationService;
+    private readonly TammaApiClient? _apiClient;
 
     /// <summary>Repository URL</summary>
     [Input(Description = "Repository URL")]
@@ -40,15 +42,23 @@ public class CollectTestResultsActivity : CodeActivity<TestResultsContext>
     [Input(Description = "Error output that may contain test results")]
     public Input<string> ErrorOutput { get; set; } = default!;
 
+    [Input(Description = "Tenant id (GUID string) for BYOK token resolution; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
     [JsonConstructor]
     public CollectTestResultsActivity() { }
 
+    /// <summary>
+    /// Story 38 (Phase 2) — thin-client DI constructor. No <c>IIntegrationService</c>
+    /// and no git token: the CI test summary is read through the CI mediation endpoint
+    /// (<c>POST /api/v1/ci/{owner}/{repo}/test-runs</c>) via <see cref="TammaApiClient"/>.
+    /// </summary>
     public CollectTestResultsActivity(
         ILogger<CollectTestResultsActivity> logger,
-        IIntegrationService integrationService)
+        TammaApiClient apiClient)
     {
         _logger = logger;
-        _integrationService = integrationService;
+        _apiClient = apiClient;
     }
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
@@ -57,6 +67,10 @@ public class CollectTestResultsActivity : CodeActivity<TestResultsContext>
         var branchName = BranchName.Get(context);
         var mode = DebugContextMode.Get(context);
         var errorOutput = ErrorOutput.Get(context) ?? string.Empty;
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var correlationId = context.WorkflowExecutionContext.Id;
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+        var ct = context.CancellationToken;
 
         _logger?.LogInformation(
             "Collecting test results for {Repository}:{Branch} in mode {Mode}",
@@ -66,10 +80,16 @@ public class CollectTestResultsActivity : CodeActivity<TestResultsContext>
         {
             var result = new TestResultsContext();
 
-            if (_integrationService != null && !string.IsNullOrEmpty(repositoryUrl))
+            if (!string.IsNullOrEmpty(repositoryUrl))
             {
-                var testRun = await _integrationService.TriggerTestsAsync(
-                    repositoryUrl, branchName);
+                var testResponse = await apiClient.TriggerTestsAsync(
+                    repositoryUrl,
+                    new CiTriggerTestsRequest { Branch = branchName, CorrelationId = correlationId },
+                    tenantId, ct);
+                if (testResponse is null || !testResponse.Success)
+                    throw new InvalidOperationException(
+                        testResponse?.FailureReason ?? "ci mediation endpoint unavailable");
+                var testRun = GitMediationMapping.ToTestRun(testResponse.TestRun);
 
                 result.TotalTests = testRun.TotalTests;
                 result.PassingTests = testRun.PassedTests;

--- a/apps/tamma-elsa/src/Tamma.Activities/Integration/EmailActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Integration/EmailActivity.cs
@@ -4,7 +4,9 @@ using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
-using Tamma.Core.Interfaces;
+using Tamma.Activities.ADL;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
 
 namespace Tamma.Activities.Integration;
 
@@ -21,7 +23,7 @@ namespace Tamma.Activities.Integration;
 public class EmailActivity : CodeActivity<EmailOperationResult>
 {
     private readonly ILogger<EmailActivity>? _logger;
-    private readonly IIntegrationService? _integrationService;
+    private readonly TammaApiClient? _apiClient;
 
     /// <summary>Recipient email address</summary>
     [Input(Description = "Recipient email address")]
@@ -47,15 +49,24 @@ public class EmailActivity : CodeActivity<EmailOperationResult>
     [Input(Description = "CC recipients (comma-separated)")]
     public Input<string?> Cc { get; set; } = default!;
 
+    [Input(Description = "Tenant id (GUID string) for the acting scope; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
     [JsonConstructor]
     public EmailActivity() { }
 
+    /// <summary>
+    /// Story 38 (Phase 2, Batch C) — thin-client DI constructor. No <c>IIntegrationService</c>
+    /// and no SMTP/Resend credential: the send routes through the outbox-backed email-mediation
+    /// endpoint via <see cref="TammaApiClient"/>, which OWNS the terminal <c>EMAIL.*</c> audit
+    /// event — this activity never emits its own.
+    /// </summary>
     public EmailActivity(
         ILogger<EmailActivity> logger,
-        IIntegrationService integrationService)
+        TammaApiClient apiClient)
     {
         _logger = logger;
-        _integrationService = integrationService;
+        _apiClient = apiClient;
     }
 
     /// <summary>
@@ -68,6 +79,10 @@ public class EmailActivity : CodeActivity<EmailOperationResult>
         var body = Body.Get(context);
         var template = Template.Get(context);
         var templateData = TemplateData.Get(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var correlationId = context.WorkflowExecutionContext.Id;
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+        var ct = context.CancellationToken;
 
         _logger?.LogInformation(
             "Sending email to {To} with subject: {Subject}",
@@ -80,7 +95,21 @@ public class EmailActivity : CodeActivity<EmailOperationResult>
                 ? ApplyTemplate(template, body, templateData)
                 : body;
 
-            await _integrationService!.SendEmailAsync(to, subject, finalBody);
+            // Route through the outbox-backed mediation endpoint (the API owns the EMAIL.*
+            // audit event; this activity emits none). A null / success:false envelope is an
+            // unexpected send failure — throw so the outer catch reports Success=false, exactly
+            // as the composite's void SendEmailAsync did when it threw.
+            var response = await apiClient.SendEmailAsync(new EmailSendRequest
+            {
+                To = to,
+                Subject = subject,
+                Body = finalBody,
+                CorrelationId = correlationId,
+            }, tenantId, ct);
+
+            if (response is null || !response.Success)
+                throw new InvalidOperationException(
+                    response?.FailureReason ?? "email mediation endpoint unavailable");
 
             _logger?.LogInformation("Email sent successfully to {To}", to);
 

--- a/apps/tamma-elsa/src/Tamma.Activities/Integration/GitHubActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Integration/GitHubActivity.cs
@@ -4,6 +4,9 @@ using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
+using Tamma.Activities.ADL;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
 using Tamma.Core.Interfaces;
 using Tamma.Data.Repositories;
 
@@ -22,7 +25,7 @@ namespace Tamma.Activities.Integration;
 public class GitHubActivity : CodeActivity<GitHubOperationResult>
 {
     private readonly ILogger<GitHubActivity>? _logger;
-    private readonly IIntegrationService? _integrationService;
+    private readonly TammaApiClient? _apiClient;
 
     /// <summary>GitHub action to perform</summary>
     [Input(Description = "Action: CreateBranch, MonitorCommits, CreatePullRequest, MergePullRequest, GetFileChanges")]
@@ -52,15 +55,24 @@ public class GitHubActivity : CodeActivity<GitHubOperationResult>
     [Input(Description = "Pull request body")]
     public Input<string?> PrBody { get; set; } = default!;
 
+    [Input(Description = "Tenant id (GUID string) for BYOK token resolution; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
     [JsonConstructor]
     public GitHubActivity() { }
 
+    /// <summary>
+    /// Story 38 (Phase 2) — thin-client DI constructor. No <c>IIntegrationService</c>
+    /// and no git token: every GitHub op (branch / commits / PR / merge / file-changes /
+    /// tests) routes through the git/CI mediation endpoints via
+    /// <see cref="TammaApiClient"/>, where the per-tenant token lives.
+    /// </summary>
     public GitHubActivity(
         ILogger<GitHubActivity> logger,
-        IIntegrationService integrationService)
+        TammaApiClient apiClient)
     {
         _logger = logger;
-        _integrationService = integrationService;
+        _apiClient = apiClient;
     }
 
     /// <summary>
@@ -75,6 +87,10 @@ public class GitHubActivity : CodeActivity<GitHubOperationResult>
         var prNumber = PullRequestNumber.Get(context);
         var prTitle = PrTitle.Get(context);
         var prBody = PrBody.Get(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var correlationId = context.WorkflowExecutionContext.Id;
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+        var ct = context.CancellationToken;
 
         _logger?.LogInformation(
             "Executing GitHub action {Action} on repository {Repository}",
@@ -84,12 +100,12 @@ public class GitHubActivity : CodeActivity<GitHubOperationResult>
         {
             GitHubOperationResult result = action switch
             {
-                GitHubAction.CreateBranch => await CreateBranch(repository, branchName!),
-                GitHubAction.MonitorCommits => await MonitorCommits(repository, branchName!),
-                GitHubAction.CreatePullRequest => await CreatePullRequest(repository, branchName!, prTitle!, prBody!),
-                GitHubAction.MergePullRequest => await MergePullRequest(repository, prNumber!.Value),
-                GitHubAction.GetFileChanges => await GetFileChanges(repository, branchName!),
-                GitHubAction.RunTests => await RunTests(repository, branchName!),
+                GitHubAction.CreateBranch => await CreateBranch(apiClient, repository, branchName!, correlationId, tenantId, ct),
+                GitHubAction.MonitorCommits => await MonitorCommits(apiClient, repository, branchName!, correlationId, tenantId, ct),
+                GitHubAction.CreatePullRequest => await CreatePullRequest(apiClient, repository, branchName!, prTitle!, prBody!, correlationId, tenantId, ct),
+                GitHubAction.MergePullRequest => await MergePullRequest(apiClient, repository, prNumber!.Value, correlationId, tenantId, ct),
+                GitHubAction.GetFileChanges => await GetFileChanges(apiClient, repository, branchName!, correlationId, tenantId, ct),
+                GitHubAction.RunTests => await RunTests(apiClient, repository, branchName!, correlationId, tenantId, ct),
                 _ => new GitHubOperationResult { Success = false, Message = $"Unknown action: {action}" }
             };
 
@@ -106,23 +122,43 @@ public class GitHubActivity : CodeActivity<GitHubOperationResult>
         }
     }
 
-    private async Task<GitHubOperationResult> CreateBranch(string repository, string branchName)
+    private static async Task<GitHubOperationResult> CreateBranch(
+        TammaApiClient apiClient, string repository, string branchName,
+        string correlationId, string? tenantId, CancellationToken ct)
     {
-        var result = await _integrationService!.CreateGitHubBranchAsync(repository, branchName);
+        var response = await apiClient.CreateBranchAsync(repository, new GitCreateBranchRequest
+        {
+            BranchName = branchName,
+            BaseRef = CreateBranchActivity.DefaultBaseBranch,
+            CorrelationId = correlationId,
+        }, tenantId, ct);
+
+        // A null / failed response (guard 403 / token 503 / auth 401 / transport) maps to
+        // the same soft failure the composite surfaced (Success=false + reason).
+        var success = response?.Success ?? false;
         return new GitHubOperationResult
         {
-            Success = result.Success,
-            Message = result.Success ? $"Created branch: {branchName}" : result.Error,
-            BranchName = result.BranchName,
-            BranchUrl = result.BranchUrl
+            Success = success,
+            Message = success
+                ? $"Created branch: {response!.BranchRef ?? branchName}"
+                : (response?.FailureReason ?? "git mediation endpoint unavailable"),
+            BranchName = response?.BranchRef ?? (success ? branchName : null),
+            // BranchUrl is not carried by the git-mediation wire response.
+            BranchUrl = null
         };
     }
 
-    private async Task<GitHubOperationResult> MonitorCommits(string repository, string branchName)
+    private static async Task<GitHubOperationResult> MonitorCommits(
+        TammaApiClient apiClient, string repository, string branchName,
+        string correlationId, string? tenantId, CancellationToken ct)
     {
-        var commits = await _integrationService!.GetGitHubCommitsAsync(
-            repository, branchName, DateTime.UtcNow.AddHours(-1));
+        var response = await apiClient.GetCommitsAsync(
+            repository, branchName, DateTime.UtcNow.AddHours(-1), correlationId, tenantId, ct);
+        if (response is null || !response.Success)
+            throw new InvalidOperationException(
+                response?.FailureReason ?? "git mediation endpoint unavailable");
 
+        var commits = GitMediationMapping.ToCommits(response.Commits);
         return new GitHubOperationResult
         {
             Success = true,
@@ -138,42 +174,61 @@ public class GitHubActivity : CodeActivity<GitHubOperationResult>
         };
     }
 
-    private async Task<GitHubOperationResult> CreatePullRequest(
-        string repository, string branchName, string title, string body)
+    private static async Task<GitHubOperationResult> CreatePullRequest(
+        TammaApiClient apiClient, string repository, string branchName, string title, string body,
+        string correlationId, string? tenantId, CancellationToken ct)
     {
-        var result = await _integrationService!.CreateGitHubPullRequestAsync(repository, new CreatePullRequestRequest
+        var response = await apiClient.CreatePullRequestAsync(repository, new GitCreatePrRequest
         {
             Title = title,
             Body = body,
-            Head = branchName,
-            Base = "main"
-        });
+            HeadRef = branchName,
+            BaseRef = "main",
+            CorrelationId = correlationId,
+        }, tenantId, ct);
 
+        var success = response?.Success ?? false;
         return new GitHubOperationResult
         {
-            Success = result.Success,
-            Message = result.Success ? $"Created PR #{result.Number}" : result.Error,
-            PullRequestNumber = result.Number,
-            PullRequestUrl = result.Url
+            Success = success,
+            Message = success
+                ? $"Created PR #{response!.PrNumber}"
+                : (response?.FailureReason ?? "git mediation endpoint unavailable"),
+            PullRequestNumber = response?.PrNumber,
+            PullRequestUrl = response?.PrUrl
         };
     }
 
-    private async Task<GitHubOperationResult> MergePullRequest(string repository, int prNumber)
+    private static async Task<GitHubOperationResult> MergePullRequest(
+        TammaApiClient apiClient, string repository, int prNumber,
+        string correlationId, string? tenantId, CancellationToken ct)
     {
-        var result = await _integrationService!.MergeGitHubPullRequestAsync(repository, prNumber);
+        var response = await apiClient.MergePullRequestAsync(repository, prNumber, new GitMergePrRequest
+        {
+            CorrelationId = correlationId,
+        }, tenantId, ct);
 
+        var success = response?.Success ?? false;
         return new GitHubOperationResult
         {
-            Success = result.Success,
-            Message = result.Success ? $"Merged PR #{prNumber}" : result.Error,
-            MergeSha = result.MergeSha
+            Success = success,
+            Message = success
+                ? $"Merged PR #{prNumber}"
+                : (response?.FailureReason ?? "git mediation endpoint unavailable"),
+            MergeSha = response?.MergeSha
         };
     }
 
-    private async Task<GitHubOperationResult> GetFileChanges(string repository, string branchName)
+    private static async Task<GitHubOperationResult> GetFileChanges(
+        TammaApiClient apiClient, string repository, string branchName,
+        string correlationId, string? tenantId, CancellationToken ct)
     {
-        var changes = await _integrationService!.GetGitHubFileChangesAsync(repository, branchName);
+        var response = await apiClient.GetFileChangesAsync(repository, branchName, correlationId, tenantId, ct);
+        if (response is null || !response.Success)
+            throw new InvalidOperationException(
+                response?.FailureReason ?? "git mediation endpoint unavailable");
 
+        var changes = GitMediationMapping.ToFileChanges(response.FileChanges);
         return new GitHubOperationResult
         {
             Success = true,
@@ -188,10 +243,20 @@ public class GitHubActivity : CodeActivity<GitHubOperationResult>
         };
     }
 
-    private async Task<GitHubOperationResult> RunTests(string repository, string branchName)
+    private static async Task<GitHubOperationResult> RunTests(
+        TammaApiClient apiClient, string repository, string branchName,
+        string correlationId, string? tenantId, CancellationToken ct)
     {
-        var result = await _integrationService!.TriggerTestsAsync(repository, branchName);
+        var response = await apiClient.TriggerTestsAsync(repository, new CiTriggerTestsRequest
+        {
+            Branch = branchName,
+            CorrelationId = correlationId,
+        }, tenantId, ct);
+        if (response is null || !response.Success)
+            throw new InvalidOperationException(
+                response?.FailureReason ?? "ci mediation endpoint unavailable");
 
+        var result = GitMediationMapping.ToTestRun(response.TestRun);
         return new GitHubOperationResult
         {
             Success = result.FailedTests == 0,

--- a/apps/tamma-elsa/src/Tamma.Activities/Integration/JiraActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Integration/JiraActivity.cs
@@ -4,7 +4,9 @@ using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
-using Tamma.Core.Interfaces;
+using Tamma.Activities.ADL;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
 
 namespace Tamma.Activities.Integration;
 
@@ -21,7 +23,7 @@ namespace Tamma.Activities.Integration;
 public class JiraActivity : CodeActivity<JiraOperationResult>
 {
     private readonly ILogger<JiraActivity>? _logger;
-    private readonly IIntegrationService? _integrationService;
+    private readonly TammaApiClient? _apiClient;
 
     /// <summary>JIRA action to perform</summary>
     [Input(Description = "Action: GetTicket, UpdateStatus, AddComment, LinkPR")]
@@ -47,15 +49,23 @@ public class JiraActivity : CodeActivity<JiraOperationResult>
     [Input(Description = "Custom fields as key-value pairs")]
     public Input<Dictionary<string, object>?> CustomFields { get; set; } = default!;
 
+    [Input(Description = "Tenant id (GUID string) for JIRA credential resolution; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
     [JsonConstructor]
     public JiraActivity() { }
 
+    /// <summary>
+    /// Story 38 (Phase 2, Batch C) — thin-client DI constructor. No <c>IIntegrationService</c>
+    /// and no JIRA credential: every JIRA op routes through the JIRA-mediation endpoints via
+    /// <see cref="TammaApiClient"/>, where the credential lives.
+    /// </summary>
     public JiraActivity(
         ILogger<JiraActivity> logger,
-        IIntegrationService integrationService)
+        TammaApiClient apiClient)
     {
         _logger = logger;
-        _integrationService = integrationService;
+        _apiClient = apiClient;
     }
 
     /// <summary>
@@ -69,6 +79,10 @@ public class JiraActivity : CodeActivity<JiraOperationResult>
         var comment = Comment.Get(context);
         var prUrl = PullRequestUrl.Get(context);
         var customFields = CustomFields.Get(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var correlationId = context.WorkflowExecutionContext.Id;
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+        var ct = context.CancellationToken;
 
         _logger?.LogInformation(
             "Executing JIRA action {Action} on ticket {TicketId}",
@@ -78,11 +92,11 @@ public class JiraActivity : CodeActivity<JiraOperationResult>
         {
             JiraOperationResult result = action switch
             {
-                JiraAction.GetTicket => await GetTicket(ticketId),
-                JiraAction.UpdateStatus => await UpdateStatus(ticketId, status!),
-                JiraAction.AddComment => await AddComment(ticketId, comment!),
-                JiraAction.LinkPR => await LinkPullRequest(ticketId, prUrl!),
-                JiraAction.UpdateFields => await UpdateCustomFields(ticketId, customFields!),
+                JiraAction.GetTicket => await GetTicket(apiClient, ticketId, correlationId, tenantId, ct),
+                JiraAction.UpdateStatus => await UpdateStatus(apiClient, ticketId, status!, correlationId, tenantId, ct),
+                JiraAction.AddComment => await AddComment(apiClient, ticketId, comment!, correlationId, tenantId, ct),
+                JiraAction.LinkPR => await LinkPullRequest(apiClient, ticketId, prUrl!, correlationId, tenantId, ct),
+                JiraAction.UpdateFields => await UpdateCustomFields(apiClient, ticketId, customFields!, correlationId, tenantId, ct),
                 _ => new JiraOperationResult { Success = false, Message = $"Unknown action: {action}" }
             };
 
@@ -99,10 +113,19 @@ public class JiraActivity : CodeActivity<JiraOperationResult>
         }
     }
 
-    private async Task<JiraOperationResult> GetTicket(string ticketId)
+    private static async Task<JiraOperationResult> GetTicket(
+        TammaApiClient apiClient, string ticketId, string correlationId, string? tenantId, CancellationToken ct)
     {
-        var ticket = await _integrationService!.GetJiraTicketAsync(ticketId);
+        var response = await apiClient.GetJiraTicketAsync(ticketId, correlationId, tenantId, ct);
 
+        // A null / failed response (mediation unavailable / platform error) is an UNEXPECTED
+        // failure — throw so the outer catch surfaces "Operation failed" (mirrors the composite
+        // GetJiraTicketAsync which threw on error, distinct from a found-but-null "not found").
+        if (response is null || !response.Success)
+            throw new InvalidOperationException(
+                response?.FailureReason ?? "jira mediation endpoint unavailable");
+
+        var ticket = GitMediationMapping.ToJiraTicket(response.Ticket);
         if (ticket == null)
         {
             return new JiraOperationResult
@@ -123,12 +146,15 @@ public class JiraActivity : CodeActivity<JiraOperationResult>
         };
     }
 
-    private async Task<JiraOperationResult> UpdateStatus(string ticketId, string newStatus)
+    private static async Task<JiraOperationResult> UpdateStatus(
+        TammaApiClient apiClient, string ticketId, string newStatus, string correlationId, string? tenantId, CancellationToken ct)
     {
-        var result = await _integrationService!.UpdateJiraTicketAsync(ticketId, new JiraTicketUpdate
-        {
-            Status = newStatus
-        });
+        var result = GitMediationMapping.ToJiraTicketResult(
+            await apiClient.UpdateJiraTicketAsync(ticketId, new JiraUpdateTicketRequest
+            {
+                Status = newStatus,
+                CorrelationId = correlationId,
+            }, tenantId, ct));
 
         return new JiraOperationResult
         {
@@ -141,12 +167,15 @@ public class JiraActivity : CodeActivity<JiraOperationResult>
         };
     }
 
-    private async Task<JiraOperationResult> AddComment(string ticketId, string comment)
+    private static async Task<JiraOperationResult> AddComment(
+        TammaApiClient apiClient, string ticketId, string comment, string correlationId, string? tenantId, CancellationToken ct)
     {
-        var result = await _integrationService!.UpdateJiraTicketAsync(ticketId, new JiraTicketUpdate
-        {
-            Comment = comment
-        });
+        var result = GitMediationMapping.ToJiraTicketResult(
+            await apiClient.UpdateJiraTicketAsync(ticketId, new JiraUpdateTicketRequest
+            {
+                Comment = comment,
+                CorrelationId = correlationId,
+            }, tenantId, ct));
 
         return new JiraOperationResult
         {
@@ -158,14 +187,17 @@ public class JiraActivity : CodeActivity<JiraOperationResult>
         };
     }
 
-    private async Task<JiraOperationResult> LinkPullRequest(string ticketId, string prUrl)
+    private static async Task<JiraOperationResult> LinkPullRequest(
+        TammaApiClient apiClient, string ticketId, string prUrl, string correlationId, string? tenantId, CancellationToken ct)
     {
         var comment = $"**Pull Request Linked**\n\nPR: {prUrl}\n\n_Linked automatically by Tamma Mentorship System_";
 
-        var result = await _integrationService!.UpdateJiraTicketAsync(ticketId, new JiraTicketUpdate
-        {
-            Comment = comment
-        });
+        var result = GitMediationMapping.ToJiraTicketResult(
+            await apiClient.UpdateJiraTicketAsync(ticketId, new JiraUpdateTicketRequest
+            {
+                Comment = comment,
+                CorrelationId = correlationId,
+            }, tenantId, ct));
 
         return new JiraOperationResult
         {
@@ -178,12 +210,15 @@ public class JiraActivity : CodeActivity<JiraOperationResult>
         };
     }
 
-    private async Task<JiraOperationResult> UpdateCustomFields(string ticketId, Dictionary<string, object> fields)
+    private static async Task<JiraOperationResult> UpdateCustomFields(
+        TammaApiClient apiClient, string ticketId, Dictionary<string, object> fields, string correlationId, string? tenantId, CancellationToken ct)
     {
-        var result = await _integrationService!.UpdateJiraTicketAsync(ticketId, new JiraTicketUpdate
-        {
-            CustomFields = fields
-        });
+        var result = GitMediationMapping.ToJiraTicketResult(
+            await apiClient.UpdateJiraTicketAsync(ticketId, new JiraUpdateTicketRequest
+            {
+                CustomFields = fields,
+                CorrelationId = correlationId,
+            }, tenantId, ct));
 
         return new JiraOperationResult
         {

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/GitMediationMapping.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/GitMediationMapping.cs
@@ -77,4 +77,56 @@ public static class GitMediationMapping
                 StartedAt = status.StartedAt,
                 FinishedAt = status.FinishedAt,
             };
+
+    /// <summary>Story 38 (Phase 2, Batch C) — project a git-merge wire response into the
+    /// composite <see cref="GitHubMergeResult"/> so the two mentorship/review merge callers
+    /// keep their downstream logic byte-compatible. Soft-fail (write op): a null response
+    /// (guard 403 / token 503 / auth 401 / transport) or a <c>Success=false</c> envelope
+    /// maps to <c>Success=false</c> with the failure reason/code surfaced on
+    /// <see cref="GitHubMergeResult.Error"/> — mirrors the composite's soft merge result
+    /// (never a fabricated success).</summary>
+    public static GitHubMergeResult ToMergeResult(GitCallResponse? response)
+        => response is null
+            ? new GitHubMergeResult { Success = false, Error = "git mediation endpoint unavailable" }
+            : new GitHubMergeResult
+            {
+                Success = response.Success,
+                MergeSha = response.MergeSha,
+                Error = response.Success ? null : (response.FailureReason ?? response.FailureCode),
+            };
+
+    /// <summary>Story 38 (Phase 2, Batch C) — project a JIRA-mediation ticket DTO into the
+    /// composite <see cref="JiraTicket"/> (null DTO → null, matching the composite's nullable
+    /// read). <see cref="JiraTicket.Labels"/> defaults to an empty list when the wire carried
+    /// none.</summary>
+    public static JiraTicket? ToJiraTicket(JiraTicketDto? dto)
+        => dto is null
+            ? null
+            : new JiraTicket
+            {
+                Id = dto.Id,
+                Key = dto.Key,
+                Summary = dto.Summary,
+                Description = dto.Description,
+                Status = dto.Status,
+                Assignee = dto.Assignee,
+                Priority = dto.Priority,
+                Labels = dto.Labels.ToList(),
+            };
+
+    /// <summary>Story 38 (Phase 2, Batch C) — project a JIRA-mediation response into the
+    /// composite <see cref="JiraTicketResult"/>. Soft-fail (write op): a null response
+    /// (transport / mediation unavailable) or a <c>Success=false</c> envelope maps to
+    /// <c>Success=false</c> with the failure reason/code on <see cref="JiraTicketResult.Error"/> —
+    /// mirrors the composite's soft update result (the update path never threw for an expected
+    /// failure).</summary>
+    public static JiraTicketResult ToJiraTicketResult(JiraCallResponse? response)
+        => response is null
+            ? new JiraTicketResult { Success = false, Error = "jira mediation endpoint unavailable" }
+            : new JiraTicketResult
+            {
+                Success = response.Success,
+                TicketKey = response.TicketKey,
+                Error = response.Success ? null : (response.FailureReason ?? response.FailureCode),
+            };
 }

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/GitMediationMapping.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/GitMediationMapping.cs
@@ -1,0 +1,63 @@
+using Tamma.Activities.LlmCall.Models;
+using Tamma.Core.Interfaces;
+
+namespace Tamma.Activities.LlmCall;
+
+/// <summary>
+/// Story 38 (Phase 2, Batch A) — shared projection of the git/CI mediation wire
+/// records (<see cref="GitCallResponse"/> / <see cref="CiCallResponse"/>) back into
+/// the composite integration models (<see cref="GitHubCommit"/> /
+/// <see cref="GitHubFileChange"/> / <see cref="TestRunResult"/>) so the eight
+/// activities cut over from <c>IIntegrationService</c> to <see cref="TammaApiClient"/>
+/// keep their downstream logic byte-compatible. Pure + null-safe (a null / empty wire
+/// list projects to an empty list), so it is unit-testable in isolation.
+/// </summary>
+public static class GitMediationMapping
+{
+    /// <summary>Project the wire commit summaries into composite <see cref="GitHubCommit"/>
+    /// records (empty list when the wire carried none).</summary>
+    public static List<GitHubCommit> ToCommits(IReadOnlyList<GitCommitSummaryDto>? commits)
+        => commits is null
+            ? new List<GitHubCommit>()
+            : commits.Select(c => new GitHubCommit
+            {
+                Sha = c.Sha,
+                Message = c.Message,
+                Author = c.Author,
+                Timestamp = c.Timestamp,
+                Additions = c.Additions,
+                Deletions = c.Deletions,
+                Files = c.Files.ToList(),
+            }).ToList();
+
+    /// <summary>Project the wire file changes into composite <see cref="GitHubFileChange"/>
+    /// records (empty list when the wire carried none).</summary>
+    public static List<GitHubFileChange> ToFileChanges(IReadOnlyList<GitFileChangeDto>? changes)
+        => changes is null
+            ? new List<GitHubFileChange>()
+            : changes.Select(c => new GitHubFileChange
+            {
+                FilePath = c.FilePath,
+                ChangeType = c.ChangeType,
+                Additions = c.Additions,
+                Deletions = c.Deletions,
+            }).ToList();
+
+    /// <summary>Project the wire test-run summary into a composite
+    /// <see cref="TestRunResult"/>. <see cref="TestRunResult.FailedTestDetails"/> is
+    /// left empty — the CI-mediation endpoint returns aggregate counts only, not
+    /// per-test detail. A null summary projects to an empty (all-zero) result.</summary>
+    public static TestRunResult ToTestRun(CiTestRunDto? run)
+        => run is null
+            ? new TestRunResult()
+            : new TestRunResult
+            {
+                RunId = run.RunId,
+                Status = run.Status,
+                TotalTests = run.TotalTests,
+                PassedTests = run.PassedTests,
+                FailedTests = run.FailedTests,
+                SkippedTests = run.SkippedTests,
+                CoveragePercentage = run.CoveragePercentage,
+            };
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/GitMediationMapping.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/GitMediationMapping.cs
@@ -60,4 +60,21 @@ public static class GitMediationMapping
                 SkippedTests = run.SkippedTests,
                 CoveragePercentage = run.CoveragePercentage,
             };
+
+    /// <summary>Story 38 (Phase 2, Batch B) — project the wire build-status summary
+    /// into a composite <see cref="BuildStatus"/>. The CI-mediation build-status DTO
+    /// carries no <c>Error</c> field (a failed build surfaces via <see cref="BuildStatus.Status"/>);
+    /// <see cref="BuildStatus.Error"/> is therefore left null — a genuine mediation
+    /// failure is handled upstream by the caller's <c>!Success</c> throw, not here. A
+    /// null summary projects to an empty (default) status.</summary>
+    public static BuildStatus ToBuildStatus(CiBuildStatusDto? status)
+        => status is null
+            ? new BuildStatus()
+            : new BuildStatus
+            {
+                Status = status.Status,
+                BuildUrl = status.BuildUrl,
+                StartedAt = status.StartedAt,
+                FinishedAt = status.FinishedAt,
+            };
 }

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Models/TammaApiModels.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Models/TammaApiModels.cs
@@ -348,6 +348,10 @@ public sealed record GitCallResponse
 
     [JsonPropertyName("comments")] public IReadOnlyList<GitCommentDto>? Comments { get; init; }
 
+    // Story 38 (Phase 1) — GitHub extra-op reads.
+    [JsonPropertyName("commits")] public IReadOnlyList<GitCommitSummaryDto>? Commits { get; init; }
+    [JsonPropertyName("fileChanges")] public IReadOnlyList<GitFileChangeDto>? FileChanges { get; init; }
+
     [JsonPropertyName("failureCode")] public string? FailureCode { get; init; }
     [JsonPropertyName("failureReason")] public string? FailureReason { get; init; }
     [JsonPropertyName("platformStatusCode")] public int? PlatformStatusCode { get; init; }
@@ -363,6 +367,27 @@ public sealed record GitCommentDto
     [JsonPropertyName("line")] public int? Line { get; init; }
     [JsonPropertyName("author")] public string Author { get; init; } = string.Empty;
     [JsonPropertyName("createdAt")] public DateTime CreatedAt { get; init; }
+}
+
+/// <summary>A key-free commit. Mirrors <c>Tamma.Api.Services.Git.GitCommitDto</c> (Story 38 Phase 1).</summary>
+public sealed record GitCommitSummaryDto
+{
+    [JsonPropertyName("sha")] public string Sha { get; init; } = string.Empty;
+    [JsonPropertyName("message")] public string Message { get; init; } = string.Empty;
+    [JsonPropertyName("author")] public string Author { get; init; } = string.Empty;
+    [JsonPropertyName("timestamp")] public DateTime Timestamp { get; init; }
+    [JsonPropertyName("additions")] public int Additions { get; init; }
+    [JsonPropertyName("deletions")] public int Deletions { get; init; }
+    [JsonPropertyName("files")] public IReadOnlyList<string> Files { get; init; } = Array.Empty<string>();
+}
+
+/// <summary>A key-free file change. Mirrors <c>Tamma.Api.Services.Git.GitFileChangeDto</c> (Story 38 Phase 1).</summary>
+public sealed record GitFileChangeDto
+{
+    [JsonPropertyName("filePath")] public string FilePath { get; init; } = string.Empty;
+    [JsonPropertyName("changeType")] public string ChangeType { get; init; } = string.Empty;
+    [JsonPropertyName("additions")] public int Additions { get; init; }
+    [JsonPropertyName("deletions")] public int Deletions { get; init; }
 }
 
 // ============================================================
@@ -466,6 +491,117 @@ public sealed record AgentInstallationApiResponse
 {
     [JsonPropertyName("success")] public bool Success { get; init; }
     [JsonPropertyName("installationId")] public long? InstallationId { get; init; }
+    [JsonPropertyName("failureCode")] public string? FailureCode { get; init; }
+    [JsonPropertyName("failureReason")] public string? FailureReason { get; init; }
+    [JsonPropertyName("correlationId")] public string? CorrelationId { get; init; }
+}
+
+// ============================================================
+// Story 38 (Phase 1): CI / JIRA / email mediation wire models
+//
+// These mirror the JSON shapes of Tamma.Api's Services/Ci, Services/Jira, and
+// Services/EmailMediation request + result records for the engine→API endpoints
+// POST/GET /api/v1/ci/... , GET/PATCH /api/v1/jira/tickets/... , and
+// POST /api/v1/notifications/email . They live in Tamma.Activities (the reference
+// graph runs Tamma.Api → Tamma.Activities) and carry [JsonPropertyName] camelCase to
+// match the API's CamelCase serialization. NONE carry a credential — the API resolves
+// it server-side; only credentialSource (the LABEL) ever comes back (CI only).
+// ============================================================
+
+/// <summary>Engine→API request for <c>POST /api/v1/ci/{owner}/{repo}/test-runs</c>.</summary>
+public sealed record CiTriggerTestsRequest
+{
+    [JsonPropertyName("branch")] public string Branch { get; init; } = string.Empty;
+    [JsonPropertyName("correlationId")] public string CorrelationId { get; init; } = string.Empty;
+}
+
+/// <summary>Response for the CI-mediation endpoints. Mirrors
+/// <c>Tamma.Api.Services.Ci.CiMediationResult</c>. KEY-FREE.</summary>
+public sealed record CiCallResponse
+{
+    [JsonPropertyName("success")] public bool Success { get; init; }
+    [JsonPropertyName("credentialSource")] public string? CredentialSource { get; init; }
+    [JsonPropertyName("outcome")] public string? Outcome { get; init; }
+    [JsonPropertyName("testRun")] public CiTestRunDto? TestRun { get; init; }
+    [JsonPropertyName("buildStatus")] public CiBuildStatusDto? BuildStatus { get; init; }
+    [JsonPropertyName("failureCode")] public string? FailureCode { get; init; }
+    [JsonPropertyName("failureReason")] public string? FailureReason { get; init; }
+    [JsonPropertyName("platformStatusCode")] public int? PlatformStatusCode { get; init; }
+    [JsonPropertyName("correlationId")] public string? CorrelationId { get; init; }
+}
+
+/// <summary>A key-free test-run projection. Mirrors <c>Tamma.Api.Services.Ci.CiTestRunDto</c>.</summary>
+public sealed record CiTestRunDto
+{
+    [JsonPropertyName("runId")] public string RunId { get; init; } = string.Empty;
+    [JsonPropertyName("status")] public string Status { get; init; } = string.Empty;
+    [JsonPropertyName("totalTests")] public int TotalTests { get; init; }
+    [JsonPropertyName("passedTests")] public int PassedTests { get; init; }
+    [JsonPropertyName("failedTests")] public int FailedTests { get; init; }
+    [JsonPropertyName("skippedTests")] public int SkippedTests { get; init; }
+    [JsonPropertyName("coveragePercentage")] public double? CoveragePercentage { get; init; }
+}
+
+/// <summary>A key-free build-status projection. Mirrors <c>Tamma.Api.Services.Ci.CiBuildStatusDto</c>.</summary>
+public sealed record CiBuildStatusDto
+{
+    [JsonPropertyName("status")] public string Status { get; init; } = string.Empty;
+    [JsonPropertyName("buildUrl")] public string? BuildUrl { get; init; }
+    [JsonPropertyName("startedAt")] public DateTime? StartedAt { get; init; }
+    [JsonPropertyName("finishedAt")] public DateTime? FinishedAt { get; init; }
+}
+
+/// <summary>Engine→API request for <c>PATCH /api/v1/jira/tickets/{ticketId}</c>.</summary>
+public sealed record JiraUpdateTicketRequest
+{
+    [JsonPropertyName("status")] public string? Status { get; init; }
+    [JsonPropertyName("comment")] public string? Comment { get; init; }
+    [JsonPropertyName("customFields")] public Dictionary<string, object>? CustomFields { get; init; }
+    [JsonPropertyName("correlationId")] public string CorrelationId { get; init; } = string.Empty;
+}
+
+/// <summary>Response for the JIRA-mediation endpoints. Mirrors
+/// <c>Tamma.Api.Services.Jira.JiraMediationResult</c>. KEY-FREE.</summary>
+public sealed record JiraCallResponse
+{
+    [JsonPropertyName("success")] public bool Success { get; init; }
+    [JsonPropertyName("outcome")] public string? Outcome { get; init; }
+    [JsonPropertyName("ticket")] public JiraTicketDto? Ticket { get; init; }
+    [JsonPropertyName("ticketKey")] public string? TicketKey { get; init; }
+    [JsonPropertyName("failureCode")] public string? FailureCode { get; init; }
+    [JsonPropertyName("failureReason")] public string? FailureReason { get; init; }
+    [JsonPropertyName("correlationId")] public string? CorrelationId { get; init; }
+}
+
+/// <summary>A key-free JIRA ticket projection. Mirrors <c>Tamma.Api.Services.Jira.JiraTicketDto</c>.</summary>
+public sealed record JiraTicketDto
+{
+    [JsonPropertyName("id")] public string Id { get; init; } = string.Empty;
+    [JsonPropertyName("key")] public string Key { get; init; } = string.Empty;
+    [JsonPropertyName("summary")] public string Summary { get; init; } = string.Empty;
+    [JsonPropertyName("description")] public string? Description { get; init; }
+    [JsonPropertyName("status")] public string Status { get; init; } = string.Empty;
+    [JsonPropertyName("assignee")] public string? Assignee { get; init; }
+    [JsonPropertyName("priority")] public string? Priority { get; init; }
+    [JsonPropertyName("labels")] public IReadOnlyList<string> Labels { get; init; } = Array.Empty<string>();
+}
+
+/// <summary>Engine→API request for <c>POST /api/v1/notifications/email</c>.</summary>
+public sealed record EmailSendRequest
+{
+    [JsonPropertyName("to")] public string To { get; init; } = string.Empty;
+    [JsonPropertyName("subject")] public string Subject { get; init; } = string.Empty;
+    [JsonPropertyName("body")] public string Body { get; init; } = string.Empty;
+    [JsonPropertyName("correlationId")] public string CorrelationId { get; init; } = string.Empty;
+}
+
+/// <summary>Response for the email-mediation endpoint. Mirrors
+/// <c>Tamma.Api.Services.EmailMediation.EmailMediationResult</c>. KEY-FREE.</summary>
+public sealed record EmailCallResponse
+{
+    [JsonPropertyName("success")] public bool Success { get; init; }
+    [JsonPropertyName("outcome")] public string? Outcome { get; init; }
+    [JsonPropertyName("txnId")] public Guid? TxnId { get; init; }
     [JsonPropertyName("failureCode")] public string? FailureCode { get; init; }
     [JsonPropertyName("failureReason")] public string? FailureReason { get; init; }
     [JsonPropertyName("correlationId")] public string? CorrelationId { get; init; }

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/TammaApiClient.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/TammaApiClient.cs
@@ -166,6 +166,112 @@ public class TammaApiClient
         return GetAsync<GitCallResponse>(url, tenantId, ct);
     }
 
+    // ----- GitHub extra ops (Story 38 Phase 1 — commits / file-changes / delete) --
+
+    /// <summary>Story 38 (Phase 1) — read recent commits on a branch via
+    /// <c>GET /api/v1/git/{owner}/{repo}/commits?branch=&amp;since=&amp;correlationId=</c>.
+    /// The token is resolved + used server-side; it never travels here. Returns null on
+    /// any non-2xx / transport failure (the thin activity maps it to its Error edge).</summary>
+    public virtual Task<GitCallResponse?> GetCommitsAsync(
+        string repo, string branch, DateTime? since = null, string? correlationId = null,
+        string? tenantId = null, CancellationToken ct = default)
+    {
+        var url = $"{_baseUrl}/api/v1/git/{RepoPath(repo)}/commits?branch={Uri.EscapeDataString(branch ?? string.Empty)}";
+        if (since is { } s)
+            url += $"&since={Uri.EscapeDataString(s.ToString("o", System.Globalization.CultureInfo.InvariantCulture))}";
+        if (!string.IsNullOrWhiteSpace(correlationId))
+            url += $"&correlationId={Uri.EscapeDataString(correlationId)}";
+        return GetAsync<GitCallResponse>(url, tenantId, ct);
+    }
+
+    /// <summary>Story 38 (Phase 1) — read the file changes on a branch via
+    /// <c>GET /api/v1/git/{owner}/{repo}/file-changes?branch=&amp;correlationId=</c>.</summary>
+    public virtual Task<GitCallResponse?> GetFileChangesAsync(
+        string repo, string branch, string? correlationId = null, string? tenantId = null, CancellationToken ct = default)
+    {
+        var url = $"{_baseUrl}/api/v1/git/{RepoPath(repo)}/file-changes?branch={Uri.EscapeDataString(branch ?? string.Empty)}";
+        if (!string.IsNullOrWhiteSpace(correlationId))
+            url += $"&correlationId={Uri.EscapeDataString(correlationId)}";
+        return GetAsync<GitCallResponse>(url, tenantId, ct);
+    }
+
+    /// <summary>Story 38 (Phase 1) — delete a branch via
+    /// <c>DELETE /api/v1/git/{owner}/{repo}/branches?branch=&amp;correlationId=</c>. The
+    /// branch name (may carry a slash) travels as a query param. Write op — fail-closed
+    /// (null on any non-2xx / transport failure).</summary>
+    public virtual async Task<GitCallResponse?> DeleteBranchAsync(
+        string repo, string branchName, string? correlationId = null, string? tenantId = null, CancellationToken ct = default)
+    {
+        var url = $"{_baseUrl}/api/v1/git/{RepoPath(repo)}/branches?branch={Uri.EscapeDataString(branchName ?? string.Empty)}";
+        if (!string.IsNullOrWhiteSpace(correlationId))
+            url += $"&correlationId={Uri.EscapeDataString(correlationId)}";
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Delete, url);
+            AddTenantHeader(request, tenantId);
+            using var response = await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
+            await RecordHealthAsync(response.IsSuccessStatusCode, (int)response.StatusCode, null, ct).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Tamma API DELETE returned {Status}", (int)response.StatusCode);
+                return null;
+            }
+            return await response.Content.ReadFromJsonAsync<GitCallResponse>(JsonOpts, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException)
+        {
+            _logger.LogWarning(ex, "Tamma API DELETE failed");
+            await RecordHealthAsync(false, null, ex.GetType().Name, ct).ConfigureAwait(false);
+            return null;
+        }
+    }
+
+    // ----- CI mediation (Story 38 Phase 1 — GitHub Actions test-run / build-status) --
+
+    /// <summary>Story 38 (Phase 1) — trigger the CI workflow on a branch via
+    /// <c>POST /api/v1/ci/{owner}/{repo}/test-runs</c>. The per-tenant git token is
+    /// resolved + used server-side; it never travels here.</summary>
+    public virtual Task<Models.CiCallResponse?> TriggerTestsAsync(
+        string repo, Models.CiTriggerTestsRequest request, string? tenantId = null, CancellationToken ct = default)
+    {
+        var url = $"{_baseUrl}/api/v1/ci/{RepoPath(repo)}/test-runs";
+        return PostAsync<Models.CiCallResponse>(url, request, tenantId, ct);
+    }
+
+    /// <summary>Story 38 (Phase 1) — read the latest build status for a branch via
+    /// <c>GET /api/v1/ci/{owner}/{repo}/build-status?branch=&amp;correlationId=</c>.</summary>
+    public virtual Task<Models.CiCallResponse?> GetBuildStatusAsync(
+        string repo, string branch, string? correlationId = null, string? tenantId = null, CancellationToken ct = default)
+    {
+        var url = $"{_baseUrl}/api/v1/ci/{RepoPath(repo)}/build-status?branch={Uri.EscapeDataString(branch ?? string.Empty)}";
+        if (!string.IsNullOrWhiteSpace(correlationId))
+            url += $"&correlationId={Uri.EscapeDataString(correlationId)}";
+        return GetAsync<Models.CiCallResponse>(url, tenantId, ct);
+    }
+
+    // ----- JIRA mediation (Story 38 Phase 1 — ticket read / update) --
+
+    /// <summary>Story 38 (Phase 1) — read a JIRA ticket via
+    /// <c>GET /api/v1/jira/tickets/{ticketId}?correlationId=</c>. The JIRA credential
+    /// lives in Tamma.Api config; it never travels here.</summary>
+    public virtual Task<Models.JiraCallResponse?> GetJiraTicketAsync(
+        string ticketId, string? correlationId = null, string? tenantId = null, CancellationToken ct = default)
+    {
+        var url = $"{_baseUrl}/api/v1/jira/tickets/{Uri.EscapeDataString(ticketId)}";
+        if (!string.IsNullOrWhiteSpace(correlationId))
+            url += $"?correlationId={Uri.EscapeDataString(correlationId)}";
+        return GetAsync<Models.JiraCallResponse>(url, tenantId, ct);
+    }
+
+    /// <summary>Story 38 (Phase 1) — update a JIRA ticket (status + comment) via
+    /// <c>PATCH /api/v1/jira/tickets/{ticketId}</c>.</summary>
+    public virtual Task<Models.JiraCallResponse?> UpdateJiraTicketAsync(
+        string ticketId, Models.JiraUpdateTicketRequest request, string? tenantId = null, CancellationToken ct = default)
+    {
+        var url = $"{_baseUrl}/api/v1/jira/tickets/{Uri.EscapeDataString(ticketId)}";
+        return PatchAsync<Models.JiraCallResponse>(url, request, tenantId, ct);
+    }
+
     // ----- Agent-dispatch mediation (Story 38-2 — the CI-run step-mediation endpoints) --
 
     /// <summary>
@@ -269,6 +375,21 @@ public class TammaApiClient
     {
         var url = $"{_baseUrl}/api/v1/notifications/slack";
         return PostVoidAsync(url, request, tenantId, ct);
+    }
+
+    /// <summary>
+    /// Story 38 (Phase 1) — send an email via the mediated, outbox-backed endpoint
+    /// <c>POST /api/v1/notifications/email</c>. The API accepts the (already-rendered)
+    /// message into the credentialed <c>IEmailService</c>; the SMTP/Resend credential
+    /// never travels here. Fail-soft: a failure rides inside 200 success:false, so a
+    /// missing notification does not break the workflow. Returns null on transport /
+    /// 5xx failure.
+    /// </summary>
+    public virtual Task<Models.EmailCallResponse?> SendEmailAsync(
+        Models.EmailSendRequest request, string? tenantId = null, CancellationToken ct = default)
+    {
+        var url = $"{_baseUrl}/api/v1/notifications/email";
+        return PostAsync<Models.EmailCallResponse>(url, request, tenantId, ct);
     }
 
     // ----- Provider Health ---------------------------------------------

--- a/apps/tamma-elsa/src/Tamma.Activities/Mentorship/CodeReviewActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Mentorship/CodeReviewActivity.cs
@@ -4,7 +4,9 @@ using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
+using Tamma.Activities.ADL;
 using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
 using Tamma.Core.Enums;
 using Tamma.Core.Interfaces;
 using Tamma.Data.Repositories;
@@ -25,7 +27,7 @@ public class CodeReviewActivity : CodeActivity<CodeReviewOutput>
 {
     private readonly ILogger<CodeReviewActivity>? _logger;
     private readonly IMentorshipSessionRepository? _repository;
-    private readonly IIntegrationService? _integrationService;
+    private readonly TammaApiClient? _apiClient;
     private readonly IAnalyticsService? _analyticsService;
 
     /// <summary>Mentorship session ID</summary>
@@ -48,18 +50,28 @@ public class CodeReviewActivity : CodeActivity<CodeReviewOutput>
     [Input(Description = "Existing PR number")]
     public Input<int?> PullRequestNumber { get; set; } = default!;
 
+    [Input(Description = "Tenant id (GUID string) for BYOK token resolution; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
     [JsonConstructor]
     public CodeReviewActivity() { }
 
+    /// <summary>
+    /// Story 38 (Phase 2) — thin-client DI constructor. No <c>IIntegrationService</c>
+    /// and no git token: the Prepare path reads file changes + commits and creates the
+    /// PR through the git-mediation endpoints via <see cref="TammaApiClient"/> (the PR
+    /// body is composed engine-side); Slack notifications already route through the
+    /// <see cref="MediatedSlack"/> seam.
+    /// </summary>
     public CodeReviewActivity(
         ILogger<CodeReviewActivity> logger,
         IMentorshipSessionRepository repository,
-        IIntegrationService integrationService,
+        TammaApiClient apiClient,
         IAnalyticsService analyticsService)
     {
         _logger = logger;
         _repository = repository;
-        _integrationService = integrationService;
+        _apiClient = apiClient;
         _analyticsService = analyticsService;
     }
 
@@ -158,47 +170,58 @@ public class CodeReviewActivity : CodeActivity<CodeReviewOutput>
             };
         }
 
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var correlationId = context.WorkflowExecutionContext.Id;
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+        var ct = context.CancellationToken;
+
         // Get file changes for PR description
-        var fileChanges = await _integrationService!.GetGitHubFileChangesAsync(
-            story.RepositoryUrl,
-            $"feature/{story.Id}");
+        var fileChangesResponse = await apiClient.GetFileChangesAsync(
+            story.RepositoryUrl, $"feature/{story.Id}", correlationId, tenantId, ct);
+        if (fileChangesResponse is null || !fileChangesResponse.Success)
+            throw new InvalidOperationException(
+                fileChangesResponse?.FailureReason ?? "git mediation endpoint unavailable");
+        var fileChanges = GitMediationMapping.ToFileChanges(fileChangesResponse.FileChanges);
 
         // Get recent commits for context
-        var commits = await _integrationService!.GetGitHubCommitsAsync(
-            story.RepositoryUrl,
-            $"feature/{story.Id}",
-            DateTime.UtcNow.AddDays(-7));
+        var commitsResponse = await apiClient.GetCommitsAsync(
+            story.RepositoryUrl, $"feature/{story.Id}", DateTime.UtcNow.AddDays(-7), correlationId, tenantId, ct);
+        if (commitsResponse is null || !commitsResponse.Success)
+            throw new InvalidOperationException(
+                commitsResponse?.FailureReason ?? "git mediation endpoint unavailable");
+        var commits = GitMediationMapping.ToCommits(commitsResponse.Commits);
 
         // Build PR description
         var prBody = BuildPullRequestBody(story, junior, fileChanges, commits);
 
         // Create the pull request
-        var prResult = await _integrationService!.CreateGitHubPullRequestAsync(
+        var prResponse = await apiClient.CreatePullRequestAsync(
             story.RepositoryUrl,
-            new CreatePullRequestRequest
+            new GitCreatePrRequest
             {
                 Title = $"[{story.Id}] {story.Title}",
                 Body = prBody,
-                Head = $"feature/{story.Id}",
-                Base = "main",
-                Labels = new List<string> { "mentorship", "junior-developer" }
-            });
+                HeadRef = $"feature/{story.Id}",
+                BaseRef = "main",
+                Labels = new List<string> { "mentorship", "junior-developer" },
+                CorrelationId = correlationId,
+            }, tenantId, ct);
 
-        if (!prResult.Success)
+        if (prResponse is null || !prResponse.Success)
         {
             return new CodeReviewOutput
             {
                 Success = false,
                 Status = ReviewStatus.Error,
                 NextState = MentorshipState.DIAGNOSE_BLOCKER,
-                Message = $"Failed to create PR: {prResult.Error}"
+                Message = $"Failed to create PR: {prResponse?.FailureReason ?? "git mediation endpoint unavailable"}"
             };
         }
 
         // Notify junior about PR creation
         if (!string.IsNullOrEmpty(junior.SlackId))
         {
-            await NotifyPullRequestCreated(context, junior.SlackId, prResult, story.Title);
+            await NotifyPullRequestCreated(context, junior.SlackId, prResponse.PrNumber, prResponse.PrUrl, story.Title);
         }
 
         // Record analytics
@@ -206,14 +229,14 @@ public class CodeReviewActivity : CodeActivity<CodeReviewOutput>
 
         _logger?.LogInformation(
             "Created pull request #{PrNumber} for story {StoryId}",
-            prResult.Number, story.Id);
+            prResponse.PrNumber, story.Id);
 
         return new CodeReviewOutput
         {
             Success = true,
             Status = ReviewStatus.Pending,
-            PullRequestNumber = prResult.Number,
-            PullRequestUrl = prResult.Url,
+            PullRequestNumber = prResponse.PrNumber,
+            PullRequestUrl = prResponse.PrUrl,
             FileChanges = fileChanges.Select(f => new FileChangeInfo
             {
                 FilePath = f.FilePath,
@@ -223,7 +246,7 @@ public class CodeReviewActivity : CodeActivity<CodeReviewOutput>
             }).ToList(),
             CommitCount = commits.Count,
             NextState = MentorshipState.MONITOR_REVIEW,
-            Message = $"PR #{prResult.Number} created successfully"
+            Message = $"PR #{prResponse.PrNumber} created successfully"
         };
     }
 
@@ -519,15 +542,15 @@ Implementation of story **{story.Id}**: {story.Title}
     }
 
     private static async Task NotifyPullRequestCreated(
-        ActivityExecutionContext context, string slackId, GitHubPullRequestResult pr, string storyTitle)
+        ActivityExecutionContext context, string slackId, int? prNumber, string? prUrl, string storyTitle)
     {
         var message = $@"**Tamma: Pull Request Created**
 
 Your code is ready for review!
 
 *Story:* {storyTitle}
-*PR:* #{pr.Number}
-*Link:* {pr.Url}
+*PR:* #{prNumber}
+*Link:* {prUrl}
 
 A reviewer will look at your code soon. You'll be notified when there's feedback.";
 

--- a/apps/tamma-elsa/src/Tamma.Activities/Mentorship/DiagnoseBlockerActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Mentorship/DiagnoseBlockerActivity.cs
@@ -4,7 +4,9 @@ using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
+using Tamma.Activities.ADL;
 using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
 using Tamma.Core.Enums;
 using Tamma.Core.Interfaces;
 using Tamma.Data.Repositories;
@@ -25,7 +27,7 @@ public class DiagnoseBlockerActivity : CodeActivity<BlockerDiagnosisOutput>
 {
     private readonly ILogger<DiagnoseBlockerActivity>? _logger;
     private readonly IMentorshipSessionRepository? _repository;
-    private readonly IIntegrationService? _integrationService;
+    private readonly TammaApiClient? _apiClient;
     private readonly IAnalyticsService? _analyticsService;
 
     /// <summary>Mentorship session ID</summary>
@@ -44,18 +46,26 @@ public class DiagnoseBlockerActivity : CodeActivity<BlockerDiagnosisOutput>
     [Input(Description = "Additional context about the blocker")]
     public Input<string?> BlockerContext { get; set; } = default!;
 
+    [Input(Description = "Tenant id (GUID string) for BYOK token resolution; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
     [JsonConstructor]
     public DiagnoseBlockerActivity() { }
 
+    /// <summary>
+    /// Story 38 (Phase 2, Batch C) — thin-client DI constructor. No <c>IIntegrationService</c>
+    /// and no git/CI credential: the diagnostic git-commit / build-status / test-trigger reads
+    /// route through the git/CI mediation endpoints via <see cref="TammaApiClient"/>.
+    /// </summary>
     public DiagnoseBlockerActivity(
         ILogger<DiagnoseBlockerActivity> logger,
         IMentorshipSessionRepository repository,
-        IIntegrationService integrationService,
+        TammaApiClient apiClient,
         IAnalyticsService analyticsService)
     {
         _logger = logger;
         _repository = repository;
-        _integrationService = integrationService;
+        _apiClient = apiClient;
         _analyticsService = analyticsService;
     }
 
@@ -68,6 +78,10 @@ public class DiagnoseBlockerActivity : CodeActivity<BlockerDiagnosisOutput>
         var storyId = StoryId.Get(context);
         var juniorId = JuniorId.Get(context);
         var blockerContext = BlockerContext.Get(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var correlationId = context.WorkflowExecutionContext.Id;
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+        var ct = context.CancellationToken;
 
         _logger?.LogInformation(
             "Diagnosing blocker for junior {JuniorId} on story {StoryId}",
@@ -97,7 +111,7 @@ public class DiagnoseBlockerActivity : CodeActivity<BlockerDiagnosisOutput>
             }
 
             // Collect diagnostic data
-            var diagnosticData = await CollectDiagnosticData(story, junior, storyId, juniorId);
+            var diagnosticData = await CollectDiagnosticData(apiClient, story, junior, storyId, correlationId, tenantId, ct);
 
             // Analyze patterns from analytics
             var patterns = await _analyticsService!.DetectPatternsAsync(juniorId);
@@ -148,10 +162,13 @@ public class DiagnoseBlockerActivity : CodeActivity<BlockerDiagnosisOutput>
     }
 
     private async Task<DiagnosticData> CollectDiagnosticData(
+        TammaApiClient apiClient,
         Tamma.Core.Entities.Story story,
         Tamma.Core.Entities.JuniorDeveloper junior,
         string storyId,
-        string juniorId)
+        string correlationId,
+        string? tenantId,
+        CancellationToken ct)
     {
         var data = new DiagnosticData
         {
@@ -160,15 +177,22 @@ public class DiagnoseBlockerActivity : CodeActivity<BlockerDiagnosisOutput>
             TimeSinceLastActivity = TimeSpan.Zero
         };
 
-        // Collect GitHub activity if repository configured
+        // Collect GitHub activity if repository configured. All three reads are mediated
+        // via the git/CI endpoints; a null / failed mediation response throws and is caught
+        // locally (best-effort — a diagnostic read failure never fails the diagnosis), exactly
+        // as the composite's throwing calls were caught here before the cutover.
         if (!string.IsNullOrEmpty(story.RepositoryUrl))
         {
             try
             {
-                var commits = await _integrationService!.GetGitHubCommitsAsync(
-                    story.RepositoryUrl,
-                    $"feature/{storyId}",
-                    DateTime.UtcNow.AddHours(-24));
+                var branch = $"feature/{storyId}";
+
+                var commitsResponse = await apiClient.GetCommitsAsync(
+                    story.RepositoryUrl, branch, DateTime.UtcNow.AddHours(-24), correlationId, tenantId, ct);
+                if (commitsResponse is null || !commitsResponse.Success)
+                    throw new InvalidOperationException(
+                        commitsResponse?.FailureReason ?? "git mediation endpoint unavailable");
+                var commits = GitMediationMapping.ToCommits(commitsResponse.Commits);
 
                 data.RecentCommitCount = commits.Count;
                 data.LastCommitTime = commits.Any() ? commits.Max(c => c.Timestamp) : null;
@@ -178,16 +202,29 @@ public class DiagnoseBlockerActivity : CodeActivity<BlockerDiagnosisOutput>
                     data.TimeSinceLastActivity = DateTime.UtcNow - data.LastCommitTime.Value;
                 }
 
-                var buildStatus = await _integrationService.GetBuildStatusAsync(
-                    story.RepositoryUrl,
-                    $"feature/{storyId}");
+                var buildResponse = await apiClient.GetBuildStatusAsync(
+                    story.RepositoryUrl, branch, correlationId, tenantId, ct);
+                if (buildResponse is null || !buildResponse.Success)
+                    throw new InvalidOperationException(
+                        buildResponse?.FailureReason ?? "ci mediation endpoint unavailable");
+                var buildStatus = GitMediationMapping.ToBuildStatus(buildResponse.BuildStatus);
                 data.BuildStatus = buildStatus.Status;
+                // NB: the CI-mediation build-status DTO carries no Error field (Batch B note),
+                // so BuildError is now always null. The build-failure branch of AnalyzeBlocker
+                // (which required a non-empty BuildError) therefore no longer fires — a failing
+                // build now surfaces only via BuildStatus + the test/inactivity branches.
                 data.BuildError = buildStatus.Error;
 
-                var testResults = await _integrationService.TriggerTestsAsync(
-                    story.RepositoryUrl,
-                    $"feature/{storyId}");
+                var testsResponse = await apiClient.TriggerTestsAsync(
+                    story.RepositoryUrl, new CiTriggerTestsRequest { Branch = branch, CorrelationId = correlationId }, tenantId, ct);
+                if (testsResponse is null || !testsResponse.Success)
+                    throw new InvalidOperationException(
+                        testsResponse?.FailureReason ?? "ci mediation endpoint unavailable");
+                var testResults = GitMediationMapping.ToTestRun(testsResponse.TestRun);
                 data.FailingTestCount = testResults.FailedTests;
+                // NB: the CI-mediation test-run DTO carries aggregate counts only (no per-test
+                // detail), so FailingTests is now always empty — FailingTestCount still drives
+                // the testing-challenge branch.
                 data.FailingTests = testResults.FailedTestDetails
                     .Select(t => t.TestName)
                     .ToList();

--- a/apps/tamma-elsa/src/Tamma.Activities/Mentorship/DiagnoseBlockerActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Mentorship/DiagnoseBlockerActivity.cs
@@ -209,10 +209,12 @@ public class DiagnoseBlockerActivity : CodeActivity<BlockerDiagnosisOutput>
                         buildResponse?.FailureReason ?? "ci mediation endpoint unavailable");
                 var buildStatus = GitMediationMapping.ToBuildStatus(buildResponse.BuildStatus);
                 data.BuildStatus = buildStatus.Status;
-                // NB: the CI-mediation build-status DTO carries no Error field (Batch B note),
-                // so BuildError is now always null. The build-failure branch of AnalyzeBlocker
-                // (which required a non-empty BuildError) therefore no longer fires — a failing
-                // build now surfaces only via BuildStatus + the test/inactivity branches.
+                // NB: BuildError remains null here — the CI-mediation build-status DTO carries
+                // no Error field, but note the pre-cutover composite CI service was ALSO a stub
+                // that never populated BuildStatus.Error, so AnalyzeBlocker's build-failure branch
+                // (which requires a non-empty BuildError) was already inert on main — this is not
+                // a regression. Populating it would require the CI service to return a real error
+                // string first; do not restore the branch without that.
                 data.BuildError = buildStatus.Error;
 
                 var testsResponse = await apiClient.TriggerTestsAsync(
@@ -222,9 +224,10 @@ public class DiagnoseBlockerActivity : CodeActivity<BlockerDiagnosisOutput>
                         testsResponse?.FailureReason ?? "ci mediation endpoint unavailable");
                 var testResults = GitMediationMapping.ToTestRun(testsResponse.TestRun);
                 data.FailingTestCount = testResults.FailedTests;
-                // NB: the CI-mediation test-run DTO carries aggregate counts only (no per-test
-                // detail), so FailingTests is now always empty — FailingTestCount still drives
-                // the testing-challenge branch.
+                // NB: FailingTests is empty — the CI-mediation test-run DTO carries aggregate
+                // counts only. The pre-cutover composite CI service was ALSO a stub (TotalTests=0,
+                // no per-test detail), so this list was already always empty on main (not a
+                // regression). FailingTestCount still drives the testing-challenge branch.
                 data.FailingTests = testResults.FailedTestDetails
                     .Select(t => t.TestName)
                     .ToList();

--- a/apps/tamma-elsa/src/Tamma.Activities/Mentorship/MergeCompleteActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Mentorship/MergeCompleteActivity.cs
@@ -4,7 +4,9 @@ using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
+using Tamma.Activities.ADL;
 using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
 using Tamma.Core.Enums;
 using Tamma.Core.Interfaces;
 using Tamma.Data.Repositories;
@@ -25,7 +27,7 @@ public class MergeCompleteActivity : CodeActivity<MergeCompleteOutput>
 {
     private readonly ILogger<MergeCompleteActivity>? _logger;
     private readonly IMentorshipSessionRepository? _repository;
-    private readonly IIntegrationService? _integrationService;
+    private readonly TammaApiClient? _apiClient;
     private readonly IAnalyticsService? _analyticsService;
 
     /// <summary>Mentorship session ID</summary>
@@ -48,18 +50,26 @@ public class MergeCompleteActivity : CodeActivity<MergeCompleteOutput>
     [Input(Description = "Auto-merge the PR", DefaultValue = true)]
     public Input<bool> AutoMerge { get; set; } = new(true);
 
+    [Input(Description = "Tenant id (GUID string) for BYOK token resolution; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
     [JsonConstructor]
     public MergeCompleteActivity() { }
 
+    /// <summary>
+    /// Story 38 (Phase 2, Batch C) — thin-client DI constructor. No <c>IIntegrationService</c>
+    /// and no git/JIRA credential: the PR merge + JIRA update route through the git/JIRA
+    /// mediation endpoints via <see cref="TammaApiClient"/>.
+    /// </summary>
     public MergeCompleteActivity(
         ILogger<MergeCompleteActivity> logger,
         IMentorshipSessionRepository repository,
-        IIntegrationService integrationService,
+        TammaApiClient apiClient,
         IAnalyticsService analyticsService)
     {
         _logger = logger;
         _repository = repository;
-        _integrationService = integrationService;
+        _apiClient = apiClient;
         _analyticsService = analyticsService;
     }
 
@@ -73,6 +83,10 @@ public class MergeCompleteActivity : CodeActivity<MergeCompleteOutput>
         var juniorId = JuniorId.Get(context);
         var prNumber = PullRequestNumber.Get(context);
         var autoMerge = AutoMerge.Get(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var correlationId = context.WorkflowExecutionContext.Id;
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+        var ct = context.CancellationToken;
 
         _logger?.LogInformation(
             "Starting merge and completion for session {SessionId}, PR #{PrNumber}",
@@ -98,13 +112,18 @@ public class MergeCompleteActivity : CodeActivity<MergeCompleteOutput>
                 return;
             }
 
-            // Step 1: Merge the PR
+            // Step 1: Merge the PR (mediated; soft-fail — a merge failure does not fail the
+            // whole completion, the PR can be merged manually).
             GitHubMergeResult? mergeResult = null;
             if (autoMerge && !string.IsNullOrEmpty(story.RepositoryUrl))
             {
-                mergeResult = await _integrationService!.MergeGitHubPullRequestAsync(
-                    story.RepositoryUrl,
-                    prNumber);
+                mergeResult = GitMediationMapping.ToMergeResult(
+                    await apiClient.MergePullRequestAsync(
+                        story.RepositoryUrl,
+                        prNumber,
+                        new GitMergePrRequest { CorrelationId = correlationId },
+                        tenantId,
+                        ct));
 
                 if (!mergeResult.Success)
                 {
@@ -130,16 +149,19 @@ public class MergeCompleteActivity : CodeActivity<MergeCompleteOutput>
                     juniorId, skillUpdate.OldSkillLevel, skillUpdate.NewSkillLevel);
             }
 
-            // Step 5: Update JIRA ticket if configured
+            // Step 5: Update JIRA ticket if configured (mediated; fire-and-forget as before).
             if (!string.IsNullOrEmpty(story.JiraTicketId))
             {
-                await _integrationService!.UpdateJiraTicketAsync(
+                await apiClient.UpdateJiraTicketAsync(
                     story.JiraTicketId,
-                    new JiraTicketUpdate
+                    new JiraUpdateTicketRequest
                     {
                         Status = "Done",
-                        Comment = $"Completed through Tamma mentorship. PR #{prNumber} merged."
-                    });
+                        Comment = $"Completed through Tamma mentorship. PR #{prNumber} merged.",
+                        CorrelationId = correlationId,
+                    },
+                    tenantId,
+                    ct);
             }
 
             // Step 6: Update session as completed

--- a/apps/tamma-elsa/src/Tamma.Activities/Mentorship/MonitorImplementationActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Mentorship/MonitorImplementationActivity.cs
@@ -4,6 +4,9 @@ using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
+using Tamma.Activities.ADL;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
 using Tamma.Core.Enums;
 using Tamma.Core.Interfaces;
 using Tamma.Data.Repositories;
@@ -24,7 +27,7 @@ public class MonitorImplementationActivity : CodeActivity<ProgressOutput>
 {
     private readonly ILogger<MonitorImplementationActivity>? _logger;
     private readonly IMentorshipSessionRepository? _repository;
-    private readonly IIntegrationService? _integrationService;
+    private readonly TammaApiClient? _apiClient;
 
     /// <summary>Mentorship session ID</summary>
     [Input(Description = "Mentorship session ID")]
@@ -46,17 +49,26 @@ public class MonitorImplementationActivity : CodeActivity<ProgressOutput>
     [Input(Description = "Check interval in minutes", DefaultValue = 5)]
     public Input<int> CheckInterval { get; set; } = new(5);
 
+    [Input(Description = "Tenant id (GUID string) for BYOK token resolution; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
     [JsonConstructor]
     public MonitorImplementationActivity() { }
 
+    /// <summary>
+    /// Story 38 (Phase 2) — thin-client DI constructor. No <c>IIntegrationService</c>
+    /// and no git token: recent commits, file changes, build status, and the CI test
+    /// summary are read through the git/CI mediation endpoints via
+    /// <see cref="TammaApiClient"/>, where the per-tenant token lives.
+    /// </summary>
     public MonitorImplementationActivity(
         ILogger<MonitorImplementationActivity> logger,
         IMentorshipSessionRepository repository,
-        IIntegrationService integrationService)
+        TammaApiClient apiClient)
     {
         _logger = logger;
         _repository = repository;
-        _integrationService = integrationService;
+        _apiClient = apiClient;
     }
 
     /// <summary>
@@ -69,6 +81,10 @@ public class MonitorImplementationActivity : CodeActivity<ProgressOutput>
         var juniorId = JuniorId.Get(context);
         var monitoringDuration = MonitoringDuration.Get(context);
         var checkInterval = CheckInterval.Get(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var correlationId = context.WorkflowExecutionContext.Id;
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+        var ct = context.CancellationToken;
 
         _logger?.LogInformation(
             "Starting implementation monitoring for junior {JuniorId} on story {StoryId}",
@@ -94,7 +110,7 @@ public class MonitorImplementationActivity : CodeActivity<ProgressOutput>
             }
 
             // Collect progress data from integrations
-            var progressData = await CollectProgressData(story.RepositoryUrl, juniorId, storyId);
+            var progressData = await CollectProgressData(apiClient, story.RepositoryUrl, juniorId, storyId, correlationId, tenantId, ct);
 
             // Analyze progress
             var analysis = AnalyzeProgress(progressData);
@@ -127,7 +143,9 @@ public class MonitorImplementationActivity : CodeActivity<ProgressOutput>
         }
     }
 
-    private async Task<ImplementationProgress> CollectProgressData(string? repositoryUrl, string juniorId, string storyId)
+    private async Task<ImplementationProgress> CollectProgressData(
+        TammaApiClient apiClient, string? repositoryUrl, string juniorId, string storyId,
+        string correlationId, string? tenantId, CancellationToken ct)
     {
         var progress = new ImplementationProgress
         {
@@ -140,11 +158,15 @@ public class MonitorImplementationActivity : CodeActivity<ProgressOutput>
         {
             try
             {
+                var branch = $"feature/{storyId}";
+
                 // Get recent commits
-                var commits = await _integrationService!.GetGitHubCommitsAsync(
-                    repositoryUrl,
-                    $"feature/{storyId}",
-                    DateTime.UtcNow.AddHours(-1));
+                var commitsResponse = await apiClient.GetCommitsAsync(
+                    repositoryUrl, branch, DateTime.UtcNow.AddHours(-1), correlationId, tenantId, ct);
+                if (commitsResponse is null || !commitsResponse.Success)
+                    throw new InvalidOperationException(
+                        commitsResponse?.FailureReason ?? "git mediation endpoint unavailable");
+                var commits = GitMediationMapping.ToCommits(commitsResponse.Commits);
 
                 progress.Commits = commits;
                 progress.LastActivity = commits.Any()
@@ -152,22 +174,30 @@ public class MonitorImplementationActivity : CodeActivity<ProgressOutput>
                     : DateTime.UtcNow.AddHours(-2); // Assume stale if no commits
 
                 // Get file changes
-                var fileChanges = await _integrationService.GetGitHubFileChangesAsync(
-                    repositoryUrl,
-                    $"feature/{storyId}");
-                progress.FileChanges = fileChanges;
+                var fileChangesResponse = await apiClient.GetFileChangesAsync(
+                    repositoryUrl, branch, correlationId, tenantId, ct);
+                if (fileChangesResponse is null || !fileChangesResponse.Success)
+                    throw new InvalidOperationException(
+                        fileChangesResponse?.FailureReason ?? "git mediation endpoint unavailable");
+                progress.FileChanges = GitMediationMapping.ToFileChanges(fileChangesResponse.FileChanges);
 
                 // Get build status
-                var buildStatus = await _integrationService.GetBuildStatusAsync(
-                    repositoryUrl,
-                    $"feature/{storyId}");
-                progress.BuildStatus = buildStatus.Status;
+                var buildResponse = await apiClient.GetBuildStatusAsync(
+                    repositoryUrl, branch, correlationId, tenantId, ct);
+                if (buildResponse is null || !buildResponse.Success)
+                    throw new InvalidOperationException(
+                        buildResponse?.FailureReason ?? "ci mediation endpoint unavailable");
+                progress.BuildStatus = GitMediationMapping.ToBuildStatus(buildResponse.BuildStatus).Status;
 
                 // Get test results
-                var testResults = await _integrationService.TriggerTestsAsync(
+                var testResponse = await apiClient.TriggerTestsAsync(
                     repositoryUrl,
-                    $"feature/{storyId}");
-                progress.TestResults = testResults;
+                    new CiTriggerTestsRequest { Branch = branch, CorrelationId = correlationId },
+                    tenantId, ct);
+                if (testResponse is null || !testResponse.Success)
+                    throw new InvalidOperationException(
+                        testResponse?.FailureReason ?? "ci mediation endpoint unavailable");
+                progress.TestResults = GitMediationMapping.ToTestRun(testResponse.TestRun);
             }
             catch (Exception ex)
             {

--- a/apps/tamma-elsa/src/Tamma.Activities/Mentorship/QualityGateCheckActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Mentorship/QualityGateCheckActivity.cs
@@ -4,6 +4,9 @@ using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
+using Tamma.Activities.ADL;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
 using Tamma.Core.Enums;
 using Tamma.Core.Interfaces;
 using Tamma.Data.Repositories;
@@ -24,7 +27,7 @@ public class QualityGateCheckActivity : CodeActivity<QualityGateOutput>
 {
     private readonly ILogger<QualityGateCheckActivity>? _logger;
     private readonly IMentorshipSessionRepository? _repository;
-    private readonly IIntegrationService? _integrationService;
+    private readonly TammaApiClient? _apiClient;
 
     /// <summary>Mentorship session ID</summary>
     [Input(Description = "Mentorship session ID")]
@@ -42,17 +45,27 @@ public class QualityGateCheckActivity : CodeActivity<QualityGateOutput>
     [Input(Description = "Allow warnings to pass", DefaultValue = true)]
     public Input<bool> AllowWarnings { get; set; } = new(true);
 
+    [Input(Description = "Tenant id (GUID string) for BYOK token resolution; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
     [JsonConstructor]
     public QualityGateCheckActivity() { }
 
+    /// <summary>
+    /// Story 38 (Phase 2) — thin-client DI constructor. No <c>IIntegrationService</c>
+    /// and no git token: the test / coverage / build gates read through the CI mediation
+    /// endpoints (<c>POST .../test-runs</c> and <c>GET .../build-status</c>) via
+    /// <see cref="TammaApiClient"/>. A mediation failure still falls back to the
+    /// simulated gate exactly as the composite-throws path did.
+    /// </summary>
     public QualityGateCheckActivity(
         ILogger<QualityGateCheckActivity> logger,
         IMentorshipSessionRepository repository,
-        IIntegrationService integrationService)
+        TammaApiClient apiClient)
     {
         _logger = logger;
         _repository = repository;
-        _integrationService = integrationService;
+        _apiClient = apiClient;
     }
 
     /// <summary>
@@ -64,6 +77,10 @@ public class QualityGateCheckActivity : CodeActivity<QualityGateOutput>
         var storyId = StoryId.Get(context);
         var minCoverage = MinCoverage.Get(context);
         var allowWarnings = AllowWarnings.Get(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var correlationId = context.WorkflowExecutionContext.Id;
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+        var ct = context.CancellationToken;
 
         _logger?.LogInformation(
             "Running quality gate checks for story {StoryId}",
@@ -95,15 +112,15 @@ public class QualityGateCheckActivity : CodeActivity<QualityGateOutput>
             if (!string.IsNullOrEmpty(story.RepositoryUrl))
             {
                 // 1. Unit Tests
-                var testResult = await RunTestGate(story.RepositoryUrl, storyId);
+                var testResult = await RunTestGate(apiClient, story.RepositoryUrl, storyId, correlationId, tenantId, ct);
                 results.Add(testResult);
 
                 // 2. Code Coverage
-                var coverageResult = await RunCoverageGate(story.RepositoryUrl, storyId, minCoverage);
+                var coverageResult = await RunCoverageGate(apiClient, story.RepositoryUrl, storyId, minCoverage, correlationId, tenantId, ct);
                 results.Add(coverageResult);
 
                 // 3. Build Compilation
-                var buildResult = await RunBuildGate(story.RepositoryUrl, storyId);
+                var buildResult = await RunBuildGate(apiClient, story.RepositoryUrl, storyId, correlationId, tenantId, ct);
                 results.Add(buildResult);
 
                 // 4. Linting (simulated)
@@ -152,11 +169,20 @@ public class QualityGateCheckActivity : CodeActivity<QualityGateOutput>
         }
     }
 
-    private async Task<GateResult> RunTestGate(string repositoryUrl, string storyId)
+    private async Task<GateResult> RunTestGate(
+        TammaApiClient apiClient, string repositoryUrl, string storyId,
+        string correlationId, string? tenantId, CancellationToken ct)
     {
         try
         {
-            var testResults = await _integrationService!.TriggerTestsAsync(repositoryUrl, $"feature/{storyId}");
+            var testResponse = await apiClient.TriggerTestsAsync(
+                repositoryUrl,
+                new CiTriggerTestsRequest { Branch = $"feature/{storyId}", CorrelationId = correlationId },
+                tenantId, ct);
+            if (testResponse is null || !testResponse.Success)
+                throw new InvalidOperationException(
+                    testResponse?.FailureReason ?? "ci mediation endpoint unavailable");
+            var testResults = GitMediationMapping.ToTestRun(testResponse.TestRun);
 
             return new GateResult
             {
@@ -181,11 +207,20 @@ public class QualityGateCheckActivity : CodeActivity<QualityGateOutput>
         }
     }
 
-    private async Task<GateResult> RunCoverageGate(string repositoryUrl, string storyId, int minCoverage)
+    private async Task<GateResult> RunCoverageGate(
+        TammaApiClient apiClient, string repositoryUrl, string storyId, int minCoverage,
+        string correlationId, string? tenantId, CancellationToken ct)
     {
         try
         {
-            var testResults = await _integrationService!.TriggerTestsAsync(repositoryUrl, $"feature/{storyId}");
+            var testResponse = await apiClient.TriggerTestsAsync(
+                repositoryUrl,
+                new CiTriggerTestsRequest { Branch = $"feature/{storyId}", CorrelationId = correlationId },
+                tenantId, ct);
+            if (testResponse is null || !testResponse.Success)
+                throw new InvalidOperationException(
+                    testResponse?.FailureReason ?? "ci mediation endpoint unavailable");
+            var testResults = GitMediationMapping.ToTestRun(testResponse.TestRun);
             var coverage = testResults.CoveragePercentage ?? 0;
 
             return new GateResult
@@ -213,11 +248,18 @@ public class QualityGateCheckActivity : CodeActivity<QualityGateOutput>
         }
     }
 
-    private async Task<GateResult> RunBuildGate(string repositoryUrl, string storyId)
+    private async Task<GateResult> RunBuildGate(
+        TammaApiClient apiClient, string repositoryUrl, string storyId,
+        string correlationId, string? tenantId, CancellationToken ct)
     {
         try
         {
-            var buildStatus = await _integrationService!.GetBuildStatusAsync(repositoryUrl, $"feature/{storyId}");
+            var buildResponse = await apiClient.GetBuildStatusAsync(
+                repositoryUrl, $"feature/{storyId}", correlationId, tenantId, ct);
+            if (buildResponse is null || !buildResponse.Success)
+                throw new InvalidOperationException(
+                    buildResponse?.FailureReason ?? "ci mediation endpoint unavailable");
+            var buildStatus = GitMediationMapping.ToBuildStatus(buildResponse.BuildStatus);
 
             return new GateResult
             {

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/CreatePRActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/CreatePRActivity.cs
@@ -4,6 +4,9 @@ using Elsa.Workflows;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
+using Tamma.Activities.ADL;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
 using Tamma.Activities.Review.Models;
 using Tamma.Core.Entities;
 using Tamma.Core.Enums;
@@ -27,7 +30,7 @@ public class CreatePRActivity : CodeActivity<PRCreationResult>
 {
     private readonly ILogger<CreatePRActivity>? _logger;
     private readonly IMentorshipSessionRepository? _repository;
-    private readonly IIntegrationService? _integrationService;
+    private readonly TammaApiClient? _apiClient;
 
     /// <summary>Mentorship session ID</summary>
     [Input(Description = "Mentorship session ID")]
@@ -49,17 +52,26 @@ public class CreatePRActivity : CodeActivity<PRCreationResult>
     [Input(Description = "Head branch containing the changes (default: feature/{storyId})")]
     public Input<string?> HeadBranch { get; set; } = default!;
 
+    [Input(Description = "Tenant id (GUID string) for BYOK token resolution; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
     [JsonConstructor]
     public CreatePRActivity() { }
 
+    /// <summary>
+    /// Story 38 (Phase 2) — thin-client DI constructor. No <c>IIntegrationService</c>
+    /// and no git token: file changes + commits are read and the PR is created through
+    /// the git-mediation endpoints via <see cref="TammaApiClient"/>. The PR body is
+    /// composed engine-side (pure, token-free).
+    /// </summary>
     public CreatePRActivity(
         ILogger<CreatePRActivity> logger,
         IMentorshipSessionRepository repository,
-        IIntegrationService integrationService)
+        TammaApiClient apiClient)
     {
         _logger = logger;
         _repository = repository;
-        _integrationService = integrationService;
+        _apiClient = apiClient;
     }
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
@@ -69,6 +81,10 @@ public class CreatePRActivity : CodeActivity<PRCreationResult>
         var juniorId = JuniorId.Get(context);
         var baseBranch = BaseBranch.Get(context);
         var headBranch = HeadBranch.Get(context) ?? $"feature/{storyId}";
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var correlationId = context.WorkflowExecutionContext.Id;
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+        var ct = context.CancellationToken;
 
         _logger?.LogInformation(
             "Creating PR for session {SessionId}, story {StoryId}, branch {HeadBranch}",
@@ -100,32 +116,43 @@ public class CreatePRActivity : CodeActivity<PRCreationResult>
             }
 
             // Gather file changes and commits for the PR body
-            var fileChanges = await _integrationService!.GetGitHubFileChangesAsync(
-                story.RepositoryUrl, headBranch);
-            var commits = await _integrationService.GetGitHubCommitsAsync(
-                story.RepositoryUrl, headBranch, DateTime.UtcNow.AddDays(-14));
+            var fileChangesResponse = await apiClient.GetFileChangesAsync(
+                story.RepositoryUrl, headBranch, correlationId, tenantId, ct);
+            if (fileChangesResponse is null || !fileChangesResponse.Success)
+                throw new InvalidOperationException(
+                    fileChangesResponse?.FailureReason ?? "git mediation endpoint unavailable");
+            var fileChanges = GitMediationMapping.ToFileChanges(fileChangesResponse.FileChanges);
+
+            var commitsResponse = await apiClient.GetCommitsAsync(
+                story.RepositoryUrl, headBranch, DateTime.UtcNow.AddDays(-14), correlationId, tenantId, ct);
+            if (commitsResponse is null || !commitsResponse.Success)
+                throw new InvalidOperationException(
+                    commitsResponse?.FailureReason ?? "git mediation endpoint unavailable");
+            var commits = GitMediationMapping.ToCommits(commitsResponse.Commits);
 
             var prBody = BuildPRBody(story, junior, fileChanges, commits);
 
             // Create the pull request
-            var prResult = await _integrationService.CreateGitHubPullRequestAsync(
+            var prResponse = await apiClient.CreatePullRequestAsync(
                 story.RepositoryUrl,
-                new CreatePullRequestRequest
+                new GitCreatePrRequest
                 {
                     Title = $"[{story.Id}] {story.Title}",
                     Body = prBody,
-                    Head = headBranch,
-                    Base = baseBranch,
-                    Labels = new List<string> { "mentorship", "code-review" }
-                });
+                    HeadRef = headBranch,
+                    BaseRef = baseBranch,
+                    Labels = new List<string> { "mentorship", "code-review" },
+                    CorrelationId = correlationId,
+                }, tenantId, ct);
 
-            if (!prResult.Success)
+            if (prResponse is null || !prResponse.Success)
             {
-                _logger?.LogWarning("Failed to create PR: {Error}", prResult.Error);
+                var error = prResponse?.FailureReason ?? "git mediation endpoint unavailable";
+                _logger?.LogWarning("Failed to create PR: {Error}", error);
                 context.SetResult(new PRCreationResult
                 {
                     Success = false,
-                    Error = $"Failed to create PR: {prResult.Error}"
+                    Error = $"Failed to create PR: {error}"
                 });
                 return;
             }
@@ -141,13 +168,13 @@ public class CreatePRActivity : CodeActivity<PRCreationResult>
 
             _logger?.LogInformation(
                 "Created PR #{PRNumber} for session {SessionId}",
-                prResult.Number, sessionId);
+                prResponse.PrNumber, sessionId);
 
             context.SetResult(new PRCreationResult
             {
                 Success = true,
-                PRNumber = prResult.Number,
-                PRUrl = prResult.Url,
+                PRNumber = prResponse.PrNumber,
+                PRUrl = prResponse.PrUrl,
                 HeadBranch = headBranch,
                 BaseBranch = baseBranch
             });

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/MergeAndCompleteReviewActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/MergeAndCompleteReviewActivity.cs
@@ -5,7 +5,9 @@ using Elsa.Workflows.Activities.Flowchart.Attributes;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
+using Tamma.Activities.ADL;
 using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
 using Tamma.Activities.Review.Models;
 using Tamma.Core.Entities;
 using Tamma.Core.Enums;
@@ -22,9 +24,9 @@ namespace Tamma.Activities.Review;
 ///     head-branch build status; a non-success status routes to the <c>Failed</c> outcome
 ///     (the workflow escalates) instead of merging on red.
 ///   - <b>Honour the merge strategy</b>: the configured <see cref="MergeStrategy"/> is mapped
-///     to GitHub's <c>merge_method</c> via the strategy-aware
-///     <see cref="IIntegrationService.MergeGitHubPullRequestAsync(string,int,string)"/>
-///     overload (the prior single-arg call let the service pick squash unconditionally).
+///     to GitHub's <c>merge_method</c> via the git-mediation merge endpoint's
+///     <c>mergeStrategy</c> field (the prior single-arg call let the service pick squash
+///     unconditionally).
 ///   - <b>Retry merge once then escalate</b>: a transient merge failure (e.g. a momentary
 ///     conflict/CI flake) is retried exactly once; a second failure routes to <c>Failed</c>
 ///     so the workflow escalates to a senior — never a silent false success.
@@ -46,7 +48,7 @@ public class MergeAndCompleteReviewActivity : Activity
 {
     private readonly ILogger<MergeAndCompleteReviewActivity>? _logger;
     private readonly IMentorshipSessionRepository? _repository;
-    private readonly IIntegrationService? _integrationService;
+    private readonly TammaApiClient? _apiClient;
     private readonly IAnalyticsService? _analyticsService;
 
     /// <summary>Mentorship session ID</summary>
@@ -89,18 +91,27 @@ public class MergeAndCompleteReviewActivity : Activity
     [Output(Description = "Merge result")]
     public Output<ReviewMergeResult?> Result { get; set; } = default!;
 
+    [Input(Description = "Tenant id (GUID string) for BYOK token resolution; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
     [JsonConstructor]
     public MergeAndCompleteReviewActivity() { }
 
+    /// <summary>
+    /// Story 38 (Phase 2, Batch C) — thin-client DI constructor. No <c>IIntegrationService</c>
+    /// and no git credential: the CI gate (build status), the strategy-aware merge (+ retry),
+    /// and the source-branch delete all route through the git/CI mediation endpoints via
+    /// <see cref="TammaApiClient"/>.
+    /// </summary>
     public MergeAndCompleteReviewActivity(
         ILogger<MergeAndCompleteReviewActivity> logger,
         IMentorshipSessionRepository repository,
-        IIntegrationService integrationService,
+        TammaApiClient apiClient,
         IAnalyticsService analyticsService)
     {
         _logger = logger;
         _repository = repository;
-        _integrationService = integrationService;
+        _apiClient = apiClient;
         _analyticsService = analyticsService;
     }
 
@@ -114,6 +125,10 @@ public class MergeAndCompleteReviewActivity : Activity
         var totalIterations = TotalIterations.Get(context);
         var verifyCi = VerifyCIBeforeMerge.Get(context);
         var deleteBranch = DeleteBranchAfterMerge.Get(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var correlationId = context.WorkflowExecutionContext.Id;
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+        var ct = context.CancellationToken;
 
         _logger?.LogInformation(
             "Merging PR #{PRNumber} with strategy {Strategy} for session {SessionId} (verifyCi={VerifyCi})",
@@ -137,7 +152,7 @@ public class MergeAndCompleteReviewActivity : Activity
             // 1) CI gate — verify the head branch's build is green before merging.
             if (verifyCi)
             {
-                var ciOk = await IsCiGreenAsync(story.RepositoryUrl, headBranch);
+                var ciOk = await IsCiGreenAsync(apiClient, story.RepositoryUrl, headBranch, correlationId, tenantId, ct);
                 if (!ciOk)
                 {
                     _logger?.LogWarning(
@@ -151,8 +166,11 @@ public class MergeAndCompleteReviewActivity : Activity
 
             // 2) Strategy-aware merge with a single retry on failure.
             var mergeStrategyWire = strategy.ToString().ToLowerInvariant(); // squash | merge | rebase
-            var mergeResult = await _integrationService!.MergeGitHubPullRequestAsync(
-                story.RepositoryUrl, prNumber, mergeStrategyWire);
+            var mergeResult = GitMediationMapping.ToMergeResult(
+                await apiClient.MergePullRequestAsync(
+                    story.RepositoryUrl, prNumber,
+                    new GitMergePrRequest { MergeStrategy = mergeStrategyWire, CorrelationId = correlationId },
+                    tenantId, ct));
 
             if (!mergeResult.Success)
             {
@@ -160,8 +178,11 @@ public class MergeAndCompleteReviewActivity : Activity
                     "Merge failed for PR #{PRNumber}: {Error}. Retrying once.",
                     prNumber, mergeResult.Error);
 
-                mergeResult = await _integrationService.MergeGitHubPullRequestAsync(
-                    story.RepositoryUrl, prNumber, mergeStrategyWire);
+                mergeResult = GitMediationMapping.ToMergeResult(
+                    await apiClient.MergePullRequestAsync(
+                        story.RepositoryUrl, prNumber,
+                        new GitMergePrRequest { MergeStrategy = mergeStrategyWire, CorrelationId = correlationId },
+                        tenantId, ct));
 
                 if (!mergeResult.Success)
                 {
@@ -174,15 +195,27 @@ public class MergeAndCompleteReviewActivity : Activity
                 }
             }
 
-            // 3) Delete the source branch (best-effort — never fails the merge).
+            // 3) Delete the source branch (best-effort — never fails the merge). Mediated:
+            // a null / failed delete response is logged and swallowed, exactly as the composite's
+            // throwing delete was caught here before the cutover.
             if (deleteBranch)
             {
                 try
                 {
-                    await _integrationService.DeleteGitHubBranchAsync(story.RepositoryUrl, headBranch);
-                    _logger?.LogInformation(
-                        "Deleted source branch {Branch} after merging PR #{PRNumber}",
-                        headBranch, prNumber);
+                    var deleteResponse = await apiClient.DeleteBranchAsync(
+                        story.RepositoryUrl, headBranch, correlationId, tenantId, ct);
+                    if (deleteResponse is null || !deleteResponse.Success)
+                    {
+                        _logger?.LogWarning(
+                            "Failed to delete source branch {Branch} after merge (merge still succeeded): {Reason}",
+                            headBranch, deleteResponse?.FailureReason ?? "git mediation endpoint unavailable");
+                    }
+                    else
+                    {
+                        _logger?.LogInformation(
+                            "Deleted source branch {Branch} after merging PR #{PRNumber}",
+                            headBranch, prNumber);
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -257,12 +290,23 @@ public class MergeAndCompleteReviewActivity : Activity
     /// Anything else (failure, pending, error, or an exception talking to CI) is treated
     /// as NOT-green — fail-closed: a PR never merges on an unknown CI state.
     /// </summary>
-    private async Task<bool> IsCiGreenAsync(string repository, string branch)
+    private async Task<bool> IsCiGreenAsync(
+        TammaApiClient apiClient, string repository, string branch,
+        string correlationId, string? tenantId, CancellationToken ct)
     {
         try
         {
-            var status = await _integrationService!.GetBuildStatusAsync(repository, branch);
-            var s = status?.Status?.Trim().ToLowerInvariant();
+            var response = await apiClient.GetBuildStatusAsync(repository, branch, correlationId, tenantId, ct);
+            // Fail-closed: a null / failed mediation response is an unknown CI state → not-green.
+            if (response is null || !response.Success)
+            {
+                _logger?.LogWarning(
+                    "CI status unavailable for branch {Branch} ({Reason}); treating as not-green",
+                    branch, response?.FailureReason ?? "ci mediation endpoint unavailable");
+                return false;
+            }
+            var status = GitMediationMapping.ToBuildStatus(response.BuildStatus);
+            var s = status.Status?.Trim().ToLowerInvariant();
             return s is "success" or "passed" or "passing" or "completed" or "green";
         }
         catch (Exception ex)

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/CiEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/CiEndpoints.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Http;
+using Tamma.Api.Services.Ci;
+using Tamma.Data;
+
+namespace Tamma.Api.Endpoints;
+
+/// <summary>
+/// Story 38 (Phase 1) — the internal, engine-only CI-mediation endpoints
+/// (<c>/api/v1/ci/{owner}/{repo}/...</c>). They mirror the Story 38-1 git plane
+/// exactly: <c>EngineServiceOnly</c> auth (a missing/invalid bearer ⇒ 401; a user JWT
+/// ⇒ 403), the acting tenant is the auth-derived <see cref="ITenantContext"/>
+/// (X-Tenant-Id, NEVER the body), and delegation to <see cref="ICiMediationService"/>
+/// (guard → per-tenant token → CI call with the resolved token → one DCB event) with
+/// the typed key-free result projected via <c>ToHttpResult()</c> (200 / 200
+/// success:false + preserved platformStatusCode / 403 REPO_NOT_AUTHORIZED / 503
+/// CI_TOKEN_UNAVAILABLE — never a raw 5xx).
+///
+/// <para><c>{owner}/{repo}</c> is bound as two route segments (an <c>owner/name</c>
+/// full name carries a slash).</para>
+/// </summary>
+public static class CiEndpoints
+{
+    public static async Task<IResult> TriggerTests(
+        string owner, string repo, TriggerTestsRequest body,
+        ITenantContext tenantContext, ICiMediationService ci, CancellationToken ct)
+    {
+        var result = await ci.TriggerTestsAsync(tenantContext.TenantId, Repo(owner, repo), body, ct).ConfigureAwait(false);
+        return result.ToHttpResult();
+    }
+
+    public static async Task<IResult> GetBuildStatus(
+        string owner, string repo, string? branch, string? correlationId,
+        ITenantContext tenantContext, ICiMediationService ci, CancellationToken ct)
+    {
+        var result = await ci.GetBuildStatusAsync(
+            tenantContext.TenantId, Repo(owner, repo), branch ?? string.Empty, correlationId ?? string.Empty, ct).ConfigureAwait(false);
+        return result.ToHttpResult();
+    }
+
+    private static string Repo(string owner, string repo) => $"{owner}/{repo}";
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/EmailEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/EmailEndpoints.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Http;
+using Tamma.Api.Services.EmailMediation;
+using Tamma.Data;
+
+namespace Tamma.Api.Endpoints;
+
+/// <summary>
+/// Story 38 (Phase 1) — the internal, engine-only email-mediation endpoint
+/// (<c>POST /api/v1/notifications/email</c>). Same engine-only plane as
+/// <c>/api/v1/llm/call</c> / <c>/api/v1/notifications/slack</c>:
+/// <c>EngineServiceOnly</c> auth (missing/invalid bearer ⇒ 401; user JWT ⇒ 403), the
+/// acting tenant is the auth-derived <see cref="ITenantContext"/> (X-Tenant-Id, NEVER
+/// the body). Email is not repo-scoped, so there is no tenant↔repo guard. Delegates
+/// to <see cref="IEmailMediationService"/>, which accepts the message into the
+/// credentialed, outbox-backed <c>IEmailService</c>; the SMTP/Resend credential
+/// never reaches the engine.
+/// </summary>
+public static class EmailEndpoints
+{
+    public static async Task<IResult> SendEmail(
+        SendEmailRequest body,
+        ITenantContext tenantContext, IEmailMediationService email, CancellationToken ct)
+    {
+        var result = await email.SendEmailAsync(tenantContext.TenantId, body, ct).ConfigureAwait(false);
+        return result.ToHttpResult();
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/GitEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/GitEndpoints.cs
@@ -70,5 +70,34 @@ public static class GitEndpoints
         return result.ToHttpResult();
     }
 
+    public static async Task<IResult> GetCommits(
+        string owner, string repo, string? branch, DateTime? since, string? correlationId,
+        ITenantContext tenantContext, IGitMediationService git, CancellationToken ct)
+    {
+        var result = await git.GetCommitsAsync(
+            tenantContext.TenantId, Repo(owner, repo), branch ?? string.Empty, since, correlationId ?? string.Empty, ct).ConfigureAwait(false);
+        return result.ToHttpResult();
+    }
+
+    public static async Task<IResult> GetFileChanges(
+        string owner, string repo, string? branch, string? correlationId,
+        ITenantContext tenantContext, IGitMediationService git, CancellationToken ct)
+    {
+        var result = await git.GetFileChangesAsync(
+            tenantContext.TenantId, Repo(owner, repo), branch ?? string.Empty, correlationId ?? string.Empty, ct).ConfigureAwait(false);
+        return result.ToHttpResult();
+    }
+
+    public static async Task<IResult> DeleteBranch(
+        string owner, string repo, string? branch, string? correlationId,
+        ITenantContext tenantContext, IGitMediationService git, CancellationToken ct)
+    {
+        // The branch name (which may contain slashes, e.g. feature/foo) travels as a
+        // query param so it is captured whole; the route owns only {owner}/{repo}.
+        var result = await git.DeleteBranchAsync(
+            tenantContext.TenantId, Repo(owner, repo), branch ?? string.Empty, correlationId ?? string.Empty, ct).ConfigureAwait(false);
+        return result.ToHttpResult();
+    }
+
     private static string Repo(string owner, string repo) => $"{owner}/{repo}";
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/JiraEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/JiraEndpoints.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Http;
+using Tamma.Api.Services.Jira;
+using Tamma.Data;
+
+namespace Tamma.Api.Endpoints;
+
+/// <summary>
+/// Story 38 (Phase 1) — the internal, engine-only JIRA-mediation endpoints
+/// (<c>/api/v1/jira/tickets/...</c>). Same engine-only plane as <c>/api/v1/llm/call</c>
+/// / <c>/api/v1/git/...</c>: <c>EngineServiceOnly</c> auth (missing/invalid bearer ⇒
+/// 401; user JWT ⇒ 403), the acting tenant is the auth-derived
+/// <see cref="ITenantContext"/> (X-Tenant-Id, NEVER the body). JIRA is not
+/// repo-scoped, so there is no tenant↔repo guard — the tenant scopes the audit event
+/// only. Delegates to <see cref="IJiraMediationService"/> and projects the typed
+/// key-free result (every non-success rides inside 200 success:false — never a raw
+/// 5xx).
+/// </summary>
+public static class JiraEndpoints
+{
+    public static async Task<IResult> GetTicket(
+        string ticketId, string? correlationId,
+        ITenantContext tenantContext, IJiraMediationService jira, CancellationToken ct)
+    {
+        var result = await jira.GetTicketAsync(tenantContext.TenantId, ticketId, correlationId ?? string.Empty, ct).ConfigureAwait(false);
+        return result.ToHttpResult();
+    }
+
+    public static async Task<IResult> UpdateTicket(
+        string ticketId, UpdateTicketRequest body,
+        ITenantContext tenantContext, IJiraMediationService jira, CancellationToken ct)
+    {
+        var result = await jira.UpdateTicketAsync(tenantContext.TenantId, ticketId, body, ct).ConfigureAwait(false);
+        return result.ToHttpResult();
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -561,6 +561,22 @@ builder.Services.AddSingleton<Tamma.Api.Services.Git.IGitHubClientFactory,
 builder.Services.AddScoped<Tamma.Api.Services.Git.IGitMediationService,
     Tamma.Api.Services.Git.GitMediationService>();
 
+// ── Story 38 (Phase 1) — CI / JIRA / email step mediation ──
+// CI (GitHub Actions) reuses the git guard + token resolver (CI runs on the same
+// per-tenant git token); the CiClientFactory mints a token-bound CIIntegrationService
+// per request. JIRA + email are NOT repo-scoped (like Slack): they run the existing
+// config-credentialed IJiraIntegrationService / outbox-backed IEmailService under the
+// caller's tenant context. In every case the credential stays in Tamma.Api; the
+// engine holds nothing.
+builder.Services.AddSingleton<Tamma.Api.Services.Ci.ICiClientFactory,
+    Tamma.Api.Services.Ci.CiClientFactory>();
+builder.Services.AddScoped<Tamma.Api.Services.Ci.ICiMediationService,
+    Tamma.Api.Services.Ci.CiMediationService>();
+builder.Services.AddScoped<Tamma.Api.Services.Jira.IJiraMediationService,
+    Tamma.Api.Services.Jira.JiraMediationService>();
+builder.Services.AddScoped<Tamma.Api.Services.EmailMediation.IEmailMediationService,
+    Tamma.Api.Services.EmailMediation.EmailMediationService>();
+
 // Story 32-5 (T4) — provider-side DI for the server-side tool loop, FORMALIZED
 // in the API process (replacing T3's best-effort GetService factory). The loop
 // (extracted verbatim into InlineToolLoopRunner) now executes HERE, where the
@@ -2359,6 +2375,40 @@ app.MapPatch("/api/v1/git/{owner}/{repo}/issues/{n:int}", GitEndpoints.UpdateIss
     .RequireAuthorization("EngineServiceOnly")
     .WithName("GitUpdateIssue");
 
+// ── Story 38 (Phase 1) — GitHub "extra ops" (commits + file-changes reads,
+// standalone branch delete) the engine's context/debug/integration activities call
+// on the composite today. Same engine-only plane + guard→token→platform→one-event
+// mediation as the git-platform ops above. The branch name (may carry a slash)
+// travels as a query param so the route owns only {owner}/{repo}.
+app.MapGet("/api/v1/git/{owner}/{repo}/commits", GitEndpoints.GetCommits)
+    .RequireAuthorization("EngineServiceOnly")
+    .WithName("GitGetCommits");
+app.MapGet("/api/v1/git/{owner}/{repo}/file-changes", GitEndpoints.GetFileChanges)
+    .RequireAuthorization("EngineServiceOnly")
+    .WithName("GitGetFileChanges");
+app.MapDelete("/api/v1/git/{owner}/{repo}/branches", GitEndpoints.DeleteBranch)
+    .RequireAuthorization("EngineServiceOnly")
+    .WithName("GitDeleteBranch");
+
+// ── Story 38 (Phase 1) — CI (GitHub Actions) step mediation ──
+// Same engine-only plane + guard→token→platform→one-event mediation as git.
+app.MapPost("/api/v1/ci/{owner}/{repo}/test-runs", CiEndpoints.TriggerTests)
+    .RequireAuthorization("EngineServiceOnly")
+    .WithName("CiTriggerTests");
+app.MapGet("/api/v1/ci/{owner}/{repo}/build-status", CiEndpoints.GetBuildStatus)
+    .RequireAuthorization("EngineServiceOnly")
+    .WithName("CiGetBuildStatus");
+
+// ── Story 38 (Phase 1) — JIRA step mediation ──
+// Not repo-scoped (like Slack): no tenant↔repo guard; the JIRA credential lives in
+// Tamma.Api config, resolved inside IJiraIntegrationService.
+app.MapGet("/api/v1/jira/tickets/{ticketId}", JiraEndpoints.GetTicket)
+    .RequireAuthorization("EngineServiceOnly")
+    .WithName("JiraGetTicket");
+app.MapPatch("/api/v1/jira/tickets/{ticketId}", JiraEndpoints.UpdateTicket)
+    .RequireAuthorization("EngineServiceOnly")
+    .WithName("JiraUpdateTicket");
+
 // ── Story 38-2 (Epic 38) — agent-dispatch step mediation (Class C) ──
 // Same engine-only plane as /api/v1/git and /api/v1/llm/call: the engine's thin
 // phase services post here as the service-scope Tamma:ApiToken; the API holds the
@@ -2393,6 +2443,15 @@ app.MapGet("/api/v1/agent-dispatch/{owner}/{repo}/installation", AgentDispatchEn
 app.MapPost("/api/v1/notifications/slack", NotificationEndpoints.QueueSlack)
     .RequireAuthorization("EngineServiceOnly")
     .WithName("QueueSlackNotification");
+
+// ── Story 38 (Phase 1) — email step mediation ──
+// Same engine-only plane as the Slack notification: the engine posts an
+// already-rendered message; the API accepts it into the credentialed, outbox-backed
+// IEmailService (which owns transport + EMAIL.* audit). Not repo-scoped; the acting
+// tenant scopes the message. NO SMTP/Resend credential ever reaches the engine.
+app.MapPost("/api/v1/notifications/email", EmailEndpoints.SendEmail)
+    .RequireAuthorization("EngineServiceOnly")
+    .WithName("SendEmailNotification");
 app.MapPost("/api/v1/workflows/{id}/status", SaaSEndpoints.UpdateWorkflowStatus).RequireAuthorization();
 app.MapPost("/api/v1/workflows/{id}/result", SaaSEndpoints.PostWorkflowResult).RequireAuthorization();
 app.MapPost("/api/v1/installations/{id}/rotate-key", SaaSEndpoints.RotateInstallationKey).RequireAuthorization();

--- a/apps/tamma-elsa/src/Tamma.Api/Services/CIIntegrationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/CIIntegrationService.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Tamma.Core.Interfaces;
@@ -15,21 +16,66 @@ public class CIIntegrationService : ICIIntegrationService
     private readonly int _ciPollIntervalMs;
     private readonly int _ciPollMaxAttempts;
 
+    /// <summary>
+    /// Story 38 (Phase 1) — when set, this request-scoped token overrides the named
+    /// "github" client's static <c>GitHub:Token</c> bearer for EVERY Actions call
+    /// made through this instance, so the CI mediation layer uses the per-tenant
+    /// token it resolved (the "token used == token resolved" invariant, mirroring
+    /// <see cref="GitHubIntegrationService"/>). Minted per-request by
+    /// <see cref="Ci.CiClientFactory"/>; never logged, returned, or persisted.
+    /// Null ⇒ legacy static-token behaviour.
+    /// </summary>
+    private readonly string? _tokenOverride;
+
     public CIIntegrationService(
         IHttpClientFactory httpClientFactory,
         IConfiguration configuration,
         ILogger<CIIntegrationService> logger)
+        : this(httpClientFactory, configuration, logger, tokenOverride: null)
+    {
+    }
+
+    /// <summary>
+    /// Story 38 (Phase 1) — construct bound to a request-scoped
+    /// <paramref name="tokenOverride"/>. Used by <see cref="Ci.CiClientFactory"/> so
+    /// the CI-mediation endpoints perform the Actions call with the resolved
+    /// per-tenant token.
+    /// </summary>
+    public CIIntegrationService(
+        IHttpClientFactory httpClientFactory,
+        IConfiguration configuration,
+        ILogger<CIIntegrationService> logger,
+        string? tokenOverride)
     {
         _httpClientFactory = httpClientFactory;
         _configuration = configuration;
         _logger = logger;
+        _tokenOverride = tokenOverride;
         _ciPollIntervalMs = configuration.GetValue<int>("CI:PollIntervalMs", 5000);
         _ciPollMaxAttempts = configuration.GetValue<int>("CI:PollMaxAttempts", 10);
     }
 
+    /// <summary>
+    /// Create the named "github" <see cref="HttpClient"/>, applying the
+    /// request-scoped <see cref="_tokenOverride"/> when present. The factory returns
+    /// a fresh client instance per call, so mutating its default Authorization
+    /// header is scoped to this instance only.
+    /// </summary>
+    private HttpClient CreateGitHubClient()
+    {
+        var client = _httpClientFactory.CreateClient("github");
+        if (!string.IsNullOrWhiteSpace(_tokenOverride))
+        {
+            client.DefaultRequestHeaders.Remove("Authorization");
+            client.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", _tokenOverride);
+        }
+        return client;
+    }
+
     public async Task<IntegrationResult<TestRunResult>> TriggerTestsAsync(string repository, string branch)
     {
-        var httpClient = _httpClientFactory.CreateClient("github");
+        var httpClient = CreateGitHubClient();
 
         try
         {
@@ -110,7 +156,7 @@ public class CIIntegrationService : ICIIntegrationService
 
     public async Task<IntegrationResult<BuildStatus>> GetBuildStatusAsync(string repository, string branch)
     {
-        var httpClient = _httpClientFactory.CreateClient("github");
+        var httpClient = CreateGitHubClient();
 
         try
         {

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Ci/CiClientFactory.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Ci/CiClientFactory.cs
@@ -1,0 +1,47 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Tamma.Core.Interfaces;
+
+namespace Tamma.Api.Services.Ci;
+
+/// <summary>
+/// Story 38 (Phase 1) — mints an <see cref="ICIIntegrationService"/> bound to a
+/// SPECIFIC resolved token so the CI (GitHub Actions) call uses the token that was
+/// resolved (the "token used == token resolved" invariant). Mirrors
+/// <see cref="Tamma.Api.Services.Git.GitHubClientFactory"/>: the bound service
+/// overrides the named "github" client's static <c>GitHub:Token</c> bearer with the
+/// request-scoped token for that one call. The token NEVER leaves the service
+/// instance — no logging, no return, no event.
+/// </summary>
+public interface ICiClientFactory
+{
+    ICIIntegrationService Create(string token);
+}
+
+/// <inheritdoc />
+public sealed class CiClientFactory : ICiClientFactory
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<CIIntegrationService> _logger;
+
+    public CiClientFactory(
+        IHttpClientFactory httpClientFactory,
+        IConfiguration configuration,
+        ILogger<CIIntegrationService> logger)
+    {
+        _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public ICIIntegrationService Create(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            throw new ArgumentException("A non-empty CI (git) token is required.", nameof(token));
+        }
+
+        return new CIIntegrationService(_httpClientFactory, _configuration, _logger, token);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Ci/CiEventTypes.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Ci/CiEventTypes.cs
@@ -1,0 +1,36 @@
+namespace Tamma.Api.Services.Ci;
+
+/// <summary>
+/// Story 38 (Phase 1) — the terminal DCB event families the CI-mediation endpoints
+/// emit (exactly one per call). Naming mirrors the Story 38-1 <c>GIT.*</c>
+/// convention (<c>AGGREGATE.ACTION.STATUS</c>). Payloads + tags are KEY-FREE — they
+/// reference the repo + branch, never the resolved git token or any Authorization
+/// header.
+/// </summary>
+public static class CiEventTypes
+{
+    public const string TestsTriggerOperation = "tests_trigger";
+    public const string BuildStatusReadOperation = "build_status_read";
+
+    public const string TestsTriggeredSuccess = "CI.TESTS_TRIGGERED.SUCCESS";
+    public const string TestsTriggeredFailed = "CI.TESTS_TRIGGERED.FAILED";
+
+    public const string BuildStatusReadSuccess = "CI.BUILD_STATUS_READ.SUCCESS";
+    public const string BuildStatusReadFailed = "CI.BUILD_STATUS_READ.FAILED";
+}
+
+/// <summary>
+/// Story 38 (Phase 1) — the coarse, key-free CI failure taxonomy surfaced on the
+/// wire so the workflow can branch on the outcome. Never a raw provider 5xx.
+/// </summary>
+public static class CiFailureCodes
+{
+    /// <summary>The tenant↔repo cross-tenant guard denied. Platform never called.</summary>
+    public const string RepoNotAuthorized = "REPO_NOT_AUTHORIZED";
+
+    /// <summary>The per-tenant git token could not be resolved (fail-closed).</summary>
+    public const string TokenUnavailable = "CI_TOKEN_UNAVAILABLE";
+
+    /// <summary>Any other expected platform failure (permission, rate-limit, transient).</summary>
+    public const string PlatformError = "PLATFORM_ERROR";
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Ci/CiMediationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Ci/CiMediationService.cs
@@ -1,0 +1,271 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Tamma.Api.Services.Git;
+using Tamma.Core.Interfaces;
+using Tamma.Core.Logging;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Ci;
+
+/// <summary>
+/// Story 38 (Phase 1) — composes the CI-mediation sequence entirely inside
+/// <c>Tamma.Api</c>: cross-tenant guard (reused from Story 38-1) → per-tenant token
+/// (BYOK→platform, reusing <see cref="IGitTokenResolver"/> — CI is GitHub Actions on
+/// the same git token) → CI call with the RESOLVED token via a token-bound
+/// <see cref="ICIIntegrationService"/> minted by <see cref="ICiClientFactory"/> →
+/// exactly-one terminal DCB event. The resolved token lives only on that
+/// request-scoped service instance; it is NEVER logged, returned, or written to the
+/// audit event (only the <c>credentialSource</c> LABEL is surfaced).
+/// </summary>
+public sealed class CiMediationService : ICiMediationService
+{
+    private readonly IGitRepoAuthorizer _authorizer;
+    private readonly IGitTokenResolver _tokenResolver;
+    private readonly ICiClientFactory _ciFactory;
+    private readonly IEventRepository _events;
+    private readonly ILogger<CiMediationService> _logger;
+
+    public CiMediationService(
+        IGitRepoAuthorizer authorizer,
+        IGitTokenResolver tokenResolver,
+        ICiClientFactory ciFactory,
+        IEventRepository events,
+        ILogger<CiMediationService> logger)
+    {
+        _authorizer = authorizer ?? throw new ArgumentNullException(nameof(authorizer));
+        _tokenResolver = tokenResolver ?? throw new ArgumentNullException(nameof(tokenResolver));
+        _ciFactory = ciFactory ?? throw new ArgumentNullException(nameof(ciFactory));
+        _events = events ?? throw new ArgumentNullException(nameof(events));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public Task<CiMediationResult> TriggerTestsAsync(Guid? tenantId, string repo, TriggerTestsRequest body, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        return ExecuteGuardedAsync(tenantId, repo, CiEventTypes.TestsTriggerOperation, CiEventTypes.TestsTriggeredFailed, body.CorrelationId, ct,
+            () => TriggerTestsCoreAsync(tenantId, repo, body, ct));
+    }
+
+    public Task<CiMediationResult> GetBuildStatusAsync(Guid? tenantId, string repo, string branch, string correlationId, CancellationToken ct = default)
+        => ExecuteGuardedAsync(tenantId, repo, CiEventTypes.BuildStatusReadOperation, CiEventTypes.BuildStatusReadFailed, correlationId, ct,
+            () => GetBuildStatusCoreAsync(tenantId, repo, branch, correlationId, ct));
+
+    // ===================================================================
+    // Trigger tests (the WRITE — dispatches an Actions workflow run)
+    // ===================================================================
+
+    private async Task<CiMediationResult> TriggerTestsCoreAsync(Guid? tenantId, string repo, TriggerTestsRequest body, CancellationToken ct)
+    {
+        var op = CiEventTypes.TestsTriggerOperation;
+
+        var gate = await GuardOrDenyAsync(tenantId, repo, op, CiEventTypes.TestsTriggeredFailed, body.CorrelationId, ct).ConfigureAwait(false);
+        if (gate is not null) return gate;
+
+        var cred = await _tokenResolver.ResolveAsync(tenantId, repo, ct).ConfigureAwait(false);
+        if (cred is null)
+            return await TokenUnavailableAsync(tenantId, repo, op, CiEventTypes.TestsTriggeredFailed, body.CorrelationId, ct).ConfigureAwait(false);
+
+        var ci = _ciFactory.Create(cred.Token);
+        var res = await ci.TriggerTestsAsync(repo, body.Branch).ConfigureAwait(false);
+
+        if (!res.Success)
+            return await PlatformFailAsync(tenantId, repo, op, CiEventTypes.TestsTriggeredFailed, body.CorrelationId, cred.Source, res.Error, new { branch = body.Branch }, ct).ConfigureAwait(false);
+
+        var data = res.Data!;
+        var ok = new CiMediationResult
+        {
+            Success = true,
+            CredentialSource = cred.Source,
+            Outcome = "Triggered",
+            TestRun = new CiTestRunDto
+            {
+                RunId = data.RunId,
+                Status = data.Status,
+                TotalTests = data.TotalTests,
+                PassedTests = data.PassedTests,
+                FailedTests = data.FailedTests,
+                SkippedTests = data.SkippedTests,
+                CoveragePercentage = data.CoveragePercentage,
+            },
+            CorrelationId = body.CorrelationId,
+        };
+        await EmitAsync(CiEventTypes.TestsTriggeredSuccess, op, tenantId, repo, body.CorrelationId, cred.Source, null,
+            new { branch = body.Branch, runId = data.RunId, status = data.Status }, ct).ConfigureAwait(false);
+        return ok;
+    }
+
+    // ===================================================================
+    // Read build status
+    // ===================================================================
+
+    private async Task<CiMediationResult> GetBuildStatusCoreAsync(Guid? tenantId, string repo, string branch, string correlationId, CancellationToken ct)
+    {
+        var op = CiEventTypes.BuildStatusReadOperation;
+
+        var gate = await GuardOrDenyAsync(tenantId, repo, op, CiEventTypes.BuildStatusReadFailed, correlationId, ct).ConfigureAwait(false);
+        if (gate is not null) return gate;
+
+        var cred = await _tokenResolver.ResolveAsync(tenantId, repo, ct).ConfigureAwait(false);
+        if (cred is null)
+            return await TokenUnavailableAsync(tenantId, repo, op, CiEventTypes.BuildStatusReadFailed, correlationId, ct).ConfigureAwait(false);
+
+        var ci = _ciFactory.Create(cred.Token);
+        var res = await ci.GetBuildStatusAsync(repo, branch).ConfigureAwait(false);
+
+        if (!res.Success)
+            return await PlatformFailAsync(tenantId, repo, op, CiEventTypes.BuildStatusReadFailed, correlationId, cred.Source, res.Error, new { branch }, ct).ConfigureAwait(false);
+
+        var data = res.Data!;
+        var ok = new CiMediationResult
+        {
+            Success = true,
+            CredentialSource = cred.Source,
+            Outcome = "Read",
+            BuildStatus = new CiBuildStatusDto
+            {
+                Status = data.Status,
+                BuildUrl = data.BuildUrl,
+                StartedAt = data.StartedAt,
+                FinishedAt = data.FinishedAt,
+            },
+            CorrelationId = correlationId,
+        };
+        await EmitAsync(CiEventTypes.BuildStatusReadSuccess, op, tenantId, repo, correlationId, cred.Source, null,
+            new { branch, status = data.Status }, ct).ConfigureAwait(false);
+        return ok;
+    }
+
+    // ===================================================================
+    // Guard / token-unavailable / failure shared paths
+    // ===================================================================
+
+    private async Task<CiMediationResult?> GuardOrDenyAsync(
+        Guid? tenantId, string repo, string operation, string failedEventType, string correlationId, CancellationToken ct)
+    {
+        var authz = await _authorizer.AuthorizeAsync(tenantId, repo, ct).ConfigureAwait(false);
+        if (authz.Allowed) return null;
+
+        var result = new CiMediationResult
+        {
+            Success = false,
+            Outcome = "Error",
+            FailureCode = CiFailureCodes.RepoNotAuthorized,
+            FailureReason = authz.Reason,
+            CorrelationId = correlationId,
+        };
+        await EmitAsync(failedEventType, operation, tenantId, repo, correlationId, credentialSource: null,
+            CiFailureCodes.RepoNotAuthorized, new { }, ct).ConfigureAwait(false);
+        return result;
+    }
+
+    private async Task<CiMediationResult> TokenUnavailableAsync(
+        Guid? tenantId, string repo, string operation, string failedEventType, string correlationId, CancellationToken ct)
+    {
+        var result = new CiMediationResult
+        {
+            Success = false,
+            Outcome = "Error",
+            FailureCode = CiFailureCodes.TokenUnavailable,
+            FailureReason = "the per-tenant CI token could not be resolved",
+            CorrelationId = correlationId,
+        };
+        await EmitAsync(failedEventType, operation, tenantId, repo, correlationId, credentialSource: null,
+            CiFailureCodes.TokenUnavailable, new { }, ct).ConfigureAwait(false);
+        return result;
+    }
+
+    private async Task<CiMediationResult> PlatformFailAsync(
+        Guid? tenantId, string repo, string operation, string failedEventType, string correlationId,
+        string credentialSource, string? reason, object data, CancellationToken ct)
+    {
+        var fail = new CiMediationResult
+        {
+            Success = false,
+            CredentialSource = credentialSource,
+            Outcome = "Error",
+            FailureCode = CiFailureCodes.PlatformError,
+            FailureReason = reason,
+            PlatformStatusCode = ParsePlatformStatus(reason),
+            CorrelationId = correlationId,
+        };
+        await EmitAsync(failedEventType, operation, tenantId, repo, correlationId, credentialSource, CiFailureCodes.PlatformError, data, ct).ConfigureAwait(false);
+        return fail;
+    }
+
+    /// <summary>Run one mediation op body; convert any unexpected exception into a
+    /// typed key-free PLATFORM_ERROR result plus exactly one terminal FAILED event.
+    /// A cancellation is not a platform failure and propagates. Mirrors Story 38-1.</summary>
+    private async Task<CiMediationResult> ExecuteGuardedAsync(
+        Guid? tenantId, string repo, string operation, string failedEventType, string correlationId,
+        CancellationToken ct, Func<Task<CiMediationResult>> body)
+    {
+        try
+        {
+            return await body().ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "ci-mediation op {Operation} threw; returning typed PLATFORM_ERROR (never a raw 5xx) with one FAILED event. correlationId={CorrelationId}, repo={Repo}, tenantId={TenantId}",
+                operation, LogSanitizer.Clean(correlationId), LogSanitizer.Clean(repo), tenantId);
+
+            await EmitAsync(failedEventType, operation, tenantId, repo, correlationId, credentialSource: null,
+                CiFailureCodes.PlatformError, new { }, ct).ConfigureAwait(false);
+
+            return new CiMediationResult
+            {
+                Success = false,
+                Outcome = "Error",
+                FailureCode = CiFailureCodes.PlatformError,
+                FailureReason = "an unexpected error occurred processing the CI operation",
+                CorrelationId = correlationId,
+            };
+        }
+    }
+
+    // ===================================================================
+    // DCB audit (exactly one terminal CI.* event per call)
+    // ===================================================================
+
+    private async Task EmitAsync(
+        string eventType, string operation, Guid? tenantId, string repo, string correlationId,
+        string? credentialSource, string? failureCode, object data, CancellationToken ct)
+    {
+        try
+        {
+            object tagsObj = failureCode is null
+                ? new { tenantId = tenantId?.ToString(), repo, operation, credentialSource, correlationId }
+                : new { tenantId = tenantId?.ToString(), repo, operation, credentialSource, correlationId, failureCode };
+
+            await _events.AppendAsync(new DomainEvent
+            {
+                Id = Guid.NewGuid(),
+                Type = eventType,
+                TenantId = tenantId,
+                Tags = JsonSerializer.Serialize(tagsObj),
+                Metadata = JsonSerializer.Serialize(new { workflowVersion = "1.0.0", eventSource = "system" }),
+                Data = JsonSerializer.Serialize(data),
+                CreatedAt = DateTime.UtcNow,
+            }).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "CI.* event append failed (type={Type}); the mediation result still returns. correlationId={CorrelationId}, repo={Repo}, tenantId={TenantId}",
+                eventType, LogSanitizer.Clean(correlationId), LogSanitizer.Clean(repo), tenantId);
+        }
+    }
+
+    private static int? ParsePlatformStatus(string? reason)
+    {
+        if (string.IsNullOrWhiteSpace(reason)) return null;
+        var colon = reason.IndexOf(':');
+        var head = colon > 0 ? reason[..colon] : reason;
+        return int.TryParse(head.Trim(), out var status) && status is >= 100 and < 600 ? status : null;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Ci/CiRequests.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Ci/CiRequests.cs
@@ -1,0 +1,19 @@
+namespace Tamma.Api.Services.Ci;
+
+// ============================================================
+// Story 38 (Phase 1) — server-side binding records for the CI-mediation endpoints.
+// Bound from the engine client's camelCase JSON. NONE carry a token — the API
+// resolves the per-tenant credential server-side (BYOK→platform); the engine holds
+// no git/CI token.
+// ============================================================
+
+/// <summary>
+/// <c>POST /api/v1/ci/{owner}/{repo}/test-runs</c>. Triggers the configured CI
+/// workflow on <see cref="Branch"/> and polls to a terminal (or last-observed)
+/// state with the resolved token.
+/// </summary>
+public sealed record TriggerTestsRequest
+{
+    public string Branch { get; init; } = string.Empty;
+    public string CorrelationId { get; init; } = string.Empty;
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Ci/CiResponses.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Ci/CiResponses.cs
@@ -1,0 +1,81 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Tamma.Api.Services.Ci;
+
+/// <summary>
+/// Story 38 (Phase 1) — the single normalized, KEY-FREE result the CI endpoints
+/// return. Only <see cref="CredentialSource"/> (the label <c>byok</c>/<c>platform</c>)
+/// is ever present; the resolved token NEVER appears here (nor in any log or DCB
+/// event). The mirroring engine-side wire type is
+/// <c>Tamma.Activities.LlmCall.Models.CiCallResponse</c>.
+/// </summary>
+public sealed record CiMediationResult
+{
+    public bool Success { get; init; }
+
+    /// <summary>"byok" | "platform" — the credential label, NEVER the token.</summary>
+    public string? CredentialSource { get; init; }
+
+    /// <summary>Operation-specific outcome the caller routes on ("Triggered" / "Read" / "Error").</summary>
+    public string? Outcome { get; init; }
+
+    // ── trigger-tests ──
+    public CiTestRunDto? TestRun { get; init; }
+
+    // ── build-status ──
+    public CiBuildStatusDto? BuildStatus { get; init; }
+
+    // ── failure-only (key-free) ──
+    public string? FailureCode { get; init; }
+    public string? FailureReason { get; init; }
+    public int? PlatformStatusCode { get; init; }
+
+    public string? CorrelationId { get; init; }
+}
+
+/// <summary>A key-free test-run projection. Mirrors <c>Core.Interfaces.TestRunResult</c>.</summary>
+public sealed record CiTestRunDto
+{
+    public string RunId { get; init; } = string.Empty;
+    public string Status { get; init; } = string.Empty;
+    public int TotalTests { get; init; }
+    public int PassedTests { get; init; }
+    public int FailedTests { get; init; }
+    public int SkippedTests { get; init; }
+    public double? CoveragePercentage { get; init; }
+}
+
+/// <summary>A key-free build-status projection. Mirrors <c>Core.Interfaces.BuildStatus</c>.</summary>
+public sealed record CiBuildStatusDto
+{
+    public string Status { get; init; } = string.Empty;
+    public string? BuildUrl { get; init; }
+    public DateTime? StartedAt { get; init; }
+    public DateTime? FinishedAt { get; init; }
+}
+
+/// <summary>
+/// Story 38 (Phase 1) — the HTTP-status decision, mirroring the Story 38-1 git
+/// mapper: success ⇒ 200; expected platform failure ⇒ 200 success:false (the
+/// workflow branches on it, preserved platformStatusCode); REPO_NOT_AUTHORIZED ⇒
+/// 403; CI_TOKEN_UNAVAILABLE ⇒ 503. A raw 5xx is NEVER produced.
+/// </summary>
+public static class CiMediationResultExtensions
+{
+    public static IResult ToHttpResult(this CiMediationResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        if (result.Success)
+        {
+            return Results.Ok(result);
+        }
+
+        return result.FailureCode switch
+        {
+            CiFailureCodes.RepoNotAuthorized => Results.Json(result, statusCode: StatusCodes.Status403Forbidden),
+            CiFailureCodes.TokenUnavailable => Results.Json(result, statusCode: StatusCodes.Status503ServiceUnavailable),
+            _ => Results.Ok(result),
+        };
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Ci/ICiMediationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Ci/ICiMediationService.cs
@@ -1,0 +1,15 @@
+namespace Tamma.Api.Services.Ci;
+
+/// <summary>
+/// Story 38 (Phase 1) — the managed CI (GitHub Actions) execution layer behind the
+/// <c>/api/v1/ci/{owner}/{repo}/...</c> endpoints. Composes the same rule-1 sequence
+/// as Story 38-1's git mediation ENTIRELY inside <c>Tamma.Api</c>: cross-tenant
+/// guard → per-tenant token resolution (BYOK→platform) → CI call with the RESOLVED
+/// token → exactly-one terminal DCB audit event. ALWAYS returns a typed, key-free
+/// <see cref="CiMediationResult"/> — a failure never throws a raw 5xx.
+/// </summary>
+public interface ICiMediationService
+{
+    Task<CiMediationResult> TriggerTestsAsync(Guid? tenantId, string repo, TriggerTestsRequest body, CancellationToken ct = default);
+    Task<CiMediationResult> GetBuildStatusAsync(Guid? tenantId, string repo, string branch, string correlationId, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/EmailMediation/EmailMediationRequests.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/EmailMediation/EmailMediationRequests.cs
@@ -1,0 +1,22 @@
+namespace Tamma.Api.Services.EmailMediation;
+
+// ============================================================
+// Story 38 (Phase 1) — server-side binding record for the email-mediation
+// endpoint. Bound from the engine client's camelCase JSON. Email is not
+// repo-scoped — the acting tenant scopes the message + its audit events. NO
+// credential travels here: the SMTP/Resend credential lives in Tamma.Api config,
+// resolved inside the outbox-backed IEmailService; the engine holds nothing.
+// ============================================================
+
+/// <summary>
+/// <c>POST /api/v1/notifications/email</c>. The composed body is already rendered
+/// engine-side; the API accepts it into the credentialed, outbox-backed
+/// <c>IEmailService</c> for delivery.
+/// </summary>
+public sealed record SendEmailRequest
+{
+    public string To { get; init; } = string.Empty;
+    public string Subject { get; init; } = string.Empty;
+    public string Body { get; init; } = string.Empty;
+    public string CorrelationId { get; init; } = string.Empty;
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/EmailMediation/EmailMediationResponses.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/EmailMediation/EmailMediationResponses.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Tamma.Api.Services.EmailMediation;
+
+/// <summary>
+/// Story 38 (Phase 1) — the single normalized, KEY-FREE result the email endpoint
+/// returns. No recipient / body / credential ever appears here. The mirroring
+/// engine-side wire type is
+/// <c>Tamma.Activities.LlmCall.Models.EmailCallResponse</c>.
+/// </summary>
+public sealed record EmailMediationResult
+{
+    public bool Success { get; init; }
+
+    /// <summary>"Queued" on accept (the outbox owns transport), else "Error".</summary>
+    public string? Outcome { get; init; }
+
+    /// <summary>The transaction id the outbox-backed IEmailService returns — the
+    /// correlation key for the later EMAIL.SENT.* / EMAIL.SENT.FAILED events.</summary>
+    public Guid? TxnId { get; init; }
+
+    // ── failure-only (key-free) ──
+    public string? FailureCode { get; init; }
+    public string? FailureReason { get; init; }
+
+    public string? CorrelationId { get; init; }
+}
+
+/// <summary>
+/// Story 38 (Phase 1) — the coarse, key-free email failure taxonomy. Never a raw
+/// provider 5xx.
+/// </summary>
+public static class EmailMediationFailureCodes
+{
+    /// <summary>Any expected accept failure (validation, DI, transient).</summary>
+    public const string PlatformError = "PLATFORM_ERROR";
+}
+
+/// <summary>
+/// Story 38 (Phase 1) — the HTTP-status decision. Email is fail-soft (a missing
+/// notification must not break a workflow), so a failure rides inside a 200
+/// success:false envelope. A raw 5xx is NEVER produced.
+/// </summary>
+public static class EmailMediationResultExtensions
+{
+    public static IResult ToHttpResult(this EmailMediationResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        return Results.Ok(result);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/EmailMediation/EmailMediationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/EmailMediation/EmailMediationService.cs
@@ -1,0 +1,101 @@
+using Microsoft.Extensions.Logging;
+using Tamma.Api.Services.Email;
+using Tamma.Core.Logging;
+
+namespace Tamma.Api.Services.EmailMediation;
+
+/// <summary>
+/// Story 38 (Phase 1) — composes the email-mediation sequence entirely inside
+/// <c>Tamma.Api</c>: accept the engine's rendered message into the credentialed,
+/// outbox-backed <see cref="IEmailService"/> (SMTP / Resend / in-memory, chosen by
+/// <c>AddEmailServices</c> config) under the caller's tenant context. Unlike git/CI
+/// there is no per-tenant BYOK token resolver and no repo guard — email is a single,
+/// server-side, config-provided integration (mirrors the Slack outbox plane).
+///
+/// <para>The DCB audit is owned by <see cref="IEmailService"/> itself, which emits
+/// <see cref="EmailEventTypes.Queued"/> on accept and later
+/// <see cref="EmailEventTypes.Sent"/> / <see cref="EmailEventTypes.Failed"/> from the
+/// transport; the mediation layer therefore does NOT emit a duplicate terminal event
+/// (that would double-audit and collide with the subsystem's <c>EMAIL.SENT.*</c>
+/// types). The email credential NEVER reaches the engine — it stays in Tamma.Api
+/// config.</para>
+/// </summary>
+public sealed class EmailMediationService : IEmailMediationService
+{
+    private readonly IEmailService _email;
+    private readonly ILogger<EmailMediationService> _logger;
+
+    public EmailMediationService(
+        IEmailService email,
+        ILogger<EmailMediationService> logger)
+    {
+        _email = email ?? throw new ArgumentNullException(nameof(email));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<EmailMediationResult> SendEmailAsync(Guid? tenantId, SendEmailRequest body, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+
+        if (string.IsNullOrWhiteSpace(body.To))
+        {
+            return new EmailMediationResult
+            {
+                Success = false,
+                Outcome = "Error",
+                FailureCode = EmailMediationFailureCodes.PlatformError,
+                FailureReason = "recipient (to) is required",
+                CorrelationId = body.CorrelationId,
+            };
+        }
+
+        try
+        {
+            // The engine sends a single already-rendered body; use it for BOTH the
+            // plain-text (required) and HTML variants. The tenant scopes the message
+            // + its EMAIL.* audit events; no per-user identity at the engine-service
+            // principal plane.
+            var message = new EmailMessage(
+                To: body.To,
+                Subject: body.Subject,
+                Html: body.Body,
+                Text: body.Body,
+                From: null,
+                Template: null,
+                TenantId: tenantId,
+                UserId: null);
+
+            var txnId = await _email.SendAsync(message, ct).ConfigureAwait(false);
+
+            return new EmailMediationResult
+            {
+                Success = true,
+                Outcome = "Queued",
+                TxnId = txnId,
+                CorrelationId = body.CorrelationId,
+            };
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Fail-soft: a missing notification must not break the workflow — surface a
+            // typed PLATFORM_ERROR inside 200 success:false (never a raw 5xx). The
+            // recipient/body are NOT logged.
+            _logger.LogError(ex,
+                "email-mediation send threw; returning typed PLATFORM_ERROR (never a raw 5xx). correlationId={CorrelationId}, tenantId={TenantId}",
+                LogSanitizer.Clean(body.CorrelationId), tenantId);
+
+            return new EmailMediationResult
+            {
+                Success = false,
+                Outcome = "Error",
+                FailureCode = EmailMediationFailureCodes.PlatformError,
+                FailureReason = "an unexpected error occurred processing the email operation",
+                CorrelationId = body.CorrelationId,
+            };
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/EmailMediation/IEmailMediationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/EmailMediation/IEmailMediationService.cs
@@ -1,0 +1,15 @@
+namespace Tamma.Api.Services.EmailMediation;
+
+/// <summary>
+/// Story 38 (Phase 1) — the managed email execution layer behind
+/// <c>POST /api/v1/notifications/email</c>. Accepts the engine's rendered message
+/// into the credentialed, outbox-backed <c>IEmailService</c> under the caller's
+/// tenant context. The SMTP/Resend credential lives in Tamma.Api config; the engine
+/// holds nothing. ALWAYS returns a typed, key-free <see cref="EmailMediationResult"/>
+/// — a failure never throws a raw 5xx. Email is not repo-scoped, so there is no
+/// cross-tenant repo guard.
+/// </summary>
+public interface IEmailMediationService
+{
+    Task<EmailMediationResult> SendEmailAsync(Guid? tenantId, SendEmailRequest body, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitEventTypes.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitEventTypes.cs
@@ -16,6 +16,14 @@ public static class GitEventTypes
     public const string IssueUpdateOperation = "issue_update";
     public const string PrCommentsReadOperation = "pr_comments_read";
 
+    // Story 38 (Phase 1) — the GitHub "extra ops" the engine's context / debug /
+    // integration activities call on the composite today (commits + file-changes
+    // reads and the standalone branch delete). Mediated here on the same
+    // guard→token→platform→one-event plane as the git-platform ops above.
+    public const string CommitsReadOperation = "commits_read";
+    public const string FileChangesReadOperation = "file_changes_read";
+    public const string BranchDeleteOperation = "branch_delete";
+
     public const string BranchCreatedSuccess = "GIT.BRANCH_CREATED.SUCCESS";
     public const string BranchCreatedFailed = "GIT.BRANCH_CREATED.FAILED";
 
@@ -30,6 +38,15 @@ public static class GitEventTypes
 
     public const string PrCommentsReadSuccess = "GIT.PR_COMMENTS_READ.SUCCESS";
     public const string PrCommentsReadFailed = "GIT.PR_COMMENTS_READ.FAILED";
+
+    public const string CommitsReadSuccess = "GIT.COMMITS_READ.SUCCESS";
+    public const string CommitsReadFailed = "GIT.COMMITS_READ.FAILED";
+
+    public const string FileChangesReadSuccess = "GIT.FILE_CHANGES_READ.SUCCESS";
+    public const string FileChangesReadFailed = "GIT.FILE_CHANGES_READ.FAILED";
+
+    public const string BranchDeletedSuccess = "GIT.BRANCH_DELETED.SUCCESS";
+    public const string BranchDeletedFailed = "GIT.BRANCH_DELETED.FAILED";
 }
 
 /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitMediationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitMediationService.cs
@@ -81,6 +81,18 @@ public sealed class GitMediationService : IGitMediationService
         => ExecuteGuardedAsync(tenantId, repo, GitEventTypes.PrCommentsReadOperation, GitEventTypes.PrCommentsReadFailed, correlationId, ct,
             () => GetPullRequestCommentsCoreAsync(tenantId, repo, prNumber, correlationId, ct));
 
+    public Task<GitMediationResult> GetCommitsAsync(Guid? tenantId, string repo, string branch, DateTime? since, string correlationId, CancellationToken ct = default)
+        => ExecuteGuardedAsync(tenantId, repo, GitEventTypes.CommitsReadOperation, GitEventTypes.CommitsReadFailed, correlationId, ct,
+            () => GetCommitsCoreAsync(tenantId, repo, branch, since, correlationId, ct));
+
+    public Task<GitMediationResult> GetFileChangesAsync(Guid? tenantId, string repo, string branch, string correlationId, CancellationToken ct = default)
+        => ExecuteGuardedAsync(tenantId, repo, GitEventTypes.FileChangesReadOperation, GitEventTypes.FileChangesReadFailed, correlationId, ct,
+            () => GetFileChangesCoreAsync(tenantId, repo, branch, correlationId, ct));
+
+    public Task<GitMediationResult> DeleteBranchAsync(Guid? tenantId, string repo, string branchName, string correlationId, CancellationToken ct = default)
+        => ExecuteGuardedAsync(tenantId, repo, GitEventTypes.BranchDeleteOperation, GitEventTypes.BranchDeletedFailed, correlationId, ct,
+            () => DeleteBranchCoreAsync(tenantId, repo, branchName, correlationId, ct));
+
     /// <summary>
     /// F3 — run one mediation op body; convert any unexpected exception (DB read,
     /// secret decrypt, client mint, transport) into a typed key-free
@@ -444,6 +456,145 @@ public sealed class GitMediationService : IGitMediationService
         await EmitAsync(GitEventTypes.PrCommentsReadSuccess, op, tenantId, repo, correlationId, cred.Source, null,
             new { prNumber, commentCount = comments.Count }, ct).ConfigureAwait(false);
         return ok;
+    }
+
+    // ===================================================================
+    // GitHub extra ops (Story 38 Phase 1) — commits / file-changes reads + delete
+    // ===================================================================
+
+    private async Task<GitMediationResult> GetCommitsCoreAsync(Guid? tenantId, string repo, string branch, DateTime? since, string correlationId, CancellationToken ct)
+    {
+        var op = GitEventTypes.CommitsReadOperation;
+
+        var gate = await GuardOrDenyAsync(tenantId, repo, op, GitEventTypes.CommitsReadFailed, correlationId, ct).ConfigureAwait(false);
+        if (gate is not null) return gate;
+
+        var cred = await _tokenResolver.ResolveAsync(tenantId, repo, ct).ConfigureAwait(false);
+        if (cred is null)
+            return await TokenUnavailableAsync(tenantId, repo, op, GitEventTypes.CommitsReadFailed, correlationId, ct).ConfigureAwait(false);
+
+        var github = _githubFactory.Create(cred.Token);
+        var res = await github.GetGitHubCommitsAsync(repo, branch, since).ConfigureAwait(false);
+
+        if (!res.Success)
+            return await ReadFailAsync(tenantId, repo, op, GitEventTypes.CommitsReadFailed, correlationId, cred.Source, res.Error, new { branch }, ct).ConfigureAwait(false);
+
+        var commits = (res.Data ?? new List<GitHubCommit>())
+            .Select(c => new GitCommitDto
+            {
+                Sha = c.Sha,
+                Message = c.Message,
+                Author = c.Author,
+                Timestamp = c.Timestamp,
+                Additions = c.Additions,
+                Deletions = c.Deletions,
+                Files = c.Files.ToList(),
+            })
+            .ToList();
+
+        var ok = new GitMediationResult
+        {
+            Success = true,
+            CredentialSource = cred.Source,
+            Outcome = "Done",
+            Commits = commits,
+            CorrelationId = correlationId,
+        };
+        await EmitAsync(GitEventTypes.CommitsReadSuccess, op, tenantId, repo, correlationId, cred.Source, null,
+            new { branch, commitCount = commits.Count }, ct).ConfigureAwait(false);
+        return ok;
+    }
+
+    private async Task<GitMediationResult> GetFileChangesCoreAsync(Guid? tenantId, string repo, string branch, string correlationId, CancellationToken ct)
+    {
+        var op = GitEventTypes.FileChangesReadOperation;
+
+        var gate = await GuardOrDenyAsync(tenantId, repo, op, GitEventTypes.FileChangesReadFailed, correlationId, ct).ConfigureAwait(false);
+        if (gate is not null) return gate;
+
+        var cred = await _tokenResolver.ResolveAsync(tenantId, repo, ct).ConfigureAwait(false);
+        if (cred is null)
+            return await TokenUnavailableAsync(tenantId, repo, op, GitEventTypes.FileChangesReadFailed, correlationId, ct).ConfigureAwait(false);
+
+        var github = _githubFactory.Create(cred.Token);
+        var res = await github.GetGitHubFileChangesAsync(repo, branch).ConfigureAwait(false);
+
+        if (!res.Success)
+            return await ReadFailAsync(tenantId, repo, op, GitEventTypes.FileChangesReadFailed, correlationId, cred.Source, res.Error, new { branch }, ct).ConfigureAwait(false);
+
+        var changes = (res.Data ?? new List<GitHubFileChange>())
+            .Select(f => new GitFileChangeDto
+            {
+                FilePath = f.FilePath,
+                ChangeType = f.ChangeType,
+                Additions = f.Additions,
+                Deletions = f.Deletions,
+            })
+            .ToList();
+
+        var ok = new GitMediationResult
+        {
+            Success = true,
+            CredentialSource = cred.Source,
+            Outcome = "Done",
+            FileChanges = changes,
+            CorrelationId = correlationId,
+        };
+        await EmitAsync(GitEventTypes.FileChangesReadSuccess, op, tenantId, repo, correlationId, cred.Source, null,
+            new { branch, fileCount = changes.Count }, ct).ConfigureAwait(false);
+        return ok;
+    }
+
+    private async Task<GitMediationResult> DeleteBranchCoreAsync(Guid? tenantId, string repo, string branchName, string correlationId, CancellationToken ct)
+    {
+        var op = GitEventTypes.BranchDeleteOperation;
+
+        var gate = await GuardOrDenyAsync(tenantId, repo, op, GitEventTypes.BranchDeletedFailed, correlationId, ct).ConfigureAwait(false);
+        if (gate is not null) return gate;
+
+        var cred = await _tokenResolver.ResolveAsync(tenantId, repo, ct).ConfigureAwait(false);
+        if (cred is null)
+            return await TokenUnavailableAsync(tenantId, repo, op, GitEventTypes.BranchDeletedFailed, correlationId, ct).ConfigureAwait(false);
+
+        var github = _githubFactory.Create(cred.Token);
+        var res = await github.DeleteGitHubBranchAsync(repo, branchName).ConfigureAwait(false);
+
+        if (!res.Success)
+            return await ReadFailAsync(tenantId, repo, op, GitEventTypes.BranchDeletedFailed, correlationId, cred.Source, res.Error, new { branchName }, ct).ConfigureAwait(false);
+
+        var ok = new GitMediationResult
+        {
+            Success = true,
+            CredentialSource = cred.Source,
+            Outcome = "Deleted",
+            BranchRef = branchName,
+            BranchDeleted = true,
+            CorrelationId = correlationId,
+        };
+        await EmitAsync(GitEventTypes.BranchDeletedSuccess, op, tenantId, repo, correlationId, cred.Source, null,
+            new { branchName }, ct).ConfigureAwait(false);
+        return ok;
+    }
+
+    /// <summary>Shared typed-failure path for the extra read/delete ops — key-free
+    /// PLATFORM_ERROR / NOT_FOUND (via the same 404 heuristic) + one FAILED event.</summary>
+    private async Task<GitMediationResult> ReadFailAsync(
+        Guid? tenantId, string repo, string operation, string failedEventType, string correlationId,
+        string credentialSource, string? reason, object data, CancellationToken ct)
+    {
+        var failCode = MapReadFailure(reason);
+        var fail = new GitMediationResult
+        {
+            Success = false,
+            CredentialSource = credentialSource,
+            Outcome = "Error",
+            FailureCode = failCode,
+            FailureReason = reason,
+            PlatformStatusCode = ParsePlatformStatus(reason),
+            CorrelationId = correlationId,
+        };
+        await EmitAsync(failedEventType, operation, tenantId, repo, correlationId, credentialSource, failCode, data, ct).ConfigureAwait(false);
+        return fail;
     }
 
     // ===================================================================

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitMediationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitMediationService.cs
@@ -107,8 +107,12 @@ public sealed class GitMediationService : IGitMediationService
         {
             return await body().ConfigureAwait(false);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
+            // Genuine caller cancellation propagates; an HttpClient timeout
+            // (TaskCanceledException with ct NOT requested) falls through to the
+            // general catch → typed PLATFORM_ERROR envelope (never a raw 5xx),
+            // matching the Ci/Jira mediation siblings.
             throw;
         }
         catch (Exception ex)

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitResponses.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitResponses.cs
@@ -47,6 +47,10 @@ public sealed record GitMediationResult
     // ── comments ──
     public IReadOnlyList<PrCommentDto>? Comments { get; init; }
 
+    // ── commits / file-changes reads (Story 38 Phase 1 — GitHub extra ops) ──
+    public IReadOnlyList<GitCommitDto>? Commits { get; init; }
+    public IReadOnlyList<GitFileChangeDto>? FileChanges { get; init; }
+
     // ── failure-only (key-free) ──
     public string? FailureCode { get; init; }   // REPO_NOT_AUTHORIZED | GIT_CONFLICT | NOT_MERGEABLE | NOT_FOUND | PLATFORM_ERROR | GIT_TOKEN_UNAVAILABLE
     public string? FailureReason { get; init; }  // key-free
@@ -64,6 +68,29 @@ public sealed record PrCommentDto
     public int? Line { get; init; }
     public string Author { get; init; } = string.Empty;
     public DateTime CreatedAt { get; init; }
+}
+
+/// <summary>A key-free commit projection (Story 38 Phase 1). Mirrors the engine
+/// wire type <c>Tamma.Activities.LlmCall.Models.GitCommitSummaryDto</c>.</summary>
+public sealed record GitCommitDto
+{
+    public string Sha { get; init; } = string.Empty;
+    public string Message { get; init; } = string.Empty;
+    public string Author { get; init; } = string.Empty;
+    public DateTime Timestamp { get; init; }
+    public int Additions { get; init; }
+    public int Deletions { get; init; }
+    public IReadOnlyList<string> Files { get; init; } = Array.Empty<string>();
+}
+
+/// <summary>A key-free file-change projection (Story 38 Phase 1). Mirrors the engine
+/// wire type <c>Tamma.Activities.LlmCall.Models.GitFileChangeDto</c>.</summary>
+public sealed record GitFileChangeDto
+{
+    public string FilePath { get; init; } = string.Empty;
+    public string ChangeType { get; init; } = string.Empty;
+    public int Additions { get; init; }
+    public int Deletions { get; init; }
 }
 
 /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Git/IGitMediationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Git/IGitMediationService.cs
@@ -15,4 +15,19 @@ public interface IGitMediationService
     Task<GitMediationResult> MergePullRequestAsync(Guid? tenantId, string repo, int prNumber, MergePrRequest body, CancellationToken ct = default);
     Task<GitMediationResult> UpdateIssueAsync(Guid? tenantId, string repo, int issueNumber, UpdateIssueRequest body, CancellationToken ct = default);
     Task<GitMediationResult> GetPullRequestCommentsAsync(Guid? tenantId, string repo, int prNumber, string correlationId, CancellationToken ct = default);
+
+    // Story 38 (Phase 1) — GitHub "extra ops" the engine's context/debug/integration
+    // activities call on the composite today, mediated on the same plane.
+
+    /// <summary>Read recent commits on <paramref name="branch"/> (optionally
+    /// <paramref name="since"/>). Read op — guard→token→platform→one event.</summary>
+    Task<GitMediationResult> GetCommitsAsync(Guid? tenantId, string repo, string branch, DateTime? since, string correlationId, CancellationToken ct = default);
+
+    /// <summary>Read the file changes on <paramref name="branch"/> relative to the
+    /// repo default. Read op — guard→token→platform→one event.</summary>
+    Task<GitMediationResult> GetFileChangesAsync(Guid? tenantId, string repo, string branch, string correlationId, CancellationToken ct = default);
+
+    /// <summary>Delete <paramref name="branchName"/> (the standalone delete the
+    /// composite exposes, distinct from the verified post-merge delete). Write op.</summary>
+    Task<GitMediationResult> DeleteBranchAsync(Guid? tenantId, string repo, string branchName, string correlationId, CancellationToken ct = default);
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Jira/IJiraMediationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Jira/IJiraMediationService.cs
@@ -1,0 +1,16 @@
+namespace Tamma.Api.Services.Jira;
+
+/// <summary>
+/// Story 38 (Phase 1) — the managed JIRA execution layer behind the
+/// <c>/api/v1/jira/tickets/...</c> endpoints. Runs the JIRA call server-side (the
+/// credential lives in Tamma.Api config, resolved inside
+/// <c>IJiraIntegrationService</c>) under the caller's tenant context, then emits
+/// exactly one terminal DCB audit event. ALWAYS returns a typed, key-free
+/// <see cref="JiraMediationResult"/> — a failure never throws a raw 5xx. JIRA is not
+/// repo-scoped, so there is no cross-tenant repo guard.
+/// </summary>
+public interface IJiraMediationService
+{
+    Task<JiraMediationResult> GetTicketAsync(Guid? tenantId, string ticketId, string correlationId, CancellationToken ct = default);
+    Task<JiraMediationResult> UpdateTicketAsync(Guid? tenantId, string ticketId, UpdateTicketRequest body, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Jira/JiraEventTypes.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Jira/JiraEventTypes.cs
@@ -1,0 +1,35 @@
+namespace Tamma.Api.Services.Jira;
+
+/// <summary>
+/// Story 38 (Phase 1) — the terminal DCB event families the JIRA-mediation
+/// endpoints emit (exactly one per call). Naming mirrors the Story 38-1 <c>GIT.*</c>
+/// convention. Payloads + tags are KEY-FREE — they reference the ticket id, never
+/// the JIRA API token / basic-auth header.
+/// </summary>
+public static class JiraEventTypes
+{
+    public const string TicketReadOperation = "ticket_read";
+    public const string TicketUpdateOperation = "ticket_update";
+
+    public const string TicketReadSuccess = "JIRA.TICKET_READ.SUCCESS";
+    public const string TicketReadFailed = "JIRA.TICKET_READ.FAILED";
+
+    public const string TicketUpdatedSuccess = "JIRA.TICKET_UPDATED.SUCCESS";
+    public const string TicketUpdatedFailed = "JIRA.TICKET_UPDATED.FAILED";
+}
+
+/// <summary>
+/// Story 38 (Phase 1) — the coarse, key-free JIRA failure taxonomy surfaced on the
+/// wire so the workflow can branch on the outcome. Never a raw provider 5xx.
+/// </summary>
+public static class JiraFailureCodes
+{
+    /// <summary>JIRA is not configured on the Tamma server (no base URL / creds).</summary>
+    public const string NotConfigured = "JIRA_NOT_CONFIGURED";
+
+    /// <summary>The referenced ticket was not found.</summary>
+    public const string NotFound = "NOT_FOUND";
+
+    /// <summary>Any other expected platform failure (permission, rate-limit, transient).</summary>
+    public const string PlatformError = "PLATFORM_ERROR";
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Jira/JiraMediationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Jira/JiraMediationService.cs
@@ -1,0 +1,209 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Tamma.Core.Interfaces;
+using Tamma.Core.Logging;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Jira;
+
+/// <summary>
+/// Story 38 (Phase 1) — composes the JIRA-mediation sequence entirely inside
+/// <c>Tamma.Api</c>: platform call via the existing config-credentialed
+/// <see cref="IJiraIntegrationService"/> (the JIRA base URL / email / API token live
+/// in Tamma.Api config, resolved inside that service) → exactly-one terminal DCB
+/// event scoped by the acting tenant. Unlike git/CI there is no per-tenant BYOK
+/// token resolver and no repo guard: JIRA is a single, server-side, config-provided
+/// integration (mirrors the Slack outbox plane, not the repo-scoped git plane). The
+/// JIRA token NEVER reaches the engine — it stays in Tamma.Api config.
+/// </summary>
+public sealed class JiraMediationService : IJiraMediationService
+{
+    private readonly IJiraIntegrationService _jira;
+    private readonly IEventRepository _events;
+    private readonly ILogger<JiraMediationService> _logger;
+
+    public JiraMediationService(
+        IJiraIntegrationService jira,
+        IEventRepository events,
+        ILogger<JiraMediationService> logger)
+    {
+        _jira = jira ?? throw new ArgumentNullException(nameof(jira));
+        _events = events ?? throw new ArgumentNullException(nameof(events));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public Task<JiraMediationResult> GetTicketAsync(Guid? tenantId, string ticketId, string correlationId, CancellationToken ct = default)
+        => ExecuteGuardedAsync(tenantId, ticketId, JiraEventTypes.TicketReadOperation, JiraEventTypes.TicketReadFailed, correlationId, ct,
+            () => GetTicketCoreAsync(tenantId, ticketId, correlationId, ct));
+
+    public Task<JiraMediationResult> UpdateTicketAsync(Guid? tenantId, string ticketId, UpdateTicketRequest body, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        return ExecuteGuardedAsync(tenantId, ticketId, JiraEventTypes.TicketUpdateOperation, JiraEventTypes.TicketUpdatedFailed, body.CorrelationId, ct,
+            () => UpdateTicketCoreAsync(tenantId, ticketId, body, ct));
+    }
+
+    // ===================================================================
+    // Read ticket
+    // ===================================================================
+
+    private async Task<JiraMediationResult> GetTicketCoreAsync(Guid? tenantId, string ticketId, string correlationId, CancellationToken ct)
+    {
+        var op = JiraEventTypes.TicketReadOperation;
+        var res = await _jira.GetJiraTicketAsync(ticketId).ConfigureAwait(false);
+
+        if (!res.Success)
+            return await FailAsync(tenantId, ticketId, op, JiraEventTypes.TicketReadFailed, correlationId, res.Error, ct).ConfigureAwait(false);
+
+        var t = res.Data;
+        var ticket = t is null ? null : new JiraTicketDto
+        {
+            Id = t.Id,
+            Key = t.Key,
+            Summary = t.Summary,
+            Description = t.Description,
+            Status = t.Status,
+            Assignee = t.Assignee,
+            Priority = t.Priority,
+            Labels = t.Labels.ToList(),
+        };
+
+        var ok = new JiraMediationResult
+        {
+            Success = true,
+            Outcome = "Read",
+            Ticket = ticket,
+            TicketKey = ticket?.Key ?? ticketId,
+            CorrelationId = correlationId,
+        };
+        await EmitAsync(JiraEventTypes.TicketReadSuccess, op, tenantId, ticketId, correlationId, null,
+            new { ticketId, found = ticket is not null }, ct).ConfigureAwait(false);
+        return ok;
+    }
+
+    // ===================================================================
+    // Update ticket (status transition + comment)
+    // ===================================================================
+
+    private async Task<JiraMediationResult> UpdateTicketCoreAsync(Guid? tenantId, string ticketId, UpdateTicketRequest body, CancellationToken ct)
+    {
+        var op = JiraEventTypes.TicketUpdateOperation;
+        var update = new JiraTicketUpdate
+        {
+            Status = body.Status,
+            Comment = body.Comment,
+            CustomFields = body.CustomFields,
+        };
+
+        var res = await _jira.UpdateJiraTicketAsync(ticketId, update).ConfigureAwait(false);
+
+        if (!res.Success)
+            return await FailAsync(tenantId, ticketId, op, JiraEventTypes.TicketUpdatedFailed, correlationId: body.CorrelationId, res.Error, ct).ConfigureAwait(false);
+
+        var ok = new JiraMediationResult
+        {
+            Success = true,
+            Outcome = "Updated",
+            TicketKey = res.Data?.TicketKey ?? ticketId,
+            CorrelationId = body.CorrelationId,
+        };
+        await EmitAsync(JiraEventTypes.TicketUpdatedSuccess, op, tenantId, ticketId, body.CorrelationId, null,
+            new { ticketId, status = body.Status }, ct).ConfigureAwait(false);
+        return ok;
+    }
+
+    // ===================================================================
+    // Failure / guarded-envelope shared paths
+    // ===================================================================
+
+    private async Task<JiraMediationResult> FailAsync(
+        Guid? tenantId, string ticketId, string operation, string failedEventType, string correlationId, string? reason, CancellationToken ct)
+    {
+        var failCode = MapFailure(reason);
+        var fail = new JiraMediationResult
+        {
+            Success = false,
+            Outcome = "Error",
+            FailureCode = failCode,
+            FailureReason = reason,
+            TicketKey = ticketId,
+            CorrelationId = correlationId,
+        };
+        await EmitAsync(failedEventType, operation, tenantId, ticketId, correlationId, failCode, new { ticketId }, ct).ConfigureAwait(false);
+        return fail;
+    }
+
+    private async Task<JiraMediationResult> ExecuteGuardedAsync(
+        Guid? tenantId, string ticketId, string operation, string failedEventType, string correlationId,
+        CancellationToken ct, Func<Task<JiraMediationResult>> body)
+    {
+        try
+        {
+            return await body().ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "jira-mediation op {Operation} threw; returning typed PLATFORM_ERROR (never a raw 5xx) with one FAILED event. correlationId={CorrelationId}, ticketId={TicketId}, tenantId={TenantId}",
+                operation, LogSanitizer.Clean(correlationId), LogSanitizer.Clean(ticketId), tenantId);
+
+            await EmitAsync(failedEventType, operation, tenantId, ticketId, correlationId, JiraFailureCodes.PlatformError, new { }, ct).ConfigureAwait(false);
+
+            return new JiraMediationResult
+            {
+                Success = false,
+                Outcome = "Error",
+                FailureCode = JiraFailureCodes.PlatformError,
+                FailureReason = "an unexpected error occurred processing the JIRA operation",
+                TicketKey = ticketId,
+                CorrelationId = correlationId,
+            };
+        }
+    }
+
+    // ===================================================================
+    // DCB audit (exactly one terminal JIRA.* event per call)
+    // ===================================================================
+
+    private async Task EmitAsync(
+        string eventType, string operation, Guid? tenantId, string ticketId, string correlationId,
+        string? failureCode, object data, CancellationToken ct)
+    {
+        try
+        {
+            object tagsObj = failureCode is null
+                ? new { tenantId = tenantId?.ToString(), ticketId, operation, correlationId }
+                : new { tenantId = tenantId?.ToString(), ticketId, operation, correlationId, failureCode };
+
+            await _events.AppendAsync(new DomainEvent
+            {
+                Id = Guid.NewGuid(),
+                Type = eventType,
+                TenantId = tenantId,
+                Tags = JsonSerializer.Serialize(tagsObj),
+                Metadata = JsonSerializer.Serialize(new { workflowVersion = "1.0.0", eventSource = "system" }),
+                Data = JsonSerializer.Serialize(data),
+                CreatedAt = DateTime.UtcNow,
+            }).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "JIRA.* event append failed (type={Type}); the mediation result still returns. correlationId={CorrelationId}, ticketId={TicketId}, tenantId={TenantId}",
+                eventType, LogSanitizer.Clean(correlationId), LogSanitizer.Clean(ticketId), tenantId);
+        }
+    }
+
+    private static string MapFailure(string? reason)
+    {
+        var r = (reason ?? string.Empty).ToLowerInvariant();
+        if (r.Contains("not configured")) return JiraFailureCodes.NotConfigured;
+        if (r.Contains("404") || r.Contains("not found")) return JiraFailureCodes.NotFound;
+        return JiraFailureCodes.PlatformError;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Jira/JiraRequests.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Jira/JiraRequests.cs
@@ -1,0 +1,21 @@
+namespace Tamma.Api.Services.Jira;
+
+// ============================================================
+// Story 38 (Phase 1) — server-side binding records for the JIRA-mediation
+// endpoints. Bound from the engine client's camelCase JSON. JIRA is not
+// repo-scoped (like Slack) — there is no tenant↔repo guard; the acting tenant
+// scopes the audit event only. The JIRA credential lives in Tamma.Api config; the
+// engine holds nothing.
+// ============================================================
+
+/// <summary>
+/// <c>PATCH /api/v1/jira/tickets/{ticketId}</c>. The status/comment are composed
+/// engine-side; the API applies them with the server-side JIRA credential.
+/// </summary>
+public sealed record UpdateTicketRequest
+{
+    public string? Status { get; init; }
+    public string? Comment { get; init; }
+    public Dictionary<string, object>? CustomFields { get; init; }
+    public string CorrelationId { get; init; } = string.Empty;
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Jira/JiraResponses.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Jira/JiraResponses.cs
@@ -1,0 +1,56 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Tamma.Api.Services.Jira;
+
+/// <summary>
+/// Story 38 (Phase 1) — the single normalized, KEY-FREE result the JIRA endpoints
+/// return. The JIRA credential NEVER appears here (nor in any log or DCB event). The
+/// mirroring engine-side wire type is
+/// <c>Tamma.Activities.LlmCall.Models.JiraCallResponse</c>.
+/// </summary>
+public sealed record JiraMediationResult
+{
+    public bool Success { get; init; }
+
+    /// <summary>Operation-specific outcome ("Read" / "Updated" / "Error").</summary>
+    public string? Outcome { get; init; }
+
+    // ── ticket read ──
+    public JiraTicketDto? Ticket { get; init; }
+
+    // ── ticket update ──
+    public string? TicketKey { get; init; }
+
+    // ── failure-only (key-free) ──
+    public string? FailureCode { get; init; }
+    public string? FailureReason { get; init; }
+
+    public string? CorrelationId { get; init; }
+}
+
+/// <summary>A key-free JIRA ticket projection. Mirrors <c>Core.Interfaces.JiraTicket</c>.</summary>
+public sealed record JiraTicketDto
+{
+    public string Id { get; init; } = string.Empty;
+    public string Key { get; init; } = string.Empty;
+    public string Summary { get; init; } = string.Empty;
+    public string? Description { get; init; }
+    public string Status { get; init; } = string.Empty;
+    public string? Assignee { get; init; }
+    public string? Priority { get; init; }
+    public IReadOnlyList<string> Labels { get; init; } = Array.Empty<string>();
+}
+
+/// <summary>
+/// Story 38 (Phase 1) — the HTTP-status decision. JIRA is not repo-scoped and has no
+/// per-tenant token resolver, so every non-success rides inside a 200 success:false
+/// envelope (the workflow branches on the outcome). A raw 5xx is NEVER produced.
+/// </summary>
+public static class JiraMediationResultExtensions
+{
+    public static IResult ToHttpResult(this JiraMediationResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        return Results.Ok(result);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Guardrails.Tests/EngineExternalCallAnalyzerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Guardrails.Tests/EngineExternalCallAnalyzerTests.cs
@@ -122,19 +122,36 @@ public class BadActivity {
     public BadActivity(SlackNet.ISlackApiClient {|TAMMA001:slack|}) { }
 }" + Vendors);
 
+    // ---------- (2b) COMPOSITE IIntegrationService injection → TAMMA001 (Epic 38 Phase 3) --
+    // The composite (and every focused variant) is now DENIED as an engine injection — the
+    // engine reaches those domains only via TammaApiClient. Reintroducing the ctor/field
+    // injection fails the build.
+
+    [Test]
+    public Task CompositeIntegrationService_CtorInjection_Flags() => Verify.Engine(@"
+using Tamma.Core.Interfaces;
+public class BadActivity {
+    public BadActivity(IIntegrationService {|TAMMA001:svc|}) { }
+}" + Vendors);
+
+    [Test]
+    public Task CompositeIntegrationService_FieldInjection_Flags() => Verify.Engine(@"
+using Tamma.Core.Interfaces;
+public class BadActivity {
+    private IIntegrationService? {|TAMMA001:_svc|};
+}" + Vendors);
+
     // ---------- (3) denied Slack SEND invocation → TAMMA001 -----------------------------
-    // Injecting the COMPOSITE IIntegrationService is allowed (no injection diagnostic); only
-    // its Slack send methods are denied at the call site (Correction 2).
+    // The composite is received as a METHOD PARAMETER here (method params are not injection,
+    // so no injection diagnostic) to isolate the call-site Slack-send denial (Correction 2).
 
     [Test]
     public Task SendSlackMessageAsync_Invocation_Flags() => Verify.Engine(@"
 using System.Threading.Tasks;
 using Tamma.Core.Interfaces;
 public class Notifier {
-    private readonly IIntegrationService _svc;
-    public Notifier(IIntegrationService svc) { _svc = svc; }
-    public async Task Ping() {
-        await {|TAMMA001:_svc.SendSlackMessageAsync(""chan"", ""hi"")|};
+    public async Task Ping(IIntegrationService svc) {
+        await {|TAMMA001:svc.SendSlackMessageAsync(""chan"", ""hi"")|};
     }
 }" + Vendors);
 
@@ -143,22 +160,18 @@ public class Notifier {
 using System.Threading.Tasks;
 using Tamma.Core.Interfaces;
 public class Notifier {
-    private readonly IIntegrationService _svc;
-    public Notifier(IIntegrationService svc) { _svc = svc; }
-    public async Task Ping() {
-        await {|TAMMA001:_svc.SendSlackDirectMessageAsync(""U1"", ""hi"")|};
+    public async Task Ping(IIntegrationService svc) {
+        await {|TAMMA001:svc.SendSlackDirectMessageAsync(""U1"", ""hi"")|};
     }
 }" + Vendors);
 
     [Test]
-    public Task CompositeIntegrationService_NonSlackMethod_DoesNotFlag() => Verify.Engine(@"
+    public Task CompositeIntegrationService_NonSlackMethod_ViaMethodParam_DoesNotFlag() => Verify.Engine(@"
 using System.Threading.Tasks;
 using Tamma.Core.Interfaces;
 public class Merger {
-    private readonly IIntegrationService _svc;
-    public Merger(IIntegrationService svc) { _svc = svc; }
-    public async Task Do() {
-        await _svc.MergePullRequestAsync(""o/r"", 5);
+    public async Task Do(IIntegrationService svc) {
+        await svc.MergePullRequestAsync(""o/r"", 5);
     }
 }" + Vendors);
 

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/AI/ContextGatheringActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/AI/ContextGatheringActivityTests.cs
@@ -1,9 +1,11 @@
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
 using Tamma.Activities.AI;
+using Tamma.Activities.LlmCall;
 using Tamma.Core.Interfaces;
 using Tamma.Data.Repositories;
 
@@ -14,7 +16,7 @@ public class ContextGatheringActivityTests
 {
     private Mock<ILogger<ContextGatheringActivity>> _mockLogger = null!;
     private Mock<IMentorshipSessionRepository> _mockRepository = null!;
-    private Mock<IIntegrationService> _mockIntegrationService = null!;
+    private TammaApiClient _apiClient = null!;
     private Mock<IHttpClientFactory> _mockHttpClientFactory = null!;
     private Mock<IConfiguration> _mockConfiguration = null!;
 
@@ -23,7 +25,9 @@ public class ContextGatheringActivityTests
     {
         _mockLogger = new Mock<ILogger<ContextGatheringActivity>>();
         _mockRepository = new Mock<IMentorshipSessionRepository>();
-        _mockIntegrationService = new Mock<IIntegrationService>();
+        // Story 38 (Phase 2): the activity now depends on the thin TammaApiClient, not
+        // the credential-holding composite IIntegrationService.
+        _apiClient = new TammaApiClient(new HttpClient(), NullLogger<TammaApiClient>.Instance, null, null);
         _mockHttpClientFactory = new Mock<IHttpClientFactory>();
         _mockConfiguration = new Mock<IConfiguration>();
     }
@@ -35,7 +39,7 @@ public class ContextGatheringActivityTests
         Action act = () => new ContextGatheringActivity(
             _mockLogger.Object,
             _mockRepository.Object,
-            _mockIntegrationService.Object,
+            _apiClient,
             _mockHttpClientFactory.Object,
             _mockConfiguration.Object);
 

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/CodeReviewActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/CodeReviewActivityTests.cs
@@ -1,7 +1,9 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
+using Tamma.Activities.LlmCall;
 using Tamma.Activities.Mentorship;
 using Tamma.Core.Entities;
 using Tamma.Core.Enums;
@@ -15,7 +17,7 @@ public class CodeReviewActivityTests
 {
     private Mock<ILogger<CodeReviewActivity>> _mockLogger = null!;
     private Mock<IMentorshipSessionRepository> _mockRepository = null!;
-    private Mock<IIntegrationService> _mockIntegrationService = null!;
+    private TammaApiClient _apiClient = null!;
     private Mock<IAnalyticsService> _mockAnalyticsService = null!;
 
     [SetUp]
@@ -23,7 +25,9 @@ public class CodeReviewActivityTests
     {
         _mockLogger = new Mock<ILogger<CodeReviewActivity>>();
         _mockRepository = new Mock<IMentorshipSessionRepository>();
-        _mockIntegrationService = new Mock<IIntegrationService>();
+        // Story 38 (Phase 2): the git reads + PR create now route through the thin
+        // TammaApiClient, not the credential-holding composite IIntegrationService.
+        _apiClient = new TammaApiClient(new HttpClient(), NullLogger<TammaApiClient>.Instance, null, null);
         _mockAnalyticsService = new Mock<IAnalyticsService>();
     }
 
@@ -34,7 +38,7 @@ public class CodeReviewActivityTests
         Action act = () => new CodeReviewActivity(
             _mockLogger.Object,
             _mockRepository.Object,
-            _mockIntegrationService.Object,
+            _apiClient,
             _mockAnalyticsService.Object);
 
         // Assert

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/DiagnoseBlockerActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/DiagnoseBlockerActivityTests.cs
@@ -1,7 +1,9 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
+using Tamma.Activities.LlmCall;
 using Tamma.Activities.Mentorship;
 using Tamma.Core.Entities;
 using Tamma.Core.Enums;
@@ -15,7 +17,11 @@ public class DiagnoseBlockerActivityTests
 {
     private Mock<ILogger<DiagnoseBlockerActivity>> _mockLogger = null!;
     private Mock<IMentorshipSessionRepository> _mockRepository = null!;
-    private Mock<IIntegrationService> _mockIntegrationService = null!;
+    // Story 38 (Phase 2, Batch C): the composite IIntegrationService injection is gone; the
+    // diagnostic git-commit / build-status / test-trigger reads now route through the thin
+    // TammaApiClient. A throwaway real client (HttpClient + NullLogger, never hit) proves the
+    // ctor resolves the thin client.
+    private TammaApiClient _apiClient = null!;
     private Mock<IAnalyticsService> _mockAnalyticsService = null!;
 
     [SetUp]
@@ -23,7 +29,7 @@ public class DiagnoseBlockerActivityTests
     {
         _mockLogger = new Mock<ILogger<DiagnoseBlockerActivity>>();
         _mockRepository = new Mock<IMentorshipSessionRepository>();
-        _mockIntegrationService = new Mock<IIntegrationService>();
+        _apiClient = new TammaApiClient(new HttpClient(), NullLogger<TammaApiClient>.Instance, null, null);
         _mockAnalyticsService = new Mock<IAnalyticsService>();
     }
 
@@ -34,7 +40,7 @@ public class DiagnoseBlockerActivityTests
         Action act = () => new DiagnoseBlockerActivity(
             _mockLogger.Object,
             _mockRepository.Object,
-            _mockIntegrationService.Object,
+            _apiClient,
             _mockAnalyticsService.Object);
 
         // Assert

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Guardrails/ActivitiesGuardrailTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Guardrails/ActivitiesGuardrailTests.cs
@@ -26,15 +26,20 @@ namespace Tamma.Activities.Tests.Guardrails;
 [TestFixture]
 public class ActivitiesGuardrailTests
 {
-    // Independent mirror of the vendor-credential INJECTION denylist (the composite
-    // IIntegrationService is deliberately NOT here — see Allowlist.cs / the story report).
+    // Independent mirror of the vendor-credential INJECTION denylist. Epic 38 Phase 3: the
+    // composite Tamma.Core.Interfaces.IIntegrationService and every focused variant are now
+    // denied as engine injections (the engine reaches those domains only via TammaApiClient).
     private static readonly HashSet<string> Denylist = new(StringComparer.Ordinal)
     {
         "Octokit.IGitHubClient",
         "Octokit.GitHubClient",
         "Tamma.Activities.AgentDispatch.IGitHubActionsClient",
+        "Tamma.Core.Interfaces.IIntegrationService",
         "Tamma.Core.Interfaces.IGitHubIntegrationService",
         "Tamma.Core.Interfaces.ISlackIntegrationService",
+        "Tamma.Core.Interfaces.ICIIntegrationService",
+        "Tamma.Core.Interfaces.IJiraIntegrationService",
+        "Tamma.Core.Interfaces.IEmailIntegrationService",
         "Tamma.Activities.LlmCall.Credentials.IProviderCredentialResolver",
         "SlackNet.ISlackApiClient",
         "Stripe.StripeClient",

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Integration/IntegrationServiceCutoverTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Integration/IntegrationServiceCutoverTests.cs
@@ -1,0 +1,154 @@
+using System.Reflection;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
+using Tamma.Core.Interfaces;
+
+namespace Tamma.Activities.Tests.Integration;
+
+/// <summary>
+/// Story 38 (Phase 2, Batch A) — the eight domain activities that used to read git
+/// commits / file-changes and trigger CI directly via the co-hosted, credential-holding
+/// composite <see cref="IIntegrationService"/> now route through the thin
+/// <see cref="TammaApiClient"/> → the git/CI mediation endpoints (the engine holds no
+/// git token). These tests cover: (1) the wire-response → composite-model projection
+/// (<see cref="GitMediationMapping"/>) so the surrounding workflows are unchanged, and
+/// (2) the per-activity cutover proof — none of the eight injects
+/// <see cref="IIntegrationService"/> via a constructor param or a field.
+/// </summary>
+[TestFixture]
+public class IntegrationServiceCutoverTests
+{
+    // ===================================================================
+    // Wire-response → composite-model mapping (GitMediationMapping)
+    // ===================================================================
+
+    [Test]
+    public void ToCommits_ProjectsAllFields()
+    {
+        var ts = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
+        var commits = GitMediationMapping.ToCommits(new[]
+        {
+            new GitCommitSummaryDto
+            {
+                Sha = "abc", Message = "msg", Author = "dev", Timestamp = ts,
+                Additions = 3, Deletions = 1, Files = new[] { "a.cs", "b.cs" },
+            },
+        });
+
+        commits.Should().HaveCount(1);
+        var c = commits[0];
+        c.Sha.Should().Be("abc");
+        c.Message.Should().Be("msg");
+        c.Author.Should().Be("dev");
+        c.Timestamp.Should().Be(ts);
+        c.Additions.Should().Be(3);
+        c.Deletions.Should().Be(1);
+        c.Files.Should().BeEquivalentTo("a.cs", "b.cs");
+    }
+
+    [Test]
+    public void ToCommits_NullOrEmpty_YieldsEmptyList()
+    {
+        GitMediationMapping.ToCommits(null).Should().BeEmpty();
+        GitMediationMapping.ToCommits(Array.Empty<GitCommitSummaryDto>()).Should().BeEmpty();
+    }
+
+    [Test]
+    public void ToFileChanges_ProjectsAllFields()
+    {
+        var changes = GitMediationMapping.ToFileChanges(new[]
+        {
+            new GitFileChangeDto { FilePath = "src/x.cs", ChangeType = "modified", Additions = 5, Deletions = 2 },
+        });
+
+        changes.Should().HaveCount(1);
+        changes[0].FilePath.Should().Be("src/x.cs");
+        changes[0].ChangeType.Should().Be("modified");
+        changes[0].Additions.Should().Be(5);
+        changes[0].Deletions.Should().Be(2);
+    }
+
+    [Test]
+    public void ToFileChanges_Null_YieldsEmptyList()
+        => GitMediationMapping.ToFileChanges(null).Should().BeEmpty();
+
+    [Test]
+    public void ToTestRun_ProjectsCounts_AndLeavesFailedDetailsEmpty()
+    {
+        var run = GitMediationMapping.ToTestRun(new CiTestRunDto
+        {
+            RunId = "r1", Status = "completed", TotalTests = 10,
+            PassedTests = 8, FailedTests = 2, SkippedTests = 0, CoveragePercentage = 82.5,
+        });
+
+        run.RunId.Should().Be("r1");
+        run.Status.Should().Be("completed");
+        run.TotalTests.Should().Be(10);
+        run.PassedTests.Should().Be(8);
+        run.FailedTests.Should().Be(2);
+        run.CoveragePercentage.Should().Be(82.5);
+        // The CI-mediation endpoint returns aggregate counts only, never per-test detail.
+        run.FailedTestDetails.Should().BeEmpty();
+    }
+
+    [Test]
+    public void ToTestRun_Null_YieldsEmptyResult()
+    {
+        var run = GitMediationMapping.ToTestRun(null);
+        run.TotalTests.Should().Be(0);
+        run.FailedTestDetails.Should().BeEmpty();
+    }
+
+    // ===================================================================
+    // Cutover proof — zero IIntegrationService injections in the eight
+    // ===================================================================
+
+    private static readonly Type[] CutoverActivityTypes =
+    {
+        typeof(Tamma.Activities.Blocker.CollectGitActivityActivity),
+        typeof(Tamma.Activities.Blocker.CollectInactivityActivity),
+        typeof(Tamma.Activities.AI.ContextGatheringActivity),
+        typeof(Tamma.Activities.Integration.GitHubActivity),
+        typeof(Tamma.Activities.Review.CreatePRActivity),
+        typeof(Tamma.Activities.Context.FetchFileContentsActivity),
+        typeof(Tamma.Activities.Context.FetchRecentCommitsActivity),
+        typeof(Tamma.Activities.Mentorship.CodeReviewActivity),
+    };
+
+    [Test]
+    [TestCaseSource(nameof(CutoverActivityTypes))]
+    public void CutoverActivity_InjectsNoIntegrationService(Type activityType)
+    {
+        foreach (var ctor in activityType.GetConstructors())
+        {
+            ctor.GetParameters()
+                .Any(p => IsIntegrationServiceType(p.ParameterType))
+                .Should().BeFalse(
+                    $"{activityType.Name} must not inject the credential-holding IIntegrationService (ctor)");
+        }
+
+        activityType
+            .GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+            .Any(f => IsIntegrationServiceType(f.FieldType))
+            .Should().BeFalse(
+                $"{activityType.Name} must hold no IIntegrationService field after the 38 Phase 2 cutover");
+    }
+
+    [Test]
+    [TestCaseSource(nameof(CutoverActivityTypes))]
+    public void CutoverActivity_InjectsTammaApiClient(Type activityType)
+    {
+        activityType
+            .GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+            .Any(f => typeof(TammaApiClient).IsAssignableFrom(f.FieldType))
+            .Should().BeTrue(
+                $"{activityType.Name} must hold a TammaApiClient field (the mediation thin client)");
+    }
+
+    private static bool IsIntegrationServiceType(Type t) =>
+        typeof(IIntegrationService).IsAssignableFrom(t)
+        || typeof(IGitHubIntegrationService).IsAssignableFrom(t)
+        || typeof(ICIIntegrationService).IsAssignableFrom(t);
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Integration/IntegrationServiceCutoverTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Integration/IntegrationServiceCutoverTests.cs
@@ -127,6 +127,100 @@ public class IntegrationServiceCutoverTests
         status.Error.Should().BeNull();
     }
 
+    // ------- Batch C: merge + JIRA projections -------
+
+    [Test]
+    public void ToMergeResult_Success_ProjectsSha_NoError()
+    {
+        var result = GitMediationMapping.ToMergeResult(new GitCallResponse
+        {
+            Success = true, Merged = true, MergeSha = "sha42",
+        });
+
+        result.Success.Should().BeTrue();
+        result.MergeSha.Should().Be("sha42");
+        result.Error.Should().BeNull();
+    }
+
+    [Test]
+    public void ToMergeResult_Failure_ProjectsError_SoftNotThrow()
+    {
+        var result = GitMediationMapping.ToMergeResult(new GitCallResponse
+        {
+            Success = false, FailureCode = "NOT_MERGEABLE", FailureReason = "closed",
+        });
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Be("closed");
+    }
+
+    [Test]
+    public void ToMergeResult_Null_SoftFailsWithReason()
+    {
+        var result = GitMediationMapping.ToMergeResult(null);
+        result.Success.Should().BeFalse();
+        result.MergeSha.Should().BeNull();
+        result.Error.Should().Be("git mediation endpoint unavailable");
+    }
+
+    [Test]
+    public void ToJiraTicket_ProjectsAllFields()
+    {
+        var ticket = GitMediationMapping.ToJiraTicket(new JiraTicketDto
+        {
+            Id = "10001", Key = "TAMMA-7", Summary = "Do the thing", Description = "desc",
+            Status = "In Progress", Assignee = "dev", Priority = "High",
+            Labels = new[] { "backend", "urgent" },
+        });
+
+        ticket.Should().NotBeNull();
+        ticket!.Id.Should().Be("10001");
+        ticket.Key.Should().Be("TAMMA-7");
+        ticket.Summary.Should().Be("Do the thing");
+        ticket.Description.Should().Be("desc");
+        ticket.Status.Should().Be("In Progress");
+        ticket.Assignee.Should().Be("dev");
+        ticket.Priority.Should().Be("High");
+        ticket.Labels.Should().BeEquivalentTo("backend", "urgent");
+    }
+
+    [Test]
+    public void ToJiraTicket_Null_YieldsNull()
+        => GitMediationMapping.ToJiraTicket(null).Should().BeNull();
+
+    [Test]
+    public void ToJiraTicketResult_Success_ProjectsKey_NoError()
+    {
+        var result = GitMediationMapping.ToJiraTicketResult(new JiraCallResponse
+        {
+            Success = true, TicketKey = "TAMMA-7",
+        });
+
+        result.Success.Should().BeTrue();
+        result.TicketKey.Should().Be("TAMMA-7");
+        result.Error.Should().BeNull();
+    }
+
+    [Test]
+    public void ToJiraTicketResult_Failure_ProjectsError_SoftNotThrow()
+    {
+        var result = GitMediationMapping.ToJiraTicketResult(new JiraCallResponse
+        {
+            Success = false, FailureCode = "JIRA_403", FailureReason = "forbidden",
+        });
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Be("forbidden");
+    }
+
+    [Test]
+    public void ToJiraTicketResult_Null_SoftFailsWithReason()
+    {
+        var result = GitMediationMapping.ToJiraTicketResult(null);
+        result.Success.Should().BeFalse();
+        result.Error.Should().Be("jira mediation endpoint unavailable");
+    }
+
     // ===================================================================
     // Cutover proof — zero IIntegrationService injections in the eight
     // ===================================================================
@@ -152,6 +246,13 @@ public class IntegrationServiceCutoverTests
         typeof(Tamma.Activities.Mentorship.MonitorImplementationActivity),
         typeof(Tamma.Activities.Context.FetchSimilarPatternsActivity),
         typeof(Tamma.Activities.Blocker.CollectCommunicationActivity),
+        // Batch C (6) — JIRA / email / merge / diagnostic reads mediated
+        typeof(Tamma.Activities.Integration.JiraActivity),
+        typeof(Tamma.Activities.Integration.EmailActivity),
+        typeof(Tamma.Activities.Mentorship.MergeCompleteActivity),
+        typeof(Tamma.Activities.Assessment.DeliverQuestionsActivity),
+        typeof(Tamma.Activities.Mentorship.DiagnoseBlockerActivity),
+        typeof(Tamma.Activities.Review.MergeAndCompleteReviewActivity),
     };
 
     /// <summary>
@@ -178,6 +279,13 @@ public class IntegrationServiceCutoverTests
         typeof(Tamma.Activities.Debug.CollectRelevantCodeActivity),
         typeof(Tamma.Activities.Mentorship.QualityGateCheckActivity),
         typeof(Tamma.Activities.Mentorship.MonitorImplementationActivity),
+        // Batch C (6) — all mediate a JIRA / email / git-merge / CI read via the thin client
+        typeof(Tamma.Activities.Integration.JiraActivity),
+        typeof(Tamma.Activities.Integration.EmailActivity),
+        typeof(Tamma.Activities.Mentorship.MergeCompleteActivity),
+        typeof(Tamma.Activities.Assessment.DeliverQuestionsActivity),
+        typeof(Tamma.Activities.Mentorship.DiagnoseBlockerActivity),
+        typeof(Tamma.Activities.Review.MergeAndCompleteReviewActivity),
     };
 
     [Test]
@@ -213,5 +321,7 @@ public class IntegrationServiceCutoverTests
     private static bool IsIntegrationServiceType(Type t) =>
         typeof(IIntegrationService).IsAssignableFrom(t)
         || typeof(IGitHubIntegrationService).IsAssignableFrom(t)
-        || typeof(ICIIntegrationService).IsAssignableFrom(t);
+        || typeof(ICIIntegrationService).IsAssignableFrom(t)
+        || typeof(IJiraIntegrationService).IsAssignableFrom(t)
+        || typeof(IEmailIntegrationService).IsAssignableFrom(t);
 }

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Integration/IntegrationServiceCutoverTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Integration/IntegrationServiceCutoverTests.cs
@@ -101,11 +101,67 @@ public class IntegrationServiceCutoverTests
         run.FailedTestDetails.Should().BeEmpty();
     }
 
+    [Test]
+    public void ToBuildStatus_ProjectsFields_AndLeavesErrorNull()
+    {
+        var started = new DateTime(2026, 7, 1, 10, 0, 0, DateTimeKind.Utc);
+        var finished = new DateTime(2026, 7, 1, 10, 5, 0, DateTimeKind.Utc);
+        var status = GitMediationMapping.ToBuildStatus(new CiBuildStatusDto
+        {
+            Status = "Success", BuildUrl = "https://ci/run/1", StartedAt = started, FinishedAt = finished,
+        });
+
+        status.Status.Should().Be("Success");
+        status.BuildUrl.Should().Be("https://ci/run/1");
+        status.StartedAt.Should().Be(started);
+        status.FinishedAt.Should().Be(finished);
+        // The CI-mediation build-status DTO carries no Error field — Error stays null.
+        status.Error.Should().BeNull();
+    }
+
+    [Test]
+    public void ToBuildStatus_Null_YieldsEmptyStatus()
+    {
+        var status = GitMediationMapping.ToBuildStatus(null);
+        status.Status.Should().BeEmpty();
+        status.Error.Should().BeNull();
+    }
+
     // ===================================================================
     // Cutover proof — zero IIntegrationService injections in the eight
     // ===================================================================
 
     private static readonly Type[] CutoverActivityTypes =
+    {
+        // Batch A (8)
+        typeof(Tamma.Activities.Blocker.CollectGitActivityActivity),
+        typeof(Tamma.Activities.Blocker.CollectInactivityActivity),
+        typeof(Tamma.Activities.AI.ContextGatheringActivity),
+        typeof(Tamma.Activities.Integration.GitHubActivity),
+        typeof(Tamma.Activities.Review.CreatePRActivity),
+        typeof(Tamma.Activities.Context.FetchFileContentsActivity),
+        typeof(Tamma.Activities.Context.FetchRecentCommitsActivity),
+        typeof(Tamma.Activities.Mentorship.CodeReviewActivity),
+        // Batch B (9) — 7 mediated + 2 dead-injection removals
+        typeof(Tamma.Activities.Blocker.CollectCIStatusActivity),
+        typeof(Tamma.Activities.Context.FetchTestResultsActivity),
+        typeof(Tamma.Activities.Debug.CollectGitHistoryActivity),
+        typeof(Tamma.Activities.Debug.CollectTestResultsActivity),
+        typeof(Tamma.Activities.Debug.CollectRelevantCodeActivity),
+        typeof(Tamma.Activities.Mentorship.QualityGateCheckActivity),
+        typeof(Tamma.Activities.Mentorship.MonitorImplementationActivity),
+        typeof(Tamma.Activities.Context.FetchSimilarPatternsActivity),
+        typeof(Tamma.Activities.Blocker.CollectCommunicationActivity),
+    };
+
+    /// <summary>
+    /// The subset that actively mediates a git/CI read through the thin client — these
+    /// must hold a <see cref="TammaApiClient"/> field. Excludes
+    /// <c>FetchSimilarPatternsActivity</c> and <c>CollectCommunicationActivity</c>, whose
+    /// composite injection was DEAD (no call site) and was removed outright without
+    /// adding a mediation client.
+    /// </summary>
+    private static readonly Type[] MediatedActivityTypes =
     {
         typeof(Tamma.Activities.Blocker.CollectGitActivityActivity),
         typeof(Tamma.Activities.Blocker.CollectInactivityActivity),
@@ -115,6 +171,13 @@ public class IntegrationServiceCutoverTests
         typeof(Tamma.Activities.Context.FetchFileContentsActivity),
         typeof(Tamma.Activities.Context.FetchRecentCommitsActivity),
         typeof(Tamma.Activities.Mentorship.CodeReviewActivity),
+        typeof(Tamma.Activities.Blocker.CollectCIStatusActivity),
+        typeof(Tamma.Activities.Context.FetchTestResultsActivity),
+        typeof(Tamma.Activities.Debug.CollectGitHistoryActivity),
+        typeof(Tamma.Activities.Debug.CollectTestResultsActivity),
+        typeof(Tamma.Activities.Debug.CollectRelevantCodeActivity),
+        typeof(Tamma.Activities.Mentorship.QualityGateCheckActivity),
+        typeof(Tamma.Activities.Mentorship.MonitorImplementationActivity),
     };
 
     [Test]
@@ -137,7 +200,7 @@ public class IntegrationServiceCutoverTests
     }
 
     [Test]
-    [TestCaseSource(nameof(CutoverActivityTypes))]
+    [TestCaseSource(nameof(MediatedActivityTypes))]
     public void CutoverActivity_InjectsTammaApiClient(Type activityType)
     {
         activityType

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Integration/SlackCallerCutoverTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Integration/SlackCallerCutoverTests.cs
@@ -138,14 +138,17 @@ public class SlackCallerCutoverTests
         typeof(Tamma.Activities.Blocker.EscalateToSeniorActivity),
     };
 
-    // The five activities that ALSO use IIntegrationService for non-Slack work
-    // (GitHub merge/PR, CI status, JIRA, email) — they legitimately retain it; the
+    // The activities that ALSO use IIntegrationService for non-Slack work (GitHub
+    // merge/PR, CI status, JIRA, email) — they legitimately retain it; the 38-3b
     // cutover removed only their Slack calls (proved by the drift guard below).
+    //
+    // NOTE: CodeReviewActivity was in this list until Story 38 Phase 2 (Batch A) cut its
+    // git reads + PR create over to the thin TammaApiClient — it now holds NO
+    // IIntegrationService and is covered by IntegrationServiceCutoverTests instead.
     private static readonly Type[] NonSlackRetainers =
     {
         typeof(Tamma.Activities.Mentorship.MergeCompleteActivity),
         typeof(Tamma.Activities.Mentorship.DiagnoseBlockerActivity),
-        typeof(Tamma.Activities.Mentorship.CodeReviewActivity),
         typeof(Tamma.Activities.Review.MergeAndCompleteReviewActivity),
         typeof(Tamma.Activities.Assessment.DeliverQuestionsActivity),
     };

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Integration/SlackCallerCutoverTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Integration/SlackCallerCutoverTests.cs
@@ -138,20 +138,13 @@ public class SlackCallerCutoverTests
         typeof(Tamma.Activities.Blocker.EscalateToSeniorActivity),
     };
 
-    // The activities that ALSO use IIntegrationService for non-Slack work (GitHub
-    // merge/PR, CI status, JIRA, email) — they legitimately retain it; the 38-3b
-    // cutover removed only their Slack calls (proved by the drift guard below).
-    //
-    // NOTE: CodeReviewActivity was in this list until Story 38 Phase 2 (Batch A) cut its
-    // git reads + PR create over to the thin TammaApiClient — it now holds NO
-    // IIntegrationService and is covered by IntegrationServiceCutoverTests instead.
-    private static readonly Type[] NonSlackRetainers =
-    {
-        typeof(Tamma.Activities.Mentorship.MergeCompleteActivity),
-        typeof(Tamma.Activities.Mentorship.DiagnoseBlockerActivity),
-        typeof(Tamma.Activities.Review.MergeAndCompleteReviewActivity),
-        typeof(Tamma.Activities.Assessment.DeliverQuestionsActivity),
-    };
+    // NOTE: the four "non-Slack retainer" activities (MergeCompleteActivity,
+    // DiagnoseBlockerActivity, MergeAndCompleteReviewActivity, DeliverQuestionsActivity) that
+    // still held IIntegrationService for GitHub / CI / JIRA / email after 38-3b were fully cut
+    // over to the thin TammaApiClient in Story 38 Phase 2 (Batch C). They now inject NO
+    // IIntegrationService and are covered by IntegrationServiceCutoverTests instead — so the
+    // former NonSlackRetainer_KeepsIntegrationService assertion was removed (no engine activity
+    // retains the composite after Batch C).
 
     [Test]
     [TestCaseSource(nameof(SlackOnlyActivities))]
@@ -170,19 +163,6 @@ public class SlackCallerCutoverTests
             .Any(f => IsIntegrationServiceType(f.FieldType))
             .Should().BeFalse(
                 $"{activityType.Name} must hold no Slack-credential integration-service field");
-    }
-
-    [Test]
-    [TestCaseSource(nameof(NonSlackRetainers))]
-    public void NonSlackRetainer_KeepsIntegrationService_ForNonSlackUse(Type activityType)
-    {
-        var hasField = activityType
-            .GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
-            .Any(f => IsIntegrationServiceType(f.FieldType));
-
-        hasField.Should().BeTrue(
-            $"{activityType.Name} still uses IIntegrationService for non-Slack work (GitHub / CI / JIRA / "
-            + "email); the cutover removed only its Slack calls");
     }
 
     private static bool IsIntegrationServiceType(Type t) =>

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/MergeCompleteActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/MergeCompleteActivityTests.cs
@@ -1,7 +1,9 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
+using Tamma.Activities.LlmCall;
 using Tamma.Activities.Mentorship;
 using Tamma.Core.Entities;
 using Tamma.Core.Enums;
@@ -15,7 +17,10 @@ public class MergeCompleteActivityTests
 {
     private Mock<ILogger<MergeCompleteActivity>> _mockLogger = null!;
     private Mock<IMentorshipSessionRepository> _mockRepository = null!;
-    private Mock<IIntegrationService> _mockIntegrationService = null!;
+    // Story 38 (Phase 2, Batch C): the composite IIntegrationService injection is gone;
+    // the merge + JIRA update now route through the thin TammaApiClient. A throwaway real
+    // client (HttpClient + NullLogger, never hit) proves the ctor resolves the thin client.
+    private TammaApiClient _apiClient = null!;
     private Mock<IAnalyticsService> _mockAnalyticsService = null!;
 
     [SetUp]
@@ -23,7 +28,7 @@ public class MergeCompleteActivityTests
     {
         _mockLogger = new Mock<ILogger<MergeCompleteActivity>>();
         _mockRepository = new Mock<IMentorshipSessionRepository>();
-        _mockIntegrationService = new Mock<IIntegrationService>();
+        _apiClient = new TammaApiClient(new HttpClient(), NullLogger<TammaApiClient>.Instance, null, null);
         _mockAnalyticsService = new Mock<IAnalyticsService>();
     }
 
@@ -34,7 +39,7 @@ public class MergeCompleteActivityTests
         Action act = () => new MergeCompleteActivity(
             _mockLogger.Object,
             _mockRepository.Object,
-            _mockIntegrationService.Object,
+            _apiClient,
             _mockAnalyticsService.Object);
 
         // Assert

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Ci/CiEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Ci/CiEndpointsTests.cs
@@ -1,0 +1,235 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using Tamma.Api.Auth;
+using Tamma.Api.Services.Ci;
+using Tamma.Api.Tests.Infrastructure;
+using Tamma.Data;
+
+namespace Tamma.Api.Tests.Ci;
+
+/// <summary>
+/// Story 38 (Phase 1) — HTTP tests for the CI-mediation endpoints. Same engine-only
+/// plane as <c>/api/v1/git/...</c>: missing/invalid bearer ⇒ 401, a user JWT ⇒ 403
+/// (both BEFORE the handler); the acting tenant comes from <see cref="ITenantContext"/>
+/// (never the body/route); the <c>ToHttpResult</c> mapping (200 / 200 success:false /
+/// 403 / 503) holds.
+/// </summary>
+[TestFixture]
+public class CiEndpointsTests
+{
+    private const string TestBearer = "engine-callback-token";
+    private const string UserBearer = "tenant-user-token";
+    private const string TriggerRoute = "/api/v1/ci/acme/widgets/test-runs";
+
+    private WebApplicationFactory<Program> _factory = null!;
+    private CapturingCiMediationService _ci = null!;
+    private StubTenantContext _tenantContext = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _ci = new CapturingCiMediationService();
+        _tenantContext = new StubTenantContext();
+
+        _factory = ApiTestFixture.Factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Development");
+            builder.DisableAlertHostedServices();
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<ICiMediationService>();
+                services.AddSingleton<ICiMediationService>(_ci);
+
+                services.RemoveAll<ITenantContext>();
+                services.AddScoped<ITenantContext>(_ => _tenantContext);
+
+                services.AddAuthentication(TestEngineAuthHandler.SchemeName)
+                    .AddScheme<AuthenticationSchemeOptions, TestEngineAuthHandler>(TestEngineAuthHandler.SchemeName, _ => { });
+
+                services.AddHttpContextAccessor();
+                services.AddSingleton<IAuthorizationHandler, ServicePrincipalHandler>();
+
+                services.AddAuthorization(options =>
+                {
+                    options.DefaultPolicy = new AuthorizationPolicyBuilder()
+                        .AddAuthenticationSchemes(TestEngineAuthHandler.SchemeName)
+                        .RequireAuthenticatedUser().Build();
+                    options.AddPolicy("EngineServiceOnly", p =>
+                    {
+                        p.AddAuthenticationSchemes(TestEngineAuthHandler.SchemeName);
+                        p.RequireAuthenticatedUser();
+                        p.AddRequirements(new ServicePrincipalRequirement());
+                    });
+                });
+            });
+        });
+    }
+
+    [TearDown]
+    public void TearDown() => _factory?.Dispose();
+
+    private HttpClient AuthedClient()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", TestBearer);
+        return client;
+    }
+
+    private static object TriggerBody() => new { branch = "feature", correlationId = "wf-1" };
+
+    [Test]
+    public async Task Post_NoBearer_Returns401_HandlerNotReached()
+    {
+        using var client = _factory.CreateClient();
+        var resp = await client.PostAsJsonAsync(TriggerRoute, TriggerBody());
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        _ci.LastRepo.Should().BeNull();
+    }
+
+    [Test]
+    public async Task Post_NonEnginePrincipal_Returns403_HandlerNotReached()
+    {
+        using var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", UserBearer);
+        var resp = await client.PostAsJsonAsync(TriggerRoute, TriggerBody());
+        resp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        _ci.LastRepo.Should().BeNull();
+    }
+
+    [Test]
+    public async Task Post_ValidBearer_ReconstructsRepo_DerivesTenantFromContext()
+    {
+        var tenant = Guid.NewGuid();
+        _tenantContext.SetTenantId(tenant);
+        _ci.Next = new CiMediationResult { Success = true, Outcome = "Triggered", CredentialSource = "byok" };
+
+        using var client = AuthedClient();
+        client.DefaultRequestHeaders.Add("X-Tenant-Id", tenant.ToString());
+        var resp = await client.PostAsJsonAsync(TriggerRoute, TriggerBody());
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        _ci.LastRepo.Should().Be("acme/widgets");
+        _ci.LastTenantId.Should().Be(tenant);
+    }
+
+    [Test]
+    public async Task Post_ExpectedPlatformFailure_Returns200SuccessFalse()
+    {
+        _ci.Next = new CiMediationResult { Success = false, Outcome = "Error", FailureCode = CiFailureCodes.PlatformError, PlatformStatusCode = 403 };
+        using var client = AuthedClient();
+        var resp = await client.PostAsJsonAsync(TriggerRoute, TriggerBody());
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        ((int)resp.StatusCode).Should().BeLessThan(500);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("success").GetBoolean().Should().BeFalse();
+    }
+
+    [Test]
+    public async Task Post_RepoNotAuthorized_Returns403()
+    {
+        _ci.Next = new CiMediationResult { Success = false, FailureCode = CiFailureCodes.RepoNotAuthorized };
+        using var client = AuthedClient();
+        var resp = await client.PostAsJsonAsync(TriggerRoute, TriggerBody());
+        resp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Test]
+    public async Task Post_TokenUnavailable_Returns503()
+    {
+        _ci.Next = new CiMediationResult { Success = false, FailureCode = CiFailureCodes.TokenUnavailable };
+        using var client = AuthedClient();
+        var resp = await client.PostAsJsonAsync(TriggerRoute, TriggerBody());
+        resp.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+    }
+
+    [Test]
+    public async Task Get_BuildStatus_Success_Returns200()
+    {
+        _ci.Next = new CiMediationResult { Success = true, Outcome = "Read", BuildStatus = new CiBuildStatusDto { Status = "success" } };
+        using var client = AuthedClient();
+        var resp = await client.GetAsync("/api/v1/ci/acme/widgets/build-status?branch=feature&correlationId=wf-2");
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        _ci.LastRepo.Should().Be("acme/widgets");
+    }
+
+    private sealed class CapturingCiMediationService : ICiMediationService
+    {
+        public Guid? LastTenantId { get; private set; }
+        public string? LastRepo { get; private set; }
+        public CiMediationResult? Next { get; set; }
+
+        public Task<CiMediationResult> TriggerTestsAsync(Guid? tenantId, string repo, TriggerTestsRequest body, CancellationToken ct = default)
+        {
+            LastTenantId = tenantId; LastRepo = repo;
+            return Task.FromResult(Next ?? new CiMediationResult { Success = true, Outcome = "Triggered" });
+        }
+
+        public Task<CiMediationResult> GetBuildStatusAsync(Guid? tenantId, string repo, string branch, string correlationId, CancellationToken ct = default)
+        {
+            LastTenantId = tenantId; LastRepo = repo;
+            return Task.FromResult(Next ?? new CiMediationResult { Success = true, Outcome = "Read" });
+        }
+    }
+
+    private sealed class StubTenantContext : ITenantContext
+    {
+        private Guid? _tenantId;
+        public Guid? TenantId => _tenantId;
+        public void SetTenantId(Guid tenantId) => _tenantId = tenantId;
+        public void ClearTenantId() => _tenantId = null;
+    }
+
+    private sealed class TestEngineAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    {
+        public const string SchemeName = "TestEngine";
+
+        public TestEngineAuthHandler(
+            IOptionsMonitor<AuthenticationSchemeOptions> options,
+            Microsoft.Extensions.Logging.ILoggerFactory logger,
+            UrlEncoder encoder)
+            : base(options, logger, encoder) { }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (!Request.Headers.TryGetValue("Authorization", out var header))
+                return Task.FromResult(AuthenticateResult.NoResult());
+            var value = header.ToString();
+            if (!value.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+                return Task.FromResult(AuthenticateResult.NoResult());
+            var token = value["Bearer ".Length..].Trim();
+
+            if (string.Equals(token, TestBearer, StringComparison.Ordinal))
+            {
+                Context.SetAuthPrincipal(new ServiceAuthPrincipal(
+                    KeyId: Guid.NewGuid(), ServiceName: "tamma-engine", Permissions: Array.Empty<string>(), TenantId: null));
+                var identity = new ClaimsIdentity(
+                    new[] { new Claim(ClaimTypes.NameIdentifier, "tamma-engine"), new Claim("scope", "service") }, SchemeName);
+                return Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName)));
+            }
+
+            if (string.Equals(token, UserBearer, StringComparison.Ordinal))
+            {
+                var identity = new ClaimsIdentity(
+                    new[] { new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()), new Claim("role", "owner") }, SchemeName);
+                return Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName)));
+            }
+
+            return Task.FromResult(AuthenticateResult.Fail("Invalid token"));
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Ci/CiMediationServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Ci/CiMediationServiceTests.cs
@@ -1,0 +1,201 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.Ci;
+using Tamma.Api.Services.Git;
+using Tamma.Core.Interfaces;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Ci;
+
+/// <summary>
+/// Story 38 (Phase 1) — <see cref="CiMediationService"/> composition (guard → token →
+/// CI-with-resolved-token → one DCB event). Mirrors the git-mediation tests: the
+/// guard runs FIRST (deny ⇒ no token resolved, CI never invoked), the resolved token
+/// is the one minted into the client, an expected platform failure rides inside
+/// success:false, the 503 token-unavailable path, and the resolved token never leaks
+/// into the result or the audit event.
+/// </summary>
+[TestFixture]
+public class CiMediationServiceTests
+{
+    private const string SecretToken = "ghp-CI-SUPER-SECRET-DO-NOT-LEAK-1234567890";
+    private const string Repo = "acme/widgets";
+
+    private Mock<IGitRepoAuthorizer> _authorizer = null!;
+    private Mock<IGitTokenResolver> _tokenResolver = null!;
+    private Mock<ICiClientFactory> _factory = null!;
+    private Mock<ICIIntegrationService> _ci = null!;
+    private RecordingEventRepository _events = null!;
+    private CiMediationService _sut = null!;
+    private readonly Guid _tenant = Guid.NewGuid();
+
+    [SetUp]
+    public void SetUp()
+    {
+        _authorizer = new Mock<IGitRepoAuthorizer>(MockBehavior.Strict);
+        _tokenResolver = new Mock<IGitTokenResolver>(MockBehavior.Strict);
+        _factory = new Mock<ICiClientFactory>(MockBehavior.Strict);
+        _ci = new Mock<ICIIntegrationService>(MockBehavior.Loose);
+        _events = new RecordingEventRepository();
+
+        _factory.Setup(f => f.Create(It.IsAny<string>())).Returns(_ci.Object);
+
+        _sut = new CiMediationService(
+            _authorizer.Object, _tokenResolver.Object, _factory.Object, _events,
+            NullLogger<CiMediationService>.Instance);
+    }
+
+    private void Allow() => _authorizer
+        .Setup(a => a.AuthorizeAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(GitRepoAuthorization.Allow());
+
+    private void Deny() => _authorizer
+        .Setup(a => a.AuthorizeAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(GitRepoAuthorization.Deny("not authorized"));
+
+    private void ResolveToken(string source) => _tokenResolver
+        .Setup(t => t.ResolveAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new GitTokenResolution(SecretToken, source));
+
+    private void NoToken() => _tokenResolver
+        .Setup(t => t.ResolveAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync((GitTokenResolution?)null);
+
+    private static TriggerTestsRequest TriggerBody() => new() { Branch = "feature", CorrelationId = "corr-ci" };
+
+    [Test]
+    public async Task TriggerTests_GuardDenied_403_NoTokenResolved_CiNeverCalled()
+    {
+        Deny();
+
+        var result = await _sut.TriggerTestsAsync(_tenant, Repo, TriggerBody());
+
+        result.Success.Should().BeFalse();
+        result.FailureCode.Should().Be(CiFailureCodes.RepoNotAuthorized);
+        result.CredentialSource.Should().BeNull();
+
+        _tokenResolver.Verify(t => t.ResolveAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _factory.Verify(f => f.Create(It.IsAny<string>()), Times.Never);
+        _ci.VerifyNoOtherCalls();
+
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(CiEventTypes.TestsTriggeredFailed);
+    }
+
+    [Test]
+    public async Task TriggerTests_Success_Byok_UsesResolvedToken_OneSuccessEvent()
+    {
+        Allow();
+        ResolveToken(GitCredentialSources.Byok);
+        _ci.Setup(c => c.TriggerTestsAsync(Repo, "feature"))
+            .ReturnsAsync(IntegrationResult<TestRunResult>.Ok(new TestRunResult { RunId = "42", Status = "success", TotalTests = 10 }));
+
+        var result = await _sut.TriggerTestsAsync(_tenant, Repo, TriggerBody());
+
+        result.Success.Should().BeTrue();
+        result.Outcome.Should().Be("Triggered");
+        result.TestRun!.RunId.Should().Be("42");
+        result.CredentialSource.Should().Be(GitCredentialSources.Byok);
+        _factory.Verify(f => f.Create(SecretToken), Times.Once, "the token USED == the token RESOLVED");
+
+        var evt = _events.Appended.Should().ContainSingle().Subject;
+        evt.Type.Should().Be(CiEventTypes.TestsTriggeredSuccess);
+        evt.TenantId.Should().Be(_tenant);
+    }
+
+    [Test]
+    public async Task GetBuildStatus_Success_Platform_StampsPlatformSource()
+    {
+        Allow();
+        ResolveToken(GitCredentialSources.Platform);
+        _ci.Setup(c => c.GetBuildStatusAsync(Repo, "feature"))
+            .ReturnsAsync(IntegrationResult<BuildStatus>.Ok(new BuildStatus { Status = "success", BuildUrl = "u" }));
+
+        var result = await _sut.GetBuildStatusAsync(_tenant, Repo, "feature", "corr-b");
+
+        result.Success.Should().BeTrue();
+        result.Outcome.Should().Be("Read");
+        result.BuildStatus!.Status.Should().Be("success");
+        result.CredentialSource.Should().Be(GitCredentialSources.Platform);
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(CiEventTypes.BuildStatusReadSuccess);
+    }
+
+    [Test]
+    public async Task TriggerTests_TokenUnavailable_503_FailClosed_CiNeverCalled()
+    {
+        Allow();
+        NoToken();
+
+        var result = await _sut.TriggerTestsAsync(_tenant, Repo, TriggerBody());
+
+        result.Success.Should().BeFalse();
+        result.FailureCode.Should().Be(CiFailureCodes.TokenUnavailable);
+        _factory.Verify(f => f.Create(It.IsAny<string>()), Times.Never);
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(CiEventTypes.TestsTriggeredFailed);
+    }
+
+    [Test]
+    public async Task GetBuildStatus_PlatformFailure_200SuccessFalse_PreservesStatus()
+    {
+        Allow();
+        ResolveToken(GitCredentialSources.Platform);
+        _ci.Setup(c => c.GetBuildStatusAsync(Repo, "feature"))
+            .ReturnsAsync(IntegrationResult<BuildStatus>.Fail("403: forbidden"));
+
+        var result = await _sut.GetBuildStatusAsync(_tenant, Repo, "feature", "corr-b");
+
+        result.Success.Should().BeFalse();
+        result.FailureCode.Should().Be(CiFailureCodes.PlatformError);
+        result.PlatformStatusCode.Should().Be(403);
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(CiEventTypes.BuildStatusReadFailed);
+    }
+
+    [Test]
+    public async Task CiThrows_TypedPlatformError_OneFailedEvent()
+    {
+        Allow();
+        ResolveToken(GitCredentialSources.Byok);
+        _ci.Setup(c => c.TriggerTestsAsync(Repo, "feature")).ThrowsAsync(new InvalidOperationException("boom"));
+
+        var result = await _sut.TriggerTestsAsync(_tenant, Repo, TriggerBody());
+
+        result.Success.Should().BeFalse();
+        result.FailureCode.Should().Be(CiFailureCodes.PlatformError);
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(CiEventTypes.TestsTriggeredFailed);
+    }
+
+    [Test]
+    public async Task CredentialSafety_ResolvedToken_NeverLeaks()
+    {
+        Allow();
+        ResolveToken(GitCredentialSources.Byok);
+        _ci.Setup(c => c.TriggerTestsAsync(Repo, "feature"))
+            .ReturnsAsync(IntegrationResult<TestRunResult>.Ok(new TestRunResult { RunId = "1", Status = "success" }));
+
+        var result = await _sut.TriggerTestsAsync(_tenant, Repo, TriggerBody());
+
+        JsonSerializer.Serialize(result).Should().NotContain(SecretToken);
+        foreach (var evt in _events.Appended)
+        {
+            (evt.Tags + evt.Data + evt.Metadata).Should().NotContain(SecretToken);
+        }
+    }
+
+    private sealed class RecordingEventRepository : IEventRepository
+    {
+        public ConcurrentBag<DomainEvent> Appended { get; } = new();
+        public Task<DomainEvent> AppendAsync(DomainEvent evt) { Appended.Add(evt); return Task.FromResult(evt); }
+        public Task<DomainEvent?> GetByIdAsync(Guid id) => Task.FromResult<DomainEvent?>(null);
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit) => Task.FromResult(new List<DomainEvent>());
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type) => Task.FromResult<DomainEvent?>(null);
+        public Task ClearAsync(Guid tenantId) => Task.CompletedTask;
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(Guid? tenantId, string? type, int? issueNumber, int limit, int offset)
+            => Task.FromResult(((IReadOnlyList<DomainEvent>)new List<DomainEvent>(), 0));
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(Guid tenantId, string? typePrefix, int limit, int offset)
+            => Task.FromResult(((IReadOnlyList<DomainEvent>)new List<DomainEvent>(), 0));
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/EmailMediation/EmailEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/EmailMediation/EmailEndpointsTests.cs
@@ -1,0 +1,201 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using Tamma.Api.Auth;
+using Tamma.Api.Services.EmailMediation;
+using Tamma.Api.Tests.Infrastructure;
+using Tamma.Data;
+
+namespace Tamma.Api.Tests.EmailMediation;
+
+/// <summary>
+/// Story 38 (Phase 1) — HTTP tests for the email-mediation endpoint
+/// (<c>POST /api/v1/notifications/email</c>). Same engine-only plane as the Slack
+/// notification: missing/invalid bearer ⇒ 401, a user JWT ⇒ 403; the acting tenant
+/// comes from <see cref="ITenantContext"/>; a fail-soft result rides inside 200
+/// success:false (never a raw 5xx).
+/// </summary>
+[TestFixture]
+public class EmailEndpointsTests
+{
+    private const string TestBearer = "engine-callback-token";
+    private const string UserBearer = "tenant-user-token";
+    private const string Route = "/api/v1/notifications/email";
+
+    private WebApplicationFactory<Program> _factory = null!;
+    private CapturingEmailMediationService _email = null!;
+    private StubTenantContext _tenantContext = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _email = new CapturingEmailMediationService();
+        _tenantContext = new StubTenantContext();
+
+        _factory = ApiTestFixture.Factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Development");
+            builder.DisableAlertHostedServices();
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<IEmailMediationService>();
+                services.AddSingleton<IEmailMediationService>(_email);
+
+                services.RemoveAll<ITenantContext>();
+                services.AddScoped<ITenantContext>(_ => _tenantContext);
+
+                services.AddAuthentication(TestEngineAuthHandler.SchemeName)
+                    .AddScheme<AuthenticationSchemeOptions, TestEngineAuthHandler>(TestEngineAuthHandler.SchemeName, _ => { });
+
+                services.AddHttpContextAccessor();
+                services.AddSingleton<IAuthorizationHandler, ServicePrincipalHandler>();
+
+                services.AddAuthorization(options =>
+                {
+                    options.DefaultPolicy = new AuthorizationPolicyBuilder()
+                        .AddAuthenticationSchemes(TestEngineAuthHandler.SchemeName)
+                        .RequireAuthenticatedUser().Build();
+                    options.AddPolicy("EngineServiceOnly", p =>
+                    {
+                        p.AddAuthenticationSchemes(TestEngineAuthHandler.SchemeName);
+                        p.RequireAuthenticatedUser();
+                        p.AddRequirements(new ServicePrincipalRequirement());
+                    });
+                });
+            });
+        });
+    }
+
+    [TearDown]
+    public void TearDown() => _factory?.Dispose();
+
+    private HttpClient AuthedClient()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", TestBearer);
+        return client;
+    }
+
+    private static object EmailBody() => new { to = "dev@example.com", subject = "s", body = "b", correlationId = "wf-1" };
+
+    [Test]
+    public async Task Post_NoBearer_Returns401_HandlerNotReached()
+    {
+        using var client = _factory.CreateClient();
+        var resp = await client.PostAsJsonAsync(Route, EmailBody());
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        _email.LastTo.Should().BeNull();
+    }
+
+    [Test]
+    public async Task Post_NonEnginePrincipal_Returns403_HandlerNotReached()
+    {
+        using var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", UserBearer);
+        var resp = await client.PostAsJsonAsync(Route, EmailBody());
+        resp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        _email.LastTo.Should().BeNull();
+    }
+
+    [Test]
+    public async Task Post_ValidBearer_DerivesTenant_Returns200()
+    {
+        var tenant = Guid.NewGuid();
+        _tenantContext.SetTenantId(tenant);
+        _email.Next = new EmailMediationResult { Success = true, Outcome = "Queued", TxnId = Guid.NewGuid() };
+
+        using var client = AuthedClient();
+        client.DefaultRequestHeaders.Add("X-Tenant-Id", tenant.ToString());
+        var resp = await client.PostAsJsonAsync(Route, EmailBody());
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        _email.LastTo.Should().Be("dev@example.com");
+        _email.LastTenantId.Should().Be(tenant);
+    }
+
+    [Test]
+    public async Task Post_FailSoft_Returns200SuccessFalse_NeverRaw5xx()
+    {
+        _email.Next = new EmailMediationResult { Success = false, Outcome = "Error", FailureCode = EmailMediationFailureCodes.PlatformError };
+        using var client = AuthedClient();
+        var resp = await client.PostAsJsonAsync(Route, EmailBody());
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        ((int)resp.StatusCode).Should().BeLessThan(500);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("success").GetBoolean().Should().BeFalse();
+    }
+
+    private sealed class CapturingEmailMediationService : IEmailMediationService
+    {
+        public Guid? LastTenantId { get; private set; }
+        public string? LastTo { get; private set; }
+        public EmailMediationResult? Next { get; set; }
+
+        public Task<EmailMediationResult> SendEmailAsync(Guid? tenantId, SendEmailRequest body, CancellationToken ct = default)
+        {
+            LastTenantId = tenantId; LastTo = body.To;
+            return Task.FromResult(Next ?? new EmailMediationResult { Success = true, Outcome = "Queued" });
+        }
+    }
+
+    private sealed class StubTenantContext : ITenantContext
+    {
+        private Guid? _tenantId;
+        public Guid? TenantId => _tenantId;
+        public void SetTenantId(Guid tenantId) => _tenantId = tenantId;
+        public void ClearTenantId() => _tenantId = null;
+    }
+
+    private sealed class TestEngineAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    {
+        public const string SchemeName = "TestEngine";
+
+        public TestEngineAuthHandler(
+            IOptionsMonitor<AuthenticationSchemeOptions> options,
+            Microsoft.Extensions.Logging.ILoggerFactory logger,
+            UrlEncoder encoder)
+            : base(options, logger, encoder) { }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (!Request.Headers.TryGetValue("Authorization", out var header))
+                return Task.FromResult(AuthenticateResult.NoResult());
+            var value = header.ToString();
+            if (!value.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+                return Task.FromResult(AuthenticateResult.NoResult());
+            var token = value["Bearer ".Length..].Trim();
+
+            if (string.Equals(token, TestBearer, StringComparison.Ordinal))
+            {
+                Context.SetAuthPrincipal(new ServiceAuthPrincipal(
+                    KeyId: Guid.NewGuid(), ServiceName: "tamma-engine", Permissions: Array.Empty<string>(), TenantId: null));
+                var identity = new ClaimsIdentity(
+                    new[] { new Claim(ClaimTypes.NameIdentifier, "tamma-engine"), new Claim("scope", "service") }, SchemeName);
+                return Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName)));
+            }
+
+            if (string.Equals(token, UserBearer, StringComparison.Ordinal))
+            {
+                var identity = new ClaimsIdentity(
+                    new[] { new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()), new Claim("role", "owner") }, SchemeName);
+                return Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName)));
+            }
+
+            return Task.FromResult(AuthenticateResult.Fail("Invalid token"));
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/EmailMediation/EmailMediationServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/EmailMediation/EmailMediationServiceTests.cs
@@ -1,0 +1,80 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.Email;
+using Tamma.Api.Services.EmailMediation;
+
+namespace Tamma.Api.Tests.EmailMediation;
+
+/// <summary>
+/// Story 38 (Phase 1) — <see cref="EmailMediationService"/> composition. Email is not
+/// repo-scoped: it accepts the engine's rendered message into the credentialed,
+/// outbox-backed <see cref="IEmailService"/> (which owns transport + EMAIL.* audit)
+/// under the acting tenant. Fail-soft: a missing recipient or an accept exception
+/// surfaces a typed PLATFORM_ERROR inside a 200 success:false envelope (never a raw
+/// 5xx). The email credential never reaches the engine.
+/// </summary>
+[TestFixture]
+public class EmailMediationServiceTests
+{
+    private Mock<IEmailService> _email = null!;
+    private EmailMediationService _sut = null!;
+    private readonly Guid _tenant = Guid.NewGuid();
+
+    [SetUp]
+    public void SetUp()
+    {
+        _email = new Mock<IEmailService>(MockBehavior.Strict);
+        _sut = new EmailMediationService(_email.Object, NullLogger<EmailMediationService>.Instance);
+    }
+
+    private static SendEmailRequest Body() => new()
+    {
+        To = "dev@example.com", Subject = "Build passed", Body = "All green", CorrelationId = "corr-e",
+    };
+
+    [Test]
+    public async Task Send_Success_AcceptsIntoOutbox_ReturnsTxnId_ScopesTenant()
+    {
+        var txn = Guid.NewGuid();
+        EmailMessage? captured = null;
+        _email.Setup(e => e.SendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<EmailMessage, CancellationToken>((m, _) => captured = m)
+            .ReturnsAsync(txn);
+
+        var result = await _sut.SendEmailAsync(_tenant, Body());
+
+        result.Success.Should().BeTrue();
+        result.Outcome.Should().Be("Queued");
+        result.TxnId.Should().Be(txn);
+        captured.Should().NotBeNull();
+        captured!.TenantId.Should().Be(_tenant, "the acting tenant scopes the message + its EMAIL.* events");
+        captured.To.Should().Be("dev@example.com");
+        captured.Text.Should().Be("All green");
+    }
+
+    [Test]
+    public async Task Send_MissingRecipient_TypedPlatformError_NeverCallsTransport()
+    {
+        var result = await _sut.SendEmailAsync(_tenant, new SendEmailRequest { To = "", Subject = "s", Body = "b", CorrelationId = "c" });
+
+        result.Success.Should().BeFalse();
+        result.FailureCode.Should().Be(EmailMediationFailureCodes.PlatformError);
+        _email.Verify(e => e.SendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Send_TransportAcceptThrows_FailSoft_TypedPlatformError_No5xx()
+    {
+        _email.Setup(e => e.SendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("smtp accept failed"));
+
+        var result = await _sut.SendEmailAsync(_tenant, Body());
+
+        result.Success.Should().BeFalse();
+        result.Outcome.Should().Be("Error");
+        result.FailureCode.Should().Be(EmailMediationFailureCodes.PlatformError);
+        result.CorrelationId.Should().Be("corr-e");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Git/GitEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Git/GitEndpointsTests.cs
@@ -268,6 +268,24 @@ public class GitEndpointsTests
             LastTenantId = tenantId; LastRepo = repo;
             return Task.FromResult(NextComments ?? new GitMediationResult { Success = true, Outcome = "Done", Comments = new List<PrCommentDto>() });
         }
+
+        public Task<GitMediationResult> GetCommitsAsync(Guid? tenantId, string repo, string branch, DateTime? since, string correlationId, CancellationToken ct = default)
+        {
+            LastTenantId = tenantId; LastRepo = repo;
+            return Task.FromResult(new GitMediationResult { Success = true, Outcome = "Done", Commits = new List<GitCommitDto>() });
+        }
+
+        public Task<GitMediationResult> GetFileChangesAsync(Guid? tenantId, string repo, string branch, string correlationId, CancellationToken ct = default)
+        {
+            LastTenantId = tenantId; LastRepo = repo;
+            return Task.FromResult(new GitMediationResult { Success = true, Outcome = "Done", FileChanges = new List<GitFileChangeDto>() });
+        }
+
+        public Task<GitMediationResult> DeleteBranchAsync(Guid? tenantId, string repo, string branchName, string correlationId, CancellationToken ct = default)
+        {
+            LastTenantId = tenantId; LastRepo = repo;
+            return Task.FromResult(new GitMediationResult { Success = true, Outcome = "Deleted", BranchDeleted = true });
+        }
     }
 
     private sealed class StubTenantContext : ITenantContext

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Git/GitExtraOpsMediationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Git/GitExtraOpsMediationTests.cs
@@ -1,0 +1,190 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.Git;
+using Tamma.Core.Interfaces;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Git;
+
+/// <summary>
+/// Story 38 (Phase 1) — the GitHub "extra ops" (<c>GetCommits</c> /
+/// <c>GetFileChanges</c> / <c>DeleteBranch</c>) added to <see cref="GitMediationService"/>.
+/// Reuse the exact guard → token → platform-with-resolved-token → one-event plane as
+/// the git-platform ops; assertions cover the fail-closed guard (deny ⇒ no token
+/// resolved, platform never called), the happy paths + their mapped projections, and
+/// the 503 token-unavailable path.
+/// </summary>
+[TestFixture]
+public class GitExtraOpsMediationTests
+{
+    private const string SecretToken = "ghp-EXTRA-SECRET-DO-NOT-LEAK-1234567890";
+    private const string Repo = "acme/widgets";
+
+    private Mock<IGitRepoAuthorizer> _authorizer = null!;
+    private Mock<IGitTokenResolver> _tokenResolver = null!;
+    private Mock<IGitHubClientFactory> _factory = null!;
+    private Mock<IGitHubIntegrationService> _github = null!;
+    private RecordingRepo _events = null!;
+    private GitMediationService _sut = null!;
+    private readonly Guid _tenant = Guid.NewGuid();
+
+    [SetUp]
+    public void SetUp()
+    {
+        _authorizer = new Mock<IGitRepoAuthorizer>(MockBehavior.Strict);
+        _tokenResolver = new Mock<IGitTokenResolver>(MockBehavior.Strict);
+        _factory = new Mock<IGitHubClientFactory>(MockBehavior.Strict);
+        _github = new Mock<IGitHubIntegrationService>(MockBehavior.Loose);
+        _events = new RecordingRepo();
+        _factory.Setup(f => f.Create(It.IsAny<string>())).Returns(_github.Object);
+        _sut = new GitMediationService(
+            _authorizer.Object, _tokenResolver.Object, _factory.Object, _events, NullLogger<GitMediationService>.Instance);
+    }
+
+    private void Allow() => _authorizer
+        .Setup(a => a.AuthorizeAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(GitRepoAuthorization.Allow());
+
+    private void Deny() => _authorizer
+        .Setup(a => a.AuthorizeAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(GitRepoAuthorization.Deny("not authorized"));
+
+    private void ResolveToken() => _tokenResolver
+        .Setup(t => t.ResolveAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new GitTokenResolution(SecretToken, GitCredentialSources.Byok));
+
+    private void NoToken() => _tokenResolver
+        .Setup(t => t.ResolveAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync((GitTokenResolution?)null);
+
+    [Test]
+    public async Task GetCommits_Success_MapsCommits_OneEvent()
+    {
+        Allow();
+        ResolveToken();
+        _github.Setup(g => g.GetGitHubCommitsAsync(Repo, "main", null))
+            .ReturnsAsync(IntegrationResult<List<GitHubCommit>>.Ok(new List<GitHubCommit>
+            {
+                new() { Sha = "abc", Message = "fix", Author = "bob", Additions = 3, Deletions = 1, Files = new List<string> { "a.cs" } },
+            }));
+
+        var result = await _sut.GetCommitsAsync(_tenant, Repo, "main", null, "corr-c");
+
+        result.Success.Should().BeTrue();
+        result.Outcome.Should().Be("Done");
+        result.Commits.Should().HaveCount(1);
+        result.Commits![0].Sha.Should().Be("abc");
+        result.Commits[0].Files.Should().Contain("a.cs");
+        _factory.Verify(f => f.Create(SecretToken), Times.Once);
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(GitEventTypes.CommitsReadSuccess);
+    }
+
+    [Test]
+    public async Task GetCommits_GuardDenied_403_PlatformNeverCalled()
+    {
+        Deny();
+
+        var result = await _sut.GetCommitsAsync(_tenant, Repo, "main", null, "corr-c");
+
+        result.FailureCode.Should().Be(GitFailureCodes.RepoNotAuthorized);
+        _tokenResolver.Verify(t => t.ResolveAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _factory.Verify(f => f.Create(It.IsAny<string>()), Times.Never);
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(GitEventTypes.CommitsReadFailed);
+    }
+
+    [Test]
+    public async Task GetFileChanges_Success_MapsChanges_OneEvent()
+    {
+        Allow();
+        ResolveToken();
+        _github.Setup(g => g.GetGitHubFileChangesAsync(Repo, "feature"))
+            .ReturnsAsync(IntegrationResult<List<GitHubFileChange>>.Ok(new List<GitHubFileChange>
+            {
+                new() { FilePath = "a.cs", ChangeType = "modified", Additions = 2, Deletions = 0 },
+            }));
+
+        var result = await _sut.GetFileChangesAsync(_tenant, Repo, "feature", "corr-f");
+
+        result.Success.Should().BeTrue();
+        result.FileChanges.Should().HaveCount(1);
+        result.FileChanges![0].FilePath.Should().Be("a.cs");
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(GitEventTypes.FileChangesReadSuccess);
+    }
+
+    [Test]
+    public async Task DeleteBranch_Success_OneEvent()
+    {
+        Allow();
+        ResolveToken();
+        _github.Setup(g => g.DeleteGitHubBranchAsync(Repo, "feature/foo"))
+            .ReturnsAsync(IntegrationResult<bool>.Ok(true));
+
+        var result = await _sut.DeleteBranchAsync(_tenant, Repo, "feature/foo", "corr-d");
+
+        result.Success.Should().BeTrue();
+        result.Outcome.Should().Be("Deleted");
+        result.BranchDeleted.Should().Be(true);
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(GitEventTypes.BranchDeletedSuccess);
+    }
+
+    [Test]
+    public async Task DeleteBranch_PlatformFailure_TypedError_OneFailedEvent()
+    {
+        Allow();
+        ResolveToken();
+        _github.Setup(g => g.DeleteGitHubBranchAsync(Repo, "feature"))
+            .ReturnsAsync(IntegrationResult<bool>.Fail("404: not found"));
+
+        var result = await _sut.DeleteBranchAsync(_tenant, Repo, "feature", "corr-d");
+
+        result.Success.Should().BeFalse();
+        result.FailureCode.Should().Be(GitFailureCodes.NotFound);
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(GitEventTypes.BranchDeletedFailed);
+    }
+
+    [Test]
+    public async Task GetCommits_TokenUnavailable_503_FailClosed()
+    {
+        Allow();
+        NoToken();
+
+        var result = await _sut.GetCommitsAsync(_tenant, Repo, "main", null, "corr-c");
+
+        result.FailureCode.Should().Be(GitFailureCodes.TokenUnavailable);
+        _factory.Verify(f => f.Create(It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task CredentialSafety_TokenNeverLeaks()
+    {
+        Allow();
+        ResolveToken();
+        _github.Setup(g => g.GetGitHubFileChangesAsync(Repo, "main"))
+            .ReturnsAsync(IntegrationResult<List<GitHubFileChange>>.Ok(new List<GitHubFileChange>()));
+
+        var result = await _sut.GetFileChangesAsync(_tenant, Repo, "main", "corr-f");
+
+        JsonSerializer.Serialize(result).Should().NotContain(SecretToken);
+        foreach (var evt in _events.Appended)
+            (evt.Tags + evt.Data + evt.Metadata).Should().NotContain(SecretToken);
+    }
+
+    private sealed class RecordingRepo : IEventRepository
+    {
+        public ConcurrentBag<DomainEvent> Appended { get; } = new();
+        public Task<DomainEvent> AppendAsync(DomainEvent evt) { Appended.Add(evt); return Task.FromResult(evt); }
+        public Task<DomainEvent?> GetByIdAsync(Guid id) => Task.FromResult<DomainEvent?>(null);
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit) => Task.FromResult(new List<DomainEvent>());
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type) => Task.FromResult<DomainEvent?>(null);
+        public Task ClearAsync(Guid tenantId) => Task.CompletedTask;
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(Guid? tenantId, string? type, int? issueNumber, int limit, int offset)
+            => Task.FromResult(((IReadOnlyList<DomainEvent>)new List<DomainEvent>(), 0));
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(Guid tenantId, string? typePrefix, int limit, int offset)
+            => Task.FromResult(((IReadOnlyList<DomainEvent>)new List<DomainEvent>(), 0));
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Jira/JiraEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Jira/JiraEndpointsTests.cs
@@ -1,0 +1,205 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using Tamma.Api.Auth;
+using Tamma.Api.Services.Jira;
+using Tamma.Api.Tests.Infrastructure;
+using Tamma.Data;
+
+namespace Tamma.Api.Tests.Jira;
+
+/// <summary>
+/// Story 38 (Phase 1) — HTTP tests for the JIRA-mediation endpoints. Same engine-only
+/// plane: missing/invalid bearer ⇒ 401, a user JWT ⇒ 403; the acting tenant comes
+/// from <see cref="ITenantContext"/>; every non-success rides inside 200 success:false
+/// (JIRA is not repo-scoped — never a 403/503 for it).
+/// </summary>
+[TestFixture]
+public class JiraEndpointsTests
+{
+    private const string TestBearer = "engine-callback-token";
+    private const string UserBearer = "tenant-user-token";
+    private const string TicketRoute = "/api/v1/jira/tickets/PROJ-42";
+
+    private WebApplicationFactory<Program> _factory = null!;
+    private CapturingJiraMediationService _jira = null!;
+    private StubTenantContext _tenantContext = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _jira = new CapturingJiraMediationService();
+        _tenantContext = new StubTenantContext();
+
+        _factory = ApiTestFixture.Factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Development");
+            builder.DisableAlertHostedServices();
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<IJiraMediationService>();
+                services.AddSingleton<IJiraMediationService>(_jira);
+
+                services.RemoveAll<ITenantContext>();
+                services.AddScoped<ITenantContext>(_ => _tenantContext);
+
+                services.AddAuthentication(TestEngineAuthHandler.SchemeName)
+                    .AddScheme<AuthenticationSchemeOptions, TestEngineAuthHandler>(TestEngineAuthHandler.SchemeName, _ => { });
+
+                services.AddHttpContextAccessor();
+                services.AddSingleton<IAuthorizationHandler, ServicePrincipalHandler>();
+
+                services.AddAuthorization(options =>
+                {
+                    options.DefaultPolicy = new AuthorizationPolicyBuilder()
+                        .AddAuthenticationSchemes(TestEngineAuthHandler.SchemeName)
+                        .RequireAuthenticatedUser().Build();
+                    options.AddPolicy("EngineServiceOnly", p =>
+                    {
+                        p.AddAuthenticationSchemes(TestEngineAuthHandler.SchemeName);
+                        p.RequireAuthenticatedUser();
+                        p.AddRequirements(new ServicePrincipalRequirement());
+                    });
+                });
+            });
+        });
+    }
+
+    [TearDown]
+    public void TearDown() => _factory?.Dispose();
+
+    private HttpClient AuthedClient()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", TestBearer);
+        return client;
+    }
+
+    [Test]
+    public async Task Get_NoBearer_Returns401_HandlerNotReached()
+    {
+        using var client = _factory.CreateClient();
+        var resp = await client.GetAsync(TicketRoute);
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        _jira.LastTicketId.Should().BeNull();
+    }
+
+    [Test]
+    public async Task Patch_NonEnginePrincipal_Returns403_HandlerNotReached()
+    {
+        using var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", UserBearer);
+        var resp = await client.PatchAsJsonAsync(TicketRoute, new { status = "Done", correlationId = "c" });
+        resp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        _jira.LastTicketId.Should().BeNull();
+    }
+
+    [Test]
+    public async Task Get_ValidBearer_DerivesTenant_Returns200()
+    {
+        var tenant = Guid.NewGuid();
+        _tenantContext.SetTenantId(tenant);
+        _jira.Next = new JiraMediationResult { Success = true, Outcome = "Read", TicketKey = "PROJ-42" };
+
+        using var client = AuthedClient();
+        client.DefaultRequestHeaders.Add("X-Tenant-Id", tenant.ToString());
+        var resp = await client.GetAsync(TicketRoute + "?correlationId=wf-1");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        _jira.LastTicketId.Should().Be("PROJ-42");
+        _jira.LastTenantId.Should().Be(tenant);
+    }
+
+    [Test]
+    public async Task Patch_Failure_Returns200SuccessFalse_NeverRaw5xx()
+    {
+        _jira.Next = new JiraMediationResult { Success = false, Outcome = "Error", FailureCode = JiraFailureCodes.NotConfigured };
+        using var client = AuthedClient();
+        var resp = await client.PatchAsJsonAsync(TicketRoute, new { status = "Done", correlationId = "c" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        ((int)resp.StatusCode).Should().BeLessThan(500);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("success").GetBoolean().Should().BeFalse();
+        body.GetProperty("failureCode").GetString().Should().Be(JiraFailureCodes.NotConfigured);
+    }
+
+    private sealed class CapturingJiraMediationService : IJiraMediationService
+    {
+        public Guid? LastTenantId { get; private set; }
+        public string? LastTicketId { get; private set; }
+        public JiraMediationResult? Next { get; set; }
+
+        public Task<JiraMediationResult> GetTicketAsync(Guid? tenantId, string ticketId, string correlationId, CancellationToken ct = default)
+        {
+            LastTenantId = tenantId; LastTicketId = ticketId;
+            return Task.FromResult(Next ?? new JiraMediationResult { Success = true, Outcome = "Read" });
+        }
+
+        public Task<JiraMediationResult> UpdateTicketAsync(Guid? tenantId, string ticketId, UpdateTicketRequest body, CancellationToken ct = default)
+        {
+            LastTenantId = tenantId; LastTicketId = ticketId;
+            return Task.FromResult(Next ?? new JiraMediationResult { Success = true, Outcome = "Updated" });
+        }
+    }
+
+    private sealed class StubTenantContext : ITenantContext
+    {
+        private Guid? _tenantId;
+        public Guid? TenantId => _tenantId;
+        public void SetTenantId(Guid tenantId) => _tenantId = tenantId;
+        public void ClearTenantId() => _tenantId = null;
+    }
+
+    private sealed class TestEngineAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    {
+        public const string SchemeName = "TestEngine";
+
+        public TestEngineAuthHandler(
+            IOptionsMonitor<AuthenticationSchemeOptions> options,
+            Microsoft.Extensions.Logging.ILoggerFactory logger,
+            UrlEncoder encoder)
+            : base(options, logger, encoder) { }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (!Request.Headers.TryGetValue("Authorization", out var header))
+                return Task.FromResult(AuthenticateResult.NoResult());
+            var value = header.ToString();
+            if (!value.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+                return Task.FromResult(AuthenticateResult.NoResult());
+            var token = value["Bearer ".Length..].Trim();
+
+            if (string.Equals(token, TestBearer, StringComparison.Ordinal))
+            {
+                Context.SetAuthPrincipal(new ServiceAuthPrincipal(
+                    KeyId: Guid.NewGuid(), ServiceName: "tamma-engine", Permissions: Array.Empty<string>(), TenantId: null));
+                var identity = new ClaimsIdentity(
+                    new[] { new Claim(ClaimTypes.NameIdentifier, "tamma-engine"), new Claim("scope", "service") }, SchemeName);
+                return Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName)));
+            }
+
+            if (string.Equals(token, UserBearer, StringComparison.Ordinal))
+            {
+                var identity = new ClaimsIdentity(
+                    new[] { new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()), new Claim("role", "owner") }, SchemeName);
+                return Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName)));
+            }
+
+            return Task.FromResult(AuthenticateResult.Fail("Invalid token"));
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Jira/JiraMediationServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Jira/JiraMediationServiceTests.cs
@@ -1,0 +1,107 @@
+using System.Collections.Concurrent;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.Jira;
+using Tamma.Core.Interfaces;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Jira;
+
+/// <summary>
+/// Story 38 (Phase 1) — <see cref="JiraMediationService"/> composition. JIRA is not
+/// repo-scoped (no guard / no token resolver): it runs the config-credentialed
+/// <see cref="IJiraIntegrationService"/> under the acting tenant, then emits exactly
+/// one terminal DCB event. Failures ride inside a typed key-free result (200
+/// success:false at the endpoint); an unexpected exception becomes PLATFORM_ERROR.
+/// </summary>
+[TestFixture]
+public class JiraMediationServiceTests
+{
+    private const string TicketId = "PROJ-42";
+
+    private Mock<IJiraIntegrationService> _jira = null!;
+    private RecordingEventRepository _events = null!;
+    private JiraMediationService _sut = null!;
+    private readonly Guid _tenant = Guid.NewGuid();
+
+    [SetUp]
+    public void SetUp()
+    {
+        _jira = new Mock<IJiraIntegrationService>(MockBehavior.Strict);
+        _events = new RecordingEventRepository();
+        _sut = new JiraMediationService(_jira.Object, _events, NullLogger<JiraMediationService>.Instance);
+    }
+
+    [Test]
+    public async Task GetTicket_Success_MapsTicket_OneEvent()
+    {
+        _jira.Setup(j => j.GetJiraTicketAsync(TicketId))
+            .ReturnsAsync(IntegrationResult<JiraTicket?>.Ok(new JiraTicket { Id = "1", Key = TicketId, Summary = "s", Status = "In Progress" }));
+
+        var result = await _sut.GetTicketAsync(_tenant, TicketId, "corr-j");
+
+        result.Success.Should().BeTrue();
+        result.Outcome.Should().Be("Read");
+        result.Ticket!.Key.Should().Be(TicketId);
+        result.Ticket.Status.Should().Be("In Progress");
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(JiraEventTypes.TicketReadSuccess);
+    }
+
+    [Test]
+    public async Task UpdateTicket_Success_ReturnsKey_OneEvent()
+    {
+        _jira.Setup(j => j.UpdateJiraTicketAsync(TicketId, It.IsAny<JiraTicketUpdate>()))
+            .ReturnsAsync(IntegrationResult<JiraTicketResult>.Ok(new JiraTicketResult { Success = true, TicketKey = TicketId }));
+
+        var body = new UpdateTicketRequest { Status = "Done", Comment = "merged", CorrelationId = "corr-u" };
+        var result = await _sut.UpdateTicketAsync(_tenant, TicketId, body);
+
+        result.Success.Should().BeTrue();
+        result.Outcome.Should().Be("Updated");
+        result.TicketKey.Should().Be(TicketId);
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(JiraEventTypes.TicketUpdatedSuccess);
+    }
+
+    [Test]
+    public async Task UpdateTicket_NotConfigured_TypedNotConfigured_OneFailedEvent()
+    {
+        _jira.Setup(j => j.UpdateJiraTicketAsync(TicketId, It.IsAny<JiraTicketUpdate>()))
+            .ReturnsAsync(IntegrationResult<JiraTicketResult>.Fail("JIRA not configured"));
+
+        var body = new UpdateTicketRequest { Status = "Done", CorrelationId = "corr-u" };
+        var result = await _sut.UpdateTicketAsync(_tenant, TicketId, body);
+
+        result.Success.Should().BeFalse();
+        result.FailureCode.Should().Be(JiraFailureCodes.NotConfigured);
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(JiraEventTypes.TicketUpdatedFailed);
+    }
+
+    [Test]
+    public async Task GetTicket_ServiceThrows_TypedPlatformError_OneFailedEvent()
+    {
+        _jira.Setup(j => j.GetJiraTicketAsync(TicketId)).ThrowsAsync(new InvalidOperationException("boom"));
+
+        var result = await _sut.GetTicketAsync(_tenant, TicketId, "corr-j");
+
+        result.Success.Should().BeFalse();
+        result.FailureCode.Should().Be(JiraFailureCodes.PlatformError);
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(JiraEventTypes.TicketReadFailed);
+    }
+
+    private sealed class RecordingEventRepository : IEventRepository
+    {
+        public ConcurrentBag<DomainEvent> Appended { get; } = new();
+        public Task<DomainEvent> AppendAsync(DomainEvent evt) { Appended.Add(evt); return Task.FromResult(evt); }
+        public Task<DomainEvent?> GetByIdAsync(Guid id) => Task.FromResult<DomainEvent?>(null);
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit) => Task.FromResult(new List<DomainEvent>());
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type) => Task.FromResult<DomainEvent?>(null);
+        public Task ClearAsync(Guid tenantId) => Task.CompletedTask;
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(Guid? tenantId, string? type, int? issueNumber, int limit, int offset)
+            => Task.FromResult(((IReadOnlyList<DomainEvent>)new List<DomainEvent>(), 0));
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(Guid tenantId, string? typePrefix, int limit, int offset)
+            => Task.FromResult(((IReadOnlyList<DomainEvent>)new List<DomainEvent>(), 0));
+    }
+}


### PR DESCRIPTION
## What

Completes the Epic 38 credential-mediation goal for the last four integration domains. Cuts **all 23 workflow-engine activities** off the composite `IIntegrationService` (which held GitHub/CI/JIRA/email credentials and threw on failure) onto the thin HTTP client `TammaApiClient`, and **locks the door** with the `TAMMA001` analyzer: reintroducing a direct injection now fails the build.

> Scope note: memory/comments said "5 activities"; the real count was **23** (the in-code comment was stale). All 23 are migrated here.

## How it's structured (Pattern A — synchronous engine→API mediation)

Each engine activity keeps its business logic but replaces the credentialed call with a thin-client HTTP call to a new `Tamma.Api` mediation endpoint; the API side runs the real call against a **tenant/BYOK-token-bound** service. New shared helper `GitMediationMapping` projects the nullable soft-fail wire records back to the old composite model types so downstream logic stays byte-compatible.

- **Phase 1** — API-side mediation stacks for GitHub-extra (commits/file-changes/delete-branch), CI (trigger-tests/build-status), JIRA (get/update ticket), email (send). GitHub/CI use per-tenant BYOK token-binding; JIRA uses platform-global config (no per-tenant secret invented); email routes to the real outbox `IEmailService` (the composite's `EmailIntegrationService` was a no-op stub).
- **Phase 2** (Batches A/B/C) — 23 activities cut over; failure-path equivalence preserved (throw-on-`!Success` where the composite threw-and-was-caught; soft `Success=false` on write ops); dead injections removed from 2 activities that never called it.
- **Phase 3** — `IIntegrationService` + `ICI/IJira/IEmail` variants added to the `TAMMA001` denylist; obsolete exclusion comment deleted; positive analyzer tests added. Build emits **zero TAMMA001 diagnostics** — engine surface verified clean.

## Review outcome

Adversarial review found **no critical/high issues** and **debunked** the flagged "behavior reductions": on `main` the composite CI service was already a stub (never populated `FailedTestDetails`/`BuildStatus.Error`), so those branches were already inert — not regressions. Two low-severity follow-ups applied: git-mediation cancellation guard aligned to the CI/JIRA siblings, and the NB comments corrected.

**Tracked latent (pre-existing, not introduced here):** JIRA mediation uses a single platform-global credential and is not tenant-scoped — fine until JIRA becomes per-tenant BYOK.

## Verification

- `dotnet build`: 0 errors, **no TAMMA001 diagnostics**.
- Full suites: `Tamma.Activities.Guardrails.Tests` 32 · `Tamma.Activities.Tests` **2141** · `Tamma.Api.Tests` **4071** — all green.
- `grep IIntegrationService src/Tamma.Activities src/Tamma.ElsaServer`: zero real injections remain (doc-comments + static-core method params only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)