### PR TITLE
fix(epic-38/28): reap stuck 'sending' outbox rows so at-least-once delivery holds

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Services/Email/OutboxSmtpSender.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Email/OutboxSmtpSender.cs
@@ -41,6 +41,16 @@ public sealed class OutboxSmtpSenderOptions
     /// gate pattern.
     /// </summary>
     public bool RunOnStartup { get; set; } = true;
+
+    /// <summary>
+    /// Lease timeout for the durability reaper. A row claimed into <c>sending</c>
+    /// whose <c>UpdatedAt</c> is older than this is assumed orphaned by a crashed
+    /// sender and reset to <c>pending</c> so it is re-delivered (at-least-once).
+    /// Applies to BOTH the per-tenant <c>email_outbox</c> and the control-plane
+    /// <c>platform_email_outbox</c>. The reap runs at most once per this interval
+    /// (throttled in the poll loop). Default 5 minutes.
+    /// </summary>
+    public TimeSpan SendingLeaseTimeout { get; set; } = TimeSpan.FromMinutes(5);
 }
 
 /// <summary>
@@ -78,6 +88,12 @@ public sealed class OutboxSmtpSender : BackgroundService
     // attempt entirely instead of letting EF log the error each cycle.
     // Volatile read in the hot path.
     private int _platformPathDisabled;
