### PR TITLE
fix(epic-38): escape Slack control tokens on the mediated notification path

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/Integration/SlackActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Integration/SlackActivity.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Serialization;
 using Tamma.Activities.LlmCall;
 using Tamma.Activities.LlmCall.Models;
 using Tamma.Core.Entities;
+using Tamma.Core.Redaction;
 using Tamma.Data.Repositories;
 
 namespace Tamma.Activities.Integration;
@@ -286,22 +287,12 @@ _Reply if you have questions or need more help!_";
 
     /// <summary>
     /// Neutralize Slack control characters in an UNTRUSTED message body before it is
-    /// interpolated into a posted body. Slack's documented escaping (<c>&amp;</c> →
-    /// <c>&amp;amp;</c>, <c>&lt;</c> → <c>&amp;lt;</c>, <c>&gt;</c> → <c>&amp;gt;</c>)
-    /// renders broadcast/mention tokens like <c>&lt;!channel&gt;</c>, <c>&lt;!here&gt;</c>,
-    /// <c>&lt;@U…&gt;</c> literally, so issue/task/AI-derived content can't expand into
-    /// pings beyond the intended audience. Applied ONLY to caller-supplied text — never
-    /// to our own emoji/label prefixes. Order matters: escape <c>&amp;</c> first so the
-    /// replacements it introduces are not double-escaped.
+    /// interpolated into a posted body. Delegates to the single shared implementation
+    /// <see cref="SlackTextSanitizer.Escape"/> so the engine-side formatters and the
+    /// mediated <c>MediatedSlack</c> seam escape identically. Applied ONLY to
+    /// caller-supplied text — never to our own emoji/label prefixes.
     /// </summary>
-    internal static string EscapeSlack(string? text)
-    {
-        if (string.IsNullOrEmpty(text)) return string.Empty;
-        return text
-            .Replace("&", "&amp;", StringComparison.Ordinal)
-            .Replace("<", "&lt;", StringComparison.Ordinal)
-            .Replace(">", "&gt;", StringComparison.Ordinal);
-    }
+    internal static string EscapeSlack(string? text) => SlackTextSanitizer.Escape(text);
 }
 
 /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/MediatedSlack.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/MediatedSlack.cs
@@ -1,6 +1,7 @@
 using Elsa.Extensions;
 using Elsa.Workflows;
 using Tamma.Activities.LlmCall.Models;
+using Tamma.Core.Redaction;
 
 namespace Tamma.Activities.LlmCall;
 
@@ -26,9 +27,16 @@ namespace Tamma.Activities.LlmCall;
 /// non-2xx) or an unwired client is returned to the caller but NEVER throws and NEVER
 /// changes the activity's outcome — a missing Slack post must not break a
 /// mentorship/review run (and this also fixes the latent "PR merged but reported
-/// Failed because the notify threw" bug). The message body is passed through UNCHANGED
-/// (each activity formats its own body engine-side exactly as before the cutover; this
-/// seam adds no re-formatting — Slack-token hardening is a separate 38-3 follow-up).</para>
+/// Failed because the notify threw" bug). Each activity formats its own body engine-side;
+/// this seam does no re-formatting BUT is the exactly-once point at which the untrusted
+/// body is hardened against Slack control tokens via
+/// <see cref="SlackTextSanitizer.Escape"/> — so <c>&lt;!channel&gt;</c> / <c>&lt;!here&gt;</c> /
+/// <c>&lt;@Uxxxx&gt;</c> / <c>&lt;!subteam^Sxxx&gt;</c> derived from issue titles or LLM output
+/// can never trigger a broadcast/mention ping. The escape is applied when the request is
+/// BUILT (before it is enqueued to <c>slack_outbox</c>), and neither the notification
+/// endpoint nor <c>OutboxSlackSender</c> re-escape, so every mediated send is escaped
+/// exactly once. (The engine-side <c>SlackActivity</c> escapes in its own formatters via
+/// the same shared helper; it does not use this seam.)</para>
 /// </summary>
 internal static class MediatedSlack
 {
@@ -60,7 +68,11 @@ internal static class MediatedSlack
             BuildChannelMessage(channel, message, messageType, action),
             ct);
 
