### PR TITLE
fix(epic-30): V2 provisioning saga defers instead of block-polling (Phase B I1)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/V2/ProvisionTenantV2Outcome.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/V2/ProvisionTenantV2Outcome.cs
@@ -1,0 +1,90 @@
+namespace Tamma.Api.Services.Provisioning.V2;
+
+/// <summary>
+/// Story 30-2 (Phase-B I1 restructure) — the three ways a single
+/// invocation of <see cref="ProvisionTenantV2Workflow.ExecuteAsync"/> can
+/// end.
+///
+/// <para>Before this restructure the workflow's InitialProbe step
+/// block-polled the provider in an in-process <c>while</c> loop (up to the
+/// ~30-min probe budget), which pinned the one-task-at-a-time
+/// <c>PlatformTaskWorker</c> slot for the whole poll. On a single worker
+/// process the outer saga occupied the only slot, so the inner
+/// <c>provisioning.tenant</c> task the Cranl provider enqueues on the SAME
+/// queue was never reserved and the provision timed out. The fix makes the
+/// probe SINGLE-SHOT: one <c>GetStatusAsync</c> per invocation, then one of
+/// these outcomes. On <see cref="DeferRequested"/> the handler releases the
+/// worker slot (defer + <c>PlatformTaskDeferredException</c>) so the single
+/// worker can interleave the inner task before re-entering the saga.</para>
+/// </summary>
+public enum ProvisionTenantV2OutcomeKind
+{
+    /// <summary>Terminal — the tenant reached <c>Ready</c> and was activated.</summary>
+    Completed,
+
+    /// <summary>Terminal — the workflow stamped <c>Failed</c> (provider
+    /// failure, probe budget exceeded, ...) and ran any compensations.</summary>
+    Failed,
+
+    /// <summary>Non-terminal — the tenant is still provisioning and the probe
+    /// budget has NOT been exceeded. The handler must return the task to the
+    /// queue with a future <c>VisibleAt</c> (defer by
+    /// <see cref="ProvisionTenantV2Outcome.DeferDelay"/>) so the worker slot
+    /// is released and the saga re-enters after the interval.</summary>
+    DeferRequested,
+}
+
+/// <summary>
+/// Result of one <see cref="ProvisionTenantV2Workflow.ExecuteAsync"/>
+/// invocation. Wraps the pre-existing <see cref="ProvisioningResult"/> so
+/// callers/tests can keep reading <see cref="Status"/> exactly as before,
+/// while adding the <see cref="Kind"/> discriminator + the
+/// <see cref="DeferDelay"/> the handler needs to schedule the next probe.
+/// </summary>
+public sealed class ProvisionTenantV2Outcome
+{
+    private ProvisionTenantV2Outcome(
+        ProvisionTenantV2OutcomeKind kind,
+        ProvisioningResult result,
+        TimeSpan deferDelay)
+    {
+        Kind = kind;
+        Result = result;
+        DeferDelay = deferDelay;
+    }
+
+    /// <summary>Which of the three terminal/non-terminal outcomes occurred.</summary>
+    public ProvisionTenantV2OutcomeKind Kind { get; }
+
+    /// <summary>The underlying provisioning snapshot. For
+    /// <see cref="ProvisionTenantV2OutcomeKind.DeferRequested"/> this carries
+    /// the last (non-terminal) snapshot the probe observed.</summary>
+    public ProvisioningResult Result { get; }
+
+    /// <summary>How long the handler should defer the task before the next
+    /// probe. Non-zero only for
+    /// <see cref="ProvisionTenantV2OutcomeKind.DeferRequested"/> (equals the
+    /// workflow's <c>ProbeInterval</c>).</summary>
+    public TimeSpan DeferDelay { get; }
+
+    /// <summary>Convenience pass-through so existing assertions
+    /// (<c>outcome.Status.State</c> / <c>outcome.Status.FailureReason</c>)
+    /// keep compiling unchanged.</summary>
+    public ProvisioningStatusSnapshot Status => Result.Status;
+
+    /// <summary><c>true</c> when the handler must defer + release the slot.</summary>
+    public bool IsDeferRequested => Kind == ProvisionTenantV2OutcomeKind.DeferRequested;
+
+    public static ProvisionTenantV2Outcome Completed(ProvisioningResult result) =>
+        new(ProvisionTenantV2OutcomeKind.Completed, result, TimeSpan.Zero);
+
+    public static ProvisionTenantV2Outcome Failed(ProvisioningResult result) =>
+        new(ProvisionTenantV2OutcomeKind.Failed, result, TimeSpan.Zero);
+
+    public static ProvisionTenantV2Outcome Defer(
+        TimeSpan deferDelay, ProvisioningStatusSnapshot lastSnapshot) =>
+        new(
+            ProvisionTenantV2OutcomeKind.DeferRequested,
+            new ProvisioningResult(lastSnapshot, new Dictionary<string, string>()),
+            deferDelay);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/V2/ProvisionTenantV2TaskHandler.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/V2/ProvisionTenantV2TaskHandler.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Tamma.Api.Services.PlatformTasks;
 using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
 
 namespace Tamma.Api.Services.Provisioning.V2;
 
@@ -29,22 +30,48 @@ namespace Tamma.Api.Services.Provisioning.V2;
 ///     completes normally. The Failed state is persisted on the tenant
 ///     row by the workflow itself; throwing here would re-enqueue the
 ///     row and trigger compensation again, which would be wrong.</description></item>
+///   <item><description>Workflow returned <c>DeferRequested</c> (tenant
+///     still provisioning, within budget) → the handler returns the row to
+///     <c>pending</c> with <c>VisibleAt = now + ProbeInterval</c> via
+///     <see cref="IPlatformQueuedTaskRepository.DeferAsync"/> and throws
+///     <see cref="PlatformTaskDeferredException"/> (modelled on
+///     <c>RetireSecretVersionTaskHandler</c>). The worker treats this as a
+///     no-op acknowledgement: no <c>CompleteAsync</c>, no <c>FailAsync</c>,
+///     retry budget untouched. This is the Phase-B I1 fix — the saga
+///     RELEASES the one-task-at-a-time worker slot between probes so a
+///     SINGLE worker can interleave the inner <c>provisioning.tenant</c>
+///     task before the next resume.</description></item>
 ///   <item><description>Workflow threw an unexpected exception → bubble
 ///     up so the worker counts a retry and re-fires the task on the
 ///     next reservation. Provider idempotency (ADR §4) makes this
 ///     safe.</description></item>
 /// </list>
+///
+/// <para><b>Cross-resume probe budget</b>: the ~30-min probe budget must
+/// span defers, not restart on each resume. The handler derives the
+/// absolute deadline from the task's first-enqueue timestamp
+/// (<see cref="PlatformQueuedTask.CreatedAt"/> + the workflow's
+/// <c>ProbeTimeout</c>) and passes it into <c>ExecuteAsync</c>. This needs
+/// NO new persisted state / migration: <c>CreatedAt</c> is set once at
+/// enqueue and <c>DeferAsync</c> leaves it untouched (it only moves
+/// <c>VisibleAt</c>), so the deadline is stable across every resume.</para>
 /// </summary>
 public sealed class ProvisionTenantV2TaskHandler : IPlatformTaskHandler
 {
     private readonly ProvisionTenantV2Workflow _workflow;
+    private readonly IPlatformQueuedTaskRepository _platformTasks;
+    private readonly TimeProvider _clock;
     private readonly ILogger<ProvisionTenantV2TaskHandler> _logger;
 
     public ProvisionTenantV2TaskHandler(
         ProvisionTenantV2Workflow workflow,
+        IPlatformQueuedTaskRepository platformTasks,
+        TimeProvider clock,
         ILogger<ProvisionTenantV2TaskHandler> logger)
     {
         _workflow = workflow;
+        _platformTasks = platformTasks;
+        _clock = clock;
         _logger = logger;
     }
 
@@ -85,17 +112,51 @@ public sealed class ProvisionTenantV2TaskHandler : IPlatformTaskHandler
         }
 
         _logger.LogInformation(
-            "v2_provisioning.task_started taskId={TaskId} tenantId={TenantId} providerKey={ProviderKey}",
-            task.Id, payload.TenantId, payload.ProviderKey);
+            "v2_provisioning.task_started taskId={TaskId} tenantId={TenantId} providerKey={ProviderKey} op={Operation}",
+            task.Id, payload.TenantId, payload.ProviderKey, payload.Operation);
 
