### PR TITLE
feat(epic-36): Story 36-2 — DCB-to-analytics dimensional projection pipeline

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/Analytics/AnalyticsRollupEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Analytics/AnalyticsRollupEvents.cs
@@ -34,6 +34,34 @@ public static class AnalyticsRollupEvents
     public const string AnalyticsPurged = "ANALYTICS.PURGE.HOURLY";
     public const string AnalyticsPurgeFailed = "ANALYTICS.PURGE.FAILED";
 
+    // ── Story 36-2 — per-tenant dimensional projection pipeline ──
+    // Same AGGREGATE.ACTION.STATUS convention; the ANALYTICS.PROJECTION /
+    // ANALYTICS.ROLLUP.TENANT_DIMENSIONAL_* family was reserved for this
+    // story by Story 36-1 §"DCB events". Per-tenant events carry tenantId so
+    // the Story 28-6 step-dedup index applies.
+
+    /// <summary>Per tenant×hour — the dimensional projection wrote its rows.</summary>
+    public const string TenantDimensionalRollupCompleted =
+        "ANALYTICS.ROLLUP.TENANT_DIMENSIONAL_COMPLETED";
+
+    /// <summary>Per tenant×hour — the dimensional projection threw (fan-out continues).</summary>
+    public const string TenantDimensionalRollupFailed =
+        "ANALYTICS.ROLLUP.TENANT_DIMENSIONAL_FAILED";
+
+    /// <summary>Per tenant×day — hourly→daily lossless compaction completed.</summary>
+    public const string DailyCompacted = "ANALYTICS.COMPACT.DAILY";
+
+    /// <summary>Terminal event for the per-tenant analytics_usage_hourly retention sweep.</summary>
+    public const string UsageHourlyPurged = "ANALYTICS.PURGE.USAGE_HOURLY";
+    public const string UsageHourlyPurgeFailed = "ANALYTICS.PURGE.USAGE_HOURLY_FAILED";
+
+    /// <summary>
+    /// Per fan-out pass, emitted only when the wall-clock lag between the
+    /// rolled-up hour and projection completion exceeds the SLO budget. A
+    /// WARN-level observability signal, never a failure.
+    /// </summary>
+    public const string DimensionalLag = "ANALYTICS.ROLLUP.DIMENSIONAL_LAG";
+
     /// <summary>
     /// Build a <see cref="PlatformEvent"/> for an hourly-rollup milestone.
     /// <paramref name="tenantId"/> is null when the event is platform-wide