-    /// <summary>Pure builder: a single-target DM request (channel = null).</summary>
+    /// <summary>
+    /// Pure builder: a single-target DM request (channel = null). The untrusted
+    /// <paramref name="message"/> is hardened against Slack control tokens exactly once
+    /// here via <see cref="SlackTextSanitizer.Escape"/> — see the class remarks.
+    /// </summary>
     public static SlackNotificationRequest BuildDirectMessage(
         string slackUserId, string message, string messageType, string action)
         => new()
@@ -68,11 +80,15 @@ internal static class MediatedSlack
             Action = action,
             Channel = null,
             UserId = slackUserId,
-            Message = message,
+            Message = SlackTextSanitizer.Escape(message),
             MessageType = string.IsNullOrWhiteSpace(messageType) ? "Info" : messageType,
         };
 
-    /// <summary>Pure builder: a single-target channel-post request (userId = null).</summary>
+    /// <summary>
+    /// Pure builder: a single-target channel-post request (userId = null). The untrusted
+    /// <paramref name="message"/> is hardened against Slack control tokens exactly once
+    /// here via <see cref="SlackTextSanitizer.Escape"/> — see the class remarks.
+    /// </summary>
     public static SlackNotificationRequest BuildChannelMessage(
         string channel, string message, string messageType, string action)
         => new()
@@ -80,7 +96,7 @@ internal static class MediatedSlack
             Action = action,
             Channel = channel,
             UserId = null,
-            Message = message,
+            Message = SlackTextSanitizer.Escape(message),
             MessageType = string.IsNullOrWhiteSpace(messageType) ? "Info" : messageType,
         };
 