-        var result = payload.Operation == ProvisioningOperation.Deprovision
-            ? await _workflow.DeprovisionAsync(payload, ct).ConfigureAwait(false)
-            : await _workflow.ExecuteAsync(payload, ct).ConfigureAwait(false);
+        if (payload.Operation == ProvisioningOperation.Deprovision)
+        {
+            var deprovisionResult = await _workflow
+                .DeprovisionAsync(payload, ct).ConfigureAwait(false);
+            _logger.LogInformation(
+                "v2_provisioning.task_finished taskId={TaskId} tenantId={TenantId} state={State} failureReason={FailureReason}",
+                task.Id, payload.TenantId,
+                deprovisionResult.Status.State.ToStorageString(),
+                deprovisionResult.Status.FailureReason);
+            return;
+        }
+
+        // Provision. Derive the STABLE cross-resume probe deadline from the
+        // task's first-enqueue timestamp so a defer never resets the budget.
+        // (CreatedAt is UTC in the DB; DeferAsync leaves it untouched.)
+        var createdAtUtc = DateTime.SpecifyKind(task.CreatedAt, DateTimeKind.Utc);
+        var probeDeadline = new DateTimeOffset(createdAtUtc) + _workflow.ProbeTimeout;
+
+        var outcome = await _workflow
+            .ExecuteAsync(payload, probeDeadline, ct).ConfigureAwait(false);
+
+        if (outcome.IsDeferRequested)
+        {
+            // Tenant still provisioning, within budget. Return the row to the
+            // queue with a future VisibleAt so this worker's slot is freed for
+            // the inner provisioning.tenant task; throw the deferred-exception
+            // sentinel so the worker does NOT Complete (clobber) or Fail (burn
+            // retry budget). Mirrors RetireSecretVersionTaskHandler exactly.
+            var visibleAt = _clock.GetUtcNow().UtcDateTime + outcome.DeferDelay;
+            await _platformTasks.DeferAsync(task.Id, visibleAt, ct).ConfigureAwait(false);
+            _logger.LogDebug(
+                "v2_provisioning.deferred taskId={TaskId} tenantId={TenantId} state={State} visibleAt={VisibleAt:o}",
+                task.Id, payload.TenantId,
+                outcome.Status.State.ToStorageString(), visibleAt);
+            throw new PlatformTaskDeferredException(
+                $"v2 provisioning task {task.Id} deferred until {visibleAt:o} (tenant {payload.TenantId} still provisioning).");
+        }
 
         _logger.LogInformation(
             "v2_provisioning.task_finished taskId={TaskId} tenantId={TenantId} state={State} failureReason={FailureReason}",
             task.Id, payload.TenantId,
-            result.Status.State.ToStorageString(),
-            result.Status.FailureReason);
+            outcome.Status.State.ToStorageString(),
+            outcome.Status.FailureReason);
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/V2/ProvisionTenantV2Workflow.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/V2/ProvisionTenantV2Workflow.cs
@@ -42,9 +42,13 @@ namespace Tamma.Api.Services.Provisioning.V2;
 ///     <c>ISecretStore.CreateAsync</c>) is wired by 30-3 once each
 ///     provider declares which secrets it surfaces. Compensation: noop
 ///     today; <c>RetireVersionAsync</c> per registered secret in 30-3.</description></item>
-///   <item><description>InitialProbe — poll
-///     <see cref="ITenantInfrastructureProvider.GetStatusAsync"/> until
-///     Ready or budget exhausted. Compensation: <c>DeprovisionAsync</c>.</description></item>
+///   <item><description>InitialProbe — SINGLE-SHOT
+///     <see cref="ITenantInfrastructureProvider.GetStatusAsync"/>: Ready →
+///     Activate; Failed → compensate; still-provisioning within budget →
+///     <see cref="ProvisionTenantV2OutcomeKind.DeferRequested"/> (caller
+///     releases the worker slot and re-enters after ProbeInterval);
+///     still-provisioning past the deadline → timeout + compensation.
+///     Compensation on terminal failure: <c>DeprovisionAsync</c>.</description></item>
 ///   <item><description>Activate — flip tenant to <c>ready</c>, emit
 ///     <c>TENANT.PROVISIONED.SUCCESS</c>. Compensation: flip back to
 ///     <c>failed</c> with diagnostic.</description></item>
@@ -106,12 +110,40 @@ public class ProvisionTenantV2Workflow
     }
 
     /// <summary>
-    /// Run (or resume) the workflow for the supplied payload.
+    /// Convenience overload for callers that drive a SINGLE invocation and
+    /// want the probe budget measured from now (unit tests, ad-hoc runs).
+    /// The cross-resume path (<see cref="ProvisionTenantV2TaskHandler"/>)
+    /// calls the 3-arg overload with a deadline derived from the task's
+    /// first-enqueue timestamp so the budget survives defers.
     /// </summary>