+
+    // Durability reaper throttle — the reclaim UPDATE matches 0 rows in steady
+    // state, so it runs at most once per SendingLeaseTimeout rather than every
+    // poll. MinValue means "reap on the first cycle" so a restart immediately
+    // recovers rows a prior crash orphaned in 'sending'.
+    private DateTime _lastReclaimUtc = DateTime.MinValue;
 
     public OutboxSmtpSender(
         IServiceProvider serviceProvider,
@@ -117,6 +133,12 @@ public sealed class OutboxSmtpSender : BackgroundService
         if (seconds > 0)
         {
             _options.PollInterval = TimeSpan.FromSeconds(seconds);
+        }
+
+        var leaseSeconds = _config.GetValue("Email:OutboxSendingLeaseSeconds", 0);
+        if (leaseSeconds > 0)
+        {
+            _options.SendingLeaseTimeout = TimeSpan.FromSeconds(leaseSeconds);
         }
 
         _logger.LogInformation(
@@ -185,7 +207,15 @@ public sealed class OutboxSmtpSender : BackgroundService
         var transport = scope.ServiceProvider.GetRequiredService<ISmtpTransport>();
         var events = scope.ServiceProvider.GetRequiredService<IEventRepository>();
 
-        var claimed = await outbox.ClaimNextPendingFromAnyTenantAsync(DateTime.UtcNow, ct);
+        var now = DateTime.UtcNow;
+
+        // Durability reaper (throttled) — recover rows a crashed sender left
+        // orphaned in 'sending' back to 'pending' before we claim the next
+        // batch. Covers both the per-tenant and platform queues so at-least-once
+        // delivery holds across process restarts.
+        await MaybeReclaimAsync(scope.ServiceProvider, outbox, now, ct);
+
+        var claimed = await outbox.ClaimNextPendingFromAnyTenantAsync(now, ct);
         if (claimed is not null)
         {
             await ProcessTenantClaimedAsync(outbox, transport, events, claimed, ct);
@@ -194,6 +224,93 @@ public sealed class OutboxSmtpSender : BackgroundService
 
         // Tenant queue empty — try the platform queue. Story 28-6.
         return await TryProcessPlatformOnceAsync(scope.ServiceProvider, transport, ct);
+    }
+
+    /// <summary>
+    /// Run the durability reaper at most once per
+    /// <see cref="OutboxSmtpSenderOptions.SendingLeaseTimeout"/>, across BOTH
+    /// the per-tenant <c>email_outbox</c> (cross-tenant fan-out) and the
+    /// control-plane <c>platform_email_outbox</c>. Rows a crashed sender
+    /// orphaned in <c>sending</c> (UpdatedAt older than the lease) are reset to
+    /// <c>pending</c> so the next claim re-delivers them. Folded into the
+    /// existing poll loop — no extra hosted service. The platform reap honours
+    /// the same 42P01 / not-registered back-compat guards as the drain path;
+    /// reap failures are logged and swallowed so the claim path still runs.
+    /// </summary>
+    private async Task MaybeReclaimAsync(
+        IServiceProvider scopedProvider,
+        IEmailOutboxRepository outbox,
+        DateTime now,
+        CancellationToken ct)
+    {
+        if (now - _lastReclaimUtc < _options.SendingLeaseTimeout) return;
+        _lastReclaimUtc = now;
+
+        // Per-tenant queues.
+        try
+        {
+            var reclaimed = await outbox.ReclaimStuckSendingFromAllTenantsAsync(
+                now, _options.SendingLeaseTimeout, ct);
+            if (reclaimed > 0)
+            {
+                _logger.LogWarning(
+                    "Reclaimed {Count} tenant email row(s) stuck in 'sending' past the {Lease} lease",
+                    reclaimed, _options.SendingLeaseTimeout);
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Tenant email outbox reclaim pass failed");
+        }
+
+        // Platform queue — same back-compat guards as TryProcessPlatformOnceAsync.
+        if (Volatile.Read(ref _platformPathDisabled) == 1) return;
+
+        var platformOutbox = scopedProvider.GetService<IPlatformEmailOutboxRepository>();
+        if (platformOutbox is null) return;
+
+        try
+        {
+            var reclaimed = await platformOutbox.ReclaimStuckSendingAsync(
+                now, _options.SendingLeaseTimeout, ct);
+            if (reclaimed > 0)
+            {
+                _logger.LogWarning(
+                    "Reclaimed {Count} platform email row(s) stuck in 'sending' past the {Lease} lease",
+                    reclaimed, _options.SendingLeaseTimeout);
+            }
+        }
+        catch (Npgsql.PostgresException pgEx)
+            when (string.Equals(pgEx.SqlState, "42P01", StringComparison.Ordinal))
+        {
+            Interlocked.Exchange(ref _platformPathDisabled, 1);
+            _logger.LogWarning(
+                "platform_email_outbox table missing on this connection — " +
+                "disabling the platform email path for this process. " +
+                "Apply the Story 28-1 CP migration to enable it.");
+        }
+        catch (Microsoft.EntityFrameworkCore.DbUpdateException dbEx)
+            when (dbEx.InnerException is Npgsql.PostgresException pgEx
+                && string.Equals(pgEx.SqlState, "42P01", StringComparison.Ordinal))
+        {
+            Interlocked.Exchange(ref _platformPathDisabled, 1);
+            _logger.LogWarning(
+                "platform_email_outbox table missing on this connection — " +
+                "disabling the platform email path for this process. " +
+                "Apply the Story 28-1 CP migration to enable it.");
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Platform email outbox reclaim pass failed");
+        }
     }
 
     private async Task ProcessTenantClaimedAsync(

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Notifications/OutboxSlackSender.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Notifications/OutboxSlackSender.cs
@@ -32,6 +32,16 @@ public sealed class OutboxSlackSenderOptions
     /// <c>OutboxSmtpSenderOptions.RunOnStartup</c>).
     /// </summary>
     public bool RunOnStartup { get; set; } = true;
+
+    /// <summary>
+    /// Lease timeout for the durability reaper. A row claimed into <c>sending</c>
+    /// whose <c>UpdatedAt</c> is older than this is assumed orphaned by a crashed
+    /// sender and reset to <c>pending</c> so it is re-delivered (at-least-once).
+    /// The reap runs at most once per this interval (throttled in the poll loop),
+    /// so a stuck row is re-delivered within ~2× this window in the worst case.
+    /// Default 5 minutes — comfortably above a single delivery's duration.
+    /// </summary>
+    public TimeSpan SendingLeaseTimeout { get; set; } = TimeSpan.FromMinutes(5);
 }
 
 /// <summary>
@@ -62,6 +72,12 @@ public sealed class OutboxSlackSender : BackgroundService
     private readonly OutboxSlackSenderOptions _options;
     private readonly IConfiguration _config;
     private readonly ILogger<OutboxSlackSender> _logger;
+
+    // Durability reaper throttle — the reclaim UPDATE matches 0 rows in steady
+    // state, so it runs at most once per SendingLeaseTimeout rather than every
+    // poll. MinValue means "reap on the first cycle" so a restart immediately
+    // recovers rows a prior crash orphaned in 'sending'.
+    private DateTime _lastReclaimUtc = DateTime.MinValue;
 
     public OutboxSlackSender(
         IServiceProvider serviceProvider,
@@ -97,6 +113,12 @@ public sealed class OutboxSlackSender : BackgroundService
         if (seconds > 0)
         {
             _options.PollInterval = TimeSpan.FromSeconds(seconds);
+        }
+
+        var leaseSeconds = _config.GetValue("Slack:OutboxSendingLeaseSeconds", 0);
+        if (leaseSeconds > 0)
+        {
+            _options.SendingLeaseTimeout = TimeSpan.FromSeconds(leaseSeconds);
         }
 
         _logger.LogInformation("OutboxSlackSender started. Poll interval={Interval}", _options.PollInterval);
@@ -140,7 +162,14 @@ public sealed class OutboxSlackSender : BackgroundService
         var slack = scope.ServiceProvider.GetRequiredService<ISlackIntegrationService>();
         var events = scope.ServiceProvider.GetService<IPlatformEventRepository>();
 
-        var claimed = await outbox.ClaimNextPendingAsync(DateTime.UtcNow, ct).ConfigureAwait(false);
+        var now = DateTime.UtcNow;
+
+        // Durability reaper (throttled) — recover rows a crashed sender left
+        // orphaned in 'sending' back to 'pending' before we claim the next
+        // batch, so at-least-once delivery holds across process restarts.
+        await MaybeReclaimAsync(outbox, now, ct).ConfigureAwait(false);
+
+        var claimed = await outbox.ClaimNextPendingAsync(now, ct).ConfigureAwait(false);
         if (claimed is null) return false;
 
         try
@@ -171,6 +200,38 @@ public sealed class OutboxSlackSender : BackgroundService
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Run the durability reaper at most once per <see cref="OutboxSlackSenderOptions.SendingLeaseTimeout"/>.
+    /// Resets rows a crashed sender orphaned in <c>sending</c> (UpdatedAt older
+    /// than the lease) back to <c>pending</c> so the very next
+    /// <see cref="ISlackOutboxRepository.ClaimNextPendingAsync"/> re-delivers
+    /// them. Folded into the existing poll loop so no extra hosted service is
+    /// needed. Reap failures are logged and swallowed — the claim path still runs.
+    /// </summary>
+    private async Task MaybeReclaimAsync(
+        ISlackOutboxRepository outbox, DateTime now, CancellationToken ct)
+    {
+        if (now - _lastReclaimUtc < _options.SendingLeaseTimeout) return;
+        _lastReclaimUtc = now;
+
+        try
+        {
+            var reclaimed = await outbox
+                .ReclaimStuckSendingAsync(now, _options.SendingLeaseTimeout, ct)
+                .ConfigureAwait(false);
+            if (reclaimed > 0)
+            {
+                _logger.LogWarning(
+                    "Reclaimed {Count} Slack outbox row(s) stuck in 'sending' past the {Lease} lease",
+                    reclaimed, _options.SendingLeaseTimeout);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "Slack outbox reclaim pass failed");
+        }
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/EmailOutboxRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/EmailOutboxRepository.cs
@@ -114,6 +114,74 @@ public class EmailOutboxRepository(
         return null;
     }
 
+    public async Task<int> ReclaimStuckSendingAsync(
+        Guid tenantId, DateTime now, TimeSpan leaseTimeout, CancellationToken ct = default)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id is required.", nameof(tenantId));
+
+        var cutoff = now - leaseTimeout;
+        await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
+
+        if (string.Equals(db.Database.ProviderName, NpgsqlProviderName, StringComparison.Ordinal))
+        {
+            // Reset to 'pending' only — Attempts is left untouched so a stuck
+            // row keeps its full retry budget (it was never attempted-to-
+            // completion). `"TenantId" = @tid` is REQUIRED while email_outbox
+            // physically co-resides on the CP DB (see ClaimViaPostgresAsync).
+            return await db.Database.ExecuteSqlInterpolatedAsync($"""
+                UPDATE email_outbox
+                SET "Status" = 'pending', "UpdatedAt" = {now}
+                WHERE "Status" = 'sending'
+                  AND "UpdatedAt" < {cutoff}
+                  AND "TenantId" = {tenantId}
+                """, ct);
+        }
+
+        var stuck = await db.EmailOutbox
+            .Where(m => m.Status == "sending"
+                && m.UpdatedAt < cutoff
+                && m.TenantId == tenantId)
+            .ToListAsync(ct);
+        foreach (var m in stuck)
+        {
+            m.Status = "pending";
+            m.UpdatedAt = now;
+        }
+        if (stuck.Count > 0) await db.SaveChangesAsync(ct);
+        return stuck.Count;
+    }
+
+    public async Task<int> ReclaimStuckSendingFromAllTenantsAsync(
+        DateTime now, TimeSpan leaseTimeout, CancellationToken ct = default)
+    {
+        var activeTenantIds = await cp.Tenants
+            .AsNoTracking()
+            .Where(t => t.DeletedAt == null)
+            .OrderBy(t => t.Id)
+            .Select(t => t.Id)
+            .ToListAsync(ct);
+
+        var total = 0;
+        foreach (var tid in activeTenantIds)
+        {
+            if (ct.IsCancellationRequested) break;
+
+            try
+            {
+                total += await ReclaimStuckSendingAsync(tid, now, leaseTimeout, ct);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // One tenant mid-deletion / transient connection failure must
+                // not starve the rest of the reap pass; the next cycle retries.
+                continue;
+            }
+        }
+
+        return total;
+    }
+
     private static async Task<EmailOutboxMessage?> ClaimViaPostgresAsync(
         TenantDbContext db, Guid tenantId, DateTime now, CancellationToken ct)
     {

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/IEmailOutboxRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/IEmailOutboxRepository.cs
@@ -66,6 +66,37 @@ public interface IEmailOutboxRepository
         DateTime now, CancellationToken ct = default);
 
     /// <summary>
+    /// Durability reaper (single tenant) — reset rows orphaned in
+    /// <c>sending</c> back to <c>pending</c> for the supplied tenant so the
+    /// sender re-claims and re-delivers them. Claiming a row flips it to
+    /// <c>sending</c> (stamping <c>UpdatedAt</c>); if the process crashes
+    /// before <see cref="MarkSentAsync"/> / <see cref="MarkFailedAsync"/> the
+    /// row is orphaned forever (never re-selected by
+    /// <see cref="ClaimNextPendingAsync"/>), defeating at-least-once delivery.
+    /// A row qualifies when its <c>Status='sending'</c> and its <c>UpdatedAt</c>
+    /// (stamped at claim time) is older than <paramref name="leaseTimeout"/>
+    /// before <paramref name="now"/>. <see cref="EmailOutboxMessage.Attempts"/>
+    /// is deliberately NOT incremented — a stuck row was never
+    /// attempted-to-completion, so it keeps its full retry budget. Returns the
+    /// number of rows reclaimed for that tenant.
+    /// </summary>
+    Task<int> ReclaimStuckSendingAsync(
+        Guid tenantId, DateTime now, TimeSpan leaseTimeout, CancellationToken ct = default);
+
+    /// <summary>
+    /// Cross-tenant reaper — enumerate active tenants from the CP
+    /// <c>tenants</c> table and run <see cref="ReclaimStuckSendingAsync"/> on
+    /// each, returning the total number of rows reclaimed. The tenant analogue
+    /// of <see cref="ClaimNextPendingFromAnyTenantAsync"/>; used by
+    /// <c>OutboxSmtpSender</c> to reap orphaned <c>sending</c> rows across the
+    /// per-tenant outbox queues before each claim pass. A per-tenant failure
+    /// (mid-deletion, transient connection error) is swallowed so one tenant's
+    /// outage does not block the rest; cooperative cancellation propagates.
+    /// </summary>
+    Task<int> ReclaimStuckSendingFromAllTenantsAsync(
+        DateTime now, TimeSpan leaseTimeout, CancellationToken ct = default);
+
+    /// <summary>
     /// Mark a claimed message as successfully delivered. Sets
     /// <c>Status=sent</c> and <c>SentAt=UtcNow</c>.
     /// </summary>

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/IPlatformEmailOutboxRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/IPlatformEmailOutboxRepository.cs
@@ -35,6 +35,24 @@ public interface IPlatformEmailOutboxRepository
         DateTime now, CancellationToken ct = default);
 
     /// <summary>
+    /// Durability reaper — reset rows orphaned in <c>sending</c> back to
+    /// <c>pending</c> so the sender re-claims and re-delivers them. Claiming a
+    /// row flips it to <c>sending</c> (stamping <c>UpdatedAt</c>); if the
+    /// process crashes before <see cref="MarkSentAsync"/> /
+    /// <see cref="MarkFailedAsync"/> the row would otherwise be orphaned forever
+    /// (never re-selected by <see cref="ClaimNextPendingAsync"/>), defeating
+    /// at-least-once delivery for verification / password-reset / welcome mail.
+    /// A row qualifies when its <c>Status='sending'</c> and its <c>UpdatedAt</c>
+    /// (stamped at claim time) is older than <paramref name="leaseTimeout"/>
+    /// before <paramref name="now"/>. <see cref="PlatformEmailOutboxMessage.Attempts"/>
+    /// is deliberately NOT incremented — a stuck row was never
+    /// attempted-to-completion, so it keeps its full retry budget. Returns the
+    /// number of rows reclaimed.
+    /// </summary>
+    Task<int> ReclaimStuckSendingAsync(
+        DateTime now, TimeSpan leaseTimeout, CancellationToken ct = default);
+
+    /// <summary>
     /// Mark a claimed message as successfully delivered. Sets
     /// <c>Status=sent</c> + <c>SentAt=UtcNow</c>.
     /// </summary>

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/ISlackOutboxRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/ISlackOutboxRepository.cs
@@ -27,6 +27,24 @@ public interface ISlackOutboxRepository
     /// </summary>
     Task<SlackOutboxMessage?> ClaimNextPendingAsync(DateTime now, CancellationToken ct = default);
 
+    /// <summary>
+    /// Durability reaper — reset rows orphaned in <c>sending</c> back to
+    /// <c>pending</c> so the sender re-claims and re-delivers them. A row is
+    /// claimed by flipping it to <c>sending</c> (stamping <c>UpdatedAt</c>);
+    /// if the process crashes before <see cref="MarkSentAsync"/> /
+    /// <see cref="MarkFailedAsync"/> the row would otherwise stay <c>sending</c>
+    /// forever (never re-selected by <see cref="ClaimNextPendingAsync"/>),
+    /// defeating at-least-once delivery. A row qualifies when its
+    /// <c>Status='sending'</c> and its <c>UpdatedAt</c> (stamped at claim time)
+    /// is older than <paramref name="leaseTimeout"/> before
+    /// <paramref name="now"/>. <see cref="SlackOutboxMessage.Attempts"/> is
+    /// deliberately NOT incremented — a stuck row was never
+    /// attempted-to-completion, so it is treated as still-pending and keeps its
+    /// full retry budget. Returns the number of rows reclaimed.
+    /// </summary>
+    Task<int> ReclaimStuckSendingAsync(
+        DateTime now, TimeSpan leaseTimeout, CancellationToken ct = default);
+
     /// <summary>Mark a claimed message delivered (<c>Status=sent</c> + <c>SentAt</c>).</summary>
     Task MarkSentAsync(Guid id, CancellationToken ct = default);
 

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/PlatformEmailOutboxRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/PlatformEmailOutboxRepository.cs
@@ -89,6 +89,37 @@ public sealed class PlatformEmailOutboxRepository : IPlatformEmailOutboxReposito
         return candidate;
     }
 
+    public async Task<int> ReclaimStuckSendingAsync(
+        DateTime now, TimeSpan leaseTimeout, CancellationToken ct = default)
+    {
+        var cutoff = now - leaseTimeout;
+
+        if (string.Equals(_db.Database.ProviderName, NpgsqlProviderName, StringComparison.Ordinal))
+        {
+            // Reset to 'pending' only — Attempts is left untouched so a stuck
+            // row keeps its full retry budget (it was never attempted-to-
+            // completion). NextAttemptAt was already <= claim-time, so the
+            // reclaimed row is immediately due for the next claim pass.
+            return await _db.Database.ExecuteSqlInterpolatedAsync($"""
+                UPDATE platform_email_outbox
+                SET "Status" = 'pending', "UpdatedAt" = {now}
+                WHERE "Status" = 'sending'
+                  AND "UpdatedAt" < {cutoff}
+                """, ct);
+        }
+
+        var stuck = await _db.PlatformEmailOutbox
+            .Where(m => m.Status == "sending" && m.UpdatedAt < cutoff)
+            .ToListAsync(ct);
+        foreach (var m in stuck)
+        {
+            m.Status = "pending";
+            m.UpdatedAt = now;
+        }
+        if (stuck.Count > 0) await _db.SaveChangesAsync(ct);
+        return stuck.Count;
+    }
+
     public async Task MarkSentAsync(Guid id, CancellationToken ct = default)
     {
         var msg = await _db.PlatformEmailOutbox.FindAsync(new object[] { id }, ct);

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/SlackOutboxRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/SlackOutboxRepository.cs
@@ -87,6 +87,37 @@ public sealed class SlackOutboxRepository : ISlackOutboxRepository
         return candidate;
     }
 
+    public async Task<int> ReclaimStuckSendingAsync(
+        DateTime now, TimeSpan leaseTimeout, CancellationToken ct = default)
+    {
+        var cutoff = now - leaseTimeout;
+
+        if (string.Equals(_db.Database.ProviderName, NpgsqlProviderName, StringComparison.Ordinal))
+        {
+            // Reset to 'pending' only — Attempts is left untouched so a stuck
+            // row keeps its full retry budget (it was never attempted-to-
+            // completion). NextAttemptAt was already <= claim-time, so the
+            // reclaimed row is immediately due for the next claim pass.
+            return await _db.Database.ExecuteSqlInterpolatedAsync($"""
+                UPDATE slack_outbox
+                SET "Status" = 'pending', "UpdatedAt" = {now}
+                WHERE "Status" = 'sending'
+                  AND "UpdatedAt" < {cutoff}
+                """, ct);
+        }
+
+        var stuck = await _db.SlackOutbox
+            .Where(m => m.Status == "sending" && m.UpdatedAt < cutoff)
+            .ToListAsync(ct);
+        foreach (var m in stuck)
+        {
+            m.Status = "pending";
+            m.UpdatedAt = now;
+        }
+        if (stuck.Count > 0) await _db.SaveChangesAsync(ct);
+        return stuck.Count;
+    }
+
     public async Task MarkSentAsync(Guid id, CancellationToken ct = default)
     {
         var msg = await _db.SlackOutbox.FindAsync(new object[] { id }, ct);

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Email/OutboxSmtpSenderTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Email/OutboxSmtpSenderTests.cs
@@ -134,6 +134,80 @@ public class OutboxSmtpSenderTests
         MaxAttempts = maxAttempts,
     };
 
+    /// <summary>
+    /// Seed a tenant row already in <c>sending</c> with an explicit
+    /// <c>UpdatedAt</c> — simulates a row claimed by a sender that crashed
+    /// before MarkSent/MarkFailed. Bypasses <c>EnqueueAsync</c> (which always
+    /// writes <c>pending</c>).
+    /// </summary>
+    private async Task<EmailOutboxMessage> SeedSendingTenantRowAsync(DateTime updatedAt)
+    {
+        await using var db = new TestTenantDbContext(_tenantOptions, TestTenantId);
+        var row = new EmailOutboxMessage
+        {
+            Id = Guid.NewGuid(),
+            TenantId = TestTenantId,
+            Template = "verification",
+            ToAddress = "u@example.com",
+            Subject = "Verify",
+            HtmlBody = "<p>hi</p>",
+            TextBody = "hi",
+            FromAddress = "noreply@tamma.dev",
+            Status = "sending",
+            Attempts = 0,
+            MaxAttempts = 5,
+            NextAttemptAt = updatedAt,
+            CreatedAt = updatedAt,
+            UpdatedAt = updatedAt,
+        };
+        db.EmailOutbox.Add(row);
+        await db.SaveChangesAsync();
+        return row;
+    }
+
+    // ── Durability reaper: orphaned 'sending' rows ────────────────────────────
+
+    [Test]
+    public async Task ProcessOnceAsync_StuckSendingTenantRowPastLease_ReclaimedAndDelivered()
+    {
+        // A row a crashed sender left in 'sending' 10 minutes ago (past the
+        // default 5-minute lease). Without the reaper it is orphaned forever —
+        // ClaimNextPendingFromAnyTenantAsync only selects 'pending'.
+        var enq = await SeedSendingTenantRowAsync(DateTime.UtcNow.AddMinutes(-10));
+        _transport.Setup(t => t.SendAsync(It.IsAny<EmailOutboxMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Single cycle: reclaim → pending → claim → deliver → purge.
+        var processed = await _sender.ProcessOnceAsync(CancellationToken.None);
+
+        processed.Should().BeTrue("the reclaimed row is claimed and delivered in the same cycle");
+        _transport.Verify(
+            t => t.SendAsync(It.Is<EmailOutboxMessage>(m => m.Id == enq.Id), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        var stored = await FreshOutbox().GetByIdAsync(TestTenantId, enq.Id);
+        stored.Should().BeNull("the re-delivered row is purged, exactly like a normal send");
+    }
+
+    [Test]
+    public async Task ProcessOnceAsync_FreshSendingTenantRowWithinLease_NotReclaimed()
+    {
+        // A row another sender just claimed (UpdatedAt = now) and is delivering
+        // right now. The reaper must NOT steal it back to pending.
+        var enq = await SeedSendingTenantRowAsync(DateTime.UtcNow);
+
+        var processed = await _sender.ProcessOnceAsync(CancellationToken.None);
+
+        processed.Should().BeFalse("a fresh 'sending' row is neither reclaimed nor claimable");
+        _transport.Verify(
+            t => t.SendAsync(It.IsAny<EmailOutboxMessage>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        var stored = await FreshOutbox().GetByIdAsync(TestTenantId, enq.Id);
+        stored!.Status.Should().Be("sending", "a within-lease claim is left untouched");
+        stored.Attempts.Should().Be(0, "reclaim never bumps the attempt counter");
+    }
+
     // ── Happy path ──────────────────────────────────────────────────────────
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/OutboxSmtpSenderPlatformPathTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/OutboxSmtpSenderPlatformPathTests.cs
@@ -158,6 +158,98 @@ public class OutboxSmtpSenderPlatformPathTests
         }
     }
 
+    /// <summary>
+    /// Seed a platform row already in <c>sending</c> with an explicit
+    /// <c>UpdatedAt</c> — simulates a row claimed by a sender that crashed
+    /// before MarkSent/MarkFailed. Bypasses <c>EnqueueAsync</c> (which always
+    /// writes <c>pending</c>).
+    /// </summary>
+    private async Task<PlatformEmailOutboxMessage> SeedSendingPlatformRowAsync(DateTime updatedAt)
+    {
+        using var cp = new ControlPlaneDbContext(_cpOptions);
+        var row = new PlatformEmailOutboxMessage
+        {
+            Id = Guid.NewGuid(),
+            Template = "verification",
+            ToAddress = "platform@example.com",
+            Subject = "Verify",
+            HtmlBody = "<p>p</p>",
+            TextBody = "p",
+            FromAddress = "noreply@tamma.dev",
+            Status = "sending",
+            Attempts = 0,
+            MaxAttempts = 5,
+            NextAttemptAt = updatedAt,
+            CreatedAt = updatedAt,
+            UpdatedAt = updatedAt,
+        };
+        cp.PlatformEmailOutbox.Add(row);
+        await cp.SaveChangesAsync();
+        return row;
+    }
+
+    // ── Durability reaper: orphaned 'sending' platform rows ──────────────────
+
+    [Test]
+    public async Task ProcessOnceAsync_StuckSendingPlatformRowPastLease_ReclaimedAndDelivered()
+    {
+        var (sp, sender) = BuildSender(registerPlatform: true);
+        try
+        {
+            // A row a crashed sender left in 'sending' 10 minutes ago (past the
+            // default 5-minute lease). Without the reaper it is orphaned forever
+            // — ClaimNextPendingAsync only selects 'pending'.
+            var enq = await SeedSendingPlatformRowAsync(DateTime.UtcNow.AddMinutes(-10));
+            _transport.Setup(t => t.SendAsync(It.IsAny<EmailOutboxMessage>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            // Single cycle: reclaim → pending → claim → deliver → purge.
+            var processed = await sender.ProcessOnceAsync(CancellationToken.None);
+
+            processed.Should().BeTrue("the reclaimed row is claimed and delivered in the same cycle");
+            _transport.Verify(t => t.SendAsync(
+                It.Is<EmailOutboxMessage>(m => m.Id == enq.Id),
+                It.IsAny<CancellationToken>()), Times.Once);
+
+            using var cpVerify = new ControlPlaneDbContext(_cpOptions);
+            (await cpVerify.PlatformEmailOutbox.FindAsync(enq.Id))
+                .Should().BeNull("the re-delivered row is purged, exactly like a normal send");
+        }
+        finally
+        {
+            sender.Dispose();
+            sp.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task ProcessOnceAsync_FreshSendingPlatformRowWithinLease_NotReclaimed()
+    {
+        var (sp, sender) = BuildSender(registerPlatform: true);
+        try
+        {
+            // A row another sender just claimed (UpdatedAt = now) and is
+            // delivering right now. The reaper must NOT steal it back to pending.
+            var enq = await SeedSendingPlatformRowAsync(DateTime.UtcNow);
+
+            var processed = await sender.ProcessOnceAsync(CancellationToken.None);
+
+            processed.Should().BeFalse("a fresh 'sending' row is neither reclaimed nor claimable");
+            _transport.Verify(t => t.SendAsync(
+                It.IsAny<EmailOutboxMessage>(), It.IsAny<CancellationToken>()), Times.Never);
+
+            using var cpVerify = new ControlPlaneDbContext(_cpOptions);
+            var row = await cpVerify.PlatformEmailOutbox.FindAsync(enq.Id);
+            row!.Status.Should().Be("sending", "a within-lease claim is left untouched");
+            row.Attempts.Should().Be(0, "reclaim never bumps the attempt counter");
+        }
+        finally
+        {
+            sender.Dispose();
+            sp.Dispose();
+        }
+    }
+
     // ── Platform path drains when tenant queue empty ─────────────────────────
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Notifications/NotificationEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Notifications/NotificationEndpointsTests.cs
@@ -295,6 +295,10 @@ public class NotificationEndpointsTests
         public Task<SlackOutboxMessage?> ClaimNextPendingAsync(DateTime now, CancellationToken ct = default)
             => Task.FromResult<SlackOutboxMessage?>(null);
 
+        // The hosted sender is gated off in tests; no rows to reap.
+        public Task<int> ReclaimStuckSendingAsync(DateTime now, TimeSpan leaseTimeout, CancellationToken ct = default)
+            => Task.FromResult(0);
+
         public Task MarkSentAsync(Guid id, CancellationToken ct = default) => Task.CompletedTask;
 
         public Task<SlackOutboxMessage?> MarkFailedAsync(Guid id, string error, TimeSpan? backoff, CancellationToken ct = default)

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Notifications/OutboxSlackSenderTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Notifications/OutboxSlackSenderTests.cs
@@ -76,6 +76,33 @@ public class OutboxSlackSenderTests
         return await repo.EnqueueAsync(row);
     }
 
+    /// <summary>
+    /// Seed a row already in <c>sending</c> with an explicit <c>UpdatedAt</c> —
+    /// simulates a row claimed by a sender that then crashed before
+    /// MarkSent/MarkFailed. Bypasses <c>EnqueueAsync</c> (which always writes
+    /// <c>pending</c>).
+    /// </summary>
+    private async Task<SlackOutboxMessage> SeedSendingAsync(DateTime updatedAt)
+    {
+        using var cp = new TestControlPlaneDbContext(_cpOptions);
+        var row = new SlackOutboxMessage
+        {
+            Id = Guid.NewGuid(),
+            Channel = "eng-updates",
+            MessageType = "Info",
+            Body = ":information_source: orphaned-in-sending",
+            Status = "sending",
+            Attempts = 0,
+            MaxAttempts = 5,
+            NextAttemptAt = updatedAt,
+            CreatedAt = updatedAt,
+            UpdatedAt = updatedAt,
+        };
+        cp.SlackOutbox.Add(row);
+        await cp.SaveChangesAsync();
+        return row;
+    }
+
     private static SlackOutboxMessage ChannelRow(int maxAttempts = 5) => new()
     {
         Channel = "eng-updates",
@@ -275,6 +302,64 @@ public class OutboxSlackSenderTests
             chanRow.Attempts.Should().Be(1);
             (await verify.SlackOutbox.FindAsync(dm.Id))
                 .Should().BeNull("the delivered DM leg is purged, untouched by the channel retry");
+        }
+        finally
+        {
+            sender.Dispose();
+            sp.Dispose();
+        }
+    }
+
+    // ── Durability reaper: orphaned 'sending' rows ────────────────────────────
+
+    [Test]
+    public async Task ProcessOnceAsync_StuckSendingRowPastLease_ReclaimedAndDelivered()
+    {
+        var (sp, sender, slack) = BuildSender();
+        try
+        {
+            // A row a crashed sender left in 'sending' 10 minutes ago (past the
+            // default 5-minute lease). Without the reaper it would be orphaned
+            // forever — ClaimNextPendingAsync only selects 'pending'.
+            var enq = await SeedSendingAsync(DateTime.UtcNow.AddMinutes(-10));
+
+            // Single poll cycle: reclaim → pending → claim → deliver → purge.
+            var processed = await sender.ProcessOnceAsync(CancellationToken.None);
+
+            processed.Should().BeTrue("the reclaimed row is claimed and delivered in the same cycle");
+            slack.ChannelCalls.Should().ContainSingle("the reclaimed row is re-sent");
+
+            using var verify = new TestControlPlaneDbContext(_cpOptions);
+            (await verify.SlackOutbox.FindAsync(enq.Id))
+                .Should().BeNull("the re-delivered row is purged, exactly like a normal send");
+        }
+        finally
+        {
+            sender.Dispose();
+            sp.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task ProcessOnceAsync_FreshSendingRowWithinLease_NotReclaimed()
+    {
+        var (sp, sender, slack) = BuildSender();
+        try
+        {
+            // A row another sender just claimed (UpdatedAt = now). It is being
+            // delivered right now by that sender — the reaper must NOT steal it.
+            var enq = await SeedSendingAsync(DateTime.UtcNow);
+
+            var processed = await sender.ProcessOnceAsync(CancellationToken.None);
+
+            processed.Should().BeFalse("a fresh 'sending' row is neither reclaimed nor claimable");
+            slack.ChannelCalls.Should().BeEmpty("nothing is (re)delivered");
+
+            using var verify = new TestControlPlaneDbContext(_cpOptions);
+            var row = await verify.SlackOutbox.FindAsync(enq.Id);
+            row.Should().NotBeNull();
+            row!.Status.Should().Be("sending", "a within-lease claim is left untouched");
+            row.Attempts.Should().Be(0, "reclaim never bumps the attempt counter");
         }
         finally
         {


### PR DESCRIPTION
## Problem (verified)

The Slack/email outboxes claim a row into `Status='sending'` (stamping `UpdatedAt`) and only re-select `Status='pending'`. A crash between claim and `MarkSent`/`MarkFailed` orphans the row forever — welcome/verification/password-reset mail + Slack pings silently lost. (`SlackOutboxRepository`, `PlatformEmailOutboxRepository`, `EmailOutboxRepository`.)

## Fix

Added a `ReclaimStuckSendingAsync` to each repo: reset `sending → pending` where `UpdatedAt` is older than a lease (default 5 min, `*:OutboxSendingLeaseSeconds`), stamping `UpdatedAt`, **leaving `Attempts` untouched** (a stuck row was never attempted-to-completion). Invoked by **folding into the existing `OutboxSlackSender`/`OutboxSmtpSender` loops** (throttled to once/lease; reaps on first cycle to recover pre-crash rows) — no new hosted service, **no `Program.cs` change, no migration**. Tenant-email reclaim carries the same `TenantId` guard as its claim path + a cross-tenant fan-out.

## Verification

- Build: 0 errors. Outbox tests 73/73, Notifications 8/8. TDD fail-before/pass-after across all three outboxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)