--- a/apps/tamma-elsa/src/Tamma.Activities/Analytics/CompactDailyAnalyticsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Analytics/CompactDailyAnalyticsActivity.cs
@@ -1,0 +1,160 @@
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+using Tamma.Core.Enums;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+
+namespace Tamma.Activities.Analytics;
+
+/// <summary>
+/// Story 36-2 — rolls a tenant's <c>analytics_usage_hourly</c> rows for a
+/// completed UTC day up into <c>analytics_usage_daily</c> as a lossless
+/// <c>GROUP BY date_trunc('day', Hour), &lt;all dims&gt;</c> with summed
+/// measures, upserting on the daily <c>UX_analytics_usage_daily_dims</c>
+/// business key.
+///
+/// <para>Lossless because Story 36-1 gave the hourly and daily entities an
+/// identical dimension + measure contract. Idempotent (whole-day
+/// read-then-upsert overwrite) so a re-run is a no-op on measures. Runs once
+/// per day — the workflow only schedules it when the target hour is the first
+/// hour of a new UTC day, compacting the day that just ended — so no second
+/// scheduler is introduced.</para>
+/// </summary>
+[Activity(
+    "Tamma.Analytics",
+    "Compact Daily Analytics",
+    "Roll analytics_usage_hourly into analytics_usage_daily for a completed UTC day.",
+    Kind = ActivityKind.Task)]
+public sealed class CompactDailyAnalyticsActivity : TammaAsyncActivity
+{
+    [Input(Description = "Tenant id to compact.")]
+    public Input<Guid> TenantId { get; set; } = default!;
+
+    [Input(Description = "UTC midnight of the day to compact (the day that just ended).")]
+    public Input<DateTime> Day { get; set; } = default!;
+
+    public override string? EventType => "ANALYTICS.COMPACT";
+
+    protected override async Task RunAsync(ActivityExecutionContext context)
+    {
+        var tenantId = TenantId.Get(context);
+        var day = TruncateToDay(Day.Get(context));
+
+        Logger ??= context.GetService<ILogger<CompactDailyAnalyticsActivity>>();
+
+        var tenantFactory = context.GetRequiredService<ITenantDbContextFactory>();
+        var publisher = context.GetRequiredService<IPlatformEventPublisher>();
+
+        await CompactAsync(tenantFactory, publisher, tenantId, day, Logger, context.CancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Pure-DI entry point — reads the day's hourly rows, groups by the full
+    /// dimension tuple, and upserts the summed measures into the daily table.
+    /// </summary>
+    public static async Task CompactAsync(
+        ITenantDbContextFactory tenantFactory,
+        IPlatformEventPublisher publisher,
+        Guid tenantId,
+        DateTime day,
+        ILogger? logger,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(tenantFactory);
+        ArgumentNullException.ThrowIfNull(publisher);
+
+        day = TruncateToDay(day);
+        var dayEnd = day.AddDays(1);
+
+        await using var tenantDb = await tenantFactory
+            .CreateAsync(tenantId, cancellationToken)
+            .ConfigureAwait(false);
+
+        var hourly = await tenantDb.AnalyticsUsageHourly
+            .AsNoTracking()
+            .Where(r => r.Hour >= day && r.Hour < dayEnd)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Lossless GROUP BY the full dimension tuple (done in memory — a day is
+        // ≤ 24 × tuple-count rows, trivially bounded).
+        var grouped = hourly
+            .GroupBy(r => (r.Provider, r.AgentId, r.WorkflowDefinitionId, r.RepoId, r.CostBasis))
+            .ToList();
+
+        var now = DateTime.UtcNow;
+        long rowsWritten = 0;
+
+        foreach (var g in grouped)
+        {
+            var (provider, agentId, workflowDefinitionId, repoId, costBasis) = g.Key;
+
+            var existing = await tenantDb.AnalyticsUsageDaily
+                .FirstOrDefaultAsync(
+                    r => r.Day == day
+                         && r.Provider == provider
+                         && r.AgentId == agentId
+                         && r.WorkflowDefinitionId == workflowDefinitionId
+                         && r.RepoId == repoId
+                         && r.CostBasis == costBasis,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            var target = existing ?? new AnalyticsUsageDaily
+            {
+                Id = Guid.NewGuid(),
+                Day = day,
+                Provider = provider,
+                AgentId = agentId,
+                WorkflowDefinitionId = workflowDefinitionId,
+                RepoId = repoId,
+                CostBasis = costBasis,
+            };
+
+            target.TokensIn = g.Sum(r => r.TokensIn);
+            target.TokensOut = g.Sum(r => r.TokensOut);
+            target.CostUsd = g.Sum(r => r.CostUsd);
+            target.PlatformBilledUsd = g.Sum(r => r.PlatformBilledUsd);
+            target.WorkflowsStarted = g.Sum(r => r.WorkflowsStarted);
+            target.WorkflowsCompleted = g.Sum(r => r.WorkflowsCompleted);
+            target.WorkflowsFailed = g.Sum(r => r.WorkflowsFailed);
+            target.AgentDispatches = g.Sum(r => r.AgentDispatches);
+            target.ComputedAt = now;
+
+            if (existing is null) tenantDb.AnalyticsUsageDaily.Add(target);
+            rowsWritten++;
+        }
+
+        await tenantDb.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        await publisher.AppendAndPublishAsync(
+            AnalyticsRollupEvents.BuildEvent(
+                AnalyticsRollupEvents.DailyCompacted,
+                day,
+                tenantId,
+                data: new Dictionary<string, object?>
+                {
+                    ["day"] = day.ToString("O"),
+                    ["rowsWritten"] = rowsWritten,
+                }),
+            cancellationToken).ConfigureAwait(false);
+
+        logger?.LogInformation(
+            "analytics.compact.daily_completed tenantId={TenantId} day={Day} rowsWritten={Rows}",
+            tenantId, day, rowsWritten);
+    }
+
+    /// <summary>Truncate to UTC midnight.</summary>
+    public static DateTime TruncateToDay(DateTime instant)
+    {
+        var utc = instant.Kind == DateTimeKind.Utc ? instant : instant.ToUniversalTime();
+        return new DateTime(utc.Year, utc.Month, utc.Day, 0, 0, 0, DateTimeKind.Utc);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Analytics/ComputeTenantDimensionalRollupActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Analytics/ComputeTenantDimensionalRollupActivity.cs
@@ -1,0 +1,500 @@
+using System.Text.Json;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+using Tamma.Core.Enums;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+
+namespace Tamma.Activities.Analytics;
+
+/// <summary>
+/// Story 36-2 — per-tenant <b>dimensional</b> rollup step. Projects one
+/// tenant's hour of <c>domain_events</c> (<c>LLM.CALL.SUCCESS</c>,
+/// <c>AGENT.DISPATCH.*</c>) + <see cref="ProviderDiagnostic"/> rows into
+/// <c>analytics_usage_hourly</c> — one row per
+/// <c>(Provider, AgentId, WorkflowDefinitionId, RepoId, CostBasis)</c> tuple.
+///
+/// <para>Mirrors <see cref="ComputeTenantRollupActivity"/> exactly (static
+/// pure-DI <see cref="ComputeAsync"/>, shared JSON measure extraction,
+/// read-then-upsert on the business key) but GROUPS BY the dimension tuple
+/// instead of collapsing to one row, and writes to the tenant's own schema
+/// via <see cref="ITenantDbContextFactory"/> instead of the control-plane
+/// fact table.</para>
+///
+/// <para><b>Idempotency:</b> the activity recomputes the entire
+/// <c>(tenant, hour)</c> bucket from source each pass and <i>overwrites</i>
+/// the measures on the full dimension business key — so replay and backfill
+/// never double-count. The Story 36-1 <c>UX_analytics_usage_hourly_dims</c>
+/// NULLS-NOT-DISTINCT index is the concurrent-replay backstop.</para>
+///
+/// <para><b>Resumable HIGH-WATER checkpoint:</b> a per-tenant
+/// <see cref="AnalyticsProjectionCheckpoint"/> (<c>Stream = "dimensional"</c>)
+/// records the max <see cref="DomainEvent.SequenceNumber"/> folded. When a fact
+/// row already exists for the bucket AND no domain event newer than the
+/// checkpoint is present (<c>maxSeq &lt;= checkpoint</c>), the recompute is
+/// SKIPPED — work happens only for events with <c>SequenceNumber &gt;
+/// checkpoint</c>. Otherwise the whole bucket is recomputed and the checkpoint
+/// advances to <c>maxSeq</c> in the same <c>SaveChanges</c>. The whole-bucket
+/// overwrite (not a delta) is the idempotency mechanism, so a stale/reset
+/// checkpoint can never corrupt totals; the checkpoint only skips redundant work.</para>
+///
+/// <para><b>Provider is NULLABLE</b> (Story 36-2): the projection stores both
+/// provider-attributed usage (<c>LLM.CALL.SUCCESS</c>,
+/// <see cref="ProviderDiagnostic"/> — always carry a provider) AND
+/// non-provider-attributed counts. Agent-dispatch events
+/// (<c>AGENT_DISPATCH.RUN_TRIGGERED.*</c> / legacy <c>AGENT.DISPATCH.*</c>) and
+/// workflow-lifecycle counts carry no provider, so they bucket under the NULL
+/// provider (as their own dimensional rows), NOT dropped. Absent nullable
+/// dimensions (<c>agent_id</c>, <c>workflowDefinitionId</c>, <c>repoId</c>) also
+/// bucket under <c>NULL</c>, so per-dimension breakdowns reconcile to the grand
+/// total via the <c>UX_*_dims</c> NULLS-NOT-DISTINCT index.</para>
+///
+/// <para><b>Cost is authoritative from <see cref="ProviderDiagnostic"/>.</b>
+/// No <c>LLM.CALL.SUCCESS</c> emitter exists in the engine today; diagnostics are
+/// the sole cost/token source. To future-proof against double-counting when both
+/// describe the same call, an <c>LLM.CALL.SUCCESS</c> event's cost is folded ONLY
+/// when NO diagnostic shares its <c>correlationId</c>.</para>
+/// </summary>
+[Activity(
+    "Tamma.Analytics",
+    "Compute Tenant Dimensional Rollup",
+    "Project one tenant's domain_events + ProviderDiagnostic for a single hour into analytics_usage_hourly.",
+    Kind = ActivityKind.Task)]
+public sealed class ComputeTenantDimensionalRollupActivity : TammaAsyncActivity
+{
+    [Input(Description = "Tenant id to roll up.")]
+    public Input<Guid> TenantId { get; set; } = default!;
+
+    [Input(Description = "UTC top-of-hour bucket this rollup targets.")]
+    public Input<DateTime> Hour { get; set; } = default!;
+
+    [Input(Description = "Reset the dimensional checkpoint before re-projecting (backfill).")]
+    public Input<bool> ResetCheckpoint { get; set; } = new(false);
+
+    public override string? EventType => "ANALYTICS.ROLLUP.TENANT_DIMENSIONAL";
+
+    protected override async Task RunAsync(ActivityExecutionContext context)
+    {
+        var tenantId = TenantId.Get(context);
+        var hour = AnalyticsRollupEvents.TruncateToHour(Hour.Get(context));
+        var reset = ResetCheckpoint.Get(context);
+
+        Logger ??= context.GetService<ILogger<ComputeTenantDimensionalRollupActivity>>();
+
+        var tenantFactory = context.GetRequiredService<ITenantDbContextFactory>();
+        var publisher = context.GetRequiredService<IPlatformEventPublisher>();
+        var pricing = context.GetService<IAnalyticsPricingConfig>() ?? new NullAnalyticsPricingConfig();
+
+        await ComputeAsync(
+            tenantFactory, publisher, tenantId, hour, pricing, reset, Logger, context.CancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Pure-DI entry point — the fan-out, the backfill endpoint, and unit
+    /// tests drive the same read-compute-upsert cycle without an
+    /// <see cref="ActivityExecutionContext"/> (mirrors
+    /// <see cref="ComputeTenantRollupActivity.ComputeAsync"/>).
+    /// </summary>
+    public static async Task ComputeAsync(
+        ITenantDbContextFactory tenantFactory,
+        IPlatformEventPublisher publisher,
+        Guid tenantId,
+        DateTime hour,
+        IAnalyticsPricingConfig pricing,
+        bool resetCheckpoint,
+        ILogger? logger,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(tenantFactory);
+        ArgumentNullException.ThrowIfNull(publisher);
+        ArgumentNullException.ThrowIfNull(pricing);
+
+        hour = AnalyticsRollupEvents.TruncateToHour(hour);
+        var hourEnd = hour.AddHours(1);
+
+        await using var tenantDb = await tenantFactory
+            .CreateAsync(tenantId, cancellationToken)
+            .ConfigureAwait(false);
+
+        // ── Read the hour window from source (whole-bucket recompute) ──
+        // Dispatch events come in TWO real families: the Story 38-2 mediation
+        // events are underscore-prefixed (AGENT_DISPATCH.RUN_TRIGGERED.*) and the
+        // legacy alert/analytics family is dotted (AGENT.DISPATCH.*). A dotted
+        // LIKE pattern would NEVER match the underscore family (and worse, '_' is
+        // a LIKE single-char wildcard), so we use StartsWith — EF escapes the '_'
+        // and it translates on both Npgsql and the InMemory provider. Only the
+        // RUN_TRIGGERED terminal (one per dispatch) counts; RUN_POLLED /
+        // RESULTS_COLLECTED are follow-up ops, not dispatches, and are excluded.
+        var events = await tenantDb.DomainEvents
+            .AsNoTracking()
+            .Where(e => e.CreatedAt >= hour && e.CreatedAt < hourEnd
+                        && (e.Type == "LLM.CALL.SUCCESS"
+                            || e.Type.StartsWith("AGENT.DISPATCH.")
+                            || e.Type.StartsWith("AGENT_DISPATCH.RUN_TRIGGERED.")))
+            .Select(e => new { e.Type, e.Tags, e.Data, e.SequenceNumber })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var diagnostics = await tenantDb.ProviderDiagnostics
+            .AsNoTracking()
+            .Where(d => d.CreatedAt >= hour && d.CreatedAt < hourEnd)
+            .Select(d => new
+            {
+                d.ProviderKey, d.AgentType, d.ProjectId, d.CorrelationId,
+                d.InputTokens, d.OutputTokens, d.TokensUsed, d.Cost,
+            })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // ── High-water skip (AC7): recompute only when a domain event newer than
+        //    the checkpoint exists (or a reset is requested / no fact row yet). ──
+        var maxSequence = events.Count > 0 ? events.Max(e => e.SequenceNumber) : 0L;
+
+        var checkpoint = await tenantDb.AnalyticsProjectionCheckpoints
+            .FirstOrDefaultAsync(c => c.Stream == AnalyticsProjectionCheckpoint.DimensionalStream,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        var factRowExists = await tenantDb.AnalyticsUsageHourly
+            .AsNoTracking()
+            .AnyAsync(r => r.Hour == hour, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!resetCheckpoint && checkpoint is not null && factRowExists
+            && maxSequence <= checkpoint.LastSequenceNumber)
+        {
+            // No event with SequenceNumber > checkpoint and the bucket is already
+            // projected — nothing to recompute. The whole-bucket overwrite would
+            // reproduce identical rows; skipping avoids the redundant write.
+            logger?.LogInformation(
+                "analytics.dimensional.skip_no_new_events tenantId={TenantId} hour={Hour} checkpoint={Checkpoint} maxSeq={MaxSeq}",
+                tenantId, hour, checkpoint.LastSequenceNumber, maxSequence);
+            return;
+        }
+
+        // The set of correlationIds already accounted for by an authoritative
+        // ProviderDiagnostic — used to dedupe LLM.CALL.SUCCESS cost (see below).
+        var diagnosticCorrelationIds = diagnostics
+            .Where(d => d.CorrelationId is not null)
+            .Select(d => d.CorrelationId!.Value)
+            .ToHashSet();
+
+        var measures = new Dictionary<DimensionKey, Measures>();
+
+        // 1) DCB events — LLM usage + agent dispatches, keyed by tag tuple.
+        //    Provider/agent tags differ by family: LLM uses provider/agent_id;
+        //    the alert dispatch family uses agentHandle; the mediation dispatch
+        //    family carries neither (→ NULL provider bucket). All read uniformly.
+        foreach (var e in events)
+        {
+            var tags = ParseTags(e.Tags);
+            var provider = FirstNonEmpty(Tag(tags, "provider"), Tag(tags, "agentProvider"));
+            var agentId = FirstNonEmpty(Tag(tags, "agent_id"), Tag(tags, "agentHandle"));
+
+            var key = new DimensionKey(
+                provider,
+                agentId,
+                ParseGuid(FirstNonEmpty(Tag(tags, "workflowDefinitionId"), Tag(tags, "definitionId"))),
+                Tag(tags, "repoId"),
+                ResolveCostBasis(Tag(tags, "billing_mode"), diagnosticBillingMode: null));
+
+            if (e.Type == "LLM.CALL.SUCCESS")
+            {
+                // Cost/token dedup: ProviderDiagnostic is authoritative. Fold an
+                // event's cost ONLY when no diagnostic shares its correlationId,
+                // so the two sources describing one call never double-count.
+                var corr = ParseGuid(Tag(tags, "correlationId"));
+                if (corr is not null && diagnosticCorrelationIds.Contains(corr.Value))
+                    continue;
+
+                var (cost, tokensIn, tokensOut) =
+                    ComputeTenantRollupActivity.ExtractLlmUsage(e.Data);
+                var m = GetOrAdd(measures, key);
+                m.CostUsd += cost;
+                m.TokensIn += tokensIn;
+                m.TokensOut += tokensOut;
+            }
+            else
+            {
+                // AGENT_DISPATCH.RUN_TRIGGERED.* / AGENT.DISPATCH.* — one dispatch.
+                var m = GetOrAdd(measures, key);
+                m.AgentDispatches += 1;
+            }
+        }
+
+        // 2) ProviderDiagnostic rows — provider (ProviderKey), agent (AgentType),
+        //    repo (ProjectId). Diagnostics carry no workflow-definition; NULL.
+        //    BillingMode column is a Story 35-2 forward dep (absent today) —
+        //    resolves to the Platform default until 35-2 lands.
+        foreach (var d in diagnostics)
+        {
+            if (string.IsNullOrWhiteSpace(d.ProviderKey)) continue;
+
+            var key = new DimensionKey(
+                d.ProviderKey,
+                NullIfEmpty(d.AgentType),
+                WorkflowDefinitionId: null,
+                NullIfEmpty(d.ProjectId),
+                ResolveCostBasis(billingModeTag: null, diagnosticBillingMode: null));
+
+            var m = GetOrAdd(measures, key);
+            // The dominant writer (LlmProxyService.RecordDiagnosticAsync) sets only
+            // the back-compat TokensUsed total, leaving InputTokens/OutputTokens 0.
+            // When the split is unset, attribute the total to TokensIn so token
+            // volume isn't under-counted; when the split IS populated, use it
+            // verbatim — never both, so no double-count.
+            if (d.InputTokens == 0 && d.OutputTokens == 0 && d.TokensUsed > 0)
+            {
+                m.TokensIn += d.TokensUsed;
+            }
+            else
+            {
+                m.TokensIn += d.InputTokens;
+                m.TokensOut += d.OutputTokens;
+            }
+            m.CostUsd += d.Cost;
+        }
+
+        // 3) Workflow lifecycle counts, per WorkflowDefinitionId (mirrors the
+        //    28-10 Status-based counts). Provider is nullable, so each definition
+        //    gets its OWN dimensional row keyed (Provider=NULL, AgentId=NULL,
+        //    WorkflowDefinitionId=<def>, RepoId=NULL, CostBasis=Platform default) —
+        //    they are NOT folded onto a provider-attributed usage row (which need
+        //    not exist). If an LLM event happened to produce that exact all-NULL
+        //    key too, GetOrAdd merges onto it (counts added once, no double-count).
+        var workflowCounts = await tenantDb.WorkflowInstances
+            .AsNoTracking()
+            .Where(w => w.CreatedAt >= hour && w.CreatedAt < hourEnd)
+            .GroupBy(w => w.DefinitionId)
+            .Select(g => new
+            {
+                DefinitionId = g.Key,
+                Started = g.LongCount(),
+                Completed = g.LongCount(w => w.Status == "completed"),
+                Failed = g.LongCount(w => w.Status == "failed"),
+            })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        foreach (var wc in workflowCounts)
+        {
+            var key = new DimensionKey(
+                Provider: null,
+                AgentId: null,
+                WorkflowDefinitionId: wc.DefinitionId,
+                RepoId: null,
+                CostBasis: ResolveCostBasis(billingModeTag: null, diagnosticBillingMode: null));
+
+            var m = GetOrAdd(measures, key);
+            m.WorkflowsStarted += wc.Started;
+            m.WorkflowsCompleted += wc.Completed;
+            m.WorkflowsFailed += wc.Failed;
+        }
+
+        // ── Upsert each tuple on the full business key (whole-bucket overwrite) ──
+        var now = DateTime.UtcNow;
+        long rowsWritten = 0;
+        long totalTokensIn = 0, totalTokensOut = 0;
+        decimal totalCost = 0m, totalBilled = 0m;
+
+        foreach (var (key, m) in measures)
+        {
+            // NULL-provider rows (workflow/dispatch counts) carry no cost, so the
+            // margin is immaterial; MarginFor gets an empty key rather than null.
+            var billed = key.CostBasis == CostBasis.Platform
+                ? Math.Round(m.CostUsd * (1 + pricing.MarginFor(key.Provider ?? string.Empty)), 4, MidpointRounding.AwayFromZero)
+                : 0m;
+            var cost = Math.Round(m.CostUsd, 4, MidpointRounding.AwayFromZero);
+
+            var existing = await tenantDb.AnalyticsUsageHourly
+                .FirstOrDefaultAsync(
+                    r => r.Hour == hour
+                         && r.Provider == key.Provider
+                         && r.AgentId == key.AgentId
+                         && r.WorkflowDefinitionId == key.WorkflowDefinitionId
+                         && r.RepoId == key.RepoId
+                         && r.CostBasis == key.CostBasis,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            if (existing is null)
+            {
+                tenantDb.AnalyticsUsageHourly.Add(new AnalyticsUsageHourly
+                {
+                    Id = Guid.NewGuid(),
+                    Hour = hour,
+                    Provider = key.Provider,
+                    AgentId = key.AgentId,
+                    WorkflowDefinitionId = key.WorkflowDefinitionId,
+                    RepoId = key.RepoId,
+                    CostBasis = key.CostBasis,
+                    TokensIn = m.TokensIn,
+                    TokensOut = m.TokensOut,
+                    CostUsd = cost,
+                    PlatformBilledUsd = billed,
+                    WorkflowsStarted = m.WorkflowsStarted,
+                    WorkflowsCompleted = m.WorkflowsCompleted,
+                    WorkflowsFailed = m.WorkflowsFailed,
+                    AgentDispatches = m.AgentDispatches,
+                    ComputedAt = now,
+                });
+            }
+            else
+            {
+                existing.TokensIn = m.TokensIn;
+                existing.TokensOut = m.TokensOut;
+                existing.CostUsd = cost;
+                existing.PlatformBilledUsd = billed;
+                existing.WorkflowsStarted = m.WorkflowsStarted;
+                existing.WorkflowsCompleted = m.WorkflowsCompleted;
+                existing.WorkflowsFailed = m.WorkflowsFailed;
+                existing.AgentDispatches = m.AgentDispatches;
+                existing.ComputedAt = now;
+            }
+
+            rowsWritten++;
+            totalTokensIn += m.TokensIn;
+            totalTokensOut += m.TokensOut;
+            totalCost += cost;
+            totalBilled += billed;
+        }
+
+        // ── Advance the checkpoint atomically with the upsert (read above) ──
+        if (checkpoint is null)
+        {
+            checkpoint = new AnalyticsProjectionCheckpoint
+            {
+                Id = Guid.NewGuid(),
+                Stream = AnalyticsProjectionCheckpoint.DimensionalStream,
+                LastSequenceNumber = 0,
+            };
+            tenantDb.AnalyticsProjectionCheckpoints.Add(checkpoint);
+        }
+
+        var previous = checkpoint.LastSequenceNumber;
+        // Whole-bucket overwrite is the idempotency mechanism; the checkpoint
+        // only ever advances forward on the happy path. A reset re-bases it to
+        // this bucket's max so an operator can re-drive an old window.
+        checkpoint.LastSequenceNumber = resetCheckpoint
+            ? maxSequence
+            : Math.Max(previous, maxSequence);
+        checkpoint.UpdatedAt = now;
+
+        await tenantDb.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        await publisher.AppendAndPublishAsync(
+            AnalyticsRollupEvents.BuildEvent(
+                AnalyticsRollupEvents.TenantDimensionalRollupCompleted,
+                hour,
+                tenantId,
+                data: new Dictionary<string, object?>
+                {
+                    ["rowsWritten"] = rowsWritten,
+                    ["tuples"] = measures.Count,
+                    ["tokensIn"] = totalTokensIn,
+                    ["tokensOut"] = totalTokensOut,
+                    ["costUsd"] = totalCost,
+                    ["platformBilledUsd"] = totalBilled,
+                    ["checkpoint"] = checkpoint.LastSequenceNumber,
+                }),
+            cancellationToken).ConfigureAwait(false);
+
+        logger?.LogInformation(
+            "analytics.dimensional.tenant_completed tenantId={TenantId} hour={Hour} rowsWritten={Rows} tuples={Tuples} tokensIn={In} tokensOut={Out} costUsd={Cost} platformBilledUsd={Billed} checkpoint={Checkpoint}",
+            tenantId, hour, rowsWritten, measures.Count, totalTokensIn, totalTokensOut, totalCost, totalBilled, checkpoint.LastSequenceNumber);
+    }
+
+    /// <summary>
+    /// Pure cost-basis resolver (Story 35-2 <c>billing_mode</c> signal). The
+    /// event tag wins; the <see cref="ProviderDiagnostic"/> billing-mode column
+    /// backs it. Absent/anything-but-<c>byok</c> → <see cref="CostBasis.Platform"/>
+    /// (single-user / legacy events predating 35-2 are billed as platform).
+    /// </summary>
+    internal static CostBasis ResolveCostBasis(string? billingModeTag, string? diagnosticBillingMode)
+    {
+        var mode = FirstNonEmpty(billingModeTag, diagnosticBillingMode);
+        return string.Equals(mode, "byok", StringComparison.OrdinalIgnoreCase)
+            ? CostBasis.Byok
+            : CostBasis.Platform;
+    }
+
+    private static Measures GetOrAdd(Dictionary<DimensionKey, Measures> map, DimensionKey key)
+    {
+        if (!map.TryGetValue(key, out var m))
+        {
+            m = new Measures();
+            map[key] = m;
+        }
+        return m;
+    }
+
+    private static Dictionary<string, string?> ParseTags(string? tagsJson)
+    {
+        var result = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        if (string.IsNullOrWhiteSpace(tagsJson)) return result;
+        try
+        {
+            using var doc = JsonDocument.Parse(tagsJson);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object) return result;
+            foreach (var prop in doc.RootElement.EnumerateObject())
+            {
+                result[prop.Name] = prop.Value.ValueKind switch
+                {
+                    JsonValueKind.String => prop.Value.GetString(),
+                    JsonValueKind.Null => null,
+                    _ => prop.Value.GetRawText(),
+                };
+            }
+        }
+        catch (JsonException)
+        {
+            // Tolerate malformed tag blobs — same posture as measure extraction.
+        }
+        return result;
+    }
+
+    private static string? Tag(Dictionary<string, string?> tags, string key) =>
+        tags.TryGetValue(key, out var v) ? NullIfEmpty(v) : null;
+
+    private static string? NullIfEmpty(string? v) =>
+        string.IsNullOrWhiteSpace(v) ? null : v;
+
+    private static string? FirstNonEmpty(params string?[] values)
+    {
+        foreach (var v in values)
+            if (!string.IsNullOrWhiteSpace(v)) return v;
+        return null;
+    }
+
+    private static Guid? ParseGuid(string? raw) =>
+        Guid.TryParse(raw, out var g) ? g : null;
+
+    /// <summary>Immutable dimension tuple — the full business key. Provider is
+    /// nullable: dispatch/workflow counts bucket under the NULL provider.</summary>
+    private readonly record struct DimensionKey(
+        string? Provider,
+        string? AgentId,
+        Guid? WorkflowDefinitionId,
+        string? RepoId,
+        CostBasis CostBasis);
+
+    /// <summary>Mutable per-tuple measure accumulator.</summary>
+    private sealed class Measures
+    {
+        public long TokensIn;
+        public long TokensOut;
+        public decimal CostUsd;
+        public long WorkflowsStarted;
+        public long WorkflowsCompleted;
+        public long WorkflowsFailed;
+        public long AgentDispatches;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Analytics/ComputeTenantRollupActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Analytics/ComputeTenantRollupActivity.cs
@@ -229,29 +229,42 @@ public sealed class ComputeTenantRollupActivity : TammaAsyncActivity
 
         foreach (var blob in dataBlobs)
         {
-            if (string.IsNullOrWhiteSpace(blob)) continue;
-            try
-            {
-                using var doc = JsonDocument.Parse(blob);
-                var root = doc.RootElement;
-                if (root.ValueKind != JsonValueKind.Object) continue;
-
-                if (root.TryGetProperty("costUsd", out var costEl))
-                    cost += ReadDecimal(costEl);
-
-                if (root.TryGetProperty("inputTokens", out var inEl))
-                    tokensIn += ReadLong(inEl);
-
-                if (root.TryGetProperty("outputTokens", out var outEl))
-                    tokensOut += ReadLong(outEl);
-            }
-            catch (JsonException)
-            {
-                // Skip malformed rows — see method doc-comment.
-            }
+            var (c, ti, to) = ExtractLlmUsage(blob);
+            cost += c;
+            tokensIn += ti;
+            tokensOut += to;
         }
 
         return (Math.Round(cost, 4, MidpointRounding.AwayFromZero), tokensIn, tokensOut);
+    }
+
+    /// <summary>
+    /// Extracts <c>costUsd</c>, <c>inputTokens</c>, <c>outputTokens</c> from a
+    /// single <c>LLM.CALL.SUCCESS</c> data-column JSON blob. Malformed / empty
+    /// / non-object blobs contribute zero (same tolerance as
+    /// <see cref="AggregateLlmUsage"/>). Shared by the Story 36-2 dimensional
+    /// rollup so per-event measure extraction never drifts from the tenant
+    /// rollup. Cost is NOT rounded here — callers round the aggregate.
+    /// </summary>
+    internal static (decimal CostUsd, long TokensIn, long TokensOut) ExtractLlmUsage(string? blob)
+    {
+        if (string.IsNullOrWhiteSpace(blob)) return (0m, 0L, 0L);
+        try
+        {
+            using var doc = JsonDocument.Parse(blob);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object) return (0m, 0L, 0L);
+
+            var cost = root.TryGetProperty("costUsd", out var costEl) ? ReadDecimal(costEl) : 0m;
+            var tokensIn = root.TryGetProperty("inputTokens", out var inEl) ? ReadLong(inEl) : 0L;
+            var tokensOut = root.TryGetProperty("outputTokens", out var outEl) ? ReadLong(outEl) : 0L;
+            return (cost, tokensIn, tokensOut);
+        }
+        catch (JsonException)
+        {
+            // Skip malformed rows — see method doc-comment.
+            return (0m, 0L, 0L);
+        }
     }
 
     private static decimal ReadDecimal(JsonElement el) => el.ValueKind switch

--- a/apps/tamma-elsa/src/Tamma.Activities/Analytics/DimensionalProjectionMetrics.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Analytics/DimensionalProjectionMetrics.cs
@@ -1,0 +1,53 @@
+using System.Diagnostics.Metrics;
+
+namespace Tamma.Activities.Analytics;
+
+/// <summary>
+/// Story 36-2 (AC13) — OpenTelemetry surface for the dimensional analytics
+/// projection SLO.
+///
+/// <list type="bullet">
+///   <item><description><c>tamma.analytics.projection_lag_seconds</c> —
+///     observable gauge of the wall-clock lag (seconds) between the rolled-up
+///     hour bucket and the time the most recent fan-out pass completed.
+///     A steady low value means the projection is keeping up; a value past the
+///     SLO budget (default 2h) is the runbook's cue.</description></item>
+/// </list>
+///
+/// <para>Self-registering meter (see <c>KekRotationMetrics</c> /
+/// <c>AuditProjectionMetrics</c>): constructing a <see cref="Meter"/> with
+/// <see cref="MeterName"/> makes the gauge discoverable; registering this class
+/// as a singleton is sufficient. Thread-safe — the gauge reads a volatile
+/// double.</para>
+/// </summary>
+public sealed class DimensionalProjectionMetrics : IDisposable
+{
+    /// <summary>Public meter name — pin so dashboards stay stable.</summary>
+    public const string MeterName = "Tamma.AnalyticsProjection";
+
+    private readonly Meter _meter;
+    private long _lagSecondsBits;
+
+    public DimensionalProjectionMetrics()
+    {
+        _meter = new Meter(MeterName, "1.0.0");
+        _meter.CreateObservableGauge(
+            "tamma.analytics.projection_lag_seconds",
+            () => LagSeconds,
+            unit: "s",
+            description: "Wall-clock lag between the rolled-up analytics hour bucket "
+                + "and the completion of the most recent dimensional fan-out pass.");
+    }
+
+    /// <summary>Last recorded projection lag in seconds.</summary>
+    public double LagSeconds => BitConverter.Int64BitsToDouble(Interlocked.Read(ref _lagSecondsBits));
+
+    /// <summary>Record the projection lag after a fan-out pass (clamped at 0).</summary>
+    public void RecordLag(double lagSeconds)
+    {
+        var value = lagSeconds < 0 ? 0d : lagSeconds;
+        Interlocked.Exchange(ref _lagSecondsBits, BitConverter.DoubleToInt64Bits(value));
+    }
+
+    public void Dispose() => _meter.Dispose();
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Analytics/FanOutTenantDimensionalRollupsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Analytics/FanOutTenantDimensionalRollupsActivity.cs
@@ -1,0 +1,264 @@
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+
+namespace Tamma.Activities.Analytics;
+
+/// <summary>
+/// Story 36-2 — iterates active tenants from the CP directory and, per tenant,
+/// runs the dimensional projection (<see cref="ComputeTenantDimensionalRollupActivity"/>),
+/// then — when the target hour is the final hour of a UTC day — the lossless
+/// daily compaction (<see cref="CompactDailyAnalyticsActivity"/>), then the
+/// best-effort hourly retention purge (<see cref="PurgeStaleUsageAnalyticsActivity"/>).
+///
+/// <para>Mirrors <see cref="FanOutTenantRollupsActivity"/>: a single activity
+/// looping the compute helpers serially (NOT an Elsa composite — that would
+/// materialise one workflow instance per tenant and explode the journal on
+/// large fleets). Serial keeps the per-tenant pool cache hot. Per-tenant
+/// failures are caught, emitted as
+/// <c>ANALYTICS.ROLLUP.TENANT_DIMENSIONAL_FAILED</c>, counted, and the loop
+/// continues (Story 28-10 AC5 tolerance).</para>
+///
+/// <para><b>Design note (single tenant iteration):</b> compaction and the
+/// usage purge are per-tenant helpers driven inside this one fan-out rather
+/// than as separate top-level workflow steps, so the workflow adds exactly one
+/// new sequence step and each tenant's schema is opened once per pass. The
+/// per-tenant compaction/purge are still best-effort — a compaction/purge
+/// failure for a tenant does not fail that tenant's projection nor the
+/// fan-out.</para>
+///
+/// <para><b>Projection-lag SLO (AC13):</b> after the loop the activity records
+/// the wall-clock lag between the rolled-up <c>hour</c> and completion; when it
+/// exceeds <see cref="SloLagBudgetSeconds"/> (default 2h) it emits
+/// <c>ANALYTICS.ROLLUP.DIMENSIONAL_LAG</c> + updates the
+/// <c>tamma.analytics.projection_lag_seconds</c> OTel gauge. A breach is a
+/// WARN, never a failure.</para>
+/// </summary>
+[Activity(
+    "Tamma.Analytics",
+    "Fan Out Tenant Dimensional Rollups",
+    "Iterate active tenants and run the dimensional projection + daily compaction + usage purge inline.",
+    Kind = ActivityKind.Task)]
+public sealed class FanOutTenantDimensionalRollupsActivity : TammaAsyncActivity
+{
+    /// <summary>Default projection-lag SLO budget — 2 hours (Story 36-2 AC13).</summary>
+    public const int DefaultSloLagBudgetSeconds = 2 * 60 * 60;
+
+    [Input(Description = "UTC top-of-hour bucket this rollup targets.")]
+    public Input<DateTime> Hour { get; set; } = default!;
+
+    [Input(Description = "Reset each tenant's dimensional checkpoint (backfill).")]
+    public Input<bool> ResetCheckpoint { get; set; } = new(false);
+
+    [Input(Description = "Projection-lag SLO budget in seconds (default 2 hours).")]
+    public Input<int> SloLagBudgetSeconds { get; set; } = new(DefaultSloLagBudgetSeconds);
+
+    [Output(Description = "Number of tenants whose dimensional rollup succeeded.")]
+    public Output<int> TenantsSuccess { get; set; } = default!;
+
+    [Output(Description = "Number of tenants whose dimensional rollup threw.")]
+    public Output<int> TenantsFailed { get; set; } = default!;
+
+    public override string? EventType => "ANALYTICS.ROLLUP.DIMENSIONAL_FANOUT";
+
+    /// <summary>
+    /// Test seam — bypass the real per-tenant compute so the fan-out loop can
+    /// be exercised without a real tenant DB.
+    /// </summary>
+    internal Func<Guid, DateTime, CancellationToken, Task>? ComputeOneOverride { get; set; }
+
+    protected override async Task RunAsync(ActivityExecutionContext context)
+    {
+        var hour = AnalyticsRollupEvents.TruncateToHour(Hour.Get(context));
+        var reset = ResetCheckpoint.Get(context);
+        var budget = SloLagBudgetSeconds.Get(context);
+        Logger ??= context.GetService<ILogger<FanOutTenantDimensionalRollupsActivity>>();
+
+        var cpFactory = context.GetRequiredService<IDbContextFactory<ControlPlaneDbContext>>();
+        var tenantFactory = context.GetRequiredService<ITenantDbContextFactory>();
+        var publisher = context.GetRequiredService<IPlatformEventPublisher>();
+        var pricing = context.GetService<IAnalyticsPricingConfig>() ?? new NullAnalyticsPricingConfig();
+        var metrics = context.GetService<DimensionalProjectionMetrics>();
+
+        List<Guid> tenantIds;
+        await using (var cp = await cpFactory
+            .CreateDbContextAsync(context.CancellationToken)
+            .ConfigureAwait(false))
+        {
+            tenantIds = await cp.Tenants
+                .IgnoreQueryFilters()
+                .Where(t => t.DeletedAt == null)
+                .Where(t => t.CreatedAt < hour.AddHours(1))
+                .Where(t => EF.Property<string?>(t, "Status") == null
+                            || EF.Property<string?>(t, "Status") == "active")
+                .Select(t => t.Id)
+                .ToListAsync(context.CancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        Logger?.LogInformation(
+            "analytics.dimensional.fanout_starting hour={Hour} tenantCount={Count}",
+            hour, tenantIds.Count);
+
+        var success = 0;
+        var failed = 0;
+
+        foreach (var tenantId in tenantIds)
+        {
+            context.CancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                if (ComputeOneOverride is not null)
+                {
+                    await ComputeOneOverride(tenantId, hour, context.CancellationToken)
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    await ProjectOneTenantAsync(
+                        tenantFactory, publisher, pricing, tenantId, hour, reset, Logger,
+                        context.CancellationToken).ConfigureAwait(false);
+                }
+                success++;
+            }
+            catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                failed++;
+                Logger?.LogWarning(ex,
+                    "analytics.dimensional.tenant_failed tenantId={TenantId} hour={Hour}",
+                    tenantId, hour);
+
+                try
+                {
+                    await publisher.AppendAndPublishAsync(
+                        AnalyticsRollupEvents.BuildEvent(
+                            AnalyticsRollupEvents.TenantDimensionalRollupFailed,
+                            hour,
+                            tenantId,
+                            data: new Dictionary<string, object?>
+                            {
+                                ["errorType"] = ex.GetType().Name,
+                                ["message"] = ex.Message,
+                            }),
+                        context.CancellationToken).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // Best-effort emission — see FanOutTenantRollupsActivity.
+                }
+            }
+        }
+
+        TenantsSuccess.Set(context, success);
+        TenantsFailed.Set(context, failed);
+
+        Logger?.LogInformation(
+            "analytics.dimensional.fanout_completed hour={Hour} success={Success} failed={Failed}",
+            hour, success, failed);
+
+        // ── Projection-lag SLO (AC13) ──
+        var lagSeconds = (DateTime.UtcNow - hour).TotalSeconds;
+        if (lagSeconds < 0) lagSeconds = 0;
+        metrics?.RecordLag(lagSeconds);
+
+        if (lagSeconds > budget)
+        {
+            Logger?.LogWarning(
+                "analytics.dimensional.lag_over_slo hour={Hour} lagSeconds={Lag} budgetSeconds={Budget}",
+                hour, lagSeconds, budget);
+            try
+            {
+                await publisher.AppendAndPublishAsync(
+                    AnalyticsRollupEvents.BuildEvent(
+                        AnalyticsRollupEvents.DimensionalLag,
+                        hour,
+                        tenantId: null,
+                        data: new Dictionary<string, object?>
+                        {
+                            ["lagSeconds"] = lagSeconds,
+                            ["hour"] = hour.ToString("O"),
+                            ["budgetSeconds"] = budget,
+                        }),
+                    context.CancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                // SLO signal is best-effort — never fail the pass on emission.
+            }
+        }
+    }
+
+    /// <summary>
+    /// Per-tenant work: dimensional projection, then (at the last hour of a UTC
+    /// day) the lossless daily compaction, then the best-effort hourly purge.
+    /// Compaction/purge failures are best-effort and do not fail the tenant's
+    /// projection. Exposed for the pure-DI / backfill path.
+    /// </summary>
+    public static async Task ProjectOneTenantAsync(
+        ITenantDbContextFactory tenantFactory,
+        IPlatformEventPublisher publisher,
+        IAnalyticsPricingConfig pricing,
+        Guid tenantId,
+        DateTime hour,
+        bool resetCheckpoint,
+        ILogger? logger,
+        CancellationToken cancellationToken)
+    {
+        await ComputeTenantDimensionalRollupActivity.ComputeAsync(
+            tenantFactory, publisher, tenantId, hour, pricing, resetCheckpoint, logger,
+            cancellationToken).ConfigureAwait(false);
+
+        // Daily compaction runs when the final hour (23:00) of a UTC day has
+        // been projected — that day is now complete.
+        if (hour.Hour == 23)
+        {
+            try
+            {
+                await CompactDailyAnalyticsActivity.CompactAsync(
+                    tenantFactory, publisher, tenantId,
+                    CompactDailyAnalyticsActivity.TruncateToDay(hour), logger, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex,
+                    "analytics.compact.daily_failed tenantId={TenantId} day={Day}",
+                    tenantId, CompactDailyAnalyticsActivity.TruncateToDay(hour));
+            }
+        }
+
+        // Best-effort hourly retention purge (runs last for the tenant).
+        try
+        {
+            await PurgeStaleUsageAnalyticsActivity.PurgeAsync(
+                tenantFactory, publisher, tenantId, DateTime.UtcNow,
+                PurgeStaleUsageAnalyticsActivity.DefaultRetentionMonths, logger, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex,
+                "analytics.purge.usage_hourly_failed tenantId={TenantId}", tenantId);
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Analytics/IAnalyticsPricingConfig.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Analytics/IAnalyticsPricingConfig.cs
@@ -1,0 +1,29 @@
+namespace Tamma.Activities.Analytics;
+
+/// <summary>
+/// Story 36-2 — read-only margin seam consumed by
+/// <see cref="ComputeTenantDimensionalRollupActivity"/> to derive
+/// <c>PlatformBilledUsd = CostUsd * (1 + margin)</c> for
+/// <see cref="Tamma.Core.Enums.CostBasis.Platform"/> rows.
+///
+/// <para>This story does <b>not</b> own the margin math — it is produced by
+/// Story 36-7 (pricing/markup config). This interface is the consumption
+/// seam so the projection stays green before 36-7 lands: when no real
+/// implementation is registered, <see cref="NullAnalyticsPricingConfig"/>
+/// supplies a zero margin (Tamma bills exactly cost) and logs a WARN.</para>
+///
+/// <para>The margin is a fraction, not a percentage — <c>0.20m</c> means a
+/// 20% markup, so a $1.00 platform cost bills at $1.20. A margin of
+/// <c>0m</c> means no markup. BYOK rows are never marked up (the activity
+/// short-circuits <c>PlatformBilledUsd = 0</c> before calling this seam).</para>
+/// </summary>
+public interface IAnalyticsPricingConfig
+{
+    /// <summary>
+    /// The platform markup margin (fraction, e.g. <c>0.20m</c> = 20%) applied
+    /// to the raw <c>CostUsd</c> for a platform-fronted call on the given
+    /// <paramref name="provider"/>. Never negative; a provider with no
+    /// configured margin yields <c>0m</c>.
+    /// </summary>
+    decimal MarginFor(string provider);
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Analytics/NullAnalyticsPricingConfig.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Analytics/NullAnalyticsPricingConfig.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.Logging;
+
+namespace Tamma.Activities.Analytics;
+
+/// <summary>
+/// Story 36-2 — zero-margin fallback for <see cref="IAnalyticsPricingConfig"/>.
+/// Registered in DI so the dimensional rollup is green before Story 36-7
+/// (pricing/markup config) lands.
+///
+/// <para>Every call to <see cref="MarginFor"/> returns <c>0m</c> (Tamma bills
+/// exactly cost, no markup) and logs a WARN once per provider so the runbook
+/// can see the projection is running without a real price book. It never
+/// throws and never hardcodes a non-zero margin — a real margin only ever
+/// comes from the 36-7 implementation replacing this seam.</para>
+/// </summary>
+public sealed class NullAnalyticsPricingConfig : IAnalyticsPricingConfig
+{
+    private readonly ILogger<NullAnalyticsPricingConfig>? _logger;
+    private readonly HashSet<string> _warned = new(StringComparer.OrdinalIgnoreCase);
+    private readonly object _gate = new();
+
+    public NullAnalyticsPricingConfig(ILogger<NullAnalyticsPricingConfig>? logger = null)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public decimal MarginFor(string provider)
+    {
+        var key = provider ?? string.Empty;
+
+        bool firstTime;
+        lock (_gate)
+        {
+            firstTime = _warned.Add(key);
+        }
+
+        if (firstTime)
+        {
+            _logger?.LogWarning(
+                "analytics.pricing.unavailable provider={Provider} — Story 36-7 pricing config "
+                + "not wired; PlatformBilledUsd computed with zero margin (billed = cost).",
+                key);
+        }
+
+        return 0m;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Analytics/PurgeStaleUsageAnalyticsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Analytics/PurgeStaleUsageAnalyticsActivity.cs
@@ -1,0 +1,157 @@
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+using Tamma.Data.Abstractions;
+
+namespace Tamma.Activities.Analytics;
+
+/// <summary>
+/// Story 36-2 — per-tenant retention sweeper for
+/// <c>analytics_usage_hourly</c>. Mirrors
+/// <see cref="PurgeStaleAnalyticsActivity"/> (which purges the CP
+/// <c>platform_analytics_hourly</c>) but targets the tenant's own hourly fact
+/// table via <see cref="ITenantDbContextFactory"/>.
+///
+/// <para>Deletes rows whose <c>Hour</c> bucket is older than the retention
+/// window (13 months by default, Doc 04 §7) via <c>ExecuteDeleteAsync</c>.
+/// Daily rows retain on the longer daily window and are NOT touched here.</para>
+///
+/// <para><b>Best-effort:</b> runs last in the sequence, after the fresh bucket
+/// and the daily compaction are persisted. A purge failure is logged +
+/// emitted as <c>ANALYTICS.PURGE.USAGE_HOURLY_FAILED</c> but never rethrown,
+/// so a transient tenant-DB hiccup cannot fail a rollup that already wrote
+/// useful rows.</para>
+/// </summary>
+[Activity(
+    "Tamma.Analytics",
+    "Purge Stale Usage Analytics",
+    "Delete analytics_usage_hourly rows older than the retention window (default 13 months).",
+    Kind = ActivityKind.Task)]
+public sealed class PurgeStaleUsageAnalyticsActivity : TammaAsyncActivity
+{
+    /// <summary>Doc 04 §7 — 13-month hourly analytics retention window.</summary>
+    public const int DefaultRetentionMonths = 13;
+
+    [Input(Description = "Tenant id whose hourly usage rows to purge.")]
+    public Input<Guid> TenantId { get; set; } = default!;
+
+    [Input(Description =
+        "Retention window in months. Rows older than now minus this window are "
+        + "deleted. Non-positive values fall back to the 13-month default.")]
+    public Input<int> RetentionMonths { get; set; } = new(DefaultRetentionMonths);
+
+    public override string? EventType => "ANALYTICS.PURGE.USAGE";
+
+    protected override async Task RunAsync(ActivityExecutionContext context)
+    {
+        Logger ??= context.GetService<ILogger<PurgeStaleUsageAnalyticsActivity>>();
+
+        var tenantFactory = context.GetRequiredService<ITenantDbContextFactory>();
+        var publisher = context.GetRequiredService<IPlatformEventPublisher>();
+        var tenantId = TenantId.Get(context);
+        var months = RetentionMonths.Get(context);
+
+        try
+        {
+            await PurgeAsync(
+                tenantFactory, publisher, tenantId, DateTime.UtcNow, months, Logger,
+                context.CancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
+        {
+            // Host shutdown / cancellation is not a purge failure — propagate.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Best-effort — never fail the parent rollup.
+            Logger?.LogWarning(ex,
+                "analytics.purge.usage_hourly_failed tenantId={TenantId} retentionMonths={Months}",
+                tenantId, months);
+            try
+            {
+                await publisher.AppendAndPublishAsync(
+                    AnalyticsRollupEvents.BuildEvent(
+                        AnalyticsRollupEvents.UsageHourlyPurgeFailed,
+                        AnalyticsRollupEvents.TruncateToHour(DateTime.UtcNow),
+                        tenantId,
+                        data: new Dictionary<string, object?>
+                        {
+                            ["errorType"] = ex.GetType().Name,
+                            ["message"] = ex.Message,
+                        }),
+                    context.CancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Emitting the failure event is itself best-effort.
+            }
+        }
+    }
+
+    /// <summary>
+    /// Pure-DI entry point — deletes stale rows for one tenant and emits the
+    /// terminal <c>ANALYTICS.PURGE.USAGE_HOURLY</c> event. Returns the number
+    /// of rows deleted.
+    /// </summary>
+    public static async Task<int> PurgeAsync(
+        ITenantDbContextFactory tenantFactory,
+        IPlatformEventPublisher publisher,
+        Guid tenantId,
+        DateTime nowUtc,
+        int retentionMonths,
+        ILogger? logger,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(tenantFactory);
+        ArgumentNullException.ThrowIfNull(publisher);
+
+        var cutoff = ComputeCutoff(nowUtc, retentionMonths);
+
+        await using var tenantDb = await tenantFactory
+            .CreateAsync(tenantId, cancellationToken)
+            .ConfigureAwait(false);
+
+        var deleted = await tenantDb.AnalyticsUsageHourly
+            .Where(r => r.Hour < cutoff)
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        await publisher.AppendAndPublishAsync(
+            AnalyticsRollupEvents.BuildEvent(
+                AnalyticsRollupEvents.UsageHourlyPurged,
+                AnalyticsRollupEvents.TruncateToHour(nowUtc),
+                tenantId,
+                data: new Dictionary<string, object?>
+                {
+                    ["cutoff"] = cutoff.ToString("O"),
+                    ["rowsDeleted"] = deleted,
+                }),
+            cancellationToken).ConfigureAwait(false);
+
+        logger?.LogInformation(
+            "analytics.purge.usage_hourly_completed tenantId={TenantId} cutoff={Cutoff} rowsDeleted={Deleted}",
+            tenantId, cutoff, deleted);
+
+        return deleted;
+    }
+
+    /// <summary>
+    /// Inclusive staleness boundary. Non-positive windows clamp to the
+    /// 13-month default so a misconfiguration can never delete live data.
+    /// Always returns a UTC instant.
+    /// </summary>
+    public static DateTime ComputeCutoff(DateTime nowUtc, int retentionMonths)
+    {
+        var utc = nowUtc.Kind == DateTimeKind.Utc
+            ? nowUtc
+            : DateTime.SpecifyKind(nowUtc.ToUniversalTime(), DateTimeKind.Utc);
+        var months = retentionMonths > 0 ? retentionMonths : DefaultRetentionMonths;
+        return DateTime.SpecifyKind(utc.AddMonths(-months), DateTimeKind.Utc);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/AnalyticsProjectionCheckpoint.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/AnalyticsProjectionCheckpoint.cs
@@ -1,0 +1,45 @@
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 36-2 — per-tenant resumable cursor for the dimensional analytics
+/// projection. Records the highest <see cref="DomainEvent.SequenceNumber"/>
+/// already folded into <c>analytics_usage_hourly</c> for a given projection
+/// <see cref="Stream"/> (e.g. <c>"dimensional"</c>).
+///
+/// <para><b>Tenancy:</b> no <c>TenantId</c> column — like the
+/// <see cref="AnalyticsUsageHourly"/> fact tables it lives in the per-tenant
+/// <c>t_&lt;hex&gt;</c> search-path schema, so a row is physically scoped to
+/// its tenant. One row per <see cref="Stream"/> (unique).</para>
+///
+/// <para><b>Cursor semantics:</b> the projection folds events with
+/// <c>SequenceNumber &gt; LastSequenceNumber</c> and advances the checkpoint
+/// atomically with the idempotent upsert. <see cref="DomainEvent.SequenceNumber"/>
+/// — the monotonic <c>BIGSERIAL</c> total order — is the cursor (never
+/// <c>Id</c>/<c>CreatedAt</c>, which are not tie-break-safe across
+/// same-millisecond events). The checkpoint is a resumability/skip
+/// optimisation; idempotency itself is guaranteed by the whole-bucket
+/// overwrite upsert, so a stale/reset checkpoint can never double-count.</para>
+/// </summary>
+public class AnalyticsProjectionCheckpoint
+{
+    /// <summary>Surrogate PK — Postgres <c>gen_random_uuid()</c> default.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Logical projection stream this cursor tracks. The dimensional rollup
+    /// uses <see cref="DimensionalStream"/>. Unique — one cursor row per stream.
+    /// </summary>
+    public string Stream { get; set; } = null!;
+
+    /// <summary>
+    /// Highest <see cref="DomainEvent.SequenceNumber"/> already folded into the
+    /// dimensional store for <see cref="Stream"/>. Starts at 0 (nothing folded).
+    /// </summary>
+    public long LastSequenceNumber { get; set; }
+
+    /// <summary>Wall-clock timestamp of the last advance; defaults to <c>now()</c>.</summary>
+    public DateTime UpdatedAt { get; set; }
+
+    /// <summary>The <see cref="Stream"/> value used by the dimensional projection.</summary>
+    public const string DimensionalStream = "dimensional";
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/AnalyticsUsageDaily.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/AnalyticsUsageDaily.cs
@@ -34,8 +34,12 @@ public class AnalyticsUsageDaily
 
     // ── Dimensions (identical to AnalyticsUsageHourly) ──
 
-    /// <summary>AI provider key (e.g. <c>anthropic-claude</c>). Required.</summary>
-    public string Provider { get; set; } = null!;
+    /// <summary>
+    /// AI provider key (e.g. <c>anthropic-claude</c>). <c>null</c> = not
+    /// provider-attributed (workflow-lifecycle / agent-dispatch counts bucket
+    /// under the NULL provider — see <see cref="AnalyticsUsageHourly.Provider"/>).
+    /// </summary>
+    public string? Provider { get; set; }
 
     /// <summary>Agent handle/id this usage is attributed to; <c>null</c> = unattributed.</summary>
     public string? AgentId { get; set; }

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/AnalyticsUsageHourly.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/AnalyticsUsageHourly.cs
@@ -48,8 +48,14 @@ public class AnalyticsUsageHourly
 
     // ── Dimensions ──
 
-    /// <summary>AI provider key (e.g. <c>anthropic-claude</c>). Required.</summary>
-    public string Provider { get; set; } = null!;
+    /// <summary>
+    /// AI provider key (e.g. <c>anthropic-claude</c>). <c>null</c> = the measure
+    /// is not provider-attributed — workflow-lifecycle counts and agent-dispatch
+    /// counts carry no provider signal and bucket under the NULL provider (Story
+    /// 36-2). The <c>UX_analytics_usage_hourly_dims</c> NULLS-NOT-DISTINCT index
+    /// dedupes these NULL-provider rows to one per bucket.
+    /// </summary>
+    public string? Provider { get; set; }
 
     /// <summary>Agent handle/id this usage is attributed to; <c>null</c> = unattributed.</summary>
     public string? AgentId { get; set; }

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260702072054_AddDimensionalAnalyticsProjection.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260702072054_AddDimensionalAnalyticsProjection.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.Tenant
 {
     [DbContext(typeof(TenantDbContext))]
-    partial class TenantDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260702072054_AddDimensionalAnalyticsProjection")]
+    partial class AddDimensionalAnalyticsProjection
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260702072054_AddDimensionalAnalyticsProjection.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260702072054_AddDimensionalAnalyticsProjection.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.Tenant
+{
+    /// <inheritdoc />
+    public partial class AddDimensionalAnalyticsProjection : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Provider",
+                table: "analytics_usage_hourly",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(100)",
+                oldMaxLength: 100);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Provider",
+                table: "analytics_usage_daily",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(100)",
+                oldMaxLength: 100);
+
+            migrationBuilder.CreateTable(
+                name: "analytics_projection_checkpoint",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    Stream = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    LastSequenceNumber = table.Column<long>(type: "bigint", nullable: false, defaultValue: 0L),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_analytics_projection_checkpoint", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "UX_analytics_projection_checkpoint_stream",
+                table: "analytics_projection_checkpoint",
+                column: "Stream",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "analytics_projection_checkpoint");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Provider",
+                table: "analytics_usage_hourly",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "character varying(100)",
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Provider",
+                table: "analytics_usage_daily",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "character varying(100)",
+                oldMaxLength: 100,
+                oldNullable: true);
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
@@ -1643,6 +1643,11 @@ internal static class TammaModelConfiguration
         // conventions NULLS NOT DISTINCT pattern for the idempotent business key.
         ConfigureAnalyticsUsageEntities(modelBuilder, fixedTenantId);
 
+        // ── Analytics projection checkpoint (Story 36-2) ──
+        // Per-tenant resumable SequenceNumber cursor for the dimensional
+        // projection. Schema is the isolation plane (no TenantId column).
+        ConfigureAnalyticsProjectionCheckpoint(modelBuilder, fixedTenantId);
+
         // ── Curated audit records (Story 37-1) ──
         // Tenant-scope curated audit trail materialized from the tenant
         // domain_events stream. The SAME table shape is also configured on the
@@ -1747,8 +1752,10 @@ internal static class TammaModelConfiguration
         ValueConverter<CostBasis, string> costBasisConverter)
         where T : class
     {
-        // Dimensions.
-        entity.Property("Provider").IsRequired().HasMaxLength(100);
+        // Dimensions. Provider is nullable (Story 36-2): workflow-lifecycle and
+        // agent-dispatch counts carry no provider and bucket under NULL — the
+        // UX_*_dims NULLS-NOT-DISTINCT index dedupes those NULL-provider rows.
+        entity.Property("Provider").IsRequired(false).HasMaxLength(100);
         entity.Property("AgentId").HasMaxLength(200);
         entity.Property("RepoId").HasMaxLength(400);
         entity.Property(typeof(CostBasis), "CostBasis")
@@ -1766,6 +1773,34 @@ internal static class TammaModelConfiguration
         entity.Property("CostUsd").HasPrecision(20, 4).HasDefaultValue(0m);
         entity.Property("PlatformBilledUsd").HasPrecision(20, 4).HasDefaultValue(0m);
         entity.Property("ComputedAt").HasDefaultValueSql("now()");
+    }
+
+    /// <summary>
+    /// Story 36-2 — maps the per-tenant <c>analytics_projection_checkpoint</c>
+    /// resumable cursor. One row per projection <c>Stream</c> (unique). No
+    /// <c>TenantId</c> column — the tenant schema is the isolation plane
+    /// (Doc 01 §1.4), so <see cref="ApplyTenantFilter{T}"/> is the deliberate
+    /// no-op accessor (returns <c>null</c>; nothing to filter).
+    /// </summary>
+    private static void ConfigureAnalyticsProjectionCheckpoint(
+        ModelBuilder modelBuilder, Guid? fixedTenantId)
+    {
+        modelBuilder.Entity<AnalyticsProjectionCheckpoint>(entity =>
+        {
+            entity.ToTable("analytics_projection_checkpoint");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+            entity.Property(e => e.Stream).IsRequired().HasMaxLength(50);
+            entity.Property(e => e.LastSequenceNumber).HasDefaultValue(0L);
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("now()");
+
+            // One cursor per stream — the upsert target for the atomic advance.
+            entity.HasIndex(e => e.Stream)
+                .IsUnique()
+                .HasDatabaseName("UX_analytics_projection_checkpoint_stream");
+
+            ApplyTenantFilter<AnalyticsProjectionCheckpoint>(entity, fixedTenantId, _ => null);
+        });
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs
@@ -70,6 +70,10 @@ public class TenantDbContext : DbContext
     public DbSet<AnalyticsUsageHourly> AnalyticsUsageHourly => Set<AnalyticsUsageHourly>();
     public DbSet<AnalyticsUsageDaily> AnalyticsUsageDaily => Set<AnalyticsUsageDaily>();
 
+    // Story 36-2 — per-tenant resumable cursor for the dimensional projection.
+    public DbSet<AnalyticsProjectionCheckpoint> AnalyticsProjectionCheckpoints =>
+        Set<AnalyticsProjectionCheckpoint>();
+
     // Story 37-1 — tenant-scope curated audit trail, materialized from this
     // tenant's domain_events stream by the AuditProjector. Platform-scope rows
     // live in the CP audit_records.

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
@@ -147,6 +147,16 @@ Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorE
     .TryAddSingleton<TimeProvider>(builder.Services, _ => TimeProvider.System);
 builder.Services.AddHostedService<Tamma.ElsaServer.Workflows.HourlyAnalyticsRollupScheduler>();
 
+// Story 36-2 — dimensional analytics projection seams. The margin/pricing
+// config is the Story 36-7 seam; until 36-7 lands the Null impl yields a zero
+// margin (billed == cost) + WARN so the rollup stays green. The metrics
+// singleton is a self-registering meter exposing
+// tamma.analytics.projection_lag_seconds (KekRotationMetrics precedent).
+Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions
+    .TryAddSingleton<Tamma.Activities.Analytics.IAnalyticsPricingConfig,
+        Tamma.Activities.Analytics.NullAnalyticsPricingConfig>(builder.Services);
+builder.Services.AddSingleton<Tamma.Activities.Analytics.DimensionalProjectionMetrics>();
+
 // Round-2 review M3 — bridge that polls platform_events for new
 // TENANT.CLEANUP.REQUESTED rows and re-publishes the matching Elsa
 // event so CleanUpFailedTenantWorkflow's starter trigger fires. The

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/HourlyAnalyticsRollupWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/HourlyAnalyticsRollupWorkflow.cs
@@ -70,6 +70,9 @@ public class HourlyAnalyticsRollupWorkflow : WorkflowBase
         var targetHour = builder.WithVariable<DateTime>("TargetHour", DateTime.MinValue);
         var tenantsSuccess = builder.WithVariable<int>("TenantsSuccess", 0);
         var tenantsFailed = builder.WithVariable<int>("TenantsFailed", 0);
+        // Story 36-2 — dimensional fan-out success/failure counts.
+        var dimTenantsSuccess = builder.WithVariable<int>("DimTenantsSuccess", 0);
+        var dimTenantsFailed = builder.WithVariable<int>("DimTenantsFailed", 0);
 
         // ── Step 1: resolve the target hour from input or now-1 ─────────
         var initBucket = new SetVariable
@@ -125,6 +128,24 @@ public class HourlyAnalyticsRollupWorkflow : WorkflowBase
             TenantsFailed = new Output<int>(tenantsFailed),
         };
 
+        // ── Step 3b: per-tenant DIMENSIONAL rollup (Story 36-2) ─────────
+        //    Runs after the platform fact-table fan-out, sharing the same
+        //    schedule / advisory lock / target hour. Projects each tenant's
+        //    domain_events + ProviderDiagnostic into its own
+        //    analytics_usage_hourly (one row per provider/agent/workflow/repo/
+        //    cost-basis tuple), then — at the last hour of a UTC day — the
+        //    lossless daily compaction, then the best-effort hourly retention
+        //    purge. Per-tenant failures are tolerated (they do NOT abort the
+        //    fan-out). The existing platform rollup + CP purge are untouched.
+        var fanOutDimensional = new FanOutTenantDimensionalRollupsActivity
+        {
+            Id = "FanOutTenantDimensionalRollups",
+            Name = "Fan Out Tenant Dimensional Rollups",
+            Hour = new Input<DateTime>(ctx => targetHour.Get(ctx)),
+            TenantsSuccess = new Output<int>(dimTenantsSuccess),
+            TenantsFailed = new Output<int>(dimTenantsFailed),
+        };
+
         // ── Step 4: emit the terminal HOUR_COMPLETED event ──────────────
         var emitCompleted = new EmitHourCompletedActivity
         {
@@ -152,6 +173,7 @@ public class HourlyAnalyticsRollupWorkflow : WorkflowBase
                 initBucket,
                 platformRollup,
                 fanOut,
+                fanOutDimensional,
                 emitCompleted,
                 purgeStale,
             },

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/AnalyticsProjectionCheckpointTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/AnalyticsProjectionCheckpointTests.cs
@@ -1,0 +1,163 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using NUnit.Framework;
+using Tamma.Activities.Analytics;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+
+namespace Tamma.Activities.Tests.Analytics;
+
+/// <summary>
+/// Story 36-2 (AC7) — checkpoint advance + crash-resume for the dimensional
+/// projection. The <see cref="AnalyticsProjectionCheckpoint"/> row advances to
+/// the max folded <see cref="DomainEvent.SequenceNumber"/>; because the upsert
+/// is a whole-bucket overwrite, re-folding un-checkpointed events never
+/// double-counts. (Relational NULLS-NOT-DISTINCT collision is proven in the
+/// Postgres Testcontainer suite.)
+/// </summary>
+[TestFixture]
+public class AnalyticsProjectionCheckpointTests
+{
+    private static readonly DateTime Hour = new(2026, 04, 18, 12, 00, 00, DateTimeKind.Utc);
+
+    private FakeTenantDbContextFactory _tenantFactory = null!;
+    private Mock<IPlatformEventPublisher> _publisher = null!;
+    private List<IDisposable> _opened = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _opened = new List<IDisposable>();
+        _tenantFactory = new FakeTenantDbContextFactory(_opened);
+        _publisher = new Mock<IPlatformEventPublisher>();
+        _publisher
+            .Setup(p => p.AppendAndPublishAsync(It.IsAny<PlatformEvent>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PlatformEvent evt, CancellationToken _) => evt);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        foreach (var ctx in _opened) ctx.Dispose();
+    }
+
+    private static DomainEvent Llm(long seq, string provider, decimal cost) => new()
+    {
+        Id = Guid.NewGuid(),
+        Type = "LLM.CALL.SUCCESS",
+        CreatedAt = Hour.AddMinutes(seq),
+        SequenceNumber = seq,
+        Tags = JsonSerializer.Serialize(new Dictionary<string, string?> { ["provider"] = provider }),
+        Metadata = "{}",
+        Data = JsonSerializer.Serialize(new { costUsd = cost, inputTokens = 10, outputTokens = 5 }),
+    };
+
+    private async Task RunAsync(Guid tenantId, bool reset = false) =>
+        await ComputeTenantDimensionalRollupActivity.ComputeAsync(
+            _tenantFactory, _publisher.Object, tenantId, Hour, new FixedMarginPricing(0m), reset, null,
+            CancellationToken.None);
+
+    [Test]
+    public async Task Checkpoint_Absent_StartsAtZero_ThenAdvances()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = _tenantFactory.Register(tenantId);
+        db.DomainEvents.AddRange(Llm(5, "anthropic", 0.10m), Llm(12, "anthropic", 0.10m));
+        await db.SaveChangesAsync();
+
+        await RunAsync(tenantId);
+
+        var verify = await _tenantFactory.CreateAsync(tenantId);
+        var cp = await verify.AnalyticsProjectionCheckpoints.SingleAsync();
+        cp.Stream.Should().Be(AnalyticsProjectionCheckpoint.DimensionalStream);
+        cp.LastSequenceNumber.Should().Be(12);
+    }
+
+    [Test]
+    public async Task Checkpoint_NeverRegresses_OnHappyPathReRun()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = _tenantFactory.Register(tenantId);
+        db.DomainEvents.Add(Llm(50, "anthropic", 0.10m));
+        await db.SaveChangesAsync();
+
+        await RunAsync(tenantId);
+        // A second (non-reset) run of the same bucket keeps the checkpoint at 50.
+        await RunAsync(tenantId);
+
+        var verify = await _tenantFactory.CreateAsync(tenantId);
+        var cp = await verify.AnalyticsProjectionCheckpoints.SingleAsync();
+        cp.LastSequenceNumber.Should().Be(50);
+    }
+
+    [Test]
+    public async Task HighWater_SecondRunWithNoNewEvents_SkipsRecompute()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = _tenantFactory.Register(tenantId);
+        db.DomainEvents.AddRange(Llm(5, "anthropic", 0.10m), Llm(10, "anthropic", 0.10m));
+        await db.SaveChangesAsync();
+
+        await RunAsync(tenantId);
+
+        // Corrupt the projected row with a sentinel. If the second run RECOMPUTES,
+        // the whole-bucket overwrite resets it; if it correctly SKIPS (no event
+        // with SequenceNumber > checkpoint 10), the sentinel survives untouched.
+        var mutate = await _tenantFactory.CreateAsync(tenantId);
+        var row = await mutate.AnalyticsUsageHourly.SingleAsync();
+        row.CostUsd = 999m;
+        await mutate.SaveChangesAsync();
+
+        await RunAsync(tenantId); // no new events → must skip
+
+        var verify = await _tenantFactory.CreateAsync(tenantId);
+        (await verify.AnalyticsUsageHourly.SingleAsync()).CostUsd
+            .Should().Be(999m, "no new events → recompute skipped → sentinel untouched");
+        (await verify.AnalyticsProjectionCheckpoints.SingleAsync()).LastSequenceNumber
+            .Should().Be(10, "checkpoint unchanged when nothing newer is folded");
+    }
+
+    [Test]
+    public async Task HighWater_ThirdRunWithNewEvent_Recomputes()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = _tenantFactory.Register(tenantId);
+        db.DomainEvents.Add(Llm(5, "anthropic", 0.10m));
+        await db.SaveChangesAsync();
+
+        await RunAsync(tenantId); // checkpoint → 5
+
+        // A NEW event (SequenceNumber 20 > checkpoint 5) must trigger a recompute
+        // that re-derives the whole bucket (0.10 + 0.30) and advances the checkpoint.
+        var add = await _tenantFactory.CreateAsync(tenantId);
+        add.DomainEvents.Add(Llm(20, "anthropic", 0.30m));
+        await add.SaveChangesAsync();
+
+        await RunAsync(tenantId);
+
+        var verify = await _tenantFactory.CreateAsync(tenantId);
+        (await verify.AnalyticsUsageHourly.SingleAsync()).CostUsd
+            .Should().Be(0.40m, "a new event forces the whole-bucket recompute");
+        (await verify.AnalyticsProjectionCheckpoints.SingleAsync()).LastSequenceNumber
+            .Should().Be(20, "checkpoint advances to the new max SequenceNumber");
+    }
+
+    [Test]
+    public async Task CrashResume_ReFoldsSameBucket_NoDoubleCount()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = _tenantFactory.Register(tenantId);
+        db.DomainEvents.AddRange(Llm(1, "anthropic", 0.10m), Llm(2, "anthropic", 0.20m));
+        await db.SaveChangesAsync();
+
+        await RunAsync(tenantId);
+        // Simulate a crash-resume: re-run re-folds the whole bucket.
+        await RunAsync(tenantId, reset: true);
+
+        var verify = await _tenantFactory.CreateAsync(tenantId);
+        var row = await verify.AnalyticsUsageHourly.SingleAsync();
+        row.CostUsd.Should().Be(0.30m, "whole-bucket overwrite absorbs the re-fold — no double-count");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/AnalyticsRollupEventsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/AnalyticsRollupEventsTests.cs
@@ -73,6 +73,33 @@ public class AnalyticsRollupEventsTests
     }
 
     [Test]
+    public void DimensionalEventConstants_FollowAggregateActionStatus()
+    {
+        // Story 36-2 — the new dimensional/compact/purge/lag constants follow
+        // the AGGREGATE.ACTION.STATUS convention (dotted, uppercase segments).
+        var constants = new[]
+        {
+            AnalyticsRollupEvents.TenantDimensionalRollupCompleted,
+            AnalyticsRollupEvents.TenantDimensionalRollupFailed,
+            AnalyticsRollupEvents.DailyCompacted,
+            AnalyticsRollupEvents.UsageHourlyPurged,
+            AnalyticsRollupEvents.UsageHourlyPurgeFailed,
+            AnalyticsRollupEvents.DimensionalLag,
+        };
+
+        foreach (var c in constants)
+        {
+            c.Should().StartWith("ANALYTICS.");
+            c.Split('.').Length.Should().BeGreaterThanOrEqualTo(3, $"{c} must be AGGREGATE.ACTION.STATUS");
+            c.Should().Be(c.ToUpperInvariant());
+        }
+
+        AnalyticsRollupEvents.TenantDimensionalRollupCompleted
+            .Should().Be("ANALYTICS.ROLLUP.TENANT_DIMENSIONAL_COMPLETED");
+        AnalyticsRollupEvents.DimensionalLag.Should().Be("ANALYTICS.ROLLUP.DIMENSIONAL_LAG");
+    }
+
+    [Test]
     public void TruncateToHour_StripsMinutesSecondsMilliseconds()
     {
         var instant = new DateTime(2026, 04, 18, 12, 34, 56, 789, DateTimeKind.Utc);

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/CompactDailyAnalyticsActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/CompactDailyAnalyticsActivityTests.cs
@@ -1,0 +1,108 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using NUnit.Framework;
+using Tamma.Activities.Analytics;
+using Tamma.Core.Enums;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+
+namespace Tamma.Activities.Tests.Analytics;
+
+/// <summary>
+/// Story 36-2 — unit tests for
+/// <see cref="CompactDailyAnalyticsActivity.CompactAsync"/>: lossless hourly →
+/// daily GROUP BY sum, and idempotent re-compaction.
+/// </summary>
+[TestFixture]
+public class CompactDailyAnalyticsActivityTests
+{
+    private static readonly DateTime Day = new(2026, 04, 18, 0, 0, 0, DateTimeKind.Utc);
+
+    private FakeTenantDbContextFactory _tenantFactory = null!;
+    private Mock<IPlatformEventPublisher> _publisher = null!;
+    private List<IDisposable> _opened = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _opened = new List<IDisposable>();
+        _tenantFactory = new FakeTenantDbContextFactory(_opened);
+        _publisher = new Mock<IPlatformEventPublisher>();
+        _publisher
+            .Setup(p => p.AppendAndPublishAsync(It.IsAny<PlatformEvent>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PlatformEvent evt, CancellationToken _) => evt);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        foreach (var ctx in _opened) ctx.Dispose();
+    }
+
+    private static AnalyticsUsageHourly HourRow(DateTime hour, string provider, long tin, decimal cost) => new()
+    {
+        Id = Guid.NewGuid(),
+        Hour = hour,
+        Provider = provider,
+        CostBasis = CostBasis.Platform,
+        TokensIn = tin,
+        TokensOut = tin / 2,
+        CostUsd = cost,
+        PlatformBilledUsd = cost,
+        WorkflowsStarted = 1,
+        AgentDispatches = 1,
+        ComputedAt = DateTime.UtcNow,
+    };
+
+    [Test]
+    public async Task CompactAsync_RollsHourlyIntoDaily_Losslessly()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = _tenantFactory.Register(tenantId);
+        // Three hours of the same provider tuple + one different provider.
+        db.AnalyticsUsageHourly.AddRange(
+            HourRow(Day.AddHours(0), "anthropic", 100, 0.10m),
+            HourRow(Day.AddHours(1), "anthropic", 200, 0.20m),
+            HourRow(Day.AddHours(2), "anthropic", 300, 0.30m),
+            HourRow(Day.AddHours(3), "openai", 50, 0.05m),
+            // Next day — excluded.
+            HourRow(Day.AddDays(1), "anthropic", 999, 9.99m));
+        await db.SaveChangesAsync();
+
+        await CompactDailyAnalyticsActivity.CompactAsync(
+            _tenantFactory, _publisher.Object, tenantId, Day, null, CancellationToken.None);
+
+        var verify = await _tenantFactory.CreateAsync(tenantId);
+        var daily = await verify.AnalyticsUsageDaily.ToListAsync();
+
+        daily.Should().HaveCount(2);
+        var anthropic = daily.Single(r => r.Provider == "anthropic");
+        anthropic.Day.Should().Be(Day);
+        anthropic.TokensIn.Should().Be(600, "3 hours summed losslessly");
+        anthropic.CostUsd.Should().Be(0.60m);
+        anthropic.WorkflowsStarted.Should().Be(3);
+        anthropic.AgentDispatches.Should().Be(3);
+
+        daily.Single(r => r.Provider == "openai").TokensIn.Should().Be(50);
+    }
+
+    [Test]
+    public async Task CompactAsync_Idempotent_ReRunOverwritesNotDuplicates()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = _tenantFactory.Register(tenantId);
+        db.AnalyticsUsageHourly.Add(HourRow(Day.AddHours(0), "anthropic", 100, 0.10m));
+        await db.SaveChangesAsync();
+
+        await CompactDailyAnalyticsActivity.CompactAsync(
+            _tenantFactory, _publisher.Object, tenantId, Day, null, CancellationToken.None);
+        await CompactDailyAnalyticsActivity.CompactAsync(
+            _tenantFactory, _publisher.Object, tenantId, Day, null, CancellationToken.None);
+
+        var verify = await _tenantFactory.CreateAsync(tenantId);
+        var daily = await verify.AnalyticsUsageDaily.ToListAsync();
+        daily.Should().ContainSingle("re-compaction upserts on the daily business key");
+        daily[0].TokensIn.Should().Be(100);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/ComputeTenantDimensionalRollupTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/ComputeTenantDimensionalRollupTests.cs
@@ -1,0 +1,411 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using NUnit.Framework;
+using Tamma.Activities.Analytics;
+using Tamma.Core.Enums;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+
+namespace Tamma.Activities.Tests.Analytics;
+
+/// <summary>
+/// Story 36-2 — unit tests for
+/// <see cref="ComputeTenantDimensionalRollupActivity.ComputeAsync"/>: dimension
+/// bucketing (incl. NULL buckets reconciling to the grand total), cost-basis
+/// classification, platform-billed margin, idempotent replay, and checkpoint
+/// advance. Uses the shared InMemory harness (relational-only guarantees are
+/// proven by the Postgres Testcontainer suite in Tamma.Api.Tests).
+/// </summary>
+[TestFixture]
+public class ComputeTenantDimensionalRollupTests
+{
+    private static readonly DateTime Hour = new(2026, 04, 18, 12, 00, 00, DateTimeKind.Utc);
+
+    private FakeTenantDbContextFactory _tenantFactory = null!;
+    private Mock<IPlatformEventPublisher> _publisher = null!;
+    private List<IDisposable> _opened = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _opened = new List<IDisposable>();
+        _tenantFactory = new FakeTenantDbContextFactory(_opened);
+        _publisher = new Mock<IPlatformEventPublisher>();
+        _publisher
+            .Setup(p => p.AppendAndPublishAsync(It.IsAny<PlatformEvent>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PlatformEvent evt, CancellationToken _) => evt);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        foreach (var ctx in _opened) ctx.Dispose();
+    }
+
+    private static string Tags(params (string k, string? v)[] pairs)
+    {
+        var d = new Dictionary<string, string?>();
+        foreach (var (k, v) in pairs) d[k] = v;
+        return JsonSerializer.Serialize(d);
+    }
+
+    private static DomainEvent Llm(long seq, DateTime at, string tags, decimal cost, long tin, long tout) => new()
+    {
+        Id = Guid.NewGuid(),
+        Type = "LLM.CALL.SUCCESS",
+        CreatedAt = at,
+        SequenceNumber = seq,
+        Tags = tags,
+        Metadata = "{}",
+        Data = JsonSerializer.Serialize(new { costUsd = cost, inputTokens = tin, outputTokens = tout }),
+    };
+
+    private async Task RunAsync(Guid tenantId, IAnalyticsPricingConfig pricing, bool reset = false) =>
+        await ComputeTenantDimensionalRollupActivity.ComputeAsync(
+            _tenantFactory, _publisher.Object, tenantId, Hour, pricing, reset, null, CancellationToken.None);
+
+    // ── AC2 / AC3 — bucketing by provider + agent, NULL bucket reconciles ──
+    [Test]
+    public async Task ComputeAsync_BucketsByProviderAndAgent_NullReconcilesToGrandTotal()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = _tenantFactory.Register(tenantId);
+        db.DomainEvents.AddRange(
+            // provider A, agent x
+            Llm(1, Hour.AddMinutes(5), Tags(("provider", "anthropic"), ("agent_id", "x"), ("billing_mode", "platform")), 0.10m, 100, 50),
+            // provider A, agent x (same tuple → sums)
+            Llm(2, Hour.AddMinutes(6), Tags(("provider", "anthropic"), ("agent_id", "x"), ("billing_mode", "platform")), 0.20m, 200, 100),
+            // provider B, no agent tag → AgentId NULL bucket
+            Llm(3, Hour.AddMinutes(7), Tags(("provider", "openai"), ("billing_mode", "platform")), 0.40m, 400, 200));
+        await db.SaveChangesAsync();
+
+        await RunAsync(tenantId, new FixedMarginPricing(0m));
+
+        var verify = await _tenantFactory.CreateAsync(tenantId);
+        var rows = await verify.AnalyticsUsageHourly.ToListAsync();
+
+        rows.Should().HaveCount(2);
+        var anthropic = rows.Single(r => r.Provider == "anthropic");
+        anthropic.AgentId.Should().Be("x");
+        anthropic.TokensIn.Should().Be(300);
+        anthropic.CostUsd.Should().Be(0.30m);
+
+        var openai = rows.Single(r => r.Provider == "openai");
+        openai.AgentId.Should().BeNull("no agent_id tag buckets under the NULL 'unattributed' bucket");
+        openai.TokensIn.Should().Be(400);
+
+        // Reconciliation: Σ per-row == grand total.
+        rows.Sum(r => r.TokensIn).Should().Be(700);
+        rows.Sum(r => r.CostUsd).Should().Be(0.70m);
+    }
+
+    // ── AC4 — cost basis from billing_mode tag ──
+    [Test]
+    public async Task ComputeAsync_ResolvesCostBasis_FromBillingModeTag()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = _tenantFactory.Register(tenantId);
+        db.DomainEvents.AddRange(
+            Llm(1, Hour.AddMinutes(5), Tags(("provider", "anthropic"), ("billing_mode", "byok")), 1.00m, 10, 10),
+            Llm(2, Hour.AddMinutes(6), Tags(("provider", "anthropic"), ("billing_mode", "platform")), 2.00m, 20, 20));
+        await db.SaveChangesAsync();
+
+        await RunAsync(tenantId, new FixedMarginPricing(0m));
+
+        var verify = await _tenantFactory.CreateAsync(tenantId);
+        var rows = await verify.AnalyticsUsageHourly.ToListAsync();
+
+        rows.Should().HaveCount(2, "byok and platform are distinct cost-basis buckets");
+        rows.Single(r => r.CostBasis == CostBasis.Byok).CostUsd.Should().Be(1.00m);
+        rows.Single(r => r.CostBasis == CostBasis.Platform).CostUsd.Should().Be(2.00m);
+    }
+
+    [Test]
+    public async Task ComputeAsync_DefaultsToPlatform_WhenNoBillingMode()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = _tenantFactory.Register(tenantId);
+        db.DomainEvents.Add(
+            Llm(1, Hour.AddMinutes(5), Tags(("provider", "anthropic")), 1.00m, 10, 10));
+        await db.SaveChangesAsync();
+
+        await RunAsync(tenantId, new FixedMarginPricing(0m));
+
+        var verify = await _tenantFactory.CreateAsync(tenantId);
+        var row = await verify.AnalyticsUsageHourly.SingleAsync();
+        row.CostBasis.Should().Be(CostBasis.Platform, "absent billing_mode → platform default");
+    }
+
+    // ── AC5 — platform margin applied; byok → 0 ──
+    [Test]
+    public async Task ComputeAsync_AppliesMargin_ToPlatformOnly()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = _tenantFactory.Register(tenantId);
+        db.DomainEvents.AddRange(
+            Llm(1, Hour.AddMinutes(5), Tags(("provider", "anthropic"), ("billing_mode", "platform")), 1.00m, 10, 10),
+            Llm(2, Hour.AddMinutes(6), Tags(("provider", "anthropic"), ("billing_mode", "byok")), 1.00m, 10, 10));
+        await db.SaveChangesAsync();
+
+        await RunAsync(tenantId, new FixedMarginPricing(0.20m));
+
+        var verify = await _tenantFactory.CreateAsync(tenantId);
+        var platform = await verify.AnalyticsUsageHourly.SingleAsync(r => r.CostBasis == CostBasis.Platform);
+        var byok = await verify.AnalyticsUsageHourly.SingleAsync(r => r.CostBasis == CostBasis.Byok);
+
+        platform.PlatformBilledUsd.Should().Be(1.20m, "platform bills cost * (1 + margin)");
+        byok.PlatformBilledUsd.Should().Be(0m, "Tamma never marks up a BYOK call");
+    }
+
+    [Test]
+    public async Task ComputeAsync_ZeroMargin_WhenNullPricingConfig()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = _tenantFactory.Register(tenantId);
+        db.DomainEvents.Add(
+            Llm(1, Hour.AddMinutes(5), Tags(("provider", "anthropic"), ("billing_mode", "platform")), 2.50m, 10, 10));
+        await db.SaveChangesAsync();
+
+        await RunAsync(tenantId, new NullAnalyticsPricingConfig());
+
+        var verify = await _tenantFactory.CreateAsync(tenantId);
+        var row = await verify.AnalyticsUsageHourly.SingleAsync();
+        row.PlatformBilledUsd.Should().Be(2.50m, "null pricing config → zero margin → billed == cost");
+    }
+
+    // ── AC1 — agent dispatches (REAL underscore family, no provider tag) land in
+    //    the NULL-provider bucket; diagnostics contribute their own provider row ──
+    [Test]
+    public async Task ComputeAsync_CountsAgentDispatches_InNullProviderBucket_AndFoldsDiagnostics()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = _tenantFactory.Register(tenantId);
+        db.DomainEvents.AddRange(
+            // Story 38-2 mediation dispatch events — underscore family, NO provider
+            // tag (they carry repo/operation/correlationId only). A dotted LIKE
+            // pattern never matched these; the fix counts them under NULL provider.
+            new DomainEvent { Id = Guid.NewGuid(), Type = "AGENT_DISPATCH.RUN_TRIGGERED.SUCCESS",
+                CreatedAt = Hour.AddMinutes(1), SequenceNumber = 10,
+                Tags = Tags(("operation", "run_trigger"), ("repo", "acme/app")), Metadata = "{}", Data = "{}" },
+            new DomainEvent { Id = Guid.NewGuid(), Type = "AGENT_DISPATCH.RUN_TRIGGERED.FAILED",
+                CreatedAt = Hour.AddMinutes(2), SequenceNumber = 11,
+                Tags = Tags(("operation", "run_trigger"), ("repo", "acme/app")), Metadata = "{}", Data = "{}" },
+            // A follow-up poll must NOT count as a dispatch.
+            new DomainEvent { Id = Guid.NewGuid(), Type = "AGENT_DISPATCH.RUN_POLLED.SUCCESS",
+                CreatedAt = Hour.AddMinutes(2), SequenceNumber = 12,
+                Tags = Tags(("operation", "run_poll"), ("repo", "acme/app")), Metadata = "{}", Data = "{}" });
+        db.ProviderDiagnostics.Add(new ProviderDiagnostic
+        {
+            Id = Guid.NewGuid(), ProviderKey = "anthropic", AgentType = "developer",
+            InputTokens = 500, OutputTokens = 250, Cost = 0.90m, CreatedAt = Hour.AddMinutes(3),
+        });
+        await db.SaveChangesAsync();
+
+        await RunAsync(tenantId, new FixedMarginPricing(0m));
+
+        var verify = await _tenantFactory.CreateAsync(tenantId);
+        var rows = await verify.AnalyticsUsageHourly.ToListAsync();
+
+        rows.Sum(r => r.AgentDispatches).Should().Be(2, "only RUN_TRIGGERED counts; RUN_POLLED does not");
+        var dispatchRow = rows.Single(r => r.AgentDispatches > 0);
+        dispatchRow.Provider.Should().BeNull("dispatch events carry no provider → NULL bucket");
+        dispatchRow.CostUsd.Should().Be(0m);
+
+        var diag = rows.Single(r => r.AgentId == "developer");
+        diag.Provider.Should().Be("anthropic");
+        diag.TokensIn.Should().Be(500);
+        diag.TokensOut.Should().Be(250);
+        diag.CostUsd.Should().Be(0.90m);
+    }
+
+    // ── Fix 2 — diagnostic TokensUsed (back-compat total) is attributed when the
+    //    InputTokens/OutputTokens split is unset (the LlmProxyService writer). ──
+    [Test]
+    public async Task ComputeAsync_AttributesDiagnosticTokensUsed_WhenSplitIsZero()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = _tenantFactory.Register(tenantId);
+        db.ProviderDiagnostics.AddRange(
+            // LlmProxyService populates only TokensUsed; In/Out stay 0.
+            new ProviderDiagnostic { Id = Guid.NewGuid(), ProviderKey = "anthropic",
+                TokensUsed = 1000, InputTokens = 0, OutputTokens = 0, Cost = 0.50m, CreatedAt = Hour.AddMinutes(1) },
+            // A writer that DOES split must not be double-counted from TokensUsed.
+            new ProviderDiagnostic { Id = Guid.NewGuid(), ProviderKey = "openai",
+                TokensUsed = 999, InputTokens = 300, OutputTokens = 200, Cost = 0.25m, CreatedAt = Hour.AddMinutes(2) });
+        await db.SaveChangesAsync();
+
+        await RunAsync(tenantId, new FixedMarginPricing(0m));
+
+        var verify = await _tenantFactory.CreateAsync(tenantId);
+        var rows = await verify.AnalyticsUsageHourly.ToListAsync();
+
+        var total = rows.Single(r => r.Provider == "anthropic");
+        total.TokensIn.Should().Be(1000, "TokensUsed total attributed to TokensIn when split is 0");
+        total.TokensOut.Should().Be(0);
+
+        var split = rows.Single(r => r.Provider == "openai");
+        split.TokensIn.Should().Be(300, "split columns used verbatim — TokensUsed ignored to avoid double-count");
+        split.TokensOut.Should().Be(200);
+    }
+
+    // ── Fix 6 — cost is NOT double-counted when a diagnostic and an LLM event
+    //    describe the same call (shared correlationId; diagnostic is authoritative). ──
+    [Test]
+    public async Task ComputeAsync_NoCostDoubleCount_WhenDiagnosticAndEventShareCorrelationId()
+    {
+        var tenantId = Guid.NewGuid();
+        var corr = Guid.NewGuid();
+        var db = _tenantFactory.Register(tenantId);
+        db.DomainEvents.Add(
+            Llm(1, Hour.AddMinutes(5),
+                Tags(("provider", "anthropic"), ("correlationId", corr.ToString())), 0.10m, 100, 50));
+        db.ProviderDiagnostics.Add(new ProviderDiagnostic
+        {
+            Id = Guid.NewGuid(), ProviderKey = "anthropic", CorrelationId = corr,
+            InputTokens = 100, OutputTokens = 50, Cost = 0.90m, CreatedAt = Hour.AddMinutes(5),
+        });
+        await db.SaveChangesAsync();
+
+        await RunAsync(tenantId, new FixedMarginPricing(0m));
+
+        var verify = await _tenantFactory.CreateAsync(tenantId);
+        var rows = await verify.AnalyticsUsageHourly.ToListAsync();
+
+        rows.Sum(r => r.CostUsd).Should().Be(0.90m,
+            "the event's 0.10 is suppressed — the diagnostic (0.90) is the authoritative cost for that correlationId");
+    }
+
+    // ── AC6 — idempotent replay (whole-bucket overwrite) ──
+    [Test]
+    public async Task ComputeAsync_IdempotentReplay_IdenticalRowsAndMeasures()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = _tenantFactory.Register(tenantId);
+        db.DomainEvents.Add(
+            Llm(1, Hour.AddMinutes(5), Tags(("provider", "anthropic"), ("billing_mode", "platform")), 0.50m, 100, 50));
+        await db.SaveChangesAsync();
+
+        await RunAsync(tenantId, new FixedMarginPricing(0.10m));
+        await RunAsync(tenantId, new FixedMarginPricing(0.10m));
+
+        var verify = await _tenantFactory.CreateAsync(tenantId);
+        var rows = await verify.AnalyticsUsageHourly.ToListAsync();
+
+        rows.Should().ContainSingle("replay upserts on the business key, never duplicates");
+        rows[0].CostUsd.Should().Be(0.50m);
+        rows[0].PlatformBilledUsd.Should().Be(0.55m);
+    }
+
+    // ── AC7 — checkpoint advances to the max SequenceNumber ──
+    [Test]
+    public async Task ComputeAsync_AdvancesCheckpoint_ToMaxSequenceNumber()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = _tenantFactory.Register(tenantId);
+        db.DomainEvents.AddRange(
+            Llm(42, Hour.AddMinutes(5), Tags(("provider", "anthropic")), 0.10m, 10, 10),
+            Llm(99, Hour.AddMinutes(6), Tags(("provider", "openai")), 0.10m, 10, 10));
+        await db.SaveChangesAsync();
+
+        await RunAsync(tenantId, new FixedMarginPricing(0m));
+
+        var verify = await _tenantFactory.CreateAsync(tenantId);
+        var cp = await verify.AnalyticsProjectionCheckpoints
+            .SingleAsync(c => c.Stream == AnalyticsProjectionCheckpoint.DimensionalStream);
+        cp.LastSequenceNumber.Should().Be(99);
+    }
+
+    // ── AC9 — backfill re-run never double-counts (crash-resume shape) ──
+    [Test]
+    public async Task ComputeAsync_ReRunAfterCheckpoint_NoDoubleCount()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = _tenantFactory.Register(tenantId);
+        db.DomainEvents.Add(
+            Llm(1, Hour.AddMinutes(5), Tags(("provider", "anthropic")), 0.25m, 100, 50));
+        await db.SaveChangesAsync();
+
+        await RunAsync(tenantId, new FixedMarginPricing(0m));
+        // Re-run the same bucket (simulating a crash-resume / backfill): the
+        // whole-bucket overwrite must re-derive the same totals, not add to them.
+        await RunAsync(tenantId, new FixedMarginPricing(0m), reset: true);
+
+        var verify = await _tenantFactory.CreateAsync(tenantId);
+        var row = await verify.AnalyticsUsageHourly.SingleAsync();
+        row.TokensIn.Should().Be(100, "whole-bucket overwrite absorbs the replay with no double-count");
+        row.CostUsd.Should().Be(0.25m);
+    }
+
+    // ── AC1 (Fix 4) — workflow lifecycle counts become their OWN NULL-provider
+    //    row keyed by WorkflowDefinitionId, distinct from any provider usage row. ──
+    [Test]
+    public async Task ComputeAsync_EmitsWorkflowCounts_AsOwnNullProviderRow()
+    {
+        var tenantId = Guid.NewGuid();
+        var defId = Guid.NewGuid();
+        var db = _tenantFactory.Register(tenantId);
+        // A provider-attributed usage row that also references the same defId —
+        // proves the counts are NOT folded onto it (would double-attribute).
+        db.DomainEvents.Add(
+            Llm(1, Hour.AddMinutes(5),
+                Tags(("provider", "anthropic"), ("workflowDefinitionId", defId.ToString())), 0.10m, 10, 10));
+        db.WorkflowInstances.AddRange(
+            new WorkflowInstance { Id = Guid.NewGuid(), DefinitionId = defId, Status = "completed",
+                Variables = "{}", CreatedAt = Hour.AddMinutes(2), UpdatedAt = Hour.AddMinutes(2) },
+            new WorkflowInstance { Id = Guid.NewGuid(), DefinitionId = defId, Status = "failed",
+                Variables = "{}", CreatedAt = Hour.AddMinutes(3), UpdatedAt = Hour.AddMinutes(3) });
+        await db.SaveChangesAsync();
+
+        await RunAsync(tenantId, new FixedMarginPricing(0m));
+
+        var verify = await _tenantFactory.CreateAsync(tenantId);
+        var rows = await verify.AnalyticsUsageHourly.Where(r => r.WorkflowDefinitionId == defId).ToListAsync();
+        rows.Should().HaveCount(2, "the provider usage row and the NULL-provider workflow-count row are distinct");
+
+        var wfRow = rows.Single(r => r.Provider == null);
+        wfRow.WorkflowsStarted.Should().Be(2);
+        wfRow.WorkflowsCompleted.Should().Be(1);
+        wfRow.WorkflowsFailed.Should().Be(1);
+        wfRow.CostUsd.Should().Be(0m, "the workflow-count row carries no cost");
+
+        var usageRow = rows.Single(r => r.Provider == "anthropic");
+        usageRow.WorkflowsStarted.Should().Be(0, "counts are not folded onto the provider usage row");
+        usageRow.CostUsd.Should().Be(0.10m);
+
+        // Grand-total reconciliation still holds across the split rows.
+        rows.Sum(r => r.WorkflowsStarted).Should().Be(2);
+        rows.Sum(r => r.CostUsd).Should().Be(0.10m);
+    }
+
+    // ── AC1 — emits the completion event ──
+    [Test]
+    public async Task ComputeAsync_EmitsTenantDimensionalCompleted()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = _tenantFactory.Register(tenantId);
+        db.DomainEvents.Add(Llm(1, Hour.AddMinutes(5), Tags(("provider", "anthropic")), 0.10m, 10, 10));
+        await db.SaveChangesAsync();
+
+        await RunAsync(tenantId, new FixedMarginPricing(0m));
+
+        _publisher.Verify(p => p.AppendAndPublishAsync(
+            It.Is<PlatformEvent>(e =>
+                e.Type == AnalyticsRollupEvents.TenantDimensionalRollupCompleted && e.TenantId == tenantId),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ── AC4 — ResolveCostBasis pure helper ──
+    [Test]
+    public void ResolveCostBasis_TagWins_ThenDiagnostic_ThenPlatformDefault()
+    {
+        ComputeTenantDimensionalRollupActivity.ResolveCostBasis("byok", null).Should().Be(CostBasis.Byok);
+        ComputeTenantDimensionalRollupActivity.ResolveCostBasis("BYOK", null).Should().Be(CostBasis.Byok);
+        ComputeTenantDimensionalRollupActivity.ResolveCostBasis("platform", null).Should().Be(CostBasis.Platform);
+        ComputeTenantDimensionalRollupActivity.ResolveCostBasis(null, "byok").Should().Be(CostBasis.Byok);
+        ComputeTenantDimensionalRollupActivity.ResolveCostBasis(null, null).Should().Be(CostBasis.Platform);
+        ComputeTenantDimensionalRollupActivity.ResolveCostBasis("", "").Should().Be(CostBasis.Platform);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/DimensionalRollupTestHarness.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/DimensionalRollupTestHarness.cs
@@ -1,0 +1,79 @@
+using Microsoft.EntityFrameworkCore;
+using Tamma.Activities.Analytics;
+using Tamma.Data;
+using Tamma.Data.Entities;
+
+namespace Tamma.Activities.Tests.Analytics;
+
+/// <summary>
+/// Story 36-2 — shared InMemory harness for the dimensional-rollup unit tests.
+/// Mirrors the Story 28-10 <c>ComputeTenantRollupActivityTests</c> fakes: each
+/// tenant id maps to its own named InMemory database so the read-compute-upsert
+/// cycle runs without a real Postgres. Relational-only guarantees (NULLS NOT
+/// DISTINCT collision, <c>ExecuteDeleteAsync</c>) are proven by the Postgres
+/// Testcontainer suite in <c>Tamma.Api.Tests</c>.
+/// </summary>
+internal sealed class FakeTenantDbContextFactory : Tamma.Data.Abstractions.ITenantDbContextFactory
+{
+    private readonly Dictionary<Guid, string> _names = new();
+    private readonly List<IDisposable> _opened;
+
+    public FakeTenantDbContextFactory(List<IDisposable> opened) => _opened = opened;
+
+    public TenantDbContext Register(Guid tenantId)
+    {
+        var name = $"dim-tenant-{tenantId:N}";
+        _names[tenantId] = name;
+        return OpenContext(name);
+    }
+
+    public ValueTask<TenantDbContext> CreateAsync(Guid tenantId, CancellationToken ct = default)
+    {
+        if (!_names.TryGetValue(tenantId, out var name))
+            throw new InvalidOperationException($"Tenant {tenantId} not reachable.");
+        return new ValueTask<TenantDbContext>(OpenContext(name));
+    }
+
+    private TenantDbContext OpenContext(string name)
+    {
+        var options = new DbContextOptionsBuilder<TenantDbContext>()
+            .UseInMemoryDatabase(name)
+            .ConfigureWarnings(w => w.Ignore(
+                Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+        var ctx = new InMemoryFriendlyTenantDbContext(options);
+        _opened.Add(ctx);
+        return ctx;
+    }
+}
+
+/// <summary>
+/// InMemory-friendly <see cref="TenantDbContext"/> — drops the mentorship
+/// aggregate (jsonb + rowversion columns the InMemory provider rejects). The
+/// dimensional rollup only reads workflow_instances, domain_events,
+/// provider_diagnostics and writes analytics_usage_* + the checkpoint.
+/// </summary>
+internal sealed class InMemoryFriendlyTenantDbContext : TenantDbContext
+{
+    public InMemoryFriendlyTenantDbContext(DbContextOptions<TenantDbContext> options)
+        : base(options)
+    {
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.Ignore<Tamma.Core.Entities.JuniorDeveloper>();
+        modelBuilder.Ignore<Tamma.Core.Entities.Story>();
+        modelBuilder.Ignore<Tamma.Core.Entities.MentorshipSession>();
+        modelBuilder.Ignore<Tamma.Core.Entities.MentorshipEvent>();
+    }
+}
+
+/// <summary>Fixed-margin test double for <see cref="IAnalyticsPricingConfig"/>.</summary>
+internal sealed class FixedMarginPricing : IAnalyticsPricingConfig
+{
+    private readonly decimal _margin;
+    public FixedMarginPricing(decimal margin) => _margin = margin;
+    public decimal MarginFor(string provider) => _margin;
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/HourlyAnalyticsRollupWorkflowStructureTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/HourlyAnalyticsRollupWorkflowStructureTests.cs
@@ -23,9 +23,10 @@ public class HourlyAnalyticsRollupWorkflowStructureTests
     {
         typeof(SetVariable),                         // initBucket
         typeof(ComputePlatformRollupActivity),
-        typeof(FanOutTenantRollupsActivity),
+        typeof(FanOutTenantRollupsActivity),         // platform fact table (28-10)
+        typeof(FanOutTenantDimensionalRollupsActivity), // per-tenant dimensional (36-2)
         typeof(EmitHourCompletedActivity),
-        typeof(PurgeStaleAnalyticsActivity),         // PURGE_ANALYTICS_HOURLY
+        typeof(PurgeStaleAnalyticsActivity),         // PURGE_ANALYTICS_HOURLY (CP, 28-10)
     };
 
     [Test]
@@ -60,6 +61,24 @@ public class HourlyAnalyticsRollupWorkflowStructureTests
                 .Be(ExpectedActivitiesInOrder[i],
                     $"position {i} should be {ExpectedActivitiesInOrder[i].Name}");
         }
+    }
+
+    [Test]
+    public void Build_DimensionalFanOut_FollowsPlatformFanOut()
+    {
+        // Story 36-2 AC14 — the dimensional fan-out is an additional step AFTER
+        // the platform fact-table fan-out and before the terminal emit/purge.
+        var workflow = new HourlyAnalyticsRollupWorkflow();
+        var builder = WorkflowTestHelper.BuildWorkflow(workflow);
+        var activities = ((Sequence)builder.Object.Root).Activities.ToList();
+
+        var platformIdx = activities.FindIndex(a => a is FanOutTenantRollupsActivity);
+        var dimensionalIdx = activities.FindIndex(a => a is FanOutTenantDimensionalRollupsActivity);
+        var emitIdx = activities.FindIndex(a => a is EmitHourCompletedActivity);
+
+        platformIdx.Should().BeGreaterThanOrEqualTo(0);
+        dimensionalIdx.Should().BeGreaterThan(platformIdx, "the platform fan-out must precede the dimensional one");
+        emitIdx.Should().BeGreaterThan(dimensionalIdx, "EmitHourCompleted stays terminal-before-purge, after the dimensional fan-out");
     }
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/AnalyticsUsageModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/AnalyticsUsageModelTests.cs
@@ -118,8 +118,9 @@ public class AnalyticsUsageModelTests
         entity.FindProperty("AgentId")!.IsNullable.Should().BeTrue();
         entity.FindProperty("WorkflowDefinitionId")!.IsNullable.Should().BeTrue();
         entity.FindProperty("RepoId")!.IsNullable.Should().BeTrue();
+        entity.FindProperty("Provider")!.IsNullable.Should().BeTrue(
+            "Provider is nullable (Story 36-2) — workflow/dispatch counts bucket under NULL");
 
-        entity.FindProperty("Provider")!.IsNullable.Should().BeFalse("Provider is required");
         entity.FindProperty("CostBasis")!.IsNullable.Should().BeFalse("CostBasis is required");
     }
 
@@ -133,7 +134,7 @@ public class AnalyticsUsageModelTests
         entity.FindProperty("AgentId")!.IsNullable.Should().BeTrue();
         entity.FindProperty("WorkflowDefinitionId")!.IsNullable.Should().BeTrue();
         entity.FindProperty("RepoId")!.IsNullable.Should().BeTrue();
-        entity.FindProperty("Provider")!.IsNullable.Should().BeFalse();
+        entity.FindProperty("Provider")!.IsNullable.Should().BeTrue();
     }
 
     // ── AC8 — counter store types are bigint, costs are numeric(20,4) ──

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/DimensionalRollupIsolationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/DimensionalRollupIsolationTests.cs
@@ -1,0 +1,210 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Npgsql;
+using NUnit.Framework;
+using Tamma.Activities.Analytics;
+using Tamma.Core.Enums;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+using Tamma.Data.Pooling;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Analytics;
+
+/// <summary>
+/// Story 36-2 (AC7/AC8/AC15) — Postgres 17 Testcontainer proof for the
+/// dimensional projection: per-tenant schema isolation, a tenant-A failure
+/// leaving tenant B intact, the NULLS-NOT-DISTINCT concurrent-replay backstop,
+/// and checkpoint resume. Follows <c>AnalyticsUsageMigrationTests</c> /
+/// <c>SchemaPerTenantMigrationTests</c> (two tenant schemas in one DB,
+/// search-path isolation). EF InMemory honours neither NULLS NOT DISTINCT nor
+/// the checkpoint migration, so a real Postgres is the only proof.
+/// </summary>
+[TestFixture]
+public class DimensionalRollupIsolationTests
+{
+    private static readonly DateTime Hour = new(2026, 04, 18, 12, 00, 00, DateTimeKind.Utc);
+
+    private PostgreSqlContainer _postgres = null!;
+    private string _baseConnectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("dim_rollup_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _baseConnectionString = _postgres.GetConnectionString();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown() => await _postgres.DisposeAsync();
+
+    private string CsFor(string schema) =>
+        new NpgsqlConnectionStringBuilder(_baseConnectionString) { SearchPath = schema }.ConnectionString;
+
+    private static Mock<IPlatformEventPublisher> Publisher()
+    {
+        var p = new Mock<IPlatformEventPublisher>();
+        p.Setup(x => x.AppendAndPublishAsync(It.IsAny<PlatformEvent>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PlatformEvent e, CancellationToken _) => e);
+        return p;
+    }
+
+    private static DomainEvent Llm(long seq, string provider, decimal cost, long tin, long tout) => new()
+    {
+        Id = Guid.NewGuid(),
+        Type = "LLM.CALL.SUCCESS",
+        CreatedAt = Hour.AddSeconds(seq),
+        SequenceNumber = seq,
+        Tags = JsonSerializer.Serialize(new Dictionary<string, string?>
+        {
+            ["provider"] = provider,
+            ["billing_mode"] = "platform",
+        }),
+        Metadata = "{}",
+        Data = JsonSerializer.Serialize(new { costUsd = cost, inputTokens = tin, outputTokens = tout }),
+    };
+
+    [Test]
+    public async Task Projection_IsPerTenantIsolated_AndFailureTolerant_AndResumable()
+    {
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+        var unreachable = Guid.NewGuid();
+        var schemaA = TenantNaming.SchemaName(tenantA);
+        var schemaB = TenantNaming.SchemaName(tenantB);
+
+        var migrator = new EfTenantDbMigrator();
+        await migrator.MigrateTenantAppAsync(CsFor(schemaA));
+        await migrator.MigrateTenantAppAsync(CsFor(schemaB));
+
+        var factory = new SchemaRoutingFactory(_baseConnectionString)
+            .Map(tenantA, schemaA)
+            .Map(tenantB, schemaB);
+        var publisher = Publisher();
+        var pricing = new NullAnalyticsPricingConfig();
+
+        // Seed only tenant A with usage events.
+        var optsA = new DbContextOptionsBuilder<TenantDbContext>().UseNpgsql(CsFor(schemaA)).Options;
+        await using (var ctxA = new TenantDbContext(optsA, tenantA))
+        {
+            ctxA.DomainEvents.AddRange(Llm(1, "anthropic", 0.10m, 100, 50), Llm(2, "anthropic", 0.20m, 200, 100));
+            await ctxA.SaveChangesAsync();
+        }
+
+        // ── (a) isolation — projecting A writes only into A's schema ──
+        await ComputeTenantDimensionalRollupActivity.ComputeAsync(
+            factory, publisher.Object, tenantA, Hour, pricing, false, null, CancellationToken.None);
+
+        var optsB = new DbContextOptionsBuilder<TenantDbContext>().UseNpgsql(CsFor(schemaB)).Options;
+        await using (var ctxB = new TenantDbContext(optsB, tenantB))
+        {
+            (await ctxB.AnalyticsUsageHourly.AnyAsync()).Should().BeFalse(
+                "tenant A's projection must be invisible in tenant B's schema");
+        }
+        await using (var ctxA = new TenantDbContext(optsA, tenantA))
+        {
+            var row = await ctxA.AnalyticsUsageHourly.SingleAsync();
+            row.Provider.Should().Be("anthropic");
+            row.CostUsd.Should().Be(0.30m);
+            (await ctxA.AnalyticsProjectionCheckpoints.SingleAsync()).LastSequenceNumber.Should().Be(2);
+        }
+
+        // ── (b) failure tolerance — an unreachable tenant throws; B still projects ──
+        Func<Task> unreachableRun = () => ComputeTenantDimensionalRollupActivity.ComputeAsync(
+            factory, publisher.Object, unreachable, Hour, pricing, false, null, CancellationToken.None);
+        await unreachableRun.Should().ThrowAsync<Exception>("an unreachable tenant surfaces to the fan-out catch");
+
+        await ComputeTenantDimensionalRollupActivity.ComputeAsync(
+            factory, publisher.Object, tenantB, Hour, pricing, false, null, CancellationToken.None);
+        await using (var ctxB = new TenantDbContext(optsB, tenantB))
+        {
+            // B had no events → zero usage rows but a checkpoint row exists.
+            (await ctxB.AnalyticsProjectionCheckpoints.AnyAsync()).Should().BeTrue(
+                "tenant B projects independently of tenant A / the unreachable tenant");
+        }
+
+        // ── (c) idempotent replay collapses on the business key (no dup) ──
+        await ComputeTenantDimensionalRollupActivity.ComputeAsync(
+            factory, publisher.Object, tenantA, Hour, pricing, false, null, CancellationToken.None);
+        await using (var ctxA = new TenantDbContext(optsA, tenantA))
+        {
+            (await ctxA.AnalyticsUsageHourly.CountAsync()).Should().Be(1,
+                "re-projection upserts on UX_analytics_usage_hourly_dims — never duplicates");
+            var row = await ctxA.AnalyticsUsageHourly.SingleAsync();
+            row.CostUsd.Should().Be(0.30m, "measures are recomputed, not doubled");
+        }
+    }
+
+    [Test]
+    public async Task NullDimensionTuple_Collides_OnNullsNotDistinct()
+    {
+        var tenant = Guid.NewGuid();
+        var schema = TenantNaming.SchemaName(tenant);
+        await new EfTenantDbMigrator().MigrateTenantAppAsync(CsFor(schema));
+
+        // Two events on the SAME provider with NO agent/workflow/repo tags →
+        // identical (Hour, provider, NULL, NULL, NULL, platform) tuple. The
+        // projection collapses them to one row (whole-bucket aggregate); a
+        // manual duplicate insert must violate UX_*_dims (NULLS NOT DISTINCT).
+        var factory = new SchemaRoutingFactory(_baseConnectionString).Map(tenant, schema);
+        var opts = new DbContextOptionsBuilder<TenantDbContext>().UseNpgsql(CsFor(schema)).Options;
+        await using (var ctx = new TenantDbContext(opts, tenant))
+        {
+            ctx.DomainEvents.AddRange(Llm(1, "anthropic", 0.10m, 10, 5), Llm(2, "anthropic", 0.20m, 20, 10));
+            await ctx.SaveChangesAsync();
+        }
+
+        await ComputeTenantDimensionalRollupActivity.ComputeAsync(
+            factory, Publisher().Object, tenant, Hour, new NullAnalyticsPricingConfig(), false, null,
+            CancellationToken.None);
+
+        await using (var ctx = new TenantDbContext(opts, tenant))
+        {
+            (await ctx.AnalyticsUsageHourly.CountAsync()).Should().Be(1,
+                "two provider-only events with all-NULL dims collapse to one tuple");
+        }
+
+        // Manual duplicate insert of the identical all-NULL tuple must collide.
+        await using var conn = new NpgsqlConnection(CsFor(schema));
+        await conn.OpenAsync();
+        await using var dup = new NpgsqlCommand(
+            """
+            INSERT INTO analytics_usage_hourly ("Hour", "Provider", "CostBasis")
+            VALUES (TIMESTAMPTZ '2026-04-18T12:00:00Z', 'anthropic', 'platform');
+            """, conn);
+        var act = async () => await dup.ExecuteNonQueryAsync();
+        (await act.Should().ThrowAsync<PostgresException>()).Which.SqlState.Should().Be("23505");
+    }
+
+    /// <summary>Routes each tenant id to its own search-path schema connection string.</summary>
+    private sealed class SchemaRoutingFactory : ITenantDbContextFactory
+    {
+        private readonly string _baseCs;
+        private readonly Dictionary<Guid, string> _schemas = new();
+        public SchemaRoutingFactory(string baseCs) => _baseCs = baseCs;
+
+        public SchemaRoutingFactory Map(Guid tenantId, string schema)
+        {
+            _schemas[tenantId] = schema;
+            return this;
+        }
+
+        public ValueTask<TenantDbContext> CreateAsync(Guid tenantId, CancellationToken ct = default)
+        {
+            if (!_schemas.TryGetValue(tenantId, out var schema))
+                throw new InvalidOperationException($"Tenant {tenantId} not reachable.");
+            var cs = new NpgsqlConnectionStringBuilder(_baseCs) { SearchPath = schema }.ConnectionString;
+            var opts = new DbContextOptionsBuilder<TenantDbContext>().UseNpgsql(cs).Options;
+            return new ValueTask<TenantDbContext>(new TenantDbContext(opts, tenantId));
+        }
+    }
+}


### PR DESCRIPTION
## What

Story 36-2 (HourlyAnalytics). Hourly per-tenant projection of the DCB event stream (`domain_events`) + `ProviderDiagnostic` rows into the `analytics_usage_hourly`/`_daily` dimensional fact tables — one row per `(Provider, AgentId, WorkflowDefinitionId, RepoId, CostBasis)` tuple. **Extends** the existing `HourlyAnalyticsRollupWorkflow` (no new scheduler).

- Idempotent whole-bucket read-then-upsert on the full 6-key business tuple (NULLS-NOT-DISTINCT unique index).
- Per-tenant schema isolation; resumable checkpoint; byok/platform cost basis with an `IAnalyticsPricingConfig` margin seam (Null impl ships zero margin); daily compaction + 13-month purge; `ANALYTICS.ROLLUP.*` events + `tamma.analytics.projection_lag_seconds` OTel gauge.
- New activities: `ComputeTenantDimensionalRollup`, `FanOutTenantDimensionalRollups`, `CompactDailyAnalytics`, `PurgeStaleUsageAnalytics`. New `AnalyticsProjectionCheckpoint` entity + **single** Tenant migration `AddDimensionalAnalyticsProjection`.

## Review-driven correctness fixes (each TDD-locked)

An adversarial review found the machinery solid but several measures didn't line up with the real source tags/columns — the projection populated little beyond per-provider `CostUsd`. Fixed:

- **`Provider` made nullable** on the fact tables — a Story 36-1 oversight (siblings were already nullable with a NULLS-NOT-DISTINCT index); AC2 requires a NULL bucket for absent provider, and workflow/dispatch count rows have no provider.
- **Token under-count** → fall back to `ProviderDiagnostic.TokensUsed` when the In/Out split is 0 (the proxy writer populates only `TokensUsed`).
- **AgentDispatches** now matches the real event family `AGENT_DISPATCH.RUN_TRIGGERED.*` (`StartsWith`, not a dotted `LIKE` that never matched).
- **Workflow lifecycle counts** emit their own NULL-provider rows keyed by definition (were folded onto a usage row that never existed).
- **Checkpoint** is now a functional high-water mark (skip recompute when no events exceed it; else whole-bucket recompute + advance) — satisfies AC7 without breaking idempotency (a naive `> checkpoint` filter would corrupt the whole-bucket overwrite).
- **Latent cost double-count** removed — `ProviderDiagnostic` is authoritative; `LLM.CALL.SUCCESS` folds only when no diagnostic shares its `correlationId`.

## Known follow-up (out of scope, pre-existing)

The Story 28-10 sibling activities (`ComputeTenantRollupActivity`/`ComputePlatformRollupActivity`) still use the dotted `AGENT.DISPATCH.%` `LIKE` pattern and would miss the underscore `AGENT_DISPATCH.*` family — a pre-existing 28-10 bug, not touched here.

## Verification

- `dotnet build`: 0 errors, no TAMMA001.
- Analytics tests: **51** (Activities) + **60** (Api, incl. Postgres Testcontainer isolation/checkpoint/NULLS-NOT-DISTINCT proof) — all green.
- Migration snapshot: `has-pending-model-changes` → no drift. Single migration; stale intermediate removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)