### PR TITLE
ci(e2e-deploy): poll origins until ready instead of a blind sleep 30

### DIFF
--- a/.github/workflows/e2e-deploy.yml
+++ b/.github/workflows/e2e-deploy.yml
@@ -72,9 +72,34 @@ jobs:
 
       - name: Wait for services to stabilize
         if: github.event_name == 'workflow_run'
+        env:
+          APP_URL: ${{ inputs.app_url || 'https://app.tamma.dev' }}
+          API_URL: ${{ inputs.api_url || 'https://api.tamma.dev' }}
+          ELSA_URL: ${{ inputs.elsa_url || 'https://elsa.tamma.dev' }}
         run: |
-          echo "Waiting 30s for services to stabilize after deploy..."
-          sleep 30
+          # The layered deploy restarts containers (dashboard/nginx come up LAST),
+          # so immediately post-deploy Cloudflare returns 521 for a window. A blind
+          # `sleep 30` under-waits and the smoke tests flake on a transient 521.
+          # Poll each origin until it responds with a real (< 500) status, up to 5m.
+          deadline=$((SECONDS + 300))
+          wait_ready() {
+            url="$1"
+            echo "Waiting for $url ..."
+            while :; do
+              code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$url" || echo 000)
+              if [ "$code" -ge 100 ] && [ "$code" -lt 500 ]; then
+                echo "  $url -> $code (ready)"; return 0
+              fi
+              if [ "$SECONDS" -ge "$deadline" ]; then
+                echo "::warning::$url still not ready (last=$code) after 5m; running tests anyway to surface the real failure"
+                return 0
+              fi
+              echo "  $url -> $code, retrying in 10s..."; sleep 10
+            done
+          }
+          wait_ready "$APP_URL"
+          wait_ready "$API_URL/health"
+          wait_ready "$ELSA_URL"
 
       - name: Run E2E smoke tests
         env:


### PR DESCRIPTION
## Problem

The post-deploy **E2E Deploy Tests** flake intermittently with `HTTP 521` ("SERVICE DOWN: Dashboard at app.tamma.dev unreachable"). Root cause: the layered deploy restarts containers (dashboard/nginx come up **last**), so Cloudflare returns a transient 521 for a window right after deploy. The wait step is a blind `sleep 30`, which under-waits — the smoke suite then runs against a still-restarting origin and fails on the 521.

Confirmed a timing flake (not a code/outage issue): the failing run passed cleanly on rerun once the origins recovered (`app`/`elsa` = 302, `api/health` = 200). The failure history shows this 521-during-restart pattern recurring across deploys.

## Fix

Replace `sleep 30` with a poll loop that waits (up to 5 min) for `app`, `api/health`, and `elsa` to each return a real (`< 500`) status before running the suite. On timeout it proceeds with a `::warning::` so a **genuine** outage still surfaces as a real test failure rather than being masked.

Workflow-only change; validated with `yaml.safe_load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)