### PR TITLE
fix(epic-38): fail-closed tenant guard on email mediation (block platform-identity abuse)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Services/EmailMediation/EmailMediationResponses.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/EmailMediation/EmailMediationResponses.cs
@@ -34,6 +34,15 @@ public static class EmailMediationFailureCodes
 {
     /// <summary>Any expected accept failure (validation, DI, transient).</summary>
     public const string PlatformError = "PLATFORM_ERROR";
+
+    /// <summary>
+    /// SaaS fail-closed guard: a tenant-workflow-initiated mediated send was denied
+    /// because the message would go out FROM the platform's configured sender
+    /// identity (<c>Email:From</c>) with no per-tenant sender/domain allowlist. Opt
+    /// back in with <c>Email:AllowMediatedSendInSaaS=true</c> once a per-tenant sender
+    /// policy exists. Single-user mode is never denied (one principal owns the domain).
+    /// </summary>
+    public const string MediationDeniedInSaaS = "email_mediation_denied_in_saas";
 }
 
 /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Api/Services/EmailMediation/EmailMediationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/EmailMediation/EmailMediationService.cs
@@ -1,5 +1,7 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Tamma.Api.Services.Email;
+using Tamma.Api.Services.PromptStore;
 using Tamma.Core.Logging;
 
 namespace Tamma.Api.Services.EmailMediation;