--- a/apps/tamma-elsa/src/Tamma.Core/Redaction/SlackTextSanitizer.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Redaction/SlackTextSanitizer.cs
@@ -1,0 +1,39 @@
+namespace Tamma.Core.Redaction;
+
+/// <summary>
+/// Neutralizes Slack control tokens in UNTRUSTED text before it is posted to Slack.
+///
+/// <para>Slack renders <c>&lt;!channel&gt;</c>, <c>&lt;!here&gt;</c>,
+/// <c>&lt;!everyone&gt;</c>, <c>&lt;@Uxxxx&gt;</c>, <c>&lt;!subteam^Sxxx&gt;</c> and
+/// <c>&lt;#Cxxx|name&gt;</c> as live broadcast / mention / channel links. If a body
+/// derived from issue titles, task text, or LLM output contains any of those, an
+/// otherwise-innocuous notification would ping the whole workspace. Applying Slack's
+/// documented message escaping — <c>&amp;</c> → <c>&amp;amp;</c>, <c>&lt;</c> →
+/// <c>&amp;lt;</c>, <c>&gt;</c> → <c>&amp;gt;</c> — renders every such token literally,
+/// so untrusted content can never expand into pings beyond the intended audience.</para>
+///
+/// <para>Because every control token is delimited by <c>&lt;</c>…<c>&gt;</c>, escaping
+/// those two characters (plus the leading <c>&amp;</c>) is sufficient and leaves ordinary
+/// text and URLs intact — a plain URL carries no <c>&amp;&lt;&gt;</c>, and a query-string
+/// <c>&amp;</c> becomes <c>&amp;amp;</c> which Slack still links correctly. Order matters:
+/// escape <c>&amp;</c> FIRST so the <c>&amp;lt;</c> / <c>&amp;gt;</c> it introduces are not
+/// double-escaped. This is the single shared implementation used by both the engine-side
+/// <c>SlackActivity</c> formatters and the mediated <c>MediatedSlack</c> seam so a body is
+/// escaped exactly once at its producer, before it is enqueued to <c>slack_outbox</c>.</para>
+/// </summary>
+public static class SlackTextSanitizer
+{
+    /// <summary>
+    /// Escape Slack control characters in an untrusted body. Null/empty inputs return
+    /// the empty string. Apply ONCE, at the point the untrusted text is folded into a
+    /// posted body — never to our own emoji/label prefixes, and never twice.
+    /// </summary>
+    public static string Escape(string? text)
+    {
+        if (string.IsNullOrEmpty(text)) return string.Empty;
+        return text
+            .Replace("&", "&amp;", StringComparison.Ordinal)
+            .Replace("<", "&lt;", StringComparison.Ordinal)
+            .Replace(">", "&gt;", StringComparison.Ordinal);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Integration/MediatedSlackEscapingTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Integration/MediatedSlackEscapingTests.cs
@@ -1,0 +1,59 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.LlmCall;
+
+namespace Tamma.Activities.Tests.Integration;
+
+/// <summary>
+/// Security hardening for the MEDIATED Slack path. The 16 domain activities
+/// (Mentorship / Review / Blocker / Assessment) build their outbox request through
+/// <see cref="MediatedSlack.BuildDirectMessage"/> / <see cref="MediatedSlack.BuildChannelMessage"/>,
+/// which fold in bodies derived from issue titles and LLM output. Those bodies MUST be
+/// hardened against Slack broadcast / mention / channel control tokens exactly once at
+/// this construction seam — before the request is enqueued to <c>slack_outbox</c> — so a
+/// body containing <c>&lt;!channel&gt;</c>, <c>&lt;!here&gt;</c>, <c>&lt;@Uxxxx&gt;</c> or
+/// <c>&lt;!subteam^Sxxx&gt;</c> can never ping the whole workspace. Ordinary text and URLs
+/// must be left intact.
+/// </summary>
+[TestFixture]
+public class MediatedSlackEscapingTests
+{
+    [Test]
+    public void BuildDirectMessage_NeutralizesBroadcastToken()
+    {
+        var req = MediatedSlack.BuildDirectMessage("U9", "<!channel> deploy done", "Info", "SendDirect");
+
+        req.Message.Should().NotContain("<!channel>", "the @channel broadcast must not reach Slack live");
+        req.Message.Should().Be("&lt;!channel&gt; deploy done");
+    }
+
+    [Test]
+    public void BuildDirectMessage_NeutralizesMentionAndSubteam()
+    {
+        var req = MediatedSlack.BuildDirectMessage("U9", "<@U123> <!subteam^S1>", "Info", "SendDirect");
+
+        req.Message.Should().NotContain("<@U123>");
+        req.Message.Should().NotContain("<!subteam^S1>");
+        req.Message.Should().Be("&lt;@U123&gt; &lt;!subteam^S1&gt;");
+    }
+
+    [Test]
+    public void BuildChannelMessage_NeutralizesHereAndEveryone()
+    {
+        var req = MediatedSlack.BuildChannelMessage("eng", "<!here> and <!everyone>", "Warning", "SendChannel");
+
+        req.Message.Should().NotContain("<!here>");
+        req.Message.Should().NotContain("<!everyone>");
+        req.Message.Should().Be("&lt;!here&gt; and &lt;!everyone&gt;");
+    }
+
+    [Test]
+    public void BuildChannelMessage_PreservesPlainTextAndUrls()
+    {
+        var req = MediatedSlack.BuildChannelMessage(
+            "eng", "Review PR at https://tamma.dev/pr/1 please", "Info", "SendChannel");
+
+        req.Message.Should().Be("Review PR at https://tamma.dev/pr/1 please",
+            "ordinary text and URLs must not be mangled by the control-token escape");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Redaction/SlackTextSanitizerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Redaction/SlackTextSanitizerTests.cs
@@ -1,0 +1,92 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core.Redaction;
+
+namespace Tamma.Core.Tests.Redaction;
+
+/// <summary>
+/// Unit tests for <see cref="SlackTextSanitizer"/> — the single shared helper that
+/// neutralizes Slack broadcast / mention / channel control tokens in untrusted bodies
+/// (issue titles, LLM output) before they are posted. The invariant: every
+/// <c>&lt;</c>…<c>&gt;</c>-delimited control token is rendered literal, while ordinary
+/// text and URLs are left intact.
+/// </summary>
+[TestFixture]
+public class SlackTextSanitizerTests
+{
+    [Test]
+    public void Escape_Null_ReturnsEmpty()
+    {
+        SlackTextSanitizer.Escape(null).Should().Be(string.Empty);
+    }
+
+    [Test]
+    public void Escape_Empty_ReturnsEmpty()
+    {
+        SlackTextSanitizer.Escape(string.Empty).Should().Be(string.Empty);
+    }
+
+    [Test]
+    public void Escape_PlainText_ReturnsVerbatim()
+    {
+        SlackTextSanitizer.Escape("deploy finished successfully")
+            .Should().Be("deploy finished successfully");
+    }
+
+    [Test]
+    public void Escape_Url_LeftIntact()
+    {
+        // A plain URL carries no & < > so it must survive unchanged (no mangling).
+        SlackTextSanitizer.Escape("see https://tamma.dev/pr/123 for details")
+            .Should().Be("see https://tamma.dev/pr/123 for details");
+    }
+
+    [Test]
+    public void Escape_ChannelBroadcast_Neutralized()
+    {
+        var escaped = SlackTextSanitizer.Escape("<!channel> ship it");
+
+        escaped.Should().NotContain("<!channel>", "the @channel broadcast must not stay live");
+        escaped.Should().Be("&lt;!channel&gt; ship it");
+    }
+
+    [Test]
+    public void Escape_HereAndEveryone_Neutralized()
+    {
+        SlackTextSanitizer.Escape("<!here>").Should().Be("&lt;!here&gt;");
+        SlackTextSanitizer.Escape("<!everyone>").Should().Be("&lt;!everyone&gt;");
+    }
+
+    [Test]
+    public void Escape_UserMention_Neutralized()
+    {
+        var escaped = SlackTextSanitizer.Escape("ping <@U123> now");
+
+        escaped.Should().NotContain("<@U123>");
+        escaped.Should().Be("ping &lt;@U123&gt; now");
+    }
+
+    [Test]
+    public void Escape_Subteam_Neutralized()
+    {
+        var escaped = SlackTextSanitizer.Escape("<!subteam^S1>");
+
+        escaped.Should().NotContain("<!subteam^S1>");
+        escaped.Should().Be("&lt;!subteam^S1&gt;");
+    }
+
+    [Test]
+    public void Escape_ChannelLink_Neutralized()
+    {
+        SlackTextSanitizer.Escape("<#C123|general>").Should().Be("&lt;#C123|general&gt;");
+    }
+
+    [Test]
+    public void Escape_Ampersand_EscapedFirst_NoDoubleEscaping()
+    {
+        // & is escaped first so the &lt; / &gt; it introduces are not re-escaped.
+        SlackTextSanitizer.Escape("a & b").Should().Be("a &amp; b");
+        SlackTextSanitizer.Escape("<x>").Should().Be("&lt;x&gt;")
+            .And.NotContain("&amp;lt;", "a single Escape pass must not double-escape");
+    }
+}


### PR DESCRIPTION
## Problem (verified)

Untrusted content (issue titles, LLM output) reached Slack via the mediated outbox with no escaping, so a body containing `<!channel>`, `<!here>`, `<@Uxxx>`, `<!subteam^…>` etc. triggered real broadcast/mention pings to the whole workspace. `SlackActivity` escaped in its own formatters, but the `MediatedSlack` seam forwarded the body verbatim.

## Fix

Escape at the **producer/construction seam** — `MediatedSlack.BuildDirectMessage`/`BuildChannelMessage` — so every mediated send is neutralized exactly once and the persisted `slack_outbox` body is already safe. Extracted the escaping into a shared `SlackTextSanitizer.Escape` in `Tamma.Core` (referenced by both engine and API); `SlackActivity.EscapeSlack` now delegates to it → one implementation. Exactly-once: the endpoint/sender don't re-escape, and `SlackActivity` still escapes its own (non-mediated) path.

## Verification

- Build: 0 errors. `SlackTextSanitizer` 10/10, engine Slack 33/33, API Outbox|Slack|Notification 96/96.
- TDD fail-before/pass-after on all control-token types; plain text + URLs preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)