### PR TITLE
fix(epic-38): fail-closed tenant guard on JIRA mediation (block cross-tenant read/patch)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Services/Jira/JiraEventTypes.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Jira/JiraEventTypes.cs
@@ -30,6 +30,15 @@ public static class JiraFailureCodes
     /// <summary>The referenced ticket was not found.</summary>
     public const string NotFound = "NOT_FOUND";
 
+    /// <summary>
+    /// SaaS fail-closed guard: JIRA uses a single platform-global credential with no
+    /// per-tenant/ticket scoping (there is no tenant↔JIRA-project mapping yet), so in
+    /// SaaS mode the shared-credential path is a confused-deputy — any tenant could
+    /// read/patch ANY ticket id. Denied by default; an operator re-enables it
+    /// knowingly via <c>Jira:AllowSharedCredentialInSaaS=true</c>.
+    /// </summary>
+    public const string SharedCredentialDeniedInSaaS = "JIRA_SHARED_CREDENTIAL_DENIED_IN_SAAS";
+
     /// <summary>Any other expected platform failure (permission, rate-limit, transient).</summary>
     public const string PlatformError = "PLATFORM_ERROR";
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Jira/JiraMediationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Jira/JiraMediationService.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Tamma.Api.Services.PromptStore;
 using Tamma.Core.Interfaces;
 using Tamma.Core.Logging;
 using Tamma.Data.Entities;
@@ -13,24 +15,52 @@ namespace Tamma.Api.Services.Jira;
 /// <see cref="IJiraIntegrationService"/> (the JIRA base URL / email / API token live
 /// in Tamma.Api config, resolved inside that service) → exactly-one terminal DCB
 /// event scoped by the acting tenant. Unlike git/CI there is no per-tenant BYOK