@@ -22,20 +24,62 @@ namespace Tamma.Api.Services.EmailMediation;
 /// </summary>
 public sealed class EmailMediationService : IEmailMediationService
 {
+    /// <summary>
+    /// Config flag (default FALSE) that opts a SaaS deployment back into
+    /// tenant-workflow-initiated mediated email sends. See the SaaS guard in
+    /// <see cref="SendEmailAsync"/> and <see cref="EmailMediationFailureCodes.MediationDeniedInSaaS"/>.
+    /// </summary>
+    internal const string AllowMediatedSendInSaaSKey = "Email:AllowMediatedSendInSaaS";
+
     private readonly IEmailService _email;
+    private readonly ITammaModeProvider _mode;
+    private readonly IConfiguration _config;
     private readonly ILogger<EmailMediationService> _logger;
 
     public EmailMediationService(
         IEmailService email,
+        ITammaModeProvider mode,
+        IConfiguration config,
         ILogger<EmailMediationService> logger)
     {
         _email = email ?? throw new ArgumentNullException(nameof(email));
+        _mode = mode ?? throw new ArgumentNullException(nameof(mode));
+        _config = config ?? throw new ArgumentNullException(nameof(config));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public async Task<EmailMediationResult> SendEmailAsync(Guid? tenantId, SendEmailRequest body, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(body);
+
+        // SaaS fail-closed tenant guard (mirrors the JIRA/git mediation guards).
+        // A mediated send composes mail FROM the platform's configured sender identity
+        // (Email:From) — there is no per-tenant From/domain allowlist here. In SaaS a
+        // tenant workflow could therefore emit arbitrary mail under the platform's
+        // reputation/domain (spam/phishing amplification), so deny-by-default. An
+        // operator opts back in with Email:AllowMediatedSendInSaaS=true once a
+        // per-tenant sender policy exists. Single-user mode is always allowed (the sole
+        // principal owns the domain). Fail-soft: return a typed denial inside 200
+        // success:false, never a raw 5xx. Only TENANT-WORKFLOW-initiated sends reach
+        // this service; system emails (welcome/verification/password-reset) call
+        // IEmailService directly and are unaffected.
+        if (_mode.Mode == TammaMode.SaaS
+            && !_config.GetValue(AllowMediatedSendInSaaSKey, false))
+        {
+            _logger.LogWarning(
+                "email-mediation send DENIED in SaaS mode: no per-tenant sender allowlist; " +
+                "set {ConfigKey}=true to opt in. correlationId={CorrelationId}, tenantId={TenantId}",
+                AllowMediatedSendInSaaSKey, LogSanitizer.Clean(body.CorrelationId), tenantId);
+
+            return new EmailMediationResult
+            {
+                Success = false,
+                Outcome = "Denied",
+                FailureCode = EmailMediationFailureCodes.MediationDeniedInSaaS,
+                FailureReason = "mediated email send is not permitted in SaaS mode",
+                CorrelationId = body.CorrelationId,
+            };
+        }
 
         if (string.IsNullOrWhiteSpace(body.To))
         {

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/EmailMediation/EmailMediationServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/EmailMediation/EmailMediationServiceTests.cs
@@ -1,9 +1,11 @@
 using FluentAssertions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
 using Tamma.Api.Services.Email;
 using Tamma.Api.Services.EmailMediation;
+using Tamma.Api.Services.PromptStore;
 
 namespace Tamma.Api.Tests.EmailMediation;
 
@@ -26,7 +28,25 @@ public class EmailMediationServiceTests
     public void SetUp()
     {
         _email = new Mock<IEmailService>(MockBehavior.Strict);
-        _sut = new EmailMediationService(_email.Object, NullLogger<EmailMediationService>.Instance);
+        // Default SUT is single-user mode — the existing accept/fail-soft tests
+        // exercise the composition without the SaaS guard tripping.
+        _sut = BuildSut(TammaMode.SingleUser);
+    }
+
+    private EmailMediationService BuildSut(TammaMode mode, bool allowMediatedSendInSaaS = false)
+    {
+        var modeProvider = new Mock<ITammaModeProvider>();
+        modeProvider.SetupGet(m => m.Mode).Returns(mode);
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [EmailMediationService.AllowMediatedSendInSaaSKey] = allowMediatedSendInSaaS ? "true" : "false",
+            })
+            .Build();
+
+        return new EmailMediationService(
+            _email.Object, modeProvider.Object, config, NullLogger<EmailMediationService>.Instance);
     }
 
     private static SendEmailRequest Body() => new()
@@ -76,5 +96,60 @@ public class EmailMediationServiceTests
         result.Outcome.Should().Be("Error");
         result.FailureCode.Should().Be(EmailMediationFailureCodes.PlatformError);
         result.CorrelationId.Should().Be("corr-e");
+    }
+
+    // ── SaaS fail-closed tenant guard ──
+    // A tenant workflow mediates mail FROM the platform's configured sender identity
+    // (Email:From). In SaaS that lets a tenant emit arbitrary mail under the
+    // platform's reputation/domain, so mediated sends are denied by default. Only
+    // TENANT-WORKFLOW-initiated sends flow through here; system emails
+    // (welcome/verification/password-reset) call IEmailService directly and are
+    // unaffected.
+
+    [Test]
+    public async Task Send_SingleUserMode_Allowed_AcceptsIntoOutbox()
+    {
+        var txn = Guid.NewGuid();
+        _email.Setup(e => e.SendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(txn);
+        var sut = BuildSut(TammaMode.SingleUser);
+
+        var result = await sut.SendEmailAsync(_tenant, Body());
+
+        result.Success.Should().BeTrue("single-user mode has one principal who owns the sender domain");
+        result.Outcome.Should().Be("Queued");
+        result.TxnId.Should().Be(txn);
+        _email.Verify(e => e.SendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task Send_SaaSMode_NoOptIn_TypedDenial_NeverEnqueues()
+    {
+        var sut = BuildSut(TammaMode.SaaS, allowMediatedSendInSaaS: false);
+
+        var result = await sut.SendEmailAsync(_tenant, Body());
+
+        result.Success.Should().BeFalse();
+        result.Outcome.Should().Be("Denied");
+        result.FailureCode.Should().Be(EmailMediationFailureCodes.MediationDeniedInSaaS);
+        result.CorrelationId.Should().Be("corr-e");
+        _email.Verify(e => e.SendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()), Times.Never,
+            "a denied mediated send must never reach the outbox/transport");
+    }
+
+    [Test]
+    public async Task Send_SaaSMode_WithOptIn_Allowed_AcceptsIntoOutbox()
+    {
+        var txn = Guid.NewGuid();
+        _email.Setup(e => e.SendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(txn);
+        var sut = BuildSut(TammaMode.SaaS, allowMediatedSendInSaaS: true);
+
+        var result = await sut.SendEmailAsync(_tenant, Body());
+
+        result.Success.Should().BeTrue("the explicit Email:AllowMediatedSendInSaaS opt-in re-enables the send");
+        result.Outcome.Should().Be("Queued");
+        result.TxnId.Should().Be(txn);
+        _email.Verify(e => e.SendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 }


### PR DESCRIPTION
## Problem (verified)

Email mediation (`EmailMediationService`, the `EngineServiceOnly` `POST /api/v1/notifications/email`) built messages with `From: null` → the platform domain, with no recipient/tenant/domain allowlist. In SaaS a tenant workflow could send arbitrary mail from the platform's reputation.

## Fix

Fail-closed guard mirroring the JIRA one, reusing `ITammaModeProvider`:
- **single-user** → allow.
- **SaaS** → deny with a typed soft-fail (`email_mediation_denied_in_saas`, nothing enqueued) + WARN, **unless** `Email:AllowMediatedSendInSaaS` (default false) is set.

**System emails are unaffected** — welcome/verification/password-reset/alerts call `IEmailService` directly (via `AuthEndpoints`/`OrgEndpoints`/`QueueWelcomeEmailActivity`/`EmailAlertChannel`), never through `EmailMediationService`. Per-tenant From/domain allowlist is a larger follow-on; this is the interim guard. **No `Program.cs`/migration.**

## Verification

- Build: 0 errors. Email tests 102/102. TDD fail-before/pass-after (single-user allows; SaaS denies + never enqueues; SaaS+opt-in allows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)