-    /// <returns>Final snapshot — either Ready (happy path) or Failed
-    /// (with FailureReason short-code).</returns>
-    public virtual async Task<ProvisioningResult> ExecuteAsync(
+    public Task<ProvisionTenantV2Outcome> ExecuteAsync(
         ProvisionTenantV2TaskPayload payload,
+        CancellationToken ct)
+        => ExecuteAsync(payload, _clock.GetUtcNow() + ProbeTimeout, ct);
+
+    /// <summary>
+    /// Run (or resume) the workflow for the supplied payload.
+    ///
+    /// <para><b>Single-shot probe + defer (Phase-B I1)</b>: the InitialProbe
+    /// step performs ONE <see cref="ITenantInfrastructureProvider.GetStatusAsync"/>
+    /// call. <c>Ready</c> → activate + <see cref="ProvisionTenantV2OutcomeKind.Completed"/>.
+    /// <c>Failed</c> → compensate + <see cref="ProvisionTenantV2OutcomeKind.Failed"/>.
+    /// Still-provisioning AND within <paramref name="probeDeadline"/> →
+    /// <see cref="ProvisionTenantV2OutcomeKind.DeferRequested"/> so the caller
+    /// releases the worker slot and re-enters after the probe interval.
+    /// Still-provisioning AND past the deadline → the timeout/compensation
+    /// path (identical to the old in-loop budget-exceeded branch).</para>
+    /// </summary>
+    /// <param name="payload">Task payload.</param>
+    /// <param name="probeDeadline">Absolute wall-clock instant the probe
+    /// budget expires. Passed in (not recomputed) so it is STABLE across
+    /// resumes — the handler derives it from the task's <c>CreatedAt</c> so a
+    /// defer never resets the ~30-min budget.</param>
+    /// <param name="ct">Cancellation.</param>
+    /// <returns>The invocation outcome (Completed / Failed / DeferRequested).</returns>
+    public virtual async Task<ProvisionTenantV2Outcome> ExecuteAsync(
+        ProvisionTenantV2TaskPayload payload,
+        DateTimeOffset probeDeadline,
         CancellationToken ct)
     {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
@@ -119,9 +151,9 @@ public class ProvisionTenantV2Workflow
         var tenant = await LoadTenantAsync(payload.TenantId, ct).ConfigureAwait(false);
         if (tenant is null)
         {
-            return BuildSyntheticFailure(
+            return ProvisionTenantV2Outcome.Failed(BuildSyntheticFailure(
                 ProvisioningFailureReasons.TenantNotFound,
-                $"tenant_{payload.TenantId}_not_found");
+                $"tenant_{payload.TenantId}_not_found"));
         }
 
         var initialState = ProvisioningStateExtensions.ParseState(tenant.ProvisioningState);
@@ -129,11 +161,11 @@ public class ProvisionTenantV2Workflow
             or ProvisioningState.Deprovisioning
             or ProvisioningState.Deprovisioned)
         {
-            return await StampFailureAsync(
+            return ProvisionTenantV2Outcome.Failed(await StampFailureAsync(
                 tenant,
                 ProvisioningFailureReasons.IllegalTenantState,
                 $"refused_to_run_against_state_{initialState.ToStorageString()}",
-                ct).ConfigureAwait(false);
+                ct).ConfigureAwait(false));
         }
 
         // ── Step 1: ResolveProvider ───────────────────────────────────
@@ -148,11 +180,11 @@ public class ProvisionTenantV2Workflow
                 {
                     ["failureReason"] = ProvisioningFailureReasons.NoProvisioningInThisMode,
                 }, ct).ConfigureAwait(false);
-            return await StampFailureAsync(
+            return ProvisionTenantV2Outcome.Failed(await StampFailureAsync(
                 tenant,
                 ProvisioningFailureReasons.NoProvisioningInThisMode,
                 "single_user_or_dev_mode",
-                ct).ConfigureAwait(false);
+                ct).ConfigureAwait(false));
         }
 
         if (!_registry.TryGetProvider(payload.ProviderKey, out var provider) || provider is null)
@@ -164,11 +196,11 @@ public class ProvisionTenantV2Workflow
                     ["failureReason"] = ProvisioningFailureReasons.ProviderNotRegistered,
                     ["providerKey"] = payload.ProviderKey,
                 }, ct).ConfigureAwait(false);
-            return await StampFailureAsync(
+            return ProvisionTenantV2Outcome.Failed(await StampFailureAsync(
                 tenant,
                 ProvisioningFailureReasons.ProviderNotRegistered,
                 $"provider_key_{payload.ProviderKey}_unknown",
-                ct).ConfigureAwait(false);
+                ct).ConfigureAwait(false));
         }
 
         await EmitStepEventAsync(payload.TenantId, "resolve_provider",
@@ -188,11 +220,11 @@ public class ProvisionTenantV2Workflow
                     ["failureReason"] = ProvisioningFailureReasons.UnsupportedTopology,
                     ["topology"] = payload.Topology.ToString(),
                 }, ct).ConfigureAwait(false);
-            return await StampFailureAsync(
+            return ProvisionTenantV2Outcome.Failed(await StampFailureAsync(
                 tenant,
                 ProvisioningFailureReasons.UnsupportedTopology,
                 $"provider_{payload.ProviderKey}_does_not_support_{payload.Topology}",
-                ct).ConfigureAwait(false);
+                ct).ConfigureAwait(false));
         }
 
         if (payload.Region is not null
@@ -206,11 +238,11 @@ public class ProvisionTenantV2Workflow
                     ["failureReason"] = ProvisioningFailureReasons.UnsupportedRegion,
                     ["region"] = payload.Region,
                 }, ct).ConfigureAwait(false);
-            return await StampFailureAsync(
+            return ProvisionTenantV2Outcome.Failed(await StampFailureAsync(
                 tenant,
                 ProvisioningFailureReasons.UnsupportedRegion,
                 $"region_{payload.Region}_not_supported_by_{payload.ProviderKey}",
-                ct).ConfigureAwait(false);
+                ct).ConfigureAwait(false));
         }
 
         // Quota check — skipped today because the per-org tenant count
@@ -273,11 +305,11 @@ public class ProvisionTenantV2Workflow
                         ["errorType"] = ex.GetType().Name,
                     }, ct).ConfigureAwait(false);
                 await RunCompensationsAsync(compensations, payload.TenantId, ct).ConfigureAwait(false);
-                return await StampFailureAsync(
+                return ProvisionTenantV2Outcome.Failed(await StampFailureAsync(
                     tenant,
                     ProvisioningFailureReasons.ProviderUnexpectedException,
                     $"provider_threw_{ex.GetType().Name}",
-                    ct).ConfigureAwait(false);
+                    ct).ConfigureAwait(false));
             }
 
             // Provider returned a structured Failed snapshot — surface
@@ -311,13 +343,13 @@ public class ProvisionTenantV2Workflow
                         ["detail"] = executeResult.Status.Detail,
                     }, ct).ConfigureAwait(false);
                 await RunCompensationsAsync(compensations, payload.TenantId, ct).ConfigureAwait(false);
-                return await StampFailureAsync(
+                return ProvisionTenantV2Outcome.Failed(await StampFailureAsync(
                     tenant,
                     executeResult.Status.FailureReason
                         ?? ProvisioningFailureReasons.ProviderUnexpectedException,
                     executeResult.Status.Detail
                         ?? "provider_returned_failed_without_detail",
-                    ct).ConfigureAwait(false);
+                    ct).ConfigureAwait(false));
             }
 
             await EmitStepEventAsync(payload.TenantId, "execute_provision",
@@ -378,28 +410,80 @@ public class ProvisionTenantV2Workflow
                 }, ct).ConfigureAwait(false);
             compensations.Add(("register_secrets", _ => Task.CompletedTask));
 