-/// token resolver and no repo guard: JIRA is a single, server-side, config-provided
-/// integration (mirrors the Slack outbox plane, not the repo-scoped git plane). The
-/// JIRA token NEVER reaches the engine — it stays in Tamma.Api config.
+/// token resolver: JIRA is a single, server-side, config-provided integration
+/// (mirrors the Slack outbox plane, not the repo-scoped git plane). The JIRA token
+/// NEVER reaches the engine — it stays in Tamma.Api config.
+///
+/// <para><b>Fail-closed tenant guard (SaaS).</b> Because that single credential has
+/// NO per-tenant/ticket authorization — and there is no tenant↔JIRA-project mapping
+/// to derive one from — the shared-credential path is a confused-deputy in SaaS: any
+/// tenant A could GET/PATCH ANY ticket id belonging to tenant B through the global
+/// client. So this service is mode-gated (mirroring <c>GitRepoAuthorizer</c>):
+/// <list type="bullet">
+///   <item><b>single-user</b> — the sole principal owns everything ⇒ ALLOW.</item>
+///   <item><b>SaaS</b> — DENY by default with a typed, key-free soft-fail
+///     (<see cref="JiraFailureCodes.SharedCredentialDeniedInSaaS"/>) and a WARN log;
+///     the underlying <see cref="IJiraIntegrationService"/> is NEVER called. An
+///     operator may re-enable the shared-credential behavior knowingly by setting
+///     <c>Jira:AllowSharedCredentialInSaaS=true</c> (default <c>false</c>).</item>
+/// </list>
+/// This is a conservative guard, not full per-tenant JIRA scoping (blocked until a
+/// tenant↔project mapping exists).</para>
 /// </summary>
 public sealed class JiraMediationService : IJiraMediationService
 {
     private readonly IJiraIntegrationService _jira;
     private readonly IEventRepository _events;
+    private readonly ITammaModeProvider _mode;
+    private readonly bool _allowSharedCredentialInSaaS;
     private readonly ILogger<JiraMediationService> _logger;
 
     public JiraMediationService(
         IJiraIntegrationService jira,
         IEventRepository events,
+        ITammaModeProvider mode,
+        IConfiguration configuration,
         ILogger<JiraMediationService> logger)
     {
         _jira = jira ?? throw new ArgumentNullException(nameof(jira));
         _events = events ?? throw new ArgumentNullException(nameof(events));
+        _mode = mode ?? throw new ArgumentNullException(nameof(mode));
+        ArgumentNullException.ThrowIfNull(configuration);
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        // Opt-in escape hatch: an operator who has accepted the cross-tenant risk of
+        // a shared JIRA credential in SaaS sets this to true. Default (unset / any
+        // non-"true" value) ⇒ false ⇒ SaaS denies.
+        _allowSharedCredentialInSaaS =
+            bool.TryParse(configuration["Jira:AllowSharedCredentialInSaaS"], out var allow) && allow;
     }
 
     public Task<JiraMediationResult> GetTicketAsync(Guid? tenantId, string ticketId, string correlationId, CancellationToken ct = default)
@@ -138,6 +168,30 @@ public sealed class JiraMediationService : IJiraMediationService
         Guid? tenantId, string ticketId, string operation, string failedEventType, string correlationId,
         CancellationToken ct, Func<Task<JiraMediationResult>> body)
     {
+        // Fail-closed tenant guard (runs BEFORE the body so the shared-credential
+        // IJiraIntegrationService is never reached on denial). In SaaS the single
+        // platform-global JIRA credential has no per-tenant/ticket scoping ⇒ deny
+        // unless an operator opted in. Single-user owns everything ⇒ allow.
+        if (_mode.Mode == TammaMode.SaaS && !_allowSharedCredentialInSaaS)
+        {
+            _logger.LogWarning(
+                "jira-mediation guard DENIED (shared-credential in SaaS): op {Operation} refused — JIRA has no per-tenant scoping and Jira:AllowSharedCredentialInSaaS is not set. correlationId={CorrelationId}, ticketId={TicketId}, tenantId={TenantId}",
+                operation, LogSanitizer.Clean(correlationId), LogSanitizer.Clean(ticketId), tenantId);
+
+            await EmitAsync(failedEventType, operation, tenantId, ticketId, correlationId,
+                JiraFailureCodes.SharedCredentialDeniedInSaaS, new { ticketId }, ct).ConfigureAwait(false);
+
+            return new JiraMediationResult
+            {
+                Success = false,
+                Outcome = "Error",
+                FailureCode = JiraFailureCodes.SharedCredentialDeniedInSaaS,
+                FailureReason = "JIRA uses a shared platform credential with no per-tenant scoping; refused in SaaS mode. Set Jira:AllowSharedCredentialInSaaS=true to allow knowingly.",
+                TicketKey = ticketId,
+                CorrelationId = correlationId,
+            };
+        }
+
         try
         {
             return await body().ConfigureAwait(false);

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Jira/JiraMediationServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Jira/JiraMediationServiceTests.cs
@@ -1,9 +1,12 @@
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using FluentAssertions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
 using Tamma.Api.Services.Jira;
+using Tamma.Api.Services.PromptStore;
 using Tamma.Core.Interfaces;
 using Tamma.Data.Entities;
 using Tamma.Data.Repositories;
@@ -11,11 +14,16 @@ using Tamma.Data.Repositories;
 namespace Tamma.Api.Tests.Jira;
 
 /// <summary>
-/// Story 38 (Phase 1) — <see cref="JiraMediationService"/> composition. JIRA is not
-/// repo-scoped (no guard / no token resolver): it runs the config-credentialed
+/// Story 38 (Phase 1) — <see cref="JiraMediationService"/> composition. JIRA has no
+/// per-tenant token resolver: it runs the config-credentialed
 /// <see cref="IJiraIntegrationService"/> under the acting tenant, then emits exactly
 /// one terminal DCB event. Failures ride inside a typed key-free result (200
 /// success:false at the endpoint); an unexpected exception becomes PLATFORM_ERROR.
+///
+/// <para>Because that single credential has no per-tenant/ticket scoping, a
+/// fail-closed mode guard applies: single-user ⇒ allow; SaaS ⇒ deny (typed
+/// <see cref="JiraFailureCodes.SharedCredentialDeniedInSaaS"/>, underlying client
+/// never called) unless <c>Jira:AllowSharedCredentialInSaaS=true</c> opts in.</para>
 /// </summary>
 [TestFixture]
 public class JiraMediationServiceTests
@@ -32,7 +40,24 @@ public class JiraMediationServiceTests
     {
         _jira = new Mock<IJiraIntegrationService>(MockBehavior.Strict);
         _events = new RecordingEventRepository();
-        _sut = new JiraMediationService(_jira.Object, _events, NullLogger<JiraMediationService>.Instance);
+        // Default SUT runs in single-user mode (the sole principal owns everything),
+        // so the shared JIRA credential is always allowed — matches the pre-guard
+        // behavior the composition tests below assert.
+        _sut = Build(TammaMode.SingleUser);
+    }
+
+    private JiraMediationService Build(TammaMode mode, bool allowSharedInSaaS = false)
+    {
+        var modeProvider = new Mock<ITammaModeProvider>();
+        modeProvider.SetupGet(m => m.Mode).Returns(mode);
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Jira:AllowSharedCredentialInSaaS"] = allowSharedInSaaS ? "true" : "false",
+            })
+            .Build();
+        return new JiraMediationService(
+            _jira.Object, _events, modeProvider.Object, configuration, NullLogger<JiraMediationService>.Instance);
     }
 
     [Test]
@@ -89,6 +114,60 @@ public class JiraMediationServiceTests
         result.Success.Should().BeFalse();
         result.FailureCode.Should().Be(JiraFailureCodes.PlatformError);
         _events.Appended.Should().ContainSingle().Which.Type.Should().Be(JiraEventTypes.TicketReadFailed);
+    }
+
+    // ── fail-closed tenant guard (SaaS shared-credential) ───────────────────
+
+    [Test]
+    public async Task SingleUser_SharedCredential_Allows_CallsJira()
+    {
+        // (a) single-user: the sole principal owns everything ⇒ the guard allows the
+        // op and the underlying JIRA client is reached.
+        _jira.Setup(j => j.GetJiraTicketAsync(TicketId))
+            .ReturnsAsync(IntegrationResult<JiraTicket?>.Ok(new JiraTicket { Id = "1", Key = TicketId, Summary = "s", Status = "Open" }));
+        var sut = Build(TammaMode.SingleUser);
+
+        var result = await sut.GetTicketAsync(_tenant, TicketId, "corr-su");
+
+        result.Success.Should().BeTrue();
+        _jira.Verify(j => j.GetJiraTicketAsync(TicketId), Times.Once);
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(JiraEventTypes.TicketReadSuccess);
+    }
+
+    [Test]
+    public async Task Saas_NoOptIn_Denies_TypedResult_NeverCallsJira()
+    {
+        // (b) SaaS without the opt-in: the shared-credential path is a confused-deputy,
+        // so the guard denies with the typed key-free failure and the strict-mock JIRA
+        // client is NEVER invoked (no Setup ⇒ any call would throw).
+        var sut = Build(TammaMode.SaaS, allowSharedInSaaS: false);
+
+        var body = new UpdateTicketRequest { Status = "Done", CorrelationId = "corr-saas" };
+        var result = await sut.UpdateTicketAsync(_tenant, TicketId, body);
+
+        result.Success.Should().BeFalse();
+        result.FailureCode.Should().Be(JiraFailureCodes.SharedCredentialDeniedInSaaS);
+        result.TicketKey.Should().Be(TicketId);
+        _jira.Verify(j => j.UpdateJiraTicketAsync(It.IsAny<string>(), It.IsAny<JiraTicketUpdate>()), Times.Never);
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(JiraEventTypes.TicketUpdatedFailed);
+    }
+
+    [Test]
+    public async Task Saas_WithOptIn_Allows_CallsJira()
+    {
+        // (c) SaaS WITH Jira:AllowSharedCredentialInSaaS=true: the operator knowingly
+        // re-enabled the shared credential ⇒ the op runs and reaches the JIRA client.
+        _jira.Setup(j => j.UpdateJiraTicketAsync(TicketId, It.IsAny<JiraTicketUpdate>()))
+            .ReturnsAsync(IntegrationResult<JiraTicketResult>.Ok(new JiraTicketResult { Success = true, TicketKey = TicketId }));
+        var sut = Build(TammaMode.SaaS, allowSharedInSaaS: true);
+
+        var body = new UpdateTicketRequest { Status = "Done", CorrelationId = "corr-optin" };
+        var result = await sut.UpdateTicketAsync(_tenant, TicketId, body);
+
+        result.Success.Should().BeTrue();
+        result.Outcome.Should().Be("Updated");
+        _jira.Verify(j => j.UpdateJiraTicketAsync(TicketId, It.IsAny<JiraTicketUpdate>()), Times.Once);
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(JiraEventTypes.TicketUpdatedSuccess);
     }
 
     private sealed class RecordingEventRepository : IEventRepository


### PR DESCRIPTION
## Problem (verified)

JIRA mediation used a single platform-global credential with no per-tenant authorization — `JiraMediationService` passed the caller `ticketId` straight to the shared client. In SaaS this is a confused-deputy: any tenant could GET/PATCH any ticket id (the git path is fail-closed via `GitRepoAuthorizer`; JIRA had nothing).

## Fix

Fail-closed guard in `ExecuteGuardedAsync` (wraps GET + PATCH), reusing the existing `ITammaModeProvider` (same service `GitRepoAuthorizer` uses — no new DI):
- **single-user** → allow (sole principal).
- **SaaS** → deny with a typed soft-fail (`JIRA_SHARED_CREDENTIAL_DENIED_IN_SAAS`, no raw 5xx, client never reached) + WARN, **unless** `Jira:AllowSharedCredentialInSaaS` (default false) is set.

Full per-tenant JIRA BYOK scoping is a separate blocked item (no tenant↔project mapping yet); this is the conservative interim guard. **No `Program.cs`/migration.**

## Verification

- Build: 0 errors. Jira tests 11/11. TDD fail-before/pass-after (single-user allows; SaaS denies + never calls client; SaaS+opt-in allows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)