-            // ── Step 7: InitialProbe ─────────────────────────────────
+            // ── Step 7: InitialProbe (SINGLE-SHOT + defer) ───────────
+            // Phase-B I1: exactly ONE GetStatusAsync per invocation. We do
+            // NOT block-poll here — a non-terminal snapshot yields a
+            // DeferRequested outcome so the caller (handler) releases the
+            // one-task-at-a-time worker slot, letting the inner
+            // provisioning.tenant task (Cranl's walk) run on the same single
+            // worker before we re-enter and probe again.
             await EmitStepEventAsync(payload.TenantId, "initial_probe",
                 "STEP_STARTED", null, ct).ConfigureAwait(false);
-            var probeOutcome = await ProbeUntilReadyAsync(
-                provider, payload.TenantId, ProbeTimeout, ct).ConfigureAwait(false);
-            if (!probeOutcome.IsReady)
+
+            var snapshot = await provider
+                .GetStatusAsync(payload.TenantId, ct).ConfigureAwait(false);
+
+            if (snapshot.State == ProvisioningState.Failed)
             {
+                // Provider transitioned to Failed during the walk — surface
+                // verbatim + compensate (same path the old in-loop Failed
+                // branch took).
                 await EmitStepEventAsync(payload.TenantId, "initial_probe",
                     "STEP_FAILED",
                     new Dictionary<string, object?>
                     {
-                        ["failureReason"] = probeOutcome.FailureReason,
-                        ["detail"] = probeOutcome.Detail,
+                        ["failureReason"] = snapshot.FailureReason
+                            ?? ProvisioningFailureReasons.ProviderUnexpectedException,
+                        ["detail"] = snapshot.Detail,
                     }, ct).ConfigureAwait(false);
                 await RunCompensationsAsync(compensations, payload.TenantId, ct).ConfigureAwait(false);
-                return await StampFailureAsync(
+                return ProvisionTenantV2Outcome.Failed(await StampFailureAsync(
                     tenant,
-                    probeOutcome.FailureReason
-                        ?? ProvisioningFailureReasons.ProbeTimeout,
-                    probeOutcome.Detail ?? "probe_timeout_no_detail",
-                    ct).ConfigureAwait(false);
+                    snapshot.FailureReason
+                        ?? ProvisioningFailureReasons.ProviderUnexpectedException,
+                    snapshot.Detail ?? "provider_reported_failed_during_probe",
+                    ct).ConfigureAwait(false));
             }
+
+            if (snapshot.State != ProvisioningState.Ready)
+            {
+                // Still provisioning. Enforce the OVERALL budget across
+                // resumes: probeDeadline is the task's first-enqueue time +
+                // ProbeTimeout (stable — a defer does not reset it). Past the
+                // deadline ⇒ same timeout + compensation the old in-loop
+                // budget-exceeded branch produced.
+                if (_clock.GetUtcNow() >= probeDeadline)
+                {
+                    var timeoutDetail =
+                        $"probe_budget_{(int)ProbeTimeout.TotalSeconds}s_exceeded_state_{snapshot.State.ToStorageString()}";
+                    await EmitStepEventAsync(payload.TenantId, "initial_probe",
+                        "STEP_FAILED",
+                        new Dictionary<string, object?>
+                        {
+                            ["failureReason"] = ProvisioningFailureReasons.ProbeTimeout,
+                            ["detail"] = timeoutDetail,
+                        }, ct).ConfigureAwait(false);
+                    await RunCompensationsAsync(compensations, payload.TenantId, ct).ConfigureAwait(false);
+                    return ProvisionTenantV2Outcome.Failed(await StampFailureAsync(
+                        tenant,
+                        ProvisioningFailureReasons.ProbeTimeout,
+                        timeoutDetail,
+                        ct).ConfigureAwait(false));
+                }
+
+                // Within budget — release the slot. NO compensation runs: the
+                // tenant stays Pending and the next resume re-enters steps 1-6
+                // (idempotent) then re-probes.
+                await EmitStepEventAsync(payload.TenantId, "initial_probe",
+                    "STEP_DEFERRED",
+                    new Dictionary<string, object?>
+                    {
+                        ["state"] = snapshot.State.ToStorageString(),
+                        ["deferSeconds"] = (int)ProbeInterval.TotalSeconds,
+                    }, ct).ConfigureAwait(false);
+                return ProvisionTenantV2Outcome.Defer(ProbeInterval, snapshot);
+            }
+
             await EmitStepEventAsync(payload.TenantId, "initial_probe",
                 "STEP_COMPLETED", null, ct).ConfigureAwait(false);
 
@@ -429,7 +513,7 @@ public class ProvisionTenantV2Workflow
                 }),
             }, ct).ConfigureAwait(false);
 
-            return new ProvisioningResult(
+            return ProvisionTenantV2Outcome.Completed(new ProvisioningResult(
                 new ProvisioningStatusSnapshot(
                     ProvisioningState.Ready,
                     Detail: "activated_v2",
@@ -437,7 +521,7 @@ public class ProvisionTenantV2Workflow
                     UpdatedAt: _clock.GetUtcNow()),
                 resourceIds,
                 endpoints,
-                executeResult.ProvisioningDurationSeconds);
+                executeResult.ProvisioningDurationSeconds));
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
@@ -613,49 +697,6 @@ public class ProvisionTenantV2Workflow
         }, ct).ConfigureAwait(false);
     }
 
-    private async Task<ProbeOutcome> ProbeUntilReadyAsync(
-        ITenantInfrastructureProvider provider,
-        Guid tenantId,
-        TimeSpan budget,
-        CancellationToken ct)
-    {
-        var start = _clock.GetUtcNow();
-        ProvisioningStatusSnapshot lastSnapshot;
-        while (true)
-        {
-            ct.ThrowIfCancellationRequested();
-            lastSnapshot = await provider.GetStatusAsync(tenantId, ct).ConfigureAwait(false);
-            if (lastSnapshot.State == ProvisioningState.Ready)
-            {
-                return ProbeOutcome.Ready();
-            }
-            if (lastSnapshot.State == ProvisioningState.Failed)
-            {
-                return ProbeOutcome.Failed(
-                    lastSnapshot.FailureReason
-                        ?? ProvisioningFailureReasons.ProviderUnexpectedException,
-                    lastSnapshot.Detail ?? "provider_reported_failed_during_probe");
-            }
-            var elapsed = _clock.GetUtcNow() - start;
-            if (elapsed >= budget)
-            {
-                return ProbeOutcome.Failed(
-                    ProvisioningFailureReasons.ProbeTimeout,
-                    $"probe_budget_{(int)budget.TotalSeconds}s_exceeded_state_{lastSnapshot.State.ToStorageString()}");
-            }
-
-            // Cancellable delay so worker shutdown unblocks fast.
-            try
-            {
-                await Task.Delay(ProbeInterval, ct).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                throw;
-            }
-        }
-    }
-
     private async Task RunCompensationsAsync(
         List<(string Step, Func<CancellationToken, Task> Run)> compensations,
         Guid tenantId,
@@ -690,16 +731,5 @@ public class ProvisionTenantV2Workflow
                 return;
             }
         }
-    }
-
-    private readonly struct ProbeOutcome
-    {
-        public bool IsReady { get; init; }
-        public string? FailureReason { get; init; }
-        public string? Detail { get; init; }
-
-        public static ProbeOutcome Ready() => new() { IsReady = true };
-        public static ProbeOutcome Failed(string reason, string detail) =>
-            new() { IsReady = false, FailureReason = reason, Detail = detail };
     }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/V2/ProvisionTenantV2SingleWorkerInterleaveTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/V2/ProvisionTenantV2SingleWorkerInterleaveTests.cs
@@ -1,0 +1,210 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.PlatformTasks;
+using Tamma.Api.Services.Provisioning;
+using Tamma.Api.Services.Provisioning.V2;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Provisioning.V2;
+
+/// <summary>
+/// Phase-B I1 regression — proves a SINGLE <see cref="PlatformTaskWorker"/>
+/// process can complete a v2 provision that requires an inner
+/// <c>provisioning.tenant</c> task to run on the SAME queue.
+///
+/// <para>Before the restructure the V2 saga block-polled the provider in an
+/// in-process loop, pinning the worker's one-task-at-a-time slot for the
+/// whole ~30-min probe budget. On a single worker the inner task the Cranl
+/// provider enqueues was never reserved, so the provision timed out — the
+/// old code needed ≥2 worker processes. After the fix the saga's InitialProbe
+/// is single-shot: a still-provisioning probe DEFERS (returns the row to the
+/// queue with a future <c>VisibleAt</c> + throws
+/// <see cref="PlatformTaskDeferredException"/>), releasing the slot so the
+/// inner task runs on the next tick of the SAME worker.</para>
+///
+/// <para>This test wires the real
+/// <see cref="ProvisionTenantV2TaskHandler"/> + <see cref="ProvisionTenantV2Workflow"/>
+/// against an InMemory control-plane DB and drives
+/// <see cref="PlatformTaskWorker.ProcessOnceAsync"/> tick-by-tick.</para>
+/// </summary>
+[TestFixture]
+public sealed class ProvisionTenantV2SingleWorkerInterleaveTests
+{
+    private const string InnerTaskType = "provisioning.tenant";
+
+    private sealed class InnerStubHandler : IPlatformTaskHandler
+    {
+        public int Calls { get; private set; }
+        public string TaskType => InnerTaskType;
+        public Task HandleAsync(PlatformQueuedTask task, CancellationToken ct)
+        {
+            Calls++;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Test]
+    public async Task SingleWorker_SagaDefers_InnerTaskRuns_ThenResumeReachesReady()
+    {
+        var dbName = $"v2-interleave-{Guid.NewGuid():N}";
+        var tenantId = Guid.NewGuid();
+
+        // ── Provider: enqueues ONE inner provisioning.tenant task on first
+        // ProvisionAsync (like CranlTenantProviderV2), and reports AppDeploying
+        // on the first probe then Ready on the second (single-shot per resume).
+        var fake = new FakeTenantInfrastructureProvider("cranl");
+        fake.EnqueueDeploying(times: 1).EnqueueReady();
+
+        var innerHandler = new InnerStubHandler();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContext<ControlPlaneDbContext>(o => o.UseInMemoryDatabase(dbName));
+        services.AddSingleton(TimeProvider.System);
+        services.AddScoped<IPlatformQueuedTaskRepository, PlatformQueuedTaskRepository>();
+        services.AddSingleton(Mock.Of<IPlatformEventPublisher>());
+        services.AddSingleton(new TenantProviderRegistry(
+            new ITenantInfrastructureProvider[] { new NullTenantProvider(), fake }));
+        // Small probe interval so the deferred saga's VisibleAt window is short;
+        // large enough that tick-2 runs before it re-opens.
+        services.AddScoped(sp => new ProvisionTenantV2Workflow(
+            sp.GetRequiredService<ControlPlaneDbContext>(),
+            sp.GetRequiredService<TenantProviderRegistry>(),
+            sp.GetRequiredService<IPlatformEventPublisher>(),
+            sp.GetRequiredService<TimeProvider>(),
+            NullLogger<ProvisionTenantV2Workflow>.Instance)
+        {
+            ProbeInterval = TimeSpan.FromMinutes(5),
+            ProbeTimeout = TimeSpan.FromMinutes(30),
+        });
+        // Both platform-task handlers share the ONE queue / ONE worker.
+        services.AddSingleton<IPlatformTaskHandler>(innerHandler);
+        services.AddScoped<IPlatformTaskHandler, ProvisionTenantV2TaskHandler>();
+        services.AddScoped<IPlatformTaskHandlerRegistry, PlatformTaskHandlerRegistry>();
+
+        await using var sp = services.BuildServiceProvider();
+
+        // Provider enqueues the inner task through its own scope on first call.
+        var innerEnqueued = false;
+        fake.OnProvision = async (_, _, _) =>
+        {
+            if (!innerEnqueued)
+            {
+                innerEnqueued = true;
+                await using var scope = sp.CreateAsyncScope();
+                var r = scope.ServiceProvider.GetRequiredService<IPlatformQueuedTaskRepository>();
+                await r.EnqueueAsync(new PlatformQueuedTask
+                {
+                    Type = InnerTaskType,
+                    TenantId = tenantId,
+                    Payload = "{}",
+                });
+            }
+            return new ProvisioningResult(
+                new ProvisioningStatusSnapshot(
+                    ProvisioningState.Pending, "queued", null, DateTimeOffset.UtcNow),
+                new Dictionary<string, string>());
+        };
+
+        // Seed the tenant + enqueue the outer saga task (older ⇒ reserved first).
+        Guid sagaId;
+        await using (var scope = sp.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ControlPlaneDbContext>();
+            db.Tenants.Add(new Tenant
+            {
+                Id = tenantId,
+                Name = "Acme",
+                Slug = "acme-" + Guid.NewGuid().ToString("N")[..6],
+                ProvisioningState = "none",
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+            });
+            await db.SaveChangesAsync();
+
+            var repo = scope.ServiceProvider.GetRequiredService<IPlatformQueuedTaskRepository>();
+            var saga = await repo.EnqueueAsync(new PlatformQueuedTask
+            {
+                Type = ProvisionTenantV2TaskPayload.TaskType,
+                TenantId = tenantId,
+                Payload = JsonSerializer.Serialize(new ProvisionTenantV2TaskPayload
+                {
+                    TenantId = tenantId,
+                    ProviderKey = "cranl",
+                    Topology = ProvisioningTopology.DedicatedCompute,
+                    Region = "germany-1",
+                }),
+            });
+            sagaId = saga.Id;
+        }
+
+        var worker = new PlatformTaskWorker(
+            sp,
+            Options.Create(new PlatformTaskWorkerOptions
+            {
+                RunOnStartup = false,
+                WorkerId = "single-worker",
+                MaxRetries = 5,
+            }),
+            TimeProvider.System,
+            NullLogger<PlatformTaskWorker>.Instance);
+
+        // ── Tick 1: the ONLY reservable row is the saga. It provisions
+        // (enqueuing the inner task), probes AppDeploying, and DEFERS —
+        // releasing the slot. Nothing is completed/failed.
+        (await worker.ProcessOnceAsync(default)).Should().BeTrue();
+        innerHandler.Calls.Should().Be(0, "the inner task hasn't been reserved yet");
+        var afterTick1 = await GetTaskAsync(sp, sagaId);
+        afterTick1!.Status.Should().Be("pending", "the saga deferred itself back to pending");
+        afterTick1.RetryCount.Should().Be(0, "a defer does not burn the retry budget");
+        afterTick1.VisibleAt.Should().NotBeNull("the saga is invisible until its probe interval elapses");
+
+        // ── Tick 2: the saga's VisibleAt is in the future, so the worker
+        // reserves the INNER task instead and runs it. THIS is the proof the
+        // single worker interleaved because the saga released the slot.
+        (await worker.ProcessOnceAsync(default)).Should().BeTrue();
+        innerHandler.Calls.Should().Be(1, "the single worker ran the inner task while the saga was deferred");
+        (await GetTaskAsync(sp, sagaId))!.Status.Should().Be("pending", "the saga is still deferred");
+
+        // Simulate the ProbeInterval window elapsing (deterministic — no real
+        // wait): open the saga's VisibleAt so it is reservable again.
+        await using (var scope = sp.CreateAsyncScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<IPlatformQueuedTaskRepository>();
+            await repo.DeferAsync(sagaId, DateTime.UtcNow.AddSeconds(-1));
+        }
+
+        // ── Tick 3: the saga resumes, re-runs steps 1-6 (idempotent), probes
+        // Ready, activates, and completes.
+        (await worker.ProcessOnceAsync(default)).Should().BeTrue();
+
+        var finalSaga = await GetTaskAsync(sp, sagaId);
+        finalSaga!.Status.Should().Be("completed", "the resumed saga reached Ready and the worker marked it completed");
+
+        await using (var scope = sp.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ControlPlaneDbContext>();
+            var tenant = await db.Tenants.IgnoreQueryFilters().FirstAsync(t => t.Id == tenantId);
+            tenant.ProvisioningState.Should().Be("ready");
+        }
+
+        fake.ProvisionCalls.Should().HaveCount(2, "provision runs once per saga invocation (idempotent on resume)");
+        fake.DeprovisionCalls.Should().BeEmpty("happy path runs no compensation");
+    }
+
+    private static async Task<PlatformQueuedTask?> GetTaskAsync(IServiceProvider sp, Guid id)
+    {
+        await using var scope = sp.CreateAsyncScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IPlatformQueuedTaskRepository>();
+        return await repo.GetAsync(id);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/V2/ProvisionTenantV2TaskHandlerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/V2/ProvisionTenantV2TaskHandlerTests.cs
@@ -11,6 +11,7 @@ using Tamma.Api.Services.Provisioning.V2;
 using Tamma.Data;
 using Tamma.Data.Abstractions;
 using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
 
 namespace Tamma.Api.Tests.Provisioning.V2;
 
@@ -69,6 +70,11 @@ public sealed class ProvisionTenantV2TaskHandlerTests
 
     private ProvisionTenantV2TaskHandler BuildHandler(
         params ITenantInfrastructureProvider[] providers)
+        => BuildHandler(new RecordingQueueRepo(), providers);
+
+    private ProvisionTenantV2TaskHandler BuildHandler(
+        RecordingQueueRepo repo,
+        params ITenantInfrastructureProvider[] providers)
     {
         var all = new List<ITenantInfrastructureProvider> { new NullTenantProvider() };
         all.AddRange(providers);
@@ -84,7 +90,38 @@ public sealed class ProvisionTenantV2TaskHandlerTests
             ProbeTimeout = TimeSpan.FromSeconds(5),
         };
         return new ProvisionTenantV2TaskHandler(
-            workflow, NullLogger<ProvisionTenantV2TaskHandler>.Instance);
+            workflow, repo, TimeProvider.System,
+            NullLogger<ProvisionTenantV2TaskHandler>.Instance);
+    }
+
+    /// <summary>
+    /// Minimal queue-repo test double: records <c>DeferAsync</c> calls (the
+    /// only method the handler invokes) and no-ops the rest. Modelled on the
+    /// <c>StubQueueRepo</c> in <c>RetireSecretVersionTaskHandlerTests</c>.
+    /// </summary>
+    private sealed class RecordingQueueRepo : IPlatformQueuedTaskRepository
+    {
+        public List<(Guid Id, DateTime VisibleAt)> Deferred { get; } = new();
+
+        public Task<PlatformQueuedTask> EnqueueAsync(PlatformQueuedTask task, CancellationToken ct = default)
+            => Task.FromResult(task);
+        public Task<PlatformQueuedTask?> ReserveNextAsync(string workerId, CancellationToken ct = default)
+            => Task.FromResult<PlatformQueuedTask?>(null);
+        public Task CompleteAsync(Guid id, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<PlatformQueuedTask?> FailAsync(Guid id, string error, int maxRetries, CancellationToken ct = default)
+            => Task.FromResult<PlatformQueuedTask?>(null);
+        public Task DeadLetterAsync(Guid id, string error, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<PlatformQueuedTask?> ParkUnprocessableAsync(Guid id, string reason, int maxRetries, CancellationToken ct = default)
+            => Task.FromResult<PlatformQueuedTask?>(null);
+        public Task DeferAsync(Guid id, DateTime visibleAt, CancellationToken ct = default)
+        {
+            Deferred.Add((id, visibleAt));
+            return Task.CompletedTask;
+        }
+        public Task<PlatformQueuedTask?> GetAsync(Guid id, CancellationToken ct = default)
+            => Task.FromResult<PlatformQueuedTask?>(null);
+        public Task<int> ReapStaleProcessingAsync(TimeSpan visibilityTimeout, int maxRetries, CancellationToken ct = default)
+            => Task.FromResult(0);
     }
 
     [Test]
@@ -263,10 +300,10 @@ public sealed class ProvisionTenantV2TaskHandlerTests
             new ProvisioningStatusSnapshot(
                 ProvisioningState.Deprovisioned, "deprovision_complete", null, DateTimeOffset.UtcNow),
             new Dictionary<string, string>());
-        var provisionResult = new ProvisioningResult(
+        var provisionOutcome = ProvisionTenantV2Outcome.Completed(new ProvisioningResult(
             new ProvisioningStatusSnapshot(
                 ProvisioningState.Ready, "ready", null, DateTimeOffset.UtcNow),
-            new Dictionary<string, string>());
+            new Dictionary<string, string>()));
 
         workflowMock
             .Setup(w => w.DeprovisionAsync(
@@ -274,11 +311,12 @@ public sealed class ProvisionTenantV2TaskHandlerTests
             .ReturnsAsync(deprovisionResult);
         workflowMock
             .Setup(w => w.ExecuteAsync(
-                It.IsAny<ProvisionTenantV2TaskPayload>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(provisionResult);
+                It.IsAny<ProvisionTenantV2TaskPayload>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(provisionOutcome);
 
         var handler = new ProvisionTenantV2TaskHandler(
-            workflowMock.Object, NullLogger<ProvisionTenantV2TaskHandler>.Instance);
+            workflowMock.Object, new RecordingQueueRepo(), TimeProvider.System,
+            NullLogger<ProvisionTenantV2TaskHandler>.Instance);
 
         var payload = new ProvisionTenantV2TaskPayload
         {
@@ -300,6 +338,102 @@ public sealed class ProvisionTenantV2TaskHandlerTests
         workflowMock.Verify(w => w.DeprovisionAsync(
             It.IsAny<ProvisionTenantV2TaskPayload>(), It.IsAny<CancellationToken>()), Times.Once);
         workflowMock.Verify(w => w.ExecuteAsync(
-            It.IsAny<ProvisionTenantV2TaskPayload>(), It.IsAny<CancellationToken>()), Times.Never);
+            It.IsAny<ProvisionTenantV2TaskPayload>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_TenantStillProvisioning_DefersAndThrowsDeferredException()
+    {
+        // Phase-B I1: a non-terminal probe within the budget makes the handler
+        // return the row to the queue (DeferAsync, VisibleAt ≈ now + ProbeInterval)
+        // and throw PlatformTaskDeferredException — the worker treats that as a
+        // no-op ack (no Complete/Fail), releasing the single-worker slot so the
+        // inner provisioning.tenant task can run before the next resume.
+        var tenant = await SeedAsync();
+        var fake = new FakeTenantInfrastructureProvider("cranl");
+        fake.EnqueueDeploying(times: 1); // still provisioning on the single probe
+
+        var repo = new RecordingQueueRepo();
+        var handler = BuildHandler(repo, fake);
+        var payload = new ProvisionTenantV2TaskPayload
+        {
+            TenantId = tenant.Id,
+            ProviderKey = "cranl",
+            Topology = ProvisioningTopology.DedicatedCompute,
+            Region = "germany-1",
+        };
+        var task = new PlatformQueuedTask
+        {
+            Id = Guid.NewGuid(),
+            Type = ProvisionTenantV2TaskPayload.TaskType,
+            TenantId = tenant.Id,
+            Payload = JsonSerializer.Serialize(payload),
+            // First-enqueue timestamp in the recent past ⇒ deadline (CreatedAt +
+            // 5s ProbeTimeout) is still in the future ⇒ within budget ⇒ defer.
+            CreatedAt = DateTime.UtcNow,
+        };
+
+        var before = DateTime.UtcNow;
+        var thrown = await Record(() => handler.HandleAsync(task, CancellationToken.None));
+
+        // Deferred, not a terminal failure.
+        thrown.Should().BeOfType<PlatformTaskDeferredException>();
+        thrown.Should().NotBeOfType<PlatformTaskTerminalException>();
+        // Row was returned to the queue with a future VisibleAt (≈ now + 1ms
+        // ProbeInterval), and only once.
+        repo.Deferred.Should().ContainSingle();
+        repo.Deferred[0].Id.Should().Be(task.Id);
+        repo.Deferred[0].VisibleAt.Should().BeOnOrAfter(before);
+        // No compensation on a defer — the tenant stays Pending for the resume.
+        fake.DeprovisionCalls.Should().BeEmpty();
+        var refreshed = await _db.Tenants.IgnoreQueryFilters()
+            .FirstAsync(t => t.Id == tenant.Id);
+        refreshed.ProvisioningState.Should().Be("pending");
+    }
+
+    [Test]
+    public async Task HandleAsync_ProbeDeadlineExceeded_FailsWithoutDeferring()
+    {
+        // When the cross-resume budget (task.CreatedAt + ProbeTimeout) is
+        // already blown, a still-provisioning probe drives Failed + compensation
+        // — it must NOT defer (which would loop forever past the deadline).
+        var tenant = await SeedAsync();
+        var fake = new FakeTenantInfrastructureProvider("cranl");
+        fake.EnqueueDeploying(times: 1);
+
+        var repo = new RecordingQueueRepo();
+        var handler = BuildHandler(repo, fake);
+        var payload = new ProvisionTenantV2TaskPayload
+        {
+            TenantId = tenant.Id,
+            ProviderKey = "cranl",
+            Topology = ProvisioningTopology.DedicatedCompute,
+            Region = "germany-1",
+        };
+        var task = new PlatformQueuedTask
+        {
+            Id = Guid.NewGuid(),
+            Type = ProvisionTenantV2TaskPayload.TaskType,
+            TenantId = tenant.Id,
+            Payload = JsonSerializer.Serialize(payload),
+            // Enqueued an hour ago ⇒ CreatedAt + 5s ProbeTimeout is long past.
+            CreatedAt = DateTime.UtcNow.AddHours(-1),
+        };
+
+        // Terminal (Failed) — the handler does NOT throw; the state is persisted.
+        Func<Task> act = async () => await handler.HandleAsync(task, CancellationToken.None);
+        await act.Should().NotThrowAsync();
+
+        repo.Deferred.Should().BeEmpty("past the deadline the handler must not defer");
+        fake.DeprovisionCalls.Should().HaveCount(1, "timeout runs compensation");
+        var refreshed = await _db.Tenants.IgnoreQueryFilters()
+            .FirstAsync(t => t.Id == tenant.Id);
+        refreshed.ProvisioningState.Should().Be("failed");
+    }
+
+    private static async Task<Exception?> Record(Func<Task> act)
+    {
+        try { await act(); return null; }
+        catch (Exception ex) { return ex; }
     }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/V2/ProvisionTenantV2WorkflowTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/V2/ProvisionTenantV2WorkflowTests.cs
@@ -115,22 +115,56 @@ public sealed class ProvisionTenantV2WorkflowTests
     {
         var tenant = await SeedAsync();
         var fake = new FakeTenantInfrastructureProvider("cranl");
-        fake.EnqueueDeploying(times: 2).EnqueueReady();
+        // Phase-B I1: the probe is SINGLE-SHOT — one GetStatusAsync per
+        // invocation. A tenant that is Ready on the first probe reaches Ready
+        // in one call; the "not ready yet" case is a DeferRequested outcome,
+        // covered by ExecuteAsync_NonTerminalWithinBudget_ReturnsDeferRequested.
+        fake.EnqueueReady();
 
         var workflow = Build(RegistryWith(fake));
 
         var result = await workflow.ExecuteAsync(
             PayloadFor(tenant.Id, "cranl"), CancellationToken.None);
 
+        result.Kind.Should().Be(ProvisionTenantV2OutcomeKind.Completed);
         result.Status.State.Should().Be(ProvisioningState.Ready);
         result.Status.FailureReason.Should().BeNull();
         fake.ProvisionCalls.Should().HaveCount(1);
-        fake.StatusCalls.Count.Should().BeGreaterThanOrEqualTo(3);
+        fake.StatusCalls.Should().HaveCount(1, "single-shot probe reads status exactly once");
         fake.DeprovisionCalls.Should().BeEmpty("happy path runs no compensation");
 
         var refreshed = await _db.Tenants.IgnoreQueryFilters()
             .FirstAsync(t => t.Id == tenant.Id);
         refreshed.ProvisioningState.Should().Be("ready");
+    }
+
+    [Test]
+    public async Task ExecuteAsync_NonTerminalWithinBudget_ReturnsDeferRequested()
+    {
+        // Phase-B I1: a still-provisioning tenant within the probe budget must
+        // NOT block-poll — it returns DeferRequested so the caller releases the
+        // worker slot. No compensation runs; the tenant stays Pending.
+        var tenant = await SeedAsync();
+        var fake = new FakeTenantInfrastructureProvider("cranl");
+        fake.EnqueueDeploying(times: 1);
+
+        var workflow = Build(RegistryWith(fake));
+        // 2-arg overload → deadline = now + ProbeTimeout(5s) ⇒ within budget.
+        var result = await workflow.ExecuteAsync(
+            PayloadFor(tenant.Id, "cranl"), CancellationToken.None);
+
+        result.Kind.Should().Be(ProvisionTenantV2OutcomeKind.DeferRequested);
+        result.IsDeferRequested.Should().BeTrue();
+        result.DeferDelay.Should().Be(workflow.ProbeInterval);
+        result.Status.State.Should().Be(ProvisioningState.AppDeploying,
+            "the defer outcome carries the last non-terminal snapshot");
+        fake.StatusCalls.Should().HaveCount(1, "exactly one probe before yielding");
+        fake.DeprovisionCalls.Should().BeEmpty("a defer runs no compensation");
+
+        var refreshed = await _db.Tenants.IgnoreQueryFilters()
+            .FirstAsync(t => t.Id == tenant.Id);
+        refreshed.ProvisioningState.Should().Be("pending",
+            "the tenant stays Pending across the yield so the next resume re-enters");
     }
 
     [Test]
@@ -188,20 +222,24 @@ public sealed class ProvisionTenantV2WorkflowTests
     }
 
     [Test]
-    public async Task ExecuteAsync_ProbeTimeout_StampsTimeoutAndDeprovisions()
+    public async Task ExecuteAsync_ProbeDeadlineExceeded_StampsTimeoutAndDeprovisions()
     {
+        // Phase-B I1: the ~30-min budget is now enforced by an ABSOLUTE
+        // deadline passed in by the caller (derived from the task's
+        // first-enqueue time so it survives defers). A still-provisioning
+        // probe past that deadline drives the same timeout + compensation the
+        // old in-loop budget-exceeded branch produced.
         var tenant = await SeedAsync();
         var fake = new FakeTenantInfrastructureProvider("cranl");
-        // Drain the script — every GetStatus call returns AppDeploying
-        // forever (until the budget runs out).
-        fake.EnqueueDeploying(times: 100);
+        fake.EnqueueDeploying(times: 1);
 
         var workflow = Build(RegistryWith(fake));
-        workflow.ProbeTimeout = TimeSpan.FromMilliseconds(20);
+        var alreadyExpired = DateTimeOffset.UtcNow.AddSeconds(-1);
 
         var result = await workflow.ExecuteAsync(
-            PayloadFor(tenant.Id, "cranl"), CancellationToken.None);
+            PayloadFor(tenant.Id, "cranl"), alreadyExpired, CancellationToken.None);
 
+        result.Kind.Should().Be(ProvisionTenantV2OutcomeKind.Failed);
         result.Status.FailureReason.Should().Be(ProvisioningFailureReasons.ProbeTimeout);
         fake.DeprovisionCalls.Should().HaveCount(1);
     }
@@ -448,8 +486,7 @@ public sealed class ProvisionTenantV2WorkflowTests
     {
         var tenant = await SeedAsync();
         var fake = new FakeTenantInfrastructureProvider("cranl");
-        // First poll: still deploying. Second poll: provider transitioned to Failed.
-        fake.EnqueueDeploying(times: 1);
+        // Single-shot probe observes the provider's Failed transition.
         fake.EnqueueProviderFailure("cranl_app_deploy_failed", "deploy returned 500");
 
         var workflow = Build(RegistryWith(fake));
@@ -457,6 +494,7 @@ public sealed class ProvisionTenantV2WorkflowTests
         var result = await workflow.ExecuteAsync(
             PayloadFor(tenant.Id, "cranl"), CancellationToken.None);
 
+        result.Kind.Should().Be(ProvisionTenantV2OutcomeKind.Failed);
         result.Status.State.Should().Be(ProvisioningState.Failed);
         result.Status.FailureReason.Should().Be("cranl_app_deploy_failed",
             "probe surfaces the provider's failure short-code");


### PR DESCRIPTION
## Problem

`ProvisionTenantV2Workflow.ExecuteAsync` block-polled up to ~30 min for an inner `provisioning.tenant` task that `CranlTenantProviderV2.ProvisionAsync` enqueues on the **same** platform queue. `PlatformTaskWorker` processes one task at a time per process, so on a **single** worker the outer saga occupies the only slot, the inner task is never reserved, and the provision times out to `Failed`. The V2 Cranl path therefore required ≥2 platform-worker processes (documented constraint in CLAUDE.md).

## Fix — single-shot probe + cooperative defer

Replace the in-process probe loop with a single `GetStatusAsync` check that yields the worker slot between probes using the **existing** defer primitive:

- New `ProvisionTenantV2Outcome { Completed | Failed | DeferRequested }`.
- Non-terminal-within-budget → the handler returns the row to `pending` (`DeferAsync`, `VisibleAt = now + ProbeInterval`) and throws `PlatformTaskDeferredException` — the yield the worker already acks as a no-op (no `Complete`/`Fail`, retry budget untouched). Modelled byte-for-byte on `RetireSecretVersionTaskHandler`.
- Releasing the slot lets a **single** worker interleave the inner Cranl task, then resume the saga on the next reservation (steps 1–6 are idempotent).

## Cross-resume budget — no migration

The ~30-min budget must span defers (the old per-invocation timer reset each resume). Derived from the task's existing `PlatformQueuedTask.CreatedAt + ProbeTimeout` — `CreatedAt` is set once at enqueue and `DeferAsync` never touches it, so the deadline is stable. **Zero new persisted state, no EF migration.** Deadline-exceeded runs the same compensations + `ProbeTimeout` stamp the old path produced.

## Verification

- `dotnet build`: 0 errors.
- `ProvisionTenantV2 | PlatformTaskWorker` tests: **54 passed**, including a new `ProvisionTenantV2SingleWorkerInterleaveTests` that drives a real `PlatformTaskWorker` tick-by-tick on one process — tick 1 saga defers (inner task enqueued), tick 2 the single worker reserves & runs the inner task (proving the slot was released), tick 3 the saga resumes → tenant `ready`.

Note: `PlatformTaskWorker.RunOnStartup` remains `false`, so this path is still opt-in; the fix removes the ≥2-worker *correctness* requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)